### PR TITLE
Ranged transfers: move a sub-range of a session buffer, not the whole allocation

### DIFF
--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -628,6 +628,45 @@
   [sess key dst spec]
   ((rt-resolve (:device-id @sess) "download-range!") (session-buffer sess key) dst spec))
 
+(defn- transfer-ranges!
+  "The batched core. VALIDATES EVERY entry (`plan-range`) before EXECUTING ANY. A batch is how a
+   whole KV cache moves — 36 per-layer buffers for gemma-270m — and a batched API newly makes a
+   partial state possible: a bad spec in the 30th entry leaving 29 layers written. All-or-nothing
+   on validation removes that class; nothing is copied until every range has been proved in
+   bounds. (A failure DURING execution — a device fault — is still partial; that is a different
+   class and is not promised here.)"
+  [sess entries direction]
+  (let [device-id (:device-id @sess)
+        plan (rt-resolve device-id "plan-range")
+        exec (rt-resolve device-id "execute-range!")
+        ;; phase 1: resolve + validate everything, collecting plans in order
+        plans (mapv (fn [[key host spec]]
+                      (let [buf (session-buffer sess key)]
+                        [buf (plan buf host spec direction) host]))
+                    entries)]
+    ;; phase 2: execute in order
+    (mapv (fn [[buf p host]] (exec buf p direction) (if (= :upload direction) buf host)) plans)))
+
+(defn upload-ranges!
+  "BATCHED `upload-range!`: many `[key src spec]` entries in one call, e.g. every layer of a KV
+   continuation:
+
+     (upload-ranges! sess (for [l (range 18)]
+                            [(keyword (str \"kc\" l)) (kc-segment l) {:elements (* tokens kvrow)}]))
+
+   Every entry is bounds-validated BEFORE any is copied, so a bad spec cannot leave the cache
+   half-restored. Returns the buffers, in entry order. This is the shape LMCache's
+   `batched_to_gpu` has; ours is a loop over validated plans rather than a fused kernel because a
+   position-major cache needs no gather."
+  [sess entries]
+  (transfer-ranges! sess entries :upload))
+
+(defn download-ranges!
+  "BATCHED `download-range!`: many `[key dst spec]` entries, validated all-or-nothing, executed
+   in order. Returns the destinations, in entry order."
+  [sess entries]
+  (transfer-ranges! sess entries :download))
+
 (defn buffer
   "Get a DeviceBuffer from the session by key."
   [sess key]

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -601,6 +601,33 @@
                                 {:available (keys buffers)})))]
     ((rt-resolve device-id "buffer->array") buf)))
 
+(defn- session-buffer
+  [sess key]
+  (let [{:keys [buffers]} @sess]
+    (or (get buffers key)
+        (throw (ex-info (str "No buffer for key: " key) {:available (keys buffers)})))))
+
+(defn upload-range!
+  "Copy a SUB-RANGE of a host array or MemorySegment into a session buffer.
+
+     (upload-range! sess :kc0 src {:src-element 0 :dst-element 0 :elements (* tokens kvrow)})
+
+   `src` may be a JVM primitive array or a MemorySegment — an mmap'd file is copied directly, no
+   JVM array in between. Offsets and length are in ELEMENTS of the buffer's dtype; byte size is
+   never the caller's to get wrong. Out-of-range is an error, not a clamp.
+
+   Why this exists: `upload!`/`download` move the WHOLE buffer. A KV cache is allocated at
+   `maxpos` positions and position-major, so a continuation of `t` tokens is one contiguous
+   prefix — exporting it should move `t` rows, not `maxpos`."
+  [sess key src spec]
+  ((rt-resolve (:device-id @sess) "upload-range!") (session-buffer sess key) src spec))
+
+(defn download-range!
+  "Copy a SUB-RANGE of a session buffer into a host array or MemorySegment; mirror of
+   `upload-range!`. Returns `dst`."
+  [sess key dst spec]
+  ((rt-resolve (:device-id @sess) "download-range!") (session-buffer sess key) dst spec))
+
 (defn buffer
   "Get a DeviceBuffer from the session by key."
   [sess key]

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -464,6 +464,66 @@
                (:segment buf) (int 0) MemorySegment/NULL MemorySegment/NULL])
     buf))
 
