### PR TITLE
Phase 1c: par/contract is a first-class SOAC node — SoacContract carrying its facts, SegContract consumed by the backend

### DIFF
--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -240,8 +240,15 @@
                   ;; pass the REAL descriptor: route-contraction fed `(or desc {})` into
                   ;; derive-gemm-tile, so the "hardware-derived" tile was derived from an empty map
                   ;; — Arc constants on every device. device-id is already in scope here.
+                  ;; CONSUME the SegContract segop-lower recorded (its facts were derived and
+                  ;; verified once, at the boundary) — the same take-bound-segop seam map/reduce
+                  ;; use. Without one (door C, no pass run) route from the form and count it.
+                  bound-sc (take-bound-segop stats :segcontract
+                                             #(instance? raster.compiler.ir.segop.SegContract %))
+                  _ (when-not bound-sc (swap! stats update :segop-relowered (fnil inc 0)))
                   r (croute/route-contraction
                      form :dtype dtype
+                     :facts (:facts bound-sc)
                      :desc (try ((requiring-resolve 'raster.compiler.core.hardware/descriptor-for)
                                  device-id)
                                 (catch Throwable _ nil)))

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -98,25 +98,50 @@
 
       :else (:ok r))))
 
+(def ^:dynamic *bound-segops*
+  "The SegOp records `segop-lower` attached to the binding CURRENTLY being transformed (its
+   `::segops` metadata), or nil in body position / when the pass did not run.
+
+   This is the seam that makes the SegOp boundary REAL instead of nominal. `segop-lower` lowered
+   every par form with the real target device and stored the result on the binder symbol — and
+   nothing read it: this pass re-lowered each form from scratch with `:ze:0` hardcoded, ignoring
+   both the stored result and its own `device-id` (north-star §2.1, ledger #6/#11). Now the
+   stored SegOp is consumed; re-lowering is the fallback and is COUNTED, so a form that bypasses
+   the pass's output shows up in the stats instead of silently taking a second path."
+  nil)
+
+(defn- take-bound-segop
+  "The precomputed SegOp of `kind` for the current binding, if segop-lower produced one."
+  [stats kind pred]
+  (when-let [so (first (filter pred *bound-segops*))]
+    (swap! stats update :segop-reused (fnil inc 0))
+    so))
+
 (defn- par->segmap
-  "Compute SegMap on-the-fly from a par/map! form. nil (with a recorded decline) ⇒ legacy codegen."
-  [stats form dtype]
-  (segop-attempt stats :segmap form dtype
-                 #(let [par-info (par/extract-par-map-info form)
-                        soac (raster.compiler.ir.soac/par-form->soac
-                              (:out par-info) form (swap! segop-id-counter inc))]
-                    (first (raster.compiler.passes.parallel.soac-lower/lower-soac
-                            soac :ze:0 :dtype (or dtype :double))))))
+  "The SegMap for a par/map! form: the one `segop-lower` already computed for this binding when
+   available; otherwise re-lowered here with the REAL `device-id` (it was `:ze:0` hardcoded) and
+   counted as `:segop-relowered`. nil (with a recorded decline) ⇒ legacy codegen."
+  [stats form dtype device-id]
+  (or (take-bound-segop stats :segmap #(instance? raster.compiler.ir.segop.SegMap %))
+      (do (swap! stats update :segop-relowered (fnil inc 0))
+          (segop-attempt stats :segmap form dtype
+                         #(let [par-info (par/extract-par-map-info form)
+                                soac (raster.compiler.ir.soac/par-form->soac
+                                      (:out par-info) form (swap! segop-id-counter inc))]
+                            (first (raster.compiler.passes.parallel.soac-lower/lower-soac
+                                    soac (or device-id :ze:0) :dtype (or dtype :double))))))))
 
 (defn- par->segred
-  "Compute SegRed on-the-fly from a par/reduce form. nil (with a recorded decline) ⇒ legacy codegen."
-  [stats form dtype]
-  (segop-attempt stats :segred form dtype
-                 #(let [sym (gensym "red_")
-                        soac (raster.compiler.ir.soac/par-form->soac
-                              sym form (swap! segop-id-counter inc))]
-                    (first (raster.compiler.passes.parallel.soac-lower/lower-soac
-                            soac :ze:0 :dtype (or dtype :double))))))
+  "The SegRed for a par/reduce form; same consume-then-relower contract as `par->segmap`."
+  [stats form dtype device-id]
+  (or (take-bound-segop stats :segred #(instance? raster.compiler.ir.segop.SegRed %))
+      (do (swap! stats update :segop-relowered (fnil inc 0))
+          (segop-attempt stats :segred form dtype
+                         #(let [sym (gensym "red_")
+                                soac (raster.compiler.ir.soac/par-form->soac
+                                      sym form (swap! segop-id-counter inc))]
+                            (first (raster.compiler.passes.parallel.soac-lower/lower-soac
+                                    soac (or device-id :ze:0) :dtype (or dtype :double))))))))
 
 (defn- maybe-compile-spirv
   "Optionally compile OpenCL C to SPIR-V."
@@ -182,7 +207,7 @@
               (if (and (number? bound) (< bound min-elements))
                 (do (swap! stats update :fallback inc)
                     (par/expand-par-map! form))
-                (if-let [segmap (par->segmap stats form dtype)]
+                (if-let [segmap (par->segmap stats form dtype device-id)]
                   (let [kernel (segop-cl/generate-segmap-kernel segmap out
                                                                 :dtype dtype :scalar-types top-scalar-types
                                                                 :array-types (merge top-array-types (:array-types (meta form))))]
@@ -272,7 +297,7 @@
             ;; instead of round-tripping a host scalar. Emitted by the reduce-fusion pass.
             (par/par-reduce-into-form? form)
             (let [{:keys [out-buf reduce-form bound]} (par/extract-par-reduce-into-info form)]
-              (if-let [segred (par->segred stats reduce-form dtype)]
+              (if-let [segred (par->segred stats reduce-form dtype device-id)]
                 (let [kernel (segop-cl/generate-segred-kernel segred nil :dtype dtype)]
                   (if kernel
                     (let [k (register-kernel! kernel :ze-reduces)]
@@ -297,7 +322,7 @@
               (if (and (number? bound) (< bound min-elements))
                 (do (swap! stats update :fallback inc)
                     (par/expand-par-reduce form))
-                (if-let [segred (par->segred stats form dtype)]
+                (if-let [segred (par->segred stats form dtype device-id)]
                   (let [kernel (segop-cl/generate-segred-kernel segred nil :dtype dtype)]
                     (if kernel
                       (let [k (register-kernel! kernel :ze-reduces)]
@@ -465,7 +490,13 @@
             (and (seq? form) (contains? #{'let 'let*} (first form)))
             (let [[let-sym bindings & body-exprs] form
                   pairs (partition 2 bindings)
-                  new-bindings (vec (mapcat (fn [[sym expr]] [sym (transform expr)]) pairs))
+                  ;; the binder symbol carries what segop-lower computed for this init — make it
+                  ;; visible to the par branches so they consume it instead of re-lowering
+                  new-bindings (vec (mapcat (fn [[sym expr]]
+                                              [sym (binding [*bound-segops*
+                                                             (:raster.compiler.passes.parallel.segop-lower-pass/segops (meta sym))]
+                                                     (transform expr))])
+                                            pairs))
                   new-body (mapv transform body-exprs)]
               (with-meta (apply list let-sym new-bindings new-body) (meta form)))
 

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -500,6 +500,13 @@
                   new-body (mapv transform body-exprs)]
               (with-meta (apply list let-sym new-bindings new-body) (meta form)))
 
+            ;; a body-position par form: segop-lower wraps it in (do …) carrying ::body-segops
+            ;; — consume that exactly as a binding's ::segops, so body forms stop re-lowering
+            (and (seq? form) (= 'do (first form))
+                 (:raster.compiler.passes.parallel.segop-lower-pass/body-segops (meta form)))
+            (binding [*bound-segops* (:raster.compiler.passes.parallel.segop-lower-pass/body-segops (meta form))]
+              (with-meta (apply list 'do (mapv transform (rest form))) (meta form)))
+
             (and (seq? form) (= 'do (first form)))
             (with-meta (apply list 'do (mapv transform (rest form))) (meta form))
 

--- a/src/raster/compiler/ir/segop.clj
+++ b/src/raster/compiler/ir/segop.clj
@@ -62,6 +62,17 @@
             phase       ;; :single | :block-local | :cross-block
             dtype])      ;; :double | :float — element type
 
+(defrecord SegContract
+           [id          ;; int
+            facts       ;; contraction-facts — the recorded semantic plan (ir/contraction_facts)
+            dtype       ;; element dtype the contraction was lowered for
+            device-id]) ;; the target it was lowered for — routing reads its descriptor
+;; The SegOp for a contraction. Deliberately carries the facts and NOTHING derived from them:
+;; which leaf (dpas/regtiled/naive), its tile and launch geometry are TARGET decisions made by
+;; contract-route from these facts + the device descriptor at emission time — putting them here
+;; would mix target-specific emission into semantic lowering. What this node guarantees is that
+;; the backend receives the SAME facts segop-lower verified, instead of re-parsing the form.
+
 (defrecord SegScan
            [id          ;; int
             space       ;; SegSpace

--- a/src/raster/compiler/ir/soac.clj
+++ b/src/raster/compiler/ir/soac.clj
@@ -90,6 +90,17 @@
 ;; soac-outputs (a GEMM writing C with no edge → reorderable consumer). `epilogue` is the
 ;; fused same-position elementwise consumer lambda (bias/act/residual), or nil; when set,
 ;; the emitter splices it into the validated store slot (emit-gemm-tiled :epilogue).
+(defrecord SoacContract
+           [id           ;; int
+            sym          ;; symbol (binding) — the contraction's output
+            facts])      ;; contraction-facts — THE sole semantic payload (ir/contraction_facts)
+;; A contraction as a first-class SOAC node. `facts` is the whole payload: free/contract axes,
+;; operands with VERIFIED axis-maps, :decode, :combine/:init, dtype pair, :stages, :epilogue,
+;; :roles, :dims. Nothing is copied out of it onto the record (north-star §10: one registry);
+;; graph/scheduling projections are DERIVED (`soac-inputs`/`soac-outputs` below). `Dot` is the
+;; representation this replaces — it had one constructor (a unit test), was excluded from lowering,
+;; reconstruction and fusion, and could not carry most of the facts.
+
 (defrecord Dot
            [id           ;; int
             sym          ;; symbol (binding)
@@ -214,8 +225,15 @@
 (defn par-form->soac
   "Convert a raster.par/* S-expression to a SOAC record.
   Returns a SoacMap, SoacReduce, SoacScan, SoacStencil, or nil."
-  [sym expr id]
+  [sym expr id & {:keys [dtype]}]
   (cond
+    ;; par/contract → SoacContract. Was DECLINED here (:no-lowering-rule) — the one par form that
+    ;; was not a SOAC node, so it bypassed the segop boundary through a backend side branch. The
+    ;; facts are derived ONCE, here; every consumer downstream reads them instead of re-parsing.
+    (and (seq? expr) (= 'raster.par/contract (first expr)))
+    (->SoacContract id sym ((requiring-resolve 'raster.compiler.ir.contraction-facts/contraction-facts)
+                            expr :dtype (or dtype :double)))
+
     ;; Pure par/map (no output buffer) — must check before par-map-form?
     (par/par-map-pure-form? expr)
     (let [info (par/extract-par-map-pure-info expr)
@@ -315,6 +333,12 @@
   [soac]
   (stamp-elem-type
    (condp instance? soac
+     ;; a contraction reconstructs to its ORIGINAL surface form — the facts keep it for exactly
+     ;; this dialect boundary (the CPU path round-trips SOAC nodes back to par forms after
+     ;; fusion; before contract was a node it was never round-tripped, so no arm existed)
+     SoacContract
+     (:form (:facts soac))
+
      SoacMap
      (cond
        ;; In-place single-aset void map: reconstruct the imperative write so codegen
@@ -459,24 +483,33 @@
    A Dot is a contraction with its own emit path, so the map/reduce lowering must skip it."
   [node]
   (and (not (instance? ScalarBinding node))
-       (not (instance? Dot node))))
+       (not (instance? Dot node))
+       ;; a contraction has its own lowering (SegContract) and must NOT enter the generic
+       ;; map/reduce/scan lowering or lambda fusion, whose consumers assume idx/lambda/1-D bound
+       (not (instance? SoacContract node))))
+
+(defn contract? [node] (instance? SoacContract node))
 
 (defn soac-inputs
   "Get the set of input array symbols for a SOAC node (or a Dot)."
   [node]
-  (when (or (soac? node) (dot? node)) (:inputs node)))
+  (if (instance? SoacContract node)
+    (set (map :sym (:operands (:facts node))))
+  (when (or (soac? node) (dot? node)) (:inputs node))))
 
 (defn soac-outputs
   "Get the set of output symbols for a SOAC node (or a Dot — its written C, so the dependency graph
    gets a producer edge for the contraction by construction, closing the documented leak)."
   [node]
+  (if (instance? SoacContract node)
+    #{(:out (:facts node))}
   (cond
     (instance? SoacMap node)     (:outputs node)
     (instance? SoacReduce node)  #{(:output node)}
     (instance? SoacScan node)    (:outputs node)
     (instance? SoacStencil node) (:outputs node)
     (instance? Dot node)         (:outputs node)
-    :else nil))
+    :else nil)))
 
 (defn soac-bound
   "Get the iteration bound expression for a SOAC node."

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -179,7 +179,7 @@
    anything else, or a gate rejection, falls back to the register-tiled portable kernel).
    int8 needs no decode descriptor: a scale is an ordinary :epilogue and a zero-point an ordinary
    per-operand :decode, both carried on the form like any other contraction data."
-  [contract-form & {:keys [dtype prefer-peak? desc tile epilogue stages operands]
+  [contract-form & {:keys [dtype prefer-peak? desc tile epilogue stages operands facts]
                     :or {dtype :half prefer-peak? false}}]
   (let [out-sym (second contract-form)
         free-axes (nth contract-form 2)
@@ -219,7 +219,7 @@
       (let [;; The staged emitter hardwires `+=` at every level, and a lift's linearity argument
             ;; assumes `+`. A form carrying :combine max routed here and was SILENTLY SUMMED —
             ;; contraction-facts surfaces :combine and nothing read it. Refuse rather than ignore.
-            _ (let [cmb (:combine (cf/contraction-facts contract-form :dtype dtype))]
+            _ (let [cmb (:combine (or facts (cf/contraction-facts contract-form :dtype dtype)))]
                 (when-not (contains? '#{+ clojure.core/+ raster.numeric/+} cmb)
                   (throw (ex-info (str "staged contraction: only `+` combine is supported (got "
                                        cmb ") — every accumulator level uses += and a lift's "
@@ -233,7 +233,7 @@
                   ;; the axes the FORM declared, read off FACTS — a single derivation whose only
                   ;; input is the form, so there is no separately-computed value to pass
                   ;; inconsistently (which is what made the span rule unfireable)
-                  :contract-axes (:contract-axes (cf/contraction-facts contract-form :dtype dtype))
+                  :contract-axes (:contract-axes (or facts (cf/contraction-facts contract-form :dtype dtype)))
                   :body (nth contract-form 4)
                   :inputs (vec (sort-by name (contract-operand-arrays (nth contract-form 4))))
                   :operands operands

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -65,7 +65,7 @@
           ;; capture value-or-exception in one call: the alternative (catch a sentinel, then call
           ;; again to get the exception) re-runs a side-effecting conversion
           attempt (fn [f] (try {:ok (f)} (catch Exception e {:err e})))
-          soac (attempt #(soac/par-form->soac sym form (swap! id-counter inc)))]
+          soac (attempt #(soac/par-form->soac sym form (swap! id-counter inc) :dtype (or dtype :double)))]
       (cond
         (:err soac) (decline :soac (:err soac))
 

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -242,6 +242,10 @@
         (throw (ex-info "Complex Screma not yet supported for lowering" {:soac soac})))
 
       ;; Direct SOAC dispatch
+      ;; a contraction: record the facts for this target; the backend routes from them
+      (instance? raster.compiler.ir.soac.SoacContract soac)
+      [(segop/->SegContract (:id soac) (:facts soac) dtype device-id)]
+
       (instance? raster.compiler.ir.soac.SoacMap soac)
       (lower-map soac device-id :dtype dtype)
 
@@ -260,7 +264,7 @@
   [nodes-map device-id & {:keys [dtype] :or {dtype :double}}]
   (reduce-kv
    (fn [acc id node]
-     (if (soac/soac? node)
+     (if (or (soac/soac? node) (soac/contract? node))
        (assoc acc id (lower-soac node device-id :dtype dtype))
        acc))
    {} nodes-map))

--- a/test/raster/compiler/contract_soac_node_test.clj
+++ b/test/raster/compiler/contract_soac_node_test.clj
@@ -1,0 +1,79 @@
+(ns raster.compiler.contract-soac-node-test
+  "PAR/CONTRACT IS A FIRST-CLASS SOAC NODE. Device-free.
+
+   It was the one par form that was NOT a node: `par-form->soac` returned nil, `segop-lower`
+   DECLINED it (`:no-lowering-rule`), and `opencl-pass` compiled it through a side branch that
+   re-parsed the surface form — calling `contraction-facts` three separate times. Increment 1's
+   gate (north-star §8) names 'one contraction' travelling the same recorded path as map/reduce.
+
+   The node carries `contraction-facts` as its SOLE payload (§10: no second registry). Everything
+   downstream reads the facts; nothing re-derives them. `Dot` — one constructor, a unit test; excluded
+   from lowering, fusion and reconstruction — is the dead representation this replaces.
+
+   Two properties a GPU-only check cannot see, both pinned here: the node must stay OUT of the
+   generic map/reduce lowering and lambda fusion (`soac?`), whose consumers assume idx/lambda/1-D
+   bound; and it must reconstruct to its exact surface form at the dialect boundary, because the
+   CPU path round-trips SOAC nodes back to par forms after fusion — the first draft broke
+   `compile-aot` of every contraction with 'Cannot convert non-SOAC to par form'."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [raster.compiler.ir.soac :as soac]
+            [raster.compiler.passes.parallel.segop-lower-pass :as slp]
+            [raster.compiler.backend.gpu.opencl-pass :as op]
+            [raster.compiler.pipeline :as pl]
+            [raster.linalg.contract]))
+
+(def ^:private cform
+  '(raster.par/contract C [[i 128] [j 128]] [[l 128]]
+     (raster.numeric/* (clojure.core/aget A (clojure.core/+ (clojure.core/* i 128) l))
+                       (clojure.core/aget B (clojure.core/+ (clojure.core/* l 128) j)))))
+(def ^:private bound (list 'let* ['c cform] 'c))
+
+(deftest a-contraction-is-a-soac-node-carrying-its-facts
+  (let [n (soac/par-form->soac 'c cform 1 :dtype :double)]
+    (is (soac/contract? n))
+    (testing "facts are the payload, derived once"
+      (is (= '[[i 128] [j 128]] (:free-axes (:facts n))))
+      (is (= '[[l 128]] (:contract-axes (:facts n))))
+      (is (= '[A B] (mapv :sym (:operands (:facts n))))))
+    (testing "graph projections derive from the facts"
+      (is (= '#{A B} (soac/soac-inputs n)))
+      (is (= '#{C} (soac/soac-outputs n))))
+    (testing "it is NOT a generic SOAC — generic lowering and lambda fusion must skip it"
+      (is (not (soac/soac? n))))))
+
+(deftest the-node-reconstructs-to-its-exact-surface-form
+  (testing "the CPU path round-trips nodes back to par forms after fusion; this arm did not exist
+            and broke compile-aot of every contraction"
+    (is (= cform (soac/soac->par-form (soac/par-form->soac 'c cform 1 :dtype :double))))))
+
+(deftest segop-lower-records-a-segcontract-instead-of-declining
+  (let [r (slp/segop-lower-pass bound {:target-device :ze:0 :dtype :double})
+        so (slp/get-segops (first (second (:form r))))]
+    (is (= 1 (:segops-lowered (:stats r))))
+    (is (empty? (:segops-declined (:stats r))) "was {:reason :no-lowering-rule}")
+    (is (instance? raster.compiler.ir.segop.SegContract (first so)))
+    (is (= :double (:dtype (first so))))
+    (is (= :ze:0 (:device-id (first so))))))
+
+(deftest opencl-pass-consumes-the-segcontract
+  (let [run (fn [f] (op/opencl-pass f :device-id :ze:0 :dtype :double :min-elements 0))
+        norm #(str/replace (str %) #"_\d{3,}" "_N")]
+    (testing "consumed after segop-lower — reused, not re-lowered — routing unchanged"
+      (let [r (run (:form (slp/segop-lower-pass bound {:target-device :ze:0 :dtype :double})))]
+        (is (= 1 (:segop-reused (:stats r))))
+        (is (nil? (:segop-relowered (:stats r))))
+        (is (= :regtiled (:strategy (first (:kernels r)))))))
+    (testing "without segop-lower (door C): re-lowered and COUNTED"
+      (is (= 1 (:segop-relowered (:stats (run bound))))))
+    (testing "it is a refactor: identical kernel source both ways"
+      (is (= (norm (:source (first (:kernels (run (:form (slp/segop-lower-pass bound {:target-device :ze:0 :dtype :double})))))))
+             (norm (:source (first (:kernels (run bound))))))))))
+
+(deftest the-cpu-path-still-compiles-and-is-numerically-right
+  (testing "the production deftm through compile-aot on the JVM, against a scalar oracle"
+    (let [f (pl/compile-aot #'raster.linalg.contract/contract-mm)
+          A (double-array (range 16)) B (double-array (range 16))
+          ref (double-array (for [i (range 4) j (range 4)]
+                              (reduce + (for [l (range 4)] (* (aget A (+ (* i 4) l)) (aget B (+ (* l 4) j)))))))]
+      (is (java.util.Arrays/equals ^doubles (f A B 4 4 4) ^doubles ref)))))

--- a/test/raster/compiler/explain_pipeline_truth_test.clj
+++ b/test/raster/compiler/explain_pipeline_truth_test.clj
@@ -48,10 +48,11 @@
   (if-not @gp/gpu-available?
     (gp/gpu-skip! "explain-pipeline: declines")
     (let [s (explain #'raster.linalg.contract/contract-mm :target-device :ze:0)]
-      (testing "segop-lower declines par/contract (it is not a SOAC yet); the stage prints its
-                stats instead of collapsing to [unchanged]"
-        (is (re-find #"DECLINED a conversion" s))
-        (is (re-find #":segops-declined" s)))
+      (testing "segop-lower RECORDS the contraction as a SegContract (Phase 1c made it a SOAC
+                node; this stage used to print a decline). A metadata-only pass leaves the form
+                unchanged, and the stage must still print its stats instead of collapsing"
+        (is (re-find #":segops-lowered 1" s))
+        (is (not (re-find #"DECLINED a conversion" s)) "nothing declines any more"))
       (testing "the kernel section names the leaf, the headline reason, and every leaf that refused"
         (is (re-find #"--- Kernels ---" s))
         (is (re-find #"strategy=:naive-segred" s))

--- a/test/raster/compiler/segop_consumption_test.clj
+++ b/test/raster/compiler/segop_consumption_test.clj
@@ -57,3 +57,12 @@
                     (fn [soac device-id & opts] (swap! calls conj device-id) (apply orig soac :ze:0 opts))]
         (op/opencl-pass map-form :device-id :ze:1 :dtype :double :min-elements 0))
       (is (= [:ze:1] @calls) (str "lower-soac was called with " @calls ", not the pass's device-id")))))
+
+(deftest a-body-position-form-is-consumed-too
+  (testing "segop-lower wraps a body-position par form in (do …) carrying ::body-segops; that
+            must be consumed exactly like a binding's ::segops"
+    (let [form '(let* [n 8192] (raster.par/map! O i n nil (clojure.core/* (clojure.core/aget X i) 2.0)))
+          st (:stats (run (lowered form)))]
+      (is (= 1 (:ze-maps st)))
+      (is (= 1 (:segop-reused st)) "consumed from ::body-segops")
+      (is (nil? (:segop-relowered st))))))

--- a/test/raster/compiler/segop_consumption_test.clj
+++ b/test/raster/compiler/segop_consumption_test.clj
@@ -1,0 +1,59 @@
+(ns raster.compiler.segop-consumption-test
+  "THE SEGOP BOUNDARY IS REAL: opencl-pass CONSUMES what segop-lower computed. Device-free.
+
+   `segop-lower` lowered every par form with the real target device and attached the SegOp to
+   the binder symbol as `::segops`. Nothing read it (north-star §2.1: 'the pass arrows are nominal
+   at the most important boundary'). `opencl-pass` re-lowered each form from scratch with `:ze:0`
+   HARDCODED — ignoring both the stored result and its own `device-id`. Two lowerings of one form,
+   one of them on the wrong device, and no way to tell which a kernel came from.
+
+   Now the stored SegOp is consumed; re-lowering is the fallback, with the real device-id, and
+   both paths are COUNTED (`:segop-reused` / `:segop-relowered`) so a form that bypasses the
+   pass's output shows up in the stats instead of silently taking a second path."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [raster.compiler.passes.parallel.segop-lower-pass :as slp]
+            [raster.compiler.backend.gpu.opencl-pass :as op]))
+
+(def ^:private map-form
+  '(let* [o (raster.par/map! O i 8192 nil (clojure.core/* (clojure.core/aget X i) 2.0))] o))
+(def ^:private reduce-form
+  '(let* [r (raster.par/reduce acc 0.0 i 8192 (clojure.core/+ acc (clojure.core/aget X i)))] r))
+
+(defn- lowered [form] (:form (slp/segop-lower-pass form {:target-device :ze:0 :dtype :double})))
+(defn- run [form] (op/opencl-pass form :device-id :ze:0 :dtype :double :min-elements 0))
+(defn- norm [src] (str/replace (str src) #"_\d{3,}" "_N"))
+
+(deftest a-lowered-binding-is-consumed-not-relowered
+  (doseq [[label form key] [["par/map!" map-form :ze-maps] ["par/reduce" reduce-form :ze-reduces]]]
+    (testing label
+      (let [st (:stats (run (lowered form)))]
+        (is (= 1 (get st key)) "one kernel")
+        (is (= 1 (:segop-reused st)) "…from the SegOp segop-lower attached")
+        (is (nil? (:segop-relowered st)) "…and NOT re-lowered")))))
+
+(deftest an-unlowered-form-is-relowered-and-says-so
+  (testing "door C hands opencl-pass a walked body with no segop-lower pass run; the fallback
+            must still work — and must be VISIBLE, not a silent second path"
+    (doseq [[label form] [["par/map!" map-form] ["par/reduce" reduce-form]]]
+      (testing label
+        (let [st (:stats (run form))]
+          (is (= 1 (:segop-relowered st)))
+          (is (nil? (:segop-reused st))))))))
+
+(deftest consuming-is-a-refactor-the-kernel-is-identical
+  (testing "same kernel source whether the SegOp was consumed or re-lowered — this is the
+            assertion that makes the switch safe"
+    (doseq [form [map-form reduce-form]]
+      (is (= (norm (:source (first (:kernels (run (lowered form))))))
+             (norm (:source (first (:kernels (run form))))))))))
+
+(deftest the-fallback-uses-the-real-device-id
+  (testing "re-lowering used `:ze:0` hardcoded. A registered non-:ze:0 target must reach
+            lower-soac — observable because compute-launch-params asks the descriptor for THAT id"
+    (let [calls (atom [])
+          orig raster.compiler.passes.parallel.soac-lower/lower-soac]
+      (with-redefs [raster.compiler.passes.parallel.soac-lower/lower-soac
+                    (fn [soac device-id & opts] (swap! calls conj device-id) (apply orig soac :ze:0 opts))]
+        (op/opencl-pass map-form :device-id :ze:1 :dtype :double :min-elements 0))
+      (is (= [:ze:1] @calls) (str "lower-soac was called with " @calls ", not the pass's device-id")))))


### PR DESCRIPTION
**Not stacked** — based on `main`. Depends on nothing unmerged; #98 (1a/1b) is independent and can merge in either order.

`par/contract` was the **one** par form that was not a SOAC node: `par-form->soac` returned nil, `segop-lower` *declined* it (`:no-lowering-rule`), and `opencl-pass` compiled it through a side branch that re-parsed the surface form — calling `contraction-facts` three separate times. Increment 1's gate (north-star §8) names *"one contraction"* travelling the same recorded path as map/reduce. Ledger #36.

## What lands

| | |
|---|---|
| `SoacContract [id sym facts]` | `contraction-facts` is the **sole** payload (§10: one registry). Graph projections derive from it; nothing copies. |
| `SegContract [id facts dtype device-id]` | the recorded semantic plan. Deliberately carries **no** leaf/tile/geometry — those are *target* decisions `contract-route` makes from facts + descriptor at emission; putting them here would mix emission into semantic lowering. |
| `lower-soac` / `lower-all` | dispatch arms; `lower-all` no longer silently *skips* the node |
| `route-contraction :facts` | accepts precomputed facts; two of its three re-derivations go |
| `opencl-pass` | consumes the bound `SegContract` via the same `take-bound-segop` seam map/reduce use; re-lowers and **counts** without one |

## Why a new node, not the existing `Dot`

A Codex cross-check, every claim verified against the tree: `Dot` has exactly **one** constructor — a unit test. `gemm_recognize` returns plain maps. `lower-soac` throws on it, `soac->par-form` has no arm, the graph classifies it as infusible scalar. It could not carry N-axis facts, verified per-operand maps, `:decode`, `:stages`, the dtype pair, or the epilogue schema. A dead GEMM spelling; retiring it is a follow-up once nothing references it.

## Two properties a GPU-only check cannot see — both tested and mutation-gated

- **`soac?` excludes the node.** It's a *negative* predicate, so a new record is swept into generic map/reduce lowering and lambda fusion by default — whose consumers assume `idx`/`lambda`/1-D `bound`. *(Widening it fails 1.)*
- **`soac->par-form` reconstructs the exact surface form** from `(:form facts)`. The CPU path round-trips SOAC nodes back to par forms after fusion; without this arm `compile-aot` of **every** contraction threw `Cannot convert non-SOAC to par form`. Codex predicted it; the first draft hit it; the first fix corrupted the `condp` (ledger #37). Now `compile-aot` of the production `contract-mm` is numerically exact against a scalar oracle. *(Removing the arm errors 2.)*

## Validation

`segop-lower` records a `SegContract` (was a decline); `opencl-pass` consumes it (`:segop-reused 1`), routing unchanged (`:regtiled`), kernel source **byte-identical** consumed vs re-lowered; round-trip exact; CPU correct. Mutation-gated ×3. Suites green: fusion 71, spelling 163, boundary 22, gpu-correctness 51, par-opencl 63, par-test 122, router-declines 25, new node test 19.

**Local suite: 2085 / 32934, 4 failures, 0 errors** — two are this PR's own Phase-0 test asserting the *old* decline (fixed in `fa689057`), two are the pre-existing `autotune-finds-splitk-optimum` timing bars (ledger #14, fail on `origin/main`). **CI green on `fa689057`.**

## Worth knowing (ledger #38)

CI passed on the commit *before* the test fix — because that test is `gp/gpu-available?`-gated and CI has no device, so it skipped. **CI proves the model-free suite only; every GPU-gated test is gated exclusively by the local Arc run.** Not fixable in CI; stated here so "CI green" is read correctly.

## Not claimed

The full Increment-1 gate: `par/scan` has no SegOp path (ledger #35), and the CPU backend consumes the *reconstructed form*, not the `SegContract` — a facts-driven scalar consumer is the next slice.