### PR TITLE
compiler: JIT materialize pass + Phase-2 raster.numeric conversion

### DIFF
--- a/src/raster/compiler/backend/jvm/bytecode.clj
+++ b/src/raster/compiler/backend/jvm/bytecode.clj
@@ -553,14 +553,6 @@
     (try (par/expand-par-reduce form)
          (catch Throwable _ form))
 
-    ;; Pure par/pmap (value-producing, no output buffer): the lazy-JIT path
-    ;; doesn't run the `materialize` pipeline pass, so a `raster.par/pmap` form
-    ;; (e.g. from `broadcast`) would leak to the Java static-call emitter and
-    ;; fail with "Cannot resolve class: raster.par". Materialize it here (alloc
-    ;; + par/map!) and re-expand. Symbolic + load-order independent.
-    (par/par-map-pure-form? form)
-    (pre-expand-par-forms (:form (materialize/materialize-pass form nil)))
-
     ;; Replace (dotimes [i n] body) with int-counted loop*
     (and (seq? form)
          (let [h (first form)]
@@ -581,6 +573,17 @@
     (vector? form)
     (with-meta (mapv pre-expand-par-forms form) (meta form))
     :else form))
+
+(defn- materialize-form
+  "Run the `materialize` pass on a single form: pure par/pmap (value-producing,
+  no output buffer — e.g. from `broadcast`) → alloc + par/map!. Used in the
+  lazy-JIT compile chain AFTER macroexpand-all, so it sees only plain-symbol
+  let* (the pass's input dialect) — running it earlier would rewrite a `let`
+  with destructuring to `let*` and orphan the destructured symbols. Keeps the
+  JIT path lowering pure par forms via the same pass compile-aot uses, so they
+  can't diverge (otherwise pure par/pmap leaks unlowered to the emitter)."
+  [form]
+  (:form (materialize/materialize-pass form nil)))
 
 ;; Forward declarations for mutual recursion
 (declare emit-form)
@@ -4541,7 +4544,7 @@
                                                             :next-slot        next-slot
                                                             :source-ns        source-ns}
                                                        expanded-body (binding [*ns* source-ns]
-                                                                       (mapv (comp pre-expand-par-forms macroexpand-all-preserving desugar-invk pre-expand-par-forms) walked-body))
+                                                                       (mapv (comp pre-expand-par-forms materialize-form macroexpand-all-preserving desugar-invk pre-expand-par-forms) walked-body))
                                                        ret-type (emit-body code expanded-body locals ctx)]
                               ;; Return according to method signature type
                                                    (when-not (#{:void :diverge} ret-type)
@@ -4616,7 +4619,7 @@
                                                             :source-ns  source-ns
                                                             :typed-sibling-methods typed-sibling-methods}
                                                        expanded-body (binding [*ns* source-ns]
-                                                                       (mapv (comp pre-expand-par-forms macroexpand-all-preserving desugar-invk pre-expand-par-forms) walked-body))
+                                                                       (mapv (comp pre-expand-par-forms materialize-form macroexpand-all-preserving desugar-invk pre-expand-par-forms) walked-body))
                                                        ret-type (emit-body code expanded-body locals ctx)
                                                        target-st (:stack-type return-info)
                                                        ret-cd (:class-desc return-info)]

