### PR TITLE
Honest GPU test gates + salvaged cold-cadence benchmark harness

### DIFF
--- a/bench/resident_gemm_cold_bench.clj
+++ b/bench/resident_gemm_cold_bench.clj
@@ -1,0 +1,224 @@
+(ns resident-gemm-cold-bench
+  "Cadence-controlled COLD benchmark for the resident XMX GEMM (Level-Zero / Intel Xe).
+
+   This is the durable measurement METHODOLOGY salvaged from the GEMM-tiling episode —
+   the harness that caught two 'wins' as pure measurement artifacts. It is the intended
+   STANDARD for any future resident-GEMM perf claim. It deliberately carries NO tiling
+   schedule knobs (see 'Dropped dead levers' below): it measures a kernel config honestly;
+   it does not advocate one.
+
+   ── The two confounds this harness controls ──────────────────────────────────────
+   1. CADENCE / CLOCK CONFOUND. A GPU boost-clocks under sustained load and throttles
+      when idle. A harness that records ONE launch, resets, reads its timestamp, then
+      records the NEXT launch gives each kernel a different clock/thermal history — a
+      faster-looking config may simply have been sampled while the clock was higher.
+      FIX: one recorded graph = `launches` (default 24) back-to-back GEMM launches
+      (barriers serialize them). The GPU stays boosted across the whole sequence, so
+      every launch runs under the SAME drifting clock — only cache temperature differs.
+      And when comparing configs, all configs are replayed ROUND-ROBIN each round, so
+      each is sampled ~ms apart under the same clock/thermal state (kills the
+      sequential-config confound where config A is timed cold and config B timed warm).
+
+   2. WARM-OPERAND CONFOUND. Reusing ONE resident A/B pair across replays leaves the
+      operands L3-resident, so the benchmark measures an all-cache-hit steady state that
+      never occurs in training (where each step's activations are first-touch DRAM
+      reads). A schedule that only hides COLD DRAM-load latency then looks worthless warm
+      and a genuinely-cold win looks like noise.
+      FIX: COLD = each of the `launches` launches reads a DISTINCT buffer pair
+      (total footprint >> L3 -> every read is a first-touch DRAM read = a realistic
+      per-step activation). WARM = one shared pair (L3-resident) kept only as a control
+      to expose the gap. Report the COLD number for any training-relevant claim.
+
+   Reproducibility on the reference machine (Arc 140V, Xe2/Lunar Lake): ±2%.
+
+   ── Dropped dead levers ───────────────────────────────────────────────────────────
+   The originating episode swept {grf128,grf256}×{prefetch-b?,k-double-buffer?}. Under
+   this cold harness NONE of them beat the plain baseline on the shapes they were
+   proposed to gate — they were warm-harness artifacts. Per the repo's no-dead-flags
+   policy they are NOT resurrected here: prefetch-b?/k-double-buffer? do not exist in the
+   emitter on main, and this harness's default kernel is the plain baseline.
+
+   The one surviving knob is `:large-grf?` (the -ze-opt-large-register-file BUILD flag),
+   kept ONLY as an opt-in EXPERIMENTAL comparand so a NEW schedule idea can be A/B'd
+   through the same rigorous method. It is OFF by default and auto-gated NOWHERE.
+
+   ── Use ──────────────────────────────────────────────────────────────────────────
+     (require 'resident-gemm-cold-bench :reload)
+     (resident-gemm-cold-bench/cold-bench {:name \"proj\" :m 1024 :k 640 :n 2048})
+     ;; A/B an experimental comparand against the baseline (both under the cold method):
+     (resident-gemm-cold-bench/compare-configs
+       {:name \"proj\" :m 1024 :k 640 :n 2048}
+       [{:label \"baseline\"}
+        {:label \"large-grf\" :large-grf? true}])"
+  (:require [raster.gpu.ze-runtime :as ze]
+            [raster.compiler.backend.gpu.opencl-codegen :as cg]
+            [raster.compiler.support.spirv-cache :as spv]
+            [raster.runtime.hardware :as hw]))
+
+(def ^:private device-hex
+  (delay (get-in (hw/device :ze:0) [:capabilities :device-id-hex])))
+
+(def ^:private I32 java.lang.foreign.ValueLayout/JAVA_INT)
+
+(defn- fa ^floats [n seed]
+  (let [r (java.util.Random. (long seed)) a (float-array n)]
+    (dotimes [i n] (aset a i (float (* 0.5 (.nextGaussian r))))) a))
+
+(defn- median [xs]
+  (let [v (vec (sort xs)) n (count v)]
+    (if (odd? n) (nth v (quot n 2))
+        (/ (+ (nth v (dec (quot n 2))) (nth v (quot n 2))) 2.0))))
+
+(defn- pctl [xs p]
+  (let [v (vec (sort xs)) n (count v)]
+    (nth v (min (dec n) (int (* p n))))))
+
+(defn- gflops [ms m n k] (/ (* 2.0 m k n) (* ms 1.0e6)))
+
+;; ── kernel build/cache ───────────────────────────────────────────────────────────
+;; A config is a map. The only recognized key is the EXPERIMENTAL, opt-in, default-off
+;; :large-grf? (the -ze-opt-large-register-file build flag). Everything else is the
+;; plain baseline resident GEMM (:c-dtype :half — matches bind-registered-gemm!'s
+;; default; f16 C write is half the DRAM traffic of f32, reproducing the resident path).
+(def ^:private kern-cache (atom {}))
+(defn build-kernel!
+  "Compile+cache the resident gemm_nonsquare_float kernel for `config`.
+   Returns {:module :kname}. config keys:
+     :large-grf?  EXPERIMENTAL build-flag comparand (default false, gated nowhere)."
+  [{:keys [large-grf?] :as _config}]
+  (let [ck [large-grf?]]
+    (or (get @kern-cache ck)
+        (let [kname (str "gemm_cold_" (if large-grf? "grf256" "grf128"))
+              src   (cg/emit-gemm-nonsquare-kernel kname :c-dtype :half)
+              spirv (spv/compile-opencl-to-spirv src :device @device-hex)
+              build-flags (when large-grf? "-ze-opt-large-register-file")
+              module (ze/load-module! spirv :spirv build-flags)
+              entry {:module module :kname kname}]
+          (swap! kern-cache assoc ck entry)
+          entry))))
+
+;; ── resident buffer plumbing ───────────────────────────────────────────────────────
+(defn- bind-gemm! [module kname a16 b16 c m n k]
+  (let [kh (ze/create-kernel-fresh module kname)
+        m (long m) n (long n) k (long k)
+        args [(:segment a16) (:segment b16) (:segment c)
+              {:type :int :value (int m)} {:type :int :value (int n)} {:type :int :value (int k)}]
+        bnd (ze/bind-kernel-2d! kh [256 1] args)
+        gc ^java.lang.foreign.MemorySegment (:gc-seg bnd)]
+    (.set gc I32 0 (int (Math/ceil (/ (double n) 128.0))))
+    (.set gc I32 4 (int (Math/ceil (/ (double m) 128.0))))
+    (.set gc I32 8 (int 1))
+    bnd))
+
+;; Cached random host arrays (values are irrelevant to timing; DISTINCT DEVICE buffers
+;; are what makes cold reads cold). Avoids regenerating millions of gaussians per pair.
+(def ^:private src-cache (atom {}))
+(defn- src ^floats [n] (or (get @src-cache n)
+                           (let [a (fa n (+ 9 n))] (swap! src-cache assoc n a) a)))
+
+(defn- alloc-pair [m n k]
+  (let [a16 (ze/buffer-of-floats-as-half (src (* m k)))
+        b16 (ze/buffer-of-floats-as-half (src (* k n)))
+        c   (ze/make-buffer (* m n) :half)]
+    {:a a16 :b b16 :c c}))
+
+(defn- free-pair [{:keys [a b c]}] (doseq [x [a b c]] (ze/free-buffer! x)))
+
+(defn- record-seq-graph
+  "Record ONE graph of `launches` back-to-back GEMM launches (barriers serialize them).
+   `pair-of` maps launch index -> a buffer pair. Identical launch cadence for warm/cold;
+   the GPU stays boosted across the whole sequence, so only cache temperature differs."
+  [module kname m n k launches pair-of]
+  (ze/record-graph!
+   (mapv (fn [i]
+           (let [p (pair-of i)]
+             {:bound (bind-gemm! module kname (:a p) (:b p) (:c p) m n k)
+              :kernel-name kname}))
+         (range launches))
+   {:profile? true}))
+
+;; ── the interleaved cold/warm measurement (THE method) ─────────────────────────────
+(defn compare-configs
+  "Cadence-controlled, interleaved COLD-vs-WARM comparison of `configs` on one GEMM shape.
+
+   For each config, builds a COLD graph (`launches` distinct buffer pairs, every read a
+   first-touch DRAM read) and a WARM control graph (one shared L3-resident pair) over
+   SHARED buffers, then replays ALL graphs ROUND-ROBIN each round so every config is
+   sampled under the same drifting clock/thermal state. Reports COLD and WARM median
+   TFLOPS relative to the first config (the baseline). The COLD column is the honest,
+   training-relevant number; WARM is the confound control.
+
+   shape:   {:name :m :k :n}
+   configs: vector of config maps (see build-kernel!); FIRST is the baseline.
+            default [{:label \"baseline\"}]
+   opts:    :launches (24) :reps (10) :warmup (6)"
+  ([shape] (compare-configs shape [{:label "baseline"}]))
+  ([{:keys [m n k name]} configs & {:keys [launches reps warmup]
+                                    :or {launches 24 reps 10 warmup 6}}]
+   (let [pairs   (mapv (fn [_] (alloc-pair m n k)) (range launches)) ;; shared cold pairs
+         wpair   (alloc-pair m n k)                                  ;; shared warm pair
+         entries (vec (map-indexed
+                       (fn [i c]
+                         (let [{:keys [module kname]} (build-kernel! c)
+                               label (or (:label c) (str "cfg" i))]
+                           {:label label
+                            :cold (record-seq-graph module kname m n k launches (fn [j] (nth pairs j)))
+                            :warm (record-seq-graph module kname m n k launches (constantly wpair))}))
+                       configs))
+         acc (atom (into {} (for [e entries] [(:label e) {:cold [] :warm []}])))]
+     ;; interleaved warmup — every graph, several rounds, for thermal/clock steady state
+     (dotimes [_ warmup]
+       (doseq [e entries]
+         (ze/replay-graph! (:cold e)) (ze/reset-graph-events! (:cold e))
+         (ze/replay-graph! (:warm e)) (ze/reset-graph-events! (:warm e))))
+     ;; interleaved timed rounds
+     (dotimes [_ reps]
+       (doseq [e entries]
+         (ze/replay-graph! (:cold e))
+         (let [ks (:kernels (ze/read-graph-timestamps! (:cold e)))]
+           (swap! acc update-in [(:label e) :cold] into (map :ms ks)))
+         (ze/replay-graph! (:warm e))
+         (let [ks (:kernels (ze/read-graph-timestamps! (:warm e)))]
+           ;; skip launch 0-1 of warm (cold first-touch of the shared pair)
+           (swap! acc update-in [(:label e) :warm] into (map :ms (drop 2 ks))))))
+     (doseq [e entries] (ze/destroy-graph! (:cold e)) (ze/destroy-graph! (:warm e)))
+     (doseq [p pairs] (free-pair p)) (free-pair wpair)
+     ;; report
+     (println (format "\n===== COLD BENCH  SHAPE %s (M%d K%d N%d) reps=%d launches=%d ====="
+                      name m k n reps launches))
+     (println (format "%-16s | %8s %9s %9s | %8s %9s %9s | %8s"
+                      "config" "cold-TF" "cMed-ms" "cP75-ms" "warm-TF" "wMed-ms" "wP25-ms" "vs-base"))
+     (let [rows (for [e entries
+                      :let [cs (get-in @acc [(:label e) :cold])
+                            ws (get-in @acc [(:label e) :warm])
+                            cmed (median cs) wmed (median ws)]]
+                  {:label (:label e)
+                   :cold-tf (/ (gflops cmed m n k) 1000.0) :cold-med cmed :cold-p75 (pctl cs 0.75)
+                   :warm-tf (/ (gflops wmed m n k) 1000.0) :warm-med wmed :warm-p25 (pctl ws 0.25)
+                   :n (count cs)})
+           base-tf (:cold-tf (first rows))]
+       (doseq [r rows]
+         (println (format "%-16s | %8.2f %9.4f %9.4f | %8.2f %9.4f %9.4f | %+7.1f%%"
+                          (:label r) (:cold-tf r) (:cold-med r) (:cold-p75 r)
+                          (:warm-tf r) (:warm-med r) (:warm-p25 r)
+                          (* 100.0 (- (/ (:cold-tf r) base-tf) 1.0)))))
+       (vec rows)))))
+
+(defn cold-bench
+  "Cold benchmark of the BASELINE resident GEMM on one shape. Convenience over
+   compare-configs with a single baseline config. Returns the baseline row map
+   {:label :cold-tf :cold-med :cold-p75 :warm-tf :warm-med :warm-p25 :n}."
+  [shape & {:as opts}]
+  (first (apply compare-configs shape [{:label "baseline"}] (apply concat opts))))
+
+;; Reference shapes from the gemma FFN (the GEMM-tiling episode's targets). Not a claim —
+;; just a convenient standard sweep to exercise the harness.
+(def reference-shapes
+  [{:name "proj      " :m 1024 :k 640  :n 2048}
+   {:name "gate      " :m 1024 :k 640  :n 1024}
+   {:name "down-proj " :m 1024 :k 2048 :n 640}])
+
+(defn run-reference
+  "Run the baseline cold bench across reference-shapes."
+  []
+  (mapv cold-bench reference-shapes))

--- a/test/raster/compiler/gpu_integration_test.clj
+++ b/test/raster/compiler/gpu_integration_test.clj
@@ -10,26 +10,20 @@
     3. Both :local (n=64) and :global/per-phase (n=4096) strategies
   Note: GPU kernels currently compute in float32 even for double inputs.
   Tolerance must account for float32 accumulated error (~1e-5 for typical workloads)."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]))
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [raster.dl.gpu-grad-parity :as gp]))
 
 ;; ================================================================
 ;; GPU availability check
 ;; ================================================================
 
-(def ^:private gpu-available?
-  "True when a Level Zero GPU device is present and initialized."
-  (delay
-    (try
-      (require 'raster.gpu.ze-runtime)
-      (let [init! (resolve 'raster.gpu.ze-runtime/init!)]
-        (init!)
-        true)
-      (catch Throwable _ false))))
-
-(defmacro ^:private when-gpu [& body]
-  `(if @gpu-available?
+;; Availability + skip routing delegate to the shared HONEST probe
+;; (raster.dl.gpu-grad-parity): a broken ze-runtime load fails loud instead of being
+;; swallowed as "no GPU", and skips register a marker so the assertion count is stable.
+(defmacro ^:private when-gpu [label & body]
+  `(if @gp/gpu-available?
      (do ~@body)
-     (println "  [SKIP] No GPU available")))
+     (gp/gpu-skip! ~label)))
 
 ;; ================================================================
 ;; Analytical reference for heat equation
@@ -101,7 +95,7 @@
 
 (deftest gpu-local-strategy-test
   (testing "GPU compound kernel (:local, n=64) matches CPU and analytical"
-    (when-gpu
+    (when-gpu "gpu-local-strategy"
      (require '[raster.compiler.pipeline :as pipeline])
      (require 'raster.ode.pde)
      (let [compile-aot (resolve 'raster.compiler.pipeline/compile-aot)
@@ -131,7 +125,7 @@
 
 (deftest gpu-global-strategy-test
   (testing "GPU per-phase kernels (n=4096) match CPU and analytical"
-    (when-gpu
+    (when-gpu "gpu-global-strategy"
      (require '[raster.compiler.pipeline :as pipeline])
      (require 'raster.ode.pde)
      (let [compile-aot (resolve 'raster.compiler.pipeline/compile-aot)

--- a/test/raster/dl/backward_kernel_resident_test.clj
+++ b/test/raster/dl/backward_kernel_resident_test.clj
@@ -179,7 +179,7 @@
 
 (deftest rms-norm-value+grad-resident-parity
   (if-not @gp/gpu-available?
-    (println "  [SKIP] rms-norm resident parity: no Level Zero GPU")
+    (gp/gpu-skip! "rms-norm resident parity")
     (let [rows 4 feat 16 go 1.0 eps 1e-6
           x (fa (* rows feat) 1) w (fa feat 2) tgt (fa (* rows feat) 3)
           {:keys [grads]}
@@ -210,7 +210,7 @@
 
 (deftest rms-norm-chunked-value+grad-resident-parity
   (if-not @gp/gpu-available?
-    (println "  [SKIP] rms-norm-chunked resident parity: no Level Zero GPU")
+    (gp/gpu-skip! "rms-norm-chunked resident parity")
     (let [rows 8 feat 32 chunks 4 go 1.0 eps 1e-6
           x (fa (* rows feat) 1) w (fa feat 2) tgt (fa (* rows feat) 3)
           {:keys [grads]}
@@ -239,7 +239,7 @@
 
 (deftest gqa-causal-mha-value+grad-resident-parity
   (if-not @gp/gpu-available?
-    (println "  [SKIP] gqa-causal-mha resident parity: no Level Zero GPU")
+    (gp/gpu-skip! "gqa-causal-mha resident parity")
     (let [sl 4 nq 4 nkv 2 hd 8
           Q (fa (* sl nq hd) 21) K (fa (* sl nkv hd) 22) V (fa (* sl nkv hd) 23)
           tgt (fa (* sl nq hd) 24)
@@ -284,7 +284,7 @@
 
 (deftest attn-block-value+grad-resident-parity
   (if-not @gp/gpu-available?
-    (println "  [SKIP] attn-block resident parity: no Level Zero GPU")
+    (gp/gpu-skip! "attn-block resident parity")
     (let [seq 6 dmodel 32 nq 4 nkv 1 hd 8 eps 1e-6 go 1.0 theta 10000.0
           x  (fa (* seq dmodel) 31) wn (fa dmodel 32)
           Wq (fa (* dmodel (* nq hd)) 33) Wk (fa (* dmodel (* nkv hd)) 34)
@@ -331,7 +331,7 @@
 ;; carries :gemm-precision on the descriptor, bind-program! binds scalar GEMMs for it.
 (deftest attn-block-f32-scalar-gemm-precision-parity
   (if-not @gp/gpu-available?
-    (println "  [SKIP] attn-block :f32-scalar gemm-precision parity: no Level Zero GPU")
+    (gp/gpu-skip! "attn-block :f32-scalar gemm-precision parity")
     (let [seq 6 dmodel 32 nq 4 nkv 1 hd 8 eps 1e-6 go 1.0 theta 10000.0
           x  (fa (* seq dmodel) 31) wn (fa dmodel 32)
           Wq (fa (* dmodel (* nq hd)) 33) Wk (fa (* dmodel (* nkv hd)) 34)
@@ -403,7 +403,7 @@
 
 (deftest resblk-value+grad-resident-parity
   (if-not @gp/gpu-available?
-    (println "  [SKIP] resblk (residual fan-out) resident parity: no Level Zero GPU")
+    (gp/gpu-skip! "resblk (residual fan-out) resident parity")
     (let [rows 4 d 16 eps 1e-6 go 1.0
           x  (fa (* rows d) 51) wn (fa d 52) W1 (fa (* d d) 53)
           pn (fa d 54) W2 (fa (* d d) 55) tgt (fa (* rows d) 56)
@@ -422,9 +422,11 @@
                           ;; grad(x) is the B2 target: x FANS OUT (residual-add ∘
                           ;; rms-norm) AND x1 = residual-add(x,m) fans out again — the
                           ;; whole reroute-over-aliases + symbolic-op-tag chain. It
-                          ;; extracts resident and matches the CPU reference at ~5e-4.
+                          ;; extracts resident and matches the CPU reference at ~5e-4,
+                          ;; so hold the gate at 1e-3 (≈2× headroom) — the former 3.0e-2
+                          ;; was 60× slack that could hide a real regression.
                           :grad-args '[x]
-                          :rtol 3.0e-2)]
+                          :rtol 1.0e-3)]
       (println "  [resblk] grad(x) steps:" (:step-kinds (get grads 'x))
                "rel-err" (:rel-err (get grads 'x)))
       (is (:resident? (get grads 'x))
@@ -456,7 +458,7 @@
 
 (deftest horizontal-fusion-multi-output-resident-parity
   (if-not @gp/gpu-available?
-    (println "  [SKIP] horizontal-fusion multi-output resident parity: no Level Zero GPU")
+    (gp/gpu-skip! "horizontal-fusion multi-output resident parity")
     (let [n 32
           a (fa n 61) b (fa n 62) tgt (fa n 63)
           {:keys [grads]}
@@ -477,7 +479,7 @@
 
 (deftest rope-value+grad-resident-parity
   (if-not @gp/gpu-available?
-    (println "  [SKIP] rope resident parity: no Level Zero GPU")
+    (gp/gpu-skip! "rope resident parity")
     (let [sl 6 heads 4 hd 8 theta 10000.0
           x (fa (* sl heads hd) 11) tgt (fa (* sl heads hd) 12)
           {:keys [grads]}

--- a/test/raster/dl/decoder_layer_gpu_test.clj
+++ b/test/raster/dl/decoder_layer_gpu_test.clj
@@ -7,11 +7,11 @@
    substrate for full gemma (the per-token loop + real weights are #32/#36)."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.quant.kernels-k :as qk] [raster.compiler.backend.cpu.quant :as q]
-            [raster.dl.nn :as nn] [raster.dl.attention :as attn] [raster.gpu.core :as gpu]))
+            [raster.dl.nn :as nn] [raster.dl.attention :as attn] [raster.gpu.core :as gpu]
+            [raster.dl.gpu-grad-parity :as gp]))
 
-(defn- gpu-available? []
-  (try (require 'raster.gpu.ze-runtime)
-       (boolean (seq ((resolve 'raster.gpu.ze-runtime/query-devices)))) (catch Throwable _ false)))
+;; Availability via the shared HONEST probe: a broken ze-runtime load fails loud
+;; (gp/gpu-skip!), not a silent "no device" skip that would drop the whole body.
 (defn- gen [n seed] (let [a (float-array n) r (java.util.Random. seed)] (dotimes [i n] (aset a i (float (* 0.3 (- (.nextDouble r) 0.5))))) a))
 (defn- b->i [^bytes b] (let [w (quot (alength b) 4) o (int-array w) bb (.order (java.nio.ByteBuffer/wrap b) java.nio.ByteOrder/LITTLE_ENDIAN)] (dotimes [i w] (aset o i (.getInt bb (* i 4)))) o))
 (defn- relerr [a b] (/ (reduce max 0.0 (map #(Math/abs (double (- %1 %2))) (seq a) (seq b))) (reduce max 1e-9 (map #(Math/abs (double %)) b))))
@@ -23,7 +23,8 @@
 (defn- add-cpu [a b n] (let [o (float-array n)] (dotimes [i n] (aset o i (float (+ (aget a i) (aget b i))))) o))
 
 (deftest full-decoder-layer-gpu
-  (when (gpu-available?)
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "full-decoder-layer-gpu")
     (testing "one full Q4_K decoder layer as a resident command graph matches CPU"
       (let [H 256 IM 512 nq 2 nkv 1 hd 128 grp 2 eps 1.0e-6 theta 1.0e4 scale (/ 1.0 (Math/sqrt (double hd))) kvrow (* nkv hd) p 2 clen (inc p)
             x (gen H 1) win (gen H 2) wqn (gen hd 3) wkn (gen hd 4) wpa (gen H 5) wpf (gen H 6) wpff (gen H 7)

--- a/test/raster/dl/gemma_train_resident_test.clj
+++ b/test/raster/dl/gemma_train_resident_test.clj
@@ -231,7 +231,7 @@
 
 (deftest gemma-lora-block-resident-train-step
   (if-not @gp/gpu-available?
-    (println "  [SKIP] gemma LoRA block resident train-step: no Level Zero GPU")
+    (gp/gpu-skip! "gemma LoRA block resident train-step")
     (let [gpu (do (require 'raster.gpu.core) (find-ns 'raster.gpu.core))
           make-session (ns-resolve gpu 'make-session)
           bind-program! (ns-resolve gpu 'bind-program!)
@@ -357,7 +357,7 @@
 
 (deftest gemma-lora-mixed-precision-backward-trajectory
   (if-not @gp/gpu-available?
-    (println "  [SKIP] gemma LoRA mixed-precision backward: no Level Zero GPU")
+    (gp/gpu-skip! "gemma LoRA mixed-precision backward")
     (let [gpu (do (require 'raster.gpu.core) (find-ns 'raster.gpu.core))
           cfg CFG-MP
           lr 0.02
@@ -444,7 +444,7 @@
 
 (deftest gemma-lora-dual-program-shared-session
   (if-not @gp/gpu-available?
-    (println "  [SKIP] gemma dual-program shared session: no Level Zero GPU")
+    (gp/gpu-skip! "gemma dual-program shared session")
     (let [gpu (do (require 'raster.gpu.core) (find-ns 'raster.gpu.core))
           make-session (ns-resolve gpu 'make-session)
           bind-program! (ns-resolve gpu 'bind-program!)

--- a/test/raster/dl/gpu_ad_gemm_test.clj
+++ b/test/raster/dl/gpu_ad_gemm_test.clj
@@ -18,12 +18,12 @@
             [raster.dl.array-ops :as ops]
             [raster.dl.attention :as attn]
             [raster.arrays :as ra]
+            [raster.dl.gpu-grad-parity :as gp]
             [raster.dl.nn :as nn]))
 
-(def ^:private gpu-available?
-  (delay (try (require 'raster.gpu.ze-runtime)
-              (boolean (seq ((resolve 'raster.gpu.ze-runtime/query-devices))))
-              (catch Throwable _ false))))
+;; Availability + skip routing use the shared HONEST probe (raster.dl.gpu-grad-parity):
+;; a broken ze-runtime load fails loud via gp/gpu-skip! instead of a silent "no device"
+;; skip, and skips register a marker so the assertion count stays deterministic.
 
 (defn- rnd [n seed]
   (let [a (float-array n) r (java.util.Random. seed)]
@@ -50,8 +50,8 @@
       (finally (close-session! s)))))
 
 (deftest gpu-ad-gemm-variants
-  (if-not @gpu-available?
-    (println "  [SKIP] gpu-ad-gemm: no Level Zero GPU")
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "gpu-ad-gemm")
     ;; XMX-friendly dims (multiples of 16); batch=16, in-f=32, out-f=16.
     (let [b 16 i 32 o 16
           ;; fp16 XMX GEMM: ~2.5e-4 relative error is the precision floor for these dims.
@@ -85,8 +85,8 @@
   ;; used inside the flat gqa-causal-mha are strided permutation/broadcast/segment-reduce
   ;; copies re-expressed over par/map-void!, so each lowers to a SINGLE resident :map-void
   ;; kernel on device (no raw loop / host-scalar fallback) and matches the CPU reference.
-  (if-not @gpu-available?
-    (println "  [SKIP] gpu-attention-layout: no Level Zero GPU")
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "gpu-attention-layout")
     (let [tol 1e-5]
       (testing "pack-heads lowers to a resident :map-void kernel and matches CPU"
         (let [sl 6 nh 4 hd 8 x (rnd (* sl nh hd) 21)
@@ -154,8 +154,8 @@
 (deftest fused-causal-sdpa-resident
   ;; batched-causal-sdpa forward lowers to resident :map-void kernels ONLY (scores /
   ;; row-softmax / W·V accumulation — no GEMM, no host scalar-let) and matches CPU.
-  (if-not @gpu-available?
-    (println "  [SKIP] fused-causal-sdpa-resident: no Level Zero GPU")
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "fused-causal-sdpa-resident")
     (let [batch 4 seq-len 6 hd 8 n (* batch seq-len hd)
           Q (rnd n 71) K (rnd n 72) V (rnd n 73)
           cpu (attn/batched-causal-sdpa Q K V batch seq-len hd)
@@ -169,8 +169,8 @@
   ;; broadcast-kv-heads → fused batched-causal-sdpa → unpack-heads) compiles to a
   ;; FULLY resident program — every step a :map-void kernel, no non-resident binding —
   ;; and matches the CPU forward on the Arc.
-  (if-not @gpu-available?
-    (println "  [SKIP] gqa-causal-mha-fully-resident: no Level Zero GPU")
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "gqa-causal-mha-fully-resident")
     (let [seq-len 6 nq 4 nkv 1 hd 8
           Q (rnd (* seq-len nq hd) 81) K (rnd (* seq-len nkv hd) 82) V (rnd (* seq-len nkv hd) 83)
           cpu (attn/gqa-causal-mha Q K V 1 seq-len nq nkv hd)
@@ -188,8 +188,8 @@
   ;; (relerr ~1). bind-program! now routes N<8 :gemm steps to a plain scalar f32 kernel
   ;; (no f16 convert/transpose). n=8 stays on the XMX path (16-byte pitch = the minimum)
   ;; as the boundary control.
-  (if-not @gpu-available?
-    (println "  [SKIP] gpu-gemm-small-n: no Level Zero GPU")
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "gpu-gemm-small-n")
     (let [tol 5e-3]
       (doseq [n [2 4 6 8]]
         (testing (str "forward linear-nb (:nt) at out-features n=" n)
@@ -218,8 +218,8 @@
   ;; and replays with the correct output. (An ESCAPING tail reduce — a loss returned as
   ;; the scalar result — still doesn't bind: that is the remaining #42 leftover, same as
   ;; bind-step!.)
-  (if-not @gpu-available?
-    (println "  [SKIP] gpu-reduce-step: no Level Zero GPU")
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "gpu-reduce-step")
     (let [probe (eval '(raster.core/deftm gpu-reduce-consumer-probe
                          [a :- (Array float) out :- (Array float) n :- Long] :- Void
                          (let [s (raster.par/reduce
@@ -278,8 +278,8 @@
           (str "an accumulating GEMM must be rejected by NAME "
                "(:unsupported-gemm-alpha-beta), got: " (.getMessage t)))
       ;; Fix (a): it compiled — then it MUST be numerically correct on device.
-      (if-not @gpu-available?
-        (println "  [SKIP] gemm-accumulate: compiled resident but no GPU to verify")
+      (if-not @gp/gpu-available?
+        (gp/gpu-skip! "gemm-accumulate device verify (compiled resident)")
         (let [m 16 k 32 n 16
               A (rnd (* m k) 11) B (rnd (* k n) 12) C0 (rnd (* m n) 13)
               cpu (let [c (float-array (seq C0))] (probe A B c m k n) c)

--- a/test/raster/dl/gpu_grad_parity.clj
+++ b/test/raster/dl/gpu_grad_parity.clj
@@ -43,11 +43,96 @@
                                              (raster.arrays/aset out i (raster.arrays/aget src i)))
                        out))
 
-;; ── GPU session plumbing (mirrors gpu-ad-gemm-test/run-resident) ────────────────
+;; ── GPU availability probe (HONEST: distinguishes "no device" from "broken load") ──
+;; The old form was `(try … (catch Throwable _ false))`, which swallowed a BROKEN
+;; ze-runtime load (a compile error in the ns, a missing native symbol, an FFM bind
+;; failure) as if it meant "no GPU here". Every GPU-gated deftest then took its skip
+;; branch and the ENTIRE GPU suite went green with zero assertions — a suite that
+;; reported success while testing nothing. `gpu-status` separates the cases so a
+;; runtime breakage surfaces LOUDLY instead of masquerading as an absent device.
+(def gpu-status
+  "Delay yielding one of:
+     {:status :available   :n-devices k}  Level-Zero device(s) present.
+     {:status :no-device}                 runtime loaded cleanly, zero devices — a
+                                          LEGITIMATE, visible skip.
+     {:status :probe-error :error e}      query-devices threw (e.g. no L0 loader on a
+                                          GPU-less box) — a loud WARNING + skip, not a
+                                          hard failure (won't redden CI with no GPU).
+     {:status :load-failed :error e}      `require 'raster.gpu.ze-runtime` THREW — the
+                                          runtime failed to LOAD. This is a breakage,
+                                          NOT 'no device', and must fail loud."
+  (delay
+    (let [loaded (try (require 'raster.gpu.ze-runtime) {:ok true}
+                      (catch Throwable e {:ok false :error e}))]
+      (if-not (:ok loaded)
+        {:status :load-failed :error (:error loaded)}
+        (try
+          (let [devs ((resolve 'raster.gpu.ze-runtime/query-devices))]
+            (if (seq devs)
+              {:status :available :n-devices (count devs)}
+              {:status :no-device}))
+          (catch Throwable e {:status :probe-error :error e}))))))
+
+;; Boolean convenience for `(if-not @gp/gpu-available? …)` call sites: TRUE only when a
+;; device is actually usable. :load-failed is FALSE here so the skip branch runs — but
+;; that branch MUST route through `gpu-skip!`, which converts :load-failed into a
+;; failing assertion (below), so the breakage is never silently skipped.
 (def gpu-available?
-  (delay (try (require 'raster.gpu.ze-runtime)
-              (boolean (seq ((resolve 'raster.gpu.ze-runtime/query-devices))))
-              (catch Throwable _ false))))
+  (delay (= :available (:status @gpu-status))))
+
+;; Accumulates skip reasons across the whole JVM run so ONE authoritative summary line
+;; can be printed at shutdown, instead of the count silently wandering ±N run-to-run.
+(defonce ^:private gpu-skip-log (atom {}))
+
+(defonce ^:private gpu-summary-hook
+  (delay
+    (.addShutdownHook
+     (Runtime/getRuntime)
+     (Thread.
+      (fn []
+        (let [{:keys [status n-devices]} @gpu-status
+              skips @gpu-skip-log
+              total (reduce + 0 (vals skips))]
+          (println (format "  [GPU SUITE] probe=%s%s | %d test(s) took the skip path%s"
+                           (name status)
+                           (if n-devices (str " (" n-devices " device)") "")
+                           total
+                           (if (pos? total) (str " " (pr-str skips)) "")))))))
+    true))
+
+(defn gpu-skip!
+  "Call in the SKIP branch of a GPU-gated deftest instead of a bare `println`. It:
+     • registers exactly ONE marker assertion so the suite's assertion count is
+       DETERMINISTIC whether or not a GPU is present (skips no longer drop the body's
+       assertions silently → no more ±N count wander between runs);
+     • emits a visible, attributed skip line and records the reason for the shutdown
+       summary;
+     • on :load-failed registers a FAILING assertion — a broken runtime load must
+       never masquerade as a clean skip."
+  [test-label]
+  @gpu-summary-hook
+  (let [{:keys [status error]} @gpu-status]
+    (swap! gpu-skip-log update status (fnil inc 0))
+    (case status
+      :load-failed
+      (is false (str "[GPU LOAD FAILED] " test-label
+                     " — raster.gpu.ze-runtime failed to load: "
+                     (some-> error .getMessage)
+                     ". This is a RUNTIME BREAKAGE, not 'no GPU device' — the whole "
+                     "GPU suite would otherwise go green having tested nothing."))
+      :probe-error
+      (do (println (str "  [GPU SKIP/WARN] " test-label
+                        " — query-devices threw (" (some-> error .getMessage)
+                        "); treating as no usable device."))
+          (is true "gpu-skip-marker"))
+      :no-device
+      (do (println (str "  [GPU SKIP] " test-label " — no Level-Zero device"))
+          (is true "gpu-skip-marker"))
+      :available
+      (throw (IllegalStateException.
+              (str "gpu-skip! called for " test-label " while a GPU IS available"))))))
+
+;; ── GPU session plumbing (mirrors gpu-ad-gemm-test/run-resident) ────────────────
 
 (defn- run-resident
   "Bind + replay f-var's resident descriptor on ze:0 for `args`; returns the result array.

--- a/test/raster/gpu/device_timing_test.clj
+++ b/test/raster/gpu/device_timing_test.clj
@@ -32,7 +32,7 @@
 
 (deftest device-timing-profile-program
   (if-not @gp/gpu-available?
-    (println "  [SKIP] device-timing: no Level Zero GPU")
+    (gp/gpu-skip! "device-timing")
     (let [gpu (do (require 'raster.gpu.core) (find-ns 'raster.gpu.core))
           make-session   (ns-resolve gpu 'make-session)
           bind-program!  (ns-resolve gpu 'bind-program!)
@@ -88,6 +88,11 @@
             (let [h (bind-program! sess prog args {})
                   out ^floats (get (run-program! sess h args) (:result-sym prog))
                   graph (get-in @sess [:programs :program :graph])]
+              ;; Guard against a VACUOUS pass: if the internal :program key path ever
+              ;; returns nil, (not (contains? nil :events)) is trivially true and the
+              ;; "fast path unchanged" assertions below pass having checked nothing.
+              (is (some? graph)
+                  "unprofiled program graph must be present under [:programs :program :graph]")
               (testing "profiling OFF: same numerical result"
                 (dotimes [i 5]
                   (is (< (Math/abs (- (aget out i) (aget expected i))) 1.0e-5))))

--- a/test/raster/gpu/gate_honesty_test.clj
+++ b/test/raster/gpu/gate_honesty_test.clj
@@ -1,0 +1,53 @@
+(ns raster.gpu.gate-honesty-test
+  "Regression gate for the GPU test-gate HONESTY property (CPU-only — needs no GPU).
+
+   The GPU-gated tests used to probe availability with `(catch Throwable _ false)`, so
+   a BROKEN ze-runtime load looked identical to 'no GPU device': every gated deftest
+   took its skip branch and the whole GPU suite went green with zero assertions — a
+   suite that reported success having tested nothing. `raster.dl.gpu-grad-parity`'s
+   honest probe + `gpu-skip!` fix that. These tests pin the contract by driving
+   `gpu-skip!` under each simulated `gpu-status` and asserting what it reports:
+
+     :load-failed  → a FAILING assertion (a runtime breakage surfaces, never a silent skip)
+     :no-device    → exactly one PASSING marker (visible, deterministic count)
+     :probe-error  → one PASSING marker + a warning (won't redden a GPU-less box)
+
+   This is also the standing proof that 'simulate a broken GPU load' surfaces loudly."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.dl.gpu-grad-parity :as gp]))
+
+(defn- capture-skip
+  "Run (gp/gpu-skip! label) with gpu-status pinned to `status-map`, capturing the
+   clojure.test report event types it emits WITHOUT touching the outer suite counters.
+   Returns a vector of :pass/:fail/:error keywords."
+  [status-map]
+  (let [events (atom [])]
+    (with-redefs [gp/gpu-status (delay status-map)
+                  clojure.test/report (fn [m] (swap! events conj (:type m)))]
+      (gp/gpu-skip! "gate-honesty-probe"))
+    @events))
+
+(deftest load-failure-fails-loud
+  (testing "a THROWN ze-runtime load registers a FAILING assertion, not a silent skip"
+    (let [events (capture-skip {:status :load-failed
+                                :error (Exception. "simulated ze-runtime load failure")})]
+      (is (some #{:fail} events)
+          (str "gpu-skip! on :load-failed must emit a :fail — got " (pr-str events)))
+      (is (not-any? #{:pass} events)
+          "a broken load must NOT register a passing marker (that would hide the breakage)"))))
+
+(deftest no-device-registers-visible-marker
+  (testing "genuinely absent GPU registers exactly one PASSING marker (stable count)"
+    (let [events (capture-skip {:status :no-device})]
+      (is (= [:pass] events)
+          (str "gpu-skip! on :no-device must emit exactly one :pass marker — got "
+               (pr-str events))))))
+
+(deftest probe-error-warns-but-does-not-fail
+  (testing "query-devices throwing (no L0 loader) warns + marks, but does not fail CI"
+    (let [events (capture-skip {:status :probe-error
+                                :error (Exception. "no Level-Zero loader")})]
+      (is (= [:pass] events)
+          (str "gpu-skip! on :probe-error must emit exactly one :pass marker — got "
+               (pr-str events)))
+      (is (not-any? #{:fail} events) ":probe-error must not redden a GPU-less machine"))))

--- a/test/raster/gpu/gemm_splitk_test.clj
+++ b/test/raster/gpu/gemm_splitk_test.clj
@@ -33,7 +33,7 @@
 
 (deftest split-k-matches-plain-xmx-gemm
   (if-not @gp/gpu-available?
-    (println "  [SKIP] gemm split-k: no Level Zero GPU")
+    (gp/gpu-skip! "gemm split-k")
     (let [ze (do (require 'raster.gpu.ze-runtime) (find-ns 'raster.gpu.ze-runtime))
           make-buffer   (ns-resolve ze 'make-buffer)
           upload!       (ns-resolve ze 'array->buffer!)
@@ -82,7 +82,7 @@
   ;; an n that is not a multiple of w (the tail loop) and an n below w (no vector iteration
   ;; at all, and a group count that must not round down to zero).
   (if-not @gp/gpu-available?
-    (println "  [SKIP] vectorized convert: no Level Zero GPU")
+    (gp/gpu-skip! "vectorized convert")
     (let [ze (do (require 'raster.gpu.ze-runtime) (find-ns 'raster.gpu.ze-runtime))
           make-buffer (ns-resolve ze 'make-buffer)
           upload!     (ns-resolve ze 'array->buffer!)


### PR DESCRIPTION
Makes "GPU suite green" actually mean something, and salvages the one durable asset from the GEMM-tiling episode. Full Valhalla suite with the Arc present: **1846 tests / 31542 assertions / 0 failures / 0 errors.**

## The silent self-disable (the important fix)
Every GPU-gated test probed availability with `(catch Throwable _ false)` — so a *broken ze-runtime load* (compile error, missing native symbol, FFM bind failure) was indistinguishable from "no GPU device." All gated deftests then took their skip branch, and the whole GPU suite went **green with zero assertions** — reporting success having tested nothing. A whole class of GPU regressions could ship behind a green suite.

**Fix** (`raster.dl.gpu-grad-parity`): a `gpu-status` probe returning `:available | :no-device | :probe-error | :load-failed`, and a `gpu-skip!` that:
- `:load-failed` (require threw) → registers a **FAILING** assertion — a runtime breakage can never masquerade as a clean skip;
- `:no-device` / `:probe-error` → exactly **one passing marker** + a visible attributed skip line;
- prints one authoritative summary via a shutdown hook: `[GPU SUITE] probe=available (1 device) | N test(s) took the skip path {…}`.

All ze-runtime gated tests routed through the shared probe (gpu_ad_gemm, backward_kernel_resident, gemma_train_resident, device_timing, gemm_splitk, decoder_layer_gpu, gpu_integration), replacing bare `println` skips. **The test count is now deterministic** (skips register markers instead of dropping assertions) — no more ±N wander that made "1843 vs 1836" ambiguous.

A standing CPU-only `gate-honesty-test` drives `gpu-skip!` under each simulated status and asserts the clojure.test output — `load-failure-fails-loud` proves the broken-load path emits a `:fail`.

## Vacuous-gate kills
- `device_timing_test`: `(is (some? graph))` so "profiling-off unchanged" can't pass on a nil internal lookup.
- `backward_kernel_resident` resblk parity: rtol **3.0e-2 → 1.0e-3** (observed 5.05e-4; the old 60× slack could hide a regression). The composed-f16 attention case stays 3.0e-2 — its ~1.7e-2 is genuine f16-GEMM noise, not slack.

## Salvaged cold-cadence harness
`bench/resident_gemm_cold_bench.clj` — the interleaved cold-cadence methodology (24 back-to-back launches in one recorded graph = constant cadence/no clock confound; round-robin config replay; distinct per-launch DRAM operands = cold first-touch), extracted as a clean reusable tool. This is now the **standard for any GEMM perf claim** (it's what caught the prefetch-b/grf256 artifacts). Dropped the dead tiling knobs; the only surviving flag is the real `-ze-opt-large-register-file` as an opt-in experimental comparand. No tiling claims resurrected.

This is the trustworthy measurement + gate substrate the schedule layer (S6) will build its acceptance tests on.