### PR TITLE
Phase 2: bind contractions as resident ordered-ABI steps

### DIFF
--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -28,6 +28,7 @@
             [raster.compiler.passes.scalar.normalize :as normalize]
             [raster.compiler.passes.scalar.rewalk :as rewalk]
             [raster.compiler.ir.par :as par]
+            [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.backend.jvm.par-simd :as par-simd]
             [raster.compiler.backend.wasm.emit :as wasm-emit]
             [raster.compiler.backend.intrinsics :as ix]
@@ -1176,6 +1177,7 @@
   '#{raster.gpu.ze-runtime/invoke-registered-map-void-kernel
      raster.gpu.ze-runtime/invoke-registered-kernel
      raster.gpu.ze-runtime/invoke-reduction-kernel
+     raster.gpu.ze-runtime/invoke-registered-contraction!
      raster.gpu.ze-runtime/invoke-registered-scatter-kernel})
 
 (def ^:private gpu-array-alloc-heads
@@ -1310,7 +1312,8 @@
   ;; the emitter changed shape — extra operands would be SILENTLY DROPPED (the store-drop /
   ;; alpha-beta bug family) and fewer would bind nil into a size/scalar slot. Each arm returns
   ;; nil on an unexpected arity so the caller rejects it BY NAME (:unparseable-kernel-invoke)
-  ;; instead of miscompiling. Emit-site arities: map-void=5, map=6, scatter=6|7, reduce=4|5.
+  ;; instead of miscompiling. Emit-site arities: map-void=5, map=6, contraction=6,
+  ;; scatter=6|7, reduce=4|5.
   (let [head (first expr)
         argc (count expr)]
     (cond
@@ -1324,6 +1327,15 @@
         (let [[_ kname inputs out scalars n] expr]
           {:kernel-name kname :arrays (conj (vec inputs) out) :scalars (vec scalars) :n-expr n
            :convention :map :returns sym}))
+      (= head 'raster.gpu.ze-runtime/invoke-registered-contraction!)
+      ;; The marker carries VALUES in exact emitter-authored ABI order.  Do not split or reorder
+      ;; them here: packed inputs and epilogue operands/scalars can interleave by signature.
+      (when (= 6 argc)
+        (let [[_ kname arguments out-elems wg grid] expr]
+          (when (and (vector? arguments) (vector? wg) (= 2 (count wg))
+                     (vector? grid) (= 2 (count grid)))
+            {:kernel-name kname :arguments arguments :out-elems-expr out-elems
+             :wg-exprs wg :grid-exprs grid :convention :contract :returns sym})))
       (= head 'raster.gpu.ze-runtime/invoke-registered-scatter-kernel)
       ;; (invoke-registered-scatter-kernel kname out src index n [stride]). out is the
       ;; accumulator buffer (a zeros-like intermediate), written in-place via atomic +=.
@@ -1400,7 +1412,8 @@
    `{::non-resident {:why <kw> :sym <sym> :form <expr>}}` naming the FIRST binding that defeated
    straight-line extraction — so the caller can fail loud with an actionable message instead of a
    bare nil (the silent-empty-graph footgun)."
-  [form]
+  ([form] (extract-gpu-program form nil))
+  ([form kernel-info-fn]
   (if-not (and (seq? form) (#{'let* 'let} (first form)))
     {::non-resident {:why :not-a-let-form :form (when (seq? form) (first form))}}
     (let [bindings (partition 2 (second form))
@@ -1454,8 +1467,17 @@
                   ;; that reads the binding sym (e.g. the primary of a horizontally-fused
                   ;; multi-output map, whose out is a fusion-materialized buffer) must
                   ;; resolve to the REAL resident buffer at bind time.
-                  (when (= :map (:convention s))
-                    (let [out (last (:arrays s))]
+                  (when (#{:map :contract} (:convention s))
+                    (let [out (if (= :map (:convention s))
+                                (last (:arrays s))
+                                (when kernel-info-fn
+                                  (let [abi (:abi (kernel-info-fn (:kernel-name s)))
+                                        result-indexes (keep-indexed
+                                                        (fn [i slot]
+                                                          (when (= :result (:role slot)) i))
+                                                        abi)]
+                                    (when (= 1 (count result-indexes))
+                                      (nth (:arguments s) (first result-indexes))))))]
                       (when (and (symbol? out) (not= sym out))
                         (vswap! aliases assoc sym out)))))
               (reject! :unparseable-kernel-invoke sym expr))
@@ -1500,7 +1522,7 @@
         (cond
           (not @ok)      {::non-resident @reason}
           (empty? @steps) {::non-resident {:why :no-kernel-steps}}
-          :else {:allocs @allocs :steps @steps :scalar-lets @scalar-lets :result body})))))
+          :else {:allocs @allocs :steps @steps :scalar-lets @scalar-lets :result body}))))))
 
 (defn- strip-meta
   "Drop a symbol's metadata — the walker stamps :tag, and a primitive-initialized local can't
@@ -1556,8 +1578,10 @@
       :array-params [a out]         ; array params (resident buffers, up/downloaded)
       :scalar-params [n]
       :allocs [{:sym b :size-fn (fn [args] int)}]   ; intermediate scratch buffers
-      :steps  [{:kernel-name str :arrays [syms] :n-fn (fn [args] int)
-                :scalar-fns [(fn [args] v) ...] :convention :map-void|:map :phase kw}]
+      :steps  [{:kernel-name str :convention :map|:contract|:reduce|... :phase kw
+                ;; maps carry split :arrays/:scalar-specs/:n-fn; contractions carry
+                ;; ordered :argument-specs plus :wg-fns/:grid-fns geometry
+                ...}]
       :result-sym sym}
 
    :on-non-resident controls what happens when the fused IR is NOT a straight-line resident
@@ -1686,7 +1710,11 @@
                          "Bind `((value+grad #'f) args…)` directly to a let symbol at the deftm's "
                          "top level and read `(nth vg k)` from there.")
                     {:fn f-var :vg-form vg})))
