### PR TITLE
AD: JVP source transform (A1+A2) — derived forward rules from structure tags

### DIFF
--- a/src/raster/ad/jvp.clj
+++ b/src/raster/ad/jvp.clj
@@ -1,0 +1,258 @@
+(ns raster.ad.jvp
+  "Forward-mode AD via source transform — the JVP fold (framework §13,
+  Option A, phase A2).
+
+  A SIBLING of the reverse engine's forward-pass: one pure reduce over the
+  ANF bindings of the shared-prepped body (raster.ad.reverse/ad-prepare —
+  the SAME lower-composites → materialize → hoist pipeline the reverse path
+  uses), threading a tangent environment {primal-sym → tangent-sym}. Each
+  active binding gets a PAIRED tangent binding emitted from the op's
+  :jvp-fn — the forward contraction DERIVED from the one rule source
+  (raster.ad.templates :structure / :grads-fn facets, §13 A1). No tape, no
+  reversal: structurally simpler than reverse.
+
+  Separate ns by design: reverse.clj is already 3000 lines and slated for
+  decomposition; jvp only consumes reverse's shared pieces (ad-prepare,
+  resolve-deftm-var, grad-acc as the ⊕ kernel).
+
+  Not yet supported (fail loud, forward loop rules are follow-up work):
+  par/map!, par/reduce, dotimes, loop — the differentiable loop forms have
+  reverse orchestrators but no forward fold yet."
+  (:require [raster.ad.reverse :as rev]
+            [raster.ad.templates :as tmpl]
+            [raster.ad.tangent :as tangent]
+            [raster.ad.reverse.normalize :as anf]
+            [raster.compiler.core.inference :as inf]
+            [raster.core :as rcore]
+            [clojure.walk :as walk]
+            ;; Kernel namespaces the derived rules emit calls into:
+            [raster.par]      ;; dot-product — the scalar-loss frule contraction
+            [raster.arrays])) ;; zeros-like/alength — typed zero tangents
+
+;; ================================================================
+;; Gensym
+;; ================================================================
+
+(def ^:private jvp-counter (atom 0))
+
+(defn- jvp-gensym
+  "Unique symbol for JVP-generated code. Optional type-tag stamps
+  :raster.type/tag so downstream dispatch/devirtualization reads types
+  without re-inference (the tag-carrying-emission hazard, §13 A2)."
+  ([prefix] (symbol (str prefix "__jvp" (swap! jvp-counter inc))))
+  ([prefix type-tag]
+   (cond-> (symbol (str prefix "__jvp" (swap! jvp-counter inc)))
+     (some? type-tag) (vary-meta assoc :raster.type/tag type-tag))))
+
+;; ================================================================
+;; The jvp-fold
+;; ================================================================
+
+(defn- extract-let-parts
+  "Bindings + body of a prepared walked form (bare forms → no bindings)."
+  [form]
+  (if (and (seq? form) (symbol? (first form)) (#{'let 'let*} (first form)))
+    [(second form) (nnext form)]
+    [[] [form]]))
+
+(defn- any-active?
+  "Does `form` reference any symbol with a tangent in tenv? (Over-approximates
+  by scanning all symbols incl. op heads — heads are qualified/mangled and
+  never tenv keys, so this is safe.)"
+  [tenv form]
+  (boolean (some #(and (symbol? %) (contains? tenv %))
+                 (tree-seq coll? seq (if (seq? form) (vec form) form)))))
+
+(defn- branch-tangent-zero
+  "Typed zero tangent for the INACTIVE branch of an if (tangent protocol):
+  tagged branch syms get a static typed zero; untagged fall back to the
+  runtime zero-like on the primal (dynamically-typed Π — cannot mis-shape)."
+  [branch]
+  (let [btag (and (symbol? branch) (:raster.type/tag (meta branch)))]
+    (if (some? btag)
+      (tangent/zero-expr btag (list 'raster.arrays/alength branch))
+      (list 'raster.ad.tangent/zero-like branch))))
+
+(def ^:private unsupported-forward-heads
+  "Differentiable-in-reverse forms with NO forward fold yet (follow-up):
+  fail loud when they carry an active value, never silently drop a tangent."
+  '#{loop loop* dotimes raster.par/map! raster.par/reduce fn* do case case*
+     try letfn letfn* new monitor-enter monitor-exit})
+
+(defn- fold-call
+  "Emit the paired tangent bindings for one active :call binding.
+  Returns [tenv' extra-bindings]."
+  [tenv sym init tag]
+  (let [head (first init)
+        invk? (= '.invk head)
+        args (if invk? (vec (nnext init)) (vec (rest init)))
+        ;; same op-recovery order as the reverse engine's ad-record :call
+        op (if invk?
+             (or (:raster.op/original (meta init)) (:op (meta init)) (second init))
+             head)
+        tangent-args (mapv #(when (symbol? %) (get tenv %)) args)]
+    (if-let [jf (tmpl/op-jvp-fn op)]
+      (let [ctx {:bindings [] :gensym-fn jvp-gensym}
+            [ctx' t-sym] (jf ctx args tangent-args sym jvp-gensym)
+            ;; tangent carries exactly its primal's tag (tangent protocol)
+            t-use (cond-> t-sym (some? tag) (vary-meta assoc :raster.type/tag tag))]
+        [(assoc tenv sym t-use) (:bindings ctx')])
+      (let [[template canonical] (or (tmpl/resolve-template op) [nil op])]
+        (throw (ex-info
+                (if template
+                  (str "jvp: op `" canonical "` has a reverse template but no "
+                       ":jvp-fn / :structure facet — hand frule pending (§13 A3). "
+                       "Tag its Jacobian structure in raster.ad.templates/op-structures "
+                       "or register an explicit :jvp-fn.")
+                  (str "jvp: no AD rule for op `" op "` (bound to `" sym
+                       "`) with active tangent inputs — un-templated deftm calls "
+                       "should have been inlined by ad-prepare."))
+                {:op op :canonical canonical :sym sym
+                 :active-args (filterv identity tangent-args)}))))))
+
+(defn- jvp-fold
+  "A2: ONE pure reduce over the normalized ANF bindings threading
+  {:tenv (tangent env, sym → tangent-sym), :bindings (flat primal+tangent)}.
+  Per binding: inactive → passthrough; alias → tangent alias; templated call
+  → paired tangent bindings via the op's (derived) :jvp-fn; templated-but-no-
+  jvp-fn or un-templated-active → FAIL LOUD; `if` → branch-selected tangent
+  with a typed zero for the inactive branch; loops/par forms → FAIL LOUD."
+  [norm-bindings param-tangents]
+  (reduce
+   (fn [{:keys [tenv bindings]} [sym init]]
+     (let [bindings (conj bindings sym init)
+           tag (:raster.type/tag (meta sym))
+           done (fn [tenv' extra] {:tenv tenv' :bindings (into bindings extra)})]
+       (cond
+         ;; literal / constant — no tangent
+         (and (anf/trivial-expr? init) (not (symbol? init)))
+         (done tenv [])
+
+         ;; alias — tangent alias
+         (symbol? init)
+         (done (if-let [t (get tenv init)] (assoc tenv sym t) tenv) [])
+
+         (seq? init)
+         (let [head (first init)]
+           (cond
+             ;; if: tangent = (if test Δthen Δelse), typed zero on the
+             ;; inactive branch (tangent protocol).
+             (= 'if head)
+             (let [[_ test then else] init
+                   t-then (and (symbol? then) (get tenv then))
+                   t-else (and (symbol? else) (get tenv else))]
+               (if (or t-then t-else)
+                 (let [dt (jvp-gensym (str "dt_" (name sym)) tag)]
+                   (done (assoc tenv sym dt)
+                         [dt (list 'if test
+                                   (or t-then (branch-tangent-zero then))
+                                   (or t-else (branch-tangent-zero else)))]))
+                 (done tenv [])))
+
+             ;; loops / par forms / other control flow: no forward rules yet
+             (contains? unsupported-forward-heads head)
+             (if (any-active? tenv init)
+               (throw (ex-info
+                       (str "jvp: forward-mode rules for `" head "` (bound to `"
+                            sym "`) are not implemented yet — forward loop/SOAC "
+                            "rules are follow-up work (reverse mode supports "
+                            "these; use vjp/value+grad).")
+                       {:form-head head :sym sym}))
+               (done tenv []))
+
+             ;; call (incl. devirtualized .invk)
+             :else
+             (if (some #(and (symbol? %) (contains? tenv %))
+                       (if (= '.invk head) (nnext init) (rest init)))
+               (let [[tenv' extra] (fold-call tenv sym init tag)]
+                 (done tenv' extra))
+               (done tenv []))))
+
+         :else (done tenv []))))
+   {:tenv param-tangents :bindings []}
+   (partition 2 norm-bindings)))
+
+;; ================================================================
+;; Entry point
+;; ================================================================
+
+(defn- make-runtime-jvp-fn
+  "Eval the transformed body into an IFn — the make-runtime-value+grad-fn
+  pattern: (& args) + indexed unpack past Clojure's 20-positional limit, and
+  clojure.core/alength → raster.arrays/alength so untyped INTERMEDIATE arrays
+  don't reflect ambiguously."
+  [form params]
+  (let [body (walk/postwalk-replace {'clojure.core/alength 'raster.arrays/alength}
+                                    form)]
+    (if (<= (count params) 20)
+      (eval (list 'fn (vec params) body))
+      (let [args-sym (gensym "jvp_args__")
+            unpack (vec (mapcat (fn [p i] [p (list 'clojure.core/nth args-sym i)])
+                                params (range)))]
+        (eval (list 'fn ['& args-sym] (list 'let unpack body)))))))
+
+(defn ^clojure.lang.IFn jvp
+  "Forward-mode value-and-directional-derivative for a deftm var.
+
+  (jvp #'f) → (fn [p1 … pN Δp_a … Δp_k] -> [primal tangent])
+
+  where Δp_a … Δp_k are tangent arguments for the DIFFERENTIABLE params only
+  (⊥ slots — Long/index/etc. — have no tangent slot), in param order. Pass
+  typed zero arrays/0.0 for unseeded directions (the JAX jvp contract). The
+  tangent output is J·v — exact, one forward sweep, no tape.
+
+  The transformed body/params are exposed deftm-style as metadata
+  (:raster.core/deftm-walked-body / -params / -tags) so compile-aot can
+  consume the transform later, mirroring value+grad."
+  [f-var]
+  (let [resolved (rev/resolve-deftm-var f-var)
+        m (meta resolved)
+        params (or (:raster.core/deftm-params m)
+                   (throw (ex-info "jvp requires a deftm var" {:var f-var})))
+        walked-body (or (rcore/ensure-walked-body! resolved)
+                        (throw (ex-info "No walked body on var" {:var f-var})))
+        tags (or (:raster.core/deftm-tags m) (vec (repeat (count params) 'double)))
+        all-params (vec (map-indexed
+                         (fn [i p]
+                           (let [tag (nth tags i nil)
+                                 base (if (symbol? p) p (symbol (name p)))]
+                             (if tag
+                               (with-meta base {:raster.type/tag tag})
+                               (with-meta base nil))))
+                         params))
+        ;; Only differentiable-tag params get tangent slots (⊥ params carry
+        ;; no tangent space — same seeding rule as build-grad-walked-body).
+        diff-params (vec (keep-indexed
+                          (fn [i p]
+                            (when (tangent/differentiable? (nth tags i nil)) p))
+                          all-params))
+        _ (when (empty? diff-params)
+            (throw (ex-info (str "jvp: no differentiable params on " f-var
+                                 " — every param tag is ⊥ (no tangent space)")
+                            {:var f-var :tags tags})))
+        ;; Shared pre-AD prep (identical to the reverse path).
+        prepared (rev/ad-prepare (first walked-body))
+        [bindings body-exprs] (extract-let-parts prepared)
+        [norm-bindings body-sym] (anf/normalize-for-ad bindings body-exprs jvp-gensym)
+        ;; Tangent params: one per differentiable param, tagged like its primal.
+        tangent-params (mapv (fn [p] (with-meta (symbol (str "d" (name p) "__jt"))
+                                       (meta p)))
+                             diff-params)
+        {:keys [tenv bindings]} (jvp-fold norm-bindings
+                                          (zipmap diff-params tangent-params))
+        tangent-out (or (get tenv body-sym)
+                        ;; output independent of every seeded input → typed 0̄
+                        (branch-tangent-zero body-sym))
+        jvp-form (list 'let* (vec bindings) [body-sym tangent-out])
+        fn-params (into all-params tangent-params)
+        source-ns (or (:ns m) *ns*)
+        qualified (inf/qualify-body-symbols jvp-form source-ns (set fn-params))
+        runtime-fn (make-runtime-jvp-fn qualified fn-params)
+        out-tags (into (vec (take (count params) (concat tags (repeat nil))))
+                       (mapv #(:raster.type/tag (meta %)) tangent-params))]
+    (with-meta (fn [& args] (apply runtime-fn args))
+      {::jvp true
+       :raster.core/deftm true
+       :raster.core/deftm-walked-body [qualified]
+       :raster.core/deftm-params fn-params
+       :raster.core/deftm-tags out-tags})))

--- a/src/raster/ad/reverse.clj
+++ b/src/raster/ad/reverse.clj
@@ -2173,6 +2173,28 @@
                                       {:body body}))
             :else (recur relifted (inc i))))))))
 
+(defn ^:no-doc ad-prepare
+  "The ONE shared pre-AD preparation, used by the reverse path
+  (`build-grad-walked-body`, `grad-expr`) AND the forward/JVP path
+  (`raster.ad.jvp/jvp`). Exactly the order the reverse path has always used:
+
+    anf-wrap-bare-body → lower-composites (inline un-templated composites to
+    a fixpoint) → materialize-pass (pure par/map → alloc + par/map!) →
+    hoist-nested-lets (flat ANF).
+
+  Behavior-identical refactor of the duplicated prep — the laws suite is the
+  regression net."
+  [body]
+  (let [;; ANF-normalize + inline composite deftm calls to a fixpoint so BARE
+        ;; and multi-level composites fully lower before AD (lower-composites
+        ;; runs anf-wrap-bare-body itself).
+        lowered (lower-composites body)
+        ;; Materialize pure par/map (broadcast → par/pmap) into alloc + par/map!
+        ;; before AD — the pure pmap has no reverse rule; the mutating map! does.
+        materialized (:form (materialize/materialize-pass lowered nil))]
+    ;; Hoist nested lets out of call args into flat ANF for AD.
+    (hoist-nested-lets materialized)))
+
 (defn grad-expr
   "Transform a quoted S-expression for reverse-mode AD.
   Returns the transformed S-expression that evaluates to
@@ -2186,15 +2208,7 @@
   because the differentiator core only knows template-bearing primitives. Ops
   WITH a template stay symbolic for the transform."
   [form active-params]
-  (let [;; ANF-normalize + inline composite deftm calls to a fixpoint so BARE
-        ;; and multi-level composites fully lower before AD (see lower-composites).
-        lowered (lower-composites form)
-        ;; Materialize pure par/map (broadcast → par/pmap) into alloc + par/map!
-        ;; so the AD sees the mutating, value-producing form it can differentiate
-        ;; (the pure pmap has no reverse rule).
-        materialized (:form (materialize/materialize-pass lowered nil))
-        hoisted (hoist-nested-lets materialized)]
-    (transform-body hoisted (vec active-params))))
+  (transform-body (ad-prepare form) (vec active-params)))
 
 (defn numerical-gradient
   "Compute gradient by finite differences (for testing).
@@ -2695,15 +2709,9 @@
                 float  :float
                 double :double
                 (if (some #{'floats 'float} tags) :float :double))
-        ;; Lower: ANF-normalize + inline compound deftm ops into primitives
-        ;; before AD, to a fixpoint so BARE and multi-level composites fully
-        ;; inline (see lower-composites).
-        lowered (lower-composites (first walked-body))
-        ;; Materialize pure par/map (broadcast → par/pmap) into alloc + par/map!
-        ;; before AD — the pure pmap has no reverse rule; the mutating map! does.
-        materialized (:form (materialize/materialize-pass lowered nil))
-        ;; Hoist nested lets out of call args into flat ANF for AD
-        hoisted (hoist-nested-lets materialized)
+        ;; Shared pre-AD preparation (lower composites → materialize → hoist
+        ;; into flat ANF) — see ad-prepare, shared with the JVP path.
+        hoisted (ad-prepare (first walked-body))
         ;; transform-body itself will lift any binding-position loop into
         ;; tail position via lift-loop-to-tail.
         ad-form (transform-body hoisted diff-active-params)

--- a/src/raster/ad/templates.clj
+++ b/src/raster/ad/templates.clj
@@ -21,7 +21,8 @@
      :grads-fn (optional)  ;; (fn [ctx params result-sym adjoint-sym gensym-fn]
                            ;;   -> [updated-ctx [grad-sym ...]]) for flat bindings}"
   (:require [raster.compiler.support.mangled :as mangled]
-            [raster.compiler.core.util :as util]))
+            [raster.compiler.core.util :as util]
+            [raster.ad.tangent :as tangent]))
 
 ;; ================================================================
 ;; Template registry
@@ -1014,3 +1015,321 @@
                                               [dA (list 'raster.linalg.core/array-det-backward
                                                         adjoint-sym result-sym A n)])
                                       [dA nil]]))})
+
+;; ================================================================
+;; §13 A1 — structure tags + DERIVED forward rules (JVP), one rule source
+;;
+;; The :structure facet is a presentation of the op's Jacobian
+;; (framework §2: ONE presentation, two contractions). The reverse
+;; contraction is the existing :grads/:grads-fn; the forward contraction
+;; (:jvp-fn) is DERIVED from the structure class — never a second
+;; hand-written table (the Julia two-forward-tables mistake):
+;;
+;;   :elementwise  diagonal J = Jᵀ      → frule(v) = grads-fn with dy:=v
+;;                 (also every SCALAR op: output is 1-dim, so grads[i] is
+;;                  Jᵢ·dy, linear in dy ⇒ frule = Σᵢ grads[i](dy:=Δxᵢ) —
+;;                  the @scalar_rule mechanics, product rule falls out)
+;;   :symmetric    J = Jᵀ (softmax)     → same diagonal reuse
+;;   :linear       jointly-linear in :in → frule = the op itself on the
+;;                 tangents (inactive :in slots get typed zeros — NOT the
+;;                 primal: f(Δa, b) ≠ df for additive ops)
+;;   :bilinear     frule = op(Δx,W,0ₑ) ⊕ op(x,ΔW,0ₑ), affine :linear-extra
+;;                 slots (biases) zeroed in every term except the first,
+;;                 which routes the extras' own tangents
+;;   :scalar-loss  frule = ⟨grads-fn(dy:=1̄), v⟩ via a generic dot kernel
+;;
+;; Emission hazard (RoR recon): every emitted call is FULLY QUALIFIED and
+;; tangent syms carry their primal's :raster.type/tag (tangent protocol) so
+;; parametric dispatch resolves and devirtualization can work downstream.
+;;
+;; ⊕ for tangent contributions is raster.ad.reverse/grad-acc — the SAME
+;; polymorphic (scalar/array, nil-safe) accumulator the reverse pass uses.
+;; The dot kernel is raster.par/dot-product ((All [T]) → Double), reused —
+;; no new kernel needed.
+;; ================================================================
+
+(def ^:private op-structures
+  "Jacobian structure classes per §13-RESOLVED inventory (indices verified
+  against each op's registered :params / deftm param list).
+  NOTE inventory corrections:
+   - class (b) linear counts 16 ops here (the doc's `14` undercounts the
+     pack/unpack and slice/scatter pairs it lists as single entries);
+   - raster.nn/dense arg order is [W x b] (weights first, unlike linear);
+   - raster.nn/softmax-cross-entropy returns a TUPLE [loss s]; its derived
+     JVP is the tangent of the LOSS component (mirrors the reverse rule,
+     whose scalar adjoint dy also addresses only the loss slot);
+   - forward-noise is JOINTLY linear in {x0, noise} (alpha-t rule-frozen);
+   - maxpool2d, einsum, dgemm! deliberately untagged (A3/kernel gaps)."
+  {;; --- (a) elementwise: diagonal Jacobian, frule = backward(tangent) ---
+   'raster.nn/relu                       {:class :elementwise :in #{0}} ;; [x]
+   'raster.dl.nn/gelu                    {:class :elementwise :in #{0}} ;; [x n]
+   'raster.dl.nn/silu                    {:class :elementwise :in #{0}} ;; [x n]
+   'raster.dl.nn/sigmoid                 {:class :elementwise :in #{0}} ;; [x n]
+   'raster.dl.nn/tanh-act                {:class :elementwise :in #{0}} ;; [x n]
+   'raster.dl.nn/leaky-relu              {:class :elementwise :in #{0}} ;; [x n alpha]
+   'raster.dl.nn/dropout                 {:class :elementwise :in #{0}} ;; [x mask n], mask frozen
+   'raster.dl.array-ops/scale-clamp-exp  {:class :elementwise :in #{0}} ;; [x scale clamp-bound n], scale rule-frozen
+   ;; --- (a′) symmetric: J = diag(s) − ssᵀ = Jᵀ ---
+   'raster.nn/softmax                    {:class :symmetric :in #{0}}   ;; [x]
+   'raster.dl.nn/softmax-1d              {:class :symmetric :in #{0}}   ;; [x n]
+   ;; --- (b) linear: frule = the op on the tangent(s) ---
+   'raster.dl.nn/residual-add            {:class :linear :in #{0 1}}    ;; [a b n]
+   'raster.dl.array-ops/array-add        {:class :linear :in #{0 1}}    ;; [a b n]
+   'raster.dl.array-ops/broadcast-add    {:class :linear :in #{0 1}}    ;; [h t batch dim]
+   'raster.dl.nn/transpose-2d            {:class :linear :in #{0}}      ;; [a rows cols]
+   'raster.dl.array-ops/pack-heads       {:class :linear :in #{0}}      ;; [x seq-len n-heads head-dim]
+   'raster.dl.array-ops/unpack-heads     {:class :linear :in #{0}}      ;; [x seq-len n-heads head-dim]
+   'raster.dl.array-ops/slice-strided-2d {:class :linear :in #{0}}      ;; [src rows row-stride col-offset n-cols]
+   'raster.dl.array-ops/scatter-strided-2d {:class :linear :in #{0}}    ;; [packed rows row-stride col-offset n-cols]
+   'raster.dl.array-ops/gather           {:class :linear :in #{0}}      ;; [src indices n-src n-pairs stride]
+   'raster.dl.array-ops/scatter-add      {:class :linear :in #{0}}      ;; [vals indices n-dst n-pairs stride]
+   'raster.dl.array-ops/reduce-axis      {:class :linear :in #{0}}      ;; [src n-rows n-cols]
+   'raster.dl.nn/embedding               {:class :linear :in #{0}}      ;; [table indices n vocab dim]
+   'raster.dl.attention/rope             {:class :linear :in #{0}}      ;; [x seq-len heads head-dim theta] — orthogonal rotation
+   'raster.dl.einsum/rearrange           {:class :linear :in #{0}}      ;; [tensor pattern axis-lengths?] — permutation
+   'raster.dl.diffusion/forward-noise    {:class :linear :in #{0 1}}    ;; [x0 noise alpha-t n], alpha-t rule-frozen
+   'raster.quant.train/qlinear-q8        {:class :linear :in #{0}}      ;; [x codes scales m in out] — codes frozen
+   'clojure.core/aget                    {:class :linear :in #{0}}      ;; [arr i] — one-hot read
+   ;; --- (c) bilinear: frule = op(Δx,·) ⊕ op(·,ΔW) ---
+   'raster.dl.nn/matmul          {:class :bilinear :args [0 1]}                   ;; [A B m k n]
+   'raster.dl.nn/linear          {:class :bilinear :args [0 1] :linear-extra #{2}} ;; [x W b batch in-f out-f]
+   'raster.dl.nn/linear-nb       {:class :bilinear :args [0 1]}                   ;; [x W batch in-f out-f]
+   'raster.nn/dense              {:class :bilinear :args [0 1] :linear-extra #{2}} ;; [W x b]
+   'raster.dl.nn/hadamard        {:class :bilinear :args [0 1]}                   ;; [a b n]
+   'raster.dl.array-ops/dot-rows {:class :bilinear :args [0 1] :linear-extra #{2}} ;; [h W bias n-rows dim]
+   'raster.dl.array-ops/indexed-dot     {:class :bilinear :args [0 1]}            ;; [A B idx-a idx-b ...]
+   'raster.dl.array-ops/scatter-mul-add {:class :bilinear :args [0 1]}            ;; [coeffs src ...]
+   'raster.dl.nn/conv1d          {:class :bilinear :args [0 1] :linear-extra #{2}} ;; [x W b batch ...]
+   'raster.dl.nn/conv2d          {:class :bilinear :args [0 1] :linear-extra #{2}} ;; [x W b batch ...]
+   ;; --- (d) scalar losses: frule = ⟨grads-fn(1̄), v⟩ ---
+   'raster.dl.loss/mse-loss             {:class :scalar-loss} ;; [pred target n], target rule-frozen
+   'raster.dl.loss/l1-loss              {:class :scalar-loss} ;; [pred target n]
+   'raster.dl.loss/huber-loss           {:class :scalar-loss} ;; [pred target n delta]
+   'raster.dl.array-ops/masked-mse-loss {:class :scalar-loss} ;; [pred target states n]
+   'raster.dl.loss/cross-entropy-loss   {:class :scalar-loss} ;; [logits target batch classes]
+   'raster.nn/cross-entropy             {:class :scalar-loss} ;; [p t], t rule-frozen
+   'raster.nn/softmax-cross-entropy     {:class :scalar-loss} ;; [logits t] → [loss s] tuple (see note)
+   ;; --- scalar primitives: frule = Σᵢ grads(dy:=Δxᵢ) (mechanical, §2) ---
+   '+          {:class :elementwise :in #{0 1}}
+   '-          {:class :elementwise :in #{0 1}}
+   '*          {:class :elementwise :in #{0 1}}
+   '/          {:class :elementwise :in #{0 1}}
+   'raster.ad.reverse/grad-acc {:class :elementwise :in #{0 1}}
+   'Math/sin   {:class :elementwise :in #{0}}
+   'Math/cos   {:class :elementwise :in #{0}}
+   'Math/exp   {:class :elementwise :in #{0}}
+   'Math/log   {:class :elementwise :in #{0}}
+   'Math/sqrt  {:class :elementwise :in #{0}}
+   'Math/pow   {:class :elementwise :in #{0 1}}
+   'Math/abs   {:class :elementwise :in #{0}}
+   'Math/tan   {:class :elementwise :in #{0}}
+   'Math/asin  {:class :elementwise :in #{0}}
+   'Math/acos  {:class :elementwise :in #{0}}
+   'Math/atan  {:class :elementwise :in #{0}}
+   'Math/atan2 {:class :elementwise :in #{0 1}}
+   'Math/min   {:class :elementwise :in #{0 1}}
+   'Math/max   {:class :elementwise :in #{0 1}}
+   'Math/fma   {:class :elementwise :in #{0 1 2}}
+   'Math/sinh  {:class :elementwise :in #{0}}
+   'Math/cosh  {:class :elementwise :in #{0}}
+   'Math/tanh  {:class :elementwise :in #{0}}
+   'Math/log1p {:class :elementwise :in #{0}}
+   'Math/expm1 {:class :elementwise :in #{0}}
+   'Math/cbrt  {:class :elementwise :in #{0}}
+   'Math/log10 {:class :elementwise :in #{0}}
+   'Math/hypot {:class :elementwise :in #{0 1}}
+   'double     {:class :elementwise :in #{0}}
+   'float      {:class :elementwise :in #{0}}
+   'long       {:class :elementwise :in #{0}}   ;; grads 0.0 → zero tangent (cast kills derivative)
+   'int        {:class :elementwise :in #{0}}
+   'raster.sci.special/lgamma   {:class :elementwise :in #{0}}
+   'raster.sci.special/digamma  {:class :elementwise :in #{0}}
+   'raster.sci.special/erf      {:class :elementwise :in #{0}}
+   'raster.sci.special/erfinv   {:class :elementwise :in #{0}}
+   'raster.sci.special/expit    {:class :elementwise :in #{0}}
+   'raster.sci.special/logit    {:class :elementwise :in #{0}}
+   'raster.sci.special/log1pexp {:class :elementwise :in #{0}}
+   'raster.sci.special/besselj0 {:class :elementwise :in #{0}}
+   'raster.sci.special/besselj1 {:class :elementwise :in #{0}}
+   'raster.sci.special/betainc  {:class :elementwise :in #{2}}})
+
+;; Merge structure facets into the registry. merge-into-template! is
+;; order-independent: ops whose :grads-fn is registered by a later-loaded ns
+;; (raster.dl.*, raster.nn, …) get a partial {:structure …} entry here that
+;; the later merge fills in. Ops registered by register-template! ABOVE in
+;; this file are merged after their registration (this block is at the end).
+(doseq [[op st] op-structures]
+  (merge-into-template! op {:structure st}))
+
+(defn- jvp-zero-like
+  "Typed zero tangent shaped/dtyped like the PRIMAL arg (tangent protocol):
+  used for :in / :linear-extra slots whose tangent is absent in a term where
+  substituting the primal would be WRONG (linear ⇒ f(Δa,b) ≠ df)."
+  [primal-arg]
+  (list 'raster.arrays/zeros-like primal-arg
+        (list 'raster.arrays/alength primal-arg)))
+
+(defn- sum-tangent-contribs
+  "Bind the ⊕-sum of tangent contribution exprs; returns [ctx' sym].
+  ⊕ is raster.ad.reverse/grad-acc — polymorphic scalar/array, the same
+  accumulator the reverse pass uses."
+  [ctx contribs gensym-fn]
+  (let [t-sym (gensym-fn "jt")
+        expr (reduce (fn [a b] (list 'raster.ad.reverse/grad-acc a b)) contribs)]
+    [(update ctx :bindings into [t-sym expr]) t-sym]))
+
+(defn- derive-jvp-fn
+  "Synthesize the :jvp-fn facet from the op's :structure tag + its EXISTING
+  gradient representation (one rule source). Returns
+    (fn [ctx args tangent-args result-sym gensym-fn] -> [ctx' tangent-sym])
+  emitting FLAT bindings (BindCtx style, like grads-fn). tangent-args is
+  aligned with args; nil = no tangent flowing into that slot."
+  [canonical-op template {:keys [class in args linear-extra]}]
+  (case class
+    ;; Diagonal / symmetric / scalar Jacobian: reuse grads-fn with dy:=Δxᵢ.
+    (:elementwise :symmetric)
+    (let [in-idxs (vec (sort (or in #{0})))]
+      (when-not (:grads-fn template)
+        (throw (ex-info (str "derive-jvp-fn: " canonical-op " tagged " class
+                             " but has no :grads-fn to reuse")
+                        {:op canonical-op :class class})))
+      (fn [ctx call-args tangent-args result-sym gensym-fn]
+        (let [[ctx contribs]
+              (reduce
+               (fn [[ctx contribs] i]
+                 (if-let [tv (and (< i (count call-args)) (nth tangent-args i nil))]
+                   (let [[ctx' gsyms] (instantiate-template-ctx
+                                       template (vec call-args) result-sym tv ctx)
+                         g (nth gsyms i nil)]
+                     (if (some? g) [ctx' (conj contribs g)] [ctx' contribs]))
+                   [ctx contribs]))
+               [ctx []] in-idxs)]
+          (when (empty? contribs)
+            (throw (ex-info (str "derive-jvp-fn: no active tangent reached " canonical-op)
+                            {:op canonical-op :tangent-args tangent-args})))
+          (sum-tangent-contribs ctx contribs gensym-fn))))
+
+    ;; Jointly-linear: run the op itself with ALL :in slots replaced by their
+    ;; tangents (typed zero where a slot's tangent is absent — linearity makes
+    ;; the simultaneous substitution exactly the pushforward; a one-at-a-time
+    ;; sum with primal in the other slot would be wrong for additive ops).
+    :linear
+    (let [in-set (set in)]
+      (fn [ctx call-args tangent-args _result-sym gensym-fn]
+        (when-not (some #(nth tangent-args % nil) in-set)
+          (throw (ex-info (str "derive-jvp-fn: no active tangent reached " canonical-op)
+                          {:op canonical-op})))
+        (let [args' (map-indexed
+                     (fn [i a]
+                       (if (contains? in-set i)
+                         (or (nth tangent-args i nil) (jvp-zero-like a))
+                         a))
+                     call-args)
+              t-sym (gensym-fn "jt")]
+          [(update ctx :bindings into [t-sym (cons canonical-op args')]) t-sym])))
+
+    ;; Bilinear(i,j) + affine extras: op(Δxᵢ, xⱼ, extras…) ⊕ op(xᵢ, Δxⱼ, 0ₑ).
+    ;; Extras (biases) are AFFINE offsets: they must be ZEROED in every term,
+    ;; except the first emitted term routes the extras' own tangents (linear).
+    :bilinear
+    (let [[bi bj] args
+          extras (set (or linear-extra #{}))]
+      (fn [ctx call-args tangent-args _result-sym gensym-fn]
+        (let [ti (nth tangent-args bi nil)
+              tj (nth tangent-args bj nil)
+              extra-active? (some #(nth tangent-args % nil) extras)
+              subst (fn [swap-idx zero-i? route-extras?]
+                      (map-indexed
+                       (fn [k a]
+                         (cond
+                           (= k swap-idx) (nth tangent-args swap-idx)
+                           (contains? extras k)
+                           (if route-extras?
+                             (or (nth tangent-args k nil) (jvp-zero-like a))
+                             (jvp-zero-like a))
+                           (and zero-i? (= k bi)) (jvp-zero-like a)
+                           :else a))
+                       call-args))
+              terms (cond-> []
+                      ti (conj (cons canonical-op (subst bi false true)))
+                      tj (conj (cons canonical-op (subst bj false (not ti))))
+                      ;; extras-only tangent: op(0ᵢ, xⱼ, Δextras) = Δextras' image
+                      (and (not ti) (not tj) extra-active?)
+                      (conj (cons canonical-op
+                                  (map-indexed
+                                   (fn [k a]
+                                     (cond
+                                       (= k bi) (jvp-zero-like a)
+                                       (contains? extras k)
+                                       (or (nth tangent-args k nil) (jvp-zero-like a))
+                                       :else a))
+                                   call-args))))]
+          (when (empty? terms)
+            (throw (ex-info (str "derive-jvp-fn: no active tangent reached " canonical-op)
+                            {:op canonical-op})))
+          (let [[ctx term-syms]
+                (reduce (fn [[ctx syms] term]
+                          (let [s (gensym-fn "jbt")]
+                            [(update ctx :bindings into [s term]) (conj syms s)]))
+                        [ctx []] terms)]
+            (sum-tangent-contribs ctx term-syms gensym-fn)))))
+
+    ;; Scalar loss: frule = ⟨grads-fn(dy := typed 1̄), Δactive⟩ per active arg,
+    ;; summed. Dot kernel: raster.par/dot-product ((All [T]) → Double), reused.
+    :scalar-loss
+    (do
+      (when-not (:grads-fn template)
+        (throw (ex-info (str "derive-jvp-fn: " canonical-op
+                             " tagged :scalar-loss but has no :grads-fn to reuse")
+                        {:op canonical-op})))
+      (fn [ctx call-args tangent-args result-sym gensym-fn]
+        (let [seed-sym (gensym-fn "jseed")
+              ;; typed unit adjoint from the RESULT's tag (tangent protocol);
+              ;; untagged falls back to 1.0 (loss is scalar by contract).
+              seed (tangent/seed-expr (:raster.type/tag (meta result-sym)))
+              ctx (update ctx :bindings into [seed-sym seed])
+              [ctx gsyms] (instantiate-template-ctx
+                           template (vec call-args) result-sym seed-sym ctx)
+              contribs (vec (keep-indexed
+                             (fn [i g]
+                               (when-let [tv (and (some? g) (nth tangent-args i nil))]
+                                 (list 'raster.par/dot-product g tv)))
+                             gsyms))]
+          (if (empty? contribs)
+            ;; every tangent-bearing arg is rule-frozen (e.g. mse target):
+            ;; the rule's pushforward is exactly 0 — mirror the reverse rule.
+            (let [t-sym (gensym-fn "jt")]
+              [(update ctx :bindings into [t-sym 0.0]) t-sym])
+            (sum-tangent-contribs ctx contribs gensym-fn)))))
+
+    (throw (ex-info (str "derive-jvp-fn: unknown :structure class " class
+                         " on " canonical-op)
+                    {:op canonical-op :class class}))))
+
+(defn op-jvp-fn
+  "The op's forward-mode (JVP) rule: an explicit :jvp-fn facet, or one derived
+  (and cached) from its :structure tag. Returns nil when the op has neither —
+  the transform (raster.ad.jvp) fails loud naming the op in that case.
+
+  Alias chasing: qualified alias entries (raster.numeric/+, clojure.core/sin
+  variants, …) were value-copied at registration BEFORE structure tagging, so
+  a structureless alias falls back to its canonical base key."
+  [op]
+  (when-let [[template canonical] (resolve-template op)]
+    (or (:jvp-fn template)
+        (when-let [st (:structure template)]
+          (let [f (derive-jvp-fn canonical template st)]
+            (swap! template-registry assoc-in [canonical :jvp-fn] f)
+            f))
+        ;; alias → base fallbacks
+        (when-let [base (get qualified->base-op canonical)]
+          (op-jvp-fn base))
+        (when (and (qualified-symbol? canonical)
+                   (= "raster.math" (namespace canonical)))
+          (let [interop (symbol "Math" (name canonical))]
+            (when (get-template interop) (op-jvp-fn interop))))
+        (when (and (qualified-symbol? canonical)
+                   (= "clojure.core" (namespace canonical))
+                   (not= canonical (symbol (name canonical))))
+          (let [bare (symbol (name canonical))]
+            (when (get-template bare) (op-jvp-fn bare)))))))

--- a/test/raster/ad/laws_test.clj
+++ b/test/raster/ad/laws_test.clj
@@ -17,6 +17,7 @@
             [raster.math :as m]
             [raster.arrays :as ra]
             [raster.ad.reverse :as rev]
+            [raster.ad.jvp :as jvp]
             [raster.ad.tangent :as tangent]
             [raster.ad.forward :as fwd]
             [raster.ad.jet :as jet]
@@ -151,6 +152,41 @@
                      batch :- Long in :- Long out :- Long] :- Double
   (loss/mse-loss (nn/linear-nb x W batch in out) tgt (clojure.core/* batch out)))
 
+;; Float-only silu wrapper: under a full-suite load the parametric
+;; (All [T]) silu already has a DOUBLES specialization when this ns walks,
+;; and a TC failure inside the composite makes the walker's single-method
+;; fallback pick it → silent [F→[D miscompile of the PRIMAL body (direct
+;; call breaks too — pre-existing devirt hole, not an AD defect). The
+;; single-method float wrapper makes even the fallback resolve float; the
+;; AD paths inline it (un-templated) down to the templated silu.
+(deftm laws-jvp-silu [x :- (Array float) n :- Long] :- (Array float)
+  (nn/silu x n))
+
+;; Deeper float chain for O1b: linear-nb → silu → linear-nb → mse.
+;; Exercises every derived-JVP class in one graph: bilinear (both x- and
+;; W-sides of two linear-nbs), elementwise (silu via diagonal grads-fn
+;; reuse), scalar-loss (mse via ⟨grads-fn(1̄), v⟩ dot contraction).
+(deftm laws-jvp-chain [x :- (Array float) W1 :- (Array float) W2 :- (Array float)
+                       tgt :- (Array float)
+                       batch :- Long in :- Long hid :- Long out :- Long] :- Double
+  (loss/mse-loss
+   (nn/linear-nb (laws-jvp-silu (nn/linear-nb x W1 batch in hid)
+                                (clojure.core/* batch hid))
+                 W2 batch hid out)
+   tgt (clojure.core/* batch out)))
+
+;; Array-OUTPUT fn for the real-jvp O7 adjoint identity (single-method float
+;; wrapper — the parametric nn/linear-nb dispatch var is ambiguous for AD).
+(deftm laws-jvp-lnb [x :- (Array float) W :- (Array float)
+                     batch :- Long in :- Long out :- Long] :- (Array float)
+  (nn/linear-nb x W batch in out))
+
+;; Class-(d) residue op (rms-norm: reverse template, NO structure tag / frule
+;; yet — §13 A3): jvp over it must FAIL LOUD naming the op.
+(deftm laws-jvp-rms [x :- (Array float) w :- (Array float)
+                     rows :- Long feats :- Long] :- (Array float)
+  (nn/rms-norm x w rows feats 1.0e-6 0.0))
+
 ;; g(x) = <f(x), w> for O7 (w passed as a param array)
 (deftm laws-lnb-dotw [x :- (Array float) W :- (Array float) w :- (Array float)
                       batch :- Long in :- Long out :- Long] :- Double
@@ -259,6 +295,93 @@
           (is (close? gr (erf-analytic-deriv x) 1e-10) (str "erf rev=analytic at " x))
           (is (close? gf (erf-analytic-deriv x) 1e-10) (str "erf fwd=analytic at " x))
           (is (close? gr (central-fd laws-f5 x 1e-4) 5e-6) (str "erf rev~FD at " x)))))))
+
+;; ================================================================
+;; O1b — array-forward mode (JVP transform, §13 A1/A2): the directional
+;; tangent J·v equals the central directional FD (f(p+hv)−f(p−hv))/2h at
+;; float tolerance, for tangents seeded on EACH active param class
+;; (elementwise / linear / bilinear / scalar-loss all exercised).
+;; ================================================================
+
+(defn- fd-dir
+  "Central directional FD of scalar (apply f args) with args[slot] shifted
+  along v."
+  [f args slot v h]
+  (let [shift (fn [s] (update (vec args) slot faxpy s v))]
+    (/ (- (double (apply f (shift h))) (double (apply f (shift (- h)))))
+       (* 2.0 h))))
+
+(deftest o1b-jvp-array-law
+  (testing "mse∘linear-nb (float): jvp tangent = directional FD per seeded param"
+    (let [batch 2 in 4 out 3
+          x (fa (* batch in) 61) W (fa (* out in) 62) tgt (fa (* batch out) 63)
+          jf (jvp/jvp #'laws-lnb-mse)
+          zx (float-array (* batch in)) zW (float-array (* out in))
+          ztgt (float-array (* batch out))
+          h 1e-2
+          run (fn [tx tW ttgt] (jf x W tgt batch in out tx tW ttgt))]
+      ;; primal agreement
+      (is (close? (nth (run zx zW ztgt) 0) (laws-lnb-mse x W tgt batch in out)
+                  tol-float) "jvp primal = direct evaluation")
+      ;; bilinear x-side + scalar-loss
+      (let [v (fa (* batch in) 64)
+            [_ t] (run v zW ztgt)]
+        (is (close? t (fd-dir laws-lnb-mse [x W tgt batch in out] 0 v h) tol-float)
+            "x-seeded tangent = FD"))
+      ;; bilinear W-side
+      (let [v (fa (* out in) 65)
+            [_ t] (run zx v ztgt)]
+        (is (close? t (fd-dir laws-lnb-mse [x W tgt batch in out] 1 v h) tol-float)
+            "W-seeded tangent = FD"))
+      ;; target is RULE-frozen (mse rrule gives target a nil grad): the
+      ;; derived JVP must mirror the rule — tangent exactly 0, matching
+      ;; reverse's typed-zero d_tgt, NOT the mathematical ∂/∂tgt.
+      (let [v (fa (* batch out) 66)
+            [_ t] (run zx zW v)]
+        (is (== 0.0 (double t)) "tgt-seeded tangent = 0 (rule-frozen slot)"))))
+
+  (testing "deep chain linear-nb→silu→linear-nb→mse: every derived class"
+    (let [batch 2 in 4 hid 5 out 3
+          x (fa (* batch in) 71) W1 (fa (* hid in) 72) W2 (fa (* out hid) 73)
+          tgt (fa (* batch out) 74)
+          args [x W1 W2 tgt batch in hid out]
+          jf (jvp/jvp #'laws-jvp-chain)
+          zx (float-array (* batch in)) zW1 (float-array (* hid in))
+          zW2 (float-array (* out hid)) ztgt (float-array (* batch out))
+          h 1e-2
+          ;; FD referee tolerance through the deep chain: float rounding +
+          ;; h² truncation across the silu nonlinearity compound to ~1e-3
+          ;; relative — the exact-vs-exact assertions below stay at tol-float.
+          tol-fd 5e-3
+          run (fn [tx tW1 tW2] (jf x W1 W2 tgt batch in hid out tx tW1 tW2 ztgt))]
+      (let [v (fa (* batch in) 75)
+            [_ t] (run v zW1 zW2)]
+        (is (close? t (fd-dir laws-jvp-chain args 0 v h) tol-fd)
+            "x seed: bilinear-x → elementwise → bilinear-x → scalar-loss"))
+      (let [v (fa (* hid in) 76)
+            [_ t] (run zx v zW2)]
+        (is (close? t (fd-dir laws-jvp-chain args 1 v h) tol-fd)
+            "W1 seed: bilinear-W through the elementwise layer"))
+      (let [v (fa (* out hid) 77)
+            [_ t] (run zx zW1 v)]
+        (is (close? t (fd-dir laws-jvp-chain args 2 v h) tol-fd)
+            "W2 seed: bilinear-W direct into the loss"))
+      ;; joint seed = sum of single seeds (linearity of the pushforward)
+      (let [vx (fa (* batch in) 75) vW1 (fa (* hid in) 76) vW2 (fa (* out hid) 77)
+            [_ tj] (run vx vW1 vW2)
+            [_ t1] (run vx zW1 zW2)
+            [_ t2] (run zx vW1 zW2)
+            [_ t3] (run zx zW1 vW2)]
+        (is (close? tj (+ (double t1) (double t2) (double t3)) tol-float)
+            "joint tangent = Σ single-seed tangents (linearity)"))))
+
+  (testing "unsupported forward forms fail LOUD naming the op (A3 pending)"
+    ;; rms-norm has a reverse template but sits in the class-(d) residue —
+    ;; no :structure tag, no :jvp-fn: the transform must throw, never drop
+    ;; a tangent silently.
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"rms-norm.*§13 A3"
+         (jvp/jvp #'laws-jvp-rms)))))
 
 ;; ================================================================
 ;; O3 — tangent-algebra laws: ⊕ accumulation, 0̄, ⊥ slots
@@ -607,7 +730,31 @@
 ;; ================================================================
 
 (deftest o7-adjoint-identity-law
-  (testing "array composite (linear-nb, float): <J·v, w> = <v, grad <f(x),w>>"
+  (testing "REAL adjoint identity <jvp(v), w> = <v, vjp(w)> — frule and rrule
+            test each other with NO FD oracle (§12 O7, upgraded for §13 A2)"
+    (let [batch 2 in 4 out 3
+          x (fa (* batch in) 11) W (fa (* out in) 12)
+          v (fa (* batch in) 13)                     ;; input tangent (x-side)
+          u (fa (* out in) 15)                       ;; input tangent (W-side)
+          w (fa (* batch out) 14)                    ;; output cotangent
+          jf (jvp/jvp #'laws-jvp-lnb)
+          zx (float-array (* batch in)) zW (float-array (* out in))
+          [y dy-x] (jf x W batch in out v zW)        ;; J·(v,0)
+          [_ dy-W] (jf x W batch in out zx u)        ;; J·(0,u)
+          res ((rev/value+grad #'laws-lnb-dotw) x W w batch in out)
+          gx ^floats (nth res 1)                     ;; Jᵀw over x
+          gW ^floats (nth res 2)]                    ;; Jᵀw over W
+      (is (close? (fdot dy-x w) (fdot v gx) tol-float)
+          "⟨jvp(v),w⟩ = ⟨v, vjp(w)⟩ over x")
+      (is (close? (fdot dy-W w) (fdot u gW) tol-float)
+          "⟨jvp(u),w⟩ = ⟨u, vjp(w)⟩ over W")
+      ;; jvp primal = the op itself
+      (is (farr-close? y (nn/linear-nb x W batch in out) tol-float)
+          "jvp primal output = forward evaluation")
+      ;; Sanity: the scalar pairing itself matches the primal value.
+      (is (close? (first res) (fdot (nn/linear-nb x W batch in out) w) tol-float))))
+
+  (testing "directional-FD anchor for the same composite (the external referee)"
     (let [batch 2 in 4 out 3
           x (fa (* batch in) 11) W (fa (* out in) 12)
           v (fa (* batch in) 13)                     ;; input tangent
@@ -619,9 +766,7 @@
           res ((rev/value+grad #'laws-lnb-dotw) x W w batch in out)
           gx ^floats (nth res 1)
           rhs (fdot v gx)]
-      (is (close? lhs rhs tol-float) "adjoint identity over x")
-      ;; Sanity: the scalar pairing itself matches the primal value.
-      (is (close? (first res) (fdot (nn/linear-nb x W batch in out) w) tol-float))))
+      (is (close? lhs rhs tol-float) "adjoint identity over x (FD LHS)")))
 
   (testing "scalar anchor: <f'(x)v, w> = <v, d/dx (w*f(x))>"
     (let [x 1.3 v 0.37 w -2.1


### PR DESCRIPTION
Phases A1+A2 of the array-forward design (framework §13-RESOLVED): forward-mode differentiation through array/NN ops with **one rule source** — no third table.

**A1 — structure tags + derived JVP rules** (`templates.clj`): 44 ops tagged by Jacobian structure — 8 elementwise, 2 symmetric (softmax: J=Jᵀ), 17 linear (incl. rope, qlinear-q8, gather/scatter), 10 bilinear (matmul/linear/conv/hadamard), 7 scalar-losses — plus scalar primitives as the mechanical `@scalar_rule` contraction. `derive-jvp-fn` synthesizes `:jvp-fn` from the tag: elementwise/symmetric **reuse the op's own `:grads-fn`** with adjoint:=tangent (diagonal/symmetric reuse); linear = simultaneous tangent substitution (correction over the spec: one-at-a-time is wrong for additive ops — joint linearity is the pushforward); bilinear = op(Δx,W) ⊕ op(x,ΔW); scalar-loss = ⟨rrule(unit-seed), v⟩ via existing `par/dot-product`. Emitted calls fully qualified + tangent syms inherit their primal's type tag.

**A2 — the jvp-fold + `ad-prepare` unification** (`ad/jvp.clj` new ns): a single pure forward fold (no tape, no reversal) pairing each ANF binding with a tangent binding; fail-loud for A3-residue ops and loops. Shared pre-AD prep (`lower-composites → materialize → hoist`) factored into ONE `ad-prepare` used by both reverse and jvp paths (behavior-identical — old track-unification goal advanced). `(jvp #'f)` returns `[primal tangent]`, carries deftm-style metadata for future compile-aot consumption.

**Laws**: new `o1b-jvp-array-law` (jvp vs directional FD on float mse∘linear-nb + a linear→silu→linear→mse chain, seeded per structure class); **O7 upgraded to the real adjoint identity** ⟨jvp(v),w⟩=⟨v,vjp(w)⟩ over x and W — frule and rrule now test each other with no FD oracle. Laws ns: 10 tests / 214 assertions.

Surfaced (pre-existing, tracked separately): under full-suite load, a float deep-chain deftm's *primal* miscompiles — the walker's single-method fallback devirtualizes inner `silu` to the already-JIT'd doubles impl inside a float chain (`[F→[D` CCE); tc_source_ns-devirt-hole class.

Fresh JVM (foreground): **1733 / 29002 / 0 / 0, census 0**.