+(defn- as-segment
+  ^MemorySegment [x]
+  (if (instance? MemorySegment x) x (MemorySegment/ofArray x)))
+
+(defn- check-range!
+  ;; no primitive hints: >4 primitive params is a Clojure limit (CLAUDE.md); the body casts
+  [what have-elements offset elements elem-size other-bytes]
+  (let [have-elements (long have-elements) offset (long offset) elements (long elements)
+        elem-size (long elem-size) other-bytes (long other-bytes)]
+  (when (or (neg? offset) (neg? elements))
+    (throw (ex-info (str what ": negative offset or length") {:offset offset :elements elements})))
+  (when (> (+ offset elements) have-elements)
+    (throw (ex-info (str what ": range exceeds the buffer")
+                    {:offset offset :elements elements :buffer-elements have-elements})))
+  (when (> (* elements elem-size) other-bytes)
+    (throw (ex-info (str what ": range exceeds the host-side array/segment")
+                    {:needed-bytes (* elements elem-size) :available-bytes other-bytes})))))
+
+(defn upload-range!
+  "Ranged host → device copy. Same element semantics as the ze runtime's `upload-range!`, but
+   OpenCL buffers are not host-coherent: the range goes through the host staging segment and a
+   clEnqueueWriteBuffer at the byte offset, so only the RANGE crosses the bus."
+  [^OclBuffer buf src {:keys [src-element dst-element elements]
+                       :or {src-element 0 dst-element 0}}]
+  (ensure-init!)
+  (let [{:keys [queue]} @state
+        es (long (get dtype-byte-sizes (:dtype buf) 4))
+        src-seg (as-segment src)
+        src-off (* (long src-element) es)
+        dst-off (* (long dst-element) es)
+        n-bytes (* (long elements) es)]
+    (check-range! "upload-range!" (:n-elements buf) dst-element elements es
+                  (- (.byteSize src-seg) src-off))
+    (MemorySegment/copy src-seg src-off (:segment buf) dst-off n-bytes)
+    (cl-call! "clEnqueueWriteBuffer" @h-clEnqueueWriteBuffer
+              [queue (:cl-mem buf) (int CL_TRUE) (long dst-off) (long n-bytes)
+               (.asSlice ^MemorySegment (:segment buf) dst-off)
+               (int 0) MemorySegment/NULL MemorySegment/NULL])
+    buf))
+
+(defn download-range!
+  "Ranged device → host copy; mirror of `upload-range!`. Returns `dst`."
+  [^OclBuffer buf dst {:keys [src-element dst-element elements]
+                       :or {src-element 0 dst-element 0}}]
+  (ensure-init!)
+  (let [{:keys [queue]} @state
+        es (long (get dtype-byte-sizes (:dtype buf) 4))
+        dst-seg (as-segment dst)
+        src-off (* (long src-element) es)
+        dst-off (* (long dst-element) es)
+        n-bytes (* (long elements) es)]
+    (check-range! "download-range!" (:n-elements buf) src-element elements es
+                  (- (.byteSize dst-seg) dst-off))
+    (cl-call! "clEnqueueReadBuffer" @h-clEnqueueReadBuffer
+              [queue (:cl-mem buf) (int CL_TRUE) (long src-off) (long n-bytes)
+               (.asSlice ^MemorySegment (:segment buf) src-off)
+               (int 0) MemorySegment/NULL MemorySegment/NULL])
+    (MemorySegment/copy (:segment buf) src-off dst-seg dst-off n-bytes)
+    dst))
+
 (defn buffer->array
   "Copy an OclBuffer's contents to a new JVM array (device → host)."
   [^OclBuffer buf]

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -482,47 +482,51 @@
     (throw (ex-info (str what ": range exceeds the host-side array/segment")
                     {:needed-bytes (* elements elem-size) :available-bytes other-bytes})))))
 