-        extracted (extract-gpu-program form)
+        runtime-ns (if (and device-id (.startsWith (name device-id) "ocl"))
+                     'raster.gpu.ocl-runtime
+                     'raster.gpu.ze-runtime)
+        reg-entry (requiring-resolve (symbol (str runtime-ns) "kernel-registry-entry"))
+        extracted (extract-gpu-program form reg-entry)
         prog (if-let [nr (::non-resident extracted)]
                (if (= on-non-resident :throw)
                  (throw (ex-info
@@ -1709,15 +1737,37 @@
         ;; calls to :constant (weights — uploaded once at bind) and persistent written state to
         ;; :state (KV cache — never downloaded): that cross-call axis isn't a single-program
         ;; property (escape analysis can't see it), so it's declared, not derived.
-        reg-entry (when prog (requiring-resolve 'raster.gpu.ze-runtime/kernel-registry-entry))
         written-params (when prog
                          (reduce (fn [acc s]
                                    (if (= :gemm (:convention s))
                                      ;; a GEMM writes its C (out-buf) in place
                                      (conj acc (symbol (name (:out-buf s))))
                                      (let [ki (reg-entry (:kernel-name s))]
-                                       (into acc (map (comp symbol name) (:written-arrays ki))))))
+                                       (into acc
+                                             (map (comp symbol name)
+                                                  (if-let [abi (:abi ki)]
+                                                    (map :name
+                                                         (filter #(or (= :output (:kind %))
+                                                                      (= :inout (:role %)))
+                                                                 (kabi/pointer-slots abi)))
+                                                    (:written-arrays ki)))))))
                                  #{} (:steps prog)))
+        ;; Scratch allocations are not necessarily the program-wide FP dtype. Ordered ABIs can
+        ;; produce half, byte or int buffers (tensorized/quant contractions and mixed pipelines),
+        ;; so carry the producing output slot's STORAGE dtype into the residency allocator.
+        buffer-dtypes (when prog
+                        (reduce (fn [m s]
+                                  (if (= :gemm (:convention s))
+                                    (assoc m (:C s) effective-dtype)
+                                    (if-let [abi (:abi (reg-entry (:kernel-name s)))]
+                                      (reduce (fn [m slot]
+                                                (if (or (= :output (:kind slot))
+                                                        (= :inout (:role slot)))
+                                                  (assoc m (:name slot) (:dtype slot))
+                                                  m))
+                                              m (kabi/pointer-slots abi))
+                                      m)))
+                                {} (:steps prog)))
         array-roles (when prog
                       (into {} (map (fn [p] [p (if (contains? written-params p) :output :input)])
                                     array-params)))]
@@ -1730,10 +1780,12 @@
        :array-roles array-roles
        :scalar-params scalar-params
        :allocs (mapv (fn [{:keys [sym size-expr]}]
-                       {:sym sym :size-fn (expr->arg-fn all-params scalar-lets size-expr)})
+                       {:sym sym :dtype (get buffer-dtypes sym effective-dtype)
+                        :size-fn (expr->arg-fn all-params scalar-lets size-expr)})
                      (:allocs prog))
        :steps (mapv (fn [i step]
-                      (if (= :gemm (:convention step))
+                      (cond
+                        (= :gemm (:convention step))
                         ;; GEMM: carries the A/B/C buffer syms + m/n/k size closures (BLAS arg
                         ;; order is A B C m k n → keep m/n/k separate). bind-program! expands this
                         ;; into [convert A→f16][convert B→f16][(transpose)][fp16 XMX gemm → f32 C].
@@ -1744,6 +1796,36 @@
                          :n-fn (expr->arg-fn all-params scalar-lets (:n-expr step))
                          :k-fn (expr->arg-fn all-params scalar-lets (:k-expr step))
                          :phase (keyword (str "gpu-step-" i))}
+
+                        (= :contract (:convention step))
+                        (let [{:keys [kernel-name arguments out-elems-expr wg-exprs grid-exprs]} step
+                              abi (some-> (reg-entry kernel-name) :abi kabi/validate!)
+                              _ (when-not abi
+                                  (throw (ex-info "resident contraction kernel has no registered ordered ABI"
+                                                  {:kernel-name kernel-name})))
+                              _ (kabi/validate-arguments! abi arguments)
+                              result-slots (filterv #(= :result (:role %)) abi)
+                              _ (when-not (= 1 (count result-slots))
+                                  (throw (ex-info "resident contraction ABI must identify exactly one :result slot"
+                                                  {:kernel-name kernel-name :abi abi
+                                                   :result-slots result-slots})))]
+                          {:convention :contract
+                           :kernel-name kernel-name
+                           :abi abi
+                           :argument-specs
+                           (mapv (fn [slot value]
+                                   (if (= :scalar (:kind slot))
+                                     {:slot slot :kind :scalar :type (:kernel-dtype slot)
+                                      :value-fn (expr->arg-fn all-params scalar-lets value)}
+                                     {:slot slot :kind (:kind slot) :role (:role slot)
+                                      :dtype (:dtype slot) :sym value}))
+                                 abi arguments)
+                           :out-elems-fn (expr->arg-fn all-params scalar-lets out-elems-expr)
+                           :wg-fns (mapv #(expr->arg-fn all-params scalar-lets %) wg-exprs)
+                           :grid-fns (mapv #(expr->arg-fn all-params scalar-lets %) grid-exprs)
+                           :phase (keyword (str "gpu-step-" i))})
+
+                        :else
                         (let [{:keys [kernel-name arrays scalars n-expr convention output accumulator]} step]
                           {:kernel-name kernel-name
                            :arrays arrays

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -1046,7 +1046,7 @@
          arr-dtype (fn [arr]
                      (condp instance? arr
                        (Class/forName "[B") :byte
-                       (Class/forName "[S") :short
+                       (Class/forName "[S") :half
                        (Class/forName "[I") :int
                        (Class/forName "[J") :long
                        (Class/forName "[F") :float
@@ -1089,13 +1089,16 @@
                                                        [adt (nel arr) arr]
                                                        (str "param " p)))))
                            array-params)
-         alloc-specs (into {} (keep (fn [{:keys [sym size-fn]}]
-                                      (let [n (long (size-fn args))]
-                                        (reuse-or-spec (alloc->key sym) dt n [dt n nil]
+         alloc-specs (into {} (keep (fn [{:keys [sym size-fn dtype]}]
+                                      (let [n (long (size-fn args))
+                                            alloc-dtype (or dtype dt)]
+                                        (reuse-or-spec (alloc->key sym) alloc-dtype n
+                                                       [alloc-dtype n nil]
                                                        (str "scratch " sym)))))
                            allocs)
          info-fn   (rt-resolve device-id "kernel-registry-entry")
          bind-fn   (rt-resolve device-id "bind-registered-map-void-kernel")
+         contract-fn (rt-resolve device-id "bind-registered-contraction!")
          gemm-fn   (rt-resolve device-id "bind-registered-gemm!")
          conv-fn   (rt-resolve device-id "bind-registered-convert!")
          trans-fn  (rt-resolve device-id "bind-registered-transpose!")
@@ -1229,6 +1232,26 @@
                                        scalar-specs)]
                      [(assoc (bind-fn kernel-name buf-vec scalars (long (n-fn args)))
                              :phase (:phase step))]))
+               ;; Routed contraction: preserve the emitter-authored ABI order all the way into
+               ;; the backend binder. Pointer slots resolve to resident buffers; scalar slots
+               ;; retain their declared kernel view dtype (not the program/output dtype). The
+               ;; 2-D workgroup and grid expressions are evaluated once at bind and baked into
+               ;; the replay graph.
+               :contract
+               (do (or (info-fn kernel-name)
+                       (throw (ex-info (str "Program kernel not registered: " kernel-name)
+                                       {:kernel kernel-name})))
+                   (let [ordered-args
+                         (mapv (fn [{:keys [kind sym type value-fn]}]
+                                 (if (= :scalar kind)
+                                   {:type type :value (value-fn args)}
+                                   (buf-of sym kernel-name)))
+                               (:argument-specs step))
+                         out-elems (long ((:out-elems-fn step) args))
+                         wg (mapv (fn [f] (long (f args))) (:wg-fns step))
+                         grid (mapv (fn [f] (long (f args))) (:grid-fns step))]
+                     [(assoc (contract-fn kernel-name ordered-args out-elems wg grid)
+                             :phase (:phase step))]))
                ;; scatter-add: out[index[e]*stride+d] += src[e*stride+d]. Expands to TWO bound
                ;; kernels — a zero-fill of the accumulator, then the atomic-add scatter — so the
                ;; recorded graph re-zeroes `out` each replay (zeros-like semantics) and fans
@@ -1283,7 +1306,8 @@
                  [(assoc (bind-fn kernel-name array-bufs scalars (long (n-fn args)) {:group-count 1})
                          :phase (:phase step))])
                (throw (ex-info (str "bind-program! cannot bind a " convention " step — only "
-                                    ":map / :map-void / :reduce / :gemm / :scatter are wired on the resident path")
+                                    ":map / :map-void / :contract / :reduce / :gemm / :scatter "
+                                    "are wired on the resident path")
                                {:convention convention :kernel kernel-name}))))
            bounds (vec (mapcat step->bounds steps))
            ;; CONSTANT PROLOGUE: the f16 conversions/transposes of :constant GEMM operands run

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -19,7 +19,8 @@
             MemoryLayout MemorySegment SymbolLookup ValueLayout
             AddressLayout]
            [java.lang.invoke MethodHandle])
-  (:require [raster.compiler.ir.kernel-abi :as kabi]))
+  (:require [raster.compiler.core.dtype :as dt]
+            [raster.compiler.ir.kernel-abi :as kabi]))
 
 ;; ================================================================
 ;; Library loading
@@ -558,6 +559,10 @@
                 (MemorySegment/copy (:segment buf) ValueLayout/JAVA_DOUBLE 0
                                     arr 0 (int n))
                 arr)
+      (:float16 :half) (let [arr (short-array n)]
+                         (MemorySegment/copy (:segment buf) ValueLayout/JAVA_SHORT 0
+                                             arr 0 (int n))
+                         arr)
       (:byte :int8) (let [arr (byte-array n)]
                       (MemorySegment/copy (:segment buf) ValueLayout/JAVA_BYTE 0
                                           arr 0 (int n))
@@ -746,6 +751,15 @@
                   (.set seg F64 0 (double value))
                   (cl-call! "clSetKernelArg" @h-clSetKernelArg
                             [kernel (int arg-idx) (long 8) seg]))
+        :half   (let [seg (.allocate arena ValueLayout/JAVA_SHORT)]
+                  (.set seg ValueLayout/JAVA_SHORT 0
+                        (short (Float/floatToFloat16 (float value))))
+                  (cl-call! "clSetKernelArg" @h-clSetKernelArg
+                            [kernel (int arg-idx) (long 2) seg]))
+        :byte   (let [seg (.allocate arena ValueLayout/JAVA_BYTE)]
+                  (.set seg ValueLayout/JAVA_BYTE 0 (byte value))
+                  (cl-call! "clSetKernelArg" @h-clSetKernelArg
+                            [kernel (int arg-idx) (long 1) seg]))
         (throw (ex-info (str "Unknown scalar type: " type) {:type type})))
       (finally (.close arena)))))
 
