### PR TITLE
Gemma training milestone: resident LoRA train-step + gqa-backward dK/dV occupancy (240x/168x)

### DIFF
--- a/src/raster/dl/attention.clj
+++ b/src/raster/dl/attention.clj
@@ -1154,20 +1154,32 @@
          out)))
 
 ;; ----------------------------------------------------------------
-;; batched-causal-sdpa BACKWARD — THREE flat resident par/map-void! kernels,
-;; one per gradient (dQ / dK / dV), each returning a SEPARATE (Array T) — NOT an
-;; object-array bundle. This is the flash-attention backward, structured so every
-;; work-item owns a DISJOINT output row (no atomics, no host dotimes, no blit).
-;; Each kernel RECOMPUTES the row softmax exactly as the forward (running max mx,
-;; denom Z via -1.0e38 OpenCL-safe sentinel and m/exp), mirroring the forward's
-;; recompute philosophy — self-contained, so all three lower to resident :map-void
-;; with no cross-kernel saved-stat buffer. Conventions match batched-causal-sdpa:
+;; batched-causal-sdpa BACKWARD — flat resident par/map-void! kernels, one deftm
+;; per gradient (dQ / dK / dV), each returning a SEPARATE (Array T) — NOT an
+;; object-array bundle. Conventions match batched-causal-sdpa:
 ;;   score_ij = (Qb[i]·Kb[j]) / sqrt(head-dim)   (causal j≤i)
 ;;   w_ij     = softmax_j(score)                  (per query row i)
 ;;   dw_ij    = <dO_i, V_j>                        (unnormalized weight adjoint)
 ;;   D_i      = Σ_{j≤i} w_ij·dw_ij  (= <dO_i, out_i>)
 ;;   dS_ij    = w_ij·(dw_ij − D_i) / sqrt(head-dim)
 ;;   dQ_i = Σ_{j≤i} dS_ij·K_j     dK_j = Σ_{i≥j} dS_ij·Q_i     dV_j = Σ_{i≥j} w_ij·dO_i
+;;
+;; SHAPES. dQ parallelizes over (batch, query row i) — n = b·seq items, each owning
+;; dQ row i — and RECOMPUTES the row softmax like the forward (each row's stats are
+;; used by exactly ONE work item, so recompute is free of redundancy). dK/dV must
+;; NOT use that shape: their outputs are KV rows, and the softmax stats of query row
+;; i are needed by EVERY kv row j≤i — a per-(b,j)-item recompute repeats each row's
+;; O(seq·hd) stat computation seq times (O(b·seq³·hd) total) on only b·seq work
+;; items (n=256 at gemma dims: 79% of the backward step, dK 307 ms + dV 181 ms).
+;; Instead dK/dV MATERIALIZE the weight matrix ONCE (batched-causal-attn-weights,
+;; O(b·seq²·hd) total work spread over b·seq² items) and then accumulate with one
+;; work item per OUTPUT ELEMENT (b, kv row j, dim d) — n = b·seq·hd items, each an
+;; O(seq) serial sum over queries i≥j. Every output element keeps a single owner:
+;; no atomics, no host dotimes, no blit. (At gemma dims: 256 → 65536 items and
+;; ~160x less total work; measured standalone dK 452→1.9 ms, dV 241→1.4 ms on Arc;
+;; inside the resident gemma train-step the whole dK+dV group drops 488 ms → <1 ms,
+;; and the identical W of dK and dV is CSE'd into one computation.)
+;;
 ;; Every scalar that touches T-data (mx/Z/dot/w/…) stays T-typed via the SAME two
 ;; mechanisms as the forward: (1) reduction seeds are bare floating literals
 ;; (0.0 / -1.0e38) that narrow to the element dtype; (2) the 1/sqrt(head-dim) scale
@@ -1275,166 +1287,163 @@
                                      nil))))
          dQ)))
 
