### PR TITLE
Type polymorphic-kernel scalars to the element type (:- T), not Double — fixes #69

### DIFF
--- a/src/raster/ad/templates.clj
+++ b/src/raster/ad/templates.clj
@@ -1721,11 +1721,11 @@
               c (list 'raster.dl.loss/mse-grad pred target 1.0 n)))}
 
    'raster.par/dot-product
-   ;; c is a SCALAR cotangent; scale's alpha is annotated Double, so widen
-   ;; explicitly (a float-typed seed dispatches [Float floats] otherwise —
-   ;; exact widening, the array dtype is preserved by scale's (All [T])).
-   {0 (fn [[_a b] c] (list 'raster.par/scale (list 'double c) b))
-    1 (fn [[a _b] c] (list 'raster.par/scale (list 'double c) a))}
+   ;; c is a SCALAR cotangent. par/scale's alpha is now (All [T])-typed, so the cotangent
+   ;; flows through at the array's element type — no explicit widening wrapper needed
+   ;; (previously `(double c)` was injected purely to satisfy a Double annotation).
+   {0 (fn [[_a b] c] (list 'raster.par/scale c b))
+    1 (fn [[a _b] c] (list 'raster.par/scale c a))}
 
    'raster.par/scale
    {0 (fn [[_alpha x] c] (list 'raster.par/dot-product c x))

--- a/src/raster/dl/nn.clj
+++ b/src/raster/dl/nn.clj
@@ -355,17 +355,17 @@
                                            [dx nil]]))})
 
 ;; --- Leaky ReLU ---
-(deftm leaky-relu (All [T] [x :- (Array T) n :- Long alpha :- Double]
+(deftm leaky-relu (All [T] [x :- (Array T) n :- Long alpha :- T]
                        :- (Array T)
                        (broadcast [x] (if (>= x 0.0) x (* alpha x)))))
 
 ;; In-place leaky-relu: writes into pre-allocated out
-(deftm leaky-relu! (All [T] [x :- (Array T) out :- (Array T) n :- Long alpha :- Double]
+(deftm leaky-relu! (All [T] [x :- (Array T) out :- (Array T) n :- Long alpha :- T]
                         :- (Array T)
                         (broadcast [x] (if (>= x 0.0) x (* alpha x)))))
 
 ;; leaky-relu': x>=0 ? 1 : alpha
-(deftm leaky-relu-backward (All [T] [dy :- (Array T) x :- (Array T) n :- Long alpha :- Double]
+(deftm leaky-relu-backward (All [T] [dy :- (Array T) x :- (Array T) n :- Long alpha :- T]
                                 :- (Array T)
                                 (let [dx (alloc-like dy n)]
                                   (dotimes [i n]

--- a/src/raster/dl/optim.clj
+++ b/src/raster/dl/optim.clj
@@ -30,7 +30,7 @@
 
 ;; SGD: in-place weight update (mutating — param is shared state)
 (deftm sgd-step! (All [T] [param :- (Array T), grad :- (Array T),
-                           n :- Long, lr :- Double] :- (Array T)
+                           n :- Long, lr :- T] :- (Array T)
                       (dotimes [i (alength param)]
                         (aset param i (- (aget param i) (* lr (aget grad i)))))
                       param))
@@ -48,8 +48,8 @@
 
 (deftm adam-step! (All [T] [param :- (Array T) grad :- (Array T)
                             m :- (Array T) v :- (Array T)
-                            n :- Long lr :- Double beta1 :- Double beta2 :- Double
-                            eps :- Double t :- Long] :- (Array T)
+                            n :- Long lr :- T beta1 :- T beta2 :- T
+                            eps :- T t :- Long] :- (Array T)
                        (let [bc1 (- 1.0 (n/pow beta1 t))
                              bc2 (- 1.0 (n/pow beta2 t))]
                          (dotimes [i n]
@@ -71,8 +71,8 @@
 
 (deftm adamw-step! (All [T] [param :- (Array T) grad :- (Array T)
                              m :- (Array T) v :- (Array T)
-                             n :- Long lr :- Double beta1 :- Double beta2 :- Double
-                             eps :- Double weight-decay :- Double t :- Long]
+                             n :- Long lr :- T beta1 :- T beta2 :- T
+                             eps :- T weight-decay :- T t :- Long]
                         :- (Array T)
                         (let [bc1 (- 1.0 (n/pow beta1 t))
                               bc2 (- 1.0 (n/pow beta2 t))]
@@ -109,7 +109,7 @@
 
 ;; EMA: in-place state update (mutating — shadow is shared state)
 (deftm ema-update! (All [T] [shadow :- (Array T), param :- (Array T),
-                             n :- Long, mu :- Double] :- (Array T)
+                             n :- Long, mu :- T] :- (Array T)
                         (dotimes [i (alength shadow)]
                           (aset shadow i (+ (* mu (aget shadow i)) (* (- 1.0 mu) (aget param i)))))
                         shadow))
@@ -174,9 +174,11 @@
       (let [{:keys [m v t]} (get state name)
             step (swap! t inc)
             n (alength param)]
-        (adam-step! param grad m v n (double lr)
-                    (double beta1) (double beta2)
-                    (double eps) (long step)))))
+        ;; The optimizer kernels are (All [T]); convert each scalar to the PARAM's element
+        ;; type here — the boundary where "what precision is my learning rate" belongs.
+        (adam-step! param grad m v n (n/oftype param lr)
+                    (n/oftype param beta1) (n/oftype param beta2)
+                    (n/oftype param eps) (long step)))))
   params)
 
 ;; ================================================================
@@ -249,17 +251,20 @@
         (let [n (alength param)]
           (case (:type state)
             :sgd
-            (sgd-step! param grad n lr)
+            (sgd-step! param grad n (n/oftype param lr))
 
             :adam
             (let [{:keys [m v t]} (get (:params-state state) name)
                   t-val (swap! t inc)]
-              (adam-step! param grad m v n lr beta1 beta2 eps t-val))
+              (adam-step! param grad m v n (n/oftype param lr) (n/oftype param beta1)
+                          (n/oftype param beta2) (n/oftype param eps) t-val))
 
             :adamw
             (let [{:keys [m v t]} (get (:params-state state) name)
                   t-val (swap! t inc)]
-              (adamw-step! param grad m v n lr beta1 beta2 eps weight-decay t-val))))))
+              (adamw-step! param grad m v n (n/oftype param lr) (n/oftype param beta1)
+                           (n/oftype param beta2) (n/oftype param eps)
+                           (n/oftype param weight-decay) t-val))))))
     params))
 
 (defn get-lr

--- a/src/raster/numeric.clj
+++ b/src/raster/numeric.clj
@@ -406,14 +406,14 @@
          out)))
 
 (deftm scale! "Scale array a by scalar c, storing result in out. Returns out."
-  (All [T] [out :- (Array T), c :- Double, a :- (Array T)]
+  (All [T] [out :- (Array T), c :- T, a :- (Array T)]
        :- (Array T)
        (let [n (alength out)]
          (dotimes [i n] (aset out i (clojure.core/* c (aget a i))))
          out)))
 
 (deftm axpy! "Compute a + c*b element-wise, storing result in out. Returns out."
-  (All [T] [out :- (Array T), a :- (Array T), c :- Double, b :- (Array T)]
+  (All [T] [out :- (Array T), a :- (Array T), c :- T, b :- (Array T)]
        :- (Array T)
        (let [n (alength out)]
          (dotimes [i n] (aset out i (clojure.core/+ (aget a i) (clojure.core/* c (aget b i)))))

--- a/src/raster/par.clj
+++ b/src/raster/par.clj
@@ -530,19 +530,19 @@
 ;; Element-wise operations: (All [T]) — body uses broadcast which is type-polymorphic
 (deftm axpy
   "Compute y + alpha*x element-wise (BLAS axpy)."
-  (All [T] [alpha :- Double,
+  (All [T] [alpha :- T,
             x :- (Array T), y :- (Array T)] :- (Array T)
        (broadcast [x y] (+ y (* alpha x)))))
 
 (deftm scale
   "Scale array x by scalar alpha element-wise."
-  (All [T] [alpha :- Double,
+  (All [T] [alpha :- T,
             x :- (Array T)] :- (Array T)
        (broadcast [x] (* alpha x))))
 
 (deftm fill
   "Fill every element of out with val."
-  (All [T] [out :- (Array T), val :- Double] :- (Array T)
+  (All [T] [out :- (Array T), val :- T] :- (Array T)
        (dotimes [i (alength out)]
          (aset out i val))
        out))

--- a/test/raster/polymorphic_scalar_dtype_test.clj
+++ b/test/raster/polymorphic_scalar_dtype_test.clj
@@ -1,0 +1,110 @@
+(ns raster.polymorphic-scalar-dtype-test
+  "Regression guard for the `(All [T])` scalar-dtype rule (CLAUDE.md ~line 316, issue #69).
+
+   A scalar that participates in `T`-typed arithmetic must be declared `:- T`, not `:- Double`.
+   With `:- Double` the call still DEVIRTUALIZES — Julia-style promotion picks the
+   `[Double Double]` overload and the walker inserts a `(double …)` cast on the float operand
+   (walker.clj:1160-1162 documents exactly this) — so results stay correct and nothing throws.
+   The damage is f64 contamination of an f32 kernel: the loop runs in f64 over float data with a
+   narrowing round-trip per element, float-lane SIMD is blocked, and on OpenCL the casts
+   force-enable cl_khr_fp64 (works on Arc, HARD-FAILS on fp64-less backends such as WGSL).
+
+   Because it neither throws nor produces wrong answers, no existing test caught it — these
+   kernels had ZERO non-double coverage. This namespace supplies it: every kernel below is
+   exercised with float[] AND double[] and must agree, which is only possible when the scalar
+   is `:- T` (a `:- Double` scalar cannot dispatch against a float array without promotion)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.numeric :as n]
+            [raster.par :as par]
+            [raster.dl.optim :as optim]
+            [raster.dl.nn :as nn]))
+
+(defn- fa ^floats [xs] (float-array (map float xs)))
+(defn- da ^doubles [xs] (double-array (map double xs)))
+(defn- close? [xs ys tol]
+  (and (= (count xs) (count ys))
+       (every? true? (map #(< (Math/abs (- (double %1) (double %2))) tol) xs ys))))
+
+;; ── raster.numeric: the two functions issue #69 reported ────────────────────────────
+(deftest numeric-scale!-axpy!-are-element-typed
+  (testing "scale! accepts a T-typed scalar for float AND double arrays, same result"
+    (let [xs [1 2 3 4]
+          f (vec (n/scale! (fa (repeat 4 0)) (float 2) (fa xs)))
+          d (vec (n/scale! (da (repeat 4 0)) (double 2) (da xs)))]
+      (is (close? f [2 4 6 8] 1e-6))
+      (is (close? f d 1e-6) "float and double paths agree")))
+  (testing "axpy! likewise"
+    (let [a [1 2 3 4] b [10 20 30 40]
+          f (vec (n/axpy! (fa (repeat 4 0)) (fa a) (float 3) (fa b)))
+          d (vec (n/axpy! (da (repeat 4 0)) (da a) (double 3) (da b)))]
+      (is (close? f [31 62 93 124] 1e-4))
+      (is (close? f d 1e-4))))
+  (testing "oftype is the documented way to pass a literal at the call site"
+    (let [a (fa [1 2 3 4])
+          out (n/scale! (fa (repeat 4 0)) (n/oftype a 2.0) a)]
+      (is (close? (vec out) [2 4 6 8] 1e-6)))))
+
+;; ── raster.par elementwise broadcasts ───────────────────────────────────────────────
+(deftest par-axpy-scale-fill-are-element-typed
+  (testing "par/scale + par/axpy agree across float and double"
+    (let [x [1 2 3 4] y [10 20 30 40]]
+      (is (close? (vec (par/scale (float 2) (fa x))) [2 4 6 8] 1e-6))
+      (is (close? (vec (par/scale (float 2) (fa x)))
+                  (vec (par/scale (double 2) (da x))) 1e-6))
+      (is (close? (vec (par/axpy (float 3) (fa x) (fa y)))
+                  (vec (par/axpy (double 3) (da x) (da y))) 1e-4))))
+  (testing "par/fill"
+    (is (close? (vec (par/fill (fa (repeat 3 0)) (float 7))) [7 7 7] 1e-6))
+    (is (close? (vec (par/fill (da (repeat 3 0)) (double 7))) [7 7 7] 1e-6))))
+
+;; ── dl/optim: the GPU-live optimizer kernels ────────────────────────────────────────
+(deftest optimizer-kernels-are-element-typed
+  (testing "sgd-step! (on the resident GPU training path) — float == double"
+    (let [p [1.0 2.0 3.0] g [0.5 0.5 0.5] lr 0.1
+          pf (fa p) pd (da p)]
+      (optim/sgd-step! pf (fa g) 3 (float lr))
+      (optim/sgd-step! pd (da g) 3 (double lr))
+      (is (close? (vec pf) [0.95 1.95 2.95] 1e-5))
+      (is (close? (vec pf) (vec pd) 1e-5))))
+  (testing "ema-update! — float == double"
+    (let [sf (fa [1 2 3]) sd (da [1 2 3]) p [5.0 5.0 5.0]]
+      (optim/ema-update! sf (fa p) 3 (float 0.9))
+      (optim/ema-update! sd (da p) 3 (double 0.9))
+      (is (close? (vec sf) (vec sd) 1e-5))))
+  (testing "adam-step! — float == double (bias correction + eps all T-typed)"
+    (let [p [1.0 2.0] g [0.1 0.2]
+          pf (fa p) pd (da p)]
+      (optim/adam-step! pf (fa g) (fa [0 0]) (fa [0 0]) 2
+                        (float 0.01) (float 0.9) (float 0.999) (float 1e-7) 1)
+      (optim/adam-step! pd (da g) (da [0 0]) (da [0 0]) 2
+                        (double 0.01) (double 0.9) (double 0.999) (double 1e-7) 1)
+      (is (close? (vec pf) (vec pd) 1e-4))))
+  (testing "adamw-step! — float == double"
+    (let [pf (fa [1 2]) pd (da [1 2]) g [0.1 0.2]]
+      (optim/adamw-step! pf (fa g) (fa [0 0]) (fa [0 0]) 2
+                         (float 0.01) (float 0.9) (float 0.999) (float 1e-7) (float 0.01) 1)
+      (optim/adamw-step! pd (da g) (da [0 0]) (da [0 0]) 2
+                         (double 0.01) (double 0.9) (double 0.999) (double 1e-7) (double 0.01) 1)
+      (is (close? (vec pf) (vec pd) 1e-4)))))
+
+;; ── dl/nn leaky-relu family ─────────────────────────────────────────────────────────
+(deftest leaky-relu-is-element-typed
+  (testing "leaky-relu / -backward agree across float and double"
+    (let [x [-2.0 -1.0 0.0 1.0 2.0] a 0.1]
+      (is (close? (vec (nn/leaky-relu (fa x) 5 (float a)))
+                  (vec (nn/leaky-relu (da x) 5 (double a))) 1e-6))
+      (is (close? (vec (nn/leaky-relu (fa x) 5 (float a)))
+                  [-0.2 -0.1 0.0 1.0 2.0] 1e-6))
+      (is (close? (vec (nn/leaky-relu-backward (fa (repeat 5 1)) (fa x) 5 (float a)))
+                  (vec (nn/leaky-relu-backward (da (repeat 5 1)) (da x) 5 (double a))) 1e-6)))))
+
+;; ── the invariant itself: a Double scalar must NOT dispatch against a float array ────
+(deftest double-scalar-cannot-silently-enter-a-float-kernel
+  (testing "passing a raw Double to a float[] kernel now FAILS LOUD instead of promoting to f64"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (n/scale! (fa [0 0 0 0]) 2.0 (fa [1 2 3 4]))))
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (optim/sgd-step! (fa [1 2 3]) (fa [1 1 1]) 3 0.1))))
+  (testing "…and double[] kernels still take plain literals unchanged"
+    (is (close? (vec (n/scale! (da [0 0 0 0]) 2.0 (da [1 2 3 4]))) [2 4 6 8] 1e-9))
+    (is (close? (vec (par/scale 2.0 (da [1 2 3 4]))) [2 4 6 8] 1e-9))))


### PR DESCRIPTION
Fixes #69.

@nstgc was right: `scale!` and `axpy!` in `raster.numeric` declare `c :- Double` inside an
`(All [T])`, and it should be `c :- T`. `CLAUDE.md` (~line 316) already states the rule — these
were oversights, not intentional.

## What actually goes wrong

Worth stating precisely, because the rule's description is a bit off for this case. The call does
**not** stay undevirtualized. Double *literals* get narrowed to the element dtype
(`walker.clj:1142-1173`), but a Double *param* does not — `walker.clj:1160-1162` says so verbatim —
so Julia-style promotion selects the `[Double Double]` overload and a `(double …)` cast is inserted
on the float operand. **Results stay correct and nothing throws**, which is exactly why no test
caught it.

The damage is f64 contamination of an f32 kernel:

- **CPU**: the whole elementwise loop runs in f64 over float data, with a narrowing round-trip per
  element via the `aset [(Array float) Long Double]` escape hatch; float-lane SIMD is blocked.
- **OpenCL**: the casts force-enable `cl_khr_fp64` (`par_opencl.clj:227-232`) — emulated and slow
  on Arc, and a **hard failure** on fp64-less backends such as WGSL, which emits every scalar as
  `f32`.

Neither existing guard could see it: `pass-late-cleanup`'s GPU throw only fires on
*undevirtualized* dispatch (promotion succeeds here), and I-T3 dtype-closure **exempts
double-tagged params by construction** (`invariants.clj:152-153`: "declared, not inferred, so they
are intentional by construction").

## Why `:- T` rather than coercing in the body

The tempting alternative was to keep `c :- Double` (Clojure literals are Doubles, so `2.0` "just
works") and convert inside the body with `(oftype out c)`. Rejected:

- the signature would lie about the contract — the kernel wants a `T`;
- it does not compose: a caller inside its own `(All [S])` can pass its `S` scalar under `:- T`,
  whereas `:- Double` forces every such caller to materialize a double, making a precision
  decision in the wrong place;
- to be consistent it would have to be applied to *every* scalar param of *every* polymorphic
  function — boilerplate the type system should be doing.

`oftype` is still the answer for literals, just at the **call site**, where the precision decision
belongs: `(scale! out (n/oftype out 2.0) a)`. That is already the idiom across `dl/nn.clj`.

Telling detail: `dl/optim.clj:177` already wrote an explicit `(double lr)` — the Double annotation
was *already* forcing a cast at a call site, just in the wrong direction.

## Scope

Retyped where the arrays are `(Array T)`, the scalar participates in `T`-typed arithmetic, and the
param is the sole f64 source:

| namespace | functions |
|---|---|
| `raster.numeric` | `scale!` `axpy!` — the reported ones |
| `raster.par` | `axpy` `scale` `fill` |
| `raster.dl.optim` | `sgd-step!` `adam-step!` `adamw-step!` `ema-update!` |
| `raster.dl.nn` | `leaky-relu` `leaky-relu!` `leaky-relu-backward` |

`sgd-step!` is live on the GPU resident-training path (`gemma_train_resident_test.clj:144-157`).

Also **deleted** the two `(double c)` wrappers at `ad/templates.clj:1723-1728`, which existed
purely to satisfy `par/scale`'s Double annotation and were injecting f64 into AD-generated code.

## Tests

These kernels had **zero** non-double coverage. New `raster.polymorphic-scalar-dtype-test`
exercises each with `float[]` **and** `double[]` and asserts the two agree — only possible when the
scalar is `:- T` — plus asserts that a raw `Double` into a float kernel now fails **loud** instead
of silently promoting.

144 tests / 1402 assertions green (AD laws, JIT/AOT differential, semantic invariants, tree e2e
included), and a cold-JVM load of every touched namespace.

## Behaviour change to be aware of

`(scale! float-out 2.0 float-a)` now throws `No matching method for scale! with argument types
[(Array float), Double, (Array float)]` — use `(n/oftype a 2.0)` or `(float 2.0)`. `double[]`
callers are unaffected. It fails loudly rather than silently, so migration is mechanical.

## Deliberately out of scope

- **Tier 2, CPU-only (no GPU path):** `sci/optim`, `linalg/iterative` (`vec-axpy!`/`vec-scale!`),
  `ode/pde`, `dl/diffusion`, `dl/loss`, and `clip-grad-norm!` (needs a body change, not a signature
  one). Follow-up PR.
- **Not a bug:** the norms' `eps`, RoPE `theta`, ODE `dt`. Those bodies create f64 islands
  *independently* via explicit `(double …)` casts — documented as intentional at
  `invariants.clj:140-153` — so retyping the param alone would not purify them.
