### PR TITLE
AD: residual-add rule + float daxpy-diff! (float training support)

### DIFF
--- a/src/raster/dl/nn.clj
+++ b/src/raster/dl/nn.clj
@@ -553,6 +553,14 @@
 (deftm residual-add (All [T] [a :- (Array T) b :- (Array T) n :- Long] :- (Array T)
                          (broadcast [a b] (+ a b))))
 
+;; residual-add backward: d_a = d_b = dy (both copies — additive fan-out). A raw
+;; (broadcast [a b] (+ a b)) has no AD template for two active inputs, so the
+;; ubiquitous transformer residual (x + attn/mlp out) needs this explicit rule.
+(deftm residual-add-backward (All [T] [dy :- (Array T) n :- Long] :- (Array T)
+                                 (let [out (alloc-like dy n)]
+                                   (acopy! dy 0 out 0 n)
+                                   out)))
+
 ;; --- Group Norm ---
 ;; x:[batch, channels, spatial], gamma:[channels], beta:[channels]
 (deftm group-norm (All [T] [x :- (Array T) gamma :- (Array T)
@@ -1800,6 +1808,21 @@
                                                     dw (list 'raster.dl.nn/rms-norm-backward-dweight
                                                              adjoint-sym x rows features eps)])
                                            [dx dw nil nil nil nil]]))})
+
+;; residual-add rrule — elementwise sum (transformer residuals, LoRA base+delta).
+(tmpl/merge-into-template! 'raster.dl.nn/residual-add
+                           {:pullback-factory (fn [_result _a _b n]
+                                                (fn [dy]
+                                                  [(residual-add-backward dy n)
+                                                   (residual-add-backward dy n)
+                                                   nil]))
+                            :params '[a b n] :result nil :adjoint 'dy
+                            :grads-fn (fn [ctx [_a _b n] _result-sym adjoint-sym gensym-fn]
+                                        (let [da (gensym-fn "da") db (gensym-fn "db")]
+                                          [(update ctx :bindings into
+                                                   [da (list 'raster.dl.nn/residual-add-backward adjoint-sym n)
+                                                    db (list 'raster.dl.nn/residual-add-backward adjoint-sym n)])
+                                           [da db nil]]))})
 
 ;; hadamard rrule — elementwise product (gated MLPs). d_a = dy⊙b, d_b = dy⊙a.
 (tmpl/merge-into-template! 'raster.dl.nn/hadamard

--- a/src/raster/linalg/blas.clj
+++ b/src/raster/linalg/blas.clj
@@ -652,6 +652,27 @@
                                          (clojure.core/aget b i)))))
   out)
 
+;; Float overloads — the MSE-loss backward runs over whatever dtype the loss
+;; was computed in, so float training (e.g. LoRA over an f32/quantized base)
+;; needs these or reverse-AD's gradient step has no matching method.
+(deftm ^:no-inline daxpy-diff!
+  [a :- (Array float) b :- (Array float) scale :- Double n :- Long]
+  :- (Array float)
+  (let [out (float-array n)]
+    (dotimes [i n]
+      (clojure.core/aset out i (float (* scale (- (clojure.core/aget a i)
+                                                  (clojure.core/aget b i))))))
+    out))
+
+(deftm ^:no-inline daxpy-diff-into!
+  [a :- (Array float) b :- (Array float) scale :- Double n :- Long
+   out :- (Array float)]
+  :- (Array float)
+  (dotimes [i n]
+    (clojure.core/aset out i (float (* scale (- (clojure.core/aget a i)
+                                                (clojure.core/aget b i))))))
+  out)
+
 ;; ================================================================
 ;; Availability check
 ;; ================================================================


### PR DESCRIPTION
Two small additive AD rules needed by the LoRA fine-tuning package (finetune-rstr), split out after #36 merged.

- **`nn/residual-add` pullback** (`d_a = d_b = dy`): the ubiquitous transformer residual (`x + attn/mlp out`) and LoRA's `base + delta` add. A raw two-active `broadcast (+ a b)` has no AD template (same class as the hadamard gap #36 fixed for `*`).
- **`daxpy-diff!` / `daxpy-diff-into!` FLOAT overloads**: the MSE-loss backward runs over the loss's dtype, so **float** training (LoRA over an f32/quantized base) needs these or reverse-AD's gradient step has no matching method — they were double-only.

Both validated by the finetune-rstr end-to-end LoRA test (adapter trains over a frozen Q8 base in f32). Full Valhalla suite: **1738 / 28815 / 0 / 0, census 0**.