### PR TITLE
#61 (part 2): centralize array-op recognition on the op-descriptor registry

### DIFF
--- a/src/raster/compiler/backend/wasm/emit.clj
+++ b/src/raster/compiler/backend/wasm/emit.clj
@@ -14,7 +14,8 @@
    memory). Float element type from the array param's tag (doubles→f64, floats→f32).
    Every loop returns its non-recur (else) value, so the function result type is
    the deftm's return tag."
-  (:require [raster.compiler.ir.form :as form]
+  (:require [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.ir.form :as form]
             [raster.compiler.backend.wasm.encoder :as e]
             [raster.compiler.backend.wasm.transcendental :as tr]
             [raster.compiler.backend.intrinsics :as ix]))
@@ -164,7 +165,7 @@
               (cond-> (emit-val ctx x)
                 (= xv :f64) (into (e/i :f32.demote_f64))      ; (float <f64>) → demote
                 (= xv :i32) (into (e/i :f32.convert_i32_s)))))) ; (float <i32>) → convert
-        (#{'clojure.core/aget 'raster.arrays/aget} h)
+        (descriptor/aget-op? h)
         (let [[arr idx] A elem (get-in ctx [:elems arr])]
           (into (addr ctx arr idx) (e/mem-load (:load elem) (:align elem) 0)))
         ;; integer step (inc/dec, incl. unchecked-*-int) — index/counter steppers
@@ -207,7 +208,7 @@
         ;; e.g. f32-loads an int array — seen in qgemm's int-aget helper).
         (and (= h '.invk)
              (let [op (:raster.op/original (meta node))]
-               (contains? #{'raster.arrays/aget 'clojure.core/aget} op)))
+               (descriptor/aget-op? op)))
         (emit-val ctx (with-meta (cons (:raster.op/original (meta node)) (rest A))
                                  (meta node)))
         ;; non-intrinsic deftm callee kept as a real wasm function (not inlined):
@@ -434,7 +435,7 @@
             (infer-vt c' (if (ends-in-recur? then) els then)))
           (= 'throw h) :diverge                        ; never produces a value
           (= :dp4a (ix/canonical h)) :i32              ; int8 dot-accumulate → i32
-          (#{'clojure.core/aget 'raster.arrays/aget} h) (get-in ctx [:elems (second node) :vt] :f64)
+          (descriptor/aget-op? h) (get-in ctx [:elems (second node) :vt] :f64)
           ;; registered numeric op/intrinsic: comparisons → bool (i32); arith /
           ;; math / rem-mod → element type of first operand
           (ix/canonical h) (if (= :cmp (ix/kind h)) :i32 (infer-vt ctx (second node)))
@@ -456,7 +457,7 @@
       (and (= h '.invk) (:raster.op/original (meta node)))
       (emit-effect ctx (with-meta (cons (:raster.op/original (meta node)) (rest A))
                                   (meta node)))
-      (#{'clojure.core/aset 'raster.arrays/aset} h)
+      (descriptor/aset-op? h)
       (let [[arr idx v] A elem (get-in ctx [:elems arr])]
         (when-not elem
           (throw (ex-info (str "aset target " arr " has no element info (not an array param?)")

--- a/src/raster/compiler/core/inference.clj
+++ b/src/raster/compiler/core/inference.clj
@@ -1831,7 +1831,7 @@
             (descriptor/scalar-op? head)
             (let [arg-tags (keep #(infer-arg-tag % env) (rest expr))]
               (cond
-                (contains? #{'clojure.core/alength 'raster.arrays/alength} head) 'long
+                (descriptor/alength-op? head) 'long
                 (some #{'double} arg-tags) 'double
                 (some #{'float} arg-tags) 'float
                 (some #{'long} arg-tags) 'long

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -12,7 +12,8 @@
   - Readable: each form handler is a separate, named function
   - Testable: handlers can be unit-tested with synthetic contexts
   - Extensible: new form types can be added via defmethod"
-  (:require [clojure.string :as str]
+  (:require [raster.compiler.core.op-descriptor :as descriptor]
+            [clojure.string :as str]
             [raster.compiler.core.types :as types]
             [raster.compiler.core.inference :as inf]
             [raster.compiler.core.macroexpand :as mex]))
@@ -553,7 +554,7 @@
           (when (every? some? ranks)
             (some (fn [[t r]] (when (= r (apply max ranks)) t)) numeric-tag-rank)))
         ;; array read: element type off the array's type-env entry
-        (contains? '#{clojure.core/aget raster.arrays/aget} h)
+        (descriptor/aget-op? h)
         (get-in type-env [(second x) :element])
         :else nil))
     :else nil))

--- a/src/raster/compiler/passes/scalar/dce.clj
+++ b/src/raster/compiler/passes/scalar/dce.clj
@@ -162,7 +162,7 @@
        (symbol? (second init))
        (not (contains? bound-syms (second init)))
        (or (.startsWith (name (first init)) ".")                  ; .field / .-field / (. obj field) — value-class field access (any interop form)
-           (contains? '#{aget clojure.core/aget raster.arrays/aget} (first init)))))
+           (descriptor/aget-op? (first init)))))
 
 (defn eliminate-dead-bindings
   "Remove dead bindings from a flat let* form.

--- a/src/raster/compiler/passes/scalar/soa_lower.clj
+++ b/src/raster/compiler/passes/scalar/soa_lower.clj
@@ -18,7 +18,8 @@
    deftm* (a `.invk` returning a value type whose body is a bare constructor) is
    NOT inlined by the current inliner, so such calls don't explode yet — that's a
    separable follow-on (extend inlinable-body? / inline value-type deftms)."
-  (:require [raster.compiler.core.types :as types]
+  (:require [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.types :as types]
             [clojure.walk :as walk]))
 
 (defn field-arr-sym [soa-sym field-name]
@@ -81,11 +82,12 @@
          (and (.startsWith s ".") (> (count s) 1) (not (#{".invk" "."} s))))))
 
 (defn- aget-head? [head]
-  (or (#{'aget 'clojure.core/aget 'raster.arrays/aget} head)
+  (or (descriptor/aget-op? head)
       (.startsWith (local-name head) "aget-")))
 
 (defn- aset-head? [head]
-  (or (#{'aset 'clojure.core/aset 'raster.arrays/aset 'raster.arrays/aset!} head)
+  (or (descriptor/aset-op? head)
+      (= 'raster.arrays/aset! head)
       (.startsWith (local-name head) "aset-")))
 
 ;; ctx: {:soa {soa-sym → soa-info}  :exploded {local-sym → {field-name → expr}}}


### PR DESCRIPTION
Follow-on to #33. The scope-report audit found the full singleton collapse is **not yet legal**: `ad/reverse.clj` emits `raster.arrays/alength`/`zeros-like` forms, and passes like DCE run between AD-emission and the rewalk — mid-pipeline multi-spelling recognition is a pipeline-stage fact (same gate class as the unwalked ABM/c_emit paths).

What lands instead is the codebase's own stated design rule — **passes query the registry, never local `#{…}` literals**: DCE alias-liveness, soa_lower head predicates, inference's alength rule, the walker's walked-value-tag, and 4 wasm emitter sites now delegate to `descriptor/aget-op?`/`aset-op?`/`alength-op?`. Adding a spelling is one registry entry. The classify-time `:array-op` set stays local by design (bare-source input surface, pre-canonicalization).

## Validation
Full Valhalla suite: **1726 / 28762 / 0 / 0, census 0**. Targeted walker+wasm+segred+par: 99/400/0/0.