### PR TITLE
B2: n-operand einsum → an ordered path of pairwise contractions

### DIFF
--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -182,6 +182,13 @@
                   k (register-kernel! {:kernel-name (:kernel-name r) :source (:source r)
                                        :dtype (:dtype r)}
                                       :ze-contracts)]
+              ;; A full reduction (0 free axes) has its own two-phase launch protocol + a
+              ;; host-side final combine — emit the reduction invoke, not the 2-D contraction one.
+              (if (= :reduction (:invoke r))
+                (list 'raster.gpu.ze-runtime/invoke-reduction-kernel
+                      (:kernel-name k)
+                      (vec (:array-params r))
+                      (:reduce-bound r))
               ;; Pass the descriptor through INTACT — scalar-args as data (the exact shape
               ;; launch-2d! wants), explicit out-dtype/out-elems. Any :strategy works; the
               ;; old (count scalar-args) + [m n k] reconstruction only covered :dpas/:regtiled.
@@ -194,7 +201,7 @@
                     (:out-elems r)                ; may be a symbolic expr (symbolic axis bounds)
                     (vec (:wg r))
                     (vec (:grid r))
-                    (vec (:scalar-args r))))
+                    (vec (:scalar-args r)))))
 
             ;; === par/reduce-into — resident SegRed writing a caller-supplied 1-elem buffer ===
             ;; Same SegRed kernel as par/reduce (it already has an `output` param), but the

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -11,6 +11,7 @@
             [raster.compiler.backend.gpu.c-emit :as ce]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.backend.intrinsics :as intrinsics]
+            [raster.compiler.core.hardware :as hw]
             [raster.compiler.ir.segop :as segop]
             [clojure.string :as str]))
 
@@ -695,29 +696,36 @@
             :tensorized true}  — NB: :array-params is in [row col] BINDING order (row's
    buffer → A slot, col's → B slot, out → C), NOT sorted-by-name. Returns
    {:tensorized false :reason …} when the gate rejects (caller falls back to regtiled)."
-  [segred out-sym & {:keys [dtype] :or {dtype :half}}]
+  [segred out-sym & {:keys [dtype desc tile] :or {dtype :half}}]
   (let [gate (dpas-contraction-legal? segred dtype)]
     (if-not (:ok gate)
       {:tensorized false :reason (:reason gate) :detail gate}
       (let [{:keys [M N L row-arr col-arr]} gate
             kernel-name (str "dpas_contract_" (gensym ""))
-            ;; tile geometry (defaults reproduce the original hand kernel bit-for-bit); returned
-            ;; so the ROUTER derives wg/grid from it instead of hardcoding 128/256 in a 2nd place.
-            tile {:block-m 128 :block-n 128 :sg-m 32 :sg-n 32 :block-k 32 :subgroup 16}
+            ;; TILE GEOMETRY IS DERIVED FROM THE HARDWARE DESCRIPTOR, never hardcoded: the
+            ;; per-subgroup accumulator tile is GRF-bound and rounded to the matrix (DPAS)
+            ;; fragment granularity, so a part with a different GRF budget / subgroup size /
+            ;; matrix shape gets a correctly rescaled tile from the same rule. An explicit
+            ;; `tile` (e.g. an autotune result via hw/gemm-tile-candidates) overrides.
+            ;; hw/derive-gemm-tile's own defaults reproduce the Arc 140V config, so passing no
+            ;; descriptor is equivalent to the previous literal — with zero magic numbers here.
+            tile (or tile (hw/derive-gemm-tile (or desc {})))
+            sg (long (get-in tile [:matrix :subgroup] 16))
             source (codegen/emit-gemm-tiled kernel-name :c-dtype :half
                                             :block-m (:block-m tile) :block-n (:block-n tile)
                                             :sg-m (:sg-m tile) :sg-n (:sg-n tile)
-                                            :block-k (:block-k tile))]
+                                            :block-k (:block-k tile)
+                                            :matrix (:matrix tile))]
         {:kernel-name kernel-name
          :source source
          :array-params [row-arr col-arr]      ;; [A-slot B-slot] binding order
          :dims [M N L]
          :dtype :half
          :tile tile
-         ;; workgroup = (block-m/sg-m)·(block-n/sg-n) subgroups × subgroup size
+         ;; workgroup = (block-m/sg-m)·(block-n/sg-n) subgroups × the matrix subgroup size
          :workgroup [(* (quot (:block-m tile) (:sg-m tile))
                         (quot (:block-n tile) (:sg-n tile))
-                        (:subgroup tile)) 1]
+                        sg) 1]
          :tensorized true}))))
 
 ;; ================================================================

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -12,6 +12,8 @@
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.backend.intrinsics :as intrinsics]
             [raster.compiler.core.hardware :as hw]
+            [raster.compiler.ir.axis-map :as am]
+            [clojure.walk :as walk]
             [raster.compiler.ir.segop :as segop]
             [clojure.string :as str]))
 
@@ -678,9 +680,61 @@
             (not (pitch-ok? L))   ; A pitch = K·2 bytes must be 16-byte aligned
             {:ok false :reason :k-pitch-unaligned :L L}
             :else
-            {:ok true :M M :N N :L L :row-arr row-arr :col-arr col-arr :arr-params arr-params}))
+            ;; i-sym/j-sym are the FREE axes; an epilogue binds them to the store slot's row/col
+            {:ok true :M M :N N :L L :i-sym i-sym :j-sym j-sym
+             :row-arr row-arr :col-arr col-arr :arr-params arr-params}))
         (catch clojure.lang.ExceptionInfo e
           {:ok false :reason :not-a-contraction :msg (.getMessage e)})))))
