### PR TITLE
Compiler straightening (1/n): ftm idempotency, pe-rewalk type-env, qualify-upfront

### DIFF
--- a/src/raster/compiler/backend/jvm/bytecode.clj
+++ b/src/raster/compiler/backend/jvm/bytecode.clj
@@ -3919,9 +3919,15 @@
   [code args locals ctx]
   (let [param-vec (first args)
         rest-args (rest args)
-        [_ret-type body] (if (= :- (first rest-args))
-                           [(second rest-args) (nnext rest-args)]
-                           [nil rest-args])
+        [_ret-type after] (if (= :- (first rest-args))
+                            [(second rest-args) (nnext rest-args)]
+                            [nil rest-args])
+        ;; Strip walker `:raster.walker/source-body <vec>` markers: bytecode emits
+        ;; the WALKED (devirtualized) body, never the raw source body (which is kept
+        ;; only for AD transparency and contains bare, unqualified deftm calls).
+        ;; Loop handles >1 marker if an ftm was walked more than once.
+        body (loop [a after]
+               (if (= :raster.walker/source-body (first a)) (recur (nnext a)) a))
         plain-params (vec (loop [items (seq param-vec) result []]
                             (if-not items
                               result

--- a/src/raster/compiler/core/inference.clj
+++ b/src/raster/compiler/core/inference.clj
@@ -1429,6 +1429,11 @@
                           (var? resolved)
                           (symbol (str (.name (.ns ^clojure.lang.Var resolved)))
                                   (str (.sym ^clojure.lang.Var resolved)))
+                          ;; Bare class name (e.g. (new Foo ...), (catch Foo e),
+                          ;; or a class in value position): qualify to its FQN so
+                          ;; the backend resolves it with no ns context.
+                          (class? resolved)
+                          (symbol (.getName ^Class resolved))
                           :else expr))
                       (and (namespace expr)
                            (try (the-ns (symbol (namespace expr))) true

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -577,9 +577,17 @@
 (defmethod walk-form :ftm [form ctx]
   (let [[ftm-sym param-vec & body-args] form
         ;; Parse optional return type: (ftm [params] :- RetType body...)
-        [ret-type body] (if (= :- (first body-args))
+        [ret-type tail] (if (= :- (first body-args))
                           [(second body-args) (nnext body-args)]
                           [nil body-args])
+        ;; Idempotency: the pipeline walks ftms more than once (walk → inline →
+        ;; pe-rewalk). An already-walked ftm carries its raw body in a
+        ;; `:raster.walker/source-body <vec>` marker; preserve that original raw
+        ;; body and re-walk only the walked body. Re-wrapping would NEST a second
+        ;; source-body and double the (64KB-method-limit-sensitive) payload.
+        already-walked? (= :raster.walker/source-body (first tail))
+        src-body (if already-walked? (second tail) (vec tail))
+        body     (if already-walked? (nnext tail) tail)
         ;; Parse typed params: [a :- Double, b :- Long] → extract names + types
         {:keys [params annotations]} (types/parse-typed-params param-vec)
         ;; Add params to walker context with their type annotations
@@ -597,10 +605,10 @@
         ;; body uses raster.numeric dispatch (handles Dual) unlike walked .invk calls.
         result (if ret-type
                  (list* ftm-sym param-vec :- ret-type
-                        :raster.walker/source-body (vec body)
+                        :raster.walker/source-body src-body
                         walked-body)
                  (list* ftm-sym param-vec
-                        :raster.walker/source-body (vec body)
+                        :raster.walker/source-body src-body
                         walked-body))]
     result))
 

--- a/src/raster/compiler/passes/scalar/rewalk.clj
+++ b/src/raster/compiler/passes/scalar/rewalk.clj
@@ -51,10 +51,22 @@
                       (assoc param-env (with-meta (if (symbol? lr) lr (symbol (name lr))) nil) scalar-tag)
                       param-env)
           ;; Type-env from param-env. Uses build-param-type-env for consistency
-          ;; with definition-time and AOT-time walks.
+          ;; with the definition-time and AOT-time walks — including the param
+          ;; ANNOTATIONS so array :element and (Fn ...) :fn-info survive the
+          ;; re-walk (the 2-arg form dropped them, diverging from walk-1 and
+          ;; under-devirtualizing parametric / fn-param code).
+          param-annotations (:param-annotations opts)
           type-env (inf/build-param-type-env
                     (vec (keys param-env))
-                    (vec (vals param-env)))
+                    (vec (vals param-env))
+                    (when param-annotations
+                      (mapv #(get param-annotations %) (keys param-env))))
+          ;; Fail loud: a re-walk with no source-ns runs under *ns* and silently
+          ;; devirtualizes nothing (the GAP-A drift). compile-aot always threads
+          ;; it; warn if a future caller forgets.
+          _ (when-not (:source-ns opts)
+              (binding [*out* *err*]
+                (println "WARNING: pe-rewalk invoked without :source-ns — deftm calls will not devirtualize")))
           ;; TC binding tags: run TC once on the post-AD form for systematic
           ;; type inference of all let bindings.
           tc-binding-tags (inf/tc-infer-binding-tags param-env optimized)

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -809,10 +809,21 @@
                         (or (when-let [s (:raster.core/deftm-source-ns m)]
                               (try (the-ns s) (catch Exception _ nil)))
                             (when (var? resolved-var) (.ns ^clojure.lang.Var resolved-var))))
+            ;; Param annotations ({sym -> typedclojure annotation}), so the PE
+            ;; re-walk reconstructs the SAME type-env as walk-1 (array :element,
+            ;; (Fn ...) :fn-info) instead of a tag-only env that under-devirtualizes.
+            param-annotations (let [m (meta resolved-var)
+                                    ps (:raster.core/deftm-params m)
+                                    anns (or (:raster.core/deftm-annotations m)
+                                             (when-let [tags (:raster.core/deftm-tags m)]
+                                               (mapv (fn [t] (if (= t 'Object) nil t)) tags)))]
+                                (when (and ps anns (= (count ps) (count anns)))
+                                  (zipmap (map #(if (symbol? %) % (symbol (name %))) ps) anns)))
             opts (cond-> {:inline? inline? :simd? simd? :target-device target-device
                           :active-params active-params :dtype effective-dtype}
                    param-env (assoc :param-env param-env)
-                   source-ns (assoc :source-ns source-ns))
+                   source-ns (assoc :source-ns source-ns)
+                   param-annotations (assoc :param-annotations param-annotations))
             compile! (fn []
                        (let [raw-form (if (= 1 (count walked-body))
                                         (first walked-body)


### PR DESCRIPTION
Compiler "correctness by construction" — first increment. Stacked on #5
(base: `feature/tc-ast-binding-types`); this diff is the straightening only.

Each change **removes an irregularity** (carry context / single representation)
rather than adding a fallback. Full audit + plan in
`.internal/compiler_correctness_by_construction.md` (local, gitignored).

### P1a — ftm walk integrity
- `emit-ftm` strips the `:raster.walker/source-body` marker and emits the **walked
  (devirtualized) body**, not the raw AD-only source body (which carries bare,
  unqualified deftm calls → "Unresolved symbol" in lifted closure helpers).
- `walk-form :ftm` is **idempotent** — preserves the single source-body and
  re-walks only the walked body, instead of nesting a second marker and doubling
  the (64KB-method-limit-sensitive) payload on every re-walk.

### P1b — type-env reconstruction
- The PE re-walk rebuilt its walk type-env via the 2-arg `build-param-type-env`
  (no annotations), dropping array `:element` and `(Fn ...)` `:fn-info` and
  diverging from walk-1. `compile-aot` now threads the param **annotations**;
  `pe-rewalk` builds the same env as walk-1.
- `pe-rewalk` **fails loud** (warns) when invoked without `:source-ns` — the GAP-A
  drift where a re-walk under `*ns*` silently devirtualizes nothing.

### P2a — qualify-upfront for class names
- `qualify-body-symbols` now FQN-qualifies **bare class names** (`(new Foo ...)`,
  `(catch Foo e)`, class refs in value position), complementing the existing
  `Class/method` static-head qualification, so the backend resolves classes with no
  `*ns*` guess.

### Validation
raster suite **1496 tests / 0 failures** at each step; umap-rstr/evoc-rstr suites
0 failures; `connected-spectral` compile-aot's; `lanczos-spectral` devirtualizes
its closure deftm call (now blocks only on GAP-B `info`). cljfmt clean.

### Follow-ups (not in this PR)
Heavier straightening, each its own PR: unify the element-type key (~30 sites);
inline-descends-into-closures; GAP-B (`info` lost-let-scope in inlined LAPACK);
formalize passes as `pattern` `defpass` (dialect arrows) + invariant checkers
(I1–I8, warn→throw); minor backend `*ns*`→`:source-ns` cleanup.
