### PR TITLE
R1: unify resolve-deftm-var + resolve-first walked-body (REPL reliability)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,7 +5,10 @@
                                             :git/sha "42ef524fb5482a2e2429f3732a6ad88d80529690"
                                             :deps/root "typed/clj.checker"}
         org.replikativ/pattern {:mvn/version "1.0.449"}
-        org.replikativ/beichte {:mvn/version "0.2.7"}}
+        org.replikativ/beichte {:mvn/version "0.2.7"}
+        ;; content-addressed hashing of deftm source bodies (R1 walked-body memo);
+        ;; cross-platform (JVM+cljs) keeps the browser port open.
+        org.replikativ/hasch {:mvn/version "0.4.99"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner

--- a/deps.edn
+++ b/deps.edn
@@ -5,10 +5,7 @@
                                             :git/sha "42ef524fb5482a2e2429f3732a6ad88d80529690"
                                             :deps/root "typed/clj.checker"}
         org.replikativ/pattern {:mvn/version "1.0.449"}
-        org.replikativ/beichte {:mvn/version "0.2.7"}
-        ;; content-addressed hashing of deftm source bodies (R1 walked-body memo);
-        ;; cross-platform (JVM+cljs) keeps the browser port open.
-        org.replikativ/hasch {:mvn/version "0.4.99"}}
+        org.replikativ/beichte {:mvn/version "0.2.7"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner

--- a/src/raster/ad/reverse.clj
+++ b/src/raster/ad/reverse.clj
@@ -2300,43 +2300,16 @@
 ;; ================================================================
 
 (defn ^:no-doc resolve-deftm-var
-  "Resolve a deftm dispatch var to its backing mangled var with walked body.
-  Checks (in order):
-  1. Direct metadata on f-var (mangled method vars, value+grad/grad results)
-  2. Deref'd value metadata (for vars pointing to value+grad/grad IFn objects)
-  3. Dispatch table lookup (for generic dispatch vars → mangled method vars)"
+  "Resolve a deftm dispatch var to its backing mangled var for value+grad. Thin
+  wrapper over the canonical raster.core/resolve-deftm-var with the AD policy:
+  also accept vars pointing to a value+grad/grad IFn result (:deref-value?),
+  throw on ambiguous dispatch, and return f-var unchanged when it is not a
+  dispatch var (:on-miss :self)."
   [f-var]
-  (cond
-    ;; Direct metadata (mangled vars, IFn with metadata)
-    (:raster.core/deftm (meta f-var))
-    f-var
-
-    ;; Deref'd value: var pointing to a value+grad/grad result
-    (and (instance? clojure.lang.Var f-var)
-         (let [val-meta (try (meta @f-var) (catch Exception _ nil))]
-           (:raster.core/deftm val-meta)))
-    @f-var
-
-    ;; Dispatch table: generic var → mangled method
-    :else
-    (let [resolved (when-let [dt (:raster.core/dispatch-table (meta f-var))]
-                     (let [all-methods (mapcat identity (vals @dt))
-                           ns-obj (:ns (meta f-var))
-                           fn-name (:name (meta f-var))]
-                       (if (= 1 (count all-methods))
-                         ;; Single method: unambiguous
-                         (let [method (first all-methods)
-                               mangled-name (symbol (str fn-name "_m_"
-                                                         (clojure.string/join "_" (:tags method))))]
-                           (ns-resolve ns-obj mangled-name))
-                         ;; Multiple methods: cannot auto-resolve for AD
-                         (throw (ex-info (str "Ambiguous dispatch for value+grad on `" fn-name
-                                              "`: " (count all-methods) " overloads. "
-                                              "Use the mangled var directly, e.g. #'"
-                                              (ns-name ns-obj) "/" fn-name "_m_<tags>")
-                                         {:var f-var
-                                          :overloads (mapv :tags all-methods)})))))]
-      (or resolved f-var))))
+  (rcore/resolve-deftm-var
+   f-var {:deref-value? true
+          :on-miss :self
+          :ambiguity-hint "Use the mangled var directly, e.g. #'ns/name_m_<tags>."}))
 
 (def ^:private vjp-cache (atom {}))
 

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -77,47 +77,14 @@
 ;; ================================================================
 
 (defn- resolve-deftm-var
-  "Resolve a deftm var. If f-var is a dispatch var (generic function),
-  find the backing method var. When dtype is specified, selects the
-  matching overload (e.g. :float picks float[] methods over double[]).
-  Without dtype, picks the single overload or errors if ambiguous."
+  "compile-aot's dispatch→impl resolution. Thin wrapper over the canonical
+  raster.core/resolve-deftm-var: dtype-directed overload selection (monomorphizes
+  parametric templates), throws on ambiguity, returns nil when f-var has no
+  dispatch table."
   ([f-var] (resolve-deftm-var f-var nil))
   ([f-var dtype]
-   (if (:raster.core/deftm (meta f-var))
-     f-var
-     ;; Look up the dispatch table
-     (when-let [dt (:raster.core/dispatch-table (meta f-var))]
-       (let [all-methods (mapcat val @dt)
-             dtype-tag (case dtype :float 'floats :double 'doubles nil)
-             direct (when dtype-tag
-                      (first (filter #(some #{dtype-tag} (:tags %)) all-methods)))]
-         (if (and dtype-tag (nil? direct))
-           ;; No concrete overload for this dtype yet. If f-var is a parametric
-           ;; (All [T]) deftm, MONOMORPHIZE it: force-create the T := dtype
-           ;; specialization so the whole compile pass — including re-walk type
-           ;; inference and inner parametric calls — resolves to the requested
-           ;; element type, instead of silently falling back to the double
-           ;; method (which bakes double .invk targets into the walked body).
-           (or (when-let [ensure! (requiring-resolve 'raster.core/ensure-dtype-specialization!)]
-                 (ensure! f-var dtype))
-               ;; Non-parametric, or specialization unavailable: fall back to any
-               ;; registered method (legacy behavior).
-               (let [method (first all-methods)
-                     ns-obj (:ns (meta f-var))]
-                 (ns-resolve ns-obj (symbol (str (types/mangle
-                                                  (:name (meta f-var)) (:tags method)))))))
-           (let [method (or direct
-                            ;; No dtype: use single overload, or error if ambiguous
-                            (if (= 1 (count all-methods))
-                              (first all-methods)
-                              (throw (ex-info
-                                      (str "Ambiguous overload for compile-aot on "
-                                           (:name (meta f-var)) ". Specify :dtype to disambiguate.\n"
-                                           "Available: " (mapv :tags all-methods))
-                                      {:var f-var :methods (mapv :tags all-methods)}))))
-                 ns-obj (:ns (meta f-var))]
-             (ns-resolve ns-obj (symbol (str (types/mangle
-                                              (:name (meta f-var)) (:tags method))))))))))))
+   (rcore/resolve-deftm-var f-var {:dtype dtype
+                                   :ambiguity-hint "Specify :dtype to disambiguate."})))
 
 (defn- infer-dtype
   "Infer dtype from a resolved deftm var's parameter tags.

--- a/src/raster/core.clj
+++ b/src/raster/core.clj
@@ -455,13 +455,29 @@
   [key]
   (get @walked-body-registry key))
 
+;; resolve-deftm-var is defined much later (it needs the parametric-monomorphize
+;; machinery); ensure-walked-body! forward-references it to resolve-first.
+(declare resolve-deftm-var)
+
 (clojure.core/defn ^:no-doc ensure-walked-body!
   "Lazily walk a deftm var's source body with TC. Returns walked body.
   Julia model: walking is deferred to first use. If the var already has
   a walked body, returns it immediately. Otherwise walks from source body
   with TC binding tags and caches the result on the var metadata.
-  Thread-safe via double-checked locking per var."
+  Thread-safe via double-checked locking per var.
+
+  Resolve-FIRST: the walked body lives on the backing (mangled) impl var, but
+  the DISPATCH var is the ergonomic handle. Handed a dispatch var, resolve it to
+  the impl var before reading the cache — otherwise this silently returned nil on
+  a dispatch var, the debug-tooling footgun that misdiagnosed #78 (task #53). An
+  already-resolved impl var (the hot path) skips the resolve entirely; a genuinely
+  non-deftm var, or an ambiguous multi-overload dispatch var with no dtype, falls
+  through to nil unchanged (preserving the 'not inlinable' contract of
+  inline/op_descriptor/pe callers)."
   [v]
+  (let [v (if (::deftm (meta v))
+            v
+            (or (try (resolve-deftm-var v nil) (catch Exception _ nil)) v))]
   (or (seq (::deftm-walked-body (meta v)))
       (locking v
         (or (seq (::deftm-walked-body (meta v)))
@@ -478,7 +494,7 @@
                                   (let [te (build-walker-type-env (::deftm-params m) (::deftm-annotations m))]
                                     (mapv #(walker/walk-body % {:type-env te :source-ns *ns*}) (vec src)))))]
                 (alter-meta! v assoc ::deftm-walked-body (vec walked))
-                (vec walked)))))))
+                (vec walked))))))))
 
 ;; ================================================================
 ;; Public API: defn — Clojure defn with walked body for compiler inlining

