### PR TITLE
QLoRA Phase 0: four mechanical GPU-training blockers

### DIFF
--- a/src/raster/compiler/backend/gpu/opencl_codegen.clj
+++ b/src/raster/compiler/backend/gpu/opencl_codegen.clj
@@ -412,6 +412,41 @@
          "}\n")))
 
 ;; ================================================================
+;; Scalar (non-XMX) GEMM kernel — small-N fallback
+;; ================================================================
+
+(defn emit-gemm-scalar-kernel
+  "Generate a plain scalar (non-XMX) f32 GEMM kernel for output-column dims too
+  small for the XMX 2D-block path: Intel 2D-block IO requires a >=16-byte pitch,
+  which at fp16 means N>=8 — N in {2,4,6} reads a garbage B tile. This kernel
+  reads the f32 resident buffers DIRECTLY (no f16 convert/transpose expansion),
+  one work-item per C element, grid-stride over m*n, scalar k-loop.
+
+    :nn  C[m,n] = A[m,k] * B[k,n]
+    :nt  C[m,n] = A[m,k] * B[n,k]^T   (B stored row-major [n,k])
+    :tn  C[m,n] = A[k,m]^T * B[k,n]   (A stored row-major [k,m])
+
+  kernel-name: string name. variant: :nn | :nt | :tn (default :nn).
+  Returns OpenCL C source string."
+  [kernel-name & {:keys [variant] :or {variant :nn}}]
+  (let [a-idx (case variant :tn "A[p * m + i]" "A[i * k + p]")
+        b-idx (case variant :nt "B[j * k + p]" "B[p * n + j]")]
+    (str "__kernel void " kernel-name
+         "(__global const float* restrict A,"
+         " __global const float* restrict B,"
+         " __global float* restrict C,"
+         " int m, int n, int k) {\n"
+         "    int total = m * n;\n"
+         "    for (int idx = get_global_id(0); idx < total; idx += get_global_size(0)) {\n"
+         "        int i = idx / n;\n"
+         "        int j = idx % n;\n"
+         "        float acc = 0.0f;\n"
+         "        for (int p = 0; p < k; ++p) acc += " a-idx " * " b-idx ";\n"
+         "        C[idx] = acc;\n"
+         "    }\n"
+         "}\n")))
+
+;; ================================================================
 ;; Axpy kernel (in-place weight update)
 ;; ================================================================
 

--- a/src/raster/compiler/passes/scalar/inline.clj
+++ b/src/raster/compiler/passes/scalar/inline.clj
@@ -205,14 +205,42 @@
             ;; → the index never advances → infinite hang. util/alpha-convert renames
             ;; only bound vars (params stay free for subst); fresh-like preserves the
             ;; name prefix + tags, so name-based heuristics and dtype tags survive.
-            hygienic-wb (mapv util/alpha-convert effective-wb)]
-        (if source-ns
+                hygienic-wb (mapv util/alpha-convert effective-wb)]
+            (if source-ns
               {:params params
                :tags (or qualified-tags tags)
                :return-tag return-tag
                :walked-body (mapv #(inf/qualify-body-symbols % source-ns param-set)
                                   hygienic-wb)}
               {:params params :tags tags :return-tag return-tag :walked-body hygienic-wb})))))))
