### PR TITLE
Coalesce chunked rms-norm stage-1 reductions (shared-emitter, no subgroup spelling)

### DIFF
--- a/src/raster/dl/nn.clj
+++ b/src/raster/dl/nn.clj
@@ -558,23 +558,29 @@
   (All [T] [x :- (Array T) weight :- (Array T)
             rows :- Long features :- Long chunks :- Long
             eps :- Double gain-offset :- Double] :- (Array T)
-       (let [csz (clojure.core/quot (clojure.core/+ features (clojure.core/- chunks 1)) chunks)
-             ps  (alloc-like x (* rows chunks))
+       (let [ps  (alloc-like x (* rows chunks))
              inv (alloc-like x rows)
              out (alloc-like x (* rows features))]
-         ;; stage 1 — chunk-parallel partial sums of squares
+         ;; stage 1 — chunk-parallel partial sums of squares.
+         ;; COALESCED SCHEDULE: chunk c owns the STRIDED feature set {c, c+chunks,
+         ;; c+2·chunks, …} rather than a contiguous [c·csz, (c+1)·csz) span. The
+         ;; contiguous span makes adjacent work items (c, c+1) start `csz` apart, so
+         ;; a subgroup's loads at any iteration are strided by csz — uncoalesced
+         ;; (measured ~22 GB/s of a ~70 GB/s ceiling). Striding the feature axis by
+         ;; `chunks` makes lane c and lane c+1 read x[rbase+c] and x[rbase+c+1] at the
+         ;; same step — contiguous across the subgroup ⇒ coalesced. Same Σx², merely
+         ;; reassociated across chunks (already non-bit-identical to rms-norm; f32
+         ;; agrees to ~1e-6 relative). The strided loop also handles a non-divisible
+         ;; `features` with no start/end/len bookkeeping. Every C backend inherits
+         ;; this — it is the deftm's own schedule, lowered by the shared c_emit.
          (raster.par/map-void! t (clojure.core/* rows chunks)
                                (let [r (quot t chunks)
                                      c (rem t chunks)
-                                     start (clojure.core/* c csz)
-                                     e0 (clojure.core/+ start csz)
-                                     end (if (< e0 features) e0 features)
-                                     len (clojure.core/- end start)
-                                     offset (clojure.core/+ (clojure.core/* r features) start)
-                                     s (loop [i 0 s 0.0]
-                                         (if (< i len)
-                                           (let [v (aget x (clojure.core/+ offset i))]
-                                             (recur (inc i) (+ s (* v v))))
+                                     rbase (clojure.core/* r features)
+                                     s (loop [i c s 0.0]
+                                         (if (< i features)
+                                           (let [v (aget x (clojure.core/+ rbase i))]
+                                             (recur (clojure.core/+ i chunks) (+ s (* v v))))
                                            s))]
                                  (aset ps t s)))
          ;; stage 2 — per-row combine (identical arithmetic to rms-norm!'s tail)
@@ -1693,30 +1699,30 @@
   (All [T] [dy :- (Array T) x :- (Array T) weight :- (Array T)
             rows :- Long features :- Long chunks :- Long
             eps :- Double gain-offset :- Double] :- (Array T)
-       (let [csz (clojure.core/quot (clojure.core/+ features (clojure.core/- chunks 1)) chunks)
-             pss (alloc-like x (* rows chunks))    ;; Σ x²        per (row, chunk)
+       (let [pss (alloc-like x (* rows chunks))    ;; Σ x²        per (row, chunk)
              pc  (alloc-like x (* rows chunks))    ;; Σ (g0+w)x·dy per (row, chunk)
              k1  (alloc-like x rows)               ;; inv-rms      per row
              k2  (alloc-like x rows)               ;; inv³·c/F     per row
              dx  (alloc-like dy (* rows features))]
+         ;; COALESCED SCHEDULE (see rms-norm-chunked stage 1): chunk c owns the
+         ;; STRIDED feature set {c, c+chunks, …} so adjacent work items read adjacent
+         ;; memory — a subgroup's loads are contiguous, not `csz` apart. Both partial
+         ;; reductions (Σ x² and Σ (g0+w)·x·dy) share the same stride. Same totals,
+         ;; reassociated across chunks (same caveat as the forward).
          (raster.par/map-void! t (clojure.core/* rows chunks)
                                (let [r (quot t chunks)
                                      c (rem t chunks)
-                                     start (clojure.core/* c csz)
-                                     e0 (clojure.core/+ start csz)
-                                     end (if (< e0 features) e0 features)
-                                     len (clojure.core/- end start)
-                                     offset (clojure.core/+ (clojure.core/* r features) start)
-                                     sq (loop [i 0 s 0.0]
-                                          (if (< i len)
-                                            (let [v (aget x (clojure.core/+ offset i))]
-                                              (recur (inc i) (+ s (* v v))))
+                                     rbase (clojure.core/* r features)
+                                     sq (loop [i c s 0.0]
+                                          (if (< i features)
+                                            (let [v (aget x (clojure.core/+ rbase i))]
+                                              (recur (clojure.core/+ i chunks) (+ s (* v v))))
                                             s))
-                                     sc (loop [i 0 s 0.0]
-                                          (if (< i len)
-                                            (let [j (clojure.core/+ offset i)
-                                                  gi (+ gain-offset (aget weight (clojure.core/+ start i)))]
-                                              (recur (inc i) (+ s (* gi (* (aget x j) (aget dy j))))))
+                                     sc (loop [i c s 0.0]
+                                          (if (< i features)
+                                            (let [j (clojure.core/+ rbase i)
+                                                  gi (+ gain-offset (aget weight i))]
+                                              (recur (clojure.core/+ i chunks) (+ s (* gi (* (aget x j) (aget dy j))))))
                                             s))]
                                  (aset pss t sq)
                                  (aset pc t sc)))


### PR DESCRIPTION
Stacks on #67. Fixes the genuinely-uncoalesced reduction access in chunked rms-norm (fwd stage-1 + backward-dx). Bit-exact-to-tolerance; suite 0F/0E.

## Diagnosis (read the emitted OpenCL C, didn't assume)
rms-norm-chunked stage-1 gave each work item `idx = r*chunks + c` a **contiguous** feature span `[c*csz, (c+1)*csz)`, so adjacent lanes started `csz`(~20) apart → a subgroup's loads strided by `csz`, one cacheline per lane → **16 GB/s** of a ~70+ GB/s coalesced ceiling.

## Fix
The deftm now gives chunk `c` the **strided** feature set `{c, c+chunks, …}`, so lanes `c, c+1` read `x[base+c], x[base+c+1]` — contiguous across the subgroup. Same Σx², reassociated across chunks (rms-norm-chunked is already documented non-bit-identical; f32 ~1e-6). It's the **deftm's own schedule**, lowered by the **shared c_emit**, so OpenCL/HIP/CUDA inherit it, and it **needs no subgroup primitive** — no probing, no per-backend spelling (a plus for the HIP plan).

## Measured (ze:0, medians of 11, interleaved A/B)
| kernel | old | new | speedup |
|---|---|---|---|
| bwd-dx stage-1, B=16 rows=1024 | 0.320 ms / 16.4 GB/s | 0.180 ms / 29 GB/s | 1.78× |
| bwd-dx stage-1, rows=16384 (BW-bound) | 2.119 ms / 39.6 | 0.847 ms / **99 GB/s** | **2.5×** |
| fwd stage-1, B=16 | 0.118 / 22.3 | 0.066 / 39.7 | 1.8× |

**Honest scope:** for gemma-270m at B=16 the rms-norm reduces are small (~0.6–1 ms/layer impact) — the win is modest here but 2.5× when the reduction is actually bandwidth-bound (wide models / long-context / large batch). The layer's *dominant* 1.05M-element reduces are the SDPA-backward `dQ/dK/dV`, which the emitted C shows are **already coalesced** (d innermost); their low useful BW is redundant Q/K/V re-reads across the triangular loop — a **flash-attention tiling** problem, not coalescing, deliberately out of scope here.

## Correctness
`norm_ad_test` 44 assertions (chunked fwd+bwd vs row-serial + FD); `backward_kernel_resident` rms-norm grad rel-err ~1e-7; `gemma_train_resident` **GPU loss trajectory bit-identical to CPU**. Full suite 0F/0E. Generalizes to any chunked reduction.