### PR TITLE
Add executable KernelCall and a uniform resident binder

### DIFF
--- a/src/raster/compiler/ir/kernel_call.clj
+++ b/src/raster/compiler/ir/kernel_call.clj
@@ -1,0 +1,136 @@
+(ns raster.compiler.ir.kernel-call
+  "A verified executable call of one emitted kernel.
+
+   KernelArtifact owns target code, ABI and symbolic launch. KernelCall adds runtime values in the
+   identical ABI order and a concrete 1-3D LaunchGeometry. Backends consume this value instead of
+   reconstructing arguments or launch dimensions from a convention-specific marker."
+  (:require [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-launch :as klaunch]))
+
+(defrecord KernelCall [artifact arguments geometry])
+
+(defn kernel-call? [x] (instance? KernelCall x))
+
+(defn- scalar-value!
+  [slot value]
+  (when-not (and (map? value) (contains? value :value) (contains? value :type))
+    (throw (ex-info "kernel scalar argument must be a typed value"
+                    {:slot slot :value value})))
+  (when-not (= (:kernel-dtype slot) (:type value))
+    (throw (ex-info "kernel scalar argument has the wrong kernel dtype"
+                    {:slot slot :expected (:kernel-dtype slot) :actual (:type value)
+                     :value value})))
+  value)
+
+(defn validate!
+  "Validate and return a KernelCall. This is driver-independent: a backend subsequently checks
+   that pointer values are its resident buffer representation and match ABI storage dtypes."
+  [call]
+  (when-not (kernel-call? call)
+    (throw (ex-info "kernel call must be a KernelCall value"
+                    {:call call :actual (type call)})))
+  (let [{:keys [artifact arguments geometry]} call
+        artifact (kart/validate! artifact)
+        abi (:abi artifact)
+        arguments (kabi/validate-arguments! abi arguments)
+        geometry (klaunch/validate-geometry! geometry)
+        spec (:launch artifact)]
+    (when-not (= (klaunch/dimensions spec) (klaunch/dimensions geometry))
+      (throw (ex-info "kernel call launch dimensionality differs from its artifact"
+                      {:kernel-name (:kernel-name artifact)
+                       :spec (:launch artifact) :geometry geometry})))
+    ;; Emitted kernels may bake workgroup-sized local arrays or subgroup assumptions into source.
+    ;; A scheduler may choose the number of groups per call, but changing this workgroup requires
+    ;; re-emission and therefore a different artifact.
+    (when-let [static-wg (when (every? integer? (:workgroup-size spec))
+                           (klaunch/static-workgroup-size spec))]
+      (when-not (= static-wg (:workgroup-size geometry))
+        (throw (ex-info "kernel call workgroup differs from its emitted artifact"
+                        {:kernel-name (:kernel-name artifact)
+                         :expected static-wg :actual (:workgroup-size geometry)}))))
+    (when-not (= (:shared-memory-bytes spec) (:shared-memory-bytes geometry))
+      (throw (ex-info "kernel call shared memory differs from its emitted artifact"
+                      {:kernel-name (:kernel-name artifact)
+                       :expected (:shared-memory-bytes spec)
+                       :actual (:shared-memory-bytes geometry)})))
+    (doseq [[slot value] (map vector abi arguments)]
+      (if (= :scalar (:kind slot))
+        (scalar-value! slot value)
+        (when (nil? value)
+          (throw (ex-info "kernel pointer argument cannot be nil"
+                          {:kernel-name (:kernel-name artifact) :slot slot})))))
+    call))
+
+(defn- runtime-number
+  [value]
+  (if (and (map? value) (contains? value :value)) (:value value) value))
+
+(defn- argument-resolver
+  [artifact arguments]
+  (let [compiler-arguments (:arguments artifact)]
+    (fn [compiler-value]
+      (let [indexes (keep-indexed (fn [i value] (when (= compiler-value value) i))
+                                  compiler-arguments)]
+        (when-not (seq indexes)
+          (throw (ex-info "launch value is not present in the artifact argument order"
+                          {:kernel-name (:kernel-name artifact)
+                           :value compiler-value :arguments compiler-arguments})))
+        (let [values (mapv #(runtime-number (nth arguments %)) indexes)]
+          (when-not (apply = values)
+            (throw (ex-info "repeated launch value resolved to conflicting runtime arguments"
+                            {:kernel-name (:kernel-name artifact)
+                             :value compiler-value :indexes (vec indexes) :values values})))
+          (first values))))))
+
+(defn make
+  "Construct a checked call from an artifact and complete ABI-ordered runtime values.
+
+   The default geometry realizes the artifact launch by resolving compiler values against the
+   artifact/runtime argument vectors. `:group-count` is the scheduling seam: it may override the
+   realized group vector without changing the emitted workgroup (resident SegRed uses `[1]` to
+   keep its partial result entirely on device)."
+  ([artifact arguments] (make artifact arguments {}))
+  ([artifact arguments {:keys [group-count resolve-value]}]
+   (let [artifact (kart/validate! artifact)
+         arguments (kabi/validate-arguments! (:abi artifact) arguments)
+         resolver (or resolve-value (argument-resolver artifact arguments))
+         realized (klaunch/realize (:launch artifact) resolver)
+         geometry (if group-count
+                    (klaunch/geometry
+                     {:workgroup-size (:workgroup-size realized)
+                      :group-count group-count
+                      :shared-memory-bytes (:shared-memory-bytes realized)})
+                    realized)]
+     (validate! (->KernelCall artifact arguments geometry)))))
+
+(defn binding-plan
+  "Backend-neutral ordered binding plan for a checked call."
+  [call]
+  (let [{:keys [artifact arguments geometry]} (validate! call)
+        pairs (mapv vector (:abi artifact) arguments)]
+    {:kernel-name (:kernel-name artifact)
+     :target (:target artifact)
+     :artifact artifact
+     :abi (:abi artifact)
+     :arguments arguments
+     :pairs pairs
+     :pointer-pairs (filterv (fn [[slot _]] (not= :scalar (:kind slot))) pairs)
+     :scalar-pairs (filterv (fn [[slot _]] (= :scalar (:kind slot))) pairs)
+     :workgroup-size (:workgroup-size geometry)
+     :group-count (:group-count geometry)
+     :shared-memory-bytes (:shared-memory-bytes geometry)}))
+
+(defn validate-registered!
+  "Prove that a runtime registry entry is the artifact named by this call. Runtime-only cached
+   handles may extend the record, so compare compiler-owned fields rather than record equality."
+  [call registered]
+  (let [artifact (:artifact (validate! call))
+        registered (kart/validate! registered)
+        compiler-fields [:kernel-name :target :source :abi :arguments :launch :temporaries
+                         :effects :provenance :attributes]]
+    (when-not (= (select-keys artifact compiler-fields)
+                 (select-keys registered compiler-fields))
+      (throw (ex-info "kernel call artifact differs from the registered artifact"
+                      {:kernel-name (:kernel-name artifact)})))
+    registered))

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -29,6 +29,7 @@
             [raster.compiler.passes.scalar.rewalk :as rewalk]
             [raster.compiler.ir.par :as par]
             [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.backend.jvm.par-simd :as par-simd]
             [raster.compiler.backend.wasm.emit :as wasm-emit]
             [raster.compiler.backend.intrinsics :as ix]
@@ -1303,9 +1304,9 @@
               (recur (next ps) subst realized rbufs (conj out [sym init'])))))))))
 
 (defn- parse-gpu-step
-  "One invoke-registered-* binding → a step record. :arrays is the full resident-buffer arg
-   list in the kernel's signature order (for map! the separate output is appended, so on the
-   resident path it is just another buffer). nil for an unrecognized head."
+  "One invoke-registered-* binding → a step record. Artifact-backed map/reduction steps retain a
+   complete `:arguments` vector; specialized compatibility markers retain their explicit fields.
+   Returns nil for an unrecognized head."
   [sym expr]
   ;; Every arm below destructures a FIXED-length invoke prefix. The invoke forms are
   ;; compiler-generated (opencl_pass) with a known arity per convention. A wrong count means
@@ -1325,7 +1326,8 @@
       (= head 'raster.gpu.ze-runtime/invoke-registered-kernel)
       (when (= 6 argc)
         (let [[_ kname inputs out scalars n] expr]
-          {:kernel-name kname :arrays (conj (vec inputs) out) :scalars (vec scalars) :n-expr n
+          {:kernel-name kname
+           :arguments (vec (concat inputs [out] scalars [n]))
            :convention :map :returns sym}))
       (= head 'raster.gpu.ze-runtime/invoke-registered-contraction!)
       ;; The marker carries VALUES in exact emitter-authored ABI order.  Do not split or reorder
@@ -1478,11 +1480,8 @@
                   ;; that reads the binding sym (e.g. the primary of a horizontally-fused
                   ;; multi-output map, whose out is a fusion-materialized buffer) must
                   ;; resolve to the REAL resident buffer at bind time.
-                  (when (or (#{:map :contract} (:convention s))
-                            (and (= :reduce (:convention s)) (:arguments s)))
-                    (let [out (if (= :map (:convention s))
-                                (last (:arrays s))
-                                (:value ordered-result))]
+                  (when (and (#{:map :contract :reduce} (:convention s)) ordered-result)
+                    (let [out (:value ordered-result)]
                       (when (and (symbol? out) (not= sym out))
                         (vswap! aliases assoc sym out)))))))
               (reject! :unparseable-kernel-invoke sym expr))
@@ -1584,8 +1583,8 @@
       :scalar-params [n]
       :allocs [{:sym b :size-fn (fn [args] int)}]   ; intermediate scratch buffers
       :steps  [{:kernel-name str :convention :map|:contract|:reduce|... :phase kw
-                ;; maps carry split :arrays/:scalar-specs/:n-fn; contractions carry
-                ;; ordered :argument-specs plus :wg-fns/:grid-fns geometry
+                ;; artifact maps/reductions carry :artifact plus ordered :argument-specs;
+                ;; contractions carry ordered :argument-specs plus :wg-fns/:grid-fns geometry
                 ...}]
       :result-sym sym}
 
@@ -1830,20 +1829,30 @@
                            :grid-fns (mapv #(expr->arg-fn all-params scalar-lets %) grid-exprs)
                            :phase (keyword (str "gpu-step-" i))})
 
-                        (and (= :reduce (:convention step)) (:arguments step))
-                        (let [{:keys [kernel-name arguments]} step
-                              abi (some-> (reg-entry kernel-name) :abi kabi/validate!)
-                              _ (when-not abi
-                                  (throw (ex-info "resident reduction kernel has no registered ordered ABI"
-                                                  {:kernel-name kernel-name})))
-                              {:keys [result-pair]} (kabi/validate-reduction-arguments! abi arguments)
-                              output (second result-pair)
+                        (and (#{:map :reduce} (:convention step)) (:arguments step))
+                        (let [{:keys [kernel-name arguments convention]} step
+                              artifact (reg-entry kernel-name)
+                              _ (when-not (kart/kernel-artifact? artifact)
+                                  (throw (ex-info "resident map/reduction kernel is not a registered KernelArtifact"
+                                                  {:kernel-name kernel-name
+                                                   :convention convention :entry artifact})))
+                              artifact (kart/validate! artifact)
+                              abi (:abi artifact)
+                              _ (kabi/validate-arguments! abi arguments)
+                              result-pairs (filterv (fn [[slot _]] (= :result (:role slot)))
+                                                    (map vector abi arguments))
+                              _ (when-not (= 1 (count result-pairs))
+                                  (throw (ex-info "resident kernel ABI must identify exactly one :result slot"
+                                                  {:kernel-name kernel-name :abi abi
+                                                   :result-slots (mapv first result-pairs)})))
+                              output (second (first result-pairs))
                               _ (when-not (symbol? output)
-                                  (throw (ex-info "resident reduction requires a concrete output buffer at the ABI :result slot"
+                                  (throw (ex-info "resident kernel requires a concrete output buffer at the ABI :result slot"
                                                   {:kernel-name kernel-name :output output
                                                    :abi abi :arguments arguments})))]
-                          {:convention :reduce
+                          {:convention convention
                            :kernel-name kernel-name
+                           :artifact artifact
                            :abi abi
                            :argument-specs
                            (mapv (fn [slot value]

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -30,6 +30,7 @@
             [raster.compiler.core.hardware :as hw]
             [raster.compiler.core.inference :as inf]
             [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.pipeline :as pl]
             [raster.core :as rcore]))
 
@@ -689,14 +690,13 @@
    weights/KV per layer and scratch shared, like the decoder's pbk). Does NOT record a graph; the
    caller collects :phase keys and records once.
 
-     :reduce    Ordered SegRed ABI values bind through bind-registered-reduction!; legacy/manual
-                descriptors retain the split inputs/output/scalars/bound compatibility path.
-     :map       SegMap sig (inputs…, out, scl…, _n_bound); the output is a SEPARATE param not in the
-                registry :array-params, so bind the step's full :arrays (inputs ++ [out]).
+     :map/:reduce
+                Artifact ABI values and realized geometry bind through one KernelCall contract.
+                SegRed explicitly schedules one resident workgroup; SegMap realizes its grid.
      :map-void  output is an in-place array among :array-params; bind by name via prepare!."
   [sess step args sym->key]
   (let [device-id (:device-id @sess)
-        {:keys [kernel-name arrays n-fn scalar-specs phase convention output]} step
+        {:keys [kernel-name arrays n-fn scalar-specs phase convention artifact argument-specs]} step
         info-fn (rt-resolve device-id "kernel-registry-entry")]
     (when-not (#{:map-void :map :reduce} convention)
       (throw (ex-info (str "bind-step! cannot bind a " convention " step (" kernel-name
@@ -711,25 +711,19 @@
                                                   {:kernel kernel-name :available (keys bufs)}))))
           scalars (mapv (fn [{:keys [type value-fn]}] {:type type :value (value-fn args)})
                         scalar-specs)
-          bind-fn (rt-resolve device-id "bind-registered-map-void-kernel")]
+          bind-fn (rt-resolve device-id "bind-registered-map-void-kernel")
+          bind-call-fn (rt-resolve device-id "bind-kernel-call")]
       (case convention
-        :reduce
-        (let [prepared
-              (if-let [specs (:argument-specs step)]
-                (let [ordered-args
-                      (mapv (fn [{:keys [kind sym type value-fn]}]
-                              (if (= :scalar kind)
-                                {:type type :value (value-fn args)}
-                                (resolve-buf sym)))
-                            specs)]
-                  ((rt-resolve device-id "bind-registered-reduction!") kernel-name ordered-args))
-                (let [array-bufs (conj (mapv resolve-buf (:array-params ki)) (resolve-buf output))]
-                  (bind-fn kernel-name array-bufs scalars (long (n-fn args)) {:group-count 1})))]
-          (swap! sess assoc-in [:prepared phase] prepared))
-
-        :map
-        (let [array-bufs (mapv resolve-buf arrays)
-              prepared (bind-fn kernel-name array-bufs scalars (long (n-fn args)) {})]
+        (:map :reduce)
+        (let [ordered-args
+              (mapv (fn [{:keys [kind sym type value-fn]}]
+                      (if (= :scalar kind)
+                        {:type type :value (value-fn args)}
+                        (resolve-buf sym)))
+                    argument-specs)
+              call (kcall/make artifact ordered-args
+                               (if (= :reduce convention) {:group-count [1]} {}))
+              prepared (bind-call-fn call)]
           (swap! sess assoc-in [:prepared phase] prepared))
 
         (let [sym->buf (into {} (map (fn [p] [(name p) (sym->key p)]) (:array-params ki)))]
@@ -1107,8 +1101,8 @@
                            allocs)
          info-fn   (rt-resolve device-id "kernel-registry-entry")
          bind-fn   (rt-resolve device-id "bind-registered-map-void-kernel")
+         bind-call-fn (rt-resolve device-id "bind-kernel-call")
          contract-fn (rt-resolve device-id "bind-registered-contraction!")
-         reduction-fn (rt-resolve device-id "bind-registered-reduction!")
          gemm-fn   (rt-resolve device-id "bind-registered-gemm!")
          conv-fn   (rt-resolve device-id "bind-registered-convert!")
          trans-fn  (rt-resolve device-id "bind-registered-transpose!")
@@ -1149,7 +1143,8 @@
            ;; 7.2 → 0.6 ms, transpose_half 3.2 → 0.2 ms per replay.
            const-operand? (fn [sym] (= :constant (get effective-roles sym)))
            step->bounds
-           (fn [{:keys [kernel-name arrays n-fn scalar-specs convention accumulator output] :as step}]
+           (fn [{:keys [kernel-name arrays n-fn scalar-specs convention accumulator
+                        artifact argument-specs] :as step}]
              (case convention
                ;; GEMM (Option B): [convert A f32→f16][convert B f32→f16][fp16 XMX gemm → f32 C].
                ;; A/B are converted into per-GEMM f16 scratch (kept alive on the session); the
@@ -1231,14 +1226,29 @@
                      (mapv (fn [[nm b c]] {:bound b :kernel-name nm :phase (:phase step)
                                            :const-prologue? (boolean c)})
                            raw))))
-               ;; map / map-void bind through bind-registered-map-void-kernel (output is just
-               ;; another resident buffer). Resolve buffers from the STEP's :arrays (full C-sig
-               ;; order incl. output).
-               (:map :map-void)
+               ;; Generic map and reduction now share the complete executable value: emitted
+               ;; artifact, ordered ABI values and realized launch. Reduction's single-group
+               ;; resident schedule is explicit here rather than hidden in a special binder.
+               (:map :reduce)
+               (let [ordered-args
+                     (mapv (fn [{:keys [kind sym type value-fn]}]
+                             (if (= :scalar kind)
+                               {:type type :value (value-fn args)}
+                               (buf-of sym kernel-name)))
+                           argument-specs)
+                     call (kcall/make artifact ordered-args
+                                      (if (= :reduce convention) {:group-count [1]} {}))]
+                 [(assoc (bind-call-fn call) :phase (:phase step))])
+
+               ;; Map-void has not migrated to KernelArtifact yet; retain its compatibility
+               ;; binder until its emitter carries a complete artifact and ordered call values.
+               :map-void
                (do (or (info-fn kernel-name)
-                       (throw (ex-info (str "Program kernel not registered: " kernel-name) {:kernel kernel-name})))
+                       (throw (ex-info (str "Program kernel not registered: " kernel-name)
+                                       {:kernel kernel-name})))
                    (let [buf-vec (mapv #(buf-of % kernel-name) arrays)
-                         scalars (mapv (fn [{:keys [type value-fn]}] {:type type :value (value-fn args)})
+                         scalars (mapv (fn [{:keys [type value-fn]}]
+                                         {:type type :value (value-fn args)})
                                        scalar-specs)]
                      [(assoc (bind-fn kernel-name buf-vec scalars (long (n-fn args)))
                              :phase (:phase step))]))
@@ -1301,32 +1311,6 @@
                      [(assoc (bind-fn zk [out-buf] [] (long out-size)) :phase (:phase step))
                       (assoc (scatter-fn kernel-name [out-buf src-buf idx-buf] n stride)
                              :phase (:phase step))]))
-               ;; reduce: SegRed sig (inputs…, output, scl…, _n_bound) — bind the registry's
-               ;; :array-params ++ [output] and launch a SINGLE workgroup (:group-count 1) so
-               ;; the kernel's grid-stride loop covers all n and writes output[0] into its
-               ;; resident 1-elem buffer (mirrors bind-step!'s :reduce; the #42 leftover).
-               :reduce
-               (do (or (info-fn kernel-name)
-                       (throw (ex-info (str "Program kernel not registered: " kernel-name)
-                                       {:kernel kernel-name})))
-                   (let [prepared
-                         (if-let [specs (:argument-specs step)]
-                           (let [ordered-args
-                                 (mapv (fn [{:keys [kind sym type value-fn]}]
-                                         (if (= :scalar kind)
-                                           {:type type :value (value-fn args)}
-                                           (buf-of sym kernel-name)))
-                                       specs)]
-                             (reduction-fn kernel-name ordered-args))
-                           (let [ki (info-fn kernel-name)
-                                 array-bufs (conj (mapv #(buf-of % kernel-name) (:array-params ki))
-                                                  (buf-of output kernel-name))
-                                 scalars (mapv (fn [{:keys [type value-fn]}]
-                                                 {:type type :value (value-fn args)})
-                                               scalar-specs)]
-                             (bind-fn kernel-name array-bufs scalars (long (n-fn args))
-                                      {:group-count 1})))]
-                     [(assoc prepared :phase (:phase step))]))
                (throw (ex-info (str "bind-program! cannot bind a " convention " step — only "
                                     ":map / :map-void / :contract / :reduce / :gemm / :scatter "
                                     "are wired on the resident path")

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -22,6 +22,7 @@
   (:require [raster.compiler.core.dtype :as dt]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-launch :as klaunch]))
 
 ;; ================================================================
@@ -1125,6 +1126,43 @@
     :else (throw (ex-info "bound path requires GPU-resident args (OclBuffer); JVM-array staging is not supported here"
                           {:arr-type (type arr)}))))
 
+(defn bind-kernel-call
+  "Bind a backend-neutral KernelCall over OpenCL resident buffers. ABI order and complete 1-3D
+   geometry come exclusively from the call; no map/reduction convention is interpreted."
+  [call]
+  (let [{:keys [kernel-name abi pairs pointer-pairs workgroup-size group-count] :as plan}
+        (kcall/binding-plan call)
+        registered (or (get @kernel-registry kernel-name)
+                       (throw (ex-info (str "Kernel not registered: " kernel-name)
+                                       {:kernel-name kernel-name
+                                        :registered (keys @kernel-registry)})))
+        _ (kcall/validate-registered! call registered)
+        pointer-values (mapv second pointer-pairs)
+        _ (doseq [[slot value] pointer-pairs]
+            (when-not (or (device-buffer? value) (instance? MemorySegment value))
+              (throw (ex-info "OpenCL KernelCall requires OclBuffer/MemorySegment pointers"
+                              {:kernel-name kernel-name :slot slot :value-type (type value)}))))
+        _ (kabi/validate-physical-pointer-dtypes!
+           abi (physical-pointer-dtypes pointer-values))
+        _ (when (= :pure-reduction (get-in registered [:effects :kind]))
+            (doseq [[slot value] pointer-pairs
+                    :when (= :result (:role slot))]
+              (when (and (device-buffer? value) (< (:n-elements ^OclBuffer value) 1))
+                (throw (ex-info "resident reduction result buffer must hold at least one element"
+                                {:kernel-name kernel-name :slot slot :buffer-elements 0})))))
+        ;; Driver contact begins only after call/artifact/ABI/value/geometry validation.
+        {:keys [program]} (ensure-kernel-loaded! kernel-name)
+        kh (create-kernel-fresh program kernel-name)]
+    (doseq [[idx [slot value]] (map-indexed vector pairs)]
+      (if (= :scalar (:kind slot))
+        (set-kernel-arg-scalar! kh idx value)
+        (set-kernel-arg-buffer! kh idx (device-mem-of value))))
+    {:bound {:kernel kh :wg workgroup-size}
+     :group-count group-count
+     :kernel-name kernel-name
+     :kernel-call call
+     :binding-plan plan}))
+
 (defn bind-registered-map-void-kernel
   "Pre-bind a registered void-map kernel's args ONCE over RESIDENT OclBuffers.
   Same contract as ze-runtime/bind-registered-map-void-kernel: buffer CONTENTS
@@ -1155,42 +1193,6 @@
       :group-count (long (or (get opts :group-count) (Math/ceil (/ (double n) wg))))
       :kernel-name kernel-name
       :async? (boolean (get opts :async?))})))
-
-(defn bind-registered-reduction!
-  "OpenCL resident SegRed binder. Consumes complete values in emitter-authored ABI order and
-   derives its pointer/scalar/bound projections exclusively from slot kinds and roles."
-  [^String kernel-name arguments]
-  (let [registered (or (get @kernel-registry kernel-name)
-                       (throw (ex-info (str "Kernel not registered: " kernel-name)
-                                       {:kernel-name kernel-name
-                                        :registered (keys @kernel-registry)})))
-        abi (kabi/validate! (:abi registered))
-        {:keys [pointer-pairs scalar-pairs result-pair bound-pair]}
-        (kabi/validate-reduction-arguments! abi arguments)
-        _ (doseq [[slot value] pointer-pairs]
-            (when-not (or (device-buffer? value) (instance? MemorySegment value))
-              (throw (ex-info "resident reduction requires OclBuffer/MemorySegment pointer arguments"
-                              {:kernel-name kernel-name :slot slot :value-type (type value)})))
-            (when (and (device-buffer? value)
-                       (not= (:dtype slot) (dt/canon (:dtype ^OclBuffer value))))
-              (throw (ex-info "reduction ABI storage dtype does not match resident buffer"
-                              {:kernel-name kernel-name :slot slot :expected (:dtype slot)
-                               :actual (dt/canon (:dtype ^OclBuffer value))}))))
-        result-value (second result-pair)
-        _ (when (and (device-buffer? result-value)
-                     (< (:n-elements ^OclBuffer result-value) 1))
-            (throw (ex-info "resident reduction result buffer must hold at least one element"
-                            {:kernel-name kernel-name :buffer-elements 0})))
-        _ (doseq [[slot value] (conj scalar-pairs bound-pair)]
-            (when-not (and (map? value) (= (:kernel-dtype slot) (:type value)))
-              (throw (ex-info "reduction ABI scalar binding has the wrong kernel dtype"
-                              {:kernel-name kernel-name :slot slot
-                               :expected (:kernel-dtype slot)
-                               :actual (when (map? value) (:type value))}))))
-        pointers (mapv second pointer-pairs)
-        scalars (mapv second scalar-pairs)
-        n (long (:value (second bound-pair)))]
-    (bind-registered-map-void-kernel kernel-name pointers scalars n {:group-count 1})))
 
 (defn bind-registered-contraction!
   "Pre-bind a routed contraction over resident OclBuffers in exact ordered ABI position.
@@ -1271,7 +1273,7 @@
 (defn launch-registered-bound!
   "Dispatch a pre-bound kernel. Synchronous."
   [prepared]
-  (enqueue-bound! (:bound prepared) (long (:group-count prepared)))
+  (enqueue-bound! (:bound prepared) (:group-count prepared))
   (cl-call! "clFinish" @h-clFinish [(:queue @state)]))
 
 (defn record-graph!

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -35,6 +35,7 @@
             [raster.compiler.core.dtype :as dt]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-launch :as klaunch]))
 
 ;; ================================================================
@@ -1464,7 +1465,7 @@
 ;; ================================================================
 
 (defn bind-kernel!
-  "Pre-bind kernel arguments for fast repeated launches.
+  "Pre-bind kernel arguments for fast repeated 1-3D launches.
   Returns a map that can be passed to launch-bound!.
 
   kernel-args: same format as launch! args
@@ -1472,14 +1473,22 @@
   Optional cmd-list selects which immediate command list launch-bound! appends to —
   default is the synchronous list (each dispatch blocks); pass (async-cmd-list) for batched
   dispatch (appends return immediately; sync once via synchronize-async!)."
-  ([^MemorySegment kernel ^long workgroup-size-x kernel-args]
-   (bind-kernel! kernel workgroup-size-x kernel-args (:cmd-list @state)))
-  ([^MemorySegment kernel ^long workgroup-size-x kernel-args ^MemorySegment cmd-list]
+  ([^MemorySegment kernel workgroup-size kernel-args]
+   (bind-kernel! kernel workgroup-size kernel-args (:cmd-list @state)))
+  ([^MemorySegment kernel workgroup-size kernel-args ^MemorySegment cmd-list]
    (ensure-init!)
-   (let [arena (:arena @state)]
+   (let [arena (:arena @state)
+         workgroup-size (if (vector? workgroup-size)
+                          workgroup-size
+                          [(long workgroup-size)])
+         _ (when-not (and (<= 1 (count workgroup-size) 3)
+                          (every? #(and (integer? %) (pos? %)) workgroup-size))
+             (throw (ex-info "Level Zero binding requires a positive 1-3D workgroup vector"
+                             {:workgroup-size workgroup-size})))
+         [wg-x wg-y wg-z] (take 3 (concat workgroup-size [1 1]))]
     ;; Set group size once
      (ze-call! "zeKernelSetGroupSize" @h-zeKernelSetGroupSize
-               [kernel (int workgroup-size-x) (int 1) (int 1)])
+               [kernel (int wg-x) (int wg-y) (int wg-z)])
     ;; Set all arguments once
      (doseq [[idx arg] (map-indexed vector kernel-args)]
        (if (instance? MemorySegment arg)
@@ -1504,10 +1513,20 @@
              :long   (let [s (.allocate ^Arena arena I64)]
                        (.set s I64 0 (long value))
                        (ze-call! (str "zeKernelSetArgumentValue[" idx "]") @h-zeKernelSetArgumentValue
-                                 [kernel (int idx) (long 8) s]))))))
+                                 [kernel (int idx) (long 8) s]))
+             :half   (let [s (.allocate ^Arena arena ValueLayout/JAVA_SHORT)]
+                       (.set s ValueLayout/JAVA_SHORT 0
+                             (short (Float/floatToFloat16 (float value))))
+                       (ze-call! (str "zeKernelSetArgumentValue[" idx "]") @h-zeKernelSetArgumentValue
+                                 [kernel (int idx) (long 2) s]))
+             :byte   (let [s (.allocate ^Arena arena ValueLayout/JAVA_BYTE)]
+                       (.set s ValueLayout/JAVA_BYTE 0 (byte value))
+                       (ze-call! (str "zeKernelSetArgumentValue[" idx "]") @h-zeKernelSetArgumentValue
+                                 [kernel (int idx) (long 1) s]))))))
      (let [gc-seg (.allocate arena 12)
            cmd cmd-list]
-      ;; Pre-fill Y=1, Z=1 (only X changes per launch)
+      ;; Pre-fill a legal 1-D launch; KernelCall binding overwrites every active dimension.
+       (.set gc-seg I32 0 (int 1))
        (.set gc-seg I32 4 (int 1))
        (.set gc-seg I32 8 (int 1))
       ;; Pre-allocate launch args array (reused every call)
@@ -1518,84 +1537,23 @@
           :h-launch @h-zeCommandListAppendLaunchKernel})))))
 
 (defn launch-bound!
-  "Launch a pre-bound kernel. Only dispatches (no arg setup, no barrier).
+  "Launch a pre-bound 1-3D kernel. Only dispatches (no arg setup, no barrier).
   Uses synchronous command list — completes before returning.
   Much faster than launch! for repeated calls on the same buffers.
 
   bound: map from bind-kernel!
-  group-count-x: number of workgroups"
-  [bound ^long group-count-x]
-  (let [^MemorySegment gc (:gc-seg bound)]
-    (.set gc I32 0 (int group-count-x))
+  `group-count` is a positive one-to-three-dimensional vector or a legacy 1-D scalar."
+  [bound group-count]
+  (let [^MemorySegment gc (:gc-seg bound)
+        group-count (if (vector? group-count) group-count [(long group-count)])]
+    (when-not (and (<= 1 (count group-count) 3)
+                   (every? #(and (integer? %) (pos? %)) group-count))
+      (throw (ex-info "Level Zero launch requires a positive 1-3D group-count vector"
+                      {:group-count group-count})))
+    (doseq [[axis count] (map-indexed vector (take 3 (concat group-count [1 1])))]
+      (.set gc I32 (long (* axis 4)) (int count)))
     ;; Synchronous cmd list: launch completes before return, no barrier needed
     ;; Reuse pre-allocated args array
-    (.invokeWithArguments ^MethodHandle (:h-launch bound)
-                          ^"[Ljava.lang.Object;" (:launch-args bound))))
-
-(defn bind-kernel-2d!
-  "Pre-bind kernel arguments for fast repeated 2D launches.
-  Returns a map that can be passed to launch-bound-2d!.
-
-  workgroup-size: [x y] threads per workgroup
-  kernel-args: same format as launch! args"
-  [^MemorySegment kernel workgroup-size kernel-args]
-  (ensure-init!)
-  (let [arena (:arena @state)
-        [wg-x wg-y] workgroup-size]
-    ;; Set group size once
-    (ze-call! "zeKernelSetGroupSize" @h-zeKernelSetGroupSize
-              [kernel (int wg-x) (int wg-y) (int 1)])
-    ;; Set all arguments once
-    (doseq [[idx arg] (map-indexed vector kernel-args)]
-      (if (instance? MemorySegment arg)
-        (let [arg-ptr (ptr-seg arena)]
-          (.set arg-ptr PTR 0 ^MemorySegment arg)
-          (ze-call! (str "zeKernelSetArgumentValue[" idx "]") @h-zeKernelSetArgumentValue
-                    [kernel (int idx) (long (.byteSize PTR)) arg-ptr]))
-        (let [{:keys [type value]} arg]
-          (case type
-            :int    (let [s (.allocate ^Arena arena I32)]
-                      (.set s I32 0 (int value))
-                      (ze-call! (str "zeKernelSetArgumentValue[" idx "]") @h-zeKernelSetArgumentValue
-                                [kernel (int idx) (long 4) s]))
-            :float  (let [s (.allocate ^Arena arena ValueLayout/JAVA_FLOAT)]
-                      (.set s ValueLayout/JAVA_FLOAT 0 (float value))
-                      (ze-call! (str "zeKernelSetArgumentValue[" idx "]") @h-zeKernelSetArgumentValue
-                                [kernel (int idx) (long 4) s]))
-            :double (let [s (.allocate ^Arena arena F64)]
-                      (.set s F64 0 (double value))
-                      (ze-call! (str "zeKernelSetArgumentValue[" idx "]") @h-zeKernelSetArgumentValue
-                                [kernel (int idx) (long 8) s]))
-            :long   (let [s (.allocate ^Arena arena I64)]
-                      (.set s I64 0 (long value))
-                      (ze-call! (str "zeKernelSetArgumentValue[" idx "]") @h-zeKernelSetArgumentValue
-                                [kernel (int idx) (long 8) s]))
-            :half   (let [s (.allocate ^Arena arena ValueLayout/JAVA_SHORT)]
-                      (.set s ValueLayout/JAVA_SHORT 0
-                            (short (Float/floatToFloat16 (float value))))
-                      (ze-call! (str "zeKernelSetArgumentValue[" idx "]") @h-zeKernelSetArgumentValue
-                                [kernel (int idx) (long 2) s]))
-            :byte   (let [s (.allocate ^Arena arena ValueLayout/JAVA_BYTE)]
-                      (.set s ValueLayout/JAVA_BYTE 0 (byte value))
-                      (ze-call! (str "zeKernelSetArgumentValue[" idx "]") @h-zeKernelSetArgumentValue
-                                [kernel (int idx) (long 1) s]))))))
-    (let [gc-seg (.allocate arena 12)
-          cmd (:cmd-list @state)]
-      (.set gc-seg I32 8 (int 1))  ;; Z=1
-      (let [launch-args (object-array [cmd kernel gc-seg
-                                       MemorySegment/NULL (int 0) MemorySegment/NULL])]
-        {:kernel kernel :cmd cmd :gc-seg gc-seg
-         :launch-args launch-args
-         :h-launch @h-zeCommandListAppendLaunchKernel}))))
-
-(defn launch-bound-2d!
-  "Launch a pre-bound 2D kernel. Only sets group counts and dispatches.
-  bound: map from bind-kernel-2d!
-  group-count-x, group-count-y: number of workgroups in each dimension"
-  [bound ^long group-count-x ^long group-count-y]
-  (let [^MemorySegment gc (:gc-seg bound)]
-    (.set gc I32 0 (int group-count-x))
-    (.set gc I32 4 (int group-count-y))
     (.invokeWithArguments ^MethodHandle (:h-launch bound)
                           ^"[Ljava.lang.Object;" (:launch-args bound))))
 
@@ -1625,7 +1583,7 @@
 
 (defn record-graph!
   "Record an ordered seq of bound kernels into a regular (replayable) command list.
-  Each `bound` (from bind-kernel!/bind-kernel-2d!, each carrying its own dedicated
+  Each `bound` (from the uniform bind-kernel!, carrying its own dedicated
   kernel handle with args + group counts already set into its :gc-seg) is appended
   once, with NO per-op barrier — ordering is implicit in the list. Returns a graph
   {:queue :list :lists-arr} for replay-graph!. Re-record only if the kernel
@@ -2050,40 +2008,6 @@
   [kernel-name]
   (get @kernel-registry kernel-name))
 
-(defn bind-registered-map-void-kernel
-  "Bind a registered void-map kernel over GPU-RESIDENT args, for recording into a
-  command graph (whole-offload). `arrays` must be resident (DeviceBuffer /
-  MemorySegment) — NO per-call JVM-array staging (residency is the whole point).
-  `scalar-args` are scalar values; `n` is the element count. Returns a bound map
-  {:kernel :gc-seg …} (from bind-kernel!, with :gc-seg X pre-set to the group
-  count) — pass directly to record-graph!. A FRESH kernel handle per binding is
-  used (LZ kernel args are mutable handle state → shared handles clobber)."
-  [kernel-name arrays scalar-args n]
-  (let [{:keys [module workgroup-size dtype]
-         :or {workgroup-size 256 dtype :float}} (ensure-kernel-loaded! kernel-name)
-        kernel-handle (create-kernel-fresh module kernel-name)
-        wg (long workgroup-size)
-        n (long n)
-        dev-segs (reduce
-                  (fn [acc arr]
-                    (cond
-                      (device-buffer? arr)          (conj acc (:segment ^DeviceBuffer arr))
-                      (instance? MemorySegment arr)  (conj acc arr)
-                      :else (throw (ex-info "bind-registered-map-void-kernel requires GPU-resident args (DeviceBuffer/MemorySegment); JVM-array staging is not supported on the bound path"
-                                            {:arr-type (type arr)}))))
-                  [] arrays)
-        scalar-type (if (= dtype :float) :float :double)
-        scalar-kernel-args (mapv (fn [v]
-                                   (if (map? v) v
-                                       {:type scalar-type
-                                        :value (if (= scalar-type :float) (float v) (double v))}))
-                                 scalar-args)
-        all-args (vec (concat dev-segs scalar-kernel-args [{:type :int :value (int n)}]))
-        group-count (long (Math/ceil (/ (double n) (double wg))))
-        bnd (bind-kernel! kernel-handle wg all-args)]
-    (.set ^MemorySegment (:gc-seg bnd) I32 0 (int group-count))
-    bnd))
-
 (defn bind-registered-gemm!
   "Bind the XMX GEMM kernel (C = A×B) over RESIDENT fp16 DeviceBuffers for recording into a
   command graph — the resident analog of invoke-registered-gemm! (which stages JVM arrays every
@@ -2106,7 +2030,7 @@
          m (long m) n (long n) k (long k)
          args [(:segment a) (:segment b) (:segment c)
                {:type :int :value (int m)} {:type :int :value (int n)} {:type :int :value (int k)}]
-         bnd (bind-kernel-2d! kh [256 1] args)
+         bnd (bind-kernel! kh [256 1] args)
          gc ^MemorySegment (:gc-seg bnd)]
      (.set gc I32 0 (int (Math/ceil (/ (double n) (double (:block-n (gemm-tile)))))))   ;; X = gc-n
      (.set gc I32 4 (int (Math/ceil (/ (double m) (double (:block-m (gemm-tile)))))))   ;; Y = gc-m
@@ -2164,7 +2088,7 @@
         kh   (create-kernel-fresh module kernel-name)
         args [(:segment a) (:segment b) (:segment c)
               {:type :int :value (int m)} {:type :int :value (int n)} {:type :int :value (int k)}]
-        bnd  (bind-kernel-2d! kh [wg 1] args)
+        bnd  (bind-kernel! kh [wg 1] args)
         gc ^MemorySegment (:gc-seg bnd)]
     (.set gc I32 0 (int (Math/ceil (/ (double n) (double block-n)))))   ;; X = gc-n
     (.set gc I32 4 (int (Math/ceil (/ (double m) (double block-m)))))   ;; Y = gc-m
@@ -2214,7 +2138,7 @@
         args (vec (concat [(:segment a) (:segment b) (:segment c)
                            {:type :int :value (int m)} {:type :int :value (int n)} {:type :int :value (int k)}]
                           (map :segment (:operands epilogue))))
-        bnd  (bind-kernel-2d! kh [wg 1] args)
+        bnd  (bind-kernel! kh [wg 1] args)
         gc ^MemorySegment (:gc-seg bnd)]
     (.set gc I32 0 (int (Math/ceil (/ (double n) (double block-n)))))
     (.set gc I32 4 (int (Math/ceil (/ (double m) (double block-m)))))
@@ -2283,7 +2207,7 @@
         args [(:segment a) (:segment b) (:segment partials)
               {:type :int :value (int m)} {:type :int :value (int n)}
               {:type :int :value (int k)} {:type :int :value (int kc)}]
-        bnd (bind-kernel-2d! kh [256 1] args)
+        bnd (bind-kernel! kh [256 1] args)
         gc ^MemorySegment (:gc-seg bnd)]
     (.set gc I32 0 (int (Math/ceil (/ (double n) 128.0))))   ;; X = gc-n
     (.set gc I32 4 (int (Math/ceil (/ (double m) 128.0))))   ;; Y = gc-m
@@ -2348,7 +2272,7 @@
         args [(:segment a) (:segment b) (:segment c)
               {:type :int :value (int m)} {:type :int :value (int n)}
               {:type :int :value (int k)}]
-        bnd (bind-kernel-2d! kh [256 1] args)
+        bnd (bind-kernel! kh [256 1] args)
         gc ^MemorySegment (:gc-seg bnd)]
     (.set gc I32 0 (int (Math/ceil (/ (double n) 128.0))))   ;; X = gc-n
     (.set gc I32 4 (int (Math/ceil (/ (double m) 128.0))))   ;; Y = gc-m
@@ -2604,6 +2528,51 @@
          (MemorySegment/copy seg 0 (MemorySegment/ofArray source) 0 (long ab))))
      nil)))
 
+(defn bind-kernel-call
+  "Bind a backend-neutral KernelCall over Level Zero resident buffers. ABI order and complete
+   1-3D geometry come exclusively from the call; no map/reduction convention is interpreted."
+  [call]
+  (let [{:keys [kernel-name abi pairs pointer-pairs workgroup-size group-count] :as plan}
+        (kcall/binding-plan call)
+        registered (or (get @kernel-registry kernel-name)
+                       (throw (ex-info (str "Kernel not registered: " kernel-name)
+                                       {:kernel-name kernel-name
+                                        :registered (keys @kernel-registry)})))
+        _ (kcall/validate-registered! call registered)
+        pointer-values (mapv second pointer-pairs)
+        _ (doseq [[slot value] pointer-pairs]
+            (when-not (or (device-buffer? value) (instance? MemorySegment value))
+              (throw (ex-info "Level Zero KernelCall requires DeviceBuffer/MemorySegment pointers"
+                              {:kernel-name kernel-name :slot slot :value-type (type value)}))))
+        _ (kabi/validate-physical-pointer-dtypes!
+           abi (physical-pointer-dtypes pointer-values))
+        _ (when (= :pure-reduction (get-in registered [:effects :kind]))
+            (doseq [[slot value] pointer-pairs
+                    :when (= :result (:role slot))]
+              (when (and (device-buffer? value) (< (:n-elements ^DeviceBuffer value) 1))
+                (throw (ex-info "resident reduction result buffer must hold at least one element"
+                                {:kernel-name kernel-name :slot slot :buffer-elements 0})))))
+        ;; Driver contact begins only after call/artifact/ABI/value/geometry validation.
+        {:keys [module]} (ensure-kernel-loaded! kernel-name)
+        kernel-handle (create-kernel-fresh module kernel-name)
+        native-args (mapv (fn [[slot value]]
+                            (if (= :scalar (:kind slot))
+                              value
+                              (if (device-buffer? value)
+                                (:segment ^DeviceBuffer value)
+                                value)))
+                          pairs)
+        bound (bind-kernel! kernel-handle workgroup-size native-args)
+        ^MemorySegment gc (:gc-seg bound)]
+    (doseq [[axis count] (map-indexed vector (take 3 (concat group-count [1 1])))]
+      (.set gc I32 (long (* axis 4)) (int count)))
+    {:bound bound
+     ;; Geometry is already baked into gc-seg. record-graph! must not reinterpret X specially.
+     :group-count nil
+     :kernel-name kernel-name
+     :kernel-call call
+     :binding-plan plan}))
+
 (defn bind-registered-map-void-kernel
   "Pre-bind a registered void-map kernel's arguments ONCE for fast repeated dispatch.
   All array args must be GPU-resident (DeviceBuffer / GpuSoA / MemorySegment) — no per-call
@@ -2658,44 +2627,6 @@
       :group-count group-count
       :kernel-name kernel-name
       :async? async?})))
