### PR TITLE
AD: loop canonicalization — raw loops differentiate transparently (framework §15.2)

### DIFF
--- a/design/autodiff.md
+++ b/design/autodiff.md
@@ -1,335 +1,507 @@
 # Automatic Differentiation in Raster
 
-Raster provides forward-mode and reverse-mode automatic differentiation (AD)
-integrated with the compiler pipeline. AD operators produce `deftm`-compatible
-forms that the compiler can inline, optimize, and compile to bytecode — the
-same training step that runs at 62us/step on CPU uses AD for the full backward
-pass.
+Raster differentiates ordinary `deftm` code. Because every arithmetic op
+(`raster.numeric/+`, `raster.math/sin`, `raster.dl.nn/linear-nb`, …) is a typed
+multiple-dispatch function, the *same* op definition runs with plain numbers, with
+`Dual` numbers (forward mode), with symbolic `Sym` values, or spliced into the IR
+and compiled. AD is not a separate interpreter — it is a set of *interpretations*
+of the one op signature, and the compiler consumes the result: the backward pass of
+a BLAS-accelerated forward pass is itself BLAS, visible to fusion and bytecode
+emission. Compiled MLP/LeNet training steps (forward + AD backward + SGD) run at
+143 µs / 221 µs on CPU (Valhalla JDK).
 
-## Two Modes
-
-### Forward-Mode: Dual Numbers
-
-Forward-mode propagates derivatives alongside primal values using Dual numbers:
-
-```
-Dual(v, dv) where v = f(x), dv = f'(x)·dx
-```
-
-Arithmetic on Duals implements the derivative rules:
-
-```
-Dual(a, da) + Dual(b, db) = Dual(a+b, da+db)
-Dual(a, da) * Dual(b, db) = Dual(a*b, a·db + b·da)
-sin(Dual(a, da))           = Dual(sin(a), cos(a)·da)
-```
-
-This works because `deftm` dispatch selects the Dual overload automatically.
-A function `f: R^n -> R` written with `raster.numeric/+`, `raster.numeric/*`,
-etc. will propagate derivatives when called with Dual inputs — no source
-transformation needed.
-
-**Multi-variable gradients** use chunked evaluation: each Dual carries `k`
-partial derivatives simultaneously, so computing `n` partials requires
-`ceil(n/k)` forward passes instead of `n`.
+Every example is REPL-validated (`;=>` = actual output) and mirrors a law family
+(O1–O10) in `test/raster/ad/laws_test.clj`.
 
 ```clojure
-(require '[raster.ad.forward :as fwd])
+(require '[raster.ad.reverse :as rev]   '[raster.ad.forward :as fwd]
+         '[raster.ad.jvp :as jvp]       '[raster.ad.jet :as jet]
+         '[raster.ad.tangent :as tangent] '[raster.ad.templates :as tmpl]
+         '[raster.numeric :as n] '[raster.math :as m] '[raster.arrays :as ra]
+         '[raster.par :as par] '[raster.core :refer [deftm]]
+         '[raster.sym.core :as sym] '[raster.sym.diff :as sdiff]
+         '[raster.dl.nn :as nn] '[raster.dl.loss :as loss])
 
-;; Single derivative
-(fwd/derivative (fn [x] (* x x x)) 2.0)  ;=> 12.0  (3x^2 at x=2)
-
-;; Gradient of f: R^n -> R
-(fwd/gradient (fn [xs] (+ (* (nth xs 0) (nth xs 0))
-                          (* (nth xs 1) (nth xs 1))))
-              [3.0 4.0])
-;=> [6.0 8.0]  (nabla(x^2 + y^2) = [2x, 2y])
+;; deterministic Gaussian float array, used by the array examples below
+(defn- fa [n seed]
+  (let [r (java.util.Random. (long seed)) a (float-array n)]
+    (dotimes [i n] (aset a i (float (.nextGaussian r)))) a))
 ```
 
-**When to use forward-mode:** Few inputs, many outputs (Jacobians), or when
-you need derivatives of functions that take non-differentiable control flow
-paths (Dual propagation handles branches naturally).
+## 1. Quick start
 
-### Reverse-Mode: Closures-as-Tape
+`value+grad` returns `[primal grads…]`; `grad` returns just the gradient (a bare
+scalar for a 1-param function — JAX semantics — a vector for multiple params).
 
-Reverse-mode computes gradients by transforming the source IR into a forward
-pass + backward pass. Raster uses the **closures-as-tape** approach (from
-Myia): the backward pass is a closure that captures forward intermediates,
-rather than an explicit tape data structure.
-
-For a function `f: R^n -> R`, reverse-mode computes all `n` partial
-derivatives in a single backward pass — O(1) passes regardless of `n`.
-
-The transformation operates on the walked S-expression (flat `let*` form):
-
-**Forward pass:**
 ```clojure
-(let* [a (* x y)       ;; record: pullback_a needs x, y
-       b (sin a)        ;; record: pullback_b needs a
-       c (+ b 1.0)]     ;; record: pullback_c is trivial
-  c)
+(deftm docqs-poly [x :- Double] :- Double          ;; f = x³ + 2x, f' = 3x² + 2
+  (n/+ (n/* x (n/* x x)) (n/* 2.0 x)))
+
+((rev/value+grad #'docqs-poly) 3.0)   ;=> [33.0 29.0]
+((rev/grad        #'docqs-poly) 3.0)  ;=> 29.0
 ```
 
-**Backward pass (generated):**
+For an array loss — float mean-squared-error over a bias-free linear layer — the
+gradient of each parameter comes back typed in that parameter's own dtype:
+
 ```clojure
-;; Start with dc = 1.0 (adjoint of output)
-(let* [dc    1.0
-       db    dc                    ;; d/db(b + 1.0) = 1
-       da    (* db (cos a))        ;; d/da(sin(a)) = cos(a)
-       dx    (* da y)              ;; d/dx(x*y) = y
-       dy    (* da x)]             ;; d/dy(x*y) = x
-  [c dx dy])                       ;; return [primal, gradients...]
+(deftm docqs-mse [x :- (Array float) W :- (Array float) tgt :- (Array float)
+                  batch :- Long in :- Long out :- Long] :- Double
+  (loss/mse-loss (nn/linear-nb x W batch in out) tgt (clojure.core/* batch out)))
+
+(let [x (fa 8 1) W (fa 12 2) tgt (fa 6 3)          ;; fa = deterministic float array
+      [loss gx gW gtgt] ((rev/value+grad #'docqs-mse) x W tgt 2 4 3)]
+  [loss (.getName (class gx)) (vec (take 3 gx))])
+;=> [3.3568948109944663 "[F" [0.15883432 0.15100321 0.021924283]]
 ```
 
-Each primitive operation has a registered **pullback** — a function that maps
-output adjoints to input adjoints. These are stored in the rrule registry.
+## 2. Mental model
 
-## Composable Operators: `grad` and `value+grad`
+A `deftm` denotes a piecewise-smooth map `f : X × P → Y`: `X` the differentiable
+inputs (scalars, dtype-tagged arrays), `P` the *parameters with no tangent space*
+(Long indices, shapes, seeds, booleans). Differentiation produces two linear maps
+at a point: the pushforward `df_x : X→Y` ("J·v", forward mode applies it to an
+input tangent) and the pullback `df*_x : Y→X` ("Jᵀ·w", reverse mode applies it to
+an output cotangent).
 
-The primary API for differentiation:
+**Modes are interpretations, not implementations.** The op set is a signature; an
+AD mode picks a *carrier* (what flows through the ops) × a *stage* (when):
+
+| carrier ╲ stage | immediate (interpret) | staged (compile) |
+|---|---|---|
+| ℝ (Double/Float) | plain evaluation | `compile-aot` forward |
+| **Dual** = ℝ[ε]/ε² | forward-mode derivative | compiled forward |
+| **Jet** = ℝ[ε]/εᵏ⁺¹ | k-th-order (higher derivatives) | — |
+| **Sym** (initial algebra) | symbolic trace = the IR itself | symbolic AD |
+| (value, cotangent) | runtime `value+grad` | compiled reverse (spliced + fused) |
+
+**A rule is ONE Jacobian presentation with two contractions.** For a primitive
+`p`, its per-param `:grads` is the reverse contraction (Jᵀ·w). The forward
+contraction (J·v) is *derived* from a small structure tag —
+`{:elementwise, :symmetric, :linear, :bilinear, :scalar-loss}` — never a second
+hand-written table. Dual/Jet/Sym need no rule table at all: the chain rule is
+implicit in evaluation order, so any op with the right overloads just works.
+There is no symbolic-vs-runtime split in a rule; the body is ordinary code and the
+engine chooses whether to eval it, splice it, or trace it.
+
+## 3. The operators
+
+### value+grad / grad
+
+`grad` peels the primal off `value+grad`. Shape follows arity:
 
 ```clojure
-(require '[raster.ad.reverse :as rev])
+(deftm doc-quad2 [x :- Double y :- Double] :- Double (n/+ (n/* x x) (n/* x y)))
 
-;; Returns [f(x,y), df/dx, df/dy]
-((rev/value+grad #'my-loss) 3.0 4.0)
-;=> [25.0 6.0 8.0]
+((rev/grad #'docqs-poly) 3.0)          ;=> 29.0        ; 1 param → bare scalar
+(vec ((rev/grad #'doc-quad2) 3.0 4.0)) ;=> [10.0 3.0]  ; n params → vector
+```
 