-(defn upload-range!
-  "Ranged host → device copy. Same element semantics as the ze runtime's `upload-range!`, but
-   OpenCL buffers are not host-coherent: the range goes through the host staging segment and a
-   clEnqueueWriteBuffer at the byte offset, so only the RANGE crosses the bus."
-  [^OclBuffer buf src {:keys [src-element dst-element elements]
-                       :or {src-element 0 dst-element 0}}]
+(defn plan-range
+  "Validate one ranged transfer and return its byte-level plan without copying. Same contract as
+   the ze runtime's `plan-range`; split from execution so a batch validates everything first."
+  [^OclBuffer buf host {:keys [src-element dst-element elements]
+                        :or {src-element 0 dst-element 0}} direction]
+  (let [es (long (get dtype-byte-sizes (:dtype buf) 4))
+        host-seg (as-segment host)
+        [buf-el host-el] (case direction :upload [dst-element src-element] :download [src-element dst-element])
+        host-off (* (long host-el) es)]
+    (check-range! (name direction) (:n-elements buf) buf-el elements es
+                  (- (.byteSize host-seg) host-off))
+    {:buf-off (* (long buf-el) es) :host-off host-off :n-bytes (* (long elements) es)
+     :host-seg host-seg}))
+
+(defn execute-range!
+  "Perform a validated transfer. OpenCL buffers are not host-coherent, so the range goes through
+   the host staging segment and a clEnqueueWrite/ReadBuffer at the byte offset — only the RANGE
+   crosses the bus."
+  [^OclBuffer buf {:keys [buf-off host-off n-bytes host-seg]} direction]
   (ensure-init!)
   (let [{:keys [queue]} @state
-        es (long (get dtype-byte-sizes (:dtype buf) 4))
-        src-seg (as-segment src)
-        src-off (* (long src-element) es)
-        dst-off (* (long dst-element) es)
-        n-bytes (* (long elements) es)]
-    (check-range! "upload-range!" (:n-elements buf) dst-element elements es
-                  (- (.byteSize src-seg) src-off))
-    (MemorySegment/copy src-seg src-off (:segment buf) dst-off n-bytes)
-    (cl-call! "clEnqueueWriteBuffer" @h-clEnqueueWriteBuffer
-              [queue (:cl-mem buf) (int CL_TRUE) (long dst-off) (long n-bytes)
-               (.asSlice ^MemorySegment (:segment buf) dst-off)
-               (int 0) MemorySegment/NULL MemorySegment/NULL])
-    buf))
+        staging (.asSlice ^MemorySegment (:segment buf) (long buf-off))]
+    (case direction
+      :upload
+      (do (MemorySegment/copy ^MemorySegment host-seg (long host-off) (:segment buf) (long buf-off) (long n-bytes))
+          (cl-call! "clEnqueueWriteBuffer" @h-clEnqueueWriteBuffer
+                    [queue (:cl-mem buf) (int CL_TRUE) (long buf-off) (long n-bytes)
+                     staging (int 0) MemorySegment/NULL MemorySegment/NULL]))
+      :download
+      (do (cl-call! "clEnqueueReadBuffer" @h-clEnqueueReadBuffer
+                    [queue (:cl-mem buf) (int CL_TRUE) (long buf-off) (long n-bytes)
+                     staging (int 0) MemorySegment/NULL MemorySegment/NULL])
+          (MemorySegment/copy (:segment buf) (long buf-off) ^MemorySegment host-seg (long host-off) (long n-bytes))))))
+
+(defn upload-range!
+  "Ranged host → device copy; returns the buffer."
+  [^OclBuffer buf src spec]
+  (execute-range! buf (plan-range buf src spec :upload) :upload)
+  buf)
 
 (defn download-range!
-  "Ranged device → host copy; mirror of `upload-range!`. Returns `dst`."
-  [^OclBuffer buf dst {:keys [src-element dst-element elements]
-                       :or {src-element 0 dst-element 0}}]
-  (ensure-init!)
-  (let [{:keys [queue]} @state
-        es (long (get dtype-byte-sizes (:dtype buf) 4))
-        dst-seg (as-segment dst)
-        src-off (* (long src-element) es)
-        dst-off (* (long dst-element) es)
-        n-bytes (* (long elements) es)]
-    (check-range! "download-range!" (:n-elements buf) src-element elements es
-                  (- (.byteSize dst-seg) dst-off))
-    (cl-call! "clEnqueueReadBuffer" @h-clEnqueueReadBuffer
-              [queue (:cl-mem buf) (int CL_TRUE) (long src-off) (long n-bytes)
-               (.asSlice ^MemorySegment (:segment buf) src-off)
-               (int 0) MemorySegment/NULL MemorySegment/NULL])
-    (MemorySegment/copy (:segment buf) src-off dst-seg dst-off n-bytes)
-    dst))
+  "Ranged device → host copy; returns `dst`."
+  [^OclBuffer buf dst spec]
+  (execute-range! buf (plan-range buf dst spec :download) :download)
+  dst)
 
 (defn buffer->array
   "Copy an OclBuffer's contents to a new JVM array (device → host)."

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -852,39 +852,50 @@
     (throw (ex-info (str what ": range exceeds the host-side array/segment")
                     {:needed-bytes (* elements elem-size) :available-bytes other-bytes})))))
 
