### PR TITLE
Contraction routing must not depend on how the array read is spelled

### DIFF
--- a/bench/soac_contract_bench.clj
+++ b/bench/soac_contract_bench.clj
@@ -87,13 +87,20 @@
 (defn- matmul-form
   ([m n k] (matmul-form :bare m n k))
   ([spelling m n k]
-   (let [[ag mul add imul] (case spelling
-                             :bare   '[aget * + *]
-                             :walker '[raster.arrays/aget raster.numeric/*
-                                       clojure.core/+ clojure.core/*])]
+   (let [[ag mul add imul cast?] (case spelling
+                                   :bare   '[aget * + * false]
+                                   ;; VERBATIM what `ensure-walked-body!` yields for a deftm whose
+                                   ;; body reads `(ra/aget A (+ (* i k) l))`: the walker's :array-op
+                                   ;; handler qualifies into clojure.core, and extents arrive wrapped
+                                   ;; in `(long …)`. Both details were independently load-bearing —
+                                   ;; the spelling blinded the operand matchers, the cast blinded the
+                                   ;; affine layout check — so a faithful row must carry both.
+                                   :walker '[clojure.core/aget raster.numeric/*
+                                             clojure.core/+ clojure.core/* true])
+         ext (fn [e] (if cast? (list 'long e) e))]
      (list 'raster.par/contract 'C [['i m] ['j n]] [['l k]]
-           (list mul (list ag 'A (list add (list imul 'i k) 'l))
-                 (list ag 'B (list add (list imul 'l n) 'j)))))))
+           (list mul (list ag 'A (list add (list imul 'i (ext k)) 'l))
+                 (list ag 'B (list add (list imul 'l (ext n)) 'j)))))))
 
 ;; ── buffer plumbing: one A[m×k]·B[k×n]→C[m×n] triple at a given dtype ────────────────
 (def ^:private host-cache (atom {}))

--- a/bench/soac_contract_bench.clj
+++ b/bench/soac_contract_bench.clj
@@ -48,10 +48,12 @@
      (soac-contract-bench/compare-ladder {:name \"proj\" :m 1024 :k 640 :n 2048} :golden? true)"
   (:require [raster.gpu.ze-runtime :as ze]
             [raster.compiler.passes.parallel.contract-lower :as cl]
+            [raster.compiler.passes.parallel.contract-route :as croute]
             [raster.compiler.backend.gpu.segop-opencl :as sco]
             [raster.compiler.backend.gpu.opencl-codegen :as cg]
             [raster.compiler.support.spirv-cache :as spv]
             [raster.runtime.hardware :as hw]
+            [raster.compiler.core.hardware :as chw]
             [clojure.string :as str])
   (:import [java.lang.foreign MemorySegment ValueLayout]))
 
@@ -73,10 +75,25 @@
 (defn- gflops [ms m n k] (/ (* 2.0 m k n) (* ms 1.0e6)))
 
 ;; ── the matmul contraction form (C[i,j] = Σ_l A[i,l]·B[l,j]) ─────────────────────────
-(defn- matmul-form [m n k]
-  (list 'raster.par/contract 'C [['i m] ['j n]] [['l k]]
-        (list '* (list 'aget 'A (list '+ (list '* 'i k) 'l))
-              (list 'aget 'B (list '+ (list '* 'l n) 'j)))))
+;; TWO SPELLINGS, because the ROUTING DEPENDS ON THE SPELLING and that is the thing being measured.
+;;
+;;   :bare   — bare `aget`/`*`/`+`, which is what every hand-written test form in this repo uses.
+;;   :walker — what the compiler ACTUALLY produces for the same computation: the qualified array op
+;;             (`raster.arrays/aget`) and `raster.numeric/*` for the float multiply, with index
+;;             arithmetic left in `clojure.core` per CLAUDE.md.
+;;
+;; These are the same contraction. If they measure differently, the difference is a compiler defect,
+;; not a property of the computation — which is exactly what this harness is for.
+(defn- matmul-form
+  ([m n k] (matmul-form :bare m n k))
+  ([spelling m n k]
+   (let [[ag mul add imul] (case spelling
+                             :bare   '[aget * + *]
+                             :walker '[raster.arrays/aget raster.numeric/*
+                                       clojure.core/+ clojure.core/*])]
+     (list 'raster.par/contract 'C [['i m] ['j n]] [['l k]]
+           (list mul (list ag 'A (list add (list imul 'i k) 'l))
+                 (list ag 'B (list add (list imul 'l n) 'j)))))))
 
 ;; ── buffer plumbing: one A[m×k]·B[k×n]→C[m×n] triple at a given dtype ────────────────
 (def ^:private host-cache (atom {}))
@@ -204,6 +221,71 @@
                             {:type :int :value (int m)} {:type :int :value (int n)} {:type :int :value (int k)}])]
        (bind! module kname [256 1] args
               (long (Math/ceil (/ (double n) 128.0))) (long (Math/ceil (/ (double m) 128.0))) 1)))})
+
+(defn- routed-spec
+  "THE PRODUCTION DOOR. Every other spec in this harness calls a generator directly and hand-computes
+   its launch grid from literals (`/128.0`, `*32`). That measures a kernel in ISOLATION, and it cannot
+   catch the two failure modes that actually shipped:
+
+     • a descriptor whose GEOMETRY disagrees with the kernel it describes — the kernel emitted with
+       one tile while the launch derived its grid from another, leaving the tail rows of C unwritten;
+     • a ROUTING decision that never selects the peak leaf for real compiler IR at all.
+
+   So this spec takes everything from `route-contraction`'s descriptor: its `:source`, its
+   `:array-params` ORDER, its `:scalar-args`, and its own `:wg`/`:grid`. Nothing here recomputes a
+   number the router already decided — if the descriptor is wrong, this row is wrong or slow, which is
+   the point. The argument order mirrors `ze-runtime/invoke-registered-contraction!` exactly
+   (operands in :array-params order, then out, then scalar-args), so this row launches the kernel the
+   way production launches it.
+
+   `spelling` is :bare or :walker (see `matmul-form`). Comparing the two rows at one dtype is the
+   measurement of whether the compiler's own output can reach the peak leaf.
+
+   NB the buffer triple is allocated at ONE dtype, so this row is valid only where the routed
+   `:out-dtype` equals the operand dtype — true for :double/:float/:half, NOT for the int8 leaves
+   (int8 in, f32 out). Those need a mixed triple; it throws rather than quietly mis-sizing C."
+  [dtype spelling]
+  {:label (str "routed-" (name spelling) "-" (name dtype)) :dtype dtype
+   :bind
+   (fn [m n k triple]
+     (let [form (matmul-form spelling m n k)
+           desc (try (chw/descriptor-for :ze:0) (catch Throwable _ nil))
+           r (croute/route-contraction form :dtype dtype :desc desc)
+           {:keys [kernel-name source array-params scalar-args grid wg out-dtype strategy]} r
+           _ (when (and out-dtype (not= out-dtype dtype))
+               (throw (ex-info (str "routed-spec: routed :out-dtype " out-dtype " differs from the "
+                                    "operand dtype " dtype " — this harness allocates one triple at "
+                                    "a single dtype, so C would be mis-sized")
+                               {:dtype dtype :out-dtype out-dtype :strategy strategy})))
+           {:keys [module kname]} (compile-src! [:routed dtype spelling m n k] kernel-name source)
+           ;; operands in the DESCRIPTOR's order — not sorted, not assumed to be [A B]
+           bufs (mapv (fn [s]
+                        (let [k (keyword (str/lower-case (name s)))]
+                          (or (:segment (get triple k))
+                              (throw (ex-info (str "routed-spec: descriptor names operand `" s
+                                                   "` which this shape has no buffer for")
+                                              {:array-params array-params})))))
+                      array-params)
+           args (into bufs (cons (:segment (:c triple)) scalar-args))
+           [gx gy] grid]
+       (assoc (bind! module kname wg args gx gy 1) :strategy strategy)))})
+
+(defn routed-strategies
+  "Which leaf each spelling routes to, per dtype — the device-free half of the measurement, and the
+   assertion a regression test wants. Prints a table and returns it."
+  [{:keys [m n k]} & {:keys [dtypes] :or {dtypes [:double :half :byte]}}]
+  (let [desc (try (chw/descriptor-for :ze:0) (catch Throwable _ nil))
+        rows (for [dt dtypes sp [:bare :walker]]
+               (let [r (try (croute/route-contraction (matmul-form sp m n k) :dtype dt :desc desc)
+                            (catch Throwable e {:strategy (str "THREW: " (.getMessage e))}))]
+                 {:dtype dt :spelling sp :strategy (:strategy r)}))]
+    (println (format "\n===== ROUTED STRATEGY BY OPERAND SPELLING (M%d K%d N%d) =====" m k n))
+    (doseq [[dt g] (group-by :dtype rows)]
+      (let [by (into {} (map (juxt :spelling :strategy)) g)]
+        (println (format "%-8s bare=%-16s walker=%-16s %s"
+                         (name dt) (str (:bare by)) (str (:walker by))
+                         (if (= (:bare by) (:walker by)) "" "<<< DIVERGES")))))
+    (vec rows)))
 
 ;; ── cadence graph over a spec (mirrors resident-gemm-cold-bench/record-seq-graph) ─────
 (defn- record-seq-graph

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -10,6 +10,7 @@
   (:require [raster.compiler.backend.gpu.opencl-codegen :as codegen]
             [raster.compiler.backend.gpu.c-emit :as ce]
             [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.util :as util]
             [raster.compiler.core.dtype :as dt]
             [raster.compiler.backend.intrinsics :as intrinsics]
             [raster.compiler.core.hardware :as hw]
@@ -488,10 +489,19 @@
         elem (let [a0 (nth op-args 0) a1 (nth op-args 1)] (if (acc-at? a0) a1 a0))
         _ (when-not (and (seq? elem) (#{'* 'clojure.core/* 'raster.numeric/*} (descriptor/semantic-op elem)))
             (throw (ex-info "tensorize: element must be a product of two agets" {:reason :non-product-element})))
+        ;; Registry-classified, not `(= 'aget (first e))`: the walker emits `clojure.core/aget`, so
+        ;; the literal match threw here for EVERY compiled deftm — and `route-2free-1contract`'s
+        ;; `(catch ExceptionInfo _ nil)` swallowed the message, silently demoting a canonical matmul
+        ;; to :naive-segred. The throw itself is right; what was wrong was which forms reached it.
         parts (fn [e] (let [e (ce/normalize-array-prims e)]
-                        (when-not (and (seq? e) (= 'aget (first e)))
-                          (throw (ex-info "tensorize: operand must be an aget" {:reason :non-aget-operand})))
-                        {:arr (nth e 1) :idx (nth e 2)}))
+                        (when-not (descriptor/aget-call? e)
+                          (throw (ex-info "tensorize: operand must be an aget"
+                                          {:reason :non-aget-operand :operand e})))
+                        {:arr (descriptor/aget-array-sym e)
+                         ;; canonicalized so the same contraction emits one kernel text whichever
+                         ;; way its body was spelled — the walked dialect's `(long 640)` extents
+                         ;; would otherwise survive into the C for verbatim-index leaves
+                         :idx (descriptor/canonicalize-index (descriptor/aget-index e))}))
         [pa pb] (mapv parts (descriptor/call-args elem))
         dep? (fn [idx s] (contains? (syms-in idx) s))
         rc (fn [x y] (when (and (dep? (:idx x) i-sym) (dep? (:idx x) l-sym) (not (dep? (:idx x) j-sym))
@@ -743,11 +753,7 @@
         int-vars (into #{} (map #(symbol (name %))) [i-sym j-sym])
         ;; substitute each operand's aget index from its declared map (maps, not pattern-matching)
         idx-of (into {} (for [{:keys [sym map]} operands] [sym (am/index-expr map)]))
-        expr' (walk/postwalk
-               (fn [f] (if (and (seq? f) (= 'aget (first f)) (contains? idx-of (second f)))
-                         (list 'aget (second f) (get idx-of (second f)))
-                         f))
-               expr)
+        expr' (descriptor/rewrite-aget-indices expr idx-of)
         acc-token (str "__acc_" (name (gensym "")))
         ;; emit once with a distinctive token standing in for the accumulator, then splice the
         ;; real acc C-expression in at call time (the hook supplies it per store slot)
@@ -884,9 +890,7 @@
   [{:keys [stages body operands dtype]}]
   (let [inner-stage (peek (vec stages))
         int-acc? (contains? #{:int :long :int32} (:dtype inner-stage))
-        agets (into {} (keep (fn [f] (when (and (seq? f) (= 'aget (first f)) (symbol? (second f)))
-                                      [(second f) (nth f 2)]))
-                             (tree-seq coll? seq body)))
+        agets (into {} (map (juxt :sym :idx)) (descriptor/aget-reads body))
         ;; THE BODY IS DISCARDED when this leaf fires — the whole summand is replaced by one
         ;; rstr_dp4a call — so the gate must account for EVERY term first. The requirement lives in
         ;; ir/contraction-facts as `body-product-of`, shared with every other body-replacing leaf,
@@ -1020,13 +1024,17 @@
         ;; accumulator dtype), and hiding it in a lambda would blind the tensorize gate to the very
         ;; pair it dispatches on.
         decodes (into {} (keep (fn [{:keys [sym decode]}] (when decode [sym decode]))) operands)
+        ;; `x` in a :decode lambda stands for the RAW LOAD. Substituted capture-avoidingly, and the
+        ;; read is matched via the registry — the literal `(= 'aget (first f))` here meant a decode
+        ;; was SILENTLY DROPPED for every walker-spelled operand, emitting `a[l]*b[l]` where the
+        ;; semantics are `(a[l]-zp)*b[l]`. A wrong answer, not a slow one.
         body (if (empty? decodes)
                body
-               (walk/postwalk
-                (fn [f] (if (and (seq? f) (= 'aget (first f)) (contains? decodes (second f)))
-                          (walk/postwalk-replace {'x f} (get decodes (second f)))
-                          f))
-                body))
+               (descriptor/rewrite-aget-reads
+                body
+                (fn [f] (let [arr (descriptor/aget-array-sym f)]
+                          (when (contains? decodes arr)
+                            (util/subst-syms {'x f} (get decodes arr)))))))
         ;; EPILOGUE — the store splice. An epilogue is a lift on a virtual outermost level of
         ;; extent 1, which is why it needs no linearity (nothing to distribute over one iteration)
         ;; while a real stage lift does. Gives this emitter the dequant scale that the two quant

--- a/src/raster/compiler/core/op_descriptor.clj
+++ b/src/raster/compiler/core/op_descriptor.clj
@@ -629,6 +629,102 @@
   (when (aget-call? form)
     (unwrap-array-arg (first (call-args form)))))
 
+(defn aget-index
+  "The INDEX expression of an aget call (bare, qualified, or devirtualized). nil when `form` is not
+   an aget call.
+
+   Exists so no pass writes `(nth f 2)`. The three spellings put the index at DIFFERENT positions —
+   `(aget A i)` at 2, `(.invk impl A i)` at 3 — so a positional read is correct for at most one of
+   them, and a positional REWRITE silently corrupts the others into `(aget impl idx)`."
+  [form]
+  (when (aget-call? form)
+    (second (call-args form))))
+
+(defn aget-reads
+  "Every array read in `expr`, as `{:sym :idx :form}` in encounter order — recognizing bare `aget`,
+   `clojure.core/aget`, `raster.arrays/aget`, and the walker-DEVIRTUALIZED `(.invk impl arr idx)`
+   alike. `:form` is the matched node, so a caller that must REWRITE it does not re-implement
+   matching.
+
+   THE ONE COLLECTOR for the contraction/fusion vertical. Twelve sites there each spelled this as
+   `(= 'aget (first f))`, which accepts only the BARE form — while the walker actually emits
+   `clojure.core/aget` (walker.clj's :array-op handler qualifies into clojure.core). So on real
+   compiled IR every one of them saw ZERO operands. Measured consequences, all from that:
+
+     • `:half` matmul routed to `:naive-segred` instead of `:dpas` — 577 vs 4357 GFLOP/s on Arc 140V
+       (the routed DPAS path is at parity with the hand-written XMX GEMM, so this is pure loss);
+     • `:byte`/staged emitted SYNTACTICALLY INVALID OpenCL — `staged_contract(, __global float*
+       restrict out, int _nseg)`, a leading comma with the operands missing from the signature while
+       the body still reads them;
+     • a `:decode` zero-point SILENTLY DROPPED, giving `acc += a[l]*b[l]` where the semantics are
+       `(a[l]-zp)*b[l]`.
+
+   Per CLAUDE.md (\"Centralize operator classification\"): passes query the registry, never a local
+   `#{...}` literal. Adding a spelling is a registry edit, not a twelve-file sweep."
+  [expr]
+  (let [out (volatile! [])]
+    ((fn go [f]
+       (cond
+         ;; `quote` is opaque — quoted data is not code, and the REWRITER treats it that way, so a
+         ;; collector that descends into it would report reads the rewriter will never touch.
+         (and (seq? f) (= 'quote (first f))) nil
+         (coll? f) (do (when (aget-call? f)
+                         (let [arr (aget-array-sym f)]
+                           (when (symbol? arr)
+                             (vswap! out conj {:sym arr :idx (aget-index f) :form f}))))
+                       (run! go (if (map? f) (apply concat f) f)))
+         :else nil))
+     expr)
+    @out))
+
+(defn rewrite-aget-index
+  "Return `form` with its aget INDEX replaced by `idx'`, preserving the read's spelling, its
+   argument positions, any trailing args, and its METADATA.
+
+   Metadata is load-bearing here: `:raster.op/original` is what makes a devirtualized read
+   recognizable at all (drop it and `aget-call?` goes blind on the very node just rewritten), and
+   `:raster.type/tag` is what the emitters read instead of re-inferring. `clojure.walk` rebuilds
+   lists with `(apply list …)` and drops meta, which is why this does not go through it."
+  [form idx']
+  (when-not (aget-call? form)
+    (throw (ex-info "rewrite-aget-index: not an array read" {:reason :raster/bug :form form})))
+  (let [pre (if (= '.invk (first form)) 3 2)          ; head+impl+arr, or head+arr
+        head (take pre form)
+        tail (drop (inc pre) form)]                    ; anything after the index
+    (with-meta (concat head [idx'] tail) (meta form))))
+
+(defn rewrite-aget-reads
+  "Rewrite array reads anywhere in `expr`. `replace-fn` receives each matched read node and returns
+   its replacement, or nil to leave it alone. `quote`d data is opaque; metadata on every rebuilt
+   form is preserved.
+
+   This is the rewriter half of `aget-reads`, and it MUST land in the same commit: four sites
+   collect operands and then substitute into them. Broadening only the collector turns a loud
+   refusal (\"epilogue would be silently dropped\") into a SILENT wrong epilogue — an index left as
+   its PLACEHOLDER, an accumulator read left unsubstituted, or a `:decode` zero-point dropped.
+
+   Not `clojure.walk/postwalk`: it rebuilds lists with `(apply list …)` and drops metadata, and the
+   bodies rewritten here flow to emitters that read `:raster.type/tag` and `:raster.op/original`."
+  [expr replace-fn]
+  (letfn [(go [f]
+            (cond
+              (and (seq? f) (= 'quote (first f))) f
+              (seq? f) (or (when (aget-call? f) (replace-fn f))
+                           (with-meta (apply list (map go f)) (meta f)))
+              (vector? f) (with-meta (mapv go f) (meta f))
+              (map? f) (with-meta (into (empty f) (map (fn [[k v]] [(go k) (go v)])) f) (meta f))
+              (set? f) (with-meta (into (empty f) (map go) f) (meta f))
+              :else f))]
+    (go expr)))
+
+(defn rewrite-aget-indices
+  "Rewrite the INDEX of every array read whose array symbol is a key of `idx-of`; other reads are
+   left alone. The common case of `rewrite-aget-reads`."
+  [expr idx-of]
+  (rewrite-aget-reads expr (fn [f] (let [arr (aget-array-sym f)]
+                                     (when (contains? idx-of arr)
+                                       (rewrite-aget-index f (get idx-of arr)))))))
+
 (defn aset-call?
   "True if `form` is an array-write call — bare (aset arr idx val) or
    walker-devirtualized (.invk aset-impl arr idx val)."
@@ -644,11 +740,17 @@
   (when (aset-call? form)
     (unwrap-array-arg (first (call-args form)))))
 
-(defn- unwrap-int-cast
-  "Unwrap an integer cast around an induction-variable reference —
-   (long i) / (int i) → i. The walked/AD-prep dialect wraps loop indices in
-   long casts ((inc (long i))), so step matching must see through them just
-   like idx-matches?/test-index+bound do. Non-cast forms pass through."
+(defn unwrap-int-cast
+  "Unwrap an integer cast around an induction-variable or extent reference —
+   (long i) / (int i) → i. The walked/AD-prep dialect wraps loop indices AND
+   extents in long casts (`(clojure.core/* i (long k))`), so step matching and
+   AFFINE-INDEX matching must see through them just like idx-matches?/
+   test-index+bound do. Non-cast forms pass through.
+
+   Public because `ir/axis-map`'s affine normal form needs exactly this: without
+   it, `(+ (* i (long 128)) l)` is not recognized as the row-major layout, the
+   DPAS orientation gate declines with :non-canonical-orientation, and a walked
+   deftm cannot reach the tensorized leaf even once its operands are found."
   [expr]
   (if (and (seq? expr)
            (contains? #{'long 'int 'clojure.core/long 'clojure.core/int}
@@ -656,6 +758,31 @@
            (= 2 (count expr)))
     (second expr)
     expr))
+
+(defn canonicalize-index
+  "Strip integer casts that wrap a NUMERIC LITERAL, anywhere in an index expression:
+   `(clojure.core/* i (long 640))` → `(clojure.core/* i 640)`.
+
+   Index canonicalization, so that one contraction emits ONE kernel text regardless of how its body
+   was spelled. The walked dialect wraps extents in `(long …)`; a leaf that regenerates the index
+   from an axis-map (DPAS, staged) loses them naturally, but a leaf that emits the body's index
+   VERBATIM (regtiled, naive) carried them through — so two spellings of the same contraction
+   produced C differing by `(long)(640)` vs `640`. Harmless to the compiler, but it breaks the
+   source-identity invariant that is the only assertion strong enough to catch an operand silently
+   missing from a kernel signature.
+
+   Only literal-wrapping casts are removed. A cast around a VARIABLE is left alone: `(long i)` on an
+   int loop counter can be load-bearing for index arithmetic width, and this is not the place to
+   decide that."
+  [expr]
+  (cond
+    (and (seq? expr) (= 'quote (first expr))) expr
+    (seq? expr) (let [u (unwrap-int-cast expr)]
+                  (if (and (not= u expr) (number? u))
+                    u
+                    (with-meta (apply list (map canonicalize-index expr)) (meta expr))))
+    (vector? expr) (with-meta (mapv canonicalize-index expr) (meta expr))
+    :else expr))
 
 (defn affine-step
   "If `expr` is an affine step of the induction variable `idx-sym` — i.e.

--- a/src/raster/compiler/ir/axis_map.clj
+++ b/src/raster/compiler/ir/axis_map.clj
@@ -19,7 +19,8 @@
 
    Extents may be numbers or symbols; index expressions fold to constants when everything is
    literal and stay symbolic otherwise."
-  (:refer-clojure :exclude [shape]))
+  (:refer-clojure :exclude [shape])
+  (:require [raster.compiler.core.op-descriptor :as od]))
 
 ;; ── construction ────────────────────────────────────────────────────────────────────
 (defn of-axes
@@ -161,6 +162,14 @@
               (cond
                 (number? e) {::one {[] e}}
                 (symbol? e) (if (axes e) {e p-one} {::one {[e] 1}})
+                ;; The walked dialect wraps axes AND extents in integer casts —
+                ;; `(clojure.core/* i (long k))`. Without unwrapping, `(long k)` is an OPAQUE atom,
+                ;; the index is not the row-major layout, and the DPAS orientation gate declines
+                ;; with :non-canonical-orientation — so a compiled deftm cannot reach the tensorized
+                ;; leaf even once its operands are recognized. `od/unwrap-int-cast` is the same
+                ;; unwrapping `affine-step` and `idx-matches?` already apply; using it here makes
+                ;; the affine normal form agree with them instead of being stricter by accident.
+                (and (seq? e) (not= e (od/unwrap-int-cast e))) (aff (od/unwrap-int-cast e))
                 (seq? e)
                 (let [h (op-head (first e)) args (rest e)]
                   (cond

--- a/src/raster/compiler/ir/contract_stages.clj
+++ b/src/raster/compiler/ir/contract_stages.clj
@@ -42,7 +42,8 @@
    stage's `:lift` is an expression in the symbol `inner` (the stage-below's accumulated value)
    and may reference its own axis plus extra operand arrays, each with a declared axis-map (so a
    scale is indexed by ITS map, not by pattern-matching — same rule as the epilogue seam)."
-  (:require [raster.compiler.ir.axis-map :as am]
+  (:require [raster.compiler.core.op-descriptor :as od]
+            [raster.compiler.ir.axis-map :as am]
             [raster.compiler.core.dtype :as dt]
             [clojure.set :as set]
             [clojure.walk :as walk]))
@@ -177,13 +178,16 @@
   (into {} (for [{:keys [sym map]} (lift-operands stages)] [sym (am/index-expr map)])))
 
 (defn substitute-operand-indices
-  "Rewrite `(aget s _)` → `(aget s <index from s's declared map>)` for every lift operand."
+  "Rewrite `(aget s _)` → `(aget s <index from s's declared map>)` for every lift operand,
+   preserving the read's spelling and metadata.
+
+   Registry-classified: a lift is AUTHOR-WRITTEN data, and CLAUDE.md's emit-qualified rule tells
+   authors to spell the read `raster.arrays/aget` — which the old literal `(= 'aget (first f))`
+   silently ignored, leaving the operand's index as its PLACEHOLDER. That corrupts the emitted
+   kernel AND `flat-equivalent`, which is the interpreter-side semantic reference the staging
+   linearity law is checked against — so the oracle would have agreed with the wrong kernel."
   [expr idx-of]
-  (walk/postwalk
-   (fn [f] (if (and (seq? f) (= 'aget (first f)) (contains? idx-of (second f)))
-             (list 'aget (second f) (get idx-of (second f)))
-             f))
-   expr))
+  (od/rewrite-aget-indices expr idx-of))
 
 (defn flat-equivalent
   "The FLAT contraction body equal (in exact arithmetic) to this staged contraction: every stage's

--- a/src/raster/compiler/ir/contraction_facts.clj
+++ b/src/raster/compiler/ir/contraction_facts.clj
@@ -43,15 +43,15 @@
     (apply hash-map tail)))
 
 (defn- aget-terms
-  "Every `(aget arr idx)` the expression reads, as {:sym :idx}, in encounter order. Uses the
-   op-descriptor's aget classification rather than a local literal set, so a devirtualized
-   `.invk` read is recognized the same way a bare `aget` is."
+  "Every array read the expression makes, as {:sym :idx}, in encounter order.
+
+   Delegates to `od/aget-reads`, which classifies via the registry — so bare `aget`,
+   `clojure.core/aget` (WHAT THE WALKER ACTUALLY EMITS), `raster.arrays/aget`, and a devirtualized
+   `.invk` are all recognized. This docstring previously CLAIMED that while the code matched
+   `(= 'aget (first f))`; the result was `:operands []` for every compiled deftm, so no tensorize
+   gate could ever see an operand and a canonical f16 matmul routed to `:naive-segred`."
   [expr]
-  (->> (tree-seq coll? seq expr)
-       (keep (fn [f]
-               (when (and (seq? f) (= 'aget (first f)) (symbol? (second f)))
-                 {:sym (second f) :idx (nth f 2)})))
-       vec))
+  (mapv #(select-keys % [:sym :idx]) (od/aget-reads expr)))
 
 (defn- verify-declared-map
   "A declared map is admitted only if it provably generates the operand's ACTUAL index."
@@ -127,9 +127,9 @@
     (when (and (seq? body) (od/multiplication-op? (od/semantic-op body)))
       (let [args (vec (od/call-args body))]
         (when (= (count syms) (count args))
-          (let [terms (keep (fn [t] (when (and (seq? t) (= 'aget (first t))
-                                               (contains? syms (second t)))
-                                      {:sym (second t) :idx (nth t 2)}))
+          (let [terms (keep (fn [t] (let [arr (od/aget-array-sym t)]
+                                      (when (contains? syms arr)
+                                        {:sym arr :idx (od/aget-index t)})))
                             args)]
             (when (and (= (count terms) (count args))
                        (= syms (set (map :sym terms))))

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -15,7 +15,8 @@
    (int8 widening). Keys: :kernel-name :source :array-params (binding order) :dtype :out-dtype
    :out-elems :wg [x y] :grid [gx gy] :scalar-args [{:type :value}…] :dims, plus optional
    :fallback-reason, :scheme (quant decode) and :pre-steps (inserted layout rearranges)."
-  (:require [clojure.string :as str]
+  (:require [raster.compiler.core.op-descriptor :as od]
+            [clojure.string :as str]
             [raster.compiler.passes.parallel.contract-lower :as cl]
             [raster.compiler.backend.gpu.segop-opencl :as sco]
             [raster.compiler.backend.gpu.c-emit :as ce]
@@ -41,9 +42,7 @@
    those are declared on the stages and surfaced separately as :lift-operands, so the two groups
    cannot be confused at bind time."
   [body]
-  (distinct (keep (fn [f] (when (and (seq? f) (= 'aget (first f)) (symbol? (second f)))
-                            (second f)))
-                  (tree-seq coll? seq body))))
+  (distinct (map :sym (od/aget-reads body))))
 
 (defn kernel-signature-params
   "The parameter list of the single __kernel in `src`, split at top-level commas. Used to check a
@@ -391,28 +390,37 @@
   [contract-form required-col-axes dtype]
   (let [[_ out free-axes contract-axes body] contract-form]
     (when (and (= 2 (count free-axes)) (= 1 (count contract-axes))
-               (seq? body) (#{'* 'clojure.core/* 'raster.numeric/*} (first body)) (= 3 (count body)))
+               (seq? body) (od/multiplication-op? (od/semantic-op body))
+               ;; TWO arguments, not three: `call-args` excludes the head (and the `.invk` receiver),
+               ;; whereas the literal check this replaced counted the whole form. Getting this wrong
+               ;; made `retarget-to-layout` bail unconditionally, so :nn int8 + :prefer-peak? stopped
+               ;; producing its transpose pre-step and silently fell back to :quant-naive.
+               (= 2 (count (od/call-args body))))
       (let [[i-sym M] (first free-axes) [j-sym N] (second free-axes) [l-sym K] (first contract-axes)
             ext {i-sym M j-sym N l-sym K}
-            agets (mapv ce/normalize-array-prims (rest body))
-            agets (filterv #(and (seq? %) (= 'aget (first %))) agets)]
+            agets (mapv ce/normalize-array-prims (od/call-args body))
+            agets (filterv od/aget-call? agets)]
         (when (= 2 (count agets))
-          (let [syms-of (fn [g] (set (filter symbol? (tree-seq coll? seq (nth g 2)))))
+          (let [syms-of (fn [g] (set (filter symbol? (tree-seq coll? seq (od/aget-index g)))))
                 col (first (filter #(and (contains? (syms-of %) j-sym)
                                          (not (contains? (syms-of %) i-sym))) agets))
                 row (first (filter #(and (contains? (syms-of %) i-sym)
                                          (not (contains? (syms-of %) j-sym))) agets))]
             (when (and col row (not= col row))
-              (let [col-arr (nth col 1)
+              (let [col-arr (od/aget-array-sym col)
                     actual-axes [l-sym j-sym]          ; the :nn storage we can retarget from
-                    cmap (operand-map contract-form col-arr (nth col 2) actual-axes
+                    cmap (operand-map contract-form col-arr (od/aget-index col) actual-axes
                                       (mapv ext actual-axes))
                     want (am/of-axes (mapv (fn [a] [a (ext a)]) required-col-axes))]
                 ;; only proceed when the ACTUAL layout is verified and the difference is a
                 ;; genuine 2-D group transposition
                 (when (and cmap (am/transposed-2d? cmap want))
                   (let [col-t (gensym (str (name col-arr) "__t"))
-                        new-body (list '* row (list 'aget col-t (am/index-expr want)))
+                        ;; QUALIFIED: this form RE-ENTERS route-contraction, so emitting bare ops
+                        ;; here would hand the router the one spelling its matchers used to be the
+                        ;; only ones that worked — and violates CLAUDE.md's emit-qualified rule.
+                        new-body (list 'raster.numeric/*
+                                       row (list 'raster.arrays/aget col-t (am/index-expr want)))
                         ;; PRESERVE THE FORM'S OPTS. Rebuilding with only :maps silently dropped
                         ;; :epilogue, :decode, :init, :combine and :out-dtype — so a retargeted
                         ;; contraction lost its scale (wrong by a constant factor), and a
@@ -477,9 +485,17 @@
                   :epilogue (:epilogue f)
                   :tensorize-inner? tz?}))
         dp4a-ok? (fn [form]
+                   ;; The router must consult the SAME gate the emitter will apply. It previously
+                   ;; checked only k%4 and the operand layout, so a `:decode` (or a body the leaf
+                   ;; would discard) passed here and then THREW inside
+                   ;; generate-staged-contraction-kernel — turning a correct :quant-naive kernel
+                   ;; into a hard compile error. Keep the emitter's throw: it is the right contract
+                   ;; for an EXPLICIT :tensorize-inner? true. The router just has to stop asking
+                   ;; when the answer is no. Same pattern the :staged-segred branch already uses.
                    (and (number? k-extent) (zero? (mod (long k-extent) 4))
                         (:ok (cf/check-layout (cf/contraction-facts form :dtype :byte)
-                                              (:dp4a cf/leaf-layouts)))))
+                                              (:dp4a cf/leaf-layouts)))
+                        (:ok (sco/staged-inner-dp4a-legal? (spec form true)))))
         emit (fn [form tz? pre-steps]
                (let [k (sco/generate-staged-contraction-kernel (spec form tz?) out-sym)]
                  (cond-> {:strategy (if tz? :dp4a :quant-naive)

--- a/src/raster/compiler/passes/parallel/par_fusion.clj
+++ b/src/raster/compiler/passes/parallel/par_fusion.clj
@@ -48,11 +48,10 @@
   "Check if body reads from sym via aget."
   [body sym]
   (cond
-    (and (seq? body)
-         (descriptor/aget-op? (first body))
-         (>= (count body) 3)
-         (symbol? (second body))
-         (= (name sym) (name (second body))))
+    ;; descriptor/aget-call? rather than aget-op? on `(first body)`: the latter is blind to a
+    ;; DEVIRTUALIZED read, whose head is `.invk` and whose array sits one position further along.
+    (and (descriptor/aget-call? body)
+         (= (name sym) (name (descriptor/aget-array-sym body))))
     true
 
     (seq? body) (some #(aget-reads-sym? % sym) (rest body))
@@ -135,10 +134,9 @@
               (recur (inc i) (conj result [sym expr]) fused skip-set))))))))
 
 (defn- agets-on-arrays
-  "Every (aget arr idx) node in `expr`, as a set of the array symbols read."
+  "Every array read in `expr`, as the set of array symbols read — every spelling."
   [expr]
-  (into #{} (keep #(when (and (seq? %) (= 'aget (first %))) (second %)))
-        (tree-seq coll? seq expr)))
+  (into #{} (map :sym) (descriptor/aget-reads expr)))
 
 (defn fuse-contract-map
   "Fuse a contraction followed by an ELEMENTWISE map over its output into ONE contraction whose
@@ -183,12 +181,11 @@
                     operands-of (fn [mi]
                                   (let [t (:idx mi)
                                         others (disj (agets-on-arrays (:body mi)) c-out)
+                                        reads (descriptor/aget-reads (:body mi))
                                         resolved (for [a others
                                                        :let [idxs (distinct
-                                                                   (keep #(when (and (seq? %) (= 'aget (first %))
-                                                                                     (= a (second %)))
-                                                                            (nth % 2))
-                                                                         (tree-seq coll? seq (:body mi))))]]
+                                                                   (keep #(when (= a (:sym %)) (:idx %))
+                                                                         reads))]]
                                                    (when (= 1 (count idxs))
                                                      (when-let [m (am/flat-index->map (first idxs) t free-axes)]
                                                        {:sym a :map m})))]
@@ -210,10 +207,16 @@
                         acc-sym (gensym "acc__")
                         ;; (aget C <map-idx>) → the accumulator symbol; every other operand keeps
                         ;; its aget, and epilogue-splice re-indexes it from the declared axis-map
-                        ep-expr (clojure.walk/postwalk
-                                 (fn [f] (if (and (seq? f) (= 'aget (first f)) (= c-out (second f)))
-                                           acc-sym f))
-                                 (:body mi))
+                        ;; Registry-classified AND metadata-preserving. With the literal match,
+                        ;; a walker-spelled `(clojure.core/aget C t)` was left in the epilogue
+                        ;; expression — so `epilogue-legal?`'s accumulator-appears-once rule saw
+                        ;; ZERO uses and the fused kernel would have read C instead of the
+                        ;; accumulator. This must change in lockstep with agets-on-arrays above:
+                        ;; broadening the collectors alone yields a fused epilogue with operands
+                        ;; but no accumulator, which is a silent wrong answer rather than a refusal.
+                        ep-expr (descriptor/rewrite-aget-reads
+                                 (:body mi)
+                                 (fn [f] (when (= c-out (descriptor/aget-array-sym f)) acc-sym)))
                         ops (operands-of mi)
                         fused-form (concat (list 'raster.par/contract (:out mi))
                                            (drop 2 (take 5 expr))

--- a/test/raster/compiler/contraction_spelling_test.clj
+++ b/test/raster/compiler/contraction_spelling_test.clj
@@ -1,0 +1,238 @@
+(ns raster.compiler.contraction-spelling-test
+  "THE ROUTE A CONTRACTION TAKES MUST NOT DEPEND ON HOW ITS ARRAY READ IS SPELLED. Device-free.
+
+   Four spellings denote the same array read:
+
+     (aget A i)                  bare — what every hand-written test form in this repo used
+     (clojure.core/aget A i)     WHAT THE WALKER ACTUALLY EMITS (walker's :array-op handler
+                                 qualifies into clojure.core)
+     (raster.arrays/aget A i)    what CLAUDE.md tells authors to write, and what
+                                 c_emit/normalize-array-prims produces from a devirtualized read
+     (.invk impl A i)            devirtualized — array at position 2, index at 3, semantic op
+                                 recovered from :raster.op/original metadata
+
+   Twelve matchers on the contraction vertical decided \"is this an array read\" with
+   `(= 'aget (first f))`, so on real compiled IR they all saw ZERO operands. Measured consequences:
+
+     • f16 matmul routed to :naive-segred instead of :dpas — 577 vs 4357 GFLOP/s on Arc 140V, where
+       the routed :dpas path is at PARITY with the hand-written XMX GEMM. Pure loss.
+     • :byte/staged emitted SYNTACTICALLY INVALID OpenCL: `staged_contract(, __global float*
+       restrict out, int _nseg)` — leading comma, operands absent from the signature while the body
+       still read them.
+     • a :decode zero-point SILENTLY DROPPED: `acc += a[l]*b[l]` where the semantics are
+       `(a[l]-zp)*b[l]`. A wrong answer, not a slow one.
+
+   WHY STRATEGY EQUALITY IS NOT ENOUGH, and why these tests assert emitted SOURCE. At `:byte` with
+   an :nn layout every spelling routes to `:quant-naive` — the strategies agree while the kernel is
+   invalid C. A test that compared only `:strategy` would have passed throughout. So the property
+   asserted here is the strongest available: for one contraction, every spelling produces the same
+   strategy, the same :array-params, and byte-identical kernel source modulo the name gensym."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [raster.compiler.passes.parallel.contract-route :as cr]
+            [raster.compiler.ir.axis-map :as am]
+            [raster.compiler.core.op-descriptor :as od]))
+
+;; ── the same contraction, four spellings ────────────────────────────────────────────
+(defn- read-form
+  "An array read `arr[idx]` in one of the four spellings."
+  [spelling arr idx]
+  (case spelling
+    :bare   (list 'aget arr idx)
+    :core   (list 'clojure.core/aget arr idx)
+    :arrays (list 'raster.arrays/aget arr idx)
+    :invk   (with-meta (list '.invk 'aget-impl arr idx)
+              {:raster.op/original 'raster.arrays/aget})))
+
+(def ^:private spellings [:bare :core :arrays :invk])
+
+(defn- mm
+  "C[i,j] = Σ_l A[i,l]·B[l,j]. `:nt` stores B as B[j,l] (K-contiguous, the dp4a layout).
+   `:cast?` wraps extents in `(long …)` the way the walked dialect does."
+  [spelling m n k & {:keys [nt decode cast?]}]
+  (let [ext (fn [e] (if cast? (list 'long e) e))
+        row (list 'clojure.core/+ (list 'clojure.core/* 'i (ext k)) 'l)
+        col (if nt
+              (list 'clojure.core/+ (list 'clojure.core/* 'j (ext k)) 'l)
+              (list 'clojure.core/+ (list 'clojure.core/* 'l (ext n)) 'j))]
+    (concat
+     (list 'raster.par/contract 'C [['i m] ['j n]] [['l k]]
+           (list 'raster.numeric/* (read-form spelling 'A row) (read-form spelling 'B col)))
+     (when decode [:decode {'A (list 'clojure.core/- 'x 8)}]))))
+
+(defn- normalize-src
+  "Kernel source with the name gensym erased, so two spellings' sources are comparable."
+  [src]
+  (some-> src (str/replace #"_\d{3,}" "_N")))
+
+(defn- route [form dtype]
+  (cr/route-contraction form :dtype dtype))
+
+;; ── the property ────────────────────────────────────────────────────────────────────
+(def ^:private cases
+  [{:label "f16 canonical matmul → the PEAK tensorized leaf" :dtype :half  :opts {}
+    :expect :dpas}
+   {:label "f64 → the portable tiled leaf"                   :dtype :double :opts {}
+    :expect :regtiled}
+   {:label "int8 :nn → widening quant"                       :dtype :byte  :opts {}
+    :expect :quant-naive}
+   {:label "int8 :nt (K-contiguous) → dp4a"                  :dtype :byte  :opts {:nt true}
+    :expect :dp4a}
+   {:label "walked dialect: extents wrapped in (long …)"      :dtype :half  :opts {:cast? true}
+    :expect :dpas}
+   ;; THE CASE THAT WAS MISSING. Every other row either has no casts, or routes to a leaf that
+   ;; REGENERATES the index from an axis-map (dpas, staged) and so drops them for free. A leaf that
+   ;; emits the body's index VERBATIM is the only place a `(long 640)` extent can reach the C — and
+   ;; it did, producing `A[((i * (long)(640)) + l)]` for the walked spelling against `A[((i * 640) +
+   ;; l)]` for the bare one. Non-square dims too, so a row/col mix-up cannot hide behind symmetry.
+   {:label "walked dialect + a VERBATIM-index leaf (regtiled)" :dtype :double
+    :opts {:cast? true} :expect :regtiled :dims [96 160 64]}])
+
+(deftest routing-is-independent-of-the-read-spelling
+  (doseq [{:keys [label dtype opts expect dims]} cases]
+    (testing label
+      (let [[m n k] (or dims [128 128 128])
+            rs (into {} (for [sp spellings]
+                          [sp (route (apply mm sp m n k (mapcat identity opts)) dtype)]))]
+        (doseq [sp spellings]
+          (is (= expect (:strategy (get rs sp)))
+              (str sp " must reach " expect)))
+        (testing "…and :array-params agree — this is the assertion that catches the invalid-C bug,
+                  where every spelling routed to the same strategy but the operands vanished from
+                  the kernel signature while the body still read them"
+          (doseq [sp spellings]
+            (is (= '[A B] (vec (:array-params (get rs sp))))
+                (str sp " operand list"))))
+        (testing "…and the emitted kernel source is byte-identical modulo the name gensym"
+          (let [ref (normalize-src (:source (get rs :bare)))]
+            (doseq [sp (rest spellings)]
+              (is (= ref (normalize-src (:source (get rs sp))))
+                  (str sp " source differs from bare")))))))))
+
+(deftest an-invalid-kernel-signature-is-impossible
+  (testing "the concrete artifact of the old defect: a signature beginning `(,` — a leading comma
+            with zero parameters. Pinned directly so the shape cannot come back by another route"
+    (doseq [sp spellings
+            dtype [:half :double :byte]]
+      (let [src (:source (route (mm sp 128 128 128) dtype))
+            sig (re-find #"__kernel void [^)]*\)" (str src))]
+        (is (not (re-find #"\(\s*," (str sig)))
+            (str sp "/" dtype " emitted a parameterless signature: " sig))
+        (doseq [arr ["A" "B"]]
+          (is (re-find (re-pattern (str "restrict\\s+" arr "\\b")) (str sig))
+              (str sp "/" dtype " reads " arr " but does not declare it: " sig)))))))
+
+;; ── rewriters: what no strategy assertion can see ───────────────────────────────────
+(deftest a-decode-zero-point-reaches-the-emitted-kernel
+  (testing "the :decode load-lambda is the per-operand zero-point subtraction. Dropping it is a
+            WRONG ANSWER that leaves the strategy, the signature and the parameter count intact —
+            invisible to every other assertion here"
+    (doseq [sp spellings]
+      (let [src (str (:source (route (mm sp 128 128 128 :decode true) :byte)))
+            acc (re-find #"acc_0 \+=[^;]*;" src)]
+        (is (some? acc) (str sp ": no accumulate statement found"))
+        (is (re-find #"- 8" (str acc))
+            (str sp ": zero-point silently dropped → " acc))))))
+
+(deftest the-router-declines-where-the-emitter-would-throw
+  (testing "int8 + :nt + :decode is dp4a-LAYOUT-legal but the dp4a leaf REPLACES the body, so it
+            would discard the decode. The emitter throws — correctly, for an explicit
+            :tensorize-inner? true — so the ROUTER must stop asking. Before the gate consulted the
+            emitter's own predicate, broadening the matchers would have converted a correct
+            :quant-naive kernel into a hard compile error"
+    (doseq [sp spellings]
+      (let [r (try (route (mm sp 128 128 128 :nt true :decode true) :byte)
+                   (catch clojure.lang.ExceptionInfo e {:threw (:reason (ex-data e))}))]
+        (is (= :quant-naive (:strategy r))
+            (str sp ": expected a decline to :quant-naive, got " (pr-str r)))))))
+
+;; ── the second, independent blocker: integer casts in the index ──────────────────────
+(deftest affine-matching-sees-through-integer-casts
+  (testing "the walked dialect wraps extents in `(long …)`. While `affine` treated `(long 128)` as
+            an OPAQUE atom, the index was not the row-major layout, the DPAS orientation gate
+            declined with :non-canonical-orientation, and a compiled deftm could not reach the
+            tensorized leaf EVEN WITH its operands recognized. Two independent blockers on one path"
+    (let [want (am/of-axes '[[i 128] [l 128]])]
+      (is (am/index-matches? want '(clojure.core/+ (clojure.core/* i 128) l)))
+      (is (am/index-matches? want '(clojure.core/+ (clojure.core/* i (long 128)) l)))
+      (is (am/index-matches? want '(clojure.core/+ (clojure.core/* i (int 128)) l)))))
+  (testing "…while genuinely opaque subterms stay opaque — distributing quot/mod would make two
+            different gathers compare equal, which is a silent wrong-operand bug"
+    (is (false? (am/index= '(clojure.core/quot i 4) '(clojure.core/mod i 4) '[i])))))
+
+;; ── the shared helpers ──────────────────────────────────────────────────────────────
+(deftest aget-reads-recognizes-every-spelling
+  (doseq [sp spellings]
+    (testing (str sp)
+      (let [f (read-form sp 'A '(clojure.core/+ i 1))
+            reads (od/aget-reads (list 'raster.numeric/* f 2.0))]
+        (is (= 1 (count reads)))
+        (is (= 'A (:sym (first reads))))
+        (is (= '(clojure.core/+ i 1) (:idx (first reads))))
+        (is (= f (:form (first reads))) "the matched NODE is returned, so a rewriter need not
+                                         re-implement matching"))))
+  (testing "quoted data is data, not code"
+    (is (empty? (od/aget-reads '(quote (aget A i))))))
+  (testing "a non-read is not a read"
+    (is (empty? (od/aget-reads '(clojure.core/+ i 1))))))
+
+(deftest rewriting-preserves-spelling-positions-and-metadata
+  (doseq [sp spellings]
+    (testing (str sp " keeps its own shape")
+      (let [f (read-form sp 'A 'OLD)
+            r (od/rewrite-aget-index f 'NEW)]
+        (is (= 'NEW (od/aget-index r)) "index replaced")
+        (is (= 'A (od/aget-array-sym r)) "array untouched — a POSITIONAL rewrite would corrupt
+                                          .invk into (aget impl idx)")
+        (is (= (first f) (first r)) "spelling preserved")
+        (is (od/aget-call? r) "still recognizable as a read after rewriting"))))
+  (testing "metadata survives — :raster.op/original is what makes a devirtualized read
+            recognizable at all, so dropping it blinds the very next matcher"
+    (let [r (od/rewrite-aget-index (read-form :invk 'A 'OLD) 'NEW)]
+      (is (= 'raster.arrays/aget (:raster.op/original (meta r))))))
+  (testing "a type tag on an enclosing form is preserved through a rewrite"
+    (let [expr (with-meta (list 'raster.numeric/* (read-form :core 'A 'OLD) 2.0)
+                 {:raster.type/tag 'Double})]
+      (is (= 'Double (:raster.type/tag (meta (od/rewrite-aget-indices expr '{A NEW})))))))
+  (testing "only the named arrays are rewritten"
+    (let [expr (list 'raster.numeric/* (read-form :core 'A 'IA) (read-form :core 'B 'IB))
+          r (od/rewrite-aget-indices expr '{A NEW})]
+      (is (= 'NEW (od/aget-index (nth r 1))))
+      (is (= 'IB (od/aget-index (nth r 2))) "B untouched")))
+  (testing "quote is opaque to the rewriter"
+    (is (= '(quote (clojure.core/aget A OLD))
+           (od/rewrite-aget-indices '(quote (clojure.core/aget A OLD)) '{A NEW}))))
+  (testing "rewriting a non-read is a bug, not a silent no-op"
+    (is (thrown? clojure.lang.ExceptionInfo (od/rewrite-aget-index '(clojure.core/+ i 1) 'NEW)))))
+
+;; ── end to end: the only test that would have caught BOTH defects ───────────────────
+(deftest a-real-walked-deftm-reaches-the-peak-leaf
+  (testing "Every other test here builds its form by hand. This one takes the compiler's OWN output
+            — `ensure-walked-body!` on a literal-dim deftm, which yields
+            `(clojure.core/aget A (clojure.core/+ (clojure.core/* i (long 128)) l))` — and asserts
+            it routes to the tensorized leaf.
+
+            Before this change it reached :naive-segred. With ONLY the matcher fix it reached
+            :regtiled with :non-canonical-orientation, because of the (long 128). It passes only
+            when both the registry classification and the affine cast-unwrapping are in place.
+            Hand-written bare-`aget` forms could never have shown either."
+    (let [ns-form '(do
+                     (clojure.core/require '[raster.arrays :as ra] 'raster.par 'raster.numeric)
+                     (raster.core/deftm spelling-e2e-mm
+                       [A :- (Array double), B :- (Array double)] :- (Array double)
+                       (let [C (ra/alloc-like A 16384)]
+                         (raster.par/contract C [[i 128] [j 128]] [[l 128]]
+                           (raster.numeric/* (ra/aget A (clojure.core/+ (clojure.core/* i 128) l))
+                                             (ra/aget B (clojure.core/+ (clojure.core/* l 128) j))))
+                         C)))
+          v (binding [*ns* (find-ns 'raster.compiler.contraction-spelling-test)] (eval ns-form))
+          walked ((requiring-resolve 'raster.core/ensure-walked-body!) v)
+          form (first (filter #(and (seq? %) (= 'raster.par/contract (first %)))
+                              (tree-seq coll? seq walked)))]
+      (is (some? form) "no par/contract survived walking")
+      (testing "the walker really does emit the qualified spelling with a cast extent"
+        (let [reads (od/aget-reads (nth form 4))]
+          (is (= 2 (count reads)))
+          (is (every? #(= 'clojure.core/aget (first (:form %))) reads))))
+      (is (= :dpas (:strategy (cr/route-contraction form :dtype :half))))
+      (is (= :regtiled (:strategy (cr/route-contraction form :dtype :double)))))))


### PR DESCRIPTION
## The defect

Twelve matchers on the contraction vertical decided "is this an array read" with `(= 'aget (first f))`. The walker emits **`clojure.core/aget`**, so on real compiled IR every one of them saw **zero operands**. Verified on the repo's own `raster.linalg.contract/contract-mm`:

```clojure
(clojure.core/aget A (clojure.core/+ (clojure.core/* i (long k)) l))
```

Nothing caught it because every contraction test hand-writes bare `aget` — capability validated in isolation, never through the seam.

Three consequences, and only the first is a performance problem:

| | |
|---|---|
| f16 canonical matmul | routed `:naive-segred` instead of `:dpas` — **577 vs 4357 GFLOP/s** on Arc 140V, where routed `:dpas` is at **parity with the hand-written XMX GEMM** (4281). Pure loss. |
| `:byte`/staged | emitted **syntactically invalid OpenCL**: `staged_contract_N(, __global float* restrict out, int _nseg)` — leading comma, operands absent from the signature while the body still read them. |
| `:decode` | zero-point **silently dropped**: `acc += a[l]*b[l]` where the semantics are `(a[l]-zp)*b[l]`. A wrong answer. |

## A second, independent blocker

`axis_map/affine` treated `(long 128)` as an opaque atom, so a walked index was not the row-major layout and the DPAS gate declined with `:non-canonical-orientation`. **With only the matcher fix, walked IR reached `:regtiled`, not `:dpas`.** `od/unwrap-int-cast` already existed for this class (privately, used by `affine-step`); it is now public and applied in `affine`, so the affine normal form agrees with the step matcher instead of being stricter by accident.

## The fix

Shared helpers in `core/op_descriptor` — the true leaf. (`core/util` requires `ir/form` + `ir/par`, so `ir/contraction-facts → core/util` would invert the layering CLAUDE.md declares.)

- `aget-reads` — collect `{:sym :idx :form}`, every spelling, quote-opaque
- `aget-index` — so no pass writes `(nth f 2)`; the index sits at position 2 for `aget` and 3 for `.invk`, so a positional *rewrite* corrupts one of them
- `rewrite-aget-reads` / `rewrite-aget-indices` — spelling-, position- and **metadata**-preserving
- `canonicalize-index` — strip int casts around **literals**, so one contraction emits one kernel text whichever way its body was spelled (a cast around a *variable* is left alone)

Collectors and rewriters land **together**, deliberately: broadening the collectors alone turns a loud refusal (`"epilogue would be silently dropped"`) into a *silent wrong epilogue*.

One place would have newly **thrown**: int8 + `:nt` + `:decode` is dp4a-layout-legal, but that leaf replaces the body and would discard the decode. `dp4a-ok?` now consults `staged-inner-dp4a-legal?` — the same gate the emitter applies — and declines to `:quant-naive`. The emitter keeps its throw; that is the right contract for an explicit `:tensorize-inner? true`.

## Validation

Four spellings (bare / `clojure.core` / `raster.arrays` / devirtualized `.invk`) × six shape+dtype cases: identical strategy, identical `:array-params`, and **byte-identical kernel source** modulo the name gensym.

Source identity is the load-bearing assertion. At `:byte :nn` every spelling *already* agreed on `:strategy` while the kernel was invalid C — a strategy-only test would have passed throughout.

End to end: `ensure-walked-body!` on a literal-dim deftm now routes `:half → :dpas`.

Mutation-checked — reverting the collector to bare-only fails **40** assertions, removing the cast unwrapping fails **7**, making the rewriter positional fails **2**.

`bench/soac_contract_bench.clj` gains a `routed-spec` that goes through `route-contraction` and takes `:source`/`:array-params`/`:scalar-args`/`:wg`/`:grid` from the descriptor, so it validates the descriptor rather than hand-computing geometry from `/128.0` literals; and a `:walker` spelling that is verbatim what `ensure-walked-body!` produces.

**Suite: 2048 tests / 32788 assertions, 0 failures.**

## Note on the performance claim

The `577 → 4357` figures characterize the **defect**, from a stable run of two genuinely different kernels. The **fix** is verified by source identity, not by re-measurement: the box was too noisy tonight to quote a ratio — unchanged `golden-gemm-f16` moved 3997 → 4281 → 5350 GF/s across runs. Since both spellings now emit identical source with identical grid, workgroup and scalar args, they cannot differ in performance by construction, which is a stronger claim than a benchmark ratio.

## Still open (found by the same audit, not in this PR)

- `contract_route.clj:365` is `(catch clojure.lang.ExceptionInfo _ nil)` — it swallowed the exact message `"tensorize: operand must be an aget"`, leaving `:fallback-reason nil`. Recording declines instead is ~30 lines and would have made this whole class self-diagnosing.
- The peak leaves still have **no production caller**: `opencl-pass` only ever passes `:float`/`:double`, so `:dpas`/`:dp4a`/`:quant-naive`/`:staged-segred` remain unreachable from a compiled deftm until a precision policy is plumbed through.