### PR TITLE
Migrate map-void to executable kernel calls

### DIFF
--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -11,6 +11,7 @@
             [raster.compiler.ir.soac]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.passes.parallel.soac-lower]
             [raster.compiler.backend.gpu.segop-opencl :as segop-cl]
@@ -234,6 +235,24 @@
     (list 'raster.gpu.ze-runtime/invoke-registered-reduction-kernel
           kernel-name arguments)))
 
+(defn- emit-map-void-invocation
+  "Render the staging marker from the artifact's logical argument projection. The marker remains
+   useful to the host evaluator, but it no longer owns or reconstructs an argument convention."
+  [artifact]
+  (let [plan (kcall/logical-argument-plan artifact)
+        pointer-values (mapv :value (filterv :pointer? plan))
+        scalar-entries (filterv (complement :pointer?) plan)
+        bound-entries (filterv #(= :bound (:role (first (:slots %)))) scalar-entries)
+        user-scalars (filterv #(not= :bound (:role (first (:slots %)))) scalar-entries)]
+    (when-not (= 1 (count bound-entries))
+      (throw (ex-info "map-void artifact must identify exactly one :bound scalar"
+                      {:kernel-name (:kernel-name artifact) :plan plan})))
+    (list 'raster.gpu.ze-runtime/invoke-registered-map-void-kernel
+          (:kernel-name artifact)
+          pointer-values
+          (mapv :value user-scalars)
+          (:value (first bound-entries)))))
+
 (defn opencl-pass
   "Pipeline pass: walk S-expression, replace par forms with GPU kernel invocations.
 
@@ -389,17 +408,8 @@
                                                                   :dtype dtype :device-id device-id
                                                                   :array-types top-array-types
                                                                   :scalar-types top-scalar-types)
-                      k (register-kernel! kernel :ze-maps)
-                      abi (:abi k)
-                      pointer-args (kabi/pointer-binding-names abi)
-                      scalar-args (mapv :name
-                                        (remove #(= :bound (:role %))
-                                                (kabi/scalar-slots abi)))]
-                  (list 'raster.gpu.ze-runtime/invoke-registered-map-void-kernel
-                        (:kernel-name k)
-                        pointer-args
-                        scalar-args
-                        bound))))
+                      k (register-kernel! kernel :ze-maps)]
+                  (emit-map-void-invocation k))))
 
             ;; par/scan-exclusive
             (par/par-scan-exclusive-form? form)
@@ -471,21 +481,15 @@
             ;; output element once (no atomics/accumulation), so it lowers to a map-void
             ;; kernel and binds through the existing resident map path.
             (par/par-gather-form? form)
-            (let [{:keys [n stride]} (par/extract-par-gather-info form)]
+            (let [{:keys [n]} (par/extract-par-gather-info form)]
               (if (and (number? n) (< n min-elements))
                 (do (swap! stats update :fallback inc)
                     (par/expand-par-gather! form))
                 (let [k (register-kernel!
                          (legacy/generate-par-gather-kernel form
                                                             :dtype dtype :device-id device-id)
-                         :ze-maps)
-                      {:keys [out src index]} (par/extract-par-gather-info form)
-                      strip-cast (fn [x] (if (and (seq? x)
-                                                  (#{'long 'int 'clojure.core/long 'clojure.core/int} (first x)))
-                                           (second x) x))]
-                  (list 'raster.gpu.ze-runtime/invoke-registered-map-void-kernel
-                        (:kernel-name k) (vec [out src index])
-                        (if stride [(strip-cast stride)] []) n))))
+                         :ze-maps)]
+                  (emit-map-void-invocation k))))
 
             ;; par/reduce-by-key
             (par/par-reduce-by-key-form? form)

--- a/src/raster/compiler/backend/gpu/par_opencl.clj
+++ b/src/raster/compiler/backend/gpu/par_opencl.clj
@@ -18,6 +18,8 @@
             [raster.compiler.backend.gpu.opencl-codegen :as codegen]
             [raster.compiler.backend.gpu.c-emit :as ce]
             [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.passes.scalar.soa-lower :as sl]
             [raster.compiler.support.spirv-cache :as spirv-cache]
             [clojure.string :as str]
@@ -64,9 +66,8 @@
   array-types: {sym -> :float|:int|:long|:double} for mixed-type params.
   Written arrays get __global TYPE* (not const restrict).
 
-  Returns {:kernel-name str :source str :abi [ordered typed physical slots]
-           :array-params [logical binding syms] :scalar-params [syms]
-           :written-arrays #{syms} :dtype kw}."
+  Returns one verified KernelArtifact. Its ABI and :arguments are physical; logical SoA bindings
+  are a projection of the ABI's contiguous `:binding` groups."
   [form & {:keys [dtype kernel-name-prefix array-types scalar-types]
            :or {dtype :float kernel-name-prefix "par_map_void"
                 array-types {} scalar-types {}}}]
@@ -243,17 +244,29 @@
                              "    }"))
                     "\n}\n")
         _ (kabi/validate-source-signature! kernel-name source abi)
