### PR TITLE
Fix mem_merge zero-fill overload resolution (LeNet-f32 [J to [S cast)

### DIFF
--- a/src/raster/compiler/passes/scalar/mem_merge.clj
+++ b/src/raster/compiler/passes/scalar/mem_merge.clj
@@ -275,14 +275,32 @@
     (list 'double-array size-expr)))
 
 (defn- zero-fill-expr
-  "Generate a zero-fill expression for a shared buffer."
+  "Generate a TYPE-SAFE zero-fill expression for a shared buffer.
+
+  Two invariants, both required, or the JVM bytecode backend's Arrays/fill
+  overload resolution mis-selects `Arrays.fill(short[],short)` and emits a
+  `[J -> [S` (or `[I -> [S`) runtime cast — the exact hazard closure.clj already
+  guards against for hoisted buffers (see closure.clj comment ~219):
+    1. the array symbol carries its element :tag, so the backend resolves the
+       array parameter class (`long[]`/`int[]` — value type alone does NOT pin
+       these, since a literal-int fill value collides with short[]/byte[]/char[]);
+    2. the fill value is an UNEVALUATED cast form — `(list 'long 0)` / `(list 'int
+       0)`, not the EVALUATED `(long 0)`/`(int 0)` which collapse to a literal int
+       `0` that stack-types to :int and excludes `fill(long[],long)`."
   [shared-sym alloc-type]
-  (list 'java.util.Arrays/fill shared-sym
-        (case alloc-type
-          :double-array 0.0
-          :float-array  (list 'float 0.0)
-          :long-array   (long 0)
-          :int-array    (int 0))))
+  (let [arr-tag (case alloc-type
+                  :double-array 'doubles
+                  :float-array  'floats
+                  :long-array   'longs
+                  :int-array    'ints
+                  nil)
+        typed-sym (if arr-tag (vary-meta shared-sym assoc :tag arr-tag) shared-sym)]
+    (list 'java.util.Arrays/fill typed-sym
+          (case alloc-type
+            :double-array 0.0
+            :float-array  (list 'float 0.0)
+            :long-array   (list 'long 0)
+            :int-array    (list 'int 0)))))
 
 ;; ================================================================
 ;; Main pass

--- a/test/raster/compiler/passes/scalar/mem_merge_test.clj
+++ b/test/raster/compiler/passes/scalar/mem_merge_test.clj
@@ -240,3 +240,31 @@
       (is (pos? (:bytes-saved stats)) "Should merge non-overlapping buffers")
       (is (== 40.0 result-before) "Original: 1+2+3+4 + 10+20 = 40")
       (is (== 40.0 result-after) "Merged must also be 40 (zero-fill prevents stale data)"))))
+
+;; ================================================================
+;; Type-safe zero-fill (regression for the LeNet-f32 [J->[S cast)
+;; ================================================================
+
+(deftest zero-fill-type-safety
+  ;; A mem-merged long[]/int[] buffer must be zero-filled with (a) a :tag-typed
+  ;; array symbol and (b) an UNEVALUATED cast value form. Otherwise the JVM
+  ;; bytecode backend resolves Arrays/fill to fill(short[],short) — an untyped
+  ;; array + literal-int 0 both stack-type ambiguously toward short[] — emitting
+  ;; a `[J -> [S` runtime cast (the LeNet-f32 maxpool-argmax crash). closure.clj
+  ;; guards the identical hazard for hoisted buffers.
+  (testing "long-array: tagged sym + UNEVALUATED (long 0), never a literal int"
+    (let [[head sym val] (#'mem-merge/zero-fill-expr 'buf :long-array)]
+      (is (= 'java.util.Arrays/fill head))
+      (is (= 'longs (:tag (meta sym))) "array sym carries :tag longs")
+      (is (seq? val) "fill value is an unevaluated form, not a collapsed literal")
+      (is (= '(long 0) val))))
+  (testing "int-array: tagged sym + UNEVALUATED (int 0)"
+    (let [[_ sym val] (#'mem-merge/zero-fill-expr 'buf :int-array)]
+      (is (= 'ints (:tag (meta sym))))
+      (is (seq? val))
+      (is (= '(int 0) val))))
+  (testing "double/float remain unambiguous (value type alone pins the overload)"
+    (let [[_ _ dval] (#'mem-merge/zero-fill-expr 'buf :double-array)
+          [_ _ fval] (#'mem-merge/zero-fill-expr 'buf :float-array)]
+      (is (= 0.0 dval))
+      (is (= '(float 0.0) fval)))))


### PR DESCRIPTION
## Summary

Fixes a runtime `class [J cannot be cast to class [S` (long[] → short[]) that crashed **LeNet-f32 training**. Root-caused to the memory-merge shared-buffer zero-fill — **not** devirtualization and **not** SIMD lowering.

Independent of PR #50 (R1); branches off `main`.

## Root cause

`mem_merge/zero-fill-expr` emitted a type-**unsafe** `Arrays/fill` for shared `long[]`/`int[]` buffers:
1. the array symbol was **untyped**, and
2. the fill value `(long 0)` / `(int 0)` was **evaluated at form-construction**, collapsing to a literal int `0`.

In the JVM bytecode backend, `emit-java-static-call` resolves `Arrays/fill` by inferred stack-types: an untyped array matches any array param, and value `0` stack-types to `:int` — which **excludes** `fill(long[],long)` and matches `fill(short[],short)` first. Result: `CHECKCAST [S` + `Arrays.fill([SS)V` → `[J cannot be cast to [S` at runtime on the maxpool argmax `long[]` buffer.

- MLP is unaffected (no maxpool → no `long[]` shared buffer).
- LeNet-f64 has the **identical latent** bug on its own argmax buffers, currently masked by a *separate* SIMD tail-OOB that crashes first — so this fix also de-latents it (that variant still needs the SIMD tail-guard fix, tracked separately).

`closure.clj` (comment ~219) **already guards this exact hazard** for hoisted buffers; `mem_merge` had duplicated the fill logic without the guard.

## Fix

Make `zero-fill-expr` type-safe the same way closure.clj does:
- **tag** the array symbol with its element tag (`doubles`/`floats`/`longs`/`ints`) so the backend resolves the correct primitive-array overload, and
- emit an **unevaluated** cast value form (`(list 'long 0)` / `(list 'int 0)`), so the value stack-types to `:long`/`:int` instead of a collapsed literal.

## Validation

- LeNet-f32 train step now **compiles and runs** (was ClassCastException).
- New regression test asserts both invariants (typed sym + unevaluated cast form) for long/int arrays.
- **Full Valhalla suite: 1748 tests, 29138 assertions, 0 failures, 0 errors.**