+(defn plan-range
+  "Validate one ranged transfer and return its byte-level PLAN, without copying anything:
+   `{:buf-off :host-off :n-bytes :host-seg}`. Throws on any out-of-range.
+
+   Split from the copy so a BATCH can validate every entry before executing any. Without that, a
+   bad spec in the 30th layer of a 36-layer KV restore would leave the first 29 written and the
+   cache half-restored — a partial state that is worse than either all or nothing, and that a
+   single-range API could never produce."
+  [^DeviceBuffer buf host {:keys [src-element dst-element elements]
+                           :or {src-element 0 dst-element 0}} direction]
+  (let [es (long (get dtype-byte-sizes (:dtype buf) 4))
+        host-seg (as-segment host)
+        ;; for :upload the host side is src and the buffer side is dst; :download is the mirror
+        [buf-el host-el] (case direction :upload [dst-element src-element] :download [src-element dst-element])
+        host-off (* (long host-el) es)]
+    (check-range! (name direction) (:n-elements buf) buf-el elements es
+                  (- (.byteSize host-seg) host-off))
+    {:buf-off (* (long buf-el) es) :host-off host-off :n-bytes (* (long elements) es)
+     :host-seg host-seg}))
+
+(defn execute-range!
+  "Perform a transfer previously validated by `plan-range`. Session buffers are SHARED
+   (host-coherent) allocations, so this is a plain Panama copy — no command list, and a
+   MemorySegment host side (e.g. an mmap'd file) is copied directly without materializing a JVM
+   array."
+  [^DeviceBuffer buf {:keys [buf-off host-off n-bytes host-seg]} direction]
+  (case direction
+    :upload   (MemorySegment/copy ^MemorySegment host-seg (long host-off) (:segment buf) (long buf-off) (long n-bytes))
+    :download (MemorySegment/copy (:segment buf) (long buf-off) ^MemorySegment host-seg (long host-off) (long n-bytes))))
+
 (defn upload-range!
   "Copy `elements` elements from `src` (JVM array or MemorySegment, starting at element
    `src-element`) into `buf` starting at element `dst-element`. Elements, not bytes: the byte
-   size comes from the buffer's own dtype, so a caller cannot mis-size a copy.
-
-   Session buffers are SHARED (host-coherent) allocations, so this is a plain Panama copy — no
-   command list, and a MemorySegment source (e.g. an mmap'd file) is copied directly without
-   materializing a JVM array. Returns the buffer."
-  [^DeviceBuffer buf src {:keys [src-element dst-element elements]
-                          :or {src-element 0 dst-element 0}}]
-  (let [es (long (get dtype-byte-sizes (:dtype buf) 4))
-        src-seg (as-segment src)
-        src-off (* (long src-element) es)
-        n-bytes (* (long elements) es)]
-    (check-range! "upload-range!" (:n-elements buf) dst-element elements es
-                  (- (.byteSize src-seg) src-off))
-    (MemorySegment/copy src-seg src-off (:segment buf) (* (long dst-element) es) n-bytes)
-    buf))
+   size comes from the buffer's own dtype, so a caller cannot mis-size a copy. Returns the buffer."
+  [^DeviceBuffer buf src spec]
+  (execute-range! buf (plan-range buf src spec :upload) :upload)
+  buf)
 
 (defn download-range!
   "Copy `elements` elements from `buf` (starting at element `src-element`) into `dst` (JVM array
-   or MemorySegment, starting at element `dst-element`). The mirror of `upload-range!`; same
-   element semantics and bounds checks. Returns `dst`."
-  [^DeviceBuffer buf dst {:keys [src-element dst-element elements]
-                          :or {src-element 0 dst-element 0}}]
-  (let [es (long (get dtype-byte-sizes (:dtype buf) 4))
-        dst-seg (as-segment dst)
-        dst-off (* (long dst-element) es)
-        n-bytes (* (long elements) es)]
-    (check-range! "download-range!" (:n-elements buf) src-element elements es
-                  (- (.byteSize dst-seg) dst-off))
-    (MemorySegment/copy (:segment buf) (* (long src-element) es) dst-seg dst-off n-bytes)
-    dst))
+   or MemorySegment, starting at element `dst-element`). Mirror of `upload-range!`. Returns `dst`."
+  [^DeviceBuffer buf dst spec]
+  (execute-range! buf (plan-range buf dst spec :download) :download)
+  dst)
 
 (defn buffer->array
   "Copy a DeviceBuffer's contents to a new JVM array.

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -828,6 +828,64 @@
     (MemorySegment/copy src 0 seg 0 n-bytes)
     buf))
 
