### PR TITLE
Route contractions through executable kernel calls

### DIFF
--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -322,7 +322,7 @@
             ;; The routing brain (contract-route) chooses the hardware-optimal kernel: DPAS/XMX
             ;; tensorize when legal (canonical f16 matmul, pitch-aligned) → peak (byte-identical
             ;; to the hand GEMM front door); otherwise the portable register-tiled kernel (any
-            ;; dtype, arbitrary dims). Emits a 2D invoke-registered-contraction! marker.
+            ;; dtype, arbitrary dims). Emits one artifact-backed marker containing only ABI values.
             (croute/par-contract-form? form)
             (let [out-sym (second form)
                   ;; pass the REAL descriptor: route-contraction fed `(or desc {})` into
@@ -341,36 +341,21 @@
                       :desc (try ((requiring-resolve 'raster.compiler.core.hardware/descriptor-for)
                                   device-id)
                                  (catch Throwable _ nil))))
-                  ;; Full reductions already arrive as a verified KernelArtifact; keep that value
-                  ;; intact. Other contraction leaves have not migrated yet and retain their
-                  ;; routed kernel map during this bounded vertical.
-                  ;; :strategy/:fallback-reason/:declines/:tile are the ROUTING DECISION. They
-                  ;; were dropped here, so no diagnostic could say which leaf a kernel came from
-                  ;; or why a faster one was refused. Tensorization/packing are codegen facts that
-                  ;; need no extra launch slot, so preserve them for inspection instead of treating
-                  ;; them like the unbound argument fields refused above.
-                  kernel (if (= :reduction (:invoke r))
-                           (:artifact r)
-                           (merge (select-keys r [:c-op :identity-val :array-params
-                                                  :out-dtype :strategy :fallback-reason
-                                                  :declines :tile :tensorized :packed
-                                                  :fused-epilogue :abi :arguments])
-                                  {:kernel-name (:kernel-name r) :source (:source r)
-                                   :dtype (:dtype r)}))
+                  ;; Every routed single-entry leaf is now a complete executable artifact. Routing
+                  ;; diagnostics and tensorization facts live in its attributes/provenance rather
+                  ;; than being flattened into the runtime registry namespace.
+                  kernel (:artifact r)
                   k (register-kernel! kernel
                                       :ze-contracts)]
               ;; A full reduction (0 free axes) has its own two-phase launch protocol + a
               ;; host-side final combine — emit the reduction invoke, not the 2-D contraction one.
               (if (= :reduction (:invoke r))
                 (emit-reduction-invocation k nil)
-              ;; The marker carries only VALUES in ABI order.  Slot kind, storage dtype and kernel
-              ;; view dtype live once in the registered ABI and drive runtime binding.
+                ;; The staging marker carries only ordered values. Output extent and complete 2-D
+                ;; launch live in the artifact; resident extraction never reconstructs geometry.
                 (list 'raster.gpu.ze-runtime/invoke-registered-contraction!
                       (:kernel-name k)
-                      (vec (:arguments r))
-                      (:out-elems r)                ; may be a symbolic expr (symbolic axis bounds)
-                      (vec (:wg r))
-                      (vec (:grid r)))))
+                      (vec (:arguments r)))))
 
             ;; === par/reduce-into — resident SegRed writing a caller-supplied 1-elem buffer ===
             ;; Same SegRed kernel as par/reduce (it already has an `output` param), but the

--- a/src/raster/compiler/ir/kernel_artifact.clj
+++ b/src/raster/compiler/ir/kernel_artifact.clj
@@ -23,7 +23,11 @@
             provenance    ;; semantic/scheduled origin for explain/profile
             attributes])  ;; emitter properties (dtype, combine, phases, ...)
 
-(defn kernel-artifact? [x] (instance? KernelArtifact x))
+(defn kernel-artifact?
+  "Recognize emitted artifacts across Typed Clojure's child DynamicClassLoaders."
+  [x]
+  (and x (= "raster.compiler.ir.kernel_artifact.KernelArtifact"
+            (.getName (class x)))))
 
 (defn validate!
   "Validate `artifact` and return it unchanged.  Validation includes the emitted OpenCL

--- a/src/raster/compiler/ir/kernel_call.clj
+++ b/src/raster/compiler/ir/kernel_call.clj
@@ -10,7 +10,11 @@
 
 (defrecord KernelCall [artifact arguments geometry])
 
-(defn kernel-call? [x] (instance? KernelCall x))
+(defn kernel-call?
+  "Recognize executable calls across Typed Clojure's child DynamicClassLoaders."
+  [x]
+  (and x (= "raster.compiler.ir.kernel_call.KernelCall"
+            (.getName (class x)))))
 
 (defn logical-argument-plan
   "Project an artifact's physical ABI into ordered logical caller arguments.
@@ -159,6 +163,14 @@
                             {:kernel-name (:kernel-name artifact)
                              :value compiler-value :indexes (vec indexes) :values values})))
           (first values))))))
+
+(defn resolve-value
+  "Resolve one compiler value through a checked call's artifact/runtime argument relation. This
+   is used for artifact attributes such as a contraction's logical output extent; backends still
+   receive no convention-specific positional metadata."
+  [call compiler-value]
+  (let [{:keys [artifact arguments]} (validate! call)]
+    ((argument-resolver artifact arguments) compiler-value)))
 
 (defn make
   "Construct a checked call from an artifact and complete ABI-ordered runtime values.

--- a/src/raster/compiler/ir/kernel_launch.clj
+++ b/src/raster/compiler/ir/kernel_launch.clj
@@ -10,6 +10,11 @@
 (defrecord LaunchSpec [workgroup-size group-count shared-memory-bytes])
 (defrecord LaunchGeometry [workgroup-size group-count shared-memory-bytes])
 
+(defn- record-kind?
+  "Recognize compiler IR records across Typed Clojure's child DynamicClassLoaders."
+  [record-class value]
+  (and value (= record-class (.getName (class value)))))
+
 (defn runtime-value
   "A launch dimension whose value is resolved when a call is bound."
   [value]
@@ -27,8 +32,17 @@
                     {:value value :divisor divisor})))
   (->CeilDiv value divisor))
 