--- a/src/raster/compiler/backend/jvm/bytecode.clj
+++ b/src/raster/compiler/backend/jvm/bytecode.clj
@@ -6,6 +6,7 @@
   special forms + function calls.  Same approach as partial-cps/ioc.clj.
   This generalizes to arbitrary Clojure code in deftm bodies."
   (:require [raster.compiler.ir.par :as par]
+            [raster.compiler.passes.parallel.materialize :as materialize]
             [raster.compiler.core.method-entry :as me]
             [raster.compiler.core.inference :as inf]
             [raster.compiler.core.util :as util]
@@ -551,6 +552,15 @@
     (par/par-reduce-form? form)
     (try (par/expand-par-reduce form)
          (catch Throwable _ form))
+
+    ;; Pure par/pmap (value-producing, no output buffer): the lazy-JIT path
+    ;; doesn't run the `materialize` pipeline pass, so a `raster.par/pmap` form
+    ;; (e.g. from `broadcast`) would leak to the Java static-call emitter and
+    ;; fail with "Cannot resolve class: raster.par". Materialize it here (alloc
+    ;; + par/map!) and re-expand. Symbolic + load-order independent.
+    (par/par-map-pure-form? form)
+    (pre-expand-par-forms (:form (materialize/materialize-pass form nil)))
+
     ;; Replace (dotimes [i n] body) with int-counted loop*
     (and (seq? form)
          (let [h (first form)]

--- a/src/raster/dl/diffusion.clj
+++ b/src/raster/dl/diffusion.clj
@@ -23,15 +23,15 @@
 (deftm linear-beta-schedule (All [T] [num-steps :- Long beta-start :- Double beta-end :- Double]
                                  :- (Array double)
                                  (par/map [i num-steps]
-                                          (+ beta-start (* (/ (double i) (double (- num-steps 1))) (- beta-end beta-start))))))
+                                          (n/+ beta-start (n/* (n// (double i) (double (- num-steps 1))) (n/- beta-end beta-start))))))
 
 (deftm cosine-beta-schedule (All [T] [num-steps :- Long s :- Double] :- (Array double)
                                  (par/map [i num-steps]
-                                          (let [t1 (/ (double i) (double num-steps))
-                                                t2 (/ (double (+ i 1)) (double num-steps))
-                                                a1 (m/cos (* (/ (+ t1 s) (+ 1.0 s)) (* 0.5 n/pi)))
-                                                a2 (m/cos (* (/ (+ t2 s) (+ 1.0 s)) (* 0.5 n/pi)))
-                                                b (n/min 0.999 (- 1.0 (/ (* a2 a2) (* a1 a1))))]
+                                          (let [t1 (n// (double i) (double num-steps))
+                                                t2 (n// (double (+ i 1)) (double num-steps))
+                                                a1 (m/cos (n/* (n// (n/+ t1 s) (n/+ 1.0 s)) (n/* 0.5 n/pi)))
+                                                a2 (m/cos (n/* (n// (n/+ t2 s) (n/+ 1.0 s)) (n/* 0.5 n/pi)))
+                                                b (n/min 0.999 (n/- 1.0 (n// (n/* a2 a2) (n/* a1 a1))))]
                                             (n/max 0.0001 b)))))
 
 (deftm cosine-beta-schedule (All [T] [num-steps :- Long] :- (Array double)
@@ -42,7 +42,7 @@
                                          alphas-cumprod (n/similar betas)]
                                      (loop [i 0 prod 1.0]
                                        (when (< i n)
-                                         (let [a (* prod (- 1.0 (aget betas i)))]
+                                         (let [a (n/* prod (n/- 1.0 (aget betas i)))]
                                            (aset alphas-cumprod i a)
                                            (recur (inc i) a))))
                                      alphas-cumprod)))
@@ -54,9 +54,9 @@
 (deftm forward-noise (All [T] [x0 :- (Array T) noise :- (Array T)
                                alpha-t :- Double n :- Long] :- (Array T)
                           (let [sqrt-alpha (n/sqrt alpha-t)
-                                sqrt-1ma (n/sqrt (- 1.0 alpha-t))]
+                                sqrt-1ma (n/sqrt (n/- 1.0 alpha-t))]
                             (broadcast [x0 noise]
-                                       (+ (* sqrt-alpha x0) (* sqrt-1ma noise))))))
+                                       (n/+ (n/* sqrt-alpha x0) (n/* sqrt-1ma noise))))))
 
 ;; forward-noise rrule
 (tmpl/merge-into-template! 'raster.dl.diffusion/forward-noise
@@ -81,10 +81,10 @@
 (deftm predict-x0 (All [T] [xt :- (Array T) eps-pred :- (Array T)
                             alpha-t :- Double n :- Long] :- (Array T)
                        (let [sqrt-alpha (n/sqrt alpha-t)
-                             sqrt-1ma (n/sqrt (- 1.0 alpha-t))
-                             inv-sqrt-alpha (/ 1.0 sqrt-alpha)]
+                             sqrt-1ma (n/sqrt (n/- 1.0 alpha-t))
+                             inv-sqrt-alpha (n// 1.0 sqrt-alpha)]
                          (broadcast [xt eps-pred]
-                                    (* inv-sqrt-alpha (- xt (* sqrt-1ma eps-pred)))))))
+                                    (n/* inv-sqrt-alpha (n/- xt (n/* sqrt-1ma eps-pred)))))))
 
 ;; ================================================================
 ;; DDPM reverse sampling step
@@ -96,12 +96,12 @@
                                   alpha-bar-t :- Double n :- Long]
                              :- (Array T)
                              (let [;; mu = (1/sqrt(alpha_t)) * (x_t - beta_t/sqrt(1-alpha_bar_t) * eps)
-                                   inv-sqrt-alpha (/ 1.0 (n/sqrt alpha-t))
-                                   coeff (/ beta-t (n/sqrt (- 1.0 alpha-bar-t)))
+                                   inv-sqrt-alpha (n// 1.0 (n/sqrt alpha-t))
+                                   coeff (n// beta-t (n/sqrt (n/- 1.0 alpha-bar-t)))
                                    sigma (n/sqrt beta-t)]
                                (broadcast [xt eps-pred noise]
-                                          (+ (* inv-sqrt-alpha (- xt (* coeff eps-pred)))
-                                             (* sigma noise))))))
+                                          (n/+ (n/* inv-sqrt-alpha (n/- xt (n/* coeff eps-pred)))
+                                               (n/* sigma noise))))))
 
 ;; ================================================================
 ;; Backward helper for forward-noise
@@ -112,13 +112,13 @@
                                         alpha-t :- Double n :- Long]
                                    :- (Array Object)
                                    (let [sqrt-alpha (n/sqrt alpha-t)
-                                         sqrt-1ma (n/sqrt (- 1.0 alpha-t))
+                                         sqrt-1ma (n/sqrt (n/- 1.0 alpha-t))
                                          dx0 (n/similar dy)
                                          d-noise (n/similar dy)]
                                      (dotimes [i n]
                                        (let [dyi (aget dy i)]
-                                         (aset dx0 i (* dyi sqrt-alpha))
-                                         (aset d-noise i (* dyi sqrt-1ma))))
+                                         (aset dx0 i (n/* dyi sqrt-alpha))
+                                         (aset d-noise i (n/* dyi sqrt-1ma))))
                                      (object-array [dx0 d-noise]))))
 
 ;; ================================================================

--- a/src/raster/noise.clj
+++ b/src/raster/noise.clj
@@ -10,7 +10,8 @@
     (perlin3d perm 1.5 2.3 0.7)    ;; → double in [-1, 1]
     (fbm2d perm 1.5 2.3 4 0.5 2.0) ;; → multi-octave noise
     (ridged2d perm 1.5 2.3 4 0.5 2.0) ;; → ridged noise (canyons/cliffs)"
-  (:require [raster.core :refer [deftm]])
+  (:require [raster.core :refer [deftm]]
+            [raster.numeric :as n])
   (:import [java.util Random]))
 
 ;; ================================================================
@@ -40,22 +41,22 @@
 (deftm fade
   "Quintic interpolation curve: 6t^5 - 15t^4 + 10t^3"
   [t :- Double] :- Double
-  (* t t t (+ (* t (- (* t 6.0) 15.0)) 10.0)))
+  (n/* (n/* (n/* t t) t) (n/+ (n/* t (n/- (n/* t 6.0) 15.0)) 10.0)))
 
 (deftm lerp
   "Linear interpolation."
   [t :- Double, a :- Double, b :- Double] :- Double
-  (+ a (* t (- b a))))
+  (n/+ a (n/* t (n/- b a))))
 
 (deftm grad2d
   "2D gradient dot product."
   [hash :- Long, x :- Double, y :- Double] :- Double
   (let [h (bit-and hash 3)]
     (case (int h)
-      0 (+ x y)
-      1 (+ (- x) y)
-      2 (- x y)
-      3 (- (- x) y))))
+      0 (n/+ x y)
+      1 (n/+ (n/- x) y)
+      2 (n/- x y)
+      3 (n/- (n/- x) y))))
 
 (deftm grad3d
   "3D gradient dot product."
@@ -63,8 +64,8 @@
   (let [h (bit-and hash 15)
         u (if (< h 8) x y)
         v (if (< h 4) y (if (or (= h 12) (= h 14)) x z))]
-    (+ (if (zero? (bit-and h 1)) u (- u))
-       (if (zero? (bit-and h 2)) v (- v)))))
+    (n/+ (if (zero? (bit-and h 1)) u (n/- u))
+         (if (zero? (bit-and h 2)) v (n/- v)))))
 
 ;; ================================================================
 ;; Perlin noise 2D / 3D
@@ -76,8 +77,8 @@
   [perm :- (Array int), x :- Double, y :- Double] :- Double
   (let [xi (bit-and (long (Math/floor x)) 255)
         yi (bit-and (long (Math/floor y)) 255)
-        xf (- x (Math/floor x))
-        yf (- y (Math/floor y))
+        xf (n/- x (Math/floor x))
+        yf (n/- y (Math/floor y))
         u (fade xf)
         v (fade yf)
         aa (long (aget perm (+ (aget perm xi) yi)))
@@ -85,8 +86,8 @@
         ba (long (aget perm (+ (aget perm (+ xi 1)) yi)))
         bb (long (aget perm (+ (aget perm (+ xi 1)) yi 1)))]
     (lerp v
-          (lerp u (grad2d aa xf yf) (grad2d ba (- xf 1.0) yf))
-          (lerp u (grad2d ab xf (- yf 1.0)) (grad2d bb (- xf 1.0) (- yf 1.0))))))
+          (lerp u (grad2d aa xf yf) (grad2d ba (n/- xf 1.0) yf))
+          (lerp u (grad2d ab xf (n/- yf 1.0)) (grad2d bb (n/- xf 1.0) (n/- yf 1.0))))))
 
 (deftm perlin3d
   "3D Perlin noise, returns value in [-1, 1].
@@ -95,9 +96,9 @@
   (let [xi (bit-and (long (Math/floor x)) 255)
         yi (bit-and (long (Math/floor y)) 255)
         zi (bit-and (long (Math/floor z)) 255)
-        xf (- x (Math/floor x))
-        yf (- y (Math/floor y))
-        zf (- z (Math/floor z))
+        xf (n/- x (Math/floor x))
+        yf (n/- y (Math/floor y))
+        zf (n/- z (Math/floor z))
         u (fade xf)
         v (fade yf)
         w (fade zf)
@@ -110,14 +111,14 @@
     (lerp w
           (lerp v
                 (lerp u (grad3d (long (aget perm aa)) xf yf zf)
-                      (grad3d (long (aget perm ba)) (- xf 1.0) yf zf))
-                (lerp u (grad3d (long (aget perm ab)) xf (- yf 1.0) zf)
-                      (grad3d (long (aget perm bb)) (- xf 1.0) (- yf 1.0) zf)))
+                      (grad3d (long (aget perm ba)) (n/- xf 1.0) yf zf))
+                (lerp u (grad3d (long (aget perm ab)) xf (n/- yf 1.0) zf)
+                      (grad3d (long (aget perm bb)) (n/- xf 1.0) (n/- yf 1.0) zf)))
           (lerp v
-                (lerp u (grad3d (long (aget perm (+ aa 1))) xf yf (- zf 1.0))
-                      (grad3d (long (aget perm (+ ba 1))) (- xf 1.0) yf (- zf 1.0)))
-                (lerp u (grad3d (long (aget perm (+ ab 1))) xf (- yf 1.0) (- zf 1.0))
-                      (grad3d (long (aget perm (+ bb 1))) (- xf 1.0) (- yf 1.0) (- zf 1.0)))))))
+                (lerp u (grad3d (long (aget perm (+ aa 1))) xf yf (n/- zf 1.0))
+                      (grad3d (long (aget perm (+ ba 1))) (n/- xf 1.0) yf (n/- zf 1.0)))
+                (lerp u (grad3d (long (aget perm (+ ab 1))) xf (n/- yf 1.0) (n/- zf 1.0))
+                      (grad3d (long (aget perm (+ bb 1))) (n/- xf 1.0) (n/- yf 1.0) (n/- zf 1.0)))))))
 
 ;; ================================================================
 ;; Multi-octave noise (FBM, ridged)
@@ -130,12 +131,12 @@
    octaves :- Long, persistence :- Double, lacunarity :- Double] :- Double
   (loop [i (long 0) amp 1.0 freq 1.0 sum 0.0 max-amp 0.0]
     (if (= i octaves)
-      (/ sum max-amp)
+      (n// sum max-amp)
       (recur (inc i)
-             (* amp persistence)
-             (* freq lacunarity)
-             (+ sum (* amp (perlin2d perm (* x freq) (* y freq))))
-             (+ max-amp amp)))))
+             (n/* amp persistence)
+             (n/* freq lacunarity)
+             (n/+ sum (n/* amp (perlin2d perm (n/* x freq) (n/* y freq))))
+             (n/+ max-amp amp)))))
 
 (deftm fbm3d
   "Fractional Brownian Motion — multi-octave 3D Perlin noise.
@@ -144,12 +145,12 @@
    octaves :- Long, persistence :- Double, lacunarity :- Double] :- Double
   (loop [i (long 0) amp 1.0 freq 1.0 sum 0.0 max-amp 0.0]
     (if (= i octaves)
-      (/ sum max-amp)
+      (n// sum max-amp)
       (recur (inc i)
-             (* amp persistence)
-             (* freq lacunarity)
-             (+ sum (* amp (perlin3d perm (* x freq) (* y freq) (* z freq))))
-             (+ max-amp amp)))))
+             (n/* amp persistence)
+             (n/* freq lacunarity)
+             (n/+ sum (n/* amp (perlin3d perm (n/* x freq) (n/* y freq) (n/* z freq))))
+             (n/+ max-amp amp)))))
 
 (deftm ridged2d
   "Ridged multi-fractal 2D noise — abs(noise) inverted to create ridges.
@@ -158,13 +159,13 @@
    octaves :- Long, persistence :- Double, lacunarity :- Double] :- Double
   (loop [i (long 0) amp 1.0 freq 1.0 sum 0.0 max-amp 0.0]
     (if (= i octaves)
-      (/ sum max-amp)
-      (let [n (- 1.0 (Math/abs (perlin2d perm (* x freq) (* y freq))))]
+      (n// sum max-amp)
+      (let [n (n/- 1.0 (Math/abs (perlin2d perm (n/* x freq) (n/* y freq))))]
         (recur (inc i)
-               (* amp persistence)
-               (* freq lacunarity)
-               (+ sum (* amp (* n n)))
-               (+ max-amp amp))))))
+               (n/* amp persistence)
+               (n/* freq lacunarity)
+               (n/+ sum (n/* amp (n/* n n)))
+               (n/+ max-amp amp))))))
 
 (deftm ridged3d
   "Ridged multi-fractal 3D noise."
@@ -172,10 +173,10 @@
    octaves :- Long, persistence :- Double, lacunarity :- Double] :- Double
   (loop [i (long 0) amp 1.0 freq 1.0 sum 0.0 max-amp 0.0]
     (if (= i octaves)
-      (/ sum max-amp)
-      (let [n (- 1.0 (Math/abs (perlin3d perm (* x freq) (* y freq) (* z freq))))]
+      (n// sum max-amp)
+      (let [n (n/- 1.0 (Math/abs (perlin3d perm (n/* x freq) (n/* y freq) (n/* z freq))))]
         (recur (inc i)
-               (* amp persistence)
-               (* freq lacunarity)
-               (+ sum (* amp (* n n)))
-               (+ max-amp amp))))))
+               (n/* amp persistence)
+               (n/* freq lacunarity)
+               (n/+ sum (n/* amp (n/* n n)))
+               (n/+ max-amp amp))))))

--- a/src/raster/sci/distributions.clj
+++ b/src/raster/sci/distributions.clj
@@ -46,44 +46,44 @@
 
 (declare lgamma regularized-beta-cf)
 
-(def ^:private ^:const LOG_2PI (m/log (* 2.0 mn/pi)))
+(def ^:private ^:const LOG_2PI (m/log (mn/* 2.0 mn/pi)))
 (def ^:private ^:const SQRT_2 (mn/sqrt 2.0))
-(def ^:private ^:const INV_SQRT_2 (/ 1.0 SQRT_2))
+(def ^:private ^:const INV_SQRT_2 (mn// 1.0 SQRT_2))
 (def ^:private ^:const LOG_2 (m/log 2.0))
 
 (deftm erf [x :- Double] :- Double
   (let [sign (if (neg? x) -1.0 1.0)
         x (mn/abs x)
-        t (/ 1.0 (m/fma 0.3275911 x 1.0))
-        y (* t (m/fma t (m/fma t (m/fma t (m/fma t 1.061405429
+        t (mn// 1.0 (m/fma 0.3275911 x 1.0))
+        y (mn/* t (m/fma t (m/fma t (m/fma t (m/fma t 1.061405429
                                                  -1.453152027)
                                         1.421413741)
                                -0.284496736)
                       0.254829592))
-        result (- 1.0 (* y (m/exp (- (* x x)))))]
-    (* sign result)))
+        result (mn/- 1.0 (mn/* y (m/exp (- (mn/* x x)))))]
+    (mn/* sign result)))
 
 (deftm erfc [x :- Double] :- Double
-  (- 1.0 (erf x)))
+  (mn/- 1.0 (erf x)))
 
-(def ^:private ^:const INV_SQRT_PI (/ 2.0 (mn/sqrt mn/pi)))
+(def ^:private ^:const INV_SQRT_PI (mn// 2.0 (mn/sqrt mn/pi)))
 
 (deftm erfinv [y :- Double] :- Double
   (if (== y 0.0)
     0.0
     ;; Initial approximation using Winitzki's formula
     (let [a  0.147
-          ln1my2 (m/log (- 1.0 (* y y)))
-          b  (+ (/ 2.0 (* mn/pi a)) (* 0.5 ln1my2))
-          x0 (* (m/signum y)
-                (mn/sqrt (- (mn/sqrt (- (* b b) (/ ln1my2 a))) b)))]
+          ln1my2 (m/log (mn/- 1.0 (mn/* y y)))
+          b  (mn/+ (mn// 2.0 (mn/* mn/pi a)) (mn/* 0.5 ln1my2))
+          x0 (mn/* (m/signum y)
+                (mn/sqrt (mn/- (mn/sqrt (mn/- (mn/* b b) (mn// ln1my2 a))) b)))]
       ;; Newton-Raphson: x_{n+1} = x_n + (y - erf(x_n)) / (2/sqrt(pi) * exp(-x_n^2))
       (loop [x x0 iter 0]
         (if (>= iter 8)
           x
-          (let [err (- y (erf x))
-                deriv (* INV_SQRT_PI (m/exp (- (* x x))))
-                x-new (+ x (/ err deriv))]
+          (let [err (mn/- y (erf x))
+                deriv (mn/* INV_SQRT_PI (m/exp (- (mn/* x x))))
+                x-new (mn/+ x (mn// err deriv))]
             (if (< (mn/abs err) 1e-15)
               x-new
               (recur x-new (inc iter)))))))))
@@ -92,9 +92,9 @@
   ;; For x >= 0.5, use Lanczos approximation (g=7, n=9)
   (if (< x 0.5)
     ;; Reflection formula: Gamma(x) = pi / (sin(pi*x) * Gamma(1-x))
-    (- (m/log (/ mn/pi (m/sin (* mn/pi x))))
-       (lgamma (- 1.0 x)))
-    (let [x (- x 1.0)
+    (mn/- (m/log (mn// mn/pi (m/sin (mn/* mn/pi x))))
+       (lgamma (mn/- 1.0 x)))
+    (let [x (mn/- x 1.0)
           coeffs (double-array [676.5203681218851
                                 -1259.1392167224028
                                 771.32342877765313
@@ -109,9 +109,9 @@
           s (loop [i 7 acc 0.99999999999980993]
               (if (neg? i)
                 acc
-                (recur (dec i) (+ acc (/ (aget coeffs i) (+ x (double i) 1.0))))))]
-      (+ (* 0.5 (m/log (* 2.0 mn/pi)))
-         (* (+ x 0.5) (m/log t))
+                (recur (dec i) (mn/+ acc (mn// (aget coeffs i) (+ x (double i) 1.0))))))]
+      (+ (mn/* 0.5 (m/log (mn/* 2.0 mn/pi)))
+         (mn/* (mn/+ x 0.5) (m/log t))
          (- t)
          (m/log s)))))
 
@@ -119,42 +119,42 @@
   (if (<= x 0.0)
     0.0
     (let [lga (lgamma a)]
-      (loop [n 0 sum 0.0 term (/ 1.0 a)]
-        (if (or (> n 200) (< (mn/abs term) (* 1e-14 (mn/abs sum))))
-          (* sum (m/exp (- (* a (m/log x)) x lga)))
-          (let [new-sum (+ sum term)
-                new-term (* term (/ x (+ a (double n) 1.0)))]
+      (loop [n 0 sum 0.0 term (mn// 1.0 a)]
+        (if (or (> n 200) (< (mn/abs term) (mn/* 1e-14 (mn/abs sum))))
+          (mn/* sum (m/exp (- (mn/* a (m/log x)) x lga)))
+          (let [new-sum (mn/+ sum term)
+                new-term (mn/* term (mn// x (+ a (double n) 1.0)))]
             (recur (inc n) new-sum new-term)))))))
 
 (deftm logsumexp [a :- Double, b :- Double] :- Double
   (let [mx (mn/max a b)]
-    (+ mx (m/log (+ (m/exp (- a mx)) (m/exp (- b mx)))))))
+    (mn/+ mx (m/log (mn/+ (m/exp (mn/- a mx)) (m/exp (mn/- b mx)))))))
 
 ;; ================================================================
 ;; logpdf / pdf — continuous distributions
 ;; ================================================================
 
 (deftm logpdf [d :- Normal, x :- Double] :- Double
-  (let [z (/ (- x (.mu d)) (.sigma d))]
-    (* -0.5 (+ LOG_2PI (* 2.0 (m/log (.sigma d))) (* z z)))))
+  (let [z (mn// (mn/- x (.mu d)) (.sigma d))]
+    (mn/* -0.5 (+ LOG_2PI (mn/* 2.0 (m/log (.sigma d))) (mn/* z z)))))
 
 (deftm logpdf [d :- Uniform, x :- Double] :- Double
   (if (and (>= x (.a d)) (<= x (.b d)))
-    (- (m/log (- (.b d) (.a d))))
+    (- (m/log (mn/- (.b d) (.a d))))
     mn/neg-inf))
 
 (deftm logpdf [d :- Exponential, x :- Double] :- Double
   (if (>= x 0.0)
-    (- (m/log (.lambda d)) (* (.lambda d) x))
+    (mn/- (m/log (.lambda d)) (mn/* (.lambda d) x))
     mn/neg-inf))
 
 (deftm logpdf [d :- Gamma, x :- Double] :- Double
   (if (> x 0.0)
     (let [a (.alpha d) b (.beta d)]
-      (- (* (- a 1.0) (m/log x))
-         (/ x b)
+      (- (mn/* (mn/- a 1.0) (m/log x))
+         (mn// x b)
          (lgamma a)
-         (* a (m/log b))))
+         (mn/* a (m/log b))))
     mn/neg-inf))
 
 ;; Generic logpdf fallbacks using polymorphic arithmetic (AD-compatible).
@@ -162,7 +162,7 @@
 ;; ones, enabling automatic differentiation through logpdf.
 (deftm logpdf [d :- Normal, x :- Object]
   (let [z (mn// (mn/- x (.mu d)) (.sigma d))]
-    (mn/* -0.5 (mn/+ LOG_2PI (* 2.0 (m/log (.sigma d))) (mn/* z z)))))
+    (mn/* -0.5 (mn/+ LOG_2PI (mn/* 2.0 (m/log (.sigma d))) (mn/* z z)))))
 
 (deftm logpdf [d :- Exponential, x :- Object]
   (mn/- (m/log (.lambda d)) (mn/* (.lambda d) x)))
@@ -178,7 +178,7 @@
 (deftm logpmf [d :- Poisson, k :- Long] :- Double
   (if (>= k 0)
     (let [lam (.lambda d)]
-      (- (* (double k) (m/log lam)) lam (lgamma (+ (double k) 1.0))))
+      (- (mn/* (double k) (m/log lam)) lam (lgamma (mn/+ (double k) 1.0))))
     mn/neg-inf))
 
 (deftm pmf [d :- Poisson, k :- Long] :- Double
@@ -189,23 +189,23 @@
 ;; ================================================================
 
 (deftm cdf [d :- Normal, x :- Double] :- Double
-  (let [z (/ (- x (.mu d)) (.sigma d))]
-    (* 0.5 (+ 1.0 (erf (* INV_SQRT_2 z))))))
+  (let [z (mn// (mn/- x (.mu d)) (.sigma d))]
+    (mn/* 0.5 (mn/+ 1.0 (erf (mn/* INV_SQRT_2 z))))))
 
 (deftm cdf [d :- Uniform, x :- Double] :- Double
   (cond
     (< x (.a d)) 0.0
     (> x (.b d)) 1.0
-    :else (/ (- x (.a d)) (- (.b d) (.a d)))))
+    :else (mn// (mn/- x (.a d)) (mn/- (.b d) (.a d)))))
 
 (deftm cdf [d :- Exponential, x :- Double] :- Double
   (if (>= x 0.0)
-    (- 1.0 (m/exp (- (* (.lambda d) x))))
+    (mn/- 1.0 (m/exp (- (mn/* (.lambda d) x))))
     0.0))
 
 (deftm cdf [d :- Gamma, x :- Double] :- Double
   (if (> x 0.0)
-    (regularized-gamma-p (.alpha d) (/ x (.beta d)))
+    (regularized-gamma-p (.alpha d) (mn// x (.beta d)))
     0.0))
 
 (deftm cdf [d :- Poisson, x :- Double] :- Double
@@ -214,20 +214,20 @@
     (let [k (long (m/floor x))
           lam (.lambda d)]
       ;; CDF = 1 - P(alpha, lambda) where alpha = k+1
-      (- 1.0 (regularized-gamma-p (+ (double k) 1.0) lam)))))
+      (mn/- 1.0 (regularized-gamma-p (mn/+ (double k) 1.0) lam)))))
 
 ;; ================================================================
 ;; Quantile (inverse CDF)
 ;; ================================================================
 
 (deftm quantile [d :- Normal, p :- Double] :- Double
-  (+ (.mu d) (* (.sigma d) SQRT_2 (erfinv (- (* 2.0 p) 1.0)))))
+  (mn/+ (.mu d) (* (.sigma d) SQRT_2 (erfinv (mn/- (mn/* 2.0 p) 1.0)))))
 
 (deftm quantile [d :- Uniform, p :- Double] :- Double
-  (+ (.a d) (* p (- (.b d) (.a d)))))
+  (mn/+ (.a d) (mn/* p (mn/- (.b d) (.a d)))))
 
 (deftm quantile [d :- Exponential, p :- Double] :- Double
-  (/ (- (m/log (- 1.0 p))) (.lambda d)))
+  (mn// (- (m/log (mn/- 1.0 p))) (.lambda d)))
 
 ;; ================================================================
 ;; Statistics
@@ -235,18 +235,18 @@
 
 ;; --- Mean ---
 (deftm mean [d :- Normal] :- Double (.mu d))
-(deftm mean [d :- Uniform] :- Double (* 0.5 (+ (.a d) (.b d))))
-(deftm mean [d :- Exponential] :- Double (/ 1.0 (.lambda d)))
-(deftm mean [d :- Gamma] :- Double (* (.alpha d) (.beta d)))
+(deftm mean [d :- Uniform] :- Double (mn/* 0.5 (mn/+ (.a d) (.b d))))
+(deftm mean [d :- Exponential] :- Double (mn// 1.0 (.lambda d)))
+(deftm mean [d :- Gamma] :- Double (mn/* (.alpha d) (.beta d)))
 (deftm mean [d :- Poisson] :- Double (.lambda d))
 
 ;; --- Variance ---
-(deftm variance [d :- Normal] :- Double (* (.sigma d) (.sigma d)))
+(deftm variance [d :- Normal] :- Double (mn/* (.sigma d) (.sigma d)))
 (deftm variance [d :- Uniform] :- Double
-  (let [w (- (.b d) (.a d))]
-    (/ (* w w) 12.0)))
+  (let [w (mn/- (.b d) (.a d))]
+    (mn// (mn/* w w) 12.0)))
 (deftm variance [d :- Exponential] :- Double
-  (/ 1.0 (* (.lambda d) (.lambda d))))
+  (mn// 1.0 (mn/* (.lambda d) (.lambda d))))
 (deftm variance [d :- Gamma] :- Double
   (* (.alpha d) (.beta d) (.beta d)))
 (deftm variance [d :- Poisson] :- Double (.lambda d))
@@ -257,21 +257,21 @@
 
 ;; --- Entropy ---
 (deftm entropy [d :- Normal] :- Double
-  (* 0.5 (+ 1.0 LOG_2PI (* 2.0 (m/log (.sigma d))))))
+  (mn/* 0.5 (+ 1.0 LOG_2PI (mn/* 2.0 (m/log (.sigma d))))))
 
 (deftm entropy [d :- Uniform] :- Double
-  (m/log (- (.b d) (.a d))))
+  (m/log (mn/- (.b d) (.a d))))
 
 (deftm entropy [d :- Exponential] :- Double
-  (- 1.0 (m/log (.lambda d))))
+  (mn/- 1.0 (m/log (.lambda d))))
 
 ;; --- Mode ---
 (deftm mode [d :- Normal] :- Double (.mu d))
-(deftm mode [d :- Uniform] :- Double (* 0.5 (+ (.a d) (.b d))))
+(deftm mode [d :- Uniform] :- Double (mn/* 0.5 (mn/+ (.a d) (.b d))))
 (deftm mode [d :- Exponential] :- Double 0.0)
 (deftm mode [d :- Gamma] :- Double
   (if (>= (.alpha d) 1.0)
-    (* (- (.alpha d) 1.0) (.beta d))
+    (mn/* (mn/- (.alpha d) 1.0) (.beta d))
     (throw (ex-info "Gamma mode undefined for alpha < 1" {:alpha (.alpha d)}))))
 (deftm mode [d :- Poisson] :- Double (m/floor (.lambda d)))
 
@@ -294,15 +294,15 @@
 
 (deftm sample [d :- Normal] :- Double
   (let [rng (ThreadLocalRandom/current)]
-    (+ (.mu d) (* (.sigma d) (.nextGaussian rng)))))
+    (mn/+ (.mu d) (mn/* (.sigma d) (.nextGaussian rng)))))
 
 (deftm sample [d :- Uniform] :- Double
   (let [rng (ThreadLocalRandom/current)]
-    (+ (.a d) (* (.nextDouble rng) (- (.b d) (.a d))))))
+    (mn/+ (.a d) (mn/* (.nextDouble rng) (mn/- (.b d) (.a d))))))
 
 (deftm sample [d :- Exponential] :- Double
   (let [rng (ThreadLocalRandom/current)]
-    (/ (- (m/log (.nextDouble rng))) (.lambda d))))
+    (mn// (- (m/log (.nextDouble rng))) (.lambda d))))
 
 (deftm sample [d :- Gamma] :- Double
   ;; Marsaglia and Tsang's method for alpha >= 1
@@ -312,28 +312,28 @@
         b (.beta d)]
     (if (< a 1.0)
       ;; Ahrens-Dieter: Gamma(a) = Gamma(a+1) * U^(1/a)
-      (let [g-a1 (let [d (- (+ a 1.0) (/ 1.0 3.0))
-                       c (/ 1.0 (mn/sqrt (* 9.0 d)))]
+      (let [g-a1 (let [d (mn/- (mn/+ a 1.0) (mn// 1.0 3.0))
+                       c (mn// 1.0 (mn/sqrt (mn/* 9.0 d)))]
                    (loop []
                      (let [x (.nextGaussian rng)
-                           v (let [tmp (+ 1.0 (* c x))]
+                           v (let [tmp (mn/+ 1.0 (mn/* c x))]
                                (* tmp tmp tmp))]
                        (if (and (> v 0.0)
                                 (< (m/log (.nextDouble rng))
-                                   (+ (* 0.5 x x) (* d (- 1.0 v (m/log v))))))
-                         (* d v)
+                                   (mn/+ (* 0.5 x x) (mn/* d (- 1.0 v (m/log v))))))
+                         (mn/* d v)
                          (recur)))))]
-        (* b g-a1 (mn/pow (.nextDouble rng) (/ 1.0 a))))
+        (* b g-a1 (mn/pow (.nextDouble rng) (mn// 1.0 a))))
       ;; Marsaglia-Tsang for alpha >= 1
-      (let [d (- a (/ 1.0 3.0))
-            c (/ 1.0 (mn/sqrt (* 9.0 d)))]
+      (let [d (mn/- a (mn// 1.0 3.0))
+            c (mn// 1.0 (mn/sqrt (mn/* 9.0 d)))]
         (loop []
           (let [x (.nextGaussian rng)
-                v (let [tmp (+ 1.0 (* c x))]
+                v (let [tmp (mn/+ 1.0 (mn/* c x))]
                     (* tmp tmp tmp))]
             (if (and (> v 0.0)
                      (< (m/log (.nextDouble rng))
-                        (+ (* 0.5 x x) (* d (- 1.0 v (m/log v))))))
+                        (mn/+ (* 0.5 x x) (mn/* d (- 1.0 v (m/log v))))))
               (* b d v)
               (recur))))))))
 
@@ -347,10 +347,10 @@
         (loop [k 0 p 1.0]
           (if (<= p L)
             (double (dec k))
-            (recur (inc k) (* p (.nextDouble rng))))))
+            (recur (inc k) (mn/* p (.nextDouble rng))))))
       ;; Normal approximation for large lambda
       (let [rng (ThreadLocalRandom/current)]
-        (m/round (+ lam (* (mn/sqrt lam) (.nextGaussian rng))))))))
+        (m/round (mn/+ lam (mn/* (mn/sqrt lam) (.nextGaussian rng))))))))
 
 (deftm sample-n [d :- Distribution, n :- Long]
   (let [out (double-array n)]
@@ -364,18 +364,18 @@
 
 (deftm fit-normal [data :- (Array double)]
   (let [n (alength data)
-        mu (/ (reduce! [acc 0.0] [data] (+ acc data))
+        mu (mn// (reduce! [acc 0.0] [data] (mn/+ acc data))
               (double n))
-        sigma (mn/sqrt (/ (reduce! [acc 0.0] [data]
-                                   (let [d (- data mu)]
-                                     (+ acc (* d d))))
+        sigma (mn/sqrt (mn// (reduce! [acc 0.0] [data]
+                                   (let [d (mn/- data mu)]
+                                     (mn/+ acc (mn/* d d))))
                           (double n)))]
     (->Normal mu sigma)))
 
 (deftm fit-exponential [data :- (Array double)]
   (let [n (alength data)
-        sum (reduce! [acc 0.0] [data] (+ acc data))]
-    (->Exponential (/ (double n) sum))))
+        sum (reduce! [acc 0.0] [data] (mn/+ acc data))]
+    (->Exponential (mn// (double n) sum))))
 
 ;; ================================================================
 ;; Additional continuous distributions
@@ -400,7 +400,7 @@
 ;; ================================================================
 
 (deftm lbeta [a :- Double, b :- Double] :- Double
-  (- (+ (lgamma a) (lgamma b)) (lgamma (+ a b))))
+  (mn/- (mn/+ (lgamma a) (lgamma b)) (lgamma (mn/+ a b))))
 
 (deftm regularized-beta-cf [x :- Double, a :- Double, b :- Double] :- Double
   (let [max-iter 200
@@ -410,47 +410,47 @@
       (<= x 0.0) 0.0
       (>= x 1.0) 1.0
       ;; Symmetry relation: when x > (a+1)/(a+b+2), use I_x(a,b) = 1 - I_{1-x}(b,a)
-      (> x (/ (+ a 1.0) (+ a b 2.0)))
-      (- 1.0 (regularized-beta-cf (- 1.0 x) b a))
+      (> x (mn// (mn/+ a 1.0) (+ a b 2.0)))
+      (mn/- 1.0 (regularized-beta-cf (mn/- 1.0 x) b a))
       :else
       (let [;; Prefactor: x^a * (1-x)^b / (a * B(a,b))
-            lnpfx (- (+ (* a (m/log x)) (* b (m/log (- 1.0 x))))
+            lnpfx (- (mn/+ (mn/* a (m/log x)) (mn/* b (m/log (mn/- 1.0 x))))
                      (lbeta a b) (m/log a))
-            qab (+ a b)
-            qap (+ a 1.0)
-            qam (- a 1.0)
+            qab (mn/+ a b)
+            qap (mn/+ a 1.0)
+            qam (mn/- a 1.0)
             ;; Initial: d = 1, c = 1, f = 1
             ;; First coefficient (m=0): a_1 = 1 (trivially)
             ;; Lentz's method modified start
             c0 1.0
-            d0 (let [v (- 1.0 (/ (* qab x) qap))]
-                 (if (< (mn/abs v) fpmin) (/ 1.0 fpmin) (/ 1.0 v)))
+            d0 (let [v (mn/- 1.0 (mn// (mn/* qab x) qap))]
+                 (if (< (mn/abs v) fpmin) (mn// 1.0 fpmin) (mn// 1.0 v)))
             h0 d0]
-        (* (m/exp lnpfx)
+        (mn/* (m/exp lnpfx)
            (loop [m 1, c c0, d d0, h h0]
              (if (>= m max-iter)
                h
                (let [dm (double m)
                      ;; Even term: a_{2m} = m*(b-m)*x / ((qam+2m)*(a+2m))
-                     em (/ (* dm (- b dm) x)
-                           (* (+ qam (* 2.0 dm)) (+ a (* 2.0 dm))))
-                     d1 (+ 1.0 (* em d))
+                     em (mn// (* dm (mn/- b dm) x)
+                           (mn/* (mn/+ qam (mn/* 2.0 dm)) (mn/+ a (mn/* 2.0 dm))))
+                     d1 (mn/+ 1.0 (mn/* em d))
                      d1 (if (< (mn/abs d1) fpmin) fpmin d1)
-                     d1 (/ 1.0 d1)
-                     c1 (+ 1.0 (/ em c))
+                     d1 (mn// 1.0 d1)
+                     c1 (mn/+ 1.0 (mn// em c))
                      c1 (if (< (mn/abs c1) fpmin) fpmin c1)
                      h (* h d1 c1)
                      ;; Odd term: a_{2m+1} = -(a+m)*(qab+m)*x / ((a+2m)*(qap+2m))
-                     ep (/ (- (* (+ a dm) (+ qab dm) x))
-                           (* (+ a (* 2.0 dm)) (+ qap (* 2.0 dm))))
-                     d2 (+ 1.0 (* ep d1))
+                     ep (mn// (- (* (mn/+ a dm) (mn/+ qab dm) x))
+                           (mn/* (mn/+ a (mn/* 2.0 dm)) (mn/+ qap (mn/* 2.0 dm))))
+                     d2 (mn/+ 1.0 (mn/* ep d1))
                      d2 (if (< (mn/abs d2) fpmin) fpmin d2)
-                     d2 (/ 1.0 d2)
-                     c2 (+ 1.0 (/ ep c1))
+                     d2 (mn// 1.0 d2)
+                     c2 (mn/+ 1.0 (mn// ep c1))
                      c2 (if (< (mn/abs c2) fpmin) fpmin c2)
-                     del (* d2 c2)
-                     h (* h del)]
-                 (if (< (mn/abs (- del 1.0)) eps)
+                     del (mn/* d2 c2)
+                     h (mn/* h del)]
+                 (if (< (mn/abs (mn/- del 1.0)) eps)
                    h
                    (recur (inc m) c2 d2 h))))))))))
 
@@ -461,64 +461,64 @@
 (deftm logpdf [d :- Beta, x :- Double] :- Double
   (if (and (> x 0.0) (< x 1.0))
     (let [a (.alpha d) b (.beta d)]
-      (+ (* (- a 1.0) (m/log x))
-         (* (- b 1.0) (m/log (- 1.0 x)))
+      (+ (mn/* (mn/- a 1.0) (m/log x))
+         (mn/* (mn/- b 1.0) (m/log (mn/- 1.0 x)))
          (- (lbeta a b))))
     mn/neg-inf))
 
 (deftm logpdf [d :- Cauchy, x :- Double] :- Double
-  (let [z (/ (- x (.mu d)) (.sigma d))]
+  (let [z (mn// (mn/- x (.mu d)) (.sigma d))]
     (- (- (m/log mn/pi))
        (m/log (.sigma d))
-       (m/log (+ 1.0 (* z z))))))
+       (m/log (mn/+ 1.0 (mn/* z z))))))
 
 (deftm logpdf [d :- LogNormal, x :- Double] :- Double
   (if (> x 0.0)
     (let [lx (m/log x)
-          z (/ (- lx (.mu d)) (.sigma d))]
-      (- (- (* -0.5 (+ LOG_2PI (* z z)))
+          z (mn// (mn/- lx (.mu d)) (.sigma d))]
+      (mn/- (mn/- (mn/* -0.5 (mn/+ LOG_2PI (mn/* z z)))
             (m/log (.sigma d)))
          lx))
     mn/neg-inf))
 
 (deftm logpdf [d :- StudentT, x :- Double] :- Double
   (let [nu (.nu d)
-        half-nu+1 (* 0.5 (+ nu 1.0))]
+        half-nu+1 (mn/* 0.5 (mn/+ nu 1.0))]
     (- (lgamma half-nu+1)
-       (lgamma (* 0.5 nu))
-       (* 0.5 (m/log (* nu mn/pi)))
-       (* half-nu+1 (m/log (+ 1.0 (/ (* x x) nu)))))))
+       (lgamma (mn/* 0.5 nu))
+       (mn/* 0.5 (m/log (mn/* nu mn/pi)))
+       (mn/* half-nu+1 (m/log (mn/+ 1.0 (mn// (mn/* x x) nu)))))))
 
 (deftm logpdf [d :- Weibull, x :- Double] :- Double
   (if (> x 0.0)
     (let [a (.alpha d) th (.theta d)
-          z (/ x th)]
-      (+ (m/log (/ a th))
-         (* (- a 1.0) (m/log z))
+          z (mn// x th)]
+      (+ (m/log (mn// a th))
+         (mn/* (mn/- a 1.0) (m/log z))
          (- (mn/pow z a))))
     mn/neg-inf))
 
 (deftm logpdf [d :- Rayleigh, x :- Double] :- Double
   (if (>= x 0.0)
     (let [s (.sigma d)
-          s2 (* s s)]
-      (- (m/log (/ x s2)) (/ (* x x) (* 2.0 s2))))
+          s2 (mn/* s s)]
+      (mn/- (m/log (mn// x s2)) (mn// (mn/* x x) (mn/* 2.0 s2))))
     mn/neg-inf))
 
 (deftm logpdf [d :- Pareto, x :- Double] :- Double
   (if (>= x (.theta d))
     (let [a (.alpha d) th (.theta d)]
       (+ (m/log a)
-         (* a (m/log th))
-         (* (- (+ a 1.0)) (m/log x))))
+         (mn/* a (m/log th))
+         (mn/* (- (mn/+ a 1.0)) (m/log x))))
     mn/neg-inf))
 
 (deftm logpdf [d :- Chisq, x :- Double] :- Double
   (if (> x 0.0)
-    (let [k (* 0.5 (.nu d))]
-      (- (* (- k 1.0) (m/log x))
-         (* 0.5 x)
-         (* k LOG_2)
+    (let [k (mn/* 0.5 (.nu d))]
+      (- (mn/* (mn/- k 1.0) (m/log x))
+         (mn/* 0.5 x)
+         (mn/* k LOG_2)
          (lgamma k)))
     mn/neg-inf))
 
@@ -530,7 +530,7 @@
   (let [p (.p d)]
     (cond
       (== k 1) (m/log p)
-      (== k 0) (m/log (- 1.0 p))
+      (== k 0) (m/log (mn/- 1.0 p))
       :else mn/neg-inf)))
 
 (deftm pmf [d :- Bernoulli, k :- Long] :- Double
@@ -540,9 +540,9 @@
   (let [n (.n d) p (.p d)]
     (if (and (>= k 0) (<= k n))
       (let [fk (double k) fn (double n)]
-        (+ (- (lgamma (+ fn 1.0)) (lgamma (+ fk 1.0)) (lgamma (+ (- fn fk) 1.0)))
-           (* fk (m/log p))
-           (* (- fn fk) (m/log (- 1.0 p)))))
+        (+ (- (lgamma (mn/+ fn 1.0)) (lgamma (mn/+ fk 1.0)) (lgamma (mn/+ (mn/- fn fk) 1.0)))
+           (mn/* fk (m/log p))
+           (mn/* (mn/- fn fk) (m/log (mn/- 1.0 p)))))
       mn/neg-inf)))
 
 (deftm pmf [d :- Binomial, k :- Long] :- Double
@@ -550,7 +550,7 @@
 
 (deftm logpmf [d :- Geometric, k :- Long] :- Double
   (if (>= k 0)
-    (+ (m/log (.p d)) (* (double k) (m/log (- 1.0 (.p d)))))
+    (mn/+ (m/log (.p d)) (mn/* (double k) (m/log (mn/- 1.0 (.p d)))))
     mn/neg-inf))
 
 (deftm pmf [d :- Geometric, k :- Long] :- Double
@@ -567,46 +567,46 @@
     :else (regularized-beta-cf x (.alpha d) (.beta d))))
 
 (deftm cdf [d :- Cauchy, x :- Double] :- Double
-  (+ 0.5 (/ (m/atan (/ (- x (.mu d)) (.sigma d))) mn/pi)))
+  (mn/+ 0.5 (mn// (m/atan (mn// (mn/- x (.mu d)) (.sigma d))) mn/pi)))
 
 (deftm cdf [d :- LogNormal, x :- Double] :- Double
   (if (<= x 0.0)
     0.0
-    (let [z (/ (- (m/log x) (.mu d)) (.sigma d))]
-      (* 0.5 (+ 1.0 (erf (* INV_SQRT_2 z)))))))
+    (let [z (mn// (mn/- (m/log x) (.mu d)) (.sigma d))]
+      (mn/* 0.5 (mn/+ 1.0 (erf (mn/* INV_SQRT_2 z)))))))
 
 (deftm cdf [d :- StudentT, x :- Double] :- Double
   (let [nu (.nu d)
-        t2 (* x x)
-        xt (/ nu (+ nu t2))]
+        t2 (mn/* x x)
+        xt (mn// nu (mn/+ nu t2))]
     (if (>= x 0.0)
-      (- 1.0 (* 0.5 (regularized-beta-cf xt (* 0.5 nu) 0.5)))
-      (* 0.5 (regularized-beta-cf xt (* 0.5 nu) 0.5)))))
+      (mn/- 1.0 (mn/* 0.5 (regularized-beta-cf xt (mn/* 0.5 nu) 0.5)))
+      (mn/* 0.5 (regularized-beta-cf xt (mn/* 0.5 nu) 0.5)))))
 
 (deftm cdf [d :- Weibull, x :- Double] :- Double
   (if (<= x 0.0)
     0.0
-    (- 1.0 (m/exp (- (mn/pow (/ x (.theta d)) (.alpha d)))))))
+    (mn/- 1.0 (m/exp (- (mn/pow (mn// x (.theta d)) (.alpha d)))))))
 
 (deftm cdf [d :- Rayleigh, x :- Double] :- Double
   (if (<= x 0.0)
     0.0
-    (- 1.0 (m/exp (/ (- (* x x)) (* 2.0 (.sigma d) (.sigma d)))))))
+    (mn/- 1.0 (m/exp (mn// (- (mn/* x x)) (* 2.0 (.sigma d) (.sigma d)))))))
 
 (deftm cdf [d :- Pareto, x :- Double] :- Double
   (if (< x (.theta d))
     0.0
-    (- 1.0 (mn/pow (/ (.theta d) x) (.alpha d)))))
+    (mn/- 1.0 (mn/pow (mn// (.theta d) x) (.alpha d)))))
 
 (deftm cdf [d :- Chisq, x :- Double] :- Double
   (if (<= x 0.0)
     0.0
-    (regularized-gamma-p (* 0.5 (.nu d)) (* 0.5 x))))
+    (regularized-gamma-p (mn/* 0.5 (.nu d)) (mn/* 0.5 x))))
 
 (deftm cdf [d :- Bernoulli, x :- Double] :- Double
   (cond
     (< x 0.0) 0.0
-    (< x 1.0) (- 1.0 (.p d))
+    (< x 1.0) (mn/- 1.0 (.p d))
     :else 1.0))
 
 (deftm cdf [d :- Binomial, x :- Double] :- Double
@@ -615,38 +615,38 @@
     (cond
       (< k 0) 0.0
       (>= k n) 1.0
-      :else (- 1.0 (regularized-beta-cf p (+ (double k) 1.0) (double (- n k)))))))
+      :else (mn/- 1.0 (regularized-beta-cf p (mn/+ (double k) 1.0) (double (mn/- n k)))))))
 
 (deftm cdf [d :- Geometric, x :- Double] :- Double
   (if (< x 0.0)
     0.0
-    (- 1.0 (mn/pow (- 1.0 (.p d)) (+ (m/floor x) 1.0)))))
+    (mn/- 1.0 (mn/pow (mn/- 1.0 (.p d)) (mn/+ (m/floor x) 1.0)))))
 
 ;; ================================================================
 ;; Mean for new distributions
 ;; ================================================================
 
 (deftm mean [d :- Beta] :- Double
-  (/ (.alpha d) (+ (.alpha d) (.beta d))))
+  (mn// (.alpha d) (mn/+ (.alpha d) (.beta d))))
 
 (deftm mean [d :- Cauchy] :- Double
   Double/NaN)  ;; undefined
 
 (deftm mean [d :- LogNormal] :- Double
-  (m/exp (+ (.mu d) (* 0.5 (.sigma d) (.sigma d)))))
+  (m/exp (mn/+ (.mu d) (* 0.5 (.sigma d) (.sigma d)))))
 
 (deftm mean [d :- StudentT] :- Double
   (if (> (.nu d) 1.0) 0.0 Double/NaN))
 
 (deftm mean [d :- Weibull] :- Double
-  (* (.theta d) (m/exp (lgamma (+ 1.0 (/ 1.0 (.alpha d)))))))
+  (mn/* (.theta d) (m/exp (lgamma (mn/+ 1.0 (mn// 1.0 (.alpha d)))))))
 
 (deftm mean [d :- Rayleigh] :- Double
-  (* (.sigma d) (mn/sqrt (* 0.5 mn/pi))))
+  (mn/* (.sigma d) (mn/sqrt (mn/* 0.5 mn/pi))))
 
 (deftm mean [d :- Pareto] :- Double
   (if (> (.alpha d) 1.0)
-    (/ (* (.alpha d) (.theta d)) (- (.alpha d) 1.0))
+    (mn// (mn/* (.alpha d) (.theta d)) (mn/- (.alpha d) 1.0))
     mn/pos-inf))
 
 (deftm mean [d :- Chisq] :- Double
@@ -656,10 +656,10 @@
   (.p d))
 
 (deftm mean [d :- Binomial] :- Double
-  (* (double (.n d)) (.p d)))
+  (mn/* (double (.n d)) (.p d)))
 
 (deftm mean [d :- Geometric] :- Double
-  (/ (- 1.0 (.p d)) (.p d)))
+  (mn// (mn/- 1.0 (.p d)) (.p d)))
 
 ;; ================================================================
 ;; Variance for new distributions
@@ -667,50 +667,50 @@
 
 (deftm variance [d :- Beta] :- Double
   (let [a (.alpha d) b (.beta d)
-        ab (+ a b)]
-    (/ (* a b) (* ab ab (+ ab 1.0)))))
+        ab (mn/+ a b)]
+    (mn// (mn/* a b) (* ab ab (mn/+ ab 1.0)))))
 
 (deftm variance [d :- Cauchy] :- Double
   Double/NaN)  ;; undefined
 
 (deftm variance [d :- LogNormal] :- Double
-  (let [s2 (* (.sigma d) (.sigma d))]
-    (* (- (m/exp s2) 1.0) (m/exp (+ (* 2.0 (.mu d)) s2)))))
+  (let [s2 (mn/* (.sigma d) (.sigma d))]
+    (mn/* (mn/- (m/exp s2) 1.0) (m/exp (mn/+ (mn/* 2.0 (.mu d)) s2)))))
 
 (deftm variance [d :- StudentT] :- Double
   (let [nu (.nu d)]
     (cond
-      (> nu 2.0) (/ nu (- nu 2.0))
+      (> nu 2.0) (mn// nu (mn/- nu 2.0))
       (> nu 1.0) mn/pos-inf
       :else Double/NaN)))
 
 (deftm variance [d :- Weibull] :- Double
   (let [a (.alpha d) th (.theta d)
-        g1 (m/exp (lgamma (+ 1.0 (/ 1.0 a))))
-        g2 (m/exp (lgamma (+ 1.0 (/ 2.0 a))))]
-    (* th th (- g2 (* g1 g1)))))
+        g1 (m/exp (lgamma (mn/+ 1.0 (mn// 1.0 a))))
+        g2 (m/exp (lgamma (mn/+ 1.0 (mn// 2.0 a))))]
+    (* th th (mn/- g2 (mn/* g1 g1)))))
 
 (deftm variance [d :- Rayleigh] :- Double
   (let [s (.sigma d)]
-    (* s s (- 2.0 (* 0.5 mn/pi)))))
+    (* s s (mn/- 2.0 (mn/* 0.5 mn/pi)))))
 
 (deftm variance [d :- Pareto] :- Double
   (let [a (.alpha d) th (.theta d)]
     (if (> a 2.0)
-      (/ (* th th a) (* (- a 1.0) (- a 1.0) (- a 2.0)))
+      (mn// (* th th a) (* (mn/- a 1.0) (mn/- a 1.0) (mn/- a 2.0)))
       mn/pos-inf)))
 
 (deftm variance [d :- Chisq] :- Double
-  (* 2.0 (.nu d)))
+  (mn/* 2.0 (.nu d)))
 
 (deftm variance [d :- Bernoulli] :- Double
-  (* (.p d) (- 1.0 (.p d))))
+  (mn/* (.p d) (mn/- 1.0 (.p d))))
 
 (deftm variance [d :- Binomial] :- Double
-  (* (double (.n d)) (.p d) (- 1.0 (.p d))))
+  (* (double (.n d)) (.p d) (mn/- 1.0 (.p d))))
 
 (deftm variance [d :- Geometric] :- Double
-  (/ (- 1.0 (.p d)) (* (.p d) (.p d))))
+  (mn// (mn/- 1.0 (.p d)) (mn/* (.p d) (.p d))))
 
 ;; ================================================================
 ;; Sampling for new distributions
@@ -720,41 +720,41 @@
   ;; Beta(a,b) = Gamma(a,1) / (Gamma(a,1) + Gamma(b,1))
   (let [x (sample (->Gamma (.alpha d) 1.0))
         y (sample (->Gamma (.beta d) 1.0))]
-    (/ x (+ x y))))
+    (mn// x (mn/+ x y))))
 
 (deftm sample [d :- Cauchy] :- Double
   (let [rng (ThreadLocalRandom/current)]
-    (+ (.mu d) (* (.sigma d) (m/tan (* mn/pi (- (.nextDouble rng) 0.5)))))))
+    (mn/+ (.mu d) (mn/* (.sigma d) (m/tan (mn/* mn/pi (mn/- (.nextDouble rng) 0.5)))))))
 
 (deftm sample [d :- LogNormal] :- Double
   (let [rng (ThreadLocalRandom/current)]
-    (m/exp (+ (.mu d) (* (.sigma d) (.nextGaussian rng))))))
+    (m/exp (mn/+ (.mu d) (mn/* (.sigma d) (.nextGaussian rng))))))
 
 (deftm sample [d :- StudentT] :- Double
   ;; T = Z / sqrt(V/nu) where Z~N(0,1), V~Chisq(nu)
   (let [rng (ThreadLocalRandom/current)
         z (.nextGaussian rng)
         v (sample (->Chisq (.nu d)))]
-    (/ z (mn/sqrt (/ v (.nu d))))))
+    (mn// z (mn/sqrt (mn// v (.nu d))))))
 
 (deftm sample [d :- Weibull] :- Double
   (let [rng (ThreadLocalRandom/current)
         u (.nextDouble rng)]
-    (* (.theta d) (mn/pow (- (m/log (- 1.0 u))) (/ 1.0 (.alpha d))))))
+    (mn/* (.theta d) (mn/pow (- (m/log (mn/- 1.0 u))) (mn// 1.0 (.alpha d))))))
 
 (deftm sample [d :- Rayleigh] :- Double
   (let [rng (ThreadLocalRandom/current)
         u (.nextDouble rng)]
-    (* (.sigma d) (mn/sqrt (* -2.0 (m/log (- 1.0 u)))))))
+    (mn/* (.sigma d) (mn/sqrt (mn/* -2.0 (m/log (mn/- 1.0 u)))))))
 
 (deftm sample [d :- Pareto] :- Double
   (let [rng (ThreadLocalRandom/current)
         u (.nextDouble rng)]
-    (/ (.theta d) (mn/pow u (/ 1.0 (.alpha d))))))
+    (mn// (.theta d) (mn/pow u (mn// 1.0 (.alpha d))))))
 
 (deftm sample [d :- Chisq] :- Double
   ;; Chisq(nu) = Gamma(nu/2, 2)
-  (sample (->Gamma (* 0.5 (.nu d)) 2.0)))
+  (sample (->Gamma (mn/* 0.5 (.nu d)) 2.0)))
 
 (deftm sample [d :- Bernoulli] :- Double
   (let [rng (ThreadLocalRandom/current)]
@@ -767,11 +767,11 @@
     (loop [i 0 count 0.0]
       (if (>= i n)
         count
-        (recur (inc i) (if (< (.nextDouble rng) p) (+ count 1.0) count))))))
+        (recur (inc i) (if (< (.nextDouble rng) p) (mn/+ count 1.0) count))))))
 
 (deftm sample [d :- Geometric] :- Double
   (let [rng (ThreadLocalRandom/current)]
-    (m/floor (/ (m/log (.nextDouble rng)) (m/log (- 1.0 (.p d)))))))
+    (m/floor (mn// (m/log (.nextDouble rng)) (m/log (mn/- 1.0 (.p d)))))))
 
 ;; ================================================================
 ;; Additional distributions (Phase 2)
@@ -788,95 +788,95 @@
 ;; --- Laplace ---
 
 (deftm logpdf [d :- Laplace, x :- Double] :- Double
-  (- (- (m/log (* 2.0 (.b d))))
-     (/ (mn/abs (- x (.mu d))) (.b d))))
+  (mn/- (- (m/log (mn/* 2.0 (.b d))))
+     (mn// (mn/abs (mn/- x (.mu d))) (.b d))))
 
 (deftm cdf [d :- Laplace, x :- Double] :- Double
-  (let [z (/ (- x (.mu d)) (.b d))]
+  (let [z (mn// (mn/- x (.mu d)) (.b d))]
     (if (<= x (.mu d))
-      (* 0.5 (m/exp z))
-      (- 1.0 (* 0.5 (m/exp (- z)))))))
+      (mn/* 0.5 (m/exp z))
+      (mn/- 1.0 (mn/* 0.5 (m/exp (- z)))))))
 
 (deftm mean [d :- Laplace] :- Double (.mu d))
 (deftm variance [d :- Laplace] :- Double (* 2.0 (.b d) (.b d)))
 
 (deftm sample [d :- Laplace] :- Double
   (let [rng (ThreadLocalRandom/current)
-        u (- (.nextDouble rng) 0.5)]
-    (- (.mu d) (* (.b d) (m/signum u) (m/log (- 1.0 (* 2.0 (mn/abs u))))))))
+        u (mn/- (.nextDouble rng) 0.5)]
+    (mn/- (.mu d) (* (.b d) (m/signum u) (m/log (mn/- 1.0 (mn/* 2.0 (mn/abs u))))))))
 
 ;; --- Gumbel ---
 
 (deftm logpdf [d :- Gumbel, x :- Double] :- Double
-  (let [z (/ (- x (.mu d)) (.beta d))]
+  (let [z (mn// (mn/- x (.mu d)) (.beta d))]
     (- (- z) (m/exp (- z)) (m/log (.beta d)))))
 
 (deftm cdf [d :- Gumbel, x :- Double] :- Double
-  (m/exp (- (m/exp (- (/ (- x (.mu d)) (.beta d)))))))
+  (m/exp (- (m/exp (- (mn// (mn/- x (.mu d)) (.beta d)))))))
 
 (deftm mean [d :- Gumbel] :- Double
-  (+ (.mu d) (* (.beta d) 0.5772156649015329))) ;; Euler-Mascheroni
+  (mn/+ (.mu d) (mn/* (.beta d) 0.5772156649015329))) ;; Euler-Mascheroni
 
 (deftm variance [d :- Gumbel] :- Double
-  (* (.beta d) (.beta d) (/ (* mn/pi mn/pi) 6.0)))
+  (* (.beta d) (.beta d) (mn// (mn/* mn/pi mn/pi) 6.0)))
 
 (deftm sample [d :- Gumbel] :- Double
   (let [rng (ThreadLocalRandom/current)
         u (.nextDouble rng)]
-    (- (.mu d) (* (.beta d) (m/log (- (m/log u)))))))
+    (mn/- (.mu d) (mn/* (.beta d) (m/log (- (m/log u)))))))
 
 ;; --- InverseGamma ---
 
 (deftm logpdf [d :- InverseGamma, x :- Double] :- Double
   (if (> x 0.0)
     (let [a (.alpha d) b (.beta d)]
-      (- (* a (m/log b))
+      (- (mn/* a (m/log b))
          (lgamma a)
-         (* (+ a 1.0) (m/log x))
-         (/ b x)))
+         (mn/* (mn/+ a 1.0) (m/log x))
+         (mn// b x)))
     mn/neg-inf))
 
 (deftm cdf [d :- InverseGamma, x :- Double] :- Double
   (if (<= x 0.0) 0.0
-      (- 1.0 (special/gammainc (.alpha d) (/ (.beta d) x)))))
+      (mn/- 1.0 (special/gammainc (.alpha d) (mn// (.beta d) x)))))
 
 (deftm mean [d :- InverseGamma] :- Double
   (if (> (.alpha d) 1.0)
-    (/ (.beta d) (- (.alpha d) 1.0))
+    (mn// (.beta d) (mn/- (.alpha d) 1.0))
     mn/pos-inf))
 
 (deftm variance [d :- InverseGamma] :- Double
   (let [a (.alpha d) b (.beta d)]
     (if (> a 2.0)
-      (/ (* b b) (* (- a 1.0) (- a 1.0) (- a 2.0)))
+      (mn// (mn/* b b) (* (mn/- a 1.0) (mn/- a 1.0) (mn/- a 2.0)))
       mn/pos-inf)))
 
 (deftm sample [d :- InverseGamma] :- Double
   ;; InverseGamma(a,b) = 1/Gamma(a,1/b)
-  (/ 1.0 (sample (->Gamma (.alpha d) (/ 1.0 (.beta d))))))
+  (mn// 1.0 (sample (->Gamma (.alpha d) (mn// 1.0 (.beta d))))))
 
 ;; --- NegativeBinomial ---
 
 (deftm logpmf [d :- NegativeBinomial, k :- Long] :- Double
   (if (>= k 0)
     (let [r (.r d) p (.p d) fk (double k)]
-      (+ (- (lgamma (+ r fk)) (lgamma (+ fk 1.0)) (lgamma r))
-         (* r (m/log p))
-         (* fk (m/log (- 1.0 p)))))
+      (+ (- (lgamma (mn/+ r fk)) (lgamma (mn/+ fk 1.0)) (lgamma r))
+         (mn/* r (m/log p))
+         (mn/* fk (m/log (mn/- 1.0 p)))))
     mn/neg-inf))
 
 (deftm pmf [d :- NegativeBinomial, k :- Long] :- Double
   (m/exp (logpmf d k)))
 
 (deftm mean [d :- NegativeBinomial] :- Double
-  (/ (* (.r d) (- 1.0 (.p d))) (.p d)))
+  (mn// (mn/* (.r d) (mn/- 1.0 (.p d))) (.p d)))
 
 (deftm variance [d :- NegativeBinomial] :- Double
-  (/ (* (.r d) (- 1.0 (.p d))) (* (.p d) (.p d))))
+  (mn// (mn/* (.r d) (mn/- 1.0 (.p d))) (mn/* (.p d) (.p d))))
 
 (deftm sample [d :- NegativeBinomial] :- Double
   ;; NB(r,p) = Poisson(Gamma(r, (1-p)/p))
-  (let [g (sample (->Gamma (.r d) (/ (- 1.0 (.p d)) (.p d))))]
+  (let [g (sample (->Gamma (.r d) (mn// (mn/- 1.0 (.p d)) (.p d))))]
     (sample (->Poisson g))))
 
 ;; --- Hypergeometric ---
@@ -886,25 +886,25 @@
         K (double (.K d))
         n (double (.nn d))
         fk (double k)]
-    (if (and (>= k (long (mn/max 0.0 (- n (- N K)))))
+    (if (and (>= k (long (mn/max 0.0 (mn/- n (mn/- N K)))))
              (<= k (long (mn/min n K))))
-      (+ (- (+ (lgamma (+ K 1.0)) (lgamma (+ (- N K) 1.0))
-               (lgamma (+ n 1.0)) (lgamma (+ (- N n) 1.0)))
-            (+ (lgamma (+ N 1.0))
-               (lgamma (+ fk 1.0)) (lgamma (+ (- K fk) 1.0))
-               (lgamma (+ (- n fk) 1.0)) (lgamma (+ (- N K n) fk 1.0)))))
+      (+ (mn/- (+ (lgamma (mn/+ K 1.0)) (lgamma (mn/+ (mn/- N K) 1.0))
+               (lgamma (mn/+ n 1.0)) (lgamma (mn/+ (mn/- N n) 1.0)))
+            (+ (lgamma (mn/+ N 1.0))
+               (lgamma (mn/+ fk 1.0)) (lgamma (mn/+ (mn/- K fk) 1.0))
+               (lgamma (mn/+ (mn/- n fk) 1.0)) (lgamma (+ (- N K n) fk 1.0)))))
       mn/neg-inf)))
 
 (deftm pmf [d :- Hypergeometric, k :- Long] :- Double
   (m/exp (logpmf d k)))
 
 (deftm mean [d :- Hypergeometric] :- Double
-  (/ (* (double (.nn d)) (double (.K d))) (double (.N d))))
+  (mn// (mn/* (double (.nn d)) (double (.K d))) (double (.N d))))
 
 (deftm variance [d :- Hypergeometric] :- Double
   (let [N (double (.N d)) K (double (.K d)) n (double (.nn d))]
-    (/ (* n K (- N K) (- N n))
-       (* N N (- N 1.0)))))
+    (mn// (* n K (mn/- N K) (mn/- N n))
+       (* N N (mn/- N 1.0)))))
 
 ;; ================================================================
 ;; Dirichlet distribution
@@ -917,16 +917,16 @@
         k (.k d)
         lbeta-val (loop [i 0 lg-sum 0.0 a-sum 0.0]
                     (if (>= i k)
-                      (- lg-sum (lgamma a-sum))
+                      (mn/- lg-sum (lgamma a-sum))
                       (let [ai (aget alpha i)]
                         (recur (inc i)
-                               (+ lg-sum (lgamma ai))
-                               (+ a-sum ai)))))]
+                               (mn/+ lg-sum (lgamma ai))
+                               (mn/+ a-sum ai)))))]
     (loop [i 0 acc 0.0]
       (if (>= i k)
-        (- acc lbeta-val)
+        (mn/- acc lbeta-val)
         (recur (inc i)
-               (+ acc (* (- (aget alpha i) 1.0) (m/log (aget x i)))))))))
+               (mn/+ acc (mn/* (mn/- (aget alpha i) 1.0) (m/log (aget x i)))))))))
 
 (deftm sample [d :- Dirichlet] :- (Array double)
   ;; Sample from Dirichlet by sampling Gamma(alpha_i, 1) and normalizing
@@ -937,19 +937,19 @@
     (loop [i 0 total 0.0]
       (if (>= i k)
         (do (dotimes [j k]
-              (aset result j (/ (aget result j) total)))
+              (aset result j (mn// (aget result j) total)))
             result)
         (let [;; Sample Gamma(alpha_i, 1) via Marsaglia-Tsang
               ai (aget alpha i)
               g (sample (->Gamma ai 1.0))
               _ (aset result i g)]
-          (recur (inc i) (+ total g)))))))
+          (recur (inc i) (mn/+ total g)))))))
 
 (deftm mean [d :- Dirichlet] :- (Array double)
   (let [alpha (.alpha d)
         k (.k d)
-        a-sum (reduce! [acc 0.0] [alpha] (+ acc alpha))]
-    (broadcast [alpha] (/ alpha a-sum))))
+        a-sum (reduce! [acc 0.0] [alpha] (mn/+ acc alpha))]
+    (broadcast [alpha] (mn// alpha a-sum))))
 
 ;; ================================================================
 ;; Multivariate Normal distribution
@@ -965,7 +965,7 @@
         ;; Compute (x - mu)
         diff (double-array dim)
         _ (dotimes [i dim]
-            (aset diff i (- (aget x i) (aget mu i))))
+            (aset diff i (mn/- (aget x i) (aget mu i))))
         ;; Cholesky of sigma: L such that L*L^T = Sigma
         ;; Inline Cholesky to avoid circular dep on linalg
         L (double-array (* dim dim))
@@ -976,8 +976,8 @@
               (let [sum-sq (loop [k 0 acc 0.0]
                              (if (>= k j) acc
                                  (let [ljk (aget L (+ (* j dim) k))]
-                                   (recur (inc k) (+ acc (* ljk ljk))))))
-                    ljj (mn/sqrt (- (aget L (+ (* j dim) j)) sum-sq))]
+                                   (recur (inc k) (mn/+ acc (mn/* ljk ljk))))))
+                    ljj (mn/sqrt (mn/- (aget L (+ (* j dim) j)) sum-sq))]
                 (aset L (+ (* j dim) j) ljj)
                 ;; Off-diagonal elements in column j
                 (loop [i (inc j)]
@@ -985,9 +985,9 @@
                     (let [sum-prod (loop [k 0 acc 0.0]
                                      (if (>= k j) acc
                                          (recur (inc k)
-                                                (+ acc (* (aget L (+ (* i dim) k))
-                                                          (aget L (+ (* j dim) k)))))))
-                          lij (/ (- (aget L (+ (* i dim) j)) sum-prod) ljj)]
+                                                (mn/+ acc (mn/* (aget L (+ (* i dim) k))
+                                                                (aget L (+ (* j dim) k)))))))
+                          lij (mn// (mn/- (aget L (+ (* i dim) j)) sum-prod) ljj)]
                       (aset L (+ (* i dim) j) lij)
                       ;; Zero upper triangle
                       (aset L (+ (* j dim) i) 0.0))
@@ -995,8 +995,8 @@
               (recur (inc j))))
         ;; log|Sigma| = 2 * sum(log(L_ii))
         log-det (loop [i 0 acc 0.0]
-                  (if (>= i dim) (* 2.0 acc)
-                      (recur (inc i) (+ acc (m/log (aget L (+ (* i dim) i)))))))
+                  (if (>= i dim) (mn/* 2.0 acc)
+                      (recur (inc i) (mn/+ acc (m/log (aget L (+ (* i dim) i)))))))
         ;; Solve L*y = diff (forward substitution)
         y (double-array dim)
         _ (loop [i 0]
@@ -1004,18 +1004,18 @@
               (let [s (loop [j 0 acc 0.0]
                         (if (>= j i) acc
                             (recur (inc j)
-                                   (+ acc (* (aget L (+ (* i dim) j))
-                                             (aget y j))))))]
-                (aset y i (/ (- (aget diff i) s)
-                             (aget L (+ (* i dim) i)))))
+                                   (mn/+ acc (mn/* (aget L (+ (* i dim) j))
+                                                   (aget y j))))))]
+                (aset y i (mn// (mn/- (aget diff i) s)
+                                (aget L (+ (* i dim) i)))))
               (recur (inc i))))
         ;; Mahalanobis distance = y^T * y
         mahal (loop [i 0 acc 0.0]
                 (if (>= i dim) acc
-                    (recur (inc i) (+ acc (* (aget y i) (aget y i))))))]
-    (* -0.5 (+ (* (double dim) (m/log (* 2.0 mn/pi)))
-               log-det
-               mahal))))
+                    (recur (inc i) (mn/+ acc (mn/* (aget y i) (aget y i))))))]
+    (mn/* -0.5 (+ (mn/* (double dim) (m/log (mn/* 2.0 mn/pi)))
+                  log-det
+                  mahal))))
 
 (deftm sample [d :- MultivariateNormal] :- (Array double)
   ;; Sample via Cholesky: z ~ N(0,I), x = mu + L*z
@@ -1031,17 +1031,17 @@
               (let [sum-sq (loop [k 0 acc 0.0]
                              (if (>= k j) acc
                                  (let [ljk (aget L (+ (* j dim) k))]
-                                   (recur (inc k) (+ acc (* ljk ljk))))))
-                    ljj (mn/sqrt (- (aget L (+ (* j dim) j)) sum-sq))]
+                                   (recur (inc k) (mn/+ acc (mn/* ljk ljk))))))
+                    ljj (mn/sqrt (mn/- (aget L (+ (* j dim) j)) sum-sq))]
                 (aset L (+ (* j dim) j) ljj)
                 (loop [i (inc j)]
                   (when (< i dim)
                     (let [sum-prod (loop [k 0 acc 0.0]
                                      (if (>= k j) acc
                                          (recur (inc k)
-                                                (+ acc (* (aget L (+ (* i dim) k))
-                                                          (aget L (+ (* j dim) k)))))))
-                          lij (/ (- (aget L (+ (* i dim) j)) sum-prod) ljj)]
+                                                (mn/+ acc (mn/* (aget L (+ (* i dim) k))
+                                                                (aget L (+ (* j dim) k)))))))
+                          lij (mn// (mn/- (aget L (+ (* i dim) j)) sum-prod) ljj)]
                       (aset L (+ (* i dim) j) lij)
                       (aset L (+ (* j dim) i) 0.0))
                     (recur (inc i)))))
@@ -1056,9 +1056,9 @@
       (let [s (loop [j 0 acc 0.0]
                 (if (> j i) acc
                     (recur (inc j)
-                           (+ acc (* (aget L (+ (* i dim) j))
-                                     (aget z j))))))]
-        (aset result i (+ (aget mu i) s))))
+                           (mn/+ acc (mn/* (aget L (+ (* i dim) j))
+                                           (aget z j))))))]
+        (aset result i (mn/+ (aget mu i) s))))
     result))
 
 (deftm mean [d :- MultivariateNormal] :- (Array double)

--- a/src/raster/sci/fft.clj
+++ b/src/raster/sci/fft.clj
@@ -52,7 +52,7 @@
     (loop [size 2]
       (when (<= size n)
         (let [half-size (bit-shift-right size 1)
-              angle (* sign (/ (* 2.0 n/pi) (double size)))
+              angle (n/* sign (n// (n/* 2.0 n/pi) (double size)))
               wr-step (m/cos angle)
               wi-step (m/sin angle)]
           (loop [k 0]
@@ -61,15 +61,15 @@
                 (when (< j half-size)
                   (let [idx1 (+ k j)
                         idx2 (+ k j half-size)
-                        tr (- (* wr (aget re idx2)) (* wi (aget im idx2)))
-                        ti (+ (* wr (aget im idx2)) (* wi (aget re idx2)))]
-                    (aset re idx2 (- (aget re idx1) tr))
-                    (aset im idx2 (- (aget im idx1) ti))
-                    (aset re idx1 (+ (aget re idx1) tr))
-                    (aset im idx1 (+ (aget im idx1) ti))
+                        tr (n/- (n/* wr (aget re idx2)) (n/* wi (aget im idx2)))
+                        ti (n/+ (n/* wr (aget im idx2)) (n/* wi (aget re idx2)))]
+                    (aset re idx2 (n/- (aget re idx1) tr))
+                    (aset im idx2 (n/- (aget im idx1) ti))
+                    (aset re idx1 (n/+ (aget re idx1) tr))
+                    (aset im idx1 (n/+ (aget im idx1) ti))
                     (recur (inc j)
-                           (- (* wr wr-step) (* wi wi-step))
-                           (+ (* wr wi-step) (* wi wr-step))))))
+                           (n/- (n/* wr wr-step) (n/* wi wi-step))
+                           (n/+ (n/* wr wi-step) (n/* wi wr-step))))))
               (recur (+ k size)))))
         (recur (* size 2))))))
 
@@ -101,9 +101,9 @@
         re (aclone re-in)
         im (aclone im-in)]
     (fft-core! re im 1.0)
-    (let [inv-n (/ 1.0 (double n))
-          re-scaled (broadcast [re] (* re inv-n))
-          im-scaled (broadcast [im] (* im inv-n))]
+    (let [inv-n (n// 1.0 (double n))
+          re-scaled (broadcast [re] (n/* re inv-n))
+          im-scaled (broadcast [im] (n/* im inv-n))]
       [re-scaled im-scaled])))
 
 (deftm rfft [x :- (Array double)]
@@ -118,18 +118,18 @@
 
 (deftm fftfreq [n :- Long, dt :- Double]
   (let [freqs (double-array n)
-        inv-ndt (/ 1.0 (* (double n) dt))
+        inv-ndt (n// 1.0 (n/* (double n) dt))
         half (bit-shift-right n 1)]
     (dotimes [i half]
-      (aset freqs i (* (double i) inv-ndt)))
+      (aset freqs i (n/* (double i) inv-ndt)))
     (loop [i half]
       (when (< i n)
-        (aset freqs i (* (double (- i n)) inv-ndt))
+        (aset freqs i (n/* (double (- i n)) inv-ndt))
         (recur (inc i))))
     freqs))
 
 (deftm magnitude [re :- (Array double), im :- (Array double)]
-  (broadcast [re im] (n/sqrt (+ (* re re) (* im im)))))
+  (broadcast [re im] (n/sqrt (n/+ (n/* re re) (n/* im im)))))
 
 (deftm phase [re :- (Array double), im :- (Array double)]
   (broadcast [im re] (m/atan2 im re)))
@@ -143,16 +143,16 @@
   X[k] = 2 * sum_{n=0}^{N-1} x[n] * cos(pi*(2n+1)*k / (2N))"
   [x :- (Array double) n :- Long] :- (Array double)
   (let [out (double-array n)
-        inv-2n (/ n/pi (* 2.0 (double n)))]
+        inv-2n (n// n/pi (n/* 2.0 (double n)))]
     (dotimes [k n]
       (let [s (loop [i 0 acc 0.0]
                 (if (>= i n) acc
                     (recur (inc i)
-                           (+ acc (* (aget x i)
-                                     (m/cos (* inv-2n
-                                               (double k)
-                                               (+ (* 2.0 (double i)) 1.0))))))))]
-        (aset out k (* 2.0 s))))
+                           (n/+ acc (n/* (aget x i)
+                                         (m/cos (n/* inv-2n
+                                                     (double k)
+                                                     (n/+ (n/* 2.0 (double i)) 1.0))))))))]
+        (aset out k (n/* 2.0 s))))
     out))
 
 ;; ================================================================
@@ -164,17 +164,17 @@
   x[n] = (1/N) * [X[0]/2 + sum_{k=1}^{N-1} X[k] * cos(pi*k*(2n+1)/(2N))]"
   [X :- (Array double) n :- Long] :- (Array double)
   (let [out (double-array n)
-        inv-2n (/ n/pi (* 2.0 (double n)))
-        inv-n (/ 1.0 (double n))]
+        inv-2n (n// n/pi (n/* 2.0 (double n)))
+        inv-n (n// 1.0 (double n))]
     (dotimes [i n]
-      (let [s (loop [k 1 acc (* 0.5 (aget X 0))]
+      (let [s (loop [k 1 acc (n/* 0.5 (aget X 0))]
                 (if (>= k n) acc
                     (recur (inc k)
-                           (+ acc (* (aget X k)
-                                     (m/cos (* inv-2n
-                                               (double k)
-                                               (+ (* 2.0 (double i)) 1.0))))))))]
-        (aset out i (* inv-n s))))
+                           (n/+ acc (n/* (aget X k)
+                                         (m/cos (n/* inv-2n
+                                                     (double k)
+                                                     (n/+ (n/* 2.0 (double i)) 1.0))))))))]
+        (aset out i (n/* inv-n s))))
     out))
 
 ;; ================================================================
@@ -186,16 +186,16 @@
   X[k] = 2 * sum_{n=0}^{N-1} x[n] * sin(pi*(n+1)*(k+1) / (N+1))"
   [x :- (Array double) n :- Long] :- (Array double)
   (let [out (double-array n)
-        inv-n1 (/ n/pi (+ (double n) 1.0))]
+        inv-n1 (n// n/pi (n/+ (double n) 1.0))]
     (dotimes [k n]
       (let [s (loop [i 0 acc 0.0]
                 (if (>= i n) acc
                     (recur (inc i)
-                           (+ acc (* (aget x i)
-                                     (m/sin (* inv-n1
-                                               (+ (double i) 1.0)
-                                               (+ (double k) 1.0))))))))]
-        (aset out k (* 2.0 s))))
+                           (n/+ acc (n/* (aget x i)
+                                         (m/sin (n/* inv-n1
+                                                     (n/+ (double i) 1.0)
+                                                     (n/+ (double k) 1.0))))))))]
+        (aset out k (n/* 2.0 s))))
     out))
 
 ;; ================================================================
@@ -207,15 +207,15 @@
   x[n] = (1/(N+1)) * sum_{k=0}^{N-1} X[k] * sin(pi*(n+1)*(k+1)/(N+1))"
   [X :- (Array double) n :- Long] :- (Array double)
   (let [out (double-array n)
-        inv-n1 (/ n/pi (+ (double n) 1.0))
-        scale (/ 1.0 (+ (double n) 1.0))]
+        inv-n1 (n// n/pi (n/+ (double n) 1.0))
+        scale (n// 1.0 (n/+ (double n) 1.0))]
     (dotimes [i n]
       (let [s (loop [k 0 acc 0.0]
                 (if (>= k n) acc
                     (recur (inc k)
-                           (+ acc (* (aget X k)
-                                     (m/sin (* inv-n1
-                                               (+ (double i) 1.0)
-                                               (+ (double k) 1.0))))))))]
-        (aset out i (* scale s))))
+                           (n/+ acc (n/* (aget X k)
+                                         (m/sin (n/* inv-n1
+                                                     (n/+ (double i) 1.0)
+                                                     (n/+ (double k) 1.0))))))))]
+        (aset out i (n/* scale s))))
     out))

--- a/src/raster/sci/interpolation.clj
+++ b/src/raster/sci/interpolation.clj
@@ -60,16 +60,16 @@
   ;; Forward sweep
                                (loop [i 1]
                                  (when (< i n)
-                                   (let [m (/ (aget a (dec i)) (aget b (dec i)))]
-                                     (aset b i (- (aget b i) (* m (aget c (dec i)))))
-                                     (aset d i (- (aget d i) (* m (aget d (dec i))))))
+                                   (let [m (n// (aget a (dec i)) (aget b (dec i)))]
+                                     (aset b i (n/- (aget b i) (n/* m (aget c (dec i)))))
+                                     (aset d i (n/- (aget d i) (n/* m (aget d (dec i))))))
                                    (recur (inc i))))
   ;; Back substitution
-                               (aset d (dec n) (/ (aget d (dec n)) (aget b (dec n))))
+                               (aset d (dec n) (n// (aget d (dec n)) (aget b (dec n))))
                                (loop [i (- n 2)]
                                  (when (>= i 0)
-                                   (aset d i (/ (- (aget d i) (* (aget c i) (aget d (inc i))))
-                                                (aget b i)))
+                                   (aset d i (n// (n/- (aget d i) (n/* (aget c i) (aget d (inc i))))
+                                                  (aget b i)))
                                    (recur (dec i))))
                                d))
 
@@ -85,7 +85,7 @@
         ;; Compute intervals h_i = x_{i+1} - x_i
                                h (raster.arrays/alloc-like xs n-1)
                                _ (dotimes [i n-1]
-                                   (aset h i (- (aget xs (inc i)) (aget xs i))))
+                                   (aset h i (n/- (aget xs (inc i)) (aget xs i))))
         ;; Set up tridiagonal system for second derivatives (moments) M
                                nm (- n 2)
                                sub (raster.arrays/alloc-like xs (max 1 (dec nm)))
@@ -96,10 +96,10 @@
       ;; Only 3 points: nm=1, trivial
                              (let [M (raster.arrays/alloc-like xs n)
                                    _ (when (== nm 1)
-                                       (aset diag 0 (* 2.0 (+ (aget h 0) (aget h 1))))
-                                       (aset rhs 0 (* 6.0 (- (/ (- (aget ys 2) (aget ys 1)) (aget h 1))
-                                                             (/ (- (aget ys 1) (aget ys 0)) (aget h 0)))))
-                                       (aset M 1 (/ (aget rhs 0) (aget diag 0))))
+                                       (aset diag 0 (n/* 2.0 (n/+ (aget h 0) (aget h 1))))
+                                       (aset rhs 0 (n/* 6.0 (n/- (n// (n/- (aget ys 2) (aget ys 1)) (aget h 1))
+                                                                 (n// (n/- (aget ys 1) (aget ys 0)) (aget h 0)))))
+                                       (aset M 1 (n// (aget rhs 0) (aget diag 0))))
                                    cs (raster.arrays/alloc-like xs n)]
                                (dotimes [i n] (aset cs i (aget M i)))
                                (ftm [x :- Double] :- Double
@@ -118,9 +118,9 @@
                              (do
                                (dotimes [i nm]
                                  (let [j (inc i)]
-                                   (aset diag i (* 2.0 (+ (aget h (dec j)) (aget h j))))
-                                   (aset rhs i (* 6.0 (- (/ (- (aget ys (inc j)) (aget ys j)) (aget h j))
-                                                         (/ (- (aget ys j) (aget ys (dec j))) (aget h (dec j))))))))
+                                   (aset diag i (n/* 2.0 (n/+ (aget h (dec j)) (aget h j))))
+                                   (aset rhs i (n/* 6.0 (n/- (n// (n/- (aget ys (inc j)) (aget ys j)) (aget h j))
+                                                             (n// (n/- (aget ys j) (aget ys (dec j))) (aget h (dec j))))))))
                                (dotimes [i (dec nm)]
                                  (aset sub i (aget h (inc i)))
                                  (aset sup i (aget h (inc i))))
@@ -155,39 +155,39 @@
         ;; Compute slopes m_i = (y_{i+1} - y_i) / (x_{i+1} - x_i)
                                m (raster.arrays/alloc-like xs (+ n-1 4))  ;; padded: m[-2], m[-1], m[0]..m[n-2], m[n-1], m[n]
                                _ (dotimes [i n-1]
-                                   (aset m (+ i 2) (/ (- (aget ys (inc i)) (aget ys i))
-                                                      (- (aget xs (inc i)) (aget xs i)))))
+                                   (aset m (+ i 2) (n// (n/- (aget ys (inc i)) (aget ys i))
+                                                        (n/- (aget xs (inc i)) (aget xs i)))))
         ;; Pad ends
                                _ (let [m0 (aget m 2) m1 (aget m 3)]
-                                   (aset m 1 (- (* 2.0 m0) m1))
-                                   (aset m 0 (- (* 2.0 (aget m 1)) m0)))
+                                   (aset m 1 (n/- (n/* 2.0 m0) m1))
+                                   (aset m 0 (n/- (n/* 2.0 (aget m 1)) m0)))
                                _ (let [mn-2 (aget m (dec n)) mn-1 (aget m n)]
-                                   (aset m (inc n) (- (* 2.0 mn-1) mn-2))
-                                   (aset m (+ n 2) (- (* 2.0 (aget m (inc n))) mn-1)))
+                                   (aset m (inc n) (n/- (n/* 2.0 mn-1) mn-2))
+                                   (aset m (+ n 2) (n/- (n/* 2.0 (aget m (inc n))) mn-1)))
         ;; Compute Akima weights and slopes at each knot
                                slopes (raster.arrays/alloc-like xs n)
                                _ (dotimes [j n]
                                    (let [i (+ j 2)
-                                         t-im1 (n/abs (- (aget m (dec i)) (aget m (- i 2))))
-                                         t-ip1 (n/abs (- (aget m (inc i)) (aget m i)))
-                                         denom (+ t-ip1 t-im1)]
+                                         t-im1 (n/abs (n/- (aget m (dec i)) (aget m (- i 2))))
+                                         t-ip1 (n/abs (n/- (aget m (inc i)) (aget m i)))
+                                         denom (n/+ t-ip1 t-im1)]
                                      (aset slopes j
                                            (if (< denom 1e-30)
-                                             (* 0.5 (+ (aget m (dec i)) (aget m i)))
-                                             (/ (+ (* t-ip1 (aget m (dec i))) (* t-im1 (aget m i)))
-                                                denom)))))
+                                             (n/* 0.5 (n/+ (aget m (dec i)) (aget m i)))
+                                             (n// (n/+ (n/* t-ip1 (aget m (dec i))) (n/* t-im1 (aget m i)))
+                                                  denom)))))
         ;; Compute cubic polynomial coefficients per interval
                                b-arr (raster.arrays/alloc-like xs n-1)
                                c-arr (raster.arrays/alloc-like xs n-1)
                                d-arr (raster.arrays/alloc-like xs n-1)
                                _ (dotimes [i n-1]
-                                   (let [hi (- (aget xs (inc i)) (aget xs i))
+                                   (let [hi (n/- (aget xs (inc i)) (aget xs i))
                                          si (aget slopes i)
                                          si+1 (aget slopes (inc i))
-                                         mi (/ (- (aget ys (inc i)) (aget ys i)) hi)]
+                                         mi (n// (n/- (aget ys (inc i)) (aget ys i)) hi)]
                                      (aset b-arr i si)
-                                     (aset c-arr i (/ (- (* 3.0 mi) (* 2.0 si) si+1) hi))
-                                     (aset d-arr i (/ (+ si si+1 (* -2.0 mi)) (* hi hi)))))]
+                                     (aset c-arr i (n// (n/- (n/- (n/* 3.0 mi) (n/* 2.0 si)) si+1) hi))
+                                     (aset d-arr i (n// (n/+ (n/+ si si+1) (n/* -2.0 mi)) (n/* hi hi)))))]
                            (ftm [x :- Double] :- Double
                                 (let [i (find-interval xs x n)
                                       dx (n/- x (aget xs i))]
@@ -217,9 +217,9 @@
              h (raster.arrays/alloc-like xs n-1)
              delta (raster.arrays/alloc-like xs n-1)
              _ (dotimes [i n-1]
-                 (let [hi (- (aget xs (inc i)) (aget xs i))]
+                 (let [hi (n/- (aget xs (inc i)) (aget xs i))]
                    (aset h i hi)
-                   (aset delta i (/ (- (aget ys (inc i)) (aget ys i)) hi))))
+                   (aset delta i (n// (n/- (aget ys (inc i)) (aget ys i)) hi))))
         ;; Compute PCHIP derivatives at each knot
              d (raster.arrays/alloc-like xs n)
              _ (do
@@ -228,13 +228,13 @@
                    (when (< i n-1)
                      (let [d1 (aget delta (dec i))
                            d2 (aget delta i)]
-                       (if (or (<= (* d1 d2) 0.0))
+                       (if (or (<= (n/* d1 d2) 0.0))
                     ;; Different signs or zero: set derivative to zero
                          (aset d i 0.0)
                     ;; Weighted harmonic mean
-                         (let [w1 (+ (* 2.0 (aget h i)) (aget h (dec i)))
-                               w2 (+ (aget h i) (* 2.0 (aget h (dec i))))]
-                           (aset d i (/ (+ w1 w2) (+ (/ w1 d1) (/ w2 d2)))))))
+                         (let [w1 (n/+ (n/* 2.0 (aget h i)) (aget h (dec i)))
+                               w2 (n/+ (aget h i) (n/* 2.0 (aget h (dec i))))]
+                           (aset d i (n// (n/+ w1 w2) (n/+ (n// w1 d1) (n// w2 d2)))))))
                      (recur (inc i))))
             ;; Endpoint derivatives: one-sided shape-preserving
                  (let [d0 (aget delta 0)]
@@ -249,8 +249,8 @@
                        di (aget d i)
                        di+1 (aget d (inc i))
                        deli (aget delta i)]
-                   (aset c2 i (/ (- (* 3.0 deli) (* 2.0 di) di+1) hi))
-                   (aset c3 i (/ (+ di di+1 (* -2.0 deli)) (* hi hi)))))]
+                   (aset c2 i (n// (n/- (n/- (n/* 3.0 deli) (n/* 2.0 di)) di+1) hi))
+                   (aset c3 i (n// (n/+ (n/+ di di+1) (n/* -2.0 deli)) (n/* hi hi)))))]
          (ftm [x :- Double] :- Double
               (let [i (find-interval xs x n)
                     dx (n/- x (aget xs i))]

--- a/src/raster/sci/optim.clj
+++ b/src/raster/sci/optim.clj
@@ -31,7 +31,7 @@
 (deftm dot
   "Compute the dot product of two arrays."
   (All [T] [a :- (Array T), b :- (Array T)] :- Double
-       (reduce! [acc 0.0] [a b] (+ acc (* a b)))))
+       (reduce! [acc 0.0] [a b] (n/+ acc (n/* a b)))))
 
 (deftm vec-norm
   "Compute the Euclidean norm of an array."
@@ -50,7 +50,7 @@
   "Write the negation of a into out, element-wise."
   (All [T] [out :- (Array T), a :- (Array T)] :- (Array T)
        (dotimes [i (alength out)]
-         (aset out i (- (aget a i))))
+         (aset out i (n/- (aget a i))))
        out))
 
 (deftm vec-step!
@@ -58,7 +58,7 @@
   (All [T] [x :- (Array T), alpha :- Double, d :- (Array T)]
        :- (Array T)
        (dotimes [i (alength x)]
-         (aset x i (+ (aget x i) (* alpha (aget d i)))))
+         (aset x i (n/+ (aget x i) (n/* alpha (aget d i)))))
        x))
 
 ;; ================================================================
@@ -75,11 +75,11 @@
              tmp (vec-copy x)]
          (dotimes [i n]
            (let [xi (aget x i)]
-             (aset tmp i (+ xi eps))
+             (aset tmp i (n/+ xi eps))
              (let [fp (f tmp)]
-               (aset tmp i (- xi eps))
+               (aset tmp i (n/- xi eps))
                (let [fm (f tmp)]
-                 (aset out i (/ (- fp fm) (* 2.0 eps)))
+                 (aset out i (n// (n/- fp fm) (n/* 2.0 eps)))
                  (aset tmp i xi)))))
          out)))
 
@@ -102,11 +102,11 @@
              alpha
              (do
                (dotimes [i n]
-                 (aset x-new i (+ (aget x i) (* alpha (aget d i)))))
+                 (aset x-new i (n/+ (aget x i) (n/* alpha (aget d i)))))
                (let [fx-new (f x-new)]
-                 (if (<= fx-new (+ fx (* c alpha grad-dot-d)))
+                 (if (<= fx-new (n/+ fx (n/* (n/* c alpha) grad-dot-d)))
                    alpha
-                   (recur (* rho alpha) (unchecked-add-int iter 1))))))))))
+                   (recur (n/* rho alpha) (unchecked-add-int iter 1))))))))))
 
 ;; ================================================================
 ;; Nelder-Mead (derivative-free simplex method)
@@ -124,8 +124,8 @@
              (when (not= idx best-idx)
                (let [v (aget simplex idx)]
                  (dotimes [k n]
-                   (aset v k (+ (aget xb k)
-                                (* 0.5 (- (aget v k) (aget xb k))))))
+                   (aset v k (n/+ (aget xb k)
+                                  (n/* 0.5 (n/- (aget v k) (aget xb k))))))
                  (aset fvals idx (f v)))))))))
 
 (deftm nm-sort-order!
@@ -155,9 +155,9 @@
            (when (not= idx worst-idx)
              (let [v (aget simplex idx)]
                (dotimes [k n]
-                 (aset centroid k (+ (aget centroid k) (aget v k))))))))
+                 (aset centroid k (n/+ (aget centroid k) (aget v k))))))))
        (dotimes [k n]
-         (aset centroid k (/ (aget centroid k) (double n))))
+         (aset centroid k (n// (aget centroid k) (double n))))
        centroid))
 
 (deftm nm-reflect!
@@ -165,8 +165,8 @@
   (All [T] [out :- (Array T), centroid :- (Array T),
             xw :- (Array T), coeff :- Double, n :- Long]
        (dotimes [k n]
-         (aset out k (+ (aget centroid k)
-                        (* coeff (- (aget centroid k) (aget xw k))))))
+         (aset out k (n/+ (aget centroid k)
+                          (n/* coeff (n/- (aget centroid k) (aget xw k))))))
        out))
 
 (deftm nm-expand!
@@ -174,8 +174,8 @@
   (All [T] [out :- (Array T), centroid :- (Array T),
             xr :- (Array T), gamma :- Double, n :- Long]
        (dotimes [k n]
-         (aset out k (+ (aget centroid k)
-                        (* gamma (- (aget xr k) (aget centroid k))))))
+         (aset out k (n/+ (aget centroid k)
+                          (n/* gamma (n/- (aget xr k) (aget centroid k))))))
        out))
 
 (deftm nm-contract-outside!
@@ -183,8 +183,8 @@
   (All [T] [out :- (Array T), centroid :- (Array T),
             xr :- (Array T), beta :- Double, n :- Long]
        (dotimes [k n]
-         (aset out k (+ (aget centroid k)
-                        (* beta (- (aget xr k) (aget centroid k))))))
+         (aset out k (n/+ (aget centroid k)
+                          (n/* beta (n/- (aget xr k) (aget centroid k))))))
        out))
 
 (deftm nm-contract-inside!
@@ -192,8 +192,8 @@
   (All [T] [out :- (Array T), centroid :- (Array T),
             xw :- (Array T), beta :- Double, n :- Long]
        (dotimes [k n]
-         (aset out k (+ (aget centroid k)
-                        (* beta (- (aget xw k) (aget centroid k))))))
+         (aset out k (n/+ (aget centroid k)
+                          (n/* beta (n/- (aget xw k) (aget centroid k))))))
        out))
 
 (deftm nelder-mead
@@ -215,8 +215,8 @@
          (dotimes [i n]
            (let [v  (vec-copy x0)
                  xi (aget x0 i)
-                 delta (if (== xi 0.0) 0.00025 (* 0.05 xi))]
-             (aset v i (+ xi delta))
+                 delta (if (== xi 0.0) 0.00025 (n/* 0.05 xi))]
+             (aset v i (n/+ xi delta))
              (aset simplex (inc i) v)
              (aset fvals (inc i) (f v))))
          (loop [iter (int 0)]
@@ -226,7 +226,7 @@
                  f-best    (aget fvals best-idx)
                  f-worst   (aget fvals worst-idx)
                  f-second  (aget fvals (aget order (dec n)))
-                 spread    (- f-worst f-best)]
+                 spread    (n/- f-worst f-best)]
              (if (or (>= iter maxiter) (< spread tol))
                {:minimizer (vec (aget simplex best-idx))
                 :minimum   f-best
@@ -340,18 +340,18 @@
                            si   (aget s-store idx)
                            yi   (aget y-store idx)
                            rhoi (aget rho-store idx)
-                           ai   (* rhoi (dot si q))]
+                           ai   (n/* rhoi (dot si q))]
                        (aset alpha-buf i ai)
                        (dotimes [j n]
-                         (aset q j (- (aget q j) (* ai (aget yi j)))))
+                         (aset q j (n/- (aget q j) (n/* ai (aget yi j)))))
                        (recur (dec i)))))
             ;; Scale by gamma
                  (when (> bound 0)
                    (let [last-idx (int (clojure.core/mod (dec k) m))
                          s-last (aget s-store last-idx)
                          y-last (aget y-store last-idx)
-                         gamma  (/ (dot s-last y-last) (dot y-last y-last))]
-                     (dotimes [j n] (aset q j (* gamma (aget q j))))))
+                         gamma  (n// (dot s-last y-last) (dot y-last y-last))]
+                     (dotimes [j n] (aset q j (n/* gamma (aget q j))))))
             ;; Second loop (forward)
                  (loop [i (int 0)]
                    (when (< i bound)
@@ -359,32 +359,32 @@
                            si   (aget s-store idx)
                            yi   (aget y-store idx)
                            rhoi (aget rho-store idx)
-                           beta (* rhoi (dot yi q))]
+                           beta (n/* rhoi (dot yi q))]
                        (dotimes [j n]
-                         (aset q j (+ (aget q j) (* (- (aget alpha-buf i) beta) (aget si j)))))
+                         (aset q j (n/+ (aget q j) (n/* (n/- (aget alpha-buf i) beta) (aget si j)))))
                        (recur (unchecked-add-int i 1)))))
             ;; d = -H*g, line search, update
                  (let [d (n/similar x0)
-                       _ (dotimes [j n] (aset d j (- (aget q j))))
+                       _ (dotimes [j n] (aset d j (n/- (aget q j))))
                        gd    (dot g d)
                        alpha (backtracking-linesearch f x d gd 1.0 1e-4 0.9 30)
                        _     (acopy! g 0 g-prev 0 n)
                        s-new (n/similar x0)]
                    (dotimes [j n]
-                     (let [step (* alpha (aget d j))]
+                     (let [step (n/* alpha (aget d j))]
                        (aset s-new j step)
-                       (aset x j (+ (aget x j) step))))
+                       (aset x j (n/+ (aget x j) step))))
                    (grad-fn x g)
                    (let [y-new (n/similar x0)]
                      (dotimes [j n]
-                       (aset y-new j (- (aget g j) (aget g-prev j))))
+                       (aset y-new j (n/- (aget g j) (aget g-prev j))))
                      (let [sy (dot s-new y-new)
                            stored? (> sy 1e-20)]
                        (when stored?
                          (let [idx (int (clojure.core/mod k m))]
                            (aset s-store idx s-new)
                            (aset y-store idx y-new)
-                           (aset rho-store idx (/ 1.0 sy))))
+                           (aset rho-store idx (n// 1.0 sy))))
                        (recur (unchecked-add-int iter 1)
                               (if stored?
                                 (unchecked-add-int k 1)
@@ -406,14 +406,14 @@
              tmp (vec-copy x)]
          (dotimes [i n]
            (let [xi (aget x i)]
-             (aset tmp i (+ xi eps))
+             (aset tmp i (n/+ xi eps))
              (finite-gradient! f tmp g1)
-             (aset tmp i (- xi eps))
+             (aset tmp i (n/- xi eps))
              (finite-gradient! f tmp g2)
              (aset tmp i xi)
              (let [row (aget H i)]
                (dotimes [j n]
-                 (aset row j (/ (- (aget g1 j) (aget g2 j)) (* 2.0 eps)))))))
+                 (aset row j (n// (n/- (aget g1 j) (aget g2 j)) (n/* 2.0 eps)))))))
          H)))
 
 (deftm solve-linear
@@ -427,7 +427,7 @@
            (let [row (double-array (inc n))
                  h-row (aget H i)]
              (dotimes [j n] (aset row j (aget h-row j)))
-             (aset row n (- (aget g i)))
+             (aset row n (n/- (aget g i)))
              (aset A i row)))
     ;; Forward elimination with partial pivoting
          (dotimes [k n]
@@ -445,12 +445,12 @@
              (when (> (n/abs akk) 1e-15)
                (loop [i (inc k)]
                  (when (< i n)
-                   (let [factor (/ (aget (aget A i) k) akk)]
+                   (let [factor (n// (aget (aget A i) k) akk)]
                      (loop [j k]
                        (when (<= j n)
                          (aset (aget A i) j
-                               (- (aget (aget A i) j)
-                                  (* factor (aget (aget A k) j))))
+                               (n/- (aget (aget A i) j)
+                                    (n/* factor (aget (aget A k) j))))
                          (recur (inc j)))))
                    (recur (inc i)))))))
     ;; Back substitution
@@ -459,9 +459,9 @@
              (when (>= i 0)
                (let [sum (loop [j (inc i) acc 0.0]
                            (if (>= j n) acc
-                               (recur (inc j) (+ acc (* (aget (aget A i) j) (aget d j))))))]
-                 (aset d i (/ (- (aget (aget A i) n) sum)
-                              (aget (aget A i) i))))
+                               (recur (inc j) (n/+ acc (n/* (aget (aget A i) j) (aget d j))))))]
+                 (aset d i (n// (n/- (aget (aget A i) n) sum)
+                                (aget (aget A i) i))))
                (recur (dec i))))
            d))))
 
@@ -494,7 +494,7 @@
                               (vec-negate! nd g)
                               nd)
                             d)
-                       gd (if (>= gd 0.0) (- (dot g g)) gd)
+                       gd (if (>= gd 0.0) (n/- (dot g g)) gd)
                        alpha (backtracking-linesearch f x d gd 1.0 1e-4 0.5 30)]
                    (vec-step! x alpha d)
                    (recur (unchecked-add-int iter 1))))))))))
@@ -537,7 +537,7 @@
   (All [T] [m :- (Array T), grads :- (Array T),
             beta1 :- Double] :- (Array T)
        (dotimes [i (alength m)]
-         (aset m i (+ (* beta1 (aget m i)) (* (- 1.0 beta1) (aget grads i)))))
+         (aset m i (n/+ (n/* beta1 (aget m i)) (n/* (n/- 1.0 beta1) (aget grads i)))))
        m))
 
 (deftm adam-update-v!
@@ -545,7 +545,7 @@
   (All [T] [v :- (Array T), grads :- (Array T),
             beta2 :- Double] :- (Array T)
        (dotimes [i (alength v)]
-         (aset v i (+ (* beta2 (aget v i)) (* (- 1.0 beta2) (* (aget grads i) (aget grads i))))))
+         (aset v i (n/+ (n/* beta2 (aget v i)) (n/* (n/- 1.0 beta2) (n/* (aget grads i) (aget grads i))))))
        v))
 
 (deftm adam-step!
@@ -553,11 +553,11 @@
   (All [T] [params :- (Array T), m :- (Array T),
             v :- (Array T), lr :- Double,
             beta1-t :- Double, beta2-t :- Double] :- (Array T)
-       (let [lr-corrected (/ lr (- 1.0 beta2-t))]
+       (let [lr-corrected (n// lr (n/- 1.0 beta2-t))]
          (dotimes [i (alength params)]
-           (aset params i (- (aget params i)
-                             (* lr-corrected (/ (/ (aget m i) (- 1.0 beta1-t))
-                                                (+ (n/sqrt (aget v i)) 1e-8))))))
+           (aset params i (n/- (aget params i)
+                               (n/* lr-corrected (n// (n// (aget m i) (n/- 1.0 beta1-t))
+                                                      (n/+ (n/sqrt (aget v i)) 1e-8))))))
          params)))
 
 (defvalue AdamState [m :- (Array double), v :- (Array double), t :- Long, beta1-t :- Double, beta2-t :- Double])
@@ -577,8 +577,8 @@
              t (.t state)
              beta1-t (.beta1-t state)
              beta2-t (.beta2-t state)
-             new-beta1-t (* beta1-t beta1)
-             new-beta2-t (* beta2-t beta2)]
+             new-beta1-t (n/* beta1-t beta1)
+             new-beta2-t (n/* beta2-t beta2)]
          (adam-update-m! m grads beta1)
          (adam-update-v! v grads beta2)
          (adam-step! params m v lr new-beta1-t new-beta2-t)
@@ -606,11 +606,11 @@
          (f x r0)
          (dotimes [j n]
            (let [xj (aget x j)]
-             (aset tmp j (+ xj eps))
+             (aset tmp j (n/+ xj eps))
              (f tmp r1)
              (aset tmp j xj)
              (dotimes [i m]
-               (aset J (+ (* i n) j) (/ (- (aget r1 i) (aget r0 i)) eps)))))
+               (aset J (+ (* i n) j) (n// (n/- (aget r1 i) (aget r0 i)) eps)))))
          J)))
 
 (deftm levenberg-marquardt
@@ -631,24 +631,24 @@
          (loop [iter (int 0)
                 lambda 1e-3]
            (let [cost (loop [i 0 s 0.0]
-                        (if (>= i m) s (recur (inc i) (+ s (* (aget r i) (aget r i))))))
+                        (if (>= i m) s (recur (inc i) (n/+ s (n/* (aget r i) (aget r i))))))
                  _ (compute-jacobian! f x J m n)
             ;; J^T * J and J^T * r
                  _ (dotimes [i n]
                      (dotimes [j n]
                        (let [s (loop [k 0 acc 0.0]
                                  (if (>= k m) acc
-                                     (recur (inc k) (+ acc (* (aget J (+ (* k n) i))
-                                                              (aget J (+ (* k n) j)))))))]
+                                     (recur (inc k) (n/+ acc (n/* (aget J (+ (* k n) i))
+                                                                  (aget J (+ (* k n) j)))))))]
                          (aset JtJ (+ (* i n) j) s)))
                      (let [s (loop [k 0 acc 0.0]
                                (if (>= k m) acc
-                                   (recur (inc k) (+ acc (* (aget J (+ (* k n) i))
-                                                            (aget r k))))))]
+                                   (recur (inc k) (n/+ acc (n/* (aget J (+ (* k n) i))
+                                                                (aget r k))))))]
                        (aset Jtr i s)))
             ;; Add lambda to diagonal (damping)
                  _ (dotimes [i n]
-                     (aset JtJ (+ (* i n) i) (+ (aget JtJ (+ (* i n) i)) lambda)))
+                     (aset JtJ (+ (* i n) i) (n/+ (aget JtJ (+ (* i n) i)) lambda)))
             ;; Solve (J^T J + lambda I) dx = -J^T r via Gaussian elimination
                  H-obj (object-array n)
                  _ (dotimes [i n]
@@ -661,23 +661,23 @@
              (let [dx-norm (vec-norm dx)]
                (if (or (>= iter maxiter) (< dx-norm tol))
                  {:minimizer (vec x)
-                  :minimum   (* 0.5 cost)
+                  :minimum   (n/* 0.5 cost)
                   :iterations (long iter)
                   :converged? (< dx-norm tol)}
             ;; Trial step
                  (do
-                   (dotimes [i n] (aset x-trial i (+ (aget x i) (aget dx i))))
+                   (dotimes [i n] (aset x-trial i (n/+ (aget x i) (aget dx i))))
                    (f x-trial r-trial)
                    (let [trial-cost (loop [i 0 s 0.0]
                                       (if (>= i m) s
-                                          (recur (inc i) (+ s (* (aget r-trial i) (aget r-trial i))))))]
+                                          (recur (inc i) (n/+ s (n/* (aget r-trial i) (aget r-trial i))))))]
                      (if (< trial-cost cost)
                   ;; Accept step, decrease lambda
                        (do (acopy! x-trial 0 x 0 n)
                            (acopy! r-trial 0 r 0 m)
-                           (recur (unchecked-add-int iter 1) (* lambda 0.1)))
+                           (recur (unchecked-add-int iter 1) (n/* lambda 0.1)))
                   ;; Reject step, increase lambda
-                       (recur (unchecked-add-int iter 1) (* lambda 10.0))))))))))))
+                       (recur (unchecked-add-int iter 1) (n/* lambda 10.0))))))))))))
 
 ;; ================================================================
 ;; Gauss-Newton
@@ -705,8 +705,8 @@
   (let [residual-fn (ftm [params :- (Array double), residuals :- (Array double)] :- (Array double)
                          (dotimes [i n-data]
                            (aset residuals i
-                                 (- (model params (aget xdata i))
-                                    (aget ydata i))))
+                                 (n/- (model params (aget xdata i))
+                                      (aget ydata i))))
                          residuals)]
     (levenberg-marquardt residual-fn p0 n-data n-params 1e-8 200)))
 
@@ -745,9 +745,9 @@
                (let [alpha (backtracking-linesearch f x
                                                     (let [d (n/similar x0)]
                                                       (vec-negate! d g) d)
-                                                    (- (dot g g)) 1.0 1e-4 0.5 30)]
+                                                    (n/- (dot g g)) 1.0 1e-4 0.5 30)]
                  (dotimes [i n]
-                   (aset x i (- (aget x i) (* alpha (aget g i)))))
+                   (aset x i (n/- (aget x i) (n/* alpha (aget g i)))))
                  (project-bounds! x lower upper n)
                  (recur (unchecked-add-int iter 1)))))))))
 
@@ -779,8 +779,8 @@
     (dotimes [i pop-size]
       (let [x (double-array n)]
         (dotimes [j n]
-          (aset x j (+ (aget lower j)
-                       (* (.nextDouble rng) (- (aget upper j) (aget lower j))))))
+          (aset x j (n/+ (aget lower j)
+                         (n/* (.nextDouble rng) (n/- (aget upper j) (aget lower j))))))
         (aset pop i x)
         (aset fitness i (f x))))
     (loop [iter (int 0)]
@@ -815,7 +815,7 @@
                 ;; Mutant + crossover
                 (dotimes [j n]
                   (if (or (== j j-rand) (< (.nextDouble rng) CR))
-                    (let [v (+ (aget xa j) (* F (- (aget xb j) (aget xc j))))
+                    (let [v (n/+ (aget xa j) (n/* F (n/- (aget xb j) (aget xc j))))
                           v (n/max (aget lower j) (n/min (aget upper j) v))]
                       (aset trial j v))
                     (aset trial j (aget xi j))))

--- a/src/raster/sci/signal.clj
+++ b/src/raster/sci/signal.clj
@@ -24,43 +24,43 @@
 
 (deftm hann [n :- Long] :- (Array double)
   (let [n-1 (double (dec n))
-        two-pi (* 2.0 n/pi)]
+        two-pi (n/* 2.0 n/pi)]
     (par/map [i n]
-             (* 0.5 (- 1.0 (m/cos (/ (* two-pi (double i)) n-1)))))))
+             (n/* 0.5 (n/- 1.0 (m/cos (n// (n/* two-pi (double i)) n-1)))))))
 
 (deftm hamming [n :- Long] :- (Array double)
   (let [n-1 (double (dec n))
-        two-pi (* 2.0 n/pi)]
+        two-pi (n/* 2.0 n/pi)]
     (par/map [i n]
-             (- 0.54 (* 0.46 (m/cos (/ (* two-pi (double i)) n-1)))))))
+             (n/- 0.54 (n/* 0.46 (m/cos (n// (n/* two-pi (double i)) n-1)))))))
 
 (deftm blackman [n :- Long] :- (Array double)
   (let [n-1 (double (dec n))
-        two-pi (* 2.0 n/pi)
-        four-pi (* 4.0 n/pi)]
+        two-pi (n/* 2.0 n/pi)
+        four-pi (n/* 4.0 n/pi)]
     (par/map [i n]
              (let [x (double i)]
-               (+ (- 0.42 (* 0.5 (m/cos (/ (* two-pi x) n-1))))
-                  (* 0.08 (m/cos (/ (* four-pi x) n-1))))))))
+               (n/+ (n/- 0.42 (n/* 0.5 (m/cos (n// (n/* two-pi x) n-1))))
+                    (n/* 0.08 (m/cos (n// (n/* four-pi x) n-1))))))))
 
 (deftm besseli0-kaiser
   "Modified Bessel function I0(x) via series expansion for Kaiser window."
   [x :- Double] :- Double
-  (let [half-x (* 0.5 x)]
+  (let [half-x (n/* 0.5 x)]
     (loop [k 1 term 1.0 sum 1.0]
-      (if (or (> k 25) (< (n/abs term) (* 1e-16 (n/abs sum))))
+      (if (or (> k 25) (< (n/abs term) (n/* 1e-16 (n/abs sum))))
         sum
-        (let [t (/ half-x (double k))
-              new-term (* term t t)]
-          (recur (inc k) new-term (+ sum new-term)))))))
+        (let [t (n// half-x (double k))
+              new-term (n/* (n/* term t) t)]
+          (recur (inc k) new-term (n/+ sum new-term)))))))
 
 (deftm kaiser [n :- Long beta :- Double] :- (Array double)
   (let [n-1 (double (dec n))
-        inv-i0-beta (/ 1.0 (besseli0-kaiser beta))]
+        inv-i0-beta (n// 1.0 (besseli0-kaiser beta))]
     (par/map [i n]
-             (let [ratio (- (* 2.0 (/ (double i) n-1)) 1.0)
-                   arg (* beta (n/sqrt (n/max 0.0 (- 1.0 (* ratio ratio)))))]
-               (* (besseli0-kaiser arg) inv-i0-beta)))))
+             (let [ratio (n/- (n/* 2.0 (n// (double i) n-1)) 1.0)
+                   arg (n/* beta (n/sqrt (n/max 0.0 (n/- 1.0 (n/* ratio ratio)))))]
+               (n/* (besseli0-kaiser arg) inv-i0-beta)))))
 
 ;; ================================================================
 ;; Spectral analysis — Welch method
@@ -83,7 +83,7 @@
                     (if (>= i nperseg)
                       s
                       (let [wi (aget window i)]
-                        (recur (inc i) (+ s (* wi wi))))))
+                        (recur (inc i) (n/+ s (n/* wi wi))))))
         psd (double-array n-freqs)
         seg (double-array nperseg)]
     ;; Average periodograms over segments
@@ -93,30 +93,30 @@
                      (do
                        ;; Extract and window segment
                        (dotimes [j nperseg]
-                         (aset seg j (* (aget x (+ start j)) (aget window j))))
+                         (aset seg j (n/* (aget x (+ start j)) (aget window j))))
                        ;; FFT
                        (let [[re im] (fft/fft seg)]
                          ;; Accumulate one-sided periodogram
                          (dotimes [k n-freqs]
                            (let [rk (aget re k)
                                  ik (aget im k)
-                                 power (+ (* rk rk) (* ik ik))]
-                             (aset psd k (+ (aget psd k) power)))))
+                                 power (n/+ (n/* rk rk) (n/* ik ik))]
+                             (aset psd k (n/+ (aget psd k) power)))))
                        (recur (+ start step) (inc cnt)))))]
       ;; Normalize: PSD = sum / (n-segs * win-power)
-      (let [norm (/ 1.0 (* (double n-segs) win-power))]
+      (let [norm (n// 1.0 (n/* (double n-segs) win-power))]
         (dotimes [k n-freqs]
-          (aset psd k (* (aget psd k) norm)))
+          (aset psd k (n/* (aget psd k) norm)))
         ;; Double interior bins (one-sided spectrum)
         (loop [k 1]
           (when (< k (dec n-freqs))
-            (aset psd k (* (aget psd k) 2.0))
+            (aset psd k (n/* (aget psd k) 2.0))
             (recur (inc k)))))
       ;; Frequency axis: k / nperseg for k = 0..n-freqs-1 (normalized)
       (let [freqs (double-array n-freqs)
-            inv-n (/ 1.0 (double nperseg))]
+            inv-n (n// 1.0 (double nperseg))]
         (dotimes [k n-freqs]
-          (aset freqs k (* (double k) inv-n)))
+          (aset freqs k (n/* (double k) inv-n)))
         (object-array [freqs psd])))))
 
 ;; ================================================================
@@ -148,8 +148,8 @@
             b (aget xi i)
             c (aget yr i)
             d (aget yi i)]
-        (aset prod-re i (+ (* a c) (* b d)))
-        (aset prod-im i (- (* b c) (* a d)))))
+        (aset prod-re i (n/+ (n/* a c) (n/* b d)))
+        (aset prod-im i (n/- (n/* b c) (n/* a d)))))
     ;; IFFT
     (let [[res-re _] (fft/ifft prod-re prod-im)
           result (double-array out-len)]
@@ -188,8 +188,8 @@
             b (aget xi i)
             c (aget yr i)
             d (aget yi i)]
-        (aset prod-re i (- (* a c) (* b d)))
-        (aset prod-im i (+ (* a d) (* b c)))))
+        (aset prod-re i (n/- (n/* a c) (n/* b d)))
+        (aset prod-im i (n/+ (n/* a d) (n/* b c)))))
     ;; IFFT and take first out-len samples
     (let [[res-re _] (fft/ifft prod-re prod-im)
           result (double-array out-len)]
@@ -210,9 +210,9 @@
                           bn (double-array nz)
                           an (double-array nz)
                           _ (dotimes [i nb]
-                              (aset bn i (/ (aget b i) a0)))
+                              (aset bn i (n// (aget b i) a0)))
                           _ (dotimes [i na]
-                              (aset an i (/ (aget a i) a0)))
+                              (aset an i (n// (aget a i) a0)))
         ;; State (delay line), length nz-1 (or 1 if nz<=1)
                           nstate (max 1 (dec nz))
                           z (double-array nstate)
@@ -221,21 +221,21 @@
                       (dotimes [n nx]
                         (let [xn (aget x n)
             ;; Output: y[n] = b[0]*x[n] + z[0]
-                              yn (+ (* (aget bn 0) xn) (aget z 0))]
+                              yn (n/+ (n/* (aget bn 0) xn) (aget z 0))]
                           (aset y n yn)
         ;; Update delay line: z[i] = b[i+1]*x[n] - a[i+1]*y[n] + z[i+1]
                           (loop [i 0]
                             (when (< i (dec nstate))
                               (let [bi1 (aget bn (inc i))
                                     ai1 (aget an (inc i))]
-                                (aset z i (+ (- (* bi1 xn) (* ai1 yn)) (aget z (inc i)))))
+                                (aset z i (n/+ (n/- (n/* bi1 xn) (n/* ai1 yn)) (aget z (inc i)))))
                               (recur (inc i))))
         ;; Last state element (no z[i+1] term)
                           (when (> nstate 0)
                             (let [last-i (dec nstate)
                                   bi1 (if (< (inc last-i) nz) (aget bn (inc last-i)) 0.0)
                                   ai1 (if (< (inc last-i) nz) (aget an (inc last-i)) 0.0)]
-                              (aset z last-i (- (* bi1 xn) (* ai1 yn)))))))
+                              (aset z last-i (n/- (n/* bi1 xn) (n/* ai1 yn)))))))
                       y)))
 
 ;; ================================================================
@@ -250,28 +250,28 @@
   Returns filter coefficients (length numtaps) with Hamming window applied."
   [numtaps :- Long cutoff :- Double fs :- Double] :- (Array double)
   (let [h (double-array numtaps)
-        fc (/ cutoff (* 0.5 fs))  ;; normalized cutoff [0, 1]
+        fc (n// cutoff (n/* 0.5 fs))  ;; normalized cutoff [0, 1]
         m (double (dec numtaps))
-        half-m (* 0.5 m)
+        half-m (n/* 0.5 m)
         win (hamming numtaps)]
     ;; Ideal sinc lowpass
     (dotimes [i numtaps]
-      (let [n-shifted (- (double i) half-m)]
+      (let [n-shifted (n/- (double i) half-m)]
         (if (< (n/abs n-shifted) 1e-15)
           (aset h i fc)
-          (aset h i (/ (m/sin (* n/pi fc n-shifted))
-                       (* n/pi n-shifted))))))
+          (aset h i (n// (m/sin (n/* (n/* n/pi fc) n-shifted))
+                         (n/* n/pi n-shifted))))))
     ;; Apply window
     (dotimes [i numtaps]
-      (aset h i (* (aget h i) (aget win i))))
+      (aset h i (n/* (aget h i) (aget win i))))
     ;; Normalize to unit DC gain
     (let [sum (loop [i 0 s 0.0]
                 (if (>= i numtaps)
                   s
-                  (recur (inc i) (+ s (aget h i)))))
-          inv-sum (/ 1.0 sum)]
+                  (recur (inc i) (n/+ s (aget h i)))))
+          inv-sum (n// 1.0 sum)]
       (dotimes [i numtaps]
-        (aset h i (* (aget h i) inv-sum))))
+        (aset h i (n/* (aget h i) inv-sum))))
     h))
 
 ;; ================================================================
@@ -302,20 +302,20 @@
                    a1 (aget sos (+ base 4))
                    a2 (aget sos (+ base 5))
               ;; Normalize by a0
-                   inv-a0 (/ 1.0 a0)
-                   b0n (* b0 inv-a0)
-                   b1n (* b1 inv-a0)
-                   b2n (* b2 inv-a0)
-                   a1n (* a1 inv-a0)
-                   a2n (* a2 inv-a0)]
+                   inv-a0 (n// 1.0 a0)
+                   b0n (n/* b0 inv-a0)
+                   b1n (n/* b1 inv-a0)
+                   b2n (n/* b2 inv-a0)
+                   a1n (n/* a1 inv-a0)
+                   a2n (n/* a2 inv-a0)]
           ;; Direct Form II Transposed for this section
                (loop [n 0 z1 0.0 z2 0.0]
                  (if (>= n nx)
                    nil
                    (let [xn (aget buf-in n)
-                         yn (+ (* b0n xn) z1)
-                         new-z1 (+ (* b1n xn) (- (* a1n yn)) z2)
-                         new-z2 (- (* b2n xn) (* a2n yn))]
+                         yn (n/+ (n/* b0n xn) z1)
+                         new-z1 (n/+ (n/+ (n/* b1n xn) (n/- (n/* a1n yn))) z2)
+                         new-z2 (n/- (n/* b2n xn) (n/* a2n yn))]
                      (aset buf-out n yn)
                      (recur (inc n) new-z1 new-z2))))
           ;; Copy output to input for next section


### PR DESCRIPTION
## Summary

Two related changes that converge on one structural goal — **making the lazy-JIT and compile-aot pipelines lower pure `par` forms identically**:

1. **JIT materialize pass** (supersedes the earlier pmap point-fix). The lazy-JIT compile chain now runs the same `materialize` pass that compile-aot uses (pure `par/pmap` → `alloc` + `par/map!`), inserted **after** `macroexpand-all` and before the final par-form expansion. This closes the JIT/AOT divergence that leaked `raster.par/pmap` to the emitter (`Cannot resolve class: raster.par`) and generalizes it to **all** pure par forms — not just the single pmap case.

   Placement is load-bearing: materialize's input dialect is plain-symbol `let*`, so it must run after `macroexpand-all`. Running it earlier (on the raw walked body) rewrites a `let` with destructuring into `let*` and orphans the destructured symbols.

   `segop-lower` is intentionally **not** run in lazy-JIT (the scalar JIT path expands `par/map!` to loops via `pre-expand`); SIMD in lazy-JIT stays gated on `*jit-simd?*` pending the `.invk`-boundary escape-analysis fix.

2. **Phase-2 `clojure.core` → `raster.numeric` conversion** (per-site): `dl/diffusion`, `sci/fft`, `sci/interpolation`, `sci/signal`, `sci/optim`, `sci/distributions`, `noise`. Float math routed through `raster.numeric`; integer index arithmetic kept on `clojure.core`.

## Validation

`clojure -X:test` → **1498 tests, 7200 assertions, 0 failures, 0 errors** (262 s).
