### PR TITLE
S4: artifact-as-value layer — DeviceArray + Compiled + donation (whole-program MVP)

### DIFF
--- a/src/raster/gpu/compiled.clj
+++ b/src/raster/gpu/compiled.clj
@@ -1,0 +1,236 @@
+(ns raster.gpu.compiled
+  "The `Compiled` artifact — a functional, inspectable GPU program value (S4 §2).
+
+   `(r/compile #'train-step args {:target :ze:0 :donate [adapters…] :constants [Wq …]})`
+   returns a `Compiled` that implements `IFn`: calling it replays the resident program and
+   returns device values (`raster.gpu.value/DeviceArray`), not host arrays. It wraps today's
+   `bind-program!`/`replay-program!` with ZERO change to the kernel/graph machinery — the
+   executable still lives in the session; `Compiled` lifts the *invocation contract* to
+   values-in / values-out with donation as a boundary write-back shim.
+
+   The three artifact primitives, honestly scoped to the whole-program MVP:
+     • device value      — outputs are DeviceArrays over resident buffers; no host round-trip.
+     • functional invoke  — `(step inputs)` → `{out-key → DeviceArray}`; mutation of resident
+                            :state is invisible (the old input value is consumed/invalidated).
+     • donation           — a donated in→out pair reuses the resident buffer; the input value
+                            is marked consumed (reads throw), the output value is fresh.
+
+   Roles are DERIVED (§4.2): `:donate` syms → :state (donated), `:constants` syms → :constant
+   (captured once at bind, never per-call), the remainder default to the descriptor's derived
+   read-only→:input / written→:output. Backend-neutral: `:target` selects the runtime; nothing
+   here hardcodes `:ze`."
+  (:refer-clojure :exclude [compile])
+  (:require [raster.gpu.core :as gpu]
+            [raster.gpu.value :as v]
+            [raster.compiler.pipeline :as pl]))
+
+(declare invoke-compiled)
+
+;; ================================================================
+;; The record
+;; ================================================================
+
+(defrecord Compiled
+           [session      ;; the GPU session atom the executable lives in (MVP: not yet lifted out)
+            handle       ;; the bind-program! handle {::gpu/program-key … :descriptor …}
+            in-tree      ;; ordered [{:key :sym :role :donate? :shape :dtype} …] — the arg spec
+            out-tree     ;; ordered [{:key :sym :shape :dtype :from} …] — the result spec (multi-output)
+            donated      ;; {in-key → out-key} — the alias plan (JAX input_output_aliases)
+            schedule     ;; the S6 Schedule map (reserved; nil until S6 fills it)
+            target       ;; device-id + (future) HardwareDescriptor
+            descriptor   ;; the raw compile-gpu-program descriptor — inspectable
+            args]         ;; captured example args (:all-params order): resident bind contents + shape source
+  clojure.lang.IFn
+  (invoke [this inputs] (invoke-compiled this inputs))
+  (invoke [this] (invoke-compiled this {}))
+  (applyTo [this argseq] (apply invoke-compiled this argseq)))
+
+(defn compiled? [x] (instance? Compiled x))
+
+;; ================================================================
+;; Role derivation (§4.2) and tree construction
+;; ================================================================
+
+(defn- derive-roles
+  "Effective {sym → role} for bind-program!: donated → :state, constants → :constant, the rest
+   fall through to the descriptor's derived defaults (read-only→:input, written→:output)."
+  [descriptor donate constants explicit-roles]
+  (let [donate-set   (set donate)
+        constant-set (set constants)]
+    (merge (into {} (map (fn [s] [s :state]) donate-set))
+           (into {} (map (fn [s] [s :constant]) constant-set))
+           explicit-roles)))
+
+(defn- flat-n
+  "Element count of a JVM array (the flat logical shape for the MVP)."
+  [arr]
+  (when arr (java.lang.reflect.Array/getLength arr)))
+
+(defn- build-in-tree
+  [descriptor argmap donate constants effective-roles]
+  (let [donate-set (set donate)]
+    (vec (for [p (:array-params descriptor)
+               :let [arr (get argmap p)]]
+           {:key     (keyword (name p))
+            :sym     p
+            :role    (get effective-roles p (get (:array-roles descriptor) p :input))
+            :donate? (contains? donate-set p)
+            :shape   (when arr [(flat-n arr)])
+            :dtype   (:dtype descriptor)}))))
+
+(defn- build-out-tree
+  "Out-tree = donated in→out nodes + any explicit :outputs + the functional :result-sym + taps.
+   Each projects to a DeviceArray over a resident buffer (§3.4 multi-output)."
+  [descriptor argmap donate outputs result-sym taps dtype]
+  (let [donate-nodes  (for [s donate]
+                        {:key (keyword (str (name s) "'")) :sym s
+                         :shape (when-let [a (get argmap s)] [(flat-n a)]) :dtype dtype
+                         :from :donated})
+        output-nodes  (for [s outputs]
+                        {:key (keyword (name s)) :sym s
+                         :shape (when-let [a (get argmap s)] [(flat-n a)]) :dtype dtype
+                         :from :output})
+        result-node   (when result-sym
+                        [{:key (keyword (name result-sym)) :sym result-sym
+                          :shape nil :dtype dtype :from :result}])
+        tap-nodes     (for [s taps]
+                        {:key (keyword (name s)) :sym s :shape nil :dtype dtype :from :tap})]
+    (vec (concat donate-nodes output-nodes result-node tap-nodes))))
+
+;; ================================================================
+;; Compile (the public verb)
+;; ================================================================
+
+(defn compile
+  "Compile a deftm var into a `Compiled` artifact bound on `target`.
+
+   args  — example args in the descriptor's :all-params order. Supplies BOTH the shapes
+           compile-gpu-program derives AND the initial resident buffer contents at bind.
+   opts  — {:target :ze:0            device-id (default :ze:0)
+            :dtype  :float           element dtype (default :float)
+            :donate  [sym …]         resident :state threaded as values (donation)
+            :constants [sym …]       frozen, captured once at bind, never per-call
+            :inputs  [sym …]         per-call uploads (default: descriptor-derived)
+            :outputs [sym …]         additional written params to project as outputs
+            :taps    [sym …]         internal nodes to additionally expose (§5.1)
+            :roles   {sym → role}    explicit role override (last word)
+            :gemm-precision :f16-xmx|:f32-scalar
+            :on-non-resident :nil|:throw
+            :profile? bool           bind in profiling mode (for r/profile)
+            :schedule <map>}         reserved S6 schedule (threaded into the cache key)"
+  [fn-var args {:keys [target dtype donate constants outputs taps roles
+                       gemm-precision on-non-resident profile? schedule]
+                :or {target :ze:0 dtype :float on-non-resident :nil}}]
+  (let [prog (apply pl/compile-gpu-program fn-var target
+                    (cond-> [:dtype dtype :on-non-resident on-non-resident]
+                      gemm-precision (conj :gemm-precision gemm-precision)))
+        _ (when-not prog
+            (throw (ex-info "compile: compile-gpu-program returned nil — a step fell back to host (non-resident). Pass :on-non-resident :throw to see which."
+                            {:fn fn-var :target target})))
+        argmap    (zipmap (:all-params prog) args)
+        eff-roles (derive-roles prog donate constants roles)
+        result-sym (:result-sym prog)
+        sess    (gpu/make-session target)
+        handle  (gpu/bind-program! sess prog args eff-roles
+                                   (cond-> {} profile? (assoc :profile? true)))
+        in-tree  (build-in-tree prog argmap donate constants eff-roles)
+        out-tree (build-out-tree prog argmap donate outputs result-sym taps dtype)
+        donated  (into {} (map (fn [s] [(keyword (name s)) (keyword (str (name s) "'"))]) donate))]
+    (->Compiled sess handle in-tree out-tree donated schedule target prog args)))
+
+;; ================================================================
+;; Functional invocation (§2.3)
+;; ================================================================
+
+(defn- project-node
+  "Wrap a resident output node's live session buffer as an ::external DeviceArray (the session
+   owns the buffer's lifetime; the value never frees it). Returns nil if the node has no resident
+   buffer (e.g. a Void map-void result)."
+  [session handle {:keys [sym shape dtype]} target]
+  (let [k   (gpu/resident-key session handle sym)
+        buf (gpu/buffer session k)]
+    (when buf
+      (v/wrap-external buf target
+                       (or dtype (:dtype buf))
+                       (or shape [(:n-elements buf)])))))
+
+(defn invoke-compiled
+  "Replay the artifact and return device values. `inputs` : {in-key → DeviceArray|host-array}.
+     1. consume any donated-slot DeviceArrays passed in (donation-invalidation, §1.3);
+     2. assemble the args vector (captured resident contents; :input keys overridden by inputs);
+     3. replay the ONE recorded graph with NO host download (replay-program!);
+     4. project out-tree nodes as ::external DeviceArrays over the resident buffers.
+   Mutation of resident :state is invisible: the caller sees fresh output values and the old
+   donated inputs invalidated — never a mutation."
+  [^Compiled c inputs]
+  (let [{:keys [session handle in-tree out-tree donated descriptor target args]} c
+        key->sym  (into {} (map (juxt :key :sym)) in-tree)
+        ;; 1. donation-invalidation: consume passed DeviceArrays bound to a donated slot.
+        _ (doseq [[k _out] donated]
+            (let [val (get inputs k)]
+              (when (v/device-array? val) (v/consume! val))))
+        ;; 2. assemble args: start from captured, override :input-role keys the caller passed.
+        input-syms (set (map :sym (filter #(= :input (:role %)) in-tree)))
+        argmap (reduce (fn [m [k val]]
+                         (let [s (get key->sym k)]
+                           (if (and s (contains? input-syms s))
+                             (assoc m s (if (v/device-array? val) (v/->host val) val))
+                             m)))
+                       (zipmap (:all-params descriptor) args)
+                       inputs)
+        call-args (mapv argmap (:all-params descriptor))]
+    ;; 3. replay, no download.
+    (gpu/replay-program! session handle call-args)
+    ;; 4. project outputs as resident device values.
+    (into {} (keep (fn [{:keys [key] :as node}]
+                     (when-let [da (project-node session handle node target)]
+                       [key da])))
+          out-tree)))
+
+;; ================================================================
+;; Inspection (§2.1) + lifecycle
+;; ================================================================
+
+(defn explain
+  "Print the artifact's shape: in-tree / out-tree / donation plan / target / schedule and the
+   resident step-kind histogram. Returns the Compiled unchanged."
+  [^Compiled c]
+  (let [{:keys [in-tree out-tree donated target schedule descriptor]} c
+        kinds (frequencies (map :convention (:steps descriptor)))]
+    (println "Compiled artifact")
+    (println "  target   :" target)
+    (println "  in-tree  :" (mapv (fn [n] [(:key n) (:role n) (when (:donate? n) :donate)]) in-tree))
+    (println "  out-tree :" (mapv (fn [n] [(:key n) (:from n)]) out-tree))
+    (println "  donated  :" donated)
+    (println "  schedule :" (or schedule :none))
+    (println "  steps    :" (count (:steps descriptor)) "resident, by kind:" kinds))
+  c)
+
+(defn ir
+  "Return the descriptor's resident steps (the artifact's lowered IR) for inspection."
+  [^Compiled c]
+  (mapv #(select-keys % [:convention :phase :variant :kernel-name]) (:steps (:descriptor c))))
+
+(defn profile
+  "Device-event profile of one replay (delegates to profile-program!). The artifact must have
+   been compiled with {:profile? true}. Returns profile-program!'s map."
+  [^Compiled c]
+  (gpu/profile-program! (:session c) (:handle c) (:args c)))
+
+(defn cache-key
+  "The serializable identity of the artifact minus closures (§2b C5): in/out trees, donation,
+   schedule, target, and the descriptor's step kinds + concrete shapes. Excludes the non-
+   serializable closures (:n-fn/:m-fn/…) and SPIR-V modules."
+  [^Compiled c]
+  {:in-tree  (mapv #(select-keys % [:key :role :donate? :shape :dtype]) (:in-tree c))
+   :out-tree (mapv #(select-keys % [:key :from :shape :dtype]) (:out-tree c))
+   :donated  (:donated c)
+   :schedule (:schedule c)
+   :target   (:target c)
+   :steps    (frequencies (map :convention (:steps (:descriptor c))))})
+
+(defn close!
+  "Release the artifact's session (frees resident buffers + destroys graphs/kernels)."
+  [^Compiled c]
+  (gpu/close-session! (:session c))
+  nil)

--- a/src/raster/gpu/compiled.clj
+++ b/src/raster/gpu/compiled.clj
@@ -20,7 +20,8 @@
    read-only→:input / written→:output. Backend-neutral: `:target` selects the runtime; nothing
    here hardcodes `:ze`."
   (:refer-clojure :exclude [compile])
-  (:require [raster.gpu.core :as gpu]
+  (:require [clojure.set :as set]
+            [raster.gpu.core :as gpu]
             [raster.gpu.value :as v]
             [raster.compiler.pipeline :as pl]))
 
@@ -39,7 +40,11 @@
             schedule     ;; the S6 Schedule map (reserved; nil until S6 fills it)
             target       ;; device-id + (future) HardwareDescriptor
             descriptor   ;; the raw compile-gpu-program descriptor — inspectable
-            args]         ;; captured example args (:all-params order): resident bind contents + shape source
+            args         ;; captured example args (:all-params order): resident bind contents + shape source
+            live-outputs] ;; atom holding the DeviceArrays projected by the LAST invocation. They
+                          ;; alias resident buffers the next replay overwrites, so they are
+                          ;; invalidated (marked dead) at the start of the next invoke and at close!
+                          ;; — otherwise a retained old output would silently observe a mutation.
   clojure.lang.IFn
   (invoke [this inputs] (invoke-compiled this inputs))
   (invoke [this] (invoke-compiled this {}))
@@ -56,7 +61,12 @@
    fall through to the descriptor's derived defaults (read-only→:input, written→:output)."
   [descriptor donate constants explicit-roles]
   (let [donate-set   (set donate)
-        constant-set (set constants)]
+        constant-set (set constants)
+        both         (set/intersection donate-set constant-set)]
+    (when (seq both)
+      (throw (ex-info (str "compile: syms are both :donate and :constants — a param is either "
+                           "donated (mutable :state) or frozen (:constant), not both: " both)
+                      {:conflict both})))
     (merge (into {} (map (fn [s] [s :state]) donate-set))
            (into {} (map (fn [s] [s :constant]) constant-set))
            explicit-roles)))
@@ -123,7 +133,11 @@
                 :or {target :ze:0 dtype :float on-non-resident :nil}}]
   (let [prog (apply pl/compile-gpu-program fn-var target
                     (cond-> [:dtype dtype :on-non-resident on-non-resident]
-                      gemm-precision (conj :gemm-precision gemm-precision)))
+                      gemm-precision (conj :gemm-precision gemm-precision)
+                      ;; forward the S6 schedule so it is resolved + gated by compile-gpu-program;
+                      ;; the RESOLVED schedule is read back off the descriptor below (never the raw
+                      ;; input). Harmless where compile-gpu-program predates :schedule (ignored kwarg).
+                      schedule (conj :schedule schedule)))
         _ (when-not prog
             (throw (ex-info "compile: compile-gpu-program returned nil — a step fell back to host (non-resident). Pass :on-non-resident :throw to see which."
                             {:fn fn-var :target target})))
@@ -131,12 +145,17 @@
         eff-roles (derive-roles prog donate constants roles)
         result-sym (:result-sym prog)
         sess    (gpu/make-session target)
-        handle  (gpu/bind-program! sess prog args eff-roles
-                                   (cond-> {} profile? (assoc :profile? true)))
+        handle  (try (gpu/bind-program! sess prog args eff-roles
+                                        (cond-> {} profile? (assoc :profile? true)))
+                     (catch Throwable e
+                       ;; don't leak the session's arena/buffers if bind throws (e.g. a
+                       ;; reuse-collision or a non-resident step).
+                       (try (gpu/close-session! sess) (catch Throwable _))
+                       (throw e)))
         in-tree  (build-in-tree prog argmap donate constants eff-roles)
         out-tree (build-out-tree prog argmap donate outputs result-sym taps dtype)
         donated  (into {} (map (fn [s] [(keyword (name s)) (keyword (str (name s) "'"))]) donate))]
