### PR TITLE
Compiler reconcile P0+P1: fix #78 gradient sign-flip + cross-cutting gates

### DIFF
--- a/src/raster/compiler/passes/scalar/pe.clj
+++ b/src/raster/compiler/passes/scalar/pe.clj
@@ -227,6 +227,23 @@
 ;; Main PE pass
 ;; ================================================================
 
+(defn- reattach-meta
+  "Reattach `form`'s metadata to a rewritten `result`. When the rewrite CHANGED
+  the form, `:raster.op/original` is DROPPED — a simplification can change the
+  surviving node's operator (e.g. `(* (- x) 1.0)` → `(- x)`), and propagating the
+  parent's `:raster.op/original` onto the survivor stamps it with a head-op that
+  contradicts its actual head. `normalize` trusts `:raster.op/original` as ground
+  truth and would then rewrite the head (`- → *`), collapsing `(* x) → x` and
+  silently deleting the negation — the task #78 gradient sign-flip. `normalize`
+  already recovers the correct op from the `.invk` impl name when the tag is
+  absent, so dropping it on a changed node is safe. Type tags are preserved."
+  [form result changed?]
+  (if-let [m (meta form)]
+    (if (instance? clojure.lang.IMeta result)
+      (with-meta result (if changed? (dissoc m :raster.op/original) m))
+      result)
+    result))
+
 (defn pe-pass
   "Single pass of partial evaluation.
   const-env: {symbol -> constant-value} for known bindings."
@@ -350,10 +367,10 @@
           (if (= simplified normalized)
             ;; Simplification didn't help — keep the .invk form with metadata
             invk-form
-            ;; Simplification reduced something — use simplified result
-            (if-let [m (meta form)]
-              (if (instance? clojure.lang.IMeta simplified) (with-meta simplified m) simplified)
-              simplified)))
+            ;; Simplification reduced something — reattach meta, but drop the now-
+            ;; possibly-stale :raster.op/original (the rewrite may have changed the
+            ;; node's operator — see reattach-meta / task #78).
+            (reattach-meta form simplified true)))
 
         ;; new — PE the constructor args
         (= head 'new)
@@ -394,10 +411,10 @@
         ;; General call — PE args, then try constant folding
         :else
         (let [pe-children (map #(pe-pass % const-env) form)
-              r (simp/simplify-1 (apply list pe-children))]
-          (if-let [m (meta form)]
-            (if (instance? clojure.lang.IMeta r) (with-meta r m) r)
-            r))))
+              called (apply list pe-children)
+              r (simp/simplify-1 called)]
+          ;; drop stale :raster.op/original iff simplify changed the head (task #78)
+          (reattach-meta form r (not= r called)))))
 
     ;; Vector
     (vector? form)

--- a/test/raster/compiler/pipeline_quality_test.clj
+++ b/test/raster/compiler/pipeline_quality_test.clj
@@ -10,6 +10,7 @@
             [raster.ad.reverse :as rev]
             [raster.arrays :as arrays]
             [raster.compiler.pipeline :as pipeline]
+            [raster.compiler.passes.scalar.pe :as pe]
             [raster.tooling.inspect :as inspect]))
 
 (use-fixtures :once
@@ -293,3 +294,41 @@
           got (double (f a b n))]
       (is (< (Math/abs (- got (double expected))) 1e-9)
           (str "lifted=" got " scalar=" expected)))))