+(defn- as-segment
+  "A JVM primitive array or a MemorySegment, as a MemorySegment. The one conversion point, so a
+   Boring mmap segment and a float[] take the same code path."
+  ^MemorySegment [x]
+  (if (instance? MemorySegment x) x (MemorySegment/ofArray x)))
+
+(defn- check-range!
+  "Element-range bounds for a ranged transfer. Throws rather than clamping: `array->buffer!`
+   silently copies `(min buf src)` bytes, which is fine for a whole-buffer transfer but is exactly
+   the wrong behaviour for a range — a clamped KV-cache export looks identical to a correct one
+   until the restored continuation diverges at the missing tokens."
+  ;; no primitive hints: >4 primitive params is a Clojure limit (CLAUDE.md); the body casts
+  [what have-elements offset elements elem-size other-bytes]
+  (let [have-elements (long have-elements) offset (long offset) elements (long elements)
+        elem-size (long elem-size) other-bytes (long other-bytes)]
+  (when (or (neg? offset) (neg? elements))
+    (throw (ex-info (str what ": negative offset or length") {:offset offset :elements elements})))
+  (when (> (+ offset elements) have-elements)
+    (throw (ex-info (str what ": range exceeds the buffer")
+                    {:offset offset :elements elements :buffer-elements have-elements})))
+  (when (> (* elements elem-size) other-bytes)
+    (throw (ex-info (str what ": range exceeds the host-side array/segment")
+                    {:needed-bytes (* elements elem-size) :available-bytes other-bytes})))))
+
+(defn upload-range!
+  "Copy `elements` elements from `src` (JVM array or MemorySegment, starting at element
+   `src-element`) into `buf` starting at element `dst-element`. Elements, not bytes: the byte
+   size comes from the buffer's own dtype, so a caller cannot mis-size a copy.
+
+   Session buffers are SHARED (host-coherent) allocations, so this is a plain Panama copy — no
+   command list, and a MemorySegment source (e.g. an mmap'd file) is copied directly without
+   materializing a JVM array. Returns the buffer."
+  [^DeviceBuffer buf src {:keys [src-element dst-element elements]
+                          :or {src-element 0 dst-element 0}}]
+  (let [es (long (get dtype-byte-sizes (:dtype buf) 4))
+        src-seg (as-segment src)
+        src-off (* (long src-element) es)
+        n-bytes (* (long elements) es)]
+    (check-range! "upload-range!" (:n-elements buf) dst-element elements es
+                  (- (.byteSize src-seg) src-off))
+    (MemorySegment/copy src-seg src-off (:segment buf) (* (long dst-element) es) n-bytes)
+    buf))
+
+(defn download-range!
+  "Copy `elements` elements from `buf` (starting at element `src-element`) into `dst` (JVM array
+   or MemorySegment, starting at element `dst-element`). The mirror of `upload-range!`; same
+   element semantics and bounds checks. Returns `dst`."
+  [^DeviceBuffer buf dst {:keys [src-element dst-element elements]
+                          :or {src-element 0 dst-element 0}}]
+  (let [es (long (get dtype-byte-sizes (:dtype buf) 4))
+        dst-seg (as-segment dst)
+        dst-off (* (long dst-element) es)
+        n-bytes (* (long elements) es)]
+    (check-range! "download-range!" (:n-elements buf) src-element elements es
+                  (- (.byteSize dst-seg) dst-off))
+    (MemorySegment/copy (:segment buf) (* (long src-element) es) dst-seg dst-off n-bytes)
+    dst))
+
 (defn buffer->array
   "Copy a DeviceBuffer's contents to a new JVM array.
   For :float16/:half, returns a short array of encoded FP16 values.

--- a/test/raster/gpu/range_transfer_test.clj
+++ b/test/raster/gpu/range_transfer_test.clj
@@ -1,0 +1,121 @@
+(ns raster.gpu.range-transfer-test
+  "RANGED TRANSFERS: move a sub-range of a session buffer, not the whole allocation.
+
+   `upload!`/`download` copy the WHOLE buffer. A KV cache is allocated at `maxpos` positions and is
+   position-major, so a continuation of `t` tokens is one contiguous prefix — exporting it should
+   move `t` rows, not `maxpos`. For gemma-270m that is 9 MiB vs 72 MiB per 256-token continuation.
+
+   The invariant that matters is not 'the range arrives' — it is 'NOTHING ELSE MOVES'. A ranged
+   write that clobbers a neighbouring position looks identical to a correct one until a restored
+   continuation diverges at the wrong token. So every test here checks the untouched regions too.
+
+   The second invariant: out-of-range is an ERROR, never a clamp. `array->buffer!` clamps to
+   `(min buf src)` bytes, which is fine for a whole-buffer copy and exactly wrong for a range."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.dl.gpu-grad-parity :as gp]
+            [raster.gpu.core :as g])
+  (:import [java.lang.foreign Arena MemorySegment ValueLayout]))
+
+;; gemma-270m's real KV shape: 2048 positions x (1 kv-head x 256 head-dim)
+(def ^:private maxpos 2048)
+(def ^:private kvrow 256)
+(def ^:private N (* maxpos kvrow))
+
+(defn- with-filled-session
+  "A session whose :kc0 buffer holds value=index at every element, so any disturbance is visible."
+  [f]
+  (let [s (g/make-session :ze:0)
+        ze (find-ns 'raster.gpu.ze-runtime)
+        buf ((ns-resolve ze 'make-buffer) N :float)]
+    (try
+      (swap! s assoc-in [:buffers :kc0] buf)
+      (let [a (float-array N)] (dotimes [i N] (aset a i (float i))) (g/upload! s :kc0 a))
+      (f s)
+      (finally (g/close-session! s)))))
+
+(defn- region-is-identity? [^floats arr from to]
+  (every? (fn [i] (== (aget arr i) (float i))) (range from to)))
+
+(deftest a-token-prefix-exports-as-one-contiguous-range
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "ranged transfers: prefix export")
+    (with-filled-session
+      (fn [s]
+        (let [tokens 128 n (* tokens kvrow) out (float-array n)]
+          (g/download-range! s :kc0 out {:src-element 0 :elements n})
+          (is (region-is-identity? out 0 n) "the first 128 positions, in order"))))))
+
+(deftest a-ranged-import-touches-only-its-range
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "ranged transfers: import from an off-heap segment")
+    (with-filled-session
+      (fn [s]
+        (let [tokens 128 n (* tokens kvrow)
+              at (* 64 kvrow)                                   ; import at token 64
+              arena (Arena/ofShared)
+              ;; an OFF-HEAP segment with the payload at a non-zero element offset — the mmap case
+              seg (.allocate arena (* 4 (+ n 100)) 64)]
+          (try
+            (dotimes [i n] (.setAtIndex seg ValueLayout/JAVA_FLOAT (+ i 100) (float (- i))))
+            (g/upload-range! s :kc0 seg {:src-element 100 :dst-element at :elements n})
+            (let [back (g/download s :kc0)]
+              (testing "the imported range is correct, from the segment's own offset"
+                (is (every? (fn [i] (== (aget back (+ at i)) (float (- i)))) (range n))))
+              (testing "NOTHING ELSE MOVED — the invariant a clobbering write would violate"
+                (is (region-is-identity? back 0 at) "positions before the import")
+                (is (region-is-identity? back (+ at n) N) "positions after the import")))
+            (finally (.close arena))))))))
+
+(deftest a-jvm-array-and-a-memory-segment-take-the-same-path
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "ranged transfers: array/segment parity")
+    (with-filled-session
+      (fn [s]
+        (let [n (* 8 kvrow)
+              arr (float-array n) _ (dotimes [i n] (aset arr i (float (* 10 i))))
+              seg (MemorySegment/ofArray (aclone arr))
+              via-arr (float-array n) via-seg (float-array n)]
+          (g/upload-range! s :kc0 arr {:dst-element 0 :elements n})
+          (g/download-range! s :kc0 via-arr {:elements n})
+          (g/upload-range! s :kc0 seg {:dst-element 0 :elements n})
+          (g/download-range! s :kc0 via-seg {:elements n})
+          (is (= (vec via-arr) (vec via-seg))))))))
+
+(deftest out-of-range-is-an-error-not-a-clamp
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "ranged transfers: bounds")
+    (with-filled-session
+      (fn [s]
+        (testing "host side too small for the requested range"
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"exceeds the host-side"
+                                (g/download-range! s :kc0 (float-array 16) {:elements 32}))))
+        (testing "range runs past the end of the buffer"
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"exceeds the buffer"
+                                (g/upload-range! s :kc0 (float-array 1024)
+                                                 {:dst-element (- N 10) :elements 1024}))))
+        (testing "negative offsets are refused, not wrapped"
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"negative"
+                                (g/download-range! s :kc0 (float-array 16)
+                                                   {:src-element -1 :elements 8}))))
+        (testing "…and a refused transfer left the buffer untouched"
+          (is (region-is-identity? (g/download s :kc0) 0 N)))))))
+
+(deftest a-segment-source-does-not-materialize-a-jvm-array
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "ranged transfers: zero-copy segment path")
+    (with-filled-session
+      (fn [s]
+        ;; The claim that motivated this API: an mmap'd segment is copied straight into the shared
+        ;; allocation. That was asserted, not measured; this MEASURES it. The threshold is an order
+        ;; of magnitude below the payload, so a float[] materialization (= payload bytes) fails it.
+        (let [n (* 128 kvrow) payload (* 4 n)
+              arena (Arena/ofShared) seg (.allocate arena payload 64)
+              bean (java.lang.management.ManagementFactory/getThreadMXBean)
+              alloc #(.getCurrentThreadAllocatedBytes bean)]
+          (try
+            (dotimes [_ 3] (g/upload-range! s :kc0 seg {:elements n}))      ; warm
+            (let [a0 (alloc) _ (dotimes [_ 20] (g/upload-range! s :kc0 seg {:elements n})) a1 (alloc)
+                  per-call (quot (- a1 a0) 20)]
+              (is (< per-call (quot payload 10))
+                  (str "per-call heap " per-call " B vs payload " payload " B")))
+            (finally (.close arena))))))))