+(deftm batched-causal-attn-weights
+  "Materialized causal softmax weight matrix of batched-causal-sdpa:
+  W[b,i,j] = softmax_j((Qb[i]·Kb[j])/√hd) for j≤i, 0 above the diagonal —
+  [batch, seq, seq], query-row-major. TWO kernels: (1) raw scaled scores, parallel
+  over (b,i,j) — one hd-dot per work item (n = b·seq², the occupancy carrier);
+  (2) per query row (b,i) — running max + denom over the ≤i scores (an O(seq)
+  serial sweep with NO hd factor, so the low-width b·seq shape is cheap here) and
+  the normalized-weight writeback covering the FULL row (explicit 0 above the
+  diagonal — no reliance on alloc zero-init). Scores land in a separate scratch
+  buffer S (never rewritten in place — no read/write alias within a kernel).
+  Backward-only helper: dK/dV read W to avoid the O(seq)-redundant per-kv-row
+  softmax recompute; not AD-registered itself."
+  (All [T]
+       [Q :- (Array T) K :- (Array T)
+        batch :- Long seq-len :- Long head-dim :- Long]
+       :- (Array T)
+       (let [slab (* seq-len head-dim)
+             ss (* seq-len seq-len)
+             S (alloc-like Q (* batch ss))
+             W (alloc-like Q (* batch ss))]
+         ;; kernel 1: raw scaled causal scores S[b,i,j] (0 above the diagonal)
+         (raster.par/map-void! t (clojure.core/* batch ss)
+                               (let [b (quot t ss)
+                                     r (rem t ss)
+                                     i (quot r seq-len)
+                                     j (rem r seq-len)
+                                     boff (clojure.core/* b slab)]
+                                 (if (<= j i)
+                                   (let [qrow (clojure.core/+ boff (clojure.core/* i head-dim))
+                                         krow (clojure.core/+ boff (clojure.core/* j head-dim))
+                                         dot (loop [d 0 acc 0.0]
+                                               (if (< d head-dim)
+                                                 (recur (inc d)
+                                                        (+ acc (* (aget Q (clojure.core/+ qrow d))
+                                                                  (aget K (clojure.core/+ krow d)))))
+                                                 acc))]
+                                     (aset S t (/ dot (n/oftype dot (n/sqrt (double head-dim))))))
+                                   (aset S t 0.0))))
+         ;; kernel 2: per query row — mx/Z over the ≤i scores, write normalized weights
+         (raster.par/map-void! bi (clojure.core/* batch seq-len)
+                               (let [b (quot bi seq-len)
+                                     i (rem bi seq-len)
+                                     roff (clojure.core/+ (clojure.core/* b ss) (clojure.core/* i seq-len))
+                                     mx (loop [j 0 mm -1.0e38]
+                                          (if (<= j i)
+                                            (recur (inc j) (n/max mm (aget S (clojure.core/+ roff j))))
+                                            mm))
+                                     sum (loop [j 0 s 0.0]
+                                           (if (<= j i)
+                                             (recur (inc j) (+ s (m/exp (- (aget S (clojure.core/+ roff j)) mx))))
+                                             s))
+                                     inv (/ 1.0 sum)]
+                                 (loop [j 0]
+                                   (if (< j seq-len)
+                                     (do (if (<= j i)
+                                           (aset W (clojure.core/+ roff j)
+                                                 (* (m/exp (- (aget S (clojure.core/+ roff j)) mx)) inv))
+                                           (aset W (clojure.core/+ roff j) 0.0))
+                                         (recur (inc j)))
+                                     nil))))
+         W)))
+
 (deftm batched-causal-sdpa-dv
-  "dV of batched-causal-sdpa. Parallel over (batch b, key row j): each work-item owns
-  dV row j (disjoint). Loops queries i≥j (causal), recomputing query i's row softmax
-  to get w_ij, and accumulates dV[j,d] = Σ_{i≥j} w_ij·dO[i,d]."
+  "dV of batched-causal-sdpa. Materializes the weight matrix W (batched-causal-
+  attn-weights), then accumulates parallel over OUTPUT ELEMENTS (batch b, key row j,
+  dim d) — each work item owns dV[b,j,d] (disjoint, n = b·seq·hd) and serially sums
+  dV[j,d] = Σ_{i≥j} W[b,i,j]·dO[i,d] over the ≥j queries (causal)."
   (All [T]
        [d-out :- (Array T) Q :- (Array T) K :- (Array T) V :- (Array T)
         batch :- Long seq-len :- Long head-dim :- Long]
        :- (Array T)
        (let [slab (* seq-len head-dim)
+             ss (* seq-len seq-len)
+             W (batched-causal-attn-weights Q K batch seq-len head-dim)
              dV (alloc-like Q (* batch slab))]
-         (raster.par/map-void! bj (clojure.core/* batch seq-len)
-                               (let [b    (quot bj seq-len)
-                                     j    (rem bj seq-len)
+         (raster.par/map-void! t (clojure.core/* batch slab)
+                               (let [b (quot t slab)
+                                     r (rem t slab)
+                                     j (quot r head-dim)
+                                     d (rem r head-dim)
                                      boff (clojure.core/* b slab)
-                                     jrow (clojure.core/+ boff (clojure.core/* j head-dim))]
-                                 (loop [d 0]
-                                   (if (< d head-dim)
-                                     (do (aset dV (clojure.core/+ jrow d) 0.0) (recur (inc d)))
-                                     nil))
-                                 (loop [i j]
-                                   (if (< i seq-len)
-                                     (let [qrow (clojure.core/+ boff (clojure.core/* i head-dim))
-                       ;; recompute query i's softmax normalization over k≤i
-                                           mx (loop [k 0 mm -1.0e38]
-                                                (if (<= k i)
-                                                  (let [krow (clojure.core/+ boff (clojure.core/* k head-dim))
-                                                        dot (loop [d 0 acc 0.0]
-                                                              (if (< d head-dim)
-                                                                (recur (inc d)
-                                                                       (+ acc (* (aget Q (clojure.core/+ qrow d))
-                                                                                 (aget K (clojure.core/+ krow d)))))
-                                                                acc))]
-                                                    (recur (inc k) (n/max mm (/ dot (n/oftype dot (n/sqrt (double head-dim)))))))
-                                                  mm))
-                                           sum (loop [k 0 s 0.0]
-                                                 (if (<= k i)
-                                                   (let [krow (clojure.core/+ boff (clojure.core/* k head-dim))
-                                                         dot (loop [d 0 acc 0.0]
-                                                               (if (< d head-dim)
-                                                                 (recur (inc d)
-                                                                        (+ acc (* (aget Q (clojure.core/+ qrow d))
-                                                                                  (aget K (clojure.core/+ krow d)))))
-                                                                 acc))]
-                                                     (recur (inc k) (+ s (m/exp (- (/ dot (n/oftype dot (n/sqrt (double head-dim)))) mx)))))
-                                                   s))
-                                           inv (/ 1.0 sum)
-                       ;; w_ij for THIS key row j (krow = jrow)
-                                           dotij (loop [d 0 acc 0.0]
-                                                   (if (< d head-dim)
-                                                     (recur (inc d)
-                                                            (+ acc (* (aget Q (clojure.core/+ qrow d))
-                                                                      (aget K (clojure.core/+ jrow d)))))
-                                                     acc))
-                                           w (* (m/exp (- (/ dotij (n/oftype dotij (n/sqrt (double head-dim)))) mx)) inv)]
-                                       (loop [d 0]
-                                         (if (< d head-dim)
-                                           (do (aset dV (clojure.core/+ jrow d)
-                                                     (+ (aget dV (clojure.core/+ jrow d))
-                                                        (* w (aget d-out (clojure.core/+ qrow d)))))
-                                               (recur (inc d)))
-                                           nil))
-                                       (recur (inc i)))
-                                     nil))))
+                                     woff (clojure.core/+ (clojure.core/* b ss) j)
+                                     acc (loop [i j acc 0.0]
+                                           (if (< i seq-len)
+                                             (recur (inc i)
+                                                    (+ acc (* (aget W (clojure.core/+ woff (clojure.core/* i seq-len)))
+                                                              (aget d-out (clojure.core/+ boff (clojure.core/+ (clojure.core/* i head-dim) d))))))
+                                             acc))]
+                                 (aset dV t acc)))
          dV)))
 
 (deftm batched-causal-sdpa-dk
-  "dK of batched-causal-sdpa. Parallel over (batch b, key row j): each work-item owns
-  dK row j (disjoint). Loops queries i≥j (causal); for each, recomputes query i's row
-  softmax + D_i and accumulates dK[j,d] = (1/√hd)·Σ_{i≥j} w_ij·(⟨dO_i,V_j⟩ − D_i)·Q[i,d]."
+  "dK of batched-causal-sdpa. FOUR kernels: (1)+(2) materialize the weight matrix W
+  (batched-causal-attn-weights); (3) DW[b,i,j] = ⟨dO_i,V_j⟩, parallel over (b,i,j)
+  — one hd-dot per item (0 above the diagonal); (4) Dbuf[b,i] = Σ_{j≤i} W·DW, a
+  cheap O(seq) per-row sweep; (5) the accumulation, parallel over OUTPUT ELEMENTS
+  (b, key row j, dim d) — each work item owns dK[b,j,d] (disjoint, n = b·seq·hd)
+  and serially sums dK[j,d] = (1/√hd)·Σ_{i≥j} W[b,i,j]·(DW[b,i,j] − Dbuf[b,i])·Q[i,d]."
   (All [T]
        [d-out :- (Array T) Q :- (Array T) K :- (Array T) V :- (Array T)
         batch :- Long seq-len :- Long head-dim :- Long]
        :- (Array T)
        (let [slab (* seq-len head-dim)
+             ss (* seq-len seq-len)
+             W (batched-causal-attn-weights Q K batch seq-len head-dim)
+             DW (alloc-like Q (* batch ss))
+             Dbuf (alloc-like Q (* batch seq-len))
              dK (alloc-like Q (* batch slab))]
-         (raster.par/map-void! bj (clojure.core/* batch seq-len)
-                               (let [b    (quot bj seq-len)
-                                     j    (rem bj seq-len)
+         ;; kernel 3: DW[b,i,j] = ⟨dO_i, V_j⟩ for j≤i (0 above the diagonal)
+         (raster.par/map-void! t (clojure.core/* batch ss)
+                               (let [b (quot t ss)
+                                     r (rem t ss)
+                                     i (quot r seq-len)
+                                     j (rem r seq-len)
+                                     boff (clojure.core/* b slab)]
+                                 (if (<= j i)
+                                   (let [qrow (clojure.core/+ boff (clojure.core/* i head-dim))
+                                         jrow (clojure.core/+ boff (clojure.core/* j head-dim))
+                                         dw (loop [d 0 acc 0.0]
+                                              (if (< d head-dim)
+                                                (recur (inc d)
+                                                       (+ acc (* (aget d-out (clojure.core/+ qrow d))
+                                                                 (aget V (clojure.core/+ jrow d)))))
+                                                acc))]
+                                     (aset DW t dw))
+                                   (aset DW t 0.0))))
+         ;; kernel 4: Dbuf[b,i] = Σ_{j≤i} W[b,i,j]·DW[b,i,j]  (= ⟨dO_i, out_i⟩)
+         (raster.par/map-void! bi (clojure.core/* batch seq-len)
+                               (let [b (quot bi seq-len)
+                                     i (rem bi seq-len)
+                                     roff (clojure.core/+ (clojure.core/* b ss) (clojure.core/* i seq-len))
+                                     acc (loop [j 0 acc 0.0]
+                                           (if (<= j i)
+                                             (recur (inc j)
+                                                    (+ acc (* (aget W (clojure.core/+ roff j))
+                                                              (aget DW (clojure.core/+ roff j)))))
+                                             acc))]
+                                 (aset Dbuf bi acc)))
+         ;; kernel 5: dK[b,j,d] = (1/√hd)·Σ_{i≥j} W[b,i,j]·(DW[b,i,j] − Dbuf[b,i])·Q[i,d]
+         (raster.par/map-void! t (clojure.core/* batch slab)
+                               (let [b (quot t slab)
+                                     r (rem t slab)
+                                     j (quot r head-dim)
+                                     d (rem r head-dim)
                                      boff (clojure.core/* b slab)
-                                     jrow (clojure.core/+ boff (clojure.core/* j head-dim))]
-                                 (loop [d 0]
-                                   (if (< d head-dim)
-                                     (do (aset dK (clojure.core/+ jrow d) 0.0) (recur (inc d)))
-                                     nil))
-                                 (loop [i j]
-                                   (if (< i seq-len)
-                                     (let [qrow (clojure.core/+ boff (clojure.core/* i head-dim))
-                                           mx (loop [k 0 mm -1.0e38]
-                                                (if (<= k i)
-                                                  (let [krow (clojure.core/+ boff (clojure.core/* k head-dim))
-                                                        dot (loop [d 0 acc 0.0]
-                                                              (if (< d head-dim)
-                                                                (recur (inc d)
-                                                                       (+ acc (* (aget Q (clojure.core/+ qrow d))
-                                                                                 (aget K (clojure.core/+ krow d)))))
-                                                                acc))]
-                                                    (recur (inc k) (n/max mm (/ dot (n/oftype dot (n/sqrt (double head-dim)))))))
-                                                  mm))
-                                           sum (loop [k 0 s 0.0]
-                                                 (if (<= k i)
-                                                   (let [krow (clojure.core/+ boff (clojure.core/* k head-dim))
-                                                         dot (loop [d 0 acc 0.0]
-                                                               (if (< d head-dim)
-                                                                 (recur (inc d)
-                                                                        (+ acc (* (aget Q (clojure.core/+ qrow d))
-                                                                                  (aget K (clojure.core/+ krow d)))))
-                                                                 acc))]
-                                                     (recur (inc k) (+ s (m/exp (- (/ dot (n/oftype dot (n/sqrt (double head-dim)))) mx)))))
-                                                   s))
-                                           inv (/ 1.0 sum)
-                       ;; D_i = Σ_{k≤i} w_ik·⟨dO_i,V_k⟩
-                                           Di (loop [k 0 acc 0.0]
-                                                (if (<= k i)
-                                                  (let [krow (clojure.core/+ boff (clojure.core/* k head-dim))
-                                                        dot (loop [d 0 a 0.0]
-                                                              (if (< d head-dim)
-                                                                (recur (inc d)
-                                                                       (+ a (* (aget Q (clojure.core/+ qrow d))
-                                                                               (aget K (clojure.core/+ krow d)))))
-                                                                a))
-                                                        w  (* (m/exp (- (/ dot (n/oftype dot (n/sqrt (double head-dim)))) mx)) inv)
-                                                        dw (loop [d 0 a 0.0]
-                                                             (if (< d head-dim)
-                                                               (recur (inc d)
-                                                                      (+ a (* (aget d-out (clojure.core/+ qrow d))
-                                                                              (aget V (clojure.core/+ krow d)))))
-                                                               a))]
-                                                    (recur (inc k) (+ acc (* w dw))))
-                                                  acc))
-                       ;; w_ij and dw_ij for key row j
-                                           dotij (loop [d 0 acc 0.0]
-                                                   (if (< d head-dim)
-                                                     (recur (inc d)
-                                                            (+ acc (* (aget Q (clojure.core/+ qrow d))
-                                                                      (aget K (clojure.core/+ jrow d)))))
-                                                     acc))
-                                           wij (* (m/exp (- (/ dotij (n/oftype dotij (n/sqrt (double head-dim)))) mx)) inv)
-                                           dwij (loop [d 0 a 0.0]
-                                                  (if (< d head-dim)
-                                                    (recur (inc d)
-                                                           (+ a (* (aget d-out (clojure.core/+ qrow d))
-                                                                   (aget V (clojure.core/+ jrow d)))))
-                                                    a))
-                                           c (* wij (- dwij Di))]
-                                       (loop [d 0]
-                                         (if (< d head-dim)
-                                           (do (aset dK (clojure.core/+ jrow d)
-                                                     (+ (aget dK (clojure.core/+ jrow d))
-                                                        (* c (aget Q (clojure.core/+ qrow d)))))
-                                               (recur (inc d)))
-                                           nil))
-                                       (recur (inc i)))
-                                     nil))
-             ;; finalize the (1/√hd) scale on this key row
-                                 (loop [d 0]
-                                   (if (< d head-dim)
-                                     (let [v (aget dK (clojure.core/+ jrow d))]
-                                       (aset dK (clojure.core/+ jrow d) (/ v (n/oftype v (n/sqrt (double head-dim)))))
-                                       (recur (inc d)))
-                                     nil))))
+                                     woff (clojure.core/+ (clojure.core/* b ss) j)
+                                     doff (clojure.core/* b seq-len)
+                                     acc (loop [i j acc 0.0]
+                                           (if (< i seq-len)
+                                             (let [wij (aget W (clojure.core/+ woff (clojure.core/* i seq-len)))
+                                                   dwij (aget DW (clojure.core/+ woff (clojure.core/* i seq-len)))
+                                                   di (aget Dbuf (clojure.core/+ doff i))]
+                                               (recur (inc i)
+                                                      (+ acc (* (* wij (- dwij di))
+                                                                (aget Q (clojure.core/+ boff (clojure.core/+ (clojure.core/* i head-dim) d)))))))
+                                             acc))]
+                                 (aset dK t (/ acc (n/oftype acc (n/sqrt (double head-dim)))))))
          dK)))
 
 (tmpl/merge-into-template! 'raster.dl.attention/batched-causal-sdpa

--- a/test/raster/dl/gemma_train_resident_test.clj
+++ b/test/raster/dl/gemma_train_resident_test.clj
@@ -1,0 +1,291 @@
+(ns raster.dl.gemma-train-resident-test
+  "MILESTONE (gemma GPU trainability, step 1): a RESIDENT TRAIN-STEP for the full
+   gemma LoRA decoder block — forward + reverse-AD backward + SGD adapter update in
+   ONE resident GPU program, adapters updated on-device, loss decreasing over steps.
+
+   The block here is a raster-side TWIN of finetune.gemma's gemma-block at tiny dims
+   (same op graph: rms-norm sandwich, LoRA q/k/v/o + GeGLU gate/up/down, per-head
+   qk-norm, rope, gqa-causal-mha, residuals), concrete (Array float) with the LoRA
+   low-rank delta spelled inline (3 linear-nb + residual-add — the flattened
+   lora-linear shape that keeps the body raster-templated-ops-only, see the B1 note
+   in finetune gemma_f32_grad_test). The real-weights run is finetune-side (step 2).
+
+   Train-step architecture (the M1 lora-train-step pattern, finetune lora_gpu.clj):
+   value+grad is bound DIRECTLY to its own symbol (the AD transform only fires on a
+   directly-bound call), the 14 LoRA adapter grads are nth'd out of the result
+   vector, and raster.dl.optim/sgd-step! folds `p := p - lr*dp` in place per adapter
+   — all ordinary deftm/par ops, so the whole fwd+bwd+update extracts as ONE
+   resident program via compile-gpu-program. The primal loss (nth vg 0) is unused
+   and DCE'd; loss is monitored host-side from the downloaded adapter state (the
+   adapters are tiny). Adapters bind :state (resident, updated on-device, never
+   re-uploaded); frozen weights / norms / data bind :constant.
+
+   GATES:
+     • the train step extracts FULLY RESIDENT under :gemm-precision :f32-scalar
+       (exact-f32 grads — the training GEMM policy);
+     • 25 on-device steps: loss decreases, adapters changed on-device;
+     • a CPU-interpreted reference loop (same value+grad + sgd-step!, same lr/data)
+       tracks the GPU loss trajectory within f32 tolerance."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.core :refer [deftm]]
+            [raster.dl.nn :as nn]
+            [raster.dl.attention :as attn]
+            [raster.dl.loss :as loss]
+            [raster.dl.optim :as optim]
+            [raster.arrays :as ra]
+            [raster.ad.reverse :as rev]
+            [raster.compiler.pipeline :as pl]
+            [raster.dl.gpu-grad-parity :as gp]))
+
+;; ── the twin block (concrete float, LoRA delta inline) ──────────────────────────
+
+;; Flattened LoRA linear: frozen base + trainable low-rank delta B·(A·x), spelled
+;; as raster.dl.nn ops only (no nested parametric user deftm — the B1-safe shape).
+(deftm lora-lin
+  [x :- (Array float) W :- (Array float) A :- (Array float) B :- (Array float)
+   rows :- Long in :- Long r :- Long out :- Long] :- (Array float)
+  (let [ax   (raster.dl.nn/linear-nb x A rows in r)
+        bax  (raster.dl.nn/linear-nb ax B rows r out)
+        base (raster.dl.nn/linear-nb x W rows in out)]
+    (raster.dl.nn/residual-add base bax (clojure.core/* rows out))))
+
+;; One gemma decoder block (twin of finetune.gemma/gemma-block): x:[seq,d] → [seq,d].
+(deftm gblk
+  [x :- (Array float)
+   input-ln :- (Array float) q-norm :- (Array float) k-norm :- (Array float)
+   post-attn :- (Array float) pre-ffn :- (Array float) post-ffn :- (Array float)
+   Wq :- (Array float) Aq :- (Array float) Bq :- (Array float)
+   Wk :- (Array float) Ak :- (Array float) Bk :- (Array float)
+   Wv :- (Array float) Av :- (Array float) Bv :- (Array float)
+   Wo :- (Array float) Ao :- (Array float) Bo :- (Array float)
+   Wg :- (Array float) Ag :- (Array float) Bg :- (Array float)
+   Wu :- (Array float) Au :- (Array float) Bu :- (Array float)
+   Wd :- (Array float) Ad :- (Array float) Bd :- (Array float)
+   seq :- Long d :- Long nq :- Long nkv :- Long hd :- Long dff :- Long r :- Long
+   eps :- Double theta :- Double] :- (Array float)
+  (let [nqh (clojure.core/* nq hd) nkh (clojure.core/* nkv hd) n (clojure.core/* seq d)
+        h  (nn/rms-norm x input-ln seq d eps 1.0)
+        q  (raster.dl.gemma-train-resident-test/lora-lin h Wq Aq Bq seq d r nqh)
+        k  (raster.dl.gemma-train-resident-test/lora-lin h Wk Ak Bk seq d r nkh)
+        v  (raster.dl.gemma-train-resident-test/lora-lin h Wv Av Bv seq d r nkh)
+        q  (nn/rms-norm q q-norm (clojure.core/* seq nq) hd eps 1.0)
+        k  (nn/rms-norm k k-norm (clojure.core/* seq nkv) hd eps 1.0)
+        q  (attn/rope q seq nq hd theta)
+        k  (attn/rope k seq nkv hd theta)
+        a  (attn/gqa-causal-mha q k v seq nq nkv hd)
+        o  (raster.dl.gemma-train-resident-test/lora-lin a Wo Ao Bo seq nqh r d)
+        o  (nn/rms-norm o post-attn seq d eps 1.0)
+        x1 (nn/residual-add x o n)
+        h2 (nn/rms-norm x1 pre-ffn seq d eps 1.0)
+        g  (raster.dl.gemma-train-resident-test/lora-lin h2 Wg Ag Bg seq d r dff)
+        g  (nn/gelu g (clojure.core/* seq dff))
+        u  (raster.dl.gemma-train-resident-test/lora-lin h2 Wu Au Bu seq d r dff)
+        hh (nn/hadamard g u (clojure.core/* seq dff))
+        m  (raster.dl.gemma-train-resident-test/lora-lin hh Wd Ad Bd seq dff r d)
+        m  (nn/rms-norm m post-ffn seq d eps 1.0)]
+    (nn/residual-add x1 m n)))
+
+;; mse loss over the block. Adapter-grad slots in value+grad's result vector
+;; (arg j → vg j+1): Aq 8→9, Bq 9→10, Ak 11→12, Bk 12→13, Av 14→15, Bv 15→16,
+;; Ao 17→18, Bo 18→19, Ag 20→21, Bg 21→22, Au 23→24, Bu 24→25, Ad 26→27, Bd 27→28.
+(deftm gblk-loss
+  [x :- (Array float)
+   input-ln :- (Array float) q-norm :- (Array float) k-norm :- (Array float)
+   post-attn :- (Array float) pre-ffn :- (Array float) post-ffn :- (Array float)
+   Wq :- (Array float) Aq :- (Array float) Bq :- (Array float)
+   Wk :- (Array float) Ak :- (Array float) Bk :- (Array float)
+   Wv :- (Array float) Av :- (Array float) Bv :- (Array float)
+   Wo :- (Array float) Ao :- (Array float) Bo :- (Array float)
+   Wg :- (Array float) Ag :- (Array float) Bg :- (Array float)
+   Wu :- (Array float) Au :- (Array float) Bu :- (Array float)
+   Wd :- (Array float) Ad :- (Array float) Bd :- (Array float)
+   tgt :- (Array float)
+   seq :- Long d :- Long nq :- Long nkv :- Long hd :- Long dff :- Long r :- Long
+   eps :- Double theta :- Double] :- Double
+  (let [y (raster.dl.gemma-train-resident-test/gblk x
+                                                    input-ln q-norm k-norm post-attn pre-ffn post-ffn
+                                                    Wq Aq Bq Wk Ak Bk Wv Av Bv Wo Ao Bo Wg Ag Bg Wu Au Bu Wd Ad Bd
+                                                    seq d nq nkv hd dff r eps theta)]
+    (raster.dl.loss/mse-loss y tgt (clojure.core/* seq d))))
+
+;; ── the RESIDENT TRAIN STEP ──────────────────────────────────────────────────────
+;; value+grad (fwd+bwd of the whole block) + 14 in-place SGD updates, one program.
+;; Returns Aq (an array result the resident extractor accepts); the loss primal is
+;; dead here and DCE'd — loss is monitored host-side from the adapter state.
+(deftm gblk-train-step
+  [Aq :- (Array float) Bq :- (Array float) Ak :- (Array float) Bk :- (Array float)
+   Av :- (Array float) Bv :- (Array float) Ao :- (Array float) Bo :- (Array float)
+   Ag :- (Array float) Bg :- (Array float) Au :- (Array float) Bu :- (Array float)
+   Ad :- (Array float) Bd :- (Array float)
+   x :- (Array float)
+   input-ln :- (Array float) q-norm :- (Array float) k-norm :- (Array float)
+   post-attn :- (Array float) pre-ffn :- (Array float) post-ffn :- (Array float)
+   Wq :- (Array float) Wk :- (Array float) Wv :- (Array float) Wo :- (Array float)
+   Wg :- (Array float) Wu :- (Array float) Wd :- (Array float)
+   tgt :- (Array float)
+   seq :- Long d :- Long nq :- Long nkv :- Long hd :- Long dff :- Long r :- Long
+   eps :- Double theta :- Double lr :- Double] :- (Array float)
+  (let [vg ((raster.ad.reverse/value+grad
+             (var raster.dl.gemma-train-resident-test/gblk-loss))
+            x input-ln q-norm k-norm post-attn pre-ffn post-ffn
+            Wq Aq Bq Wk Ak Bk Wv Av Bv Wo Ao Bo Wg Ag Bg Wu Au Bu Wd Ad Bd
+            tgt seq d nq nkv hd dff r eps theta)
+        dAq (clojure.core/nth vg 9)  dBq (clojure.core/nth vg 10)
+        dAk (clojure.core/nth vg 12) dBk (clojure.core/nth vg 13)
+        dAv (clojure.core/nth vg 15) dBv (clojure.core/nth vg 16)
+        dAo (clojure.core/nth vg 18) dBo (clojure.core/nth vg 19)
+        dAg (clojure.core/nth vg 21) dBg (clojure.core/nth vg 22)
+        dAu (clojure.core/nth vg 24) dBu (clojure.core/nth vg 25)
+        dAd (clojure.core/nth vg 27) dBd (clojure.core/nth vg 28)]
+    (raster.dl.optim/sgd-step! Aq dAq (raster.arrays/alength Aq) lr)
+    (raster.dl.optim/sgd-step! Bq dBq (raster.arrays/alength Bq) lr)
+    (raster.dl.optim/sgd-step! Ak dAk (raster.arrays/alength Ak) lr)
+    (raster.dl.optim/sgd-step! Bk dBk (raster.arrays/alength Bk) lr)
+    (raster.dl.optim/sgd-step! Av dAv (raster.arrays/alength Av) lr)
+    (raster.dl.optim/sgd-step! Bv dBv (raster.arrays/alength Bv) lr)
+    (raster.dl.optim/sgd-step! Ao dAo (raster.arrays/alength Ao) lr)
+    (raster.dl.optim/sgd-step! Bo dBo (raster.arrays/alength Bo) lr)
+    (raster.dl.optim/sgd-step! Ag dAg (raster.arrays/alength Ag) lr)
+    (raster.dl.optim/sgd-step! Bg dBg (raster.arrays/alength Bg) lr)
+    (raster.dl.optim/sgd-step! Au dAu (raster.arrays/alength Au) lr)
+    (raster.dl.optim/sgd-step! Bu dBu (raster.arrays/alength Bu) lr)
+    (raster.dl.optim/sgd-step! Ad dAd (raster.arrays/alength Ad) lr)
+    (raster.dl.optim/sgd-step! Bd dBd (raster.arrays/alength Bd) lr)
+    Aq))
+
+;; ── data / config ────────────────────────────────────────────────────────────────
+
+(def CFG {:seq 4 :d 8 :nq 2 :nkv 1 :hd 4 :dff 16 :r 4 :eps 1.0e-6 :theta 10000.0})
+
+(defn- fa
+  "Deterministic gaussian float array."
+  ^floats [n seed scale]
+  (let [rng (java.util.Random. (long seed)) a (float-array n)]
+    (dotimes [i n] (aset a i (float (* (double scale) (.nextGaussian rng))))) a))
+
+(def ^:private adapter-syms
+  '[Aq Bq Ak Bk Av Bv Ao Bo Ag Bg Au Bu Ad Bd])
+
+(defn- init-state
+  "All arrays for one training problem, keyed by param sym. Adapters random
+   (scale 0.2 — nonzero so every adapter grad is live from step 0)."
+  [{:keys [seq d nq nkv hd dff r]}]
+  (let [nqh (* nq hd) nkh (* nkv hd) f (fn [n s] (fa n s 0.2))]
+    {'x  (f (* seq d) 700)
+     'input-ln (f d 1) 'q-norm (f hd 2) 'k-norm (f hd 3)
+     'post-attn (f d 4) 'pre-ffn (f d 5) 'post-ffn (f d 6)
+     'Wq (f (* nqh d) 7)  'Aq (f (* r d) 8)   'Bq (f (* nqh r) 9)
+     'Wk (f (* nkh d) 10) 'Ak (f (* r d) 11)  'Bk (f (* nkh r) 12)
+     'Wv (f (* nkh d) 13) 'Av (f (* r d) 14)  'Bv (f (* nkh r) 15)
+     'Wo (f (* d nqh) 16) 'Ao (f (* r nqh) 17) 'Bo (f (* d r) 18)
+     'Wg (f (* dff d) 19) 'Ag (f (* r d) 20)  'Bg (f (* dff r) 21)
+     'Wu (f (* dff d) 22) 'Au (f (* r d) 23)  'Bu (f (* dff r) 24)
+     'Wd (f (* d dff) 25) 'Ad (f (* r dff) 26) 'Bd (f (* d r) 27)
+     'tgt (f (* seq d) 800)}))
+
+(defn- loss-args
+  "gblk-loss arg vector for a state map."
+  [{:keys [seq d nq nkv hd dff r eps theta]} st]
+  (into (mapv st '[x input-ln q-norm k-norm post-attn pre-ffn post-ffn
+                   Wq Aq Bq Wk Ak Bk Wv Av Bv Wo Ao Bo Wg Ag Bg Wu Au Bu Wd Ad Bd
+                   tgt])
+        [seq d nq nkv hd dff r eps theta]))
+
+(defn- train-args
+  "gblk-train-step arg vector for a state map."
+  [{:keys [seq d nq nkv hd dff r eps theta]} st lr]
+  (into (mapv st (concat adapter-syms
+                         '[x input-ln q-norm k-norm post-attn pre-ffn post-ffn
+                           Wq Wk Wv Wo Wg Wu Wd tgt]))
+        [seq d nq nkv hd dff r eps theta lr]))
+
+(defn- host-loss ^double [cfg st]
+  (double (apply gblk-loss (loss-args cfg st))))
+
+(defn- clone-adapters [st]
+  (reduce (fn [m s] (assoc m s (aclone ^floats (st s)))) st adapter-syms))
+
+;; vg slot per adapter sym (arg idx + 1 in gblk-loss).
+(def ^:private adapter-vg-slot
+  (zipmap adapter-syms [9 10 12 13 15 16 18 19 21 22 24 25 27 28]))
+
+(defn- cpu-train!
+  "CPU-interpreted reference loop: n-steps of value+grad + sgd-step! in place on
+   st's adapter arrays. Returns the loss trajectory [loss(state_0) … loss(state_n)]."
+  [cfg st lr n-steps]
+  (let [vg-fn (rev/value+grad #'gblk-loss)]
+    (loop [k 0 losses []]
+      (if (= k n-steps)
+        (conj losses (host-loss cfg st))
+        (let [vg (apply vg-fn (loss-args cfg st))]
+          (doseq [s adapter-syms]
+            (optim/sgd-step! (st s) (nth vg (adapter-vg-slot s))
+                             (ra/alength ^floats (st s)) lr))
+          (recur (inc k) (conj losses (double (nth vg 0)))))))))
+
+;; ── the gate ─────────────────────────────────────────────────────────────────────
+
+(deftest gemma-lora-block-resident-train-step
+  (if-not @gp/gpu-available?
+    (println "  [SKIP] gemma LoRA block resident train-step: no Level Zero GPU")
+    (let [gpu (do (require 'raster.gpu.core) (find-ns 'raster.gpu.core))
+          make-session (ns-resolve gpu 'make-session)
+          bind-program! (ns-resolve gpu 'bind-program!)
+          run-program! (ns-resolve gpu 'run-program!)
+          close-session! (ns-resolve gpu 'close-session!)
+          download (ns-resolve gpu 'download)
+          cfg CFG
+          lr 0.02
+          n-steps 25
+          st0 (init-state cfg)
+          args (train-args cfg st0 lr)
+          prog (pl/compile-gpu-program #'gblk-train-step :ze:0 :dtype :float
+                                       :on-non-resident :nil
+                                       :gemm-precision :f32-scalar)
+          step-kinds (frequencies (mapv :convention (:steps prog)))]
+      (testing "the fused fwd+bwd+SGD train step extracts FULLY RESIDENT"
+        (is (some? prog)
+            "compile-gpu-program returned nil ⇒ a step fell back to the host")
+        (println "  [gemma train-step] resident steps:" (count (:steps prog))
+                 "by kind:" step-kinds))
+      (when prog
+        (let [sess (make-session :ze:0)]
+          (try
+            (bind-program! sess prog args
+                           (merge (zipmap adapter-syms (repeat :state))
+                                  (zipmap '[x input-ln q-norm k-norm post-attn
+                                            pre-ffn post-ffn Wq Wk Wv Wo Wg Wu Wd tgt]
+                                          (repeat :constant))))
+            (let [gpu-state (fn [] (reduce (fn [m s]
+                                             (assoc m s (download sess (keyword (name s)))))
+                                           st0 adapter-syms))
+                  gpu-losses (loop [k 0 losses [(host-loss cfg st0)]]
+                               (if (= k n-steps)
+                                 losses
+                                 (do (run-program! sess prog args)
+                                     (recur (inc k)
+                                            (conj losses (host-loss cfg (gpu-state)))))))
+                  cpu-losses (cpu-train! cfg (clone-adapters st0) lr n-steps)
+                  final-adapters (gpu-state)]
+              (println "  [gemma train-step] GPU loss:"
+                       (mapv #(format "%.6f" %) (take 4 gpu-losses)) "…"
+                       (mapv #(format "%.6f" %) (take-last 3 gpu-losses)))
+              (println "  [gemma train-step] CPU loss:"
+                       (mapv #(format "%.6f" %) (take 4 cpu-losses)) "…"
+                       (mapv #(format "%.6f" %) (take-last 3 cpu-losses)))
+              (testing "loss decreases over 25 on-device steps"
+                (is (< (peek gpu-losses) (* 0.7 (first gpu-losses)))
+                    (str "final " (peek gpu-losses) " vs initial " (first gpu-losses)))
+                ;; overall decreasing: allow small plateaus/bumps, not a rising tail
+                (is (>= 3 (count (filter true? (map >= (rest gpu-losses) gpu-losses))))
+                    "at most 3 non-decreasing steps"))
+              (testing "adapters changed on-device"
+                (doseq [s adapter-syms]
+                  (is (not (java.util.Arrays/equals ^floats (final-adapters s)
+                                                    ^floats (st0 s)))
+                      (str s " must differ from init after training"))))
+              (testing "CPU-interpreted loop tracks the GPU trajectory (f32 tolerance)"
+                (doseq [[k g c] (map vector (range) gpu-losses cpu-losses)]
+                  (is (< (/ (Math/abs (- g c)) (max 1e-9 (Math/abs c))) 1.0e-3)
+                      (format "step %d GPU %.6f vs CPU %.6f" k g c)))))
+            (finally (close-session! sess))))))))


### PR DESCRIPTION
Raster-side of the gemma GPU trainability milestone (on top of #61).

## Resident train-step (9752706)
New GPU-gated regression test `gemma_train_resident_test.clj`: the gemma LoRA block (rms-norm sandwich, LoRA q/k/v/o + GeGLU gate/up/down, qk-norm, rope, gqa-causal-mha, residuals) trains as **one resident GPU program** — value+grad + 14× `optim/sgd-step!` folded in, 146 resident steps, adapters `:state` updated on-device. 25-step loss 2.80 → 0.26 strictly decreasing; GPU-vs-CPU trajectory rel-err ≤3.5e-7 under `:gemm-precision :f32-scalar`. Zero compiler changes were needed — validates the #60/#61 arc end-to-end.

## gqa backward dK/dV occupancy (10f0a6d)
The dK/dV kernels parallelized over (batch, kv-row) — n=256 work items at gemma-270m dims (MQA: nkv=1, hd=256), each recomputing every query row's softmax stats: O(b·seq³·hd) on 256 items, measured at **79% of the gemma backward step** (18-layer real-weights training, finetune-side).

Reshape (single-owner everywhere, no atomics): materialize the causal weight matrix W[b,i,j] (scores kernel n=b·seq², per-row normalize n=b·seq) + output-element-parallel accumulations over (b, kv-row, dim) with n=b·seq·hd=65536; dK adds DW=⟨dO_i,V_j⟩ (n=b·seq²) + a cheap per-row D sweep. Kernel signatures and the grads-fn unchanged; SOAC fusion CSEs the W computation shared by dK and dV.

At seq=64 / d=640 / nq=4 / nkv=1 / hd=256 on Arc (ze:0):
- dK **452 → 1.88 ms (240x)**, dV **241 → 1.43 ms (168x)**
- per-layer fused fwd+bwd+SGD step **614.8 → 67.7 ms**; dK/dV no longer in the top-15 steps (bwd now dominated by dQ at 10.9 ms and the forward SDPA/GEMMs)

Parity: FD gates (f64+f32) pass; GPU-vs-CPU kernel outputs ≤2.3e-6; backward_kernel_resident 13/13 (gqa grad(Q) 3.3e-7 resident); gemma train-step trajectories match to 1e-6.

## Suite
**1805 tests / 31273 assertions / 0 failures / 0 errors** (fresh Valhalla JVM).

Context: with these, the real gemma-3-270m (18 layers, real HF weights) trains on the Arc via per-layer chained VJP programs (finetune-rstr side, separate PR): 2-layer chain grads ≤2e-3 vs monolithic CPU, forward parity ≥0.9993 cosine vs the pretrained decoder, ~1.7 GB VRAM.