-(defn launch-spec? [x] (instance? LaunchSpec x))
-(defn launch-geometry? [x] (instance? LaunchGeometry x))
+(defn launch-spec? [x]
+  (record-kind? "raster.compiler.ir.kernel_launch.LaunchSpec" x))
+
+(defn launch-geometry? [x]
+  (record-kind? "raster.compiler.ir.kernel_launch.LaunchGeometry" x))
+
+(defn- runtime-value? [x]
+  (record-kind? "raster.compiler.ir.kernel_launch.RuntimeValue" x))
+
+(defn- ceil-div? [x]
+  (record-kind? "raster.compiler.ir.kernel_launch.CeilDiv" x))
 
 (defn- dimension-vector!
   [owner field dimensions pred expected]
@@ -47,8 +61,8 @@
 (defn- launch-expression?
   [x]
   (or (and (integer? x) (pos? x))
-      (instance? RuntimeValue x)
-      (instance? CeilDiv x)))
+      (runtime-value? x)
+      (ceil-div? x)))
 
 (defn validate-spec!
   "Validate and return a symbolic launch specification."
@@ -136,9 +150,9 @@
   (long
    (cond
      (integer? dimension) dimension
-     (instance? RuntimeValue dimension)
+     (runtime-value? dimension)
      (resolve-integer! resolve-value dimension (:value dimension))
-     (instance? CeilDiv dimension)
+     (ceil-div? dimension)
      (let [value (resolve-integer! resolve-value dimension (:value dimension))
            divisor (:divisor dimension)]
        ;; This form avoids overflowing `value + divisor - 1` for a large positive value.

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -22,7 +22,9 @@
             [raster.compiler.backend.gpu.c-emit :as ce]
             [raster.compiler.ir.axis-map :as am]
             [raster.compiler.ir.contraction-facts :as cf]
-            [raster.compiler.ir.kernel-abi :as kabi]))
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-launch :as klaunch]))
 
 (defn par-contract-form?
   "Is `form` a (raster.par/contract out free-axes contract-axes body & opts) form?"
@@ -44,6 +46,54 @@
    cannot be confused at bind time."
   [body]
   (distinct (map :sym (od/aget-reads body))))
+
+(defn- launch-dimension
+  "Translate the router's legacy arithmetic dimension into canonical launch IR. The router emits
+  symbolic ceil-div as `(quot (+ value (dec divisor)) divisor)`; preserve that operation as a
+  CeilDiv so KernelCall resolves the underlying compiler value directly from the ABI arguments."
+  [dimension]
+  (cond
+    (integer? dimension)
+    (if (pos? dimension)
+      dimension
+      (throw (ex-info "contract launch dimension must be positive"
+                      {:dimension dimension})))
+
+    :else
+    (let [[q numerator divisor] (when (seq? dimension) dimension)
+          [plus value offset] (when (seq? numerator) numerator)]
+      (if (and (contains? '#{quot clojure.core/quot} q)
+               (contains? '#{+ clojure.core/+} plus)
+               (integer? divisor) (pos? divisor)
+               (= (dec divisor) offset))
+        (klaunch/ceil-div value divisor)
+        (klaunch/runtime-value dimension)))))
+
+(defn- descriptor-artifact
+  "Close a validated single-launch contraction descriptor into one executable compiler value."
+  [{:keys [strategy kernel-name source abi arguments wg grid out-elems dtype out-dtype]
+    :as descriptor}]
+  (when (and (not (number? out-elems)) (not (some #(= out-elems %) arguments)))
+    (throw (ex-info "contract descriptor: symbolic :out-elems is absent from artifact arguments"
+                    {:strategy strategy :out-elems out-elems :arguments arguments})))
+  (kart/make
+   {:kernel-name kernel-name
+    :source source
+    :abi abi
+    :arguments arguments
+    :launch (klaunch/spec
+             {:workgroup-size (mapv launch-dimension wg)
+              :group-count (mapv launch-dimension grid)})
+    :temporaries []
+    :effects {:kind :tensor-contraction}
+    :provenance {:dialect :segcontract :strategy strategy}
+    :attributes
+    (merge {:strategy strategy
+            :out-elems out-elems
+            :dtype dtype
+            :out-dtype out-dtype}
+           (select-keys descriptor [:fallback-reason :declines :tile :tensorized :packed
+                                    :fused-epilogue :dims :stages]))}))
 
 (defn kernel-signature-params
   "The parameter list of the single __kernel in `src`, split at top-level commas. Used to check a
@@ -74,17 +124,13 @@
    7-arg kernel. Both are mechanically detectable by comparing the emitted signature with what the
    descriptor says to bind, which is what this does.
 
-   Pointer params must equal (array-params + 1 output + epilogue-operands). The rest depends on the
-   INVOKE PROTOCOL, of which there are two — writing this validator is what forced them to be stated
-   explicitly instead of living implicitly in two call sites:
+   Pointer params must equal (array-params + 1 output + epilogue-operands). Default single-launch
+   leaves must also supply positive 2-D workgroup/grid data; validation closes those fields and the
+   ordered compiler values into a KernelArtifact. Full reductions already arrive as a verified
+   artifact and retain their distinct two-phase invoke protocol, whose scheduler owns geometry.
 
-     default (:invoke nil)  invoke-registered-contraction! binds :scalar-args positionally and
-                            launches with :wg/:grid — so all three must be present and match.
-     :invoke :reduction     invoke-registered-reduction-kernel consumes the emitter's complete
-                            ordered ABI (the staging marker replaces only the :result value with
-                            nil) and computes its own two-phase launch geometry; :wg/:grid are absent.
-
-   Returns the descriptor with `:arguments`, the compiler values in exact ABI order."
+   Returns the descriptor with `:arguments`, the compiler values in exact ABI order, and an
+   executable `:artifact` for every route."
   [{:keys [strategy kernel-name source array-params scalar-args epilogue-operands lift-operands abi
            epilogue-scalars out-elems wg grid invoke reduce-bound] :as d}]
   (let [params (kernel-signature-params source)
@@ -102,11 +148,9 @@
         ;; epilogue's (bias/residual/scale, appended after the dims) or a staged contraction's
         ;; lift operands (the per-block scales, bound between the operands and the output).
         expect-ptr (+ (count array-params) 1 (count epilogue-operands) (count lift-operands))
-        ;; TWO invoke protocols, made explicit here because the validator forced the question:
-        ;;   :invoke nil (default) — invoke-registered-contraction! binds :scalar-args positionally,
-        ;;                           so they must match the kernel's scalar params exactly.
-        ;;   :invoke :reduction    — the ordered reduction ABI includes the count slot; the routed
-        ;;                           descriptor carries no separate positional scalar convention.
+        ;; Full reduction carries a complete ordered ABI. Other leaves still construct their
+        ;; compiler argument values from descriptor scalars here, exactly once, before artifact
+        ;; validation eliminates the positional convention from all runtime paths.
         ;; an epilogue's SCALARS are kernel scalar params too — they are emitted into the
         ;; signature by epilogue-splice, so a descriptor that omits them under-counts and the
         ;; capability becomes unusable (which is what pushed `:scheme` into a private channel)
@@ -139,7 +183,7 @@
                       {:strategy strategy :kernel-name kernel-name :params params
                        :invoke invoke :scalar-args scalar-args}))
       (nil? out-elems)
-      (throw (ex-info "contract descriptor: :out-elems is required (the invoke sizes the output with it)"
+      (throw (ex-info "contract descriptor: :out-elems is required (the artifact sizes the output with it)"
                       {:strategy strategy}))
       ;; wg/grid belong to the 2-D launch contract only. The reduction invoke computes its own
       ;; two-phase geometry, so a :reduction descriptor legitimately carries neither — a third
@@ -170,8 +214,9 @@
                             (throw (ex-info "contract descriptor: no value for ABI scalar"
                                             {:strategy strategy :slot slot
                                              :scalar-args scalar-args}))))))
-                    abi)]
-          (assoc d :arguments arguments))))))
+                    abi)
+              descriptor (assoc d :arguments arguments)]
+          (assoc descriptor :artifact (descriptor-artifact descriptor)))))))
 
 (declare route-2free-1contract route-quant)
 

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -1314,7 +1314,7 @@
   ;; the emitter changed shape — extra operands would be SILENTLY DROPPED (the store-drop /
   ;; alpha-beta bug family) and fewer would bind nil into a size/scalar slot. Each arm returns
   ;; nil on an unexpected arity so the caller rejects it BY NAME (:unparseable-kernel-invoke)
