### PR TITLE
#38 GEMM-as-late-recognizer — PR-A: recognizers (device-free, Design-S neutral)

### DIFF
--- a/src/raster/compiler/passes/parallel/gemm_recognize.clj
+++ b/src/raster/compiler/passes/parallel/gemm_recognize.clj
@@ -21,6 +21,7 @@
    `dotimes` matmul. A Screma-level lift (Design B, catches par/map+par/reduce
    dense) reuses this same index/variance/extraction core."
   (:require [raster.compiler.passes.parallel.patterns :as pat]
+            [raster.compiler.ir.soac :as soac]
             [raster.compiler.core.op-descriptor :as descriptor]))
 
 (def ^:private canonical-add #{'+ 'clojure.core/+ 'raster.numeric/+})
@@ -168,3 +169,15 @@
         ;; result-sym = the do's tail buffer, unless the tail IS the store dotimes
         ;; itself (no explicit result) — then the output C is the result.
         (assoc d :result-sym (if (and (some? tail) (not= tail nest)) tail (:C d)))))))
+
+(defn redomap->dot
+  "Build the Dot IR node (the late-recognizer OUTPUT, Feature 4) from a
+   match-gemm-* descriptor + the binding id/sym. This is Dot's first real producer:
+   the node was defined with dep-graph + epilogue-emit support but never constructed
+   outside a test. inputs = {A B}, outputs = {C} (the producer edge that closes the
+   soac-outputs leak), bound = m*n, alpha/beta from the descriptor, epilogue/layout
+   nil (later vertical fusion / transpose-elim fill them). This is what the resident
+   Screma-level recognizer (Design B) emits in place of the map/reduce SOACs."
+  [id sym {:keys [A B C m n k variant alpha beta]}]
+  (soac/->Dot id sym #{A B} #{C} (list 'clojure.core/* m n)
+              A B C m n k variant (or alpha 1.0) (or beta 0.0) nil nil nil))

--- a/src/raster/compiler/passes/parallel/gemm_recognize.clj
+++ b/src/raster/compiler/passes/parallel/gemm_recognize.clj
@@ -112,7 +112,7 @@
       (when (and (seq? body) (contains? aset-syms (first body)) (= 4 (count body)))
         (let [[_ c-sym idx-c stored] body]
           (when (and (symbol? c-sym)
-                     (pat/row-major-linear-index? idx-c i j n))   ;; C[i,j], m×n
+                     (pat/row-major-linear-index? idx-c i j n))    ;; C[i,j], m×n
             ;; strip an optional store cast, then split off an accumulating (β=1) add.
             (let [uncast (if (and (seq? stored) (= 2 (count stored))
                                   (contains? value-casts (first stored)))
@@ -138,3 +138,22 @@
                                :A (:arr gA) :B (:arr gB) :C c-sym
                                :m m :n n :k k :alpha 1.0 :beta beta})))]
                   (or (assign ga gb) (assign gb ga)))))))))))
+
+(defn match-gemm-redomap
+  "Match a GEMM redomap as it appears in a let* BINDING VALUE — either a bare
+   nested `dotimes`, or a `(do … (dotimes …) result)` wrapper (the matmul writes C
+   as a side effect, then yields the result buffer). Returns the match-gemm-loop-nest
+   descriptor augmented with :result-sym (the do's tail expr, or C when the store is
+   the tail) — the exact shape gpu-plan/rewrite-gemm consumes, so the redomap front
+   door reuses the BLAS emission path verbatim. nil if not a GEMM redomap."
+  [expr]
+  (let [[nest tail] (if (and (seq? expr) (= 'do (first expr)))
+                      (let [body (rest expr)]
+                        [(some #(when (and (seq? %) (= 'dotimes (first %))) %) body)
+                         (last body)])
+                      [expr nil])]
+    (when nest
+      (when-let [d (match-gemm-loop-nest nest)]
+        ;; result-sym = the do's tail buffer, unless the tail IS the store dotimes
+        ;; itself (no explicit result) — then the output C is the result.
+        (assoc d :result-sym (if (and (some? tail) (not= tail nest)) tail (:C d)))))))

--- a/src/raster/compiler/passes/parallel/gemm_recognize.clj
+++ b/src/raster/compiler/passes/parallel/gemm_recognize.clj
@@ -170,6 +170,58 @@
         ;; itself (no explicit result) — then the output C is the result.
         (assoc d :result-sym (if (and (some? tail) (not= tail nest)) tail (:C d)))))))
 
