### PR TITLE
Correctness sweep: resident-GEMM alpha/beta, scalar-op tag gap, wrong-arity fail-loud + close #55/#56/#2

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,9 @@ Forward-mode (Dual numbers) and reverse-mode (IR source transformation):
         b (- 1.0 x)]
     (+ (* 100.0 a a) (* b b))))
 
-;; value+grad returns [f(x), ∇f(x)]
-(value+grad rosenbrock 1.0 1.0) ;; => [0.0 [0.0 0.0]]
+;; value+grad takes the deftm VAR and returns a function
+;; computing [f(x), df/dx, df/dy]
+((value+grad #'rosenbrock) 1.0 1.0) ;; => [0.0 0.0 0.0]
 ```
 
 ### Compilation

--- a/src/raster/ad/forward.clj
+++ b/src/raster/ad/forward.clj
@@ -460,6 +460,51 @@
                                  (aset result i (n/* (aget px i) scale)))
                                (->Dual cv result))))
 
+;; sqrt/pow on raster.math (issue #55) — same lifts as the raster.numeric ones.
+(deftm raster.math/sqrt (All [T] [x :- Dual] :- Dual
+                             (let [sv (n/sqrt (.v x))
+                                   inv2sv (n// 1.0 (n/* 2.0 sv))
+                                   px (.partials x)
+                                   len (alength px)
+                                   result (aclone px)]
+                               (dotimes [i len]
+                                 (aset result i (n/* (aget px i) inv2sv)))
+                               (->Dual sv result))))
+
+(deftm raster.math/pow (All [T] [x :- Dual, n :- Double] :- Dual
+                            (let [xv (.v x)
+                                  scale (n/* n (n/pow xv (n/- n 1.0)))
+                                  px (.partials x)
+                                  len (alength px)
+                                  result (aclone px)]
+                              (dotimes [i len]
+                                (aset result i (n/* (aget px i) scale)))
+                              (->Dual (n/pow xv n) result))))
+
+(deftm raster.math/pow (All [T] [x :- Dual, y :- Dual] :- Dual
+                            (let [xv (.v x) yv (.v y)
+                                  pv (n/pow xv yv)
+                                  dfdx (n/* yv (n/pow xv (n/- yv 1.0)))
+                                  dfdy (n/* pv (m/log xv))
+                                  px (.partials x) py (.partials y)
+                                  len (alength px)
+                                  result (aclone px)]
+                              (dotimes [i len]
+                                (aset result i (n/+ (n/* (aget px i) dfdx)
+                                                    (n/* (aget py i) dfdy))))
+                              (->Dual pv result))))
+
+(deftm raster.math/pow (All [T] [x :- Double, y :- Dual] :- Dual
+                            (let [yv (.v y)
+                                  pv (n/pow x yv)
+                                  dfdy (n/* pv (m/log x))
+                                  py (.partials y)
+                                  len (alength py)
+                                  result (aclone py)]
+                              (dotimes [i len]
+                                (aset result i (n/* (aget py i) dfdy)))
+                              (->Dual pv result))))
+
 (deftm raster.math/log10 (All [T] [x :- Dual] :- Dual
                               (let [xv (.v x)
                                     scale (n// 1.0 (n/* xv 2.302585092994046))

--- a/src/raster/ad/reverse.clj
+++ b/src/raster/ad/reverse.clj
@@ -2556,6 +2556,27 @@
           :on-miss :self
           :ambiguity-hint "Use the mangled var directly, e.g. #'ns/name_m_<tags>."}))
 
+(defn- deftm-params-or-throw
+  "The resolved deftm's param vector, or a throw that tells the user HOW to fix
+   the call. The most common miss (issue #56, hit on the README example) is
+   passing the DEREF'D dispatch fn — `(value+grad rosenbrock …)` — instead of
+   the var `#'rosenbrock`: the fn object carries none of the deftm metadata the
+   AD transform reads, and the old bare \"grad requires a deftm var\" named
+   neither the mistake nor the remedy."
+  [f-var resolved]
+  (or (:raster.core/deftm-params (meta resolved))
+      (throw (ex-info
+              (str "grad/value+grad requires a deftm VAR, got "
+                   (cond
+                     (var? f-var)
+                     (str f-var " — a var, but not one defined by deftm/ftm.")
+                     (ifn? f-var)
+                     (str "a function object. Pass the var instead: "
+                          "((value+grad #'my-fn) args…), not (value+grad my-fn) — "
+                          "the deftm metadata the AD transform reads lives on the var.")
+                     :else (pr-str f-var)))
+              {:var f-var}))))
+
 (def ^:private vjp-cache (atom {}))
 
 (defn- get-vjp-fn
@@ -3592,8 +3613,7 @@
   (with-ad-gensym
     (let [resolved (resolve-deftm-var f-var)
           m (meta resolved)
-          params (or (:raster.core/deftm-params m)
-                     (throw (ex-info "grad requires a deftm var" {:var f-var})))
+          params (deftm-params-or-throw f-var resolved)
           walked-body (or (rcore/ensure-walked-body! resolved)
                           (throw (ex-info "No walked body on var" {:var f-var})))
         ;; TUPLE-VALUED OUTPUT GUARD (#74, framework §14): grad/value+grad is
@@ -3931,8 +3951,7 @@
                         :array-params (:array-params cov)})))
            resolved (resolve-deftm-var f-var)
            m (meta resolved)
-           params (or (:raster.core/deftm-params m)
-                      (throw (ex-info "grad requires a deftm var" {:var f-var})))
+           params (deftm-params-or-throw f-var resolved)
            walked-body (or (rcore/ensure-walked-body! resolved)
                            (throw (ex-info "No walked body on var" {:var f-var})))
            tags (or (:raster.core/deftm-tags m) (vec (repeat (count params) 'double)))

--- a/src/raster/ad/templates.clj
+++ b/src/raster/ad/templates.clj
@@ -635,6 +635,8 @@
 (register-template! 'raster.math/cbrt (get-template 'Math/cbrt))
 (register-template! 'raster.math/log10 (get-template 'Math/log10))
 (register-template! 'raster.math/hypot (get-template 'Math/hypot))
+(register-template! 'raster.math/sqrt (get-template 'Math/sqrt))
+(register-template! 'raster.math/pow  (get-template 'Math/pow))
 
 ;; ================================================================
 ;; Numeric cast templates (identity passthrough)

