### PR TITLE
Compositional substrate dedup: 8 new dl kernels, 2 Void-dispatch bug fixes, quant packers upstreamed

### DIFF
--- a/src/raster/compiler/backend/jvm/bytecode.clj
+++ b/src/raster/compiler/backend/jvm/bytecode.clj
@@ -242,10 +242,10 @@
   [form h locals]
   (cond
         ;; Cast expressions
-        (= (name h) "double") :double
-        (= (name h) "long")   :long
-        (= (name h) "int")    :int
-        (= (name h) "float")  :float
+    (= (name h) "double") :double
+    (= (name h) "long")   :long
+    (= (name h) "int")    :int
+    (= (name h) "float")  :float
         ;; Arithmetic: JVM numeric promotion — all-float → float, all-integer
         ;; → int/long (any long ⇒ long), anything unknown/mixed-float → double.
         ;; The old rule hard-defaulted every non-float case to :double, typing
@@ -253,101 +253,101 @@
         ;; bit-shift-right in the body) into double slots — the false-positive
         ;; class of the A2 stamp-vs-LUB census, where the STAMP (long) was
         ;; right and this guess was wrong.
-        (contains? #{"+" "-" "*" "/"} (name h))
-        (let [ts (mapv #(infer-arg-stack-type % locals) (rest form))]
-          (cond
-            (and (seq ts) (every? #(= :float %) ts)) :float
-            (and (seq ts) (every? #(contains? #{:int :long} %) ts))
-            (if (some #(= :long %) ts) :long :int)
-            :else :double))
+    (contains? #{"+" "-" "*" "/"} (name h))
+    (let [ts (mapv #(infer-arg-stack-type % locals) (rest form))]
+      (cond
+        (and (seq ts) (every? #(= :float %) ts)) :float
+        (and (seq ts) (every? #(contains? #{:int :long} %) ts))
+        (if (some #(= :long %) ts) :long :int)
+        :else :double))
         ;; Bitwise / shifts: integer-typed (any long operand ⇒ long). Without
         ;; this rule they inferred nil and poisoned enclosing arithmetic to the
         ;; :double guess (the quant int8 dot's (* (long ..) (bit-and ..))).
-        (contains? #{"bit-and" "bit-or" "bit-xor" "bit-not"
-                     "bit-shift-left" "bit-shift-right" "unsigned-bit-shift-right"}
-                   (name h))
-        (if (some #(= :long (infer-arg-stack-type % locals)) (rest form)) :long :int)
+    (contains? #{"bit-and" "bit-or" "bit-xor" "bit-not"
+                 "bit-shift-left" "bit-shift-right" "unsigned-bit-shift-right"}
+               (name h))
+    (if (some #(= :long (infer-arg-stack-type % locals)) (rest form)) :long :int)
         ;; Comparison ops produce primitive :bool (int 0/1) — see emit-comparison.
-        (contains? #{"<" "<=" ">" ">=" "==" "not="} (name h)) :bool
+    (contains? #{"<" "<=" ">" ">=" "==" "not="} (name h)) :bool
         ;; if → infer from branches (enables skip-box for nested ifs)
         ;; Only returns a primitive type when BOTH branches are known
         ;; to produce the same primitive. Conservative: returns nil when
         ;; either branch is unknown, forcing the caller to box.
-        (= (name h) "if")
-        (let [[_ _pred then else] form
-              t1 (infer-arg-stack-type then locals)
-              t2 (infer-arg-stack-type else locals)]
-          (when (and t1 t2 (= t1 t2) (primitive? t1)) t1))
+    (= (name h) "if")
+    (let [[_ _pred then else] form
+          t1 (infer-arg-stack-type then locals)
+          t2 (infer-arg-stack-type else locals)]
+      (when (and t1 t2 (= t1 t2) (primitive? t1)) t1))
         ;; do → type of last form
-        (= (name h) "do")
-        (when-let [last-form (last (rest form))]
-          (infer-arg-stack-type last-form locals))
+    (= (name h) "do")
+    (when-let [last-form (last (rest form))]
+      (infer-arg-stack-type last-form locals))
         ;; let/let* → type of last body form
-        (contains? #{"let" "let*"} (name h))
-        (when-let [last-form (last (nnext form))]
-          (infer-arg-stack-type last-form locals))
+    (contains? #{"let" "let*"} (name h))
+    (when-let [last-form (last (nnext form))]
+      (infer-arg-stack-type last-form locals))
         ;; loop/loop* → type of the non-recur branch (a nested reduction used
         ;; as a recur arg is common — without this rule it fell to nil and the
         ;; caller guessed :double, mistyping all-integer tile kernels)
-        (contains? #{"loop" "loop*"} (name h))
-        (let [locals' (reduce (fn [ls [sym init]]
-                                (if-let [t (infer-arg-stack-type init ls)]
-                                  (assoc ls sym {:type t})
-                                  ls))
-                              locals (partition 2 (second form)))
-              tail (last (nnext form))]
-          (when (and (seq? tail) (= 4 (count tail))
-                     (= "if" (name (first tail))))
-            (let [[_ _ then els] tail
-                  recur? (fn r? [f] (and (seq? f)
-                                         (or (= 'recur (first f))
-                                             (and (contains? '#{do let let*} (first f))
-                                                  (r? (last f))))))]
-              (cond
-                (recur? then) (infer-arg-stack-type els locals')
-                (recur? els)  (infer-arg-stack-type then locals')
-                :else nil))))
+    (contains? #{"loop" "loop*"} (name h))
+    (let [locals' (reduce (fn [ls [sym init]]
+                            (if-let [t (infer-arg-stack-type init ls)]
+                              (assoc ls sym {:type t})
+                              ls))
+                          locals (partition 2 (second form)))
+          tail (last (nnext form))]
+      (when (and (seq? tail) (= 4 (count tail))
+                 (= "if" (name (first tail))))
+        (let [[_ _ then els] tail
+              recur? (fn r? [f] (and (seq? f)
+                                     (or (= 'recur (first f))
+                                         (and (contains? '#{do let let*} (first f))
+                                              (r? (last f))))))]
+          (cond
+            (recur? then) (infer-arg-stack-type els locals')
+            (recur? els)  (infer-arg-stack-type then locals')
+            :else nil))))
         ;; inc/dec → preserves input type
-        (contains? #{"inc" "dec" "unchecked-inc" "unchecked-dec"} (name h))
-        (or (infer-arg-stack-type (second form) locals) :long)
+    (contains? #{"inc" "dec" "unchecked-inc" "unchecked-dec"} (name h))
+    (or (infer-arg-stack-type (second form) locals) :long)
         ;; min/max → preserves first arg type
-        (contains? #{"min" "max"} (name h))
-        (or (infer-arg-stack-type (second form) locals) :double)
+    (contains? #{"min" "max"} (name h))
+    (or (infer-arg-stack-type (second form) locals) :double)
         ;; Unchecked int ops
-        (contains? #{"unchecked-add-int" "unchecked-inc-int" "unchecked-dec-int"
-                     "unchecked-subtract-int" "unchecked-multiply-int"} (name h)) :int
+    (contains? #{"unchecked-add-int" "unchecked-inc-int" "unchecked-dec-int"
+                 "unchecked-subtract-int" "unchecked-multiply-int"} (name h)) :int
         ;; .invk: return type from walker metadata on the impl symbol.
         ;; Handles both pre-expand (.invk impl args) and post-expand (. impl invk args).
-        (or (= (str h) ".invk")
-            (and (= (str h) ".") (= 'invk (nth form 2 nil))))
-        (let [impl-sym (if (= (str h) ".") (second form) (second form))]
-          (when (symbol? impl-sym)
-            (let [ret (or (:raster.type/ret-tag (meta impl-sym))
-                          (try (when-let [v (resolve impl-sym)]
-                                 (:raster.core/return-tag (meta v)))
-                               (catch Exception _ nil)))]
-              (case ret
-                (double Double) :double
-                (long Long) :long
-                (float Float) :float
-                (int Integer) :int
-                nil))))
+    (or (= (str h) ".invk")
+        (and (= (str h) ".") (= 'invk (nth form 2 nil))))
+    (let [impl-sym (if (= (str h) ".") (second form) (second form))]
+      (when (symbol? impl-sym)
+        (let [ret (or (:raster.type/ret-tag (meta impl-sym))
+                      (try (when-let [v (resolve impl-sym)]
+                             (:raster.core/return-tag (meta v)))
+                           (catch Exception _ nil)))]
+          (case ret
+            (double Double) :double
+            (long Long) :long
+            (float Float) :float
+            (int Integer) :int
+            nil))))
         ;; Math static methods — infer from the first arg type
         ;; (Math/abs, Math/sqrt, Math/fma all preserve arg type)
-        (let [s (str h)] (and (.contains s "/") (.startsWith s "Math")))
-        (or (infer-arg-stack-type (second form) locals) :double)
+    (let [s (str h)] (and (.contains s "/") (.startsWith s "Math")))
+    (or (infer-arg-stack-type (second form) locals) :double)
         ;; deftm calls: infer return type from var metadata
-        (namespace h)
-        (try (when-let [v (ns-resolve *ns* h)]
-               (when (var? v)
-                 (when-let [rt (:raster.core/return-tag (meta v))]
-                   (case rt
-                     Double :double Long :long Float :float
-                     (double) :double (long) :long (float) :float (int) :int
-                     nil))))
-             (catch Exception _ nil))
+    (namespace h)
+    (try (when-let [v (ns-resolve *ns* h)]
+           (when (var? v)
+             (when-let [rt (:raster.core/return-tag (meta v))]
+               (case rt
+                 Double :double Long :long Float :float
+                 (double) :double (long) :long (float) :float (int) :int
+                 nil))))
+         (catch Exception _ nil))
         ;; Default: unknown
-        :else nil))
+    :else nil))
 
 (defn- resolve-static-call
   "Given a deftm walked body that is a single static method call,
@@ -3486,7 +3486,7 @@
                                                        (.getParameterTypes m)))
                                                non-bridge))
                                     {:class (.getName cls) :method meth-str :arg-index i
-                                     :arg arg}))))))) ]
+                                     :arg arg})))))))]
             (if method
             ;; Method call — invokeinterface/invokevirtual.
             ;; For IFn__ .invk on LOCAL vars (Fn-typed params like `f`),
@@ -4536,6 +4536,12 @@
     (byte Byte)      {:class-desc (ClassDesc/ofDescriptor "B") :stack-type :int}
     (short Short)    {:class-desc (ClassDesc/ofDescriptor "S") :stack-type :int}
     (char Character) {:class-desc (ClassDesc/ofDescriptor "C") :stack-type :int}
+    ;; Void deftms must compile to a V-returning method — the $TI wrapper's
+    ;; invk already handles crd "V" (aconst_null). Without this case 'void
+    ;; fell to the Class/forName default → Object descriptor while emit-body
+    ;; produced :void → bare RETURN in an Object method (VerifyError on the
+    ;; first direct JVM call of a monomorphic Void deftm).
+    (void Void) {:class-desc V-cd :stack-type :void}
     boolean  {:class-desc (ClassDesc/ofDescriptor "Z") :stack-type :bool}
     objects  {:class-desc objarr-cd :stack-type :ref}
     doubles  {:class-desc dblarr-cd :stack-type :ref}
@@ -4738,6 +4744,9 @@
                               ;; Return according to method signature type
                                                    (when-not (#{:void :diverge} ret-type)
                                                      (case return-stack-type
+                                                       ;; void method, value-producing body: discard + RETURN
+                                                       :void (do (if (two-slot? ret-type) (.pop2 code) (.pop code))
+                                                                 (.return_ code))
                                                        :double (do (when (not= ret-type :double)
                                                                      (emit-coerce code ret-type :double))
                                                                    (.dreturn code))
@@ -4768,7 +4777,15 @@
                                                                         (= ret-type :ref))
                                                                (.checkcast code ret-cd)))
                                                            (.areturn code))))
-                                                   (when (= ret-type :void) (.return_ code)))))))
+                                                   (when (= ret-type :void)
+                                                     (case return-stack-type
+                                                       :void (.return_ code)
+                                                       ;; void body but ref-returning method: null
+                                                       (:double :long :int :bool :float)
+                                                       (throw (ex-info "void body for primitive-returning method"
+                                                                       {:method method-name
+                                                                        :return-stack-type return-stack-type}))
+                                                       (do (.aconst_null code) (.areturn code)))))))))
                     ;; Emit typed deftm methods as same-class siblings
                           (doseq [{:keys [method-name method-type params tags param-infos
                                           return-info walked-body source-ns]} deftm-method-specs]

--- a/src/raster/compiler/core/dispatch.clj
+++ b/src/raster/compiler/core/dispatch.clj
@@ -323,11 +323,10 @@
                             4 [a0 a1 a2 a3] (vec args))
             qname (when dispatch-var
                     (let [m (meta dispatch-var)]
-                      (symbol (str (ns-name (:ns m))) (str (:name m)))))
-            parametric-result (when qname
-                                (try-parametric-dispatch qname full-args))]
-        (if (some? parametric-result)
-          parametric-result
+                      (symbol (str (ns-name (:ns m))) (str (:name m)))))]
+        (if-let [boxed (when qname
+                         (try-parametric-dispatch qname full-args))]
+          (::result boxed)
           (throw-no-method fn-name full-args dispatch-table)))
       (let [m (first ms)]
         (if (case n
@@ -379,10 +378,9 @@
               (let [full-args (case n 0 [] 1 [a0] 2 [a0 a1] 3 [a0 a1 a2]
                                     4 [a0 a1 a2 a3] (vec args))
                     qname (let [mv (meta dispatch-var)]
-                            (symbol (str (ns-name (:ns mv))) (str (:name mv))))
-                    parametric-result (try-parametric-dispatch qname full-args)]
-                (if (some? parametric-result)
-                  parametric-result
+                            (symbol (str (ns-name (:ns mv))) (str (:name mv))))]
+                (if-let [boxed (try-parametric-dispatch qname full-args)]
+                  (::result boxed)
                   (invoke-entry m a0 a1 a2 a3 args n)))
 
               :else
@@ -498,46 +496,50 @@
             (let [ms (get @table-atom 1)]
               (if ms
                 (dispatch-arity fn-name ms a0 nil nil nil nil 1 table-atom @dispatch-var-ref)
-                (or (when @dispatch-var-ref
-                      (try-parametric-dispatch
-                       (let [m (meta @dispatch-var-ref)]
-                         (symbol (str (ns-name (:ns m))) (str (:name m))))
-                       [a0]))
-                    (throw-no-method fn-name [a0] table-atom)))))
+                (if-let [boxed (when @dispatch-var-ref
+                                 (try-parametric-dispatch
+                                  (let [m (meta @dispatch-var-ref)]
+                                    (symbol (str (ns-name (:ns m))) (str (:name m))))
+                                  [a0]))]
+                  (::result boxed)
+                  (throw-no-method fn-name [a0] table-atom)))))
            ([a0 a1]
             (let [ms (get @table-atom 2)]
               (if ms
                 (dispatch-arity fn-name ms a0 a1 nil nil nil 2 table-atom @dispatch-var-ref)
-                (or (when @dispatch-var-ref
-                      (try-parametric-dispatch
-                       (let [m (meta @dispatch-var-ref)]
-                         (symbol (str (ns-name (:ns m))) (str (:name m))))
-                       [a0 a1]))
-                    (throw-no-method fn-name [a0 a1] table-atom)))))
+                (if-let [boxed (when @dispatch-var-ref
+                                 (try-parametric-dispatch
+                                  (let [m (meta @dispatch-var-ref)]
+                                    (symbol (str (ns-name (:ns m))) (str (:name m))))
+                                  [a0 a1]))]
+                  (::result boxed)
+                  (throw-no-method fn-name [a0 a1] table-atom)))))
            ([a0 a1 a2]
             (let [t @table-atom]
               (if-let [ms (get t 3)]
                 (dispatch-arity fn-name ms a0 a1 a2 nil nil 3 table-atom @dispatch-var-ref)
                 (if (and reducible? (get t 2))
                   (raster-dispatch (raster-dispatch a0 a1) a2)
-                  (or (when @dispatch-var-ref
-                        (try-parametric-dispatch
-                         (let [m (meta @dispatch-var-ref)]
-                           (symbol (str (ns-name (:ns m))) (str (:name m))))
-                         [a0 a1 a2]))
-                      (throw-no-method fn-name [a0 a1 a2] table-atom))))))
+                  (if-let [boxed (when @dispatch-var-ref
+                                   (try-parametric-dispatch
+                                    (let [m (meta @dispatch-var-ref)]
+                                      (symbol (str (ns-name (:ns m))) (str (:name m))))
+                                    [a0 a1 a2]))]
+                    (::result boxed)
+                    (throw-no-method fn-name [a0 a1 a2] table-atom))))))
            ([a0 a1 a2 a3]
             (let [t @table-atom]
               (if-let [ms (get t 4)]
                 (dispatch-arity fn-name ms a0 a1 a2 a3 [a0 a1 a2 a3] 4 table-atom @dispatch-var-ref)
                 (if (and reducible? (get t 2))
                   (raster-dispatch (raster-dispatch (raster-dispatch a0 a1) a2) a3)
-                  (or (when @dispatch-var-ref
-                        (try-parametric-dispatch
-                         (let [m (meta @dispatch-var-ref)]
-                           (symbol (str (ns-name (:ns m))) (str (:name m))))
-                         [a0 a1 a2 a3]))
-                      (throw-no-method fn-name [a0 a1 a2 a3] table-atom))))))
+                  (if-let [boxed (when @dispatch-var-ref
+                                   (try-parametric-dispatch
+                                    (let [m (meta @dispatch-var-ref)]
+                                      (symbol (str (ns-name (:ns m))) (str (:name m))))
+                                    [a0 a1 a2 a3]))]
+                    (::result boxed)
+                    (throw-no-method fn-name [a0 a1 a2 a3] table-atom))))))
            ([a0 a1 a2 a3 & more]
             (let [args (into [a0 a1 a2 a3] more)
                   n (count args)
@@ -546,12 +548,13 @@
                 (dispatch-arity fn-name ms a0 a1 a2 a3 args n table-atom @dispatch-var-ref)
                 (if (and reducible? (get t 2))
                   (reduce raster-dispatch args)
-                  (or (when @dispatch-var-ref
-                        (try-parametric-dispatch
-                         (let [m (meta @dispatch-var-ref)]
-                           (symbol (str (ns-name (:ns m))) (str (:name m))))
-                         args))
-                      (throw-no-method fn-name args table-atom)))))))]
+                  (if-let [boxed (when @dispatch-var-ref
+                                   (try-parametric-dispatch
+                                    (let [m (meta @dispatch-var-ref)]
+                                      (symbol (str (ns-name (:ns m))) (str (:name m))))
+                                    args))]
+                    (::result boxed)
+                    (throw-no-method fn-name args table-atom)))))))]
      dispatch)))
 
 ;; ================================================================
