### PR TITLE
AD: forward/symbolic completion — Dual coverage, admissibility-constrained :auto, diff.clj demotion

### DIFF
--- a/src/raster/ad/forward.clj
+++ b/src/raster/ad/forward.clj
@@ -20,6 +20,7 @@
             [raster.par]
             [raster.numeric :as n]
             [raster.math :as m]
+            [raster.sci.special :as special]
             [raster.types.promote :as promote]))
 
 ;; ================================================================
@@ -292,6 +293,369 @@
                                  (dotimes [i len]
                                    (aset result i (n/* (aget px i) scale)))
                                  (->Dual (n/pow xv n) result))))
+
+;; pow with an active (Dual) exponent: d/dx x^n = n*x^(n-1), d/dn x^n = x^n ln(x)
+(deftm raster.numeric/pow (All [T] [x :- Dual, y :- Dual] :- Dual
+                               (let [xv (.v x) yv (.v y)
+                                     pv (n/pow xv yv)
+                                     dfdx (n/* yv (n/pow xv (n/- yv 1.0)))
+                                     dfdy (n/* pv (m/log xv))
+                                     px (.partials x) py (.partials y)
+                                     len (alength px)
+                                     result (aclone px)]
+                                 (dotimes [i len]
+                                   (aset result i (n/+ (n/* (aget px i) dfdx)
+                                                       (n/* (aget py i) dfdy))))
+                                 (->Dual pv result))))
+
+(deftm raster.numeric/pow (All [T] [x :- Double, y :- Dual] :- Dual
+                               (let [yv (.v y)
+                                     pv (n/pow x yv)
+                                     dfdy (n/* pv (m/log x))
+                                     py (.partials y)
+                                     len (alength py)
+                                     result (aclone py)]
+                                 (dotimes [i len]
+                                   (aset result i (n/* (aget py i) dfdy)))
+                                 (->Dual pv result))))
+
+;; ================================================================
+;; Math functions — carrier-coverage completion (framework §4a/§11):
+;; every scalar op with a reverse template gets a Dual lift. Forward
+;; mode is rule-free by construction — these are Σ-algebra overloads,
+;; NOT template registrations. Same chunked-partials style as above;
+;; parametric (All [T]) + n/ ops so Dual{Sym} flows (initiality, O6).
+;; ================================================================
+
+(deftm raster.math/tan (All [T] [x :- Dual] :- Dual
+                            (let [tv (m/tan (.v x))
+                                  scale (n/+ 1.0 (n/* tv tv))
+                                  px (.partials x)
+                                  len (alength px)
+                                  result (aclone px)]
+                              (dotimes [i len]
+                                (aset result i (n/* (aget px i) scale)))
+                              (->Dual tv result))))
+
+(deftm raster.math/asin (All [T] [x :- Dual] :- Dual
+                             (let [xv (.v x)
+                                   scale (n// 1.0 (n/sqrt (n/- 1.0 (n/* xv xv))))
+                                   px (.partials x)
+                                   len (alength px)
+                                   result (aclone px)]
+                               (dotimes [i len]
+                                 (aset result i (n/* (aget px i) scale)))
+                               (->Dual (m/asin xv) result))))
+
+(deftm raster.math/acos (All [T] [x :- Dual] :- Dual
+                             (let [xv (.v x)
+                                   scale (n/- (n// 1.0 (n/sqrt (n/- 1.0 (n/* xv xv)))))
+                                   px (.partials x)
+                                   len (alength px)
+                                   result (aclone px)]
+                               (dotimes [i len]
+                                 (aset result i (n/* (aget px i) scale)))
+                               (->Dual (m/acos xv) result))))
+
+(deftm raster.math/atan (All [T] [x :- Dual] :- Dual
+                             (let [xv (.v x)
+                                   scale (n// 1.0 (n/+ 1.0 (n/* xv xv)))
+                                   px (.partials x)
+                                   len (alength px)
+                                   result (aclone px)]
+                               (dotimes [i len]
+                                 (aset result i (n/* (aget px i) scale)))
+                               (->Dual (m/atan xv) result))))
+
+;; atan2(y, x): d/dy = x/(x²+y²), d/dx = -y/(x²+y²)
+(deftm raster.math/atan2 (All [T] [y :- Dual, x :- Dual] :- Dual
+                              (let [yv (.v y) xv (.v x)
+                                    denom (n/+ (n/* xv xv) (n/* yv yv))
+                                    py (.partials y) px (.partials x)
+                                    len (alength py)
+                                    result (aclone py)]
+                                (dotimes [i len]
+                                  (aset result i (n// (n/- (n/* (aget py i) xv)
+                                                           (n/* (aget px i) yv))
+                                                      denom)))
+                                (->Dual (m/atan2 yv xv) result))))
+
+(deftm raster.math/atan2 (All [T] [y :- Dual, x :- Number] :- Dual
+                              (let [yv (.v y)
+                                    denom (n/+ (n/* x x) (n/* yv yv))
+                                    py (.partials y)
+                                    len (alength py)
+                                    result (aclone py)]
+                                (dotimes [i len]
+                                  (aset result i (n// (n/* (aget py i) x) denom)))
+                                (->Dual (m/atan2 yv x) result))))
+
+(deftm raster.math/atan2 (All [T] [y :- Number, x :- Dual] :- Dual
+                              (let [xv (.v x)
+                                    denom (n/+ (n/* xv xv) (n/* y y))
+                                    px (.partials x)
+                                    len (alength px)
+                                    result (aclone px)]
+                                (dotimes [i len]
+                                  (aset result i (n/- (n// (n/* (aget px i) y) denom))))
+                                (->Dual (m/atan2 y xv) result))))
+
+(deftm raster.math/sinh (All [T] [x :- Dual] :- Dual
+                             (let [xv (.v x)
+                                   scale (m/cosh xv)
+                                   px (.partials x)
+                                   len (alength px)
+                                   result (aclone px)]
+                               (dotimes [i len]
+                                 (aset result i (n/* (aget px i) scale)))
+                               (->Dual (m/sinh xv) result))))
+
+(deftm raster.math/cosh (All [T] [x :- Dual] :- Dual
+                             (let [xv (.v x)
+                                   scale (m/sinh xv)
+                                   px (.partials x)
+                                   len (alength px)
+                                   result (aclone px)]
+                               (dotimes [i len]
+                                 (aset result i (n/* (aget px i) scale)))
+                               (->Dual (m/cosh xv) result))))
+
+(deftm raster.math/tanh (All [T] [x :- Dual] :- Dual
+                             (let [tv (m/tanh (.v x))
+                                   scale (n/- 1.0 (n/* tv tv))
+                                   px (.partials x)
+                                   len (alength px)
+                                   result (aclone px)]
+                               (dotimes [i len]
+                                 (aset result i (n/* (aget px i) scale)))
+                               (->Dual tv result))))
+
+(deftm raster.math/log1p (All [T] [x :- Dual] :- Dual
+                              (let [xv (.v x)
+                                    scale (n// 1.0 (n/+ 1.0 xv))
+                                    px (.partials x)
+                                    len (alength px)
+                                    result (aclone px)]
+                                (dotimes [i len]
+                                  (aset result i (n/* (aget px i) scale)))
+                                (->Dual (m/log1p xv) result))))
+
+(deftm raster.math/expm1 (All [T] [x :- Dual] :- Dual
+                              (let [ev (m/expm1 (.v x))
+                                    scale (n/+ ev 1.0)
+                                    px (.partials x)
+                                    len (alength px)
+                                    result (aclone px)]
+                                (dotimes [i len]
+                                  (aset result i (n/* (aget px i) scale)))
+                                (->Dual ev result))))
+
+(deftm raster.math/cbrt (All [T] [x :- Dual] :- Dual
+                             (let [cv (m/cbrt (.v x))
+                                   scale (n// 1.0 (n/* 3.0 (n/* cv cv)))
+                                   px (.partials x)
+                                   len (alength px)
+                                   result (aclone px)]
+                               (dotimes [i len]
+                                 (aset result i (n/* (aget px i) scale)))
+                               (->Dual cv result))))
+
+(deftm raster.math/log10 (All [T] [x :- Dual] :- Dual
+                              (let [xv (.v x)
+                                    scale (n// 1.0 (n/* xv 2.302585092994046))
+                                    px (.partials x)
+                                    len (alength px)
+                                    result (aclone px)]
+                                (dotimes [i len]
+                                  (aset result i (n/* (aget px i) scale)))
+                                (->Dual (m/log10 xv) result))))
+
+;; hypot(x, y): d/dx = x/hypot, d/dy = y/hypot
+(deftm raster.math/hypot (All [T] [x :- Dual, y :- Dual] :- Dual
+                              (let [xv (.v x) yv (.v y)
+                                    hv (m/hypot xv yv)
+                                    px (.partials x) py (.partials y)
+                                    len (alength px)
+                                    result (aclone px)]
+                                (dotimes [i len]
+                                  (aset result i (n// (n/+ (n/* (aget px i) xv)
+                                                           (n/* (aget py i) yv))
+                                                      hv)))
+                                (->Dual hv result))))
+
+(deftm raster.math/hypot (All [T] [x :- Dual, y :- Number] :- Dual
+                              (let [xv (.v x)
+                                    hv (m/hypot xv y)
+                                    px (.partials x)
+                                    len (alength px)
+                                    result (aclone px)]
+                                (dotimes [i len]
+                                  (aset result i (n// (n/* (aget px i) xv) hv)))
+                                (->Dual hv result))))
+
+(deftm raster.math/hypot (All [T] [x :- Number, y :- Dual] :- Dual
+                              (let [yv (.v y)
+                                    hv (m/hypot x yv)
+                                    py (.partials y)
+                                    len (alength py)
+                                    result (aclone py)]
+                                (dotimes [i len]
+                                  (aset result i (n// (n/* (aget py i) yv) hv)))
+                                (->Dual hv result))))
+
+;; ================================================================
+;; min/max — primal-select (branch on .v, like the comparisons above)
+;; + partial routing: the winner's partials flow, the loser's are
+;; dropped. Tie-breaking mirrors the reverse templates (min: x on
+;; ties via <=; max: x on ties via >=) so both modes agree at kinks.
+;; ================================================================
+
+(deftm raster.numeric/min [x :- Dual, y :- Dual] :- Dual
+  (if (clojure.core/<= (.v x) (.v y)) x y))
+
+(deftm raster.numeric/min [x :- Dual, y :- Double] :- Dual
+  (if (clojure.core/<= (.v x) y) x (->Dual y (zero-partials (.partials x)))))
+
+(deftm raster.numeric/min [x :- Double, y :- Dual] :- Dual
+  (if (clojure.core/<= x (.v y)) (->Dual x (zero-partials (.partials y))) y))
+
+(deftm raster.numeric/max [x :- Dual, y :- Dual] :- Dual
+  (if (clojure.core/>= (.v x) (.v y)) x y))
+
+(deftm raster.numeric/max [x :- Dual, y :- Double] :- Dual
+  (if (clojure.core/>= (.v x) y) x (->Dual y (zero-partials (.partials x)))))
+
+(deftm raster.numeric/max [x :- Double, y :- Dual] :- Dual
+  (if (clojure.core/>= x (.v y)) (->Dual x (zero-partials (.partials y))) y))
+
+;; ================================================================
+;; Special functions (raster.sci.special) — concrete Double carriers
+;; (the primal calls the double-only special-function implementations)
+;; ================================================================
+
+;; erf: d/dx = 2/sqrt(pi) * exp(-x²)
+(deftm raster.sci.special/erf [x :- Dual] :- Dual
+  (let [xv (.v x)
+        scale (n/* 1.1283791670955126 (m/exp (n/- (n/* xv xv))))
+        px (.partials x)
+        len (alength px)
+        result (aclone px)]
+    (dotimes [i len]
+      (aset result i (n/* (aget px i) scale)))
+    (->Dual (special/erf xv) result)))
+
+;; erfc = 1 - erf: d/dx = -2/sqrt(pi) * exp(-x²)
+(deftm raster.sci.special/erfc [x :- Dual] :- Dual
+  (let [xv (.v x)
+        scale (n/* -1.1283791670955126 (m/exp (n/- (n/* xv xv))))
+        px (.partials x)
+        len (alength px)
+        result (aclone px)]
+    (dotimes [i len]
+      (aset result i (n/* (aget px i) scale)))
+    (->Dual (special/erfc xv) result)))
+
+;; erfinv: d/dy = sqrt(pi)/2 * exp(erfinv(y)²)
+(deftm raster.sci.special/erfinv [y :- Dual] :- Dual
+  (let [rv (special/erfinv (.v y))
+        scale (n/* 0.8862269254527579 (m/exp (n/* rv rv)))
+        py (.partials y)
+        len (alength py)
+        result (aclone py)]
+    (dotimes [i len]
+      (aset result i (n/* (aget py i) scale)))
+    (->Dual rv result)))
+
+;; lgamma: d/dx = digamma(x)
+(deftm raster.sci.special/lgamma [x :- Dual] :- Dual
+  (let [xv (.v x)
+        scale (special/digamma xv)
+        px (.partials x)
+        len (alength px)
+        result (aclone px)]
+    (dotimes [i len]
+      (aset result i (n/* (aget px i) scale)))
+    (->Dual (special/lgamma xv) result)))
+
+;; digamma: d/dx = trigamma(x)
+(deftm raster.sci.special/digamma [x :- Dual] :- Dual
+  (let [xv (.v x)
+        scale (special/trigamma xv)
+        px (.partials x)
+        len (alength px)
+        result (aclone px)]
+    (dotimes [i len]
+      (aset result i (n/* (aget px i) scale)))
+    (->Dual (special/digamma xv) result)))
+
+;; expit (sigmoid): d/dx = s(x)(1 - s(x))
+(deftm raster.sci.special/expit [x :- Dual] :- Dual
+  (let [sv (special/expit (.v x))
+        scale (n/* sv (n/- 1.0 sv))
+        px (.partials x)
+        len (alength px)
+        result (aclone px)]
+    (dotimes [i len]
+      (aset result i (n/* (aget px i) scale)))
+    (->Dual sv result)))
+
+;; logit: d/dx = 1/(x(1-x))
+(deftm raster.sci.special/logit [x :- Dual] :- Dual
+  (let [xv (.v x)
+        scale (n// 1.0 (n/* xv (n/- 1.0 xv)))
+        px (.partials x)
+        len (alength px)
+        result (aclone px)]
+    (dotimes [i len]
+      (aset result i (n/* (aget px i) scale)))
+    (->Dual (special/logit xv) result)))
+
+;; log1pexp (softplus): d/dx = expit(x)
+(deftm raster.sci.special/log1pexp [x :- Dual] :- Dual
+  (let [xv (.v x)
+        scale (special/expit xv)
+        px (.partials x)
+        len (alength px)
+        result (aclone px)]
+    (dotimes [i len]
+      (aset result i (n/* (aget px i) scale)))
+    (->Dual (special/log1pexp xv) result)))
+
+;; besselj0: d/dx J0(x) = -J1(x)
+(deftm raster.sci.special/besselj0 [x :- Dual] :- Dual
+  (let [xv (.v x)
+        scale (n/- (special/besselj1 xv))
+        px (.partials x)
+        len (alength px)
+        result (aclone px)]
+    (dotimes [i len]
+      (aset result i (n/* (aget px i) scale)))
+    (->Dual (special/besselj0 xv) result)))
+
+;; besselj1: d/dx J1(x) = J0(x) - J1(x)/x
+(deftm raster.sci.special/besselj1 [x :- Dual] :- Dual
+  (let [xv (.v x)
+        scale (n/- (special/besselj0 xv) (n// (special/besselj1 xv) xv))
+        px (.partials x)
+        len (alength px)
+        result (aclone px)]
+    (dotimes [i len]
+      (aset result i (n/* (aget px i) scale)))
+    (->Dual (special/besselj1 xv) result)))
+
+;; betainc: differentiable in x only (a, b parameters — same contract
+;; as the reverse template): d/dx I_x(a,b) = x^(a-1)(1-x)^(b-1)/B(a,b)
+(deftm raster.sci.special/betainc [a :- Double, b :- Double, x :- Dual] :- Dual
+  (let [xv (.v x)
+        scale (n// (n/* (n/pow xv (n/- a 1.0))
+                        (n/pow (n/- 1.0 xv) (n/- b 1.0)))
+                   (special/beta a b))
+        px (.partials x)
+        len (alength px)
+        result (aclone px)]
+    (dotimes [i len]
+      (aset result i (n/* (aget px i) scale)))
+    (->Dual (special/betainc a b xv) result)))
 
 ;; Re-export math functions for backward compatibility.
 ;; After loading raster.ad, these dispatch to raster.math/* or raster.numeric/*

--- a/src/raster/ad/reverse.clj
+++ b/src/raster/ad/reverse.clj
@@ -28,6 +28,7 @@
             [raster.compiler.core.op-descriptor :as op]
             [raster.compiler.core.inference :as inf]
             [raster.ad.reverse.normalize :as anf]
+            [raster.ad.tangent :as tangent]
             [raster.compiler.ir.form :as form]
             [raster.compiler.passes.scalar.inline :as inline]
             [raster.compiler.passes.parallel.materialize :as materialize]
@@ -148,7 +149,9 @@
   (if (form/binding-form? body)
     body
     (with-ad-gensym
-      (let [r-sym (ad-gensym "adbody")
+      ;; Propagate the body form's type tag onto the wrapper sym so the
+      ;; tangent protocol can emit a statically-typed zero for it.
+      (let [r-sym (ad-gensym "adbody" (:raster.type/tag (meta body)))
             anf-b (anf-normalize-bindings [r-sym body])]
         (list 'let* anf-b r-sym)))))
 
@@ -160,8 +163,9 @@
 
 (def ^:private differentiable-tag?
   "Param tags that carry gradient. Floating-point arrays and scalars only —
-  Long/long, longs (indices), Boolean, Object, etc. are never differentiated."
-  #{'doubles 'floats 'double 'float})
+  Long/long, longs (indices), Boolean, Object, etc. are never differentiated.
+  Delegates to the tangent-type protocol (Π) — the type-level ⊥ test."
+  tangent/differentiable?)
 
 (defn- auto-make-deftm-rule
   "Create a transient AD rule for a deftm op that has no explicit template.
@@ -441,12 +445,14 @@
    (partition 2 norm-bindings)))
 
 (defn- array-zero-of-shape
-  "Form for a zero adjoint array shaped like `arr-sym` (doubles/floats), else 0.0."
+  "Form for a typed zero adjoint shaped like `arr-sym`, derived from its
+  :raster.type/tag (Π). doubles/floats → typed array ctor; double/float →
+  typed scalar zero. FAIL-LOUD on untagged/⊥ tags: the old scalar-0.0
+  fallback could silently mis-shape an array slot. Callers must only
+  materialize this zero when it is actually consumed (compute lazily)."
   [arr-sym]
-  (case (:raster.type/tag (meta arr-sym))
-    doubles (list 'double-array (list 'raster.arrays/alength arr-sym))
-    floats  (list 'float-array  (list 'raster.arrays/alength arr-sym))
-    0.0))
+  (tangent/zero-expr (:raster.type/tag (meta arr-sym))
+                     (list 'raster.arrays/alength arr-sym)))
 
 (defn- wire-read-adjoints
   "Append the per-read-array and per-scalar gradient syms into adj-env (the SOAC
@@ -497,12 +503,19 @@
   [{:keys [sym branch then else]} adj-sym activity {:keys [adj-env rev-ctx]}]
   ;; Route the adjoint to the taken branch; the other branch gets a SHAPE-matched
   ;; zero (a scalar 0.0 where an array is expected crashes array-add-backward).
-  (let [zero (array-zero-of-shape sym)
+  ;; Tagged syms get a STATIC typed zero (fail-loud for known-⊥ tags); untagged
+  ;; syms fall back to the runtime `zero-like` on the primal — dynamically
+  ;; typed Π, which unlike the old scalar 0.0 cannot mis-shape an array slot.
+  ;; `zero` is a delay so the fail-loud path only fires when a branch
+  ;; actually materializes the zero.
+  (let [zero (delay (if (some? (:raster.type/tag (meta sym)))
+                      (array-zero-of-shape sym)
+                      (list 'raster.ad.tangent/zero-like sym)))
         adj-env (cond-> adj-env
                   (and (symbol? then) (get activity then false))
-                  (update then (fnil conj []) (list 'if branch adj-sym zero))
+                  (update then (fnil conj []) (list 'if branch adj-sym @zero))
                   (and else (symbol? else) (get activity else false))
-                  (update else (fnil conj []) (list 'if branch zero adj-sym)))]
+                  (update else (fnil conj []) (list 'if branch @zero adj-sym)))]
     {:adj-env adj-env :rev-ctx rev-ctx}))
 
 (defmethod emit-backward :alias
@@ -521,10 +534,11 @@
         ;; adj-env[sym]; a direct buffer write lands in adj-env[out-arr]. SUM both
         ;; (grad-acc element-wise) — dropping either disconnects the gradient.
         rev-ctx (if-let [out-arr (first written-arrs)]
-                  (bindings-into rev-ctx
-                                 [d-out-sym (sum-contribs (concat (get adj-env sym)
-                                                                  (get adj-env out-arr))
-                                                          (array-zero-of-shape out-arr))])
+                  (let [contribs (concat (get adj-env sym) (get adj-env out-arr))
+                        ;; Materialize the typed zero (fail-loud on unknown
+                        ;; tangent space) only when there are no contributions.
+                        default (when (empty? contribs) (array-zero-of-shape out-arr))]
+                    (bindings-into rev-ctx [d-out-sym (sum-contribs contribs default)]))
                   rev-ctx)
         rev-ctx (reduce bindings-into rev-ctx backward-maps)
         rev-ctx (reduce bindings-into rev-ctx backward-reduces)]
@@ -536,8 +550,14 @@
            shadow-allocs backward-maps backward-reduces d-acc-sym]}
    _adj-sym _activity {:keys [adj-env rev-ctx]}]
   (let [rev-ctx (bindings-into rev-ctx (vec shadow-allocs))
-        ;; par/reduce returns a SCALAR — 0.0 default is correct for the empty case.
-        rev-ctx (bindings-into rev-ctx [d-acc-sym (sum-contribs (get adj-env sym) 0.0)])
+        ;; par/reduce returns a SCALAR — a typed scalar zero (Π on the reduce
+        ;; result's tag) for the empty case; untagged stays the double 0.0
+        ;; (scalar slots cannot mis-shape, only mis-dtype).
+        acc-tag (:raster.type/tag (meta sym))
+        acc-zero (if (= :scalar (:kind (tangent/tangent-kind acc-tag)))
+                   (tangent/zero-expr acc-tag nil)
+                   0.0)
+        rev-ctx (bindings-into rev-ctx [d-acc-sym (sum-contribs (get adj-env sym) acc-zero)])
         rev-ctx (reduce bindings-into rev-ctx backward-maps)
         rev-ctx (reduce bindings-into rev-ctx backward-reduces)]
     {:rev-ctx rev-ctx
@@ -551,10 +571,9 @@
         ;; result sym aliases the buffer — sum consumer (adj-env[sym]) and direct
         ;; buffer (adj-env[out-arr]) contributions (see :par-map).
         rev-ctx (if-let [out-arr (first written-arrs)]
-                  (bindings-into rev-ctx
-                                 [d-out-sym (sum-contribs (concat (get adj-env sym)
-                                                                  (get adj-env out-arr))
-                                                          (array-zero-of-shape out-arr))])
+                  (let [contribs (concat (get adj-env sym) (get adj-env out-arr))
+                        default (when (empty? contribs) (array-zero-of-shape out-arr))]
+                    (bindings-into rev-ctx [d-out-sym (sum-contribs contribs default)]))
                   rev-ctx)
         rev-ctx (bindings-into rev-ctx [n-bwd-sym bound-expr])
         bwd-result-sym (ad-gensym "dt_bwd")
@@ -588,22 +607,45 @@
    {:adj-env seed-adj-env :rev-ctx (bind-ctx/make-ctx ad-gensym)}
    (reverse records)))
 
+(defn- param-zero-expr
+  "Typed zero default for a param's adjoint slot (Π): array params get a
+  shape-matched typed zero (zeros-like keeps the exemplar's dtype), scalar
+  params a typed scalar zero. Untagged params keep the scalar 0.0 double
+  default (the HVP path differentiates untagged double scalars)."
+  [p]
+  (let [tag (:raster.type/tag (meta p))]
+    (case (:kind (tangent/tangent-kind tag))
+      :array  (list 'raster.arrays/zeros-like p (list 'raster.arrays/alength p))
+      :scalar (tangent/zero-expr tag nil)
+      0.0)))
+
 (defn- collect-param-adjoints
   "Phase 3 (pure): bind a d_<param> for each active param (shape-matched zero when
-  no contributions) into rev-ctx; return {:rev-ctx :param-adj-syms}."
+  no contributions) into rev-ctx; return {:rev-ctx :param-adj-syms}.
+
+  Π at the boundary: each accumulated scalar adjoint is PROJECTED into the
+  primal param's tangent space — float params always (double contamination
+  via promotion is the default in raster.numeric), double params only when
+  float params are present (provably-double-only functions emit no cast).
+  Array adjoints are anchored by their typed shadow buffers — no cast."
   [active-params adj-env rev-ctx]
-  (reduce
-   (fn [{:keys [rev-ctx param-adj-syms]} p]
-     (let [tag (:raster.type/tag (meta p))
-           default (case tag
-                     doubles (list 'raster.arrays/zeros-like p (list 'raster.arrays/alength p))
-                     floats  (list 'raster.arrays/zeros-like p (list 'raster.arrays/alength p))
-                     0.0)
-           adj-sym (ad-gensym (str "d_" (name p)) tag)]
-       {:rev-ctx (bindings-into rev-ctx [adj-sym (sum-contribs (get adj-env p) default)])
-        :param-adj-syms (conj param-adj-syms adj-sym)}))
-   {:rev-ctx rev-ctx :param-adj-syms []}
-   active-params))
+  (let [param-dtype #(-> % meta :raster.type/tag tangent/tangent-kind :dtype)
+        mixed-float? (boolean (some #(= :float (param-dtype %)) active-params))]
+    (reduce
+     (fn [{:keys [rev-ctx param-adj-syms]} p]
+       (let [tag (:raster.type/tag (meta p))
+             {:keys [kind dtype]} (tangent/tangent-kind tag)
+             raw (sum-contribs (get adj-env p) (param-zero-expr p))
+             expr (if (and (= kind :scalar)
+                           (or (= dtype :float)
+                               (and (= dtype :double) mixed-float?)))
+                    (tangent/project-expr tag raw)
+                    raw)
+             adj-sym (ad-gensym (str "d_" (name p)) tag)]
+         {:rev-ctx (bindings-into rev-ctx [adj-sym expr])
+          :param-adj-syms (conj param-adj-syms adj-sym)}))
+     {:rev-ctx rev-ctx :param-adj-syms []}
+     active-params)))
 
 (defn- process-bindings
   "The shared engine: run Phases 1-3 over a NORMALIZED binding vector and return
@@ -1935,18 +1977,19 @@
         :else
         (let [body-expr (first body-exprs)]
           (cond
-            ;; Literal — zero gradient
+            ;; Literal — zero gradient (typed per param tag: a float-array
+            ;; param's slot must be a float[] zero, not a scalar 0.0)
             (or (number? body-expr) (nil? body-expr))
             (vector body-expr
                     (list 'fn* ['dy__rad]
-                          (vec (repeat (count active-params) 0.0))))
+                          (mapv param-zero-expr active-params)))
 
-            ;; Symbol — gradient is 1 for that param, 0 for others
+            ;; Symbol — gradient is 1 for that param, typed 0 for others
             (symbol? body-expr)
             (vector body-expr
                     (list 'fn* ['dy__rad]
-                          (vec (map (fn [p] (if (= p body-expr) 'dy__rad 0.0))
-                                    active-params))))
+                          (mapv (fn [p] (if (= p body-expr) 'dy__rad (param-zero-expr p)))
+                                active-params)))
 
             ;; If form — route through gen-reverse-let (normalization handles it)
             (and (seq? body-expr) (= 'if (first body-expr)))
@@ -2596,6 +2639,17 @@
                            [new-loop-form])
                     new-loop-form))))))))))
 
+(defn- body-tail-tag
+  "The :raster.type/tag of a walked body's TAIL expression — the type of the
+  actual primal the differentiated graph produces (which may be narrower than
+  the deftm's declared return type, e.g. a `:- Double` fn whose body is a
+  parametric T=float chain). Prefers the form's own tag, else descends
+  through binding forms to the final body expression."
+  [form]
+  (or (:raster.type/tag (meta form))
+      (when (and (seq? form) (form/binding-form? form) (seq (drop 2 form)))
+        (body-tail-tag (last form)))))
+
 (defn- build-grad-walked-body
   "Build the AD-transformed walked body for a deftm var.
   Returns {:walked-body [form], :params [sym ...], :source-ns ns}
@@ -2627,8 +2681,18 @@
                                    (when (differentiable-tag? (nth tags i nil)) p))
                                  all-params))
         source-ns (or (:ns m) *ns*)
-        ;; Infer dtype from parameter tags for correct AD seed type
-        dtype (if (some #{'floats 'float} tags) :float :double)
+        ;; Π: the SEED is the cotangent of the RESULT of the differentiated
+        ;; GRAPH, so its dtype derives from the walked body's TAIL tag (the
+        ;; actual primal flowing) — not from a global binary any-param-is-float
+        ;; switch, and NOT from the declared return tag: a fn declared
+        ;; `:- Double` whose body is a parametric float chain (T=float
+        ;; cross-entropy) needs a FLOAT seed for its pullback; the Double is
+        ;; only the .invk interface boundary. The legacy binary inference
+        ;; remains as fallback for untagged tails.
+        dtype (case (body-tail-tag (first walked-body))
+                float  :float
+                double :double
+                (if (some #{'floats 'float} tags) :float :double))
         ;; Lower: ANF-normalize + inline compound deftm ops into primitives
         ;; before AD, to a fixpoint so BARE and multi-level composites fully
         ;; inline (see lower-composites).

--- a/src/raster/ad/reverse.clj
+++ b/src/raster/ad/reverse.clj
@@ -33,6 +33,8 @@
             [raster.compiler.passes.scalar.inline :as inline]
             [raster.compiler.passes.parallel.materialize :as materialize]
             [raster.compiler.core.util :as util]
+            [raster.compiler.core.dispatch :as dispatch]
+            [raster.compiler.support.mangled :as mangled]
             [raster.core :as rcore]
             [raster.arrays :as arrays]))
 
@@ -2751,6 +2753,144 @@
         (eval (list 'fn ['& args-sym]
                     (list 'let unpack body)))))))
 
+;; ================================================================
+;; Forward-mode admissibility (framework §11): mode selection is
+;; constrained by CARRIER COVERAGE — an interpretation is admissible
+;; only when every op that would execute on the carrier has a lift in
+;; that carrier. The coverage matrix is a queryable artifact derived
+;; from the dispatch registry (the single source of truth for what a
+;; carrier accepts) — never documentation, never a hardcoded op list.
+;; ================================================================
+
+(def ^:private forward-neutral-namespaces
+  "Op namespaces that never execute on the Dual carrier: clojure.core is
+  integer index/counter arithmetic by convention (see CLAUDE.md), and
+  raster.arrays is array plumbing (forward mode is scalar-only — array
+  params are rejected separately)."
+  #{"clojure.core" "raster.arrays"})
+
+(def ^:private forward-interop-namespaces
+  "JVM static-method namespaces: primitive interop calls cannot accept a
+  Dual, so their presence in a body makes forward mode inadmissible."
+  #{"Math" "java.lang.Math" "StrictMath" "java.lang.StrictMath"})
+
+(defn- collect-op-heads
+  "All semantic op heads in a walked-body form. For devirtualized
+  (.invk impl args...) calls this reads the walk's stamped original-op
+  metadata via op/semantic-op (never parses mangled names); a bare .invk
+  without metadata (typed fn-param call) contributes nothing."
+  [form]
+  (let [acc (volatile! #{})]
+    (letfn [(go [f]
+              (cond
+                (seq? f)
+                (do (when-let [h (if (= '.invk (first f))
+                                   ;; same recovery order as undevirtualize
+                                   (or (:raster.op/original (meta f)) (:op (meta f)))
+                                   (op/semantic-op f))]
+                      (when (symbol? h) (vswap! acc conj h)))
+                    (doseq [x f] (go x)))
+                (vector? f) (doseq [x f] (go x))
+                (map? f) (doseq [[k v] f] (go k) (go v))))]
+      (go form))
+    @acc))
+
+(defn- dual-tag?
+  "True if a dispatch tag denotes the Dual carrier (short `Dual` for explicit
+  overloads, fully qualified `raster.ad.forward.Dual` for auto-specialized
+  parametric entries). Dual__Sym etc. do NOT count — they are other carriers."
+  [tag]
+  (cond
+    (symbol? tag) (= "Dual" (peek (str/split (name tag) #"\.")))
+    (class? tag) (= "Dual" (.getSimpleName ^Class tag))
+    :else false))
+
+(defn- dual-lift?
+  "True when a deftm generic var can accept a Dual argument: an explicit
+  Dual overload in its dispatch table, or a parametric (All [T]) template
+  with a bare type-var param (auto-specializes for Dual on first dispatch,
+  e.g. raster.sci.special/sinc)."
+  [v qualified-op]
+  (or (when-let [dt (:raster.core/dispatch-table (meta v))]
+        (boolean (some (fn [entry] (some dual-tag? (:tags entry)))
+                       (mapcat val @dt))))
+      (boolean (some (fn [entry]
+                       (some #(contains? (:type-vars entry) %)
+                             (:annotations entry)))
+                     (get @dispatch/parametric-registry qualified-op)))))
+
+(defn- forward-op-status
+  "Classify one op head for execution on the Dual carrier.
+  Returns :covered, :neutral (never carries a Dual), or :uncovered."
+  [op-sym]
+  (let [ns-str (namespace op-sym)
+        nm (name op-sym)]
+    (cond
+      ;; Unqualified heads: special forms, binders, locals, constructors,
+      ;; interop field/method access (.v/.partials/...) — structural, not
+      ;; Dual-carrying calls (the walk qualifies every deftm call head).
+      (nil? ns-str) :neutral
+
+      ;; JVM static interop (Math/tan ...) — no Dual lift is possible.
+      (contains? forward-interop-namespaces ns-str) :uncovered
+
+      (contains? forward-neutral-namespaces ns-str) :neutral
+
+      :else
+      (let [base (mangled/extract-deftm-base
+                  (symbol ns-str (mangled/strip-impl-suffix nm)))
+            v (try (resolve base) (catch Exception _ nil))]
+        (cond
+          (nil? v) :neutral
+          ;; deftm generic (dispatch table or parametric template): the
+          ;; registry decides whether the Dual carrier is accepted.
+          (or (:raster.core/dispatch-table (meta v))
+              (contains? @dispatch/parametric-registry base))
+          (if (dual-lift? v base) :covered :uncovered)
+          ;; Plain var (defn helper, constant) — not carrier-dispatched.
+          :else :neutral)))))
+
+(def ^:private array-param-tags
+  '#{doubles floats ints longs shorts bytes booleans chars objects})
+
+(defn forward-coverage
+  "Queryable Dual-carrier coverage for a deftm var (framework §4a/§11).
+  Walks the deftm's walked body, collects semantic op heads, and checks
+  each op that would execute on the Dual carrier against the dispatch
+  registry for a Dual lift.
+
+  Returns {:admissible?   bool
+           :uncovered-ops sorted vector of op symbols without a Dual lift
+           :array-params  params whose type is an array (forward mode is
+                          scalar-only — arrays have no Dual seeding)}"
+  [f-var]
+  (let [resolved (resolve-deftm-var f-var)
+        m (meta resolved)
+        walked-body (or (rcore/ensure-walked-body! resolved)
+                        (throw (ex-info "No walked body on var" {:var f-var})))
+        params (or (:raster.core/deftm-params m) [])
+        tags (or (:raster.core/deftm-tags m) [])
+        array-params (vec (remove nil?
+                                  (map (fn [p tag]
+                                         (when (or (contains? array-param-tags tag)
+                                                   (and (seq? tag) (= 'Array (first tag))))
+                                           p))
+                                       params (concat tags (repeat nil)))))
+        uncovered (->> (collect-op-heads (first walked-body))
+                       (filter #(= :uncovered (forward-op-status %)))
+                       sort
+                       vec)]
+    {:admissible? (and (empty? uncovered) (empty? array-params))
+     :uncovered-ops uncovered
+     :array-params array-params}))
+
+(defn forward-admissible?
+  "True when forward mode (the Dual carrier) is admissible for f-var:
+  every op in the walked body that would execute on the Dual carrier has
+  a Dual lift in the dispatch registry, and no param is array-typed."
+  [f-var]
+  (:admissible? (forward-coverage f-var)))
+
 (defn ^clojure.lang.IFn value+grad
   "Composable value+gradient operator.
 
@@ -2809,7 +2949,26 @@
      :forward
      ;; Forward-mode gradient via Dual numbers on the walked body.
      ;; Un-devirtualize .invk → generic dispatch so Dual numbers propagate.
-     (let [resolved (resolve-deftm-var f-var)
+     ;; Admissibility is checked at CONSTRUCTION time (framework §11): fail
+     ;; with the uncovered ops named, never a No-matching-method at call time.
+     (let [cov (forward-coverage f-var)
+           _ (when-not (:admissible? cov)
+               (throw (ex-info
+                       (str "value+grad :mode :forward is not admissible for `"
+                            f-var "` — "
+                            (when (seq (:uncovered-ops cov))
+                              (str "ops without a Dual lift: "
+                                   (str/join ", " (:uncovered-ops cov)) ". "))
+                            (when (seq (:array-params cov))
+                              (str "array-typed params (forward mode is scalar-only): "
+                                   (str/join ", " (:array-params cov)) ". "))
+                            "Mode selection is constrained by carrier coverage "
+                            "(framework §11): use :mode :reverse, or add the "
+                            "missing Dual overloads in raster.ad.forward.")
+                       {:var f-var
+                        :uncovered-ops (:uncovered-ops cov)
+                        :array-params (:array-params cov)})))
+           resolved (resolve-deftm-var f-var)
            m (meta resolved)
            params (or (:raster.core/deftm-params m)
                       (throw (ex-info "grad requires a deftm var" {:var f-var})))
@@ -2849,12 +3008,18 @@
                       (seq grads))))))
 
      :auto
-     ;; Griewank heuristic: forward when n_inputs ≤ n_outputs, reverse otherwise.
-     ;; For scalar-output functions (the common case), reverse is better for n > 1.
-     ;; For n = 1, forward avoids tape overhead.
+     ;; Mode selection = argmin cost over ADMISSIBLE interpretations
+     ;; (framework §7 + §11). The Griewank dimension test (forward when
+     ;; n_inputs ≤ n_outputs; reverse otherwise — for n = 1 forward avoids
+     ;; tape overhead) is the cost heuristic; carrier coverage is the HARD
+     ;; filter: forward is only selectable when every op in the body has a
+     ;; Dual lift. Reverse is always admissible for deftm bodies (templates
+     ;; + composite inlining), so it is the fallback.
      (let [resolved (resolve-deftm-var f-var)
            n-params (count (or (:raster.core/deftm-params (meta resolved)) []))
-           selected (if (<= n-params 1) :forward :reverse)]
+           selected (if (and (<= n-params 1) (forward-admissible? f-var))
+                      :forward
+                      :reverse)]
        (value+grad f-var :mode selected)))))
 
 (defn grad

--- a/src/raster/ad/tangent.clj
+++ b/src/raster/ad/tangent.clj
@@ -1,0 +1,127 @@
+(ns raster.ad.tangent
+  "Π — the tangent-type protocol (framework §5, task #44).
+
+  A COMPILE-TIME protocol: these functions are consulted during the AD
+  transform / flatten / template codegen to emit correctly-TYPED seeds,
+  zeros, and casts in the generated IR, derived from the PRIMAL's type
+  tag. Never runtime wrapper objects — a tagged-object tangent flowing
+  through compiled code would destroy the flat fusible backward. The
+  tangent algebra acts at STAGE time and emits monomorphic code.
+
+  Runtime `nil` remains the dynamic ⊕-identity (grad-acc handles it);
+  ⊥ (no tangent space — Long/Boolean/Object slots) remains STATIC:
+  `differentiable?` is the type-level ⊥ test that activity analysis
+  abstracts.
+
+  Tag vocabulary is the :raster.type/tag / deftm-tags symbols:
+    double float          → scalar tangent spaces
+    doubles floats        → array tangent spaces
+    long longs int ints boolean Object … (and nil) → ⊥ (no tangent space)
+
+  Dependency-light BY DESIGN: no requires. Both raster.ad.reverse and
+  raster.compiler.ad.flatten (and compiler passes) may require this ns
+  without creating cycles."
+  (:refer-clojure :exclude []))
+
+(def ^:private scalar-tag->dtype {'double :double 'float :float})
+(def ^:private array-tag->dtype  {'doubles :double 'floats :float})
+
+(defn tangent-kind
+  "Classify a primal type tag into its tangent space.
+  Returns {:kind :scalar|:array, :dtype :double|:float} for tags with a
+  tangent space, {:kind :none} for ⊥ tags (integers, booleans, Object,
+  untagged/nil — no tangent space or statically unknown)."
+  [tag]
+  (if-let [dt (scalar-tag->dtype tag)]
+    {:kind :scalar :dtype dt}
+    (if-let [dt (array-tag->dtype tag)]
+      {:kind :array :dtype dt}
+      {:kind :none})))
+
+(defn differentiable?
+  "Type-level ⊥ test: does `tag` denote a tangent space that carries
+  gradient? (The single source of truth that reverse.clj's
+  differentiable-tag? and the inliner's local copy delegate to.)"
+  [tag]
+  (not= :none (:kind (tangent-kind tag))))
+
+(defn zero-expr
+  "IR expression for a typed zero cotangent of the tangent space of `tag`.
+  Scalars: a typed zero literal. Arrays: a typed array constructor sized
+  by `shape-expr` (an IR expression for the element count).
+
+  FAIL-LOUD on ⊥/unknown tags: a materialized zero whose tangent space is
+  unknown could silently mis-shape an array slot (scalar 0.0 where an
+  array adjoint is expected). Callers that can tolerate absence must use
+  nil (the dynamic 0̄) instead of asking for a materialized zero."
+  [tag shape-expr]
+  (let [{:keys [kind dtype]} (tangent-kind tag)]
+    (case kind
+      :scalar (case dtype :float (list 'float 0.0) :double 0.0)
+      :array  (case dtype
+                :float  (list 'float-array shape-expr)
+                :double (list 'double-array shape-expr))
+      (throw (ex-info (str "No tangent space for tag " (pr-str tag)
+                           " — cannot materialize a typed zero cotangent. "
+                           "Untagged adjoint slots must stay nil (dynamic 0̄) "
+                           "or the primal must carry a :raster.type/tag.")
+                      {:tag tag :shape-expr shape-expr})))))
+
+(defn seed-expr
+  "IR expression for the typed seed cotangent (1̄) of a SCALAR loss with
+  type `tag`. nil/unknown tags fall back to the double 1.0 (the loss of a
+  value+grad is scalar by contract; array tags fail loud)."
+  [tag]
+  (let [{:keys [kind dtype]} (tangent-kind tag)]
+    (case kind
+      :scalar (case dtype :float (list 'float 1.0) :double 1.0)
+      :none 1.0
+      (throw (ex-info (str "Seed requires a scalar loss; got array tag " (pr-str tag))
+                      {:tag tag})))))
+
+;; ================================================================
+;; Projection Π_x — runtime helpers + the expr emitter
+;; ================================================================
+
+(defn project-double
+  "Runtime Π onto a Double primal's tangent space. nil-safe: nil is the
+  dynamic 0̄ and passes through."
+  [x]
+  (when (some? x) (Double/valueOf (double x))))
+
+(defn project-float
+  "Runtime Π onto a Float primal's tangent space. nil-safe: nil is the
+  dynamic 0̄ and passes through."
+  [x]
+  (when (some? x) (Float/valueOf (float x))))
+
+(defn zero-like
+  "Runtime Π fallback: a zero cotangent shaped like the PRIMAL value `x`,
+  deriving dtype+shape dynamically. Used only where no static tag exists
+  (e.g. untagged if-result syms in runtime AD) — unlike a bare scalar 0.0
+  it can never mis-shape an array slot. nil (0̄) passes through."
+  [x]
+  (cond
+    (nil? x) nil
+    (instance? Double x) 0.0
+    (instance? Float x) (Float/valueOf (float 0.0))
+    (.isArray (class x))
+    (java.lang.reflect.Array/newInstance (.getComponentType (class x))
+                                         (java.lang.reflect.Array/getLength x))
+    (number? x) 0.0
+    :else (throw (ex-info (str "No runtime tangent zero for value of class "
+                               (class x))
+                          {:class (class x)}))))
+
+(defn project-expr
+  "Wrap `cotangent-expr` with the projection onto the tangent space of the
+  primal `tag` (Π_x), when the dtypes could mismatch. Scalars get a
+  nil-safe cast call; arrays and unknown tags pass through unchanged
+  (array adjoints are anchored by their typed shadow buffers)."
+  [tag cotangent-expr]
+  (let [{:keys [kind dtype]} (tangent-kind tag)]
+    (if (= kind :scalar)
+      (case dtype
+        :float  (list 'raster.ad.tangent/project-float cotangent-expr)
+        :double (list 'raster.ad.tangent/project-double cotangent-expr))
+      cotangent-expr)))

--- a/src/raster/compiler/ad/flatten.clj
+++ b/src/raster/compiler/ad/flatten.clj
@@ -24,7 +24,8 @@
   2. Extracts and inlines the reverse-pass bindings with dy=1.0
   3. Names the gradient outputs (one per active param)
   4. Appends SGD weight update calls: (nc/axpy! (- lr) d_Wi Wi)"
-  (:require [raster.compiler.ir.form :as form]))
+  (:require [raster.ad.tangent :as tangent]
+            [raster.compiler.ir.form :as form]))
 
 (def ^:dynamic *flatten-dtype*
   "Pipeline dtype for type-appropriate AD seed values.
@@ -159,12 +160,17 @@
            :param-adj-syms [d_p1 d_p2 ...] gradient symbols}
   or nil if form doesn't match AD pattern."
   [form]
-  (when-let [{:keys [fwd-bindings result-sym dy-sym
+  (when-let [{:keys [fwd-bindings result-sym body-sym dy-sym
                      rev-bindings param-adj-syms]} (extract-ad-structure form)]
-    (let [;; Seed value: 1.0 in the pipeline's dtype.
-          ;; Float pipelines use (float 1.0) so the adjoint matches
-          ;; the parametric return type of the loss function.
-          seed (case *flatten-dtype* :float (list 'float 1.0) 1.0)
+    (let [;; Seed value: 1.0 typed by the RESULT's tangent space (Π): the
+          ;; seed is the cotangent of the loss, so its dtype derives from
+          ;; the result/body sym's :raster.type/tag when present. Falls
+          ;; back to the pipeline-wide *flatten-dtype* for untagged results.
+          result-tag (or (some-> result-sym meta :raster.type/tag)
+                         (some-> body-sym meta :raster.type/tag))
+          seed (if (= :scalar (:kind (tangent/tangent-kind result-tag)))
+                 (tangent/seed-expr result-tag)
+                 (case *flatten-dtype* :float (list 'float 1.0) 1.0))
           ;; Build flat bindings: fwd + [dy seed] + rev
           flat-bindings (vec (concat fwd-bindings
                                      [dy-sym seed]

--- a/src/raster/compiler/passes/scalar/inline.clj
+++ b/src/raster/compiler/passes/scalar/inline.clj
@@ -4,6 +4,7 @@
 	This namespace owns cross-function inlining, pre-AD lowering, and
 	post-AD backend expansion. It does not perform buffer reuse."
   (:require [clojure.string :as str]
+            [raster.ad.tangent :as tangent]
             [raster.ad.templates :as rt]
             [raster.compiler.ad.flatten :as flatten]
             [raster.compiler.core.types :as types]
@@ -725,8 +726,9 @@
             ;; are constants for AD — passing them as active forces AD to look
             ;; for rules on integer ops like (quot d-model n-heads), which
             ;; don't exist (and shouldn't, since the result is non-diff).
-            ;; Same rule as raster.ad.reverse/build-grad-walked-body.
-            differentiable-tag? '#{doubles floats double float}
+            ;; Same rule as raster.ad.reverse/build-grad-walked-body —
+            ;; delegates to the tangent protocol's type-level ⊥ test.
+            differentiable-tag? tangent/differentiable?
             tags-vec (or tags (vec (repeat (count all-params) 'double)))
             active-params (vec (keep-indexed
                                 (fn [i p]

--- a/src/raster/sym/diff.clj
+++ b/src/raster/sym/diff.clj
@@ -1,5 +1,15 @@
 (ns raster.sym.diff
-  "Symbolic differentiation of S-expressions.
+  "INTERNAL — symbolic differentiation of raw S-expressions.
+
+   This is the fast-path calculus engine for raster.sym.analysis and
+   raster.sym.taylor. It is NOT the semantically-primary symbolic-derivative
+   route: that is Dual{Sym} — flowing a Dual number with Sym components
+   through the UNCHANGED numeric/math ops (initiality of the Sym carrier,
+   .internal/ad_formal_framework.md §4b). This hand-unrolled rule table is
+   redundant in principle; it is kept only as a fast path, and the O6 law
+   (test/raster/ad/laws_test.clj, o6-initiality-law) enforces agreement of
+   the two routes over the shared op corpus. When adding a derivative rule
+   here, add the op to the O6 corpus as well.
 
    Differentiates an S-expression w.r.t. a named variable using
    standard calculus rules (sum, product, quotient, chain).
@@ -222,8 +232,18 @@
 
 (defn differentiate
   "Differentiate and simplify a symbolic expression.
-   Uses raster.compiler.passes.scalar.simplify/simplify-derivative for cleanup."
+   Uses raster.compiler.passes.scalar.simplify/simplify-derivative for cleanup.
+
+   Takes a RAW S-expression form (seq/symbol/number), not a Sym object —
+   a Sym-wrapped input used to silently differentiate to 0 (garbage-in-
+   zero-out, framework §11 hazard); it now fails loud."
   ([expr var-sym]
    (differentiate expr var-sym 5))
   ([expr var-sym max-rounds]
+   (when-not (or (seq? expr) (symbol? expr) (number? expr))
+     (throw (ex-info (str "differentiate expects a raw S-expression form "
+                          "(seq/symbol/number), got " (pr-str (class expr))
+                          ". If this is a raster.sym.core Sym object, unwrap it "
+                          "first: (raster.sym.core/unwrap expr).")
+                     {:expr expr :class (class expr) :var var-sym})))
    (simplify/simplify-derivative (diff expr var-sym) max-rounds)))

--- a/test/raster/ad/laws_test.clj
+++ b/test/raster/ad/laws_test.clj
@@ -185,6 +185,14 @@
       (recur (inc i) (n/+ acc (n/* x x)))
       acc)))
 
+;; Deliberately-UNCOVERED op for the §11 admissibility law: Math/expm1 as a
+;; raw JVM static interop call has a reverse template (Math/expm1) but can
+;; NEVER have a Dual lift (primitive-typed static method), so forward mode
+;; must be inadmissible while reverse works. (Every templated scalar deftm
+;; op now has a Dual overload — interop is the remaining uncovered class.)
+(deftm laws-uncovered-fn [x :- Double] :- Double
+  (n/* x (Math/expm1 (double x))))
+
 ;; ================================================================
 ;; O1 — mode agreement: grad_rev = grad_fwd = FD on the shared domain
 ;; ================================================================
@@ -234,18 +242,22 @@
           (is (close? gr (laws-f4' x) tol-double) (str "branch rev=analytic at " x))
           (is (close? gf gr tol-double) (str "branch fwd=rev at " x))))))
 
-  (testing "erf: reverse = analytic; FD only loosely (approximation slope)"
-    ;; KNOWN-GAP: erf has a reverse template but no Dual overload, so forward
-    ;; mode is unavailable (see o5-boundary-law for the loud :auto trap).
-    ;; The erf rrule is the ANALYTIC derivative 2/sqrt(pi)*exp(-x^2); the
-    ;; primal is the Abramowitz-Stegun 7.1.26 approximation (max err 1.5e-7),
-    ;; so FD-of-the-primal converges ~1.4e-6 away from the rule — the 5e-6
-    ;; tolerance absorbs the approximation's slope error (measured, stable
-    ;; across h), not an AD error. A wrong rule would be off by O(1).
-    (let [vg-r (rev/value+grad #'laws-f5)]
+  (testing "erf: reverse = forward = analytic; FD only loosely (approximation slope)"
+    ;; erf got its Dual lift in the carrier-coverage completion (framework
+    ;; §4a/§11): forward mode is available and must agree with reverse.
+    ;; The erf rrule (and the Dual scale) is the ANALYTIC derivative
+    ;; 2/sqrt(pi)*exp(-x^2); the primal is the Abramowitz-Stegun 7.1.26
+    ;; approximation (max err 1.5e-7), so FD-of-the-primal converges ~1.4e-6
+    ;; away from the rule — the 5e-6 tolerance absorbs the approximation's
+    ;; slope error (measured, stable across h), not an AD error. A wrong
+    ;; rule would be off by O(1).
+    (let [vg-r (rev/value+grad #'laws-f5)
+          vg-f (rev/value+grad #'laws-f5 :mode :forward)]
       (doseq [x [0.3 0.5 1.1]]
-        (let [gr (nth (vg-r x) 1)]
+        (let [gr (nth (vg-r x) 1)
+              gf (nth (vg-f x) 1)]
           (is (close? gr (erf-analytic-deriv x) 1e-10) (str "erf rev=analytic at " x))
+          (is (close? gf (erf-analytic-deriv x) 1e-10) (str "erf fwd=analytic at " x))
           (is (close? gr (central-fd laws-f5 x 1e-4) 5e-6) (str "erf rev~FD at " x)))))))
 
 ;; ================================================================
@@ -460,18 +472,35 @@
          #"cannot assemble a runtime gradient"
          (rev/value+grad #'laws-tail-loop-fn))))
 
-  (testing ":mode :auto on erf throws loudly (n=1 selects forward; no Dual lift)"
-    ;; KNOWN-GAP (§11): mode selection lacks the admissibility constraint —
-    ;; :auto must select argmin-cost over interpretations whose carrier covers
-    ;; every op in the body. erf has a reverse template but no Dual overload,
-    ;; so :auto (n<=1 → forward) throws at call time. This test documents the
-    ;; CURRENT loud behavior; when admissibility lands, :auto must fall back
-    ;; to :reverse here and this test flips to a value assertion.
-    (is (thrown-with-msg? Exception #"No matching method for `erf`"
-                          ((rev/value+grad #'laws-f5 :mode :auto) 0.5)))
-    ;; ...while :reverse on the same fn works (coverage exists there).
+  (testing ":auto is admissibility-constrained (§11): erf goes forward AND is correct"
+    ;; FLIPPED 2026-07-04 (was the KNOWN-GAP ':auto trap'): erf now has a
+    ;; Dual lift, so :auto (n=1 + admissible) legitimately selects forward.
+    ;; The LAW is the gradient value, whatever admissible mode is selected.
+    (is (rev/forward-admissible? #'laws-f5) "erf body is Dual-covered")
+    (is (close? (nth ((rev/value+grad #'laws-f5 :mode :auto) 0.7) 1)
+                (erf-analytic-deriv 0.7) 1e-10)
+        ":auto on erf returns the analytic gradient")
+    ;; ...and :reverse on the same fn agrees (coverage exists there too).
     (is (close? (nth ((rev/value+grad #'laws-f5 :mode :reverse) 0.5) 1)
-                (erf-analytic-deriv 0.5) 1e-10))))
+                (erf-analytic-deriv 0.5) 1e-10)))
+
+  (testing ":auto hard-filters inadmissible forward; :forward fails loud at construction"
+    ;; laws-uncovered-fn calls Math/expm1 (JVM static interop): reverse-
+    ;; templated, but no Dual lift can exist. n=1 would select forward by
+    ;; the Griewank dimension test alone — admissibility must force reverse
+    ;; (§11: select argmin-cost over ADMISSIBLE interpretations only).
+    (is (not (rev/forward-admissible? #'laws-uncovered-fn)))
+    (is (= '[Math/expm1] (:uncovered-ops (rev/forward-coverage #'laws-uncovered-fn)))
+        "the coverage artifact names exactly the uncovered op")
+    (let [x 0.7
+          expected (+ (Math/expm1 x) (* x (Math/exp x)))] ;; d/dx x·expm1(x)
+      (is (close? (nth ((rev/value+grad #'laws-uncovered-fn :mode :auto) x) 1)
+                  expected tol-double)
+          ":auto selects reverse and the gradient is correct"))
+    ;; :mode :forward itself: a clear CONSTRUCTION-time ex-info naming the
+    ;; uncovered op — never a No-matching-method at call time.
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Math/expm1"
+                          (rev/value+grad #'laws-uncovered-fn :mode :forward)))))
 
 ;; ================================================================
 ;; O6 — initiality / two-route symbolic agreement:
@@ -482,8 +511,18 @@
 ;; Flow the corpus ops over an arbitrary carrier (Sym or Dual__Sym): the
 ;; UNCHANGED numeric/math ops, generic dispatch. Must stay in sync with
 ;; laws-f2 / the x^2*cos(x) form below.
+;;
+;; Corpus rule: SHARED-COVERAGE ops only — an op joins when it has BOTH a
+;; Dual lift (raster.ad.forward) AND Sym support (sym/core overload + a
+;; sdiff rule). tan/tanh/atan2 joined with the carrier-coverage completion.
+;; erf is deliberately absent: it has a Dual lift but NO Sym overload/sdiff
+;; rule, so there is no second route to agree with (its Dual route is
+;; law-checked against the analytic derivative in O1/O5 instead).
 (defn- o6-f2-ops [x] (n/+ (n/* x (m/sin x)) (m/exp x)))
 (defn- o6-x2cos-ops [x] (n/* (n/* x x) (m/cos x)))
+(defn- o6-xtan-ops [x] (n/* x (m/tan x)))
+(defn- o6-tanh-ops [x] (m/tanh (n/* x x)))
+(defn- o6-atan2-ops [x] (m/atan2 x 2.0))
 
 (defn- num-eval
   "Numerically evaluate a symbolic derivative form at x. Direct structural
@@ -505,6 +544,10 @@
                    sin (Math/sin (first args))
                    cos (Math/cos (first args))
                    exp (Math/exp (first args))
+                   tan (Math/tan (first args))
+                   tanh (Math/tanh (first args))
+                   atan2 (Math/atan2 (first args) (second args))
+                   sqrt (Math/sqrt (first args))
                    pow (Math/pow (first args) (second args))
                    (throw (ex-info "num-eval: unknown op in symbolic derivative"
                                    {:op (first f) :form form}))))
@@ -536,7 +579,13 @@
   (doseq [[label ops-fn analytic]
           [["x*sin(x)+exp(x)" o6-f2-ops laws-f2']
            ["x^2*cos(x)" o6-x2cos-ops
-            (fn [x] (- (* 2.0 x (Math/cos x)) (* x x (Math/sin x))))]]]
+            (fn [x] (- (* 2.0 x (Math/cos x)) (* x x (Math/sin x))))]
+           ["x*tan(x)" o6-xtan-ops
+            (fn [x] (let [t (Math/tan x)] (+ t (* x (+ 1.0 (* t t))))))]
+           ["tanh(x^2)" o6-tanh-ops
+            (fn [x] (let [t (Math/tanh (* x x))] (* (- 1.0 (* t t)) 2.0 x)))]
+           ["atan2(x,2)" o6-atan2-ops
+            (fn [x] (/ 2.0 (+ 4.0 (* x x))))]]]
     (testing (str "two-route symbolic derivative agreement: " label)
       (let [traced (sym/unwrap (ops-fn (sym/sym 'x)))     ;; Sym trace of f
             route-a (sdiff/differentiate traced 'x)        ;; diff.clj calculus

--- a/test/raster/ad/laws_test.clj
+++ b/test/raster/ad/laws_test.clj
@@ -17,6 +17,7 @@
             [raster.math :as m]
             [raster.arrays :as ra]
             [raster.ad.reverse :as rev]
+            [raster.ad.tangent :as tangent]
             [raster.ad.forward :as fwd]
             [raster.ad.jet :as jet]
             [raster.ad.templates :as tmpl]
@@ -288,6 +289,117 @@
     (let [x (fa 8 1) W (fa 12 2) tgt (fa 6 3)
           res ((rev/value+grad #'laws-lnb-mse) x W tgt 2 4 3)]
       (is (every? nil? (drop 4 res)) "batch/in/out Long slots are nil"))))
+
+;; ================================================================
+;; O3b — Π (tangent-type protocol): per-param dtype preservation
+;; (framework §5, task #44). Every cotangent lives in the tangent space
+;; of ITS OWN primal — dtype derives from each param's type tag, and
+;; the seed from the RESULT's type, never from a global binary switch.
+;; ================================================================
+
+;; Mixed scalars: Double × Float. d_x must stay Double, d_y must be Float.
+(deftm laws-pi-scalar [x :- Double, y :- Float] :- Double
+  (n/* x y))
+
+;; THE mixed acceptance shape: float array params + a Double scalar param
+;; + Long ⊥ slots, Double loss. loss = w * mse(linear-nb(x,W), tgt).
+(deftm laws-pi-mixed-d [x :- (Array float) W :- (Array float) tgt :- (Array float)
+                        w :- Double batch :- Long in :- Long out :- Long] :- Double
+  (n/* w (loss/mse-loss (nn/linear-nb x W batch in out) tgt (clojure.core/* batch out))))
+
+;; Same but w :- Float: d_w must come back Float (Π projects the Double
+;; cotangent dy·mse into Float32 — the daxpy-diff!-class bug direction).
+(deftm laws-pi-mixed-f [x :- (Array float) W :- (Array float) tgt :- (Array float)
+                        w :- Float batch :- Long in :- Long out :- Long] :- Double
+  (n/* w (loss/mse-loss (nn/linear-nb x W batch in out) tgt (clojure.core/* batch out))))
+
+;; Double-array twin of laws-lnb-mse for the double[] regression direction.
+(deftm laws-pi-darr [x :- (Array double) W :- (Array double) tgt :- (Array double)
+                     batch :- Long in :- Long out :- Long] :- Double
+  (loss/mse-loss (nn/linear-nb x W batch in out) tgt (clojure.core/* batch out)))
+
+(defn- da
+  "Deterministic Gaussian double array."
+  ^doubles [n seed]
+  (let [r (java.util.Random. (long seed)) a (double-array n)]
+    (dotimes [i n] (aset a i (.nextGaussian r))) a))
+
+(deftest o3b-tangent-type-protocol-law
+  (testing "mixed scalar dtypes: each grad in its own primal's tangent space"
+    (let [[v dx dy] ((rev/value+grad #'laws-pi-scalar) 2.0 (float 3.0))]
+      (is (instance? Double v))
+      (is (instance? Double dx) "d_x: Double primal → Double cotangent")
+      (is (instance? Float dy) "d_y: Float primal → Float cotangent (Π projects)")
+      (is (close? dx 3.0 tol-double))
+      (is (close? dy 2.0 tol-float))))
+
+  (testing "mixed array/scalar fn: per-param dtypes preserved in ONE fn"
+    (let [x (fa 8 11) W (fa 12 12) tgt (fa 6 13)
+          [v gx gW gtgt gw & longs] ((rev/value+grad #'laws-pi-mixed-d) x W tgt 2.0 2 4 3)
+          mse (loss/mse-loss (nn/linear-nb x W 2 4 3) tgt 6)]
+      (is (instance? Double v) "Double loss")
+      (is (instance? (Class/forName "[F") gx) "grad-x is float[]")
+      (is (instance? (Class/forName "[F") gW) "grad-W is float[]")
+      (is (instance? (Class/forName "[F") gtgt) "grad-tgt is float[] (typed zero default)")
+      (is (instance? Double gw) "grad-w is Double, not Float")
+      (is (every? nil? longs) "Long slots stay ⊥/nil")
+      (is (close? gw mse tol-double) "d(w·L)/dw = L")))
+
+  (testing "Float scalar param in a Double-loss fn: grad projected to Float"
+    (let [x (fa 8 21) W (fa 12 22) tgt (fa 6 23)
+          [v gx _gW _gtgt gw] ((rev/value+grad #'laws-pi-mixed-f) x W tgt (float 2.0) 2 4 3)
+          mse (loss/mse-loss (nn/linear-nb x W 2 4 3) tgt 6)]
+      (is (instance? Double v))
+      (is (instance? (Class/forName "[F") gx))
+      (is (instance? Float gw) "d_w: Float primal → Float cotangent")
+      (is (close? gw mse tol-float))))
+
+  (testing "float-only fn still yields float[] grads (regression)"
+    (let [x (fa 8 1) W (fa 12 2) tgt (fa 6 3)
+          [v gx gW gtgt] ((rev/value+grad #'laws-lnb-mse) x W tgt 2 4 3)]
+      (is (instance? Double v))
+      (is (instance? (Class/forName "[F") gx))
+      (is (instance? (Class/forName "[F") gW))
+      (is (instance? (Class/forName "[F") gtgt))))
+
+  (testing "double-only fn yields Double/double[] grads with no projection churn"
+    (let [[v dx dy] ((rev/value+grad #'laws-f6) 0.8 1.2)]
+      (is (instance? Double v))
+      (is (instance? Double dx))
+      (is (instance? Double dy)))
+    (let [x (da 8 31) W (da 12 32) tgt (da 6 33)
+          [v gx gW gtgt] ((rev/value+grad #'laws-pi-darr) x W tgt 2 4 3)]
+      (is (instance? Double v))
+      (is (instance? (Class/forName "[D") gx) "grad-x is double[]")
+      (is (instance? (Class/forName "[D") gW) "grad-W is double[]")
+      (is (instance? (Class/forName "[D") gtgt) "grad-tgt is double[]")))
+
+  (testing "materialized zeros are typed or fail loud (unit: the protocol + helper)"
+    ;; The protocol ns directly:
+    (is (= {:kind :array :dtype :float} (tangent/tangent-kind 'floats)))
+    (is (= {:kind :scalar :dtype :double} (tangent/tangent-kind 'double)))
+    (is (= {:kind :none} (tangent/tangent-kind 'long)))
+    (is (= {:kind :none} (tangent/tangent-kind nil)) "untagged = statically unknown = ⊥")
+    (is (= (list 'float-array 'n) (tangent/zero-expr 'floats 'n)))
+    (is (= 0.0 (tangent/zero-expr 'double 'n)))
+    (is (thrown? clojure.lang.ExceptionInfo (tangent/zero-expr nil 'n))
+        "unknown tangent space cannot materialize a zero")
+    (is (thrown? clojure.lang.ExceptionInfo (tangent/zero-expr 'long 'n))
+        "⊥ has no zero — NoTangent ≠ ZeroTangent")
+    ;; nil-safe runtime projection (0̄ passes through):
+    (is (nil? (tangent/project-double nil)))
+    (is (instance? Float (tangent/project-float 1.5)))
+    ;; zero-like: the dynamic fallback derives dtype+shape from the value.
+    (is (instance? (Class/forName "[F") (tangent/zero-like (float-array 3))))
+    (is (instance? Float (tangent/zero-like (float 2.0))))
+    (is (nil? (tangent/zero-like nil)))
+    ;; array-zero-of-shape (private helper): tag-reading path emits typed
+    ;; ctors; untagged throws instead of the old silent scalar 0.0.
+    (let [azos @#'rev/array-zero-of-shape]
+      (is (= (list 'float-array (list 'raster.arrays/alength 'xs))
+             (azos (with-meta 'xs {:raster.type/tag 'floats}))))
+      (is (thrown? clojure.lang.ExceptionInfo (azos 'untagged))
+          "untagged array slot fails loud, no scalar-0.0 mis-shape"))))
 
 ;; ================================================================
 ;; O4 — composition: HVP = FD(grad); Jet-k coeffs = k-th derivatives


### PR DESCRIPTION
Closes the carrier-coverage gaps the laws suite exposed (framework §4a/§7/§11):

- **36 new Dual scalar overloads** — every scalar op with a reverse template now has its forward lift (tan/atan2/sinh/tanh/erf/erfc/min/max/hypot/…), each FD-validated. Forward mode is no longer a partial-coverage trap.
- **Admissibility-constrained mode selection**: `forward-admissible?` introspects the dispatch registry and classifies body ops `:covered/:neutral/:uncovered`; `:auto` selects forward only when the dimension test *and* admissibility hold; `:mode :forward` on an inadmissible body throws a clear **construction-time** error naming the uncovered ops. The O5 ':auto trap' law **flipped** — `:auto` on erf now returns the exact analytic gradient.
- **`sym/diff.clj` demoted to INTERNAL**: the hand-written calculus table is the fast-path engine for `sym/analysis`+`taylor`; the semantically-primary symbolic route is `Dual{Sym}` (initiality, framework §4b), with the O6 two-route agreement law extended over the newly-shared corpus. Silent garbage-in-zero-out on Sym-wrapped input now fails loud.

Fresh JVM: **1732 / 28990 / 0 / 0, census 0** (validation run by the orchestrator; the agent's own suite runs were interrupted). Smokes: `:auto`-erf and Dual-tanh exact vs analytic.