-  ;; instead of miscompiling. Emit-site arities: map-void=5, map=6, contraction=6,
+  ;; instead of miscompiling. Emit-site arities: map-void=5, map=6, contraction=3,
   ;; scatter=6|7, ordered-reduce=3.
   (let [head (first expr)
         argc (count expr)]
@@ -1331,14 +1331,13 @@
            :arguments (vec (concat inputs [out] scalars [n]))
            :convention :map :returns sym}))
       (= head 'raster.gpu.ze-runtime/invoke-registered-contraction!)
-      ;; The marker carries VALUES in exact emitter-authored ABI order.  Do not split or reorder
-      ;; them here: packed inputs and epilogue operands/scalars can interleave by signature.
-      (when (= 6 argc)
-        (let [[_ kname arguments out-elems wg grid] expr]
-          (when (and (vector? arguments) (vector? wg) (= 2 (count wg))
-                     (vector? grid) (= 2 (count grid)))
-            {:kernel-name kname :arguments arguments :out-elems-expr out-elems
-             :wg-exprs wg :grid-exprs grid :convention :contract :returns sym})))
+      ;; The marker carries VALUES in exact emitter-authored ABI order. Output extent and launch
+      ;; are artifact-owned and therefore cannot drift as extra marker positions.
+      (when (= 3 argc)
+        (let [[_ kname arguments] expr]
+          (when (vector? arguments)
+            {:kernel-name kname :arguments arguments
+             :convention :contract :returns sym})))
       (= head 'raster.gpu.ze-runtime/invoke-registered-scatter-kernel)
       ;; (invoke-registered-scatter-kernel kname out src index n [stride]). out is the
       ;; accumulator buffer (a zeros-like intermediate), written in-place via atomic +=.
@@ -1585,7 +1584,7 @@
       :allocs [{:sym b :size-fn (fn [args] int)}]   ; intermediate scratch buffers
       :steps  [{:kernel-name str :convention :map|:contract|:reduce|... :phase kw
                 ;; artifact maps/reductions carry :artifact plus ordered :argument-specs;
-                ;; contractions carry ordered :argument-specs plus :wg-fns/:grid-fns geometry
+                ;; contractions carry ordered :argument-specs plus their executable artifact
                 ...}]
       :result-sym sym}
 
@@ -1803,11 +1802,13 @@
                          :phase (keyword (str "gpu-step-" i))}
 
                         (= :contract (:convention step))