-        binding-params (kabi/pointer-binding-names abi)]
-    {:kernel-name    kernel-name
-     :source         source
-     :abi            abi
-     :arguments      (vec (concat binding-params scl-params [(:bound info)]))
-     :array-params   binding-params
-     :soa-expansions soa-expansions
-     :scalar-params  scl-params
-     :written-arrays written-syms
-     :array-types    array-types
-     :dtype          dtype}))
+        binding-params (kabi/pointer-binding-names abi)
+        bound (:bound info)
+        physical-arguments
+        (mapv (fn [slot]
+                (if (= :bound (:role slot)) bound (:name slot)))
+              abi)]
+    (kart/make
+     {:kernel-name kernel-name
+      :source source
+      :abi abi
+      :arguments physical-arguments
+      :launch (klaunch/spec
+               {:workgroup-size [256]
+                :group-count [(klaunch/ceil-div bound 256)]})
+      :temporaries []
+      :effects {:kind :side-effect-map}
+      :provenance {:dialect :map-void}
+      :attributes {:array-params binding-params
+                   :soa-expansions soa-expansions
+                   :scalar-params scl-params
+                   :written-arrays written-syms
+                   :array-types array-types
+                   :dtype dtype}})))
 
 (defn generate-par-scan-exclusive-kernel
   "Generate OpenCL Blelloch exclusive scan kernels from a par/scan-exclusive form.
@@ -717,15 +730,14 @@
   Gather: out[e*stride+d] = src[index[e]*stride+d] — one work-item per gathered pair
   e (inner loop over stride). A gather writes every output element exactly once (no
   atomics, no accumulation), so it uses the map-void calling convention
-  (out, src, index, [stride,] int _n_bound) and binds through
-  bind-registered-map-void-kernel — `out` is just another resident buffer.
+  (out, src, index, [stride,] int _n_bound); resident execution binds its artifact through
+  KernelCall — `out` is just another effect pointer.
 
-  Returns {:kernel-name str :source str :array-params [out src index]
-           :scalar-params [...] :written-arrays [out] :dtype kw :strided? bool}."
+  Returns one verified KernelArtifact using the same side-effect map contract."
   [form & {:keys [dtype kernel-name-prefix]
            :or {dtype :float kernel-name-prefix "par_gather"}}]
   (let [info (par/extract-par-gather-info form)
-        {:keys [out src index stride]} info
+        {:keys [out src index stride n]} info
         kernel-name (str kernel-name-prefix "_" (gensym ""))
         ctype (get codegen/opencl-type-map dtype "float")
         strided? (some? stride)
@@ -747,14 +759,32 @@
                            "        }\n")
                       (str "        " out-c "[e] = " src-c "[src_idx];\n"))
                     "    }\n"
-                    "}\n")]
-    {:kernel-name kernel-name
-     :source source
-     :array-params [out src index]
-     :scalar-params (if strided? [{:name 'stride :type :int}] [])
-     :written-arrays [out]
-     :strided? strided?
-     :dtype dtype}))
+                    "}\n")
+        scalar-params (if strided? ['stride] [])
+        abi (kabi/validate!
+             (vec (concat
+                   [(kabi/slot out :output dtype :c-name (ce/c-symbol out) :role :effect)
+                    (kabi/slot src :input dtype :c-name (ce/c-symbol src) :role :operand)
+                    (kabi/slot index :input :int :c-name (ce/c-symbol index) :role :operand)]
+                   (when strided?
+                     [(kabi/slot 'stride :scalar :int :role :parameter)])
+                   [(kabi/slot '_n_bound :scalar :int :role :bound)])))]
+    (kart/make
+     {:kernel-name kernel-name
+      :source source
+      :abi abi
+      :arguments (vec (concat [out src index] (when strided? [stride]) [n]))
+      :launch (klaunch/spec
+               {:workgroup-size [256]
+                :group-count [(klaunch/ceil-div n 256)]})
+      :temporaries []
+      :effects {:kind :side-effect-map}
+      :provenance {:dialect :gather}
+      :attributes {:array-params [out src index]
+                   :scalar-params scalar-params
+                   :written-arrays [out]
+                   :strided? strided?
+                   :dtype dtype}})))
 
 ;; ================================================================
 ;; Reduce-by-key kernel generator

--- a/src/raster/compiler/ir/kernel_call.clj
+++ b/src/raster/compiler/ir/kernel_call.clj
@@ -12,6 +12,83 @@
 
 (defn kernel-call? [x] (instance? KernelCall x))
 
+(defn logical-argument-plan
+  "Project an artifact's physical ABI into ordered logical caller arguments.
+
+   Ordinary pointers and every scalar remain one entry. Contiguous physical pointer slots that
+   share `:binding` become one logical pointer entry (an SoA, for example). The physical slots and
+   compiler arguments are retained on every entry, so this is a checked view of the one ABI rather
+   than a second signature."
+  [artifact]
+  (let [artifact (kart/validate! artifact)
+        pairs (mapv vector (:abi artifact) (:arguments artifact))]
+    (reduce (fn [plan [index [slot argument]]]
+              (let [pointer? (not= :scalar (:kind slot))
+                    binding (when pointer? (or (:binding slot) (:name slot)))
+                    previous (peek plan)]
+                (if (and pointer?
+                         (:pointer? previous)
+                         (= binding (:binding previous))
+                         (:binding slot))
+                  (-> plan
+                      pop
+                      (conj (-> previous
+                                (update :slots conj slot)
+                                (update :physical-arguments conj argument)
+                                (update :physical-indexes conj index))))
+                  (conj plan
+                        {:pointer? pointer?
+                         :kind (if pointer? :pointer :scalar)
+                         :binding (when pointer? binding)
+                         :value (if pointer? binding argument)
+                         :slots [slot]
+                         :physical-arguments [argument]
+                         :physical-indexes [index]}))))
+            []
+            (map-indexed vector pairs))))
+
+(defn logical-arguments
+  "Compiler values in logical caller order. SoA field slots collapse to their shared binding."
+  [artifact]
+  (mapv :value (logical-argument-plan artifact)))
+
+(defn expand-logical-arguments
+  "Expand logical runtime values into the artifact's complete physical ABI order.
+
+   `expand-pointer` receives `[plan-entry logical-value]` and must return a vector containing one
+   resident value per physical pointer slot. Scalar values are already physical and pass through.
+   Representation-specific expansion therefore happens explicitly before `make`, while the
+   resulting KernelCall and all backend binders remain physical and backend-neutral."
+  [artifact logical-values expand-pointer]
+  (let [artifact (kart/validate! artifact)
+        plan (logical-argument-plan artifact)]
+    (when-not (vector? logical-values)
+      (throw (ex-info "logical kernel arguments must be an ordered vector"
+                      {:kernel-name (:kernel-name artifact) :arguments logical-values})))
+    (when-not (= (count plan) (count logical-values))
+      (throw (ex-info "logical kernel argument count mismatch"
+                      {:kernel-name (:kernel-name artifact)
+                       :expected (count plan) :actual (count logical-values)
+                       :plan plan})))
+    (vec
+     (mapcat (fn [entry value]
+               (if (:pointer? entry)
+                 (let [expanded (expand-pointer entry value)]
+                   (when-not (vector? expanded)
+                     (throw (ex-info "logical pointer expansion must return an ordered vector"
+                                     {:kernel-name (:kernel-name artifact)
+                                      :binding (:binding entry) :expanded expanded})))
+                   (when-not (= (count (:slots entry)) (count expanded))
+                     (throw (ex-info "logical pointer expansion count differs from physical ABI"
+                                     {:kernel-name (:kernel-name artifact)
+                                      :binding (:binding entry)
+                                      :expected (count (:slots entry))
+                                      :actual (count expanded)
+                                      :slots (:slots entry)})))
+                   expanded)
+                 [value]))
+             plan logical-values))))
+
 (defn- scalar-value!
   [slot value]
   (when-not (and (map? value) (contains? value :value) (contains? value :type))

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -30,6 +30,7 @@
             [raster.compiler.ir.par :as par]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.backend.jvm.par-simd :as par-simd]
             [raster.compiler.backend.wasm.emit :as wasm-emit]
             [raster.compiler.backend.intrinsics :as ix]
@@ -1750,7 +1751,7 @@
                                        (into acc
                                              (map (comp symbol name)
                                                   (if-let [abi (:abi ki)]
-                                                    (map :name
+                                                    (map #(or (:binding %) (:name %))
                                                          (filter #(or (= :output (:kind %))
                                                                       (= :inout (:role %)))
                                                                  (kabi/pointer-slots abi)))
@@ -1827,6 +1828,38 @@
                            :out-elems-fn (expr->arg-fn all-params scalar-lets out-elems-expr)
                            :wg-fns (mapv #(expr->arg-fn all-params scalar-lets %) wg-exprs)
                            :grid-fns (mapv #(expr->arg-fn all-params scalar-lets %) grid-exprs)
+                           :phase (keyword (str "gpu-step-" i))})
+
+                        (= :map-void (:convention step))
+                        (let [{:keys [kernel-name arrays scalars n-expr convention]} step
+                              artifact (reg-entry kernel-name)
+                              _ (when-not (kart/kernel-artifact? artifact)
+                                  (throw (ex-info "resident map-void kernel is not a registered KernelArtifact"
+                                                  {:kernel-name kernel-name :entry artifact})))
+                              artifact (kart/validate! artifact)
+                              plan (kcall/logical-argument-plan artifact)
+                              marker-values (vec (concat arrays scalars [n-expr]))
+                              expected-values (kcall/logical-arguments artifact)
+                              _ (when-not (= expected-values marker-values)
+                                  (throw (ex-info "map-void marker differs from its artifact logical argument plan"
+                                                  {:kernel-name kernel-name
+                                                   :expected expected-values
+                                                   :actual marker-values
+                                                   :plan plan})))]
+                          {:convention convention
+                           :kernel-name kernel-name
+                           :artifact artifact
+                           :abi (:abi artifact)
+                           :logical-bindings? true
+                           :argument-specs
+                           (mapv (fn [entry value]
+                                   (let [slot (first (:slots entry))]
+                                     (if (:pointer? entry)
+                                       {:slots (:slots entry) :kind :pointer
+                                        :binding (:binding entry) :sym value}
+                                       {:slot slot :kind :scalar :type (:kernel-dtype slot)
+                                        :value-fn (expr->arg-fn all-params scalar-lets value)})))
+                                 plan marker-values)
                            :phase (keyword (str "gpu-step-" i))})
 
                         (and (#{:map :reduce} (:convention step)) (:arguments step))

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -690,45 +690,42 @@
    weights/KV per layer and scratch shared, like the decoder's pbk). Does NOT record a graph; the
    caller collects :phase keys and records once.
 
-     :map/:reduce
+     :map/:reduce/:map-void
                 Artifact ABI values and realized geometry bind through one KernelCall contract.
-                SegRed explicitly schedules one resident workgroup; SegMap realizes its grid.
-     :map-void  output is an in-place array among :array-params; bind by name via prepare!."
+                SegRed explicitly schedules one resident workgroup; maps realize their grid.
+                Logical SoA arguments expand through the backend representation adapter before
+                the physical KernelCall is constructed."
   [sess step args sym->key]
   (let [device-id (:device-id @sess)
-        {:keys [kernel-name arrays n-fn scalar-specs phase convention artifact argument-specs]} step
-        info-fn (rt-resolve device-id "kernel-registry-entry")]
+        {:keys [kernel-name phase convention artifact argument-specs]} step]
     (when-not (#{:map-void :map :reduce} convention)
       (throw (ex-info (str "bind-step! cannot bind a " convention " step (" kernel-name
                            ") — only :map-void / :map / :reduce are supported on the resident path")
                       {:convention convention :kernel kernel-name})))
-    (let [ki (or (info-fn kernel-name)
-                 (throw (ex-info (str "Program kernel not registered: " kernel-name)
-                                 {:kernel kernel-name})))
-          bufs (:buffers @sess)
+    (let [bufs (:buffers @sess)
           resolve-buf (fn [a] (or (get bufs (sym->key a))
                                   (throw (ex-info (str "No buffer for kernel arg: " a " → " (sym->key a))
                                                   {:kernel kernel-name :available (keys bufs)}))))
-          scalars (mapv (fn [{:keys [type value-fn]}] {:type type :value (value-fn args)})
-                        scalar-specs)
-          bind-fn (rt-resolve device-id "bind-registered-map-void-kernel")
           bind-call-fn (rt-resolve device-id "bind-kernel-call")]
       (case convention
-        (:map :reduce)
-        (let [ordered-args
+        (:map :reduce :map-void)
+        (let [logical-or-physical-args
               (mapv (fn [{:keys [kind sym type value-fn]}]
                       (if (= :scalar kind)
                         {:type type :value (value-fn args)}
                         (resolve-buf sym)))
                     argument-specs)
+              ordered-args
+              (if (:logical-bindings? step)
+                (kcall/expand-logical-arguments
+                 artifact logical-or-physical-args
+                 (rt-resolve device-id "expand-pointer-binding"))
+                logical-or-physical-args)
               call (kcall/make artifact ordered-args
                                (if (= :reduce convention) {:group-count [1]} {}))
               prepared (bind-call-fn call)]
           (swap! sess assoc-in [:prepared phase] prepared))
-
-        (let [sym->buf (into {} (map (fn [p] [(name p) (sym->key p)]) (:array-params ki)))]
-          (swap! sess assoc-in [:kernels phase] [ki])
-          (prepare! sess phase sym->buf scalars (long (n-fn args)) {:kernel-phase phase}))))
+        nil))
     sess))
 
 ;; ----------------------------------------------------------------
@@ -747,6 +744,7 @@
    compile-gpu-program's scalar typing (same derive-param-types) — not a special case."
   [op ki scalars dtype]
   (let [v (or (resolve-deftm-var op) op)
+        scalar-params (or (:scalar-params ki) (get-in ki [:attributes :scalar-params]))
         types (:scalar-types (opencl-pass/derive-param-types
                               (:raster.core/deftm-params (meta v))
                               (:raster.core/deftm-tags (meta v)) dtype))]
@@ -756,9 +754,9 @@
                           (if (contains? scalars sp) (get scalars sp)
                               (throw (ex-info (str "chain step for " (:name (meta v))
                                                    " missing scalar: " sp)
-                                              {:need (:scalar-params ki) :have (keys scalars)}))))]
+                                              {:need scalar-params :have (keys scalars)}))))]
               {:type t :value (case t :int (int raw) :long (long raw) :double (double raw) (float raw))}))
-          (:scalar-params ki))))
+          scalar-params)))
 
 (def ^:private valid-chain-roles
   "Residency roles a chain buffer may carry. run-chain!/run-chain-ctx! move :input up and
@@ -1100,7 +1098,7 @@
                                                        (str "scratch " sym)))))
                            allocs)
          info-fn   (rt-resolve device-id "kernel-registry-entry")