-    (->Compiled sess handle in-tree out-tree donated schedule target prog args)))
+    (->Compiled sess handle in-tree out-tree donated (:schedule prog) target prog args (atom nil))))
 
 ;; ================================================================
 ;; Functional invocation (§2.3)
@@ -144,15 +163,19 @@
 
 (defn- project-node
   "Wrap a resident output node's live session buffer as an ::external DeviceArray (the session
-   owns the buffer's lifetime; the value never frees it). Returns nil if the node has no resident
-   buffer (e.g. a Void map-void result)."
-  [session handle {:keys [sym shape dtype]} target]
+   owns the buffer's lifetime; the value never frees it). Fail-loud: a requested output node with
+   no resident buffer is an error (a dropped result / tap), NOT a silent omission — the ONE
+   documented exception is a :result node whose deftm returns Void/map-void (no result buffer),
+   which yields nil and is filtered by the caller."
+  [session handle {:keys [sym shape dtype from key] :as node} target]
   (let [k   (gpu/resident-key session handle sym)
         buf (gpu/buffer session k)]
-    (when buf
-      (v/wrap-external buf target
-                       (or dtype (:dtype buf))
-                       (or shape [(:n-elements buf)])))))
+    (cond
+      buf (v/wrap-external buf target (or dtype (:dtype buf)) (or shape [(:n-elements buf)]))
+      (= from :result) nil   ;; documented Void/map-void result — no resident buffer to project
+      :else (throw (ex-info (str "invoke: requested output node " key " (" from ") resolved to no "
+                                 "resident buffer (key " k ") — the graph did not produce it")
+                            {:node node :resident-key k :available (keys (:buffers @session))})))))
 
 (defn invoke-compiled
   "Replay the artifact and return device values. `inputs` : {in-key → DeviceArray|host-array}.
@@ -163,14 +186,42 @@
    Mutation of resident :state is invisible: the caller sees fresh output values and the old
    donated inputs invalidated — never a mutation."
   [^Compiled c inputs]
-  (let [{:keys [session handle in-tree out-tree donated descriptor target args]} c
-        key->sym  (into {} (map (juxt :key :sym)) in-tree)
-        ;; 1. donation-invalidation: consume passed DeviceArrays bound to a donated slot.
+  (let [{:keys [session handle in-tree out-tree donated descriptor target args live-outputs]} c
+        key->sym     (into {} (map (juxt :key :sym)) in-tree)
+        in-nodes     (into {} (map (juxt :key identity)) in-tree)
+        input-syms   (set (map :sym (filter #(= :input (:role %)) in-tree)))
+        input-keys   (set (map :key (filter #(= :input (:role %)) in-tree)))
+        donated-keys (set (keys donated))
+        ;; 0. VALIDATE inputs: every passed key must be an :input-role param or a donated slot —
+        ;;    never a :constant/:state key silently ignored (fail-loud, §7.7).
+        _ (doseq [[k _v] inputs]
+            (when-not (or (contains? input-keys k) (contains? donated-keys k))
+              (throw (ex-info (str "invoke: unsupported input key " k " — only :input-role params "
+                                   (vec input-keys) " or donated slots " (vec donated-keys)
+                                   " may be passed; a :constant/:state slot is captured at bind")
+                              {:key k :inputs (keys inputs)}))))
+        ;; 1. donation-invalidation. A DeviceArray passed to a donated slot MUST be this artifact's
+        ;;    own resident value threaded back (residency IS the donation; the buffer never moves).
+        ;;    A foreign device buffer would need a rebind that does not exist yet → FAIL LOUD rather
+        ;;    than consume-and-ignore-its-contents (the silent miscompile the review caught).
         _ (doseq [[k _out] donated]
-            (let [val (get inputs k)]
-              (when (v/device-array? val) (v/consume! val))))
-        ;; 2. assemble args: start from captured, override :input-role keys the caller passed.
-        input-syms (set (map :sym (filter #(= :input (:role %)) in-tree)))
+            (when-let [val (get inputs k)]
+              (when (v/device-array? val)
+                (let [s    (get key->sym k)
+                      rbuf (gpu/buffer session (gpu/resident-key session handle s))
+                      node (get in-nodes k)]
+                  (when-not (identical? (:buffer val) rbuf)
+                    (throw (ex-info (str "invoke: donated input " k " is not this artifact's resident "
+                                         "value — the MVP only supports threading the artifact's own "
+                                         "output back into its donated slot; uploading a foreign "
+                                         "device value needs a rebind that is not yet wired")
+                                    {:key k})))
+                  (when (and node (:shape node) (:shape val) (not= (:shape node) (:shape val)))
+                    (throw (ex-info (str "invoke: donated input " k " shape " (:shape val)
+                                         " ≠ bound shape " (:shape node)) {:key k})))
+                  (v/consume! val)))))
+        ;; 2. assemble args: override :input-role syms (a DeviceArray :input is downloaded then
+        ;;    re-uploaded by replay — MVP limitation; device-resident :input rebind is future work).
         argmap (reduce (fn [m [k val]]
                          (let [s (get key->sym k)]
                            (if (and s (contains? input-syms s))
@@ -179,13 +230,21 @@
                        (zipmap (:all-params descriptor) args)
                        inputs)
         call-args (mapv argmap (:all-params descriptor))]
-    ;; 3. replay, no download.
+    ;; 3. invalidate the PREVIOUS batch of outputs — they alias resident buffers this replay
+    ;;    overwrites, so a retained old wrapper would observe a silent mutation (§2.3). ::external
+    ;;    free! only marks the wrapper dead; it never frees the session-owned buffer.
+    (when live-outputs
+      (doseq [da @live-outputs] (v/free! da))
+      (reset! live-outputs nil))
+    ;; 4. replay, no download.
     (gpu/replay-program! session handle call-args)
-    ;; 4. project outputs as resident device values.
-    (into {} (keep (fn [{:keys [key] :as node}]
-                     (when-let [da (project-node session handle node target)]
-                       [key da])))
-          out-tree)))
+    ;; 5. project outputs as resident device values; record them for next-call invalidation.
+    (let [out (into {} (keep (fn [{:keys [key] :as node}]
+                               (when-let [da (project-node session handle node target)]
+                                 [key da]))
+                             out-tree))]
+      (when live-outputs (reset! live-outputs (vec (vals out))))
+      out)))
 
 ;; ================================================================
 ;; Inspection (§2.1) + lifecycle
@@ -230,7 +289,12 @@
    :steps    (frequencies (map :convention (:steps (:descriptor c))))})
 
 (defn close!
-  "Release the artifact's session (frees resident buffers + destroys graphs/kernels)."
+  "Release the artifact's session (frees resident buffers + destroys graphs/kernels). Invalidates
+   any still-live projected output values FIRST, so a `->host` on a value returned before close!
+   fails loud (use-after-free) instead of copying from a zeMemFree'd segment (SIGSEGV/garbage)."
   [^Compiled c]
+  (when-let [lo (:live-outputs c)]
+    (doseq [da @lo] (v/free! da))
+    (reset! lo nil))
   (gpu/close-session! (:session c))
   nil)

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -1294,6 +1294,39 @@
            (contains? (:buffers @sess) result-key))
       (assoc result-sym (download sess result-key)))))
 
+(defn replay-program!
+  "Replay a bound program WITHOUT downloading any output — the device-value path (S4).
+   Refreshes only :input array params (same as run-program!), replays the recorded graph, and
+   returns the session. Output/:state/:result buffers stay RESIDENT; the caller wraps them as
+   DeviceArrays (raster.gpu.value) and downloads explicitly only when a host value is needed.
+   This is what `raster.gpu.compiled/invoke-compiled` calls — run-program!'s upload+replay with
+   the host round-trip removed. `resident-key` (below) resolves the buffer key for a param/result
+   symbol so the wrapper can fetch the live buffer via `buffer`."
+  [sess prog-or-handle args]
+  (let [{:keys [descriptor roles graph param->key profile?]}
+        (resolve-program sess prog-or-handle)
+        {:keys [all-params array-params]} descriptor
+        device-id (:device-id @sess)
+        argmap (zipmap all-params args)
+        replay-fn (rt-resolve device-id "replay-graph!")]
+    (doseq [p array-params :when (= :input (get roles p :input))]
+      (upload! sess (get param->key p) (get argmap p)))
+    (replay-fn graph)
+    (when profile?
+      (when-let [reset-fn (rt-resolve-soft device-id "reset-graph-events!")]
+        (reset-fn graph)))
+    sess))
+
+(defn resident-key
+  "Resolve the session buffer key for a param/result symbol of a bound program — the seam
+   `raster.gpu.compiled` uses to fetch a live resident buffer (via `buffer`) and wrap it as a
+   DeviceArray. Handles array params (param->key) and the functional :result-sym (result-key)."
+  [sess prog-or-handle sym]
+  (let [{:keys [param->key result-key descriptor]} (resolve-program sess prog-or-handle)]
+    (or (get param->key sym)
+        (when (= sym (:result-sym descriptor)) result-key)
+        (keyword (name sym)))))
+
 (defn profile-program!
   "The profiling twin of run-program!: same upload → replay → download sequence over a program
    bound with {:profile? true}, but reads the per-kernel DEVICE timestamps the replay produced.

--- a/src/raster/gpu/value.clj
+++ b/src/raster/gpu/value.clj
@@ -1,0 +1,202 @@
+(ns raster.gpu.value
+  "The device-value type — `DeviceArray`, a `jax.Array` analogue (S4 §1).
+
+   A `DeviceArray` is a first-class value that *is* device residency: it wraps a
+   backend `DeviceBuffer` (ze_runtime/DeviceBuffer or ocl equivalent) and adds the
+   three things a *value* needs that the byte-storage buffer lacks — WHICH device it
+   lives on, its logical SHAPE, and an OWNERSHIP/lifetime discipline. This is the
+   prerequisite for functional artifact invocation (values-in / values-out) and for
+   donation-as-residency: without a device value, `:donate` is just today's `:state`
+   plus a per-step host copy (the design's C2 finding).
+
+   Ownership (`owner` field), the lifetime discipline:
+     ::owned    — raster allocated it; freed on `free!`, session-close, or GC (Cleaner
+                  safety net). The only kind reclaim frees.
+     ::donated  — ownership was transferred INTO a `step` call; the value is marked
+                  consumed (freed? = true) and its buffer now belongs to an output
+                  value. Reads throw; its Cleaner is disarmed (never frees the buffer).
+     ::aliased  — a view onto another value's buffer (a KV-cache slice). Never frees on
+                  reclaim; the base owner does.
+     ::external — wraps a buffer raster did not allocate. Never freed by raster.
+
+   Backend-neutral by construction: every runtime call routes through `device-id`
+   (`:ze:0` / `:ocl:0`) via `requiring-resolve`, never a hardcoded `:ze`. Depends only
+   on the runtime records, never on the session layer — this ns sits at the bottom of
+   the GPU dependency graph so `raster.gpu.compiled` / `raster.gpu.core` can build on it
+   without a cycle."
+  (:import [java.lang.ref Cleaner]
+           [java.util.concurrent.atomic AtomicBoolean]))
+
+;; ================================================================
+;; Backend dispatch (mirror of core/rt-resolve; kept local so this
+;; ns depends on neither the session nor a specific runtime)
+;; ================================================================
+
+(defn- backend-ns
+  [device-id]
+  (let [s (name device-id)]
+    (cond
+      (.startsWith s "ze")  'raster.gpu.ze-runtime
+      (.startsWith s "ocl") 'raster.gpu.ocl-runtime
+      :else (throw (ex-info (str "Unknown GPU backend for device " device-id
+                                 " — use :ze:N or :ocl:N")
+                            {:device-id device-id})))))
+
+(defn- rt-fn
+  "Resolve a runtime fn by name for the given device-id's backend."
+  [device-id fn-name]
+  (let [ns-sym (backend-ns device-id)]
+    (or (requiring-resolve (symbol (str ns-sym) fn-name))
+        (throw (ex-info (str "Cannot resolve " fn-name " in " ns-sym)
+                        {:device-id device-id :fn fn-name})))))
+
+;; ================================================================
+;; The Cleaner (GC-backed reclamation safety net)
+;; ================================================================
+
+(def ^:private ^Cleaner cleaner (Cleaner/create))
+
+(defn- arm-cleaner!
+  "Register a GC cleaning action that frees `buffer` on `device-id` IF this value is
+   still the live owner when it becomes unreachable. Captures only value-independent
+   state (never the DeviceArray) so the action does not pin the value in memory.
+
+   Idempotent with explicit `free!` and donation via the shared AtomicBoolean:
+   whoever wins `compareAndSet(false,true)` performs (or suppresses) the free exactly
+   once. Donation wins the CAS without freeing → the buffer survives on the output
+   value and this Cleaner is disarmed."
+  [holder ^AtomicBoolean freed buffer device-id free-on-reclaim?]
+  (.register cleaner holder
+             (reify Runnable
+               (run [_]
+                 (when (and free-on-reclaim? (.compareAndSet freed false true))
+                   (try ((rt-fn device-id "free-buffer!") buffer)
+                        (catch Throwable _)))))))
+
+;; ================================================================
+;; The type
+;; ================================================================
+
+(defrecord DeviceArray
+           [buffer      ;; backend DeviceBuffer (byte storage: segment + n-elements + dtype)
+            device      ;; device-id keyword (:ze:0) — which runtime it lives on
+            dtype       ;; :float :half :int … (redundant with buffer.dtype; cheap inspection)
+            shape       ;; [d0 d1 …] logical shape (the buffer knows only flat n-elements)
+            owner       ;; ::owned | ::donated | ::aliased | ::external
+            freed])     ;; AtomicBoolean — use-after-free / double-free / donation guard
+
+(defn device-array? [x] (instance? DeviceArray x))
+
+(defn- make-device-array
+  "Build a DeviceArray over an existing backend buffer, arming the Cleaner for
+   ::owned values. Low-level constructor used by `->device` and output projection."
+  [buffer device-id dtype shape owner]
+  (let [freed (AtomicBoolean. false)
+        da    (->DeviceArray buffer device-id dtype (vec shape) owner freed)]
+    (arm-cleaner! da freed buffer device-id (= owner ::owned))
+    da))
+
+;; ================================================================
+;; Lifetime guards
+;; ================================================================
+
+(defn live?
+  "True if the value has not been freed, consumed (donated), or reclaimed."
+  [^DeviceArray da]
+  (not (.get ^AtomicBoolean (:freed da))))
+
+(defn- ensure-live!
+  [^DeviceArray da op]
+  (when (.get ^AtomicBoolean (:freed da))
+    (throw (ex-info (str "DeviceArray use-after-free: " op
+                         " on a value that was already freed, consumed by donation,"
+                         " or reclaimed")
+                    {:op op :owner (:owner da) :shape (:shape da) :device (:device da)})))
+  da)
+
+;; ================================================================
+;; Host <-> device transfer
+;; ================================================================
+
+(defn ->device
+  "Lift a JVM primitive array onto `device-id` as a fresh ::owned DeviceArray.
+   dtype is auto-detected from the array type unless supplied in opts.
+
+   opts: {:shape [d0 d1 …]   ;; logical shape (default [n])
+          :dtype :float|…}    ;; override auto-detected dtype"
+  ([arr device-id] (->device arr device-id nil))
+  ([arr device-id opts]
+   (let [dtype   (:dtype opts)
+         buffer  (if dtype
+                   ((rt-fn device-id "buffer-of-array") arr dtype)
+                   ((rt-fn device-id "buffer-of-array") arr))
+         n       (:n-elements buffer)
+         shape   (or (:shape opts) [n])]
+     (make-device-array buffer device-id (:dtype buffer) shape ::owned))))
+
+(defn ->host
+  "Download a DeviceArray to a fresh JVM array. Throws if the value is not live.
+   For :half/:float16 returns the encoded short array (matches buffer->array)."
+  [^DeviceArray da]
+  (ensure-live! da :->host)
+  ((rt-fn (:device da) "buffer->array") (:buffer da)))
+
+;; ================================================================
+;; Explicit free + donation
+;; ================================================================
+
+(defn free!
+  "Explicitly free a DeviceArray. Idempotent and race-safe with GC reclamation and
+   donation (whoever wins the CAS acts once). Only ::owned values free their buffer;
+   ::aliased/::external values just mark themselves dead without touching the buffer
+   (the base owner frees it)."
+  [^DeviceArray da]
+  (let [^AtomicBoolean freed (:freed da)]
+    (when (.compareAndSet freed false true)
+      (when (= (:owner da) ::owned)
+        (try ((rt-fn (:device da) "free-buffer!") (:buffer da))
+             (catch Throwable _)))))
+  nil)
+
+(defn consume!
+  "Consume a DeviceArray for donation: mark it dead (reads now throw) and hand its
+   buffer to the caller WITHOUT freeing it. Wins the CAS so the input's Cleaner is
+   disarmed — the buffer's ownership moves to the output value the caller builds with
+   `donate-output`. Throws if the value was already freed/consumed."
+  [^DeviceArray da]
+  (ensure-live! da :consume!)
+  (let [^AtomicBoolean freed (:freed da)]
+    (when-not (.compareAndSet freed false true)
+      (throw (ex-info "DeviceArray consumed concurrently"
+                      {:owner (:owner da) :shape (:shape da)})))
+    (:buffer da)))
+
+(defn donate-output
+  "Build the output DeviceArray of a donated in→out pair: a fresh ::owned value over
+   the consumed input's buffer, with the output's logical shape/dtype. Call `consume!`
+   on the input first (this fn takes the buffer it returned)."
+  [buffer device-id dtype shape]
+  (make-device-array buffer device-id dtype shape ::owned))
+
+;; ================================================================
+;; Constructors for the other ownership kinds
+;; ================================================================
+
+(defn wrap-owned
+  "Wrap an existing raster-allocated backend buffer as an ::owned DeviceArray
+   (Cleaner-armed). Used by output projection for freshly allocated result buffers."
+  [buffer device-id dtype shape]
+  (make-device-array buffer device-id dtype shape ::owned))
+
+(defn wrap-external
+  "Wrap a caller-owned backend buffer raster did not allocate. Never freed by raster."
+  [buffer device-id dtype shape]
+  (make-device-array buffer device-id dtype shape ::external))
+
+(defn alias-of
+  "Build an ::aliased view onto `base`'s buffer with a (possibly different) logical
+   shape — the cross-artifact / KV-slice sharing case. Never frees on reclaim; the
+   base owner's lifetime governs the buffer."
+  ([^DeviceArray base] (alias-of base (:shape base) (:dtype base)))
+  ([^DeviceArray base shape dtype]
+   (make-device-array (:buffer base) (:device base) dtype shape ::aliased)))

--- a/src/raster/gpu/value.clj
+++ b/src/raster/gpu/value.clj
@@ -83,18 +83,24 @@
             dtype       ;; :float :half :int … (redundant with buffer.dtype; cheap inspection)
             shape       ;; [d0 d1 …] logical shape (the buffer knows only flat n-elements)
             owner       ;; ::owned | ::donated | ::aliased | ::external
-            freed])     ;; AtomicBoolean — use-after-free / double-free / donation guard
+            freed       ;; AtomicBoolean — use-after-free / double-free / donation guard
+            base])      ;; for ::aliased: the base DeviceArray it views (else nil). Held as a
+                        ;; STRONG ref so reachability of an alias keeps the base — and thus the
+                        ;; base's Cleaner-guarded buffer — alive; also the seam ensure-live! reads
+                        ;; to reject reads through a base that was freed/consumed.
 
 (defn device-array? [x] (instance? DeviceArray x))
 
 (defn- make-device-array
   "Build a DeviceArray over an existing backend buffer, arming the Cleaner for
-   ::owned values. Low-level constructor used by `->device` and output projection."
-  [buffer device-id dtype shape owner]
-  (let [freed (AtomicBoolean. false)
-        da    (->DeviceArray buffer device-id dtype (vec shape) owner freed)]
-    (arm-cleaner! da freed buffer device-id (= owner ::owned))
-    da))
+   ::owned values. Low-level constructor used by `->device` and output projection.
+   `base` is non-nil only for ::aliased views (§ alias-of)."
+  ([buffer device-id dtype shape owner] (make-device-array buffer device-id dtype shape owner nil))
+  ([buffer device-id dtype shape owner base]
+   (let [freed (AtomicBoolean. false)
+         da    (->DeviceArray buffer device-id dtype (vec shape) owner freed base)]
+     (arm-cleaner! da freed buffer device-id (= owner ::owned))
+     da)))
 
 ;; ================================================================
 ;; Lifetime guards
@@ -112,6 +118,13 @@
                          " on a value that was already freed, consumed by donation,"
                          " or reclaimed")
                     {:op op :owner (:owner da) :shape (:shape da) :device (:device da)})))