--- a/test/raster/gpu/range_transfer_test.clj
+++ b/test/raster/gpu/range_transfer_test.clj
@@ -119,3 +119,71 @@
               (is (< per-call (quot payload 10))
                   (str "per-call heap " per-call " B vs payload " payload " B")))
             (finally (.close arena))))))))
+
+;; ── batched: the whole KV cache in one call ─────────────────────────────────────────
+(defn- with-kv-session
+  "A session with `layers` kc/vc pairs, each holding value = (layer-tag + index) so a write to the
+   wrong layer is as visible as a write to the wrong position."
+  [layers f]
+  (let [s (g/make-session :ze:0)
+        make (ns-resolve (find-ns 'raster.gpu.ze-runtime) 'make-buffer)]
+    (try
+      (doseq [l (range layers) kind ["kc" "vc"]]
+        (let [k (keyword (str kind l)) tag (float (* 1e6 (+ 1 (* 2 l) (if (= kind "vc") 1 0))))
+              a (float-array N)]
+          (dotimes [i N] (aset a i (+ tag (float i))))
+          (swap! s assoc-in [:buffers k] (make N :float))
+          (g/upload! s k a)))
+      (f s)
+      (finally (g/close-session! s)))))
+
+(deftest a-batch-moves-every-layer-in-one-call
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "batched ranged transfers: whole-cache export/import")
+    (with-kv-session 3
+      (fn [s]
+        (let [tokens 64 n (* tokens kvrow)
+              keys* (for [l (range 3) kind ["kc" "vc"]] (keyword (str kind l)))
+              outs (zipmap keys* (repeatedly #(float-array n)))
+              res (g/download-ranges! s (for [k keys*] [k (get outs k) {:elements n}]))]
+          (is (= 6 (count res)) "one result per entry")
+          (is (= (map #(get outs %) keys*) (seq res))
+              "…and IN ENTRY ORDER — the i-th result is the i-th entry's destination, which is
+               what lets a caller zip results back to layers without re-deriving the mapping")
+          (doseq [[l kind] (for [l (range 3) kind ["kc" "vc"]] [l kind])]
+            (let [k (keyword (str kind l)) tag (* 1e6 (+ 1 (* 2 l) (if (= kind "vc") 1 0)))]
+              (is (every? (fn [i] (== (aget ^floats (get outs k) i) (float (+ tag i)))) (range n))
+                  (str k " carries ITS OWN layer's prefix, not a neighbour's")))))))))
+
+(deftest a-bad-entry-anywhere-leaves-the-whole-cache-untouched
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "batched ranged transfers: all-or-nothing")
+    (with-kv-session 3
+      (fn [s]
+        ;; The failure a batched API newly makes possible: entries 1-5 valid, entry 6 out of range.
+        ;; Without validate-all-first, five layers get overwritten before the throw and the cache
+        ;; is half-restored — indistinguishable from correct until decode diverges.
+        (let [n (* 64 kvrow)
+              zeros (float-array n)
+              entries (concat (for [l (range 3) kind ["kc"]] [(keyword (str kind l)) zeros {:elements n}])
+                              (for [l (range 2)] [(keyword (str "vc" l)) zeros {:elements n}])
+                              [[:vc2 zeros {:dst-element (- N 10) :elements n}]])]   ; the bad one, LAST
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"exceeds the buffer"
+                                (g/upload-ranges! s entries)))
+          (testing "NOT ONE of the five valid earlier entries was written"
+            (doseq [[l kind] (for [l (range 3) kind ["kc" "vc"]] [l kind])]
+              (let [k (keyword (str kind l)) tag (* 1e6 (+ 1 (* 2 l) (if (= kind "vc") 1 0)))
+                    back (g/download s k)]
+                (is (every? (fn [i] (== (aget ^floats back i) (float (+ tag i)))) (range n))
+                    (str k " must be untouched"))))))))))
+
+(deftest an-unknown-key-is-refused-before-anything-moves
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "batched ranged transfers: unknown key")
+    (with-kv-session 1
+      (fn [s]
+        (let [n (* 8 kvrow) zeros (float-array n)]
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"No buffer for key"
+                                (g/upload-ranges! s [[:kc0 zeros {:elements n}]
+                                                     [:kc99 zeros {:elements n}]])))
+          (is (== (aget ^floats (g/download s :kc0) 0) (float 1e6)) ":kc0 untouched"))))))