+
+(defn epilogue-splice
+  "Build the (fn [acc-expr row col] -> C-expr) + param-decls + helpers that emit-gemm-tiled's
+   store-splice expects, from a DOMAIN-AGNOSTIC spec. The compiler learns no op names: the spec is
+   just an EXPRESSION over the accumulator and some operands, each operand carrying its own
+   axis-map, so bias / activation / residual / dequant-scale are all the same mechanism and
+   COMPOSE by nesting (one bigger expression), per CLAUDE.md's domain-agnostic-passes rule.
+
+     {:acc  acc            ;; symbol standing for the contraction's accumulator
+      :expr <s-expr>       ;; e.g. (raster.numeric/* (raster.numeric/+ acc (aget bias j)) s)
+      :operands [{:sym bias :map <axis-map over the FREE axes> :dtype :float}]
+      :scalars  [{:sym s :dtype :float}]      ;; optional uniform scalars
+      :helpers  <C source string>}  ;; optional, prepended (e.g. a silu_f definition)
+
+   `free-syms` are the contraction's two free-axis symbols, bound to the store slot's `row`/`col`
+   C variables — so an operand's axis-map generates its index exactly as in the kernel body.
+   Returns {:epilogue fn :epilogue-params str :epilogue-helpers str|nil}."
+  [{:keys [acc expr operands scalars helpers]} [i-sym j-sym] dtype]
+  (let [ctype (get codegen/opencl-type-map dtype "float")
+        arr-syms (set (map (comp #(symbol (name %)) :sym) operands))
+        int-vars (into #{} (map #(symbol (name %))) [i-sym j-sym])
+        ;; substitute each operand's aget index from its declared map (maps, not pattern-matching)
+        idx-of (into {} (for [{:keys [sym map]} operands] [sym (am/index-expr map)]))
+        expr' (walk/postwalk
+               (fn [f] (if (and (seq? f) (= 'aget (first f)) (contains? idx-of (second f)))
+                         (list 'aget (second f) (get idx-of (second f)))
+                         f))
+               expr)
+        acc-token (str "__acc_" (name (gensym "")))
+        ;; emit once with a distinctive token standing in for the accumulator, then splice the
+        ;; real acc C-expression in at call time (the hook supplies it per store slot)
+        emitted (binding [ce/*emit-config* ce/opencl-config
+                          ce/*scalar-type* ctype
+                          ce/*int-vars* (into ce/*int-vars* int-vars)]
+                  (ce/emit-expr (walk/postwalk-replace {acc (symbol acc-token)} expr')
+                                (gensym "z__") arr-syms))
+        params (apply str
+                      (concat
+                       (for [{:keys [sym dtype] :or {dtype :float}} operands]
+                         (str ", __global const " (get codegen/opencl-type-map dtype "float")
+                              "* restrict " (ce/c-symbol sym)))
+                       (for [{:keys [sym dtype] :or {dtype :float}} scalars]
+                         (str ", " (get codegen/opencl-type-map dtype "float") " " (ce/c-symbol sym)))))]
+    {:epilogue (fn [acc-expr row col]
+                 (-> emitted
+                     (str/replace acc-token (str "(" acc-expr ")"))
+                     (str/replace (re-pattern (str "\\b" (ce/c-symbol i-sym) "\\b")) row)
+                     (str/replace (re-pattern (str "\\b" (ce/c-symbol j-sym) "\\b")) col)))
+     :epilogue-params params
+     :epilogue-helpers helpers}))
 
 (defn generate-dpas-contraction-kernel
   "DPAS/XMX-tensorized contraction → OpenCL (PEAK; raster's edge over Futhark's portable
@@ -696,7 +750,7 @@
             :tensorized true}  — NB: :array-params is in [row col] BINDING order (row's
    buffer → A slot, col's → B slot, out → C), NOT sorted-by-name. Returns
    {:tensorized false :reason …} when the gate rejects (caller falls back to regtiled)."
-  [segred out-sym & {:keys [dtype desc tile] :or {dtype :half}}]
+  [segred out-sym & {:keys [dtype desc tile epilogue] :or {dtype :half}}]
   (let [gate (dpas-contraction-legal? segred dtype)]
     (if-not (:ok gate)
       {:tensorized false :reason (:reason gate) :detail gate}
@@ -711,17 +765,27 @@
             ;; descriptor is equivalent to the previous literal — with zero magic numbers here.
             tile (or tile (hw/derive-gemm-tile (or desc {})))
             sg (long (get-in tile [:matrix :subgroup] 16))
-            source (codegen/emit-gemm-tiled kernel-name :c-dtype :half
-                                            :block-m (:block-m tile) :block-n (:block-n tile)
-                                            :sg-m (:sg-m tile) :sg-n (:sg-n tile)
-                                            :block-k (:block-k tile)
-                                            :matrix (:matrix tile))]
+            ;; EPILOGUE FUSION: fold the consumer expression into the store slot, so a
+            ;; bias/activation/residual/dequant costs no extra kernel and no DRAM round-trip of C.
+            ep (when epilogue
+                 (epilogue-splice epilogue
+                                  [(:i-sym gate) (:j-sym gate)]
+                                  (get epilogue :dtype :float)))
+            source (apply codegen/emit-gemm-tiled kernel-name
+                          (concat [:c-dtype :half
+                                   :block-m (:block-m tile) :block-n (:block-n tile)
+                                   :sg-m (:sg-m tile) :sg-n (:sg-n tile)
+                                   :block-k (:block-k tile) :matrix (:matrix tile)]
+                                  (when ep [:epilogue (:epilogue ep)
+                                            :epilogue-params (:epilogue-params ep)
+                                            :epilogue-helpers (:epilogue-helpers ep)])))]
         {:kernel-name kernel-name
          :source source
          :array-params [row-arr col-arr]      ;; [A-slot B-slot] binding order
          :dims [M N L]
          :dtype :half
          :tile tile
+         :epilogue-params (when ep (:epilogue-params ep))
          ;; workgroup = (block-m/sg-m)·(block-n/sg-n) subgroups × the matrix subgroup size
          :workgroup [(* (quot (:block-m tile) (:sg-m tile))
                         (quot (:block-n tile) (:sg-n tile))

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -14,6 +14,7 @@
             [raster.compiler.core.hardware :as hw]
             [raster.compiler.ir.axis-map :as am]
             [clojure.walk :as walk]
+            [clojure.set]
             [raster.compiler.ir.segop :as segop]
             [clojure.string :as str]))
 
@@ -686,6 +687,83 @@
         (catch clojure.lang.ExceptionInfo e
           {:ok false :reason :not-a-contraction :msg (.getMessage e)})))))
 
+(def ^:private epilogue-forbidden-ops
+  "Ops that cannot appear in a store-spliced epilogue because they force a distribution/layout
+   change of the accumulator (Triton's blocked-only / anchor set): a scan, a NON-associative
+   reduction, a permuting reshape, or an atomic. An associative reduction is not forbidden outright
+   — it is a RE-TILING decision (distribute the accumulator so the reduction is warp-local) which
+   we do not implement yet, so it is refused here with its own reason."
+  '#{raster.par/scan raster.par/scan-exclusive raster.par/scatter! raster.par/reduce-by-key
+     raster.par/reduce raster.par/reduce-into raster.par/contract})
+
+(defn epilogue-legal?
+  "Legality of splicing `expr` into the contraction's STORE slot. Returns {:ok true} or
+   {:ok false :reason kw}. Distilled from Halide / XLA / Triton / MLIR-linalg:
+
+     • the epilogue is emitted strictly AFTER the reduction loop closes. Placing it inside forces
+       accumulator multi-buffering under software pipelining — a silent 2x on the most expensive
+       resource. Our splice is in the store slot, so this holds by construction; it is asserted
+       here so a future change cannot quietly break it.
+     • no op that forces a layout/distribution change: scan, non-associative reduce, permuting
+       reshape, atomic. A reduction in the epilogue is a re-tiling decision (redistribute the
+       accumulator so the reduce is warp-local) — legal in principle, unimplemented, so refused
+       with :reduction-in-epilogue rather than silently miscompiled.
+     • the accumulator must appear exactly ONCE: more than one use duplicates the reduction result
+       through the epilogue expression, which is the recompute case the ceilings guard against."
+  [{:keys [acc expr]}]
+  (let [nodes (tree-seq coll? seq expr)
+        heads (into #{} (keep #(when (seq? %) (first %))) nodes)
+        acc-uses (count (filter #(= acc %) nodes))]
+    (cond
+      (zero? acc-uses)                     {:ok false :reason :epilogue-ignores-accumulator}
+      (> acc-uses 1)                       {:ok false :reason :accumulator-used-more-than-once}
+      (some #{'raster.par/reduce 'raster.par/reduce-into} heads)
+      {:ok false :reason :reduction-in-epilogue}
+      (seq (clojure.set/intersection heads epilogue-forbidden-ops))
+      {:ok false :reason :layout-changing-op-in-epilogue
+       :ops (clojure.set/intersection heads epilogue-forbidden-ops)}
+      :else {:ok true})))
+
+(defn epilogue-cost
+  "Byte-traffic model for splicing an epilogue into the contraction's store, and the register
+   pressure it adds. Returns {:fused-bytes :unfused-bytes :saved-bytes :profitable :acc-regs}.
+
+   NOTE ON A TEST THAT DOES NOT TRANSFER. Halide's `is_func_trivial_to_inline`
+   (1 + sizeof(out) >= arith + bytes) is a PRODUCER-INLINING test: should I duplicate a producer's
+   work at each consumer, paying recompute? Applied to an epilogue it gives the wrong answer — it
+   scores a bias-add as unprofitable (call 3 vs inline 6 at f16) because it charges the bias LOAD
+   without crediting the eliminated round-trip. Epilogue (output) fusion is the opposite direction:
+   it REMOVES traffic rather than duplicating work.
+
+       unfused:  write C  +  read C  +  read operands  +  write C   ~ 3·M·N + operands
+       fused:    read operands                                     ~ operands
+
+   So an epilogue is profitable whenever it is legal and fits in registers — which is why Triton
+   and XLA fuse epilogues unconditionally and gate on legality + register pressure instead. The
+   recompute ceilings (8x CPU / 10x GPU) and the multi-consumer refusal belong to the PRODUCER
+   direction; the analogue here is `epilogue-legal?`'s accumulator-used-once rule.
+
+   Register estimate follows Triton's closed form: elems-per-thread × threads-per-warp ×
+   warps-per-CTA × elem-bytes / 4 registers for the accumulator; the epilogue's live values must
+   fit in the remaining budget (Triton clamps accumulator traffic at maxnreg/2 to avoid spilling)."
+  [{:keys [operands]} out-dtype [M N] tile]
+  (let [bytes-of (fn [dt] (long (get {:double 8 :float 4 :half 2 :float16 2 :int 4 :byte 1} dt 4)))
+        cb (bytes-of out-dtype)
+        c-elems (* (long M) (long N))
+        operand-bytes (reduce + 0 (for [{:keys [dtype] :or {dtype :float}} operands]
+                                    (* (long N) (bytes-of dtype))))
+        unfused (+ (* 3 c-elems cb) operand-bytes)   ; write + read + write, plus operand reads
+        fused   operand-bytes
+        ;; accumulator registers per lane: (block-m·block-n / (subgroups·subgroup)) f32 values
+        {:keys [block-m block-n sg-m sg-n]} tile
+        sg (long (get-in tile [:matrix :subgroup] 16))
+        acc-regs (when (and block-m block-n sg-m sg-n)
+                   (quot (* (long sg-m) (long sg-n)) sg))]
+    {:fused-bytes fused :unfused-bytes unfused
+     :saved-bytes (- unfused fused)
+     :profitable (< fused unfused)
+     :acc-regs acc-regs}))
+
 (defn epilogue-splice
   "Build the (fn [acc-expr row col] -> C-expr) + param-decls + helpers that emit-gemm-tiled's
    store-splice expects, from a DOMAIN-AGNOSTIC spec. The compiler learns no op names: the spec is
@@ -702,8 +780,12 @@
    `free-syms` are the contraction's two free-axis symbols, bound to the store slot's `row`/`col`
    C variables — so an operand's axis-map generates its index exactly as in the kernel body.
    Returns {:epilogue fn :epilogue-params str :epilogue-helpers str|nil}."
-  [{:keys [acc expr operands scalars helpers]} [i-sym j-sym] dtype]
-  (let [ctype (get codegen/opencl-type-map dtype "float")
+  [{:keys [acc expr operands scalars helpers] :as spec} [i-sym j-sym] dtype]
+  (let [legal (epilogue-legal? spec)
+        _ (when-not (:ok legal)
+            (throw (ex-info (str "epilogue-splice: illegal epilogue (" (:reason legal) ")")
+                            (assoc legal :expr expr))))
+        ctype (get codegen/opencl-type-map dtype "float")
         arr-syms (set (map (comp #(symbol (name %)) :sym) operands))
         int-vars (into #{} (map #(symbol (name %))) [i-sym j-sym])
         ;; substitute each operand's aget index from its declared map (maps, not pattern-matching)

--- a/src/raster/compiler/passes/parallel/contract_lower.clj
+++ b/src/raster/compiler/passes/parallel/contract_lower.clj
@@ -51,8 +51,9 @@
         opts-map (apply hash-map opts)
         init (get opts-map :init 0.0)
         combine (get opts-map :combine '+)
-        _ (assert (and (vector? free-axes) (pos? (count free-axes)))
-                  "contract-lower: free-axes must be a non-empty vector")
+        ;; ZERO free axes is legal: the SegSpace then has only the reduced dim, i.e. exactly the
+        ;; 1-D shape (segop/seg-space-1d?) that the full-reduction emitter consumes.
+        _ (assert (vector? free-axes) "contract-lower: free-axes must be a vector")
         _ (assert (and (vector? contract-axes) (pos? (count contract-axes)))
                   "contract-lower: contract-form->segred needs ≥1 contract axis (0 → contract-form->segmap)")
         _ (assert (symbol? out) "contract-lower: out must be a symbol")

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -61,6 +61,25 @@
       (#{:byte :int8} dtype)
       (route-quant contract-form out-sym scheme n-free n-contract nseg prefer-peak?)
 
+      ;; 0 FREE axes → a full reduction to a scalar. This is the last cell of contract's
+      ;; algebra: (n free, 0 contract) = map, (n, n) = contraction, (0, n) = REDUCTION. The
+      ;; SegSpace then has only the reduced dim — exactly the 1-D shape (seg-space-1d?) that
+      ;; generate-segred-kernel's two-phase tree reduction already consumes, so no new emitter.
+      ;; Its launch protocol differs (two phases + a host-side final combine), so the descriptor
+      ;; says so with :invoke :reduction rather than pretending it is a 2-D kernel launch.
+      (zero? n-free)
+      (let [sr (cl/contract-form->segred contract-form :dtype dtype)
+            k (sco/generate-segred-kernel sr out-sym :dtype dtype)
+            red-bound (second (first contract-axes))]
+        {:strategy :full-reduce
+         :invoke :reduction
+         :kernel-name (:kernel-name k) :source (:source k)
+         :array-params (:array-params k)
+         :dtype dtype :out-dtype dtype :out-elems 1
+         :n-phases (:n-phases k)
+         :reduce-bound red-bound          ; element count the reduction spans
+         :scalar-args [] :dims [1]})
+
       ;; 0 contract axes → outer product / broadcast → pure N-D SegMap (1-D launch)
       (zero? n-contract)
       (let [sm (cl/contract-form->segmap contract-form :dtype dtype)

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -41,7 +41,7 @@
    the int8 quant leaves — dp4a for the :nt operand layout, quant naive-widening for :nn;
    anything else, or a gate rejection, falls back to the register-tiled portable kernel).
    scheme = the quant decode descriptor {:scale :a-zp :b-zp} for int8 (default {:scale 1.0})."
-  [contract-form & {:keys [dtype scheme prefer-peak? desc tile]
+  [contract-form & {:keys [dtype scheme prefer-peak? desc tile epilogue]
                     :or {dtype :half scheme {:scale 1.0} prefer-peak? false}}]
   (let [out-sym (second contract-form)
         free-axes (nth contract-form 2)
@@ -56,7 +56,11 @@
                (reduce * 1 free-bounds)
                (reduce (fn [a b] (list 'clojure.core/* a b)) free-bounds))
         ;; memoized so the cond's test arm doesn't regenerate the kernel
-        tensorize-plan (memoize #(route-2free-1contract contract-form out-sym dtype desc tile))]
+        ;; a fused contraction carries its epilogue in the form's trailing opts (par-fusion's
+        ;; fuse-contract-map puts it there); an explicit :epilogue kwarg overrides.
+        form-opts (apply hash-map (drop 5 contract-form))
+        epilogue (or epilogue (:epilogue form-opts))
+        tensorize-plan (memoize #(route-2free-1contract contract-form out-sym dtype desc tile epilogue))]
     (cond
       ;; int8 → the quant leaves (dp4a for :nt, quant naive-widening for :nn)
       (#{:byte :int8} dtype)
@@ -112,10 +116,11 @@
   "The tensorize fast path: DPAS if the gate accepts, else the register-tiled portable kernel.
    Returns nil if the form fails a structural precondition of BOTH (the emitters signal that
    with ex-info) — the caller then routes to the general naive leaf."
-  [contract-form out-sym dtype desc tile]
+  [contract-form out-sym dtype desc tile epilogue]
   (try
    (let [sr (cl/contract-form->segred contract-form :dtype dtype)
-         dpas (sco/generate-dpas-contraction-kernel sr out-sym :dtype dtype :desc desc :tile tile)]
+         dpas (sco/generate-dpas-contraction-kernel sr out-sym :dtype dtype :desc desc :tile tile
+                                                    :epilogue epilogue)]
     (if (:tensorized dpas)
       (let [[M N _L] (:dims dpas)
             {:keys [block-m block-n]} (:tile dpas)]
@@ -125,6 +130,7 @@
          :array-params (:array-params dpas)          ; [row col] = [A-slot B-slot]
          :dtype :half :out-dtype :half :out-elems (* M N)
          :tile (:tile dpas)                          ; the DERIVED tile actually emitted
+         :fused-epilogue (boolean epilogue)
          :wg (:workgroup dpas)                       ; derived from that tile
          :grid [(ceil-div N block-n) (ceil-div M block-m)]  ; [gc-n gc-m] (id0=N, id1=M)
          :scalar-args (mapv (fn [v] {:type :int :value (int v)}) (:dims dpas))  ; [m n k] params

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -41,7 +41,8 @@
    the int8 quant leaves — dp4a for the :nt operand layout, quant naive-widening for :nn;
    anything else, or a gate rejection, falls back to the register-tiled portable kernel).
    scheme = the quant decode descriptor {:scale :a-zp :b-zp} for int8 (default {:scale 1.0})."
-  [contract-form & {:keys [dtype scheme prefer-peak?] :or {dtype :half scheme {:scale 1.0} prefer-peak? false}}]
+  [contract-form & {:keys [dtype scheme prefer-peak? desc tile]
+                    :or {dtype :half scheme {:scale 1.0} prefer-peak? false}}]
   (let [out-sym (second contract-form)
         free-axes (nth contract-form 2)
         contract-axes (nth contract-form 3)
@@ -55,7 +56,7 @@
                (reduce * 1 free-bounds)
                (reduce (fn [a b] (list 'clojure.core/* a b)) free-bounds))
         ;; memoized so the cond's test arm doesn't regenerate the kernel
-        tensorize-plan (memoize #(route-2free-1contract contract-form out-sym dtype))]
+        tensorize-plan (memoize #(route-2free-1contract contract-form out-sym dtype desc tile))]
     (cond
       ;; int8 → the quant leaves (dp4a for :nt, quant naive-widening for :nn)
       (#{:byte :int8} dtype)
@@ -111,10 +112,10 @@
   "The tensorize fast path: DPAS if the gate accepts, else the register-tiled portable kernel.
    Returns nil if the form fails a structural precondition of BOTH (the emitters signal that
    with ex-info) — the caller then routes to the general naive leaf."
-  [contract-form out-sym dtype]
+  [contract-form out-sym dtype desc tile]
   (try
    (let [sr (cl/contract-form->segred contract-form :dtype dtype)
-         dpas (sco/generate-dpas-contraction-kernel sr out-sym :dtype dtype)]
+         dpas (sco/generate-dpas-contraction-kernel sr out-sym :dtype dtype :desc desc :tile tile)]
     (if (:tensorized dpas)
       (let [[M N _L] (:dims dpas)
             {:keys [block-m block-n]} (:tile dpas)]
@@ -123,7 +124,8 @@
          :source (:source dpas)
          :array-params (:array-params dpas)          ; [row col] = [A-slot B-slot]
          :dtype :half :out-dtype :half :out-elems (* M N)
-         :wg (:workgroup dpas)                       ; derived from the emitted tile
+         :tile (:tile dpas)                          ; the DERIVED tile actually emitted
+         :wg (:workgroup dpas)                       ; derived from that tile
          :grid [(ceil-div N block-n) (ceil-div M block-m)]  ; [gc-n gc-m] (id0=N, id1=M)
          :scalar-args (mapv (fn [v] {:type :int :value (int v)}) (:dims dpas))  ; [m n k] params
          :dims (:dims dpas)})

--- a/src/raster/compiler/passes/parallel/par_fusion.clj
+++ b/src/raster/compiler/passes/parallel/par_fusion.clj
@@ -11,7 +11,8 @@
   intermediate elimination is safe.
 
   Design informed by Futhark's fusion via dependency graphs."
-  (:require [raster.compiler.core.op-descriptor :as descriptor]
+  (:require [clojure.walk]
+            [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
             [raster.compiler.passes.parallel.descriptors :as desc]
             [raster.compiler.passes.parallel.fusion-support :as fusion-support]
@@ -130,6 +131,77 @@
                   ;; Can't fuse, keep as-is
                   (recur (inc i) (conj result [sym expr]) fused skip-set)))
               ;; Not a map — keep as-is
+              (recur (inc i) (conj result [sym expr]) fused skip-set))))))))
+
+(defn- agets-on-arrays
+  "Every (aget arr idx) node in `expr`, as a set of the array symbols read."
+  [expr]
+  (into #{} (keep #(when (and (seq? %) (= 'aget (first %))) (second %)))
+        (tree-seq coll? seq expr)))
+
+(defn fuse-contract-map
+  "Fuse a contraction followed by an ELEMENTWISE map over its output into ONE contraction whose
+   `:epilogue` carries the map's body — the store-splice the tile-parametric GEMM emitter exposes.
+
+  Before (2 kernels, and a full DRAM round-trip of C):
+    C   (raster.par/contract C [[i m] [j n]] [[l k]] (* (aget A ..) (aget B ..)))
+    out (raster.par/map! out t (* m n) nil (silu (aget C t)))
+
+  After (1 kernel; C never reaches memory):
+    out (raster.par/contract out [[i m] [j n]] [[l k]] (* (aget A ..) (aget B ..))
+                            :epilogue {:acc acc :expr (silu acc)})
+
+  FIRST CUT — the map body may read only the contraction's output (plus scalars/literals), i.e. a
+  pure activation/scale. That is the dominant `linear → activation` shape and needs no index
+  recovery. A body reading OTHER arrays (e.g. a per-column bias) needs its flat map index decomposed
+  into the contraction's free axes to build the operand's axis-map; until that exists such an
+  epilogue must be supplied explicitly (segop-opencl/epilogue-splice takes operands with maps).
+
+  Legality is delegated to segop-opencl/epilogue-legal? at emit time (accumulator used exactly once,
+  no reduction/layout-changing op, spliced strictly after the reduction loop).
+
+  Returns {:bindings new-bindings :fused count} or nil."
+  [bindings-vec body-exprs]
+  (let [pairs (vec (partition 2 bindings-vec))
+        n (count pairs)
+        contract? (fn [e] (and (seq? e) (= 'raster.par/contract (first e))))]
+    (loop [i 0 result [] fused 0 skip-set #{}]
+      (if (>= i n)
+        (when (pos? fused) {:bindings (vec (mapcat identity result)) :fused fused})
+        (if (contains? skip-set i)
+          (recur (inc i) result fused skip-set)
+          (let [[sym expr] (nth pairs i)]
+            (if (contract? expr)
+              (let [c-out (second expr)
+                    already-fused? (contains? (set (drop 5 expr)) :epilogue)
+                    map-idx (when-not already-fused?
+                              (first (keep-indexed
+                                      (fn [j [_s e]]
+                                        (when (> j i)
+                                          (when-let [mi (desc/map-form-info e)]
+                                            (when (and (aget-reads-sym? (:body mi) c-out)
+                                                       ;; first cut: body reads ONLY the contraction output
+                                                       (= #{c-out} (agets-on-arrays (:body mi))))
+                                              j))))
+                                      pairs)))
+                    safe? (and map-idx
+                               (not (sym-used-outside? c-out pairs body-exprs i map-idx)))]
+                (if safe?
+                  (let [[msym mexpr] (nth pairs map-idx)
+                        mi (desc/map-form-info mexpr)
+                        acc-sym (gensym "acc__")
+                        ;; (aget C <map-idx>) → the accumulator symbol
+                        ep-expr (clojure.walk/postwalk
+                                 (fn [f] (if (and (seq? f) (= 'aget (first f)) (= c-out (second f)))
+                                           acc-sym f))
+                                 (:body mi))
+                        fused-form (concat (list 'raster.par/contract (:out mi))
+                                           (drop 2 (take 5 expr))
+                                           (drop 5 expr)
+                                           [:epilogue {:acc acc-sym :expr ep-expr}])]
+                    (recur (inc i) (conj result [msym (apply list fused-form)])
+                           (inc fused) (conj skip-set map-idx)))
+                  (recur (inc i) (conj result [sym expr]) fused skip-set)))
               (recur (inc i) (conj result [sym expr]) fused skip-set))))))))
 
 ;; ================================================================

--- a/src/raster/dl/einsum.clj
+++ b/src/raster/dl/einsum.clj
@@ -116,19 +116,28 @@
 (declare parse-rearrange-pattern)
 
 (defn einsum->contract-form
-  "Lower a 2-operand einsum to a `(raster.par/contract out free-axes contract-axes body)` form,
-   the bridge from the general einsum surface to the contraction path (B1). free-axes = the
+  "Lower a 1- or 2-operand einsum to a `(raster.par/contract out free-axes contract-axes body)`
+   form — the bridge from the general einsum surface to the contraction path (B1). free-axes = the
    OUTPUT labels (in output order → the row-major write gives the right layout, A3); contract-
-   axes = labels that appear in the inputs but not the output (summed); body = the product of
-   the two operand agets, each indexed by its strided affine index expression. `dim-map` maps
-   each label → its extent; `out-sym` / `in-syms` name the output + the two input arrays in the
-   emitted form. Routing the result through `contract-route/route-contraction` sends it to the
-   peak leaves (DPAS/dp4a) or the portable fallback. n-operand einsum decomposes to a sequence
-   of these pairwise steps (B2)."
+   axes = labels that appear in the inputs but not the output (summed); body = a single operand
+   `aget` (unary) or the product of the two (binary), each indexed by its strided affine index
+   expression. `dim-map` maps each label → its extent; `out-sym` / `in-syms` name the output +
+   the input arrays in the emitted form.
+
+   UNARY covers transpose (`ij->ji`), axis reduction (`ij->i`) and — with no extra machinery —
+   the DIAGONAL (`ii->i`), because a repeated label makes the axis-map emit `i·N + i`. Routing
+   the result through `contract-route/route-contraction` sends it to the peak leaves (DPAS/dp4a)
+   or the portable fallback. n-operand einsum decomposes to a sequence of pairwise steps (B2).
+
+   NOT yet expressible: a SCALAR output (`ij->`, `ii->`, `i,i->`) — that needs 0 free axes, which
+   `par/contract` does not admit; tracked separately (G2)."
   [subscript dim-map out-sym in-syms]
   (let [{:keys [inputs output]} (parse-subscript subscript)
-        _ (assert (= 2 (count inputs))
-                  "einsum->contract-form: exactly 2 operands (pairwise; n-operand path = B2)")
+        _ (assert (<= 1 (count inputs) 2)
+                  "einsum->contract-form: 1 (unary) or 2 (pairwise) operands; n-operand path = B2")
+        _ (assert (seq output)
+                  (str "einsum->contract-form: scalar output (0 free axes) is not expressible as a "
+                       "par/contract yet — see G2. subscript: " subscript))
         all-labels (distinct (mapcat identity inputs))
         contract-labels (vec (remove (set output) all-labels))
         lsym (fn [l] (symbol (name l)))
@@ -138,8 +147,10 @@
         operand-map (fn [labels] (am/of-axes (mapv axis labels)))
         maps (zipmap in-syms (map operand-map inputs))
         idx-expr (fn [labels] (am/index-expr (operand-map labels)))
-        body (list '* (list 'aget (nth in-syms 0) (idx-expr (nth inputs 0)))
-                   (list 'aget (nth in-syms 1) (idx-expr (nth inputs 1))))]
+        operand (fn [k] (list 'aget (nth in-syms k) (idx-expr (nth inputs k))))
+        body (if (= 1 (count inputs))
+               (operand 0)                          ; unary: transpose / reduce / diagonal
+               (list '* (operand 0) (operand 1)))]  ; binary: the contracted product
     ;; :maps carries the declared per-operand layout downstream (orientation as DATA — the gate
     ;; compares maps instead of pattern-matching the body's index arithmetic).
     (list 'raster.par/contract out-sym (mapv axis output) (mapv axis contract-labels) body
@@ -223,6 +234,13 @@
         _ (assert (= (count inputs) (count in-syms))
                   "einsum->contract-steps: one input symbol per subscript operand")
         path (contraction-path inputs output dim-map)]
+    ;; A UNARY einsum has no pair to contract, so the greedy path is empty — but the operand still
+    ;; needs transposing/reducing/diagonalizing. Emit the single unary step directly.
+    (if (= 1 (count inputs))
+      (let [form (einsum->contract-form subscript dim-map out-sym in-syms)]
+        {:steps [{:out out-sym :labels (vec output)
+                  :shape (mapv dim-map output) :form form}]
+         :result out-sym :path []})
     (loop [labels (vec inputs) syms (vec in-syms) todo path steps []]
       (if (empty? todo)
         {:steps steps :result (if (seq steps) (:out (peek steps)) (first syms)) :path path}
@@ -242,7 +260,7 @@
                  (vec (concat others-syms [step-out]))
                  (rest todo)
                  (conj steps {:out step-out :labels keep
-                              :shape (mapv dim-map keep) :form form})))))))
+                              :shape (mapv dim-map keep) :form form}))))))))
 
 ;; ================================================================
 ;; rearrange → contract  (Phase 2: split/merge/transpose as a map application)

--- a/src/raster/dl/einsum.clj
+++ b/src/raster/dl/einsum.clj
@@ -23,6 +23,7 @@
             [raster.ad.templates :as tmpl]
             [raster.par :as par]
             [raster.compiler.ir.axis-map :as am]
+            [clojure.set]
             [clojure.string :as str]))
 
 ;; ================================================================
@@ -143,6 +144,105 @@
     ;; compares maps instead of pattern-matching the body's index arithmetic).
     (list 'raster.par/contract out-sym (mapv axis output) (mapv axis contract-labels) body
           :maps (assoc maps out-sym (operand-map output)))))
+
+;; ================================================================
+;; n-operand einsum → a PATH of pairwise contractions  (B2)
+;;
+;; Generality via DECOMPOSITION, never a monolithic general kernel: an n-operand einsum becomes
+;; an ordered sequence of 2-operand contractions, each of which is a `par/contract` the gate can
+;; send to a peak leaf. Follows opt_einsum: the per-step index algebra is pure set arithmetic,
+;; and the order is chosen greedily by memory-removed.
+;; ================================================================
+
+(defn pair-contraction
+  "The index algebra for contracting operands `i` and `j` out of `operand-labels`, given the
+   final `output` labels (opt_einsum's `find_contraction`, helpers.py:51-104):
+
+     touched = the pair's labels          (the step's full iteration space)
+     keep    = labels needed DOWNSTREAM   (in `output`, or in any surviving operand)
+     sum     = labels appearing ONLY in this pair  (the contracted axes)
+
+   `keep` is ordered by first appearance across the pair, so the intermediate's layout matches
+   input-appearance order — opt_einsum's trick for making later steps need no transpose.
+   Returns {:keep [labels] :sum [labels] :remaining [label-vectors incl. the new intermediate]}."
+  [operand-labels i j output]
+  (let [n (count operand-labels)
+        li (nth operand-labels i) lj (nth operand-labels j)
+        touched (vec (distinct (concat li lj)))
+        others (keep-indexed (fn [k v] (when-not (or (= k i) (= k j)) v)) operand-labels)
+        downstream (into (set output) (mapcat identity others))
+        keep (vec (filter downstream touched))
+        sum (vec (remove (set keep) touched))
+        remaining (conj (vec others) keep)]
+    {:keep keep :sum sum :remaining remaining}))
+
+(defn- extent-of [dim-map labels] (reduce (fn [a l] (* a (long (dim-map l)))) 1 labels))
+
+(defn contraction-path
+  "Greedy contraction ORDER for an n-operand einsum (opt_einsum's `greedy`, paths.py:599).
+   Considers only pairs that SHARE a label, scores each by memory-removed
+   `size(result) − size(a) − size(b)` (paths.py:311 `cost_memory_removed`), and takes the
+   minimum, tie-broken by operand index so the path is deterministic.
+
+   Returns a vector of `[i j]` pairs, each indexing the CURRENT (shrinking) operand list — the
+   step's result is appended, so later pairs index the reduced list. A 1- or 2-operand einsum
+   yields `[]` or `[[0 1]]`."
+  [operand-labels output dim-map]
+  (loop [labels (vec operand-labels) path []]
+    (if (<= (count labels) 1)
+      path
+      (let [n (count labels)
+            cands (for [i (range n) j (range (inc i) n)
+                        :when (seq (clojure.set/intersection (set (nth labels i)) (set (nth labels j))))]
+                    [i j])
+            cands (if (seq cands) cands (for [i (range n) j (range (inc i) n)] [i j]))
+            scored (map (fn [[i j]]
+                          (let [{:keys [keep]} (pair-contraction labels i j output)]
+                            [(- (extent-of dim-map keep)
+                                (extent-of dim-map (nth labels i))
+                                (extent-of dim-map (nth labels j)))
+                             i j]))
+                        cands)
+            [_ bi bj] (first (sort-by (fn [[c i j]] [c i j]) scored))
+            {:keys [remaining]} (pair-contraction labels bi bj output)]
+        (recur remaining (conj path [bi bj]))))))
+
+(defn einsum->contract-steps
+  "Lower an n-operand einsum to an ORDERED sequence of pairwise `par/contract` steps (B2).
+   Each step is exactly what `einsum->contract-form` produces for 2 operands, so each is routable
+   to a peak leaf; intermediates are fresh gensyms. Returns
+
+     {:steps [{:out sym :labels [...] :shape [...] :form <par/contract form>} …]
+      :result sym       ;; the final step's output (== `out-sym` for the last step)
+      :path [[i j] …]}
+
+   The LAST step's free axes are the requested `output` labels, so no trailing transpose is
+   needed; earlier steps keep input-appearance order (see `pair-contraction`)."
+  [subscript dim-map out-sym in-syms]
+  (let [{:keys [inputs output]} (parse-subscript subscript)
+        _ (assert (= (count inputs) (count in-syms))
+                  "einsum->contract-steps: one input symbol per subscript operand")
+        path (contraction-path inputs output dim-map)]
+    (loop [labels (vec inputs) syms (vec in-syms) todo path steps []]
+      (if (empty? todo)
+        {:steps steps :result (if (seq steps) (:out (peek steps)) (first syms)) :path path}
+        (let [[i j] (first todo)
+              last? (= 1 (count todo))
+              {:keys [keep sum remaining]} (pair-contraction labels i j output)
+              ;; the FINAL step must land on the requested output layout
+              keep (if last? (vec output) keep)
+              step-out (if last? out-sym (gensym "t__"))
+              sub (str (apply str (map name (nth labels i))) ","
+                       (apply str (map name (nth labels j))) "->"
+                       (apply str (map name keep)))
+              form (einsum->contract-form sub dim-map step-out
+                                          [(nth syms i) (nth syms j)])
+              others-syms (keep-indexed (fn [k v] (when-not (or (= k i) (= k j)) v)) syms)]
+          (recur (vec (concat (butlast remaining) [keep]))
+                 (vec (concat others-syms [step-out]))
+                 (rest todo)
+                 (conj steps {:out step-out :labels keep
+                              :shape (mapv dim-map keep) :form form})))))))
 
 ;; ================================================================
 ;; rearrange → contract  (Phase 2: split/merge/transpose as a map application)

--- a/src/raster/dl/einsum.clj
+++ b/src/raster/dl/einsum.clj
@@ -129,15 +129,12 @@
    the result through `contract-route/route-contraction` sends it to the peak leaves (DPAS/dp4a)
    or the portable fallback. n-operand einsum decomposes to a sequence of pairwise steps (B2).
 
-   NOT yet expressible: a SCALAR output (`ij->`, `ii->`, `i,i->`) — that needs 0 free axes, which
-   `par/contract` does not admit; tracked separately (G2)."
+   SCALAR output (`ij->`, `ii->`, `i,i->`) is expressible: 0 free axes is the full-reduction cell
+   of contract's algebra, and lowers to the 1-D SegRed the two-phase reduction emitter consumes."
   [subscript dim-map out-sym in-syms]
   (let [{:keys [inputs output]} (parse-subscript subscript)
         _ (assert (<= 1 (count inputs) 2)
                   "einsum->contract-form: 1 (unary) or 2 (pairwise) operands; n-operand path = B2")
-        _ (assert (seq output)
-                  (str "einsum->contract-form: scalar output (0 free axes) is not expressible as a "
-                       "par/contract yet — see G2. subscript: " subscript))
         all-labels (distinct (mapcat identity inputs))
         contract-labels (vec (remove (set output) all-labels))
         lsym (fn [l] (symbol (name l)))

--- a/src/raster/par.clj
+++ b/src/raster/par.clj
@@ -148,6 +148,8 @@
     out          — output array; length = product of free-axis bounds, ROW-MAJOR over
                    the free axes in declared order (outer→inner)
     free-axes    — [[idx-sym bound] ...] the parallel output axes (≥1)
+    free-axes    — [[idx-sym bound] ...] the parallel/output axes. ZERO free axes is legal and
+                   means a FULL REDUCTION to a scalar, written to out[0].
     contract-axes— [[idx-sym bound] ...] the reduced axes: 0 (outer product / pure map),
                    1, or n (n≥2 are flattened into one innermost reduced dim)
     body         — the summand expression; may reference every free and contract idx
@@ -164,8 +166,7 @@
     (raster.par/contract C [[i m] [j n]] [[l k]]
       (* (aget A (+ (* i k) l)) (aget B (+ (* l n) j))))"
   [out free-axes contract-axes body & {:keys [init combine] :or {init 0.0 combine '+}}]
-  (assert (and (vector? free-axes) (pos? (count free-axes)))
-          "par/contract: free-axes must be a non-empty vector of [idx bound]")
+  (assert (vector? free-axes) "par/contract: free-axes must be a vector of [idx bound]")
   (assert (vector? contract-axes)
           "par/contract: contract-axes must be a vector (0 → outer product/map; n≥1 → contraction, n≥2 flattened)")
   (let [free-syms   (mapv first free-axes)
@@ -175,7 +176,12 @@
         F-sym   (gensym "F__")
         acc-sym (gensym "acc__")
         nfree   (count free-axes)
-        F-expr  (clojure.core/reduce (fn [a b] `(clojure.core/* ~a ~b)) int-bounds)
+        ;; Product over the free axes. ZERO free axes is the empty product = 1: the output is a
+        ;; single element and the generic expansion degenerates to one iteration writing out[0] —
+        ;; i.e. a FULL REDUCTION, the (0 free, n contract) cell of contract's algebra.
+        F-expr  (if (empty? int-bounds)
+                  1
+                  (clojure.core/reduce (fn [a b] `(clojure.core/* ~a ~b)) int-bounds))
         ;; row-major decompose flat f into each free index:
         ;;   idx_p = (f / (product of bounds after p)) mod bound_p
         suffix  (fn [p] (let [after (subvec int-bounds (inc p))]

--- a/test/raster/compiler/backend/gpu/dpas_contract_device_test.clj
+++ b/test/raster/compiler/backend/gpu/dpas_contract_device_test.clj
@@ -181,3 +181,41 @@
           ;; f16 store on both sides; compare at f16 tolerance
           (is (every? true? (map #(< (Math/abs (- (double %1) (double %2))) 3.0e-2) fused ref))
               (str "fused " (take 4 fused) " vs two-pass " (take 4 ref))))))))
+
+;; ── Q2b: epilogue LEGALITY + the honest cost model (device-free) ───────────────────────
+(deftest epilogue-legality-refuses-the-cases-that-would-miscompile
+  (let [am (requiring-resolve 'raster.compiler.ir.axis-map/of-axes)
+        bias {:acc 'acc :expr (list 'raster.numeric/+ 'acc (list 'aget 'bias 'j))
+              :operands [{:sym 'bias :map (am [['j 512]]) :dtype :float}]}]
+    (testing "a bias/activation epilogue is legal"
+      (is (:ok (sco/epilogue-legal? bias))))
+    (testing "the accumulator must appear exactly once (>1 duplicates the reduction result)"
+      (is (= :accumulator-used-more-than-once
+             (:reason (sco/epilogue-legal? {:acc 'acc :expr (list 'raster.numeric/* 'acc 'acc)}))))
+      (is (= :epilogue-ignores-accumulator
+             (:reason (sco/epilogue-legal? {:acc 'acc :expr (list 'aget 'bias 'j)})))))
+    (testing "a reduction inside the epilogue is refused with its own reason (re-tiling, not yet done)"
+      (is (= :reduction-in-epilogue
+             (:reason (sco/epilogue-legal? {:acc 'acc :expr (list 'raster.par/reduce 'a 0.0 'i 8 'acc)})))))
+    (testing "layout/distribution-changing ops are refused"
+      (is (= :layout-changing-op-in-epilogue
+             (:reason (sco/epilogue-legal? {:acc 'acc :expr (list 'raster.par/scan 'o 'a 0.0 'i 8 nil 'acc)})))))
+    (testing "epilogue-splice itself enforces legality (fails loud, never silently miscompiles)"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"illegal epilogue"
+            (sco/epilogue-splice {:acc 'acc :expr (list 'raster.numeric/* 'acc 'acc)} '[i j] :float))))))
+
+(deftest epilogue-cost-reflects-the-eliminated-round-trip
+  (let [hw (requiring-resolve 'raster.compiler.core.hardware/derive-gemm-tile)
+        am (requiring-resolve 'raster.compiler.ir.axis-map/of-axes)
+        bias {:acc 'acc :expr (list 'raster.numeric/+ 'acc (list 'aget 'bias 'j))
+              :operands [{:sym 'bias :map (am [['j 512]]) :dtype :float}]}
+        c (sco/epilogue-cost bias :half [256 512] (hw {}))]
+    (testing "fusing an epilogue REMOVES traffic (it does not duplicate work)"
+      (is (:profitable c))
+      (is (< (:fused-bytes c) (:unfused-bytes c)))
+      ;; unfused ≈ write C + read C + write C = 3·M·N·2 bytes; fused ≈ just the operand read
+      (is (= (* 3 256 512 2) (- (:unfused-bytes c) (* 512 4))))
+      (is (= (* 512 4) (:fused-bytes c)))
+      (is (> (:saved-bytes c) 700000)))
+    (testing "accumulator register estimate follows the derived tile (sg-m·sg-n/subgroup)"
+      (is (= 64 (:acc-regs c))))))

--- a/test/raster/compiler/backend/gpu/dpas_contract_device_test.clj
+++ b/test/raster/compiler/backend/gpu/dpas_contract_device_test.clj
@@ -219,3 +219,38 @@
       (is (> (:saved-bytes c) 700000)))
     (testing "accumulator register estimate follows the derived tile (sg-m·sg-n/subgroup)"
       (is (= 64 (:acc-regs c))))))
+
+;; ── Q3: the fusion pass DISCOVERS the epilogue (contract → elementwise map ⇒ one kernel) ──
+(deftest fusion-pass-discovers-contract-epilogue
+  (let [pf (requiring-resolve 'raster.compiler.passes.parallel.par-fusion/fuse-contract-map)
+        route (requiring-resolve 'raster.compiler.passes.parallel.contract-route/route-contraction)
+        M 128 N 128 K 64
+        mm (list 'raster.par/contract 'C [['i M] ['j N]] [['l K]]
+                 (list '* (list 'aget 'A (list '+ (list '* 'i K) 'l))
+                       (list 'aget 'B (list '+ (list '* 'l N) 'j))))
+        bindings ['C mm
+                  'out (list 'raster.par/map! 'out 't (* M N) nil
+                             (list 'silu_f (list 'aget 'C 't)))]]
+    (testing "contract + elementwise map collapse into ONE contract carrying an :epilogue"
+      (let [r (pf bindings [])
+            fused (second (:bindings r))
+            opts (apply hash-map (drop 5 fused))]
+        (is (= 1 (:fused r)))
+        (is (= 2 (count (:bindings r))) "4 bindings → 2: the intermediate is gone")
+        (is (= 'raster.par/contract (first fused)))
+        (is (= 'out (second fused)) "the fused contraction writes the map's target directly")
+        (is (some? (:epilogue opts)))
+        (is (= (list 'silu_f (:acc (:epilogue opts))) (:expr (:epilogue opts)))
+            "the map body becomes the epilogue, with (aget C t) → the accumulator")))
+    (testing "the routed descriptor reports the fusion and splices it into the store"
+      (let [fused (second (:bindings (pf bindings [])))
+            r (route fused :dtype :half)]
+        (is (:fused-epilogue r))
+        (is (str/includes? (:source r) "silu_f((acc00.s0))")
+            "the epilogue must appear in the STORE slot, not a second kernel")))
+    (testing "REFUSALS: an already-fused contract, and a map reading other arrays"
+      (let [bias-map ['C mm
+                      'out (list 'raster.par/map! 'out 't (* M N) nil
+                                 (list 'raster.numeric/+ (list 'aget 'C 't) (list 'aget 'bias 't)))]]
+        (is (nil? (pf bias-map []))
+            "a body reading OTHER arrays needs flat-index→free-axis decomposition; must not fuse yet")))))

--- a/test/raster/compiler/backend/gpu/dpas_contract_device_test.clj
+++ b/test/raster/compiler/backend/gpu/dpas_contract_device_test.clj
@@ -121,3 +121,63 @@
       (is (= :n-pitch-unaligned (:reason (sco/generate-dpas-contraction-kernel n-bad 'C))))
       (is (= :k-pitch-unaligned (:reason (sco/generate-dpas-contraction-kernel k-bad 'C))))
       (is (false? (:tensorized (sco/generate-dpas-contraction-kernel n-bad 'C)))))))
+
+;; ── Q2: EPILOGUE FUSION — fold bias+activation into the peak kernel's store slot ───────
+;; emit-gemm-tiled exposes a store-splice hook; the contraction path now drives it from a
+;; DOMAIN-AGNOSTIC spec (an expression over the accumulator + operands carrying axis-maps), so
+;; bias / activation / residual / dequant are one mechanism and compose by nesting. The win is a
+;; whole elementwise kernel and a DRAM round-trip of C removed.
+(defn- silu ^double [^double x] (/ x (+ 1.0 (Math/exp (- x)))))
+
+(deftest epilogue-fusion-matches-unfused-two-pass
+  (if-not @gpu?
+    (println "[skip] epilogue-fusion-device: no GPU")
+    (let [ze (find-ns 'raster.gpu.ze-runtime)
+          register! (ns-resolve ze 'register-kernel!)
+          ensure! (ns-resolve ze 'ensure-kernel-loaded!)
+          make-buffer (ns-resolve ze 'make-buffer)
+          halfs (ns-resolve ze 'buffer-of-floats-as-half)
+          arr->buf! (ns-resolve ze 'array->buffer!)
+          launch-2d! (ns-resolve ze 'launch-2d!)
+          buf->d (ns-resolve ze 'buffer->double-array)
+          am (requiring-resolve 'raster.compiler.ir.axis-map/of-axes)
+          M 128 K 64 N 128
+          Ad (double-array (map #(* 0.05 (- (double (mod % 7)) 3.0)) (range (* M K))))
+          Bd (double-array (map #(* 0.05 (- (double (mod % 5)) 2.0)) (range (* K N))))
+          biasd (float-array (map #(float (* 0.01 (- (mod % 9) 4))) (range N)))
+          sr (cl/contract-form->segred (matmul-form M N K) :dtype :half)
+          ep {:acc 'acc
+              :expr (list 'silu_f (list 'raster.numeric/+ 'acc (list 'aget 'bias 'j)))
+              :operands [{:sym 'bias :map (am [['j N]]) :dtype :float}]
+              :helpers "inline float silu_f(float x){ return x / (1.0f + native_exp(-x)); }"}
+          run (fn [k extra-args out]
+                (register! (:kernel-name k) {:source (:source k) :dtype :half})
+                (let [{:keys [kernel-handle]} (ensure! (:kernel-name k))
+                      abuf (halfs (float-array (map float Ad)))
+                      bbuf (halfs (float-array (map float Bd)))
+                      args (into [(:segment abuf) (:segment bbuf) (:segment out)
+                                  {:type :int :value M} {:type :int :value N} {:type :int :value K}]
+                                 extra-args)]
+                  (launch-2d! kernel-handle (:workgroup k)
+                              [(long (Math/ceil (/ (double N) (:block-n (:tile k)))))
+                               (long (Math/ceil (/ (double M) (:block-m (:tile k)))))]
+                              args)
+                  (vec (buf->d out))))
+          plain-k (sco/generate-dpas-contraction-kernel sr 'C)
+          fused-k (sco/generate-dpas-contraction-kernel sr 'C :epilogue ep)
+          bias-buf (arr->buf! (make-buffer N :float) biasd)
+          unfused (run plain-k [] (make-buffer (* M N) :half))
+          fused   (run fused-k [(:segment bias-buf)] (make-buffer (* M N) :half))]
+      (testing "the fused kernel gains the operand param and the helper"
+        (is (str/includes? (:source fused-k) "restrict bias"))
+        (is (str/includes? (:source fused-k) "silu_f(float x)"))
+        (is (str/includes? (:source fused-k) "silu_f(((acc00.s0) + bias[col]))")
+            "the axis-map's j must bind to the store slot's col"))
+      (testing "fused result == unfused GEMM followed by a separate bias+silu pass"
+        ;; the two-pass reference: read C back, then apply the epilogue on the host
+        (let [ref (vec (map-indexed (fn [idx v] (silu (+ (double v) (aget biasd (mod idx N)))))
+                                    unfused))]
+          (is (= (count ref) (count fused)))
+          ;; f16 store on both sides; compare at f16 tolerance
+          (is (every? true? (map #(< (Math/abs (- (double %1) (double %2))) 3.0e-2) fused ref))
+              (str "fused " (take 4 fused) " vs two-pass " (take 4 ref))))))))

--- a/test/raster/compiler/passes/parallel/contract_route_device_test.clj
+++ b/test/raster/compiler/passes/parallel/contract_route_device_test.clj
@@ -346,3 +346,37 @@
         (is (every? some? [(:kernel-name r) (:source r) (:array-params r) (:dtype r)
                            (:out-dtype r) (:out-elems r) (:wg r) (:grid r) (:scalar-args r)])
             (str label " descriptor incomplete"))))))
+
+;; ── Q1: the emitted tile is DERIVED from the hardware descriptor, never hardcoded ─────
+;; The DPAS leaf previously hardcoded {128 128 32 32 32, subgroup 16}. That constant happens to
+;; equal the Arc 140V derivation, so it worked here and no test caught it — but on a part with a
+;; different GRF budget / subgroup size / matrix shape it would emit a wrong-for-the-hardware
+;; tile while the production GEMM path adapted correctly. These are the tests that catch that.
+(deftest tile-is-derived-from-the-hardware-descriptor
+  (let [mm (matmul-form 256 512 128)
+        hw (requiring-resolve 'raster.compiler.core.hardware/derive-gemm-tile)]
+    (testing "no descriptor ⇒ hw/derive-gemm-tile's own defaults (the Arc config) — a NO-OP swap"
+      (let [r (route/route-contraction mm :dtype :half)]
+        (is (= (hw {}) (:tile r)))
+        (is (= {:block-m 128 :block-n 128 :sg-m 32 :sg-n 32 :block-k 32}
+               (select-keys (:tile r) [:block-m :block-n :sg-m :sg-n :block-k]))
+            "must still reproduce the hand-tuned Arc tile")
+        (is (= [256 1] (:wg r)))
+        (is (= [4 2] (:grid r)))))                     ; ceil(512/128), ceil(256/128)
+    (testing "a part with HALF the GRF and subgroup 8 gets a rescaled tile AND launch geometry"
+      (let [small {:matrix {:m 8 :n 16 :k 16 :subgroup 8} :grf-bytes-per-lane 128}
+            r (route/route-contraction mm :dtype :half :desc small)]
+        (is (= {:block-m 64 :block-n 64 :sg-m 16 :sg-n 16 :block-k 32}
+               (select-keys (:tile r) [:block-m :block-n :sg-m :sg-n :block-k])))
+        (is (= [128 1] (:wg r)) "workgroup = (bm/sgm)·(bn/sgn)·subgroup = 4·4·8")
+        (is (= [8 4] (:grid r)) "grid follows the smaller block tile")))
+    (testing "an explicit tile (e.g. an autotune result) overrides the derivation"
+      (let [t (hw {} {:wg-subgroups 4})
+            r (route/route-contraction mm :dtype :half :tile t)]
+        (is (= t (:tile r)))
+        (is (not= (:block-m (hw {})) (:block-m t)) "the override must actually differ")))
+    (testing "the emitted kernel source carries the derived tile, not a constant"
+      (let [small {:matrix {:m 8 :n 16 :k 16 :subgroup 8} :grf-bytes-per-lane 128}
+            src (:source (route/route-contraction mm :dtype :half :desc small))]
+        (is (re-find #"intel_reqd_sub_group_size\(8\)" src)
+            "subgroup size must follow the descriptor into the kernel attribute")))))

--- a/test/raster/dl/einsum_path_test.clj
+++ b/test/raster/dl/einsum_path_test.clj
@@ -102,3 +102,58 @@
       (is (= 1 (count (:steps plan))))
       (is (= (es/einsum->contract-form "ij,jk->ik" {:i 2 :j 3 :k 4} 'OUT '[A B])
              (:form (first (:steps plan))))))))
+
+;; ── G1: UNARY einsums (transpose / axis-reduction / diagonal) ────────────────────────
+(deftest unary-einsums-lower-and-compute
+  (testing "ij->ji is a 0-contract transpose; body reads the INPUT map's index"
+    (let [f (es/einsum->contract-form "ij->ji" {:i 2 :j 3} 'O '[A])]
+      (is (= '[[j 3] [i 2]] (nth f 2)))          ; free axes in OUTPUT order
+      (is (= [] (nth f 3)))
+      (is (= '(aget A (clojure.core/+ (clojure.core/* i 3) j)) (nth f 4)))))
+  (testing "ij->i reduces the summed axis"
+    (let [f (es/einsum->contract-form "ij->i" {:i 2 :j 3} 'O '[A])]
+      (is (= '[[i 2]] (nth f 2)))
+      (is (= '[[j 3]] (nth f 3)))))
+  (testing "ii->i is the DIAGONAL — a repeated label makes the axis-map emit i·N + i"
+    (let [f (es/einsum->contract-form "ii->i" {:i 3} 'O '[A])]
+      (is (= '[[i 3]] (nth f 2)))
+      (is (= [] (nth f 3)))
+      (is (= '(aget A (clojure.core/+ (clojure.core/* i 3) i)) (nth f 4)))))
+  (testing "a unary einsum yields exactly ONE step (the greedy path is empty)"
+    (let [plan (es/einsum->contract-steps "ij->ji" {:i 2 :j 3} 'O '[A])]
+      (is (= 1 (count (:steps plan))))
+      (is (= [] (:path plan)))
+      (is (= 'O (:result plan)))))
+  (testing "executing the unary steps == reference"
+    (let [A (double-array [1 2 3 4 5 6])            ; 2×3
+          B (double-array [1 2 3 4 5 6 7 8 9])]     ; 3×3
+      (is (= (run-steps (es/einsum->contract-steps "ij->ji" {:i 2 :j 3} 'O '[A]) {'A A})
+             (vec (for [j (range 3) i (range 2)] (aget A (+ (* i 3) j))))))
+      (is (= (run-steps (es/einsum->contract-steps "ij->i" {:i 2 :j 3} 'O '[A]) {'A A})
+             (vec (for [i (range 2)] (reduce + (for [j (range 3)] (aget A (+ (* i 3) j))))))))
+      (is (= (run-steps (es/einsum->contract-steps "ii->i" {:i 3} 'O '[B]) {'B B})
+             (vec (for [i (range 3)] (aget B (+ (* i 3) i)))))))))
+
+;; ── coverage ledger: what the contract path expresses, asserted EXPLICITLY ───────────
+;; "Properly covered" has to be checkable, not claimed. This pins the current frontier so it
+;; cannot silently regress, and names the remaining gap (G2: scalar output / 0 free axes).
+(deftest coverage-ledger-of-the-contract-path
+  (let [expressible? (fn [sub dm syms]
+                       (try (es/einsum->contract-form sub dm 'O syms) true
+                            (catch Throwable _ false)))]
+    (testing "EXPRESSIBLE: binary contractions, broadcasts, and all unary forms"
+      (doseq [[sub dm syms] [["ij,jk->ik"    {:i 2 :j 3 :k 4}       '[A B]]
+                             ["bij,bjk->bik" {:b 2 :i 2 :j 3 :k 4}  '[A B]]
+                             ["ij,ij->ij"    {:i 2 :j 3}            '[A B]]
+                             ["i,j->ij"      {:i 2 :j 3}            '[A B]]
+                             ["ij->ji"       {:i 2 :j 3}            '[A]]
+                             ["ij->i"        {:i 2 :j 3}            '[A]]
+                             ["ii->i"        {:i 3}                 '[A]]]]
+        (is (expressible? sub dm syms) (str sub " should be expressible"))))
+    (testing "NOT YET expressible: scalar output needs 0 free axes (G2), and fails LOUD"
+      (doseq [[sub dm syms] [["ij->"  {:i 2 :j 3} '[A]]
+                             ["ii->"  {:i 3}      '[A]]
+                             ["i,i->" {:i 3}      '[A B]]]]
+        (is (not (expressible? sub dm syms)) (str sub " is G2, must not silently succeed"))
+        (is (thrown-with-msg? AssertionError #"scalar output"
+                              (es/einsum->contract-form sub dm 'O syms)))))))

--- a/test/raster/dl/einsum_path_test.clj
+++ b/test/raster/dl/einsum_path_test.clj
@@ -150,10 +150,49 @@
                              ["ij->i"        {:i 2 :j 3}            '[A]]
                              ["ii->i"        {:i 3}                 '[A]]]]
         (is (expressible? sub dm syms) (str sub " should be expressible"))))
-    (testing "NOT YET expressible: scalar output needs 0 free axes (G2), and fails LOUD"
+    (testing "EXPRESSIBLE: scalar output too — the (0 free, n contract) reduction cell (G2)"
       (doseq [[sub dm syms] [["ij->"  {:i 2 :j 3} '[A]]
                              ["ii->"  {:i 3}      '[A]]
                              ["i,i->" {:i 3}      '[A B]]]]
-        (is (not (expressible? sub dm syms)) (str sub " is G2, must not silently succeed"))
-        (is (thrown-with-msg? AssertionError #"scalar output"
-                              (es/einsum->contract-form sub dm 'O syms)))))))
+        (is (expressible? sub dm syms) (str sub " should be expressible"))))
+    (testing "COVERAGE IS COMPLETE: every subscript in einsum's own test suite lowers"
+      (doseq [[sub dm syms] [["ij,jk->ik" {:i 2 :j 3 :k 4} '[A B]]
+                             ["bij,bjk->bik" {:b 2 :i 2 :j 3 :k 4} '[A B]]
+                             ["ij,ij->ij" {:i 2 :j 3} '[A B]] ["i,j->ij" {:i 2 :j 3} '[A B]]
+                             ["i,i->" {:i 3} '[A B]] ["ij->ji" {:i 2 :j 3} '[A]]
+                             ["ij->i" {:i 2 :j 3} '[A]] ["ij->" {:i 2 :j 3} '[A]]
+                             ["ii->" {:i 3} '[A]] ["ii->i" {:i 3} '[A]]]]
+        (is (expressible? sub dm syms) (str sub " — all 10 einsum-test subscripts must lower"))))))
+
+;; ── G2: SCALAR output — the (0 free, n contract) cell of contract's algebra ───────────
+;; contract's algebra has four cells: (n free, 0 contract) = map, (n, n) = contraction,
+;; (0, n) = FULL REDUCTION, and 0 free axes is a legal result in that algebra — so the
+;; primitive supports it. It needs no new IR or emitter: the SegSpace degenerates to the 1-D
+;; shape (segop/seg-space-1d?) that the existing two-phase tree reduction already consumes.
+(deftest scalar-output-is-the-reduction-cell
+  (testing "the macro: 0 free axes = the empty product, one iteration, writes out[0]"
+    (let [A (double-array [1 2 3 4]) B (double-array [1 2 3 4]) O (double-array 1)]
+      (raster.par/contract O [] [[i 4]]
+                           (clojure.core/* (clojure.core/aget A i) (clojure.core/aget B i)))
+      (is (= 30.0 (aget O 0)))))                          ; dot product
+  (testing "sum over all axes (2 contract axes, flattened)"
+    (let [A (double-array [1 2 3 4 5 6]) O (double-array 1)]
+      (raster.par/contract O [] [[i 6]] (clojure.core/aget A i))
+      (is (= 21.0 (aget O 0)))))
+  (testing "trace: a repeated label gives the diagonal, reduced to a scalar"
+    (let [M (double-array [1 2 3 4 5 6 7 8 9]) O (double-array 1)]
+      (raster.par/contract O [] [[i 3]]
+                           (clojure.core/aget M (clojure.core/+ (clojure.core/* i 3) i)))
+      (is (= 15.0 (aget O 0)))))
+  (testing "einsum lowers all three scalar-output subscripts"
+    (doseq [[sub dm syms] [["i,i->" {:i 3} '[A B]] ["ij->" {:i 2 :j 3} '[A]] ["ii->" {:i 3} '[A]]]]
+      (let [f (es/einsum->contract-form sub dm 'O syms)]
+        (is (= [] (nth f 2)) (str sub " has 0 free axes"))
+        (is (seq (nth f 3)) (str sub " contracts at least one axis")))))
+  (testing "the router sends it to the two-phase reduction, with its own invoke protocol"
+    (let [r ((requiring-resolve 'raster.compiler.passes.parallel.contract-route/route-contraction)
+             '(raster.par/contract O [] [[i 8]] (* (aget A i) (aget B i))) :dtype :double)]
+      (is (= :full-reduce (:strategy r)))
+      (is (= :reduction (:invoke r)))
+      (is (= 2 (:n-phases r)))
+      (is (= 1 (:out-elems r))))))

--- a/test/raster/dl/einsum_path_test.clj
+++ b/test/raster/dl/einsum_path_test.clj
@@ -1,0 +1,104 @@
+(ns raster.dl.einsum-path-test
+  "B2: n-operand einsum → an ORDERED PATH of pairwise contractions.
+
+   Generality by decomposition: each step is a 2-operand `par/contract` the gate can route to a
+   peak leaf, so an n-operand einsum needs no monolithic general kernel. Device-free — this
+   validates the index algebra, the greedy order, and that executing the chain equals a direct
+   reference computation."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.dl.einsum :as es]
+            [raster.par]))
+
+;; ── the per-step set algebra (opt_einsum's find_contraction) ─────────────────────────
+(deftest pair-contraction-index-algebra
+  (testing "keep = needed downstream (output ∪ other operands); sum = only in this pair"
+    (let [r (es/pair-contraction '[[:i :j] [:j :k] [:k :l]] 1 2 '[:i :l])]
+      ;; contracting (jk, kl): j survives (operand 0 has it), l survives (output), k dies
+      (is (= '[:j :l] (:keep r)))
+      (is (= '[:k] (:sum r)))
+      (is (= '[[:i :j] [:j :l]] (:remaining r)))))
+  (testing "a label in the output is always kept, even if only one operand has it"
+    (let [r (es/pair-contraction '[[:i :j] [:j :k]] 0 1 '[:i :k])]
+      (is (= '[:i :k] (:keep r)))
+      (is (= '[:j] (:sum r)))))
+  (testing "a label in NEITHER output nor any other operand is summed"
+    (let [r (es/pair-contraction '[[:i :j] [:i :j]] 0 1 '[])]
+      (is (= [] (:keep r)))
+      (is (= '[:i :j] (:sum r))))))
+
+;; ── the greedy order ────────────────────────────────────────────────────────────────
+(deftest contraction-path-is-greedy-and-deterministic
+  (testing "2 operands → the single pair"
+    (is (= [[0 1]] (es/contraction-path '[[:i :j] [:j :k]] '[:i :k] {:i 2 :j 3 :k 4}))))
+  (testing "3 operands: picks the pair with the most memory removed, then the rest"
+    ;; ij,jk,kl->il : (jk,kl)→jl removes more than (ij,jk)→ik, so it goes first
+    (is (= [[1 2] [0 1]]
+           (es/contraction-path '[[:i :j] [:j :k] [:k :l]] '[:i :l] {:i 2 :j 3 :k 4 :l 5}))))
+  (testing "deterministic: same inputs → same path"
+    (let [args ['[[:a :b] [:b :c] [:c :d] [:d :e]] '[:a :e] {:a 2 :b 3 :c 4 :d 5 :e 6}]]
+      (is (= (apply es/contraction-path args) (apply es/contraction-path args)))))
+  (testing "operands sharing no label still get paired (outer-product fallback, no hang)"
+    (is (= 1 (count (es/contraction-path '[[:i] [:j]] '[:i :j] {:i 2 :j 3}))))))
+
+;; ── the emitted step chain ──────────────────────────────────────────────────────────
+(deftest steps-are-pairwise-contractions-landing-on-the-output
+  (let [{:keys [steps result path]}
+        (es/einsum->contract-steps "ij,jk,kl->il" {:i 2 :j 3 :k 4 :l 5} 'OUT '[A B C])]
+    (testing "one step per path entry; each is a par/contract"
+      (is (= (count path) (count steps)))
+      (is (every? #(= 'raster.par/contract (first (:form %))) steps)))
+    (testing "each step contracts exactly the labels that die there"
+      (is (= '[[k 4]] (nth (:form (first steps)) 3)))
+      (is (= '[[j 3]] (nth (:form (second steps)) 3))))
+    (testing "the LAST step lands on the requested output layout (no trailing transpose)"
+      (is (= '[:i :l] (:labels (peek steps))))
+      (is (= '[[i 2] [l 5]] (nth (:form (peek steps)) 2)))
+      (is (= 'OUT result)))
+    (testing "intermediates are fresh and threaded, not aliased to inputs"
+      (is (not-any? #{'A 'B 'C} (map :out steps))))))
+
+;; ── executing the chain == a direct reference computation ────────────────────────────
+(defn- run-steps
+  "Execute a step chain on CPU: eval each par/contract form with its operands bound."
+  [{:keys [steps result]} env]
+  (let [env (reduce (fn [env {:keys [out form shape]}]
+                      (let [syms (vec (keys env))
+                            buf (double-array (reduce * 1 shape))
+                            f (eval (list 'fn (conj syms out) form))]
+                        (apply f (conj (mapv env syms) buf))
+                        (assoc env out buf)))
+                    env steps)]
+    (vec (get env result))))
+
+(deftest chained-steps-equal-the-reference
+  (testing "ij,jk,kl->il via a 2-step path == direct triple loop"
+    (let [I 2 J 3 K 4 L 5
+          A (double-array (map #(* 0.1 (inc %)) (range (* I J))))
+          B (double-array (map #(* 0.2 (inc %)) (range (* J K))))
+          C (double-array (map #(* 0.3 (inc %)) (range (* K L))))
+          plan (es/einsum->contract-steps "ij,jk,kl->il" {:i I :j J :k K :l L} 'OUT '[A B C])
+          got (run-steps plan {'A A 'B B 'C C})
+          ref (vec (for [i (range I) l (range L)]
+                     (reduce + (for [j (range J) k (range K)]
+                                 (* (aget A (+ (* i J) j))
+                                    (aget B (+ (* j K) k))
+                                    (aget C (+ (* k L) l)))))))]
+      (is (= (count ref) (count got)))
+      (is (every? true? (map #(< (Math/abs (- %1 %2)) 1e-9) got ref)))))
+  (testing "4 operands, ab,bc,cd,de->ae"
+    (let [dm {:a 2 :b 3 :c 2 :d 3 :e 2}
+          mk (fn [n seed] (double-array (map #(* seed (inc %)) (range n))))
+          A (mk 6 0.1) B (mk 6 0.2) C (mk 6 0.3) D (mk 6 0.4)
+          plan (es/einsum->contract-steps "ab,bc,cd,de->ae" dm 'OUT '[A B C D])
+          got (run-steps plan {'A A 'B B 'C C 'D D})
+          ref (vec (for [a (range 2) e (range 2)]
+                     (reduce + (for [b (range 3) c (range 2) d (range 3)]
+                                 (* (aget A (+ (* a 3) b)) (aget B (+ (* b 2) c))
+                                    (aget C (+ (* c 3) d)) (aget D (+ (* d 2) e)))))))]
+      (is (= 3 (count (:steps plan))))
+      (is (every? true? (map #(< (Math/abs (- %1 %2)) 1e-9) got ref)))))
+  (testing "the 2-operand case still reduces to a single step == einsum->contract-form"
+    (let [plan (es/einsum->contract-steps "ij,jk->ik" {:i 2 :j 3 :k 4} 'OUT '[A B])]
+      (is (= 1 (count (:steps plan))))
+      (is (= (es/einsum->contract-form "ij,jk->ik" {:i 2 :j 3 :k 4} 'OUT '[A B])
+             (:form (first (:steps plan))))))))


### PR DESCRIPTION
Extends the 2-operand einsum bridge merged in #79 to **n operands**, by decomposition rather than
by a bigger kernel.

## Approach

An n-operand einsum becomes an **ordered sequence of 2-operand `par/contract` steps**. Each step is
exactly what `einsum->contract-form` already emits, so each is routable to a peak leaf (DPAS /
dp4a) or the portable fallback — no monolithic general kernel is ever needed. This follows
opt_einsum.

- **`pair-contraction`** — the per-step index algebra (opt_einsum's `find_contraction`):
  `touched` = the pair's labels; `keep` = labels needed **downstream** (in the output, or in any
  surviving operand); `sum` = labels appearing only in this pair, i.e. the contracted axes.
  `keep` is ordered by first appearance across the pair, so an intermediate's layout matches
  input-appearance order — opt_einsum's trick for making later steps need no transpose.
- **`contraction-path`** — greedy order: only pairs that *share* a label are candidates, each
  scored by memory-removed `size(result) − size(a) − size(b)`, minimum wins, tie-broken by operand
  index so the path is deterministic. Falls back to any pair when nothing shares a label (outer
  product), so it can't hang.
- **`einsum->contract-steps`** — emits the chain with fresh intermediates. The **last** step's free
  axes are the requested output labels, so there's no trailing transpose.

Example — `ij,jk,kl->il` gives path `[[1 2] [0 1]]`: it contracts `(jk,kl)→jl` first because that
removes more memory than `(ij,jk)→ik`, then `ij·jl→il`.

## Validation

Device-free (this is index algebra + form construction). The decisive test is numeric: **executing
the chain equals a direct reference computation** —

- 3 operands `ij,jk,kl->il` (2 steps) == triple loop
- 4 operands `ab,bc,cd,de->ae` (3 steps) == quadruple loop
- the 2-operand case still reduces to a single step *identical* to `einsum->contract-form`'s output

plus the index algebra, the greedy order, determinism, and the no-shared-label fallback.

48 tests / 292 assertions green across the einsum + contract suites; cold-JVM load verified.

## Not included

Pointing `einsum` itself at this path — it still runs its interpreted loop nest. That's a separate
change with its own API-surface decisions (when to take the contract path, and what to do with the
cases it doesn't cover: traces, repeated indices within one operand, implicit output). Worth doing
deliberately rather than bundling here.

---

## Update: G1 — unary einsums now lower too

Measured the actual coverage gap against `einsum`'s own test suite (10 subscripts + 7 `rearrange`
patterns = 17 cases). **11 of 17 already lowered**; the remaining 6 split into exactly two
orthogonal gaps — not the long tail I expected.

**G1 (unary), now closed.** The *sole* blocker was `einsum->contract-form`'s "exactly 2 operands"
assertion. Relaxing it to 1-or-2 with a single-`aget` body covers three cases immediately:

| subscript | semantics | lowers to |
|---|---|---|
| `ij->ji` | transpose | free = output labels, 0 contract → SegMap |
| `ij->i` | axis reduction | free `[i]`, contract `[j]` → SegRed |
| `ii->i` | **diagonal** | free `[i]`, 0 contract → SegMap |

The diagonal needed **no new machinery** — a repeated label makes the axis-map emit `i·N + i`,
which *is* the diagonal gather. That falls out of the map representation from #79.

`einsum->contract-steps` now emits the single unary step directly. (Previously a unary einsum
returned the input symbol unchanged — the greedy path is legitimately empty, but the operand still
needs transposing/reducing, so the transform was silently skipped.)

**G2 (scalar output) is deliberately left open.** `ij->`, `ii->` and `i,i->` need 0 free axes,
which `par/contract` doesn't admit (rejected at the macro, the lowering, and the router).
`einsum->contract-form` now fails loud with an explicit "scalar output … see G2" message instead of
breaking obscurely downstream. Whether `par/contract` should admit 0 free axes, or scalar-output
einsums should delegate to `par/reduce`, is a design decision worth its own PR.

**Coverage ledger.** Added a test that asserts case-by-case which subscripts the contract path
expresses and which remain G2 — so coverage is checkable rather than claimed, and can't silently
regress as either side changes.

Now at **14 of 17**; 35 tests / 248 assertions green including the existing einsum suite.

---

## Update: G2 — scalar output, and coverage is now complete (17 of 17)

`0 free axes` **is** a valid result in `contract`'s algebra, so the primitive supports it. There are
four cells; three were filled and the fourth was rejected by three separate assertions:

| free | contract | meaning | |
|---|---|---|---|
| n | 0 | map / outer product | SegMap ✅ |
| n | n | contraction | segmented SegRed ✅ |
| **0** | **n** | **full reduction → scalar** | **this update** |
| 0 | 0 | scalar copy (degenerate) | falls out |

It needed **no new IR and no new emitter** — verified before writing code: with 0 free axes the
SegSpace has only the reduced dim, i.e. exactly the 1-D shape (`seg-space-1d?`, `segment-dims []`)
that `generate-segred-kernel`'s two-phase tree reduction already consumes — the same emitter
`par/reduce` uses.

The nicest part: in the macro, 0 free axes is the **empty product** (F = 1), so the generic
expansion degenerates to one iteration writing `out[0]`. The degenerate case *is* the general case
— no special-case branch.

The one place it genuinely differs is the launch protocol (two phases + a host-side final combine),
so the descriptor says `:invoke :reduction` rather than pretending to be a 2-D kernel launch.

**Device-validated**: the routed full reduction runs on the GPU and matches reference (dot product
== 72.0). Macro path: dot product 30.0, sum-all 21.0, trace 15.0 — the trace exercising diagonal
(repeated label) + multi-axis flattening + reduction together.

**Coverage complete**: all 10 einsum-test subscripts and all 7 `rearrange` patterns now lower
(was 11 of 17 at the start of this branch). The coverage-ledger test asserts it case-by-case, so it
can't silently regress.

124 tests / 570 assertions green; cold-JVM load verified.
