### PR TITLE
numeric: convert Phase-1 sci/abm/ad namespaces to raster.numeric arithmetic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -277,6 +277,16 @@ Clojure arithmetic bypasses typed dispatch and is invisible to the walker. Simil
 The only exception is internal compiler emit code (e.g., `clojure.core/aset` in expanded
 loop bodies) which intentionally bypasses dispatch for direct JVM primitives.
 
+`inc`/`dec` (and `quot`/`rem`/`mod`) stay `clojure.core`: they are integer
+index/counter steppers, never polymorphic float arithmetic. They are already
+optimal on every backend — a zero-cost `ladd`/`lsub` intrinsic in the bytecode
+compiler, `+1`/`-1` in the GPU C emitter, and they are the keys the SIMD
+loop-lift induction-variable matcher (`op_descriptor`) recognizes. Routing them
+through `raster.numeric` would regress the hot path and risk boxing array
+indices. Integer index/counter arithmetic with `+ - * /` (e.g. `(+ (* row n) col)`
+for a flat array index) likewise stays `clojure.core` — only genuine
+floating-point computation goes through `raster.numeric`.
+
 **Centralize operator classification.** Compiler passes must not maintain independent
 hardcoded sets of operator symbols. Operator properties (simplifiable, SIMD-capable,
 effectful, type-preserving, allocating) belong in the op-descriptor registry. Passes

--- a/src/raster/abm/firms/econ.clj
+++ b/src/raster/abm/firms/econ.clj
@@ -6,7 +6,9 @@
    Effort:     Newton-Raphson FOC solver for equal-shares compensation
 
    All functions are deftm — zero allocation, primitive fast-path."
-  (:require [raster.core :refer [deftm]]))
+  (:refer-clojure :exclude [+ - * /])
+  (:require [raster.core :refer [deftm]]
+            [raster.numeric :as n :refer [+ - * /]]))
 
 ;; ================================================================
 ;; Production function: Y = a*E + b*E^β

--- a/src/raster/ad/fixed_point.clj
+++ b/src/raster/ad/fixed_point.clj
@@ -12,8 +12,9 @@
 
    The rrule is registered so reverse-mode AD differentiates through
    fixed-point-solve calls automatically."
+  (:refer-clojure :exclude [+ - * /])
   (:require [raster.core :refer [deftm ftm]]
-            [raster.numeric :as n]
+            [raster.numeric :as n :refer [+ - * /]]
             [raster.ad.templates :as tmpl]))
 
 ;; ================================================================

--- a/src/raster/numeric.clj
+++ b/src/raster/numeric.clj
@@ -172,6 +172,8 @@
 ;; Mark +, *, - as reducible (variadic via fold)
 (set-reducible! #'+)
 (set-reducible! #'*)
+(set-reducible! #'-)
+(set-reducible! #'/)
 
 ;; ================================================================
 ;; Number tower: abs, sign, clamp, min, max, zero?

--- a/src/raster/sci/quadrature.clj
+++ b/src/raster/sci/quadrature.clj
@@ -9,11 +9,11 @@
     (quadgk (fn [x] (* x x)) 0.0 1.0)         ;=> [0.3333... ~0.0]
     (trapz (double-array [0 1 4 9]) 1.0)        ;=> 9.5
     (simps (fn [x] (m/sin x)) 0.0 n/pi)   ;=> ~2.0"
-  (:refer-clojure :exclude [aget aset alength aclone])
+  (:refer-clojure :exclude [aget aset alength aclone + - * /])
   (:require [raster.core :refer [deftm ftm]]
             [raster.arrays :refer [aget aset alength aclone]]
             [raster.math :as m]
-            [raster.numeric :as n]))
+            [raster.numeric :as n :refer [+ - * /]]))
 
 ;; ================================================================
 ;; Gauss-Kronrod 7-15 point rule

--- a/src/raster/sci/roots.clj
+++ b/src/raster/sci/roots.clj
@@ -14,9 +14,10 @@
     (newton (ftm [x :- Double] :- Double (- (* x x) 2.0))
             (ftm [x :- Double] :- Double (* 2.0 x))
             1.5)"
+  (:refer-clojure :exclude [+ - * /])
   (:require [raster.core :refer [deftm ftm]]
             [raster.math :as m]
-            [raster.numeric :as n]))
+            [raster.numeric :as n :refer [+ - * /]]))
 
 ;; ================================================================
 ;; Bisection method

