### PR TITLE
Phase 1d: make CPU consume the SegOp boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ passes that you can inspect individually.
 | Document | Description |
 |----------|-------------|
 | [Compiler Pipeline](doc/compiler.md) | Nanopass architecture, passes, `compile-aot`, diagnostics |
+| [Compiler North Star](design/compiler-north-star.md) | GPU IR, scheduling, artifacts, autotuning, and distributed execution |
 | [Automatic Differentiation](doc/autodiff.md) | Forward/reverse AD, rrules, sensitivity analysis |
 | [GPU Computing](doc/gpu.md) | Parallel primitives, session API, backends, SoA layout |
 | [Deep Learning](doc/deep-learning.md) | Layers, loss, optimizers, compiled training |

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -75,7 +75,9 @@
    kernel, or why the modern one declined. That is the same warn-and-vanish shape north-star §3.5
    rejects at the SegOp boundary, one door along."
   [stats kind form dtype thunk]
-  (let [r (try {:ok (thunk)} (catch Exception e {:err e}))]
+  ;; Only structured conversion refusals are legal fallbacks. An implementation exception is not
+  ;; evidence that legacy codegen is legal, and must escape instead of becoming :no-lowering-rule.
+  (let [r (try {:ok (thunk)} (catch clojure.lang.ExceptionInfo e {:err e}))]
     (cond
       (:err r)
       (let [e (:err r)]

--- a/src/raster/compiler/backend/jvm/par_simd.clj
+++ b/src/raster/compiler/backend/jvm/par_simd.clj
@@ -154,9 +154,15 @@
                                            f))
                                        (:body info2))
                           fused-expr (list 'raster.par/map! (:out info2) (:idx info2) (:bound info2)
-                                           (:cast info2) inline-body)]
+                                           (:cast info2) inline-body)
+                          ;; sym2's SegOp describes expr2 before body1 was inlined. Keeping that
+                          ;; metadata makes boundary consumption silently emit expr2 alone. The
+                          ;; fused expression did not pass through segop-lower, so invalidate its
+                          ;; stale certificate and let the counted backend re-lowering handle it.
+                          fused-sym (vary-meta sym2 dissoc
+                                               :raster.compiler.passes.parallel.segop-lower-pass/segops)]
                       ;; Skip sym1 binding (tmp is eliminated), replace sym2 with fused
-                      (recur (+ i 2) (conj result [sym2 fused-expr]) true))
+                      (recur (+ i 2) (conj result [fused-sym fused-expr]) true))
                     ;; Not fusable — keep both
                     (recur (inc i) (conj result (nth pairs i)) fused?)))
                 ;; Not both par maps

--- a/src/raster/compiler/backend/jvm/par_simd.clj
+++ b/src/raster/compiler/backend/jvm/par_simd.clj
@@ -383,6 +383,12 @@
 
 (def ^:private segop-id-counter (atom 0))
 
