### PR TITLE
Conversion declines are data: the router, the SegOp boundary, and a schedule axis that reached nothing

### DIFF
--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -60,29 +60,63 @@
 
 (def ^:private segop-id-counter (atom 0))
 
+(def ^:private fatal-reasons
+  "A violated invariant is not \"the SegOp path does not cover this form\". Letting one fall through
+   to the legacy generator would run the pipeline on with the bug intact."
+  #{:raster/fatal :raster/bug})
+
+(defn- segop-attempt
+  "Run a SegOp lowering `thunk`, returning the SegOp or nil — and RECORDING why on `stats` when it
+   declines, so the choice between the modern SegOp path and `legacy/generate-par-*` stops being
+   invisible.
+
+   Both outcomes increment the same `:ze-maps`/`:ze-reduces` counter, so nothing downstream — not
+   the kernel record, not explain-pipeline — could say which of the two code generators produced a
+   kernel, or why the modern one declined. That is the same warn-and-vanish shape north-star §3.5
+   rejects at the SegOp boundary, one door along."
+  [stats kind form dtype thunk]
+  (let [r (try {:ok (thunk)} (catch Exception e {:err e}))]
+    (cond
+      (:err r)
+      (let [e (:err r)]
+        (when (contains? fatal-reasons (:reason (ex-data e))) (throw e))
+        (swap! stats update :segop-declined (fnil conj [])
+               {:kind kind :op (when (seq? form) (first form))
+                :dtype (or dtype :double)
+                :reason (or (:reason (ex-data e)) :no-lowering-rule)
+                :message (.getMessage e)
+                :fallback :legacy-codegen})
+        nil)
+
+      (nil? (:ok r))
+      (do (swap! stats update :segop-declined (fnil conj [])
+                 {:kind kind :op (when (seq? form) (first form))
+                  :dtype (or dtype :double)
+                  :reason :lowering-produced-nothing
+                  :fallback :legacy-codegen})
+          nil)
+
+      :else (:ok r))))
+
 (defn- par->segmap
-  "Compute SegMap on-the-fly from a par/map! form."
-  [form dtype]
-  (try
-    (let [par-info (par/extract-par-map-info form)
-          soac (raster.compiler.ir.soac/par-form->soac
-                (:out par-info) form (swap! segop-id-counter inc))
-          segops (raster.compiler.passes.parallel.soac-lower/lower-soac
-                  soac :ze:0 :dtype (or dtype :double))]
-      (first segops))
-    (catch Exception _ nil)))
+  "Compute SegMap on-the-fly from a par/map! form. nil (with a recorded decline) ⇒ legacy codegen."
+  [stats form dtype]
+  (segop-attempt stats :segmap form dtype
+                 #(let [par-info (par/extract-par-map-info form)
+                        soac (raster.compiler.ir.soac/par-form->soac
+                              (:out par-info) form (swap! segop-id-counter inc))]
+                    (first (raster.compiler.passes.parallel.soac-lower/lower-soac
+                            soac :ze:0 :dtype (or dtype :double))))))
 
 (defn- par->segred
-  "Compute SegRed on-the-fly from a par/reduce form."
-  [form dtype]
-  (try
-    (let [sym (gensym "red_")
-          soac (raster.compiler.ir.soac/par-form->soac
-                sym form (swap! segop-id-counter inc))
-          segops (raster.compiler.passes.parallel.soac-lower/lower-soac
-                  soac :ze:0 :dtype (or dtype :double))]
-      (first segops))
-    (catch Exception _ nil)))
+  "Compute SegRed on-the-fly from a par/reduce form. nil (with a recorded decline) ⇒ legacy codegen."
+  [stats form dtype]
+  (segop-attempt stats :segred form dtype
+                 #(let [sym (gensym "red_")
+                        soac (raster.compiler.ir.soac/par-form->soac
+                              sym form (swap! segop-id-counter inc))]
+                    (first (raster.compiler.passes.parallel.soac-lower/lower-soac
+                            soac :ze:0 :dtype (or dtype :double))))))
 
 (defn- maybe-compile-spirv
   "Optionally compile OpenCL C to SPIR-V."
@@ -148,7 +182,7 @@
               (if (and (number? bound) (< bound min-elements))
                 (do (swap! stats update :fallback inc)
                     (par/expand-par-map! form))
-                (if-let [segmap (par->segmap form dtype)]
+                (if-let [segmap (par->segmap stats form dtype)]
                   (let [kernel (segop-cl/generate-segmap-kernel segmap out
                                                                 :dtype dtype :scalar-types top-scalar-types
                                                                 :array-types (merge top-array-types (:array-types (meta form))))]
@@ -233,7 +267,7 @@
             ;; instead of round-tripping a host scalar. Emitted by the reduce-fusion pass.
             (par/par-reduce-into-form? form)
             (let [{:keys [out-buf reduce-form bound]} (par/extract-par-reduce-into-info form)]
-              (if-let [segred (par->segred reduce-form dtype)]
+              (if-let [segred (par->segred stats reduce-form dtype)]
                 (let [kernel (segop-cl/generate-segred-kernel segred nil :dtype dtype)]
                   (if kernel
                     (let [k (register-kernel! kernel :ze-reduces)]
@@ -258,7 +292,7 @@
               (if (and (number? bound) (< bound min-elements))
                 (do (swap! stats update :fallback inc)
                     (par/expand-par-reduce form))
-                (if-let [segred (par->segred form dtype)]
+                (if-let [segred (par->segred stats form dtype)]
                   (let [kernel (segop-cl/generate-segred-kernel segred nil :dtype dtype)]
                     (if kernel
                       (let [k (register-kernel! kernel :ze-reduces)]

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -816,7 +816,17 @@
                           (concat [:c-dtype :half
                                    :block-m (:block-m tile) :block-n (:block-n tile)
                                    :sg-m (:sg-m tile) :sg-n (:sg-n tile)
-                                   :block-k (:block-k tile) :matrix (:matrix tile)]
+                                   :block-k (:block-k tile) :matrix (:matrix tile)
+                                   ;; PIPELINE DEPTH. Omitting this pinned every routed kernel to
+                                   ;; emit-gemm-tiled's `:or prefetch 3` while the schedule, the
+                                   ;; SLM-capped feasibility filter and the autotuner all believed
+                                   ;; :num-stages was live — so tiles differing ONLY in :num-stages
+                                   ;; emitted identical source, and a tuner "measuring" that axis was
+                                   ;; measuring noise. The resident door has always passed it
+                                   ;; (ze_runtime `:prefetch (:num-stages tile 3)`); this door had
+                                   ;; not, which is the schema-without-emission that CLAUDE.md and
+                                   ;; north-star §10 forbid.
+                                   :prefetch (:num-stages tile 3)]
                                   (when ep [:epilogue (:epilogue ep)
                                             :epilogue-params (:epilogue-params ep)
                                             :epilogue-helpers (:epilogue-helpers ep)])))]

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -299,10 +299,10 @@
          :out-elems nseg :dims [nseg]})
 
       ;; 2 free + 1 contract → the tensorize fast path (DPAS if legal, else regtiled).
-      ;; Returns nil when the form fails a TENSORIZE structural precondition (symbolic dims,
-      ;; non-+ combine, non-product element …) — then we fall through to the general naive
-      ;; leaf rather than hard-failing a perfectly legal contraction.
-      (and (= 2 n-free) (= 1 n-contract) (tensorize-plan))
+      ;; A `{::declines …}` result means BOTH tensorize leaves refused for a documented reason —
+      ;; we fall through to the general naive leaf rather than hard-failing a perfectly legal
+      ;; contraction, and carry the reasons onto that leaf's descriptor.
+      (and (= 2 n-free) (= 1 n-contract) (:strategy (tensorize-plan)))
       (tensorize-plan)
 
       ;; everything else (n-free≠2, n≥2 contract axes, or a tensorize-ineligible 2-free form)
@@ -311,25 +311,99 @@
       :else
       (let [sr (cl/contract-form->segred contract-form :dtype dtype)
             {:keys [kernel-name source array-params scalar-params]}
-            (sco/generate-segmented-reduce-kernel sr out-sym :dtype dtype)]
+            (sco/generate-segmented-reduce-kernel sr out-sym :dtype dtype)
+            ;; WHY THIS LEAF AND NOT A FASTER ONE. Only meaningful for the 2-free/1-contract shape,
+            ;; where a tensorize leaf was actually attempted; for every other shape no faster leaf
+            ;; exists to decline, so an empty vector is the honest answer rather than a fabricated
+            ;; "not eligible".
+            declines (when (and (= 2 n-free) (= 1 n-contract))
+                       (::declines (tensorize-plan)))]
+        (cond->
         {:strategy :naive-segred
+         :declines (vec declines)
          :kernel-name kernel-name :source source :array-params array-params
          :dtype dtype :out-dtype dtype :wg [256 1] :grid [(ceil-div nseg 256) 1]
          ;; SYMBOLIC axis bounds become int kernel params (the emitter declares them, sorted by
          ;; name); they must be bound BEFORE the trailing count or the launch arity is wrong.
          :scalar-args (conj (mapv (fn [p] {:type :int :value p}) scalar-params)
                             {:type :int :value nseg})
-         :out-elems nseg :dims [nseg]}))))))
+         :out-elems nseg :dims [nseg]}
+          ;; the LAST decline is the decisive one — the leaf that would otherwise have taken the
+          ;; work. Using the first reported DPAS's generic :not-a-contraction where regtiled's
+          ;; specific :symbolic-dims / :non-plus-combine is the actual answer.
+          (seq declines) (assoc :fallback-reason (:reason (last declines))))))))))
+
+(def ^:private decline-reasons
+  "The reasons a tensorize leaf may legitimately REFUSE a shape — a WHITELIST.
+
+   A denylist was written here first and was wrong for the usual reason: it assumed every unknown
+   reason is safe to treat as a decline. `emit-gemm-tiled` throws VALIDATION errors carrying no
+   `:reason` at all (`opencl_codegen.clj:649-660`: `{:tile …}`, `{:beta beta}`, `{}`), so a genuine
+   emitter bug — a non-divisible tile, split-k with beta≠0 — would have been filed as \"this shape
+   is not tiled-leaf shaped\" and silently demoted to `:naive-segred`. That is exactly the
+   loud-to-silent trade this whole change exists to prevent.
+
+   So: only these reasons are declines. Anything else — a different reason, or none — propagates.
+   Adding a gate reason means adding it here; forgetting to is a LOUD failure, which is the safe
+   direction. These are the reasons the legality gates themselves produce; grep `:reason :` in
+   `segop_opencl.clj` to see the full set."
+  #{;; shape / structure — the contraction is fine, it just is not tiled-leaf shaped
+    :symbolic-dims :symbolic-bounds-unsupported :non-plus-combine :non-product-element
+    :non-aget-operand :not-a-contraction :not-2-free :body-has-unmodeled-terms
+    ;; dtype / orientation / alignment
+    :dtype-not-dpas :non-canonical-orientation :n-pitch-unaligned :k-pitch-unaligned
+    ;; declared-operand and quant-leaf legality
+    :operand-without-a-declared-map :missing-declared-contract-axes
+    :declared-operand-not-read-by-the-body :declared-map-does-not-match-the-body-index
+    :dp4a-needs-int8-operands :dp4a-needs-two-declared-operands
+    :decode-on-a-body-replacing-leaf :inner-extent-not-a-multiple-of-4
+    :inner-stage-accumulator-not-integral :inner-stage-axis-is-not-contiguous
+    ;; epilogue legality
+    :epilogue-needs-2-free :epilogue-ignores-accumulator :accumulator-used-more-than-once
+    :reduction-in-epilogue :layout-changing-op-in-epilogue})
+
+(defn- decline
+  "A structured record of ONE leaf declining. `:data` is the gate's own ex-data minus its `:reason`
+   (already lifted) — deliberately small: a descriptor is compared and logged, and stuffing whole
+   forms in here makes diffs unreadable and would poison any future descriptor-derived cache key."
+  [leaf reason message data]
+  (cond-> {:leaf leaf :reason reason}
+    message (assoc :message message)
+    (seq data) (assoc :data data)))
+
+(defn- decline-of
+  "Classify an ExceptionInfo from a leaf gate. Returns a decline record for a WHITELISTED legality
+   reason; RETHROWS anything else — an unrecognized or absent reason is the compiler saying
+   something is wrong, and a violated invariant is not a routing decision."
+  [leaf ^clojure.lang.ExceptionInfo e]
+  (let [reason (:reason (ex-data e))]
+    (when-not (contains? decline-reasons reason) (throw e))
+    (decline leaf reason (.getMessage e) (dissoc (ex-data e) :reason))))
 
 (defn- route-2free-1contract
   "The tensorize fast path: DPAS if the gate accepts, else the register-tiled portable kernel.
-   Returns nil if the form fails a structural precondition of BOTH (the emitters signal that
-   with ex-info) — the caller then routes to the general naive leaf."
+
+   Returns a descriptor, or `{::declines [...]}` when BOTH tensorize leaves refuse — the caller then
+   routes to the general naive leaf and carries the declines onto ITS descriptor.
+
+   This used to be `(catch ExceptionInfo _ nil)`. The emitters throw messages as specific as
+   \"tensorize: operand must be an aget\" and \"tensorize: needs literal dims\"; the catch discarded
+   every one of them, so a canonical matmul demoted to `:naive-segred` with NOTHING recorded, and the
+   only way to discover why was to read the emitter source. Two things are true at once and the old
+   shape could express neither: a decline is usually LEGITIMATE (symbolic dims, a non-`+` combine and
+   a non-product body are all perfectly good contractions that merely are not tiled-leaf shaped), and
+   it is always worth REPORTING."
   [contract-form out-sym dtype desc tile epilogue]
-  (try
+  (let [acc (volatile! [])
+        note! (fn [d] (vswap! acc conj d) nil)]
+   (try
    (let [sr (cl/contract-form->segred contract-form :dtype dtype)
          dpas (sco/generate-dpas-contraction-kernel sr out-sym :dtype dtype :desc desc :tile tile
                                                     :epilogue epilogue)]
+    (when-not (:tensorized dpas)
+      ;; the DPAS gate DECLINES by returning {:tensorized false :reason …} rather than throwing,
+      ;; so its reason is available without an exception — record it either way
+      (note! (decline :dpas (:reason dpas) nil (dissoc dpas :tensorized :reason))))
     (if (:tensorized dpas)
       (let [[M N _L] (:dims dpas)
             {:keys [block-m block-n]} (:tile dpas)]
@@ -352,7 +426,8 @@
             [bm bn _bk] (:block rt)
             [M N _L] (:dims rt)]
         {:strategy :regtiled
-         :fallback-reason (:reason dpas)
+         :fallback-reason (:reason dpas)             ; kept: existing consumers read it
+         :declines @acc
          :kernel-name (:kernel-name rt)
          :source (:source rt)
          :array-params (:array-params rt)            ; sorted-by-name (dims baked in source)
@@ -361,7 +436,11 @@
          :grid [(ceil-div N bn) (ceil-div M bm)]
          :scalar-args []                             ; regtiled bakes dims → no scalar params
          :dims (:dims rt)})))
-   (catch clojure.lang.ExceptionInfo _ nil)))
+   (catch clojure.lang.ExceptionInfo e
+     ;; whichever tensorize leaf threw, record WHY and let the caller fall through. `decline-of`
+     ;; rethrows :raster/fatal and :raster/bug — those are not routing decisions.
+     (note! (decline-of (if (seq @acc) :regtiled :dpas) e))
+     {::declines @acc}))))
 
 (defn- operand-map
   "The declared axis-map for `arr` if the form carries :maps, else DERIVE one by checking the

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -17,28 +17,72 @@
 
 (def ^:private id-counter (atom 0))
 
-(defn- par-form->segops
-  "Convert a par form to SegOp records via SOAC intermediate.
-   sym: binding symbol (or gensym for body-position forms).
-   form: the par/* S-expression.
-   Returns [SegOp ...] or nil if not a par form."
+(def ^:private fatal-reasons
+  "A violated invariant is not a missing lowering rule. Recording one as a conversion decline would
+   let the pipeline continue on the legacy path with the bug intact — the loud-to-silent trade this
+   whole change exists to prevent."
+  #{:raster/fatal :raster/bug})
+
+(defn- diagnostic
+  "The structured record north-star §3.5 asks for in place of a warning: WHICH operation, in which
+   binding, for which target dialect and device, what rule was missing, and what happens instead."
+  [sym form stage ^Exception e device-id dtype]
+  {:op (when (seq? form) (first form))
+   :sym sym
+   :stage stage                     ; :soac (par form → SOAC) or :segop (SOAC → SegOp)
+   :target-dialect :segop
+   :device (or device-id :cpu:0)
+   :dtype (or dtype :double)
+   :reason (or (:reason (ex-data e)) :no-lowering-rule)
+   :message (.getMessage e)
+   ;; a fallback is a stated outcome, not the absence of one
+   :fallback :no-segop-metadata-backend-lowers-or-uses-legacy-codegen})
+
+(defn- lower-attempt
+  "Lower a par form to SegOp records via the SOAC intermediate.
+
+   Returns `{:segops [...]}` on success, `{:declined <diagnostic>}` when the form IS a parallel
+   primitive but no lowering rule applies, and nil when the form is simply not a par form — the
+   common, correctly-silent case (most bindings are ordinary values).
+
+   This used to `println` a WARNING to stderr and return nil for BOTH of the last two cases. That
+   conflation is the defect: `nil` meant \"nothing to do here\" and \"a parallel form the middle end
+   cannot represent\" at once, so a real coverage gap looked exactly like an ordinary binding and the
+   only trace was a line on stderr that no pass, stat, or diagnostic could see. north-star §3.5 names
+   this precise code: SegOp lowering \"may no longer warn and return nil\".
+
+   The lowering ATTEMPT is unchanged — still tried for any seq, so nothing that lowered before stops
+   lowering now. What is new is that a failure on a recognized par form is reported as data.
+
+   NB success/failure is carried in an explicit `{:ok …}`/`{:err …}` rather than a truthy value: a
+   SOAC node is a RECORD, and records satisfy `map?` and are always truthy, so a compact
+   `or`/`if-let` version silently misread every successful lowering as a decline marker."
   [sym form device-id dtype]
   (when (seq? form)
-    (let [id (swap! id-counter inc)
-          soac-node (try (soac/par-form->soac sym form id)
-                         (catch Exception e
-                           (binding [*out* *err*]
-                             (println (str "WARNING: SegOp lowering failed for " sym ": " (.getMessage e))))
-                           nil))]
-      (when soac-node
-        (try
-          (soac-lower/lower-soac soac-node
-                                 (or device-id :cpu:0)
-                                 :dtype (or dtype :double))
-          (catch Exception e
-            (binding [*out* *err*]
-              (println (str "WARNING: SegOp lowering failed for " sym ": " (.getMessage e))))
-            nil))))))
+    (let [par? (par/par-form? form)
+          decline (fn [stage e] (when (contains? fatal-reasons (:reason (ex-data e))) (throw e))
+                    (when par? {:declined (diagnostic sym form stage e device-id dtype)}))
+          ;; capture value-or-exception in one call: the alternative (catch a sentinel, then call
+          ;; again to get the exception) re-runs a side-effecting conversion
+          attempt (fn [f] (try {:ok (f)} (catch Exception e {:err e})))
+          soac (attempt #(soac/par-form->soac sym form (swap! id-counter inc)))]
+      (cond
+        (:err soac) (decline :soac (:err soac))
+
+        (nil? (:ok soac))
+        (when par? {:declined (diagnostic sym form :soac
+                                          (ex-info "par-form->soac produced no SOAC node" {})
+                                          device-id dtype)})
+
+        :else
+        (let [segops (attempt #(soac-lower/lower-soac (:ok soac) (or device-id :cpu:0)
+                                                      :dtype (or dtype :double)))]
+          (cond
+            (:err segops) (decline :segop (:err segops))
+            (seq (:ok segops)) {:segops (:ok segops)}
+            :else (when par? {:declined (diagnostic sym form :segop
+                                                    (ex-info "lower-soac produced no SegOps" {})
+                                                    device-id dtype)})))))))
 
 (defn- annotate-binding
   "Attach SegOp metadata to a binding symbol."
@@ -69,10 +113,18 @@
           device-id (:target-device opts)
           dtype (:dtype opts)
           lowered (atom 0)
+          ;; Every par form the middle end could NOT represent, as data. Previously these went to
+          ;; stderr as `WARNING: …` and vanished — invisible to stats, to explain-pipeline, and to
+          ;; anyone diagnosing why a kernel took the legacy path.
+          declined (atom [])
+          attempt (fn [sym init]
+                    (let [r (lower-attempt sym init device-id dtype)]
+                      (when-let [d (:declined r)] (swap! declined conj d))
+                      (:segops r)))
           ;; Annotate bindings with SegOp metadata
           new-pairs
           (mapv (fn [[sym init]]
-                  (if-let [segops (par-form->segops sym init device-id dtype)]
+                  (if-let [segops (attempt sym init)]
                     (do (swap! lowered inc)
                         [(annotate-binding sym segops) init])
                     [sym init]))
@@ -81,7 +133,7 @@
           new-body
           (mapv (fn [expr]
                   (let [tmp-sym (gensym "body_par_")]
-                    (if-let [segops (par-form->segops tmp-sym expr device-id dtype)]
+                    (if-let [segops (attempt tmp-sym expr)]
                       (do (swap! lowered inc)
                           (with-meta (list 'do expr)
                             {::body-segops segops}))
@@ -89,4 +141,5 @@
                 body-exprs)
           new-bindings (vec (mapcat identity new-pairs))]
       {:form (list* let-sym new-bindings new-body)
-       :stats {:segops-lowered @lowered}})))
+       :stats (cond-> {:segops-lowered @lowered}
+                (seq @declined) (assoc :segops-declined @declined))})))

--- a/test/raster/compiler/router_declines_test.clj
+++ b/test/raster/compiler/router_declines_test.clj
@@ -1,0 +1,136 @@
+(ns raster.compiler.router-declines-test
+  "THE ROUTER MUST SAY WHY IT CHOSE A SLOWER LEAF. Device-free.
+
+   `route-2free-1contract` ended with `(catch clojure.lang.ExceptionInfo _ nil)`. The tensorize
+   emitters throw messages as specific as `tensorize: operand must be an aget` and
+   `tensorize: needs literal dims`; every one was discarded, and the caller fell through to
+   `:naive-segred` with nothing recorded. Discovering why a canonical matmul had been demoted meant
+   reading emitter source — which is how an 8x slowdown lived in the compiler unnoticed.
+
+   Two things are true at once, and the old shape could express neither:
+
+     • a decline is usually LEGITIMATE — symbolic dims, a non-`+` combine, a non-product body are
+       all perfectly good contractions that merely are not tiled-leaf shaped;
+     • it is always worth REPORTING.
+
+   So declines become data, and the distinction that must NOT be lost is decline-vs-fatal: a
+   violated invariant recorded as a fallback would convert a loud error into a slow silent path,
+   which is the exact inversion this work exists to prevent."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.passes.parallel.contract-route :as cr]
+            [raster.compiler.core.hardware :as chw]))
+
+(defn- mm
+  [m n k & {:keys [sym-dims combine]}]
+  (concat (list 'raster.par/contract 'C
+                [['i (if sym-dims 'M m)] ['j n]] [['l k]]
+                (list 'raster.numeric/*
+                      (list 'clojure.core/aget 'A
+                            (list 'clojure.core/+ (list 'clojure.core/* 'i k) 'l))
+                      (list 'clojure.core/aget 'B
+                            (list 'clojure.core/+ (list 'clojure.core/* 'l n) 'j))))
+          (when combine [:combine combine])))
+
+(defn- route [form dtype] (cr/route-contraction form :dtype dtype))
+
+(deftest a-peak-route-declines-nothing
+  (testing "when the fastest leaf is taken there is nothing to explain — an empty/absent :declines
+            is the honest answer, not a fabricated 'not eligible'"
+    (let [r (route (mm 128 128 128) :half)]
+      (is (= :dpas (:strategy r)))
+      (is (empty? (:declines r))))))
+
+(deftest a-demoted-route-names-every-leaf-that-refused
+  (testing "f64: DPAS declines on dtype and regtiled takes the work. The existing
+            :fallback-reason is preserved for its consumers, AND the attempt is now itemized"
+    (let [r (route (mm 128 128 128) :double)]
+      (is (= :regtiled (:strategy r)))
+      (is (= :dtype-not-dpas (:fallback-reason r)) "existing key kept")
+      (is (= [[:dpas :dtype-not-dpas]] (mapv (juxt :leaf :reason) (:declines r))))))
+
+  (testing "symbolic dims: BOTH tensorize leaves refuse, so we land on the general leaf — which
+            previously recorded NOTHING AT ALL, not even a :fallback-reason key"
+    (let [r (route (mm 128 128 128 :sym-dims true) :half)
+          by-leaf (into {} (map (juxt :leaf identity)) (:declines r))]
+      (is (= :naive-segred (:strategy r)))
+      (is (= #{:dpas :regtiled} (set (keys by-leaf))) "both attempts itemized")
+      (is (= :symbolic-dims (:reason (get by-leaf :regtiled))))
+      (is (re-find #"literal dims" (str (:message (get by-leaf :regtiled))))
+          "the emitter's own sentence survives — it is the thing that was being thrown away")
+      (is (= :symbolic-dims (:fallback-reason r))
+          "the headline reason is the DECISIVE (last) decline — the leaf that would otherwise have
+           taken the work — not DPAS's generic :not-a-contraction")))
+
+  (testing "a non-+ combine is a legitimate contraction that simply is not tiled-leaf shaped"
+    (let [r (route (mm 128 128 128 :combine 'max) :half)
+          by-leaf (into {} (map (juxt :leaf identity)) (:declines r))]
+      (is (= :naive-segred (:strategy r)))
+      (is (= :non-plus-combine (:reason (get by-leaf :regtiled))))
+      (is (re-find #"combine must be \+" (str (:message (get by-leaf :regtiled))))))))
+
+(deftest a-shape-with-no-faster-leaf-claims-no-declines
+  (testing "a 0-free full reduction never attempts a tensorize leaf, so reporting one as having
+            'declined' would be a fabrication"
+    (let [r (route '(raster.par/contract O [] [[l 256]]
+                      (raster.numeric/* (clojure.core/aget A l) (clojure.core/aget B l)))
+                   :double)]
+      (is (empty? (:declines r))))))
+
+;; ── the guard that matters most ─────────────────────────────────────────────────────
+(deftest only-whitelisted-legality-reasons-become-declines
+  (testing "A DENYLIST was written here first and was wrong the usual way — it assumed every
+            unknown reason is safe to treat as a decline. `emit-gemm-tiled` throws validation
+            errors with NO :reason at all (a non-divisible tile, split-k with beta≠0), so an
+            emitter BUG would have been filed as 'not tiled-leaf shaped' and silently demoted.
+            Only whitelisted legality reasons are declines; anything else propagates."
+    (let [decline-of (var-get (requiring-resolve
+                              'raster.compiler.passes.parallel.contract-route/decline-of))]
+      (testing "a documented leaf-legality reason becomes a record"
+        (let [d (decline-of :regtiled (ex-info "tensorize: needs literal dims"
+                                               {:reason :symbolic-dims :dims '[M 128 128]}))]
+          (is (= :regtiled (:leaf d)))
+          (is (= :symbolic-dims (:reason d)))
+          (is (= "tensorize: needs literal dims" (:message d)))
+          (is (= '{:dims [M 128 128]} (:data d)) ":reason is lifted, not duplicated into :data")))
+      (testing "an invariant violation escapes"
+        (doseq [fatal [:raster/fatal :raster/bug]]
+          (is (thrown? clojure.lang.ExceptionInfo
+                       (decline-of :dpas (ex-info "invariant violated" {:reason fatal})))
+              (str fatal " must escape, not become a decline"))))
+      (testing "…and so does an exception with NO reason, or an unrecognized one"
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (decline-of :dpas (ex-info "emit-gemm-tiled: not divisible" {:tile [129 128]}))))
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (decline-of :dpas (ex-info "something new" {:reason :a-reason-nobody-declared}))))))))
+
+(deftest an-emitter-failure-propagates-through-the-WHOLE-router
+  (testing "the end-to-end version of the above, injected through `route-contraction` rather than
+            at the private classifier: a tile whose block-m is not divisible by sg-m makes
+            emit-gemm-tiled throw a REASONLESS validation error. That must surface, not become a
+            quietly slower kernel"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"not divisible"
+         (cr/route-contraction (mm 128 128 128) :dtype :half
+                               :tile {:block-m 129 :block-n 128 :sg-m 32 :sg-n 32 :block-k 32
+                                      :matrix {:m 8 :n 16 :k 16 :subgroup 16}})))))
+
+;; ── the schedule axis that was declared, costed, gated — and never emitted ───────────
+(deftest pipeline-depth-actually-reaches-the-emitted-kernel
+  (testing "`:num-stages` is a schedule key with a schema, an SLM-capped feasibility filter and an
+            autotune axis. The contraction door never passed it to the emitter, so every routed
+            kernel used emit-gemm-tiled's `:or prefetch 3` and tiles differing ONLY in :num-stages
+            emitted IDENTICAL source — a tuner 'measuring' that axis was measuring noise.
+
+            This is north-star §10's 'no knob without emission', and the resident door had always
+            passed it (ze_runtime `:prefetch (:num-stages tile 3)`)."
+    (let [desc (try (chw/descriptor-for :ze:0) (catch Throwable _ nil))
+          base (chw/gemm-tile-for desc)
+          norm #(clojure.string/replace (str %) #"_\d{3,}" "_N")
+          src-for (fn [ns] (norm (:source (cr/route-contraction (mm 256 256 256) :dtype :half
+                                                                :tile (assoc base :num-stages ns)
+                                                                :desc desc))))
+          sources (mapv src-for [2 3 4 8])]
+      (is (= 4 (count (distinct sources)))
+          "four pipeline depths must produce four different kernels")
+      (is (= :dpas (:strategy (cr/route-contraction (mm 256 256 256) :dtype :half :desc desc)))
+          "and threading it must not change which leaf is chosen"))))

--- a/test/raster/compiler/segop_boundary_test.clj
+++ b/test/raster/compiler/segop_boundary_test.clj
@@ -1,0 +1,90 @@
+(ns raster.compiler.segop-boundary-test
+  "SEGOP LOWERING MAY NO LONGER WARN AND RETURN NIL. Device-free.
+
+   `design/compiler-north-star.md` §3.5 names this code directly. Both sites printed
+   `WARNING: SegOp lowering failed for <sym>: <msg>` to stderr and returned nil:
+
+     passes/parallel/segop_lower_pass.clj  — par form → SOAC → SegOp
+     backend/gpu/opencl_pass.clj           — the on-the-fly SegMap/SegRed door
+
+   The defect is not the warning, it is the CONFLATION. `nil` meant two different things at once:
+   \"this binding is an ordinary value, nothing to do\" and \"this is a parallel form the middle end
+   cannot represent\". A genuine coverage gap therefore looked exactly like an ordinary binding, and
+   the only trace was a line on stderr that no pass, stat or diagnostic could see. In `opencl_pass`
+   it is worse: the SegOp path and the legacy generator increment the SAME counter, so nothing
+   downstream could say which of two code generators produced a kernel, or why the modern one
+   declined.
+
+   The fallbacks themselves are legitimate and are deliberately preserved — a form the SegOp path
+   cannot represent SHOULD reach the legacy generator. What changes is that the choice becomes
+   data, per §3.5's requirement that an unsupported form 'produce a structured diagnostic naming
+   the operation, source, missing rule, target dialect, and possible legal fallback'."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.passes.parallel.segop-lower-pass :as slp]))
+
+(defn- stats-of [form] (:stats (slp/segop-lower-pass form {})))
+
+(deftest an-ordinary-binding-is-silent
+  (testing "most bindings are not par forms. Reporting them as 'declined' would drown the signal —
+            absence of a decline must keep meaning 'nothing to lower here'"
+    (let [st (stats-of '(let* [a (clojure.core/+ 1 2)] a))]
+      (is (zero? (:segops-lowered st)))
+      (is (nil? (:segops-declined st)) "no key at all, not an empty vector of nothing"))))
+
+(deftest a-lowerable-par-form-still-lowers
+  (testing "the lowering ATTEMPT is unchanged — nothing that lowered before may stop lowering.
+            (This caught a real regression: a SOAC node is a RECORD, records satisfy `map?` and are
+            always truthy, so a compact or/if-let version misread every SUCCESS as a decline.)"
+    (let [st (stats-of '(let* [o (raster.par/map! O i 256 nil (clojure.core/* i 2.0))] o))]
+      (is (= 1 (:segops-lowered st)))
+      (is (empty? (:segops-declined st))))))
+
+(deftest an-unrepresentable-par-form-becomes-a-diagnostic
+  (testing "a par form with no lowering rule is the case that used to vanish onto stderr"
+    (let [st (stats-of '(let* [o (raster.par/scatter! O IDX V 256)] o))
+          d (first (:segops-declined st))]
+      (is (zero? (:segops-lowered st)))
+      (is (= 1 (count (:segops-declined st))))
+      (testing "…and it names what §3.5 asks for"
+        (is (= 'raster.par/scatter! (:op d)) "the operation")
+        (is (contains? #{:soac :segop} (:stage d)) "which conversion")
+        (is (= :segop (:target-dialect d)) "the target dialect")
+        (is (some? (:reason d)) "the missing rule")
+        (is (some? (:fallback d)) "and what happens instead — a stated outcome, not an absence")))))
+
+(deftest a-fatal-reason-still-escapes
+  (testing "a violated invariant is not a missing lowering rule. Recording one as a conversion
+            decline would let the pipeline continue on the legacy path with the bug intact — the
+            loud-to-silent trade this change exists to prevent"
+    (let [fatal (var-get (requiring-resolve
+                          'raster.compiler.passes.parallel.segop-lower-pass/fatal-reasons))]
+      (is (contains? fatal :raster/fatal))
+      (is (contains? fatal :raster/bug)))))
+
+(deftest the-gpu-door-records-which-generator-it-used
+  (testing "opencl_pass's SegMap/SegRed door recorded nothing when it fell back to legacy codegen,
+            and both paths incremented the same counter. The decline is now structured data on the
+            pass stats; a form the SegOp path handles reports no decline at all."
+    (let [op (requiring-resolve 'raster.compiler.backend.gpu.opencl-pass/opencl-pass)
+          r (op '(raster.par/map! O i 8192 nil (clojure.core/* i 2.0)) :dtype :double)]
+      (is (= 1 (:ze-maps (:stats r))) "still lowered through the SegOp path")
+      (is (empty? (:segop-declined (:stats r))) "so nothing to explain"))
+    (testing "and the recorder itself distinguishes decline from invariant violation"
+      (let [attempt (var-get (requiring-resolve
+                              'raster.compiler.backend.gpu.opencl-pass/segop-attempt))
+            stats (atom {})]
+        (testing "an ordinary lowering failure is recorded and yields nil ⇒ legacy codegen"
+          (is (nil? (attempt stats :segmap '(raster.par/map! O i 4 nil x) :double
+                             (fn [] (throw (ex-info "no rule" {:reason :no-lowering-rule}))))))
+          (let [d (first (:segop-declined @stats))]
+            (is (= :segmap (:kind d)))
+            (is (= :no-lowering-rule (:reason d)))
+            (is (= :legacy-codegen (:fallback d)))))
+        (testing "a lowering that simply produces nothing is ALSO recorded, not silently dropped"
+          (is (nil? (attempt stats :segred '(raster.par/reduce a 0.0 i 4 x) :double (fn [] nil))))
+          (is (= :lowering-produced-nothing
+                 (:reason (last (:segop-declined @stats))))))
+        (testing "…while an invariant violation escapes to the caller"
+          (is (thrown? clojure.lang.ExceptionInfo
+                       (attempt stats :segmap '(raster.par/map! O i 4 nil x) :double
+                                (fn [] (throw (ex-info "bug" {:reason :raster/bug})))))))))))


### PR DESCRIPTION
**Based on `main`, not stacked.** This re-lands #94, which GitHub reports as merged but whose content never reached main: it was based on #93's branch, #93 squash-merged first, and #94 then merged into a branch that no longer led anywhere. Verified absent from main (`decline-reasons`, `:prefetch (:num-stages`, and `router_declines_test.clj` all missing). Same failure mode as #85. Lesson recorded: **no stacked PRs in a squash-merge repo.**

Three defects of one kind — a fact the compiler knew, discarded, and then could not explain. All are north-star §10 violations (*no knob without emission*; *do not infer semantics from exception fallbacks*) and §3.5 names the third directly.

## 1. The router says why it chose a slower leaf (re-landed from #94)

`route-2free-1contract` ended in `(catch ExceptionInfo _ nil)`. The tensorize emitters throw sentences as specific as `"tensorize: needs literal dims"`; every one was discarded and the caller fell through to `:naive-segred` recording **nothing** — not even a `:fallback-reason` key. That is how the 8× slowdown in #93 lived unnoticed.

Each attempted leaf now contributes `{:leaf :reason :message :data}`, carried on the chosen descriptor. Decline-vs-fatal is a **whitelist** of 27 documented legality reasons; anything else — unrecognized or absent — propagates. The first draft was a denylist, and `emit-gemm-tiled` throws reasonless validation errors (`{:tile …}`, `{:beta beta}`, `{}`), so a non-divisible tile would have been filed as "not tiled-leaf shaped" and silently demoted — the exact loud→silent trade this PR exists to prevent. Now verified end-to-end: it surfaces `"emit-gemm-tiled: block-m/sg-m not divisible (129/32)"`.

## 2. `:num-stages` reaches emission (re-landed from #94)

The contraction door passed tile geometry but not prefetch depth, so every routed kernel used `emit-gemm-tiled`'s `:or prefetch 3` while the schema, the SLM-capped feasibility filter and the autotune axis all believed the key was live. Four `:num-stages` values → **1** distinct kernel before, **4** after. A tuner "measuring" that axis was measuring noise.

## 3. SegOp lowering may no longer warn and return nil (new)

`segop_lower_pass.clj` and `opencl_pass.clj` printed `WARNING: SegOp lowering failed…` to stderr and returned nil. The defect is the **conflation**: `nil` meant both "ordinary binding, nothing to do" and "a parallel form the middle end cannot represent", so a real coverage gap looked exactly like an ordinary value. In `opencl_pass` the SegOp path and the legacy generator incremented the **same** counter, so nothing could say which generator produced a kernel.

The fallbacks are legitimate and preserved. The choice is now data on the pass stats, per §3.5 — operation, stage, target dialect, device, dtype, missing rule, and the fallback as a stated outcome. Ordinary non-par bindings report nothing (no key), so absence keeps meaning "nothing to lower". `:raster/fatal`/`:raster/bug` still escape.

A regression the test caught in the first draft, worth recording: a SOAC node is a **record**, records satisfy `map?` and are always truthy, so a compact `or`/`if-let` version misread every *successful* lowering as a decline — baseline lowered 1, draft lowered 0. Success/failure is now an explicit `{:ok}`/`{:err}`.

## Validation

All three suites mutation-checked: fatal-rethrow removal fails 2; prefetch un-threading fails 1; suppressing SegOp declines fails 6; the record trap fails 2; `opencl_pass` ceasing to record fails 3+1. Codex (gpt-5.6-sol) reviewed #94's diff adversarially and found the denylist defect.

**Suite: 2059 tests / 32835 assertions.** The only failures are `autotune-finds-splitk-optimum` (`gemm_autotune_test.clj:66-67`) — a device-timing test with absolute bars (≥8 splits, >4.0×) that searches only `:splits` via `bench-splitk-ms` and never enters `route-contraction`. **It fails identically on `origin/main` with none of this branch applied** (3.63× < 4.0). Pre-existing and environmental; flagged, not fixed here.

## Next (not in this PR)

Kernel ABI (Increment 2); then the `download-range!`/`upload-range!` facility that unblocks the pretrained-rstr continuation work; then precision plumbing so the peak leaves gain a production caller.