### PR TITLE
Re-land dp4a inner-stage tensorize (#85 landed on a side branch, not main)

### DIFF
--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -1023,6 +1023,61 @@
                    (str "    int " (ce/c-symbol sym) " = " div " % " bound ";")))
                v))))
 
+(defn staged-inner-dp4a-legal?
+  "Can the INNERMOST stage of a staged contraction be tensorized with dp4a (4 int8 MACs into an
+   int32 in one op)? Returns {:ok true :packed-maps {sym amap} :packed-extent n} or
+   {:ok false :reason kw}.
+
+   This is the int8 PEAK leaf for block-quant, and it is the same structure llama.cpp hand-writes:
+   the inner stage is already an exact int32 accumulation over a short K-contiguous run, which is
+   precisely dp4a's shape. Because the stage list says which axis the inner accumulation runs over,
+   there is nothing to recognize — the gate only has to CHECK.
+
+   Required, and the failure each check prevents:
+     • declared operand axis-maps. Tensorizing needs to know each operand's innermost axis; per the
+       compiler's declare-don't-pattern-match rule that is data, not inference.
+     • each map must VERIFIABLY equal the operand's actual index in the body (am/index-matches?).
+       Assuming a layout while having checked only the axis symbols is how a transpose rewrite
+       silently miscompiled before; a leaf may only assume what it has proved.
+     • the inner stage's axis must be the INNERMOST axis of both maps — dp4a packs 4 consecutive
+       elements along the contraction, so both operands must be contiguous in it (the :nt layout).
+     • int8 operands, integral inner accumulator (widening as a dtype pair).
+     • the inner extent must be a literal multiple of 4, else the packed load is mis-strided."
+  [{:keys [stages body operands dtype]}]
+  (let [inner-stage (peek (vec stages))
+        int-acc? (contains? #{:int :long :int32} (:dtype inner-stage))
+        agets (into {} (keep (fn [f] (when (and (seq? f) (= 'aget (first f)) (symbol? (second f)))
+                                      [(second f) (nth f 2)]))
+                             (tree-seq coll? seq body)))]
+    (cond
+      (not= 2 (count operands)) {:ok false :reason :dp4a-needs-two-declared-operands}
+      (not (every? :map operands)) {:ok false :reason :operand-without-a-declared-map}
+      (not (#{:byte :int8} dtype)) {:ok false :reason :dp4a-needs-int8-operands :dtype dtype}
+      (not int-acc?) {:ok false :reason :inner-stage-accumulator-not-integral
+                      :dtype (:dtype inner-stage)}
+      :else
+      (or
+       ;; the declared map must PROVABLY be the operand's actual index expression
+       (first (keep (fn [{:keys [sym map]}]
+                      (let [idx (get agets sym)]
+                        (cond
+                          (nil? idx) {:ok false :reason :declared-operand-not-read-by-the-body :sym sym}
+                          (not (am/index-matches? map idx))
+                          {:ok false :reason :declared-map-does-not-match-the-body-index
+                           :sym sym :declared (am/index-expr map) :actual idx}
+                          (not= (:axis inner-stage) (am/innermost-axis map))
+                          {:ok false :reason :inner-stage-axis-is-not-contiguous
+                           :sym sym :innermost (am/innermost-axis map) :axis (:axis inner-stage)}
+                          :else nil)))
+                    operands))
+       (let [p-sym (gensym "p__")
+             packed (into {} (for [{:keys [sym map]} operands]
+                               [sym (am/pack-innermost map 4 p-sym)]))]
+         (if (some nil? (vals packed))
+           {:ok false :reason :inner-extent-not-a-multiple-of-4 :extent (:extent inner-stage)}
+           {:ok true :packed-maps packed :p-sym p-sym
+            :packed-extent (quot (long (:extent inner-stage)) 4)}))))))
+
 (defn generate-staged-contraction-kernel
   "STAGED contraction → OpenCL: a reduction accumulating in N levels, each with its own
    accumulator dtype, with a `lift` splicing each level's partial sum into the level above.
@@ -1048,20 +1103,31 @@
             :lift-operands}. :array-params is the body's inputs; :lift-operands are the EXTRA
    scale arrays, bound after them — surfaced because omitting them from a launch descriptor is
    an arity bug (the signature has them either way)."
-  [{:keys [free-axes stages body inputs dtype out-dtype]
-    :or {dtype :float out-dtype :float}} out-sym]
+  [{:keys [free-axes stages body inputs dtype out-dtype operands tensorize-inner?]
+    :or {dtype :float out-dtype :float} :as spec} out-sym]
   (let [legal (cstage/stages-legal? stages (mapv (juxt :axis :extent) stages))
         _ (when-not (:ok legal)
             (throw (ex-info (str "staged contraction: illegal stages (" (:reason legal) ")")
                             (assoc legal :stages stages))))
         stages (vec stages)
-        op-ctype  (get codegen/opencl-type-map dtype "float")
+        ;; TENSORIZE THE INNER STAGE: the innermost accumulation is already an exact int32 sum over
+        ;; a short K-contiguous run, which is exactly dp4a's shape. Requested explicitly (a schedule
+        ;; choice), then GATED — a rejection falls back to the scalar nest, never to a wrong kernel.
+        tz (when tensorize-inner?
+             (let [g (staged-inner-dp4a-legal? spec)]
+               (when-not (:ok g)
+                 (throw (ex-info (str "staged contraction: cannot tensorize inner stage ("
+                                      (:reason g) ")") g)))
+               g))
+        ;; packed operands are READ as int32 words (4 int8 each); the buffer bytes are unchanged
+        op-ctype  (get codegen/opencl-type-map (if tz :int dtype) "float")
         out-ctype (get codegen/opencl-type-map out-dtype "float")
         lift-ops (cstage/lift-operands stages)
         idx-of (cstage/stage-index-exprs stages)
         ;; every axis in scope is an int loop/decompose variable
         int-vars (into #{} (map (comp symbol name))
-                       (concat (map first free-axes) (map :axis stages)))
+                       (concat (map first free-axes) (map :axis stages)
+                               (when tz [(:p-sym tz)])))
         arr-syms (into #{} (map (comp symbol name)) (concat inputs (map :sym lift-ops)))
         emit (fn [expr]
                (binding [ce/*emit-config* ce/opencl-config
@@ -1072,13 +1138,31 @@
         ;; innermost accumulates the body; each outer accumulates its lift with `inner` bound to
         ;; the accumulator one level down. Built inside-out.
         n (count stages)
-        inner-most (let [{:keys [dtype init axis extent]} (peek stages)
-                         t (get codegen/opencl-type-map dtype "float")]
-                     (str "        " t " " (acc-name (dec n)) " = " (or init 0) ";\n"
-                          "        for (int " (ce/c-symbol axis) " = 0; "
-                          (ce/c-symbol axis) " < " extent "; " (ce/c-symbol axis) "++) {\n"
-                          "            " (acc-name (dec n)) " += " (emit body) ";\n"
-                          "        }\n"))
+        ;; ONE description of the innermost loop, used at both nesting depths.
+        inner-loop
+        (fn [indent acc]
+          (let [{:keys [dtype init axis extent]} (peek stages)
+                t (get codegen/opencl-type-map dtype "float")
+                [loop-var bound step]
+                (if tz [(:p-sym tz) (:packed-extent tz) "dp4a"] [axis extent "scalar"])
+                pad (apply str (repeat indent " "))]
+            (str pad t " " acc " = " (or init 0) ";\n"
+                 pad "for (int " (ce/c-symbol loop-var) " = 0; "
+                 (ce/c-symbol loop-var) " < " bound "; " (ce/c-symbol loop-var) "++) {\n"
+                 pad "    " acc
+                 (if (= "dp4a" step)
+                   ;; 4 int8 MACs into the int32 accumulator per op; indices come from the PACKED
+                   ;; maps, so the stride rescaling is the axis-map algebra's, not hand-written.
+                   (str " = rstr_dp4a("
+                        (str/join ", " (for [{:keys [sym]} operands]
+                                         (str (ce/c-symbol sym) "["
+                                              (emit (am/index-expr (get (:packed-maps tz) sym)))
+                                              "]")))
+                        ", " acc ")")
+                   (str " += " (emit body)))
+                 ";\n"
+                 pad "}\n")))
+        inner-most (inner-loop 8 (acc-name (dec n)))
         nest (reduce
               (fn [inner-src d]
                 (let [{:keys [dtype init axis extent lift]} (nth stages d)
@@ -1095,15 +1179,7 @@
               inner-most
               (reverse (range (dec n))))
         ;; a single stage has no lift, so its accumulator is the whole nest, unindented
-        nest (if (= 1 n)
-               (let [{:keys [dtype init axis extent]} (peek stages)
-                     t (get codegen/opencl-type-map dtype "float")]
-                 (str "    " t " " (acc-name 0) " = " (or init 0) ";\n"
-                      "    for (int " (ce/c-symbol axis) " = 0; "
-                      (ce/c-symbol axis) " < " extent "; " (ce/c-symbol axis) "++) {\n"
-                      "        " (acc-name 0) " += " (emit body) ";\n"
-                      "    }\n"))
-               nest)
+        nest (if (= 1 n) (inner-loop 4 (acc-name 0)) nest)
         n-out (am/n-elements (am/of-axes (vec free-axes)))
         kernel-name (str "staged_contract_" (gensym ""))
         params (str (str/join ", " (for [a inputs]
@@ -1112,7 +1188,8 @@
                                  (str ", __global const " (get codegen/opencl-type-map dtype "float")
                                       "* restrict " (ce/c-symbol sym))))
                     ", __global " out-ctype "* restrict out, int _nseg")
-        src (str "__kernel void " kernel-name "(" params ") {\n"
+        src (str (when tz (:c-helper-src (intrinsics/descriptor 'dp4a)))
+                 "__kernel void " kernel-name "(" params ") {\n"
                  "    int seg = get_global_id(0);\n"
                  "    if (seg >= _nseg) return;\n"
                  (flat-decompose-c free-axes) "\n"
@@ -1124,5 +1201,8 @@
      :lift-operands (mapv :sym lift-ops)
      :dtype dtype :out-dtype out-dtype
      :stages stages
+     ;; the operand buffers are BOUND unchanged; only the kernel's view of them widens
+     :tensorized (boolean tz)
+     :packed (when tz :int8x4)
      :out-elems n-out
      :dims (mapv second free-axes)}))

--- a/src/raster/compiler/ir/axis_map.clj
+++ b/src/raster/compiler/ir/axis_map.clj
@@ -120,14 +120,23 @@
       (mapv #(.indexOf ^java.util.List fk %) tk))))
 
 (defn- canonicalize-ops
-  "Normalize +/* heads (bare, clojure.core, raster.numeric) so index expressions from different
-   producers compare structurally."
+  "Normalize index expressions so ones from different producers compare structurally:
+   unify +/* heads (bare, clojure.core, raster.numeric) and FLATTEN nested sums, since `+` is
+   associative and a hand-written index nests it differently than `rowmajor` emits it
+   (`(+ (* i K) (+ (* blk B) t))` vs `(+ (* i K) (* blk B) t)`). Without the flattening,
+   `index-matches?` would reject correct declarations and push callers to skip verification —
+   worse than the brittleness it was meant to catch. Products are NOT reassociated or folded, so
+   `(* (* i 2) 3)` still fails to match `(* i 6)`; that is a deliberate limit, not an oversight."
   [e]
-  (cond (seq? e) (let [h (first e)
-                       h' (get '{+ + clojure.core/+ + raster.numeric/+ +
-                                 * * clojure.core/* * raster.numeric/* *} h h)]
-                   (cons h' (map canonicalize-ops (rest e))))
-        :else e))
+  (if (seq? e)
+    (let [h (first e)
+          h' (get '{+ + clojure.core/+ + raster.numeric/+ +
+                    * * clojure.core/* * raster.numeric/* *} h h)
+          args (map canonicalize-ops (rest e))]
+      (if (= '+ h')
+        (cons '+ (mapcat (fn [a] (if (and (seq? a) (= '+ (first a))) (rest a) [a])) args))
+        (cons h' args)))
+    e))
 
 (defn index-matches?
   "Does `idx-expr` equal this map's generated index, modulo operator qualification? This is the
@@ -177,3 +186,32 @@
               (core-op? h 'quot)     (when (seq outer) (of-axes outer))
               :else nil))
       :else nil)))
+
+;; ── packing: reinterpreting a buffer as wider words ─────────────────────────────────
+(defn pack-innermost
+  "Reinterpret the buffer this map indexes as words holding `factor` consecutive elements, e.g. a
+   `char*` read as `int*` (4 int8 per int32, what dp4a consumes). The bytes are unchanged; only the
+   INDEXING changes, and the change is entirely local to the map: the innermost axis's extent is
+   divided by `factor` and the axis renamed to `new-sym` (which now counts words, not elements).
+
+   Everything else follows from row-major arithmetic and needs no special case — each outer group's
+   stride is expressed as a product that already contains the innermost extent, so dividing that one
+   extent rescales every stride correctly. `(index-expr (pack-innermost m 4 'p))` is therefore the
+   packed index, with no separate derivation.
+
+   Returns nil when the innermost extent is not a literal multiple of `factor` — the caller must
+   then refuse to tensorize rather than emit a mis-strided load."
+  [amap factor new-sym]
+  (let [groups (:groups amap)
+        gi (dec (count groups))
+        g (nth groups gi)
+        ai (dec (count g))
+        [_ e] (nth g ai)]
+    (when (and (number? e) (zero? (mod (long e) (long factor))))
+      {:groups (assoc groups gi (assoc g ai [new-sym (quot (long e) (long factor))]))})))
+
+(defn innermost-axis
+  "The last atomic axis in map order — the one with stride 1. A tensorize leaf that packs along the
+   contraction must check that THIS is the axis it means to pack."
+  [amap]
+  (peek (axes amap)))

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -150,7 +150,7 @@
    the int8 quant leaves — dp4a for the :nt operand layout, quant naive-widening for :nn;
    anything else, or a gate rejection, falls back to the register-tiled portable kernel).
    scheme = the quant decode descriptor {:scale :a-zp :b-zp} for int8 (default {:scale 1.0})."
-  [contract-form & {:keys [dtype scheme prefer-peak? desc tile epilogue stages]
+  [contract-form & {:keys [dtype scheme prefer-peak? desc tile epilogue stages operands]
                     :or {dtype :half scheme {:scale 1.0} prefer-peak? false}}]
   (let [out-sym (second contract-form)
         free-axes (nth contract-form 2)
@@ -170,6 +170,9 @@
         form-opts (apply hash-map (drop 5 contract-form))
         epilogue (or epilogue (:epilogue form-opts))
         stages (or stages (:stages (apply hash-map (drop 5 contract-form))))
+        ;; declared operand axis-maps, needed to tensorize a staged inner stage (the gate VERIFIES
+        ;; them against the body rather than trusting them)
+        operands (or operands (:operands (apply hash-map (drop 5 contract-form))))
         tensorize-plan (memoize #(route-2free-1contract contract-form out-sym dtype desc tile epilogue))]
     ;; Every descriptor is validated against the kernel it describes before it leaves this fn. The
     ;; failure mode it guards is a LAUNCH-time arity mismatch (valid C, wrong number of bound args),
@@ -182,13 +185,20 @@
       ;; contraction algebra at all. The flat leaves below cannot represent it — they have one
       ;; accumulator. 1 stage is the flat case and is left to them.
       (and (seq stages) (> (count stages) 1))
-      (let [k (sco/generate-staged-contraction-kernel
-               {:free-axes free-axes :stages stages
-                :body (nth contract-form 4)
-                :inputs (vec (sort-by name (contract-operand-arrays (nth contract-form 4))))
-                :dtype dtype :out-dtype (or (:out-dtype (apply hash-map (drop 5 contract-form)))
-                                            :float)}
-               out-sym)]
+      (let [;; PEAK: with declared+verified operand maps, the inner stage tensorizes to dp4a (4 int8
+            ;; MACs per int32 op) — the int8 peak leaf, and the same shape llama.cpp hand-writes.
+            ;; Only attempted when the caller asked for peak AND the gate passes; a gate rejection
+            ;; falls back to the scalar nest, so requesting peak can never yield a wrong kernel.
+            spec {:free-axes free-axes :stages stages
+                  :body (nth contract-form 4)
+                  :inputs (vec (sort-by name (contract-operand-arrays (nth contract-form 4))))
+                  :operands operands
+                  :dtype dtype :out-dtype (or (:out-dtype (apply hash-map (drop 5 contract-form)))
+                                              :float)}
+            tz? (and prefer-peak? (seq operands)
+                     (:ok (sco/staged-inner-dp4a-legal? spec)))
+            k (sco/generate-staged-contraction-kernel
+               (assoc spec :tensorize-inner? (boolean tz?)) out-sym)]
         {:strategy :staged-segred
          :kernel-name (:kernel-name k) :source (:source k)
          :array-params (:array-params k)
@@ -197,6 +207,8 @@
          :dtype (:dtype k) :out-dtype (:out-dtype k)
          :out-elems (:out-elems k)
          :stages (:stages k)
+         ;; the operand BUFFERS are bound unchanged; only the kernel's view of them widens to int32
+         :tensorized (:tensorized k) :packed (:packed k)
          :scalar-args [{:type :int :value nseg}]
          :wg [256 1]
          :grid [(ceil-div nseg 256) 1]})

--- a/test/raster/compiler/backend/gpu/staged_contract_device_test.clj
+++ b/test/raster/compiler/backend/gpu/staged_contract_device_test.clj
@@ -17,6 +17,7 @@
    float, so it is asserted with `=`, not a tolerance. Gated on a real GPU."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.contract-stages :as cs]
+            [raster.compiler.ir.axis-map :as am]
             [raster.compiler.backend.gpu.segop-opencl :as sco]))
 
 (def ^:private gpu?
@@ -92,7 +93,7 @@
 (defn- run-staged
   "Emit, register and launch a staged contraction; return the device output vector. `lift-arrays`
    maps each lift operand symbol → its float array, bound in the emitter's declared order."
-  [stages body-expr ^bytes a ^bytes b lift-arrays]
+  [stages body-expr ^bytes a ^bytes b lift-arrays & [extra]]
   (let [ze (find-ns 'raster.gpu.ze-runtime)
         register! (ns-resolve ze 'register-kernel!)
         ensure-loaded! (ns-resolve ze 'ensure-kernel-loaded!)
@@ -102,8 +103,9 @@
         launch-2d! (ns-resolve ze 'launch-2d!)
         {:keys [kernel-name source array-params lift-operands out-elems]}
         (sco/generate-staged-contraction-kernel
-         {:free-axes [['i M] ['j N]] :stages stages :body body-expr
-          :inputs '[a b] :dtype :byte :out-dtype :float}
+         (merge {:free-axes [['i M] ['j N]] :stages stages :body body-expr
+                 :inputs '[a b] :dtype :byte :out-dtype :float}
+                extra)
          'out)
         _ (assert (= '[a b] array-params))
         _ (register! kernel-name {:source source :dtype :byte})
@@ -239,3 +241,69 @@
                     {:axis 't :extent B :dtype :int :init 0}]
            :body body :inputs '[a b] :dtype :byte :out-dtype :float}
           'out)))))
+
+;; ── the int8 PEAK leaf: tensorize the inner stage with dp4a ──────────────────────────
+(def ^:private body-maps
+  ;; a[i,(blk t)] and b[j,(blk t)] — both K-CONTIGUOUS in the inner stage axis, which is what dp4a
+  ;; requires (the :nt layout). Declared, then VERIFIED against the body by the gate.
+  {'a (am/of-groups [[['i M]] [['blk NB] ['t B]]])
+   'b (am/of-groups [[['j N]] [['blk NB] ['t B]]])})
+
+(deftest dp4a-tensorized-inner-stage-matches-the-scalar-nest
+  (if-not @gpu?
+    (println "  [skip] no GPU — dp4a staged inner-stage device test")
+    (let [da (pow2-scales (* M NB) 0)
+          db (pow2-scales (* N NB) 3)
+          ;; body built FROM the declared maps, so declaration and use cannot drift
+          body' (list 'raster.numeric/*
+                      (list 'aget 'a (am/index-expr (get body-maps 'a)))
+                      (list 'aget 'b (am/index-expr (get body-maps 'b))))
+          operands [{:sym 'a :map (get body-maps 'a)} {:sym 'b :map (get body-maps 'b)}]
+          scalar (run-staged two-stage body' a-data b-data {'da da 'db db})
+          packed (run-staged two-stage body' a-data b-data {'da da 'db db}
+                             {:operands operands :tensorize-inner? true})
+          ref (vec (ref-staged a-data b-data da db))]
+      (testing "dp4a and the scalar nest agree EXACTLY — int32 accumulation is exact, so any
+                difference would be a real defect, not rounding"
+        (is (= scalar packed)))
+      (testing "…and both match the host reference"
+        (is (= ref packed)))
+      (testing "non-trivial result"
+        (is (some #(not (zero? %)) packed))))))
+
+(deftest dp4a-gate-refuses-rather-than-miscompiling
+  (let [good-a (get body-maps 'a) good-b (get body-maps 'b)
+        body' (list 'raster.numeric/*
+                    (list 'aget 'a (am/index-expr good-a))
+                    (list 'aget 'b (am/index-expr good-b)))
+        spec {:free-axes [['i M] ['j N]] :stages two-stage :body body'
+              :inputs '[a b] :dtype :byte :out-dtype :float
+              :operands [{:sym 'a :map good-a} {:sym 'b :map good-b}]}]
+    (testing "the honest case is legal"
+      (is (:ok (sco/staged-inner-dp4a-legal? spec))))
+    (testing "a MISDECLARED operand map is caught, not trusted — assuming a layout while having
+              checked only the axis symbols is how a transpose rewrite silently miscompiled before"
+      (is (= :declared-map-does-not-match-the-body-index
+             (:reason (sco/staged-inner-dp4a-legal?
+                       (assoc-in spec [:operands 0 :map]
+                                 (am/of-groups [[['i M]] [['t B] ['blk NB]]])))))))
+    (testing "an operand that is NOT contiguous in the inner stage axis cannot be packed"
+      (let [nn-b (am/of-groups [[['blk NB] ['t B]] [['j N]]])]   ; b[(blk t), j] — j innermost
+        (is (= :inner-stage-axis-is-not-contiguous
+               (:reason (sco/staged-inner-dp4a-legal?
+                         (-> spec
+                             (assoc-in [:operands 1 :map] nn-b)
+                             (assoc :body (list 'raster.numeric/*
+                                                (list 'aget 'a (am/index-expr good-a))
+                                                (list 'aget 'b (am/index-expr nn-b)))))))))))
+    (testing "a float inner accumulator is not a dp4a shape"
+      (is (= :inner-stage-accumulator-not-integral
+             (:reason (sco/staged-inner-dp4a-legal?
+                       (assoc-in spec [:stages 1 :dtype] :float))))))
+    (testing "requesting tensorize when illegal THROWS — it never silently degrades to scalar,
+              because a silent degradation is an invisible perf cliff"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"cannot tensorize inner stage"
+           (sco/generate-staged-contraction-kernel
+            (assoc spec :tensorize-inner? true
+                   :operands [{:sym 'a :map good-a}]) 'out))))))

--- a/test/raster/compiler/ir/axis_map_test.clj
+++ b/test/raster/compiler/ir/axis_map_test.clj
@@ -69,3 +69,27 @@
       (is (= '(clojure.core/+ (clojure.core/* i k) l) (am/index-expr m)))
       (is (= '[m k] (am/shape m)))
       (is (= '(clojure.core/* m k) (am/n-elements m))))))
+
+(deftest index-verification-normalizes-sum-associativity
+  (testing "a hand-nested index still verifies against the flat form the map generates —
+            otherwise the gate would reject correct declarations and get bypassed"
+    (let [m (am/of-groups '[[[i 4]] [[blk 4] [t 32]]])]
+      (is (= '(clojure.core/+ (clojure.core/* i 128) (clojure.core/* blk 32) t)
+             (am/index-expr m)))
+      (is (am/index-matches? m '(clojure.core/+ (clojure.core/* i 128)
+                                                (clojure.core/+ (clojure.core/* blk 32) t)))
+          "nested sum")
+      (is (am/index-matches? m '(+ (* i 128) (+ (* blk 32) t)))
+          "…and bare operator heads")
+      (is (not (am/index-matches? m '(clojure.core/+ (clojure.core/* i 128) t)))
+          "a genuinely different index must still be rejected"))))
+
+(deftest packing-reinterprets-the-buffer-as-wider-words
+  (testing "pack-innermost rescales every stride by dividing ONE extent"
+    (let [m (am/of-groups '[[[i 4]] [[blk 4] [t 32]]])]
+      (is (= '(clojure.core/+ (clojure.core/* i 32) (clojure.core/* blk 8) p)
+             (am/index-expr (am/pack-innermost m 4 'p))))
+      (is (= 't (am/innermost-axis m)))))
+  (testing "refuse a non-divisible or symbolic innermost extent instead of mis-striding"
+    (is (nil? (am/pack-innermost (am/of-groups '[[[i 4]] [[t 30]]]) 4 'p)))
+    (is (nil? (am/pack-innermost (am/of-axes '[[i 4] [t k]]) 4 'p)))))

--- a/test/raster/compiler/passes/parallel/staged_contract_route_test.clj
+++ b/test/raster/compiler/passes/parallel/staged_contract_route_test.clj
@@ -121,3 +121,45 @@
                                                :stages [{:axis blk :extent 2 :dtype :float :init 0.0
                                                          :lift (raster.numeric/* 2.0 3.0)}
                                                         {:axis t :extent 4 :dtype :double :init 0.0}])))))))
+
+;; ── peak: the router tensorizes the inner stage when asked and legal ─────────────────
+(defn- nt-maps []
+  {'a {:groups [[['i M]] [['blk NB] ['t B]]]}
+   'b {:groups [[['j N]] [['blk NB] ['t B]]]}})
+
+(defn- staged-form-with-maps []
+  (let [ms (nt-maps)
+        idx (fn [m] ((requiring-resolve 'raster.compiler.ir.axis-map/index-expr) m))]
+    (concat (take 4 (staged-form :byte))
+            [(list 'raster.numeric/*
+                   (list 'aget 'a (idx (get ms 'a)))
+                   (list 'aget 'b (idx (get ms 'b))))]
+            (drop 5 (staged-form :byte))
+            [:operands [{:sym 'a :map (get ms 'a)} {:sym 'b :map (get ms 'b)}]])))
+
+(deftest prefer-peak-tensorizes-the-inner-stage
+  (let [form (staged-form-with-maps)
+        peak (cr/route-contraction form :dtype :byte :prefer-peak? true)
+        base (cr/route-contraction form :dtype :byte)]
+    (testing "with peak requested the inner stage becomes dp4a"
+      (is (:tensorized peak))
+      (is (= :int8x4 (:packed peak)))
+      (is (re-find #"rstr_dp4a" (:source peak))))
+    (testing "without it, the scalar nest — same descriptor SHAPE either way, so the caller binds
+              the same buffers; only the kernel's view of them widens"
+      (is (not (:tensorized base)))
+      (is (not (re-find #"rstr_dp4a" (:source base))))
+      (is (= (:array-params base) (:array-params peak)))
+      (is (= (:lift-operands base) (:lift-operands peak)))
+      (is (= (:out-elems base) (:out-elems peak)))
+      (is (= (:scalar-args base) (:scalar-args peak))))
+    (testing "both descriptors passed validate-descriptor on the way out"
+      (is (some? (:kernel-name peak)))
+      (is (some? (:kernel-name base))))))
+
+(deftest peak-without-declared-maps-falls-back-instead-of-guessing
+  (testing "no operand maps → no tensorize, because the gate has nothing to VERIFY; it must not
+            infer the layout from the index arithmetic"
+    (let [r (cr/route-contraction (staged-form :byte) :dtype :byte :prefer-peak? true)]
+      (is (= :staged-segred (:strategy r)))
+      (is (not (:tensorized r))))))


### PR DESCRIPTION
## Re-lands #85, which never reached `main`

#85 was approved and merged — but into `fix/contract-descriptor-validator`, **after** #83 had already
been squash-merged to `main`. So the squash carried the validator + #84's staged axes across, and
#85's dp4a work was left stranded on the side branch. `pack-innermost` is absent from `main`.

Verified rather than assumed:

```
main:              84bd3517  (#83 squash — validator + staged axes)
fix/…validator:    aaef66c4  (#85 — dp4a, merged after the squash)

git grep pack-innermost origin/main -- src/raster/compiler/ir/axis_map.clj  →  ABSENT
```

This branch is `aaef66c4` cherry-picked onto current `main`. Clean apply, no conflicts — the dp4a
changes sit on content the squash already brought over.

**Content is unchanged from #85**, so the original review still applies; see
https://github.com/replikativ/raster/pull/85 for the full rationale (packed index derived by
`pack-innermost` rather than hand-written strides; a gate that verifies declared operand maps
against the body instead of inferring layout; emitter throws on an illegal tensorize request while
the router falls back).

31 tests / 144 assertions green on top of `main`'s squash, including the Arc device tests
(dp4a inner stage equals the scalar nest exactly and matches the host reference).

Once this is in, `fix/contract-descriptor-validator` and `feat/staged-inner-dp4a` can both be
deleted — everything they hold will be on `main`.
