### PR TITLE
bytecode: fix branch-merge stack mismatch on mispredicted if-else

### DIFF
--- a/src/raster/compiler/backend/jvm/bytecode.clj
+++ b/src/raster/compiler/backend/jvm/bytecode.clj
@@ -3064,12 +3064,22 @@
               (do (.aconst_null code)
                   (.labelBinding code end-label)
                   :ref)
-              ;; Different types or prediction was wrong — box else
+              ;; Prediction was wrong. The skip-box? path already committed the
+              ;; then-branch to an UNBOXED primitive (then-type); boxing else to
+              ;; :ref here would leave a 1-slot ref on the else path against a
+              ;; 1-or-2-slot primitive on the then path => branch-merge stack
+              ;; mismatch (the bug). Reconcile by COERCING else to then-type.
+              ;; When not skip-box?, then is already :ref, so box else to match.
               :else
-              (do (when (primitive? else-type)
-                    (emit-box-to-ref code else-type))
-                  (.labelBinding code end-label)
-                  (if skip-box? then-type :ref)))))))))
+              (if skip-box?
+                (do (when (not= else-type then-type)
+                      (emit-coerce code else-type then-type))
+                    (.labelBinding code end-label)
+                    then-type)
+                (do (when (primitive? else-type)
+                      (emit-box-to-ref code else-type))
+                    (.labelBinding code end-label)
+                    :ref)))))))))
 
 (defn- emit-dot-handler
   "Emit bytecode for (. obj method args...) — instance method or field access.

--- a/test/raster/compiler/backend/jvm/bytecode_test.clj
+++ b/test/raster/compiler/backend/jvm/bytecode_test.clj
@@ -5,6 +5,8 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.core :refer [deftm ftm]]
             [raster.ad.reverse]
+            [raster.arrays :as arr]
+            [raster.numeric :as rn]
             [raster.compiler.pipeline :as pipeline]
             [raster.compiler.passes.scalar.mem-merge :as mm]))
 
@@ -538,3 +540,33 @@
       (is (< (Math/abs (- 0.6 (aget W 0))) 1e-10))
       (is (< (Math/abs (- 1.5 (aget W 1))) 1e-10))
       (is (< (Math/abs (- 2.4 (aget W 2))) 1e-10)))))
+
+;; ================================================================
+;; Branch-merge stack-map regression
+;;
+;; (if cond <const> <deep .invk-arithmetic with a loop>): the if-emitter's
+;; skip-box? optimization predicts the else-branch's stack type; when that
+;; prediction disagreed with the actually-emitted type it boxed the else to a
+;; ref while the then-branch was left an unboxed primitive — different stack
+;; heights at the join => "Stack size mismatch" bytecode-verifier failure.
+;; This is the trapz/besselj0 shape (raster.numeric .invk arithmetic).
+;; ================================================================
+
+(deftm bc-if-deep-arith-loop [ys :- (Array double), dx :- Double] :- Double
+  (if (< (arr/alength ys) 2)
+    0.0
+    (let [n-1 (dec (arr/alength ys))]
+      (rn/* dx
+            (rn/+ (rn/* 0.5 (rn/+ (double (arr/aget ys 0)) (double (arr/aget ys n-1))))
+                  (loop [i 1 s 0.0]
+                    (if (>= i n-1)
+                      s
+                      (recur (inc i) (rn/+ s (double (arr/aget ys i)))))))))))
+
+(deftest if-merge-deep-arith-loop-test
+  (testing "if with a constant then-branch and a deep .invk-arithmetic else
+            containing a loop compiles and computes correctly"
+    ;; Call directly to exercise the lazy-JIT bytecode path (where the
+    ;; skip-box? misprediction occurs — compile-aot's richer inference hides
+    ;; it). trapezoidal sum of [0 1 4 9] dx=1: 0.5*(0+9) + (1+4) = 9.5
+    (is (== 9.5 (bc-if-deep-arith-loop (double-array [0.0 1.0 4.0 9.0]) 1.0)))))


### PR DESCRIPTION
## Problem

Deep-arithmetic deftm bodies failed JVM bytecode verification with **"Stack size mismatch"** when an `if` had a constant-ish then-branch and a deep `raster.numeric` `.invk`-arithmetic else-branch containing a loop. Seen in `raster.sci.special` (besselj0/bessely0), `raster.sci.quadrature` (trapz), `raster.ad.fixed-point` — only on the **lazy-JIT** path (compile-aot's richer type inference hid it).

## Root cause

`emit-if-handler` has a `skip-box?` optimization: it *predicts* the else-branch's stack type via `infer-arg-stack-type`, and if it equals the then-branch primitive type, emits the then-branch **unboxed** and commits — *before* the else is emitted. When the prediction was wrong (the actually-emitted `else-type` differed), the merge **boxed the else to `:ref`** while the then-branch sat unboxed (a 1-slot ref vs a 1-or-2-slot primitive at the join) → inconsistent operand-stack height at the branch target → verifier failure. It also returned `then-type` while the else path held a `:ref`.

## Fix

At the merge, the prediction must only drive the *optimization*, never the final stack shape. When `skip-box?` committed the then-branch to an unboxed primitive, reconcile the else by **coercing** it to `then-type` (`emit-coerce`) instead of boxing. When `skip-box?` is false the then-branch is already `:ref`, so box the else as before.

```clojure
:else
(if skip-box?
  (do (when (not= else-type then-type) (emit-coerce code else-type then-type))
      (.labelBinding code end-label) then-type)
  (do (when (primitive? else-type) (emit-box-to-ref code else-type))
      (.labelBinding code end-label) :ref))
```

## Minimal repro (regression test added)

```clojure
(if (< (alength ys) 2) 0.0
  (* dx (+ (* 0.5 (+ (double (aget ys 0)) (double (aget ys n-1))))
           (loop [i 1 s 0.0] (if (>= i n-1) s (recur (inc i) (+ s (double (aget ys i)))))))))
```
Fails with "Stack size mismatch" without the fix; returns 9.5 (trapezoidal sum) with it. Added as `if-merge-deep-arith-loop-test` (calls directly to exercise the lazy-JIT path).

## Validation

Full suite **1497 tests / 7199 assertions / 0 failures / 0 errors** (394 s). No regression in the if/branch-heavy tests (`bytecode`, `pipeline-quality`, `devirtualization`). The diff is the single `emit-if-handler` merge change + the regression test (pre-existing file formatting left untouched).

Found while investigating the clojure.core→raster.numeric conversion; this is an independent correctness fix that benefits any deep-arithmetic deftm.
