### PR TITLE
bytecode: promotion-aware arith inference + tag-first form typing (census 22→13)

### DIFF
--- a/src/raster/compiler/backend/jvm/bytecode.clj
+++ b/src/raster/compiler/backend/jvm/bytecode.clj
@@ -202,6 +202,8 @@
         (.equals c Void/TYPE) :void
         :else :ref))
 
+(declare infer-arg-stack-type-structural)
+
 (defn- infer-arg-stack-type
   "Infer the stack type of a form WITHOUT emitting bytecode.
   Used to select the correct overloaded method (e.g. Math.abs(int) vs Math.abs(double))."
@@ -223,18 +225,41 @@
     (let [h (first form)]
       (cond
         (not (symbol? h)) nil
+        :else
+        (or
+         ;; Tags first (A1): the walker stamps composed forms (.invk ret-tags,
+         ;; casts, control-form results) — read the stamp before any structural
+         ;; guessing. Kills the conservative :double guess on opaque-but-tagged
+         ;; calls (e.g. int8->long chains in integer reductions).
+         (when-let [tag (:raster.type/tag (meta form))]
+           (get {'double :double 'long :long 'int :int 'float :float
+                 'boolean :bool 'byte :int 'short :int} tag))
+         (infer-arg-stack-type-structural form h locals))))
+    :else nil))
+
+(defn- infer-arg-stack-type-structural
+  "Structural fallback of infer-arg-stack-type for UNTAGGED seq forms."
+  [form h locals]
+  (cond
         ;; Cast expressions
         (= (name h) "double") :double
         (= (name h) "long")   :long
         (= (name h) "int")    :int
         (= (name h) "float")  :float
-        ;; Arithmetic: float×float→float, otherwise→double
-        ;; (matches emit-arithmetic behavior)
+        ;; Arithmetic: JVM numeric promotion — all-float → float, all-integer
+        ;; → int/long (any long ⇒ long), anything unknown/mixed-float → double.
+        ;; The old rule hard-defaulted every non-float case to :double, typing
+        ;; genuinely integer loops (e.g. fft's (recur (* size 2)) with
+        ;; bit-shift-right in the body) into double slots — the false-positive
+        ;; class of the A2 stamp-vs-LUB census, where the STAMP (long) was
+        ;; right and this guess was wrong.
         (contains? #{"+" "-" "*" "/"} (name h))
-        (let [args (rest form)]
-          (if (every? #(= :float (infer-arg-stack-type % locals)) args)
-            :float
-            :double))
+        (let [ts (mapv #(infer-arg-stack-type % locals) (rest form))]
+          (cond
+            (and (seq ts) (every? #(= :float %) ts)) :float
+            (and (seq ts) (every? #(contains? #{:int :long} %) ts))
+            (if (some #(= :long %) ts) :long :int)
+            :else :double))
         ;; Comparison ops produce primitive :bool (int 0/1) — see emit-comparison.
         (contains? #{"<" "<=" ">" ">=" "==" "not="} (name h)) :bool
         ;; if → infer from branches (enables skip-box for nested ifs)
@@ -295,7 +320,6 @@
              (catch Exception _ nil))
         ;; Default: unknown
         :else nil))
-    :else nil))
 
 (defn- resolve-static-call
   "Given a deftm walked body that is a single static method call,
@@ -3751,7 +3775,8 @@
                                                " stamped " stag " but derived "
                                                slot-t " (LUB of init+recur) — "
                                                "front-half stamp diverges from "
-                                               "backend derivation."))))))
+                                               "backend derivation. init=" (pr-str init)
+                                               " recur-types=" (pr-str rt)))))))
                          (when (not= t slot-t) (emit-coerce code t slot-t))
                          (let [slot (alloc-slot! ctx slot-t)]
                            (case slot-t


### PR DESCRIPTION
Follow-on to #29 — chasing the stamp-vs-LUB differential census into the **derivation** side found the false-positive class was the bytecode shadow engine itself.

## The bug class

`infer-arg-stack-type` hard-defaulted **every non-float arithmetic form to `:double`** (`;; Arithmetic: float×float→float, otherwise→double`). Genuinely integer loops — fft's `(recur (* size 2))` with `bit-shift-right` on the var in the body — were typed into double slots: a wrong guess that also quietly cost integer-loop performance wherever it fired.

## Fixes

- **JVM-promotion-aware arithmetic rule**: all-float → `:float`, all-integer → `:int`/`:long` (any long ⇒ long), unknown/mixed → `:double` (the old conservative behavior, now only where actually unknown).
- **Tags first** (the A1 tag-reader principle applied to this engine): seq forms resolve from their walker-stamped `:raster.type/tag` before any structural guessing — `.invk` ret-tags, casts, and control-form results now come from stamps.
- Census warnings now print `init=` and `recur-types=` for direct attribution.

## Census: 22 → 13

- **9 false positives eliminated** (the integer loops wrongly derived `:double`).
- **6 residual `long→:double`**: opaque undevirtualized+untagged calls in recur positions (2 confirmed as the known int8 `int8->long` dispatch gap; each now self-attributing via the enriched warning) — honest monitor signal, not noise.
- **7 `double→:ref`**: bytecode boxes loop vars the stamps promise are primitive (ABM's mixed float/double loops) — real perf suspects, queued.

## Validation

Full Valhalla suite: **1723 / 28756 / 0 / 0**. Targeted int8/fft/ode: 57/178/0/0.