### PR TITLE
Validate contract launch descriptors against their kernels (catches a 3rd real bug)

### DIFF
--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -426,14 +426,21 @@
                            ce/*int-vars* (into ce/*int-vars* int-vars)]
                    (ce/emit-expr (ce/adapt-casts-for-dtype body dtype) dummy arr-sym-set))
         arr-param-str (str/join ", " (map (fn [s] (str "__global const " ctype "* restrict " (ce/c-symbol s))) arr-params))
+        ;; SYMBOLIC axis bounds must be DECLARED as int params, exactly as the segmented-reduce
+        ;; sibling does — the decompose above emits their names, so without this the kernel
+        ;; references undeclared identifiers and fails to compile.
+        scl-params (vec (sort-by name (:scalars segmap)))
+        scl-param-str (str/join "" (map (fn [s] (str ", int " (ce/c-symbol s))) scl-params))
         src (str (codegen/extension-pragmas dtype)
-                 "__kernel void " kernel-name "(" arr-param-str ", __global " ctype "* restrict out, int _nseg) {\n"
+                 "__kernel void " kernel-name "(" arr-param-str ", __global " ctype "* restrict out"
+                 scl-param-str ", int _nseg) {\n"
                  "    int seg = get_global_id(0);\n"
                  "    if (seg >= _nseg) return;\n"
                  decomp "\n"
                  "    out[seg] = " body-str ";\n"
                  "}\n")]
-    {:kernel-name kernel-name :source src :array-params arr-params :dtype dtype}))
+    {:kernel-name kernel-name :source src :array-params arr-params
+     :scalar-params scl-params :dtype dtype}))
 
 ;; ================================================================
 ;; Block-tiled + __local-staged contraction (BlkRegTiling, block-tile level)

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -13,6 +13,7 @@
             [raster.compiler.backend.intrinsics :as intrinsics]
             [raster.compiler.core.hardware :as hw]
             [raster.compiler.ir.axis-map :as am]
+            [raster.compiler.ir.contract-stages :as cstage]
             [clojure.walk :as walk]
             [clojure.set]
             [raster.compiler.ir.segop :as segop]
@@ -1003,3 +1004,125 @@
      :dtype :byte :acc-dtype :int :out-dtype :float :packed :int8x4
      :scheme (merge {:scale scale :a-zp a-zp :b-zp b-zp} scheme)
      :dims [M N L]}))
+
+;; ── staged (multi-level) contraction ────────────────────────────────────────────────
+(defn- flat-decompose-c
+  "C declarations recovering each free index from the flat segment id `seg`, row-major:
+   idx_p = (seg / Π bounds-after-p) % bound_p, with the innermost simplifying to `seg % bound`.
+   ONE source for the row-major decompose. (Debt: three older copies of this arithmetic remain
+   inline — generate-segmented-reduce-kernel, generate-segmap-nd-kernel, and the two quant
+   kernels — and should collapse onto this helper; not done here to keep their emitted text
+   provably byte-identical.)"
+  [free-axes]
+  (let [v (vec free-axes) n (count v)]
+    (str/join "\n"
+              (map-indexed
+               (fn [p [sym bound]]
+                 (let [after (map second (subvec v (inc p) n))
+                       div (if (seq after) (str "(seg / (" (str/join " * " after) "))") "seg")]
+                   (str "    int " (ce/c-symbol sym) " = " div " % " bound ";")))
+               v))))
+
+(defn generate-staged-contraction-kernel
+  "STAGED contraction → OpenCL: a reduction accumulating in N levels, each with its own
+   accumulator dtype, with a `lift` splicing each level's partial sum into the level above.
+   This is the shape every block-quantized format needs and the flat leaves cannot express —
+   an int32 MAC inside the block, a float accumulate across blocks (see ir/contract-stages).
+   2 stages = q8_0/q4_0, 3 = k-quants, 1 = the flat contraction (so this emitter subsumes it).
+
+   The emitted nest is exactly the schedule `backend/cpu/quant.clj` already uses on CPU and
+   llama.cpp hand-writes per format — here it comes from the stage list, not from a kernel per
+   format. Domain-agnostic: no scale/zero-point/format concept appears below; a stage is an
+   accumulator dtype plus a lift expression, and the lift's operand arrays are indexed by their
+   DECLARED axis-maps (never by inferred strides).
+
+   Spec:
+     {:free-axes [[i M] [j N]]      ;; output axes, outer→inner (any rank ≥ 1)
+      :stages    [outer … inner]    ;; see ir/contract-stages for the stage shape
+      :body      <expr>             ;; the summand, over the free + stage axes
+      :inputs    [a b]              ;; the body's operand arrays
+      :dtype     :byte              ;; the body operands' element dtype
+      :out-dtype :float}
+
+   Returns {:kernel-name :source :array-params :dtype :out-dtype :dims :stages :out-elems
+            :lift-operands}. :array-params is the body's inputs; :lift-operands are the EXTRA
+   scale arrays, bound after them — surfaced because omitting them from a launch descriptor is
+   an arity bug (the signature has them either way)."
+  [{:keys [free-axes stages body inputs dtype out-dtype]
+    :or {dtype :float out-dtype :float}} out-sym]
+  (let [legal (cstage/stages-legal? stages (mapv (juxt :axis :extent) stages))
+        _ (when-not (:ok legal)
+            (throw (ex-info (str "staged contraction: illegal stages (" (:reason legal) ")")
+                            (assoc legal :stages stages))))
+        stages (vec stages)
+        op-ctype  (get codegen/opencl-type-map dtype "float")
+        out-ctype (get codegen/opencl-type-map out-dtype "float")
+        lift-ops (cstage/lift-operands stages)
+        idx-of (cstage/stage-index-exprs stages)
+        ;; every axis in scope is an int loop/decompose variable
+        int-vars (into #{} (map (comp symbol name))
+                       (concat (map first free-axes) (map :axis stages)))
+        arr-syms (into #{} (map (comp symbol name)) (concat inputs (map :sym lift-ops)))
+        emit (fn [expr]
+               (binding [ce/*emit-config* ce/opencl-config
+                         ce/*scalar-type* out-ctype
+                         ce/*int-vars* (into ce/*int-vars* int-vars)]
+                 (ce/emit-expr expr (gensym "z__") arr-syms)))
+        acc-name (fn [d] (str "acc_" d))
+        ;; innermost accumulates the body; each outer accumulates its lift with `inner` bound to
+        ;; the accumulator one level down. Built inside-out.
+        n (count stages)
+        inner-most (let [{:keys [dtype init axis extent]} (peek stages)
+                         t (get codegen/opencl-type-map dtype "float")]
+                     (str "        " t " " (acc-name (dec n)) " = " (or init 0) ";\n"
+                          "        for (int " (ce/c-symbol axis) " = 0; "
+                          (ce/c-symbol axis) " < " extent "; " (ce/c-symbol axis) "++) {\n"
+                          "            " (acc-name (dec n)) " += " (emit body) ";\n"
+                          "        }\n"))
+        nest (reduce
+              (fn [inner-src d]
+                (let [{:keys [dtype init axis extent lift]} (nth stages d)
+                      t (get codegen/opencl-type-map dtype "float")
+                      lift' (cstage/substitute-operand-indices lift idx-of)
+                      ;; splice the level-below accumulator in for `inner`
+                      lift'' (walk/postwalk-replace {'inner (symbol (acc-name (inc d)))} lift')]
+                  (str "    " t " " (acc-name d) " = " (or init 0) ";\n"
+                       "    for (int " (ce/c-symbol axis) " = 0; "
+                       (ce/c-symbol axis) " < " extent "; " (ce/c-symbol axis) "++) {\n"
+                       inner-src
+                       "        " (acc-name d) " += " (emit lift'') ";\n"
+                       "    }\n")))
+              inner-most
+              (reverse (range (dec n))))
+        ;; a single stage has no lift, so its accumulator is the whole nest, unindented
+        nest (if (= 1 n)
+               (let [{:keys [dtype init axis extent]} (peek stages)
+                     t (get codegen/opencl-type-map dtype "float")]
+                 (str "    " t " " (acc-name 0) " = " (or init 0) ";\n"
+                      "    for (int " (ce/c-symbol axis) " = 0; "
+                      (ce/c-symbol axis) " < " extent "; " (ce/c-symbol axis) "++) {\n"
+                      "        " (acc-name 0) " += " (emit body) ";\n"
+                      "    }\n"))
+               nest)
+        n-out (am/n-elements (am/of-axes (vec free-axes)))
+        kernel-name (str "staged_contract_" (gensym ""))
+        params (str (str/join ", " (for [a inputs]
+                                     (str "__global const " op-ctype "* restrict " (ce/c-symbol a))))
+                    (apply str (for [{:keys [sym dtype] :or {dtype :float}} lift-ops]
+                                 (str ", __global const " (get codegen/opencl-type-map dtype "float")
+                                      "* restrict " (ce/c-symbol sym))))
+                    ", __global " out-ctype "* restrict out, int _nseg")
+        src (str "__kernel void " kernel-name "(" params ") {\n"
+                 "    int seg = get_global_id(0);\n"
+                 "    if (seg >= _nseg) return;\n"
+                 (flat-decompose-c free-axes) "\n"
+                 nest
+                 "    out[seg] = (" out-ctype ")" (acc-name 0) ";\n"
+                 "}\n")]
+    {:kernel-name kernel-name :source src
+     :array-params (vec inputs)
+     :lift-operands (mapv :sym lift-ops)
+     :dtype dtype :out-dtype out-dtype
+     :stages stages
+     :out-elems n-out
+     :dims (mapv second free-axes)}))

--- a/src/raster/compiler/ir/contract_stages.clj
+++ b/src/raster/compiler/ir/contract_stages.clj
@@ -1,0 +1,193 @@
+(ns raster.compiler.ir.contract-stages
+  "STAGED contract axes: a contraction whose reduction accumulates in more than one stage, each
+   with its own accumulator dtype.
+
+   WHY THIS EXISTS. `flatten-contract-axes` collapses n≥2 contract axes into one flat reduced
+   dim (the A0 convention, Futhark's single-width Screma). That is right for dense contraction —
+   and it is exactly what block-quantized arithmetic cannot do. Every real int8/int4 format
+   (GGUF q8_0/q4_0, k-quants, AWQ, and raster's own `backend/cpu/quant.clj`) computes
+
+       Σ_blk  d[blk] · ( Σ_{t<B} a[blk,t]·b[blk,t] )
+              ^^^^^^^   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              float acc      int32 acc, exact
+
+   The per-block scale multiplies a PARTIAL sum, so the reduction is two-level: an int32 MAC
+   inside the block, a float accumulate across blocks. Flatten it and the int accumulator is
+   gone — you are back to per-element float multiplies, which is the entire cost the format
+   exists to avoid. Our CPU quant backend already schedules it this way (\"deferred per-block
+   scale, float-vector accumulation, one reduce/row\"); this namespace is what lets the SAME
+   structure be expressed in the contraction algebra instead of beside it.
+
+   Number of stages is not special-cased — it is the format's nesting depth:
+     1 stage  → today's flat contraction (nothing changes)
+     2 stages → q8_0 / q4_0            (per-block scale)
+     3 stages → k-quants               (super-block scale-of-scales)
+
+   STAGES ARE A SCHEDULE, NOT NEW SEMANTICS. Because a lift must be LINEAR in the inner
+   accumulator (see `stages-legal?`), a staged contraction is *equal in exact arithmetic* to the
+   flat contraction whose body absorbed the lift factors — `flat-equivalent` derives it. Staging
+   changes only (a) the accumulator dtype/rounding and (b) performance. That is what makes it a
+   schedule annotation, and it is why an interpreter/CPU path needs no staged implementation: it
+   runs the flat equivalent. It also hands us a free ORACLE — the flat form is the reference a
+   staged device kernel is validated against.
+
+   REPRESENTATION — stages are OUTER→INNER, positionally aligned with the contract axes:
+
+     [{:axis blk :extent NB :dtype :float :init 0.0
+       :lift (raster.numeric/* inner (aget da blk) (aget db blk))
+       :operands [{:sym da :map <axis-map>} {:sym db :map <axis-map>}]}
+      {:axis t   :extent 32 :dtype :int   :init 0}]
+
+   The innermost stage carries no lift — it accumulates the contraction body itself. Each outer
+   stage's `:lift` is an expression in the symbol `inner` (the stage-below's accumulated value)
+   and may reference its own axis plus extra operand arrays, each with a declared axis-map (so a
+   scale is indexed by ITS map, not by pattern-matching — same rule as the epilogue seam)."
+  (:require [raster.compiler.ir.axis-map :as am]
+            [clojure.set :as set]
+            [clojure.walk :as walk]))
+
+(def ^:private forbidden-in-lift
+  "Ops that force a layout/distribution change and so cannot appear in a lift: the lift runs
+   between two accumulator levels, where a re-tiling decision is not available to us."
+  '#{raster.par/scan raster.par/scan-exclusive raster.par/scatter! raster.par/reduce-by-key
+     raster.par/reduce raster.par/reduce-into raster.par/contract})
+
+(defn- mul-head? [h]
+  (contains? '#{* clojure.core/* raster.numeric/*} h))
+
+(defn linear-in-inner
+  "If `lift` is LINEAR in `inner` — i.e. `inner` itself, or a product one of whose factors is
+   `inner` — return the vector of the REMAINING factors (possibly empty). Otherwise nil.
+
+   Linearity is what makes staging a schedule rather than a different computation: it is exactly
+   the condition under which the accumulate distributes,
+       Σ_blk F(blk)·(Σ_t x)  =  Σ_blk Σ_t F(blk)·x
+   so the lift factors can be pushed into the body to obtain the flat equivalent. A non-linear
+   lift (say `(sqrt inner)`) has no flat form — it is a genuinely different reduction, and is
+   refused rather than silently mis-scheduled."
+  [lift inner]
+  (cond
+    (= lift inner) []
+    (and (seq? lift) (mul-head? (first lift)))
+    (let [args (vec (rest lift))
+          n (count (filter #(= inner %) args))]
+      (when (= 1 n) (vec (remove #(= inner %) args))))
+    :else nil))
+
+(defn stages-legal?
+  "Legality of a staged contract axis. Returns {:ok true} or {:ok false :reason kw …}.
+
+   Rules, and the failure each one prevents:
+
+     • stages must cover the contract axes exactly once, OUTER→INNER. A stage naming an axis
+       that is not a contract axis (or omitting one) means the reduction does not span the
+       contraction — a wrong answer, not a slow one.
+     • the INNERMOST stage takes no lift: it accumulates the contraction body.
+     • every OUTER stage must have a lift, and that lift must use `inner` EXACTLY ONCE. Zero uses
+       DISCARDS the partial sum below it (silently wrong); more than one use duplicates the whole
+       inner reduction. Direct analogue of the epilogue's accumulator-used-once rule.
+     • a lift must be LINEAR in `inner` (see `linear-in-inner`) — otherwise there is no flat
+       equivalent and staging would change the computation rather than schedule it.
+     • accumulator dtypes must not NARROW going outward: a float inner accumulator feeding an
+       integral outer accumulator truncates every partial sum. (int → float, the quant case, is
+       the whole point and is fine.)
+     • no layout/distribution-changing op in a lift."
+  [stages contract-axes & {:keys [inner] :or {inner 'inner}}]
+  (let [stages (vec stages)
+        int-dtypes #{:int :long :byte :short :uint :int8 :int32}
+        float-dtypes #{:float :double :half :float16}
+        n (count stages)]
+    (cond
+      (zero? n) {:ok false :reason :no-stages}
+
+      (not= (mapv :axis stages) (mapv first contract-axes))
+      {:ok false :reason :stages-do-not-match-contract-axes
+       :stage-axes (mapv :axis stages) :contract-axes (mapv first contract-axes)}
+
+      (some? (:lift (peek stages)))
+      {:ok false :reason :innermost-stage-has-a-lift :axis (:axis (peek stages))}
+
+      :else
+      (or
+       ;; every outer stage: lift present, uses `inner` once, linear, no forbidden ops
+       (first
+        (keep
+         (fn [{:keys [axis lift]}]
+           (let [nodes (tree-seq coll? seq lift)
+                 uses (count (filter #(= inner %) nodes))
+                 heads (into #{} (keep #(when (seq? %) (first %))) nodes)]
+             (cond
+               (nil? lift) {:ok false :reason :outer-stage-without-a-lift :axis axis}
+               (zero? uses) {:ok false :reason :lift-discards-inner-accumulator :axis axis}
+               (> uses 1) {:ok false :reason :inner-accumulator-used-more-than-once
+                           :axis axis :uses uses}
+               (seq (set/intersection heads forbidden-in-lift))
+               {:ok false :reason :layout-changing-op-in-lift :axis axis
+                :ops (set/intersection heads forbidden-in-lift)}
+               (nil? (linear-in-inner lift inner))
+               {:ok false :reason :lift-not-linear-in-inner :axis axis :lift lift}
+               :else nil)))
+         (butlast stages)))
+       ;; dtypes must not narrow outward (inner → outer)
+       (first
+        (keep (fn [[outer inner-st]]
+                (when (and (contains? int-dtypes (:dtype outer))
+                           (contains? float-dtypes (:dtype inner-st)))
+                  {:ok false :reason :narrowing-stage-accumulator
+                   :outer (:dtype outer) :inner (:dtype inner-st)}))
+              (partition 2 1 stages)))
+       {:ok true}))))
+
+(defn contract-extent
+  "Total extent of the staged contract axis = product of the stage extents. Folds literals and
+   stays symbolic otherwise (reuses the axis-map product so one rule covers both)."
+  [stages]
+  (am/group-extent (mapv (fn [{:keys [axis extent]}] [axis extent]) stages)))
+
+(defn lift-operands
+  "All operand specs across all stages, in outer→inner stage order. These become EXTRA kernel
+   params (the scale arrays), so a caller must bind them — surfaced explicitly for the same
+   reason the epilogue's operands are: omitting them from a launch descriptor is an arity bug."
+  [stages]
+  (vec (mapcat :operands stages)))
+
+(defn stage-index-exprs
+  "Map of operand symbol → its flat index expression, taken from each operand's DECLARED axis-map.
+   The emitter substitutes these into `(aget scale …)` rather than inferring strides."
+  [stages]
+  (into {} (for [{:keys [sym map]} (lift-operands stages)] [sym (am/index-expr map)])))
+
+(defn substitute-operand-indices
+  "Rewrite `(aget s _)` → `(aget s <index from s's declared map>)` for every lift operand."
+  [expr idx-of]
+  (walk/postwalk
+   (fn [f] (if (and (seq? f) (= 'aget (first f)) (contains? idx-of (second f)))
+             (list 'aget (second f) (get idx-of (second f)))
+             f))
+   expr))
+
+(defn flat-equivalent
+  "The FLAT contraction body equal (in exact arithmetic) to this staged contraction: every stage's
+   lift factors multiplied into the body. Returns `body` unchanged for a single stage.
+
+   This is the semantics of a staged contraction — staging is a schedule over it. Two uses:
+   an interpreter/CPU path evaluates this instead of implementing stages at all, and a staged
+   device kernel is validated against it (they agree up to the accumulator's rounding, which is
+   the only thing staging actually changes).
+
+   The returned body is SELF-CONTAINED: each lift operand's `aget` index is substituted from its
+   declared axis-map, so the placeholder index in a lift expression never escapes to a consumer.
+   The stage axes remain free variables — the caller supplies the flat contract axis and its
+   decomposition (`flatten-contract-axes` does exactly that), so `da[i,blk]` becomes
+   `da[i*NB + l/B]` once the axes are flattened — no extra machinery."
+  [stages body & {:keys [inner] :or {inner 'inner}}]
+  (let [stages (vec stages)
+        idx-of (stage-index-exprs stages)
+        factors (map #(substitute-operand-indices % idx-of)
+                     (mapcat (fn [{:keys [lift]}]
+                               (when lift (linear-in-inner lift inner)))
+                             (butlast stages)))]
+    (if (empty? factors)
+      body
+      (cons 'raster.numeric/* (cons body (vec factors))))))
+

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -15,7 +15,8 @@
    (int8 widening). Keys: :kernel-name :source :array-params (binding order) :dtype :out-dtype
    :out-elems :wg [x y] :grid [gx gy] :scalar-args [{:type :value}…] :dims, plus optional
    :fallback-reason, :scheme (quant decode) and :pre-steps (inserted layout rearranges)."
-  (:require [raster.compiler.passes.parallel.contract-lower :as cl]
+  (:require [clojure.string :as str]
+            [raster.compiler.passes.parallel.contract-lower :as cl]
             [raster.compiler.backend.gpu.segop-opencl :as sco]
             [raster.compiler.backend.gpu.c-emit :as ce]
             [raster.compiler.ir.axis-map :as am]))
@@ -32,6 +33,98 @@
   (if (number? a)
     (long (Math/ceil (/ (double a) (double b))))
     (list 'quot (list 'clojure.core/+ a (dec (long b))) (long b))))
+
+(defn kernel-signature-params
+  "The parameter list of the single __kernel in `src`, split at top-level commas. Used to check a
+   launch descriptor against the kernel it actually describes."
+  [src]
+  (when-let [i (str/index-of src "__kernel void")]
+    (let [open (str/index-of src "(" i)
+          ;; scan to the matching close paren
+          close (loop [k (inc open) depth 1]
+                  (cond (>= k (count src)) nil
+                        (= \( (.charAt ^String src k)) (recur (inc k) (inc depth))
+                        (= \) (.charAt ^String src k)) (if (= 1 depth) k (recur (inc k) (dec depth)))
+                        :else (recur (inc k) depth)))]
+      (when close
+        (->> (str/split (subs src (inc open) close) #",")
+             (map str/trim)
+             (remove str/blank?)
+             vec)))))
+
+(defn validate-descriptor
+  "Check a launch descriptor against the kernel source it describes, and THROW on a mismatch.
+
+   The bug class this exists for has now bitten twice: a descriptor that under-describes the kernel
+   fails at LAUNCH, not at compile — the kernel is valid C, the caller simply binds the wrong number
+   of arguments. First occurrence: invoke-registered-contraction! reconstructed scalar-args from a
+   `case` with no default, so four of six strategies crashed. Second: an epilogue's operand arrays
+   were declared in the signature but absent from the descriptor, so a caller bound 6 args to a
+   7-arg kernel. Both are mechanically detectable by comparing the emitted signature with what the
+   descriptor says to bind, which is what this does.
+
+   Pointer params must equal (array-params + 1 output + epilogue-operands). The rest depends on the
+   INVOKE PROTOCOL, of which there are two — writing this validator is what forced them to be stated
+   explicitly instead of living implicitly in two call sites:
+
+     default (:invoke nil)  invoke-registered-contraction! binds :scalar-args positionally and
+                            launches with :wg/:grid — so all three must be present and match.
+     :invoke :reduction     invoke-reduction-kernel supplies the kernel's single trailing count
+                            param from :reduce-bound and computes its own two-phase launch geometry
+                            — so :scalar-args must be EMPTY and :wg/:grid ABSENT.
+
+   Returns the descriptor unchanged when consistent."
+  [{:keys [strategy kernel-name source array-params scalar-args epilogue-operands
+           out-elems wg grid invoke reduce-bound] :as d}]
+  (let [params (kernel-signature-params source)
+        _ (when (nil? params)
+            (throw (ex-info "contract descriptor: no __kernel signature found in source"
+                            {:strategy strategy :kernel-name kernel-name})))
+        ptr? (fn [p] (str/includes? p "*"))
+        n-ptr (count (filter ptr? params))
+        n-scalar (count (remove ptr? params))
+        expect-ptr (+ (count array-params) 1 (count epilogue-operands))
+        ;; TWO invoke protocols, made explicit here because the validator forced the question:
+        ;;   :invoke nil (default) — invoke-registered-contraction! binds :scalar-args positionally,
+        ;;                           so they must match the kernel's scalar params exactly.
+        ;;   :invoke :reduction    — invoke-reduction-kernel supplies the kernel's single trailing
+        ;;                           count param itself, from :reduce-bound; :scalar-args stays empty.
+        expect-scalar (if (= :reduction invoke) 1 (count scalar-args))]
+    (cond
+      (not= n-ptr expect-ptr)
+      (throw (ex-info (str "contract descriptor: kernel takes " n-ptr " pointer params but the "
+                           "descriptor binds " expect-ptr " (" (count array-params) " operands + out"
+                           (when (seq epilogue-operands)
+                             (str " + " (count epilogue-operands) " epilogue")) ")")
+                      {:strategy strategy :kernel-name kernel-name :params params
+                       :array-params array-params :epilogue-operands epilogue-operands}))
+      (not= n-scalar expect-scalar)
+      (throw (ex-info (str "contract descriptor: kernel takes " n-scalar " scalar params but the "
+                           (if (= :reduction invoke)
+                             "reduction invoke supplies 1 (the count, from :reduce-bound)"
+                             (str "descriptor supplies " expect-scalar " scalar-args")))
+                      {:strategy strategy :kernel-name kernel-name :params params
+                       :invoke invoke :scalar-args scalar-args}))
+      (and (= :reduction invoke) (seq scalar-args))
+      (throw (ex-info "contract descriptor: :invoke :reduction must leave :scalar-args empty (the count comes from :reduce-bound)"
+                      {:strategy strategy :scalar-args scalar-args}))
+      (nil? out-elems)
+      (throw (ex-info "contract descriptor: :out-elems is required (the invoke sizes the output with it)"
+                      {:strategy strategy}))
+      ;; wg/grid belong to the 2-D launch contract only. The reduction invoke computes its own
+      ;; two-phase geometry, so a :reduction descriptor legitimately carries neither — a third
+      ;; protocol difference this validator forced into the open rather than leaving implicit.
+      (and (not= :reduction invoke)
+           (not (and (vector? wg) (= 2 (count wg)) (vector? grid) (= 2 (count grid)))))
+      (throw (ex-info "contract descriptor: :wg and :grid must both be 2-element vectors"
+                      {:strategy strategy :wg wg :grid grid}))
+      (and (= :reduction invoke) (or (some? wg) (some? grid)))
+      (throw (ex-info "contract descriptor: :invoke :reduction must not carry :wg/:grid (the invoke owns the two-phase launch)"
+                      {:strategy strategy :wg wg :grid grid}))
+      (and (= :reduction invoke) (nil? reduce-bound))
+      (throw (ex-info "contract descriptor: :invoke :reduction requires :reduce-bound"
+                      {:strategy strategy}))
+      :else d)))
 
 (declare route-2free-1contract route-quant)
 
@@ -61,7 +154,11 @@
         form-opts (apply hash-map (drop 5 contract-form))
         epilogue (or epilogue (:epilogue form-opts))
         tensorize-plan (memoize #(route-2free-1contract contract-form out-sym dtype desc tile epilogue))]
-    (cond
+    ;; Every descriptor is validated against the kernel it describes before it leaves this fn. The
+    ;; failure mode it guards is a LAUNCH-time arity mismatch (valid C, wrong number of bound args),
+    ;; which has bitten twice; validating at generation makes it a loud compile-time error instead.
+    (validate-descriptor
+     (cond
       ;; int8 → the quant leaves (dp4a for :nt, quant naive-widening for :nn)
       (#{:byte :int8} dtype)
       (route-quant contract-form out-sym scheme n-free n-contract nseg prefer-peak?)
@@ -88,11 +185,14 @@
       ;; 0 contract axes → outer product / broadcast → pure N-D SegMap (1-D launch)
       (zero? n-contract)
       (let [sm (cl/contract-form->segmap contract-form :dtype dtype)
-            {:keys [kernel-name source array-params]} (sco/generate-segmap-nd-kernel sm out-sym :dtype dtype)]
+            {:keys [kernel-name source array-params scalar-params]}
+            (sco/generate-segmap-nd-kernel sm out-sym :dtype dtype)]
         {:strategy :segmap
          :kernel-name kernel-name :source source :array-params array-params
          :dtype dtype :out-dtype dtype :wg [256 1] :grid [(ceil-div nseg 256) 1]
-         :scalar-args [{:type :int :value nseg}] :out-elems nseg :dims [nseg]})
+         :scalar-args (conj (mapv (fn [p] {:type :int :value p}) scalar-params)
+                            {:type :int :value nseg})
+         :out-elems nseg :dims [nseg]})
 
       ;; 2 free + 1 contract → the tensorize fast path (DPAS if legal, else regtiled).
       ;; Returns nil when the form fails a TENSORIZE structural precondition (symbolic dims,
@@ -106,11 +206,16 @@
       ;; contract-form->segred flattens n≥2 contract axes into one innermost dim.
       :else
       (let [sr (cl/contract-form->segred contract-form :dtype dtype)
-            {:keys [kernel-name source array-params]} (sco/generate-segmented-reduce-kernel sr out-sym :dtype dtype)]
+            {:keys [kernel-name source array-params scalar-params]}
+            (sco/generate-segmented-reduce-kernel sr out-sym :dtype dtype)]
         {:strategy :naive-segred
          :kernel-name kernel-name :source source :array-params array-params
          :dtype dtype :out-dtype dtype :wg [256 1] :grid [(ceil-div nseg 256) 1]
-         :scalar-args [{:type :int :value nseg}] :out-elems nseg :dims [nseg]}))))
+         ;; SYMBOLIC axis bounds become int kernel params (the emitter declares them, sorted by
+         ;; name); they must be bound BEFORE the trailing count or the launch arity is wrong.
+         :scalar-args (conj (mapv (fn [p] {:type :int :value p}) scalar-params)
+                            {:type :int :value nseg})
+         :out-elems nseg :dims [nseg]})))))
 
 (defn- route-2free-1contract
   "The tensorize fast path: DPAS if the gate accepts, else the register-tiled portable kernel.

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -34,6 +34,16 @@
     (long (Math/ceil (/ (double a) (double b))))
     (list 'quot (list 'clojure.core/+ a (dec (long b))) (long b))))
 
+(defn- contract-operand-arrays
+  "The array symbols the contraction BODY reads, i.e. every `(aget arr …)` target. These are the
+   contraction's own operands; a staged contraction's per-stage scale arrays are NOT among them —
+   those are declared on the stages and surfaced separately as :lift-operands, so the two groups
+   cannot be confused at bind time."
+  [body]
+  (distinct (keep (fn [f] (when (and (seq? f) (= 'aget (first f)) (symbol? (second f)))
+                            (second f)))
+                  (tree-seq coll? seq body))))
+
 (defn kernel-signature-params
   "The parameter list of the single __kernel in `src`, split at top-level commas. Used to check a
    launch descriptor against the kernel it actually describes."
@@ -74,7 +84,7 @@
                             — so :scalar-args must be EMPTY and :wg/:grid ABSENT.
 
    Returns the descriptor unchanged when consistent."
-  [{:keys [strategy kernel-name source array-params scalar-args epilogue-operands
+  [{:keys [strategy kernel-name source array-params scalar-args epilogue-operands lift-operands
            out-elems wg grid invoke reduce-bound] :as d}]
   (let [params (kernel-signature-params source)
         _ (when (nil? params)
@@ -83,7 +93,10 @@
         ptr? (fn [p] (str/includes? p "*"))
         n-ptr (count (filter ptr? params))
         n-scalar (count (remove ptr? params))
-        expect-ptr (+ (count array-params) 1 (count epilogue-operands))
+        ;; EXTRA operand arrays are pointer params too, whichever seam declared them: an
+        ;; epilogue's (bias/residual/scale, appended after the dims) or a staged contraction's
+        ;; lift operands (the per-block scales, bound between the operands and the output).
+        expect-ptr (+ (count array-params) 1 (count epilogue-operands) (count lift-operands))
         ;; TWO invoke protocols, made explicit here because the validator forced the question:
         ;;   :invoke nil (default) — invoke-registered-contraction! binds :scalar-args positionally,
         ;;                           so they must match the kernel's scalar params exactly.
@@ -95,9 +108,12 @@
       (throw (ex-info (str "contract descriptor: kernel takes " n-ptr " pointer params but the "
                            "descriptor binds " expect-ptr " (" (count array-params) " operands + out"
                            (when (seq epilogue-operands)
-                             (str " + " (count epilogue-operands) " epilogue")) ")")
+                             (str " + " (count epilogue-operands) " epilogue"))
+                           (when (seq lift-operands)
+                             (str " + " (count lift-operands) " lift")) ")")
                       {:strategy strategy :kernel-name kernel-name :params params
-                       :array-params array-params :epilogue-operands epilogue-operands}))
+                       :array-params array-params :epilogue-operands epilogue-operands
+                       :lift-operands lift-operands}))
       (not= n-scalar expect-scalar)
       (throw (ex-info (str "contract descriptor: kernel takes " n-scalar " scalar params but the "
                            (if (= :reduction invoke)
@@ -134,7 +150,7 @@
    the int8 quant leaves — dp4a for the :nt operand layout, quant naive-widening for :nn;
    anything else, or a gate rejection, falls back to the register-tiled portable kernel).
    scheme = the quant decode descriptor {:scale :a-zp :b-zp} for int8 (default {:scale 1.0})."
-  [contract-form & {:keys [dtype scheme prefer-peak? desc tile epilogue]
+  [contract-form & {:keys [dtype scheme prefer-peak? desc tile epilogue stages]
                     :or {dtype :half scheme {:scale 1.0} prefer-peak? false}}]
   (let [out-sym (second contract-form)
         free-axes (nth contract-form 2)
@@ -153,12 +169,38 @@
         ;; fuse-contract-map puts it there); an explicit :epilogue kwarg overrides.
         form-opts (apply hash-map (drop 5 contract-form))
         epilogue (or epilogue (:epilogue form-opts))
+        stages (or stages (:stages (apply hash-map (drop 5 contract-form))))
         tensorize-plan (memoize #(route-2free-1contract contract-form out-sym dtype desc tile epilogue))]
     ;; Every descriptor is validated against the kernel it describes before it leaves this fn. The
     ;; failure mode it guards is a LAUNCH-time arity mismatch (valid C, wrong number of bound args),
     ;; which has bitten twice; validating at generation makes it a loud compile-time error instead.
     (validate-descriptor
      (cond
+      ;; STAGED contract axis → the multi-level accumulate leaf. Checked FIRST because staging is
+      ;; a property of the reduction itself, not of the dtype: it is what lets a block-quantized
+      ;; format (int32 MAC inside the block, float accumulate across blocks) be expressed in the
+      ;; contraction algebra at all. The flat leaves below cannot represent it — they have one
+      ;; accumulator. 1 stage is the flat case and is left to them.
+      (and (seq stages) (> (count stages) 1))
+      (let [k (sco/generate-staged-contraction-kernel
+               {:free-axes free-axes :stages stages
+                :body (nth contract-form 4)
+                :inputs (vec (sort-by name (contract-operand-arrays (nth contract-form 4))))
+                :dtype dtype :out-dtype (or (:out-dtype (apply hash-map (drop 5 contract-form)))
+                                            :float)}
+               out-sym)]
+        {:strategy :staged-segred
+         :kernel-name (:kernel-name k) :source (:source k)
+         :array-params (:array-params k)
+         ;; the per-stage scale arrays are EXTRA pointer params — surfaced so a caller binds them
+         :lift-operands (:lift-operands k)
+         :dtype (:dtype k) :out-dtype (:out-dtype k)
+         :out-elems (:out-elems k)
+         :stages (:stages k)
+         :scalar-args [{:type :int :value nseg}]
+         :wg [256 1]
+         :grid [(ceil-div nseg 256) 1]})
+
       ;; int8 → the quant leaves (dp4a for :nt, quant naive-widening for :nn)
       (#{:byte :int8} dtype)
       (route-quant contract-form out-sym scheme n-free n-contract nseg prefer-peak?)

--- a/src/raster/par.clj
+++ b/src/raster/par.clj
@@ -165,11 +165,24 @@
   Example (C[m,n] = A[m,k]·B[k,n], row-major):
     (raster.par/contract C [[i m] [j n]] [[l k]]
       (* (aget A (+ (* i k) l)) (aget B (+ (* l n) j))))"
-  [out free-axes contract-axes body & {:keys [init combine] :or {init 0.0 combine '+}}]
+  [out free-axes contract-axes body & {:keys [init combine stages] :or {init 0.0 combine '+}}]
   (assert (vector? free-axes) "par/contract: free-axes must be a vector of [idx bound]")
   (assert (vector? contract-axes)
           "par/contract: contract-axes must be a vector (0 → outer product/map; n≥1 → contraction, n≥2 flattened)")
-  (let [free-syms   (mapv first free-axes)
+  (let [;; A STAGED contract axis (:stages) is a SCHEDULE: the multi-level accumulate is equal, in
+        ;; exact arithmetic, to the flat contraction whose body absorbed the lift factors, so the
+        ;; interpreted expansion runs THAT and needs no staged implementation. Ignoring :stages
+        ;; here would silently drop the lift factors (e.g. every per-block quant scale) — a wrong
+        ;; answer, not a slower one. See compiler/ir/contract_stages.clj; the GPU leaf that
+        ;; actually schedules the levels is segop-opencl/generate-staged-contraction-kernel.
+        _ (when (seq stages)
+            (let [legal ((requiring-resolve 'raster.compiler.ir.contract-stages/stages-legal?)
+                         stages contract-axes)]
+              (assert (:ok legal) (str "par/contract: illegal :stages (" (:reason legal) ")"))))
+        body (if (seq stages)
+               ((requiring-resolve 'raster.compiler.ir.contract-stages/flat-equivalent) stages body)
+               body)
+        free-syms   (mapv first free-axes)
         int-bounds  (mapv (fn [[_ b]] `(int ~b)) free-axes)
         f-sym   (gensym "f__")
         out-sym (gensym "out__")

--- a/test/raster/compiler/backend/gpu/contract_pipeline_device_test.clj
+++ b/test/raster/compiler/backend/gpu/contract_pipeline_device_test.clj
@@ -109,4 +109,13 @@
              :dtype :double)]
       (is (some? (:out-elems r)))
       (is (not (number? (:out-elems r))))            ; carried symbolically
-      (is (contains? #{:regtiled :naive-segred} (:strategy r))))))
+      (is (contains? #{:regtiled :naive-segred} (:strategy r)))
+      ;; STRENGTHENED: the original assertion only checked that routing did not CRASH, which let a
+      ;; real bug through — the descriptor supplied 1 scalar arg where the kernel declares 4
+      ;; (int k, int m, int n, int _nseg), so a caller would have mis-bound at launch. The
+      ;; descriptor validator caught it; assert usability here, not merely non-crashing.
+      (is (= 4 (count (:scalar-args r)))
+          "the symbolic axis bounds must be bound as int params, before the trailing count")
+      (is (= '[k m n] (mapv :value (butlast (:scalar-args r))))
+          "…in the kernel's declared (name-sorted) order")
+      (is (= (:out-elems r) (:value (last (:scalar-args r))))))))

--- a/test/raster/compiler/backend/gpu/staged_contract_device_test.clj
+++ b/test/raster/compiler/backend/gpu/staged_contract_device_test.clj
@@ -1,0 +1,241 @@
+(ns raster.compiler.backend.gpu.staged-contract-device-test
+  "STAGED contraction on device: a reduction that accumulates in more than one level, which is
+   the shape every block-quantized format needs and the flat leaves cannot express.
+
+       out[i,j] = Σ_blk  da[i,blk]·db[j,blk] · ( Σ_t  a[i,blk,t] · b[j,blk,t] )
+                         ^^^^^^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                         float, once per block   int32, exact, 32 MACs
+
+   This is q8_0/q4_0 (2 stages) and, with one more level, k-quants (3 stages). The scales are
+   indexed [i,blk] / [j,blk] — a free axis AND a stage axis — which is the real format layout and
+   exercises the declared axis-maps rather than a per-tensor scalar.
+
+   THE ORACLE IS THE FLAT EQUIVALENT. Because a lift is linear in the inner accumulator, staging
+   is a SCHEDULE: the staged contraction equals the flat contraction whose body absorbed the lift
+   factors (ir/contract-stages/flat-equivalent). So each case is checked against BOTH a direct
+   block reference and the flat form — and with power-of-two scales the identity is exact in
+   float, so it is asserted with `=`, not a tolerance. Gated on a real GPU."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.contract-stages :as cs]
+            [raster.compiler.backend.gpu.segop-opencl :as sco]))
+
+(def ^:private gpu?
+  (delay (try (require 'raster.gpu.ze-runtime)
+              (boolean (seq ((resolve 'raster.gpu.ze-runtime/query-devices))))
+              (catch Throwable _ false))))
+
+(def ^:private M 4)
+(def ^:private N 6)
+(def ^:private B 32)                  ; block length (q8_0's block)
+(def ^:private NB 4)                  ; blocks per row
+(def ^:private K (* NB B))            ; 128
+
+;; operands are K-contiguous (the :nt layout block-quant formats use)
+(defn- a-idx [] (list 'clojure.core/+ (list 'clojure.core/* 'i K)
+                      (list 'clojure.core/+ (list 'clojure.core/* 'blk B) 't)))
+(defn- b-idx [] (list 'clojure.core/+ (list 'clojure.core/* 'j K)
+                      (list 'clojure.core/+ (list 'clojure.core/* 'blk B) 't)))
+(def ^:private body
+  (list 'raster.numeric/* (list 'aget 'a (a-idx)) (list 'aget 'b (b-idx))))
+
+(def ^:private two-stage
+  ;; scale maps: da[i,blk] → i*NB + blk ; db[j,blk] → j*NB + blk (declared, not inferred)
+  [{:axis 'blk :extent NB :dtype :float :init 0.0
+    :lift '(raster.numeric/* inner (aget da _) (aget db _))
+    :operands [{:sym 'da :map {:groups [[['i M]] [['blk NB]]]} :dtype :float}
+               {:sym 'db :map {:groups [[['j N]] [['blk NB]]]} :dtype :float}]}
+   {:axis 't :extent B :dtype :int :init 0}])
+
+;; ── host references ─────────────────────────────────────────────────────────────────
+(defn- ref-staged
+  "The block formula, evaluated exactly as the kernel schedules it: int32 inner, float outer."
+  [^bytes a ^bytes b ^floats da ^floats db]
+  (let [out (float-array (* M N))]
+    (dotimes [i M]
+      (dotimes [j N]
+        (let [acc (loop [blk 0 acc 0.0]
+                    (if (< blk NB)
+                      (let [inner (loop [t 0 s 0]
+                                    (if (< t B)
+                                      (recur (inc t)
+                                             (+ s (* (int (aget a (+ (* i K) (* blk B) t)))
+                                                     (int (aget b (+ (* j K) (* blk B) t))))))
+                                      s))]
+                        (recur (inc blk)
+                               (+ acc (* (double inner)
+                                         (double (aget da (+ (* i NB) blk)))
+                                         (double (aget db (+ (* j NB) blk)))))))
+                      acc))]
+          (aset out (+ (* i N) j) (float acc)))))
+    out))
+
+(defn- ref-flat
+  "The FLAT equivalent: one reduction over l, lift factors pushed into the body — i.e. what
+   `flat-equivalent` derives, and what a CPU/interpreter path would run."
+  [^bytes a ^bytes b ^floats da ^floats db]
+  (let [out (float-array (* M N))]
+    (dotimes [i M]
+      (dotimes [j N]
+        (let [acc (loop [l 0 acc 0.0]
+                    (if (< l K)
+                      (let [blk (quot l B)]
+                        (recur (inc l)
+                               (+ acc (* (double (int (aget a (+ (* i K) l))))
+                                         (double (int (aget b (+ (* j K) l))))
+                                         (double (aget da (+ (* i NB) blk)))
+                                         (double (aget db (+ (* j NB) blk)))))))
+                      acc))]
+          (aset out (+ (* i N) j) (float acc)))))
+    out))
+
+;; ── device run ──────────────────────────────────────────────────────────────────────
+(defn- run-staged
+  "Emit, register and launch a staged contraction; return the device output vector. `lift-arrays`
+   maps each lift operand symbol → its float array, bound in the emitter's declared order."
+  [stages body-expr ^bytes a ^bytes b lift-arrays]
+  (let [ze (find-ns 'raster.gpu.ze-runtime)
+        register! (ns-resolve ze 'register-kernel!)
+        ensure-loaded! (ns-resolve ze 'ensure-kernel-loaded!)
+        make-buffer (ns-resolve ze 'make-buffer)
+        arr->buf! (ns-resolve ze 'array->buffer!)
+        buf->floats (ns-resolve ze 'buffer->float-array)
+        launch-2d! (ns-resolve ze 'launch-2d!)
+        {:keys [kernel-name source array-params lift-operands out-elems]}
+        (sco/generate-staged-contraction-kernel
+         {:free-axes [['i M] ['j N]] :stages stages :body body-expr
+          :inputs '[a b] :dtype :byte :out-dtype :float}
+         'out)
+        _ (assert (= '[a b] array-params))
+        _ (register! kernel-name {:source source :dtype :byte})
+        {:keys [kernel-handle]} (ensure-loaded! kernel-name)
+        abuf (arr->buf! (make-buffer (alength a) :byte) a)
+        bbuf (arr->buf! (make-buffer (alength b) :byte) b)
+        lbufs (mapv (fn [sym] (let [^floats arr (get lift-arrays sym)]
+                                (arr->buf! (make-buffer (alength arr) :float) arr)))
+                    lift-operands)
+        obuf (make-buffer out-elems :float)
+        nseg (long out-elems)
+        gx (long (Math/ceil (/ (double nseg) 256.0)))
+        args (concat [(:segment abuf) (:segment bbuf)]
+                     (map :segment lbufs)
+                     [(:segment obuf) {:type :int :value (int nseg)}])]
+    (launch-2d! kernel-handle [256 1] [gx 1] (vec args))
+    (vec (buf->floats obuf))))
+
+(defn- pow2-scales [n seed]
+  ;; powers of two → every float multiply is exact, so staged and flat agree BIT-for-bit
+  (float-array (map (fn [i] (Math/scalb 1.0 (int (- (int (mod (+ i seed) 5)) 2)))) (range n))))
+
+(def ^:private a-data (byte-array (map #(byte (- (mod (* 7 %) 15) 7)) (range (* M K)))))
+(def ^:private b-data (byte-array (map #(byte (- (mod (* 5 %) 15) 7)) (range (* N K)))))
+
+(deftest two-stage-block-quant-on-device
+  (if-not @gpu?
+    (println "  [skip] no GPU — staged contraction device test")
+    (let [da (pow2-scales (* M NB) 0)
+          db (pow2-scales (* N NB) 3)
+          gpu (run-staged two-stage body a-data b-data {'da da 'db db})
+          staged (vec (ref-staged a-data b-data da db))
+          flat (vec (ref-flat a-data b-data da db))]
+      (testing "flat-equivalent derives exactly the flat body ref-flat evaluates by hand"
+        (is (= (list 'raster.numeric/* body
+                     '(aget da (clojure.core/+ (clojure.core/* i 4) blk))
+                     '(aget db (clojure.core/+ (clojure.core/* j 4) blk)))
+               (cs/flat-equivalent two-stage body))
+            "and the placeholder index never escapes — it is replaced by the declared map"))
+      (testing "the staged/flat identity holds EXACTLY on real data (power-of-two scales)"
+        (is (= staged flat)
+            "staging is a schedule: it must not change the value, only the accumulator"))
+      (testing "device matches the reference"
+        (is (= staged gpu)))
+      (testing "the result is actually non-trivial (guards against an all-zero pass)"
+        (is (some #(not (zero? %)) gpu))))))
+
+(deftest three-stage-super-block-on-device
+  (if-not @gpu?
+    (println "  [skip] no GPU — 3-stage staged contraction device test")
+    ;; k-quant nesting: super-block scale × sub-block scale × int MAC. NB is split 4 = 2 × 2.
+    (let [nsb 2 nsub 2
+          stages [{:axis 'sb :extent nsb :dtype :float :init 0.0
+                   :lift '(raster.numeric/* inner (aget dsuper _))
+                   :operands [{:sym 'dsuper :map {:groups [[['i M]] [['sb nsb]]]} :dtype :float}]}
+                  {:axis 'blk2 :extent nsub :dtype :float :init 0.0
+                   :lift '(raster.numeric/* inner (aget dsub _))
+                   :operands [{:sym 'dsub :map {:groups [[['j N]] [['blk2 nsub]]]} :dtype :float}]}
+                  {:axis 't :extent B :dtype :int :init 0}]
+          ;; l = ((sb*nsub) + blk2)*B + t
+          l-expr (list 'clojure.core/+
+                       (list 'clojure.core/* (list 'clojure.core/+
+                                                   (list 'clojure.core/* 'sb nsub) 'blk2) B)
+                       't)
+          body3 (list 'raster.numeric/*
+                      (list 'aget 'a (list 'clojure.core/+ (list 'clojure.core/* 'i K) l-expr))
+                      (list 'aget 'b (list 'clojure.core/+ (list 'clojure.core/* 'j K) l-expr)))
+          dsuper (pow2-scales (* M nsb) 1)
+          dsub (pow2-scales (* N nsub) 2)
+          gpu (run-staged stages body3 a-data b-data {'dsuper dsuper 'dsub dsub})
+          ;; host reference for the 3-level nest
+          ref (let [out (float-array (* M N))]
+                (dotimes [i M]
+                  (dotimes [j N]
+                    (let [acc (loop [sb 0 acc 0.0]
+                                (if (< sb nsb)
+                                  (let [mid (loop [blk2 0 m 0.0]
+                                              (if (< blk2 nsub)
+                                                (let [inner (loop [t 0 s 0]
+                                                              (if (< t B)
+                                                                (let [l (+ (* (+ (* sb nsub) blk2) B) t)]
+                                                                  (recur (inc t)
+                                                                         (+ s (* (int (aget a-data (+ (* i K) l)))
+                                                                                 (int (aget b-data (+ (* j K) l)))))))
+                                                                s))]
+                                                  (recur (inc blk2)
+                                                         (+ m (* (double inner)
+                                                                 (double (aget dsub (+ (* j nsub) blk2)))))))
+                                                m))]
+                                    (recur (inc sb)
+                                           (+ acc (* mid (double (aget dsuper (+ (* i nsb) sb)))))))
+                                  acc))]
+                      (aset out (+ (* i N) j) (float acc)))))
+                (vec out))]
+      (testing "3 stages (k-quant nesting) is the same mechanism, one level deeper"
+        (is (= ref gpu)))
+      (testing "non-trivial result"
+        (is (some #(not (zero? %)) gpu))))))
+
+(deftest one-stage-is-the-flat-contraction
+  (testing "a single stage needs no lift and emits a plain accumulate loop (no nesting)"
+    (let [{:keys [source lift-operands]}
+          (sco/generate-staged-contraction-kernel
+           {:free-axes [['i M] ['j N]]
+            :stages [{:axis 'l :extent K :dtype :float :init 0.0}]
+            :body (list 'raster.numeric/*
+                        (list 'aget 'a (list 'clojure.core/+ (list 'clojure.core/* 'i K) 'l))
+                        (list 'aget 'b (list 'clojure.core/+ (list 'clojure.core/* 'j K) 'l)))
+            :inputs '[a b] :dtype :float :out-dtype :float}
+           'out)]
+      (is (= [] lift-operands) "no scale arrays, so no extra kernel params")
+      (is (= 1 (count (re-seq #"for \(int" source))) "exactly one loop level")
+      (is (not (clojure.string/includes? source "acc_1"))))))
+
+(deftest illegal-stages-are-refused-not-emitted
+  (testing "the emitter refuses an illegal stage list rather than emitting a wrong kernel"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"lift-discards-inner-accumulator"
+         (sco/generate-staged-contraction-kernel
+          {:free-axes [['i M] ['j N]]
+           :stages [{:axis 'blk :extent NB :dtype :float :init 0.0
+                     :lift '(raster.numeric/* (aget da _) 2.0)
+                     :operands [{:sym 'da :map {:groups [[['blk NB]]]}}]}
+                    {:axis 't :extent B :dtype :int :init 0}]
+           :body body :inputs '[a b] :dtype :byte :out-dtype :float}
+          'out)))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"lift-not-linear-in-inner"
+         (sco/generate-staged-contraction-kernel
+          {:free-axes [['i M] ['j N]]
+           :stages [{:axis 'blk :extent NB :dtype :float :init 0.0
+                     :lift '(raster.numeric/sqrt inner)}
+                    {:axis 't :extent B :dtype :int :init 0}]
+           :body body :inputs '[a b] :dtype :byte :out-dtype :float}
+          'out)))))

--- a/test/raster/compiler/ir/contract_stages_test.clj
+++ b/test/raster/compiler/ir/contract_stages_test.clj
@@ -1,0 +1,137 @@
+(ns raster.compiler.ir.contract-stages-test
+  "Staged contract axes: legality + the flat-equivalence identity. Device-free — this is IR.
+
+   The identity is the load-bearing claim: staging is a SCHEDULE, so a staged contraction must
+   have a flat form equal to it in exact arithmetic. Everything else (the GPU leaf, the CPU path,
+   the device oracle) rests on that, so it is tested here directly rather than only via a kernel."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.contract-stages :as cs]
+            [raster.compiler.ir.axis-map :as am]))
+
+;; q8_0-shaped: 2 stages, per-block scale on each operand
+(def ^:private q8-stages
+  '[{:axis blk :extent 4 :dtype :float :init 0.0
+      :lift (raster.numeric/* inner (aget da blk) (aget db blk))
+      :operands [{:sym da :map {:groups [[[blk 4]]]}}
+                 {:sym db :map {:groups [[[blk 4]]]}}]}
+    {:axis t :extent 32 :dtype :int :init 0}])
+
+(def ^:private body '(raster.numeric/* (aget a idx-a) (aget b idx-b)))
+
+(deftest single-stage-is-todays-flat-contraction
+  (testing "one stage is legal, needs no lift, and its flat equivalent is the body verbatim"
+    (let [s '[{:axis l :extent 128 :dtype :float :init 0.0}]]
+      (is (:ok (cs/stages-legal? s '[[l 128]])))
+      (is (= body (cs/flat-equivalent s body)))
+      (is (= 128 (cs/contract-extent s)))
+      (is (= [] (cs/lift-operands s))))))
+
+(deftest two-stage-block-quant
+  (testing "the q8_0 shape is legal"
+    (is (:ok (cs/stages-legal? q8-stages '[[blk 4] [t 32]]))))
+  (testing "extent is the product of the stage extents"
+    (is (= 128 (cs/contract-extent q8-stages))))
+  (testing "flat equivalent multiplies the lift factors into the body — this IS the semantics"
+    (is (= '(raster.numeric/* (raster.numeric/* (aget a idx-a) (aget b idx-b))
+                              (aget da blk) (aget db blk))
+           (cs/flat-equivalent q8-stages body))
+        "operand indices come from the declared maps, so the result is self-contained"))
+  (testing "scale arrays are surfaced as operands so a launch descriptor binds them"
+    (is (= '[da db] (mapv :sym (cs/lift-operands q8-stages)))))
+  (testing "operand indices come from the DECLARED axis-map, not from inferred strides"
+    (is (= '{da blk db blk} (cs/stage-index-exprs q8-stages)))))
+
+(deftest three-stage-super-block
+  (testing "k-quant nesting is just one more stage — no new concept"
+    (let [s '[{:axis sb :extent 2 :dtype :float :init 0.0
+               :lift (raster.numeric/* inner (aget dsuper sb))
+               :operands [{:sym dsuper :map {:groups [[[sb 2]]]}}]}
+              {:axis blk :extent 8 :dtype :float :init 0.0
+               :lift (raster.numeric/* inner (aget dsub blk))
+               :operands [{:sym dsub :map {:groups [[[blk 8]]]}}]}
+              {:axis t :extent 32 :dtype :int :init 0}]]
+      (is (:ok (cs/stages-legal? s '[[sb 2] [blk 8] [t 32]])))
+      (is (= 512 (cs/contract-extent s)))
+      (is (= '[dsuper dsub] (mapv :sym (cs/lift-operands s))))
+      (is (= '(raster.numeric/* (raster.numeric/* (aget a idx-a) (aget b idx-b))
+                                (aget dsuper sb) (aget dsub blk))
+             (cs/flat-equivalent s body))))))
+
+(deftest linearity-is-the-schedule-condition
+  (testing "linear-in-inner returns the remaining factors"
+    (is (= [] (cs/linear-in-inner 'inner 'inner)))
+    (is (= '[(aget da blk)] (cs/linear-in-inner '(raster.numeric/* inner (aget da blk)) 'inner)))
+    (is (= '[(aget da blk)] (cs/linear-in-inner '(raster.numeric/* (aget da blk) inner) 'inner))
+        "factor order does not matter"))
+  (testing "non-linear lifts have NO flat form and are rejected, not mis-scheduled"
+    (is (nil? (cs/linear-in-inner '(raster.numeric/sqrt inner) 'inner)))
+    (is (nil? (cs/linear-in-inner '(raster.numeric/+ inner 1.0) 'inner))
+        "additive is not linear-with-a-factor: Σ(x+1) ≠ (Σx)+1 across stages")
+    (is (= :lift-not-linear-in-inner
+           (:reason (cs/stages-legal?
+                     '[{:axis blk :extent 4 :dtype :float :init 0.0
+                        :lift (raster.numeric/sqrt inner)}
+                       {:axis t :extent 32 :dtype :int :init 0}]
+                     '[[blk 4] [t 32]]))))))
+
+(deftest rejections
+  (testing "stages must cover the contract axes exactly, outer→inner"
+    (is (= :stages-do-not-match-contract-axes
+           (:reason (cs/stages-legal? q8-stages '[[t 32] [blk 4]])) ) "wrong order")
+    (is (= :stages-do-not-match-contract-axes
+           (:reason (cs/stages-legal? q8-stages '[[blk 4]]))) "missing axis"))
+  (testing "a lift that DISCARDS the inner accumulator is silently wrong — refuse it"
+    (is (= :lift-discards-inner-accumulator
+           (:reason (cs/stages-legal?
+                     '[{:axis blk :extent 4 :dtype :float :init 0.0
+                        :lift (raster.numeric/* (aget da blk) 2.0)}
+                       {:axis t :extent 32 :dtype :int :init 0}]
+                     '[[blk 4] [t 32]])))))
+  (testing "…and one that uses it twice duplicates the whole inner reduction"
+    (is (= :inner-accumulator-used-more-than-once
+           (:reason (cs/stages-legal?
+                     '[{:axis blk :extent 4 :dtype :float :init 0.0
+                        :lift (raster.numeric/* inner inner)}
+                       {:axis t :extent 32 :dtype :int :init 0}]
+                     '[[blk 4] [t 32]])))))
+  (testing "the innermost stage accumulates the body, so it must not carry a lift"
+    (is (= :innermost-stage-has-a-lift
+           (:reason (cs/stages-legal?
+                     '[{:axis blk :extent 4 :dtype :float :init 0.0
+                        :lift (raster.numeric/* inner (aget da blk))}
+                       {:axis t :extent 32 :dtype :int :init 0
+                        :lift (raster.numeric/* inner 2.0)}]
+                     '[[blk 4] [t 32]])))))
+  (testing "an outer stage with no lift at all"
+    (is (= :outer-stage-without-a-lift
+           (:reason (cs/stages-legal?
+                     '[{:axis blk :extent 4 :dtype :float :init 0.0}
+                       {:axis t :extent 32 :dtype :int :init 0}]
+                     '[[blk 4] [t 32]])))))
+  (testing "an integral OUTER accumulator over a float inner one truncates every partial sum"
+    (is (= :narrowing-stage-accumulator
+           (:reason (cs/stages-legal?
+                     '[{:axis blk :extent 4 :dtype :int :init 0
+                        :lift (raster.numeric/* inner (aget da blk))}
+                       {:axis t :extent 32 :dtype :float :init 0.0}]
+                     '[[blk 4] [t 32]]))))
+    (is (:ok (cs/stages-legal? q8-stages '[[blk 4] [t 32]]))
+        "int inner → float outer is the quant case and must stay legal"))
+  (testing "a reduction inside a lift is a re-tiling decision we do not have"
+    (is (= :layout-changing-op-in-lift
+           (:reason (cs/stages-legal?
+                     '[{:axis blk :extent 4 :dtype :float :init 0.0
+                        :lift (raster.numeric/* inner (raster.par/reduce (aget da blk)))}
+                       {:axis t :extent 32 :dtype :int :init 0}]
+                     '[[blk 4] [t 32]])))))
+  (testing "no stages at all"
+    (is (= :no-stages (:reason (cs/stages-legal? [] []))))))
+
+(deftest symbolic-extents
+  (testing "extents may be symbolic; the product stays symbolic"
+    (let [s '[{:axis blk :extent nb :dtype :float :init 0.0
+               :lift (raster.numeric/* inner (aget da blk))
+               :operands [{:sym da :map {:groups [[[blk nb]]]}}]}
+              {:axis t :extent 32 :dtype :int :init 0}]]
+      (is (:ok (cs/stages-legal? s '[[blk nb] [t 32]])))
+      (is (= '(clojure.core/* 32 nb) (cs/contract-extent s))))))

--- a/test/raster/compiler/passes/parallel/contract_descriptor_validator_test.clj
+++ b/test/raster/compiler/passes/parallel/contract_descriptor_validator_test.clj
@@ -1,0 +1,102 @@
+(ns raster.compiler.passes.parallel.contract-descriptor-validator-test
+  "A launch descriptor that under-describes its kernel fails at LAUNCH, not at compile — the kernel
+   is valid C, the caller simply binds the wrong number of arguments. That bug class has bitten
+   twice in this subsystem:
+
+     1. invoke-registered-contraction! reconstructed scalar-args from a `case` with no default, so
+        four of six strategies crashed when reached.
+     2. an epilogue's operand arrays were declared in the emitted signature but absent from the
+        descriptor, so a caller bound 6 args to a 7-arg kernel.
+
+   Both are mechanically detectable by comparing the emitted signature with what the descriptor
+   says to bind. This suite pins that every strategy stays consistent, and that the validator
+   actually rejects each historical shape."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.passes.parallel.contract-route :as route]
+            [raster.compiler.passes.parallel.par-fusion :as pf]))
+
+(defn- mm [m n k]
+  (list 'raster.par/contract 'C [['i m] ['j n]] [['l k]]
+        (list '* (list 'aget 'A (list '+ (list '* 'i k) 'l))
+              (list 'aget 'B (list '+ (list '* 'l n) 'j)))))
+
+(defn- fused [mbody]
+  (let [b ['C (mm 128 256 64) 'out (list 'raster.par/map! 'out 't (* 128 256) nil mbody)]]
+    (second (:bindings (pf/fuse-contract-map b [])))))
+
+;; ── every strategy's descriptor matches the kernel it describes ───────────────────────
+(deftest every-strategy-descriptor-is-consistent
+  ;; route-contraction validates on the way out, so simply routing each shape is the assertion.
+  (testing "the six base strategies"
+    (is (= :dpas         (:strategy (route/route-contraction (mm 256 512 128) :dtype :half))))
+    (is (= :regtiled     (:strategy (route/route-contraction (mm 96 96 64) :dtype :double))))
+    (is (= :segmap       (:strategy (route/route-contraction
+                                     '(raster.par/contract C [[i 4] [j 3]] [] (* (aget a i) (aget b j)))
+                                     :dtype :double))))
+    (is (= :naive-segred (:strategy (route/route-contraction
+                                     '(raster.par/contract C [[b 2] [i 4] [j 3]] [[l 5]]
+                                        (* (aget A x) (aget B y))) :dtype :double))))
+    (is (= :full-reduce  (:strategy (route/route-contraction
+                                     '(raster.par/contract O [] [[i 8]] (* (aget A i) (aget B i)))
+                                     :dtype :double))))
+    (is (= :dp4a         (:strategy (route/route-contraction
+                                     '(raster.par/contract C [[i 4] [j 4]] [[l 8]]
+                                        (* (aget A (+ (* i 8) l)) (aget B (+ (* j 8) l))))
+                                     :dtype :byte))))
+    (is (= :quant-naive  (:strategy (route/route-contraction
+                                     '(raster.par/contract C [[i 4] [j 4]] [[l 8]]
+                                        (* (aget A (+ (* i 8) l)) (aget B (+ (* l 4) j))))
+                                     :dtype :byte)))))
+  (testing "fused epilogues, including the operand-carrying shapes"
+    (doseq [[label body] [[:activation (list 'silu_f (list 'aget 'C 't))]
+                          [:bias  (list 'raster.numeric/+ (list 'aget 'C 't)
+                                        (list 'aget 'bias (list 'mod 't 256)))]
+                          [:resid (list 'raster.numeric/+ (list 'aget 'C 't) (list 'aget 'R 't))]
+                          [:rowscale (list 'raster.numeric/* (list 'aget 'C 't)
+                                           (list 'aget 'rs (list 'quot 't 256)))]]]
+      (is (= :dpas (:strategy (route/route-contraction (fused body) :dtype :half)))
+          (str label " descriptor must validate")))))
+
+;; ── the validator rejects each historical bug shape ──────────────────────────────────
+(deftest validator-rejects-the-bugs-that-actually-happened
+  (let [good (route/route-contraction (fused (list 'raster.numeric/+ (list 'aget 'C 't)
+                                                   (list 'aget 'bias (list 'mod 't 256))))
+                                      :dtype :half)]
+    (testing "bug 2: dropping the epilogue's operand under-describes the kernel"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"pointer params"
+            (route/validate-descriptor (assoc good :epilogue-operands [])))))
+    (testing "bug 1: a scalar-arg count that disagrees with the signature"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"scalar params"
+            (route/validate-descriptor (update good :scalar-args conj {:type :int :value 1}))))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"scalar params"
+            (route/validate-descriptor (assoc good :scalar-args [])))))
+    (testing "a missing :out-elems (the invoke sizes the output with it)"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"out-elems"
+            (route/validate-descriptor (dissoc good :out-elems)))))
+    (testing "malformed launch geometry"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"2-element vectors"
+            (route/validate-descriptor (assoc good :grid [4])))))))
+
+(deftest validator-models-both-invoke-protocols
+  (let [red (route/route-contraction '(raster.par/contract O [] [[i 8]] (* (aget A i) (aget B i)))
+                                     :dtype :double)]
+    (testing ":invoke :reduction owns its launch — no :wg/:grid, empty :scalar-args, needs :reduce-bound"
+      (is (= :reduction (:invoke red)))
+      (is (nil? (:wg red)))
+      (is (nil? (:grid red)))
+      (is (empty? (:scalar-args red)))
+      (is (some? (:reduce-bound red))))
+    (testing "…and the validator enforces each of those, so the protocol cannot drift"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must not carry"
+            (route/validate-descriptor (assoc red :wg [256 1]))))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must leave :scalar-args empty"
+            (route/validate-descriptor (assoc red :scalar-args [{:type :int :value 8}]))))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"requires :reduce-bound"
+            (route/validate-descriptor (dissoc red :reduce-bound)))))))
+
+(deftest signature-parser-handles-the-real-kernels
+  (testing "the parser finds every param of a multi-line DPAS signature"
+    (let [d (route/route-contraction (mm 256 512 128) :dtype :half)
+          ps (route/kernel-signature-params (:source d))]
+      (is (= 3 (count (filter #(clojure.string/includes? % "*") ps))) "A, B, C")
+      (is (= 3 (count (remove #(clojure.string/includes? % "*") ps))) "M, N, K"))))

--- a/test/raster/compiler/passes/parallel/staged_contract_route_test.clj
+++ b/test/raster/compiler/passes/parallel/staged_contract_route_test.clj
@@ -1,0 +1,123 @@
+(ns raster.compiler.passes.parallel.staged-contract-route-test
+  "Routing + surface for a STAGED contract axis. Device-free.
+
+   Three things are checked, because a staged contraction has three places to go wrong:
+     1. ROUTING — `:stages` reaches the multi-level leaf and the descriptor it produces survives
+        validate-descriptor (the per-stage scale arrays are extra POINTER params, so a descriptor
+        that forgets them is the exact launch-arity bug class the validator exists for).
+     2. DISPATCH ORDER — staging is a property of the REDUCTION, not the dtype, so it must win
+        over the int8 leaves rather than being shadowed by them.
+     3. THE SURFACE — `par/contract` with `:stages` must compute the flat EQUIVALENT, not the bare
+        body. Ignoring the option would silently drop every lift factor (i.e. every quant scale),
+        which is the one failure mode that produces plausible wrong numbers instead of an error."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.passes.parallel.contract-route :as cr]
+            [raster.par :as par]
+            [raster.numeric]))
+
+(def ^:private M 4) (def ^:private N 6)
+(def ^:private NB 4) (def ^:private B 32) (def ^:private K (* NB B))
+
+(defn- staged-form [dtype]
+  (list 'raster.par/contract 'out [['i M] ['j N]] [['blk NB] ['t B]]
+        (list 'raster.numeric/*
+              (list 'aget 'a (list 'clojure.core/+ (list 'clojure.core/* 'i K)
+                                   (list 'clojure.core/+ (list 'clojure.core/* 'blk B) 't)))
+              (list 'aget 'b (list 'clojure.core/+ (list 'clojure.core/* 'j K)
+                                   (list 'clojure.core/+ (list 'clojure.core/* 'blk B) 't))))
+        :stages [{:axis 'blk :extent NB :dtype :float :init 0.0
+                  :lift '(raster.numeric/* inner (aget da _) (aget db _))
+                  :operands [{:sym 'da :map {:groups [[['i M]] [['blk NB]]]} :dtype :float}
+                             {:sym 'db :map {:groups [[['j N]] [['blk NB]]]} :dtype :float}]}
+                 {:axis 't :extent B :dtype :int :init 0}]))
+
+(deftest staged-routes-to-the-multi-level-leaf
+  (let [r (cr/route-contraction (staged-form :byte) :dtype :byte)]
+    (testing "strategy + the two operand groups are kept distinct"
+      (is (= :staged-segred (:strategy r)))
+      (is (= '[a b] (:array-params r)) "the contraction's own operands")
+      (is (= '[da db] (:lift-operands r)) "the per-stage scale arrays, bound separately"))
+    (testing "dtypes: int8 operands, float output — the widening comes from the dtype pair"
+      (is (= :byte (:dtype r)))
+      (is (= :float (:out-dtype r))))
+    (testing "launch geometry + count, on the default (non-reduction) invoke protocol"
+      (is (= (* M N) (:out-elems r)))
+      (is (= [256 1] (:wg r)))
+      (is (= [{:type :int :value (* M N)}] (:scalar-args r))))
+    (testing "the emitted kernel really nests one loop per stage"
+      (is (= 2 (count (re-seq #"for \(int" (:source r)))))
+      (is (re-find #"int acc_1 = 0;" (:source r)) "inner accumulator is int32")
+      (is (re-find #"float acc_0 = 0.0;" (:source r)) "outer accumulator is float"))
+    (testing "route-contraction validated it on the way out (it returned at all)"
+      (is (some? (:kernel-name r))))))
+
+(deftest staging-beats-dtype-in-the-dispatch
+  (testing "an int8 staged contraction must NOT be captured by the flat int8 leaves — they have a
+            single accumulator and cannot express a per-block scale at all"
+    (is (= :staged-segred (:strategy (cr/route-contraction (staged-form :byte) :dtype :byte))))
+    (is (= :staged-segred (:strategy (cr/route-contraction (staged-form :half) :dtype :half))))))
+
+(deftest a-descriptor-that-forgets-the-scale-arrays-is-rejected
+  (testing "dropping :lift-operands leaves the kernel with 2 unbound pointer params — the launch
+            arity bug class, caught at generation instead of at launch"
+    (let [r (cr/route-contraction (staged-form :byte) :dtype :byte)]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"pointer params"
+           (cr/validate-descriptor (dissoc r :lift-operands))))
+      (is (some? (cr/validate-descriptor r)) "…while the real descriptor validates"))))
+
+(deftest single-stage-falls-through-to-the-flat-leaves
+  (testing "one stage is the flat case; nothing about the existing routing changes"
+    (let [form (list 'raster.par/contract 'out [['i M] ['j N]] [['l K]]
+                     (list 'raster.numeric/*
+                           (list 'aget 'a (list 'clojure.core/+ (list 'clojure.core/* 'i K) 'l))
+                           (list 'aget 'b (list 'clojure.core/+ (list 'clojure.core/* 'l N) 'j)))
+                     :stages [{:axis 'l :extent K :dtype :float :init 0.0}])]
+      (is (not= :staged-segred (:strategy (cr/route-contraction form :dtype :double)))))))
+
+;; ── the surface: par/contract with :stages must compute the flat EQUIVALENT ──────────
+(deftest surface-contract-honours-stages
+  (let [m 2 n 2 nb 2 b 4 k (* nb b)
+        ;; double[] — par/contract's interpreted expansion writes its output with a double aset
+        a (double-array (map #(double (mod % 5)) (range (* m k))))
+        bb (double-array (map #(double (mod (* 3 %) 5)) (range (* n k))))
+        ;; powers of two → the identity is exact in floating point, so it is asserted with =
+        da (double-array (map #(Math/scalb 1.0 (int (- (mod % 3) 1))) (range (* m nb))))
+        db (double-array (map #(Math/scalb 1.0 (int (- (mod (inc %) 3) 1))) (range (* n nb))))
+        out (double-array (* m n))
+        ;; reference: the block formula, scale applied once per block
+        ref (vec (for [i (range m) j (range n)]
+                   (double (reduce + (for [blk (range nb)]
+                                      (* (double (aget da (+ (* i nb) blk)))
+                                         (double (aget db (+ (* j nb) blk)))
+                                         (reduce + (for [t (range b)]
+                                                     (let [l (+ (* blk b) t)]
+                                                       (* (double (aget a (+ (* i k) l)))
+                                                          (double (aget bb (+ (* j k) l)))))))))))))]
+    (par/contract out [[i 2] [j 2]] [[blk 2] [t 4]]
+                  (raster.numeric/* (aget a (clojure.core/+ (clojure.core/* i 8)
+                                                            (clojure.core/+ (clojure.core/* blk 4) t)))
+                                    (aget bb (clojure.core/+ (clojure.core/* j 8)
+                                                             (clojure.core/+ (clojure.core/* blk 4) t))))
+                  :stages [{:axis blk :extent 2 :dtype :float :init 0.0
+                            :lift (raster.numeric/* inner (aget da _) (aget db _))
+                            :operands [{:sym da :map {:groups [[[i 2]] [[blk 2]]]}}
+                                       {:sym db :map {:groups [[[j 2]] [[blk 2]]]}}]}
+                           ;; NB the surface runs the FLAT equivalent, so the stage dtypes are a
+                           ;; schedule annotation for the device leaf, not a cast applied here
+                           {:axis t :extent 4 :dtype :double :init 0.0}])
+    (testing "the surface applies the lift factors — dropping them would give plausible wrong numbers"
+      (is (= ref (vec out))))
+    (testing "…and the result is non-trivial"
+      (is (some #(not (zero? %)) (vec out))))))
+
+(deftest surface-rejects-illegal-stages
+  (testing "an illegal stage list fails at macroexpansion, not at runtime"
+    (is (thrown? Throwable
+                 (eval '(let [out (float-array 4) a (float-array 32) bb (float-array 32)]
+                          (raster.par/contract out [[i 2] [j 2]] [[blk 2] [t 4]]
+                                               (raster.numeric/* (aget a t) (aget bb t))
+                                               ;; lift discards `inner` → the partial sum is lost
+                                               :stages [{:axis blk :extent 2 :dtype :float :init 0.0
+                                                         :lift (raster.numeric/* 2.0 3.0)}
+                                                        {:axis t :extent 4 :dtype :double :init 0.0}])))))))


### PR DESCRIPTION
> **Now carries two commits.** #84 (staged contract axes) was squash-merged into this branch, so
> merging this PR brings both to `main`:
> - `6ef126b7` — the descriptor validator (described below)
> - `85d106c3` — [#84] staged contract axes (block-quant in the contraction algebra)

Third time this bug class bit, so it gets a mechanical check.

## The failure mode

A launch descriptor that under-describes its kernel fails at **launch, not compile** — the emitted
OpenCL is valid, the caller just binds the wrong number of arguments. Prior occurrences:

1. `invoke-registered-contraction!` reconstructed `scalar-args` from a `case` with no default → four
   of six strategies crashed when reached.
2. An epilogue's operand arrays were declared in the signature but absent from the descriptor → 6
   args bound to a 7-arg kernel.

Both are mechanically detectable by comparing the emitted signature with what the descriptor says to
bind. `validate-descriptor` does that, and `route-contraction` now validates every descriptor on the
way out, turning a launch-time mystery into a loud compile-time error.

## Writing it forced two implicit protocols into the open

| protocol | scalar args | launch geometry |
|---|---|---|
| default (`:invoke nil`) | `:scalar-args`, bound positionally | `:wg` / `:grid` |
| `:invoke :reduction` | **empty** — the count comes from `:reduce-bound` | **absent** — the invoke owns its two-phase launch |

Both previously lived implicitly in two call sites. The validator enforces them and rejects a
`:reduction` descriptor carrying `:wg`/`:grid` or non-empty `:scalar-args`. Twice while building
this, the validator flagged the reduction path and I had to decide whether it was a bug or an
unmodelled protocol — that's the documentation value, not just the bug-catching.

## The third bug it found, which was mine

The **symbolic-bounds** path from Phase 0 routed without crashing but supplied **1 scalar arg where
the kernel declares 4** (`int k, int m, int n, int _nseg`). My own test only asserted "does not
crash", never "is usable" — so it let this straight through. Both the `naive-segred` and `segmap`
branches now bind the emitter's declared `scalar-params` (name-sorted, before the trailing count),
and I strengthened that Phase-0 test to assert the full argument list.

## Also closes a known gap

`generate-segmap-nd-kernel` accepted symbolic bounds it could not **declare** — the index decompose
emitted their names with no matching params, so a symbolic-bound segmap produced C referencing
undeclared identifiers. It now emits `int` params like its segmented-reduce sibling.

## Validation

- All **ten** descriptor shapes validate: six base strategies (dpas, regtiled, segmap,
  naive-segred, full-reduce, dp4a, quant-naive) plus four fused-epilogue variants
  (activation, bias, residual, row-scale).
- The validator **provably rejects each historical bug shape**: dropped epilogue operand, wrong
  scalar count, missing `:out-elems`, malformed geometry, and each `:reduction` protocol violation.

72 tests / 468 assertions green; cold-JVM load verified.

