### PR TITLE
Phase 2: refuse unbound contraction ABI fields

### DIFF
--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -153,6 +153,35 @@
            (legacy/compile-kernel-to-spirv (:source kernel) :device-id device-id))
     kernel))
 
+(def ^:private contraction-marker-unexpressed-fields
+  "Descriptor capabilities that `invoke-registered-contraction!` cannot execute or bind yet.
+
+   `:tensorized` and `:packed` are deliberately absent: they describe code already baked into the
+   emitted kernel and require no additional launch arguments. These fields do. Silently dropping
+   any non-empty one produces either a wrong layout (`:pre-steps`) or a launch-arity mismatch."
+  [:pre-steps :lift-operands :epilogue-operands :epilogue-scalars])
+
+(defn- ensure-contraction-marker-expressible!
+  "Refuse a routed descriptor whose required work/arguments the current invoke marker cannot carry.
+
+   This is the fail-loud bridge to the ordered kernel ABI: until the marker and runtime consume one
+   typed slot vector, accepting these fields would register a valid kernel and emit an invocation
+   that binds fewer arguments than its signature."
+  [descriptor]
+  (let [unsupported (filterv #(seq (get descriptor %))
+                             contraction-marker-unexpressed-fields)]
+    (when (seq unsupported)
+      (throw (ex-info (str "contraction: invoke marker cannot express descriptor fields "
+                           (pr-str unsupported))
+                      {:reason :raster/fatal
+                       :missing-rule :ordered-contraction-kernel-abi
+                       :target 'raster.gpu.ze-runtime/invoke-registered-contraction!
+                       :strategy (:strategy descriptor)
+                       :unsupported-fields unsupported
+                       :unsupported-values (select-keys descriptor unsupported)
+                       :fallback :none})))
+    descriptor))
+
 (defn opencl-pass
   "Pipeline pass: walk S-expression, replace par forms with GPU kernel invocations.
 
@@ -248,21 +277,13 @@
                   bound-sc (take-bound-segop stats :segcontract
                                              #(instance? raster.compiler.ir.segop.SegContract %))
                   _ (when-not bound-sc (swap! stats update :segop-relowered (fnil inc 0)))
-                  r (croute/route-contraction
-                     form :dtype dtype
-                     :facts (:facts bound-sc)
-                     :desc (try ((requiring-resolve 'raster.compiler.core.hardware/descriptor-for)
-                                 device-id)
-                                (catch Throwable _ nil)))
-                  ;; :pre-steps (an inserted layout transpose) is PRODUCED by route-contraction
-                  ;; under :prefer-peak? but executed by NOTHING — the kernel would index a
-                  ;; transposed layout against an untransposed buffer, a wrong answer with no
-                  ;; diagnostic. Unreachable today (:prefer-peak? is never set here), so refusing
-                  ;; costs nothing now and converts a future silent miscompile into a loud one.
-                  _ (when (seq (:pre-steps r))
-                      (throw (ex-info (str "contraction: descriptor carries :pre-steps, which no "
-                                           "pass executes — the operand would be read untransposed")
-                                      {:reason :raster/fatal :pre-steps (:pre-steps r)})))
+                  r (ensure-contraction-marker-expressible!
+                     (croute/route-contraction
+                      form :dtype dtype
+                      :facts (:facts bound-sc)
+                      :desc (try ((requiring-resolve 'raster.compiler.core.hardware/descriptor-for)
+                                  device-id)
+                                 (catch Throwable _ nil))))
                   ;; Register the ROUTED KERNEL MAP, not three hand-picked keys. Dropping
                   ;; :c-op/:identity-val made invoke-reduction-kernel fall back to its
                   ;; `:or {c-op "+" identity-val 0.0}` for the HOST-SIDE FINAL COMBINE — so a
@@ -271,11 +292,13 @@
                   ;; 0-free-axis contraction at :float/:double is exactly what this pass routes.
                   ;; :strategy/:fallback-reason/:declines/:tile are the ROUTING DECISION. They
                   ;; were dropped here, so no diagnostic could say which leaf a kernel came from
-                  ;; or why a faster one was refused. (:scalar-params is kept for the existing
-                  ;; consumers; route-contraction actually returns :scalar-args — ledger.)
+                  ;; or why a faster one was refused. Tensorization/packing are codegen facts that
+                  ;; need no extra launch slot, so preserve them for inspection instead of treating
+                  ;; them like the unbound argument fields refused above.
                   k (register-kernel! (merge (select-keys r [:c-op :identity-val :array-params
-                                                             :scalar-params :out-dtype
-                                                             :strategy :fallback-reason :declines :tile])
+                                                             :out-dtype :strategy :fallback-reason
+                                                             :declines :tile :tensorized :packed
+                                                             :fused-epilogue])
                                              {:kernel-name (:kernel-name r) :source (:source r)
                                               :dtype (:dtype r)})
                                       :ze-contracts)]
@@ -289,16 +312,16 @@
               ;; Pass the descriptor through INTACT — scalar-args as data (the exact shape
               ;; launch-2d! wants), explicit out-dtype/out-elems. Any :strategy works; the
               ;; old (count scalar-args) + [m n k] reconstruction only covered :dpas/:regtiled.
-              (list 'raster.gpu.ze-runtime/invoke-registered-contraction!
-                    (:kernel-name k)
-                    (vec (:array-params r))       ; operand symbols (vector literal evaluates them)
-                    out-sym
-                    (:dtype r)
-                    (:out-dtype r)
-                    (:out-elems r)                ; may be a symbolic expr (symbolic axis bounds)
-                    (vec (:wg r))
-                    (vec (:grid r))
-                    (vec (:scalar-args r)))))
+                (list 'raster.gpu.ze-runtime/invoke-registered-contraction!
+                      (:kernel-name k)
+                      (vec (:array-params r))       ; operand symbols (vector literal evaluates them)
+                      out-sym
+                      (:dtype r)
+                      (:out-dtype r)
+                      (:out-elems r)                ; may be a symbolic expr (symbolic axis bounds)
+                      (vec (:wg r))
+                      (vec (:grid r))
+                      (vec (:scalar-args r)))))
 
             ;; === par/reduce-into — resident SegRed writing a caller-supplied 1-elem buffer ===
             ;; Same SegRed kernel as par/reduce (it already has an `output` param), but the