--- a/src/raster/compiler/core/inference.clj
+++ b/src/raster/compiler/core/inference.clj
@@ -1041,29 +1041,51 @@
    ~100x-slower IFn.invoke). This is the same scalar-op typing gap d915365 closed in
    infer-expr-tag; the REWRITTEN-form reader needed it too.
 
-   aget/alength are tested OUTSIDE the scalar-op? guard, on their own predicates: an
-   ELEMENT READ is not the unification of its operands (unifying `(aget a i)` over the
-   array tag and the long index would yield `long`), and `clojure.core/aget` — the
-   spelling the walker leaves behind after lowering `raster.arrays/aget` — is in
-   aget-op? but NOT in known-scalar-ops, so a scalar-op?-first guard would miss it and
-   leave `(+ (aget a i) (aget a j))` untyped whenever neither operand is a literal."
+   SCOPE — this fallback types ARITHMETIC forms only, but its OPERAND reader also
+   understands aget/alength (element reads under arithmetic): `clojure.core/aget` —
+   the spelling the walker leaves behind after lowering `raster.arrays/aget` — is in
+   aget-op? but NOT in known-scalar-ops, and infer-rewritten-tag's var clause can't
+   type it, so `(+ (aget a i) (aget a j))` stayed untyped whenever neither operand
+   was a literal. A BARE top-level aget deliberately still returns nil here: typing
+   it flips the value from the boxed emission the bytecode emitter currently pairs
+   with untyped case*/loop merges to a primitive one — matrix-norm's `(aget S 0)`
+   2-norm branch then expects a primitive double at the case merge while the sibling
+   loop branches still box theirs → 'Stack size mismatch' VerifyError. That is a
+   pre-existing case*-merge boxing inconsistency in the emitter (see
+   bc-compiler known issues), not a reason to lose the arithmetic coverage; when the
+   emitter unifies case-branch boxing this can graduate to a plain infer-aget-type
+   branch.
+
+   SOUNDNESS: the unification only fires when EVERY operand's tag is known AND
+   primitive-numeric. Both relaxations are miscompiles, found the hard way (7 suite
+   errors on the keep-over-partial-info draft of this rule):
+     * partial coverage — `(* x 2.0)` with x UNTYPED unified over just the literal
+       to 'double; but x is a Sym/Dual in the Dual{Sym} initiality flows and the ODE
+       Dual sensitivity path, so the consuming op devirtualized to a Number-casting
+       specialization → ClassCastException (Sym/Dual cannot be cast to Number).
+     * non-primitive tags — operands tagged Dual/Sym/etc. fell through a
+       primitives-only cond to a bogus default. A boxed-carrier scalar op is exactly
+       what runtime dispatch is FOR; this rule must stay out of its way (nil)."
   [head form type-env]
