### PR TITLE
Phase A: prove/fix two silent miscompiles; one dtype registry; one index relation

### DIFF
--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -10,6 +10,7 @@
   (:require [raster.compiler.backend.gpu.opencl-codegen :as codegen]
             [raster.compiler.backend.gpu.c-emit :as ce]
             [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.dtype :as dt]
             [raster.compiler.backend.intrinsics :as intrinsics]
             [raster.compiler.core.hardware :as hw]
             [raster.compiler.ir.axis-map :as am]
@@ -56,8 +57,8 @@
         body (ce/normalize-array-prims (:lambda segmap))
         cast-fn (:cast-fn segmap)
         out-dtype (or (:dtype segmap) dtype)
-        default-ctype (get codegen/opencl-type-map dtype "double")
-        out-ctype (get codegen/opencl-type-map out-dtype "double")
+        default-ctype (dt/ctype :opencl dtype)
+        out-ctype (dt/ctype :opencl out-dtype)
         ;; (2) per-array element types: declared (array-types) ∪ body :tag metadata
         meta-types (ce/collect-array-types-from-meta body)
         array-types (merge meta-types array-types)
@@ -167,7 +168,7 @@
         lambda (ce/normalize-array-prims lambda)
         dtype (or (:dtype segred) dtype)
         kernel-name (str kernel-name-prefix "_" (gensym ""))
-        ctype (get codegen/opencl-type-map dtype "double")
+        ctype (dt/ctype :opencl dtype)
         arr-params (vec (sort-by name (:inputs segred)))
         scl-params (vec (sort-by name (:scalars segred)))
         ;; Detect reduction op from lambda — unwrap let to find op, keep let for elem
@@ -312,7 +313,7 @@
             (throw (ex-info "segmented-reduce: no segment dims — use generate-segred-kernel for a full reduction"
                             {:space space})))
         dtype (or (:dtype segred) dtype)
-        ctype (get codegen/opencl-type-map dtype "double")
+        ctype (dt/ctype :opencl dtype)
         {:keys [acc init lambda]} (:reduce-op segred)
         lambda (ce/normalize-array-prims lambda)
         ;; combine op + element detection (mirrors generate-segred-kernel)
