### PR TITLE
Phase 2: add ordered map-void kernel ABI

### DIFF
--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -1705,6 +1705,27 @@
      body)
     @written))
 
+(defn collect-read-arrays
+  "Collect array symbols whose existing contents are read. Atomic updates and collect! counters
+   are read-modify-write operations and therefore count as reads as well as writes."
+  [body]
+  (let [read (atom #{})]
+    (walk/postwalk
+     (fn [form]
+       (when (seq? form)
+         (let [head (first form)]
+           (when (and (descriptor/aget-op? head) (>= (count form) 3))
+             (swap! read conj (second form)))
+           (when (and (contains? #{'raster.par/atomic-add! 'par/atomic-add!} head)
+                      (>= (count form) 4))
+             (swap! read conj (second form)))
+           (when (and (contains? #{'raster.par/collect! 'par/collect!} head)
+                      (>= (count form) 2))
+             (swap! read conj (second form)))))
+       form)
+     body)
+    @read))
+
 ;; ================================================================
 ;; GPU function helpers — auto-inlining of deftm scalar helpers
 ;; ================================================================

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -410,14 +410,15 @@
                                                                   :array-types top-array-types
                                                                   :scalar-types top-scalar-types)
                       k (register-kernel! kernel :ze-maps)
-                      soa-exp (or (:soa-expansions k) {})
-                      all-params (:array-params k)
-                      plain-params (filterv #(not (contains? soa-exp (symbol (name %)))) all-params)
-                      soa-params (filterv #(contains? soa-exp (symbol (name %))) all-params)]
+                      abi (:abi k)
+                      pointer-args (kabi/pointer-binding-names abi)
+                      scalar-args (mapv :name
+                                        (remove #(= :bound (:role %))
+                                                (kabi/scalar-slots abi)))]
                   (list 'raster.gpu.ze-runtime/invoke-registered-map-void-kernel
                         (:kernel-name k)
-                        (vec (concat plain-params soa-params))
-                        (vec (:scalar-params k))
+                        pointer-args
+                        scalar-args
                         bound))))
 
             ;; par/scan-exclusive

--- a/src/raster/compiler/backend/gpu/par_opencl.clj
+++ b/src/raster/compiler/backend/gpu/par_opencl.clj
@@ -129,8 +129,9 @@
   array-types: {sym -> :float|:int|:long|:double} for mixed-type params.
   Written arrays get __global TYPE* (not const restrict).
 
-  Returns {:kernel-name str :source str :array-params [syms]
-           :scalar-params [syms] :written-arrays #{syms} :dtype kw}."
+  Returns {:kernel-name str :source str :abi [ordered typed physical slots]
+           :array-params [logical binding syms] :scalar-params [syms]
+           :written-arrays #{syms} :dtype kw}."
   [form & {:keys [dtype kernel-name-prefix array-types scalar-types]
            :or {dtype :float kernel-name-prefix "par_map_void"
                 array-types {} scalar-types {}}}]
@@ -149,6 +150,7 @@
         soa-expansions (sl/collect-soa-env body)
         array-syms (ce/collect-arrays-in-body body)
         written-syms (ce/collect-written-arrays body)
+        read-syms (ce/collect-read-arrays body)
         scalar-syms (ce/collect-scalars-in-body body idx array-syms)
         all-arr-params (vec (sort-by name array-syms))
         ;; Partition: SoA arrays vs plain arrays
@@ -161,6 +163,13 @@
                      (get codegen/opencl-type-map t default-ctype)))
         written? (fn [s] (or (contains? written-syms s)
                              (contains? written-syms (symbol (name s)))))
+        read? (fn [s] (or (contains? read-syms s)
+                          (contains? read-syms (symbol (name s)))))
+        pointer-role (fn [s]
+                       (cond
+                         (and (written? s) (read? s)) :inout
+                         (written? s) :effect
+                         :else :operand))
         ;; Plain array params
         plain-arr-param-str (str/join ", "
                                       (map (fn [s]
@@ -185,12 +194,53 @@
                                             soa-arr-params))
         ;; Infer scalar types: check explicit scalar-types map, name heuristic, or metadata
         scl-type (fn [s] (ce/scalar-native-type s scalar-types default-ctype))
+        scalar-dtype (fn [s]
+                       (case (scl-type s)
+                         "int" :int
+                         "long" :long
+                         "double" :double
+                         "float" :float))
+        element-dtype (fn [tag]
+                        (case tag
+                          double :double
+                          float :float
+                          long :long
+                          int :int
+                          byte :byte))
         scl-param-str (str/join ", "
                                 (map (fn [s] (str (scl-type s) " " (ce/c-symbol s)))
                                      scl-params))
         all-params (str/join ", "
                              (remove empty?
                                      [plain-arr-param-str soa-arr-param-str scl-param-str "int _n_bound"]))
+        ;; The ABI describes the PHYSICAL C signature. An SoA contributes one pointer per field,
+        ;; each linked back to the single logical caller binding via :binding. This lets source
+        ;; validation and driver binding share one record without making the marker flatten a
+        ;; GpuSoA itself.
+        abi (kabi/validate!
+             (vec
+              (concat
+               (map (fn [s]
+                      (kabi/slot s (if (written? s) :output :input)
+                                 (get array-types s (get array-types (symbol (name s)) dtype))
+                                 :c-name (ce/c-symbol s)
+                                 :role (pointer-role s)))
+                    plain-arr-params)
+               (mapcat (fn [s]
+                         (map (fn [{field-name :name element-tag :element-tag}]
+                                (let [field-sym (sl/field-arr-sym (symbol (name s)) field-name)]
+                                  (kabi/slot field-sym (if (written? s) :output :input)
+                                             (element-dtype element-tag)
+                                             :c-name (ce/c-symbol field-sym)
+                                             :binding s
+                                             :role (pointer-role s))))
+                              (:fields (get soa-expansions (symbol (name s))))))
+                       soa-arr-params)
+               (map (fn [s]
+                      (kabi/slot s :scalar (scalar-dtype s)
+                                 :c-name (ce/c-symbol s) :role :parameter))
+                    scl-params)
+               [(kabi/slot '_n_bound :scalar :int :role :bound)])))
         ;; SROA: scalar-replace value-type access so the body has only per-field
         ;; plain array ops (no struct typedef / SoA aget-aset left for the C emitter).
         lowered-body (sl/lower-body soa-expansions body)
@@ -256,10 +306,14 @@
                         (str "for (int idx = get_global_id(0); idx < _n_bound; idx += get_global_size(0)) {\n"
                              "        " body-str "\n"
                              "    }"))
-                    "\n}\n")]
+                    "\n}\n")
+        _ (kabi/validate-source-signature! kernel-name source abi)
+        binding-params (kabi/pointer-binding-names abi)]
     {:kernel-name    kernel-name
      :source         source
-     :array-params   all-arr-params
+     :abi            abi
+     :arguments      (vec (concat binding-params scl-params [(:bound info)]))
+     :array-params   binding-params
      :soa-expansions soa-expansions
      :scalar-params  scl-params
      :written-arrays written-syms

--- a/src/raster/compiler/ir/kernel_abi.clj
+++ b/src/raster/compiler/ir/kernel_abi.clj
@@ -11,14 +11,19 @@
 (def ^:private kinds #{:input :output :scalar})
 
 (defn slot
-  "Construct one ABI slot.  Options: :c-name, :kernel-dtype and :role."
-  [nm kind dtype & {:keys [c-name kernel-dtype role]}]
+  "Construct one ABI slot. Options: :c-name, :kernel-dtype, :role, and :binding.
+
+   `:binding` names the logical caller value that supplies a physical pointer slot. It is
+   normally absent (and therefore identical to `:name`), but an SoA argument has one physical
+   slot per field and all of those slots share the same logical binding."
+  [nm kind dtype & {:keys [c-name kernel-dtype role binding]}]
   (cond-> {:name nm
            :c-name (or c-name (name nm))
            :kind kind
            :dtype (dt/canon dtype)
            :kernel-dtype (dt/canon (or kernel-dtype dtype))}
-    role (assoc :role role)))
+    role (assoc :role role)
+    binding (assoc :binding binding)))
 
 (defn validate!
   "Validate an ordered ABI and return it unchanged.  A kernel has at least one output;
@@ -38,9 +43,18 @@
     (doseq [k [:dtype :kernel-dtype]]
       (when-not (dt/known? (get s k))
         (throw (ex-info (str "kernel ABI slot has an unknown " k)
-                        {:index i :slot s :dtype (get s k)})))))
+                        {:index i :slot s :dtype (get s k)}))))
+    (when (and (= :scalar (:kind s)) (:binding s))
+      (throw (ex-info "kernel ABI scalar slot cannot have a logical pointer :binding"
+                      {:index i :slot s :abi abi}))))
   (when-not (= (count abi) (count (distinct (map :c-name abi))))
     (throw (ex-info "kernel ABI parameter names must be unique" {:abi abi})))