+;; ── Design B: the Screma/SoacMap-level recognizer (the RESIDENT front door) ──────
+;; A par-form matmul `(par/map-void! ij (* m n) … (aset C ij <k-dot>))` lowers to ONE
+;; SoacMap whose lambda is the inner k-dot, with the outer (i,j) INLINED as
+;; (quot ij N)/(rem ij N) in the operand indices. Same tileable-redomap, different
+;; surface — reuses match-inner-dot + row-major variance via structural extraction.
+(def ^:private quot-ops #{'quot 'clojure.core/quot})
+(def ^:private rem-ops  #{'rem 'clojure.core/rem})
+
+(defn- add3 "(+-op a b) → [a b], else nil." [e]
+  (when (and (seq? e) (= 3 (count e)) (descriptor/addition-op? (first e))) (vec (rest e))))
+(defn- mul3 "(*-op a b) → [a b], else nil." [e]
+  (when (and (seq? e) (= 3 (count e)) (descriptor/multiplication-op? (first e))) (vec (rest e))))
+
+(defn- extract-m
+  "From a flat map bound = (* M N) and the recovered N, return M (the other factor), else nil."
+  [bound n]
+  (when-let [[a b] (mul3 bound)]
+    (cond (= b n) a (= a n) b)))
+
+(defn match-gemm-screma
+  "Match a flat par-form matmul SoacMap → {:variant :A :B :C :m :k :n :alpha :beta},
+   else nil. Recognizes the :nn shape (A row-major(quot idx N, p, K); B
+   row-major(p, rem idx N, N)); declines transposes/other shapes (sound — narrower,
+   never a false positive). CONSERVATIVE proven-or-nil: a false positive would emit a
+   tiled XMX kernel for a non-GEMM SoacMap (a silent miscompile). `redomap->dot` turns
+   the result into the Dot node the resident emit consumes."
+  [node]
+  (when (and (instance? raster.compiler.ir.soac.SoacMap node)
+             (= 1 (count (:outputs node))))
+    (let [idx   (:idx node)
+          bound (:bound node)
+          c-sym (first (:outputs node))]
+      (when-let [{:keys [p k ga gb]} (match-inner-dot (:lambda node))]
+        (letfn [(quot-idx? [e n] (and (seq? e) (contains? quot-ops (first e)) (= 3 (count e))
+                                      (= idx (nth e 1)) (= n (nth e 2))))
+                (rem-idx?  [e n] (and (seq? e) (contains? rem-ops (first e)) (= 3 (count e))
+                                      (= idx (nth e 1)) (= n (nth e 2))))
+                (assign-nn [gA gB]
+                  ;; B index = (+ (* p N) (rem idx N)) — recover N, require the rem
+                  (when-let [[mulB colB] (add3 (:idx gB))]
+                    (when-let [[pB nB] (mul3 mulB)]
+                      (when (and (= p pB) (rem-idx? colB nB))
+                        ;; A index = (+ (* (quot idx N) K) p)
+                        (when-let [[mulA pA] (add3 (:idx gA))]
+                          (when (= p pA)
+                            (when-let [[rowA kA] (mul3 mulA)]
+                              (when (and (quot-idx? rowA nB) (= k kA))
+                                (when-let [m (extract-m bound nB)]
+                                  {:variant :nn :A (:arr gA) :B (:arr gB) :C c-sym
+                                   :m m :n nB :k k :alpha 1.0 :beta 0.0})))))))))]
+          (or (assign-nn ga gb) (assign-nn gb ga)))))))
+
 (defn redomap->dot
   "Build the Dot IR node (the late-recognizer OUTPUT, Feature 4) from a
    match-gemm-* descriptor + the binding id/sym. This is Dot's first real producer:

--- a/src/raster/compiler/passes/parallel/gemm_recognize.clj
+++ b/src/raster/compiler/passes/parallel/gemm_recognize.clj
@@ -47,11 +47,22 @@
         {:sym sym :bound bound :body (first body)}))))
 
 (defn- aget-affine
-  "(aget arr idx-expr) → {:arr :idx}, else nil. idx-expr may be affine (not bare)."
+  "An array read `(aget arr idx-expr)` → {:arr :idx}, else nil. idx-expr may be
+   affine (not bare). Handles BOTH the literal head and a devirtualized
+   `(.invk impl arr idx)` whose :raster.op/original is an aget op — so the matcher
+   fires whether or not the walker has lowered array reads by this pipeline stage.
+   A missed match is only a missed offload (safe-fail), never a miscompile."
   [form]
-  (when (and (seq? form) (contains? aget-syms (first form)) (= 3 (count form))
-             (symbol? (second form)))
-    {:arr (second form) :idx (nth form 2)}))
+  (when (seq? form)
+    (cond
+      ;; literal (aget arr idx)
+      (and (contains? aget-syms (first form)) (= 3 (count form)) (symbol? (second form)))
+      {:arr (second form) :idx (nth form 2)}
+      ;; devirtualized (.invk impl arr idx) with :raster.op/original an aget op
+      (contains? aget-syms (descriptor/semantic-op form))
+      (let [args (descriptor/call-args form)]
+        (when (and (= 2 (count args)) (symbol? (first args)))
+          {:arr (first args) :idx (second args)})))))
 
 (defn- a-variant
   "Transpose of the A operand from its index shape, or nil.

--- a/src/raster/compiler/passes/parallel/gemm_recognize.clj
+++ b/src/raster/compiler/passes/parallel/gemm_recognize.clj
@@ -194,8 +194,9 @@
    else nil. Recognizes the :nn shape (A row-major(quot idx N, p, K); B
    row-major(p, rem idx N, N)); declines transposes/other shapes (sound — narrower,
    never a false positive). CONSERVATIVE proven-or-nil: a false positive would emit a
-   tiled XMX kernel for a non-GEMM SoacMap (a silent miscompile). `redomap->dot` turns
-   the result into the Dot node the resident emit consumes."
+   tiled XMX kernel for a non-GEMM SoacMap (a silent miscompile). The descriptor is the
+   GEMM *schedule payload* — the resident pass attaches it as a `:gemm` facet on this
+   SoacMap (Design S), which then dispatches to emit-gemm-tiled while staying a SOAC."
   [node]
   (when (and (instance? raster.compiler.ir.soac.SoacMap node)
              (= 1 (count (:outputs node))))
@@ -221,15 +222,3 @@
                                   {:variant :nn :A (:arr gA) :B (:arr gB) :C c-sym
                                    :m m :n nB :k k :alpha 1.0 :beta 0.0})))))))))]
           (or (assign-nn ga gb) (assign-nn gb ga)))))))
-
-(defn redomap->dot
-  "Build the Dot IR node (the late-recognizer OUTPUT, Feature 4) from a
-   match-gemm-* descriptor + the binding id/sym. This is Dot's first real producer:
-   the node was defined with dep-graph + epilogue-emit support but never constructed
-   outside a test. inputs = {A B}, outputs = {C} (the producer edge that closes the
-   soac-outputs leak), bound = m*n, alpha/beta from the descriptor, epilogue/layout
-   nil (later vertical fusion / transpose-elim fill them). This is what the resident
-   Screma-level recognizer (Design B) emits in place of the map/reduce SOACs."
-  [id sym {:keys [A B C m n k variant alpha beta]}]
-  (soac/->Dot id sym #{A B} #{C} (list 'clojure.core/* m n)
-              A B C m n k variant (or alpha 1.0) (or beta 0.0) nil nil nil))