+
+(defn- force-mangled-specialization!
+  "Fresh-JVM determinism: a walked body may reference a mangled specialization
+   (foo_m_floats_… / its -impl) that does not exist yet in THIS JVM — e.g. the
+   dtype monomorphizer rewrote call names to the float mangle before the float
+   specialization was ever forced. Parse the dispatch tags back out of the
+   mangled name, verify the parse by re-mangling (never act on a mis-parse),
+   and force the concrete specialization through the standard parametric entry
+   point (inf/try-parametric-specialize!). Returns the now-resolved mangled var,
+   or nil. Only simple tags parse unambiguously — compound (`_dot_`) and
+   parametric-class (`__`) tag names are skipped (try-parametric-specialize!
+   cannot fabricate trigger args for those anyway)."
+  [base-sym]
+  (let [nm (name base-sym)
+        idx (str/index-of nm "_m_")]
+    (when (and idx (namespace base-sym))
+      (let [tag-str (subs nm (+ (long idx) 3))]
+        (when-not (or (.contains ^String tag-str "__")
+                      (.contains ^String tag-str "_dot_")
+                      (str/blank? tag-str))
+          (let [parent-name (subs nm 0 (long idx))
+                tags (mapv symbol (str/split tag-str #"_"))
+                parent-sym (symbol (namespace base-sym) parent-name)]
+            ;; Round-trip check: mangling the parsed pieces must reproduce the name.
+            (when (and (= nm (name (types/mangle parent-name tags)))
+                       (try (resolve parent-sym) (catch Exception _ nil)))
+              (inf/try-parametric-specialize! parent-sym tags)
+              (try (resolve base-sym) (catch Exception _ nil)))))))))
 
 (defn- try-resolve-deftm
   "Try to resolve a symbol to a deftm var with an inlinable walked body.
@@ -228,7 +256,11 @@
            ;; Single source of truth for inline opacity (direct + `_m_` parent).
            dispatch-no-inline? (dispatch/no-inline? base-sym)]
        (when-not dispatch-no-inline?
-         (when-let [v (try (resolve base-sym) (catch Exception _ nil))]
+         (when-let [v (or (try (resolve base-sym) (catch Exception _ nil))
+                          ;; Cold-compile gate: the mangled specialization does not
+                          ;; exist yet in this JVM — force it deterministically so the
+                          ;; FIRST compile behaves like every later one.
+                          (force-mangled-specialization! base-sym))]
            (when-not (:no-inline (meta v))
              (let [parametric-sym (symbol (namespace base-sym) (name base-sym))
                    has-parametric? (contains? @dispatch/parametric-registry parametric-sym)]

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -395,12 +395,37 @@
   [form opts]
   (let [max-iters 5
         ;; Force simplify mode for the fixpoint — we always want normalize+rewalk
-        opts (assoc opts :simplify? true)]
+        opts (assoc opts :simplify? true)
+        ;; GPU determinism epilogue (cold-compile inline gate). An AD-emitted generic
+        ;; parametric call (e.g. linear-dx from linear-nb's grads-fn) can survive the
+        ;; whole fixpoint UNdevirtualized when the incremental type env can't type an
+        ;; intermediate arg yet. On a FRESH JVM the later resolve-generic-deftm-calls
+        ;; (buffer-fuse/late-cleanup) then devirtualizes it to `.invk foo_m_floats…-impl`
+        ;; — creating the float specialization as a SIDE EFFECT — but that is AFTER the
+        ;; last inline pass, so the .invk survives to resident extraction and the first
+        ;; compile-gpu-program fails while the second succeeds. Run the same resolver
+        ;; HERE at convergence and, if it devirtualized anything, expand once more so
+        ;; the first compile inlines exactly like every later one. GPU-gated: CPU
+        ;; backends call .invk directly, so late devirtualization is sufficient there
+        ;; (and the shared-suite behavior stays untouched).
+        finalize (fn [current]
+                   (if-not (and (device/gpu-target? (:target-device opts))
+                                (form/binding-form? current))
+                     current
+                     ;; The resolver needs binding :tag metadata — the AD-emitted
+                     ;; bindings from THIS fixpoint don't carry it yet (late-cleanup
+                     ;; re-tags for the same reason before ITS resolve call).
+                     (let [tagged (tag-binding-types current (:param-env opts))
+                           resolved (inline/resolve-generic-deftm-calls
+                                     tagged (:param-env opts))]
+                       (if (= resolved tagged)
+                         current
+                         (inline/expand-for-backends resolved 3 (:param-env opts))))))]
     (loop [current form
            iter 0
            total-stats {:fixpoint-iterations 0}]
       (if (>= iter max-iters)
-        {:form (ensure-let*-result current) :stats total-stats}
+        {:form (ensure-let*-result (finalize current)) :stats total-stats}
         (let [;; Step 1: Expand (inline deftm calls + value+grad AD inlining)
               expanded (binding [inline/*ad-transform-body-fn* ad-reverse/transform-body]
                          (inline/expand-for-backends current 3 (:param-env opts)))
@@ -420,7 +445,8 @@
                            (if (map? rw-result) (:form rw-result) rw-result))
                          expanded)]
           (if (= rewalked current)
-            {:form (ensure-let*-result current) :stats (assoc total-stats :fixpoint-iterations iter)}
+            {:form (ensure-let*-result (finalize current))
+             :stats (assoc total-stats :fixpoint-iterations iter)}
             (recur rewalked (inc iter)
                    (assoc total-stats :fixpoint-iterations (inc iter)))))))))
 

--- a/src/raster/core.clj
+++ b/src/raster/core.clj
@@ -1681,9 +1681,14 @@
                   (when cls
                     (.importClass ^clojure.lang.Namespace source-ns cls)
                     (swap! types/tag-class-registry assoc specialized-name cls)))))
-            ;; Create the mangled defn var (minimal — just a placeholder for metadata)
+            ;; Create the mangled defn var (minimal — just a placeholder for metadata).
+            ;; Variadic [& args]: the real params are carried in ::deftm-params metadata
+            ;; below, and the placeholder is replaced by a delegating variadic fn after
+            ;; do-bytecode-upgrade! anyway. A positional param vector here would hit
+            ;; Clojure's 20-positional-param limit for wide deftms (e.g. a 37-param
+            ;; transformer block): "Can't specify more than 20 params".
             (binding [*ns* source-ns]
-              (eval (list 'defn mangled-sym (vec params)
+              (eval (list 'defn mangled-sym '[& args]
                           (list 'throw (list 'UnsupportedOperationException.
                                              "bytecode-compiled — should not reach here")))))
             ;; Set metadata on the mangled var

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -916,7 +916,7 @@
                         (throw (ex-info (str "bind-program!: no resident buffer for step array " sym)
                                         {:sym sym :ctx ctx :have (keys buffers)}))))
            step->bounds
-           (fn [{:keys [kernel-name arrays n-fn scalar-specs convention accumulator] :as step}]
+           (fn [{:keys [kernel-name arrays n-fn scalar-specs convention accumulator output] :as step}]
              (case convention
                ;; GEMM (Option B): [convert A f32→f16][convert B f32→f16][fp16 XMX gemm → f32 C].
                ;; A/B are converted into per-GEMM f16 scratch (kept alive on the session); weights
@@ -925,36 +925,44 @@
                :gemm
                (let [m (long ((:m-fn step) args)) n (long ((:n-fn step) args)) k (long ((:k-fn step) args))
                      abuf (buf-of (:A step) :gemm-A) bbuf (buf-of (:B step) :gemm-B)
-                     cbuf (buf-of (:C step) :gemm-C)
-                     a16 (mkbuf-fn (* m k) :half)
+                     cbuf (buf-of (:C step) :gemm-C)]
+                 (if (< n 8)
+                   ;; Small-N fallback: the XMX kernel's B-operand 2D-block VNNI read needs a
+                   ;; >=16-byte pitch (N*2 bytes at fp16) — N<8 violates it and yields garbage
+                   ;; (relerr ~1). Bind the plain scalar f32 GEMM instead: it reads the f32
+                   ;; residents directly, so NO convert/transpose expansion kernels at all.
+                   ;; Resolved lazily — Level-Zero-only for now (like the scatter binder).
+                   (let [scalar-gemm-fn (rt-resolve device-id "bind-registered-gemm-scalar!")]
+                     [{:bound (scalar-gemm-fn abuf bbuf cbuf m n k (:variant step))}])
+                   (let [a16 (mkbuf-fn (* m k) :half)
                      ;; each expansion kernel (convert/transpose/gemm) pre-bakes its FULL gc-seg —
                      ;; wrap as {:bound bnd} with NO :group-count so record-graph! keeps the grid.
-                     raw
-                     (case (:variant step)
+                         raw
+                         (case (:variant step)
                        ;; C = A[m,k] · B[k,n]
-                       :nn
-                       (let [b16 (mkbuf-fn (* k n) :half)]
-                         (swap! gemm-scratch conj a16 b16)
-                         [(conv-fn abuf a16 (* m k)) (conv-fn bbuf b16 (* k n))
-                          (gemm-fn a16 b16 cbuf m n k :float)])
+                           :nn
+                           (let [b16 (mkbuf-fn (* k n) :half)]
+                             (swap! gemm-scratch conj a16 b16)
+                             [(conv-fn abuf a16 (* m k)) (conv-fn bbuf b16 (* k n))
+                              (gemm-fn a16 b16 cbuf m n k :float)])
                        ;; C = A[m,k] · B[n,k]ᵀ — convert B then transpose [n,k]→[k,n], then :nn gemm.
                        ;; (HF linear weights [out,in] and attention Q·Kᵀ are :nt.)
-                       :nt
-                       (let [b16 (mkbuf-fn (* n k) :half) bt16 (mkbuf-fn (* k n) :half)]
-                         (swap! gemm-scratch conj a16 b16 bt16)
-                         [(conv-fn abuf a16 (* m k)) (conv-fn bbuf b16 (* n k))
-                          (trans-fn b16 bt16 n k :half) (gemm-fn a16 bt16 cbuf m n k :float)])
+                           :nt
+                           (let [b16 (mkbuf-fn (* n k) :half) bt16 (mkbuf-fn (* k n) :half)]
+                             (swap! gemm-scratch conj a16 b16 bt16)
+                             [(conv-fn abuf a16 (* m k)) (conv-fn bbuf b16 (* n k))
+                              (trans-fn b16 bt16 n k :half) (gemm-fn a16 bt16 cbuf m n k :float)])
                        ;; C[m,n] = Aᵀ·B — A stored [k,m], B [k,n]. Convert A then transpose
                        ;; [k,m]→[m,k], convert B ([k,n] already the :nn B layout), then :nn gemm.
                        ;; (linear-dW = dgemm-tn! : the weight-gradient backward matmul.)
-                       :tn
-                       (let [at16 (mkbuf-fn (* m k) :half) b16 (mkbuf-fn (* k n) :half)]
-                         (swap! gemm-scratch conj a16 at16 b16)
-                         [(conv-fn abuf a16 (* k m)) (trans-fn a16 at16 k m :half)
-                          (conv-fn bbuf b16 (* k n)) (gemm-fn at16 b16 cbuf m n k :float)])
-                       (throw (ex-info (str "GEMM variant not yet wired on resident path: " (:variant step)
-                                            " (only :nn / :nt / :tn)") {:variant (:variant step)})))]
-                 (mapv (fn [b] {:bound b}) raw))
+                           :tn
+                           (let [at16 (mkbuf-fn (* m k) :half) b16 (mkbuf-fn (* k n) :half)]
+                             (swap! gemm-scratch conj a16 at16 b16)
+                             [(conv-fn abuf a16 (* k m)) (trans-fn a16 at16 k m :half)
+                              (conv-fn bbuf b16 (* k n)) (gemm-fn at16 b16 cbuf m n k :float)])
+                           (throw (ex-info (str "GEMM variant not yet wired on resident path: " (:variant step)
+                                                " (only :nn / :nt / :tn)") {:variant (:variant step)})))]
+                     (mapv (fn [b] {:bound b}) raw))))
                ;; map / map-void bind through bind-registered-map-void-kernel (output is just
                ;; another resident buffer). Resolve buffers from the STEP's :arrays (full C-sig
                ;; order incl. output).
@@ -995,8 +1003,21 @@
                          zk (zerofill-fn (if (= dtype :double) :double :float))]
                      [(bind-fn zk [out-buf] [] (long out-size))
                       (scatter-fn kernel-name [out-buf src-buf idx-buf] n stride)]))
+               ;; reduce: SegRed sig (inputs…, output, scl…, _n_bound) — bind the registry's
+               ;; :array-params ++ [output] and launch a SINGLE workgroup (:group-count 1) so
+               ;; the kernel's grid-stride loop covers all n and writes output[0] into its
+               ;; resident 1-elem buffer (mirrors bind-step!'s :reduce; the #42 leftover).
+               :reduce
+               (let [ki (or (info-fn kernel-name)
+                            (throw (ex-info (str "Program kernel not registered: " kernel-name)
+                                            {:kernel kernel-name})))
+                     array-bufs (conj (mapv #(buf-of % kernel-name) (:array-params ki))
+                                      (buf-of output kernel-name))
+                     scalars (mapv (fn [{:keys [type value-fn]}] {:type type :value (value-fn args)})
+                                   scalar-specs)]
+                 [(bind-fn kernel-name array-bufs scalars (long (n-fn args)) {:group-count 1})])
                (throw (ex-info (str "bind-program! cannot bind a " convention " step — only "
-                                    ":map / :map-void / :gemm / :scatter are wired on the resident path")
+                                    ":map / :map-void / :reduce / :gemm / :scatter are wired on the resident path")
                                {:convention convention :kernel kernel-name}))))
            bounds (vec (mapcat step->bounds steps))
            graph (record-fn bounds)]

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -1820,6 +1820,52 @@
      (.set gc I32 8 (int 1))
      bnd)))
 
+(def ^:private gemm-scalar-cache
+  "Cache for compiled scalar (non-XMX) GEMM kernels, keyed by variant (:nn|:nt|:tn).
+   Each entry is {:module :kernel :kernel-name}. f32 in/out — the small-N fallback."
+  (atom {}))
+
+(defn- ensure-gemm-scalar-kernel!
+  "Lazily compile + cache the plain scalar f32 GEMM kernel for a layout variant
+   (:nn | :nt | :tn). Returns {:module :kernel :kernel-name}. Used when the output
+   column dim N is too small for the XMX 2D-block path (2D-block IO needs a
+   >=16-byte pitch → N>=8 at fp16; N<8 reads garbage)."
+  [variant]
+  (ensure-init!)
+  (or (get @gemm-scalar-cache variant)
+      (let [kname (str "gemm_scalar_" (name variant))
+            cl-src (do (require 'raster.compiler.backend.gpu.opencl-codegen)
+                       ((resolve 'raster.compiler.backend.gpu.opencl-codegen/emit-gemm-scalar-kernel)
+                        kname :variant variant))
+            device-hex (:device-id-hex @state)
+            spv (do (require 'raster.compiler.support.spirv-cache)
+                    ((resolve 'raster.compiler.support.spirv-cache/compile-opencl-to-spirv)
+                     cl-src :device device-hex))
+            module (load-module! spv)
+            kernel (create-kernel module kname)
+            entry {:module module :kernel kernel :kernel-name kname}]
+        (swap! gemm-scalar-cache assoc variant entry)
+        entry)))
+
+(defn bind-registered-gemm-scalar!
+  "Bind the plain scalar (non-XMX) f32 GEMM kernel over RESIDENT f32 DeviceBuffers for
+  recording into a command graph — the small-N fallback for bind-program!'s :gemm steps
+  (XMX's 2D-block B read violates the 16-byte minimum pitch when N<8 and produces
+  garbage). Reads/writes the f32 buffers directly: no f16 convert or transpose expansion.
+  variant :nn (C=A·B), :nt (C=A·Bᵀ, B stored [n,k]), :tn (C=Aᵀ·B, A stored [k,m]).
+  Returns a bound {:kernel :gc-seg …} map (1D grid over m·n). A fresh kernel handle per
+  binding (LZ kernel args are mutable handle state → shared handles clobber)."
+  [a b c m n k variant]
+  (let [{:keys [module kernel-name]} (ensure-gemm-scalar-kernel! variant)
+        kh (create-kernel-fresh module kernel-name)
+        m (long m) n (long n) k (long k)
+        total (* m n)
+        args [(:segment a) (:segment b) (:segment c)
+              {:type :int :value (int m)} {:type :int :value (int n)} {:type :int :value (int k)}]
+        bnd (bind-kernel! kh 256 args)]
+    (.set ^MemorySegment (:gc-seg bnd) I32 0 (int (Math/ceil (/ (double total) 256.0))))
+    bnd))
+
 (def ^:private convert-cache (atom nil))
 
 (defn- ensure-convert-kernel!

--- a/test/raster/compiler/parametric_dispatch_test.clj
+++ b/test/raster/compiler/parametric_dispatch_test.clj
@@ -9,7 +9,12 @@
   e.g. UMAP's cos-dist/init-leaves over float data. Fix derefs the Var so the
   field holds the compiled IFn__ instance."
   (:require [clojure.test :refer [deftest testing is]]
-            [raster.core :refer [deftm]]))
+            [raster.core :refer [deftm]]
+            ;; deftm bodies use raster.numeric/raster.arrays ops — load them so a
+            ;; single-ns test run can bytecode-compile the specializations.
+            [raster.numeric]
+            [raster.arrays]
+            [raster.par]))
 
 (deftm pdot
   "Parametric dot product — instantiated per element type."
@@ -39,3 +44,46 @@
       (let [ifaces (set (map #(.getName %) (.getInterfaces (class @#'pdot))))]
         (is (some #(re-find #"IFn__floats" %) ifaces)
             (str "pdot dispatch interfaces " ifaces " — missing IFn__floats* (float .invk path)"))))))
+
+;; 22 params — past Clojure's 20-positional-param limit. Regression for the
+;; parametric-specialize! placeholder defn: it eval'd a POSITIONAL param vector,
+;; so any (All [T]) deftm with >20 params (e.g. a 37-param transformer block)
+;; died at specialization with "Can't specify more than 20 params". The
+;; placeholder is variadic now (the real params live in ::deftm-params meta and
+;; the bytecode impl carries the typed signature).
+(deftm psum22
+  "Sum 20 arrays element-wise over [0,n) — a >20-param parametric kernel."
+  (All [T] [a1 :- (Array T) a2 :- (Array T) a3 :- (Array T) a4 :- (Array T)
+            a5 :- (Array T) a6 :- (Array T) a7 :- (Array T) a8 :- (Array T)
+            a9 :- (Array T) a10 :- (Array T) a11 :- (Array T) a12 :- (Array T)
+            a13 :- (Array T) a14 :- (Array T) a15 :- (Array T) a16 :- (Array T)
+            a17 :- (Array T) a18 :- (Array T) a19 :- (Array T) a20 :- (Array T)
+            n :- Long scale :- T] :- Double
+       (raster.par/reduce
+        acc 0.0 i n
+        (raster.numeric/+
+         acc
+         (raster.numeric/*
+          scale
+          (raster.numeric/+ (raster.arrays/aget a1 i) (raster.arrays/aget a2 i)
+                            (raster.arrays/aget a3 i) (raster.arrays/aget a4 i)
+                            (raster.arrays/aget a5 i) (raster.arrays/aget a6 i)
+                            (raster.arrays/aget a7 i) (raster.arrays/aget a8 i)
+                            (raster.arrays/aget a9 i) (raster.arrays/aget a10 i)
+                            (raster.arrays/aget a11 i) (raster.arrays/aget a12 i)
+                            (raster.arrays/aget a13 i) (raster.arrays/aget a14 i)
+                            (raster.arrays/aget a15 i) (raster.arrays/aget a16 i)
+                            (raster.arrays/aget a17 i) (raster.arrays/aget a18 i)
+                            (raster.arrays/aget a19 i) (raster.arrays/aget a20 i)))))))
+
+(deftest parametric-22-param-specializes-and-runs
+  (testing "a 22-param (All [T]) deftm specializes + runs at float (no 20-param wall)"
+    (let [n 3
+          fas (mapv (fn [k] (float-array (repeat n (float (inc k))))) (range 20))
+          ;; sum over 20 arrays of constant (k+1): per-element 1+2+...+20 = 210; n=3 → 630
+          expect (double (* n 210))]
+      (is (== expect (double (apply psum22 (into fas [n (float 1.0)]))))
+          "float specialization of a 22-param parametric deftm runs")
+      (let [das (mapv (fn [k] (double-array (repeat n (double (inc k))))) (range 20))]
+        (is (== expect (double (apply psum22 (into das [n 1.0]))))
+            "double specialization runs too")))))

--- a/test/raster/dl/gpu_ad_gemm_test.clj
+++ b/test/raster/dl/gpu_ad_gemm_test.clj
@@ -175,14 +175,79 @@
         (let [{:keys [out]} (run-resident #'attn/gqa-causal-mha [Q K V seq-len nq nkv hd])]
           (is (< (rel-err out cpu) 1e-5) (str "gqa-causal-mha GPU relerr " (rel-err out cpu))))))))
 
-(deftest gpu-ad-full-train-step-residency-boundary
-  ;; This test does NOT need a GPU — it pins the CURRENT residency boundary at the IR level.
-  ;; The full mse∘linear-nb float train step (value+grad + SGD) is AD-transformed and its 3
-  ;; matmuls DO lower to resident GEMM steps, but its loss reduction (mse-loss) and the
-  ;; daxpy-diff-into! elementwise gradient have no resident kernel in this composed path, so
-  ;; compile-gpu-program returns nil (→ compile-aot :target-device uses the staging fn). When
-  ;; the saved-activation / elementwise-loss lowering lands (see .internal/ad_gpu_residency.md),
-  ;; this returns a descriptor and the assertion below must flip to a full end-to-end run.
+(deftest gpu-gemm-small-n-scalar-fallback
+  ;; XMX GEMM's B-operand 2D-block VNNI read requires Intel 2D-block IO's 16-byte minimum
+  ;; pitch (N*2 bytes at fp16) — output-column dims N<8 violated it and produced garbage
+  ;; (relerr ~1). bind-program! now routes N<8 :gemm steps to a plain scalar f32 kernel
+  ;; (no f16 convert/transpose). n=8 stays on the XMX path (16-byte pitch = the minimum)
+  ;; as the boundary control.
+  (if-not @gpu-available?
+    (println "  [SKIP] gpu-gemm-small-n: no Level Zero GPU")
+    (let [tol 5e-3]
+      (doseq [n [2 4 6 8]]
+        (testing (str "forward linear-nb (:nt) at out-features n=" n)
+          (let [b 16 i 32 o n
+                x (rnd (* b i) (+ 100 n)) W (rnd (* o i) (+ 200 n))
+                cpu (nn/linear-nb x W b i o)
+                {:keys [descriptor out]} (run-resident #'nn/linear-nb [x W b i o])]
+            (is (= [:nt] (mapv :variant (:steps descriptor))))
+            (is (< (rel-err out cpu) tol)
+                (str ":nt n=" n " relerr " (rel-err out cpu)))))
+        (testing (str "backward linear-dx (:nn) at in-features n=" n)
+          (let [b 16 o 32 i n
+                dy (rnd (* b o) (+ 300 n)) W (rnd (* o i) (+ 400 n))
+                cpu (nn/linear-dx dy W b i o)
+                {:keys [descriptor out]} (run-resident #'nn/linear-dx [dy W b i o])]
+            (is (= [:nn] (mapv :variant (:steps descriptor))))
+            (is (< (rel-err out cpu) tol)
+                (str ":nn n=" n " relerr " (rel-err out cpu)))))))))
+
+(deftest gpu-reduce-step-program-binds-and-replays
+  ;; bind-program! (the resident whole-offload binder) wired only :map/:map-void/:gemm/
+  ;; :scatter step kinds; a program containing a par/reduce whose result stays resident
+  ;; (the #42 resident-reduce work: fuse-reduce-results gives it a device 1-elem out-buf)
+  ;; threw at bind time even though bind-step! already handled :reduce. This pins the
+  ;; wiring: sum(a) feeding an elementwise scale compiles to [:reduce :map] steps, binds,
+  ;; and replays with the correct output. (An ESCAPING tail reduce — a loss returned as
+  ;; the scalar result — still doesn't bind: that is the remaining #42 leftover, same as
+  ;; bind-step!.)
+  (if-not @gpu-available?
+    (println "  [SKIP] gpu-reduce-step: no Level Zero GPU")
+    (let [probe (eval '(raster.core/deftm gpu-reduce-consumer-probe
+                         [a :- (Array float) out :- (Array float) n :- Long] :- Void
+                         (let [s (raster.par/reduce
+                                  acc 0.0 i n
+                                  (raster.numeric/+ acc (raster.arrays/aget a i)))]
+                           (raster.par/map-void!
+                            j n
+                            (raster.arrays/aset out j
+                                                (raster.numeric/* (raster.arrays/aget a j) s))))))
+          n 64
+          a (rnd n 51)
+          out (float-array n)
+          s (double (reduce + 0.0 (map double (seq a))))
+          cpu (float-array (map #(float (* (double %) s)) (seq a)))
+          {:keys [descriptor] :as r} (run-resident probe [a out n])
+          gpu (:out r)]
+      (is (some #(= :reduce (:convention %)) (:steps descriptor))
+          "resident-consumed par/reduce compiles to a :reduce step")
+      (is (< (rel-err gpu cpu) 1e-4)
+          (str "reduce→map-void replay relerr " (rel-err gpu cpu))))))
+
+(deftest gpu-ad-full-train-step-fully-resident
+  ;; This test does NOT need a GPU — it pins residency at the IR level. The full
+  ;; mse∘linear-nb float train step (value+grad + SGD, returning the updated weights like
+  ;; finetune's lora-train-step) is AD-transformed and EVERY piece — the matmuls (resident
+  ;; GEMM steps), the fused loss-reduction chain, and the elementwise gradient/SGD kernels —
+  ;; lowers to a resident program descriptor. This used to assert the OPPOSITE
+  ;; (compile-gpu-program → nil) while the loss reduction had no resident kernel; the #42
+  ;; par/reduce residency work flipped it. A regression back to nil means some step fell
+  ;; off the resident path (staging-fn fallback = the old gap).
+  ;;
+  ;; NOTE the remaining #42 leftover: a train step whose RESULT is the loss scalar still
+  ;; does NOT extract (the primal mse reduce ESCAPES to the host, so it can't fuse —
+  ;; :scalar-let-reads-device-buffer). The resident train-step convention is therefore
+  ;; "return the updated weights, monitor loss on host" (same as lora-train-step).
   (require 'raster.core 'raster.dl.loss 'raster.dl.optim 'raster.ad.reverse 'raster.arrays)
   (let [loss (eval '(raster.core/deftm gpu-ad-probe-loss
                       [W :- (Array float) x :- (Array float) tgt :- (Array float)
@@ -191,14 +256,16 @@
                         (raster.dl.loss/mse-loss pred tgt (clojure.core/* batch out-f)))))
         train (eval '(raster.core/deftm gpu-ad-probe-train
                        [W :- (Array float) x :- (Array float) tgt :- (Array float)
-                        batch :- Long in-f :- Long out-f :- Long lr :- Double] :- Double
+                        batch :- Long in-f :- Long out-f :- Long lr :- Double] :- (Array float)
                        (let [vg ((raster.ad.reverse/value+grad #'gpu-ad-probe-loss)
                                  W x tgt batch in-f out-f)
-                             loss (clojure.core/nth vg 0)
                              dW (clojure.core/nth vg 1)]
                          (raster.dl.optim/sgd-step! W dW (raster.arrays/alength W) lr)
-                         loss)))]
-    (testing "full AD train step is not yet a fully-resident program (documents the gap)"
+                         W)))]
+    (testing "full AD train step compiles to a fully-resident program (pins residency)"
       ;; :on-non-resident :nil = probe the boundary without throwing (default is :throw now)
-      (is (nil? (pl/compile-gpu-program train :ze:0 :dtype :float :on-non-resident :nil))
-          "mse reduction + daxpy elementwise gradient have no resident kernel yet"))))
+      (let [p (pl/compile-gpu-program train :ze:0 :dtype :float :on-non-resident :nil)]
+        (is (some? p)
+            "mse∘linear train step must extract fully resident (matmuls + fused loss + SGD)")
+        (when p
+          (is (seq (:steps p)) "resident descriptor carries kernel steps"))))))


### PR DESCRIPTION
## What

Four verified mechanical fixes that unblock resident QLoRA training on the Intel GPU, ahead of the Phase 1 backward-kernel work. Each was reproduced on the Arc before fixing.

### Compiler (commit 1)
- **>20-param specialization wall**: `parametric-specialize!`'s placeholder `defn` was eval'd with the full positional param vector → Clojure's 20-param limit for wide deftms (gemma-block = 37 params: *"Can't specify more than 20 params"*). Now a variadic `[& args]` placeholder (real params live in `::deftm-params` meta; replaced by a delegating variadic fn immediately after). Blocked the block forward AND cascaded into *"No AD template"* on backward.
- **Cold-compile non-determinism**: on a fresh JVM the *first* `compile-gpu-program` of a value+grad train step failed (`:unlowered-array-op` on `.invk foo_m_floats-impl`) while the second succeeded. An AD-emitted generic parametric call survived `:fixpoint` undevirtualized; a *later* pass devirtualized it (creating the specialization as a side effect) but after the last inline pass. Fix: a **GPU-gated** `finalize` epilogue in `pass-fixpoint` runs the same `resolve-generic-deftm-calls` at convergence and re-expands once — so the first compile inlines identically to every later one. CPU path untouched.

### GPU runtime (commit 2)
- **XMX GEMM wrong for output dim N<8**: the B-operand 2D-block VNNI read used surface pitch `N*2` bytes, below Intel 2D-block-IO's 16-byte minimum (=16 exactly at N=8) → relerr ~0.9–1.5 at N∈{2,4,6}. New scalar f32 GEMM fallback, selected when `(< n 8)`. Bites LoRA rank r<8.
- **`bind-program!` `:reduce`**: the whole-offload binder wired only `:map/:map-void/:gemm/:scatter`; `:reduce` (already in `bind-step!`, the #42 leftover) now wired → on-device loss monitoring.

## Validation
- Full Valhalla suite **1777 tests / 31054 assertions / 0 failures / 0 errors** (+3 new tests).
- GEMM N∈{2,4,6,8} `:nt/:nn` vs CPU + a resident `:reduce` program: green on the Arc.
- Fresh-JVM first+second `compile-gpu-program` of a resident train step: both extract fully resident (deterministic).
- Downstream: finetune-rstr lora+gemma+broadcast-scale 8/57 green against this branch (its embed-scale AD workaround removed).

## Context
This is the prelude to the QLoRA-on-GPU completion phase. The measured gap map: the 11-step resident QLoRA program already trains with GPU-vs-CPU gradient parity ~1e-6; Phase 1 is four backward-kernel rewrites (rms-norm bwd, rope, sdpa-backward [riskiest], cross-entropy) then per-layer resident assembly at real gemma-270m dims.