+  (let [pointers (vec (remove #(= :scalar (:kind %)) abi))]
+    (doseq [binding (distinct (keep :binding pointers))]
+      (let [indexes (keep-indexed (fn [i slot] (when (= binding (:binding slot)) i)) pointers)]
+        (when-not (= (count indexes) (inc (- (apply max indexes) (apply min indexes))))
+          (throw (ex-info "kernel ABI physical slots for one logical binding must be contiguous"
+                          {:binding binding :indexes (vec indexes) :abi abi}))))))
   (when-not (some #(= :output (:kind %)) abi)
     (throw (ex-info "kernel ABI must contain at least one output" {:abi abi})))
   abi)
@@ -54,6 +68,22 @@
   "Scalar ABI slots, in kernel signature order."
   [abi]
   (filterv #(= :scalar (:kind %)) (validate! abi)))
+
+(defn pointer-binding-names
+  "Logical caller pointer values, in first physical-signature occurrence order.
+
+   Usually this is simply `(mapv :name (pointer-slots abi))`. An SoA occupies several physical
+   C pointer slots but is supplied by one logical GpuSoA value; those slots carry a shared
+   `:binding` and collapse to one name here."
+  [abi]
+  (:names
+   (reduce (fn [{:keys [seen] :as acc} slot]
+             (if-let [binding (:binding slot)]
+               (if (contains? seen binding)
+                 acc
+                 (-> acc (update :names conj binding) (update :seen conj binding)))
+               (update acc :names conj (:name slot))))
+           {:names [] :seen #{}} (pointer-slots abi))))
 
 (defn validate-arguments!
   "Check that `arguments` supplies exactly one value per ordered ABI slot."
@@ -72,15 +102,16 @@
    ordered ABI. Pre-typed scalar maps must also agree with the ABI's kernel view dtype."
   [abi pointers scalars]
   (let [pointer-slots (pointer-slots abi)
+        pointer-bindings (pointer-binding-names abi)
         all-scalars (scalar-slots abi)
         bound-slots (filterv #(= :bound (:role %)) all-scalars)
         user-slots (filterv #(not= :bound (:role %)) all-scalars)]
     (when-not (= 1 (count bound-slots))
       (throw (ex-info "split map binding requires exactly one implicit :bound ABI slot"
                       {:abi abi :bound-slots bound-slots})))
-    (when-not (= (count pointer-slots) (count pointers))
+    (when-not (= (count pointer-bindings) (count pointers))
       (throw (ex-info "kernel ABI pointer count does not match binding"
-                      {:expected (count pointer-slots) :actual (count pointers) :abi abi})))
+                      {:expected (count pointer-bindings) :actual (count pointers) :abi abi})))
     (when-not (= (count user-slots) (count scalars))
       (throw (ex-info "kernel ABI scalar count does not match binding"
                       {:expected (count user-slots) :actual (count scalars) :abi abi})))
@@ -89,7 +120,27 @@
       (when-not (= (:kernel-dtype slot) (:type value))
         (throw (ex-info "kernel ABI scalar dtype does not match binding"
                         {:slot slot :expected (:kernel-dtype slot) :actual (:type value)}))))
-    {:pointer-slots pointer-slots :scalar-slots user-slots :bound-slot (first bound-slots)}))
+    {:pointer-slots pointer-slots :pointer-bindings pointer-bindings
+     :scalar-slots user-slots :bound-slot (first bound-slots)}))
+
+(defn validate-physical-pointer-dtypes!
+  "Check the storage dtype of every PHYSICAL pointer value after logical values (notably SoAs)
+   have been expanded. `actual-dtypes` must follow the emitted C signature order. This is kept
+   separate from `validate-split-binding!` because expansion is a runtime representation concern,
+   while the ABI remains a backend-neutral physical signature."
+  [abi actual-dtypes]
+  (let [slots (pointer-slots abi)]
+    (when-not (= (count slots) (count actual-dtypes))
+      (throw (ex-info "kernel ABI physical pointer count does not match expanded binding"
+                      {:expected (count slots) :actual (count actual-dtypes) :abi abi})))
+    (doseq [[slot actual] (map vector slots actual-dtypes)]
+      (when-not (or (= :opaque actual) (and actual (dt/known? actual)))
+        (throw (ex-info "kernel ABI pointer value has no supported storage dtype"
+                        {:slot slot :actual actual :abi abi})))
+      (when (and (not= :opaque actual) (not= (:dtype slot) (dt/canon actual)))
+        (throw (ex-info "kernel ABI storage dtype does not match binding"
+                        {:slot slot :expected (:dtype slot) :actual (dt/canon actual)}))))
+    actual-dtypes))
 
 (defn validate-reduction-arguments!
   "Validate a complete ordered reduction binding and expose its semantic projections without

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -417,7 +417,7 @@
                 (throw (ex-info (str "No buffer for kernel param: " sym-name)
                                 {:sym sym :available (keys bufs)})))))
         (if-let [abi (:abi kernel-info)]
-          (mapv :name (kabi/pointer-slots abi))
+          (kabi/pointer-binding-names abi)
           (:array-params kernel-info))))
 
 ;; ================================================================

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -413,6 +413,23 @@
 (defn device-buffer? [x]
   (instance? OclBuffer x))
 
+(defn- jvm-array-dtype [x]
+  (cond
+    (instance? (Class/forName "[D") x) :double
+    (instance? (Class/forName "[F") x) :float
+    (instance? (Class/forName "[I") x) :int
+    (instance? (Class/forName "[J") x) :long
+    (instance? (Class/forName "[S") x) :half
+    (instance? (Class/forName "[B") x) :byte
+    :else nil))
+
+(defn- physical-pointer-dtypes [arrays]
+  (mapv #(cond
+           (device-buffer? %) (:dtype ^OclBuffer %)
+           (instance? MemorySegment %) :opaque
+           :else (jvm-array-dtype %))
+        arrays))
+
 (defn make-buffer
   "Allocate a persistent GPU buffer via clCreateBuffer."
   ([n] (make-buffer n :float))
@@ -792,7 +809,11 @@
   ([^String kernel-name arrays scalar-args n]
    (invoke-registered-map-void-kernel kernel-name arrays scalar-args n {}))
   ([^String kernel-name arrays scalar-args n opts]
-   (let [{:keys [kernel-handle workgroup-size dtype]
+   (let [abi (:abi (get @kernel-registry kernel-name))
+         _ (when abi
+             (kabi/validate-split-binding! abi arrays scalar-args)
+             (kabi/validate-physical-pointer-dtypes! abi (physical-pointer-dtypes arrays)))
+         {:keys [kernel-handle workgroup-size dtype]
           :or {workgroup-size 256 dtype :float}
           :as info} (ensure-kernel-loaded! kernel-name)
          {:keys [queue]} @state
@@ -815,6 +836,8 @@
                                          (instance? (Class/forName "[I") arr) 4
                                          (instance? (Class/forName "[D") arr) 8
                                          (instance? (Class/forName "[J") arr) 8
+                                         (instance? (Class/forName "[S") arr) 2
+                                         (instance? (Class/forName "[B") arr) 1
                                          :else default-elem-size)))
                      ;; Create temp cl_mem and upload
                     {:keys [context arena]} @state
@@ -830,6 +853,14 @@
                            :host-seg host-seg :temp? true}))))
           []
           (map-indexed vector arrays))
