### PR TITLE
simd: fix silent miscompile on one-array-two-bases kernels + de-box index math

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -83,7 +83,7 @@
           :ns-default build}
   :valhalla {:extra-paths ["classes"]
              :jvm-opts ["-XX:ReservedCodeCacheSize=512m"
-                        "-Xmx12g"
+                        "-Xmx8g"
                         "--enable-preview"
                         "--add-exports" "java.base/jdk.internal.vm.annotation=ALL-UNNAMED"
                         "--add-exports" "java.base/jdk.internal.classfile.components=ALL-UNNAMED"

--- a/src/raster/compiler/backend/jvm/par_simd.clj
+++ b/src/raster/compiler/backend/jvm/par_simd.clj
@@ -45,6 +45,14 @@
 (def ^:private aget-form? segop-simd/aget-form?)
 (defn- simd-able-expr? [expr idx] (segop-simd/simd-able? expr idx))
 
+;; Integer index/offset/bound arithmetic must emit as clojure.core primitives —
+;; bare symbols resolve to raster.numeric in the kernel ns and box per iteration.
+;; See segop-simd's ix+ rationale / CLAUDE.md (integer index arith stays clojure.core).
+(defn- ix+ [a b] (list 'clojure.core/+ a b))
+(defn- ix- [a b] (list 'clojure.core/- a b))
+(defn- ix<= [a b] (list 'clojure.core/<= a b))
+(defn- ix< [a b] (list 'clojure.core/< a b))
+
 (defn- collect-scalars
   "Collect scalar symbols from body expression (delegates to segop-simd analysis)."
   [body-expr idx-sym]
@@ -243,9 +251,9 @@
               load-bindings (vec (mapcat
                                   (fn [s]
                                     (let [{:keys [left center right]} (get arr-shifted-syms s)]
-                                      [left (list from-array species-sym s (list '- j-sym 1))
+                                      [left (list from-array species-sym s (ix- j-sym 1))
                                        center (list from-array species-sym s j-sym)
-                                       right (list from-array species-sym s (list '+ j-sym 1))]))
+                                       right (list from-array species-sym s (ix+ j-sym 1))]))
                                   arr-syms))
               ;; Build vec-env for body emission: map each aget pattern to its shifted vector
               ;; We need a custom approach: rewrite body replacing agets with vector refs
@@ -333,18 +341,18 @@
                   (list 'do
                 ;; Fill boundary elements with boundary value
                         (list 'clojure.core/aset out 0 (or boundary 0.0))
-                        (list 'clojure.core/aset out (list '- n-sym 1) (or boundary 0.0))
+                        (list 'clojure.core/aset out (ix- n-sym 1) (or boundary 0.0))
                 ;; SIMD interior loop: [radius, n-radius) with vector width steps
                         (if (seq scalar-broadcast-bindings)
                           (list 'let* (vec scalar-broadcast-bindings)
                                 (list 'loop* [j-sym (list 'int radius)]
-                                      (list 'if (list '<= (list '+ j-sym lanes-sym) (list '- n-sym radius))
+                                      (list 'if (ix<= (ix+ j-sym lanes-sym) (ix- n-sym radius))
                                             (list 'let* (vec (concat load-bindings [simd-result-sym simd-body-expr]))
                                                   (list '.intoArray simd-result-sym out j-sym)
-                                                  (list 'recur (list '+ j-sym lanes-sym)))
+                                                  (list 'recur (ix+ j-sym lanes-sym)))
                         ;; Scalar tail
                                             (list 'loop* [j-sym j-sym]
-                                                  (list 'if (list '< j-sym (list '- n-sym radius))
+                                                  (list 'if (ix< j-sym (ix- n-sym radius))
                                                         (list 'do scalar-aset
                                                               (list 'recur (list 'inc j-sym)))
                                                         out)))))

--- a/src/raster/compiler/backend/jvm/segop_simd.clj
+++ b/src/raster/compiler/backend/jvm/segop_simd.clj
@@ -153,6 +153,19 @@
 ;; SIMD-ability check
 ;; ================================================================
 
+;; --- Integer index/offset/bound/stride arithmetic constructors ----------------
+;; SIMD scaffolding (loop bounds, per-lane load offsets, strides, counters) is
+;; integer index arithmetic and MUST be emitted as clojure.core primitives
+;; (iadd/ladd/...), never bare symbols. These forms are synthesized AFTER the
+;; walker runs, so a bare `+` resolves to raster.numeric/+ in the kernel ns
+;; (which excludes clojure.core arithmetic); the bytecode emitter then compiles
+;; it as a reflective, boxing RT.var -> IFn.invoke call on every iteration. Per
+;; CLAUDE.md, integer index arithmetic stays clojure.core.
+(defn- ix+ [a b] (list 'clojure.core/+ a b))
+(defn- ix* [a b] (list 'clojure.core/* a b))
+(defn- ix<= [a b] (list 'clojure.core/<= a b))
+(defn- ix< [a b] (list 'clojure.core/< a b))
+
 (defn- expr-free-of?
   "True if expr does not contain sym anywhere in its tree."
   [expr sym]
@@ -194,11 +207,11 @@
         ;; (+ base (+ ... j ...)) — recurse into nested +
         (and (expr-free-of? a idx-sym) (seq? b))
         (when-let [inner-base (extract-affine-base b idx-sym)]
-          (list '+ a inner-base))
+          (ix+ a inner-base))
         ;; (+ (+ ... j ...) base) — recurse into nested +
         (and (expr-free-of? b idx-sym) (seq? a))
         (when-let [inner-base (extract-affine-base a idx-sym)]
-          (list '+ inner-base b))
+          (ix+ inner-base b))
         :else nil))))
 
 (defn aget-form?
@@ -344,6 +357,35 @@
     (apply merge {} (map #(collect-arrays % idx-sym) (rest body-expr)))
     :else {}))
 
+(defn collect-load-sites
+  "Distinct SIMD load sites in body, in first-seen order: a vector of
+  [arr-sym base] pairs where base is the affine base offset (nil for a direct
+  (aget arr j)). Unlike collect-arrays (keyed by array symbol, last-base-wins),
+  this distinguishes the SAME array read at DIFFERENT affine bases — e.g.
+  (aget data (+ ab d)) and (aget data (+ bb d)) yield two sites [data ab] and
+  [data bb], so each becomes its own vector load. Keying loads by site (not by
+  array symbol) is what makes row-a-minus-row-b style kernels vectorize
+  correctly instead of collapsing to (.sub v v) = 0."
+  [body-expr idx-sym]
+  (letfn [(unwrap [arr]
+            (if (and (seq? arr)
+                     (contains? #{'double 'float 'int 'long
+                                  'clojure.core/double 'clojure.core/float} (first arr)))
+              (second arr) arr))
+          (go [e]
+            (cond
+              (some? (aget-form? e idx-sym))
+              (let [[arr base] (aget-form? e idx-sym)
+                    a (unwrap arr)]
+                [[(if (symbol? a) (symbol (name a)) a) base]])
+              (and (seq? e) (contains? #{'let 'let*} (first e)))
+              (let [[_ bindings & body] e]
+                (concat (mapcat (fn [[_ v]] (go v)) (partition 2 bindings))
+                        (mapcat go body)))
+              (seq? e) (mapcat go (rest e))
+              :else nil))]
+    (vec (distinct (go body-expr)))))
+
 (defn- collect-all-aget-arrays
   "Collect ALL array symbols from aget patterns in body, regardless of index.
   Returns a set of symbols. Used to prevent outer-loop-indexed arrays from being
@@ -396,6 +438,30 @@
       (apply clojure.set/union #{} (map #(collect-free-syms % idx-sym) (rest body-expr))))
     :else #{}))
 
+(defn collect-value-free-syms
+  "Like collect-free-syms but only symbols used in VALUE position — does NOT
+  descend into an affine aget's index/offset expression. Used to avoid
+  broadcasting integer index bases (e.g. ab, bb in (aget data (+ ab d))) into
+  dead scalar vectors: those symbols are consumed as primitive offsets by the
+  load, never as vector values."
+  [body-expr idx-sym]
+  (cond
+    (and (symbol? body-expr) (not= body-expr idx-sym)) #{body-expr}
+    (and (seq? body-expr) (contains? #{'let 'let*} (first body-expr)))
+    (let [[_ bindings & body] body-expr
+          pairs (partition 2 bindings)
+          bound-syms (set (map first pairs))
+          binding-frees (apply clojure.set/union #{}
+                               (map (fn [[_ v]] (collect-value-free-syms v idx-sym)) pairs))
+          body-frees (apply clojure.set/union #{}
+                            (map #(collect-value-free-syms % idx-sym) body))]
+      (clojure.set/difference (clojure.set/union binding-frees body-frees) bound-syms))
+    (seq? body-expr)
+    (if (some? (aget-form? body-expr idx-sym))
+      #{}   ;; affine aget: the offset is an index, not a value — skip it
+      (apply clojure.set/union #{} (map #(collect-value-free-syms % idx-sym) (rest body-expr))))
+    :else #{}))
+
 (defn collect-free-syms-scoped
   "Collect free symbols from an S-expression tree, respecting bindings.
    For JIT isolation (wrap-in-fn). Delegates to util/free-syms."
@@ -431,12 +497,17 @@
           (list broadcast species-sym (list cast-fn expr)))
 
       (some? (aget-form? expr idx-sym))
-      (let [[arr-raw _offset] (aget-form? expr idx-sym)
+      (let [[arr-raw base] (aget-form? expr idx-sym)
             arr (if (and (seq? arr-raw)
                          (contains? #{'double 'float 'int 'long
                                       'clojure.core/double 'clojure.core/float} (first arr-raw)))
-                  (second arr-raw) arr-raw)]
-        (or (get vec-env (if (symbol? arr) (symbol (name arr)) arr))
+                  (second arr-raw) arr-raw)
+            arr-name (if (symbol? arr) (symbol (name arr)) arr)]
+        ;; Resolve to the vector for THIS load site [arr base]; a single array read
+        ;; at multiple bases has one vector per site (see collect-load-sites). Fall
+        ;; back to array-symbol keys only for legacy single-load callers.
+        (or (get vec-env [arr-name base])
+            (get vec-env arr-name)
             (get vec-env arr)))
 
       ;; Scalar array access: (aget arr non-idx-expr) — broadcast as scalar
@@ -543,15 +614,6 @@
                      (if (>= lanes 8) 8 4))
         (catch Exception _ 4))))
 
-(defn- make-arr-load-bindings
-  "Generate let-bindings to load SIMD vectors from arrays.
-  arr-vec-offsets: {arr-sym → [vec-sym, offset-expr]} where offset-expr
-  is the full combined offset (base + j + k*lanes) for fromArray."
-  [arr-vec-offsets species-sym from-array]
-  (vec (mapcat (fn [[_arr-sym [vec-sym offset-expr]]]
-                 [vec-sym (list from-array species-sym _arr-sym offset-expr)])
-               arr-vec-offsets)))
-
 ;; ================================================================
 ;; SegMap → SIMD
 ;; ================================================================
@@ -605,32 +667,38 @@
             ;; broadcast as scalars — emit-simd handles them in-place via the
             ;; "Scalar array access" branch: (broadcast species (cast (aget arr expr)))
             outer-arr-syms (clojure.set/difference (collect-all-aget-arrays body) arr-syms)
-            scalar-syms (into (set (filter #(and (symbol? %) (not= '.invk %)) (:scalars segmap)))
-                              (clojure.set/difference all-inputs arr-syms outer-arr-syms))
+            ;; keep only scalars used as VALUES (drop dead integer index bases)
+            scalar-syms (clojure.set/intersection
+                         (into (set (filter #(and (symbol? %) (not= '.invk %)) (:scalars segmap)))
+                               (clojure.set/difference all-inputs arr-syms outer-arr-syms))
+                         (collect-value-free-syms body idx))
             ;; Type tag for vector symbols — enables bytecode compiler to resolve methods
             vec-tag (case elem-type
                       :double 'jdk.incubator.vector.DoubleVector
                       :float  'jdk.incubator.vector.FloatVector)
             tag-vec (fn [sym] (vary-meta sym assoc :tag vec-tag))
-            arr-vec-syms (into {} (map (fn [s] [s (tag-vec (gensym (str "v_" (name s) "_")))]) arr-syms))
+            ;; Distinct load sites [arr base] — one vector load per site, so a single
+            ;; array read at two bases does NOT collapse to (.op v v) (see collect-load-sites).
+            load-sites (filterv (fn [[a _]] (contains? arr-syms a))
+                                (collect-load-sites body idx))
+            arr-vec-syms (into {} (map (fn [[arr _base :as site]]
+                                         [site (tag-vec (gensym (str "v_" (name arr) "_")))])
+                                       load-sites))
             scalar-vec-syms (into {} (map (fn [s] [(symbol (name s)) (tag-vec (gensym (str "sv_" (name s) "_")))])
                                           scalar-syms))
-            vec-env (merge (into {} (map (fn [[s vs]] [(symbol (name s)) vs]) arr-vec-syms))
-                           scalar-vec-syms)
+            vec-env (merge arr-vec-syms scalar-vec-syms)
             simd-result-sym (tag-vec (gensym "vr__"))
             simd-body-expr (let [e (emit-simd body idx vec-env species-sym elem-type)]
                              (if (seq? e) (with-meta (apply list e) {:tag vec-tag}) e))
-            ;; Build per-array offset loads: (fromArray species arr (+ base j))
-            arr-vec-offsets (into {} (map (fn [[a v]]
-                                            (let [base (get arr-offsets a)
-                                                  offset (if base (list '+ base j-sym) j-sym)]
-                                              [a [v offset]]))
-                                          arr-vec-syms))
-            arr-loads (make-arr-load-bindings arr-vec-offsets species-sym from-array)
+            ;; Build per-site offset loads: (fromArray species arr (+ base j))
+            arr-loads (vec (mapcat (fn [[[arr base] v]]
+                                     (let [offset (if base (ix+ base j-sym) j-sym)]
+                                       [v (list from-array species-sym arr offset)]))
+                                   arr-vec-syms))
             scalar-bcasts (vec (mapcat (fn [[s sv]] [sv (list broadcast species-sym (list cf s))])
                                        scalar-vec-syms))
             ;; Store index: j or (+ offset j) for offset par/map!
-            store-idx (fn [j] (if store-offset (list '+ store-offset j) j))
+            store-idx (fn [j] (if store-offset (ix+ store-offset j) j))
             ;; Scalar tail — uses desugared body (.invk → mangled fn calls)
             ;; so the bytecode compiler can handle it
             scalar-body (clojure.walk/postwalk (fn [f] (if (= f idx) j-sym f)) desugared-body)
@@ -640,12 +708,12 @@
             ;; SIMD loop + tail
             simd-loop
             (list 'loop* [j-sym '(int 0)]
-                  (list 'if (list '<= (list '+ j-sym lanes-sym) n-sym)
+                  (list 'if (ix<= (ix+ j-sym lanes-sym) n-sym)
                         (list 'let* (vec (concat arr-loads [simd-result-sym simd-body-expr]))
                               (list '.intoArray simd-result-sym out (store-idx j-sym))
-                              (list 'recur (list '+ j-sym lanes-sym)))
+                              (list 'recur (ix+ j-sym lanes-sym)))
                         (list 'loop* [j-sym j-sym]
-                              (list 'if (list '< j-sym n-sym)
+                              (list 'if (ix< j-sym n-sym)
                                     (list 'do scalar-aset (list 'recur (list 'inc j-sym)))
                                     out))))]
         (when simd-body-expr
@@ -680,14 +748,14 @@
                    lanes-sym (list '.length species-sym)
                    n-sym (list 'int n)]
             (list 'loop* [j-sym '(int 0)]
-                  (list 'if (list '<= (list '+ j-sym lanes-sym) n-sym)
+                  (list 'if (ix<= (ix+ j-sym lanes-sym) n-sym)
                         ;; vgather: src[index[j..j+L)] → contiguous out[j..j+L)
                         (list 'let* [gv-sym (list from-array species-sym src 0 index j-sym)]
                               (list '.intoArray gv-sym out j-sym)
-                              (list 'recur (list '+ j-sym lanes-sym)))
+                              (list 'recur (ix+ j-sym lanes-sym)))
                         ;; scalar tail
                         (list 'loop* [j-sym j-sym]
-                              (list 'if (list '< j-sym n-sym)
+                              (list 'if (ix< j-sym n-sym)
                                     (list 'do
                                           (list 'clojure.core/aset out j-sym
                                                 (list 'clojure.core/aget src
@@ -752,9 +820,18 @@
                         outer-arr-syms (clojure.set/difference (collect-all-aget-arrays elem-expr)
                                                                (set (keys arr-offsets)))
                         arr-syms (clojure.set/difference all-inputs outer-arr-syms)
-                        scalar-syms (clojure.set/difference
-                                     (set (filter #(and (symbol? %) (not= '.invk %)) (:scalars segred)))
-                                     outer-arr-syms)
+                        ;; Distinct load sites [arr base] — one vector load per site, so a
+                        ;; single array read at two bases (row-a vs row-b) does NOT collapse.
+                        load-sites (filterv (fn [[a _]] (contains? arr-syms a))
+                                            (collect-load-sites elem-expr idx))
+                        ;; keep only scalars used as VALUES; integer index bases
+                        ;; (ab, bb) appear solely in aget offsets and must not be
+                        ;; broadcast into dead vectors.
+                        scalar-syms (clojure.set/intersection
+                                     (clojure.set/difference
+                                      (set (filter #(and (symbol? %) (not= '.invk %)) (:scalars segred)))
+                                      outer-arr-syms)
+                                     (collect-value-free-syms elem-expr idx))
                         vec-tag (case elem-type
                                   :double 'jdk.incubator.vector.DoubleVector
                                   :float  'jdk.incubator.vector.FloatVector)
@@ -766,15 +843,15 @@
                         j-sym (gensym "j__")
                         nacc (effective-n-accumulators elem-type)
                         vacc-syms (vec (for [k (range nacc)] (tag-vec (gensym (str "va" k "__")))))
+                        ;; one vec sym per [site, accumulator]; key by site [arr base]
                         arr-groups (vec (for [k (range nacc)]
-                                          (into {} (map (fn [s] [s (tag-vec (gensym (str "v" k "_" (name s) "_")))])
-                                                        arr-syms))))
+                                          (into {} (map (fn [[arr base :as site]]
+                                                          [site (tag-vec (gensym (str "v" k "_" (name arr) "_")))])
+                                                        load-sites))))
                         scalar-vec-syms (into {} (map (fn [s] [(symbol (name s)) (tag-vec (gensym (str "sv_" (name s) "_")))])
                                                       scalar-syms))
                         vec-envs (vec (for [k (range nacc)]
-                                        (merge (into {} (map (fn [[s vs]] [(symbol (name s)) vs])
-                                                             (nth arr-groups k)))
-                                               scalar-vec-syms)))
+                                        (merge (nth arr-groups k) scalar-vec-syms)))
                         simd-elems (vec (for [k (range nacc)]
                                           (let [e (emit-simd elem-expr idx (nth vec-envs k) species-sym elem-type)]
                                             (if (seq? e) (with-meta (apply list e) {:tag vec-tag}) e))))
@@ -795,25 +872,20 @@
                                                       (contains? #{'double 'float 'clojure.core/double 'clojure.core/float}
                                                                  (first arr0)))
                                                (second arr0) arr0)
-                                         k-offset (if (zero? k) j-sym (list '+ j-sym (list '* (int k) lanes-sym)))
-                                         off (if base (list '+ base k-offset) k-offset)]
+                                         k-offset (if (zero? k) j-sym (ix+ j-sym (ix* (int k) lanes-sym)))
+                                         off (if base (ix+ base k-offset) k-offset)]
                                      (with-meta (list from-array species-sym arr off) {:tag vec-tag})))
                         identity-val (reduce-identity op elem-type)
-                        ;; Build per-array, per-accumulator offset loads
-                        ;; For each arr, combine: base-offset + j + k*lanes
+                        ;; Build per-site, per-accumulator offset loads.
+                        ;; For each site [arr base], combine: base + j + k*lanes
                         chunk-loads
                         (vec (for [k (range nacc)]
                                (let [k-offset (if (zero? k) j-sym
-                                                  (list '+ j-sym (list '* (int k) lanes-sym)))
-                                     arr-vec-offsets
-                                     (into {} (map (fn [[a v]]
-                                                     (let [base (get arr-offsets a)
-                                                           offset (if base
-                                                                    (list '+ base k-offset)
-                                                                    k-offset)]
-                                                       [a [v offset]]))
-                                                   (nth arr-groups k)))]
-                                 (make-arr-load-bindings arr-vec-offsets species-sym from-array))))
+                                                  (ix+ j-sym (ix* (int k) lanes-sym)))]
+                                 (vec (mapcat (fn [[[arr base] v]]
+                                                (let [offset (if base (ix+ base k-offset) k-offset)]
+                                                  [v (list from-array species-sym arr offset)]))
+                                              (nth arr-groups k))))))
                         elem-syms (vec (for [k (range nacc)] (tag-vec (gensym (str "el" k "__")))))
                         inner-binds (if fuse-fma?
                                       []   ;; loads are inlined into the .fma below
@@ -821,7 +893,7 @@
                                                      (concat (nth chunk-loads k)
                                                              [(nth elem-syms k) (nth simd-elems k)]))
                                                    (range nacc))))
-                        recur-args (into [(list '+ j-sym stride-sym)]
+                        recur-args (into [(ix+ j-sym stride-sym)]
                                          (for [k (range nacc)]
                                            (if fuse-fma?
                                              ;; vacc_k = a[..]*b[..] + vacc_k, loads inline → memory-operand FMA
@@ -850,19 +922,24 @@
                                                     (mapcat (fn [vs] [vs vinit]) vacc-syms)))
                                 csym (gensym "vc__")]
                             (list 'loop* lbinds
-                                  (list 'if (list '<= (list '+ j-sym stride-sym) n-sym)
+                                  (list 'if (ix<= (ix+ j-sym stride-sym) n-sym)
                                         (list 'let* inner-binds (list* 'recur recur-args))
                                         (list 'let* [csym combine
-                                                     acc (list op (list cf init)
+                                                     ;; final scalar combine: monomorphic double/float
+                                                     ;; in the SIMD path → clojure.core primitive (no box)
+                                                     acc (list (cond (= op '+) 'clojure.core/+
+                                                                     (= op '*) 'clojure.core/*
+                                                                     :else op)
+                                                               (list cf init)
                                                                (list '.reduceLanes csym lanes-op))]
                                               (list 'loop* [j-sym j-sym acc acc]
-                                                    (list 'if (list '< j-sym n-sym)
+                                                    (list 'if (ix< j-sym n-sym)
                                                           (list 'recur (list 'inc j-sym) scalar-body)
                                                           acc)))))))]
                     (when (and (every? some? simd-elems) lanes-op)
                       (list 'let* [species-sym species-expr
                                    lanes-sym (list '.length species-sym)
-                                   stride-sym (list '* (int nacc) lanes-sym)
+                                   stride-sym (ix* (int nacc) lanes-sym)
                                    n-sym (list 'int bound)]
                             (if (seq scalar-bcasts)
                               (list 'let* (vec scalar-bcasts) (build-loop))

--- a/test/raster/compiler/backend/jvm/par_simd_test.clj
+++ b/test/raster/compiler/backend/jvm/par_simd_test.clj
@@ -92,6 +92,58 @@
       (is (segop-simd/compile-segmap segmap 'out 'double)
           "Should produce SIMD form for array+array"))))
 
+;; ----------------------------------------------------------------------------
+;; Regression: same array read at TWO distinct affine bases must NOT collapse to
+;; one vector load. Before the load-site fix, vector loads were keyed by array
+;; symbol, so (- (aget data (+ ab i)) (aget data (+ bb i))) loaded `data` once and
+;; emitted (.sub v v) = 0 — silently wrong (0.0 at dim=16/64, partial elsewhere).
+;; ----------------------------------------------------------------------------
+
+(deftest collect-load-sites-distinguishes-bases
+  (testing "one array at two affine bases yields two distinct load sites"
+    (is (= '[[data ab] [data bb]]
+           (segop-simd/collect-load-sites
+            '(let [df (- (aget data (+ ab d)) (aget data (+ bb d)))] (* df df))
+            'd))))
+  (testing "same base appears once (CSE), simple index has nil base"
+    (is (= '[[data ab]]
+           (segop-simd/collect-load-sites '(* (aget data (+ ab d)) (aget data (+ ab d))) 'd)))
+    (is (= '[[a nil] [b nil]]
+           (segop-simd/collect-load-sites '(+ (aget a i) (aget b i)) 'i)))))
+
+(defn- from-array-loads [form]
+  (filter #(and (seq? %)
+                (= 'jdk.incubator.vector.DoubleVector/fromArray (first %)))
+          (all-nodes form)))
+
+(deftest compile-segmap-two-bases-distinct-loads
+  (testing "par/map! reading one array at two bases emits two distinct loads"
+    (let [form '(raster.par/map! out i 100 double
+                                 (- (aget data (+ ab i)) (aget data (+ bb i))))
+          segmap (par->segmap form)
+          result (segop-simd/compile-segmap segmap 'out 'double)
+          loads (from-array-loads result)
+          offsets (set (map #(nth % 3) loads))]
+      (is result "Should produce SIMD form")
+      (is (>= (count loads) 2) "Should emit a separate load per base, not collapse to one")
+      (is (= 2 (count offsets))
+          (str "The two loads must use distinct offset expressions, got: " offsets)))))
+
+(deftest compile-segred-two-bases-distinct-loads
+  (testing "par/reduce of (* df df) with df across two bases emits two distinct loads"
+    (let [form '(raster.par/reduce acc 0.0 d 100
+                                   (let [df (- (aget data (+ ab d)) (aget data (+ bb d)))]
+                                     (+ acc (* df df))))
+          segred (par->segred form)
+          result (segop-simd/compile-segred segred)
+          loads (from-array-loads result)
+          ;; per accumulator there are 2 distinct-base loads; distinct *offset shapes*
+          ;; (modulo the k*lanes term) must reference both ab and bb
+          offset-syms (set (mapcat #(filter symbol? (all-nodes (nth % 3))) loads))]
+      (is result "Should produce SIMD form")
+      (is (contains? offset-syms 'ab) "loads must reference base ab")
+      (is (contains? offset-syms 'bb) "loads must reference base bb — not collapse to one"))))
+
 (deftest compile-segmap-fma
   (testing "compile-segmap handles fma"
     (let [form '(raster.par/map! out i 100 double


### PR DESCRIPTION
## Summary

Fixes a **silent SIMD miscompilation** plus a major SIMD perf bug, both in the par-form vectorizer, found while investigating the lazy-JIT kNN "SIMD regression."

### 1. Correctness — silent miscompile on one-array-two-bases kernels
The vectorizer keyed array vector-loads by **array symbol only**, so a kernel reading the same array at two distinct affine bases — the row-a-minus-row-b distance/dot shape (`eucl-dist`/`cos-dist`):
```clojure
(par/reduce acc 0.0 d dim
  (let [df (- (aget data (+ ab d)) (aget data (+ bb d)))] (+ acc (* df df))))
```
collapsed both `aget`s into **one** load (last base won via `collect-arrays`' `merge`) and emitted `(.sub v v) = 0`. `compile-aot :simd? true` returned **0.0 at dim=16/64** and partial garbage elsewhere; correct only when `dim < SIMD stride` (pure scalar tail). Affected **both** `compile-segred` (par/reduce) and `compile-segmap` (par/map!). Latent because nndescent/kNN run via lazy-JIT (SIMD off by default); the FMA-fusion path was unaffected (per-factor loads).

**Fix:** key load sites by `[arr base]`, not array symbol — new `collect-load-sites`, `emit-simd` resolves `(get vec-env [arr-name base])`, and both compile paths build one vector load per site. Verified vs a hand sum across dim=8/16/31/50/64/100 for reduce **and** map!.

### 2. Perf — boxed reflective index arithmetic in the vector loop
SIMD scaffolding (per-lane offsets, loop bound, stride, counter) was emitted with **bare** `+`/`*`/`<=`/`<`, which resolve to `raster.numeric/*` in a kernel ns. Since these forms are synthesized *after* the walker runs, nothing devirtualizes them, so the bytecode emitter compiled each as a reflective, boxing `RT.var → IFn.invoke` **on every iteration** — turning a "vectorized" affine reduction into a per-iteration box storm (orders of magnitude slower than scalar; the isolated kernel *timed out*). Now emitted as `clojure.core` primitives (`ix+`/`ix*`/`ix<=`/`ix<`), per the CLAUDE.md "integer index arithmetic stays clojure.core" rule. Result: **0 bytes/call, SIMD faster than scalar (~17 ns)**.

### 3. Cleanup
- Prune dead base broadcasts (affine bases `ab`/`bb` were broadcast into unused `sv_*` vectors) via `collect-value-free-syms`.
- Remove now-dead `make-arr-load-bindings`.

### 4. Infra
- `:valhalla` alias heap `-Xmx12g → 8g` — 12g OOM-killed the test JVM on a 30G box when other processes were running.

## Tests
- New structural regression tests in `par_simd_test`: `collect-load-sites-distinguishes-bases`, `compile-segmap-two-bases-distinct-loads`, `compile-segred-two-bases-distinct-loads`.
- Full suite green: **1501 tests, 7209 assertions, 0 failures, 0 errors**.

## Audit notes (not addressed here — no current trigger)
A soundness audit of the array-handling paths found stencil/gather sound; remaining items for later: no explicit input/output aliasing guard (safe today via scalar fallback), and `simd-able?` can over-accept vs `emit-simd` (currently safe via nil→scalar fallback).
