### PR TITLE
Phase B: one derivation of contraction facts + leaf layouts as data rows

### DIFF
--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -15,6 +15,7 @@
             [raster.compiler.core.hardware :as hw]
             [raster.compiler.ir.axis-map :as am]
             [raster.compiler.ir.contract-stages :as cstage]
+            [raster.compiler.ir.contraction-facts :as cf]
             [clojure.walk :as walk]
             [clojure.set]
             [raster.compiler.ir.segop :as segop]
@@ -1046,19 +1047,10 @@
                                       [(second f) (nth f 2)]))
                              (tree-seq coll? seq body)))
         ;; THE BODY IS DISCARDED when this leaf fires — the whole summand is replaced by one
-        ;; rstr_dp4a call. So the gate must account for EVERY term first: a body carrying any
-        ;; factor beyond the two declared operands (a mask, a third tensor) would be silently
-        ;; dropped, with the extra array still declared as an unread kernel param. Require the
-        ;; body to be exactly the product of the two declared operands' agets.
-        declared-syms (set (map :sym operands))
-        body-terms (when (and (seq? body) (descriptor/multiplication-op? (descriptor/semantic-op body)))
-                     (vec (descriptor/call-args body)))
-        exact-product?
-        (and body-terms
-             (= 2 (count body-terms))
-             (every? (fn [t] (and (seq? t) (= 'aget (first t))
-                                  (contains? declared-syms (second t))))
-                     body-terms))]
+        ;; rstr_dp4a call — so the gate must account for EVERY term first. The requirement lives in
+        ;; ir/contraction-facts as `body-product-of`, shared with every other body-replacing leaf,
+        ;; rather than re-derived per gate.
+        exact-product? (some? (cf/body-product-of body (map :sym operands)))]
     (cond
       (not= 2 (count operands)) {:ok false :reason :dp4a-needs-two-declared-operands}
       (not (every? :map operands)) {:ok false :reason :operand-without-a-declared-map}
@@ -1067,7 +1059,7 @@
       (not exact-product?)
       {:ok false :reason :body-has-unmodeled-terms
        :detail "this leaf replaces the body with a single hardware op; any term beyond the two declared operands would be silently dropped"
-       :body body :declared (vec declared-syms)}
+       :body body :declared (mapv :sym operands)}
       (not int-acc?) {:ok false :reason :inner-stage-accumulator-not-integral
                       :dtype (:dtype inner-stage)}
       :else

