### PR TITLE
GPU: vendor-portable extension pragmas + OpenCL device-type override (CUDA/HIP Phase A)

### DIFF
--- a/src/raster/compiler/backend/gpu/opencl_codegen.clj
+++ b/src/raster/compiler/backend/gpu/opencl_codegen.clj
@@ -48,11 +48,11 @@
 
 (def ^:private fp64-pragma
   "Enable double precision (required for OpenCL)."
-  "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n")
+  "#if defined(cl_khr_fp64)\n#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n#endif\n")
 
 (def ^:private subgroup-pragma
   "Enable Intel subgroup extensions for shuffle ops."
-  "#pragma OPENCL EXTENSION cl_intel_subgroups : enable\n")
+  "#if defined(cl_khr_subgroups)\n#pragma OPENCL EXTENSION cl_khr_subgroups : enable\n#elif defined(cl_intel_subgroups)\n#pragma OPENCL EXTENSION cl_intel_subgroups : enable\n#endif\n")
 
 ;; ================================================================
 ;; Kernel templates

--- a/src/raster/compiler/backend/gpu/par_opencl.clj
+++ b/src/raster/compiler/backend/gpu/par_opencl.clj
@@ -97,7 +97,7 @@
                            ce/*scalar-type* ctype]
                    (ce/emit-expr adapted-body idx (set (map #(symbol (name %)) arr-params))))
         cast-str (if cast (str "(" (name cast) ")(" body-str ")") body-str)
-        source (str (when use-fp64? "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n")
+        source (str (when use-fp64? "#if defined(cl_khr_fp64)\n#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n#endif\n")
                     "__kernel void " kernel-name
                     "(" all-params ") {\n"
                     "    for (int idx = get_global_id(0); idx < _n_bound; idx += get_global_size(0)) {\n"
@@ -228,7 +228,7 @@
         needs-fp64? (or use-fp64?
                         (str/includes? body-str "double")
                         (str/includes? helper-sources "double"))
-        source (str (when needs-fp64? "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n")
+        source (str (when needs-fp64? "#if defined(cl_khr_fp64)\n#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n#endif\n")
                     "#pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : enable\n"
                     helper-sources
                     (when needs-float-atomic? atomic-add-float-helper)
@@ -338,7 +338,7 @@
         half-block (/ block-size 2)
         ;; Generate source with two kernels
         source (str
-                (when use-fp64? "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n")
+                (when use-fp64? "#if defined(cl_khr_fp64)\n#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n#endif\n")
                 "\n"
                  ;; Kernel 1: Block-level exclusive scan (Blelloch)
                 "__kernel void " block-kn "(\n"
@@ -501,8 +501,8 @@
                                                    [(or adapted-element 'input)])]
                                (ce/emit-expr let-body idx array-sym-names "i"))
                              element-str))
-        source (str (when use-fp64? "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n")
-                    "#pragma OPENCL EXTENSION cl_intel_subgroups : enable\n"
+        source (str (when use-fp64? "#if defined(cl_khr_fp64)\n#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n#endif\n")
+                    "#if defined(cl_khr_subgroups)\n#pragma OPENCL EXTENSION cl_khr_subgroups : enable\n#elif defined(cl_intel_subgroups)\n#pragma OPENCL EXTENSION cl_intel_subgroups : enable\n#endif\n"
                     "__kernel void " kernel-name
                     "(" all-params ") {\n"
                     "    __local " ctype " sdata[" wg-size "];\n"
@@ -729,7 +729,7 @@
                    (ce/emit-expr adapted-body idx (set (map #(symbol (name %)) arr-params))))
         cast-str (if cast (str "(" (name cast) ")(" body-str ")") body-str)
         out-c (ce/c-symbol out)
-        source (str (when use-fp64? "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n")
+        source (str (when use-fp64? "#if defined(cl_khr_fp64)\n#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n#endif\n")
                     "__kernel void " kernel-name
                     "(" all-params ") {\n"
                     "    for (int idx = get_global_id(0); idx < _n_bound; idx += get_global_size(0)) {\n"
@@ -778,7 +778,7 @@
         index-c (ce/c-symbol index)
         ;; Scatter needs float atomic CAS for float types, native atomic for int
         needs-float-atomic? (contains? #{:float :double} dtype)
-        source (str (when use-fp64? "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n")
+        source (str (when use-fp64? "#if defined(cl_khr_fp64)\n#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n#endif\n")
                     "#pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : enable\n"
                     (when needs-float-atomic? atomic-add-float-helper)
                     "__kernel void " kernel-name
@@ -835,7 +835,7 @@
         vals-c (ce/c-symbol vals)
         needs-float-atomic? (contains? #{:float :double} dtype)
         ;; Only + is supported for atomic reduce-by-key (most common case)
-        source (str (when use-fp64? "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n")
+        source (str (when use-fp64? "#if defined(cl_khr_fp64)\n#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n#endif\n")
                     "#pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : enable\n"
                     (when needs-float-atomic? atomic-add-float-helper)
                     "__kernel void " kernel-name
@@ -957,7 +957,7 @@
                                                                (set (map symbol (map name all-arrays)))
                                                                ctype)
                                     non-reduce-phases))
-        source (str (when use-fp64? "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n")
+        source (str (when use-fp64? "#if defined(cl_khr_fp64)\n#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n#endif\n")
                     "__kernel void " kernel-name
                     "(" all-params ") {\n"
                     "    int i = get_local_id(0);\n"
@@ -1030,7 +1030,7 @@
                   (str "    for (int idx = get_global_id(0); idx < _n_bound; idx += get_global_size(0)) {\n"
                        "        " (ce/c-symbol out) "[idx] = " body-str ";\n"
                        "    }\n"))
-                source (str (when use-fp64? "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n")
+                source (str (when use-fp64? "#if defined(cl_khr_fp64)\n#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n#endif\n")
                             "__kernel void " kernel-name
                             "(" all-params ") {\n"
                             kernel-body

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -87,7 +87,7 @@
                            ce/*int-vars* (into ce/*int-vars* int-scalar-syms)]
                    (ce/emit-expr adapted-body idx (set (map #(symbol (name %)) arr-params))))
         cast-str (if cast-fn (str "(" (name cast-fn) ")(" body-str ")") body-str)
-        source (str (when use-fp64? "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n")
+        source (str (when use-fp64? "#if defined(cl_khr_fp64)\n#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n#endif\n")
                     "__kernel void " kernel-name
                     "(" all-params ") {\n"
                     "    for (int idx = get_global_id(0); idx < _n_bound; idx += get_global_size(0)) {\n"
@@ -191,8 +191,8 @@
                                       "int _n_bound"]))
         ;; Static shared memory — matches invoke-reduction-kernel (no __local arg)
         source (when elem-str
-                 (str (when use-fp64? "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n")
-                      "#pragma OPENCL EXTENSION cl_intel_subgroups : enable\n"
+                 (str (when use-fp64? "#if defined(cl_khr_fp64)\n#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n#endif\n")
+                      "#if defined(cl_khr_subgroups)\n#pragma OPENCL EXTENSION cl_khr_subgroups : enable\n#elif defined(cl_intel_subgroups)\n#pragma OPENCL EXTENSION cl_intel_subgroups : enable\n#endif\n"
                       "__kernel void " kernel-name
                       "(" all-params ") {\n"
                       "    __local " ctype " sdata[256];\n"

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -81,6 +81,17 @@
 
 (def ^:private CL_SUCCESS 0)
 (def ^:private CL_DEVICE_TYPE_GPU (long 4))
+(def ^:private CL_DEVICE_TYPE_CPU (long 2))
+(def ^:private CL_DEVICE_TYPE_ALL (long 0xFFFFFFFF))
+
+(defn- requested-device-type
+  "CL device type from RASTER_OCL_DEVICE_TYPE (cpu|all; default gpu) — lets the
+  same runtime bind POCL/Intel-CPU OpenCL for vendor-portability validation."
+  ^long []
+  (case (some-> (System/getenv "RASTER_OCL_DEVICE_TYPE") .toLowerCase)
+    "cpu" CL_DEVICE_TYPE_CPU
+    "all" CL_DEVICE_TYPE_ALL
+    CL_DEVICE_TYPE_GPU))
 (def ^:private CL_MEM_READ_WRITE (long 1))
 (def ^:private CL_MEM_COPY_HOST_PTR (long 32))
 (def ^:private CL_TRUE (int 1))
@@ -272,7 +283,9 @@
 
 (defn init!
   "Initialize OpenCL runtime. Idempotent.
-  Finds first GPU platform/device, creates context and in-order command queue."
+  Finds the first platform with a device of the requested type (default GPU;
+  RASTER_OCL_DEVICE_TYPE=cpu|all selects CPU/any device — POCL, Intel CPU
+  runtime, vendor-portability testing), creates context and in-order queue."
   []
   (when-not (:initialized? @state)
     (let [arena (Arena/ofShared)
@@ -294,14 +307,14 @@
                  (let [plat (.get plat-buf PTR (* plat-idx 8))
                        num-dev-seg (.allocate arena I32)
                        ret (int (.invokeWithArguments ^MethodHandle @h-clGetDeviceIDs
-                                                      (into-array Object [plat (long CL_DEVICE_TYPE_GPU)
+                                                      (into-array Object [plat (long (requested-device-type))
                                                                           (int 0) MemorySegment/NULL num-dev-seg])))]
                    (when (== CL_SUCCESS ret)
                      (let [num-dev (read-int num-dev-seg)]
                        (when (> num-dev 0)
                          (let [dev-buf (.allocate arena 8)
                                _ (cl-call! "clGetDeviceIDs" @h-clGetDeviceIDs
-                                           [plat (long CL_DEVICE_TYPE_GPU) (int 1) dev-buf num-dev-seg])
+                                           [plat (long (requested-device-type)) (int 1) dev-buf num-dev-seg])
                                dev (.get dev-buf PTR 0)]
                            [plat dev]))))))
                (range num-plat))
@@ -359,13 +372,13 @@
               (let [plat (.get plat-buf PTR (* plat-idx 8))
                     num-dev-seg (.allocate arena I32)
                     ret (int (.invokeWithArguments ^MethodHandle @h-clGetDeviceIDs
-                                                   (into-array Object [plat (long CL_DEVICE_TYPE_GPU)
+                                                   (into-array Object [plat (long (requested-device-type))
                                                                        (int 0) MemorySegment/NULL num-dev-seg])))]
                 (when (== CL_SUCCESS ret)
                   (let [num-dev (read-int num-dev-seg)
                         dev-buf (.allocate arena (* num-dev 8))
                         _ (cl-call! "clGetDeviceIDs" @h-clGetDeviceIDs
-                                    [plat (long CL_DEVICE_TYPE_GPU) (int num-dev) dev-buf num-dev-seg])]
+                                    [plat (long (requested-device-type)) (int num-dev) dev-buf num-dev-seg])]
                     (mapv
                      (fn [dev-idx]
                        (let [dev (.get dev-buf PTR (* dev-idx 8))]


### PR DESCRIPTION
First slice of the CUDA/HIP plan (raster/.internal/cuda_hip_plan.md, informed by the llama.cpp/Triton/Halide study):

- **Self-gating extension pragmas**: subgroups now emit an `#if defined(cl_khr_subgroups) … #elif defined(cl_intel_subgroups)` chain instead of the hardcoded Intel spelling (the one hard portability bug for NVIDIA/AMD ICDs — the builtins we use, `get_sub_group_id`/`get_sub_group_local_id`, are core/KHR already). `cl_khr_fp64` pragmas guarded at 12 sites. The XMX `intel_sub_group_2d_block_*` GEMM remains Intel-specific by design (per-target kernel).
- **`RASTER_OCL_DEVICE_TYPE=cpu|all`**: the OpenCL runtime can bind CPU devices (POCL / Intel CPU runtime) — the local, no-GPU execution oracle for kernel portability.
- Verified on Arc: GPU test namespaces green before and after the runtime refactor.

Known limit (mapped, not fixed here): `bind-program!`'s resident-session layer is Level-Zero-only (~20 fns incl. `kernel-registry-entry`, `record-graph!`); porting it to OpenCL is #26/#38 and is the prerequisite for actually *executing* full programs on non-Intel devices. `compile-gpu-program` already works on `:ocl:0`.