### PR TITLE
Compiler straightening: ftm/type-env/qualify/element + invariant enforcement

### DIFF
--- a/src/raster/compiler/backend/jvm/bytecode.clj
+++ b/src/raster/compiler/backend/jvm/bytecode.clj
@@ -3919,9 +3919,15 @@
   [code args locals ctx]
   (let [param-vec (first args)
         rest-args (rest args)
-        [_ret-type body] (if (= :- (first rest-args))
-                           [(second rest-args) (nnext rest-args)]
-                           [nil rest-args])
+        [_ret-type after] (if (= :- (first rest-args))
+                            [(second rest-args) (nnext rest-args)]
+                            [nil rest-args])
+        ;; Strip walker `:raster.walker/source-body <vec>` markers: bytecode emits
+        ;; the WALKED (devirtualized) body, never the raw source body (which is kept
+        ;; only for AD transparency and contains bare, unqualified deftm calls).
+        ;; Loop handles >1 marker if an ftm was walked more than once.
+        body (loop [a after]
+               (if (= :raster.walker/source-body (first a)) (recur (nnext a)) a))
         plain-params (vec (loop [items (seq param-vec) result []]
                             (if-not items
                               result

--- a/src/raster/compiler/core/inference.clj
+++ b/src/raster/compiler/core/inference.clj
@@ -1429,6 +1429,11 @@
                           (var? resolved)
                           (symbol (str (.name (.ns ^clojure.lang.Var resolved)))
                                   (str (.sym ^clojure.lang.Var resolved)))
+                          ;; Bare class name (e.g. (new Foo ...), (catch Foo e),
+                          ;; or a class in value position): qualify to its FQN so
+                          ;; the backend resolves it with no ns context.
+                          (class? resolved)
+                          (symbol (.getName ^Class resolved))
                           :else expr))
                       (and (namespace expr)
                            (try (the-ns (symbol (namespace expr))) true

--- a/src/raster/compiler/core/inference.clj
+++ b/src/raster/compiler/core/inference.clj
@@ -777,6 +777,9 @@
       (when (symbol? arr-sym)
         (let [env-tag (type-env-tag type-env arr-sym)]
           (or (type-env-element type-env arr-sym)
+              ;; Element dispatch tag carried on the symbol (stamped at the binding
+              ;; site) — survives a re-walk whose env doesn't reach a captured var.
+              (:raster.type/element (meta arr-sym))
               (get types/primitive-array-element-types env-tag)
               (get types/primitive-array-element-types (:tag (meta arr-sym)))
               (get @types/soa-reverse-registry env-tag)))))))

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -89,17 +89,21 @@
   "Stamp type metadata onto a symbol. Always sets :raster.type/tag (compiler
   canonical). Only sets Clojure :tag for non-primitive types (arrays, classes,
   interfaces) — Clojure rejects :tag on locals with primitive initializers.
-  Also sets :raster.type/fn-info for typed function interfaces.
+  Also sets :raster.type/fn-info for typed function interfaces, and
+  :raster.type/element for the element dispatch tag of Object[]/parametric arrays
+  so it travels on the AST (survives re-walks that don't re-bind a captured var).
   This is the ONLY place type metadata should be attached to symbols."
-  [sym tag]
-  (if tag
-    (let [;; Clojure :tag is safe for arrays and classes, not bare primitives
-          clj-hint (inf/compute-binding-hint tag sym)]
-      (cond-> (vary-meta sym assoc :raster.type/tag tag)
-        clj-hint (vary-meta assoc :tag clj-hint)
-        (types/fn-type-tag? tag)
-        (vary-meta assoc :raster.type/fn-info {:iface-name tag})))
-    sym))
+  ([sym tag] (stamp-type-meta sym tag nil))
+  ([sym tag element]
+   (if tag
+     (let [;; Clojure :tag is safe for arrays and classes, not bare primitives
+           clj-hint (inf/compute-binding-hint tag sym)]
+       (cond-> (vary-meta sym assoc :raster.type/tag tag)
+         clj-hint (vary-meta assoc :tag clj-hint)
+         (types/fn-type-tag? tag)
+         (vary-meta assoc :raster.type/fn-info {:iface-name tag})
+         element (vary-meta assoc :raster.type/element element)))
+     sym)))
 
 (defn ctx-get-tag
   "Get the dispatch tag for a symbol.
@@ -120,9 +124,13 @@
   (get-in (:type-env ctx) [sym :fn-info]))
 
 (defn ctx-get-element
-  "Get element type for an Object[] symbol."
+  "Get the element dispatch tag for an Object[]/parametric symbol. Reads the ctx
+  type-env first, then a carried `:raster.type/element` on the symbol (stamped at
+  the binding site) so the element survives a re-walk that doesn't re-bind a
+  captured var — mirroring ctx-get-tag."
   [ctx sym]
-  (get-in (:type-env ctx) [sym :element]))
+  (or (get-in (:type-env ctx) [sym :element])
+      (when (symbol? sym) (:raster.type/element (meta sym)))))
 
 ;; ================================================================
 ;; Form Classification
