### PR TITLE
GPU-AD: validated end-to-end on Arc — backward GEMMs resident (:tn wired, recognition restored)

### DIFF
--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -665,18 +665,18 @@
         :cuda
         (throw (ex-info "CUDA backend not yet reimplemented (use :opencl)" {:target target-device}))
 
-      :opencl
+        :opencl
       ;; Attach the declared scalar/array types (from opts) onto the form so opencl-pass's
       ;; generators read declared types instead of guessing. The materialized form preserves
       ;; the original param symbols, so a name-keyed type map still applies.
-      (let [form (cond-> form
-                   (or (:scalar-types opts) (:array-types opts))
-                   (vary-meta assoc :scalar-types (:scalar-types opts) :array-types (:array-types opts)))
-            result (opencl-pass/opencl-pass form
-                                            :device-id target-device
-                                            :dtype (:dtype opts))]
-        (register-gpu-kernels! (:kernels result) target-device)
-        {:form (:form result) :stats (:stats result) :kernels (:kernels result) :backend :opencl})
+        (let [form (cond-> form
+                     (or (:scalar-types opts) (:array-types opts))
+                     (vary-meta assoc :scalar-types (:scalar-types opts) :array-types (:array-types opts)))
+              result (opencl-pass/opencl-pass form
+                                              :device-id target-device
+                                              :dtype (:dtype opts))]
+          (register-gpu-kernels! (:kernels result) target-device)
+          {:form (:form result) :stats (:stats result) :kernels (:kernels result) :backend :opencl})
 
         :simd
         (let [clean-form (strip-compound-markers form)
@@ -985,6 +985,52 @@
      clojure.core/double-array clojure.core/float-array
      clojure.core/int-array clojure.core/long-array clojure.core/byte-array})
 