--- a/src/raster/compiler/ir/contraction_facts.clj
+++ b/src/raster/compiler/ir/contraction_facts.clj
@@ -1,0 +1,131 @@
+(ns raster.compiler.ir.contraction-facts
+  "FACTS: the one derivation of everything checkable about a `par/contract` form.
+
+   WHY THIS EXISTS — a gate must not validate its own arguments. Two silent miscompiles shipped
+   because a gate was handed a value derived from the very thing it was meant to check:
+
+     • `stages-legal?` was called with contract axes derived FROM THE STAGES, so its span rule
+       could never fire; a stage under-covering its axis emitted a kernel summing a fraction of
+       the terms while the interpreted path summed all of them.
+     • the dp4a gate verified operand maps but never the body SHAPE, and that leaf DISCARDS the
+       body — so an extra factor was silently dropped.
+
+   Patching each instance leaves the shape intact. This closes it structurally: there is exactly
+   ONE producer of facts, its only input is the FORM, and a checker takes facts — so there is no
+   argument to pass inconsistently. A checker that wants the contract axes cannot be handed a
+   different set; it reads `:contract-axes`, which came from the form's own declaration slot.
+
+   DECLARATIONS ARE EVIDENCE, NOT FACTS. A form may declare operand axis-maps (`:maps`), which is
+   what lets a merged/batched operand be understood at all — a derived map cannot guess grouping.
+   But a declaration is admitted only after `am/index-matches?` proves it generates the operand's
+   actual index. A declaration that fails verification does not fall back to derivation; it makes
+   the whole extraction fail. Trusting a declared layout while having checked only its axis
+   symbols is how a transpose rewrite risked a silent miscompile."
+  (:require [raster.compiler.ir.axis-map :as am]
+            [raster.compiler.core.op-descriptor :as od]))
+
+(def ^:private facts-tag ::facts)
+
+(defn facts?
+  "Is `x` the output of `contraction-facts`? Checkers assert this so a hand-built map — the shape
+   that made the original defects writable — cannot be substituted."
+  [x]
+  (boolean (and (map? x) (get x facts-tag))))
+
+(defn- form-opts
+  "The trailing option map of a contract form, parsed ONCE. (It was previously re-parsed with
+   `(apply hash-map (drop 5 form))` at six separate call sites.)"
+  [form]
+  (let [tail (drop 5 form)]
+    (when (odd? (count tail))
+      (throw (ex-info "contract form: trailing options must be key/value pairs"
+                      {:reason :malformed-opts :opts (vec tail)})))
+    (apply hash-map tail)))
+
+(defn- aget-terms
+  "Every `(aget arr idx)` the expression reads, as {:sym :idx}, in encounter order. Uses the
+   op-descriptor's aget classification rather than a local literal set, so a devirtualized
+   `.invk` read is recognized the same way a bare `aget` is."
+  [expr]
+  (->> (tree-seq coll? seq expr)
+       (keep (fn [f]
+               (when (and (seq? f) (= 'aget (first f)) (symbol? (second f)))
+                 {:sym (second f) :idx (nth f 2)})))
+       vec))
+
+(defn- verify-declared-map
+  "A declared map is admitted only if it provably generates the operand's ACTUAL index."
+  [sym declared idx]
+  (when declared
+    (when-not (am/index-matches? declared idx)
+      (throw (ex-info (str "contract form: declared :maps entry for `" sym
+                           "` does not generate that operand's actual index")
+                      {:reason :declared-map-does-not-match-the-body-index
+                       :sym sym :declared (am/index-expr declared) :actual idx})))
+    declared))
+
+(defn contraction-facts
+  "Derive the checkable facts of `(raster.par/contract out free-axes contract-axes body & opts)`.
+   The ONLY input is the form (plus the intended element dtype, which is a compilation choice
+   rather than a property of the form). Throws on a malformed form or an unverifiable declaration."
+  [form & {:keys [dtype] :or {dtype :double}}]
+  (when-not (and (seq? form) (= 'raster.par/contract (first form)))
+    (throw (ex-info "contraction-facts: not a par/contract form" {:reason :not-a-contract-form
+                                                                  :form form})))
+  (let [[_ out free-axes contract-axes body] form
+        opts (form-opts form)
+        _ (when-not (vector? free-axes)
+            (throw (ex-info "contract form: free-axes must be a vector" {:reason :malformed-free-axes})))
+        _ (when-not (vector? contract-axes)
+            (throw (ex-info "contract form: contract-axes must be a vector" {:reason :malformed-contract-axes})))
+        declared (:maps opts)
+        terms (mapv (fn [{:keys [sym idx]}]
+                      {:sym sym :idx idx
+                       :map (verify-declared-map sym (get declared sym) idx)})
+                    (aget-terms body))
+        ;; role → axis symbol, so a leaf contract can say [:free0 :contract0] instead of naming
+        ;; the user's own symbols
+        roles (merge (into {} (map-indexed (fn [n [a _]] [(keyword (str "free" n)) a])) free-axes)
+                     (into {} (map-indexed (fn [n [a _]] [(keyword (str "contract" n)) a])) contract-axes))
+        dims (merge (into {} (map-indexed (fn [n [_ e]] [(keyword (str "free" n)) e])) free-axes)
+                    (into {} (map-indexed (fn [n [_ e]] [(keyword (str "contract" n)) e])) contract-axes))]
+    {facts-tag true
+     :form form
+     :out out
+     :free-axes (mapv vec free-axes)
+     :contract-axes (mapv vec contract-axes)
+     :n-free (count free-axes)
+     :n-contract (count contract-axes)
+     :body body
+     :operands terms
+     :combine (get opts :combine '+)
+     :init (get opts :init 0.0)
+     :dtype dtype
+     :out-dtype (get opts :out-dtype)
+     :stages (:stages opts)
+     :epilogue (:epilogue opts)
+     :roles roles
+     :dims dims
+     :opts opts}))
+
+;; ── body shape: what a leaf that DISCARDS the body must first account for ────────────
+(defn body-product-of
+  "If `body` is exactly the product of agets on the operands named by `syms` (each once, no other
+   factors), return those terms; otherwise nil.
+
+   This is the requirement a body-REPLACING leaf must carry. dp4a and DPAS both emit a hardware op
+   in place of the whole summand, so any term the gate has not accounted for is silently dropped —
+   with its array still declared as an unread kernel parameter. `nil` here means `refuse`, and the
+   router falls back to a leaf that actually evaluates the body."
+  [body syms]
+  (let [syms (set syms)]
+    (when (and (seq? body) (od/multiplication-op? (od/semantic-op body)))
+      (let [args (vec (od/call-args body))]
+        (when (= (count syms) (count args))
+          (let [terms (keep (fn [t] (when (and (seq? t) (= 'aget (first t))
+                                               (contains? syms (second t)))
+                                      {:sym (second t) :idx (nth t 2)}))
+                            args)]
+            (when (and (= (count terms) (count args))
+                       (= syms (set (map :sym terms))))
+              (vec terms))))))))

--- a/src/raster/compiler/ir/contraction_facts.clj
+++ b/src/raster/compiler/ir/contraction_facts.clj
@@ -129,3 +129,63 @@
             (when (and (= (count terms) (count args))
                        (= syms (set (map :sym terms))))
               (vec terms))))))))
