### PR TITLE
walker: recur-LUB rewalk fixpoint (fixes silent accumulator truncation)

### DIFF
--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -497,6 +497,87 @@
 ;; Branch: let/let*/loop
 ;; ================================================================
 
+(def ^:private numeric-tag-rank
+  "Widening order for the recur-LUB: a loop var must hold every iteration's
+   value, so its type is LUB(init, recur args) — not the init's class alone.
+   A wrong (narrower) stamp is not just a slot-type issue: the walker CASTS
+   variables to their stamped type, and (long acc) on a double-carrying
+   accumulator TRUNCATES the value every iteration — silent numerical
+   corruption (found live: (loop [acc 0] (+ acc <double>)) summed 3.5 not 4.5)."
+  {'int 1 'long 2 'float 3 'double 4})
+
+(defn- walked-value-tag
+  "Numeric tag of a walked form, promotion-aware: stamped meta first, then
+   casts, clojure.core arithmetic (LUB of args — mirrors JVM promotion),
+   aget element types, symbols via type-env, literal classes. nil = unknown
+   (never widen on a guess)."
+  [x type-env]
+  (cond
+    (and (instance? clojure.lang.IObj x) (:raster.type/tag (meta x)))
+    (:raster.type/tag (meta x))
+    (symbol? x) (inf/type-env-tag type-env x)
+    (instance? Double x) 'double
+    (instance? Long x) 'long
+    (seq? x)
+    (let [h (first x)]
+      (cond
+        (contains? '#{long int double float} h) h
+        (contains? '#{clojure.core/long clojure.core/int
+                      clojure.core/double clojure.core/float} h)
+        (symbol (name h))
+        ;; arithmetic: numeric promotion = rank-LUB of the args
+        (contains? '#{+ - * / clojure.core/+ clojure.core/- clojure.core/*
+                      clojure.core// raster.numeric/+ raster.numeric/-
+                      raster.numeric/* raster.numeric//} h)
+        (let [ranks (map #(get numeric-tag-rank (walked-value-tag % type-env))
+                         (rest x))]
+          (when (every? some? ranks)
+            (some (fn [[t r]] (when (= r (apply max ranks)) t)) numeric-tag-rank)))
+        ;; array read: element type off the array's type-env entry
+        (contains? '#{clojure.core/aget raster.arrays/aget} h)
+        (get-in type-env [(second x) :element])
+        :else nil))
+    :else nil))
+
+(defn- collect-recur-args
+  "Arg vectors of every `recur` belonging to THIS loop in walked body forms —
+   does not descend into nested recur targets (loop/loop*/fn*/ftm/reify*)."
+  [forms]
+  (let [out (volatile! [])]
+    (letfn [(scan [f]
+              (when (seq? f)
+                (let [h (first f)]
+                  (cond
+                    (= h 'recur) (vswap! out conj (vec (rest f)))
+                    (contains? '#{loop loop* fn* ftm reify*} h) nil
+                    :else (run! scan f)))))]
+      (run! scan forms)
+      @out)))
+
+(defn- recur-widened-types
+  "Map of binding-sym → widened tag for loop vars whose recur args carry a
+   WIDER numeric type than the stamped tag. Empty when nothing widens."
+  [new-bindings walked-body type-env]
+  (let [recurs (collect-recur-args walked-body)
+        pairs  (vec (partition 2 new-bindings))]
+    (if (or (empty? recurs) (some #(not= (count %) (count pairs)) recurs))
+      {}
+      (into {}
+            (keep-indexed
+             (fn [i [sym _]]
+               (let [stag (:raster.type/tag (meta sym))
+                     srank (get numeric-tag-rank stag)]
+                 (when srank
+                   (let [lub (reduce (fn [r args]
+                                       (let [t (walked-value-tag (nth args i) type-env)
+                                             tr (get numeric-tag-rank t)]
+                                         (if (and tr (> tr r)) tr r)))
+                                     srank recurs)]
+                     (when (> lub srank)
+                       [sym (some (fn [[t r]] (when (= r lub) t))
+                                  numeric-tag-rank)]))))))
+            pairs))))
+
 (defmethod walk-form :let [form ctx]
   (let [[let-sym bindings & body] form
         [new-bindings new-ctx]
@@ -549,7 +630,28 @@
                 elem-tag (update-in [:type-env sym] assoc :element elem-tag))]))
          [[] ctx]
          (partition 2 bindings))]
-    (list* let-sym (vec new-bindings) (walk-forms body new-ctx))))
+    (let [walked-body (walk-forms body new-ctx)]
+      (if-not (contains? '#{loop loop*} let-sym)
+        (list* let-sym (vec new-bindings) walked-body)
+        ;; recur-LUB fixpoint: if a recur passes a wider numeric type than a
+        ;; binding's stamp, REWALK the body with the widened types — the walk
+        ;; inserts casts from the stamps, so a narrow stamp doesn't just
+        ;; mistype the slot, it TRUNCATES the value ((long acc) per iteration).
+        ;; Numeric ranks are a 4-level lattice → terminates in ≤3 rewalks.
+        (loop [bindings new-bindings ctx' new-ctx wb walked-body guard 0]
+          (let [widened (recur-widened-types bindings wb (:type-env ctx'))]
+            (if (or (empty? widened) (>= guard 3))
+              (list* let-sym (vec bindings) wb)
+              (let [bindings' (vec (mapcat
+                                    (fn [[sym init]]
+                                      [(if-let [t (get widened sym)]
+                                         (stamp-type-meta sym t nil)
+                                         sym)
+                                       init])
+                                    (partition 2 bindings)))
+                    ctx'' (reduce (fn [c [sym t]] (ctx-assoc-type c sym t))
+                                  ctx' widened)]
+                (recur bindings' ctx'' (walk-forms body ctx'') (inc guard))))))))))
 
 ;; ================================================================
 ;; Branch: fn/fn*

--- a/test/raster/compiler/recur_lub_test.clj
+++ b/test/raster/compiler/recur_lub_test.clj
@@ -1,0 +1,47 @@
+(ns raster.compiler.recur-lub-test
+  "Recur-LUB fixpoint regression: a loop var's type is LUB(init, recur args),
+   not the init's class. Before the walker rewalk-fixpoint, an integer-literal
+   accumulator carrying doubles was stamped `long`, and the stamp-driven
+   (long acc) cast TRUNCATED the running value every iteration — silent
+   numerical corruption in BOTH the interpreted and compiled paths:
+   (loop [acc 0] (+ acc 1.5)) over 3 elements summed 3.5 instead of 4.5.
+
+   Surfaced by the A2 bytecode stamp-vs-LUB differential census (the
+   'stamped long but derived :double' class)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.core :refer [deftm]]
+            [raster.arrays :as ra]
+            [raster.compiler.pipeline :as pl]
+            [clojure.walk :as w]))
+
+(deftm lub-sum-k [x :- (Array double) n :- Long] :- Double
+  ;; acc deliberately initialized with the INTEGER literal 0 — the natural
+  ;; spelling that used to truncate
+  (loop [i 0 acc 0]
+    (if (< i n)
+      (recur (inc i) (+ acc (ra/aget x i)))
+      (double acc))))
+
+(deftest integer-init-accumulator-does-not-truncate
+  (let [xs (double-array [1.5 1.5 1.5])]
+    (testing "interpreted path"
+      (is (= 4.5 (lub-sum-k xs 3))))
+    (testing "compiled path"
+      (is (= 4.5 ((pl/compile-aot #'lub-sum-k) xs 3))))))
+
+(deftest loop-var-stamp-is-the-lub
+  (testing "walked IR stamps the accumulator with the widened type"
+    (let [wb ((deref #'pl/get-walked-body) #'lub-sum-k :double)
+          tags (volatile! {})]
+      (w/postwalk
+       (fn [f]
+         (when (and (seq? f) (= 'loop* (first f)))
+           (doseq [[sym _] (partition 2 (second f))]
+             (vswap! tags assoc (symbol (re-find #"^[a-z-]+" (name sym)))
+                     (:raster.type/tag (meta sym)))))
+         f)
+       wb)
+      (is (= 'double (get @tags 'acc))
+          "acc must be widened long→double by the recur-LUB fixpoint")
+      (is (= 'long (get @tags 'i))
+          "the genuine integer counter stays long"))))


### PR DESCRIPTION
## The bug (live, both paths)

\`\`\`clojure
(deftm sum-k [x :- (Array double) n :- Long] :- Double
  (loop [i 0 acc 0]                      ; acc: the natural integer-literal init
    (if (< i n)
      (recur (inc i) (+ acc (ra/aget x i)))
      (double acc))))

(sum-k (double-array [1.5 1.5 1.5]) 3)  ;=> 3.5   (expected 4.5)
\`\`\`

The walker stamped `acc` as `long` (its init's class), and since stamps drive cast insertion, the body got `(long acc)` — **truncating the running sum every iteration**, identically in the interpreted and `compile-aot` paths. Found by following the A2 stamp-vs-LUB differential census (#28).

## The fix

A loop var's type is **LUB(init, recur args)**. Implemented as a walk-time **rewalk fixpoint** in the walker's loop handler — post-hoc restamping can't work because the truncating cast is already baked into the walked body:

1. Walk the body as before.
2. Promotion-aware detection over the walked recur args (stamped tags, casts, arith LUB mirroring JVM promotion, aget element types, type-env symbols). Never widens on a guess (unknown → no change).
3. If any binding widens: re-stamp, extend the type-env, **rewalk the body**. The 4-level numeric lattice (int < long < float < double) bounds this at ≤3 rewalks; non-widening loops pay one map lookup.

This also subsumes the walker-side recur-LUB stamping item deferred from A1 — bytecode's local `widen-loop-type` remains as the (now-agreeing) differential monitor.

## Census note

The 22 bytecode differential warnings do **not** shrink: they all trace to the ABM module, whose kernel bodies bypass the walker entirely — the same root as the c_emit silent-default census. Stamping the ABM path is the single gate for both (tracked in the review notes). Walked code couldn't have carried this bug through the suite (wrong results ⇒ failing tests); it was a landmine for new user code.

## Validation

- New `recur_lub_test.clj`: live-bug repro (interpreted + compiled) + walked-IR tag assertions (acc widens to double, the genuine int counter stays long)
- Full Valhalla suite: **1723 / 28756 / 0 / 0**
- Targeted wasm + par: 83/361/0/0