### PR TITLE
bytecode: never pick a narrowing Java-static overload (econ silent-miscompile fix)

### DIFF
--- a/src/raster/compiler/backend/jvm/bytecode.clj
+++ b/src/raster/compiler/backend/jvm/bytecode.clj
@@ -2315,6 +2315,33 @@
     (.invokestatic code class-desc "invoke" method-type)
     return-stack-type))
 
+;; Numeric widening ranks for overload selection (int < long < float < double).
+;; A boxed/unknown numeric arg (:ref/nil) ranks as double so we never pick a
+;; narrowing primitive overload for it.
+(def ^:private stack-numeric-rank {:int 1 :bool 1 :long 2 :float 3 :double 4 :ref 4 nil 4})
+
+(defn- class-numeric-rank [^Class c]
+  (condp identical? c
+    Integer/TYPE 1 Long/TYPE 2 Float/TYPE 3 Double/TYPE 4 nil))
+
+(defn- pick-widening-numeric-method
+  "From candidate overloads whose params are ALL numeric primitives, pick the
+  one that accepts every arg by widening (param rank >= arg rank) with the
+  tightest total fit. Prevents choosing a NARROWING overload (e.g.
+  Math.min(int,int) for [:double :ref] args) that would truncate the doubles to
+  0 — the static-call selector must never truncate an argument. Returns nil when
+  no candidate is all-numeric (caller falls back to ref/hint matching)."
+  [candidates arg-types]
+  (let [ranked (keep (fn [^java.lang.reflect.Method m]
+                       (let [pranks (mapv class-numeric-rank (.getParameterTypes m))]
+                         (when (and (every? some? pranks)
+                                    (every? true?
+                                            (map (fn [pr at] (>= (long pr) (long (get stack-numeric-rank at 4))))
+                                                 pranks arg-types)))
+                           [(reduce + pranks) m])))
+                     candidates)]
+    (when (seq ranked) (second (apply min-key first ranked)))))
+
 (defn- emit-java-static-call
   "Emit bytecode for Java static method calls (e.g. Math/sin, System/arraycopy).
   Resolves the class and method via reflection, disambiguates overloads by
@@ -2343,9 +2370,14 @@
                                                 (or (nil? at) (= at (class-type->stack pt))))
                                               (.getParameterTypes m) arg-types)))
                                candidates)
+        ;; Numeric widening: never pick a NARROWING primitive overload (it
+        ;; truncates an arg — e.g. Math.min(int,int) on doubles → 0). nil when
+        ;; the candidates aren't all-numeric (falls through to :hint matching).
+        widened (pick-widening-numeric-method candidates arg-types)
         method    (cond
                     (<= (count candidates) 1) (first candidates)
                     (= 1 (count stack-matched)) (first stack-matched)
+                    widened widened
                     ;; Ambiguous ref types — use :hint from locals for precise matching
                     :else
                     (let [hint-resolve

--- a/test/raster/compiler/backend/jvm/bytecode_test.clj
+++ b/test/raster/compiler/backend/jvm/bytecode_test.clj
@@ -570,3 +570,29 @@
     ;; skip-box? misprediction occurs — compile-aot's richer inference hides
     ;; it). trapezoidal sum of [0 1 4 9] dx=1: 0.5*(0+9) + (1+4) = 9.5
     (is (== 9.5 (bc-if-deep-arith-loop (double-array [0.0 1.0 4.0 9.0]) 1.0)))))
+
+;; ================================================================
+;; Java static-method narrowing-overload regression
+;;
+;; A raster.numeric value whose type infers as :ref (boxed) — e.g. one derived
+;; from Math/pow — fed into Math/min as `(Math/min <:double> <:ref>)` matched no
+;; (double,double) overload, so the selector fell through to an arbitrary
+;; candidate (Math.min(int,int)) and emit-coerce truncated the doubles to 0.
+;; The selector must never pick a NARROWING overload. Uses raster.numeric
+;; arithmetic and a direct call (lazy-JIT path, where the :ref tag arises).
+;; ================================================================
+
+(deftm bc-static-narrowing [a :- Double, b :- Double, c :- Double,
+                            d :- Double, e :- Double, f :- Double] :- Double
+  (let [p     (Math/pow e f)       ;; :ref-tagged double
+        step0 (rn// a p)
+        half  (rn// d 2.0)]
+    (Math/min half step0)))
+
+(deftest static-call-narrowing-overload-test
+  (testing "Math/min on a :double and a :ref(-tagged) double must not pick a
+            narrowing int/long overload (which truncates to 0)"
+    ;; e=f=2 → p=4; step0 = -0.12/4 = -0.03; half = 0.999/2 = 0.4995;
+    ;; min(0.4995, -0.03) = -0.03 (the bug returned 0.0).
+    (let [r (bc-static-narrowing -0.12 1.0 1.0 0.999 2.0 2.0)]
+      (is (< (Math/abs (- r -0.03)) 1e-9) (str "got " r)))))


### PR DESCRIPTION
## Problem

A **silent miscompile**: converting `raster.abm.firms.econ` to `raster.numeric` made its Newton solver `solve-effort` return its clamped initial guess (`0.001`) instead of converging (`~0.531`) — both compiled *and* interpreted, while clojure.core arithmetic was correct.

## Root cause (bisected)

All arithmetic *values* were correct; the single failing op was the damping:
```clojure
(Math/min (/ e-max 2.0) step0)   ; returned 0.0, should be -0.0314
```
`emit-java-static-call` picks a `Math.min` overload by matching inferred arg stack types. Here `step0` (derived from `Math/pow`, which is tagged `:ref`) gave arg-types `[:double :ref]`, which matched **no** `(double,double)` overload (`nstack=0`). The selector then fell through to the arbitrary `(first candidates)` — and `.getMethods` order is unspecified, so it landed on **`Math.min(int,int)`**. The per-arg coercion then narrowed the doubles to `int` (`0.4995 → 0`), so `min(0,0) = 0`.

Instrumentation:
```
DBG-STATIC min arg-types= [:double :ref] ncand= 4 nstack= 0 chosen= [int int]
```

## Fix

Add `pick-widening-numeric-method`: among all-numeric-primitive candidate overloads, pick the one that accepts every arg by **widening** (param rank ≥ arg rank, with `:ref`/unknown numeric ranked as `double`) with the tightest fit. The static-call selector must **never** pick a narrowing overload — the prior arbitrary `(first candidates)` was unsound. Tried before the `:hint`-based ref/array matching; returns `nil` for non-numeric candidates, so ref/array methods are unaffected.

## Validation

- Regression test (`static-call-narrowing-overload-test`): a deftm whose `Math/pow`-derived (`:ref`) value feeds `Math/min` returns `0.0` without the fix, the correct value with it (verified fail-without / pass-with).
- Full suite: **1497 tests / 7199 assertions / 0 failures** (274 s). No regression in the static-call / arithmetic tests.

Found while investigating the clojure.core→raster.numeric conversion (companion to the if-merge fix). Independent correctness fix — benefits any deftm whose Java-static-method args have imperfectly-inferred (boxed/`:ref`) numeric types. Pre-existing formatting in `bytecode.clj` left untouched.
