### PR TITLE
Harden the permissive-extractor bug family: unmodeled resident forms fail loud, not silently miscompile

### DIFF
--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -152,6 +152,15 @@
         [let-bindings inner-body]
         (if (and (seq? lambda) (contains? #{'let* 'let} (first lambda)))
           (let [[_ binds & bdy] lambda]
+            ;; A reduce combine's let body must be ONE expression `(op acc elem)`. Taking
+            ;; `(last bdy)` of a multi-statement body would SILENTLY DROP the earlier forms
+            ;; — the same shape as the single-aset-void store-drop. If earlier statements
+            ;; exist they carry computation/effects the combine depends on; reject loudly.
+            (when (> (count bdy) 1)
+              (throw (ex-info (str "SegRed: reduce combine lambda has a multi-statement body ("
+                                   (count bdy) " forms) — only a single combine expression is"
+                                   " modeled; earlier forms would be dropped")
+                              {:lambda lambda :body (vec bdy)})))
             [(vec (partition 2 binds)) (last bdy)])
           [nil lambda])
         ;; .invk-aware: the walker devirtualizes (raster.numeric/+ acc x) into
@@ -179,6 +188,15 @@
                               (str "(" a " " c-op " " b ")")))
         ;; Extract the element expression (the non-acc operand) from the SEMANTIC args.
         op-args (vec (when (seq? inner-body) (descriptor/call-args inner-body)))