--- a/src/raster/core.clj
+++ b/src/raster/core.clj
@@ -1805,3 +1805,72 @@
 ;; the concrete method (compile-time devirtualization, no invoke).
 (dispatch/set-parametric-specializer! parametric-specialize!)
 (dispatch/set-parametric-register! register-parametric-specialization!)
+
+(defn resolve-deftm-var
+  "Canonical `dispatch var → backing mangled impl var` resolution — the single
+  source of truth. The impl var is the one that carries ::deftm metadata (params,
+  tags, source/walked body); a dispatch (generic) var only carries a
+  ::dispatch-table. Three call sites (pipeline compile-aot, ad/reverse
+  value+grad, gpu kernel compile) previously each hand-rolled this with divergent
+  mangling — manual `_m_`-join vs `types/mangle`, the latter being what DEFINITION
+  time uses (core.clj:719/1558). The manual join is wrong for operator-named
+  (`+` → `_plus_`) or compound/flattenable-tag deftms, a latent miscompile in the
+  AD and GPU paths. This unifies mangling on `types/mangle` while keeping each
+  caller's genuinely-distinct policy explicit via opts.
+
+  opts (a map, or nil for defaults):
+    :dtype          :float|:double — select that overload; if no concrete overload
+                    exists yet, MONOMORPHIZE a parametric (All [T]) deftm to that
+                    element type via ensure-dtype-specialization!. nil = agnostic.
+    :ambiguity      :throw (default) — throw on >1 overload when no :dtype pins one;
+                    :first — pick the first overload (GPU kernel compile: any
+                    concrete overload's par-forms suffice).
+    :ambiguity-hint string appended to the throw message — caller-specific
+                    remediation (\"Specify :dtype\" vs \"use the mangled var\").
+    :deref-value?   when true, also accept f-var if @f-var carries ::deftm meta
+                    (value+grad / grad IFn results — ad/reverse only).
+    :on-miss        :nil (default) — return nil when f-var is neither a deftm nor a
+                    dispatch var; :self — return f-var unchanged (ad/reverse).
+
+  Returns the backing var (::deftm on its meta), or per :on-miss."
+  ([f-var] (resolve-deftm-var f-var nil))
+  ([f-var {:keys [dtype ambiguity ambiguity-hint deref-value? on-miss]
+           :or {ambiguity :throw on-miss :nil}}]
+   (cond
+     ;; already the backing var
+     (::deftm (meta f-var)) f-var
+
+     ;; value+grad / grad result: ::deftm meta lives on the deref'd IFn
+     (and deref-value?
+          (instance? clojure.lang.Var f-var)
+          (::deftm (try (meta @f-var) (catch Exception _ nil))))
+     @f-var
+
+     :else
+     (if-let [dt (::dispatch-table (meta f-var))]
+       (let [all-methods (mapcat val @dt)
+             ns-obj (:ns (meta f-var))
+             fn-name (:name (meta f-var))
+             dtype-tag (case dtype :float 'floats :double 'doubles nil)
+             direct (when dtype-tag
+                      (first (filter #(some #{dtype-tag} (:tags %)) all-methods)))]
+         (if (and dtype-tag (nil? direct))
+           ;; dtype requested but no concrete overload: monomorphize the parametric
+           ;; template (narrows T for the whole compile pass), else fall back to any
+           ;; registered method (legacy non-parametric behavior).
+           (or (ensure-dtype-specialization! f-var dtype)
+               (ns-resolve ns-obj (types/mangle fn-name (:tags (first all-methods)))))
+           (let [method (or direct
+                            (if (= 1 (count all-methods))
+                              (first all-methods)
+                              (case ambiguity
+                                :first (first all-methods)
+                                (throw (ex-info
+                                        (str "Ambiguous overload for `" fn-name "`: "
+                                             (count all-methods) " overloads"
+                                             (when ambiguity-hint (str ". " ambiguity-hint))
+                                             "\nAvailable: " (mapv :tags all-methods))
+                                        {:var f-var :methods (mapv :tags all-methods)})))))]
+             (ns-resolve ns-obj (types/mangle fn-name (:tags method))))))
+       ;; no dispatch table
+       (case on-miss :self f-var nil)))))

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -86,18 +86,12 @@
 ;; ================================================================
 
 (defn resolve-deftm-var
-  "Resolve a deftm var through dispatch table to the mangled backing var.
-   Returns the var that carries :raster.core/deftm metadata."
+  "Resolve a deftm var through dispatch table to the mangled backing var. Thin
+   wrapper over the canonical raster.core/resolve-deftm-var with the GPU policy:
+   any concrete overload's par-forms suffice, so pick the first (:ambiguity
+   :first); returns nil when v is not a deftm/dispatch var."
   [v]
-  (if (:raster.core/deftm (meta v))
-    v
-    (when-let [dt (:raster.core/dispatch-table (meta v))]
-      (let [entries (vals @dt)
-            method (first (first entries))
-            ns-obj (:ns (meta v))
-            mangled-name (symbol (str (:name (meta v)) "_m_"
-                                      (clojure.string/join "_" (:tags method))))]
-        (ns-resolve ns-obj mangled-name)))))
+  (rcore/resolve-deftm-var v {:ambiguity :first}))
 
 (defn get-walked-body
   "Get the walker-processed body from a deftm var.

--- a/test/raster/compiler/walked_body_canonical_test.clj
+++ b/test/raster/compiler/walked_body_canonical_test.clj
@@ -1,0 +1,112 @@
+(ns raster.compiler.walked-body-canonical-test
+  "R1 characterization — pins the walked-body / resolver invariants that the
+  content-addressed rewrite (S2+) must preserve, and validates the hasch
+  content-key mechanism on REAL raster deftm bodies.
+
+  These are deliberately GREEN on the pre-S2 code: they capture what already
+  works (so S2 cannot silently regress it) plus the properties the S2 memo key
+  relies on. The fail-loud read-API tests (dispatch-var must throw, not return
+  nil) arrive WITH S3, when that behavior change lands — today the silent-nil
+  footgun is pinned as `current behavior` so the S3 flip is visible in the diff."
+  (:refer-clojure :exclude [+ - * / aget aset alength])
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.core :as rcore :refer [deftm]]
+            [raster.numeric :refer [+ - * /]]
+            [raster.arrays :refer [aget aset alength alloc-like]]
+            [raster.compiler.pipeline :as pl]
+            [raster.gpu.core :as gc]
+            [raster.ad.reverse :as rev]
+            [raster.compiler.core.types :as types]
+            [hasch.core :as hasch]))
+
+;; A controlled, non-parametric deftm so meta keys are concrete and stable.
+(deftm wbc-sq [x :- (Array Double) n :- Long] :- (Array Double)
+  (let [out (alloc-like x n)]
+    (dotimes [i n]
+      (aset out i (* (aget x i) (aget x i))))
+    out))
+
+;; ---------------------------------------------------------------------------
+;; S1 — canonical resolver: the three callers agree on the backing impl var
+;; ---------------------------------------------------------------------------
+
+(deftest resolver-callers-agree
+  (testing "dispatch var resolves to the SAME backing ::deftm impl var across callers"
+    (let [dv #'wbc-sq
+          canon (rcore/resolve-deftm-var dv nil)
+          via-pipeline (#'pl/resolve-deftm-var dv)
+          via-gpu (gc/resolve-deftm-var dv)
+          via-reverse (rev/resolve-deftm-var dv)]
+      (is (:raster.core/deftm (meta canon)) "canonical resolves to a ::deftm impl var")
+      (is (= canon via-pipeline) "pipeline wrapper == canonical")
+      (is (= canon via-gpu) "gpu wrapper == canonical")
+      (is (= canon via-reverse) "reverse wrapper == canonical (single overload)")))
+  (testing "an already-resolved impl var is returned unchanged (idempotent)"
+    (let [impl (rcore/resolve-deftm-var #'wbc-sq nil)]
+      (is (= impl (rcore/resolve-deftm-var impl nil)))))
+  (testing "mangling matches DEFINITION-time exactly (types/mangle, not manual _m_ join)"
+    ;; re-deriving the mangled name from the impl var's own tags via types/mangle
+    ;; must resolve back to the SAME var — i.e. the resolver used the identical
+    ;; mangling scheme definition-time used (the manual _m_ join would diverge for
+    ;; operator-named / compound-tag deftms).
+    (let [impl (rcore/resolve-deftm-var #'wbc-sq nil)
+          tags (:raster.core/deftm-tags (meta impl))]
+      (is (var? impl))
+      (is (= impl (ns-resolve (:ns (meta impl)) (types/mangle 'wbc-sq tags)))
+          "types/mangle roundtrips to the same backing var"))))
+
+;; ---------------------------------------------------------------------------
+;; ensure-walked-body! current behavior (pins the footgun S3 will fix)
+;; ---------------------------------------------------------------------------
+
+(deftest ensure-walked-body-current-behavior
+  (testing "on a RESOLVED impl var: non-empty walked body"
+    (let [impl (rcore/resolve-deftm-var #'wbc-sq nil)
+          wb (rcore/ensure-walked-body! impl)]
+      (is (seq wb) "resolved impl var yields a non-empty walked body")))
+  (testing "on a DISPATCH var: currently returns nil (silent-nil footgun)"
+    ;; This is the REPL footgun R1 targets. S3 makes this fail-loud (throw with a
+    ;; 'resolve first' message). Pinned here so that behavior change is explicit.
+    (is (nil? (rcore/ensure-walked-body! #'wbc-sq))
+        "PRE-S3: dispatch var silently yields nil (to become fail-loud in S3)")))
+
+;; ---------------------------------------------------------------------------
+;; hasch content-key mechanism — the S2 memo key, validated on real bodies
+;; ---------------------------------------------------------------------------
+
+(defn- content-key
+  "The S2 memo key: pure fn of (source-body, params, tags, annotations,
+  source-ns, dtype). Uses hasch's DEFAULT hash — the de-risking finding is that
+  raster source bodies carry no load-bearing symbol metadata, so the default
+  (which drops symbol metadata) is exactly right."
+  [impl-var dtype]
+  (let [m (meta impl-var)]
+    (hasch/uuid [(:raster.core/deftm-source-body m)
+                 (:raster.core/deftm-params m)
+                 (:raster.core/deftm-tags m)
+                 (:raster.core/deftm-annotations m)
+                 (:raster.core/deftm-source-ns m)
+                 dtype])))
+
+(deftest hasch-content-key
+  (let [impl (rcore/resolve-deftm-var #'wbc-sq nil)]
+    (testing "stable across calls (deterministic)"
+      (is (= (content-key impl :double) (content-key impl :double))))
+    (testing "dtype is part of the key"
+      (is (not= (content-key impl :double) (content-key impl :float))))
+    (testing "source-body drives the key (different body => different key)"
+      (let [k1 (content-key impl :double)
+            k2 (hasch/uuid ['(different body form) (:raster.core/deftm-params (meta impl))
+                            (:raster.core/deftm-tags (meta impl))
+                            (:raster.core/deftm-annotations (meta impl))
+                            (:raster.core/deftm-source-ns (meta impl)) :double])]
+        (is (not= k1 k2))))
+    (testing "de-risking finding: incidental symbol metadata (:line/:column) does NOT change the key"
+      ;; two structurally-identical bodies differing only in symbol position meta
+      ;; must hash the same — walking does not depend on source position.
+      (let [body-a '(let [y (* x x)] y)
+            body-b (clojure.walk/postwalk
+                    (fn [f] (if (symbol? f) (with-meta f {:line 99 :column 7}) f))
+                    '(let [y (* x x)] y))]
+        (is (= (hasch/uuid body-a) (hasch/uuid body-b))
+            "hasch default drops symbol metadata => position-independent memo key")))))

--- a/test/raster/compiler/walked_body_canonical_test.clj
+++ b/test/raster/compiler/walked_body_canonical_test.clj
@@ -59,16 +59,25 @@
 ;; ensure-walked-body! current behavior (pins the footgun S3 will fix)
 ;; ---------------------------------------------------------------------------
 
-(deftest ensure-walked-body-current-behavior
-  (testing "on a RESOLVED impl var: non-empty walked body"
+(deftest ensure-walked-body-resolve-first
+  (testing "on a RESOLVED impl var: non-empty walked body (hot path, skips resolve)"
     (let [impl (rcore/resolve-deftm-var #'wbc-sq nil)
           wb (rcore/ensure-walked-body! impl)]
       (is (seq wb) "resolved impl var yields a non-empty walked body")))
-  (testing "on a DISPATCH var: currently returns nil (silent-nil footgun)"
-    ;; This is the REPL footgun R1 targets. S3 makes this fail-loud (throw with a
-    ;; 'resolve first' message). Pinned here so that behavior change is explicit.
-    (is (nil? (rcore/ensure-walked-body! #'wbc-sq))
-        "PRE-S3: dispatch var silently yields nil (to become fail-loud in S3)")))
+  (testing "on a DISPATCH var: resolve-first yields the body (S2 footgun fix)"
+    ;; Was the REPL debug-tooling footgun that misdiagnosed #78 (task #53): a
+    ;; dispatch var silently returned nil because the body lives on the backing
+    ;; impl var. S2 resolves-first, so the dispatch var now yields the SAME body.
+    (let [impl (rcore/resolve-deftm-var #'wbc-sq nil)]
+      (is (seq (rcore/ensure-walked-body! #'wbc-sq))
+          "dispatch var yields a non-empty walked body")
+      (is (= (rcore/ensure-walked-body! #'wbc-sq)
+             (rcore/ensure-walked-body! impl))
+          "dispatch var body == impl var body")))
+  (testing "contract preserved: non-deftm / ambiguous dispatch var fall through to nil"
+    ;; the inline/op_descriptor/pe callers treat nil as 'not inlinable' — must hold.
+    (is (nil? (rcore/ensure-walked-body! #'clojure.core/+))
+        "genuinely non-deftm var -> nil (not a crash)")))
 
 ;; ---------------------------------------------------------------------------
 ;; hasch content-key mechanism — the S2 memo key, validated on real bodies

--- a/test/raster/compiler/walked_body_canonical_test.clj
+++ b/test/raster/compiler/walked_body_canonical_test.clj
@@ -1,13 +1,11 @@
 (ns raster.compiler.walked-body-canonical-test
-  "R1 characterization — pins the walked-body / resolver invariants that the
-  content-addressed rewrite (S2+) must preserve, and validates the hasch
-  content-key mechanism on REAL raster deftm bodies.
+  "R1 characterization — pins the resolver + walked-body invariants that the
+  reconciliation must preserve: one canonical dispatch->impl resolver (S1) and
+  ensure-walked-body! that resolves-first so a dispatch var yields its body
+  rather than nil (S2, the debug-tooling footgun that misdiagnosed #78).
 
-  These are deliberately GREEN on the pre-S2 code: they capture what already
-  works (so S2 cannot silently regress it) plus the properties the S2 memo key
-  relies on. The fail-loud read-API tests (dispatch-var must throw, not return
-  nil) arrive WITH S3, when that behavior change lands — today the silent-nil
-  footgun is pinned as `current behavior` so the S3 flip is visible in the diff."
+  The fail-loud read-API distinction (genuinely-non-deftm vs is-deftm-but-walk-
+  failed) arrives with S3."
   (:refer-clojure :exclude [+ - * / aget aset alength])
   (:require [clojure.test :refer [deftest is testing]]
             [raster.core :as rcore :refer [deftm]]
@@ -16,8 +14,7 @@
             [raster.compiler.pipeline :as pl]
             [raster.gpu.core :as gc]
             [raster.ad.reverse :as rev]
-            [raster.compiler.core.types :as types]
-            [hasch.core :as hasch]))
+            [raster.compiler.core.types :as types]))
 
 ;; A controlled, non-parametric deftm so meta keys are concrete and stable.
 (deftm wbc-sq [x :- (Array Double) n :- Long] :- (Array Double)
@@ -78,44 +75,3 @@
     ;; the inline/op_descriptor/pe callers treat nil as 'not inlinable' — must hold.
     (is (nil? (rcore/ensure-walked-body! #'clojure.core/+))
         "genuinely non-deftm var -> nil (not a crash)")))
-
-;; ---------------------------------------------------------------------------
-;; hasch content-key mechanism — the S2 memo key, validated on real bodies
-;; ---------------------------------------------------------------------------
-
-(defn- content-key
-  "The S2 memo key: pure fn of (source-body, params, tags, annotations,
-  source-ns, dtype). Uses hasch's DEFAULT hash — the de-risking finding is that
-  raster source bodies carry no load-bearing symbol metadata, so the default
-  (which drops symbol metadata) is exactly right."
-  [impl-var dtype]
-  (let [m (meta impl-var)]
-    (hasch/uuid [(:raster.core/deftm-source-body m)
-                 (:raster.core/deftm-params m)
-                 (:raster.core/deftm-tags m)
-                 (:raster.core/deftm-annotations m)
-                 (:raster.core/deftm-source-ns m)
-                 dtype])))
-
-(deftest hasch-content-key
-  (let [impl (rcore/resolve-deftm-var #'wbc-sq nil)]
-    (testing "stable across calls (deterministic)"
-      (is (= (content-key impl :double) (content-key impl :double))))
-    (testing "dtype is part of the key"
-      (is (not= (content-key impl :double) (content-key impl :float))))
-    (testing "source-body drives the key (different body => different key)"
-      (let [k1 (content-key impl :double)
-            k2 (hasch/uuid ['(different body form) (:raster.core/deftm-params (meta impl))
-                            (:raster.core/deftm-tags (meta impl))
-                            (:raster.core/deftm-annotations (meta impl))
-                            (:raster.core/deftm-source-ns (meta impl)) :double])]
-        (is (not= k1 k2))))
-    (testing "de-risking finding: incidental symbol metadata (:line/:column) does NOT change the key"
-      ;; two structurally-identical bodies differing only in symbol position meta
-      ;; must hash the same — walking does not depend on source position.
-      (let [body-a '(let [y (* x x)] y)
-            body-b (clojure.walk/postwalk
-                    (fn [f] (if (symbol? f) (with-meta f {:line 99 :column 7}) f))
-                    '(let [y (* x x)] y))]
-        (is (= (hasch/uuid body-a) (hasch/uuid body-b))
-            "hasch default drops symbol metadata => position-independent memo key")))))


### PR DESCRIPTION
## R1 — walked-body / resolver reconciliation (compiler reconciliation Phase 2)

Targets the REPL-reliability / debug-tooling class (task #53) — the same silent-nil footgun that *misdiagnosed* #78 as load-order-sensitive. Scope was **narrowed on evidence** gathered mid-implementation (see "Evidence-based scope" below); this PR lands the high-value correctness core.

### S1 — unify the triplicated `resolve-deftm-var` (773defe)
Three call sites (pipeline compile-aot, ad/reverse value+grad, gpu kernel compile) each hand-rolled `dispatch var → backing impl var` resolution with divergent mangling and ambiguity policy. Unified onto **one** `raster.core/resolve-deftm-var`; each caller keeps its real policy as explicit opts (`:dtype` monomorphize, `:ambiguity :throw|:first`, `:deref-value?`, `:on-miss :nil|:self`).

**Latent-bug fix:** reverse+gpu used manual `_m_`-join mangling that diverged from definition-time `types/mangle` for operator-named (`+` → `_plus_`) and compound/flattenable-tag deftms — a silent resolution miss now closed.

### S2 — `ensure-walked-body!` resolves dispatch→impl first (09acf2f)
The walked body lives on the backing mangled impl var, but the dispatch var is the ergonomic handle. Handed a dispatch var, `ensure-walked-body!` silently returned `nil` — the debug-tooling footgun. Now it resolves-first: an already-resolved impl var (hot path) skips resolve via the `::deftm` guard; a non-deftm var or ambiguous multi-overload dispatch var falls through to `nil` unchanged (preserving the "not inlinable" contract of inline/op_descriptor/pe callers).

### Characterization test (`walked_body_canonical_test.clj`)
Pins: resolver-callers-agree (canonical == pipeline == gpu == reverse), `types/mangle` roundtrips to the same var, dispatch-var-yields-body (footgun fixed), non-deftm→nil contract.

### Evidence-based scope (why the memo + aggressive unification were dropped)
The agenda's motivation was "redefinition keeps stale cache" → content-addressed hashing. A REPL probe **disproved the premise on the JVM**: re-eval'ing `deftm` overwrites the definition-time walked-body cache, and derived caches (vjp-cache etc.) key by walked-body *value*, so they invalidate automatically. So:
- **Content-key memo → deferred.** `hasch` was added (S0) then **reverted** (S0-revise) — it dragged clojurescript + closure-compiler + jackson + msgpack into core `:deps` for zero production use.
- **Aggressive cache unification (kill `::deftm-walked-body-typed` dup, thin delegators, 33 direct-meta refs) → deferred.** Pure streamlining, real risk; production read-paths (`get-walked-body`) already fail-loud at their boundary.

### Validation
- **Full Valhalla suite: 1750 tests, 29144 assertions, 0 failures, 0 errors.**