-                        (let [{:keys [kernel-name arguments out-elems-expr wg-exprs grid-exprs]} step
-                              abi (some-> (reg-entry kernel-name) :abi kabi/validate!)
-                              _ (when-not abi
-                                  (throw (ex-info "resident contraction kernel has no registered ordered ABI"
-                                                  {:kernel-name kernel-name})))
+                        (let [{:keys [kernel-name arguments]} step
+                              artifact (reg-entry kernel-name)
+                              _ (when-not (kart/kernel-artifact? artifact)
+                                  (throw (ex-info "resident contraction kernel is not a registered KernelArtifact"
+                                                  {:kernel-name kernel-name :entry artifact})))
+                              artifact (kart/validate! artifact)
+                              abi (:abi artifact)
                               _ (kabi/validate-arguments! abi arguments)
                               result-slots (filterv #(= :result (:role %)) abi)
                               _ (when-not (= 1 (count result-slots))
@@ -1816,6 +1817,7 @@
                                                    :result-slots result-slots})))]
                           {:convention :contract
                            :kernel-name kernel-name
+                           :artifact artifact
                            :abi abi
                            :argument-specs
                            (mapv (fn [slot value]
@@ -1825,9 +1827,6 @@
                                      {:slot slot :kind (:kind slot) :role (:role slot)
                                       :dtype (:dtype slot) :sym value}))
                                  abi arguments)
-                           :out-elems-fn (expr->arg-fn all-params scalar-lets out-elems-expr)
-                           :wg-fns (mapv #(expr->arg-fn all-params scalar-lets %) wg-exprs)
-                           :grid-fns (mapv #(expr->arg-fn all-params scalar-lets %) grid-exprs)
                            :phase (keyword (str "gpu-step-" i))})
 
                         (= :map-void (:convention step))

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -690,7 +690,7 @@
    weights/KV per layer and scratch shared, like the decoder's pbk). Does NOT record a graph; the
    caller collects :phase keys and records once.
 
-     :map/:reduce/:map-void
+     :map/:reduce/:map-void/:contract
                 Artifact ABI values and realized geometry bind through one KernelCall contract.
                 SegRed explicitly schedules one resident workgroup; maps realize their grid.
                 Logical SoA arguments expand through the backend representation adapter before
@@ -698,9 +698,9 @@
   [sess step args sym->key]
   (let [device-id (:device-id @sess)
         {:keys [kernel-name phase convention artifact argument-specs]} step]
-    (when-not (#{:map-void :map :reduce} convention)
+    (when-not (#{:map-void :map :reduce :contract} convention)
       (throw (ex-info (str "bind-step! cannot bind a " convention " step (" kernel-name
-                           ") — only :map-void / :map / :reduce are supported on the resident path")
+                           ") — only artifact-backed kernel steps are supported on the resident path")
                       {:convention convention :kernel kernel-name})))
     (let [bufs (:buffers @sess)
           resolve-buf (fn [a] (or (get bufs (sym->key a))
@@ -708,7 +708,7 @@
                                                   {:kernel kernel-name :available (keys bufs)}))))
           bind-call-fn (rt-resolve device-id "bind-kernel-call")]
       (case convention
-        (:map :reduce :map-void)
+        (:map :reduce :map-void :contract)
         (let [logical-or-physical-args
               (mapv (fn [{:keys [kind sym type value-fn]}]
                       (if (= :scalar kind)
@@ -1100,7 +1100,6 @@
          info-fn   (rt-resolve device-id "kernel-registry-entry")
          specialized-bind-fn (rt-resolve device-id "bind-registered-map-void-kernel")
          bind-call-fn (rt-resolve device-id "bind-kernel-call")
-         contract-fn (rt-resolve device-id "bind-registered-contraction!")
          gemm-fn   (rt-resolve device-id "bind-registered-gemm!")
          conv-fn   (rt-resolve device-id "bind-registered-convert!")
          trans-fn  (rt-resolve device-id "bind-registered-transpose!")
@@ -1224,10 +1223,10 @@
                      (mapv (fn [[nm b c]] {:bound b :kernel-name nm :phase (:phase step)
                                            :const-prologue? (boolean c)})
                            raw))))
-               ;; Generic map and reduction now share the complete executable value: emitted
-               ;; artifact, ordered ABI values and realized launch. Reduction's single-group
-               ;; resident schedule is explicit here rather than hidden in a special binder.
-               (:map :reduce :map-void)
+               ;; Artifact-backed kernels share the complete executable value: emitted artifact,
+               ;; ordered ABI values and realized launch. Reduction's single-group resident
+               ;; schedule is explicit here rather than hidden in a special binder.
+               (:map :reduce :map-void :contract)
                (let [logical-or-physical-args
                      (mapv (fn [{:keys [kind sym type value-fn]}]
                              (if (= :scalar kind)
@@ -1243,26 +1242,6 @@
                      call (kcall/make artifact ordered-args
                                       (if (= :reduce convention) {:group-count [1]} {}))]
                  [(assoc (bind-call-fn call) :phase (:phase step))])
-               ;; Routed contraction: preserve the emitter-authored ABI order all the way into
-               ;; the backend binder. Pointer slots resolve to resident buffers; scalar slots
-               ;; retain their declared kernel view dtype (not the program/output dtype). The
-               ;; 2-D workgroup and grid expressions are evaluated once at bind and baked into
-               ;; the replay graph.
-               :contract
-               (do (or (info-fn kernel-name)
-                       (throw (ex-info (str "Program kernel not registered: " kernel-name)
-                                       {:kernel kernel-name})))
-                   (let [ordered-args
-                         (mapv (fn [{:keys [kind sym type value-fn]}]
-                                 (if (= :scalar kind)
-                                   {:type type :value (value-fn args)}
-                                   (buf-of sym kernel-name)))
-                               (:argument-specs step))
-                         out-elems (long ((:out-elems-fn step) args))
-                         wg (mapv (fn [f] (long (f args))) (:wg-fns step))
-                         grid (mapv (fn [f] (long (f args))) (:grid-fns step))]
-                     [(assoc (contract-fn kernel-name ordered-args out-elems wg grid)
-                             :phase (:phase step))]))
                ;; scatter-add: out[index[e]*stride+d] += src[e*stride+d]. Expands to TWO bound
                ;; kernels — a zero-fill of the accumulator, then the atomic-add scatter — so the
                ;; recorded graph re-zeroes `out` each replay (zeros-like semantics) and fans

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -1172,6 +1172,23 @@
               (when (and (device-buffer? value) (< (:n-elements ^OclBuffer value) 1))
                 (throw (ex-info "resident reduction result buffer must hold at least one element"
                                 {:kernel-name kernel-name :slot slot :buffer-elements 0})))))
+        _ (when (= :tensor-contraction (get-in registered [:effects :kind]))
+            (let [extent-expr (kart/attribute registered :out-elems)
+                  out-elems (long (if (number? extent-expr)
+                                    extent-expr
+                                    (kcall/resolve-value call extent-expr)))]
+              (when (neg? out-elems)
+                (throw (ex-info "resident contraction output extent must be non-negative"
+                                {:kernel-name kernel-name :out-elems out-elems})))
+              (doseq [[slot value] pointer-pairs :when (= :result (:role slot))]
+                (let [capacity (cond
+                                 (device-buffer? value) (:n-elements ^OclBuffer value)
+                                 (instance? MemorySegment value)
+                                 (quot (.byteSize ^MemorySegment value) (dt/bytes-of (:dtype slot))))]
+                  (when (< (long capacity) out-elems)
+                    (throw (ex-info "contraction output buffer is smaller than its artifact extent"
+                                    {:kernel-name kernel-name :slot slot :out-elems out-elems
+                                     :buffer-elements capacity})))))))
         ;; Driver contact begins only after call/artifact/ABI/value/geometry validation.
         {:keys [program]} (ensure-kernel-loaded! kernel-name)
         kh (create-kernel-fresh program kernel-name)]
@@ -1215,60 +1232,6 @@
       :group-count (long (or (get opts :group-count) (Math/ceil (/ (double n) wg))))
       :kernel-name kernel-name
       :async? (boolean (get opts :async?))})))
-
-(defn bind-registered-contraction!
-  "Pre-bind a routed contraction over resident OclBuffers in exact ordered ABI position.
-  The returned prepared launch carries vector workgroup/group-count geometry; the OpenCL graph
-  replay path accepts both these 2-D values and the scalar 1-D values used by map kernels."
-  [^String kernel-name arguments out-elems wg grid]
-  (let [registered (or (get @kernel-registry kernel-name)
-                       (throw (ex-info (str "Kernel not registered: " kernel-name)
-                                       {:kernel-name kernel-name
-                                        :registered (keys @kernel-registry)})))
-        abi (kabi/validate! (:abi registered))
-        arguments (kabi/validate-arguments! abi arguments)
-        _ (when-not (and (vector? wg) (= 2 (count wg))
-                         (every? pos? wg)
-                         (vector? grid) (= 2 (count grid))
-                         (every? pos? grid))
-            (throw (ex-info "resident contraction requires positive 2-D :wg and :grid vectors"
-                            {:kernel-name kernel-name :wg wg :grid grid})))
-        out-elems (long out-elems)
-        _ (when (neg? out-elems)
-            (throw (ex-info "resident contraction :out-elems must be non-negative"
-                            {:kernel-name kernel-name :out-elems out-elems})))
-        _ (doseq [[slot value] (map vector abi arguments)]
-            (if (= :scalar (:kind slot))
-              (when-not (and (map? value) (= (:kernel-dtype slot) (:type value)))
-                (throw (ex-info "contraction ABI scalar binding has the wrong kernel dtype"
-                                {:kernel-name kernel-name :slot slot
-                                 :expected (:kernel-dtype slot)
-                                 :actual (when (map? value) (:type value))})))
-              (do
-                (when-not (or (device-buffer? value) (instance? MemorySegment value))
-                  (throw (ex-info "resident contraction requires OclBuffer/MemorySegment pointer arguments"
-                                  {:kernel-name kernel-name :slot slot :value-type (type value)})))
-                (when (and (device-buffer? value)
-                           (not= (:dtype slot) (dt/canon (:dtype ^OclBuffer value))))
-                  (throw (ex-info "contraction ABI storage dtype does not match resident buffer"
-                                  {:kernel-name kernel-name :slot slot
-                                   :expected (:dtype slot)
-                                   :actual (dt/canon (:dtype ^OclBuffer value))})))
-                (when (and (= :output (:kind slot)) (device-buffer? value)
-                           (< (:n-elements ^OclBuffer value) out-elems))
-                  (throw (ex-info "contraction output buffer is smaller than :out-elems"
-                                  {:kernel-name kernel-name :slot slot :out-elems out-elems
-                                   :buffer-elements (:n-elements ^OclBuffer value)}))))))
-        ;; Driver touch starts only after ABI/value/geometry validation.
-        {:keys [program]} (ensure-kernel-loaded! kernel-name)
-        kh (create-kernel-fresh program kernel-name)]
-    (doseq [[idx [slot value]] (map-indexed vector (map vector abi arguments))]
-      (if (= :scalar (:kind slot))
-        (set-kernel-arg-scalar! kh idx value)
-        (set-kernel-arg-buffer! kh idx (device-mem-of value))))
-    {:bound {:kernel kh :wg (mapv long wg)}
-     :group-count (mapv long grid)
-     :kernel-name kernel-name}))
 
 (defn- enqueue-bound!
   "Enqueue one pre-bound kernel (no finish)."

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -2594,6 +2594,23 @@
               (when (and (device-buffer? value) (< (:n-elements ^DeviceBuffer value) 1))
                 (throw (ex-info "resident reduction result buffer must hold at least one element"
                                 {:kernel-name kernel-name :slot slot :buffer-elements 0})))))
+        _ (when (= :tensor-contraction (get-in registered [:effects :kind]))
+            (let [extent-expr (kart/attribute registered :out-elems)
+                  out-elems (long (if (number? extent-expr)
+                                    extent-expr
+                                    (kcall/resolve-value call extent-expr)))]
+              (when (neg? out-elems)
+                (throw (ex-info "resident contraction output extent must be non-negative"
+                                {:kernel-name kernel-name :out-elems out-elems})))
+              (doseq [[slot value] pointer-pairs :when (= :result (:role slot))]
+                (let [capacity (cond
+                                 (device-buffer? value) (:n-elements ^DeviceBuffer value)
+                                 (instance? MemorySegment value)
+                                 (quot (.byteSize ^MemorySegment value) (dt/bytes-of (:dtype slot))))]
+                  (when (< (long capacity) out-elems)
+                    (throw (ex-info "contraction output buffer is smaller than its artifact extent"
+                                    {:kernel-name kernel-name :slot slot :out-elems out-elems
+                                     :buffer-elements capacity})))))))
         ;; Driver contact begins only after call/artifact/ABI/value/geometry validation.
         {:keys [module]} (ensure-kernel-loaded! kernel-name)
         kernel-handle (create-kernel-fresh module kernel-name)
@@ -2669,67 +2686,6 @@
       :group-count group-count
       :kernel-name kernel-name
       :async? async?})))
