### PR TITLE
Bump TypedClojure to Clojars 1.4.0; drop now-upstreamed unchecked-* overrides

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,9 +1,7 @@
 {:paths ["src"]
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
         org.clojure/data.json {:mvn/version "2.5.1"}
-        org.typedclojure/typed.clj.checker {:git/url "https://github.com/typedclojure/typedclojure"
-                                            :git/sha "42ef524fb5482a2e2429f3732a6ad88d80529690"
-                                            :deps/root "typed/clj.checker"}
+        org.typedclojure/typed.clj.checker {:mvn/version "1.4.0"}
         org.replikativ/pattern {:mvn/version "1.0.449"}
         org.replikativ/beichte {:mvn/version "0.2.7"}}
  :aliases

--- a/src/raster/compiler/core/inference.clj
+++ b/src/raster/compiler/core/inference.clj
@@ -262,8 +262,6 @@
 
 (defn tc-analyze-deftm-body
   "Analyze a deftm body once with Typed Clojure.
-  Forces tc-extensions/ensure-core-ann-overrides! first (late registration of
-  the unchecked-* precise overloads — see tc_extensions.clj for why late).
 
   Returns a map with:
     :ret-tag           — inferred return type tag
@@ -278,7 +276,6 @@
   definition) *ns* must be bound to the source ns or every refer'd op fails to
   resolve — yielding a TCError return and discarding ALL inferred binding types."
   [fn-name params annotations body & [source-ns]]
