### PR TITLE
AD: reverse-over-reverse closure (#72) — derived adjoint rrules, act″ kernels, reified-grad

### DIFF
--- a/src/raster/ad/jvp.clj
+++ b/src/raster/ad/jvp.clj
@@ -16,8 +16,11 @@
   resolve-deftm-var, grad-acc as the ⊕ kernel).
 
   Not yet supported (fail loud, forward loop rules are follow-up work):
-  par/map!, par/reduce, dotimes, loop — the differentiable loop forms have
-  reverse orchestrators but no forward fold yet."
+  par/map!, par/reduce, par/scan, dotimes, loop — the differentiable loop
+  forms have reverse orchestrators but no forward fold yet. (par/scan's JVP
+  is itself a scan over the linearized recurrence — δout[i] = ∂body/∂acc ·
+  δacc_{i-1} ⊕ Σ ∂body/∂free · δfree — a natural follow-up once the SOAC
+  forward-fold family lands as a group.)"
   (:require [raster.ad.reverse :as rev]
             [raster.ad.templates :as tmpl]
             [raster.ad.tangent :as tangent]
@@ -83,8 +86,8 @@
 (def ^:private unsupported-forward-heads
   "Differentiable-in-reverse forms with NO forward fold yet (follow-up):
   fail loud when they carry an active value, never silently drop a tangent."
-  '#{loop loop* dotimes raster.par/map! raster.par/reduce fn* do case case*
-     try letfn letfn* new monitor-enter monitor-exit})
+  '#{loop loop* dotimes raster.par/map! raster.par/reduce raster.par/scan
+     fn* do case case* try letfn letfn* new monitor-enter monitor-exit})
 
 (defn- fold-call
   "Emit the paired tangent bindings for one active :call binding.

--- a/src/raster/ad/reverse.clj
+++ b/src/raster/ad/reverse.clj
@@ -236,6 +236,7 @@
 (declare ^:private gen-reverse-dotimes)
 (declare ^:private gen-reverse-par-map)
 (declare ^:private gen-reverse-par-reduce)
+(declare ^:private gen-reverse-par-scan)
 
 (defn- init-active?
   "Decide whether a binding init carries gradient (is active), given the current
@@ -268,6 +269,12 @@
         (let [[_ _acc _init _idx _bound body] init-expr]
           (boolean (some #(get activity % false) (free-syms-excluding body #{_idx _acc}))))
 
+        (= 'raster.par/scan head)
+        (let [[_ _out _acc init _idx _bound _cast body] init-expr]
+          (boolean (some #(get activity % false)
+                         (into (free-syms-excluding body #{_idx _acc})
+                               (free-syms-excluding init #{})))))
+
         ;; Loop: active iff any init or body references an active symbol
         (contains? #{'loop 'loop*} head)
         (let [[_ bindings-vec & body-forms] init-expr
@@ -299,6 +306,7 @@
   (cond
     (and (seq? init-expr) (= 'raster.par/map!   (first init-expr))) :par-map
     (and (seq? init-expr) (= 'raster.par/reduce (first init-expr))) :par-reduce
+    (and (seq? init-expr) (= 'raster.par/scan   (first init-expr))) :par-scan
     (and (seq? init-expr) (= 'dotimes           (first init-expr))) :dotimes
     (not active?)                                                   :inactive
     (and (seq? init-expr) (= 'if (first init-expr)))                :if
@@ -340,7 +348,9 @@
 (defmethod ad-record :loop [_ sym _init-expr _activity]
   (throw (ex-info
           (str "Cannot differentiate through raw `loop` form bound to `" sym "`. "
-               "Use `par/reduce` for differentiable reductions, or wrap "
+               "Use `par/reduce` for differentiable reductions, `par/scan` for "
+               "differentiable recurrences (a chained carry whose per-step values "
+               "you keep — out[i] = acc_i is its own tape), or wrap "
                "the loop in a deftm with an AD template.")
           {:sym sym :form-head 'loop})))
 
@@ -370,6 +380,16 @@
                                  [pair-sym (:forward-code pr-info)
                                   tape-sym (list 'aget pair-sym 0)
                                   sym (list 'aget pair-sym 1)]))))}))
+
+(defmethod ad-record :par-scan [_ sym init-expr activity]
+  ;; NO :fwd-patch — this is the point of scan-as-recurrence: out[i] = acc_i,
+  ;; so THE OUTPUT ARRAY IS THE CARRY TAPE. The forward binding runs completely
+  ;; unpatched (the scan macro returns `out`, so `sym` IS the buffer), and the
+  ;; backward reconstructs every step's inputs from out[] — no closure tape,
+  ;; no ArrayList, no separate residual stack (Griewank store-the-carry
+  ;; checkpointing at every step; zero recompute depth).
+  (let [active-set (vec (keys (filter val activity)))]
+    {:record (assoc (gen-reverse-par-scan init-expr active-set) :sym sym)}))
 
 (defmethod ad-record :dotimes [_ sym init-expr activity]
   (let [active-set (vec (keys (filter val activity)))
@@ -565,6 +585,42 @@
     {:rev-ctx rev-ctx
      :adj-env (wire-read-adjoints adj-env read-arrs d-read-arr-syms active-free d-scalar-syms)}))
 
+(defmethod emit-backward :par-scan
+  [{:keys [sym written-arrs read-arrs active-free shadow-allocs backward-loop
+           d-out-sym n-bwd-sym bound-expr init-expr]}
+   _adj-sym activity {:keys [adj-env rev-ctx]}]
+  ;; out-as-tape: NO tape unpack — the forward scan ran unpatched; out[] holds
+  ;; every carry. The result sym aliases the out buffer, so sum consumer
+  ;; (adj-env[sym]) and direct buffer (adj-env[out-arr]) contributions
+  ;; (see :par-map) into d_out, the per-step δout[i] source.
+  (let [rev-ctx (bindings-into rev-ctx (vec shadow-allocs))
+        out-arr (first written-arrs)
+        contribs (concat (get adj-env sym) (get adj-env out-arr))
+        default (when (empty? contribs) (array-zero-of-shape out-arr))
+        rev-ctx (bindings-into rev-ctx [d-out-sym (sum-contribs contribs default)])
+        rev-ctx (bindings-into rev-ctx [n-bwd-sym bound-expr])
+        bwd-result-sym (ad-gensym "scan_bwd")
+        rev-ctx (bindings-into rev-ctx [bwd-result-sym backward-loop])
+        ;; backward-loop returns [d_read_arr_0 ... d_scalar_0 ... d_init-carry]
+        n-reads (count read-arrs)
+        n-scalars (count active-free)
+        adj-env (reduce (fn [ae [i arr]]
+                          (update ae arr (fnil conj []) (list 'nth bwd-result-sym i)))
+                        adj-env (map-indexed vector read-arrs))
+        adj-env (reduce (fn [ae [i p]]
+                          (update ae p (fnil conj [])
+                                  (list 'nth bwd-result-sym (clojure.core/+ n-reads i))))
+                        adj-env (map-indexed vector active-free))
+        ;; δinit: the carry cotangent remaining after step 0 is ∂loss/∂init —
+        ;; wire it to the init symbol when it is active (h0-style learnable
+        ;; initial states). Compound active inits are rejected loudly at
+        ;; record-construction time (gen-reverse-par-scan).
+        adj-env (if (and (symbol? init-expr) (get activity init-expr false))
+                  (update adj-env init-expr (fnil conj [])
+                          (list 'nth bwd-result-sym (clojure.core/+ n-reads n-scalars)))
+                  adj-env)]
+    {:adj-env adj-env :rev-ctx rev-ctx}))
+
 (defmethod emit-backward :dotimes
   [{:keys [sym written-arrs read-arrs active-free shadow-allocs backward-loop
            d-out-sym n-bwd-sym bound-expr]}
@@ -596,7 +652,7 @@
   [records activity seed-adj-env]
   (reduce
    (fn [{:keys [adj-env rev-ctx]} {:keys [type sym] :as record}]
-     (let [array-type? (contains? #{:dotimes :par-map :par-reduce} type)
+     (let [array-type? (contains? #{:dotimes :par-map :par-reduce :par-scan} type)
            adj-contribs (when-not array-type? (get adj-env sym))
            adj-sym (when-not array-type?
                      (ad-gensym (str "d_" (name sym)) (:raster.type/tag (meta sym))))
@@ -1928,6 +1984,182 @@
      :result-pair-sym result-pair-sym}))
 
 ;; ================================================================
+;; Par scan reverse-mode AD — the differentiable RECURRENCE primitive
+;; ================================================================
+
+(defn- gen-reverse-par-scan
+  "Generate reverse-mode AD code for a raster.par/scan form — the sanctioned
+  differentiable recurrence (the carry chains across steps AND every per-step
+  value is kept).
+
+  Forward form: (raster.par/scan out acc init idx bound cast body)
+    acc = init; for idx in 0..bound: acc = body; out[idx] = acc; return out.
+
+  KEY INSIGHT (out-as-tape): out[i] = acc_i, so THE OUTPUT ARRAY IS THE CARRY
+  TAPE — no closure tape, no ArrayList, no separate residual stack. This is
+  Griewank's store-the-carry checkpointing at EVERY step (zero recompute
+  depth): the forward binding runs completely unpatched, and the backward
+  reconstructs step i's body inputs from the tape — acc_{i-1} = out[i-1]
+  (init for i=0) — plus the original array reads at the scan index.
+  Body-internal values re-derive from the carry (recompute-from-carry; cheap
+  for scalar-carry bodies). Flat-buffer/GPU-ready by construction.
+
+  Backward: one reversed loop, i from bound-1 downto 0, threading the running
+  carry cotangent δacc:
+    total_i = δout[i] ⊕ δacc          (the out[i] store + step i+1's body)
+    grads   = pullback_i(total_i)      (pullback evaluated at acc_{i-1}, x[i])
+    δacc    = grads[∂body/∂acc]        (chains to step i-1)
+    d_x[·] ⊕= grads[∂body/∂aget_r]     (scatter-ADD at each read's index)
+    d_w_s  ⊕= grads[∂body/∂w_s]        (accumulate across steps, loop-carried)
+  The carry remaining after step 0 is δinit.
+
+  Cast note: the forward chains the UNCAST acc while out stores cast(acc);
+  reconstruction reads the stored value — exact identity for the `double`
+  cast, standard checkpoint rounding for narrowing casts (float).
+
+  Returns a record map for the reverse-pass engine (emit-backward :par-scan)."
+  [par-scan-form active-params]
+  (let [[_ out-sym acc-sym init-expr idx-sym bound-expr _cast-fn body-expr] par-scan-form
+        ;; Same body analysis as par/map!: let*-bound agets + inline agets at
+        ;; the scan index join the scatter path. acc-sym lands in :free-syms
+        ;; but is never an active param, so it cannot leak into active-free.
+        {:keys [agets scalar-bindings body-result free-syms]}
+        (analyze-par-map-body body-expr idx-sym)
+
+        read-arrs (vec (distinct (map :arr agets)))
+        active-free (filterv (fn [p] (contains? free-syms p)) active-params)
+
+        ;; Fail loud: an ACTIVE array referenced outside the recognized aget
+        ;; reads would be mis-treated as a free SCALAR (mis-shaped gradient —
+        ;; the par/map `No promotion rule` class of bug). Never miscompile.
+        _ (doseq [p active-free]
+            (when (= :array (:kind (tangent/tangent-kind (:raster.type/tag (meta p)))))
+              (throw (ex-info
+                      (str "par/scan AD: active array `" p "` is referenced in the "
+                           "scan body outside an `(aget " p " <idx>)` read. Only "
+                           "aget reads have a scatter gradient path — bind the "
+                           "needed element to a let sym inside the body.")
+                      {:array p :body body-expr}))))
+        ;; Fail loud: a compound init that DEPENDS on active params would
+        ;; reconstruct the value correctly but silently drop δinit (the final
+        ;; carry only wires to a SYMBOL). Bind it outside the scan first.
+        _ (when (and (seq? init-expr)
+                     (some (set active-params) (free-syms-excluding init-expr #{})))
+            (throw (ex-info
+                    (str "par/scan AD: the scan init `" (pr-str init-expr)
+                         "` depends on active params. Bind it to a let symbol "
+                         "before the scan so its gradient (δinit, the final "
+                         "carry cotangent) has a symbol to flow to.")
+                    {:init init-expr})))
+
+        aget-syms (mapv :sym agets)
+        ;; Pullback grads layout: [∂body/∂acc, ∂body/∂aget..., ∂body/∂free...]
+        iter-active (vec (distinct (concat [acc-sym] aget-syms active-free)))
+
+        pure-scalar-bindings (vec (mapcat identity
+                                          (remove (fn [[sym _]]
+                                                    (contains? (set aget-syms) sym))
+                                                  scalar-bindings)))
+
+        ;; Per-step scalar transform (primal recompute + pullback closure) —
+        ;; evaluated in the BACKWARD loop at the reconstructed inputs. This is
+        ;; recompute-from-carry: no forward-time tape stores it.
+        val-result-sym (ad-gensym "val")
+        scalar-transform
+        (let [binds (if (seq pure-scalar-bindings)
+                      (vec (concat pure-scalar-bindings [val-result-sym body-result]))
+                      [val-result-sym body-result])]
+          (gen-reverse-let binds [val-result-sym] iter-active))
+
+        ;; === Backward code ===
+        out-array-tag (or (some-> out-sym meta :raster.type/tag) 'doubles)
+        d-out-sym (ad-gensym "d_out" out-array-tag)
+        d-read-arr-syms (mapv (fn [arr]
+                                (ad-gensym (str "d_" (name arr))
+                                           (or (:raster.type/tag (meta arr)) 'doubles)))
+                              read-arrs)
+        arr->d-sym (zipmap read-arrs d-read-arr-syms)
+        d-scalar-syms (mapv (fn [p] (ad-gensym (str "d_" (name p) "_acc"))) active-free)
+        n-bwd-sym (ad-gensym "n_bwd")
+        d-carry-sym (ad-gensym "d_carry")
+        vpb-sym (ad-gensym "vpb")
+        pb-sym (ad-gensym "pb")
+        grads-sym (ad-gensym "grads")
+        total-sym (ad-gensym "d_total")
+        n-agets (count agets)
+
+        shadow-allocs (vec (mapcat (fn [d-arr-sym arr-sym]
+                                     [d-arr-sym (list 'raster.arrays/zeros-like arr-sym
+                                                      (list 'clojure.core/alength arr-sym))])
+                                   d-read-arr-syms read-arrs))
+
+        ;; Step-i reconstruction + pullback. The backward loop counter IS
+        ;; idx-sym, so any body sub-expression that still references the scan
+        ;; index (index arithmetic, non-lifted reads) sees the right value.
+        bwd-body-bindings
+        (vec (concat
+              ;; acc_{i-1} from the carry tape: out[i-1], init at i=0.
+              [acc-sym (list 'if (list 'clojure.core/== idx-sym 0)
+                             init-expr
+                             (list 'aget out-sym (list 'clojure.core/- idx-sym 1)))]
+              ;; Re-bind the body's array reads at their ORIGINAL indices.
+              (mapcat (fn [{:keys [sym arr idx]}] [sym (list 'aget arr idx)]) agets)
+              [total-sym (list 'raster.ad.reverse/grad-acc
+                               (list 'aget d-out-sym idx-sym) d-carry-sym)
+               vpb-sym scalar-transform
+               pb-sym (list 'nth vpb-sym 1)
+               grads-sym (list pb-sym total-sym)]
+              ;; Scatter-ADD each read's cotangent at the read's own index
+              ;; (read-modify-write: correct for repeated reads of one array
+              ;; and for shifted indices like (aget x (- idx 1))).
+              (mapcat (fn [k {:keys [arr idx]}]
+                        (let [d-arr (arr->d-sym arr)]
+                          [(ad-gensym "_scatter")
+                           (list 'aset d-arr idx
+                                 (list 'raster.ad.reverse/grad-acc
+                                       (list 'aget d-arr idx)
+                                       (list 'nth grads-sym (clojure.core/+ 1 k))))]))
+                      (range) agets)))
+
+        bwd-recur-args
+        (list* (list 'clojure.core/- idx-sym 1)
+               ;; the carry cotangent chains: δacc_{i-1} = grads[∂body/∂acc]
+               (list 'nth grads-sym 0)
+               (map-indexed (fn [i d-s]
+                              (list 'raster.ad.reverse/grad-acc d-s
+                                    (list 'nth grads-sym
+                                          (clojure.core/+ 1 n-agets i))))
+                            d-scalar-syms))
+
+        bwd-loop-init
+        (vec (concat [idx-sym (list 'clojure.core/- n-bwd-sym 1)
+                      d-carry-sym 0.0]
+                     (mapcat (fn [s] [s nil]) d-scalar-syms)))
+
+        ;; Loop value: [d_read_arr_0 ... d_scalar_0 ... d_init-carry]
+        bwd-return (conj (vec (concat d-read-arr-syms d-scalar-syms)) d-carry-sym)
+
+        backward-loop
+        (list 'loop* bwd-loop-init
+              (list 'if (list 'clojure.core/>= idx-sym 0)
+                    (list 'let* bwd-body-bindings (cons 'recur bwd-recur-args))
+                    bwd-return))]
+
+    {:type :par-scan
+     ;; no :forward-code / :tape-sym — the forward binding IS the tape build.
+     :written-arrs [out-sym]
+     :read-arrs read-arrs
+     :d-read-arr-syms d-read-arr-syms
+     :d-scalar-syms d-scalar-syms
+     :active-free active-free
+     :shadow-allocs shadow-allocs
+     :backward-loop backward-loop
+     :d-out-sym d-out-sym
+     :n-bwd-sym n-bwd-sym
+     :bound-expr bound-expr
+     :init-expr init-expr}))
+
+;; ================================================================
 ;; Top-level transform
 ;; ================================================================
 
@@ -2721,8 +2953,14 @@
           hoisted-body (map hoist-nested-lets body)]
       (apply list let-sym flat-bindings hoisted-body))
 
-    ;; Scope-introducing forms — recurse but don't hoist across scope boundaries
-    (and (seq? form) (contains? #{'if 'loop 'loop* 'fn* 'do 'when 'recur 'dotimes} (first form)))
+    ;; Scope-introducing forms — recurse but don't hoist across scope boundaries.
+    ;; This includes every par/* SOAC (form/introduces-scope?): their bodies
+    ;; close over the loop index/accumulator, so splicing a body let* out into
+    ;; the wrapping let would free those scoped vars (unresolvable `i` after
+    ;; alpha-conversion) — and the SOAC reverse analyzers expect the body's
+    ;; let*-bound agets IN PLACE (analyze-par-map-body).
+    (and (seq? form) (or (contains? #{'if 'loop 'loop* 'fn* 'do 'when 'recur 'dotimes} (first form))
+                         (form/introduces-scope? form)))
     (with-meta (apply list (first form) (map hoist-nested-lets (rest form))) (meta form))
 
     ;; Function call — check for let expressions in arguments
@@ -3109,9 +3347,11 @@
                        (str "value+grad: cannot assemble a runtime gradient for `"
                             f-var "` — the body reduces to a loop form the runtime "
                             "flattener does not support. Express the reduction via "
-                            "`par/reduce` or a registered op (e.g. a loss deftm with "
-                            "an AD template), or use the compiled path (compile-aot "
-                            "of a deftm calling value+grad).")
+                            "`par/reduce`, the recurrence via `par/scan` (the "
+                            "sanctioned differentiable recurrence — out[i] = acc_i "
+                            "is its own tape), or a registered op (e.g. a loss deftm "
+                            "with an AD template), or use the compiled path "
+                            "(compile-aot of a deftm calling value+grad).")
                        {:var f-var :reason :flatten-failed})))
            {:keys [walked-body params tags source-ns]} bgw
            runtime-fn (make-runtime-value+grad-fn walked-body params)

--- a/src/raster/ad/reverse.clj
+++ b/src/raster/ad/reverse.clj
@@ -2829,6 +2829,29 @@
                    (throw (ex-info "grad requires a deftm var" {:var f-var})))
         walked-body (or (rcore/ensure-walked-body! resolved)
                         (throw (ex-info "No walked body on var" {:var f-var})))
+        ;; TUPLE-VALUED OUTPUT GUARD (#74, framework §14): grad/value+grad is
+        ;; only defined for SCALAR-valued functions — a vector tail (e.g. the
+        ;; [primal grads...] of a value+grad result, or a tuple-returning
+        ;; deftm) has a PRODUCT cotangent space with no canonical seed, and
+        ;; the reverse fold would silently return zero gradients. Fail loud.
+        ;; The transparent-composition idiom is to USE the components in a
+        ;; scalar program: (let [vg ((value+grad #'f) x)] ...scalar of (nth vg i)...).
+        _ (let [wb-form (first walked-body)
+                tail (if (and (seq? wb-form)
+                              (contains? #{'let 'let*} (first wb-form)))
+                       (last wb-form)
+                       wb-form)]
+            (when (vector? tail)
+              (throw (ex-info
+                      (str "Cannot differentiate the tuple-valued function `" f-var
+                           "` — its output is a vector, which has no canonical "
+                           "cotangent seed (this is what value+grad returns; "
+                           "value+grad of value+grad is ill-typed). Compose "
+                           "transparently instead: call the inner gradient in a "
+                           "scalar deftm and differentiate that, e.g. "
+                           "(let [vg ((value+grad #'f) x)] ...scalar use of (nth vg i)...). "
+                           "For 1-param scalar fns, (grad (grad f)) composes directly.")
+                      {:var f-var :tail-shape :vector :reason :tuple-valued-output}))))
         tags (or (:raster.core/deftm-tags m) (vec (repeat (count params) 'double)))
         all-params (vec (map-indexed
                          (fn [i p]
@@ -3184,14 +3207,21 @@
 (defn grad
   "Composable gradient operator.
 
-  (grad f) returns a function that computes [grad1, ..., gradN].
-  Like value+grad but drops the primal value.
+  (grad f) returns a function that computes [grad1, ..., gradN] — or, for a
+  SINGLE-param scalar function, the bare scalar derivative g (JAX semantics).
+  The 1-param scalar tail is what makes the textbook composition
+  (grad (grad f)) = f'' well-typed: grad of f : R -> R IS f' : R -> R, so it
+  can be differentiated again directly (framework §14). Multi-param grads
+  remain vector-valued; re-differentiating those requires using the components
+  in a scalar program (the transparent-composition idiom).
 
   Options:
     :mode  - :reverse (default), :forward, or :auto
 
   Usage:
-    ((grad #'my-loss) 3.0 4.0)  ;; => [6.0 8.0]"
+    ((grad #'my-loss) 3.0 4.0)   ;; => [6.0 8.0]
+    ((grad #'square) 3.0)        ;; => 6.0        (1-param: bare scalar)
+    ((grad (grad #'cube)) 2.0)   ;; => 12.0       (f'' composes directly)"
   ([f-var] (grad f-var :mode :reverse))
   ([f-var & {:keys [mode] :or {mode :reverse}}]
    (let [vg-fn (value+grad f-var :mode mode)
@@ -3200,15 +3230,19 @@
      (if-let [wb (:raster.core/deftm-walked-body vg-meta)]
        (let [params (:raster.core/deftm-params vg-meta)
              tags (:raster.core/deftm-tags vg-meta)
-             ;; Rewrite walked body: [primal g1 g2 ...] → [g1 g2 ...]
+             ;; Rewrite walked body: [primal g1 g2 ...] → [g1 g2 ...], and for
+             ;; the 1-param case → the bare scalar g1 (scalar tail: composable).
              grad-wb (mapv (fn [form]
                              (if (and (seq? form) (#{'let 'let*} (first form)))
                                (let [[let-sym bindings & body-exprs] form
                                      last-body (last body-exprs)]
                                  (if (vector? last-body)
-                                   (list* let-sym bindings
-                                          (concat (butlast body-exprs)
-                                                  [(vec (rest last-body))]))
+                                   (let [grads (vec (rest last-body))
+                                         tail (if (= 1 (count grads))
+                                                (first grads)
+                                                grads)]
+                                     (list* let-sym bindings
+                                            (concat (butlast body-exprs) [tail])))
                                    form))
                                form))
                            wb)

--- a/src/raster/ad/reverse.clj
+++ b/src/raster/ad/reverse.clj
@@ -2365,6 +2365,121 @@
      :pullback pullback
      :reified reified}))
 
+;; ================================================================
+;; Reified gradient program as a first-class deftm-style fn (#72)
+;; ================================================================
+
+(declare ^:private make-runtime-value+grad-fn)
+
+(defonce ^:private ror-rename-counter (atom 0))
+
+(defn- alpha-rename-bound
+  "α-rename every let*-bound symbol in a FLAT binding vector to a globally
+  unique name (\"__gp<N>\" suffix, monotonic defonce counter), preserving
+  each binding sym's :raster.type/tag on all occurrences.
+
+  Why: a reified gradient program FREEZES symbols minted under one
+  `with-ad-gensym` scope (counter starts at 0). A LATER AD pass over the
+  frozen program starts a fresh counter, and its ANF lifts mint the same
+  names — silently REBINDING inner syms mid-program (e.g. a float[] anf__2
+  rebound to a Double ANF temp → ClassCastException, or worse a silent
+  wrong gradient). Globally-unique renames make the frozen program safe to
+  re-enter with any gensym state."
+  [bindings tail]
+  (let [bound (vec (take-nth 2 bindings))
+        smap (into {}
+                   (map (fn [s]
+                          [s (with-meta
+                               (symbol (str (name s) "__gp" (swap! ror-rename-counter inc)))
+                               (meta s))]))
+                   bound)
+        rename (fn [form] (walk/postwalk-replace smap form))]
+    [(vec (mapcat (fn [[s init]] [(get smap s s) (rename init)])
+                  (partition 2 bindings)))
+     (rename tail)]))
+
+(defn ^clojure.lang.IFn reified-grad
+  "Reify ∂f/∂param of a scalar deftm as a deftm-style meta-fn — the
+  double-backward (reverse-over-reverse) composition surface (#72).
+
+  The result's walked body IS the flat gradient program (reify-pullback
+  assembled with the unit adjoint, as hvp does), so `value+grad` of the
+  result differentiates THROUGH the gradient computation — grad-of-grad,
+  L2(∇f) regularization, MAML-class meta-objectives — using the backward
+  kernels' own derived reverse rules (raster.ad.templates op-adjoints).
+
+  param: symbol naming one differentiable param of f.
+  - SCALAR param p → (fn [args…] -> ∂f/∂p), a scalar-valued program.
+  - ARRAY  param p → (fn [args… c] -> ⟨∂f/∂p, c⟩) with a cotangent array
+    `c` appended after f's params (value+grad w.r.t. an array-valued
+    gradient needs a scalar contraction; ∇ₓ⟨∇ₓf, c⟩ = Hₓₓ·c).
+
+  NOTE value+grad-of-value+grad does NOT compose: value+grad's walked body
+  ends in the VECTOR [primal grads…]; seeding a vector-valued tail silently
+  yields zero gradients. This assembly (scalar tail) is the shape that
+  composes."
+  [f-var param]
+  (let [resolved (resolve-deftm-var f-var)
+        m (meta resolved)
+        params (or (:raster.core/deftm-params m)
+                   (throw (ex-info "reified-grad requires a deftm var" {:var f-var})))
+        walked-body (or (rcore/ensure-walked-body! resolved)
+                        (throw (ex-info "No walked body on var" {:var f-var})))
+        tags (or (:raster.core/deftm-tags m) (vec (repeat (count params) 'double)))
+        all-params (vec (map-indexed
+                         (fn [i p]
+                           (let [base (if (symbol? p) p (symbol (name p)))
+                                 tag (nth tags i nil)]
+                             (if tag
+                               (with-meta base {:raster.type/tag tag})
+                               (with-meta base nil))))
+                         params))
+        diff-params (vec (filter #(differentiable-tag? (:raster.type/tag (meta %)))
+                                 all-params))
+        param-sym (symbol (name param))
+        slot-idx (or (first (keep-indexed
+                             (fn [i p] (when (= p param-sym) i)) diff-params))
+                     (throw (ex-info (str "reified-grad: `" param "` is not a "
+                                          "differentiable param of " f-var)
+                                     {:param param :diff-params diff-params})))
+        param-tag (:raster.type/tag (meta (nth diff-params slot-idx)))
+        array-param? (= :array (:kind (tangent/tangent-kind param-tag)))
+        ;; The gradient program, assembled exactly as hvp does.
+        prepared (ad-prepare (first walked-body))
+        {:keys [fwd-bindings result-sym body-sym pullback-form]}
+        (reify-pullback prepared diff-params)
+        [_ rev-bindings grad-slots] pullback-form
+        grad-slot (nth (vec grad-slots) slot-idx)
+        c-sym (when array-param?
+                (with-meta (symbol (str "c__ror" (swap! ror-rename-counter inc)))
+                  {:raster.type/tag param-tag}))
+        tail-bindings (if array-param?
+                        [(symbol (str "gdot__ror" (swap! ror-rename-counter inc)))
+                         (list 'raster.par/dot-product grad-slot c-sym)]
+                        [])
+        tail (if array-param? (first tail-bindings) grad-slot)
+        bindings (vec (concat fwd-bindings
+                              [result-sym body-sym]
+                              ['dy__rad 1.0]
+                              rev-bindings
+                              tail-bindings))
+        ;; α-rename: the frozen program must survive a fresh-countered
+        ;; second AD pass (see alpha-rename-bound).
+        [bindings' tail'] (alpha-rename-bound bindings tail)
+        form (list 'let* bindings' tail')
+        fn-params (cond-> all-params array-param? (conj c-sym))
+        source-ns (or (:ns m) *ns*)
+        qualified (inf/qualify-body-symbols form source-ns (set fn-params))
+        runtime-fn (make-runtime-value+grad-fn [qualified] fn-params)
+        out-tags (cond-> (vec (take (count params) (concat tags (repeat nil))))
+                   array-param? (conj param-tag))]
+    (with-meta (fn [& args] (apply runtime-fn args))
+      {::reified-grad true
+       :raster.core/deftm true
+       :raster.core/deftm-walked-body [qualified]
+       :raster.core/deftm-params fn-params
+       :raster.core/deftm-tags out-tags})))
+
 (defn compile-hvp-fn
   "Compile a Hessian-vector product function for a scalar deftm var.
 

--- a/src/raster/ad/templates.clj
+++ b/src/raster/ad/templates.clj
@@ -659,6 +659,19 @@
                     {:params '[arr] :result nil :adjoint 'dy
                      :grads '[nil]})
 
+;; Polymorphic spelling: gradient programs reference arrays through
+;; raster.arrays (shape reads on active arrays are shape REFERENCES, not
+;; differentiable dependence — the RoR path hits these on the typed-zero
+;; adjoint slots the reverse pass itself emits, #72).
+(register-template! 'raster.arrays/alength (get-template 'clojure.core/alength))
+
+;; zeros-like: a fresh zero buffer — the exemplar arg only supplies
+;; dtype/shape, no differentiable dependence (aclone, the COPY, has a real
+;; :linear rule below).
+(register-template! 'raster.arrays/zeros-like
+                    {:params '[ref n] :result nil :adjoint 'dy
+                     :grads '[nil nil]})
+
 ;; aset: arr[i] = v → no gradient through aset itself (mutation side-effect).
 ;; The gradient for mutation flows through the stored value's downstream reads.
 (register-template! 'clojure.core/aset
@@ -1134,6 +1147,9 @@
    'raster.dl.nn/linear-dW  {:class :bilinear :args [0 1]} ;; [dy x batch in-f out-f]
    'raster.dl.nn/linear-db  {:class :linear :in #{0}}      ;; [dy batch out-f]
    'raster.nn/relu-backward {:class :linear :in #{0}}      ;; [dy x]
+   ;; contraction kernels appearing in gradient programs (#72): ⟨a,b⟩ and α·x
+   'raster.par/dot-product  {:class :bilinear :args [0 1]} ;; [a b] → Double
+   'raster.par/scale        {:class :bilinear :args [0 1]} ;; [alpha x] → α·x
    ;; --- scalar primitives: frule = Σᵢ grads(dy:=Δxᵢ) (mechanical, §2) ---
    '+          {:class :elementwise :in #{0 1}}
    '-          {:class :elementwise :in #{0 1}}
@@ -1406,23 +1422,191 @@
         (sum-tangent-contribs ctx terms gensym-fn))))})
 
 ;; silu/gelu-backward (dy, x, n) → dy⊙act′(x): LINEAR in dy (that term is the
-;; kernel itself on the dy-tangent); the x-slot derivative is dy⊙act″(x)⊙dx —
-;; a GENUINE second-order elementwise rule that does not exist yet (#72).
-;; Fail LOUD if an x-tangent flows in — never silently drop it (unlike relu,
-;; whose act″ is 0 a.e., these have smooth nonzero act″).
-(doseq [op ['raster.dl.nn/silu-backward 'raster.dl.nn/gelu-backward]]
+;; kernel itself on the dy-tangent); the x-direction is the SECOND-ORDER
+;; elementwise rule (#72, act″ LANDED): d/dx[dy⊙act′(x)]·Δx = dy⊙act″(x)⊙Δx,
+;; with act″ the closed-form silu/gelu-second-deriv kernels (FD-validated
+;; against the backward kernels in the o4c double-backward law). The 3-way
+;; elementwise product is spelled as two hadamards (both RoR-closed).
+(doseq [[op dd-op] {'raster.dl.nn/silu-backward 'raster.dl.nn/silu-second-deriv
+                    'raster.dl.nn/gelu-backward 'raster.dl.nn/gelu-second-deriv}]
   (merge-into-template!
    op
    {:jvp-fn
-    (let [op op]
-      (fn [ctx [_dy x n] tangent-args _result-sym gensym-fn]
-        (when (nth tangent-args 1 nil)
-          (throw (ex-info (str "jvp: `" op "` received a tangent on its x slot — "
-                               "the second-order elementwise frule (act″) is not "
-                               "implemented yet (§13 A4 / #72 pending). Only the "
-                               "dy slot is linear.")
-                          {:op op})))
-        (let [t-dy (or (nth tangent-args 0 nil)
-                       (throw (ex-info (str "jvp: no active tangent reached " op)
-                                       {:op op})))]
-          (bind-jvp-term ctx gensym-fn "jactb" (list op t-dy x n)))))}))
+    (let [op op dd-op dd-op]
+      (fn [ctx [dy x n] tangent-args _result-sym gensym-fn]
+        (let [t-dy (nth tangent-args 0 nil)
+              t-x  (nth tangent-args 1 nil)]
+          (when-not (or t-dy t-x)
+            (throw (ex-info (str "jvp: no active tangent reached " op) {:op op})))
+          (let [[ctx terms]
+                (if t-dy
+                  (let [[ctx' s] (bind-jvp-term ctx gensym-fn "jactb_dy"
+                                                (list op t-dy x n))]
+                    [ctx' [s]])
+                  [ctx []])
+                [ctx terms]
+                (if t-x
+                  ;; dy⊙act″(x)⊙Δx
+                  (let [[ctx' dd] (bind-jvp-term ctx gensym-fn "jactb_dd"
+                                                 (list dd-op x n))
+                        [ctx'' s] (bind-jvp-term ctx' gensym-fn "jactb_x"
+                                                 (list 'raster.dl.nn/hadamard
+                                                       (list 'raster.dl.nn/hadamard dy t-x n)
+                                                       dd n))]
+                    [ctx'' (conj terms s)])
+                  [ctx terms])]
+            (sum-tangent-contribs ctx terms gensym-fn)))))}))
+
+;; ================================================================
+;; #72 — RoR closure, reverse side: DERIVED reverse rules for the backward
+;; kernels themselves (double backward / grad-of-grad / MAML-class shapes).
+;;
+;; The kernels emitted by first-order grads-fns are linear (or bilinear) maps,
+;; so their own rrules are mechanically derivable from the same :structure
+;; tags: the adjoint of a linear op is its TRANSPOSE, spelled with EXISTING
+;; kernels. The :adjoint facet is that spelling — {arg-idx (fn [call-args
+;; adjoint-sym] expr)}, one cotangent expression per differentiable slot —
+;; and derive-rrule-from-structure turns it into a standard :grads-fn.
+;; ================================================================
+
+(defn- derive-rrule-from-structure
+  "Synthesize the :grads-fn facet for a :structure-tagged op from its
+  :adjoint facet (#72 RoR closure). Sound because for :linear/:bilinear ops
+  each partial Jacobian is CONSTANT in the differentiated slot: d_argᵢ =
+  adjointᵢ(cotangent) with the other args as frozen coefficients (bilinear
+  gives two different partial adjoints, both spelled with existing kernels).
+  Slots without an :adjoint entry are ⊥ (nil grad). Returns a standard
+  grads-fn (BindCtx convention, one flat binding per adjoint expression)."
+  [_canonical-op adjoint-map]
+  (fn [ctx actual-params _result-sym adjoint-sym gensym-fn]
+    (let [args (vec actual-params)
+          [ctx grads]
+          (reduce
+           (fn [[ctx grads] i]
+             (if-let [adj-f (get adjoint-map i)]
+               (let [g (gensym-fn (str "dadj_" i))]
+                 [(update ctx :bindings into [g (adj-f args adjoint-sym)])
+                  (conj grads g)])
+               [ctx (conj grads nil)]))
+           [ctx []] (range (count args)))]
+      [ctx grads])))
+
+(def ^:private op-adjoints
+  "#72: per-slot adjoint spellings for structure-tagged kernels WITHOUT a
+  reverse rule of their own. Each entry is {arg-idx (fn [args c] expr)} with
+  c the incoming cotangent. The math, per kernel (shapes cited):
+
+  linear-dx(dy,W,b,i,o) = dy@W          dy:[B,out] W:[out,in] → [B,in]
+    ⟨c, dy@W⟩ with c:[B,in]:
+    d_dy[b,o] = Σᵢ c[b,i]·W[o,i] = (c@Wᵀ)[b,o]  = linear-nb(c, W, B, in, out)
+    d_W[o,i]  = Σ_b dy[b,o]·c[b,i] = (dyᵀ@c)[o,i] = linear-dW(dy, c, B, in, out)
+
+  linear-dW(dy,x,b,i,o) = dyᵀ@x         dy:[B,out] x:[B,in] → [out,in]
+    ⟨c, dyᵀ@x⟩ with c:[out,in]:
+    d_dy[b,o] = Σᵢ c[o,i]·x[b,i] = (x@cᵀ)[b,o]  = linear-nb(x, c, B, in, out)
+    d_x[b,i]  = Σ_o dy[b,o]·c[o,i] = (dy@c)[b,i] = linear-dx(dy, c, B, in, out)
+    ({linear-nb, linear-dx, linear-dW} is CLOSED under partial adjoints.)
+
+  linear-db(dy,b,o) = colsum(dy)        dy:[B,out] → [out]
+    adjoint of colsum = tile c:[out] across the B rows
+    = ones[B,1] @ c[1,out] = matmul(fill(zeros[B],1), c, B, 1, out)
+
+  relu-backward(dy,x) = dy⊙1[x>0]: diagonal 0/1 mask = its own transpose →
+    d_dy = relu-backward(c, x); d_x = 0 a.e. (relu″, same kink convention)
+
+  silu/gelu-backward(dy,x,n) = dy⊙act′(x):
+    d_dy = c⊙act′(x) = the kernel itself on c (diagonal, self-adjoint)
+    d_x  = c⊙dy⊙act″(x) — hadamard twice with the act″ kernel (#72)
+
+  daxpy-diff!(a,b,scale,n) = scale·(a−b):
+    d_a = scale·c      = daxpy-diff!(c, 0ⁿ, scale, n)
+    d_b = −scale·c     = daxpy-diff!(0ⁿ, c, scale, n)
+    d_scale = ⟨c, a−b⟩ = dot-product(c, daxpy-diff!(a, b, 1.0, n))
+
+  dot-product(a,b) = ⟨a,b⟩ (scalar out, c is a scalar):
+    d_a = c·b = scale(c, b);  d_b = c·a = scale(c, a)
+
+  scale(α,x) = α·x:
+    d_α = ⟨c,x⟩ = dot-product(c, x);  d_x = α·c = scale(α, c)
+
+  aclone(arr): identity copy → d_arr = aclone(c) (fresh copy so downstream
+    accumulation can never alias the incoming cotangent)."
+  {'raster.dl.nn/linear-dx
+   {0 (fn [[_dy W batch in-f out-f] c]
+        (list 'raster.dl.nn/linear-nb c W batch in-f out-f))
+    1 (fn [[dy _W batch in-f out-f] c]
+        (list 'raster.dl.nn/linear-dW dy c batch in-f out-f))}
+
+   'raster.dl.nn/linear-dW
+   {0 (fn [[_dy x batch in-f out-f] c]
+        (list 'raster.dl.nn/linear-nb x c batch in-f out-f))
+    1 (fn [[dy _x batch in-f out-f] c]
+        (list 'raster.dl.nn/linear-dx dy c batch in-f out-f))}
+
+   'raster.dl.nn/linear-db
+   {0 (fn [[_dy batch out-f] c]
+        (list 'raster.dl.nn/matmul
+              (list 'raster.par/fill (list 'raster.arrays/zeros-like c batch) 1.0)
+              c batch 1 out-f))}
+
+   'raster.nn/relu-backward
+   {0 (fn [[_dy x] c] (list 'raster.nn/relu-backward c x))}
+
+   'raster.dl.nn/silu-backward
+   {0 (fn [[_dy x n] c] (list 'raster.dl.nn/silu-backward c x n))
+    1 (fn [[dy x n] c]
+        (list 'raster.dl.nn/hadamard
+              (list 'raster.dl.nn/hadamard c dy n)
+              (list 'raster.dl.nn/silu-second-deriv x n) n))}
+
+   'raster.dl.nn/gelu-backward
+   {0 (fn [[_dy x n] c] (list 'raster.dl.nn/gelu-backward c x n))
+    1 (fn [[dy x n] c]
+        (list 'raster.dl.nn/hadamard
+              (list 'raster.dl.nn/hadamard c dy n)
+              (list 'raster.dl.nn/gelu-second-deriv x n) n))}
+
+   'raster.linalg.blas/daxpy-diff!
+   {0 (fn [[_a _b scale n] c]
+        (list 'raster.linalg.blas/daxpy-diff!
+              c (list 'raster.arrays/zeros-like c n) scale n))
+    1 (fn [[_a _b scale n] c]
+        (list 'raster.linalg.blas/daxpy-diff!
+              (list 'raster.arrays/zeros-like c n) c scale n))
+    2 (fn [[a b _scale n] c]
+        (list 'raster.par/dot-product
+              c (list 'raster.linalg.blas/daxpy-diff! a b 1.0 n)))}
+
+   'raster.par/dot-product
+   ;; c is a SCALAR cotangent; scale's alpha is annotated Double, so widen
+   ;; explicitly (a float-typed seed dispatches [Float floats] otherwise —
+   ;; exact widening, the array dtype is preserved by scale's (All [T])).
+   {0 (fn [[_a b] c] (list 'raster.par/scale (list 'double c) b))
+    1 (fn [[a _b] c] (list 'raster.par/scale (list 'double c) a))}
+
+   'raster.par/scale
+   {0 (fn [[_alpha x] c] (list 'raster.par/dot-product c x))
+    1 (fn [[alpha _x] c] (list 'raster.par/scale alpha c))}
+
+   'raster.arrays/aclone
+   {0 (fn [[_arr] c] (list 'raster.arrays/aclone c))}
+
+   'clojure.core/aclone
+   {0 (fn [[_arr] c] (list 'raster.arrays/aclone c))}})
+
+;; Install: the :adjoint facet always; a derived :grads-fn only where no
+;; HAND reverse rule exists (never clobber one — transpose-2d etc. already
+;; have theirs). Eager so has-ad-rule? (the compiler-inliner gate and the
+;; reverse engine's record-time check) sees these ops as AD primitives.
+;; The ::derived-grads-fn marker makes re-registration idempotent under
+;; :reload (the defonce registry survives; a previously DERIVED fn must be
+;; refreshed, a hand-written one must not be touched).
+(doseq [[op adjoint-map] op-adjoints]
+  (let [t (get-template op)]
+    (merge-into-template!
+     op
+     (cond-> {:adjoint adjoint-map}
+       (or (::derived-grads-fn t)
+           (not (or (:grads t) (:grads-fn t))))
+       (assoc :grads-fn (derive-rrule-from-structure op adjoint-map)
+              ::derived-grads-fn true)))))

--- a/src/raster/compiler/passes/scalar/pe.clj
+++ b/src/raster/compiler/passes/scalar/pe.clj
@@ -170,17 +170,26 @@
               (constant? pe-init)
               (recur (next pairs) new-bindings (assoc env sym pe-init))
 
-              ;; Single-use trivial expression — inline
+              ;; Single-use trivial expression — inline.
+              ;; SOUNDNESS: a symbol alias (sym := rhs-sym) may only be
+              ;; dropped when rhs-sym is never REBOUND by a later binding in
+              ;; this let* — under sequential shadowing the env substitution
+              ;; would make later use sites (including AD pullback closures
+              ;; capturing sliced buffers) read the WRONG (latest) rhs value.
               (and (trivial? pe-init)
+                   (or (not (symbol? pe-init))
+                       (not-any? #(= pe-init (first %)) (next pairs)))
                    (let [uses (reduce + 0 (map #(count-uses sym %) body))]
                      (<= uses 1)))
               (recur (next pairs) new-bindings (assoc env sym pe-init))
 
-              ;; Keep the binding
+              ;; Keep the binding. A kept binding REBINDS sym for everything
+              ;; downstream — any previously propagated value for that name
+              ;; is now stale and must leave the env (sequential let*).
               :else
               (recur (next pairs)
                      (conj new-bindings [sym pe-init])
-                     env))))))))
+                     (dissoc env sym)))))))))
 
 (defn- pe-if
   "Partially evaluate an if form.
@@ -285,7 +294,24 @@
                                              [params]
                                              pe-body))]
               (if-let [m (meta form)] (with-meta r m) r))
-            ;; Multi-arity or unrecognized — leave alone
+            ;; Wrapped/multi arities: (fn* name? ([params] body…) …) — the
+            ;; reified AD pullback shape. Substitute per arity: without this,
+            ;; an env-dropped alias leaves DANGLING refs inside the closure
+            ;; (bytecode emit: "Unresolved symbol"), while count-uses (which
+            ;; IS arity-aware) says the binding is droppable.
+            (every? #(and (seq? %) (vector? (first %))) rest-tail)
+            (let [pe-arities (map (fn [arity]
+                                    (let [params (first arity)
+                                          abody (rest arity)
+                                          shadowed (set (filter symbol? params))
+                                          body-env (if (seq shadowed)
+                                                     (apply dissoc const-env shadowed)
+                                                     const-env)]
+                                      (cons params (map #(pe-pass % body-env) abody))))
+                                  rest-tail)
+                  r (apply list head (concat (when name? [name?]) pe-arities))]
+              (if-let [m (meta form)] (with-meta r m) r))
+            ;; Unrecognized — leave alone
             :else form))
 
         ;; ftm — leave alone

--- a/src/raster/dl/nn.clj
+++ b/src/raster/dl/nn.clj
@@ -141,6 +141,18 @@
                                                   grad (* si (+ 1.0 (* x (- 1.0 si))))]
                                               (* dy grad)))))
 
+;; SiLU second derivative (act″) — the RoR-closure kernel (#72).
+;; silu(x) = x·σ(x); σ′ = σ(1−σ); σ″ = σ′(1−2σ) = σ(1−σ)(1−2σ)
+;;   silu′(x) = σ + x·σ′
+;;   silu″(x) = σ′ + σ′ + x·σ″ = 2σ′ + x·σ″ = σ(x)(1−σ(x))·(2 + x·(1−2σ(x)))
+;; Consumed by silu-backward's own reverse/forward rules (raster.ad.templates):
+;; the x-direction of d(dy⊙silu′(x)) is dy⊙silu″(x)⊙Δx. FD-validated against
+;; the silu-backward kernel in the o4c double-backward law.
+(deftm silu-second-deriv (All [T] [x :- (Array T) n :- Long] :- (Array T)
+                              (broadcast [x] (let [si (/ 1.0 (+ 1.0 (m/exp (- x))))]
+                                               (* (* si (- 1.0 si))
+                                                  (+ 2.0 (* x (- 1.0 (* 2.0 si)))))))))
+
 ;; ================================================================
 ;; Linear: y = x @ W^T + b
 ;; x:[batch, in_f], W:[out_f, in_f], b:[out_f] -> y:[batch, out_f]
@@ -269,6 +281,28 @@
                                             (* 0.5 xi sech2 c (+ 1.0 (* 3.0 0.044715 xi xi))))]
                                 (aset dx i (* (aget dy i) grad))))
                             dx)))
+
+;; GELU second derivative (act″) — the RoR-closure kernel (#72).
+;; With u = c(x + a·x³), a = 0.044715, c = √(2/π), t = tanh u,
+;; s2 = 1 − t² (= sech²u), u′ = c(1 + 3a·x²), u″ = 6·a·c·x:
+;;   gelu′(x) = 0.5(1+t) + 0.5·x·s2·u′            (= gelu-backward's grad)
+;;   gelu″(x) = 0.5·s2·u′ + 0.5·[s2·u′ + x·(ds2/dx·u′ + s2·u″)]
+;;            = s2·u′ + 0.5·x·s2·(u″ − 2·t·(u′)²)  (ds2/dx = −2·t·s2·u′)
+;; Same exact-tanh spelling as gelu-backward, so FD of that kernel validates
+;; this one directly (o4c double-backward law).
+(deftm gelu-second-deriv (All [T] [x :- (Array T) n :- Long] :- (Array T)
+                              (let [dd (alloc-like x n)
+                                    c (n/sqrt (/ 2.0 n/pi))]
+                                (dotimes [i n]
+                                  (let [xi (aget x i)
+                                        u (* c (+ xi (* 0.044715 xi xi xi)))
+                                        up (* c (+ 1.0 (* 3.0 0.044715 xi xi)))
+                                        upp (* 6.0 0.044715 c xi)
+                                        t (raster.math/tanh u)
+                                        s2 (- 1.0 (* t t))]
+                                    (aset dd i (+ (* s2 up)
+                                                  (* 0.5 xi s2 (- upp (* 2.0 t up up)))))))
+                                dd)))
 
 (tmpl/merge-into-template! 'raster.dl.nn/gelu
                            {:params '[x n] :adjoint 'dy

--- a/test/raster/ad/laws_test.clj
+++ b/test/raster/ad/laws_test.clj
@@ -25,6 +25,7 @@
             [raster.sym.core :as sym]
             [raster.sym.diff :as sdiff]
             [raster.sci.special :as special]
+            [raster.nn :as rnn]
             [raster.dl.nn :as nn]
             [raster.dl.loss :as loss]
             [raster.dl.attention :as attn]))
@@ -699,6 +700,136 @@
             "W-seed: tangent of ∇ₓf = FD-of-grad (cross block)")
         (is (farr-close? (nth hv 1) (fd-diff gW+ gW- h) tol-hvp)
             "W-seed: tangent of ∇_W f = FD-of-grad")))))
+
+;; ================================================================
+;; O4c — double backward (#72 RoR closure): value+grad THROUGH a gradient
+;; program. The backward kernels emitted by first-order rules (linear-dx/dW,
+;; daxpy-diff!, silu/relu-backward, dot-product/scale) now carry their own
+;; DERIVED reverse rules (adjoint of a linear op = its transpose, spelled
+;; with existing kernels — raster.ad.templates op-adjoints), closing the
+;; reverse engine under its own output (grad-of-grad, L2(∇f), MAML shapes).
+;;
+;; Composition shape that works: (value+grad (rev/reified-grad #'f 'p)) —
+;; the reified SCALAR-tail gradient program. value+grad-of-value+grad does
+;; NOT compose: value+grad's walked body ends in the VECTOR [primal grads…],
+;; and seeding a vector tail silently yields zero gradients (documented on
+;; reified-grad; same reason grad-of-hvp doesn't fall out).
+;; ================================================================
+
+;; x³ — the canonical grad-of-grad sanity: g = ∂f/∂x = 3x², g′ = f″ = 6x.
+(deftm laws-cube [x :- Double] :- Double
+  (n/* x (n/* x x)))
+
+;; Float-only relu wrapper (same devirt-hazard dodge as laws-jvp-silu).
+(deftm laws-dbb-relu-act [x :- (Array float)] :- (Array float)
+  (rnn/relu x))
+
+;; THE double-backward target: mse ∘ silu ∘ linear-nb (float). Its gradient
+;; program is daxpy-diff! → silu-backward → linear-dx/dW — every #72 kernel.
+(deftm laws-dbb [x :- (Array float) W :- (Array float) tgt :- (Array float)
+                 batch :- Long in :- Long out :- Long] :- Double
+  (loss/mse-loss (laws-jvp-silu (nn/linear-nb x W batch in out)
+                                (clojure.core/* batch out))
+                 tgt (clojure.core/* batch out)))
+
+;; relu variant — exercises relu-backward's self-adjoint derived rule.
+(deftm laws-dbb-relu [x :- (Array float) W :- (Array float) tgt :- (Array float)
+                      batch :- Long in :- Long out :- Long] :- Double
+  (loss/mse-loss (laws-dbb-relu-act (nn/linear-nb x W batch in out))
+                 tgt (clojure.core/* batch out)))
+
+(deftest o4c-act-second-deriv-kernels
+  (testing "silu″/gelu″ closed forms = central FD of the backward kernels (double)"
+    ;; silu-backward(1̄, x)ᵢ = silu′(xᵢ), so d/dxᵢ of it is silu″(xᵢ) —
+    ;; the act″ kernels must match the FD of the very kernels whose reverse
+    ;; rules consume them. Points span both tails and the active region.
+    (let [n 7
+          x (double-array [-2.3 -0.9 -0.1 0.0 0.4 1.3 2.7])
+          ones (double-array (repeat n 1.0))
+          h 1e-6
+          shift (fn [s] (let [x2 (aclone x)]
+                          (dotimes [i n]
+                            (aset x2 i (clojure.core/+ (clojure.core/aget x2 i) (double s))))
+                          x2))
+          fd-of (fn [bwd]
+                  (let [y+ ^doubles (bwd ones (shift h) n)
+                        y- ^doubles (bwd ones (shift (- h)) n)]
+                    (mapv #(/ (- (clojure.core/aget y+ %) (clojure.core/aget y- %))
+                              (* 2.0 h))
+                          (range n))))]
+      (is (every? true? (map #(close? %1 %2 1e-8)
+                             (nn/silu-second-deriv x n) (fd-of nn/silu-backward)))
+          "silu″ = FD of silu-backward")
+      (is (every? true? (map #(close? %1 %2 1e-8)
+                             (nn/gelu-second-deriv x n) (fd-of nn/gelu-backward)))
+          "gelu″ = FD of gelu-backward"))))
+
+(deftest o4c-double-backward-law
+  (testing "scalar grad-of-grad: x³ → g = 3x², ∇g = 6x (exact)"
+    (let [vg-g (rev/value+grad (rev/reified-grad #'laws-cube 'x))]
+      (doseq [x [0.7 1.5 -2.0]]
+        (let [[g dg] (vg-g x)]
+          (is (close? g (* 3.0 x x) 1e-12) (str "g = f′ at " x))
+          (is (close? dg (* 6.0 x) 1e-12) (str "∇g = f″ at " x))))))
+
+  (testing "scalar 2-param: quad Hessian row via grad-of-grad (exact)"
+    ;; laws-quad = x² + xy, ∇ₓ = 2x + y, so ∇(∇ₓ) = [2 1] — the x-row of H.
+    (let [vg-g (rev/value+grad (rev/reified-grad #'laws-quad 'x))]
+      (let [[g dgx dgy] (vg-g 3.0 2.0)]
+        (is (== 8.0 g) "g = ∂f/∂x = 2x+y")
+        (is (== 2.0 dgx) "H[x,x]")
+        (is (== 1.0 dgy) "H[x,y]"))))
+
+  (testing "NN block double backward: ∇ₓ⟨∇ₓf, c⟩ = Hₓₓ·c vs FD-of-grad
+            (mse∘silu∘linear-nb float — daxpy-diff!, silu-backward(+act″),
+            linear-dx/dW, dot-product/scale second-order rules)"
+    (let [batch 2 in 4 out 3
+          x (fa (* batch in) 61) W (fa (* out in) 62) tgt (fa (* batch out) 63)
+          c (fa (* batch in) 64)
+          g-fn (rev/reified-grad #'laws-dbb 'x)
+          vg-f (rev/value+grad #'laws-dbb)
+          vg-g (rev/value+grad g-fn)
+          gx (nth (vg-f x W tgt batch in out) 1)
+          [g d-x d-W _d-tgt _ _ _ d-c] (vg-g x W tgt batch in out c)
+          h 1e-2]
+      ;; primal of the gradient program = ⟨∇ₓf, c⟩
+      (is (close? g (fdot gx c) tol-float) "g = ⟨∇ₓf, c⟩")
+      ;; ∂g/∂c = ∇ₓf itself (g is linear in c) — exact same array values
+      (is (farr-close? d-c gx tol-float) "∇_c g = ∇ₓf")
+      ;; ∂g/∂x = Hₓₓ·c, refereed by central FD OF THE GRADIENT along c
+      (let [gx+ (nth (vg-f (faxpy x h c) W tgt batch in out) 1)
+            gx- (nth (vg-f (faxpy x (- h) c) W tgt batch in out) 1)]
+        (is (farr-close? d-x (fd-diff gx+ gx- h) 5e-3)
+            "∇ₓ⟨∇ₓf,c⟩ = FD-of-grad (Hₓₓ·c)"))
+      ;; ∂g/∂W (the mixed block H_Wx·c): directional FD of g itself
+      (let [u (fa (* out in) 77)
+            g+ (g-fn x (faxpy W h u) tgt batch in out c)
+            g- (g-fn x (faxpy W (- h) u) tgt batch in out c)]
+        (is (close? (fdot d-W u) (/ (- (double g+) (double g-)) (* 2.0 h)) 1e-3)
+            "⟨∇_W g, u⟩ = directional FD (mixed second derivative)"))
+      ;; Cross-route: forward-over-reverse hvp with v = c must give the SAME
+      ;; Hₓₓ·c. This is also the o1b FLIP (#72): the silu-backward x-slot
+      ;; tangent used to FAIL LOUD (act″ pending) — hvp through a silu chain
+      ;; now works, and the two independent second-order routes agree.
+      (let [hf (jvp/hvp #'laws-dbb)
+            zW (float-array (* out in)) ztgt (float-array (* batch out))
+            [grads hv] (hf x W tgt batch in out c zW ztgt)]
+        (is (farr-close? (nth grads 0) gx tol-float) "hvp grads = ∇f")
+        (is (farr-close? (nth hv 0) d-x tol-float)
+            "reverse-over-reverse = forward-over-reverse (Hₓₓ·c)"))))
+
+  (testing "relu chain double backward: relu-backward's self-adjoint rule"
+    (let [batch 2 in 4 out 3
+          x (fa (* batch in) 61) W (fa (* out in) 62) tgt (fa (* batch out) 63)
+          c (fa (* batch in) 64)
+          vg-f (rev/value+grad #'laws-dbb-relu)
+          [_ d-x & _] ((rev/value+grad (rev/reified-grad #'laws-dbb-relu 'x))
+                       x W tgt batch in out c)
+          h 1e-2
+          gx+ (nth (vg-f (faxpy x h c) W tgt batch in out) 1)
+          gx- (nth (vg-f (faxpy x (- h) c) W tgt batch in out) 1)]
+      (is (farr-close? d-x (fd-diff gx+ gx- h) 5e-3)
+          "∇ₓ⟨∇ₓf,c⟩ = FD-of-grad through the relu mask"))))
 
 ;; SDPA JVP law (A3 attention frule, double kernels): directional FD referee.
 (deftest o1b-sdpa-jvp-law

--- a/test/raster/ad/laws_test.clj
+++ b/test/raster/ad/laws_test.clj
@@ -16,6 +16,7 @@
             [raster.numeric :as n]
             [raster.math :as m]
             [raster.arrays :as ra]
+            [raster.par :as par]
             [raster.ad.reverse :as rev]
             [raster.ad.jvp :as jvp]
             [raster.ad.tangent :as tangent]
@@ -1191,3 +1192,129 @@
     (is (thrown-with-msg? Exception #"tuple-valued"
                           (rev/value+grad (rev/value+grad #'o4d-cube)))
         "value+grad of value+grad is ill-typed — was a silent zero before")))
+
+;; ================================================================
+;; O9 — par/scan: the differentiable RECURRENCE primitive.
+;;
+;; out[i] = acc_i, so THE OUTPUT ARRAY IS THE CARRY TAPE — no closure tape,
+;; no ArrayList, no separate residual stack (Griewank store-the-carry
+;; checkpointing at every step, zero recompute depth). The reverse walks
+;; i = n-1..0 with a running carry cotangent δacc, re-deriving step i's
+;; inputs from out[i-1] (init at i=0) and the array reads at the scan index:
+;;   total_i = δout[i] ⊕ δacc;  grads = pullback_i(total_i);
+;;   δacc ← grads[∂/∂acc];  d_x scatter-adds;  scalar frees accumulate;
+;;   the carry after step 0 is δinit.
+;; FD is the referee; the linear RNN also has an ANALYTIC closed form.
+;; ================================================================
+
+;; linear RNN: h_i = w·h_{i-1} + x_i, h_{-1} = h0. Closed form:
+;;   h_{n-1} = w^n·h0 + Σ_{k=0}^{n-1} w^{n-1-k}·x_k
+;;   ∂h_{n-1}/∂x_k = w^{n-1-k};  ∂h_{n-1}/∂h0 = w^n
+;;   ∂h_{n-1}/∂w   = n·w^{n-1}·h0 + Σ_{k=0}^{n-2} (n-1-k)·w^{n-2-k}·x_k
+(deftm laws-scan-lin [w :- Double, h0 :- Double, x :- (Array double), sn :- Long] :- Double
+  (let [out (double-array sn)
+        h (par/scan out acc h0 i sn double
+                    (n/+ (n/* w acc) (ra/aget x i)))]
+    (ra/aget h (dec sn))))
+
+;; nonlinear recurrence — no closed form, FD referee only
+(deftm laws-scan-tanh [w :- Double, x :- (Array double), sn :- Long] :- Double
+  (let [out (double-array sn)
+        h (par/scan out acc 0.0 i sn double
+                    (m/tanh (n/+ (n/* w acc) (ra/aget x i))))]
+    (ra/aget h (dec sn))))
+
+;; composition with a REGISTERED op downstream of the scan: mse over out[]
+;; (every out[i] carries an adjoint — the full δout vector feeds the reverse
+;; scan, not just the last element).
+(deftm laws-scan-mse [w :- Double, x :- (Array double), tgt :- (Array double),
+                      sn :- Long] :- Double
+  (let [out (double-array sn)
+        h (par/scan out acc 0.0 i sn double
+                    (m/tanh (n/+ (n/* w acc) (ra/aget x i))))]
+    (loss/mse-loss h tgt sn)))
+
+;; let*-bound reads at a SHIFTED index: the backward scatter-ADDS at each
+;; read's own index expression (x_k contributes through step k AND step k+1).
+(deftm laws-scan-shift [w :- Double, x :- (Array double), sn :- Long] :- Double
+  (let [out (double-array sn)
+        h (par/scan out acc 0.0 i sn double
+                    (let [xc (ra/aget x i)
+                          xp (ra/aget x (if (> i 0) (dec i) 0))]
+                      (n/+ (n/* w acc) (n/+ xc (n/* 0.1 xp)))))]
+    (ra/aget h (dec sn))))
+
+(defn- fd-wrt-slot
+  "Central FD of scalar-valued f in one array slot k."
+  ^double [f ^doubles x k]
+  (let [h 1e-6
+        xp (aclone x) xm (aclone x)]
+    (aset xp (int k) (+ (aget x (int k)) h))
+    (aset xm (int k) (- (aget x (int k)) h))
+    (/ (- (double (f xp)) (double (f xm))) (* 2.0 h))))
+
+(deftest o9-scan-recurrence-law
+  (let [w 0.6 h0 0.8 sn 4
+        x (double-array [0.7 -1.3 0.4 0.9])]
+    (testing "linear RNN: grads w.r.t. w, h0 and x = ANALYTIC closed form"
+      (let [[v dw dh0 dx] ((rev/value+grad #'laws-scan-lin) w h0 x sn)
+            a-v (+ (* (Math/pow w sn) h0)
+                   (reduce + (map-indexed
+                              (fn [k xk] (* (Math/pow w (- sn 1 k)) xk)) x)))
+            a-dw (+ (* sn (Math/pow w (dec sn)) h0)
+                    (reduce + (map-indexed
+                               (fn [k xk] (* (- sn 1 k) (Math/pow w (- sn 2 k)) xk))
+                               (butlast (vec x)))))
+            a-dx (double-array (map #(Math/pow w (- sn 1 %)) (range sn)))]
+        (is (close? v a-v tol-double) "primal = closed form")
+        (is (close? dw a-dw tol-double) "∂/∂w = Σ over steps of powers of w")
+        (is (close? dh0 (Math/pow w sn) tol-double) "∂/∂h0 = w^n (δinit chain)")
+        (is (darr-close? dx a-dx tol-double) "∂/∂x_k = w^{n-1-k}")))
+
+    (testing "linear RNN: same grads vs FD referee"
+      (let [[_ dw dh0 dx] ((rev/value+grad #'laws-scan-lin) w h0 x sn)]
+        (is (close? dw (central-fd #(laws-scan-lin % h0 x sn) w 1e-6) tol-double))
+        (is (close? dh0 (central-fd #(laws-scan-lin w % x sn) h0 1e-6) tol-double))
+        (dotimes [k sn]
+          (is (close? (ra/aget dx k)
+                      (fd-wrt-slot #(laws-scan-lin w h0 % sn) x k) tol-double)
+              (str "∂/∂x_" k " vs FD")))))
+
+    (testing "nonlinear (tanh) recurrence vs FD"
+      (let [[_ dw dx] ((rev/value+grad #'laws-scan-tanh) w x sn)]
+        (is (close? dw (central-fd #(laws-scan-tanh % x sn) w 1e-6) tol-double))
+        (dotimes [k sn]
+          (is (close? (ra/aget dx k)
+                      (fd-wrt-slot #(laws-scan-tanh w % sn) x k) tol-double)))))
+
+    (testing "loss = mse over the WHOLE scan out array (registered op downstream)"
+      (let [tgt (double-array [0.1 -0.2 0.3 0.2])
+            [_ dw dx _dtgt] ((rev/value+grad #'laws-scan-mse) w x tgt sn)]
+        (is (close? dw (central-fd #(laws-scan-mse % x tgt sn) w 1e-6) tol-double)
+            "∂mse/∂w vs FD — δout[i] ≠ 0 at every i")
+        (dotimes [k sn]
+          (is (close? (ra/aget dx k)
+                      (fd-wrt-slot #(laws-scan-mse w % tgt sn) x k) tol-double)))))
+
+    (testing "shifted let*-bound reads: scatter-ADD at the read's own index"
+      (let [[_ dw dx] ((rev/value+grad #'laws-scan-shift) w x sn)]
+        (is (close? dw (central-fd #(laws-scan-shift % x sn) w 1e-6) tol-double))
+        (dotimes [k sn]
+          (is (close? (ra/aget dx k)
+                      (fd-wrt-slot #(laws-scan-shift w % sn) x k) tol-double)
+              (str "x_" k " accumulates via steps k and k+1")))))
+
+    (testing "the raw-loop reject points at par/scan as the sanctioned recurrence"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"par/scan"
+           (rev/value+grad #'laws-loop-fn)))
+      (is (thrown-with-msg?
+           Exception #"par/scan"
+           (rev/value+grad #'laws-tail-loop-fn))))
+
+    (testing "forward mode (jvp) on scan fails LOUD — no forward SOAC fold yet"
+      ;; When the scan jvp lands (a second scan over the linearized
+      ;; recurrence), FLIP this to a jvp-vs-directional-FD law.
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"raster\.par/scan"
+           ((jvp/jvp #'laws-scan-lin) [w h0 x sn] [1.0 0.0 (double-array sn) nil]))))))

--- a/test/raster/ad/laws_test.clj
+++ b/test/raster/ad/laws_test.clj
@@ -1155,3 +1155,39 @@
       (is (< elapsed-ms 5000.0)
           (str "value+grad under fan-out must be linear-time, took "
                elapsed-ms "ms")))))
+
+;; ================================================================
+;; O4d — transparent composition of gradient operators (framework §14)
+;; The design guarantee: nesting happens through ORDINARY PROGRAM USE —
+;; the same syntax works nested or not. The only rejected spelling is
+;; operator-directly-on-operator over a tuple-valued output (ill-typed;
+;; fails loud, #74). For 1-param scalar fns, grad returns a bare scalar
+;; (JAX semantics), so the textbook (grad (grad f)) composes literally.
+;; ================================================================
+
+(deftm o4d-cube [x :- Double] :- Double (n/* x (n/* x x)))
+(deftm o4d-quad2 [x :- Double, y :- Double] :- Double (n/+ (n/* x x) (n/* x y)))
+
+;; outer deftm USES the inner gradient — same syntax as un-nested code
+(deftm o4d-outer [x :- Double] :- Double
+  (let [vg ((rev/value+grad #'o4d-cube) x)
+        g  (double (nth vg 1))]      ; g = 3x^2
+    (n/* g g)))                       ; 9x^4 -> d/dx = 36x^3
+
+(deftest o4d-transparent-composition-law
+  (testing "USE-shape nesting: value+grad of a deftm that uses an inner value+grad"
+    (let [[v g] ((rev/value+grad #'o4d-outer) 2.0)]
+      (is (= 144.0 v) "primal: (3*4)^2")
+      (is (= 288.0 g) "outer grad: 36x^3 at 2")))
+
+  (testing "textbook grad-of-grad for 1-param scalar fns (bare-scalar tail)"
+    (is (= 12.0 ((rev/grad #'o4d-cube) 2.0)) "1-param grad is a bare scalar: 3x^2")
+    (is (= 12.0 ((rev/grad (rev/grad #'o4d-cube)) 2.0)) "f'' = 6x composes literally"))
+
+  (testing "multi-param grad stays vector-valued"
+    (is (= [10.0 3.0] (vec ((rev/grad #'o4d-quad2) 3.0 4.0)))))
+
+  (testing "operator-on-operator over a tuple output fails LOUD (#74)"
+    (is (thrown-with-msg? Exception #"tuple-valued"
+                          (rev/value+grad (rev/value+grad #'o4d-cube)))
+        "value+grad of value+grad is ill-typed — was a silent zero before")))

--- a/test/raster/compiler/pe_test.clj
+++ b/test/raster/compiler/pe_test.clj
@@ -178,6 +178,59 @@
       (is (#{'fn 'fn*} (first result))))))
 
 ;; ================================================================
+;; Alias propagation soundness under sequential shadowing (#72 find)
+;; ================================================================
+
+(deftest alias-shadowed-rhs-test
+  (testing "a symbol alias whose RHS is REBOUND later must be kept"
+    ;; Kh := out, then out is rebound; the closure and the later call must
+    ;; keep reading the FIRST out. Dropping Kh + env substitution would make
+    ;; them read the rebound out (silent wrong value) — PE must keep Kh.
+    (let [form '(let* [out (clojure.core/double-array 3)
+                       Kh out
+                       out (clojure.core/double-array 4)
+                       r (some.ns/f Kh out)]
+                      r)
+          result (pe/pe form)
+          bindings (partition 2 (second result))]
+      (is (some #(= 'Kh (first %)) bindings)
+          "alias with later-shadowed RHS survives")
+      (is (= '(some.ns/f Kh out) (second (last bindings)))
+          "use site still references the alias, not the rebound RHS")))
+
+  (testing "a symbol alias with a STABLE RHS is still propagated"
+    (let [form '(let* [a b
+                       r (some.ns/f a)]
+                      r)
+          result (pe/pe form)]
+      (is (not (some #{'a} (flatten result)))
+          "stable alias is inlined away")))
+
+  (testing "kept rebinding invalidates a previously propagated constant"
+    ;; x := 1.0 propagates; then x is REBOUND to a call — later refs must
+    ;; use the new x, not the stale constant.
+    (let [form '(let* [x 1.0
+                       x (some.ns/g)
+                       r (some.ns/f x)]
+                      r)
+          result (pe/pe form)
+          bindings (partition 2 (second result))]
+      (is (= '(some.ns/f x) (second (last bindings)))
+          "post-rebind reference is NOT replaced by the stale constant"))))
+
+(deftest fn*-wrapped-arity-substitution-test
+  (testing "env substitution reaches (fn* ([params] body)) — the reified
+            AD pullback shape (dangling-ref regression, #72 find)"
+    ;; h := x is droppable (x never rebound); the closure body must get the
+    ;; substitution — otherwise its h is a dangling symbol at bytecode emit.
+    (let [form '(let* [h x
+                       pb (fn* ([dy] (some.ns/f h dy)))]
+                      pb)
+          result (pe/pe form)]
+      (is (not (some #{'h} (flatten result)))
+          "alias substituted inside the wrapped-arity closure body"))))
+
+;; ================================================================
 ;; Specialize-var API on real deftm
 ;; ================================================================
 


### PR DESCRIPTION
**Stacked on #43** (will rebase onto main when it merges). Closes task #72 — the RoR follow-up: backward kernels are no longer AD-opaque, so **true double-backward works**.

**Derived rrules from structure tags** (`op-adjoints` + `derive-rrule-from-structure`, new `:adjoint` facet): each bilinear backward kernel's partial adjoints worked out on paper (shapes in docstrings) and validated via the adjoint pairing ⟨c,op(v)⟩=⟨op†(c),v⟩ at 1e-12. Highlight: **{linear-nb, linear-dx, linear-dW} is closed under partial adjoints** — the derivatives of the derivatives are the same three kernels. Plus relu/silu/gelu-backward, daxpy-diff!, dot-product↔scale (closed pair), aclone. Reload-idempotent registration; hand rules never clobbered.

**act″ kernels** (silu″, gelu″ — closed forms, FD-validated ~1e-10): removes PR #43's deliberate fail-loud on x-tangents — HVP through smooth activations now works, and the o1b law flips to positive.

**Double-backward acceptance** (`o4c` laws): x³→f″ exact; mse∘silu∘linear-nb (float): ∇ₓ⟨∇ₓf,c⟩ = Hₓₓ·c vs FD-of-grad 2.7e-4, mixed H_Wx block 2.9e-5, and **RoR ≡ forward-over-reverse hvp bit-exactly** — the two second-order routes cross-validate.

**New API `rev/reified-grad`** (the composition shape that works — with an α-rename fix for frozen-program rebinding). Honest boundary documented: `value+grad`-of-`value+grad` **silently returns zero** on vector-tailed bodies (pre-existing hazard, tracked separately).

**Bonus: two pre-existing PE miscompiles root-caused + fixed** (exposed by the gpt2 test when the new rules reshaped the fixpoint): `pe-let` unsound copy-prop under sequential shadowing; `pe-pass` not substituting into wrapped-arity `(fn* ([p]…))` closures (exactly the reified-pullback shape). Unit regressions added in `pe_test.clj`.

Valhalla fresh JVM: **1739 / 29044 / 0 / 0, census 0**.