### PR TITLE
Phase 2: add ordered generic map kernel ABI

### DIFF
--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -9,6 +9,7 @@
    par form vocabulary but produce different target code."
   (:require [raster.compiler.ir.par :as par]
             [raster.compiler.ir.soac]
+            [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.passes.parallel.soac-lower]
             [raster.compiler.backend.gpu.segop-opencl :as segop-cl]
@@ -176,6 +177,34 @@
                        :fallback :none})))
     descriptor))
 
+(defn- emit-map-invocation
+  "Render the compatibility map marker from the emitter-authored ABI and ordered values."
+  [{:keys [kernel-name abi arguments]}]
+  (let [arguments (kabi/validate-arguments! abi arguments)
+        pairs (mapv vector abi arguments)
+        result-pairs (filterv #(= :result (:role (first %))) pairs)
+        bound-pairs (filterv #(= :bound (:role (first %))) pairs)]
+    (when-not (= 1 (count result-pairs))
+      (throw (ex-info "map kernel ABI must identify exactly one :result slot"
+                      {:kernel-name kernel-name :abi abi})))
+    (when-not (= 1 (count bound-pairs))
+      (throw (ex-info "map kernel ABI must identify exactly one :bound slot"
+                      {:kernel-name kernel-name :abi abi})))
+    (let [[_ out] (first result-pairs)
+          [_ bound] (first bound-pairs)
+          inputs (mapv second
+                       (filter (fn [[slot _]]
+                                 (and (not= :scalar (:kind slot))
+                                      (not= :result (:role slot))))
+                               pairs))
+          scalars (mapv second
+                        (filter (fn [[slot _]]
+                                  (and (= :scalar (:kind slot))
+                                       (not= :bound (:role slot))))
+                                pairs))]
+      (list 'raster.gpu.ze-runtime/invoke-registered-kernel
+            kernel-name inputs out scalars bound))))
+
 (defn opencl-pass
   "Pipeline pass: walk S-expression, replace par forms with GPU kernel invocations.
 
@@ -237,23 +266,13 @@
                                                                 :dtype dtype :scalar-types top-scalar-types
                                                                 :array-types (merge top-array-types (:array-types (meta form))))]
                     (let [k (register-kernel! kernel :ze-maps)]
-                      (list 'raster.gpu.ze-runtime/invoke-registered-kernel
-                            (:kernel-name k)
-                            (vec (:array-params k))
-                            out
-                            (vec (:scalar-params k))
-                            bound)))
+                      (emit-map-invocation k)))
                   ;; SegOp failed — use legacy
                   (let [kernel (legacy/generate-par-map-kernel form
                                                                :dtype dtype :device-id device-id
                                                                :scalar-types top-scalar-types)
                         k (register-kernel! kernel :ze-maps)]
-                    (list 'raster.gpu.ze-runtime/invoke-registered-kernel
-                          (:kernel-name k)
-                          (vec (:array-params k))
-                          out
-                          (vec (:scalar-params k))
-                          bound)))))
+                    (emit-map-invocation k)))))
 
             ;; === par/contract — tensor contraction, routed through the DPAS legality gate ===
             ;; The routing brain (contract-route) chooses the hardware-optimal kernel: DPAS/XMX

--- a/src/raster/compiler/backend/gpu/par_opencl.clj
+++ b/src/raster/compiler/backend/gpu/par_opencl.clj
@@ -17,6 +17,7 @@
             [raster.compiler.core.hardware :as chw]
             [raster.compiler.backend.gpu.opencl-codegen :as codegen]
             [raster.compiler.backend.gpu.c-emit :as ce]
+            [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.passes.scalar.soa-lower :as sl]
             [raster.compiler.support.spirv-cache :as spirv-cache]
             [clojure.string :as str]