+(def ^:private blas-gemm-ops
+  "BLAS GEMM ops the resident path recognizes (via :raster.op/original on the devirtualized
+   .invk form). dgemm! = C=A·B (:nn); -nt! = A·Bᵀ; -tn! = AᵀB. A backward matmul (linear-dx =
+   dgemm! :nn, linear-dW = dgemm-tn! :tn) is just another GEMM — recognizing it here is what
+   lets an AD-expanded train step lower to a resident graph."
+  {'raster.linalg.blas/dgemm! :nn
+   'raster.linalg.blas/dgemm-nt! :nt
+   'raster.linalg.blas/dgemm-tn! :tn})
+
+(defn- gemm-invk?
+  "True if form is a devirtualized BLAS GEMM .invk (carries :raster.op/original in
+   blas-gemm-ops). Metadata-based — the walker stamps the op, opencl-pass preserves it."
+  [form]
+  (and (seq? form) (= '.invk (first form))
+       (contains? blas-gemm-ops (:raster.op/original (meta form)))))
+
+(def ^:private gpu-alloc-ops
+  "Array-allocating ops that appear as devirtualized .invk (not a bare `float-array` head): a
+   deftm's `(alloc-like x n)` / `(zeros-like x n)` output buffer. On the resident path these are
+   device scratch buffers sized by the second (n) arg. Recognized so a GEMM output buffer —
+   allocated via zeros-like in a matmul/backward deftm — becomes a resident :alloc, not a
+   host scalar-let referencing a device buffer that never gets allocated."
+  '#{raster.arrays/zeros-like raster.arrays/alloc-like})
+
+(defn- alloc-invk?
+  "True if form is a devirtualized array-alloc .invk (:raster.op/original in gpu-alloc-ops).
+   Returns [sym-form size-expr] via alloc-invk-size when matched."
+  [form]
+  (and (seq? form) (= '.invk (first form))
+       (contains? gpu-alloc-ops (:raster.op/original (meta form)))))
+
+(defn- alloc-invk-size
+  "The length expr of an alloc .invk: (.invk impl ref n) → n (the 4th element)."
+  [form]
+  (nth form 3))
+
+(def ^:private array-tags
+  "Walker :tag values that denote a JVM primitive array (an array-VALUED binding). Used to detect
+   an unlowered device-array op that leaked into the scalar-let bucket of extract-gpu-program."
+  '#{floats doubles ints longs bytes shorts chars objects})
+
+(defn- array-tag?
+  "True if sym carries an array-valued :tag stamped by the walker."
+  [sym]
+  (contains? array-tags (:tag (meta sym))))
+
 ;; --- Stage A: functional reduce → resident-buffer fusion ------------------------------------
 ;; A par/reduce result is a SCALAR in the materialized IR, but on the resident GPU path it must
 ;; live in device memory (a 1-element buffer) so the per-token graph never syncs to host. This
@@ -1079,6 +1125,17 @@
         (let [[_ kname inputs n] expr]
           {:kernel-name kname :arrays (vec inputs) :scalars [] :n-expr n
            :convention :reduce :returns sym}))
+      ;; devirtualized BLAS GEMM: (.invk dgemm*-impl A B C m k n alpha beta). BLAS arg order is
+      ;; (A B C m k n) — note m,k,n (NOT m,n,k). C (out) is written in place. This is how a
+      ;; forward matmul (linear-nb → dgemm-nt!) AND its backward (linear-dx → dgemm!, linear-dW →
+      ;; dgemm-tn!) lower to resident GEMM steps.
+      (gemm-invk? expr)
+      (let [args (vec (drop 2 expr))]
+        {:convention :gemm
+         :variant (get blas-gemm-ops (:raster.op/original (meta expr)))
+         :A (nth args 0) :B (nth args 1) :C (nth args 2)
+         :m-expr (nth args 3) :k-expr (nth args 4) :n-expr (nth args 5)
+         :out-buf (nth args 2) :returns sym})
       :else nil)))
 
 (defn- contains-gpu-invoke?
@@ -1113,10 +1170,26 @@
         (cond
           (and (seq? expr) (contains? gpu-array-alloc-heads (first expr)))
           (vswap! allocs conj {:sym sym :size-expr (second expr)})
+          ;; devirtualized array alloc (alloc-like/zeros-like .invk) — a GEMM/kernel output buffer.
+          (alloc-invk? expr)
+          (vswap! allocs conj {:sym sym :size-expr (alloc-invk-size expr)})
           (and (seq? expr) (symbol? (first expr)) (contains? gpu-invoke-heads (first expr)))
           (if-let [s (parse-gpu-step sym expr)]
             (vswap! steps conj s)
             (vreset! ok false))
+          ;; devirtualized BLAS GEMM (.invk dgemm*-impl …) → a :gemm step.
+          (gemm-invk? expr)
+          (if-let [s (parse-gpu-step sym expr)]
+            (vswap! steps conj s)
+            (vreset! ok false))
+          ;; An ARRAY-tagged binding that reached here is an unlowered device-array op (an
+          ;; elementwise/reduction op with no resident kernel, or an array alias the resident path
+          ;; can't rewire) — NOT a host scalar-let. Reject the straight-line extraction so the
+          ;; caller falls back to the staging fn (rather than eval'ing an array .invk as a scalar
+          ;; size closure). E.g. an AD-emitted daxpy-diff-into! or a raw loss reduction that did
+          ;; not lower to a par kernel in this composed path.
+          (array-tag? sym)
+          (vreset! ok false)
           ;; A pure scalar binding (no nested kernel) feeds sizes/counts — keep it.
           (not (contains-gpu-invoke? expr))
           (vswap! scalar-lets into [sym expr])
@@ -1223,8 +1296,11 @@
         reg-entry (when prog (requiring-resolve 'raster.gpu.ze-runtime/kernel-registry-entry))
         written-params (when prog
                          (reduce (fn [acc s]
-                                   (let [ki (reg-entry (:kernel-name s))]
-                                     (into acc (map (comp symbol name) (:written-arrays ki)))))
+                                   (if (= :gemm (:convention s))
+                                     ;; a GEMM writes its C (out-buf) in place
+                                     (conj acc (symbol (name (:out-buf s))))
+                                     (let [ki (reg-entry (:kernel-name s))]
+                                       (into acc (map (comp symbol name) (:written-arrays ki))))))
                                  #{} (:steps prog)))
         array-roles (when prog
                       (into {} (map (fn [p] [p (if (contains? written-params p) :output :input)])
@@ -1238,24 +1314,36 @@
        :allocs (mapv (fn [{:keys [sym size-expr]}]
                        {:sym sym :size-fn (expr->arg-fn all-params scalar-lets size-expr)})
                      (:allocs prog))
-       :steps (mapv (fn [i {:keys [kernel-name arrays scalars n-expr convention output]}]
-                      {:kernel-name kernel-name
-                       :arrays arrays
-                       ;; :reduce steps carry the resident 1-elem output buffer (sym keyword) so
-                       ;; bind-program! wires it like a map output (it lives in :allocs as scratch).
-                       :output (when output (keyword (name output)))
-                       :n-fn (expr->arg-fn all-params scalar-lets n-expr)
-                       ;; Each scalar typed by the deftm's DECLARED type (the invoke scalars are
-                       ;; the kernel's scalar-param syms = deftm params), so an int param (e.g.
-                       ;; `features`) is bound as :int, not mis-typed float (→ launch error).
-                       :scalar-specs (mapv (fn [s]
-                                             {:type (or (and (symbol? s)
-                                                             (get (:scalar-types gpu-param-types) s))
-                                                        (if (= effective-dtype :double) :double :float))
-                                              :value-fn (expr->arg-fn all-params scalar-lets s)})
-                                           scalars)
-                       :convention convention
-                       :phase (keyword (str "gpu-step-" i))})
+       :steps (mapv (fn [i step]
+                      (if (= :gemm (:convention step))
+                        ;; GEMM: carries the A/B/C buffer syms + m/n/k size closures (BLAS arg
+                        ;; order is A B C m k n → keep m/n/k separate). bind-program! expands this
+                        ;; into [convert A→f16][convert B→f16][(transpose)][fp16 XMX gemm → f32 C].
+                        {:convention :gemm
+                         :variant (:variant step)
+                         :A (:A step) :B (:B step) :C (:C step)
+                         :m-fn (expr->arg-fn all-params scalar-lets (:m-expr step))
+                         :n-fn (expr->arg-fn all-params scalar-lets (:n-expr step))
+                         :k-fn (expr->arg-fn all-params scalar-lets (:k-expr step))
+                         :phase (keyword (str "gpu-step-" i))}
+                        (let [{:keys [kernel-name arrays scalars n-expr convention output]} step]
+                          {:kernel-name kernel-name
+                           :arrays arrays
+                           ;; :reduce steps carry the resident 1-elem output buffer (sym keyword) so
+                           ;; bind-program! wires it like a map output (it lives in :allocs as scratch).
+                           :output (when output (keyword (name output)))
+                           :n-fn (expr->arg-fn all-params scalar-lets n-expr)
+                           ;; Each scalar typed by the deftm's DECLARED type (the invoke scalars are
+                           ;; the kernel's scalar-param syms = deftm params), so an int param (e.g.
+                           ;; `features`) is bound as :int, not mis-typed float (→ launch error).
+                           :scalar-specs (mapv (fn [s]
+                                                 {:type (or (and (symbol? s)
+                                                                 (get (:scalar-types gpu-param-types) s))
+                                                            (if (= effective-dtype :double) :double :float))
+                                                  :value-fn (expr->arg-fn all-params scalar-lets s)})
+                                               scalars)
+                           :convention convention
+                           :phase (keyword (str "gpu-step-" i))})))
                     (range) (:steps prog))
        :result-sym (:result prog)})))
 

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -920,23 +920,35 @@
                (let [m (long ((:m-fn step) args)) n (long ((:n-fn step) args)) k (long ((:k-fn step) args))
                      abuf (buf-of (:A step) :gemm-A) bbuf (buf-of (:B step) :gemm-B)
                      cbuf (buf-of (:C step) :gemm-C)
-                     a16 (mkbuf-fn (* m k) :half)]
-                 (case (:variant step)
-                   ;; C = A[m,k] · B[k,n]
-                   :nn
-                   (let [b16 (mkbuf-fn (* k n) :half)]
-                     (swap! gemm-scratch conj a16 b16)
-                     [(conv-fn abuf a16 (* m k)) (conv-fn bbuf b16 (* k n))
-                      (gemm-fn a16 b16 cbuf m n k :float)])
-                   ;; C = A[m,k] · B[n,k]ᵀ — convert B then transpose [n,k]→[k,n], then :nn gemm.
-                   ;; (HF linear weights [out,in] and attention Q·Kᵀ are :nt.)
-                   :nt
-                   (let [b16 (mkbuf-fn (* n k) :half) bt16 (mkbuf-fn (* k n) :half)]
-                     (swap! gemm-scratch conj a16 b16 bt16)
-                     [(conv-fn abuf a16 (* m k)) (conv-fn bbuf b16 (* n k))
-                      (trans-fn b16 bt16 n k :half) (gemm-fn a16 bt16 cbuf m n k :float)])
-                   (throw (ex-info (str "GEMM variant not yet wired on resident path: " (:variant step)
-                                        " (only :nn / :nt)") {:variant (:variant step)}))))
+                     a16 (mkbuf-fn (* m k) :half)
+                     ;; each expansion kernel (convert/transpose/gemm) pre-bakes its FULL gc-seg —
+                     ;; wrap as {:bound bnd} with NO :group-count so record-graph! keeps the grid.
+                     raw
+                     (case (:variant step)
+                       ;; C = A[m,k] · B[k,n]
+                       :nn
+                       (let [b16 (mkbuf-fn (* k n) :half)]
+                         (swap! gemm-scratch conj a16 b16)
+                         [(conv-fn abuf a16 (* m k)) (conv-fn bbuf b16 (* k n))
+                          (gemm-fn a16 b16 cbuf m n k :float)])
+                       ;; C = A[m,k] · B[n,k]ᵀ — convert B then transpose [n,k]→[k,n], then :nn gemm.
+                       ;; (HF linear weights [out,in] and attention Q·Kᵀ are :nt.)
+                       :nt
+                       (let [b16 (mkbuf-fn (* n k) :half) bt16 (mkbuf-fn (* k n) :half)]
+                         (swap! gemm-scratch conj a16 b16 bt16)
+                         [(conv-fn abuf a16 (* m k)) (conv-fn bbuf b16 (* n k))
+                          (trans-fn b16 bt16 n k :half) (gemm-fn a16 bt16 cbuf m n k :float)])
+                       ;; C[m,n] = Aᵀ·B — A stored [k,m], B [k,n]. Convert A then transpose
+                       ;; [k,m]→[m,k], convert B ([k,n] already the :nn B layout), then :nn gemm.
+                       ;; (linear-dW = dgemm-tn! : the weight-gradient backward matmul.)
+                       :tn
+                       (let [at16 (mkbuf-fn (* m k) :half) b16 (mkbuf-fn (* k n) :half)]
+                         (swap! gemm-scratch conj a16 at16 b16)
+                         [(conv-fn abuf a16 (* k m)) (trans-fn a16 at16 k m :half)
+                          (conv-fn bbuf b16 (* k n)) (gemm-fn at16 b16 cbuf m n k :float)])
+                       (throw (ex-info (str "GEMM variant not yet wired on resident path: " (:variant step)
+                                            " (only :nn / :nt / :tn)") {:variant (:variant step)})))]
+                 (mapv (fn [b] {:bound b}) raw))
                ;; map / map-void bind through bind-registered-map-void-kernel (output is just
                ;; another resident buffer). Resolve buffers from the STEP's :arrays (full C-sig
                ;; order incl. output).

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -1718,9 +1718,9 @@
          :or {workgroup-size 256 identity-val 0.0 c-op "+" dtype :double}
          :as info} (ensure-kernel-loaded! kernel-name)
         combine (case c-op "fmax" (fn ^double [^double a ^double b] (Math/max a b))
-                           "fmin" (fn ^double [^double a ^double b] (Math/min a b))
-                           "*"    (fn ^double [^double a ^double b] (* a b))
-                           (fn ^double [^double a ^double b] (+ a b)))
+                      "fmin" (fn ^double [^double a ^double b] (Math/min a b))
+                      "*"    (fn ^double [^double a ^double b] (* a b))
+                      (fn ^double [^double a ^double b] (+ a b)))
         n (long n)
         wg (long (or workgroup-size 256))
         group-count (long (Math/ceil (/ (double n) wg)))
