### PR TITLE
Add verified KernelGraph for scan scheduling

### DIFF
--- a/src/raster/compiler/ir/kernel_graph.clj
+++ b/src/raster/compiler/ir/kernel_graph.clj
@@ -1,0 +1,270 @@
+(ns raster.compiler.ir.kernel-graph
+  "Verified scheduling IR for algorithms that require one or more kernels.
+
+   KernelGraph is deliberately earlier than target emission: a ScheduledKernel owns a SegOp (or a
+   future target-neutral kernel body), explicit buffer uses, and dependencies.  Emission later
+   replaces the operation with a KernelArtifact without reconstructing dataflow from marker
+   conventions.  Stable GraphBuffer identities make intermediate storage part of the program."
+  (:require [clojure.set :as set]
+            [raster.compiler.ir.segop :as segop]))
+
+(defrecord GraphBuffer [id dtype elements memory-space role])
+(defrecord ValueUse [buffer access])
+(defrecord ScheduledKernel [id operation uses dependencies])
+(defrecord KernelGraph [inputs outputs temporaries nodes effects provenance attributes])
+
+(def ^:private buffer-roles #{:input :output :inout :temporary})
+(def ^:private access-modes #{:read :write :read-write})
+
+(defn- record-kind? [record-class value]
+  (and value (= record-class (.getName (class value)))))
+
+(defn graph-buffer? [x]
+  (record-kind? "raster.compiler.ir.kernel_graph.GraphBuffer" x))
+
+(defn value-use? [x]
+  (record-kind? "raster.compiler.ir.kernel_graph.ValueUse" x))
+
+(defn scheduled-kernel? [x]
+  (record-kind? "raster.compiler.ir.kernel_graph.ScheduledKernel" x))
+
+(defn kernel-graph? [x]
+  (record-kind? "raster.compiler.ir.kernel_graph.KernelGraph" x))
+
+(defn- validate-buffer-fields! [{:keys [id dtype elements memory-space role] :as value}]
+  (when (nil? id)
+    (throw (ex-info "graph buffer requires an identity" {:id id})))
+  (when-not (keyword? dtype)
+    (throw (ex-info "graph buffer requires a dtype" {:id id :dtype dtype})))
+  (when-not (contains? buffer-roles role)
+    (throw (ex-info "graph buffer has an invalid role" {:id id :role role})))
+  (when-not (keyword? memory-space)
+    (throw (ex-info "graph buffer requires a memory space" {:id id :memory-space memory-space})))
+  (when (and (= :temporary role) (nil? elements))
+    (throw (ex-info "temporary graph buffer requires an element count" {:id id})))
+  value)
+
+(defn buffer
+  "Construct a scheduled buffer. `elements` may be symbolic, but a temporary must state it."
+  [id dtype elements memory-space role]
+  (validate-buffer-fields! (->GraphBuffer id dtype elements memory-space role)))
+
+(defn- reads? [access] (contains? #{:read :read-write} access))
+(defn- writes? [access] (contains? #{:write :read-write} access))
+
+(defn- access-sets [node]
+  (reduce (fn [{:keys [reads writes] :as result} use]
+            (cond-> result
+              (reads? (:access use)) (assoc :reads (conj reads (:buffer use)))
+              (writes? (:access use)) (assoc :writes (conj writes (:buffer use)))))
+          {:reads #{} :writes #{}}
+          (:uses node)))
+
+(defn- hazard? [earlier later]
+  (let [{er :reads ew :writes} (access-sets earlier)
+        {lr :reads lw :writes} (access-sets later)]
+    (or (seq (set/intersection ew lr))
+        (seq (set/intersection ew lw))
+        (seq (set/intersection er lw)))))
+
+(defn validate!
+  "Validate a KernelGraph and return it unchanged.
+
+   Besides structural checks this proves the property that motivated the first graph conversion:
+   every temporary is written before it is read, and every memory hazard is represented by a
+   dependency."
+  [graph]
+  (when-not (kernel-graph? graph)
+    (throw (ex-info "kernel graph must be a KernelGraph value"
+                    {:graph graph :actual (type graph)})))
+  (let [{:keys [inputs outputs temporaries nodes effects provenance attributes]} graph
+        sections [inputs outputs temporaries]
+        buffers (vec (mapcat identity sections))
+        buffer-ids (mapv :id buffers)]
+    (doseq [[field values] [[:inputs inputs] [:outputs outputs] [:temporaries temporaries]
+                            [:nodes nodes]]]
+      (when-not (vector? values)
+        (throw (ex-info "kernel graph sections must be ordered vectors"
+                        {:field field :value values}))))
+    (doseq [b buffers]
+      (when-not (graph-buffer? b)
+        (throw (ex-info "kernel graph contains a non-buffer value" {:buffer b})))
+      (validate-buffer-fields! b))
+    (doseq [[field values allowed-roles]
+            [[:inputs inputs #{:input :inout}]
+             [:outputs outputs #{:output :inout}]
+             [:temporaries temporaries #{:temporary}]]
+            b values]
+      (when-not (contains? allowed-roles (:role b))
+        (throw (ex-info "kernel graph buffer role disagrees with its section"
+                        {:field field :buffer b :allowed-roles allowed-roles}))))
+    ;; An in-place value intentionally occurs in both external sections. It must be the same
+    ;; GraphBuffer value, not two descriptions that happen to reuse a symbol.
+    (doseq [[id occurrences] (group-by :id buffers)]
+      (when (or (> (count occurrences) 2)
+                (and (= 2 (count occurrences))
+                     (not (and (apply = occurrences)
+                               (= :inout (:role (first occurrences)))
+                               (some #(= id (:id %)) inputs)
+                               (some #(= id (:id %)) outputs)))))
+        (throw (ex-info "kernel graph buffer identity is declared inconsistently"
+                        {:id id :occurrences occurrences}))))
+    (doseq [[field value] [[:effects effects] [:provenance provenance] [:attributes attributes]]]
+      (when-not (map? value)
+        (throw (ex-info "kernel graph descriptive sections must be maps"
+                        {:field field :value value}))))
+    (let [declared (set buffer-ids)
+          output-ids (set (map :id outputs))
+          initially-written (set (map :id (filter #(contains? #{:input :inout} (:role %)) buffers)))]
+      (loop [remaining nodes
+             preceding []
+             node-ids #{}
+             initialized initially-written
+             graph-writes #{}]
+        (if-let [node (first remaining)]
+          (do
+            (when-not (scheduled-kernel? node)
+              (throw (ex-info "kernel graph contains a non-scheduled node" {:node node})))
+            (when (nil? (:id node))
+              (throw (ex-info "scheduled kernel requires an identity" {:node node})))
+            (when (contains? node-ids (:id node))
+              (throw (ex-info "scheduled kernel identities must be unique" {:id (:id node)})))
+            (when-not (vector? (:uses node))
+              (throw (ex-info "scheduled kernel uses must be an ordered vector" {:node (:id node)})))
+            (when-not (vector? (:dependencies node))
+              (throw (ex-info "scheduled kernel dependencies must be an ordered vector"
+                              {:node (:id node)})))
+            (when (nil? (:operation node))
+              (throw (ex-info "scheduled kernel requires an operation" {:node (:id node)})))
+            (let [uses (:uses node)
+                  use-ids (mapv :buffer uses)
+                  duplicate-use (not= (count use-ids) (count (set use-ids)))
+                  dependency-set (set (:dependencies node))
+                  preceding-ids (set (map :id preceding))]
+              (doseq [use uses]
+                (when-not (value-use? use)
+                  (throw (ex-info "scheduled kernel contains a non-use value"
+                                  {:node (:id node) :use use})))
+                (when-not (contains? access-modes (:access use))
+                  (throw (ex-info "scheduled kernel use has an invalid access mode"
+                                  {:node (:id node) :use use})))
+                (when-not (contains? declared (:buffer use))
+                  (throw (ex-info "scheduled kernel uses an undeclared buffer"
+                                  {:node (:id node) :buffer (:buffer use)}))))
+              (when duplicate-use
+                (throw (ex-info "scheduled kernel must combine access to each buffer into one use"
+                                {:node (:id node) :uses use-ids})))
+              (when-not (= (count dependency-set) (count (:dependencies node)))
+                (throw (ex-info "scheduled kernel dependencies must be unique"
+                                {:node (:id node) :dependencies (:dependencies node)})))
+              (when-not (set/subset? dependency-set preceding-ids)
+                (throw (ex-info "scheduled kernel dependency must name an earlier node"
+                                {:node (:id node) :dependencies (:dependencies node)
+                                 :earlier preceding-ids})))
+              (let [missing-hazards (->> preceding
+                                         (filter #(hazard? % node))
+                                         (map :id)
+                                         (remove dependency-set)
+                                         vec)
+                    reads (->> uses (filter #(reads? (:access %))) (map :buffer) set)
+                    writes (->> uses (filter #(writes? (:access %))) (map :buffer) set)
+                    uninitialized (set/difference reads initialized)]
+                (when (seq missing-hazards)
+                  (throw (ex-info "scheduled kernel omits a memory-hazard dependency"
+                                  {:node (:id node) :missing missing-hazards})))
+                (when (seq uninitialized)
+                  (throw (ex-info "scheduled kernel reads a buffer before any graph node writes it"
+                                  {:node (:id node) :buffers uninitialized})))
+                (recur (next remaining)
+                       (conj preceding node)
+                       (conj node-ids (:id node))
+                       (set/union initialized writes)
+                       (set/union graph-writes writes)))))
+          (when-not (set/subset? output-ids graph-writes)
+            (throw (ex-info "kernel graph does not write every output"
+                            {:outputs output-ids :written graph-writes}))))))
+    graph))
+
+(defn make
+  "Construct and verify a scheduled KernelGraph from explicit compiler values."
+  [{:keys [inputs outputs temporaries nodes effects provenance attributes]
+    :or {inputs [] outputs [] temporaries [] nodes [] effects {} provenance {} attributes {}}}]
+  (validate! (->KernelGraph inputs outputs temporaries nodes effects provenance attributes)))
+
+(defn- ordered [xs]
+  (vec (sort-by pr-str xs)))
+
+(defn- operation-use [input-ids output-ids id]
+  (->ValueUse id (cond
+                   (and (contains? input-ids id) (contains? output-ids id)) :read-write
+                   (contains? output-ids id) :write
+                   :else :read)))
+
+(defn from-segops
+  "Build and verify a scheduled graph from an already selected SegOp sequence.
+
+   `temporaries` is a map from stable buffer identity to at least `{:elements expr}`. External
+   inputs/outputs are explicit; therefore a newly introduced intermediate can never hide as an
+   undeclared symbol in a later kernel."
+  [segops {:keys [inputs outputs temporaries dtype memory-space effects provenance attributes]
+           :or {temporaries {} memory-space :device effects {} provenance {} attributes {}}}]
+  (when-not (vector? segops)
+    (throw (ex-info "scheduled SegOps must be an ordered vector" {:segops segops})))
+  (doseq [operation segops]
+    (when-not (segop/segop? operation)
+      (throw (ex-info "scheduled SegOp graph contains a non-SegOp operation"
+                      {:operation operation :actual (type operation)}))))
+  (let [input-ids (set inputs)
+        output-ids (set outputs)
+        external-ids (set/union input-ids output-ids)
+        operation-ids (reduce set/union #{}
+                              (map #(set/union (or (segop/segop-inputs %) #{})
+                                               (or (segop/segop-outputs %) #{}))
+                                   segops))
+        temporary-ids (set (keys temporaries))
+        expected-temporaries (set/difference operation-ids external-ids)]
+    (when-not (= expected-temporaries temporary-ids)
+      (throw (ex-info "scheduled temporary declarations differ from SegOp dataflow"
+                      {:expected expected-temporaries :declared temporary-ids})))
+    (let [external-buffers (into {}
+                                 (map (fn [id]
+                                        [id (buffer id dtype nil memory-space
+                                                    (cond
+                                                      (contains? (set/intersection input-ids
+                                                                                   output-ids) id)
+                                                      :inout
+                                                      (contains? input-ids id) :input
+                                                      :else :output))]))
+                                 (ordered external-ids))
+          inputs* (mapv external-buffers (ordered input-ids))
+          outputs* (mapv external-buffers (ordered output-ids))
+          temporaries* (mapv (fn [id]
+                               (let [spec (get temporaries id)]
+                                 (buffer id
+                                         (or (:dtype spec) dtype)
+                                         (:elements spec)
+                                         (or (:memory-space spec) memory-space)
+                                         :temporary)))
+                             (ordered temporary-ids))
+          nodes (loop [ops segops index 0 previous [] result []]
+                  (if-let [op (first ops)]
+                    (let [ins (or (segop/segop-inputs op) #{})
+                          outs (or (segop/segop-outputs op) #{})
+                          uses (mapv #(operation-use ins outs %)
+                                     (ordered (set/union ins outs)))
+                          ;; A scheduled-node identity is not a SegOp identity. The position makes
+                          ;; repeated/colliding source ids safe when larger graphs are assembled.
+                          candidate (->ScheduledKernel [:segop (:id op) index] op uses [])
+                          dependencies (->> previous
+                                            (filter #(hazard? % candidate))
+                                            (mapv :id))
+                          node (assoc candidate :dependencies dependencies)]
+                      (recur (next ops) (inc index) (conj previous node) (conj result node)))
+                    result))]
+      (make {:inputs inputs*
+             :outputs outputs*
+             :temporaries temporaries*
+             :nodes nodes
+             :effects effects
+             :provenance provenance
+             :attributes attributes}))))

--- a/src/raster/compiler/ir/segop.clj
+++ b/src/raster/compiler/ir/segop.clj
@@ -91,11 +91,13 @@
 ;; ================================================================
 
 (defn segop?
-  "Check if a value is a SegOp record."
+  "Check if a value is a generic SegOp record across Typed Clojure child classloaders."
   [x]
-  (or (instance? SegMap x)
-      (instance? SegRed x)
-      (instance? SegScan x)))
+  (and x
+       (contains? #{"raster.compiler.ir.segop.SegMap"
+                    "raster.compiler.ir.segop.SegRed"
+                    "raster.compiler.ir.segop.SegScan"}
+                  (.getName (class x)))))
 
 (defn segop-grid
   "Get the KernelGrid from a SegOp."

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -82,20 +82,29 @@
                                                       :dtype (or dtype :double)))]
           (cond
             (:err segops) (decline :segop (:err segops))
-            (seq (:ok segops)) {:segops (:ok segops)}
+            (seq (:ok segops)) (cond-> {:segops (:ok segops)}
+                                 (soac-lower/scan-soac? (:ok soac))
+                                 (assoc :kernel-graph
+                                        (soac-lower/scan-kernel-graph (:ok soac) (:ok segops))))
             :else (when par? {:declined (diagnostic sym form :segop
                                                     (ex-info "lower-soac produced no SegOps" {})
                                                     device-id dtype)})))))))
 
 (defn- annotate-binding
-  "Attach SegOp metadata to a binding symbol."
-  [sym segops]
-  (vary-meta sym assoc ::segops segops))
+  "Attach scheduled compiler values to a binding symbol."
+  [sym {:keys [segops kernel-graph]}]
+  (cond-> (vary-meta sym assoc ::segops segops)
+    kernel-graph (vary-meta assoc ::kernel-graph kernel-graph)))
 
 (defn get-segops
   "Retrieve SegOp records from a binding symbol's metadata."
   [sym]
   (::segops (meta sym)))
+
+(defn get-kernel-graph
+  "Retrieve a scheduled KernelGraph from a binding symbol's metadata."
+  [sym]
+  (::kernel-graph (meta sym)))
 
 (defn segop-lower-pass
   "Pipeline pass: convert par forms in let* bindings to SegOp records.
@@ -103,19 +112,21 @@
    Walks the form's let* bindings. For each par/map!, par/reduce, par/scan!
    binding, converts to SegOp and attaches as metadata on the binding symbol.
 
-   Returns {:form annotated-form :stats {:segops-lowered N}}.
+   Scan decomposition additionally records one verified KernelGraph with its intermediate buffers
+   and dependencies. Returns both `:segops-lowered` and `:kernel-graphs-lowered` stats.
 
    Options from pipeline opts:
      :target-device — device for launch param computation
      :dtype — element type (:double or :float)"
   [form opts]
   (if-not (form/binding-form? form)
-    {:form form :stats {:segops-lowered 0}}
+    {:form form :stats {:segops-lowered 0 :kernel-graphs-lowered 0}}
     (let [[let-sym bindings-vec & body-exprs] form
           pairs (partition 2 bindings-vec)
           device-id (:target-device opts)
           dtype (:dtype opts)
           lowered (atom 0)
+          graphs-lowered (atom 0)
           ;; Every par form the middle end could NOT represent, as data. Previously these went to
           ;; stderr as `WARNING: …` and vanished — invisible to stats, to explain-pipeline, and to
           ;; anyone diagnosing why a kernel took the legacy path.
@@ -123,26 +134,30 @@
           attempt (fn [sym init]
                     (let [r (lower-attempt sym init device-id dtype)]
                       (when-let [d (:declined r)] (swap! declined conj d))
-                      (:segops r)))
+                      (when (:segops r) r)))
           ;; Annotate bindings with SegOp metadata
           new-pairs
           (mapv (fn [[sym init]]
-                  (if-let [segops (attempt sym init)]
+                  (if-let [lowered-values (attempt sym init)]
                     (do (swap! lowered inc)
-                        [(annotate-binding sym segops) init])
+                        (when (:kernel-graph lowered-values) (swap! graphs-lowered inc))
+                        [(annotate-binding sym lowered-values) init])
                     [sym init]))
                 pairs)
           ;; Also check body expressions for par forms
           new-body
           (mapv (fn [expr]
                   (let [tmp-sym (gensym "body_par_")]
-                    (if-let [segops (attempt tmp-sym expr)]
+                    (if-let [{:keys [segops kernel-graph]} (attempt tmp-sym expr)]
                       (do (swap! lowered inc)
+                          (when kernel-graph (swap! graphs-lowered inc))
                           (with-meta (list 'do expr)
-                            {::body-segops segops}))
+                            (cond-> {::body-segops segops}
+                              kernel-graph (assoc ::body-kernel-graph kernel-graph))))
                       expr)))
                 body-exprs)
           new-bindings (vec (mapcat identity new-pairs))]
       {:form (list* let-sym new-bindings new-body)
-       :stats (cond-> {:segops-lowered @lowered}
+       :stats (cond-> {:segops-lowered @lowered
+                       :kernel-graphs-lowered @graphs-lowered}
                 (seq @declined) (assoc :segops-declined @declined))})))

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -12,7 +12,9 @@
          Stage 1: intra-block Blelloch scan
          Stage 2: scan of block totals
          Stage 3: carry-in addition (SegMap)"
-  (:require [raster.compiler.ir.soac :as soac]
+  (:require [clojure.set :as set]
+            [raster.compiler.ir.kernel-graph :as kernel-graph]
+            [raster.compiler.ir.soac :as soac]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.execution-plan :as execution-plan]))
 
@@ -173,14 +175,14 @@
 
       :three-stage
       (let [level-1 (segop/->SegLevel :block :virtual)
+            totals-sym (gensym "block_totals_")
             stage-1 (segop/->SegScan (:id soac) space level-1
                                      scan-op map-lambda
                                      (:inputs soac)
-                                     (soac-outputs* soac)
+                                     (conj (soac-outputs* soac) totals-sym)
                                      (:scalars soac)
                                      grid-1 :intra-block
                                      dtype)
-            totals-sym (gensym "block_totals_")
             stage-2-idx (gensym "k_")
             stage-2-space (segop/make-seg-space stage-2-idx (:num-blocks grid-1))
             grid-2 (single-block-grid grid-1)
@@ -210,6 +212,43 @@
                                     #{} grid-3
                                     dtype out-sym nil)]
         [stage-1 stage-2 stage-3]))))
+
+(defn scan-kernel-graph
+  "Turn an already lowered scan into a verified scheduled graph.
+
+   This consumes the exact SegOps returned by `lower-scan`; it must not lower a second time because
+   the block-totals buffer identity is generated during decomposition."
+  [soac segops]
+  (let [external (set/union (or (:inputs soac) #{}) (or (soac-outputs* soac) #{}))
+        used (reduce set/union #{}
+                     (map #(set/union (or (segop/segop-inputs %) #{})
+                                      (or (segop/segop-outputs %) #{}))
+                          segops))
+        temporary-ids (set/difference used external)
+        block-stage (some #(when (= :block-scan (:phase %)) %) segops)
+        temporary-elements (when block-stage
+                             (:bound (segop/seg-space-reduced-dim (:space block-stage))))
+        dtype (or (:elem-type soac) (:dtype (first segops)) :double)
+        temporaries (into {}
+                          (map (fn [id]
+                                 [id {:dtype dtype :elements temporary-elements
+                                      :memory-space :device}]))
+                          temporary-ids)]
+    (kernel-graph/from-segops
+     segops
+     {:inputs (or (:inputs soac) #{})
+      :outputs (or (soac-outputs* soac) #{})
+      :temporaries temporaries
+      :dtype dtype
+      :effects {:memory-order :dependency-ordered}
+      :provenance {:dialect :segop :algorithm :scan :soac-id (:id soac)}
+      :attributes {:strategy (if (= 1 (count segops)) :single :three-stage)}})))
+
+(defn scan-soac?
+  "True when a SOAC/Screma node selects scan decomposition."
+  [node]
+  (or (soac/soac-scan? node)
+      (and (soac/screma? node) (seq (:scans node)) (empty? (:reduces node)))))
 
 ;; ================================================================
 ;; Unified lowering dispatch

--- a/test/raster/compiler/ir/kernel_graph_test.clj
+++ b/test/raster/compiler/ir/kernel_graph_test.clj
@@ -1,0 +1,81 @@
+(ns raster.compiler.ir.kernel-graph-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.ir.soac :as soac]
+            [raster.compiler.passes.parallel.soac-lower :as lower]))
+
+(defn- symbolic-scan []
+  (soac/par-form->soac
+   'scan-result
+   '(raster.par/scan out acc 0.0 i n double (+ acc (aget values i)))
+   41))
+
+(deftest three-stage-scan-has-explicit-scheduled-dataflow
+  (let [node (symbolic-scan)
+        operations (lower/lower-scan node nil)
+        scheduled (lower/scan-kernel-graph node operations)
+        [intra block carry] (:nodes scheduled)
+        temporary (first (:temporaries scheduled))]
+    (is (graph/kernel-graph? scheduled))
+    (is (= :three-stage (get-in scheduled [:attributes :strategy])))
+    (is (= ['values] (mapv :id (:inputs scheduled))))
+    (is (= ['out] (mapv :id (:outputs scheduled))))
+    (is (= 1 (count (:temporaries scheduled))))
+    (is (= :temporary (:role temporary)))
+    (is (= (:id temporary)
+           (first (disj (:outputs (:operation intra)) 'out)))
+        "stage 1 produces the same stable block-totals buffer consumed by stages 2 and 3")
+    (is (= [(:id intra)] (:dependencies block)))
+    (is (= (mapv :id [intra block]) (:dependencies carry))
+        "the explicit schedule contains every RAW/WAW hazard; a later pass may transitively reduce it")
+    (is (= [:intra-block :block-scan nil]
+           (mapv #(get-in % [:operation :phase]) (:nodes scheduled))))))
+
+(deftest graph-validation-rejects-the-old-disconnected-scan
+  (let [node (symbolic-scan)
+        operations (lower/lower-scan node nil)
+        totals (first (disj (:outputs (first operations)) 'out))
+        disconnected (assoc-in operations [0 :outputs] #{'out})]
+    (testing "ledger #41: stage 2 cannot read block totals that stage 1 never wrote"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"reads a buffer before any graph node writes it"
+           (graph/from-segops
+            disconnected
+            {:inputs #{'values}
+             :outputs #{'out}
+             :temporaries {totals {:dtype :double :elements 'num-blocks}}
+             :dtype :double}))))))
+
+(deftest graph-validation-rejects-an-unscheduled-memory-hazard
+  (let [node (symbolic-scan)
+        operations (lower/lower-scan node nil)
+        scheduled (lower/scan-kernel-graph node operations)
+        missing-edge (assoc-in scheduled [:nodes 1 :dependencies] [])]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"omits a memory-hazard dependency"
+                          (graph/validate! missing-edge)))))
+
+(deftest single-stage-scan-is-the-degenerate-kernel-graph
+  (let [node (soac/par-form->soac
+              'scan-result
+              '(raster.par/scan out acc 0.0 i 64 double (+ acc (aget values i)))
+              5)
+        operations (lower/lower-scan node nil)
+        scheduled (lower/scan-kernel-graph node operations)]
+    (is (= :single (get-in scheduled [:attributes :strategy])))
+    (is (= 1 (count (:nodes scheduled))))
+    (is (empty? (:temporaries scheduled)))
+    (is (empty? (:dependencies (first (:nodes scheduled)))))))
+
+(deftest in-place-dataflow-retains-one-buffer-identity
+  (let [operation (segop/->SegMap
+                   9 (segop/make-seg-space 'i 'n) (segop/->SegLevel :thread :virtual)
+                   '(inc (aget state i)) #{'state} #{'state} #{}
+                   (segop/->KernelGrid 1 32 0) :float 'state nil)
+        scheduled (graph/from-segops [operation]
+                                     {:inputs #{'state} :outputs #{'state} :dtype :float})]
+    (is (= :inout (get-in scheduled [:inputs 0 :role])))
+    (is (identical? (first (:inputs scheduled)) (first (:outputs scheduled))))
+    (is (= :read-write (get-in scheduled [:nodes 0 :uses 0 :access])))))

--- a/test/raster/compiler/ir/segop_test.clj
+++ b/test/raster/compiler/ir/segop_test.clj
@@ -124,6 +124,9 @@
       ;; Stage 2: block-totals scan
       (is (instance? raster.compiler.ir.segop.SegScan (nth segops 1)))
       (is (= :block-scan (:phase (nth segops 1))))
+      (let [totals (first (:inputs (nth segops 1)))]
+        (is (contains? (:outputs (nth segops 0)) totals)
+            "stage 1 explicitly produces the block-totals storage consumed by stage 2"))
       ;; Stage 3: carry-in (SegMap)
       (is (instance? raster.compiler.ir.segop.SegMap (nth segops 2))))))
 

--- a/test/raster/compiler/segop_boundary_test.clj
+++ b/test/raster/compiler/segop_boundary_test.clj
@@ -18,6 +18,7 @@
    Map and reduction are full conversions: an unrepresentable SegOp is an illegal remaining
    operation with no alternate emitter."
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-graph :as kernel-graph]
             [raster.compiler.passes.parallel.segop-lower-pass :as slp]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
             [raster.compiler.ir.soac :as soac]))
@@ -38,6 +39,21 @@
     (let [st (stats-of '(let* [o (raster.par/map! O i 256 nil (clojure.core/* i 2.0))] o))]
       (is (= 1 (:segops-lowered st)))
       (is (empty? (:segops-declined st))))))
+
+(deftest scan-crosses-the-boundary-as-one-scheduled-kernel-graph
+  (let [r (slp/segop-lower-pass
+           '(let* [result (raster.par/scan out acc 0.0 i n double
+                                           (+ acc (aget values i)))]
+                  result)
+           {})
+        binding (first (second (:form r)))
+        scheduled (slp/get-kernel-graph binding)]
+    (is (= 1 (get-in r [:stats :segops-lowered])))
+    (is (= 1 (get-in r [:stats :kernel-graphs-lowered])))
+    (is (kernel-graph/kernel-graph? scheduled))
+    (is (= 3 (count (:nodes scheduled))))
+    (is (= [:intra-block :block-scan nil]
+           (mapv #(get-in % [:operation :phase]) (:nodes scheduled))))))
 
 (deftest an-unrepresentable-par-form-becomes-a-diagnostic
   (testing "a par form with no lowering rule is the case that used to vanish onto stderr"


### PR DESCRIPTION
## Summary

- introduce a checked pre-emission KernelGraph with stable typed buffers, ordered uses, scheduled nodes, and explicit dependencies
- verify declared storage, temporary initialization, output writes, node ordering, and RAW/WAR/WAW hazards before target emission
- make inclusive scan the first graph consumer, representing small scans as one node and symbolic/large scans as the three-stage intra-block/block-totals/carry graph
- repair ledger #41 by making stage 1 explicitly produce the block-totals temporary consumed by stages 2 and 3
- attach scheduled graphs at the SegOp boundary while keeping existing SegOps available to current single-kernel consumers
- make generic SegOp recognition safe across Typed Clojure child classloaders

This is the scheduling/dataflow slice only. It does not claim executable scan coverage; target-lowering graph nodes to KernelArtifacts and running their temporaries/dependencies is the next slice.

## Verification

- 54 focused compiler/IR/boundary/OpenCL-neighbor tests, 210 assertions
- explicit negative tests for disconnected block totals and omitted hazard dependencies
- single-node, three-node, and in-place/inout graph cases
- cljfmt check on all changed source/test files
- git diff --check