### PR TITLE
AD: Π tangent-type protocol — typed seeds/zeros/projection from primal tags (#44)

### DIFF
--- a/src/raster/ad/reverse.clj
+++ b/src/raster/ad/reverse.clj
@@ -28,6 +28,7 @@
             [raster.compiler.core.op-descriptor :as op]
             [raster.compiler.core.inference :as inf]
             [raster.ad.reverse.normalize :as anf]
+            [raster.ad.tangent :as tangent]
             [raster.compiler.ir.form :as form]
             [raster.compiler.passes.scalar.inline :as inline]
             [raster.compiler.passes.parallel.materialize :as materialize]
@@ -148,7 +149,9 @@
   (if (form/binding-form? body)
     body
     (with-ad-gensym
-      (let [r-sym (ad-gensym "adbody")
+      ;; Propagate the body form's type tag onto the wrapper sym so the
+      ;; tangent protocol can emit a statically-typed zero for it.
+      (let [r-sym (ad-gensym "adbody" (:raster.type/tag (meta body)))
             anf-b (anf-normalize-bindings [r-sym body])]
         (list 'let* anf-b r-sym)))))
 
@@ -160,8 +163,9 @@
 
 (def ^:private differentiable-tag?
   "Param tags that carry gradient. Floating-point arrays and scalars only —
-  Long/long, longs (indices), Boolean, Object, etc. are never differentiated."
-  #{'doubles 'floats 'double 'float})
+  Long/long, longs (indices), Boolean, Object, etc. are never differentiated.
+  Delegates to the tangent-type protocol (Π) — the type-level ⊥ test."
+  tangent/differentiable?)
 
 (defn- auto-make-deftm-rule
   "Create a transient AD rule for a deftm op that has no explicit template.
@@ -441,12 +445,14 @@
    (partition 2 norm-bindings)))
 
 (defn- array-zero-of-shape
-  "Form for a zero adjoint array shaped like `arr-sym` (doubles/floats), else 0.0."
+  "Form for a typed zero adjoint shaped like `arr-sym`, derived from its
+  :raster.type/tag (Π). doubles/floats → typed array ctor; double/float →
+  typed scalar zero. FAIL-LOUD on untagged/⊥ tags: the old scalar-0.0
+  fallback could silently mis-shape an array slot. Callers must only
+  materialize this zero when it is actually consumed (compute lazily)."
   [arr-sym]
-  (case (:raster.type/tag (meta arr-sym))
-    doubles (list 'double-array (list 'raster.arrays/alength arr-sym))
-    floats  (list 'float-array  (list 'raster.arrays/alength arr-sym))
-    0.0))
+  (tangent/zero-expr (:raster.type/tag (meta arr-sym))
+                     (list 'raster.arrays/alength arr-sym)))
 
 (defn- wire-read-adjoints
   "Append the per-read-array and per-scalar gradient syms into adj-env (the SOAC
@@ -497,12 +503,19 @@
   [{:keys [sym branch then else]} adj-sym activity {:keys [adj-env rev-ctx]}]
   ;; Route the adjoint to the taken branch; the other branch gets a SHAPE-matched
   ;; zero (a scalar 0.0 where an array is expected crashes array-add-backward).
-  (let [zero (array-zero-of-shape sym)
+  ;; Tagged syms get a STATIC typed zero (fail-loud for known-⊥ tags); untagged
+  ;; syms fall back to the runtime `zero-like` on the primal — dynamically
+  ;; typed Π, which unlike the old scalar 0.0 cannot mis-shape an array slot.
+  ;; `zero` is a delay so the fail-loud path only fires when a branch
+  ;; actually materializes the zero.
+  (let [zero (delay (if (some? (:raster.type/tag (meta sym)))
+                      (array-zero-of-shape sym)
+                      (list 'raster.ad.tangent/zero-like sym)))
         adj-env (cond-> adj-env
                   (and (symbol? then) (get activity then false))
-                  (update then (fnil conj []) (list 'if branch adj-sym zero))
+                  (update then (fnil conj []) (list 'if branch adj-sym @zero))
                   (and else (symbol? else) (get activity else false))
-                  (update else (fnil conj []) (list 'if branch zero adj-sym)))]
+                  (update else (fnil conj []) (list 'if branch @zero adj-sym)))]
     {:adj-env adj-env :rev-ctx rev-ctx}))
 
 (defmethod emit-backward :alias
@@ -521,10 +534,11 @@
         ;; adj-env[sym]; a direct buffer write lands in adj-env[out-arr]. SUM both
         ;; (grad-acc element-wise) — dropping either disconnects the gradient.
         rev-ctx (if-let [out-arr (first written-arrs)]
-                  (bindings-into rev-ctx
-                                 [d-out-sym (sum-contribs (concat (get adj-env sym)
-                                                                  (get adj-env out-arr))
-                                                          (array-zero-of-shape out-arr))])
+                  (let [contribs (concat (get adj-env sym) (get adj-env out-arr))
+                        ;; Materialize the typed zero (fail-loud on unknown
+                        ;; tangent space) only when there are no contributions.
+                        default (when (empty? contribs) (array-zero-of-shape out-arr))]
+                    (bindings-into rev-ctx [d-out-sym (sum-contribs contribs default)]))
                   rev-ctx)
         rev-ctx (reduce bindings-into rev-ctx backward-maps)
         rev-ctx (reduce bindings-into rev-ctx backward-reduces)]
@@ -536,8 +550,14 @@
            shadow-allocs backward-maps backward-reduces d-acc-sym]}
    _adj-sym _activity {:keys [adj-env rev-ctx]}]
   (let [rev-ctx (bindings-into rev-ctx (vec shadow-allocs))
-        ;; par/reduce returns a SCALAR — 0.0 default is correct for the empty case.
-        rev-ctx (bindings-into rev-ctx [d-acc-sym (sum-contribs (get adj-env sym) 0.0)])
+        ;; par/reduce returns a SCALAR — a typed scalar zero (Π on the reduce
+        ;; result's tag) for the empty case; untagged stays the double 0.0
+        ;; (scalar slots cannot mis-shape, only mis-dtype).
+        acc-tag (:raster.type/tag (meta sym))
+        acc-zero (if (= :scalar (:kind (tangent/tangent-kind acc-tag)))
+                   (tangent/zero-expr acc-tag nil)
+                   0.0)
+        rev-ctx (bindings-into rev-ctx [d-acc-sym (sum-contribs (get adj-env sym) acc-zero)])
         rev-ctx (reduce bindings-into rev-ctx backward-maps)
         rev-ctx (reduce bindings-into rev-ctx backward-reduces)]
     {:rev-ctx rev-ctx
@@ -551,10 +571,9 @@
         ;; result sym aliases the buffer — sum consumer (adj-env[sym]) and direct
         ;; buffer (adj-env[out-arr]) contributions (see :par-map).
         rev-ctx (if-let [out-arr (first written-arrs)]
-                  (bindings-into rev-ctx
-                                 [d-out-sym (sum-contribs (concat (get adj-env sym)
-                                                                  (get adj-env out-arr))
-                                                          (array-zero-of-shape out-arr))])
+                  (let [contribs (concat (get adj-env sym) (get adj-env out-arr))
+                        default (when (empty? contribs) (array-zero-of-shape out-arr))]
+                    (bindings-into rev-ctx [d-out-sym (sum-contribs contribs default)]))
                   rev-ctx)
         rev-ctx (bindings-into rev-ctx [n-bwd-sym bound-expr])
         bwd-result-sym (ad-gensym "dt_bwd")
@@ -588,22 +607,45 @@
    {:adj-env seed-adj-env :rev-ctx (bind-ctx/make-ctx ad-gensym)}
    (reverse records)))
 
+(defn- param-zero-expr
+  "Typed zero default for a param's adjoint slot (Π): array params get a
+  shape-matched typed zero (zeros-like keeps the exemplar's dtype), scalar
+  params a typed scalar zero. Untagged params keep the scalar 0.0 double
+  default (the HVP path differentiates untagged double scalars)."
+  [p]
+  (let [tag (:raster.type/tag (meta p))]
+    (case (:kind (tangent/tangent-kind tag))
+      :array  (list 'raster.arrays/zeros-like p (list 'raster.arrays/alength p))
+      :scalar (tangent/zero-expr tag nil)
+      0.0)))
+
 (defn- collect-param-adjoints
   "Phase 3 (pure): bind a d_<param> for each active param (shape-matched zero when
-  no contributions) into rev-ctx; return {:rev-ctx :param-adj-syms}."
+  no contributions) into rev-ctx; return {:rev-ctx :param-adj-syms}.
+
+  Π at the boundary: each accumulated scalar adjoint is PROJECTED into the
+  primal param's tangent space — float params always (double contamination
+  via promotion is the default in raster.numeric), double params only when
+  float params are present (provably-double-only functions emit no cast).
+  Array adjoints are anchored by their typed shadow buffers — no cast."
   [active-params adj-env rev-ctx]
-  (reduce
-   (fn [{:keys [rev-ctx param-adj-syms]} p]
-     (let [tag (:raster.type/tag (meta p))
-           default (case tag
-                     doubles (list 'raster.arrays/zeros-like p (list 'raster.arrays/alength p))
-                     floats  (list 'raster.arrays/zeros-like p (list 'raster.arrays/alength p))
-                     0.0)
-           adj-sym (ad-gensym (str "d_" (name p)) tag)]
-       {:rev-ctx (bindings-into rev-ctx [adj-sym (sum-contribs (get adj-env p) default)])
-        :param-adj-syms (conj param-adj-syms adj-sym)}))
-   {:rev-ctx rev-ctx :param-adj-syms []}
-   active-params))
+  (let [param-dtype #(-> % meta :raster.type/tag tangent/tangent-kind :dtype)
+        mixed-float? (boolean (some #(= :float (param-dtype %)) active-params))]
+    (reduce
+     (fn [{:keys [rev-ctx param-adj-syms]} p]
+       (let [tag (:raster.type/tag (meta p))
+             {:keys [kind dtype]} (tangent/tangent-kind tag)
+             raw (sum-contribs (get adj-env p) (param-zero-expr p))
+             expr (if (and (= kind :scalar)
+                           (or (= dtype :float)
+                               (and (= dtype :double) mixed-float?)))
+                    (tangent/project-expr tag raw)
+                    raw)
+             adj-sym (ad-gensym (str "d_" (name p)) tag)]
+         {:rev-ctx (bindings-into rev-ctx [adj-sym expr])
+          :param-adj-syms (conj param-adj-syms adj-sym)}))
+     {:rev-ctx rev-ctx :param-adj-syms []}
+     active-params)))
 
 (defn- process-bindings
   "The shared engine: run Phases 1-3 over a NORMALIZED binding vector and return
@@ -1935,18 +1977,19 @@
         :else
         (let [body-expr (first body-exprs)]
           (cond
-            ;; Literal — zero gradient
+            ;; Literal — zero gradient (typed per param tag: a float-array
+            ;; param's slot must be a float[] zero, not a scalar 0.0)
             (or (number? body-expr) (nil? body-expr))
             (vector body-expr
                     (list 'fn* ['dy__rad]
-                          (vec (repeat (count active-params) 0.0))))
+                          (mapv param-zero-expr active-params)))
 
-            ;; Symbol — gradient is 1 for that param, 0 for others
+            ;; Symbol — gradient is 1 for that param, typed 0 for others
             (symbol? body-expr)
             (vector body-expr
                     (list 'fn* ['dy__rad]
-                          (vec (map (fn [p] (if (= p body-expr) 'dy__rad 0.0))
-                                    active-params))))
+                          (mapv (fn [p] (if (= p body-expr) 'dy__rad (param-zero-expr p)))
+                                active-params)))
 
             ;; If form — route through gen-reverse-let (normalization handles it)
             (and (seq? body-expr) (= 'if (first body-expr)))
@@ -2596,6 +2639,17 @@
                            [new-loop-form])
                     new-loop-form))))))))))
 
+(defn- body-tail-tag
+  "The :raster.type/tag of a walked body's TAIL expression — the type of the
+  actual primal the differentiated graph produces (which may be narrower than
+  the deftm's declared return type, e.g. a `:- Double` fn whose body is a
+  parametric T=float chain). Prefers the form's own tag, else descends
+  through binding forms to the final body expression."
+  [form]
+  (or (:raster.type/tag (meta form))
+      (when (and (seq? form) (form/binding-form? form) (seq (drop 2 form)))
+        (body-tail-tag (last form)))))
+
 (defn- build-grad-walked-body
   "Build the AD-transformed walked body for a deftm var.
   Returns {:walked-body [form], :params [sym ...], :source-ns ns}
@@ -2627,8 +2681,18 @@
                                    (when (differentiable-tag? (nth tags i nil)) p))
                                  all-params))
         source-ns (or (:ns m) *ns*)
-        ;; Infer dtype from parameter tags for correct AD seed type
-        dtype (if (some #{'floats 'float} tags) :float :double)
+        ;; Π: the SEED is the cotangent of the RESULT of the differentiated
+        ;; GRAPH, so its dtype derives from the walked body's TAIL tag (the
+        ;; actual primal flowing) — not from a global binary any-param-is-float
+        ;; switch, and NOT from the declared return tag: a fn declared
+        ;; `:- Double` whose body is a parametric float chain (T=float
+        ;; cross-entropy) needs a FLOAT seed for its pullback; the Double is
+        ;; only the .invk interface boundary. The legacy binary inference
+        ;; remains as fallback for untagged tails.
+        dtype (case (body-tail-tag (first walked-body))
+                float  :float
+                double :double
+                (if (some #{'floats 'float} tags) :float :double))
         ;; Lower: ANF-normalize + inline compound deftm ops into primitives
         ;; before AD, to a fixpoint so BARE and multi-level composites fully
         ;; inline (see lower-composites).

--- a/src/raster/ad/tangent.clj
+++ b/src/raster/ad/tangent.clj
@@ -1,0 +1,127 @@
+(ns raster.ad.tangent
+  "Π — the tangent-type protocol (framework §5, task #44).
+
+  A COMPILE-TIME protocol: these functions are consulted during the AD
+  transform / flatten / template codegen to emit correctly-TYPED seeds,
+  zeros, and casts in the generated IR, derived from the PRIMAL's type
+  tag. Never runtime wrapper objects — a tagged-object tangent flowing
+  through compiled code would destroy the flat fusible backward. The
+  tangent algebra acts at STAGE time and emits monomorphic code.
+
+  Runtime `nil` remains the dynamic ⊕-identity (grad-acc handles it);
+  ⊥ (no tangent space — Long/Boolean/Object slots) remains STATIC:
+  `differentiable?` is the type-level ⊥ test that activity analysis
+  abstracts.
+
+  Tag vocabulary is the :raster.type/tag / deftm-tags symbols:
+    double float          → scalar tangent spaces
+    doubles floats        → array tangent spaces
+    long longs int ints boolean Object … (and nil) → ⊥ (no tangent space)
+
+  Dependency-light BY DESIGN: no requires. Both raster.ad.reverse and
+  raster.compiler.ad.flatten (and compiler passes) may require this ns
+  without creating cycles."
+  (:refer-clojure :exclude []))
+
+(def ^:private scalar-tag->dtype {'double :double 'float :float})
+(def ^:private array-tag->dtype  {'doubles :double 'floats :float})
+
+(defn tangent-kind
+  "Classify a primal type tag into its tangent space.
+  Returns {:kind :scalar|:array, :dtype :double|:float} for tags with a
+  tangent space, {:kind :none} for ⊥ tags (integers, booleans, Object,
+  untagged/nil — no tangent space or statically unknown)."
+  [tag]
+  (if-let [dt (scalar-tag->dtype tag)]
+    {:kind :scalar :dtype dt}
+    (if-let [dt (array-tag->dtype tag)]
+      {:kind :array :dtype dt}
+      {:kind :none})))
+
+(defn differentiable?
+  "Type-level ⊥ test: does `tag` denote a tangent space that carries
+  gradient? (The single source of truth that reverse.clj's
+  differentiable-tag? and the inliner's local copy delegate to.)"
+  [tag]
+  (not= :none (:kind (tangent-kind tag))))
+
+(defn zero-expr
+  "IR expression for a typed zero cotangent of the tangent space of `tag`.
+  Scalars: a typed zero literal. Arrays: a typed array constructor sized
+  by `shape-expr` (an IR expression for the element count).
+
+  FAIL-LOUD on ⊥/unknown tags: a materialized zero whose tangent space is
+  unknown could silently mis-shape an array slot (scalar 0.0 where an
+  array adjoint is expected). Callers that can tolerate absence must use
+  nil (the dynamic 0̄) instead of asking for a materialized zero."
+  [tag shape-expr]
+  (let [{:keys [kind dtype]} (tangent-kind tag)]
+    (case kind
+      :scalar (case dtype :float (list 'float 0.0) :double 0.0)
+      :array  (case dtype
+                :float  (list 'float-array shape-expr)
+                :double (list 'double-array shape-expr))
+      (throw (ex-info (str "No tangent space for tag " (pr-str tag)
+                           " — cannot materialize a typed zero cotangent. "
+                           "Untagged adjoint slots must stay nil (dynamic 0̄) "
+                           "or the primal must carry a :raster.type/tag.")
+                      {:tag tag :shape-expr shape-expr})))))
+
+(defn seed-expr
+  "IR expression for the typed seed cotangent (1̄) of a SCALAR loss with
+  type `tag`. nil/unknown tags fall back to the double 1.0 (the loss of a
+  value+grad is scalar by contract; array tags fail loud)."
+  [tag]
+  (let [{:keys [kind dtype]} (tangent-kind tag)]
+    (case kind
+      :scalar (case dtype :float (list 'float 1.0) :double 1.0)
+      :none 1.0
+      (throw (ex-info (str "Seed requires a scalar loss; got array tag " (pr-str tag))
+                      {:tag tag})))))
+
+;; ================================================================
+;; Projection Π_x — runtime helpers + the expr emitter
+;; ================================================================
+
+(defn project-double
+  "Runtime Π onto a Double primal's tangent space. nil-safe: nil is the
+  dynamic 0̄ and passes through."
+  [x]
+  (when (some? x) (Double/valueOf (double x))))
+
+(defn project-float
+  "Runtime Π onto a Float primal's tangent space. nil-safe: nil is the
+  dynamic 0̄ and passes through."
+  [x]
+  (when (some? x) (Float/valueOf (float x))))
+
+(defn zero-like
+  "Runtime Π fallback: a zero cotangent shaped like the PRIMAL value `x`,
+  deriving dtype+shape dynamically. Used only where no static tag exists
+  (e.g. untagged if-result syms in runtime AD) — unlike a bare scalar 0.0
+  it can never mis-shape an array slot. nil (0̄) passes through."
+  [x]
+  (cond
+    (nil? x) nil
+    (instance? Double x) 0.0
+    (instance? Float x) (Float/valueOf (float 0.0))
+    (.isArray (class x))
+    (java.lang.reflect.Array/newInstance (.getComponentType (class x))
+                                         (java.lang.reflect.Array/getLength x))
+    (number? x) 0.0
+    :else (throw (ex-info (str "No runtime tangent zero for value of class "
+                               (class x))
+                          {:class (class x)}))))
+
+(defn project-expr
+  "Wrap `cotangent-expr` with the projection onto the tangent space of the
+  primal `tag` (Π_x), when the dtypes could mismatch. Scalars get a
+  nil-safe cast call; arrays and unknown tags pass through unchanged
+  (array adjoints are anchored by their typed shadow buffers)."
+  [tag cotangent-expr]
+  (let [{:keys [kind dtype]} (tangent-kind tag)]
+    (if (= kind :scalar)
+      (case dtype
+        :float  (list 'raster.ad.tangent/project-float cotangent-expr)
+        :double (list 'raster.ad.tangent/project-double cotangent-expr))
+      cotangent-expr)))

--- a/src/raster/compiler/ad/flatten.clj
+++ b/src/raster/compiler/ad/flatten.clj
@@ -24,7 +24,8 @@
   2. Extracts and inlines the reverse-pass bindings with dy=1.0
   3. Names the gradient outputs (one per active param)
   4. Appends SGD weight update calls: (nc/axpy! (- lr) d_Wi Wi)"
-  (:require [raster.compiler.ir.form :as form]))
+  (:require [raster.ad.tangent :as tangent]
+            [raster.compiler.ir.form :as form]))
 
 (def ^:dynamic *flatten-dtype*
   "Pipeline dtype for type-appropriate AD seed values.
@@ -159,12 +160,17 @@
            :param-adj-syms [d_p1 d_p2 ...] gradient symbols}
   or nil if form doesn't match AD pattern."
   [form]
-  (when-let [{:keys [fwd-bindings result-sym dy-sym
+  (when-let [{:keys [fwd-bindings result-sym body-sym dy-sym
                      rev-bindings param-adj-syms]} (extract-ad-structure form)]
-    (let [;; Seed value: 1.0 in the pipeline's dtype.
-          ;; Float pipelines use (float 1.0) so the adjoint matches
-          ;; the parametric return type of the loss function.
-          seed (case *flatten-dtype* :float (list 'float 1.0) 1.0)
+    (let [;; Seed value: 1.0 typed by the RESULT's tangent space (Π): the
+          ;; seed is the cotangent of the loss, so its dtype derives from
+          ;; the result/body sym's :raster.type/tag when present. Falls
+          ;; back to the pipeline-wide *flatten-dtype* for untagged results.
+          result-tag (or (some-> result-sym meta :raster.type/tag)
+                         (some-> body-sym meta :raster.type/tag))
+          seed (if (= :scalar (:kind (tangent/tangent-kind result-tag)))
+                 (tangent/seed-expr result-tag)
+                 (case *flatten-dtype* :float (list 'float 1.0) 1.0))
           ;; Build flat bindings: fwd + [dy seed] + rev
           flat-bindings (vec (concat fwd-bindings
                                      [dy-sym seed]

--- a/src/raster/compiler/passes/scalar/inline.clj
+++ b/src/raster/compiler/passes/scalar/inline.clj
@@ -4,6 +4,7 @@
 	This namespace owns cross-function inlining, pre-AD lowering, and
 	post-AD backend expansion. It does not perform buffer reuse."
   (:require [clojure.string :as str]
+            [raster.ad.tangent :as tangent]
             [raster.ad.templates :as rt]
             [raster.compiler.ad.flatten :as flatten]
             [raster.compiler.core.types :as types]
@@ -725,8 +726,9 @@
             ;; are constants for AD — passing them as active forces AD to look
             ;; for rules on integer ops like (quot d-model n-heads), which
             ;; don't exist (and shouldn't, since the result is non-diff).
-            ;; Same rule as raster.ad.reverse/build-grad-walked-body.
-            differentiable-tag? '#{doubles floats double float}
+            ;; Same rule as raster.ad.reverse/build-grad-walked-body —
+            ;; delegates to the tangent protocol's type-level ⊥ test.
+            differentiable-tag? tangent/differentiable?
             tags-vec (or tags (vec (repeat (count all-params) 'double)))
             active-params (vec (keep-indexed
                                 (fn [i p]

--- a/test/raster/ad/laws_test.clj
+++ b/test/raster/ad/laws_test.clj
@@ -17,6 +17,7 @@
             [raster.math :as m]
             [raster.arrays :as ra]
             [raster.ad.reverse :as rev]
+            [raster.ad.tangent :as tangent]
             [raster.ad.forward :as fwd]
             [raster.ad.jet :as jet]
             [raster.ad.templates :as tmpl]
@@ -288,6 +289,117 @@
     (let [x (fa 8 1) W (fa 12 2) tgt (fa 6 3)
           res ((rev/value+grad #'laws-lnb-mse) x W tgt 2 4 3)]
       (is (every? nil? (drop 4 res)) "batch/in/out Long slots are nil"))))
+
+;; ================================================================
+;; O3b — Π (tangent-type protocol): per-param dtype preservation
+;; (framework §5, task #44). Every cotangent lives in the tangent space
+;; of ITS OWN primal — dtype derives from each param's type tag, and
+;; the seed from the RESULT's type, never from a global binary switch.
+;; ================================================================
+
+;; Mixed scalars: Double × Float. d_x must stay Double, d_y must be Float.
+(deftm laws-pi-scalar [x :- Double, y :- Float] :- Double
+  (n/* x y))
+
+;; THE mixed acceptance shape: float array params + a Double scalar param
+;; + Long ⊥ slots, Double loss. loss = w * mse(linear-nb(x,W), tgt).
+(deftm laws-pi-mixed-d [x :- (Array float) W :- (Array float) tgt :- (Array float)
+                        w :- Double batch :- Long in :- Long out :- Long] :- Double
+  (n/* w (loss/mse-loss (nn/linear-nb x W batch in out) tgt (clojure.core/* batch out))))
+
+;; Same but w :- Float: d_w must come back Float (Π projects the Double
+;; cotangent dy·mse into Float32 — the daxpy-diff!-class bug direction).
+(deftm laws-pi-mixed-f [x :- (Array float) W :- (Array float) tgt :- (Array float)
+                        w :- Float batch :- Long in :- Long out :- Long] :- Double
+  (n/* w (loss/mse-loss (nn/linear-nb x W batch in out) tgt (clojure.core/* batch out))))
+
+;; Double-array twin of laws-lnb-mse for the double[] regression direction.
+(deftm laws-pi-darr [x :- (Array double) W :- (Array double) tgt :- (Array double)
+                     batch :- Long in :- Long out :- Long] :- Double
+  (loss/mse-loss (nn/linear-nb x W batch in out) tgt (clojure.core/* batch out)))
+
+(defn- da
+  "Deterministic Gaussian double array."
+  ^doubles [n seed]
+  (let [r (java.util.Random. (long seed)) a (double-array n)]
+    (dotimes [i n] (aset a i (.nextGaussian r))) a))
+
+(deftest o3b-tangent-type-protocol-law
+  (testing "mixed scalar dtypes: each grad in its own primal's tangent space"
+    (let [[v dx dy] ((rev/value+grad #'laws-pi-scalar) 2.0 (float 3.0))]
+      (is (instance? Double v))
+      (is (instance? Double dx) "d_x: Double primal → Double cotangent")
+      (is (instance? Float dy) "d_y: Float primal → Float cotangent (Π projects)")
+      (is (close? dx 3.0 tol-double))
+      (is (close? dy 2.0 tol-float))))
+
+  (testing "mixed array/scalar fn: per-param dtypes preserved in ONE fn"
+    (let [x (fa 8 11) W (fa 12 12) tgt (fa 6 13)
+          [v gx gW gtgt gw & longs] ((rev/value+grad #'laws-pi-mixed-d) x W tgt 2.0 2 4 3)
+          mse (loss/mse-loss (nn/linear-nb x W 2 4 3) tgt 6)]
+      (is (instance? Double v) "Double loss")
+      (is (instance? (Class/forName "[F") gx) "grad-x is float[]")
+      (is (instance? (Class/forName "[F") gW) "grad-W is float[]")
+      (is (instance? (Class/forName "[F") gtgt) "grad-tgt is float[] (typed zero default)")
+      (is (instance? Double gw) "grad-w is Double, not Float")
+      (is (every? nil? longs) "Long slots stay ⊥/nil")
+      (is (close? gw mse tol-double) "d(w·L)/dw = L")))
+
+  (testing "Float scalar param in a Double-loss fn: grad projected to Float"
+    (let [x (fa 8 21) W (fa 12 22) tgt (fa 6 23)
+          [v gx _gW _gtgt gw] ((rev/value+grad #'laws-pi-mixed-f) x W tgt (float 2.0) 2 4 3)
+          mse (loss/mse-loss (nn/linear-nb x W 2 4 3) tgt 6)]
+      (is (instance? Double v))
+      (is (instance? (Class/forName "[F") gx))
+      (is (instance? Float gw) "d_w: Float primal → Float cotangent")
+      (is (close? gw mse tol-float))))
+
+  (testing "float-only fn still yields float[] grads (regression)"
+    (let [x (fa 8 1) W (fa 12 2) tgt (fa 6 3)
+          [v gx gW gtgt] ((rev/value+grad #'laws-lnb-mse) x W tgt 2 4 3)]
+      (is (instance? Double v))
+      (is (instance? (Class/forName "[F") gx))
+      (is (instance? (Class/forName "[F") gW))
+      (is (instance? (Class/forName "[F") gtgt))))
+
+  (testing "double-only fn yields Double/double[] grads with no projection churn"
+    (let [[v dx dy] ((rev/value+grad #'laws-f6) 0.8 1.2)]
+      (is (instance? Double v))
+      (is (instance? Double dx))
+      (is (instance? Double dy)))
+    (let [x (da 8 31) W (da 12 32) tgt (da 6 33)
+          [v gx gW gtgt] ((rev/value+grad #'laws-pi-darr) x W tgt 2 4 3)]
+      (is (instance? Double v))
+      (is (instance? (Class/forName "[D") gx) "grad-x is double[]")
+      (is (instance? (Class/forName "[D") gW) "grad-W is double[]")
+      (is (instance? (Class/forName "[D") gtgt) "grad-tgt is double[]")))
+
+  (testing "materialized zeros are typed or fail loud (unit: the protocol + helper)"
+    ;; The protocol ns directly:
+    (is (= {:kind :array :dtype :float} (tangent/tangent-kind 'floats)))
+    (is (= {:kind :scalar :dtype :double} (tangent/tangent-kind 'double)))
+    (is (= {:kind :none} (tangent/tangent-kind 'long)))
+    (is (= {:kind :none} (tangent/tangent-kind nil)) "untagged = statically unknown = ⊥")
+    (is (= (list 'float-array 'n) (tangent/zero-expr 'floats 'n)))
+    (is (= 0.0 (tangent/zero-expr 'double 'n)))
+    (is (thrown? clojure.lang.ExceptionInfo (tangent/zero-expr nil 'n))
+        "unknown tangent space cannot materialize a zero")
+    (is (thrown? clojure.lang.ExceptionInfo (tangent/zero-expr 'long 'n))
+        "⊥ has no zero — NoTangent ≠ ZeroTangent")
+    ;; nil-safe runtime projection (0̄ passes through):
+    (is (nil? (tangent/project-double nil)))
+    (is (instance? Float (tangent/project-float 1.5)))
+    ;; zero-like: the dynamic fallback derives dtype+shape from the value.
+    (is (instance? (Class/forName "[F") (tangent/zero-like (float-array 3))))
+    (is (instance? Float (tangent/zero-like (float 2.0))))
+    (is (nil? (tangent/zero-like nil)))
+    ;; array-zero-of-shape (private helper): tag-reading path emits typed
+    ;; ctors; untagged throws instead of the old silent scalar 0.0.
+    (let [azos @#'rev/array-zero-of-shape]
+      (is (= (list 'float-array (list 'raster.arrays/alength 'xs))
+             (azos (with-meta 'xs {:raster.type/tag 'floats}))))
+      (is (thrown? clojure.lang.ExceptionInfo (azos 'untagged))
+          "untagged array slot fails loud, no scalar-0.0 mis-shape"))))
 
 ;; ================================================================
 ;; O4 — composition: HVP = FD(grad); Jet-k coeffs = k-th derivatives


### PR DESCRIPTION
Implements the Π tangent protocol (framework §5, task #44) as a **compile-time protocol**: `raster.ad.tangent` (dependency-free) provides `tangent-kind` / `differentiable?` / `zero-expr` / `seed-expr` / `project-expr` / `zero-like`, and the AD transform derives every materialized seed/zero/projection from the **primal's type tag** instead of the global binary `*flatten-dtype*` switch and hardcoded double fallbacks. Runtime `nil` remains the ⊕-identity; ⊥ (no tangent space) stays static and now **fails loud** where a zero is demanded of it (NoTangent ≠ ZeroTangent).

Key mechanics finding: the **seed must derive from the graph's tail tag, not the declared return tag** — `mlp-loss-f32 :- Double` has a float-parametric body whose pullbacks dispatch on a float dy; the old any-param-float sniff worked by luck. Seed = per-loss from the actual tail primal; per-param dtype enters at zero defaults + boundary projection ("one presentation, dtype at the boundaries").

Fixes the `daxpy-diff!`-class bug family at its root: **mixed-dtype functions now return each gradient in its own param's dtype** (float[] for float params, Double for double params, nil for ⊥ slots) — previously impossible. The silent scalar-`0.0` array-zero fallback is gone (fail-loud; audited: the `:if` backward legitimately needed a fallback → runtime `zero-like` derives dtype+shape from the primal value, cannot mis-shape).

New law `o3b-tangent-type-protocol-law`: the mixed acceptance fn (3×float[] + Double + 3×Long → 3×float[] grads, Double grad, 3×nil), Float-scalar-in-Double-loss → Float grad, dtype regressions, protocol unit laws (fail-loud zero on ⊥, nil-safe projection).

Deliberately left double: rule-internal math constants (rules stay generic, Π at boundaries), f64 accumulate-then-project reduce inits (numerics), HVP/Jet carriers.

Fresh JVM: **1732 / 28964 / 0 / 0, census 0** (dl/train, gsdm, gpt2_train, decoder_ad, norm_ad, f32 compiled, quant.train all green). Laws file alone: 9 tests / 176 assertions.