-         bind-fn   (rt-resolve device-id "bind-registered-map-void-kernel")
+         specialized-bind-fn (rt-resolve device-id "bind-registered-map-void-kernel")
          bind-call-fn (rt-resolve device-id "bind-kernel-call")
          contract-fn (rt-resolve device-id "bind-registered-contraction!")
          gemm-fn   (rt-resolve device-id "bind-registered-gemm!")
@@ -1229,29 +1227,22 @@
                ;; Generic map and reduction now share the complete executable value: emitted
                ;; artifact, ordered ABI values and realized launch. Reduction's single-group
                ;; resident schedule is explicit here rather than hidden in a special binder.
-               (:map :reduce)
-               (let [ordered-args
+               (:map :reduce :map-void)
+               (let [logical-or-physical-args
                      (mapv (fn [{:keys [kind sym type value-fn]}]
                              (if (= :scalar kind)
                                {:type type :value (value-fn args)}
                                (buf-of sym kernel-name)))
                            argument-specs)
+                     ordered-args
+                     (if (:logical-bindings? step)
+                       (kcall/expand-logical-arguments
+                        artifact logical-or-physical-args
+                        (rt-resolve device-id "expand-pointer-binding"))
+                       logical-or-physical-args)
                      call (kcall/make artifact ordered-args
                                       (if (= :reduce convention) {:group-count [1]} {}))]
                  [(assoc (bind-call-fn call) :phase (:phase step))])
-
-               ;; Map-void has not migrated to KernelArtifact yet; retain its compatibility
-               ;; binder until its emitter carries a complete artifact and ordered call values.
-               :map-void
-               (do (or (info-fn kernel-name)
-                       (throw (ex-info (str "Program kernel not registered: " kernel-name)
-                                       {:kernel kernel-name})))
-                   (let [buf-vec (mapv #(buf-of % kernel-name) arrays)
-                         scalars (mapv (fn [{:keys [type value-fn]}]
-                                         {:type type :value (value-fn args)})
-                                       scalar-specs)]
-                     [(assoc (bind-fn kernel-name buf-vec scalars (long (n-fn args)))
-                             :phase (:phase step))]))
                ;; Routed contraction: preserve the emitter-authored ABI order all the way into
                ;; the backend binder. Pointer slots resolve to resident buffers; scalar slots
                ;; retain their declared kernel view dtype (not the program/output dtype). The
@@ -1308,7 +1299,8 @@
                          zerofill-fn (rt-resolve device-id "ensure-zero-fill-kernel!")
                          scatter-fn (rt-resolve device-id "bind-registered-scatter-kernel!")
                          zk (zerofill-fn (if (= dtype :double) :double :float))]
-                     [(assoc (bind-fn zk [out-buf] [] (long out-size)) :phase (:phase step))
+                     [(assoc (specialized-bind-fn zk [out-buf] [] (long out-size))
+                             :phase (:phase step))
                       (assoc (scatter-fn kernel-name [out-buf src-buf idx-buf] n stride)
                              :phase (:phase step))]))
                (throw (ex-info (str "bind-program! cannot bind a " convention " step — only "

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -433,6 +433,26 @@
            :else (jvm-array-dtype %))
         arrays))
 
+(defn expand-pointer-binding
+  "Expand one logical artifact pointer binding into OpenCL physical resident values. OpenCL's
+   current resident representation is one OclBuffer per logical value; multi-slot SoA bindings
+   fail here explicitly until an OpenCL SoA view is introduced. Driver state is not touched."
+  [{:keys [binding slots]} value]
+  (when-not (= 1 (count slots))
+    (throw (ex-info "OpenCL has no resident representation for a multi-slot logical pointer"
+                    {:binding binding :slots slots :value-type (type value)})))
+  (when-not (or (device-buffer? value) (instance? MemorySegment value))
+    (throw (ex-info "OpenCL logical pointer requires OclBuffer/MemorySegment"
+                    {:binding binding :slot (first slots) :value-type (type value)})))
+  [value])
+
+(defn- kernel-info-value
+  "Read a compiler-owned emitter attribute from an artifact or a remaining specialized entry."
+  [kernel-info k default]
+  (if (kart/kernel-artifact? kernel-info)
+    (get (:attributes kernel-info) k default)
+    (get kernel-info k default)))
+
 (defn make-buffer
   "Allocate a persistent GPU buffer via clCreateBuffer."
   ([n] (make-buffer n :float))
@@ -817,11 +837,13 @@
          _ (when abi
              (kabi/validate-split-binding! abi arrays scalar-args)
              (kabi/validate-physical-pointer-dtypes! abi (physical-pointer-dtypes arrays)))
-         {:keys [kernel-handle workgroup-size dtype]
-          :or {workgroup-size 256 dtype :float}
-          :as info} (ensure-kernel-loaded! kernel-name)
+         {:keys [kernel-handle] :as info} (ensure-kernel-loaded! kernel-name)
          {:keys [queue]} @state
-         workgroup-size (long (get opts :workgroup-size workgroup-size))
+         dtype (kernel-info-value info :dtype :float)
+         workgroup-size (long (get opts :workgroup-size
+                                   (if (:launch info)
+                                     (first (klaunch/static-workgroup-size (:launch info)))
+                                     (long (or (:workgroup-size info) 256)))))
          n (long n)
          default-elem-size (long (get dtype-byte-sizes dtype 4))
 
@@ -1173,8 +1195,8 @@
    (let [_ (when-let [abi (:abi (get @kernel-registry kernel-name))]
              (kabi/validate-split-binding! abi arrays scalar-args)
              (kabi/validate-physical-pointer-dtypes! abi (physical-pointer-dtypes arrays)))
-         {:keys [program dtype] :or {dtype :float} :as loaded}
-         (ensure-kernel-loaded! kernel-name)
+         {:keys [program] :as loaded} (ensure-kernel-loaded! kernel-name)
+         dtype (kernel-info-value loaded :dtype :float)
          kh (create-kernel-fresh program kernel-name)
          wg (long (get opts :workgroup-size (registered-1d-workgroup-size loaded)))
          n (long n)

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -1129,6 +1129,41 @@
               :else (conj dtypes (jvm-array-dtype arr))))
           [] arrays))
 