### PR DESCRIPTION
`upload!`/`download` copy the **whole** buffer. A KV cache is allocated at `maxpos` positions and is position-major, so a continuation of `t` tokens is one contiguous prefix — exporting it should move `t` rows, not `maxpos`. For gemma-270m: 9 MiB vs 72 MiB per 256-token continuation.

```clojure
(gpu/upload-range!   sess :kc0 src {:src-element 0 :dst-element 0 :elements (* tokens kvrow)})
(gpu/download-range! sess :kc0 dst {:src-element 0 :elements (* tokens kvrow)})
```

`src`/`dst` may be a JVM primitive array **or** a `MemorySegment` — an mmap'd file is copied straight into the shared allocation with no JVM array in between. Offsets and length are in **elements** of the buffer's dtype; byte size is never the caller's to get wrong.

## Two invariants, tested on the device and mutation-checked

- **Nothing else moves.** A ranged write that clobbers a neighbouring position looks identical to a correct one until a restored continuation diverges at the wrong token. Every test checks the untouched regions, not just the range. *(Ignoring the dst offset fails 2.)*
- **Out-of-range is an error, never a clamp.** `array->buffer!` clamps to `(min buf src)` bytes — fine for a whole-buffer copy, exactly wrong for a range. *(Clamping instead fails 1.)*