--- a/src/raster/compiler/passes/parallel/gemm_recognize.clj
+++ b/src/raster/compiler/passes/parallel/gemm_recognize.clj
@@ -1,0 +1,140 @@
+(ns raster.compiler.passes.parallel.gemm-recognize
+  "Structural recognizer for a GEMM redomap — a matmul written in the raster
+   language as a nested map over C[i,j] with an inner k-reduction of the product
+   of two array reads. It extracts the SAME descriptor the BLAS-name-match
+   (gpu-plan/match-gemm-call) emits — {:variant :A :B :C :m :k :n :alpha :beta} —
+   so both front doors converge on ONE emission path (emit-gemm-tiled) instead of
+   the redomap falling through to the naive per-element SegOp kernel.
+
+   This is Futhark's `isTileableRedomap`: the register-tiling precondition is that
+   the reduction inputs are INVARIANT along one tile dimension (A invariant in j,
+   B invariant in i). That invariance IS the affine-index shape checked here — A
+   indexed by (i,p), B by (p,j) — so the variance test falls out of
+   `row-major-linear-index?` rather than needing a separate analysis.
+
+   PURE + device-free. CONSERVATIVE by mandate: a false positive would dispatch a
+   tiled XMX kernel for a non-GEMM redomap — a silent miscompile — so every
+   structural condition is PROVEN or the matcher returns nil. Stage-2 gates any
+   match numerically (bit-identical to the naive redomap) as a backstop.
+
+   Stage 1 = the loop-nest (Design A) matcher: a hand-written / lowered nested
+   `dotimes` matmul. A Screma-level lift (Design B, catches par/map+par/reduce
+   dense) reuses this same index/variance/extraction core."
+  (:require [raster.compiler.passes.parallel.patterns :as pat]
+            [raster.compiler.core.op-descriptor :as descriptor]))
+
+(def ^:private canonical-add #{'+ 'clojure.core/+ 'raster.numeric/+})
+(def ^:private canonical-mul #{'* 'clojure.core/* 'raster.numeric/*})
+(def ^:private aget-syms descriptor/aget-ops)
+(def ^:private aset-syms descriptor/aset-ops)
+(def ^:private value-casts #{'double 'float 'int 'long})
+
+(defn- zero-init?
+  "A dot-product accumulator must start at 0 (0, 0.0, (double 0.0), (float 0))."
+  [expr]
+  (or (and (number? expr) (zero? expr))
+      (and (seq? expr) (= 2 (count expr))
+           (contains? value-casts (first expr))
+           (number? (second expr)) (zero? (second expr)))))
+
+(defn- peel-dotimes
+  "(dotimes [sym bound] single-body) → {:sym :bound :body}, else nil."
+  [form]
+  (when (and (seq? form) (= 'dotimes (first form))
+             (vector? (second form)) (= 2 (count (second form))))
+    (let [[_ [sym bound] & body] form]
+      (when (and (symbol? sym) (= 1 (count body)))
+        {:sym sym :bound bound :body (first body)}))))
+
+(defn- aget-affine
+  "(aget arr idx-expr) → {:arr :idx}, else nil. idx-expr may be affine (not bare)."
+  [form]
+  (when (and (seq? form) (contains? aget-syms (first form)) (= 3 (count form))
+             (symbol? (second form)))
+    {:arr (second form) :idx (nth form 2)}))
+
+(defn- a-variant
+  "Transpose of the A operand from its index shape, or nil.
+     :n → A is m×k, index = (+ (* i k) p)  (row-major (i,p), cols k)
+     :t → A is k×m, index = (+ (* p m) i)  (row-major (p,i), cols m)"
+  [idx i p m k]
+  (cond (pat/row-major-linear-index? idx i p k) :n
+        (pat/row-major-linear-index? idx p i m) :t))
+
+(defn- b-variant
+  "Transpose of the B operand from its index shape, or nil.
+     :n → B is k×n, index = (+ (* p n) j)  (row-major (p,j), cols n)
+     :t → B is n×k, index = (+ (* j k) p)  (row-major (j,p), cols k)"
+  [idx p j n k]
+  (cond (pat/row-major-linear-index? idx p j n) :n
+        (pat/row-major-linear-index? idx j p k) :t))
+
+(defn- match-inner-dot
+  "The inner k-reduction `(loop [acc 0 p 0] (if (< p k) (recur (+ acc (* (aget A idxA)
+   (aget B idxB))) (inc p)) acc))`. Returns {:p :k :ga :gb} (the reduce index/bound and
+   the two affine aget operands) or nil. Operand ORDER is as written; the caller
+   resolves which is A vs B by index shape."
+  [loop-form]
+  (when-let [{:keys [acc-init index-sym bound-expr update-expr acc-sym]}
+             (pat/match-reduce-loop loop-form)]
+    (when (and (zero-init? acc-init)
+               (seq? update-expr)
+               (contains? canonical-add (descriptor/semantic-op update-expr)))
+      (let [[ua ub] (descriptor/call-args update-expr)
+            prod (cond (= ua acc-sym) ub (= ub acc-sym) ua)]
+        (when (and prod (seq? prod)
+                   (contains? canonical-mul (descriptor/semantic-op prod)))
+          (let [args (descriptor/call-args prod)]
+            (when (= 2 (count args))
+              (let [ga (aget-affine (first args))
+                    gb (aget-affine (second args))]
+                (when (and ga gb)
+                  {:p index-sym :k bound-expr :ga ga :gb gb})))))))))
+
+(defn match-gemm-loop-nest
+  "Match a nested-`dotimes` GEMM redomap. Returns
+     {:variant :A :B :C :m :k :n :alpha :beta}
+   (identical to gpu-plan/match-gemm-call — the shared emission contract) or nil.
+
+   Recognized shape (α=1; β∈{0 fresh-store, 1 accumulating-store}):
+     (dotimes [i m]
+       (dotimes [j n]
+         (aset C (+ (* i n) j)
+           [(+ (aget C (+ (* i n) j))]                 ; present ⇒ β=1
+             (loop [acc 0 p 0]
+               (if (< p k)
+                 (recur (+ acc (* (aget A idxA) (aget B idxB))) (inc p))
+                 acc)))))
+   idxA/idxB may carry either transpose (row/col swapped), yielding :nn/:nt/:tn/:tt."
+  [form]
+  (when-let [{i :sym m :bound inner :body} (peel-dotimes form)]
+    (when-let [{j :sym n :bound body :body} (peel-dotimes inner)]
+      (when (and (seq? body) (contains? aset-syms (first body)) (= 4 (count body)))
+        (let [[_ c-sym idx-c stored] body]
+          (when (and (symbol? c-sym)
+                     (pat/row-major-linear-index? idx-c i j n))   ;; C[i,j], m×n
+            ;; strip an optional store cast, then split off an accumulating (β=1) add.
+            (let [uncast (if (and (seq? stored) (= 2 (count stored))
+                                  (contains? value-casts (first stored)))
+                           (second stored) stored)
+                  c-read? (fn [e] (and (seq? e) (contains? aget-syms (first e))
+                                       (= 3 (count e)) (= c-sym (second e)) (= idx-c (nth e 2))))
+                  [beta inner-loop]
+                  (if (and (seq? uncast)
+                           (contains? canonical-add (descriptor/semantic-op uncast))
+                           (= 2 (count (descriptor/call-args uncast))))
+                    (let [[a1 a2] (descriptor/call-args uncast)]
+                      (cond (c-read? a1) [1.0 a2]
+                            (c-read? a2) [1.0 a1]
+                            :else [0.0 uncast]))
+                    [0.0 uncast])]
+              (when-let [{:keys [p k ga gb]} (match-inner-dot inner-loop)]
+                ;; resolve A/B by index shape (product is commutative): the operand whose
+                ;; index is (i,p)/(p,i) is A; the one that is (p,j)/(j,p) is B.
+                (letfn [(assign [gA gB]
+                          (when-let [av (a-variant (:idx gA) i p m k)]
+                            (when-let [bv (b-variant (:idx gB) p j n k)]
+                              {:variant (keyword (str (name av) (name bv)))
+                               :A (:arr gA) :B (:arr gB) :C c-sym
+                               :m m :n n :k k :alpha 1.0 :beta beta})))]
+                  (or (assign ga gb) (assign gb ga)))))))))))

--- a/src/raster/compiler/passes/parallel/gpu_plan.clj
+++ b/src/raster/compiler/passes/parallel/gpu_plan.clj
@@ -20,6 +20,7 @@
    [raster.compiler.core.op-descriptor :as op]
    [raster.compiler.passes.parallel.device :as device]
    [raster.compiler.passes.parallel.patterns :as patterns]
+   [raster.compiler.passes.parallel.gemm-recognize :as gemm-recognize]
    [raster.compiler.backend.gpu.opencl-codegen :as codegen]))
 
 ;; ================================================================
@@ -264,6 +265,19 @@
                      (into acc (conj bs [sym result-sym]))))
                   ;; Can't classify — keep original
                  (conj acc [sym expr]))
+
+                ;; GEMM REDOMAP (matmul written in the raster language, no BLAS call) →
+                ;; the SAME rewrite-gemm/emit-gemm-tiled path. #38: the redomap front door
+                ;; converges with the BLAS-name-match instead of falling through to the
+                ;; naive per-element SegOp kernel. gemm-info carries the identical
+                ;; {:variant :A :B :C :m :k :n :alpha :beta :result-sym} contract.
+               (gemm-recognize/match-gemm-redomap expr)
+               (let [gemm-info (gemm-recognize/match-gemm-redomap expr)
+                     {:keys [bindings kernels result-sym]}
+                     (rewrite-gemm gemm-info buf-plan dtype kernel-counter)]
+                 (swap! gemm-rewrites inc)
+                 (swap! all-kernels into kernels)
+                 (into acc (conj (vec bindings) [sym result-sym])))
 
                 ;; Nested dotimes transpose → GPU transpose kernel
                (patterns/match-do-wrapped-transpose expr)

--- a/test/raster/compiler/passes/parallel/gemm_recognize_test.clj
+++ b/test/raster/compiler/passes/parallel/gemm_recognize_test.clj
@@ -5,7 +5,8 @@
    extractions (all four transpose variants, α/β) and — load-bearing — the
    NEGATIVE cases that MUST reject."
   (:require [clojure.test :refer [deftest is testing]]
-            [raster.compiler.passes.parallel.gemm-recognize :as gr]))
+            [raster.compiler.passes.parallel.gemm-recognize :as gr]
+            [raster.compiler.ir.soac :as soac]))
 
 ;; Canonical row-major GEMM redomap: C[m×n] = A[m×k]·B[k×n].
 ;;   outer dotimes i∈[0,m), j∈[0,n); C at row-major (i,j,n)
@@ -155,3 +156,27 @@
       (is (= :nn (:variant r)))
       (is (= 'A (:A r)))
       (is (= 'B (:B r))))))
+
+;; ── redomap->dot: the matcher descriptor becomes the Dot IR node (Dot's first real
+;; producer; Feature 4 defined the node + a test but nothing constructed it). This is
+;; what the resident Screma-level recognizer (Design B) will emit in place of SOACs.
+(deftest redomap-to-dot-node
+  (let [desc (gr/match-gemm-loop-nest (gemm '(+ (* i k) p) '(+ (* p n) j)))
+        dot  (gr/redomap->dot 7 'gemm-out desc)]
+    (testing "produces a Dot IR record, NOT a generic SOAC (map/reduce lowering skips it)"
+      (is (instance? raster.compiler.ir.soac.Dot dot))
+      (is (soac/dot? dot))
+      (is (not (soac/soac? dot))))
+    (testing "carries operands/dims/variant from the descriptor"
+      (is (= ['A 'B 'C] [(:A dot) (:B dot) (:C dot)]))
+      (is (= ['m 'n 'k] [(:m dot) (:n dot) (:k dot)]))
+      (is (= :nn (:variant dot)))
+      (is (= [1.0 0.0] [(:alpha dot) (:beta dot)])))
+    (testing "dep-graph fields: inputs {A B}, outputs {C} (the producer edge), bound m*n"
+      (is (= #{'A 'B} (:inputs dot)))
+      (is (= #{'C} (:outputs dot)))
+      (is (= '(clojure.core/* m n) (:bound dot))))
+    (testing "epilogue + layout start nil (later vertical fusion / transpose-elim fill them)"
+      (is (nil? (:epilogue dot)))
+      (is (nil? (:layout-a dot)))
+      (is (nil? (:layout-b dot))))))

--- a/test/raster/compiler/passes/parallel/gemm_recognize_test.clj
+++ b/test/raster/compiler/passes/parallel/gemm_recognize_test.clj
@@ -121,3 +121,37 @@
       (is (nil? (gr/match-gemm-redomap '(do (dotimes [i n] (aset C i (aget A i))) C)))))
     (testing "a plain non-loop expr → nil"
       (is (nil? (gr/match-gemm-redomap '(+ 1 2)))))))
+
+;; ── the matcher must fire whether or not the walker has devirtualized array reads
+;; by the gpu-plan stage: numeric ops arrive as (.invk impl … {:raster.op/original …})
+;; and aget MAY too. aget-affine handles both; a missed match is safe-fail (no offload).
+(defn- dv
+  "A devirtualized (.invk impl args…) call carrying :raster.op/original, as the walker emits."
+  [orig & args]
+  (with-meta (apply list '.invk 'impl args) {:raster.op/original orig}))
+
+(deftest matches-devirtualized-forms
+  (testing "numeric ops as .invk (aget still literal) → matches (semantic-op resolves them)"
+    (let [f (list 'dotimes '[i m] (list 'dotimes '[j n]
+                  (list 'aset 'C '(+ (* i n) j)
+                        (list 'loop ['acc 0.0 'p 0]
+                              (list 'if '(< p k)
+                                    (list 'recur (dv 'raster.numeric/+ 'acc
+                                                     (dv 'raster.numeric/* '(aget A (+ (* i k) p)) '(aget B (+ (* p n) j))))
+                                          '(inc p))
+                                    'acc)))))]
+      (is (= :nn (:variant (gr/match-gemm-loop-nest f))))))
+  (testing "aget ALSO devirtualized → still matches (aget-affine handles .invk aget)"
+    (let [f (list 'dotimes '[i m] (list 'dotimes '[j n]
+                  (list 'aset 'C '(+ (* i n) j)
+                        (list 'loop ['acc 0.0 'p 0]
+                              (list 'if '(< p k)
+                                    (list 'recur (dv 'raster.numeric/+ 'acc
+                                                     (dv 'raster.numeric/* (dv 'raster.arrays/aget 'A '(+ (* i k) p))
+                                                         (dv 'raster.arrays/aget 'B '(+ (* p n) j))))
+                                          '(inc p))
+                                    'acc)))))
+          r (gr/match-gemm-loop-nest f)]
+      (is (= :nn (:variant r)))
+      (is (= 'A (:A r)))
+      (is (= 'B (:B r))))))

--- a/test/raster/compiler/passes/parallel/gemm_recognize_test.clj
+++ b/test/raster/compiler/passes/parallel/gemm_recognize_test.clj
@@ -1,0 +1,105 @@
+(ns raster.compiler.passes.parallel.gemm-recognize-test
+  "#38 Stage 1 — the tileable-redomap (GEMM) matcher. Device-free. The matcher is
+   the riskiest logic in #38 (a false positive → a tiled XMX kernel emitted for a
+   non-GEMM redomap = silent miscompile), so this corpus pins both the POSITIVE
+   extractions (all four transpose variants, α/β) and — load-bearing — the
+   NEGATIVE cases that MUST reject."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.passes.parallel.gemm-recognize :as gr]))
+
+;; Canonical row-major GEMM redomap: C[m×n] = A[m×k]·B[k×n].
+;;   outer dotimes i∈[0,m), j∈[0,n); C at row-major (i,j,n)
+;;   inner reduce p∈[0,k); acc += A[i,p]·B[p,j]
+(defn- gemm
+  "Build a nested-dotimes GEMM with the given operand index exprs + optional
+   accumulating (β=1) store."
+  [idx-a idx-b & {:keys [beta] :or {beta 0}}]
+  (let [dot (list 'loop ['acc 0.0 'p 0]
+                  (list 'if '(< p k)
+                        (list 'recur (list '+ 'acc (list '* (list 'aget 'A idx-a) (list 'aget 'B idx-b)))
+                              '(inc p))
+                        'acc))
+        stored (if (= beta 1) (list '+ '(aget C (+ (* i n) j)) dot) dot)]
+    (list 'dotimes '[i m]
+          (list 'dotimes '[j n]
+                (list 'aset 'C '(+ (* i n) j) stored)))))
+
+(deftest matches-all-transpose-variants
+  (testing ":nn — A[i,p] B[p,j]"
+    (let [r (gr/match-gemm-loop-nest (gemm '(+ (* i k) p) '(+ (* p n) j)))]
+      (is (= {:variant :nn :A 'A :B 'B :C 'C :m 'm :n 'n :k 'k :alpha 1.0 :beta 0.0} r))))
+  (testing ":nt — B transposed, B[j,p]"
+    (is (= :nt (:variant (gr/match-gemm-loop-nest (gemm '(+ (* i k) p) '(+ (* j k) p)))))))
+  (testing ":tn — A transposed, A[p,i]"
+    (is (= :tn (:variant (gr/match-gemm-loop-nest (gemm '(+ (* p m) i) '(+ (* p n) j)))))))
+  (testing ":tt — both transposed"
+    (is (= :tt (:variant (gr/match-gemm-loop-nest (gemm '(+ (* p m) i) '(+ (* j k) p))))))))
+
+(deftest extraction-contract-matches-blas-shape
+  (testing "emits the same keys as gpu-plan/match-gemm-call"
+    (let [r (gr/match-gemm-loop-nest (gemm '(+ (* i k) p) '(+ (* p n) j)))]
+      (is (= #{:variant :A :B :C :m :k :n :alpha :beta} (set (keys r)))))))
+
+(deftest beta-and-commutativity
+  (testing "accumulating store (C += A·B) is β=1"
+    (is (= 1.0 (:beta (gr/match-gemm-loop-nest (gemm '(+ (* i k) p) '(+ (* p n) j) :beta 1))))))
+  (testing "fresh store is β=0"
+    (is (= 0.0 (:beta (gr/match-gemm-loop-nest (gemm '(+ (* i k) p) '(+ (* p n) j)))))))
+  (testing "product is commutative — B·A written still resolves A=A, B=B by index shape"
+    (let [comm (list 'dotimes '[i m]
+                     (list 'dotimes '[j n]
+                           (list 'aset 'C '(+ (* i n) j)
+                                 (list 'loop ['acc 0.0 'p 0]
+                                       (list 'if '(< p k)
+                                             (list 'recur '(+ acc (* (aget B (+ (* p n) j)) (aget A (+ (* i k) p)))) '(inc p))
+                                             'acc)))))
+          r (gr/match-gemm-loop-nest comm)]
+      (is (= 'A (:A r)))
+      (is (= 'B (:B r)))
+      (is (= :nn (:variant r))))))
+
+(deftest widening-cast-store
+  (testing "a cast on the stored value (double …) is stripped, still matches"
+    (let [casted (list 'dotimes '[i m]
+                       (list 'dotimes '[j n]
+                             (list 'aset 'C '(+ (* i n) j)
+                                   (list 'double
+                                         (list 'loop ['acc 0.0 'p 0]
+                                               (list 'if '(< p k)
+                                                     (list 'recur '(+ acc (* (aget A (+ (* i k) p)) (aget B (+ (* p n) j)))) '(inc p))
+                                                     'acc))))))]
+      (is (= :nn (:variant (gr/match-gemm-loop-nest casted)))))))
+
+(deftest rejects-non-gemm-redomaps
+  (testing "both operands indexed by the SAME output position (no reduce variance) → nil"
+    (is (nil? (gr/match-gemm-loop-nest (gemm '(+ (* i n) j) '(+ (* i n) j))))))
+  (testing "reduce of a single array (not a product) → nil"
+    (let [sum1 (list 'dotimes '[i m]
+                     (list 'dotimes '[j n]
+                           (list 'aset 'C '(+ (* i n) j)
+                                 (list 'loop ['acc 0.0 'p 0]
+                                       (list 'if '(< p k)
+                                             (list 'recur '(+ acc (aget A (+ (* i k) p))) '(inc p))
+                                             'acc)))))]
+      (is (nil? (gr/match-gemm-loop-nest sum1)))))
+  (testing "accumulator not initialized to 0 → nil (not a fresh dot product)"
+    (let [nz (list 'dotimes '[i m]
+                   (list 'dotimes '[j n]
+                         (list 'aset 'C '(+ (* i n) j)
+                               (list 'loop ['acc 1.0 'p 0]
+                                     (list 'if '(< p k)
+                                           (list 'recur '(+ acc (* (aget A (+ (* i k) p)) (aget B (+ (* p n) j)))) '(inc p))
+                                           'acc)))))]
+      (is (nil? (gr/match-gemm-loop-nest nz)))))
+  (testing "C written column-major (+ (* j n) i) → nil (index shape mismatch)"
+    (let [badc (list 'dotimes '[i m]
+                     (list 'dotimes '[j n]
+                           (list 'aset 'C '(+ (* j n) i)
+                                 (list 'loop ['acc 0.0 'p 0]
+                                       (list 'if '(< p k)
+                                             (list 'recur '(+ acc (* (aget A (+ (* i k) p)) (aget B (+ (* p n) j)))) '(inc p))
+                                             'acc)))))]
+      (is (nil? (gr/match-gemm-loop-nest badc)))))
+  (testing "not a nested dotimes at all → nil"
+    (is (nil? (gr/match-gemm-loop-nest '(dotimes [i m] (aset C i (aget A i))))))
+    (is (nil? (gr/match-gemm-loop-nest '(+ 1 2))))))

--- a/test/raster/compiler/passes/parallel/gemm_recognize_test.clj
+++ b/test/raster/compiler/passes/parallel/gemm_recognize_test.clj
@@ -157,30 +157,6 @@
       (is (= 'A (:A r)))
       (is (= 'B (:B r))))))
 
-;; ── redomap->dot: the matcher descriptor becomes the Dot IR node (Dot's first real
-;; producer; Feature 4 defined the node + a test but nothing constructed it). This is
-;; what the resident Screma-level recognizer (Design B) will emit in place of SOACs.
-(deftest redomap-to-dot-node
-  (let [desc (gr/match-gemm-loop-nest (gemm '(+ (* i k) p) '(+ (* p n) j)))
-        dot  (gr/redomap->dot 7 'gemm-out desc)]
-    (testing "produces a Dot IR record, NOT a generic SOAC (map/reduce lowering skips it)"
-      (is (instance? raster.compiler.ir.soac.Dot dot))
-      (is (soac/dot? dot))
-      (is (not (soac/soac? dot))))
-    (testing "carries operands/dims/variant from the descriptor"
-      (is (= ['A 'B 'C] [(:A dot) (:B dot) (:C dot)]))
-      (is (= ['m 'n 'k] [(:m dot) (:n dot) (:k dot)]))
-      (is (= :nn (:variant dot)))
-      (is (= [1.0 0.0] [(:alpha dot) (:beta dot)])))
-    (testing "dep-graph fields: inputs {A B}, outputs {C} (the producer edge), bound m*n"
-      (is (= #{'A 'B} (:inputs dot)))
-      (is (= #{'C} (:outputs dot)))
-      (is (= '(clojure.core/* m n) (:bound dot))))
-    (testing "epilogue + layout start nil (later vertical fusion / transpose-elim fill them)"
-      (is (nil? (:epilogue dot)))
-      (is (nil? (:layout-a dot)))
-      (is (nil? (:layout-b dot))))))
-
 ;; ── Design B: the Screma/SoacMap-level recognizer (the RESIDENT front door). A
 ;; par-form matmul lowers to ONE SoacMap with the outer (i,j) inlined as
 ;; (quot ij N)/(rem ij N) in the operand indices. Built + tested against the REAL
@@ -214,8 +190,4 @@
       (is (nil? (gr/match-gemm-screma
                  (par-matmul-soacmap
                   '(aset C ij (loop [acc 0.0 p 0]
-                                (if (< p k) (recur (+ acc (* (aget A ij) (aget B ij))) (inc p)) acc)))))))))
-  (testing "the Screma recognizer feeds redomap->dot — Screma → descriptor → Dot node"
-    (let [dot (gr/redomap->dot 3 'c (gr/match-gemm-screma (par-matmul-soacmap nn-body)))]
-      (is (instance? raster.compiler.ir.soac.Dot dot))
-      (is (= ['A 'B 'C 'm 'n 'k] [(:A dot) (:B dot) (:C dot) (:m dot) (:n dot) (:k dot)])))))
+                                (if (< p k) (recur (+ acc (* (aget A ij) (aget B ij))) (inc p)) acc))))))))))

--- a/test/raster/compiler/passes/parallel/gemm_recognize_test.clj
+++ b/test/raster/compiler/passes/parallel/gemm_recognize_test.clj
@@ -180,3 +180,42 @@
       (is (nil? (:epilogue dot)))
       (is (nil? (:layout-a dot)))
       (is (nil? (:layout-b dot))))))
+
+;; ── Design B: the Screma/SoacMap-level recognizer (the RESIDENT front door). A
+;; par-form matmul lowers to ONE SoacMap with the outer (i,j) inlined as
+;; (quot ij N)/(rem ij N) in the operand indices. Built + tested against the REAL
+;; soac/let-bindings->nodes output, not a hand-form.
+(defn- par-matmul-soacmap
+  "Lower a par/map-void! matmul body to its SoacMap (as the resident pipeline sees it)."
+  [body]
+  (first (soac/let-bindings->nodes
+          [['_ (list 'raster.par/map-void! 'ij '(clojure.core/* m n) body)]])))
+
+(def ^:private nn-body
+  '(let [i (clojure.core/quot ij n) j (clojure.core/rem ij n)]
+     (aset C ij (loop [acc 0.0 p 0]
+                  (if (< p k)
+                    (recur (+ acc (* (aget A (clojure.core/+ (clojure.core/* i k) p))
+                                     (aget B (clojure.core/+ (clojure.core/* p n) j)))) (inc p))
+                    acc)))))
+
+(deftest screma-level-gemm-recognizer
+  (testing "a flat par-form matmul SoacMap → the :nn GEMM descriptor (m/n/k from quot/rem)"
+    (is (= {:variant :nn :A 'A :B 'B :C 'C :m 'm :n 'n :k 'k :alpha 1.0 :beta 0.0}
+           (gr/match-gemm-screma (par-matmul-soacmap nn-body)))))
+  (testing "SOUND rejections"
+    (testing "single-array reduce (no product) → nil"
+      (is (nil? (gr/match-gemm-screma
+                 (par-matmul-soacmap
+                  '(let [i (clojure.core/quot ij n) j (clojure.core/rem ij n)]
+                     (aset C ij (loop [acc 0.0 p 0]
+                                  (if (< p k) (recur (+ acc (aget A (clojure.core/+ (clojure.core/* i k) p))) (inc p)) acc)))))))))
+    (testing "both operands at the same flat index (elementwise, no contraction structure) → nil"
+      (is (nil? (gr/match-gemm-screma
+                 (par-matmul-soacmap
+                  '(aset C ij (loop [acc 0.0 p 0]
+                                (if (< p k) (recur (+ acc (* (aget A ij) (aget B ij))) (inc p)) acc)))))))))
+  (testing "the Screma recognizer feeds redomap->dot — Screma → descriptor → Dot node"
+    (let [dot (gr/redomap->dot 3 'c (gr/match-gemm-screma (par-matmul-soacmap nn-body)))]
+      (is (instance? raster.compiler.ir.soac.Dot dot))
+      (is (= ['A 'B 'C 'm 'n 'k] [(:A dot) (:B dot) (:C dot) (:m dot) (:n dot) (:k dot)])))))

--- a/test/raster/compiler/passes/parallel/gemm_recognize_test.clj
+++ b/test/raster/compiler/passes/parallel/gemm_recognize_test.clj
@@ -103,3 +103,21 @@
   (testing "not a nested dotimes at all → nil"
     (is (nil? (gr/match-gemm-loop-nest '(dotimes [i m] (aset C i (aget A i))))))
     (is (nil? (gr/match-gemm-loop-nest '(+ 1 2))))))
+
+;; ── binding-level entry point (do-unwrap + :result-sym for rewrite-gemm) ──────────
+(deftest binding-level-match-gemm-redomap
+  (let [nest (gemm '(+ (* i k) p) '(+ (* p n) j))]
+    (testing "a bare nested-dotimes binding value → result-sym defaults to the output C"
+      (is (= 'C (:result-sym (gr/match-gemm-redomap nest)))))
+    (testing "a (do (dotimes …) Cout) wrapper → result-sym is the do's tail buffer"
+      (let [r (gr/match-gemm-redomap (list 'do nest 'Cout))]
+        (is (= :nn (:variant r)))
+        (is (= 'C (:C r)))
+        (is (= 'Cout (:result-sym r)))))
+    (testing "the descriptor still carries the full rewrite-gemm contract"
+      (is (= #{:variant :A :B :C :m :k :n :alpha :beta :result-sym}
+             (set (keys (gr/match-gemm-redomap nest))))))
+    (testing "a non-GEMM do body → nil"
+      (is (nil? (gr/match-gemm-redomap '(do (dotimes [i n] (aset C i (aget A i))) C)))))
+    (testing "a plain non-loop expr → nil"
+      (is (nil? (gr/match-gemm-redomap '(+ 1 2)))))))

--- a/test/raster/compiler/passes/parallel/gpu_plan_test.clj
+++ b/test/raster/compiler/passes/parallel/gpu_plan_test.clj
@@ -43,3 +43,38 @@
       (is (= 'out (nth rewritten-expr 3)))
       (is (= 'rows (nth rewritten-expr 4)))
       (is (= 'cols (nth rewritten-expr 5))))))
+;; ── #38: a GEMM redomap (matmul in the raster language, no BLAS call) is rewritten
+;; to the SAME registered-GEMM kernel path as a blas/dgemm! call — the two front doors
+;; converge. Device-free: gpu-plan-pass PLANS kernels (form→form), it does not execute.
+(deftest rewrite-gemm-redomap-to-gpu-kernel
+  (testing "a nested-dotimes matmul redomap is recognized and offloaded to invoke-registered-gemm!"
+    (let [form '(let* [C   (clojure.core/double-array (clojure.core/* m n))
+                       out (do (dotimes [i m]
+                                 (dotimes [j n]
+                                   (aset C (+ (* i n) j)
+                                         (loop [acc 0.0 p 0]
+                                           (if (< p k)
+                                             (recur (+ acc (* (aget A (+ (* i k) p)) (aget B (+ (* p n) j)))) (inc p))
+                                             acc)))))
+                               C)]
+                  out)
+          {:keys [form kernels stats]} (gpu-plan/gpu-plan-pass form :dtype :float)]
+      (is (= 1 (:gemm-rewrites stats)) "the redomap counts as a GEMM rewrite, like a BLAS call")
+      (is (= 1 (count kernels)))
+      (is (re-find #"invoke-registered-gemm!" (pr-str form))
+          "emits the same registered-GEMM invocation the BLAS path uses"))))
+
+(deftest non-gemm-redomap-is-not-offloaded
+  (testing "a reduction that is NOT a GEMM (single-array sum) is left for the SegOp backend"
+    (let [form '(let* [C   (clojure.core/double-array (clojure.core/* m n))
+                       out (do (dotimes [i m]
+                                 (dotimes [j n]
+                                   (aset C (+ (* i n) j)
+                                         (loop [acc 0.0 p 0]
+                                           (if (< p k)
+                                             (recur (+ acc (aget A (+ (* i k) p))) (inc p))
+                                             acc)))))
+                               C)]
+                  out)
+          {:keys [stats]} (gpu-plan/gpu-plan-pass form :dtype :float)]
+      (is (= 0 (:gemm-rewrites stats)) "not a matmul → no GEMM offload (sound)"))))


### PR DESCRIPTION
## #38 GEMM-as-late-recognizer — PR-A: the recognizers (device-free, design-neutral)

Make GEMM a first-class SOAC citizen (Futhark `isTileableRedomap`) instead of a hand-bound special kernel matched only by BLAS library-name. This PR lands the **pure, device-free recognizers** that structurally identify a tileable GEMM and produce its schedule descriptor. Nothing here changes emitted code (see "Scope").

### The mismatch it targets
GEMM enters today as a BLAS *library-name* match (`gpu-plan/blas-gemm-call?` on `raster.linalg.blas/dgemm!`) → hand kernel. A **redomap** (matmul written in the raster language) hits the generic SegOp emitter → naive ~5%-of-peak GEMM. `bind-step!` throwing on `:gemm` is the symptom.

### North star (Design S — schedule facet, not a Dot node)
Investigation showed **GEMM is already a generic `SoacMap`**: a par-form matmul lowers to a `SoacMap` over the `m*n` output domain with the k-contraction inlined in the map-lambda, and `soac_lower.clj:245` already emits a (naive) kernel for it. A special `Dot` node adds **zero representational power** — everything it would carry (variant, α/β, epilogue, layout) is a **schedule**. So the plan is:

- **Recognizer → schedule descriptor** (this PR).
- Resident pass attaches the descriptor as a **`:gemm` facet on the existing SoacMap** (stays `soac?`-true); `lower-map` dispatches that facet to the existing tile-parametric `emit-gemm-tiled` → **perfect GEMM code, but the node stays a SOAC** so vertical fusion (#40) stays fully general and epilogue/transpose fusion fall out for free. (Follow-up PR-B, on-device.)

### What landed (recognizers only)
- **Stage 1** — `match-gemm-loop-nest`: pure, sound (proven-or-nil) nested-`dotimes` matcher. All four transpose variants (`:nn/:nt/:tn/:tt`), α/β, commutativity. The Futhark variance test (A invariant in `j`, B invariant in `i`) falls out of `patterns/row-major-linear-index?`. Handles literal *and* devirtualized `.invk` array reads.
- **Stage 2a** — `match-gemm-redomap`: binding-level matcher (do-unwrap + `:result-sym`).
- **Stage 2b** — recognizer wired as a sibling of `blas-gemm-call?` in `gpu-plan-pass`, demonstrating the matcher plugs into the existing `rewrite-gemm`→`invoke-registered-gemm!` rewrite (note: `pass-gpu-plan` is legacy, so this exercises the mechanism, not a live compile).
- **Design B Part 1** — `match-gemm-screma`: matches the flat par-form matmul **SoacMap** (the *resident* GPU shape), tested against real `soac/let-bindings->nodes` output. `:nn` sound; transposes decline safely. This is the node the resident `:gemm`-facet pass will annotate.

All three matchers emit the same `{:variant :A :B :C :m :k :n :alpha :beta}` descriptor — the schedule payload.

### Scope — what this does NOT do (deliberately)
- No `Dot` node (the earlier `redomap->dot` bridge was **removed** — Design S supersedes it).
- Does not attach a schedule facet or change any emitted kernel. That, plus the `lower-map` → `emit-gemm-tiled` dispatch and the GPU bit-identical-to-naive backstop, is **PR-B** (on-device validated).

### Tests (device-free, green on standard JDK)
- `gemm_recognize_test`: **8 tests / 31 assertions** — all transpose variants, extraction contract, β + commutativity, widening cast, soundness negatives (same-index, non-product, nonzero-init, column-major-C, non-dotimes), binding-level, devirtualized forms, Screma-level recognizer against the real lowered shape + its soundness rejections.
- `gpu_plan_test`: +2 tests (redomap→rewrite; non-GEMM redomap not offloaded). 4 tests / 14 assertions.