@@ -511,7 +519,7 @@
                                                 {:source-ns (:source-ns ctx)}))
                  elem-tag (inf/infer-element-tag init tag type-env)
                  hint (inf/compute-binding-hint tag sym)
-                 sym (stamp-type-meta sym (or hint tag))]
+                 sym (stamp-type-meta sym (or hint tag) elem-tag)]
              [(conj binds sym rewritten-init)
               (cond-> ctx
                 tag (ctx-assoc-type sym tag)

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -577,9 +577,17 @@
 (defmethod walk-form :ftm [form ctx]
   (let [[ftm-sym param-vec & body-args] form
         ;; Parse optional return type: (ftm [params] :- RetType body...)
-        [ret-type body] (if (= :- (first body-args))
+        [ret-type tail] (if (= :- (first body-args))
                           [(second body-args) (nnext body-args)]
                           [nil body-args])
+        ;; Idempotency: the pipeline walks ftms more than once (walk → inline →
+        ;; pe-rewalk). An already-walked ftm carries its raw body in a
+        ;; `:raster.walker/source-body <vec>` marker; preserve that original raw
+        ;; body and re-walk only the walked body. Re-wrapping would NEST a second
+        ;; source-body and double the (64KB-method-limit-sensitive) payload.
+        already-walked? (= :raster.walker/source-body (first tail))
+        src-body (if already-walked? (second tail) (vec tail))
+        body     (if already-walked? (nnext tail) tail)
         ;; Parse typed params: [a :- Double, b :- Long] → extract names + types
         {:keys [params annotations]} (types/parse-typed-params param-vec)
         ;; Add params to walker context with their type annotations
@@ -597,10 +605,10 @@
         ;; body uses raster.numeric dispatch (handles Dual) unlike walked .invk calls.
         result (if ret-type
                  (list* ftm-sym param-vec :- ret-type
-                        :raster.walker/source-body (vec body)
+                        :raster.walker/source-body src-body
                         walked-body)
                  (list* ftm-sym param-vec
-                        :raster.walker/source-body (vec body)
+                        :raster.walker/source-body src-body
                         walked-body))]
     result))
 

--- a/src/raster/compiler/ir/invariants.clj
+++ b/src/raster/compiler/ir/invariants.clj
@@ -1,0 +1,83 @@
+(ns raster.compiler.ir.invariants
+  "Compiler invariants enforced at pass boundaries (via validate-dialect!).
+
+  Two tiers, mirroring the design in
+  .internal/compiler_correctness_by_construction.md:
+
+  - STRUCTURAL (cheap, always-on under *validate-dialects?*): shape properties a
+    dialect grammar could express. These THROW — they guard guarantees the
+    pipeline establishes (e.g. idempotent ftm ⇒ no nested source-body). When the
+    dialect grammars are wired (Option 3) these migrate into the grammar.
+
+  - SEMANTIC (deep, opt-in under *validate-deep?*): cross-cutting properties a
+    context-free grammar CANNOT express — qualification (scope/free-var analysis),
+    type-tag presence (metadata), op classification (registry). These live here
+    permanently and run alongside whatever pass implementation produced the form
+    (direct-walking today, pattern `defpass` later — same boundary seam)."
+  (:require [raster.compiler.core.util :as util]
+            [raster.compiler.ir.form :as form]))
+
+;; ---------------------------------------------------------------------------
+;; I2 — no nested / duplicated :raster.walker/source-body  (STRUCTURAL)
+;; Idempotent walk-form :ftm guarantees each ftm carries exactly one raw
+;; source-body marker. A second marker at the same level means a non-idempotent
+;; re-walk doubled the (64KB-method-limit-sensitive) payload.
+;; ---------------------------------------------------------------------------
+(defn nested-source-body
+  "First ftm form carrying >1 :raster.walker/source-body marker at its own level,
+  or nil if clean."
+  [form]
+  (->> (tree-seq coll? seq form)
+       (filter #(and (seq? %) (= 'ftm (first %))))
+       (some (fn [ftm]
+               (when (> (count (filter #(= :raster.walker/source-body %) ftm)) 1)
+                 ftm)))))
+
+;; ---------------------------------------------------------------------------
+;; I3 — every free symbol reaching the backend is namespace-qualified (SEMANTIC)
+;; A bare (unqualified, non-local, non-form-head) symbol forces the backend to
+;; guess a namespace — the qualify-upfront invariant. Grammars can't express this
+;; (it needs scope/free-var analysis), so it stays a predicate.
+;; ---------------------------------------------------------------------------
+(def ^:private always-bare-ok
+  "Unqualified symbols that are legitimately bare at the backend."
+  '#{.invk double float long int boolean recur finally & do})
+
+(defn unqualified-leaks
+  "Free (non-local) unqualified symbols that are not form heads, cast intrinsics,
+  interop (.foo), or one of the function's params — i.e. ones the backend would
+  have to resolve against a guessed namespace. `params` is the deftm's parameter
+  symbols (free-syms already excludes let-bound locals via scope; params are bound
+  at the fn boundary, outside the validated body, so must be excluded explicitly).
+  Returns a distinct seq, or nil if none."
+  [form params]
+  (let [param-set (set (map #(if (symbol? %) % (symbol (name %))) params))]
+    (seq (distinct
+          (->> (util/free-syms form)
+               (remove always-bare-ok)
+               (remove form/known-form-heads)
+               (remove param-set)
+               (remove #(.startsWith (name %) ".")))))))
+
+;; ---------------------------------------------------------------------------
+;; Boundary entry points (called by pipeline/validate-dialect!)
+;; ---------------------------------------------------------------------------
+(defn check-structural!
+  "Always-on structural invariants. Throws on violation."
+  [dialect-key form pass-key]
+  (when-let [bad (nested-source-body form)]
+    (throw (ex-info (str "Invariant I2 violated after :" pass-key
+                         " — nested :raster.walker/source-body (non-idempotent ftm walk)")
+                    {:invariant :I2 :pass pass-key :dialect dialect-key
+                     :form-preview (pr-str (take 3 bad))}))))
+
+(defn check-deep!
+  "Opt-in semantic invariants. WARN mode (no throw) until the corpus is clean;
+  flip individual checks to throw once baselined. `params` = the deftm's
+  parameter symbols (legitimately unqualified; excluded from the leak check)."
+  [dialect-key form pass-key params]
+  (when (= dialect-key :backend-applied)
+    (when-let [leaks (unqualified-leaks form params)]
+      (binding [*out* *err*]
+        (println (str "WARNING: invariant I3 (qualify-upfront) after :" pass-key
+                      " — unqualified symbols reaching backend: " (vec leaks)))))))

--- a/src/raster/compiler/ir/par.clj
+++ b/src/raster/compiler/ir/par.clj
@@ -407,6 +407,10 @@
   (raster.par/pmap idx bound cast body)
   Returns {:idx :bound :cast :body} + optional :elem-type from metadata."
   [form]
+  ;; Key convention (NOT drift): the element type is carried on AST METADATA under
+  ;; the namespaced :raster.type/elem-type, and translated here into the bare
+  ;; :elem-type field of the plain info maps handed to the backend. Namespaced on
+  ;; metadata, bare on plain data maps — this is the single translation boundary.
   (let [[_ idx bound cast body] form
         elem-type (:raster.type/elem-type (meta form))]
     (cond-> {:idx idx :bound bound :cast cast :body body}

--- a/src/raster/compiler/passes/scalar/rewalk.clj
+++ b/src/raster/compiler/passes/scalar/rewalk.clj
@@ -51,10 +51,22 @@
                       (assoc param-env (with-meta (if (symbol? lr) lr (symbol (name lr))) nil) scalar-tag)
                       param-env)
           ;; Type-env from param-env. Uses build-param-type-env for consistency
-          ;; with definition-time and AOT-time walks.
+          ;; with the definition-time and AOT-time walks — including the param
+          ;; ANNOTATIONS so array :element and (Fn ...) :fn-info survive the
+          ;; re-walk (the 2-arg form dropped them, diverging from walk-1 and
+          ;; under-devirtualizing parametric / fn-param code).
+          param-annotations (:param-annotations opts)
           type-env (inf/build-param-type-env
                     (vec (keys param-env))
-                    (vec (vals param-env)))
+                    (vec (vals param-env))
+                    (when param-annotations
+                      (mapv #(get param-annotations %) (keys param-env))))
+          ;; Fail loud: a re-walk with no source-ns runs under *ns* and silently
+          ;; devirtualizes nothing (the GAP-A drift). compile-aot always threads
+          ;; it; warn if a future caller forgets.
+          _ (when-not (:source-ns opts)
+              (binding [*out* *err*]
+                (println "WARNING: pe-rewalk invoked without :source-ns — deftm calls will not devirtualize")))
           ;; TC binding tags: run TC once on the post-AD form for systematic
           ;; type inference of all let bindings.
           tc-binding-tags (inf/tc-infer-binding-tags param-env optimized)

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -809,10 +809,21 @@
                         (or (when-let [s (:raster.core/deftm-source-ns m)]
                               (try (the-ns s) (catch Exception _ nil)))
                             (when (var? resolved-var) (.ns ^clojure.lang.Var resolved-var))))
+            ;; Param annotations ({sym -> typedclojure annotation}), so the PE
+            ;; re-walk reconstructs the SAME type-env as walk-1 (array :element,
+            ;; (Fn ...) :fn-info) instead of a tag-only env that under-devirtualizes.
+            param-annotations (let [m (meta resolved-var)
+                                    ps (:raster.core/deftm-params m)
+                                    anns (or (:raster.core/deftm-annotations m)
+                                             (when-let [tags (:raster.core/deftm-tags m)]
+                                               (mapv (fn [t] (if (= t 'Object) nil t)) tags)))]
+                                (when (and ps anns (= (count ps) (count anns)))
+                                  (zipmap (map #(if (symbol? %) % (symbol (name %))) ps) anns)))
             opts (cond-> {:inline? inline? :simd? simd? :target-device target-device
                           :active-params active-params :dtype effective-dtype}
                    param-env (assoc :param-env param-env)
-                   source-ns (assoc :source-ns source-ns))
+                   source-ns (assoc :source-ns source-ns)
+                   param-annotations (assoc :param-annotations param-annotations))
             compile! (fn []
                        (let [raw-form (if (= 1 (count walked-body))
                                         (first walked-body)

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -57,6 +57,7 @@
             [clojure.walk :as walk]
             [raster.runtime.hardware :as hardware]
             [raster.compiler.ir.dialects :as dialects]
+            [raster.compiler.ir.invariants :as invariants]
             [raster.compiler.ir.form :as form]
             [raster.compiler.core.method-entry :as me]
             [raster.core :as rcore]))
@@ -187,13 +188,24 @@
 ;; ================================================================
 
 (def ^:private ^:dynamic *validate-dialects?*
-  "When true, validate IR structure at each pass boundary.
-  Default true. Disable for production performance."
+  "Structural validation at each pass boundary: dialect-shape checkers +
+  always-on structural invariants (cheap). Default true."
   true)
 
+(def ^:dynamic *validate-deep?*
+  "Deep SEMANTIC invariants (qualify-upfront, type-tag presence, op
+  classification) at pass boundaries. Cross-cutting properties a dialect grammar
+  cannot express. Currently WARN-only; default off (enable in CI / tests).
+  Independent of how a pass is implemented — runs at the same boundary seam
+  whether the pass is direct-walking or a pattern `defpass`."
+  false)
+
 (defn- validate-dialect!
-  "Validate form against dialect. Throws on failure with detailed error."
-  [dialect-key form pass-key]
+  "Validate form against dialect at a pass boundary. Throws on a structural
+  violation (dialect shape or always-on structural invariant); warns on a deep
+  semantic invariant when *validate-deep?* is set. `opts` carries :active-params
+  (the deftm params), needed to exclude them from the qualify-upfront check."
+  [dialect-key form pass-key opts]
   (when *validate-dialects?*
     (when-let [[valid? validate-fn] (get dialects/dialect-checkers dialect-key)]
       (when-not (valid? form)
@@ -204,7 +216,10 @@
                            :validation-error details
                            :form-preview (pr-str (if (seq? form)
                                                    (take 3 form)
-                                                   form))})))))))
+                                                   form))})))))
+    (invariants/check-structural! dialect-key form pass-key))
+  (when *validate-deep?*
+    (invariants/check-deep! dialect-key form pass-key (:active-params opts))))
 
 ;; ================================================================
 ;; Pass functions — each takes (form, opts) → form or {:form :stats}
@@ -700,7 +715,7 @@
                    result (pass-fn f opts)
                    f' (pass-result-form result)]
                 ;; Validate output against target dialect (fails hard)
-               (validate-dialect! to f' pass-key)
+               (validate-dialect! to f' pass-key opts)
                [f' to]))
            [form :walked] passes)))
 
@@ -733,7 +748,7 @@
                                  current-dialect))
                   result (pass-fn (:form acc) opts)
                   new-form (pass-result-form result)]
-              (validate-dialect! to new-form pass-key)
+              (validate-dialect! to new-form pass-key opts)
               (-> acc
                   (assoc :form new-form :dialect to)
                   (assoc-in [:stages to] new-form)


### PR DESCRIPTION
Compiler "correctness by construction" straightening — replayed cleanly onto main.

(PR #6 merged into the feature branch but its merge captured only the first three
of these five commits; P2c + P3 never reached main. This PR lands all five.)

Each change removes an irregularity (carry context / single representation):
- **ftm walk integrity**: `emit-ftm` emits the walked (devirtualized) body, not the
  raw AD source-body; `walk-form :ftm` is idempotent (no doubled source-body).
- **pe-rewalk type-env**: reconstructs walk-1's full env (threads annotations →
  `:element`/`:fn-info` survive); fails loud on missing `:source-ns`.
- **qualify-upfront**: `qualify-body-symbols` FQN-qualifies bare class names
  (`new`/`catch`/value-position).
- **element on the AST**: `stamp-type-meta` stamps `:raster.type/element`;
  `infer-aget-type`/`ctx-get-element` read it (parametric `Object[]` element
  survives re-walk).
- **invariant enforcement**: `raster.compiler.ir.invariants` at the
  `validate-dialect!` seam — I2 (no nested source-body, always-on, throws) + I3
  (qualify-upfront, deep/warn). Split `*validate-dialects?*` (structural) /
  `*validate-deep?*` (semantic, opt-in).

Validated: full raster suite 1496 tests / 0 failures at each step (and on the
re-based branch); umap-rstr/evoc-rstr suites 0 failures; cljfmt clean.

Follow-ups (separate PRs): P3 cont (I6 type-env-shape, I7 no-raw-arith, I8
Object-closure-param), inline-into-closures (P2d), GAP-B (`info`), and the
pattern-`defpass` formalization once the dialect grammars are wired.