+(defn expand-pointer-binding
+  "Expand one logical artifact pointer binding into Level Zero's physical resident values.
+   A GpuSoA supplies one checked field segment per ABI slot; ordinary resident buffers supply one
+   slot. This function is driver-free and is called before KernelCall construction."
+  [{:keys [binding slots]} value]
+  (cond
+    (gpu-soa? value)
+    (let [fields (:field-segs ^GpuSoA value)]
+      (when-not (= (count slots) (count fields))
+        (throw (ex-info "GpuSoA field count differs from its artifact binding"
+                        {:binding binding :expected (count slots) :actual (count fields)
+                         :slots slots :fields (mapv :name fields)})))
+      (doseq [[slot field] (map vector slots fields)]
+        (let [expected-name (symbol (str (name binding) "_" (name (:name field))))]
+          (when-not (= expected-name (:name slot))
+            (throw (ex-info "GpuSoA field order/name differs from its physical ABI slot"
+                            {:binding binding :slot slot :field (:name field)
+                             :expected expected-name :actual (:name slot)}))))
+        (when-not (= (:dtype slot) (dt/canon (:dtype field)))
+          (throw (ex-info "GpuSoA field dtype differs from its physical ABI slot"
+                          {:binding binding :slot slot :field (:name field)
+                           :expected (:dtype slot) :actual (dt/canon (:dtype field))}))))
+      (mapv :seg fields))
+
+    (not= 1 (count slots))
+    (throw (ex-info "multi-slot logical pointer requires a GpuSoA resident value"
+                    {:binding binding :slots slots :value-type (type value)}))
+
+    (or (device-buffer? value) (instance? MemorySegment value))
+    [value]
+
+    :else
+    (throw (ex-info "Level Zero logical pointer requires DeviceBuffer/GpuSoA/MemorySegment"
+                    {:binding binding :slot (first slots) :value-type (type value)}))))
+
 (defn gpu-array
   "Allocate GPU-resident (shared) storage for n elements of scalar-type.
    scalar-type: the defvalue type symbol (e.g. 'Particle) or Class.
@@ -1749,6 +1784,13 @@
                         {:kernel-name (:kernel-name kernel-info) :launch launch})))
       (first workgroup))
     (long (or (:workgroup-size kernel-info) 256))))
