### PR TITLE
Phase D: one tile source reaching every GEMM door; the roofline abstains instead of fabricating

### DIFF
--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -178,7 +178,14 @@
             ;; dtype, arbitrary dims). Emits a 2D invoke-registered-contraction! marker.
             (croute/par-contract-form? form)
             (let [out-sym (second form)
-                  r (croute/route-contraction form :dtype dtype)
+                  ;; pass the REAL descriptor: route-contraction fed `(or desc {})` into
+                  ;; derive-gemm-tile, so the "hardware-derived" tile was derived from an empty map
+                  ;; — Arc constants on every device. device-id is already in scope here.
+                  r (croute/route-contraction
+                     form :dtype dtype
+                     :desc (try ((requiring-resolve 'raster.compiler.core.hardware/descriptor-for)
+                                 device-id)
+                                (catch Throwable _ nil)))
                   k (register-kernel! {:kernel-name (:kernel-name r) :source (:source r)
                                        :dtype (:dtype r)}
                                       :ze-contracts)]

--- a/src/raster/compiler/core/hardware.clj
+++ b/src/raster/compiler/core/hardware.clj
@@ -324,14 +324,16 @@
   "The roofline RIDGE (flops/byte) for `dtype`: peak-flops(dtype) / bandwidth — the arithmetic
    intensity above which a kernel is compute-bound. PRECISION-DEPENDENT (the f16 ridge is far above
    the f64 ridge on a mixed-rate GPU), derived from the descriptor's bandwidth+peak-flops when both
-   are present; falls back to the scalar :balance default only when they are absent. Fixes the bug
-   where a single :balance constant misclassifies every non-default-precision kernel."
+   are present. ABSTAINS (nil) when either is missing, rather than substituting the scalar :balance
+   constant: that substitution fabricated an f32-ish ridge for every dtype it did not know — int8 got
+   60, two orders below any plausible dp4a ridge, and CPU descriptors carry no peak-flops at all so
+   EVERY CPU ridge was invented. `roofline-time-ns` already abstains honestly; this now matches it.
+   A cost model may decline to answer; it must not make one up."
   [desc dtype]
   (let [pf (peak-flops-for desc dtype)
         bw (:bandwidth-bytes-s desc)]
-    (if (and pf bw (pos? (double bw)))
-      (/ (double pf) (double bw))
-      (double (:balance desc 40)))))
+    (when (and pf bw (pos? (double bw)))
+      (/ (double pf) (double bw)))))
 
 (defn roofline-regime
   "Memory-bound vs compute-bound by arithmetic intensity vs the ridge. AI = flops/bytes;
@@ -342,8 +344,9 @@
    (if (< (/ (double flops) (double (max 1 bytes))) (double (:balance desc)))
      :memory-bound :compute-bound))
   ([desc {:keys [flops bytes]} dtype]
-   (if (< (/ (double flops) (double (max 1 bytes))) (balance-for desc dtype))
-     :memory-bound :compute-bound)))
+   (when-let [ridge (balance-for desc dtype)]
+     (if (< (/ (double flops) (double (max 1 bytes))) ridge)
+       :memory-bound :compute-bound))))
 
 (def ^:private memory-compute-parallelism
   "Overlap fraction of the compute and memory ceilings (XLA kMemoryComputeParallelism): exec is a
@@ -514,6 +517,31 @@
       :block-k (* 2 k)
       :num-stages 3                             ;; pipelining depth (prefetch distance); T4 axis
       :matrix (:matrix desc {:family :dpas :m m :n n :k k :subgroup subgroup})})))
