### PR TITLE
A2: registry convergence, semantics decision table, emitter drift guards

### DIFF
--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -196,10 +196,11 @@
          'round "round"
          'fma   "fma"
    ;; int8 4-way dot-accumulate → portable OpenCL/C helper (pattern-matched to
-   ;; a hardware dp4a). All call spellings that can survive into a par/deftm body.
-         'dp4a            "rstr_dp4a"
-         'par/dp4a        "rstr_dp4a"
-         'raster.par/dp4a "rstr_dp4a"}]
+   ;; a hardware dp4a). Spelling sourced from the intrinsics registry (:dp4a
+   ;; canonical entry) — CUDA/HIP spellings will be sibling rows there, not here.
+         'dp4a            (get-in intrinsics/table [:dp4a :c :fn])
+         'par/dp4a        (get-in intrinsics/table [:dp4a :c :fn])
+         'raster.par/dp4a (get-in intrinsics/table [:dp4a :c :fn])}]
     ;; auto-alias java.lang.Math/X -> the short Math/X entry (the inliner emits
     ;; fully-qualified Java method symbols; both must lower the same).
     (merge base
@@ -339,6 +340,22 @@
      clojure.core/bit-shift-left clojure.core/bit-shift-right
      clojure.core/unsigned-bit-shift-right})
 
+(def ^:private scalar-default-seen (atom #{}))
+
+(defn- warn-scalar-default!
+  "A2 instrumentation: infer-c-type fell through to *scalar-type* — the silent
+   default that miscompiles when the expression isn't actually the kernel element
+   type. Warn ONCE per distinct head so hot compile paths don't flood stderr.
+   Goal: zero warnings across the suite, then this default becomes a throw
+   (same fail-loud policy as the wasm emitter's *lenient-types?*)."
+  [expr]
+  (let [k (if (seq? expr) (first expr) (class expr))]
+    (when-not (contains? @scalar-default-seen k)
+      (swap! scalar-default-seen conj k)
+      (binding [*out* *err*]
+        (println (str "WARNING: infer-c-type scalar-type default for head " (pr-str k)
+                      " — expr: " (pr-str (if (seq? expr) (take 4 expr) expr))))))))
+
 (defn infer-c-type
   "Infer the C type of an expression. Prefers the walker-stamped :raster.type/tag
   result-type metadata (the single source of truth — no mangled-name parsing); falls
@@ -418,7 +435,7 @@
      (let [types (map infer-c-type (rest expr))]
        (if (some #(= "long" %) types) "long" "int"))
 
-     :else *scalar-type*)))
+     :else (do (warn-scalar-default! expr) *scalar-type*))))
 
 ;; ================================================================
 ;; Side effect detection

--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -208,6 +208,23 @@
                           :when (and (qualified-symbol? k) (= "Math" (namespace k)))]
                       [(symbol "java.lang.Math" (name k)) v])))))
 
