### PR TITLE
Retire the typedclojure fork — raster on upstream TC main

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
         org.clojure/data.json {:mvn/version "2.5.1"}
-        org.typedclojure/typed.clj.checker {:git/url "https://github.com/whilo/typedclojure"
-                                            :git/sha "ea66226f7e998f88e779b6ec3bb7332049728438"
+        org.typedclojure/typed.clj.checker {:git/url "https://github.com/typedclojure/typedclojure"
+                                            :git/sha "42ef524fb5482a2e2429f3732a6ad88d80529690"
                                             :deps/root "typed/clj.checker"}
         org.replikativ/pattern {:mvn/version "1.0.449"}
         org.replikativ/beichte {:mvn/version "0.2.7"}}

--- a/src/raster/compiler/core/inference.clj
+++ b/src/raster/compiler/core/inference.clj
@@ -262,6 +262,8 @@
 
 (defn tc-analyze-deftm-body
   "Analyze a deftm body once with Typed Clojure.
+  Forces tc-extensions/ensure-core-ann-overrides! first (late registration of
+  the unchecked-* precise overloads — see tc_extensions.clj for why late).
 
   Returns a map with:
     :ret-tag           — inferred return type tag
@@ -276,6 +278,7 @@
   definition) *ns* must be bound to the source ns or every refer'd op fails to
   resolve — yielding a TCError return and discarding ALL inferred binding types."
   [fn-name params annotations body & [source-ns]]
