### PR TITLE
Phase C (1/3): close the epilogue-scalars hole; delete the unreachable tiled generator

### DIFF
--- a/bench/soac_contract_bench.clj
+++ b/bench/soac_contract_bench.clj
@@ -148,7 +148,7 @@
    (fn [m n k triple]
      ;; literal-dim kernel (dims baked in source ⇒ recompile per shape): params A B out.
      (let [sr (cl/contract-form->segred (matmul-form m n k) :dtype dtype)
-           {:keys [kernel-name source]} (sco/generate-tiled-contraction-kernel sr 'C :dtype dtype :tile tile)
+           {:keys [kernel-name source]} (sco/generate-regtiled-contraction-kernel sr 'C :dtype dtype :bm tile :bn tile :bk 16 :tm 1 :tn 1)
            {:keys [module kname]} (compile-src! [:block dtype tile m n k] kernel-name source)
            args [(:segment (:a triple)) (:segment (:b triple)) (:segment (:c triple))]]
        (bind! module kname [tile tile] args

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -455,58 +455,6 @@
 ;; declared here because the block-tiled emitter above it shares the same analysis.
 (declare analyze-contraction)
 
-(defn generate-tiled-contraction-kernel
-  "BLOCK-TILED + __local-staged contraction → OpenCL (Futhark BlkRegTiling, block-tile
-   level — no register/DPAS tiling yet). Square T×T tiles; workgroup = T×T threads (one
-   output/thread); cooperatively stage A/B tiles into __local, loop the contracted axis in
-   T-chunks. Zero-padded loads + a guarded store handle non-tile-divisible dims.
-
-   Prototype scope: EXACTLY 2 free axes (the tiled M×N output) + 1 contracted axis, LITERAL
-   dims, a sum-of-two-agets element (GEMM-shape redomap). The operands are assigned row/col
-   by which DECLARED axis their index depends on (row: free0+contract, not free1; col:
-   contract+free1, not free0) — the variance test made trivial by the declared axes, no
-   recognition. This is the perf substrate under DPAS tensorize (step 4).
-
-   Requires a 2-D launch: workgroup [T T], grid [ceil(N/T) ceil(M/T)] (group-id(0)=col/N,
-   group-id(1)=row/M). Returns {:kernel-name :source :array-params :dtype :tile :dims [M N L]}."
-  [segred out-sym & {:keys [dtype tile] :or {dtype :double tile 16}}]
-  (let [{:keys [M N L i-sym j-sym l-sym ctype init arr-params row-load col-load]}
-        (analyze-contraction segred dtype)
-        dtype (or (:dtype segred) dtype)
-        T (long tile)
-        i-c (ce/c-symbol i-sym) j-c (ce/c-symbol j-sym) l-c (ce/c-symbol l-sym)
-        kernel-name (str "tiled_contract_" (gensym ""))
-        arr-param-str (str/join ", " (map (fn [s] (str "__global const " ctype "* restrict " (ce/c-symbol s))) arr-params))
-        src (str (codegen/extension-pragmas dtype)
-                 "__kernel void " kernel-name "(" arr-param-str
-                 ", __global " ctype "* restrict out) {\n"
-                 "    __local " ctype " As[" T "][" T "];\n"
-                 "    __local " ctype " Bs[" T "][" T "];\n"
-                 "    int li = get_local_id(1);\n"
-                 "    int lj = get_local_id(0);\n"
-                 "    int " (ce/c-symbol i-sym) " = get_group_id(1) * " T " + li;\n"
-                 "    int " (ce/c-symbol j-sym) " = get_group_id(0) * " T " + lj;\n"
-                 "    " ctype " acc = " (str init) ";\n"
-                 "    for (int l0 = 0; l0 < " L "; l0 += " T ") {\n"
-                 "        { int " (ce/c-symbol l-sym) " = l0 + lj; As[li][lj] = ((" (ce/c-symbol i-sym) " < " M ") && (" (ce/c-symbol l-sym) " < " L ")) ? " row-load " : 0.0; }\n"
-                 "        { int " (ce/c-symbol l-sym) " = l0 + li; Bs[li][lj] = ((" (ce/c-symbol l-sym) " < " L ") && (" (ce/c-symbol j-sym) " < " N ")) ? " col-load " : 0.0; }\n"
-                 "        barrier(CLK_LOCAL_MEM_FENCE);\n"
-                 "        for (int t = 0; t < " T "; t++) { acc = acc + As[li][t] * Bs[t][lj]; }\n"
-                 "        barrier(CLK_LOCAL_MEM_FENCE);\n"
-                 "    }\n"
-                 "    if ((" (ce/c-symbol i-sym) " < " M ") && (" (ce/c-symbol j-sym) " < " N ")) { out[" (ce/c-symbol i-sym) " * " N " + " (ce/c-symbol j-sym) "] = acc; }\n"
-                 "}\n")]
-    {:kernel-name kernel-name
-     :source src
-     :array-params arr-params
-     :dtype dtype
-     :tile T
-     :dims [M N L]}))
-
-;; ================================================================
-;; Register-tiled + __local-staged contraction (BlkRegTiling, register level)
-;; ================================================================
-
 (defn- analyze-contraction
   "Shared structural analysis for the tiled contraction emitters. Prototype scope: 2 free
    axes + 1 contract, LITERAL dims, sum-of-two-agets element. Returns dims (M N L), axis
@@ -877,6 +825,12 @@
          ;; them from the descriptor would be a launch-arity bug (6 args bound to a 7-arg kernel).
          :epilogue-params (when ep (:epilogue-params ep))
          :epilogue-operands (when ep (mapv :sym (:operands epilogue)))
+         ;; …and its SCALARS. epilogue-splice has always emitted these into the signature, but
+         ;; nothing surfaced them, so any epilogue carrying a `:scalars` entry tripped
+         ;; validate-descriptor's scalar count and threw. That unusable capability is exactly why
+         ;; `:scheme` had to invent a private per-tensor scale channel instead of being an
+         ;; epilogue. Surfacing them makes the scale expressible where it belongs.
+         :epilogue-scalars (when ep (mapv :sym (:scalars epilogue)))
          ;; workgroup = (block-m/sg-m)·(block-n/sg-n) subgroups × the matrix subgroup size
          :workgroup [(* (quot (:block-m tile) (:sg-m tile))
                         (quot (:block-n tile) (:sg-n tile))

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -86,7 +86,7 @@
 
    Returns the descriptor unchanged when consistent."
   [{:keys [strategy kernel-name source array-params scalar-args epilogue-operands lift-operands
-           out-elems wg grid invoke reduce-bound] :as d}]
+           epilogue-scalars out-elems wg grid invoke reduce-bound] :as d}]
   (let [params (kernel-signature-params source)
         _ (when (nil? params)
             (throw (ex-info "contract descriptor: no __kernel signature found in source"
@@ -103,7 +103,12 @@
         ;;                           so they must match the kernel's scalar params exactly.
         ;;   :invoke :reduction    — invoke-reduction-kernel supplies the kernel's single trailing
         ;;                           count param itself, from :reduce-bound; :scalar-args stays empty.
-        expect-scalar (if (= :reduction invoke) 1 (count scalar-args))]
+        ;; an epilogue's SCALARS are kernel scalar params too — they are emitted into the
+        ;; signature by epilogue-splice, so a descriptor that omits them under-counts and the
+        ;; capability becomes unusable (which is what pushed `:scheme` into a private channel)
+        expect-scalar (if (= :reduction invoke)
+                        1
+                        (+ (count scalar-args) (count epilogue-scalars)))]
     (cond
       (not= n-ptr expect-ptr)
       (throw (ex-info (str "contract descriptor: kernel takes " n-ptr " pointer params but the "

--- a/test/raster/compiler/backend/gpu/tiled_contract_device_test.clj
+++ b/test/raster/compiler/backend/gpu/tiled_contract_device_test.clj
@@ -31,36 +31,6 @@
     (MemorySegment/copy (MemorySegment/ofArray arr) 0 seg 0 nbytes)
     [seg nbytes]))
 
-(defn- run-tiled
-  "Emit the tiled kernel for m×n×k, launch on device, return the output vector."
-  [m k n]
-  (let [ze (find-ns 'raster.gpu.ze-runtime)
-        register! (ns-resolve ze 'register-kernel!)
-        ensure-loaded! (ns-resolve ze 'ensure-kernel-loaded!)
-        alloc (ns-resolve ze 'alloc-shared)
-        launch-2d! (ns-resolve ze 'launch-2d!)
-        A (double-array (map double (range (* m k))))
-        B (double-array (map #(* 0.5 (double %)) (range (* k n))))
-        form (list 'raster.par/contract 'C [['i m] ['j n]] [['l k]]
-                   (list '* (list 'aget 'A (list '+ (list '* 'i k) 'l))
-                         (list 'aget 'B (list '+ (list '* 'l n) 'j))))
-        sr (cl/contract-form->segred form)
-        {:keys [kernel-name source tile]} (sco/generate-tiled-contraction-kernel sr 'C)
-        _ (register! kernel-name {:source source :dtype :double})
-        {:keys [kernel-handle]} (ensure-loaded! kernel-name)
-        [aseg _] (upload! A)
-        [bseg _] (upload! B)
-        out-bytes (* m n 8)
-        oseg (alloc out-bytes)
-        T (long tile)
-        gcx (long (Math/ceil (/ (double n) T)))   ; columns / N
-        gcy (long (Math/ceil (/ (double m) T)))]  ; rows / M
-    ;; args order = sorted inputs [A B] then out
-    (launch-2d! kernel-handle [T T] [gcx gcy] [aseg bseg oseg])
-    (let [out (double-array (* m n))]
-      (MemorySegment/copy oseg 0 (MemorySegment/ofArray out) 0 out-bytes)
-      {:gpu (vec out) :cpu (vec (ref-matmul A B m k n))})))
-
 (defn- run-regtiled
   "Emit the register-tiled kernel for m×n×k, launch on device, return {:gpu :cpu}."
   [m k n]
@@ -96,20 +66,9 @@
   (and (= (count xs) (count ys))
        (every? true? (map (fn [a b] (< (Math/abs (- (double a) (double b))) 1.0e-9)) xs ys))))
 
-(deftest tiled-contraction-matches-cpu-on-device
-  (if-not @gpu?
-    (println "[skip] tiled-contraction-device: no GPU device available")
-    (do
-      (testing "tile-divisible dims (32×32×32)"
-        (let [{:keys [gpu cpu]} (run-tiled 32 32 32)]
-          (is (approx-eq? gpu cpu) (str "divisible: GPU " (take 4 gpu) " vs CPU " (take 4 cpu)))))
-      (testing "non-divisible dims (30×24×20) — boundary padding path"
-        (let [{:keys [gpu cpu]} (run-tiled 30 24 20)]
-          (is (approx-eq? gpu cpu) (str "boundary: GPU " (take 4 gpu) " vs CPU " (take 4 cpu)))))
-      (testing "skewed dims (17×48×5)"
-        (let [{:keys [gpu cpu]} (run-tiled 17 48 5)]
-          (is (approx-eq? gpu cpu) "skewed"))))))
-
+;; NB the block-tiled generator this namespace also covered is gone — it was unreachable from
+;; route-contraction and strictly a `regtiled` with tm=tn=1, so its cases (non-tile-divisible dims,
+;; tiny dims) are carried by the regtiled deftest below rather than by a second emitter.
 (deftest regtiled-contraction-matches-cpu-on-device
   (if-not @gpu?
     (println "[skip] regtiled-contraction-device: no GPU device available")

--- a/test/raster/compiler/ir/contraction_facts_test.clj
+++ b/test/raster/compiler/ir/contraction_facts_test.clj
@@ -126,3 +126,28 @@
   (testing "check-layout refuses a hand-built map — it requires real facts"
     (is (thrown? clojure.lang.ExceptionInfo
                  (cf/check-layout {:operands [] :roles {}} (:dpas cf/leaf-layouts))))))
+
+;; ── anti-drift: the data table and the predicate it will replace must AGREE ──────────
+;; `check-layout` is not yet consumed by the gates. That is deliberate — four of the six
+;; orientation call sites live in the quant and dp4a generators, which the next increment deletes
+;; outright, and wiring only the fifth (dpas) would create a dual path. But an unconsumed
+;; capability is how this subsystem drifted in the first place, so the equivalence is PINNED here:
+;; if the table and the live predicate ever disagree on a case, this fails.
+(deftest table-agrees-with-the-live-orientation-gate
+  (let [cases [[:nn nn-idx :dpas true] [:nn nn-idx :dp4a false]
+               [:nt nt-idx :dp4a true] [:nt nt-idx :dpas false]]
+        gate (requiring-resolve 'raster.compiler.backend.gpu.segop-opencl/dpas-contraction-legal?)
+        lower (requiring-resolve 'raster.compiler.passes.parallel.contract-lower/contract-form->segred)]
+    (doseq [[label idx leaf expected] cases]
+      (testing (str label " under " leaf)
+        (is (= expected (boolean (:ok (cf/check-layout (cf/contraction-facts (mm-form idx))
+                                                       (get cf/leaf-layouts leaf)))))
+            "table verdict")))
+    (testing "and the live DPAS gate reaches the same orientation verdict the table does"
+      ;; f64 so the gate's own dtype requirement does not mask the orientation decision
+      (let [nn-sr (lower (mm-form nn-idx) :dtype :half)
+            nt-sr (lower (mm-form nt-idx) :dtype :half)]
+        (is (not= :non-canonical-orientation (:reason (gate nn-sr :half)))
+            ":nn is orientation-legal for dpas (it may still fail on pitch alignment)")
+        (is (= :non-canonical-orientation (:reason (gate nt-sr :half)))
+            ":nt is orientation-ILLEGAL for dpas — same verdict the table gives")))))


### PR DESCRIPTION
Two small things that unblock the rest of Phase C, plus an anti-drift guard on #88's table.

## The hole that made `:scheme` necessary

`epilogue-splice` has always emitted an epilogue's `:scalars` into the kernel signature, but **no
descriptor surfaced them** — so any epilogue carrying a scalar tripped `validate-descriptor`'s
scalar count and threw. The capability existed and was unusable, which is exactly why `:scheme` had
to invent a private per-tensor scale channel instead of a scale being an ordinary epilogue.

`:epilogue-scalars` is now surfaced and counted. That makes a per-tensor scale expressible where it
belongs — and because an epilogue operand carries an axis-map, **per-row and per-column scales fall
out for free**, which `:scheme` could never express. Deleting `:scheme` is increment 2, once the two
quant leaves it serves are gone.

## Delete `generate-tiled-contraction-kernel` (52 lines)

Unreachable from `route-contraction`, and strictly a `regtiled` with `tm=tn=1`. Its only callers
were one device test and one bench row — and the test namespace already had a `run-regtiled` sibling
covering the same shapes, so the dead half is removed rather than ported twice.

## Anti-drift on the leaf-layouts table

`check-layout` from #88 is **not yet consumed by the gates**, and that is deliberate: four of the six
orientation call sites live in the quant and dp4a generators that increment 2 deletes outright, and
wiring only the fifth (dpas) would create a dual path.

But an unconsumed capability is how this subsystem drifted in the first place — so rather than leave
that unstated, the equivalence is **pinned by test**: the table and the live DPAS gate must reach the
same orientation verdict for `:nn` and `:nt`, and disagreement fails the suite.

## Validation

107 contraction tests / 616 assertions, 0 failures. Cold-JVM load verified.

## Remaining in Phase C

2. Delete `:scheme`; collapse the quant + dp4a generators into the staged emitter (the staged
   emitter with one level already emits that exact dp4a loop) — and consume `check-layout` on the way.
3. Collapse `segmented-reduce` + `segmap-nd` into the same emitter (0 or 1 contract level).