@@ -57,8 +58,8 @@
 (defn generate-par-map-kernel
   "Generate an OpenCL C kernel from a raster.par/map! form.
 
-  Returns {:kernel-name str :source str :array-params [syms]
-           :scalar-params [syms] :dtype kw}."
+  Returns {:kernel-name str :source str :abi [ordered typed slots]
+           :array-params [syms] :scalar-params [syms] :dtype kw}."
   [form & {:keys [dtype kernel-name-prefix scalar-types]
            :or {dtype :double kernel-name-prefix "par_map"
                 scalar-types {}}}]
@@ -87,17 +88,35 @@
                            ce/*scalar-type* ctype]
                    (ce/emit-expr adapted-body idx (set (map #(symbol (name %)) arr-params))))
         cast-str (if cast (str "(" (name cast) ")(" body-str ")") body-str)
+        scalar-dtype (fn [s]
+                       (case (scl-type s)
+                         "int" :int
+                         "long" :long
+                         "double" :double
+                         "float" :float))
+        abi (kabi/validate!
+             (vec (concat
+                   (map #(kabi/slot % :input dtype :c-name (ce/c-symbol %) :role :operand)
+                        arr-params)
+                   [(kabi/slot out :output dtype :c-name "out" :role :result)]
+                   (map #(kabi/slot % :scalar (scalar-dtype %)
+                                   :c-name (ce/c-symbol %) :role :parameter)
+                        scl-params)
+                   [(kabi/slot '_n_bound :scalar :int :role :bound)])))
         source (str (codegen/extension-pragmas dtype)
                     "__kernel void " kernel-name
                     "(" all-params ") {\n"
                     "    for (int idx = get_global_id(0); idx < _n_bound; idx += get_global_size(0)) {\n"
                     "        out[idx] = " cast-str ";\n"
                     "    }\n"
-                    "}\n")]
+                    "}\n")
+        _ (kabi/validate-source-signature! kernel-name source abi)]
     {:kernel-name kernel-name
      :source source
      :array-params arr-params
      :scalar-params scl-params
+     :abi abi
+     :arguments (vec (concat arr-params [out] scl-params [(:bound info)]))
      :out-param out
      :dtype dtype}))
 

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -50,8 +50,8 @@
    dtype (:dtype segmap), which may differ from the inputs (e.g. a float input
    promoted to double by a double literal).
 
-   Returns {:kernel-name str :source str :array-params [syms]
-            :scalar-params [syms] :dtype kw}."
+   Returns {:kernel-name str :source str :abi [ordered typed slots]
+            :array-params [syms] :scalar-params [syms] :dtype kw}."
   [segmap out-sym & {:keys [dtype kernel-name-prefix scalar-types array-types]
                      :or {dtype :double kernel-name-prefix "par_map"
                           scalar-types {} array-types {}}}]
@@ -125,6 +125,29 @@
                        idx (conj arr-sym-set 'out) "idx" scalar-body-str
                        {:n-bound "_n_bound" :store-name "out"}))
         ;; pragmas cover the output dtype AND every input array's dtype
+        scalar-dtype (fn [s]
+                       (case (scl-type s)
+                         "int" :int
+                         "long" :long
+                         "double" :double
+                         "float" :float))
+        abi (kabi/validate!
+             (vec (concat
+                   (map (fn [s]
+                          (let [written? (contains? written (symbol (name s)))
+                                extra-output? (and written? (not (contains? input-name-set
+                                                                           (symbol (name s)))))]
+                            (kabi/slot s (if extra-output? :output :input) (arr-dtype s)
+                                       :c-name (ce/c-symbol s)
+                                       :role (cond extra-output? :secondary-result
+                                                   written? :inout
+                                                   :else :operand))))
+                        arr-params)
+                   [(kabi/slot out-sym :output out-dtype :c-name "out" :role :result)]
+                   (map #(kabi/slot % :scalar (scalar-dtype %)
+                                   :c-name (ce/c-symbol %) :role :parameter)
+                        scl-params)
+                   [(kabi/slot '_n_bound :scalar :int :role :bound)])))
         source (str (apply codegen/extension-pragmas out-dtype (map arr-dtype arr-params))
                     ;; registry intrinsics this body calls (e.g. rstr_dp4a) must be DEFINED
                     (ce/intrinsic-helper-sources scalar-body-str)
@@ -135,11 +158,14 @@
                         (str "for (int idx = get_global_id(0); idx < _n_bound; idx += get_global_size(0)) {\n"
                              "        " scalar-body-str "\n"
                              "    }"))
-                    "\n}\n")]
+                    "\n}\n")
+        _ (kabi/validate-source-signature! kernel-name source abi)]
     {:kernel-name kernel-name
      :source source
      :array-params arr-params
      :scalar-params scl-params
+     :abi abi
+     :arguments (vec (concat arr-params [out-sym] scl-params [(seg-bound segmap)]))
      ;; array params (by sig name) the kernel WRITES — secondary fused outputs and
      ;; read+write inputs. The staging invoke copies these back to their JVM arrays
      ;; after launch; the resident role-derivation marks written PARAMS :output.

--- a/src/raster/compiler/ir/kernel_abi.clj
+++ b/src/raster/compiler/ir/kernel_abi.clj
@@ -5,7 +5,8 @@
    compiler value, `:c-name` identifies the emitted parameter, `:kind` controls binding,
    `:dtype` is the storage dtype, and `:kernel-dtype` is the kernel's view.  The last two
    deliberately differ for packed inputs (for example byte storage viewed as int32 by dp4a)."
-  (:require [raster.compiler.core.dtype :as dt]))
+  (:require [clojure.string :as str]
+            [raster.compiler.core.dtype :as dt]))
 
 (def ^:private kinds #{:input :output :scalar})
 
@@ -20,7 +21,8 @@
     role (assoc :role role)))
 
 (defn validate!
-  "Validate an ordered ABI and return it unchanged.  Contraction ABIs have exactly one output."
+  "Validate an ordered ABI and return it unchanged.  A kernel has at least one output;
+   multi-output maps represent every independently written result in signature order."
   [abi]
   (when-not (vector? abi)
     (throw (ex-info "kernel ABI must be a vector (argument order is semantic)" {:abi abi})))
@@ -39,9 +41,55 @@
                         {:index i :slot s :dtype (get s k)})))))
   (when-not (= (count abi) (count (distinct (map :c-name abi))))
     (throw (ex-info "kernel ABI parameter names must be unique" {:abi abi})))
-  (when-not (= 1 (count (filter #(= :output (:kind %)) abi)))
-    (throw (ex-info "contraction kernel ABI must contain exactly one output" {:abi abi})))
+  (when-not (some #(= :output (:kind %)) abi)
+    (throw (ex-info "kernel ABI must contain at least one output" {:abi abi})))
   abi)
+
+(defn pointer-slots
+  "Pointer-valued ABI slots, in kernel signature order."
+  [abi]
+  (filterv #(not= :scalar (:kind %)) (validate! abi)))
+
+(defn scalar-slots
+  "Scalar ABI slots, in kernel signature order."
+  [abi]
+  (filterv #(= :scalar (:kind %)) (validate! abi)))
+
+(defn validate-arguments!
+  "Check that `arguments` supplies exactly one value per ordered ABI slot."
+  [abi arguments]
+  (let [abi (validate! abi)]
+    (when-not (vector? arguments)
+      (throw (ex-info "kernel ABI arguments must be a vector (argument order is semantic)"
+                      {:arguments arguments :abi abi})))
+    (when-not (= (count abi) (count arguments))
+      (throw (ex-info "kernel ABI argument count mismatch"
+                      {:expected (count abi) :actual (count arguments) :abi abi})))
+    arguments))
+
+(defn validate-split-binding!
+  "Validate the compatibility binder shape `(pointers, user-scalars, implicit-bound)` against an
+   ordered ABI. Pre-typed scalar maps must also agree with the ABI's kernel view dtype."
+  [abi pointers scalars]
+  (let [pointer-slots (pointer-slots abi)
+        all-scalars (scalar-slots abi)
+        bound-slots (filterv #(= :bound (:role %)) all-scalars)
+        user-slots (filterv #(not= :bound (:role %)) all-scalars)]
+    (when-not (= 1 (count bound-slots))
+      (throw (ex-info "split map binding requires exactly one implicit :bound ABI slot"
+                      {:abi abi :bound-slots bound-slots})))
+    (when-not (= (count pointer-slots) (count pointers))
+      (throw (ex-info "kernel ABI pointer count does not match binding"
+                      {:expected (count pointer-slots) :actual (count pointers) :abi abi})))
+    (when-not (= (count user-slots) (count scalars))
+      (throw (ex-info "kernel ABI scalar count does not match binding"
+                      {:expected (count user-slots) :actual (count scalars) :abi abi})))
+    (doseq [[slot value] (map vector user-slots scalars)
+            :when (map? value)]
+      (when-not (= (:kernel-dtype slot) (:type value))
+        (throw (ex-info "kernel ABI scalar dtype does not match binding"
+                        {:slot slot :expected (:kernel-dtype slot) :actual (:type value)}))))
+    {:pointer-slots pointer-slots :scalar-slots user-slots :bound-slot (first bound-slots)}))
 
 (defn signature-shape
   "The structural portion checked against emitted C."
@@ -49,3 +97,34 @@
   (mapv (fn [{:keys [c-name kind]}]
           {:c-name c-name :pointer? (not= :scalar kind)})
         (validate! abi)))
+
+(defn source-signature-shape
+  "Extract ordered C parameter names and pointer/scalar shape for one OpenCL kernel."
+  [kernel-name source]
+  (let [pattern (re-pattern
+                 (str "(?s)__kernel\\s+void\\s+" (java.util.regex.Pattern/quote kernel-name)
+                      "\\s*\\(([^)]*)\\)"))
+        params (second (re-find pattern source))]
+    (when-not params
+      (throw (ex-info "kernel ABI could not find emitted OpenCL signature"
+                      {:kernel-name kernel-name})))
+    (if (str/blank? params)
+      []
+      (mapv (fn [param]
+              (let [param (str/trim param)
+                    c-name (second (re-find #"([A-Za-z_][A-Za-z0-9_]*)\s*$" param))]
+                (when-not c-name
+                  (throw (ex-info "kernel ABI could not parse emitted OpenCL parameter"
+                                  {:kernel-name kernel-name :parameter param})))
+                {:c-name c-name :pointer? (str/includes? param "*")}))
+            (str/split params #",")))))
+
+(defn validate-source-signature!
+  "Compare emitted OpenCL parameter order/shape with the ABI before registration."
+  [kernel-name source abi]
+  (let [expected (signature-shape abi)
+        actual (source-signature-shape kernel-name source)]
+    (when-not (= expected actual)
+      (throw (ex-info "emitted OpenCL signature does not match kernel ABI"
+                      {:kernel-name kernel-name :expected expected :actual actual :abi abi})))
+    abi))

--- a/src/raster/compiler/ir/kernel_abi.clj
+++ b/src/raster/compiler/ir/kernel_abi.clj
@@ -112,7 +112,10 @@
       []
       (mapv (fn [param]
               (let [param (str/trim param)
-                    c-name (second (re-find #"([A-Za-z_][A-Za-z0-9_]*)\s*$" param))]
+                    ;; Clojure gensyms in emitted kernels may retain Unicode letters (for example
+                    ;; the AD pipeline uses α). Capture the complete final non-whitespace token;
+                    ;; an ASCII-only C-identifier regex silently reduced `y_α_42` to `_42`.
+                    c-name (second (re-find #"([^\s*]+)\s*$" param))]
                 (when-not c-name
                   (throw (ex-info "kernel ABI could not parse emitted OpenCL parameter"
                                   {:kernel-name kernel-name :parameter param})))

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -29,6 +29,7 @@
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
             [raster.compiler.core.hardware :as hw]
             [raster.compiler.core.inference :as inf]
+            [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.pipeline :as pl]
             [raster.core :as rcore]))
 
@@ -400,7 +401,8 @@
 
 (defn- resolve-kernel-bufs
   "Resolve buffer arguments for a kernel from session buffers.
-   sym->buf-key maps kernel param names to session buffer keys."
+   sym->buf-key maps kernel param names to session buffer keys.  When present,
+   the ordered ABI is authoritative and includes a functional map's output."
   [kernel-info bufs sym->buf-key]
   (mapv (fn [sym]
           (let [sym-name (name sym)
@@ -414,7 +416,9 @@
             (or (get bufs k)
                 (throw (ex-info (str "No buffer for kernel param: " sym-name)
                                 {:sym sym :available (keys bufs)})))))
-        (:array-params kernel-info)))
+        (if-let [abi (:abi kernel-info)]
+          (mapv :name (kabi/pointer-slots abi))
+          (:array-params kernel-info))))
 
 ;; ================================================================
 ;; Kernel invocation

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -18,7 +18,8 @@
             Arena FunctionDescriptor Linker Linker$Option
             MemoryLayout MemorySegment SymbolLookup ValueLayout
             AddressLayout]
-           [java.lang.invoke MethodHandle]))
+           [java.lang.invoke MethodHandle])
+  (:require [raster.compiler.ir.kernel-abi :as kabi]))
 
 ;; ================================================================
 ;; Library loading
@@ -1071,7 +1072,9 @@
   ([^String kernel-name arrays scalar-args n]
    (bind-registered-map-void-kernel kernel-name arrays scalar-args n {}))
   ([^String kernel-name arrays scalar-args n opts]
-   (let [{:keys [program workgroup-size dtype]
+   (let [_ (when-let [abi (:abi (get @kernel-registry kernel-name))]
+             (kabi/validate-split-binding! abi arrays scalar-args))
+         {:keys [program workgroup-size dtype]
           :or {workgroup-size 256 dtype :float}} (ensure-kernel-loaded! kernel-name)
          kh (create-kernel-fresh program kernel-name)
          wg (long (get opts :workgroup-size workgroup-size))

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -32,6 +32,7 @@
            [java.lang.invoke MethodHandle]
            [java.nio.file Files Path])
   (:require [raster.compiler.core.types :as types]
+            [raster.compiler.core.dtype :as dt]
             [raster.compiler.ir.kernel-abi :as kabi]))
 
 ;; ================================================================
@@ -772,6 +773,18 @@
 
 (def ^:private dtype-byte-sizes
   {:double 8 :float 4 :float32 4 :int 4 :long 8 :half 2 :float16 2 :byte 1 :int8 1})
+
+(defn- jvm-array-dtype
+  "Canonical storage dtype of a supported JVM primitive array, or nil."
+  [x]
+  (cond
+    (instance? (Class/forName "[D") x) :double
+    (instance? (Class/forName "[F") x) :float
+    (instance? (Class/forName "[I") x) :int
+    (instance? (Class/forName "[J") x) :long
+    (instance? (Class/forName "[S") x) :half
+    (instance? (Class/forName "[B") x) :byte
+    :else nil))
 
 (defn make-buffer
   "Allocate a persistent shared-memory GPU buffer.
@@ -1804,69 +1817,105 @@
         arr))))
 
 (defn invoke-registered-kernel
-  "Pipeline-friendly kernel invocation. Looks up kernel from registry.
-  input-arrays: vector of JVM arrays (double[] or float[]) or DeviceBuffers
+  "Pipeline-friendly map invocation. Looks up the emitter-authored ordered ABI from the registry
+  and stages/binds every pointer and scalar in that order.
+  input-arrays: vector of JVM primitive arrays or DeviceBuffers
   output-array: JVM array or DeviceBuffer to receive results
   scalar-args: vector of scalar values
   n: element count
-  Dtype is read from kernel registry entry (:dtype, default :double)."
+  The split call shape is retained for compiled-code compatibility; it is structurally checked
+  against :abi before the driver is touched."
   [^String kernel-name input-arrays output-array scalar-args n]
-  (let [{:keys [kernel-handle workgroup-size dtype]
-         :or {workgroup-size 256 dtype :double}
-         :as info} (ensure-kernel-loaded! kernel-name)
-        n (long n)
-        dtype-size (long (get dtype-byte-sizes dtype 8))
-        scalar-type (if (= dtype :float) :float :double)
-        n-bytes (* n dtype-size)
-        ;; Copy input arrays to cached shared memory
-        dev-inputs (mapv (fn [arr idx]
-                           (if (device-buffer? arr)
-                             (:segment ^DeviceBuffer arr)
-                             (let [arr-bytes (if (= dtype :float)
-                                               (* (alength ^floats arr) 4)
-                                               (* (alength ^doubles arr) 8))
-                                   seg (ensure-seg kernel-name (keyword (str "input-seg-" idx)) arr-bytes)
-                                   src (MemorySegment/ofArray arr)]
-                               (MemorySegment/copy src 0 seg 0 arr-bytes)
-                               seg)))
-                         input-arrays (range))
-        ;; Output buffer
-        output-is-buffer? (device-buffer? output-array)
-        dev-output (if output-is-buffer?
-                     (:segment ^DeviceBuffer output-array)
-                     (ensure-seg kernel-name :output-seg n-bytes))
-        ;; Build args: inputs, output, scalars, n
-        scalar-kernel-args (mapv (fn [v] {:type scalar-type
-                                          :value (if (= scalar-type :float)
-                                                   (float v) (double v))})
-                                 scalar-args)
-        all-args (vec (concat dev-inputs
-                              [dev-output]
-                              scalar-kernel-args
-                              [{:type :int :value (int n)}]))
+  (let [registered (or (get @kernel-registry kernel-name)
+                       (throw (ex-info (str "Kernel not registered: " kernel-name)
+                                       {:kernel-name kernel-name
+                                        :registered (keys @kernel-registry)})))
+        {:keys [dtype abi array-params scalar-params written-arrays]
+         :or {dtype :double}} registered
+        ;; Old registered/manual map kernels get an equivalent synthetic ABI. New compiler
+        ;; artifacts always carry :abi, so mixed pointer/scalar types are no longer guessed from
+        ;; the output dtype.
+        abi (or abi
+                (let [written (set (map name written-arrays))]
+                  (kabi/validate!
+                   (vec (concat
+                         (map-indexed
+                          (fn [i _]
+                            (let [nm (or (nth array-params i nil) (symbol (str "input" i)))]
+                              (kabi/slot nm :input dtype
+                                         :role (if (contains? written (name nm)) :inout :operand))))
+                          input-arrays)
+                         [(kabi/slot 'out :output dtype :role :result)]
+                         (map-indexed
+                          (fn [i _]
+                            (kabi/slot (or (nth scalar-params i nil) (symbol (str "scalar" i)))
+                                       :scalar dtype :role :parameter))
+                          scalar-args)
+                         [(kabi/slot '_n_bound :scalar :int :role :bound)])))))
+        arguments (vec (concat input-arrays [output-array] scalar-args [n]))
+        _ (kabi/validate-arguments! abi arguments)
+        pairs (mapv vector abi arguments)
+        pointer-count (count (kabi/pointer-slots abi))
+        scalar-user-count (count (remove #(= :bound (:role %)) (kabi/scalar-slots abi)))
+        _ (when-not (= pointer-count (inc (count input-arrays)))
+            (throw (ex-info "map kernel ABI pointer count does not match marker"
+                            {:kernel-name kernel-name :expected pointer-count
+                             :actual (inc (count input-arrays)) :abi abi})))
+        _ (when-not (= scalar-user-count (count scalar-args))
+            (throw (ex-info "map kernel ABI scalar count does not match marker"
+                            {:kernel-name kernel-name :expected scalar-user-count
+                             :actual (count scalar-args) :abi abi})))
+        _ (doseq [[slot value] pairs :when (not= :scalar (:kind slot))]
+            (let [actual (if (device-buffer? value)
+                           (dt/canon (:dtype ^DeviceBuffer value))
+                           (jvm-array-dtype value))]
+              (when-not actual
+                (throw (ex-info "map kernel ABI pointer value is not a supported buffer/array"
+                                {:kernel-name kernel-name :slot slot :value-type (type value)})))
+              (when-not (= (:dtype slot) actual)
+                (throw (ex-info "map kernel ABI storage dtype mismatch"
+                                {:kernel-name kernel-name :slot slot
+                                 :expected (:dtype slot) :actual actual})))))
+        ;; Loading/compilation may touch the native driver. Every ABI check above deliberately
+        ;; runs first, so a malformed marker fails deterministically even on a machine without
+        ;; the target device.
+        {:keys [kernel-handle workgroup-size]
+         :or {workgroup-size 256}} (ensure-kernel-loaded! kernel-name)
+        staged (mapv
+                (fn [idx [slot value]]
+                  (if (= :scalar (:kind slot))
+                    (let [t (:kernel-dtype slot)]
+                      {:arg {:type t
+                             :value (case t
+                                      :int (int value)
+                                      :long (long value)
+                                      :float (float value)
+                                      :double (double value)
+                                      value)}})
+                    (if (device-buffer? value)
+                      {:arg (:segment ^DeviceBuffer value) :value value :slot slot}
+                      (let [host (MemorySegment/ofArray value)
+                            n-bytes (.byteSize host)
+                            seg (ensure-seg kernel-name (keyword (str "abi-arg-" idx)) n-bytes)]
+                        (when (or (= :input (:kind slot)) (= :inout (:role slot)))
+                          (MemorySegment/copy host 0 seg 0 n-bytes))
+                        {:arg seg :value value :host host :n-bytes n-bytes :slot slot}))))
+                (range) pairs)
+        all-args (mapv :arg staged)
+        bound-pair (first (filter #(= :bound (:role (first %))) pairs))
+        _ (when-not bound-pair
+            (throw (ex-info "map kernel ABI has no :bound scalar" {:kernel-name kernel-name :abi abi})))
+        n (long (second bound-pair))
         wg (long (or workgroup-size 256))
         group-count (long (Math/ceil (/ (double n) wg)))]
     (launch! kernel-handle group-count wg all-args)
-    ;; Copy results back
-    (when-not output-is-buffer?
-      (let [dst-seg (MemorySegment/ofArray output-array)]
-        (MemorySegment/copy dev-output 0 dst-seg 0 n-bytes)))
-    ;; Copy back WRITTEN input-position arrays (a horizontally-fused kernel's
-    ;; secondary outputs / read+write buffers, named by the registry's
-    ;; :written-arrays). Only JVM arrays need the copy — device buffers were
-    ;; written in place.
-    (when-let [wa (seq (:written-arrays info))]
-      (let [wnames (set (map name wa))
-            aps (mapv name (:array-params info))]
-        (doseq [[arr seg ^long idx] (map vector input-arrays dev-inputs (range))]
-          (when (and (not (device-buffer? arr))
-                     (< idx (count aps))
-                     (contains? wnames (nth aps idx)))
-            (let [arr-bytes (if (= dtype :float)
-                              (* (alength ^floats arr) 4)
-                              (* (alength ^doubles arr) 8))]
-              (MemorySegment/copy ^MemorySegment seg 0 (MemorySegment/ofArray arr) 0 arr-bytes))))))
-    output-array))
+    ;; ABI output and inout roles are the single source of copy-back truth. DeviceBuffers are
+    ;; already resident and therefore need no host copy.
+    (doseq [{:keys [arg host n-bytes slot]} staged
+            :when (and host (or (= :output (:kind slot)) (= :inout (:role slot))))]
+      (MemorySegment/copy ^MemorySegment arg 0 ^MemorySegment host 0 (long n-bytes)))
+    (or (some (fn [[slot value]] (when (= :result (:role slot)) value)) pairs)
+        output-array)))
 
 (defn invoke-reduction-kernel
   "Pipeline-friendly reduction kernel invocation. Returns scalar double.
@@ -2400,7 +2449,9 @@
   ([^String kernel-name arrays scalar-args n]
    (invoke-registered-map-void-kernel kernel-name arrays scalar-args n {}))
   ([^String kernel-name arrays scalar-args n opts]
-   (let [{:keys [kernel-handle workgroup-size dtype written-arrays array-types]
+   (let [_ (when-let [abi (:abi (get @kernel-registry kernel-name))]
+             (kabi/validate-split-binding! abi arrays scalar-args))
+         {:keys [kernel-handle workgroup-size dtype written-arrays array-types]
           :or {workgroup-size 256 dtype :float}
           :as info} (ensure-kernel-loaded! kernel-name)
          workgroup-size (long (get opts :workgroup-size workgroup-size))
@@ -2477,7 +2528,9 @@
   ([^String kernel-name arrays scalar-args n]
    (bind-registered-map-void-kernel kernel-name arrays scalar-args n {}))
   ([^String kernel-name arrays scalar-args n opts]
-   (let [{:keys [module workgroup-size dtype]
+   (let [_ (when-let [abi (:abi (get @kernel-registry kernel-name))]
+             (kabi/validate-split-binding! abi arrays scalar-args))
+         {:keys [module workgroup-size dtype]
           :or {workgroup-size 256 dtype :float}} (ensure-kernel-loaded! kernel-name)
          ;; CRITICAL: create a DEDICATED kernel handle per binding. Level Zero kernel args are
          ;; mutable state ON the kernel handle, so reusing the registry's shared handle would

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -45,6 +45,9 @@
       (is (not (str/includes? (:source kernel) "extern \"C\"")))
       ;; Check parameter lists
       (is (= 2 (count (:array-params kernel))))
+      (is (= '[a b out _n_bound] (mapv :name (:abi kernel))))
+      (is (= [:input :input :output :scalar] (mapv :kind (:abi kernel))))
+      (is (= '[a b out n] (:arguments kernel)))
       (is (= :double (:dtype kernel))))))
 
 (deftest generate-par-map-kernel-scalar-test
@@ -53,7 +56,9 @@
           kernel (par-opencl/generate-par-map-kernel form)]
       (is (some? kernel))
       (is (str/includes? (:source kernel) "alpha"))
-      (is (= 1 (count (:array-params kernel)))))))
+      (is (= 1 (count (:array-params kernel))))
+      (is (= '[a out alpha _n_bound] (mapv :name (:abi kernel))))
+      (is (= [:double :double :double :int] (mapv :dtype (:abi kernel)))))))
 
 (deftest generate-par-map-kernel-math-test
   (testing "Map with math operations"

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -86,4 +86,21 @@
       (is (re-find #"__global float\* restrict hout2" (:source k)))
       (is (not (re-find #"const float\* restrict hout2" (:source k)))))
     (testing "written via subscript in the body"
-      (is (re-find #"hout2\[" (:source k))))))
+      (is (re-find #"hout2\[" (:source k))))
+    (testing "the ABI preserves secondary-output, primary-output, scalar and bound order"
+      (is (= '[a b d hout2 hout1 _n_bound] (mapv :name (:abi k))))
+      (is (= [:input :input :input :output :output :scalar]
+             (mapv :kind (:abi k))))
+      (is (= '[a b d hout2 hout1 n] (:arguments k))))))
+
+(deftest segmap-abi-preserves-integer-scalar-type
+  (let [form '(raster.par/map! out i n float
+                               (clojure.core/aget a (clojure.core/+ i offset)))
+        s (soac/par-form->soac 'out form 1)
+        segmap (first (lower/lower-map s nil :dtype :float))
+        k (sg/generate-segmap-kernel segmap 'out :dtype :float
+                                     :scalar-types {'offset :int})]
+    (is (= '[a out offset _n_bound] (mapv :name (:abi k))))
+    (is (= [:float :float :int :int] (mapv :dtype (:abi k))))
+    (is (re-find #"int offset" (:source k)))
+    (is (= '[a out offset n] (:arguments k)))))

--- a/test/raster/compiler/kernel_abi_test.clj
+++ b/test/raster/compiler/kernel_abi_test.clj
@@ -27,8 +27,14 @@
   (is (thrown-with-msg?
        clojure.lang.ExceptionInfo #"does not match"
        (kabi/validate-source-signature!
-        "map_k" "__kernel void map_k(__global float* out, __global const float* x, float scale, int _n_bound) {}"
-        map-abi))))
+       "map_k" "__kernel void map_k(__global float* out, __global const float* x, float scale, int _n_bound) {}"
+        map-abi)))
+  (let [unicode-abi [(kabi/slot 'y_α_42 :input :float)
+                     (kabi/slot 'out :output :float :role :result)]]
+    (is (= unicode-abi
+           (kabi/validate-source-signature!
+            "unicode_k" "__kernel void unicode_k(__global const float* y_α_42, __global float* out) {}"
+            unicode-abi)))))
 
 (deftest split-resident-binding-is-checked-against-abi
   (is (= '[x out]

--- a/test/raster/compiler/kernel_abi_test.clj
+++ b/test/raster/compiler/kernel_abi_test.clj
@@ -1,0 +1,82 @@
+(ns raster.compiler.kernel-abi-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.gpu.core]
+            [raster.gpu.ze-runtime :as ze]))
+
+(def map-abi
+  [(kabi/slot 'x :input :float :role :operand)
+   (kabi/slot 'out :output :float :role :result)
+   (kabi/slot 'scale :scalar :float :role :parameter)
+   (kabi/slot '_n_bound :scalar :int :role :bound)])
+
+(deftest generic-abi-allows-ordered-multi-output
+  (let [abi [(kabi/slot 'x :input :float)
+             (kabi/slot 'side :output :float :role :secondary-result)
+             (kabi/slot 'out :output :float :role :result)
+             (kabi/slot '_n_bound :scalar :int :role :bound)]]
+    (is (= abi (kabi/validate! abi)))
+    (is (= '[x side out] (mapv :name (kabi/pointer-slots abi))))
+    (is (= '[_n_bound] (mapv :name (kabi/scalar-slots abi))))))
+
+(deftest emitted-signature-is-checked-structurally
+  (is (= map-abi
+         (kabi/validate-source-signature!
+          "map_k" "__kernel void map_k(__global const float* x, __global float* out, float scale, int _n_bound) {}"
+          map-abi)))
+  (is (thrown-with-msg?
+       clojure.lang.ExceptionInfo #"does not match"
+       (kabi/validate-source-signature!
+        "map_k" "__kernel void map_k(__global float* out, __global const float* x, float scale, int _n_bound) {}"
+        map-abi))))
+
+(deftest split-resident-binding-is-checked-against-abi
+  (is (= '[x out]
+         (mapv :name (:pointer-slots (kabi/validate-split-binding!
+                                     map-abi [:x :out] [{:type :float :value 2.0}])))))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"pointer count"
+                        (kabi/validate-split-binding! map-abi [:x] [{:type :float :value 2.0}])))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"scalar dtype"
+                        (kabi/validate-split-binding! map-abi [:x :out]
+                                                      [{:type :int :value 2}]))))
+
+(deftest session-resolution-consumes-abi-not-legacy-input-list
+  (testing "door C resolves the functional output slot instead of binding only :array-params"
+    (let [resolve-bufs @#'raster.gpu.core/resolve-kernel-bufs]
+      (is (= [:x-buffer :out-buffer]
+             (resolve-bufs {:abi map-abi :array-params '[x]}
+                           {:x :x-buffer :out :out-buffer}
+                           {}))))))
+
+(deftest staging-rejects-marker-abi-mismatch-before-driver-loading
+  (let [kernel-name (str "abi_mismatch_" (gensym))]
+    (ze/register-kernel! kernel-name {:abi map-abi :dtype :float})
+    (try
+      ;; Missing x and scale: validation must fail before ensure-kernel-loaded! can initialize
+      ;; Level Zero or try compiling a source-less registry entry.
+      (let [e (try
+                (ze/invoke-registered-kernel kernel-name [] (float-array 1) [] 1)
+                nil
+                (catch clojure.lang.ExceptionInfo e e))]
+        (is (some? e))
+        (is (= 4 (:expected (ex-data e))))
+        (is (= 2 (:actual (ex-data e)))))
+      (finally
+        ;; Public registration is intentionally global; overwrite with a harmless tombstone so
+        ;; this unique test entry cannot retain native resources (none were created here).
+        (ze/register-kernel! kernel-name {:test-tombstone? true})))))
+
+(deftest staging-rejects-pointer-dtype-mismatch-before-driver-loading
+  (let [kernel-name (str "abi_dtype_mismatch_" (gensym))]
+    (ze/register-kernel! kernel-name {:abi map-abi :dtype :float})
+    (try
+      (let [e (try
+                (ze/invoke-registered-kernel kernel-name [(double-array 1)]
+                                             (float-array 1) [1.0] 1)
+                nil
+                (catch clojure.lang.ExceptionInfo e e))]
+        (is (some? e))
+        (is (= :float (:expected (ex-data e))))
+        (is (= :double (:actual (ex-data e)))))
+      (finally
+        (ze/register-kernel! kernel-name {:test-tombstone? true})))))


### PR DESCRIPTION
## Outcome

Generic SegMap and its legacy fallback now carry the same ordered typed kernel ABI already used by contractions. Emission, source verification, marker construction, staging, and resident binding all consume that artifact.

## Correctness changes

- Emit ordered input/output/scalar/bound slots, including secondary outputs and inout buffers.
- Compare emitted OpenCL parameter names/order and pointer shape with the ABI before registration.
- Derive the compatibility map marker from ABI-ordered values instead of rebuilding positional lists.
- Validate Level Zero and OpenCL resident pointer/scalar bindings before native driver work.
- Make door C resolve ABI pointer slots, including the functional `out` slot omitted by legacy `:array-params`.
- Stage mixed pointer dtypes and encode scalars from `:kernel-dtype`.

The last item fixes a latent wrong-answer bug: integer map index/shape scalars were previously encoded as output-dtype float/double bits.

## Scope

This advances, but does not close, Increment 2. Reduction, map-void, specialized conventions, and door-B contraction extraction remain separate bounded migrations. Layout pre-steps remain explicitly refused because they require scheduling another operation rather than binding another argument.

## Verification

- Focused cold gate: 40 tests, 132 assertions, green.
- Includes emitter/source/marker, resident extraction, door-C resolution, Level Zero staging, and OpenCL/Level Zero session neighbors.
- Production JAR build passes.
- Hardware-gated neighbors took their documented skip path because this run found no usable Level Zero/OpenCL device.