## The zero-copy claim, measured rather than asserted

| | |
|---|---|
| heap per segment upload | **722 B** vs 131,072 B payload |
| heap per `float[]` upload | 9,785 B |
| 128-of-2048 export, whole vs range | 0.497 ms → **0.029 ms** |

The test pins it: a mutant that materializes a `float[]` from the segment fails.

ze: Panama copy into the host-coherent `alloc-shared` segment — no command list. ocl: buffers aren't host-coherent, so the range goes through the staging segment and a `clEnqueueWrite/ReadBuffer` at the byte offset — only the range crosses the bus.

Unblocks the GPU slice of pretrained-rstr's KV-continuation work. Deliberately **not** foreign `DeviceArray` rebinding or buffer exposure — north-star §2.3, far larger than this needs.

## Validation

**Suite: 2064 tests / 32845 assertions.** Only failures are the pre-existing `autotune-finds-splitk-optimum` device-timing flake (fails identically on `origin/main`, flagged in #95).

Two pre-existing silent skips surfaced by reading the skip-path summary, **not introduced here** (present in the #95 run), filed separately: `gpu_correctness_test.clj:186` reports a scan-kernel NPE (`"x" is null`) as a `[SKIP]`; and `gate-honesty-probe` reports "no Level-Zero device" while the suite header says `probe=available (1 device)`.

---

## Addendum: batched variant (second commit on this PR)

`upload-ranges!` / `download-ranges!` — many `[key host spec]` entries in one call, for the 36 per-layer buffers a gemma-270m continuation spans. This is the shape LMCache's `batched_to_gpu`/`batched_from_gpu` has; ours is a loop over validated plans rather than a fused gather kernel, because a position-major cache needs no gather (the structural difference from vLLM's paged cache — an advantage until we page).

**The property a batch newly makes possible, and the one this guards: partial state.** A bad spec in the 30th entry would leave 29 layers written and the cache half-restored. Each runtime's transfer is split into `plan-range` (validate, return the byte plan) and `execute-range!`, and the batch validates **every** entry before executing **any**. Mutation-checked: interleaving plan and execute fails 6 assertions.

Results come back in entry order. That was documented but ungated — a reversed return passed the first test; now it fails 1.

A failure *during* execution (a device fault) is still partial; that's a different class and not promised.

The single-range fns are now thin wrappers over plan+execute; the original 5 tests pass unchanged. 8 tests / 27 assertions on the device.