-
-(defn bind-registered-contraction!
-  "Pre-bind a routed contraction over resident buffers using its ordered typed ABI.
-  `arguments` is in exact kernel-signature order and may interleave pointer and scalar slots.
-  The complete 2-D launch geometry is baked into the returned prepared binding, so command-graph
-  recording must leave :gc-seg untouched (:group-count is nil). All structural/type checks run
-  before kernel loading touches the native driver."
-  [^String kernel-name arguments out-elems wg grid]
-  (let [registered (or (get @kernel-registry kernel-name)
-                       (throw (ex-info (str "Kernel not registered: " kernel-name)
-                                       {:kernel-name kernel-name
-                                        :registered (keys @kernel-registry)})))
-        abi (kabi/validate! (:abi registered))
-        arguments (kabi/validate-arguments! abi arguments)
-        _ (when-not (and (vector? wg) (= 2 (count wg))
-                         (every? pos? wg)
-                         (vector? grid) (= 2 (count grid))
-                         (every? pos? grid))
-            (throw (ex-info "resident contraction requires positive 2-D :wg and :grid vectors"
-                            {:kernel-name kernel-name :wg wg :grid grid})))
-        out-elems (long out-elems)
-        _ (when (neg? out-elems)
-            (throw (ex-info "resident contraction :out-elems must be non-negative"
-                            {:kernel-name kernel-name :out-elems out-elems})))
-        _ (doseq [[slot value] (map vector abi arguments)]
-            (if (= :scalar (:kind slot))
-              (when-not (and (map? value) (= (:kernel-dtype slot) (:type value)))
-                (throw (ex-info "contraction ABI scalar binding has the wrong kernel dtype"
-                                {:kernel-name kernel-name :slot slot
-                                 :expected (:kernel-dtype slot)
-                                 :actual (when (map? value) (:type value))})))
-              (do
-                (when-not (or (device-buffer? value) (instance? MemorySegment value))
-                  (throw (ex-info "resident contraction requires DeviceBuffer/MemorySegment pointer arguments"
-                                  {:kernel-name kernel-name :slot slot :value-type (type value)})))
-                (when (and (device-buffer? value)
-                           (not= (:dtype slot) (dt/canon (:dtype ^DeviceBuffer value))))
-                  (throw (ex-info "contraction ABI storage dtype does not match resident buffer"
-                                  {:kernel-name kernel-name :slot slot
-                                   :expected (:dtype slot)
-                                   :actual (dt/canon (:dtype ^DeviceBuffer value))})))
-                (when (and (= :output (:kind slot)) (device-buffer? value)
-                           (< (:n-elements ^DeviceBuffer value) out-elems))
-                  (throw (ex-info "contraction output buffer is smaller than :out-elems"
-                                  {:kernel-name kernel-name :slot slot :out-elems out-elems
-                                   :buffer-elements (:n-elements ^DeviceBuffer value)}))))))
-        ;; Driver touch starts only after the ordered ABI and resident values are proven valid.
-        {:keys [module]} (ensure-kernel-loaded! kernel-name)
-        kernel-handle (create-kernel-fresh module kernel-name)
-        all-args (mapv (fn [slot value]
-                         (if (= :scalar (:kind slot))
-                           value
-                           (if (device-buffer? value)
-                             (:segment ^DeviceBuffer value)
-                             value)))
-                       abi arguments)
-        bound (bind-kernel! kernel-handle (mapv long wg) all-args)
-        ^MemorySegment gc (:gc-seg bound)]
-    (.set gc I32 0 (int (first grid)))
-    (.set gc I32 4 (int (second grid)))
-    {:bound bound :group-count nil :kernel-name kernel-name}))
 
 (defn launch-registered-bound!
   "Dispatch a pre-bound kernel. A KernelCall has its complete geometry baked into :gc-seg;
@@ -3461,23 +3417,32 @@
   out))
 
 (defn invoke-registered-contraction!
-  "Launch a routed contraction by its registered ordered ABI.
+  "Launch a routed contraction by its registered executable artifact.
 
    `arguments` contains evaluated values in exact ABI order.  The ABI decides which values are
    buffers or scalars, how host buffers are staged, and the scalar type passed to Level Zero.
-  Packed kernels therefore retain byte storage while declaring a distinct int32 kernel view."
-  [^String kernel-name arguments out-elems wg grid]
+   Packed kernels therefore retain byte storage while declaring a distinct int32 kernel view.
+   Output extent and 2-D geometry are resolved from the artifact, never marker positions."
+  [^String kernel-name arguments]
   (let [registered (get @kernel-registry kernel-name)
         _ (when-not registered
             (throw (ex-info (str "Kernel not registered: " kernel-name)
                             {:kernel-name kernel-name :registered (keys @kernel-registry)})))
-        abi (kabi/validate! (:abi registered))
-        _ (when-not (= (count abi) (count arguments))
-            (throw (ex-info "contraction invocation value count does not match registered ABI"
-                            {:kernel-name kernel-name :expected (count abi)
-                             :actual (count arguments) :abi abi})))
-        {:keys [kernel-handle]} (ensure-kernel-loaded! kernel-name)
-        out-elems (long out-elems)
+        artifact (kart/validate! registered)
+        abi (:abi artifact)
+        arguments (kabi/validate-arguments! abi arguments)
+        typed-arguments
+        (mapv (fn [{:keys [kind kernel-dtype]} value]
+                (if (= :scalar kind)
+                  (if (map? value) value {:type kernel-dtype :value value})
+                  value))
+              abi arguments)
+        call (kcall/make artifact typed-arguments)
+        out-elems-expr (kart/attribute artifact :out-elems)
+        out-elems (long (if (number? out-elems-expr)
+                          out-elems-expr
+                          (kcall/resolve-value call out-elems-expr)))
+        {:keys [workgroup-size group-count]} (kcall/binding-plan call)
         input-index (volatile! -1)
         output (volatile! nil)
         output-seg (volatile! nil)
@@ -3504,15 +3469,15 @@
                     seg)
 
                   :scalar
-                  {:type kernel-dtype :value value}
+                  value
 
                   (throw (ex-info "unsupported contraction ABI slot kind"
                                   {:kernel-name kernel-name :slot slot}))))
