### PR TITLE
wasm: quantized int8 inference — scalar (Tier 1) + SIMD128 i32x4.dot_i16x8_s (Tier 2)

### DIFF
--- a/src/raster/compiler/backend/wasm/emit.clj
+++ b/src/raster/compiler/backend/wasm/emit.clj
@@ -465,14 +465,120 @@
 
 (declare emit-result emit-loop-scalar simd-loop-plan emit-loop-simd)
 
+(defn- strip-int-cast
+  "Strip (long …)/(int …) wrappers to reach the underlying expression."
+  [x]
+  (if (and (seq? x) (#{'long 'int} (first x))) (recur (second x)) x))
+
+(defn- byte-aget-arr
+  "If `expr` is (aget arr i-sym) on an int8 (byte, elem-size 1) array indexed
+   exactly by i-sym, return arr; else nil."
+  [ctx expr i-sym]
+  (let [e (strip-int-cast expr)]
+    (when (and (seq? e) (= 'clojure.core/aget (first e))
+               (= 1 (get-in ctx [:elems (second e) :bytes]))
+               (= (strip-int-cast (nth e 2)) i-sym))
+      (second e))))
+
+(defn- int8-dot-loop-plan
+  "Recognize the int8 quantized dot reduction:
+     (loop* [i 0 acc 0]
+       (if (< i n) (recur (inc i) (+ acc (* (aget x i) (aget y i)))) acc))
+   over two int8 (byte) arrays x,y. Returns {:i-sym :acc-sym :x :y :n-node} or nil.
+   This is the pattern that maps to i32x4.dot_i16x8_s (widen i8→i16, dot, accumulate)."
+  [ctx node]
+  (when (and (seq? node) (= 'loop* (first node)))
+    (let [[_ bindvec ifform] node
+          pairs (partition 2 bindvec)]
+      (when (and (= 2 (count pairs)) (seq? ifform) (= 'if (first ifform)))
+        (let [[i-sym i-init] (first pairs)
+              [acc-sym acc-init] (second pairs)
+              [_ cnd then els] ifform]
+          (when (and (= 0 i-init) (= 0 acc-init) (symbol? i-sym) (symbol? acc-sym)
+                     (= els acc-sym)                                   ; recur-in-then, else returns acc
+                     (seq? cnd) (= 'clojure.core/< (first cnd))
+                     (= (strip-int-cast (nth cnd 1)) i-sym)
+                     (seq? then) (= 'recur (first then)))
+            (let [n-node (nth cnd 2)
+                  [_ i-step acc-step] then
+                  is (strip-int-cast i-step)
+                  as (strip-int-cast acc-step)]
+              (when (and (seq? is) (= 'clojure.core/inc (first is)) (= (strip-int-cast (second is)) i-sym)
+                         (seq? as) (= 'clojure.core/+ (first as)) (= (strip-int-cast (nth as 1)) acc-sym))
+                (let [prod (strip-int-cast (nth as 2))]
+                  (when (and (seq? prod) (= 'clojure.core/* (first prod)))
+                    (let [x (byte-aget-arr ctx (nth prod 1) i-sym)
+                          y (byte-aget-arr ctx (nth prod 2) i-sym)]
+                      (when (and x y)
+                        {:i-sym i-sym :acc-sym acc-sym :x x :y y :n-node n-node}))))))))))))
+
+(defn- emit-loop-int8-dot
+  "Emit a v128 int8 dot: 16-wide main loop (widen i8→i16, i32x4.dot_i16x8_s,
+   accumulate into an i32x4) + horizontal sum + scalar remainder. → [bytes :i32]."
+  [ctx {:keys [i-sym acc-sym x y n-node]}]
+  (let [i-idx    (alloc! ctx :i32)
+        acc-idx  (alloc! ctx :i32)
+        vacc-idx (alloc! ctx :v128)
+        vx-idx   (alloc! ctx :v128)
+        vy-idx   (alloc! ctx :v128)
+        ctx'     (-> ctx (assoc-in [:env i-sym] {:idx i-idx :vt :i32})
+                     (assoc-in [:env acc-sym] {:idx acc-idx :vt :i32}))
+        n-bytes  (fn [] (emit-val ctx' n-node))         ; re-emit n each use (pure load)
+        gi       (fn [] (e/local-get i-idx))
+        vload    (fn [arr] (-> (addr ctx' arr i-sym) (into (e/v128-load 0 0))))
+        ;; main loop body: break when i+16 > n, else dot & accumulate, i += 16
+        main-body (-> []
+                      (into (gi)) (into (e/i32-const 16)) (into (e/i :i32.add))
+                      (into (n-bytes)) (into (e/i :i32.gt_s)) (into (e/br-if 1))
+                      (into (vload x)) (into (e/local-set vx-idx))
+                      (into (vload y)) (into (e/local-set vy-idx))
+                      (into (e/local-get vx-idx)) (into (e/v :i16x8.extend-low-i8x16-s))
+                      (into (e/local-get vy-idx)) (into (e/v :i16x8.extend-low-i8x16-s))
+                      (into (e/v :i32x4.dot-i16x8-s))
+                      (into (e/local-get vx-idx)) (into (e/v :i16x8.extend-high-i8x16-s))
+                      (into (e/local-get vy-idx)) (into (e/v :i16x8.extend-high-i8x16-s))
+                      (into (e/v :i32x4.dot-i16x8-s))
+                      (into (e/v :i32x4.add))
+                      (into (e/local-get vacc-idx)) (into (e/v :i32x4.add)) (into (e/local-set vacc-idx))
+                      (into (gi)) (into (e/i32-const 16)) (into (e/i :i32.add)) (into (e/local-set i-idx))
+                      (into (e/br 0)))
+        hsum (-> (e/local-get acc-idx)
+                 (into (e/local-get vacc-idx)) (into (e/v-lane :i32x4.extract-lane 0)) (into (e/i :i32.add))
+                 (into (e/local-get vacc-idx)) (into (e/v-lane :i32x4.extract-lane 1)) (into (e/i :i32.add))
+                 (into (e/local-get vacc-idx)) (into (e/v-lane :i32x4.extract-lane 2)) (into (e/i :i32.add))
+                 (into (e/local-get vacc-idx)) (into (e/v-lane :i32x4.extract-lane 3)) (into (e/i :i32.add))
+                 (into (e/local-set acc-idx)))
+        ;; scalar remainder: while i < n: acc += x[i]*y[i]; i++
+        rem-body (-> []
+                     (into (gi)) (into (n-bytes)) (into (e/i :i32.ge_s)) (into (e/br-if 1))
+                     (into (e/local-get acc-idx))
+                     (into (addr ctx' x i-sym)) (into (e/mem-load :i32.load8_s 0 0))
+                     (into (addr ctx' y i-sym)) (into (e/mem-load :i32.load8_s 0 0))
+                     (into (e/i :i32.mul)) (into (e/i :i32.add)) (into (e/local-set acc-idx))
+                     (into (gi)) (into (e/i32-const 1)) (into (e/i :i32.add)) (into (e/local-set i-idx))
+                     (into (e/br 0)))]
+    [(-> []
+         (into (e/i32-const 0)) (into (e/local-set i-idx))
+         (into (e/i32-const 0)) (into (e/local-set acc-idx))
+         (into (e/i32-const 0)) (into (e/v :i32x4.splat)) (into (e/local-set vacc-idx))
+         (into (e/block (e/loop* main-body)))
+         (into hsum)
+         (into (e/block (e/loop* rem-body)))
+         (into (e/local-get acc-idx)))
+     :i32]))
+
 (defn- emit-loop
   "(loop [v init ...] (if cond <recur|do…recur> <result>)) → [bytes ret-vt].
    When ctx :simd? is set and the loop is an elementwise counted map, emits a
-   v128 main loop + scalar remainder; otherwise the scalar loop."
+   v128 main loop + scalar remainder; otherwise the scalar loop. int8 dot
+   reductions get a dedicated i32x4.dot_i16x8_s vectorization."
   [ctx node]
-  (if-let [plan (and (:simd? ctx) (simd-loop-plan ctx node))]
-    (emit-loop-simd ctx node plan)
-    (emit-loop-scalar ctx node)))
+  (cond
+    (and (:simd? ctx) (int8-dot-loop-plan ctx node))
+    (emit-loop-int8-dot ctx (int8-dot-loop-plan ctx node))
+    (and (:simd? ctx) (simd-loop-plan ctx node))
+    (emit-loop-simd ctx node (simd-loop-plan ctx node))
+    :else (emit-loop-scalar ctx node)))
 
 (defn- emit-loop-scalar
   "(loop [v init ...] (if cond <recur|do…recur> <result>)) → [bytes ret-vt].

--- a/src/raster/compiler/backend/wasm/encoder.clj
+++ b/src/raster/compiler/backend/wasm/encoder.clj
@@ -95,7 +95,13 @@
    :f32x4.add 0xe4 :f32x4.sub 0xe5 :f32x4.mul 0xe6 :f32x4.div 0xe7
    :f32x4.min 0xe8 :f32x4.max 0xe9
    :f64x2.add 0xf0 :f64x2.sub 0xf1 :f64x2.mul 0xf2 :f64x2.div 0xf3
-   :f64x2.min 0xf4 :f64x2.max 0xf5})
+   :f64x2.min 0xf4 :f64x2.max 0xf5
+   ;; integer lanes — int8 quantized dot: widen i8→i16, i32x4.dot_i16x8_s, accumulate
+   :i32x4.splat 0x11
+   :i32x4.extract-lane 0x1b            ; + 1 lane-index immediate byte
+   :i16x8.extend-low-i8x16-s 0x87 :i16x8.extend-high-i8x16-s 0x88
+   :i32x4.add 0xae
+   :i32x4.dot-i16x8-s 0xba})
 
 ;; ---------------------------------------------------------------------------
 ;; instruction helpers — each returns a byte vector
@@ -118,6 +124,8 @@
 (defn v [simd-key] (into [0xfd] (uleb (simd-op simd-key))))
 (defn v128-load  [align offset] (into (into [0xfd] (uleb (simd-op :v128.load)))  (into (uleb align) (uleb offset))))
 (defn v128-store [align offset] (into (into [0xfd] (uleb (simd-op :v128.store))) (into (uleb align) (uleb offset))))
+;; SIMD op carrying a single lane-index immediate (e.g. i32x4.extract_lane)
+(defn v-lane [simd-key lane] (conj (into [0xfd] (uleb (simd-op simd-key))) lane))
 (defn block  [body] (into (into [(op :block) empty-block] body) [(op :end)]))
 (defn loop*  [body] (into (into [(op :loop)  empty-block] body) [(op :end)]))
 ;; block whose result is a single value of valtype vt-kw

--- a/test/raster/compiler/backend/wasm/emit_test.clj
+++ b/test/raster/compiler/backend/wasm/emit_test.clj
@@ -654,3 +654,57 @@
                                     (Double/doubleToRawLongBits 4.0)]))]
       (is (= [:f64] (:result-types m)))
       (is (< (Math/abs (- (Double/longBitsToDouble (aget r 0)) 5.0)) 1e-12)))))
+
+;; ── int8 quantized kernels (scalar, Tier 1) ───────────────────────────────
+;; The quant inner products are integer compute on (Array byte): int8×int8 → i32
+;; accumulate, and Q4 nibble unpack via bit-and. These lower through the EXISTING
+;; emitter with no new ops — the 'bytes tag (i32.load8_s) + clojure.core integer
+;; arithmetic + bit-and cover both. SIMD128 i32x4.dot acceleration is Tier 2.
+
+(deftm idot-k [x :- (Array byte), y :- (Array byte), n :- Long] :- Long
+  (loop [i 0 acc 0]
+    (if (clojure.core/< (long i) (long n))
+      (recur (clojure.core/inc (long i))
+             (clojure.core/+ (long acc)
+                             (clojure.core/* (long (raster.arrays/aget x i))
+                                             (long (raster.arrays/aget y i)))))
+      acc)))
+
+;; Q4_0-style: low nibble of each packed byte, minus the 8 zero-point. bit-and 0xFF
+;; recovers unsigned semantics from the signed byte load; bit-and 0x0F takes the nibble.
+(deftm q4lo-k [p :- (Array byte), n :- Long] :- Long
+  (loop [i 0 acc 0]
+    (if (clojure.core/< (long i) (long n))
+      (recur (clojure.core/inc (long i))
+             (clojure.core/+ (long acc)
+                             (clojure.core/- (clojure.core/bit-and
+                                              (clojure.core/bit-and (long (raster.arrays/aget p i)) 0xFF)
+                                              0x0F)
+                                             8)))
+      acc)))
+
+(deftest int8-dot-kernel
+  (testing "int8×int8 → i32 accumulate: byte arrays + integer MAC execute correctly"
+    (let [m    (pl/compile-wasm #'idot-k :name "idot")
+          inst (instantiate (:bytes m))
+          mem  (.memory inst)
+          n    64
+          xs   (byte-array (map #(byte (- (mod (* 7 %) 17) 8)) (range n)))
+          ys   (byte-array (map #(byte (- (mod (* 3 %) 13) 6)) (range n)))]
+      (is (= [:i32] (:result-types m)))
+      (dotimes [i n] (.writeByte mem i (aget xs i)) (.writeByte mem (+ n i) (aget ys i)))
+      (let [r   (aget (.apply (.export inst "idot") (long-array [0 n n])) 0)
+            exp (reduce + (map (fn [a b] (* (int a) (int b))) xs ys))]
+        (is (= r exp) (str "idot=" r " exp=" exp))))))
+
+(deftest q4-nibble-unpack-kernel
+  (testing "Q4 low-nibble unpack (bit-and mask + zero-point) executes correctly"
+    (let [m    (pl/compile-wasm #'q4lo-k :name "q4lo")
+          inst (instantiate (:bytes m))
+          mem  (.memory inst)
+          n    32
+          ps   (byte-array (map #(unchecked-byte (mod (* 11 %) 256)) (range n)))]
+      (dotimes [i n] (.writeByte mem i (aget ps i)))
+      (let [r   (aget (.apply (.export inst "q4lo") (long-array [0 n])) 0)
+            exp (reduce + (map (fn [p] (- (bit-and (int p) 0x0F) 8)) ps))]
+        (is (= r exp) (str "q4lo=" r " exp=" exp))))))

--- a/test/raster/compiler/backend/wasm/emit_test.clj
+++ b/test/raster/compiler/backend/wasm/emit_test.clj
@@ -708,3 +708,71 @@
       (let [r   (aget (.apply (.export inst "q4lo") (long-array [0 n])) 0)
             exp (reduce + (map (fn [p] (- (bit-and (int p) 0x0F) 8)) ps))]
         (is (= r exp) (str "q4lo=" r " exp=" exp))))))
+
+;; ── int8 dot SIMD128 vectorization (Tier 2) ───────────────────────────────
+;; The int8-dot reduction lowers to i32x4.dot_i16x8_s (widen i8→i16, dot,
+;; accumulate) + horizontal sum + scalar remainder. Chicory can PARSE (validate)
+;; a v128 module but cannot EXECUTE it, so validity is asserted here and
+;; execution is asserted on V8 via node (guarded — skips where node is absent).
+
+(defn- node-available? []
+  (try
+    (let [p (-> (ProcessBuilder. ^java.util.List ["node" "--version"])
+                (.redirectErrorStream true) (.start))]
+      (.waitFor p) (zero? (.exitValue p)))
+    (catch Exception _ false)))
+
+(defn- run-idot-on-node
+  "Execute the SIMD idot .wasm on V8 for int8 vectors xs,ys (length n).
+   Returns the kernel's i32 result. Requires node."
+  [^bytes wasm xs ys n]
+  (let [dir  (java.nio.file.Files/createTempDirectory "idot" (make-array java.nio.file.attribute.FileAttribute 0))
+        wp   (str dir "/idot.wasm")
+        jp   (str dir "/run.mjs")]
+    (with-open [o (java.io.FileOutputStream. wp)] (.write o wasm))
+    (spit jp (str "import fs from 'fs';\n"
+                  "const b=fs.readFileSync('" wp "');\n"
+                  "const {instance}=await WebAssembly.instantiate(b,{});\n"
+                  "const m=new Int8Array(instance.exports.memory.buffer);\n"
+                  "const xs=[" (clojure.string/join "," xs) "],ys=[" (clojure.string/join "," ys) "];\n"
+                  "for(let i=0;i<" n ";i++){m[i]=xs[i];m[" n "+i]=ys[i];}\n"
+                  "console.log(instance.exports.idot(0," n "," n "));\n"))
+    (let [p (-> (ProcessBuilder. ^java.util.List ["node" jp]) (.redirectErrorStream true) (.start))
+          out (slurp (.getInputStream p))]
+      (.waitFor p)
+      (Integer/parseInt (clojure.string/trim out)))))
+
+(deftm idot-simd-k [x :- (Array byte), y :- (Array byte), n :- Long] :- Long
+  (loop [i 0 acc 0]
+    (if (clojure.core/< (long i) (long n))
+      (recur (clojure.core/inc (long i))
+             (clojure.core/+ (long acc)
+                             (clojure.core/* (long (raster.arrays/aget x i))
+                                             (long (raster.arrays/aget y i)))))
+      acc)))
+
+(deftest int8-dot-simd-vectorizes
+  (testing "int8 dot with :wasm-simd? emits a valid v128 module using i32x4.dot_i16x8_s"
+    (let [m  (pl/compile-wasm #'idot-simd-k :name "idot" :wasm-simd? true)
+          bs (:bytes m)]
+      (is (= [:i32] (:result-types m)))
+      ;; Chicory parses = structural validation of the v128 bytecode
+      (is (some? (Parser/parse bs)))
+      ;; the i32x4.dot_i16x8_s workhorse (0xfd 0xba) is present
+      (is (some (fn [i] (and (= (bit-and (nth bs i) 0xff) 0xfd)
+                             (= (bit-and (nth bs (inc i)) 0xff) 0xba)))
+                (range (dec (count bs))))
+          "emitted module contains i32x4.dot_i16x8_s"))))
+
+(deftest int8-dot-simd-executes-on-v8
+  (testing "SIMD int8 dot executes bit-exactly on V8 across block boundaries"
+    (if-not (node-available?)
+      (println "SKIP int8-dot-simd-executes-on-v8: node not available")
+      (let [m (pl/compile-wasm #'idot-simd-k :name "idot" :wasm-simd? true)]
+        ;; n < 16 (all remainder), = 16 (one block), block+remainder, many blocks
+        (doseq [n [15 16 17 64 70 256]]
+          (let [xs  (mapv #(int (- (mod (* 7 %) 17) 8)) (range n))
+                ys  (mapv #(int (- (mod (* 3 %) 13) 6)) (range n))
+                got (run-idot-on-node (:bytes m) xs ys n)
+                exp (reduce + (map * xs ys))]
+            (is (= got exp) (str "n=" n " got=" got " exp=" exp))))))))


### PR DESCRIPTION
## Overview

Brings **quantized int8 inference to the WebAssembly (browser) backend** in two tiers —
a correctness path and a SIMD-accelerated path. This makes int8 GEMV / dot products (the
inner loop of quantized LLM + embedding inference) run in the browser through the same
`deftm` → wasm pipeline as the float kernels. Independent of the CPU-C quant work (#17) and
the compiler-convergence PR (#19) — different backend, different files.

## Tier 1 — scalar int8, zero emitter changes

The quantized inner products are integer compute on `(Array byte)`: int8×int8 → i32
accumulate, plus Q4 nibble unpack via `bit-and`. Both already lower through the **existing**
wasm emitter — the `bytes` tag (`i32.load8_s`), `clojure.core` integer arithmetic, and
`bit-and` cover it. Signed byte load + `(bit-and _ 0xFF)` recovers unsigned nibble semantics,
so **no new dtype tag** was needed. Tests execute int8-dot + Q4-unpack kernels on Chicory
(pure-JVM) against an integer reference.

## Tier 2 — SIMD128 vectorization via `i32x4.dot_i16x8_s`

- **New integer v128 opcodes** (`encoder.clj`): `i16x8.extend_low/high_i8x16_s`,
  `i32x4.dot_i16x8_s`, `i32x4.add`, `i32x4.splat`, `i32x4.extract_lane` (+ lane-immediate
  helper). All **finalized baseline SIMD128** — ships in every browser, no relaxed-SIMD
  dependency.
- **New reduction vectorizer** (`emit.clj`): recognizes the int8-dot reduction loop and emits
  the ggml-style sequence — 16-wide main loop (widen i8→i16, `i32x4.dot_i16x8_s`, accumulate
  into an i32x4) + horizontal lane sum + scalar remainder for the tail. Gated on
  `:wasm-simd?`; the scalar path is unchanged. (The prior wasm SIMD path only vectorized
  elementwise *maps* and only f32/f64 — this adds *integer reduction* vectorization.)
- **Validated on V8** (node): bit-exact across block boundaries — n = 15 (all-remainder),
  16 (one block), 17 (block+tail), 64/70/256 (many blocks). In-suite, Chicory asserts module
  validity + dot-opcode presence (it parses but can't execute v128); a node-guarded test
  asserts execution (skips cleanly where node is absent).

## Design note

This is the **wasm schedule of the same int8-MAC primitive** the CPU (`maddubs`/VNNI
`dpbusd`) and GPU (`dp4a`) backends use — one algorithm, N hardware schedules. Converging
these onto a single `widening-i8-dot` op-descriptor primitive (so the recognition is shared,
not per-backend) is the follow-up cross-backend-quant abstraction work.

## Tests

`clojure -M:test` → **1651 tests, 7828 assertions, 0 failures, 0 errors.**
