### PR TITLE
Release prep: bump to 0.2.x + complete publishable POM

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -16,7 +16,7 @@
 (def org "replikativ")
 (def lib 'org.replikativ/raster)
 (def current-commit (b/git-process {:git-args "rev-parse HEAD"}))
-(def version (format "0.1.%s" (b/git-count-revs nil)))
+(def version (format "0.2.%s" (b/git-count-revs nil)))
 (def class-dir "target/classes")
 (def basis (b/create-basis {:project "deps.edn"}))
 (def jar-file (format "target/%s-%s.jar" (name lib) version))

--- a/template/pom.xml
+++ b/template/pom.xml
@@ -13,9 +13,16 @@
             <url>https://opensource.org/licenses/MIT</url>
         </license>
     </licenses>
+    <developers>
+        <developer>
+            <id>whilo</id>
+            <name>Christian Weilbach</name>
+            <email>christian@weilbach.name</email>
+        </developer>
+    </developers>
     <scm>
         <connection>scm:git:git@github.com:replikativ/raster.git</connection>
-        <developerConnection>scm:git:git@github.com/replikativ/raster.git</developerConnection>
+        <developerConnection>scm:git:git@github.com:replikativ/raster.git</developerConnection>
         <url>https://github.com/replikativ/raster</url>
     </scm>
 </project>


### PR DESCRIPTION
## Summary

Makes raster's first **Maven-resolvable** Clojars release. The prior `0.1.x` releases published a POM that couldn't express raster's git-dep on TypedClojure (fork / upstream-main), so consumers got a raster jar with **no TC dependency** — broken through Maven. With TC now on Clojars (1.4.0, merged), the generated POM declares `typed.clj.checker 1.4.0` as a real dependency.

## Changes
- **`build.clj`**: version `0.1.x` → `0.2.x` to mark the fix + all accumulated changes.
- **`template/pom.xml`**: add `<developers>` block; fix the `developerConnection` SCM URL (`git@github.com/` → `git@github.com:`). Matches the ansatz/superficie convention.

## Verified
Installed `0.2.257` locally — generated `pom.xml` correctly declares `org.typedclojure/typed.clj.checker` **1.4.0** as a dependency (the thing the old release lacked).

Unblocks the `-rstr` package publishes (they flip `io.github.replikativ/raster {:git…}` → `org.replikativ/raster {:mvn/version "0.2.x"}`).