+(def ^:dynamic *bound-segops*
+  "SegOps segop-lower attached to the binding currently being transformed (its ::segops metadata),
+   or nil. The JVM SIMD backend used to re-lower every par form on the fly, same as opencl-pass
+   did before PR #98 — the third copy of that seam. Consumption is dtype-guarded."
+  nil)
+
 (defn simd-pass
   "Pipeline pass: walk an S-expression, replace raster.par/* forms with SIMD code.
 
@@ -397,6 +403,13 @@
     (let [min-elements (or min-elements (effective-min-elements))
           stats (atom {:simd-maps 0 :simd-reduces 0 :fallback 0 :fused 0 :skipped-small 0})
           ;; On-the-fly SegOp computation for any par form
+          ;; the SegOps segop-lower attached to the binding being transformed — same seam as
+          ;; opencl-pass (*bound-segops* there). Consumed only when the dtype matches what this
+          ;; backend would derive, so consumption cannot silently change the SIMD element type.
+          take-bound (fn [pred dtype]
+                       (when-let [so (first (filter #(and (pred %) (= dtype (:dtype %))) *bound-segops*))]
+                         (swap! stats update :segop-reused (fnil inc 0))
+                         so))
           par->segmap (fn [form]
                         (try
                           (let [par-info (par/extract-par-map-info form)
@@ -412,24 +425,31 @@
                                          " from-meta=" (:elem-type par-info)
                                          " out-tag=" (or (:raster.type/tag (meta (:out par-info)))
                                                          (:tag (meta (:out par-info)))))))
-                            (let [soac (raster.compiler.ir.soac/par-form->soac
-                                        (:out par-info) form (swap! segop-id-counter inc))
-                                  segops (raster.compiler.passes.parallel.soac-lower/lower-soac
-                                          soac :cpu:0 :dtype dtype)]
-                              (first segops)))
-                          (catch Exception _ nil)))
+                            (or (take-bound #(instance? raster.compiler.ir.segop.SegMap %) dtype)
+                                (do (swap! stats update :segop-relowered (fnil inc 0))
+                                    (let [soac (raster.compiler.ir.soac/par-form->soac
+                                                (:out par-info) form (swap! segop-id-counter inc))
+                                          segops (raster.compiler.passes.parallel.soac-lower/lower-soac
+                                                  soac :cpu:0 :dtype dtype)]
+                                      (first segops)))))
+                          ;; A structured unsupported-form refusal may fall back to scalar code.
+                          ;; Raw implementation exceptions must escape, as on the GPU boundary.
+                          (catch clojure.lang.ExceptionInfo _ nil)))
           par->segred (fn [form]
                         (try
                           (let [par-info (par/extract-par-reduce-info form)
                                 dtype (or (:elem-type par-info)
                                           :double)
                                 sym (gensym "red_")
-                                soac (raster.compiler.ir.soac/par-form->soac
-                                      sym form (swap! segop-id-counter inc))
-                                segops (raster.compiler.passes.parallel.soac-lower/lower-soac
-                                        soac :cpu:0 :dtype dtype)]
-                            (first segops))
-                          (catch Exception _ nil)))
+                                bound (take-bound #(instance? raster.compiler.ir.segop.SegRed %) dtype)]
+                            (or bound
+                                (do (swap! stats update :segop-relowered (fnil inc 0))
+                                    (let [soac (raster.compiler.ir.soac/par-form->soac
+                                                sym form (swap! segop-id-counter inc))
+                                          segops (raster.compiler.passes.parallel.soac-lower/lower-soac
+                                                  soac :cpu:0 :dtype dtype)]
+                                      (first segops)))))
+                          (catch clojure.lang.ExceptionInfo _ nil)))
           transform
           (fn transform [form]
             (cond
@@ -501,7 +521,11 @@
                   ;; No fusion — recurse into bindings and body
                   ;; transform handles par forms via SegOp uniformly
                   (let [pairs (partition 2 bindings)
-                        new-bindings (vec (mapcat (fn [[s e]] [s (transform e)]) pairs))
+                        new-bindings (vec (mapcat (fn [[s e]]
+                                                    [s (binding [*bound-segops*
+                                                                 (:raster.compiler.passes.parallel.segop-lower-pass/segops (meta s))]
+                                                         (transform e))])
+                                                  pairs))
                         new-body (doall (map transform body))]
                     (list* let-sym new-bindings new-body))))
 

--- a/src/raster/compiler/ir/soac.clj
+++ b/src/raster/compiler/ir/soac.clj
@@ -79,17 +79,6 @@
             expr])      ;; the RHS expression
 
 ;; ================================================================
