### PR TITLE
S3: GPU prefill/embed mode — signed q8_0 W8A8 kernels + bidirectional prefill attention

### DIFF
--- a/src/raster/dl/attention.clj
+++ b/src/raster/dl/attention.clj
@@ -1204,3 +1204,30 @@
                        (+ a (* (aget sc (clojure.core/+ scb j))
                                (aget v (clojure.core/+ (clojure.core/* j kvstride) hkvb)))))
                 a)))))))
+
+;; Bidirectional scores (EmbeddingGemma-style encoder): all-to-all, no causal mask.
+;; (Symmetric sliding window |i-j| < w only matters for T > window — the binder
+;; asserts T <= window, so full attention here is exact.)
+(deftm attn-prefill-scores-bidir! (All [T] [q :- (Array T) k :- (Array T) sc :- (Array T)
+                                            nrows :- Long n-q :- Long group :- Long
+                                            n-kv :- Long head-dim :- Long
+                                            scale :- Double] :- Void
+  (raster.par/map-void! idx (clojure.core/* nrows (clojure.core/* n-q nrows))
+    (let [per-i (clojure.core/* n-q nrows)
+          i (quot idx per-i)
+          rest0 (rem idx per-i)
+          hq (quot rest0 nrows)
+          j (rem rest0 nrows)
+          row (clojure.core/+ (clojure.core/* i n-q) hq)
+          hkv (quot hq group)
+          qb (clojure.core/+ (clojure.core/* i (clojure.core/* n-q head-dim))
+                             (clojure.core/* hq head-dim))
+          kb (clojure.core/+ (clojure.core/* j (clojure.core/* n-kv head-dim))
+                             (clojure.core/* hkv head-dim))
+          dot (loop [d 0 acc 0.0]
+                (if (< d head-dim)
+                  (recur (inc d)
+                         (+ acc (* (aget q (clojure.core/+ qb d))
+                                   (aget k (clojure.core/+ kb d)))))
+                  acc))]
+      (aset sc (clojure.core/+ (clojure.core/* row nrows) j) (* dot scale))))))

--- a/src/raster/dl/attention.clj
+++ b/src/raster/dl/attention.clj
@@ -1109,3 +1109,98 @@
                                                     dK (list 'clojure.core/aget grads-arr 1)
                                                     dV (list 'clojure.core/aget grads-arr 2)])
                                            [dQ dK dV nil nil nil nil]]))})
+
+;; ---------------------------------------------------------------------------
+;; PREFILL variants (S3 GPU embed mode): a whole T-token block per replay, no KV
+;; cache, positions from the work-item index. Causal mask via -1e30 scores.
+;; ---------------------------------------------------------------------------
+
+(deftm rope-prefill! (All [T] [x :- (Array T) out :- (Array T)
+                               nrows :- Long heads :- Long head-dim :- Long
+                               theta :- Double] :- Void
+  (raster.par/map-void! idx (clojure.core/* nrows (clojure.core/* heads (quot head-dim 2)))
+    (let [hdim2 (quot head-dim 2)
+          per-row (clojure.core/* heads hdim2)
+          t (quot idx per-row)
+          rest0 (rem idx per-row)
+          h (quot rest0 hdim2)
+          i (rem rest0 hdim2)
+          base (clojure.core/+ (clojure.core/* t (clojure.core/* heads head-dim))
+                               (clojure.core/* h head-dim))
+          ln-theta (m/log theta)
+          freq (m/exp (* (/ (* -2.0 (double i)) (double head-dim)) ln-theta))
+          ang (* (double t) freq)
+          c (m/cos ang) s (m/sin ang)
+          x0 (aget x (clojure.core/+ base i))
+          x1 (aget x (clojure.core/+ (clojure.core/+ base i) hdim2))]
+      (aset out (clojure.core/+ base i) (- (* x0 c) (* x1 s)))
+      (aset out (clojure.core/+ (clojure.core/+ base i) hdim2) (+ (* x1 c) (* x0 s)))))))
+
+;; Causal batched attention, 3 phases. q:[T,nq*hd] k,v:[T,nkv*hd] row-major;
+;; sc:[T*nq, T] scores/probs scratch; out:[T, nq*hd].
+(deftm attn-prefill-scores! (All [T] [q :- (Array T) k :- (Array T) sc :- (Array T)
+                                      nrows :- Long n-q :- Long group :- Long
+                                      n-kv :- Long head-dim :- Long
+                                      scale :- Double] :- Void
+  (raster.par/map-void! idx (clojure.core/* nrows (clojure.core/* n-q nrows))
+    (let [per-i (clojure.core/* n-q nrows)
+          i (quot idx per-i)
+          rest0 (rem idx per-i)
+          hq (quot rest0 nrows)
+          j (rem rest0 nrows)
+          row (clojure.core/+ (clojure.core/* i n-q) hq)]
+      (if (< i j)
+        (aset sc (clojure.core/+ (clojure.core/* row nrows) j) -1.0e30)
+        (let [hkv (quot hq group)
+              qb (clojure.core/+ (clojure.core/* i (clojure.core/* n-q head-dim))
+                                 (clojure.core/* hq head-dim))
+              kb (clojure.core/+ (clojure.core/* j (clojure.core/* n-kv head-dim))
+                                 (clojure.core/* hkv head-dim))
+              dot (loop [d 0 acc 0.0]
+                    (if (< d head-dim)
+                      (recur (inc d)
+                             (+ acc (* (aget q (clojure.core/+ qb d))
+                                       (aget k (clojure.core/+ kb d)))))
+                      acc))]
+          (aset sc (clojure.core/+ (clojure.core/* row nrows) j) (* dot scale))))))))
+
+(deftm attn-prefill-softmax! (All [T] [sc :- (Array T)
+                                       nrows :- Long n-q :- Long] :- Void
+  (raster.par/map-void! row (clojure.core/* nrows n-q)
+    (let [scb (clojure.core/* row nrows)
+          mx (loop [j 0 mm -1.0e30]
+               (if (< j nrows)
+                 (recur (inc j) (n/max mm (aget sc (clojure.core/+ scb j)))) mm))
+          sum (loop [j 0 s 0.0]
+                (if (< j nrows)
+                  (let [e (m/exp (- (aget sc (clojure.core/+ scb j)) mx))]
+                    (aset sc (clojure.core/+ scb j) e)
+                    (recur (inc j) (+ s e)))
+                  s))
+          inv (/ 1.0 sum)]
+      (loop [j 0]
+        (if (< j nrows)
+          (do (aset sc (clojure.core/+ scb j) (* (aget sc (clojure.core/+ scb j)) inv))
+              (recur (inc j)))
+          nil))))))
+
+(deftm attn-prefill-out! (All [T] [sc :- (Array T) v :- (Array T) out :- (Array T)
+                                   nrows :- Long n-q :- Long group :- Long
+                                   n-kv :- Long head-dim :- Long] :- Void
+  (raster.par/map-void! idx (clojure.core/* nrows (clojure.core/* n-q head-dim))
+    (let [per-i (clojure.core/* n-q head-dim)
+          i (quot idx per-i)
+          rest0 (rem idx per-i)
+          hq (quot rest0 head-dim)
+          d (rem rest0 head-dim)
+          row (clojure.core/+ (clojure.core/* i n-q) hq)
+          scb (clojure.core/* row nrows)
+          hkvb (clojure.core/+ (clojure.core/* (quot hq group) head-dim) d)
+          kvstride (clojure.core/* n-kv head-dim)]
+      (aset out (clojure.core/+ (clojure.core/* i per-i) (clojure.core/+ (clojure.core/* hq head-dim) d))
+            (loop [j 0 a 0.0]
+              (if (< j nrows)
+                (recur (inc j)
+                       (+ a (* (aget sc (clojure.core/+ scb j))
+                               (aget v (clojure.core/+ (clojure.core/* j kvstride) hkvb)))))
+                a)))))))

--- a/src/raster/quant/kernels_k.clj
+++ b/src/raster/quant/kernels_k.clj
@@ -298,3 +298,73 @@
                                  (recur (inc sb) (+ a (* dv dact ssum))))
                                a))]
                    (ra/aset y o (float acc)))))
+
+;; ---- signed q8_0 PREFILL kernels (GPU embed mode, S3) ----
+;; Embeddings need >=8-bit weights (measured: 4-bit costs ~5%+ cosine). Signed
+;; symmetric q8_0 (d = max|x|/127, q in [-127,127]) x signed i8 activations means
+;; the dp4a dot needs NO zero-point fold and NO block sums — the simplest exact
+;; int8 pipeline. Prefill processes T rows per replay (weights read once — the
+;; compute-bound shape where the GPU wins), so both kernels carry a rows dim.
+
+(deftm quant-act-i8-rows-gpu!
+  "Signed q8_0 activation quantizer over T rows: one work-item per (row, 32-block)
+  computes d = max|x|/127 for its block, packs 32 signed int8 into 8 int32 words
+  (xp, little-endian lanes) and stores d (xs, one float per row-block).
+  Grid = nrows*(in/32)."
+  [x :- (Array float), xp :- (Array int), xs :- (Array float),
+   in :- Long, nrows :- Long] :- Void
+  (par/map-void! rb (* nrows (quot in 32))
+    (let [nb (quot in 32)
+          b (rem rb nb)
+          r (quot rb nb)
+          base (+ (* r in) (* b 32))
+          mx (loop [k 0 m 0.0]
+               (if (< k 32)
+                 (let [v (ra/aget x (+ base k))]
+                   (recur (inc k) (max m (max v (- v)))))
+                 m))
+          d (/ (double mx) 127.0)
+          id (if (> (double d) 0.0) (/ 1.0 (double d)) 0.0)]
+      (ra/aset xs rb (float d))
+      (loop [w 0]
+        (if (< w 8)
+          (let [e (+ base (* w 4))
+                q0 (long (Math/round (* (double (ra/aget x e)) id)))
+                q1 (long (Math/round (* (double (ra/aget x (+ e 1))) id)))
+                q2 (long (Math/round (* (double (ra/aget x (+ e 2))) id)))
+                q3 (long (Math/round (* (double (ra/aget x (+ e 3))) id)))
+                word (bit-or (bit-and q0 0xFF)
+                             (bit-shift-left (bit-and q1 0xFF) 8)
+                             (bit-shift-left (bit-and q2 0xFF) 16)
+                             (bit-shift-left (bit-and q3 0xFF) 24))]
+            (ra/aset xp (+ (* rb 8) w) (int word))
+            (recur (inc w)))
+          nil)))))
+
+(deftm qmatmul-i8-gemm!
+  "Signed q8_0 x q8_0 GEMM for prefill: one work-item per (token, out-row) —
+  y[t*out+o] = sum_b ws[o,b]*xs[t,b]*dp4a-dot(block b). Weights row-major signed-i8
+  int-packed (wp int[out*in/4], ws float[out*(in/32)]); activations from
+  quant-act-i8-rows-gpu!. Grid = nrows*out."
+  [xp :- (Array int), xs :- (Array float),
+   wp :- (Array int), ws :- (Array float), y :- (Array float),
+   in :- Long, out :- Long, nrows :- Long] :- Void
+  (par/map-void! ot (* nrows out)
+    (let [o (rem ot out)
+          t (quot ot out)
+          nb (quot in 32)
+          ni4 (quot in 4)
+          acc (loop [b 0 a 0.0]
+                (if (< b nb)
+                  (let [dp (loop [k 0 d 0]
+                             (if (< k 8)
+                               (recur (inc k)
+                                      (par/dp4a (ra/aget wp (+ (* o ni4) (* b 8) k))
+                                                (ra/aget xp (+ (* t ni4) (* b 8) k)) d))
+                               d))]
+                    (recur (inc b)
+                           (+ a (* (* (double (ra/aget ws (+ (* o nb) b)))
+                                      (double (ra/aget xs (+ (* t nb) b))))
+                                   (double dp)))))
+                  a))]
+      (ra/aset y (+ (* t out) o) (float acc)))))


### PR DESCRIPTION
The compute-bound embed shape: a whole T-token block per replay, weights read once.

## Kernels (raster.quant.kernels-k + raster.dl.attention)
- `quant-act-i8-rows-gpu!` — signed i8 per-(row, 32-block) activation quantizer (d=max|x|/127, int-packed). Signed×signed dp4a needs **no zero-point fold and no block sums**.
- `qmatmul-i8-gemm!` — one work-item per (token, out-row), dp4a dot with per-block scale fold; grid T×out.
- Prefill attention: `rope-prefill!` (position from work-item index), `attn-prefill-scores!` (causal via −1e30) / `attn-prefill-scores-bidir!` (encoder-style, exact for T ≤ sliding window), softmax + weighted-sum — the validated decode 3-phase structure batched over T.

## Why signed Q8_0
Embeddings need ≥8-bit weights (measured on Qwen3-Embedding vs torch f32: 4-bit costs ~5%+ cosine regardless of scheme; Q8_0 lossless).

## Validation
- Full Valhalla suite: **1717 tests / 28,746 assertions / 0 failures / 0 errors**
- Synthetic W8A8 GEMM: relerr 0.006 vs f64 (expected quant noise)
- End-to-end (pretrained-rstr): Qwen3-Embedding GPU embed **cos 0.999 vs torch f32 gold**, T=128 = 255 tok/s (~15× the CPU stream path); **EmbeddingGemma-300M** (bidirectional + mean-pool + Dense head) cos 0.988–0.993 vs torch gold, retrieval structure reproduced.

Known follow-up: the GEMM has no data reuse yet (one work-item per output, ~2–4% of dp4a peak) — tiling/local-memory is the next perf lever; the architecture doesn't change.