@@ -991,7 +994,12 @@
 (defn- try-parametric-with
   "Shared core of parametric dispatch/registration: unify the first matching
   template against `args` and hand off to `callback` (which either invokes or
-  just registers). Returns the callback's result or nil if no template matches."
+  just registers). Returns {::result r} (r = the callback's result) when a
+  template matched, or nil when no template matches. The box distinguishes a
+  matched method that legitimately returned nil — a Void deftm like
+  residual-add! — from no-match; an unboxed nil here made every (All [T]) Void
+  deftm throw no-matching-method on its FIRST eager dispatch for a fresh
+  element type (after already running its side effect)."
   [callback fn-name args]
   (let [;; Resolve namespace aliases: nn/linear → raster.dl.nn/linear
         resolved-name (if-let [v (resolve fn-name)]
@@ -1003,14 +1011,15 @@
               (when-let [bindings (unify-parametric
                                    (:annotations template) args
                                    (:type-vars template))]
-                (callback resolved-name template bindings args)))
+                {::result (callback resolved-name template bindings args)}))
             templates))))
 
 (defn try-parametric-dispatch
   "Try to dispatch via parametric specialization.
    If a parametric template matches, delegates to the specializer callback
    (provided by core.clj) to generate and register a concrete method,
-   then INVOKES it. Returns the result or nil if no match."
+   then INVOKES it. Returns {::result r} (r may be nil for Void methods)
+   when a template matched, nil if no match — unwrap with ::result."
   [fn-name args]
   (try-parametric-with @parametric-specializer fn-name args))
 
