### PR TITLE
GPU: OpenCL resident-session port — POCL becomes the no-GPU portability oracle

### DIFF
--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -570,16 +570,23 @@
     (par-fusion/par-fusion-pass form)))
 
 (defn- register-gpu-kernels!
-  "Register generated GPU kernels eagerly so they're available at eval time."
-  [kernels]
-  (when (seq kernels)
-    (try
-      (require 'raster.gpu.ze-runtime)
-      (let [register! (resolve 'raster.gpu.ze-runtime/register-kernel!)]
-        (doseq [k kernels]
-          (register! (:kernel-name k) k)))
-      (catch Exception e
-        (println "Warning: could not register GPU kernels:" (.getMessage e))))))
+  "Register generated GPU kernels eagerly so they're available at eval time.
+  Registers into the TARGET backend's registry (ze for :ze:N, ocl for :ocl:N) —
+  a hardcoded ze registration left :ocl programs unbindable (kernel lookup at
+  bind-program! time hits the per-backend registry)."
+  ([kernels] (register-gpu-kernels! kernels :ze:0))
+  ([kernels device-id]
+   (when (seq kernels)
+     (let [ns-sym (if (and device-id (.startsWith (name device-id) "ocl"))
+                    'raster.gpu.ocl-runtime
+                    'raster.gpu.ze-runtime)]
+       (try
+         (require ns-sym)
+         (let [register! (resolve (symbol (str ns-sym) "register-kernel!"))]
+           (doseq [k kernels]
+             (register! (:kernel-name k) k)))
+         (catch Exception e
+           (println "Warning: could not register GPU kernels:" (.getMessage e))))))))
 
 (defn- pass-gpu-plan
   "GPU execution plan: rewrite BLAS calls to GPU GEMM kernels,
@@ -598,7 +605,7 @@
                                            :active-params (:active-params opts)
                                            :target-device target-device)
             kernels (:kernels result)]
-        (register-gpu-kernels! kernels)
+        (register-gpu-kernels! kernels target-device)
         (if (pos? (+ (get-in result [:stats :gemm-rewrites] 0)
                      (get-in result [:stats :transpose-rewrites] 0)
                      (get-in result [:stats :map-rewrites] 0)
@@ -668,7 +675,7 @@
             result (opencl-pass/opencl-pass form
                                             :device-id target-device
                                             :dtype (:dtype opts))]
-        (register-gpu-kernels! (:kernels result))
+        (register-gpu-kernels! (:kernels result) target-device)
         {:form (:form result) :stats (:stats result) :kernels (:kernels result) :backend :opencl})
 
         :simd

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -961,6 +961,141 @@
 ;; Lifecycle
 ;; ================================================================
 
+
+;; ================================================================
+;; Resident session layer (ports of the ze_runtime bound/graph API)
+;; OpenCL has no command graphs in core: record-graph! stores the ordered
+;; launches; replay-graph! enqueues them on the in-order queue (which gives
+;; the ze barrier semantics) and clFinish-es once. The ~us/enqueue host cost
+;; is paid per replay rather than once — correct now, cl_khr_command_buffer
+;; later if it matters.
+;; ================================================================
+
+(defn kernel-registry-entry
+  "Public read of a registered kernel's info map (source, :array-params,
+  :scalar-params, dtype, ...). Same contract as ze-runtime."
+  [kernel-name]
+  (get @kernel-registry kernel-name))
+
+(defn- create-kernel-fresh
+  "A DEDICATED cl_kernel per binding — kernel args are mutable state on the
+  kernel object (same clobbering hazard as Level Zero shared handles)."
+  ^MemorySegment [^MemorySegment program ^String kernel-name]
+  (let [{:keys [arena]} @state
+        err-seg (.allocate ^Arena arena I32)
+        kname-seg (.allocateFrom ^Arena arena kernel-name)
+        kh (.invokeWithArguments ^MethodHandle @h-clCreateKernel
+                                 (into-array Object [program kname-seg err-seg]))]
+    (when (not= CL_SUCCESS (read-int err-seg))
+      (throw (ex-info (str "clCreateKernel (fresh) failed for " kernel-name)
+                      {:error (read-int err-seg)})))
+    kh))
+
+(defn- device-mem-of
+  "cl_mem of a resident arg (OclBuffer or raw cl_mem MemorySegment)."
+  ^MemorySegment [arr]
+  (cond
+    (device-buffer? arr) (:cl-mem arr)
+    (instance? MemorySegment arr) arr
+    :else (throw (ex-info "bound path requires GPU-resident args (OclBuffer); JVM-array staging is not supported here"
+                          {:arr-type (type arr)}))))
+
+(defn bind-registered-map-void-kernel
+  "Pre-bind a registered void-map kernel's args ONCE over RESIDENT OclBuffers.
+  Same contract as ze-runtime/bind-registered-map-void-kernel: buffer CONTENTS
+  may change between launches; re-bind only on reallocation or n change."
+  ([^String kernel-name arrays scalar-args n]
+   (bind-registered-map-void-kernel kernel-name arrays scalar-args n {}))
+  ([^String kernel-name arrays scalar-args n opts]
+   (let [{:keys [program workgroup-size dtype]
+          :or {workgroup-size 256 dtype :float}} (ensure-kernel-loaded! kernel-name)
+         kh (create-kernel-fresh program kernel-name)
+         wg (long (get opts :workgroup-size workgroup-size))
+         n (long n)
+         scalar-type (if (= dtype :float) :float :double)
+         idx (atom -1)
+         next-idx! #(swap! idx inc)]
+     (doseq [arr arrays]
+       (set-kernel-arg-buffer! kh (next-idx!) (device-mem-of arr)))
+     (doseq [v scalar-args]
+       (set-kernel-arg-scalar! kh (next-idx!)
+                               (if (map? v) v
+                                   {:type scalar-type
+                                    :value (if (= scalar-type :float) (float v) (double v))})))
+     (set-kernel-arg-scalar! kh (next-idx!) {:type :int :value (int n)})
+     {:bound {:kernel kh :wg wg}
+      :group-count (long (or (get opts :group-count) (Math/ceil (/ (double n) wg))))
+      :kernel-name kernel-name
+      :async? (boolean (get opts :async?))})))
+
+(defn- enqueue-bound!
+  "Enqueue one pre-bound kernel (no finish)."
+  [{:keys [^MemorySegment kernel ^long wg]} ^long group-count]
+  (let [{:keys [queue]} @state
+        arena (Arena/ofConfined)]
+    (try
+      (let [g (.allocate ^Arena arena I64) l (.allocate ^Arena arena I64)]
+        (.set g I64 0 (* group-count wg))
+        (.set l I64 0 wg)
+        (cl-call! "clEnqueueNDRangeKernel" @h-clEnqueueNDRangeKernel
+                  [queue kernel (int 1) MemorySegment/NULL g l
+                   (int 0) MemorySegment/NULL MemorySegment/NULL]))
+      (finally (.close arena)))))
+
+(defn launch-registered-bound!
+  "Dispatch a pre-bound kernel. Synchronous."
+  [prepared]
+  (enqueue-bound! (:bound prepared) (long (:group-count prepared)))
+  (cl-call! "clFinish" @h-clFinish [(:queue @state)]))
+
+(defn record-graph!
+  "OpenCL 'graph': capture the ordered pre-bound launches for replay. The
+  in-order queue serializes them (= ze per-kernel barriers)."
+  ([prepareds] (record-graph! prepareds {}))
+  ([prepareds _opts]
+   {:launches (mapv (fn [{:keys [bound group-count]}]
+                      {:bound bound :group-count (long group-count)})
+                    prepareds)}))
+
+(defn replay-graph!
+  "Enqueue every recorded launch in order, then clFinish. Synchronous."
+  [graph]
+  (doseq [{:keys [bound group-count]} (:launches graph)]
+    (enqueue-bound! bound group-count))
+  (cl-call! "clFinish" @h-clFinish [(:queue @state)]))
+
+(defn synchronize-async!
+  "Block until all enqueued work completes."
+  []
+  (cl-call! "clFinish" @h-clFinish [(:queue @state)]))
+
+(defn destroy-prepared!
+  "Release the dedicated cl_kernel a binding owns."
+  [prepared]
+  (when-let [^MemorySegment kh (get-in prepared [:bound :kernel])]
+    (try (.invokeWithArguments ^MethodHandle @h-clReleaseKernel
+                               (into-array Object [kh]))
+         (catch Exception _))))
+
+(defn destroy-graph!
+  "OpenCL graphs hold no driver objects (the launches reference kernels owned
+  by their bindings) — nothing to free."
+  [_graph]
+  nil)
+
+(defn bind-registered-gemm!
+  "Intel-XMX fp16 GEMM is not available on generic OpenCL devices."
+  [& _]
+  (throw (ex-info "bind-registered-gemm! (XMX fp16 tile GEMM) is Level-Zero/Intel-only; generic OpenCL GEMM fallback not yet implemented" {})))
+
+(defn bind-registered-convert!
+  [& _]
+  (throw (ex-info "bind-registered-convert! (fp16 cast for XMX) is Level-Zero/Intel-only" {})))
+
+(defn bind-registered-transpose!
+  [& _]
+  (throw (ex-info "bind-registered-transpose! (XMX operand transpose) is Level-Zero/Intel-only" {})))
+
 (defn shutdown!
   "Shutdown OpenCL runtime, releasing all handles."
   []

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -1,0 +1,48 @@
+(ns raster.gpu.ocl-session-test
+  "Resident-session layer on the OpenCL backend: compile → bind-program! →
+  record → replay → download, on whatever OpenCL device is available. With
+  RASTER_OCL_DEVICE_TYPE=cpu this runs on POCL/Intel-CPU — the no-GPU
+  vendor-portability oracle (CUDA/HIP Phase A). Skips cleanly without OpenCL.
+
+  Portability lesson encoded here: kernels must not read from :output-only
+  buffers (uninitialized device memory — Intel's driver zeroes allocations,
+  POCL's malloc does not)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.pipeline :as pl]
+            [raster.arrays :as ra]
+            [raster.core :refer [deftm]]))
+
+(def ^:private ocl-available?
+  (delay (try (require 'raster.gpu.ocl-runtime)
+              ((resolve 'raster.gpu.ocl-runtime/init!))
+              true
+              (catch Throwable _ false))))
+
+(deftm ocl-session-ax! (All [T] [x :- (Array T) y :- (Array T) a :- T n :- Long] :- Void
+  (raster.par/map-void! i n (ra/aset y i (* a (ra/aget x i))))))
+
+(deftest ocl-resident-session-roundtrip
+  (if-not @ocl-available?
+    (println "SKIP ocl-session test (no OpenCL device)")
+    (let [gpu (do (require 'raster.gpu.core) (find-ns 'raster.gpu.core))
+          make-session (ns-resolve gpu 'make-session)
+          bind-program! (ns-resolve gpu 'bind-program!)
+          run-program! (ns-resolve gpu 'run-program!)
+          close-session! (ns-resolve gpu 'close-session!)
+          p (pl/compile-gpu-program #'ocl-session-ax! :ocl:0 :dtype :float)
+          n 4096
+          x (float-array (map float (range n)))
+          y (float-array n)
+          s (make-session :ocl:0)]
+      (try
+        (bind-program! s p [x y (float 2.0) n] {'x :input 'y :output})
+        (testing "replayed program computes correctly"
+          (let [r (run-program! s p [x y (float 2.0) n])
+                ^floats yg (get r 'y)]
+            (is (every? (fn [i] (< (Math/abs (- (aget yg (int i)) (* 2.0 i))) 1e-3))
+                        (range n)))))
+        (testing "replay is stable across repeated runs"
+          (let [r2 (run-program! s p [x y (float 2.0) n])
+                ^floats yg (get r2 'y)]
+            (is (< (Math/abs (- (aget yg 100) 200.0)) 1e-3))))
+        (finally (close-session! s))))))


### PR DESCRIPTION
Second slice of the CUDA/HIP plan: the 9 missing session functions ported from ze_runtime to ocl_runtime (graphs = ordered replay on the in-order queue; XMX binds throw clearly as Intel-only), plus a real bug fix — `register-gpu-kernels!` hardcoded the ze registry, leaving `:ocl` programs unbindable.

**Validated**: full `compile-gpu-program → bind-program! → record → replay → download` round-trip green on Intel Arc via OpenCL **and on POCL** — the first execution of raster GPU programs outside Intel's driver stack. The POCL run immediately caught a genuine portability class (reads from `:output`-only buffers = uninitialized device memory; Intel zeroes allocations, POCL doesn't) — now encoded in `raster.gpu.ocl-session-test`, which runs on whatever OpenCL device exists (`RASTER_OCL_DEVICE_TYPE=cpu` → POCL) and skips cleanly without one.

ze regression: GPU namespaces 37/91 green. This unlocks: local CI for kernel portability without GPUs, and the execution path for NVIDIA/AMD OpenCL ICDs (Phase B's CUDA/HIP dialect builds on the same session shape).