@@ -1095,17 +1109,79 @@
       :kernel-name kernel-name
       :async? (boolean (get opts :async?))})))
 
+(defn bind-registered-contraction!
+  "Pre-bind a routed contraction over resident OclBuffers in exact ordered ABI position.
+  The returned prepared launch carries vector workgroup/group-count geometry; the OpenCL graph
+  replay path accepts both these 2-D values and the scalar 1-D values used by map kernels."
+  [^String kernel-name arguments out-elems wg grid]
+  (let [registered (or (get @kernel-registry kernel-name)
+                       (throw (ex-info (str "Kernel not registered: " kernel-name)
+                                       {:kernel-name kernel-name
+                                        :registered (keys @kernel-registry)})))
+        abi (kabi/validate! (:abi registered))
+        arguments (kabi/validate-arguments! abi arguments)
+        _ (when-not (and (vector? wg) (= 2 (count wg))
+                         (every? pos? wg)
+                         (vector? grid) (= 2 (count grid))
+                         (every? pos? grid))
+            (throw (ex-info "resident contraction requires positive 2-D :wg and :grid vectors"
+                            {:kernel-name kernel-name :wg wg :grid grid})))
+        out-elems (long out-elems)
+        _ (when (neg? out-elems)
+            (throw (ex-info "resident contraction :out-elems must be non-negative"
+                            {:kernel-name kernel-name :out-elems out-elems})))
+        _ (doseq [[slot value] (map vector abi arguments)]
+            (if (= :scalar (:kind slot))
+              (when-not (and (map? value) (= (:kernel-dtype slot) (:type value)))
+                (throw (ex-info "contraction ABI scalar binding has the wrong kernel dtype"
+                                {:kernel-name kernel-name :slot slot
+                                 :expected (:kernel-dtype slot)
+                                 :actual (when (map? value) (:type value))})))
+              (do
+                (when-not (or (device-buffer? value) (instance? MemorySegment value))
+                  (throw (ex-info "resident contraction requires OclBuffer/MemorySegment pointer arguments"
+                                  {:kernel-name kernel-name :slot slot :value-type (type value)})))
+                (when (and (device-buffer? value)
+                           (not= (:dtype slot) (dt/canon (:dtype ^OclBuffer value))))
+                  (throw (ex-info "contraction ABI storage dtype does not match resident buffer"
+                                  {:kernel-name kernel-name :slot slot
+                                   :expected (:dtype slot)
+                                   :actual (dt/canon (:dtype ^OclBuffer value))})))
+                (when (and (= :output (:kind slot)) (device-buffer? value)
+                           (< (:n-elements ^OclBuffer value) out-elems))
+                  (throw (ex-info "contraction output buffer is smaller than :out-elems"
+                                  {:kernel-name kernel-name :slot slot :out-elems out-elems
+                                   :buffer-elements (:n-elements ^OclBuffer value)}))))))
+        ;; Driver touch starts only after ABI/value/geometry validation.
+        {:keys [program]} (ensure-kernel-loaded! kernel-name)
+        kh (create-kernel-fresh program kernel-name)]
+    (doseq [[idx [slot value]] (map-indexed vector (map vector abi arguments))]
+      (if (= :scalar (:kind slot))
+        (set-kernel-arg-scalar! kh idx value)
+        (set-kernel-arg-buffer! kh idx (device-mem-of value))))
+    {:bound {:kernel kh :wg (mapv long wg)}
+     :group-count (mapv long grid)
+     :kernel-name kernel-name}))
+
 (defn- enqueue-bound!
   "Enqueue one pre-bound kernel (no finish)."
-  [{:keys [^MemorySegment kernel ^long wg]} ^long group-count]
+  [{:keys [^MemorySegment kernel wg]} group-count]
   (let [{:keys [queue]} @state
-        arena (Arena/ofConfined)]
+        arena (Arena/ofConfined)
+        wg (if (vector? wg) wg [(long wg)])
+        group-count (if (vector? group-count) group-count [(long group-count)])
+        work-dim (count wg)]
+    (when-not (= work-dim (count group-count))
+      (throw (ex-info "bound OpenCL workgroup and grid dimensionality differ"
+                      {:workgroup wg :grid group-count})))
     (try
-      (let [g (.allocate ^Arena arena I64) l (.allocate ^Arena arena I64)]
-        (.set g I64 0 (* group-count wg))
-        (.set l I64 0 wg)
+      (let [g (.allocate ^Arena arena (* 8 work-dim))
+            l (.allocate ^Arena arena (* 8 work-dim))]
+        (doseq [i (range work-dim)]
+          (.set g I64 (long (* 8 i)) (* (long (nth group-count i)) (long (nth wg i))))
+          (.set l I64 (long (* 8 i)) (long (nth wg i))))
         (cl-call! "clEnqueueNDRangeKernel" @h-clEnqueueNDRangeKernel
-                  [queue kernel (int 1) MemorySegment/NULL g l
+                  [queue kernel (int work-dim) MemorySegment/NULL g l
                    (int 0) MemorySegment/NULL MemorySegment/NULL]))
       (finally (.close arena)))))
 
@@ -1121,7 +1197,7 @@
   ([prepareds] (record-graph! prepareds {}))
   ([prepareds _opts]
    {:launches (mapv (fn [{:keys [bound group-count]}]
-                      {:bound bound :group-count (long group-count)})
+                      {:bound bound :group-count group-count})
                     prepareds)}))
 
 (defn replay-graph!

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -1556,7 +1556,16 @@
             :long   (let [s (.allocate ^Arena arena I64)]
                       (.set s I64 0 (long value))
                       (ze-call! (str "zeKernelSetArgumentValue[" idx "]") @h-zeKernelSetArgumentValue
-                                [kernel (int idx) (long 8) s]))))))
+                                [kernel (int idx) (long 8) s]))
+            :half   (let [s (.allocate ^Arena arena ValueLayout/JAVA_SHORT)]
+                      (.set s ValueLayout/JAVA_SHORT 0
+                            (short (Float/floatToFloat16 (float value))))
+                      (ze-call! (str "zeKernelSetArgumentValue[" idx "]") @h-zeKernelSetArgumentValue
+                                [kernel (int idx) (long 2) s]))
+            :byte   (let [s (.allocate ^Arena arena ValueLayout/JAVA_BYTE)]
+                      (.set s ValueLayout/JAVA_BYTE 0 (byte value))
+                      (ze-call! (str "zeKernelSetArgumentValue[" idx "]") @h-zeKernelSetArgumentValue
+                                [kernel (int idx) (long 1) s]))))))
     (let [gc-seg (.allocate arena 12)
           cmd (:cmd-list @state)]
       (.set gc-seg I32 8 (int 1))  ;; Z=1
@@ -2568,6 +2577,67 @@
       :group-count group-count
       :kernel-name kernel-name
       :async? async?})))