--- a/src/raster/sci/special.clj
+++ b/src/raster/sci/special.clj
@@ -9,11 +9,11 @@
     (require '[raster.sci.special :refer [lgamma gamma digamma erf besselj0]])
     (lgamma 5.0)       ;; => 3.178053830...
     (besselj0 1.0)     ;; => 0.765197686..."
-  (:refer-clojure :exclude [aget aset alength aclone])
+  (:refer-clojure :exclude [aget aset alength aclone + - * /])
   (:require [raster.core :refer [deftm]]
             [raster.arrays :refer [aget aset alength aclone]]
             [raster.math :as m]
-            [raster.numeric :as n]))
+            [raster.numeric :as n :refer [+ - * /]]))
 
 ;; ================================================================
 ;; Constants

--- a/src/raster/sci/stats.clj
+++ b/src/raster/sci/stats.clj
@@ -12,11 +12,11 @@
      (t-test-1sample (double-array [1 2 3 4 5]) 5 0.0)
      (describe (double-array [1 2 3 4 5]) 5)
      (pearson (double-array [1 2 3]) (double-array [2 4 6]) 3)"
-  (:refer-clojure :exclude [aget aset alength aclone])
+  (:refer-clojure :exclude [aget aset alength aclone + - * /])
   (:require [raster.core :refer [deftm defvalue reduce!]]
             [raster.arrays :refer [aget aset alength aclone]]
             [raster.math :as m]
-            [raster.numeric :as n]
+            [raster.numeric :as n :refer [+ - * /]]
             [raster.sci.special :refer [lgamma gammainc betainc]]))
 
 ;; ================================================================


### PR DESCRIPTION
## What

Converts six numeric namespaces from `clojure.core` to `raster.numeric` arithmetic (`+ - * /`), per the CLAUDE.md convention that numeric-computation arithmetic must flow through typed dispatch (so it devirtualizes and is AOT/GPU-compilable):

`sci.special`, `sci.roots`, `sci.stats`, `sci.quadrature`, `abm.firms.econ`, `ad.fixed-point`.

The change is ns-level only — `:refer` raster.numeric `+ - * /` and exclude them from clojure.core; the bodies are unchanged (their bare `+ - * /` now resolve to raster.numeric). These are all-float numeric namespaces; integer index/counter arithmetic and `inc`/`dec` stay clojure.core.

Also:
- **Mark n-ary `-` and `/` reducible** (`set-reducible!`). The comment already said "+,*,-" but only `+`,`*` were registered, so `(- a b c)` / `(/ a b c)` reached dispatch as raw 3-arg calls. The walker and dispatch fn left-fold reducible ops only at arity >2, so unary `(- x)`/`(/ x)` and binary calls are unaffected; left-fold is the correct n-ary semantics for the non-associative `-`, `/`.
- **Document the `inc`/`dec` + integer-index-arithmetic exception** in CLAUDE.md.

## Why it was blocked (now unblocked)

This conversion surfaced — and depended on — three separate compiler bugs, all now fixed on main:
- TC arithmetic exponential re-checking (#8)
- if-merge branch-merge stack mismatch (#9)
- Java-static narrowing-overload truncation (#10)

## Validation

Full suite **1498 tests / 7200 assertions / 0 failures** on top of #7–#10. Each converted namespace's test passes; `numeric`/`linalg.core` regression-checked for the reducible change.

## Follow-up

Phase 2 (per-site conversion of mixed float/index namespaces: `sci.distributions`, `sci.optim`, `sci.signal`, `sci.fft`, `noise`, …) remains a separate effort — those interleave float math with flat array indices, so they need per-site `n/` rather than a blanket ns `:refer`.