-;; Dot — a first-class GEMM/contraction node (feature 4 keystone)
-;; ================================================================
-;; A contraction C[m,n] = Σ_k A[m,k]·B[k,n], modelled as an IR NODE (not an opaque
-;; BLAS .invk) so it participates in the dependency graph + fusion. It is NOT a generic
-;; SOAC (its K-reduction is a real contraction, not a fold over the SOAC iteration — the
-;; eval agent's finding), so `soac?` EXCLUDES it and the map/reduce lowering skips it; a
-;; dedicated GEMM emit path handles it. But the DEPENDENCY accessors DO handle it, so its
-;; output C carries a producer edge BY CONSTRUCTION — closing the documented leak at
-;; soac-outputs (a GEMM writing C with no edge → reorderable consumer). `epilogue` is the
-;; fused same-position elementwise consumer lambda (bias/act/residual), or nil; when set,
-;; the emitter splices it into the validated store slot (emit-gemm-tiled :epilogue).
 (defrecord SoacContract
            [id           ;; int
             sym          ;; symbol (binding) — the contraction's output
@@ -101,20 +90,6 @@
 ;; representation this replaces — it had one constructor (a unit test), was excluded from lowering,
 ;; reconstruction and fusion, and could not carry most of the facts.
 
-(defrecord Dot
-           [id           ;; int
-            sym          ;; symbol (binding)
-            inputs       ;; #{A B + epilogue operands} — read arrays (dep graph)
-            outputs      ;; #{C} — written array (dep graph producer edge)
-            bound        ;; expr — output element count m*n (for scheduling)
-            A B C        ;; operand symbols
-            m n k        ;; dim exprs
-            variant      ;; :nn | :tn | :nt
-            alpha beta   ;; scalars
-            epilogue     ;; {:lambda expr :element sym :operands #{sym}} or nil (fused consumer)
-            layout-a layout-b])  ;; :layout facets on the operands (transpose-elim), or nil
-
-(defn dot? [node] (instance? Dot node))
 
 ;; ================================================================
 ;; Input/output extraction helpers
@@ -479,11 +454,10 @@
 ;; ================================================================
 
 (defn soac?
-  "Check if a node is a generic SOAC (map/reduce/scan/stencil) — NOT a ScalarBinding and NOT a Dot.
-   A Dot is a contraction with its own emit path, so the map/reduce lowering must skip it."
+  "Check if a node is a generic SOAC (map/reduce/scan/stencil) — NOT a ScalarBinding, and NOT a
+   SoacContract (a contraction has its own lowering; generic map/reduce lowering must skip it)."
   [node]
   (and (not (instance? ScalarBinding node))
-       (not (instance? Dot node))
        ;; a contraction has its own lowering (SegContract) and must NOT enter the generic
        ;; map/reduce/scan lowering or lambda fusion, whose consumers assume idx/lambda/1-D bound
        (not (instance? SoacContract node))))
@@ -491,15 +465,14 @@
 (defn contract? [node] (instance? SoacContract node))
 
 (defn soac-inputs
-  "Get the set of input array symbols for a SOAC node (or a Dot)."
+  "Get the set of input array symbols for a SOAC node."
   [node]
   (if (instance? SoacContract node)
     (set (map :sym (:operands (:facts node))))
-  (when (or (soac? node) (dot? node)) (:inputs node))))
+    (when (soac? node) (:inputs node))))
 
 (defn soac-outputs
-  "Get the set of output symbols for a SOAC node (or a Dot — its written C, so the dependency graph
-   gets a producer edge for the contraction by construction, closing the documented leak)."
+  "Get the set of output symbols for a SOAC node."
   [node]
   (if (instance? SoacContract node)
     #{(:out (:facts node))}
@@ -508,7 +481,6 @@
     (instance? SoacReduce node)  #{(:output node)}
     (instance? SoacScan node)    (:outputs node)
     (instance? SoacStencil node) (:outputs node)
-    (instance? Dot node)         (:outputs node)
     :else nil)))
 
 (defn soac-bound

--- a/src/raster/compiler/ir/soac.clj
+++ b/src/raster/compiler/ir/soac.clj
@@ -90,6 +90,23 @@
 ;; representation this replaces — it had one constructor (a unit test), was excluded from lowering,
 ;; reconstruction and fusion, and could not carry most of the facts.
 
+(defn- record-kind?
+  "Recognize a SOAC record without pinning the caller to one DynamicClassLoader instance.
+
+   Typed Clojure may analyze and re-evaluate this namespace in a child DynamicClassLoader. A
+   record produced after that re-evaluation has the same public record type but is not `instance?`
+   the class literal captured earlier by a compiler pass. Dispatching through this namespace's Var
+   and comparing the stable generated class name keeps the IR boundary valid across that reload."
+  [record-class node]
+  (and node (= record-class (.getName (class node)))))
+
+(defn soac-map? [node] (record-kind? "raster.compiler.ir.soac.SoacMap" node))
+(defn soac-reduce? [node] (record-kind? "raster.compiler.ir.soac.SoacReduce" node))
+(defn soac-scan? [node] (record-kind? "raster.compiler.ir.soac.SoacScan" node))
+(defn soac-stencil? [node] (record-kind? "raster.compiler.ir.soac.SoacStencil" node))
+(defn scalar-binding? [node] (record-kind? "raster.compiler.ir.soac.ScalarBinding" node))
+(defn screma? [node] (record-kind? "raster.compiler.ir.soac.Screma" node))
+(defn contract? [node] (record-kind? "raster.compiler.ir.soac.SoacContract" node))
 
 ;; ================================================================
 ;; Input/output extraction helpers
@@ -457,31 +474,29 @@
   "Check if a node is a generic SOAC (map/reduce/scan/stencil) — NOT a ScalarBinding, and NOT a
    SoacContract (a contraction has its own lowering; generic map/reduce lowering must skip it)."
   [node]
-  (and (not (instance? ScalarBinding node))
+  (and (not (scalar-binding? node))
        ;; a contraction has its own lowering (SegContract) and must NOT enter the generic
        ;; map/reduce/scan lowering or lambda fusion, whose consumers assume idx/lambda/1-D bound
-       (not (instance? SoacContract node))))
-
-(defn contract? [node] (instance? SoacContract node))
+       (not (contract? node))))
 
 (defn soac-inputs
   "Get the set of input array symbols for a SOAC node."
   [node]
-  (if (instance? SoacContract node)
+  (if (contract? node)
     (set (map :sym (:operands (:facts node))))
     (when (soac? node) (:inputs node))))
 
 (defn soac-outputs
   "Get the set of output symbols for a SOAC node."
   [node]
-  (if (instance? SoacContract node)
+  (if (contract? node)
     #{(:out (:facts node))}
-  (cond
-    (instance? SoacMap node)     (:outputs node)
-    (instance? SoacReduce node)  #{(:output node)}
-    (instance? SoacScan node)    (:outputs node)
-    (instance? SoacStencil node) (:outputs node)
-    :else nil)))
+    (cond
+      (soac-map? node)     (:outputs node)
+      (soac-reduce? node)  #{(:output node)}
+      (soac-scan? node)    (:outputs node)
+      (soac-stencil? node) (:outputs node)
+      :else nil)))
 
 (defn soac-bound
   "Get the iteration bound expression for a SOAC node."

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -64,7 +64,10 @@
                     (when par? {:declined (diagnostic sym form stage e device-id dtype)}))
           ;; capture value-or-exception in one call: the alternative (catch a sentinel, then call
           ;; again to get the exception) re-runs a side-effecting conversion