-  @raster.compiler.core.tc-extensions/ensure-core-ann-overrides!
   (try
     ;; Skip TC analysis for fully-untyped methods (all Object/Any params).
     ;; These are polymorphic fallbacks where TC can't add value — every operation

--- a/src/raster/compiler/core/tc_extensions.clj
+++ b/src/raster/compiler/core/tc_extensions.clj
@@ -34,56 +34,11 @@
 (t/ann ^:no-check clojure.core/object-array [(t/U Long (t/Seqable t/Any)) :-> (Array Object)])
 (t/ann ^:no-check clojure.core/long-array [(t/U Long (t/Seqable Long)) :-> (Array long)])
 (t/ann ^:no-check clojure.core/float-array [(t/U Long (t/Seqable t/Num)) :-> (Array float)])
-;; Precise unchecked-* arithmetic overloads. Upstream TC annotates these as
-;; AnyInteger -> AnyInteger, which makes BARE `(dotimes [b 4] b)` fail to check:
-;; dotimes expands to (loop [b 0] ... (recur (unchecked-inc b))), upstream #257
-;; widens the loop init to Long, and AnyInteger </: Long at the recur — one
-;; spurious delayed error per dotimes, which (via the load-bearing all-or-
-;; nothing error gate) discards every binding tag in the deftm. These overrides
-;; replace the last load-bearing commit of the whilo/typedclojure fork, letting
-;; raster run on UPSTREAM TC main. Upstreaming the fix (one annotation change)
-;; is proposed to TC with the (dotimes [b 4] b) repro.
-;;
-;; REGISTRATION MUST BE LATE: TC's base type env initializes lazily at the
-;; first check and clobbers load-time user annotations for clojure.core vars
-;; (verified: load-time ann ineffective, post-init ann effective). So the
-;; overrides live in a delay forced by inference.clj before each analysis.
-(defonce ^{:doc "Force before TC analysis: registers the unchecked-* overloads
-  AFTER TC's base env exists so they take precedence. Idempotent."}
-  ensure-core-ann-overrides!
-  (delay
-    (eval
-     '(do
-        ;; Force TC's lazy base-env initialization FIRST (a trivial check), so
-        ;; the anns below land AFTER it and are not clobbered by it. Without
-        ;; this, forcing the delay before the first real check would register
-        ;; into a pre-init env and be lost — with no second chance (defonce).
-        ((requiring-resolve 'typed.clj.checker/check-form-info) 1)
-        (typed.clojure/ann ^:no-check clojure.core/unchecked-inc
-          (typed.clojure/IFn [Long :-> Long] [Double :-> Double]
-                             [typed.clojure/AnyInteger :-> typed.clojure/AnyInteger]
-                             [typed.clojure/Num :-> typed.clojure/Num]))
-        (typed.clojure/ann ^:no-check clojure.core/unchecked-dec
-          (typed.clojure/IFn [Long :-> Long] [Double :-> Double]
-                             [typed.clojure/AnyInteger :-> typed.clojure/AnyInteger]
-                             [typed.clojure/Num :-> typed.clojure/Num]))
-        (typed.clojure/ann ^:no-check clojure.core/unchecked-negate
-          (typed.clojure/IFn [Long :-> Long] [Double :-> Double]
-                             [typed.clojure/AnyInteger :-> typed.clojure/AnyInteger]
-                             [typed.clojure/Num :-> typed.clojure/Num]))
-        (typed.clojure/ann ^:no-check clojure.core/unchecked-add
-          (typed.clojure/IFn [Long Long :-> Long] [Double Double :-> Double]
-                             [typed.clojure/AnyInteger typed.clojure/AnyInteger :-> typed.clojure/AnyInteger]
-                             [typed.clojure/Num typed.clojure/Num :-> typed.clojure/Num]))
-        (typed.clojure/ann ^:no-check clojure.core/unchecked-subtract
-          (typed.clojure/IFn [Long Long :-> Long] [Double Double :-> Double]
-                             [typed.clojure/AnyInteger typed.clojure/AnyInteger :-> typed.clojure/AnyInteger]
-                             [typed.clojure/Num typed.clojure/Num :-> typed.clojure/Num]))
-        (typed.clojure/ann ^:no-check clojure.core/unchecked-multiply
-          (typed.clojure/IFn [Long Long :-> Long] [Double Double :-> Double]
-                             [typed.clojure/AnyInteger typed.clojure/AnyInteger :-> typed.clojure/AnyInteger]
-                             [typed.clojure/Num typed.clojure/Num :-> typed.clojure/Num]))
-        :registered))))
+;; NOTE: the precise unchecked-* overloads (Long/Double arms so BARE
+;; `(dotimes [b 4] b)` checks) that raster used to register here via a late-forced
+;; `ensure-core-ann-overrides!` delay now ship natively in Typed Clojure ≥1.4.0
+;; (upstream #265 "Add unchecked-* overloads", verbatim the same arms). The
+;; workaround is therefore removed; the base env carries them from init.
 
 (t/ann ^:no-check clojure.core/conj! (t/All [x] [(t/Transient x) x :-> (t/Transient x)]))
 (t/ann ^:no-check clojure.core/transient (t/All [x] [(t/Coll x) :-> (t/Transient x)]))


### PR DESCRIPTION
## Summary

Swaps raster's TypedClojure git-dep for the **Clojars release `1.4.0`** and deletes the now-obsolete `unchecked-*` annotation workaround it made redundant. **Unblocks publishing** raster (and the downstream `-rstr` packages) to Clojars — a git-dep can't be expressed in a Maven POM, which is exactly what the `-rstr` deps.edn comments flag as the release blocker.

## The bump

`org.typedclojure/typed.clj.checker`: `:git/sha 42ef524fb…` → `{:mvn/version "1.4.0"}`.

`1.4.0` (release commit `647ffc8e2`, 2026-06-30) is a **superset** of the sha raster pinned on upstream main — it adds only #265 on top of it (verified `git merge-base --is-ancestor`), and resolves from Clojars.

## Removes the now-upstreamed workaround

TC **#265 ("Add `unchecked-*` overloads", in 1.4.0)** adds `[Long→Long]` + `[Double→Double]` arms for `unchecked-inc/dec/negate/add/subtract/multiply` — **verbatim** the arms raster hand-registered via the late-forced `ensure-core-ann-overrides!` delay (the fix raster had itself proposed upstream). So this PR deletes:
- `tc_extensions.clj`: the `ensure-core-ann-overrides!` delay (~50 lines) → a short historical note.
- `inference.clj`: the `@…ensure-core-ann-overrides!` force in `tc-analyze-deftm-body` + its docstring line.

The base env now carries the overloads from init, so bare `(dotimes [b 4] b)` type-checks without the `AnyInteger </: Long` spurious delayed error that used to discard every binding tag in the deftm.

## Validation

**Full Valhalla suite: 1753 tests, 29153 assertions, 0 failures, 0 errors** with the workaround removed — devirtualization is intact (the tag-discard regression the workaround guarded against does not recur, which is the sensitive thing here).