@@ -402,7 +403,7 @@
   [segmap out-sym & {:keys [dtype] :or {dtype :double}}]
   (let [dims (segop/seg-space-dims (:space segmap))   ; all free (no reduced dim)
         dtype (or (:dtype segmap) dtype)
-        ctype (get codegen/opencl-type-map dtype "double")
+        ctype (dt/ctype :opencl dtype)
         body (ce/normalize-array-prims (:lambda segmap))
         arr-params (vec (sort-by name (:inputs segmap)))
         arr-sym-set (set (map #(symbol (name %)) arr-params))
@@ -527,7 +528,7 @@
             (throw (ex-info "tensorize: needs literal dims" {:reason :symbolic-dims :dims [M N L]})))
         i-sym (:name fi) j-sym (:name fj) l-sym (:name red-dim)
         dtype (or (:dtype segred) dtype)
-        ctype (get codegen/opencl-type-map dtype "double")
+        ctype (dt/ctype :opencl dtype)
         {:keys [init lambda]} (:reduce-op segred)
         lambda (ce/normalize-array-prims lambda)
         _ (when-not (#{'+ 'clojure.core/+ 'raster.numeric/+} (descriptor/semantic-op lambda))
@@ -636,21 +637,16 @@
 ;; ================================================================
 
 (defn- canonical-rowmajor?
-  "Does affine index `idx` equal `(+ (* outer stride) inner)` (row-major, leading dim
-   `stride`)? outer/inner are axis syms, stride the expected leading extent (a number).
-   Order-agnostic on both the + and the *. Returns true/false."
+  "Does affine index `idx` equal `(+ (* outer stride) inner)` (row-major, leading dim `stride`)?
+
+   ONE RELATION. This used to be a hand-rolled pattern match that was +/*-order-agnostic but could
+   only see a literal 3-element sum, while `am/index-matches?` flattened nested sums but compared
+   terms positionally. The two accepted DIFFERENT languages, so a legal :nt operand written
+   `(+ l (* j K))` passed one gate and was rejected by the other — reaching no leaf at all. Both
+   now normalize to the same affine form, which accepts every arithmetically-identical spelling."
   [idx outer stride inner]
-  (let [idx (ce/normalize-array-prims idx)
-        add? #(and (seq? %) (#{'+ 'clojure.core/+ 'raster.numeric/+} (first %)))
-        mul? #(and (seq? %) (#{'* 'clojure.core/* 'raster.numeric/*} (first %)))]
-    (boolean
-     (when (and (add? idx) (= 3 (count idx)))
-       (let [[_ a b] idx
-             [prod other] (cond (mul? a) [a b] (mul? b) [b a] :else [nil nil])]
-         (when (and prod (= other inner) (= 3 (count prod)))
-           (let [[_ p q] prod]
-             (or (and (= p outer) (= q stride))
-                 (and (= q outer) (= p stride))))))))))
+  (am/index-matches? (am/of-axes [[outer 1] [inner stride]])
+                     (ce/normalize-array-prims idx)))
 
 (defn dpas-contraction-legal?
   "The tensorize LEGALITY GATE: is `segred` a contraction that lowers to the DPAS/XMX
@@ -674,7 +670,7 @@
   [segred dtype]
   (let [dtype (or (:dtype segred) dtype)
         pitch-ok? (fn [d] (and (number? d) (zero? (mod (long d) 8))))]
-    (if-not (#{:half :float16} dtype)
+    (if-not (and (dt/known? dtype) (= :half (dt/canon dtype)))
       {:ok false :reason :dtype-not-dpas :dtype dtype}
       (try
         (let [{:keys [M N L i-sym j-sym l-sym row-idx col-idx row-arr col-arr arr-params]}
@@ -755,7 +751,7 @@
    warps-per-CTA × elem-bytes / 4 registers for the accumulator; the epilogue's live values must
    fit in the remaining budget (Triton clamps accumulator traffic at maxnreg/2 to avoid spilling)."
   [{:keys [operands]} out-dtype [M N] tile]
-  (let [bytes-of (fn [dt] (long (get {:double 8 :float 4 :half 2 :float16 2 :int 4 :byte 1} dt 4)))
+  (let [bytes-of (fn [d] (long (dt/bytes-of d)))   ; one registry, not a private table
         cb (bytes-of out-dtype)
         c-elems (* (long M) (long N))
         operand-bytes (reduce + 0 (for [{:keys [dtype] :or {dtype :float}} operands]
@@ -793,7 +789,7 @@
         _ (when-not (:ok legal)
             (throw (ex-info (str "epilogue-splice: illegal epilogue (" (:reason legal) ")")
                             (assoc legal :expr expr))))
-        ctype (get codegen/opencl-type-map dtype "float")
+        ctype (dt/ctype :opencl dtype)
         arr-syms (set (map (comp #(symbol (name %)) :sym) operands))
         int-vars (into #{} (map #(symbol (name %))) [i-sym j-sym])
         ;; substitute each operand's aget index from its declared map (maps, not pattern-matching)
@@ -814,10 +810,10 @@
         params (apply str
                       (concat
                        (for [{:keys [sym dtype] :or {dtype :float}} operands]
-                         (str ", __global const " (get codegen/opencl-type-map dtype "float")
+                         (str ", __global const " (dt/ctype :opencl dtype)
                               "* restrict " (ce/c-symbol sym)))
                        (for [{:keys [sym dtype] :or {dtype :float}} scalars]
-                         (str ", " (get codegen/opencl-type-map dtype "float") " " (ce/c-symbol sym)))))]
+                         (str ", " (dt/ctype :opencl dtype) " " (ce/c-symbol sym)))))]
     {:epilogue (fn [acc-expr row col]
                  (-> emitted
                      (str/replace acc-token (str "(" acc-expr ")"))
@@ -1048,11 +1044,30 @@
         int-acc? (contains? #{:int :long :int32} (:dtype inner-stage))
         agets (into {} (keep (fn [f] (when (and (seq? f) (= 'aget (first f)) (symbol? (second f)))
                                       [(second f) (nth f 2)]))
-                             (tree-seq coll? seq body)))]
+                             (tree-seq coll? seq body)))
+        ;; THE BODY IS DISCARDED when this leaf fires — the whole summand is replaced by one
+        ;; rstr_dp4a call. So the gate must account for EVERY term first: a body carrying any
+        ;; factor beyond the two declared operands (a mask, a third tensor) would be silently
+        ;; dropped, with the extra array still declared as an unread kernel param. Require the
+        ;; body to be exactly the product of the two declared operands' agets.
+        declared-syms (set (map :sym operands))
+        body-terms (when (and (seq? body) (descriptor/multiplication-op? (descriptor/semantic-op body)))
+                     (vec (descriptor/call-args body)))
+        exact-product?
+        (and body-terms
+             (= 2 (count body-terms))
+             (every? (fn [t] (and (seq? t) (= 'aget (first t))
+                                  (contains? declared-syms (second t))))
+                     body-terms))]
     (cond
       (not= 2 (count operands)) {:ok false :reason :dp4a-needs-two-declared-operands}
       (not (every? :map operands)) {:ok false :reason :operand-without-a-declared-map}
-      (not (#{:byte :int8} dtype)) {:ok false :reason :dp4a-needs-int8-operands :dtype dtype}
+      (not (and (dt/known? dtype) (= :byte (dt/canon dtype))))
+      {:ok false :reason :dp4a-needs-int8-operands :dtype dtype}
+      (not exact-product?)
+      {:ok false :reason :body-has-unmodeled-terms
+       :detail "this leaf replaces the body with a single hardware op; any term beyond the two declared operands would be silently dropped"
+       :body body :declared (vec declared-syms)}
       (not int-acc?) {:ok false :reason :inner-stage-accumulator-not-integral
                       :dtype (:dtype inner-stage)}
       :else
@@ -1103,12 +1118,20 @@
             :lift-operands}. :array-params is the body's inputs; :lift-operands are the EXTRA
    scale arrays, bound after them — surfaced because omitting them from a launch descriptor is
    an arity bug (the signature has them either way)."
-  [{:keys [free-axes stages body inputs dtype out-dtype operands tensorize-inner?]
+  [{:keys [free-axes stages body inputs dtype out-dtype operands tensorize-inner? contract-axes]
     :or {dtype :float out-dtype :float} :as spec} out-sym]
-  (let [legal (cstage/stages-legal? stages (mapv (juxt :axis :extent) stages))
+  (let [;; The stage list is checked against the axes the FORM DECLARED, never against axes derived
+        ;; from the stages themselves. Deriving them made the span rule unfireable, and a stage list
+        ;; that under-covers the contract space emitted a kernel summing a FRACTION of the terms
+        ;; while par/contract's CPU path summed all of them — a silent divergence between two
+        ;; consumers of one form. A gate must not validate its own arguments.
+        _ (when (nil? contract-axes)
+            (throw (ex-info "staged contraction: :contract-axes is required — the stage list can only be validated against the axes the form declared"
+                            {:reason :missing-declared-contract-axes :stages stages})))
+        legal (cstage/stages-legal? stages contract-axes)
         _ (when-not (:ok legal)
             (throw (ex-info (str "staged contraction: illegal stages (" (:reason legal) ")")
-                            (assoc legal :stages stages))))
+                            (assoc legal :stages stages :contract-axes contract-axes))))
         stages (vec stages)
         ;; TENSORIZE THE INNER STAGE: the innermost accumulation is already an exact int32 sum over
         ;; a short K-contiguous run, which is exactly dp4a's shape. Requested explicitly (a schedule
@@ -1121,7 +1144,7 @@
                g))
         ;; packed operands are READ as int32 words (4 int8 each); the buffer bytes are unchanged
         op-ctype  (get codegen/opencl-type-map (if tz :int dtype) "float")
-        out-ctype (get codegen/opencl-type-map out-dtype "float")
+        out-ctype (dt/ctype :opencl out-dtype)
         lift-ops (cstage/lift-operands stages)
         idx-of (cstage/stage-index-exprs stages)
         ;; every axis in scope is an int loop/decompose variable
@@ -1142,7 +1165,7 @@
         inner-loop
         (fn [indent acc]
           (let [{:keys [dtype init axis extent]} (peek stages)
-                t (get codegen/opencl-type-map dtype "float")
+                t (dt/ctype :opencl dtype)
                 [loop-var bound step]
                 (if tz [(:p-sym tz) (:packed-extent tz) "dp4a"] [axis extent "scalar"])
                 pad (apply str (repeat indent " "))]
@@ -1166,7 +1189,7 @@
         nest (reduce
               (fn [inner-src d]
                 (let [{:keys [dtype init axis extent lift]} (nth stages d)
-                      t (get codegen/opencl-type-map dtype "float")
+                      t (dt/ctype :opencl dtype)
                       lift' (cstage/substitute-operand-indices lift idx-of)
                       ;; splice the level-below accumulator in for `inner`
                       lift'' (walk/postwalk-replace {'inner (symbol (acc-name (inc d)))} lift')]
@@ -1185,7 +1208,7 @@
         params (str (str/join ", " (for [a inputs]
                                      (str "__global const " op-ctype "* restrict " (ce/c-symbol a))))
                     (apply str (for [{:keys [sym dtype] :or {dtype :float}} lift-ops]
-                                 (str ", __global const " (get codegen/opencl-type-map dtype "float")
+                                 (str ", __global const " (dt/ctype :opencl dtype)
                                       "* restrict " (ce/c-symbol sym))))
                     ", __global " out-ctype "* restrict out, int _nseg")
         src (str (when tz (:c-helper-src (intrinsics/descriptor 'dp4a)))

--- a/src/raster/compiler/core/dtype.clj
+++ b/src/raster/compiler/core/dtype.clj
@@ -15,19 +15,68 @@
 ;;   :vt           wasm / vector value-type keyword
 ;;   :needs-pragma OpenCL extension pragma this type requires, or nil
 ;;   :fp?          floating-point?
+;;   :bytes        width of one element
+;;   :aliases      other spellings that MEAN this dtype (:int8 and :byte are one type, not two)
+;;
+;; ALIASES EXIST BECAUSE THE ABSENCE OF THEM WAS A BUG. Gates accepted `:int8`/`:int32`/`:float16`
+;; while this map had no such rows, so `(get opencl-type-map :int32 "double")` handed back "double"
+;; — emitting `__global const double*` over an int8 buffer and turning an int32 accumulator into a
+;; float, losing the exactness that block-quant staging exists for. Hence the two access rules
+;; below: `ctype`/`bytes-of`/`canon` THROW on an unknown dtype (an emitter must fail loud), while
+;; `known?` RETURNS false (a legality gate must return a verdict, never throw).
 (def dtype-info
   {:double {:native {:c "double" :opencl "double" :glsl "double"}
-            :scalar-tag 'double :array-tag 'doubles :vt :f64 :needs-pragma :cl_khr_fp64 :fp? true}
+            :scalar-tag 'double :array-tag 'doubles :vt :f64 :needs-pragma :cl_khr_fp64 :fp? true
+            :bytes 8 :aliases #{:float64 :f64}}
    :float  {:native {:c "float" :opencl "float" :glsl "float"}
-            :scalar-tag 'float :array-tag 'floats :vt :f32 :needs-pragma nil :fp? true}
+            :scalar-tag 'float :array-tag 'floats :vt :f32 :needs-pragma nil :fp? true
+            :bytes 4 :aliases #{:float32 :f32}}
    :half   {:native {:c "_Float16" :opencl "half" :glsl "float16_t"}
-            :scalar-tag nil :array-tag 'shorts :vt :f16 :needs-pragma :cl_khr_fp16 :fp? true}
+            :scalar-tag nil :array-tag 'shorts :vt :f16 :needs-pragma :cl_khr_fp16 :fp? true
+            :bytes 2 :aliases #{:float16 :f16}}
    :int    {:native {:c "int" :opencl "int" :glsl "int"}
-            :scalar-tag 'int :array-tag 'ints :vt :i32 :needs-pragma nil :fp? false}
+            :scalar-tag 'int :array-tag 'ints :vt :i32 :needs-pragma nil :fp? false
+            :bytes 4 :aliases #{:int32 :i32}}
    :long   {:native {:c "long long" :opencl "long" :glsl "int"}
-            :scalar-tag 'long :array-tag 'longs :vt :i64 :needs-pragma nil :fp? false}
+            :scalar-tag 'long :array-tag 'longs :vt :i64 :needs-pragma nil :fp? false
+            :bytes 8 :aliases #{:int64 :i64}}
    :byte   {:native {:c "int8_t" :opencl "char" :glsl "int"}
-            :scalar-tag 'byte :array-tag 'bytes :vt :i32 :needs-pragma nil :fp? false}})
+            :scalar-tag 'byte :array-tag 'bytes :vt :i32 :needs-pragma nil :fp? false
+            :bytes 1 :aliases #{:int8 :i8}}})
+
+(def ^:private alias->canonical
+  (into {} (for [[k v] dtype-info, a (cons k (:aliases v))] [a k])))
+
+(defn known?
+  "Is `dt` a dtype this compiler can spell (canonical or alias)? Returns a BOOLEAN — this is the
+   accessor a legality gate uses, because a gate must return a verdict rather than throw."
+  [dt]
+  (contains? alias->canonical dt))
+
+(defn canon
+  "Alias → canonical dtype (`:int8`/`:i8` → `:byte`, `:float16` → `:half`, …). THROWS on an unknown
+   dtype: an emitter that cannot spell a type must fail loudly, never silently substitute one."
+  [dt]
+  (or (alias->canonical dt)
+      (throw (ex-info (str "unknown dtype `" dt "`. Known: "
+                           (pr-str (sort (keys alias->canonical))))
+                      {:reason :unknown-dtype :dtype dt}))))
+
+(defn info "Facet row for a dtype, resolving aliases. Throws on unknown." [dt]
+  (get dtype-info (canon dt)))
+
+(defn ctype
+  "Native type name for `backend` (:c / :opencl / :glsl). THROWS on an unknown dtype — the silent
+   string default this replaces is what emitted `double*` over int8 buffers."
+  [backend dt]
+  (or (get-in dtype-info [(canon dt) :native backend])
+      (throw (ex-info (str "dtype `" dt "` has no " backend " native type")
+                      {:reason :no-native-type :dtype dt :backend backend}))))
+
+(defn bytes-of "Width of one element in bytes. Throws on unknown." [dt] (:bytes (info dt)))
+
+(defn integral? "True for integer dtypes (the widening-accumulator side of a dtype pair)."
+  [dt] (not (:fp? (info dt))))
 
 (def native-types
   "Scalar dtype keyword → {backend → native type name}. Derived from dtype-info."
@@ -63,9 +112,10 @@
   (:needs-pragma (get dtype-info dtype)))
 
 (defn fp-dtype?
-  "True when `dtype` is a floating-point dtype."
+  "True when `dtype` is a floating-point dtype. Alias-tolerant; false for an unknown dtype
+   (callers wanting a loud failure use `canon`/`info`)."
   [dtype]
-  (boolean (:fp? (get dtype-info dtype))))
+  (boolean (when (known? dtype) (:fp? (info dtype)))))
 
 (def ^:private dtype-type-remap
   "Type tag remapping per dtype. Only FP types are remapped."

--- a/src/raster/compiler/ir/axis_map.clj
+++ b/src/raster/compiler/ir/axis_map.clj
@@ -119,31 +119,81 @@
     (when (and (= (count fk) (count tk)) (= (set fk) (set tk)) (apply distinct? fk))
       (mapv #(.indexOf ^java.util.List fk %) tk))))
 
-(defn- canonicalize-ops
-  "Normalize index expressions so ones from different producers compare structurally:
-   unify +/* heads (bare, clojure.core, raster.numeric) and FLATTEN nested sums, since `+` is
-   associative and a hand-written index nests it differently than `rowmajor` emits it
-   (`(+ (* i K) (+ (* blk B) t))` vs `(+ (* i K) (* blk B) t)`). Without the flattening,
-   `index-matches?` would reject correct declarations and push callers to skip verification —
-   worse than the brittleness it was meant to catch. Products are NOT reassociated or folded, so
-   `(* (* i 2) 3)` still fails to match `(* i 6)`; that is a deliberate limit, not an oversight."
-  [e]
-  (if (seq? e)
-    (let [h (first e)
-          h' (get '{+ + clojure.core/+ + raster.numeric/+ +
-                    * * clojure.core/* * raster.numeric/* *} h h)
-          args (map canonicalize-ops (rest e))]
-      (if (= '+ h')
-        (cons '+ (mapcat (fn [a] (if (and (seq? a) (= '+ (first a))) (rest a) [a])) args))
-        (cons h' args)))
-    e))
+(defn- op-head
+  "Unify +/* heads (bare, clojure.core, raster.numeric)."
+  [h] (get '{+ + clojure.core/+ + raster.numeric/+ +
+             * * clojure.core/* * raster.numeric/* *} h h))
+
+;; ── affine normal form: ONE canonicalization for index expressions ───────────────────
+;; An index expression is normalized to {atom → polynomial-coefficient}, where an atom is an
+;; ITERATION AXIS (or an opaque subterm such as quot/mod/rem/aget) and a coefficient is a map
+;; from a sorted vector of symbolic factors to a number — so `(* i k)` and `(* k i)`, and
+;; `(+ (* i K) (+ (* b B) t))` and `(+ (* i K) (* b B) t)`, all normalize to one value.
+;;
+;; WHY NORMALIZE RATHER THAN COMPARE STRUCTURALLY. This file previously carried TWO relations
+;; that accepted DIFFERENT languages: a hand-rolled pattern match that was +/*-order-agnostic but
+;; could not see merged groups, and a structural comparison that flattened nested sums but
+;; rejected commuted ones. A legal :nt operand written `(+ l (* j K))` therefore passed one gate
+;; and was rejected by the other — reaching no leaf at all. And an over-strict relation is worse
+;; than a lax one here: it rejects CORRECT declarations, which teaches callers to skip
+;; verification, and a skipped gate is a silent one.
+;;
+;; `axes` is required because `(* i k)` is ambiguous without it — axis × extent, or axis × axis.
+;; Symbols in `axes` are atoms; every other symbol is a coefficient factor.
+(defn- p* [a b]
+  (reduce (fn [acc [sa ca]]
+            (reduce (fn [acc [sb cb]]
+                      (update acc (vec (sort-by str (concat sa sb))) (fnil + 0) (* ca cb)))
+                    acc b))
+          {} a))
+(defn- p+ [a b] (into {} (remove (comp zero? val)) (merge-with + a b)))
+(def ^:private p-one {[] 1})
+
+(defn affine
+  "Index expression → `{atom → coeff-polynomial}` (the constant term keyed `::one`), or nil when
+   the expression is not affine in `axes` (e.g. an axis multiplied by an axis). quot/mod/rem and
+   nested agets are treated as OPAQUE atoms and never distributed through — distributing them
+   would make two different gathers compare equal, which is a silent wrong-operand bug."
+  [e axes]
+  (let [axes (set axes)
+        opaque (fn [x] [::opaque (pr-str x)])
+        aff (fn aff [e]
+              (cond
+                (number? e) {::one {[] e}}
+                (symbol? e) (if (axes e) {e p-one} {::one {[e] 1}})
+                (seq? e)
+                (let [h (op-head (first e)) args (rest e)]
+                  (cond
+                    (= '+ h) (reduce (fn [acc a] (when-let [x (aff a)] (when acc (merge-with p+ acc x))))
+                                     {} args)
+                    (= '* h) (reduce (fn [acc a]
+                                       (when-let [x (aff a)]
+                                         (when acc
+                                           ;; affine × affine is affine only if at most one side
+                                           ;; carries an axis
+                                           (let [ax? (fn [m] (some #(not= ::one %) (keys m)))]
+                                             (when-not (and (ax? acc) (ax? x))
+                                               (let [[base other] (if (ax? acc) [acc x] [x acc])
+                                                     k (get other ::one)]
+                                                 (when k
+                                                   (into {} (map (fn [[a c]] [a (p* c k)])) base))))))))
+                                     {::one p-one} args)
+                    :else {(opaque e) p-one}))
+                :else {(opaque e) p-one}))]
+    (some->> (aff e) (into {} (remove (comp empty? val))))))
+
+(defn index=
+  "Do two index expressions denote the same element for all values of `axes`? The single index
+   relation — replaces the two divergent ones. Returns false when either side is non-affine."
+  [a b axes]
+  (let [pa (affine a axes) pb (affine b axes)]
+    (boolean (and pa pb (= pa pb)))))
 
 (defn index-matches?
-  "Does `idx-expr` equal this map's generated index, modulo operator qualification? This is the
-   VERIFICATION step: a leaf may only assume an operand's layout if the operand's actual index
-   expression provably is that layout."
+  "Does `idx-expr` equal this map's generated index? The VERIFICATION step: a leaf may only assume
+   an operand's layout if the operand's actual index provably IS that layout."
   [amap idx-expr]
-  (= (canonicalize-ops idx-expr) (canonicalize-ops (index-expr amap))))
+  (index= idx-expr (index-expr amap) (axes amap)))
 
 (defn transposed-2d?
   "True when `to` is `from` with its two groups swapped (the 2-D transpose case a physical

--- a/src/raster/compiler/ir/contract_stages.clj
+++ b/src/raster/compiler/ir/contract_stages.clj
@@ -43,6 +43,7 @@
    and may reference its own axis plus extra operand arrays, each with a declared axis-map (so a
    scale is indexed by ITS map, not by pattern-matching — same rule as the epilogue seam)."
   (:require [raster.compiler.ir.axis-map :as am]
+            [raster.compiler.core.dtype :as dt]
             [clojure.set :as set]
             [clojure.walk :as walk]))
 
@@ -74,6 +75,8 @@
       (when (= 1 n) (vec (remove #(= inner %) args))))
     :else nil))
 
+(declare contract-extent)
+
 (defn stages-legal?
   "Legality of a staged contract axis. Returns {:ok true} or {:ok false :reason kw …}.
 
@@ -94,8 +97,9 @@
      • no layout/distribution-changing op in a lift."
   [stages contract-axes & {:keys [inner] :or {inner 'inner}}]
   (let [stages (vec stages)
-        int-dtypes #{:int :long :byte :short :uint :int8 :int32}
-        float-dtypes #{:float :double :half :float16}
+        ;; dtype classification comes from the ONE registry. The ad-hoc sets this replaces listed
+        ;; :short/:uint/:int8/:int32/:float16 — four of which no emitter could spell, so the gate
+        ;; blessed accumulator dtypes that silently became "float" C types downstream.
         n (count stages)]
     (cond
       (zero? n) {:ok false :reason :no-stages}
@@ -103,6 +107,16 @@
       (not= (mapv :axis stages) (mapv first contract-axes))
       {:ok false :reason :stages-do-not-match-contract-axes
        :stage-axes (mapv :axis stages) :contract-axes (mapv first contract-axes)}
+
+      ;; EXTENTS too, not just axis names. Comparing symbols alone let a stage under-cover its
+      ;; axis — a stage of extent 4 against a declared extent of 32 emitted a loop summing an
+      ;; EIGHTH of the terms, while the interpreted path summed all of them. The stage list must
+      ;; span exactly the space the form declared.
+      (not= (mapv :extent stages) (mapv second contract-axes))
+      {:ok false :reason :stage-extents-do-not-span-the-contract-axes
+       :stage-extents (mapv :extent stages) :declared-extents (mapv second contract-axes)
+       :spans (contract-extent stages)
+       :declared (am/group-extent (mapv vec contract-axes))}
 
       (some? (:lift (peek stages)))
       {:ok false :reason :innermost-stage-has-a-lift :axis (:axis (peek stages))}
@@ -129,10 +143,15 @@
                :else nil)))
          (butlast stages)))
        ;; dtypes must not narrow outward (inner → outer)
+       ;; an accumulator dtype the compiler cannot spell is a REFUSAL, not a silent substitution
+       (first (keep (fn [{:keys [axis dtype]}]
+                      (when-not (dt/known? dtype)
+                        {:ok false :reason :unknown-stage-accumulator-dtype :axis axis :dtype dtype}))
+                    stages))
        (first
         (keep (fn [[outer inner-st]]
-                (when (and (contains? int-dtypes (:dtype outer))
-                           (contains? float-dtypes (:dtype inner-st)))
+                (when (and (dt/integral? (:dtype outer))
+                           (not (dt/integral? (:dtype inner-st))))
                   {:ok false :reason :narrowing-stage-accumulator
                    :outer (:dtype outer) :inner (:dtype inner-st)}))
               (partition 2 1 stages)))

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -190,6 +190,9 @@
             ;; Only attempted when the caller asked for peak AND the gate passes; a gate rejection
             ;; falls back to the scalar nest, so requesting peak can never yield a wrong kernel.
             spec {:free-axes free-axes :stages stages
+                  ;; the axes the FORM declared — the stage list is validated against THESE, never
+                  ;; against axes re-derived from the stages (which made the span rule unfireable)
+                  :contract-axes contract-axes
                   :body (nth contract-form 4)
                   :inputs (vec (sort-by name (contract-operand-arrays (nth contract-form 4))))
                   :operands operands

--- a/src/raster/compiler/passes/parallel/soac_graph.clj
+++ b/src/raster/compiler/passes/parallel/soac_graph.clj
@@ -10,7 +10,8 @@
     :dep     — consumer reads producer's array output (fusible)
     :inf-dep — consumer reads producer's scalar output (infusible)
     :cons    — consumer mutates array producer reads (anti-dep)"
-  (:require [raster.compiler.ir.soac :as soac]
+  (:require [raster.compiler.core.dtype :as dt]
+            [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.fusion-support :as fusion-support]
             [raster.compiler.passes.parallel.schedule-support :as schedule-support]
             [raster.compiler.core.op-descriptor :as opd]
@@ -347,9 +348,12 @@
     @total))
 
 (defn- elem-bytes
-  "Byte width of the AM's working element dtype (GPU training default :f16)."
+  "Byte width of the AM's working element dtype (GPU training default :f16), from the ONE dtype
+   registry — the private table this replaces had no :byte branch and priced int8 at 2 bytes.
+   Returns nil for a dtype the compiler cannot spell, so the caller ABSTAINS: this is a cost
+   model, and a cost model may decline to answer but must never throw or fabricate."
   [dtype]
-  (case dtype (:f16 :half) 2 (:f32 :float) 4 (:f64 :double) 8 2))
+  (when (dt/known? dtype) (dt/bytes-of dtype)))
 
 (defn vertical-fusion-profitable?
   "PROFITABILITY (decline-only). A MULTI-consumer vertical fusion inlines the
@@ -374,11 +378,13 @@
   (or (nil? am)
       (empty? (other-consumers graph producer-id consumer-id))   ;; sole consumer → pure win
       (let [producer (get (:nodes graph) producer-id)
-            ridge    (get-in am [:ridge dtype])]
+            ridge    (get-in am [:ridge dtype])
+            eb       (elem-bytes dtype)]
         (or (nil? ridge)
+            (nil? eb)                    ; unspellable dtype ⇒ abstain (fuse), never throw
             (not (instance? raster.compiler.ir.soac.SoacMap producer))
             (<= (lambda-flops (:lambda producer))
-                (* (elem-bytes dtype) (double ridge)))))))
+                (* (long eb) (double ridge)))))))
 
 (defn can-fuse-vertically?
   "Check if producer can be vertically fused into consumer.

--- a/src/raster/gpu/schedule.clj
+++ b/src/raster/gpu/schedule.clj
@@ -20,7 +20,8 @@
    ARGUMENT (probed OR supplied) so target-aware compilation is 'pass a different descriptor',
    not a retrofit — the Intel-GRF vs AMD-VGPR budget flows through the same gate."
   (:refer-clojure :exclude [resolve])
-  (:require [raster.compiler.core.hardware :as hw]))
+  (:require [raster.compiler.core.dtype :as dt]
+            [raster.compiler.core.hardware :as hw]))
 
 ;; ================================================================
 ;; Stage 1 — derive-default
@@ -215,8 +216,12 @@
    function the cost-guided chooser / autotune seed rank schedules with. Returns nil when the
    descriptor carries no bandwidth/peak-flops (the roofline abstains rather than fabricating)."
   [schedule {:keys [m n k dtype] :or {dtype :f16}} desc]
+  (when-not (dt/known? dtype)
+    ;; a cost model abstains rather than fabricating a width — the private table this replaces
+    ;; silently returned 2 bytes for every dtype it did not know, including int8
+    (throw (ex-info "schedule-cost-ns: unknown dtype" {:reason :unknown-dtype :dtype dtype})))
   (let [res      (:residency schedule)
-        elem-b   (case dtype (:f16 :half) 2 (:f32 :float) 4 (:f64 :double) 8 2)
+        elem-b   (dt/bytes-of dtype)
         ;; row-major operand footprints: A[m×k] B[k×n] C[m×n]
         ob       {:a (* (long m) (long k) elem-b) :b (* (long k) (long n) elem-b) :c (* (long m) (long n) elem-b)}
         warm?    (fn [o] (= :resident (get res o :dram)))

--- a/test/raster/compiler/backend/gpu/staged_contract_device_test.clj
+++ b/test/raster/compiler/backend/gpu/staged_contract_device_test.clj
@@ -47,6 +47,12 @@
                {:sym 'db :map {:groups [[['j N]] [['blk NB]]]} :dtype :float}]}
    {:axis 't :extent B :dtype :int :init 0}])
 
+(def ^:private two-stage-axes
+  "The contract axes the FORM declares. Stated independently of `two-stage` on purpose: validating
+   a stage list against axes derived from itself is exactly the tautology that let a stage list
+   under-cover its contract space and emit a kernel summing a fraction of the terms."
+  [['blk NB] ['t B]])
+
 ;; ── host references ─────────────────────────────────────────────────────────────────
 (defn- ref-staged
   "The block formula, evaluated exactly as the kernel schedules it: int32 inner, float outer."
@@ -93,7 +99,7 @@
 (defn- run-staged
   "Emit, register and launch a staged contraction; return the device output vector. `lift-arrays`
    maps each lift operand symbol → its float array, bound in the emitter's declared order."
-  [stages body-expr ^bytes a ^bytes b lift-arrays & [extra]]
+  [stages contract-axes body-expr ^bytes a ^bytes b lift-arrays & [extra]]
   (let [ze (find-ns 'raster.gpu.ze-runtime)
         register! (ns-resolve ze 'register-kernel!)
         ensure-loaded! (ns-resolve ze 'ensure-kernel-loaded!)
@@ -103,8 +109,8 @@
         launch-2d! (ns-resolve ze 'launch-2d!)
         {:keys [kernel-name source array-params lift-operands out-elems]}
         (sco/generate-staged-contraction-kernel
-         (merge {:free-axes [['i M] ['j N]] :stages stages :body body-expr
-                 :inputs '[a b] :dtype :byte :out-dtype :float}
+         (merge {:free-axes [['i M] ['j N]] :stages stages :contract-axes contract-axes
+                 :body body-expr :inputs '[a b] :dtype :byte :out-dtype :float}
                 extra)
          'out)
         _ (assert (= '[a b] array-params))
@@ -136,7 +142,7 @@
     (println "  [skip] no GPU — staged contraction device test")
     (let [da (pow2-scales (* M NB) 0)
           db (pow2-scales (* N NB) 3)
-          gpu (run-staged two-stage body a-data b-data {'da da 'db db})
+          gpu (run-staged two-stage two-stage-axes body a-data b-data {'da da 'db db})
           staged (vec (ref-staged a-data b-data da db))
           flat (vec (ref-flat a-data b-data da db))]
       (testing "flat-equivalent derives exactly the flat body ref-flat evaluates by hand"
@@ -150,6 +156,10 @@
             "staging is a schedule: it must not change the value, only the accumulator"))
       (testing "device matches the reference"
         (is (= staged gpu)))
+      (testing "…and matches the FLAT equivalent — the free oracle the design claims but that
+                was never actually asserted (flat was only ever compared to staged, both of them
+                host-side fixtures that touch no production code)"
+        (is (= flat gpu)))
       (testing "the result is actually non-trivial (guards against an all-zero pass)"
         (is (some #(not (zero? %)) gpu))))))
 
@@ -175,7 +185,8 @@
                       (list 'aget 'b (list 'clojure.core/+ (list 'clojure.core/* 'j K) l-expr)))
           dsuper (pow2-scales (* M nsb) 1)
           dsub (pow2-scales (* N nsub) 2)
-          gpu (run-staged stages body3 a-data b-data {'dsuper dsuper 'dsub dsub})
+          gpu (run-staged stages [['sb nsb] ['blk2 nsub] ['t B]] body3 a-data b-data
+                             {'dsuper dsuper 'dsub dsub})
           ;; host reference for the 3-level nest
           ref (let [out (float-array (* M N))]
                 (dotimes [i M]
@@ -211,6 +222,7 @@
           (sco/generate-staged-contraction-kernel
            {:free-axes [['i M] ['j N]]
             :stages [{:axis 'l :extent K :dtype :float :init 0.0}]
+            :contract-axes [['l K]]
             :body (list 'raster.numeric/*
                         (list 'aget 'a (list 'clojure.core/+ (list 'clojure.core/* 'i K) 'l))
                         (list 'aget 'b (list 'clojure.core/+ (list 'clojure.core/* 'j K) 'l)))
@@ -225,7 +237,7 @@
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo #"lift-discards-inner-accumulator"
          (sco/generate-staged-contraction-kernel
-          {:free-axes [['i M] ['j N]]
+          {:free-axes [['i M] ['j N]] :contract-axes [['blk NB] ['t B]]
            :stages [{:axis 'blk :extent NB :dtype :float :init 0.0
                      :lift '(raster.numeric/* (aget da _) 2.0)
                      :operands [{:sym 'da :map {:groups [[['blk NB]]]}}]}
@@ -235,7 +247,7 @@
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo #"lift-not-linear-in-inner"
          (sco/generate-staged-contraction-kernel
-          {:free-axes [['i M] ['j N]]
+          {:free-axes [['i M] ['j N]] :contract-axes [['blk NB] ['t B]]
            :stages [{:axis 'blk :extent NB :dtype :float :init 0.0
                      :lift '(raster.numeric/sqrt inner)}
                     {:axis 't :extent B :dtype :int :init 0}]
@@ -259,8 +271,8 @@
                       (list 'aget 'a (am/index-expr (get body-maps 'a)))
                       (list 'aget 'b (am/index-expr (get body-maps 'b))))
           operands [{:sym 'a :map (get body-maps 'a)} {:sym 'b :map (get body-maps 'b)}]
-          scalar (run-staged two-stage body' a-data b-data {'da da 'db db})
-          packed (run-staged two-stage body' a-data b-data {'da da 'db db}
+          scalar (run-staged two-stage two-stage-axes body' a-data b-data {'da da 'db db})
+          packed (run-staged two-stage two-stage-axes body' a-data b-data {'da da 'db db}
                              {:operands operands :tensorize-inner? true})
           ref (vec (ref-staged a-data b-data da db))]
       (testing "dp4a and the scalar nest agree EXACTLY — int32 accumulation is exact, so any
@@ -276,7 +288,8 @@
         body' (list 'raster.numeric/*
                     (list 'aget 'a (am/index-expr good-a))
                     (list 'aget 'b (am/index-expr good-b)))
-        spec {:free-axes [['i M] ['j N]] :stages two-stage :body body'
+        spec {:free-axes [['i M] ['j N]] :stages two-stage :contract-axes two-stage-axes
+              :body body'
               :inputs '[a b] :dtype :byte :out-dtype :float
               :operands [{:sym 'a :map good-a} {:sym 'b :map good-b}]}]
     (testing "the honest case is legal"

--- a/test/raster/compiler/ir/contract_stages_test.clj
+++ b/test/raster/compiler/ir/contract_stages_test.clj
@@ -135,3 +135,44 @@
               {:axis t :extent 32 :dtype :int :init 0}]]
       (is (:ok (cs/stages-legal? s '[[blk nb] [t 32]])))
       (is (= '(clojure.core/* 32 nb) (cs/contract-extent s))))))
+
+;; ── the oracle: a stage list must SPAN the axes the form declared ────────────────────
+(deftest stages-must-span-the-declared-contract-space
+  (testing "axis names matching is not enough — extents must span the declared space.
+            A stage of extent 4 against a declared extent of 32 emitted a kernel summing an
+            EIGHTH of the terms while the interpreted path summed all of them: two consumers of
+            one form disagreeing silently."
+    (is (= :stage-extents-do-not-span-the-contract-axes
+           (:reason (cs/stages-legal?
+                     '[{:axis blk :extent 2 :dtype :float :init 0.0 :lift inner}
+                       {:axis t :extent 4 :dtype :int :init 0}]
+                     '[[blk 2] [t 32]]))))
+    (is (:ok (cs/stages-legal?
+              '[{:axis blk :extent 2 :dtype :float :init 0.0 :lift inner}
+                {:axis t :extent 32 :dtype :int :init 0}]
+              '[[blk 2] [t 32]]))
+        "…and the spanning list is legal"))
+  (testing "the failure names both sides, so the diagnostic is actionable"
+    (let [r (cs/stages-legal? '[{:axis l :extent 8 :dtype :float :init 0.0}] '[[l 64]])]
+      (is (= 8 (:spans r)))
+      (is (= 64 (:declared r))))))
+
+;; hoisted OUT of a GPU-gated device test: this is the only assertion anywhere that pins
+;; multi-axis map substitution, and behind a GPU gate it never ran in CI. A mutation making
+;; stage-index-exprs always return the bare axis survived every CI-visible assertion.
+(deftest flat-equivalent-substitutes-multi-axis-operand-maps
+  (testing "an operand indexed by a FREE axis and a STAGE axis gets its declared 2-D index,
+            not the bare stage axis"
+    (let [stages '[{:axis blk :extent 4 :dtype :float :init 0.0
+                    :lift (raster.numeric/* inner (aget da _) (aget db _))
+                    :operands [{:sym da :map {:groups [[[i 4]] [[blk 4]]]}}
+                               {:sym db :map {:groups [[[j 6]] [[blk 4]]]}}]}
+                   {:axis t :extent 32 :dtype :int :init 0}]
+          b '(raster.numeric/* (aget a ia) (aget b ib))]
+      (is (= '(raster.numeric/* (raster.numeric/* (aget a ia) (aget b ib))
+                                (aget da (clojure.core/+ (clojure.core/* i 4) blk))
+                                (aget db (clojure.core/+ (clojure.core/* j 4) blk)))
+             (cs/flat-equivalent stages b)))
+      (is (= '{da (clojure.core/+ (clojure.core/* i 4) blk)
+               db (clojure.core/+ (clojure.core/* j 4) blk)}
+             (cs/stage-index-exprs stages))))))

--- a/test/raster/compiler/passes/parallel/staged_contract_route_test.clj
+++ b/test/raster/compiler/passes/parallel/staged_contract_route_test.clj
@@ -163,3 +163,36 @@
     (let [r (cr/route-contraction (staged-form :byte) :dtype :byte :prefer-peak? true)]
       (is (= :staged-segred (:strategy r)))
       (is (not (:tensorized r))))))
+
+;; ── the oracle at the router: both defects, refused rather than emitted ──────────────
+(deftest router-refuses-stages-that-do-not-span-the-declared-axes
+  (testing "a stage under-covering its declared extent must be REFUSED, not emitted.
+            Before: routed happily and emitted `for (int t = 0; t < 4` against a declared
+            extent of 32 — the GPU summed 8 of 64 terms while par/contract summed all 64."
+    (let [bad (list 'raster.par/contract 'out [['i 2] ['j 2]] [['blk 2] ['t 32]]
+                    (list 'raster.numeric/* (list 'aget 'a 't) (list 'aget 'b 't))
+                    :stages [{:axis 'blk :extent 2 :dtype :float :init 0.0 :lift 'inner}
+                             {:axis 't :extent 4 :dtype :int :init 0}])]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"illegal stages"
+                            (cr/route-contraction bad :dtype :byte))))))
+
+(deftest dp4a-refuses-a-body-it-would-discard
+  (testing "this leaf replaces the whole summand with one rstr_dp4a call, so a body carrying any
+            factor beyond the two declared operands would be SILENTLY dropped — with the extra
+            array still declared as an unread kernel param."
+    (let [ma {:groups [['[i 4]] ['[blk 4] '[t 32]]]}
+          mb {:groups [['[j 4]] ['[blk 4] '[t 32]]]}
+          idx (requiring-resolve 'raster.compiler.ir.axis-map/index-expr)
+          gate (requiring-resolve 'raster.compiler.backend.gpu.segop-opencl/staged-inner-dp4a-legal?)
+          base {:stages [{:axis 'blk :extent 4 :dtype :float :init 0.0 :lift 'inner}
+                         {:axis 't :extent 32 :dtype :int :init 0}]
+                :operands [{:sym 'a :map ma} {:sym 'b :map mb}]
+                :dtype :byte}
+          pure (list 'raster.numeric/* (list 'aget 'a (idx ma)) (list 'aget 'b (idx mb)))]
+      (is (:ok (gate (assoc base :body pure))) "the exact product is accepted")
+      (is (= :body-has-unmodeled-terms
+             (:reason (gate (assoc base :body (list 'raster.numeric/* pure (list 'aget 'mask 't))))))
+          "an extra factor is refused")
+      (is (= :body-has-unmodeled-terms
+             (:reason (gate (assoc base :body (list 'raster.numeric/+ pure (list 'aget 'c 't))))))
+          "…and so is a non-product body"))))

--- a/test/raster/dl/gemma_train_resident_test.clj
+++ b/test/raster/dl/gemma_train_resident_test.clj
@@ -32,6 +32,7 @@
             [raster.dl.attention :as attn]
             [raster.dl.loss :as loss]
             [raster.dl.optim :as optim]
+            [raster.numeric :as n]
             [raster.arrays :as ra]
             [raster.ad.reverse :as rev]
             [raster.compiler.pipeline :as pl]
@@ -141,20 +142,23 @@
         dAg (clojure.core/nth vg 21) dBg (clojure.core/nth vg 22)
         dAu (clojure.core/nth vg 24) dBu (clojure.core/nth vg 25)
         dAd (clojure.core/nth vg 27) dBd (clojure.core/nth vg 28)]
-    (raster.dl.optim/sgd-step! Aq dAq (raster.arrays/alength Aq) lr)
-    (raster.dl.optim/sgd-step! Bq dBq (raster.arrays/alength Bq) lr)
-    (raster.dl.optim/sgd-step! Ak dAk (raster.arrays/alength Ak) lr)
-    (raster.dl.optim/sgd-step! Bk dBk (raster.arrays/alength Bk) lr)
-    (raster.dl.optim/sgd-step! Av dAv (raster.arrays/alength Av) lr)
-    (raster.dl.optim/sgd-step! Bv dBv (raster.arrays/alength Bv) lr)
-    (raster.dl.optim/sgd-step! Ao dAo (raster.arrays/alength Ao) lr)
-    (raster.dl.optim/sgd-step! Bo dBo (raster.arrays/alength Bo) lr)
-    (raster.dl.optim/sgd-step! Ag dAg (raster.arrays/alength Ag) lr)
-    (raster.dl.optim/sgd-step! Bg dBg (raster.arrays/alength Bg) lr)
-    (raster.dl.optim/sgd-step! Au dAu (raster.arrays/alength Au) lr)
-    (raster.dl.optim/sgd-step! Bu dBu (raster.arrays/alength Bu) lr)
-    (raster.dl.optim/sgd-step! Ad dAd (raster.arrays/alength Ad) lr)
-    (raster.dl.optim/sgd-step! Bd dBd (raster.arrays/alength Bd) lr)
+    ;; `lr` is :- Double but the adapters are (Array float): a T-typed scalar must be brought to
+    ;; the element type at the call site (raster.dl.optim:254 does the same). This call site was
+    ;; missed when sgd-step!'s scalar became :- T (#80), so the test has been red on main since.
+    (raster.dl.optim/sgd-step! Aq dAq (raster.arrays/alength Aq) (n/oftype Aq lr))
+    (raster.dl.optim/sgd-step! Bq dBq (raster.arrays/alength Bq) (n/oftype Bq lr))
+    (raster.dl.optim/sgd-step! Ak dAk (raster.arrays/alength Ak) (n/oftype Ak lr))
+    (raster.dl.optim/sgd-step! Bk dBk (raster.arrays/alength Bk) (n/oftype Bk lr))
+    (raster.dl.optim/sgd-step! Av dAv (raster.arrays/alength Av) (n/oftype Av lr))
+    (raster.dl.optim/sgd-step! Bv dBv (raster.arrays/alength Bv) (n/oftype Bv lr))
+    (raster.dl.optim/sgd-step! Ao dAo (raster.arrays/alength Ao) (n/oftype Ao lr))
+    (raster.dl.optim/sgd-step! Bo dBo (raster.arrays/alength Bo) (n/oftype Bo lr))
+    (raster.dl.optim/sgd-step! Ag dAg (raster.arrays/alength Ag) (n/oftype Ag lr))
+    (raster.dl.optim/sgd-step! Bg dBg (raster.arrays/alength Bg) (n/oftype Bg lr))
+    (raster.dl.optim/sgd-step! Au dAu (raster.arrays/alength Au) (n/oftype Au lr))
+    (raster.dl.optim/sgd-step! Bu dBu (raster.arrays/alength Bu) (n/oftype Bu lr))
+    (raster.dl.optim/sgd-step! Ad dAd (raster.arrays/alength Ad) (n/oftype Ad lr))
+    (raster.dl.optim/sgd-step! Bd dBd (raster.arrays/alength Bd) (n/oftype Bd lr))
     Aq))
 
 ;; ── data / config ────────────────────────────────────────────────────────────────
@@ -224,7 +228,7 @@
         (let [vg (apply vg-fn (loss-args cfg st))]
           (doseq [s adapter-syms]
             (optim/sgd-step! (st s) (nth vg (adapter-vg-slot s))
-                             (ra/alength ^floats (st s)) lr))
+                             (ra/alength ^floats (st s)) (n/oftype (st s) lr)))
           (recur (inc k) (conj losses (double (nth vg 0)))))))))
 
 ;; ── the gate ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
First of four phases from the coherence audit. Groundwork: two verified silent miscompiles die
here, and so do the two root enablers that made them writable.

## The two defects (both verified by execution, both mine from the recent contraction work)

**A gate must not validate its own arguments.** `generate-staged-contraction-kernel` called
`stages-legal?` with contract axes *derived from the stages themselves*, so the span rule could
never fire:

```
form declares [[blk 2] [t 32]]   (64 terms)
stage says     t extent 4
→ routed happily, emitted  for (int t = 0; t < 4
→ GPU summed 8 of 64 terms; par/contract's interpreted path summed all 64
```

`:contract-axes` is now **required**, carrying what the form declared, and `stages-legal?` compares
**extents** rather than only axis names. Updating the tests was the proof — every direct caller
failed to compile until it declared its axes. The device test states `two-stage-axes`
*independently* of `two-stage`; deriving it would have rebuilt the tautology inside the test.

**A leaf that replaces the body must first account for all of it.** When dp4a fires, the summand is
never emitted — it's replaced by one `rstr_dp4a` call. The gate checked operand maps but not body
shape, so `(* (* A B) mask)` returned `:ok true` and **silently dropped `mask`**, which stayed
declared as an unread kernel param. Now `:body-has-unmodeled-terms`.

## The two enablers

**One dtype registry.** `dtype-info` had six rows and no `:int8`/`:int32`/`:float16`, while gates
accepted all three — so `(get opencl-type-map :int32 "double")` returned `"double"`, emitting
`__global const double*` over an int8 buffer and turning an int32 accumulator into a float. The
access split is the point:

| accessor | on unknown dtype | for |
|---|---|---|
| `canon` / `ctype` / `bytes-of` | **throws** | emitters — must fail loud |
| `known?` | **returns false** | gates — must return a verdict |

Removes 13 silent `"double"`/`"float"` fallbacks, the epilogue cost model's private byte table, and
two cost-path tables that priced int8 at 2 bytes. Cost paths **abstain** rather than throw or
fabricate.

**One index relation.** The two relations accepted different languages:

| spelling | `canonical-rowmajor?` | `index-matches?` | now |
|---|---|---|---|
| `(+ (* j 8) l)` | ✅ | ✅ | ✅ |
| `(+ l (* j 8))` | ✅ | ❌ | ✅ |
| `(+ (* 8 j) l)` | ✅ | ❌ | ✅ |
| nested 3-axis sum | ❌ | ✅ | ✅ |

Rows two and three are a live bug: a legal `:nt` operand written with a commuted `+` passed the flat
dp4a gate and was rejected by the staged one, **reaching no leaf at all**. Both now normalize
through `am/affine` (`{atom → coefficient-polynomial}`).

`affine` takes the **axis set** because `(* i k)` is otherwise ambiguous — axis×extent or axis×axis.
`quot`/`mod`/`rem` and nested agets stay **opaque atoms**, never distributed through: distributing
them would make two different gathers compare equal, a silent wrong-operand bug. Verified
`(quot t 4)` ≠ `(quot t 8)`. `canonical-rowmajor?` keeps its name and delegates, so its six call
sites don't churn twice (Phase B deletes the wrapper).

## Pre-existing red test, fixed

`gemma-train-resident-test` has been **red on `main`** since #80 made optimizer scalars `:- T`: it
passes `lr :- Double` against `(Array float)` adapters. 15 call sites now use `(n/oftype param lr)`.
Confirmed pre-existing rather than assumed — this branch touches nothing under `src/raster/dl/`,
`core.clj` or `dispatch.clj`, and the test was last modified in #74, *before* #80.

Worth recording: my first sweep matched **14 of 15** by regex and reported a count rather than
coverage; the 15th had computed args and failed identically after the "fix". That is the same
incomplete-sweep pattern that let #80 miss the file originally.

## Validation

Full suite **2006 tests / 32458 assertions**, 0 failures. Cold-JVM load verified on every touched
namespace.

## Next

Phase B replaces the two patches above with structure that makes the class unwritable: one
`contraction-facts` derived from the form alone (no arity accepts caller-supplied axes), leaves
declaring requirements as a data table, and one verifier — plus the ABI datum that closes the
*live* invoke↔descriptor bug where epilogue and lift operands are never bound.
