### PR TITLE
test: guard the TC delayed-error binding-types gate

### DIFF
--- a/test/raster/compiler/core/inference_test.clj
+++ b/test/raster/compiler/core/inference_test.clj
@@ -115,6 +115,43 @@
 ;; trace-inference
 ;; ================================================================
 
+;; ================================================================
+;; tc-analyze-deftm-body — types are consumed ONLY from a clean check
+;; ================================================================
+
+(deftest tc-clean-body-yields-binding-tags-test
+  (testing "a body that type-checks cleanly exposes ret-tag + per-binding tags"
+    (let [r (inf/tc-analyze-deftm-body
+             'clean '[x] '[Double]
+             '[(let [y (clojure.core/+ x 1.0)
+                     z (clojure.core/* y 2.0)]
+                 z)]
+             *ns*)]
+      (is (= 'double (:ret-tag r)))
+      (is (= 'double (get (:binding-tags r) 'y)))
+      (is (= 'double (get (:binding-tags r) 'z))))))
+
+(deftest tc-delayed-error-discards-all-tags-test
+  ;; GUARD against re-relaxing the (empty? type-errors) gate. It is tempting to
+  ;; read partial per-binding types off the :checked-ast even when the body has a
+  ;; delayed type-error (to devirtualize the "well-typed" bindings of a kernel
+  ;; whose interop bits TC can't type). That is UNSOUND: under error recovery TC
+  ;; can assign a *concrete but wrong* type to a SIBLING binding (e.g. tag a
+  ;; double-array local as Long), which maps to a real dispatch tag and overrides
+  ;; the correct structural inference — emitting a bad cast (observed as
+  ;; ClassCastException in raster.linalg dgetrf!/sparse dot when this was tried).
+  ;; So any delayed error must discard the whole TC result; the walker then falls
+  ;; back to structural inference, which handles these bodies correctly.
+  (let [r (inf/tc-analyze-deftm-body
+           'mixed '[x o] '[Double nil]
+           '[(let [y (clojure.core/+ x 1.0)
+                   z (clojure.core/* y 2.0)
+                   w (.someUnknownMethod o)]
+               z)]
+           *ns*)]
+    (is (or (nil? r) (empty? (:binding-tags r)))
+        "delayed type-error => no TC binding tags are exposed (structural fallback)")))
+
 (deftest trace-inference-test
   (testing "trace-inference prints provenance when enabled"
     (let [output (with-out-str


### PR DESCRIPTION
## What

Adds a regression guard around `tc-analyze-deftm-body`'s `(empty? (:type-errors result))` gate in `compiler/core/inference.clj`. No production code changes — the gate is already correct; this locks in *why*.

## Why

While investigating whether raster could read per-binding TC types off the `:checked-ast` even when a body has a delayed type-error (to devirtualize the well-typed bindings of kernels whose interop/HOF/parametric bits TC can't fully type), I confirmed it is **unsound**:

- A narrow probe looked fine (errored binding → `Any` → no tag).
- But the full suite went from `0 failures / 0 errors` to `2 failures / 42 errors`, e.g.
  - `DT_dgetrf!…doubles_ints_long_long` → `ClassCastException: Long cannot be cast to [D`
  - `DT_dot…SparseVector` → `ClassCastException: [D cannot be cast to Collection`

Under error recovery TC can assign a **concrete-but-wrong** type to a *sibling* binding (e.g. a double-array local tagged `Long`), which maps to a real dispatch tag and **overrides correct structural inference**, emitting a bad cast. So once any delayed error is present, no inferred type on that AST may be trusted — the gate must discard the whole result and let the walker fall back to structural inference (which handles these bodies correctly).

## Tests

- `tc-delayed-error-discards-all-tags-test` — a body with a delayed error exposes no TC binding tags.
- `tc-clean-body-yields-binding-tags-test` — the clean path still exposes `ret-tag` + per-binding tags.

Both green (inference-test ns: 13 tests / 46 assertions, 0/0, with the deftm registry loaded).

## Context

Follow-up to closing TypedClojure PR #244 (the unsound `nth`/method/`TopFunction` rule relaxations): the raster-side 'read partial types under errors' alternative is unsound too, so the gate stays and raster needs no change.