### PR TITLE
compiler convergence: DCE map-hole fix + dtype faceting + GPU reduction dedup

### DIFF
--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -197,6 +197,21 @@
   "Dtype keyword → C type. Derived from the single faceted dtype/native-types."
   (dtype/backend-types :c))
 
+(defn fn-style-reduction-op?
+  "True if a reduction op emits as a C function call `f(a,b)` (fmax/fmin) rather
+   than an infix operator `(a op b)`. Single source for the GPU reduction
+   combine-shape classification (was duplicated across the OpenCL backends)."
+  [op]
+  (contains? #{'Math/max 'Math/min} op))
+
+(defn combine-fn
+  "Return a (fn [a b] -> C string) that combines two operands with reduction
+   operator string `c-op`, as `c-op(a, b)` when `fn-style?` else `(a c-op b)`."
+  [c-op fn-style?]
+  (if fn-style?
+    (fn [a b] (str c-op "(" a ", " b ")"))
+    (fn [a b] (str "(" a " " c-op " " b ")"))))
+
 (def tag->ctype
   "Map walker :tag metadata to C type strings."
   {'ints "int" 'floats "float" 'doubles "double" 'longs "long"

--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -15,6 +15,7 @@
       (emit-expr body idx-sym array-syms \"idx\"))"
   (:require [clojure.string :as str]
             [clojure.walk :as walk]
+            [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.types :as types]
             [raster.compiler.backend.intrinsics :as intrinsics]
@@ -193,10 +194,8 @@
 ;; ================================================================
 
 (def type-map
-  {:double "double"
-   :float  "float"
-   :int    "int"
-   :long   "long long"})
+  "Dtype keyword → C type. Derived from the single faceted dtype/native-types."
+  (dtype/backend-types :c))
 
 (def tag->ctype
   "Map walker :tag metadata to C type strings."

--- a/src/raster/compiler/backend/gpu/opencl_codegen.clj
+++ b/src/raster/compiler/backend/gpu/opencl_codegen.clj
@@ -135,10 +135,7 @@
                     'Math/max "fmax"
                     'Math/min "fmin"
                     "+")
-        is-fn-op (contains? #{'Math/max 'Math/min} op)
-        combine (if is-fn-op
-                  (fn [a b] (str reduce-op "(" a ", " b ")"))
-                  (fn [a b] (str "(" a " " reduce-op " " b ")")))]
+        combine (ce/combine-fn reduce-op (ce/fn-style-reduction-op? op))]
     (str (when use-fp64? fp64-pragma)
          subgroup-pragma
          "__kernel void " kernel-name

--- a/src/raster/compiler/backend/gpu/opencl_codegen.clj
+++ b/src/raster/compiler/backend/gpu/opencl_codegen.clj
@@ -16,6 +16,7 @@
     (emit-reduction-kernel \"sum\" :double '+ 0.0)
     (kernel-launch-config 100000 :device-id :ze:0)"
   (:require [clojure.string :as str]
+            [raster.compiler.core.dtype :as dtype]
             [raster.compiler.backend.gpu.c-emit :as ce]))
 
 ;; ================================================================
@@ -28,11 +29,9 @@
   ce/op-map)
 
 (def opencl-type-map
-  "Maps Raster type keywords to OpenCL C types."
-  {:double "double"
-   :float  "float"
-   :int    "int"
-   :long   "long"})  ;; OpenCL 'long' is 64-bit (unlike CUDA's 'long long')
+  "Maps Raster type keywords to OpenCL C types. Derived from the single faceted
+   dtype/native-types. OpenCL 'long' is 64-bit (unlike CUDA's 'long long')."
+  (dtype/backend-types :opencl))
 
 ;; ================================================================
 ;; Expression emission (delegates to shared)

--- a/src/raster/compiler/backend/gpu/par_opencl.clj
+++ b/src/raster/compiler/backend/gpu/par_opencl.clj
@@ -288,10 +288,7 @@
         block-size (* 2 wg-size) ;; Each thread handles 2 elements
         ;; OpenCL combine op
         combine-str (condp = op '+ "+" '* "*" 'Math/max "fmax" 'Math/min "fmin" "+")
-        is-fn-op (contains? #{'Math/max 'Math/min} op)
-        combine (if is-fn-op
-                  (fn [a b] (str combine-str "(" a ", " b ")"))
-                  (fn [a b] (str "(" a " " combine-str " " b ")")))
+        combine (ce/combine-fn combine-str (ce/fn-style-reduction-op? op))
         ;; Emit element expression as OpenCL C
         array-sym-names (set (map #(symbol (name %)) arr-params))
         adapted-element (when element-expr (ce/adapt-casts-for-dtype element-expr scan-dtype))
@@ -448,10 +445,7 @@
                         'Math/max "fmax"
                         'Math/min "fmin"
                         "+")
-        is-fn-op (contains? #{'Math/max 'Math/min} op)
-        combine (if is-fn-op
-                  (fn [a b] (str reduce-op-str "(" a ", " b ")"))
-                  (fn [a b] (str "(" a " " reduce-op-str " " b ")")))
+        combine (ce/combine-fn reduce-op-str (ce/fn-style-reduction-op? op))
         ;; Generate per-array kernel params
         arr-param-str (str/join ", "
                                 (map (fn [s] (str "__global const " ctype "* restrict "

--- a/src/raster/compiler/backend/gpu/par_vulkan.clj
+++ b/src/raster/compiler/backend/gpu/par_vulkan.clj
@@ -30,6 +30,7 @@
     (generate-compute-map-kernel form :dtype :float)
     (generate-compute-map-void-kernel form :dtype :float)"
   (:require [raster.compiler.ir.par :as par]
+            [raster.compiler.core.dtype :as dtype]
             [raster.compiler.backend.gpu.c-emit :as ce]
             [raster.compiler.passes.scalar.soa-lower :as sl]
             [clojure.string :as str]))
@@ -39,10 +40,9 @@
 ;; ================================================================
 
 (def glsl-type-map
-  {:double "double"
-   :float  "float"
-   :int    "int"
-   :long   "int"})  ;; GLSL has no 64-bit int by default; use int
+  "Dtype keyword → GLSL type. Derived from the single faceted dtype/native-types.
+   GLSL has no 64-bit int by default; long→int."
+  (dtype/backend-types :glsl))
 
 ;; ================================================================
 ;; GLSL buffer declaration helpers

--- a/src/raster/compiler/core/dtype.clj
+++ b/src/raster/compiler/core/dtype.clj
@@ -1,6 +1,25 @@
 (ns raster.compiler.core.dtype
   "Dtype-driven type tag remapping helpers for compiler lowering.")
 
+;; ── Single faceted source for scalar dtype → per-backend native type ────────
+;; Previously each textual backend kept its own {:double "double" …} map, which
+;; drifted independently. Per-backend value differences are LEGITIMATE facets,
+;; not inconsistencies: GLSL has no 64-bit int (long→"int"), OpenCL `long` is
+;; 64-bit, C uses `long long`. Add a new dtype = add ONE row here; backends
+;; derive their map via `backend-types`.
+(def native-types
+  "Scalar dtype keyword → {backend → native type name}."
+  {:double {:c "double"    :opencl "double" :glsl "double"}
+   :float  {:c "float"     :opencl "float"  :glsl "float"}
+   :int    {:c "int"       :opencl "int"    :glsl "int"}
+   :long   {:c "long long" :opencl "long"   :glsl "int"}})
+
+(defn backend-types
+  "The {dtype → native-type-string} map for one backend (:c / :opencl / :glsl),
+   derived from `native-types`. Replaces the per-backend literal type maps."
+  [backend]
+  (into {} (map (fn [[dt facets]] [dt (get facets backend)])) native-types))
+
 (def ^:private dtype-type-remap
   "Type tag remapping per dtype. Only FP types are remapped."
   {:float {'double 'float, 'doubles 'floats}})

--- a/src/raster/compiler/passes/scalar/dce.clj
+++ b/src/raster/compiler/passes/scalar/dce.clj
@@ -89,6 +89,13 @@
     (vector? expr)
     (apply clojure.set/union #{} (map extract-mutation-targets expr))
 
+    ;; map literals carry mutating subforms too — e.g. a `case*` clause map
+    ;; {hash [test (aset buf i v)] …}. Without this, a mutation inside a case arm
+    ;; is invisible, so DCE fails to seed the mutated buffer live and can
+    ;; eliminate the live mutating binding (same map-blind class as free-syms-flat).
+    (map? expr)
+    (apply clojure.set/union #{} (map extract-mutation-targets (apply concat expr)))
+
     :else #{}))
 
 (defn- locally-pure-form?

--- a/test/raster/compiler/passes/scalar/dce_test.clj
+++ b/test/raster/compiler/passes/scalar/dce_test.clj
@@ -6,6 +6,20 @@
 ;; Dead binding removal
 ;; ================================================================
 
+(deftest mutation-targets-traverse-maps-test
+  ;; Regression: extract-mutation-targets must descend into map literals. A `case*`
+  ;; clause map {hash [test (aset buf …)]} can hold a mutation; missing it made DCE
+  ;; fail to seed the mutated buffer live → it could eliminate the live mutating
+  ;; binding (same map-blind class as the free-syms-flat / case* fix in #18).
+  (let [emt @#'dce/extract-mutation-targets
+        form '(case* g 0 0 (throw e)
+                     {0 [0 (clojure.core/aset buf (long i) 1.0)]
+                      1 [1 (clojure.core/aset other (long i) 2.0)]}
+                     :compact :int)]
+    (testing "a mutation inside a case* clause map is seen as a mutation target"
+      (is (contains? (emt form) 'buf))
+      (is (contains? (emt form) 'other)))))
+
 (deftest dead-binding-removal-test
   (testing "unused pure binding is removed"
     (let [form '(let* [x 1 y 2] x)


### PR DESCRIPTION
## Overview

A focused **compiler-convergence** PR from the backend-duplication audit: closes a live
DCE miscompile and removes two genuine sources of backend duplication — **verified
behavior-preserving**, no functional change. Scoped deliberately: only the clean,
provably-safe subsets were taken; the messier audit items are left for their own analysis
(noted below).

## What's in

**1. Fix: `extract-mutation-targets` must traverse map literals** (live DCE hole)
Same map-blind class as #18's `free-syms-flat` fix — found by the audit and confirmed live.
The mutation-target scan recursed into seqs/vectors but fell through `:else` on maps, so a
mutation inside a `case*` clause map (`{hash [test (aset buf …)]}`) was invisible → DCE
could eliminate the live mutating binding (silent miscompile). Adds a `map?` clause; only
*widens* the live set, so it can never cause unsound elimination. Regression test added.

**2. Converge: single faceted dtype→native-type source** (audit #3)
The three textual GPU backends each kept their own `{:double "double" …}` dtype map, which
could drift independently. Unified into one faceted `core/dtype/native-types`; each backend
derives its map via `(dtype/backend-types <backend>)`. Per-backend value differences are
**legitimate facets, preserved exactly** (GLSL has no 64-bit int → `long`→`"int"`; OpenCL
`long` is 64-bit; C uses `"long long"`). Each derived map verified byte-identical to the
prior literal. The wasm `array-tag->elem` map is intentionally left alone — it carries
load/store/align opcodes and is a genuine backend specialization, not a duplicated
type-name table.

**3. Converge: centralize GPU reduction combine-shape classification** (audit #2a, scoped)
The fn-style-vs-infix reduction classification (`#{'Math/max 'Math/min}`) plus its
combine-expression builder were copy-pasted identically across three OpenCL codegen sites.
Extracted to `c_emit/fn-style-reduction-op?` + `combine-fn`. Byte-identical behavior.

## Scope discipline (what was deliberately NOT done)

Verifying each audit item showed several were messier than the audit's framing — so only
the provably-safe parts were taken:

- **Audit #1 (free-var walker consolidation) — mostly already done.** Verified all ~9
  "walkers": most already delegate to the canonical `util/free-syms`; the two `segop_simd`
  ones are justified SIMD specializations (idx/aget-aware) and `bytecode/collect-free-vars`
  is specialized closure-capture that already handles maps. Blindly rerouting them would
  have *broken* SIMD handling. Only the two map-blind *correctness* holes were real — both
  now closed (#18 + item 1 here).
- **Audit #2 registry merge — deferred.** The reduction-op *acceptance* sets
  (`#{'+ '* 'Math/max 'Math/min}` vs `#{'+ '- '* 'Math/max 'Math/min}`) don't map to the
  existing `op_descriptor` predicates and even disagree with each other on `-` (a latent
  inconsistency). Merging `op_descriptor` + `intrinsics` is architectural; both deserve
  their own PR.
- **Audit #4 (form.clj bypasses) — dropped.** ~30 `#{'let 'let*}` sites *do* map cleanly to
  `form/binding-form?` (proven), but the payoff is cosmetic (let/let* are stable) and the
  churn wide; not worth bundling.

## Tests

Targeted suites green during development (dce, util, wasm-emit, GPU codegen — 400+
assertions). Full `clojure -M:test` result posted in a comment below.