-;; Returns [df/dx, df/dy] only
-((rev/grad #'my-loss) 3.0 4.0)
+Long/shape slots are `⊥` (NoTangent): they get `nil` grads and never seed. In the
+array example above, `gtgt` is a typed zero and the `batch/in/out` slots are
+`nil` (law O3).
+
+### jvp — directional derivative through array ops
+
+`jvp` builds a function taking the primal args followed by a tangent per
+differentiable arg. It threads tangents forward through every array op, deriving
+each op's frule from its structure class (elementwise / symmetric / linear /
+bilinear derived mechanically; the residue — softmax, norms, attention — is a few
+hand-written frules). Output tangents are plain `float[]`/`double[]`, so the whole
+thing stays fusible and GPU-ready (law O1b).
+
+```clojure
+(let [jf (jvp/jvp #'docqs-mse)
+      x (fa 8 1) W (fa 12 2) tgt (fa 6 3)
+      v (fa 8 9)                              ;; tangent seeded on x
+      [primal tangent] (jf x W tgt 2 4 3 v (float-array 12) (float-array 6))]
+  [primal tangent])
+;=> [3.3568948109944663 1.0070443153381348]   ; directional FD ≈ 1.0070641835
+```
+
+### hvp — Hessian-vector product (forward-over-reverse)
+
+`jvp/hvp` is the JVP fold applied to the *reified gradient program* (Pearlmutter
+1994): one reverse sweep to build ∇f, one forward sweep to push a tangent through
+it. Cost is O(cost of f) per H·v, no Hessian formed. It returns `[grads Hv]`.
+
+```clojure
+(deftm docquad [x :- Double y :- Double] :- Double (n/+ (n/* x x) (n/* x y)))
+;; quad = x² + xy, Hessian [[2 1][1 0]]
+((jvp/hvp #'docquad) 3.0 2.0 1.0 0.0)   ;=> [[8.0 3.0] [2.0 1.0]]   ; grads, H·e1
+((jvp/hvp #'docquad) 3.0 2.0 0.0 1.0)   ;=> [[8.0 3.0] [1.0 0.0]]   ; H·e2
+```
+
+It runs through array layers too — an MLP loss, seeding a tangent on `x`, matched
+against FD-of-gradient in law O4b:
+
+```clojure
+(let [hf (jvp/hvp #'docqs-mse)
+      x (fa 8 1) W (fa 12 2) tgt (fa 6 3) v (fa 8 9)
+      [grads hv] (hf x W tgt 2 4 3 v (float-array 12) (float-array 6))]
+  [(.getName (class (nth hv 0))) (vec (take 3 (nth hv 0)))])
+;=> ["[F" [0.86591256 1.34398 -0.076107144]]
+```
+
+### Double-backward via transparent composition
+
+The headline: **nesting differentiation happens through ordinary program use.**
+The same syntax works nested or not. The idiom is to call an inner gradient inside
+a scalar `deftm` and differentiate *that*:
+
+```clojure
+(deftm doccube [x :- Double] :- Double (n/* x (n/* x x)))   ;; x³
+
+(deftm docouter [x :- Double] :- Double
+  (let [vg ((rev/value+grad #'doccube) x)                   ;; g = 3x²
+        g  (double (nth vg 1))]
+    (n/* g g)))                                             ;; 9x⁴ → d/dx = 36x³
+
+((rev/value+grad #'docouter) 2.0)   ;=> [144.0 288.0]       ; (3·4)², 36·8
+```
+
+For a 1-param scalar function `grad` returns a bare scalar, so the textbook
+spelling composes literally, and `reified-grad` scalarizes a gradient program so
+`value+grad` can consume it (law O4c/O4d):
+
+```clojure
+((rev/grad (rev/grad #'doccube)) 2.0)                    ;=> 12.0   ; f″ = 6x
+((rev/value+grad (rev/reified-grad #'doccube 'x)) 2.0)   ;=> [12.0 12.0]  ; [3x², 6x]
+```
+
+Applying an operator *directly* to another operator over a tuple output is
+ill-typed — a product cotangent space has no canonical seed — and it **fails
+loud** (this is a feature: it used to be a silent zero):
+
+```clojure
+(try ((rev/value+grad (rev/value+grad #'doccube)) 2.0)
+     (catch Exception e (.getMessage e)))
+;=> "Cannot differentiate the tuple-valued function `…` — its output is a vector,
+;    which has no canonical cotangent seed (this is what value+grad returns;
+;    value+grad of value+grad is ill-typed). Compose transparently instead: call
+;    the inner gradient in a scalar deftm and differentiate that … For 1-param
+;    scalar fns, (grad (grad f)) composes directly."
+```
+
+### Loops & recurrences — write loops, they differentiate
+
+The other headline: a raw `(loop [i 0 …] …)` with a static/affine trip count is
+**canonicalized to a `par/scan`/`par/reduce` in `ad-prepare`** — before the
+reverse transform ever sees it — so the user does not rewrite anything (unlike
+JAX, which makes you convert `while`→`scan`). A loop-written linear RNN and its
+`par/scan` twin give bit-identical gradients (law O10):
+
+```clojure
+(deftm docrnn-loop [w :- Double h0 :- Double x :- (Array double) sn :- Long] :- Double
+  (let [out (double-array sn)]
+    (loop [i 0 h h0]                                   ;; per-step store, return carry
+      (if (< i sn)
+        (let [h2 (n/+ (n/* w h) (ra/aget x i))] (ra/aset out i h2) (recur (inc i) h2))
+        h))))
+
+(deftm docrnn-scan [w :- Double h0 :- Double x :- (Array double) sn :- Long] :- Double
+  (let [out (double-array sn)                          ;; explicit par/scan: out[i]=acc_i
+        h (par/scan out acc h0 i sn double (n/+ (n/* w acc) (ra/aget x i)))]
+    (ra/aget h (dec sn))))
+
+(let [w 0.6 h0 0.8 x (double-array [0.7 -1.3 0.4 0.9])
+      r1 ((rev/value+grad #'docrnn-loop) w h0 x 4)
+      r2 ((rev/value+grad #'docrnn-scan) w h0 x 4)]
+  [(take 3 r1) (= (nth r1 1) (nth r2 1))])
+;=> [(0.92688 0.28719999999999996 0.1296) true]   ; loop ≡ scan, exact
+```
+
+`par/scan` is the sanctioned differentiable recurrence: because `out[i] = acc_i`,
+the output array *is* the carry tape — no closure tape, no residual stack (Griewank
+store-the-carry at every step). Tail-accumulation loops lift to `par/reduce`:
+
+```clojure
+(deftm doc-ssq [xs :- (Array double) rn :- Long] :- Double
+  (loop [i 0 acc 0.0]
+    (if (< i rn) (recur (inc i) (n/+ acc (n/* (ra/aget xs i) (ra/aget xs i)))) acc)))
+(let [xs (double-array [1.0 2.0 3.0])
+      [v dxs] ((rev/value+grad #'doc-ssq) xs 3)] [v (vec dxs)])
+;=> [14.0 [2.0 4.0 6.0]]   ; Σx², grad 2xᵢ exact
+```
+
+A **data-dependent** trip count (the bound reads the carry) has no sized residual
+stack, so the soundness gates decline and it fails loud, pointing at the modeling
+alternatives:
+
+```clojure
+(deftm docdatadep [x :- Double] :- Double
+  (loop [i 0 acc x] (if (< i (long acc)) (recur (inc i) (n/+ acc x)) acc)))
+(try (rev/value+grad #'docdatadep) (catch Exception e (subs (.getMessage e) 0 96)))
+;=> "value+grad: cannot assemble a runtime gradient for `#'user/docdatadep` — the body reduces to a l"
+;    …full message: express the recurrence via `par/scan`, a convergence loop via a fixed-point solve.
+```
+
+### Dual forward mode (scalar)
+
+`:mode :forward` runs the body over `Dual` numbers; agreement with reverse is law
+O1. Forward is the right choice for few inputs / many outputs, and its Dual
+comparison overloads let it flow through `if` branches (a.e.-correct):
+
+```clojure
+(deftm docfwd [x :- Double] :- Double (n/+ (n/* x (m/sin x)) (m/exp x)))
+[(nth ((rev/value+grad #'docfwd :mode :forward) 1.3) 1)
+ (nth ((rev/value+grad #'docfwd :mode :reverse) 1.3) 1)]
+;=> [4.980603330248401 4.9806033302484005]
+```
+
+The lower-level `fwd/derivative` / `fwd/gradient` compute single derivatives and
+∇ directly over Duals:
+
+```clojure
+(fwd/derivative (fn [x] (n/* x (n/* x x))) 2.0)   ;=> 12.0
+(vec (fwd/gradient (fn [xs] (n/+ (n/* (nth xs 0) (nth xs 0))
+                                 (n/* (nth xs 1) (nth xs 1)))) [3.0 4.0]))
 ;=> [6.0 8.0]
 ```
 
-These operators are **composable with the compiler**. The returned function
-carries `deftm` metadata (`:raster.core/deftm-walked-body`,
-`:raster.core/deftm-params`, `:raster.core/deftm-tags`), so when used
-inside a compiled `deftm`, the compiler can inline the AD-expanded form:
+### Jets — higher-order derivatives
+
+A `Jet` is a truncated Taylor ring ℝ[ε]/εᵏ⁺¹; one pass gives all derivatives up to
+order k in O(k²) work (vs nested Duals' O(2ᵏ)). Law O4:
 
 ```clojure
-(deftm train-step
-  [W1 :- (Array double), b1 :- (Array double),
-   W2 :- (Array double), b2 :- (Array double),
-   x :- (Array double), y :- (Array double),
-   lr :- Double] :- Double
-  (let [vg ((rev/value+grad (var nn/loss-fn)) W1 b1 W2 b2 x y)
-        loss (nth vg 0)]
-    (optim/sgd-step! W1 (nth vg 1) (arrays/alength W1) lr)
-    ;; ... update other params ...
-    loss))
+(vec (jet/higher-derivatives (fn [x] (m/sin x)) Math/PI 3))
+;=> [1.2246467991473532E-16 -1.0 -1.2246467991473532E-16 1.0]
+;   [sin(π)≈0, cos(π)=-1, -sin(π)≈0, -cos(π)=1]
 ```
 
-When `compile-aot` compiles this, the `value+grad` call is expanded
-into ~80 flat bindings covering the full forward + backward pass. The compiler
-then applies buffer fusion, memory merge, and bytecode emission to the
-combined form — producing a single JVM class with zero per-call allocations.
+### Symbolic — two routes, one answer
 
-## The Template Registry
-
-Gradient rules live in a single registry (`templates.clj`). The canonical form
-is `:grads` — static S-expression gradients that the reverse pass splices into
-the generated code. At registration time `:grads` is auto-compiled to a
-`:grads-fn` (a code-generating closure); both the compiled path and the
-interpreted `value+grad` path run the *same* generated backward bindings, so
-there is one source of truth per op:
+Because `Sym` is the *initial* algebra, symbolic differentiation is free: run any
+mode over `Sym` carriers. `sym/differentiate` (the calculus table) and `Dual{Sym}`
+(the *same* numeric ops over a symbolic carrier — no table) agree (law O6):
 
 ```clojure
-(register-template! 'raster.math/sin
-  {:params '[x]
-   :result 'y
-   :adjoint 'dy
-   :grads [(list 'raster.numeric/* 'dy (list 'raster.math/cos 'x))]})
+(defn- o6f [x] (n/+ (n/* x (m/sin x)) (m/exp x)))
+(let [traced  (sym/unwrap (o6f (sym/sym 'x)))
+      route-a (sdiff/differentiate traced 'x)            ;; diff.clj calculus
+      dx (fwd/make-dual (sym/sym 'x) (object-array [(sym/sym 1)]))
+      route-b (sym/unwrap (aget ^objects (.partials (o6f dx)) 0))]  ;; Dual{Sym}
+  [route-a route-b])
+;=> [(+ (+ (sin x) (* x (cos x))) (exp x))
+;    (+ (+ (* x (* 1 (cos x))) (* 1 (sin x))) (* 1 (exp x)))]
+;   both = sin(x) + x·cos(x) + eˣ  (route-b before (* 1 ·) simplification)
 ```
 
-For ops whose backward isn't a simple S-expression (array kernels calling BLAS
-backward routines), a `:grads-fn` may be supplied directly — it emits flat
-`let*` bindings that call the backward deftm (e.g. `linear-dx`/`linear-dW`),
-keeping the backward pass BLAS-visible to buffer fusion.
+### IFT / fixed-point
 
-The compiler's inline pass checks for `:grads` / `:grads-fn` metadata to
-decide whether a `deftm` call is **AD-opaque** (has an explicit gradient rule,
-stays symbolic during AD) or **AD-transparent** (no rule, gets inlined and
-differentiated through — the Zygote "recurse-into-IR unless a rule exists"
-model).
-
-For the MLP training step, `dense`, `relu`, `softmax`, and `cross-entropy`
-all have explicit gradient templates. Their rules are inlined as flat `let*`
-bindings in the backward pass, making buffer fusion and BLAS dispatch
-visible to the compiler.
-
-## Higher-Order Differentiation
-
-### Jets: Truncated Taylor Polynomials
-
-For computing k-th order derivatives efficiently, Raster provides Jet
-arithmetic — truncated Taylor polynomial rings:
-
-```
-Jet(order=k, coeffs=[f(a), f'(a)/1!, f''(a)/2!, ..., f^(k)(a)/k!])
-```
-
-Arithmetic on Jets uses truncated Cauchy products:
-
-```
-(Jet a) * (Jet b) = Jet c where c[k] = sum_{j=0}^{k} a[j] * b[k-j]
-```
-
-This gives all derivatives up to order k in a single pass with O(k^2)
-work per arithmetic operation — much better than nested Duals which
-require O(2^k) work.
+`fixed-point-solve` finds z* = g(z*, θ) and carries an rrule that applies the
+Implicit Function Theorem — dz*/dθ = (∂g/∂θ)/(1 − ∂g/∂z) — instead of unrolling
+the iteration. Exact at convergence, O(1) memory:
 
 ```clojure
-(require '[raster.ad.jet :as jet])
-
-;; All derivatives of sin(x) at x=pi up to order 3:
-(jet/higher-derivatives (fn [x] (Math/sin x)) Math/PI 3)
-;=> [~0, -1.0, ~0, 1.0]  ;; [sin(pi), cos(pi), -sin(pi), -cos(pi)]
+(require '[raster.ad.fixed-point :as fp] '[raster.core :refer [ftm]])
+(deftm docift [theta :- Double] :- Double            ;; g(z,θ)=½z+θ ⇒ z*=2θ, dz*/dθ=2
+  (fp/fixed-point-solve (ftm [z :- Double th :- Double] :- Double (n/+ (n/* 0.5 z) th))
+                        0.0 theta 1e-12 1000))
+((rev/value+grad #'docift) 3.0)   ;=> [5.999999999999318 2.0]
 ```
 
-Math functions on Jets use recurrence relations (Griewank & Walther,
-Algorithm 13.1). For example, `exp(f)`:
+### :mode :auto and admissibility
 
-```
-e[0] = exp(f[0])
-e[k] = (1/k) * sum_{j=1}^{k} j * f[j] * e[k-j]
-```
-
-### Hessian-Vector Products
-
-For second-order optimization, `compile-hvp-fn` computes Hessian-vector
-products `H*v` without forming the full Hessian:
+`:auto` selects the cheapest *admissible* mode: cheapest by the Griewank dimension
+test, but constrained to carriers whose ops are all covered. `forward-coverage`
+names the uncovered ops. `erf` has a Dual lift, so `:auto` may go forward; a raw
+JVM `Math/expm1` interop can never have a Dual lift, so `:auto` must stay reverse
+(law O5):
 
 ```clojure
-(let [hvp (rev/compile-hvp-fn #'rosenbrock)]
-  (hvp [1.0 1.0] [0.1 0.0]))  ;; H(1,1) * [0.1, 0]
+(deftm docerf   [x :- Double] :- Double (raster.sci.special/erf x))
+(deftm docuncov [x :- Double] :- Double (n/* x (Math/expm1 (double x))))
+[(rev/forward-admissible? #'docerf)
+ (rev/forward-admissible? #'docuncov)
+ (:uncovered-ops (rev/forward-coverage #'docuncov))
+ (nth ((rev/value+grad #'docuncov :mode :auto) 0.7) 1)]   ;; auto → reverse, correct
+;=> [true false [Math/expm1] 0.6912748604105386]
 ```
 
-This uses reverse-over-forward AD:
-1. Compute `g(x) = v^T * grad(f)(x)` (a scalar function of x)
-2. Differentiate `g` with respect to x → `H*v`
+Forcing an inadmissible mode fails at *construction* time (never a
+No-matching-method at call time):
 
-Cost: O(n) for n parameters, regardless of Hessian size. This enables
-Newton-CG and trust-region methods on high-dimensional problems.
-
-## Pipeline Integration: The Fixpoint Pass
-
-When `value+grad` appears inside a compiled `deftm`, the pipeline handles
-it through the **fixpoint pass**:
-
-1. **Lower** — expands `(value+grad #'loss-fn)` into the AD-transformed body
-   (forward pass + backward pass as flat bindings)
-2. **Fixpoint** — the expanded backward pass may contain un-devirtualized
-   arithmetic (from gradient templates). The fixpoint pass iterates:
-   - **Expand** — inline remaining deftm calls
-   - **Rewalk** — devirtualize new `.invk` calls introduced by expansion
-   - Repeat until stable (typically 1-2 iterations)
-
-This is what enables composable AD — `grad(grad(f))` works because each
-level of differentiation produces a new set of arithmetic operations that
-the next fixpoint iteration devirtualizes.
-
-After fixpoint, the MLP training step has ~79 bindings covering:
-- Forward: dense (BLAS dgemv), relu (par/map!), softmax, cross-entropy
-- Backward: cross-entropy grad, softmax grad (reduce + map), dense backward
-  (dger! for dW, dgemv-t! for dx), relu backward (masked multiply)
-- SGD: four update loops (par/map! with broadcast)
-
-All fully typed, ready for buffer fusion and bytecode compilation.
-
-## Activity Analysis
-
-Before generating the backward pass, activity analysis determines which
-bindings carry gradient information:
-
-- **Active:** depends on a parameter that has a non-zero gradient
-- **Constant:** independent of all active parameters (gradient is zero)
-
-A binding is active if any of its inputs is active. Constants skip adjoint
-computation entirely, reducing both time and memory. For the MLP backward
-pass, constants include the learning rate, array dimensions, and any
-precomputed values that don't depend on the parameters.
-
-## AD Through Control Flow
-
-### Loops
-
-Reverse-mode AD supports **tail-position** `loop*/recur` (accumulation loops)
-by storing per-iteration pullbacks:
-
-1. **Forward:** run the loop, store each iteration's pullback in a list
-2. **Backward:** replay pullbacks in reverse order, accumulating adjoints
-
-This is exact (not truncated) reverse-mode through the loop. Note the current
-limitation: only tail-position loops lift this way; a raw `loop` bound in a
-`let` binding is **rejected** (it throws, mirroring JAX's refusal to reverse
-`while_loop` — a data-dependent trip count can't size/reverse the residual
-stack). The sanctioned differentiable-recurrence primitive is `par/reduce`
-(and, in progress, a `par/scan` with a flat residual buffer); arbitrary raw
-loops are not generally differentiable. See `.internal/ad_generalization_plan.md`.
-
-### Parallel Forms
-
-`par/map!` and `par/reduce` preserve their parallel structure through AD:
-
-- **Forward:** the parallel form runs normally, also storing per-element
-  pullbacks via a sequential tape pass
-- **Backward for array inputs:** emit `par/map!` applying pullbacks
-  element-wise
-- **Backward for scalar inputs:** emit `par/reduce` summing pullback
-  contributions across elements
-
-This means the backward pass of a BLAS-accelerated forward pass still uses
-BLAS operations — the compiler sees `dger!` and `dgemv-t!` in the gradient
-code, not hand-written loops.
-
-## Differentiable Agent-Based Models
-
-The firms ABM (`raster.abm.firms.differentiable`) demonstrates AD through
-complex simulation loops:
-
-### Implicit Function Theorem (IFT)
-
-The ABM's effort solver uses Newton-Raphson to find `e*` satisfying the
-first-order condition `F(e*, params) = 0`. Differentiating through
-Newton-Raphson naively would require differentiating through all iterations.
-
-Instead, the IFT gives the exact derivative at convergence:
-
-```
-de*/dp_i = -(dF/dp_i) / (dF/de)
+```clojure
+(try (rev/value+grad #'docuncov :mode :forward) (catch Exception e (.getMessage e)))
+;=> "value+grad :mode :forward is not admissible for `#'user/docuncov` — ops
+;    without a Dual lift: Math/expm1. Mode selection is constrained by carrier
+;    coverage (framework §11): use :mode :reverse, or add the missing Dual overloads…"
 ```
 
-This is registered as an rrule, so reverse-mode AD through `solve-effort`
-uses the IFT formula instead of unrolling the Newton iterations. The result
-is exact (not approximate) and costs only one extra function evaluation
-per parameter.
+## 4. Adding a differentiable op
 
-### Soft Decisions
+Register a rule and the op becomes AD-opaque (stays symbolic for the transform);
+without one, a `deftm` is simply inlined and differentiated through (the Zygote
+recurse-into-IR default). A rule is:
 
-Hard argmax decisions are non-differentiable. The differentiable variant
-replaces them with softmax:
+- **`:grads`** — canonical per-param reverse expressions (Jᵀ·w); auto-compiled to a
+  code-generating `:grads-fn` at registration. One source of truth per op.
+- **`:grads-fn`** — the escape hatch: emit flat `let*` bindings directly (used for
+  array kernels that call BLAS backward routines, keeping them fusion-visible).
+- **`:structure`** — a Jacobian tag (`:elementwise` / `:symmetric` / `:linear` /
+  `:bilinear` / `:scalar-loss`). From it the forward rule (`:jvp-fn`) and, for
+  closure under second-order AD, the derived adjoint are synthesized — no second
+  table.
 
+Registering a scalar primitive with both `:grads` and `:structure` makes reverse
+*and* forward work through it:
+
+```clojure
+(deftm docsq [x :- Double] :- Double (n/* x x))               ;; y = x²
+(tmpl/register-template! 'user/docsq
+  {:params '[x] :result 'y :adjoint 'dy
+   :grads [(list 'raster.numeric/* 'dy (list 'raster.numeric/* 2.0 'x))]})
+(tmpl/merge-into-template! 'user/docsq {:structure {:class :elementwise :in #{0}}})
+
+(deftm docusesq [x :- Double] :- Double (docsq (n/* 3.0 x)))  ;; (3x)²=9x², f'=18x
+[(nth ((rev/value+grad #'docusesq) 2.0) 1)     ;; reverse: uses :grads
+ (nth ((jvp/jvp #'docusesq) 2.0 1.0) 1)]       ;; forward: :jvp-fn derived from :structure
+;=> [36.0 36.0]
 ```
-p_i = exp(u_i / tau) / sum_j exp(u_j / tau)
-output = sum_i p_i * e_i
+
+Emitted grad expressions must use fully-qualified `raster.numeric/*` etc. so the
+walker resolves them and devirtualization fires downstream.
+
+## 5. The tangent protocol
+
+Cotangents form a commutative monoid `(⊕, 0̄)` with scalar action and a projector
+Π. Two distinct "nothings": `0̄` (ZeroTangent — a dynamic zero, still typed and
+shaped) and `⊥` (NoTangent — a *static* absence of tangent space, Long/index/bool
+slots). ⊕ (`grad-acc`) must be commutative/associative so reverse-emission order
+never matters; Π maps a raw cotangent into *its own primal's* tangent space,
+deriving dtype/shape from the primal type — this is what makes per-param dtypes
+survive without a global switch (framework §5, task #44; law O3b):
+
+```clojure
+(deftm docpi [x :- Double y :- Float] :- Double (n/* x y))
+(let [[v dx dy] ((rev/value+grad #'docpi) 2.0 (float 3.0))]
+  [(class v) (class dx) (class dy)])
+;=> [java.lang.Double java.lang.Double java.lang.Float]  ; each grad in its primal's space
 ```
 
-Temperature `tau` controls smoothness: `tau -> 0` recovers argmax,
-`tau -> inf` gives uniform weights. This makes the full simulation
-loop — decide, work, produce, distribute — differentiable end-to-end,
-enabling gradient-based calibration of model parameters against empirical
-data.
+Zeros are materialized from the primal's tag, and `⊥` has no zero (NoTangent ≠
+ZeroTangent) — so it fails loud rather than mis-shaping a slot:
+
+```clojure
+[(tangent/tangent-kind 'floats) (tangent/tangent-kind 'long)
+ (tangent/zero-expr 'floats 'n) (tangent/zero-expr 'double 'n)
+ (try (tangent/zero-expr 'long 'n) (catch Exception _ :NoTangent-has-no-zero))]
+;=> [{:kind :array, :dtype :float} {:kind :none}
+;    (float-array n) 0.0 :NoTangent-has-no-zero]
+```
+
+## 6. Correctness: the laws suite
+
+`test/raster/ad/laws_test.clj` encodes the commuting-diagram obligations as
+property-style tests over a `deftm` corpus, with central finite differences as the
+external referee where one exists.
+
+| Law | Guarantees |
+|---|---|
+| O1  | mode agreement: reverse = forward = FD = analytic on the shared scalar domain |
+| O1b | array-forward (JVP): directional tangent J·v = directional FD, per param class |
+| O3  | tangent algebra: ⊕ fan-out exact; 0̄ identity; ⊥ (Long) slots nil, never seed |
+| O3b | Π protocol: per-param dtype preserved (float primal → float grad) |
+| O4  | composition: HVP = FD(grad); Jet-k coeffs = k-th derivative |
+| O4b | HVP-through-layers (forward-over-reverse) vs FD-of-grad |
+| O4c | double-backward (RoR closure): grad-of-grad, Hₓₓ·c through NN blocks |
+| O5  | boundaries: unsupported forms throw; :auto admissibility; ⊥ never seeds |
+| O6  | initiality: `sym/differentiate` ≡ `Dual{Sym}` ≡ analytic |
+| O7  | adjoint identity ⟨J·v, w⟩ = ⟨v, Jᵀ·w⟩ — frule and rrule test each other |
+| O8  | rule linearity: every pullback is linear over the tangent algebra |
+| O9  | par/scan recurrence vs analytic closed form + FD |
+| O10 | loop ≡ scan commuting law: loop-written RNN gradients = scan-written, exact |
+
+The flagship checks are self-refereeing. **O7** — the adjoint dot-product identity
+— pits the forward rule against the reverse rule with no FD oracle:
+
+```clojure
+(deftm doc-lnb [x :- (Array float) W :- (Array float) b :- Long i :- Long o :- Long]
+  :- (Array float) (nn/linear-nb x W b i o))
+(deftm doc-dotw [x :- (Array float) W :- (Array float) w :- (Array float)  ;; g = ⟨f(x,W), w⟩
+                 b :- Long i :- Long o :- Long] :- Double
+  (let [y (nn/linear-nb x W b i o) n* (clojure.core/* b o)]
+    (loop [k 0 s 0.0] (if (clojure.core/< k n*)
+      (recur (clojure.core/inc k) (+ s (* (ra/aget y k) (ra/aget w k)))) s))))
+(defn- fdot [a b] (areduce a k s 0.0 (+ s (* (double (aget a k)) (double (aget b k))))))
+(let [x (fa 8 11) W (fa 12 12) v (fa 8 13) w (fa 6 14)
+      [_ jv] ((jvp/jvp #'doc-lnb) x W 2 4 3 v (float-array 12))   ;; J·(v,0)
+      gx (nth ((rev/value+grad #'doc-dotw) x W w 2 4 3) 1)]        ;; Jᵀ·w over x
+  [(fdot jv w) (fdot v gx)])                                       ;; must be equal
+;=> [-0.5583058855371057 -0.5583058402333747]   ; ⟨J·v,w⟩ = ⟨v,Jᵀ·w⟩ (float)
+```
+
+And the two independent second-order routes — **reverse-over-reverse** (O4c) and
+**forward-over-reverse** HVP (O4b) — agree bit-exactly, the commuting square at
+machine precision:
+
+```clojure
+(let [ror (nth ((rev/value+grad (rev/reified-grad #'doccube 'x)) 2.0) 1)  ;; d/dx(3x²)
+      hvp (first (nth ((jvp/hvp #'doccube) 2.0 1.0) 1))]                   ;; f″·1
+  [ror hvp (== ror hvp)])   ;=> [12.0 12.0 true]
+```
+
+## 7. GPU status (honest)
+
+The AD-generated backward matmuls run on Intel Arc (Level Zero / XMX) and match
+CPU BLAS. Validated on the `mse ∘ linear-nb` probe (branch `ad/gpu-validation`):
+forward `linear-nb` → resident `:nt` GEMM (relerr 2.55e-4, fp16), backward
+`linear-dx` → `:nn` GEMM (2.28e-4), backward `linear-dW` → `:tn` weight-gradient
+GEMM (2.60e-4, `:tn` newly wired). The post-SOA IR carries all three GEMM `.invk`
+with `:raster.op/original` intact — the AD transform reaches GPU lowering
+unchanged.
+
+**Pinned gap:** a *whole* train step is not yet one resident graph. The non-matmul
+gradient ops in the composed path (the loss reduction, the `daxpy-diff` elementwise
+gradient) have no resident kernel there yet, so `compile-gpu-program` returns nil
+and falls back gracefully. The residency / saved-activation policy (store-vs-
+recompute for forward intermediates; params + optimizer moments as the donation
+set) is *designed* but not built — it converges with the loop-checkpointing policy
+(framework §15: one store-vs-recompute pass, two clients). Small-M fp16 DPAS GEMM
+has a known boundary bug (rows 1..M-1 wrong for tiny M; multiples of 16 correct),
+independent of AD.
+
+## 8. Boundaries & limits
+
+- **Data-dependent loops** (`while`/convergence) are not unrolled — model them as a
+  `fixed-point-solve` (adjoint-of-fixed-point / IFT) instead. Fail-loud otherwise.
+- **Multi-carry loops** (`loop [i a b]`) are still rejected by the canonicalizer
+  (v2: tuple-packed carry); they retain the older ArrayList tail-loop tape on the
+  compiled/inline path only.
+- **Mutation soundness (R1)** — the tape/IR must capture pre-mutation values;
+  raster's typed named buffers make the store-adjoint discipline cheap, but this is
+  currently guarded by convention, not analysis (deferred).
+- **Vector-tail rule** — `value+grad` of `value+grad` is ill-typed and fails loud
+  (§3); compose transparently or use `reified-grad`.
+- **Skipped frules** (documented A3 skips — reverse works, forward fails loud
+  naming the op): `solve`, `einsum`, `maxpool2d` (needs a gather-at-argmax kernel),
+  `array-det`, effectful `dgemm!`. `par/scan` forward mode also fails loud (a
+  forward SOAC fold is not landed).
+- **Kinks** — differentiation through `if` and through activation kinks (relu) is
+  correct almost-everywhere; there is no oracle *at* a nondifferentiable point, so
+  the laws sample away from kinks.
+- **Known bugs.** #73: the walker's single-method fallback can pick a wrong-dtype
+  parametric specialization for a composite when TypedClojure inference fails
+  inside it (a `[F→[D` primal miscompile — a devirt hole, not an AD defect; worked
+  around with single-method float wrappers). #75: `par/reduce` over `aget` reads has
+  a namespace-sensitive lowering hazard (segred aget).
 
 ## Summary
 
-| Feature | Implementation | Use Case |
-|---|---|---|
-| Forward-mode (Dual) | deftm dispatch on Dual type | Few params, Jacobians |
-| Reverse-mode | Source transform, closures-as-tape | Many params, scalar loss |
-| Jets | Truncated Taylor polynomials | k-th order derivatives |
-| value+grad | Composable operator with deftm metadata | Training loops |
-| HVP | Reverse-over-forward | Newton/trust-region methods |
-| rrule registry | Pullback factories + code templates | Custom op gradients |
-| Activity analysis | Forward propagation of active/const | Skip dead gradients |
-| IFT | Registered rrule for implicit functions | Differentiable solvers |
-| Loop AD | Per-iteration pullback storage | RNNs, ODE sensitivity |
-| Parallel AD | par/map! and par/reduce preserved | BLAS in backward pass |
+| Operator | Mode / mechanism | Use case | Law |
+|---|---|---|---|
+| `value+grad` / `grad` | reverse source-transform | scalar loss, many params | O1, O3 |
+| `:mode :forward` / `fwd/*` | Dual carrier | few inputs, Jacobians, branches | O1 |
+| `jvp/jvp` | JVP source-transform (derived frules) | directional deriv through arrays | O1b, O7 |
+| `jvp/hvp` | forward-over-reverse | Hessian-vector (Newton-CG, trust region) | O4b |
+| `reified-grad` + `value+grad` | reverse-over-reverse | grad-of-grad, ‖∇f‖², MAML | O4c |
+| transparent composition | ordinary program use | any nested differentiation | O4d |
+| `par/scan` / raw loop | canonicalized recurrence (out-as-tape) | RNNs, sensitivity | O9, O10 |
+| `jet` | truncated Taylor ring | k-th-order derivatives | O4 |
+| `sym/differentiate`, `Dual{Sym}` | Sym initial algebra | symbolic derivatives | O6 |
+| `fixed-point-solve` | IFT rrule | differentiable solvers | — |
+| `:mode :auto` | Griewank + admissibility | let the engine pick | O5 |
+| `register-template!` | `:grads` + `:structure` | custom differentiable ops | O8 |
+| tangent protocol | typed 0̄/⊥, Π projector | per-param dtype correctness | O3b |

--- a/src/raster/ad/reverse.clj
+++ b/src/raster/ad/reverse.clj
@@ -32,6 +32,8 @@
             [raster.compiler.ir.form :as form]
             [raster.compiler.passes.scalar.inline :as inline]
             [raster.compiler.passes.parallel.materialize :as materialize]
+            [raster.compiler.passes.parallel.loop-lift :as loop-lift]
+            [raster.compiler.passes.parallel.patterns :as patterns]
             [raster.compiler.core.util :as util]
             [raster.compiler.core.dispatch :as dispatch]
             [raster.compiler.support.mangled :as mangled]
@@ -348,10 +350,14 @@
 (defmethod ad-record :loop [_ sym _init-expr _activity]
   (throw (ex-info
           (str "Cannot differentiate through raw `loop` form bound to `" sym "`. "
+               "Canonical loops ((< i n) test, +1 step, single carry) are lifted "
+               "to SOACs automatically; this one declined the soundness gates. "
                "Use `par/reduce` for differentiable reductions, `par/scan` for "
                "differentiable recurrences (a chained carry whose per-step values "
-               "you keep — out[i] = acc_i is its own tape), or wrap "
-               "the loop in a deftm with an AD template.")
+               "you keep — out[i] = acc_i is its own tape), a fixed-point solve "
+               "for data-dependent trip counts (while/convergence loops — the "
+               "adjoint-of-fixed-point rule differentiates the converged state), "
+               "or wrap the loop in a deftm with an AD template.")
           {:sym sym :form-head 'loop})))
 
 (defmethod ad-record :par-map [_ sym init-expr activity]
@@ -458,7 +464,16 @@
            activity (assoc activity sym active?)
            fwd      (conj fwd-bindings sym (qualify-fwd-expr init-expr))
            {:keys [record fwd-patch]} (ad-record (ad-form-kind init-expr active? sym)
-                                                 sym init-expr activity)]
+                                                 sym init-expr activity)
+           ;; A SOAC whose body carries gradient makes its WRITTEN buffers
+           ;; gradient-carrying too: a downstream DIRECT read (aget out k)
+           ;; must scatter into adj-env[out] (emit-backward already sums the
+           ;; buffer's contributions into d_out alongside the result sym's).
+           ;; Without this, statement-position map!/scan followed by a direct
+           ;; buffer read silently drops the adjoint (zero gradients).
+           activity (if (and active? (seq (:written-arrs record)))
+                      (reduce #(assoc %1 %2 true) activity (:written-arrs record))
+                      activity)]
        {:activity activity
         :fwd-bindings (if fwd-patch (fwd-patch fwd) fwd)
         :records (if record (conj records record) records)}))
@@ -1748,11 +1763,17 @@
 
 (defn- analyze-par-reduce-body
   "Analyze a par/reduce body for aget references and free scalars.
-  Similar to analyze-par-map-body but for reduce body context."
+  Similar to analyze-par-map-body but for reduce body context — including
+  its INLINE-aget lift (source (2) there): a bare `(aget arr i)` sitting in
+  the body result (the shape the §15.2 loop canonicalization emits, since a
+  tail-accumulation loop body is one expression) is lifted to a synthetic
+  aget binding so it joins the array-input machinery. Without the lift, the
+  aget would be re-emitted inside the forward loop, which alpha-renames the
+  index (fi__N) — leaving the original index symbol free/unresolved."
   [body-expr idx-sym acc-sym]
   (let [agets (atom [])
         scalar-bindings (atom [])
-        [bindings body-result]
+        [bindings body-result0]
         (if (and (seq? body-expr) (#{'let 'let*} (first body-expr)))
           [(partition 2 (second body-expr)) (last (drop 2 body-expr))]
           [[] body-expr])]
@@ -1761,17 +1782,37 @@
                (op/aget-op? (first init)))
         (swap! agets conj {:sym sym :arr (nth init 1) :idx (nth init 2)})
         (swap! scalar-bindings conj [sym init])))
-    (let [aget-syms (set (map :sym @agets))
-          bound-syms (set (list* idx-sym acc-sym (concat (map first @scalar-bindings) aget-syms)))
-          free-syms (free-syms-excluding body-result bound-syms)
-          all-free (reduce into free-syms
-                           (map (fn [[_ init]]
-                                  (free-syms-excluding init bound-syms))
-                                @scalar-bindings))]
-      {:agets @agets
-       :scalar-bindings @scalar-bindings
-       :body-result body-result
-       :free-syms (disj all-free idx-sym acc-sym)})))
+    ;; Lift inline (aget arr idx-sym) reads to synthetic aget bindings (dedup
+    ;; by array — idx is fixed = the reduce index, so a repeated read shares
+    ;; one sym; e.g. sum-of-squares reads xs[i] twice).
+    (let [seen (atom {})
+          lift (fn lift [form]
+                 (cond
+                   (and (seq? form) (op/aget-op? (first form))
+                        (= 3 (count form)) (= idx-sym (nth form 2)))
+                   (let [arr (nth form 1)
+                         k (if (symbol? arr) arr form)]
+                     (or (get @seen k)
+                         (let [s (ad-gensym (str "ag_" (if (symbol? arr) (name arr) "arr")))]
+                           (swap! seen assoc k s)
+                           (swap! agets conj {:sym s :arr arr :idx idx-sym})
+                           s)))
+                   (seq? form) (with-meta (apply list (map lift form)) (meta form))
+                   (vector? form) (mapv lift form)
+                   :else form))
+          body-result (lift body-result0)
+          scalar-bindings* (mapv (fn [[s init]] [s (lift init)]) @scalar-bindings)]
+      (let [aget-syms (set (map :sym @agets))
+            bound-syms (set (list* idx-sym acc-sym (concat (map first scalar-bindings*) aget-syms)))
+            free-syms (free-syms-excluding body-result bound-syms)
+            all-free (reduce into free-syms
+                             (map (fn [[_ init]]
+                                    (free-syms-excluding init bound-syms))
+                                  scalar-bindings*))]
+        {:agets @agets
+         :scalar-bindings scalar-bindings*
+         :body-result body-result
+         :free-syms (disj all-free idx-sym acc-sym)}))))
 
 (defn- gen-reverse-par-reduce
   "Generate reverse-mode AD code for a raster.par/reduce form.
@@ -1839,7 +1880,13 @@
                                     pb-sym (list 'nth vpb-sym 1)]
                 store-binding [(ad-gensym "_store") (list 'aset tape-sym fwd-idx-sym pb-sym)]
                 all-bindings (vec (concat aget-bindings transform-bindings store-binding))]
-            (list 'let* all-bindings val-result-sym)))
+            ;; The forward loop binds the ALPHA-RENAMED index (fwd-idx-sym) —
+            ;; rewrite any surviving reference to the original reduce index
+            ;; (aget-binding index exprs, index refs in scalar-binding inits)
+            ;; onto it, capture-avoidingly. Without this the emitted loop body
+            ;; references an unbound symbol.
+            (util/subst-syms {idx-sym fwd-idx-sym}
+                             (list 'let* all-bindings val-result-sym))))
 
         ;; Forward code packs [tape, reduce-result] in an object-array pair.
         ;; The caller (gen-reverse-let) unpacks tape and result from the pair.
@@ -2405,25 +2452,200 @@
                                       {:body body}))
             :else (recur relifted (inc i))))))))
 
+;; ================================================================
+;; Loop canonicalization (framework §15.2) — carry→scan materializer
+;;
+;; The SIMD loop-lift (`lift-parallel-forms`) recovers dotimes+aset → par/map!,
+;; tail-accumulation → par/reduce, and carry+aset-returning-out → par/scan.
+;; What it cannot lift is the PURE-carry recurrence (no per-step store) and the
+;; carry+aset loop that returns the FINAL CARRY instead of the out array —
+;; par/scan needs an out buffer, and the loop's value is a scalar. This AD-only
+;; materializer closes that gap: it synthesizes the out buffer (which IS the
+;; tape — explicit Griewank store-the-carry checkpointing at every step, §15.2)
+;; and rebinds the loop's value as the guarded last element. It runs only in
+;; ad-prepare because materializing the carry history is pure waste for a
+;; non-differentiated primal.
+;; ================================================================
+
+(defn- carry-scan-dtype
+  "The scalar dtype (:double/:float) of a carry expression, proven from a
+  cast wrapper, a typed literal, a tag-stamped symbol, or a tag-stamped call
+  form (the walker stamps :raster.type/tag on typed calls — emitters/passes
+  READ stamps, never re-infer). nil when it cannot be proven → the
+  materializer declines (the loop falls through to the fail-loud :loop
+  ladder)."
+  [expr]
+  (cond
+    (and (seq? expr) (contains? #{'float 'clojure.core/float} (first expr))
+         (= 2 (count expr))) :float
+    (and (seq? expr) (contains? #{'double 'clojure.core/double} (first expr))
+         (= 2 (count expr))) :double
+    (instance? Double expr) :double
+    (instance? Float expr) :float
+    (or (symbol? expr) (seq? expr))
+    (let [{:keys [kind dtype]} (tangent/tangent-kind
+                                (or (:raster.type/tag (meta expr))
+                                    (:tag (meta expr))))]
+      (when (= kind :scalar) dtype))
+    :else nil))
+
+(defn- emit-carry-scan
+  "Emit the canonical scan form for a carry loop. Returns a let* expression
+  whose value is the loop's value (the final carry).
+
+  RESULT-BINDING CHOICE: par/scan RETURNS the out array (and the :par-scan
+  ad-record depends on that — `sym` aliases the buffer, out-as-tape), so the
+  final carry must be READ BACK as (aget out (dec n)), exactly the shape the
+  o9 scan laws differentiate. The n=0 guard cannot be a lazy branch around the
+  aget — flat ANF evaluates binding inits eagerly — so instead BOTH the read
+  index and (for the synthesized buffer) the allocation length are clamped to
+  keep the eager aget in bounds, and the RESULT is selected by an :if record
+  over two symbols: (if (< 0 n) last init). Values and adjoints are exact in
+  both cases: for n=0 the aget reads a clamped dummy slot whose adjoint is
+  gated to zero by the same branch, and δinit flows through the :if route;
+  for n>0 the else-route contributes the branch-gated zero and δinit flows
+  through the scan's carry chain."
+  [{:keys [out dtype cast acc idx bound init body]}]
+  (with-ad-gensym
+    (let [scalar-tag (case dtype :float 'float :double 'double nil)
+          array-tag  (case dtype :float 'floats :double 'doubles nil)
+          alloc-fn   (case dtype :float 'clojure.core/float-array
+                                 :double 'clojure.core/double-array nil)
+          init-sym   (ad-gensym "carry_init" scalar-tag)
+          n-sym      (ad-gensym "carry_n" 'long)
+          pos-sym    (ad-gensym "carry_pos")
+          out-sym    (or out (ad-gensym "carry_out" array-tag))
+          scan-sym   (ad-gensym "carry_scan" array-tag)
+          li-sym     (ad-gensym "carry_lastidx" 'long)
+          last-sym   (ad-gensym "carry_last" scalar-tag)
+          bindings   (-> []
+                         (into [init-sym init
+                                n-sym bound
+                                pos-sym (list 'clojure.core/< 0 n-sym)])
+                         (into (if out
+                                 []   ;; loop already owns the out buffer
+                                 [out-sym (list alloc-fn
+                                                (list 'if pos-sym n-sym 1))]))
+                         (into [scan-sym (list 'raster.par/scan out-sym acc
+                                               init-sym idx n-sym cast body)
+                                li-sym (list 'if pos-sym
+                                             (list 'clojure.core/dec n-sym) 0)
+                                last-sym (list 'raster.arrays/aget
+                                               scan-sym li-sym)]))]
+      (list 'let* (vec bindings)
+            (list 'if pos-sym last-sym init-sym)))))
+
+(defn- carry-dtype-consistent?
+  "The carry dtype must agree with every KNOWN element type of the arrays the
+  step body reads: a mixed-precision scan (double carry over float[] reads)
+  would scatter carry-dtype adjoints into read-dtype shadow buffers in the
+  backward (typed-aset dispatch CCE). Mixed recurrences decline — they fall
+  through to the pre-canonicalization paths, exactly as before."
+  [dtype body]
+  (every? #(= dtype %) (patterns/read-array-elem-types body)))
+
+(defn- carry-loop->scan
+  "Rewrite a carry loop into its canonical par/scan form, or nil when the
+  soundness gates decline (see patterns/match-carry-loop). Two shapes:
+
+  (a) carry + per-step aset, loop returns the FINAL CARRY (a scan the lift
+      declines because its value is the carry, not out): reuse the loop's
+      own out buffer. The n=0 read-guard requires a non-empty out — which
+      the loop's own aset contract already implies for n>0; for n=0 an
+      empty out throws (degenerate: a zero-trip loop over an empty buffer).
+
+  (b) PURE carry (no store): synthesize the out buffer — the synthesized
+      out IS the tape (explicit store-the-carry checkpointing, §15.2)."
+  [loop-form]
+  (or
+   ;; (a) carry + aset returning the carry
+   (when-let [{:keys [out-sym acc-sym acc-init index-sym bound-expr cast-fn
+                      acc-next-expr else-expr]}
+              (patterns/match-scan-loop loop-form)]
+     (let [dtype (or (carry-scan-dtype acc-init)
+                     (carry-scan-dtype acc-next-expr))]
+       (when (and (patterns/acc-ref? else-expr acc-sym)
+                  (not (patterns/contains-sym? bound-expr index-sym))
+                  (not (patterns/contains-sym? bound-expr acc-sym))
+                  (some? dtype)
+                  (carry-dtype-consistent? dtype acc-next-expr))
+         (emit-carry-scan {:out out-sym
+                           :dtype dtype
+                           :cast cast-fn
+                           :acc acc-sym :idx index-sym
+                           :bound bound-expr :init acc-init
+                           :body acc-next-expr}))))
+   ;; (b) pure carry — dtype from the init or (fallback) the tag-stamped
+   ;; step body: the scan stores cast(body), so the body's stamp IS the
+   ;; out-buffer dtype.
+   (when-let [{:keys [acc-sym acc-init index-sym bound-expr body]}
+              (patterns/match-carry-loop loop-form)]
+     (let [dtype (or (carry-scan-dtype acc-init)
+                     (carry-scan-dtype body))]
+       (when (and (some? dtype)
+                  (carry-dtype-consistent? dtype body))
+         (emit-carry-scan {:out nil
+                           :dtype dtype
+                           :cast (case dtype :float 'float :double 'double)
+                           :acc acc-sym :idx index-sym
+                           :bound bound-expr :init acc-init
+                           :body body}))))))
+
+(defn- canonicalize-carry-loops
+  "Walk a (post-lift) prep form and materialize surviving carry loops as
+  par/scan (carry-loop->scan). Descends let* binding inits and body exprs —
+  the positions loops occupy after lower-composites' ANF — and leaves par
+  forms and unmatched loops untouched (those fall through to the existing
+  paths: gen-reverse-loop-with-let on the inline path, the fail-loud ladder
+  on the runtime path)."
+  [form]
+  (cond
+    (and (seq? form) (contains? #{'loop 'loop*} (first form)))
+    (or (carry-loop->scan form) form)
+
+    (and (seq? form) (form/binding-form? form))
+    (let [[head bindings & body] form
+          new-bindings (into []
+                             (mapcat (fn [[s e]]
+                                       [s (canonicalize-carry-loops e)]))
+                             (partition 2 bindings))
+          new-body (map canonicalize-carry-loops body)]
+      (with-meta (apply list head new-bindings new-body) (meta form)))
+
+    :else form))
+
 (defn ^:no-doc ad-prepare
   "The ONE shared pre-AD preparation, used by the reverse path
   (`build-grad-walked-body`, `grad-expr`) AND the forward/JVP path
-  (`raster.ad.jvp/jvp`). Exactly the order the reverse path has always used:
+  (`raster.ad.jvp/jvp`):
 
     anf-wrap-bare-body → lower-composites (inline un-templated composites to
-    a fixpoint) → materialize-pass (pure par/map → alloc + par/map!) →
+    a fixpoint) → lift-parallel-forms (loop → SOAC canonicalization, §15.2)
+    → canonicalize-carry-loops (AD-only carry → scan materializer) →
+    materialize-pass (pure par/map → alloc + par/map!) →
     hoist-nested-lets (flat ANF).
 
-  Behavior-identical refactor of the duplicated prep — the laws suite is the
-  regression net."
+  The loop canonicalization runs AFTER lower-composites (inlining exposes
+  callee loops) and BEFORE materialize/hoist. It is a PHASE-ORDERING fix:
+  the pipeline's :loop-lift pass runs too late (post-fixpoint) for AD and
+  never on the runtime path, so ad-prepare runs the same pure form→form fn
+  here. Loops the gates decline are left untouched for the existing paths."
   [body]
   (let [;; ANF-normalize + inline composite deftm calls to a fixpoint so BARE
         ;; and multi-level composites fully lower before AD (lower-composites
         ;; runs anf-wrap-bare-body itself).
         lowered (lower-composites body)
+        ;; §15.2 (1): recover SOAC structure from raw loop syntax — dotimes →
+        ;; par/map!, tail-accumulation → par/reduce, carry+aset → par/scan —
+        ;; with the lift's proven-soundness gates (stats are discarded here;
+        ;; matched loops simply become differentiable SOACs).
+        lifted (:form (loop-lift/lift-parallel-forms lowered))
+        ;; §15.2 (2): materialize surviving pure-carry recurrences as par/scan
+        ;; (the synthesized out IS the tape — store-the-carry checkpointing).
+        canonical (canonicalize-carry-loops lifted)
         ;; Materialize pure par/map (broadcast → par/pmap) into alloc + par/map!
         ;; before AD — the pure pmap has no reverse rule; the mutating map! does.
-        materialized (:form (materialize/materialize-pass lowered nil))]
+        materialized (:form (materialize/materialize-pass canonical nil))]
     ;; Hoist nested lets out of call args into flat ANF for AD.
     (hoist-nested-lets materialized)))
 
@@ -2951,7 +3173,21 @@
                   []
                   (partition 2 bindings))
           hoisted-body (map hoist-nested-lets body)]
-      (apply list let-sym flat-bindings hoisted-body))
+      ;; A SINGLE let*-tail merges into this let* (same flat-ANF invariant as
+      ;; binding inits): (let* B1 (let* B2 e)) ≡ (let* B1+B2 e) — sequential
+      ;; binding semantics are preserved exactly. Loop canonicalization
+      ;; produces this shape when a TAIL-position loop rewrites to a let*-
+      ;; wrapped par/scan; without the merge the inner let* reaches
+      ;; gen-reverse-let as an opaque tail expression (dropped adjoints).
+      ;; Only the single-expr case merges: with statement exprs before the
+      ;; tail, splicing would move the inner bindings BEFORE the statements'
+      ;; effects (e.g. an aset the bindings read).
+      (if (and (= 1 (count hoisted-body))
+               (seq? (first hoisted-body))
+               (contains? #{'let 'let*} (ffirst hoisted-body)))
+        (let [[_ inner-binds & inner-body] (util/alpha-convert (first hoisted-body))]
+          (apply list let-sym (into flat-bindings (vec inner-binds)) inner-body))
+        (apply list let-sym flat-bindings hoisted-body)))
 
     ;; Scope-introducing forms — recurse but don't hoist across scope boundaries.
     ;; This includes every par/* SOAC (form/introduces-scope?): their bodies
@@ -3346,12 +3582,17 @@
                (throw (ex-info
                        (str "value+grad: cannot assemble a runtime gradient for `"
                             f-var "` — the body reduces to a loop form the runtime "
-                            "flattener does not support. Express the reduction via "
+                            "flattener does not support (canonical fixed-trip loops "
+                            "are lifted to SOACs automatically; this one declined "
+                            "the soundness gates, e.g. a data-dependent trip count "
+                            "or a multi-carry body). Express the reduction via "
                             "`par/reduce`, the recurrence via `par/scan` (the "
                             "sanctioned differentiable recurrence — out[i] = acc_i "
-                            "is its own tape), or a registered op (e.g. a loss deftm "
-                            "with an AD template), or use the compiled path "
-                            "(compile-aot of a deftm calling value+grad).")
+                            "is its own tape), a data-dependent/convergence loop via "
+                            "a fixed-point solve (adjoint-of-fixed-point rule), or a "
+                            "registered op (e.g. a loss deftm with an AD template), "
+                            "or use the compiled path (compile-aot of a deftm "
+                            "calling value+grad).")
                        {:var f-var :reason :flatten-failed})))
            {:keys [walked-body params tags source-ns]} bgw
            runtime-fn (make-runtime-value+grad-fn walked-body params)

--- a/src/raster/compiler/core/op_descriptor.clj
+++ b/src/raster/compiler/core/op_descriptor.clj
@@ -620,16 +620,31 @@
   (when (aset-call? form)
     (unwrap-array-arg (first (call-args form)))))
 
+(defn- unwrap-int-cast
+  "Unwrap an integer cast around an induction-variable reference —
+   (long i) / (int i) → i. The walked/AD-prep dialect wraps loop indices in
+   long casts ((inc (long i))), so step matching must see through them just
+   like idx-matches?/test-index+bound do. Non-cast forms pass through."
+  [expr]
+  (if (and (seq? expr)
+           (contains? #{'long 'int 'clojure.core/long 'clojure.core/int}
+                      (first expr))
+           (= 2 (count expr)))
+    (second expr)
+    expr))
+
 (defn affine-step
   "If `expr` is an affine step of the induction variable `idx-sym` — i.e.
    (inc idx), (unchecked-inc idx), or (+ idx c) / (+ c idx) with a constant
    integer c — return the constant stride as a long. Otherwise nil.
    Works on both bare ops and walker-devirtualized (.invk impl ...) forms via
-   semantic-op/call-args, so no form rewriting is needed for matching."
+   semantic-op/call-args, so no form rewriting is needed for matching. The
+   idx reference may be cast-wrapped ((inc (long i))) — walked-dialect loops
+   emit that shape."
   [expr idx-sym]
   (when (seq? expr)
     (let [op   (semantic-op expr)
-          args (vec (call-args expr))]
+          args (vec (map unwrap-int-cast (call-args expr)))]
       (cond
         (and (increment-op? op)
              (= 1 (count args))

--- a/src/raster/compiler/passes/parallel/loop_lift.clj
+++ b/src/raster/compiler/passes/parallel/loop_lift.clj
@@ -133,14 +133,88 @@
      :cast cast-fn
      :body value-expr}))
 
-(defn- contains-sym?
-  "True if `sym` occurs anywhere in `form` (as a value, not just head)."
-  [form sym]
+(def ^:private contains-sym?
+  "True if `sym` occurs anywhere in `form` (shared helper in patterns)."
+  patterns/contains-sym?)
+
+(defn- reduce-init-elem-type
+  "Element type of a reduce accumulator init, or nil when it cannot be
+  proven: a (float x)/(double x) cast, a typed numeric literal, or a
+  symbol carrying a :raster.type/tag (the walked/AD-prep dialect stamps
+  binding symbols). nil = the lift DECLINES (conservative bail — a missed
+  optimization, never a throw mid-pass)."
+  [init]
   (cond
-    (= form sym)   true
-    (seq? form)    (boolean (some #(contains-sym? % sym) form))
-    (vector? form) (boolean (some #(contains-sym? % sym) form))
-    :else          false))
+    (and (seq? init) (contains? #{'float 'clojure.core/float} (first init))) :float
+    (and (seq? init) (contains? #{'double 'clojure.core/double} (first init))) :double
+    (number? init) (condp instance? init
+                     Double :double
+                     Float :float
+                     Long :long
+                     Integer :int
+                     nil)
+    (symbol? init) (case (or (:raster.type/tag (meta init)) (:tag (meta init)))
+                     float :float
+                     double :double
+                     long :long
+                     int :int
+                     nil)
+    :else nil))
+
+(defn- form-tag-elem-type
+  "Element type from a form's :raster.type/tag stamp (walked dialect), or
+  nil when unstamped. Emitters/passes READ stamps, never re-infer."
+  [form]
+  (case (:raster.type/tag (meta form))
+    float :float
+    double :double
+    long :long
+    int :int
+    nil))
+
+(defn- acc-cast-elem-type
+  "Element type evidenced by a cast on the accumulator reference inside the
+  update body — recur-LUB widening spells the accumulator as (double acc) /
+  (float acc) even when the init literal is integer. nil when the acc is
+  referenced bare (or not found)."
+  [update-expr acc-sym]
+  (let [found (atom nil)
+        casts {'double :double 'clojure.core/double :double
+               'float :float 'clojure.core/float :float}
+        walk (fn walk [e]
+               (when (seq? e)
+                 (if (and (contains? casts (first e))
+                          (= 2 (count e))
+                          (= acc-sym (second e)))
+                   (reset! found (get casts (first e)))
+                   (run! walk (descriptor/call-args e)))))]
+    (walk update-expr)
+    @found))
+
+(def ^:private read-array-elem-types
+  "Element types of the arrays READ inside a body (shared helper in patterns)."
+  patterns/read-array-elem-types)
+
+(defn- reduce-elem-type
+  "The provable accumulator element type of a reduce loop, or nil to DECLINE.
+  Independent evidence sources — the body's :raster.type/tag stamp, an
+  accumulator cast in the update ((double acc), recur-LUB spelling), the
+  init expression, and the element types of the arrays the body READS —
+  must AGREE wherever known:
+    - under recur-LUB widening (init 0, double accumulation) or parametric
+      :dtype narrowing (init 0.0 in a T=float kernel) the init literal alone
+      is NOT authoritative — lifting with a contradicted type truncates or
+      miscasts (integer-init-accumulator / jit-aot-differential regressions);
+    - a MIXED-precision reduce (double accumulator over float[] reads) must
+      decline outright: the SIMD segred loads arrays at the accumulator
+      dtype ([F→[D ClassCastException)."
+  [update-expr acc-sym acc-init]
+  (let [known (remove nil? (concat [(form-tag-elem-type update-expr)
+                                    (acc-cast-elem-type update-expr acc-sym)
+                                    (reduce-init-elem-type acc-init)]
+                                   (read-array-elem-types update-expr)))]
+    (when (and (seq known) (apply = known))
+      (first known))))
 
 (defn- reduction-update-ok?
   "The update body must be (⊕ acc e) / (⊕ e acc) where ⊕ is a registered
@@ -211,12 +285,19 @@
                (body-element-wise? update-expr index-sym nil)
                ;; (6) the exit value depends only on acc + invariants, never the
                ;;     index (which would otherwise escape its loop scope).
-               (not (contains-sym? else-expr index-sym)))
+               (not (contains-sym? else-expr index-sym))
+               ;; (7) the accumulator element type is provable AND consistent
+               ;;     across body tag / acc cast / init (reduce-elem-type) —
+               ;;     emission needs it for the par/reduce elem-type metadata,
+               ;;     and a contradicted init (recur-LUB widening, parametric
+               ;;     narrowing) must decline, not truncate.
+               (some? (reduce-elem-type update-expr acc-sym acc-init)))
           {:acc acc-sym
            :init acc-init
            :idx index-sym
            :bound bound-expr
            :body update-expr
+           :elem-type (reduce-elem-type update-expr acc-sym acc-init)
            :post-fn (when (not= else-expr acc-sym) else-expr)}))
 
       (contains? #{'let 'let*} (first form))
@@ -314,23 +395,15 @@
     (if et (with-meta form {:raster.type/elem-type et}) form)))
 
 (defn- reduce-lift-form
-  [{:keys [acc init idx bound body post-fn]}]
+  [{:keys [acc init idx bound body elem-type post-fn]}]
   (let [reduce-form (list 'raster.par/reduce acc init idx bound body)
-        ;; Infer elem-type from init expression
-        et (cond
-             (and (seq? init) (= 'float (first init))) :float
-             (and (seq? init) (= 'double (first init))) :double
-             (number? init) (condp instance? init
-                              Double :double
-                              Float :float
-                              Long :long
-                              Integer :int
-                              (throw (ex-info (str "loop-lift: cannot infer element type for reduce init `"
-                                                   (pr-str init) "` of type " (type init))
-                                              {:init init})))
-             :else (throw (ex-info (str "loop-lift: cannot infer element type for reduce init `"
-                                        (pr-str init) "`. Use a typed cast like (double 0).")
-                                   {:init init})))
+        ;; Elem-type is provable by construction: loop-reduce-pattern? gate (7)
+        ;; declined any loop reduce-elem-type cannot classify consistently.
+        et (or elem-type
+               (throw (ex-info (str "loop-lift: unreachable — reduce init `"
+                                    (pr-str init) "` passed the pattern gate "
+                                    "but has no inferable element type.")
+                               {:init init})))
         reduce-form (with-meta reduce-form {:raster.type/elem-type et})]
     (if post-fn
       (clojure.walk/postwalk-replace {acc reduce-form} post-fn)

--- a/src/raster/compiler/passes/parallel/patterns.clj
+++ b/src/raster/compiler/passes/parallel/patterns.clj
@@ -645,6 +645,17 @@
            (= 2 (count expr))
            (= (second expr) acc-sym))))
 
+(defn contains-sym?
+  "True if `sym` occurs anywhere in `form` (as a value, not just head).
+  Shared soundness helper for loop-invariance gates (loop-lift and the AD
+  carry->scan materializer both gate bounds on it)."
+  [form sym]
+  (cond
+    (= form sym)   true
+    (seq? form)    (boolean (some #(contains-sym? % sym) form))
+    (vector? form) (boolean (some #(contains-sym? % sym) form))
+    :else          false))
+
 (defn find-recur-form
   "Find the recur form in a then-branch. Handles direct, do-wrapped, and
 	let-wrapped recur forms."
@@ -830,3 +841,65 @@
                    :then-branch then-branch
                    :aset-form aset-form
                    :recur-form recur-form})))))))))
+
+(defn read-array-elem-types
+  "Element types of the arrays READ (aget) inside a loop/SOAC body,
+  recovered from the array symbols' :raster.type/tag stamps (floats/doubles/
+  longs/ints). Unstamped arrays contribute nothing (raw dialect). Shared
+  dtype-consistency evidence for loop-lift's reduce gate and the AD
+  carry->scan materializer (a mixed-precision rewrite miscompiles: SIMD
+  segred loads arrays at the accumulator dtype; scan backward scatters
+  accumulator-dtype adjoints into read-array shadows)."
+  [body-expr]
+  (let [ets (atom [])
+        walk (fn walk [e]
+               (when (seq? e)
+                 (when (descriptor/aget-call? e)
+                   (let [arr (first (descriptor/call-args e))]
+                     (when (symbol? arr)
+                       (when-let [et (case (or (:raster.type/tag (meta arr))
+                                               (:tag (meta arr)))
+                                       floats :float
+                                       doubles :double
+                                       longs :long
+                                       ints :int
+                                       nil)]
+                         (swap! ets conj et)))))
+                 (run! walk (descriptor/call-args e))))]
+    (walk body-expr)
+    @ets))
+
+(defn match-carry-loop
+  "Matcher for PURE-carry recurrence loops — a chained accumulator with NO
+  per-step store:
+
+    (loop [i 0 acc init] (if (< i n) (recur (inc i) BODY) acc))
+
+  This is match-scan-loop minus the aset requirement: it reuses the exact
+  induction-variable machinery (match-reduce-loop: test-identified index,
+  0-start, (< i n) contiguous bound, +1 affine step) plus the soundness
+  gates the rewrite needs:
+    - the consequent is a DIRECT recur (a do/let then-branch could carry
+      side effects that a carry->scan rewrite would drop or reorder)
+    - the exit value is exactly the carry (acc-ref) — the loop RESULT is
+      the final accumulator state
+    - the bound is loop-invariant w.r.t. BOTH index and carry: a
+      data-dependent trip count (bound reads the accumulator) declines
+      here, keeping while/convergence loops on the fail-loud ladder that
+      points at the fixed-point rule.
+
+  Returns {:acc-sym :acc-init :index-sym :bound-expr :body} or nil."
+  [loop-form]
+  (when-let [{:keys [acc-sym acc-init index-sym then-branch else-expr
+                     bound-expr update-expr]}
+             (match-reduce-loop loop-form)]
+    (when (and (seq? then-branch)
+               (= 'recur (first then-branch))
+               (acc-ref? else-expr acc-sym)
+               (not (contains-sym? bound-expr index-sym))
+               (not (contains-sym? bound-expr acc-sym)))
+      {:acc-sym acc-sym
+       :acc-init acc-init
+       :index-sym index-sym
+       :bound-expr bound-expr
+       :body update-expr})))

--- a/test/raster/ad/laws_test.clj
+++ b/test/raster/ad/laws_test.clj
@@ -243,8 +243,10 @@
               (if (< i 3) (recur (inc i) nxt) acc)))]
     (n/* a a)))
 
-;; body IS a canonical tail-accumulation loop — the shape that used to yield a
-;; silent broken IFn from value+grad (flatten nil, unguarded). Now fails loud.
+;; body IS a canonical tail-accumulation loop — historically: silent broken
+;; IFn (pre-2026-07-04) → fail-loud guard → NOW (§15.2 loop canonicalization)
+;; it lifts to par/reduce in ad-prepare and simply DIFFERENTIATES.
+;; f(x) = 4·x², f'(x) = 8x — asserted exactly in o10.
 (deftm laws-tail-loop-fn [x :- Double] :- Double
   (loop [i 0 acc 0.0]
     (if (< i 4)
@@ -875,15 +877,15 @@
          #"Cannot differentiate through raw `loop`"
          (rev/value+grad #'laws-loop-fn))))
 
-  (testing "tail-loop body: value+grad fails LOUDLY (never a broken IFn)"
-    ;; Laws-suite finding 2026-07-04: a body that IS (or tail-lifts to) a raw
-    ;; loop produced flatten nil → an unguarded broken IFn (wrong-arity at call
-    ;; time). Now guarded: clear ex-info at construction time. The compiled /
-    ;; inline path handles these loops; the runtime assembler does not yet.
-    (is (thrown-with-msg?
-         Exception
-         #"cannot assemble a runtime gradient"
-         (rev/value+grad #'laws-tail-loop-fn))))
+  (testing "tail-loop body: canonicalizes to par/reduce and differentiates"
+    ;; History: silent broken IFn → fail-loud guard (2026-07-04) → §15.2 loop
+    ;; canonicalization (ad-prepare runs lift-parallel-forms), so the canonical
+    ;; tail-accumulation shape is no longer a boundary at all. The boundary
+    ;; moved to shapes the soundness gates decline (see laws-loop-fn above and
+    ;; the o10 data-dependent-bound law).
+    (let [[v dx] ((rev/value+grad #'laws-tail-loop-fn) 3.0)]
+      (is (== 36.0 v) "f(3) = 4·9")
+      (is (== 24.0 dx) "f'(3) = 8·3, exact")))
 
   (testing ":auto is admissibility-constrained (§11): erf goes forward AND is correct"
     ;; FLIPPED 2026-07-04 (was the KNOWN-GAP ':auto trap'): erf now has a
@@ -1305,12 +1307,11 @@
               (str "x_" k " accumulates via steps k and k+1")))))
 
     (testing "the raw-loop reject points at par/scan as the sanctioned recurrence"
+      ;; (laws-tail-loop-fn used to be the second witness here — §15.2
+      ;; canonicalization differentiates it now; see o5 + o10.)
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo #"par/scan"
-           (rev/value+grad #'laws-loop-fn)))
-      (is (thrown-with-msg?
-           Exception #"par/scan"
-           (rev/value+grad #'laws-tail-loop-fn))))
+           (rev/value+grad #'laws-loop-fn))))
 
     (testing "forward mode (jvp) on scan fails LOUD — no forward SOAC fold yet"
       ;; When the scan jvp lands (a second scan over the linearized
@@ -1318,3 +1319,139 @@
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo #"raster\.par/scan"
            ((jvp/jvp #'laws-scan-lin) [w h0 x sn] [1.0 0.0 (double-array sn) nil]))))))
+
+;; ================================================================
+;; Corpus — O10 loop canonicalization (framework §15.2)
+;;
+;; ad-prepare now runs the SIMD loop-lift (dotimes+aset → par/map!,
+;; tail-accumulation → par/reduce, carry+aset → par/scan) plus the AD-only
+;; carry→scan materializer (pure carry / carry+aset-returning-carry →
+;; par/scan whose out buffer IS the tape). Raw loops differentiate
+;; invisibly — same §14 syntax-transparency guarantee — and shapes the
+;; soundness gates decline stay on the fail-loud ladder.
+;; ================================================================
+
+;; loop-WRITTEN linear RNN (per-step aset, returns the final carry) — the
+;; syntactic twin of laws-scan-lin (par/scan-written). Same recurrence,
+;; same params, same result.
+(deftm laws-o10-rnn-loop [w :- Double, h0 :- Double, x :- (Array double),
+                          sn :- Long] :- Double
+  (let [out (double-array sn)]
+    (loop [i 0 h h0]
+      (if (< i sn)
+        (let [h2 (n/+ (n/* w h) (ra/aget x i))]
+          (ra/aset out i h2)
+          (recur (inc i) h2))
+        h))))
+
+;; PURE carry (no per-step store): tanh chain. Was fail-loud — the §15.2
+;; materializer synthesizes the out buffer (explicit store-the-carry
+;; checkpointing) and differentiates it.
+(deftm laws-o10-tanh-carry [x0 :- Double, w :- Double, cn :- Long] :- Double
+  (loop [i 0 h x0]
+    (if (< i cn)
+      (recur (inc i) (m/tanh (n/* w h)))
+      h)))
+
+;; ... and the same computation written as scan + aget-last, for the
+;; commuting check (post-canon they are the same computation).
+(deftm laws-o10-tanh-scan [x0 :- Double, w :- Double, cn :- Long] :- Double
+  (let [out (double-array cn)
+        h (par/scan out acc x0 i cn double (m/tanh (n/* w acc)))]
+    (ra/aget h (dec cn))))
+
+;; tail-accumulation with array reads (sum of squares) → par/reduce rule.
+(deftm laws-o10-ssq [xs :- (Array double), rn :- Long] :- Double
+  (loop [i 0 acc 0.0]
+    (if (< i rn)
+      (recur (inc i) (n/+ acc (n/* (ra/aget xs i) (ra/aget xs i))))
+      acc)))
+
+;; dotimes + aset (SGD-ish elementwise shape) — regression on the map! path.
+(deftm laws-o10-scale [xs :- (Array double), a :- Double, mn :- Long] :- Double
+  (let [out (double-array mn)]
+    (dotimes [i mn]
+      (ra/aset out i (n/* a (ra/aget xs i))))
+    (ra/aget out (dec mn))))
+
+;; DATA-DEPENDENT trip count: the bound reads the carry. Every gate on the
+;; soundness ladder must decline (lift, materializer), leaving the loud
+;; reject that points at par/scan and the fixed-point rule.
+(deftm laws-o10-datadep [x :- Double] :- Double
+  (loop [i 0 acc x]
+    (if (< i (long acc))
+      (recur (inc i) (n/+ acc x))
+      acc)))
+
+(deftest o10-loop-canonicalization-law
+  (let [w 0.6 h0 0.8 sn 4
+        x (double-array [0.7 -1.3 0.4 0.9])]
+    (testing "THE commuting law: loop-written RNN ≡ par/scan-written RNN, EXACT =="
+      ;; Post-canonicalization both are the same par/scan computation, so
+      ;; the gradients are bit-identical — not merely within tolerance.
+      (let [[v1 dw1 dh01 dx1] ((rev/value+grad #'laws-o10-rnn-loop) w h0 x sn)
+            [v2 dw2 dh02 dx2] ((rev/value+grad #'laws-scan-lin) w h0 x sn)]
+        (is (== v1 v2) "primal commutes")
+        (is (== dw1 dw2) "δw commutes exactly")
+        (is (== dh01 dh02) "δh0 commutes exactly")
+        (dotimes [k sn]
+          (is (== (ra/aget dx1 k) (ra/aget dx2 k))
+              (str "δx_" k " commutes exactly")))))
+
+    (testing "pure-carry loop (no store) differentiates — was fail-loud"
+      (let [x0 0.5 wc 0.8 cn 6
+            [v dx0 dwc] ((rev/value+grad #'laws-o10-tanh-carry) x0 wc cn)]
+        (is (close? v (laws-o10-tanh-carry x0 wc cn) 0.0) "primal unchanged")
+        (is (close? dx0 (central-fd #(laws-o10-tanh-carry % wc cn) x0 1e-6)
+                    1e-6) "δx0 vs FD")
+        (is (close? dwc (central-fd #(laws-o10-tanh-carry x0 % cn) wc 1e-6)
+                    1e-6) "δw vs FD")
+        ;; ... and commutes EXACTLY with the scan+aget-last spelling.
+        (let [[v2 dx02 dwc2] ((rev/value+grad #'laws-o10-tanh-scan) x0 wc cn)]
+          (is (== v v2))
+          (is (== dx0 dx02))
+          (is (== dwc dwc2)))))
+
+    (testing "tail-accumulation loop → par/reduce rule: Σx² grad = 2x EXACT"
+      (let [xs (double-array [1.0 2.0 3.0])
+            [v dxs] ((rev/value+grad #'laws-o10-ssq) xs 3)]
+        (is (== 14.0 v))
+        (dotimes [k 3]
+          (is (== (* 2.0 (ra/aget xs k)) (ra/aget dxs k))
+              (str "2·x_" k " exact")))))
+
+    (testing "dotimes+aset (map! path) still differentiates"
+      (let [xs (double-array [0.3 -0.7 1.1]) a 2.5
+            [v dxs da] ((rev/value+grad #'laws-o10-scale) xs a 3)]
+        (is (== (* a 1.1) v))
+        (is (== 0.0 (ra/aget dxs 0)))
+        (is (== 0.0 (ra/aget dxs 1)))
+        (is (== a (ra/aget dxs 2)) "δxs_last = a exact")
+        (is (== 1.1 da) "δa = xs_last exact")))
+
+    (testing "n = 0: canonicalized carry loop returns init with δinit = 1"
+      ;; The guard binds the result through an :if record — value AND
+      ;; adjoint route to init when the trip count is zero.
+      (let [[v dx0 dwc] ((rev/value+grad #'laws-o10-tanh-carry) 0.5 0.8 0)]
+        (is (== 0.5 v))
+        (is (== 1.0 dx0))
+        (is (or (nil? dwc) (== 0.0 dwc)) "δw is the (dynamic) zero")))
+
+    (testing "data-dependent trip count FAILS LOUD, pointing at par/scan + fixed-point"
+      ;; The soundness ladder: gates decline (bound reads the carry), the
+      ;; runtime path rejects with modeling guidance — never a silent
+      ;; unrolled tape.
+      (is (thrown-with-msg?
+           Exception #"par/scan"
+           (rev/value+grad #'laws-o10-datadep)))
+      (is (thrown-with-msg?
+           Exception #"fixed-point"
+           (rev/value+grad #'laws-o10-datadep))))
+
+    (testing "Item 3 status: canonicalization is PREFERRED, ArrayList path retained"
+      ;; Matched shapes never reach lift-loop-to-tail/gen-reverse-loop-with-let
+      ;; anymore (ad-prepare rewrites them to SOACs first — witnessed by the
+      ;; runtime value+grad successes above, which the ArrayList path never
+      ;; served). The path itself stays: multi-carry loops (loop [i a b])
+      ;; still need it on the compiled/inline path (rad_test multi-var laws).
+      (is true))))


### PR DESCRIPTION
Raw `loop`/`dotimes` forms now differentiate **transparently** — the compiler canonicalizes them onto the rule-bearing SOAC primitives inside `ad-prepare`, so the same syntax works whether or not it's being differentiated (the §14 transparency principle extended to loops). No user rewriting to `par/scan`; strictly more ergonomic than JAX's user-must-use-scan contract.

- **`lift-parallel-forms` wired into `ad-prepare`** (after `lower-composites`, before materialize/hoist): `dotimes`+`aset` → `par/map!`, tail-accumulation → `par/reduce`, carry+store → `par/scan` — reusing the SIMD loop-lift's proven-soundness gates and metadata-aware matchers.
- **Carry→scan materializer** (the one new piece): pure-carry loops (no per-step store) get a synthesized `out` buffer — which *is* the reverse tape (explicit store-the-carry checkpointing) — and become scans.
- **Soundness ladder intact**: data-dependent bounds are declined by the gates and still fail loud, pointing at `par/scan` + fixed-point/IFT.
- **`o10-loop-canonicalization` laws**, headlined by the commuting law: a loop-written linear RNN yields gradients **exactly identical** (`==`, not tolerance) to the scan-written one — post-canonicalization they are the same computation. Plus pure-carry tanh chain vs FD (was fail-loud, now differentiates), tail-accum via the reduce rule (exact), dotimes/SGD regression, and the fail-loud law.

Intermediate gate caught two real integration effects (recur-lub integer-init truncation on the new path; JIT/AOT differential divergence) — both fixed before the final gate.

Valhalla fresh JVM: **1744 / 29113 / 0 / 0, census 0**.