+
+(defn bind-registered-contraction!
+  "Pre-bind a routed contraction over resident buffers using its ordered typed ABI.
+  `arguments` is in exact kernel-signature order and may interleave pointer and scalar slots.
+  The complete 2-D launch geometry is baked into the returned prepared binding, so command-graph
+  recording must leave :gc-seg untouched (:group-count is nil). All structural/type checks run
+  before kernel loading touches the native driver."
+  [^String kernel-name arguments out-elems wg grid]
+  (let [registered (or (get @kernel-registry kernel-name)
+                       (throw (ex-info (str "Kernel not registered: " kernel-name)
+                                       {:kernel-name kernel-name
+                                        :registered (keys @kernel-registry)})))
+        abi (kabi/validate! (:abi registered))
+        arguments (kabi/validate-arguments! abi arguments)
+        _ (when-not (and (vector? wg) (= 2 (count wg))
+                         (every? pos? wg)
+                         (vector? grid) (= 2 (count grid))
+                         (every? pos? grid))
+            (throw (ex-info "resident contraction requires positive 2-D :wg and :grid vectors"
+                            {:kernel-name kernel-name :wg wg :grid grid})))
+        out-elems (long out-elems)
+        _ (when (neg? out-elems)
+            (throw (ex-info "resident contraction :out-elems must be non-negative"
+                            {:kernel-name kernel-name :out-elems out-elems})))
+        _ (doseq [[slot value] (map vector abi arguments)]
+            (if (= :scalar (:kind slot))
+              (when-not (and (map? value) (= (:kernel-dtype slot) (:type value)))
+                (throw (ex-info "contraction ABI scalar binding has the wrong kernel dtype"
+                                {:kernel-name kernel-name :slot slot
+                                 :expected (:kernel-dtype slot)
+                                 :actual (when (map? value) (:type value))})))
+              (do
+                (when-not (or (device-buffer? value) (instance? MemorySegment value))
+                  (throw (ex-info "resident contraction requires DeviceBuffer/MemorySegment pointer arguments"
+                                  {:kernel-name kernel-name :slot slot :value-type (type value)})))
+                (when (and (device-buffer? value)
+                           (not= (:dtype slot) (dt/canon (:dtype ^DeviceBuffer value))))
+                  (throw (ex-info "contraction ABI storage dtype does not match resident buffer"
+                                  {:kernel-name kernel-name :slot slot
+                                   :expected (:dtype slot)
+                                   :actual (dt/canon (:dtype ^DeviceBuffer value))})))
+                (when (and (= :output (:kind slot)) (device-buffer? value)
+                           (< (:n-elements ^DeviceBuffer value) out-elems))
+                  (throw (ex-info "contraction output buffer is smaller than :out-elems"
+                                  {:kernel-name kernel-name :slot slot :out-elems out-elems
+                                   :buffer-elements (:n-elements ^DeviceBuffer value)}))))))
+        ;; Driver touch starts only after the ordered ABI and resident values are proven valid.
+        {:keys [module]} (ensure-kernel-loaded! kernel-name)
+        kernel-handle (create-kernel-fresh module kernel-name)
+        all-args (mapv (fn [slot value]
+                         (if (= :scalar (:kind slot))
+                           value
+                           (if (device-buffer? value)
+                             (:segment ^DeviceBuffer value)
+                             value)))
+                       abi arguments)
+        bound (bind-kernel-2d! kernel-handle (mapv long wg) all-args)
+        ^MemorySegment gc (:gc-seg bound)]
+    (.set gc I32 0 (int (first grid)))
+    (.set gc I32 4 (int (second grid)))
+    {:bound bound :group-count nil :kernel-name kernel-name}))
 
 (defn launch-registered-bound!
   "Dispatch a kernel pre-bound by bind-registered-map-void-kernel. Synchronous."

--- a/test/raster/compiler/backend/gpu/contract_pipeline_device_test.clj
+++ b/test/raster/compiler/backend/gpu/contract_pipeline_device_test.clj
@@ -5,7 +5,11 @@
    that the SOAC contraction path compiles automatically (not just as a standalone emitter).
    Gated on a real GPU."
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.arrays :as ra]
             [raster.compiler.backend.gpu.opencl-pass :as ocl]