+
+(defn- kernel-info-value
+  "Read a compiler-owned emitter attribute from an artifact or a remaining specialized entry."
+  [kernel-info k default]
+  (if (kart/kernel-artifact? kernel-info)
+    (get (:attributes kernel-info) k default)
+    (get kernel-info k default)))
 
 (defn- ensure-kernel-loaded!
   "Lazily compile SPIR-V and load module for a registered kernel.
@@ -2452,10 +2494,10 @@
          _ (when abi
              (kabi/validate-split-binding! abi arrays scalar-args)
              (kabi/validate-physical-pointer-dtypes! abi (physical-pointer-dtypes arrays)))
-         {:keys [kernel-handle workgroup-size dtype written-arrays array-types]
-          :or {workgroup-size 256 dtype :float}
-          :as info} (ensure-kernel-loaded! kernel-name)
-         workgroup-size (long (get opts :workgroup-size workgroup-size))
+         {:keys [kernel-handle] :as info} (ensure-kernel-loaded! kernel-name)
+         dtype (kernel-info-value info :dtype :float)
+         workgroup-size (long (get opts :workgroup-size
+                                   (registered-1d-workgroup-size info)))
          n (long n)
          default-dtype-size (long (get dtype-byte-sizes dtype 4))
         ;; Determine per-array byte size from actual array type
@@ -2588,8 +2630,8 @@
    (let [_ (when-let [abi (:abi (get @kernel-registry kernel-name))]
              (kabi/validate-split-binding! abi arrays scalar-args)
              (kabi/validate-physical-pointer-dtypes! abi (physical-pointer-dtypes arrays)))
-         {:keys [module dtype] :or {dtype :float} :as loaded}
-         (ensure-kernel-loaded! kernel-name)
+         {:keys [module] :as loaded} (ensure-kernel-loaded! kernel-name)
+         dtype (kernel-info-value loaded :dtype :float)
          ;; CRITICAL: create a DEDICATED kernel handle per binding. Level Zero kernel args are
          ;; mutable state ON the kernel handle, so reusing the registry's shared handle would
          ;; make every binding of the same kernel clobber the others (the last prepare! wins).

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -4,6 +4,7 @@
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.passes.parallel.device :as device]
             [raster.compiler.support.spirv-cache :as spirv-cache]
             [raster.runtime.hardware :as hw]
@@ -98,13 +99,24 @@
              form :dtype :float
              :array-types {'state :int 'x :float 'y :float}
              :scalar-types {'limit :int 'scale :float})]
+      (is (kart/kernel-artifact? k))
       (is (= '[state x y limit scale _n_bound] (mapv :name (:abi k))))
       (is (= [:output :input :output :scalar :scalar :scalar] (mapv :kind (:abi k))))
       (is (= [:int :float :float :int :float :int] (mapv :dtype (:abi k))))
       (is (= [:inout :operand :effect :parameter :parameter :bound]
              (mapv :role (:abi k))))
-      (is (= '[state x y] (:array-params k)))
+      (is (= '[state x y] (kart/attribute k :array-params)))
       (is (= '[state x y limit scale n] (:arguments k))))))
+
+(deftest generate-gather-kernel-is-a-side-effect-artifact
+  (let [k (par-opencl/generate-par-gather-kernel
+           '(raster.par/gather out src index n stride) :dtype :float)]
+    (is (kart/kernel-artifact? k))
+    (is (= '[out src index stride _n_bound] (mapv :name (:abi k))))
+    (is (= '[out src index stride n] (:arguments k)))
+    (is (= '[out src index stride n] (kcall/logical-arguments k)))
+    (is (= :side-effect-map (get-in k [:effects :kind])))
+    (is (= [256] (get-in k [:launch :workgroup-size])))))
 
 ;; ================================================================
 ;; Kernel generation: par/reduce

--- a/test/raster/compiler/backend/gpu/segmented_contract_device_test.clj
+++ b/test/raster/compiler/backend/gpu/segmented_contract_device_test.clj
@@ -41,10 +41,13 @@
                      (list '* (list 'aget 'A (list '+ (list '* 'i k) 'l))
                            (list 'aget 'B (list '+ (list '* 'l n) 'j))))
           sr  (cl/contract-form->segred form)
-          {:keys [kernel-name source scalar-params]} (sco/generate-segmented-reduce-kernel sr 'C)]
+          {:keys [kernel-name scalar-params] :as kernel}
+          (sco/generate-segmented-reduce-kernel sr 'C)]
       (testing "literal-dim contraction has no scalar params (dims inlined)"
         (is (empty? scalar-params)))
-      (register! kernel-name {:source source :dtype :double :workgroup-size 256})
+      ;; Register the emitter-owned ABI as well as its source. The runtime deliberately refuses
+      ;; a hand-reconstructed map signature because dropping one slot here is a silent miscompile.
+      (register! kernel-name (assoc kernel :workgroup-size 256))
       (invoke! kernel-name [A B] C [] (* m n))     ; args: A, B, out, int _nseg=(m*n)
       (testing "GPU segmented-contraction result == CPU reference"
         (let [ref (ref-matmul A B m k n)]

--- a/test/raster/compiler/ir/kernel_call_test.clj
+++ b/test/raster/compiler/ir/kernel_call_test.clj
@@ -72,6 +72,55 @@
                            call (assoc artifact :source
                                        "__kernel void kernel_call_contract_test(__global const float* x, __global float* out, float scale, int n) { out[0] = 0; }"))))))
 
+(deftest logical-soa-plan-expands-once-before-physical-call
+  (let [soa-artifact
+        (kart/make
+         {:kernel-name "logical_soa_contract_test"
+          :source (str "__kernel void logical_soa_contract_test("
+                       "__global const float* particles_x, "
+                       "__global const int* particles_id, __global float* out, int n) {}")
+          :abi [(kabi/slot 'particles_x :input :float :binding 'particles :role :operand)
+                (kabi/slot 'particles_id :input :int :binding 'particles :role :operand)
+                (kabi/slot 'out :output :float :role :effect)
+                (kabi/slot 'n :scalar :int :role :bound)]
+          :arguments '[particles_x particles_id out n]
+          :launch (klaunch/spec {:workgroup-size [64]
+                                 :group-count [(klaunch/ceil-div 'n 64)]})})
+        plan (kcall/logical-argument-plan soa-artifact)
+        physical (kcall/expand-logical-arguments
+                  soa-artifact
+                  [:resident-particles :resident-out {:type :int :value 65}]
+                  (fn [{:keys [binding]} value]
+                    (if (= binding 'particles)
+                      [(keyword (str (name value) "-x"))
+                       (keyword (str (name value) "-id"))]
+                      [value])))
+        call (kcall/make soa-artifact physical)]
+    (is (= '[particles out n] (kcall/logical-arguments soa-artifact)))
+    (is (= [2 1 1] (mapv (comp count :slots) plan)))
+    (is (= [:resident-particles-x :resident-particles-id :resident-out
+            {:type :int :value 65}]
+           physical))
+    (is (= [2] (get-in call [:geometry :group-count])))
+    (is (= [:seg-x :seg-id]
+           (ze/expand-pointer-binding
+            (first plan)
+            (ze/->GpuSoA 'Particle 'ParticleSoA 65
+                         [{:name "x" :dtype :float :seg :seg-x}
+                          {:name "id" :dtype :int :seg :seg-id}]))))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"field order/name"
+         (ze/expand-pointer-binding
+          (first plan)
+          (ze/->GpuSoA 'Particle 'ParticleSoA 65
+                       [{:name "id" :dtype :float :seg :seg-id}
+                        {:name "x" :dtype :int :seg :seg-x}]))))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"differs from physical ABI"
+         (kcall/expand-logical-arguments soa-artifact
+                                         [:particles :out {:type :int :value 1}]
+                                         (fn [_ value] [value]))))))
+
 (deftest both-resident-backends-consume-the-same-call-contract
   (let [call (kcall/make artifact args)]
     (doseq [[register! bind!] [[ze/register-kernel! ze/bind-kernel-call]

--- a/test/raster/compiler/kernel_call_pipeline_test.clj
+++ b/test/raster/compiler/kernel_call_pipeline_test.clj
@@ -17,6 +17,11 @@
     (raster.par/map-void! j n
                           (ra/aset out j (* (ra/aget x j) sum)))))
 
+(deftm resident-kernel-call-map-void
+  [x :- (Array float) out :- (Array float) scale :- Float n :- Long] :- Void
+  (raster.par/map-void! i n
+                        (ra/aset out i (* scale (ra/aget x i)))))
+
 (deftest resident-segmap-step-carries-one-executable-call-template
   (let [descriptor (pipeline/compile-gpu-program #'resident-kernel-call-map
                                                  :ze:0 :dtype :float)
@@ -56,3 +61,24 @@
            (mapv :kind (:argument-specs step))))
     (is (= [3] (get-in default-call [:geometry :group-count])))
     (is (= [1] (get-in resident-call [:geometry :group-count])))))
+
+(deftest resident-map-void-step-carries-a-logical-plan-for-one-physical-call
+  (let [descriptor (pipeline/compile-gpu-program #'resident-kernel-call-map-void
+                                                 :ze:0 :dtype :float)
+        step (first (:steps descriptor))
+        runtime-params [(float-array 513) (float-array 513) (float 2.0) 513]
+        logical-values
+        (mapv (fn [{:keys [kind sym type value-fn]}]
+                (if (= :scalar kind)
+                  {:type type :value (value-fn runtime-params)}
+                  (keyword (name sym))))
+              (:argument-specs step))
+        physical-values (kcall/expand-logical-arguments
+                         (:artifact step) logical-values (fn [_ value] [value]))
+        call (kcall/make (:artifact step) physical-values)]
+    (is (= :map-void (:convention step)))
+    (is (:logical-bindings? step))
+    (is (kart/kernel-artifact? (:artifact step)))
+    (is (= '[out x scale]
+           (subvec (kcall/logical-arguments (:artifact step)) 0 3)))
+    (is (= [3] (get-in call [:geometry :group-count])))))

--- a/test/raster/gpu/soa_test.clj
+++ b/test/raster/gpu/soa_test.clj
@@ -10,6 +10,7 @@
             [raster.compiler.backend.gpu.par-opencl :as par-opencl]
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
             [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as kart]
             [raster.runtime.display :as display])
   (:import [java.lang.foreign MemorySegment ValueLayout]))
 
@@ -170,7 +171,7 @@
         (is (= '[particles_x particles_y particles_vx particles_vy _n_bound]
                (mapv :name abi)))
         (is (= '[particles] (kabi/pointer-binding-names abi)))
-        (is (= '[particles] (:array-params kernel)))))))
+        (is (= '[particles] (kart/attribute kernel :array-params)))))))
 
 (deftest soa-kernel-aget-field-projects-test
   (testing "SoA aget + field projection scalar-replaces to the per-field array read"
@@ -231,8 +232,8 @@
                 {'particles 'TestParticleSoA})
           result (opencl-pass/opencl-pass body :dtype :float)
           kernel (first (:kernels result))]
-      (is (some? (:soa-expansions kernel)))
-      (is (contains? (:soa-expansions kernel) 'particles)))))
+      (is (some? (kart/attribute kernel :soa-expansions)))
+      (is (contains? (kart/attribute kernel :soa-expansions) 'particles)))))
 
 ;; ================================================================
 ;; Phase 3: deftm inlining in OpenCL kernels


### PR DESCRIPTION
## Summary

- emit map-void and gather as verified KernelArtifact values with canonical launch contracts
- derive one explicit logical argument plan from the physical ABI, including checked SoA field expansion
- construct ordinary physical KernelCall values before the shared Level Zero/OpenCL resident binder
- remove compiled map-void use of the split compatibility binder and retain typed emitter attributes inside the artifact
- repair the live segmented-contraction fixture so it no longer drops its emitter ABI

## Verification

- focused compiler/runtime gate: 54 tests, 215 assertions, zero failures/errors
- live Level Zero and OpenCL map-void/session/SoA coverage passed
- full 138-step Gemma training graph passed with 42 migrated map-void launches and GPU/CPU loss parity
- attention, backward, GQA, RMSNorm, and mixed-precision resident schedules passed
- standalone GEMM autotune gate passed on rerun: split-K 16, 10.7x over baseline

The exhaustive local run found the now-fixed stale contraction test fixture and one timing-sensitive autotune sample that chose split-K 4 despite an 8.7x win; the autotune test passed when rerun in isolation.