+        ;; A segmented reduce combine is BINARY: (op acc elem). A variadic combine like
+        ;; (+ acc x y) has 3 operands — extracting only ONE non-acc operand would SILENTLY
+        ;; emit a kernel that sums just `x`, dropping `y` (the store-drop family). A legit
+        ;; fused map→reduce nests the map body as a single elem operand, so >2 is unmodeled.
+        _ (when (> (count op-args) 2)
+            (throw (ex-info (str "SegRed: reduce combine op has " (count op-args)
+                                 " operands — only a binary (op acc elem) combine is modeled;"
+                                 " extra operands would be dropped")
+                            {:op op-sym :op-args op-args :lambda lambda})))
         acc-at? (fn [a] (or (= a acc)
                             (and (seq? a) (= 'double (first a)) (= acc (second a)))))
         [_acc-pos elem-expr-raw]

--- a/src/raster/compiler/ir/soac.clj
+++ b/src/raster/compiler/ir/soac.clj
@@ -479,7 +479,18 @@
    like rms-norm/attention/quant-act that doesn't reduce to a single-aset SoacMap)
    still declares the buffers it produces — otherwise consumers of those buffers
    get no dependency edge and the scheduler / horizontal-fuser can incorrectly
-   reorder or parallelize across the write (silent miscompile in composed layers)."
+   reorder or parallelize across the write (silent miscompile in composed layers).
+
+   KNOWN GAP (silently-ignored-information family, deferred): this sees ONLY aset
+   writes. An op whose output buffer is declared via the op-descriptor :buffer-write
+   registry but that writes with NO literal aset in this expr (a BLAS/GEMM .invk that
+   writes C in place, a runtime scatter) contributes NO producer edge here, so the
+   SOAC topological sort could reorder a consumer ahead of it. The registry DCE now
+   consults IS the right source of truth, but wiring it in here is a non-trivial change
+   (this runs pre-lowering where those ops are still symbolic deftm calls, not the
+   devirtualized .invk the registry keys on). Fixing it belongs with the descriptor
+   VALIDATOR (S4). Until then a genuinely reorderable buffer-write-only op reaching the
+   SOAC scheduler is the outstanding risk — documented, not yet guarded."
   [expr]
   (let [w (volatile! #{})]
     (walk/postwalk
@@ -575,12 +586,15 @@
             (list 'raster.par/scan (:out s) (:acc s) (:init s)
                   (:idx screma) (:bound screma) (:cast-fn screma) (:lambda s)))
 
-          ;; Map+Reduce: map feeds reduce
+          ;; Map+Reduce: a reduce WITH a still-present map-lambda. screma-compose's Map→Reduce
+          ;; inlines the producer map body INTO the reduce lambda and leaves :map-lambda nil, so
+          ;; a screma reaching here with both set is an UN-fused map — emitting only the reduce
+          ;; lambda (as this arm used to) would SILENTLY DROP the map computation. Reject loudly.
           (and (empty? (:scans screma)) (= 1 (count (:reduces screma))) (:map-lambda screma))
-          ;; Emit as reduce with map body inlined
-          (let [r (first (:reduces screma))]
-            (list 'raster.par/reduce (:acc r) (:init r)
-                  (:idx screma) (:bound screma) (:lambda r)))
+          (throw (ex-info (str "screma->par-form: Map+Reduce screma still carries a :map-lambda"
+                               " — the map body was not inlined into the reduce lambda; emitting"
+                               " the reduce alone would drop the map computation")
+                          {:screma screma}))
 
           :else
           (throw (ex-info "Cannot convert complex Screma to single par form"
@@ -589,7 +603,12 @@
 
 (defn- substitute-aget-sym
   "Replace (aget target-sym idx) with replacement-expr in body,
-  adjusting index variable from src-idx to dst-idx."
+  adjusting index variable from src-idx to dst-idx.
+
+  INDEX-INSENSITIVE (see fusion-support/substitute-aget): matches by array name only and
+  substitutes at ANY index, assuming same-position elementwise producer→consumer fusion.
+  A non-same-index consumer (gather/transpose/offset read) would be mis-fused. Reachable
+  only for the same-index case today; a real guard belongs with the descriptor VALIDATOR."
   [body target-sym src-idx dst-idx replacement-expr]
   (walk/postwalk
    (fn [f]

--- a/src/raster/compiler/passes/parallel/fusion_support.clj
+++ b/src/raster/compiler/passes/parallel/fusion_support.clj
@@ -5,7 +5,18 @@
 
 (defn substitute-aget
   "Replace reads of `(aget target-sym idx)` inside `body` with `replacement`.
-	Rewrites the replacement so uses of `source-idx` become `target-idx`."
+	Rewrites the replacement so uses of `source-idx` become `target-idx`.
+
+	INDEX-INSENSITIVE (silently-ignored-information family, deferred): this matches an
+	aget by ARRAY NAME only and substitutes regardless of the aget's actual index expr —
+	it assumes the consumer reads target-sym at the SAME logical position the producer
+	wrote (differing only in index-var name, which the source-idx→target-idx rewrite
+	handles). A consumer that reads a DIFFERENT element — `(aget tmp (+ j 1))`, a
+	transpose, a gather — would be wrongly replaced with the producer's element at the
+	consumer's index. Vertical fusion only fires on same-index elementwise producer→
+	consumer pairs, so no reachable caller violates this today; a real guard must abort
+	the whole fusion (declining to substitute would leave a dangling ref to an eliminated
+	buffer), which belongs with the descriptor VALIDATOR (S4). Documented, not yet asserted."
   [body target-sym source-idx target-idx replacement]
   (walk/postwalk
    (fn [form]

--- a/src/raster/compiler/passes/parallel/par_fusion.clj
+++ b/src/raster/compiler/passes/parallel/par_fusion.clj
@@ -32,6 +32,10 @@
   (cond (symbol? e) #{e}
         (seq? e)    (apply set/union #{} (map all-symbol-uses e))
         (vector? e) (apply set/union #{} (map all-symbol-uses e))
+        ;; Map literals carry symbol references too — notably a `case*` clause map. Missing
+        ;; them makes this liveness map-blind (a sym used only inside a case* would look dead
+        ;; and be wrongly fused away), the same hole util/free-syms-flat was fixed for.
+        (map? e)    (apply set/union #{} (map all-symbol-uses (apply concat e)))
         :else       #{}))
 
 ;; ================================================================

--- a/src/raster/compiler/passes/parallel/write_read_fuse.clj
+++ b/src/raster/compiler/passes/parallel/write_read_fuse.clj
@@ -100,6 +100,10 @@
 
     (seq? expr) (apply clojure.set/union #{} (map collect-aget-syms (rest expr)))
     (vector? expr) (apply clojure.set/union #{} (map collect-aget-syms expr))
+    ;; Map literals (e.g. a `case*` clause map) can hide an aget read; missing them makes the
+    ;; sole-consumer/liveness check map-blind — a buffer still read inside a case* would look
+    ;; dead and be wrongly fused away. Recurse into keys+vals like util/free-syms-flat does.
+    (map? expr) (apply clojure.set/union #{} (map collect-aget-syms (apply concat expr)))
     :else #{}))
 
 (defn- reads-sym?

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -1294,16 +1294,25 @@
    list in the kernel's signature order (for map! the separate output is appended, so on the
    resident path it is just another buffer). nil for an unrecognized head."
   [sym expr]
-  (let [head (first expr)]
+  ;; Every arm below destructures a FIXED-length invoke prefix. The invoke forms are
+  ;; compiler-generated (opencl_pass) with a known arity per convention. A wrong count means
+  ;; the emitter changed shape — extra operands would be SILENTLY DROPPED (the store-drop /
+  ;; alpha-beta bug family) and fewer would bind nil into a size/scalar slot. Each arm returns
+  ;; nil on an unexpected arity so the caller rejects it BY NAME (:unparseable-kernel-invoke)
+  ;; instead of miscompiling. Emit-site arities: map-void=5, map=6, scatter=6|7, reduce=4|5.
+  (let [head (first expr)
+        argc (count expr)]
     (cond
       (= head 'raster.gpu.ze-runtime/invoke-registered-map-void-kernel)
-      (let [[_ kname arrays scalars n] expr]
-        {:kernel-name kname :arrays (vec arrays) :scalars (vec scalars) :n-expr n
-         :convention :map-void :returns sym})
+      (when (= 5 argc)
+        (let [[_ kname arrays scalars n] expr]
+          {:kernel-name kname :arrays (vec arrays) :scalars (vec scalars) :n-expr n
+           :convention :map-void :returns sym}))
       (= head 'raster.gpu.ze-runtime/invoke-registered-kernel)
-      (let [[_ kname inputs out scalars n] expr]
-        {:kernel-name kname :arrays (conj (vec inputs) out) :scalars (vec scalars) :n-expr n
-         :convention :map :returns sym})
+      (when (= 6 argc)
+        (let [[_ kname inputs out scalars n] expr]
+          {:kernel-name kname :arrays (conj (vec inputs) out) :scalars (vec scalars) :n-expr n
+           :convention :map :returns sym}))
       (= head 'raster.gpu.ze-runtime/invoke-registered-scatter-kernel)
       ;; (invoke-registered-scatter-kernel kname out src index n [stride]). out is the
       ;; accumulator buffer (a zeros-like intermediate), written in-place via atomic +=.
@@ -1311,26 +1320,33 @@
       ;; scatter). :arrays is the kernel C-sig order (out src index); the extra scalar
       ;; (stride) is a :scalar (n stays :n-expr, and n precedes stride in the C-sig — the
       ;; scatter bind places n before the scalars, unlike the map-void arrays,scalars,n order).
-      (let [[_ kname out src index n stride] expr
-            ;; Strip a `(long x)`/`(int x)` cast so the scalar is a bare symbol
-            ;; (scalar-native-type keys on the name, and the value-fn still evaluates
-            ;; the raw symbol — it is an int stride/index param either way).
-            strip-cast (fn [x] (if (and (seq? x)
-                                        (#{'long 'int 'clojure.core/long 'clojure.core/int} (first x)))
-                                 (second x) x))]
-        {:kernel-name kname :arrays [out src index]
-         :scalars (if stride [(strip-cast stride)] [])
-         :n-expr n :convention :scatter :accumulator out :returns sym})
+      ;; stride is optional: emitted 7-wide with a trailing nil, or 6-wide when absent.
+      (when (#{6 7} argc)
+        (let [[_ kname out src index n stride] expr
+              ;; Strip a `(long x)`/`(int x)` cast so the scalar is a bare symbol
+              ;; (scalar-native-type keys on the name, and the value-fn still evaluates
+              ;; the raw symbol — it is an int stride/index param either way).
+              strip-cast (fn [x] (if (and (seq? x)
+                                          (#{'long 'int 'clojure.core/long 'clojure.core/int} (first x)))
+                                   (second x) x))]
+          {:kernel-name kname :arrays [out src index]
+           :scalars (if stride [(strip-cast stride)] [])
+           :n-expr n :convention :scatter :accumulator out :returns sym}))
 
       (= head 'raster.gpu.ze-runtime/invoke-reduction-kernel)
-      ;; 3-arg legacy (host-scalar return) vs 4-arg resident (writes out-buf, stays on device).
-      (if (= 5 (count expr))
+      ;; 3-arg legacy (host-scalar return, argc 4) vs resident (writes out-buf, stays on
+      ;; device, argc 5). Any OTHER count is an unmodeled shape — reject by name instead of
+      ;; silently treating it as the legacy 3-arg form (which would drop a real out-buf).
+      (cond
+        (= 5 argc)
         (let [[_ kname inputs out-buf n] expr]
           {:kernel-name kname :arrays (vec inputs) :output out-buf :scalars [] :n-expr n
            :convention :reduce :returns sym})
+        (= 4 argc)
         (let [[_ kname inputs n] expr]
           {:kernel-name kname :arrays (vec inputs) :scalars [] :n-expr n
-           :convention :reduce :returns sym}))
+           :convention :reduce :returns sym})
+        :else nil)
       ;; devirtualized BLAS GEMM: (.invk dgemm*-impl A B C m k n alpha beta). BLAS arg order is
       ;; (A B C m k n) — note m,k,n (NOT m,n,k). C (out) is written in place. This is how a
       ;; forward matmul (linear-nb → dgemm-nt!) AND its backward (linear-dx → dgemm!, linear-dW →

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -687,6 +687,27 @@
               {:type t :value (case t :int (int raw) :long (long raw) :double (double raw) (float raw))}))
           (:scalar-params ki))))
 
+(def ^:private valid-chain-roles
+  "Residency roles a chain buffer may carry. run-chain!/run-chain-ctx! move :input up and
+   download :output; :constant/:state/:scratch stay put. A role OUTSIDE this set (e.g. a
+   typo `:ouput`) is never matched by the `(= r :output)` filters and would SILENTLY never
+   be downloaded — so an unknown role is rejected at bind time, not lost at replay."
+  #{:constant :state :input :output :scratch})
+
+(defn- chain-roles-of
+  "Extract {buf-key → role} from the buffers spec, defaulting :scratch, and REJECT any
+   unknown role by name rather than storing it (where it would silently never download)."
+  [buffers]
+  (into {}
+        (map (fn [[k v]]
+               (let [r (or (nth v 3 nil) :scratch)]
+                 (when-not (contains? valid-chain-roles r)
+                   (throw (ex-info (str "chain buffer " k " has unknown role " (pr-str r)
+                                        " — must be one of " valid-chain-roles)
+                                   {:buffer k :role r :valid valid-chain-roles})))
+                 [k r])))
+        buffers))
+
 (defn chain-program!
   "Bind a hand-authored op-chain as one resident command graph.
      buffers: {buf-key → [dtype size init-array-or-nil role]} — role ∈
@@ -701,7 +722,7 @@
   ([sess buffers steps] (chain-program! sess buffers steps :float))
   ([sess buffers steps dtype]
    (let [specs (into {} (map (fn [[k [dt sz init _]]] [k [dt sz init]]) buffers))
-         roles (into {} (map (fn [[k v]] [k (or (nth v 3 nil) :scratch)]) buffers))]
+         roles (chain-roles-of buffers)]
      (alloc! sess specs)
      ;; A multi-par-form op compiles to SEVERAL kernels — bind them ALL, in order (the old
      ;; `first` silently dropped every kernel after the first). All kernels of a step share
@@ -744,7 +765,7 @@
   ([sess buffers steps] (bind-chain! sess buffers steps :float))
   ([sess buffers steps dtype]
    (let [specs (into {} (map (fn [[k [dt sz init _]]] [k [dt sz init]]) buffers))
-         roles (into {} (map (fn [[k v]] [k (or (nth v 3 nil) :scratch)]) buffers))]
+         roles (chain-roles-of buffers)]
      (alloc! sess specs)
      (doseq [{:keys [op phase]} steps] (compile! sess phase op))
      (swap! sess assoc :chain-steps steps :chain-roles roles :chain-dtype dtype)
@@ -1143,6 +1164,14 @@
                          src-buf (buf-of src-sym :scatter-src)
                          idx-buf (buf-of idx-sym :scatter-idx)
                          n       (long (n-fn args))
+                         ;; A scatter step has AT MOST one scalar (the optional stride). Taking
+                         ;; `(first scalar-specs)` would silently drop any further scalars — so
+                         ;; assert the shape instead of miscompiling a multi-scalar scatter.
+                         _       (when (> (count scalar-specs) 1)
+                                   (throw (ex-info (str "resident scatter step " kernel-name
+                                                        " has " (count scalar-specs)
+                                                        " scalars — only a single stride is modeled")
+                                                   {:kernel kernel-name :scalar-specs scalar-specs})))
                          stride  (when (seq scalar-specs) (long ((:value-fn (first scalar-specs)) args)))
                          out-size (or (alloc-size-of accumulator)
                                       ;; fallback: accumulator is a param, use its length

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -18,6 +18,29 @@
         segops (lower/lower-reduce s nil)]
     (:source (sg/generate-segred-kernel (first segops) 'out :dtype :float))))
 
+;; ================================================================
+;; Silently-ignored-information family: a SegRed combine that the
+;; extractor only partially models must FAIL LOUD, not miscompile.
+;; ================================================================
+
+(deftest segred-nary-combine-rejected
+  (testing "a variadic (+ acc x y) combine is rejected, not silently summing only x"
+    ;; Before the fix, op-args extraction took a0=acc a1=x and DROPPED y — emitting a
+    ;; kernel that reduced with just x. A segmented reduce combine is binary (op acc elem).
+    (is (thrown-with-msg?
+         Exception #"only a binary \(op acc elem\) combine"
+         (segred-source '(+ acc (clojure.core/aget a j) (clojure.core/aget b j))))))
+  (testing "the ordinary binary combine still lowers unchanged"
+    (is (re-find #"val = " (segred-source '(+ acc (clojure.core/aget a j)))))))
+
+(deftest segred-multistatement-lambda-rejected
+  (testing "a reduce lambda with a multi-statement let body is rejected, not (last bdy)-dropped"
+    ;; The single-aset-void store-drop shape on the reduce side: (last bdy) silently dropped
+    ;; the earlier body forms.
+    (is (thrown-with-msg?
+         Exception #"multi-statement body"
+         (segred-source '(let* [t (clojure.core/aget a j)] (+ acc t) (+ acc t)))))))
+
 (deftest segred-devirtualized-aget-lowers-to-subscript
   (testing "the parametric (.invk aget-impl …) shape — the qlinear-k side of #55"
     (let [aget-invk (with-meta (list '.invk 'raster.arrays/aget_m_floats_long-impl 'a 'j)

--- a/test/raster/compiler/ir/screma_test.clj
+++ b/test/raster/compiler/ir/screma_test.clj
@@ -72,6 +72,28 @@
       (is (= 'out (second par-form))))))
 
 ;; ================================================================
+;; Silently-ignored-information family: a Map+Reduce screma whose map
+;; was NOT inlined into the reduce lambda must fail loud — emitting only
+;; the reduce (as the arm used to) would drop the map computation.
+;; ================================================================
+
+(deftest screma-map-reduce-unfused-throws
+  (testing "a reduce screma still carrying a :map-lambda is rejected, not silently reduce-only"
+    (let [screma (soac/->Screma 1 'r 'i 'n #{'a 'tmp} #{'r} #{}
+                                nil [] [{:acc 'acc :init 0.0
+                                         :lambda '(+ acc (aget tmp i))}]
+                                '(* (aget a i) 2.0))]
+      (is (thrown-with-msg?
+           Exception #"was not inlined into the reduce lambda"
+           (soac/screma->par-form screma)))))
+  (testing "a properly-fused reduce (no map-lambda) still converts"
+    (let [screma (soac/->Screma 1 'r 'i 'n #{'a} #{'r} #{}
+                                nil [] [{:acc 'acc :init 0.0
+                                         :lambda '(+ acc (aget a i))}]
+                                nil)]
+      (is (= 'raster.par/reduce (first (soac/screma->par-form screma)))))))
+
+;; ================================================================
 ;; Screma composition
 ;; ================================================================
 

--- a/test/raster/compiler/passes/parallel/liveness_map_recursion_test.clj
+++ b/test/raster/compiler/passes/parallel/liveness_map_recursion_test.clj
@@ -1,0 +1,23 @@
+(ns raster.compiler.passes.parallel.liveness-map-recursion-test
+  "Silently-ignored-information family: fusion-pass local liveness helpers must recurse
+   into MAP literals (a `case*` clause map) the same way util/free-syms-flat does. A
+   symbol / aget read reachable only inside a map literal used to look dead, so the
+   sole-consumer / liveness checks could wrongly fuse away a still-live buffer.
+
+   These pin the two remaining local copies (par-fusion/all-symbol-uses and
+   write-read-fuse/collect-aget-syms). Before the fix each returned #{} for the map
+   literal, so the symbol was invisible."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.passes.parallel.par-fusion :as pf]
+            [raster.compiler.passes.parallel.write-read-fuse :as wrf]))
+
+(deftest all-symbol-uses-sees-map-literal
+  (testing "a symbol reachable only inside a map literal is collected, not dropped"
+    (is (contains? (#'pf/all-symbol-uses '(foo {:k barsym})) 'barsym))
+    (is (contains? (#'pf/all-symbol-uses
+                    '(case* x 0 default {0 [(quote lit) hidden-sym]}))
+                   'hidden-sym))))
+
+(deftest collect-aget-syms-sees-map-literal
+  (testing "an aget read reachable only inside a map literal is collected, not dropped"
+    (is (contains? (#'wrf/collect-aget-syms '(foo {:k (clojure.core/aget buf i)})) 'buf))))

--- a/test/raster/compiler/pipeline_extractor_test.clj
+++ b/test/raster/compiler/pipeline_extractor_test.clj
@@ -1,0 +1,64 @@
+(ns raster.compiler.pipeline-extractor-test
+  "Resident GPU-program extractor hardening (silently-ignored-information family).
+
+   extract-gpu-program walks a straight-line fused GPU IR into flat kernel steps.
+   parse-gpu-step destructures a FIXED-length invoke prefix per convention. With no
+   arity check an extra operand was silently DROPPED and a short form bound nil into a
+   size slot — the same shape as the resident-GEMM alpha/beta drop (#65). Each arm now
+   returns nil on an unmodeled arity so the extractor rejects it BY NAME
+   (:unparseable-kernel-invoke) via its existing ::non-resident mechanism, instead of
+   emitting a miscompiled kernel step. These pin the reject; before the fix each malformed
+   form extracted to a (wrong) step with no ::non-resident."
+  (:require [clojure.test :refer [deftest testing is]]
+            [raster.compiler.pipeline :as pipeline]))
+
+(def ^:private nr-key :raster.compiler.pipeline/non-resident)
+
+(defn- why [form] (get-in (pipeline/extract-gpu-program form) [nr-key :why]))
+
+(deftest map-void-arity
+  (testing "a correct 5-wide map-void invoke extracts to one step, no rejection"
+    (let [r (pipeline/extract-gpu-program
+             '(let* [out (raster.gpu.ze-runtime/invoke-registered-map-void-kernel
+                          "k" [a b] [s] 10)]
+                    out))]
+      (is (nil? (nr-key r)))
+      (is (= 1 (count (:steps r))))
+      (is (= :map-void (:convention (first (:steps r)))))))
+  (testing "an EXTRA operand is rejected by name, not silently dropped"
+    (is (= :unparseable-kernel-invoke
+           (why '(let* [out (raster.gpu.ze-runtime/invoke-registered-map-void-kernel
+                             "k" [a b] [s] 10 extra)]
+                       out))))))
+
+(deftest map-arity
+  (testing "a correct 6-wide map invoke extracts"
+    (let [r (pipeline/extract-gpu-program
+             '(let* [out (raster.gpu.ze-runtime/invoke-registered-kernel
+                          "k" [a b] out0 [s] 10)]
+                    out))]
+      (is (nil? (nr-key r)))
+      (is (= :map (:convention (first (:steps r)))))))
+  (testing "a short 5-wide map invoke (missing a slot) is rejected"
+    (is (= :unparseable-kernel-invoke
+           (why '(let* [out (raster.gpu.ze-runtime/invoke-registered-kernel
+                             "k" [a b] out0 10)]
+                       out))))))
+
+(deftest reduce-arity
+  (testing "a 5-wide resident reduction and a 4-wide legacy reduction both extract"
+    (is (= :reduce (:convention (first (:steps (pipeline/extract-gpu-program
+                                                '(let* [out (raster.gpu.ze-runtime/invoke-reduction-kernel
+                                                             "k" [a] obuf 10)]
+                                                       out)))))))
+    (is (= :reduce (:convention (first (:steps (pipeline/extract-gpu-program
+                                                '(let* [out (raster.gpu.ze-runtime/invoke-reduction-kernel
+                                                             "k" [a] 10)]
+                                                       out))))))))
+  (testing "a 6-wide reduction (unmodeled) is REJECTED, not silently read as legacy 3-arg"
+    ;; Before the fix this fell to the else-branch and destructured [_ kname inputs n],
+    ;; binding n = the out-buf symbol — a silent miscompile.
+    (is (= :unparseable-kernel-invoke
+           (why '(let* [out (raster.gpu.ze-runtime/invoke-reduction-kernel
+                             "k" [a] obuf 10 extra)]
+                       out))))))

--- a/test/raster/gpu/chain_roles_test.clj
+++ b/test/raster/gpu/chain_roles_test.clj
@@ -1,0 +1,20 @@
+(ns raster.gpu.chain-roles-test
+  "Silently-ignored-information family: a chain buffer's residency role is validated at
+   bind time. An unknown role (a typo like :ouput) used to be stored verbatim and then
+   never matched by the (= r :output) download filter — so the buffer was silently never
+   downloaded. chain-roles-of now rejects any role outside the modeled set by name.
+
+   Pure test — exercises the role helper only, no device/session."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.gpu.core :as gc]))
+
+(deftest chain-roles-validated
+  (testing "known roles pass through; a missing role defaults to :scratch"
+    (is (= {:w :constant :x :input :y :scratch}
+           (#'gc/chain-roles-of {:w [:float 10 nil :constant]
+                                 :x [:float 10 nil :input]
+                                 :y [:float 10 nil nil]}))))
+  (testing "an unknown/typo'd role is REJECTED by name, not silently stored (never downloaded)"
+    (is (thrown-with-msg?
+         Exception #"unknown role :ouput"
+         (#'gc/chain-roles-of {:z [:float 10 nil :ouput]})))))


### PR DESCRIPTION
Systematic follow-up to the three "silently-ignored-information" miscompiles (SOAC store-drop 88d6d28, `.invk` DCE seed 0f92b40, resident-GEMM alpha/beta #65). A compiler audit found the pattern is a *style*, not three incidents — extractors/analyses that take the prefix or branch they understand and silently ignore the rest. This closes the reachable siblings using the extractor's existing named-rejection mechanism (`::non-resident {:why …}`) and plain asserts, so an unmodeled form throws instead of emitting wrong GPU output.

Suite: **1845 tests / 31545 assertions / 0 failures / 0 errors** (baseline 1836/31525 after #65 + new regression tests). Each fix has a test that fails on main before it.

## Fixed (reachable sites)
- **`08cacaa` — resident invoke steps reject wrong-arity forms.** `parse-gpu-step`'s `:map-void`/`:map`/`:scatter`/`:reduce` arms destructured fixed prefixes with no arity check (the `:reduce` arm treated *any* count ≠ 5 as the legacy 3-arg shape) — the exact mechanism of the alpha/beta bug, on four more conventions. Now each rejects by name when the arg count doesn't match what its binder consumes.
- **`2013228` — SegRed rejects n-ary combine / multi-statement reduce lambdas.** `(when (>= (count op-args) 2) …)` extracted one operand, so `(+ acc x y)` would have emitted a kernel summing only `x`; the `(last bdy)` on a multi-statement reduce body was the same shape as the fixed store-drop bug, unfixed on the reduce side. Both now fail loud.
- **`a003ee6` — Map+Reduce screma with an un-inlined `:map-lambda` fails loud** instead of silently dropping the map computation. Also **documents two deferred gaps** (see below).
- **`e6ae478` — fusion local liveness helpers recurse into `case*`-clause map literals** (the shared `util/free-syms-flat` was already fixed for this; the local copies weren't — replaced with the fixed shared util).
- **`7c07547` — chain buffer roles validated at bind time** (a typo'd role silently meant "never downloaded"); scatter step asserts its single scalar spec.

## Deliberately deferred (documented, not hastily patched)
Two deeper sites where a hasty fix risked correctness and the honest disposition is a loud comment + a filed note:
- `node-produced-syms` (soac.clj) sees only `aset`s — a `:buffer-write`-declared op contributes no producer edge to the SOAC topological sort (the registry DCE consults is not consulted here).
- index-insensitive `aget` substitution in vertical fusion — replaces every `(aget tmp …)` regardless of the consumer's index expression.

Both are structural and point at the real long-term fix: **a descriptor/steps validator** (the S4 item). Per-site hardening is the right stopgap; a schema on the resident-program IR is what kills this family wholesale, since today dialect validation ends at extraction and every binder feature lands schema-less.