-          attempt (fn [f] (try {:ok (f)} (catch Exception e {:err e})))
+          ;; Only an intentional, structured conversion refusal may become a decline. A raw
+          ;; NullPointerException/ClassCastException/etc. is an implementation bug and must escape;
+          ;; treating it as "no lowering rule" would silently select a different backend path.
+          attempt (fn [f] (try {:ok (f)} (catch clojure.lang.ExceptionInfo e {:err e})))
           soac (attempt #(soac/par-form->soac sym form (swap! id-counter inc) :dtype (or dtype :double)))]
       (cond
         (:err soac) (decline :soac (:err soac))

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -226,6 +226,10 @@
   [soac device-id & {:keys [dtype] :or {dtype :double}}]
   (let [dtype (or (:elem-type soac) dtype)]
     (cond
+      (nil? soac)
+      (throw (ex-info "Cannot lower nil: the preceding conversion produced no SOAC node"
+                      {:reason :no-soac-node :target-dialect :segop}))
+
       ;; Screma dispatch based on contents
       (instance? raster.compiler.ir.soac.Screma soac)
       (cond

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -34,18 +34,18 @@
 
 (defn- screma-map-lambda
   [soac]
-  (when (instance? raster.compiler.ir.soac.Screma soac)
+  (when (soac/screma? soac)
     (:map-lambda soac)))
 
 (defn- reduce-op-info
   [soac]
-  (if (instance? raster.compiler.ir.soac.SoacReduce soac)
+  (if (soac/soac-reduce? soac)
     {:acc (:acc soac) :init (:init soac) :lambda (:lambda soac)}
     (first (:reduces soac))))
 
 (defn- scan-op-info
   [soac]
-  (if (instance? raster.compiler.ir.soac.SoacScan soac)
+  (if (soac/soac-scan? soac)
     {:acc (:acc soac) :init (:init soac)
      :lambda (:lambda soac) :out (:out soac)}
     (first (:scans soac))))
@@ -231,7 +231,7 @@
                       {:reason :no-soac-node :target-dialect :segop}))
 
       ;; Screma dispatch based on contents
-      (instance? raster.compiler.ir.soac.Screma soac)
+      (soac/screma? soac)
       (cond
         (and (empty? (:scans soac)) (empty? (:reduces soac)) (:map-lambda soac))
         (lower-map soac device-id :dtype dtype)
@@ -247,16 +247,16 @@
 
       ;; Direct SOAC dispatch
       ;; a contraction: record the facts for this target; the backend routes from them
-      (instance? raster.compiler.ir.soac.SoacContract soac)
+      (soac/contract? soac)
       [(segop/->SegContract (:id soac) (:facts soac) dtype device-id)]
 
-      (instance? raster.compiler.ir.soac.SoacMap soac)
+      (soac/soac-map? soac)
       (lower-map soac device-id :dtype dtype)
 
-      (instance? raster.compiler.ir.soac.SoacReduce soac)
+      (soac/soac-reduce? soac)
       (lower-reduce soac device-id :dtype dtype)
 
-      (instance? raster.compiler.ir.soac.SoacScan soac)
+      (soac/soac-scan? soac)
       (lower-scan soac device-id :dtype dtype)
 
       :else

--- a/test/raster/compiler/fusion_test.clj
+++ b/test/raster/compiler/fusion_test.clj
@@ -417,18 +417,3 @@
     (testing "a gather/offset read (aget t (+ dst 1)) FAILS LOUD instead of mis-fusing"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"non-same-position read"
             (subst '(clojure.core/aget t (clojure.core/+ dst 1)) 't 'src 'dst '(raster.numeric/* p p)))))))
-
-;; ── Dot node: a correct dependency-graph citizen, excluded from map/reduce lowering ──
-(deftest dot-node-dependency-edges
-  (let [dot (soac/->Dot 1 'c '#{A B} '#{C} '(* m n) 'A 'B 'C 'm 'n 'k :nn 1.0 0.0 nil nil nil)]
-    (testing "Dot carries its C output as a producer edge (closes the documented soac-outputs leak)"
-      (is (= '#{C} (soac/soac-outputs dot)) "C is a producer edge by construction")
-      (is (= '#{A B} (soac/soac-inputs dot)) "A,B are read edges"))
-    (testing "Dot is NOT a generic SOAC (map/reduce lowering skips it) but IS a Dot"
-      (is (false? (soac/soac? dot)))
-      (is (true? (soac/dot? dot))))
-    (testing "free-syms include operands + output (dep graph sees the full footprint)"
-      (is (every? (soac/node-all-free-syms dot) '[A B C])))
-    (testing "the epilogue slot holds a fused same-position consumer lambda or nil"
-      (is (nil? (:epilogue dot)))
-      (is (= '(silu (+ %el bias)) (:lambda (:epilogue (assoc dot :epilogue {:lambda '(silu (+ %el bias))}))))))))

--- a/test/raster/compiler/segop_boundary_test.clj
+++ b/test/raster/compiler/segop_boundary_test.clj
@@ -20,7 +20,9 @@
    data, per §3.5's requirement that an unsupported form 'produce a structured diagnostic naming
    the operation, source, missing rule, target dialect, and possible legal fallback'."
   (:require [clojure.test :refer [deftest is testing]]
-            [raster.compiler.passes.parallel.segop-lower-pass :as slp]))
+            [raster.compiler.passes.parallel.segop-lower-pass :as slp]
+            [raster.compiler.passes.parallel.soac-lower :as soac-lower]
+            [raster.compiler.ir.soac :as soac]))
 
 (defn- stats-of [form] (:stats (slp/segop-lower-pass form {})))
 
@@ -61,6 +63,21 @@
       (is (contains? fatal :raster/fatal))
       (is (contains? fatal :raster/bug)))))
 
+(deftest implementation-exceptions-are-not-conversion-declines
+  (testing "an implementation bug in par→SOAC escapes instead of silently selecting a fallback"
+    (with-redefs [soac/par-form->soac
+                  (fn [& _] (throw (NullPointerException. "simulated compiler bug")))]
+      (is (thrown-with-msg? NullPointerException #"simulated compiler bug"
+                            (stats-of '(let* [o (raster.par/map! O i 256 nil i)] o))))))
+  (testing "nil and an unsupported SOAC type have distinct diagnostics"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"produced no SOAC node"
+                          (soac-lower/lower-soac nil :cpu:0)))
+    (try
+      (soac-lower/lower-soac nil :cpu:0)
+      (is false "nil SOAC must throw")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :no-soac-node (:reason (ex-data e))))))))
+
 (deftest the-gpu-door-records-which-generator-it-used
   (testing "opencl_pass's SegMap/SegRed door recorded nothing when it fell back to legacy codegen,
             and both paths incremented the same counter. The decline is now structured data on the
@@ -87,4 +104,9 @@
         (testing "…while an invariant violation escapes to the caller"
           (is (thrown? clojure.lang.ExceptionInfo
                        (attempt stats :segmap '(raster.par/map! O i 4 nil x) :double
-                                (fn [] (throw (ex-info "bug" {:reason :raster/bug})))))))))))
+                                (fn [] (throw (ex-info "bug" {:reason :raster/bug})))))))
+        (testing "…and an unstructured implementation exception is never a decline"
+          (is (thrown-with-msg? NullPointerException #"implementation bug"
+                                (attempt stats :segmap '(raster.par/map! O i 4 nil x) :double
+                                         (fn [] (throw (NullPointerException.
+                                                        "implementation bug")))))))))))

