### PR TITLE
AD: differentiable par/scan — the recurrence primitive with out-as-tape reverse

### DIFF
--- a/src/raster/ad/jvp.clj
+++ b/src/raster/ad/jvp.clj
@@ -16,8 +16,11 @@
   resolve-deftm-var, grad-acc as the ⊕ kernel).
 
   Not yet supported (fail loud, forward loop rules are follow-up work):
-  par/map!, par/reduce, dotimes, loop — the differentiable loop forms have
-  reverse orchestrators but no forward fold yet."
+  par/map!, par/reduce, par/scan, dotimes, loop — the differentiable loop
+  forms have reverse orchestrators but no forward fold yet. (par/scan's JVP
+  is itself a scan over the linearized recurrence — δout[i] = ∂body/∂acc ·
+  δacc_{i-1} ⊕ Σ ∂body/∂free · δfree — a natural follow-up once the SOAC
+  forward-fold family lands as a group.)"
   (:require [raster.ad.reverse :as rev]
             [raster.ad.templates :as tmpl]
             [raster.ad.tangent :as tangent]
@@ -83,8 +86,8 @@
 (def ^:private unsupported-forward-heads
   "Differentiable-in-reverse forms with NO forward fold yet (follow-up):
   fail loud when they carry an active value, never silently drop a tangent."
-  '#{loop loop* dotimes raster.par/map! raster.par/reduce fn* do case case*
-     try letfn letfn* new monitor-enter monitor-exit})
+  '#{loop loop* dotimes raster.par/map! raster.par/reduce raster.par/scan
+     fn* do case case* try letfn letfn* new monitor-enter monitor-exit})
 
 (defn- fold-call
   "Emit the paired tangent bindings for one active :call binding.

--- a/src/raster/ad/reverse.clj
+++ b/src/raster/ad/reverse.clj
@@ -236,6 +236,7 @@
 (declare ^:private gen-reverse-dotimes)
 (declare ^:private gen-reverse-par-map)
 (declare ^:private gen-reverse-par-reduce)
+(declare ^:private gen-reverse-par-scan)
 
 (defn- init-active?
   "Decide whether a binding init carries gradient (is active), given the current
@@ -268,6 +269,12 @@
         (let [[_ _acc _init _idx _bound body] init-expr]
           (boolean (some #(get activity % false) (free-syms-excluding body #{_idx _acc}))))
 
+        (= 'raster.par/scan head)
+        (let [[_ _out _acc init _idx _bound _cast body] init-expr]
+          (boolean (some #(get activity % false)
+                         (into (free-syms-excluding body #{_idx _acc})
+                               (free-syms-excluding init #{})))))
+
         ;; Loop: active iff any init or body references an active symbol
         (contains? #{'loop 'loop*} head)
         (let [[_ bindings-vec & body-forms] init-expr
@@ -299,6 +306,7 @@
   (cond
     (and (seq? init-expr) (= 'raster.par/map!   (first init-expr))) :par-map
     (and (seq? init-expr) (= 'raster.par/reduce (first init-expr))) :par-reduce
+    (and (seq? init-expr) (= 'raster.par/scan   (first init-expr))) :par-scan
     (and (seq? init-expr) (= 'dotimes           (first init-expr))) :dotimes
     (not active?)                                                   :inactive
     (and (seq? init-expr) (= 'if (first init-expr)))                :if
@@ -340,7 +348,9 @@
 (defmethod ad-record :loop [_ sym _init-expr _activity]
   (throw (ex-info
           (str "Cannot differentiate through raw `loop` form bound to `" sym "`. "
-               "Use `par/reduce` for differentiable reductions, or wrap "
+               "Use `par/reduce` for differentiable reductions, `par/scan` for "
+               "differentiable recurrences (a chained carry whose per-step values "
+               "you keep — out[i] = acc_i is its own tape), or wrap "
                "the loop in a deftm with an AD template.")
           {:sym sym :form-head 'loop})))
 
@@ -370,6 +380,16 @@
                                  [pair-sym (:forward-code pr-info)
                                   tape-sym (list 'aget pair-sym 0)
                                   sym (list 'aget pair-sym 1)]))))}))
+
+(defmethod ad-record :par-scan [_ sym init-expr activity]
+  ;; NO :fwd-patch — this is the point of scan-as-recurrence: out[i] = acc_i,
+  ;; so THE OUTPUT ARRAY IS THE CARRY TAPE. The forward binding runs completely
+  ;; unpatched (the scan macro returns `out`, so `sym` IS the buffer), and the
+  ;; backward reconstructs every step's inputs from out[] — no closure tape,
+  ;; no ArrayList, no separate residual stack (Griewank store-the-carry
+  ;; checkpointing at every step; zero recompute depth).
+  (let [active-set (vec (keys (filter val activity)))]
+    {:record (assoc (gen-reverse-par-scan init-expr active-set) :sym sym)}))
 
 (defmethod ad-record :dotimes [_ sym init-expr activity]
   (let [active-set (vec (keys (filter val activity)))
@@ -565,6 +585,42 @@
     {:rev-ctx rev-ctx
      :adj-env (wire-read-adjoints adj-env read-arrs d-read-arr-syms active-free d-scalar-syms)}))
 
+(defmethod emit-backward :par-scan
+  [{:keys [sym written-arrs read-arrs active-free shadow-allocs backward-loop
+           d-out-sym n-bwd-sym bound-expr init-expr]}
+   _adj-sym activity {:keys [adj-env rev-ctx]}]
+  ;; out-as-tape: NO tape unpack — the forward scan ran unpatched; out[] holds
+  ;; every carry. The result sym aliases the out buffer, so sum consumer
+  ;; (adj-env[sym]) and direct buffer (adj-env[out-arr]) contributions
+  ;; (see :par-map) into d_out, the per-step δout[i] source.
+  (let [rev-ctx (bindings-into rev-ctx (vec shadow-allocs))
+        out-arr (first written-arrs)
+        contribs (concat (get adj-env sym) (get adj-env out-arr))
+        default (when (empty? contribs) (array-zero-of-shape out-arr))
+        rev-ctx (bindings-into rev-ctx [d-out-sym (sum-contribs contribs default)])
+        rev-ctx (bindings-into rev-ctx [n-bwd-sym bound-expr])
+        bwd-result-sym (ad-gensym "scan_bwd")
+        rev-ctx (bindings-into rev-ctx [bwd-result-sym backward-loop])
+        ;; backward-loop returns [d_read_arr_0 ... d_scalar_0 ... d_init-carry]
+        n-reads (count read-arrs)
+        n-scalars (count active-free)
+        adj-env (reduce (fn [ae [i arr]]
+                          (update ae arr (fnil conj []) (list 'nth bwd-result-sym i)))
+                        adj-env (map-indexed vector read-arrs))
+        adj-env (reduce (fn [ae [i p]]
+                          (update ae p (fnil conj [])
+                                  (list 'nth bwd-result-sym (clojure.core/+ n-reads i))))
+                        adj-env (map-indexed vector active-free))
+        ;; δinit: the carry cotangent remaining after step 0 is ∂loss/∂init —
+        ;; wire it to the init symbol when it is active (h0-style learnable
+        ;; initial states). Compound active inits are rejected loudly at
+        ;; record-construction time (gen-reverse-par-scan).
+        adj-env (if (and (symbol? init-expr) (get activity init-expr false))
+                  (update adj-env init-expr (fnil conj [])
+                          (list 'nth bwd-result-sym (clojure.core/+ n-reads n-scalars)))
+                  adj-env)]
+    {:adj-env adj-env :rev-ctx rev-ctx}))
+
 (defmethod emit-backward :dotimes
   [{:keys [sym written-arrs read-arrs active-free shadow-allocs backward-loop
            d-out-sym n-bwd-sym bound-expr]}
@@ -596,7 +652,7 @@
   [records activity seed-adj-env]
   (reduce
    (fn [{:keys [adj-env rev-ctx]} {:keys [type sym] :as record}]
-     (let [array-type? (contains? #{:dotimes :par-map :par-reduce} type)
+     (let [array-type? (contains? #{:dotimes :par-map :par-reduce :par-scan} type)
            adj-contribs (when-not array-type? (get adj-env sym))
            adj-sym (when-not array-type?
                      (ad-gensym (str "d_" (name sym)) (:raster.type/tag (meta sym))))
@@ -1928,6 +1984,182 @@
      :result-pair-sym result-pair-sym}))
 
 ;; ================================================================
+;; Par scan reverse-mode AD — the differentiable RECURRENCE primitive
+;; ================================================================
+
+(defn- gen-reverse-par-scan
+  "Generate reverse-mode AD code for a raster.par/scan form — the sanctioned
+  differentiable recurrence (the carry chains across steps AND every per-step
+  value is kept).
+
+  Forward form: (raster.par/scan out acc init idx bound cast body)
+    acc = init; for idx in 0..bound: acc = body; out[idx] = acc; return out.
+
+  KEY INSIGHT (out-as-tape): out[i] = acc_i, so THE OUTPUT ARRAY IS THE CARRY
+  TAPE — no closure tape, no ArrayList, no separate residual stack. This is
+  Griewank's store-the-carry checkpointing at EVERY step (zero recompute
+  depth): the forward binding runs completely unpatched, and the backward
+  reconstructs step i's body inputs from the tape — acc_{i-1} = out[i-1]
+  (init for i=0) — plus the original array reads at the scan index.
+  Body-internal values re-derive from the carry (recompute-from-carry; cheap
+  for scalar-carry bodies). Flat-buffer/GPU-ready by construction.
+
+  Backward: one reversed loop, i from bound-1 downto 0, threading the running
+  carry cotangent δacc:
+    total_i = δout[i] ⊕ δacc          (the out[i] store + step i+1's body)
+    grads   = pullback_i(total_i)      (pullback evaluated at acc_{i-1}, x[i])
+    δacc    = grads[∂body/∂acc]        (chains to step i-1)
+    d_x[·] ⊕= grads[∂body/∂aget_r]     (scatter-ADD at each read's index)
+    d_w_s  ⊕= grads[∂body/∂w_s]        (accumulate across steps, loop-carried)
+  The carry remaining after step 0 is δinit.
+
+  Cast note: the forward chains the UNCAST acc while out stores cast(acc);
+  reconstruction reads the stored value — exact identity for the `double`
+  cast, standard checkpoint rounding for narrowing casts (float).
+
+  Returns a record map for the reverse-pass engine (emit-backward :par-scan)."
+  [par-scan-form active-params]
+  (let [[_ out-sym acc-sym init-expr idx-sym bound-expr _cast-fn body-expr] par-scan-form
+        ;; Same body analysis as par/map!: let*-bound agets + inline agets at
+        ;; the scan index join the scatter path. acc-sym lands in :free-syms
+        ;; but is never an active param, so it cannot leak into active-free.
+        {:keys [agets scalar-bindings body-result free-syms]}
+        (analyze-par-map-body body-expr idx-sym)
+
+        read-arrs (vec (distinct (map :arr agets)))
+        active-free (filterv (fn [p] (contains? free-syms p)) active-params)
+
+        ;; Fail loud: an ACTIVE array referenced outside the recognized aget
+        ;; reads would be mis-treated as a free SCALAR (mis-shaped gradient —
+        ;; the par/map `No promotion rule` class of bug). Never miscompile.
+        _ (doseq [p active-free]
+            (when (= :array (:kind (tangent/tangent-kind (:raster.type/tag (meta p)))))
+              (throw (ex-info
+                      (str "par/scan AD: active array `" p "` is referenced in the "
+                           "scan body outside an `(aget " p " <idx>)` read. Only "
+                           "aget reads have a scatter gradient path — bind the "
+                           "needed element to a let sym inside the body.")
+                      {:array p :body body-expr}))))
+        ;; Fail loud: a compound init that DEPENDS on active params would
+        ;; reconstruct the value correctly but silently drop δinit (the final
+        ;; carry only wires to a SYMBOL). Bind it outside the scan first.
+        _ (when (and (seq? init-expr)
+                     (some (set active-params) (free-syms-excluding init-expr #{})))
+            (throw (ex-info
+                    (str "par/scan AD: the scan init `" (pr-str init-expr)
+                         "` depends on active params. Bind it to a let symbol "
+                         "before the scan so its gradient (δinit, the final "
+                         "carry cotangent) has a symbol to flow to.")
+                    {:init init-expr})))
+
+        aget-syms (mapv :sym agets)
+        ;; Pullback grads layout: [∂body/∂acc, ∂body/∂aget..., ∂body/∂free...]
+        iter-active (vec (distinct (concat [acc-sym] aget-syms active-free)))
+
+        pure-scalar-bindings (vec (mapcat identity
+                                          (remove (fn [[sym _]]
+                                                    (contains? (set aget-syms) sym))
+                                                  scalar-bindings)))
+
+        ;; Per-step scalar transform (primal recompute + pullback closure) —
+        ;; evaluated in the BACKWARD loop at the reconstructed inputs. This is
+        ;; recompute-from-carry: no forward-time tape stores it.
+        val-result-sym (ad-gensym "val")
+        scalar-transform
+        (let [binds (if (seq pure-scalar-bindings)
+                      (vec (concat pure-scalar-bindings [val-result-sym body-result]))
+                      [val-result-sym body-result])]
+          (gen-reverse-let binds [val-result-sym] iter-active))
+
+        ;; === Backward code ===
+        out-array-tag (or (some-> out-sym meta :raster.type/tag) 'doubles)
+        d-out-sym (ad-gensym "d_out" out-array-tag)
+        d-read-arr-syms (mapv (fn [arr]
+                                (ad-gensym (str "d_" (name arr))
+                                           (or (:raster.type/tag (meta arr)) 'doubles)))
+                              read-arrs)
+        arr->d-sym (zipmap read-arrs d-read-arr-syms)
+        d-scalar-syms (mapv (fn [p] (ad-gensym (str "d_" (name p) "_acc"))) active-free)
+        n-bwd-sym (ad-gensym "n_bwd")
+        d-carry-sym (ad-gensym "d_carry")
+        vpb-sym (ad-gensym "vpb")
+        pb-sym (ad-gensym "pb")
+        grads-sym (ad-gensym "grads")
+        total-sym (ad-gensym "d_total")
+        n-agets (count agets)
+
+        shadow-allocs (vec (mapcat (fn [d-arr-sym arr-sym]
+                                     [d-arr-sym (list 'raster.arrays/zeros-like arr-sym
+                                                      (list 'clojure.core/alength arr-sym))])
+                                   d-read-arr-syms read-arrs))
+
+        ;; Step-i reconstruction + pullback. The backward loop counter IS
+        ;; idx-sym, so any body sub-expression that still references the scan
+        ;; index (index arithmetic, non-lifted reads) sees the right value.
+        bwd-body-bindings
+        (vec (concat
+              ;; acc_{i-1} from the carry tape: out[i-1], init at i=0.
+              [acc-sym (list 'if (list 'clojure.core/== idx-sym 0)
+                             init-expr
+                             (list 'aget out-sym (list 'clojure.core/- idx-sym 1)))]
+              ;; Re-bind the body's array reads at their ORIGINAL indices.
+              (mapcat (fn [{:keys [sym arr idx]}] [sym (list 'aget arr idx)]) agets)
+              [total-sym (list 'raster.ad.reverse/grad-acc
+                               (list 'aget d-out-sym idx-sym) d-carry-sym)
+               vpb-sym scalar-transform
+               pb-sym (list 'nth vpb-sym 1)
+               grads-sym (list pb-sym total-sym)]
+              ;; Scatter-ADD each read's cotangent at the read's own index
+              ;; (read-modify-write: correct for repeated reads of one array
+              ;; and for shifted indices like (aget x (- idx 1))).
+              (mapcat (fn [k {:keys [arr idx]}]
+                        (let [d-arr (arr->d-sym arr)]
+                          [(ad-gensym "_scatter")
+                           (list 'aset d-arr idx
+                                 (list 'raster.ad.reverse/grad-acc
+                                       (list 'aget d-arr idx)
+                                       (list 'nth grads-sym (clojure.core/+ 1 k))))]))
+                      (range) agets)))
+
+        bwd-recur-args
+        (list* (list 'clojure.core/- idx-sym 1)
+               ;; the carry cotangent chains: δacc_{i-1} = grads[∂body/∂acc]
+               (list 'nth grads-sym 0)
+               (map-indexed (fn [i d-s]
+                              (list 'raster.ad.reverse/grad-acc d-s
+                                    (list 'nth grads-sym
+                                          (clojure.core/+ 1 n-agets i))))
+                            d-scalar-syms))
+
+        bwd-loop-init
+        (vec (concat [idx-sym (list 'clojure.core/- n-bwd-sym 1)
+                      d-carry-sym 0.0]
+                     (mapcat (fn [s] [s nil]) d-scalar-syms)))
+
+        ;; Loop value: [d_read_arr_0 ... d_scalar_0 ... d_init-carry]
+        bwd-return (conj (vec (concat d-read-arr-syms d-scalar-syms)) d-carry-sym)
+
+        backward-loop
+        (list 'loop* bwd-loop-init
+              (list 'if (list 'clojure.core/>= idx-sym 0)
+                    (list 'let* bwd-body-bindings (cons 'recur bwd-recur-args))
+                    bwd-return))]
+
+    {:type :par-scan
+     ;; no :forward-code / :tape-sym — the forward binding IS the tape build.
+     :written-arrs [out-sym]
+     :read-arrs read-arrs
+     :d-read-arr-syms d-read-arr-syms
+     :d-scalar-syms d-scalar-syms
+     :active-free active-free
+     :shadow-allocs shadow-allocs
+     :backward-loop backward-loop
+     :d-out-sym d-out-sym
+     :n-bwd-sym n-bwd-sym
+     :bound-expr bound-expr
+     :init-expr init-expr}))
+
+;; ================================================================
 ;; Top-level transform
 ;; ================================================================
 
@@ -2721,8 +2953,14 @@
           hoisted-body (map hoist-nested-lets body)]
       (apply list let-sym flat-bindings hoisted-body))
 
-    ;; Scope-introducing forms — recurse but don't hoist across scope boundaries
-    (and (seq? form) (contains? #{'if 'loop 'loop* 'fn* 'do 'when 'recur 'dotimes} (first form)))
+    ;; Scope-introducing forms — recurse but don't hoist across scope boundaries.
+    ;; This includes every par/* SOAC (form/introduces-scope?): their bodies
+    ;; close over the loop index/accumulator, so splicing a body let* out into
+    ;; the wrapping let would free those scoped vars (unresolvable `i` after
+    ;; alpha-conversion) — and the SOAC reverse analyzers expect the body's
+    ;; let*-bound agets IN PLACE (analyze-par-map-body).
+    (and (seq? form) (or (contains? #{'if 'loop 'loop* 'fn* 'do 'when 'recur 'dotimes} (first form))
+                         (form/introduces-scope? form)))
     (with-meta (apply list (first form) (map hoist-nested-lets (rest form))) (meta form))
 
     ;; Function call — check for let expressions in arguments
@@ -3109,9 +3347,11 @@
                        (str "value+grad: cannot assemble a runtime gradient for `"
                             f-var "` — the body reduces to a loop form the runtime "
                             "flattener does not support. Express the reduction via "
-                            "`par/reduce` or a registered op (e.g. a loss deftm with "
-                            "an AD template), or use the compiled path (compile-aot "
-                            "of a deftm calling value+grad).")
+                            "`par/reduce`, the recurrence via `par/scan` (the "
+                            "sanctioned differentiable recurrence — out[i] = acc_i "
+                            "is its own tape), or a registered op (e.g. a loss deftm "
+                            "with an AD template), or use the compiled path "
+                            "(compile-aot of a deftm calling value+grad).")
                        {:var f-var :reason :flatten-failed})))
            {:keys [walked-body params tags source-ns]} bgw
            runtime-fn (make-runtime-value+grad-fn walked-body params)

--- a/test/raster/ad/laws_test.clj
+++ b/test/raster/ad/laws_test.clj
@@ -16,6 +16,7 @@
             [raster.numeric :as n]
             [raster.math :as m]
             [raster.arrays :as ra]
+            [raster.par :as par]
             [raster.ad.reverse :as rev]
             [raster.ad.jvp :as jvp]
             [raster.ad.tangent :as tangent]
@@ -1191,3 +1192,129 @@
     (is (thrown-with-msg? Exception #"tuple-valued"
                           (rev/value+grad (rev/value+grad #'o4d-cube)))
         "value+grad of value+grad is ill-typed — was a silent zero before")))
+
+;; ================================================================
+;; O9 — par/scan: the differentiable RECURRENCE primitive.
+;;
+;; out[i] = acc_i, so THE OUTPUT ARRAY IS THE CARRY TAPE — no closure tape,
+;; no ArrayList, no separate residual stack (Griewank store-the-carry
+;; checkpointing at every step, zero recompute depth). The reverse walks
+;; i = n-1..0 with a running carry cotangent δacc, re-deriving step i's
+;; inputs from out[i-1] (init at i=0) and the array reads at the scan index:
+;;   total_i = δout[i] ⊕ δacc;  grads = pullback_i(total_i);
+;;   δacc ← grads[∂/∂acc];  d_x scatter-adds;  scalar frees accumulate;
+;;   the carry after step 0 is δinit.
+;; FD is the referee; the linear RNN also has an ANALYTIC closed form.
+;; ================================================================
+
+;; linear RNN: h_i = w·h_{i-1} + x_i, h_{-1} = h0. Closed form:
+;;   h_{n-1} = w^n·h0 + Σ_{k=0}^{n-1} w^{n-1-k}·x_k
+;;   ∂h_{n-1}/∂x_k = w^{n-1-k};  ∂h_{n-1}/∂h0 = w^n
+;;   ∂h_{n-1}/∂w   = n·w^{n-1}·h0 + Σ_{k=0}^{n-2} (n-1-k)·w^{n-2-k}·x_k
+(deftm laws-scan-lin [w :- Double, h0 :- Double, x :- (Array double), sn :- Long] :- Double
+  (let [out (double-array sn)
+        h (par/scan out acc h0 i sn double
+                    (n/+ (n/* w acc) (ra/aget x i)))]
+    (ra/aget h (dec sn))))
+
+;; nonlinear recurrence — no closed form, FD referee only
+(deftm laws-scan-tanh [w :- Double, x :- (Array double), sn :- Long] :- Double
+  (let [out (double-array sn)
+        h (par/scan out acc 0.0 i sn double
+                    (m/tanh (n/+ (n/* w acc) (ra/aget x i))))]
+    (ra/aget h (dec sn))))
+
+;; composition with a REGISTERED op downstream of the scan: mse over out[]
+;; (every out[i] carries an adjoint — the full δout vector feeds the reverse
+;; scan, not just the last element).
+(deftm laws-scan-mse [w :- Double, x :- (Array double), tgt :- (Array double),
+                      sn :- Long] :- Double
+  (let [out (double-array sn)
+        h (par/scan out acc 0.0 i sn double
+                    (m/tanh (n/+ (n/* w acc) (ra/aget x i))))]
+    (loss/mse-loss h tgt sn)))
+
+;; let*-bound reads at a SHIFTED index: the backward scatter-ADDS at each
+;; read's own index expression (x_k contributes through step k AND step k+1).
+(deftm laws-scan-shift [w :- Double, x :- (Array double), sn :- Long] :- Double
+  (let [out (double-array sn)
+        h (par/scan out acc 0.0 i sn double
+                    (let [xc (ra/aget x i)
+                          xp (ra/aget x (if (> i 0) (dec i) 0))]
+                      (n/+ (n/* w acc) (n/+ xc (n/* 0.1 xp)))))]
+    (ra/aget h (dec sn))))
+
+(defn- fd-wrt-slot
+  "Central FD of scalar-valued f in one array slot k."
+  ^double [f ^doubles x k]
+  (let [h 1e-6
+        xp (aclone x) xm (aclone x)]
+    (aset xp (int k) (+ (aget x (int k)) h))
+    (aset xm (int k) (- (aget x (int k)) h))
+    (/ (- (double (f xp)) (double (f xm))) (* 2.0 h))))
+
+(deftest o9-scan-recurrence-law
+  (let [w 0.6 h0 0.8 sn 4
+        x (double-array [0.7 -1.3 0.4 0.9])]
+    (testing "linear RNN: grads w.r.t. w, h0 and x = ANALYTIC closed form"
+      (let [[v dw dh0 dx] ((rev/value+grad #'laws-scan-lin) w h0 x sn)
+            a-v (+ (* (Math/pow w sn) h0)
+                   (reduce + (map-indexed
+                              (fn [k xk] (* (Math/pow w (- sn 1 k)) xk)) x)))
+            a-dw (+ (* sn (Math/pow w (dec sn)) h0)
+                    (reduce + (map-indexed
+                               (fn [k xk] (* (- sn 1 k) (Math/pow w (- sn 2 k)) xk))
+                               (butlast (vec x)))))
+            a-dx (double-array (map #(Math/pow w (- sn 1 %)) (range sn)))]
+        (is (close? v a-v tol-double) "primal = closed form")
+        (is (close? dw a-dw tol-double) "∂/∂w = Σ over steps of powers of w")
+        (is (close? dh0 (Math/pow w sn) tol-double) "∂/∂h0 = w^n (δinit chain)")
+        (is (darr-close? dx a-dx tol-double) "∂/∂x_k = w^{n-1-k}")))
+
+    (testing "linear RNN: same grads vs FD referee"
+      (let [[_ dw dh0 dx] ((rev/value+grad #'laws-scan-lin) w h0 x sn)]
+        (is (close? dw (central-fd #(laws-scan-lin % h0 x sn) w 1e-6) tol-double))
+        (is (close? dh0 (central-fd #(laws-scan-lin w % x sn) h0 1e-6) tol-double))
+        (dotimes [k sn]
+          (is (close? (ra/aget dx k)
+                      (fd-wrt-slot #(laws-scan-lin w h0 % sn) x k) tol-double)
+              (str "∂/∂x_" k " vs FD")))))
+
+    (testing "nonlinear (tanh) recurrence vs FD"
+      (let [[_ dw dx] ((rev/value+grad #'laws-scan-tanh) w x sn)]
+        (is (close? dw (central-fd #(laws-scan-tanh % x sn) w 1e-6) tol-double))
+        (dotimes [k sn]
+          (is (close? (ra/aget dx k)
+                      (fd-wrt-slot #(laws-scan-tanh w % sn) x k) tol-double)))))
+
+    (testing "loss = mse over the WHOLE scan out array (registered op downstream)"
+      (let [tgt (double-array [0.1 -0.2 0.3 0.2])
+            [_ dw dx _dtgt] ((rev/value+grad #'laws-scan-mse) w x tgt sn)]
+        (is (close? dw (central-fd #(laws-scan-mse % x tgt sn) w 1e-6) tol-double)
+            "∂mse/∂w vs FD — δout[i] ≠ 0 at every i")
+        (dotimes [k sn]
+          (is (close? (ra/aget dx k)
+                      (fd-wrt-slot #(laws-scan-mse w % tgt sn) x k) tol-double)))))
+
+    (testing "shifted let*-bound reads: scatter-ADD at the read's own index"
+      (let [[_ dw dx] ((rev/value+grad #'laws-scan-shift) w x sn)]
+        (is (close? dw (central-fd #(laws-scan-shift % x sn) w 1e-6) tol-double))
+        (dotimes [k sn]
+          (is (close? (ra/aget dx k)
+                      (fd-wrt-slot #(laws-scan-shift w % sn) x k) tol-double)
+              (str "x_" k " accumulates via steps k and k+1")))))
+
+    (testing "the raw-loop reject points at par/scan as the sanctioned recurrence"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"par/scan"
+           (rev/value+grad #'laws-loop-fn)))
+      (is (thrown-with-msg?
+           Exception #"par/scan"
+           (rev/value+grad #'laws-tail-loop-fn))))
+
+    (testing "forward mode (jvp) on scan fails LOUD — no forward SOAC fold yet"
+      ;; When the scan jvp lands (a second scan over the linearized
+      ;; recurrence), FLIP this to a jvp-vs-directional-FD law.
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"raster\.par/scan"
+           ((jvp/jvp #'laws-scan-lin) [w h0 x sn] [1.0 0.0 (double-array sn) nil]))))))


### PR DESCRIPTION
**Stacked on #44.** The loop-AD story, closed the honest way (framework §13 step 4 / §15): `par/scan` (which already had lax.scan's carry semantics) becomes the sanctioned differentiable recurrence, and the raw-/tail-loop reject messages now point at it.

**The design insight held all the way down**: `out[i] = acc_i`, so the scan's own output **is** the carry tape — the `:par-scan` ad-record has *no forward patch and no tape structure at all* (vs `:par-map`/`:par-reduce`'s object-array tapes). The backward is one reversed `loop*` reading `out[i-1]` (init at i=0), re-evaluating per-step pullbacks at reconstructed inputs (recompute-from-carry, Griewank store-the-carry). Flat buffers only → GPU-lowerable by construction.

Correctness subtleties handled: read-arrays accumulate via **scatter-add at each read's own index** (correct for repeated + shifted reads like `x[i-1]`, which a scatter-store would corrupt); the final carry cotangent is **δinit**, wired to learnable initial states (`h0`); compound active inits and unrecognized array references **fail loud** — never a mis-shaped gradient. JVP-of-scan is fail-loud with the derivation documented (= a second scan over the linearized recurrence; the SOAC forward-fold family is the noted follow-up).

**Laws (`o9-scan-recurrence-law`)**: linear RNN vs the *analytic closed form* (exact) + FD; tanh recurrence vs FD (~1e-9); mse-loss over the scan output (downstream registered ops); shifted let-bound reads; updated reject messages asserted.

**Required prep fix with reach beyond scan**: `hoist-nested-lets` treated par forms as plain calls and spliced their body `let*` across the scope boundary (α-renaming binders, orphaning hoisted inits) — fixed via `form/introduces-scope?` per the form-classifier convention.

Also surfaced (tracked, task #75): pre-existing runtime `par/reduce` AD breakage for aget-reading bodies.

Valhalla fresh JVM: **1741 / 29078 / 0 / 0**, census 0.