### PR TITLE
S6 PR-1: schedule-as-data + register-budget feasibility gate

### DIFF
--- a/src/raster/compiler/core/hardware.clj
+++ b/src/raster/compiler/core/hardware.clj
@@ -77,13 +77,17 @@
              :balance     (if gpu? 60 40)}
       gpu? (assoc :integrated? (boolean (:integrated? caps))
                   :subgroup-size flanes
-                  ;; GRF budget per LANE = grf-regs/thread × reg-bytes / subgroup-size. The Xe2
-                  ;; register file is 128 GRF registers/thread of 32 B (256-bit) at grf128; per
-                  ;; SIMD lane that is 128×32/subgroup. Arc 140V (subgroup 16): 256 B/lane — the
-                  ;; budget the schedule feasibility gate (raster.gpu.schedule/feasible?) charges
-                  ;; the accumulator + register staging against. AMD VGPR budget slots in here for
-                  ;; HIP. (:num-vector-registers above is a CPU-shaped placeholder; this is the
-                  ;; real GPU value.)
+                  ;; GRF budget per LANE = grf-regs/thread × reg-bytes / subgroup-size. INTEL Xe/Xe2
+                  ;; grf128 model: 128 GRF registers/thread of 32 B (256-bit); per SIMD lane that is
+                  ;; 128×32/subgroup. Arc 140V (subgroup 16): 256 B/lane — the budget the schedule
+                  ;; feasibility gate (raster.gpu.schedule/feasible?) charges the accumulator +
+                  ;; register staging against.
+                  ;; NOTE (vendor-specificity, HIP/CUDA follow-up): 128×32 is the Intel-Xe-grf128
+                  ;; constant. NVIDIA (255 regs × 4 B / warp 32 ≈ 1020 B/lane) and AMD VGPR budgets
+                  ;; differ ~8× — this value is only correct for Intel targets until it is derived
+                  ;; from per-vendor caps (with descriptor :vendor/:arch). The gate must not be
+                  ;; trusted for a non-Intel descriptor yet. (:num-vector-registers above is a
+                  ;; CPU-shaped placeholder; this is the Intel GPU value.)
                   :grf-bytes-per-lane (long (quot (* 128 32) (max 1 flanes)))
                   :max-workgroup-size (long (or (:max-workgroup-size caps) 256)))
       ;; MACHINE WIDTH — work-items in flight when the device is full: EUs x hw threads per

--- a/src/raster/compiler/core/hardware.clj
+++ b/src/raster/compiler/core/hardware.clj
@@ -76,6 +76,15 @@
                               (* 16 1024 1024))
              :balance     (if gpu? 60 40)}
       gpu? (assoc :integrated? (boolean (:integrated? caps))
+                  :subgroup-size flanes
+                  ;; GRF budget per LANE = grf-regs/thread × reg-bytes / subgroup-size. The Xe2
+                  ;; register file is 128 GRF registers/thread of 32 B (256-bit) at grf128; per
+                  ;; SIMD lane that is 128×32/subgroup. Arc 140V (subgroup 16): 256 B/lane — the
+                  ;; budget the schedule feasibility gate (raster.gpu.schedule/feasible?) charges
+                  ;; the accumulator + register staging against. AMD VGPR budget slots in here for
+                  ;; HIP. (:num-vector-registers above is a CPU-shaped placeholder; this is the
+                  ;; real GPU value.)
+                  :grf-bytes-per-lane (long (quot (* 128 32) (max 1 flanes)))
                   :max-workgroup-size (long (or (:max-workgroup-size caps) 256)))
       ;; MACHINE WIDTH — work-items in flight when the device is full: EUs x hw threads per
       ;; EU x SIMD lanes. Every GPU launch geometry is a function of this and the problem

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -1577,13 +1577,20 @@
    cotangent by S, use lr/S), not in this policy: the VJP is linear in the seed.
    No size heuristics; the XMX hardware pitch gate (n<8 or k<8 → scalar) applies in
    bind-program! regardless of policy."