+  ;; an ::aliased view is only as live as its base owner — reading through a freed base is a
+  ;; use-after-free even if the alias's own flag is clear.
+  (when-let [^DeviceArray b (:base da)]
+    (when (.get ^AtomicBoolean (:freed b))
+      (throw (ex-info (str "DeviceArray use-after-free: " op
+                           " through an ::aliased view whose base was freed/consumed")
+                      {:op op :owner (:owner da) :shape (:shape da) :device (:device da)}))))
   da)
 
 ;; ================================================================
@@ -139,7 +152,12 @@
    For :half/:float16 returns the encoded short array (matches buffer->array)."
   [^DeviceArray da]
   (ensure-live! da :->host)
-  ((rt-fn (:device da) "buffer->array") (:buffer da)))
+  ;; reachabilityFence: without it the JIT may treat `da` as dead after the (:buffer da) field
+  ;; load, letting GC run its Cleaner and zeMemFree the segment WHILE buffer->array copies from
+  ;; it — a native use-after-free. Keep `da` (and, via its :base field, any aliased base) reachable
+  ;; across the whole native copy.
+  (try ((rt-fn (:device da) "buffer->array") (:buffer da))
+       (finally (java.lang.ref.Reference/reachabilityFence da))))
 
 ;; ================================================================
 ;; Explicit free + donation
