### PR TITLE
#61 (part 1) canonical call-heads in the walk + #55 SegRed aget fix

### DIFF
--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -119,6 +119,12 @@
   (let [idx (seg-idx segred)
         bound (seg-bound segred)
         {:keys [acc init lambda]} (:reduce-op segred)
+        ;; #55 fix: normalize devirtualized array prims ((.invk aget-impl arr i)
+        ;; → canonical aget head) BEFORE any rewrapping, exactly as SegMap does.
+        ;; Without it, a parametric-array kernel (qlinear-k) emitted broken
+        ;; gpufn_aget helper calls while a typed-array kernel (decoder-gpu)
+        ;; emitted x[i] — same op, ns-sensitive lowering.
+        lambda (ce/normalize-array-prims lambda)
         dtype (or (:dtype segred) dtype)
         kernel-name (str kernel-name-prefix "_" (gensym ""))
         ctype (get codegen/opencl-type-map dtype "double")
@@ -166,8 +172,11 @@
               (acc-at? a1) [:right a0]
               :else [nil nil])))
         ;; Re-wrap in let if there were bindings (preserves local variable scope)
+        ;; preserve the raw expr's metadata across the rewrap — dropping it
+        ;; severed :raster.op/original on .invk forms (part of #55)
         elem-expr (if (and elem-expr-raw (seq let-bindings))
-                    (list 'let* (vec (mapcat identity let-bindings)) elem-expr-raw)
+                    (with-meta (list 'let* (vec (mapcat identity let-bindings)) elem-expr-raw)
+                               (meta elem-expr-raw))
                     elem-expr-raw)
         adapted-elem (when elem-expr (ce/adapt-casts-for-dtype elem-expr dtype))
         idx-c-name (ce/c-symbol idx)

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -377,6 +377,25 @@
                    form)
                  form)
                form)
+        ;; #61: canonicalize the CALL-POSITION head once, before classification,
+        ;; so dispatch and every handler see the canonical var symbol per op
+        ;; (ra/aget → raster.arrays/aget, n/+ → raster.numeric/+). The array-op
+        ;; family is NOT collapsed here: typed arrays get clojure.core/* from
+        ;; the :array-op handler and parametric arrays must still reach
+        ;; :deftm-call for dispatch — the walk's OUTPUT spellings per array op
+        ;; are exactly {clojure.core/x (typed), .invk+:raster.op/original
+        ;; (parametric)}. Bare heads, macros, special forms and locals are
+        ;; untouched — macros must stay unqualified for macroexpansion.
+        form (if (and (seq? form) (symbol? (first form)) (namespace (first form))
+                      (not (ctx-get-tag ctx (first form))))
+               (let [h  (first form)
+                     h' (resolve-aliased-symbol h (:source-ns ctx))]
+                 (if (identical? h' h)
+                   form
+                   (with-meta (cons (if-let [m (meta h)] (with-meta h' m) h')
+                                    (rest form))
+                              (meta form))))
+               form)
         result (walk-form form ctx)
         ;; Preserve metadata from original form
         result (if-let [m (meta form)]

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -1,0 +1,39 @@
+(ns raster.compiler.backend.gpu.segop-opencl-test
+  "SegRed OpenCL kernel generation — pins #55: aget lowering must NOT be
+   ns-sensitive. A parametric-array kernel's reads arrive DEVIRTUALIZED
+   ((.invk aget-impl arr i) with :raster.op/original), a typed-array kernel's
+   as bare clojure.core/aget — both must lower to the subscript `arr[i]`.
+   Before the fix SegRed skipped normalize-array-prims (SegMap didn't) and its
+   let*-rewrap dropped the metadata, so the devirtualized shape fell through
+   to a broken gpufn_aget helper call (qlinear-k) while the typed shape
+   emitted x[i] (decoder-gpu)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.soac :as soac]
+            [raster.compiler.passes.parallel.soac-lower :as lower]
+            [raster.compiler.backend.gpu.segop-opencl :as sg]))
+
+(defn- segred-source [body-expr]
+  (let [form (list 'raster.par/reduce 'acc 0.0 'j 'n body-expr)
+        s (soac/par-form->soac 'result form 0)
+        segops (lower/lower-reduce s nil)]
+    (:source (sg/generate-segred-kernel (first segops) 'out :dtype :float))))
+
+(deftest segred-devirtualized-aget-lowers-to-subscript
+  (testing "the parametric (.invk aget-impl …) shape — the qlinear-k side of #55"
+    (let [aget-invk (with-meta (list '.invk 'raster.arrays/aget_m_floats_long-impl 'a 'j)
+                               {:raster.op/original 'raster.arrays/aget
+                                :raster.type/tag 'float})
+          plus-invk (with-meta (list '.invk 'raster.numeric/_plus__m_double_double-impl
+                                     'acc (list 'double aget-invk))
+                               {:raster.op/original 'raster.numeric/+
+                                :raster.type/tag 'double})
+          src (segred-source plus-invk)]
+      (is (not (re-find #"gpufn_aget" src))
+          "devirtualized aget must normalize to a subscript, not a helper call")
+      (is (re-find #"a\[" src)))))
+
+(deftest segred-bare-aget-lowers-to-subscript
+  (testing "the typed clojure.core/aget shape — the decoder-gpu side of #55"
+    (let [src (segred-source '(+ acc (clojure.core/aget a j)))]
+      (is (not (re-find #"gpufn_aget" src)))
+      (is (re-find #"a\[" src)))))


### PR DESCRIPTION
Scoped by a full canonicalization report (`.internal/emitter_review/4_canonicalization_scope.md`, gitignored): the walker resolved call-position symbols ad-hoc along 7+ divergent paths, so the same op reached emitters in multiple spellings — the root of every downstream `#{'x 'clojure.core/x 'raster.arrays/x}` set and of #55.

## walk: one canonicalization point

Call-position heads canonicalize **once in `walk`, before classification** — aliased heads (`ra/aget`, `n/+`) resolve to their canonical var symbol. Deliberate scope decision: the array family is **not** collapsed to `clojure.core/*` in the walk — typed arrays get that from the `:array-op` handler, but parametric arrays must still reach `:deftm-call` for dispatch. The walk's output spellings per array op are exactly two well-defined shapes: `clojure.core/x` (typed) and `.invk` + `:raster.op/original` (parametric).

## #55 fixed

SegRed never called `normalize-array-prims` on its lambda (SegMap has since #37), **and** its `let*` rewrap dropped metadata — severing `:raster.op/original` on devirtualized aget forms: broken `gpufn_aget` calls (qlinear-k) vs correct `x[i]` (decoder-gpu). SegRed now normalizes like SegMap and preserves metadata; both shapes pinned in `segop_opencl_test.clj`.

## Validation

Full Valhalla suite: 1726/28762/0/0, census 0. (Part 2 — registry-centralized recognition — follows in its own PR.)