### PR TITLE
Add ordered contraction kernel ABI

### DIFF
--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -154,19 +154,13 @@
     kernel))
 
 (def ^:private contraction-marker-unexpressed-fields
-  "Descriptor capabilities that `invoke-registered-contraction!` cannot execute or bind yet.
-
-   `:tensorized` and `:packed` are deliberately absent: they describe code already baked into the
-   emitted kernel and require no additional launch arguments. These fields do. Silently dropping
-   any non-empty one produces either a wrong layout (`:pre-steps`) or a launch-arity mismatch."
-  [:pre-steps :lift-operands :epilogue-operands :epilogue-scalars])
+  "Descriptor work that is outside a single kernel launch.  Kernel arguments, including lift and
+   epilogue values, are carried by the ABI; pre-steps require a scheduler to emit another launch."
+  [:pre-steps])
 
 (defn- ensure-contraction-marker-expressible!
-  "Refuse a routed descriptor whose required work/arguments the current invoke marker cannot carry.
-
-   This is the fail-loud bridge to the ordered kernel ABI: until the marker and runtime consume one
-   typed slot vector, accepting these fields would register a valid kernel and emit an invocation
-   that binds fewer arguments than its signature."
+  "Refuse routed work that is not a kernel argument.  Lift and epilogue arguments are represented
+   by the ordered ABI; a pre-step is a separate operation and still needs explicit scheduling."
   [descriptor]
   (let [unsupported (filterv #(seq (get descriptor %))
                              contraction-marker-unexpressed-fields)]
@@ -174,7 +168,7 @@
       (throw (ex-info (str "contraction: invoke marker cannot express descriptor fields "
                            (pr-str unsupported))
                       {:reason :raster/fatal
-                       :missing-rule :ordered-contraction-kernel-abi
+                       :missing-rule :contraction-pre-step-scheduling
                        :target 'raster.gpu.ze-runtime/invoke-registered-contraction!
                        :strategy (:strategy descriptor)
                        :unsupported-fields unsupported
@@ -298,7 +292,7 @@
                   k (register-kernel! (merge (select-keys r [:c-op :identity-val :array-params
                                                              :out-dtype :strategy :fallback-reason
                                                              :declines :tile :tensorized :packed
-                                                             :fused-epilogue])
+                                                             :fused-epilogue :abi])
                                              {:kernel-name (:kernel-name r) :source (:source r)
                                               :dtype (:dtype r)})
                                       :ze-contracts)]
@@ -309,19 +303,14 @@
                       (:kernel-name k)
                       (vec (:array-params r))
                       (:reduce-bound r))
-              ;; Pass the descriptor through INTACT — scalar-args as data (the exact shape
-              ;; launch-2d! wants), explicit out-dtype/out-elems. Any :strategy works; the
-              ;; old (count scalar-args) + [m n k] reconstruction only covered :dpas/:regtiled.
+              ;; The marker carries only VALUES in ABI order.  Slot kind, storage dtype and kernel
+              ;; view dtype live once in the registered ABI and drive runtime binding.
                 (list 'raster.gpu.ze-runtime/invoke-registered-contraction!
                       (:kernel-name k)
-                      (vec (:array-params r))       ; operand symbols (vector literal evaluates them)
-                      out-sym
-                      (:dtype r)
-                      (:out-dtype r)
+                      (vec (:arguments r))
                       (:out-elems r)                ; may be a symbolic expr (symbolic axis bounds)
                       (vec (:wg r))
-                      (vec (:grid r))
-                      (vec (:scalar-args r)))))
+                      (vec (:grid r)))))
 
             ;; === par/reduce-into — resident SegRed writing a caller-supplied 1-elem buffer ===
             ;; Same SegRed kernel as par/reduce (it already has an `output` param), but the

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -17,6 +17,7 @@
             [raster.compiler.ir.axis-map :as am]
             [raster.compiler.ir.contract-stages :as cstage]
             [raster.compiler.ir.contraction-facts :as cf]
+            [raster.compiler.ir.kernel-abi :as kabi]
             [clojure.walk :as walk]
             [clojure.set]
             [raster.compiler.ir.segop :as segop]
@@ -394,6 +395,12 @@
      :source source
      :array-params arr-params
      :scalar-params scl-params