-              abi arguments)
+              abi typed-arguments)
+        {:keys [kernel-handle]} (ensure-kernel-loaded! kernel-name)
         out @output
-        [out-seg out-half? out-esize] @output-seg
-        [gx gy] grid]
-    (launch-2d! kernel-handle wg [gx gy] all-args)
+        [out-seg out-half? out-esize] @output-seg]
+    (launch-2d! kernel-handle workgroup-size group-count all-args)
     (when-not (device-buffer? out)
       (readback-operand! out-seg out out-elems out-half? out-esize))
     out))

--- a/test/raster/compiler/backend/gpu/contract_pipeline_device_test.clj
+++ b/test/raster/compiler/backend/gpu/contract_pipeline_device_test.clj
@@ -7,6 +7,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.arrays :as ra]
             [raster.compiler.backend.gpu.opencl-pass :as ocl]
+            [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.pipeline :as pipeline]
             [raster.core :refer [deftm]]
             [raster.gpu.core :as gpu]
@@ -67,7 +68,7 @@
    driver path used here is the runtime path production takes for these kernels."
   [dt m k n]
   (let [{:keys [form kernels]} (ocl/opencl-pass (matmul-form m n k) :dtype dt :compile-spirv? false)
-        _ (doseq [kr kernels] (ze/register-kernel! (:kernel-name kr) (select-keys kr [:source :dtype :abi])))
+        _ (doseq [kr kernels] (ze/register-kernel! (:kernel-name kr) kr))
         f (eval (list 'fn '[A B C] form))
         A (double-array (map #(* 0.1 (- (double (mod % 7)) 3.0)) (range (* m k))))
         B (double-array (map #(* 0.1 (- (double (mod % 5)) 2.0)) (range (* k n))))
@@ -102,7 +103,7 @@
 ;; staged at int8 size (4× undersized).
 (defn- run-form [form dt args-map out-len]
   (let [{:keys [form kernels]} (ocl/opencl-pass form :dtype dt :compile-spirv? false)
-        _ (doseq [kr kernels] (ze/register-kernel! (:kernel-name kr) (select-keys kr [:source :dtype :abi])))
+        _ (doseq [kr kernels] (ze/register-kernel! (:kernel-name kr) kr))
         syms (vec (keys args-map))
         f (eval (list 'fn (conj syms 'C) form))]
     (apply f (conj (mapv args-map syms) (double-array out-len)))))
@@ -138,7 +139,17 @@
     (let [r ((requiring-resolve 'raster.compiler.passes.parallel.contract-route/route-contraction)
              '(raster.par/contract C [[i m] [j n]] [[l k]]
                 (* (aget A (+ (* i k) l)) (aget B (+ (* l n) j))))
-             :dtype :double)]
+             :dtype :double)
+          artifact (:artifact r)
+          scalar-values {"k" 7 "m" 20 "n" 20 "_nseg" 400}
+          runtime-arguments
+          (mapv (fn [slot]
+                  (if (= :scalar (:kind slot))
+                    {:type (:kernel-dtype slot)
+                     :value (get scalar-values (:c-name slot))}
+                    (Object.)))
+                (:abi artifact))
+          call (kcall/make artifact runtime-arguments)]
       (is (some? (:out-elems r)))
       (is (not (number? (:out-elems r))))            ; carried symbolically
       (is (contains? #{:regtiled :naive-segred} (:strategy r)))
@@ -150,4 +161,7 @@
           "the symbolic axis bounds must be bound as int params, before the trailing count")
       (is (= '[k m n] (mapv :value (butlast (:scalar-args r))))
           "…in the kernel's declared (name-sorted) order")
-      (is (= (:out-elems r) (:value (last (:scalar-args r))))))))
+      (is (= (:out-elems r) (:value (last (:scalar-args r)))))
+      (is (= [256 1] (get-in call [:geometry :workgroup-size])))
+      (is (= [2 1] (get-in call [:geometry :group-count]))
+          "the artifact resolves its symbolic ceil-div grid from ordered ABI values"))))