@@ -2039,23 +2039,23 @@
   Re-record only if the kernel sequence or any buffer is reallocated."
   ([prepareds] (record-graph! prepareds {:barriers? true}))
   ([prepareds {:keys [barriers?] :or {barriers? true}}]
-  (ensure-init!)
-  (let [{:keys [arena context device]} @state
-        cq-desc (.allocate ^Arena arena 40)
-        _ (.set cq-desc I32 0 (int ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC))
-        _ (.set cq-desc I32 28 (int 1)) ;; SYNCHRONOUS: execute blocks until the list completes
-        q-out (ptr-seg arena)
-        _ (ze-call! "zeCommandQueueCreate" @h-zeCommandQueueCreate
-                    [context device cq-desc q-out])
-        queue (read-ptr q-out)
-        cl-desc (.allocate ^Arena arena 24)
-        _ (.set cl-desc I32 0 (int ZE_STRUCTURE_TYPE_COMMAND_LIST_DESC))
-        l-out (ptr-seg arena)
-        _ (ze-call! "zeCommandListCreate" @h-zeCommandListCreate
-                    [context device cl-desc l-out])
-        lst (read-ptr l-out)
-        h-launch @h-zeCommandListAppendLaunchKernel
-        h-barrier @h-zeCommandListAppendBarrier]
+   (ensure-init!)
+   (let [{:keys [arena context device]} @state
+         cq-desc (.allocate ^Arena arena 40)
+         _ (.set cq-desc I32 0 (int ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC))
+         _ (.set cq-desc I32 28 (int 1)) ;; SYNCHRONOUS: execute blocks until the list completes
+         q-out (ptr-seg arena)
+         _ (ze-call! "zeCommandQueueCreate" @h-zeCommandQueueCreate
+                     [context device cq-desc q-out])
+         queue (read-ptr q-out)
+         cl-desc (.allocate ^Arena arena 24)
+         _ (.set cl-desc I32 0 (int ZE_STRUCTURE_TYPE_COMMAND_LIST_DESC))
+         l-out (ptr-seg arena)
+         _ (ze-call! "zeCommandListCreate" @h-zeCommandListCreate
+                     [context device cl-desc l-out])
+         lst (read-ptr l-out)
+         h-launch @h-zeCommandListAppendLaunchKernel
+         h-barrier @h-zeCommandListAppendBarrier]
     ;; append each bound kernel's launch (args already live on its dedicated handle; the
     ;; group-count value is captured into the recorded command at append time). A barrier
     ;; after each launch enforces ordering so a kernel sees the previous one's writes — the
@@ -2063,18 +2063,21 @@
     ;; each is memory-bound so overlap buys little; correctness first. (Measured: an IN_ORDER
     ;; command list with no barriers is the same replay time — the ~50µs/kernel floor on this
     ;; iGPU is per-dispatch overhead, not the barrier. Fewer/bigger kernels is the lever.)
-    (doseq [{:keys [bound group-count]} prepareds]
-      (let [^MemorySegment gc (:gc-seg bound)]
-        (.set gc I32 0 (int group-count))
-        (ze-call! "zeCommandListAppendLaunchKernel" h-launch
-                  [lst (:kernel bound) gc MemorySegment/NULL (int 0) MemorySegment/NULL])
-        (when barriers?
-          (ze-call! "zeCommandListAppendBarrier" h-barrier
-                    [lst MemorySegment/NULL (int 0) MemorySegment/NULL]))))
-    (ze-call! "zeCommandListClose" @h-zeCommandListClose [lst])
-    (let [lists-arr (ptr-seg arena)]
-      (.set lists-arr PTR 0 ^MemorySegment lst)
-      {:queue queue :list lst :lists-arr lists-arr}))))
+     (doseq [{:keys [bound group-count]} prepareds]
+       (let [^MemorySegment gc (:gc-seg bound)]
+        ;; A 1D map/map-void carries its X-grid as group-count (Y=Z=1 pre-filled). A GEMM /
+        ;; convert / transpose expansion pre-bakes its FULL (2D) gc-seg at bind time and passes
+        ;; group-count = nil — leave its X/Y/Z untouched (overwriting X would break the 2D grid).
+         (when (some? group-count) (.set gc I32 0 (int group-count)))
+         (ze-call! "zeCommandListAppendLaunchKernel" h-launch
+                   [lst (:kernel bound) gc MemorySegment/NULL (int 0) MemorySegment/NULL])
+         (when barriers?
+           (ze-call! "zeCommandListAppendBarrier" h-barrier
+                     [lst MemorySegment/NULL (int 0) MemorySegment/NULL]))))
+     (ze-call! "zeCommandListClose" @h-zeCommandListClose [lst])
+     (let [lists-arr (ptr-seg arena)]
+       (.set lists-arr PTR 0 ^MemorySegment lst)
+       {:queue queue :list lst :lists-arr lists-arr}))))
 
 (defn replay-graph!
   "Execute a recorded command graph once. Synchronous (the queue blocks until complete)."
@@ -2420,9 +2423,9 @@
          :or {workgroup-size 256 identity-val 0.0 c-op "+" dtype :float}
          :as info} (ensure-kernel-loaded! kernel-name)
         combine (case c-op "fmax" (fn ^double [^double a ^double b] (Math/max a b))
-                           "fmin" (fn ^double [^double a ^double b] (Math/min a b))
-                           "*"    (fn ^double [^double a ^double b] (* a b))
-                           (fn ^double [^double a ^double b] (+ a b)))
+                      "fmin" (fn ^double [^double a ^double b] (Math/min a b))
+                      "*"    (fn ^double [^double a ^double b] (* a b))
+                      (fn ^double [^double a ^double b] (+ a b)))
         n (long n)
         wg (long (or workgroup-size 256))
         group-count (long (Math/ceil (/ (double n) wg)))

