### PR TITLE
Gemma-block GPU residency: fusion/extraction fixes, typed-emission completion (1d), Phase-2 enforced typedness, :gemm-precision policy

### DIFF
--- a/src/raster/ad/fixed_point.clj
+++ b/src/raster/ad/fixed_point.clj
@@ -74,7 +74,7 @@
 (tmpl/merge-into-template! 'raster.ad.fixed-point/fixed-point-solve
                            {:params '[g z0 theta tol maxiter] :result 'z-star :adjoint 'v
                             :grads-fn (fn [ctx [g z0 theta tol maxiter] result-sym adjoint-sym gensym-fn]
-                                        (let [d-theta (gensym-fn "d_theta")]
+                                        (let [d-theta (gensym-fn "d_theta" (tmpl/grad-tag theta))]
                                           [(update ctx :bindings into
                                                    [d-theta (list 'raster.ad.fixed-point/fixed-point-backward
                                                                   g result-sym theta adjoint-sym)])

--- a/src/raster/ad/reverse.clj
+++ b/src/raster/ad/reverse.clj
@@ -77,11 +77,21 @@
 ;; corpus is clean.
 (def ^:private default-tag-warn-seen (atom #{}))
 
+(def default-tag-fire-counts
+  "Phase-2 (plan D2) instrumentation: TOTAL warn-default-tag! activations by site
+  keyword — every fire counts, unlike the printed warning (dedup'd by
+  [site binding]). The assert-then-delete audit reads this after a full-suite run:
+  a site with count 0 is provably dead and becomes a fail-loud throw; a site that
+  still fires marks an upstream forward-path tag loss to fix at its source."
+  (atom {}))
+
 (defn- warn-default-tag!
   "Emit a dedup'd LOST-TAG warning to *err* when a reverse-AD codegen site falls
   back to `default-tag` because the primal binding carries no :raster.type/tag.
-  Keyed by [site binding]. Returns `default-tag` unchanged (no behavior change)."
+  Keyed by [site binding]. Returns `default-tag` unchanged (no behavior change).
+  Every activation is counted in `default-tag-fire-counts` (undedup'd)."
   [site binding-hint default-tag]
+  (swap! default-tag-fire-counts update site (fnil inc 0))
   (let [k [site (str binding-hint)]]
     (when-not (contains? @default-tag-warn-seen k)
       (swap! default-tag-warn-seen conj k)
@@ -1716,7 +1726,7 @@
                           (warn-default-tag! :dotimes-out-arr (some-> written-arrs first name) 'doubles))
         out-elem-tag (case out-array-tag
                        doubles 'double, floats 'float, longs 'long, ints 'int,
-                       'double)
+                       (warn-default-tag! :dotimes-out-elem out-array-tag 'double))
         d-out-sym (ad-gensym "d_out" out-array-tag)
         iter-pb-sym (ad-gensym "iter_pb")
         d-val-sym (ad-gensym "d_val" out-elem-tag)
@@ -1940,7 +1950,7 @@
                           (warn-default-tag! :parmap-out-arr (some-> out-sym name) 'doubles))
         out-elem-tag (case out-array-tag
                        doubles 'double, floats 'float, longs 'long, ints 'int,
-                       'double)
+                       (warn-default-tag! :parmap-out-elem out-array-tag 'double))
         d-out-sym (ad-gensym "d_out" out-array-tag)
         bwd-idx-sym (ad-gensym "bi")
         iter-pb-sym (ad-gensym "iter_pb")

--- a/src/raster/ad/reverse.clj
+++ b/src/raster/ad/reverse.clj
@@ -67,39 +67,27 @@
        sym))))
 
 ;; ----------------------------------------------------------------
-;; Lost-tag instrumentation (diagnostic-first; task #58 phase-1b).
-;; The raw-loop reverse-AD codegen defaults an untagged cotangent's shadow
-;; array/scalar to 'doubles/'double (silently narrowing f32 → f64: the [F/[D
-;; ClassCast + F5 GPU under-devirtualization root). Until the enumeration of
-;; lost-tag sites is clean these sites WARN (dedup'd to *err*, keyed by
-;; [site binding]) instead of throwing, so the full corpus can be collected
-;; without behavior change. Flip to fail-loud (tangent/zero-expr) only once the
-;; corpus is clean.
-(def ^:private default-tag-warn-seen (atom #{}))
-
-(def default-tag-fire-counts
-  "Phase-2 (plan D2) instrumentation: TOTAL warn-default-tag! activations by site
-  keyword — every fire counts, unlike the printed warning (dedup'd by
-  [site binding]). The assert-then-delete audit reads this after a full-suite run:
-  a site with count 0 is provably dead and becomes a fail-loud throw; a site that
-  still fires marks an upstream forward-path tag loss to fix at its source."
-  (atom {}))
-
-(defn- warn-default-tag!
-  "Emit a dedup'd LOST-TAG warning to *err* when a reverse-AD codegen site falls
-  back to `default-tag` because the primal binding carries no :raster.type/tag.
-  Keyed by [site binding]. Returns `default-tag` unchanged (no behavior change).
-  Every activation is counted in `default-tag-fire-counts` (undedup'd)."
-  [site binding-hint default-tag]
-  (swap! default-tag-fire-counts update site (fnil inc 0))
-  (let [k [site (str binding-hint)]]
-    (when-not (contains? @default-tag-warn-seen k)
-      (swap! default-tag-warn-seen conj k)
-      (binding [*out* *err*]
-        (println (str "[ad.reverse LOST-TAG default] site=" site
-                      " binding=" binding-hint " -> default " default-tag
-                      " (primal has no :raster.type/tag)"))))
-    default-tag))
+;; Lost-tag enforcement (plan Phase 2 / D2, .internal/ad_typed_emission_plan.md).
+;; These sites used to default an untagged cotangent's shadow array/scalar to
+;; 'doubles/'double (silently narrowing f32 → f64: the [F/[D ClassCast + F5 GPU
+;; under-devirtualization root), warn-first while the lost-tag corpus was
+;; collected. The instrumented full-suite run (2026-07-11, 1804 tests /
+;; 31230 assertions, fresh JVM incl. all resident GPU compiles) measured
+;; ZERO activations at every site — under the Phase-1 Π emission invariant
+;; the primal tag is always present, so the defaults are provably dead and
+;; now FAIL LOUD instead: a fire means an upstream forward-path tag loss that
+;; must be fixed at its source (walker/inference), never papered over in AD.
+(defn- lost-tag!
+  "Fail-loud replacement for the retired warn-default-tag! 'doubles/'double
+  default sites: a reverse-AD codegen site needed the primal binding's
+  :raster.type/tag and it is absent."
+  [site binding-hint]
+  (throw (ex-info (str "reverse-AD lost tag at " site " (binding " binding-hint
+                       "): primal carries no :raster.type/tag. This default site "
+                       "was retired (Π emission invariant, plan D2) — fix the "
+                       "upstream forward-path tag loss; do not re-add a silent "
+                       "'doubles/'double default (f32→f64 narrowing hazard).")
+                  {:site site :binding (str binding-hint)})))
 
 (defmacro ^:private with-ad-gensym
   "Ensure *gensym-counter* is bound. If already bound (non-nil), inherit it;
@@ -1706,27 +1694,27 @@
 
         ;; === Backward code ===
         ;; For each read array: shadow array d_arr — tag matches source array's
-        ;; element type (inherits :raster.type/tag if present; defaults to doubles).
+        ;; element type (inherits :raster.type/tag; absent tag fails loud — plan D2).
         d-read-arr-syms (mapv (fn [arr]
                                 (ad-gensym (str "d_" (name arr))
                                            (or (:raster.type/tag (meta arr))
-                                               (warn-default-tag! :dotimes-read-arr (name arr) 'doubles))))
+                                               (lost-tag! :dotimes-read-arr (name arr)))))
                               read-arrs)
         d-scalar-syms (mapv (fn [p]
                               (ad-gensym (str "d_" (name p) "_acc")
                                          (or (:raster.type/tag (meta p))
-                                             (warn-default-tag! :dotimes-scalar (name p) 'double))))
+                                             (lost-tag! :dotimes-scalar (name p)))))
                             active-free)
 
         ;; Backward loop: reads d_out, calls pullbacks, accumulates
         ;; d-out-sym is the gradient of the output array — bound by gen-reverse-let
         ;; from adj-env contributions. Tag inherits from the output array type
-        ;; (defaults to doubles, the dominant case for raster training).
+        ;; (absent tag fails loud — plan D2).
         out-array-tag (or (some-> written-arrs first meta :raster.type/tag)
-                          (warn-default-tag! :dotimes-out-arr (some-> written-arrs first name) 'doubles))
+                          (lost-tag! :dotimes-out-arr (some-> written-arrs first name)))
         out-elem-tag (case out-array-tag
                        doubles 'double, floats 'float, longs 'long, ints 'int,
-                       (warn-default-tag! :dotimes-out-elem out-array-tag 'double))
+                       (lost-tag! :dotimes-out-elem out-array-tag))
         d-out-sym (ad-gensym "d_out" out-array-tag)
         iter-pb-sym (ad-gensym "iter_pb")
         d-val-sym (ad-gensym "d_val" out-elem-tag)
@@ -1939,18 +1927,18 @@
         d-read-arr-syms (mapv (fn [arr]
                                 (ad-gensym (str "d_" (name arr))
                                            (or (:raster.type/tag (meta arr))
-                                               (warn-default-tag! :parmap-read-arr (name arr) 'doubles))))
+                                               (lost-tag! :parmap-read-arr (name arr)))))
                               read-arrs)
         d-scalar-syms (mapv (fn [p]
                               (ad-gensym (str "d_" (name p) "_acc")
                                          (or (:raster.type/tag (meta p))
-                                             (warn-default-tag! :parmap-scalar (name p) 'double))))
+                                             (lost-tag! :parmap-scalar (name p)))))
                             active-free)
         out-array-tag (or (some-> out-sym meta :raster.type/tag)
-                          (warn-default-tag! :parmap-out-arr (some-> out-sym name) 'doubles))
+                          (lost-tag! :parmap-out-arr (some-> out-sym name)))
         out-elem-tag (case out-array-tag
                        doubles 'double, floats 'float, longs 'long, ints 'int,
-                       (warn-default-tag! :parmap-out-elem out-array-tag 'double))
+                       (lost-tag! :parmap-out-elem out-array-tag))
         d-out-sym (ad-gensym "d_out" out-array-tag)
         bwd-idx-sym (ad-gensym "bi")
         iter-pb-sym (ad-gensym "iter_pb")
@@ -2375,12 +2363,12 @@
 
         ;; === Backward code ===
         out-array-tag (or (some-> out-sym meta :raster.type/tag)
-                          (warn-default-tag! :carry-out-arr (some-> out-sym name) 'doubles))
+                          (lost-tag! :carry-out-arr (some-> out-sym name)))
         d-out-sym (ad-gensym "d_out" out-array-tag)
         d-read-arr-syms (mapv (fn [arr]
                                 (ad-gensym (str "d_" (name arr))
                                            (or (:raster.type/tag (meta arr))
-                                               (warn-default-tag! :carry-read-arr (name arr) 'doubles))))
+                                               (lost-tag! :carry-read-arr (name arr)))))
                               read-arrs)
         arr->d-sym (zipmap read-arrs d-read-arr-syms)
         d-scalar-syms (mapv (fn [p] (ad-gensym (str "d_" (name p) "_acc"))) active-free)

--- a/src/raster/ad/tangent.clj
+++ b/src/raster/ad/tangent.clj
@@ -127,15 +127,53 @@
                                (class x))
                           {:class (class x)}))))
 
+(defn- expr-manifest-tag
+  "The statically KNOWN scalar tag of an IR expression — carried or manifest,
+  never inferred: a symbol's/form's carried :raster.type/tag stamp, the head
+  of an explicit float/double cast form, or a numeric literal's own type.
+  nil when the expression's type is not statically known."
+  [expr]
+  (cond
+    (or (symbol? expr) (seq? expr))
+    (or (:raster.type/tag (meta expr))
+        (when (and (seq? expr)
+                   (contains? #{'float 'clojure.core/float} (first expr)))
+          'float)
+        (when (and (seq? expr)
+                   (contains? #{'double 'clojure.core/double} (first expr)))
+          'double))
+    (float? expr) 'double  ;; a bare Clojure literal like 0.0 is a double
+    :else nil))
+
 (defn project-expr
   "Wrap `cotangent-expr` with the projection onto the tangent space of the
-  primal `tag` (Π_x), when the dtypes could mismatch. Scalars get a
-  nil-safe cast call; arrays and unknown tags pass through unchanged
-  (array adjoints are anchored by their typed shadow buffers)."
+  primal `tag` (Π_x), when the dtypes could mismatch.
+
+  Emission is TYPED IR whenever the cotangent's type is statically known
+  (carried tag / manifest cast / literal): same dtype → identity (no wrap),
+  different scalar dtype → a bare primitive cast, which devirtualizes to a
+  zero-cost intrinsic on every backend. A statically-typed cotangent is a
+  materialized typed value — never the runtime nil 0̄ — so the nil-safe
+  runtime helpers (project-double/project-float) are emitted ONLY for
+  UNTAGGED cotangents (the dynamic/interpreted path, where nil can flow).
+  Arrays and unknown primal tags pass through unchanged (array adjoints are
+  anchored by their typed shadow buffers)."
   [tag cotangent-expr]
   (let [{:keys [kind dtype]} (tangent-kind tag)]
     (if (= kind :scalar)
-      (case dtype
-        :float  (list 'raster.ad.tangent/project-float cotangent-expr)
-        :double (list 'raster.ad.tangent/project-double cotangent-expr))
+      (let [ct (tangent-kind (expr-manifest-tag cotangent-expr))]
+        (cond
+          ;; Statically in the primal's tangent space already — Π is the identity.
+          (and (= :scalar (:kind ct)) (= dtype (:dtype ct)))
+          cotangent-expr
+          ;; Statically scalar of the other dtype — Π is a primitive cast.
+          (= :scalar (:kind ct))
+          (let [cast-tag (case dtype :float 'float :double 'double)]
+            (with-meta (list cast-tag cotangent-expr)
+              {:raster.type/tag cast-tag}))
+          ;; Untagged — the runtime nil-safe projection (dynamic 0̄ may flow).
+          :else
+          (case dtype
+            :float  (list 'raster.ad.tangent/project-float cotangent-expr)
+            :double (list 'raster.ad.tangent/project-double cotangent-expr))))
       cotangent-expr)))

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -9,11 +9,23 @@
    par form vocabulary but produce different target code."
   (:require [raster.compiler.ir.par :as par]
             [raster.compiler.ir.soac]
+            [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.passes.parallel.soac-lower]
             [raster.compiler.backend.gpu.segop-opencl :as segop-cl]
             [raster.compiler.backend.gpu.par-opencl :as legacy]
             [raster.compiler.support.spirv-cache :as spirv-cache]
             [raster.runtime.hardware :as hw]))
+
+;; Buffer semantics of the emitted kernel-invoke marker: invoke-registered-kernel
+;; WRITES its `out` arg in place (arg 2 of [kname inputs out scalars n]) and
+;; RETURNS it, so the binding sym is a pure alias of the out buffer. Declared in
+;; the registry (not pattern-matched in passes) so resolve-alength's call-through
+;; alias tracking resolves `(alength <invoke-binding>)` to the out buffer's alloc
+;; size — a shape horizontal fusion produces when a later map's bound reads the
+;; length of a fused map's result.
+(descriptor/register-op-descriptor!
+ 'raster.gpu.ze-runtime/invoke-registered-kernel
+ {:buffer {:allocates? false :in-place-arg 2}})
 
 ;; ================================================================
 ;; Single source of declared GPU param types (shared by BOTH compile entries:

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -56,13 +56,30 @@
         meta-types (ce/collect-array-types-from-meta body)
         array-types (merge meta-types array-types)
         kernel-name (str kernel-name-prefix "_" (gensym ""))
-        ;; Use pre-computed inputs/scalars from SegOp
-        arr-params (vec (sort-by name (:inputs segmap)))
+        ;; Use pre-computed inputs/outputs/scalars from SegOp.
+        ;; :outputs may carry SECONDARY outputs beyond `out-sym` — the side-effect
+        ;; aset targets of a horizontally-fused multi-output map. Those are array
+        ;; params too (declared NON-const, appended after the inputs so the invoke's
+        ;; positional arg order matches the C signature); an input that is also
+        ;; written (read+write buffer) likewise loses const.
+        written (set (map #(symbol (name %)) (:outputs segmap)))
+        input-params (vec (sort-by name (:inputs segmap)))
+        input-name-set (set (map #(symbol (name %)) input-params))
+        out-name (when out-sym (symbol (name out-sym)))
+        extra-outs (vec (sort-by name
+                                 (remove #(or (= % out-name)
+                                              (contains? input-name-set %))
+                                         written)))
+        arr-params (into input-params extra-outs)
         scl-params (vec (sort-by name (:scalars segmap)))
         arr-dtype (fn [s] (get array-types s (get array-types (symbol (name s)) dtype)))
         arr-type (fn [s] (get codegen/opencl-type-map (arr-dtype s) default-ctype))
+        written-params (filterv #(contains? written (symbol (name %))) arr-params)
         arr-param-str (str/join ", "
-                                (map (fn [s] (str "__global const " (arr-type s) "* restrict "
+                                (map (fn [s] (str "__global "
+                                                  (when-not (contains? written (symbol (name s)))
+                                                    "const ")
+                                                  (arr-type s) "* restrict "
                                                   (ce/c-symbol s)))
                                      arr-params))
         ;; Integer scalar params seed *int-vars* so index math stays integer
@@ -95,6 +112,10 @@
      :source source
      :array-params arr-params
      :scalar-params scl-params
+     ;; array params (by sig name) the kernel WRITES — secondary fused outputs and
+     ;; read+write inputs. The staging invoke copies these back to their JVM arrays
+     ;; after launch; the resident role-derivation marks written PARAMS :output.
+     :written-arrays written-params
      :out-param out-param
      :dtype out-dtype}))
 

--- a/src/raster/compiler/core/inference.clj
+++ b/src/raster/compiler/core/inference.clj
@@ -1934,7 +1934,19 @@
                 (empty? arg-tags) nil
                 :else 'long))
             (= 'new head) (when-let [cls-sym (second expr)] (symbol (str cls-sym)))
-            (and (symbol? head) (.endsWith (name head) "."))
+            ;; Constructor sugar (ClassName. args) → the class name. The guard
+            ;; must EXCLUDE the degenerate dot heads that also end in ".":
+            ;; the host dot special form `.` itself (stripping it yields the
+            ;; EMPTY symbol — tag poison the bytecode emitter once trusted as
+            ;; :verified → VerifyError) and `..`/`...`-style member-access
+            ;; heads (stripping yields "."/".." — equally meaningless as a
+            ;; class tag). A real constructor head has a non-"." class name
+            ;; before the trailing dot, so require length>1 and no leading dot.
+            (and (symbol? head)
+                 (let [nm (name head)]
+                   (and (> (count nm) 1)
+                        (.endsWith nm ".")
+                        (not (.startsWith nm ".")))))
             (symbol (subs (name head) 0 (dec (count (name head)))))
             (and (symbol? head) (namespace head))
             (try

--- a/src/raster/compiler/core/op_descriptor.clj
+++ b/src/raster/compiler/core/op_descriptor.clj
@@ -827,19 +827,27 @@
       ;; a fixed result tag symbol
       (symbol? rule)                 rule)))
 
-;; oftype coerces its value to the ELEMENT type of its ref (first arg): a float
-;; at :float (ref a float[]), a double at :double. The registry rule lets the
-;; walker and late inference stamp oftype-seeded scalars (reduction seeds, an
-;; attention scale) without per-op arms in either.
-(register-result-type! 'raster.numeric/oftype :element-of-first-arg)
-
-;; grad-acc (reverse-AD nil-safe +) returns the type of its (first typed) arg.
-(register-result-type! 'raster.ad.reverse/grad-acc :first-typed-arg)
+;; DELETED (plan D2 assert-then-delete audit, 2026-07-11):
+;;   - 'raster.numeric/oftype :element-of-first-arg — oftype-seeded scalars
+;;     (softmax neg-inf seeds, attention scales) are now tagged without the
+;;     facet: every resident attention/gqa/rms-norm/rope value+grad compile
+;;     passes COLD (fresh JVM) with the entry removed, as does the full suite.
+;;     (Historically the walker's oftype :element arm needed it; emission-time
+;;     tagging + TC stamps cover those sites today.)
+;;   - 'raster.ad.reverse/grad-acc :first-typed-arg — grad-acc adjoint bindings
+;;     are tagged at their mint site (Π tagged gensym) and the GPU fan-out path
+;;     reroutes grad-acc to residual-add before the fixpoint edge; resblk/hfuse/
+;;     attn-block cold + ODE/laws canaries + full suite green without it.
+;; The fixpoint-edge census throw (pipeline/record-fixpoint-census!) guards the
+;; invariant: if either becomes load-bearing again it resurfaces as a loud GPU
+;; compile error naming the untagged binding, not silent narrowing.
+;; NB raster.dl.nn/residual-add(+backward) :same-as-first-arg SURVIVED the same
+;; audit as LOAD-BEARING — see the comment at its registration in raster.dl.nn.
 
 ;; NOTE: ops defined in higher layers (raster.dl.*, raster.ad.*) register their own
 ;; :result-type facet from THEIR namespace (e.g. residual-add in raster.dl.nn), so
 ;; compiler core does not depend on those namespaces. Only compiler-owned ops belong
-;; here. `grad-acc` above is a borderline case kept for now (reverse-AD primitive).
+;; here.
 
 ;; par/reduce returns its accumulator type — arg 1, the init value. The CANONICAL
 ;; spelling `raster.par/reduce` is typed independently by form-info's

--- a/src/raster/compiler/ir/par.clj
+++ b/src/raster/compiler/ir/par.clj
@@ -670,6 +670,30 @@
 
     :else #{}))
 
+(defn collect-aset-arrays
+  "Collect array symbols WRITTEN via aset in a body expression.
+  Returns a set of array symbols (stripped of metadata).
+
+  The write-side counterpart of collect-aget-arrays: recognizes bare
+  (clojure.core/aset arr idx v) / (raster.arrays/aset arr idx v) AND
+  devirtualized (.invk aset-impl arr idx v) via the carried :raster.op/original.
+  Used by SOAC io classification so an array a lambda writes (e.g. the
+  side-effect writes of a horizontally-fused multi-output map) is classified as
+  an array OUTPUT — never a scalar param."
+  [body-expr]
+  (cond
+    (descriptor/aset-call? body-expr)
+    (apply set/union #{(descriptor/aset-array-sym body-expr)}
+           (map collect-aset-arrays (descriptor/call-args body-expr)))
+
+    (seq? body-expr)
+    (apply set/union #{} (map collect-aset-arrays (rest body-expr)))
+
+    (vector? body-expr)
+    (apply set/union #{} (map collect-aset-arrays body-expr))
+
+    :else #{}))
+
 (defn extract-par-stencil-info
   "Extract structured info from a par/stencil! form.
   Returns {:out, :inputs, :radius, :boundary, :cast, :idx, :bound, :body} or nil."

--- a/src/raster/compiler/ir/soac.clj
+++ b/src/raster/compiler/ir/soac.clj
@@ -89,13 +89,22 @@
 (defn- extract-io
   "Extract inputs, outputs, and scalars from a SOAC lambda.
   inputs: array syms read via aget
-  outputs: the output array sym(s)
-  scalars: free syms minus inputs, outputs, idx, acc, and operators"
+  outputs: the output array sym(s) PLUS any array the lambda writes via aset
+  scalars: free syms minus inputs, outputs, idx, acc, and operators
+
+  INVARIANT: an array symbol written inside the lambda is an array OUTPUT of
+  the SOAC — never a scalar. The structural out slot alone is not enough: a
+  horizontally-fused multi-output map carries its secondary outputs only as
+  side-effect asets in the lambda body (soac->par-form flattens the fused node
+  to a single-out par/map!), so the write-side collection is what keeps them
+  classified as array params when the par form is re-parsed."
   [lambda idx-sym out-syms & {:keys [acc-sym]}]
   (let [inputs (collect-aget-arrays lambda)
+        written (par/collect-aset-arrays lambda)
         all-free (util/free-syms lambda)
         exclude (set/union inputs
                            (set out-syms)
+                           written
                            #{idx-sym}
                            (if acc-sym #{acc-sym} #{})
                            ;; Exclude common operators/literals that appear as symbols
@@ -103,7 +112,7 @@
                                       #{'do 'let 'let* 'if 'double 'float 'int 'long}))
         scalars (set/difference all-free exclude)]
     {:inputs inputs
-     :outputs (set out-syms)
+     :outputs (into (set out-syms) written)
      :scalars scalars}))
 
 ;; ================================================================

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -1463,8 +1463,25 @@
                         correct default: a caller that binds the result to a session graph would
                         otherwise silently record an EMPTY graph (all-zero output). See #42.
      :nil             — return nil, for probing callers that legitimately fall back to the
-                        compile-aot :target-device staging fn (e.g. the AD-GEMM boundary test)."
-  [f-var device-id & {:keys [dtype on-non-resident] :or {on-non-resident :throw}}]
+                        compile-aot :target-device staging fn (e.g. the AD-GEMM boundary test).
+
+   :gemm-precision sets the resident :gemm binding policy CARRIED on the descriptor
+   (bind-program! reads it; a bind-time caller may still override with
+   (assoc descriptor :gemm-precision …)):
+     :f16-xmx (default) — convert A/B f32→f16, XMX gemm, f32 C. Fast, but the f16 input
+                          conversion costs gradient precision (~1e-3-level composed-grad
+                          noise) — right for decode/inference.
+     :f32-scalar        — plain scalar f32 GEMM for ALL :gemm steps (reads f32 residents
+                          directly, no convert/transpose expansion). Exact f32 grads
+                          (~1e-6-level parity) — right for training.
+   No size heuristics; the XMX hardware pitch gate (n<8 or k<8 → scalar) applies in
+   bind-program! regardless of policy."
+  [f-var device-id & {:keys [dtype on-non-resident gemm-precision]
+                      :or {on-non-resident :throw gemm-precision :f16-xmx}}]
+  (when-not (contains? #{:f16-xmx :f32-scalar} gemm-precision)
+    (throw (ex-info (str "compile-gpu-program: unknown :gemm-precision " (pr-str gemm-precision)
+                         " (expected :f16-xmx or :f32-scalar)")
+                    {:gemm-precision gemm-precision})))
   (let [resolved-var (or (resolve-deftm-var f-var dtype) f-var)
         params       (get-params f-var dtype)
         walked-body  (get-walked-body f-var dtype)
@@ -1586,6 +1603,7 @@
                                     array-params)))]
     (when prog
       {:dtype effective-dtype
+       :gemm-precision gemm-precision
        :all-params all-params
        :array-params array-params
        :array-roles array-roles

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -388,16 +388,6 @@
   progress. One compile at a time assumed (plain atom, no per-compile key)."
   (atom []))
 
-(def fixpoint-finalize-divergence
-  "Phase-2 (plan D2) instrumentation: count of pass-fixpoint finalize-epilogue
-  activations where resolve-generic-deftm-calls actually CHANGED the re-tagged
-  form (i.e. the re-tag + re-expand epilogue was load-bearing, not a no-op).
-  Emission-time devirtualization (Phase 1c) may have obsoleted it — if this
-  stays 0 across a full suite + a fresh-JVM GPU resident compile, the epilogue
-  is provably dead and gets deleted. Each activation also prints a dedup-free
-  [pass-fixpoint finalize] line to *err* so the suite log is greppable."
-  (atom 0))
-
 (declare record-fixpoint-census!)
 
 (defn- pass-fixpoint
@@ -414,43 +404,24 @@
   Max 5 iterations to prevent divergence.
   (=> :* :fixpointed)"
   [form opts]
+  ;; NOTE (plan D2): the former GPU-determinism finalize epilogue (re-tag +
+  ;; resolve-generic-deftm-calls + re-expand at convergence, for cold-JVM
+  ;; AD-emitted generic calls) was DELETED after instrumentation proved it a
+  ;; no-op: 0 activations across the full fresh-JVM suite incl. every resident
+  ;; GPU compile (2026-07-11). Phase-1c emission-time devirtualization
+  ;; obsoleted it — AD-emitted calls now devirtualize at emission, so the
+  ;; resolver never found anything left to do. The fixpoint-edge census throw
+  ;; (record-fixpoint-census!) guards the invariant: a regression shows up as
+  ;; a loud GPU compile error here, not a first-compile-fails flake.
   (let [max-iters 5
         ;; Force simplify mode for the fixpoint — we always want normalize+rewalk
-        opts (assoc opts :simplify? true)
-        ;; GPU determinism epilogue (cold-compile inline gate). An AD-emitted generic
-        ;; parametric call (e.g. linear-dx from linear-nb's grads-fn) can survive the
-        ;; whole fixpoint UNdevirtualized when the incremental type env can't type an
-        ;; intermediate arg yet. On a FRESH JVM the later resolve-generic-deftm-calls
-        ;; (buffer-fuse/late-cleanup) then devirtualizes it to `.invk foo_m_floats…-impl`
-        ;; — creating the float specialization as a SIDE EFFECT — but that is AFTER the
-        ;; last inline pass, so the .invk survives to resident extraction and the first
-        ;; compile-gpu-program fails while the second succeeds. Run the same resolver
-        ;; HERE at convergence and, if it devirtualized anything, expand once more so
-        ;; the first compile inlines exactly like every later one. GPU-gated: CPU
-        ;; backends call .invk directly, so late devirtualization is sufficient there
-        ;; (and the shared-suite behavior stays untouched).
-        finalize (fn [current]
-                   (if-not (and (device/gpu-target? (:target-device opts))
-                                (form/binding-form? current))
-                     current
-                     ;; The resolver needs binding :tag metadata — the AD-emitted
-                     ;; bindings from THIS fixpoint don't carry it yet (late-cleanup
-                     ;; re-tags for the same reason before ITS resolve call).
-                     (let [tagged (tag-binding-types current (:param-env opts))
-                           resolved (inline/resolve-generic-deftm-calls
-                                     tagged (:param-env opts))]
-                       (if (= resolved tagged)
-                         current
-                         (do (swap! fixpoint-finalize-divergence inc)
-                             (binding [*out* *err*]
-                               (println "[pass-fixpoint finalize] resolve-generic-deftm-calls devirtualized at the fixpoint edge (epilogue LIVE)"))
-                             (inline/expand-for-backends resolved 3 (:param-env opts)))))))]
+        opts (assoc opts :simplify? true)]
     (reset! fixpoint-census [])
     (loop [current form
            iter 0
            total-stats {:fixpoint-iterations 0}]
       (if (>= iter max-iters)
-        (let [final (ensure-let*-result (finalize current))]
+        (let [final (ensure-let*-result current)]
           (record-fixpoint-census! :final final opts)
           {:form final :stats total-stats})
         (let [;; Step 1: Expand (inline deftm calls + value+grad AD inlining)
@@ -472,7 +443,7 @@
                            (if (map? rw-result) (:form rw-result) rw-result))
                          expanded)]
           (if (= rewalked current)
-            (let [final (ensure-let*-result (finalize current))]
+            (let [final (ensure-let*-result current)]
               (record-fixpoint-census! :final final opts)
               {:form final
                :stats (assoc total-stats :fixpoint-iterations iter)})

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -1350,7 +1350,17 @@
                 (vswap! device-buffers conj sym))
             (and (seq? expr) (symbol? (first expr)) (contains? gpu-invoke-heads (first expr)))
             (if-let [s (parse-gpu-step sym expr)]
-              (do (vswap! steps conj s) (vswap! device-buffers conj sym))
+              (do (vswap! steps conj s) (vswap! device-buffers conj sym)
+                  ;; A :map step's runtime VALUE is its out buffer (invoke-registered-kernel
+                  ;; returns output-array), so the binding sym is a pure alias of the out
+                  ;; array. Copy-propagate it like any other array alias — a later step
+                  ;; that reads the binding sym (e.g. the primary of a horizontally-fused
+                  ;; multi-output map, whose out is a fusion-materialized buffer) must
+                  ;; resolve to the REAL resident buffer at bind time.
+                  (when (= :map (:convention s))
+                    (let [out (last (:arrays s))]
+                      (when (and (symbol? out) (not= sym out))
+                        (vswap! aliases assoc sym out)))))
               (reject! :unparseable-kernel-invoke sym expr))
           ;; devirtualized BLAS GEMM (.invk dgemm*-impl …) → a :gemm step.
             (gemm-invk? expr)

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -388,6 +388,16 @@
   progress. One compile at a time assumed (plain atom, no per-compile key)."
   (atom []))
 
+(def fixpoint-finalize-divergence
+  "Phase-2 (plan D2) instrumentation: count of pass-fixpoint finalize-epilogue
+  activations where resolve-generic-deftm-calls actually CHANGED the re-tagged
+  form (i.e. the re-tag + re-expand epilogue was load-bearing, not a no-op).
+  Emission-time devirtualization (Phase 1c) may have obsoleted it — if this
+  stays 0 across a full suite + a fresh-JVM GPU resident compile, the epilogue
+  is provably dead and gets deleted. Each activation also prints a dedup-free
+  [pass-fixpoint finalize] line to *err* so the suite log is greppable."
+  (atom 0))
+
 (declare record-fixpoint-census!)
 
 (defn- pass-fixpoint
@@ -431,14 +441,17 @@
                                      tagged (:param-env opts))]
                        (if (= resolved tagged)
                          current
-                         (inline/expand-for-backends resolved 3 (:param-env opts))))))]
+                         (do (swap! fixpoint-finalize-divergence inc)
+                             (binding [*out* *err*]
+                               (println "[pass-fixpoint finalize] resolve-generic-deftm-calls devirtualized at the fixpoint edge (epilogue LIVE)"))
+                             (inline/expand-for-backends resolved 3 (:param-env opts)))))))]
     (reset! fixpoint-census [])
     (loop [current form
            iter 0
            total-stats {:fixpoint-iterations 0}]
       (if (>= iter max-iters)
         (let [final (ensure-let*-result (finalize current))]
-          (record-fixpoint-census! :final final)
+          (record-fixpoint-census! :final final opts)
           {:form final :stats total-stats})
         (let [;; Step 1: Expand (inline deftm calls + value+grad AD inlining)
               expanded (binding [inline/*ad-transform-body-fn* ad-reverse/transform-body]
@@ -460,11 +473,11 @@
                          expanded)]
           (if (= rewalked current)
             (let [final (ensure-let*-result (finalize current))]
-              (record-fixpoint-census! :final final)
+              (record-fixpoint-census! :final final opts)
               {:form final
                :stats (assoc total-stats :fixpoint-iterations iter)})
             (do
-              (record-fixpoint-census! iter rewalked)
+              (record-fixpoint-census! iter rewalked opts)
               (recur rewalked (inc iter)
                      (assoc total-stats :fixpoint-iterations (inc iter))))))))))
 
@@ -568,18 +581,88 @@
     (vector? e) :vector
     :else :atom))
 
+(def ^:private census-exempt-int-arith-heads
+  "clojure.core integer index/dim arithmetic heads — EXEMPT from the fixpoint-edge
+  typedness contract. By convention (CLAUDE.md) integer index/counter/dimension
+  arithmetic stays clojure.core (zero-cost ladd/lsub intrinsics on the JVM, +1/-1
+  in the GPU C emitter) and is never polymorphic float arithmetic, so an untagged
+  Long-arith binding needs no :raster.type/tag to lower correctly."
+  '#{clojure.core/* clojure.core/+ clojure.core/- clojure.core//
+     clojure.core/quot clojure.core/rem clojure.core/mod
+     clojure.core/inc clojure.core/dec})
+
+(defn- census-exempt-head?
+  "The fixpoint-edge typedness contract's EXEMPT classes (measured floor, plan
+  Phase 0/2 of .internal/ad_typed_emission_plan.md), keyed by census-rhs-head:
+
+    1. void-returning SOAC/effect STATEMENT bindings (raster.par/map-void!,
+       dotimes) — the binding exists only to sequence an effect; there is no
+       result VALUE to tag (the census's untagged-binding-pairs already excludes
+       fn* pullback closures and loop*/dotimes BINDERS for the same reason).
+    2. clojure.core integer scalar arithmetic on Long dims/indices — see
+       census-exempt-int-arith-heads.
+    3. :vector — an aggregate host result (the AD [primal grads] result vector);
+       a persistent vector carries no element dtype, so tag-typedness does not
+       apply to the binding.
+
+  Everything else (raster.dl/raster.nn kernels, .invk impls, raster.numeric
+  scalar math, aliases, constants) MUST carry :raster.type/tag at the fixpoint
+  edge."
+  [head]
+  (or (contains? '#{raster.par/map-void! par/map-void! dotimes} head)
+      (contains? census-exempt-int-arith-heads head)
+      (= :vector head)))
+
 (defn- record-fixpoint-census!
   "Append one tag-completeness entry to fixpoint-census (Phase 0 of
-  .internal/ad_typed_emission_plan.md)."
-  [label form]
+  .internal/ad_typed_emission_plan.md).
+
+  Phase 2 (D1) ENFORCEMENT: at the :final entry on a GPU target (the same
+  device/gpu-target? gate pass-late-cleanup's throw uses), typedness is an
+  invariant — any NON-EXEMPT untagged binding (see census-exempt-head?) or any
+  surviving undevirtualized raster.* dispatch call THROWS with op frequencies +
+  example forms. GPU cannot fall back to IFn.invoke, and a tag lost here is
+  guessed downstream (the f32→f64 narrowing hazard) — fail loud at the AD/
+  fixpoint edge instead. CPU targets keep the warn-only census line (printed
+  under *log-tag-census* / RASTER_TAG_CENSUS)."
+  [label form opts]
   (let [untagged (untagged-binding-pairs form)
         undevirt (collect-undevirtualized form)
+        non-exempt (remove (fn [[_ e]] (census-exempt-head? (census-rhs-head e))) untagged)
         entry {:label label
                :untagged-bindings (count untagged)
                :untagged-by-head (frequencies (map (comp census-rhs-head second) untagged))
+               :non-exempt-untagged (count non-exempt)
                :undevirtualized (count undevirt)
                :undevirtualized-ops (frequencies (map first undevirt))}]
     (swap! fixpoint-census conj entry)
+    (when (and (= label :final)
+               (device/gpu-target? (:target-device opts))
+               (or (seq non-exempt) (seq undevirt)))
+      (let [trunc (fn [f] (let [s (pr-str f)] (subs s 0 (min 200 (count s)))))
+            untagged-heads (frequencies (map (comp census-rhs-head second) non-exempt))
+            untagged-examples (mapv (fn [[s e]] (trunc (list s '= e))) (take 3 non-exempt))
+            undevirt-ops (frequencies (map first undevirt))
+            undevirt-examples (mapv trunc (take 3 (distinct undevirt)))]
+        (throw (ex-info (str "fixpoint edge typedness violation on GPU target: "
+                             (count non-exempt) " non-exempt untagged binding(s) "
+                             (pr-str untagged-heads)
+                             (when (seq untagged-examples)
+                               (str " e.g. " (pr-str untagged-examples)))
+                             "; " (count undevirt) " undevirtualized dispatch call(s) "
+                             (pr-str undevirt-ops)
+                             (when (seq undevirt-examples)
+                               (str " e.g. " (pr-str undevirt-examples)))
+                             ". Tags must be CARRIED from emission (Π), never guessed "
+                             "downstream — an untagged binding here narrows f32→f64 or "
+                             "miscompiles to GPU garbage. Fix the emission site (grads-fn "
+                             "tagged gensym / template Π) or the upstream forward-path tag "
+                             "loss; exempt classes are documented at census-exempt-head?.")
+                        {:non-exempt-untagged untagged-heads
+                         :untagged-examples untagged-examples
+                         :undevirtualized undevirt-ops
+                         :undevirtualized-examples undevirt-examples
+                         :target-device (:target-device opts)}))))
     (when (and (= label :final)
                (or *log-tag-census* (System/getenv "RASTER_TAG_CENSUS"))
                (or (pos? (:untagged-bindings entry))

--- a/src/raster/dl/array_ops.clj
+++ b/src/raster/dl/array_ops.clj
@@ -228,9 +228,9 @@
                             :params '[x seq-len n-heads head-dim]
                             :result nil :adjoint 'dy
                             :grads-fn
-                            (fn [ctx [_x seq-len n-heads head-dim]
+                            (fn [ctx [x seq-len n-heads head-dim]
                                  _result-sym adjoint-sym gensym-fn]
-                              (let [dx (gensym-fn "d_x")]
+                              (let [dx (gensym-fn "d_x" (tmpl/grad-tag x))]
                                 [(update ctx :bindings into
                                          [dx (list 'raster.dl.array-ops/unpack-heads
                                                    adjoint-sym seq-len n-heads head-dim)])
@@ -243,9 +243,9 @@
                             :params '[x seq-len n-heads head-dim]
                             :result nil :adjoint 'dy
                             :grads-fn
-                            (fn [ctx [_x seq-len n-heads head-dim]
+                            (fn [ctx [x seq-len n-heads head-dim]
                                  _result-sym adjoint-sym gensym-fn]
-                              (let [dx (gensym-fn "d_x")]
+                              (let [dx (gensym-fn "d_x" (tmpl/grad-tag x))]
                                 [(update ctx :bindings into
                                          [dx (list 'raster.dl.array-ops/pack-heads
                                                    adjoint-sym seq-len n-heads head-dim)])
@@ -322,8 +322,8 @@
                                 [(sum-kv-heads d-out n-kv group slab) nil nil nil]))
                             :params '[src n-kv group slab] :result nil :adjoint 'dy
                             :grads-fn
-                            (fn [ctx [_src n-kv group slab] _result-sym adjoint-sym gensym-fn]
-                              (let [d-src (gensym-fn "d_src")]
+                            (fn [ctx [src n-kv group slab] _result-sym adjoint-sym gensym-fn]
+                              (let [d-src (gensym-fn "d_src" (tmpl/grad-tag src))]
                                 [(update ctx :bindings into
                                          [d-src (list 'raster.dl.array-ops/sum-kv-heads
                                                       adjoint-sym n-kv group slab)])
@@ -335,8 +335,8 @@
                                 [(broadcast-kv-heads d-out n-kv group slab) nil nil nil]))
                             :params '[src n-kv group slab] :result nil :adjoint 'dy
                             :grads-fn
-                            (fn [ctx [_src n-kv group slab] _result-sym adjoint-sym gensym-fn]
-                              (let [d-src (gensym-fn "d_src")]
+                            (fn [ctx [src n-kv group slab] _result-sym adjoint-sym gensym-fn]
+                              (let [d-src (gensym-fn "d_src" (tmpl/grad-tag src))]
                                 [(update ctx :bindings into
                                          [d-src (list 'raster.dl.array-ops/broadcast-kv-heads
                                                       adjoint-sym n-kv group slab)])
@@ -350,9 +350,9 @@
                            {:params '[src rows row-stride col-offset n-cols]
                             :result nil :adjoint 'dy
                             :grads-fn
-                            (fn [ctx [_src rows row-stride col-offset n-cols]
+                            (fn [ctx [src rows row-stride col-offset n-cols]
                                  _result-sym adjoint-sym gensym-fn]
-                              (let [d-src (gensym-fn "d_src")]
+                              (let [d-src (gensym-fn "d_src" (tmpl/grad-tag src))]
                                 [(update ctx :bindings into
                                          [d-src (list 'raster.dl.array-ops/scatter-strided-2d
                                                       adjoint-sym rows row-stride col-offset n-cols)])
@@ -362,9 +362,9 @@
                            {:params '[packed rows row-stride col-offset n-cols]
                             :result nil :adjoint 'dy
                             :grads-fn
-                            (fn [ctx [_packed rows row-stride col-offset n-cols]
+                            (fn [ctx [packed rows row-stride col-offset n-cols]
                                  _result-sym adjoint-sym gensym-fn]
-                              (let [d-packed (gensym-fn "d_packed")]
+                              (let [d-packed (gensym-fn "d_packed" (tmpl/grad-tag packed))]
                                 [(update ctx :bindings into
                                          [d-packed (list 'raster.dl.array-ops/slice-strided-2d
                                                          adjoint-sym rows row-stride col-offset n-cols)])
@@ -927,8 +927,8 @@
                            {:params '[a b n] :result nil :adjoint 'dy
                             :grads-fn
                             (fn [ctx [a b n] _result-sym adjoint-sym gensym-fn]
-                              (let [da (gensym-fn "da")
-                                    db (gensym-fn "db")]
+                              (let [da (gensym-fn "da" (tmpl/grad-tag a))
+                                    db (gensym-fn "db" (tmpl/grad-tag b))]
                                 [(update ctx :bindings into
                                          [da (list 'raster.dl.array-ops/array-add-backward adjoint-sym n)
                                           db (list 'raster.dl.array-ops/array-add-backward adjoint-sym n)])
@@ -938,8 +938,10 @@
                            {:params '[h t batch dim] :result nil :adjoint 'dy
                             :grads-fn
                             (fn [ctx [h t batch dim] _result-sym adjoint-sym gensym-fn]
-                              (let [dh (gensym-fn "dh")
-                                    dt (gensym-fn "dt")
+                              (let [dh (gensym-fn "dh" (tmpl/grad-tag h))
+                                    dt (gensym-fn "dt" (tmpl/grad-tag t))
+                                    ;; integer element-count intermediate: Π is ⊥
+                                    ;; on long — stays untagged by design
                                     n (gensym-fn "ba_n")]
                                 [(update ctx :bindings into
                                          [n (list 'raster.numeric/* batch dim)
@@ -953,7 +955,7 @@
                             :grads-fn
                             (fn [ctx [vals indices n-dst n-pairs stride]
                                  _result-sym adjoint-sym gensym-fn]
-                              (let [d-vals (gensym-fn "d_vals")]
+                              (let [d-vals (gensym-fn "d_vals" (tmpl/grad-tag vals))]
                                 [(update ctx :bindings into
                                          [d-vals (list 'raster.dl.array-ops/gather
                                                        adjoint-sym indices n-dst n-pairs stride)])
@@ -965,7 +967,7 @@
                             :grads-fn
                             (fn [ctx [src indices n-src n-pairs stride]
                                  _result-sym adjoint-sym gensym-fn]
-                              (let [d-src (gensym-fn "d_src")]
+                              (let [d-src (gensym-fn "d_src" (tmpl/grad-tag src))]
                                 [(update ctx :bindings into
                                          [d-src (list 'raster.dl.array-ops/scatter-add
                                                       adjoint-sym indices n-src n-pairs stride)])
@@ -977,8 +979,8 @@
                             :grads-fn
                             (fn [ctx [A B idx-a idx-b n-a n-b n-pairs slice-dim total-dim n-slices]
                                  _result-sym adjoint-sym gensym-fn]
-                              (let [dA (gensym-fn "dA")
-                                    dB (gensym-fn "dB")]
+                              (let [dA (gensym-fn "dA" (tmpl/grad-tag A))
+                                    dB (gensym-fn "dB" (tmpl/grad-tag B))]
                                 [(update ctx :bindings into
                                          [dA (list 'raster.dl.array-ops/indexed-dot-dA
                                                    adjoint-sym B idx-a idx-b n-a n-pairs
@@ -996,8 +998,8 @@
                             (fn [ctx [coeffs src dst-indices src-indices n-dst n-src n-pairs
                                       slice-dim total-dim n-slices]
                                  _result-sym adjoint-sym gensym-fn]
-                              (let [d-coeffs (gensym-fn "d_coeffs")
-                                    d-src (gensym-fn "d_src")]
+                              (let [d-coeffs (gensym-fn "d_coeffs" (tmpl/grad-tag coeffs))
+                                    d-src (gensym-fn "d_src" (tmpl/grad-tag src))]
                                 [(update ctx :bindings into
                                          [d-coeffs (list 'raster.dl.array-ops/scatter-mul-add-d-coeffs
                                                          adjoint-sym src dst-indices src-indices
@@ -1013,7 +1015,7 @@
                             :grads-fn
                             (fn [ctx [x scale clamp-bound n]
                                  result-sym adjoint-sym gensym-fn]
-                              (let [dx (gensym-fn "dx")]
+                              (let [dx (gensym-fn "dx" (tmpl/grad-tag x))]
                                 [(update ctx :bindings into
                                          [dx (list 'raster.dl.array-ops/scale-clamp-exp-backward
                                                    adjoint-sym x result-sym scale clamp-bound n)])
@@ -1025,7 +1027,7 @@
                             :grads-fn
                             (fn [ctx [src n-rows n-cols]
                                  _result-sym adjoint-sym gensym-fn]
-                              (let [d-src (gensym-fn "d_src")]
+                              (let [d-src (gensym-fn "d_src" (tmpl/grad-tag src))]
                                 [(update ctx :bindings into
                                          [d-src (list 'raster.dl.array-ops/reduce-axis-backward
                                                       adjoint-sym n-rows n-cols)])
@@ -1037,8 +1039,8 @@
                             :grads-fn
                             (fn [ctx [wV Z n-nodes emb-dim n-heads eps]
                                  _result-sym adjoint-sym gensym-fn]
-                              (let [dwV (gensym-fn "dwV")
-                                    dZ (gensym-fn "dZ")]
+                              (let [dwV (gensym-fn "dwV" (tmpl/grad-tag wV))
+                                    dZ (gensym-fn "dZ" (tmpl/grad-tag Z))]
                                 [(update ctx :bindings into
                                          [dwV (list 'raster.dl.array-ops/segment-div-dwV
                                                     adjoint-sym Z n-nodes emb-dim n-heads eps)
@@ -1083,11 +1085,11 @@
                             (fn [ctx [values space-emb spaces state-emb states pos-emb
                                       We be n-vars emb-dim n-spaces n-states]
                                  _result-sym adjoint-sym gensym-fn]
-                              (let [d-values (gensym-fn "d_values")
-                                    d-space-emb (gensym-fn "d_space_emb")
-                                    d-state-emb (gensym-fn "d_state_emb")
-                                    d-We (gensym-fn "d_We")
-                                    d-be (gensym-fn "d_be")]
+                              (let [d-values (gensym-fn "d_values" (tmpl/grad-tag values))
+                                    d-space-emb (gensym-fn "d_space_emb" (tmpl/grad-tag space-emb))
+                                    d-state-emb (gensym-fn "d_state_emb" (tmpl/grad-tag state-emb))
+                                    d-We (gensym-fn "d_We" (tmpl/grad-tag We))
+                                    d-be (gensym-fn "d_be" (tmpl/grad-tag be))]
                                 [(update ctx :bindings into
                                          [d-values (list 'raster.dl.array-ops/flat-embed-d-values
                                                          adjoint-sym We n-vars emb-dim)
@@ -1106,9 +1108,9 @@
                            {:params '[h W bias n-rows dim] :result nil :adjoint 'dy
                             :grads-fn
                             (fn [ctx [h W bias n-rows dim] _result-sym adjoint-sym gensym-fn]
-                              (let [dh (gensym-fn "dh")
-                                    dW (gensym-fn "dW")
-                                    dbias (gensym-fn "dbias")]
+                              (let [dh (gensym-fn "dh" (tmpl/grad-tag h))
+                                    dW (gensym-fn "dW" (tmpl/grad-tag W))
+                                    dbias (gensym-fn "dbias" (tmpl/grad-tag bias))]
                                 [(update ctx :bindings into
                                          [dh (list 'raster.dl.array-ops/dot-rows-dh adjoint-sym W n-rows dim)
                                           dW (list 'raster.dl.array-ops/dot-rows-dW adjoint-sym h n-rows dim)
@@ -1119,7 +1121,7 @@
                            {:params '[pred target states n] :result nil :adjoint 'dy
                             :grads-fn
                             (fn [ctx [pred target states n] _result-sym adjoint-sym gensym-fn]
-                              (let [d-pred (gensym-fn "d_pred")]
+                              (let [d-pred (gensym-fn "d_pred" (tmpl/grad-tag pred))]
                                 [(update ctx :bindings into
                                          [d-pred (list 'raster.dl.array-ops/masked-mse-loss-backward
                                                        adjoint-sym pred target states n)])

--- a/src/raster/dl/attention.clj
+++ b/src/raster/dl/attention.clj
@@ -131,8 +131,8 @@
 
 (tmpl/merge-into-template! 'raster.dl.attention/rope
                            {:params '[x seq-len heads head-dim theta] :result nil :adjoint 'dy
-                            :grads-fn (fn [ctx [_x seq-len heads head-dim theta] _result-sym adjoint-sym gensym-fn]
-                                        (let [dx (gensym-fn "dx")]
+                            :grads-fn (fn [ctx [x seq-len heads head-dim theta] _result-sym adjoint-sym gensym-fn]
+                                        (let [dx (gensym-fn "dx" (tmpl/grad-tag x))]
                                           [(update ctx :bindings into
                                                    [dx (list 'raster.dl.attention/rope-backward-dx
                                                              adjoint-sym seq-len heads head-dim theta)])
@@ -879,9 +879,9 @@
                             :result nil :adjoint 'dy
                             :grads-fn
                             (fn [ctx [Q K V seq-len dk dv] _result-sym adjoint-sym gensym-fn]
-                              (let [dQ (gensym-fn "dQ")
-                                    dK (gensym-fn "dK")
-                                    dV (gensym-fn "dV")]
+                              (let [dQ (gensym-fn "dQ" (tmpl/grad-tag Q))
+                                    dK (gensym-fn "dK" (tmpl/grad-tag K))
+                                    dV (gensym-fn "dV" (tmpl/grad-tag V))]
                                 [(update ctx :bindings into
                                          [dQ (list 'raster.dl.attention/causal-scaled-dot-product-attn-dq
                                                    adjoint-sym Q K V seq-len dk dv)
@@ -1443,9 +1443,9 @@
                             :grads-fn
                             (fn [ctx [Q K V batch seq-len head-dim]
                                  _result-sym adjoint-sym gensym-fn]
-                              (let [dQ (gensym-fn "dQ")
-                                    dK (gensym-fn "dK")
-                                    dV (gensym-fn "dV")]
+                              (let [dQ (gensym-fn "dQ" (tmpl/grad-tag Q))
+                                    dK (gensym-fn "dK" (tmpl/grad-tag K))
+                                    dV (gensym-fn "dV" (tmpl/grad-tag V))]
                                 [(update ctx :bindings into
                                          [dQ (list 'raster.dl.attention/batched-causal-sdpa-dq
                                                    adjoint-sym Q K V batch seq-len head-dim)
@@ -2133,9 +2133,9 @@
 (tmpl/merge-into-template! 'raster.dl.attention/scaled-dot-product-attn
                            {:params '[Q K V seq-q seq-k dk dv] :result nil :adjoint 'dy
                             :grads-fn (fn [ctx [Q K V seq-q seq-k dk dv] _result-sym adjoint-sym gensym-fn]
-                                        (let [dQ (gensym-fn "dQ")
-                                              dK (gensym-fn "dK")
-                                              dV (gensym-fn "dV")]
+                                        (let [dQ (gensym-fn "dQ" (tmpl/grad-tag Q))
+                                              dK (gensym-fn "dK" (tmpl/grad-tag K))
+                                              dV (gensym-fn "dV" (tmpl/grad-tag V))]
                                           [(update ctx :bindings into
                                                    [dQ (list 'raster.dl.attention/scaled-dot-product-attn-dq
                                                              adjoint-sym Q K V seq-q seq-k dk dv)

--- a/src/raster/dl/diffusion.clj
+++ b/src/raster/dl/diffusion.clj
@@ -112,9 +112,12 @@
 (tmpl/merge-into-template! 'raster.dl.diffusion/forward-noise
                            {:params '[x0 noise alpha-t n] :result nil :adjoint 'dy
                             :grads-fn (fn [ctx [x0 noise alpha-t n] _result-sym adjoint-sym gensym-fn]
+                                        ;; grads-arr is the Object[] bundle from the
+                                        ;; multi-output backward — no differentiable
+                                        ;; tag (Π ⊥), stays untagged by design.
                                         (let [grads-arr (gensym-fn "fn_grads")
-                                              dx0 (gensym-fn "dx0")
-                                              d-noise (gensym-fn "d_noise")]
+                                              dx0 (gensym-fn "dx0" (tmpl/grad-tag x0))
+                                              d-noise (gensym-fn "d_noise" (tmpl/grad-tag noise))]
                                           [(update ctx :bindings into
                                                    [grads-arr (list 'raster.dl.diffusion/forward-noise-backward
                                                                     adjoint-sym alpha-t n)

--- a/src/raster/dl/loss.clj
+++ b/src/raster/dl/loss.clj
@@ -119,7 +119,7 @@
 (tmpl/merge-into-template! 'raster.dl.loss/cross-entropy-loss
                            {:params '[logits target batch classes] :adjoint 'dy
                             :grads-fn (fn [ctx [logits target batch classes] _result adjoint gensym-fn]
-                                        (let [dl (gensym-fn "d_logits")]
+                                        (let [dl (gensym-fn "d_logits" (tmpl/grad-tag logits))]
                                           [(update ctx :bindings into
                                                    [dl (list 'raster.dl.loss/cross-entropy-loss-backward
                                                              adjoint logits target batch classes)])
@@ -154,7 +154,7 @@
 (tmpl/merge-into-template! 'raster.dl.loss/huber-loss
                            {:params '[pred target n delta] :adjoint 'dy
                             :grads-fn (fn [ctx [pred target n delta] _result adjoint gensym-fn]
-                                        (let [dp (gensym-fn "d_pred")]
+                                        (let [dp (gensym-fn "d_pred" (tmpl/grad-tag pred))]
                                           [(update ctx :bindings into
                                                    [dp (list 'raster.dl.loss/huber-loss-backward adjoint pred target n delta)])
                                            [dp nil nil nil]]))})
@@ -183,7 +183,7 @@
 (tmpl/merge-into-template! 'raster.dl.loss/l1-loss
                            {:params '[pred target n] :adjoint 'dy
                             :grads-fn (fn [ctx [pred target n] _result adjoint gensym-fn]
-                                        (let [dp (gensym-fn "d_pred")]
+                                        (let [dp (gensym-fn "d_pred" (tmpl/grad-tag pred))]
                                           [(update ctx :bindings into
                                                    [dp (list 'raster.dl.loss/l1-loss-backward adjoint pred target n)])
                                            [dp nil nil]]))})

--- a/src/raster/dl/nn.clj
+++ b/src/raster/dl/nn.clj
@@ -2103,6 +2103,12 @@
 ;; resident residual-add ONLY when x1's sym-tag is :array. Without the tag the residual
 ;; fan-out d_x1 falls back to the GPU-kernel-less nil-safe grad-acc → non-resident (B2).
 ;; Registered HERE (not in compiler core) so core keeps no dependency on raster.dl.nn.
+;; LOAD-BEARING (plan D2 assert-then-delete audit, 2026-07-11): with this pair removed,
+;; backward-kernel-resident-test/resblk-value+grad-resident-parity FAILS on a cold JVM —
+;; x1 = (residual-add x m n) stays untagged, the grad-acc→residual-add reroute can't
+;; fire, and the surviving untagged `d_x1 = (grad-acc d_pred d_x)` trips the
+;; fixpoint-edge typedness throw. (The oftype and grad-acc facets from the same audit
+;; were provably dead and deleted — see op_descriptor.clj.) KEEP.
 (descriptor/register-result-type! 'raster.dl.nn/residual-add :same-as-first-arg)
 (descriptor/register-result-type! 'raster.dl.nn/residual-add-backward :same-as-first-arg)
 

--- a/src/raster/dl/nn.clj
+++ b/src/raster/dl/nn.clj
@@ -307,7 +307,7 @@
 (tmpl/merge-into-template! 'raster.dl.nn/gelu
                            {:params '[x n] :adjoint 'dy
                             :grads-fn (fn [ctx [x n] _result adjoint gensym-fn]
-                                        (let [dx (gensym-fn "dx")]
+                                        (let [dx (gensym-fn "dx" (tmpl/grad-tag x))]
                                           [(update ctx :bindings into
                                                    [dx (list 'raster.dl.nn/gelu-backward adjoint x n)])
                                            [dx nil]]))})
@@ -328,7 +328,7 @@
 (tmpl/merge-into-template! 'raster.dl.nn/sigmoid
                            {:params '[x n] :adjoint 'dy
                             :grads-fn (fn [ctx [x n] result adjoint gensym-fn]
-                                        (let [dx (gensym-fn "dx")]
+                                        (let [dx (gensym-fn "dx" (tmpl/grad-tag x))]
                                           [(update ctx :bindings into
                                                    [dx (list 'raster.dl.nn/sigmoid-backward adjoint result n)])
                                            [dx nil]]))})
@@ -349,7 +349,7 @@
 (tmpl/merge-into-template! 'raster.dl.nn/tanh-act
                            {:params '[x n] :adjoint 'dy
                             :grads-fn (fn [ctx [x n] result adjoint gensym-fn]
-                                        (let [dx (gensym-fn "dx")]
+                                        (let [dx (gensym-fn "dx" (tmpl/grad-tag x))]
                                           [(update ctx :bindings into
                                                    [dx (list 'raster.dl.nn/tanh-act-backward adjoint result n)])
                                            [dx nil]]))})
@@ -377,7 +377,7 @@
 (tmpl/merge-into-template! 'raster.dl.nn/leaky-relu
                            {:params '[x n alpha] :adjoint 'dy
                             :grads-fn (fn [ctx [x n alpha] _result adjoint gensym-fn]
-                                        (let [dx (gensym-fn "dx")]
+                                        (let [dx (gensym-fn "dx" (tmpl/grad-tag x))]
                                           [(update ctx :bindings into
                                                    [dx (list 'raster.dl.nn/leaky-relu-backward adjoint x n alpha)])
                                            [dx nil nil]]))})
@@ -1246,7 +1246,7 @@
 (tmpl/merge-into-template! 'raster.dl.nn/embedding
                            {:params '[table indices n vocab dim] :adjoint 'dy
                             :grads-fn (fn [ctx [table indices n vocab dim] _result adjoint gensym-fn]
-                                        (let [dt (gensym-fn "d_table")]
+                                        (let [dt (gensym-fn "d_table" (tmpl/grad-tag table))]
                                           [(update ctx :bindings into
                                                    [dt (list 'raster.dl.nn/embedding-backward adjoint indices n vocab dim)])
                                            [dt nil nil nil nil]]))})
@@ -1275,7 +1275,7 @@
 (tmpl/merge-into-template! 'raster.dl.nn/dropout
                            {:params '[x mask n] :adjoint 'dy
                             :grads-fn (fn [ctx [x mask n] _result adjoint gensym-fn]
-                                        (let [dx (gensym-fn "dx")]
+                                        (let [dx (gensym-fn "dx" (tmpl/grad-tag x))]
                                           [(update ctx :bindings into
                                                    [dx (list 'raster.dl.nn/dropout-backward adjoint mask n)])
                                            [dx nil nil]]))})
@@ -1329,7 +1329,7 @@
 (tmpl/merge-into-template! 'raster.dl.nn/softmax-1d
                            {:params '[x n] :adjoint 'dy
                             :grads-fn (fn [ctx [x n] result adjoint gensym-fn]
-                                        (let [dx (gensym-fn "dx")]
+                                        (let [dx (gensym-fn "dx" (tmpl/grad-tag x))]
                                           [(update ctx :bindings into
                                                    [dx (list 'raster.dl.nn/softmax-1d-backward adjoint result n)])
                                            [dx nil]]))})
@@ -2071,7 +2071,8 @@
                            {:params '[x weight rows features eps gain-offset] :result nil :adjoint 'dy
                             :grads-fn (fn [ctx [x weight rows features eps gain-offset]
                                            _result-sym adjoint-sym gensym-fn]
-                                        (let [dx (gensym-fn "dx") dw (gensym-fn "dw")]
+                                        (let [dx (gensym-fn "dx" (tmpl/grad-tag x))
+                                              dw (gensym-fn "dw" (tmpl/grad-tag weight))]
                                           [(update ctx :bindings into
                                                    [dx (list 'raster.dl.nn/rms-norm-backward-dx
                                                              adjoint-sym x weight rows features eps gain-offset)
@@ -2109,7 +2110,8 @@
 (tmpl/merge-into-template! 'raster.dl.nn/hadamard
                            {:params '[a b n] :result nil :adjoint 'dy
                             :grads-fn (fn [ctx [a b n] _result-sym adjoint-sym gensym-fn]
-                                        (let [da (gensym-fn "da") db (gensym-fn "db")]
+                                        (let [da (gensym-fn "da" (tmpl/grad-tag a))
+                                              db (gensym-fn "db" (tmpl/grad-tag b))]
                                           [(update ctx :bindings into
                                                    [da (list 'raster.dl.nn/hadamard-backward adjoint-sym b n)
                                                     db (list 'raster.dl.nn/hadamard-backward adjoint-sym a n)])
@@ -2120,7 +2122,8 @@
 (tmpl/merge-into-template! 'raster.dl.nn/linear-nb
                            {:params '[x W batch in-f out-f] :result nil :adjoint 'dy
                             :grads-fn (fn [ctx [x W batch in-f out-f] _result-sym adjoint-sym gensym-fn]
-                                        (let [dx (gensym-fn "dx") dW (gensym-fn "dW")]
+                                        (let [dx (gensym-fn "dx" (tmpl/grad-tag x))
+                                              dW (gensym-fn "dW" (tmpl/grad-tag W))]
                                           [(update ctx :bindings into
                                                    [dx (list 'raster.dl.nn/linear-dx adjoint-sym W batch in-f out-f)
                                                     dW (list 'raster.dl.nn/linear-dW adjoint-sym x batch in-f out-f)])
@@ -2139,10 +2142,10 @@
 ;; layer-norm template — direct calls to per-gradient deftms
 (tmpl/merge-into-template! 'raster.dl.nn/layer-norm
                            {:params '[x gamma beta batch features eps] :result nil :adjoint 'dy
-                            :grads-fn (fn [ctx [x gamma _beta batch features eps] _result-sym adjoint-sym gensym-fn]
-                                        (let [dx (gensym-fn "dx")
-                                              dgamma (gensym-fn "dgamma")
-                                              dbeta (gensym-fn "dbeta")]
+                            :grads-fn (fn [ctx [x gamma beta batch features eps] _result-sym adjoint-sym gensym-fn]
+                                        (let [dx (gensym-fn "dx" (tmpl/grad-tag x))
+                                              dgamma (gensym-fn "dgamma" (tmpl/grad-tag gamma))
+                                              dbeta (gensym-fn "dbeta" (tmpl/grad-tag beta))]
                                           [(update ctx :bindings into
                                                    [dx (list 'raster.dl.nn/layer-norm-backward-dx
                                                              adjoint-sym x gamma batch features eps)
@@ -2155,11 +2158,11 @@
 ;; group-norm template — direct calls to per-gradient deftms
 (tmpl/merge-into-template! 'raster.dl.nn/group-norm
                            {:params '[x gamma beta batch channels spatial groups eps] :result nil :adjoint 'dy
-                            :grads-fn (fn [ctx [x gamma _beta batch channels spatial groups eps]
+                            :grads-fn (fn [ctx [x gamma beta batch channels spatial groups eps]
                                            _result-sym adjoint-sym gensym-fn]
-                                        (let [dx (gensym-fn "dx")
-                                              dgamma (gensym-fn "dgamma")
-                                              dbeta (gensym-fn "dbeta")]
+                                        (let [dx (gensym-fn "dx" (tmpl/grad-tag x))
+                                              dgamma (gensym-fn "dgamma" (tmpl/grad-tag gamma))
+                                              dbeta (gensym-fn "dbeta" (tmpl/grad-tag beta))]
                                           [(update ctx :bindings into
                                                    [dx (list 'raster.dl.nn/group-norm-backward-dx
                                                              adjoint-sym x gamma batch channels spatial groups eps)
@@ -2173,11 +2176,11 @@
 (tmpl/merge-into-template! 'raster.dl.nn/batch-norm
                            {:params '[x gamma beta running-mean running-var batch features eps momentum training]
                             :result nil :adjoint 'dy
-                            :grads-fn (fn [ctx [x gamma _beta _rm _rv batch features eps _momentum _training]
+                            :grads-fn (fn [ctx [x gamma beta _rm _rv batch features eps _momentum _training]
                                            _result-sym adjoint-sym gensym-fn]
-                                        (let [dx (gensym-fn "dx")
-                                              dgamma (gensym-fn "dgamma")
-                                              dbeta (gensym-fn "dbeta")]
+                                        (let [dx (gensym-fn "dx" (tmpl/grad-tag x))
+                                              dgamma (gensym-fn "dgamma" (tmpl/grad-tag gamma))
+                                              dbeta (gensym-fn "dbeta" (tmpl/grad-tag beta))]
                                           [(update ctx :bindings into
                                                    [dx (list 'raster.dl.nn/batch-norm-backward-dx
                                                              adjoint-sym x gamma batch features eps)
@@ -2191,11 +2194,11 @@
 (tmpl/merge-into-template! 'raster.dl.nn/conv1d
                            {:params '[x W b batch c-in length c-out kernel stride pad-left pad-right]
                             :result nil :adjoint 'dy
-                            :grads-fn (fn [ctx [x W _b batch c-in length c-out kernel stride pad-left pad-right]
+                            :grads-fn (fn [ctx [x W b batch c-in length c-out kernel stride pad-left pad-right]
                                            _result-sym adjoint-sym gensym-fn]
-                                        (let [dx (gensym-fn "dx")
-                                              dW (gensym-fn "dW")
-                                              db (gensym-fn "db")]
+                                        (let [dx (gensym-fn "dx" (tmpl/grad-tag x))
+                                              dW (gensym-fn "dW" (tmpl/grad-tag W))
+                                              db (gensym-fn "db" (tmpl/grad-tag b))]
                                           [(update ctx :bindings into
                                                    [dx (list 'raster.dl.nn/conv1d-backward-dx
                                                              adjoint-sym x W batch c-in length c-out kernel stride pad-left pad-right)

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -869,11 +869,23 @@
    program can't derive: :constant = weights (uploaded once here, never re-uploaded by
    run-program!); :state = persistent device state e.g. a KV cache (never downloaded). All buffer
    CONTENTS are uploaded once here at bind; run-program! then moves only :input (up) and :output
-   (down)."
+   (down).
+
+   :gemm steps bind per the descriptor's :gemm-precision policy (set at compile time by
+   compile-gpu-program, default :f16-xmx; a bind-time caller may override with
+   (assoc descriptor :gemm-precision …) since the descriptor is plain data):
+     :f16-xmx    — convert A/B f32→f16 and run the XMX gemm (f32 accumulate/output). Fast
+                   (systolic), but the f16 input conversion costs gradient precision
+                   (~1e-3-level composed-grad noise) — the decode/inference default.
+     :f32-scalar — bind the plain scalar f32 GEMM for ALL :gemm steps: reads the f32
+                   residents directly, no convert/transpose expansion kernels. Exact f32
+                   grads (~1e-6-level parity) — what training wants.
+   The XMX hardware pitch gate (n<8 or k<8 → scalar) applies regardless of policy."
   ([sess descriptor args] (bind-program! sess descriptor args {}))
   ([sess descriptor args roles]
    (let [device-id (:device-id @sess)
          {:keys [dtype all-params array-params allocs steps]} descriptor
+         gemm-precision (or (:gemm-precision descriptor) :f16-xmx)
          effective-roles (merge (:array-roles descriptor) roles)
          argmap (zipmap all-params args)
          dt (if (= dtype :double) :double :float)
@@ -926,12 +938,15 @@
                (let [m (long ((:m-fn step) args)) n (long ((:n-fn step) args)) k (long ((:k-fn step) args))
                      abuf (buf-of (:A step) :gemm-A) bbuf (buf-of (:B step) :gemm-B)
                      cbuf (buf-of (:C step) :gemm-C)]
-                 (if (or (< n 8) (< k 8))
-                   ;; Small-dim fallback: the XMX kernel's 2D-block reads need a >=16-byte
-                   ;; pitch — the B-operand VNNI read's pitch is N*2 bytes (fp16) and the
-                   ;; A-operand row read's pitch is K*2 bytes, so N<8 OR K<8 violates it and
-                   ;; yields garbage (relerr ~1; K<8 shows as scrambled + zeroed C rows).
-                   ;; Bind the plain scalar f32 GEMM instead: it reads the f32 residents
+                 (if (or (= :f32-scalar gemm-precision) (< n 8) (< k 8))
+                   ;; Scalar f32 path, taken when (a) the :gemm-precision policy is
+                   ;; :f32-scalar (exact-grad training — see the docstring), or (b) the
+                   ;; XMX hardware pitch gate fires regardless of policy: the XMX
+                   ;; kernel's 2D-block reads need a >=16-byte pitch — the B-operand
+                   ;; VNNI read's pitch is N*2 bytes (fp16) and the A-operand row read's
+                   ;; pitch is K*2 bytes, so N<8 OR K<8 violates it and yields garbage
+                   ;; (relerr ~1; K<8 shows as scrambled + zeroed C rows).
+                   ;; Binds the plain scalar f32 GEMM: it reads the f32 residents
                    ;; directly, so NO convert/transpose expansion kernels at all.
                    ;; Resolved lazily — Level-Zero-only for now (like the scatter binder).
                    (let [scalar-gemm-fn (rt-resolve device-id "bind-registered-gemm-scalar!")]

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -926,11 +926,13 @@
                (let [m (long ((:m-fn step) args)) n (long ((:n-fn step) args)) k (long ((:k-fn step) args))
                      abuf (buf-of (:A step) :gemm-A) bbuf (buf-of (:B step) :gemm-B)
                      cbuf (buf-of (:C step) :gemm-C)]
-                 (if (< n 8)
-                   ;; Small-N fallback: the XMX kernel's B-operand 2D-block VNNI read needs a
-                   ;; >=16-byte pitch (N*2 bytes at fp16) — N<8 violates it and yields garbage
-                   ;; (relerr ~1). Bind the plain scalar f32 GEMM instead: it reads the f32
-                   ;; residents directly, so NO convert/transpose expansion kernels at all.
+                 (if (or (< n 8) (< k 8))
+                   ;; Small-dim fallback: the XMX kernel's 2D-block reads need a >=16-byte
+                   ;; pitch — the B-operand VNNI read's pitch is N*2 bytes (fp16) and the
+                   ;; A-operand row read's pitch is K*2 bytes, so N<8 OR K<8 violates it and
+                   ;; yields garbage (relerr ~1; K<8 shows as scrambled + zeroed C rows).
+                   ;; Bind the plain scalar f32 GEMM instead: it reads the f32 residents
+                   ;; directly, so NO convert/transpose expansion kernels at all.
                    ;; Resolved lazily — Level-Zero-only for now (like the scatter binder).
                    (let [scalar-gemm-fn (rt-resolve device-id "bind-registered-gemm-scalar!")]
                      [{:bound (scalar-gemm-fn abuf bbuf cbuf m n k (:variant step))}])

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -1706,6 +1706,21 @@
     (when-not output-is-buffer?
       (let [dst-seg (MemorySegment/ofArray output-array)]
         (MemorySegment/copy dev-output 0 dst-seg 0 n-bytes)))
+    ;; Copy back WRITTEN input-position arrays (a horizontally-fused kernel's
+    ;; secondary outputs / read+write buffers, named by the registry's
+    ;; :written-arrays). Only JVM arrays need the copy — device buffers were
+    ;; written in place.
+    (when-let [wa (seq (:written-arrays info))]
+      (let [wnames (set (map name wa))
+            aps (mapv name (:array-params info))]
+        (doseq [[arr seg ^long idx] (map vector input-arrays dev-inputs (range))]
+          (when (and (not (device-buffer? arr))
+                     (< idx (count aps))
+                     (contains? wnames (nth aps idx)))
+            (let [arr-bytes (if (= dtype :float)
+                              (* (alength ^floats arr) 4)
+                              (* (alength ^doubles arr) 8))]
+              (MemorySegment/copy ^MemorySegment seg 0 (MemorySegment/ofArray arr) 0 arr-bytes))))))
     output-array))
 
 (defn invoke-reduction-kernel

--- a/src/raster/linalg/blas.clj
+++ b/src/raster/linalg/blas.clj
@@ -715,9 +715,12 @@
 (tmpl/merge-into-template! 'raster.linalg.blas/dgemm!
                            {:params '[A B C m k n alpha beta] :result nil :adjoint 'dy
                             :grads-fn (fn [ctx [A B C m k n alpha beta] _result-sym adjoint-sym gensym-fn]
+                                        ;; grads-arr is the Object[] bundle from
+                                        ;; dgemm-backward — no differentiable tag
+                                        ;; (Π ⊥), stays untagged by design.
                                         (let [grads-arr (gensym-fn "dgemm_grads")
-                                              dA (gensym-fn "dA")
-                                              dB (gensym-fn "dB")]
+                                              dA (gensym-fn "dA" (tmpl/grad-tag A))
+                                              dB (gensym-fn "dB" (tmpl/grad-tag B))]
                                           [(update ctx :bindings into
                                                    [grads-arr (list 'raster.linalg.blas/dgemm-backward
                                                                     adjoint-sym A B m k n alpha beta)

--- a/src/raster/nn.clj
+++ b/src/raster/nn.clj
@@ -357,10 +357,13 @@
 
 (tmpl/merge-into-template! 'raster.nn/softmax-cross-entropy
                            {:params '[logits t] :result 'r :adjoint 'dy
-                            :grads-fn (fn [ctx [_logits t] result-sym adjoint-sym gensym-fn]
-               ;; result is [loss s], need to extract s
-                                        (let [s-sym (gensym-fn "sce_s")
-                                              d-logits (gensym-fn "d_logits")]
+                            :grads-fn (fn [ctx [logits t] result-sym adjoint-sym gensym-fn]
+               ;; result is [loss s], need to extract s — a PRIMAL intermediate
+               ;; (the softmax output), so it carries the primal logits tag
+               ;; directly (arg-tag, not Π of it; identical for differentiable
+               ;; tags but semantically the primal space).
+                                        (let [s-sym (gensym-fn "sce_s" (tmpl/arg-tag logits))
+                                              d-logits (gensym-fn "d_logits" (tmpl/grad-tag logits))]
                                           [(update ctx :bindings into
                                                    [s-sym (list 'clojure.core/nth result-sym 1)
                                                     d-logits (list 'raster.nn/softmax-cross-entropy-backward

--- a/src/raster/quant/train.clj
+++ b/src/raster/quant/train.clj
@@ -147,8 +147,8 @@
 ;; Only x gets a gradient; the quantized weight is frozen (nil for the rest).
 (tmpl/merge-into-template! 'raster.quant.train/qlinear-q8
   {:params '[x codes scales m in out] :result nil :adjoint 'dy
-   :grads-fn (fn [ctx [_x codes scales m in out] _result-sym adjoint-sym gensym-fn]
-               (let [dx (gensym-fn "dx")]
+   :grads-fn (fn [ctx [x codes scales m in out] _result-sym adjoint-sym gensym-fn]
+               (let [dx (gensym-fn "dx" (tmpl/grad-tag x))]
                  [(update ctx :bindings into
                           [dx (list 'raster.quant.train/qlinear-q8-dx
                                     adjoint-sym codes scales m in out)])

--- a/test/raster/ad/typed_emission_test.clj
+++ b/test/raster/ad/typed_emission_test.clj
@@ -11,7 +11,12 @@
   (:require [clojure.test :refer [deftest testing is]]
             [raster.ad.tangent :as tangent]
             [raster.ad.templates :as tmpl]
-            [raster.compiler.ad.bind-ctx :as bind-ctx]))
+            [raster.compiler.ad.bind-ctx :as bind-ctx]
+            ;; external :grads-fn registration sites (Phase 1d — tagged mints)
+            [raster.dl.nn]
+            [raster.dl.array-ops]
+            [raster.dl.attention]
+            [raster.nn]))
 
 (defn- make-test-ctx
   "Deterministic single-arity gensym (the pre-change BindCtx contract) —
@@ -148,3 +153,76 @@
           "a call with ANY unknown arg tag stays symbolic")
       (is (every? #(nil? (tag-of %)) grad-syms)
           "Π of an absent primal tag is nil — LHS stays untagged"))))
+
+;; ================================================================
+;; Phase 1d — external :grads-fn registration sites mint tagged syms
+;; (dl/nn, dl/array-ops, dl/attention, raster.nn) at the mint site,
+;; independent of the positional net in stamp-emitted-bindings.
+;; ================================================================
+
+(defn- instantiate
+  "Instantiate `op`'s template with the given actuals; returns
+  [binding-pairs grad-syms]."
+  [op actuals result-sym adjoint]
+  (let [[template _] (tmpl/resolve-template op)
+        [ctx grad-syms] (tmpl/instantiate-template-ctx
+                         template actuals result-sym adjoint (make-test-ctx))]
+    [(partition 2 (:bindings ctx)) grad-syms]))
+
+(deftest external-grads-fn-tagged-mints-test
+  (testing "dl/nn rms-norm: float primals ⇒ float-tagged dx/dw at mint"
+    (let [[pairs grad-syms]
+          (instantiate 'raster.dl.nn/rms-norm
+                       [(tagged 'x0 'floats) (tagged 'w0 'floats)
+                        'rows0 'feat0 'eps0 'go0]
+                       nil (tagged 'dy0 'floats))]
+      (is (= '[floats floats nil nil nil nil] (mapv tag-of grad-syms)))
+      (is (every? (fn [[s rhs]] (and (= 'floats (tag-of s))
+                                     (= 'floats (tag-of rhs))))
+                  pairs)
+          "both grad bindings carry Π(primal) on LHS and RHS form")))
+
+  (testing "dl/array-ops broadcast-add: dh/dt tagged, integer intermediate ba_n stays ⊥"
+    (let [[pairs grad-syms]
+          (instantiate 'raster.dl.array-ops/broadcast-add
+                       [(tagged 'h0 'floats) (tagged 't0 'floats) 'batch0 'dim0]
+                       nil (tagged 'dy0 'floats))
+          by-prefix (fn [p] (first (filter #(.startsWith (name (first %)) p) pairs)))]
+      (is (= '[floats floats nil nil] (mapv tag-of grad-syms)))
+      (is (nil? (tag-of (first (by-prefix "ba_n"))))
+          "Π is ⊥ on the integer element-count intermediate — never guessed")
+      (is (= 'floats (tag-of (first (by-prefix "dh")))))
+      (is (= 'floats (tag-of (first (by-prefix "dt")))))))
+
+  (testing "dl/attention batched-causal-sdpa: dQ/dK/dV tagged from Q/K/V"
+    (let [[pairs grad-syms]
+          (instantiate 'raster.dl.attention/batched-causal-sdpa
+                       [(tagged 'Q0 'floats) (tagged 'K0 'floats) (tagged 'V0 'floats)
+                        'b0 'sl0 'hd0]
+                       nil (tagged 'dy0 'floats))]
+      (is (= '[floats floats floats nil nil nil] (mapv tag-of grad-syms)))
+      (is (every? (fn [[s _]] (= 'floats (tag-of s))) pairs))))
+
+  (testing "raster.nn softmax-cross-entropy: the PRIMAL intermediate sce_s is tagged"
+    (let [[pairs grad-syms]
+          (instantiate 'raster.nn/softmax-cross-entropy
+                       [(tagged 'logits0 'floats) (tagged 't0 'floats)]
+                       'r0 (tagged 'dy0 'float))
+          [[s-sym _] [dl-sym _]] pairs]
+      (is (.startsWith (name s-sym) "sce_s"))
+      (is (= 'floats (tag-of s-sym))
+          "intermediate softmax extraction carries the primal logits tag")
+      (is (= 'floats (tag-of dl-sym)))
+      (is (= '[floats nil] (mapv tag-of grad-syms))))))
+
+(deftest external-grads-fn-untagged-unchanged-test
+  (testing "untagged primals ⇒ emission byte-identical, no tags anywhere"
+    (let [[pairs grad-syms]
+          (instantiate 'raster.dl.nn/rms-norm
+                       '[x0 w0 rows0 feat0 eps0 go0] nil 'dy0)]
+      (is (= '[[dx__1 (raster.dl.nn/rms-norm-backward-dx dy0 x0 w0 rows0 feat0 eps0 go0)]
+               [dw__2 (raster.dl.nn/rms-norm-backward-dweight dy0 x0 rows0 feat0 eps0)]]
+             (mapv vec pairs)))
+      (is (every? (fn [[s rhs]] (and (nil? (tag-of s)) (nil? (tag-of rhs)))) pairs)
+          "no :raster.type/tag invented on LHS or RHS")
+      (is (every? #(nil? (tag-of %)) (remove nil? grad-syms))))))

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -37,3 +37,30 @@
     (let [src (segred-source '(+ acc (clojure.core/aget a j)))]
       (is (not (re-find #"gpufn_aget" src)))
       (is (re-find #"a\[" src)))))
+
+;; ================================================================
+;; Horizontally-fused multi-output SegMap: the SECONDARY output (written
+;; only via a side-effect aset in the fused lambda) must be a NON-const
+;; __global array param — never a scalar. Before the fix it was declared
+;; `float hfuse_out__N` (a scalar) while the body indexed it as an array:
+;; a broken kernel, and the extraction layer then eval'd the bare buffer
+;; symbol on the host (`Unable to resolve symbol: hfuse_out__N`).
+;; ================================================================
+
+(deftest segmap-fused-secondary-output-is-array-param
+  (let [form '(raster.par/map! hout1 i n float
+                               (do (raster.arrays/aset hout2 i (float (* (clojure.core/aget d i)
+                                                                         (clojure.core/aget a i))))
+                                   (* (clojure.core/aget d i) (clojure.core/aget b i))))
+        s (soac/par-form->soac 'da form 0)
+        segmap (first (lower/lower-map s nil :dtype :float))
+        k (sg/generate-segmap-kernel segmap 'hout1 :dtype :float)]
+    (testing "secondary output is an array param, not a scalar param"
+      (is (some #{'hout2} (:array-params k)))
+      (is (not (some #{'hout2} (:scalar-params k))))
+      (is (some #{'hout2} (:written-arrays k))))
+    (testing "declared __global and NON-const in the C signature"
+      (is (re-find #"__global float\* restrict hout2" (:source k)))
+      (is (not (re-find #"const float\* restrict hout2" (:source k)))))
+    (testing "written via subscript in the body"
+      (is (re-find #"hout2\[" (:source k))))))

--- a/test/raster/compiler/core/inference_test.clj
+++ b/test/raster/compiler/core/inference_test.clj
@@ -112,6 +112,26 @@
     (is (not (inf/generic-fn? 'no.such/fn)))))
 
 ;; ================================================================
+;; infer-arg-tag: constructor arm vs degenerate dot heads
+;; ================================================================
+
+(deftest infer-arg-tag-ctor-arm-dot-heads-test
+  (testing "host dot special forms never yield the empty-symbol tag"
+    ;; The ctor arm strips a trailing "." from the head; on the bare dot
+    ;; special form `.` that produced (symbol "") — tag poison the bytecode
+    ;; emitter once trusted as :verified (no checkcast → VerifyError).
+    (is (nil? (inf/infer-arg-tag '(. obj method x) {})))
+    (is (nil? (inf/infer-arg-tag '(. obj (method x)) {}))))
+  (testing "degenerate all-dot heads (`..`, `...`) yield nil, not \".\"/\"..\""
+    (is (nil? (inf/infer-arg-tag '(.. obj (foo) (bar)) {})))
+    (is (nil? (inf/infer-arg-tag (list (symbol "...") 'obj) {}))))
+  (testing "method-sugar heads (.foo obj) do not hit the ctor arm"
+    (is (nil? (inf/infer-arg-tag '(.foo obj) {}))))
+  (testing "real constructor sugar still yields the class symbol"
+    (is (= 'java.util.Random (inf/infer-arg-tag '(java.util.Random.) {})))
+    (is (= 'Foo (inf/infer-arg-tag '(Foo. 1 2) {})))))
+
+;; ================================================================
 ;; trace-inference
 ;; ================================================================
 

--- a/test/raster/compiler/ir/soac_test.clj
+++ b/test/raster/compiler/ir/soac_test.clj
@@ -100,6 +100,40 @@
       (is (= 'out (second reconstructed))))))
 
 ;; ================================================================
+;; Written arrays are OUTPUTS, never scalars (the horizontal-fusion
+;; multi-output invariant): soac->par-form flattens a fused multi-output
+;; map to a single-out par/map! whose SECONDARY outputs survive only as
+;; side-effect asets in the lambda — re-parsing that form must classify
+;; them as array outputs or the GPU backend declares them as scalar
+;; kernel params (`float hfuse_out__N`) and extraction emits an
+;; unresolvable host reference.
+;; ================================================================
+
+(deftest aset-written-array-classified-as-output-test
+  (testing "bare aset target in a par/map! lambda → :outputs, not :scalars"
+    (let [expr '(raster.par/map! hout1 i n float
+                                 (do (raster.arrays/aset hout2 i (float (* (aget d i) (aget a i))))
+                                     (* (aget d i) (aget b i))))
+          node (soac/par-form->soac 'da expr 0)]
+      (is (contains? (:outputs node) 'hout2)
+          "aset-written array must be a SOAC output")
+      (is (not (contains? (:scalars node) 'hout2))
+          "aset-written array must never be a scalar param")
+      (is (contains? (:outputs node) 'hout1))
+      (is (= #{'d 'a 'b} (:inputs node)))))
+
+  (testing "devirtualized (.invk aset-impl …) target → :outputs, not :scalars"
+    (let [aset-invk (with-meta
+                      (list '.invk 'raster.arrays/aset_m_floats_long_float-impl
+                            'hout2 'i (list 'float '(* (aget d i) (aget a i))))
+                      {:raster.op/original 'raster.arrays/aset})
+          expr (list 'raster.par/map! 'hout1 'i 'n 'float
+                     (list 'do aset-invk '(* (aget d i) (aget b i))))
+          node (soac/par-form->soac 'da expr 0)]
+      (is (contains? (:outputs node) 'hout2))
+      (is (not (contains? (:scalars node) 'hout2))))))
+
+;; ================================================================
 ;; let-bindings->nodes / nodes->let-bindings
 ;; ================================================================
 

--- a/test/raster/dl/backward_kernel_resident_test.clj
+++ b/test/raster/dl/backward_kernel_resident_test.clj
@@ -290,6 +290,50 @@
       (is (:resident? (get grads 'x))
           "full attention-block grad(x) must extract FULLY RESIDENT"))))
 
+;; ── :gemm-precision :f32-scalar — exact-grad GEMM policy (training) ──────────────
+;; Same composed attention block as above, but the resident :gemm steps bind the plain
+;; scalar f32 GEMM (no f32→f16 convert/transpose expansion). The ~1.7e-2 composed
+;; divergence of the default :f16-xmx path is pure f16 INPUT-CONVERSION noise, not an
+;; AD/compile defect — under :f32-scalar the same compiled program matches the CPU f32
+;; reference at ~1e-6-level. This pins the policy end-to-end: compile-gpu-program
+;; carries :gemm-precision on the descriptor, bind-program! binds scalar GEMMs for it.
+(deftest attn-block-f32-scalar-gemm-precision-parity
+  (if-not @gp/gpu-available?
+    (println "  [SKIP] attn-block :f32-scalar gemm-precision parity: no Level Zero GPU")
+    (let [seq 6 dmodel 32 nq 4 nkv 1 hd 8 eps 1e-6 go 1.0 theta 10000.0
+          x  (fa (* seq dmodel) 31) wn (fa dmodel 32)
+          Wq (fa (* dmodel (* nq hd)) 33) Wk (fa (* dmodel (* nkv hd)) 34)
+          Wv (fa (* dmodel (* nkv hd)) 35) Wo (fa (* (* nq hd) dmodel) 36)
+          tgt (fa (* seq dmodel) 37)
+          {:keys [grads]}
+          (gp/grad-parity #'attn-block-parity-loss
+                          [{:name 'x :type '(Array float) :val x}
+                           {:name 'wn :type '(Array float) :val wn}
+                           {:name 'Wq :type '(Array float) :val Wq}
+                           {:name 'Wk :type '(Array float) :val Wk}
+                           {:name 'Wv :type '(Array float) :val Wv}
+                           {:name 'Wo :type '(Array float) :val Wo}
+                           {:name 'tgt :type '(Array float) :val tgt}
+                           {:name 'seq :type 'Long :val seq}
+                           {:name 'dmodel :type 'Long :val dmodel}
+                           {:name 'nq :type 'Long :val nq}
+                           {:name 'nkv :type 'Long :val nkv}
+                           {:name 'hd :type 'Long :val hd}
+                           {:name 'eps :type 'Double :val eps}
+                           {:name 'go :type 'Double :val go}
+                           {:name 'theta :type 'Double :val theta}]
+                          :grad-args '[x]
+                          :gemm-precision :f32-scalar
+                          ;; exact-f32 GEMM: only summation-order noise remains
+                          ;; (CPU BLAS sgemm vs scalar device GEMM, both f32).
+                          :rtol 1.0e-5)]
+      (println "  [attn-block :f32-scalar] grad(x) steps:" (:step-kinds (get grads 'x))
+               "rel-err" (:rel-err (get grads 'x)))
+      (is (:resident? (get grads 'x))
+          "attn-block grad(x) under :gemm-precision :f32-scalar must extract FULLY RESIDENT")
+      (is (some #{:gemm} (:step-kinds (get grads 'x)))
+          "the policy case must actually exercise resident :gemm steps"))))
+
 ;; ── B2 MILESTONE: RESIDUAL-connection fan-out value+grad, FULLY RESIDENT ──────────
 ;; A real decoder layer has RESIDUAL connections (the attention block above has none):
 ;; a value `x1 = residual-add(x, m)` feeds BOTH the next `residual-add(x1, o)` AND

--- a/test/raster/dl/backward_kernel_resident_test.clj
+++ b/test/raster/dl/backward_kernel_resident_test.clj
@@ -354,6 +354,51 @@
       (is (:resident? (get grads 'x))
           "residual fan-out grad(x) must extract FULLY RESIDENT"))))
 
+;; ── horizontal-fusion multi-output regression (the gemma-block extraction bug) ────
+;; Two independent same-bound pure elementwise branches (g = a⊙a, u = b⊙b) consumed
+;; elementwise (y = g⊙u) then reduced (mse) — the residual/fan-out shape of the gemma
+;; FFN at tiny dims. The SOAC fuser horizontally fuses the branch pair into ONE
+;; multi-output map whose SECONDARY output buffer (`hfuse_out__N`) exists only as a
+;; side-effect aset in the fused lambda; the backward re-creates the same pair
+;; (da = d_y⊙…, db = d_y⊙…). This pins three formerly-broken layers:
+;;   1. SOAC io classification: an aset-written array is an array OUTPUT, never a
+;;      scalar (before: the kernel declared `float hfuse_out__N` and the extraction
+;;      eval'd the bare buffer sym on the host → `Unable to resolve symbol`).
+;;   2. Resident extraction: a :map step's binding sym ALIASES its out buffer
+;;      (invoke-registered-kernel returns it), so a later step reading the fused
+;;      PRIMARY's binding resolves to the real resident buffer at bind time.
+;;   3. resolve-alength: `(alength <invoke-binding>)` — a later fused branch's bound —
+;;      resolves through the invoke's registered buffer semantics (:in-place-arg) to
+;;      the out buffer's alloc size instead of surviving as a host read of a device
+;;      buffer.
+(deftm hfuse-two-branch-loss
+  [a :- (Array float) b :- (Array float) tgt :- (Array float) n :- Long] :- Double
+  (let [g (raster.dl.nn/hadamard a a n)
+        u (raster.dl.nn/hadamard b b n)
+        y (raster.dl.nn/hadamard g u n)]
+    (raster.dl.loss/mse-loss y tgt n)))
+
+(deftest horizontal-fusion-multi-output-resident-parity
+  (if-not @gp/gpu-available?
+    (println "  [SKIP] horizontal-fusion multi-output resident parity: no Level Zero GPU")
+    (let [n 32
+          a (fa n 61) b (fa n 62) tgt (fa n 63)
+          {:keys [grads]}
+          (gp/grad-parity #'hfuse-two-branch-loss
+                          [{:name 'a :type '(Array float) :val a}
+                           {:name 'b :type '(Array float) :val b}
+                           {:name 'tgt :type '(Array float) :val tgt}
+                           {:name 'n :type 'Long :val n}]
+                          ;; grad(a) reads the fused PRIMARY output (the invoke-binding
+                          ;; alias), grad(b) the SECONDARY (the hfuse_out alias binding).
+                          :grad-args '[a b]
+                          :rtol 1.0e-5)]
+      (doseq [g '[a b]]
+        (println "  [hfuse] grad(" g ") steps:" (:step-kinds (get grads g))
+                 "rel-err" (:rel-err (get grads g)))
+        (is (:resident? (get grads g))
+            (str "fused multi-output grad(" g ") must extract FULLY RESIDENT"))))))
+
 (deftest rope-value+grad-resident-parity
   (if-not @gp/gpu-available?
     (println "  [SKIP] rope resident parity: no Level Zero GPU")

--- a/test/raster/dl/gpu_grad_parity.clj
+++ b/test/raster/dl/gpu_grad_parity.clj
@@ -50,14 +50,15 @@
               (catch Throwable _ false))))
 
 (defn- run-resident
-  "Bind + replay f-var's resident descriptor on ze:0 for `args`; returns the result array."
-  [f-var args dtype]
+  "Bind + replay f-var's resident descriptor on ze:0 for `args`; returns the result array.
+   gemm-precision is compile-gpu-program's :gemm-precision (:f16-xmx | :f32-scalar)."
+  [f-var args dtype gemm-precision]
   (let [gpu (do (require 'raster.gpu.core) (find-ns 'raster.gpu.core))
         make-session (ns-resolve gpu 'make-session)
         bind-program! (ns-resolve gpu 'bind-program!)
         run-program! (ns-resolve gpu 'run-program!)
         close-session! (ns-resolve gpu 'close-session!)
-        p (pl/compile-gpu-program f-var :ze:0 :dtype dtype)
+        p (pl/compile-gpu-program f-var :ze:0 :dtype dtype :gemm-precision gemm-precision)
         s (make-session :ze:0)]
     (try
       (bind-program! s p args {})
@@ -102,12 +103,14 @@
      :dtype       :float (default) | :double   — resident compile dtype
      :rtol        max relative error (default 1e-3 for f32)
      :grad-args   coll of arg :name symbols to check (default: all Array-typed args)
+     :gemm-precision  :f16-xmx (default) | :f32-scalar — compile-gpu-program's resident
+                  :gemm binding policy (:f32-scalar = exact-grad scalar f32 GEMM)
 
    Runs on ze:0. Fails loudly (via clojure.test/is) if any checked gradient's wrapper
    does not extract fully resident, or if the GPU grad diverges beyond rtol.
    Returns {:grads {argname {:resident? :step-kinds :rel-err}}}."
-  [loss-var arg-specs & {:keys [dtype rtol grad-args]
-                         :or {dtype :float rtol 1.0e-3}}]
+  [loss-var arg-specs & {:keys [dtype rtol grad-args gemm-precision]
+                         :or {dtype :float rtol 1.0e-3 gemm-precision :f16-xmx}}]
   (let [names (mapv :name arg-specs)
         types (mapv :type arg-specs)
         vals  (mapv :val arg-specs)
@@ -130,14 +133,15 @@
                                            "-" (Math/abs (hash [loss-fqsym gname dtype]))))
                         wvar (build-wrapper wname names types loss-fqsym k (nth types j))
                         ;; residency probe (no throw): nil ⇒ a step fell to the host.
-                        desc (pl/compile-gpu-program wvar :ze:0 :dtype dtype :on-non-resident :nil)
+                        desc (pl/compile-gpu-program wvar :ze:0 :dtype dtype :on-non-resident :nil
+                                                     :gemm-precision gemm-precision)
                         step-kinds (mapv :convention (:steps desc))
                         _ (is (some? desc)
                               (str "grad(" gname ") of " loss-fqsym
                                    " must extract FULLY RESIDENT (compile-gpu-program returned nil ⇒ "
                                    "a kernel fell back to the host)"))
                         re (when desc
-                             (let [{:keys [out]} (run-resident wvar wargs dtype)
+                             (let [{:keys [out]} (run-resident wvar wargs dtype gemm-precision)
                                    e (rel-err out cpu-grad)]
                                (is (< e rtol)
                                    (str "grad(" gname ") GPU-vs-CPU rel-err " e " (rtol " rtol ")"))


### PR DESCRIPTION
Completes the typed-AD-emission queue on top of #60. **The gemma decoder block (LoRA on all 7 roles) now compiles to a single fully-resident GPU program with machine-precision gradients.**

## Residency fixes (the actual gemma blockers)
- **soac** (417ac93): an array a SOAC lambda writes via `aset` is an OUTPUT, never a scalar param — horizontal fusion's secondary outputs previously re-parsed into `:scalars`, emitting `float hfuse_out__N` as a scalar C param and eval'ing the device buffer on the host (`Unable to resolve symbol: hfuse_out__N`). Classified at the IR layer (`collect-aset-arrays`, carried `:raster.op/original`); kernel emitter declares secondaries `__global` + `:written-arrays`; staging fallback copies them back.
- **extraction** (2d65f2e): a `:map` kernel-invoke binding is a pure alias of its out buffer — extraction copy-propagates it; `invoke-registered-kernel` got a registry buffer-semantics descriptor so `resolve-alength`'s existing aliasing handles it (no pass-local pattern matching).
- **XMX** (939e89c): the A-operand 2D-block read needs pitch ≥16B like the B operand — `k<8` produced scrambled/zeroed C rows; the scalar fallback now gates on `(or (< n 8) (< k 8))`.
- **Π typed projection** (5ee5eeb): `project-expr` emits typed IR when the cotangent tag is manifest → census 0 undevirtualized on the gemma compile.

## Typed emission completed (1d) + inference fix
- All 44 external `:grads-fn` sites mint Π-tagged intermediates from their actual source-arg tags (73 mints); Π-⊥ intermediates deliberately untagged (74b0b2d, 8ad0e63).
- `infer-arg-tag` ctor arm no longer returns an empty/degenerate symbol for host dot heads (807c0fe; emitter guard from #60 stays as defense in depth).

## Phase 2 — typedness is now an ENFORCED invariant
- **Throw on GPU targets** at the fixpoint edge for non-exempt untagged bindings / undevirtualized calls, with op frequencies + example forms; CPU warns. Exempt classes documented in `census-exempt-head?` (void SOAC statements, clojure.core integer index arith, the result vector) (f333dcd).
- **Sound assert-then-delete** (instrumented fire counts, every decision re-derived on cold JVMs):
  - 8 `warn-default-tag!` `'doubles` defaults + 2 silent case-defaults: **0 fires across the suite → deleted, replaced by fail-loud `lost-tag!` throws** — the f32-narrowing hazard class is gone (4d173b9).
  - fixpoint-finalize re-tag/re-expand epilogue: 0 divergences → deleted; emission-time devirt made it a no-op and the new throw guards the cold-compile flake class it existed for (71e4413).
  - `oftype` + `grad-acc` facets: provably dead → deleted (e55fad3). `residual-add` facet: **load-bearing** (resblk resident parity fails cold without it) → kept + documented (2140033).

## :gemm-precision policy (explicit, user-approved)
`compile-gpu-program ... :gemm-precision :f16-xmx (default) | :f32-scalar`, carried on the program descriptor, bind-time overridable; no size heuristics; hardware gate independent (3a6bf52). Attention-block grad parity: **4.1e-6 under `:f32-scalar`** vs 1.7e-2 f16-XMX. Training requests exact f32; decode keeps XMX.

## Results
- **gemma block-f32-loss (finetune-side): fully resident, 133 steps (63 gemm / 44 map-void / 26 map)**; grads x 4.1e-4, Bd 5.2e-4 (f16 default), exact under `:f32-scalar`.
- Full Valhalla suite: **1804 tests / 31230 assertions / 0 failures / 0 errors**; ODE + laws + jit-aot-differential canaries green throughout.
- New regression tests: SOAC io classification, fused-secondary kernel params, hfuse two-branch resident parity (rel-err 0.0), f32-scalar precision parity, typed-emission per-file-class, inference dot-head.

Next (separate PR): resident train-step + 18-layer stack + SFT on real gemma-270m weights.