+;; A2 drift guard: op-map is a PARALLEL table to backend.intrinsics (the full
+;; fold — per-dialect :c facets — is the D4 end state, tracked in
+;; .internal/emitter_review/). Until then: for the unambiguous infix/cmp/bitwise
+;; subset, the two tables must agree at load time. Fn-style ops (fabs vs abs,
+;; fmax vs max) are per-backend override territory and excluded.
+(let [checkable (fn [k] (and (string? (get op-map k))
+                             (re-matches #"[+\-*/%<>=!&|^]+" (get op-map k))))]
+  (doseq [k (keys op-map)
+          :when (checkable k)
+          :let [canon (intrinsics/canonical k)
+                ix-c  (when canon (get-in intrinsics/table [canon :c]))]
+          :when (string? ix-c)]
+    (when (not= ix-c (get op-map k))
+      (throw (ex-info (str "c_emit op-map drifted from intrinsics for " k
+                           ": op-map=" (get op-map k) " intrinsics=" ix-c)
+                      {:op k})))))
+
 ;; ================================================================
 ;; Devirtualized arithmetic → C operator/function mapping
 ;; ================================================================

--- a/src/raster/compiler/backend/gpu/par_opencl.clj
+++ b/src/raster/compiler/backend/gpu/par_opencl.clj
@@ -10,7 +10,8 @@
   Usage:
     (opencl-pass form :device-id :ze:0)
     ;; Returns {:form new-form :stats {...} :kernels [...]}"
-  (:require [raster.compiler.ir.par :as par]
+  (:require [raster.compiler.backend.intrinsics :as intrinsics]
+            [raster.compiler.ir.par :as par]
             [raster.runtime.hardware :as hw]
             [raster.compiler.backend.gpu.opencl-codegen :as codegen]
             [raster.compiler.backend.gpu.c-emit :as ce]
@@ -37,15 +38,9 @@
 }\n")
 
 (def ^:private rstr-dp4a-helper
-  "Portable int8 4-way dot-accumulate. `as_char4` reinterprets each int32's 4 bytes
-  (little-endian: .x = low byte) as signed int8 lanes; the OpenCL compiler (Intel IGC,
-  NVIDIA, AMD) pattern-matches this idiom to a hardware dp4a instruction."
-  "inline int rstr_dp4a(int a, int b, int acc) {
-    char4 va = as_char4(a);
-    char4 vb = as_char4(b);
-    return acc + (int)va.x*(int)vb.x + (int)va.y*(int)vb.y
-               + (int)va.z*(int)vb.z + (int)va.w*(int)vb.w;
-}\n")
+  "Portable int8 4-way dot-accumulate helper SOURCE — canonical home is the
+   intrinsics registry (:dp4a :c-helper-src); this def just reads it."
+  (:c-helper-src (intrinsics/descriptor 'dp4a)))
 
 (defn- body-uses-dp4a?
   "True if the kernel body calls the dp4a int8-dot primitive (any spelling)."

--- a/src/raster/compiler/backend/gpu/wgsl.clj
+++ b/src/raster/compiler/backend/gpu/wgsl.clj
@@ -14,7 +14,8 @@
    (inc i))) els)) shape the passes lower dotimes into, and the bare dotimes SoA
    shape) — one or more `(aset arr i pure)` stores whose value is aget@i / arith
    / Math / scalar. Reductions + i32 fixed-point atomic scatter are a follow-on."
-  (:require [raster.compiler.backend.intrinsics :as ix]
+  (:require [raster.compiler.ir.form :as form]
+            [raster.compiler.backend.intrinsics :as ix]
             [clojure.string :as str]))
 
 ;; ---------------------------------------------------------------------------
@@ -38,14 +39,14 @@
       (some find-counted-loop (drop 2 f))
       (and (seq? f) (= 'do (first f)))
       (some find-counted-loop (rest f))
-      (and (seq? f) (#{'loop 'loop* 'dotimes} (first f))) f
+      (and (seq? f) ((some-fn form/loop-head? #{'dotimes}) (first f))) f
       :else nil)))
 
 (defn- store? [x]
   (and (seq? x) (= 'clojure.core/aset (first x)) (= 4 (count x))))
 
 (defn- flatten-body [forms]
-  (mapcat (fn f [x] (if (and (seq? x) (#{'do 'let*} (first x)))
+  (mapcat (fn f [x] (if (and (seq? x) ((some-fn #{'do} form/let-head?) (first x)))
                       (mapcat f (if (= 'let* (first x)) (drop 2 x) (rest x))) [x]))
           forms))
 

--- a/src/raster/compiler/backend/intrinsics.clj
+++ b/src/raster/compiler/backend/intrinsics.clj
@@ -31,6 +31,29 @@
 (defn- vt3 [f64 f32 i32] (cond-> {} f64 (assoc :f64 f64) f32 (assoc :f32 f32) i32 (assoc :i32 i32)))
 (defn- math1 [f64 f32 cfn] {:arity 1 :kind :fn :wasm (vt3 f64 f32 nil) :c {:fn cfn} :wgsl {:fn cfn}})
 
+;; ---------------------------------------------------------------------------
+;; CROSS-BACKEND SEMANTICS DECISION TABLE (A2)
+;; Where backends could diverge on the same op, the CHOICE is recorded here —
+;; an emitter deviating from this table is a bug, not a preference.
+;;
+;; :round  Java semantics — floor(x+0.5) — everywhere possible. wasm lowers as
+;;         the floor(x+0.5) polynomial (NOT f64.nearest: round-half-EVEN).
+;;         KNOWN DEVIATION: the C backends emit native round() =
+;;         round-half-AWAY-from-zero, which differs from Java at NEGATIVE .5
+;;         ties (C round(-2.5) = -3, Java = -2). Exact half-ties are
+;;         measure-zero on real data; accepted for GPU speed. Fixing = emit
+;;         floor(x+0.5) in C too.
+;; :mod    floored (Julia/Clojure mod). C/WGSL lower via the :floored-mod
+;;         strategy; wasm computes a-floor(a/b)*b; JVM uses clojure.core/mod.
+;; :rem    truncated (C %, JVM rem, wasm i32.rem_s) — all agree natively.
+;; :i64    wasm v1 treats long/int scalars as i32 (loads reject 'longs arrays);
+;;         JVM keeps true :long; C widens integer arith to long. A kernel whose
+;;         values exceed i32 range is NOT portable to wasm — the emitter's
+;;         reject-guards are the enforcement.
+;; :div    integer division truncates toward zero on all backends (C, JVM,
+;;         wasm i32.div_s agree).
+;; ---------------------------------------------------------------------------
+
 (def table
   {;; binary arithmetic
    :+ {:arity 2 :kind :infix :wasm (vt3 :f64.add :f32.add :i32.add) :c "+" :wgsl "+"}

--- a/src/raster/compiler/backend/intrinsics.clj
+++ b/src/raster/compiler/backend/intrinsics.clj
@@ -81,6 +81,25 @@
    ;; the vector lowering is a fixed intrinsic SEQUENCE per ISA (AVX2
    ;; maddubs→madd→add, wasm i32x4.dot_i16x8_s, GPU dp4a) — see simd-widen below.
    :wi8-dot {:arity 2 :kind :widening-mac :wasm {:i32 :i32x4.dot-i16x8-s}}
+   ;; dp4a(a, b, acc) = acc + Σₖ aₖ·bₖ over the 4 SIGNED bytes packed
+   ;; little-endian in each i32 — the scalar int8-MAC primitive (semantic op
+   ;; raster.par/dp4a, JVM reference impl in raster.par). ONE canonical entry;
+   ;; every backend spelling lives HERE as data:
+   ;;   :c    — portable helper name; :c-helper-src is its OpenCL/C source
+   ;;           (as_char4 idiom, pattern-matched to hardware dp4a by IGC/NV/AMD)
+   ;;   :cuda/:hip (Phase B) — __dp4a / __builtin_amdgcn_sdot4 go HERE, not in
+   ;;           an emitter table
+   ;;   :wasm — :scalar-lanes (shift/mask lane extraction; emitter-local emit fn)
+   ;; The VECTOR schedules (AVX2 maddubs, wasm i32x4.dot) are :wi8-dot above.
+   :dp4a {:arity 3 :kind :dp4a
+          :c {:fn "rstr_dp4a"}
+          :c-helper-src (str "inline int rstr_dp4a(int a, int b, int acc) {\n"
+                             "    char4 va = as_char4(a);\n"
+                             "    char4 vb = as_char4(b);\n"
+                             "    return acc + (int)va.x*(int)vb.x + (int)va.y*(int)vb.y\n"
+                             "               + (int)va.z*(int)vb.z + (int)va.w*(int)vb.w;\n"
+                             "}\n")
+          :wasm :scalar-lanes}
    ;; broader elementary set — all wasm via composition/polynomial (see
    ;; backend.wasm.transcendental); GPU facet set only where it's a builtin (else
    ;; omitted → GPU keeps its generated-helper fallback, no regression).
@@ -129,7 +148,7 @@
    "cbrt" :cbrt "log2" :log2 "log10" :log10 "exp2" :exp2 "exp10" :exp10
    "expm1" :expm1 "log1p" :log1p "hypot" :hypot "deg2rad" :deg2rad "rad2deg" :rad2deg
    "clamp" :clamp "signum" :signum "copysign" :copysign "copySign" :copysign
-   "flipsign" :flipsign "wi8-dot" :wi8-dot})
+   "flipsign" :flipsign "wi8-dot" :wi8-dot "dp4a" :dp4a})
 
 ;; mangled devirtualized prefix → canonical key (e.g. _plus__m_double_double)
 (def ^:private mangled-prefix->key

--- a/src/raster/compiler/backend/jvm/bytecode.clj
+++ b/src/raster/compiler/backend/jvm/bytecode.clj
@@ -3730,6 +3730,28 @@
                      (fn [locs [[sym init] rt]]
                        (let [t (emit-form code init locs (dissoc ctx :void-context))
                              slot-t (widen-loop-type t rt)]
+                         ;; A2 differential: the walker stamps loop-var types
+                         ;; (TC-fed); this backend still derives its own via
+                         ;; LUB(init, recur). A PRIMITIVE mismatch between the
+                         ;; two is a front-half stamping bug OR a recur-widening
+                         ;; the stamp missed — surface it. (Ref types skipped:
+                         ;; stamps carry class names, slots carry :ref.)
+                         (when-let [stag (:raster.type/tag (meta sym))]
+                           (let [stamp-t ({'double :double 'float :float
+                                           'long :long 'int :int
+                                           'boolean :bool} stag)]
+                             (when (and stamp-t
+                                        ;; only CLASS mismatches (float vs int)
+                                        ;; are miscompile signals — width picks
+                                        ;; (int↔long, f32↔f64) are backend-legit
+                                        (not= (contains? #{:double :float} stamp-t)
+                                              (contains? #{:double :float} slot-t)))
+                               (binding [*out* *err*]
+                                 (println (str "WARNING: bytecode loop-var " sym
+                                               " stamped " stag " but derived "
+                                               slot-t " (LUB of init+recur) — "
+                                               "front-half stamp diverges from "
+                                               "backend derivation."))))))
                          (when (not= t slot-t) (emit-coerce code t slot-t))
                          (let [slot (alloc-slot! ctx slot-t)]
                            (case slot-t

--- a/src/raster/compiler/backend/jvm/segop_simd.clj
+++ b/src/raster/compiler/backend/jvm/segop_simd.clj
@@ -51,25 +51,12 @@
             :broadcast     'jdk.incubator.vector.FloatVector/broadcast
             :cast-fn       'float}})
 
-(def ^:private reduce-identity-double
-  {'+ 0.0, '- 0.0, '* 1.0,
-   'Math/max 'Double/NEGATIVE_INFINITY,
-   'Math/min 'Double/POSITIVE_INFINITY})
-
-(def ^:private reduce-identity-float
-  {'+ '(float 0.0), '- '(float 0.0), '* '(float 1.0),
-   'Math/max 'Float/NEGATIVE_INFINITY,
-   'Math/min 'Float/POSITIVE_INFINITY})
-
 (defn- reduce-identity
-  "Look up the identity element for a reduction op, typed by elem-type."
+  "Identity element for a reduction op, typed by elem-type — sourced from the
+   op-descriptor :algebra facet (single registry), not a local table. `-` in a
+   reduction accumulates additively (a - x0 - x1 ...), so it seeds like +."
   [op elem-type]
-  (let [table (if (= elem-type :float) reduce-identity-float reduce-identity-double)]
-    (or (get table op)
-        (throw (ex-info (str "segop-simd: no reduction identity for op `" op
-                             "` (elem-type=" elem-type "). Register in reduce-identity-"
-                             (name elem-type) ".")
-                        {:op op :elem-type elem-type})))))
+  (descriptor/typed-reduce-identity (if (= op '-) '+ op) elem-type))
 
 (defn- normalize-reduce-op
   "clojure.core/+ → +, etc."

--- a/src/raster/compiler/backend/wasm/emit.clj
+++ b/src/raster/compiler/backend/wasm/emit.clj
@@ -14,7 +14,8 @@
    memory). Float element type from the array param's tag (doubles→f64, floats→f32).
    Every loop returns its non-recur (else) value, so the function result type is
    the deftm's return tag."
-  (:require [raster.compiler.backend.wasm.encoder :as e]
+  (:require [raster.compiler.ir.form :as form]
+            [raster.compiler.backend.wasm.encoder :as e]
             [raster.compiler.backend.wasm.transcendental :as tr]
             [raster.compiler.backend.intrinsics :as ix]))
 
@@ -73,13 +74,13 @@
              (or (#{'dotimes 'when} h)
                  (and (symbol? h) (= "aset" (name h)))
                  ;; statement loop: (loop [..] (if c <recur…> nil)) — void exit
-                 (and (#{'loop 'loop*} h)
+                 (and (form/loop-head? h)
                       (let [[_ _ ifform] node]
                         (and (seq? ifform) (= 'if (first ifform))
                              (let [[_ _ t e] ifform]
                                (or (and (ends-in-recur? t) (void-effect-form? e))
                                    (and (ends-in-recur? e) (void-effect-form? t)))))))
-                 (and (#{'do 'let* 'let} h) (void-effect-form? (last node))))))))
+                 (and (or (= 'do h) (form/let-head? h)) (void-effect-form? (last node))))))))
 
 (defn- synth-case*
   "Lower the macroexpanded `case*` special form
@@ -197,7 +198,7 @@
         (e/i :unreachable)
         ;; loop in VALUE position (e.g. an inlined reduction as a let* binding init)
         ;; — emit-loop already yields a value-producing block(result vt); take bytes.
-        (#{'loop 'loop*} h)
+        (form/loop-head? h)
         (first (emit-loop ctx node))
         ;; array access .invk (aget is a deftm and may arrive devirtualized OR
         ;; survive as an un-inlined callee) — ALWAYS emit through the elems
@@ -261,7 +262,7 @@
         (and (symbol? h) (ix/canonical h))
         (emit-intrinsic ctx h A nil)
         ;; let* / do in VALUE position (introduced by inlined deftm calls)
-        (#{'let* 'let} h)
+        (form/let-head? h)
         (let [[binds & body] A
               [ctx' init-bytes] (emit-bindings ctx binds)
               tail (if (= 1 (count body)) (first body) (cons 'do body))]
@@ -407,7 +408,7 @@
           ;; let* — bind its locals so the tail's refs resolve (a let* used as an
           ;; operand, e.g. (/ (let* …) (let* …)), must infer its tail's vt, which
           ;; may reference a binding introduced inside it).
-          (#{'let* 'let} h) (let [c' (reduce (fn [c [s init]]
+          (form/let-head? h) (let [c' (reduce (fn [c [s init]]
                                                (assoc-in c [:env s]
                                                          {:vt (or (sym-vt s) (infer-vt c init))}))
                                              ctx (partition 2 (second node)))]
@@ -425,7 +426,7 @@
           ;; so it's intentional rather than relying on the unknown-head default
           (and (symbol? h) (#{"inc" "unchecked-inc-int" "unchecked-inc"
                               "dec" "unchecked-dec-int" "unchecked-dec"} (name h))) :i32
-          (#{'loop 'loop*} h)                                         ; loop result = its non-recur branch
+          (form/loop-head? h)                                         ; loop result = its non-recur branch
           (let [c' (reduce (fn [c [s init]]
                              (assoc-in c [:env s] {:vt (or (sym-vt s) (infer-vt c init))}))
                            ctx (partition 2 (nth node 1)))  ; bind loop vars so the result ref resolves
@@ -470,7 +471,7 @@
       (= h 'do) (vec (mapcat #(emit-effect ctx %) A))
       ;; let* in effect position (e.g. soa-lower floats arg bindings out of a
       ;; store: (let* [args…] (do (aset …) …))). Bind locals, emit body as effects.
-      (#{'let* 'let} h)
+      (form/let-head? h)
       (let [[binds & body] A
             [ctx' init-bytes] (emit-bindings ctx binds)]
         (into init-bytes (vec (mapcat #(emit-effect ctx' %) body))))
@@ -490,7 +491,7 @@
       (= h 'when) (emit-effect ctx (list 'if (second node) (list* 'do (drop 2 node))))
       ;; statement-position loop (model kernels: packing/softmax inner loops that
       ;; end in nil) — the value-loop emission with a void exit branch.
-      (#{'loop 'loop*} h) (emit-loop-void ctx node)
+      (form/loop-head? h) (emit-loop-void ctx node)
       :else (throw (ex-info (str "unhandled effect head " h) {:node node}))))))
 
 (defn- emit-recur
@@ -512,7 +513,7 @@
   (and (seq? node)
        (let [h (first node)]
          (or (= 'recur h)
-             (and (#{'do 'let* 'let} h) (ends-in-recur? (last node)))
+             (and (or (= 'do h) (form/let-head? h)) (ends-in-recur? (last node)))
              (and (= 'if h) (or (ends-in-recur? (nth node 2))
                                 (ends-in-recur? (nth node 3 nil))))))))
 
@@ -530,7 +531,7 @@
     (let [stmts (vec (rest node))]
       (-> (vec (mapcat #(emit-effect ctx %) (butlast stmts)))
           (into (emit-then ctx (last stmts) loop-idxs loop-vts ret-vt loop-depth block-depth))))
-    (and (seq? node) (#{'let* 'let} (first node)))
+    (and (seq? node) (form/let-head? (first node)))
     (let [[binds & body] (rest node)
           [ctx' init-bytes] (emit-bindings ctx binds)
           tail (if (= 1 (count body)) (first body) (cons 'do body))]
@@ -999,7 +1000,7 @@
     ;; void-bound symbol in tail position (e.g. (let* [_ret (dotimes …)] _ret))
     (and (symbol? node) (get-in ctx [:env node :void])) [[] nil]
 
-    (and (seq? node) (#{'let* 'let} (first node)))
+    (and (seq? node) (form/let-head? (first node)))
     (let [[_ binds & body] node
           [ctx' init-bytes] (emit-bindings ctx binds)
           tail (if (= 1 (count body)) (first body) (cons 'do body))

--- a/src/raster/compiler/backend/wasm/emit.clj
+++ b/src/raster/compiler/backend/wasm/emit.clj
@@ -241,7 +241,7 @@
         ;; CPU-C dpbusd). Wasm Tier-1 scalar: extract sign-extended bytes by
         ;; shl/shr_s pairs, 4 muls, chained adds onto acc. (Tier-2 SIMD via the
         ;; existing i32x4.dot int8-dot loop plan when the enclosing loop matches.)
-        (or (= h 'raster.par/dp4a) (= h 'par/dp4a))
+        (= :dp4a (ix/canonical h))    ; any spelling — canonical collapses them
         (let [[a b acc] A
               la (alloc! ctx :i32) lb (alloc! ctx :i32)
               lane (fn [l k]                               ; sign-extended byte k
@@ -432,7 +432,7 @@
                 ifform (nth node 2) then (nth ifform 2) els (nth ifform 3)]
             (infer-vt c' (if (ends-in-recur? then) els then)))
           (= 'throw h) :diverge                        ; never produces a value
-          (#{'raster.par/dp4a 'par/dp4a} h) :i32       ; int8 dot-accumulate → i32
+          (= :dp4a (ix/canonical h)) :i32              ; int8 dot-accumulate → i32
           (#{'clojure.core/aget 'raster.arrays/aget} h) (get-in ctx [:elems (second node) :vt] :f64)
           ;; registered numeric op/intrinsic: comparisons → bool (i32); arith /
           ;; math / rem-mod → element type of first operand

--- a/src/raster/compiler/core/op_descriptor.clj
+++ b/src/raster/compiler/core/op_descriptor.clj
@@ -722,10 +722,38 @@
          'bit-and {:associative? true :commutative? true :identity -1}
          'bit-or  {:associative? true :commutative? true :identity 0}
          'bit-xor {:associative? true :commutative? true :identity 0}}
-        v    [base
-              (symbol "clojure.core" (name base))
-              (symbol "raster.numeric" (name base))]]
+        v    (cond-> [base
+                      (symbol "clojure.core" (name base))
+                      (symbol "raster.numeric" (name base))]
+               (contains? #{'min 'max} base) (conj (symbol "Math" (name base))))]
   (register-algebra! v algebra))
+
+(defn typed-reduce-identity
+  "The identity element for a reduction op, TYPED for the element dtype — the
+   single source emitters use to seed accumulators (segop-simd, GPU segred).
+   Derived from the :algebra facet's abstract identity; min/max (whose abstract
+   identity is nil — no identity over unbounded domains) become the dtype's
+   ∓Infinity, which IS their identity over IEEE floats. Emits a LITERAL or a
+   symbol suitable for splicing into generated code. Throws for ops without a
+   registered monoid — an unregistered reduction must fail loud, not seed 0."
+  [op-sym dtype]
+  (let [base (symbol (name op-sym))                 ; spelling-collapse
+        a    (algebra-facet base)]
+    (when-not a
+      (throw (ex-info (str "no :algebra facet for reduction op " op-sym
+                           " — register it (op-descriptor) before reducing with it")
+                      {:op op-sym :dtype dtype})))
+    (let [float? (= dtype :float)]
+      (case base
+        (min Math/min) (if float? 'Float/POSITIVE_INFINITY 'Double/POSITIVE_INFINITY)
+        (max Math/max) (if float? 'Float/NEGATIVE_INFINITY 'Double/NEGATIVE_INFINITY)
+        ;; numeric monoids: type the abstract identity for the dtype
+        (let [id (:identity a)]
+          (cond
+            (nil? id) (throw (ex-info (str "op " op-sym " has no identity") {:op op-sym}))
+            (contains? #{:int :long :byte} dtype) id
+            float?    (list 'float (double id))
+            :else     (double id)))))))
 
 ;; --- Devirtualization detection ---
 

--- a/src/raster/compiler/ir/form.clj
+++ b/src/raster/compiler/ir/form.clj
@@ -327,6 +327,15 @@
   [form]
   (= :binding (:kind (form-info form))))
 
+(defn let-head?
+  "True for the let-family heads (let, let*). Emitters and passes must use this
+   instead of local #{'let 'let*} sets — one place to extend, no drift."
+  [h] (contains? #{'let 'let*} h))
+
+(defn loop-head?
+  "True for the loop-family heads (loop, loop*)."
+  [h] (contains? #{'loop 'loop*} h))
+
 (defn scope-form?
   "True if the form introduces a new scope (dotimes, loop, fn, par)."
   [form]


### PR DESCRIPTION
Follow-on to #27 (A1). Three registry convergences, one decision table, and two measurement instruments — each producing a census that gates or motivates the next step.

## Registry convergence
- **dp4a is ONE canonical intrinsics entry**: the C spelling and the portable `as_char4` helper source are registry data; wasm recognizes any spelling via `canonical`; c_emit + par_opencl read the registry. CUDA `__dp4a` / HIP `sdot4` become sibling rows in Phase B — zero emitter edits. (5 spelling sites → 1.)
- **Typed reduce identities** derive from the op-descriptor `:algebra` facet (`typed-reduce-identity`: min/max → dtype-typed ∓Infinity; unregistered monoids throw). segop_simd's local tables deleted.
- **ir/form head predicates** (`let-head?`/`loop-head?`) adopted across wasm + wgsl multi-head sets.

## Semantics decision table (intrinsics.clj)
Per-op/per-target choices recorded in one place: `:round` Java `floor(x+0.5)` (with the documented C native-`round` deviation at negative ties — previously implicit), `:mod` floored, `:rem` truncated, `:i64` wasm-i32 policy, `:div` trunc-toward-zero. An emitter deviating from the table is a bug, not a preference.

## Measurement instruments + censuses (the interesting part)
- **c_emit silent-default instrumentation** (warn-once-per-head): suite census found **18 unstamped head classes**, concentrated in the ABM/econ GPU kernels + par-reduce paths → the fail-loud flip is explicitly **gated** on stamping those paths.
- **bytecode stamp-vs-LUB differential**: suite census found **22 divergences in two classes** — (1) *the recur-LUB gap made concrete*: accumulators stamped `long` from their init while the loop carries doubles (bytecode's LUB silently rescues the JVM; stamp-trusting backends fail loud on the same loops) → direct evidence for the walker recur-LUB stamping item; (2) loop vars boxed (`:ref`) where stamps promise primitives — each a potential hidden perf bug.
- **op-map ↔ intrinsics drift guard**: load-time equality check on the unambiguous operator subset — the parallel tables can no longer drift silently (full per-dialect D4 fold tracked in the review notes).

## Validation
Full Valhalla suite ×3 across the increments: **1721 / 28752 / 0 / 0** each. Targeted wasm + par: 81/357/0/0.

Deferred with reasons (in `.internal/emitter_review/0_synthesis.md`, gitignored): full D4 fold (needs per-dialect `:c` facets), D6 shared counted-loop recognizer, walker recur-LUB stamping (now evidence-backed, natural next PR).