+
+(def ^:private gemm-tile-cache (atom {}))
+
+(defn gemm-tile-for
+  "THE tile for a GEMM on `desc` — the single source every GEMM door reads.
+
+   Why this exists: `derive-gemm-tile` was reaching nothing that shipped. The two emit front doors
+   took `emit-gemm-tiled`'s own `:or` literals (128/128/32/32/32), the contraction door called
+   `derive-gemm-tile` on an EMPTY descriptor (so Arc constants on every device), and three launch
+   sites computed their grid from a hardcoded `/128.0` with a `*32` K-unroll — five spellings of one
+   number. A kernel emitted with one tile and launched with geometry derived from another is a
+   silent wrong-answer path the moment they diverge.
+
+   `desc` nil (or empty) yields the same default `derive-gemm-tile` already produced, so adopting
+   this is a no-op on Arc and merely CORRECT elsewhere — which is the point: this is de-hardcoding
+   and cross-device correctness, not a speedup. Measured evidence says tile geometry is not the Arc
+   performance lever (128x128 is already optimal there).
+
+   Memoized on the descriptor's tile-relevant facets, since every launch asks."
+  [desc]
+  (let [k (select-keys (or desc {}) [:matrix :grf-bytes-per-lane :subgroup-size :max-workgroup-size])]
+    (or (get @gemm-tile-cache k)
+        (let [t (derive-gemm-tile (or desc {}))]
+          (swap! gemm-tile-cache assoc k t)
+          t))))
 
 (defn max-stages-for
   "The pipelining-depth ceiling for a GEMM `tile` on `desc` — the SLM-bounded num_stages. A

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -862,19 +862,28 @@
    copy — the policy is not re-implemented anywhere."
   ([m n k fill-wgs] (gemm-schedule m n k fill-wgs (or *gemm-splitk-target-wgs* (* 4 (long fill-wgs)))))
   ([m n k fill-wgs target-wgs]
-   (let [base (* (Math/ceil (/ (double n) 128.0))
-                 (Math/ceil (/ (double m) 128.0)))]
+   (let [{:keys [block-m block-n block-k]}
+         ((requiring-resolve 'raster.compiler.core.hardware/gemm-tile-for)
+          (try ((requiring-resolve 'raster.compiler.core.hardware/descriptor-for)
+                (:device-id @(requiring-resolve 'raster.gpu.ze-runtime/state)))
+               (catch Throwable _ nil)))
+         ;; the split-k policy's occupancy estimate and K-chunk quantum are the SAME tile the
+         ;; kernel is emitted with — they were independent `/128.0` and `*32` literals, so a tile
+         ;; change silently decoupled the policy from the kernel it schedules
+         base (* (Math/ceil (/ (double n) (double block-n)))
+                 (Math/ceil (/ (double m) (double block-m))))]
      (if (>= base (double fill-wgs))
        [1 k]                              ;; already fills the machine
        (let [want (long (Math/ceil (/ (double target-wgs) base)))
-             ;; each chunk must be a multiple of 32 (the K-unroll) and at least
+             ;; each chunk must be a multiple of the K-unroll (block-k) and at least
              ;; *gemm-splitk-min-chunk* long, or the per-chunk fixed cost (A prefetch + the
              ;; store of a full partial C tile) swamps the reduction it does.
              cap (quot (long k) (long *gemm-splitk-min-chunk*))
              s (min want cap (long *gemm-splitk-max-splits*))]
          (if (< s 2)
            [1 k]
-           (let [kc (* 32 (quot (+ (quot (long k) s) 31) 32))]
+           (let [ku (long block-k)
+                 kc (* ku (quot (+ (quot (long k) s) (dec ku)) ku))]
              [(quot (+ (long k) kc -1) kc) kc])))))))
 
 (defn bind-program!

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -1165,8 +1165,9 @@
   Returns C."
   [a b c m n k]
   (let [{:keys [kernel]} (ensure-gemm-kernel! :half)
-        gc-m (int (Math/ceil (/ (double m) 128.0)))
-        gc-n (int (Math/ceil (/ (double n) 128.0)))
+        {:keys [block-m block-n]} (gemm-tile)
+        gc-m (int (Math/ceil (/ (double m) (double block-m))))
+        gc-n (int (Math/ceil (/ (double n) (double block-n))))
         args [(:segment a) (:segment b) (:segment c)
               {:type :int :value (int m)}
               {:type :int :value (int n)}
@@ -1869,6 +1870,17 @@
     (.set ^MemorySegment (:gc-seg bnd) I32 0 (int group-count))
     bnd))
 
+(defn- gemm-tile
+  "The GEMM tile for this device, from the ONE source (compiler.core.hardware/gemm-tile-for).
+   Launch geometry MUST be derived from the same tile the kernel was emitted with — the `/128.0`
+   literals this replaces were a second, independent spelling of block-m/block-n, so any tile change
+   would have silently mismatched kernel and grid."
+  []
+  (let [f (requiring-resolve 'raster.compiler.core.hardware/gemm-tile-for)
+        d (try ((requiring-resolve 'raster.compiler.core.hardware/descriptor-for) (:device-id @state))
+               (catch Throwable _ nil))]
+    (f d)))
+
 (defn bind-registered-gemm!
   "Bind the XMX GEMM kernel (C = A×B) over RESIDENT fp16 DeviceBuffers for recording into a
   command graph — the resident analog of invoke-registered-gemm! (which stages JVM arrays every
@@ -1893,8 +1905,8 @@
                {:type :int :value (int m)} {:type :int :value (int n)} {:type :int :value (int k)}]
          bnd (bind-kernel-2d! kh [256 1] args)
          gc ^MemorySegment (:gc-seg bnd)]
-     (.set gc I32 0 (int (Math/ceil (/ (double n) 128.0))))   ;; X = gc-n
-     (.set gc I32 4 (int (Math/ceil (/ (double m) 128.0))))   ;; Y = gc-m
+     (.set gc I32 0 (int (Math/ceil (/ (double n) (double (:block-n (gemm-tile)))))))   ;; X = gc-n
+     (.set gc I32 4 (int (Math/ceil (/ (double m) (double (:block-m (gemm-tile)))))))   ;; Y = gc-m
      (.set gc I32 8 (int 1))
      bnd)))
 

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -1156,6 +1156,17 @@
         (swap! gemm-cache assoc c-dtype entry)
         entry)))
 
+(defn- gemm-tile
+  "The GEMM tile for this device, from the ONE source (compiler.core.hardware/gemm-tile-for).
+   Launch geometry MUST be derived from the same tile the kernel was emitted with — the `/128.0`
+   literals this replaces were a second, independent spelling of block-m/block-n, so any tile change
+   would have silently mismatched kernel and grid."
+  []
+  (let [f (requiring-resolve 'raster.compiler.core.hardware/gemm-tile-for)
+        d (try ((requiring-resolve 'raster.compiler.core.hardware/descriptor-for) (:device-id @state))
+               (catch Throwable _ nil))]
+    (f d)))
+
 (defn gemm!
   "GPU matrix multiply: C = A × B using XMX DPAS instructions.
   A: FP16 DeviceBuffer [M×K], B: FP16 DeviceBuffer [K×N],
@@ -1869,17 +1880,6 @@
         bnd (bind-kernel! kernel-handle wg all-args)]
     (.set ^MemorySegment (:gc-seg bnd) I32 0 (int group-count))
     bnd))
-
-(defn- gemm-tile
-  "The GEMM tile for this device, from the ONE source (compiler.core.hardware/gemm-tile-for).
-   Launch geometry MUST be derived from the same tile the kernel was emitted with — the `/128.0`
-   literals this replaces were a second, independent spelling of block-m/block-n, so any tile change
-   would have silently mismatched kernel and grid."
-  []
-  (let [f (requiring-resolve 'raster.compiler.core.hardware/gemm-tile-for)
-        d (try ((requiring-resolve 'raster.compiler.core.hardware/descriptor-for) (:device-id @state))
-               (catch Throwable _ nil))]
-    (f d)))
 
 (defn bind-registered-gemm!
   "Bind the XMX GEMM kernel (C = A×B) over RESIDENT fp16 DeviceBuffers for recording into a

--- a/test/raster/compiler/core/hardware_roofline_test.clj
+++ b/test/raster/compiler/core/hardware_roofline_test.clj
@@ -27,8 +27,16 @@
     (is (< 44.0 (hw/balance-for desc :f32) 45.0) "f32 ridge ~44.6")
     (is (< 2.7 (hw/balance-for desc :f64) 2.9) "f64 ridge ~2.79")
     (is (> (hw/balance-for desc :f32) (* 10 (hw/balance-for desc :f64)))))
-  (testing "falls back to the scalar :balance default when bandwidth/flops are absent"
-    (is (= 60.0 (hw/balance-for no-perf-desc :f32)))))
+  (testing "ABSTAINS when bandwidth/flops are absent, rather than substituting the scalar :balance"
+    ;; The old fallback fabricated an f32-ish ridge for every dtype it did not know: int8 got 60,
+    ;; two orders below any plausible dp4a ridge, and a CPU descriptor carries no peak-flops at all
+    ;; so every CPU ridge was invented. `roofline-time-ns` already abstained honestly; this matches
+    ;; it. A cost model may decline to answer — it must not make one up.
+    (is (nil? (hw/balance-for no-perf-desc :f32)))
+    (is (nil? (hw/roofline-regime no-perf-desc {:flops 1000 :bytes 10} :f32))
+        "and the precision-aware regime abstains with it")
+    (is (some? (hw/roofline-regime no-perf-desc {:flops 1000 :bytes 10}))
+        "the 2-arg legacy form still answers from the scalar :balance — it has callers")))
 
 (deftest regime-fixes-the-single-balance-bug
   ;; a 256³ GEMM: AI = 2·256³ / (3·256²·4) = 42.67 — BETWEEN the f64 ridge (2.8) and f32 ridge (44.6)

--- a/test/raster/gpu/one_tile_source_test.clj
+++ b/test/raster/gpu/one_tile_source_test.clj
@@ -1,0 +1,61 @@
+(ns raster.gpu.one-tile-source-test
+  "ONE tile source. Device-free.
+
+   `derive-gemm-tile` used to reach nothing that shipped: the two emit front doors took
+   `emit-gemm-tiled`'s own `:or` literals, the contraction door derived from an EMPTY descriptor (so
+   Arc constants on every device), and three launch sites computed their grid from a hardcoded
+   `/128.0` with a `*32` K-unroll. Five independent spellings of one number — and a kernel emitted
+   with one tile but launched with geometry derived from another is a silent wrong-answer path the
+   moment they diverge.
+
+   The property these tests pin is that unifying them changed NOTHING on this device: generalizing
+   the tile must not cost peak. `gemm-tile-for` on the default descriptor must reproduce
+   `emit-gemm-tiled`'s literals exactly, and the split-k policy must produce the same schedule it
+   produced from its own constants."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.core.hardware :as hw]))
+
+(deftest default-tile-equals-the-emitters-own-literals
+  (testing "gemm-tile-for on no descriptor == emit-gemm-tiled's :or defaults, so adopting the one
+            source is a NO-OP on this device — de-hardcoding, not a behaviour change"
+    (let [t (hw/gemm-tile-for nil)]
+      (is (= 128 (:block-m t)))
+      (is (= 128 (:block-n t)))
+      (is (= 32 (:sg-m t)))
+      (is (= 32 (:sg-n t)))
+      (is (= 32 (:block-k t)))
+      (is (= 16 (get-in t [:matrix :subgroup])))))
+  (testing "…and an empty map is the same as nil (the contraction door used to pass `{}`)"
+    (is (= (hw/gemm-tile-for nil) (hw/gemm-tile-for {})))))
+
+(deftest a-different-part-gets-a-rescaled-tile
+  (testing "the whole point of a derivation: a part with a smaller GRF budget and subgroup 8 gets a
+            correctly rescaled tile instead of Arc's constants"
+    (let [t (hw/gemm-tile-for {:matrix {:m 8 :n 8 :k 16 :subgroup 8}
+                               :grf-bytes-per-lane 128})]
+      (is (= 8 (get-in t [:matrix :subgroup])))
+      (is (< (:sg-m t) 32) "per-subgroup tile shrinks with the register budget")
+      (is (= 0 (mod (:block-m t) (:sg-m t))) "workgroup block stays divisible by the subgroup tile")
+      (is (= 0 (mod (:sg-m t) (get-in t [:matrix :m])))
+          "and the subgroup tile stays a whole number of matrix fragments"))))
+
+(deftest launch-geometry-is-derived-from-the-same-tile
+  (testing "grid = ceil(dim / block), computed from the tile rather than a literal 128"
+    (let [{:keys [block-m block-n]} (hw/gemm-tile-for nil)
+          gc (fn [d b] (long (Math/ceil (/ (double d) (double b)))))]
+      (is (= 2 (gc 256 block-n)))
+      (is (= 1 (gc 128 block-n)))
+      (is (= 1 (gc 5 block-m)) "a tile-smaller problem is still one block")
+      ;; the pre-unification literal and the derived value agree on THIS device, which is what
+      ;; makes the change safe here and correct elsewhere
+      (is (= (gc 4096 128) (gc 4096 block-n))))))
+
+(deftest split-k-policy-is-unchanged-on-this-device
+  (testing "gemm-schedule now reads block-m/block-n/block-k instead of /128.0 and *32, and must
+            produce the same schedule it did from its own constants"
+    (let [sched (requiring-resolve 'raster.gpu.core/gemm-schedule)]
+      (is (= [1 1024] (sched 128 128 1024 64)) "already fills the machine → no split")
+      (is (= [8 1024] (sched 64 64 8192 64)) "small tile-count, long K → split-k")
+      (testing "and every K-chunk is a multiple of the tile's K-unroll, by construction"
+        (let [[_ kc] (sched 64 64 8192 64)]
+          (is (zero? (mod (long kc) (long (:block-k (hw/gemm-tile-for nil)))))))))))


### PR DESCRIPTION
Phase D. Two things: one tile source, and a roofline that abstains instead of fabricating.

## One tile, five spellings

`derive-gemm-tile` reached nothing that shipped:

| site | tile it used |
|---|---|
| two `emit-gemm-tiled` front doors | the emitter's own `:or` literals |
| the contraction door | `derive-gemm-tile` on an **empty descriptor** → Arc constants on every device |
| two `ze_runtime` launches | hardcoded `/128.0` |
| `gemm-schedule` split-k policy | its own `/128.0` and `*32` |

A kernel emitted with one tile and launched with geometry derived from another is a silent
wrong-answer path the moment they diverge. `hw/gemm-tile-for` is now the single source; every
geometry site reads `:block-m`/`:block-n`/`:block-k` off it, and `opencl_pass` passes the **real**
device descriptor (`device-id` was already in scope).

**Generalizing cost nothing here, and that is tested rather than asserted.** `gemm-tile-for` on the
default descriptor reproduces `emit-gemm-tiled`'s literals exactly — 128/128, 32/32, K32, subgroup 16
— and `gemm-schedule` returns the same schedules it returned from its own constants (`[1 1024]`,
`[8 1024]`), with every K-chunk still a multiple of the tile's K-unroll by construction. A part with a
smaller GRF budget and subgroup 8 gets a correctly **rescaled** tile instead of Arc's.

This is de-hardcoding and cross-device correctness, **not a speedup** — prior measurement in-repo says
tile geometry is not the Arc lever (128×128 already optimal, 64×64 −27%).

## The roofline abstains

`balance-for` substituted the scalar `:balance` constant whenever peak-flops or bandwidth were
missing, fabricating an f32-ish ridge for every dtype it didn't know: int8 got **60**, two orders
below any plausible dp4a ridge, and a CPU descriptor carries no peak-flops at all so **every** CPU
ridge was invented. It now returns `nil`, matching `roofline-time-ns`, which already abstained
honestly. A cost model may decline to answer; it must not make one up.

**No live decision changes.** On this device the descriptor carries neither bandwidth nor peak-flops,
so `abstract-machine`'s `:ridge` was *already* `nil` and `vertical-fusion-profitable?` already
abstained. The fabrication was reachable only through direct calls, which have no production callers.
Worth recording separately: the catalogue **has** Arc 140V peak-flops but they are not reaching the
descriptor, so the roofline is even less live than the audit found.

## Validation

40 hardware / schedule / cost / contraction tests + 4 new one-tile-source tests, 0 failures.
Cold-JVM load verified — which is how the one bug in this PR was caught (a definition-order error,
the third of this effort, invisible to a warm REPL because the var was already interned).

## Follow-ups this exposes

1. **`emit-gemm-tiled` hardcodes its instruction family.** It never reads `:matrix :family`, so an
   `:mma`/`:mfma` tile emits Intel builtins with a foreign fragment shape — a latent wrong-kernel
   path. And `emit-gemm-tiled-cuda` exists as a second hand-written GEMM with zero callers. The fix
   is an instruction-**spelling table** keyed by `(:family, operand-dtype, acc-dtype)` — the body
   structure stays (its subgroup-cooperative accumulators and byte-pitch block reads genuinely can't
   come from a generic nest), and about five slots vary per vendor. Intel output stays byte-identical
   because the Intel row *is* today's builtins.
2. **A load-order lint.** Three definition-order errors in this effort, each invisible to the REPL and
   caught only by a cold JVM. Cheap to check per-namespace; better than a fourth manual catch.
