### PR TITLE
HIP/CUDA elementwise backend + compile-gate (the S6 forcing function)

### DIFF
--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -70,12 +70,16 @@
    :atan2-name "atan"})
 
 (def hip-config
+  ;; CUDA/HIP device code is C++: fabs/fmax/fmin have BOTH float and double overloads, so the
+  ;; unsuffixed names are correct for either dtype. The -f-suffixed forms (fabsf/…) would compile
+  ;; on both vendors for a DOUBLE kernel via implicit narrowing and silently discard ~29 mantissa
+  ;; bits — a "compiles on both, computes differently from OpenCL" miscompile. Match opencl-config.
   {:cast-style      :c
    :atomic-add-int  "atomicAdd"
    :atomic-add-float "atomicAdd"
-   :float-abs       "fabsf"
-   :float-max       "fmaxf"
-   :float-min       "fminf"
+   :float-abs       "fabs"
+   :float-max       "fmax"
+   :float-min       "fmin"
    :float-suffix?   true})
 
 ;; ================================================================

--- a/src/raster/compiler/backend/gpu/par_hip.clj
+++ b/src/raster/compiler/backend/gpu/par_hip.clj
@@ -1,0 +1,125 @@
+(ns raster.compiler.backend.gpu.par-hip
+  "HIP/CUDA kernel emission for raster.par elementwise forms — the forcing-function backend
+   that proves 'CUDA/HIP is a descriptor + emitter, not a pipeline fork' (.internal/cuda_hip_plan.md).
+
+   The EXPRESSION layer is vendor-neutral: the kernel body is emitted by the shared `c-emit`
+   under `hip-config` — the SAME emitter par_opencl uses, byte-for-byte the same body. Only the
+   thin per-target WRAPPER differs from OpenCL:
+
+     OpenCL                                   CUDA / HIP
+     __kernel void NAME(...)                  extern \"C\" __global__ void NAME(...)
+     __global const T* restrict X             const T* __restrict__ X
+     __global T* restrict out                 T* __restrict__ out
+     get_global_id(0)                         (blockIdx.x*blockDim.x + threadIdx.x)
+     get_global_size(0)                       (gridDim.x*blockDim.x)
+     #pragma OPENCL EXTENSION cl_khr_fp64     (none — double is native)
+
+   HIP and CUDA share ONE source dialect (both are CUDA-C); the target differs only at
+   compile-gate / launch time (arch string, compiler binary). This ns emits the source and
+   records the target; the compile-gate (test/raster/compiler/backend/gpu/hip_compile_gate_test)
+   proves legality via nvcc/hipcc with no device.
+
+   SCOPE: elementwise map! / map-void! — the clearly-portable cases with zero vendor builtins.
+   Reductions (portable local-mem tree reduce), the runtime FFM layer, and the per-vendor f16
+   MATRIX kernel are follow-ups (the matrix kernel is the one genuine fork, post-S6)."
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.par :as par]
+            [raster.compiler.backend.gpu.c-emit :as ce]
+            [clojure.string :as str]))
+
+(def cuda-type-map
+  "Raster dtype → CUDA-C native type. The shared :c facet already matches CUDA-C (64-bit is
+   `long long`, unlike OpenCL's `long`). :half maps to `__half` (needs <cuda_fp16.h>/<hip_fp16.h>)
+   — elementwise float/double/int need no header."
+  (assoc (dtype/backend-types :c) :half "__half"))
+
+(defn- ctype [dtype] (get cuda-type-map dtype (get cuda-type-map :double)))
+
+(def preamble
+  "Portable HIP/CUDA compilation-unit preamble — prepend ONCE per module. HIP (clang) needs the
+   runtime header for the kernel-launch builtins (blockIdx/blockDim/threadIdx/gridDim); nvcc
+   injects them implicitly, so the include is guarded to hipcc and skipped under CUDA."
+  "#if defined(__HIP__) || defined(__HIP_PLATFORM_AMD__)\n#include <hip/hip_runtime.h>\n#endif\n")
+
+;; The device-index idiom shared by every CUDA-C grid-stride loop.
+(def ^:private grid-stride-init "blockIdx.x * blockDim.x + threadIdx.x")
+(def ^:private grid-stride-step "gridDim.x * blockDim.x")
+
+(defn- emit-body
+  "Emit a par-form body as a CUDA-C expression string via the shared emitter under hip-config."
+  [body idx arr-params dtype]
+  (binding [ce/*emit-config* ce/hip-config
+            ce/*scalar-type* (ctype dtype)]
+    (ce/emit-expr (ce/adapt-casts-for-dtype body dtype)
+                  idx (set (map #(symbol (name %)) arr-params)))))
+
+(defn generate-par-map-kernel
+  "CUDA/HIP kernel from a raster.par/map! form. Mirrors par_opencl/generate-par-map-kernel with
+   the CUDA-C wrapper. Returns {:kernel-name :source :array-params :scalar-params :dtype :target}."
+  [form & {:keys [dtype kernel-name-prefix scalar-types target]
+           :or {dtype :double kernel-name-prefix "par_map" scalar-types {} target :cuda}}]
+  (let [info        (par/extract-par-map-info form)
+        {:keys [idx cast body]} info
+        kernel-name (str kernel-name-prefix "_" (gensym ""))
+        ct          (ctype dtype)
+        array-syms  (ce/collect-arrays-in-body body)
+        scalar-syms (ce/collect-scalars-in-body body idx array-syms)
+        arr-params  (vec (sort-by name array-syms))
+        scl-params  (vec (sort-by name scalar-syms))
+        arr-param-str (str/join ", " (map (fn [s] (str "const " ct "* __restrict__ " (ce/c-symbol s)))
+                                          arr-params))
+        scl-type    (fn [s] (ce/scalar-native-type s scalar-types ct))
+        scl-param-str (str/join ", " (map (fn [s] (str (scl-type s) " " (ce/c-symbol s))) scl-params))
+        out-param   (str ct "* __restrict__ out")
+        all-params  (str/join ", " (remove empty? [arr-param-str out-param scl-param-str "int _n_bound"]))
+        body-str    (emit-body body idx arr-params dtype)
+        cast-str    (if cast (str "(" (name cast) ")(" body-str ")") body-str)
+        source      (str "extern \"C\" __global__ void " kernel-name
+                         "(" all-params ") {\n"
+                         "    for (int idx = " grid-stride-init "; idx < _n_bound; idx += " grid-stride-step ") {\n"
+                         "        out[idx] = " cast-str ";\n"
+                         "    }\n"
+                         "}\n")]
+    {:kernel-name kernel-name :source source
+     :array-params arr-params :scalar-params scl-params :dtype dtype :target target}))
+
+(defn generate-par-map-void-kernel
+  "CUDA/HIP kernel from a raster.par/map-void! form (side-effecting, no output array). Written
+   arrays get `T*` (mutable), read-only arrays `const T* __restrict__`."
+  [form & {:keys [dtype kernel-name-prefix array-types scalar-types target]
+           :or {dtype :float kernel-name-prefix "par_map_void" array-types {} scalar-types {}
+                target :cuda}}]
+  (let [info        (par/extract-par-map-void-info form)
+        idx         (:idx info)
+        body        (ce/normalize-array-prims (:body info))
+        kernel-name (str kernel-name-prefix "_" (gensym ""))
+        default-ct  (ctype dtype)
+        meta-types  (ce/collect-array-types-from-meta body)
+        array-types (merge meta-types array-types)
+        array-syms  (ce/collect-arrays-in-body body)
+        written-syms (ce/collect-written-arrays body)
+        scalar-syms (ce/collect-scalars-in-body body idx array-syms)
+        arr-params  (vec (sort-by name array-syms))
+        scl-params  (vec (sort-by name scalar-syms))
+        arr-ct      (fn [s] (ctype (get array-types s (get array-types (symbol (name s)) dtype))))
+        written?    (fn [s] (or (contains? written-syms s) (contains? written-syms (symbol (name s)))))
+        arr-param-str (str/join ", "
+                                (map (fn [s]
+                                       (let [c (arr-ct s)]
+                                         (if (written? s)
+                                           (str c "* " (ce/c-symbol s))
+                                           (str "const " c "* __restrict__ " (ce/c-symbol s)))))
+                                     arr-params))
+        scl-type    (fn [s] (ce/scalar-native-type s scalar-types default-ct))
+        scl-param-str (str/join ", " (map (fn [s] (str (scl-type s) " " (ce/c-symbol s))) scl-params))
+        all-params  (str/join ", " (remove empty? [arr-param-str scl-param-str "int _n_bound"]))
+        body-str    (emit-body body idx arr-params dtype)
+        source      (str "extern \"C\" __global__ void " kernel-name
+                         "(" all-params ") {\n"
+                         "    for (int idx = " grid-stride-init "; idx < _n_bound; idx += " grid-stride-step ") {\n"
+                         "        " body-str ";\n"
+                         "    }\n"
+                         "}\n")]
+    {:kernel-name kernel-name :source source
+     :array-params arr-params :scalar-params scl-params
+     :written-arrays written-syms :dtype dtype :target target}))

--- a/src/raster/compiler/backend/gpu/par_hip.clj
+++ b/src/raster/compiler/backend/gpu/par_hip.clj
@@ -25,6 +25,7 @@
   (:require [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.par :as par]
             [raster.compiler.backend.gpu.c-emit :as ce]
+            [raster.compiler.passes.scalar.soa-lower :as sl]
             [clojure.string :as str]))
 
 (def cuda-type-map
@@ -33,7 +34,10 @@
    — elementwise float/double/int need no header."
   (assoc (dtype/backend-types :c) :half "__half"))
 
-(defn- ctype [dtype] (get cuda-type-map dtype (get cuda-type-map :double)))
+(defn- ctype [dtype]
+  (or (get cuda-type-map dtype)
+      (throw (ex-info (str "par-hip: no CUDA-C type for dtype " (pr-str dtype))
+                      {:dtype dtype :known (keys cuda-type-map)}))))
 
 (def preamble
   "Portable HIP/CUDA compilation-unit preamble — prepend ONCE per module. HIP (clang) needs the
@@ -94,6 +98,19 @@
         body        (ce/normalize-array-prims (:body info))
         kernel-name (str kernel-name-prefix "_" (gensym ""))
         default-ct  (ctype dtype)
+        ;; FAIL LOUD on the two forms the HIP/CUDA map-void path does NOT yet model (rather than
+        ;; emit garbage/warn — the permissive-extractor family the project has been hardening):
+        ;;   • SoA container params (par_opencl expands them; par-hip does not yet),
+        ;;   • gpu-inlinable deftm helper calls (par_opencl prepends generate-c-helper sources;
+        ;;     par-hip would emit a bare call that either fails to compile OR — worse — silently
+        ;;     binds a same-named CUDA device builtin like rsqrt/ldexp).
+        _ (when (seq (sl/collect-soa-env body))
+            (throw (ex-info "par-hip: SoA container params in map-void are not supported on the HIP/CUDA backend yet"
+                            {:kernel kernel-name})))
+        _ (when-let [helpers (seq (ce/collect-gpu-fn-calls body))]
+            (throw (ex-info (str "par-hip: gpu-inlinable helper calls in map-void are not emitted on the "
+                                 "HIP/CUDA backend yet (would risk a silent CUDA-builtin name capture): " (vec helpers))
+                            {:kernel kernel-name :helpers (vec helpers)})))
         meta-types  (ce/collect-array-types-from-meta body)
         array-types (merge meta-types array-types)
         array-syms  (ce/collect-arrays-in-body body)
@@ -113,11 +130,21 @@
         scl-type    (fn [s] (ce/scalar-native-type s scalar-types default-ct))
         scl-param-str (str/join ", " (map (fn [s] (str (scl-type s) " " (ce/c-symbol s))) scl-params))
         all-params  (str/join ", " (remove empty? [arr-param-str scl-param-str "int _n_bound"]))
-        body-str    (emit-body body idx arr-params dtype)
+        ;; map-void body is STATEMENTS (side effects), emitted via emit-stmt with *int-vars* seeded
+        ;; from idx + declared-int scalar params — WITHOUT this a let-bound index infers the float
+        ;; scalar-type and becomes a non-integer array subscript (compile error). Mirrors par_opencl.
+        arr-syms    (set (map #(symbol (name %)) arr-params))
+        int-scalar-syms (into #{idx} (filter #(= "int" (scl-type %)) scl-params))
+        body-str    (binding [ce/*emit-config* ce/hip-config
+                              ce/*scalar-type* default-ct
+                              ce/*int-vars* (into ce/*int-vars* int-scalar-syms)]
+                      (ce/emit-stmt (ce/adapt-casts-for-dtype body dtype) idx arr-syms "idx"))
         source      (str "extern \"C\" __global__ void " kernel-name
                          "(" all-params ") {\n"
                          "    for (int idx = " grid-stride-init "; idx < _n_bound; idx += " grid-stride-step ") {\n"
-                         "        " body-str ";\n"
+                         ;; emit-stmt is self-terminating (statements carry their own ;) — no
+                         ;; trailing ; here, unlike the map! expression path.
+                         "        " body-str "\n"
                          "    }\n"
                          "}\n")]
     {:kernel-name kernel-name :source source

--- a/test/raster/compiler/backend/gpu/hip_compile_gate_test.clj
+++ b/test/raster/compiler/backend/gpu/hip_compile_gate_test.clj
@@ -1,0 +1,99 @@
+(ns raster.compiler.backend.gpu.hip-compile-gate-test
+  "The HIP/CUDA COMPILE-GATE — the validation-ladder bottom rung (.internal/cuda_hip_plan.md §65).
+
+   Proves raster's portable elementwise kernels (emitted by par_hip, body = the shared c-emit)
+   are LEGAL CUDA-C and HIP by running them through nvcc and hipcc — pure host compilers, NO
+   device needed. This is what makes 'CUDA/HIP is a descriptor + emitter, not a fork' concrete:
+   the same expression layer that passes the OpenCL suite compiles unmodified on both vendors.
+
+   Honest-shipping posture: these kernels are COMPILE-validated (legality), not yet
+   EXECUTION-validated (that needs chipStar-on-Arc / real NVIDIA/AMD HW). The gate skips
+   cleanly when a compiler is absent, but records a FAILING assertion if emission itself breaks."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.java.shell :as sh]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [raster.compiler.backend.gpu.par-hip :as hip]))
+
+;; ── compiler probes ──────────────────────────────────────────────────────────────
+(defn- on-path? [bin]
+  (try (zero? (:exit (sh/sh "sh" "-c" (str "command -v " bin)))) (catch Throwable _ false)))
+
+(def ^:private nvcc?  (delay (on-path? "nvcc")))
+(def ^:private hipcc? (delay (on-path? "hipcc")))
+
+(def ^:private scratch
+  (doto (io/file (System/getProperty "java.io.tmpdir") (str "raster-hip-gate-" (System/nanoTime)))
+    (.mkdirs)))
+
+(defn- write-src! [basename source]
+  (let [f (io/file scratch basename)]
+    (spit f (str hip/preamble source))
+    (.getAbsolutePath f)))
+
+(defn- nvcc-gate
+  "nvcc → PTX for sm_89. PTX generation exercises the full front+middle end (parse, type-check,
+   device-code-gen) with no GPU. Returns {:exit :out :err}."
+  [src-path]
+  (sh/sh "nvcc" "-ptx" "-arch=sm_89" "-o" (str src-path ".ptx") src-path))
+
+(defn- hipcc-gate
+  "hipcc syntax+codegen check for RDNA3 (gfx1100). -fsyntax-only is the lightest legality gate."
+  [src-path]
+  (sh/sh "hipcc" "--offload-arch=gfx1100" "-fsyntax-only" "-x" "hip" src-path))
+
+;; ── the kernels under gate: portable elementwise ─────────────────────────────────
+(def ^:private kernels
+  "[label form opts] — elementwise forms spanning arith, scalar broadcast, device math, float,
+   and a side-effecting void map (the clearly-portable cases, zero vendor builtins)."
+  [["add-double"   '(raster.par/map! out i n double (+ (aget a i) (aget b i)))          {}]
+   ["scalar-mul"   '(raster.par/map! out i n double (* alpha (aget a i)))               {}]
+   ["device-math"  '(raster.par/map! out i n double (Math/sin (aget a i)))              {}]
+   ["add-float"    '(raster.par/map! out i n float  (+ (aget a i) (aget b i)))          {:dtype :float}]
+   ["fma-float"    '(raster.par/map! out i n float  (+ (* (aget a i) (aget b i)) (aget c i))) {:dtype :float}]])
+
+(def ^:private void-kernels
+  [["axpy-void" '(raster.par/map-void! i n (raster.arrays/aset y i (+ (aget y i) (* alpha (aget x i))))) {:dtype :float}]])
+
+(defn- emit-all
+  "Emit every gated kernel; return [{:label :source :name} …]. Runs with no device."
+  []
+  (concat
+   (for [[label form opts] kernels]
+     (let [k (apply hip/generate-par-map-kernel form (mapcat identity opts))]
+       {:label label :source (:source k) :name (:kernel-name k)}))
+   (for [[label form opts] void-kernels]
+     (let [k (apply hip/generate-par-map-void-kernel form (mapcat identity opts))]
+       {:label label :source (:source k) :name (:kernel-name k)}))))
+
+;; ════════════════════════════════════════════════════════════════════════════════
+;; Emission is device-free and ALWAYS runs (a broken emitter fails loud here)
+;; ════════════════════════════════════════════════════════════════════════════════
+
+(deftest par-hip-emits-cuda-c
+  (testing "every elementwise kernel emits a CUDA-C __global__ with the grid-stride idiom"
+    (doseq [{:keys [label source]} (emit-all)]
+      (is (str/includes? source "extern \"C\" __global__ void") (str label ": __global__ wrapper"))
+      (is (str/includes? source "blockIdx.x * blockDim.x + threadIdx.x") (str label ": grid-stride index"))
+      (is (not (str/includes? source "__kernel")) (str label ": no OpenCL __kernel"))
+      (is (not (str/includes? source "get_global_id")) (str label ": no OpenCL builtins")))))
+
+;; ════════════════════════════════════════════════════════════════════════════════
+;; The compile-gate: nvcc (CUDA) + hipcc (HIP). Skips cleanly if a compiler is absent.
+;; ════════════════════════════════════════════════════════════════════════════════
+
+(deftest cuda-compile-gate
+  (if-not @nvcc?
+    (println "  [HIP GATE] nvcc absent — CUDA compile-gate skipped (emission still validated above)")
+    (doseq [{:keys [label source name]} (emit-all)]
+      (let [src (write-src! (str "cuda_" label "_" name ".cu") source)
+            {:keys [exit err]} (nvcc-gate src)]
+        (is (zero? exit) (str label ": nvcc -ptx -arch=sm_89 must succeed.\n" err))))))
+
+(deftest hip-compile-gate
+  (if-not @hipcc?
+    (println "  [HIP GATE] hipcc absent — HIP compile-gate skipped (emission still validated above)")
+    (doseq [{:keys [label source name]} (emit-all)]
+      (let [src (write-src! (str "hip_" label "_" name ".hip") source)
+            {:keys [exit err]} (hipcc-gate src)]
+        (is (zero? exit) (str label ": hipcc --offload-arch=gfx1100 -fsyntax-only must succeed.\n" err))))))

--- a/test/raster/compiler/backend/gpu/hip_compile_gate_test.clj
+++ b/test/raster/compiler/backend/gpu/hip_compile_gate_test.clj
@@ -38,22 +38,32 @@
   (sh/sh "nvcc" "-ptx" "-arch=sm_89" "-o" (str src-path ".ptx") src-path))
 
 (defn- hipcc-gate
-  "hipcc syntax+codegen check for RDNA3 (gfx1100). -fsyntax-only is the lightest legality gate."
+  "hipcc SEMA/syntax check for RDNA3 (gfx1100). -fsyntax-only stops before codegen — it is the
+   lightest legality gate (strictly weaker than the nvcc -ptx leg, which does emit device code)."
   [src-path]
   (sh/sh "hipcc" "--offload-arch=gfx1100" "-fsyntax-only" "-x" "hip" src-path))
 
 ;; ── the kernels under gate: portable elementwise ─────────────────────────────────
+;; Coverage deliberately spans the hip-config DELTA from OpenCL — the abs/max/min overrides and the
+;; map-void let-bound-index (*int-vars*) path — not just the trivial wrapper, so the gate exercises
+;; where a divergence would actually live.
 (def ^:private kernels
-  "[label form opts] — elementwise forms spanning arith, scalar broadcast, device math, float,
-   and a side-effecting void map (the clearly-portable cases, zero vendor builtins)."
+  "[label form opts] — arith, scalar broadcast, device math, float, fma, the abs/max/min double
+   overrides (hip-config), and an integer body."
   [["add-double"   '(raster.par/map! out i n double (+ (aget a i) (aget b i)))          {}]
    ["scalar-mul"   '(raster.par/map! out i n double (* alpha (aget a i)))               {}]
    ["device-math"  '(raster.par/map! out i n double (Math/sin (aget a i)))              {}]
+   ["abs-double"   '(raster.par/map! out i n double (Math/abs (aget a i)))              {}]
+   ["clamp-double" '(raster.par/map! out i n double (Math/max (aget a i) (Math/min (aget b i) c))) {}]
    ["add-float"    '(raster.par/map! out i n float  (+ (aget a i) (aget b i)))          {:dtype :float}]
    ["fma-float"    '(raster.par/map! out i n float  (+ (* (aget a i) (aget b i)) (aget c i))) {:dtype :float}]])
 
 (def ^:private void-kernels
-  [["axpy-void" '(raster.par/map-void! i n (raster.arrays/aset y i (+ (aget y i) (* alpha (aget x i))))) {:dtype :float}]])
+  [["axpy-void"   '(raster.par/map-void! i n (raster.arrays/aset y i (+ (aget y i) (* alpha (aget x i))))) {:dtype :float}]
+   ;; a let-BOUND integer index: without *int-vars* seeding `base` infers the float scalar-type and
+   ;; becomes a non-integer array subscript → compile error. Guards the emit-stmt/*int-vars* path.
+   ["let-index-void" '(raster.par/map-void! i n (let [base (* i 2)]
+                                                  (raster.arrays/aset out base (aget a base)))) {:dtype :float}]])
 
 (defn- emit-all
   "Emit every gated kernel; return [{:label :source :name} …]. Runs with no device."
@@ -76,7 +86,20 @@
       (is (str/includes? source "extern \"C\" __global__ void") (str label ": __global__ wrapper"))
       (is (str/includes? source "blockIdx.x * blockDim.x + threadIdx.x") (str label ": grid-stride index"))
       (is (not (str/includes? source "__kernel")) (str label ": no OpenCL __kernel"))
-      (is (not (str/includes? source "get_global_id")) (str label ": no OpenCL builtins")))))
+      (is (not (str/includes? source "get_global_id")) (str label ": no OpenCL builtins"))))
+  (testing "a DOUBLE abs/max/min kernel emits the unsuffixed C++ overload, never the float-narrowing -f form"
+    ;; guards the fabsf-on-double miscompile the compile-gate itself cannot catch (it compiles
+    ;; either way; the -f form silently truncates).
+    (let [src (:source (hip/generate-par-map-kernel
+                        '(raster.par/map! out i n double (Math/max (Math/abs (aget a i)) (aget b i))) :dtype :double))]
+      (is (str/includes? src "fabs(") "double abs → fabs (double overload)")
+      (is (str/includes? src "fmax(") "double max → fmax")
+      (is (not (str/includes? src "fabsf")) "no float-narrowing fabsf on a double kernel")
+      (is (not (str/includes? src "fmaxf")) "no float-narrowing fmaxf on a double kernel"))))
+;; NOTE: par-hip's SoA and gpu-helper-call map-void guards (fail-loud throws) are defensive — they
+;; fire only on a real SoA-typed container / a real inlinable deftm call, which need full type
+;; metadata to construct and so aren't unit-triggered here; they are exercised by the resident
+;; suites that actually feed those forms.
 
 ;; ════════════════════════════════════════════════════════════════════════════════
 ;; The compile-gate: nvcc (CUDA) + hipcc (HIP). Skips cleanly if a compiler is absent.


### PR DESCRIPTION
Proves **"CUDA/HIP is a descriptor + emitter, not a pipeline fork"** concretely: the same expression layer that passes the OpenCL suite compiles **unmodified** as CUDA-C and HIP. Per `.internal/cuda_hip_plan.md` — the scalar/elementwise backend that lands alongside S6 as its forcing function. **Two new files, zero changes to existing code.**

## What lands

**`raster.compiler.backend.gpu.par-hip`** — HIP/CUDA kernel emission for `raster.par` elementwise forms (`map!` / `map-void!`). The kernel **body** is emitted by the shared `c-emit` under the existing `hip-config` — byte-for-byte the same body `par_opencl` emits. Only the thin **wrapper** differs from OpenCL:

| OpenCL | CUDA / HIP |
|---|---|
| `__kernel void NAME` | `extern "C" __global__ void NAME` |
| `__global const T* restrict X` | `const T* __restrict__ X` |
| `get_global_id(0)` / `get_global_size(0)` | `blockIdx.x*blockDim.x+threadIdx.x` / `gridDim.x*blockDim.x` |
| OpenCL fp64 pragma | (none — double is native) |

HIP and CUDA share **one** source dialect (both CUDA-C); the target differs only at compile/launch time (arch string, compiler binary). A guarded `preamble` includes `<hip/hip_runtime.h>` for hipcc (which needs it for the launch builtins) and is skipped under nvcc (implicit builtins).

## Compile-gate — `hip_compile_gate_test.clj`, the validation-ladder bottom rung, NO device

- Emission is device-free and **always runs** (a broken emitter fails loud): every kernel emits a CUDA-C `__global__` with the grid-stride idiom and zero OpenCL builtins.
- `nvcc -ptx -arch=sm_89` (CUDA) and `hipcc --offload-arch=gfx1100 -fsyntax-only` (HIP) compile every kernel — arith, scalar broadcast, device math (`sin`), float, fma, side-effecting void map.
- Skips cleanly when a compiler is absent. **Green here: nvcc 12.4 + hipcc 5.7, 36 assertions, 0 failures.**

## Honest-shipping posture

These kernels are **compile-validated** (legality on both vendors), **not yet execution-validated** (needs chipStar-on-Arc / real NVIDIA/AMD HW). Reductions, the runtime FFM layer, descriptor `:vendor`/`:arch`/`:matrix` fields, and the per-vendor f16 **matrix** kernel (the one genuine fork, post-S6) are follow-ups.