### PR TITLE
fix: WASM backend regression — DCE dropped case* bindings (map-blind liveness scan)

### DIFF
--- a/src/raster/compiler/core/util.clj
+++ b/src/raster/compiler/core/util.clj
@@ -16,6 +16,11 @@
   (cond (and (symbol? e) (not (namespace e))) #{e}
         (seq? e)    (apply set/union #{} (map free-syms-flat e))
         (vector? e) (apply set/union #{} (map free-syms-flat e))
+        ;; map literals carry symbol references too — notably a `case*` clause map
+        ;; {hash [test result-expr] …}, whose result exprs reference let-bound
+        ;; locals. Without this, a flat-DCE liveness scan misses those uses and
+        ;; wrongly eliminates the binding they depend on (→ unbound-sym miscompile).
+        (map? e)    (apply set/union #{} (map free-syms-flat (apply concat e)))
         :else       #{}))
 
 (defn- free-leaf?

--- a/test/raster/compiler/core/util_test.clj
+++ b/test/raster/compiler/core/util_test.clj
@@ -32,6 +32,27 @@
     (is (= #{'x} (util/free-syms '(double x)))
         "only x is free in (double x)")))
 
+(deftest free-syms-flat-map-test
+  ;; Regression: the flat scanner (used by DCE liveness) must traverse map
+  ;; literals. A `case*` clause map {hash [test result-expr]} carries symbol
+  ;; references in its result exprs; missing them made DCE drop the binding they
+  ;; depend on → "unbound sym" wasm miscompile (broke valley perlin `grad`).
+  ;; free-syms-flat over-approximates (it keeps all unqualified symbols incl.
+  ;; operators) — that's safe for DCE liveness. What matters is that variable
+  ;; refs inside maps are not MISSED. Assert containment, not exact equality.
+  (testing "free-syms-flat descends into map literals"
+    (let [fs (util/free-syms-flat '{0 [0 (.invk + x y)]})]
+      (is (and (contains? fs 'x) (contains? fs 'y))
+          "symbols inside map values are seen"))
+    (let [fs (util/free-syms-flat '{k v})]
+      (is (and (contains? fs 'k) (contains? fs 'v))
+          "both map keys and values are scanned"))
+    (is (contains? (util/free-syms-flat
+                    '(case* g 0 0 (throw e) {0 [0 (.invk + arg_x yf)]
+                                             1 [1 (.invk - arg_x yf)]} :compact :int))
+                   'arg_x)
+        "case* clause-map result exprs are visible to the flat scanner")))
+
 (deftest free-syms-let-binding-test
   (testing "let* binding scopes correctly"
     (is (= #{'x} (util/free-syms '(let* [a x] a)))


### PR DESCRIPTION
## Overview

Fixes a **WASM-backend regression** introduced by #16: valley's browser kernels
(`surface-height-biome`, `biome-index`) fail to compile with `unbound sym arg_x…`,
breaking the Pages build. Asteroids is unaffected; the failure is in any kernel that
lowers a polymorphic dispatch to a `case*` whose arms reference an inlined argument
(here, perlin `grad`'s hash-keyed corners).

## Root cause

Bisecting the pass pipeline: the IR is well-formed after `:fixpoint` (inlining) and
breaks after `:dce`.

- #16's inliner now **lifts** non-trivial call-args (`xf - 1.0`) into `let*` bindings
  `[arg_x …]` that wrap the callee body — a `case*` form — where the previous inliner
  substituted them inline.
- DCE's liveness uses `free-syms-flat`, whose `cond` traversed `seq?` and `vector?` but
  had **no `map?` clause**. A `case*` clause map `{0 [0 (.invk + arg_x yf)] …}` is a map
  literal, so the scan never saw the `arg_x` uses inside it, concluded the binding was
  dead, and deleted it — leaving the `case*` referencing an unbound symbol.

`free-syms-flat` is byte-identical before/after #16; the inliner change is what began
feeding `case*`-with-bindings through DCE, exposing the latent hole.

## Fix

One clause, mirroring the nested `free-syms` (which already handles maps):

```clojure
(map? e) (apply set/union #{} (map free-syms-flat (apply concat e)))
```

A free-symbol collector must see references inside maps. For DCE this only ever widens
the live set, so it cannot cause unsound elimination — it strictly prevents dropping a
live binding.

## Verification

- `valley/gen.clj` → **5 exports**; `asteroids/web/gen.clj` → `move_shape`. Both compile
  to wasm again (verified at the pre-#16 commit `34eafda` they worked, at #16 `ad5ef57`
  they broke, and with this fix they work).
- `util` / `dce` / `wasm-emit` suites green.
- Regression test added: `free-syms-flat-map-test` (asserts `case*` clause-map refs are
  visible to the flat scanner).