+
+         expanded-entries
+         (if abi
+           (mapv (fn [entry slot]
+                   (assoc entry :write? (or (= :output (:kind slot))
+                                            (= :inout (:role slot)))))
+                 expanded-entries (kabi/pointer-slots abi))
+           expanded-entries)
 
          ;; Set kernel args: buffers first, then scalars, then n
          arg-idx (atom 0)]
@@ -864,8 +895,8 @@
          (finally (.close gs-arena))))
 
      ;; Copy back JVM arrays and free temp cl_mems
-     (doseq [{:keys [cl-mem source byte-size host-seg temp?]} expanded-entries]
-       (when source
+     (doseq [{:keys [cl-mem source byte-size host-seg temp? write?]} expanded-entries]
+       (when (and source (or (nil? abi) write?))
          ;; Read back from device
          (cl-call! "clEnqueueReadBuffer" @h-clEnqueueReadBuffer
                    [queue cl-mem (int CL_TRUE) (long 0) (long byte-size)
@@ -1087,7 +1118,8 @@
    (bind-registered-map-void-kernel kernel-name arrays scalar-args n {}))
   ([^String kernel-name arrays scalar-args n opts]
    (let [_ (when-let [abi (:abi (get @kernel-registry kernel-name))]
-             (kabi/validate-split-binding! abi arrays scalar-args))
+             (kabi/validate-split-binding! abi arrays scalar-args)
+             (kabi/validate-physical-pointer-dtypes! abi (physical-pointer-dtypes arrays)))
          {:keys [program workgroup-size dtype]
           :or {workgroup-size 256 dtype :float}} (ensure-kernel-loaded! kernel-name)
          kh (create-kernel-fresh program kernel-name)

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -1115,6 +1115,17 @@
   [x]
   (instance? GpuSoA x))
 
+(defn- physical-pointer-dtypes
+  "Storage dtypes after expanding each logical map/map-void pointer binding."
+  [arrays]
+  (reduce (fn [dtypes arr]
+            (cond
+              (gpu-soa? arr) (into dtypes (mapv :dtype (:field-segs ^GpuSoA arr)))
+              (device-buffer? arr) (conj dtypes (:dtype ^DeviceBuffer arr))
+              (instance? MemorySegment arr) (conj dtypes :opaque)
+              :else (conj dtypes (jvm-array-dtype arr))))
+          [] arrays))
+
 (defn gpu-array
   "Allocate GPU-resident (shared) storage for n elements of scalar-type.
    scalar-type: the defvalue type symbol (e.g. 'Particle) or Class.
@@ -2562,8 +2573,10 @@
   ([^String kernel-name arrays scalar-args n]
    (invoke-registered-map-void-kernel kernel-name arrays scalar-args n {}))
   ([^String kernel-name arrays scalar-args n opts]
-   (let [_ (when-let [abi (:abi (get @kernel-registry kernel-name))]
-             (kabi/validate-split-binding! abi arrays scalar-args))
+   (let [abi (:abi (get @kernel-registry kernel-name))
+         _ (when abi
+             (kabi/validate-split-binding! abi arrays scalar-args)
+             (kabi/validate-physical-pointer-dtypes! abi (physical-pointer-dtypes arrays)))
          {:keys [kernel-handle workgroup-size dtype written-arrays array-types]
           :or {workgroup-size 256 dtype :float}
           :as info} (ensure-kernel-loaded! kernel-name)
@@ -2581,6 +2594,10 @@
                            (* (alength ^doubles arr) 8)
                            (instance? (Class/forName "[J") arr)
                            (* (alength ^longs arr) 8)
+                           (instance? (Class/forName "[S") arr)
+                           (* (alength ^shorts arr) 2)
+                           (instance? (Class/forName "[B") arr)
+                           (alength ^bytes arr)
                            :else
                            (* n default-dtype-size)))
         ;; Build expanded entries: GpuSoA expands to N field segments,
@@ -2607,6 +2624,13 @@
                 (conj acc {:seg seg :source arr :ab ab}))))
           []
           (map-indexed vector arrays))
+         expanded-entries
+         (if abi
+           (mapv (fn [entry slot]
+                   (assoc entry :write? (or (= :output (:kind slot))
+                                            (= :inout (:role slot)))))
+                 expanded-entries (kabi/pointer-slots abi))
+           expanded-entries)
          dev-segs (mapv :seg expanded-entries)
         ;; Scalar args
          scalar-type (if (= dtype :float) :float :double)
@@ -2624,8 +2648,8 @@
          group-count (long (Math/ceil (/ (double n) wg)))]
      (launch! kernel-handle group-count wg all-args)
     ;; Copy back only JVM arrays (GpuSoA/DeviceBuffer have :source nil)
-     (doseq [{:keys [seg source ab]} expanded-entries]
-       (when source
+     (doseq [{:keys [seg source ab write?]} expanded-entries]
+       (when (and source (or (nil? abi) write?))
          (MemorySegment/copy seg 0 (MemorySegment/ofArray source) 0 (long ab))))
      nil)))
 
@@ -2642,7 +2666,8 @@
    (bind-registered-map-void-kernel kernel-name arrays scalar-args n {}))
   ([^String kernel-name arrays scalar-args n opts]
    (let [_ (when-let [abi (:abi (get @kernel-registry kernel-name))]
-             (kabi/validate-split-binding! abi arrays scalar-args))
+             (kabi/validate-split-binding! abi arrays scalar-args)
+             (kabi/validate-physical-pointer-dtypes! abi (physical-pointer-dtypes arrays)))
          {:keys [module workgroup-size dtype]
           :or {workgroup-size 256 dtype :float}} (ensure-kernel-loaded! kernel-name)
          ;; CRITICAL: create a DEDICATED kernel handle per binding. Level Zero kernel args are

--- a/test/raster/compiler/backend/gpu/gpu_correctness_test.clj
+++ b/test/raster/compiler/backend/gpu/gpu_correctness_test.clj
@@ -236,6 +236,26 @@
        (is (seq devices) "Should find at least one GPU device")
        (is (string? (:name (first devices))) "Device should have a name")))))
 
+(deftest gpu-map-void-mixed-storage-abi-test
+  (when-ze
+   (testing "map-void stages byte input, int output and an int scalar through the ABI"
+     (require 'raster.gpu.ze-runtime)
+     ((resolve 'raster.gpu.ze-runtime/init!))
+     (let [n 64
+           q (byte-array (map #(byte (- (mod % 31) 15)) (range n)))
+           out (int-array n)
+           kernel (par-opencl/generate-par-map-void-kernel
+                   '(raster.par/map-void! i n
+                      (aset out i (+ (int (aget q i)) limit)))
+                   :dtype :float
+                   :array-types {'out :int 'q :byte}
+                   :scalar-types {'limit :int})
+           register! (resolve 'raster.gpu.ze-runtime/register-kernel!)
+           invoke! (resolve 'raster.gpu.ze-runtime/invoke-registered-map-void-kernel)]
+       (register! (:kernel-name kernel) kernel)
+       (invoke! (:kernel-name kernel) [out q] [{:type :int :value 7}] n)
+       (is (every? true? (map-indexed (fn [i v] (= v (+ 7 (aget q i)))) out)))))))
+
 (deftest gpu-segred-staging-captured-scalar-test
   (when-ze
    (testing "ordered SegRed staging inserts its partial output and binds captured scalars"

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [raster.compiler.backend.gpu.par-opencl :as par-opencl]
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
+            [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.passes.parallel.device :as device]
             [raster.compiler.support.spirv-cache :as spirv-cache]
             [raster.runtime.hardware :as hw]
@@ -77,6 +78,27 @@
       (is (= :float (:dtype kernel))))))
 
 ;; ================================================================
+;; Kernel generation: par/map-void!
+;; ================================================================
+
+(deftest generate-par-map-void-ordered-abi-test
+  (testing "multi-write/inout map-void ABI follows the emitted signature and preserves dtypes"
+    (let [form '(raster.par/map-void! i n
+                  (do (aset y i (* scale (aget x i)))
+                      (aset state i (+ (aget state i) limit))))
+          k (par-opencl/generate-par-map-void-kernel
+             form :dtype :float
+             :array-types {'state :int 'x :float 'y :float}
+             :scalar-types {'limit :int 'scale :float})]
+      (is (= '[state x y limit scale _n_bound] (mapv :name (:abi k))))
+      (is (= [:output :input :output :scalar :scalar :scalar] (mapv :kind (:abi k))))
+      (is (= [:int :float :float :int :float :int] (mapv :dtype (:abi k))))
+      (is (= [:inout :operand :effect :parameter :parameter :bound]
+             (mapv :role (:abi k))))
+      (is (= '[state x y] (:array-params k)))
+      (is (= '[state x y limit scale n] (:arguments k))))))
+
+;; ================================================================
 ;; Kernel generation: par/reduce
 ;; ================================================================
 
@@ -116,6 +138,22 @@
             body (nth transformed 2)] ;; body of let*
         (is (and (seq? body)
                  (= 'raster.gpu.ze-runtime/invoke-registered-kernel (first body))))))))
+
+(deftest opencl-pass-map-void-marker-follows-abi-test
+  (testing "the compatibility marker is projected from the ordered ABI"
+    (let [form '(raster.par/map-void! i n
+                  (do (aset y i (* scale (aget x i)))
+                      (aset state i (+ (aget state i) limit))))
+          result (opencl-pass/opencl-pass
+                  form :device-id :ze:0 :dtype :float
+                  :array-types {'state :int 'x :float 'y :float}
+                  :scalar-types {'limit :int 'scale :float})
+          marker (:form result)
+          abi (:abi (first (:kernels result)))]
+      (is (= 'raster.gpu.ze-runtime/invoke-registered-map-void-kernel (first marker)))
+      (is (= (kabi/pointer-binding-names abi) (nth marker 2)))
+      (is (= '[limit scale] (nth marker 3)))
+      (is (= 'n (nth marker 4))))))
 
 (deftest opencl-pass-fallback-test
   (testing "Small arrays fall back to scalar expansion"

--- a/test/raster/compiler/kernel_abi_test.clj
+++ b/test/raster/compiler/kernel_abi_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.gpu.core]
+            [raster.gpu.ocl-runtime :as ocl]
             [raster.gpu.ze-runtime :as ze]))
 
 (def map-abi
@@ -45,6 +46,38 @@
   (is (thrown-with-msg? clojure.lang.ExceptionInfo #"scalar dtype"
                         (kabi/validate-split-binding! map-abi [:x :out]
                                                       [{:type :int :value 2}]))))
+
+(deftest soa-physical-slots-collapse-to-one-logical-binding
+  (let [abi [(kabi/slot 'particles_x :output :float :binding 'particles :role :inout)
+             (kabi/slot 'particles_id :output :int :binding 'particles :role :inout)
+             (kabi/slot '_n_bound :scalar :int :role :bound)]]
+    (is (= '[particles] (kabi/pointer-binding-names abi)))
+    (is (= '[particles]
+           (:pointer-bindings (kabi/validate-split-binding! abi [:gpu-soa] []))))
+    (is (= [:float :int]
+           (kabi/validate-physical-pointer-dtypes! abi [:float :int])))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"physical pointer count"
+                          (kabi/validate-physical-pointer-dtypes! abi [:float])))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"storage dtype"
+                          (kabi/validate-physical-pointer-dtypes! abi [:float :float]))))
+  (testing "a logical SoA cannot be split around another physical binding"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must be contiguous"
+          (kabi/validate!
+           [(kabi/slot 'particles_x :output :float :binding 'particles)
+            (kabi/slot 'other :input :float)
+            (kabi/slot 'particles_id :output :int :binding 'particles)])))))
+
+(deftest repeated-unbound-name-remains-positional
+  (testing "an in-place generic map may bind the same value as an input and the result"
+    (let [abi [(kabi/slot 'x :input :float :role :inout)
+               (kabi/slot 'other :input :float :role :operand)
+               (kabi/slot 'x :output :float :c-name "out" :role :result)
+               (kabi/slot '_n_bound :scalar :int :role :bound)]]
+      (is (= abi (kabi/validate! abi)))
+      (is (= '[x other x] (kabi/pointer-binding-names abi)))
+      (is (= '[x other x]
+             (:pointer-bindings
+              (kabi/validate-split-binding! abi [:x-in :other :x-out] [])))))))
 
 (deftest ordered-reduction-binding-is-derived-from-roles
   (let [abi [(kabi/slot 'x :input :float :role :operand)
@@ -109,6 +142,42 @@
         (is (= :double (:actual (ex-data e)))))
       (finally
         (ze/register-kernel! kernel-name {:test-tombstone? true})))))
+
+(deftest map-void-staging-rejects-abi-errors-before-driver-loading
+  (let [kernel-name (str "map_void_abi_mismatch_" (gensym))
+        abi [(kabi/slot 'x :input :float :role :operand)
+             (kabi/slot 'out :output :int :role :effect)
+             (kabi/slot 'limit :scalar :int :role :parameter)
+             (kabi/slot '_n_bound :scalar :int :role :bound)]]
+    (ze/register-kernel! kernel-name {:abi abi :dtype :float})
+    (try
+      (testing "typed scalar mismatch is rejected before source-less kernel loading"
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"scalar dtype"
+              (ze/invoke-registered-map-void-kernel
+               kernel-name [(float-array 1) (int-array 1)]
+               [{:type :float :value 1.0}] 1))))
+      (testing "mixed pointer storage mismatch is rejected before source-less kernel loading"
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"storage dtype"
+              (ze/invoke-registered-map-void-kernel
+               kernel-name [(float-array 1) (float-array 1)]
+               [{:type :int :value 1}] 1))))
+      (finally
+        (ze/register-kernel! kernel-name {:test-tombstone? true})))))
+
+(deftest opencl-map-void-staging-rejects-abi-errors-before-driver-loading
+  (let [kernel-name (str "ocl_map_void_abi_mismatch_" (gensym))
+        abi [(kabi/slot 'x :input :float :role :operand)
+             (kabi/slot 'out :output :int :role :effect)
+             (kabi/slot 'limit :scalar :int :role :parameter)
+             (kabi/slot '_n_bound :scalar :int :role :bound)]]
+    (ocl/register-kernel! kernel-name {:abi abi :dtype :float})
+    (try
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"storage dtype"
+            (ocl/invoke-registered-map-void-kernel
+             kernel-name [(float-array 1) (float-array 1)]
+             [{:type :int :value 1}] 1)))
+      (finally
+        (ocl/register-kernel! kernel-name {:test-tombstone? true})))))
 
 (deftest reduction-staging-rejects-abi-errors-before-driver-loading
   (let [kernel-name (str "reduction_abi_mismatch_" (gensym))

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -8,6 +8,7 @@
   buffers (uninitialized device memory — Intel's driver zeroes allocations,
   POCL's malloc does not)."
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.par-opencl :as par-opencl]
             [raster.compiler.pipeline :as pl]
             [raster.arrays :as ra]
             [raster.core :refer [deftm]]))
@@ -36,6 +37,24 @@
             (clojure.core/+ acc (clojure.core/* scale (ra/aget x i))))]
     (raster.par/map-void! j n
       (ra/aset out j (clojure.core/* (ra/aget x j) s)))))
+
+(deftest ocl-map-void-mixed-storage-abi-roundtrip
+  (if-not @ocl-available?
+    (println "SKIP ocl mixed-storage map-void (no OpenCL device)")
+    (let [n 64
+          q (byte-array (map #(byte (- (mod % 31) 15)) (range n)))
+          out (int-array n)
+          kernel (par-opencl/generate-par-map-void-kernel
+                  '(raster.par/map-void! i n
+                     (aset out i (+ (int (aget q i)) limit)))
+                  :dtype :float
+                  :array-types {'out :int 'q :byte}
+                  :scalar-types {'limit :int})
+          register! (resolve 'raster.gpu.ocl-runtime/register-kernel!)
+          invoke! (resolve 'raster.gpu.ocl-runtime/invoke-registered-map-void-kernel)]
+      (register! (:kernel-name kernel) kernel)
+      (invoke! (:kernel-name kernel) [out q] [{:type :int :value 7}] n)
+      (is (every? true? (map-indexed (fn [i v] (= v (+ 7 (aget q i)))) out))))))
 
 (deftest ocl-resident-session-roundtrip
   (if-not @ocl-available?

--- a/test/raster/gpu/soa_test.clj
+++ b/test/raster/gpu/soa_test.clj
@@ -9,6 +9,7 @@
             [raster.core :refer [defvalue deftm]]
             [raster.compiler.backend.gpu.par-opencl :as par-opencl]
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
+            [raster.compiler.ir.kernel-abi :as kabi]
             [raster.runtime.display :as display])
   (:import [java.lang.foreign MemorySegment ValueLayout]))
 
@@ -157,7 +158,19 @@
       (is (str/includes? source "__global float* particles_vx"))
       (is (str/includes? source "__global float* particles_vy"))
       ;; Should NOT have a single particles param
-      (is (not (re-find #"__global float\* particles[^_]" source))))))
+      (is (not (re-find #"__global float\* particles[^_]" source))))
+    (testing "physical field slots retain one logical GpuSoA binding"
+      (let [body (tag-body
+                  (list 'raster.par/map-void! 'i 'n
+                        '(let* [p (aget particles i)]
+                               (aset particles i p)))
+                  {'particles 'TestParticleSoA})
+            kernel (first (:kernels (opencl-pass/opencl-pass body :dtype :float)))
+            abi (:abi kernel)]
+        (is (= '[particles_x particles_y particles_vx particles_vy _n_bound]
+               (mapv :name abi)))
+        (is (= '[particles] (kabi/pointer-binding-names abi)))
+        (is (= '[particles] (:array-params kernel)))))))
 
 (deftest soa-kernel-aget-field-projects-test
   (testing "SoA aget + field projection scalar-replaces to the per-field array read"


### PR DESCRIPTION
Summary

- emit and source-validate an ordered typed physical ABI for map-void kernels
- distinguish write-only effects, inout pointers, captured scalar types, and the implicit bound
- represent each SoA field as a physical slot while projecting one logical caller binding
- validate logical arity, expanded pointer storage, and scalar types before Level Zero/OpenCL driver loading
- use the ABI for door C buffer resolution and avoid downloading read-only staging inputs
- handle byte and half staging widths for quant-style mixed-storage kernels

Validation

- focused emitter/ABI/SoA: 49 tests, 186 assertions
- live Level Zero + OpenCL mixed-storage/runtime: 17 tests, 60 assertions
- exact Gemma resident regression: 3 tests, 94 assertions, including a 138-step training graph
- live Level Zero SoA launch: one logical binding expanded to four physical field pointers
- neighboring live resident/quant/backward gate: 58 tests, 226 assertions
- clojure -T:build jar

CI has no GPU, so the local Arc runs are the hardware gate.