### PR TITLE
AD: JVP residue frules (A3) + HVP-through-layers (A4)

### DIFF
--- a/src/raster/ad/jvp.clj
+++ b/src/raster/ad/jvp.clj
@@ -23,7 +23,9 @@
             [raster.ad.tangent :as tangent]
             [raster.ad.reverse.normalize :as anf]
             [raster.compiler.core.inference :as inf]
+            [raster.compiler.core.op-descriptor :as opdesc]
             [raster.core :as rcore]
+            [clojure.string :as string]
             [clojure.walk :as walk]
             ;; Kernel namespaces the derived rules emit calls into:
             [raster.par]      ;; dot-product — the scalar-loss frule contraction
@@ -72,6 +74,11 @@
     (if (some? btag)
       (tangent/zero-expr btag (list 'raster.arrays/alength branch))
       (list 'raster.ad.tangent/zero-like branch))))
+
+(def ^:private shape-read-heads
+  "Shape/length reads: integer-valued, no tangent space — an active array
+  reaching them is a shape REFERENCE, not a differentiable dependence."
+  '#{raster.arrays/alength clojure.core/alength alength})
 
 (def ^:private unsupported-forward-heads
   "Differentiable-in-reverse forms with NO forward fold yet (follow-up):
@@ -162,11 +169,30 @@
 
              ;; call (incl. devirtualized .invk)
              :else
-             (if (some #(and (symbol? %) (contains? tenv %))
+             (let [op-sym (if (= '.invk head)
+                            (or (:raster.op/original (meta init))
+                                (:op (meta init)) (second init))
+                            head)]
+               (cond
+                 ;; Pure allocations (zeros-like / alloc-like / *-array …):
+                 ;; a fresh zero/uninitialized buffer with NO differentiable
+                 ;; dependence on any input — active syms reach them only as
+                 ;; shape/dtype REFERENCES (e.g. the gradient program's
+                 ;; (zeros-like tgt (alength tgt)) typed zeros). No tangent.
+                 ;; aclone is a COPY, deliberately NOT covered — it carries a
+                 ;; :linear structure tag (tangent = aclone of the tangent).
+                 (and (symbol? op-sym)
+                      (or (contains? shape-read-heads op-sym)
+                          (and (opdesc/alloc-op? op-sym)
+                               (not (string/starts-with? (name op-sym) "aclone")))))
+                 (done tenv [])
+
+                 (some #(and (symbol? %) (contains? tenv %))
                        (if (= '.invk head) (nnext init) (rest init)))
-               (let [[tenv' extra] (fold-call tenv sym init tag)]
-                 (done tenv' extra))
-               (done tenv []))))
+                 (let [[tenv' extra] (fold-call tenv sym init tag)]
+                   (done tenv' extra))
+
+                 :else (done tenv [])))))
 
          :else (done tenv []))))
    {:tenv param-tangents :bindings []}
@@ -256,3 +282,96 @@
        :raster.core/deftm-walked-body [qualified]
        :raster.core/deftm-params fn-params
        :raster.core/deftm-tags out-tags})))
+
+;; ================================================================
+;; HVP — forward-over-reverse (§13 A4, Pearlmutter 1994)
+;; ================================================================
+
+(defn ^clojure.lang.IFn hvp
+  "Exact Hessian-vector product for a SCALAR-valued deftm var via
+  forward-over-reverse: the jvp-fold applied to the GRADIENT PROGRAM.
+
+  Mechanics: reify-pullback (the shared reverse engine) yields the flat
+  forward bindings and the reverse bindings that compute [g_a … g_k]; the
+  gradient program is their concatenation assembled with the unit adjoint
+  (dy__rad = 1.0) — exactly compile-hvp-fn's combined form WITHOUT the
+  v·grad dot. The jvp-fold then runs over THAT program with tangent seeds
+  v on the differentiable params: the tangent of each gradient g_i is
+  (H·v)_i. The pullback's kernels are linear/bilinear in dy (§13 classes
+  b/c — including the backward kernels' own :structure tags), so no
+  second-order rrules are needed.
+
+  (hvp #'f) → (fn [p1 … pN Δp_a … Δp_k] -> [grads hv])
+
+  where Δp_a … Δp_k are tangent (v) slots for the DIFFERENTIABLE params
+  only (⊥ slots — Long dims etc. — have no tangent slot), in param order;
+  `grads` is the gradient vector [∂f/∂p_a …] and `hv` its directional
+  tangent [(H·v)_a …], both aligned with the differentiable params."
+  [f-var]
+  (let [resolved (rev/resolve-deftm-var f-var)
+        m (meta resolved)
+        params (or (:raster.core/deftm-params m)
+                   (throw (ex-info "hvp requires a deftm var" {:var f-var})))
+        walked-body (or (rcore/ensure-walked-body! resolved)
+                        (throw (ex-info "No walked body on var" {:var f-var})))
+        tags (or (:raster.core/deftm-tags m) (vec (repeat (count params) 'double)))
+        all-params (vec (map-indexed
+                         (fn [i p]
+                           (let [tag (nth tags i nil)
+                                 base (if (symbol? p) p (symbol (name p)))]
+                             (if tag
+                               (with-meta base {:raster.type/tag tag})
+                               (with-meta base nil))))
+                         params))
+        diff-params (vec (keep-indexed
+                          (fn [i p]
+                            (when (tangent/differentiable? (nth tags i nil)) p))
+                          all-params))
+        _ (when (empty? diff-params)
+            (throw (ex-info (str "hvp: no differentiable params on " f-var
+                                 " — every param tag is ⊥ (no tangent space)")
+                            {:var f-var :tags tags})))
+        ;; The gradient program: shared prep → reified pullback → flat
+        ;; fwd + (dy = 1.0) + rev bindings, outputs [g_a … g_k].
+        prepared (rev/ad-prepare (first walked-body))
+        {:keys [fwd-bindings result-sym body-sym pullback-form]}
+        (rev/reify-pullback prepared diff-params)
+        [_ rev-bindings grad-vec] pullback-form
+        grad-slots (vec grad-vec)
+        ;; ANF-normalize: the reverse engine's grad-acc chains nest calls in
+        ;; argument position; the fold's tangent lookup is symbol-only, so
+        ;; un-lifted nested calls would silently DROP tangent contributions.
+        grad-bindings (anf/anf-normalize-bindings
+                       (vec (concat fwd-bindings
+                                    [result-sym body-sym]
+                                    ['dy__rad 1.0]
+                                    rev-bindings))
+                       jvp-gensym)
+        ;; Seed tangents: one v per differentiable param, tagged like it.
+        tangent-params (mapv (fn [p] (with-meta (symbol (str "d" (name p) "__jt"))
+                                       (meta p)))
+                             diff-params)
+        {:keys [tenv bindings]} (jvp-fold grad-bindings
+                                          (zipmap diff-params tangent-params))
+        ;; Tangent of each gradient slot = the H·v row. Non-symbol slots
+        ;; (nil / materialized typed-zero exprs for rule-frozen params) have
+        ;; constant gradients → nil tangent (dynamic 0̄).
+        hv-outs (mapv (fn [g]
+                        (when (symbol? g)
+                          (or (get tenv g) (branch-tangent-zero g))))
+                      grad-slots)
+        hvp-form (list 'let* (vec bindings)
+                       (list 'clojure.core/vector grad-slots hv-outs))
+        fn-params (into all-params tangent-params)
+        source-ns (or (:ns m) *ns*)
+        qualified (inf/qualify-body-symbols hvp-form source-ns (set fn-params))
+        runtime-fn (make-runtime-jvp-fn qualified fn-params)]
+    (with-meta (fn [& args] (apply runtime-fn args))
+      {::hvp true
+       :raster.core/deftm true
+       :raster.core/deftm-walked-body [qualified]
+       :raster.core/deftm-params fn-params
+       :raster.core/deftm-tags (into (vec (take (count params)
+                                                (concat tags (repeat nil))))
+                                     (mapv #(:raster.type/tag (meta %))
+                                           tangent-params))})))

--- a/src/raster/ad/reverse.clj
+++ b/src/raster/ad/reverse.clj
@@ -2251,8 +2251,10 @@
   [bindings-vec]
   (set (take-nth 2 bindings-vec)))
 
-(defn- reify-pullback
+(defn ^:no-doc reify-pullback
   "Transform a walked body into a reified pullback suitable for composition.
+  Public (^:no-doc) consumer: raster.ad.jvp/hvp jvp-folds the reified
+  gradient program (forward-over-reverse, §13 A4).
 
   Instead of the standard [primal, (fn* [dy] ...)] output, returns a map:
     {:primal-form     S-expr that computes the primal value
@@ -2385,7 +2387,25 @@
                      (throw (ex-info "compile-hvp-fn requires a deftm var" {:var f-var})))
           walked-body (or (rcore/ensure-walked-body! resolved)
                           (throw (ex-info "No walked body" {:var f-var})))
-          active-params (vec (map #(with-meta (if (symbol? %) % (symbol (name %))) nil) params))
+          tags (or (:raster.core/deftm-tags m)
+                   (vec (repeat (count params) 'double)))
+          ;; KEEP each param's :raster.type/tag (§13 A4 fix): the tangent
+          ;; protocol reads it to type seeds/zeros — stripping it forced
+          ;; untyped zeros downstream.
+          all-params (vec (map-indexed
+                           (fn [i p]
+                             (let [base (if (symbol? p) p (symbol (name p)))
+                                   tag (nth tags i nil)]
+                               (if tag
+                                 (with-meta base {:raster.type/tag tag})
+                                 (with-meta base nil))))
+                           params))
+          ;; Differentiate only w.r.t. params WITH a tangent space (⊥ slots —
+          ;; Long dims etc. — get no v slot and no Hv row). All-double scalar
+          ;; fns are unchanged: every param stays active.
+          active-params (vec (filter #(differentiable-tag?
+                                       (:raster.type/tag (meta %)))
+                                     all-params))
           n (count active-params)
 
         ;; Phase 1: Reify the pullback
@@ -2412,13 +2432,26 @@
         ;; (let* [...fwd... dy__rad 1.0 ...rev...
         ;;        vdg (+ (* v0 d_p1) (* v1 d_p2) ...)]
         ;;   vdg)
-          v-syms (mapv #(symbol (str "v__" (name %))) active-params)
+          v-syms (mapv #(with-meta (symbol (str "v__" (name %))) (meta %))
+                       active-params)
           [_ rev-bindings-vec rev-body] pullback-form
         ;; rev-body is the [d_p1 d_p2 ...] vector
           grad-syms (vec rev-body)
 
-        ;; Build dot product: v^T * grad
-          dot-terms (mapv (fn [vi gi] (list 'raster.numeric/* vi gi))
+        ;; Build v·grad — PER-PARAM contraction (§13 A4 fix): scalar params
+        ;; contract with numeric/*, ARRAY params with par/dot-product; after
+        ;; contraction every term is a scalar, folded with numeric/+.
+          array-param? (fn [p]
+                         (= :array (:kind (tangent/tangent-kind
+                                           (:raster.type/tag (meta p))))))
+          _ (when (some array-param? active-params)
+              ;; par/dot-product must be loadable when the compiled form
+              ;; evals (requiring lazily avoids a reverse→par ns cycle).
+              (require 'raster.par))
+          dot-terms (mapv (fn [vi gi]
+                            (if (array-param? vi)
+                              (list 'raster.par/dot-product vi gi)
+                              (list 'raster.numeric/* vi gi)))
                           v-syms grad-syms)
           dot-expr (if (= 1 (count dot-terms))
                      (first dot-terms)
@@ -2441,11 +2474,14 @@
           hvp-transformed (transform-body combined-form active-params)
 
         ;; Phase 4: Build the compiled function
-        ;; Parameters: [x1 x2 ... v1 v2 ...]
-          all-params (vec (concat active-params v-syms))
-          compiled-fn (eval (list 'fn all-params hvp-transformed))]
+        ;; Parameters: [p1 p2 ... v_a v_b ...] — ALL original params (⊥ dims
+        ;; are still needed to evaluate) + one v per differentiable param.
+          fn-params (vec (concat all-params v-syms))
+          compiled-fn (eval (list 'fn fn-params hvp-transformed))]
 
     ;; Return a function that takes [args-vec v-vec] -> [value Hv-vec]
+    ;; (args-vec: all params; v-vec: one entry per DIFFERENTIABLE param;
+    ;;  Hv rows align with the differentiable params.)
       (fn [args-vec v-vec]
         (let [all-args (vec (concat args-vec v-vec))
               [_vdg_value pullback] (apply compiled-fn all-args)
@@ -2790,16 +2826,16 @@
   [form]
   (let [acc (volatile! #{})]
     (letfn [(go [f]
-              (cond
-                (seq? f)
-                (do (when-let [h (if (= '.invk (first f))
+                (cond
+                  (seq? f)
+                  (do (when-let [h (if (= '.invk (first f))
                                    ;; same recovery order as undevirtualize
-                                   (or (:raster.op/original (meta f)) (:op (meta f)))
-                                   (op/semantic-op f))]
-                      (when (symbol? h) (vswap! acc conj h)))
-                    (doseq [x f] (go x)))
-                (vector? f) (doseq [x f] (go x))
-                (map? f) (doseq [[k v] f] (go k) (go v))))]
+                                     (or (:raster.op/original (meta f)) (:op (meta f)))
+                                     (op/semantic-op f))]
+                        (when (symbol? h) (vswap! acc conj h)))
+                      (doseq [x f] (go x)))
+                  (vector? f) (doseq [x f] (go x))
+                  (map? f) (doseq [[k v] f] (go k) (go v))))]
       (go form))
     @acc))
 

--- a/src/raster/ad/templates.clj
+++ b/src/raster/ad/templates.clj
@@ -1059,7 +1059,14 @@
      JVP is the tangent of the LOSS component (mirrors the reverse rule,
      whose scalar adjoint dy also addresses only the loss slot);
    - forward-noise is JOINTLY linear in {x0, noise} (alpha-t rule-frozen);
-   - maxpool2d, einsum, dgemm! deliberately untagged (A3/kernel gaps)."
+   - A3 residue landed as hand :jvp-fn facets at the op's home ns (rms-norm,
+     layer-norm, group-norm, batch-norm in raster.dl.nn; segment-div in
+     raster.dl.array-ops; scaled-dot-product-attn / causal-… / gqa-causal-mha
+     in raster.dl.attention);
+   - STILL fail-loud (documented A3 skips): solve, array-det,
+     fixed-point-solve, solve-effort (forward-IFT needs a linear solve —
+     separate phase), embed-timestep (needs a small kernel), maxpool2d,
+     einsum, dgemm! (effectful β-accumulate)."
   {;; --- (a) elementwise: diagonal Jacobian, frule = backward(tangent) ---
    'raster.nn/relu                       {:class :elementwise :in #{0}} ;; [x]
    'raster.dl.nn/gelu                    {:class :elementwise :in #{0}} ;; [x n]
@@ -1090,6 +1097,8 @@
    'raster.dl.diffusion/forward-noise    {:class :linear :in #{0 1}}    ;; [x0 noise alpha-t n], alpha-t rule-frozen
    'raster.quant.train/qlinear-q8        {:class :linear :in #{0}}      ;; [x codes scales m in out] — codes frozen
    'clojure.core/aget                    {:class :linear :in #{0}}      ;; [arr i] — one-hot read
+   'raster.arrays/aclone                 {:class :linear :in #{0}}      ;; [arr] — copy (tangent = aclone of tangent)
+   'clojure.core/aclone                  {:class :linear :in #{0}}      ;; [arr] — copy
    ;; --- (c) bilinear: frule = op(Δx,·) ⊕ op(·,ΔW) ---
    'raster.dl.nn/matmul          {:class :bilinear :args [0 1]}                   ;; [A B m k n]
    'raster.dl.nn/linear          {:class :bilinear :args [0 1] :linear-extra #{2}} ;; [x W b batch in-f out-f]
@@ -1109,6 +1118,22 @@
    'raster.dl.loss/cross-entropy-loss   {:class :scalar-loss} ;; [logits target batch classes]
    'raster.nn/cross-entropy             {:class :scalar-loss} ;; [p t], t rule-frozen
    'raster.nn/softmax-cross-entropy     {:class :scalar-loss} ;; [logits t] → [loss s] tuple (see note)
+   ;; --- A4 RoR-closure seeds (#72): backward kernels appearing as CALLS in
+   ;; gradient programs. Forward-over-reverse HVP jvp-folds the reified
+   ;; pullback, so each backward kernel needs its OWN structure tag.
+   ;; Linearity justifications (per kernel):
+   ;;   linear-dx  (dy,W)→dy@W        — bilinear in (dy, W)
+   ;;   linear-dW  (dy,x)→dyᵀ@x       — bilinear in (dy, x)
+   ;;   linear-db  (dy)→colsum(dy)    — linear in dy
+   ;;   relu-backward (dy,x)→dy⊙1[x>0] — linear in dy; the x-derivative is
+   ;;     0 a.e. (relu″ = 0 away from the kink), so dropping an x-tangent is
+   ;;     the exact a.e. rule, same convention as the primal relu kink.
+   ;; (silu/gelu-backward and daxpy-diff! have explicit :jvp-fn below:
+   ;;  their structure is not a single class.) ---
+   'raster.dl.nn/linear-dx  {:class :bilinear :args [0 1]} ;; [dy W batch in-f out-f]
+   'raster.dl.nn/linear-dW  {:class :bilinear :args [0 1]} ;; [dy x batch in-f out-f]
+   'raster.dl.nn/linear-db  {:class :linear :in #{0}}      ;; [dy batch out-f]
+   'raster.nn/relu-backward {:class :linear :in #{0}}      ;; [dy x]
    ;; --- scalar primitives: frule = Σᵢ grads(dy:=Δxᵢ) (mechanical, §2) ---
    '+          {:class :elementwise :in #{0 1}}
    '-          {:class :elementwise :in #{0 1}}
@@ -1161,22 +1186,32 @@
 (doseq [[op st] op-structures]
   (merge-into-template! op {:structure st}))
 
-(defn- jvp-zero-like
+(defn jvp-zero-like
   "Typed zero tangent shaped/dtyped like the PRIMAL arg (tangent protocol):
   used for :in / :linear-extra slots whose tangent is absent in a term where
-  substituting the primal would be WRONG (linear ⇒ f(Δa,b) ≠ df)."
+  substituting the primal would be WRONG (linear ⇒ f(Δa,b) ≠ df).
+  Public: hand-written :jvp-fn facets (§13 A3) use the same convention."
   [primal-arg]
   (list 'raster.arrays/zeros-like primal-arg
         (list 'raster.arrays/alength primal-arg)))
 
-(defn- sum-tangent-contribs
+(defn sum-tangent-contribs
   "Bind the ⊕-sum of tangent contribution exprs; returns [ctx' sym].
   ⊕ is raster.ad.reverse/grad-acc — polymorphic scalar/array, the same
-  accumulator the reverse pass uses."
+  accumulator the reverse pass uses.
+  Public: hand-written :jvp-fn facets (§13 A3) use the same convention."
   [ctx contribs gensym-fn]
   (let [t-sym (gensym-fn "jt")
         expr (reduce (fn [a b] (list 'raster.ad.reverse/grad-acc a b)) contribs)]
     [(update ctx :bindings into [t-sym expr]) t-sym]))
+
+(defn bind-jvp-term
+  "Bind `expr` as one fresh flat tangent-term binding (BindCtx convention,
+  same shape as derive-jvp-fn output); returns [ctx' sym]. Helper for
+  hand-written :jvp-fn facets (§13 A3)."
+  [ctx gensym-fn prefix expr]
+  (let [s (gensym-fn prefix)]
+    [(update ctx :bindings into [s expr]) s]))
 
 (defn- derive-jvp-fn
   "Synthesize the :jvp-fn facet from the op's :structure tag + its EXISTING
@@ -1333,3 +1368,61 @@
                    (not= canonical (symbol (name canonical))))
           (let [bare (symbol (name canonical))]
             (when (get-template bare) (op-jvp-fn bare)))))))
+
+;; ================================================================
+;; §13 A4 — explicit :jvp-fn for backward kernels whose Jacobian structure
+;; is NOT a single class (the rest of the RoR-closure seed, task #72).
+;; ================================================================
+
+;; daxpy-diff!: out = scale·(a−b) — jointly LINEAR in (a,b) and BILINEAR
+;; with scale. Product rule, both terms the op itself:
+;;   d = scale·(da−db) ⊕ dscale·(a−b)
+(merge-into-template!
+ 'raster.linalg.blas/daxpy-diff!
+ {:jvp-fn
+  (fn [ctx [a b scale n] tangent-args _result-sym gensym-fn]
+    (let [da (nth tangent-args 0 nil)
+          db (nth tangent-args 1 nil)
+          dscale (nth tangent-args 2 nil)]
+      (when-not (or da db dscale)
+        (throw (ex-info "daxpy-diff! jvp: no active tangent reached the call"
+                        {:op 'raster.linalg.blas/daxpy-diff!})))
+      (let [[ctx terms]
+            (if (or da db)
+              (let [[ctx' s] (bind-jvp-term ctx gensym-fn "jdaxpy_ab"
+                                            (list 'raster.linalg.blas/daxpy-diff!
+                                                  (or da (jvp-zero-like a))
+                                                  (or db (jvp-zero-like b))
+                                                  scale n))]
+                [ctx' [s]])
+              [ctx []])
+            [ctx terms]
+            (if dscale
+              (let [[ctx' s] (bind-jvp-term ctx gensym-fn "jdaxpy_s"
+                                            (list 'raster.linalg.blas/daxpy-diff!
+                                                  a b dscale n))]
+                [ctx' (conj terms s)])
+              [ctx terms])]
+        (sum-tangent-contribs ctx terms gensym-fn))))})
+
+;; silu/gelu-backward (dy, x, n) → dy⊙act′(x): LINEAR in dy (that term is the
+;; kernel itself on the dy-tangent); the x-slot derivative is dy⊙act″(x)⊙dx —
+;; a GENUINE second-order elementwise rule that does not exist yet (#72).
+;; Fail LOUD if an x-tangent flows in — never silently drop it (unlike relu,
+;; whose act″ is 0 a.e., these have smooth nonzero act″).
+(doseq [op ['raster.dl.nn/silu-backward 'raster.dl.nn/gelu-backward]]
+  (merge-into-template!
+   op
+   {:jvp-fn
+    (let [op op]
+      (fn [ctx [_dy x n] tangent-args _result-sym gensym-fn]
+        (when (nth tangent-args 1 nil)
+          (throw (ex-info (str "jvp: `" op "` received a tangent on its x slot — "
+                               "the second-order elementwise frule (act″) is not "
+                               "implemented yet (§13 A4 / #72 pending). Only the "
+                               "dy slot is linear.")
+                          {:op op})))
+        (let [t-dy (or (nth tangent-args 0 nil)
+                       (throw (ex-info (str "jvp: no active tangent reached " op)
+                                       {:op op})))]
+          (bind-jvp-term ctx gensym-fn "jactb" (list op t-dy x n)))))}))

--- a/src/raster/dl/array_ops.clj
+++ b/src/raster/dl/array_ops.clj
@@ -51,7 +51,6 @@
     (acopy! dy 0 out 0 n)
     out))
 
-
 ;; ================================================================
 ;; array-copy: utility for gradient copying
 ;; ================================================================
@@ -101,7 +100,6 @@
                 (+ (aget out d)
                    (aget dy idx))))))
     out))
-
 
 ;; ================================================================
 ;; GENERIC PRIMITIVES
@@ -167,29 +165,29 @@
   "Reshape [seq-len, n-heads*head-dim] (row-major) → [n-heads, seq-len, head-dim]
   so each head slab is contiguous: out[h*seq*hd + s*hd + d] = x[s*(nh*hd) + h*hd + d]."
   (All [T] [x :- (Array T) seq-len :- Long n-heads :- Long head-dim :- Long] :- (Array T)
-    (let [d-model (* n-heads head-dim)
-          out (alloc-like x (* seq-len d-model))]
-      (dotimes [h n-heads]
-        (dotimes [s seq-len]
-          (let [src (+ (* s d-model) (* h head-dim))
-                dst (+ (* h seq-len head-dim) (* s head-dim))]
-            (dotimes [d head-dim]
-              (aset out (+ dst d) (aget x (+ src d)))))))
-      out)))
+       (let [d-model (* n-heads head-dim)
+             out (alloc-like x (* seq-len d-model))]
+         (dotimes [h n-heads]
+           (dotimes [s seq-len]
+             (let [src (+ (* s d-model) (* h head-dim))
+                   dst (+ (* h seq-len head-dim) (* s head-dim))]
+               (dotimes [d head-dim]
+                 (aset out (+ dst d) (aget x (+ src d)))))))
+         out)))
 
 (deftm unpack-heads
   "Dual of pack-heads: [n-heads, seq-len, head-dim] → [seq-len, n-heads*head-dim]:
   out[s*(nh*hd) + h*hd + d] = x[h*seq*hd + s*hd + d]."
   (All [T] [x :- (Array T) seq-len :- Long n-heads :- Long head-dim :- Long] :- (Array T)
-    (let [d-model (* n-heads head-dim)
-          out (alloc-like x (* seq-len d-model))]
-      (dotimes [h n-heads]
-        (dotimes [s seq-len]
-          (let [src (+ (* h seq-len head-dim) (* s head-dim))
-                dst (+ (* s d-model) (* h head-dim))]
-            (dotimes [d head-dim]
-              (aset out (+ dst d) (aget x (+ src d)))))))
-      out)))
+       (let [d-model (* n-heads head-dim)
+             out (alloc-like x (* seq-len d-model))]
+         (dotimes [h n-heads]
+           (dotimes [s seq-len]
+             (let [src (+ (* h seq-len head-dim) (* s head-dim))
+                   dst (+ (* s d-model) (* h head-dim))]
+               (dotimes [d head-dim]
+                 (aset out (+ dst d) (aget x (+ src d)))))))
+         out)))
 
 ;; pack ↔ unpack are duals (both are non-diff on the Long shape params). No
 ;; grads-fn exists for them, so the runtime pullback (each is the other's
@@ -220,7 +218,6 @@
                                          [d-src (list 'raster.dl.array-ops/scatter-strided-2d
                                                       adjoint-sym rows row-stride col-offset n-cols)])
                                  [d-src nil nil nil nil]]))})
-
 
 (tmpl/merge-into-template! 'raster.dl.array-ops/scatter-strided-2d
                            {:params '[packed rows row-stride col-offset n-cols]
@@ -278,7 +275,6 @@
     out))
 
 ;; scatter-add backward = gather, gather backward = scatter-add
-
 
 ;; ================================================================
 ;; indexed-dot: batched indexed dot product (multi-head aware)
@@ -359,7 +355,6 @@
                          (* coeff (aget A a-idx))))))))))
     out))
 
-
 ;; ================================================================
 ;; scatter-mul-add: weighted scatter (multi-head aware)
 ;; out[dst[e]*total-dim+s*slice-dim+d] += coeffs[e*n-slices+s]
@@ -438,7 +433,6 @@
                          (* w (aget dy dst-idx))))))))))
     out))
 
-
 ;; ================================================================
 ;; scale-clamp-exp: out[i] = exp(clamp(x[i]*scale, -bound, bound))
 ;; Separates attention nonlinearity from dot product.
@@ -468,7 +462,6 @@
                     (aget result i))
                  (* scale clamp-mask)))))
     out))
-
 
 ;; ================================================================
 ;; reduce-axis: out[d] = Σ_b src[b*n-cols+d]
@@ -500,7 +493,6 @@
         (aset out (+ (* b (int n-cols)) d)
               (aget dy d))))
     out))
-
 
 ;; ================================================================
 ;; segment-div: out[n*d+h_off+j] = wV[n*d+h_off+j] / (Z[n*nh+h] + eps)
@@ -543,6 +535,28 @@
                     (/ (aget dy idx) z)))))))
     dwV))
 
+(deftm segment-div-jvp-dZ
+  "Forward tangent (JVP, §13 A3) of segment-div in the Z direction — the
+  quotient rule's second term: out = wV/(Z+eps) so
+    d_i = −out_i·dZ_seg/(Z_seg+eps) = −wV_i·dZ_seg/(Z_seg+eps)².
+  (The wV-direction term dwV/(Z+eps) is segment-div itself — linear in wV;
+  see the :jvp-fn registration below.) Mirrors segment-div's loop structure."
+  [wV :- (Array double) dZ :- (Array double) Z :- (Array double)
+   n-nodes :- Long emb-dim :- Long n-heads :- Long eps :- Double]
+  :- (Array double)
+  (let [dk (quot emb-dim n-heads)
+        out (double-array (* n-nodes emb-dim))]
+    (dotimes [node n-nodes]
+      (dotimes [head n-heads]
+        (let [z-idx (+ (* node (int n-heads)) head)
+              z (+ (aget Z z-idx) eps)
+              factor (- (/ (aget dZ z-idx) (* z z)))
+              off (+ (* node (int emb-dim)) (* head (int dk)))]
+          (dotimes [d dk]
+            (let [idx (+ off d)]
+              (aset out idx (* (aget wV idx) factor)))))))
+    out))
+
 (deftm segment-div-dZ
   "Backward for Z: dZ[n*nh+h] = -sum_d(dy[..] * wV[..] / z²)"
   [dy :- (Array double) wV :- (Array double) Z :- (Array double)
@@ -564,7 +578,6 @@
                                  (aget wV idx)))))
               (aset dZ z-idx (- (/ acc z2))))))))
     dZ))
-
 
 ;; ================================================================
 ;; flat-embed-op: out[v*d+j] = values[v]*We[j] + be[j]
@@ -667,7 +680,6 @@
                      (aget dy (+ (* v (int emb-dim)) d))))))))
     out))
 
-
 ;; ================================================================
 ;; dot-rows: out[v] = h[v,:] · W + bias[0]
 ;; ================================================================
@@ -726,7 +738,6 @@
         (aset out 0 acc)))
     out))
 
-
 ;; ================================================================
 ;; masked-mse-loss: loss = mean((pred[i]-target[i])² for i where states[i]!=1)
 ;; ================================================================
@@ -767,7 +778,6 @@
                   (* scale (- (aget pred i)
                               (aget target i))))))))
     out))
-
 
 ;; ================================================================
 ;; Flat AD templates
@@ -898,6 +908,35 @@
                                           dZ (list 'raster.dl.array-ops/segment-div-dZ
                                                    adjoint-sym wV Z n-nodes emb-dim n-heads eps)])
                                  [dwV dZ nil nil nil nil]]))})
+
+;; segment-div forward tangent (JVP, §13 A3) — quotient rule:
+;;   d = dwV/(Z+eps) ⊕ (−out⊙dZ/(Z+eps))
+;; The wV term is segment-div ITSELF on the tangent (linear in wV); the Z
+;; term is the dedicated segment-div-jvp-dZ kernel above.
+(tmpl/merge-into-template!
+ 'raster.dl.array-ops/segment-div
+ {:jvp-fn
+  (fn [ctx [wV Z n-nodes emb-dim n-heads eps] tangent-args _result-sym gensym-fn]
+    (let [dwV (nth tangent-args 0 nil)
+          dZ (nth tangent-args 1 nil)]
+      (when-not (or dwV dZ)
+        (throw (ex-info "segment-div jvp: no active tangent reached the call"
+                        {:op 'raster.dl.array-ops/segment-div})))
+      (let [[ctx terms]
+            (if dwV
+              (let [[ctx' s] (tmpl/bind-jvp-term ctx gensym-fn "jsdiv_wV"
+                                                 (list 'raster.dl.array-ops/segment-div
+                                                       dwV Z n-nodes emb-dim n-heads eps))]
+                [ctx' [s]])
+              [ctx []])
+            [ctx terms]
+            (if dZ
+              (let [[ctx' s] (tmpl/bind-jvp-term ctx gensym-fn "jsdiv_Z"
+                                                 (list 'raster.dl.array-ops/segment-div-jvp-dZ
+                                                       wV dZ Z n-nodes emb-dim n-heads eps))]
+                [ctx' (conj terms s)])
+              [ctx terms])]
+        (tmpl/sum-tangent-contribs ctx terms gensym-fn))))})
 
 (tmpl/merge-into-template! 'raster.dl.array-ops/flat-embed-op
                            {:params '[values space-emb spaces state-emb states pos-emb

--- a/src/raster/dl/attention.clj
+++ b/src/raster/dl/attention.clj
@@ -94,21 +94,21 @@
 ;; No trainable params (theta/positions are fixed) — only x gets a gradient.
 (deftm rope-backward-dx (All [T] [dy :- (Array T) seq-len :- Long heads :- Long
                                   head-dim :- Long theta :- Double] :- (Array T)
-                            (let [dx (alloc-like dy (* seq-len (* heads head-dim)))
-                                  half (quot head-dim 2)
-                                  ln-theta (m/log theta)]
-                              (dotimes [p seq-len]
-                                (dotimes [h heads]
-                                  (let [base (+ (* p (* heads head-dim)) (* h (int head-dim)))]
-                                    (dotimes [i half]
-                                      (let [freq (m/exp (* (/ (* -2.0 (double i)) (double head-dim)) ln-theta))
-                                            ang (* (double p) freq)
-                                            c (m/cos ang) s (m/sin ang)
-                                            d0 (aget dy (+ base i))
-                                            d1 (aget dy (+ (+ base i) half))]
-                                        (aset dx (+ base i) (+ (* d0 c) (* d1 s)))
-                                        (aset dx (+ (+ base i) half) (- (* d1 c) (* d0 s))))))))
-                              dx)))
+                             (let [dx (alloc-like dy (* seq-len (* heads head-dim)))
+                                   half (quot head-dim 2)
+                                   ln-theta (m/log theta)]
+                               (dotimes [p seq-len]
+                                 (dotimes [h heads]
+                                   (let [base (+ (* p (* heads head-dim)) (* h (int head-dim)))]
+                                     (dotimes [i half]
+                                       (let [freq (m/exp (* (/ (* -2.0 (double i)) (double head-dim)) ln-theta))
+                                             ang (* (double p) freq)
+                                             c (m/cos ang) s (m/sin ang)
+                                             d0 (aget dy (+ base i))
+                                             d1 (aget dy (+ (+ base i) half))]
+                                         (aset dx (+ base i) (+ (* d0 c) (* d1 s)))
+                                         (aset dx (+ (+ base i) half) (- (* d1 c) (* d0 s))))))))
+                               dx)))
 
 (tmpl/merge-into-template! 'raster.dl.attention/rope
                            {:params '[x seq-len heads head-dim theta] :result nil :adjoint 'dy
@@ -410,59 +410,59 @@
                                        out :- (Array T) sc :- (Array T)
                                        clenbuf :- (Array long) n-q :- Long group :- Long
                                        n-kv :- Long head-dim :- Long maxpos :- Long scale :- Double] :- Void
- (do
+                                      (do
   ;; phase 1: sc[hq,j] = scale * dot(q[hq,:], k[j,hkv,:]) — one work-item per (hq, j)
-  (raster.par/map-void! ij (clojure.core/* n-q maxpos)
-    (let [cache-len (aget clenbuf 0)
-          hq (quot ij maxpos)
-          j (rem ij maxpos)]
-      (when (< j cache-len)
-        (let [hkv (quot hq group)
-              qb (clojure.core/* hq head-dim)
-              kb (clojure.core/+ (clojure.core/* j (clojure.core/* n-kv head-dim))
-                                 (clojure.core/* hkv head-dim))
-              dot (loop [d 0 acc 0.0]
-                    (if (< d head-dim)
-                      (recur (inc d)
-                             (+ acc (* (aget q (clojure.core/+ qb d))
-                                       (aget k (clojure.core/+ kb d)))))
-                      acc))]
-          (aset sc (clojure.core/+ (clojure.core/* hq maxpos) j) (* dot scale))))))
+                                        (raster.par/map-void! ij (clojure.core/* n-q maxpos)
+                                                              (let [cache-len (aget clenbuf 0)
+                                                                    hq (quot ij maxpos)
+                                                                    j (rem ij maxpos)]
+                                                                (when (< j cache-len)
+                                                                  (let [hkv (quot hq group)
+                                                                        qb (clojure.core/* hq head-dim)
+                                                                        kb (clojure.core/+ (clojure.core/* j (clojure.core/* n-kv head-dim))
+                                                                                           (clojure.core/* hkv head-dim))
+                                                                        dot (loop [d 0 acc 0.0]
+                                                                              (if (< d head-dim)
+                                                                                (recur (inc d)
+                                                                                       (+ acc (* (aget q (clojure.core/+ qb d))
+                                                                                                 (aget k (clojure.core/+ kb d)))))
+                                                                                acc))]
+                                                                    (aset sc (clojure.core/+ (clojure.core/* hq maxpos) j) (* dot scale))))))
   ;; phase 2: softmax per head (serial over cache-len — tiny); sc ← e * (1/sum)
-  (raster.par/map-void! hq n-q
-    (let [cache-len (aget clenbuf 0)
-          scb (clojure.core/* hq maxpos)
-          neg-inf -1.0e38
-          mx (loop [j 0 mm neg-inf]
-               (if (< j cache-len)
-                 (recur (inc j) (n/max mm (aget sc (clojure.core/+ scb j)))) mm))
-          sum (loop [j 0 s 0.0]
-                (if (< j cache-len)
-                  (let [e (m/exp (- (aget sc (clojure.core/+ scb j)) mx))]
-                    (aset sc (clojure.core/+ scb j) e)
-                    (recur (inc j) (+ s e)))
-                  s))
-          inv (/ 1.0 sum)]
-      (loop [j 0]
-        (if (< j cache-len)
-          (do (aset sc (clojure.core/+ scb j) (* (aget sc (clojure.core/+ scb j)) inv))
-              (recur (inc j)))
-          nil))))
+                                        (raster.par/map-void! hq n-q
+                                                              (let [cache-len (aget clenbuf 0)
+                                                                    scb (clojure.core/* hq maxpos)
+                                                                    neg-inf -1.0e38
+                                                                    mx (loop [j 0 mm neg-inf]
+                                                                         (if (< j cache-len)
+                                                                           (recur (inc j) (n/max mm (aget sc (clojure.core/+ scb j)))) mm))
+                                                                    sum (loop [j 0 s 0.0]
+                                                                          (if (< j cache-len)
+                                                                            (let [e (m/exp (- (aget sc (clojure.core/+ scb j)) mx))]
+                                                                              (aset sc (clojure.core/+ scb j) e)
+                                                                              (recur (inc j) (+ s e)))
+                                                                            s))
+                                                                    inv (/ 1.0 sum)]
+                                                                (loop [j 0]
+                                                                  (if (< j cache-len)
+                                                                    (do (aset sc (clojure.core/+ scb j) (* (aget sc (clojure.core/+ scb j)) inv))
+                                                                        (recur (inc j)))
+                                                                    nil))))
   ;; phase 3: out[hq,d] = Σ_j sc[hq,j] * v[j,hkv,d] — one work-item per (hq, d)
-  (raster.par/map-void! hd (clojure.core/* n-q head-dim)
-    (let [cache-len (aget clenbuf 0)
-          hq (quot hd head-dim)
-          d (rem hd head-dim)
-          scb (clojure.core/* hq maxpos)
-          kvstride (clojure.core/* n-kv head-dim)
-          hkvb (clojure.core/+ (clojure.core/* (quot hq group) head-dim) d)]
-      (aset out (clojure.core/+ (clojure.core/* hq head-dim) d)
-            (loop [j 0 a 0.0]
-              (if (< j cache-len)
-                (recur (inc j)
-                       (+ a (* (aget sc (clojure.core/+ scb j))
-                               (aget v (clojure.core/+ (clojure.core/* j kvstride) hkvb)))))
-                a))))))))
+                                        (raster.par/map-void! hd (clojure.core/* n-q head-dim)
+                                                              (let [cache-len (aget clenbuf 0)
+                                                                    hq (quot hd head-dim)
+                                                                    d (rem hd head-dim)
+                                                                    scb (clojure.core/* hq maxpos)
+                                                                    kvstride (clojure.core/* n-kv head-dim)
+                                                                    hkvb (clojure.core/+ (clojure.core/* (quot hq group) head-dim) d)]
+                                                                (aset out (clojure.core/+ (clojure.core/* hq head-dim) d)
+                                                                      (loop [j 0 a 0.0]
+                                                                        (if (< j cache-len)
+                                                                          (recur (inc j)
+                                                                                 (+ a (* (aget sc (clojure.core/+ scb j))
+                                                                                         (aget v (clojure.core/+ (clojure.core/* j kvstride) hkvb)))))
+                                                                          a))))))))
 
 (deftm causal-scaled-dot-product-attn (All [T]
                                            [Q :- (Array T) K :- (Array T) V :- (Array T)
@@ -612,6 +612,88 @@
                                           dK (list 'clojure.core/aget bundle 1)
                                           dV (list 'clojure.core/aget bundle 2)])
                                  [dQ dK dV nil nil nil]]))})
+
+;; Forward tangent (JVP, §13 A3) of causal SDPA — the standard form, single
+;; output array (mirrors the backward's recompute-then-gemm structure):
+;;   W  = causal-softmax(s·Q·Kᵀ)              (recomputed)
+;;   dZ = s·(dQ·Kᵀ + Q·dKᵀ)
+;;   dW = W ⊙ (dZ − rowsum(W⊙dZ))             (softmax JVP per query row;
+;;                                             masked j>i have W=0 ⇒ dW=0)
+;;   dO = dW·V + W·dV
+(deftm causal-scaled-dot-product-attn-jvp
+  [dQ :- (Array double) dK :- (Array double) dV :- (Array double)
+   Q :- (Array double) K :- (Array double) V :- (Array double)
+   seq-len :- Long dk :- Long dv :- Long]
+  :- (Array double)
+  (let [scale (/ 1.0 (n/sqrt (double dk)))
+        neg-inf-c Double/NEGATIVE_INFINITY
+        ;; Recompute causal softmax weights (same as the backward)
+        weights (double-array (* seq-len seq-len))
+        _ (blas/dgemm-nt! Q K weights seq-len dk seq-len scale 0.0)
+        _ (dotimes [i seq-len]
+            (let [offset (* i (int seq-len))]
+              (dotimes [j seq-len]
+                (when (> j i)
+                  (aset weights (+ offset j) neg-inf-c)))))
+        _ (dotimes [i seq-len]
+            (let [offset (* i (int seq-len))
+                  max-s (loop [j 0 m neg-inf-c]
+                          (if (< j seq-len)
+                            (recur (inc j) (n/max m (aget weights (+ offset j))))
+                            m))
+                  sum-exp (loop [j 0 s 0.0]
+                            (if (< j seq-len)
+                              (let [s-ij (aget weights (+ offset j))
+                                    e (if (== s-ij neg-inf-c)
+                                        0.0
+                                        (m/exp (- s-ij max-s)))]
+                                (aset weights (+ offset j) e)
+                                (recur (inc j) (+ s e)))
+                              s))
+                  inv-sum (if (== sum-exp 0.0) 0.0 (/ 1.0 sum-exp))]
+              (dotimes [j seq-len]
+                (aset weights (+ offset j) (* (aget weights (+ offset j)) inv-sum)))))
+        ;; dZ = scale·(dQ·Kᵀ + Q·dKᵀ)
+        dZ (double-array (* seq-len seq-len))
+        _ (blas/dgemm-nt! dQ K dZ seq-len dk seq-len scale 0.0)
+        _ (blas/dgemm-nt! Q dK dZ seq-len dk seq-len scale 1.0)
+        ;; softmax JVP per row: dW = W⊙(dZ − ⟨W,dZ⟩_row)
+        dW (double-array (* seq-len seq-len))
+        _ (dotimes [i seq-len]
+            (let [offset (* i (int seq-len))
+                  wdz (loop [j 0 s 0.0]
+                        (if (< j seq-len)
+                          (recur (inc j) (+ s (* (aget weights (+ offset j))
+                                                 (aget dZ (+ offset j)))))
+                          s))]
+              (dotimes [j seq-len]
+                (aset dW (+ offset j)
+                      (* (aget weights (+ offset j))
+                         (- (aget dZ (+ offset j)) wdz))))))
+        ;; dO = dW·V + W·dV
+        dO (double-array (* seq-len dv))
+        _ (blas/dgemm! dW V dO seq-len seq-len dv 1.0 0.0)
+        _ (blas/dgemm! weights dV dO seq-len seq-len dv 1.0 1.0)]
+    dO))
+
+;; causal SDPA :jvp-fn — one kernel call; absent tangents get typed zeros
+;; (the pushforward is jointly linear in (dQ,dK,dV), so zeros are exact).
+(tmpl/merge-into-template!
+ 'raster.dl.attention/causal-scaled-dot-product-attn
+ {:jvp-fn
+  (fn [ctx [Q K V seq-len dk dv] tangent-args _result-sym gensym-fn]
+    (let [dQ (nth tangent-args 0 nil)
+          dK (nth tangent-args 1 nil)
+          dV (nth tangent-args 2 nil)]
+      (when-not (or dQ dK dV)
+        (throw (ex-info "causal-scaled-dot-product-attn jvp: no active tangent reached the call"
+                        {:op 'raster.dl.attention/causal-scaled-dot-product-attn})))
+      (tmpl/bind-jvp-term ctx gensym-fn "jcspa"
+                          (list 'raster.dl.attention/causal-scaled-dot-product-attn-jvp
+                                (or dQ (tmpl/jvp-zero-like Q))
+                                (or dK (tmpl/jvp-zero-like K))
+                                (or dV (tmpl/jvp-zero-like V))
+                                Q K V seq-len dk dv))))})
 
 ;; ================================================================
 ;; Causal single-head attention (AD-friendly: no head-split shuffles).
@@ -769,6 +851,57 @@
                                           dV (list 'clojure.core/aget b 2)])
                                  [dQ dK dV nil nil nil nil]]))})
 
+;; Forward tangent (JVP, §13 A3) of GQA/MQA causal attention — mirrors
+;; gqa-causal-mha-backward's head iteration: per query head hq, slice the
+;; (Q,K,V) and (dQ,dK,dV) head slabs, run the single-head causal-SDPA JVP,
+;; and WRITE the head tangent into hq's output slab (each hq owns its slab —
+;; no accumulation on the output side; the kv-head fan-IN that forces dK/dV
+;; accumulation in the backward has no forward counterpart).
+(deftm gqa-causal-mha-jvp
+  [dQ :- (Array double) dK :- (Array double) dV :- (Array double)
+   Q :- (Array double) K :- (Array double) V :- (Array double)
+   seq-len :- Long n-q :- Long n-kv :- Long head-dim :- Long]
+  :- (Array double)
+  (let [group (quot n-q n-kv)
+        qstride (* n-q head-dim)
+        kvstride (* n-kv head-dim)
+        dOut (double-array (* seq-len qstride))]
+    (dotimes [hq n-q]
+      (let [hkv (quot hq (int group))
+            Qh (ops/slice-strided-2d Q seq-len qstride (* hq (int head-dim)) head-dim)
+            Kh (ops/slice-strided-2d K seq-len kvstride (* hkv (int head-dim)) head-dim)
+            Vh (ops/slice-strided-2d V seq-len kvstride (* hkv (int head-dim)) head-dim)
+            dQh (ops/slice-strided-2d dQ seq-len qstride (* hq (int head-dim)) head-dim)
+            dKh (ops/slice-strided-2d dK seq-len kvstride (* hkv (int head-dim)) head-dim)
+            dVh (ops/slice-strided-2d dV seq-len kvstride (* hkv (int head-dim)) head-dim)
+            dOh (causal-scaled-dot-product-attn-jvp dQh dKh dVh Qh Kh Vh
+                                                    seq-len head-dim head-dim)]
+        (dotimes [r seq-len]
+          (let [qoff (+ (* r (int qstride)) (* hq (int head-dim)))
+                hoff (* r (int head-dim))]
+            (dotimes [c head-dim]
+              (aset dOut (+ qoff c) (aget dOh (+ hoff c))))))))
+    dOut))
+
+;; gqa-causal-mha :jvp-fn — one kernel call; absent tangents get typed zeros
+;; (jointly linear pushforward in (dQ,dK,dV)).
+(tmpl/merge-into-template!
+ 'raster.dl.attention/gqa-causal-mha
+ {:jvp-fn
+  (fn [ctx [Q K V seq-len n-q n-kv head-dim] tangent-args _result-sym gensym-fn]
+    (let [dQ (nth tangent-args 0 nil)
+          dK (nth tangent-args 1 nil)
+          dV (nth tangent-args 2 nil)]
+      (when-not (or dQ dK dV)
+        (throw (ex-info "gqa-causal-mha jvp: no active tangent reached the call"
+                        {:op 'raster.dl.attention/gqa-causal-mha})))
+      (tmpl/bind-jvp-term ctx gensym-fn "jgqa"
+                          (list 'raster.dl.attention/gqa-causal-mha-jvp
+                                (or dQ (tmpl/jvp-zero-like Q))
+                                (or dK (tmpl/jvp-zero-like K))
+                                (or dV (tmpl/jvp-zero-like V))
+                                Q K V seq-len n-q n-kv head-dim))))})
+
 ;; ================================================================
 ;; Multi-head self-attention (bidirectional, for BERT-style models)
 ;; x:[seq_len, d_model], Wq/Wk/Wv:[d_model, d_model], Wo:[d_model, d_model]
@@ -783,52 +916,52 @@
   [-88,0]. (SVML VectorOperators/EXP is not intrinsified on this JVM, so Math/exp
   stays scalar; this does not depend on it.)"
   (All [T] [x :- T] :- T
-    (let [t (n/* x 9.765625E-4)                    ; x / 1024
-          p (n/+ 0.008333334 (n/* t 0.0013888889)) ; 1/120 + t/720
-          p (n/+ 0.041666668 (n/* t p))            ; 1/24  + t p
-          p (n/+ 0.16666667 (n/* t p))             ; 1/6
-          p (n/+ 0.5 (n/* t p))                    ; 1/2
-          p (n/+ 1.0 (n/* t p))                    ; 1
-          p (n/+ 1.0 (n/* t p))                    ; e^t (Taylor deg 6)
-          p (n/* p p) p (n/* p p) p (n/* p p) p (n/* p p) p (n/* p p)
-          p (n/* p p) p (n/* p p) p (n/* p p) p (n/* p p) p (n/* p p)]
-      p)))
+       (let [t (n/* x 9.765625E-4)                    ; x / 1024
+             p (n/+ 0.008333334 (n/* t 0.0013888889)) ; 1/120 + t/720
+             p (n/+ 0.041666668 (n/* t p))            ; 1/24  + t p
+             p (n/+ 0.16666667 (n/* t p))             ; 1/6
+             p (n/+ 0.5 (n/* t p))                    ; 1/2
+             p (n/+ 1.0 (n/* t p))                    ; 1
+             p (n/+ 1.0 (n/* t p))                    ; e^t (Taylor deg 6)
+             p (n/* p p) p (n/* p p) p (n/* p p) p (n/* p p) p (n/* p p)
+             p (n/* p p) p (n/* p p) p (n/* p p) p (n/* p p) p (n/* p p)]
+         p)))
 
 (deftm softmax-rows!
   "In-place row-wise softmax of a [rows, cols] row-major array — one fused pass
   per row (max → exp → sum → normalize). Scale is assumed already folded into the
   values (via the QK^T GEMM alpha). Parametric; float-pure."
   (All [T] [x :- (Array T) rows :- Long cols :- Long] :- (Array T)
-    (let [n (* rows (int cols))
+       (let [n (* rows (int cols))
           ;; per-row max → broadcast to per-element (cheap, memory-bound scalar)
-          maxes (alloc-like x n)
-          _ (dotimes [r rows]
-              (let [off (* r (int cols))
-                    mx (loop [j 0 m (n/neg-inf-val (aget x off))]
-                         (if (< j cols) (recur (inc j) (n/max m (aget x (+ off j)))) m))]
-                (dotimes [j cols] (aset maxes (+ off j) mx))))
+             maxes (alloc-like x n)
+             _ (dotimes [r rows]
+                 (let [off (* r (int cols))
+                       mx (loop [j 0 m (n/neg-inf-val (aget x off))]
+                            (if (< j cols) (recur (inc j) (n/max m (aget x (+ off j)))) m))]
+                   (dotimes [j cols] (aset maxes (+ off j) mx))))
           ;; VECTORIZED exp = exp(x - max): a flat `broadcast` (recognized par
           ;; form → SIMD-vectorized SegMap under compile-aot) with the fast-exp
           ;; polynomial INLINED (e^(v/1024)^1024, deg-6 Taylor + 10 squarings;
           ;; only +/* → a pure FMA/mul lane chain). A raw nested dotimes here
           ;; stays scalar; a deftm call stays opaque; SVML EXP is not intrinsified.
-          e (broadcast [x maxes]
-              (let [v (- x maxes) t (* v 9.765625E-4)
-                    a (+ 0.008333334 (* t 0.0013888889)) b (+ 0.041666668 (* t a))
-                    c (+ 0.16666667 (* t b)) d (+ 0.5 (* t c))
-                    ee (+ 1.0 (* t d)) f (+ 1.0 (* t ee))
-                    p1 (* f f) p2 (* p1 p1) p3 (* p2 p2) p4 (* p3 p3) p5 (* p4 p4)
-                    p6 (* p5 p5) p7 (* p6 p6) p8 (* p7 p7) p9 (* p8 p8) p10 (* p9 p9)]
-                p10))
+             e (broadcast [x maxes]
+                          (let [v (- x maxes) t (* v 9.765625E-4)
+                                a (+ 0.008333334 (* t 0.0013888889)) b (+ 0.041666668 (* t a))
+                                c (+ 0.16666667 (* t b)) d (+ 0.5 (* t c))
+                                ee (+ 1.0 (* t d)) f (+ 1.0 (* t ee))
+                                p1 (* f f) p2 (* p1 p1) p3 (* p2 p2) p4 (* p3 p3) p5 (* p4 p4)
+                                p6 (* p5 p5) p7 (* p6 p6) p8 (* p7 p7) p9 (* p8 p8) p10 (* p9 p9)]
+                            p10))
           ;; per-row sum of e, normalize back into x (cheap, memory-bound scalar)
-          _ (dotimes [r rows]
-              (let [off (* r (int cols))
-                    s (loop [j 0 acc 0.0]
-                        (if (< j cols) (recur (inc j) (+ acc (aget e (+ off j)))) acc))
-                    inv (/ 1.0 s)]
-                (dotimes [j cols]
-                  (aset x (+ off j) (* (aget e (+ off j)) inv)))))]
-      x)))
+             _ (dotimes [r rows]
+                 (let [off (* r (int cols))
+                       s (loop [j 0 acc 0.0]
+                           (if (< j cols) (recur (inc j) (+ acc (aget e (+ off j)))) acc))
+                       inv (/ 1.0 s)]
+                   (dotimes [j cols]
+                     (aset x (+ off j) (* (aget e (+ off j)) inv)))))]
+         x)))
 
 ;; Batched multi-head attention: composed from the layout/GEMM/softmax
 ;; combinators (pack-heads → batched QK^T with scale folded → fused row-softmax →
@@ -845,27 +978,27 @@
                                   Wo :- (Array T) bo :- (Array T)
                                   seq-len :- Long d-model :- Long n-heads :- Long]
                                  :- (Array T)
-  (let [dk (quot d-model n-heads)
-        scale (n/oftype x (clojure.core// 1.0 (Math/sqrt (double dk))))
+                                 (let [dk (quot d-model n-heads)
+                                       scale (n/oftype x (clojure.core// 1.0 (Math/sqrt (double dk))))
         ;; Q,K,V projections: [seq_len, d_model]
-        Q (nn/linear x Wq bq seq-len d-model d-model)
-        K (nn/linear x Wk bk seq-len d-model d-model)
-        V (nn/linear x Wv bv seq-len d-model d-model)
+                                       Q (nn/linear x Wq bq seq-len d-model d-model)
+                                       K (nn/linear x Wk bk seq-len d-model d-model)
+                                       V (nn/linear x Wv bv seq-len d-model d-model)
         ;; pack to head-major contiguous [n_heads, seq_len, dk]
-        Qh (ops/pack-heads Q seq-len n-heads dk)
-        Kh (ops/pack-heads K seq-len n-heads dk)
-        Vh (ops/pack-heads V seq-len n-heads dk)
+                                       Qh (ops/pack-heads Q seq-len n-heads dk)
+                                       Kh (ops/pack-heads K seq-len n-heads dk)
+                                       Vh (ops/pack-heads V seq-len n-heads dk)
         ;; scores[n_heads, seq, seq] = scale * Qh @ Kh^T  (one batched GEMM)
-        scores (alloc-like x (* n-heads seq-len seq-len))
-        _ (blas/batched-gemm-nt! Qh Kh scores n-heads seq-len dk seq-len scale)
+                                       scores (alloc-like x (* n-heads seq-len seq-len))
+                                       _ (blas/batched-gemm-nt! Qh Kh scores n-heads seq-len dk seq-len scale)
         ;; fused row-softmax over the key dimension
-        _ (softmax-rows! scores (* n-heads seq-len) seq-len)
+                                       _ (softmax-rows! scores (* n-heads seq-len) seq-len)
         ;; ctx[n_heads, seq, dk] = scores @ Vh  (one batched GEMM)
-        ctxh (alloc-like x (* n-heads seq-len dk))
-        _ (blas/batched-gemm-nn! scores Vh ctxh n-heads seq-len seq-len dk (n/oftype x 1.0))
+                                       ctxh (alloc-like x (* n-heads seq-len dk))
+                                       _ (blas/batched-gemm-nn! scores Vh ctxh n-heads seq-len seq-len dk (n/oftype x 1.0))
         ;; unpack to [seq_len, d_model] and project out
-        ctx (ops/unpack-heads ctxh seq-len n-heads dk)]
-    (nn/linear ctx Wo bo seq-len d-model d-model))))
+                                       ctx (ops/unpack-heads ctxh seq-len n-heads dk)]
+                                   (nn/linear ctx Wo bo seq-len d-model d-model))))
 
 ;; ================================================================
 ;; KV-cache: incremental attention for autoregressive generation
@@ -1170,6 +1303,76 @@
                                                     dV (list 'clojure.core/aget grads-arr 2)])
                                            [dQ dK dV nil nil nil nil]]))})
 
+;; Forward tangent (JVP, §13 A3) of (bidirectional) SDPA — the standard form,
+;; single output array (mirrors the backward's recompute-then-gemm structure):
+;;   W  = softmax(s·Q·Kᵀ);  dZ = s·(dQ·Kᵀ + Q·dKᵀ)
+;;   dW = W ⊙ (dZ − rowsum(W⊙dZ));  dO = dW·V + W·dV
+(deftm scaled-dot-product-attn-jvp
+  [dQ :- (Array double) dK :- (Array double) dV :- (Array double)
+   Q :- (Array double) K :- (Array double) V :- (Array double)
+   seq-q :- Long seq-k :- Long dk :- Long dv :- Long]
+  :- (Array double)
+  (let [scale (/ 1.0 (n/sqrt (double dk)))
+        ;; Recompute softmax weights (same as the backward)
+        weights (double-array (* seq-q seq-k))
+        _ (blas/dgemm-nt! Q K weights seq-q dk seq-k scale 0.0)
+        _ (dotimes [i seq-q]
+            (let [offset (* i (int seq-k))
+                  max-s (loop [j 0 m n/neg-inf]
+                          (if (< j seq-k)
+                            (recur (inc j) (n/max m (aget weights (+ offset j))))
+                            m))
+                  sum-exp (loop [j 0 s 0.0]
+                            (if (< j seq-k)
+                              (let [e (m/exp (- (aget weights (+ offset j)) max-s))]
+                                (aset weights (+ offset j) e)
+                                (recur (inc j) (+ s e)))
+                              s))
+                  inv-sum (/ 1.0 sum-exp)]
+              (dotimes [j seq-k]
+                (aset weights (+ offset j) (* (aget weights (+ offset j)) inv-sum)))))
+        ;; dZ = scale·(dQ·Kᵀ + Q·dKᵀ)
+        dZ (double-array (* seq-q seq-k))
+        _ (blas/dgemm-nt! dQ K dZ seq-q dk seq-k scale 0.0)
+        _ (blas/dgemm-nt! Q dK dZ seq-q dk seq-k scale 1.0)
+        ;; softmax JVP per row: dW = W⊙(dZ − ⟨W,dZ⟩_row)
+        dW (double-array (* seq-q seq-k))
+        _ (dotimes [i seq-q]
+            (let [offset (* i (int seq-k))
+                  wdz (loop [j 0 s 0.0]
+                        (if (< j seq-k)
+                          (recur (inc j) (+ s (* (aget weights (+ offset j))
+                                                 (aget dZ (+ offset j)))))
+                          s))]
+              (dotimes [j seq-k]
+                (aset dW (+ offset j)
+                      (* (aget weights (+ offset j))
+                         (- (aget dZ (+ offset j)) wdz))))))
+        ;; dO = dW·V + W·dV
+        dO (double-array (* seq-q dv))
+        _ (blas/dgemm! dW V dO seq-q seq-k dv 1.0 0.0)
+        _ (blas/dgemm! weights dV dO seq-q seq-k dv 1.0 1.0)]
+    dO))
+
+;; SDPA :jvp-fn — one kernel call; absent tangents get typed zeros (the
+;; pushforward is jointly linear in (dQ,dK,dV), so zeros are exact).
+(tmpl/merge-into-template!
+ 'raster.dl.attention/scaled-dot-product-attn
+ {:jvp-fn
+  (fn [ctx [Q K V seq-q seq-k dk dv] tangent-args _result-sym gensym-fn]
+    (let [dQ (nth tangent-args 0 nil)
+          dK (nth tangent-args 1 nil)
+          dV (nth tangent-args 2 nil)]
+      (when-not (or dQ dK dV)
+        (throw (ex-info "scaled-dot-product-attn jvp: no active tangent reached the call"
+                        {:op 'raster.dl.attention/scaled-dot-product-attn})))
+      (tmpl/bind-jvp-term ctx gensym-fn "jsdpa"
+                          (list 'raster.dl.attention/scaled-dot-product-attn-jvp
+                                (or dQ (tmpl/jvp-zero-like Q))
+                                (or dK (tmpl/jvp-zero-like K))
+                                (or dV (tmpl/jvp-zero-like V))
+                                Q K V seq-q seq-k dk dv))))})
+
 ;; ---------------------------------------------------------------------------
 ;; PREFILL variants (S3 GPU embed mode): a whole T-token block per replay, no KV
 ;; cache, positions from the work-item index. Causal mask via -1e30 scores.
@@ -1178,23 +1381,23 @@
 (deftm rope-prefill! (All [T] [x :- (Array T) out :- (Array T)
                                nrows :- Long heads :- Long head-dim :- Long
                                theta :- Double] :- Void
-  (raster.par/map-void! idx (clojure.core/* nrows (clojure.core/* heads (quot head-dim 2)))
-    (let [hdim2 (quot head-dim 2)
-          per-row (clojure.core/* heads hdim2)
-          t (quot idx per-row)
-          rest0 (rem idx per-row)
-          h (quot rest0 hdim2)
-          i (rem rest0 hdim2)
-          base (clojure.core/+ (clojure.core/* t (clojure.core/* heads head-dim))
-                               (clojure.core/* h head-dim))
-          ln-theta (m/log theta)
-          freq (m/exp (* (/ (* -2.0 (double i)) (double head-dim)) ln-theta))
-          ang (* (double t) freq)
-          c (m/cos ang) s (m/sin ang)
-          x0 (aget x (clojure.core/+ base i))
-          x1 (aget x (clojure.core/+ (clojure.core/+ base i) hdim2))]
-      (aset out (clojure.core/+ base i) (- (* x0 c) (* x1 s)))
-      (aset out (clojure.core/+ (clojure.core/+ base i) hdim2) (+ (* x1 c) (* x0 s)))))))
+                          (raster.par/map-void! idx (clojure.core/* nrows (clojure.core/* heads (quot head-dim 2)))
+                                                (let [hdim2 (quot head-dim 2)
+                                                      per-row (clojure.core/* heads hdim2)
+                                                      t (quot idx per-row)
+                                                      rest0 (rem idx per-row)
+                                                      h (quot rest0 hdim2)
+                                                      i (rem rest0 hdim2)
+                                                      base (clojure.core/+ (clojure.core/* t (clojure.core/* heads head-dim))
+                                                                           (clojure.core/* h head-dim))
+                                                      ln-theta (m/log theta)
+                                                      freq (m/exp (* (/ (* -2.0 (double i)) (double head-dim)) ln-theta))
+                                                      ang (* (double t) freq)
+                                                      c (m/cos ang) s (m/sin ang)
+                                                      x0 (aget x (clojure.core/+ base i))
+                                                      x1 (aget x (clojure.core/+ (clojure.core/+ base i) hdim2))]
+                                                  (aset out (clojure.core/+ base i) (- (* x0 c) (* x1 s)))
+                                                  (aset out (clojure.core/+ (clojure.core/+ base i) hdim2) (+ (* x1 c) (* x0 s)))))))
 
 ;; Causal batched attention, 3 phases. q:[T,nq*hd] k,v:[T,nkv*hd] row-major;
 ;; sc:[T*nq, T] scores/probs scratch; out:[T, nq*hd].
@@ -1202,68 +1405,68 @@
                                       nrows :- Long n-q :- Long group :- Long
                                       n-kv :- Long head-dim :- Long
                                       scale :- Double] :- Void
-  (raster.par/map-void! idx (clojure.core/* nrows (clojure.core/* n-q nrows))
-    (let [per-i (clojure.core/* n-q nrows)
-          i (quot idx per-i)
-          rest0 (rem idx per-i)
-          hq (quot rest0 nrows)
-          j (rem rest0 nrows)
-          row (clojure.core/+ (clojure.core/* i n-q) hq)]
-      (if (< i j)
-        (aset sc (clojure.core/+ (clojure.core/* row nrows) j) -1.0e30)
-        (let [hkv (quot hq group)
-              qb (clojure.core/+ (clojure.core/* i (clojure.core/* n-q head-dim))
-                                 (clojure.core/* hq head-dim))
-              kb (clojure.core/+ (clojure.core/* j (clojure.core/* n-kv head-dim))
-                                 (clojure.core/* hkv head-dim))
-              dot (loop [d 0 acc 0.0]
-                    (if (< d head-dim)
-                      (recur (inc d)
-                             (+ acc (* (aget q (clojure.core/+ qb d))
-                                       (aget k (clojure.core/+ kb d)))))
-                      acc))]
-          (aset sc (clojure.core/+ (clojure.core/* row nrows) j) (* dot scale))))))))
+                                 (raster.par/map-void! idx (clojure.core/* nrows (clojure.core/* n-q nrows))
+                                                       (let [per-i (clojure.core/* n-q nrows)
+                                                             i (quot idx per-i)
+                                                             rest0 (rem idx per-i)
+                                                             hq (quot rest0 nrows)
+                                                             j (rem rest0 nrows)
+                                                             row (clojure.core/+ (clojure.core/* i n-q) hq)]
+                                                         (if (< i j)
+                                                           (aset sc (clojure.core/+ (clojure.core/* row nrows) j) -1.0e30)
+                                                           (let [hkv (quot hq group)
+                                                                 qb (clojure.core/+ (clojure.core/* i (clojure.core/* n-q head-dim))
+                                                                                    (clojure.core/* hq head-dim))
+                                                                 kb (clojure.core/+ (clojure.core/* j (clojure.core/* n-kv head-dim))
+                                                                                    (clojure.core/* hkv head-dim))
+                                                                 dot (loop [d 0 acc 0.0]
+                                                                       (if (< d head-dim)
+                                                                         (recur (inc d)
+                                                                                (+ acc (* (aget q (clojure.core/+ qb d))
+                                                                                          (aget k (clojure.core/+ kb d)))))
+                                                                         acc))]
+                                                             (aset sc (clojure.core/+ (clojure.core/* row nrows) j) (* dot scale))))))))
 
 (deftm attn-prefill-softmax! (All [T] [sc :- (Array T)
                                        nrows :- Long n-q :- Long] :- Void
-  (raster.par/map-void! row (clojure.core/* nrows n-q)
-    (let [scb (clojure.core/* row nrows)
-          mx (loop [j 0 mm -1.0e30]
-               (if (< j nrows)
-                 (recur (inc j) (n/max mm (aget sc (clojure.core/+ scb j)))) mm))
-          sum (loop [j 0 s 0.0]
-                (if (< j nrows)
-                  (let [e (m/exp (- (aget sc (clojure.core/+ scb j)) mx))]
-                    (aset sc (clojure.core/+ scb j) e)
-                    (recur (inc j) (+ s e)))
-                  s))
-          inv (/ 1.0 sum)]
-      (loop [j 0]
-        (if (< j nrows)
-          (do (aset sc (clojure.core/+ scb j) (* (aget sc (clojure.core/+ scb j)) inv))
-              (recur (inc j)))
-          nil))))))
+                                  (raster.par/map-void! row (clojure.core/* nrows n-q)
+                                                        (let [scb (clojure.core/* row nrows)
+                                                              mx (loop [j 0 mm -1.0e30]
+                                                                   (if (< j nrows)
+                                                                     (recur (inc j) (n/max mm (aget sc (clojure.core/+ scb j)))) mm))
+                                                              sum (loop [j 0 s 0.0]
+                                                                    (if (< j nrows)
+                                                                      (let [e (m/exp (- (aget sc (clojure.core/+ scb j)) mx))]
+                                                                        (aset sc (clojure.core/+ scb j) e)
+                                                                        (recur (inc j) (+ s e)))
+                                                                      s))
+                                                              inv (/ 1.0 sum)]
+                                                          (loop [j 0]
+                                                            (if (< j nrows)
+                                                              (do (aset sc (clojure.core/+ scb j) (* (aget sc (clojure.core/+ scb j)) inv))
+                                                                  (recur (inc j)))
+                                                              nil))))))
 
 (deftm attn-prefill-out! (All [T] [sc :- (Array T) v :- (Array T) out :- (Array T)
                                    nrows :- Long n-q :- Long group :- Long
                                    n-kv :- Long head-dim :- Long] :- Void
-  (raster.par/map-void! idx (clojure.core/* nrows (clojure.core/* n-q head-dim))
-    (let [per-i (clojure.core/* n-q head-dim)
-          i (quot idx per-i)
-          rest0 (rem idx per-i)
-          hq (quot rest0 head-dim)
-          d (rem rest0 head-dim)
-          row (clojure.core/+ (clojure.core/* i n-q) hq)
-          scb (clojure.core/* row nrows)
-          hkvb (clojure.core/+ (clojure.core/* (quot hq group) head-dim) d)
-          kvstride (clojure.core/* n-kv head-dim)]
-      (aset out (clojure.core/+ (clojure.core/* i per-i) (clojure.core/+ (clojure.core/* hq head-dim) d))
-            (loop [j 0 a 0.0]
-              (if (< j nrows)
-                (recur (inc j)
-                       (+ a (* (aget sc (clojure.core/+ scb j))
-                               (aget v (clojure.core/+ (clojure.core/* j kvstride) hkvb)))))
-                a)))))))
+                              (raster.par/map-void! idx (clojure.core/* nrows (clojure.core/* n-q head-dim))
+                                                    (let [per-i (clojure.core/* n-q head-dim)
+                                                          i (quot idx per-i)
+                                                          rest0 (rem idx per-i)
+                                                          hq (quot rest0 head-dim)
+                                                          d (rem rest0 head-dim)
+                                                          row (clojure.core/+ (clojure.core/* i n-q) hq)
+                                                          scb (clojure.core/* row nrows)
+                                                          hkvb (clojure.core/+ (clojure.core/* (quot hq group) head-dim) d)
+                                                          kvstride (clojure.core/* n-kv head-dim)]
+                                                      (aset out (clojure.core/+ (clojure.core/* i per-i) (clojure.core/+ (clojure.core/* hq head-dim) d))
+                                                            (loop [j 0 a 0.0]
+                                                              (if (< j nrows)
+                                                                (recur (inc j)
+                                                                       (+ a (* (aget sc (clojure.core/+ scb j))
+                                                                               (aget v (clojure.core/+ (clojure.core/* j kvstride) hkvb)))))
+                                                                a)))))))
 
 ;; Bidirectional scores (EmbeddingGemma-style encoder): all-to-all, no causal mask.
 ;; (Symmetric sliding window |i-j| < w only matters for T > window — the binder
@@ -1272,22 +1475,22 @@
                                             nrows :- Long n-q :- Long group :- Long
                                             n-kv :- Long head-dim :- Long
                                             scale :- Double] :- Void
-  (raster.par/map-void! idx (clojure.core/* nrows (clojure.core/* n-q nrows))
-    (let [per-i (clojure.core/* n-q nrows)
-          i (quot idx per-i)
-          rest0 (rem idx per-i)
-          hq (quot rest0 nrows)
-          j (rem rest0 nrows)
-          row (clojure.core/+ (clojure.core/* i n-q) hq)
-          hkv (quot hq group)
-          qb (clojure.core/+ (clojure.core/* i (clojure.core/* n-q head-dim))
-                             (clojure.core/* hq head-dim))
-          kb (clojure.core/+ (clojure.core/* j (clojure.core/* n-kv head-dim))
-                             (clojure.core/* hkv head-dim))
-          dot (loop [d 0 acc 0.0]
-                (if (< d head-dim)
-                  (recur (inc d)
-                         (+ acc (* (aget q (clojure.core/+ qb d))
-                                   (aget k (clojure.core/+ kb d)))))
-                  acc))]
-      (aset sc (clojure.core/+ (clojure.core/* row nrows) j) (* dot scale))))))
+                                       (raster.par/map-void! idx (clojure.core/* nrows (clojure.core/* n-q nrows))
+                                                             (let [per-i (clojure.core/* n-q nrows)
+                                                                   i (quot idx per-i)
+                                                                   rest0 (rem idx per-i)
+                                                                   hq (quot rest0 nrows)
+                                                                   j (rem rest0 nrows)
+                                                                   row (clojure.core/+ (clojure.core/* i n-q) hq)
+                                                                   hkv (quot hq group)
+                                                                   qb (clojure.core/+ (clojure.core/* i (clojure.core/* n-q head-dim))
+                                                                                      (clojure.core/* hq head-dim))
+                                                                   kb (clojure.core/+ (clojure.core/* j (clojure.core/* n-kv head-dim))
+                                                                                      (clojure.core/* hkv head-dim))
+                                                                   dot (loop [d 0 acc 0.0]
+                                                                         (if (< d head-dim)
+                                                                           (recur (inc d)
+                                                                                  (+ acc (* (aget q (clojure.core/+ qb d))
+                                                                                            (aget k (clojure.core/+ kb d)))))
+                                                                           acc))]
+                                                               (aset sc (clojure.core/+ (clojure.core/* row nrows) j) (* dot scale))))))

--- a/src/raster/dl/nn.clj
+++ b/src/raster/dl/nn.clj
@@ -212,25 +212,25 @@
 (deftm skip-layer-norm
   (All [T] [a :- (Array T) b :- (Array T) gamma :- (Array T) beta :- (Array T)
             batch :- Long features :- Long eps :- Double] :- (Array T)
-    (let [out  (alloc-like a (* batch features))
-          finv (/ 1.0 (double features))]
-      (dotimes [r batch]
-        (let [offset (* r (int features))
-              mean (loop [i 0 s 0.0]
-                     (if (< i features)
-                       (recur (inc i) (+ s (+ (aget a (+ offset i)) (aget b (+ offset i)))))
-                       (* s finv)))
-              var  (loop [i 0 s 0.0]
-                     (if (< i features)
-                       (let [d (- (+ (aget a (+ offset i)) (aget b (+ offset i))) mean)]
-                         (recur (inc i) (+ s (* d d))))
-                       (* s finv)))
-              inv-std (/ 1.0 (n/sqrt (+ var eps)))]
-          (dotimes [i features]
-            (let [v (+ (aget a (+ offset i)) (aget b (+ offset i)))]
-              (aset out (+ offset i)
-                    (+ (* (aget gamma i) (* (- v mean) inv-std)) (aget beta i)))))))
-      out)))
+       (let [out  (alloc-like a (* batch features))
+             finv (/ 1.0 (double features))]
+         (dotimes [r batch]
+           (let [offset (* r (int features))
+                 mean (loop [i 0 s 0.0]
+                        (if (< i features)
+                          (recur (inc i) (+ s (+ (aget a (+ offset i)) (aget b (+ offset i)))))
+                          (* s finv)))
+                 var  (loop [i 0 s 0.0]
+                        (if (< i features)
+                          (let [d (- (+ (aget a (+ offset i)) (aget b (+ offset i))) mean)]
+                            (recur (inc i) (+ s (* d d))))
+                          (* s finv)))
+                 inv-std (/ 1.0 (n/sqrt (+ var eps)))]
+             (dotimes [i features]
+               (let [v (+ (aget a (+ offset i)) (aget b (+ offset i)))]
+                 (aset out (+ offset i)
+                       (+ (* (aget gamma i) (* (- v mean) inv-std)) (aget beta i)))))))
+         out)))
 
 ;; --- GELU: x * Phi(x) (tanh approximation) ---
 ;; The tanh is inlined as a vectorizable odd-rational approximation (Eigen ptanh:
@@ -239,21 +239,21 @@
 (deftm gelu (All [T] [x :- (Array T) n :- Long] :- (Array T)
                  (let [c (n/sqrt (/ 2.0 n/pi))]
                    (broadcast [x]
-                     (let [u  (n/min 9.0 (n/max -9.0 (* c (+ x (* 0.044715 x x x)))))
-                           u2 (* u u)
-                           np (+ 4.89352455891786e-3
-                                 (* u2 (+ 6.37261928875436e-4
-                                          (* u2 (+ 1.48572235717979e-5
-                                                   (* u2 (+ 5.12229709037114e-8
-                                                            (* u2 (+ -8.60467152213735e-11
-                                                                     (* u2 (+ 2.00018790482477e-13
-                                                                              (* u2 -2.76076847742355e-16))))))))))))
-                           dp (+ 4.89352518554385e-3
-                                 (* u2 (+ 2.268434632439e-3
-                                          (* u2 (+ 1.18534705686654e-4
-                                                   (* u2 1.19825839466702e-6))))))
-                           th (/ (* u np) dp)]
-                       (* 0.5 x (+ 1.0 th)))))))
+                              (let [u  (n/min 9.0 (n/max -9.0 (* c (+ x (* 0.044715 x x x)))))
+                                    u2 (* u u)
+                                    np (+ 4.89352455891786e-3
+                                          (* u2 (+ 6.37261928875436e-4
+                                                   (* u2 (+ 1.48572235717979e-5
+                                                            (* u2 (+ 5.12229709037114e-8
+                                                                     (* u2 (+ -8.60467152213735e-11
+                                                                              (* u2 (+ 2.00018790482477e-13
+                                                                                       (* u2 -2.76076847742355e-16))))))))))))
+                                    dp (+ 4.89352518554385e-3
+                                          (* u2 (+ 2.268434632439e-3
+                                                   (* u2 (+ 1.18534705686654e-4
+                                                            (* u2 1.19825839466702e-6))))))
+                                    th (/ (* u np) dp)]
+                                (* 0.5 x (+ 1.0 th)))))))
 
 ;; gelu': 0.5*(1+tanh(inner)) + 0.5*x*sech^2(inner)*c*(1+3*0.044715*x^2)
 (deftm gelu-backward (All [T] [dy :- (Array T) x :- (Array T) n :- Long]
@@ -269,7 +269,6 @@
                                             (* 0.5 xi sech2 c (+ 1.0 (* 3.0 0.044715 xi xi))))]
                                 (aset dx i (* (aget dy i) grad))))
                             dx)))
-
 
 (tmpl/merge-into-template! 'raster.dl.nn/gelu
                            {:params '[x n] :adjoint 'dy
@@ -292,7 +291,6 @@
                                    (aset dx i (* (aget dy i) si (- 1.0 si)))))
                                dx)))
 
-
 (tmpl/merge-into-template! 'raster.dl.nn/sigmoid
                            {:params '[x n] :adjoint 'dy
                             :grads-fn (fn [ctx [x n] result adjoint gensym-fn]
@@ -313,7 +311,6 @@
                                   (let [ti (aget result i)]
                                     (aset dx i (* (aget dy i) (- 1.0 (* ti ti))))))
                                 dx)))
-
 
 (tmpl/merge-into-template! 'raster.dl.nn/tanh-act
                            {:params '[x n] :adjoint 'dy
@@ -342,7 +339,6 @@
                                           grad (if (>= xi 0.0) 1.0 alpha)]
                                       (aset dx i (* (aget dy i) grad))))
                                   dx)))
-
 
 (tmpl/merge-into-template! 'raster.dl.nn/leaky-relu
                            {:params '[x n alpha] :adjoint 'dy
@@ -390,42 +386,42 @@
 (deftm layer-norm! (All [T] [x :- (Array T) gamma :- (Array T) beta :- (Array T)
                              out :- (Array T) rows :- Long features :- Long
                              eps :- Double] :- Void
-  (raster.par/map-void! r rows
-    (let [offset (clojure.core/* r features)
-          mean (loop [i 0 s 0.0]
-                 (if (< i features)
-                   (recur (inc i) (+ s (aget x (clojure.core/+ offset i))))
-                   (/ s (double features))))
-          var (loop [i 0 s 0.0]
-                (if (< i features)
-                  (let [dv (- (aget x (clojure.core/+ offset i)) mean)]
-                    (recur (inc i) (+ s (* dv dv))))
-                  (/ s (double features))))
-          inv (/ 1.0 (n/sqrt (+ var eps)))]
-      (loop [i 0]
-        (if (< i features)
-          (do (aset out (clojure.core/+ offset i)
-                    (+ (* (aget gamma i)
-                          (* (- (aget x (clojure.core/+ offset i)) mean) inv))
-                       (aget beta i)))
-              (recur (inc i)))
-          nil))))))
+                        (raster.par/map-void! r rows
+                                              (let [offset (clojure.core/* r features)
+                                                    mean (loop [i 0 s 0.0]
+                                                           (if (< i features)
+                                                             (recur (inc i) (+ s (aget x (clojure.core/+ offset i))))
+                                                             (/ s (double features))))
+                                                    var (loop [i 0 s 0.0]
+                                                          (if (< i features)
+                                                            (let [dv (- (aget x (clojure.core/+ offset i)) mean)]
+                                                              (recur (inc i) (+ s (* dv dv))))
+                                                            (/ s (double features))))
+                                                    inv (/ 1.0 (n/sqrt (+ var eps)))]
+                                                (loop [i 0]
+                                                  (if (< i features)
+                                                    (do (aset out (clojure.core/+ offset i)
+                                                              (+ (* (aget gamma i)
+                                                                    (* (- (aget x (clojure.core/+ offset i)) mean) inv))
+                                                                 (aget beta i)))
+                                                        (recur (inc i)))
+                                                    nil))))))
 
 ;; !-variant elementwise GELU (tanh approximation, matches `gelu`/gelu-mul!).
 (deftm gelu! (All [T] [x :- (Array T) out :- (Array T) n :- Long] :- Void
-  (raster.par/map-void! i n
-    (let [v (aget x i)]
-      (aset out i (* 0.5 v
-                     (+ 1.0 (m/tanh (* 0.7978845608028654
-                                       (+ v (* 0.044715 v v v)))))))))))
+                  (raster.par/map-void! i n
+                                        (let [v (aget x i)]
+                                          (aset out i (* 0.5 v
+                                                         (+ 1.0 (m/tanh (* 0.7978845608028654
+                                                                           (+ v (* 0.044715 v v v)))))))))))
 
 ;; Broadcast row-bias add in place semantics via separate out (resident-graph
 ;; friendly): out[r,j] = x[r,j] + b[j]. Follows every biased linear in
 ;; encoder-family layers (AuT, BERT) — the quantized GEMM kernels are bias-free.
 (deftm add-bias-rows! (All [T] [x :- (Array T) b :- (Array T) out :- (Array T)
                                 rows :- Long features :- Long] :- Void
-  (raster.par/map-void! i (* rows features)
-    (aset out i (+ (aget x i) (aget b (clojure.core/rem i features)))))))
+                           (raster.par/map-void! i (* rows features)
+                                                 (aset out i (+ (aget x i) (aget b (clojure.core/rem i features)))))))
 
 ;; layer-norm rrule — pullback registered after backward deftm (below)
 
@@ -485,10 +481,10 @@
 ;; TWO active inputs (the SOAC map differentiates only single-active), so gated
 ;; MLPs need this dedicated op. Pullback: d_a = dy⊙b, d_b = dy⊙a.
 (deftm hadamard (All [T] [a :- (Array T) b :- (Array T) n :- Long] :- (Array T)
-                    (broadcast [a b] (* a b))))
+                     (broadcast [a b] (* a b))))
 
 (deftm hadamard-backward (All [T] [dy :- (Array T) other :- (Array T) n :- Long] :- (Array T)
-                             (broadcast [dy other] (* dy other))))
+                              (broadcast [dy other] (* dy other))))
 
 ;; Gated MLP (GeGLU): down( gelu(x@gate^T) ⊙ (x@up^T) ), bias-free.
 ;; This is Gemma's / T5-v1.1's MLP. The SwiGLU variant (Llama/Qwen) is identical
@@ -520,9 +516,9 @@
 ;; (broadcast [a b] (+ a b)) has no AD template for two active inputs, so the
 ;; ubiquitous transformer residual (x + attn/mlp out) needs this explicit rule.
 (deftm residual-add-backward (All [T] [dy :- (Array T) n :- Long] :- (Array T)
-                                 (let [out (alloc-like dy n)]
-                                   (acopy! dy 0 out 0 n)
-                                   out)))
+                                  (let [out (alloc-like dy n)]
+                                    (acopy! dy 0 out 0 n)
+                                    out)))
 
 ;; --- Group Norm ---
 ;; x:[batch, channels, spatial], gamma:[channels], beta:[channels]
@@ -1082,7 +1078,6 @@
                                                 (aget dy (+ (* i (int dim)) d)))))))
                                  d-table)))
 
-
 (tmpl/merge-into-template! 'raster.dl.nn/embedding
                            {:params '[table indices n vocab dim] :adjoint 'dy
                             :grads-fn (fn [ctx [table indices n vocab dim] _result adjoint gensym-fn]
@@ -1111,7 +1106,6 @@
                                (dotimes [i n]
                                  (aset dx i (* (aget dy i) (aget mask i))))
                                dx)))
-
 
 (tmpl/merge-into-template! 'raster.dl.nn/dropout
                            {:params '[x mask n] :adjoint 'dy
@@ -1166,7 +1160,6 @@
                                           (* (aget result i)
                                              (- (aget dy i) s-dot-dy))))
                                   dx)))
-
 
 (tmpl/merge-into-template! 'raster.dl.nn/softmax-1d
                            {:params '[x n] :adjoint 'dy
@@ -1349,6 +1342,50 @@
                                         dbeta)))
 
 ;; ----------------------------------------------------------------
+;; Layer-norm forward tangent (JVP, §13 A3) — the x-directional differential:
+;;   x̂ = (x−μ)·inv,  inv = 1/σ = 1/sqrt(var+eps)
+;;   dx̂ = (dx − mean(dx) − x̂·mean(x̂⊙dx))·inv
+;;   d  = γ⊙dx̂
+;; The γ/β tangent terms are NOT here: layer-norm is JOINTLY LINEAR in
+;; (γ, β), so their pushforward is the op itself with (dγ, dβ) — see the
+;; :jvp-fn registration below.
+;; ----------------------------------------------------------------
+
+(deftm layer-norm-jvp-dx (All [T] [dx :- (Array T) x :- (Array T)
+                                   gamma :- (Array T)
+                                   batch :- Long features :- Long eps :- Double]
+                              :- (Array T)
+                              (let [out (alloc-like dx (* batch features))]
+                                (dotimes [b batch]
+                                  (let [offset (* b (int features))
+                                        mean (loop [i 0 s 0.0]
+                                               (if (< i features)
+                                                 (recur (inc i) (+ s (aget x (+ offset i))))
+                                                 (/ s features)))
+                                        var (loop [i 0 s 0.0]
+                                              (if (< i features)
+                                                (let [d (- (aget x (+ offset i)) mean)]
+                                                  (recur (inc i) (+ s (* d d))))
+                                                (/ s features)))
+                                        inv-std (/ 1.0 (n/sqrt (+ var eps)))
+                                        dmean (loop [i 0 s 0.0]
+                                                (if (< i features)
+                                                  (recur (inc i) (+ s (aget dx (+ offset i))))
+                                                  (/ s features)))
+                                        m2 (loop [i 0 s 0.0]
+                                             (if (< i features)
+                                               (let [x-hat (* (- (aget x (+ offset i)) mean) inv-std)]
+                                                 (recur (inc i) (+ s (* x-hat (aget dx (+ offset i))))))
+                                               (/ s features)))]
+                                    (dotimes [i features]
+                                      (let [x-hat (* (- (aget x (+ offset i)) mean) inv-std)]
+                                        (aset out (+ offset i)
+                                              (* (aget gamma i)
+                                                 (* inv-std
+                                                    (- (aget dx (+ offset i)) (+ dmean (* x-hat m2))))))))))
+                                out)))
+
+;; ----------------------------------------------------------------
 ;; RMS-norm backward: dx, dweight
 ;;   y_i = x_i · inv · (g0 + w_i),  inv = 1/sqrt(mean_j(x_j²) + eps)
 ;;   c   = Σ_i (g0+w_i)·x_i·dy_i   (per row)
@@ -1359,46 +1396,81 @@
 (deftm rms-norm-backward-dx (All [T] [dy :- (Array T) x :- (Array T) weight :- (Array T)
                                       rows :- Long features :- Long
                                       eps :- Double gain-offset :- Double] :- (Array T)
-                                (let [dx (alloc-like dy (* rows features))]
-                                  (dotimes [r rows]
-                                    (let [offset (* r (int features))
-                                          ms (loop [i 0 s 0.0]
+                                 (let [dx (alloc-like dy (* rows features))]
+                                   (dotimes [r rows]
+                                     (let [offset (* r (int features))
+                                           ms (loop [i 0 s 0.0]
+                                                (if (< i features)
+                                                  (let [v (aget x (+ offset i))]
+                                                    (recur (inc i) (+ s (* v v))))
+                                                  (/ s features)))
+                                           inv (/ 1.0 (n/sqrt (+ ms eps)))
+                                           c (loop [i 0 s 0.0]
                                                (if (< i features)
-                                                 (let [v (aget x (+ offset i))]
-                                                   (recur (inc i) (+ s (* v v))))
-                                                 (/ s features)))
-                                          inv (/ 1.0 (n/sqrt (+ ms eps)))
-                                          c (loop [i 0 s 0.0]
-                                              (if (< i features)
-                                                (let [gi (+ gain-offset (aget weight i))]
-                                                  (recur (inc i)
-                                                         (+ s (* gi (* (aget x (+ offset i))
-                                                                       (aget dy (+ offset i)))))))
-                                                s))
-                                          inv3f (/ (* inv (* inv inv)) features)]
-                                      (dotimes [i features]
-                                        (let [gi (+ gain-offset (aget weight i))]
-                                          (aset dx (+ offset i)
-                                                (- (* inv (* gi (aget dy (+ offset i))))
-                                                   (* inv3f (* (aget x (+ offset i)) c))))))))
-                                  dx)))
+                                                 (let [gi (+ gain-offset (aget weight i))]
+                                                   (recur (inc i)
+                                                          (+ s (* gi (* (aget x (+ offset i))
+                                                                        (aget dy (+ offset i)))))))
+                                                 s))
+                                           inv3f (/ (* inv (* inv inv)) features)]
+                                       (dotimes [i features]
+                                         (let [gi (+ gain-offset (aget weight i))]
+                                           (aset dx (+ offset i)
+                                                 (- (* inv (* gi (aget dy (+ offset i))))
+                                                    (* inv3f (* (aget x (+ offset i)) c))))))))
+                                   dx)))
 
 (deftm rms-norm-backward-dweight (All [T] [dy :- (Array T) x :- (Array T)
                                            rows :- Long features :- Long eps :- Double] :- (Array T)
-                                     (let [dw (alloc-like dy features)]
-                                       (dotimes [r rows]
-                                         (let [offset (* r (int features))
-                                               ms (loop [i 0 s 0.0]
-                                                    (if (< i features)
-                                                      (let [v (aget x (+ offset i))]
-                                                        (recur (inc i) (+ s (* v v))))
-                                                      (/ s features)))
-                                               inv (/ 1.0 (n/sqrt (+ ms eps)))]
-                                           (dotimes [i features]
-                                             (aset dw i (+ (aget dw i)
-                                                           (* (aget dy (+ offset i))
-                                                              (* (aget x (+ offset i)) inv)))))))
-                                       dw)))
+                                      (let [dw (alloc-like dy features)]
+                                        (dotimes [r rows]
+                                          (let [offset (* r (int features))
+                                                ms (loop [i 0 s 0.0]
+                                                     (if (< i features)
+                                                       (let [v (aget x (+ offset i))]
+                                                         (recur (inc i) (+ s (* v v))))
+                                                       (/ s features)))
+                                                inv (/ 1.0 (n/sqrt (+ ms eps)))]
+                                            (dotimes [i features]
+                                              (aset dw i (+ (aget dw i)
+                                                            (* (aget dy (+ offset i))
+                                                               (* (aget x (+ offset i)) inv)))))))
+                                        dw)))
+
+;; ----------------------------------------------------------------
+;; RMS-norm forward tangent (JVP, §13 A3) — the x-directional differential:
+;;   r = sqrt(mean(x²)+eps),  c = ⟨x,dx⟩ per row
+;;   d_i = (g0+w_i)·(dx_i/r − x_i·c/(F·r³))
+;; The weight-tangent term dw⊙x/r is NOT here: rms-norm is LINEAR in
+;; (g0 + w), so its pushforward is rms-norm(x, dw, …, gain-offset 0.0) —
+;; see the :jvp-fn registration below.
+;; ----------------------------------------------------------------
+
+(deftm rms-norm-jvp-dx (All [T] [dx :- (Array T) x :- (Array T) weight :- (Array T)
+                                 rows :- Long features :- Long
+                                 eps :- Double gain-offset :- Double] :- (Array T)
+                            (let [out (alloc-like dx (* rows features))]
+                              (dotimes [r rows]
+                                (let [offset (* r (int features))
+                                      ms (loop [i 0 s 0.0]
+                                           (if (< i features)
+                                             (let [v (aget x (+ offset i))]
+                                               (recur (inc i) (+ s (* v v))))
+                                             (/ s features)))
+                                      inv (/ 1.0 (n/sqrt (+ ms eps)))
+                                      c (loop [i 0 s 0.0]
+                                          (if (< i features)
+                                            (recur (inc i)
+                                                   (+ s (* (aget x (+ offset i))
+                                                           (aget dx (+ offset i)))))
+                                            s))
+                                      inv3f (/ (* inv (* inv inv)) features)]
+                                  (dotimes [i features]
+                                    (aset out (+ offset i)
+                                          (* (+ gain-offset (aget weight i))
+                                             (- (* inv (aget dx (+ offset i)))
+                                                (* inv3f (* (aget x (+ offset i)) c))))))))
+                              out)))
 
 ;; ----------------------------------------------------------------
 ;; Group-norm backward: dx, dgamma, dbeta
@@ -1522,6 +1594,77 @@
                                         dbeta)))
 
 ;; ----------------------------------------------------------------
+;; Group-norm forward tangent (JVP, §13 A3) — layer-norm JVP per group,
+;; iterating groups exactly like group-norm-backward-dx:
+;;   per (b,g): x̂ = (x−μ_g)·inv_g
+;;              dx̂ = (dx − mean_g(dx) − x̂·mean_g(x̂⊙dx))·inv_g
+;;              d = γ_ch⊙dx̂
+;; γ/β tangent terms: group-norm is jointly LINEAR in (γ, β) → the op
+;; itself with (dγ, dβ); see the :jvp-fn registration below.
+;; ----------------------------------------------------------------
+
+(deftm group-norm-jvp-dx (All [T] [dx :- (Array T) x :- (Array T)
+                                   gamma :- (Array T)
+                                   batch :- Long channels :- Long
+                                   spatial :- Long groups :- Long eps :- Double]
+                              :- (Array T)
+                              (let [cpg (quot channels groups)
+                                    group-size (* cpg spatial)
+                                    out (alloc-like dx (* batch channels spatial))]
+                                (dotimes [b batch]
+                                  (dotimes [g groups]
+                                    (let [mean (loop [c 0 acc 0.0]
+                                                 (if (< c cpg)
+                                                   (let [ch (+ (* g (int cpg)) c)
+                                                         acc (loop [sp 0 inner-acc acc]
+                                                               (if (< sp spatial)
+                                                                 (recur (inc sp)
+                                                                        (+ inner-acc
+                                                                           (aget x (+ (* b (int (* channels spatial)))
+                                                                                      (* ch (int spatial)) sp))))
+                                                                 inner-acc))]
+                                                     (recur (inc c) acc))
+                                                   (/ acc group-size)))
+                                          var (loop [c 0 acc 0.0]
+                                                (if (< c cpg)
+                                                  (let [ch (+ (* g (int cpg)) c)
+                                                        acc (loop [sp 0 inner-acc acc]
+                                                              (if (< sp spatial)
+                                                                (let [idx (+ (* b (int (* channels spatial)))
+                                                                             (* ch (int spatial)) sp)
+                                                                      d (- (aget x idx) mean)]
+                                                                  (recur (inc sp) (+ inner-acc (* d d))))
+                                                                inner-acc))]
+                                                    (recur (inc c) acc))
+                                                  (/ acc group-size)))
+                                          inv-std (/ 1.0 (n/sqrt (+ var eps)))
+              ;; group means of dx and x̂⊙dx (double-array accumulator — same
+              ;; vector-return workaround as group-norm-backward-dx)
+                                          sums-buf (double-array 2)
+                                          _ (dotimes [c cpg]
+                                              (let [ch (+ (* g (int cpg)) c)]
+                                                (dotimes [sp spatial]
+                                                  (let [idx (+ (* b (int (* channels spatial)))
+                                                               (* ch (int spatial)) sp)
+                                                        x-hat (* (- (aget x idx) mean) inv-std)]
+                                                    (aset sums-buf 0 (+ (aget sums-buf 0) (aget dx idx)))
+                                                    (aset sums-buf 1 (+ (aget sums-buf 1)
+                                                                        (* x-hat (aget dx idx))))))))
+                                          dmean (/ (aget sums-buf 0) group-size)
+                                          m2 (/ (aget sums-buf 1) group-size)]
+                                      (dotimes [c cpg]
+                                        (let [ch (+ (* g (int cpg)) c)]
+                                          (dotimes [sp spatial]
+                                            (let [idx (+ (* b (int (* channels spatial)))
+                                                         (* ch (int spatial)) sp)
+                                                  x-hat (* (- (aget x idx) mean) inv-std)]
+                                              (aset out idx
+                                                    (* (aget gamma ch)
+                                                       (* inv-std
+                                                          (- (aget dx idx) (+ dmean (* x-hat m2)))))))))))))
+                                out)))
+
+;; ----------------------------------------------------------------
 ;; Batch-norm backward: dx, dgamma, dbeta
 ;; ----------------------------------------------------------------
 
@@ -1593,6 +1736,53 @@
                                           (dotimes [j features]
                                             (aset dbeta j (+ (aget dbeta j) (aget dy (+ (* i (int features)) j))))))
                                         dbeta)))
+
+;; ----------------------------------------------------------------
+;; Batch-norm forward tangent (JVP, §13 A3) — the standard TRAINING-MODE
+;; differential (batch statistics; mirrors batch-norm-backward-dx, which
+;; has the same training-only structure), per feature column j over batch:
+;;   x̂ = (x−μ_j)·inv_j
+;;   dx̂ = (dx − mean_i(dx) − x̂·mean_i(x̂⊙dx))·inv_j
+;;   d = γ_j⊙dx̂
+;; γ/β tangent terms: batch-norm is jointly LINEAR in (γ, β) → the op
+;; itself with (dγ, dβ) over CLONED running stats (the primal call already
+;; updated them; the tangent call must not double-update) — see :jvp-fn.
+;; ----------------------------------------------------------------
+
+(deftm batch-norm-jvp-dx (All [T] [dx :- (Array T) x :- (Array T)
+                                   gamma :- (Array T)
+                                   batch :- Long features :- Long eps :- Double]
+                              :- (Array T)
+                              (let [out (alloc-like dx (* batch features))]
+                                (dotimes [j features]
+                                  (let [mean (loop [i 0 s 0.0]
+                                               (if (< i batch)
+                                                 (recur (inc i) (+ s (aget x (+ (* i (int features)) j))))
+                                                 (/ s batch)))
+                                        var (loop [i 0 s 0.0]
+                                              (if (< i batch)
+                                                (let [d (- (aget x (+ (* i (int features)) j)) mean)]
+                                                  (recur (inc i) (+ s (* d d))))
+                                                (/ s batch)))
+                                        inv-std (/ 1.0 (n/sqrt (+ var eps)))
+                                        dmean (loop [i 0 s 0.0]
+                                                (if (< i batch)
+                                                  (recur (inc i) (+ s (aget dx (+ (* i (int features)) j))))
+                                                  (/ s batch)))
+                                        m2 (loop [i 0 s 0.0]
+                                             (if (< i batch)
+                                               (let [idx (+ (* i (int features)) j)
+                                                     x-hat (* (- (aget x idx) mean) inv-std)]
+                                                 (recur (inc i) (+ s (* x-hat (aget dx idx)))))
+                                               (/ s batch)))]
+                                    (dotimes [i batch]
+                                      (let [idx (+ (* i (int features)) j)
+                                            x-hat (* (- (aget x idx) mean) inv-std)]
+                                        (aset out idx
+                                              (* (aget gamma j)
+                                                 (* inv-std
+                                                    (- (aget dx idx) (+ dmean (* x-hat m2))))))))))
+                                out)))
 
 ;; ----------------------------------------------------------------
 ;; Conv1d backward: dx, dW, db
@@ -1787,3 +1977,149 @@
                                                              adjoint-sym batch c-out length kernel stride pad)])
                                            ;; 10 params: dx dW db + 7 nil (batch c-in length c-out kernel stride pad)
                                            [dx dW db nil nil nil nil nil nil nil]]))})
+
+;; ================================================================
+;; Forward (JVP) rules — §13 A3 hand frules for the norm residue.
+;;
+;; Each norm's differential splits into
+;;   (1) the x-direction (the *-jvp-dx kernels above — textbook forms,
+;;       mirroring the corresponding backward kernel's iteration), and
+;;   (2) the (γ, β) / weight direction: every norm is JOINTLY LINEAR in its
+;;       affine parameters, so that pushforward is the op ITSELF on the
+;;       parameter tangents (typed zeros where a tangent is absent — exact
+;;       by linearity).
+;; Terms combine via grad-acc (the same ⊕ the reverse pass uses); emitted
+;; calls are fully qualified; flat bindings (BindCtx), matching
+;; derive-jvp-fn output conventions.
+;; ================================================================
+
+;; rms-norm [x weight rows features eps gain-offset]:
+;;   d = rms-norm-jvp-dx(dx, …) ⊕ rms-norm(x, dw, …, gain-offset 0.0)
+;; (weight enters only as (g0 + w) — linear; the tangent of the g0 offset
+;;  is 0, hence gain-offset 0.0 in the weight-tangent term.)
+(tmpl/merge-into-template!
+ 'raster.dl.nn/rms-norm
+ {:jvp-fn
+  (fn [ctx [x weight rows features eps gain-offset] tangent-args _result-sym gensym-fn]
+    (let [dx (nth tangent-args 0 nil)
+          dw (nth tangent-args 1 nil)]
+      (when-not (or dx dw)
+        (throw (ex-info "rms-norm jvp: no active tangent reached the call"
+                        {:op 'raster.dl.nn/rms-norm})))
+      (let [[ctx terms]
+            (if dx
+              (let [[ctx' s] (tmpl/bind-jvp-term ctx gensym-fn "jrms_dx"
+                                                 (list 'raster.dl.nn/rms-norm-jvp-dx
+                                                       dx x weight rows features eps gain-offset))]
+                [ctx' [s]])
+              [ctx []])
+            [ctx terms]
+            (if dw
+              (let [[ctx' s] (tmpl/bind-jvp-term ctx gensym-fn "jrms_dw"
+                                                 (list 'raster.dl.nn/rms-norm
+                                                       x dw rows features eps 0.0))]
+                [ctx' (conj terms s)])
+              [ctx terms])]
+        (tmpl/sum-tangent-contribs ctx terms gensym-fn))))})
+
+;; layer-norm [x gamma beta batch features eps]:
+;;   d = layer-norm-jvp-dx(dx, …) ⊕ layer-norm(x, dγ|0, dβ|0, …)
+(tmpl/merge-into-template!
+ 'raster.dl.nn/layer-norm
+ {:jvp-fn
+  (fn [ctx [x gamma beta batch features eps] tangent-args _result-sym gensym-fn]
+    (let [dx (nth tangent-args 0 nil)
+          dgamma (nth tangent-args 1 nil)
+          dbeta (nth tangent-args 2 nil)]
+      (when-not (or dx dgamma dbeta)
+        (throw (ex-info "layer-norm jvp: no active tangent reached the call"
+                        {:op 'raster.dl.nn/layer-norm})))
+      (let [[ctx terms]
+            (if dx
+              (let [[ctx' s] (tmpl/bind-jvp-term ctx gensym-fn "jln_dx"
+                                                 (list 'raster.dl.nn/layer-norm-jvp-dx
+                                                       dx x gamma batch features eps))]
+                [ctx' [s]])
+              [ctx []])
+            [ctx terms]
+            (if (or dgamma dbeta)
+              (let [[ctx' s] (tmpl/bind-jvp-term ctx gensym-fn "jln_gb"
+                                                 (list 'raster.dl.nn/layer-norm
+                                                       x
+                                                       (or dgamma (tmpl/jvp-zero-like gamma))
+                                                       (or dbeta (tmpl/jvp-zero-like beta))
+                                                       batch features eps))]
+                [ctx' (conj terms s)])
+              [ctx terms])]
+        (tmpl/sum-tangent-contribs ctx terms gensym-fn))))})
+
+;; group-norm [x gamma beta batch channels spatial groups eps]:
+;;   d = group-norm-jvp-dx(dx, …) ⊕ group-norm(x, dγ|0, dβ|0, …)
+(tmpl/merge-into-template!
+ 'raster.dl.nn/group-norm
+ {:jvp-fn
+  (fn [ctx [x gamma beta batch channels spatial groups eps] tangent-args _result-sym gensym-fn]
+    (let [dx (nth tangent-args 0 nil)
+          dgamma (nth tangent-args 1 nil)
+          dbeta (nth tangent-args 2 nil)]
+      (when-not (or dx dgamma dbeta)
+        (throw (ex-info "group-norm jvp: no active tangent reached the call"
+                        {:op 'raster.dl.nn/group-norm})))
+      (let [[ctx terms]
+            (if dx
+              (let [[ctx' s] (tmpl/bind-jvp-term ctx gensym-fn "jgn_dx"
+                                                 (list 'raster.dl.nn/group-norm-jvp-dx
+                                                       dx x gamma batch channels spatial groups eps))]
+                [ctx' [s]])
+              [ctx []])
+            [ctx terms]
+            (if (or dgamma dbeta)
+              (let [[ctx' s] (tmpl/bind-jvp-term ctx gensym-fn "jgn_gb"
+                                                 (list 'raster.dl.nn/group-norm
+                                                       x
+                                                       (or dgamma (tmpl/jvp-zero-like gamma))
+                                                       (or dbeta (tmpl/jvp-zero-like beta))
+                                                       batch channels spatial groups eps))]
+                [ctx' (conj terms s)])
+              [ctx terms])]
+        (tmpl/sum-tangent-contribs ctx terms gensym-fn))))})
+
+;; batch-norm [x gamma beta running-mean running-var batch features eps momentum training]:
+;;   d = batch-norm-jvp-dx(dx, …)                        (training-mode, like the backward)
+;;     ⊕ batch-norm(x, dγ|0, dβ|0, clone(rm), clone(rv), …)
+;; Running stats are CLONED for the tangent term: the primal call already
+;; applied the momentum update; re-running the op must not update them again.
+;; Their tangents are rule-frozen (the reverse rule gives rm/rv nil grads).
+(tmpl/merge-into-template!
+ 'raster.dl.nn/batch-norm
+ {:jvp-fn
+  (fn [ctx [x gamma beta running-mean running-var batch features eps momentum training]
+       tangent-args _result-sym gensym-fn]
+    (let [dx (nth tangent-args 0 nil)
+          dgamma (nth tangent-args 1 nil)
+          dbeta (nth tangent-args 2 nil)]
+      (when-not (or dx dgamma dbeta)
+        (throw (ex-info "batch-norm jvp: no active tangent reached the call"
+                        {:op 'raster.dl.nn/batch-norm})))
+      (let [[ctx terms]
+            (if dx
+              (let [[ctx' s] (tmpl/bind-jvp-term ctx gensym-fn "jbn_dx"
+                                                 (list 'raster.dl.nn/batch-norm-jvp-dx
+                                                       dx x gamma batch features eps))]
+                [ctx' [s]])
+              [ctx []])
+            [ctx terms]
+            (if (or dgamma dbeta)
+              (let [[ctx rmc] (tmpl/bind-jvp-term ctx gensym-fn "jbn_rmc"
+                                                  (list 'raster.arrays/aclone running-mean))
+                    [ctx rvc] (tmpl/bind-jvp-term ctx gensym-fn "jbn_rvc"
+                                                  (list 'raster.arrays/aclone running-var))
+                    [ctx' s] (tmpl/bind-jvp-term ctx gensym-fn "jbn_gb"
+                                                 (list 'raster.dl.nn/batch-norm
+                                                       x
+                                                       (or dgamma (tmpl/jvp-zero-like gamma))
+                                                       (or dbeta (tmpl/jvp-zero-like beta))
+                                                       rmc rvc batch features eps momentum training))]
+                [ctx' (conj terms s)])
+              [ctx terms])]
+        (tmpl/sum-tangent-contribs ctx terms gensym-fn))))})

--- a/test/raster/ad/laws_test.clj
+++ b/test/raster/ad/laws_test.clj
@@ -26,7 +26,8 @@
             [raster.sym.diff :as sdiff]
             [raster.sci.special :as special]
             [raster.dl.nn :as nn]
-            [raster.dl.loss :as loss]))
+            [raster.dl.loss :as loss]
+            [raster.dl.attention :as attn]))
 
 ;; ================================================================
 ;; Tolerances (per-dtype, scaled) and FD referee
@@ -73,6 +74,14 @@
 (defn- fadd ^floats [^floats a ^floats b]
   (let [len (alength a) out (float-array len)]
     (dotimes [i len] (aset out i (float (+ (aget a i) (aget b i))))) out))
+
+(defn- fd-diff
+  "Elementwise central-difference quotient (a − b)/2h as a float array —
+  the FD referee for array-valued directional derivatives / FD-of-grad."
+  ^floats [^floats a ^floats b ^double h]
+  (let [len (alength a) out (float-array len)]
+    (dotimes [i len] (aset out i (float (/ (- (aget a i) (aget b i)) (* 2.0 h)))))
+    out))
 
 (defn- fscale ^floats [^double c ^floats a]
   (let [len (alength a) out (float-array len)]
@@ -181,11 +190,30 @@
                      batch :- Long in :- Long out :- Long] :- (Array float)
   (nn/linear-nb x W batch in out))
 
-;; Class-(d) residue op (rms-norm: reverse template, NO structure tag / frule
-;; yet — §13 A3): jvp over it must FAIL LOUD naming the op.
+;; Class-(d) residue ops with HAND :jvp-fn frules (§13 A3 LANDED): rms-norm
+;; and layer-norm — array-valued outputs, tangents checked against
+;; elementwise directional FD in o1b.
 (deftm laws-jvp-rms [x :- (Array float) w :- (Array float)
                      rows :- Long feats :- Long] :- (Array float)
   (nn/rms-norm x w rows feats 1.0e-6 0.0))
+
+(deftm laws-jvp-ln [x :- (Array float) g :- (Array float) b :- (Array float)
+                    batch :- Long feats :- Long] :- (Array float)
+  (nn/layer-norm x g b batch feats 1.0e-6))
+
+;; Class-(d) residue op still PENDING after A3 (documented skip): maxpool2d
+;; has a reverse template but no :structure/:jvp-fn (its forward tangent
+;; needs a gather-at-argmax kernel) — jvp over it must FAIL LOUD naming the
+;; op, never silently drop a tangent.
+(deftm laws-jvp-maxpool [x :- (Array float) batch :- Long channels :- Long
+                         h :- Long w :- Long] :- (Array float)
+  (nn/maxpool2d x batch channels h w 2 2))
+
+;; SDPA (double kernels): the A3 attention frule (standard form
+;; dS = softmax-JVP(s·(dQ·Kᵀ + Q·dKᵀ)); dOut = dS·V + S·dV).
+(deftm laws-jvp-sdpa [Q :- (Array double) K :- (Array double) V :- (Array double)
+                      sq :- Long sk :- Long dk :- Long dv :- Long] :- (Array double)
+  (attn/scaled-dot-product-attn Q K V sq sk dk dv))
 
 ;; g(x) = <f(x), w> for O7 (w passed as a param array)
 (deftm laws-lnb-dotw [x :- (Array float) W :- (Array float) w :- (Array float)
@@ -375,13 +403,57 @@
         (is (close? tj (+ (double t1) (double t2) (double t3)) tol-float)
             "joint tangent = Σ single-seed tangents (linearity)"))))
 
-  (testing "unsupported forward forms fail LOUD naming the op (A3 pending)"
-    ;; rms-norm has a reverse template but sits in the class-(d) residue —
-    ;; no :structure tag, no :jvp-fn: the transform must throw, never drop
-    ;; a tangent silently.
+  (testing "rms-norm JVP (A3 hand frule): tangent = directional FD, x and w seeds"
+    (let [rows 3 feats 4
+          x (fa (* rows feats) 81) w (fa feats 82)
+          jf (jvp/jvp #'laws-jvp-rms)
+          zx (float-array (* rows feats)) zw (float-array feats)
+          h 1e-2 tol-fd 5e-3
+          run-fd (fn [slot v]
+                   (let [args [x w rows feats]
+                         shift (fn [s] (update args slot faxpy s v))
+                         y+ (apply laws-jvp-rms (shift h))
+                         y- (apply laws-jvp-rms (shift (- h)))]
+                     (fd-diff y+ y- h)))]
+      (is (farr-close? (nth (jf x w rows feats zx zw) 0)
+                       (laws-jvp-rms x w rows feats) tol-float)
+          "jvp primal = forward evaluation")
+      (let [v (fa (* rows feats) 83)
+            [_ t] (jf x w rows feats v zw)]
+        (is (farr-close? t (run-fd 0 v) tol-fd) "x-seeded rms tangent = FD"))
+      (let [v (fa feats 84)
+            [_ t] (jf x w rows feats zx v)]
+        (is (farr-close? t (run-fd 1 v) tol-fd) "w-seeded rms tangent = FD"))))
+
+  (testing "layer-norm JVP (A3 hand frule): tangent = directional FD, x/γ/β seeds"
+    (let [batch 3 feats 4
+          x (fa (* batch feats) 85) g (fa feats 86) b (fa feats 87)
+          jf (jvp/jvp #'laws-jvp-ln)
+          zx (float-array (* batch feats)) zf (float-array feats)
+          h 1e-2 tol-fd 5e-3
+          run-fd (fn [slot v]
+                   (let [args [x g b batch feats]
+                         shift (fn [s] (update args slot faxpy s v))
+                         y+ (apply laws-jvp-ln (shift h))
+                         y- (apply laws-jvp-ln (shift (- h)))]
+                     (fd-diff y+ y- h)))]
+      (let [v (fa (* batch feats) 88)
+            [_ t] (jf x g b batch feats v zf zf)]
+        (is (farr-close? t (run-fd 0 v) tol-fd) "x-seeded layer-norm tangent = FD"))
+      (let [v (fa feats 89)
+            [_ t] (jf x g b batch feats zx v zf)]
+        (is (farr-close? t (run-fd 1 v) tol-fd) "γ-seeded layer-norm tangent = FD"))
+      (let [v (fa feats 90)
+            [_ t] (jf x g b batch feats zx zf v)]
+        (is (farr-close? t (run-fd 2 v) tol-fd) "β-seeded layer-norm tangent = FD"))))
+
+  (testing "unsupported forward forms fail LOUD naming the op (A3 documented skip)"
+    ;; maxpool2d has a reverse template but stays in the class-(d) residue
+    ;; (forward tangent needs a gather-at-argmax kernel) — the transform must
+    ;; throw, never drop a tangent silently.
     (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo #"rms-norm.*§13 A3"
-         (jvp/jvp #'laws-jvp-rms)))))
+         clojure.lang.ExceptionInfo #"maxpool2d.*§13 A3"
+         (jvp/jvp #'laws-jvp-maxpool)))))
 
 ;; ================================================================
 ;; O3 — tangent-algebra laws: ⊕ accumulation, 0̄, ⊥ slots
@@ -566,6 +638,92 @@
       (is (close? (nth d 1) -1.0 1e-12) "cos(pi)")
       (is (close? (nth d 2) 0.0 1e-12) "-sin(pi)")
       (is (close? (nth d 3) 1.0 1e-12) "-cos(pi)"))))
+
+;; ================================================================
+;; O4b — HVP-through-layers (§13 A4): forward-over-reverse (jvp-fold over
+;; the reified gradient program, Pearlmutter 1994). FD-of-grad is the
+;; external referee: hvp(v) = (∇f(p+hv) − ∇f(p−hv))/2h.
+;; ================================================================
+
+(defn- daxpy-d ^doubles [^doubles a ^double h ^doubles v]
+  (let [len (alength a) out (double-array len)]
+    (dotimes [i len] (aset out i (+ (aget a i) (* h (aget v i))))) out))
+
+(defn- fd-diff-d ^doubles [^doubles a ^doubles b ^double h]
+  (let [len (alength a) out (double-array len)]
+    (dotimes [i len] (aset out i (/ (- (aget a i) (aget b i)) (* 2.0 h)))) out))
+
+(defn- darr-close? [^doubles a ^doubles b tol]
+  (and (= (alength a) (alength b))
+       (every? true? (map #(close? %1 %2 tol) a b))))
+
+(deftest o4b-hvp-through-layers-law
+  (testing "hvp (forward-over-reverse) subsumes the scalar case: exact quad Hessian"
+    (let [hf (jvp/hvp #'laws-quad)
+          [g hv1] (hf 3.0 2.0 1.0 0.0)
+          [_ hv2] (hf 3.0 2.0 0.0 1.0)]
+      (is (= [8.0 3.0] g) "gradient slots of the folded program = ∇f")
+      (is (= [2.0 1.0] hv1) "H·e1 exact")
+      (is (= [1.0 0.0] hv2) "H·e2 exact")))
+
+  (testing "MLP-style HVP: mse∘linear-nb (float), seeds on x and W vs FD-of-grad"
+    (let [batch 2 in 4 out 3
+          x (fa (* batch in) 91) W (fa (* out in) 92) tgt (fa (* batch out) 93)
+          zx (float-array (* batch in)) zW (float-array (* out in))
+          ztgt (float-array (* batch out))
+          hf (jvp/hvp #'laws-lnb-mse)
+          vg (rev/value+grad #'laws-lnb-mse)
+          grad-of (fn [x' W'] (let [r (vg x' W' tgt batch in out)]
+                                [(nth r 1) (nth r 2)]))
+          h 1e-2 tol-hvp 5e-3]
+      ;; the gradient slots of the hvp program = value+grad's gradients
+      (let [[g _] (hf x W tgt batch in out zx zW ztgt)
+            [gx gW] (grad-of x W)]
+        (is (farr-close? (nth g 0) gx tol-float) "hvp grad-x = value+grad")
+        (is (farr-close? (nth g 1) gW tol-float) "hvp grad-W = value+grad"))
+      ;; seed on x: H·v columns vs central FD of the gradient
+      (let [v (fa (* batch in) 94)
+            [_ hv] (hf x W tgt batch in out v zW ztgt)
+            [gx+ gW+] (grad-of (faxpy x h v) W)
+            [gx- gW-] (grad-of (faxpy x (- h) v) W)]
+        (is (farr-close? (nth hv 0) (fd-diff gx+ gx- h) tol-hvp)
+            "x-seed: tangent of ∇ₓf = FD-of-grad")
+        (is (farr-close? (nth hv 1) (fd-diff gW+ gW- h) tol-hvp)
+            "x-seed: tangent of ∇_W f = FD-of-grad (cross block)"))
+      ;; seed on W
+      (let [v (fa (* out in) 95)
+            [_ hv] (hf x W tgt batch in out zx v ztgt)
+            [gx+ gW+] (grad-of x (faxpy W h v))
+            [gx- gW-] (grad-of x (faxpy W (- h) v))]
+        (is (farr-close? (nth hv 0) (fd-diff gx+ gx- h) tol-hvp)
+            "W-seed: tangent of ∇ₓf = FD-of-grad (cross block)")
+        (is (farr-close? (nth hv 1) (fd-diff gW+ gW- h) tol-hvp)
+            "W-seed: tangent of ∇_W f = FD-of-grad")))))
+
+;; SDPA JVP law (A3 attention frule, double kernels): directional FD referee.
+(deftest o1b-sdpa-jvp-law
+  (testing "scaled-dot-product-attn: jvp tangent = directional FD per seeded slot"
+    (let [sq 3 sk 4 dk 5 dv 2
+          Q (da (* sq dk) 51) K (da (* sk dk) 52) V (da (* sk dv) 53)
+          jf (jvp/jvp #'laws-jvp-sdpa)
+          zQ (double-array (* sq dk)) zK (double-array (* sk dk))
+          zV (double-array (* sk dv))
+          h 1e-6 tol 1e-6
+          run-fd (fn [slot v]
+                   (let [args [Q K V sq sk dk dv]
+                         shift (fn [s] (update args slot daxpy-d s v))
+                         y+ (apply laws-jvp-sdpa (shift h))
+                         y- (apply laws-jvp-sdpa (shift (- h)))]
+                     (fd-diff-d y+ y- h)))]
+      (is (darr-close? (nth (jf Q K V sq sk dk dv zQ zK zV) 0)
+                       (laws-jvp-sdpa Q K V sq sk dk dv) 1e-12)
+          "jvp primal = forward evaluation")
+      (let [v (da (* sq dk) 54) [_ t] (jf Q K V sq sk dk dv v zK zV)]
+        (is (darr-close? t (run-fd 0 v) tol) "Q-seeded SDPA tangent = FD"))
+      (let [v (da (* sk dk) 55) [_ t] (jf Q K V sq sk dk dv zQ v zV)]
+        (is (darr-close? t (run-fd 1 v) tol) "K-seeded SDPA tangent = FD"))
+      (let [v (da (* sk dv) 56) [_ t] (jf Q K V sq sk dk dv zQ zK v)]
+        (is (darr-close? t (run-fd 2 v) tol) "V-seeded SDPA tangent = FD")))))
 
 ;; ================================================================
 ;; O5 — boundaries: unsupported forms throw (never silent), ⊥ never seeds,


### PR DESCRIPTION
Completes the array-forward arc (framework §13) on top of #42.

**A3 — hand `:jvp-fn` for the class-(d) residue**, all FD-validated to ~1e-10: rms-norm, layer-norm, group-norm, batch-norm (weight-direction JVPs are the *ops themselves* — norms are linear in γ/β), segment-div, and all three attention ops **including gqa-causal-mha** (standard form dS = softmax-JVP((dQKᵀ+QdKᵀ)/√d), dO = dS·V + S·dV, mirroring the backwards' per-head structure). Honestly skipped, fail-loud: solve/IFT-forward, maxpool2d (needs gather-at-argmax), einsum, dgemm!.

**A4 — HVP-through-layers** (`raster.ad.jvp/hvp` = jvp-fold over the ANF-normalized gradient program via `ad-prepare` → `reify-pullback`): MLP-float HVP vs FD-of-grad ≤9e-6; embedded gradients match `value+grad` **exactly**; scalar Hessian columns exact. Found+fixed a real fold bug: nested calls in arg position silently dropped tangent contributions until the gradient program is ANF-normalized. `compile-hvp-fn`'s two scalar-hardwired spots fixed (per-param array contraction via `par/dot-product`; param tags no longer stripped).

**RoR seed (#72)**: first backward kernels structure-tagged (linear-dx/dW bilinear, linear-db, daxpy-diff!, relu-backward, aclone). Deliberate soundness call: silu/gelu-backward **fail loud on x-tangents** rather than carrying a lossy "linear" tag — HVP through smooth activations needs the act″ second-order elementwise frule (part of #72), and a wrong tag would have silently miscomputed.

Laws: norm-JVP + SDPA-JVP laws added; `o4b-hvp-through-layers`; the fail-loud example moved (rms-norm now positive) to maxpool2d — moved, not weakened.

Valhalla fresh JVM (orchestrator-run): **1735 / 29021 / 0 / 0, census 0**.