### PR TITLE
Affine-index vectorization in the shared C emitter (backend-agnostic vloadN, provably non-straddling)

### DIFF
--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -109,6 +109,15 @@
   vectorization section). Drives the ::vload / vector-cast emission in emit-expr."
   nil)
 
+(defn- contains-vload?
+  "True if the vectorizer's ::vload marker occurs anywhere in expr (i.e. the expr is
+  vector-valued). Used to drop element-type casts the walker inserted around what is
+  now a vector — `(double)(double4)` is illegal C but semantically identity here."
+  [expr]
+  (let [found (volatile! false)]
+    (walk/postwalk (fn [f] (when (and (seq? f) (= ::vload (first f))) (vreset! found true)) f) expr)
+    @found))
+
 ;; ================================================================
 ;; Op mapping (valid across all C-family backends)
 ;; ================================================================
@@ -940,8 +949,17 @@
      (and (seq? expr)
           (contains? #{'double 'float 'long 'int} (first expr))
           (= 2 (count expr)))
-     (emit-cast (remap-type (name (first expr)))
-                (emit-expr (second expr) idx-sym array-syms opencl-idx))
+     ;; Vectorizing: a cast the walker inserted around a now-vector expr. An element-type
+     ;; cast MATCHING the element type (e.g. `(double x)` where x is a double vload) is a
+     ;; no-op → drop it (`(double)(double4)` is illegal C). A cast to a DIFFERENT element
+     ;; type over a vector is a genuine per-lane precision change (a `^double` helper in a
+     ;; float kernel) with no clean vector lowering → bail this kernel to the scalar loop.
+     (if (and *vec-width* (contains-vload? (second expr)))
+       (if (= (name (first expr)) *scalar-type*)
+         (emit-expr (second expr) idx-sym array-syms opencl-idx)
+         (throw (ex-info "vector precision cast" {:raster.compiler.backend.gpu.c-emit/bail true})))
+       (emit-cast (remap-type (name (first expr)))
+                  (emit-expr (second expr) idx-sym array-syms opencl-idx)))
 
      ;; let/let* -> local variables with CSE
      (and (seq? expr) (contains? #{'let 'let*} (first expr)))
@@ -1413,6 +1431,13 @@
   "Infer the type tag of an expression in the current body context."
   [expr]
   (cond
+    ;; Vectorizer marker: a ::vload carries V element-type lanes — tag it as the element
+    ;; type so the deftm inliner accepts it and inlines the helper body with the vector
+    ;; flowing through (OpenCL vector arithmetic uses the scalar operators/builtins).
+    (and (seq? expr) (= ::vload (first expr)))
+    (when *scalar-type*
+      (get {"float" 'float "double" 'double "int" 'int "long" 'long} *scalar-type*))
+
     (symbol? expr)
     (or (:tag (meta expr))
         ;; Fall back to scalar type for untagged symbols (push constants, locals)
@@ -1915,10 +1940,12 @@
   become ::vload markers (emit-expr renders vloadV); broadcast/invariant loads and bare
   scalars stay scalar (OpenCL broadcasts them into the vector arithmetic). Element-type
   casts (float/double) wrapping a vector are no-ops and are dropped — a `(float)(float4)`
-  is illegal C but semantically identity here. Collects the divisor of every broadcast/
-  rowrel subscript into `divisors!` (an atom). Throws vec-bail! on anything that cannot
-  be proven vector-safe (non-affine subscript, gather, integer-narrowing over a vector,
-  non-integer divisor)."
+  is illegal C but semantically identity here. A deftm helper call keeps its shape; a
+  ::vload arg makes emit-expr's inliner (via infer-arg-tag) inline the helper body with
+  the vector flowing through — so no scalar-per-lane helper call survives. Collects the
+  divisor of every broadcast/rowrel subscript into `divisors!` (an atom). Throws vec-bail!
+  on anything that cannot be proven vector-safe (non-affine subscript, gather,
+  integer-narrowing over a vector, non-integer divisor)."
   [expr idx-sym array-syms divisors!]
   (letfn [(record-div! [d]
             (when-not (contains? #{"int" "uint" "long"} (infer-c-type d)) (vec-bail!))
@@ -2025,32 +2052,36 @@
    {:keys [n-bound store-name] :or {n-bound "_n_bound"}}]
   (when (:vectorize? *emit-config*)
     (when-let [{:keys [stores divisors]} (analyze-elementwise-vectorizable body idx-sym array-syms)]
-      (let [scalar-loop (str "for (int " opencl-idx " = get_global_id(0); "
-                             opencl-idx " < " n-bound "; "
-                             opencl-idx " += get_global_size(0)) {\n"
-                             "        " scalar-body-str "\n"
-                             "    }")
-            emit-vec-loop
-            (fn [V]
-              (let [store-strs (str/join " "
-                                         (map #(emit-vec-store % idx-sym array-syms opencl-idx V store-name) stores))]
-                (str "for (int _vb = get_global_id(0); _vb < (" n-bound " / " V "); "
-                     "_vb += get_global_size(0)) {\n"
-                     "        int " opencl-idx " = _vb * " V ";\n"
-                     "        " store-strs "\n"
-                     "    }")))
-            guard (fn [V] (str/join " && "
-                                    (cons (str "((" n-bound " % " V ") == 0)")
-                                          (map (fn [d]
-                                                 (str "((" (emit-expr d idx-sym array-syms opencl-idx)
-                                                      " % " V ") == 0)"))
-                                               divisors))))
-            v4 (binding [*vec-width* 4] (emit-vec-loop 4))
-            v2 (binding [*vec-width* 2] (emit-vec-loop 2))]
-        ;; A real GPU-helper call (gpufn_*) in the vectorized body would pass a vector
-        ;; to a scalar helper — its vector overload is a separate concern. Until then,
-        ;; bail to scalar if the emitted vector body calls one. (Numeric ops resolve to
-        ;; C operators, not gpufn_ calls, so they pass.)
-        (when-not (or (str/includes? v4 "gpufn_") (str/includes? v2 "gpufn_"))
-          (str "if (" (guard 4) ") {\n    " v4 "\n    } else if (" (guard 2) ") {\n    "
-               v2 "\n    } else {\n    " scalar-loop "\n    }"))))))
+      (try
+        (let [scalar-loop (str "for (int " opencl-idx " = get_global_id(0); "
+                               opencl-idx " < " n-bound "; "
+                               opencl-idx " += get_global_size(0)) {\n"
+                               "        " scalar-body-str "\n"
+                               "    }")
+              emit-vec-loop
+              (fn [V]
+                (let [store-strs (str/join " "
+                                           (map #(emit-vec-store % idx-sym array-syms opencl-idx V store-name) stores))]
+                  (str "for (int _vb = get_global_id(0); _vb < (" n-bound " / " V "); "
+                       "_vb += get_global_size(0)) {\n"
+                       "        int " opencl-idx " = _vb * " V ";\n"
+                       "        " store-strs "\n"
+                       "    }")))
+              guard (fn [V] (str/join " && "
+                                      (cons (str "((" n-bound " % " V ") == 0)")
+                                            (map (fn [d]
+                                                   (str "((" (emit-expr d idx-sym array-syms opencl-idx)
+                                                        " % " V ") == 0)"))
+                                                 divisors))))
+              v4 (binding [*vec-width* 4] (emit-vec-loop 4))
+              v2 (binding [*vec-width* 2] (emit-vec-loop 2))]
+          ;; A gpufn_ helper call surviving in the vectorized body would pass a vector to a
+          ;; scalar helper — bail to scalar. (Deftm helpers inline via emit-expr; numeric
+          ;; ops resolve to C operators — both pass. A non-inlinable helper leaves gpufn_.)
+          (when-not (or (str/includes? v4 "gpufn_") (str/includes? v2 "gpufn_"))
+            (str "if (" (guard 4) ") {\n    " v4 "\n    } else if (" (guard 2) ") {\n    "
+                 v2 "\n    } else {\n    " scalar-loop "\n    }")))
+        ;; A precision-changing vector cast (or other vector-unsafe form) surfaced during
+        ;; emission → fall back to the scalar loop (caller emits it).
+        (catch clojure.lang.ExceptionInfo e
+          (if (::bail (ex-data e)) nil (throw e)))))))

--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -1815,6 +1815,10 @@
 ;; inherits it; the vloadV/vstoreV spelling is OpenCL-specific and gated on that
 ;; flag, so HIP/CUDA enable it later by adding their spelling, not by rewriting.
 
+(defn- vec-bail!
+  "Abort vectorization of the current kernel (caught at the top level → scalar loop)."
+  [] (throw (ex-info "not-vectorizable" {::bail true})))
+
 (def ^:private quot-ops #{'quot 'clojure.core/quot})
 (def ^:private rem-ops  #{'rem 'clojure.core/rem 'mod 'clojure.core/mod})
 (def ^:private prim-cast-ops #{'double 'float 'long 'int
@@ -1858,26 +1862,28 @@
       :else nil)))
 
 (defn- inline-pure-lets
-  "Fully inline let/let* bindings that are pure (no side effects, not loops) so
-  subscript index expressions are exposed. Returns the inlined body, or nil if any
-  binding is side-effecting/loop-valued (can't safely inline → bail vectorization)."
+  "Deep-inline EVERY pure let/let* (no side effects, not loops) anywhere in the form,
+  so subscript index expressions are exposed and no scalar local is declared for a
+  value that becomes a vector (a nested let inside a store value would otherwise emit
+  `float x = <float4>` — a type error). A vectorizable straight-line body has only
+  pure bindings; an impure/loop-valued binding throws vec-bail! (→ scalar loop)."
   [expr]
-  (loop [expr expr]
-    (if (and (seq? expr) (contains? #{'let 'let*} (first expr)))
-      (let [[_ bindings & body] expr
-            pairs (partition 2 bindings)]
-        (if (some (fn [[_ v]] (or (has-side-effects? v)
-                                  (and (seq? v) (contains? #{'loop 'loop*} (first v)))))
-                  pairs)
-          nil
-          (let [env (reduce (fn [env [s v]]
-                              (assoc env s (walk/postwalk-replace env v)))
-                            {} pairs)
-                body' (mapv #(walk/postwalk-replace env %) body)]
-            (if (= 1 (count body'))
-              (recur (first body'))
-              (cons 'do body')))))
-      expr)))
+  (walk/prewalk
+   (fn [f]
+     (if (and (seq? f) (contains? #{'let 'let*} (first f)))
+       (let [[_ bindings & body] f
+             pairs (partition 2 bindings)]
+         (when (some (fn [[_ v]] (or (has-side-effects? v)
+                                     (and (seq? v) (contains? #{'loop 'loop*} (first v)))))
+                     pairs)
+           (vec-bail!))
+         (let [env (reduce (fn [env [s v]]
+                             (assoc env s (walk/postwalk-replace env v)))
+                           {} pairs)
+               body' (mapv #(walk/postwalk-replace env %) body)]
+           (if (= 1 (count body')) (first body') (cons 'do body'))))
+       f))
+   expr))
 
 (defn- aget-form?* [f] (and (seq? f) (>= (count f) 3) (descriptor/aget-op? (first f))))
 (defn- aset-form?* [f] (and (seq? f) (>= (count f) 4) (descriptor/aset-op? (first f))))
@@ -1892,10 +1898,6 @@
     (let [ss (rest core)]
       (when (every? aset-form?* ss) (vec ss)))
     :else nil))
-
-(defn- vec-bail!
-  "Abort vectorization of the current kernel (caught at the top level → scalar loop)."
-  [] (throw (ex-info "not-vectorizable" {::bail true})))
 
 (def ^:private cast-target
   {'float "float" 'double "double" 'int "int" 'long "long"
@@ -1974,7 +1976,7 @@
   [body idx-sym array-syms]
   (when (contains? #{"float" "double"} *scalar-type*)
     (try
-      (let [core (or (inline-pure-lets body) (vec-bail!))
+      (let [core (inline-pure-lets body)
             stores (or (collect-stores core) (vec-bail!))]
         (when (idx-leaks? core idx-sym) (vec-bail!))
         ;; no control flow in a vectorizable straight-line body
@@ -1990,6 +1992,9 @@
                         ;; a vstore writes contiguous lanes — the store index must be idx
                         (when-not (= :contiguous (:kind (classify-subscript idx-e idx-sym)))
                           (vec-bail!))
+                        ;; a nested store inside the value (horizontally-fused multi-output
+                        ;; map) can't be a lane vector store — bail to scalar
+                        (walk/postwalk (fn [f] (when (aset-form?* f) (vec-bail!)) f) val)
                         {:arr arr :val (preprocess-value val idx-sym array-syms divisors!)}))
                     stores)]
           {:stores store-recs :divisors (vec (distinct @divisors!))}))
@@ -1998,13 +2003,14 @@
 
 (defn- emit-vec-store
   "Emit one vstoreV statement for a store {:arr :val} at width V (element type =
-  *scalar-type*, bound by the caller)."
-  [{:keys [arr val]} idx-sym array-syms opencl-idx V]
+  *scalar-type*, bound by the caller). store-name overrides the target C name (used by
+  the SegMap path whose output param is the literal `out`, not c-symbol-mangled)."
+  [{:keys [arr val]} idx-sym array-syms opencl-idx V store-name]
   (let [val-str (emit-expr val idx-sym array-syms opencl-idx)
         vtype   (str *scalar-type* V)
         ;; a pure-broadcast value (no vector load) must be widened to the vector type
         data    (if (value-has-vload? val) val-str (str "(" vtype ")(" val-str ")"))]
-    (str "vstore" V "(" data ", 0, " (c-symbol arr) " + " opencl-idx ");")))
+    (str "vstore" V "(" data ", 0, " (or store-name (c-symbol arr)) " + " opencl-idx ");")))
 
 (defn emit-vectorized-elementwise-loop
   "Given an elementwise kernel body and the scalar loop body already emitted by the
@@ -2013,8 +2019,10 @@
   scalar grid-stride loop. Returns nil if the body is not provably vectorizable, in
   which case the caller emits its usual scalar loop.
 
-  opts: {:n-bound \"_n_bound\"}  (the C variable holding the element count)"
-  [body idx-sym array-syms opencl-idx scalar-body-str {:keys [n-bound] :or {n-bound "_n_bound"}}]
+  opts: {:n-bound \"_n_bound\"   (the C variable holding the element count)
+         :store-name \"out\"}     (optional literal target name for a single store)"
+  [body idx-sym array-syms opencl-idx scalar-body-str
+   {:keys [n-bound store-name] :or {n-bound "_n_bound"}}]
   (when (:vectorize? *emit-config*)
     (when-let [{:keys [stores divisors]} (analyze-elementwise-vectorizable body idx-sym array-syms)]
       (let [scalar-loop (str "for (int " opencl-idx " = get_global_id(0); "
@@ -2025,7 +2033,7 @@
             emit-vec-loop
             (fn [V]
               (let [store-strs (str/join " "
-                                         (map #(emit-vec-store % idx-sym array-syms opencl-idx V) stores))]
+                                         (map #(emit-vec-store % idx-sym array-syms opencl-idx V store-name) stores))]
                 (str "for (int _vb = get_global_id(0); _vb < (" n-bound " / " V "); "
                      "_vb += get_global_size(0)) {\n"
                      "        int " opencl-idx " = _vb * " V ";\n"

--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -51,7 +51,11 @@
    :float-abs       "fabs"
    :float-max       "fmax"
    :float-min       "fmin"
-   :float-suffix?   true})
+   :float-suffix?   true
+   ;; Affine-index vectorization emits OpenCL vloadV/vstoreV. HIP/CUDA/GLSL configs
+   ;; omit this until their vector load/store spelling is added (they fall back to
+   ;; the scalar loop — always correct).
+   :vectorize?      true})
 
 (def glsl-config
   {:cast-style      :glsl
@@ -97,6 +101,13 @@
   so index arithmetic bound to a name (e.g. `base = b*32`) is typed int rather than
   defaulting to *scalar-type*. Loop and let* emitters seed it for their bodies."
   #{})
+
+(def ^:dynamic *vec-width*
+  "When non-nil (2 or 4), the affine-index vectorizer is active and *scalar-type*
+  refers to the ELEMENT type of the V-wide vectors being emitted. Only set inside
+  the vectorized fast-path of an elementwise kernel loop (see the affine
+  vectorization section). Drives the ::vload / vector-cast emission in emit-expr."
+  nil)
 
 ;; ================================================================
 ;; Op mapping (valid across all C-family backends)
@@ -914,6 +925,16 @@
            idx-expr (if invk? (nth expr 3) (nth expr 2))]
        (str (c-symbol arr) "["
             (emit-expr idx-expr idx-sym array-syms opencl-idx) "]"))
+
+     ;; Vectorizer marker: (::vload arr off-expr) → a V-wide contiguous vector load
+     ;; vloadV(0, arr + off). Emitted only inside the vectorized fast-path of an
+     ;; elementwise kernel (see the affine vectorization section), where *vec-width*
+     ;; is bound and the runtime divisibility guard guarantees off is V-aligned and
+     ;; the block stays within one row (so a rowrel `off = idx % C` load is contiguous).
+     (and (seq? expr) (= ::vload (first expr)))
+     (let [[_ arr off] expr]
+       (str "vload" *vec-width* "(0, " (c-symbol arr) " + "
+            (emit-expr off idx-sym array-syms opencl-idx) ")"))
 
      ;; Primitive cast
      (and (seq? expr)
@@ -1761,3 +1782,267 @@
      :source (str "static " ret-type " " c-name "(" param-strs ") {\n"
                   "    return " body-str ";\n"
                   "}\n")}))
+
+;; ================================================================
+;; Affine-index vectorization (shared, opt-in-by-provability)
+;; ================================================================
+;; Rewrites a straight-line elementwise kernel body so each work item processes
+;; V consecutive elements via vector loads/stores (vloadV / vstoreV). This is the
+;; #1 GPU bandwidth lever for the indexed elementwise family (chunked-rms-norm
+;; apply and friends): the currency for these streaming kernels is outstanding
+;; bytes per lane, and float4 loads/stores recover ~40% of the bandwidth the
+;; scalar path leaves on the table.
+;;
+;; Subscript classification (relative to the work-item index `idx`):
+;;   identity  a[idx]        -> contiguous  vloadV(0, a + idx)
+;;   a[idx/C]  (broadcast)   -> CONSTANT across the V lanes of one block -> scalar
+;;                             load a[idx/C], broadcast into the vector arithmetic
+;;   a[idx%C]  (row-relative)-> contiguous within a row -> vloadV(0, a + (idx%C))
+;;   free of idx (invariant) -> scalar broadcast
+;;   anything else           -> NOT vectorizable; fall back to the scalar loop.
+;;
+;; Legality (non-straddling) is enforced at RUNTIME, not guessed: the vectorized
+;; fast-path runs only when the element count and EVERY divisor C are multiples of
+;; V. Given the loop hands each work item a V-aligned block base (vb*V), C % V == 0
+;; guarantees a V-block never straddles a `/C` or `%C` row boundary — so idx/C is
+;; constant across the block and idx%C is contiguous. Otherwise the scalar loop
+;; runs. The transform is therefore always correct; it only ever CAPTURES the win
+;; when the dims cooperate (gemma d=640, hd=256 are multiples of 4).
+;;
+;; The classification is pure S-expression analysis (the JVM/CPU affine matchers in
+;; segop_simd are backend-coupled, so the small pure equivalents live here). Living
+;; in c_emit, every C-family backend that sets :vectorize? in its emit-config
+;; inherits it; the vloadV/vstoreV spelling is OpenCL-specific and gated on that
+;; flag, so HIP/CUDA enable it later by adding their spelling, not by rewriting.
+
+(def ^:private quot-ops #{'quot 'clojure.core/quot})
+(def ^:private rem-ops  #{'rem 'clojure.core/rem 'mod 'clojure.core/mod})
+(def ^:private prim-cast-ops #{'double 'float 'long 'int
+                               'clojure.core/double 'clojure.core/float
+                               'clojure.core/long 'clojure.core/int})
+(def ^:private idx-cast-ops #{'long 'int 'clojure.core/long 'clojure.core/int})
+
+(defn- sym-occurs?
+  "True if symbol s (matched by name) occurs anywhere in expr."
+  [expr s]
+  (let [found (atom false)]
+    (walk/postwalk (fn [f] (when (and (symbol? f) s (= (name f) (name s)))
+                             (reset! found true))
+                     f)
+                   expr)
+    @found))
+
+(defn- strip-idx-cast
+  "Unwrap a single (long idx)/(int idx) cast."
+  [e]
+  (if (and (seq? e) (= 2 (count e)) (contains? idx-cast-ops (first e)))
+    (second e) e))
+
+(defn- classify-subscript
+  "Classify an aget/aset index expression E relative to idx-sym. Returns one of
+  {:kind :contiguous} / {:kind :broadcast :divisor C} / {:kind :rowrel :divisor C}
+  / {:kind :invariant} / nil (non-affine → not vectorizable)."
+  [e idx-sym]
+  (let [e (strip-idx-cast e)
+        idx? (fn [x] (let [x (strip-idx-cast x)]
+                       (and (symbol? x) (= (name x) (name idx-sym)))))]
+    (cond
+      (idx? e) {:kind :contiguous}
+      (and (seq? e) (= 3 (count e)) (contains? quot-ops (first e))
+           (idx? (nth e 1)) (not (sym-occurs? (nth e 2) idx-sym)))
+      {:kind :broadcast :divisor (nth e 2)}
+      (and (seq? e) (= 3 (count e)) (contains? rem-ops (first e))
+           (idx? (nth e 1)) (not (sym-occurs? (nth e 2) idx-sym)))
+      {:kind :rowrel :divisor (nth e 2)}
+      (not (sym-occurs? e idx-sym)) {:kind :invariant}
+      :else nil)))
+
+(defn- inline-pure-lets
+  "Fully inline let/let* bindings that are pure (no side effects, not loops) so
+  subscript index expressions are exposed. Returns the inlined body, or nil if any
+  binding is side-effecting/loop-valued (can't safely inline → bail vectorization)."
+  [expr]
+  (loop [expr expr]
+    (if (and (seq? expr) (contains? #{'let 'let*} (first expr)))
+      (let [[_ bindings & body] expr
+            pairs (partition 2 bindings)]
+        (if (some (fn [[_ v]] (or (has-side-effects? v)
+                                  (and (seq? v) (contains? #{'loop 'loop*} (first v)))))
+                  pairs)
+          nil
+          (let [env (reduce (fn [env [s v]]
+                              (assoc env s (walk/postwalk-replace env v)))
+                            {} pairs)
+                body' (mapv #(walk/postwalk-replace env %) body)]
+            (if (= 1 (count body'))
+              (recur (first body'))
+              (cons 'do body')))))
+      expr)))
+
+(defn- aget-form?* [f] (and (seq? f) (>= (count f) 3) (descriptor/aget-op? (first f))))
+(defn- aset-form?* [f] (and (seq? f) (>= (count f) 4) (descriptor/aset-op? (first f))))
+
+(defn- collect-stores
+  "Return a vector of (aset ...) forms from a straight-line core (an aset or a do
+  of asets). nil if the shape is not straight-line stores."
+  [core]
+  (cond
+    (aset-form?* core) [core]
+    (and (seq? core) (= 'do (first core)))
+    (let [ss (rest core)]
+      (when (every? aset-form?* ss) (vec ss)))
+    :else nil))
+
+(defn- vec-bail!
+  "Abort vectorization of the current kernel (caught at the top level → scalar loop)."
+  [] (throw (ex-info "not-vectorizable" {::bail true})))
+
+(def ^:private cast-target
+  {'float "float" 'double "double" 'int "int" 'long "long"
+   'clojure.core/float "float" 'clojure.core/double "double"
+   'clojure.core/int "int" 'clojure.core/long "long"})
+
+(def ^:private value-has-vload?
+  (fn [expr]
+    (let [found (atom false)]
+      (walk/postwalk (fn [f] (when (and (seq? f) (= ::vload (first f))) (reset! found true)) f) expr)
+      @found)))
+
+(defn- preprocess-value
+  "Rewrite a value expression into its vectorized form: contiguous/row-relative loads
+  become ::vload markers (emit-expr renders vloadV); broadcast/invariant loads and bare
+  scalars stay scalar (OpenCL broadcasts them into the vector arithmetic). Element-type
+  casts (float/double) wrapping a vector are no-ops and are dropped — a `(float)(float4)`
+  is illegal C but semantically identity here. Collects the divisor of every broadcast/
+  rowrel subscript into `divisors!` (an atom). Throws vec-bail! on anything that cannot
+  be proven vector-safe (non-affine subscript, gather, integer-narrowing over a vector,
+  non-integer divisor)."
+  [expr idx-sym array-syms divisors!]
+  (letfn [(record-div! [d]
+            (when-not (contains? #{"int" "uint" "long"} (infer-c-type d)) (vec-bail!))
+            (swap! divisors! conj d))
+          (go [f]
+              (cond
+              ;; explicit aget → classify its index
+                (aget-form?* f)
+                (let [arr (nth f 1) idx-e (nth f 2)
+                      c (classify-subscript idx-e idx-sym)]
+                  (case (:kind c)
+                    :contiguous (list ::vload arr idx-sym)
+                    :rowrel     (do (record-div! (:divisor c)) (list ::vload arr idx-e))
+                    :broadcast  (do (record-div! (:divisor c)) f) ;; scalar broadcast load
+                    :invariant  f                                 ;; scalar, free of idx
+                    (vec-bail!)))                                 ;; nil → non-affine/gather
+              ;; primitive cast: element-type cast over a vector is a no-op → drop it
+                (and (seq? f) (= 2 (count f)) (contains? prim-cast-ops (first f)))
+                (let [inner (go (second f))
+                      target (get cast-target (first f))]
+                  (if (value-has-vload? inner)
+                    (if (= target *scalar-type*) inner (vec-bail!))
+                    (list (first f) inner)))
+              ;; bare array symbol used as a value → contiguous load
+                (and (symbol? f) (contains? array-syms (symbol (name f))))
+                (list ::vload f idx-sym)
+                (seq? f)    (doall (map go f))
+                (vector? f) (mapv go f)
+                :else f))]
+    (go expr)))
+
+(defn- idx-leaks?
+  "True if idx-sym occurs anywhere OUTSIDE an aget/aset index position — i.e. it
+  would feed per-lane arithmetic, which the block-scalar `idx` can't represent."
+  [core idx-sym]
+  (let [blanked (walk/postwalk
+                 (fn [f]
+                   (cond
+                     (aset-form?* f) (list (first f) (nth f 1) 0 (nth f 3))
+                     (aget-form?* f) (list (first f) (nth f 1) 0)
+                     :else f))
+                 core)]
+    (sym-occurs? blanked idx-sym)))
+
+(defn analyze-elementwise-vectorizable
+  "Analyze an elementwise kernel body for affine-index vectorization. Returns nil
+  (fall back to scalar) or a map {:stores [{:arr :val'} ...] :divisors [C-expr ...]}
+  where val' has contiguous/rowrel loads rewritten to ::vload markers. Width-independent
+  — the runtime guard is emitted per width by emit-vectorized-elementwise-loop.
+
+  Bails (nil) unless the body is straight-line elementwise stores over contiguous
+  positions, every array subscript classifies, idx never leaks into per-lane
+  arithmetic, and there is no control flow. Real GPU-helper calls (gpufn_*) are caught
+  downstream in the emitter (their vector overloads are a separate concern)."
+  [body idx-sym array-syms]
+  (when (contains? #{"float" "double"} *scalar-type*)
+    (try
+      (let [core (or (inline-pure-lets body) (vec-bail!))
+            stores (or (collect-stores core) (vec-bail!))]
+        (when (idx-leaks? core idx-sym) (vec-bail!))
+        ;; no control flow in a vectorizable straight-line body
+        (walk/postwalk
+         (fn [f] (when (and (seq? f)
+                            (contains? #{'if 'when 'case 'cond 'loop 'loop* 'and 'or} (first f)))
+                   (vec-bail!)) f)
+         core)
+        (let [divisors! (atom [])
+              store-recs
+              (mapv (fn [st]
+                      (let [[_ arr idx-e val] st]
+                        ;; a vstore writes contiguous lanes — the store index must be idx
+                        (when-not (= :contiguous (:kind (classify-subscript idx-e idx-sym)))
+                          (vec-bail!))
+                        {:arr arr :val (preprocess-value val idx-sym array-syms divisors!)}))
+                    stores)]
+          {:stores store-recs :divisors (vec (distinct @divisors!))}))
+      (catch clojure.lang.ExceptionInfo e
+        (if (::bail (ex-data e)) nil (throw e))))))
+
+(defn- emit-vec-store
+  "Emit one vstoreV statement for a store {:arr :val} at width V (element type =
+  *scalar-type*, bound by the caller)."
+  [{:keys [arr val]} idx-sym array-syms opencl-idx V]
+  (let [val-str (emit-expr val idx-sym array-syms opencl-idx)
+        vtype   (str *scalar-type* V)
+        ;; a pure-broadcast value (no vector load) must be widened to the vector type
+        data    (if (value-has-vload? val) val-str (str "(" vtype ")(" val-str ")"))]
+    (str "vstore" V "(" data ", 0, " (c-symbol arr) " + " opencl-idx ");")))
+
+(defn emit-vectorized-elementwise-loop
+  "Given an elementwise kernel body and the scalar loop body already emitted by the
+  backend (scalar-body-str), return the FULL loop region: a runtime divisibility
+  guard choosing a float4 / float2 vectorized grid-stride loop, falling back to the
+  scalar grid-stride loop. Returns nil if the body is not provably vectorizable, in
+  which case the caller emits its usual scalar loop.
+
+  opts: {:n-bound \"_n_bound\"}  (the C variable holding the element count)"
+  [body idx-sym array-syms opencl-idx scalar-body-str {:keys [n-bound] :or {n-bound "_n_bound"}}]
+  (when (:vectorize? *emit-config*)
+    (when-let [{:keys [stores divisors]} (analyze-elementwise-vectorizable body idx-sym array-syms)]
+      (let [scalar-loop (str "for (int " opencl-idx " = get_global_id(0); "
+                             opencl-idx " < " n-bound "; "
+                             opencl-idx " += get_global_size(0)) {\n"
+                             "        " scalar-body-str "\n"
+                             "    }")
+            emit-vec-loop
+            (fn [V]
+              (let [store-strs (str/join " "
+                                         (map #(emit-vec-store % idx-sym array-syms opencl-idx V) stores))]
+                (str "for (int _vb = get_global_id(0); _vb < (" n-bound " / " V "); "
+                     "_vb += get_global_size(0)) {\n"
+                     "        int " opencl-idx " = _vb * " V ";\n"
+                     "        " store-strs "\n"
+                     "    }")))
+            guard (fn [V] (str/join " && "
+                                    (cons (str "((" n-bound " % " V ") == 0)")
+                                          (map (fn [d]
+                                                 (str "((" (emit-expr d idx-sym array-syms opencl-idx)
+                                                      " % " V ") == 0)"))
+                                               divisors))))
+            v4 (binding [*vec-width* 4] (emit-vec-loop 4))
+            v2 (binding [*vec-width* 2] (emit-vec-loop 2))]
+        ;; A real GPU-helper call (gpufn_*) in the vectorized body would pass a vector
+        ;; to a scalar helper — its vector overload is a separate concern. Until then,
+        ;; bail to scalar if the emitted vector body calls one. (Numeric ops resolve to
+        ;; C operators, not gpufn_ calls, so they pass.)
+        (when-not (or (str/includes? v4 "gpufn_") (str/includes? v2 "gpufn_"))
+          (str "if (" (guard 4) ") {\n    " v4 "\n    } else if (" (guard 2) ") {\n    "
+               v2 "\n    } else {\n    " scalar-loop "\n    }"))))))

--- a/src/raster/compiler/backend/gpu/par_opencl.clj
+++ b/src/raster/compiler/backend/gpu/par_opencl.clj
@@ -198,6 +198,14 @@
                            ce/*scalar-type* default-ctype
                            ce/*int-vars* (into ce/*int-vars* int-scalar-syms)]
                    (ce/emit-stmt adapted-body idx all-arr-syms "idx"))
+        ;; Affine-index vectorization (shared c_emit): float4/float2 grid-stride loop
+        ;; guarded by a runtime divisibility check, else the scalar loop. nil ⇒ not
+        ;; provably vectorizable ⇒ scalar loop below.
+        loop-region (binding [ce/*emit-config* ce/opencl-config
+                              ce/*scalar-type* default-ctype
+                              ce/*int-vars* (into ce/*int-vars* int-scalar-syms)]
+                      (ce/emit-vectorized-elementwise-loop
+                       adapted-body idx all-arr-syms "idx" body-str {:n-bound "_n_bound"}))
         ;; Detect if body uses float atomic-add (needs CAS helper function)
         needs-float-atomic? (let [found (atom false)]
                               (walk/postwalk
@@ -227,10 +235,12 @@
                     (when (body-uses-dp4a? body) rstr-dp4a-helper)
                     "__kernel void " kernel-name
                     "(" all-params ") {\n"
-                    "    for (int idx = get_global_id(0); idx < _n_bound; idx += get_global_size(0)) {\n"
-                    "        " body-str "\n"
-                    "    }\n"
-                    "}\n")]
+                    "    "
+                    (or loop-region
+                        (str "for (int idx = get_global_id(0); idx < _n_bound; idx += get_global_size(0)) {\n"
+                             "        " body-str "\n"
+                             "    }"))
+                    "\n}\n")]
     {:kernel-name    kernel-name
      :source         source
      :array-params   all-arr-params

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -94,20 +94,36 @@
                                      [arr-param-str out-param scl-param-str "int _n_bound"]))
         ;; Emit body as C expression
         adapted-body (ce/adapt-casts-for-dtype body out-dtype)
+        arr-sym-set (set (map #(symbol (name %)) arr-params))
         body-str (binding [ce/*emit-config* ce/opencl-config
                            ce/*scalar-type* out-ctype
                            ce/*idx-sym* idx
                            ce/*int-vars* (into ce/*int-vars* int-scalar-syms)]
-                   (ce/emit-expr adapted-body idx (set (map #(symbol (name %)) arr-params))))
+                   (ce/emit-expr adapted-body idx arr-sym-set))
         cast-str (if cast-fn (str "(" (name cast-fn) ")(" body-str ")") body-str)
+        scalar-body-str (str "out[idx] = " cast-str ";")
+        ;; Affine-index vectorization (shared c_emit): a SegMap store is `out[idx] = f(..)`,
+        ;; expressed here as the synthetic aset the vectorizer analyzes. The store target
+        ;; is the literal `out` param (not c-symbol-mangled), so pass :store-name. nil ⇒
+        ;; scalar loop.
+        loop-region (binding [ce/*emit-config* ce/opencl-config
+                              ce/*scalar-type* out-ctype
+                              ce/*idx-sym* idx
+                              ce/*int-vars* (into ce/*int-vars* int-scalar-syms)]
+                      (ce/emit-vectorized-elementwise-loop
+                       (list 'aset 'out idx (if cast-fn (list cast-fn adapted-body) adapted-body))
+                       idx (conj arr-sym-set 'out) "idx" scalar-body-str
+                       {:n-bound "_n_bound" :store-name "out"}))
         ;; pragmas cover the output dtype AND every input array's dtype
         source (str (apply codegen/extension-pragmas out-dtype (map arr-dtype arr-params))
                     "__kernel void " kernel-name
                     "(" all-params ") {\n"
-                    "    for (int idx = get_global_id(0); idx < _n_bound; idx += get_global_size(0)) {\n"
-                    "        out[idx] = " cast-str ";\n"
-                    "    }\n"
-                    "}\n")]
+                    "    "
+                    (or loop-region
+                        (str "for (int idx = get_global_id(0); idx < _n_bound; idx += get_global_size(0)) {\n"
+                             "        " scalar-body-str "\n"
+                             "    }"))
+                    "\n}\n")]
     {:kernel-name kernel-name
      :source source
      :array-params arr-params


### PR DESCRIPTION
Vectorizes contiguous / row-broadcast / row-relative elementwise kernel bodies with `vloadN`/`vstoreN`, landed in the **shared** `c_emit.clj` so OpenCL and the future HIP/CUDA backends inherit it — not the Level-Zero path. Bit-exact; suite 0F/0E.

## What it does
Classifies each array subscript in an elementwise kernel body: `a[idx]` → contiguous `vloadV`; `a[idx/C]` → broadcast (scalar, broadcast into vector arithmetic); `a[idx%C]` → row-relative contiguous `vloadV`; free-of-idx → scalar; anything else (gather, non-affine, control flow, fused multi-store) → **bail to the scalar loop**. Helpers are inlined so the vector type flows through (bit-identical to the scalar path's inlining), rather than needing precision-matched `_v4` overloads.

## Correctness is by *provability*, not by guess
The vectorized fast-path is emitted behind a runtime guard `(_n_bound % V == 0) && (C % V == 0)` for every divisor `C`. Since each work item gets a V-aligned block base, `C % V == 0` guarantees a V-block never crosses a `/C` or `%C` row boundary — so `idx/C` is constant across the block and `idx%C` is contiguous. If the guard fails, the scalar loop runs. **The transform is always correct; it only captures the win when dims cooperate** (gemma d=640, hd=256). V ∈ {4,2} with scalar tail; float4 preferred (the measured lesson: outstanding-bytes-per-lane, not occupancy).

Verified: vector output **bit-identical to scalar** (relerr 0.0) across v4/v2/scalar and gemma dims; matches CPU at f32 epsilon; a double helper vectorizes bit-exact (8.9e-16); a `^double` helper in a float kernel correctly falls back. All GPU canaries green on both ze and the ocl runtime.

## Measured (device-event, Arc 140V) — smaller than the roofline predicted, honestly
`rms-norm-chunked` stage-3 apply: 4096 rows 0.449→0.396 ms (70→79 GB/s, 1.13×); 8192 rows 1.19→0.72 ms (53→88 GB/s, **1.66×**, right at the streaming ceiling). The roofline predicted ~1.4× / ~12 ms/layer from a **35.9 GB/s** baseline; on this hardware the scalar baseline of the *apply* kernel is already ~70 GB/s (Intel's IGC auto-vectorizes contiguous float access), so the headroom on that kernel is smaller. The float4 lever is genuine (reaches the ceiling); it was competing against a baseline nearer the ceiling than the roofline implied. See the PR discussion for the follow-up (the 49%/35.9 GB/s family bottleneck is likely dominated by the reduction *stages 1-2*, which are non-affine and did not vectorize — a separate lever).

## Strategic value (the reason it's in c_emit)
This is the shared-emitter infrastructure for the AMD/NVIDIA path. Only two pieces remain backend-specific for HIP/CUDA: the `vloadN`/`vstoreN` spelling (OpenCL builtins vs `reinterpret_cast<float4*>`/`make_floatN`), which should move to `emit-config`, and the `:vectorize?` flag. Classification, the legality guard, cast handling, and helper inlining are all dialect-agnostic and already shared.