### PR TITLE
The router must say why it chose a slower leaf

### DIFF
--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -816,7 +816,17 @@
                           (concat [:c-dtype :half
                                    :block-m (:block-m tile) :block-n (:block-n tile)
                                    :sg-m (:sg-m tile) :sg-n (:sg-n tile)
-                                   :block-k (:block-k tile) :matrix (:matrix tile)]
+                                   :block-k (:block-k tile) :matrix (:matrix tile)
+                                   ;; PIPELINE DEPTH. Omitting this pinned every routed kernel to
+                                   ;; emit-gemm-tiled's `:or prefetch 3` while the schedule, the
+                                   ;; SLM-capped feasibility filter and the autotuner all believed
+                                   ;; :num-stages was live — so tiles differing ONLY in :num-stages
+                                   ;; emitted identical source, and a tuner "measuring" that axis was
+                                   ;; measuring noise. The resident door has always passed it
+                                   ;; (ze_runtime `:prefetch (:num-stages tile 3)`); this door had
+                                   ;; not, which is the schema-without-emission that CLAUDE.md and
+                                   ;; north-star §10 forbid.
+                                   :prefetch (:num-stages tile 3)]
                                   (when ep [:epilogue (:epilogue ep)
                                             :epilogue-params (:epilogue-params ep)
                                             :epilogue-helpers (:epilogue-helpers ep)])))]

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -299,10 +299,10 @@
          :out-elems nseg :dims [nseg]})
 
       ;; 2 free + 1 contract → the tensorize fast path (DPAS if legal, else regtiled).
-      ;; Returns nil when the form fails a TENSORIZE structural precondition (symbolic dims,
-      ;; non-+ combine, non-product element …) — then we fall through to the general naive
-      ;; leaf rather than hard-failing a perfectly legal contraction.
-      (and (= 2 n-free) (= 1 n-contract) (tensorize-plan))
+      ;; A `{::declines …}` result means BOTH tensorize leaves refused for a documented reason —
+      ;; we fall through to the general naive leaf rather than hard-failing a perfectly legal
+      ;; contraction, and carry the reasons onto that leaf's descriptor.
+      (and (= 2 n-free) (= 1 n-contract) (:strategy (tensorize-plan)))
       (tensorize-plan)
 
       ;; everything else (n-free≠2, n≥2 contract axes, or a tensorize-ineligible 2-free form)
