### PR TITLE
Fail loud instead of silently wrong: six plausible-wrong-answer paths in the contraction leaves

### DIFF
--- a/src/raster/ad/reverse.clj
+++ b/src/raster/ad/reverse.clj
@@ -3072,31 +3072,6 @@
 
 (defonce ^:private ror-rename-counter (atom 0))
 
-(defn- alpha-rename-bound
-  "α-rename every let*-bound symbol in a FLAT binding vector to a globally
-  unique name (\"__gp<N>\" suffix, monotonic defonce counter), preserving
-  each binding sym's :raster.type/tag on all occurrences.
-
-  Why: a reified gradient program FREEZES symbols minted under one
-  `with-ad-gensym` scope (counter starts at 0). A LATER AD pass over the
-  frozen program starts a fresh counter, and its ANF lifts mint the same
-  names — silently REBINDING inner syms mid-program (e.g. a float[] anf__2
-  rebound to a Double ANF temp → ClassCastException, or worse a silent
-  wrong gradient). Globally-unique renames make the frozen program safe to
-  re-enter with any gensym state."
-  [bindings tail]
-  (let [bound (vec (take-nth 2 bindings))
-        smap (into {}
-                   (map (fn [s]
-                          [s (with-meta
-                               (symbol (str (name s) "__gp" (swap! ror-rename-counter inc)))
-                               (meta s))]))
-                   bound)
-        rename (fn [form] (walk/postwalk-replace smap form))]
-    [(vec (mapcat (fn [[s init]] [(get smap s s) (rename init)])
-                  (partition 2 bindings)))
-     (rename tail)]))
-
 (defn ^clojure.lang.IFn reified-grad
   "Reify ∂f/∂param of a scalar deftm as a deftm-style meta-fn — the
   double-backward (reverse-over-reverse) composition surface (#72).
@@ -3147,10 +3122,9 @@
         ;; (lower-composites) and reify-pullback each open their OWN
         ;; with-ad-gensym; run BOTH under one shared counter so reify-pullback
         ;; continues from ad-prepare's high-water mark instead of resetting to 0
-        ;; and re-minting colliding anf__ temps. The alpha-rename-bound below
-        ;; assumes its input bindings are already unique — it collapses (not
-        ;; separates) any duplicate bound name — so the collision must be
-        ;; prevented HERE, upstream of the rename.
+        ;; and re-minting colliding anf__ temps. (The old local rename ALSO required its input
+        ;; bindings to be unique, since it collapsed duplicates; util/alpha-convert does not, so
+        ;; this shared counter is now belt-and-braces rather than load-bearing for that reason.)
         {:keys [fwd-bindings result-sym body-sym pullback-form]}
         (call-with-shared-ad-gensym
          (fn [] (reify-pullback (ad-prepare (first walked-body)) diff-params)))
@@ -3169,10 +3143,18 @@
                               ['dy__rad 1.0]
                               rev-bindings
                               tail-bindings))
-        ;; α-rename: the frozen program must survive a fresh-countered
-        ;; second AD pass (see alpha-rename-bound).
-        [bindings' tail'] (alpha-rename-bound bindings tail)
-        form (list 'let* bindings' tail')
+        ;; α-rename so the frozen program survives a fresh-countered second AD pass: a reified
+        ;; gradient FREEZES symbols minted under one `with-ad-gensym` scope, and a later pass starts a
+        ;; fresh counter that re-mints the same `anf__` names, silently rebinding inner syms.
+        ;;
+        ;; util/alpha-convert, not a local rename. The previous local version built its map with
+        ;; `(into {} …)` over the bound names, so a name bound TWICE collapsed to one entry and the
+        ;; first binding's uses read the second's value — a silent wrong gradient. Its docstring and
+        ;; this call site both stated "assumes the bindings are already unique"; nothing asserted it.
+        ;; alpha-convert has no such precondition (util_test pins the separation), renames nested
+        ;; binders too (consistent renaming is semantics-preserving), and carries binder metadata onto
+        ;; every reference — which is what preserved :raster.type/tag before.
+        form (util/alpha-convert (list 'let* bindings tail))
         fn-params (cond-> all-params array-param? (conj c-sym))
         source-ns (or (:ns m) *ns*)
         qualified (inf/qualify-body-symbols form source-ns (set fn-params))

--- a/src/raster/compiler/backend/cpu/csimd.clj
+++ b/src/raster/compiler/backend/cpu/csimd.clj
@@ -19,21 +19,32 @@
             [raster.compiler.backend.intrinsics :as in]
             [raster.compiler.backend.gpu.c-emit :as ce]
             [raster.compiler.core.hardware :as hw]
+            [raster.compiler.core.util :as util]
             [clojure.string :as str]
             [clojure.walk :as walk]))
 
 (defn- inline-lets
-  "Substitute a let*/let's bindings into its body so the lane expression is a single
-   form (no manual kernel-source inlining needed). SIMD value-lambdas are effect-free,
-   so this is sound; each binding value gets prior substitutions, and nested/sequential
-   lets recurse."
+  "Beta-reduce a lane lambda's let bindings into its body so the lane expression is a single form
+   (no manual kernel-source inlining needed). nil if that is not possible, so the caller keeps the
+   scalar loop.
+
+   The rewrite is `util/inline-pure-lets`, shared with the GPU emitter and the SOAC lowerer. Two
+   things the local copy this replaces got wrong, both silent:
+
+     • it had NO purity gate, resting on the unstated claim that `SIMD value-lambdas are effect-free`
+       — an effectful binding was inlined and its effect duplicated per lane;
+     • it kept only `(last body)`, DISCARDING the earlier forms of a multi-statement body. Those
+       forms are exactly the ones held for their effects, so a store could vanish from the
+       vectorized loop while the scalar loop performed it.
+
+   Both are now refusals: nil ⇒ scalar loop, which is correct by construction."
   [expr]
-  (if (and (seq? expr) (contains? #{'let 'let*} (first expr)))
-    (let [[_ binds & body] expr
-          env (reduce (fn [m [s v]] (assoc m s (walk/postwalk-replace m v)))
-                      {} (partition 2 binds))]
-      (inline-lets (walk/postwalk-replace env (last body))))
-    expr))
+  (try
+    (let [r (util/inline-pure-lets expr)]
+      ;; a `do` means the body had several forms; a lane expression cannot carry statements
+      (when-not (and (seq? r) (= 'do (first r))) r))
+    (catch clojure.lang.ExceptionInfo e
+      (when-not (= :impure-binding (:reason (ex-data e))) (throw e)))))
 
 ;; element keyword → intrinsics vector-facet element key
 (defn- vt-of [dtype] (case dtype :double :f64 :float :f32 :long :i32 :int :i32 nil))

--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -14,6 +14,7 @@
               *scalar-type* \"float\"]
       (emit-expr body idx-sym array-syms \"idx\"))"
   (:require [clojure.string :as str]
+            [raster.compiler.core.util :as util]
             [clojure.walk :as walk]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.op-descriptor :as descriptor]
@@ -495,30 +496,7 @@
 ;; Side effect detection
 ;; ================================================================
 
-(defn void-form?
-  "True if the form itself is a void (statement-only) operation.
-   Checks walker-stamped :raster.type/tag first — if present, the form has
-   a return type and is not void. Falls back to op-descriptor registry for
-   compiler primitives (aset, collect!) that pass through the walker as
-   opaque macros and are handled directly by GPU codegen."
-  [expr]
-  (and (seq? expr)
-       (not (:raster.type/tag (meta expr)))
-       (descriptor/void-op? (first expr))))
 
-(defn has-side-effects?
-  "Check if an expression tree contains void (side-effect) operations — including
-  DEVIRTUALIZED array writes (.invk aset-impl …), recognized via the walker-stamped
-  :raster.op/original op (an intermediate's aset materializes to .invk, which the
-  surface-op void-form? check would otherwise miss → a side-effecting binding would be
-  wrongly inlined and re-run)."
-  [expr]
-  (cond
-    (not (seq? expr)) false
-    (void-form? expr) true
-    (and (= '.invk (first expr))
-         (descriptor/aset-op? (:raster.op/original (meta expr)))) true
-    :else (some has-side-effects? (rest expr))))
 
 ;; ================================================================
 ;; Backend-specific helpers
@@ -786,11 +764,11 @@
   "Terminal (non-recur) value expression of a loop BODY (a seq of body forms) —
   the value the loop evaluates to when it exits, via form/terminal-value-expr
   over the implicit do. A VOID terminal (a body ending in a statement-only op
-  like aset) yields nil, so callers fall back to *scalar-type*; void-form? is a
+  like aset) yields nil, so callers fall back to *scalar-type*; util/void-form? is a
   GPU-emission concept, so that check lives here, not in ir/form."
   [body]
   (let [t (form/terminal-value-expr (if (= 1 (count body)) (first body) (cons 'do body)))]
-    (when-not (void-form? t) t)))
+    (when-not (util/void-form? t) t)))
 
 (defn- emit-loop-body
   "Emit the body of a loop as C while-body statements. var-types parallels var-names — the
@@ -887,7 +865,7 @@
            " } else { break; }"))
 
     ;; Void terminal (aset, collect!, atomic-add!) -> emit as stmt then break
-    (void-form? expr)
+    (util/void-form? expr)
     (str (emit-stmt expr idx-sym array-syms opencl-idx) " break;")
 
     ;; Terminal expression -> assign to the typed result var (reduction value)
@@ -1005,7 +983,7 @@
                   ;; side-effecting binding into a later loop body re-runs its writes every
                   ;; iteration (silent miscompile).
                   (if (or (multi-use? sym)
-                          (has-side-effects? val)
+                          (util/effectful? val)
                           (and (seq? val-subst) (contains? #{'loop 'loop*} (first val-subst))))
                     (let [base-name (c-symbol sym)
                           prev-count (get seen-names base-name 0)
@@ -1034,7 +1012,7 @@
            leading-body (butlast all-body)
            tail-body (last all-body)
            has-leading? (and (seq leading-body)
-                             (some has-side-effects? leading-body))]
+                             (some util/effectful? leading-body))]
        ;; Emit leading statements + body under the int vars bound by this scope's
        ;; bindings, so references to int-typed locals (index math) type as int.
        (binding [*int-vars* (into *int-vars* ints)]
@@ -1079,7 +1057,7 @@
                   " " (emit-expr last-expr idx-sym array-syms opencl-idx) "; })"))
            ;; GLSL: no statement expressions
            (let [leading (butlast stmts)]
-             (if (some has-side-effects? leading)
+             (if (some util/effectful? leading)
                (throw (ex-info "GLSL: do block has non-tail forms with side effects but statement expressions are not supported"
                                {:expr expr}))
                (emit-expr (last stmts) idx-sym array-syms opencl-idx))))))
@@ -1099,8 +1077,8 @@
            ;; GLSL: emit as ternary with 0 fallback
            (str "((" cond-str ") ? ("
                 (emit-expr then-expr idx-sym array-syms opencl-idx) ") : 0)"))
-         (let [side-effects? (or (has-side-effects? then-expr)
-                                 (has-side-effects? else-expr))]
+         (let [side-effects? (or (util/effectful? then-expr)
+                                 (util/effectful? else-expr))]
            (if (and side-effects? (supports-stmt-expr?))
              (str "({ " *scalar-type* " _r; if (" cond-str ") { "
                   (emit-stmts-with-result then-expr idx-sym array-syms opencl-idx "_r")
@@ -1891,28 +1869,16 @@
       :else nil)))
 
 (defn- inline-pure-lets
-  "Deep-inline EVERY pure let/let* (no side effects, not loops) anywhere in the form,
-  so subscript index expressions are exposed and no scalar local is declared for a
-  value that becomes a vector (a nested let inside a store value would otherwise emit
-  `float x = <float4>` — a type error). A vectorizable straight-line body has only
-  pure bindings; an impure/loop-valued binding throws vec-bail! (→ scalar loop)."
+  "Deep-inline every pure let/let* anywhere in the form, so subscript index expressions are exposed
+  and no scalar local is declared for a value that becomes a vector (a nested let inside a store
+  value would otherwise emit `float x = <float4>` — a type error).
+
+  The rewrite itself is `util/inline-pure-lets` — shared with the SOAC lowerer and the CPU SIMD
+  emitter, whose own copies lacked this purity gate. All this adds is the local refusal channel: a
+  vectorizable straight-line body has only pure bindings, so an impure or loop-valued binding
+  vec-bail!s to the scalar loop rather than throwing."
   [expr]
-  (walk/prewalk
-   (fn [f]
-     (if (and (seq? f) (contains? #{'let 'let*} (first f)))
-       (let [[_ bindings & body] f
-             pairs (partition 2 bindings)]
-         (when (some (fn [[_ v]] (or (has-side-effects? v)
-                                     (and (seq? v) (contains? #{'loop 'loop*} (first v)))))
-                     pairs)
-           (vec-bail!))
-         (let [env (reduce (fn [env [s v]]
-                             (assoc env s (walk/postwalk-replace env v)))
-                           {} pairs)
-               body' (mapv #(walk/postwalk-replace env %) body)]
-           (if (= 1 (count body')) (first body') (cons 'do body'))))
-       f))
-   expr))
+  (util/inline-pure-lets expr :on-impure (fn [_ _] (vec-bail!))))
 
 (defn- aget-form?* [f] (and (seq? f) (>= (count f) 3) (descriptor/aget-op? (first f))))
 (defn- aset-form?* [f] (and (seq? f) (>= (count f) 4) (descriptor/aset-op? (first f))))

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -186,8 +186,25 @@
                      :desc (try ((requiring-resolve 'raster.compiler.core.hardware/descriptor-for)
                                  device-id)
                                 (catch Throwable _ nil)))
-                  k (register-kernel! {:kernel-name (:kernel-name r) :source (:source r)
-                                       :dtype (:dtype r)}
+                  ;; :pre-steps (an inserted layout transpose) is PRODUCED by route-contraction
+                  ;; under :prefer-peak? but executed by NOTHING — the kernel would index a
+                  ;; transposed layout against an untransposed buffer, a wrong answer with no
+                  ;; diagnostic. Unreachable today (:prefer-peak? is never set here), so refusing
+                  ;; costs nothing now and converts a future silent miscompile into a loud one.
+                  _ (when (seq (:pre-steps r))
+                      (throw (ex-info (str "contraction: descriptor carries :pre-steps, which no "
+                                           "pass executes — the operand would be read untransposed")
+                                      {:reason :raster/fatal :pre-steps (:pre-steps r)})))
+                  ;; Register the ROUTED KERNEL MAP, not three hand-picked keys. Dropping
+                  ;; :c-op/:identity-val made invoke-reduction-kernel fall back to its
+                  ;; `:or {c-op "+" identity-val 0.0}` for the HOST-SIDE FINAL COMBINE — so a
+                  ;; full reduction with :combine max or :combine * spanning more than one
+                  ;; workgroup silently SUMMED the per-group partials. Reachable today: a
+                  ;; 0-free-axis contraction at :float/:double is exactly what this pass routes.
+                  k (register-kernel! (merge (select-keys r [:c-op :identity-val :array-params
+                                                             :scalar-params :out-dtype])
+                                             {:kernel-name (:kernel-name r) :source (:source r)
+                                              :dtype (:dtype r)})
                                       :ze-contracts)]
               ;; A full reduction (0 free axes) has its own two-phase launch protocol + a
               ;; host-side final combine — emit the reduction invoke, not the 2-D contraction one.

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -897,6 +897,16 @@
       (not (every? :map operands)) {:ok false :reason :operand-without-a-declared-map}
       (not (and (dt/known? dtype) (= :byte (dt/canon dtype))))
       {:ok false :reason :dp4a-needs-int8-operands :dtype dtype}
+      ;; A :decode is a LOAD-LAMBDA applied by substituting into the body — and this leaf discards
+      ;; the body, replacing the whole summand with one rstr_dp4a call. So a zero-point would be
+      ;; silently dropped: Σ a·b instead of Σ(a−za)(b−zb), wrong by a constant-plus-linear term with
+      ;; no diagnostic. Load-bearing, since q4_0/q8_0 carry zero-points 8 and 128. Same underlying
+      ;; reason as :body-has-unmodeled-terms below — the body is not evaluated here.
+      (some :decode operands)
+      {:ok false :reason :decode-on-a-body-replacing-leaf
+       :detail "this leaf replaces the body with a single hardware op, so a per-operand :decode (e.g. a zero-point) would be silently dropped"
+       :decoded (mapv :sym (filter :decode operands))}
+
       (not exact-product?)
       {:ok false :reason :body-has-unmodeled-terms
        :detail "this leaf replaces the body with a single hardware op; any term beyond the two declared operands would be silently dropped"

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -853,9 +853,12 @@
     (str/join "\n"
               (map-indexed
                (fn [p [sym bound]]
-                 (let [after (map second (subvec v (inc p) n))
+                 ;; bounds go through c-symbol too: a symbolic bound named `n-cols` was emitted
+                 ;; raw as `(seg / (n-cols))` — valid C that computes `n - cols`.
+                 (let [bc (fn [b] (if (symbol? b) (ce/c-symbol b) b))
+                       after (map (comp bc second) (subvec v (inc p) n))
                        div (if (seq after) (str "(seg / (" (str/join " * " after) "))") "seg")]
-                   (str "    int " (ce/c-symbol sym) " = " div " % " bound ";")))
+                   (str "    int " (ce/c-symbol sym) " = " div " % " (bc bound) ";")))
                v))))
 
 (defn staged-inner-dp4a-legal?
@@ -959,6 +962,16 @@
         _ (when (nil? contract-axes)
             (throw (ex-info "staged contraction: :contract-axes is required — the stage list can only be validated against the axes the form declared"
                             {:reason :missing-declared-contract-axes :stages stages})))
+        ;; This emitter interpolates extents into the loop bounds and the decompose but declares no
+        ;; scalar params for them, so a symbolic bound emits an UNDECLARED identifier — and
+        ;; validate-descriptor passes it (the counts agree), so it fails only at device build, i.e.
+        ;; never in CI. Its segmented-reduce sibling declares them; until this one does, refuse.
+        _ (let [syms (remove number? (concat (map second free-axes) (map :extent stages)))]
+            (when (seq syms)
+              (throw (ex-info (str "staged contraction: symbolic bounds are not supported by this "
+                                   "emitter (it declares no scalar params for them) — "
+                                   (pr-str (vec syms)))
+                              {:reason :symbolic-bounds-unsupported :bounds (vec syms)}))))
         legal (cstage/stages-legal? stages contract-axes)
         _ (when-not (:ok legal)
             (throw (ex-info (str "staged contraction: illegal stages (" (:reason legal) ")")
@@ -1068,7 +1081,12 @@
                     ", __global " out-ctype "* restrict out"
                     (when ep (:epilogue-params ep))
                     ", int _nseg")
-        src (str (when tz (:c-helper-src (intrinsics/descriptor 'dp4a)))
+        src (str
+                 ;; fp64/fp16 need their OpenCL extension enabled. All three sibling emitters emit
+                 ;; this; the staged one did not, so a :double staged contraction — reachable from
+                 ;; opencl_pass, whose default dtype IS :double — emitted `double` with no pragma.
+                 (codegen/extension-pragmas out-dtype dtype)
+                 (when tz (:c-helper-src (intrinsics/descriptor 'dp4a)))
                  (when ep (:epilogue-helpers ep))
                  "__kernel void " kernel-name "(" params ") {\n"
                  "    int seg = get_global_id(0);\n"

--- a/src/raster/compiler/core/util.clj
+++ b/src/raster/compiler/core/util.clj
@@ -1,6 +1,7 @@
 (ns raster.compiler.core.util
   "Shared utilities for the compiler pipeline."
   (:require [clojure.set :as set]
+            [raster.compiler.core.op-descriptor :as od]
             [raster.compiler.ir.form :as form]
             [raster.compiler.ir.par :as par]))
 
@@ -292,6 +293,46 @@
     (set? form) (into (empty form) (map #(uniquify* env bound %) form))
     :else form))
 
+(defn scope-blind-substitution-safe?
+  "Is a scope-BLIND symbol substitution of `smap` over `expr` provably equivalent to the
+   capture-avoiding `subst-syms`?
+
+   A hot pass may legitimately want the blind version — it is measured ~4x faster than `subst-syms`
+   on a 300-binding ANF form, because `subst-syms` recomputes the free set of every smap value at
+   every binder it crosses. What it may NOT do is assume the precondition. Blind substitution
+   diverges in exactly three ways, and this checks all three:
+
+     • KEY capture — a binder in `expr` rebinds an smap key. Blind substitution keeps rewriting
+       inside that scope, and rewrites the BINDER itself: substituting {k → HIJACKED} over
+       `(fn* [k] …)` yields `(fn* [HIJACKED] …)`.
+     • VALUE capture — a binder shadows a name that is free in an smap VALUE, so the substituted
+       value silently starts referring to the inner binding instead of the outer one.
+     • `quote` — blind substitution descends into quoted data and rewrites it as if it were code.
+
+   Callers that get `false` must use `subst-syms`. The cost here is one binder scan plus ONE free-set
+   computation over the smap values (versus one per binder inside `subst-syms`), so checking and then
+   taking the fast path stays well ahead of the safe path."
+  [smap expr]
+  (if (empty? smap)
+    true
+    (let [dangerous (into (set (keys smap)) (smap-value-frees smap))
+          safe (volatile! true)]
+      ((fn go [e]
+         (when @safe
+           (cond
+             (and (seq? e) (= 'quote (first e))) (vreset! safe false)
+             (seq? e)
+             (do (when-let [{:keys [scopes]} (form/scope-info e)]
+                   (doseq [{:keys [binders]} scopes
+                           b binders
+                           :when (and (symbol? b) (contains? dangerous b))]
+                     (vreset! safe false)))
+                 (run! go e))
+             (coll? e) (run! go e)
+             :else nil)))
+       expr)
+      @safe)))
+
 (defn uniquify-rebindings
   "SSA-normalize let*/loop* REBINDINGS: rename any binder that SHADOWS a name
    already in scope (seeded with `params`) to a fresh name, capture-avoidingly
@@ -389,3 +430,112 @@
          m (cond-> (or original-meta {})
              op (assoc :raster.op/original op))]
      (with-meta (list* '.invk impl-sym args) m))))
+
+(defn void-form?
+  "Does this form have NO return value — i.e. is it a statement rather than an expression?
+
+   Reads the walker/TC-stamped `:raster.type/tag` first: if the form has a return type it is not
+   void. Falls back to the op-descriptor registry for the compiler primitives (`aset`, `collect!`)
+   that pass through the walker as opaque macros."
+  [expr]
+  (and (seq? expr)
+       (not (:raster.type/tag (meta expr)))
+       (od/void-op? (first expr))))
+
+(defn effectful?
+  "Does `expr` contain a side-effecting (void) operation anywhere?
+
+   The layer-neutral purity predicate for beta-reduction decisions. Recognizes both the surface
+   spelling (`void-form?`) and the DEVIRTUALIZED array write — an intermediate's `aset`
+   materializes to `(.invk aset-impl …)`, which a head-only check misses, so an effectful binding
+   would be inlined and its effect duplicated or reordered.
+
+   `quote` is opaque: quoted data is not code to be scanned for effects."
+  [expr]
+  (boolean
+   (and (seq? expr)
+        (not= 'quote (first expr))
+        (or (void-form? expr)
+            (and (= '.invk (first expr))
+                 (od/aset-op? (:raster.op/original (meta expr))))
+            (some effectful? (rest expr))))))
+
+(defn binding-env
+  "A `let*` binding vector → the substitution env that beta-reduces it: {sym → init}, with each
+   init already carrying the substitutions of the bindings BEFORE it (`let*` is sequential).
+
+   Built with `subst-syms`, so an init that rebinds an earlier name internally is not corrupted.
+   Split out because one caller (the SOAC lowerer) has already destructured the let and recursed
+   into its body, so it needs the env rather than the whole-form rewrite."
+  [bindings]
+  (reduce (fn [m [s init]] (assoc m s (subst-syms m init)))
+          {} (partition 2 bindings)))
+
+(defn inline-pure-lets
+  "Beta-reduce `let*`/`let` bindings into their body — the ONE implementation of this rewrite.
+
+   Consolidates three copies that each used `walk/postwalk-replace` and each carried a different,
+   unstated precondition: the GPU expression emitter's (the only one with a purity gate), the SOAC
+   lowerer's (`walker bindings are SSA`), and the CPU SIMD emitter's (which additionally kept only
+   the LAST body form, silently discarding the effects of the earlier ones).
+
+   Three things this does that `walk/postwalk-replace` inside `walk/prewalk` did not:
+
+     • substitutes via `subst-syms`, so a nested rebinding of an inlined name — or a name that also
+       appears in a binder or array position — cannot be corrupted;
+     • preserves metadata on every rebuilt form. `clojure.walk` rebuilds seqs with `(apply list …)`
+       and drops meta, which in this pipeline discards TC `:raster.type/tag` stamps AND the
+       `:raster.op/original` stamps that `effectful?` itself reads — so the old version could defeat
+       its own purity gate on a second pass;
+     • reaches a FIXPOINT bottom-up. `prewalk` never revisits the form a reduction produces, so a
+       `let*` exposed by inlining survived.
+
+   opts:
+     :pure?      (fn [init] -> boolean) — is this binding's value inlinable? Defaults to
+                 `(complement effectful?)` plus a refusal of loop-valued inits. The default is the
+                 REAL gate, not `(constantly true)`: the whole point of consolidating is that the
+                 two callers which lacked a gate gain one.
+     :on-impure  (fn [sym init] -> any) — called for the first non-inlinable binding; its value is
+                 discarded, so it must escape (throw / bail). Default throws. The GPU vectorizer
+                 passes its `vec-bail!` to fall back to a scalar loop.
+     :deep?      rewrite nested lets throughout the form (default true) rather than only a
+                 top-level chain.
+
+   A multi-form body becomes `(do …)`. It is NOT reduced to its last form: that silently drops the
+   earlier forms' effects. A consumer that cannot emit `do` must refuse loudly instead."
+  [expr & {:keys [pure? on-impure deep?] :or {deep? true}}]
+  (let [pure? (or pure?
+                  (fn [init] (not (or (effectful? init)
+                                      (and (seq? init) (form/loop-head? (first init)))))))
+        let-form? (fn [f] (and (seq? f) (form/let-head? (first f))
+                               (not (form/loop-head? (first f)))))
+        reduce-one
+        (fn [form]
+          (let [[_ bindings & body] form
+                pairs (partition 2 bindings)]
+            (when-let [[bs bv] (first (remove (comp pure? second) pairs))]
+              (if on-impure
+                (on-impure bs bv)
+                (throw (ex-info "inline-pure-lets: binding value is not inlinable"
+                                {:reason :impure-binding :sym bs :init bv})))
+              ;; on-impure returned instead of escaping — that would silently inline an effect
+              (throw (ex-info "inline-pure-lets: :on-impure must escape, it returned normally"
+                              {:reason :raster/bug :sym bs :init bv})))
+            (let [env (binding-env bindings)
+                  body' (mapv #(subst-syms env %) body)]
+              (if (= 1 (count body'))
+                (first body')
+                (with-meta (cons 'do body') (meta form))))))
+        ;; bottom-up, metadata-preserving, quote-opaque descent. Not clojure.walk: it drops meta.
+        go (fn go [f]
+             (cond
+               (and (seq? f) (= 'quote (first f))) f
+               (seq? f) (let [f' (remake-from f (map go f))]
+                          (if (let-form? f') (recur (reduce-one f')) f'))
+               (vector? f) (with-meta (mapv go f) (meta f))
+               (map? f) (with-meta (into (empty f) (map (fn [[k v]] [(go k) (go v)])) f) (meta f))
+               (set? f) (with-meta (into (empty f) (map go) f) (meta f))
+               :else f))]
+    (if deep?
+      (go expr)
+      (loop [e expr] (if (let-form? e) (recur (reduce-one e)) e)))))

--- a/src/raster/compiler/ir/soac.clj
+++ b/src/raster/compiler/ir/soac.clj
@@ -12,6 +12,7 @@
     SoacStencil — neighborhood stencil (fixed radius)
     ScalarBinding — non-parallel scalar/allocation binding"
   (:require [raster.compiler.ir.par :as par]
+            [raster.compiler.ir.form :as form]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
             [clojure.set :as set]
@@ -154,18 +155,6 @@
     (second e)
     e))
 
-(defn- inline-let-bindings
-  "Beta-reduce let* bindings into `expr`: substitute each bound symbol with its
-   definition. Walker-produced bindings are SSA (each symbol bound once, no
-   shadowing), so iterative substitution in reverse order is sound — a later
-   binding referencing an earlier one is resolved when the earlier one is
-   inlined. Duplicates loads (e.g. g=gate[i] used several times), which the C
-   compiler CSEs; the payoff is a single flat expression that the existing
-   aget-substitution fusion + expression emitter handle directly."
-  [binds expr]
-  (reduce (fn [acc [s e]] (walk/postwalk-replace {s e} acc))
-          expr (reverse (partition 2 binds))))
-
 (defn- single-aset-void
   "If a par/map-void! body is a SINGLE in-place write `(aset OUT idx VAL)` whose
    index is exactly the loop index (a 1:1 elementwise write — NOT an offset/scatter
@@ -190,11 +179,20 @@
                (second body) body)]
     (cond
       ;; let*-wrapped write: recurse into the SOLE let body form, then inline the bindings
-      (and (seq? stmt) (contains? #{'let* 'let} (first stmt)))
+      (and (seq? stmt) (form/let-head? (first stmt)))
       (let [[_ binds & lbody] stmt]
-        (when (= 1 (count lbody))
+        (when (and (= 1 (count lbody))
+                   ;; PURITY GATE. This inlining duplicates each binding into the lambda, so an
+                   ;; effectful init would have its effect duplicated or reordered. The old
+                   ;; `postwalk-replace` copy had no gate and rested on an unstated `walker bindings
+                   ;; are SSA` precondition. Refusing here is free: nil ⇒ ScalarBinding ⇒ the legacy
+                   ;; void path, which emits the body as written.
+                   (not-any? util/effectful? (take-nth 2 (rest binds))))
           (when-let [inner (single-aset-void (first lbody) idx-sym)]
-            (update inner :value #(inline-let-bindings binds %)))))
+            ;; capture-avoiding: an init that rebinds an earlier name internally, or a name that
+            ;; also appears in a binder/array position, is not corrupted the way postwalk-replace
+            ;; corrupted it.
+            (update inner :value #(util/subst-syms (util/binding-env binds) %)))))
 
       (descriptor/aset-call? stmt)
       (let [cargs (vec (descriptor/call-args stmt))]   ;; (arr idx-expr val)

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -192,7 +192,16 @@
       ;; contraction algebra at all. The flat leaves below cannot represent it — they have one
       ;; accumulator. 1 stage is the flat case and is left to them.
       (and (seq stages) (> (count stages) 1))
-      (let [;; PEAK: with declared+verified operand maps, the inner stage tensorizes to dp4a (4 int8
+      (let [;; The staged emitter hardwires `+=` at every level, and a lift's linearity argument
+            ;; assumes `+`. A form carrying :combine max routed here and was SILENTLY SUMMED —
+            ;; contraction-facts surfaces :combine and nothing read it. Refuse rather than ignore.
+            _ (let [cmb (:combine (cf/contraction-facts contract-form :dtype dtype))]
+                (when-not (contains? '#{+ clojure.core/+ raster.numeric/+} cmb)
+                  (throw (ex-info (str "staged contraction: only `+` combine is supported (got "
+                                       cmb ") — every accumulator level uses += and a lift's "
+                                       "linearity argument assumes addition")
+                                  {:reason :non-plus-combine-on-staged :combine cmb}))))
+            ;; PEAK: with declared+verified operand maps, the inner stage tensorizes to dp4a (4 int8
             ;; MACs per int32 op) — the int8 peak leaf, and the same shape llama.cpp hand-writes.
             ;; Only attempted when the caller asked for peak AND the gate passes; a gate rejection
             ;; falls back to the scalar nest, so requesting peak can never yield a wrong kernel.
@@ -248,6 +257,17 @@
          :scalar-args [] :dims [1]})
 
       ;; 0 contract axes → outer product / broadcast → pure N-D SegMap (1-D launch)
+      ;; :segmap and the :else fallback have no store splice, so an :epilogue reaching them was
+      ;; silently DROPPED — the consumer's computation vanished with no error. fuse-contract-map
+      ;; already produces such forms (no rank restriction), and it is one line in par-fusion-pass
+      ;; away from being live, so this refuses now rather than after.
+      (and (seq epilogue) (or (zero? n-contract)
+                              (not (and (= 2 n-free) (= 1 n-contract)))))
+      (throw (ex-info (str "contraction: this leaf has no store splice, so its :epilogue would be "
+                           "silently dropped (n-free " n-free ", n-contract " n-contract ")")
+                      {:reason :epilogue-unsupported-by-this-leaf
+                       :n-free n-free :n-contract n-contract}))
+
       (zero? n-contract)
       (let [sm (cl/contract-form->segmap contract-form :dtype dtype)
             {:keys [kernel-name source array-params scalar-params]}

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -150,6 +150,29 @@
 
 (declare route-2free-1contract route-quant)
 
+(def ^:private splice-capable-strategies
+  "Strategies whose emitter has a store splice, and can therefore honour an :epilogue.
+   A WHITELIST on purpose: refuse by ABSENCE of support, never by a blacklist of shapes — a
+   blacklist got this wrong twice, most recently by exempting the only shape production produces.
+   `:dpas` splices through emit-gemm-tiled; the three staged-emitter strategies splice at the store
+   (which is how a quant dequant scale is expressed since :scheme was deleted)."
+  #{:dpas :dp4a :quant-naive :staged-segred})
+
+(defn- epilogue-honoured-or-refused
+  "An :epilogue is a STORE SPLICE, and only the DPAS leaf has one. Every other leaf drops it
+   silently — the consumer's computation vanishes with no error.
+
+   Decided AFTER routing, on the strategy actually chosen, because a pre-routing shape test got this
+   wrong twice: a shape blacklist exempted (2 free, 1 contract) — the only shape production produces
+   — and a version keyed on the tensorize plan forced that plan early and refused shapes DPAS would
+   have accepted. The chosen strategy is the only reliable witness of whether a splice exists."
+  [epilogue d]
+  (when (and (seq epilogue) (not (contains? splice-capable-strategies (:strategy d))))
+    (throw (ex-info (str "contraction: strategy " (:strategy d) " has no store splice, so its "
+                         ":epilogue would be silently dropped")
+                    {:reason :epilogue-unsupported-by-this-leaf :strategy (:strategy d)})))
+  d)
+
 (defn route-contraction
   "Route a contraction form to the hardware-optimal kernel via the DPAS legality gate.
    dtype selects the element type of the intended kernel (:half tries DPAS; :byte/:int8 tries
@@ -185,7 +208,9 @@
     ;; failure mode it guards is a LAUNCH-time arity mismatch (valid C, wrong number of bound args),
     ;; which has bitten twice; validating at generation makes it a loud compile-time error instead.
     (validate-descriptor
-     (cond
+     (epilogue-honoured-or-refused
+      epilogue
+      (cond
       ;; STAGED contract axis → the multi-level accumulate leaf. Checked FIRST because staging is
       ;; a property of the reduction itself, not of the dtype: it is what lets a block-quantized
       ;; format (int32 MAC inside the block, float accumulate across blocks) be expressed in the
@@ -253,20 +278,15 @@
          :array-params (:array-params k)
          :dtype dtype :out-dtype dtype :out-elems 1
          :n-phases (:n-phases k)
+         ;; CARRY THE COMBINE. invoke-reduction-kernel reads :c-op/:identity-val from the kernel
+         ;; REGISTRY for its host-side final combine, defaulting to `+`/0.0. Widening the
+         ;; registration to pass the whole descriptor through (as a previous commit did) is a no-op
+         ;; unless the descriptor actually contains them — generate-segred-kernel returns them into
+         ;; a local that was discarded here. Without this, a multi-workgroup `:combine max` or `*`
+         ;; silently SUMS its per-group partials.
+         :c-op (:c-op k) :identity-val (:identity-val k)
          :reduce-bound red-bound          ; element count the reduction spans
          :scalar-args [] :dims [1]})
-
-      ;; 0 contract axes → outer product / broadcast → pure N-D SegMap (1-D launch)
-      ;; :segmap and the :else fallback have no store splice, so an :epilogue reaching them was
-      ;; silently DROPPED — the consumer's computation vanished with no error. fuse-contract-map
-      ;; already produces such forms (no rank restriction), and it is one line in par-fusion-pass
-      ;; away from being live, so this refuses now rather than after.
-      (and (seq epilogue) (or (zero? n-contract)
-                              (not (and (= 2 n-free) (= 1 n-contract)))))
-      (throw (ex-info (str "contraction: this leaf has no store splice, so its :epilogue would be "
-                           "silently dropped (n-free " n-free ", n-contract " n-contract ")")
-                      {:reason :epilogue-unsupported-by-this-leaf
-                       :n-free n-free :n-contract n-contract}))
 
       (zero? n-contract)
       (let [sm (cl/contract-form->segmap contract-form :dtype dtype)
@@ -300,7 +320,7 @@
          ;; name); they must be bound BEFORE the trailing count or the launch arity is wrong.
          :scalar-args (conj (mapv (fn [p] {:type :int :value p}) scalar-params)
                             {:type :int :value nseg})
-         :out-elems nseg :dims [nseg]})))))
+         :out-elems nseg :dims [nseg]}))))))
 
 (defn- route-2free-1contract
   "The tensorize fast path: DPAS if the gate accepts, else the register-tiled portable kernel.

--- a/src/raster/compiler/passes/scalar/cse.clj
+++ b/src/raster/compiler/passes/scalar/cse.clj
@@ -4,6 +4,7 @@
    Walks forward through bindings, caching expr → first-sym.
    Duplicate expressions become aliases; DCE cleans dead bindings."
   (:require [raster.compiler.passes.scalar.effects :as effects]
+            [raster.compiler.core.util :as util]
             [raster.compiler.ir.form :as form]))
 
 (defn- normalize-expr
@@ -33,21 +34,32 @@
           (when (and (>= idx 0) (< idx (count v)))
             (clojure.core/nth v idx)))))))
 
-(defn- subst-syms-in
-  "Scope-BLIND symbol substitution. Intentionally NOT the capture-avoiding
-   `util/subst-syms`: cse-let runs only on a FLAT `let*` with gensym-unique
-   binding names (the pipeline guarantees ANF flatness before CSE), so there is
-   no shadowing and blind substitution is both correct and faster. Do NOT use
-   this on nested/un-flattened forms — use `util/subst-syms` there."
+(defn- subst-blind
+  "Scope-BLIND symbol substitution — the fast path, valid only under the precondition that
+   `util/scope-blind-substitution-safe?` checks."
   [smap expr]
   (cond
     (symbol? expr) (get smap expr expr)
-    (seq? expr) (let [new-children (map (partial subst-syms-in smap) expr)]
-                  (if-let [m (meta expr)]
-                    (with-meta (apply list new-children) m)
-                    (apply list new-children)))
-    (vector? expr) (mapv (partial subst-syms-in smap) expr)
+    (seq? expr) (util/remake-from expr (map (partial subst-blind smap) expr))
+    (vector? expr) (mapv (partial subst-blind smap) expr)
     :else expr))
+
+(defn- subst-syms-in
+  "Substitute symbols per `smap` in `expr`.
+
+   cse-let runs on a FLAT `let*` with gensym-unique binding names (the pipeline guarantees ANF
+   flatness before CSE), so scope-blind substitution is normally both correct and ~4x faster than
+   the capture-avoiding `util/subst-syms`. That precondition used to live only in this docstring.
+   Now it is CHECKED, and a form that violates it takes the capture-avoiding path instead of being
+   quietly corrupted — blind substitution rewrites binder positions outright, e.g. {k → v} over
+   `(fn* [k] …)` produces `(fn* [v] …)`.
+
+   So there is one semantics and one optimization guarded by a verified precondition, rather than a
+   second substitution with an assumption attached."
+  [smap expr]
+  (if (util/scope-blind-substitution-safe? smap expr)
+    (subst-blind smap expr)
+    (util/subst-syms smap expr)))
 
 (defn cse-let
   "Apply CSE and constant propagation to a flat let* form.

--- a/src/raster/compiler/passes/scalar/pe.clj
+++ b/src/raster/compiler/passes/scalar/pe.clj
@@ -16,6 +16,7 @@
   and the bytecode compiler consumes. Does NOT modify the form structure
   beyond the transformations above — preserves metadata, qualified symbols, etc."
   (:require [raster.compiler.ir.form :as form]
+            [raster.compiler.core.util :as util]
             [raster.compiler.passes.scalar.normalize :as normalize]
             [raster.compiler.passes.scalar.simplify :as simp]
             [raster.core :as rcore]))
@@ -114,6 +115,26 @@
 ;; Partial evaluation - single pass
 ;; ================================================================
 
+(defn- env-safe-in-scope
+  "The const-env entries that may be substituted INSIDE a scope binding `binders`.
+
+   Drops two capture directions, and only the first was previously handled anywhere:
+
+     KEY capture   — a binder rebinds an env KEY, so substituting would replace the scope-local
+                     name (a par index `i` against an outer `{i 99}`).
+     VALUE capture — an env VALUE is free out here but BOUND in there, so substituting moves the
+                     reference from the outer binding to the inner binder. `pe`'s env can hold a
+                     bare symbol (`trivial?` admits symbols), so `{x i}` inside
+                     `(dotimes [i n] … x …)` rewrote `x` to the LOOP INDEX: a well-formed program
+                     computing the wrong thing, with no key collision to notice.
+
+   Dropped rather than alpha-renamed. Renaming would add another substitution surface, and losing a
+   constant here costs one folding opportunity in a rare shape — `util/subst-syms` renames because
+   it must preserve every substitution, whereas a partial evaluator is free to decline."
+  [const-env binders]
+  (let [bs (into #{} (filter symbol?) binders)]
+    (into {} (remove (fn [[k v]] (or (bs k) (some bs (util/free-syms v))))) const-env)))
+
 (defn- pe-let
   "Partially evaluate a let/let*/loop form.
   - Propagate constants into body
@@ -139,7 +160,7 @@
       ;; Loop: PE init exprs but keep all bindings. Don't propagate
       ;; constants into body because recur will change them.
       (let [loop-syms (set (map first binding-pairs))
-            body-env (apply dissoc const-env loop-syms)
+            body-env (env-safe-in-scope const-env loop-syms)
             pe-bindings (vec (mapcat (fn [[sym init]]
                                        [sym (pe-fn init const-env)])
                                      binding-pairs))
@@ -401,7 +422,7 @@
         (form/scope-info form)
         (let [{:keys [scopes outer rebuild]} (form/scope-info form)]
           (rebuild (mapv (fn [{:keys [binders inits body]}]
-                           (let [env' (apply dissoc const-env (filter symbol? binders))]
+                           (let [env' (env-safe-in-scope const-env binders)]
                              {:binders binders
                               :inits (mapv #(pe-pass % env') inits)
                               :body  (mapv #(pe-pass % env') body)}))

--- a/test/raster/compiler/core/inline_pure_lets_test.clj
+++ b/test/raster/compiler/core/inline_pure_lets_test.clj
@@ -1,0 +1,212 @@
+(ns raster.compiler.core.inline-pure-lets-test
+  "ONE beta-reduction of `let*`. Device-free.
+
+   Three copies of this rewrite existed — the GPU expression emitter's, the SOAC lowerer's, and the
+   CPU SIMD emitter's — each built on `walk/postwalk-replace` inside `walk/prewalk`, and each
+   carrying a DIFFERENT unstated precondition. Consolidating them is only safe if the shared version
+   keeps the one gate that existed and repairs what all three shared:
+
+     • `postwalk-replace` is not capture-avoiding: it rewrites binders and array positions.
+     • `clojure.walk` rebuilds seqs with `(apply list …)`, dropping metadata — which in this pipeline
+       discards TC `:raster.type/tag` stamps and the `:raster.op/original` stamps the purity
+       predicate itself reads, so the gate could be defeated on a later pass.
+     • `prewalk` never revisits the form a reduction produces, so a `let*` exposed by inlining
+       survived.
+
+   The migration's real risk is a loud→silent trade: two of the three callers had NO purity gate, so
+   the natural refactor is to make the shared signature agree by dropping the gate. The final
+   section pins each caller's refusal channel so that cannot happen quietly."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.core.util :as util]))
+
+;; ── the purity predicate the default gate is built from ─────────────────────────────
+(deftest effectful-sees-surface-and-devirtualized-writes
+  (testing "a surface void op"
+    (is (util/effectful? '(raster.arrays/aset O 0 1.0)))
+    (is (util/effectful? '(clojure.core/+ 1 (raster.arrays/aset O 0 1.0)))
+        "…at any depth, since inlining hoists the whole tree"))
+  (testing "a DEVIRTUALIZED write, recognized only via the walker's :raster.op/original stamp —
+            an intermediate's aset materializes to .invk, which a head-only check misses"
+    (is (util/effectful? (with-meta (list '.invk 'impl 'O 0 1.0)
+                           {:raster.op/original 'raster.arrays/aset}))))
+  (testing "a tagged form has a return type and is therefore not a statement"
+    (is (not (util/effectful? (with-meta (list 'raster.arrays/aset 'O 0 1.0)
+                                {:raster.type/tag 'Double})))))
+  (testing "pure arithmetic and reads"
+    (is (not (util/effectful? '(clojure.core/* (raster.arrays/aget A i) 2)))))
+  (testing "quoted data is data, not code to scan"
+    (is (not (util/effectful? '(quote (raster.arrays/aset O 0 1.0)))))))
+
+;; ── the rewrite ─────────────────────────────────────────────────────────────────────
+(deftest sequential-inits-see-the-prior-bindings
+  (testing "let* is sequential: b's init must already carry a's substitution"
+    (is (= '(clojure.core/+ (clojure.core/* (raster.arrays/aget A i) 2) 1)
+           (util/inline-pure-lets
+            '(let* [a (raster.arrays/aget A i)
+                    b (clojure.core/* a 2)]
+               (clojure.core/+ b 1))))))
+  (testing "binding-env exposes the same env for the caller that has already destructured"
+    (is (= '{a (raster.arrays/aget A i) b (clojure.core/* (raster.arrays/aget A i) 2)}
+           (util/binding-env '[a (raster.arrays/aget A i) b (clojure.core/* a 2)])))))
+
+(deftest an-inner-rebinding-of-an-inlined-name-is-not-corrupted
+  (testing "postwalk-replace would rewrite the inner BINDER, producing
+            (let* [(aget A i) 99] …) — a form that is not even well-formed"
+    (is (= '(clojure.core/+ 99 1)
+           (util/inline-pure-lets
+            '(let* [x (raster.arrays/aget A i)]
+               (let* [x 99] (clojure.core/+ x 1)))))))
+  (testing "a name in an ARRAY position is likewise a binder-independent occurrence: substituting
+            an array symbol must not be confused with substituting an index"
+    (is (= '(raster.arrays/aget A (clojure.core/* 2 4))
+           (util/inline-pure-lets
+            '(let* [i (clojure.core/* 2 4)] (raster.arrays/aget A i))))))
+  (testing "a par binder shadowing an inlined name alpha-renames rather than capturing"
+    (let [r (util/inline-pure-lets
+             '(let* [s (clojure.core/* n 2)]
+                (raster.par/map! O n (fn* [n] (clojure.core/+ n s)))))]
+      (is (not= 'n (first (nth (nth r 3) 1)))
+          "the fn* binder was renamed, so `s`'s reference to the OUTER n still resolves"))))
+
+(deftest the-reduction-reaches-a-fixpoint
+  (testing "prewalk never revisited the form a reduction produced, so a let* exposed by inlining
+            survived into the emitter"
+    (is (= '(clojure.core/+ (clojure.core/* 7 2) 1)
+           (util/inline-pure-lets
+            '(let* [x 7] (let* [y (clojure.core/* x 2)] (clojure.core/+ y 1)))))))
+  (testing "a let* nested in a binding VALUE reduces too"
+    (is (= '(clojure.core/+ 3 1)
+           (util/inline-pure-lets '(let* [a (let* [b 3] b)] (clojure.core/+ a 1)))))))
+
+(deftest metadata-survives-the-rewrite
+  (testing "clojure.walk drops meta on every rebuilt list. Here the TC tag on an untouched
+            subform must survive — the bytecode emitter reads it, and losing it was a live
+            ClassCastException in the SIMD-fusion path"
+    (let [r (util/inline-pure-lets
+             (list 'let* ['a 1]
+                   (list 'clojure.core/+
+                         (with-meta (list 'g 'a) {:raster.type/tag 'Double})
+                         2)))]
+      (is (= 'Double (:raster.type/tag (meta (second r)))))))
+  (testing "…and losing it would defeat the purity gate itself, which reads
+            :raster.op/original from meta"
+    (let [devirt (with-meta (list '.invk 'impl 'O 0 1.0)
+                   {:raster.op/original 'raster.arrays/aset})]
+      (is (util/effectful? (util/inline-pure-lets (list 'do (list 'clojure.core/identity devirt))))
+          "the stamp is still readable after a rewrite pass over the enclosing form"))))
+
+(deftest a-multi-form-body-becomes-do-and-is-never-truncated
+  (testing "keeping only (last body) drops the earlier forms — which are exactly the ones held
+            for their effects. That was a vanished store, not a missed fusion"
+    (is (= '(do (clojure.core/aset O 0 1) (clojure.core/+ 1 1))
+           (util/inline-pure-lets
+            '(let* [a 1] (clojure.core/aset O 0 a) (clojure.core/+ a 1)))))))
+
+(deftest non-let-binders-are-left-alone
+  (testing "loop* is not beta-reducible — its binders are re-assigned by recur"
+    (is (= '(loop* [i 0] (recur (clojure.core/inc i)))
+           (util/inline-pure-lets '(loop* [i 0] (recur (clojure.core/inc i)))))))
+  (testing "quote is opaque"
+    (is (= '(clojure.core/list (quote (let* [a 1] a)))
+           (util/inline-pure-lets '(clojure.core/list (quote (let* [a 1] a))))))))
+
+;; ── the gate: default REFUSES, and :on-impure must escape ────────────────────────────
+(deftest the-default-gate-is-the-real-gate
+  (testing "the default is (complement effectful?), NOT (constantly true) — the whole point of
+            consolidating is that the two ungated callers gain a gate"
+    (is (= :impure-binding
+           (try (util/inline-pure-lets '(let* [a (raster.arrays/aset O 0 1.0)] a))
+                (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+    (is (= :impure-binding
+           (try (util/inline-pure-lets
+                 (list 'let* ['a (with-meta (list '.invk 'impl 'O 0 1.0)
+                                   {:raster.op/original 'raster.arrays/aset})] 'a))
+                (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))
+        "including the devirtualized spelling"))
+  (testing "a loop-valued init is refused: inlining it duplicates the whole loop per use"
+    (is (= :impure-binding
+           (try (util/inline-pure-lets '(let* [a (loop* [i 0] i)] a))
+                (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))
+  (testing "an :on-impure that RETURNS instead of escaping is a bug, not a licence to inline —
+            returning normally would fall through and inline the effect anyway"
+    (is (= :raster/bug
+           (try (util/inline-pure-lets '(let* [a (raster.arrays/aset O 0 1.0)] a)
+                                       :on-impure (fn [_ _] :shrug))
+                (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))
+  (testing "a caller may still widen the gate deliberately"
+    (is (= '(raster.arrays/aset O 0 1.0)
+           (util/inline-pure-lets '(let* [a (raster.arrays/aset O 0 1.0)] a)
+                                  :pure? (constantly true))))))
+
+;; ── anti-regression: each caller's refusal channel ──────────────────────────────────
+;; The migration's failure mode is quiet: make the three signatures agree by dropping the gate, and
+;; one loud refusal becomes two silent miscompiles. These pin that each caller still REFUSES.
+(deftest each-caller-refuses-rather-than-inlining-an-effect
+  (testing "the CPU SIMD emitter returns nil (⇒ scalar loop) for an effectful lane lambda"
+    (let [inline-lets (var-get (requiring-resolve 'raster.compiler.backend.cpu.csimd/inline-lets))]
+      (is (nil? (inline-lets '(let* [a (raster.arrays/aset O 0 1.0)] a)))
+          "impure init ⇒ nil, not a per-lane duplicated store")
+      (is (nil? (inline-lets '(let* [a 1] (clojure.core/aset O 0 a) (clojure.core/+ a 1))))
+          "a multi-statement body ⇒ nil, not (last body) with the store silently dropped")
+      (is (= '(clojure.core/+ (raster.arrays/aget A i) 1)
+             (inline-lets '(let* [a (raster.arrays/aget A i)] (clojure.core/+ a 1))))
+          "…and the pure case still flattens, so the money path is unchanged")))
+  (testing "the GPU vectorizer bails to a scalar loop (its own ::bail marker), not an ex-info"
+    (let [ipl (var-get (requiring-resolve 'raster.compiler.backend.gpu.c-emit/inline-pure-lets))]
+      (is (true? (try (ipl '(let* [a (raster.arrays/aset O 0 1.0)] a))
+                      nil
+                      (catch clojure.lang.ExceptionInfo e
+                        (:raster.compiler.backend.gpu.c-emit/bail (ex-data e)))))
+          "vec-bail! is the refusal channel the enclosing try already catches")))
+  (testing "the SOAC lowerer returns nil (⇒ ScalarBinding ⇒ legacy void path) for an effectful
+            let-wrapped write, instead of duplicating the effect into a SoacMap lambda"
+    (let [sav (var-get (requiring-resolve 'raster.compiler.ir.soac/single-aset-void))]
+      (is (nil? (sav '(let* [t (raster.arrays/aset SIDE 0 1.0)]
+                        (raster.arrays/aset OUT i t))
+                     'i)))
+      (is (some? (sav '(let* [g (raster.arrays/aget GATE i)]
+                         (raster.arrays/aset OUT i g))
+                      'i))
+          "…and the pure case is still recognized, so fusion is unchanged"))))
+
+;; ── the one remaining scope-blind substitution, now with a CHECKED precondition ──────
+;; CSE keeps a blind substitution deliberately: measured ~4x faster than subst-syms on a
+;; 300-binding ANF form, because subst-syms recomputes each smap value's free set at every binder.
+;; That is a legitimate optimization — but its precondition ("the pipeline guarantees ANF flatness")
+;; used to live only in a docstring. These pin that it is now verified, and that a violation takes
+;; the capture-avoiding path instead of corrupting the form.
+(deftest scope-blind-substitution-is-gated-on-a-verified-precondition
+  (testing "a flat ANF let* with gensym-unique binders is safe — the money path keeps the fast route"
+    (is (util/scope-blind-substitution-safe? '{t__1 a__1}
+                                             '(let* [t__2 (clojure.core/* t__1 2)] t__2))))
+  (testing "KEY capture: a binder rebinds an smap key. Blind substitution rewrites the BINDER"
+    (is (not (util/scope-blind-substitution-safe?
+              '{k v} '(raster.par/map! O k 4 nil (clojure.core/+ k 1))))))
+  (testing "VALUE capture: a binder shadows a name free in an smap VALUE"
+    (is (not (util/scope-blind-substitution-safe?
+              '{t (clojure.core/* k 9)} '(raster.par/map! O k 4 nil (clojure.core/+ k t))))))
+  (testing "quote: blind substitution would rewrite data as if it were code"
+    (is (not (util/scope-blind-substitution-safe? '{a b} '(clojure.core/list (quote a))))))
+  (testing "an empty smap is trivially safe"
+    (is (util/scope-blind-substitution-safe? {} '(let* [a 1] a)))))
+
+(deftest cse-substitution-falls-back-instead-of-corrupting
+  (let [subst (var-get (requiring-resolve 'raster.compiler.passes.scalar.cse/subst-syms-in))]
+    (testing "the flat-ANF fast path is unchanged"
+      (is (= '(let* [t__2 (clojure.core/* a__1 2)] t__2)
+             (subst '{t__1 a__1} '(let* [t__2 (clojure.core/* t__1 2)] t__2)))))
+    (testing "a binder colliding with an smap key is LEFT ALONE, not rewritten into the value"
+      (let [wf '(raster.par/map! O k 4 nil (clojure.core/+ k 1))]
+        (is (= wf (subst '{k HIJACKED} wf)))))
+    (testing "a value-capturing substitution alpha-renames the binder, so the substituted value
+              still refers to the OUTER k — blind substitution produced (+ k (* k 9)), silently
+              conflating the loop index with an unrelated outer variable"
+      (let [r (subst '{t (clojure.core/* k 9)}
+                     '(raster.par/map! O k 4 nil (clojure.core/+ k t)))
+            idx (nth r 2)]
+        (is (not= 'k idx) "the loop index was renamed")
+        (is (= (list 'clojure.core/+ idx '(clojure.core/* k 9)) (nth r 5))
+            "the body uses the RENAMED index, and the value's k is the outer one")))
+    (testing "the fallback preserves par-form shape (rebuild is arity-faithful)"
+      (let [wf '(raster.par/map! O k 4 nil (clojure.core/+ k t))]
+        (is (= (count wf) (count (subst '{t (clojure.core/* k 9)} wf))))))))

--- a/test/raster/compiler/core/util_test.clj
+++ b/test/raster/compiler/core/util_test.clj
@@ -267,3 +267,28 @@
           a' (nth binds 0) b-init (nth binds 3)]
       (is (= a' b-init) "b's init references the renamed a, not a stale name"))))
 
+
+;; ── alpha-convert SEPARATES duplicate bound names; postwalk-replace COLLAPSES them ──
+(deftest alpha-convert-separates-duplicate-bound-names
+  ;; `ad/reverse/alpha-rename-bound` built its rename map with `(into {} (map …))` over the bound
+  ;; names, so a name bound twice kept only the LAST entry: the two distinct bindings collapsed to
+  ;; one and the first binding's uses silently read the second's value — a wrong gradient. Its
+  ;; docstring and call site both stated "assumes its input bindings are already unique"; nothing
+  ;; asserted it. alpha-convert has no such precondition, and this pins that.
+  (testing "a let* binding the same name twice keeps the two bindings distinct"
+    (let [r (util/alpha-convert '(let* [a 1 b (clojure.core/+ a 10)
+                                        a 2 c (clojure.core/+ a 20)]
+                                   (clojure.core/+ b c)))
+          [_ bs _] r
+          bound (vec (take-nth 2 bs))]
+      (is (= 4 (count (distinct bound))) "all four binders are distinct names")
+      (is (apply distinct? bound))
+      ;; b must read the FIRST a, c the SECOND — check by structure, not by name
+      (let [[a1 _ b1 bi a2 _ c1 ci] bs]
+        (is (= (list 'clojure.core/+ a1 10) bi) "b's init reads the first a")
+        (is (= (list 'clojure.core/+ a2 20) ci) "c's init reads the second a")
+        (is (not= a1 a2) "…and those are different symbols"))))
+  (testing "for contrast: postwalk-replace on the same shape collapses them"
+    ;; documents WHY the mechanism was replaced, and would fail if postwalk-replace ever became safe
+    (let [smap (into {} (map (fn [s] [s (gensym (str (name s) "__"))])) '[a b a c])]
+      (is (= 3 (count smap)) "the duplicate `a` yields ONE entry — the collapse, in one line"))))

--- a/test/raster/compiler/fail_loud_contraction_test.clj
+++ b/test/raster/compiler/fail_loud_contraction_test.clj
@@ -61,15 +61,69 @@
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"silently dropped"
                             (cr/route-contraction form :dtype :double))))))
 
-(deftest the-decompose-mangles-symbolic-bound-names
-  (testing "a bound named `n-cols` was emitted raw as `(seg / (n-cols))` — valid C computing
-            `n - cols`. Bounds go through c-symbol like every other emitted symbol."
-    (let [m (am/of-axes '[[i 4] [l 8]])]
-      ;; exercised through a literal-bound kernel: the mangling path must not alter literals
-      (is (re-find #"\(seg / \(2\)\) % 2"
-                   (:source (sco/generate-staged-contraction-kernel
-                             {:free-axes '[[i 2] [j 2]] :contract-axes '[[l 8]]
-                              :stages [{:axis 'l :extent 8 :dtype :float :init 0.0}]
-                              :body '(raster.numeric/* (aget a l) (aget b l))
-                              :inputs '[a b] :dtype :float :out-dtype :float}
-                             'out)))))))
+(deftest the-decompose-is-row-major-and-distinguishably-so
+  ;; MUTATION-PROVEN INADEQUATE, and this is the replacement. The previous version asserted
+  ;;     (re-find #"\(seg / \(2\)\) % 2" src)     with free axes [[i 2] [j 2]]
+  ;; Both extents were 2, so row-major and column-major emit the SAME two lines with the axes
+  ;; swapped — a one-line regex over a symmetric shape cannot tell them apart. Flipping
+  ;; flat-decompose-c to column-major left 101 CI-visible contraction assertions passing.
+  ;;
+  ;; Fix: ASYMMETRIC extents, and assert each axis's own line, so the two orderings differ.
+  (let [src (:source (sco/generate-staged-contraction-kernel
+                      {:free-axes '[[i 3] [j 5]] :contract-axes '[[l 8]]
+                       :stages [{:axis 'l :extent 8 :dtype :float :init 0.0}]
+                       :body '(raster.numeric/* (aget a l) (aget b l))
+                       :inputs '[a b] :dtype :float :out-dtype :float}
+                      'out))]
+    (testing "outer axis divides by the product of the extents INSIDE it, then mods by its own"
+      (is (re-find #"int i = \(seg / \(5\)\) % 3;" src)))
+    (testing "innermost axis is a bare mod — no division"
+      (is (re-find #"int j = seg % 5;" src)))
+    (testing "and the column-major spelling is ABSENT (this is what the old test could not say)"
+      (is (not (re-find #"int i = seg % 3;" src)))
+      (is (not (re-find #"int j = \(seg / \(3\)\) % 5;" src))))))
+
+(deftest symbolic-bounds-are-refused-not-mangled
+  ;; The bug the old test NAMED was a symbolic bound (`n-cols` emitted raw as `(seg / (n-cols))`,
+  ;; valid C computing `n - cols`) — but its fixture passed only literals, so it exercised nothing.
+  ;; Symbolic bounds are now refused outright by this emitter, so assert THAT.
+  (testing "a symbolic free-axis bound is refused rather than emitted undeclared"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"symbolic bounds are not supported"
+         (sco/generate-staged-contraction-kernel
+          {:free-axes '[[i n-cols] [j 5]] :contract-axes '[[l 8]]
+           :stages [{:axis 'l :extent 8 :dtype :float :init 0.0}]
+           :body '(raster.numeric/* (aget a l) (aget b l))
+           :inputs '[a b] :dtype :float :out-dtype :float}
+          'out)))))
+
+;; ── producer-side assertions: a widened channel is only a fix if something fills it ──────
+(deftest full-reduce-descriptor-carries-its-combine
+  ;; A previous commit "fixed" the silent-sum by widening the REGISTRATION to pass the whole
+  ;; descriptor through. That was a no-op: the descriptor did not contain :c-op/:identity-val —
+  ;; generate-segred-kernel returned them into a local that route-contraction discarded. The
+  ;; consumer-side assertion could not catch it; only this producer-side one can.
+  (testing ":combine max reaches the descriptor as fmax + its identity, not defaulted to +/0.0"
+    (let [r (cr/route-contraction
+             (list 'raster.par/contract 'O [] [['l 8]]
+                   (list 'raster.numeric/* (list 'aget 'a 'l) (list 'aget 'b 'l))
+                   :combine 'max :init -1.0e30)
+             :dtype :double)]
+      (is (= :full-reduce (:strategy r)))
+      (is (= "fmax" (:c-op r)))
+      (is (= Double/NEGATIVE_INFINITY (:identity-val r))
+          "the identity must be the op's, not 0.0 — summing max-partials from 0.0 is wrong for
+           all-negative data"))))
+
+(deftest epilogue-refused-on-the-shape-production-actually-produces
+  ;; The first version of this guard blacklisted shapes and so exempted (2 free, 1 contract) — the
+  ;; ONLY shape production produces. The form fell through to :regtiled, which has no store splice,
+  ;; and the epilogue was dropped. Refuse by ABSENCE of splice support instead.
+  (testing "an epilogue on an f64 2-free/1-contract contraction is refused, not dropped"
+    (let [form (list 'raster.par/contract 'C [['i 4] ['j 4]] [['l 8]]
+                     (list 'raster.numeric/*
+                           (list 'aget 'A (list 'clojure.core/+ (list 'clojure.core/* 'i 8) 'l))
+                           (list 'aget 'B (list 'clojure.core/+ (list 'clojure.core/* 'l 4) 'j)))
+                     :epilogue {:acc 'acc :expr '(raster.numeric/* acc 2.0)})]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"silently dropped"
+                            (cr/route-contraction form :dtype :double))))))

--- a/test/raster/compiler/fail_loud_contraction_test.clj
+++ b/test/raster/compiler/fail_loud_contraction_test.clj
@@ -127,3 +127,26 @@
                      :epilogue {:acc 'acc :expr '(raster.numeric/* acc 2.0)})]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"silently dropped"
                             (cr/route-contraction form :dtype :double))))))
+
+(deftest dp4a-refuses-a-decode-it-would-discard
+  ;; The dp4a leaf replaces the whole summand with one hardware op, so a per-operand :decode — the
+  ;; load-lambda where a zero-point lives — would be silently dropped: Σ a·b instead of
+  ;; Σ(a−za)(b−zb). Load-bearing, since q4_0/q8_0 zero-points are 8 and 128.
+  (let [am (requiring-resolve 'raster.compiler.ir.axis-map/of-groups)
+        idx (requiring-resolve 'raster.compiler.ir.axis-map/index-expr)
+        gate (requiring-resolve 'raster.compiler.backend.gpu.segop-opencl/staged-inner-dp4a-legal?)
+        ma (am [['[i 4]] ['[blk 4] '[t 32]]])
+        mb (am [['[j 4]] ['[blk 4] '[t 32]]])
+        base {:stages [{:axis 'blk :extent 4 :dtype :float :init 0.0 :lift 'inner}
+                       {:axis 't :extent 32 :dtype :int :init 0}]
+              :dtype :byte
+              :body (list 'raster.numeric/* (list 'aget 'a (idx ma)) (list 'aget 'b (idx mb)))}]
+    (testing "no decode → the peak leaf is legal"
+      (is (:ok (gate (assoc base :operands [{:sym 'a :map ma} {:sym 'b :map mb}])))))
+    (testing "a zero-point on either operand → refused by name, not silently dropped"
+      (is (= :decode-on-a-body-replacing-leaf
+             (:reason (gate (assoc base :operands [{:sym 'a :map ma :decode '(clojure.core/- x 8)}
+                                                   {:sym 'b :map mb}])))))
+      (is (= :decode-on-a-body-replacing-leaf
+             (:reason (gate (assoc base :operands [{:sym 'a :map ma}
+                                                   {:sym 'b :map mb :decode '(clojure.core/- x 128)}]))))))))

--- a/test/raster/compiler/fail_loud_contraction_test.clj
+++ b/test/raster/compiler/fail_loud_contraction_test.clj
@@ -1,0 +1,75 @@
+(ns raster.compiler.fail-loud-contraction-test
+  "Silently-wrong paths, converted to loud ones. Device-free.
+
+   Each case here produced a plausible wrong ANSWER rather than an error. That is the worst failure
+   mode a compiler has, and every one of these was invisible to the suite — three were found by
+   audit, not by a test."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.passes.parallel.contract-route :as cr]
+            [raster.compiler.backend.gpu.segop-opencl :as sco]
+            [raster.compiler.ir.axis-map :as am]))
+
+(defn- staged-form [& {:keys [combine extent] :or {extent 32}}]
+  (concat (list 'raster.par/contract 'out [['i 2] ['j 2]] [['blk 2] ['t extent]]
+                (list 'raster.numeric/* (list 'aget 'a 't) (list 'aget 'b 't))
+                :stages [{:axis 'blk :extent 2 :dtype :float :init 0.0 :lift 'inner}
+                         {:axis 't :extent extent :dtype :int :init 0}])
+          (when combine [:combine combine])))
+
+(deftest staged-refuses-a-combine-it-would-silently-turn-into-a-sum
+  (testing "every accumulator level uses `+=` and a lift's linearity argument assumes addition, so
+            a form carrying :combine max was SILENTLY SUMMED — contraction-facts surfaced :combine
+            and nothing read it"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"only `\+` combine"
+                          (cr/route-contraction (staged-form :combine 'max) :dtype :byte)))
+    (is (some? (cr/route-contraction (staged-form) :dtype :byte)) "…and `+` still routes")))
+
+(deftest staged-refuses-symbolic-bounds-it-cannot-declare
+  (testing "this emitter interpolates extents but declares no scalar params for them, so a symbolic
+            bound emitted an UNDECLARED identifier — and validate-descriptor passed it (the counts
+            agree), so it failed only at device build, i.e. never in CI"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"symbolic bounds are not supported"
+         (sco/generate-staged-contraction-kernel
+          {:free-axes '[[i m] [j 2]] :contract-axes '[[l 8]]
+           :stages [{:axis 'l :extent 8 :dtype :float :init 0.0}]
+           :body '(raster.numeric/* (aget a l) (aget b l))
+           :inputs '[a b] :dtype :float :out-dtype :float}
+          'out)))))
+
+(deftest staged-emits-the-extension-pragma-its-dtype-needs
+  (testing "all three sibling emitters emit this; the staged one did not, so a :double staged
+            contraction — reachable from opencl_pass, whose default dtype IS :double — emitted
+            `double` with no #pragma"
+    (let [src (:source (sco/generate-staged-contraction-kernel
+                        {:free-axes '[[i 2] [j 2]] :contract-axes '[[l 8]]
+                         :stages [{:axis 'l :extent 8 :dtype :double :init 0.0}]
+                         :body '(raster.numeric/* (aget a l) (aget b l))
+                         :inputs '[a b] :dtype :double :out-dtype :double}
+                        'out))]
+      (is (re-find #"cl_khr_fp64" src)))))
+
+(deftest a-leaf-without-a-store-splice-refuses-an-epilogue
+  (testing "an :epilogue reaching :segmap or the :else fallback was silently DROPPED — the
+            consumer's computation vanished with no error. fuse-contract-map already produces such
+            forms (it has no rank restriction) and is one line from being wired."
+    (let [ep {:acc 'acc :expr '(raster.numeric/* acc 2.0)}
+          ;; 3 free axes → the universal fallback, which has no store splice
+          form (concat (list 'raster.par/contract 'out [['b 2] ['i 2] ['j 2]] [['l 4]]
+                             (list 'raster.numeric/* (list 'aget 'a 'l) (list 'aget 'c 'l)))
+                       [:epilogue ep])]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"silently dropped"
+                            (cr/route-contraction form :dtype :double))))))
+
+(deftest the-decompose-mangles-symbolic-bound-names
+  (testing "a bound named `n-cols` was emitted raw as `(seg / (n-cols))` — valid C computing
+            `n - cols`. Bounds go through c-symbol like every other emitted symbol."
+    (let [m (am/of-axes '[[i 4] [l 8]])]
+      ;; exercised through a literal-bound kernel: the mangling path must not alter literals
+      (is (re-find #"\(seg / \(2\)\) % 2"
+                   (:source (sco/generate-staged-contraction-kernel
+                             {:free-axes '[[i 2] [j 2]] :contract-axes '[[l 8]]
+                              :stages [{:axis 'l :extent 8 :dtype :float :init 0.0}]
+                              :body '(raster.numeric/* (aget a l) (aget b l))
+                              :inputs '[a b] :dtype :float :out-dtype :float}
+                             'out)))))))

--- a/test/raster/compiler/passes/parallel/epilogue_operand_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/epilogue_operand_fusion_test.clj
@@ -120,3 +120,11 @@
           (is (= (count ref) (count fused)))
           (is (every? true? (map #(< (Math/abs (- (double %1) (double %2))) 3.0e-2) fused ref))
               (str "fused " (take 4 fused) " vs two-pass " (take 4 ref))))))))
+
+;; NOTE (deferred to the epilogue-gate work): an operand or scalar sharing a name with a free axis
+;; is an ILL-FORMED spec, not something to preserve. Probed: axis `s` + scalar `s` emits `acc * row`
+;; — valid C, wrong number, silent — and no substitution mechanism can resolve it, because the spec
+;; keeps one symbol namespace for three C-level roles (operand arrays and scalars become kernel
+;; params; free axes become store-slot locals). The fix is `:operand-shadows-free-axis` in
+;; epilogue-legal?, plus a matching DECLINE in fuse-contract-map so fusion backs off to two kernels
+;; rather than the emitter throwing on a program that compiles today.

--- a/test/raster/compiler/passes/scalar/scope_capture_test.clj
+++ b/test/raster/compiler/passes/scalar/scope_capture_test.clj
@@ -54,3 +54,30 @@
                               r (dense-into buf)]
                              (clojure.core/alength buf))))]
       (is (= 'n (last out)) "top-level (alength buf) resolves to its alloc size n"))))
+
+;; ================================================================
+;; pe.clj — const-env must not have its VALUES captured either
+;; ================================================================
+;; The tests above cover KEY capture: a binder that rebinds a const-env key. The other half is
+;; VALUE capture: a const-env VALUE that is free in the enclosing scope but BOUND inside this one.
+;; Substituting it moves the reference from the outer binding to the inner binder — a silent wrong
+;; answer, with no key collision to notice. `pe` protected the first half and not the second.
+
+(deftest pe-const-env-value-not-captured-by-par-index
+  (testing "an alias to an OUTER i must not become the par loop's index"
+    ;; `x` aliases the outer `i`; the par form binds its own `i`. Substituting x→i inside the loop
+    ;; body silently reads the loop index instead of the outer value.
+    (let [r (pe/pe-pass '(let* [x i
+                               r (raster.par/map! out i n nil (clojure.core/+ x 1))]
+                           r)
+                        {})]
+      (is (some #{'x} (flatten r))
+          "x must survive inside the loop body (or be renamed) — it must NOT become the loop index")
+      (is (not= '(clojure.core/+ i 1) (last (nth r 1)))
+          "the body must not read the loop index in place of the outer i"))))
+
+(deftest pe-const-env-value-not-captured-by-dotimes-index
+  (testing "the same hazard on dotimes, substituting from a pre-seeded env"
+    (let [r (pe/pe-pass '(dotimes [i n] (clojure.core/aset out i x)) '{x i})]
+      (is (= '(clojure.core/aset out i x) (last r))
+          "x must stay x: substituting it would make the store read the loop index"))))


### PR DESCRIPTION
Every case here produced a plausible wrong **answer** rather than an error, and every one was
invisible to the suite — found by audit, not by a test.

## Reachable today

`opencl_pass` registered only `{:kernel-name :source :dtype}`, dropping the `:c-op`/`:identity-val`
that `generate-segred-kernel` returns. `invoke-reduction-kernel` then fell back to its
`:or {c-op "+" identity-val 0.0}` for the **host-side final combine** — so a full reduction with
`:combine max` or `:combine *` spanning more than one workgroup **silently summed** the per-group
partials. A 0-free-axis contraction at `:float`/`:double` is exactly what this pass routes.

## Reachable on one wiring change

| path | was | now |
|---|---|---|
| staged + `:combine max` | silently summed (`+=` hardwired; facts surfaced `:combine`, nothing read it) | refused by name |
| `:epilogue` → `:segmap` / `:else` | silently dropped — the consumer's computation vanished | refused |
| `:pre-steps` | produced under `:prefer-peak?`, executed by nothing → operand read untransposed | refused where the descriptor is in hand |

`fuse-contract-map` already produces epilogue-carrying forms at any rank and is **one line** in
`par-fusion-pass` from being live — which is when a silent path is cheapest to close.

## Silent at compile, loud only on a device

- The staged emitter emitted fp64/fp16 with **no extension pragma** while all three siblings emit
  one — and `:double` is `opencl_pass`'s *default* dtype.
- **Symbolic bounds** emitted undeclared identifiers, and `validate-descriptor` passed them because
  the counts agree. Failed only at device build — never in CI. Refused until the emitter can declare
  them (its `segmented-reduce` sibling already does).
- `flat-decompose-c` interpolated bound names raw, so a bound named `n-cols` emitted
  `(seg / (n-cols))` — valid C computing `n − cols`.

## Validation

61 contraction tests / 297 assertions + 5 new fail-loud tests, 0 failures. Cold-JVM load verified.

## Next

The `clang -x cl -fsyntax-only` CI gate, which would have caught **two** of the above on its own
(CI already installs clang). The missing pragma is the exception — clang doesn't flag it, so that one
keeps its string assertion.