--- a/test/raster/dl/gpu_ad_gemm_test.clj
+++ b/test/raster/dl/gpu_ad_gemm_test.clj
@@ -1,0 +1,105 @@
+(ns raster.dl.gpu-ad-gemm-test
+  "GPU-AD validation: the matmuls an AD-transformed train step emits — the forward projection
+   (linear-nb → dgemm-nt!, :nt) and its two backward gradients (linear-dx → dgemm!, :nn;
+   linear-dW → dgemm-tn!, :tn) — each lower through compile-gpu-program to a RESIDENT XMX GEMM
+   graph and match the CPU BLAS reference. This is the empirical end of the framework claim
+   that AD-transformed IR flows through the GPU pipeline: the backward kernels ARE ordinary
+   GEMMs, so recognizing them on the resident path (incl. the :tn weight-gradient variant) is
+   what makes gradient computation run on device.
+
+   The full mse∘linear-nb TRAIN STEP does NOT yet fully lower (its loss reduction + the
+   daxpy-diff-into! elementwise gradient have no resident kernel in the composed AD path);
+   compile-gpu-program returns nil for it (clean staging-fn fallback). That current boundary is
+   asserted below so progress flips it — see .internal/ad_gpu_residency.md.
+
+   Level-Zero / Intel-XMX only (the fp16 DPAS GEMM kernel). Skips cleanly without a GPU."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.pipeline :as pl]
+            [raster.dl.nn :as nn]))
+
+(def ^:private gpu-available?
+  (delay (try (require 'raster.gpu.ze-runtime)
+              (boolean (seq ((resolve 'raster.gpu.ze-runtime/query-devices))))
+              (catch Throwable _ false))))
+
+(defn- rnd [n seed]
+  (let [a (float-array n) r (java.util.Random. seed)]
+    (dotimes [i n] (aset a i (float (- (.nextDouble r) 0.5))))
+    a))
+
+(defn- rel-err [gpu cpu]
+  (let [err (reduce max 0.0 (map #(Math/abs (double (- %1 %2))) (seq gpu) (seq cpu)))
+        mag (reduce max 1e-9 (map #(Math/abs (double %)) cpu))]
+    (/ err mag)))
+
+(defn- run-resident [f-var args]
+  (let [gpu (do (require 'raster.gpu.core) (find-ns 'raster.gpu.core))
+        make-session (ns-resolve gpu 'make-session)
+        bind-program! (ns-resolve gpu 'bind-program!)
+        run-program! (ns-resolve gpu 'run-program!)
+        close-session! (ns-resolve gpu 'close-session!)
+        p (pl/compile-gpu-program f-var :ze:0 :dtype :float)
+        s (make-session :ze:0)]
+    (try
+      (bind-program! s p args {})
+      (let [r (run-program! s p args)]
+        {:descriptor p :out (or (get r (:result-sym p)) (first (vals r)))})
+      (finally (close-session! s)))))
+
+(deftest gpu-ad-gemm-variants
+  (if-not @gpu-available?
+    (println "  [SKIP] gpu-ad-gemm: no Level Zero GPU")
+    ;; XMX-friendly dims (multiples of 16); batch=16, in-f=32, out-f=16.
+    (let [b 16 i 32 o 16
+          ;; fp16 XMX GEMM: ~2.5e-4 relative error is the precision floor for these dims.
+          tol 5e-3]
+      (testing "forward linear-nb (:nt) on GPU matches CPU BLAS"
+        (let [x (rnd (* b i) 1) W (rnd (* o i) 2)
+              cpu (nn/linear-nb x W b i o)
+              {:keys [descriptor out]} (run-resident #'nn/linear-nb [x W b i o])]
+          (is (= [:nt] (mapv :variant (:steps descriptor)))
+              "forward projection lowers to a single :nt resident GEMM step")
+          (is (< (rel-err out cpu) tol)
+              (str "forward relerr " (rel-err out cpu)))))
+      (testing "backward linear-dx (:nn) on GPU matches CPU BLAS"
+        (let [dy (rnd (* b o) 3) W (rnd (* o i) 4)
+              cpu (nn/linear-dx dy W b i o)
+              {:keys [descriptor out]} (run-resident #'nn/linear-dx [dy W b i o])]
+          (is (= [:nn] (mapv :variant (:steps descriptor))))
+          (is (< (rel-err out cpu) tol)
+              (str "linear-dx relerr " (rel-err out cpu)))))
+      (testing "backward linear-dW (:tn, weight gradient) on GPU matches CPU BLAS"
+        (let [dy (rnd (* b o) 5) x (rnd (* b i) 6)
+              cpu (nn/linear-dW dy x b i o)
+              {:keys [descriptor out]} (run-resident #'nn/linear-dW [dy x b i o])]
+          (is (= [:tn] (mapv :variant (:steps descriptor)))
+              "weight-gradient lowers to a :tn resident GEMM step (transpose-A path)")
+          (is (< (rel-err out cpu) tol)
+              (str "linear-dW relerr " (rel-err out cpu))))))))
+
+(deftest gpu-ad-full-train-step-residency-boundary
+  ;; This test does NOT need a GPU — it pins the CURRENT residency boundary at the IR level.
+  ;; The full mse∘linear-nb float train step (value+grad + SGD) is AD-transformed and its 3
+  ;; matmuls DO lower to resident GEMM steps, but its loss reduction (mse-loss) and the
+  ;; daxpy-diff-into! elementwise gradient have no resident kernel in this composed path, so
+  ;; compile-gpu-program returns nil (→ compile-aot :target-device uses the staging fn). When
+  ;; the saved-activation / elementwise-loss lowering lands (see .internal/ad_gpu_residency.md),
+  ;; this returns a descriptor and the assertion below must flip to a full end-to-end run.
+  (require 'raster.core 'raster.dl.loss 'raster.dl.optim 'raster.ad.reverse 'raster.arrays)
+  (let [loss (eval '(raster.core/deftm gpu-ad-probe-loss
+                      [W :- (Array float) x :- (Array float) tgt :- (Array float)
+                       batch :- Long in-f :- Long out-f :- Long] :- Double
+                      (let [pred (raster.dl.nn/linear-nb x W batch in-f out-f)]
+                        (raster.dl.loss/mse-loss pred tgt (clojure.core/* batch out-f)))))
+        train (eval '(raster.core/deftm gpu-ad-probe-train
+                       [W :- (Array float) x :- (Array float) tgt :- (Array float)
+                        batch :- Long in-f :- Long out-f :- Long lr :- Double] :- Double
+                       (let [vg ((raster.ad.reverse/value+grad #'gpu-ad-probe-loss)
+                                 W x tgt batch in-f out-f)
+                             loss (clojure.core/nth vg 0)
+                             dW (clojure.core/nth vg 1)]
+                         (raster.dl.optim/sgd-step! W dW (raster.arrays/alength W) lr)
+                         loss)))]
+    (testing "full AD train step is not yet a fully-resident program (documents the gap)"
+      (is (nil? (pl/compile-gpu-program train :ze:0 :dtype :float))
+          "mse reduction + daxpy elementwise gradient have no resident kernel yet"))))


### PR DESCRIPTION
The GPU validation + completion phase (framework §13 step 5, scoped honestly: validate → wire cheap gaps → design-doc the rest).

**Validation (empirical, Intel Arc / Level Zero XMX)** — the "AD-IR flows through the GPU pipeline" claim is now confirmed at the kernel level:

| stage | result |
|---|---|
| AD transform reaches GPU lowering (post-SOA IR carries fwd `:nt` + bwd `:nn` + bwd `:tn` GEMMs, `:raster.op/original` intact) | ✅ |
| forward `linear-nb` resident GEMM vs CPU | ✅ 2.55e-4 (fp16 XMX) |
| **backward `linear-dx`** resident vs CPU | ✅ 2.28e-4 |
| **backward `linear-dW` (`:tn`)** resident vs CPU | ✅ 2.60e-4 |
| full train step as ONE resident graph | ❌ graceful nil — loss-reduction + elementwise-gradient kernels not yet resident (the pinned coverage gap) |

**Wired** (validated): GEMM-to-resident recognition **restored** — it had been dropped in the `bcb7131` curation redo, so *no* backward matmul reached the resident path (the real blocker; `:tn`-unwired was the visible symptom); `:tn` bind path (the weight gradient); `record-graph!` 2D-grid fix; devirtualized `zeros-like`/`alloc-like` recognized as device allocs; clean fallback for unlowered device-array ops.

**Pinned, not built** (with estimates): non-matmul gradient kernels → SOAC inlining for a one-graph train step (~2–4 d, the real coverage gap); pre-existing small-dim XMX DPAS bug (M<16 garbage rows, independent of AD, ~1 d); `aget-grad` scatter (not hit by this corpus); `:tt` (unneeded).

**Residency design note** (`.internal/ad_gpu_residency.md`): the saved-activation policy is the *same* store-vs-recompute decision as loop checkpointing (§15 convergence); donation set = params; correctly sequenced AFTER the coverage gap (nothing to govern until a full step lowers to one graph).

Tests: `gpu_ad_gemm_test.clj` — GPU-vs-CPU differential for all three GEMM variants (self-skipping), plus a **boundary test that flips** when the coverage gap lands.

Valhalla fresh JVM: **1743 / 29085 / 0 / 0, census 0**.