--- a/test/raster/compiler/contract_soac_node_test.clj
+++ b/test/raster/compiler/contract_soac_node_test.clj
@@ -17,6 +17,7 @@
    `compile-aot` of every contraction with 'Cannot convert non-SOAC to par form'."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
+            [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.segop-lower-pass :as slp]
             [raster.compiler.backend.gpu.opencl-pass :as op]
@@ -63,7 +64,7 @@
       (let [r (run (:form (slp/segop-lower-pass bound {:target-device :ze:0 :dtype :double})))]
         (is (= 1 (:segop-reused (:stats r))))
         (is (nil? (:segop-relowered (:stats r))))
-        (is (= :regtiled (:strategy (first (:kernels r)))))))
+        (is (= :regtiled (kart/attribute (first (:kernels r)) :strategy)))))
     (testing "without segop-lower (door C): re-lowered and COUNTED"
       (is (= 1 (:segop-relowered (:stats (run bound))))))
     (testing "it is a refactor: identical kernel source both ways"

--- a/test/raster/compiler/contraction_marker_abi_test.clj
+++ b/test/raster/compiler/contraction_marker_abi_test.clj
@@ -4,6 +4,9 @@
             [raster.arrays :as ra]
             [raster.compiler.pipeline :as pipeline]
             [raster.compiler.backend.gpu.opencl-pass :as op]
+            [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.passes.parallel.contract-route :as route]
             [raster.compiler.passes.parallel.par-fusion :as fusion]
             [raster.core :refer [deftm]]
@@ -44,6 +47,16 @@
     (catch clojure.lang.ExceptionInfo e
       (ex-data e))))
 
