### PR TITLE
Typed AD emission (Π): signature-derived typing + emit-time tags + fixpoint-edge instrumentation

### DIFF
--- a/src/raster/ad/reverse.clj
+++ b/src/raster/ad/reverse.clj
@@ -445,6 +445,15 @@
                   (let [without-last (vec (drop-last 2 bs))]
                     (vec (concat without-last [tape-sym (:forward-code dt-info) sym out-buf]))))}))
 
+(def ^:private mangled-arg-stamp-tags
+  "Dispatch tags from a devirtualized forward call's mangled name that are
+  precise enough to CARRY onto its arg symbols as :raster.type/tag for the
+  backward emission (ad-record :call): concrete primitive scalars/arrays
+  only. 'Object and value-type tags are deliberately excluded — the runtime
+  value may be more specific than the boxed dispatch slot, and stamping
+  them would lock the emitted backward helpers onto generic overloads."
+  '#{double float long int doubles floats longs ints})
+
 (defmethod ad-record :call [_ sym init-expr activity]
   (let [head (first init-expr)
         [op args invk?] (if (= '.invk head)
@@ -469,8 +478,24 @@
                                 tag-str (if (.endsWith ^String tag-str "-impl")
                                           (subs tag-str 0 (clojure.core/- (count tag-str) 5))
                                           tag-str)]
-                            (mapv symbol (.split ^String tag-str "_")))))]
-         {:type :call :sym sym :base-op base-op :args args :arg-tags arg-tags
+                            (mapv symbol (.split ^String tag-str "_")))))
+             ;; Π-emission input (plan 1c): CARRY the devirtualized forward
+             ;; call's dispatch tags onto its arg SYMBOLS, so the template
+             ;; grads-fn and the emission-time resolver read them as primal
+             ;; tags. Only stamps a symbol that has no tag yet, and only
+             ;; concrete primitive scalar/array tags — 'Object (and value
+             ;; types) are excluded so backward helpers aren't locked onto
+             ;; the generic overload. Carried, never guessed.
+             args (if (and arg-tags (= (count arg-tags) (count args)))
+                    (mapv (fn [a t]
+                            (if (and (symbol? a)
+                                     (nil? (:raster.type/tag (meta a)))
+                                     (contains? mangled-arg-stamp-tags t))
+                              (vary-meta a assoc :raster.type/tag t)
+                              a))
+                          args arg-tags)
+                    args)]
+         {:type :call :sym sym :base-op base-op :args args
           :active-args (set (filter #(and (symbol? %) (get activity % false)) args))}))}))
 
 ;; ================================================================

--- a/src/raster/ad/reverse.clj
+++ b/src/raster/ad/reverse.clj
@@ -552,25 +552,44 @@
 
 (defn- provably-non-nil-contrib?
   "Conservative static test: can `contrib` NEVER evaluate to nil (the dynamic 0̄)?
-  True only for a symbol bound (in `binding-map`, the rev-ctx bindings gathered so
-  far) to a plain op-call whose head is not a nil-producing form — i.e. a real
-  backward-kernel/allocation output (`linear-dx`, `aget-grad`, `residual-add`,
-  `float-array`, …). A literal nil, a `(nth grads i)` pullback slot, a nil-safe
-  `grad-acc`, an `(if …)`, or a symbol we can't vouch for → false. When in doubt,
-  false: the caller then keeps the nil-safe `grad-acc` fold. This is what makes the
-  resident `residual-add` reroute SOUND — `residual-add` has no nil check, so it may
-  only see cotangents that are provably present."
+  True only when `contrib` resolves — possibly through a chain of pure symbol
+  ALIASES in `binding-map` (the rev-ctx bindings gathered so far) — to a plain
+  op-call whose head is not a nil-producing form, i.e. a real backward-kernel /
+  allocation output (`linear-dx`, `mse-grad`, `rms-norm-backward-dx`,
+  `residual-add`, `float-array`, …).
+
+  Alias-following is essential: a residual cotangent is a bare symbol alias.
+  `sum-contribs` returns a single contribution AS ITSELF (an alias), and
+  `residual-add`'s identity-grad passthrough forwards its output adjoint SYMBOL to
+  both input slots — so a fan-out contribution like `d_z` binds to `d_pred` which
+  binds to `(mse-grad …)`. TWO symbol hops precede the kernel. We chase them,
+  validating EVERY hop.
+
+  Returns false for: a literal nil, a `(nth grads i)` pullback slot, a nil-safe
+  `grad-acc`, an `(if …)`, a symbol bound to any of those (directly or through
+  aliases), or a free symbol not in `binding-map` (a param / the `dy__rad` seed —
+  we can't vouch for it). When in doubt, false: the caller then keeps the nil-safe
+  `grad-acc` fold.
+
+  SOUND because every binding is a pure SSA alias (`s1 = s2` ⇒ equal runtime
+  values) and the binding-map is acyclic (reverse-pass gensyms, each bound once,
+  referencing only earlier bindings). A chain is non-nil iff its terminal op-call
+  is non-nil, and EVERY hop is checked — a chain passing through a nil-possible
+  head (grad-acc / nth / if) or a nil binding is still rejected. This is what keeps
+  the resident `residual-add` reroute nil-safe: `residual-add` has no nil check, so
+  it may only see cotangents that are provably present."
   [binding-map contrib]
-  (letfn [(non-nil-expr? [e]
-            (and (some? e) (seq? e) (symbol? (first e))
-                 (not (contains? nil-possible-heads (first e)))))]
-    (cond
-      (nil? contrib)    false
-      (symbol? contrib) (if-let [b (find binding-map contrib)]
-                          (non-nil-expr? (val b))
-                          false)
-      (seq? contrib)    (non-nil-expr? contrib)
-      :else             false)))
+  (letfn [(go [c seen]
+              (cond
+                (nil? c)     false
+                (symbol? c)  (cond
+                               (contains? seen c)        false   ;; cycle guard (SSA ⇒ unreachable)
+                               (contains? binding-map c) (recur (get binding-map c) (conj seen c))
+                               :else                     false)  ;; free var / dy__rad seed
+                (seq? c)     (and (symbol? (first c))
+                                  (not (contains? nil-possible-heads (first c))))
+                :else        false))]
+    (go contrib #{})))
 
 (defn- sum-contribs-into
   "Bind `target-sym` to the sum of `contribs` (default when empty) inside

--- a/src/raster/ad/tangent.clj
+++ b/src/raster/ad/tangent.clj
@@ -45,6 +45,20 @@
   [tag]
   (not= :none (:kind (tangent-kind tag))))
 
+(defn tangent-tag
+  "Π — the tangent-type projection on TAGS (.internal/ad_formal_framework.md
+  §5, item #1): maps a PRIMAL's :raster.type/tag to the tag of its
+  tangent/cotangent space. Identity on the differentiable tags
+  (double/float scalars, doubles/floats arrays — exactly the tags
+  `differentiable?` accepts), nil for everything else — ⊥/no-tangent
+  (integers, booleans, Object) AND unknown (nil in, nil out).
+
+  The single seam every AD emission site asks instead of copying the
+  primal tag ad hoc or defaulting a dtype: a nil result means the
+  emission stays UNTAGGED (never guess, never narrow)."
+  [primal-tag]
+  (when (differentiable? primal-tag) primal-tag))
+
 (defn zero-expr
   "IR expression for a typed zero cotangent of the tangent space of `tag`.
   Scalars: a typed zero literal. Arrays: a typed array constructor sized

--- a/src/raster/ad/templates.clj
+++ b/src/raster/ad/templates.clj
@@ -22,6 +22,7 @@
                            ;;   -> [updated-ctx [grad-sym ...]]) for flat bindings}"
   (:require [raster.compiler.support.mangled :as mangled]
             [raster.compiler.core.util :as util]
+            [raster.compiler.ad.bind-ctx :as bind-ctx]
             [raster.ad.tangent :as tangent]))
 
 ;; ================================================================
@@ -126,9 +127,120 @@
 ;; values are plain symbols (param→actual, result→sym, adjoint→sym), so this is
 ;; a strict superset of the old hand-rolled let*/loop*/dotimes substitutor.
 
+;; ================================================================
+;; Π at emission (plan 1a-1c): tags are CARRIED from the primal call
+;; site into the emitted backward code — read from the actual arg
+;; symbols' :raster.type/tag, projected through tangent/tangent-tag,
+;; stamped on the minted gradient syms + emitted call forms, and used
+;; to devirtualize fully-tagged backward calls AT EMISSION. Where a
+;; primal tag is absent the emission is byte-identical to the untagged
+;; path — never guess, never default.
+;; ================================================================
+
+(defn arg-tag
+  "The carried :raster.type/tag of an actual call-site argument: symbol
+  metadata, or the literal's own type. nil when unknown (no guessing)."
+  [x]
+  (cond
+    (symbol? x) (:raster.type/tag (meta x))
+    (instance? Double x) 'double
+    (instance? Float x) 'float
+    (instance? Long x) 'long
+    (instance? Integer x) 'int
+    :else nil))
+
+(defn grad-tag
+  "Π of an actual argument: the tag the gradient binding FOR that argument
+  carries — (tangent-tag (arg-tag x)) — or nil when the primal tag is
+  absent/⊥ (the emission then stays untagged). Grads-fn emission sites pass
+  this to the tagged gensym arity: (gensym-fn \"dx\" (grad-tag x))."
+  [x]
+  (tangent/tangent-tag (arg-tag x)))
+
+(def ^:private emission-resolver
+  "inline.clj's single-call devirtualizer (resolve-call-with-tags), loaded
+  lazily via requiring-resolve — genuine cycle (inline requires templates),
+  and the interpreted runtime-AD path may instantiate templates before the
+  compiler pass namespaces are loaded."
+  (delay (try (requiring-resolve
+               'raster.compiler.passes.scalar.inline/resolve-call-with-tags)
+              (catch Throwable _ nil))))
+
+(defn- resolve-emitted-expr
+  "Emission-time devirtualization of an emitted gradient expression (the
+  LIVE successor of the abandoned resolve-emitted-calls path). Inside-out:
+  resolves each generic deftm call using ONLY carried tags — symbol
+  :raster.type/tag metadata (primal args / Π-tagged grad syms), `env`
+  (tags of earlier bindings in the same emission), literals, and the
+  result tags of already-resolved nested calls. inline's
+  resolve-call-with-tags resolves a call ONLY when every arg tag is known;
+  otherwise the form is returned unchanged (the no-guessing property —
+  an untagged emission is byte-identical to the pre-tagging path).
+  Resolving here is deterministic on the FIRST compile: parametric
+  specializations are created at emission rather than as a later-pass
+  side effect (the pipeline.clj fixpoint-finalize cold-compile hazard)."
+  [expr env]
+  (if-let [resolve-call @emission-resolver]
+    (letfn [(walk [e]
+              (if (and (seq? e) (seq e) (not= 'quote (first e)))
+                (let [args (map walk (rest e))
+                      e' (if (= (seq args) (seq (rest e)))
+                           e
+                           (with-meta (apply list (first e) args) (meta e)))]
+                  (if (and (symbol? (first e')) (namespace (first e')))
+                    (or (resolve-call e' env) e')
+                    e'))
+                e))]
+      (walk expr))
+    expr))
+
+(defn- stamp-emitted-bindings
+  "Post-process the bindings a grads-fn just emitted (plan 1c):
+   1. LHS: the gradient binding for parameter i gets Π(tag of actual arg i)
+      when the grads-fn didn't already mint it tagged (positional net for
+      sites not yet using the tagged gensym arity). Only stamps when the
+      primal tag is PRESENT — absent tags leave the emission untouched.
+   2. RHS: resolve fully-tagged backward calls at emission
+      (resolve-emitted-expr), threading earlier tagged LHS syms as env.
+   3. RHS call forms get the binding's tag as :raster.type/tag when known,
+      so downstream consumers (walker signature-result-tag,
+      resolve-generic-deftm-calls) read it instead of re-deriving.
+  Returns [bindings' grad-syms']."
+  [new-bindings actual-params grad-syms]
+  (let [;; Positional Π map for RETURNED grad syms still untagged; a sym
+        ;; returned for two conflicting slots is dropped (never guess).
+        pos-tags (reduce
+                  (fn [m [i g]]
+                    (if (and (symbol? g) (nil? (:raster.type/tag (meta g))))
+                      (if-let [t (grad-tag (nth actual-params i nil))]
+                        (if (and (contains? m g) (not= (get m g) t))
+                          (dissoc m g)
+                          (assoc m g t))
+                        m)
+                      m))
+                  {} (map-indexed vector grad-syms))
+        stamp-sym (fn [s]
+                    (if-let [t (and (symbol? s) (get pos-tags s))]
+                      (vary-meta s assoc :raster.type/tag t)
+                      s))
+        [pairs _] (reduce
+                   (fn [[acc env] [s e]]
+                     (let [s (stamp-sym s)
+                           t (when (symbol? s) (:raster.type/tag (meta s)))
+                           e (resolve-emitted-expr e env)
+                           e (if (and t (seq? e)
+                                      (nil? (:raster.type/tag (meta e))))
+                               (vary-meta e assoc :raster.type/tag t)
+                               e)]
+                       [(conj acc s e) (if t (assoc env s t) env)]))
+                   [[] {}] (partition 2 new-bindings))]
+    [pairs (mapv stamp-sym grad-syms)]))
+
 (defn- compile-grads-to-fn
   "Compile static :grads data into a :grads-fn closure.
-  This unifies the two template paths so instantiation always uses :grads-fn."
+  This unifies the two template paths so instantiation always uses :grads-fn.
+  Each grad binding is minted through the tagged gensym arity with
+  Π(tag of the actual arg it differentiates) — untagged when unknown."
   [{:keys [params result adjoint grads]}]
   (fn [ctx actual-params result-sym adjoint-sym gensym-fn]
     (let [param-subst (zipmap params actual-params)
@@ -136,7 +248,8 @@
           adj-subst {adjoint adjoint-sym}
           smap (merge param-subst result-subst adj-subst)
           grad-bindings (mapv (fn [i grad-expr]
-                                (let [grad-sym (gensym-fn (str "dg_" (name (nth params i))))
+                                (let [grad-sym (gensym-fn (str "dg_" (name (nth params i)))
+                                                          (grad-tag (nth actual-params i nil)))
                                       substituted (util/subst-syms smap grad-expr)]
                                   [grad-sym substituted]))
                               (range) grads)]
@@ -149,6 +262,13 @@
 
   All templates have a :grads-fn (static :grads are auto-compiled at registration).
   The :grads-fn receives actual call-site params and produces gradient bindings.
+  The gensym-fn handed to the grads-fn is canonicalized tag-capable
+  (bind-ctx/tag-capable), so every emission site can mint Π-tagged syms.
+
+  Emitted bindings are post-processed (stamp-emitted-bindings): gradient
+  LHS syms carry Π(primal arg tag), fully-tagged backward calls are
+  devirtualized at emission, and tagged call forms carry :raster.type/tag —
+  all no-ops when the primal args carry no tags.
 
   Returns [updated-ctx, [grad-sym ...]] where grad-syms are the symbols
   bound to gradient values for each parameter."
@@ -156,7 +276,9 @@
   (let [grads-fn (or (:grads-fn template)
                      (throw (ex-info "AD template has no :grads-fn (and no :grads to compile)"
                                      {:template (select-keys template [:params :result :adjoint])})))
-        [ctx' grad-syms :as result] (grads-fn ctx actual-params result-sym adjoint-sym (:gensym-fn ctx))]
+        gensym-fn (bind-ctx/tag-capable (:gensym-fn ctx))
+        n-before (count (:bindings ctx))
+        [ctx' grad-syms] (grads-fn ctx actual-params result-sym adjoint-sym gensym-fn)]
     ;; Validate gradient count matches actual parameter count
     (when (and grad-syms (not= (count grad-syms) (count actual-params)))
       (throw (ex-info (str "AD template gradient count mismatch: " (count grad-syms)
@@ -166,63 +288,12 @@
                        :param-count (count actual-params)
                        :actual-params (vec actual-params)
                        :declared-params (:params template)})))
-    result))
-
-;; ================================================================
-;; Resolve generic deftm calls emitted by grads-fn
-;; ================================================================
-
-(defn- try-resolve-call-with-tags
-  "Resolve a generic deftm call to its mangled implementation using arg-tags
-   from the forward call as type context. Returns resolved form or nil."
-  [expr forward-tags]
-  (when (and (seq? expr) (symbol? (first expr)) (namespace (first expr))
-             (not (.contains ^String (name (first expr)) "_m_")))
-    (try
-      (when-let [v (resolve (first expr))]
-        (when-let [dt-atom (:raster.core/dispatch-table (meta v))]
-          (let [dt @dt-atom
-                arity (dec (count expr))
-                entries (get dt arity)]
-            (when (seq entries)
-              ;; Build expected tags: backward helpers typically use the same
-              ;; element types as the forward call (doubles→doubles, etc.)
-              ;; Use the forward tags as a pool of known types
-              (let [dominant-tag (first forward-tags) ;; e.g., doubles
-                    ;; Match: find entry whose tags are all the dominant type
-                    match (or (first (filter (fn [entry]
-                                               (every? #(= % dominant-tag) (:tags entry)))
-                                             entries))
-                             ;; Or single-method fallback
-                              (when (= 1 (count entries)) (first entries)))]
-                (when match
-                  (let [mangled-name (str (name (first expr)) "_m_"
-                                          (clojure.string/join "_" (map name (:tags match))))
-                        mangled (symbol (str (:mangled-ns match)) mangled-name)]
-                    (when (resolve mangled)
-                      (cons mangled (rest expr))))))))))
-      (catch Exception _ nil))))
-
-(defn- resolve-in-expr
-  "Recursively resolve generic deftm calls in an expression."
-  [expr forward-tags]
-  (cond
-    (not (seq? expr)) expr
-    (and (symbol? (first expr)) (namespace (first expr)))
-    (or (try-resolve-call-with-tags expr forward-tags)
-        (let [resolved (map #(resolve-in-expr % forward-tags) expr)]
-          (if (= (seq resolved) (seq expr)) expr (apply list resolved))))
-    :else (let [resolved (map #(resolve-in-expr % forward-tags) expr)]
-            (if (= (seq resolved) (seq expr)) expr (apply list resolved)))))
-
-(defn resolve-emitted-calls
-  "Resolve generic deftm calls in template-emitted bindings using the
-   forward call's arg-tags as type context. This devirtualizes backward
-   helper calls at AD transform time, avoiding runtime dispatch."
-  [bindings forward-tags]
-  (vec (mapcat (fn [[sym expr]]
-                 [sym (resolve-in-expr expr forward-tags)])
-               (partition 2 bindings))))
+    (let [bindings' (:bindings ctx')
+          [new-part grad-syms'] (stamp-emitted-bindings
+                                 (subvec (vec bindings') n-before)
+                                 (vec actual-params) (vec grad-syms))]
+      [(assoc ctx' :bindings (into (vec (take n-before bindings')) new-part))
+       (when grad-syms grad-syms')])))
 
 ;; ================================================================
 ;; Qualified numeric op → base op reverse mapping
@@ -372,12 +443,12 @@
                      :grads-fn (fn [ctx actual-params _result-sym adjoint-sym gensym-fn]
                                  (if (= 1 (count actual-params))
                  ;; Unary negation: grad = -dy
-                                   (let [g (gensym-fn "dg_x")]
+                                   (let [g (gensym-fn "dg_x" (grad-tag (first actual-params)))]
                                      [(update ctx :bindings into [g (list 'raster.numeric/- adjoint-sym)])
                                       [g]])
                  ;; Binary subtraction: grad_x = dy, grad_y = -dy
-                                   (let [gx (gensym-fn "dg_x")
-                                         gy (gensym-fn "dg_y")]
+                                   (let [gx (gensym-fn "dg_x" (grad-tag (first actual-params)))
+                                         gy (gensym-fn "dg_y" (grad-tag (second actual-params)))]
                                      [(update ctx :bindings into [gx adjoint-sym
                                                                   gy (list 'raster.numeric/- adjoint-sym)])
                                       [gx gy]])))})
@@ -475,8 +546,8 @@
 (register-template! 'Math/min
                     {:params '[x y] :result nil :adjoint 'dy
                      :grads-fn (fn [ctx [x y] _result-sym adjoint-sym gensym-fn]
-                                 (let [gx (gensym-fn "dg_x")
-                                       gy (gensym-fn "dg_y")]
+                                 (let [gx (gensym-fn "dg_x" (grad-tag x))
+                                       gy (gensym-fn "dg_y" (grad-tag y))]
                                    [(update ctx :bindings into
                                             [gx (list 'if (list 'clojure.core/<= (list 'double x) (list 'double y))
                                                       adjoint-sym 0.0)
@@ -488,8 +559,8 @@
 (register-template! 'Math/max
                     {:params '[x y] :result nil :adjoint 'dy
                      :grads-fn (fn [ctx [x y] _result-sym adjoint-sym gensym-fn]
-                                 (let [gx (gensym-fn "dg_x")
-                                       gy (gensym-fn "dg_y")]
+                                 (let [gx (gensym-fn "dg_x" (grad-tag x))
+                                       gy (gensym-fn "dg_y" (grad-tag y))]
                                    [(update ctx :bindings into
                                             [gx (list 'if (list 'clojure.core/>= (list 'double x) (list 'double y))
                                                       adjoint-sym 0.0)
@@ -647,7 +718,7 @@
 (register-template! 'raster.sci.special/betainc
                     {:params '[a b x] :result nil :adjoint 'dy
                      :grads-fn (fn [ctx [a b x] _result-sym adjoint-sym gensym-fn]
-                                 (let [dx (gensym-fn "dg_x")]
+                                 (let [dx (gensym-fn "dg_x" (grad-tag x))]
                                    [(update ctx :bindings into
                                             [dx (list 'raster.numeric/*
                                                       adjoint-sym
@@ -719,7 +790,7 @@
                     {:params '[arr i] :result nil :adjoint 'dy
                      :grads-fn
                      (fn [ctx [arr i] _result-sym adjoint-sym gensym-fn]
-                       (let [d-arr (gensym-fn "d_arr")]
+                       (let [d-arr (gensym-fn "d_arr" (grad-tag arr))]
                          [(update ctx :bindings into
                                   [d-arr (list 'raster.ad.reverse/aget-grad arr i adjoint-sym)])
                           [d-arr nil]]))})
@@ -752,7 +823,7 @@
                     {:params '[pred target n] :result nil :adjoint 'dy
                      :grads-fn
                      (fn [ctx [pred target n] _result-sym adjoint-sym gensym-fn]
-                       (let [d-pred (gensym-fn "d_pred")
+                       (let [d-pred (gensym-fn "d_pred" (grad-tag pred))
            ;; d_pred[i] = (2*dy/n)*(pred[i]-target[i]). Emitted as the inlinable
            ;; (All [T]) mse-grad SOAC (a broadcast), NOT the CPU-era ^:no-inline
            ;; BLAS helper daxpy-diff! — so the fused backward lowers to a resident
@@ -775,7 +846,7 @@
                     {:params '[a rows cols] :result nil :adjoint 'dy
                      :grads-fn
                      (fn [ctx [a rows cols] _result-sym adjoint-sym gensym-fn]
-                       (let [d-a (gensym-fn "d_a")]
+                       (let [d-a (gensym-fn "d_a" (grad-tag a))]
                          [(update ctx :bindings into
                                   [d-a (list 'raster.dl.nn/transpose-2d adjoint-sym cols rows)])
                           [d-a nil nil]]))})
@@ -787,8 +858,8 @@
                     {:params '[A B m k n] :result nil :adjoint 'dy
                      :grads-fn
                      (fn [ctx [A B m k n] _result-sym adjoint-sym gensym-fn]
-                       (let [dA (gensym-fn "dA")
-                             dB (gensym-fn "dB")]
+                       (let [dA (gensym-fn "dA" (grad-tag A))
+                             dB (gensym-fn "dB" (grad-tag B))]
                          [(update ctx :bindings into
                                   [dA (list 'raster.dl.nn/matmul-dA adjoint-sym B m k n)
                                    dB (list 'raster.dl.nn/matmul-dB A adjoint-sym m k n)])
@@ -802,9 +873,9 @@
                     {:params '[x W b batch in-f out-f] :result nil :adjoint 'dy
                      :grads-fn
                      (fn [ctx [x W b batch in-f out-f] _result-sym adjoint-sym gensym-fn]
-                       (let [dx (gensym-fn "dx")
-                             dW (gensym-fn "dW")
-                             db (gensym-fn "db")]
+                       (let [dx (gensym-fn "dx" (grad-tag x))
+                             dW (gensym-fn "dW" (grad-tag W))
+                             db (gensym-fn "db" (grad-tag b))]
                          [(update ctx :bindings into
                                   [dx (list 'raster.dl.nn/linear-dx adjoint-sym W batch in-f out-f)
                                    dW (list 'raster.dl.nn/linear-dW adjoint-sym x batch in-f out-f)
@@ -817,7 +888,7 @@
                     {:params '[x n] :result nil :adjoint 'dy
                      :grads-fn
                      (fn [ctx [x n] _result-sym adjoint-sym gensym-fn]
-                       (let [dx (gensym-fn "dx")]
+                       (let [dx (gensym-fn "dx" (grad-tag x))]
                          [(update ctx :bindings into
                                   [dx (list 'raster.dl.nn/silu-backward adjoint-sym x n)])
                           [dx nil]]))})
@@ -830,7 +901,7 @@
                     {:params '[ref t dim] :result nil :adjoint 'dy
                      :grads-fn
                      (fn [ctx [ref t dim] _result-sym adjoint-sym gensym-fn]
-                       (let [dt (gensym-fn "dt")]
+                       (let [dt (gensym-fn "dt" (grad-tag t))]
                          [(update ctx :bindings into
                                   [dt (list 'raster.dl.gsdm/sinusoidal-embed-backward
                                             adjoint-sym t dim)])
@@ -853,12 +924,12 @@
                        (let [;; dimension bindings — reference forward params directly for hoistability
                              dW-rows (gensym-fn "dW_rows")
                              dW-cols (gensym-fn "dW_cols")
-                             dW-buf  (gensym-fn "dW_buf")
-                             dW      (gensym-fn "dW")
-                             dx-buf  (gensym-fn "dx_buf")
-                             dx      (gensym-fn "dx")
-                             db-buf  (gensym-fn "db_buf")
-                             db      (gensym-fn "db")]
+                             dW-buf  (gensym-fn "dW_buf" (grad-tag W))
+                             dW      (gensym-fn "dW" (grad-tag W))
+                             dx-buf  (gensym-fn "dx_buf" (grad-tag x))
+                             dx      (gensym-fn "dx" (grad-tag x))
+                             db-buf  (gensym-fn "db_buf" (grad-tag b))
+                             db      (gensym-fn "db" (grad-tag b))]
                          [(update ctx :bindings into
                                   [;; compute dimensions from forward params (b, x) for hoistability
                                    dW-rows (list 'clojure.core/alength b)
@@ -883,7 +954,7 @@
                     {:params '[x] :result nil :adjoint 'dy
                      :grads-fn
                      (fn [ctx [x] _result-sym adjoint-sym gensym-fn]
-                       (let [dx (gensym-fn "dx")]
+                       (let [dx (gensym-fn "dx" (grad-tag x))]
                          [(update ctx :bindings into
                                   [dx (list 'raster.nn/relu-backward adjoint-sym x)])
                           [dx]]))})
@@ -894,7 +965,7 @@
                     {:params '[x] :result 's :adjoint 'dy
                      :grads-fn
                      (fn [ctx [x] result-sym adjoint-sym gensym-fn]
-                       (let [dx (gensym-fn "dx")]
+                       (let [dx (gensym-fn "dx" (grad-tag x))]
                          [(update ctx :bindings into
                                   [dx (list 'raster.nn/softmax-backward adjoint-sym result-sym)])
                           [dx]]))})
@@ -905,7 +976,7 @@
                     {:params '[p t] :result nil :adjoint 'dy
                      :grads-fn
                      (fn [ctx [p t] _result-sym adjoint-sym gensym-fn]
-                       (let [dp (gensym-fn "dp")]
+                       (let [dp (gensym-fn "dp" (grad-tag p))]
                          [(update ctx :bindings into
                                   [dp (list 'raster.nn/cross-entropy-backward-dp adjoint-sym p t)])
                           [dp nil]]))})
@@ -928,19 +999,20 @@
                              w-out  (gensym-fn "w_out")
                              ckk    (gensym-fn "ckk")
                              bhw    (gensym-fn "bhw")
-           ;; buffers
-                             dy-cols-buf (gensym-fn "dy_cols_buf")
-                             dy-cols     (gensym-fn "dy_cols")
-                             cols-buf    (gensym-fn "cols_buf")
-                             cols        (gensym-fn "cols")
-                             dW-buf      (gensym-fn "dW_buf")
-                             dW          (gensym-fn "dW")
-                             d-cols-buf  (gensym-fn "d_cols_buf")
-                             d-cols      (gensym-fn "d_cols")
-                             dx-buf      (with-meta (gensym-fn "dx_buf") {:hoistable true})
-                             dx          (gensym-fn "dx")
-                             db-buf      (with-meta (gensym-fn "db_buf") {:hoistable true})
-                             db          (gensym-fn "db")]
+           ;; buffers — Π-tagged from the primal args they derive from
+           ;; (vary-meta, not with-meta: :hoistable must not wipe the tag)
+                             dy-cols-buf (gensym-fn "dy_cols_buf" (grad-tag W))
+                             dy-cols     (gensym-fn "dy_cols" (grad-tag W))
+                             cols-buf    (gensym-fn "cols_buf" (grad-tag x))
+                             cols        (gensym-fn "cols" (grad-tag x))
+                             dW-buf      (gensym-fn "dW_buf" (grad-tag W))
+                             dW          (gensym-fn "dW" (grad-tag W))
+                             d-cols-buf  (gensym-fn "d_cols_buf" (grad-tag x))
+                             d-cols      (gensym-fn "d_cols" (grad-tag x))
+                             dx-buf      (vary-meta (gensym-fn "dx_buf" (grad-tag x)) assoc :hoistable true)
+                             dx          (gensym-fn "dx" (grad-tag x))
+                             db-buf      (vary-meta (gensym-fn "db_buf" (grad-tag b)) assoc :hoistable true)
+                             db          (gensym-fn "db" (grad-tag b))]
                          [(update ctx :bindings into
                                   [;; compute output dims
                                    h-out (list 'clojure.core/+ 1
@@ -956,22 +1028,22 @@
                                    ckk   (list 'long (list 'clojure.core/* c-in (list 'clojure.core/* kh kw)))
                                    bhw   (list 'long (list 'clojure.core/* batch (list 'clojure.core/* h-out w-out)))
            ;; rearrange dy -> dy_cols[c_out, bhw]
-                                   (with-meta dy-cols-buf {:hoistable true})
+                                   (vary-meta dy-cols-buf assoc :hoistable true)
                                    (list 'raster.arrays/zeros-like W (list 'clojure.core/* c-out bhw))
                                    dy-cols     (list 'raster.dl.nn/conv2d-rearrange-dy!
                                                      adjoint-sym dy-cols-buf batch c-out h-out w-out)
            ;; im2col for forward recomputation
-                                   (with-meta cols-buf {:hoistable true})
+                                   (vary-meta cols-buf assoc :hoistable true)
                                    (list 'raster.arrays/zeros-like x (list 'clojure.core/* ckk bhw))
                                    cols        (list 'raster.dl.nn/im2col-2d!
                                                      x cols-buf batch c-in h w kh kw stride-h stride-w pad-h pad-w)
            ;; dW = dy_cols @ cols^T
-                                   (with-meta dW-buf {:hoistable true})
+                                   (vary-meta dW-buf assoc :hoistable true)
                                    (list 'raster.arrays/zeros-like W (list 'clojure.core/* c-out ckk))
                                    dW          (list 'raster.dl.nn/conv2d-backward-dW-into!
                                                      dy-cols cols dW-buf c-out bhw ckk)
            ;; d_cols = W^T @ dy_cols
-                                   (with-meta d-cols-buf {:hoistable true})
+                                   (vary-meta d-cols-buf assoc :hoistable true)
                                    (list 'raster.arrays/zeros-like x (list 'clojure.core/* ckk bhw))
                                    d-cols      (list 'raster.dl.nn/conv2d-backward-dcols-into!
                                                      W dy-cols d-cols-buf ckk c-out bhw)
@@ -1005,11 +1077,11 @@
            ;; bound syms
                              n-out    (gensym-fn "n_out")
                              n-in     (gensym-fn "n_in")
-                             out-buf  (with-meta (gensym-fn "mp_out_buf") {:hoistable true})
-                             argmax   (with-meta (gensym-fn "argmax") {:hoistable true})
+                             out-buf  (vary-meta (gensym-fn "mp_out_buf" (grad-tag x)) assoc :hoistable true)
+                             argmax   (vary-meta (gensym-fn "argmax") assoc :hoistable true)
                              fwd      (gensym-fn "mp_fwd")
-                             dx-buf   (with-meta (gensym-fn "dx_buf") {:hoistable true})
-                             dx       (gensym-fn "dx")]
+                             dx-buf   (vary-meta (gensym-fn "dx_buf" (grad-tag x)) assoc :hoistable true)
+                             dx       (gensym-fn "dx" (grad-tag x))]
                          [(update ctx :bindings into
                                   [n-out  n-out-expr
                                    n-in   n-in-expr
@@ -1034,8 +1106,8 @@
                       {:params '[A b n] :result 'x :adjoint 'dy
                        :grads-fn (fn [ctx [A b n] result-sym adjoint-sym gensym-fn]
                                    (let [grads-arr (gensym-fn "solve_grads")
-                                         dA (gensym-fn "dA")
-                                         db (gensym-fn "db")]
+                                         dA (gensym-fn "dA" (grad-tag A))
+                                         db (gensym-fn "db" (grad-tag b))]
                                      [(update ctx :bindings into
                                               [grads-arr (list 'raster.linalg.core/solve-backward
                                                                adjoint-sym A result-sym n)
@@ -1047,7 +1119,7 @@
 (merge-into-template! 'raster.linalg.core/array-det
                       {:params '[A n] :result 'det-val :adjoint 'dy
                        :grads-fn (fn [ctx [A n] result-sym adjoint-sym gensym-fn]
-                                   (let [dA (gensym-fn "dA")]
+                                   (let [dA (gensym-fn "dA" (grad-tag A))]
                                      [(update ctx :bindings into
                                               [dA (list 'raster.linalg.core/array-det-backward
                                                         adjoint-sym result-sym A n)])
@@ -1540,7 +1612,7 @@
           (reduce
            (fn [[ctx grads] i]
              (if-let [adj-f (get adjoint-map i)]
-               (let [g (gensym-fn (str "dadj_" i))]
+               (let [g (gensym-fn (str "dadj_" i) (grad-tag (nth args i nil)))]
                  [(update ctx :bindings into [g (adj-f args adjoint-sym)])
                   (conj grads g)])
                [ctx (conj grads nil)]))

--- a/src/raster/compiler/ad/bind_ctx.clj
+++ b/src/raster/compiler/ad/bind_ctx.clj
@@ -11,11 +11,33 @@
       (emit-let* ctx sym))
     ;; => (let* [buf__1 (nc/raw x)] buf__1)")
 
+(defn tag-capable
+  "Canonicalize a caller-supplied gensym-fn into the two-arity BindCtx
+  contract:
+    (f prefix)      — mint a fresh symbol (unchanged behavior)
+    (f prefix tag)  — mint a fresh symbol stamped {:raster.type/tag tag}
+                      when `tag` is non-nil; nil tag = plain mint, so
+                      callers can pass Π's nil (no tangent space / unknown
+                      primal tag) without branching.
+  Always mints through the wrapped fn's single arity and stamps in the
+  wrapper, so any provider (plain gensym closures, reverse.clj's
+  ad-gensym, jvp-gensym) yields identical tagging semantics. Idempotent
+  under re-wrapping."
+  [gensym-fn]
+  (fn mint
+    ([prefix] (gensym-fn prefix))
+    ([prefix tag]
+     (let [sym (gensym-fn prefix)]
+       (if (some? tag)
+         (vary-meta sym assoc :raster.type/tag tag)
+         sym)))))
+
 (defn make-ctx
   "Create a fresh binding context.
-  gensym-fn: (fn [prefix] -> unique-symbol)"
+  gensym-fn: (fn [prefix] -> unique-symbol); wrapped via `tag-capable`
+  so (gensym-fn prefix tag) is always available to template grads-fns."
   [gensym-fn]
-  {:bindings [] :gensym-fn gensym-fn})
+  {:bindings [] :gensym-fn (tag-capable gensym-fn)})
 
 (defn genlet
   "Add a binding to the context. Returns [updated-ctx, sym].

--- a/src/raster/compiler/ad/flatten.clj
+++ b/src/raster/compiler/ad/flatten.clj
@@ -25,6 +25,7 @@
   3. Names the gradient outputs (one per active param)
   4. Appends SGD weight update calls: (nc/axpy! (- lr) d_Wi Wi)"
   (:require [raster.ad.tangent :as tangent]
+            [raster.compiler.ir.dialects :as dialects]
             [raster.compiler.ir.form :as form]))
 
 (def ^:dynamic *flatten-dtype*
@@ -64,24 +65,34 @@
     - [primal pullback]
 
   Returns a canonical let* form or nil when the input is not recognized
-  as AD output."
+  as AD output. Every caller passes what it believes is transform-body
+  output and treats nil as \"leave the call unexpanded\" — a silent
+  degradation — so a nil result warns with the ADTransformed dialect
+  validator's diagnosis."
   [form]
-  (cond
-    (let-form? form)
-    (when-let [{:keys [bindings body]} (decompose-flat-let* form)]
-      (when (and (vector? body)
-                 (= 2 (count body))
-                 (seq? (second body))
-                 (= 'fn* (first (second body))))
-        (with-meta (make-flat-let* bindings body) (meta form))))
+  (let [canonical
+        (cond
+          (let-form? form)
+          (when-let [{:keys [bindings body]} (decompose-flat-let* form)]
+            (when (and (vector? body)
+                       (= 2 (count body))
+                       (seq? (second body))
+                       (= 'fn* (first (second body))))
+              (with-meta (make-flat-let* bindings body) (meta form))))
 
-    (and (vector? form)
-         (= 2 (count form))
-         (seq? (second form))
-         (= 'fn* (first (second form))))
-    (with-meta (make-flat-let* [] form) (meta form))
+          (and (vector? form)
+               (= 2 (count form))
+               (seq? (second form))
+               (= 'fn* (first (second form))))
+          (with-meta (make-flat-let* [] form) (meta form))
 
-    :else nil))
+          :else nil)]
+    (when (and (nil? canonical) (some? form))
+      (binding [*out* *err*]
+        (println (str "WARNING: AD output failed canonicalization — the value+grad "
+                      "call stays unexpanded (silent fallback). Dialect check: "
+                      (pr-str (dialects/validate-ad-transformed form))))))
+    canonical))
 
 (defn- decompose-flat-let*
   "Decompose a let/let* form and normalize it to the canonical flat-let view.

--- a/src/raster/compiler/backend/jvm/bytecode.clj
+++ b/src/raster/compiler/backend/jvm/bytecode.clj
@@ -1847,6 +1847,7 @@
   [code args locals ctx]
   (let [[arr idx] args
         arr-tag (or (:tag (meta arr))
+                    (:raster.type/tag (meta arr))
                     (when (symbol? arr) (:hint (get locals arr))))
         ;; Skip checkcast when the local's type is verified by the
         ;; JVM method descriptor (typed param, not Object)
@@ -1878,7 +1879,7 @@
       objects (do (.aaload code) :ref)
       (do (when arr-tag
             (binding [*out* *err*]
-              (println "WARNING: emit-aget-intrinsic: unrecognized arr-tag" arr-tag
+              (println "WARNING: emit-aget-intrinsic: unrecognized arr-tag" (pr-str arr-tag)
                        "for" arr "— falling back to aaload (Object[])")))
           (.aaload code) :ref))))
 
@@ -1889,6 +1890,7 @@
   [code args locals ctx]
   (let [[arr idx val] args
         arr-tag (or (:tag (meta arr))
+                    (:raster.type/tag (meta arr))
                     (when (symbol? arr) (:hint (get locals arr))))
         arr-verified? (when (symbol? arr) (:verified (get locals arr)))
         arr-type (emit-form code arr locals ctx)]
@@ -2837,9 +2839,12 @@
                              ;; ^objects → checkcast [Ljava/lang/Object;
                              ;; ^doubles → checkcast [D
                              ;; ^ClassName → checkcast to that class
-                            ;; Infer tag: explicit hint, alias source, deftm return-tag,
-                            ;; .invk return-tag, or Java static field/method return type
+                            ;; Infer tag: explicit hint, CARRIED :raster.type/tag stamp
+                            ;; (AD emission / walker — emitters read stamps, never
+                            ;; re-infer), alias source, deftm return-tag, .invk
+                            ;; return-tag, or Java static field/method return type
                             tag (or (:tag (meta sym))
+                                    (:raster.type/tag (meta sym))
                                     ;; Alias: inherit from source
                                     (when (symbol? init)
                                       (:hint (get locs init)))
@@ -2947,6 +2952,13 @@
                                                                      locs))]
                                         (inf/infer-arg-tag init local-env))
                                       (catch Throwable _ nil)))
+                            ;; A degenerate empty-symbol tag (infer-arg-tag's ctor arm
+                            ;; misfires on host `(. obj meth …)` dot forms: (name '.)
+                            ;; ends with ".") is POISON: it would mark the local
+                            ;; :verified (≠ 'Object) while emitting no checkcast, so a
+                            ;; downstream aget skips its checkcast too → VerifyError
+                            ;; (aaload on Object). Treat it as absent.
+                            tag (if (and (symbol? tag) (zero? (count (name tag)))) nil tag)
                             ;; Checkcast for typed let bindings (arrays, records, etc.)
                             ;; These CHECKCASTs are redundant when getfield already returns
                             ;; the typed value, but C2 uses them as type proofs for downstream

--- a/src/raster/compiler/core/dispatch.clj
+++ b/src/raster/compiler/core/dispatch.clj
@@ -935,6 +935,107 @@
 
     :else annotation))
 
+;; ================================================================
+;; Signature-derived result typing (tag-level)
+;;
+;; The `unify-type-var` / `unify-parametric` machinery above unifies a
+;; parametric (All [T]) signature against runtime CLASSES (for dispatch).
+;; `signature-result-tag` is the compile-time TAG-level twin: it unifies the
+;; declared signature against the argument dispatch TAGS a pass already knows
+;; (floats/doubles/long/…) and substitutes the bound type vars into the RETURN
+;; annotation to derive the op's result tag — deriving what a :result-type
+;; op-descriptor facet would otherwise hand-restate. It is the single mechanism
+;; the walker and late inference route through (facet is the fallback).
+;; ================================================================
+
+(defn- tag-unify-type-var
+  "Tag-level twin of `unify-type-var`: unify a single param ANNOTATION against an
+   argument dispatch TAG (a symbol like 'floats/'double/'long, or nil).
+   Returns:
+     - a binding map {T elem}      when the annotation binds a type variable
+                                   ((Array T) vs 'floats → {T float}; bare T vs
+                                    'float → {T float})
+     - {}                          when the annotation is concrete and CONSISTENT
+                                   with arg-tag (no variable to bind)
+     - nil                         on any mismatch / underdetermined (nil) tag —
+                                   the caller then yields nil and the facet speaks."
+  [annotation arg-tag type-vars]
+  (cond
+    (nil? arg-tag) nil
+
+    ;; (Array T) — bind T to the array tag's element type ('floats → 'float)
+    (and (sequential? annotation) (= 'Array (first annotation))
+         (symbol? (second annotation))
+         (contains? type-vars (second annotation)))
+    (when-let [elem (get types/primitive-array-element-types arg-tag)]
+      {(second annotation) elem})
+
+    ;; bare T — bind T directly to the (scalar element) arg tag ('float/'double)
+    (and (symbol? annotation) (contains? type-vars annotation))
+    {annotation arg-tag}
+
+    ;; concrete annotation (no variable) — consistency check by tag equality.
+    ;; Strict: a mismatch yields nil so the facet fallback speaks rather than a
+    ;; possibly-wrong signature tag.
+    :else
+    (when (= (types/annotation->tag annotation nil) arg-tag) {})))
+
+(defn- op->parametric-qname
+  "Resolve an op (var or symbol) to the qualified symbol key used in
+   `parametric-registry`. Returns nil when it cannot be resolved."
+  [op]
+  (cond
+    (var? op)    (let [m (meta op)] (symbol (str (:ns m)) (str (:name m))))
+    (symbol? op) (or (try (when-let [v (resolve op)]
+                            (let [m (meta v)]
+                              (when (and (:ns m) (:name m))
+                                (symbol (str (:ns m)) (str (:name m))))))
+                          (catch Exception _ nil))
+                     op)
+    :else nil))
+
+(defn signature-result-tag
+  "Derive the result dispatch tag of `op` applied to arguments whose inferred
+   dispatch tags are `arg-tags`, by unifying op's declared (All [T]) signature
+   against those tags and substituting the bound type variables into the RETURN
+   annotation. `op` is a var or (qualified/bare) symbol; `arg-tags` a seq of
+   dispatch-tag symbols (or nils).
+
+   Returns nil — so callers fall back to the :result-type facet — when:
+     - op has no registered parametric (All [T]) template (e.g. a monomorphic
+       overloaded deftm like oftype, or a plain host fn),
+     - no template's arity matches, a concrete param is inconsistent, or the
+       type variables are underdetermined,
+     - the type vars don't all bind (return annotation would stay symbolic)."
+  [op arg-tags]
+  (let [qn        (op->parametric-qname op)
+        templates (or (and qn (get @parametric-registry qn))
+                      (when (symbol? op) (get @parametric-registry op)))
+        arg-tags  (vec arg-tags)]
+    (when (seq templates)
+      (some
+       (fn [{:keys [type-var-list annotations ret-annotation]}]
+         (when (and ret-annotation
+                    (= (count annotations) (count arg-tags)))
+           (let [tvs (set type-var-list)
+                 bindings
+                 (reduce
+                  (fn [acc [ann tag]]
+                    (let [b (tag-unify-type-var ann tag tvs)]
+                      (if (or (nil? b)
+                              (not (every? (fn [[k v]]
+                                             (or (not (contains? acc k))
+                                                 (= (get acc k) v)))
+                                           b)))
+                        (reduced nil)
+                        (merge acc b))))
+                  {} (map vector annotations arg-tags))]
+             (when (and bindings (every? #(contains? bindings %) tvs))
+               (let [subst (substitute-type-var ret-annotation bindings)
+                     tag   (types/annotation->tag subst nil)]
+                 tag)))))
+       templates))))
+
 (defn register-parametric!
   "Register a parametric method template.
    type-vars: [T] — the type variables

--- a/src/raster/compiler/core/inference.clj
+++ b/src/raster/compiler/core/inference.clj
@@ -23,6 +23,18 @@
             [raster.compiler.ir.form :as form]
             [raster.compiler.core.tc-extensions]))
 
+;; Signature-derived result typing lives in dispatch (with the parametric
+;; registry). dispatch → specialize → inference, so we resolve it lazily
+;; (cached) — the same requiring-resolve pattern used for parametric-registry.
+(def ^:private signature-result-tag-fn
+  (delay (requiring-resolve 'raster.compiler.core.dispatch/signature-result-tag)))
+
+(defn- signature-result-tag
+  "Signature-derived result tag (dispatch/signature-result-tag), or nil when the
+   op has no unifiable (All [T]) signature. Callers fall back to the facet."
+  [op arg-tags]
+  (when-let [f @signature-result-tag-fn] (f op arg-tags)))
+
 ;; ================================================================
 ;; Type-env accessors
 ;; ================================================================
@@ -1838,9 +1850,10 @@
             ;; below can't supply it. Register new ops in op-descriptor, not here.
             (some? (descriptor/result-type-rule
                     (or (:raster.op/original (meta expr)) (form/effective-op expr))))
-            (let [op (or (:raster.op/original (meta expr)) (form/effective-op expr))]
-              (descriptor/result-tag
-               op (map #(infer-arg-tag % env) (form/effective-args expr))))
+            (let [op (or (:raster.op/original (meta expr)) (form/effective-op expr))
+                  arg-tags (map #(infer-arg-tag % env) (form/effective-args expr))]
+              (or (signature-result-tag op arg-tags)  ; signature first
+                  (descriptor/result-tag op arg-tags)))
 
             (= '.invk head)
             (when-let [impl-sym (second expr)]

--- a/src/raster/compiler/core/op_descriptor.clj
+++ b/src/raster/compiler/core/op_descriptor.clj
@@ -836,6 +836,11 @@
 ;; grad-acc (reverse-AD nil-safe +) returns the type of its (first typed) arg.
 (register-result-type! 'raster.ad.reverse/grad-acc :first-typed-arg)
 
+;; NOTE: ops defined in higher layers (raster.dl.*, raster.ad.*) register their own
+;; :result-type facet from THEIR namespace (e.g. residual-add in raster.dl.nn), so
+;; compiler core does not depend on those namespaces. Only compiler-owned ops belong
+;; here. `grad-acc` above is a borderline case kept for now (reverse-AD primitive).
+
 ;; par/reduce returns its accumulator type — arg 1, the init value (matches
 ;; form-info's :return-type-arg for :par forms; registered for the defensive
 ;; bare alias spelling too, which form-info's raster.par-namespace matcher

--- a/src/raster/compiler/core/op_descriptor.clj
+++ b/src/raster/compiler/core/op_descriptor.clj
@@ -841,11 +841,14 @@
 ;; compiler core does not depend on those namespaces. Only compiler-owned ops belong
 ;; here. `grad-acc` above is a borderline case kept for now (reverse-AD primitive).
 
-;; par/reduce returns its accumulator type — arg 1, the init value (matches
-;; form-info's :return-type-arg for :par forms; registered for the defensive
-;; bare alias spelling too, which form-info's raster.par-namespace matcher
-;; doesn't classify).
-(register-result-type! 'raster.par/reduce [:arg 1])
+;; par/reduce returns its accumulator type — arg 1, the init value. The CANONICAL
+;; spelling `raster.par/reduce` is typed independently by form-info's
+;; :return-type-arg (:par forms → arg 1; ir/form.clj) — the walker types it via its
+;; dedicated `:par-reduce` handler and late inference falls through to the form-info
+;; arm — so no op-descriptor entry is needed for it. Only the DEFENSIVE bare alias
+;; `par/reduce` needs one: form-info's raster.par-namespace matcher (namespace
+;; "raster.par…") does not classify the bare "par" namespace, so it has no
+;; :return-type-arg of its own.
 (register-result-type! 'par/reduce [:arg 1])
 
 ;; --- Devirtualization detection ---

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -19,6 +19,19 @@
             [raster.compiler.ir.form :as form]
             [raster.compiler.core.macroexpand :as mex]))
 
+;; Signature-derived result typing lives in dispatch (with the parametric
+;; registry + substitute-type-var). dispatch → specialize → walker, so the
+;; walker cannot statically require dispatch; resolve lazily (cached) like
+;; inference.clj does for parametric-registry.
+(def ^:private signature-result-tag-fn
+  (delay (requiring-resolve 'raster.compiler.core.dispatch/signature-result-tag)))
+
+(defn- signature-result-tag
+  "Signature-derived result tag (dispatch/signature-result-tag), or nil when the
+   op has no unifiable (All [T]) signature. Callers fall back to the facet."
+  [op arg-tags]
+  (when-let [f @signature-result-tag-fn] (f op arg-tags)))
+
 (defn- warn-boxed-dispatch?
   "Check if *warn-on-boxed-dispatch* is bound and true."
   []
@@ -462,7 +475,10 @@
             (let [op   (:raster.op/original (meta result))
                   rule (descriptor/result-type-rule op)
                   ref  (nth result 2)
-                  et   (or (when (= :element-of-first-arg rule)
+                  ;; .invk = (.invk impl arg0 arg1 …) — the op args start at idx 2.
+                  arg-tags (map walked-tag (drop 2 result))
+                  et   (or (signature-result-tag op arg-tags)  ; signature first
+                           (when (= :element-of-first-arg rule)
                              (get-in type-env [ref :element]))     ; parametric array ref → element
                            (descriptor/result-tag op [(get-in type-env [ref :tag])]))]
               (if et (vary-meta result assoc :raster.type/tag et) result))
@@ -482,7 +498,9 @@
             ;; (:result-type), not here.
             (and (symbol? head) (namespace head)
                  (some? (descriptor/result-type-rule head)))
-            (let [rt (descriptor/result-tag head (map walked-tag (rest result)))]
+            (let [arg-tags (map walked-tag (rest result))
+                  rt (or (signature-result-tag head arg-tags)  ; signature first
+                         (descriptor/result-tag head arg-tags))]
               (if rt (vary-meta result assoc :raster.type/tag rt) result))
             ;; Primitive cast — (double x), (float x), etc.
             (contains? types/primitive-info head)

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -471,6 +471,19 @@
             (if-let [ret-tag (:raster.type/ret-tag (meta (second result)))]
               (vary-meta result assoc :raster.type/tag ret-tag)
               result)
+            ;; Kept-symbolic op with a :result-type facet — an op that does NOT
+            ;; devirtualize to .invk (residual-add, grad-acc: they lower via SOAC
+            ;; fusion / stay a nil-safe host defn) but whose result tag still derives
+            ;; from its ARG tags via the registry (:same-as-first-arg for
+            ;; residual-add, :first-typed-arg for grad-acc). The .invk arms above
+            ;; can't reach these (no impl-sym / ret-tag), so without this arm the
+            ;; result stays untagged and the reverse-AD fan-out reroute (which gates
+            ;; on an :array sym-tag) can't fire. Register new ops in op-descriptor
+            ;; (:result-type), not here.
+            (and (symbol? head) (namespace head)
+                 (some? (descriptor/result-type-rule head)))
+            (let [rt (descriptor/result-tag head (map walked-tag (rest result)))]
+              (if rt (vary-meta result assoc :raster.type/tag rt) result))
             ;; Primitive cast — (double x), (float x), etc.
             (contains? types/primitive-info head)
             (vary-meta result assoc :raster.type/tag head)
@@ -701,6 +714,13 @@
                  tag (or (inf/floating-literal-narrowed-tag init (:element-dtype ctx))
                          (inf/walked-init-monomorphized-tag rewritten-init tc-tag
                                                             (:element-dtype ctx))
+                         ;; A tag the walker's post-stamp derived on the init FORM
+                         ;; itself (e.g. a kept-symbolic residual-add stamped via the
+                         ;; :result-type facet, which infer-binding-tag can't reach —
+                         ;; no impl-sym/.invk ret-tag). Monomorphization-correct (it
+                         ;; came from the already-walked args), so it beats TC's
+                         ;; dtype-blind guess.
+                         (:raster.type/tag (meta rewritten-init))
                          tc-tag
                          (inf/infer-binding-tag sym init rewritten-init type-env
                                                 {:source-ns (:source-ns ctx)

--- a/src/raster/compiler/passes/scalar/inline.clj
+++ b/src/raster/compiler/passes/scalar/inline.clj
@@ -1538,6 +1538,20 @@
                         (let [r (cons ms args)]
                           (if-let [m (meta expr)] (with-meta r m) r))))))))))))))
 
+(defn resolve-call-with-tags
+  "Resolve ONE generic deftm call whose argument tags are all statically
+  known — from `env` (sym → tag), symbol :raster.type/tag metadata, or
+  literals (via inf/infer-arg-tag). Returns the devirtualized form (.invk
+  or mangled call, result tag stamped) or nil when any arg tag is unknown
+  or no signature matches — the caller keeps the symbolic form unchanged.
+
+  Emission-time seam for raster.ad.templates (which requiring-resolves
+  this — genuine cycle: inline requires templates), so AD backward calls
+  devirtualize AT EMISSION when the primal tags suffice, deterministically
+  on the first compile (see pipeline.clj's fixpoint-finalize hazard note)."
+  [expr env]
+  (try-resolve-dispatch expr env))
+
 (defn- resolve-dispatch-walk
   "Recursively resolve generic deftm calls in an expression.
    Tracks types through let/loop bindings for inner resolution.

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -379,6 +379,17 @@
       norm
       (let [g (gensym "_ret_")] (list 'let* [g norm] g)))))
 
+(def fixpoint-census
+  "Tag-completeness census at the fixpoint edge (Phase 0 of
+  .internal/ad_typed_emission_plan.md). Reset at every pass-fixpoint entry;
+  one entry per iteration plus a :final entry on the finalized form, each
+  {:label :untagged-bindings :untagged-by-head :undevirtualized
+   :undevirtualized-ops}. Tests read this to assert emission-time tagging
+  progress. One compile at a time assumed (plain atom, no per-compile key)."
+  (atom []))
+
+(declare record-fixpoint-census!)
+
 (defn- pass-fixpoint
   "Fixpoint pass: expand → normalize → rewalk → PE+CSE until stable.
 
@@ -421,11 +432,14 @@
                        (if (= resolved tagged)
                          current
                          (inline/expand-for-backends resolved 3 (:param-env opts))))))]
+    (reset! fixpoint-census [])
     (loop [current form
            iter 0
            total-stats {:fixpoint-iterations 0}]
       (if (>= iter max-iters)
-        {:form (ensure-let*-result (finalize current)) :stats total-stats}
+        (let [final (ensure-let*-result (finalize current))]
+          (record-fixpoint-census! :final final)
+          {:form final :stats total-stats})
         (let [;; Step 1: Expand (inline deftm calls + value+grad AD inlining)
               expanded (binding [inline/*ad-transform-body-fn* ad-reverse/transform-body]
                          (inline/expand-for-backends current 3 (:param-env opts)))
@@ -445,10 +459,14 @@
                            (if (map? rw-result) (:form rw-result) rw-result))
                          expanded)]
           (if (= rewalked current)
-            {:form (ensure-let*-result (finalize current))
-             :stats (assoc total-stats :fixpoint-iterations iter)}
-            (recur rewalked (inc iter)
-                   (assoc total-stats :fixpoint-iterations (inc iter)))))))))
+            (let [final (ensure-let*-result (finalize current))]
+              (record-fixpoint-census! :final final)
+              {:form final
+               :stats (assoc total-stats :fixpoint-iterations iter)})
+            (do
+              (record-fixpoint-census! iter rewalked)
+              (recur rewalked (inc iter)
+                     (assoc total-stats :fixpoint-iterations (inc iter))))))))))
 
 (defn- pass-mode-select
   "Analyze Jacobian structure and annotate form with recommended AD mode.
@@ -510,6 +528,68 @@
             (mapcat collect-undevirtualized form))
     (vector? form) (mapcat collect-undevirtualized form)
     :else nil))
+
+(def ^:dynamic *log-tag-census*
+  "When true (or env RASTER_TAG_CENSUS is set), pass-fixpoint prints the
+  :final tag-census line to *err* when it is nonzero. The fixpoint-census
+  atom is populated regardless."
+  false)
+
+(defn- untagged-binding-pairs
+  "Collect [sym init] for every let* binding whose sym lacks
+  :raster.type/tag. fn* pullback bindings are excluded (closures are never
+  tagged); loop*/dotimes binders are excluded (integer counters/carries are
+  outside the let*-binding typedness contract)."
+  [form]
+  (cond
+    (seq? form)
+    (if (and (= 'let* (first form)) (vector? (second form)))
+      (let [pairs (partition 2 (second form))]
+        (concat (keep (fn [[s e]]
+                        (when (and (symbol? s)
+                                   (nil? (:raster.type/tag (meta s)))
+                                   (not (and (seq? e) (= 'fn* (first e)))))
+                          [s e]))
+                      pairs)
+                (mapcat (fn [[_ e]] (untagged-binding-pairs e)) pairs)
+                (mapcat untagged-binding-pairs (drop 2 form))))
+      (mapcat untagged-binding-pairs form))
+    (vector? form) (mapcat untagged-binding-pairs form)
+    :else nil))
+
+(defn- census-rhs-head
+  "Classification key that makes an untagged binding actionable: the impl
+  symbol for .invk calls (its mangled name shows the chosen dtype), the head
+  symbol for other calls, :vector/:atom otherwise."
+  [e]
+  (cond
+    (and (seq? e) (= '.invk (first e))) (second e)
+    (seq? e) (first e)
+    (vector? e) :vector
+    :else :atom))
+
+(defn- record-fixpoint-census!
+  "Append one tag-completeness entry to fixpoint-census (Phase 0 of
+  .internal/ad_typed_emission_plan.md)."
+  [label form]
+  (let [untagged (untagged-binding-pairs form)
+        undevirt (collect-undevirtualized form)
+        entry {:label label
+               :untagged-bindings (count untagged)
+               :untagged-by-head (frequencies (map (comp census-rhs-head second) untagged))
+               :undevirtualized (count undevirt)
+               :undevirtualized-ops (frequencies (map first undevirt))}]
+    (swap! fixpoint-census conj entry)
+    (when (and (= label :final)
+               (or *log-tag-census* (System/getenv "RASTER_TAG_CENSUS"))
+               (or (pos? (:untagged-bindings entry))
+                   (pos? (:undevirtualized entry))))
+      (binding [*out* *err*]
+        (println (str "TAG-CENSUS fixpoint-final: " (:untagged-bindings entry)
+                      " untagged binding(s) " (pr-str (:untagged-by-head entry))
+                      "; " (:undevirtualized entry) " undevirtualized call(s) "
+                      (pr-str (:undevirtualized-ops entry))))))
+    entry))
 
 (defn- pass-late-cleanup
   "Late CSE + DCE + dispatch resolution after buffer fusion and backward inlining.

--- a/src/raster/dl/nn.clj
+++ b/src/raster/dl/nn.clj
@@ -2093,6 +2093,18 @@
                             :grads-fn (fn [ctx [_a _b _n] _result-sym adjoint-sym _gensym-fn]
                                         [ctx [adjoint-sym adjoint-sym nil]])})
 
+;; residual-add / residual-add-backward are kept SYMBOLIC in the walk (they lower via
+;; broadcast SOAC fusion to a :map kernel, not .invk), so the walker's .invk ret-tag
+;; arm never fires and their result sym would stay untagged. They return (Array T) —
+;; the SAME array tag as their first arg. The :result-type facet lets the walker stamp
+;; the result (via its bare-symbolic-call arm), which the reverse-AD fan-out reroute
+;; needs: a value x1 = (residual-add …) that FANS OUT folds its cotangent via the
+;; resident residual-add ONLY when x1's sym-tag is :array. Without the tag the residual
+;; fan-out d_x1 falls back to the GPU-kernel-less nil-safe grad-acc → non-resident (B2).
+;; Registered HERE (not in compiler core) so core keeps no dependency on raster.dl.nn.
+(descriptor/register-result-type! 'raster.dl.nn/residual-add :same-as-first-arg)
+(descriptor/register-result-type! 'raster.dl.nn/residual-add-backward :same-as-first-arg)
+
 ;; hadamard rrule — elementwise product (gated MLPs). d_a = dy⊙b, d_b = dy⊙a.
 (tmpl/merge-into-template! 'raster.dl.nn/hadamard
                            {:params '[a b n] :result nil :adjoint 'dy

--- a/test/raster/ad/typed_emission_test.clj
+++ b/test/raster/ad/typed_emission_test.clj
@@ -1,0 +1,150 @@
+(ns raster.ad.typed-emission-test
+  "Phase 1 (Π) of .internal/ad_typed_emission_plan.md: emit-time
+  tangent-typed template emission.
+
+  (i)   tangent-tag (Π) — identity on differentiable tags, nil on ⊥/unknown
+  (ii)  a grads-fn emission from tagged primal args produces Π-tagged
+        binding LHS syms, tagged call forms, and emission-time
+        devirtualization when all arg tags are known
+  (iii) an emission with UNtagged primal args is byte-identical to the
+        pre-change emission — tags are carried, never guessed."
+  (:require [clojure.test :refer [deftest testing is]]
+            [raster.ad.tangent :as tangent]
+            [raster.ad.templates :as tmpl]
+            [raster.compiler.ad.bind-ctx :as bind-ctx]))
+
+(defn- make-test-ctx
+  "Deterministic single-arity gensym (the pre-change BindCtx contract) —
+  make-ctx must canonicalize it tag-capable."
+  []
+  (let [counter (atom 0)]
+    (bind-ctx/make-ctx (fn [prefix] (symbol (str prefix "__" (swap! counter inc)))))))
+
+(defn- tag-of [x] (some-> x meta :raster.type/tag))
+
+(defn- tagged [sym tag] (with-meta sym {:raster.type/tag tag}))
+
+;; ================================================================
+;; (i) Π — tangent-tag
+;; ================================================================
+
+(deftest tangent-tag-test
+  (testing "identity on differentiable tags (mirrors differentiable?)"
+    (is (= 'double  (tangent/tangent-tag 'double)))
+    (is (= 'float   (tangent/tangent-tag 'float)))
+    (is (= 'doubles (tangent/tangent-tag 'doubles)))
+    (is (= 'floats  (tangent/tangent-tag 'floats))))
+  (testing "⊥ (no tangent space) and unknown → nil, never a default"
+    (is (nil? (tangent/tangent-tag 'long)))
+    (is (nil? (tangent/tangent-tag 'longs)))
+    (is (nil? (tangent/tangent-tag 'int)))
+    (is (nil? (tangent/tangent-tag 'boolean)))
+    (is (nil? (tangent/tangent-tag 'Object)))
+    (is (nil? (tangent/tangent-tag nil))))
+  (testing "Π agrees with differentiable? on its whole domain"
+    (doseq [t '[double float doubles floats long longs int ints boolean Object nil]]
+      (is (= (tangent/differentiable? t) (some? (tangent/tangent-tag t)))
+          (str "Π and differentiable? disagree on " t)))))
+
+;; ================================================================
+;; Tag-capable bind-ctx gensym
+;; ================================================================
+
+(deftest tag-capable-gensym-test
+  (testing "make-ctx canonicalizes a single-arity gensym-fn to two arities"
+    (let [{:keys [gensym-fn]} (make-test-ctx)]
+      (is (= 'g__1 (gensym-fn "g")))
+      (is (nil? (tag-of (gensym-fn "g"))))
+      (let [s (gensym-fn "g" 'floats)]
+        (is (= 'floats (tag-of s))))
+      (testing "nil tag = plain mint (Π's ⊥ needs no branching at call sites)"
+        (is (nil? (tag-of (gensym-fn "g" nil))))))))
+
+;; ================================================================
+;; (ii) tagged primal → Π-tagged binding + resolved/tagged call
+;; ================================================================
+
+(deftest tagged-emission-test
+  (testing "float scalar primals: Π-tagged LHS, devirtualized float RHS (O3)"
+    (let [[template _] (tmpl/resolve-template '*)
+          a  (tagged 'a0 'float)
+          b  (tagged 'b0 'float)
+          dy (tagged 'dy0 'float)
+          [ctx grad-syms] (tmpl/instantiate-template-ctx template [a b] nil dy (make-test-ctx))
+          pairs (partition 2 (:bindings ctx))]
+      (is (= '[float float] (mapv tag-of grad-syms))
+          "gradient binding LHS carries Π(primal arg tag)")
+      (is (every? (fn [[s _]] (= 'float (tag-of s))) pairs))
+      (doseq [[_ rhs] pairs]
+        (is (= '.invk (first rhs))
+            "fully-tagged backward call devirtualizes at emission")
+        (is (.contains (name (second rhs)) "_m_float_float")
+            "resolved to the FLOAT specialization, not a widened double"))))
+
+  (testing "static :grads alias bindings get Π-tagged LHS"
+    ;; '+ grads are [dy dy] — plain symbol RHS, so only the LHS tag applies.
+    (let [[template _] (tmpl/resolve-template '+)
+          x  (tagged 'x0 'doubles)
+          y  (tagged 'y0 'doubles)
+          dy (tagged 'dy0 'doubles)
+          [_ grad-syms] (tmpl/instantiate-template-ctx template [x y] nil dy (make-test-ctx))]
+      (is (= '[doubles doubles] (mapv tag-of grad-syms)))))
+
+  (testing "unresolvable-but-tagged emission stamps the call form itself"
+    ;; min/max emit (if (<= ...) dy 0.0) — no deftm call to resolve, but the
+    ;; grad binding carries Π and the census/downstream read the LHS tag.
+    (let [[template _] (tmpl/resolve-template 'Math/min)
+          x  (tagged 'x0 'double)
+          y  (tagged 'y0 'double)
+          dy (tagged 'dy0 'double)
+          [ctx grad-syms] (tmpl/instantiate-template-ctx template [x y] nil dy (make-test-ctx))
+          pairs (partition 2 (:bindings ctx))]
+      (is (= '[double double] (mapv tag-of grad-syms)))
+      (doseq [[s rhs] pairs]
+        (is (= 'if (first rhs)))
+        (is (= (tag-of s) (tag-of rhs))
+            "emitted (non-deftm) call form carries the binding's tag"))))
+
+  (testing "mixed known/⊥ primal args: only differentiable slots are tagged"
+    ;; aget: (arr idx) — d_arr gets Π(floats)=floats, idx slot grad is nil.
+    (let [[template _] (tmpl/resolve-template 'clojure.core/aget)
+          arr (tagged 'arr0 'floats)
+          [_ grad-syms] (tmpl/instantiate-template-ctx template [arr 'i0] nil (tagged 'dy0 'float) (make-test-ctx))]
+      (is (= 'floats (tag-of (first grad-syms))))
+      (is (nil? (second grad-syms))))))
+
+;; ================================================================
+;; (iii) untagged primal → byte-identical emission (no guessing)
+;; ================================================================
+
+(deftest untagged-emission-unchanged-test
+  (testing "scalar * with untagged args: exact pre-change bindings, no metadata"
+    (let [[template _] (tmpl/resolve-template '*)
+          [ctx grad-syms] (tmpl/instantiate-template-ctx template '[a0 b0] nil 'dy0 (make-test-ctx))]
+      (is (= '[dg_x__1 (raster.numeric/* dy0 b0)
+               dg_y__2 (raster.numeric/* dy0 a0)]
+             (:bindings ctx))
+          "untagged emission is byte-identical (symbolic, undevirtualized)")
+      (is (every? #(nil? (tag-of %)) grad-syms))
+      (is (every? #(nil? (tag-of %)) (:bindings ctx))
+          "no :raster.type/tag invented anywhere — LHS or RHS")))
+
+  (testing "min with untagged args: exact pre-change if-form"
+    (let [[template _] (tmpl/resolve-template 'Math/min)
+          [ctx _] (tmpl/instantiate-template-ctx template '[x0 y0] nil 'dy0 (make-test-ctx))]
+      (is (= '[dg_x__1 (if (clojure.core/<= (double x0) (double y0)) dy0 0.0)
+               dg_y__2 (if (clojure.core/<= (double x0) (double y0)) 0.0 dy0)]
+             (:bindings ctx)))
+      (is (every? #(nil? (tag-of %)) (:bindings ctx)))))
+
+  (testing "partially tagged args do NOT resolve the call (all-or-nothing)"
+    ;; dy tagged, b0 untagged → (raster.numeric/* dy0 b0) must stay symbolic.
+    (let [[template _] (tmpl/resolve-template '*)
+          dy (tagged 'dy0 'double)
+          [ctx grad-syms] (tmpl/instantiate-template-ctx template ['a0 'b0] nil dy (make-test-ctx))]
+      (is (= '[dg_x__1 (raster.numeric/* dy0 b0)
+               dg_y__2 (raster.numeric/* dy0 a0)]
+             (:bindings ctx))
+          "a call with ANY unknown arg tag stays symbolic")
+      (is (every? #(nil? (tag-of %)) grad-syms)
+          "Π of an absent primal tag is nil — LHS stays untagged"))))

--- a/test/raster/compiler/core/dispatch_test.clj
+++ b/test/raster/compiler/core/dispatch_test.clj
@@ -214,3 +214,67 @@
     (is (true? (dispatch/assignable-from? Object String)))
     (is (not (dispatch/assignable-from? Double String))
         "Double is not assignable from String")))
+
+;; ================================================================
+;; Signature-derived result typing (tag-level)
+;; ================================================================
+
+(deftest signature-result-tag-test
+  ;; Register synthetic (All [T]) templates so the test is self-contained
+  ;; (no dl.nn dependency). Shapes mirror the real facet-registered ops.
+  (testing "array-in/array-out (residual-add shape) — element tag preserved"
+    (dispatch/register-parametric!
+     'raster.numeric/sigtest-resid '[T]
+     '[(Array T) (Array T) Long] '(Array T)
+     '[a b n] nil *ns*)
+    ;; float and double both derive purely from the arg tags — no hard-coding
+    (is (= 'floats  (dispatch/signature-result-tag
+                     'raster.numeric/sigtest-resid '[floats floats long])))
+    (is (= 'doubles (dispatch/signature-result-tag
+                     'raster.numeric/sigtest-resid '[doubles doubles long]))))
+
+  (testing "bare-T return (residual-add-backward-style scalar out)"
+    (dispatch/register-parametric!
+     'raster.numeric/sigtest-scalar '[T]
+     '[(Array T) Long] 'T
+     '[dy n] nil *ns*)
+    (is (= 'float  (dispatch/signature-result-tag
+                    'raster.numeric/sigtest-scalar '[floats long])))
+    (is (= 'double (dispatch/signature-result-tag
+                    'raster.numeric/sigtest-scalar '[doubles long]))))
+
+  (testing "multiple type variables — return follows the SECOND var"
+    (dispatch/register-parametric!
+     'raster.numeric/sigtest-multi '[T U]
+     '[(Array T) (Array U)] '(Array U)
+     '[a b] nil *ns*)
+    (is (= 'doubles (dispatch/signature-result-tag
+                     'raster.numeric/sigtest-multi '[floats doubles])))
+    (is (= 'floats  (dispatch/signature-result-tag
+                     'raster.numeric/sigtest-multi '[doubles floats]))))
+
+  (testing "concrete-param consistency — Long param must match arg tag"
+    (dispatch/register-parametric!
+     'raster.numeric/sigtest-consistent '[T]
+     '[(Array T) Long] '(Array T)
+     '[a n] nil *ns*)
+    ;; consistent: Long param vs 'long arg → resolves
+    (is (= 'floats (dispatch/signature-result-tag
+                    'raster.numeric/sigtest-consistent '[floats long])))
+    ;; inconsistent: Long param vs 'double arg → nil (facet fallback speaks)
+    (is (nil? (dispatch/signature-result-tag
+               'raster.numeric/sigtest-consistent '[floats double]))))
+
+  (testing "nil / underdetermined → nil"
+    ;; no template registered for this op
+    (is (nil? (dispatch/signature-result-tag
+               'raster.numeric/sigtest-unregistered '[floats long])))
+    ;; nil arg tag underdetermines T
+    (is (nil? (dispatch/signature-result-tag
+               'raster.numeric/sigtest-resid '[nil floats long])))
+    ;; arity mismatch → no matching template
+    (is (nil? (dispatch/signature-result-tag
+               'raster.numeric/sigtest-resid '[floats])))
+    ;; non-array arg against (Array T) → cannot bind T → nil
+    (is (nil? (dispatch/signature-result-tag
+               'raster.numeric/sigtest-resid '[float floats long])))))

--- a/test/raster/dl/backward_kernel_resident_test.clj
+++ b/test/raster/dl/backward_kernel_resident_test.clj
@@ -290,6 +290,70 @@
       (is (:resident? (get grads 'x))
           "full attention-block grad(x) must extract FULLY RESIDENT"))))
 
+;; ── B2 MILESTONE: RESIDUAL-connection fan-out value+grad, FULLY RESIDENT ──────────
+;; A real decoder layer has RESIDUAL connections (the attention block above has none):
+;; a value `x1 = residual-add(x, m)` feeds BOTH the next `residual-add(x1, o)` AND
+;; `rms-norm(x1)` (fan-out), so its cotangent is `d_x1 = grad-acc(d_z, dx)` — a
+;; multi-contribution ARRAY accumulation. Before B2 this fell back to the nil-safe
+;; `grad-acc` (no GPU kernel) → :unlowered-array-op → non-resident. B2 makes it fold
+;; via the resident `residual-add`. THREE things had to line up:
+;;   1. `residual-add` is kept SYMBOLIC in the walk (lowers via broadcast SOAC), so its
+;;      result sym was UNTAGGED — the reverse-AD reroute gates on an :array sym-tag and
+;;      never fired. Fixed by a :result-type facet (raster.dl.nn) + the walker's
+;;      bare-symbolic-call arm + the let-binder reading the init's stamped tag.
+;;   2. The residual contribution `d_z` is a bare SYMBOL ALIAS: mse-loss binds
+;;      `d_pred = (mse-grad …)`, residual-add's IDENTITY-grad passthrough forwards that
+;;      adjoint SYMBOL to both input slots, and `sum-contribs` aliases a single
+;;      contribution to itself — so `d_z → d_pred → (mse-grad …)`, two symbol hops
+;;      before the kernel. `provably-non-nil-contrib?` now FOLLOWS pure symbol aliases
+;;      through the SSA binding-map to their non-nil kernel source (nil-safety intact:
+;;      any hop through grad-acc/nth/if/nil is still rejected → keeps nil-safe grad-acc).
+;;   3. The differentiated input `x` ALSO fans out (linear-nb ∘ residual), exercising
+;;      the param-adjoint reroute path too.
+;; grad(x) and grad(W1) must extract FULLY RESIDENT and match CPU. This is the B2
+;; regression pin (the grad-acc→residual-add reroute over aliases + the symbolic-op tag).
+(deftm resblk-parity-loss
+  [x :- (Array float) wn :- (Array float) W1 :- (Array float)
+   pn :- (Array float) W2 :- (Array float) tgt :- (Array float)
+   rows :- Long d :- Long eps :- Double go :- Double] :- Double
+  (let [n  (clojure.core/* rows d)
+        h  (raster.dl.nn/rms-norm x wn rows d eps go)
+        m  (raster.dl.nn/linear-nb h W1 rows d d)
+        x1 (raster.dl.nn/residual-add x m n)       ;; x1 FANS OUT ↓↓
+        h2 (raster.dl.nn/rms-norm x1 pn rows d eps go)
+        o  (raster.dl.nn/linear-nb h2 W2 rows d d)
+        z  (raster.dl.nn/residual-add x1 o n)]
+    (raster.dl.loss/mse-loss z tgt n)))
+
+(deftest resblk-value+grad-resident-parity
+  (if-not @gp/gpu-available?
+    (println "  [SKIP] resblk (residual fan-out) resident parity: no Level Zero GPU")
+    (let [rows 4 d 16 eps 1e-6 go 1.0
+          x  (fa (* rows d) 51) wn (fa d 52) W1 (fa (* d d) 53)
+          pn (fa d 54) W2 (fa (* d d) 55) tgt (fa (* rows d) 56)
+          {:keys [grads]}
+          (gp/grad-parity #'resblk-parity-loss
+                          [{:name 'x :type '(Array float) :val x}
+                           {:name 'wn :type '(Array float) :val wn}
+                           {:name 'W1 :type '(Array float) :val W1}
+                           {:name 'pn :type '(Array float) :val pn}
+                           {:name 'W2 :type '(Array float) :val W2}
+                           {:name 'tgt :type '(Array float) :val tgt}
+                           {:name 'rows :type 'Long :val rows}
+                           {:name 'd :type 'Long :val d}
+                           {:name 'eps :type 'Double :val eps}
+                           {:name 'go :type 'Double :val go}]
+                          ;; grad(x) is the B2 target: x FANS OUT (residual-add ∘
+                          ;; rms-norm) AND x1 = residual-add(x,m) fans out again — the
+                          ;; whole reroute-over-aliases + symbolic-op-tag chain. It
+                          ;; extracts resident and matches the CPU reference at ~5e-4.
+                          :grad-args '[x]
+                          :rtol 3.0e-2)]
+      (println "  [resblk] grad(x) steps:" (:step-kinds (get grads 'x))
+               "rel-err" (:rel-err (get grads 'x)))
+      (is (:resident? (get grads 'x))
+          "residual fan-out grad(x) must extract FULLY RESIDENT"))))
+
 (deftest rope-value+grad-resident-parity
   (if-not @gp/gpu-available?
     (println "  [SKIP] rope resident parity: no Level Zero GPU")


### PR DESCRIPTION
## What

Makes type tags an emission-time property of the AD transform instead of a re-derived afterthought, per the staged plan in \`.internal/ad_typed_emission_plan.md\` (gitignored working doc).

**Step 1 — signature-derived result typing** (926c388): \`signature-result-tag\` unifies an op's \`(All [T])\` signature against arg tags as the primary result-typer; \`:result-type\` facets remain the lenient fallback (they are load-bearing for nil-tagged args — verified empirically). Pinned safety property: any nil arg tag ⇒ nil (no guessing).

**Step 2** (643603d): delete the one provably redundant facet (canonical \`raster.par/reduce\`).

**B2 — residual fan-out resident** (02f4d3b): \`provably-non-nil-contrib?\` follows pure SSA aliases, so residual-connection \`grad-acc\` fan-outs fold to resident \`residual-add\`.

**Phase 0 — instrumentation** (f09be4c): tag-completeness census at the fixpoint edge (\`pipeline/fixpoint-census\`, per-iteration + final, classified by RHS head); \`canonicalize-ad-form\` fail-loud via the previously-orphaned ADTransformed dialect validator.

**Phase 1 — Π emit-time tagging** (eda8873, bfa218f, 44ac48f, e1ce127):
- \`tangent-tag\` (Π) in tangent.clj — the tangent-algebra projection from \`ad_formal_framework.md\` §5
- tag-capable BindCtx gensym (all providers canonicalized to the two-arity contract)
- template grads-fn emissions stamp Π-derived tags on gradient bindings/calls and **devirtualize backward calls at emission** when every arg tag is known (deterministic on first compile); untagged emissions stay byte-identical (no-guessing property pinned by test)
- the dead \`try-resolve-call-with-tags\`/\`:arg-tags\` machinery replaced by a live, sound path (the old dominant-tag heuristic guessed one tag for all args)
- bytecode emitter reads carried \`:raster.type/tag\` and neutralizes a pre-existing empty-symbol-tag poison (inference.clj ctor-arm misfire on host dot forms → \`:verified\` local without checkcast → VerifyError; emitter-side fix here, inference-side follow-up filed)

## Results

- Full Valhalla suite: **1797 tests / 31186 assertions / 0 failures / 0 errors**
- gqa attention-block resident compile: census 39→22 untagged (all exempt classes), parity 3.3e-7 unchanged
- **Gemma-block acceptance (finetune-side): the ~30-undevirtualized-cotangent wall is gone** — census shows 1 surviving undevirt (\`tangent/project-double\`, needs GPU lowering) and only exempt-class untagged bindings. The next gemma-residency blocker is now the pre-existing SOAC horizontal-fusion forward-ref (\`hfuse_out__N\` out of scope at extraction) — separate work.

## Follow-ups (tracked in the plan doc)

- 1d: ~46 \`:grads-fn\` sites outside templates.clj adopt the tagged gensym arity
- inference.clj:1937 ctor-arm empty-symbol-tag misfire
- Phase 2: flip the fixpoint-edge check to throw (GPU) once census-zero, then re-run assert-then-delete on the compensations — soundly this time
- hfuse forward-ref extraction bug (gemma GPU residency front blocker)