### PR TITLE
Phase 2: add ordered reduction kernel ABI

### DIFF
--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -205,6 +205,19 @@
       (list 'raster.gpu.ze-runtime/invoke-registered-kernel
             kernel-name inputs out scalars bound))))
 
+(defn- emit-reduction-invocation
+  "Render a SegRed marker as one complete ordered ABI value vector. `result` is the caller-owned
+   resident buffer for reduce-into, or nil for a host-scalar reduction whose staging runtime owns
+   the temporary partial-results buffer. No input/scalar/bound positions are reconstructed here."
+  [{:keys [kernel-name abi arguments]} result]
+  (let [arguments (kabi/validate-arguments! abi arguments)
+        arguments (mapv (fn [slot value]
+                          (if (= :result (:role slot)) result value))
+                        abi arguments)]
+    (kabi/validate-reduction-arguments! abi arguments)
+    (list 'raster.gpu.ze-runtime/invoke-registered-reduction-kernel
+          kernel-name arguments)))
+
 (defn opencl-pass
   "Pipeline pass: walk S-expression, replace par forms with GPU kernel invocations.
 
@@ -311,17 +324,14 @@
                   k (register-kernel! (merge (select-keys r [:c-op :identity-val :array-params
                                                              :out-dtype :strategy :fallback-reason
                                                              :declines :tile :tensorized :packed
-                                                             :fused-epilogue :abi])
+                                                             :fused-epilogue :abi :arguments])
                                              {:kernel-name (:kernel-name r) :source (:source r)
                                               :dtype (:dtype r)})
                                       :ze-contracts)]
               ;; A full reduction (0 free axes) has its own two-phase launch protocol + a
               ;; host-side final combine — emit the reduction invoke, not the 2-D contraction one.
               (if (= :reduction (:invoke r))
-                (list 'raster.gpu.ze-runtime/invoke-reduction-kernel
-                      (:kernel-name k)
-                      (vec (:array-params r))
-                      (:reduce-bound r))
+                (emit-reduction-invocation k nil)
               ;; The marker carries only VALUES in ABI order.  Slot kind, storage dtype and kernel
               ;; view dtype live once in the registered ABI and drive runtime binding.
                 (list 'raster.gpu.ze-runtime/invoke-registered-contraction!
@@ -338,11 +348,11 @@
             (par/par-reduce-into-form? form)
             (let [{:keys [out-buf reduce-form bound]} (par/extract-par-reduce-into-info form)]
               (if-let [segred (par->segred stats reduce-form dtype device-id)]
-                (let [kernel (segop-cl/generate-segred-kernel segred nil :dtype dtype)]
+                (let [kernel (segop-cl/generate-segred-kernel
+                              segred out-buf :dtype dtype :scalar-types top-scalar-types)]
                   (if kernel
                     (let [k (register-kernel! kernel :ze-reduces)]
-                      (list 'raster.gpu.ze-runtime/invoke-reduction-kernel
-                            (:kernel-name k) (vec (:array-params k)) out-buf bound))
+                      (emit-reduction-invocation k out-buf))
                     (let [k (register-kernel!
                              (legacy/generate-par-reduce-kernel reduce-form
                                                                 :dtype dtype :device-id device-id)
@@ -363,13 +373,11 @@
                 (do (swap! stats update :fallback inc)
                     (par/expand-par-reduce form))
                 (if-let [segred (par->segred stats form dtype device-id)]
-                  (let [kernel (segop-cl/generate-segred-kernel segred nil :dtype dtype)]
+                  (let [kernel (segop-cl/generate-segred-kernel
+                                segred nil :dtype dtype :scalar-types top-scalar-types)]
                     (if kernel
                       (let [k (register-kernel! kernel :ze-reduces)]
-                        (list 'raster.gpu.ze-runtime/invoke-reduction-kernel
-                              (:kernel-name k)
-                              (vec (:array-params k))
-                              bound))
+                        (emit-reduction-invocation k nil))
                       ;; SegOp codegen failed — use legacy
                       (let [k (register-kernel!
                                (legacy/generate-par-reduce-kernel form

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -184,10 +184,15 @@
    Phase 1: block-local shared-memory tree reduction
    Phase 2: single-block reduction of partial results
 
-   Returns {:kernel-name str :source str :array-params [syms]
-            :scalar-params [syms] :dtype kw :n-phases int}."
-  [segred out-sym & {:keys [dtype kernel-name-prefix]
-                     :or {dtype :double kernel-name-prefix "par_reduce"}}]
+   Returns {:kernel-name str :source str :abi [ordered typed slots]
+            :arguments [ordered compiler values] :array-params [syms]
+            :scalar-params [syms] :dtype kw :n-phases int}.
+
+   `out-sym` is nil for the host-scalar staging protocol: the ordered :arguments vector then
+   carries nil at the single :result slot, which the runtime replaces with its partial-results
+   buffer.  Resident reduce-into supplies the real output buffer symbol at that same ABI position."
+  [segred out-sym & {:keys [dtype kernel-name-prefix scalar-types]
+                     :or {dtype :double kernel-name-prefix "par_reduce" scalar-types {}}}]
   (let [idx (seg-idx segred)
         bound (seg-bound segred)
         {:keys [acc init lambda]} (:reduce-op segred)
@@ -202,6 +207,15 @@
         ctype (dt/ctype :opencl dtype)
         arr-params (vec (sort-by name (:inputs segred)))
         scl-params (vec (sort-by name (:scalars segred)))
+        int-scalar-syms (set (keep (fn [[k v]] (when (= v :int) (symbol (name k))))
+                                   scalar-types))
+        scl-type (fn [s] (ce/scalar-native-type s scalar-types ctype))
+        scalar-dtype (fn [s]
+                       (case (scl-type s)
+                         "int" :int
+                         "long" :long
+                         "double" :double
+                         "float" :float))
         ;; Detect reduction op from lambda — unwrap let to find op, keep let for elem
         [let-bindings inner-body]
         (if (and (seq? lambda) (contains? #{'let* 'let} (first lambda)))
@@ -251,8 +265,16 @@
                                  " operands — only a binary (op acc elem) combine is modeled;"
                                  " extra operands would be dropped")
                             {:op op-sym :op-args op-args :lambda lambda})))
+        ;; Typed float pipelines cast the accumulator to `(float acc)` while double pipelines
+        ;; use `(double acc)`. Treat both as the accumulator position; recognizing only double
+        ;; made an otherwise-valid float SegRed return nil and fall through to a legacy kernel
+        ;; whose body referenced captured scalars absent from its signature.
         acc-at? (fn [a] (or (= a acc)
-                            (and (seq? a) (= 'double (first a)) (= acc (second a)))))
+                            (and (seq? a)
+                                 (contains? #{'float 'double 'clojure.core/float
+                                              'clojure.core/double}
+                                            (first a))
+                                 (= acc (second a)))))
         [_acc-pos elem-expr-raw]
         (when (>= (count op-args) 2)
           (let [a0 (nth op-args 0) a1 (nth op-args 1)]
@@ -271,7 +293,8 @@
         idx-c-name (ce/c-symbol idx)
         elem-str (when adapted-elem
                    (binding [ce/*emit-config* ce/opencl-config
-                             ce/*scalar-type* ctype]
+                             ce/*scalar-type* ctype
+                             ce/*int-vars* (into ce/*int-vars* int-scalar-syms)]
                      (ce/emit-expr adapted-elem idx (set (map #(symbol (name %)) arr-params)) idx-c-name)))
         ;; Build kernel source
         arr-param-str (str/join ", "
@@ -279,7 +302,7 @@
                                                   (ce/c-symbol s)))
                                      arr-params))
         scl-param-str (str/join ", "
-                                (map (fn [s] (str ctype " " (ce/c-symbol s))) scl-params))
+                                (map (fn [s] (str (scl-type s) " " (ce/c-symbol s))) scl-params))
         ;; Use output param name matching invoke-reduction-kernel expectations
         all-params (str/join ", "
                              (remove empty?
@@ -287,6 +310,16 @@
                                       (str "__global " ctype "* restrict output")
                                       scl-param-str
                                       "int _n_bound"]))
+        result-name (or out-sym 'output)
+        abi (kabi/validate!
+             (vec (concat
+                   (map #(kabi/slot % :input dtype :c-name (ce/c-symbol %) :role :operand)
+                        arr-params)
+                   [(kabi/slot result-name :output dtype :c-name "output" :role :result)]
+                   (map #(kabi/slot % :scalar (scalar-dtype %)
+                                   :c-name (ce/c-symbol %) :role :parameter)
+                        scl-params)
+                   [(kabi/slot '_n_bound :scalar :int :role :bound)])))
         ;; Static shared memory — matches invoke-reduction-kernel (no __local arg)
         source (when elem-str
                  (str (codegen/extension-pragmas dtype)
@@ -310,12 +343,15 @@
                       "        barrier(CLK_LOCAL_MEM_FENCE);\n"
                       "    }\n"
                       "    if (tid == 0) output[get_group_id(0)] = sdata[0];\n"
-                      "}\n"))]
+                      "}\n"))
+        _ (when source (kabi/validate-source-signature! kernel-name source abi))]
     (when source
       {:kernel-name kernel-name
        :source source
        :array-params arr-params
        :scalar-params scl-params
+       :abi abi
+       :arguments (vec (concat arr-params [out-sym] scl-params [(seg-bound segred)]))
        :dtype dtype
        :n-phases 2
        :identity-val identity-val

--- a/src/raster/compiler/ir/kernel_abi.clj
+++ b/src/raster/compiler/ir/kernel_abi.clj
@@ -91,6 +91,35 @@
                         {:slot slot :expected (:kernel-dtype slot) :actual (:type value)}))))
     {:pointer-slots pointer-slots :scalar-slots user-slots :bound-slot (first bound-slots)}))
 
+(defn validate-reduction-arguments!
+  "Validate a complete ordered reduction binding and expose its semantic projections without
+   reconstructing positional conventions.  A reduction owns exactly one pointer-valued :result
+   and exactly one scalar :bound; captured scalars and operands may otherwise be arbitrary ABI
+   slots.  Returns the ordered slot/value pairs plus role-derived projections."
+  [abi arguments]
+  (let [arguments (validate-arguments! abi arguments)
+        pairs (mapv vector abi arguments)
+        result-pairs (filterv (fn [[slot _]] (= :result (:role slot))) pairs)
+        bound-pairs (filterv (fn [[slot _]] (= :bound (:role slot))) pairs)]
+    (when-not (= 1 (count result-pairs))
+      (throw (ex-info "reduction ABI must identify exactly one :result slot"
+                      {:abi abi :result-slots (mapv first result-pairs)})))
+    (when-not (= :output (:kind (ffirst result-pairs)))
+      (throw (ex-info "reduction ABI :result slot must be an output pointer"
+                      {:abi abi :result-slot (ffirst result-pairs)})))
+    (when-not (= 1 (count bound-pairs))
+      (throw (ex-info "reduction ABI must identify exactly one :bound slot"
+                      {:abi abi :bound-slots (mapv first bound-pairs)})))
+    (when-not (= :scalar (:kind (ffirst bound-pairs)))
+      (throw (ex-info "reduction ABI :bound slot must be scalar"
+                      {:abi abi :bound-slot (ffirst bound-pairs)})))
+    {:pairs pairs
+     :pointer-pairs (filterv (fn [[slot _]] (not= :scalar (:kind slot))) pairs)
+     :scalar-pairs (filterv (fn [[slot _]] (and (= :scalar (:kind slot))
+                                                 (not= :bound (:role slot)))) pairs)
+     :result-pair (first result-pairs)
+     :bound-pair (first bound-pairs)}))
+
 (defn signature-shape
   "The structural portion checked against emitted C."
   [abi]

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -80,9 +80,9 @@
 
      default (:invoke nil)  invoke-registered-contraction! binds :scalar-args positionally and
                             launches with :wg/:grid — so all three must be present and match.
-     :invoke :reduction     invoke-reduction-kernel supplies the kernel's single trailing count
-                            param from :reduce-bound and computes its own two-phase launch geometry
-                            — so :scalar-args must be EMPTY and :wg/:grid ABSENT.
+     :invoke :reduction     invoke-registered-reduction-kernel consumes the emitter's complete
+                            ordered ABI (the staging marker replaces only the :result value with
+                            nil) and computes its own two-phase launch geometry; :wg/:grid are absent.
 
    Returns the descriptor with `:arguments`, the compiler values in exact ABI order."
   [{:keys [strategy kernel-name source array-params scalar-args epilogue-operands lift-operands abi
@@ -111,14 +111,13 @@
         ;; signature by epilogue-splice, so a descriptor that omits them under-counts and the
         ;; capability becomes unusable (which is what pushed `:scheme` into a private channel)
         expect-scalar (if (= :reduction invoke)
-                        1
+                        (count (when abi (kabi/scalar-slots abi)))
                         (+ (count scalar-args) (count epilogue-scalars)))]
     (cond
-      (and (not= :reduction invoke) (nil? abi))
+      (nil? abi)
       (throw (ex-info "contract descriptor: the ordered :abi is required"
                       {:strategy strategy :kernel-name kernel-name}))
-      (and (not= :reduction invoke)
-           (not= param-shape (kabi/signature-shape abi)))
+      (not= param-shape (kabi/signature-shape abi))
       (throw (ex-info "contract descriptor: ordered ABI does not match the emitted kernel signature"
                       {:strategy strategy :kernel-name kernel-name
                        :signature param-shape :abi (kabi/signature-shape abi)}))
@@ -135,13 +134,10 @@
       (not= n-scalar expect-scalar)
       (throw (ex-info (str "contract descriptor: kernel takes " n-scalar " scalar params but the "
                            (if (= :reduction invoke)
-                             "reduction invoke supplies 1 (the count, from :reduce-bound)"
+                             (str "ordered reduction ABI supplies " expect-scalar)
                              (str "descriptor supplies " expect-scalar " scalar-args")))
                       {:strategy strategy :kernel-name kernel-name :params params
                        :invoke invoke :scalar-args scalar-args}))
-      (and (= :reduction invoke) (seq scalar-args))
-      (throw (ex-info "contract descriptor: :invoke :reduction must leave :scalar-args empty (the count comes from :reduce-bound)"
-                      {:strategy strategy :scalar-args scalar-args}))
       (nil? out-elems)
       (throw (ex-info "contract descriptor: :out-elems is required (the invoke sizes the output with it)"
                       {:strategy strategy}))
@@ -160,7 +156,7 @@
                       {:strategy strategy}))
       :else
       (if (= :reduction invoke)
-        d
+        (do (kabi/validate-reduction-arguments! abi (:arguments d)) d)
         (let [remaining-scalars (volatile! (seq scalar-args))
               arguments
               (mapv (fn [{:keys [name kind role] :as slot}]
@@ -306,6 +302,7 @@
          :invoke :reduction
          :kernel-name (:kernel-name k) :source (:source k)
          :array-params (:array-params k)
+         :abi (:abi k) :arguments (:arguments k)
          :dtype dtype :out-dtype dtype :out-elems 1
          :n-phases (:n-phases k)
          ;; CARRY THE COMBINE. invoke-reduction-kernel reads :c-op/:identity-val from the kernel

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -1176,6 +1176,7 @@
 (def ^:private gpu-invoke-heads
   '#{raster.gpu.ze-runtime/invoke-registered-map-void-kernel
      raster.gpu.ze-runtime/invoke-registered-kernel
+     raster.gpu.ze-runtime/invoke-registered-reduction-kernel
      raster.gpu.ze-runtime/invoke-reduction-kernel
      raster.gpu.ze-runtime/invoke-registered-contraction!
      raster.gpu.ze-runtime/invoke-registered-scatter-kernel})
@@ -1313,7 +1314,7 @@
   ;; alpha-beta bug family) and fewer would bind nil into a size/scalar slot. Each arm returns
   ;; nil on an unexpected arity so the caller rejects it BY NAME (:unparseable-kernel-invoke)
   ;; instead of miscompiling. Emit-site arities: map-void=5, map=6, contraction=6,
-  ;; scatter=6|7, reduce=4|5.
+  ;; scatter=6|7, ordered-reduce=3, legacy-reduce=4|5.
   (let [head (first expr)
         argc (count expr)]
     (cond
@@ -1355,6 +1356,16 @@
           {:kernel-name kname :arrays [out src index]
            :scalars (if stride [(strip-cast stride)] [])
            :n-expr n :convention :scatter :accumulator out :returns sym}))
+
+      (= head 'raster.gpu.ze-runtime/invoke-registered-reduction-kernel)
+      ;; SegRed carries VALUES in exact emitter-authored ABI order, including its result and
+      ;; bound slots. A nil result is the host-scalar staging protocol and cannot enter a
+      ;; resident graph; descriptor construction rejects it with the registered ABI in hand.
+      (when (= 3 argc)
+        (let [[_ kname arguments] expr]
+          (when (vector? arguments)
+            {:kernel-name kname :arguments arguments
+             :convention :reduce :returns sym})))
 
       (= head 'raster.gpu.ze-runtime/invoke-reduction-kernel)
       ;; 3-arg legacy (host-scalar return, argc 4) vs resident (writes out-buf, stays on
@@ -1460,26 +1471,35 @@
                 (vswap! device-buffers conj sym))
             (and (seq? expr) (symbol? (first expr)) (contains? gpu-invoke-heads (first expr)))
             (if-let [s (parse-gpu-step sym expr)]
-              (do (vswap! steps conj s) (vswap! device-buffers conj sym)
+              (let [ordered-result
+                    (when (and (:arguments s) kernel-info-fn)
+                      (let [abi (:abi (kernel-info-fn (:kernel-name s)))
+                            result-indexes (keep-indexed
+                                            (fn [i slot]
+                                              (when (= :result (:role slot)) i))
+                                            abi)]
+                        (when (= 1 (count result-indexes))
+                          {:value (nth (:arguments s) (first result-indexes))})))]
+                (if (and (= :reduce (:convention s)) ordered-result
+                         (nil? (:value ordered-result)))
+                  ;; The explicit nil :result is the host-scalar staging protocol. It cannot be
+                  ;; recorded into a resident graph, but must remain a clean non-resident fallback
+                  ;; (rather than reaching descriptor construction and throwing there).
+                  (reject! :host-scalar-reduction sym expr)
+                  (do (vswap! steps conj s) (vswap! device-buffers conj sym)
                   ;; A :map step's runtime VALUE is its out buffer (invoke-registered-kernel
                   ;; returns output-array), so the binding sym is a pure alias of the out
                   ;; array. Copy-propagate it like any other array alias — a later step
                   ;; that reads the binding sym (e.g. the primary of a horizontally-fused
                   ;; multi-output map, whose out is a fusion-materialized buffer) must
                   ;; resolve to the REAL resident buffer at bind time.
-                  (when (#{:map :contract} (:convention s))
+                  (when (or (#{:map :contract} (:convention s))
+                            (and (= :reduce (:convention s)) (:arguments s)))
                     (let [out (if (= :map (:convention s))
                                 (last (:arrays s))
-                                (when kernel-info-fn
-                                  (let [abi (:abi (kernel-info-fn (:kernel-name s)))
-                                        result-indexes (keep-indexed
-                                                        (fn [i slot]
-                                                          (when (= :result (:role slot)) i))
-                                                        abi)]
-                                    (when (= 1 (count result-indexes))
-                                      (nth (:arguments s) (first result-indexes))))))]
+                                (:value ordered-result))]
                       (when (and (symbol? out) (not= sym out))
-                        (vswap! aliases assoc sym out)))))
+                        (vswap! aliases assoc sym out)))))))
               (reject! :unparseable-kernel-invoke sym expr))
           ;; devirtualized BLAS GEMM (.invk dgemm*-impl …) → a :gemm step. A non-default
           ;; alpha/beta is NOT representable by the resident GEMM kernels (they compute
@@ -1823,6 +1843,32 @@
                            :out-elems-fn (expr->arg-fn all-params scalar-lets out-elems-expr)
                            :wg-fns (mapv #(expr->arg-fn all-params scalar-lets %) wg-exprs)
                            :grid-fns (mapv #(expr->arg-fn all-params scalar-lets %) grid-exprs)
+                           :phase (keyword (str "gpu-step-" i))})
+
+                        (and (= :reduce (:convention step)) (:arguments step))
+                        (let [{:keys [kernel-name arguments]} step
+                              abi (some-> (reg-entry kernel-name) :abi kabi/validate!)
+                              _ (when-not abi
+                                  (throw (ex-info "resident reduction kernel has no registered ordered ABI"
+                                                  {:kernel-name kernel-name})))
+                              {:keys [result-pair]} (kabi/validate-reduction-arguments! abi arguments)
+                              output (second result-pair)
+                              _ (when-not (symbol? output)
+                                  (throw (ex-info "resident reduction requires a concrete output buffer at the ABI :result slot"
+                                                  {:kernel-name kernel-name :output output
+                                                   :abi abi :arguments arguments})))]
+                          {:convention :reduce
+                           :kernel-name kernel-name
+                           :abi abi
+                           :argument-specs
+                           (mapv (fn [slot value]
+                                   (if (= :scalar (:kind slot))
+                                     {:slot slot :kind :scalar :type (:kernel-dtype slot)
+                                      :value-fn (expr->arg-fn all-params scalar-lets value)}
+                                     {:slot slot :kind (:kind slot) :role (:role slot)
+                                      :dtype (:dtype slot) :sym value}))
+                                 abi arguments)
+                           :output (keyword (name output))
                            :phase (keyword (str "gpu-step-" i))})
 
                         :else

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -689,8 +689,8 @@
    weights/KV per layer and scratch shared, like the decoder's pbk). Does NOT record a graph; the
    caller collects :phase keys and records once.
 
-     :reduce    SegRed sig (inputs…, output, scl…, _n_bound); bind inputs ++ [output], SINGLE
-                workgroup (:group-count 1) so the grid-stride loop writes output[0] device-resident.
+     :reduce    Ordered SegRed ABI values bind through bind-registered-reduction!; legacy/manual
+                descriptors retain the split inputs/output/scalars/bound compatibility path.
      :map       SegMap sig (inputs…, out, scl…, _n_bound); the output is a SEPARATE param not in the
                 registry :array-params, so bind the step's full :arrays (inputs ++ [out]).
      :map-void  output is an in-place array among :array-params; bind by name via prepare!."
@@ -714,8 +714,17 @@
           bind-fn (rt-resolve device-id "bind-registered-map-void-kernel")]
       (case convention
         :reduce
-        (let [array-bufs (conj (mapv resolve-buf (:array-params ki)) (resolve-buf output))
-              prepared (bind-fn kernel-name array-bufs scalars (long (n-fn args)) {:group-count 1})]
+        (let [prepared
+              (if-let [specs (:argument-specs step)]
+                (let [ordered-args
+                      (mapv (fn [{:keys [kind sym type value-fn]}]
+                              (if (= :scalar kind)
+                                {:type type :value (value-fn args)}
+                                (resolve-buf sym)))
+                            specs)]
+                  ((rt-resolve device-id "bind-registered-reduction!") kernel-name ordered-args))
+                (let [array-bufs (conj (mapv resolve-buf (:array-params ki)) (resolve-buf output))]
+                  (bind-fn kernel-name array-bufs scalars (long (n-fn args)) {:group-count 1})))]
           (swap! sess assoc-in [:prepared phase] prepared))
 
         :map
@@ -1099,6 +1108,7 @@
          info-fn   (rt-resolve device-id "kernel-registry-entry")
          bind-fn   (rt-resolve device-id "bind-registered-map-void-kernel")
          contract-fn (rt-resolve device-id "bind-registered-contraction!")
+         reduction-fn (rt-resolve device-id "bind-registered-reduction!")
          gemm-fn   (rt-resolve device-id "bind-registered-gemm!")
          conv-fn   (rt-resolve device-id "bind-registered-convert!")
          trans-fn  (rt-resolve device-id "bind-registered-transpose!")
@@ -1296,15 +1306,27 @@
                ;; the kernel's grid-stride loop covers all n and writes output[0] into its
                ;; resident 1-elem buffer (mirrors bind-step!'s :reduce; the #42 leftover).
                :reduce
-               (let [ki (or (info-fn kernel-name)
-                            (throw (ex-info (str "Program kernel not registered: " kernel-name)
-                                            {:kernel kernel-name})))
-                     array-bufs (conj (mapv #(buf-of % kernel-name) (:array-params ki))
-                                      (buf-of output kernel-name))
-                     scalars (mapv (fn [{:keys [type value-fn]}] {:type type :value (value-fn args)})
-                                   scalar-specs)]
-                 [(assoc (bind-fn kernel-name array-bufs scalars (long (n-fn args)) {:group-count 1})
-                         :phase (:phase step))])
+               (do (or (info-fn kernel-name)
+                       (throw (ex-info (str "Program kernel not registered: " kernel-name)
+                                       {:kernel kernel-name})))
+                   (let [prepared
+                         (if-let [specs (:argument-specs step)]
+                           (let [ordered-args
+                                 (mapv (fn [{:keys [kind sym type value-fn]}]
+                                         (if (= :scalar kind)
+                                           {:type type :value (value-fn args)}
+                                           (buf-of sym kernel-name)))
+                                       specs)]
+                             (reduction-fn kernel-name ordered-args))
+                           (let [ki (info-fn kernel-name)
+                                 array-bufs (conj (mapv #(buf-of % kernel-name) (:array-params ki))
+                                                  (buf-of output kernel-name))
+                                 scalars (mapv (fn [{:keys [type value-fn]}]
+                                                 {:type type :value (value-fn args)})
+                                               scalar-specs)]
+                             (bind-fn kernel-name array-bufs scalars (long (n-fn args))
+                                      {:group-count 1})))]
+                     [(assoc prepared :phase (:phase step))]))
                (throw (ex-info (str "bind-program! cannot bind a " convention " step — only "
                                     ":map / :map-void / :contract / :reduce / :gemm / :scatter "
                                     "are wired on the resident path")

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -1109,6 +1109,42 @@
       :kernel-name kernel-name
       :async? (boolean (get opts :async?))})))
 
+(defn bind-registered-reduction!
+  "OpenCL resident SegRed binder. Consumes complete values in emitter-authored ABI order and
+   derives its pointer/scalar/bound projections exclusively from slot kinds and roles."
+  [^String kernel-name arguments]
+  (let [registered (or (get @kernel-registry kernel-name)
+                       (throw (ex-info (str "Kernel not registered: " kernel-name)
+                                       {:kernel-name kernel-name
+                                        :registered (keys @kernel-registry)})))
+        abi (kabi/validate! (:abi registered))
+        {:keys [pointer-pairs scalar-pairs result-pair bound-pair]}
+        (kabi/validate-reduction-arguments! abi arguments)
+        _ (doseq [[slot value] pointer-pairs]
+            (when-not (or (device-buffer? value) (instance? MemorySegment value))
+              (throw (ex-info "resident reduction requires OclBuffer/MemorySegment pointer arguments"
+                              {:kernel-name kernel-name :slot slot :value-type (type value)})))
+            (when (and (device-buffer? value)
+                       (not= (:dtype slot) (dt/canon (:dtype ^OclBuffer value))))
+              (throw (ex-info "reduction ABI storage dtype does not match resident buffer"
+                              {:kernel-name kernel-name :slot slot :expected (:dtype slot)
+                               :actual (dt/canon (:dtype ^OclBuffer value))}))))
+        result-value (second result-pair)
+        _ (when (and (device-buffer? result-value)
+                     (< (:n-elements ^OclBuffer result-value) 1))
+            (throw (ex-info "resident reduction result buffer must hold at least one element"
+                            {:kernel-name kernel-name :buffer-elements 0})))
+        _ (doseq [[slot value] (conj scalar-pairs bound-pair)]
+            (when-not (and (map? value) (= (:kernel-dtype slot) (:type value)))
+              (throw (ex-info "reduction ABI scalar binding has the wrong kernel dtype"
+                              {:kernel-name kernel-name :slot slot
+                               :expected (:kernel-dtype slot)
+                               :actual (when (map? value) (:type value))}))))
+        pointers (mapv second pointer-pairs)
+        scalars (mapv second scalar-pairs)
+        n (long (:value (second bound-pair)))]
+    (bind-registered-map-void-kernel kernel-name pointers scalars n {:group-count 1})))
+
 (defn bind-registered-contraction!
   "Pre-bind a routed contraction over resident OclBuffers in exact ordered ABI position.
   The returned prepared launch carries vector workgroup/group-count geometry; the OpenCL graph

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -1926,6 +1926,110 @@
     (or (some (fn [[slot value]] (when (= :result (:role slot)) value)) pairs)
         output-array)))
 
+(defn invoke-registered-reduction-kernel
+  "Run a SegRed host-scalar reduction from one complete ordered ABI value vector. The single
+   :result value must be nil: staging owns and inserts the workgroup-partial buffer at exactly
+   that slot. Captured scalars retain their declared kernel dtypes, and every structural/storage
+   check runs before kernel loading touches the driver. Returns a scalar double after combining
+   workgroup partials on the host."
+  [^String kernel-name arguments]
+  (let [registered (or (get @kernel-registry kernel-name)
+                       (throw (ex-info (str "Kernel not registered: " kernel-name)
+                                       {:kernel-name kernel-name
+                                        :registered (keys @kernel-registry)})))
+        abi (kabi/validate! (:abi registered))
+        {:keys [pairs pointer-pairs scalar-pairs result-pair bound-pair]}
+        (kabi/validate-reduction-arguments! abi arguments)
+        _ (when-not (nil? (second result-pair))
+            (throw (ex-info "staging reduction ABI :result value must be nil (runtime-owned partial buffer)"
+                            {:kernel-name kernel-name :result-pair result-pair})))
+        non-result-pointers (filterv #(not= :result (:role (first %))) pointer-pairs)
+        _ (doseq [[slot value] non-result-pointers]
+            (when-not (= :input (:kind slot))
+              (throw (ex-info "staging reduction supports only input pointers besides its :result"
+                              {:kernel-name kernel-name :slot slot})))
+            (let [actual (if (device-buffer? value)
+                           (dt/canon (:dtype ^DeviceBuffer value))
+                           (jvm-array-dtype value))]
+              (when-not actual
+                (throw (ex-info "reduction ABI pointer value is not a supported buffer/array"
+                                {:kernel-name kernel-name :slot slot :value-type (type value)})))
+              (when-not (= (:dtype slot) actual)
+                (throw (ex-info "reduction ABI storage dtype mismatch"
+                                {:kernel-name kernel-name :slot slot
+                                 :expected (:dtype slot) :actual actual})))))
+        _ (doseq [[slot value] scalar-pairs]
+            (when (map? value)
+              (when-not (= (:kernel-dtype slot) (:type value))
+                (throw (ex-info "reduction ABI scalar binding has the wrong kernel dtype"
+                                {:kernel-name kernel-name :slot slot
+                                 :expected (:kernel-dtype slot) :actual (:type value)})))))
+        [bound-slot bound-value] bound-pair
+        _ (when (and (map? bound-value)
+                     (not= (:kernel-dtype bound-slot) (:type bound-value)))
+            (throw (ex-info "reduction ABI bound binding has the wrong kernel dtype"
+                            {:kernel-name kernel-name :slot bound-slot
+                             :expected (:kernel-dtype bound-slot) :actual (:type bound-value)})))
+        n (long (if (map? bound-value) (:value bound-value) bound-value))
+        result-dtype (:dtype (first result-pair))
+        _ (when-not (#{:float :double} result-dtype)
+            (throw (ex-info "host partial combine currently supports only float/double SegRed results"
+                            {:kernel-name kernel-name :dtype result-dtype})))
+        ;; Native driver/loading begins only after every ABI/value check above.
+        {:keys [kernel-handle workgroup-size identity-val c-op]
+         :or {workgroup-size 256 identity-val 0.0 c-op "+"}}
+        (ensure-kernel-loaded! kernel-name)
+        combine (case c-op "fmax" (fn ^double [^double a ^double b] (Math/max a b))
+                      "fmin" (fn ^double [^double a ^double b] (Math/min a b))
+                      "*"    (fn ^double [^double a ^double b] (* a b))
+                      (fn ^double [^double a ^double b] (+ a b)))
+        wg (long (or workgroup-size 256))
+        group-count (max 1 (long (Math/ceil (/ (double n) wg))))
+        dtype-size (long (get dtype-byte-sizes result-dtype))
+        value-layout (if (= result-dtype :float) ValueLayout/JAVA_FLOAT ValueLayout/JAVA_DOUBLE)
+        staged-inputs
+        (into {}
+              (map-indexed
+               (fn [idx [slot value]]
+                 [slot
+                  (if (device-buffer? value)
+                    (:segment ^DeviceBuffer value)
+                    (let [host (MemorySegment/ofArray value)
+                          n-bytes (.byteSize host)
+                          seg (ensure-seg kernel-name (keyword (str "red-abi-input-" idx)) n-bytes)]
+                      (MemorySegment/copy host 0 seg 0 n-bytes)
+                      seg))])
+               non-result-pointers))
+        partial-bytes (* group-count dtype-size)
+        dev-partial (ensure-seg kernel-name :partial-seg partial-bytes)
+        scalar-arg (fn [slot value]
+                     (if (map? value)
+                       value
+                       (let [t (:kernel-dtype slot)]
+                         {:type t
+                          :value (case t
+                                   :int (int value)
+                                   :long (long value)
+                                   :float (float value)
+                                   :double (double value)
+                                   value)})))
+        all-args
+        (mapv (fn [[slot value]]
+                (cond
+                  (= :result (:role slot)) dev-partial
+                  (= :scalar (:kind slot)) (scalar-arg slot value)
+                  :else (get staged-inputs slot)))
+              pairs)]
+    (launch! kernel-handle group-count wg all-args)
+    (if (= group-count 1)
+      (double (.get dev-partial value-layout 0))
+      (loop [i 0 acc (double identity-val)]
+        (if (< i group-count)
+          (recur (inc i)
+                 (double (combine acc (double (.get dev-partial value-layout
+                                                    (* i dtype-size))))))
+          acc)))))
+
 (defn invoke-reduction-kernel
   "Pipeline-friendly reduction kernel invocation. Returns scalar double.
   input-arrays: vector of JVM arrays (double[] or float[]) or DeviceBuffers
@@ -2577,6 +2681,44 @@
       :group-count group-count
       :kernel-name kernel-name
       :async? async?})))
+
+(defn bind-registered-reduction!
+  "Pre-bind a SegRed kernel from its complete ordered ABI values. The ABI roles—not registry
+   :array-params or a caller-side concatenation convention—select pointers, captured scalars,
+   the result buffer and the bound. A single workgroup lets the grid-stride kernel write the
+   resident one-element result without a host combine."
+  [^String kernel-name arguments]
+  (let [registered (or (get @kernel-registry kernel-name)
+                       (throw (ex-info (str "Kernel not registered: " kernel-name)
+                                       {:kernel-name kernel-name
+                                        :registered (keys @kernel-registry)})))
+        abi (kabi/validate! (:abi registered))
+        {:keys [pointer-pairs scalar-pairs result-pair bound-pair]}
+        (kabi/validate-reduction-arguments! abi arguments)
+        _ (doseq [[slot value] pointer-pairs]
+            (when-not (or (device-buffer? value) (instance? MemorySegment value))
+              (throw (ex-info "resident reduction requires DeviceBuffer/MemorySegment pointer arguments"
+                              {:kernel-name kernel-name :slot slot :value-type (type value)})))
+            (when (and (device-buffer? value)
+                       (not= (:dtype slot) (dt/canon (:dtype ^DeviceBuffer value))))
+              (throw (ex-info "reduction ABI storage dtype does not match resident buffer"
+                              {:kernel-name kernel-name :slot slot :expected (:dtype slot)
+                               :actual (dt/canon (:dtype ^DeviceBuffer value))}))))
+        result-value (second result-pair)
+        _ (when (and (device-buffer? result-value)
+                     (< (:n-elements ^DeviceBuffer result-value) 1))
+            (throw (ex-info "resident reduction result buffer must hold at least one element"
+                            {:kernel-name kernel-name :buffer-elements 0})))
+        _ (doseq [[slot value] (conj scalar-pairs bound-pair)]
+            (when-not (and (map? value) (= (:kernel-dtype slot) (:type value)))
+              (throw (ex-info "reduction ABI scalar binding has the wrong kernel dtype"
+                              {:kernel-name kernel-name :slot slot
+                               :expected (:kernel-dtype slot)
+                               :actual (when (map? value) (:type value))}))))
+        pointers (mapv second pointer-pairs)
+        scalars (mapv second scalar-pairs)
+        n (long (:value (second bound-pair)))]
+    (bind-registered-map-void-kernel kernel-name pointers scalars n {:group-count 1})))
 
 (defn bind-registered-contraction!
   "Pre-bind a routed contraction over resident buffers using its ordered typed ABI.

--- a/test/raster/compiler/backend/gpu/gpu_correctness_test.clj
+++ b/test/raster/compiler/backend/gpu/gpu_correctness_test.clj
@@ -236,6 +236,28 @@
        (is (seq devices) "Should find at least one GPU device")
        (is (string? (:name (first devices))) "Device should have a name")))))
 
+(deftest gpu-segred-staging-captured-scalar-test
+  (when-ze
+   (testing "ordered SegRed staging inserts its partial output and binds captured scalars"
+     (require 'raster.gpu.ze-runtime)
+     ((resolve 'raster.gpu.ze-runtime/init!))
+     (let [n 1024
+           scale 0.75
+           input (float-array (map #(float (/ (inc %) 1024.0)) (range n)))
+           form '(raster.par/reduce acc 0.0 i n
+                                    (+ acc (* scale (aget input i))))
+           compiled (opencl-pass/opencl-pass
+                     form :device-id :ze:0 :dtype :float
+                     :scalar-types {'scale :float 'n :int})
+           kernel (first (:kernels compiled))
+           invoke (resolve 'raster.gpu.ze-runtime/invoke-registered-reduction-kernel)
+           register! (resolve 'raster.gpu.ze-runtime/register-kernel!)
+           _ (register! (:kernel-name kernel) kernel)
+           actual (invoke (:kernel-name kernel) [input nil scale n])
+           expected (reduce + 0.0 (map #(* scale (double %)) (seq input)))]
+       (is (< (Math/abs (- (double actual) expected)) 1e-3)
+           (str "captured-scalar SegRed expected " expected ", got " actual))))))
+
 (deftest gpu-scan-correctness-test
   (when-ze
    (testing "GPU exclusive scan matches CPU reference"

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -126,10 +126,35 @@
 
 (deftest opencl-pass-reduce-test
   (testing "par/reduce gets replaced with ze invoke-reduction-kernel"
-    (let [form '(raster.par/reduce acc 0.0 i n (+ acc (aget a i)))
-          result (opencl-pass/opencl-pass form :device-id :ze:0)]
+    (let [form '(raster.par/reduce acc 0.0 i n (+ acc (* scale (aget a i))))
+          result (opencl-pass/opencl-pass form :device-id :ze:0 :dtype :float
+                                          :scalar-types {'scale :float 'n :int})]
       (is (= 1 (:ze-reduces (:stats result))))
-      (is (= 1 (count (:kernels result)))))))
+      (is (= 1 (count (:kernels result))))
+      (is (= 'raster.gpu.ze-runtime/invoke-registered-reduction-kernel
+             (first (:form result))))
+      (is (= '[a nil scale n] (nth (:form result) 2)))
+      (is (= '[a output scale _n_bound]
+             (mapv :name (:abi (first (:kernels result))))))))
+  (testing "reduce-into supplies its resident result at the same ordered ABI slot"
+    (let [form '(raster.par/reduce-into obuf acc 0.0 i n (+ acc (* scale (aget a i))))
+          result (opencl-pass/opencl-pass form :device-id :ze:0 :dtype :float
+                                          :scalar-types {'scale :float 'n :int})]
+      (is (= 'raster.gpu.ze-runtime/invoke-registered-reduction-kernel
+             (first (:form result))))
+      (is (= '[a obuf scale n] (nth (:form result) 2)))
+      (is (= '[a obuf scale _n_bound]
+             (mapv :name (:abi (first (:kernels result)))))))))
+
+(deftest opencl-pass-full-contraction-reduction-uses-ordered-marker
+  (let [form '(raster.par/contract O [] [[i 8]] (* (aget A i) (aget B i)))
+        result (opencl-pass/opencl-pass form :device-id :ze:0 :dtype :float)
+        kernel (first (:kernels result))]
+    (is (= 'raster.gpu.ze-runtime/invoke-registered-reduction-kernel
+           (first (:form result))))
+    (is (= '[A B nil 8] (nth (:form result) 2)))
+    (is (= '[A B O _n_bound] (mapv :name (:abi kernel))))
+    (is (= [:operand :operand :result :bound] (mapv :role (:abi kernel))))))
 
 (deftest opencl-pass-nested-let-test
   (testing "Nested let* forms are traversed"

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -61,6 +61,28 @@
       (is (not (re-find #"gpufn_aget" src)))
       (is (re-find #"a\[" src)))))
 
+(deftest segred-emits-complete-ordered-typed-abi
+  (let [form (with-meta '(raster.par/reduce acc 0.0 i n
+                                           (+ (float acc) (* scale (clojure.core/aget a i))))
+               {:raster.type/elem-type :float})
+        s (soac/par-form->soac 'result form 0)
+        segred (first (lower/lower-reduce s nil))
+        k (sg/generate-segred-kernel segred 'result-buffer :dtype :float
+                                     :scalar-types {'scale :float 'n :int})]
+    (testing "signature, ABI and compiler values have one identical order"
+      (is (= '[a result-buffer scale _n_bound] (mapv :name (:abi k))))
+      (is (= [:input :output :scalar :scalar] (mapv :kind (:abi k))))
+      (is (= [:float :float :float :int] (mapv :kernel-dtype (:abi k))))
+      (is (= [:operand :result :parameter :bound] (mapv :role (:abi k))))
+      (is (= '[a result-buffer scale n] (:arguments k)))
+      (is (re-find #"\(.*a,.*output, float scale, int _n_bound\)" (:source k)))))
+  (testing "host-scalar staging retains the result position as an explicit nil placeholder"
+    (let [form '(raster.par/reduce acc 0.0 i n (+ acc (clojure.core/aget a i)))
+          s (soac/par-form->soac 'result form 0)
+          k (sg/generate-segred-kernel (first (lower/lower-reduce s nil)) nil :dtype :float)]
+      (is (= '[a output _n_bound] (mapv :name (:abi k))))
+      (is (= '[a nil n] (:arguments k))))))
+
 ;; ================================================================
 ;; Horizontally-fused multi-output SegMap: the SECONDARY output (written
 ;; only via a side-effect aset in the fused lambda) must be a NON-const

--- a/test/raster/compiler/kernel_abi_test.clj
+++ b/test/raster/compiler/kernel_abi_test.clj
@@ -46,6 +46,29 @@
                         (kabi/validate-split-binding! map-abi [:x :out]
                                                       [{:type :int :value 2}]))))
 
+(deftest ordered-reduction-binding-is-derived-from-roles
+  (let [abi [(kabi/slot 'x :input :float :role :operand)
+             (kabi/slot 'out :output :float :role :result)
+             (kabi/slot 'scale :scalar :float :role :parameter)
+             (kabi/slot '_n_bound :scalar :int :role :bound)]
+        binding (kabi/validate-reduction-arguments! abi [:x :out :scale :n])]
+    (is (= '[x out] (mapv (comp :name first) (:pointer-pairs binding))))
+    (is (= '[scale] (mapv (comp :name first) (:scalar-pairs binding))))
+    (is (= 'out (-> binding :result-pair first :name)))
+    (is (= '_n_bound (-> binding :bound-pair first :name))))
+  (testing "missing or wrongly-kinded semantic roles fail loudly"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"exactly one :result"
+          (kabi/validate-reduction-arguments!
+           [(kabi/slot 'x :input :float)
+            (kabi/slot 'out :output :float)
+            (kabi/slot '_n_bound :scalar :int :role :bound)]
+           [:x :out :n])))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #":bound slot must be scalar"
+          (kabi/validate-reduction-arguments!
+           [(kabi/slot 'x :input :float :role :bound)
+            (kabi/slot 'out :output :float :role :result)]
+           [:x :out])))))
+
 (deftest session-resolution-consumes-abi-not-legacy-input-list
   (testing "door C resolves the functional output slot instead of binding only :array-params"
     (let [resolve-bufs @#'raster.gpu.core/resolve-kernel-bufs]
@@ -84,5 +107,29 @@
         (is (some? e))
         (is (= :float (:expected (ex-data e))))
         (is (= :double (:actual (ex-data e)))))
+      (finally
+        (ze/register-kernel! kernel-name {:test-tombstone? true})))))
+
+(deftest reduction-staging-rejects-abi-errors-before-driver-loading
+  (let [kernel-name (str "reduction_abi_mismatch_" (gensym))
+        abi [(kabi/slot 'x :input :float :role :operand)
+             (kabi/slot 'out :output :float :role :result)
+             (kabi/slot 'scale :scalar :float :role :parameter)
+             (kabi/slot '_n_bound :scalar :int :role :bound)]]
+    (ze/register-kernel! kernel-name {:abi abi :dtype :float})
+    (try
+      (testing "a caller-owned staging result is rejected before source-less kernel loading"
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"result value must be nil"
+              (ze/invoke-registered-reduction-kernel
+               kernel-name [(float-array 4) (float-array 1) 2.0 4]))))
+      (testing "input storage dtype is checked before source-less kernel loading"
+        (let [e (try
+                  (ze/invoke-registered-reduction-kernel
+                   kernel-name [(double-array 4) nil 2.0 4])
+                  nil
+                  (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? e))
+          (is (= :float (:expected (ex-data e))))
+          (is (= :double (:actual (ex-data e))))))
       (finally
         (ze/register-kernel! kernel-name {:test-tombstone? true})))))

--- a/test/raster/compiler/passes/parallel/contract_descriptor_validator_test.clj
+++ b/test/raster/compiler/passes/parallel/contract_descriptor_validator_test.clj
@@ -83,17 +83,19 @@
 (deftest validator-models-both-invoke-protocols
   (let [red (route/route-contraction '(raster.par/contract O [] [[i 8]] (* (aget A i) (aget B i)))
                                      :dtype :double)]
-    (testing ":invoke :reduction owns its launch — no :wg/:grid, empty :scalar-args, needs :reduce-bound"
+    (testing ":invoke :reduction owns its launch and carries an ordered ABI"
       (is (= :reduction (:invoke red)))
       (is (nil? (:wg red)))
       (is (nil? (:grid red)))
       (is (empty? (:scalar-args red)))
-      (is (some? (:reduce-bound red))))
+      (is (some? (:reduce-bound red)))
+      (is (= '[A B O _n_bound] (mapv :name (:abi red))))
+      (is (= '[A B O 8] (:arguments red))))
     (testing "…and the validator enforces each of those, so the protocol cannot drift"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must not carry"
             (route/validate-descriptor (assoc red :wg [256 1]))))
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must leave :scalar-args empty"
-            (route/validate-descriptor (assoc red :scalar-args [{:type :int :value 8}]))))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"ordered :abi is required"
+            (route/validate-descriptor (dissoc red :abi))))
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"requires :reduce-bound"
             (route/validate-descriptor (dissoc red :reduce-bound)))))))
 

--- a/test/raster/compiler/pipeline_extractor_test.clj
+++ b/test/raster/compiler/pipeline_extractor_test.clj
@@ -10,7 +10,8 @@
    emitting a miscompiled kernel step. These pin the reject; before the fix each malformed
    form extracted to a (wrong) step with no ::non-resident."
   (:require [clojure.test :refer [deftest testing is]]
-            [raster.compiler.pipeline :as pipeline]))
+            [raster.compiler.pipeline :as pipeline]
+            [raster.compiler.ir.kernel-abi :as kabi]))
 
 (def ^:private nr-key :raster.compiler.pipeline/non-resident)
 
@@ -69,7 +70,14 @@
                        result))))))
 
 (deftest reduce-arity
-  (testing "a 5-wide resident reduction and a 4-wide legacy reduction both extract"
+  (testing "an ordered resident reduction preserves the complete argument vector"
+    (let [step (first (:steps (pipeline/extract-gpu-program
+                               '(let* [out (raster.gpu.ze-runtime/invoke-registered-reduction-kernel
+                                            "k" [a obuf scale n])]
+                                      out))))]
+      (is (= :reduce (:convention step)))
+      (is (= '[a obuf scale n] (:arguments step)))))
+  (testing "the 5-wide resident compatibility reduction and 4-wide legacy reduction still extract"
     (is (= :reduce (:convention (first (:steps (pipeline/extract-gpu-program
                                                 '(let* [out (raster.gpu.ze-runtime/invoke-reduction-kernel
                                                              "k" [a] obuf 10)]
@@ -84,4 +92,35 @@
     (is (= :unparseable-kernel-invoke
            (why '(let* [out (raster.gpu.ze-runtime/invoke-reduction-kernel
                              "k" [a] obuf 10 extra)]
+                       out)))))
+  (testing "ordered reduction requires exactly one vector operand"
+    (is (= :unparseable-kernel-invoke
+           (why '(let* [out (raster.gpu.ze-runtime/invoke-registered-reduction-kernel
+                             "k" [a obuf n] extra)]
+                       out))))
+    (is (= :unparseable-kernel-invoke
+           (why '(let* [out (raster.gpu.ze-runtime/invoke-registered-reduction-kernel
+                             "k" (list a obuf n))]
                        out))))))
+
+(deftest ordered-reduction-residency-is-decided-by-result-role
+  (let [abi [(kabi/slot 'a :input :float :role :operand)
+             (kabi/slot 'out :output :float :role :result)
+             (kabi/slot 'scale :scalar :float :role :parameter)
+             (kabi/slot '_n_bound :scalar :int :role :bound)]
+        info (constantly {:abi abi})]
+    (testing "nil at the ABI result role is an explicit host-scalar staging fallback"
+      (let [r (pipeline/extract-gpu-program
+               '(let* [out (raster.gpu.ze-runtime/invoke-registered-reduction-kernel
+                             "k" [a nil scale n])]
+                      out)
+               info)]
+        (is (= :host-scalar-reduction (get-in r [nr-key :why])))))
+    (testing "a concrete result buffer remains resident and aliases the marker binding"
+      (let [r (pipeline/extract-gpu-program
+               '(let* [out (raster.gpu.ze-runtime/invoke-registered-reduction-kernel
+                             "k" [a obuf scale n])]
+                      out)
+               info)]
+        (is (nil? (nr-key r)))
+        (is (= 'obuf (:result r)))))))

--- a/test/raster/dl/gpu_ad_gemm_test.clj
+++ b/test/raster/dl/gpu_ad_gemm_test.clj
@@ -214,30 +214,38 @@
   ;; :scatter step kinds; a program containing a par/reduce whose result stays resident
   ;; (the #42 resident-reduce work: fuse-reduce-results gives it a device 1-elem out-buf)
   ;; threw at bind time even though bind-step! already handled :reduce. This pins the
-  ;; wiring: sum(a) feeding an elementwise scale compiles to [:reduce :map] steps, binds,
+  ;; wiring: scale*sum(a) (a captured reduction scalar) feeding an elementwise scale compiles to
+  ;; [:reduce :map] steps, binds its full ordered ABI,
   ;; and replays with the correct output. (An ESCAPING tail reduce — a loss returned as
   ;; the scalar result — still doesn't bind: that is the remaining #42 leftover, same as
   ;; bind-step!.)
   (if-not @gp/gpu-available?
     (gp/gpu-skip! "gpu-reduce-step")
     (let [probe (eval '(raster.core/deftm gpu-reduce-consumer-probe
-                         [a :- (Array float) out :- (Array float) n :- Long] :- Void
+                         [a :- (Array float) out :- (Array float) n :- Long scale :- Double] :- Void
                          (let [s (raster.par/reduce
                                   acc 0.0 i n
-                                  (raster.numeric/+ acc (raster.arrays/aget a i)))]
+                                  (raster.numeric/+ acc
+                                                    (raster.numeric/* scale
+                                                                      (raster.arrays/aget a i))))]
                            (raster.par/map-void!
                             j n
                             (raster.arrays/aset out j
                                                 (raster.numeric/* (raster.arrays/aget a j) s))))))
           n 64
+          scale 0.75
           a (rnd n 51)
           out (float-array n)
-          s (double (reduce + 0.0 (map double (seq a))))
+          s (double (reduce + 0.0 (map #(* scale (double %)) (seq a))))
           cpu (float-array (map #(float (* (double %) s)) (seq a)))
-          {:keys [descriptor] :as r} (run-resident probe [a out n])
+          {:keys [descriptor] :as r} (run-resident probe [a out n scale])
           gpu (:out r)]
-      (is (some #(= :reduce (:convention %)) (:steps descriptor))
-          "resident-consumed par/reduce compiles to a :reduce step")
+      (let [red-step (first (filter #(= :reduce (:convention %)) (:steps descriptor)))]
+        (is (some? red-step) "resident-consumed par/reduce compiles to a :reduce step")
+        (is (= [:input :output :scalar :scalar]
+               (mapv :kind (:argument-specs red-step))))
+        (is (= [:float :float :float :int]
+               (mapv (comp :kernel-dtype :slot) (:argument-specs red-step)))))
       (is (< (rel-err gpu cpu) 1e-4)
           (str "reduce→map-void replay relerr " (rel-err gpu cpu))))))
 

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -30,6 +30,13 @@
        (ra/aget B (clojure.core/+ (clojure.core/* l 8) j))))
     C))
 
+(deftm ocl-session-reduce
+  [x :- (Array float) out :- (Array float) scale :- Double n :- Long] :- Void
+  (let [s (raster.par/reduce acc 0.0 i n
+            (clojure.core/+ acc (clojure.core/* scale (ra/aget x i))))]
+    (raster.par/map-void! j n
+      (ra/aset out j (clojure.core/* (ra/aget x j) s)))))
+
 (deftest ocl-resident-session-roundtrip
   (if-not @ocl-available?
     (println "SKIP ocl-session test (no OpenCL device)")
@@ -76,4 +83,30 @@
                               (map (fn [row] (reduce + (range (* row 8) (* (inc row) 8))))
                                    (range 8))))
                  (vec result))))
+        (finally (close-session! s))))))
+
+(deftest ocl-resident-reduction-ordered-abi-roundtrip
+  (if-not @ocl-available?
+    (println "SKIP ocl resident reduction (no OpenCL device)")
+    (let [gpu (do (require 'raster.gpu.core) (find-ns 'raster.gpu.core))
+          make-session (ns-resolve gpu 'make-session)
+          bind-program! (ns-resolve gpu 'bind-program!)
+          run-program! (ns-resolve gpu 'run-program!)
+          close-session! (ns-resolve gpu 'close-session!)
+          descriptor (pl/compile-gpu-program #'ocl-session-reduce :ocl:0 :dtype :float)
+          n 1024
+          scale 0.75
+          x (float-array (map #(float (/ (inc %) 1024.0)) (range n)))
+          out (float-array n)
+          expected-sum (reduce + 0.0 (map #(* scale (double %)) (seq x)))
+          s (make-session :ocl:0)]
+      (try
+        (let [handle (bind-program! s descriptor [x out scale n])
+              result (get (run-program! s handle [x out scale n]) 'out)
+              red-step (first (filter #(= :reduce (:convention %)) (:steps descriptor)))]
+          (is (= [:input :output :scalar :scalar]
+                 (mapv :kind (:argument-specs red-step))))
+          (is (< (Math/abs (- (double (aget ^floats result 511))
+                              (* (double (aget x 511)) expected-sum)))
+                 1e-3)))
         (finally (close-session! s))))))


### PR DESCRIPTION
## Summary

- emit and source-validate a complete ordered typed SegRed ABI for inputs, result, captured scalars, and bound
- carry the same ordered values through host staging and resident program extraction; staging marks the runtime-owned partial result explicitly
- bind resident reductions by ABI roles on Level Zero and OpenCL, including captured scalar types and buffer dtype checks
- keep legacy reduction emission on its compatibility marker until that emitter has an ABI
- recognize typed float accumulator casts so valid SegRed kernels do not decline into an invalid legacy fallback

## Verification

- focused cold gate: 41 tests, 186 assertions
- neighboring contraction gate: 26 tests, 95 assertions
- local hardware gate: 25 tests, 107 assertions across Level Zero staging/resident replay and OpenCL resident replay
- clojure -T:build jar

The hardware tests cover a captured float scalar in Level Zero staging, Level Zero resident reduce-to-map replay, and OpenCL resident replay. CI remains the device-free gate.