+     :abi (kabi/validate!
+           (vec (concat
+                 (map #(kabi/slot % :input dtype :c-name (ce/c-symbol %) :role :operand) arr-params)
+                 [(kabi/slot out-sym :output dtype :c-name "out" :role :result)]
+                 (map #(kabi/slot % :scalar :int :c-name (ce/c-symbol %) :role :parameter) scl-params)
+                 [(kabi/slot '_nseg :scalar :int :role :bound)])))
      :dtype dtype
      :c-op c-op}))
 
@@ -446,7 +453,14 @@
                  "    out[seg] = " body-str ";\n"
                  "}\n")]
     {:kernel-name kernel-name :source src :array-params arr-params
-     :scalar-params scl-params :dtype dtype}))
+     :scalar-params scl-params
+     :abi (kabi/validate!
+           (vec (concat
+                 (map #(kabi/slot % :input dtype :c-name (ce/c-symbol %) :role :operand) arr-params)
+                 [(kabi/slot out-sym :output dtype :c-name "out" :role :result)]
+                 (map #(kabi/slot % :scalar :int :c-name (ce/c-symbol %) :role :parameter) scl-params)
+                 [(kabi/slot '_nseg :scalar :int :role :bound)])))
+     :dtype dtype}))
 
 ;; ================================================================
 ;; Block-tiled + __local-staged contraction (BlkRegTiling, block-tile level)
@@ -587,6 +601,13 @@
     {:kernel-name kernel-name
      :source src
      :array-params arr-params
+     :abi (kabi/validate!
+           (vec (concat
+                 (map #(kabi/slot % :input (or (:dtype segred) dtype)
+                                  :c-name (ce/c-symbol %) :role :operand)
+                      arr-params)
+                 [(kabi/slot out-sym :output (or (:dtype segred) dtype)
+                             :c-name "out" :role :result)])))
      :dtype (or (:dtype segred) dtype)
      :block [bm bn bk]
      :micro [tm tn]
@@ -835,6 +856,18 @@
         {:kernel-name kernel-name
          :source source
          :array-params [row-arr col-arr]      ;; [A-slot B-slot] binding order
+         :abi (kabi/validate!
+               (vec (concat
+                     [(kabi/slot row-arr :input :half :c-name "A" :role :operand)
+                      (kabi/slot col-arr :input :half :c-name "B" :role :operand)
+                      (kabi/slot out-sym :output :half :c-name "C" :role :result)
+                      (kabi/slot 'M :scalar :int :role :dimension)
+                      (kabi/slot 'N :scalar :int :role :dimension)
+                      (kabi/slot 'K :scalar :int :role :dimension)]
+                     (for [{:keys [sym dtype] :or {dtype :float}} (:operands epilogue)]
+                       (kabi/slot sym :input dtype :c-name (ce/c-symbol sym) :role :epilogue))
+                     (for [{:keys [sym dtype] :or {dtype :float}} (:scalars epilogue)]
+                       (kabi/slot sym :scalar dtype :c-name (ce/c-symbol sym) :role :epilogue)))))
          :dims [M N L]
          :dtype :half
          :tile tile
@@ -1136,6 +1169,20 @@
                  "}\n")]
     {:kernel-name kernel-name :source src
      :array-params (vec inputs)
+     :abi (kabi/validate!
+           (vec (concat
+                 (for [a inputs]
+                   (kabi/slot a :input dtype :c-name (ce/c-symbol a)
+                              :kernel-dtype (if tz :int dtype)
+                              :role :operand))
+                 (for [{:keys [sym dtype] :or {dtype :float}} lift-ops]
+                   (kabi/slot sym :input dtype :c-name (ce/c-symbol sym) :role :lift))
+                 [(kabi/slot out-sym :output out-dtype :c-name "out" :role :result)]
+                 (for [{:keys [sym dtype] :or {dtype :float}} (:operands epilogue)]
+                   (kabi/slot sym :input dtype :c-name (ce/c-symbol sym) :role :epilogue))
+                 (for [{:keys [sym dtype] :or {dtype :float}} (:scalars epilogue)]
+                   (kabi/slot sym :scalar dtype :c-name (ce/c-symbol sym) :role :epilogue))
+                 [(kabi/slot '_nseg :scalar :int :role :bound)])))
      :lift-operands (mapv :sym lift-ops)
      :epilogue-operands (when ep (mapv :sym (:operands epilogue)))
      :epilogue-scalars (when ep (mapv :sym (:scalars epilogue)))

--- a/src/raster/compiler/ir/kernel_abi.clj
+++ b/src/raster/compiler/ir/kernel_abi.clj
@@ -1,0 +1,51 @@
+(ns raster.compiler.ir.kernel-abi
+  "Ordered, typed kernel argument ABI.
+
+   An ABI is a vector because kernel arguments are positional.  `:name` identifies the
+   compiler value, `:c-name` identifies the emitted parameter, `:kind` controls binding,
+   `:dtype` is the storage dtype, and `:kernel-dtype` is the kernel's view.  The last two
+   deliberately differ for packed inputs (for example byte storage viewed as int32 by dp4a)."
+  (:require [raster.compiler.core.dtype :as dt]))
+
+(def ^:private kinds #{:input :output :scalar})
+
+(defn slot
+  "Construct one ABI slot.  Options: :c-name, :kernel-dtype and :role."
+  [nm kind dtype & {:keys [c-name kernel-dtype role]}]
+  (cond-> {:name nm
+           :c-name (or c-name (name nm))
+           :kind kind
+           :dtype (dt/canon dtype)
+           :kernel-dtype (dt/canon (or kernel-dtype dtype))}
+    role (assoc :role role)))
+
+(defn validate!
+  "Validate an ordered ABI and return it unchanged.  Contraction ABIs have exactly one output."
+  [abi]
+  (when-not (vector? abi)
+    (throw (ex-info "kernel ABI must be a vector (argument order is semantic)" {:abi abi})))
+  (doseq [[i s] (map-indexed vector abi)]
+    (when-not (map? s)
+      (throw (ex-info "kernel ABI slot must be a map" {:index i :slot s :abi abi})))
+    (when-not (contains? kinds (:kind s))
+      (throw (ex-info "kernel ABI slot has an invalid :kind"
+                      {:index i :slot s :allowed kinds})))
+    (doseq [k [:name :c-name :dtype :kernel-dtype]]
+      (when-not (some? (get s k))
+        (throw (ex-info (str "kernel ABI slot is missing " k) {:index i :slot s}))))
+    (doseq [k [:dtype :kernel-dtype]]
+      (when-not (dt/known? (get s k))
+        (throw (ex-info (str "kernel ABI slot has an unknown " k)
+                        {:index i :slot s :dtype (get s k)})))))
+  (when-not (= (count abi) (count (distinct (map :c-name abi))))
+    (throw (ex-info "kernel ABI parameter names must be unique" {:abi abi})))
+  (when-not (= 1 (count (filter #(= :output (:kind %)) abi)))
+    (throw (ex-info "contraction kernel ABI must contain exactly one output" {:abi abi})))
+  abi)
+
+(defn signature-shape
+  "The structural portion checked against emitted C."
+  [abi]
+  (mapv (fn [{:keys [c-name kind]}]
+          {:c-name c-name :pointer? (not= :scalar kind)})
+        (validate! abi)))

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -21,7 +21,8 @@
             [raster.compiler.backend.gpu.segop-opencl :as sco]
             [raster.compiler.backend.gpu.c-emit :as ce]
             [raster.compiler.ir.axis-map :as am]
-            [raster.compiler.ir.contraction-facts :as cf]))
+            [raster.compiler.ir.contraction-facts :as cf]
+            [raster.compiler.ir.kernel-abi :as kabi]))
 
 (defn par-contract-form?
   "Is `form` a (raster.par/contract out free-axes contract-axes body & opts) form?"
@@ -83,14 +84,18 @@
                             param from :reduce-bound and computes its own two-phase launch geometry
                             — so :scalar-args must be EMPTY and :wg/:grid ABSENT.
 
-   Returns the descriptor unchanged when consistent."
-  [{:keys [strategy kernel-name source array-params scalar-args epilogue-operands lift-operands
+   Returns the descriptor with `:arguments`, the compiler values in exact ABI order."
+  [{:keys [strategy kernel-name source array-params scalar-args epilogue-operands lift-operands abi
            epilogue-scalars out-elems wg grid invoke reduce-bound] :as d}]
   (let [params (kernel-signature-params source)
         _ (when (nil? params)
             (throw (ex-info "contract descriptor: no __kernel signature found in source"
                             {:strategy strategy :kernel-name kernel-name})))
         ptr? (fn [p] (str/includes? p "*"))
+        param-shape (mapv (fn [p]
+                            {:c-name (second (re-find #"([A-Za-z_][A-Za-z0-9_]*)\s*$" p))
+                             :pointer? (ptr? p)})
+                          params)
         n-ptr (count (filter ptr? params))
         n-scalar (count (remove ptr? params))
         ;; EXTRA operand arrays are pointer params too, whichever seam declared them: an
@@ -109,6 +114,14 @@
                         1
                         (+ (count scalar-args) (count epilogue-scalars)))]
     (cond
+      (and (not= :reduction invoke) (nil? abi))
+      (throw (ex-info "contract descriptor: the ordered :abi is required"
+                      {:strategy strategy :kernel-name kernel-name}))
+      (and (not= :reduction invoke)
+           (not= param-shape (kabi/signature-shape abi)))
+      (throw (ex-info "contract descriptor: ordered ABI does not match the emitted kernel signature"
+                      {:strategy strategy :kernel-name kernel-name
+                       :signature param-shape :abi (kabi/signature-shape abi)}))
       (not= n-ptr expect-ptr)
       (throw (ex-info (str "contract descriptor: kernel takes " n-ptr " pointer params but the "
                            "descriptor binds " expect-ptr " (" (count array-params) " operands + out"
@@ -145,7 +158,24 @@
       (and (= :reduction invoke) (nil? reduce-bound))
       (throw (ex-info "contract descriptor: :invoke :reduction requires :reduce-bound"
                       {:strategy strategy}))
-      :else d)))
+      :else
+      (if (= :reduction invoke)
+        d
+        (let [remaining-scalars (volatile! (seq scalar-args))
+              arguments
+              (mapv (fn [{:keys [name kind role] :as slot}]
+                      (case kind
+                        (:input :output) name
+                        :scalar
+                        (if (= :epilogue role)
+                          name
+                          (if-let [arg (first @remaining-scalars)]
+                            (do (vswap! remaining-scalars next) (:value arg))
+                            (throw (ex-info "contract descriptor: no value for ABI scalar"
+                                            {:strategy strategy :slot slot
+                                             :scalar-args scalar-args}))))))
+                    abi)]
+          (assoc d :arguments arguments))))))
 
 (declare route-2free-1contract route-quant)
 
@@ -246,6 +276,7 @@
         {:strategy :staged-segred
          :kernel-name (:kernel-name k) :source (:source k)
          :array-params (:array-params k)
+         :abi (:abi k)
          ;; the per-stage scale arrays are EXTRA pointer params — surfaced so a caller binds them
          :lift-operands (:lift-operands k)
          :dtype (:dtype k) :out-dtype (:out-dtype k)
@@ -289,10 +320,10 @@
 
       (zero? n-contract)
       (let [sm (cl/contract-form->segmap contract-form :dtype dtype)
-            {:keys [kernel-name source array-params scalar-params]}
+            {:keys [kernel-name source array-params scalar-params abi]}
             (sco/generate-segmap-nd-kernel sm out-sym :dtype dtype)]
         {:strategy :segmap
-         :kernel-name kernel-name :source source :array-params array-params
+         :kernel-name kernel-name :source source :array-params array-params :abi abi
          :dtype dtype :out-dtype dtype :wg [256 1] :grid [(ceil-div nseg 256) 1]
          :scalar-args (conj (mapv (fn [p] {:type :int :value p}) scalar-params)
                             {:type :int :value nseg})
@@ -310,7 +341,7 @@
       ;; contract-form->segred flattens n≥2 contract axes into one innermost dim.
       :else
       (let [sr (cl/contract-form->segred contract-form :dtype dtype)
-            {:keys [kernel-name source array-params scalar-params]}
+            {:keys [kernel-name source array-params scalar-params abi]}
             (sco/generate-segmented-reduce-kernel sr out-sym :dtype dtype)
             ;; WHY THIS LEAF AND NOT A FASTER ONE. Only meaningful for the 2-free/1-contract shape,
             ;; where a tensorize leaf was actually attempted; for every other shape no faster leaf
@@ -321,7 +352,7 @@
         (cond->
         {:strategy :naive-segred
          :declines (vec declines)
-         :kernel-name kernel-name :source source :array-params array-params
+         :kernel-name kernel-name :source source :array-params array-params :abi abi
          :dtype dtype :out-dtype dtype :wg [256 1] :grid [(ceil-div nseg 256) 1]
          ;; SYMBOLIC axis bounds become int kernel params (the emitter declares them, sorted by
          ;; name); they must be bound BEFORE the trailing count or the launch arity is wrong.
@@ -411,11 +442,13 @@
          :kernel-name (:kernel-name dpas)
          :source (:source dpas)
          :array-params (:array-params dpas)          ; [row col] = [A-slot B-slot]
+         :abi (:abi dpas)
          :dtype :half :out-dtype :half :out-elems (* M N)
          :tile (:tile dpas)                          ; the DERIVED tile actually emitted
          :fused-epilogue (boolean epilogue)
          ;; extra kernel args the epilogue needs, in signature order (after out + the dims)
          :epilogue-operands (:epilogue-operands dpas)
+         :epilogue-scalars (:epilogue-scalars dpas)
          :epilogue-params (:epilogue-params dpas)
          :wg (:workgroup dpas)                       ; derived from that tile
          :grid [(ceil-div N block-n) (ceil-div M block-m)]  ; [gc-n gc-m] (id0=N, id1=M)
@@ -431,6 +464,7 @@
          :kernel-name (:kernel-name rt)
          :source (:source rt)
          :array-params (:array-params rt)            ; sorted-by-name (dims baked in source)
+         :abi (:abi rt)
          :dtype (:dtype rt) :out-dtype (:dtype rt) :out-elems (* M N)
          :wg (:workgroup rt)
          :grid [(ceil-div N bn) (ceil-div M bm)]
@@ -580,6 +614,7 @@
                  (cond-> {:strategy (if tz? :dp4a :quant-naive)
                           :kernel-name (:kernel-name k) :source (:source k)
                           :array-params (:array-params k)
+                          :abi (:abi k)
                           :lift-operands (:lift-operands k)
                           :epilogue-operands (:epilogue-operands k)
                           :epilogue-scalars (:epilogue-scalars k)

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -31,7 +31,8 @@
             AddressLayout]
            [java.lang.invoke MethodHandle]
            [java.nio.file Files Path])
-  (:require [raster.compiler.core.types :as types]))
+  (:require [raster.compiler.core.types :as types]
+            [raster.compiler.ir.kernel-abi :as kabi]))
 
 ;; ================================================================
 ;; Library loading
@@ -1413,7 +1414,16 @@
             :long   (let [s (.allocate ^Arena arena I64)]
                       (.set s I64 0 (long value))
                       (ze-call! (str "zeKernelSetArgumentValue[" idx "]") @h-zeKernelSetArgumentValue
-                                [kernel (int idx) (long 8) s]))))))
+                                [kernel (int idx) (long 8) s]))
+            :half   (let [s (.allocate ^Arena arena ValueLayout/JAVA_SHORT)]
+                      (.set s ValueLayout/JAVA_SHORT 0
+                            (short (Float/floatToFloat16 (float value))))
+                      (ze-call! (str "zeKernelSetArgumentValue[" idx "]") @h-zeKernelSetArgumentValue
+                                [kernel (int idx) (long 2) s]))
+            :byte   (let [s (.allocate ^Arena arena ValueLayout/JAVA_BYTE)]
+                      (.set s ValueLayout/JAVA_BYTE 0 (byte value))
+                      (ze-call! (str "zeKernelSetArgumentValue[" idx "]") @h-zeKernelSetArgumentValue
+                                [kernel (int idx) (long 1) s]))))))
 
     ;; 2D group count
     (let [gc (.allocate arena 12)]
@@ -3231,43 +3241,59 @@
   out))
 
 (defn invoke-registered-contraction!
-  "Pipeline-friendly tensor contraction: launch a routed contraction kernel (the descriptor
-  from contract-route/route-contraction) over host arrays or DeviceBuffers with a 2D grid.
-  This is the resident/host-staging analog of invoke-registered-kernel for the 2-operand
-  contraction shape C[m×n] = Σ_k A[m×k]·B[k×n]. The routing brain already chose DPAS-vs-
-  regtiled and the dtype; this just stages + launches.
+  "Launch a routed contraction by its registered ordered ABI.
 
-  Takes the routed descriptor's values INTACT — no reconstruction from dims (which only worked
-  for the two 2-operand strategies and crashed on the rest). Input sizes come from the arrays
-  themselves (alength), so any operand arity/shape works.
-
-  inputs      : host arrays (double[]/float[]/byte[]) or DeviceBuffers, in :array-params order
-  out         : host array or DeviceBuffer for the result
-  dtype       : OPERAND element type (:half converts operands to f16 for the DPAS/XMX leaf)
-  out-dtype   : RESULT element type (differs from dtype for quant: int8 in, f32 out)
-  out-elems   : number of result elements
-  wg          : [x y] workgroup   grid : [gx gy] group counts
-  scalar-args : the descriptor's :scalar-args, passed straight through to launch-2d!"
-  [^String kernel-name inputs out dtype out-dtype out-elems wg grid scalar-args]
-  (let [{:keys [kernel-handle]} (ensure-kernel-loaded! kernel-name)
+   `arguments` contains evaluated values in exact ABI order.  The ABI decides which values are
+   buffers or scalars, how host buffers are staged, and the scalar type passed to Level Zero.
+  Packed kernels therefore retain byte storage while declaring a distinct int32 kernel view."
+  [^String kernel-name arguments out-elems wg grid]
+  (let [registered (get @kernel-registry kernel-name)
+        _ (when-not registered
+            (throw (ex-info (str "Kernel not registered: " kernel-name)
+                            {:kernel-name kernel-name :registered (keys @kernel-registry)})))
+        abi (kabi/validate! (:abi registered))
+        _ (when-not (= (count abi) (count arguments))
+            (throw (ex-info "contraction invocation value count does not match registered ABI"
+                            {:kernel-name kernel-name :expected (count abi)
+                             :actual (count arguments) :abi abi})))
+        {:keys [kernel-handle]} (ensure-kernel-loaded! kernel-name)
         out-elems (long out-elems)
-        half? (boolean (#{:half :float16} dtype))
-        esize (long (get dtype-byte-sizes dtype 8))
-        out-half? (boolean (#{:half :float16} out-dtype))
-        out-esize (long (get dtype-byte-sizes out-dtype 8))
-        dev-inputs (mapv (fn [arr idx]
-                           (if (device-buffer? arr)
-                             (:segment ^DeviceBuffer arr)
-                             (stage-operand! kernel-name (keyword (str "c-in-" idx))
-                                             arr (java.lang.reflect.Array/getLength arr) half? esize)))
-                         inputs (range))
-        out-buffer? (device-buffer? out)
-        out-seg (if out-buffer? (:segment ^DeviceBuffer out)
-                    (ensure-seg kernel-name :c-out (* out-elems out-esize)))
-        all-args (vec (concat dev-inputs [out-seg] scalar-args))
+        input-index (volatile! -1)
+        output (volatile! nil)
+        output-seg (volatile! nil)
+        all-args
+        (mapv (fn [{:keys [kind dtype kernel-dtype] :as slot} value]
+                (case kind
+                  :input
+                  (let [idx (vswap! input-index inc)
+                        half? (boolean (#{:half :float16} dtype))
+                        esize (long (get dtype-byte-sizes dtype 8))]
+                    (if (device-buffer? value)
+                      (:segment ^DeviceBuffer value)
+                      (stage-operand! kernel-name (keyword (str "c-in-" idx))
+                                      value (java.lang.reflect.Array/getLength value) half? esize)))
+
+                  :output
+                  (let [half? (boolean (#{:half :float16} dtype))
+                        esize (long (get dtype-byte-sizes dtype 8))
+                        seg (if (device-buffer? value)
+                              (:segment ^DeviceBuffer value)
+                              (ensure-seg kernel-name :c-out (* out-elems esize)))]
+                    (vreset! output value)
+                    (vreset! output-seg [seg half? esize])
+                    seg)
+
+                  :scalar
+                  {:type kernel-dtype :value value}
+
+                  (throw (ex-info "unsupported contraction ABI slot kind"
+                                  {:kernel-name kernel-name :slot slot}))))
+              abi arguments)
+        out @output
+        [out-seg out-half? out-esize] @output-seg
         [gx gy] grid]
     (launch-2d! kernel-handle wg [gx gy] all-args)
-    (when-not out-buffer?
+    (when-not (device-buffer? out)
       (readback-operand! out-seg out out-elems out-half? out-esize))
     out))
 
@@ -3422,4 +3448,3 @@
   (shutdown!)
   (init!)
   nil)
-

--- a/test/raster/compiler/backend/gpu/contract_pipeline_device_test.clj
+++ b/test/raster/compiler/backend/gpu/contract_pipeline_device_test.clj
@@ -35,7 +35,7 @@
    driver path used here is the runtime path production takes for these kernels."
   [dt m k n]
   (let [{:keys [form kernels]} (ocl/opencl-pass (matmul-form m n k) :dtype dt :compile-spirv? false)
-        _ (doseq [kr kernels] (ze/register-kernel! (:kernel-name kr) (select-keys kr [:source :dtype])))
+        _ (doseq [kr kernels] (ze/register-kernel! (:kernel-name kr) (select-keys kr [:source :dtype :abi])))
         f (eval (list 'fn '[A B C] form))
         A (double-array (map #(* 0.1 (- (double (mod % 7)) 3.0)) (range (* m k))))
         B (double-array (map #(* 0.1 (- (double (mod % 5)) 2.0)) (range (* k n))))
@@ -70,7 +70,7 @@
 ;; staged at int8 size (4× undersized).
 (defn- run-form [form dt args-map out-len]
   (let [{:keys [form kernels]} (ocl/opencl-pass form :dtype dt :compile-spirv? false)
-        _ (doseq [kr kernels] (ze/register-kernel! (:kernel-name kr) (select-keys kr [:source :dtype])))
+        _ (doseq [kr kernels] (ze/register-kernel! (:kernel-name kr) (select-keys kr [:source :dtype :abi])))
         syms (vec (keys args-map))
         f (eval (list 'fn (conj syms 'C) form))]
     (apply f (conj (mapv args-map syms) (double-array out-len)))))

--- a/test/raster/compiler/contraction_marker_abi_test.clj
+++ b/test/raster/compiler/contraction_marker_abi_test.clj
@@ -1,12 +1,10 @@
 (ns raster.compiler.contraction-marker-abi-test
-  "The contraction route can describe capabilities the current invocation marker cannot bind.
-
-   Until contraction descriptors and runtime launches share one ordered typed ABI, the compiler
-   must reject those descriptors rather than emit a valid kernel with an under-bound invocation."
+  "The contraction emitter, route, marker, registry and runtime share one ordered typed ABI."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.opencl-pass :as op]
             [raster.compiler.passes.parallel.contract-route :as route]
-            [raster.compiler.passes.parallel.par-fusion :as fusion]))
+            [raster.compiler.passes.parallel.par-fusion :as fusion]
+            [raster.gpu.ze-runtime :as ze]))
 
 (defn- mm [m n k]
   (list 'raster.par/contract 'C [['i m] ['j n]] [['l k]]
@@ -33,18 +31,19 @@
     (catch clojure.lang.ExceptionInfo e
       (ex-data e))))
 
-(deftest fused-epilogue-operands-are-refused-before-an-under-bound-marker-is-emitted
+(deftest fused-epilogue-operands-are-carried-in-the-ordered-marker
   (let [contract (fuse-epilogue
                   (list 'raster.numeric/+ (list 'aget 'C 't)
                         (list 'aget 'bias (list 'mod 't 256))))
-        data (thrown-data #(compile-form contract))]
-    (testing "this is a real routed DPAS descriptor, not a synthetic malformed map"
-      (is (= :dpas (:strategy data))))
-    (testing "the marker would bind [A B] while the kernel signature also requires bias"
-      (is (= :raster/fatal (:reason data)))
-      (is (= :ordered-contraction-kernel-abi (:missing-rule data)))
-      (is (= [:epilogue-operands] (:unsupported-fields data)))
-      (is (= {:epilogue-operands '[bias]} (:unsupported-values data))))))
+        compiled (compile-form contract)
+        kernel (first (:kernels compiled))
+        marker (-> compiled :form second second)]
+    (is (= :dpas (:strategy kernel)))
+    (is (= '[A B out M N K bias] (mapv :name (:abi kernel))))
+    (is (= [:input :input :output :scalar :scalar :scalar :input]
+           (mapv :kind (:abi kernel))))
+    (testing "values appear in exactly the same order as ABI slots"
+      (is (= '[A B out 128 256 64 bias] (nth marker 2))))))
 
 (deftest codegen-only-routing-facts-remain-legal-and-observable
   (let [dp4a '(raster.par/contract C [[i 4] [j 4]] [[l 8]]
@@ -55,12 +54,25 @@
     (testing "tensorization and packing are already baked into source and need no extra launch slot"
       (is (= :dp4a (:strategy kernel)))
       (is (true? (:tensorized kernel)))
-      (is (= :int8x4 (:packed kernel))))
+      (is (= :int8x4 (:packed kernel)))
+      (is (= [:byte :byte] (mapv :dtype (take 2 (:abi kernel)))))
+      (is (= [:int :int] (mapv :kernel-dtype (take 2 (:abi kernel))))))
     (testing "the ordinary two-input descriptor still emits the production marker"
       (is (= 'raster.gpu.ze-runtime/invoke-registered-contraction!
              (-> compiled :form second second first))))))
 
-(deftest every-unexpressed-marker-field-is-fail-loud
+(deftest epilogue-scalars-occupy-their-real-signature-position
+  (let [contract (concat (mm 128 256 64)
+                         [:epilogue {:acc 'acc
+                                     :expr '(raster.numeric/* acc alpha)
+                                     :scalars [{:sym 'alpha :dtype :float}]}])
+        compiled (compile-form contract)
+        kernel (first (:kernels compiled))
+        marker (-> compiled :form second second)]
+    (is (= '[A B C M N K alpha] (mapv :name (:abi kernel))))
+    (is (= '[A B C 128 256 64 alpha] (nth marker 2)))))
+
+(deftest non-argument-pre-steps-remain-fail-loud
   (let [base {:strategy :probe
               :kernel-name "probe_contract"
               :source "__kernel void probe_contract(__global double* A, __global double* C) {}"
@@ -68,14 +80,20 @@
               :dtype :double :out-dtype :double :out-elems 1
               :wg [1 1] :grid [1 1] :scalar-args []}
         contract (mm 1 1 1)]
-    (doseq [[field value] [[:pre-steps [{:op :transpose}]]
-                           [:lift-operands '[scale]]
-                           [:epilogue-operands '[bias]]
-                           [:epilogue-scalars '[alpha]]]]
-      (testing (name field)
-        (let [data (with-redefs [route/route-contraction
-                                 (fn [& _] (assoc base field value))]
-                     (thrown-data #(compile-form contract)))]
-          (is (= :raster/fatal (:reason data)))
-          (is (= [field] (:unsupported-fields data)))
-          (is (= {field value} (:unsupported-values data))))))))
+    (let [value [{:op :transpose}]
+          data (with-redefs [route/route-contraction
+                             (fn [& _] (assoc base :pre-steps value))]
+                 (thrown-data #(compile-form contract)))]
+      (is (= :raster/fatal (:reason data)))
+      (is (= [:pre-steps] (:unsupported-fields data)))
+      (is (= {:pre-steps value} (:unsupported-values data))))))
+
+(deftest runtime-rejects-an-abi-value-count-mismatch-before-touching-the-driver
+  (let [kernel-name (str "abi_count_probe_" (gensym))
+        abi [{:name 'A :c-name "A" :kind :input :dtype :float :kernel-dtype :float}
+             {:name 'C :c-name "C" :kind :output :dtype :float :kernel-dtype :float}]
+        _ (ze/register-kernel! kernel-name {:abi abi})
+        data (thrown-data #(ze/invoke-registered-contraction!
+                            kernel-name [(float-array 1)] 1 [1 1] [1 1]))]
+    (is (= 2 (:expected data)))
+    (is (= 1 (:actual data)))))

--- a/test/raster/compiler/passes/parallel/contract_descriptor_validator_test.clj
+++ b/test/raster/compiler/passes/parallel/contract_descriptor_validator_test.clj
@@ -70,6 +70,9 @@
             (route/validate-descriptor (update good :scalar-args conj {:type :int :value 1}))))
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"scalar params"
             (route/validate-descriptor (assoc good :scalar-args [])))))
+    (testing "the same counts in the wrong order are still an ABI mismatch"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"ordered ABI"
+            (route/validate-descriptor (update good :abi #(vec (reverse %)))))))
     (testing "a missing :out-elems (the invoke sizes the output with it)"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"out-elems"
             (route/validate-descriptor (dissoc good :out-elems)))))
@@ -99,4 +102,10 @@
     (let [d (route/route-contraction (mm 256 512 128) :dtype :half)
           ps (route/kernel-signature-params (:source d))]
       (is (= 3 (count (filter #(clojure.string/includes? % "*") ps))) "A, B, C")
-      (is (= 3 (count (remove #(clojure.string/includes? % "*") ps))) "M, N, K"))))
+      (is (= 3 (count (remove #(clojure.string/includes? % "*") ps))) "M, N, K")))
+  (testing "ABI C names use the emitter's symbol mangling"
+    (let [d (route/route-contraction
+             '(raster.par/contract out-buffer [[row-index 4]] []
+                (aget input-buffer row-index))
+             :dtype :double)]
+      (is (= ["input_buffer" "out" "_nseg"] (mapv :c-name (:abi d)))))))

--- a/test/raster/compiler/passes/parallel/staged_contract_route_test.clj
+++ b/test/raster/compiler/passes/parallel/staged_contract_route_test.clj
@@ -44,6 +44,11 @@
       (is (= (* M N) (:out-elems r)))
       (is (= [256 1] (:wg r)))
       (is (= [{:type :int :value (* M N)}] (:scalar-args r))))
+    (testing "lift buffers are real ABI slots between operands and output"
+      (is (= '[a b da db out _nseg] (mapv :name (:abi r))))
+      (is (= [:input :input :input :input :output :scalar]
+             (mapv :kind (:abi r))))
+      (is (= '[a b da db out 24] (:arguments r))))
     (testing "the emitted kernel really nests one loop per stage"
       (is (= 2 (count (re-seq #"for \(int" (:source r)))))
       (is (re-find #"int acc_1 = 0;" (:source r)) "inner accumulator is int32")


### PR DESCRIPTION
## Summary
- add one ordered typed ABI for production contraction kernels
- validate ABI order and C parameter names against emitted signatures
- carry ABI-ordered values through markers and bind buffers/scalars by ABI at runtime
- support lift buffers and epilogue operands/scalars while retaining fail-loud pre-step refusal
- distinguish storage dtype from packed kernel-view dtype for DP4A

## Verification
- focused contraction ABI/route/runtime suite: 19 tests, 85 assertions, green
- broader contraction/compiler suite: 35 tests, 283 assertions, green
- full suite: 2,094 tests, 32,965 assertions; 2 unrelated hardware-performance failures in raster.gpu.gemm-autotune-test (split-K tuned to 2 / 2.1x versus fixed expectations >=8 / >4x), reproduced in isolation