### PR TITLE
int8 ops → deftm + bytecode byte-param support

### DIFF
--- a/src/raster/compiler/backend/jvm/bytecode.clj
+++ b/src/raster/compiler/backend/jvm/bytecode.clj
@@ -4473,6 +4473,13 @@
     float    {:class-desc F-cd :stack-type :float}
     long     {:class-desc J-cd :stack-type :long}
     int      {:class-desc I-cd :stack-type :int}
+    ;; byte/short/char are int-width on the JVM stack; without these cases a
+    ;; Byte-tagged deftm param fell to the boxed default while the typed
+    ;; interface declared primitive B — a VerifyError'ing bridge mismatch
+    ;; (surfaced converting raster.types.int8 ops to deftm).
+    (byte Byte)      {:class-desc (ClassDesc/ofDescriptor "B") :stack-type :int}
+    (short Short)    {:class-desc (ClassDesc/ofDescriptor "S") :stack-type :int}
+    (char Character) {:class-desc (ClassDesc/ofDescriptor "C") :stack-type :int}
     boolean  {:class-desc (ClassDesc/ofDescriptor "Z") :stack-type :bool}
     objects  {:class-desc objarr-cd :stack-type :ref}
     doubles  {:class-desc dblarr-cd :stack-type :ref}
@@ -5128,7 +5135,22 @@
                                           (= iface-pd "D") (do (.dload code slot) (recur (+ slot 2) (inc i)))
                                           (= iface-pd "J") (do (.lload code slot) (recur (+ slot 2) (inc i)))
                                           (= iface-pd "F") (do (.fload code slot) (recur (+ slot 1) (inc i)))
-                                          (#{"I" "Z" "B" "S" "C"} iface-pd) (do (.iload code slot) (recur (+ slot 1) (inc i)))
+                                          (#{"I" "Z" "B" "S" "C"} iface-pd)
+                                          (do (.iload code slot)
+                                              ;; compute takes a REF here → box with the
+                                              ;; exact wrapper (Byte/valueOf, not Integer)
+                                              ;; so downstream type dispatch stays correct
+                                              (when-not (#{"I" "Z" "B" "S" "C"} (.descriptorString ^ClassDesc (nth compute-param-cds i)))
+                                                (let [[cls prim] (case iface-pd
+                                                                   "B" ["java.lang.Byte" "B"]
+                                                                   "S" ["java.lang.Short" "S"]
+                                                                   "C" ["java.lang.Character" "C"]
+                                                                   "Z" ["java.lang.Boolean" "Z"]
+                                                                   ["java.lang.Integer" "I"])
+                                                      box-cd (ClassDesc/of cls)]
+                                                  (.invokestatic code box-cd "valueOf"
+                                                                 (MethodTypeDesc/of box-cd (into-array ClassDesc [(ClassDesc/ofDescriptor prim)])))))
+                                              (recur (+ slot 1) (inc i)))
                                           :else (do (.aload code slot)
                                                     (when (not= iface-pd compute-pd)
                                                       (.checkcast code (nth compute-param-cds i)))

--- a/src/raster/types/int8.clj
+++ b/src/raster/types/int8.clj
@@ -38,19 +38,27 @@
 ;; Construction + WIDENING conversions (the defining operations)
 ;; ================================================================
 
-(defn int8
-  "Create an Int8 from any integer, truncated to signed 8-bit (wraps, like Julia)."
-  [x]
+(deftm int8
+  "Create an Int8 from a long, truncated to signed 8-bit (wraps, like Julia)."
+  [x :- Long] :- Int8
+  (->Int8 (unchecked-byte x)))
+
+(deftm int8 [x :- Integer] :- Int8
   (->Int8 (unchecked-byte (long x))))
 
-(defn int8->long
+(deftm int8
+  "From a byte (e.g. a byte-array read) — already 8-bit, wrap directly."
+  [x :- Byte] :- Int8
+  (->Int8 x))
+
+(deftm int8->long
   "Widen an Int8 to a (sign-extended) long — the exact embedding int8 ↪ int64."
-  ^long [^Int8 x]
+  [x :- Int8] :- Long
   (long (.val x)))
 
-(defn int8->int
-  "Widen an Int8 to a (sign-extended) int."
-  ^long [^Int8 x]
+(deftm int8->int
+  "Widen an Int8 to a (sign-extended) int (returned as long — JVM int-width value)."
+  [x :- Int8] :- Long
   (long (int (.val x))))
 
 ;; ================================================================
@@ -91,8 +99,8 @@
 ;; byte[] + explicit widening). Pull an int8 out with `(int8 (raster.arrays/aget
 ;; bs i))` or widen directly with `(int8->long (int8 (aget bs i)))`.
 
-(defn aget-widen
+(deftm aget-widen
   "Read byte[] element i and widen (sign-extend) to a long — the int8 load used by
    the quantized dot. Equivalent to (int8->long (int8 (aget bs i))) but direct."
-  ^long [^bytes bs ^long i]
-  (long (clojure.core/aget bs (int i))))
+  [bs :- (Array byte), i :- Long] :- Long
+  (long (raster.arrays/aget bs i)))


### PR DESCRIPTION
Third census-driven PR (after #29, #30). The 6 residual `long→:double` warnings pointed at `raster.types.int8`: `int8`/`int8->long`/`int8->int`/`aget-widen` were plain `defn`s — invisible to the walker (no devirtualization, no ret-tags), so recur args through them were untyped and the backend had to guess. Converted to `deftm` per the codebase's own always-deftm rule (`int8` gains Long/Integer/Byte arities).

## Bonus find: bytecode-compiler hole for byte params

The conversion immediately VerifyError'd — **`Byte`-tagged deftm params were never supported**: `param-tag->jvm` had no `byte`/`short`/`char` cases, so `compute_static` took a boxed param while the typed interface declared primitive `B`; the bridge then passed a raw int where an Object was expected. Fixed at both layers:

- `param-tag->jvm`: `(byte Byte)`/`(short Short)`/`(char Character)` → primitive descriptors, `:int` stack type
- TI bridge: defensive **exact-wrapper** boxing (`Byte/valueOf`, not `Integer.valueOf` — downstream type dispatch cares) when a primitive interface param meets a ref compute param

## Census: 13 → 11

int8's warnings zeroed at the root (devirtualized `.invk` + ret-tag → typed recur args). Residual: 4 `long→:double` (other opaque-call sites, self-attributing via the enriched warnings) + 7 `double→:ref` ABM boxing perf suspects.

## Validation

Full Valhalla suite: **1724 / 28758 / 0 / 0**. int8 namespace: 4/14/0/0.