@@ -1021,4 +1030,5 @@
   degenerate trigger args. Returns a truthy registration result or nil if no
   template matches (throws if a template matches but compilation fails)."
   [fn-name args]
-  (try-parametric-with @parametric-register fn-name args))
+  (when-let [boxed (try-parametric-with @parametric-register fn-name args)]
+    (or (::result boxed) true)))

--- a/src/raster/dl/attention.clj
+++ b/src/raster/dl/attention.clj
@@ -1606,3 +1606,40 @@
                                                                                             (aget k (clojure.core/+ kb d)))))
                                                                            acc))]
                                                                (aset sc (clojure.core/+ (clojure.core/* row nrows) j) (* dot scale))))))
+
+;; Sliding-window scores (moonshine-style 'ergodic' encoder): query i attends j
+;; iff 0 <= i-j <= left-1 (past incl. self) or 0 < j-i <= right-1 (future).
+;; left >= 1 required; right = 0 and right = 1 both mean "no future" (the
+;; diagonal always attends — same as moonshine's j1 = i + max(0, right-1)).
+;; Degenerate windows recover the siblings exactly: [nrows, 1] == the causal
+;; kernel, [nrows, nrows] == the bidir kernel; per-block calls with
+;; left = right = block-size give block-diagonal attention. Out-of-window
+;; scores get the same -1.0e30 sentinel as the causal kernel, so
+;; attn-prefill-softmax!/attn-prefill-out! compose unchanged: exp(-1e30 - mx)
+;; underflows to exactly 0.0 and masked lanes contribute exact zeros.
+(deftm attn-prefill-scores-windowed! (All [T] [q :- (Array T) k :- (Array T) sc :- (Array T)
+                                               nrows :- Long n-q :- Long group :- Long
+                                               n-kv :- Long head-dim :- Long
+                                               scale :- Double left :- Long right :- Long] :- Void
+                                          (raster.par/map-void! idx (clojure.core/* nrows (clojure.core/* n-q nrows))
+                                                                (let [per-i (clojure.core/* n-q nrows)
+                                                                      i (quot idx per-i)
+                                                                      rest0 (rem idx per-i)
+                                                                      hq (quot rest0 nrows)
+                                                                      j (rem rest0 nrows)
+                                                                      row (clojure.core/+ (clojure.core/* i n-q) hq)]
+                                                                  (if (or (> (clojure.core/- i j) (dec left))
+                                                                          (and (< i j) (> (clojure.core/- j i) (dec right))))
+                                                                    (aset sc (clojure.core/+ (clojure.core/* row nrows) j) -1.0e30)
+                                                                    (let [hkv (quot hq group)
+                                                                          qb (clojure.core/+ (clojure.core/* i (clojure.core/* n-q head-dim))
+                                                                                             (clojure.core/* hq head-dim))
+                                                                          kb (clojure.core/+ (clojure.core/* j (clojure.core/* n-kv head-dim))
+                                                                                             (clojure.core/* hkv head-dim))
+                                                                          dot (loop [d 0 acc 0.0]
+                                                                                (if (< d head-dim)
+                                                                                  (recur (inc d)
+                                                                                         (+ acc (* (aget q (clojure.core/+ qb d))
+                                                                                                   (aget k (clojure.core/+ kb d)))))
+                                                                                  acc))]
+                                                                      (aset sc (clojure.core/+ (clojure.core/* row nrows) j) (* dot scale))))))))

--- a/src/raster/dl/attention.clj
+++ b/src/raster/dl/attention.clj
@@ -188,6 +188,33 @@
                                  (aset out (+ (+ base i) half) (+ (* x1 c) (* x0 s))))))))
                        out)))
 
+;; --- Partial INTERLEAVED RoPE at an absolute position (GPT-J convention) ---
+;; Rotates only the first rotary-dim dims of each head, pairing ADJACENT
+;; elements (2j, 2j+1) — the GPT-J/moonshine convention. NOT interchangeable
+;; with rope-pos above, which is NeoX HALF-SPLIT (i, i+half) over the full
+;; head_dim: different pairing AND partial coverage (THE moonshine port trap,
+;; validated against HF activations). x is ONE position [heads, head_dim]
+;; flattened; dims [rotary-dim, head_dim) pass through untouched. Frequencies
+;; via pow (theta^(-2j/rotary-dim)) to match reference implementations
+;; bit-exactly (exp/log recomposition differs in ulps). In place; returns x.
+(deftm rope-pos-partial! (All [T] [x :- (Array T) heads :- Long head-dim :- Long
+                                   rotary-dim :- Long theta :- Double pos :- Long]
+                              :- (Array T)
+                              (let [pairs (quot rotary-dim 2)
+                                    posd (double pos)]
+                                (dotimes [h heads]
+                                  (let [base (* h (int head-dim))]
+                                    (dotimes [j pairs]
+                                      (let [freq (n/pow theta (/ (* -2.0 (double j)) (double rotary-dim)))
+                                            ang (* posd freq)
+                                            c (m/cos ang) s (m/sin ang)
+                                            i0 (+ base (* 2 j))
+                                            i1 (inc i0)
+                                            x0 (aget x i0) x1 (aget x i1)]
+                                        (aset x i0 (- (* x0 c) (* x1 s)))
+                                        (aset x i1 (+ (* x1 c) (* x0 s)))))))
+                                x)))
+
 ;; --- Single-query attention over a KV cache (decode step) ---
 ;; q:[1, n_q, hd], k/v:[>=cache_len, n_kv, hd] (the cache; only first cache_len
 ;; positions are read). The single query attends ALL cache_len keys (all causal).
@@ -231,6 +258,58 @@
                                                                     (aget v (+ kvb d))))))
                                                    a))))))
                                    out)))
+
+;; --- Decode attention that also captures the attention-weight distribution ---
+;; Identical layout/scale semantics (and bit-identical output) to
+;; gqa-decode-attention above, plus ACCUMULATES the head-averaged softmax
+;; weights into wsink (length >= cache-len): wsink[j] += (1/n_q) * weight[hq,j].
+;; This is the cross-attention alignment signal for DTW word timestamps
+;; (whisper/moonshine style) — call with a zeroed wsink per decode step, or let
+;; it accumulate across layers for a layer+head average.
+(deftm gqa-decode-attention-weights! (All [T]
+                                          [q :- (Array T) k :- (Array T) v :- (Array T)
+                                           cache-len :- Long n-q :- Long n-kv :- Long
+                                           head-dim :- Long scale :- Double
+                                           wsink :- (Array T)] :- (Array T)
+                                          (let [out (alloc-like q (* n-q head-dim))
+                                                group (quot n-q n-kv)
+                                                havg (/ 1.0 (double n-q))
+                                                neg-inf (n/neg-inf-val (aget q 0))]
+                                            (dotimes [hq n-q]
+                                              (let [hkv (quot hq group)
+                                                    qb (* hq (int head-dim))
+                                                    sc (alloc-like q cache-len)
+                                                    _ (dotimes [j cache-len]
+                                                        (let [kb (+ (* j (* n-kv head-dim)) (* hkv (int head-dim)))
+                                                              dot (loop [d 0 acc 0.0]
+                                                                    (if (< d head-dim)
+                                                                      (recur (inc d)
+                                                                             (+ acc (* (aget q (+ qb d))
+                                                                                       (aget k (+ kb d)))))
+                                                                      acc))]
+                                                          (aset sc j (* dot scale))))
+                                                    mx (loop [j 0 mm neg-inf]
+                                                         (if (< j cache-len) (recur (inc j) (n/max mm (aget sc j))) mm))
+                                                    sum (loop [j 0 s 0.0]
+                                                          (if (< j cache-len)
+                                                            (let [e (m/exp (- (aget sc j) mx))]
+                                                              (aset sc j e) (recur (inc j) (+ s e)))
+                                                            s))
+                                                    inv (/ 1.0 sum)
+                                                    ob (* hq (int head-dim))]
+                                                (dotimes [j cache-len]
+                                                  (aset wsink j (+ (aget wsink j)
+                                                                   (* havg (* (aget sc j) inv)))))
+                                                (dotimes [d head-dim]
+                                                  (aset out (+ ob d)
+                                                        (loop [j 0 a 0.0]
+                                                          (if (< j cache-len)
+                                                            (let [kvb (+ (* j (* n-kv head-dim)) (* hkv (int head-dim)))]
+                                                              (recur (inc j)
+                                                                     (+ a (* (* (aget sc j) inv)
+                                                                             (aget v (+ kvb d))))))
+                                                            a))))))
+                                            out)))
 
 (deftm gqa-decode-attention-heads! (All [T]
                                         [q :- (Array T) k :- (Array T) v :- (Array T) out :- (Array T)

--- a/src/raster/dl/nn.clj
+++ b/src/raster/dl/nn.clj
@@ -560,6 +560,42 @@
 (deftm residual-add-backward (All [T] [dy :- (Array T) n :- Long] :- (Array T)
                                   (broadcast [dy] dy)))
 
+;; ================================================================
+;; Sentence-embedding pooling (mean pool + L2 normalize)
+;; ================================================================
+
+;; The sentence-transformers pooling tail shared by the BERT-family encoders
+;; (MiniLM/MPNet/BGE: mean pool + L2) and the decoder embedders
+;; (Qwen3-Embedding last-token pool + L2, EmbeddingGemma mean pool + Dense + L2).
+
+(deftm mean-pool
+  "Mean pooling over rows: x [rows, dim] row-major -> out [dim],
+  out_d = mean_r x[r,d]. Returns a fresh array."
+  (All [T] [x :- (Array T) rows :- Long dim :- Long] :- (Array T)
+       (let [out (alloc-like x dim)
+             inv-n (/ 1.0 (double rows))]
+         (dotimes [r rows]
+           (dotimes [d dim]
+             (aset out d (+ (aget out d)
+                            (aget x (+ (* r (int dim)) d))))))
+         (dotimes [d dim]
+           (aset out d (* (aget out d) inv-n)))
+         out)))
+
+(deftm l2-normalize!
+  "In-place L2 normalization: v <- v / max(||v||_2, 1e-12). Returns v.
+  The 1e-12 floor only guards the all-zero vector (any real embedding norm
+  is far above it, where the result is exactly v/||v||)."
+  (All [T] [v :- (Array T) n :- Long] :- (Array T)
+       (let [norm (n/sqrt (loop [i 0 acc 0.0]
+                            (if (< i n)
+                              (recur (inc i) (+ acc (* (aget v i) (aget v i))))
+                              acc)))
+             inv-norm (/ 1.0 (n/max norm 1e-12))]
+         (dotimes [i n]
+           (aset v i (* (aget v i) inv-norm)))
+         v)))
+
 ;; --- Group Norm ---
 ;; x:[batch, channels, spatial], gamma:[channels], beta:[channels]
 (deftm group-norm (All [T] [x :- (Array T) gamma :- (Array T)

--- a/src/raster/dl/nn.clj
+++ b/src/raster/dl/nn.clj
@@ -522,6 +522,37 @@
                        (rms-norm! x weight out rows features eps gain-offset)
                        out)))
 
+;; Single-ROW Stage-A rms-norm: the functional par/reduce + par/map form.
+;; rms-norm! parallelizes over ROWS (one work-item per row, serial feature
+;; reduce — the right shape for multi-row/prefill); this variant is for the
+;; rows=1 decode case, where rms-norm! degenerates to ONE work-item. Here the
+;; feature reduce itself is parallel: on the GPU-resident graph the reduce
+;; result is realized as a resident 1-elem buffer and its scalar chain (inv)
+;; is fused into the consuming map — ~4x better occupancy than the 1-work-item
+;; serial reduce (validated on the gemma-3 resident decode graph).
+;;
+;; Concrete-float ON PURPOSE (not (All [T])): this is a float GPU kernel, so
+;; the reduce accumulator and every FP scalar must be float. Threading double
+;; eps/gain-offset/literals through it would leave raster.numeric ops
+;; undevirtualized (float x double has no monomorphic overload) → on GPU that
+;; cannot lower to OpenCL C → garbage output. The Double params are cast to
+;; float at entry, keeping the whole dataflow float-typed.
+(deftm rms-norm-1row!
+  [x :- (Array float) weight :- (Array float) out :- (Array float)
+   features :- Long eps :- Double gain-offset :- Double] :- Void
+  (let [ss  (raster.par/reduce acc (float 0.0) i features
+                               (raster.numeric/+ acc (raster.numeric/* (raster.arrays/aget x i)
+                                                                       (raster.arrays/aget x i))))
+        inv (raster.numeric// (float 1.0)
+                              (raster.numeric/sqrt
+                               (raster.numeric/+ (raster.numeric// ss (float features))
+                                                 (float eps))))]
+    (raster.par/map-void! j features
+                          (raster.arrays/aset out j
+                                              (raster.numeric/* (raster.numeric/* (raster.arrays/aget x j) inv)
+                                                                (raster.numeric/+ (float gain-offset)
+                                                                                  (raster.arrays/aget weight j)))))))
+
 ;; --- Bias-free linear + gated MLP (modern decoder LMs) ---
 ;; Modern LLMs (Llama, Qwen, Gemma, Mistral) use bias-free projections.
 ;; linear-nb: y = x @ W^T, W:[out_f,in_f] (HF layout), no bias.

--- a/src/raster/dl/nn.clj
+++ b/src/raster/dl/nn.clj
@@ -449,6 +449,28 @@
                                                          (+ 1.0 (m/tanh (* 0.7978845608028654
                                                                            (+ v (* 0.044715 v v v)))))))))))
 
+;; !-variant erf-EXACT GELU: out = 0.5*x*(1 + erf(x/sqrt(2))), erf via the
+;; Abramowitz–Stegun 7.1.26 polynomial (|abs err| <= 1.5e-7 — below f32 output
+;; resolution). NOT interchangeable with `gelu`/`gelu!` (tanh approximation):
+;; HF checkpoints trained with exact GELU (moonshine encoder, Qwen3-ASR AuT
+;; stem/encoder/projector) disagree with tanh-GELU well above f32 noise — a
+;; documented port trap. In-place safe (x = out, same-index read/write).
+(deftm gelu-erf! (All [T] [x :- (Array T) out :- (Array T) n :- Long] :- Void
+                      (raster.par/map-void! i n
+                                            (let [v (aget x i)
+                                                  z (* v 0.7071067811865476)
+                                                  az (n/abs z)
+                                                  tt (/ 1.0 (+ 1.0 (* 0.3275911 az)))
+                                                  e (- 1.0 (* tt
+                                                              (+ 0.254829592
+                                                                 (* tt (+ -0.284496736
+                                                                          (* tt (+ 1.421413741
+                                                                                   (* tt (+ -1.453152027
+                                                                                            (* tt 1.061405429))))))))
+                                                              (m/exp (- (* az az)))))
+                                                  erf (if (< z 0.0) (- e) e)]
+                                              (aset out i (* 0.5 v (+ 1.0 erf)))))))
+
 ;; Broadcast row-bias add in place semantics via separate out (resident-graph
 ;; friendly): out[r,j] = x[r,j] + b[j]. Follows every biased linear in
 ;; encoder-family layers (AuT, BERT) — the quantized GEMM kernels are bias-free.

--- a/src/raster/dl/nn.clj
+++ b/src/raster/dl/nn.clj
@@ -760,10 +760,13 @@
 
 ;; im2col-1d: rearrange input patches into columns for GEMM
 ;; x:[batch, c_in, length] -> cols:[c_in*kernel, batch*l_out]
+;; Padding is split left/right so causal convs (pad-left = kernel-1,
+;; pad-right = 0 — the moonshine frontend) share this kernel with the
+;; symmetric case (pad-left = pad-right).
 (deftm im2col-1d (All [T] [x :- (Array T) batch :- Long c-in :- Long
                            length :- Long kernel :- Long stride :- Long
-                           pad :- Long] :- (Array T)
-                      (let [l-out (+ 1 (quot (+ length (* 2 pad) (- kernel)) stride))
+                           pad-left :- Long pad-right :- Long] :- (Array T)
+                      (let [l-out (+ 1 (quot (+ length pad-left pad-right (- kernel)) stride))
                             col-rows (* c-in kernel)
                             col-cols (* batch l-out)
                             cols (alloc-like x (* col-rows col-cols))]
@@ -771,7 +774,7 @@
                           (dotimes [c c-in]
                             (dotimes [kk kernel]
                               (dotimes [out-pos l-out]
-                                (let [in-pos (+ (- (* out-pos (int stride)) pad) kk)
+                                (let [in-pos (+ (- (* out-pos (int stride)) (int pad-left)) kk)
                                       row (+ (* c (int kernel)) kk)
                                       col (+ (* b (int l-out)) out-pos)]
                                   (when (and (>= in-pos 0) (< in-pos length))
@@ -782,19 +785,39 @@
                                                    in-pos)))))))))
                         cols)))
 
+;; im2col-1d-cl: channels-LAST variant for row-major sequence layouts.
+;; x:[length, c_in] -> patches:[l_out, c_in*kernel] (one row per output
+;; position, (c*kernel + k) within the row — matches a contiguous torch
+;; [c_out, c_in, kernel] weight reshaped to [c_out, c_in*kernel], so the
+;; conv is `linear patches W b`). Out-of-range taps stay zero.
+(deftm im2col-1d-cl (All [T] [x :- (Array T) length :- Long c-in :- Long
+                              kernel :- Long stride :- Long
+                              pad-left :- Long pad-right :- Long] :- (Array T)
+                         (let [l-out (+ 1 (quot (+ length pad-left pad-right (- kernel)) stride))
+                               row-w (* c-in kernel)
+                               patches (alloc-like x (* l-out row-w))]
+                           (dotimes [out-pos l-out]
+                             (dotimes [c c-in]
+                               (dotimes [kk kernel]
+                                 (let [in-pos (+ (- (* out-pos (int stride)) (int pad-left)) kk)]
+                                   (when (and (>= in-pos 0) (< in-pos length))
+                                     (aset patches (+ (* out-pos (int row-w)) (* c (int kernel)) kk)
+                                           (aget x (+ (* in-pos (int c-in)) c))))))))
+                           patches)))
+
 ;; col2im-1d: reverse of im2col (accumulate)
 ;; cols:[c_in*kernel, batch*l_out] -> dx:[batch, c_in, length]
 (deftm col2im-1d (All [T] [cols :- (Array T) batch :- Long c-in :- Long
                            length :- Long kernel :- Long stride :- Long
-                           pad :- Long] :- (Array T)
-                      (let [l-out (+ 1 (quot (+ length (* 2 pad) (- kernel)) stride))
+                           pad-left :- Long pad-right :- Long] :- (Array T)
+                      (let [l-out (+ 1 (quot (+ length pad-left pad-right (- kernel)) stride))
                             col-cols (* batch l-out)
                             dx (alloc-like cols (* batch c-in length))]
                         (dotimes [b batch]
                           (dotimes [c c-in]
                             (dotimes [kk kernel]
                               (dotimes [out-pos l-out]
-                                (let [in-pos (+ (- (* out-pos (int stride)) pad) kk)]
+                                (let [in-pos (+ (- (* out-pos (int stride)) (int pad-left)) kk)]
                                   (when (and (>= in-pos 0) (< in-pos length))
                                     (let [row (+ (* c (int kernel)) kk)
                                           col (+ (* b (int l-out)) out-pos)
@@ -812,10 +835,10 @@
 (deftm conv1d (All [T] [x :- (Array T) W :- (Array T) b :- (Array T)
                         batch :- Long c-in :- Long length :- Long
                         c-out :- Long kernel :- Long stride :- Long
-                        pad :- Long] :- (Array T)
-                   (let [l-out (+ 1 (quot (+ length (* 2 pad) (- kernel)) stride))
+                        pad-left :- Long pad-right :- Long] :- (Array T)
+                   (let [l-out (+ 1 (quot (+ length pad-left pad-right (- kernel)) stride))
         ;; im2col: x -> cols:[c_in*kernel, batch*l_out]
-                         cols (im2col-1d x batch c-in length kernel stride pad)
+                         cols (im2col-1d x batch c-in length kernel stride pad-left pad-right)
         ;; GEMM: W_reshaped:[c_out, c_in*kernel] @ cols -> y_cols:[c_out, batch*l_out]
                          ck (* c-in kernel)
                          bl (* batch l-out)
@@ -833,6 +856,19 @@
                                    (+ (aget y-cols src-idx)
                                       (aget b co)))))))
                      y)))
+
+;; Channels-last conv1d for row-major sequence layouts (single sequence,
+;; no batch dim): x:[length, c_in], W:[c_out, c_in*kernel] (contiguous
+;; torch [c_out, c_in, kernel]), b:[c_out] -> y:[l_out, c_out].
+;; im2col-1d-cl + `linear` — a causal stride-2 conv (moonshine frontend)
+;; is (conv1d-cl x W b length c-in c-out kernel 2 (dec kernel) 0).
+(deftm conv1d-cl (All [T] [x :- (Array T) W :- (Array T) b :- (Array T)
+                           length :- Long c-in :- Long c-out :- Long
+                           kernel :- Long stride :- Long
+                           pad-left :- Long pad-right :- Long] :- (Array T)
+                      (let [l-out (+ 1 (quot (+ length pad-left pad-right (- kernel)) stride))
+                            patches (im2col-1d-cl x length c-in kernel stride pad-left pad-right)]
+                        (linear patches W b l-out (* c-in kernel) c-out))))
 
 ;; conv1d rrule — pullback registered after backward deftm (below)
 
@@ -1935,9 +1971,9 @@
                                     W :- (Array T)
                                     batch :- Long c-in :- Long length :- Long
                                     c-out :- Long kernel :- Long stride :- Long
-                                    pad :- Long]
+                                    pad-left :- Long pad-right :- Long]
                                :- (Array T)
-                               (let [l-out (+ 1 (quot (+ length (* 2 pad) (- kernel)) stride))
+                               (let [l-out (+ 1 (quot (+ length pad-left pad-right (- kernel)) stride))
                                      ck (* c-in kernel)
                                      bl (* batch l-out)
                                      dy-cols (alloc-like dy (* c-out bl))]
@@ -1950,14 +1986,14 @@
                                          (aset dy-cols dst-idx (aget dy src-idx))))))
                                  (let [d-cols (alloc-like dy (* ck bl))
                                        _ (blas/dgemm-tn! W dy-cols d-cols ck c-out bl (n/oftype dy 1.0) (n/oftype dy 0.0))]
-                                   (col2im-1d d-cols batch c-in length kernel stride pad)))))
+                                   (col2im-1d d-cols batch c-in length kernel stride pad-left pad-right)))))
 
 (deftm conv1d-backward-dW (All [T] [dy :- (Array T) x :- (Array T)
                                     batch :- Long c-in :- Long length :- Long
                                     c-out :- Long kernel :- Long stride :- Long
-                                    pad :- Long]
+                                    pad-left :- Long pad-right :- Long]
                                :- (Array T)
-                               (let [l-out (+ 1 (quot (+ length (* 2 pad) (- kernel)) stride))
+                               (let [l-out (+ 1 (quot (+ length pad-left pad-right (- kernel)) stride))
                                      ck (* c-in kernel)
                                      bl (* batch l-out)
                                      dy-cols (alloc-like dy (* c-out bl))]
@@ -1968,7 +2004,7 @@
                                                         (* co (int l-out)) li)
                                              dst-idx (+ (* co (int bl)) (* bi (int l-out)) li)]
                                          (aset dy-cols dst-idx (aget dy src-idx))))))
-                                 (let [cols (im2col-1d x batch c-in length kernel stride pad)
+                                 (let [cols (im2col-1d x batch c-in length kernel stride pad-left pad-right)
                                        dW (alloc-like dy (* c-out ck))
                                        _ (blas/dgemm-nt! dy-cols cols dW c-out bl ck (n/oftype dy 1.0) (n/oftype dy 0.0))]
                                    dW))))
@@ -1976,9 +2012,9 @@
 (deftm conv1d-backward-db (All [T] [dy :- (Array T)
                                     batch :- Long c-out :- Long
                                     length :- Long kernel :- Long
-                                    stride :- Long pad :- Long]
+                                    stride :- Long pad-left :- Long pad-right :- Long]
                                :- (Array T)
-                               (let [l-out (+ 1 (quot (+ length (* 2 pad) (- kernel)) stride))
+                               (let [l-out (+ 1 (quot (+ length pad-left pad-right (- kernel)) stride))
                                      db (alloc-like dy c-out)]
                                  (dotimes [bi batch]
                                    (dotimes [co c-out]
@@ -2108,22 +2144,22 @@
 
 ;; conv1d template — direct calls to per-gradient deftms
 (tmpl/merge-into-template! 'raster.dl.nn/conv1d
-                           {:params '[x W b batch c-in length c-out kernel stride pad]
+                           {:params '[x W b batch c-in length c-out kernel stride pad-left pad-right]
                             :result nil :adjoint 'dy
-                            :grads-fn (fn [ctx [x W _b batch c-in length c-out kernel stride pad]
+                            :grads-fn (fn [ctx [x W _b batch c-in length c-out kernel stride pad-left pad-right]
                                            _result-sym adjoint-sym gensym-fn]
                                         (let [dx (gensym-fn "dx")
                                               dW (gensym-fn "dW")
                                               db (gensym-fn "db")]
                                           [(update ctx :bindings into
                                                    [dx (list 'raster.dl.nn/conv1d-backward-dx
-                                                             adjoint-sym x W batch c-in length c-out kernel stride pad)
+                                                             adjoint-sym x W batch c-in length c-out kernel stride pad-left pad-right)
                                                     dW (list 'raster.dl.nn/conv1d-backward-dW
-                                                             adjoint-sym x batch c-in length c-out kernel stride pad)
+                                                             adjoint-sym x batch c-in length c-out kernel stride pad-left pad-right)
                                                     db (list 'raster.dl.nn/conv1d-backward-db
-                                                             adjoint-sym batch c-out length kernel stride pad)])
-                                           ;; 10 params: dx dW db + 7 nil (batch c-in length c-out kernel stride pad)
-                                           [dx dW db nil nil nil nil nil nil nil]]))})
+                                                             adjoint-sym batch c-out length kernel stride pad-left pad-right)])
+                                           ;; 11 params: dx dW db + 8 nil (batch c-in length c-out kernel stride pad-left pad-right)
+                                           [dx dW db nil nil nil nil nil nil nil nil]]))})
 
 ;; ================================================================
 ;; Forward (JVP) rules — §13 A3 hand frules for the norm residue.

--- a/src/raster/quant/pack.clj
+++ b/src/raster/quant/pack.clj
@@ -1,0 +1,81 @@
+(ns raster.quant.pack
+  "Host-side weight packers for the quantized GEMV/GEMM kernel layouts.
+
+  These pack row-major f32 weight matrices into the buffer sets the
+  raster.quant.kernels-k device kernels read — the layouts are OWNED by those
+  kernels, so the packers live next to them on the substrate (downstream model
+  runners like pretrained-rstr call them at bind time):
+
+    - `quantize-one-q8`  → signed q8_0 int32-packed rows {:wp :ws} read by
+      qmatmul-i8-gemm! / i8gemv-dp4a!.
+    - `q4k-of`           → the Q4_K dp4a buffer set {:wp :da :db :aq :bq}
+      read by qmatmul-q4k-dp4a!, delegating to the validated CPU packer
+      (raster.compiler.backend.cpu.quant/quantize-weight-q4k), zero-padding
+      rows to in % 256 == 0 and reinterpreting the nibble bytes as int[].
+
+  Plain host-side load-time code (defn, not deftm): runs once per weight at
+  model-bind time, never inside a compiled program."
+  (:require [raster.compiler.backend.cpu.quant :as cq]))
+
+(defn- bytes->ints
+  "Reinterpret a little-endian byte[] as int[] (the dp4a kernels read packed
+  quants as int[])."
+  ^ints [^bytes b]
+  (let [n (quot (alength b) 4)
+        o (int-array n)
+        bb (.order (java.nio.ByteBuffer/wrap b) java.nio.ByteOrder/LITTLE_ENDIAN)]
+    (dotimes [i n] (aset o i (.getInt bb (* i 4))))
+    o))
+
+(defn nextpad
+  "Round `in` up to the next multiple of 256 (the Q4_K super-block size)."
+  ^long [^long in]
+  (long (* 256 (Math/ceil (/ (double in) 256.0)))))
+
+(defn- padw
+  "Zero-pad each row of a row-major [out,in] weight up to inp (Q4_K needs
+  in % 256 == 0)."
+  ^floats [^floats W ^long out ^long in ^long inp]
+  (if (= in inp)
+    W
+    (let [Wp (float-array (* out inp))]
+      (dotimes [o out] (System/arraycopy W (* o in) Wp (* o inp) in))
+      Wp)))
+
+(defn q4k-of
+  "Quantize a row-major [out,in] f32 weight to the Q4_K dp4a buffer set
+  {:wp int[] :da :db floats :aq :bq bytes :in <padded in> :out} — the layout
+  qmatmul-q4k-dp4a! reads. Rows are zero-padded to in % 256 == 0."
+  [^floats W ^long out ^long in]
+  (let [inp (nextpad in)
+        z (cq/quantize-weight-q4k (padw W out in inp) cq/q4-K)]
+    {:wp (bytes->ints (:wq z)) :da (:da z) :db (:db z) :aq (:aq z) :bq (:bq z)
+     :in inp :out out}))
+
+(defn quantize-one-q8
+  "Signed q8_0 quantize+pack ONE row-major [out,in] weight: per-32 block
+  d = max|w|/127, q in [-127,127], 4 bytes/int32 (little-endian lanes) →
+  {:wp int[out*in/4] :ws float[out*in/32] :in :out} — the layout
+  qmatmul-i8-gemm! reads. `in` must be %32. `nm` names the tensor in errors."
+  [^floats W in out nm]
+  (assert (zero? (mod (long in) 32)) (str nm " in=" in " not %32"))
+  (let [in (long in) out (long out) nb (quot in 32)
+        wp (int-array (* out (quot in 4)))
+        ws (float-array (* out nb))]
+    (dotimes [o out]
+      (dotimes [b nb]
+        (let [base (+ (* o in) (* b 32))
+              mx (loop [k 0 mm 0.0]
+                   (if (< k 32)
+                     (recur (inc k) (max mm (Math/abs (double (aget W (+ base k))))))
+                     mm))
+              d (/ mx 127.0) id (if (pos? d) (/ 1.0 d) 0.0)]
+          (aset ws (+ (* o nb) b) (float d))
+          (dotimes [w 8]
+            (let [e (+ base (* w 4))
+                  q (fn [i] (bit-and (long (Math/round (* (aget W (+ e i)) id))) 0xFF))]
+              (aset wp (+ (* o (quot in 4)) (* b 8) w)
+                    (unchecked-int (bit-or (q 0) (bit-shift-left (q 1) 8)
+                                           (bit-shift-left (q 2) 16)
+                                           (bit-shift-left (q 3) 24)))))))))
+    {:wp wp :ws ws :in in :out out}))

--- a/test/raster/dl/attention_test.clj
+++ b/test/raster/dl/attention_test.clj
@@ -137,3 +137,69 @@
           emb (attn/sinusoidal-embedding timesteps 2 8)]
       ;; First and second rows should differ
       (is (not (= (aget emb 0) (aget emb 8)))))))
+
+;; ================================================================
+;; Windowed prefill scores (moonshine-style sliding-window encoder)
+;; ================================================================
+
+(deftest attn-prefill-scores-windowed-test
+  (let [T 7 heads 2 hd 4
+        dim (* heads hd)
+        rng (java.util.Random. 42)
+        frand (fn [n] (let [a (float-array n)]
+                        (dotimes [i n] (aset a i (float (.nextGaussian rng)))) a))
+        q (frand (* T dim)) k (frand (* T dim)) v (frand (* T dim))
+        scale (/ 1.0 (Math/sqrt (double hd)))
+        scores (fn [f & extra]
+                 (let [sc (float-array (* T heads T))]
+                   (apply f q k sc T heads 1 heads hd scale extra) sc))
+        composed (fn [left right]
+                   (let [sc (scores attn/attn-prefill-scores-windowed! left right)
+                         out (float-array (* T dim))]
+                     (attn/attn-prefill-softmax! sc T heads)
+                     (attn/attn-prefill-out! sc v out T heads 1 heads hd)
+                     out))
+        ;; naive double-precision windowed reference: query i attends
+        ;; j in [i-(left-1), i+max(0, right-1)] inclusive
+        naive (fn [left right]
+                (let [out (double-array (* T dim))]
+                  (dotimes [i T]
+                    (let [j0 (max 0 (- i (dec (long left))))
+                          j1 (min (dec T) (+ i (max 0 (dec (long right)))))]
+                      (dotimes [h heads]
+                        (let [qb (+ (* i dim) (* h hd))
+                              es (double-array T)
+                              mx (reduce max -1.0e30
+                                         (for [j (range j0 (inc j1))]
+                                           (* scale (reduce + (for [d (range hd)]
+                                                                (* (aget q (+ qb d))
+                                                                   (aget k (+ (* (long j) dim) (* h hd) d))))))))
+                              sum (reduce + (for [j (range j0 (inc j1))]
+                                              (let [s (* scale (reduce + (for [d (range hd)]
+                                                                           (* (aget q (+ qb d))
+                                                                              (aget k (+ (* (long j) dim) (* h hd) d))))))
+                                                    e (Math/exp (- s mx))]
+                                                (aset es (long j) e) e)))]
+                          (dotimes [d hd]
+                            (aset out (+ (* i dim) (* h hd) d)
+                                  (double (/ (reduce + (for [j (range j0 (inc j1))]
+                                                         (* (aget es (long j))
+                                                            (aget v (+ (* (long j) dim) (* h hd) d)))))
+                                             sum))))))))
+                  out))]
+    (testing "left=T right=1 degenerates BIT-IDENTICALLY to the causal kernel"
+      (is (java.util.Arrays/equals ^floats (scores attn/attn-prefill-scores!)
+                                   ^floats (scores attn/attn-prefill-scores-windowed! T 1))))
+    (testing "left=T right=T degenerates BIT-IDENTICALLY to the bidir kernel"
+      (is (java.util.Arrays/equals ^floats (scores attn/attn-prefill-scores-bidir!)
+                                   ^floats (scores attn/attn-prefill-scores-windowed! T T))))
+    (testing "small [left right] windows match a naive double reference through softmax+out"
+      (doseq [[l r] [[3 2] [16 4] [2 1] [1 1] [4 3]]]
+        (let [got (composed l r)
+              ref* (naive l r)]
+          (dotimes [i (* T dim)]
+            (is (< (Math/abs (- (aget ref* i) (double (aget got i)))) 1e-5)
+                (str "window [" l " " r "] element " i))))))
+    (testing "right=0 attends the diagonal (same as right=1, moonshine's j1 = i + max(0, right-1))"
+      (is (java.util.Arrays/equals ^floats (scores attn/attn-prefill-scores-windowed! 3 0)
+                                   ^floats (scores attn/attn-prefill-scores-windowed! 3 1))))))

--- a/test/raster/dl/attention_test.clj
+++ b/test/raster/dl/attention_test.clj
@@ -203,3 +203,85 @@
     (testing "right=0 attends the diagonal (same as right=1, moonshine's j1 = i + max(0, right-1))"
       (is (java.util.Arrays/equals ^floats (scores attn/attn-prefill-scores-windowed! 3 0)
                                    ^floats (scores attn/attn-prefill-scores-windowed! 3 1))))))
+
+;; ================================================================
+;; Partial interleaved RoPE (GPT-J convention, moonshine decoder)
+;; ================================================================
+
+(defn- moonshine-rope-partial!
+  "Copied reference: moonshine's rope-partial! — GPT-J interleaved partial RoPE
+  in place, rotate first 32 of each 64-dim head, theta 10000."
+  [^floats x heads pos]
+  (let [pos (double pos)]
+    (dotimes [h (long heads)]
+      (let [base (* h 64)]
+        (dotimes [j 16]
+          (let [freq (Math/pow 10000.0 (- (/ (* 2.0 j) 32.0)))
+                ang (* pos freq)
+                c (Math/cos ang) s (Math/sin ang)
+                i0 (+ base (* 2 j)) i1 (inc i0)
+                x0 (aget x i0) x1 (aget x i1)]
+            (aset x i0 (float (- (* x0 c) (* x1 s))))
+            (aset x i1 (float (+ (* x1 c) (* x0 s)))))))))
+  x)
+
+(deftest rope-pos-partial-test
+  (let [heads 3 hd 64 rd 32
+        rng (java.util.Random. 7)
+        frand (fn [n] (let [a (float-array n)]
+                        (dotimes [i n] (aset a i (float (.nextGaussian rng)))) a))]
+    (testing "bit-exact vs the copied moonshine reference loop"
+      (doseq [pos [0 1 7 100 255]]
+        (let [x (frand (* heads hd))
+              ref* (moonshine-rope-partial! (aclone ^floats x) heads pos)
+              got (attn/rope-pos-partial! (aclone ^floats x) heads hd rd 10000.0 pos)]
+          (is (java.util.Arrays/equals ^floats ref* ^floats got)
+              (str "pos " pos)))))
+    (testing "dims beyond rotary-dim pass through untouched"
+      (let [x (frand (* heads hd))
+            got (attn/rope-pos-partial! (aclone ^floats x) heads hd rd 10000.0 42)]
+        (dotimes [h heads]
+          (doseq [d (range rd hd)]
+            (is (= (aget x (+ (* h hd) d)) (aget ^floats got (+ (* h hd) d))))))))
+    (testing "pos 0 is the identity"
+      (let [x (frand (* heads hd))
+            got (attn/rope-pos-partial! (aclone ^floats x) heads hd hd 10000.0 0)]
+        (is (java.util.Arrays/equals ^floats x ^floats got))))
+    (testing "rotary-dim = head-dim rotates every adjacent pair, norm-preserving"
+      (let [x (frand (* heads hd))
+            got ^floats (attn/rope-pos-partial! (aclone ^floats x) heads hd hd 10000.0 5)]
+        (is (not (java.util.Arrays/equals ^floats x got)))
+        (dotimes [p (quot (* heads hd) 2)]
+          (let [i0 (* 2 p) i1 (inc i0)
+                n-in (+ (* (double (aget x i0)) (aget x i0))
+                        (* (double (aget x i1)) (aget x i1)))
+                n-out (+ (* (double (aget got i0)) (aget got i0))
+                         (* (double (aget got i1)) (aget got i1)))]
+            (is (< (Math/abs (- n-in n-out)) 1e-4) (str "pair " p))))))))
+
+;; ================================================================
+;; Decode attention with weight capture (timestamp alignment signal)
+;; ================================================================
+
+(deftest gqa-decode-attention-weights-test
+  (let [n 5 hd 8
+        rng (java.util.Random. 11)
+        frand (fn [k] (let [a (float-array k)]
+                        (dotimes [i k] (aset a i (float (.nextGaussian rng)))) a))
+        scale (/ 1.0 (Math/sqrt (double hd)))]
+    (doseq [[n-q n-kv] [[4 4] [4 2]]]
+      (let [q (frand (* n-q hd))
+            kc (frand (* n n-kv hd))
+            vc (frand (* n n-kv hd))
+            wsink (float-array n)
+            base ^floats (attn/gqa-decode-attention q kc vc n n-q n-kv hd scale)
+            got ^floats (attn/gqa-decode-attention-weights! q kc vc n n-q n-kv hd scale wsink)]
+        (testing (str "output bit-identical to gqa-decode-attention (n-q " n-q " n-kv " n-kv ")")
+          (is (java.util.Arrays/equals base got)))
+        (testing "head-averaged weights sum to ~1 for the query"
+          (let [s (loop [j 0 s 0.0] (if (< j n) (recur (inc j) (+ s (aget wsink j))) s))]
+            (is (approx= s 1.0 1e-5))))
+        (testing "wsink ACCUMULATES across calls (per-layer averaging contract)"
+          (attn/gqa-decode-attention-weights! q kc vc n n-q n-kv hd scale wsink)
+          (let [s (loop [j 0 s 0.0] (if (< j n) (recur (inc j) (+ s (aget wsink j))) s))]
+            (is (approx= s 2.0 1e-5))))))))

--- a/test/raster/dl/nn_test.clj
+++ b/test/raster/dl/nn_test.clj
@@ -581,3 +581,27 @@
   (testing "xavier-init creates correct size"
     (let [w (nn/xavier-init 3 5)]
       (is (= 15 (alength w))))))
+
+;; ================================================================
+;; rms-norm-1row! (single-row Stage-A par/reduce form) tests
+;; ================================================================
+
+(deftest rms-norm-1row-test
+  (testing "matches rms-norm! at rows=1 (float, gemma-style gain-offset 1.0)"
+    (let [n 640
+          r (java.util.Random. 42)
+          x (float-array n) w (float-array n)
+          _ (dotimes [i n]
+              (aset x i (float (- (.nextDouble r) 0.5)))
+              (aset w i (float (* 0.1 (- (.nextDouble r) 0.5)))))
+          out-ref (float-array n)
+          out-1row (float-array n)]
+      (nn/rms-norm! x w out-ref 1 n 1e-6 1.0)
+      (nn/rms-norm-1row! x w out-1row n 1e-6 1.0)
+      (dotimes [i n]
+        ;; the 1row form accumulates in float (consistent-float GPU kernel);
+        ;; rms-norm! accumulates in double — compare within float tolerance.
+        (is (< (Math/abs (- (aget out-ref i) (aget out-1row i))) 1e-5)
+            (str "elem " i)))
+      (is (some #(> (Math/abs (aget out-1row (int %))) 0.1) (range n))
+          "non-degenerate output"))))

--- a/test/raster/dl/nn_test.clj
+++ b/test/raster/dl/nn_test.clj
@@ -188,6 +188,43 @@
                   x 1e-5)]
       (is (arr-approx= dx num-dx 1e-4)))))
 
+(deftest gelu-erf-test
+  ;; erf-exact GELU (A&S 7.1.26) — the HF-checkpoint activation (moonshine,
+  ;; Qwen3-ASR AuT). Reference: the same polynomial evaluated in double.
+  (let [erf-as (fn ^double [^double z]
+                 (let [x (Math/abs z)
+                       t (/ 1.0 (+ 1.0 (* 0.3275911 x)))
+                       y (- 1.0 (* t
+                                   (+ 0.254829592
+                                      (* t (+ -0.284496736
+                                              (* t (+ 1.421413741
+                                                      (* t (+ -1.453152027
+                                                              (* t 1.061405429))))))))
+                                   (Math/exp (- (* x x)))))]
+                   (if (neg? z) (- y) y)))
+        gold (fn ^double [^double v]
+               (* 0.5 v (+ 1.0 (erf-as (/ v (Math/sqrt 2.0))))))
+        vals [-4.0 -2.0 -1.0 -0.5 -0.1 0.0 0.1 0.5 1.0 2.0 4.0]]
+    (testing "double: matches the double A&S reference"
+      (let [x (double-array vals)
+            out (double-array (count vals))]
+        (nn/gelu-erf! x out (count vals))
+        (dotimes [i (count vals)]
+          (is (approx= (gold (nth vals i)) (aget out i) 1e-12)))))
+    (testing "float: matches the double reference within f32 resolution, in place"
+      (let [x (float-array (map float vals))]
+        (nn/gelu-erf! x x (count vals))
+        (dotimes [i (count vals)]
+          (is (approx= (gold (nth vals i)) (aget x i) 1e-6)))))
+    (testing "erf-exact vs tanh approximation differ measurably (the port trap)"
+      (let [x (double-array [-1.0 0.5 3.0])
+            erf-out (double-array 3)
+            _ (nn/gelu-erf! x erf-out 3)
+            tanh-out (nn/gelu x 3)
+            md (apply max (map #(Math/abs (- (aget erf-out %) (aget ^doubles tanh-out %))) (range 3)))]
+        (is (> md 1e-5) "tanh-GELU is NOT a substitute for erf-GELU")
+        (is (< md 1e-2) "but they are the same activation family")))))
+
 (deftest sigmoid-test
   (testing "sigmoid forward"
     (let [x (double-array [0 -100 100])

--- a/test/raster/dl/nn_test.clj
+++ b/test/raster/dl/nn_test.clj
@@ -361,7 +361,7 @@
       (let [x (double-array [1 2 3 4 5])
             W (double-array [1 1 1])
             b (double-array [0])
-            y (nn/conv1d x W b 1 1 5 1 3 1 0)]
+            y (nn/conv1d x W b 1 1 5 1 3 1 0 0)]
         (is (= 3 (alength y)))
         (is (approx= 6.0 (aget y 0)))
         (is (approx= 9.0 (aget y 1)))
@@ -375,22 +375,95 @@
             W (double-array [0.1 0.2 0.3])
             b (double-array [0.01])
             rrfn (tmpl/template-pullback 'raster.dl.nn/conv1d)
-            y (nn/conv1d x W b 1 1 5 1 3 1 0)
-            pb (rrfn y x W b 1 1 5 1 3 1 0)
+            y (nn/conv1d x W b 1 1 5 1 3 1 0 0)
+            pb (rrfn y x W b 1 1 5 1 3 1 0 0)
             dy (double-array (repeat (alength y) 1.0))
             [dx dW db _ _ _ _ _ _] (pb dy)
             num-dW (numerical-grad-array
-                    #(let [y (nn/conv1d x W b 1 1 5 1 3 1 0)]
+                    #(let [y (nn/conv1d x W b 1 1 5 1 3 1 0 0)]
                        (loop [i 0 s 0.0]
                          (if (< i (alength y)) (recur (inc i) (+ s (aget y i))) s)))
                     W 1e-5)
             num-dx (numerical-grad-array
-                    #(let [y (nn/conv1d x W b 1 1 5 1 3 1 0)]
+                    #(let [y (nn/conv1d x W b 1 1 5 1 3 1 0 0)]
                        (loop [i 0 s 0.0]
                          (if (< i (alength y)) (recur (inc i) (+ s (aget y i))) s)))
                     x 1e-5)]
         (is (arr-approx= dW num-dW 1e-3))
         (is (arr-approx= dx num-dx 1e-3))))))
+
+;; Naive direct conv1d reference: x:[length,c-in] channels-last (or [c-in,length]
+;; channel-first via cf?), W:[c-out, c-in, kernel] contiguous, split padding.
+(defn- naive-conv1d
+  "Returns [l-out, c-out] (channels-last) as a vector of doubles."
+  [x length c-in W b c-out kernel stride pad-left pad-right cl?]
+  (let [l-out (inc (quot (- (+ length pad-left pad-right) kernel) stride))]
+    (vec (for [t (range l-out), co (range c-out)]
+           (+ (nth b co)
+              (reduce + 0.0
+                      (for [c (range c-in), k (range kernel)
+                            :let [src (+ (- (* t stride) pad-left) k)]
+                            :when (and (>= src 0) (< src length))]
+                        (* (nth W (+ (* co c-in kernel) (* c kernel) k))
+                           (nth x (if cl? (+ (* src c-in) c) (+ (* c length) src)))))))))))
+
+(deftest conv1d-asymmetric-pad-test
+  (when-not (blas/available?) (println "  [SKIP] No BLAS library"))
+  (when (blas/available?)
+    (testing "causal conv1d (pad-left=k-1, pad-right=0, stride 2) vs naive reference"
+      (let [length 9 c-in 2 c-out 3 kernel 5 stride 2 pl (dec kernel) pr 0
+            xs (vec (for [i (range (* c-in length))] (/ (double (inc i)) 7.0)))
+            ws (vec (for [i (range (* c-out c-in kernel))] (Math/sin (double i))))
+            bs [0.1 -0.2 0.3]
+            ;; channel-first x:[1,c-in,length]
+            y (nn/conv1d (double-array xs) (double-array ws) (double-array bs)
+                         1 c-in length c-out kernel stride pl pr)
+            gold (naive-conv1d xs length c-in ws bs c-out kernel stride pl pr false)
+            l-out (inc (quot (- (+ length pl pr) kernel) stride))]
+        (is (= (* l-out c-out) (alength y)))
+        ;; nn/conv1d output is [1,c-out,l-out]; gold is [l-out,c-out]
+        (dotimes [t l-out]
+          (dotimes [co c-out]
+            (is (approx= (nth gold (+ (* t c-out) co))
+                         (aget y (+ (* co l-out) t)) 1e-9))))))
+    (testing "symmetric pad = old behavior sanity ([1,2,3,4,5]*[1,1,1] pad 1)"
+      (let [y (nn/conv1d (double-array [1 2 3 4 5]) (double-array [1 1 1])
+                         (double-array [0]) 1 1 5 1 3 1 1 1)]
+        (is (= [3.0 6.0 9.0 12.0 9.0] (vec y)))))))
+
+(deftest conv1d-cl-test
+  (when-not (blas/available?) (println "  [SKIP] No BLAS library"))
+  (when (blas/available?)
+    (testing "channels-last conv1d-cl vs naive reference (causal, stride 2)"
+      (let [length 11 c-in 3 c-out 2 kernel 5 stride 2 pl (dec kernel) pr 0
+            xs (vec (for [i (range (* length c-in))] (Math/cos (* 0.37 (double i)))))
+            ws (vec (for [i (range (* c-out c-in kernel))] (Math/sin (* 0.21 (double i)))))
+            bs [0.25 -0.5]
+            y (nn/conv1d-cl (double-array xs) (double-array ws) (double-array bs)
+                            length c-in c-out kernel stride pl pr)
+            gold (naive-conv1d xs length c-in ws bs c-out kernel stride pl pr true)
+            l-out (inc (quot (- (+ length pl pr) kernel) stride))]
+        (is (= (* l-out c-out) (alength y)))
+        (dotimes [i (* l-out c-out)]
+          (is (approx= (nth gold i) (aget y i) 1e-9)))))
+    (testing "channels-last agrees with channel-first conv1d (symmetric pad, stride 1)"
+      (let [length 7 c-in 2 c-out 2 kernel 3
+            xs (vec (for [i (range (* length c-in))] (/ (double (- i 5)) 3.0)))
+            ws (vec (for [i (range (* c-out c-in kernel))] (/ (double (inc i)) 11.0)))
+            bs [0.0 1.0]
+            ;; channels-last input
+            ycl (nn/conv1d-cl (double-array xs) (double-array ws) (double-array bs)
+                              length c-in c-out kernel 1 1 1)
+            ;; transpose x to [c-in,length] for channel-first
+            xcf (double-array (for [c (range c-in), t (range length)]
+                                (nth xs (+ (* t c-in) c))))
+            ycf (nn/conv1d xcf (double-array ws) (double-array bs)
+                           1 c-in length c-out kernel 1 1 1)
+            l-out length]
+        (dotimes [t l-out]
+          (dotimes [co c-out]
+            (is (approx= (aget ycf (+ (* co l-out) t))
+                         (aget ycl (+ (* t c-out) co)) 1e-9))))))))
 
 ;; ================================================================
 ;; MaxPool2d tests

--- a/test/raster/quant/pack_test.clj
+++ b/test/raster/quant/pack_test.clj
@@ -1,0 +1,69 @@
+(ns raster.quant.pack-test
+  "Host-side quant packers (raster.quant.pack) — layout faithfulness of the
+  packed buffers against the kernel read conventions and the CPU reference
+  packer. Model-free, CPU-only."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.quant.pack :as pack]
+            [raster.compiler.backend.cpu.quant :as cq]))
+
+(defn- gen ^floats [n seed]
+  (let [a (float-array n) r (java.util.Random. (long seed))]
+    (dotimes [i n] (aset a i (float (- (.nextDouble r) 0.5))))
+    a))
+
+(deftest nextpad-test
+  (is (= 256 (pack/nextpad 1)))
+  (is (= 256 (pack/nextpad 256)))
+  (is (= 512 (pack/nextpad 257)))
+  (is (= 768 (pack/nextpad 640))))
+
+(deftest quantize-one-q8-roundtrip
+  (testing "signed q8_0 pack: dequant(wp,ws) reconstructs W within per-block step/2"
+    (let [out 4 in 64 nb (quot in 32)
+          W (gen (* out in) 7)
+          {:keys [wp ws]} (pack/quantize-one-q8 W in out "t")]
+      (is (= (* out (quot in 4)) (alength ^ints wp)))
+      (is (= (* out nb) (alength ^floats ws)))
+      (dotimes [o out]
+        (dotimes [b nb]
+          (let [d (double (aget ^floats ws (+ (* o nb) b)))]
+            (dotimes [k 32]
+              (let [i (+ (* b 32) k)
+                    word (aget ^ints wp (+ (* o (quot in 4)) (* b 8) (quot k 4)))
+                    q (unchecked-byte (bit-and (bit-shift-right word (* 8 (rem k 4))) 0xFF))
+                    wv (double (aget W (+ (* o in) i)))]
+                ;; |round(w/d)*d - w| <= d/2 (+ eps); q must sit in [-127,127]
+                (is (<= -127 (long q) 127))
+                (is (< (Math/abs (- (* (long q) d) wv)) (+ (* 0.5 d) 1e-7))
+                    (str "row " o " elem " i)))))))))
+  (testing "in % 32 enforced"
+    (is (thrown? AssertionError (pack/quantize-one-q8 (float-array 30) 30 1 "bad")))))
+
+(deftest q4k-of-test
+  (testing "no-pad case matches the CPU reference packer byte-for-byte"
+    (let [out 2 in 256
+          W (gen (* out in) 11)
+          {:keys [wp da db aq bq] :as z} (pack/q4k-of W out in)
+          ref (cq/quantize-weight-q4k W cq/q4-K)]
+      (is (= in (:in z)))
+      (is (= out (:out z)))
+      (is (java.util.Arrays/equals ^floats da ^floats (:da ref)))
+      (is (java.util.Arrays/equals ^floats db ^floats (:db ref)))
+      (is (java.util.Arrays/equals ^bytes aq ^bytes (:aq ref)))
+      (is (java.util.Arrays/equals ^bytes bq ^bytes (:bq ref)))
+      ;; wp is the little-endian int reinterpretation of ref's wq bytes
+      (let [^bytes wq (:wq ref)
+            bb (.order (java.nio.ByteBuffer/wrap wq) java.nio.ByteOrder/LITTLE_ENDIAN)]
+        (is (= (quot (alength wq) 4) (alength ^ints wp)))
+        (dotimes [i (alength ^ints wp)]
+          (is (= (.getInt bb (* i 4)) (aget ^ints wp i)))))))
+  (testing "padding: in=640 pads rows to 768; padded packing == packing the padded W"
+    (let [out 3 in 640 inp 768
+          W (gen (* out in) 13)
+          Wp (float-array (* out inp))
+          _ (dotimes [o out] (System/arraycopy W (* o in) Wp (* o inp) in))
+          z (pack/q4k-of W out in)
+          ref (cq/quantize-weight-q4k Wp cq/q4-K)]
+      (is (= inp (:in z)))
+      (is (java.util.Arrays/equals ^floats (:da z) ^floats (:da ref)))
+      (is (java.util.Arrays/equals ^bytes (:aq z) ^bytes (:aq ref))))))


### PR DESCRIPTION
## What

The substrate half of the compositional-dedup phase (refactor map R1-R8): every kernel that downstream model code (pretrained-rstr, finetune-rstr) had hand-rolled in duplicate moves into raster.dl as an `(All [T])` deftm, and two latent Void-dispatch bugs the migration surfaced are fixed.

### New substrate kernels
- `nn/mean-pool` + `nn/l2-normalize!` — existed in triplicate downstream (R2)
- `nn/gelu-erf!` — erf-exact GELU (A&S 7.1.26); the tanh `nn/gelu` is not bit-compatible; both ASR ports carried identical private copies (R3)
- `attn/attn-prefill-scores-windowed!` — `[left,right]` j-bounds subsume causal / bidirectional / sliding-window / block attention in one kernel, reusing the existing prefill softmax/out unchanged (R4)
- `attn/rope-pos-partial!` — GPT-J interleaved partial RoPE (not interchangeable with the NeoX half-split `rope-pos`) (R5)
- `attn/gqa-decode-attention-weights!` — decode attention + head-averaged weight capture (DTW timestamp alignment) (R5)
- `nn/conv1d` family: pad-left/right split (causal conv) + channels-last `conv1d-cl` variants; `nn/rms-norm-1row!` (R6/R7)
- new ns `raster.quant.pack` — the int8/q4k packers move next to the qmatmul kernels that own their layouts (were in pretrained's decoder_gpu with cross-namespace reach-ins) (R7)

### Bug fixes (both surfaced by routing downstream code through Void `(All [T])` deftms)
- **dispatch**: `try-parametric-dispatch` used nil for no-match, but Void deftms legitimately return nil — first eager dispatch ran the side effect then threw "No matching method". Result now boxed.
- **bytecode**: `'void` fell to the Class/forName default → Object-descriptor method with bare RETURN → VerifyError on the first direct JVM call of a monomorphic Void deftm. Now V-descriptor + explicit void/value stack handling (ambiguous case throws).

## Validation
- Suite: **1774 tests / 31033 assertions / 0 failures / 0 errors** (Valhalla), up from 1764/29243 at branch base — every new kernel unit-tested vs naive references.
- Downstream anchor gates (pretrained-rstr, weights + Arc GPU): moonshine JFK transcript **char-identical** (batch AND streaming) through the windowed-attention, RoPE, KV, conv and CMVN rewires — the frontend rewrite gated on **byte-identical** float output vs pre-rewrite gold; qwen3-asr CPU+GPU, qwen3-embedding, EmbeddingGemma, gemma-3 GPU decode, BERT anchors all green.
- The qwen3-asr GPU quantization lazy-seq memory hog is fixed downstream (anchor passes at -Xmx6g, was OOM at 8g).

## Follow-ups noted (not in this PR)
- Walker literal narrowing devirtualizes deliberately-f64 scalar chains inside concrete-float kernels (1-ULP drift; downstream uses load-bearing `(double ...)` casts) — the inverse of the fixed f64-in-f32 class; belongs to the typing.clj consolidation batch.
- EmbeddingGemma T>512 symmetric-window GPU wiring (per-layer windowed-vs-bidir program generation; the kernel now exists).

Downstream counterpart commits (pretrained-rstr R1-R8, finetune-rstr) are held locally until this merges and a release is cut, then the pins bump.