+  @raster.compiler.core.tc-extensions/ensure-core-ann-overrides!
   (try
     ;; Skip TC analysis for fully-untyped methods (all Object/Any params).
     ;; These are polymorphic fallbacks where TC can't add value — every operation

--- a/src/raster/compiler/core/tc_extensions.clj
+++ b/src/raster/compiler/core/tc_extensions.clj
@@ -34,6 +34,57 @@
 (t/ann ^:no-check clojure.core/object-array [(t/U Long (t/Seqable t/Any)) :-> (Array Object)])
 (t/ann ^:no-check clojure.core/long-array [(t/U Long (t/Seqable Long)) :-> (Array long)])
 (t/ann ^:no-check clojure.core/float-array [(t/U Long (t/Seqable t/Num)) :-> (Array float)])
+;; Precise unchecked-* arithmetic overloads. Upstream TC annotates these as
+;; AnyInteger -> AnyInteger, which makes BARE `(dotimes [b 4] b)` fail to check:
+;; dotimes expands to (loop [b 0] ... (recur (unchecked-inc b))), upstream #257
+;; widens the loop init to Long, and AnyInteger </: Long at the recur — one
+;; spurious delayed error per dotimes, which (via the load-bearing all-or-
+;; nothing error gate) discards every binding tag in the deftm. These overrides
+;; replace the last load-bearing commit of the whilo/typedclojure fork, letting
+;; raster run on UPSTREAM TC main. Upstreaming the fix (one annotation change)
+;; is proposed to TC with the (dotimes [b 4] b) repro.
+;;
+;; REGISTRATION MUST BE LATE: TC's base type env initializes lazily at the
+;; first check and clobbers load-time user annotations for clojure.core vars
+;; (verified: load-time ann ineffective, post-init ann effective). So the
+;; overrides live in a delay forced by inference.clj before each analysis.
+(defonce ^{:doc "Force before TC analysis: registers the unchecked-* overloads
+  AFTER TC's base env exists so they take precedence. Idempotent."}
+  ensure-core-ann-overrides!
+  (delay
+    (eval
+     '(do
+        ;; Force TC's lazy base-env initialization FIRST (a trivial check), so
+        ;; the anns below land AFTER it and are not clobbered by it. Without
+        ;; this, forcing the delay before the first real check would register
+        ;; into a pre-init env and be lost — with no second chance (defonce).
+        ((requiring-resolve 'typed.clj.checker/check-form-info) 1)
+        (typed.clojure/ann ^:no-check clojure.core/unchecked-inc
+          (typed.clojure/IFn [Long :-> Long] [Double :-> Double]
+                             [typed.clojure/AnyInteger :-> typed.clojure/AnyInteger]
+                             [typed.clojure/Num :-> typed.clojure/Num]))
+        (typed.clojure/ann ^:no-check clojure.core/unchecked-dec
+          (typed.clojure/IFn [Long :-> Long] [Double :-> Double]
+                             [typed.clojure/AnyInteger :-> typed.clojure/AnyInteger]
+                             [typed.clojure/Num :-> typed.clojure/Num]))
+        (typed.clojure/ann ^:no-check clojure.core/unchecked-negate
+          (typed.clojure/IFn [Long :-> Long] [Double :-> Double]
+                             [typed.clojure/AnyInteger :-> typed.clojure/AnyInteger]
+                             [typed.clojure/Num :-> typed.clojure/Num]))
+        (typed.clojure/ann ^:no-check clojure.core/unchecked-add
+          (typed.clojure/IFn [Long Long :-> Long] [Double Double :-> Double]
+                             [typed.clojure/AnyInteger typed.clojure/AnyInteger :-> typed.clojure/AnyInteger]
+                             [typed.clojure/Num typed.clojure/Num :-> typed.clojure/Num]))
+        (typed.clojure/ann ^:no-check clojure.core/unchecked-subtract
+          (typed.clojure/IFn [Long Long :-> Long] [Double Double :-> Double]
+                             [typed.clojure/AnyInteger typed.clojure/AnyInteger :-> typed.clojure/AnyInteger]
+                             [typed.clojure/Num typed.clojure/Num :-> typed.clojure/Num]))
+        (typed.clojure/ann ^:no-check clojure.core/unchecked-multiply
+          (typed.clojure/IFn [Long Long :-> Long] [Double Double :-> Double]
+                             [typed.clojure/AnyInteger typed.clojure/AnyInteger :-> typed.clojure/AnyInteger]
+                             [typed.clojure/Num typed.clojure/Num :-> typed.clojure/Num]))
+        :registered))))
+
 (t/ann ^:no-check clojure.core/conj! (t/All [x] [(t/Transient x) x :-> (t/Transient x)]))
 (t/ann ^:no-check clojure.core/transient (t/All [x] [(t/Coll x) :-> (t/Transient x)]))
 (t/ann ^:no-check clojure.core/persistent! (t/All [x] [(t/Transient x) :-> (t/Coll x)]))


### PR DESCRIPTION
raster now runs on **unmodified upstream TypedClojure main** (42ef524) — the `whilo/typedclojure` fork is retired. This is the keystone for the Clojars release chain (raster → Clojars needs a Maven-resolvable TC; the fork was the blocker).

**Why it's possible now**: Ambrose's #249/#256/#257/#259/#260 subsume 7 of the fork's 8 commits, with an API-compatible `:checked-ast`. Verified empirically: full suite against bare upstream = 29,111 assertions with **exactly 2 errors**, both one annotation.

**The one residual (now raster-side, upstream fix proposed)**: upstream annotates `unchecked-inc` as `AnyInteger → AnyInteger`, so bare `(dotimes [b 4] b)` fails to check (#257 correctly widens the loop init to `Long`; the recur arg fails against it). One spurious error per `dotimes` trips raster's load-bearing all-or-nothing error gate → all binding tags discarded → the x8-simd kernel's index binding C-emitted as `float`. Fixed with precise unchecked-* overloads registered raster-side in `tc-extensions` — **late** (TC's lazily-initialized base env clobbers load-time user annotations for core vars; the delay forces a trivial check first). The annotation fix + the `(dotimes [b 4] b)` repro go to TC as an issue; once fixed+released upstream, the overrides delete.

Valhalla fresh JVM: **1744 / 29113 / 0 / 0, census 0** — identical to the fork baseline.

Release chain after this: TC release (Ambrose) → raster drops git-dep → raster to Clojars → children (pretrained/finetune/umap/evoc/transformers-rstr) to Clojars.