+(defn- probe-artifact
+  [kernel-name source abi arguments]
+  (kart/make {:kernel-name kernel-name
+              :source source
+              :abi abi
+              :arguments arguments
+              :launch (klaunch/spec {:workgroup-size [1 1] :group-count [1 1]})
+              :effects {:kind :tensor-contraction}
+              :attributes {:out-elems 1 :dtype :float :out-dtype :float}}))
+
 (deftest fused-epilogue-operands-are-carried-in-the-ordered-marker
   (let [contract (fuse-epilogue
                   (list 'raster.numeric/+ (list 'aget 'C 't)
@@ -51,7 +64,7 @@
         compiled (compile-form contract)
         kernel (first (:kernels compiled))
         marker (-> compiled :form second second)]
-    (is (= :dpas (:strategy kernel)))
+    (is (= :dpas (kart/attribute kernel :strategy)))
     (is (= '[A B out M N K bias] (mapv :name (:abi kernel))))
     (is (= [:input :input :output :scalar :scalar :scalar :input]
            (mapv :kind (:abi kernel))))
@@ -65,9 +78,9 @@
         compiled (compile-form dp4a :byte)
         kernel (first (:kernels compiled))]
     (testing "tensorization and packing are already baked into source and need no extra launch slot"
-      (is (= :dp4a (:strategy kernel)))
-      (is (true? (:tensorized kernel)))
-      (is (= :int8x4 (:packed kernel)))
+      (is (= :dp4a (kart/attribute kernel :strategy)))
+      (is (true? (kart/attribute kernel :tensorized)))
+      (is (= :int8x4 (kart/attribute kernel :packed)))
       (is (= [:byte :byte] (mapv :dtype (take 2 (:abi kernel)))))
       (is (= [:int :int] (mapv :kernel-dtype (take 2 (:abi kernel))))))
     (testing "the ordinary two-input descriptor still emits the production marker"
@@ -104,10 +117,16 @@
 (deftest runtime-rejects-an-abi-value-count-mismatch-before-touching-the-driver
   (let [kernel-name (str "abi_count_probe_" (gensym))
         abi [{:name 'A :c-name "A" :kind :input :dtype :float :kernel-dtype :float}
-             {:name 'C :c-name "C" :kind :output :dtype :float :kernel-dtype :float}]
-        _ (ze/register-kernel! kernel-name {:abi abi})
+             {:name 'C :c-name "C" :kind :output :dtype :float :kernel-dtype :float
+              :role :result}]
+        artifact (probe-artifact
+                  kernel-name
+                  (str "__kernel void " kernel-name
+                       "(__global float* A, __global float* C) {}")
+                  abi '[A C])
+        _ (ze/register-kernel! kernel-name artifact)
         data (thrown-data #(ze/invoke-registered-contraction!
-                            kernel-name [(float-array 1)] 1 [1 1] [1 1]))]
+                            kernel-name [(float-array 1)]))]
     (is (= 2 (:expected data)))
     (is (= 1 (:actual data)))))
 
@@ -117,16 +136,21 @@
              {:name 'C :c-name "C" :kind :output :dtype :float :kernel-dtype :float :role :result}]
         raw-seg (java.lang.foreign.MemorySegment/ofArray (float-array 1))]
     (doseq [[backend register! bind!]
-            [[:ze ze/register-kernel! ze/bind-registered-contraction!]
-             [:ocl ocl/register-kernel! ocl/bind-registered-contraction!]]]
+            [[:ze ze/register-kernel! ze/bind-kernel-call]
+             [:ocl ocl/register-kernel! ocl/bind-kernel-call]]]
       (let [kernel-name (str "resident_abi_probe_" (name backend) "_" (gensym))
-            _ (register! kernel-name {:abi abi})
-            pointer-data (thrown-data #(bind! kernel-name
-                                              [(Object.) {:type :float :value 1.0} (Object.)]
-                                              1 [1 1] [1 1]))
-            scalar-data (thrown-data #(bind! kernel-name
-                                             [raw-seg {:type :int :value 1} raw-seg]
-                                             1 [1 1] [1 1]))]
+            artifact (probe-artifact
+                      kernel-name
+                      (str "__kernel void " kernel-name
+                           "(__global float* A, float alpha, __global float* C) {}")
+                      abi '[A alpha C])
+            _ (register! kernel-name artifact)
+            pointer-call (kcall/make artifact
+                                     [(Object.) {:type :float :value 1.0} (Object.)])
+            pointer-data (thrown-data #(bind! pointer-call))
+            scalar-data (thrown-data #(kcall/make
+                                       artifact
+                                       [raw-seg {:type :int :value 1} raw-seg]))]
         (is (= kernel-name (:kernel-name pointer-data)))
         (is (= :input (get-in pointer-data [:slot :kind])))
         (is (= Object (:value-type pointer-data)))
@@ -138,7 +162,13 @@
   (let [descriptor (pipeline/compile-gpu-program #'resident-contract-descriptor-probe
                                                   :ze:0 :dtype :float)
         step (first (:steps descriptor))
-        args [(float-array 64) (float-array 64)]]
+        args [(float-array 64) (float-array 64)]
+        call-arguments (mapv (fn [{:keys [kind type value-fn]}]
+                               (if (= :scalar kind)
+                                 {:type type :value (value-fn args)}
+                                 (Object.)))
+                             (:argument-specs step))
+        call (kcall/make (:artifact step) call-arguments)]
     (is (= :contract (:convention step)))
     (is (= '[A B C] (mapv (comp :name :slot) (:argument-specs step))))
     (is (= [:input :input :output] (mapv :kind (:argument-specs step))))
@@ -146,6 +176,8 @@
     (is (= {'A :input 'B :input} (:array-roles descriptor)))
     (is (= :float (:dtype (first (:allocs descriptor))))
         "scratch allocation dtype comes from the contraction output ABI")
-    (is (= 64 (long ((:out-elems-fn step) args))))
-    (is (every? pos? (map #(% args) (:wg-fns step))))
-    (is (every? pos? (map #(% args) (:grid-fns step))))))
+    (is (= 64 (kart/attribute (:artifact step) :out-elems)))
+    (is (= 2 (count (get-in call [:geometry :workgroup-size]))))
+    (is (= 2 (count (get-in call [:geometry :group-count]))))
+    (is (every? pos? (get-in call [:geometry :workgroup-size])))
+    (is (every? pos? (get-in call [:geometry :group-count])))))

--- a/test/raster/compiler/pipeline_extractor_test.clj
+++ b/test/raster/compiler/pipeline_extractor_test.clj
@@ -46,27 +46,26 @@
                              "k" [a b] out0 10)]
                        out))))))
 
-(deftest contraction-arity-and-geometry
+(deftest contraction-arity-and-artifact-owned-geometry
   (testing "a correct ordered-ABI contraction marker extracts without flattening its arguments"
     (let [r (pipeline/extract-gpu-program
              '(let* [result (raster.gpu.ze-runtime/invoke-registered-contraction!
-                             "contract_k" [A scale C M N K] (* M N)
-                             [16 16] [(quot (+ N 15) 16) (quot (+ M 15) 16)])]
+                             "contract_k" [A scale C M N K])]
                     result))
           step (first (:steps r))]
       (is (nil? (nr-key r)))
       (is (= :contract (:convention step)))
       (is (= '[A scale C M N K] (:arguments step)))
-      (is (= '[16 16] (:wg-exprs step)))
-      (is (= '[(quot (+ N 15) 16) (quot (+ M 15) 16)] (:grid-exprs step)))))
-  (testing "extra operands and malformed 2-D geometry are rejected by marker name"
+      (is (not (contains? step :wg-exprs)))
+      (is (not (contains? step :grid-exprs)))))
+  (testing "extra operands and a non-vector ABI value list are rejected by marker name"
     (is (= :unparseable-kernel-invoke
            (why '(let* [result (raster.gpu.ze-runtime/invoke-registered-contraction!
-                                "contract_k" [A C] 16 [8 8] [1 1] extra)]
+                                "contract_k" [A C] extra)]
                        result))))
     (is (= :unparseable-kernel-invoke
            (why '(let* [result (raster.gpu.ze-runtime/invoke-registered-contraction!
-                                "contract_k" [A C] 16 [64] [1 1])]
+                                "contract_k" (list A C))]
                        result))))))
 
 (deftest reduce-arity


### PR DESCRIPTION
## Summary

- close every routed single-launch contraction into a verified KernelArtifact with canonical 2D LaunchSpec
- shrink the staging marker to kernel name plus ordered ABI values and realize extent/geometry through KernelCall
- route resident ZE and OpenCL contractions through the shared binder and delete both backend-specific contraction binders
- make KernelArtifact, KernelCall, and launch record recognition safe across Typed Clojure child classloaders
- preserve routing and tensorization diagnostics as artifact attributes

## Verification

- 12 marker/extractor tests, 63 assertions
- 27 Kernel IR/router tests, 145 assertions
- 69 contraction/SOAC/lowering/emission tests, 433 assertions
- 16 live Level Zero contraction tests, 83 assertions, covering DPAS, DP4A, quant, segmented, tiled, and portable routes
- 5 live OpenCL resident-session tests, 9 assertions
- git diff --check