-  (cond
-    (descriptor/alength-op? head) 'long
-    (descriptor/aget-op? head) (infer-aget-type form type-env)
-    (descriptor/scalar-op? head)
-    (let [arg-tags (keep (fn [a]
-                           (or (when (seq? a) (infer-rewritten-tag a nil type-env))
-                               (literal-tag a)
-                               (when (symbol? a) (type-env-tag type-env a))))
-                         (rest form))]
-      (cond
-        (some #{'double} arg-tags) 'double
-        (some #{'float} arg-tags) 'float
-        (some #{'long} arg-tags) 'long
-        (empty? arg-tags) nil
-        :else 'long))
-    :else nil))
+  (when (and (descriptor/scalar-op? head)
+             (not (descriptor/aget-op? head))
+             (not (descriptor/alength-op? head)))
+    (let [operand-tag (fn operand-tag [a]
+                        (or (when (seq? a)
+                              (let [h (first a)]
+                                (cond
+                                  (descriptor/alength-op? h) 'long
+                                  (descriptor/aget-op? h) (infer-aget-type a type-env)
+                                  :else (infer-rewritten-tag a nil type-env))))
+                            (literal-tag a)
+                            (when (symbol? a) (type-env-tag type-env a))))
+          arg-tags (mapv operand-tag (rest form))]
+      (when (and (seq arg-tags)
+                 (every? #{'double 'float 'long 'int} arg-tags))
+        (cond
+          (some #{'double} arg-tags) 'double
+          (some #{'float} arg-tags) 'float
+          :else 'long)))))
 
 (defn- prim-class->tag
   "Map a (boxed or primitive) numeric Class to a raster type tag, else nil."

--- a/src/raster/compiler/core/inference.clj
+++ b/src/raster/compiler/core/inference.clj
@@ -1028,6 +1028,43 @@
 
 (declare infer-rewritten-tag)
 
+(defn- rewritten-scalar-op-tag
+  "Tag of a REWRITTEN scalar-op form — clojure.core arithmetic (+ - * / min max …),
+   aget, alength — by unifying its OPERAND tags.
+
+   infer-rewritten-tag's var-resolution clause cannot type these: clojure.core's
+   arithmetic vars carry no :tag, so `(clojure.core/+ (aget a i) 1.0)` resolved to
+   the #'clojure.core/+ var, found no :tag, and typed as NIL. Every raster.numeric
+   call CONSUMING that result (e.g. `(n/sqrt (+ …))`) then lost its operand tag, so
+   its overload could not be confirmed and the call stayed UNDEVIRTUALIZED — which on
+   a GPU target trips the fixpoint typedness census (CPU silently falls back to the
+   ~100x-slower IFn.invoke). This is the same scalar-op typing gap d915365 closed in
+   infer-expr-tag; the REWRITTEN-form reader needed it too.
+
+   aget/alength are tested OUTSIDE the scalar-op? guard, on their own predicates: an
+   ELEMENT READ is not the unification of its operands (unifying `(aget a i)` over the
+   array tag and the long index would yield `long`), and `clojure.core/aget` — the
+   spelling the walker leaves behind after lowering `raster.arrays/aget` — is in
+   aget-op? but NOT in known-scalar-ops, so a scalar-op?-first guard would miss it and
+   leave `(+ (aget a i) (aget a j))` untyped whenever neither operand is a literal."
+  [head form type-env]
+  (cond
+    (descriptor/alength-op? head) 'long
+    (descriptor/aget-op? head) (infer-aget-type form type-env)
+    (descriptor/scalar-op? head)
+    (let [arg-tags (keep (fn [a]
+                           (or (when (seq? a) (infer-rewritten-tag a nil type-env))
+                               (literal-tag a)
+                               (when (symbol? a) (type-env-tag type-env a))))
+                         (rest form))]
+      (cond
+        (some #{'double} arg-tags) 'double
+        (some #{'float} arg-tags) 'float
+        (some #{'long} arg-tags) 'long
+        (empty? arg-tags) nil
+        :else 'long))
+    :else nil))
+
 (defn- prim-class->tag
   "Map a (boxed or primitive) numeric Class to a raster type tag, else nil."
   [c]
@@ -1113,7 +1150,11 @@
           (or (when-let [v (try (resolve head) (catch Throwable _ nil))]
                 (or (:raster.core/return-tag (meta v))
                     (:tag (meta v))))
-              (static-method-return-tag head (rest rewritten-form) type-env))
+              (static-method-return-tag head (rest rewritten-form) type-env)
+              ;; LAST — a scalar op whose var carries no :tag (clojure.core arithmetic).
+              ;; Placed as a fallback so it can never shadow a var's declared return tag
+              ;; or a resolved static-method overload: it only fills a slot that was nil.
+              (rewritten-scalar-op-tag head rewritten-form type-env))
 
            ;; .invk call
           (and (= '.invk head) (symbol? (second rewritten-form)))

--- a/src/raster/compiler/core/op_descriptor.clj
+++ b/src/raster/compiler/core/op_descriptor.clj
@@ -876,3 +876,69 @@
               (not (.startsWith ^String ns-str "java."))
               (not= ns-str "Math")))))
 
+
+;; --- BLAS GEMM alpha/beta (the resident + staged GPU GEMM representability gate) ---
+
+(def blas-gemm-ops
+  "BLAS GEMM ops the GPU lowering paths recognize, → layout variant. dgemm! = C=A·B (:nn);
+   -nt! = A·Bᵀ; -tn! = AᵀB. Single source of truth for both the RESIDENT extractor
+   (pipeline/extract-gpu-program) and the STAGED plan pass (passes.parallel.gpu-plan)."
+  {'raster.linalg.blas/dgemm!    :nn
+   'raster.linalg.blas/dgemm-nt! :nt
+   'raster.linalg.blas/dgemm-tn! :tn})
+
+(defn gemm-scalar-literal
+  "The compile-time numeric VALUE of a GEMM alpha/beta operand, or nil if it is not a
+   literal. Sees through the two wrappers the walker leaves on a `(n/oftype x 1.0)`
+   argument — the devirtualized oftype .invk, and the primitive cast around the literal:
+
+     (.invk raster.numeric/oftype_m_floats_float-impl x (float 1.0))  →  1.0
+
+   nil (= 'not a literal', e.g. a runtime `scale` symbol like attention's 1/√dk) is
+   treated as NON-default by callers: rejecting a runtime expression that happens to
+   equal 1.0/0.0 costs only a CPU/staging fallback, whereas accepting one we cannot read
+   would be a wrong answer."
+  [expr]
+  (cond
+    (number? expr) (double expr)
+    (and (seq? expr) (contains? '#{float double long int
+                                   clojure.core/float clojure.core/double
+                                   clojure.core/long clojure.core/int}
+                                (first expr)))
+    (gemm-scalar-literal (second expr))
+    (and (seq? expr) (= '.invk (first expr))
+         (= 'raster.numeric/oftype (:raster.op/original (meta expr))))
+    (gemm-scalar-literal (last expr))
+    :else nil))
+
+(defn gemm-default-alpha-beta?
+  "True iff a GEMM call's (alpha, beta) operands are literally (1.0, 0.0) — the plain
+   C = A·B that the GPU GEMM kernels actually implement.
+
+   EVERY GPU GEMM kernel — resident XMX, resident scalar, split-k, and the staged
+   invoke-registered-gemm! — takes only (A B C m n k). None has an alpha/beta operand,
+   and all OVERWRITE C. So a call with alpha≠1 or beta≠0 is NOT representable, and the
+   lowering paths must REJECT it rather than drop the scalars on the floor:
+   `(dgemm! A B C m k n 1.0 1.0)` is an ACCUMULATE (C += A·B) — exactly how nn/linear
+   folds in its bias and how the SDPA backward sums its two dScores contributions — and
+   dropping beta silently computes C = A·B on GPU while CPU computes C += A·B. Wrong
+   results, no error, GPU only.
+
+   Honoring alpha/beta instead of rejecting is NOT the cheap kernel-arg change it looks
+   like. emit-gemm-nonsquare-kernel already accepts :alpha/:beta (baking the shape and
+   passing the values as runtime args), but:
+     - the XMX kernel CACHE keys on c-dtype alone, and the scalar + split-k combine
+       kernels have no alpha/beta at all (the split-k emitter explicitly THROWS on
+       beta≠0 — its partials are summed by a separate reduce kernel); and
+     - beta≠0 READS C, which collides with the residency model: buffer contents are
+       uploaded once at BIND, and run-program! re-uploads only :input buffers. A beta=1
+       GEMM writing an :output param would be correct on the FIRST replay and then
+       silently ACCUMULATE ACROSS REPLAYS — trading one silent miscompile for another.
+       A sound implementation must additionally prove that C's pre-step contents are
+       produced WITHIN the program (a prior beta=0 GEMM or fill kernel), which is a
+       residency analysis, not a kernel signature.
+   That work belongs with the first real consumer (sdpa-bwd on GPU), under a
+   MULTI-REPLAY test. Until then: fail loud."
+  [alpha-expr beta-expr]
+  (and (= 1.0 (gemm-scalar-literal alpha-expr))
+       (= 0.0 (gemm-scalar-literal beta-expr))))

--- a/src/raster/compiler/core/op_descriptor.clj
+++ b/src/raster/compiler/core/op_descriptor.clj
@@ -876,7 +876,6 @@
               (not (.startsWith ^String ns-str "java."))
               (not= ns-str "Math")))))
 
-
 ;; --- BLAS GEMM alpha/beta (the resident + staged GPU GEMM representability gate) ---
 
 (def blas-gemm-ops

--- a/src/raster/compiler/passes/parallel/gpu_plan.clj
+++ b/src/raster/compiler/passes/parallel/gpu_plan.clj
@@ -17,6 +17,7 @@
      :stats {:gemm-rewrites :map-rewrites :reduce-rewrites ...}}"
   (:require
    [clojure.set :as set]
+   [raster.compiler.core.op-descriptor :as op]
    [raster.compiler.passes.parallel.device :as device]
    [raster.compiler.passes.parallel.patterns :as patterns]
    [raster.compiler.backend.gpu.opencl-codegen :as codegen]))
@@ -33,10 +34,9 @@
     (:raster.op/original (meta form))))
 
 (def ^:private blas-gemm-ops
-  "Set of original op symbols that are BLAS GEMM variants."
-  #{'raster.linalg.blas/dgemm!
-    'raster.linalg.blas/dgemm-tn!
-    'raster.linalg.blas/dgemm-nt!})
+  "Set of original op symbols that are BLAS GEMM variants. Keys of the shared
+   op-descriptor registry (also used by the RESIDENT extractor in pipeline)."
+  (set (keys op/blas-gemm-ops)))
 
 (defn- blas-gemm-call?
   "Match .invk calls to raster.linalg.blas/dgemm variants.
@@ -71,18 +71,23 @@
   "Classify a BLAS .invk call into GEMM variant.
   Handles both direct and do-wrapped (.invk blas/dgemm! ...) patterns.
   Returns {:variant :nn|:tn|:nt, :A sym :B sym :C sym :m expr :k expr :n expr
-           :alpha expr :beta expr :result-sym sym-or-nil} or nil."
+           :alpha expr :beta expr :result-sym sym-or-nil} or nil.
+
+  Returns nil — 'not a GPU-representable GEMM', so gpu-plan-pass KEEPS the original CPU
+  BLAS call — when alpha≠1.0 or beta≠0.0. invoke-registered-gemm! takes only
+  (A B C m n k) and OVERWRITES C, so rewriting an accumulating GEMM (beta=1, e.g.
+  nn/linear's bias fold) to it silently turned C += A·B into C = A·B. Declining the
+  offload costs performance; dropping the scalars cost CORRECTNESS. See
+  op/gemm-default-alpha-beta?."
   [form]
   (when (blas-gemm-call? form)
     (let [invk (extract-gemm-invk form)
           result-sym (patterns/unwrap-do-result form)
           original-op (invk-original-op invk)
           args (drop 2 invk)
-          variant (case original-op
-                    raster.linalg.blas/dgemm-tn! :tn
-                    raster.linalg.blas/dgemm-nt! :nt
-                    :nn)]
-      (when (>= (count args) 8)
+          variant (get op/blas-gemm-ops original-op :nn)]
+      (when (and (>= (count args) 8)
+                 (op/gemm-default-alpha-beta? (nth args 6) (nth args 7)))
         {:variant variant
          :A (nth args 0) :B (nth args 1) :C (nth args 2)
          :m (nth args 3) :k (nth args 4) :n (nth args 5)

--- a/src/raster/compiler/passes/scalar/inline.clj
+++ b/src/raster/compiler/passes/scalar/inline.clj
@@ -1088,6 +1088,31 @@
                          (if (and deftm-info (safe-to-inline? deftm-info))
                            (let [{:keys [params walked-body tags]} deftm-info
                                  args (call-args init)
+                 ;; ARITY GATE. The substitution below pairs callee params with call
+                 ;; args POSITIONALLY — `(nth args i)` over the param index. A call
+                 ;; whose arg count doesn't match the resolved deftm's param count
+                 ;; therefore died as a bare `IndexOutOfBoundsException: null` out of
+                 ;; PersistentVector, naming neither the callee nor the arities — and
+                 ;; only from inside the AD-prep inliner, which made it read like a
+                 ;; compiler bug rather than the wrong-arity CALL it is. (The same
+                 ;; stale call against a PARAMETRIC callee fails even more obscurely:
+                 ;; no overload resolves, the call is left symbolic, and reverse-AD
+                 ;; reports "No AD template for <callee>".) A deftm call with the wrong
+                 ;; number of args is always a bug — say so, at the call.
+                                 _ (when (not= (count params) (count args))
+                                     (throw (ex-info
+                                             (str "Arity mismatch inlining `" head "`: it takes "
+                                                  (count params) " arg(s) " (pr-str (vec params))
+                                                  " but the call passes " (count args) " "
+                                                  (pr-str (vec args))
+                                                  ". Fix the call site — a deftm has no variadic or "
+                                                  "multi-arity form, so this call can never dispatch.")
+                                             {:callee head
+                                              :expected-arity (count params)
+                                              :actual-arity (count args)
+                                              :params (vec params)
+                                              :args (vec args)
+                                              :form init})))
                  ;; Handle multi-form bodies: wrap in (do ...) if more than one form
                                  body-form (if (> (count walked-body) 1)
                                              (list* 'do walked-body)

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -1189,7 +1189,6 @@
   (and (seq? form) (= '.invk (first form))
        (contains? blas-gemm-ops (:raster.op/original (meta form)))))
 
-
 (def ^:private gpu-alloc-ops
   "Array-allocating ops that appear as devirtualized .invk (not a bare `float-array` head): a
    deftm's `(alloc-like x n)` / `(zeros-like x n)` output buffer. On the resident path these are

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -1176,10 +1176,11 @@
   "BLAS GEMM ops the resident path recognizes (via :raster.op/original on the devirtualized
    .invk form). dgemm! = C=A·B (:nn); -nt! = A·Bᵀ; -tn! = AᵀB. A backward matmul (linear-dx =
    dgemm! :nn, linear-dW = dgemm-tn! :tn) is just another GEMM — recognizing it here is what
-   lets an AD-expanded train step lower to a resident graph."
-  {'raster.linalg.blas/dgemm! :nn
-   'raster.linalg.blas/dgemm-nt! :nt
-   'raster.linalg.blas/dgemm-tn! :tn})
+   lets an AD-expanded train step lower to a resident graph.
+
+   The op→variant map itself lives in the op-descriptor registry (shared with the STAGED
+   gpu-plan pass), so a new GEMM spelling is one registry entry, not two."
+  op/blas-gemm-ops)
 
 (defn- gemm-invk?
   "True if form is a devirtualized BLAS GEMM .invk (carries :raster.op/original in
@@ -1187,6 +1188,7 @@
   [form]
   (and (seq? form) (= '.invk (first form))
        (contains? blas-gemm-ops (:raster.op/original (meta form)))))
+
 
 (def ^:private gpu-alloc-ops
   "Array-allocating ops that appear as devirtualized .invk (not a bare `float-array` head): a
@@ -1335,11 +1337,15 @@
       ;; forward matmul (linear-nb → dgemm-nt!) AND its backward (linear-dx → dgemm!, linear-dW →
       ;; dgemm-tn!) lower to resident GEMM steps.
       (gemm-invk? expr)
+      ;; BLAS arg order is (A B C m k n alpha beta). alpha/beta are CARRIED, not dropped:
+      ;; the resident kernels implement only C = A·B, so extract-gpu-program rejects any
+      ;; call whose alpha/beta are not the default (1.0, 0.0) — see gemm-alpha-beta-default?.
       (let [args (vec (drop 2 expr))]
         {:convention :gemm
          :variant (get blas-gemm-ops (:raster.op/original (meta expr)))
          :A (nth args 0) :B (nth args 1) :C (nth args 2)
          :m-expr (nth args 3) :k-expr (nth args 4) :n-expr (nth args 5)
+         :alpha-expr (nth args 6 nil) :beta-expr (nth args 7 nil)
          :out-buf (nth args 2) :returns sym})
       :else nil)))
 
@@ -1427,10 +1433,16 @@
                       (when (and (symbol? out) (not= sym out))
                         (vswap! aliases assoc sym out)))))
               (reject! :unparseable-kernel-invoke sym expr))
-          ;; devirtualized BLAS GEMM (.invk dgemm*-impl …) → a :gemm step.
+          ;; devirtualized BLAS GEMM (.invk dgemm*-impl …) → a :gemm step. A non-default
+          ;; alpha/beta is NOT representable by the resident GEMM kernels (they compute
+          ;; C = A·B and overwrite C) — reject it by NAME instead of silently dropping the
+          ;; scalars, which turned an ACCUMULATE (C += A·B, beta=1) into an OVERWRITE on
+          ;; GPU while CPU accumulated. See gemm-alpha-beta-default?.
             (gemm-invk? expr)
             (if-let [s (parse-gpu-step sym expr)]
-              (do (vswap! steps conj s) (vswap! device-buffers conj sym))
+              (if (op/gemm-default-alpha-beta? (:alpha-expr s) (:beta-expr s))
+                (do (vswap! steps conj s) (vswap! device-buffers conj sym))
+                (reject! :unsupported-gemm-alpha-beta sym expr))
               (reject! :unparseable-gemm sym expr))
           ;; An ARRAY-tagged binding that reached here is an unlowered device-array op (an
           ;; elementwise/reduction op with no resident kernel, or an array alias the resident path

--- a/src/raster/math.clj
+++ b/src/raster/math.clj
@@ -87,6 +87,25 @@
   (float (Math/pow 10.0 (double x))))
 
 ;; ================================================================
+;; Powers and roots
+;; ================================================================
+;; sqrt/pow were documented (ns docstring, README) but never defined here —
+;; they existed only in raster.numeric (issue #55). raster.math is the Julia
+;; Base math surface, so it carries them too, with the same dispatch style as
+;; cbrt. AD coverage mirrors the other math fns: reverse templates alias the
+;; Math/sqrt / Math/pow rules (ad/templates.clj), forward-mode Dual lifts live
+;; in ad/forward.clj.
+
+(deftm sqrt "Compute the square root of x."
+  [x :- Double] :- Double (Math/sqrt x))
+(deftm sqrt [x :- Float] :- Float (float (Math/sqrt (double x))))
+
+(deftm pow "Raise x to the power y."
+  [x :- Double, y :- Double] :- Double (Math/pow x y))
+(deftm pow [x :- Double, y :- Long] :- Double (Math/pow x (double y)))
+(deftm pow [x :- Float, y :- Float] :- Float (float (Math/pow (double x) (double y))))
+
+;; ================================================================
 ;; Rounding functions
 ;; ================================================================
 

--- a/test/raster/ad/rad_test.clj
+++ b/test/raster/ad/rad_test.clj
@@ -607,3 +607,30 @@
           analysis (#'rad/analyze-dotimes-body body 'i)]
       (is (= 1 (count (:asets analysis))))
       (is (= 'out (:arr (first (:asets analysis))))))))
+
+;; ================================================================
+;; issue #56: value+grad on the deref'd fn must say HOW to fix it
+;; ================================================================
+;; The README example was `(value+grad rosenbrock 1.0 1.0)` — the deref'd
+;; dispatch fn, not the var. The old error was a bare "grad requires a deftm
+;; var" naming neither the mistake nor the remedy.
+
+(deftm issue56-rosenbrock [x :- Double, y :- Double] :- Double
+  (let [a (raster.numeric/- y (raster.numeric/* x x))
+        b (raster.numeric/- 1.0 x)]
+    (raster.numeric/+ (raster.numeric/* 100.0 (raster.numeric/* a a))
+                      (raster.numeric/* b b))))
+
+(deftest value+grad-on-fn-object-names-the-remedy
+  (testing "passing the fn object throws with the #'var remedy in the message"
+    (let [t (try (doall ((rad/value+grad issue56-rosenbrock) 1.0 1.0))
+                 nil
+                 (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? t) "fn-object argument must throw")
+      (when t
+        (is (re-find #"#'my-fn" (ex-message t))
+            (str "message must show the (value+grad #'my-fn) remedy, got: "
+                 (ex-message t))))))
+  (testing "the corrected README call works"
+    (is (= [0.0 0.0 0.0]
+           (mapv double ((rad/value+grad #'issue56-rosenbrock) 1.0 1.0))))))

--- a/test/raster/compiler/devirtualization_test.clj
+++ b/test/raster/compiler/devirtualization_test.clj
@@ -51,3 +51,42 @@
 ;; raster.numeric/raster.math ops, NOT un-devirtualized user-deftm calls (e.g.
 ;; byte-dist inside local-join-bytes!, which still runs via runtime dispatch).
 ;; Extending it to flag user-deftm dispatch is tracked follow-up work.
+
+(deftest numeric-op-over-core-arithmetic-devirtualizes
+  ;; A raster.numeric op whose OPERAND is a clojure.core arithmetic result (the legal
+  ;; and idiomatic spelling for integer/index math, and what a fused reduction leaves
+  ;; behind) lost its operand tag: infer-rewritten-tag resolved the `clojure.core/+`
+  ;; var, found no :tag on it, and typed the operand NIL — so the consuming
+  ;; raster.numeric/sqrt could not confirm an overload and stayed RUNTIME-DISPATCHED.
+  ;; On CPU that is silently ~100x slower; on a GPU target it trips the fixpoint
+  ;; typedness census (`undevirtualized dispatch call raster.numeric/sqrt`) and was
+  ;; blocking the 2-kernel rms-norm schedule.
+  ;;
+  ;; Same scalar-op typing gap d915365 closed in infer-expr-tag — the REWRITTEN-form
+  ;; tag reader (infer-rewritten-tag) needed it too. Both operand shapes must devirt:
+  ;; with a literal (one operand already typed) AND with two agets (neither operand
+  ;; typed unless `clojure.core/aget` itself is read as an element load).
+  (testing "n/sqrt over clojure.core/+ and clojure.core/* results devirtualizes"
+    (let [probe-lit (eval '(raster.core/deftm devirt-core-arith-lit-probe
+                             [a :- (Array float) out :- (Array float) n :- Long] :- Void
+                             (raster.par/map-void!
+                              i n
+                              (raster.arrays/aset
+                               out i
+                               (raster.numeric/sqrt
+                                (clojure.core/+ (raster.arrays/aget a i) 1.0))))))
+          probe-agets (eval '(raster.core/deftm devirt-core-arith-agets-probe
+                               [a :- (Array float) out :- (Array float) n :- Long] :- Void
+                               (raster.par/map-void!
+                                i n
+                                (raster.arrays/aset
+                                 out i
+                                 (raster.numeric/sqrt
+                                  (clojure.core/* (raster.arrays/aget a i)
+                                                  (raster.arrays/aget a i)))))))]
+      (doseq [v [probe-lit probe-agets]]
+        (let [{:keys [dispatched]} (dispatch-counts v :float)]
+          (is (zero? dispatched)
+              (str v " has " dispatched " undevirtualized dispatch op(s) — a "
+                   "raster.numeric op over a clojure.core arithmetic result lost its "
+                   "operand tag (infer-rewritten-tag scalar-op gap)")))))))

--- a/test/raster/compiler/passes/scalar/inline_test.clj
+++ b/test/raster/compiler/passes/scalar/inline_test.clj
@@ -1,0 +1,74 @@
+(ns raster.compiler.passes.scalar.inline-test
+  "Guards the deftm inliner's call/callee arity contract.
+
+  The inliner substitutes callee params for call args POSITIONALLY — `(nth args i)`
+  over the param index. Nothing checked that the two had the same length, so a stale
+  call site — a deftm that grew a parameter while one of its callers was not
+  updated — died as a bare `IndexOutOfBoundsException: null` out of PersistentVector,
+  thrown from deep inside the AD-prep inliner (inline.clj:1108), naming neither the
+  callee nor the arities. It read like a compiler bug; it was a wrong-arity CALL.
+
+  (The same stale call against a PARAMETRIC (All [T]) callee fails differently and
+  even more obscurely: no overload resolves, the call is never inlined, stays
+  symbolic, and reverse-AD reports `No AD template for <callee>` — a message that
+  points at the AD registry rather than at the call. Both shapes were hit in the same
+  finetune commit, where the gemma block gained a `bs` batch param and two reference
+  losses were not updated.)
+
+  A deftm has no variadic or multi-arity form, so a wrong-arity call can never
+  dispatch: it is always a bug, and the inliner must say so AT THE CALL — naming the
+  callee and both arities."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.core :refer [deftm]]
+            [raster.par]
+            [raster.numeric]
+            [raster.arrays]
+            [raster.ad.reverse :as rev]))
+
+;; Monomorphic callee taking THREE args (mirrors the concrete-float finetune.train/gblock,
+;; which takes 38 and was called with 37).
+(deftm arity-callee
+  [a :- (Array double) n :- Long s :- Double] :- Double
+  (raster.par/reduce acc 0.0 i n
+                     (raster.numeric/+ acc (raster.numeric/* (raster.arrays/aget a i) s))))
+
+;; The STALE caller: arity-callee takes (a n s); this passes only (a n).
+;; deftm walking is lazy, so the bad call is only reached when value+grad forces the
+;; AD-prep inline — exactly where the finetune chain died.
+(deftm arity-caller-stale
+  [a :- (Array double) n :- Long] :- Double
+  (raster.compiler.passes.scalar.inline-test/arity-callee a n))
+
+;; The correct caller — the guard must not over-fire.
+(deftm arity-caller-good
+  [a :- (Array double) n :- Long s :- Double] :- Double
+  (raster.compiler.passes.scalar.inline-test/arity-callee a n s))
+
+(deftest wrong-arity-deftm-call-fails-loud-in-ad-inline
+  (testing "value+grad over a stale (wrong-arity) deftm call names the callee and both arities"
+    (let [t (try (let [vg (rev/value+grad #'arity-caller-stale)]
+                   ;; if grad-body construction is deferred, force it with a call
+                   (vg (double-array [1.0 2.0]) 2)
+                   nil)
+                 (catch Throwable e e))]
+      (is (some? t) "a wrong-arity deftm call must throw, not silently mis-inline")
+      (is (not (instance? IndexOutOfBoundsException t))
+          "must not surface as a bare IndexOutOfBoundsException from PersistentVector")
+      (is (instance? clojure.lang.ExceptionInfo t)
+          (str "must be a NAMED ex-info, got: " (some-> t class str)))
+      (when (instance? clojure.lang.ExceptionInfo t)
+        (let [d (ex-data t)]
+          (is (= 'raster.compiler.passes.scalar.inline-test/arity-callee (:callee d))
+              "names the callee")
+          (is (= 3 (:expected-arity d)) "reports the callee's declared arity")
+          (is (= 2 (:actual-arity d)) "reports the call's actual arity")
+          (is (re-find #"Arity mismatch" (ex-message t))
+              (str "message must say what is wrong, got: " (ex-message t))))))))
+
+(deftest correct-arity-call-still-inlines-and-differentiates
+  (testing "the guard must not over-fire: a well-formed call differentiates through the inline"
+    (let [a (double-array [1.0 2.0])
+          [v da] ((rev/value+grad #'arity-caller-good) a 2 3.0)]
+      ;; L = s * sum(a) = 3 * (1+2) = 9 ; dL/da_i = s = 3
+      (is (= 9.0 (double v)))
+      (is (= [3.0 3.0] (vec da))))))

--- a/test/raster/dl/gpu_ad_gemm_test.clj
+++ b/test/raster/dl/gpu_ad_gemm_test.clj
@@ -241,6 +241,67 @@
       (is (< (rel-err gpu cpu) 1e-4)
           (str "reduce→map-void replay relerr " (rel-err gpu cpu))))))
 
+;; ── GEMM alpha/beta must never be silently dropped ───────────────────────────────
+;; The resident extractor took only args 0-5 of a dgemm .invk (A B C m k n) and dropped
+;; alpha/beta on the floor. Every GPU GEMM kernel computes C = A·B and OVERWRITES C, so
+;; an ACCUMULATING gemm — `(dgemm! A B C m k n 1.0 1.0)`, i.e. C += A·B, which is how
+;; nn/linear folds in its bias and how the SDPA backward sums its two dScores
+;; contributions — silently computed C = A·B on GPU while the CPU accumulated. Wrong
+;; results, no error, GPU only.
+
+(defn- accum-gemm-probe []
+  (eval '(raster.core/deftm gemm-beta-accum-probe
+           [A :- (Array float) B :- (Array float) C :- (Array float)
+            m :- Long k :- Long n :- Long] :- (Array float)
+           (let [_ (raster.linalg.blas/dgemm! A B C m k n
+                                              (raster.numeric/oftype A 1.0)
+                                              (raster.numeric/oftype A 1.0))]
+             C))))
+
+(deftest gemm-accumulate-never-silently-dropped
+  ;; THE anti-silent-miscompile gate. An accumulating GEMM must EITHER lower to a
+  ;; resident program that computes the correct C += A·B on device, OR be REJECTED at
+  ;; compile time. What it must never do is compile and return C = A·B.
+  ;;
+  ;; Written to pass under either fix, so it keeps holding if the resident GEMM later
+  ;; learns real alpha/beta (which additionally requires proving C's pre-step contents
+  ;; are produced inside the program — buffers upload once at BIND, so a beta=1 GEMM on
+  ;; an :output param would accumulate ACROSS REPLAYS; see op/gemm-default-alpha-beta?).
+  (require 'raster.linalg.blas 'raster.numeric)
+  (let [probe (accum-gemm-probe)
+        compiled (try {:ok (pl/compile-gpu-program probe :ze:0 :dtype :float)}
+                      (catch Throwable t {:err t}))]
+    (if-let [t (:err compiled)]
+      ;; Fix (b): rejected at compile. Assert it is the PRINCIPLED, named rejection —
+      ;; not an incidental failure that might mask a real regression.
+      (is (= :unsupported-gemm-alpha-beta (:why (:non-resident (ex-data t))))
+          (str "an accumulating GEMM must be rejected by NAME "
+               "(:unsupported-gemm-alpha-beta), got: " (.getMessage t)))
+      ;; Fix (a): it compiled — then it MUST be numerically correct on device.
+      (if-not @gpu-available?
+        (println "  [SKIP] gemm-accumulate: compiled resident but no GPU to verify")
+        (let [m 16 k 32 n 16
+              A (rnd (* m k) 11) B (rnd (* k n) 12) C0 (rnd (* m n) 13)
+              cpu (let [c (float-array (seq C0))] (probe A B c m k n) c)
+              ab-only (float-array (map - (seq cpu) (seq C0)))  ; A·B with beta dropped
+              {:keys [out]} (run-resident probe [A B (float-array (seq C0)) m k n])]
+          (is (< (rel-err out cpu) 5e-3)
+              (str "resident accumulating GEMM must compute C += A·B (CPU parity), "
+                   "relerr " (rel-err out cpu)))
+          (is (> (rel-err out ab-only) 1e-2)
+              "resident GEMM returned exactly A·B — beta was DROPPED (silent miscompile)"))))))
+
+(deftest gemm-default-alpha-beta-still-lowers
+  ;; The other side of the gate: the alpha=1/beta=0 GEMMs that DO lower must keep
+  ;; lowering. The alpha/beta literal reader has to see through the walker's wrappers
+  ;; — `(.invk raster.numeric/oftype…-impl x (float 1.0))` — or it would reject every
+  ;; working GEMM and silently un-offload the whole training path to the staging fn.
+  (doseq [[v variant] [[#'nn/linear-nb :nt] [#'nn/linear-dx :nn] [#'nn/linear-dW :tn]]]
+    (let [p (pl/compile-gpu-program v :ze:0 :dtype :float :on-non-resident :nil)]
+      (is (some? p) (str v " (alpha=1, beta=0) must still extract as a resident GEMM"))
+      (is (= [variant] (mapv :variant (:steps p)))
+          (str v " must still lower to a single " variant " GEMM step")))))
+
 (deftest gpu-ad-full-train-step-fully-resident
   ;; This test does NOT need a GPU — it pins residency at the IR level. The full
   ;; mse∘linear-nb float train step (value+grad + SGD, returning the updated weights like

--- a/test/raster/math_test.clj
+++ b/test/raster/math_test.clj
@@ -3,7 +3,7 @@
             [raster.math :refer [sin cos tan asin acos atan atan2
                                  exp log log2 log10 expm1 log1p exp2 exp10
                                  ceil floor round trunc
-                                 hypot cbrt
+                                 hypot cbrt sqrt pow
                                  sinh cosh tanh asinh acosh atanh
                                  deg2rad rad2deg
                                  nextfloat prevfloat eps
@@ -475,3 +475,47 @@
     (is (= (float -1.0) (signum (float -42.0))))
     (is (= (float 0.0) (signum (float 0.0))))
     (is (instance? Float (signum (float 1.0))))))
+
+;; ================================================================
+;; sqrt / pow (issue #55)
+;; ================================================================
+;; raster.math's ns docstring and the README's FIRST example both refer
+;; `sqrt` (and the autodiff notebook uses `pow`), but the fns only existed in
+;; raster.numeric — `(require '[raster.math :refer [sqrt]])` threw at the very
+;; first step of the getting-started path.
+
+(deftest sqrt-test
+  (testing "sqrt at known values"
+    (is (approx= 0.0 (sqrt 0.0)))
+    (is (approx= 2.0 (sqrt 4.0)))
+    (is (approx= 5.0 (sqrt 25.0))))
+  (testing "sqrt Float variant"
+    (is (approx= 2.0 (sqrt (float 4.0)) float-tol))
+    (is (instance? Float (sqrt (float 4.0))))))
+
+(deftest pow-test
+  (testing "pow at known values"
+    (is (approx= 8.0 (pow 2.0 3.0)))
+    (is (approx= 8.0 (pow 2.0 3)))       ; Long exponent
+    (is (approx= 0.25 (pow 2.0 -2.0))))
+  (testing "pow Float variant"
+    (is (approx= 8.0 (pow (float 2.0) (float 3.0)) float-tol))
+    (is (instance? Float (pow (float 2.0) (float 3.0))))))
+
+(deftest readme-norm-example-test
+  ;; The exact README opening example — the issue-#55 repro.
+  (let [norm (eval '(raster.core/deftm issue55-norm [x :- Double, y :- Double] :- Double
+                      (raster.math/sqrt (raster.numeric/+ (raster.numeric/* x x)
+                                                          (raster.numeric/* y y)))))]
+    (is (approx= 5.0 (norm 3.0 4.0)))))
+
+(deftest sqrt-pow-differentiate-test
+  ;; The math-ns spellings must be AD-covered like the numeric ones
+  ;; (reverse templates alias Math/sqrt & Math/pow; Dual lifts in ad/forward).
+  (let [f (eval '(raster.core/deftm issue55-ad-probe [x :- Double] :- Double
+                   (raster.math/pow (raster.math/sqrt x) 3.0)))
+        vg ((requiring-resolve 'raster.ad.reverse/value+grad) (resolve 'issue55-ad-probe))
+        [v dx] (vg 4.0)]
+    ;; f(x) = x^(3/2): f(4) = 8, f'(4) = (3/2)*sqrt(4) = 3
+    (is (approx= 8.0 v))
+    (is (approx= 3.0 dx))))


### PR DESCRIPTION
Five correctness fixes and the three open issues. Every fix carries a regression test that fails on main before it. Suite: **1836 tests / 31525 assertions / 0 failures / 0 errors** (baseline 1824/31441 + 12 new tests).

## The silent-miscompile family (the important one)
This is the third instance of the same shape — *an extractor takes the prefix it understands and silently ignores the rest* (after the SOAC store-drop and the `.invk` DCE seed). All three fixes make the ignored information **fail loud** rather than compute wrong.

**Resident GEMM dropped alpha/beta** (`3724c40`). `parse-gpu-step`'s `:gemm` arm read only args 0–5 of the dgemm `.invk`, discarding alpha/beta — confirmed **on the Arc GPU**: a `beta=1.0` accumulating GEMM compiled resident and returned exactly `A·B` (relerr 0.24 vs the CPU `C += A·B`), silent and GPU-only. The staged path dropped them too. Real at-risk callers: `nn/linear`'s bias fold and SDPA backward (alpha=1/√dk *and* beta=1 → wrong **gradients** had it gone resident). Fix is the loud floor: steps carry `:alpha-expr`/`:beta-expr`, the resident extractor rejects non-defaults by name (`::non-resident {:why :unsupported-gemm-alpha-beta}`), the staged pass declines the offload and keeps the correct CPU BLAS. The op→variant map + gate now live once in the op-descriptor registry (was duplicated in two files). Honoring beta on-device was deliberately *not* landed — it reads C, which collides with residency (buffers upload once at bind; a beta=1 GEMM would accumulate across replays); the docstring records that as work for the first real consumer under a multi-replay test.

**Wrong-arity deftm call** (`cf16892`). The inliner's unchecked `(nth args i)` at inline.clj:1108 threw a bare `IndexOutOfBoundsException: null`, pointing at the wrong subsystem. Now a named ex-info (callee, expected/actual arity, params, args).

## Type inference
**`n/sqrt` over a `clojure.core/+` result lost its tag** (`5553066` + `085a208`). `infer-rewritten-tag` read `:tag` off the head var; clojure.core arithmetic vars carry none, so the operand typed nil and the consuming `raster.numeric` call stayed undevirtualized → GPU census throw. Fix is a scalar-op operand-unification fallback, placed last (never shadows a declared tag), firing only when every operand tag is known and primitive. The first cut was too broad — it broke Dual{Sym}/ODE-Dual/matrix-norm (7 suite errors); caught, root-caused, tightened, and the story is in the `085a208` message. Unblocks the 2-kernel rms-norm shape (compiles now; the variant itself not landed here).

## Issues
- **#55**: `raster.math/sqrt` was documented in the ns docstring and the README's first example but never defined. Added `sqrt`+`pow` with the full pattern (dispatch, reverse templates, forward Dual lifts); tests include the exact README `norm` example.
- **#56**: the README example was wrong twice (`(value+grad rosenbrock 1.0 1.0)` — fn object, applied directly). Fixed the README to `((value+grad #'rosenbrock) 1.0 1.0)` and made both "grad requires a deftm var" throws state the remedy. The var stays the API (a dispatch fn object has no reliable back-pointer).
- **#2**: not a bug — a 2021 pointer to aiscm whose author invited closing; everything suggested is long implemented. Closed directly with a comment (no synthetic change).

Also fixes the two red tests on the finetune batched branch (stale 37-arg CPU-reference calls after `gblock` gained a `bs` param — finetune side, committed there separately).