-
-(defn bind-registered-reduction!
-  "Pre-bind a SegRed kernel from its complete ordered ABI values. The ABI roles—not registry
-   :array-params or a caller-side concatenation convention—select pointers, captured scalars,
-   the result buffer and the bound. A single workgroup lets the grid-stride kernel write the
-   resident one-element result without a host combine."
-  [^String kernel-name arguments]
-  (let [registered (or (get @kernel-registry kernel-name)
-                       (throw (ex-info (str "Kernel not registered: " kernel-name)
-                                       {:kernel-name kernel-name
-                                        :registered (keys @kernel-registry)})))
-        abi (kabi/validate! (:abi registered))
-        {:keys [pointer-pairs scalar-pairs result-pair bound-pair]}
-        (kabi/validate-reduction-arguments! abi arguments)
-        _ (doseq [[slot value] pointer-pairs]
-            (when-not (or (device-buffer? value) (instance? MemorySegment value))
-              (throw (ex-info "resident reduction requires DeviceBuffer/MemorySegment pointer arguments"
-                              {:kernel-name kernel-name :slot slot :value-type (type value)})))
-            (when (and (device-buffer? value)
-                       (not= (:dtype slot) (dt/canon (:dtype ^DeviceBuffer value))))
-              (throw (ex-info "reduction ABI storage dtype does not match resident buffer"
-                              {:kernel-name kernel-name :slot slot :expected (:dtype slot)
-                               :actual (dt/canon (:dtype ^DeviceBuffer value))}))))
-        result-value (second result-pair)
-        _ (when (and (device-buffer? result-value)
-                     (< (:n-elements ^DeviceBuffer result-value) 1))
-            (throw (ex-info "resident reduction result buffer must hold at least one element"
-                            {:kernel-name kernel-name :buffer-elements 0})))
-        _ (doseq [[slot value] (conj scalar-pairs bound-pair)]
-            (when-not (and (map? value) (= (:kernel-dtype slot) (:type value)))
-              (throw (ex-info "reduction ABI scalar binding has the wrong kernel dtype"
-                              {:kernel-name kernel-name :slot slot
-                               :expected (:kernel-dtype slot)
-                               :actual (when (map? value) (:type value))}))))
-        pointers (mapv second pointer-pairs)
-        scalars (mapv second scalar-pairs)
-        n (long (:value (second bound-pair)))]
-    (bind-registered-map-void-kernel kernel-name pointers scalars n {:group-count 1})))
 
 (defn bind-registered-contraction!
   "Pre-bind a routed contraction over resident buffers using its ordered typed ABI.
@@ -2752,16 +2683,21 @@
                              (:segment ^DeviceBuffer value)
                              value)))
                        abi arguments)