+
+(defn- permutations
+  "All orderings of `xs`. Operand counts here are 2 (occasionally 3), so the factorial cost is
+   irrelevant and an explicit search is clearer than a variance heuristic."
+  [xs]
+  (if (<= (count xs) 1)
+    (list (vec xs))
+    (for [i (range (count xs))
+          rest-perm (permutations (concat (take i xs) (drop (inc i) xs)))]
+      (into [(nth xs i)] rest-perm))))
+
+;; ── leaf layout requirements as DATA ────────────────────────────────────────────────
+(def leaf-layouts
+  "Each tensorize leaf's required operand layout, as ROLE → the axis roles that index it,
+   outer→inner. `:nn` and `:nt` are not concepts here — they are two different data rows:
+
+     :dpas / :quant  row A[i,l]  col B[l,j]   → col is [:contract0 :free1]
+     :dp4a           row A[i,l]  col B[j,l]   → col is [:free1 :contract0]  (K-contiguous)
+
+   The required layout is a property of the LEAF (dp4a packs 4 int8 along the contraction, so both
+   operands must be contiguous in it), never of the contraction. Adding a layout — a batch axis, a
+   merged group, a `:tn` orientation — is a row edit, not a new predicate. This replaces three
+   hand-written checks that called one pattern-matcher with six different argument orders."
+  {:dpas        {:row [:free0 :contract0] :col [:contract0 :free1]}
+   :quant-naive {:row [:free0 :contract0] :col [:contract0 :free1]}
+   :dp4a        {:row [:free0 :contract0] :col [:free1 :contract0]}})
+
+(defn- role-map
+  "The axis-map a role-spec denotes, e.g. [:free0 :contract0] → of-axes [[i M] [l L]] (index i·L+l)."
+  [facts axis-roles]
+  (am/of-axes (mapv (fn [r] [(get-in facts [:roles r]) (get-in facts [:dims r])]) axis-roles)))
+
+(defn check-layout
+  "Assign the body's operands to a leaf's declared roles BY VERIFICATION, and return
+   {:ok true :bindings {role sym}} or {:ok false :reason :layout …}.
+
+   This replaces the variance test (\"row is the operand depending on free0+contract but not
+   free1\"). An operand is the row operand because its index PROVABLY IS the row layout — not
+   because of which axes it happens to mention. Every candidate assignment is checked, so a leaf
+   cannot be handed an operand whose layout was assumed rather than proved.
+
+   `required` is a `leaf-layouts` entry."
+  [facts required]
+  (when-not (facts? facts)
+    (throw (ex-info "check-layout: expected contraction-facts" {:reason :raster/bug})))
+  (let [ops (:operands facts)
+        roles (vec (keys required))]
+    (if (not= (count ops) (count roles))
+      {:ok false :reason :operand-count
+       :required (count roles) :actual (count ops) :operands (mapv :sym ops)}
+      (let [fits? (fn [assignment]
+                    (every? (fn [[role op]]
+                              (am/index-matches? (role-map facts (get required role)) (:idx op)))
+                            assignment))
+            candidates (map #(zipmap roles %) (permutations ops))]
+        (if-let [hit (first (filter fits? candidates))]
+          {:ok true :bindings (into {} (map (fn [[r o]] [r (:sym o)])) hit)}
+          {:ok false :reason :layout
+           :required (into {} (map (fn [r] [r (am/index-expr (role-map facts (get required r)))])) roles)
+           :actual (mapv (juxt :sym :idx) ops)})))))

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -19,7 +19,8 @@
             [raster.compiler.passes.parallel.contract-lower :as cl]
             [raster.compiler.backend.gpu.segop-opencl :as sco]
             [raster.compiler.backend.gpu.c-emit :as ce]
-            [raster.compiler.ir.axis-map :as am]))
+            [raster.compiler.ir.axis-map :as am]
+            [raster.compiler.ir.contraction-facts :as cf]))
 
 (defn par-contract-form?
   "Is `form` a (raster.par/contract out free-axes contract-axes body & opts) form?"
@@ -190,9 +191,10 @@
             ;; Only attempted when the caller asked for peak AND the gate passes; a gate rejection
             ;; falls back to the scalar nest, so requesting peak can never yield a wrong kernel.
             spec {:free-axes free-axes :stages stages
-                  ;; the axes the FORM declared — the stage list is validated against THESE, never
-                  ;; against axes re-derived from the stages (which made the span rule unfireable)
-                  :contract-axes contract-axes
+                  ;; the axes the FORM declared, read off FACTS — a single derivation whose only
+                  ;; input is the form, so there is no separately-computed value to pass
+                  ;; inconsistently (which is what made the span rule unfireable)
+                  :contract-axes (:contract-axes (cf/contraction-facts contract-form :dtype dtype))
                   :body (nth contract-form 4)
                   :inputs (vec (sort-by name (contract-operand-arrays (nth contract-form 4))))
                   :operands operands

--- a/test/raster/compiler/ir/contraction_facts_test.clj
+++ b/test/raster/compiler/ir/contraction_facts_test.clj
@@ -1,0 +1,80 @@
+(ns raster.compiler.ir.contraction-facts-test
+  "FACTS: the single derivation whose only input is the form. Device-free.
+
+   The property under test is structural, not behavioural: because there is one producer and its
+   only input is the form, a checker cannot be handed a value derived from the thing it is meant
+   to check. That shape is what made two silent miscompiles writable — a stage list validated
+   against axes derived from itself, and a body-replacing leaf that never checked the body."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.contraction-facts :as cf]
+            [raster.compiler.ir.axis-map :as am]))
+
+(def ^:private ma (am/of-groups '[[[i 4]] [[blk 4] [t 32]]]))
+(def ^:private mb (am/of-groups '[[[j 6]] [[blk 4] [t 32]]]))
+(def ^:private body
+  (list 'raster.numeric/* (list 'aget 'a (am/index-expr ma)) (list 'aget 'b (am/index-expr mb))))
+
+(defn- form [& opts]
+  (concat (list 'raster.par/contract 'out [['i 4] ['j 6]] [['blk 4] ['t 32]] body) opts))
+
+(deftest facts-come-from-the-forms-own-slots
+  (let [f (cf/contraction-facts (form) :dtype :byte)]
+    (testing "tagged, so a hand-built map cannot be substituted for a derivation"
+      (is (cf/facts? f))
+      (is (not (cf/facts? {:contract-axes '[[t 4]]}))))
+    (testing "axes come from the form's declaration slots"
+      (is (= '[[i 4] [j 6]] (:free-axes f)))
+      (is (= '[[blk 4] [t 32]] (:contract-axes f)))
+      (is (= 2 (:n-free f)))
+      (is (= 2 (:n-contract f))))
+    (testing "roles let a leaf state requirements without naming the user's symbols"
+      (is (= '{:free0 i :free1 j :contract0 blk :contract1 t} (:roles f)))
+      (is (= {:free0 4 :free1 6 :contract0 4 :contract1 32} (:dims f))))
+    (testing "operands are the body's aget reads"
+      (is (= '[a b] (mapv :sym (:operands f)))))))
+
+(deftest a-stage-list-cannot-supply-the-axes-it-is-checked-against
+  (testing "the form's contract axes are independent of its :stages — the two are separate slots,
+            so a stage list that under-covers cannot make itself look complete"
+    (let [f (cf/contraction-facts
+             (form :stages [{:axis 'blk :extent 4 :dtype :float :init 0.0 :lift 'inner}
+                            {:axis 't :extent 4 :dtype :int :init 0}])   ; 4, not 32
+             :dtype :byte)]
+      (is (= '[[blk 4] [t 32]] (:contract-axes f)) "from the form, not from the stages")
+      (is (= [4 4] (mapv :extent (:stages f))) "the stage list is carried verbatim, unmerged")
+      (is (not= (mapv second (:contract-axes f)) (mapv :extent (:stages f)))
+          "…so the mismatch is VISIBLE to a checker instead of being defined away"))))
+
+(deftest declarations-are-evidence-not-facts
+  (testing "a declared :maps entry is admitted only after it provably generates the actual index"
+    (let [f (cf/contraction-facts (form :maps {'a ma 'b mb}) :dtype :byte)]
+      (is (every? some? (map :map (:operands f))))))
+  (testing "a LYING declaration fails extraction — it does not quietly fall back to derivation"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"does not generate that operand's actual index"
+         (cf/contraction-facts (form :maps {'a (am/of-groups '[[[i 4]] [[t 32] [blk 4]]])})
+                               :dtype :byte))))
+  (testing "an undeclared operand simply has no map — absence is not a lie"
+    (let [f (cf/contraction-facts (form :maps {'a ma}) :dtype :byte)]
+      (is (some? (:map (first (:operands f)))))
+      (is (nil? (:map (second (:operands f))))))))
+
+(deftest body-product-is-the-requirement-a-body-replacing-leaf-carries
+  (testing "the exact product of the named operands"
+    (is (= '[a b] (mapv :sym (cf/body-product-of body '[a b])))))
+  (testing "an extra factor is NOT accounted for — this leaf would drop it silently"
+    (is (nil? (cf/body-product-of (list 'raster.numeric/* body (list 'aget 'mask 't)) '[a b]))))
+  (testing "…nor is a sum, nor a product of the wrong arity"
+    (is (nil? (cf/body-product-of (list 'raster.numeric/+ body) '[a b])))
+    (is (nil? (cf/body-product-of body '[a b c])))
+    (is (nil? (cf/body-product-of body '[a]))))
+  (testing "operator spelling does not matter (bare / clojure.core / raster.numeric)"
+    (is (some? (cf/body-product-of (list '* (list 'aget 'a 'x) (list 'aget 'b 'y)) '[a b])))))
+
+(deftest malformed-forms-are-refused
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not a par/contract form"
+                        (cf/contraction-facts '(raster.par/map! out i 4 body))))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"key/value pairs"
+                        (cf/contraction-facts (concat (form) [:dangling]))))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"free-axes must be a vector"
+                        (cf/contraction-facts (list 'raster.par/contract 'out '(i 4) [['l 8]] body)))))

--- a/test/raster/compiler/ir/contraction_facts_test.clj
+++ b/test/raster/compiler/ir/contraction_facts_test.clj
@@ -78,3 +78,51 @@
                         (cf/contraction-facts (concat (form) [:dangling]))))
   (is (thrown-with-msg? clojure.lang.ExceptionInfo #"free-axes must be a vector"
                         (cf/contraction-facts (list 'raster.par/contract 'out '(i 4) [['l 8]] body)))))
+
+;; ── leaf layout requirements as data rows, not three hand-written predicates ─────────
+(defn- mm-form [col-idx]
+  (list 'raster.par/contract 'C [['i 4] ['j 6]] [['l 8]]
+        (list 'raster.numeric/*
+              (list 'aget 'A (list 'clojure.core/+ (list 'clojure.core/* 'i 8) 'l))
+              (list 'aget 'B col-idx))))
+(def ^:private nn-idx '(clojure.core/+ (clojure.core/* l 6) j))   ; B[l,j]
+(def ^:private nt-idx '(clojure.core/+ (clojure.core/* j 8) l))   ; B[j,l] — K-contiguous
+
+(deftest orientation-is-a-data-row
+  (let [nn (cf/contraction-facts (mm-form nn-idx))
+        nt (cf/contraction-facts (mm-form nt-idx))]
+    (testing ":nn satisfies the dpas/quant row, not the dp4a row"
+      (is (:ok (cf/check-layout nn (:dpas cf/leaf-layouts))))
+      (is (:ok (cf/check-layout nn (:quant-naive cf/leaf-layouts))))
+      (is (= :layout (:reason (cf/check-layout nn (:dp4a cf/leaf-layouts))))))
+    (testing ":nt satisfies the dp4a row (both operands K-contiguous), not dpas"
+      (is (:ok (cf/check-layout nt (:dp4a cf/leaf-layouts))))
+      (is (= :layout (:reason (cf/check-layout nt (:dpas cf/leaf-layouts))))))
+    (testing "the two rows differ ONLY in the col operand's axis order"
+      (is (= [:free0 :contract0] (get-in cf/leaf-layouts [:dpas :row])
+                                 (get-in cf/leaf-layouts [:dp4a :row])))
+      (is (= [:contract0 :free1] (get-in cf/leaf-layouts [:dpas :col])))
+      (is (= [:free1 :contract0] (get-in cf/leaf-layouts [:dp4a :col]))))))
+
+(deftest role-assignment-is-by-verification-not-by-variance
+  (testing "operands written in the OTHER order still bind correctly — an operand is the row
+            operand because its index provably IS the row layout, not because of which axes it
+            mentions (which is what the variance heuristic tested)"
+    (let [swapped (cf/contraction-facts
+                   (list 'raster.par/contract 'C [['i 4] ['j 6]] [['l 8]]
+                         (list 'raster.numeric/*
+                               (list 'aget 'B nn-idx)
+                               (list 'aget 'A '(clojure.core/+ (clojure.core/* i 8) l)))))]
+      (is (= '{:row A :col B} (:bindings (cf/check-layout swapped (:dpas cf/leaf-layouts)))))))
+  (testing "a commuted index spelling binds too (one affine relation underneath)"
+    (let [commuted (cf/contraction-facts (mm-form '(clojure.core/+ j (clojure.core/* l 6))))]
+      (is (:ok (cf/check-layout commuted (:dpas cf/leaf-layouts))))))
+  (testing "a wrong operand count is named, not guessed at"
+    (let [three (cf/contraction-facts
+                 (list 'raster.par/contract 'C [['i 4] ['j 6]] [['l 8]]
+                       (list 'raster.numeric/* (list 'aget 'A 'l) (list 'aget 'B 'l)
+                                               (list 'aget 'D 'l))))]
+      (is (= :operand-count (:reason (cf/check-layout three (:dpas cf/leaf-layouts)))))))
+  (testing "check-layout refuses a hand-built map — it requires real facts"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (cf/check-layout {:operands [] :roles {}} (:dpas cf/leaf-layouts))))))


### PR DESCRIPTION
> Stacked on #87 (Phase A).

Phase A fixed two silent miscompiles by patching each gate. This removes the **shape** that made
them writable.

Both defects were the same mistake — *a gate handed a value derived from the very thing it was
meant to check*:

- `stages-legal?` received contract axes derived **from the stages**, so its span rule could never fire
- the dp4a gate verified operand maps but not the **body** — and that leaf discards the body

`ir/contraction-facts` is the single producer, and **its only input is the form**. A checker takes
facts and reads `:contract-axes` off the form's own declaration slot; there is no separately-computed
argument to pass inconsistently. Facts are **tagged** (`facts?`) so a hand-built map cannot be
substituted for a derivation.

## Declarations are evidence, not facts

A form may declare operand axis-maps (`:maps`) — that's what lets a merged or batched operand be
understood at all, since a derived map cannot guess grouping. But a declaration is admitted only
after `am/index-matches?` proves it generates the operand's **actual** index, and a failing
declaration **aborts extraction** rather than quietly falling back to derivation:

```clojure
(cf/contraction-facts (form :maps {'a <a-map-that-lies>}))
;; => throws :declared-map-does-not-match-the-body-index
```

Trusting a declared layout while having checked only its axis symbols is exactly how the transpose
retarget risked a miscompile.

## Shared requirement instead of a per-gate check

`body-product-of` moves *"a leaf that replaces the body must first account for all of it"* out of the
dp4a gate and into the IR layer, where the other body-replacing leaf (DPAS) can share it. Phase A's
inline version is deleted.

Also removes the sixth re-parse of the form's trailing options — `(apply hash-map (drop 5 form))`
appeared at six call sites, three of them inside a single `let`.

## Validation

45 contraction tests + 5 new facts tests, 0 failures. Cold-JVM load verified.

## Next (2/2)

The leaf-contracts **data table** + one verifier, so `:nn`/`:nt` become data rows
(`[:contract0 :free1]` vs `[:free1 :contract0]`) rather than three hand-written predicates; and the
**ABI datum** closing the *live* invoke↔descriptor bug where epilogue and lift operands are never
bound.