-  [f-var device-id & {:keys [dtype on-non-resident gemm-precision]
+  [f-var device-id & {:keys [dtype on-non-resident gemm-precision schedule]
                       :or {on-non-resident :throw gemm-precision :f16-xmx}}]
   (when-not (contains? #{:f16-xmx :f32-scalar} gemm-precision)
     (throw (ex-info (str "compile-gpu-program: unknown :gemm-precision " (pr-str gemm-precision)
                          " (expected :f16-xmx or :f32-scalar)")
                     {:gemm-precision gemm-precision})))
-  (let [resolved-var (or (resolve-deftm-var f-var dtype) f-var)
+  ;; S6 schedule: derive the descriptor-default schedule, deep-merge the user :schedule override
+  ;; (:gemm-precision is deprecated sugar → the precision policy), and run the register-budget
+  ;; FEASIBILITY GATE before any emission — an infeasible schedule (e.g. register double-buffering
+  ;; that would spill the GRF file) is a loud compile error, not a measurement-time regression.
+  (let [resolved-schedule ((requiring-resolve 'raster.gpu.schedule/schedule-for-device)
+                           nil device-id schedule {:precision gemm-precision})
+        gemm-precision (:precision resolved-schedule)
+        resolved-var (or (resolve-deftm-var f-var dtype) f-var)
         params       (get-params f-var dtype)
         walked-body  (get-walked-body f-var dtype)
         active-params (clean-params params)
@@ -1705,6 +1712,7 @@
     (when prog
       {:dtype effective-dtype
        :gemm-precision gemm-precision
+       :schedule resolved-schedule
        :all-params all-params
        :array-params array-params
        :array-roles array-roles

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -1557,9 +1557,10 @@
      :nil             — return nil, for probing callers that legitimately fall back to the
                         compile-aot :target-device staging fn (e.g. the AD-GEMM boundary test).
 
-   :gemm-precision sets the resident :gemm binding policy CARRIED on the descriptor
-   (bind-program! reads it; a bind-time caller may still override with
-   (assoc descriptor :gemm-precision …)):
+   :gemm-precision sets the resident :gemm binding policy. It is now deprecated SUGAR for the S6
+   schedule's [:schedule :precision] (the source of truth bind-program! reads). A bind-time caller
+   overrides the policy on the plain-data descriptor with (assoc-in descriptor [:schedule :precision] …)
+   — NOT (assoc descriptor :gemm-precision …), which the resolved schedule now shadows:
      :f16-xmx (default) — convert A/B f32→f16, XMX gemm, f32 C accumulate/output. The
                           mixed-precision (AMP) policy: f16 INPUTS, f32 math. Costs ~1e-3
                           relative gradient noise (f16 mantissa, cosine similarity to the

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -952,7 +952,10 @@
                                   " — bind each program under a distinct :key")
                              {:key pkey :bound (keys (:programs @sess))})))
          {:keys [dtype all-params array-params allocs steps]} descriptor
-         gemm-precision (or (:gemm-precision descriptor) :f16-xmx)
+         ;; precision reads from the resolved S6 schedule (source of truth); :gemm-precision is
+         ;; back-compat sugar for a descriptor built before the schedule field, or one hand-assoc'd.
+         gemm-precision (or (get-in descriptor [:schedule :precision])
+                            (:gemm-precision descriptor) :f16-xmx)
          effective-roles (merge (:array-roles descriptor) roles)
          argmap (zipmap all-params args)
          dt (if (= dtype :double) :double :float)

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -923,9 +923,10 @@
                      (no events, no overhead); run-program! on a profiled program still works
                      (it resets the events after each replay).
 
-   :gemm steps bind per the descriptor's :gemm-precision policy (set at compile time by
-   compile-gpu-program, default :f16-xmx; a bind-time caller may override with
-   (assoc descriptor :gemm-precision …) since the descriptor is plain data):
+   :gemm steps bind per the resolved S6 schedule's precision — [:schedule :precision] (set at
+   compile time by compile-gpu-program, default :f16-xmx). :gemm-precision on the descriptor is a
+   back-compat fallback for a hand-built descriptor with no :schedule. A bind-time caller overrides
+   the plain-data descriptor with (assoc-in descriptor [:schedule :precision] …):
      :f16-xmx    — convert A/B f32→f16 and run the XMX gemm (f32 accumulate/output): the
                    mixed-precision (AMP) policy — f16 inputs, f32 math. Valid for BACKWARD
                    programs too (measured on the real gemma-3-270m layer VJP: adapter grads

--- a/src/raster/gpu/schedule.clj
+++ b/src/raster/gpu/schedule.clj
@@ -1,0 +1,164 @@
+(ns raster.gpu.schedule
+  "The schedule layer (S6) — schedule-as-DATA plus the register-budget feasibility gate.
+
+   A `Schedule` is an EDN map attached to a compiled artifact (rides on the `Compiled`
+   record's `:schedule` field). It unifies the four scattered representations of today's
+   tuning knobs — the `gemm-schedule` pure fn, the `:gemm-precision` descriptor field, the
+   `*gemm-splitk-*` dynamic vars, and the hardcoded launch geometry — into ONE inspectable,
+   pinnable structure, and adds the piece all three reference compilers (Halide anderson2021,
+   oneDNN, Triton) have and raster lacked: a register-budget feasibility gate that rejects an
+   infeasible schedule at COMPILE time instead of discovering it as a measurement-time spill.
+
+   PR-1 scope (see .internal/schedule_layer_design.md §4): the representation + the gate + the
+   ONE robust axis (precision) wired end-to-end. Launch-geometry unification (the 256-literal
+   kill), split-k promotion, and the autotuner are later increments. The dead inner-loop knobs
+   (`:grf`, `:stage`) have a HOME here as opt-in, default-off data policed by the gate — never
+   an untracked emitter branch.
+
+   Three-stage mechanism (per axis): descriptor-derived default → optional data override →
+   (deferred) autotuner. `derive-default` and `feasible?` both take the HardwareDescriptor as an
+   ARGUMENT (probed OR supplied) so target-aware compilation is 'pass a different descriptor',
+   not a retrofit — the Intel-GRF vs AMD-VGPR budget flows through the same gate."
+  (:refer-clojure :exclude [resolve])
+  (:require [raster.compiler.core.hardware :as hw]))
+
+;; ================================================================
+;; Stage 1 — derive-default
+;; ================================================================
+
+(def ^:private default-precision
+  "The one POLICY axis. Training default: mixed-precision f16 GEMM inputs, f32 accumulate —
+   the measured-robust 2.33× backward speedup at grads cosine 1.000."
+  :f16-xmx)
+
+(defn- machine-params
+  "The cost/legality numbers the schedule carries in :meta for inspection + the gate."
+  [desc]
+  {:machine-lanes      (:machine-lanes desc 8192)
+   :grf-bytes-per-lane (:grf-bytes-per-lane desc 256)
+   :subgroup           (:subgroup-size desc (:subgroup desc 16))})
+
+(defn derive-default
+  "Stage 1: (program-steps × HardwareDescriptor) → Schedule. Replaces hardcodes with analytic
+   descriptor values. PR-1 wires the precision axis; :grf/:stage are the dead-knob homes,
+   default OFF (:grf128 / :stage :none) so the emitter never sees a dead default on.
+
+   opts: {:precision :f16-xmx|:f32-scalar}  — policy override of the training default."
+  ([desc] (derive-default nil desc {}))
+  ([steps desc] (derive-default steps desc {}))
+  ([steps desc {:keys [precision]}]
+   {:precision (or precision default-precision)
+    :grf   {:mode :grf128}                     ;; axis 8a — OPT-IN, default OFF
+    :stage {:space :none}                      ;; axis 7a — DEAD family, default :none
+    :meta  {:target (:device-id desc)
+            :machine-params (machine-params desc)
+            :derived-by :raster.gpu.schedule/derive-default
+            :overrides #{}
+            :autotuned-at nil}}))
+
+;; ================================================================
+;; Stage 2 — resolve (data override deep-merged onto the default)
+;; ================================================================
+
+(defn- deep-merge
+  [a b]
+  (cond
+    (and (map? a) (map? b)) (merge-with deep-merge a b)
+    (some? b) b
+    :else a))
+
+(defn resolve
+  "Stage 2: deep-merge a user `override` schedule onto the derived default, recording the pinned
+   top-level keys in :meta :overrides. `:gemm-precision` is deprecated sugar: an override of
+   `{:gemm-precision p}` writes `{:precision p}`. Returns the resolved Schedule."
+  [derived override]
+  (if (nil? override)
+    derived
+    (let [override  (if-let [p (:gemm-precision override)]
+                      (-> override (dissoc :gemm-precision) (assoc :precision p))
+                      override)
+          pinned    (set (remove #{:meta} (keys override)))
+          merged    (deep-merge derived override)]
+      (update-in merged [:meta :overrides] (fnil into #{}) pinned))))
+
+;; ================================================================
+;; Stage 3 — the register-budget feasibility gate (axis 8b)
+;; ================================================================
+
+(defn- grf-budget-bytes-per-lane
+  "The per-lane GRF budget for the schedule's GRF mode. grf256 doubles the file."
+  [schedule desc]
+  (let [base (long (:grf-bytes-per-lane desc 256))]
+    (if (= :grf256 (get-in schedule [:grf :mode]))
+      (* 2 base)
+      base)))
+
+(defn- acc-bytes-per-lane
+  "Accumulator footprint per lane by precision. The f16-xmx accumulator (8 float8 = 256 B/lane
+   at grf128) FILLS the register file — the design's core finding, and why ANY register staging
+   on top of it spills. :f32-scalar uses a quarter of the file."
+  [schedule budget]
+  (case (:precision schedule)
+    :f16-xmx    budget
+    :f32-scalar (quot budget 4)
+    budget))
+
+(defn- register-staged-bytes-per-lane
+  "GRF charge of the staging schedule. ONLY :space :register consumes the register file; :slm /
+   :l3 / :none stage into SLM/L3 and cost nothing against the GRF budget (the design's measured
+   lesson: the winning staging space is L3/SLM, never register). Each register-staged operand
+   copy is a quarter-file operand panel."
+  [schedule budget]
+  (let [{:keys [space copies]} (:stage schedule)]
+    (if (= space :register)
+      (let [n-copies (+ (long (get copies :a 0)) (long (get copies :b 0)))]
+        (* n-copies (quot budget 4)))
+      0)))
+
+(defn feasible?
+  "The register-budget feasibility gate: (Schedule × HardwareDescriptor) → true | (throw).
+   Called after `resolve`, before emission, so the emitter never sees an infeasible schedule.
+   Requires `acc + register-staged ≤ GRF-budget` per lane. Fail-loud (raster-native); a
+   `minimize()` fallback is deferred until an autotuner generates candidates.
+
+   Anchors (grf128, 256 B/lane): the default f16-xmx GEMM with :stage :none is 256 ≤ 256 → OK;
+   register double-buffering both operands is 256 + 4×64 = 512 > 256 → REJECTED at compile time
+   (precisely the measurement-time spill, turned into a loud rejection)."
+  [schedule desc]
+  (let [budget (grf-budget-bytes-per-lane schedule desc)
+        acc    (acc-bytes-per-lane schedule budget)
+        staged (register-staged-bytes-per-lane schedule budget)
+        req    (+ acc staged)]
+    (when (> req budget)
+      (throw (ex-info (str "schedule/feasible?: register budget exceeded — " req
+                           " B/lane required > " budget " B/lane available"
+                           " (grf mode " (get-in schedule [:grf :mode] :grf128) ", precision "
+                           (:precision schedule) ", stage " (:stage schedule) ")."
+                           " Move staging to :slm/:l3, drop copies, or (if deep-K) opt into :grf256.")
+                      {:required-bytes-per-lane req
+                       :budget-bytes-per-lane budget
+                       :acc-bytes-per-lane acc
+                       :register-staged-bytes-per-lane staged
+                       :schedule schedule})))
+    true))
+
+;; ================================================================
+;; Convenience — the whole stage-1→2→3 pipeline
+;; ================================================================
+
+(defn schedule-for
+  "Derive → resolve → gate in one call. Returns the feasible resolved Schedule (or throws at
+   the gate). `override` may be nil. `policy` carries derive-default opts (e.g. {:precision …})."
+  ([steps desc] (schedule-for steps desc nil nil))
+  ([steps desc override] (schedule-for steps desc override nil))
+  ([steps desc override policy]
+   (let [sched (resolve (derive-default steps desc (or policy {})) override)]
+     (feasible? sched desc)
+     sched)))
+
+(defn schedule-for-device
+  "schedule-for against the descriptor PROBED for `device-id` — the live-device convenience the
+   compiler uses. (Target-aware compilation for an ABSENT target passes a supplied descriptor to
+   `schedule-for` instead.)"
+  [steps device-id override policy]
+  (schedule-for steps (hw/descriptor-for device-id) override policy))

--- a/src/raster/gpu/schedule.clj
+++ b/src/raster/gpu/schedule.clj
@@ -67,17 +67,28 @@
     (some? b) b
     :else a))
 
+(def ^:private valid-precisions #{:f16-xmx :f32-scalar})
+(def ^:private valid-stage-spaces #{:none :slm :l3 :register})
+(def ^:private valid-grf-modes #{:grf128 :grf256})
+
 (defn resolve
   "Stage 2: deep-merge a user `override` schedule onto the derived default, recording the pinned
-   top-level keys in :meta :overrides. `:gemm-precision` is deprecated sugar: an override of
-   `{:gemm-precision p}` writes `{:precision p}`. Returns the resolved Schedule."
+   top-level keys in :meta :overrides. `:gemm-precision` is deprecated sugar for `:precision`.
+   A user `:meta` is NOT allowed to clobber the derived machine-params (stripped before merge).
+   Throws on a `{:gemm-precision X :precision Y}` conflict rather than silently letting the
+   deprecated key win."
   [derived override]
   (if (nil? override)
     derived
-    (let [override  (if-let [p (:gemm-precision override)]
-                      (-> override (dissoc :gemm-precision) (assoc :precision p))
-                      override)
-          pinned    (set (remove #{:meta} (keys override)))
+    (let [gp (:gemm-precision override)
+          _ (when (and gp (:precision override) (not= gp (:precision override)))
+              (throw (ex-info (str "schedule/resolve: conflicting :gemm-precision " gp
+                                   " and :precision " (:precision override)
+                                   " — pass one (prefer :precision; :gemm-precision is deprecated sugar)")
+                              {:gemm-precision gp :precision (:precision override)})))
+          override  (cond-> (dissoc override :meta)   ;; user :meta never clobbers machine-params
+                      gp (-> (dissoc :gemm-precision) (assoc :precision gp)))
+          pinned    (set (keys override))
           merged    (deep-merge derived override)]
       (update-in merged [:meta :overrides] (fnil into #{}) pinned))))
 
@@ -85,8 +96,27 @@
 ;; Stage 3 — the register-budget feasibility gate (axis 8b)
 ;; ================================================================
 
+;; The byte model charges KERNEL-TILE properties against the per-lane GRF budget — NOT fractions
+;; of the budget (an earlier draft did, which coupled the accumulator to the budget and made the
+;; gate unable to detect an accumulator that spills on a smaller budget). The accumulator and the
+;; staged-operand panel are fixed footprints of the emitted XMX tile; the budget is the device's.
+(def ^:private xmx-f16-acc-bytes-per-lane
+  "Per-lane accumulator footprint of the emitted f16 XMX tile: 8 float8 = 8×8×4 = 256 B/lane.
+   A CONSTANT of the kernel tile (independent of the device's GRF budget), so the gate detects a
+   tile whose accumulator alone exceeds a smaller-budget device. When descriptor `:matrix {:tile
+   …}` lands (HIP/CUDA follow-up) this is derived as tile_m/lane × tile_n × 4; 256 is the current
+   Arc XMX tile."
+  256)
+
+(def ^:private operand-panel-bytes-per-lane
+  "Per-lane footprint of ONE register-staged operand panel (a quarter of the f16 accumulator tile).
+   Register double-buffering both operands is 4 panels = 256 B/lane — on top of the 256 B/lane
+   accumulator that is the measured grf128 spill."
+  64)
+
 (defn- grf-budget-bytes-per-lane
-  "The per-lane GRF budget for the schedule's GRF mode. grf256 doubles the file."
+  "The per-lane GRF budget for the schedule's GRF mode. grf256 doubles the register file — so it
+   genuinely buys headroom the accumulator+staging can use (the accumulator does NOT scale with it)."
   [schedule desc]
   (let [base (long (:grf-bytes-per-lane desc 256))]
     (if (= :grf256 (get-in schedule [:grf :mode]))
@@ -94,25 +124,24 @@
       base)))
 
 (defn- acc-bytes-per-lane
-  "Accumulator footprint per lane by precision. The f16-xmx accumulator (8 float8 = 256 B/lane
-   at grf128) FILLS the register file — the design's core finding, and why ANY register staging
-   on top of it spills. :f32-scalar uses a quarter of the file."
-  [schedule budget]
+  "Accumulator footprint per lane by precision — a fixed kernel-tile property. f16-xmx uses the
+   full XMX accumulator tile; :f32-scalar a quarter of it (no wide MMA accumulator)."
+  [schedule]
   (case (:precision schedule)
-    :f16-xmx    budget
-    :f32-scalar (quot budget 4)
-    budget))
+    :f16-xmx    xmx-f16-acc-bytes-per-lane
+    :f32-scalar (quot xmx-f16-acc-bytes-per-lane 4)
+    xmx-f16-acc-bytes-per-lane))
 
 (defn- register-staged-bytes-per-lane
   "GRF charge of the staging schedule. ONLY :space :register consumes the register file; :slm /
-   :l3 / :none stage into SLM/L3 and cost nothing against the GRF budget (the design's measured
-   lesson: the winning staging space is L3/SLM, never register). Each register-staged operand
-   copy is a quarter-file operand panel."
-  [schedule budget]
-  (let [{:keys [space copies]} (:stage schedule)]
+   :l3 / :none stage into SLM/L3 and cost nothing against the GRF budget (the measured lesson: the
+   winning staging space is L3/SLM, never register). Charge = Σcopies × depth × operand-panel —
+   `:depth` (the staging ring depth) is honored, so deeper staging costs proportionally more."
+  [schedule]
+  (let [{:keys [space copies depth]} (:stage schedule)]
     (if (= space :register)
       (let [n-copies (+ (long (get copies :a 0)) (long (get copies :b 0)))]
-        (* n-copies (quot budget 4)))
+        (* n-copies (long (or depth 1)) operand-panel-bytes-per-lane))
       0)))
 
 (defn feasible?
@@ -125,16 +154,31 @@
    register double-buffering both operands is 256 + 4×64 = 512 > 256 → REJECTED at compile time
    (precisely the measurement-time spill, turned into a loud rejection)."
   [schedule desc]
+  ;; validate the resolved schedule BEFORE pricing it — an unmodeled precision / stage-space / grf
+  ;; mode (e.g. a :bf16 typo, or `:regsiter`) must FAIL LOUD here, not slip past into a silent XMX
+  ;; bind (the #{:f16-xmx :f32-scalar} kwarg check upstream only sees the sugar, not a :schedule).
+  (let [prec  (:precision schedule)
+        space (get-in schedule [:stage :space] :none)
+        grf   (get-in schedule [:grf :mode] :grf128)]
+    (when-not (valid-precisions prec)
+      (throw (ex-info (str "schedule: unknown :precision " (pr-str prec) " — expected " valid-precisions)
+                      {:precision prec})))
+    (when-not (valid-stage-spaces space)
+      (throw (ex-info (str "schedule: unknown :stage :space " (pr-str space) " — expected " valid-stage-spaces)
+                      {:space space})))
+    (when-not (valid-grf-modes grf)
+      (throw (ex-info (str "schedule: unknown :grf :mode " (pr-str grf) " — expected " valid-grf-modes)
+                      {:grf grf}))))
   (let [budget (grf-budget-bytes-per-lane schedule desc)
-        acc    (acc-bytes-per-lane schedule budget)
-        staged (register-staged-bytes-per-lane schedule budget)
+        acc    (acc-bytes-per-lane schedule)
+        staged (register-staged-bytes-per-lane schedule)
         req    (+ acc staged)]
     (when (> req budget)
       (throw (ex-info (str "schedule/feasible?: register budget exceeded — " req
                            " B/lane required > " budget " B/lane available"
                            " (grf mode " (get-in schedule [:grf :mode] :grf128) ", precision "
                            (:precision schedule) ", stage " (:stage schedule) ")."
-                           " Move staging to :slm/:l3, drop copies, or (if deep-K) opt into :grf256.")
+                           " Move staging to :slm/:l3, drop copies/depth, or opt into :grf256.")
                       {:required-bytes-per-lane req
                        :budget-bytes-per-lane budget
                        :acc-bytes-per-lane acc

--- a/test/raster/dl/gemma_train_resident_test.clj
+++ b/test/raster/dl/gemma_train_resident_test.clj
@@ -366,8 +366,12 @@
           args (train-args cfg st0 lr)
           p32 (pl/compile-gpu-program #'gblk-train-step :ze:0 :dtype :float
                                       :on-non-resident :nil :gemm-precision :f32-scalar)
-          ;; the descriptor is plain data: the policy is a bind-time re-tag, same program
-          p16 (assoc p32 :gemm-precision :f16-xmx)]
+          ;; the descriptor is plain data: the precision is a bind-time re-tag on the SAME program.
+          ;; The S6 schedule is the source of truth bind-program! reads, so the override goes
+          ;; through [:schedule :precision] (NOT the deprecated top-level :gemm-precision, which the
+          ;; schedule now shadows — assoc'ing it would be a silent no-op and both trajectories would
+          ;; run f32).
+          p16 (assoc-in p32 [:schedule :precision] :f16-xmx)]
       (is (some? p32) "train-step must extract fully resident")
       (when p32
         (let [dims (gemm-dims p32 args)]

--- a/test/raster/gpu/schedule_test.clj
+++ b/test/raster/gpu/schedule_test.clj
@@ -1,0 +1,112 @@
+(ns raster.gpu.schedule-test
+  "S6 PR-1 acceptance: schedule-as-data + the register-budget feasibility gate.
+
+   T1–T3 are device-free (the schedule is pure data+fns). T4 checks the schedule threads
+   through compile-gpu-program and the gate fires on the real Arc."
+  (:require [clojure.test :refer [deftest testing is]]
+            [raster.gpu.schedule :as sched]
+            [raster.dl.gpu-grad-parity :as gp]
+            [raster.compiler.pipeline :as pl]))
+
+;; A hand-built Arc-140V-shaped descriptor (grf128, subgroup 16 → 256 B/lane) — lets the pure
+;; schedule fns be tested with no live device.
+(def ^:private arc-desc
+  {:device-type :gpu :device-id :ze:0
+   :machine-lanes 8192 :subgroup-size 16 :grf-bytes-per-lane 256
+   :max-workgroup-size 1024})
+
+;; ════════════════════════════════════════════════════════════════════════════════
+;; T1 — parity: :gemm-precision sugar ≡ :schedule {:precision …} (no device)
+;; ════════════════════════════════════════════════════════════════════════════════
+
+(deftest t1-precision-parity
+  (let [derived (sched/derive-default nil arc-desc)]
+    (testing "the deprecated :gemm-precision sugar resolves to the same :precision as an explicit override"
+      (is (= :f32-scalar (:precision (sched/resolve derived {:gemm-precision :f32-scalar}))))
+      (is (= :f32-scalar (:precision (sched/resolve derived {:precision :f32-scalar}))))
+      (is (= (sched/resolve derived {:gemm-precision :f32-scalar})
+             (sched/resolve derived {:precision :f32-scalar}))
+          "sugar and explicit override produce byte-identical schedules"))
+    (testing "the default policy is f16-xmx (training AMP)"
+      (is (= :f16-xmx (:precision derived))))
+    (testing "a pinned override is recorded in :meta :overrides"
+      (is (contains? (get-in (sched/resolve derived {:precision :f32-scalar}) [:meta :overrides])
+                     :precision)))))
+
+;; ════════════════════════════════════════════════════════════════════════════════
+;; T2 — the gate: rejects register double-buffering, passes the default (no device)
+;; ════════════════════════════════════════════════════════════════════════════════
+
+(deftest t2-feasibility-gate
+  (testing "the DEFAULT f16-xmx GEMM (stage :none) is feasible at grf128 — 256 ≤ 256"
+    (is (true? (sched/feasible? (sched/derive-default nil arc-desc) arc-desc))))
+  (testing "f32-scalar (quarter-file accumulator) is comfortably feasible"
+    (is (true? (sched/feasible? (sched/resolve (sched/derive-default nil arc-desc)
+                                               {:precision :f32-scalar})
+                                arc-desc))))
+  (testing "register double-buffering BOTH operands on f16-xmx at grf128 is REJECTED before emit"
+    (let [infeasible (sched/resolve (sched/derive-default nil arc-desc)
+                                    {:stage {:space :register :copies {:a 2 :b 2}}})
+          ex (try (sched/feasible? infeasible arc-desc) nil
+                  (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+      (is (some? ex) "must throw an ex-info, not silently pass")
+      (is (= 512 (:required-bytes-per-lane ex)) "256 acc + 4×64 staged = 512")
+      (is (= 256 (:budget-bytes-per-lane ex)))
+      (is (> (:required-bytes-per-lane ex) (:budget-bytes-per-lane ex)))))
+  (testing "SLM/L3 staging is FREE against the GRF budget (the winning staging space)"
+    (is (true? (sched/feasible? (sched/resolve (sched/derive-default nil arc-desc)
+                                               {:stage {:space :slm :copies {:a 2 :b 2}}})
+                                arc-desc))))
+  (testing "grf256 DOUBLES the budget (opt-in, for the deep-K follow-up)"
+    (let [s (sched/resolve (sched/derive-default nil arc-desc)
+                           {:grf {:mode :grf256} :stage {:space :register :copies {:a 1 :b 0}}})]
+      ;; f16-xmx acc scales with the file (512), + 1×128 staged = 640 > 512 → still rejected,
+      ;; but a f32-scalar acc (128) + 128 staged = 256 ≤ 512 fits.
+      (is (true? (sched/feasible? (assoc s :precision :f32-scalar) arc-desc))))))
+
+;; ════════════════════════════════════════════════════════════════════════════════
+;; T3 — derive-default: no dead knobs on by default (no device)
+;; ════════════════════════════════════════════════════════════════════════════════
+
+(deftest t3-derived-default
+  (let [d (sched/derive-default nil arc-desc)]
+    (testing "precision default is f16-xmx"
+      (is (= :f16-xmx (:precision d))))
+    (testing "the dead inner-loop knobs are OFF by default"
+      (is (= :grf128 (get-in d [:grf :mode])))
+      (is (= :none (get-in d [:stage :space]))))
+    (testing ":meta carries the machine params the gate reads"
+      (is (= 256 (get-in d [:meta :machine-params :grf-bytes-per-lane])))
+      (is (= 16 (get-in d [:meta :machine-params :subgroup])))
+      (is (= :ze:0 (get-in d [:meta :target]))))))
+
+;; ════════════════════════════════════════════════════════════════════════════════
+;; T4 — the schedule threads through compile-gpu-program + the gate fires (device)
+;; ════════════════════════════════════════════════════════════════════════════════
+
+(deftest t4-schedule-flows-through-compile
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "S6 schedule threads through compile-gpu-program")
+    (let [hw (requiring-resolve 'raster.compiler.core.hardware/descriptor-for)
+          desc (hw :ze:0)]
+      (testing "descriptor-for exposes the real Arc GRF budget"
+        (is (= 256 (:grf-bytes-per-lane desc))
+            "Arc 140V grf128, subgroup 16 → 256 B/lane")
+        (is (= 16 (:subgroup-size desc))))
+      (require 'raster.dl.gemma-train-resident-test)
+      (let [step-var (ns-resolve 'raster.dl.gemma-train-resident-test 'gblk-train-step)]
+        (testing ":gemm-precision sugar and :schedule override both resolve on the descriptor"
+          (let [via-sugar (pl/compile-gpu-program step-var :ze:0 :dtype :float
+                                                  :on-non-resident :nil :gemm-precision :f32-scalar)
+                via-sched (pl/compile-gpu-program step-var :ze:0 :dtype :float
+                                                  :on-non-resident :nil
+                                                  :schedule {:precision :f32-scalar})]
+            (is (= :f32-scalar (get-in via-sugar [:schedule :precision])))
+            (is (= :f32-scalar (get-in via-sched [:schedule :precision])))
+            (is (= :f32-scalar (:gemm-precision via-sugar))
+                "back-compat :gemm-precision mirrors the resolved precision")))
+        (testing "a pinned INFEASIBLE schedule is rejected at compile (reject-before-emit)"
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo #"register budget exceeded"
+               (pl/compile-gpu-program step-var :ze:0 :dtype :float :on-non-resident :nil
+                                       :schedule {:stage {:space :register :copies {:a 2 :b 2}}}))))))))

--- a/test/raster/gpu/schedule_test.clj
+++ b/test/raster/gpu/schedule_test.clj
@@ -57,12 +57,43 @@
     (is (true? (sched/feasible? (sched/resolve (sched/derive-default nil arc-desc)
                                                {:stage {:space :slm :copies {:a 2 :b 2}}})
                                 arc-desc))))
-  (testing "grf256 DOUBLES the budget (opt-in, for the deep-K follow-up)"
-    (let [s (sched/resolve (sched/derive-default nil arc-desc)
-                           {:grf {:mode :grf256} :stage {:space :register :copies {:a 1 :b 0}}})]
-      ;; f16-xmx acc scales with the file (512), + 1×128 staged = 640 > 512 → still rejected,
-      ;; but a f32-scalar acc (128) + 128 staged = 256 ≤ 512 fits.
-      (is (true? (sched/feasible? (assoc s :precision :f32-scalar) arc-desc))))))
+  (testing "grf256 DOUBLES the budget and GENUINELY unblocks register staging (acc is fixed, not budget-coupled)"
+    ;; the accumulator is a fixed 256 B/lane tile property; grf256 lifts the budget to 512, so
+    ;; register double-buffering both operands (256 acc + 256 staged = 512) now FITS — the knob is
+    ;; not pointless (the earlier budget-coupled model made grf256 useless for f16-xmx).
+    (let [g128 (sched/resolve (sched/derive-default nil arc-desc)
+                              {:stage {:space :register :copies {:a 2 :b 2}}})
+          g256 (sched/resolve (sched/derive-default nil arc-desc)
+                              {:grf {:mode :grf256} :stage {:space :register :copies {:a 2 :b 2}}})]
+      (is (thrown? clojure.lang.ExceptionInfo (sched/feasible? g128 arc-desc)) "rejected at grf128")
+      (is (true? (sched/feasible? g256 arc-desc)) "same schedule FITS at grf256 (512 ≤ 512)")))
+  (testing "deeper staging costs proportionally more (:depth is honored, not ignored)"
+    (let [d1 (sched/resolve (sched/derive-default nil arc-desc)
+                            {:grf {:mode :grf256} :stage {:space :register :copies {:a 2 :b 0} :depth 1}})
+          d3 (sched/resolve (sched/derive-default nil arc-desc)
+                            {:grf {:mode :grf256} :stage {:space :register :copies {:a 2 :b 0} :depth 3}})]
+      (is (true? (sched/feasible? d1 arc-desc)) "depth 1: 256 + 2×1×64 = 384 ≤ 512")
+      (is (thrown? clojure.lang.ExceptionInfo (sched/feasible? d3 arc-desc))
+          "depth 3: 256 + 2×3×64 = 640 > 512")))
+  (testing "FALSE-NEGATIVE guard: a smaller-budget (subgroup-32) device REJECTS the default f16-xmx"
+    ;; the dangerous case the budget-coupled model missed: on a 128 B/lane device the 256 B/lane
+    ;; accumulator genuinely spills — the fixed-acc model detects it; a budget-coupled acc would
+    ;; have charged acc=budget=128 and passed.
+    (let [sg32 (assoc arc-desc :grf-bytes-per-lane 128 :subgroup-size 32)]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (sched/feasible? (sched/derive-default nil sg32) sg32))
+          "default f16-xmx tile (256 B/lane acc) does NOT fit a 128 B/lane budget")))
+  (testing "unmodeled precision / stage-space FAIL LOUD (not a silent XMX bind)"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"unknown :precision"
+                          (sched/feasible? (sched/resolve (sched/derive-default nil arc-desc)
+                                                          {:precision :bf16}) arc-desc)))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"unknown :stage :space"
+                          (sched/feasible? (sched/resolve (sched/derive-default nil arc-desc)
+                                                          {:stage {:space :regsiter}}) arc-desc))))
+  (testing "conflicting :gemm-precision sugar and :precision throw, not silently prefer the deprecated key"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"conflicting"
+                          (sched/resolve (sched/derive-default nil arc-desc)
+                                         {:gemm-precision :f16-xmx :precision :f32-scalar})))))
 
 ;; ════════════════════════════════════════════════════════════════════════════════
 ;; T3 — derive-default: no dead knobs on by default (no device)


### PR DESCRIPTION
The first S6 PR from `.internal/schedule_layer_design.md` §7: unifies the scattered tuning knobs into one inspectable **Schedule map** and adds the correctness structure raster lacked — a **register-budget feasibility gate** that rejects an infeasible schedule at compile time instead of discovering it as a measurement-time GRF spill.

## What lands

**`raster.gpu.schedule`** — the standalone data + pure-fn ns (depends only on `hardware`; consumed by both `compile-gpu-program` today and `r/compile` under S4). Three stages:
- `derive-default : (steps × HardwareDescriptor) → Schedule` — precision policy (default `:f16-xmx` training AMP) + the dead-knob homes `:grf`/`:stage`, **default OFF** (`:grf128` / `:stage :none`).
- `resolve` — deep-merge a user override onto the default; `:gemm-precision` is deprecated sugar → `:precision`.
- `feasible?` — the gate. Requires `acc + register-staged ≤ GRF-budget` per lane. The f16-xmx accumulator (256 B/lane) fills the grf128 file, so **any** register staging spills — precisely the measured double-buffering regression, turned into a loud compile-time rejection. SLM/L3 staging is free against GRF (the winning space).

`derive-default` and `feasible?` take the descriptor **as an argument** (probed *or* supplied), so target-aware compilation is "pass a different descriptor" — Intel GRF vs AMD VGPR flow through the same gate.

**`hardware.clj`** — `descriptor-for` exposes `:grf-bytes-per-lane` (128 GRF regs × 32 B / subgroup; Arc 140V grf128 subgroup-16 = **256 B/lane**) and `:subgroup-size`.

**`pipeline.clj`** — `compile-gpu-program` accepts `:schedule`, derives+resolves+**gates** it before emission, carries it on the descriptor. `:gemm-precision` → sugar; derived default replaces the `:or` literal.

**`core.clj`** — `bind-program!` reads `:precision` from the resolved schedule (source of truth), `:gemm-precision` fallback for hand-built descriptors. Behavior-identical.

## Acceptance — `test/raster/gpu/schedule_test.clj`, 25 assertions

- **T1 (no device)** `:gemm-precision` sugar ≡ `:schedule {:precision …}` — byte-identical schedules.
- **T2 (no device)** the gate: default f16-xmx passes (256 ≤ 256); register double-buffer both operands rejects (256 + 4×64 = 512 > 256); SLM/L3 free; grf256 doubles the budget.
- **T3 (no device)** `derive-default`: f16-xmx, grf128, stage `:none` — no dead knobs on by default.
- **T4 (device, Arc `ze:0`)** `descriptor-for` → 256 B/lane; schedule threads through `compile-gpu-program`; a pinned **infeasible** schedule is rejected at compile (reject-before-emit on the real path).

**No regression:** gemma resident + mixed-precision suites green (160 assertions); the f16-xmx vs f32-scalar loss trajectories are bit-identical through the new representation.

## Deferred (explicitly out of scope)

The autotuner (cold verdicts killed the inner-loop tiling axes — no headroom to search); `minimize()` fallback; launch-geometry unification (the 256-literal kill, PR-2); per-kernel `(op × shape-class)` keying (arrives with PR-2).