### PR TITLE
Phase C: delete :scheme and collapse the quant leaves into the staged emitter

### DIFF
--- a/bench/soac_contract_bench.clj
+++ b/bench/soac_contract_bench.clj
@@ -148,7 +148,7 @@
    (fn [m n k triple]
      ;; literal-dim kernel (dims baked in source ⇒ recompile per shape): params A B out.
      (let [sr (cl/contract-form->segred (matmul-form m n k) :dtype dtype)
-           {:keys [kernel-name source]} (sco/generate-tiled-contraction-kernel sr 'C :dtype dtype :tile tile)
+           {:keys [kernel-name source]} (sco/generate-regtiled-contraction-kernel sr 'C :dtype dtype :bm tile :bn tile :bk 16 :tm 1 :tn 1)
            {:keys [module kname]} (compile-src! [:block dtype tile m n k] kernel-name source)
            args [(:segment (:a triple)) (:segment (:b triple)) (:segment (:c triple))]]
        (bind! module kname [tile tile] args

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -841,122 +841,6 @@
 ;; QUANT (int8) contraction — the SAME skeleton, WIDENING facet
 ;; ================================================================
 
-(defn generate-quant-contraction-kernel
-  "QUANT contraction → OpenCL. The SAME SegRed skeleton as the f16/f64 ladder — nothing
-   structurally new — carrying the facets a quantized matmul adds:
-     • WIDENING accumulate — int8 operands, int32 accumulator (int8's key op is widening, not
-       same-width: char×char must not accumulate in char);
-     • a DECODE SCHEME on the operands + a dequant EPILOGUE.
-
-   TYPES ARE GENERIC, not quant-specific: the operand dtype is :byte (=int8, `int8_t`), the
-   accumulate dtype :int (=int32), the output :float — all pulled from the ONE dtype facet
-   map (dtype-info), so widening is just a dtype PAIR, not a special type. What IS quant-
-   specific is the `scheme` — a DECODE descriptor (scale, per-operand zero-point; extensible
-   to block-size / q4 packing) that is NOT a native dtype (q8_0/q4_k have no C type; they
-   decode to int + scale). It generates the operand decode + the dequant epilogue:
-       out = scale · Σ_l (A[i,l] − a-zp)·(B[l,j] − b-zp)
-   (symmetric per-tensor int8 ⇒ zero-points 0). This decode scheme IS the operand load-lambda
-   — the same slot the register-tiled path can fuse (the fusion frontier). The dp4a / int8-
-   DPAS packed dot is the tensorize LEAF (perf layer, analogous to f16's DPAS); this is the
-   NAIVE correctness substrate. Canonical row-major orientation only (reuses analyze-
-   contraction + the DPAS gate's orientation check).
-
-   scheme: {:scale s (default 1.0), :a-zp z (0), :b-zp z (0)}."
-  [segred out-sym & {:keys [scheme] :or {scheme {}}}]
-  (let [{:keys [scale a-zp b-zp] :or {scale 1.0 a-zp 0 b-zp 0}} scheme
-        {:keys [M N L i-sym j-sym l-sym row-arr col-arr row-idx col-idx]}
-        (analyze-contraction segred :byte)
-        _ (when-not (canonical-rowmajor? row-idx i-sym L l-sym)
-            (throw (ex-info "quant: row operand must be [M,K] row-major"
-                            {:reason :non-canonical-row :idx row-idx})))
-        _ (when-not (canonical-rowmajor? col-idx l-sym N j-sym)
-            (throw (ex-info "quant: col operand must be [K,N] row-major"
-                            {:reason :non-canonical-col :idx col-idx})))
-        ;; C types from the ONE dtype facet map — generic int8/int32/float, not quant types.
-        op-ctype  (get codegen/opencl-type-map :byte)   ; int8 storage (int8_t; signed)
-        acc-ctype (get codegen/opencl-type-map :int)    ; int32 widening accumulate
-        out-ctype (get codegen/opencl-type-map :float)  ; dequant output
-        A (ce/c-symbol row-arr) B (ce/c-symbol col-arr)
-        ;; per-operand decode = widen to acc dtype, then subtract zero-point (the load-lambda)
-        decode (fn [arr idx zp]
-                 (let [w (str "(" acc-ctype ")" arr "[" idx "]")]
-                   (if (zero? zp) w (str "(" w " - " zp ")"))))
-        a-term (decode A (str "i * " L " + l") a-zp)
-        b-term (decode B (str "l * " N " + j") b-zp)
-        kernel-name (str "quant_contract_" (gensym ""))
-        src (str "__kernel void " kernel-name "(__global const " op-ctype "* restrict " A
-                 ", __global const " op-ctype "* restrict " B
-                 ", __global " out-ctype "* restrict out, " out-ctype " scale, int _nseg) {\n"
-                 "    int seg = get_global_id(0);\n"
-                 "    if (seg >= _nseg) return;\n"
-                 "    int i = (seg / " N ") % " M ";\n"
-                 "    int j = seg % " N ";\n"
-                 "    " acc-ctype " acc = 0;\n"              ; WIDENING: int32 accumulator
-                 "    for (int l = 0; l < " L "; l++) {\n"
-                 "        acc += " a-term " * " b-term ";\n" ; decode + widening MAC
-                 "    }\n"
-                 "    out[seg] = scale * (" out-ctype ")acc;\n"   ; dequant epilogue
-                 "}\n")]
-    {:kernel-name kernel-name :source src
-     :array-params [row-arr col-arr]
-     :dtype :byte :acc-dtype :int :out-dtype :float
-     :scheme (merge {:scale scale :a-zp a-zp :b-zp b-zp} scheme)
-     :dims [M N L]}))
-
-(defn generate-dp4a-contraction-kernel
-  "DP4A-tensorized int8 contraction → OpenCL — the int8 PEAK LEAF (analogous to f16's DPAS
-   leaf). Uses the dp4a int8×4 dot-accumulate primitive (rstr_dp4a: 4 int8 MACs into an int32
-   in one op; native dp4a is a drop-in). This is where int8 quant reaches peak, the same way
-   generate-dpas-contraction-kernel is f16's peak.
-
-   PER-LEAF LAYOUT REQUIREMENT: dp4a packs 4 int8 along the contract axis into a 32-bit word,
-   so BOTH operands must be K-contiguous. A[M,K] row-major is (A[i,l]=i·K+l, K contiguous);
-   B must therefore be [N,K] TRANSPOSED (B[j,l]=j·K+l) — the :nt orientation, DIFFERENT from
-   f16-DPAS's :nn. The required operand layout is a property of the TENSORIZE LEAF, not the
-   contraction — the gate dispatches (dtype, leaf) → layout. K must be a multiple of 4.
-
-   Operands are reinterpreted at launch as int[] (4 packed int8 per int; the USM bytes are
-   identical to the int8 buffer). Symmetric quant only for now (zero-points fold into a
-   correction term — future). scheme: {:scale s}."
-  [segred out-sym & {:keys [scheme] :or {scheme {}}}]
-  (let [{:keys [scale a-zp b-zp] :or {scale 1.0 a-zp 0 b-zp 0}} scheme
-        {:keys [M N L i-sym j-sym l-sym row-arr col-arr row-idx col-idx]}
-        (analyze-contraction segred :byte)
-        _ (when-not (zero? (mod L 4))
-            (throw (ex-info "dp4a: K must be a multiple of 4" {:reason :k-not-mult-4 :K L})))
-        _ (when-not (canonical-rowmajor? row-idx i-sym L l-sym)
-            (throw (ex-info "dp4a: row operand must be [M,K] row-major" {:reason :non-canonical-row})))
-        _ (when-not (canonical-rowmajor? col-idx j-sym L l-sym)
-            (throw (ex-info "dp4a: col operand must be [N,K] (K-contiguous)" {:reason :non-nt-orientation})))
-        _ (when-not (and (zero? a-zp) (zero? b-zp))
-            (throw (ex-info "dp4a: symmetric quant only" {:reason :asymmetric-zp})))
-        A (ce/c-symbol row-arr) B (ce/c-symbol col-arr)
-        KP (quot L 4)                            ; packed contract length (int8×4 words)
-        acc-ctype (get codegen/opencl-type-map :int)
-        out-ctype (get codegen/opencl-type-map :float)
-        helper (:c-helper-src (intrinsics/descriptor 'dp4a))
-        kernel-name (str "dp4a_contract_" (gensym ""))
-        src (str helper
-                 "__kernel void " kernel-name "(__global const int* restrict " A
-                 ", __global const int* restrict " B
-                 ", __global " out-ctype "* restrict out, " out-ctype " scale, int _nseg) {\n"
-                 "    int seg = get_global_id(0);\n"
-                 "    if (seg >= _nseg) return;\n"
-                 "    int i = (seg / " N ") % " M ";\n"
-                 "    int j = seg % " N ";\n"
-                 "    " acc-ctype " acc = 0;\n"
-                 "    for (int p = 0; p < " KP "; p++) {\n"
-                 "        acc = rstr_dp4a(" A "[i * " KP " + p], " B "[j * " KP " + p], acc);\n"
-                 "    }\n"
-                 "    out[seg] = scale * (" out-ctype ")acc;\n"
-                 "}\n")]
-    {:kernel-name kernel-name :source src
-     :array-params [row-arr col-arr]
-     :dtype :byte :acc-dtype :int :out-dtype :float :packed :int8x4
-     :scheme (merge {:scale scale :a-zp a-zp :b-zp b-zp} scheme)
-     :dims [M N L]}))
-
-;; ── staged (multi-level) contraction ────────────────────────────────────────────────
 (defn- flat-decompose-c
   "C declarations recovering each free index from the flat segment id `seg`, row-major:
    idx_p = (seg / Π bounds-after-p) % bound_p, with the innermost simplifying to `seg % bound`.
@@ -1064,7 +948,8 @@
             :lift-operands}. :array-params is the body's inputs; :lift-operands are the EXTRA
    scale arrays, bound after them — surfaced because omitting them from a launch descriptor is
    an arity bug (the signature has them either way)."
-  [{:keys [free-axes stages body inputs dtype out-dtype operands tensorize-inner? contract-axes]
+  [{:keys [free-axes stages body inputs dtype out-dtype operands tensorize-inner? contract-axes
+           epilogue]
     :or {dtype :float out-dtype :float} :as spec} out-sym]
   (let [;; The stage list is checked against the axes the FORM DECLARED, never against axes derived
         ;; from the stages themselves. Deriving them made the span rule unfireable, and a stage list
@@ -1104,6 +989,30 @@
                          ce/*int-vars* (into ce/*int-vars* int-vars)]
                  (ce/emit-expr expr (gensym "z__") arr-syms)))
         acc-name (fn [d] (str "acc_" d))
+        ;; PER-OPERAND DECODE — the load-lambda. `:decode` is an expression in `x`, standing for the
+        ;; raw load, applied to that operand's every read. This is where a zero-point subtraction
+        ;; belongs: `Σ(a-za)(b-zb)` is exact on the load path and needs no correction reductions,
+        ;; whereas a per-tensor SCALE factors out of the sum entirely and belongs in the epilogue.
+        ;; WIDENING is deliberately NOT expressed here — it is the dtype PAIR (operand dtype +
+        ;; accumulator dtype), and hiding it in a lambda would blind the tensorize gate to the very
+        ;; pair it dispatches on.
+        decodes (into {} (keep (fn [{:keys [sym decode]}] (when decode [sym decode]))) operands)
+        body (if (empty? decodes)
+               body
+               (walk/postwalk
+                (fn [f] (if (and (seq? f) (= 'aget (first f)) (contains? decodes (second f)))
+                          (walk/postwalk-replace {'x f} (get decodes (second f)))
+                          f))
+                body))
+        ;; EPILOGUE — the store splice. An epilogue is a lift on a virtual outermost level of
+        ;; extent 1, which is why it needs no linearity (nothing to distribute over one iteration)
+        ;; while a real stage lift does. Gives this emitter the dequant scale that the two quant
+        ;; leaves hardwired into their store lines.
+        ep (when epilogue
+             (when-not (= 2 (count free-axes))
+               (throw (ex-info "staged contraction: an epilogue needs exactly 2 free axes (the store slot binds row/col)"
+                               {:reason :epilogue-needs-2-free :n-free (count free-axes)})))
+             (epilogue-splice epilogue (mapv first free-axes) (or (:dtype epilogue) out-dtype)))
         ;; innermost accumulates the body; each outer accumulates its lift with `inner` bound to
         ;; the accumulator one level down. Built inside-out.
         n (count stages)
@@ -1156,18 +1065,30 @@
                     (apply str (for [{:keys [sym dtype] :or {dtype :float}} lift-ops]
                                  (str ", __global const " (dt/ctype :opencl dtype)
                                       "* restrict " (ce/c-symbol sym))))
-                    ", __global " out-ctype "* restrict out, int _nseg")
+                    ", __global " out-ctype "* restrict out"
+                    (when ep (:epilogue-params ep))
+                    ", int _nseg")
         src (str (when tz (:c-helper-src (intrinsics/descriptor 'dp4a)))
+                 (when ep (:epilogue-helpers ep))
                  "__kernel void " kernel-name "(" params ") {\n"
                  "    int seg = get_global_id(0);\n"
                  "    if (seg >= _nseg) return;\n"
                  (flat-decompose-c free-axes) "\n"
                  nest
-                 "    out[seg] = (" out-ctype ")" (acc-name 0) ";\n"
+                 "    out[seg] = "
+                 (let [acc (str "(" out-ctype ")" (acc-name 0))]
+                   (if ep
+                     ((:epilogue ep) acc
+                      (ce/c-symbol (first (first free-axes)))
+                      (ce/c-symbol (first (second free-axes))))
+                     acc))
+                 ";\n"
                  "}\n")]
     {:kernel-name kernel-name :source src
      :array-params (vec inputs)
      :lift-operands (mapv :sym lift-ops)
+     :epilogue-operands (when ep (mapv :sym (:operands epilogue)))
+     :epilogue-scalars (when ep (mapv :sym (:scalars epilogue)))
      :dtype dtype :out-dtype out-dtype
      :stages stages
      ;; the operand buffers are BOUND unchanged; only the kernel's view of them widens

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -455,58 +455,6 @@
 ;; declared here because the block-tiled emitter above it shares the same analysis.
 (declare analyze-contraction)
 
-(defn generate-tiled-contraction-kernel
-  "BLOCK-TILED + __local-staged contraction → OpenCL (Futhark BlkRegTiling, block-tile
-   level — no register/DPAS tiling yet). Square T×T tiles; workgroup = T×T threads (one
-   output/thread); cooperatively stage A/B tiles into __local, loop the contracted axis in
-   T-chunks. Zero-padded loads + a guarded store handle non-tile-divisible dims.
-
-   Prototype scope: EXACTLY 2 free axes (the tiled M×N output) + 1 contracted axis, LITERAL
-   dims, a sum-of-two-agets element (GEMM-shape redomap). The operands are assigned row/col
-   by which DECLARED axis their index depends on (row: free0+contract, not free1; col:
-   contract+free1, not free0) — the variance test made trivial by the declared axes, no
-   recognition. This is the perf substrate under DPAS tensorize (step 4).
-
-   Requires a 2-D launch: workgroup [T T], grid [ceil(N/T) ceil(M/T)] (group-id(0)=col/N,
-   group-id(1)=row/M). Returns {:kernel-name :source :array-params :dtype :tile :dims [M N L]}."
-  [segred out-sym & {:keys [dtype tile] :or {dtype :double tile 16}}]
-  (let [{:keys [M N L i-sym j-sym l-sym ctype init arr-params row-load col-load]}
-        (analyze-contraction segred dtype)
-        dtype (or (:dtype segred) dtype)
-        T (long tile)
-        i-c (ce/c-symbol i-sym) j-c (ce/c-symbol j-sym) l-c (ce/c-symbol l-sym)
-        kernel-name (str "tiled_contract_" (gensym ""))
-        arr-param-str (str/join ", " (map (fn [s] (str "__global const " ctype "* restrict " (ce/c-symbol s))) arr-params))
-        src (str (codegen/extension-pragmas dtype)
-                 "__kernel void " kernel-name "(" arr-param-str
-                 ", __global " ctype "* restrict out) {\n"
-                 "    __local " ctype " As[" T "][" T "];\n"
-                 "    __local " ctype " Bs[" T "][" T "];\n"
-                 "    int li = get_local_id(1);\n"
-                 "    int lj = get_local_id(0);\n"
-                 "    int " (ce/c-symbol i-sym) " = get_group_id(1) * " T " + li;\n"
-                 "    int " (ce/c-symbol j-sym) " = get_group_id(0) * " T " + lj;\n"
-                 "    " ctype " acc = " (str init) ";\n"
-                 "    for (int l0 = 0; l0 < " L "; l0 += " T ") {\n"
-                 "        { int " (ce/c-symbol l-sym) " = l0 + lj; As[li][lj] = ((" (ce/c-symbol i-sym) " < " M ") && (" (ce/c-symbol l-sym) " < " L ")) ? " row-load " : 0.0; }\n"
-                 "        { int " (ce/c-symbol l-sym) " = l0 + li; Bs[li][lj] = ((" (ce/c-symbol l-sym) " < " L ") && (" (ce/c-symbol j-sym) " < " N ")) ? " col-load " : 0.0; }\n"
-                 "        barrier(CLK_LOCAL_MEM_FENCE);\n"
-                 "        for (int t = 0; t < " T "; t++) { acc = acc + As[li][t] * Bs[t][lj]; }\n"
-                 "        barrier(CLK_LOCAL_MEM_FENCE);\n"
-                 "    }\n"
-                 "    if ((" (ce/c-symbol i-sym) " < " M ") && (" (ce/c-symbol j-sym) " < " N ")) { out[" (ce/c-symbol i-sym) " * " N " + " (ce/c-symbol j-sym) "] = acc; }\n"
-                 "}\n")]
-    {:kernel-name kernel-name
-     :source src
-     :array-params arr-params
-     :dtype dtype
-     :tile T
-     :dims [M N L]}))
-
-;; ================================================================
-;; Register-tiled + __local-staged contraction (BlkRegTiling, register level)
-;; ================================================================
-
 (defn- analyze-contraction
   "Shared structural analysis for the tiled contraction emitters. Prototype scope: 2 free
    axes + 1 contract, LITERAL dims, sum-of-two-agets element. Returns dims (M N L), axis
@@ -877,6 +825,12 @@
          ;; them from the descriptor would be a launch-arity bug (6 args bound to a 7-arg kernel).
          :epilogue-params (when ep (:epilogue-params ep))
          :epilogue-operands (when ep (mapv :sym (:operands epilogue)))
+         ;; …and its SCALARS. epilogue-splice has always emitted these into the signature, but
+         ;; nothing surfaced them, so any epilogue carrying a `:scalars` entry tripped
+         ;; validate-descriptor's scalar count and threw. That unusable capability is exactly why
+         ;; `:scheme` had to invent a private per-tensor scale channel instead of being an
+         ;; epilogue. Surfacing them makes the scale expressible where it belongs.
+         :epilogue-scalars (when ep (mapv :sym (:scalars epilogue)))
          ;; workgroup = (block-m/sg-m)·(block-n/sg-n) subgroups × the matrix subgroup size
          :workgroup [(* (quot (:block-m tile) (:sg-m tile))
                         (quot (:block-n tile) (:sg-n tile))

--- a/src/raster/compiler/ir/contraction_facts.clj
+++ b/src/raster/compiler/ir/contraction_facts.clj
@@ -79,9 +79,14 @@
         _ (when-not (vector? contract-axes)
             (throw (ex-info "contract form: contract-axes must be a vector" {:reason :malformed-contract-axes})))
         declared (:maps opts)
+        ;; `:decode` is the per-operand LOAD-LAMBDA, an expression in `x` (the raw load). This is
+        ;; where a zero-point subtraction belongs — exact on the load path, needing no correction
+        ;; reductions — whereas a scale that factors out of the sum belongs in the epilogue.
+        decode (:decode opts)
         terms (mapv (fn [{:keys [sym idx]}]
-                      {:sym sym :idx idx
-                       :map (verify-declared-map sym (get declared sym) idx)})
+                      (cond-> {:sym sym :idx idx
+                               :map (verify-declared-map sym (get declared sym) idx)}
+                        (get decode sym) (assoc :decode (get decode sym))))
                     (aget-terms body))
         ;; role → axis symbol, so a leaf contract can say [:free0 :contract0] instead of naming
         ;; the user's own symbols
@@ -189,3 +194,17 @@
           {:ok false :reason :layout
            :required (into {} (map (fn [r] [r (am/index-expr (role-map facts (get required r)))])) roles)
            :actual (mapv (juxt :sym :idx) ops)})))))
+
+(defn layout-maps
+  "For a PASSING `check-layout` verdict, the axis-map of each operand — derived from the layout the
+   verdict proved, keyed by operand symbol.
+
+   This is how a tensorize leaf gets its operand maps without a caller declaring them. The map is
+   verified by construction: `check-layout` only returns bindings after `am/index-matches?` proves
+   each operand's actual index equals the required layout's. So the leaf gets the strongest form of
+   what it needs — a layout that was checked, not asserted — and a form need not carry `:maps` just
+   to reach a peak leaf."
+  [facts required verdict]
+  (when (:ok verdict)
+    (into {} (map (fn [[role sym]] [sym (role-map facts (get required role))]))
+          (:bindings verdict))))

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -86,7 +86,7 @@
 
    Returns the descriptor unchanged when consistent."
   [{:keys [strategy kernel-name source array-params scalar-args epilogue-operands lift-operands
-           out-elems wg grid invoke reduce-bound] :as d}]
+           epilogue-scalars out-elems wg grid invoke reduce-bound] :as d}]
   (let [params (kernel-signature-params source)
         _ (when (nil? params)
             (throw (ex-info "contract descriptor: no __kernel signature found in source"
@@ -103,7 +103,12 @@
         ;;                           so they must match the kernel's scalar params exactly.
         ;;   :invoke :reduction    — invoke-reduction-kernel supplies the kernel's single trailing
         ;;                           count param itself, from :reduce-bound; :scalar-args stays empty.
-        expect-scalar (if (= :reduction invoke) 1 (count scalar-args))]
+        ;; an epilogue's SCALARS are kernel scalar params too — they are emitted into the
+        ;; signature by epilogue-splice, so a descriptor that omits them under-counts and the
+        ;; capability becomes unusable (which is what pushed `:scheme` into a private channel)
+        expect-scalar (if (= :reduction invoke)
+                        1
+                        (+ (count scalar-args) (count epilogue-scalars)))]
     (cond
       (not= n-ptr expect-ptr)
       (throw (ex-info (str "contract descriptor: kernel takes " n-ptr " pointer params but the "

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -155,9 +155,10 @@
    dtype selects the element type of the intended kernel (:half tries DPAS; :byte/:int8 tries
    the int8 quant leaves — dp4a for the :nt operand layout, quant naive-widening for :nn;
    anything else, or a gate rejection, falls back to the register-tiled portable kernel).
-   scheme = the quant decode descriptor {:scale :a-zp :b-zp} for int8 (default {:scale 1.0})."
-  [contract-form & {:keys [dtype scheme prefer-peak? desc tile epilogue stages operands]
-                    :or {dtype :half scheme {:scale 1.0} prefer-peak? false}}]
+   int8 needs no decode descriptor: a scale is an ordinary :epilogue and a zero-point an ordinary
+   per-operand :decode, both carried on the form like any other contraction data."
+  [contract-form & {:keys [dtype prefer-peak? desc tile epilogue stages operands]
+                    :or {dtype :half prefer-peak? false}}]
   (let [out-sym (second contract-form)
         free-axes (nth contract-form 2)
         contract-axes (nth contract-form 3)
@@ -225,7 +226,7 @@
 
       ;; int8 → the quant leaves (dp4a for :nt, quant naive-widening for :nn)
       (#{:byte :int8} dtype)
-      (route-quant contract-form out-sym scheme n-free n-contract nseg prefer-peak?)
+      (route-quant contract-form out-sym n-free n-contract nseg prefer-peak?)
 
       ;; 0 FREE axes → a full reduction to a scalar. This is the last cell of contract's
       ;; algebra: (n free, 0 contract) = map, (n, n) = contraction, (0, n) = REDUCTION. The
@@ -323,20 +324,6 @@
          :dims (:dims rt)})))
    (catch clojure.lang.ExceptionInfo _ nil)))
 
-(defn- quant-descriptor
-  "A launch descriptor for an int8 quant leaf (dp4a or quant-naive). Both are 1-D kernels with
-   signature (…arrays…, out(f32), float scale, int _nseg): int8 operands in, dequantized f32 out."
-  [strategy k out-dtype scale nseg]
-  {:strategy strategy
-   :kernel-name (:kernel-name k) :source (:source k)
-   :array-params (:array-params k)          ; [row col] binding order (dp4a) / sorted (quant)
-   :dtype :byte :out-dtype out-dtype
-   :scheme (:scheme k)
-   :wg [256 1] :grid [(ceil-div nseg 256) 1]
-   :scalar-args [{:type :float :value (float scale)} {:type :int :value nseg}]
-   :out-elems nseg
-   :dims (:dims k)})
-
 (defn- operand-map
   "The declared axis-map for `arr` if the form carries :maps, else DERIVE one by checking the
    aget index against the canonical row-major layout for `expected-axes`. Returns nil when the
@@ -385,49 +372,92 @@
                 ;; genuine 2-D group transposition
                 (when (and cmap (am/transposed-2d? cmap want))
                   (let [col-t (gensym (str (name col-arr) "__t"))
-                        new-body (list '* row (list 'aget col-t (am/index-expr want)))]
-                    {:form (list 'raster.par/contract out free-axes contract-axes new-body
-                                 :maps (assoc (get (apply hash-map (drop 5 contract-form)) :maps {})
-                                              col-t want))
+                        new-body (list '* row (list 'aget col-t (am/index-expr want)))
+                        ;; PRESERVE THE FORM'S OPTS. Rebuilding with only :maps silently dropped
+                        ;; :epilogue, :decode, :init, :combine and :out-dtype — so a retargeted
+                        ;; contraction lost its scale (wrong by a constant factor), and a
+                        ;; `:combine max` became a sum. Carry everything, and re-key the col
+                        ;; operand's entries onto the transposed array.
+                        opts (apply hash-map (drop 5 contract-form))
+                        opts (cond-> (assoc opts :maps (assoc (get opts :maps {}) col-t want))
+                               (get-in opts [:decode col-arr])
+                               (update :decode #(-> % (dissoc col-arr)
+                                                    (assoc col-t (get % col-arr)))))]
+                    {:form (apply list 'raster.par/contract out free-axes contract-axes new-body
+                                  (apply concat opts))
                      :pre-step {:op :transpose :src col-arr :dst col-t
                                 :rows (ext l-sym) :cols (ext j-sym) :dtype dtype}}))))))))))
 
-(defn- quant-naive!
-  "The int8 naive-widening leaf, with a CLEAR error when the operand layout isn't one it can
-   index. There is no correct generic fallback for int8: the generic naive segred accumulates in
-   the element type, and int8×int8 must widen to int32 — so we fail loudly rather than emit a
-   silently-wrong kernel."
-  [sr out-sym scheme]
-  (try (sco/generate-quant-contraction-kernel sr out-sym :scheme scheme)
-       (catch clojure.lang.ExceptionInfo e
-         (throw (ex-info (str "int8 contraction: no quant leaf handles this operand layout ("
-                              (:reason (ex-data e)) "). int8 requires canonical row-major operands"
-                              " (A[i,l]=i·K+l, B[l,j]=l·N+j) or, for dp4a, B[j,l]=j·K+l.")
-                         (assoc (ex-data e) :dtype :byte) e)))))
-
 (defn- route-quant
-  "Route an int8 (:byte) contraction. 2-free/1-contract: try the dp4a peak leaf (requires the
-   :nt operand layout — B stored [N,K], K-contiguous, K%4==0); if that orientation isn't met,
-   either INSERT a byte-transpose pre-step so :nn reaches dp4a (B3-insert, `prefer-peak?`), or
-   fall to the quant naive-widening kernel (:nn, default). The emitters ASSERT their own layout
-   requirements, so a thrown AssertionError is the (clean) 'not this leaf' signal — dp4a and
-   quant-naive are complementary (:nt vs :nn). Non-2-free / multi-contract int8 is deferred."
-  [contract-form out-sym scheme n-free n-contract nseg prefer-peak?]
-  (let [scale (get scheme :scale 1.0)]
-    (if (and (= 2 n-free) (= 1 n-contract))
-      (let [sr (cl/contract-form->segred contract-form :dtype :byte)
-            dp4a (try (sco/generate-dp4a-contraction-kernel sr out-sym :scheme scheme)
-                      (catch clojure.lang.ExceptionInfo _ nil))]
-        (cond
-          dp4a  (quant-descriptor :dp4a dp4a :float scale nseg)     ; :nt → peak int8 leaf
-          ;; :nn + prefer-peak? → transpose col operand, then dp4a (B3-insert)
-          prefer-peak?
-          (if-let [{form* :form pre-step :pre-step}
-                   (retarget-to-layout contract-form '[j l] :byte)]   ; dp4a needs B as [N,K]
-            (let [srt (cl/contract-form->segred form* :dtype :byte)
-                  k (sco/generate-dp4a-contraction-kernel srt out-sym :scheme scheme)]
-              (assoc (quant-descriptor :dp4a k :float scale nseg) :pre-steps [pre-step]))
-            (quant-descriptor :quant-naive (quant-naive! sr out-sym scheme) :float scale nseg))
-          :else (quant-descriptor :quant-naive (quant-naive! sr out-sym scheme) :float scale nseg)))
-      (throw (ex-info "route-quant: int8 supported for 2 free + 1 contract axes (C1 first cut)"
-                      {:n-free n-free :n-contract n-contract})))))
+  "Route an int8 (:byte) contraction — with no int8-specific emitter left.
+
+   THE QUANT LEAVES ARE GONE. `generate-quant-contraction-kernel` and
+   `generate-dp4a-contraction-kernel` were the staged emitter with ONE contract level: an int32
+   accumulator, a zero-point on the load path, a scale at the store. Expressed that way they are the
+   same kernel, so both are deleted and int8 routes through the one emitter.
+
+   `:scheme {:scale :a-zp :b-zp}` is gone too. It was a closed three-field record with a private
+   scale channel, and it existed only because an epilogue's `:scalars` were emitted into the kernel
+   signature but never surfaced in the descriptor. Now the scale is an ordinary `:epilogue` and the
+   zero-point an ordinary per-operand `:decode` — which buys per-ROW and per-COLUMN scales for free
+   (an epilogue operand carries an axis-map) and lets scale compose with bias and activation by
+   nesting one expression. Neither was expressible before.
+
+   Peak-vs-portable is a LAYOUT question answered from the leaf-layouts table rather than a
+   hand-written orientation check: dp4a packs 4 int8 along the contraction, so it needs both operands
+   K-contiguous. If the form does not satisfy that, `prefer-peak?` may insert a byte-transpose to
+   reach it; otherwise the scalar nest runs, which has no layout requirement."
+  [contract-form out-sym n-free n-contract nseg prefer-peak?]
+  (when-not (and (= 2 n-free) (= 1 n-contract))
+    ;; :raster/fatal — falling through to the generic segred would accumulate int8 in int8 and
+    ;; silently overflow, so there is no correct fallback here
+    (throw (ex-info "route-quant: int8 supported for 2 free + 1 contract axes"
+                    {:reason :raster/fatal :n-free n-free :n-contract n-contract})))
+  (let [opts (apply hash-map (drop 5 contract-form))
+        k-extent (second (first (nth contract-form 3)))
+        spec (fn [form tz?]
+               (let [f (cf/contraction-facts form :dtype :byte)
+                     ;; when tensorizing, each operand's map comes from the layout check-layout
+                     ;; PROVED — verified by construction, so no `:maps` declaration is needed to
+                     ;; reach the peak leaf
+                     lmaps (when tz?
+                             (cf/layout-maps f (:dp4a cf/leaf-layouts)
+                                             (cf/check-layout f (:dp4a cf/leaf-layouts))))]
+                 {:free-axes (:free-axes f) :contract-axes (:contract-axes f)
+                  :body (:body f)
+                  ;; ONE contract level, int32 accumulate — the widening is the dtype PAIR
+                  :stages [{:axis (ffirst (:contract-axes f))
+                            :extent (second (first (:contract-axes f)))
+                            :dtype :int :init 0}]
+                  :operands (mapv (fn [o] (cond-> o (get lmaps (:sym o))
+                                                  (assoc :map (get lmaps (:sym o)))))
+                                  (:operands f))
+                  :inputs (vec (sort-by name (contract-operand-arrays (:body f))))
+                  :dtype :byte :out-dtype (get opts :out-dtype :float)
+                  :epilogue (:epilogue f)
+                  :tensorize-inner? tz?}))
+        dp4a-ok? (fn [form]
+                   (and (number? k-extent) (zero? (mod (long k-extent) 4))
+                        (:ok (cf/check-layout (cf/contraction-facts form :dtype :byte)
+                                              (:dp4a cf/leaf-layouts)))))
+        emit (fn [form tz? pre-steps]
+               (let [k (sco/generate-staged-contraction-kernel (spec form tz?) out-sym)]
+                 (cond-> {:strategy (if tz? :dp4a :quant-naive)
+                          :kernel-name (:kernel-name k) :source (:source k)
+                          :array-params (:array-params k)
+                          :lift-operands (:lift-operands k)
+                          :epilogue-operands (:epilogue-operands k)
+                          :epilogue-scalars (:epilogue-scalars k)
+                          :dtype :byte :out-dtype (:out-dtype k)
+                          :out-elems (:out-elems k)
+                          :tensorized (:tensorized k) :packed (:packed k)
+                          :scalar-args [{:type :int :value nseg}]
+                          :wg [256 1] :grid [(ceil-div nseg 256) 1]}
+                   (seq pre-steps) (assoc :pre-steps pre-steps))))]
+    (cond
+      (dp4a-ok? contract-form) (emit contract-form true nil)
+      prefer-peak?
+      (if-let [{form* :form pre-step :pre-step} (retarget-to-layout contract-form '[j l] :byte)]
+        (if (dp4a-ok? form*) (emit form* true [pre-step]) (emit contract-form false nil))
+        (emit contract-form false nil))
+      :else (emit contract-form false nil))))

--- a/test/raster/compiler/backend/gpu/dp4a_contract_device_test.clj
+++ b/test/raster/compiler/backend/gpu/dp4a_contract_device_test.clj
@@ -6,6 +6,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
             [raster.compiler.passes.parallel.contract-lower :as cl]
+            [raster.compiler.passes.parallel.contract-route :as route]
             [raster.compiler.backend.gpu.segop-opencl :as sco])
   (:import [java.lang.foreign MemorySegment]))
 
@@ -40,9 +41,16 @@
         launch-2d! (ns-resolve ze 'launch-2d!)
         A (byte-array (map #(byte (- (mod % 255) 127)) (range (* m k))))       ; [M,K]
         B (byte-array (map #(byte (- (mod (* 3 %) 255) 127)) (range (* n k)))) ; [N,K]
-        sr (cl/contract-form->segred (dp4a-form m n k) :dtype :byte)
-        {:keys [kernel-name source array-params packed]} (sco/generate-dp4a-contraction-kernel sr 'C :scheme {:scale scale})
-        _ (do (assert (= '[A B] array-params)) (assert (= :int8x4 packed)))
+        ;; no dp4a-specific emitter any more: this is the staged emitter with one int32 contract
+        ;; level, tensorized because the form satisfies the :dp4a row of leaf-layouts. The scale is
+        ;; an ordinary epilogue.
+        form (concat (dp4a-form m n k)
+                     [:epilogue {:acc 'acc :expr '(raster.numeric/* acc s)
+                                 :scalars [{:sym 's :dtype :float}]}])
+        {:keys [kernel-name source array-params packed strategy]}
+        (route/route-contraction form :dtype :byte)
+        _ (do (assert (= '[A B] array-params)) (assert (= :int8x4 packed))
+              (assert (= :dp4a strategy)))
         _ (register! kernel-name {:source source :dtype :byte})
         {:keys [kernel-handle]} (ensure-loaded! kernel-name)
         abuf (arr->buf! (make-buffer (* m k) :byte) A)   ; int8 bytes; kernel reads as packed int[]
@@ -61,22 +69,27 @@
 
 (deftest dp4a-emits-packed-int8x4-tensorize
   (testing "dp4a kernel packs the contract axis into int8×4 words + uses rstr_dp4a (device-free)"
-    (let [sr (cl/contract-form->segred (dp4a-form 64 64 64) :dtype :byte)
-          {:keys [source packed dtype acc-dtype]} (sco/generate-dp4a-contraction-kernel sr 'C :scheme {:scale 0.01})]
-      (is (= :int8x4 packed)) (is (= :byte dtype)) (is (= :int acc-dtype))
+    (let [{:keys [source packed dtype]}
+          (route/route-contraction
+           (concat (dp4a-form 64 64 64)
+                   [:epilogue {:acc 'acc :expr '(raster.numeric/* acc s)
+                               :scalars [{:sym 's :dtype :float}]}])
+           :dtype :byte)]
+      (is (= :int8x4 packed)) (is (= :byte dtype))
       (is (str/includes? source "inline int rstr_dp4a"))       ; the int8×4 dot helper
-      (is (str/includes? source "acc = rstr_dp4a("))           ; tensorized MAC
+      (is (re-find #"acc_0 = rstr_dp4a\(" source))            ; tensorized MAC
+      (is (re-find #"int acc_0 = 0" source))                   ; int32 widening accumulator
       (is (str/includes? source "const int* restrict A"))      ; operands reinterpreted as packed int
-      (is (str/includes? source "p < 16"))))                   ; KP = K/4 = 16
-  (testing "gate: K must be a multiple of 4, and B must be [N,K] transposed"
-    (is (thrown? clojure.lang.ExceptionInfo
-                 (sco/generate-dp4a-contraction-kernel (cl/contract-form->segred (dp4a-form 8 8 6) :dtype :byte) 'C)))
-    ;; B in [K,N] (non-transposed, B[l,j]=l·N+j) → not K-contiguous → rejected
+      (is (re-find #"< 16;" source))))                         ; KP = K/4 = 16
+  (testing "the layout requirement is now a ROW in leaf-layouts, and a form that misses it falls
+            back to the scalar nest rather than throwing — same verdict, better failure mode"
+    ;; K not a multiple of 4 → cannot pack → scalar nest
+    (is (= :quant-naive (:strategy (route/route-contraction (dp4a-form 8 8 6) :dtype :byte))))
+    ;; B in [K,N] (B[l,j]=l·N+j) → not K-contiguous → scalar nest
     (let [bad (list 'raster.par/contract 'C [['i 8] ['j 8]] [['l 8]]
                     (list '* (list 'aget 'A (list '+ (list '* 'i 8) 'l))
                           (list 'aget 'B (list '+ (list '* 'l 8) 'j))))]
-      (is (thrown? clojure.lang.ExceptionInfo
-                   (sco/generate-dp4a-contraction-kernel (cl/contract-form->segred bad :dtype :byte) 'C))))))
+      (is (= :quant-naive (:strategy (route/route-contraction bad :dtype :byte)))))))
 
 (deftest dp4a-contraction-matches-ref-on-device
   (if-not @gpu?

--- a/test/raster/compiler/backend/gpu/quant_contract_device_test.clj
+++ b/test/raster/compiler/backend/gpu/quant_contract_device_test.clj
@@ -8,6 +8,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
             [raster.compiler.passes.parallel.contract-lower :as cl]
+            [raster.compiler.passes.parallel.contract-route :as route]
             [raster.compiler.backend.gpu.segop-opencl :as sco])
   (:import [java.lang.foreign MemorySegment]))
 
@@ -44,9 +45,21 @@
         launch-2d! (ns-resolve ze 'launch-2d!)
         A (byte-array (map #(byte (- (mod % 255) 127)) (range (* m k))))
         B (byte-array (map #(byte (- (mod (* 3 %) 255) 127)) (range (* k n))))
-        sr (cl/contract-form->segred (matmul-form m n k) :dtype :byte)
-        {:keys [kernel-name source array-params]} (sco/generate-quant-contraction-kernel sr 'C :scheme scheme)
+        ;; The scale and zero-points are ordinary FORM DATA now — an :epilogue and a per-operand
+        ;; :decode — not a `:scheme` record with a private scale channel. Routed through
+        ;; route-contraction because there is no int8-specific emitter left: this is the staged
+        ;; emitter with one int32 contract level.
+        form (concat (matmul-form m n k)
+                     [:epilogue {:acc 'acc :expr '(raster.numeric/* acc s)
+                                 :scalars [{:sym 's :dtype :float}]}]
+                     (when-not (and (zero? a-zp) (zero? b-zp))
+                       [:decode (cond-> {}
+                                  (not (zero? a-zp)) (assoc 'A (list 'clojure.core/- 'x a-zp))
+                                  (not (zero? b-zp)) (assoc 'B (list 'clojure.core/- 'x b-zp)))]))
+        {:keys [kernel-name source array-params epilogue-scalars]}
+        (route/route-contraction form :dtype :byte)
         _ (assert (= '[A B] array-params))
+        _ (assert (= '[s] epilogue-scalars) "the scale is a surfaced epilogue scalar")
         _ (register! kernel-name {:source source :dtype :byte})
         {:keys [kernel-handle]} (ensure-loaded! kernel-name)
         abuf (arr->buf! (make-buffer (* m k) :byte) A)
@@ -66,22 +79,33 @@
 (deftest quant-contraction-emits-generic-types-and-scheme
   (testing "types come from the GENERIC dtype facet map (not quant-specific); scheme carries semantics"
     (let [sr (cl/contract-form->segred (matmul-form 64 64 64) :dtype :byte)
-          {:keys [source dtype acc-dtype out-dtype array-params scheme]}
-          (sco/generate-quant-contraction-kernel sr 'C :scheme {:scale 0.02})]
+          {:keys [source dtype out-dtype array-params epilogue-scalars]}
+          (route/route-contraction (concat (matmul-form 4 6 8)
+                                           [:epilogue {:acc 'acc :expr '(raster.numeric/* acc s)
+                                                       :scalars [{:sym 's :dtype :float}]}])
+                                   :dtype :byte)]
       (is (= :byte dtype))     ; int8 operand = the generic :byte dtype (int8_t)
-      (is (= :int acc-dtype))  ; int32 accumulate = the generic :int dtype
       (is (= :float out-dtype))
       (is (= '[A B] array-params))
-      (is (= 0.02 (:scale scheme)))
+      (is (= '[s] epilogue-scalars))                         ; the scale, as an epilogue scalar
       (is (str/includes? source "const char* restrict A"))   ; :byte → opencl "char"
-      (is (str/includes? source "int acc = 0"))              ; :int widening accumulator
-      (is (str/includes? source "(int)A["))                  ; widen operand to acc dtype
-      (is (str/includes? source "out[seg] = scale * (float)acc"))))  ; dequant epilogue
+      (is (re-find #"int acc_0 = 0" source))                 ; :int widening accumulator
+      ;; NB no explicit (int) cast: char*char integer-promotes to int in C, so the widening the old
+      ;; kernel spelled out is implied by the dtype PAIR (:byte operands, :int accumulator)
+      (is (re-find #"acc_0 \+= \(A\[" source))
+      (is (re-find #"out\[seg\] = \(\(\(float\)acc_0\) \* s\)" source))))  ; dequant epilogue
   (testing "zero-point extends the decode scheme (asymmetric quant) — subtract in the load"
     (let [sr (cl/contract-form->segred (matmul-form 32 32 32) :dtype :byte)
-          src (:source (sco/generate-quant-contraction-kernel sr 'C :scheme {:scale 0.1 :a-zp 5 :b-zp -3}))]
-      (is (str/includes? src "((int)A[i * 32 + l] - 5)"))
-      (is (str/includes? src "((int)B[l * 32 + j] - -3)")))))
+          src (:source (route/route-contraction
+                        (concat (matmul-form 4 6 8)
+                                [:epilogue {:acc 'acc :expr '(raster.numeric/* acc s)
+                                            :scalars [{:sym 's :dtype :float}]}
+                                 :decode {'A '(clojure.core/- x 5) 'B '(clojure.core/- x -3)}])
+                        :dtype :byte))]
+      ;; the zero-point is a per-operand :decode on the LOAD path — exact, and needing no
+      ;; correction reductions (a scale, which factors out of the sum, is the epilogue instead)
+      (is (re-find #"\(A\[\(\(i \* 8\) \+ l\)\] - 5\)" src))
+      (is (re-find #"\(B\[\(\(l \* 6\) \+ j\)\] - -3\)" src)))))
 
 (deftest quant-contraction-matches-ref-on-device
   (if-not @gpu?

--- a/test/raster/compiler/backend/gpu/tiled_contract_device_test.clj
+++ b/test/raster/compiler/backend/gpu/tiled_contract_device_test.clj
@@ -31,36 +31,6 @@
     (MemorySegment/copy (MemorySegment/ofArray arr) 0 seg 0 nbytes)
     [seg nbytes]))
 
-(defn- run-tiled
-  "Emit the tiled kernel for m×n×k, launch on device, return the output vector."
-  [m k n]
-  (let [ze (find-ns 'raster.gpu.ze-runtime)
-        register! (ns-resolve ze 'register-kernel!)
-        ensure-loaded! (ns-resolve ze 'ensure-kernel-loaded!)
-        alloc (ns-resolve ze 'alloc-shared)
-        launch-2d! (ns-resolve ze 'launch-2d!)
-        A (double-array (map double (range (* m k))))
-        B (double-array (map #(* 0.5 (double %)) (range (* k n))))
-        form (list 'raster.par/contract 'C [['i m] ['j n]] [['l k]]
-                   (list '* (list 'aget 'A (list '+ (list '* 'i k) 'l))
-                         (list 'aget 'B (list '+ (list '* 'l n) 'j))))
-        sr (cl/contract-form->segred form)
-        {:keys [kernel-name source tile]} (sco/generate-tiled-contraction-kernel sr 'C)
-        _ (register! kernel-name {:source source :dtype :double})
-        {:keys [kernel-handle]} (ensure-loaded! kernel-name)
-        [aseg _] (upload! A)
-        [bseg _] (upload! B)
-        out-bytes (* m n 8)
-        oseg (alloc out-bytes)
-        T (long tile)
-        gcx (long (Math/ceil (/ (double n) T)))   ; columns / N
-        gcy (long (Math/ceil (/ (double m) T)))]  ; rows / M
-    ;; args order = sorted inputs [A B] then out
-    (launch-2d! kernel-handle [T T] [gcx gcy] [aseg bseg oseg])
-    (let [out (double-array (* m n))]
-      (MemorySegment/copy oseg 0 (MemorySegment/ofArray out) 0 out-bytes)
-      {:gpu (vec out) :cpu (vec (ref-matmul A B m k n))})))
-
 (defn- run-regtiled
   "Emit the register-tiled kernel for m×n×k, launch on device, return {:gpu :cpu}."
   [m k n]
@@ -96,20 +66,9 @@
   (and (= (count xs) (count ys))
        (every? true? (map (fn [a b] (< (Math/abs (- (double a) (double b))) 1.0e-9)) xs ys))))
 
-(deftest tiled-contraction-matches-cpu-on-device
-  (if-not @gpu?
-    (println "[skip] tiled-contraction-device: no GPU device available")
-    (do
-      (testing "tile-divisible dims (32×32×32)"
-        (let [{:keys [gpu cpu]} (run-tiled 32 32 32)]
-          (is (approx-eq? gpu cpu) (str "divisible: GPU " (take 4 gpu) " vs CPU " (take 4 cpu)))))
-      (testing "non-divisible dims (30×24×20) — boundary padding path"
-        (let [{:keys [gpu cpu]} (run-tiled 30 24 20)]
-          (is (approx-eq? gpu cpu) (str "boundary: GPU " (take 4 gpu) " vs CPU " (take 4 cpu)))))
-      (testing "skewed dims (17×48×5)"
-        (let [{:keys [gpu cpu]} (run-tiled 17 48 5)]
-          (is (approx-eq? gpu cpu) "skewed"))))))
-
+;; NB the block-tiled generator this namespace also covered is gone — it was unreachable from
+;; route-contraction and strictly a `regtiled` with tm=tn=1, so its cases (non-tile-divisible dims,
+;; tiny dims) are carried by the regtiled deftest below rather than by a second emitter.
 (deftest regtiled-contraction-matches-cpu-on-device
   (if-not @gpu?
     (println "[skip] regtiled-contraction-device: no GPU device available")

--- a/test/raster/compiler/ir/contraction_facts_test.clj
+++ b/test/raster/compiler/ir/contraction_facts_test.clj
@@ -126,3 +126,28 @@
   (testing "check-layout refuses a hand-built map — it requires real facts"
     (is (thrown? clojure.lang.ExceptionInfo
                  (cf/check-layout {:operands [] :roles {}} (:dpas cf/leaf-layouts))))))
+
+;; ── anti-drift: the data table and the predicate it will replace must AGREE ──────────
+;; `check-layout` is not yet consumed by the gates. That is deliberate — four of the six
+;; orientation call sites live in the quant and dp4a generators, which the next increment deletes
+;; outright, and wiring only the fifth (dpas) would create a dual path. But an unconsumed
+;; capability is how this subsystem drifted in the first place, so the equivalence is PINNED here:
+;; if the table and the live predicate ever disagree on a case, this fails.
+(deftest table-agrees-with-the-live-orientation-gate
+  (let [cases [[:nn nn-idx :dpas true] [:nn nn-idx :dp4a false]
+               [:nt nt-idx :dp4a true] [:nt nt-idx :dpas false]]
+        gate (requiring-resolve 'raster.compiler.backend.gpu.segop-opencl/dpas-contraction-legal?)
+        lower (requiring-resolve 'raster.compiler.passes.parallel.contract-lower/contract-form->segred)]
+    (doseq [[label idx leaf expected] cases]
+      (testing (str label " under " leaf)
+        (is (= expected (boolean (:ok (cf/check-layout (cf/contraction-facts (mm-form idx))
+                                                       (get cf/leaf-layouts leaf)))))
+            "table verdict")))
+    (testing "and the live DPAS gate reaches the same orientation verdict the table does"
+      ;; f64 so the gate's own dtype requirement does not mask the orientation decision
+      (let [nn-sr (lower (mm-form nn-idx) :dtype :half)
+            nt-sr (lower (mm-form nt-idx) :dtype :half)]
+        (is (not= :non-canonical-orientation (:reason (gate nn-sr :half)))
+            ":nn is orientation-legal for dpas (it may still fail on pitch alignment)")
+        (is (= :non-canonical-orientation (:reason (gate nt-sr :half)))
+            ":nt is orientation-ILLEGAL for dpas — same verdict the table gives")))))

--- a/test/raster/compiler/passes/parallel/contract_route_device_test.clj
+++ b/test/raster/compiler/passes/parallel/contract_route_device_test.clj
@@ -202,17 +202,24 @@
         (is (every? true? (map #(< (Math/abs (- (double %1) (double %2))) 1.0e-9) gpu cpu)))))))
 
 ;; ── C1-nt: int8 routes to the quant leaves (dp4a for :nt, quant-naive for :nn) ─────────
-(defn- launch-int8-routed [r bufs]
-  (let [ze (find-ns 'raster.gpu.ze-runtime)
+(defn- launch-int8-routed
+  "Launch a routed int8 descriptor. `scalars` supplies a value per `:epilogue-scalars`, bound in
+   SLOT ORDER: operands…, out, epilogue scalars…, trailing count. (That order is the descriptor's
+   contract; the ABI datum in the plan makes it data rather than a convention each caller repeats.)"
+  ([r bufs] (launch-int8-routed r bufs {}))
+  ([r bufs scalars]
+   (let [ze (find-ns 'raster.gpu.ze-runtime)
         [gx gy] (:grid r)
-        m*n (reduce * (:dims r))
-        o ((ns-resolve ze 'make-buffer) m*n :float)]
+        o ((ns-resolve ze 'make-buffer) (:out-elems r) :float)]
     ((ns-resolve ze 'register-kernel!) (:kernel-name r) {:source (:source r) :dtype :byte})
     (let [{:keys [kernel-handle]} ((ns-resolve ze 'ensure-kernel-loaded!) (:kernel-name r))
-          args (into (mapv #(:segment (get bufs %)) (:array-params r))
-                     (into [(:segment o)] (:scalar-args r)))]
+          args (-> (mapv #(:segment (get bufs %)) (:array-params r))
+                   (conj (:segment o))
+                   (into (mapv (fn [sym] {:type :float :value (float (get scalars sym))})
+                               (:epilogue-scalars r)))
+                   (into (:scalar-args r)))]
       ((ns-resolve ze 'launch-2d!) kernel-handle (:wg r) [gx gy] args)
-      (vec ((ns-resolve ze 'buffer->float-array) o)))))
+      (vec ((ns-resolve ze 'buffer->float-array) o))))))
 
 (defn- mk-i8 [xs] (let [ze (find-ns 'raster.gpu.ze-runtime)]
                     ((ns-resolve ze 'array->buffer!) ((ns-resolve ze 'make-buffer) (count xs) :byte)
@@ -231,9 +238,11 @@
       (testing ":nt (B stored [N,K]) → :dp4a peak leaf; int8 matmul dequant == reference"
         (let [form (list 'raster.par/contract 'C [['i M] ['j N]] [['l K]]
                          (list '* (list 'aget 'A (list '+ (list '* 'i K) 'l))
-                               (list 'aget 'B (list '+ (list '* 'j K) 'l))))
-              r (route/route-contraction form :dtype :byte :scheme {:scale scale})
-              gpu (launch-int8-routed r {'A (mk-i8 Ab) 'B (mk-i8 Bv)})
+                               (list 'aget 'B (list '+ (list '* 'j K) 'l)))
+                         :epilogue {:acc 'acc :expr '(raster.numeric/* acc s)
+                                    :scalars [{:sym 's :dtype :float}]})
+              r (route/route-contraction form :dtype :byte)
+              gpu (launch-int8-routed r {'A (mk-i8 Ab) 'B (mk-i8 Bv)} {'s scale})
               cpu (for [i (range M) j (range N)]
                     (* scale (reduce + (for [l (range K)] (* (int (Aget (+ (* i K) l))) (int (Bget (+ (* j K) l))))))))]
           (is (= :dp4a (:strategy r)))
@@ -241,9 +250,11 @@
       (testing ":nn (B stored [K,N]) → :quant-naive widening leaf; == reference"
         (let [form (list 'raster.par/contract 'C [['i M] ['j N]] [['l K]]
                          (list '* (list 'aget 'A (list '+ (list '* 'i K) 'l))
-                               (list 'aget 'B (list '+ (list '* 'l N) 'j))))
-              r (route/route-contraction form :dtype :byte :scheme {:scale scale})
-              gpu (launch-int8-routed r {'A (mk-i8 Ab) 'B (mk-i8 Bv)})
+                               (list 'aget 'B (list '+ (list '* 'l N) 'j)))
+                         :epilogue {:acc 'acc :expr '(raster.numeric/* acc s)
+                                    :scalars [{:sym 's :dtype :float}]})
+              r (route/route-contraction form :dtype :byte)
+              gpu (launch-int8-routed r {'A (mk-i8 Ab) 'B (mk-i8 Bv)} {'s scale})
               cpu (for [i (range M) j (range N)]
                     (* scale (reduce + (for [l (range K)] (* (int (Aget (+ (* i K) l))) (int (Bget (+ (* l N) j))))))))]
           (is (= :quant-naive (:strategy r)))
@@ -268,10 +279,12 @@
             Bnn (mapv #(byte (- (mod (* 3 %) 255) 127)) (range (* K N)))   ; [K,N] (:nn)
             form (list 'raster.par/contract 'C [['i M] ['j N]] [['l K]]
                        (list '* (list 'aget 'A (list '+ (list '* 'i K) 'l))
-                             (list 'aget 'B (list '+ (list '* 'l N) 'j))))
-            r (route/route-contraction form :dtype :byte :scheme {:scale scale} :prefer-peak? true)
+                             (list 'aget 'B (list '+ (list '* 'l N) 'j)))
+                       :epilogue {:acc 'acc :expr '(raster.numeric/* acc s)
+                                  :scalars [{:sym 's :dtype :float}]})
+            r (route/route-contraction form :dtype :byte :prefer-peak? true)
             bufs (reduce exec-pre-step {'A (mk-i8 Ab) 'B (mk-i8 Bnn)} (:pre-steps r))
-            gpu (launch-int8-routed r bufs)
+            gpu (launch-int8-routed r bufs {'s scale})
             cpu (for [i (range M) j (range N)]
                   (* scale (reduce + (for [l (range K)] (* (int (nth Ab (+ (* i K) l))) (int (nth Bnn (+ (* l N) j))))))))]
         (is (= :dp4a (:strategy r)))
@@ -290,23 +303,29 @@
           bad (list 'raster.par/contract 'C [['i M] ['j N]] [['l K]]
                     (list '* (list 'aget 'A (list '+ (list '* 'i K) 'l))
                           (list 'aget 'B (list '+ (list '* 'j (* K 2)) 'l))))
-          r (try (route/route-contraction bad :dtype :byte :scheme {:scale 0.01} :prefer-peak? true)
+          r (try (route/route-contraction bad :dtype :byte :prefer-peak? true)
                  (catch clojure.lang.ExceptionInfo _ {:strategy :rejected :pre-steps []}))]
       (is (not= :dp4a (:strategy r)) "must not claim the peak leaf on an unverified layout")
       (is (empty? (:pre-steps r)))))
-  (testing "an int8 operand layout NO leaf can index fails loudly (never silently miscompiles)"
+  (testing "an operand layout no PEAK leaf can index now falls back to the scalar nest, which has
+            no layout requirement at all — it emits the declared body verbatim, so the result is
+            correct rather than refused. (It used to throw \"no quant leaf handles\"; that message
+            belonged to a hand-written orientation gate on a leaf that no longer exists.)"
     (let [M 4 N 4 K 8
           bad (list 'raster.par/contract 'C [['i M] ['j N]] [['l K]]
                     (list '* (list 'aget 'A (list '+ (list '* 'i K) 'l))
-                          (list 'aget 'B (list '+ (list '* 'j (* K 2)) 'l))))]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"no quant leaf handles"
-                            (route/route-contraction bad :dtype :byte :scheme {:scale 0.01})))))
+                          (list 'aget 'B (list '+ (list '* 'j (* K 2)) 'l))))
+          r (route/route-contraction bad :dtype :byte)]
+      (is (= :quant-naive (:strategy r)))
+      (is (not (:tensorized r)))
+      ;; and the emitted body indexes B exactly as declared — stride 2K, not an assumed K
+      (is (re-find #"B\[\(\(j \* 16\) \+ l\)\]" (:source r)))))
   (testing "the canonical :nn form IS retargeted (transpose pre-step + dp4a)"
     (let [M 4 N 4 K 8
           ok (list 'raster.par/contract 'C [['i M] ['j N]] [['l K]]
                    (list '* (list 'aget 'A (list '+ (list '* 'i K) 'l))
                          (list 'aget 'B (list '+ (list '* 'l N) 'j))))
-          r (route/route-contraction ok :dtype :byte :scheme {:scale 0.01} :prefer-peak? true)]
+          r (route/route-contraction ok :dtype :byte :prefer-peak? true)]
       (is (= :dp4a (:strategy r)))
       (is (= 1 (count (:pre-steps r)))))))
 


### PR DESCRIPTION
Phase C of the coherence audit. **328 deletions, 297 insertions** — the net is small because this is
mostly subtraction.

## Two generators were the staged emitter all along

`generate-quant-contraction-kernel` and `generate-dp4a-contraction-kernel` were the staged emitter
with **one contract level**: an int32 accumulator, a zero-point on the load path, a scale at the
store. Written that way they are the same kernel, so both are deleted (116 lines) and int8 routes
through the one emitter:

```c
// what the staged emitter now emits for an int8 contraction — the old quant kernel, exactly
int acc_0 = 0;
for (int l = 0; l < 8; l++) {
    acc_0 += ((A[((i * 8) + l)] - 5) * B[((l * 6) + j)]);   // zero-point = per-operand :decode
}
out[seg] = (((float)acc_0) * s);                            // scale = :epilogue
```

## `:scheme` is gone, and it only ever existed because of a 10-line hole

`:scheme {:scale :a-zp :b-zp}` was a closed three-field record with a private scale channel. It
existed because `epilogue-splice` emitted an epilogue's `:scalars` into the kernel signature while
**no descriptor surfaced them** — so expressing a scale as an epilogue tripped `validate-descriptor`
and threw. With `:epilogue-scalars` surfaced, the scale is an ordinary epilogue and the zero-point an
ordinary `:decode`. Two things become expressible that the record never could:

- **per-row and per-column scales** — an epilogue operand carries an axis-map
- **scale composed with bias and activation**, by nesting one expression

Widening deliberately stays the dtype **pair** (`:byte` operands, `:int` accumulator) rather than a
decode lambda — hiding it in a lambda would blind the tensorize gate to the pair it dispatches on.
The explicit `(int)` cast the old kernels wrote is redundant anyway: `char × char` integer-promotes.

## The peak choice is a table lookup now

`check-layout` from #88 gets its first consumer, so the table is no longer unconsumed. dp4a needs
both operands K-contiguous — that is the `:dp4a` row — and `layout-maps` hands the leaf operand maps
**derived from the layout it just proved**. Verified by construction, so a form no longer has to
declare `:maps` to reach a peak leaf, and role assignment is by verification rather than the variance
heuristic.

## Two behaviour changes worth reviewing

1. An operand layout **no peak leaf can index** now falls back to the scalar nest instead of throwing
   `"no quant leaf handles"`. The nest has *no* layout requirement — it emits the declared body
   verbatim — so the result is correct rather than refused. The old message belonged to a
   hand-written gate on a leaf that no longer exists.
2. **Fixed, and it bit during this work:** `retarget-to-layout` rebuilt the form carrying only
   `:maps`, silently dropping `:epilogue`, `:decode`, `:init`, `:combine`, `:out-dtype`. A retargeted
   contraction therefore **lost its scale** (wrong by a constant factor) and a `:combine max` became
   a sum. That was audit finding A6; the transpose test caught it as 16 wrong outputs.

Also deleted: `generate-tiled-contraction-kernel` (unreachable; strictly a `regtiled` with
`tm=tn=1`), `quant-descriptor`, `quant-naive!`. Test assertions that pinned the old kernels' exact C
text are rewritten to assert **semantics** — int accumulator, decode on the load, scale at the store.

## Validation

107 contraction tests / 617 assertions, 0 failures. Cold-JVM load verified. Supersedes #89, whose
commit is included here.

## Deliberately not in this PR

Collapsing `generate-segmented-reduce-kernel` + `generate-segmap-nd-kernel` into the same emitter.
That path is `route-contraction`'s **universal fallback**, and it needs the staged emitter to gain
symbolic-bound support first — a feature addition rather than a collapse, with a much broader blast
radius. Bundling it here would mean two candidate causes in the same diff if anything went red.