+
+;; ================================================================
+;; Task #78 regression: pe must not propagate a stale :raster.op/original
+;; across a rewrite that changed the node's operator.
+;; ================================================================
+
+(defn- count-name
+  "Count symbols in `form` whose name contains substring `s`."
+  [form ^String s]
+  (count (filter #(and (symbol? %) (.contains (str %) s))
+                 (tree-seq #(or (seq? %) (vector? %)) seq form))))
+
+;; cross-entropy-backward-dp = (broadcast [p t] (* (- (/ t (max 1e-15 p))) dy)).
+;; With a LITERAL 1.0 adjoint (the f64 loss seed), mul-by-one folds (* X 1.0)->X;
+;; pe then re-stamped the surviving (- X) with the *'s :raster.op/original,
+;; normalize rewrote the head - -> * and single-arg-mul deleted the negation ->
+;; dp = +t/p -> exact gradient sign flip -> MLP-f64 training divergence.
+(deftm ce-bwd-literal-seed [p :- (Array double) t :- (Array double)] :- (Array double)
+  (nn/cross-entropy-backward-dp 1.0 p t))
+
+(deftest cross-entropy-backward-literal-seed-keeps-negation-issue-78
+  (let [fx (:fixpointed (pipeline/show-pipeline #'ce-bwd-literal-seed :dtype :double))]
+    (is (>= (count-name fx "_minus__m_double-impl") 1)
+        (str "task #78: a LITERAL 1.0 f64 adjoint must NOT delete the -t/p "
+             "negation in cross-entropy-backward-dp (gradient sign flip)"))))
+
+;; Direct invariant on pe-pass: a rewrite that changes a node's operator must not
+;; leave the surviving node claiming the parent's :raster.op/original.
+(deftest pe-drops-stale-op-original-on-rewrite-issue-78
+  (let [node (with-meta
+               (list '.invk 'raster.numeric/_star__m_double_double-impl
+                     (with-meta (list '.invk 'raster.numeric/_minus__m_double-impl 'x)
+                       {:raster.op/original 'raster.numeric/-})
+                     1.0)
+               {:raster.op/original 'raster.numeric/*})
+        out (pe/pe-pass node {})]
+    (is (not= 'raster.numeric/* (:raster.op/original (meta out)))
+        "surviving (- x) must not inherit the *'s :raster.op/original after mul-by-one")))

--- a/test/raster/compiler/pipeline_quality_test.clj
+++ b/test/raster/compiler/pipeline_quality_test.clj
@@ -11,6 +11,7 @@
             [raster.arrays :as arrays]
             [raster.compiler.pipeline :as pipeline]
             [raster.compiler.passes.scalar.pe :as pe]
+            [raster.compiler.passes.scalar.normalize :as normalize]
             [raster.tooling.inspect :as inspect]))
 
 (use-fixtures :once
@@ -332,3 +333,38 @@
         out (pe/pe-pass node {})]
     (is (not= 'raster.numeric/* (:raster.op/original (meta out)))
         "surviving (- x) must not inherit the *'s :raster.op/original after mul-by-one")))
+
+;; ================================================================
+;; Cross-cutting gate (task #78): a .invk node's :raster.op/original must never
+;; contradict the op-family of its impl name. A violation is the pe/normalize
+;; provenance corruption that flipped #78's gradient sign — normalize trusts
+;; :raster.op/original, so a stale one silently rewrites the head.
+;; ================================================================
+
+(defn- op-original-violations
+  "Seq of .invk nodes whose :raster.op/original contradicts the impl's op-family
+   (per normalize's canonical demangler)."
+  [form]
+  (let [demangle @#'normalize/direct-op-for-impl
+        v (atom [])]
+    ((fn walk [f]
+       (when (coll? f)
+         (when (and (seq? f) (= '.invk (first f)) (symbol? (second f)))
+           (let [o (:raster.op/original (meta f))
+                 o2 (demangle (name (second f)))]
+             (when (and o o2 (not= o o2))
+               (swap! v conj {:claimed o :impl-op o2 :impl (second f)}))))
+         (doseq [x f] (walk x))))
+     form)
+    @v))
+
+(deftest op-original-agrees-with-head-invariant-issue-78
+  (doseq [v [#'nn/predict-fn #'nn/loss-fn #'ce-bwd-literal-seed]]
+    (let [sp (pipeline/show-pipeline v :dtype :double)]
+      (doseq [stage [:walked :fixpointed :materialized :lowered]]
+        (when-let [form (get sp stage)]
+          (is (empty? (op-original-violations form))
+              (str v " @ " stage
+                   " has :raster.op/original contradicting its .invk head "
+                   "(the #78 pe/normalize corruption class): "
+                   (pr-str (first (op-original-violations form))))))))))

--- a/test/raster/jit_aot_differential_test.clj
+++ b/test/raster/jit_aot_differential_test.clj
@@ -17,6 +17,9 @@
             [raster.numeric :refer [+ - * /]]
             [raster.arrays :refer [aget aset alength alloc-like]]
             [raster.dl.nn :as nn]
+            [raster.nn :as snn]
+            [raster.dl.optim :as optim]
+            [raster.ad.reverse :as rev]
             [raster.compiler.pipeline :as pl]))
 
 ;; ---------------------------------------------------------------------------
@@ -60,6 +63,26 @@
                                  x (nn/gelu x (clojure.core/* rows dh))
                                  x (nn/linear x w2 b2 rows dh din)]
                              x)))
+
+;; AD-differential axis (task #78): runtime value+grad vs compiled value+grad
+;; must agree. The forward-only corpus above CANNOT catch backward miscompiles.
+;; cross-entropy's backward is a broadcast `(* (- (/ t (max eps p))) dy)`; a stale
+;; :raster.op/original from `pe` let `normalize` rewrite `- -> *` and delete the
+;; negation on the compile path only (f64 literal-1.0 seed) — an exact gradient
+;; sign flip. A gradient-returning deftm routes straight through run-one's
+;; JIT-vs-AOT comparison, so the drop shows up as runtime≠compiled here.
+(deftm d-ce-loss (All [T] [logits :- (Array T) y :- (Array T)] :- T
+                      (snn/cross-entropy (snn/softmax logits) y)))
+
+;; gradient w.r.t. logits (index 1 of [loss d_logits d_y])
+(deftm d-ce-grad (All [T] [logits :- (Array T) y :- (Array T)] :- (Array T)
+                      (nth ((rev/value+grad (var d-ce-loss)) logits y) 1)))
+
+;; value+grad + in-place SGD — the train-step shape that surfaced #78 at scale
+(deftm d-ce-step (All [T] [w :- (Array T) y :- (Array T) lr :- Double] :- (Array T)
+                      (let [vg ((rev/value+grad (var d-ce-loss)) w y)]
+                        (optim/sgd-step! w (nth vg 1) (alength w) lr)
+                        w)))
 
 ;; ---------------------------------------------------------------------------
 ;; harness
@@ -112,13 +135,27 @@
    ;; D2 guard — allocating-op rebind at real-ish dims (rows=32, din=64, dh=256)
    {:name "d-rebind-block"  :var #'d-rebind-block
     :make (fn [dt] [(ramp dt (* 32 64)) (ramp dt (* 64 256)) (ramp dt 256)
-                    (ramp dt (* 256 64)) (ramp dt 64) 32 64 256])}])
+                    (ramp dt (* 256 64)) (ramp dt 64) 32 64 256])}
+   ;; AD-differential (#78): backward of a template op whose backward is itself a
+   ;; deftm (cross-entropy → cross-entropy-backward-dp broadcast). runtime keeps
+   ;; it a call; compile inlines it → the pe/normalize sign-drop showed up here.
+   ;; :double-only until R4/#77 (tag-safe devirt) fixes the :float [F→[D in the
+   ;; backward — then flip :dtypes to enable :float and make this R4's gate.
+   {:name "d-ce-grad"       :var #'d-ce-grad :dtypes [:double]
+    :make (fn [dt] [(ramp dt 10) (ramp dt 10)])}
+   {:name "d-ce-step"       :var #'d-ce-step :dtypes [:double]
+    :make (fn [dt] [(ramp dt 10) (ramp dt 10) 0.1])}])
 
 (def tol 1.0e-4)  ;; FP reassociation between serial-JIT and SIMD/fused-AOT
 
 (deftest jit-aot-differential
-  (doseq [dt [:double :float]
-          entry corpus]
+  ;; An entry may restrict which dtypes it runs via :dtypes (default both). The
+  ;; AD-differential entries are :double-only until R4 (tag-safe devirtualization,
+  ;; task #77) lands — at :float the backward devirtualizes to a doubles impl and
+  ;; throws [F→[D (the same class as LeNet-f32 [J→[S). Flip them to both dtypes
+  ;; when R4 lands: this test then becomes R4's regression gate.
+  (doseq [entry corpus
+          dt (:dtypes entry [:double :float])]
     (testing (str (:name entry) " @ " dt)
       (let [r (run-one entry dt)]
         (if (:ok r)


### PR DESCRIPTION
## Compiler reconciliation, Phase 0+1 — fix #78 + the cross-cutting gates

First slice of the compiler reconciliation agenda (`.internal/compiler_reconciliation_agenda.md`). Fixes the MLP-f64 training-divergence bug (#78) at its true root, and adds the two boundary gates that make its whole class visible instead of silent.

### P0 — `pe` drops stale `:raster.op/original` on rewrite (the #78 fix)
`pe-pass` re-stamped a *rewritten* node with the *original* node's `:raster.op/original`: mul-by-one folds `(* (- X) 1.0) → (- X)`, but the surviving `(- X)` inherited `:op = *`. `normalize` trusts `:raster.op/original` as ground truth, rewrote the head `- → *`, and single-arg-mul `(* X) → X` **silently deleted the negation** → `dp = +t/p` → exact gradient **sign flip** → MLP-f64 diverges. f32 escaped only because `(float 1.0)` isn't a bare literal, so mul-by-one never fired.

`reattach-meta` now drops `:raster.op/original` when a rewrite changed the node's operator (both `.invk` and general-call sites); `normalize` recovers the real op from the `.invk` impl name. **Deterministic** — the earlier "load-order sensitive" theory was a REPL-tooling artifact.

Verified: compiled MLP-f64 gradient `−0.873103` == finite-difference `−0.873103` (was `+0.873103`).

### P1 — the two cross-cutting gates
- **D1 AD-differential axis**: the harness was forward-only and structurally could not catch backward miscompiles (#78 slipped past it). Gradient-returning corpus entries now compare runtime `value+grad` vs compiled `value+grad`. `:double` locks in #78; the `:float` cases **immediately surfaced R4/#77** (backward devirtualizes to a doubles impl → `[F→[D`), so they're `:dtypes [:double]`-gated until tag-safe devirt lands, at which point they become R4's regression gate.
- **`:raster.op/original`-agrees-with-head invariant**: walks every pipeline stage of a corpus and asserts no `.invk` node's `:raster.op/original` contradicts its impl's op-family. Dry-run found zero violations post-fix (confirming the pe fix was complete for this class); guards against any pass reintroducing the corruption.

### Gate
Full Valhalla suite **1747 / 29129 / 0 / 0**. +regression tests (pure `show-pipeline`, no execution/benchmark).

Follow-on phases (R1 content-addressed walked-body + hasch, R3 seed asymmetry, R4 tag-safe devirt, R5a SSA invariant) tracked in the agenda doc and tasks #53/#76/#77.
