### PR TITLE
Fix resolve-alength buffer-role aliasing (LeNet-f64 SIMD OOB; latent silent-miscompile class)

### DIFF
--- a/src/raster/compiler/passes/scalar/resolve_alength.clj
+++ b/src/raster/compiler/passes/scalar/resolve_alength.clj
@@ -153,7 +153,6 @@
           ;; Forward pass: build size map and rewrite simultaneously
           size-map (atom {})
           resolved-count (atom 0)
-          hoistable-alloc-syms (atom #{})
 
           new-pairs
           (mapv
@@ -169,39 +168,47 @@
                 ;; locally-allocated arrays must be resolved to the original
                 ;; size expression before mem-merge runs.
                (when-let [size (alloc-size init')]
-                 (swap! size-map assoc sym size)
-                 (when (:raster.buffer/hoistable (meta sym))
-                   (swap! hoistable-alloc-syms conj sym)))
+                 (swap! size-map assoc sym size))
 
                 ;; Track aliases: sym = known-size-sym (direct alias).
-                ;; Check size-map (not just hoistable-alloc-syms) to handle
-                ;; transitive alias chains like d_out = dx__5 = dx (alloc).
+                ;; Check size-map to handle transitive alias chains like
+                ;; d_out = dx__5 = dx (alloc).
                (when (and (symbol? init')
                           (contains? @size-map init'))
                  (when-let [size (get @size-map init')]
                    (swap! size-map assoc sym size)))
 
-                ;; Track call-through aliases: sym = (f ... buf ...) where
-                ;; buf is a hoistable allocation. The into-variant writes into
-                ;; buf and returns it. Convention: the output buffer is the
-                ;; LAST argument. Only match actual hoistable-alloc-syms, not
-                ;; general size-map entries — opaque calls like conv2d/maxpool
-                ;; return differently-sized arrays than their inputs.
-                ;; Skip if sym already has a known size (from alloc-size above)
-                ;; to avoid overwriting correct allocation sizes — e.g.,
-                ;; (zeros-like ref 8) has its own size 8, even though ref may
-                ;; be a larger hoistable buffer that appears as an argument.
+                ;; Track call-through aliases: sym = (f ... out-buf ...) where an
+                ;; into-variant writes into and RETURNS one of its argument
+                ;; buffers, so (alength sym) must resolve to that buffer's logical
+                ;; size before mem-merge resizes it.
+                ;;
+                ;; Identify the output buffer AUTHORITATIVELY from the op-descriptor
+                ;; buffer-semantics (:in-place-arg) — never by guessing "the last
+                ;; hoistable argument". That heuristic mis-identified the DY *input*
+                ;; as the output for into-variants like conv2d-backward-db-into!
+                ;; [dy db ...] (whose output db is arg 1, and is often allocated
+                ;; out-of-scope so it is the only NON-tracked buffer). It then
+                ;; aliased (alength result) to the wrong, larger input buffer,
+                ;; overrunning every later reduce/scale loop bound — a runtime OOB
+                ;; when the mis-aliased buffer is larger, and a SILENT wrong-count
+                ;; miscompile when it is smaller or equal.
+                ;;
+                ;; SAFE FALLBACK: only pure into-variants (:allocates? false with a
+                ;; concrete :in-place-arg) alias, and only when that arg's size is
+                ;; already known. Otherwise DO NOT alias — leaving (alength result)
+                ;; intact returns the true runtime length, which is always correct
+                ;; (the aliased buffer, if any, is then not a mem-merge target).
                (when (and (not (contains? @size-map sym))
-                          (form/call-form? init')
-                          (not (descriptor/alloc-op? (form/effective-op init'))))
-                 (let [args (vec (form/effective-args init'))
-                       last-buf (last (filter (fn [a]
-                                                (and (symbol? a)
-                                                     (contains? @hoistable-alloc-syms a)))
-                                              args))]
-                   (when last-buf
-                     (when-let [size (get @size-map last-buf)]
-                       (swap! size-map assoc sym size)))))
+                          (form/call-form? init'))
+                 (when-let [[bs _] (descriptor/resolve-buffer-semantics
+                                    (form/effective-op init'))]
+                   (when (and (not (:allocates? bs)) (:in-place-arg bs))
+                     (let [args    (vec (form/effective-args init'))
+                           out-idx (:in-place-arg bs)
+                           out-arg (when (< out-idx (count args)) (nth args out-idx))]
+                       (when (and (symbol? out-arg) (contains? @size-map out-arg))
+                         (swap! size-map assoc sym (get @size-map out-arg)))))))
 
                 ;; Track loop/let return aliases: sym = (let* [...] (loop* [...]
                 ;; (if ... (recur ...) buf))). When the expanded par/map! loop

--- a/src/raster/dl/nn.clj
+++ b/src/raster/dl/nn.clj
@@ -1279,6 +1279,20 @@
                                        {:allocates? true
                                         :in-place-arg nil})
 
+;; Backward into-variants: write into and RETURN one argument buffer (no fresh
+;; alloc). :allocates? false so buffer_fuse leaves them untouched; :in-place-arg
+;; is the AUTHORITATIVE output-buffer index resolve-alength uses to size-alias
+;; (alength result) to the correct buffer (never guessed from arg position).
+;; conv2d-backward-db-into!    [dy db ...]           -> db     (arg 1)
+;; conv2d-backward-dcols-into! [W dy-cols d-cols ...] -> d-cols (arg 2)
+;; conv2d-backward-dW-into!    [dy-cols cols dW ...]  -> dW     (arg 2)
+(descriptor/register-buffer-semantics! 'raster.dl.nn/conv2d-backward-db-into!
+                                       {:allocates? false :in-place-arg 1})
+(descriptor/register-buffer-semantics! 'raster.dl.nn/conv2d-backward-dcols-into!
+                                       {:allocates? false :in-place-arg 2})
+(descriptor/register-buffer-semantics! 'raster.dl.nn/conv2d-backward-dW-into!
+                                       {:allocates? false :in-place-arg 2})
+
 ;; Dim rules for shape propagation through conv/pool layers
 ;; conv2d: output length = batch * c_out * h_out * w_out
 (descriptor/register-dim-rule! 'raster.dl.nn/conv2d

--- a/src/raster/nn.clj
+++ b/src/raster/nn.clj
@@ -308,6 +308,20 @@
 ;; dense-backward-db-into!: acopy!(dy→out) — overwrite
 (descriptor/register-buffer-write! 'raster.nn/dense-backward-db-into! :overwrite 1)
 
+;; Buffer-SEMANTICS for the dense into-variants (distinct facet from write-mode
+;; above): :in-place-arg is the authoritative output-buffer index resolve-alength
+;; uses to size-alias (alength result) to the correct returned buffer instead of
+;; guessing. :allocates? false so buffer_fuse leaves them untouched.
+;; dense-backward-dW-into! [dy-cols/... dW ...] -> dW  (arg 2)
+;; dense-backward-dx-into! [dy W dx]            -> dx  (arg 2)
+;; dense-backward-db-into! [dy out]            -> out (arg 1)
+(descriptor/register-buffer-semantics! 'raster.nn/dense-backward-dW-into!
+                                       {:allocates? false :in-place-arg 2})
+(descriptor/register-buffer-semantics! 'raster.nn/dense-backward-dx-into!
+                                       {:allocates? false :in-place-arg 2})
+(descriptor/register-buffer-semantics! 'raster.nn/dense-backward-db-into!
+                                       {:allocates? false :in-place-arg 1})
+
 ;; ================================================================
 ;; Reverse-mode AD rules (rrules)
 ;; ================================================================

--- a/test/raster/compiler/passes/scalar/resolve_alength_test.clj
+++ b/test/raster/compiler/passes/scalar/resolve_alength_test.clj
@@ -1,0 +1,73 @@
+(ns raster.compiler.passes.scalar.resolve-alength-test
+  "resolve-alength rewrites (alength buf) to a static size expression before
+  mem-merge resizes buffers. The call-through alias step must identify an
+  into-variant's OUTPUT buffer authoritatively from the op-descriptor
+  (:in-place-arg), never by guessing 'the last hoistable argument' — the latter
+  mis-aliased (alength result) to a DY *input*, overrunning later loop bounds
+  (a runtime OOB when the input is larger, a silent wrong-count when smaller)."
+  (:require [clojure.test :refer [deftest testing is]]
+            [raster.compiler.passes.scalar.resolve-alength :as ra]
+            ;; load the ops whose buffer-semantics :in-place-arg we rely on
+            [raster.dl.nn]
+            [raster.nn]))
+
+(defn- bindings-of [form] (second form))
+
+(defn- init-of
+  "Return the init expr bound to `sym` in the pass output form."
+  [form sym]
+  (->> (partition 2 (bindings-of form))
+       (some (fn [[s init]] (when (= s sym) init)))))
+
+(deftest into-variant-output-identified-by-in-place-arg
+  (testing "UNtracked output + tracked input: (alength result) is NOT aliased to the input"
+    ;; result = conv2d-backward-db-into! [dy=big(3456), db=out-buf(untracked)] -> db (arg 1).
+    ;; The real output out-buf is out-of-scope (untracked); the DY input `big` IS a
+    ;; tracked hoistable alloc. The OLD 'last hoistable arg' heuristic aliased
+    ;; (alength result) -> (alength big) = 3456, overrunning the length-6 db. The
+    ;; fix leaves (alength result) intact (true runtime length).
+    (let [dybuf (vary-meta 'big assoc :raster.buffer/hoistable true)
+          form  (list 'let*
+                      (vector dybuf   '(clojure.core/double-array 3456)
+                              'result '(raster.dl.nn/conv2d-backward-db-into! big out-buf 1 6 24 24)
+                              'reduced '(clojure.core/alength result))
+                      'reduced)
+          out   (:form (ra/resolve-alength-pass form))]
+      (is (= '(clojure.core/alength result) (init-of out 'reduced))
+          "(alength result) must NOT be rewritten to (alength big)/3456")))
+
+  (testing "TRACKED output buffer: (alength result) IS aliased to the output's size"
+    ;; here the output db buffer is a locally-tracked hoistable alloc of size 6;
+    ;; the pass should size-alias result -> 6 (so mem-merge resize stays correct).
+    (let [dybuf  (vary-meta 'big assoc :raster.buffer/hoistable true)
+          dbbuf  (vary-meta 'db  assoc :raster.buffer/hoistable true)
+          form   (list 'let*
+                       (vector dybuf   '(clojure.core/double-array 3456)
+                               dbbuf   '(clojure.core/double-array 6)
+                               'result '(raster.dl.nn/conv2d-backward-db-into! big db 1 6 24 24)
+                               'reduced '(clojure.core/alength result))
+                       'reduced)
+          out    (:form (ra/resolve-alength-pass form))]
+      (is (= 6 (init-of out 'reduced))
+          "(alength result) aliases to the OUTPUT db buffer's size (6), not the input"))))
+
+(deftest opaque-call-leaves-alength-intact
+  (testing "an unregistered call with tracked args does NOT alias (fail-safe)"
+    (let [buf  (vary-meta 'buf assoc :raster.buffer/hoistable true)
+          form (list 'let*
+                     (vector buf     '(clojure.core/double-array 100)
+                             'result '(some.unknown/helper buf 7)
+                             'reduced '(clojure.core/alength result))
+                     'reduced)
+          out  (:form (ra/resolve-alength-pass form))]
+      (is (= '(clojure.core/alength result) (init-of out 'reduced))
+          "no buffer-semantics => leave (alength result) intact"))))
+
+(deftest direct-alloc-alength-still-resolves
+  (testing "plain (alength local-alloc) still resolves to its static size (no regression)"
+    (let [form (list 'let*
+                     (vector 'a '(clojure.core/double-array 42)
+                             'n '(clojure.core/alength a))
+                     'n)
+          out  (:form (ra/resolve-alength-pass form))]
+      (is (= 42 (init-of out 'n))))))


### PR DESCRIPTION
## Summary

Fixes a runtime `Index 4 out of bounds for length 3` (in `DoubleVector.fromArray`) that crashed **LeNet-f64 training**, and — more importantly — closes a **latent silent-miscompile class** the crash was one visible instance of. Root-caused via a bench-free minimal reproduction.

Independent of PRs #50/#51; branches off `main`.

## Root cause

`resolve-alength` rewrites `(alength buf)` to a static size expression before `mem-merge` resizes buffers. Its *call-through alias* step identified an into-variant's **output** buffer by **guessing** "the last hoistable-tracked argument."

For into-variants like `conv2d-backward-db-into! [dy db …]`, the output `db` is arg 1 and is typically allocated out-of-scope (so it is *untracked*). The only tracked array arg is therefore the **DY input** — and the guess aliased `(alength result)` to that wrong, larger buffer. Every later reduce/scale-loop bound over the result then used the input's length:

- **Runtime OOB** when the input is larger: the conv1-bias (`len 6`) `clip-grad-norm!` SIMD reduce got bound `n = (alength dx) = 3456`, so `DoubleVector.fromArray(db, 4)` overran the length-6 array → `Index 4 out of bounds for length 3`. The SIMD tail guard was *correct*; it was fed a wrong `n`.
- **Silent wrong-count miscompile** (or OOB write) whenever the mis-aliased buffer is smaller-or-equal — no error, just a reduction/optimizer step over the wrong element count. Confirmed for both conv-bias clips (`len 6`, `len 16`).

## Fix (root, per CLAUDE.md "passes must not reverse-engineer semantics — carry it in the op-descriptor")

- `resolve-alength` now identifies the output buffer **authoritatively** from the op-descriptor buffer-semantics `:in-place-arg` (only pure into-variants: `:allocates? false` with a concrete `:in-place-arg`), aliasing the result size **only** to that arg, and only when its size is known. **Safe fallback:** otherwise it does not alias — leaving `(alength result)` intact returns the true runtime length, which is always correct. The old "last hoistable arg" guess (and its now-dead `hoistable-alloc-syms` set) is deleted.
- Registered buffer-semantics `:in-place-arg` for the five backward into-variants the AD templates emit: `conv2d-backward-{db,dcols,dW}-into!` and `dense-backward-{dW,dx,db}-into!`. `:allocates? false`, so `buffer_fuse` (which only acts on `:allocates? true`) leaves them untouched.

## Validation

- **Full Valhalla suite: 1751 tests, 29142 assertions, 0 failures, 0 errors.**
- Regression test (`resolve_alength_test.clj`): wrong-alias prevented; correct-alias to a *tracked* output preserved; unregistered opaque call leaves `(alength result)` intact; plain alloc-alength still resolves.
- End-to-end (with #51 also applied, since LeNet-f64's argmax `[S` was latent behind this OOB): **LeNet-f64 now compiles and trains** — loss 4.606 → 1.946 over 60 steps (decreasing). The full mnist bench trio (MLP-f64, LeNet-f32, LeNet-f64) is now correct.

## Note

The fail-safe makes the pass sound for the current op set. A future hardening could `fail-loud` when an unregistered into-variant-shaped call feeds a later `(alength)` — flagged as follow-up, not required here.