--- a/test/raster/compiler/segop_consumption_test.clj
+++ b/test/raster/compiler/segop_consumption_test.clj
@@ -92,6 +92,19 @@
       (is (= 1 (:segop-relowered st)))
       (is (nil? (:segop-reused st))))))
 
+(deftest jvm-simd-invalidates-segops-when-it-fuses-after-lowering
+  (testing "a fused expression cannot consume the second input map's now-stale SegOp"
+    (let [form '(let* [tmp-step (raster.par/map! TMP i 8192 nil
+                                                 (clojure.core/* (clojure.core/aget X i) 2.0))
+                       out-step (raster.par/map! O j 8192 nil
+                                                 (clojure.core/+ (clojure.core/aget TMP j) 1.0))]
+                      out-step)
+          st (:stats (run-simd (lowered-cpu form :double)))]
+      (is (= 1 (:fused st)))
+      (is (= 1 (:simd-maps st)))
+      (is (= 1 (:segop-relowered st)) "the fused lambda gets a fresh SegOp")
+      (is (nil? (:segop-reused st)) "neither pre-fusion SegOp certifies the fused lambda"))))
+
 (deftest jvm-simd-does-not-turn-an-implementation-bug-into-scalar-fallback
   (testing "an unstructured re-lowering exception is a compiler bug, not an unsupported SIMD form"
     (with-redefs [soac/par-form->soac

--- a/test/raster/compiler/segop_consumption_test.clj
+++ b/test/raster/compiler/segop_consumption_test.clj
@@ -1,5 +1,6 @@
 (ns raster.compiler.segop-consumption-test
-  "THE SEGOP BOUNDARY IS REAL: opencl-pass CONSUMES what segop-lower computed. Device-free.
+  "THE SEGOP BOUNDARY IS REAL: GPU and JVM SIMD backends CONSUME what segop-lower computed.
+   Device-free.
 
    `segop-lower` lowered every par form with the real target device and attached the SegOp to
    the binder symbol as `::segops`. Nothing read it (north-star §2.1: 'the pass arrows are nominal
@@ -13,7 +14,9 @@
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
             [raster.compiler.passes.parallel.segop-lower-pass :as slp]
-            [raster.compiler.backend.gpu.opencl-pass :as op]))
+            [raster.compiler.ir.soac :as soac]
+            [raster.compiler.backend.gpu.opencl-pass :as op]
+            [raster.compiler.backend.jvm.par-simd :as par-simd]))
 
 (def ^:private map-form
   '(let* [o (raster.par/map! O i 8192 nil (clojure.core/* (clojure.core/aget X i) 2.0))] o))
@@ -22,6 +25,9 @@
 
 (defn- lowered [form] (:form (slp/segop-lower-pass form {:target-device :ze:0 :dtype :double})))
 (defn- run [form] (op/opencl-pass form :device-id :ze:0 :dtype :double :min-elements 0))
+(defn- lowered-cpu [form dtype]
+  (:form (slp/segop-lower-pass form {:target-device :cpu:0 :dtype dtype})))
+(defn- run-simd [form] (par-simd/simd-pass form :min-elements 0))
 (defn- norm [src] (str/replace (str src) #"_\d{3,}" "_N"))
 
 (deftest a-lowered-binding-is-consumed-not-relowered
@@ -66,3 +72,29 @@
       (is (= 1 (:ze-maps st)))
       (is (= 1 (:segop-reused st)) "consumed from ::body-segops")
       (is (nil? (:segop-relowered st))))))
+
+(deftest jvm-simd-consumes-the-boundary-too
+  (testing "matching map/reduce SegOps are reused rather than independently re-derived"
+    (doseq [[label form stat-key]
+            [["par/map!" map-form :simd-maps]
+             ["par/reduce" reduce-form :simd-reduces]]]
+      (testing label
+        (let [st (:stats (run-simd (lowered-cpu form :double)))]
+          (is (= 1 (get st stat-key)))
+          (is (= 1 (:segop-reused st)))
+          (is (nil? (:segop-relowered st))))))))
+
+(deftest jvm-simd-refuses-a-bound-segop-with-the-wrong-dtype
+  (testing "the backend re-lowers when its locally derived dtype disagrees with the boundary;
+            consuming the float SegOp as a double SIMD operation would silently change semantics"
+    (let [st (:stats (run-simd (lowered-cpu map-form :float)))]
+      (is (= 1 (:simd-maps st)))
+      (is (= 1 (:segop-relowered st)))
+      (is (nil? (:segop-reused st))))))
+
+(deftest jvm-simd-does-not-turn-an-implementation-bug-into-scalar-fallback
+  (testing "an unstructured re-lowering exception is a compiler bug, not an unsupported SIMD form"
+    (with-redefs [soac/par-form->soac
+                  (fn [& _] (throw (NullPointerException. "simulated SIMD lowering bug")))]
+      (is (thrown-with-msg? NullPointerException #"simulated SIMD lowering bug"
+                            (run-simd map-form))))))


### PR DESCRIPTION
## Summary

- make the JVM SIMD backend consume dtype-matching SegMap and SegRed records attached by SegOp lowering
- count and preserve dtype-safe re-lowering when the backend derives a different element type
- allow only structured ExceptionInfo conversion declines to select legacy or scalar fallback paths
- distinguish a missing SOAC node from an unsupported SOAC type
- retire the dead Dot record now superseded by SoacContract
- link the tracked compiler north-star document from the README

## Why

The GPU backend began consuming the SegOp boundary in Phase 1a, while JVM SIMD still independently re-lowered the same parallel forms. This makes CPU and GPU use the same recorded boundary where legal without allowing a dtype mismatch to silently change SIMD semantics. It also prevents implementation exceptions such as NPEs from being misreported as unsupported lowering rules.

## Verification

Cold, device-free checks:

- boundary, consumption, JVM SIMD and fusion: 55 tests, 161 assertions
- SOAC, SegOp and contraction regressions: 41 tests, 144 assertions
- total: 96 tests, 305 assertions, zero failures or errors
- git diff --check passes

## Scope

This does not close north-star Increment 1. Inclusive scan is recorded as SegScan but has no backend consumer, exclusive scan has no SOAC conversion, and the existing three-stage scan plan needs its block-totals dataflow repaired before emission. The metadata transport also remains an interim seam before a first-class program container.

CI has no GPU and GPU-gated tests skip there. This PR changes and tests device-free conversion/consumption behavior; it does not claim local GPU execution coverage.