@@ -311,25 +311,99 @@
       :else
       (let [sr (cl/contract-form->segred contract-form :dtype dtype)
             {:keys [kernel-name source array-params scalar-params]}
-            (sco/generate-segmented-reduce-kernel sr out-sym :dtype dtype)]
+            (sco/generate-segmented-reduce-kernel sr out-sym :dtype dtype)
+            ;; WHY THIS LEAF AND NOT A FASTER ONE. Only meaningful for the 2-free/1-contract shape,
+            ;; where a tensorize leaf was actually attempted; for every other shape no faster leaf
+            ;; exists to decline, so an empty vector is the honest answer rather than a fabricated
+            ;; "not eligible".
+            declines (when (and (= 2 n-free) (= 1 n-contract))
+                       (::declines (tensorize-plan)))]
+        (cond->
         {:strategy :naive-segred
+         :declines (vec declines)
          :kernel-name kernel-name :source source :array-params array-params
          :dtype dtype :out-dtype dtype :wg [256 1] :grid [(ceil-div nseg 256) 1]
          ;; SYMBOLIC axis bounds become int kernel params (the emitter declares them, sorted by
          ;; name); they must be bound BEFORE the trailing count or the launch arity is wrong.
          :scalar-args (conj (mapv (fn [p] {:type :int :value p}) scalar-params)
                             {:type :int :value nseg})
-         :out-elems nseg :dims [nseg]}))))))
+         :out-elems nseg :dims [nseg]}
+          ;; the LAST decline is the decisive one — the leaf that would otherwise have taken the
+          ;; work. Using the first reported DPAS's generic :not-a-contraction where regtiled's
+          ;; specific :symbolic-dims / :non-plus-combine is the actual answer.
+          (seq declines) (assoc :fallback-reason (:reason (last declines))))))))))
+
+(def ^:private decline-reasons
+  "The reasons a tensorize leaf may legitimately REFUSE a shape — a WHITELIST.
+
+   A denylist was written here first and was wrong for the usual reason: it assumed every unknown
+   reason is safe to treat as a decline. `emit-gemm-tiled` throws VALIDATION errors carrying no
+   `:reason` at all (`opencl_codegen.clj:649-660`: `{:tile …}`, `{:beta beta}`, `{}`), so a genuine
+   emitter bug — a non-divisible tile, split-k with beta≠0 — would have been filed as \"this shape
+   is not tiled-leaf shaped\" and silently demoted to `:naive-segred`. That is exactly the
+   loud-to-silent trade this whole change exists to prevent.
+
+   So: only these reasons are declines. Anything else — a different reason, or none — propagates.
+   Adding a gate reason means adding it here; forgetting to is a LOUD failure, which is the safe
+   direction. These are the reasons the legality gates themselves produce; grep `:reason :` in
+   `segop_opencl.clj` to see the full set."
+  #{;; shape / structure — the contraction is fine, it just is not tiled-leaf shaped
+    :symbolic-dims :symbolic-bounds-unsupported :non-plus-combine :non-product-element
+    :non-aget-operand :not-a-contraction :not-2-free :body-has-unmodeled-terms
+    ;; dtype / orientation / alignment
+    :dtype-not-dpas :non-canonical-orientation :n-pitch-unaligned :k-pitch-unaligned
+    ;; declared-operand and quant-leaf legality
+    :operand-without-a-declared-map :missing-declared-contract-axes
+    :declared-operand-not-read-by-the-body :declared-map-does-not-match-the-body-index
+    :dp4a-needs-int8-operands :dp4a-needs-two-declared-operands
+    :decode-on-a-body-replacing-leaf :inner-extent-not-a-multiple-of-4
+    :inner-stage-accumulator-not-integral :inner-stage-axis-is-not-contiguous
+    ;; epilogue legality
+    :epilogue-needs-2-free :epilogue-ignores-accumulator :accumulator-used-more-than-once
+    :reduction-in-epilogue :layout-changing-op-in-epilogue})
+
+(defn- decline
+  "A structured record of ONE leaf declining. `:data` is the gate's own ex-data minus its `:reason`
+   (already lifted) — deliberately small: a descriptor is compared and logged, and stuffing whole
+   forms in here makes diffs unreadable and would poison any future descriptor-derived cache key."
+  [leaf reason message data]
+  (cond-> {:leaf leaf :reason reason}
+    message (assoc :message message)
+    (seq data) (assoc :data data)))
+
+(defn- decline-of
+  "Classify an ExceptionInfo from a leaf gate. Returns a decline record for a WHITELISTED legality
+   reason; RETHROWS anything else — an unrecognized or absent reason is the compiler saying
+   something is wrong, and a violated invariant is not a routing decision."
+  [leaf ^clojure.lang.ExceptionInfo e]
+  (let [reason (:reason (ex-data e))]
+    (when-not (contains? decline-reasons reason) (throw e))
+    (decline leaf reason (.getMessage e) (dissoc (ex-data e) :reason))))
 
 (defn- route-2free-1contract
   "The tensorize fast path: DPAS if the gate accepts, else the register-tiled portable kernel.
-   Returns nil if the form fails a structural precondition of BOTH (the emitters signal that
-   with ex-info) — the caller then routes to the general naive leaf."
+
+   Returns a descriptor, or `{::declines [...]}` when BOTH tensorize leaves refuse — the caller then
+   routes to the general naive leaf and carries the declines onto ITS descriptor.
+
+   This used to be `(catch ExceptionInfo _ nil)`. The emitters throw messages as specific as
+   \"tensorize: operand must be an aget\" and \"tensorize: needs literal dims\"; the catch discarded
+   every one of them, so a canonical matmul demoted to `:naive-segred` with NOTHING recorded, and the
+   only way to discover why was to read the emitter source. Two things are true at once and the old
+   shape could express neither: a decline is usually LEGITIMATE (symbolic dims, a non-`+` combine and
+   a non-product body are all perfectly good contractions that merely are not tiled-leaf shaped), and
+   it is always worth REPORTING."
   [contract-form out-sym dtype desc tile epilogue]
-  (try
+  (let [acc (volatile! [])
+        note! (fn [d] (vswap! acc conj d) nil)]
+   (try
    (let [sr (cl/contract-form->segred contract-form :dtype dtype)
          dpas (sco/generate-dpas-contraction-kernel sr out-sym :dtype dtype :desc desc :tile tile
                                                     :epilogue epilogue)]
+    (when-not (:tensorized dpas)
+      ;; the DPAS gate DECLINES by returning {:tensorized false :reason …} rather than throwing,
+      ;; so its reason is available without an exception — record it either way
+      (note! (decline :dpas (:reason dpas) nil (dissoc dpas :tensorized :reason))))
     (if (:tensorized dpas)
       (let [[M N _L] (:dims dpas)
             {:keys [block-m block-n]} (:tile dpas)]
@@ -352,7 +426,8 @@
             [bm bn _bk] (:block rt)
             [M N _L] (:dims rt)]
         {:strategy :regtiled
-         :fallback-reason (:reason dpas)
+         :fallback-reason (:reason dpas)             ; kept: existing consumers read it
+         :declines @acc
          :kernel-name (:kernel-name rt)
          :source (:source rt)
          :array-params (:array-params rt)            ; sorted-by-name (dims baked in source)
@@ -361,7 +436,11 @@
          :grid [(ceil-div N bn) (ceil-div M bm)]
          :scalar-args []                             ; regtiled bakes dims → no scalar params
          :dims (:dims rt)})))
-   (catch clojure.lang.ExceptionInfo _ nil)))
+   (catch clojure.lang.ExceptionInfo e
+     ;; whichever tensorize leaf threw, record WHY and let the caller fall through. `decline-of`
+     ;; rethrows :raster/fatal and :raster/bug — those are not routing decisions.
+     (note! (decline-of (if (seq @acc) :regtiled :dpas) e))
+     {::declines @acc}))))
 
 (defn- operand-map
   "The declared axis-map for `arr` if the form carries :maps, else DERIVE one by checking the

--- a/test/raster/compiler/router_declines_test.clj
+++ b/test/raster/compiler/router_declines_test.clj
@@ -1,0 +1,136 @@
+(ns raster.compiler.router-declines-test
+  "THE ROUTER MUST SAY WHY IT CHOSE A SLOWER LEAF. Device-free.
+
+   `route-2free-1contract` ended with `(catch clojure.lang.ExceptionInfo _ nil)`. The tensorize
+   emitters throw messages as specific as `tensorize: operand must be an aget` and
+   `tensorize: needs literal dims`; every one was discarded, and the caller fell through to
+   `:naive-segred` with nothing recorded. Discovering why a canonical matmul had been demoted meant
+   reading emitter source — which is how an 8x slowdown lived in the compiler unnoticed.
+
+   Two things are true at once, and the old shape could express neither:
+
+     • a decline is usually LEGITIMATE — symbolic dims, a non-`+` combine, a non-product body are
+       all perfectly good contractions that merely are not tiled-leaf shaped;
+     • it is always worth REPORTING.
+
+   So declines become data, and the distinction that must NOT be lost is decline-vs-fatal: a
+   violated invariant recorded as a fallback would convert a loud error into a slow silent path,
+   which is the exact inversion this work exists to prevent."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.passes.parallel.contract-route :as cr]
+            [raster.compiler.core.hardware :as chw]))
+
+(defn- mm
+  [m n k & {:keys [sym-dims combine]}]
+  (concat (list 'raster.par/contract 'C
+                [['i (if sym-dims 'M m)] ['j n]] [['l k]]
+                (list 'raster.numeric/*
+                      (list 'clojure.core/aget 'A
+                            (list 'clojure.core/+ (list 'clojure.core/* 'i k) 'l))
+                      (list 'clojure.core/aget 'B
+                            (list 'clojure.core/+ (list 'clojure.core/* 'l n) 'j))))
+          (when combine [:combine combine])))
+
+(defn- route [form dtype] (cr/route-contraction form :dtype dtype))
+
+(deftest a-peak-route-declines-nothing
+  (testing "when the fastest leaf is taken there is nothing to explain — an empty/absent :declines
+            is the honest answer, not a fabricated 'not eligible'"
+    (let [r (route (mm 128 128 128) :half)]
+      (is (= :dpas (:strategy r)))
+      (is (empty? (:declines r))))))
+
+(deftest a-demoted-route-names-every-leaf-that-refused
+  (testing "f64: DPAS declines on dtype and regtiled takes the work. The existing
+            :fallback-reason is preserved for its consumers, AND the attempt is now itemized"
+    (let [r (route (mm 128 128 128) :double)]
+      (is (= :regtiled (:strategy r)))
+      (is (= :dtype-not-dpas (:fallback-reason r)) "existing key kept")
+      (is (= [[:dpas :dtype-not-dpas]] (mapv (juxt :leaf :reason) (:declines r))))))
+
+  (testing "symbolic dims: BOTH tensorize leaves refuse, so we land on the general leaf — which
+            previously recorded NOTHING AT ALL, not even a :fallback-reason key"
+    (let [r (route (mm 128 128 128 :sym-dims true) :half)
+          by-leaf (into {} (map (juxt :leaf identity)) (:declines r))]
+      (is (= :naive-segred (:strategy r)))
+      (is (= #{:dpas :regtiled} (set (keys by-leaf))) "both attempts itemized")
+      (is (= :symbolic-dims (:reason (get by-leaf :regtiled))))
+      (is (re-find #"literal dims" (str (:message (get by-leaf :regtiled))))
+          "the emitter's own sentence survives — it is the thing that was being thrown away")
+      (is (= :symbolic-dims (:fallback-reason r))
+          "the headline reason is the DECISIVE (last) decline — the leaf that would otherwise have
+           taken the work — not DPAS's generic :not-a-contraction")))
+
+  (testing "a non-+ combine is a legitimate contraction that simply is not tiled-leaf shaped"
+    (let [r (route (mm 128 128 128 :combine 'max) :half)
+          by-leaf (into {} (map (juxt :leaf identity)) (:declines r))]
+      (is (= :naive-segred (:strategy r)))
+      (is (= :non-plus-combine (:reason (get by-leaf :regtiled))))
+      (is (re-find #"combine must be \+" (str (:message (get by-leaf :regtiled))))))))
+
+(deftest a-shape-with-no-faster-leaf-claims-no-declines
+  (testing "a 0-free full reduction never attempts a tensorize leaf, so reporting one as having
+            'declined' would be a fabrication"
+    (let [r (route '(raster.par/contract O [] [[l 256]]
+                      (raster.numeric/* (clojure.core/aget A l) (clojure.core/aget B l)))
+                   :double)]
+      (is (empty? (:declines r))))))
+
+;; ── the guard that matters most ─────────────────────────────────────────────────────
+(deftest only-whitelisted-legality-reasons-become-declines
+  (testing "A DENYLIST was written here first and was wrong the usual way — it assumed every
+            unknown reason is safe to treat as a decline. `emit-gemm-tiled` throws validation
+            errors with NO :reason at all (a non-divisible tile, split-k with beta≠0), so an
+            emitter BUG would have been filed as 'not tiled-leaf shaped' and silently demoted.
+            Only whitelisted legality reasons are declines; anything else propagates."
+    (let [decline-of (var-get (requiring-resolve
+                              'raster.compiler.passes.parallel.contract-route/decline-of))]
+      (testing "a documented leaf-legality reason becomes a record"
+        (let [d (decline-of :regtiled (ex-info "tensorize: needs literal dims"
+                                               {:reason :symbolic-dims :dims '[M 128 128]}))]
+          (is (= :regtiled (:leaf d)))
+          (is (= :symbolic-dims (:reason d)))
+          (is (= "tensorize: needs literal dims" (:message d)))
+          (is (= '{:dims [M 128 128]} (:data d)) ":reason is lifted, not duplicated into :data")))
+      (testing "an invariant violation escapes"
+        (doseq [fatal [:raster/fatal :raster/bug]]
+          (is (thrown? clojure.lang.ExceptionInfo
+                       (decline-of :dpas (ex-info "invariant violated" {:reason fatal})))
+              (str fatal " must escape, not become a decline"))))
+      (testing "…and so does an exception with NO reason, or an unrecognized one"
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (decline-of :dpas (ex-info "emit-gemm-tiled: not divisible" {:tile [129 128]}))))
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (decline-of :dpas (ex-info "something new" {:reason :a-reason-nobody-declared}))))))))
+
+(deftest an-emitter-failure-propagates-through-the-WHOLE-router
+  (testing "the end-to-end version of the above, injected through `route-contraction` rather than
+            at the private classifier: a tile whose block-m is not divisible by sg-m makes
+            emit-gemm-tiled throw a REASONLESS validation error. That must surface, not become a
+            quietly slower kernel"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"not divisible"
+         (cr/route-contraction (mm 128 128 128) :dtype :half
+                               :tile {:block-m 129 :block-n 128 :sg-m 32 :sg-n 32 :block-k 32
+                                      :matrix {:m 8 :n 16 :k 16 :subgroup 16}})))))
+
+;; ── the schedule axis that was declared, costed, gated — and never emitted ───────────
+(deftest pipeline-depth-actually-reaches-the-emitted-kernel
+  (testing "`:num-stages` is a schedule key with a schema, an SLM-capped feasibility filter and an
+            autotune axis. The contraction door never passed it to the emitter, so every routed
+            kernel used emit-gemm-tiled's `:or prefetch 3` and tiles differing ONLY in :num-stages
+            emitted IDENTICAL source — a tuner 'measuring' that axis was measuring noise.
+
+            This is north-star §10's 'no knob without emission', and the resident door had always
+            passed it (ze_runtime `:prefetch (:num-stages tile 3)`)."
+    (let [desc (try (chw/descriptor-for :ze:0) (catch Throwable _ nil))
+          base (chw/gemm-tile-for desc)
+          norm #(clojure.string/replace (str %) #"_\d{3,}" "_N")
+          src-for (fn [ns] (norm (:source (cr/route-contraction (mm 256 256 256) :dtype :half
+                                                                :tile (assoc base :num-stages ns)
+                                                                :desc desc))))
+          sources (mapv src-for [2 3 4 8])]
+      (is (= 4 (count (distinct sources)))
+          "four pipeline depths must produce four different kernels")
+      (is (= :dpas (:strategy (cr/route-contraction (mm 256 256 256) :dtype :half :desc desc)))
+          "and threading it must not change which leaf is chosen"))))


### PR DESCRIPTION
**Stacked on #93** — base is `fix/aget-spelling-blocks-peak-leaves`, not `main`.

Two defects of one kind: a schedule decision that reached nothing, and a diagnostic that reached no one. Both are north-star §10 violations — *"no knob without … emission"* and *"do not infer semantics from … exception fallbacks"*.

## 1. Declines become data

`route-2free-1contract` ended in `(catch clojure.lang.ExceptionInfo _ nil)`. The tensorize emitters throw sentences as specific as `"tensorize: needs literal dims"` and `"tensorize: combine must be +"` — every one discarded, with the caller falling through to `:naive-segred` recording **nothing**, not even a `:fallback-reason` key. Finding out why a canonical matmul had been demoted meant reading emitter source. That is how the 8× slowdown in #93 lived here unnoticed.

```
:naive-segred   :fallback-reason :symbolic-dims
    :dpas      :not-a-contraction
    :regtiled  :symbolic-dims  | "tensorize: needs literal dims"
```

Two things are true at once, and the old shape could express neither: a decline is usually **legitimate** — symbolic dims, a non-`+` combine, a non-product body are all perfectly good contractions that merely are not tiled-leaf shaped — and it is always worth **reporting**. `:regtiled` keeps its existing `:fallback-reason` for current consumers.

## 2. `:num-stages` now reaches emission

The contraction door passed tile geometry and `:matrix` but **not** prefetch depth, so every routed kernel used `emit-gemm-tiled`'s `:or prefetch 3` — while the schema, the SLM-capped feasibility filter and the autotune axis all believed the key was live.

Measured: four `:num-stages` values → **1** distinct kernel before, **4** after. A tuner "measuring" that axis was measuring noise. The resident door has always passed it (`ze_runtime` `:prefetch (:num-stages tile 3)`).

## A correction worth recording

The first version classified decline-vs-fatal with a **denylist** — `:raster/fatal`/`:raster/bug` rethrow, everything else is a decline. That assumes every unknown reason is safe, and it isn't: `emit-gemm-tiled` throws validation errors carrying **no `:reason` at all** (`opencl_codegen.clj:649-660` — `{:tile …}`, `{:beta beta}`, `{}`). A non-divisible tile, or split-k with beta≠0, would have been filed as "not tiled-leaf shaped" and silently demoted — the exact loud→silent trade this PR exists to prevent, inside the PR that prevents it.

Now a **whitelist** of the 27 documented legality reasons; anything else, unrecognized or absent, propagates. Verified end-to-end: a non-divisible tile surfaces `"emit-gemm-tiled: block-m/sg-m not divisible (129/32)"` instead of quietly producing a slower kernel. Adding a gate reason means adding it here — and forgetting to is a *loud* failure, which is the safe direction.

Also fixed: the general leaf's `:fallback-reason` is now the **decisive** (last) decline — regtiled's specific `:symbolic-dims` — not the first-reported DPAS `:not-a-contraction`.

## Validation

Mutation-checked: removing the fatal rethrow fails 2 assertions; removing the prefetch threading fails 1. The test injects a reasonless emitter failure through the **whole router**, not only at the private classifier.

**Suite: 2054 tests / 32813 assertions, 0 failures.**

## Not in scope, same class, next

`segop_lower_pass.clj:28/34` (warn-and-nil — named directly by north-star §3.5) and `opencl_pass.clj:66/78` (catch-all into the legacy generator, incrementing the same stat either way). Those are Increment 1's SegOp-boundary work.