### PR TITLE
Emitters read stamped types (A1) + complete wasm model-kernel dialect

### DIFF
--- a/dev/wasm_dis.py
+++ b/dev/wasm_dis.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Minimal wasm disassembler for raster's emitted opcode subset — enough to see
+type-mismatch sites without wabt. Usage: python3 dev/wasm_dis.py file.wasm"""
+import sys, struct
+
+OPS = {
+ 0x00:"unreachable",0x01:"nop",0x02:"block",0x03:"loop",0x04:"if",0x05:"else",0x0b:"end",
+ 0x0c:"br",0x0d:"br_if",0x0f:"return",0x10:"call",
+ 0x20:"local.get",0x21:"local.set",0x22:"local.tee",
+ 0x28:"i32.load",0x2a:"f32.load",0x2b:"f64.load",0x2c:"i32.load8_s",0x2d:"i32.load8_u",
+ 0x2e:"i32.load16_s",0x36:"i32.store",0x38:"f32.store",0x39:"f64.store",0x3a:"i32.store8",
+ 0x41:"i32.const",0x42:"i64.const",0x43:"f32.const",0x44:"f64.const",
+ 0x45:"i32.eqz",0x46:"i32.eq",0x47:"i32.ne",0x48:"i32.lt_s",0x4a:"i32.gt_s",0x4c:"i32.le_s",0x4e:"i32.ge_s",
+ 0x5b:"f32.eq",0x5c:"f32.ne",0x5d:"f32.lt",0x5e:"f32.gt",0x5f:"f32.le",0x60:"f32.ge",
+ 0x61:"f64.eq",0x62:"f64.ne",0x63:"f64.lt",0x64:"f64.gt",0x65:"f64.le",0x66:"f64.ge",
+ 0x6a:"i32.add",0x6b:"i32.sub",0x6c:"i32.mul",0x6d:"i32.div_s",0x6f:"i32.rem_s",
+ 0x71:"i32.and",0x72:"i32.or",0x73:"i32.xor",0x74:"i32.shl",0x75:"i32.shr_s",0x76:"i32.shr_u",
+ 0x8b:"f32.abs",0x8c:"f32.neg",0x8e:"f32.ceil",0x8f:"f32.floor",0x91:"f32.sqrt",
+ 0x92:"f32.add",0x93:"f32.sub",0x94:"f32.mul",0x95:"f32.div",0x96:"f32.min",0x97:"f32.max",
+ 0x99:"f64.abs",0x9a:"f64.neg",0x9c:"f64.ceil",0x9d:"f64.floor",0x9f:"f64.sqrt",
+ 0xa0:"f64.add",0xa1:"f64.sub",0xa2:"f64.mul",0xa3:"f64.div",0xa4:"f64.min",0xa5:"f64.max",
+ 0xa7:"i32.wrap_i64",0xa8:"i32.trunc_f32_s",0xaa:"i32.trunc_f64_s",
+ 0xb2:"f32.convert_i32_s",0xb6:"f32.demote_f64",0xb7:"f64.convert_i32_s",0xbb:"f64.promote_f32",
+}
+IMM_LEB = {0x0c,0x0d,0x10,0x20,0x21,0x22,0x41,0x42}
+IMM_MEM = {0x28,0x2a,0x2b,0x2c,0x2d,0x2e,0x36,0x38,0x39,0x3a}
+IMM_BLK = {0x02,0x03,0x04}
+
+def leb(b, i, signed=False):
+    r = sh = 0
+    while True:
+        x = b[i]; i += 1
+        r |= (x & 0x7f) << sh; sh += 7
+        if not (x & 0x80):
+            if signed and (x & 0x40): r -= 1 << sh
+            return r, i
+
+def main(path):
+    b = open(path, "rb").read()
+    assert b[:4] == b"\0asm"
+    i = 8
+    while i < len(b):
+        sid = b[i]; i += 1
+        size, i = leb(b, i)
+        if sid == 10:  # code section
+            n, j = leb(b, i)
+            for f in range(n):
+                fsize, j = leb(b, j)
+                end = j + fsize
+                nloc, j = leb(b, j)
+                locs = []
+                for _ in range(nloc):
+                    cnt, j = leb(b, j); vt = b[j]; j += 1
+                    locs.append(f"{cnt}x{ {0x7f:'i32',0x7e:'i64',0x7d:'f32',0x7c:'f64'}.get(vt, hex(vt))}")
+                print(f"func[{f}] locals: {' '.join(locs)}")
+                depth = 1
+                while j < end:
+                    off = j; op = b[j]; j += 1
+                    name = OPS.get(op, f"??0x{op:02x}")
+                    imm = ""
+                    if op in IMM_LEB:
+                        v, j = leb(b, j, signed=(op in (0x41, 0x42)))
+                        imm = str(v)
+                    elif op in IMM_MEM:
+                        a, j = leb(b, j); o, j = leb(b, j)
+                        imm = f"align={a} off={o}"
+                    elif op in IMM_BLK:
+                        bt = b[j]; j += 1
+                        imm = {0x40:"void",0x7f:"i32",0x7d:"f32",0x7c:"f64"}.get(bt, hex(bt))
+                    elif op == 0x43:
+                        imm = str(struct.unpack("<f", b[j:j+4])[0]); j += 4
+                    elif op == 0x44:
+                        imm = str(struct.unpack("<d", b[j:j+8])[0]); j += 8
+                    if op in (0x05, 0x0b): depth -= 1
+                    print(f"  {off:5d} {'  '*max(depth,0)}{name} {imm}")
+                    if op in (0x02, 0x03, 0x04, 0x05): depth += 1
+            i += size
+        else:
+            i += size
+
+main(sys.argv[1])

--- a/src/raster/compiler/backend/intrinsics.clj
+++ b/src/raster/compiler/backend/intrinsics.clj
@@ -61,7 +61,7 @@
    :floor (math1 :f64.floor :f32.floor "floor")
    :ceil  {:arity 1 :kind :fn :wasm :poly :c {:fn "ceil"} :wgsl {:fn "ceil"}}   ; -floor(-x)
    :trunc {:arity 1 :kind :fn :wasm (vt3 :f64.trunc :f32.trunc nil) :c {:fn "trunc"} :wgsl {:fn "trunc"}}
-   :round {:arity 1 :kind :fn :c {:fn "round"} :wgsl {:fn "round"}}    ; returns int — no wasm
+   :round {:arity 1 :kind :fn :c {:fn "round"} :wgsl {:fn "round"} :wasm :poly} ; wasm: floor(x+0.5) poly (Java semantics)
    :neg   {:arity 1 :kind :fn :wasm (vt3 :f64.neg :f32.neg nil) :c {:prefix "-"} :wgsl {:prefix "-"}}
    ;; math — binary
    :min {:arity 2 :kind :fn :wasm (vt3 :f64.min :f32.min nil) :c {:fn "fmin" :glsl "min"} :wgsl {:fn "min"}}

--- a/src/raster/compiler/backend/wasm/emit.clj
+++ b/src/raster/compiler/backend/wasm/emit.clj
@@ -47,7 +47,7 @@
 ;; raster.compiler.backend.intrinsics — emit dispatches through ix/wasm-op.
 
 ;; ctx: {:env {sym {:idx :vt}}  :elems {sym elem-map}}
-(declare emit-val infer-vt emit-effect alloc! emit-intrinsic emit-loop ends-in-recur? emit-bindings)
+(declare emit-val infer-vt emit-effect alloc! emit-intrinsic emit-loop ends-in-recur? emit-bindings emit-operand-at)
 
 (defn- addr
   "byte address of array element: ptr + idx*elem-bytes  (i32)."
@@ -105,18 +105,28 @@
         (or (nil? c) (false? c))    :else
         :else nil))
 
+(defn- sym-vt
+  "Valtype from the walker's stamped :raster.type/tag on a binding symbol — the
+   single type source (TC-fed). nil when unstamped (pass-introduced bindings)."
+  [s]
+  (when-let [tag (:raster.type/tag (meta s))]
+    (case tag
+      double :f64  float :f32  (long int byte short char boolean) :i32
+      nil)))                                     ; array/ref tags: not a scalar local
+
 (defn- emit-bindings
-  "Lower a let* binding vector → [ctx' init-bytes]: each `[sym init]` either binds a
-   void effect form (no value — recorded as {:void true}, init emitted as an effect) or
-   allocates a typed local and emits `(local-set …)`. Shared by every position handler
-   (value / effect / then / result) so the binding lowering lives in one place."
+  "Lower a let* binding vector → [ctx' init-bytes]. The local's type comes from the
+   STAMPED symbol tag (walker/TC — the single type source); init inference is only
+   the fallback for pass-introduced unstamped bindings. Init values are coerced to
+   the local's valtype (emit-operand-at), so a widened local takes a narrower init."
   [ctx binds]
   (reduce (fn [[c acc] [s init]]
             (if (void-effect-form? init)
               [(assoc-in c [:env s] {:void true}) (into acc (emit-effect c init))]
-              (let [vt (infer-vt c init) idx (alloc! c vt)]
+              (let [vt (or (sym-vt s) (infer-vt c init))
+                    idx (alloc! c vt)]
                 [(assoc-in c [:env s] {:idx idx :vt vt})
-                 (-> acc (into (emit-val c init)) (into (e/local-set idx)))])))
+                 (-> acc (into (emit-operand-at c vt init)) (into (e/local-set idx)))])))
           [ctx []] (partition 2 binds)))
 
 (defn- emit-val
@@ -177,7 +187,8 @@
             :else (emit-val ctx e)
             (let [tv (infer-vt ctx t)
                   vt (if (= tv :i32) (infer-vt ctx e) tv)]
-              (-> (emit-val ctx c) (into (e/if-t vt (emit-val ctx t) (emit-val ctx e)))))))
+              (-> (emit-val ctx c)
+                  (into (e/if-t vt (emit-operand-at ctx vt t) (emit-operand-at ctx vt e)))))))
         ;; case* (macroexpanded) → lower to a let*+if-chain, emitted via normal path
         (= h 'case*)
         (emit-val ctx (synth-case* A))
@@ -201,7 +212,7 @@
         (= h '.invk)
         (let [tag (:raster.type/tag (meta node))
               vt  (case tag
-                    double :f64, float :f32, (long int) :i32
+                    double :f64, float :f32, (long int byte short char boolean) :i32
                     ;; No semantic tag — a devirtualization site failed to stamp it
                     ;; (the walker, inline-invk, and resolve-generic-deftm-calls all
                     ;; should). Recover the element type from the first operand
@@ -330,16 +341,26 @@
                 (-> (emit-operand-at ctx vt (first args)) (into (e/i opk))))))
       (throw (ex-info (str "intrinsic not emittable: " op) {:op op :kind (:kind d)})))))
 
+(def ^:dynamic *lenient-types?*
+  "When true, missing type info warns and defaults to i32 (the historical behavior)
+   instead of throwing. Types come from walker/TC stamps — a miss is a front-half
+   bug; bind this only to diagnose."
+  false)
+
 (defn- warn-unknown-vt
   "G1: surface a type-inference miss (mirrors the .invk loud-recovery policy) and
    default to :i32, instead of *silently* assuming i32 — a silent i32 on a float expr
    miscompiles. A warning here means a node reached the emitter without a resolvable
    type: a missing :raster.type/tag stamp, an unhandled form head, or an unbound symbol."
   [node why]
-  (binding [*out* *err*]
-    (println (str "WARNING: wasm infer-vt — no type for " why ": " (pr-str node)
-                  " → defaulting to i32 (may miscompile a float expr).")))
-  :i32)
+  (if *lenient-types?*
+    (do (binding [*out* *err*]
+          (println (str "WARNING: wasm infer-vt — no type for " why ": " (pr-str node)
+                        " → defaulting to i32 (may miscompile a float expr).")))
+        :i32)
+    (throw (ex-info (str "wasm emit: no type for " why " — a node reached the emitter "
+                         "without a resolvable :raster.type/tag (front-half stamping gap)")
+                    {:node node :why why}))))
 
 (defn- infer-vt
   "Result valtype of an expression, from env + carried :raster.type/tag. Genuinely
@@ -348,12 +369,13 @@
   (cond
     (symbol? node)  (if (contains? (:env ctx) node)
                       (get-in ctx [:env node :vt] :i32)   ; in env w/o :vt = a void binding
-                      (warn-unknown-vt node "unbound symbol"))
+                      (or (sym-vt node)                    ; stamped tag (walker/TC)
+                          (warn-unknown-vt node "unbound symbol")))
     (float? node)   :f64
     (integer? node) :i32
     (seq? node)
     (case (:raster.type/tag (meta node))
-      double :f64, float :f32, long :i32, int :i32
+      double :f64, float :f32, (long int byte short char boolean) :i32
       (let [h (first node)]
         (cond
           (and (symbol? h) (= "float" (name h)))  :f32
@@ -363,7 +385,8 @@
           ;; operand, e.g. (/ (let* …) (let* …)), must infer its tail's vt, which
           ;; may reference a binding introduced inside it).
           (#{'let* 'let} h) (let [c' (reduce (fn [c [s init]]
-                                               (assoc-in c [:env s] {:vt (infer-vt c init)}))
+                                               (assoc-in c [:env s]
+                                                         {:vt (or (sym-vt s) (infer-vt c init))}))
                                              ctx (partition 2 (second node)))]
                               (infer-vt c' (last node)))
           (= 'do h) (infer-vt ctx (last node))           ; value of tail
@@ -380,10 +403,12 @@
           (and (symbol? h) (#{"inc" "unchecked-inc-int" "unchecked-inc"
                               "dec" "unchecked-dec-int" "unchecked-dec"} (name h))) :i32
           (#{'loop 'loop*} h)                                         ; loop result = its non-recur branch
-          (let [c' (reduce (fn [c [s init]] (assoc-in c [:env s] {:vt (infer-vt c init)}))
+          (let [c' (reduce (fn [c [s init]]
+                             (assoc-in c [:env s] {:vt (or (sym-vt s) (infer-vt c init))}))
                            ctx (partition 2 (nth node 1)))  ; bind loop vars so the result ref resolves
                 ifform (nth node 2) then (nth ifform 2) els (nth ifform 3)]
             (infer-vt c' (if (ends-in-recur? then) els then)))
+          (#{'raster.par/dp4a 'par/dp4a} h) :i32       ; int8 dot-accumulate → i32
           (#{'clojure.core/aget 'raster.arrays/aget} h) (get-in ctx [:elems (second node) :vt] :f64)
           ;; registered numeric op/intrinsic: comparisons → bool (i32); arith /
           ;; math / rem-mod → element type of first operand
@@ -445,11 +470,12 @@
       :else (throw (ex-info (str "unhandled effect head " h) {:node node}))))))
 
 (defn- emit-recur
-  "(recur v0 v1 ...) → push all new values, set loop locals in REVERSE (so each
-   value is read from the OLD locals before any are overwritten), then branch to
-   the loop header at depth `loop-depth`."
-  [ctx args loop-idxs loop-depth]
-  (-> (vec (mapcat #(emit-val ctx %) args))
+  "(recur v0 v1 ...) → push all new values COERCED to their loop-var valtypes
+   (the typed slot, from the stamped loop-var tags), set loop locals in REVERSE
+   (so each value is read from the OLD locals before any are overwritten), then
+   branch to the loop header at depth `loop-depth`."
+  [ctx args loop-idxs loop-vts loop-depth]
+  (-> (vec (mapcat (fn [a vt] (emit-operand-at ctx vt a)) args loop-vts))
       (into (vec (mapcat #(e/local-set %) (reverse loop-idxs))))
       (into (e/br loop-depth))))
 
@@ -468,35 +494,33 @@
 
 (defn- emit-then
   "Emit a loop's recur-branch: effects/bindings ending in a recur, or an `if` that
-   splits into a recur side and a loop-result side (nested-loop early-exit, e.g.
-   aabb-collides?). `loop-depth` is the br target of the enclosing loop header;
-   `block-depth` is the br target of the result block (a result-producing branch
-   pushes its value then br's out). Each nested `if` adds one wasm block level, so
-   both depths increment when recursing through it."
-  [ctx node loop-idxs loop-depth block-depth]
+   splits into a recur side and a loop-result side. Recur args coerce to the
+   loop-var valtypes; a result branch coerces to the block's ret-vt (nil ret-vt =
+   void loop: result side emits as effects). `loop-depth`/`block-depth` as before;
+   both increment through each nested if."
+  [ctx node loop-idxs loop-vts ret-vt loop-depth block-depth]
   (cond
     (and (seq? node) (= 'recur (first node)))
-    (emit-recur ctx (vec (rest node)) loop-idxs loop-depth)
+    (emit-recur ctx (vec (rest node)) loop-idxs loop-vts loop-depth)
     (and (seq? node) (= 'do (first node)))
     (let [stmts (vec (rest node))]
       (-> (vec (mapcat #(emit-effect ctx %) (butlast stmts)))
-          (into (emit-then ctx (last stmts) loop-idxs loop-depth block-depth))))
-    ;; let*/let before the recur — bind locals, then recurse into the tail
+          (into (emit-then ctx (last stmts) loop-idxs loop-vts ret-vt loop-depth block-depth))))
     (and (seq? node) (#{'let* 'let} (first node)))
     (let [[binds & body] (rest node)
           [ctx' init-bytes] (emit-bindings ctx binds)
           tail (if (= 1 (count body)) (first body) (cons 'do body))]
-      (into init-bytes (emit-then ctx' tail loop-idxs loop-depth block-depth)))
-    ;; if splitting into recur side + loop-result side. Each side either continues
-    ;; the loop (recur → emit-then) or yields the loop's result (value → br to the
-    ;; result block). The if itself adds a block level → depths +1 inside it.
+      (into init-bytes (emit-then ctx' tail loop-idxs loop-vts ret-vt loop-depth block-depth)))
     (and (seq? node) (= 'if (first node)))
     (let [[_ c a b] node
           ld (inc loop-depth), bd (inc block-depth)
           branch (fn [br-node]
                    (if (ends-in-recur? br-node)
-                     (emit-then ctx br-node loop-idxs ld bd)
-                     (-> (emit-val ctx br-node) (into (e/br bd)))))]  ; loop result → leave block
+                     (emit-then ctx br-node loop-idxs loop-vts ret-vt ld bd)
+                     (-> (if (nil? ret-vt)
+                           (emit-effect ctx br-node)
+                           (emit-operand-at ctx ret-vt br-node))
+                         (into (e/br bd)))))]
       (-> (emit-val ctx c)
           (into [(e/op :if) e/empty-block])
           (into (branch a))
@@ -655,11 +679,12 @@
         ;; allocate loop-var locals; inits emitted with the OUTER env (loop vars
         ;; not yet in scope for their own inits)
         loop-vars (mapv (fn [[sym init]]
-                          (let [vt (infer-vt ctx init)]  ; 0→i32, 0.0→f64, (float 0.0)→f32
+                          ;; stamped symbol tag first (TC loop inference via walker)
+                          (let [vt (or (sym-vt sym) (infer-vt ctx init))]
                             {:sym sym :idx (alloc! ctx vt) :vt vt :init init}))
                         pairs)
-        inits (vec (mapcat (fn [{:keys [idx init]}]
-                             (into (emit-val ctx init) (e/local-set idx))) loop-vars))
+        inits (vec (mapcat (fn [{:keys [idx vt init]}]
+                             (into (emit-operand-at ctx vt init) (e/local-set idx))) loop-vars))
         ctx' (reduce (fn [c {:keys [sym idx vt]}] (assoc-in c [:env sym] {:idx idx :vt vt}))
                      ctx loop-vars)
         loop-idxs (mapv :idx loop-vars)
@@ -670,20 +695,21 @@
         recur-then? (ends-in-recur? then)
         result (if recur-then? els then)
         ret-vt (infer-vt ctx' result)
+        loop-vts (mapv :vt loop-vars)
         ;; depths from inside the if: if=0, loop=1, block=2. The result branch
-        ;; leaves its value then br 2 (out of the block); the recur branch br 1.
+        ;; leaves its value (coerced to ret-vt) then br 2; the recur branch br 1.
         if-bytes (if recur-then?
                    (-> (emit-val ctx' cnd)
                        (into [(e/op :if) e/empty-block])
-                       (into (emit-then ctx' then loop-idxs 1 2))
+                       (into (emit-then ctx' then loop-idxs loop-vts ret-vt 1 2))
                        (into [(e/op :else)])
-                       (into (emit-val ctx' els)) (into (e/br 2))
+                       (into (emit-operand-at ctx' ret-vt els)) (into (e/br 2))
                        (into [(e/op :end)]))
                    (-> (emit-val ctx' cnd)
                        (into [(e/op :if) e/empty-block])
-                       (into (emit-val ctx' then)) (into (e/br 2))
+                       (into (emit-operand-at ctx' ret-vt then)) (into (e/br 2))
                        (into [(e/op :else)])
-                       (into (emit-then ctx' els loop-idxs 1 2))
+                       (into (emit-then ctx' els loop-idxs loop-vts ret-vt 1 2))
                        (into [(e/op :end)])))]
     [(into inits (e/block-t ret-vt (into (e/loop* if-bytes) (e/i :unreachable))))
      ret-vt]))
@@ -697,11 +723,12 @@
   (let [[_ bindvec ifform] node
         pairs (vec (partition 2 bindvec))
         loop-vars (mapv (fn [[sym init]]
-                          (let [vt (infer-vt ctx init)]
+                          ;; stamped symbol tag first (TC loop inference via walker)
+                          (let [vt (or (sym-vt sym) (infer-vt ctx init))]
                             {:sym sym :idx (alloc! ctx vt) :vt vt :init init}))
                         pairs)
-        inits (vec (mapcat (fn [{:keys [idx init]}]
-                             (into (emit-val ctx init) (e/local-set idx))) loop-vars))
+        inits (vec (mapcat (fn [{:keys [idx vt init]}]
+                             (into (emit-operand-at ctx vt init) (e/local-set idx))) loop-vars))
         ctx' (reduce (fn [c {:keys [sym idx vt]}] (assoc-in c [:env sym] {:idx idx :vt vt}))
                      ctx loop-vars)
         loop-idxs (mapv :idx loop-vars)
@@ -710,11 +737,12 @@
         exit (if recur-then? els then)
         rec  (if recur-then? then els)
         exit-bytes (if (nil? exit) [] (emit-effect ctx' exit))
+        loop-vts (mapv :vt loop-vars)
         ;; depths from inside the if: if=0, loop=1, void block=2
         if-bytes (if recur-then?
                    (-> (emit-val ctx' cnd)
                        (into [(e/op :if) e/empty-block])
-                       (into (emit-then ctx' rec loop-idxs 1 2))
+                       (into (emit-then ctx' rec loop-idxs loop-vts nil 1 2))
                        (into [(e/op :else)])
                        (into exit-bytes) (into (e/br 2))
                        (into [(e/op :end)]))
@@ -722,7 +750,7 @@
                        (into [(e/op :if) e/empty-block])
                        (into exit-bytes) (into (e/br 2))
                        (into [(e/op :else)])
-                       (into (emit-then ctx' rec loop-idxs 1 2))
+                       (into (emit-then ctx' rec loop-idxs loop-vts nil 1 2))
                        (into [(e/op :end)])))]
     (into inits (e/block-v (into (e/loop* if-bytes) (e/i :unreachable))))))
 

--- a/src/raster/compiler/backend/wasm/emit.clj
+++ b/src/raster/compiler/backend/wasm/emit.clj
@@ -59,17 +59,27 @@
         (into (e/i32-const eb)) (into (e/i :i32.mul)) (into (e/i :i32.add)))))
 
 (defn- void-effect-form?
-  "A form producing no value (side-effect only): an array store (aset), dotimes/
-   when, or a do whose tail is itself a void effect. Such a form bound in a let*
-   — e.g. the inliner's (let* [_ret (dotimes …)] _ret) body-lift, or trailing
-   `(aset …)` statements lifted to `_eff_` bindings — is emitted as an effect, not
-   a value."
+  "A form producing no value (side-effect only): nil, an array store (aset),
+   dotimes/when, a statement loop ending in nil, or a do/let* whose TAIL is
+   itself void. Such a form bound in a let* — e.g. the inliner's
+   (let* [_ret (dotimes …)] _ret) body-lift, the par lowering's
+   (let* [body_result (let* [n …] (dotimes …) nil)] body_result), or trailing
+   `(aset …)` statements lifted to `_eff_` bindings — is emitted as an effect,
+   not a value."
   [node]
-  (and (seq? node)
-       (let [h (first node)]
-         (or (#{'dotimes 'when} h)
-             (and (symbol? h) (= "aset" (name h)))
-             (and (= 'do h) (void-effect-form? (last node)))))))
+  (or (nil? node)
+      (and (seq? node)
+           (let [h (first node)]
+             (or (#{'dotimes 'when} h)
+                 (and (symbol? h) (= "aset" (name h)))
+                 ;; statement loop: (loop [..] (if c <recur…> nil)) — void exit
+                 (and (#{'loop 'loop*} h)
+                      (let [[_ _ ifform] node]
+                        (and (seq? ifform) (= 'if (first ifform))
+                             (let [[_ _ t e] ifform]
+                               (or (and (ends-in-recur? t) (void-effect-form? e))
+                                   (and (ends-in-recur? e) (void-effect-form? t)))))))
+                 (and (#{'do 'let* 'let} h) (void-effect-form? (last node))))))))
 
 (defn- synth-case*
   "Lower the macroexpanded `case*` special form
@@ -143,7 +153,7 @@
               (cond-> (emit-val ctx x)
                 (= xv :f64) (into (e/i :f32.demote_f64))      ; (float <f64>) → demote
                 (= xv :i32) (into (e/i :f32.convert_i32_s)))))) ; (float <i32>) → convert
-        (= h 'clojure.core/aget)
+        (#{'clojure.core/aget 'raster.arrays/aget} h)
         (let [[arr idx] A elem (get-in ctx [:elems arr])]
           (into (addr ctx arr idx) (e/mem-load (:load elem) (:align elem) 0)))
         ;; integer step (inc/dec, incl. unchecked-*-int) — index/counter steppers
@@ -205,6 +215,26 @@
                                       " from its operand. A devirtualization site didn't stamp it.")))
                       v))]
           (emit-intrinsic ctx (:raster.op/original (meta node)) (drop 1 A) vt))
+        ;; par/dp4a — 4-way signed-int8 dot + accumulate: the ONE quantization
+        ;; primitive, spelled per backend (CUDA __dp4a / AMD sdot4 / OpenCL helper /
+        ;; CPU-C dpbusd). Wasm Tier-1 scalar: extract sign-extended bytes by
+        ;; shl/shr_s pairs, 4 muls, chained adds onto acc. (Tier-2 SIMD via the
+        ;; existing i32x4.dot int8-dot loop plan when the enclosing loop matches.)
+        (or (= h 'raster.par/dp4a) (= h 'par/dp4a))
+        (let [[a b acc] A
+              la (alloc! ctx :i32) lb (alloc! ctx :i32)
+              lane (fn [l k]                               ; sign-extended byte k
+                     (let [sh (- 24 (* 8 k))]
+                       (cond-> (e/local-get l)
+                         (pos? sh) (-> (into (e/i32-const sh)) (into (e/i :i32.shl)))
+                         true      (-> (into (e/i32-const 24)) (into (e/i :i32.shr_s))))))]
+          (-> (emit-val ctx a) (into (e/local-set la))
+              (into (emit-val ctx b)) (into (e/local-set lb))
+              (into (emit-val ctx acc))
+              (into (vec (mapcat (fn [k]
+                                   (-> (lane la k) (into (lane lb k))
+                                       (into (e/i :i32.mul)) (into (e/i :i32.add))))
+                                 (range 4))))))
         ;; any registered numeric op / intrinsic (arith, comparison, rem/mod,
         ;; Math, min/max) — dispatched through backend.intrinsics (single table).
         (and (symbol? h) (ix/canonical h))
@@ -218,6 +248,7 @@
         (= h 'do)
         (into (vec (mapcat #(emit-effect ctx %) (butlast A))) (emit-val ctx (last A)))
         :else (throw (ex-info (str "unhandled value head " h) {:node node}))))
+    (nil? node) []                                  ; void leaf (statement-loop exit, if-void arm)
     :else (throw (ex-info (str "unhandled value node " (pr-str node)) {}))))
 
 (defn- emit-rem-mod
@@ -353,24 +384,40 @@
                            ctx (partition 2 (nth node 1)))  ; bind loop vars so the result ref resolves
                 ifform (nth node 2) then (nth ifform 2) els (nth ifform 3)]
             (infer-vt c' (if (ends-in-recur? then) els then)))
-          (= 'clojure.core/aget h)  (get-in ctx [:elems (second node) :vt] :f64)
+          (#{'clojure.core/aget 'raster.arrays/aget} h) (get-in ctx [:elems (second node) :vt] :f64)
           ;; registered numeric op/intrinsic: comparisons → bool (i32); arith /
           ;; math / rem-mod → element type of first operand
           (ix/canonical h) (if (= :cmp (ix/kind h)) :i32 (infer-vt ctx (second node)))
           :else (warn-unknown-vt node (str "unhandled head " h)))))
     :else (warn-unknown-vt node "non-expression node")))
 
-(declare emit-dotimes emit-dotimes-scalar)
+(declare emit-dotimes emit-dotimes-scalar emit-loop-void)
 
 (defn- emit-effect
   "Side-effecting statement that leaves nothing on the stack (aset / when / do /
    let* / dotimes)."
   [ctx node]
+  (if (nil? node)
+    []                                              ; statement nil (void tails)
   (let [h (first node), A (vec (rest node))]
     (cond
-      (= h 'clojure.core/aset)
+      ;; devirtualized statement call: recover the semantic op and re-dispatch
+      ;; (raster.arrays/aset is a deftm — it can arrive as (.invk impl arr i v))
+      (and (= h '.invk) (:raster.op/original (meta node)))
+      (emit-effect ctx (with-meta (cons (:raster.op/original (meta node)) (rest A))
+                                  (meta node)))
+      (#{'clojure.core/aset 'raster.arrays/aset} h)
       (let [[arr idx v] A elem (get-in ctx [:elems arr])]
-        (-> (addr ctx arr idx) (into (emit-val ctx v)) (into (e/mem-store (:store elem) (:align elem) 0))))
+        (when-not elem
+          (throw (ex-info (str "aset target " arr " has no element info (not an array param?)")
+                          {:arr arr :node node})))
+        ;; the store's element type is ground truth — coerce the value like an
+        ;; intrinsic operand (kernels' explicit (float ...) casts make this a
+        ;; no-op; a mixed-width expression gets the correct convert instead of
+        ;; a validation failure)
+        (-> (addr ctx arr idx)
+            (into (emit-operand-at ctx (:vt elem) v))
+            (into (e/mem-store (:store elem) (:align elem) 0))))
       (= h 'do) (vec (mapcat #(emit-effect ctx %) A))
       ;; let* in effect position (e.g. soa-lower floats arg bindings out of a
       ;; store: (let* [args…] (do (aset …) …))). Bind locals, emit body as effects.
@@ -391,7 +438,11 @@
       (= h 'case*) (emit-effect ctx (synth-case* A))
       (= h 'throw) (e/i :unreachable)               ; exhaustive-case default
       (= h 'dotimes) (emit-dotimes ctx node)
-      :else (throw (ex-info (str "unhandled effect head " h) {:node node})))))
+      (= h 'when) (emit-effect ctx (list 'if (second node) (list* 'do (drop 2 node))))
+      ;; statement-position loop (model kernels: packing/softmax inner loops that
+      ;; end in nil) — the value-loop emission with a void exit branch.
+      (#{'loop 'loop*} h) (emit-loop-void ctx node)
+      :else (throw (ex-info (str "unhandled effect head " h) {:node node}))))))
 
 (defn- emit-recur
   "(recur v0 v1 ...) → push all new values, set loop locals in REVERSE (so each
@@ -636,6 +687,44 @@
                        (into [(e/op :end)])))]
     [(into inits (e/block-t ret-vt (into (e/loop* if-bytes) (e/i :unreachable))))
      ret-vt]))
+
+(defn- emit-loop-void
+  "(loop [v init ...] (if cond <recur-branch> <exit>)) in STATEMENT position —
+   the exit branch is effects/nil, the block carries no result. Model kernels'
+   packing/softmax inner loops end in nil; rms/softmax normalize loops end in a
+   final effect."
+  [ctx node]
+  (let [[_ bindvec ifform] node
+        pairs (vec (partition 2 bindvec))
+        loop-vars (mapv (fn [[sym init]]
+                          (let [vt (infer-vt ctx init)]
+                            {:sym sym :idx (alloc! ctx vt) :vt vt :init init}))
+                        pairs)
+        inits (vec (mapcat (fn [{:keys [idx init]}]
+                             (into (emit-val ctx init) (e/local-set idx))) loop-vars))
+        ctx' (reduce (fn [c {:keys [sym idx vt]}] (assoc-in c [:env sym] {:idx idx :vt vt}))
+                     ctx loop-vars)
+        loop-idxs (mapv :idx loop-vars)
+        [_ cnd then els] ifform
+        recur-then? (ends-in-recur? then)
+        exit (if recur-then? els then)
+        rec  (if recur-then? then els)
+        exit-bytes (if (nil? exit) [] (emit-effect ctx' exit))
+        ;; depths from inside the if: if=0, loop=1, void block=2
+        if-bytes (if recur-then?
+                   (-> (emit-val ctx' cnd)
+                       (into [(e/op :if) e/empty-block])
+                       (into (emit-then ctx' rec loop-idxs 1 2))
+                       (into [(e/op :else)])
+                       (into exit-bytes) (into (e/br 2))
+                       (into [(e/op :end)]))
+                   (-> (emit-val ctx' cnd)
+                       (into [(e/op :if) e/empty-block])
+                       (into exit-bytes) (into (e/br 2))
+                       (into [(e/op :else)])
+                       (into (emit-then ctx' rec loop-idxs 1 2))
+                       (into [(e/op :end)])))]
+    (into inits (e/block-v (into (e/loop* if-bytes) (e/i :unreachable))))))
 
 ;; ─────────────────────────────────────────────────────────────────────────
 ;; SIMD128 vectorization of elementwise dotimes-maps (opt-in via ctx :simd?).

--- a/src/raster/compiler/backend/wasm/emit.clj
+++ b/src/raster/compiler/backend/wasm/emit.clj
@@ -199,6 +199,16 @@
         ;; — emit-loop already yields a value-producing block(result vt); take bytes.
         (#{'loop 'loop*} h)
         (first (emit-loop ctx node))
+        ;; array access .invk (aget is a deftm and may arrive devirtualized OR
+        ;; survive as an un-inlined callee) — ALWAYS emit through the elems
+        ;; machinery: outlining it as a sibling function loses the per-array
+        ;; element type (the callee monomorphizes under the CALLER's dtype and
+        ;; e.g. f32-loads an int array — seen in qgemm's int-aget helper).
+        (and (= h '.invk)
+             (let [op (:raster.op/original (meta node))]
+               (contains? #{'raster.arrays/aget 'clojure.core/aget} op)))
+        (emit-val ctx (with-meta (cons (:raster.op/original (meta node)) (rest A))
+                                 (meta node)))
         ;; non-intrinsic deftm callee kept as a real wasm function (not inlined):
         ;; push args, then `call` its function index. Intrinsics (raster.numeric,
         ;; Math, …) fall through to inline emission below.
@@ -289,6 +299,7 @@
         b  (emit-val ctx node)]
     (cond
       (= nv vt) b
+      (= nv :diverge) b                       ; throw/unreachable: value never flows
       (and (= vt :f64) (= nv :i32)) (into b (e/i :f64.convert_i32_s))
       (and (= vt :f32) (= nv :i32)) (into b (e/i :f32.convert_i32_s))
       (and (= vt :f64) (= nv :f32)) (into b (e/i :f64.promote_f32))
@@ -327,11 +338,15 @@
                          (emit-operand-at ctx vt (first args)) (rest args))))
       :fn (if (ix/wasm-poly? k)
             ;; transcendental → inline polynomial form, emitted via the normal path.
-            ;; f32: compute in f64 (promote args) and demote the result.
-            (let [vt (or vt-hint (infer-vt ctx (first args)))]
+            ;; Args are ALWAYS cast-wrapped to f64 so the synthetic form is
+            ;; homogeneous by construction — a raw f32 arg inside an f64 poly
+            ;; otherwise makes individual ops pick f32 (first-operand rule) while
+            ;; the caller believes f64 (mixed-width miscompile). f32 result demotes.
+            (let [vt (or vt-hint (infer-vt ctx (first args)))
+                  form (tr/form k (map #(list 'double %) args))]
               (if (= vt :f32)
-                (emit-val ctx (list 'float (tr/form k (map #(list 'double %) args))))
-                (emit-val ctx (tr/form k args))))
+                (emit-val ctx (list 'float form))
+                (emit-val ctx form)))
             (let [vt (or vt-hint (infer-vt ctx (first args)))
                   opk (or (ix/wasm-op k vt)
                           (throw (ex-info (str "no wasm lowering for intrinsic " k " @ " vt
@@ -363,8 +378,16 @@
                     {:node node :why why}))))
 
 (defn- infer-vt
-  "Result valtype of an expression, from env + carried :raster.type/tag. Genuinely
-   undeterminable types warn (warn-unknown-vt) rather than silently defaulting to i32."
+  "node-vt: the TOTAL type reader (never an inferrer). Sources, in order:
+   stamped :raster.type/tag (walker/TC — symbols and forms), a literal's Clojure
+   class (0.5 IS a double; retyping a literal is the narrowing pass's job via
+   cast-wrapping), the binding env, and a CLOSED set of dialect rules for the
+   untagged heads the lowered dialect defines (clojure.core index arith → i32,
+   comparisons/predicates → i32, casts, aget element types, dp4a → i32,
+   control forms = their tail, synthetic math forms = their first operand —
+   homogeneous by construction). Anything else THROWS (front-half stamping gap);
+   bind *lenient-types?* only to diagnose. Emission emits exactly this type and
+   consumers coerce at typed slots — prediction ≡ lookup, divergence impossible."
   [ctx node]
   (cond
     (symbol? node)  (if (contains? (:env ctx) node)
@@ -408,6 +431,7 @@
                            ctx (partition 2 (nth node 1)))  ; bind loop vars so the result ref resolves
                 ifform (nth node 2) then (nth ifform 2) els (nth ifform 3)]
             (infer-vt c' (if (ends-in-recur? then) els then)))
+          (= 'throw h) :diverge                        ; never produces a value
           (#{'raster.par/dp4a 'par/dp4a} h) :i32       ; int8 dot-accumulate → i32
           (#{'clojure.core/aget 'raster.arrays/aget} h) (get-in ctx [:elems (second node) :vt] :f64)
           ;; registered numeric op/intrinsic: comparisons → bool (i32); arith /

--- a/src/raster/compiler/backend/wasm/encoder.clj
+++ b/src/raster/compiler/backend/wasm/encoder.clj
@@ -130,6 +130,7 @@
 (defn loop*  [body] (into (into [(op :loop)  empty-block] body) [(op :end)]))
 ;; block whose result is a single value of valtype vt-kw
 (defn block-t [vt-kw body] (into (into [(op :block) (valtype vt-kw)] body) [(op :end)]))
+(defn block-v [body] (into (into [(op :block) empty-block] body) [(op :end)]))
 ;; value-position if: cond already on stack → if(result vt){then}else{else}
 (defn if-t [vt-kw then-bytes else-bytes]
   (-> [(op :if) (valtype vt-kw)] (into then-bytes) (into [(op :else)]) (into else-bytes) (into [(op :end)])))

--- a/src/raster/compiler/backend/wasm/transcendental.clj
+++ b/src/raster/compiler/backend/wasm/transcendental.clj
@@ -133,6 +133,9 @@
       :rad2deg (list '* a RAD2DEG)
       :clamp (list 'min (list 'max a b) (nth args 2))
       :ceil (neg (list 'floor (neg a)))
+      ;; Java Math/round semantics: floor(x + 0.5) — NOT wasm f64.nearest
+      ;; (round-half-even), which would diverge from the JVM reference at .5
+      :round (list 'floor (list '+ a 0.5))
       :signum (list 'let* ['tr-gx a]
                     (list 'if (list '> 'tr-gx 0.0) 1.0 (list 'if (list '< 'tr-gx 0.0) -1.0 0.0)))
       :copysign (list 'let* ['tr-cax (list 'abs a)] (list 'if (list '< b 0.0) (neg 'tr-cax) 'tr-cax))

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -401,8 +401,15 @@
       ;; Propagates the return type from impl-sym metadata onto the call form,
       ;; so downstream passes and GPU codegen can query (:raster.type/tag (meta expr)).
       ;; Stripped before reify emission in ftm to avoid 64KB bytecode limit.
+      ;; Re-derive even when a tag is already present: on the specialization
+      ;; REWALK, forms arrive carrying the GENERIC phase's tags (e.g. a loop
+      ;; form tagged double whose accumulator was narrowed to float) — a
+      ;; preserved stale tag diverges from the re-stamped binding symbols and
+      ;; miscompiles any backend that trusts form tags. Each arm below only
+      ;; overwrites when it can derive a value; underivable forms keep their
+      ;; existing tag (par-form out-tags etc. are stamped by their own handlers
+      ;; and don't match these heads).
       (if (and (seq? result)
-               (not (:raster.type/tag (meta result)))
                (instance? clojure.lang.IObj result))
         (let [head (first result)
               type-env (:type-env ctx)

--- a/test/raster/compiler/backend/wasm/model_kernels_test.clj
+++ b/test/raster/compiler/backend/wasm/model_kernels_test.clj
@@ -1,0 +1,152 @@
+(ns raster.compiler.backend.wasm.model-kernels-test
+  "Differential execution tests for the model-kernel wasm dialect: real
+   transformer kernels (raster.dl.nn / attention / quant) compiled to wasm at
+   :dtype :float, executed via Chicory, compared against the SAME deftm run on
+   the JVM. This is the correctness oracle behind the compile+validate smoke —
+   wasm validation proves type-soundness, these prove value-equality.
+
+   Also pins the regressions found while building the dialect:
+   - stale form tags after :float specialization (walker re-derive fix)
+   - .invk aget/aset must emit inline via elems (outlined callees monomorphize
+     under the CALLER's dtype and e.g. f32-load an int array)
+   - par/dp4a scalar lowering semantics (packed signed bytes, little-endian)"
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.pipeline :as pl]
+            [raster.core :refer [deftm]]
+            [raster.arrays :as ra]
+            [raster.dl.nn :as nn])
+  (:import [com.dylibso.chicory.wasm Parser]
+           [com.dylibso.chicory.runtime Instance]))
+
+(defn- instantiate ^Instance [^bytes wasm]
+  (-> (Instance/builder (Parser/parse wasm)) (.build)))
+
+(defn- compile-f32 [v nm]
+  (pl/compile-wasm v :name nm :dtype :float))
+
+(defn- write-f32s! [mem base ^floats xs]
+  (dotimes [i (alength xs)] (.writeF32 mem (+ base (* 4 i)) (aget xs i))))
+
+(defn- read-f32s ^floats [mem base n]
+  (let [out (float-array n)]
+    (dotimes [i n] (aset out i (.readFloat mem (+ base (* 4 i)))))
+    out))
+
+(defn- max-abs-err ^double [^floats a ^floats b]
+  (reduce (fn [mx i] (max (double mx)
+                          (Math/abs (- (double (aget a i)) (double (aget b i))))))
+          0.0 (range (alength a))))
+
+(defn- randf ^floats [n seed]
+  (let [r (java.util.Random. (long seed)) out (float-array n)]
+    (dotimes [i n] (aset out i (float (- (.nextDouble r) 0.5))))
+    out))
+
+;; Hand-rolled Clojure references — an oracle EXTERNAL to raster dispatch,
+;; mirroring the deftm bodies' f32 store discipline (float cast per store).
+
+(defn- ref-residual-add ^floats [^floats a ^floats b n]
+  (let [out (float-array n)]
+    (dotimes [i n] (aset out i (float (+ (aget a i) (aget b i)))))
+    out))
+
+(defn- ref-gelu-mul ^floats [^floats gate ^floats up n]
+  (let [out (float-array n)]
+    (dotimes [i n]
+      (let [g (double (aget gate i))]
+        (aset out i (float (* (* 0.5 g (+ 1.0 (Math/tanh (* 0.7978845608028654
+                                                            (+ g (* 0.044715 g g g))))))
+                              (aget up i))))))
+    out))
+
+(defn- ref-rms-norm ^floats [^floats x ^floats w rows features eps gain]
+  (let [out (float-array (* rows features))]
+    (dotimes [r rows]
+      (let [off (* r features)
+            ms (/ (reduce (fn [s i] (let [v (double (aget x (+ off i)))] (+ s (* v v))))
+                          0.0 (range features))
+                  (double features))
+            inv (/ 1.0 (Math/sqrt (+ ms (double eps))))]
+        (dotimes [i features]
+          (aset out (+ off i)
+                (float (* (aget x (+ off i)) inv (+ (double gain) (aget w i))))))))
+    out))
+
+(deftest residual-add-differential
+  (testing "residual-add! wasm f32 == JVM deftm"
+    (let [n 257                                   ; non-power-of-2 on purpose
+          a (randf n 1) b (randf n 2)
+          jvm (ref-residual-add a b n)
+          m (compile-f32 #'nn/residual-add! "residual_add")
+          inst (instantiate (byte-array (:bytes m)))
+          mem (.memory inst)
+          [pa pb po] [0 (* 4 n) (* 8 n)]]
+      (write-f32s! mem pa a) (write-f32s! mem pb b)
+      (.apply (.export inst "residual_add") (long-array [pa pb po n]))
+      (is (zero? (max-abs-err jvm (read-f32s mem po n)))
+          "elementwise add must be bit-identical"))))
+
+(deftest gelu-mul-differential
+  (testing "gelu-mul! wasm f32 == JVM deftm (tanh-approx transcendental path)"
+    (let [n 128
+          gate (randf n 3) up (randf n 4)
+          jvm (ref-gelu-mul gate up n)
+          m (compile-f32 #'nn/gelu-mul! "gelu_mul")
+          inst (instantiate (byte-array (:bytes m)))
+          mem (.memory inst)
+          [pg pu po] [0 (* 4 n) (* 8 n)]]
+      (write-f32s! mem pg gate) (write-f32s! mem pu up)
+      (.apply (.export inst "gelu_mul") (long-array [pg pu po n]))
+      ;; wasm tanh is the emitter's f64 polynomial; JVM uses Math/tanh — allow
+      ;; polynomial-approximation error, not structural error
+      (let [err (max-abs-err jvm (read-f32s mem po n))]
+        (is (< err 1e-5) (str "gelu max-err=" err))))))
+
+(deftest rms-norm-differential
+  (testing "rms-norm! wasm f32 == JVM deftm (reduce loop + rsqrt over rows)"
+    (let [rows 4 features 64 n (* rows features)
+          x (randf n 5) w (randf features 6)
+          eps 1e-6 gain 0.0
+          jvm (ref-rms-norm x w rows features eps gain)
+          m (compile-f32 #'nn/rms-norm! "rms_norm")
+          inst (instantiate (byte-array (:bytes m)))
+          mem (.memory inst)
+          [px pw po] [0 (* 4 n) (* 4 (+ n features))]]
+      (write-f32s! mem px x) (write-f32s! mem pw w)
+      (.apply (.export inst "rms_norm")
+              (long-array [px pw po rows features
+                           (Double/doubleToRawLongBits eps)
+                           (Double/doubleToRawLongBits gain)]))
+      (let [err (max-abs-err jvm (read-f32s mem po n))]
+        (is (< err 1e-5) (str "rms-norm max-err=" err))))))
+
+;; --- dp4a semantics: packed signed bytes, little-endian, 32-bit accumulate ---
+
+(deftm dp4a-rows-k! [xp :- (Array int) yo :- (Array int) n :- Long] :- Void
+  (raster.par/map-void! i n
+    (ra/aset yo i
+             (loop [k 0 d 0]
+               (if (< k 2)
+                 (recur (inc k) (raster.par/dp4a (ra/aget xp (+ (* i 2) k))
+                                                 (ra/aget xp (+ (* i 2) k))
+                                                 d))
+                 d)))))
+
+(deftest dp4a-scalar-lowering-differential
+  (testing "par/dp4a wasm scalar lowering == JVM reference (self dot = Σ byte²)"
+    (let [n 3
+          ;; rows of 2 ints, each packing 4 signed bytes little-endian
+          packs (int-array [(unchecked-int 0x01020304) (unchecked-int 0xFF7F8001)
+                            (unchecked-int 0x00000000) (unchecked-int 0x7F7F7F7F)
+                            (unchecked-int 0xDEADBEEF) (unchecked-int 0x11223344)])
+          jvm (int-array n)
+          _ (dp4a-rows-k! packs jvm n)
+          m (pl/compile-wasm #'dp4a-rows-k! :name "dp4a_rows" :dtype :float)
+          inst (instantiate (byte-array (:bytes m)))
+          mem (.memory inst)
+          [pp py] [0 (* 4 (alength packs))]]
+      (dotimes [i (alength packs)] (.writeI32 mem (+ pp (* 4 i)) (aget packs i)))
+      (.apply (.export inst "dp4a_rows") (long-array [pp py n]))
+      (dotimes [i n]
+        (is (= (aget jvm i) (.readInt mem (+ py (* 4 i))))
+            (str "dp4a row " i " diverges from JVM reference"))))))


### PR DESCRIPTION
## What

Two things that turned out to be one thing:

1. **A1 of the emitter-consolidation agenda**: emitters consume the walker/TC type stamps instead of running shadow type inference. The wasm emitter's \`infer-vt\` is now a **total type reader** — stamped tag | literal's Clojure class | binding env | a closed set of dialect rules (clojure.core index arith → i32, comparisons → i32, casts, aget element types, dp4a → i32, control forms = their tail). Missing type = **throw** (front-half stamping gap), replacing the silent default-to-i32.

2. **The wasm model-kernel dialect** (#62 adjacent): all 10 real model kernels — S3 quant (quant-act-i8, int8 GEMM), Q4K dp4a GEMV, prefill attention (scores/softmax/out/rope), gelu/rms-norm/residual — now compile + validate, with **differential execution tests vs hand-rolled external oracles** (residual bit-identical, dp4a value-exact on adversarial packed bytes like 0xDEADBEEF/0x8001).

## Compiler bugs the discipline surfaced (the payoff)

- **Stale form tags after dtype specialization** (walker): form result tags were only stamped when absent, so the :float rewalk preserved generic-phase \`double\` tags on \`loop*\`/\`if\`/\`let*\` forms while re-stamping their binding symbols \`float\`. Every backend that trusts form tags was exposed. Now derived tags are authoritative.
- **Outlined array-access callees monomorphize under the caller's dtype**: un-inlined \`aget\` deftm callees became sibling wasm functions that \`f32.load\`-ed int arrays. \`.invk\` aget/aset now always emits inline via the per-array element machinery. (The general callee-dtype issue for genuine callees is recorded in \`.internal/emitter_review/\`.)

## Also in here

- Typed-slot coercion made systematic (recur args, loop results, if-arms, inits, stores — one mechanism)
- Java-semantics \`Math/round\` lowering (floor(x+0.5), NOT wasm's round-half-even \`f64.nearest\` — quantizers do a round per weight)
- par/dp4a Tier-1 scalar lowering — the 4th backend spelling of the one int8-MAC primitive
- \`dev/wasm_dis.py\` — minimal wasm disassembler (cracked both bugs)
- OCL session-layer groundwork from earlier in the branch

## Validation

- Full Valhalla suite: **1721 tests / 28743 assertions / 0 failures / 0 errors**
- wasm namespaces: 34 tests / 235 assertions green (incl. 4 new differential tests)

Follow-ups tracked: A2 (emitter dedup via form classifier + intrinsics registry, dp4a as descriptor data), A3 (backend dialect contracts), TC June class-widening cherry-pick queued for the upstream PR series.