### PR TITLE
Phase 1a/1b: opencl-pass consumes the SegOps segop-lower computed — the boundary stops being nominal

### DIFF
--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -98,25 +98,50 @@
 
       :else (:ok r))))
 
+(def ^:dynamic *bound-segops*
+  "The SegOp records `segop-lower` attached to the binding CURRENTLY being transformed (its
+   `::segops` metadata), or nil in body position / when the pass did not run.
+
+   This is the seam that makes the SegOp boundary REAL instead of nominal. `segop-lower` lowered
+   every par form with the real target device and stored the result on the binder symbol — and
+   nothing read it: this pass re-lowered each form from scratch with `:ze:0` hardcoded, ignoring
+   both the stored result and its own `device-id` (north-star §2.1, ledger #6/#11). Now the
+   stored SegOp is consumed; re-lowering is the fallback and is COUNTED, so a form that bypasses
+   the pass's output shows up in the stats instead of silently taking a second path."
+  nil)
+
+(defn- take-bound-segop
+  "The precomputed SegOp of `kind` for the current binding, if segop-lower produced one."
+  [stats kind pred]
+  (when-let [so (first (filter pred *bound-segops*))]
+    (swap! stats update :segop-reused (fnil inc 0))
+    so))
+
 (defn- par->segmap
-  "Compute SegMap on-the-fly from a par/map! form. nil (with a recorded decline) ⇒ legacy codegen."
-  [stats form dtype]
-  (segop-attempt stats :segmap form dtype
-                 #(let [par-info (par/extract-par-map-info form)
-                        soac (raster.compiler.ir.soac/par-form->soac
-                              (:out par-info) form (swap! segop-id-counter inc))]
-                    (first (raster.compiler.passes.parallel.soac-lower/lower-soac
-                            soac :ze:0 :dtype (or dtype :double))))))
+  "The SegMap for a par/map! form: the one `segop-lower` already computed for this binding when
+   available; otherwise re-lowered here with the REAL `device-id` (it was `:ze:0` hardcoded) and
+   counted as `:segop-relowered`. nil (with a recorded decline) ⇒ legacy codegen."
+  [stats form dtype device-id]
+  (or (take-bound-segop stats :segmap #(instance? raster.compiler.ir.segop.SegMap %))
+      (do (swap! stats update :segop-relowered (fnil inc 0))
+          (segop-attempt stats :segmap form dtype
+                         #(let [par-info (par/extract-par-map-info form)
+                                soac (raster.compiler.ir.soac/par-form->soac
+                                      (:out par-info) form (swap! segop-id-counter inc))]
+                            (first (raster.compiler.passes.parallel.soac-lower/lower-soac
+                                    soac (or device-id :ze:0) :dtype (or dtype :double))))))))
 
 (defn- par->segred
-  "Compute SegRed on-the-fly from a par/reduce form. nil (with a recorded decline) ⇒ legacy codegen."
-  [stats form dtype]
-  (segop-attempt stats :segred form dtype
-                 #(let [sym (gensym "red_")
-                        soac (raster.compiler.ir.soac/par-form->soac
-                              sym form (swap! segop-id-counter inc))]
-                    (first (raster.compiler.passes.parallel.soac-lower/lower-soac
-                            soac :ze:0 :dtype (or dtype :double))))))
+  "The SegRed for a par/reduce form; same consume-then-relower contract as `par->segmap`."
+  [stats form dtype device-id]
+  (or (take-bound-segop stats :segred #(instance? raster.compiler.ir.segop.SegRed %))
+      (do (swap! stats update :segop-relowered (fnil inc 0))
+          (segop-attempt stats :segred form dtype
+                         #(let [sym (gensym "red_")
+                                soac (raster.compiler.ir.soac/par-form->soac
+                                      sym form (swap! segop-id-counter inc))]
+                            (first (raster.compiler.passes.parallel.soac-lower/lower-soac
+                                    soac (or device-id :ze:0) :dtype (or dtype :double))))))))
 
 (defn- maybe-compile-spirv
   "Optionally compile OpenCL C to SPIR-V."
@@ -182,7 +207,7 @@
               (if (and (number? bound) (< bound min-elements))
                 (do (swap! stats update :fallback inc)
                     (par/expand-par-map! form))
-                (if-let [segmap (par->segmap stats form dtype)]
+                (if-let [segmap (par->segmap stats form dtype device-id)]
                   (let [kernel (segop-cl/generate-segmap-kernel segmap out
                                                                 :dtype dtype :scalar-types top-scalar-types
                                                                 :array-types (merge top-array-types (:array-types (meta form))))]
@@ -272,7 +297,7 @@
             ;; instead of round-tripping a host scalar. Emitted by the reduce-fusion pass.
             (par/par-reduce-into-form? form)
             (let [{:keys [out-buf reduce-form bound]} (par/extract-par-reduce-into-info form)]
-              (if-let [segred (par->segred stats reduce-form dtype)]
+              (if-let [segred (par->segred stats reduce-form dtype device-id)]
                 (let [kernel (segop-cl/generate-segred-kernel segred nil :dtype dtype)]
                   (if kernel
                     (let [k (register-kernel! kernel :ze-reduces)]
@@ -297,7 +322,7 @@
               (if (and (number? bound) (< bound min-elements))
                 (do (swap! stats update :fallback inc)
                     (par/expand-par-reduce form))
-                (if-let [segred (par->segred stats form dtype)]
+                (if-let [segred (par->segred stats form dtype device-id)]
                   (let [kernel (segop-cl/generate-segred-kernel segred nil :dtype dtype)]
                     (if kernel
                       (let [k (register-kernel! kernel :ze-reduces)]
@@ -465,7 +490,13 @@
             (and (seq? form) (contains? #{'let 'let*} (first form)))
             (let [[let-sym bindings & body-exprs] form
                   pairs (partition 2 bindings)
-                  new-bindings (vec (mapcat (fn [[sym expr]] [sym (transform expr)]) pairs))
+                  ;; the binder symbol carries what segop-lower computed for this init — make it
+                  ;; visible to the par branches so they consume it instead of re-lowering
+                  new-bindings (vec (mapcat (fn [[sym expr]]
+                                              [sym (binding [*bound-segops*
+                                                             (:raster.compiler.passes.parallel.segop-lower-pass/segops (meta sym))]
+                                                     (transform expr))])
+                                            pairs))
                   new-body (mapv transform body-exprs)]
               (with-meta (apply list let-sym new-bindings new-body) (meta form)))
 

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -500,6 +500,13 @@
                   new-body (mapv transform body-exprs)]
               (with-meta (apply list let-sym new-bindings new-body) (meta form)))
 
+            ;; a body-position par form: segop-lower wraps it in (do …) carrying ::body-segops
+            ;; — consume that exactly as a binding's ::segops, so body forms stop re-lowering
+            (and (seq? form) (= 'do (first form))
+                 (:raster.compiler.passes.parallel.segop-lower-pass/body-segops (meta form)))
+            (binding [*bound-segops* (:raster.compiler.passes.parallel.segop-lower-pass/body-segops (meta form))]
+              (with-meta (apply list 'do (mapv transform (rest form))) (meta form)))
+
             (and (seq? form) (= 'do (first form)))
             (with-meta (apply list 'do (mapv transform (rest form))) (meta form))
 

--- a/test/raster/compiler/segop_consumption_test.clj
+++ b/test/raster/compiler/segop_consumption_test.clj
@@ -57,3 +57,12 @@
                     (fn [soac device-id & opts] (swap! calls conj device-id) (apply orig soac :ze:0 opts))]
         (op/opencl-pass map-form :device-id :ze:1 :dtype :double :min-elements 0))
       (is (= [:ze:1] @calls) (str "lower-soac was called with " @calls ", not the pass's device-id")))))
+
+(deftest a-body-position-form-is-consumed-too
+  (testing "segop-lower wraps a body-position par form in (do …) carrying ::body-segops; that
+            must be consumed exactly like a binding's ::segops"
+    (let [form '(let* [n 8192] (raster.par/map! O i n nil (clojure.core/* (clojure.core/aget X i) 2.0)))
+          st (:stats (run (lowered form)))]
+      (is (= 1 (:ze-maps st)))
+      (is (= 1 (:segop-reused st)) "consumed from ::body-segops")
+      (is (nil? (:segop-relowered st))))))

--- a/test/raster/compiler/segop_consumption_test.clj
+++ b/test/raster/compiler/segop_consumption_test.clj
@@ -1,0 +1,59 @@
+(ns raster.compiler.segop-consumption-test
+  "THE SEGOP BOUNDARY IS REAL: opencl-pass CONSUMES what segop-lower computed. Device-free.
+
+   `segop-lower` lowered every par form with the real target device and attached the SegOp to
+   the binder symbol as `::segops`. Nothing read it (north-star §2.1: 'the pass arrows are nominal
+   at the most important boundary'). `opencl-pass` re-lowered each form from scratch with `:ze:0`
+   HARDCODED — ignoring both the stored result and its own `device-id`. Two lowerings of one form,
+   one of them on the wrong device, and no way to tell which a kernel came from.
+
+   Now the stored SegOp is consumed; re-lowering is the fallback, with the real device-id, and
+   both paths are COUNTED (`:segop-reused` / `:segop-relowered`) so a form that bypasses the
+   pass's output shows up in the stats instead of silently taking a second path."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [raster.compiler.passes.parallel.segop-lower-pass :as slp]
+            [raster.compiler.backend.gpu.opencl-pass :as op]))
+
+(def ^:private map-form
+  '(let* [o (raster.par/map! O i 8192 nil (clojure.core/* (clojure.core/aget X i) 2.0))] o))
+(def ^:private reduce-form
+  '(let* [r (raster.par/reduce acc 0.0 i 8192 (clojure.core/+ acc (clojure.core/aget X i)))] r))
+
+(defn- lowered [form] (:form (slp/segop-lower-pass form {:target-device :ze:0 :dtype :double})))
+(defn- run [form] (op/opencl-pass form :device-id :ze:0 :dtype :double :min-elements 0))
+(defn- norm [src] (str/replace (str src) #"_\d{3,}" "_N"))
+
+(deftest a-lowered-binding-is-consumed-not-relowered
+  (doseq [[label form key] [["par/map!" map-form :ze-maps] ["par/reduce" reduce-form :ze-reduces]]]
+    (testing label
+      (let [st (:stats (run (lowered form)))]
+        (is (= 1 (get st key)) "one kernel")
+        (is (= 1 (:segop-reused st)) "…from the SegOp segop-lower attached")
+        (is (nil? (:segop-relowered st)) "…and NOT re-lowered")))))
+
+(deftest an-unlowered-form-is-relowered-and-says-so
+  (testing "door C hands opencl-pass a walked body with no segop-lower pass run; the fallback
+            must still work — and must be VISIBLE, not a silent second path"
+    (doseq [[label form] [["par/map!" map-form] ["par/reduce" reduce-form]]]
+      (testing label
+        (let [st (:stats (run form))]
+          (is (= 1 (:segop-relowered st)))
+          (is (nil? (:segop-reused st))))))))
+
+(deftest consuming-is-a-refactor-the-kernel-is-identical
+  (testing "same kernel source whether the SegOp was consumed or re-lowered — this is the
+            assertion that makes the switch safe"
+    (doseq [form [map-form reduce-form]]
+      (is (= (norm (:source (first (:kernels (run (lowered form))))))
+             (norm (:source (first (:kernels (run form))))))))))
+
+(deftest the-fallback-uses-the-real-device-id
+  (testing "re-lowering used `:ze:0` hardcoded. A registered non-:ze:0 target must reach
+            lower-soac — observable because compute-launch-params asks the descriptor for THAT id"
+    (let [calls (atom [])
+          orig raster.compiler.passes.parallel.soac-lower/lower-soac]
+      (with-redefs [raster.compiler.passes.parallel.soac-lower/lower-soac
+                    (fn [soac device-id & opts] (swap! calls conj device-id) (apply orig soac :ze:0 opts))]
+        (op/opencl-pass map-form :device-id :ze:1 :dtype :double :min-elements 0))
+      (is (= [:ze:1] @calls) (str "lower-soac was called with " @calls ", not the pass's device-id")))))


### PR DESCRIPTION
`segop-lower` lowered every par form with the real target device and attached the result to the binder symbol as `::segops`. **Nothing read it.** `opencl-pass` re-lowered each form from scratch with `:ze:0` hardcoded — ignoring both the stored SegOp and its own `device-id`. Two lowerings of one form, one on the wrong device, no way to tell which a kernel came from. North-star §2.1 names this exactly: *"the pass arrows are nominal at the most important boundary."* Ledger #6, #11.

## What changes

- The `let*` walk binds each symbol's `::segops` around transforming its init; body-position `(do …)` wrappers bind `::body-segops` the same way. The `par/map!` and `par/reduce` branches **consume** it.
- Re-lowering is the fallback — with the pass's **real `device-id`** — and both paths are **counted** (`:segop-reused` / `:segop-relowered`), so a form that bypasses the pass's output is visible in the stats instead of silently taking a second path.

It is a refactor: kernel source is byte-identical whether consumed or re-lowered (asserted). The "two lowerings differ in `:space`" scare turned out to be only the gensym'd `flat-idx`.

## Validation

`segop_consumption_test`: consumed after `segop-lower` (reused 1, relowered nil) for map!, reduce and body-position; re-lowered without it (door C's shape); `:ze:1` reaches `lower-soac` via `with-redefs`. Mutation-checked: disabling consumption fails 4, re-hardcoding the device fails 1, removing the `do`-branch consumption fails 2. Existing `opencl-pass` suites green: segop-boundary 22, gpu-correctness 51, par-opencl 63, par-test 122.

## What this does NOT claim

Increment 1's gate says map, reduce, scan **and one contraction** travel the same path on **CPU and GPU**. This lands map/reduce on GPU. Found while scoping the rest, recorded as ledger #35/#36: `par/scan` has no SegOp path at all (`SegScan` exists, is never produced); and `par/contract` is **declined** by `segop-lower` — it isn't a SOAC node. A Codex cross-check settled the shape for that: the existing `Dot` record has zero production constructors (only a unit test) and is excluded from lowering, fusion and reconstruction — a dead representation. The path is a new `SoacContract` carrying `contraction-facts` as its sole payload, lowered to a `SegContract` that both backends consume. That is the next PR, not this one.