### PR TITLE
Fuse operand-carrying epilogues (bias / residual / row-scale) via flat-index decomposition

### DIFF
--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -867,7 +867,11 @@
          :dims [M N L]
          :dtype :half
          :tile tile
+         ;; The epilogue's operand arrays are EXTRA kernel params, appended AFTER the dims.
+         ;; Surfaced so a caller binds them — the signature has them either way, so omitting
+         ;; them from the descriptor would be a launch-arity bug (6 args bound to a 7-arg kernel).
          :epilogue-params (when ep (:epilogue-params ep))
+         :epilogue-operands (when ep (mapv :sym (:operands epilogue)))
          ;; workgroup = (block-m/sg-m)·(block-n/sg-n) subgroups × the matrix subgroup size
          :workgroup [(* (quot (:block-m tile) (:sg-m tile))
                         (quot (:block-n tile) (:sg-n tile))

--- a/src/raster/compiler/ir/axis_map.clj
+++ b/src/raster/compiler/ir/axis_map.clj
@@ -141,3 +141,39 @@
    transpose kernel realizes)."
   [from to]
   (= [1 0] (permutation from to)))
+
+;; ── flat index → free-axis map (what an epilogue's operands need) ────────────────────
+;; A contraction's consumer is usually a 1-D map over the FLAT output: `(par/map! out t (* M N) …)`
+;; with `t = i·N + j` for free axes [[i M] [j N]]. To fuse that map as an epilogue we must express
+;; each operand's index in terms of the free axes instead of `t`. These are the broadcast shapes
+;; that appear in practice; anything else returns nil so the caller refuses to fuse rather than
+;; guessing (an operand indexed wrongly is a silent miscompile).
+
+(defn- core-op? [h & names] (contains? (set (mapcat (fn [n] [n (symbol "clojure.core" (name n))
+                                                             (symbol "raster.numeric" (name n))]) names)) h))
+
+(defn flat-index->map
+  "Interpret `idx-expr`, an index expression in the flat map variable `t`, as an axis-map over the
+   contraction's `free-axes` (a vector of [sym extent], outer→inner). Recognized:
+
+     t              → the full output layout           (elementwise operand, e.g. a residual)
+     (mod  t Ninner)→ the innermost axis only          (per-column broadcast, e.g. a bias)
+     (rem  t Ninner)→ same
+     (quot t Ninner)→ the outer axes only              (per-row broadcast, e.g. a row scale)
+     <constant/none>→ nil
+
+   Returns an axis-map, or nil when the shape is not recognized."
+  [idx-expr t free-axes]
+  (let [fa (vec free-axes)
+        n-inner (second (peek fa))
+        outer (vec (butlast fa))]
+    (cond
+      (= idx-expr t) (of-axes fa)
+      (and (seq? idx-expr) (= 3 (count idx-expr))
+           (= t (second idx-expr))
+           (= n-inner (nth idx-expr 2)))
+      (let [h (first idx-expr)]
+        (cond (core-op? h 'mod 'rem) (of-axes [(peek fa)])
+              (core-op? h 'quot)     (when (seq outer) (of-axes outer))
+              :else nil))
+      :else nil)))

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -131,6 +131,9 @@
          :dtype :half :out-dtype :half :out-elems (* M N)
          :tile (:tile dpas)                          ; the DERIVED tile actually emitted
          :fused-epilogue (boolean epilogue)
+         ;; extra kernel args the epilogue needs, in signature order (after out + the dims)
+         :epilogue-operands (:epilogue-operands dpas)
+         :epilogue-params (:epilogue-params dpas)
          :wg (:workgroup dpas)                       ; derived from that tile
          :grid [(ceil-div N block-n) (ceil-div M block-m)]  ; [gc-n gc-m] (id0=N, id1=M)
          :scalar-args (mapv (fn [v] {:type :int :value (int v)}) (:dims dpas))  ; [m n k] params

--- a/src/raster/compiler/passes/parallel/par_fusion.clj
+++ b/src/raster/compiler/passes/parallel/par_fusion.clj
@@ -14,6 +14,7 @@
   (:require [clojure.walk]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
+            [raster.compiler.ir.axis-map :as am]
             [raster.compiler.passes.parallel.descriptors :as desc]
             [raster.compiler.passes.parallel.fusion-support :as fusion-support]
             [raster.compiler.passes.parallel.schedule-support :as schedule-support]
@@ -151,11 +152,12 @@
     out (raster.par/contract out [[i m] [j n]] [[l k]] (* (aget A ..) (aget B ..))
                             :epilogue {:acc acc :expr (silu acc)})
 
-  FIRST CUT — the map body may read only the contraction's output (plus scalars/literals), i.e. a
-  pure activation/scale. That is the dominant `linear → activation` shape and needs no index
-  recovery. A body reading OTHER arrays (e.g. a per-column bias) needs its flat map index decomposed
-  into the contraction's free axes to build the operand's axis-map; until that exists such an
-  epilogue must be supplied explicitly (segop-opencl/epilogue-splice takes operands with maps).
+  A body reading OTHER arrays (a per-column bias, a per-row scale, an elementwise residual) is
+  fused too: each such operand's index is decomposed from the map's FLAT variable into the
+  contraction's free axes via axis-map/flat-index->map, which yields the operand's own axis-map so
+  epilogue-splice can re-index it against the store slot's row/col. An operand whose index is not
+  one of the recognized broadcast shapes, or which is read at more than one index, is REFUSED — a
+  wrongly-indexed operand is a silent miscompile, so guessing is not an option.
 
   Legality is delegated to segop-opencl/epilogue-legal? at emit time (accumulator used exactly once,
   no reduction/layout-changing op, spliced strictly after the reduction loop).
@@ -174,14 +176,30 @@
             (if (contract? expr)
               (let [c-out (second expr)
                     already-fused? (contains? (set (drop 5 expr)) :epilogue)
+                    free-axes (nth expr 2)
+                    ;; every OTHER array the map body reads must have an index we can express in
+                    ;; the contraction's free axes; otherwise we refuse (a wrongly-indexed operand
+                    ;; is a silent miscompile, so guessing is not an option)
+                    operands-of (fn [mi]
+                                  (let [t (:idx mi)
+                                        others (disj (agets-on-arrays (:body mi)) c-out)
+                                        resolved (for [a others
+                                                       :let [idxs (distinct
+                                                                   (keep #(when (and (seq? %) (= 'aget (first %))
+                                                                                     (= a (second %)))
+                                                                            (nth % 2))
+                                                                         (tree-seq coll? seq (:body mi))))]]
+                                                   (when (= 1 (count idxs))
+                                                     (when-let [m (am/flat-index->map (first idxs) t free-axes)]
+                                                       {:sym a :map m})))]
+                                    (when (every? some? resolved) (vec resolved))))
                     map-idx (when-not already-fused?
                               (first (keep-indexed
                                       (fn [j [_s e]]
                                         (when (> j i)
                                           (when-let [mi (desc/map-form-info e)]
                                             (when (and (aget-reads-sym? (:body mi) c-out)
-                                                       ;; first cut: body reads ONLY the contraction output
-                                                       (= #{c-out} (agets-on-arrays (:body mi))))
+                                                       (some? (operands-of mi)))
                                               j))))
                                       pairs)))
                     safe? (and map-idx
@@ -190,15 +208,18 @@
                   (let [[msym mexpr] (nth pairs map-idx)
                         mi (desc/map-form-info mexpr)
                         acc-sym (gensym "acc__")
-                        ;; (aget C <map-idx>) → the accumulator symbol
+                        ;; (aget C <map-idx>) → the accumulator symbol; every other operand keeps
+                        ;; its aget, and epilogue-splice re-indexes it from the declared axis-map
                         ep-expr (clojure.walk/postwalk
                                  (fn [f] (if (and (seq? f) (= 'aget (first f)) (= c-out (second f)))
                                            acc-sym f))
                                  (:body mi))
+                        ops (operands-of mi)
                         fused-form (concat (list 'raster.par/contract (:out mi))
                                            (drop 2 (take 5 expr))
                                            (drop 5 expr)
-                                           [:epilogue {:acc acc-sym :expr ep-expr}])]
+                                           [:epilogue (cond-> {:acc acc-sym :expr ep-expr}
+                                                        (seq ops) (assoc :operands ops))])]
                     (recur (inc i) (conj result [msym (apply list fused-form)])
                            (inc fused) (conj skip-set map-idx)))
                   (recur (inc i) (conj result [sym expr]) fused skip-set)))

--- a/test/raster/compiler/backend/gpu/dpas_contract_device_test.clj
+++ b/test/raster/compiler/backend/gpu/dpas_contract_device_test.clj
@@ -248,9 +248,18 @@
         (is (:fused-epilogue r))
         (is (str/includes? (:source r) "silu_f((acc00.s0))")
             "the epilogue must appear in the STORE slot, not a second kernel")))
-    (testing "REFUSALS: an already-fused contract, and a map reading other arrays"
-      (let [bias-map ['C mm
-                      'out (list 'raster.par/map! 'out 't (* M N) nil
-                                 (list 'raster.numeric/+ (list 'aget 'C 't) (list 'aget 'bias 't)))]]
-        (is (nil? (pf bias-map []))
-            "a body reading OTHER arrays needs flat-index→free-axis decomposition; must not fuse yet")))))
+    (testing "a body reading OTHER arrays now fuses too (flat-index→free-axis decomposition)"
+      ;; This assertion previously required a REFUSAL. That limitation is gone: an operand's flat
+      ;; index is decomposed into the contraction's free axes, so bias/residual/row-scale fuse.
+      ;; See epilogue-operand-fusion-test for the full matrix; here we only pin that it no longer
+      ;; refuses, so the two suites cannot drift apart.
+      (let [resid ['C mm
+                   'out (list 'raster.par/map! 'out 't (* M N) nil
+                              (list 'raster.numeric/+ (list 'aget 'C 't) (list 'aget 'R 't)))]]
+        (is (some? (pf resid [])) "an elementwise residual operand fuses")))
+    (testing "REFUSAL that remains valid: an operand index we cannot decompose"
+      (let [bad ['C mm
+                 'out (list 'raster.par/map! 'out 't (* M N) nil
+                            (list 'raster.numeric/+ (list 'aget 'C 't)
+                                  (list 'aget 'bias (list 'mod 't 7))))]]
+        (is (nil? (pf bad [])) "an unrecognized stride must refuse, never guess")))))

--- a/test/raster/compiler/passes/parallel/epilogue_operand_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/epilogue_operand_fusion_test.clj
@@ -1,0 +1,122 @@
+(ns raster.compiler.passes.parallel.epilogue-operand-fusion-test
+  "Completes the refusal left by the contract→map epilogue fusion: a consumer map that reads OTHER
+   arrays (a per-column bias, a per-row scale, an elementwise residual) now fuses too.
+
+   The consumer is a 1-D map over the FLAT output (`t = i·N + j`), so each operand's index must be
+   re-expressed in the contraction's FREE axes before it can be spliced into the store slot — that
+   is axis-map/flat-index->map. An index that is not a recognized broadcast shape is REFUSED rather
+   than guessed: a wrongly-indexed operand is a silent miscompile."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [raster.compiler.ir.axis-map :as am]
+            [raster.compiler.passes.parallel.par-fusion :as pf]
+            [raster.compiler.passes.parallel.contract-route :as route]))
+
+(def ^:private M 128)
+(def ^:private N 256)
+(def ^:private K 64)
+
+(defn- mm []
+  (list 'raster.par/contract 'C [['i M] ['j N]] [['l K]]
+        (list '* (list 'aget 'A (list '+ (list '* 'i K) 'l))
+              (list 'aget 'B (list '+ (list '* 'l N) 'j)))))
+
+(defn- fuse [mbody]
+  (let [b ['C (mm) 'out (list 'raster.par/map! 'out 't (* M N) nil mbody)]]
+    (when-let [r (pf/fuse-contract-map b [])]
+      (let [fused (second (:bindings r))]
+        {:form fused :epilogue (:epilogue (apply hash-map (drop 5 fused)))}))))
+
+(defn- store-line [fused]
+  (let [r (route/route-contraction fused :dtype :half)]
+    {:store (some #(when (str/includes? % "C[row*N+col] =") (str/trim %))
+                  (str/split-lines (:source r)))
+     :epi-ops (:epilogue-operands r)
+     :declares (fn [sym] (str/includes? (:source r) (str "restrict " sym)))}))
+
+;; ── the flat-index decomposition itself ──────────────────────────────────────────────
+(deftest flat-index-decomposition
+  (let [fa [['i M] ['j N]]]
+    (testing "t → the full row-major output layout (elementwise operand, e.g. a residual)"
+      (is (= (am/of-axes fa) (am/flat-index->map 't 't fa))))
+    (testing "(mod t N) → the innermost axis only (per-column broadcast, e.g. a bias)"
+      (is (= (am/of-axes [['j N]]) (am/flat-index->map (list 'mod 't N) 't fa)))
+      (is (= 'j (am/index-expr (am/flat-index->map (list 'mod 't N) 't fa)))))
+    (testing "(quot t N) → the outer axes only (per-row broadcast)"
+      (is (= (am/of-axes [['i M]]) (am/flat-index->map (list 'clojure.core/quot 't N) 't fa))))
+    (testing "a non-matching stride is NOT recognized (must refuse, never guess)"
+      (is (nil? (am/flat-index->map (list 'mod 't 7) 't fa)))
+      (is (nil? (am/flat-index->map (list 'raster.numeric/* 't 3) 't fa))))))
+
+;; ── fusion of operand-carrying epilogues ─────────────────────────────────────────────
+(deftest operand-carrying-epilogues-fuse-with-correct-indices
+  (testing "per-column bias: operand map is [j], emitted index is bias[col]"
+    (let [f (fuse (list 'raster.numeric/+ (list 'aget 'C 't) (list 'aget 'bias (list 'mod 't N))))
+          {:keys [store epi-ops declares]} (store-line (:form f))]
+      (is (= '[bias] (mapv :sym (:operands (:epilogue f)))))
+      (is (= (am/of-axes [['j N]]) (:map (first (:operands (:epilogue f))))))
+      (is (str/includes? store "bias[col]"))
+      (is (= '[bias] epi-ops) "the descriptor must surface the extra kernel arg")
+      (is (declares "bias") "…and the signature must declare it")))
+  (testing "elementwise residual: full map, emitted index is R[row*N+col]"
+    (let [f (fuse (list 'raster.numeric/+ (list 'aget 'C 't) (list 'aget 'R 't)))
+          {:keys [store epi-ops]} (store-line (:form f))]
+      (is (= (am/of-axes [['i M] ['j N]]) (:map (first (:operands (:epilogue f))))))
+      (is (str/includes? store (str "R[((row * " N ") + col)]")))
+      (is (= '[R] epi-ops))))
+  (testing "per-row scale: operand map is [i], emitted index is rs[row]"
+    (let [f (fuse (list 'raster.numeric/* (list 'aget 'C 't) (list 'aget 'rs (list 'quot 't N))))
+          {:keys [store]} (store-line (:form f))]
+      (is (str/includes? store "rs[row]"))))
+  (testing "an activation-only body still fuses, with no operands"
+    (let [f (fuse (list 'silu_f (list 'aget 'C 't)))
+          {:keys [epi-ops]} (store-line (:form f))]
+      (is (empty? (:operands (:epilogue f))))
+      (is (empty? epi-ops)))))
+
+(deftest refusals-never-guess-an-operand-index
+  (testing "an unrecognized stride refuses to fuse"
+    (is (nil? (fuse (list 'raster.numeric/+ (list 'aget 'C 't)
+                          (list 'aget 'bias (list 'mod 't 7)))))))
+  (testing "an operand read at TWO different indices refuses"
+    (is (nil? (fuse (list 'raster.numeric/+ (list 'aget 'C 't)
+                          (list 'raster.numeric/+ (list 'aget 'bias (list 'mod 't N))
+                                (list 'aget 'bias (list 'quot 't N)))))))))
+
+;; ── device: the fused bias+activation equals the two-pass reference ───────────────────
+(def ^:private gpu?
+  (delay (try (require 'raster.gpu.ze-runtime)
+              (boolean (seq ((resolve 'raster.gpu.ze-runtime/query-devices))))
+              (catch Throwable _ false))))
+
+(deftest fused-operand-epilogue-matches-two-pass-on-device
+  (if-not @gpu?
+    (println "[skip] fused-operand-epilogue-device: no GPU")
+    (let [ze (find-ns 'raster.gpu.ze-runtime)
+          reg! (ns-resolve ze 'register-kernel!) ens! (ns-resolve ze 'ensure-kernel-loaded!)
+          mkbuf (ns-resolve ze 'make-buffer) halfs (ns-resolve ze 'buffer-of-floats-as-half)
+          a->b (ns-resolve ze 'array->buffer!) l2d (ns-resolve ze 'launch-2d!)
+          b->d (ns-resolve ze 'buffer->double-array)
+          Ad (float-array (map #(float (* 0.05 (- (mod % 7) 3))) (range (* M K))))
+          Bd (float-array (map #(float (* 0.05 (- (mod % 5) 2))) (range (* K N))))
+          biasd (float-array (map #(float (* 0.02 (- (mod % 9) 4))) (range N)))
+          run (fn [mbody extra]
+                (let [fused (:form (fuse mbody))
+                      r (route/route-contraction fused :dtype :half)
+                      out (mkbuf (* M N) :half)]
+                  (reg! (:kernel-name r) {:source (:source r) :dtype :half})
+                  (let [{:keys [kernel-handle]} (ens! (:kernel-name r))]
+                    (l2d kernel-handle (:wg r) (:grid r)
+                         (into [(:segment (halfs Ad)) (:segment (halfs Bd)) (:segment out)
+                                {:type :int :value M} {:type :int :value N} {:type :int :value K}]
+                               extra))
+                    (vec (b->d out)))))
+          plain (run (list 'aget 'C 't) [])                       ; identity epilogue = plain GEMM
+          bias-buf (a->b (mkbuf N :float) biasd)
+          fused (run (list 'raster.numeric/+ (list 'aget 'C 't) (list 'aget 'bias (list 'mod 't N)))
+                     [(:segment bias-buf)])]
+      (testing "fused bias == plain GEMM followed by a separate per-column bias pass"
+        (let [ref (vec (map-indexed (fn [idx v] (+ (double v) (aget biasd (mod idx N)))) plain))]
+          (is (= (count ref) (count fused)))
+          (is (every? true? (map #(< (Math/abs (- (double %1) (double %2))) 3.0e-2) fused ref))
+              (str "fused " (take 4 fused) " vs two-pass " (take 4 ref))))))))


### PR DESCRIPTION
Completes the one refusal left by #81's epilogue fusion.

## The gap

#81 fused `contract → elementwise map` into a single kernel by splicing the map's body into the
GEMM's store slot — but only when the map body read *nothing but* the contraction's output. A body
reading another array (a per-column bias, a residual) was refused, because the consumer is a **1-D
map over the flat output** (`t = i·N + j`) while the store slot has the **free axes** (`row`, `col`)
in scope. Without translating between them, an operand would be indexed wrongly — a silent
miscompile.

## The fix

`axis-map/flat-index->map` decomposes a flat index into the contraction's free axes, for the
broadcast shapes that actually occur:

| consumer index | meaning | emitted |
|---|---|---|
| `t` | full row-major (elementwise residual) | `R[((row * N) + col)]` |
| `(mod t N)` / `(rem t N)` | innermost axis only (per-column bias) | `bias[col]` |
| `(quot t N)` | outer axes only (per-row scale) | `rs[row]` |
| anything else | — | **refuses to fuse** |

`fuse-contract-map` builds each operand's axis-map from that and puts it in the epilogue spec.
`epilogue-splice` already re-indexes operands from their declared maps, so the store slot gets the
right index with **no new emitter logic** — the fourth thing the indexing-map representation has
paid for.

Refusals are explicit, never guesses: an unrecognized stride (`(mod t 7)`) and an operand read at
two different indices both decline.

## A bug found while wiring it

The routed descriptor didn't surface the epilogue's operand arrays, so a caller would have bound
**6 args to a 7-arg kernel** (the signature declares them either way). Descriptors now carry
`:epilogue-operands` (in signature order, after `out` + the dims) and `:epilogue-params`. Same
descriptor-completeness class as the earlier `invoke-registered-contraction!` fix.

## Validation

- Device: the fused bias epilogue equals a plain GEMM followed by a separate per-column bias pass,
  at f16 tolerance.
- Emitted-index assertions for all three broadcast shapes, plus both refusals.
- The regression run caught a now-obsolete assertion in #81's suite that required these bodies to
  refuse — updated, and cross-referenced so the two suites can't drift apart.

108 tests / 517 assertions green; cold-JVM load verified.