@@ -154,8 +172,9 @@
   (let [^AtomicBoolean freed (:freed da)]
     (when (.compareAndSet freed false true)
       (when (= (:owner da) ::owned)
-        (try ((rt-fn (:device da) "free-buffer!") (:buffer da))
-             (catch Throwable _)))))
+        ;; explicit free surfaces runtime errors (fail-loud) — unlike the Cleaner thread, whose
+        ;; reclamation MUST swallow (arm-cleaner!). The CAS guarantees this fires at most once.
+        ((rt-fn (:device da) "free-buffer!") (:buffer da)))))
   nil)
 
 (defn consume!
@@ -199,4 +218,5 @@
    base owner's lifetime governs the buffer."
   ([^DeviceArray base] (alias-of base (:shape base) (:dtype base)))
   ([^DeviceArray base shape dtype]
-   (make-device-array (:buffer base) (:device base) dtype shape ::aliased)))
+   (ensure-live! base :alias-of)
+   (make-device-array (:buffer base) (:device base) dtype shape ::aliased base)))

--- a/test/raster/gpu/artifact_test.clj
+++ b/test/raster/gpu/artifact_test.clj
@@ -1,0 +1,169 @@
+(ns raster.gpu.artifact-test
+  "S4 acceptance tests for the artifact-as-value layer (raster.gpu.value + raster.gpu.compiled).
+
+   CPU-only (always run):
+     A2 — donation-invalidation state machine (device value ownership discipline).
+     A5 — inspection: explain / cache-key over a Compiled record (no device).
+
+   Device-gated (Level-Zero, via the gpu_grad_parity honesty gate):
+     A1 — the gemma LoRA resident train-step ported to `(r/compile …)` + `(step …)`, threaded
+          as device values across 25 steps with ZERO host download in the loop, producing
+          adapters BIT-IDENTICAL to the raw bind-program!/run-program! path (A6 no-regression),
+          and a decreasing loss trajectory.
+     A3 — frozen weights are :constant (captured at bind), never per-call inputs.
+     A4 — multi-output: the out-tree projects all 14 donated adapters as DeviceArrays."
+  (:require [clojure.test :refer [deftest testing is]]
+            [raster.gpu.value :as v]
+            [raster.gpu.compiled :as r]
+            [raster.dl.gpu-grad-parity :as gp]
+            [raster.dl.gemma-train-resident-test :as g]
+            [raster.compiler.pipeline :as pl]))
+
+;; ── access the gemma harness (privates) ──────────────────────────────────────────
+(defn- gv [sym] @(ns-resolve 'raster.dl.gemma-train-resident-test sym))
+
+;; ════════════════════════════════════════════════════════════════════════════════
+;; A2 — donation-invalidation (CPU, no device)
+;; ════════════════════════════════════════════════════════════════════════════════
+
+(defrecord ^:private FakeBuf [n-elements dtype])
+
+(deftest a2-donation-invalidation
+  (testing "an ::owned value is live and readable until consumed"
+    (let [inp (v/wrap-owned (->FakeBuf 8 :float) :ze:0 :float [2 4])]
+      (is (v/live? inp))
+      (let [buf (v/consume! inp)]
+        (is (instance? FakeBuf buf) "consume! returns the buffer for the output value")
+        (is (not (v/live? inp)) "input is dead after donation")
+        (is (thrown? clojure.lang.ExceptionInfo (v/->host inp))
+            "reading a consumed value throws use-after-free")
+        (is (thrown? clojure.lang.ExceptionInfo (v/consume! inp))
+            "double-consume throws")
+        (let [out (v/donate-output buf :ze:0 :float [8])]
+          (is (v/live? out) "output value is live")
+          (is (identical? buf (:buffer out)) "output reuses the donated buffer (no copy)")))))
+  (testing "::aliased free! never frees the base buffer"
+    (let [base (v/wrap-owned (->FakeBuf 6 :float) :ze:0 :float [6])
+          al   (v/alias-of base [2 3] :float)]
+      (is (identical? (:buffer base) (:buffer al)))
+      (v/free! al)
+      (is (not (v/live? al)))
+      (is (v/live? base) "base survives an alias free!")))
+  (testing "unknown backend fails loud"
+    (is (thrown? clojure.lang.ExceptionInfo (v/->device (float-array 3) :cuda:0)))))
+
+;; ════════════════════════════════════════════════════════════════════════════════
+;; A5 — inspection over a Compiled record (CPU, no device)
+;; ════════════════════════════════════════════════════════════════════════════════
+
+(deftest a5-inspection
+  (let [descriptor {:all-params '[a b n]
+                    :array-params '[a b]
+                    :array-roles '{a :input b :output}
+                    :result-sym 'b
+                    :dtype :float
+                    :steps [{:convention :map} {:convention :gemm} {:convention :map}]}
+        c (r/map->Compiled
+           {:session nil :handle nil
+            :in-tree  [{:key :a :sym 'a :role :input :donate? false :shape [4] :dtype :float}]
+            :out-tree [{:key :b' :sym 'b :shape [4] :dtype :float :from :donated}]
+            :donated  {:a :a'}
+            :schedule nil :target :ze:0 :descriptor descriptor :args nil})]
+    (testing "explain returns the artifact unchanged and prints the shape"
+      (is (identical? c (r/explain c))))
+    (testing "ir dumps the resident steps"
+      (is (= 3 (count (r/ir c))))
+      (is (= [:map :gemm :map] (mapv :convention (r/ir c)))))
+    (testing "cache-key captures the serializable identity (closures excluded)"
+      (let [k (r/cache-key c)]
+        (is (= :ze:0 (:target k)))
+        (is (= {:map 2 :gemm 1} (:steps k)))
+        (is (= {:a :a'} (:donated k)))
+        (is (= [4] (-> k :in-tree first :shape)))))))
+
+;; ════════════════════════════════════════════════════════════════════════════════
+;; A1 / A3 / A4 — the device acceptance: gemma resident train-step as a VALUE
+;; ════════════════════════════════════════════════════════════════════════════════
+
+(def ^:private frozen-syms
+  '[x input-ln q-norm k-norm post-attn pre-ffn post-ffn Wq Wk Wv Wo Wg Wu Wd tgt])
+
+(deftest a1-gemma-resident-train-step-as-value
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "S4 gemma resident train-step as a value")
+    (let [cfg      (gv 'CFG)
+          adapters (gv 'adapter-syms)
+          init-state (ns-resolve 'raster.dl.gemma-train-resident-test 'init-state)
+          train-args (ns-resolve 'raster.dl.gemma-train-resident-test 'train-args)
+          host-loss  (ns-resolve 'raster.dl.gemma-train-resident-test 'host-loss)
+          lr 0.02
+          n-steps 25
+          st0  (init-state cfg)
+          args (train-args cfg st0 lr)
+          ;; ── raw reference path: bind-program! + N× run-program! ──
+          gpu  (do (require 'raster.gpu.core) (find-ns 'raster.gpu.core))
+          make-session   (ns-resolve gpu 'make-session)
+          bind-program!  (ns-resolve gpu 'bind-program!)
+          run-program!   (ns-resolve gpu 'run-program!)
+          close-session! (ns-resolve gpu 'close-session!)
+          download       (ns-resolve gpu 'download)
+          raw-prog (pl/compile-gpu-program #'raster.dl.gemma-train-resident-test/gblk-train-step
+                                           :ze:0 :dtype :float
+                                           :on-non-resident :nil :gemm-precision :f32-scalar)
+          _ (is (some? raw-prog) "gblk-train-step must extract fully resident")
+          raw-final
+          (let [sess (make-session :ze:0)]
+            (try
+              (bind-program! sess raw-prog args
+                             (merge (zipmap adapters (repeat :state))
+                                    (zipmap frozen-syms (repeat :constant))))
+              (dotimes [_ n-steps] (run-program! sess raw-prog args))
+              (reduce (fn [m s] (assoc m s (download sess (keyword (name s))))) {} adapters)
+              (finally (close-session! sess))))
+          ;; ── artifact-as-value path: r/compile + N× (step {}) ──
+          step (r/compile #'raster.dl.gemma-train-resident-test/gblk-train-step
+                          args
+                          {:target :ze:0 :dtype :float
+                           :donate adapters :constants frozen-syms
+                           :gemm-precision :f32-scalar})]
+      (try
+        (testing "A3: frozen weights are :constant, never per-call inputs"
+          (let [roles (into {} (map (juxt :sym :role)) (:in-tree step))]
+            (is (every? #(= :constant (roles %)) frozen-syms)
+                "all frozen syms derive to :constant")
+            (is (every? #(= :state (roles %)) adapters)
+                "all adapters derive to :state (donated)")))
+        (let [;; 25 resident steps — NO host download inside the loop (residency proof)
+              last-out (loop [k 0 out nil]
+                         (if (= k n-steps)
+                           out
+                           (recur (inc k) (step {}))))]
+          (testing "A4: out-tree projects all 14 donated adapters (+ the result node) as DeviceArrays"
+            (doseq [s adapters]
+              (is (v/device-array? (get last-out (keyword (str (name s) "'"))))
+                  (str s "' must be projected as a device-resident DeviceArray")))
+            (is (>= (count (keys last-out)) (count adapters))
+                "multi-output: at least one node per donated adapter")
+            (is (every? v/device-array? (vals last-out))
+                "every output is a DeviceArray (device-resident, not a host array)"))
+          (testing "A1/A6: the value path is BIT-IDENTICAL to the raw run-program! path"
+            (doseq [s adapters]
+              (let [art (v/->host (get last-out (keyword (str (name s) "'"))))
+                    raw (get raw-final s)]
+                (is (java.util.Arrays/equals ^floats art ^floats raw)
+                    (str s ": artifact adapters must match the raw path bit-for-bit")))))
+          (testing "A1: the trained adapters differ from init (learning happened)"
+            (doseq [s adapters]
+              (is (not (java.util.Arrays/equals
+                        ^floats (v/->host (get last-out (keyword (str (name s) "'"))))
+                        ^floats (get st0 s)))
+                  (str s " must change after 25 on-device steps"))))
+          (testing "A1: loss decreased over the resident trajectory"
+            (let [final-st (reduce (fn [m s]
+                                     (assoc m s (v/->host (get last-out (keyword (str (name s) "'"))))))
+                                   st0 adapters)
+                  l0 (host-loss cfg st0)
+                  lN (host-loss cfg final-st)]
+              (println "  [S4 artifact] loss" (format "%.6f → %.6f" l0 lN))
+              (is (< lN (* 0.7 l0)) (str "final " lN " vs initial " l0)))))
+        (finally (r/close! step))))))

--- a/test/raster/gpu/artifact_test.clj
+++ b/test/raster/gpu/artifact_test.clj
@@ -165,5 +165,23 @@
                   l0 (host-loss cfg st0)
                   lN (host-loss cfg final-st)]
               (println "  [S4 artifact] loss" (format "%.6f → %.6f" l0 lN))
-              (is (< lN (* 0.7 l0)) (str "final " lN " vs initial " l0)))))
+              (is (< lN (* 0.7 l0)) (str "final " lN " vs initial " l0))))
+          (testing "S4 boundary contract (M4): a retained prior output is invalidated by the next call"
+            (let [prev    (step {})
+                  prev-da (get prev (keyword (str (name (first adapters)) "'")))]
+              (is (v/live? prev-da) "a freshly projected output is live")
+              (step {})
+              (is (not (v/live? prev-da)) "the next invocation invalidates the prior output (no silent mutation)")
+              (is (thrown? clojure.lang.ExceptionInfo (v/->host prev-da))
+                  "->host on a stale output fails loud")))
+          (testing "S4 boundary contract (B1): unsupported / foreign inputs fail loud, never silently ignored"
+            (is (thrown-with-msg? clojure.lang.ExceptionInfo #"unsupported input key"
+                                  (step {:not-a-param (float-array 1)}))
+                "a non-param key throws instead of being dropped")
+            (let [foreign (v/->device (float-array (java.lang.reflect.Array/getLength ^floats (st0 (first adapters))))
+                                      :ze:0)]
+              (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not this artifact's resident value"
+                                    (step {(keyword (name (first adapters))) foreign}))
+                  "a foreign device value donated to a slot throws instead of being consumed-and-ignored")
+              (v/free! foreign))))
         (finally (r/close! step))))))


### PR DESCRIPTION
The first S4 PR from `.internal/artifact_layer_design.md` §6: ships the **device-value type** and **functional artifact invocation** end-to-end with **zero change to the kernel/graph machinery** and **zero change to the decoder**.

## What lands

**`raster.gpu.value` — `DeviceArray`**, a `jax.Array` analogue over the backend `DeviceBuffer`. Adds what a *value* needs that byte-storage lacks: which device, logical shape, and an ownership/lifetime discipline (`::owned`/`::donated`/`::aliased`/`::external`). Cleaner-backed GC reclamation is the safety net; explicit `free!`/`consume!` the fast path. Donation is a CAS on a shared `AtomicBoolean` — whoever wins frees-or-suppresses exactly once, so GC / explicit-free / donation never double-free and a consumed value's reads throw (use-after-free guard). Backend-neutral: every runtime call routes through `device-id`, never a hardcoded `:ze`.

**`raster.gpu.compiled` — `Compiled` record + `IFn`.** `(r/compile #'f args opts)` binds once and returns a functional artifact: `(step inputs)` → `{out-key → DeviceArray}`, no host round-trip. Roles are **derived** (§4.2): `:donate` → `:state`, `:constants` → `:constant`, the rest fall through to the descriptor's `read-only→:input` / `written→:output`. Donation reuses the resident buffer — the write-back shim makes "mutation" a value-identity swap, never a semantic. Multi-output `out-tree` (§3.4) generalizes the single `:result-sym`. `r/explain` / `r/ir` / `r/profile` / `r/cache-key` inspect; `r/close!` releases.

**`core.clj` — two additive helpers:** `replay-program!` (upload `:input` + replay, **no download** — the device-value path) and `resident-key` (resolve a param/result sym to its live buffer key). `run-program!`/`bind-program!`/`bind-step!` unchanged — every existing consumer keeps working (additive, not migratory).

## Acceptance — `test/raster/gpu/artifact_test.clj`, 66 assertions, 0 failures on Arc `ze:0`

- **A2 (CPU)** donation-invalidation state machine; **A5 (CPU)** `explain`/`ir`/`cache-key`.
- **A1/A3/A4/A6 (device)** — the gemma LoRA resident train-step ported to `(r/compile …)` + 25× `(step {})`, threaded as device values with **zero host download in the loop**:
  - adapters **bit-identical** to the raw `bind-program!`/`run-program!` path (no regression)
  - loss **2.800152 → 0.256915** over 25 on-device steps
  - frozen weights derive to `:constant`, adapters to `:state` (donated)
  - `out-tree` projects all 14 donated adapters as `DeviceArray`s (multi-output)

## Not in this PR (kept additive / gated)

- Deleting legacy style-c `chain-program!`/`run-chain!` — one consumer (`decoder_layer_gpu_test`) needs porting first.
- The composition/linking PR is gated on the §7.2 two-instance de-risk spike.