--- a/test/raster/compiler/contraction_marker_abi_test.clj
+++ b/test/raster/compiler/contraction_marker_abi_test.clj
@@ -1,0 +1,81 @@
+(ns raster.compiler.contraction-marker-abi-test
+  "The contraction route can describe capabilities the current invocation marker cannot bind.
+
+   Until contraction descriptors and runtime launches share one ordered typed ABI, the compiler
+   must reject those descriptors rather than emit a valid kernel with an under-bound invocation."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.opencl-pass :as op]
+            [raster.compiler.passes.parallel.contract-route :as route]
+            [raster.compiler.passes.parallel.par-fusion :as fusion]))
+
+(defn- mm [m n k]
+  (list 'raster.par/contract 'C [['i m] ['j n]] [['l k]]
+        (list '* (list 'aget 'A (list '+ (list '* 'i k) 'l))
+              (list 'aget 'B (list '+ (list '* 'l n) 'j)))))
+
+(defn- fuse-epilogue [body]
+  (second (:bindings
+           (fusion/fuse-contract-map
+            ['C (mm 128 256 64)
+             'out (list 'raster.par/map! 'out 't (* 128 256) nil body)]
+            []))))
+
+(defn- compile-form
+  ([contract] (compile-form contract :half))
+  ([contract dtype]
+   (op/opencl-pass (list 'let* ['result contract] 'result)
+                   :device-id :ze:0 :dtype dtype :min-elements 0)))
+
+(defn- thrown-data [thunk]
+  (try
+    (thunk)
+    nil
+    (catch clojure.lang.ExceptionInfo e
+      (ex-data e))))
+
+(deftest fused-epilogue-operands-are-refused-before-an-under-bound-marker-is-emitted
+  (let [contract (fuse-epilogue
+                  (list 'raster.numeric/+ (list 'aget 'C 't)
+                        (list 'aget 'bias (list 'mod 't 256))))
+        data (thrown-data #(compile-form contract))]
+    (testing "this is a real routed DPAS descriptor, not a synthetic malformed map"
+      (is (= :dpas (:strategy data))))
+    (testing "the marker would bind [A B] while the kernel signature also requires bias"
+      (is (= :raster/fatal (:reason data)))
+      (is (= :ordered-contraction-kernel-abi (:missing-rule data)))
+      (is (= [:epilogue-operands] (:unsupported-fields data)))
+      (is (= {:epilogue-operands '[bias]} (:unsupported-values data))))))
+
+(deftest codegen-only-routing-facts-remain-legal-and-observable
+  (let [dp4a '(raster.par/contract C [[i 4] [j 4]] [[l 8]]
+                                   (* (aget A (+ (* i 8) l))
+                                      (aget B (+ (* j 8) l))))
+        compiled (compile-form dp4a :byte)
+        kernel (first (:kernels compiled))]
+    (testing "tensorization and packing are already baked into source and need no extra launch slot"
+      (is (= :dp4a (:strategy kernel)))
+      (is (true? (:tensorized kernel)))
+      (is (= :int8x4 (:packed kernel))))
+    (testing "the ordinary two-input descriptor still emits the production marker"
+      (is (= 'raster.gpu.ze-runtime/invoke-registered-contraction!
+             (-> compiled :form second second first))))))
+
+(deftest every-unexpressed-marker-field-is-fail-loud
+  (let [base {:strategy :probe
+              :kernel-name "probe_contract"
+              :source "__kernel void probe_contract(__global double* A, __global double* C) {}"
+              :array-params '[A]
+              :dtype :double :out-dtype :double :out-elems 1
+              :wg [1 1] :grid [1 1] :scalar-args []}
+        contract (mm 1 1 1)]
+    (doseq [[field value] [[:pre-steps [{:op :transpose}]]
+                           [:lift-operands '[scale]]
+                           [:epilogue-operands '[bias]]
+                           [:epilogue-scalars '[alpha]]]]
+      (testing (name field)
+        (let [data (with-redefs [route/route-contraction
+                                 (fn [& _] (assoc base field value))]
+                     (thrown-data #(compile-form contract)))]
+          (is (= :raster/fatal (:reason data)))
+          (is (= [field] (:unsupported-fields data)))
+          (is (= {field value} (:unsupported-values data))))))))


### PR DESCRIPTION
## Summary

- reject routed contraction descriptors when the current invoke marker cannot execute `:pre-steps` or bind staged/epilogue pointer and scalar arguments
- report the exact unsupported fields with `:missing-rule :ordered-contraction-kernel-abi` instead of emitting an under-bound launch
- retain codegen-only `:tensorized` / `:packed` facts on registered kernels and remove the permanently dead `:scalar-params` projection

## Why

A real fused DPAS+bias contraction produced a kernel signature containing `A`, `B`, `C`, `M`, `N`, `K`, and `bias`, while `opencl-pass` emitted `invoke-registered-contraction!` with only `[A B]`, the output, and the dimension scalars. The kernel was valid; the invocation was structurally incapable of binding it. This safety slice makes that ABI gap loud before the ordered typed ABI is introduced.

## Verification

- `raster.compiler.contraction-marker-abi-test`: production DPAS+bias refusal, all four unsupported field classes, and legal DP4A tensorization/packing metadata
- affected contraction routing cluster: 37 tests, 301 assertions, 0 failures/errors
- cljfmt and `git diff --check` clean

CircleCI has no GPU/ocloc, so this PR validates the device-free routing and marker boundary; it does not claim on-device GPU execution coverage.