-        bound (bind-kernel-2d! kernel-handle (mapv long wg) all-args)
+        bound (bind-kernel! kernel-handle (mapv long wg) all-args)
         ^MemorySegment gc (:gc-seg bound)]
     (.set gc I32 0 (int (first grid)))
     (.set gc I32 4 (int (second grid)))
     {:bound bound :group-count nil :kernel-name kernel-name}))
 
 (defn launch-registered-bound!
-  "Dispatch a kernel pre-bound by bind-registered-map-void-kernel. Synchronous."
+  "Dispatch a pre-bound kernel. A KernelCall has its complete geometry baked into :gc-seg;
+   compatibility bindings may still supply a scalar :group-count."
   [prepared]
-  (launch-bound! (:bound prepared) (long (:group-count prepared))))
+  (if-some [group-count (:group-count prepared)]
+    (launch-bound! (:bound prepared) group-count)
+    (let [bound (:bound prepared)]
+      (.invokeWithArguments ^MethodHandle (:h-launch bound)
+                            ^"[Ljava.lang.Object;" (:launch-args bound)))))
 
 (defn ensure-zero-fill-kernel!
   "Register (idempotently) a zero-fill kernel `out[i]=0` for the given dtype and
@@ -2824,8 +2760,8 @@
   record time; buffer CONTENTS may change freely between replays (the decode pattern — each
   token rewrites the activation buffers, the recorded matmuls read whatever is there).
 
-  prepareds: ordered seq of maps from bind-registered-map-void-kernel (each carries its own
-  dedicated kernel handle with args already set). Returns a graph handle for replay-graph!.
+  prepareds: ordered seq from bind-kernel-call or a specialized compatibility binder (each
+  carries its own dedicated kernel handle with args already set). Returns a graph handle for replay-graph!.
   Re-record only if the kernel sequence or any buffer is reallocated.
 
   Profiling (:profile? true): one kernel-timestamp device event per launch is created from a

--- a/test/raster/compiler/backend/gpu/gemm_tiled_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_tiled_test.clj
@@ -46,7 +46,7 @@
           I32  @(r 'I32)
           dev  (:device-id-hex @@(r 'state))
           f16  @(r 'buffer-of-floats-as-half)  MB @(r 'make-buffer)
-          LM   @(r 'load-module!)  CK @(r 'create-kernel-fresh)  BK2 @(r 'bind-kernel-2d!)
+          LM   @(r 'load-module!)  CK @(r 'create-kernel-fresh)  BK2 @(r 'bind-kernel!)
           RG   @(r 'record-graph!) RP @(r 'replay-graph!) DG @(r 'destroy-graph!)
           BA   @(r 'buffer->array) FB @(r 'free-buffer!)  breg @(r 'bind-registered-gemm!)
           seti (fn [seg off v] (.set ^java.lang.foreign.MemorySegment seg I32 (int off) (int v)))

--- a/test/raster/compiler/ir/kernel_call_test.clj
+++ b/test/raster/compiler/ir/kernel_call_test.clj
@@ -1,0 +1,87 @@
+(ns raster.compiler.ir.kernel-call-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.gpu.ocl-runtime :as ocl]
+            [raster.gpu.ze-runtime :as ze]))
+
+(def ^:private artifact
+  (kart/make
+   {:kernel-name "kernel_call_contract_test"
+    :source "__kernel void kernel_call_contract_test(__global const float* x, __global float* out, float scale, int n) {}"
+    :abi [(kabi/slot 'x :input :float :role :operand)
+          (kabi/slot 'out :output :float :role :result)
+          (kabi/slot 'scale :scalar :float :role :parameter)
+          (kabi/slot 'n :scalar :int :role :bound)]
+    :arguments '[x out scale n]
+    :launch (klaunch/spec {:workgroup-size [256]
+                           :group-count [(klaunch/ceil-div 'n 256)]})}))
+
+(def ^:private args
+  [:resident-x :resident-out {:type :float :value 2.0} {:type :int :value 513}])
+
+(deftest call-realizes-artifact-launch-from-ordered-values
+  (let [call (kcall/make artifact args)
+        plan (kcall/binding-plan call)]
+    (is (kcall/kernel-call? call))
+    (is (= [256] (:workgroup-size plan)))
+    (is (= [3] (:group-count plan)))
+    (is (= [:resident-x :resident-out] (mapv second (:pointer-pairs plan))))
+    (is (= [:float :int] (mapv (comp :type second) (:scalar-pairs plan))))))
+
+(deftest scheduling-may-change-groups-but-not-emitted-workgroup
+  (let [call (kcall/make artifact args {:group-count [1]})]
+    (is (= [1] (get-in call [:geometry :group-count]))))
+  (is (thrown-with-msg?
+       clojure.lang.ExceptionInfo #"workgroup differs"
+       (kcall/validate!
+        (kcall/->KernelCall artifact args
+                            (klaunch/geometry {:workgroup-size [128] :group-count [5]}))))))
+
+(deftest calls-preserve-one-to-three-dimensional-geometry
+  (doseq [dimensions (range 1 4)]
+    (let [workgroup (vec (repeat dimensions 4))
+          groups (vec (repeat dimensions 2))
+          nd-artifact (kart/make (assoc artifact :launch
+                                        (klaunch/spec {:workgroup-size workgroup
+                                                       :group-count groups})))
+          call (kcall/make nd-artifact args)]
+      (is (= dimensions (klaunch/dimensions (:geometry call))))
+      (is (= workgroup (get-in call [:geometry :workgroup-size])))
+      (is (= groups (get-in call [:geometry :group-count]))))))
+
+(deftest call-rejects-untyped-or-mistyped-scalars
+  (testing "runtime scalar typing is part of the call, not a backend guess"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"typed value"
+                          (kcall/make artifact
+                                      [:x :out 2.0 {:type :int :value 513}])))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"wrong kernel dtype"
+                          (kcall/make artifact
+                                      [:x :out {:type :double :value 2.0}
+                                       {:type :int :value 513}])))))
+
+(deftest registered-artifact-check-ignores-runtime-cache-fields
+  (let [call (kcall/make artifact args)]
+    (is (= :native-handle
+           (:module (kcall/validate-registered! call
+                                                (assoc artifact :module :native-handle)))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"differs from"
+                          (kcall/validate-registered!
+                           call (assoc artifact :source
+                                       "__kernel void kernel_call_contract_test(__global const float* x, __global float* out, float scale, int n) { out[0] = 0; }"))))))
+
+(deftest both-resident-backends-consume-the-same-call-contract
+  (let [call (kcall/make artifact args)]
+    (doseq [[register! bind!] [[ze/register-kernel! ze/bind-kernel-call]
+                               [ocl/register-kernel! ocl/bind-kernel-call]]]
+      (register! "kernel_call_contract_test" artifact)
+      (try
+        ;; Keywords are valid opaque values to neutral KernelCall validation, but not backend
+        ;; resident buffers. Both binders must reject at the identical post-call boundary before
+        ;; either native driver is initialized.
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"KernelCall requires"
+                              (bind! call)))
+        (finally
+          (register! "kernel_call_contract_test" {:test-tombstone? true}))))))

--- a/test/raster/compiler/kernel_call_pipeline_test.clj
+++ b/test/raster/compiler/kernel_call_pipeline_test.clj
@@ -1,0 +1,58 @@
+(ns raster.compiler.kernel-call-pipeline-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.arrays :as ra]
+            [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.pipeline :as pipeline]
+            [raster.core :refer [deftm]]))
+
+(deftm resident-kernel-call-map
+  [x :- (Array float) out :- (Array float) scale :- Float n :- Long] :- (Array float)
+  (raster.par/map! out i n float (* scale (ra/aget x i))))
+
+(deftm resident-kernel-call-reduce
+  [x :- (Array float) out :- (Array float) scale :- Double n :- Long] :- Void
+  (let [sum (raster.par/reduce acc 0.0 i n
+                               (+ acc (* scale (ra/aget x i))))]
+    (raster.par/map-void! j n
+                          (ra/aset out j (* (ra/aget x j) sum)))))
+
+(deftest resident-segmap-step-carries-one-executable-call-template
+  (let [descriptor (pipeline/compile-gpu-program #'resident-kernel-call-map
+                                                 :ze:0 :dtype :float)
+        step (first (:steps descriptor))
+        runtime-params [(float-array 513) (float-array 513) (float 2.0) 513]
+        ordered-values
+        (mapv (fn [{:keys [kind sym type value-fn]}]
+                (if (= :scalar kind)
+                  {:type type :value (value-fn runtime-params)}
+                  (keyword (name sym))))
+              (:argument-specs step))
+        call (kcall/make (:artifact step) ordered-values)]
+    (is (= :map (:convention step)))
+    (is (kart/kernel-artifact? (:artifact step)))
+    (is (= '[x out scale _n_bound]
+           (mapv (comp :name :slot) (:argument-specs step))))
+    (is (= [:input :output :scalar :scalar]
+           (mapv :kind (:argument-specs step))))
+    (is (= [256] (get-in call [:geometry :workgroup-size])))
+    (is (= [3] (get-in call [:geometry :group-count])))))
+
+(deftest resident-segred-schedule-is-an-explicit-kernel-call-override
+  (let [descriptor (pipeline/compile-gpu-program #'resident-kernel-call-reduce
+                                                 :ze:0 :dtype :float)
+        step (first (filter #(= :reduce (:convention %)) (:steps descriptor)))
+        runtime-params [(float-array 513) (float-array 513) 0.75 513]
+        ordered-values
+        (mapv (fn [{:keys [kind sym type value-fn]}]
+                (if (= :scalar kind)
+                  {:type type :value (value-fn runtime-params)}
+                  (keyword (name sym))))
+              (:argument-specs step))
+        default-call (kcall/make (:artifact step) ordered-values)
+        resident-call (kcall/make (:artifact step) ordered-values {:group-count [1]})]
+    (is (kart/kernel-artifact? (:artifact step)))
+    (is (= [:input :output :scalar :scalar]
+           (mapv :kind (:argument-specs step))))
+    (is (= [3] (get-in default-call [:geometry :group-count])))
+    (is (= [1] (get-in resident-call [:geometry :group-count])))))


### PR DESCRIPTION
## Summary

- introduce a verified KernelCall containing its KernelArtifact, complete ABI-ordered runtime values, and realized 1-3D LaunchGeometry
- route resident SegMap and SegRed through one backend-neutral binding contract on Level Zero and OpenCL
- make Level Zero launch binding uniformly 1-3D and delete the reduction-specific binders plus the separate 2-D binding path
- preserve an explicit scheduling seam: resident SegRed overrides group count to one without changing the emitted workgroup

## Verification

- complete cold suite: 2,138 tests, 32,703 assertions, zero failures/errors
- focused compiler/runtime gate: 61 tests, 256 assertions, zero failures/errors
- final KernelCall and pipeline gate: 8 tests, 32 assertions, zero failures/errors
- live Intel Arc: resident SegMap and SegRed on Level Zero and OpenCL
- live Intel Arc Gemma resident suite: 3 tests, 94 assertions, including a 138-step train graph, loss parity, mixed-precision backward trajectories, and shared-session memory deduplication

The complete-suite GPU cases took expected skip paths because the separate live nREPL owned the device.