+            [raster.compiler.pipeline :as pipeline]
+            [raster.core :refer [deftm]]
+            [raster.gpu.core :as gpu]
             [raster.gpu.ze-runtime :as ze]))
 
 (def ^:private gpu?
@@ -24,6 +28,34 @@
   (list 'raster.par/contract 'C [['i m] ['j n]] [['l k]]
         (list '* (list 'aget 'A (list '+ (list '* 'i k) 'l))
               (list 'aget 'B (list '+ (list '* 'l n) 'j)))))
+
+(deftm resident-contract-probe
+  [A :- (Array float) B :- (Array float)] :- (Array float)
+  (let [C (ra/alloc-like A 64)]
+    (raster.par/contract C [[i 8] [j 8]] [[l 8]]
+      (clojure.core/*
+       (ra/aget A (clojure.core/+ (clojure.core/* i 8) l))
+       (ra/aget B (clojure.core/+ (clojure.core/* l 8) j))))
+    C))
+
+(deftest par-contract-runs-as-a-resident-compiled-step
+  (if-not @gpu?
+    (println "[skip] resident contract pipeline: no GPU device available")
+    (let [descriptor (pipeline/compile-gpu-program #'resident-contract-probe
+                                                   :ze:0 :dtype :float)
+          A (float-array (map float (range 64)))
+          B (float-array (repeat 64 (float 1.0)))
+          session (gpu/make-session :ze:0)]
+      (try
+        (let [handle (gpu/bind-program! session descriptor [A B])
+              result (get (gpu/run-program! session handle [A B]) 'C)]
+          (is (= [:contract] (mapv :convention (:steps descriptor))))
+          (is (= (vec (mapcat #(repeat 8 (float %))
+                              (map (fn [row] (reduce + (range (* row 8) (* (inc row) 8))))
+                                   (range 8))))
+                 (vec result))))
+        (finally
+          (gpu/close-session! session))))))
 
 (defn- compile+run
   "Run a matmul par/contract form through opencl-pass at `dt`, register the emitted kernel,

--- a/test/raster/compiler/contraction_marker_abi_test.clj
+++ b/test/raster/compiler/contraction_marker_abi_test.clj
@@ -1,10 +1,23 @@
 (ns raster.compiler.contraction-marker-abi-test
   "The contraction emitter, route, marker, registry and runtime share one ordered typed ABI."
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.arrays :as ra]
+            [raster.compiler.pipeline :as pipeline]
             [raster.compiler.backend.gpu.opencl-pass :as op]
             [raster.compiler.passes.parallel.contract-route :as route]
             [raster.compiler.passes.parallel.par-fusion :as fusion]
+            [raster.core :refer [deftm]]
+            [raster.gpu.ocl-runtime :as ocl]
             [raster.gpu.ze-runtime :as ze]))
+
+(deftm resident-contract-descriptor-probe
+  [A :- (Array float) B :- (Array float)] :- (Array float)
+  (let [C (ra/alloc-like A 64)]
+    (raster.par/contract C [[i 8] [j 8]] [[l 8]]
+      (clojure.core/*
+       (ra/aget A (clojure.core/+ (clojure.core/* i 8) l))
+       (ra/aget B (clojure.core/+ (clojure.core/* l 8) j))))
+    C))
 
 (defn- mm [m n k]
   (list 'raster.par/contract 'C [['i m] ['j n]] [['l k]]
@@ -97,3 +110,42 @@
                             kernel-name [(float-array 1)] 1 [1 1] [1 1]))]
     (is (= 2 (:expected data)))
     (is (= 1 (:actual data)))))
+
+(deftest resident-binders-validate-ordered-values-before-touching-a-driver
+  (let [abi [{:name 'A :c-name "A" :kind :input :dtype :float :kernel-dtype :float}
+             {:name 'alpha :c-name "alpha" :kind :scalar :dtype :float :kernel-dtype :float}
+             {:name 'C :c-name "C" :kind :output :dtype :float :kernel-dtype :float :role :result}]
+        raw-seg (java.lang.foreign.MemorySegment/ofArray (float-array 1))]
+    (doseq [[backend register! bind!]
+            [[:ze ze/register-kernel! ze/bind-registered-contraction!]
+             [:ocl ocl/register-kernel! ocl/bind-registered-contraction!]]]
+      (let [kernel-name (str "resident_abi_probe_" (name backend) "_" (gensym))
+            _ (register! kernel-name {:abi abi})
+            pointer-data (thrown-data #(bind! kernel-name
+                                              [(Object.) {:type :float :value 1.0} (Object.)]
+                                              1 [1 1] [1 1]))
+            scalar-data (thrown-data #(bind! kernel-name
+                                             [raw-seg {:type :int :value 1} raw-seg]
+                                             1 [1 1] [1 1]))]
+        (is (= kernel-name (:kernel-name pointer-data)))
+        (is (= :input (get-in pointer-data [:slot :kind])))
+        (is (= Object (:value-type pointer-data)))
+        (is (= 'alpha (get-in scalar-data [:slot :name])))
+        (is (= :float (:expected scalar-data)))
+        (is (= :int (:actual scalar-data)))))))
+
+(deftest compile-gpu-program-extracts-a-real-contraction-as-an-ordered-resident-step
+  (let [descriptor (pipeline/compile-gpu-program #'resident-contract-descriptor-probe
+                                                  :ze:0 :dtype :float)
+        step (first (:steps descriptor))
+        args [(float-array 64) (float-array 64)]]
+    (is (= :contract (:convention step)))
+    (is (= '[A B C] (mapv (comp :name :slot) (:argument-specs step))))
+    (is (= [:input :input :output] (mapv :kind (:argument-specs step))))
+    (is (= 'C (:result-sym descriptor)) "the invoke result aliases its ABI :result buffer")
+    (is (= {'A :input 'B :input} (:array-roles descriptor)))
+    (is (= :float (:dtype (first (:allocs descriptor))))
+        "scratch allocation dtype comes from the contraction output ABI")
+    (is (= 64 (long ((:out-elems-fn step) args))))
+    (is (every? pos? (map #(% args) (:wg-fns step))))
+    (is (every? pos? (map #(% args) (:grid-fns step))))))

--- a/test/raster/compiler/pipeline_extractor_test.clj
+++ b/test/raster/compiler/pipeline_extractor_test.clj
@@ -45,6 +45,29 @@
                              "k" [a b] out0 10)]
                        out))))))
 
+(deftest contraction-arity-and-geometry
+  (testing "a correct ordered-ABI contraction marker extracts without flattening its arguments"
+    (let [r (pipeline/extract-gpu-program
+             '(let* [result (raster.gpu.ze-runtime/invoke-registered-contraction!
+                             "contract_k" [A scale C M N K] (* M N)
+                             [16 16] [(quot (+ N 15) 16) (quot (+ M 15) 16)])]
+                    result))
+          step (first (:steps r))]
+      (is (nil? (nr-key r)))
+      (is (= :contract (:convention step)))
+      (is (= '[A scale C M N K] (:arguments step)))
+      (is (= '[16 16] (:wg-exprs step)))
+      (is (= '[(quot (+ N 15) 16) (quot (+ M 15) 16)] (:grid-exprs step)))))
+  (testing "extra operands and malformed 2-D geometry are rejected by marker name"
+    (is (= :unparseable-kernel-invoke
+           (why '(let* [result (raster.gpu.ze-runtime/invoke-registered-contraction!
+                                "contract_k" [A C] 16 [8 8] [1 1] extra)]
+                       result))))
+    (is (= :unparseable-kernel-invoke
+           (why '(let* [result (raster.gpu.ze-runtime/invoke-registered-contraction!
+                                "contract_k" [A C] 16 [64] [1 1])]
+                       result))))))
+
 (deftest reduce-arity
   (testing "a 5-wide resident reduction and a 4-wide legacy reduction both extract"
     (is (= :reduce (:convention (first (:steps (pipeline/extract-gpu-program

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -21,6 +21,15 @@
 (deftm ocl-session-ax! (All [T] [x :- (Array T) y :- (Array T) a :- T n :- Long] :- Void
   (raster.par/map-void! i n (ra/aset y i (* a (ra/aget x i))))))
 
+(deftm ocl-session-contract
+  [A :- (Array float) B :- (Array float)] :- (Array float)
+  (let [C (ra/alloc-like A 64)]
+    (raster.par/contract C [[i 8] [j 8]] [[l 8]]
+      (clojure.core/*
+       (ra/aget A (clojure.core/+ (clojure.core/* i 8) l))
+       (ra/aget B (clojure.core/+ (clojure.core/* l 8) j))))
+    C))
+
 (deftest ocl-resident-session-roundtrip
   (if-not @ocl-available?
     (println "SKIP ocl-session test (no OpenCL device)")
@@ -45,4 +54,26 @@
           (let [r2 (run-program! s p [x y (float 2.0) n])
                 ^floats yg (get r2 'y)]
             (is (< (Math/abs (- (aget yg 100) 200.0)) 1e-3))))
+        (finally (close-session! s))))))
+
+(deftest ocl-resident-contraction-roundtrip
+  (if-not @ocl-available?
+    (println "SKIP ocl resident contraction (no OpenCL device)")
+    (let [gpu (do (require 'raster.gpu.core) (find-ns 'raster.gpu.core))
+          make-session (ns-resolve gpu 'make-session)
+          bind-program! (ns-resolve gpu 'bind-program!)
+          run-program! (ns-resolve gpu 'run-program!)
+          close-session! (ns-resolve gpu 'close-session!)
+          descriptor (pl/compile-gpu-program #'ocl-session-contract :ocl:0 :dtype :float)
+          A (float-array (map float (range 64)))
+          B (float-array (repeat 64 (float 1.0)))
+          s (make-session :ocl:0)]
+      (try
+        (let [handle (bind-program! s descriptor [A B])
+              result (get (run-program! s handle [A B]) 'C)]
+          (is (= [:contract] (mapv :convention (:steps descriptor))))
+          (is (= (vec (mapcat #(repeat 8 (float %))
+                              (map (fn [row] (reduce + (range (* row 8) (* (inc row) 8))))
+                                   (range 8))))
+                 (vec result))))
         (finally (close-session! s))))))


### PR DESCRIPTION
## Summary

- extract the production contraction marker into door B without splitting or reconstructing its ordered ABI arguments
- compile output size and 2-D workgroup/grid expressions into bind-time closures, alias the marker return to the ABI result, and derive written roles plus scratch storage dtype from ABI slots
- add ordered resident contraction binders for Level Zero and OpenCL; both validate pointer/scalar types before driver loading
- generalize OpenCL resident graph replay from scalar 1-D geometry to fixed 1-D or 2-D geometry

Layout pre-steps remain explicitly refused. Reduction, map-void, and specialized conventions still need bounded ABI migrations before Increment 2 is complete. Precision policy remains the prerequisite for reaching DPAS from a compiled deftm.

## Verification

- clojure -M:test -n raster.compiler.pipeline-extractor-test -n raster.compiler.contraction-marker-abi-test -n raster.compiler.backend.gpu.contract-pipeline-device-test -n raster.gpu.ocl-session-test
  - 17 tests, 75 assertions, green
  - local Arc exercised both Level Zero and OpenCL resident contraction replay numerically
- clojure -M:test -n raster.gpu.artifact-test -n raster.gpu.link-spike-test -n raster.gpu.schedule-test
  - 10 tests, 113 assertions, green
- clojure -T:build jar
  - green

CircleCI has no GPU, so its full-suite result covers the device-free checks; the local Arc runs are the hardware gate.