### PR TITLE
Certify and emit associative scan graphs

### DIFF
--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -19,7 +19,9 @@
             [raster.compiler.ir.contraction-facts :as cf]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.compiler.ir.scan :as scan]
             [clojure.walk :as walk]
             [clojure.set]
             [raster.compiler.ir.segop :as segop]
@@ -139,7 +141,7 @@
                    (map (fn [s]
                           (let [written? (contains? written (symbol (name s)))
                                 extra-output? (and written? (not (contains? input-name-set
-                                                                           (symbol (name s)))))]
+                                                                            (symbol (name s)))))]
                             (kabi/slot s (if extra-output? :output :input) (arr-dtype s)
                                        :c-name (ce/c-symbol s)
                                        :role (cond extra-output? :secondary-result
@@ -148,7 +150,7 @@
                         arr-params)
                    [(kabi/slot out-sym :output out-dtype :c-name "out" :role :result)]
                    (map #(kabi/slot % :scalar (scalar-dtype %)
-                                   :c-name (ce/c-symbol %) :role :parameter)
+                                    :c-name (ce/c-symbol %) :role :parameter)
                         scl-params)
                    [(kabi/slot '_n_bound :scalar :int :role :bound)])))
         source (str (apply codegen/extension-pragmas out-dtype (map arr-dtype arr-params))
@@ -329,7 +331,7 @@
                         arr-params)
                    [(kabi/slot result-name :output dtype :c-name "output" :role :result)]
                    (map #(kabi/slot % :scalar (scalar-dtype %)
-                                   :c-name (ce/c-symbol %) :role :parameter)
+                                    :c-name (ce/c-symbol %) :role :parameter)
                         scl-params)
                    [(kabi/slot '_n_bound :scalar :int :role :bound)])))
         ;; Static shared memory is part of the artifact launch contract (no dynamic-local ABI slot).
@@ -381,6 +383,224 @@
                    :n-phases 2
                    :identity-val identity-val
                    :c-op c-op}})))
+
+;; ================================================================
+;; KernelGraph scan → OpenCL KernelArtifacts
+;; ================================================================
+
+(defn- scan-c-combine
+  [combine dtype]
+  (let [op (symbol (name combine))
+        floating? (contains? #{:float :double} dtype)
+        token (case op
+                + "+"
+                * "*"
+                bit-and "&"
+                bit-or "|"
+                bit-xor "^"
+                min (if floating? "fmin" "min")
+                max (if floating? "fmax" "max")
+                (throw (ex-info "certified scan combine has no OpenCL lowering"
+                                {:reason :scan-combine-not-emittable
+                                 :combine combine :dtype dtype})))]
+    (fn [left right]
+      (if (contains? #{"fmin" "fmax" "min" "max"} token)
+        (str token "(" left ", " right ")")
+        (str "(" left " " token " " right ")")))))
+
+(defn- scan-c-identity
+  [identity dtype]
+  (cond
+    (contains? #{'Double/POSITIVE_INFINITY 'Float/POSITIVE_INFINITY} identity) "INFINITY"
+    (contains? #{'Double/NEGATIVE_INFINITY 'Float/NEGATIVE_INFINITY} identity) "-INFINITY"
+    (number? identity) (if (= :float dtype) (str (float identity) "f") (str identity))
+    (and (seq? identity) (= 2 (count identity)) (number? (second identity)))
+    (scan-c-identity (second identity) dtype)
+    :else (throw (ex-info "certified scan identity has no OpenCL literal"
+                          {:reason :scan-identity-not-emittable
+                           :identity identity :dtype dtype}))))
+
+(defn generate-scan-kernel-graph
+  "Target-lower a certified scheduled scan graph into a graph of verified KernelArtifacts.
+
+   The graph remains the owner of buffers and dependencies. Each node artifact owns exactly one
+   OpenCL entry point, ordered ABI, arguments, and launch. No runtime marker convention is involved
+   in this conversion. The block-totals kernel deliberately scans arbitrarily many totals in
+   workgroup-sized chunks, so symbolic input sizes do not require an unrolled recursive graph."
+  [graph & {:keys [kernel-name-prefix scalar-types]
+            :or {kernel-name-prefix "segscan" scalar-types {}}}]
+  (let [graph (kgraph/validate! graph)
+        algebra (get-in graph [:attributes :scan-algebra])
+        _ (when-not (scan/associative-scan? algebra)
+            (throw (ex-info "scan KernelGraph lacks certified associative algebra"
+                            {:reason :uncertified-scan-graph :algebra algebra})))
+        _ (when-not (= 1 (count (:outputs graph)))
+            (throw (ex-info "scan artifact lowering requires exactly one graph output"
+                            {:reason :scan-multi-output-unimplemented
+                             :outputs (mapv :id (:outputs graph))})))
+        dtype (:dtype algebra)
+        ctype (dt/ctype :opencl dtype)
+        combine-c (scan-c-combine (:combine algebra) dtype)
+        identity-c (scan-c-identity (:identity algebra) dtype)
+        buffers (into {} (map (juxt :id identity))
+                      (concat (:inputs graph) (:outputs graph) (:temporaries graph)))
+        temporary-ids (set (map :id (:temporaries graph)))
+        output-ids (set (map :id (:outputs graph)))
+        first-scan (some #(when (segop/segop? (:operation %))
+                            (when (:scan-op (:operation %)) (:operation %)))
+                         (:nodes graph))
+        scan-workgroup (or (get-in first-scan [:grid :block-size]) 256)
+        scalar-dtype (fn [sym]
+                       (or (get scalar-types sym)
+                           (get scalar-types (symbol (name sym)))
+                           dtype))
+        emit-node
+        (fn [{:keys [id operation uses]}]
+          (let [phase (or (:phase operation) :carry-in)
+                bound (seg-bound operation)
+                workgroup (or (get-in operation [:grid :block-size]) scan-workgroup)
+                pointer-ids (mapv :buffer uses)
+                scalar-ids (vec (sort-by name (:scalars operation)))
+                pointer-slots
+                (mapv (fn [{:keys [buffer access]}]
+                        (let [spec (get buffers buffer)
+                              output? (contains? #{:write :read-write} access)]
+                          (kabi/slot buffer (if output? :output :input) (:dtype spec)
+                                     :c-name (ce/c-symbol buffer)
+                                     :role (cond
+                                             (contains? temporary-ids buffer) :temporary
+                                             (and output? (contains? output-ids buffer)) :result
+                                             (= :read-write access) :inout
+                                             :else :operand))))
+                      uses)
+                scalar-slots (mapv #(kabi/slot % :scalar (scalar-dtype %)
+                                               :c-name (ce/c-symbol %) :role :parameter)
+                                   scalar-ids)
+                bound-slot (kabi/slot '_n_bound :scalar :int :role :bound)
+                abi (kabi/validate! (vec (concat pointer-slots scalar-slots [bound-slot])))
+                pointer-param
+                (fn [slot]
+                  (str "__global " (when (= :input (:kind slot)) "const ")
+                       (dt/ctype :opencl (:kernel-dtype slot)) "* restrict " (:c-name slot)))
+                scalar-param
+                (fn [slot]
+                  (str (dt/ctype :opencl (:kernel-dtype slot)) " " (:c-name slot)))
+                params (str/join ", "
+                                 (concat (map pointer-param pointer-slots)
+                                         (map scalar-param scalar-slots)
+                                         ["int _n_bound"]))
+                kernel-name (str kernel-name-prefix "_" (str/replace (name phase) "-" "_")
+                                 "_" (gensym ""))
+                totals-id (first (filter temporary-ids pointer-ids))
+                out-id (first (filter output-ids pointer-ids))
+                totals-c (some-> totals-id ce/c-symbol)
+                out-c (some-> out-id ce/c-symbol)
+                idx (or (some-> operation :space segop/seg-space-reduced-dim :name) 'idx)
+                input-ids (vec (:inputs operation))
+                int-scalars (set (keep #(when (= :int (scalar-dtype %)) %) scalar-ids))
+                element (:element algebra)
+                element-c
+                (when (contains? #{:single :intra-block} phase)
+                  (binding [ce/*emit-config* ce/opencl-config
+                            ce/*scalar-type* ctype
+                            ce/*idx-sym* idx
+                            ce/*int-vars* (into ce/*int-vars* int-scalars)]
+                    (ce/emit-expr (ce/adapt-casts-for-dtype
+                                   (ce/normalize-array-prims element) dtype)
+                                  idx (set (map #(symbol (name %)) input-ids)) "idx")))
+                source-body
+                (case phase
+                  (:single :intra-block)
+                  (str "    __local " ctype " sdata[" workgroup "];\n"
+                       "    int tid = get_local_id(0);\n"
+                       "    int block = get_group_id(0);\n"
+                       "    int base = block * " workgroup ";\n"
+                       "    int idx = base + tid;\n"
+                       "    " ctype " value = " identity-c ";\n"
+                       "    if (idx < _n_bound) value = (" ctype ")(" element-c ");\n"
+                       "    sdata[tid] = value;\n"
+                       "    barrier(CLK_LOCAL_MEM_FENCE);\n"
+                       "    for (int offset = 1; offset < " workgroup "; offset <<= 1) {\n"
+                       "        " ctype " self = sdata[tid];\n"
+                       "        " ctype " left = " identity-c ";\n"
+                       "        if (tid >= offset) left = sdata[tid - offset];\n"
+                       "        barrier(CLK_LOCAL_MEM_FENCE);\n"
+                       "        if (tid >= offset) sdata[tid] = " (combine-c "left" "self") ";\n"
+                       "        barrier(CLK_LOCAL_MEM_FENCE);\n"
+                       "    }\n"
+                       "    if (idx < _n_bound) " out-c "[idx] = sdata[tid];\n"
+                       (when totals-c
+                         (str "    if (tid == 0) {\n"
+                              "        int valid = min(" workgroup ", _n_bound - base);\n"
+                              "        " totals-c "[block] = sdata[valid - 1];\n"
+                              "    }\n")))
+
+                  :block-scan
+                  (str "    __local " ctype " sdata[" workgroup "];\n"
+                       "    __local " ctype " carry;\n"
+                       "    int tid = get_local_id(0);\n"
+                       "    if (tid == 0) carry = " identity-c ";\n"
+                       "    barrier(CLK_LOCAL_MEM_FENCE);\n"
+                       "    for (int base = 0; base < _n_bound; base += " workgroup ") {\n"
+                       "        int idx = base + tid;\n"
+                       "        sdata[tid] = (idx < _n_bound) ? " totals-c "[idx] : " identity-c ";\n"
+                       "        barrier(CLK_LOCAL_MEM_FENCE);\n"
+                       "        for (int offset = 1; offset < " workgroup "; offset <<= 1) {\n"
+                       "            " ctype " self = sdata[tid];\n"
+                       "            " ctype " left = " identity-c ";\n"
+                       "            if (tid >= offset) left = sdata[tid - offset];\n"
+                       "            barrier(CLK_LOCAL_MEM_FENCE);\n"
+                       "            if (tid >= offset) sdata[tid] = " (combine-c "left" "self") ";\n"
+                       "            barrier(CLK_LOCAL_MEM_FENCE);\n"
+                       "        }\n"
+                       "        " ctype " prefix = carry;\n"
+                       "        barrier(CLK_LOCAL_MEM_FENCE);\n"
+                       "        if (idx < _n_bound) " totals-c "[idx] = "
+                       (combine-c "prefix" "sdata[tid]") ";\n"
+                       "        barrier(CLK_LOCAL_MEM_FENCE);\n"
+                       "        if (tid == 0) {\n"
+                       "            int valid = min(" workgroup ", _n_bound - base);\n"
+                       "            carry = " (combine-c "prefix" "sdata[valid - 1]") ";\n"
+                       "        }\n"
+                       "        barrier(CLK_LOCAL_MEM_FENCE);\n"
+                       "    }\n")
+
+                  :carry-in
+                  (str "    int stride = get_global_size(0);\n"
+                       "    for (int idx = get_global_id(0); idx < _n_bound; idx += stride) {\n"
+                       "        int block = idx / " scan-workgroup ";\n"
+                       "        if (block > 0) " out-c "[idx] = "
+                       (combine-c (str totals-c "[block - 1]") (str out-c "[idx]")) ";\n"
+                       "    }\n")
+
+                  (throw (ex-info "scheduled scan node has no target lowering"
+                                  {:reason :scan-phase-not-emittable :phase phase :node id})))
+                source (str (apply codegen/extension-pragmas
+                                   dtype (map :dtype (keep buffers pointer-ids)))
+                            "__kernel void " kernel-name "(" params ") {\n"
+                            source-body
+                            "}\n")
+                group-count (case phase
+                              (:single :block-scan) [1]
+                              :intra-block [(klaunch/ceil-div bound workgroup)]
+                              :carry-in [(klaunch/ceil-div bound workgroup)])
+                shared-bytes (if (= :carry-in phase) 0 (* workgroup (dt/bytes-of dtype)))]
+            (kart/make
+             {:kernel-name kernel-name
+              :source source
+              :abi abi
+              :arguments (vec (concat pointer-ids scalar-ids [bound]))
+              :launch (klaunch/spec {:workgroup-size [workgroup]
+                                     :group-count group-count
+                                     :shared-memory-bytes shared-bytes})
+              :temporaries []
+              :effects {:kind :scan-stage :phase phase}
+              :provenance {:dialect :segscan :segop-id (:id operation) :graph-node id}
+              :attributes {:phase phase :dtype dtype :scan-workgroup scan-workgroup}})))]
+    (-> (kgraph/map-operations graph emit-node)
+        (assoc-in [:provenance :target-dialect] :opencl-c)
+        (assoc-in [:attributes :emitted?] true)
+        kgraph/validate!)))
 
 ;; ================================================================
 ;; Segmented reduction (contraction) → OpenCL — the multi-axis SegSpace path
@@ -1235,25 +1455,25 @@
                  ;; fp64/fp16 need their OpenCL extension enabled. All three sibling emitters emit
                  ;; this; the staged one did not, so a :double staged contraction — reachable from
                  ;; opencl_pass, whose default dtype IS :double — emitted `double` with no pragma.
-                 (codegen/extension-pragmas out-dtype dtype)
+             (codegen/extension-pragmas out-dtype dtype)
                  ;; registry-driven, not `(intrinsics/descriptor 'dp4a)`: define every intrinsic
                  ;; helper this body actually calls — the same scan every other emitter uses
-                 (ce/intrinsic-helper-sources nest)
-                 (when ep (:epilogue-helpers ep))
-                 "__kernel void " kernel-name "(" params ") {\n"
-                 "    int seg = get_global_id(0);\n"
-                 "    if (seg >= _nseg) return;\n"
-                 (flat-decompose-c free-axes) "\n"
-                 nest
-                 "    out[seg] = "
-                 (let [acc (str "(" out-ctype ")" (acc-name 0))]
-                   (if ep
-                     ((:epilogue ep) acc
-                      (ce/c-symbol (first (first free-axes)))
-                      (ce/c-symbol (first (second free-axes))))
-                     acc))
-                 ";\n"
-                 "}\n")]
+             (ce/intrinsic-helper-sources nest)
+             (when ep (:epilogue-helpers ep))
+             "__kernel void " kernel-name "(" params ") {\n"
+             "    int seg = get_global_id(0);\n"
+             "    if (seg >= _nseg) return;\n"
+             (flat-decompose-c free-axes) "\n"
+             nest
+             "    out[seg] = "
+             (let [acc (str "(" out-ctype ")" (acc-name 0))]
+               (if ep
+                 ((:epilogue ep) acc
+                                 (ce/c-symbol (first (first free-axes)))
+                                 (ce/c-symbol (first (second free-axes))))
+                 acc))
+             ";\n"
+             "}\n")]
     {:kernel-name kernel-name :source src
      :array-params (vec inputs)
      :abi (kabi/validate!

--- a/src/raster/compiler/ir/kernel_graph.clj
+++ b/src/raster/compiler/ir/kernel_graph.clj
@@ -191,6 +191,14 @@
     :or {inputs [] outputs [] temporaries [] nodes [] effects {} provenance {} attributes {}}}]
   (validate! (->KernelGraph inputs outputs temporaries nodes effects provenance attributes)))
 
+(defn map-operations
+  "Replace each scheduled operation while preserving and revalidating graph dataflow. `f` receives
+   the complete ScheduledKernel, so target lowering can use phase-local uses and provenance."
+  [graph f]
+  (let [graph (validate! graph)]
+    (validate! (update graph :nodes
+                       #(mapv (fn [node] (assoc node :operation (f node))) %)))))
+
 (defn- ordered [xs]
   (vec (sort-by pr-str xs)))
 
@@ -206,8 +214,10 @@
    `temporaries` is a map from stable buffer identity to at least `{:elements expr}`. External
    inputs/outputs are explicit; therefore a newly introduced intermediate can never hide as an
    undeclared symbol in a later kernel."
-  [segops {:keys [inputs outputs temporaries dtype memory-space effects provenance attributes]
-           :or {temporaries {} memory-space :device effects {} provenance {} attributes {}}}]
+  [segops {:keys [inputs outputs temporaries buffer-specs dtype memory-space effects provenance
+                  attributes]
+           :or {temporaries {} buffer-specs {} memory-space :device effects {} provenance {}
+                attributes {}}}]
   (when-not (vector? segops)
     (throw (ex-info "scheduled SegOps must be an ordered vector" {:segops segops})))
   (doseq [operation segops]
@@ -228,13 +238,16 @@
                       {:expected expected-temporaries :declared temporary-ids})))
     (let [external-buffers (into {}
                                  (map (fn [id]
-                                        [id (buffer id dtype nil memory-space
-                                                    (cond
-                                                      (contains? (set/intersection input-ids
-                                                                                   output-ids) id)
-                                                      :inout
-                                                      (contains? input-ids id) :input
-                                                      :else :output))]))
+                                        (let [spec (get buffer-specs id)]
+                                          [id (buffer id (or (:dtype spec) dtype)
+                                                      (:elements spec)
+                                                      (or (:memory-space spec) memory-space)
+                                                      (cond
+                                                        (contains? (set/intersection input-ids
+                                                                                     output-ids) id)
+                                                        :inout
+                                                        (contains? input-ids id) :input
+                                                        :else :output))])))
                                  (ordered external-ids))
           inputs* (mapv external-buffers (ordered input-ids))
           outputs* (mapv external-buffers (ordered output-ids))

--- a/src/raster/compiler/ir/scan.clj
+++ b/src/raster/compiler/ir/scan.clj
@@ -1,0 +1,102 @@
+(ns raster.compiler.ir.scan
+  "Certified algebra for parallel prefix scans.
+
+   Raster's surface `par/scan` is also a general left-to-right recurrence primitive. Such a
+   recurrence is not automatically a parallel scan: Blelloch/Hillis-Steele scheduling is sound
+   only when the body is an associative combine of the prior accumulator and an accumulator-free
+   element expression. This boundary proves that property before SegScan scheduling."
+  (:require [raster.ad.purity :as purity]
+            [raster.compiler.core.op-descriptor :as descriptor]))
+
+(defrecord AssociativeScan [acc init combine element identity dtype])
+
+(defn associative-scan? [x]
+  (and x (= "raster.compiler.ir.scan.AssociativeScan" (.getName (class x)))))
+
+(defn- acc-ref?
+  [expr acc]
+  (or (= expr acc)
+      (and (seq? expr)
+           (= 2 (count expr))
+           (contains? #{'float 'double 'int 'long
+                        'clojure.core/float 'clojure.core/double
+                        'clojure.core/int 'clojure.core/long}
+                      (first expr))
+           (= acc (second expr)))))
+
+(defn- contains-symbol?
+  [expr target]
+  (cond
+    (= expr target) true
+    (coll? expr) (boolean (some #(contains-symbol? % target) expr))
+    :else false))
+
+(defn- literal-value
+  [expr]
+  (if (and (seq? expr)
+           (= 2 (count expr))
+           (contains? #{'float 'double 'int 'long
+                        'clojure.core/float 'clojure.core/double
+                        'clojure.core/int 'clojure.core/long}
+                      (first expr))
+           (number? (second expr)))
+    (second expr)
+    expr))
+
+(defn- identity-equivalent?
+  [left right]
+  (let [left (literal-value left)
+        right (literal-value right)]
+    (if (and (number? left) (number? right))
+      (== (double left) (double right))
+      (= left right))))
+
+(defn- pure-element?
+  [expr]
+  (cond
+    (seq? expr) (let [op (descriptor/semantic-op expr)]
+                  (and op
+                       (= :pure (purity/pure-op? op))
+                       (every? pure-element? (descriptor/call-args expr))))
+    (coll? expr) (every? pure-element? expr)
+    :else true))
+
+(defn certify
+  "Certify `scan-op` as a parallel associative scan or throw a structured conversion decline.
+
+   The accepted core is `(combine acc element)` or `(combine element acc)`, where `combine` is a
+   registered commutative monoid and `element` does not mention `acc`. Commutativity is stricter
+   than the mathematical minimum but matches the current shared-memory emitters' reassociation.
+   The initial value must be the registered identity: injecting a non-identity once globally needs
+   a distinct schedule and must not be duplicated independently in every block."
+  [scan-op dtype]
+  (let [{:keys [acc init lambda]} scan-op
+        combine (descriptor/semantic-op lambda)
+        args (vec (descriptor/call-args lambda))
+        dtype (or dtype :double)]
+    (when-not (contains? #{:int :long :float :double} dtype)
+      (throw (ex-info "parallel scan dtype is not supported by the current kernel dialect"
+                      {:reason :scan-dtype-unsupported :dtype dtype :scan-op scan-op})))
+    (when-not (and combine (= 2 (count args))
+                   (descriptor/commutative-monoid-op? combine))
+      (throw (ex-info "par/scan is a general recurrence, not a certified associative scan"
+                      {:reason :scan-not-associative
+                       :combine combine :body lambda :scan-op scan-op})))
+    (let [[left right] args
+          element (cond
+                    (and (acc-ref? left acc) (not (contains-symbol? right acc))) right
+                    (and (acc-ref? right acc) (not (contains-symbol? left acc))) left
+                    :else nil)]
+      (when-not element
+        (throw (ex-info "parallel scan body must combine one accumulator with an accumulator-free element"
+                        {:reason :scan-not-elementwise :acc acc :body lambda :scan-op scan-op})))
+      (when-not (pure-element? element)
+        (throw (ex-info "parallel scan element expression is impure or has unknown effects"
+                        {:reason :scan-element-impure-or-unknown
+                         :element element :body lambda :scan-op scan-op})))
+      (let [identity (descriptor/typed-reduce-identity combine dtype)]
+        (when-not (identity-equivalent? init identity)
+          (throw (ex-info "parallel scan with a non-identity init requires a distinct global-prefix schedule"
+                          {:reason :scan-nonidentity-init
+                           :combine combine :init init :identity identity :dtype dtype})))
+        (->AssociativeScan acc init combine element identity dtype)))))

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -57,7 +57,7 @@
    NB success/failure is carried in an explicit `{:ok …}`/`{:err …}` rather than a truthy value: a
    SOAC node is a RECORD, and records satisfy `map?` and are always truthy, so a compact
    `or`/`if-let` version silently misread every successful lowering as a decline marker."
-  [sym form device-id dtype]
+  [sym form device-id dtype array-types]
   (when (seq? form)
     (let [par? (par/par-form? form)
           decline (fn [stage e] (when (contains? fatal-reasons (:reason (ex-data e))) (throw e))
@@ -85,7 +85,8 @@
             (seq (:ok segops)) (cond-> {:segops (:ok segops)}
                                  (soac-lower/scan-soac? (:ok soac))
                                  (assoc :kernel-graph
-                                        (soac-lower/scan-kernel-graph (:ok soac) (:ok segops))))
+                                        (soac-lower/scan-kernel-graph
+                                         (:ok soac) (:ok segops) {:array-types array-types})))
             :else (when par? {:declined (diagnostic sym form :segop
                                                     (ex-info "lower-soac produced no SegOps" {})
                                                     device-id dtype)})))))))
@@ -125,6 +126,7 @@
           pairs (partition 2 bindings-vec)
           device-id (:target-device opts)
           dtype (:dtype opts)
+          array-types (:array-types opts)
           lowered (atom 0)
           graphs-lowered (atom 0)
           ;; Every par form the middle end could NOT represent, as data. Previously these went to
@@ -132,7 +134,7 @@
           ;; anyone diagnosing why a kernel took the legacy path.
           declined (atom [])
           attempt (fn [sym init]
-                    (let [r (lower-attempt sym init device-id dtype)]
+                    (let [r (lower-attempt sym init device-id dtype array-types)]
                       (when-let [d (:declined r)] (swap! declined conj d))
                       (when (:segops r) r)))
           ;; Annotate bindings with SegOp metadata

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -9,11 +9,12 @@
            Phase 1: block-local shared-memory tree reduction
            Phase 2: cross-block reduction of partial results
   Scan → single-phase (n ≤ block-size) or three-stage (large n):
-         Stage 1: intra-block Blelloch scan
+         Stage 1: intra-block workgroup scan
          Stage 2: scan of block totals
-         Stage 3: carry-in addition (SegMap)"
+         Stage 3: carry-in combination (SegMap)"
   (:require [clojure.set :as set]
             [raster.compiler.ir.kernel-graph :as kernel-graph]
+            [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.execution-plan :as execution-plan]))
@@ -29,6 +30,18 @@
 (defn- phase-grid
   [segop-type device-id bound-expr dtype]
   (segop/compute-launch-params segop-type device-id bound-expr :dtype dtype))
+
+(defn- scan-grid
+  "A scan needs one workgroup per contiguous block. Unlike map/reduce it cannot cap the grid and
+   recover coverage with a grid-stride loop because block prefixes are ordered dataflow."
+  [device-id bound-expr dtype]
+  (let [planned (phase-grid :scan device-id bound-expr dtype)
+        block-size (:block-size planned)]
+    (segop/->KernelGrid
+     (list 'int (list 'Math/ceil
+                      (list '/ (list 'double bound-expr) (double block-size))))
+     block-size
+     (:shared-mem-bytes planned))))
 
 (defn- single-block-grid
   [grid]
@@ -142,22 +155,28 @@
   "Lower a SoacScan/Screma-scan to SegScan SegOps.
 
   Decision criteria:
-    - n ≤ block-size → single-phase intra-block Blelloch scan
+    - n ≤ block-size → single-phase intra-block workgroup scan
     - n > block-size → three-stage:
-        Stage 1 (:intra-block): Blelloch scan within each block,
+        Stage 1 (:intra-block): scan within each block,
                  last element = block total
-        Stage 2 (:block-scan): scan of block totals (recursive)
-        Stage 3 (:carry-in): add carry-in to each element (SegMap)
+        Stage 2 (:block-scan): ordered scan of block totals
+        Stage 3 (:carry-in): combine carry-in with each element (SegMap)
 
   Returns a vector of SegScan/SegMap records."
   [soac device-id & {:keys [dtype] :or {dtype :double}}]
   (let [dtype (or (:elem-type soac) dtype)
         bound (:bound soac)
         idx (:idx soac)
-        scan-op (scan-op-info soac)
+        raw-scan-op (scan-op-info soac)
         map-lambda (screma-map-lambda soac)
+        _ (when map-lambda
+            (throw (ex-info "fused scan/map needs an explicit scheduled scan epilogue"
+                            {:reason :scan-fused-map-unimplemented
+                             :scan-op raw-scan-op :map-lambda map-lambda})))
+        scan-facts (scan/certify raw-scan-op dtype)
+        scan-op (assoc raw-scan-op :algebra scan-facts)
         space (segop/make-seg-space idx bound)
-        grid-1 (phase-grid :scan device-id bound dtype)
+        grid-1 (scan-grid device-id bound dtype)
         execution (execution-plan/scan-execution bound grid-1)]
     (case (:strategy execution)
       :single
@@ -199,10 +218,12 @@
             level-3 (segop/->SegLevel :thread :virtual)
             out-sym (or (:out scan-op) (first (soac-outputs* soac)))
             block-idx-expr (list 'clojure.core/quot carry-idx (:block-size grid-1))
+            combine (:combine scan-facts)
             carry-lambda (list 'if (list '> block-idx-expr 0)
-                               (list '+ (list 'aget out-sym carry-idx)
+                               (list combine
                                      (list 'aget totals-sym
-                                           (list 'clojure.core/- block-idx-expr 1)))
+                                           (list 'clojure.core/- block-idx-expr 1))
+                                     (list 'aget out-sym carry-idx))
                                (list 'aget out-sym carry-idx))
             stage-3 (segop/->SegMap (+ (:id soac) 3000)
                                     carry-space level-3
@@ -218,31 +239,41 @@
 
    This consumes the exact SegOps returned by `lower-scan`; it must not lower a second time because
    the block-totals buffer identity is generated during decomposition."
-  [soac segops]
-  (let [external (set/union (or (:inputs soac) #{}) (or (soac-outputs* soac) #{}))
-        used (reduce set/union #{}
-                     (map #(set/union (or (segop/segop-inputs %) #{})
-                                      (or (segop/segop-outputs %) #{}))
-                          segops))
-        temporary-ids (set/difference used external)
-        block-stage (some #(when (= :block-scan (:phase %)) %) segops)
-        temporary-elements (when block-stage
-                             (:bound (segop/seg-space-reduced-dim (:space block-stage))))
-        dtype (or (:elem-type soac) (:dtype (first segops)) :double)
-        temporaries (into {}
-                          (map (fn [id]
-                                 [id {:dtype dtype :elements temporary-elements
-                                      :memory-space :device}]))
-                          temporary-ids)]
-    (kernel-graph/from-segops
-     segops
-     {:inputs (or (:inputs soac) #{})
-      :outputs (or (soac-outputs* soac) #{})
-      :temporaries temporaries
-      :dtype dtype
-      :effects {:memory-order :dependency-ordered}
-      :provenance {:dialect :segop :algorithm :scan :soac-id (:id soac)}
-      :attributes {:strategy (if (= 1 (count segops)) :single :three-stage)}})))
+  ([soac segops]
+   (scan-kernel-graph soac segops {}))
+  ([soac segops {:keys [array-types] :or {array-types {}}}]
+   (let [external (set/union (or (:inputs soac) #{}) (or (soac-outputs* soac) #{}))
+         used (reduce set/union #{}
+                      (map #(set/union (or (segop/segop-inputs %) #{})
+                                       (or (segop/segop-outputs %) #{}))
+                           segops))
+         temporary-ids (set/difference used external)
+         block-stage (some #(when (= :block-scan (:phase %)) %) segops)
+         temporary-elements (when block-stage
+                              (:bound (segop/seg-space-reduced-dim (:space block-stage))))
+         dtype (or (:elem-type soac) (:dtype (first segops)) :double)
+         temporaries (into {}
+                           (map (fn [id]
+                                  [id {:dtype dtype :elements temporary-elements
+                                       :memory-space :device}]))
+                           temporary-ids)
+         buffer-specs (into {}
+                            (map (fn [id]
+                                   [id {:dtype (or (get array-types id)
+                                                   (get array-types (symbol (name id)))
+                                                   dtype)}]))
+                            external)]
+     (kernel-graph/from-segops
+      segops
+      {:inputs (or (:inputs soac) #{})
+       :outputs (or (soac-outputs* soac) #{})
+       :temporaries temporaries
+       :buffer-specs buffer-specs
+       :dtype dtype
+       :effects {:memory-order :dependency-ordered}
+       :provenance {:dialect :segop :algorithm :scan :soac-id (:id soac)}
+       :attributes {:strategy (if (= 1 (count segops)) :single :three-stage)
+                    :scan-algebra (get-in (first segops) [:scan-op :algebra])}}))))
 
 (defn scan-soac?
   "True when a SOAC/Screma node selects scan decomposition."

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -10,6 +10,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.passes.parallel.soac-lower :as lower]
             [raster.compiler.backend.gpu.segop-opencl :as sg]))
@@ -19,6 +20,71 @@
         s (soac/par-form->soac 'result form 0)
         segops (lower/lower-reduce s nil)]
     (:source (sg/generate-segred-kernel (first segops) 'out :dtype :float))))
+
+(defn- emitted-scan-graph
+  ([form] (emitted-scan-graph form {}))
+  ([form opts]
+   (let [node (soac/par-form->soac 'scan-result form 71)
+         operations (lower/lower-scan node nil)
+         graph (lower/scan-kernel-graph node operations opts)]
+     (sg/generate-scan-kernel-graph graph
+                                    :scalar-types (:scalar-types opts)))))
+
+(deftest segscan-graph-emits-one-verified-artifact-per-scheduled-node
+  (let [emitted (emitted-scan-graph
+                 '(raster.par/scan out acc 0.0 i n double
+                                   (+ acc (* scale (clojure.core/aget values i))))
+                 {:array-types {'values :double 'out :double}
+                  :scalar-types {'scale :double}})
+        [intra block carry] (mapv :operation (:nodes emitted))]
+    (is (kgraph/kernel-graph? emitted))
+    (is (every? kart/kernel-artifact? [intra block carry]))
+    (is (= [:intra-block :block-scan :carry-in]
+           (mapv #(get-in % [:attributes :phase]) [intra block carry])))
+    (testing "stage 1 owns both the result and graph temporary in one exact ABI"
+      (is (= [:temporary :result :operand :parameter :bound]
+             (mapv :role (:abi intra))))
+      (is (= '[scale n] (take-last 2 (:arguments intra))))
+      (is (re-find #"value = \(double\).*scale.*values\[idx\]" (:source intra))))
+    (testing "block totals are scanned in one chunked workgroup for unbounded symbolic sizes"
+      (is (= [1] (get-in block [:launch :group-count])))
+      (is (re-find #"for \(int base = 0; base < _n_bound; base \+= 256\)" (:source block))))
+    (testing "carry consumes the scanned total of the preceding block"
+      (is (re-find #"block_totals_.*\[block - 1\].*out_\[idx\]" (:source carry))))
+    (testing "entry-point names are valid C identifiers"
+      (is (every? #(re-matches #"[A-Za-z_][A-Za-z0-9_]*" (:kernel-name %))
+                  [intra block carry])))
+    (let [[intra-node block-node carry-node] (:nodes emitted)]
+      (is (= [(:id intra-node)] (:dependencies block-node)))
+      (is (= (mapv :id [intra-node block-node]) (:dependencies carry-node))
+          "target lowering preserves the verified schedule"))))
+
+(deftest segscan-artifact-abi-preserves-mixed-input-storage
+  (let [emitted (emitted-scan-graph
+                 '(raster.par/scan out acc 0.0 i n double
+                                   (+ acc (double (clojure.core/aget values i))))
+                 {:array-types {'values :int 'out :double}})
+        intra (get-in emitted [:nodes 0 :operation])
+        values-slot (first (filter #(= 'values (:name %)) (:abi intra)))]
+    (is (= :int (:dtype values-slot)))
+    (is (= :int (:kernel-dtype values-slot)))
+    (is (re-find #"__global const int\* restrict values" (:source intra)))))
+
+(deftest small-segscan-emits-the-degenerate-one-artifact-graph
+  (let [emitted (emitted-scan-graph
+                 '(raster.par/scan out acc 0.0 i 64 double (+ acc (aget values i))))
+        artifact (get-in emitted [:nodes 0 :operation])]
+    (is (= 1 (count (:nodes emitted))))
+    (is (= :single (get-in artifact [:attributes :phase])))
+    (is (= [1] (get-in artifact [:launch :group-count])))
+    (is (not (re-find #"block_totals" (:source artifact))))))
+
+(deftest segscan-carry-emits-the-certified-combine
+  (let [emitted (emitted-scan-graph
+                 '(raster.par/scan out acc 1.0 i n double (* acc (aget values i))))
+        carry (get-in emitted [:nodes 2 :operation])]
+    (is (re-find #"block_totals_.*\[block - 1\] \* out_\[idx\]" (:source carry))
+        "carry propagation must use the certified monoid, not a hard-coded addition")))
 
 ;; ================================================================
 ;; Silently-ignored-information family: a SegRed combine that the
@@ -46,12 +112,12 @@
 (deftest segred-devirtualized-aget-lowers-to-subscript
   (testing "the parametric (.invk aget-impl …) shape — the qlinear-k side of #55"
     (let [aget-invk (with-meta (list '.invk 'raster.arrays/aget_m_floats_long-impl 'a 'j)
-                               {:raster.op/original 'raster.arrays/aget
-                                :raster.type/tag 'float})
+                      {:raster.op/original 'raster.arrays/aget
+                       :raster.type/tag 'float})
           plus-invk (with-meta (list '.invk 'raster.numeric/_plus__m_double_double-impl
                                      'acc (list 'double aget-invk))
-                               {:raster.op/original 'raster.numeric/+
-                                :raster.type/tag 'double})
+                      {:raster.op/original 'raster.numeric/+
+                       :raster.type/tag 'double})
           src (segred-source plus-invk)]
       (is (not (re-find #"gpufn_aget" src))
           "devirtualized aget must normalize to a subscript, not a helper call")
@@ -65,7 +131,7 @@
 
 (deftest segred-emits-complete-ordered-typed-abi
   (let [form (with-meta '(raster.par/reduce acc 0.0 i n
-                                           (+ (float acc) (* scale (clojure.core/aget a i))))
+                                            (+ (float acc) (* scale (clojure.core/aget a i))))
                {:raster.type/elem-type :float})
         s (soac/par-form->soac 'result form 0)
         segred (first (lower/lower-reduce s nil))

--- a/test/raster/compiler/ir/kernel_graph_test.clj
+++ b/test/raster/compiler/ir/kernel_graph_test.clj
@@ -23,6 +23,8 @@
     (is (= ['out] (mapv :id (:outputs scheduled))))
     (is (= 1 (count (:temporaries scheduled))))
     (is (= :temporary (:role temporary)))
+    (is (not (re-find #"min" (pr-str (get-in operations [0 :grid :num-blocks]))))
+        "scan coverage is an uncapped ceil-div grid, never map/reduce grid-stride virtualization")
     (is (= (:id temporary)
            (first (disj (:outputs (:operation intra)) 'out)))
         "stage 1 produces the same stable block-totals buffer consumed by stages 2 and 3")
@@ -79,3 +81,16 @@
     (is (= :inout (get-in scheduled [:inputs 0 :role])))
     (is (identical? (first (:inputs scheduled)) (first (:outputs scheduled))))
     (is (= :read-write (get-in scheduled [:nodes 0 :uses 0 :access])))))
+
+(deftest scan-graph-preserves-per-buffer-storage-dtypes
+  (let [node (soac/par-form->soac
+              'scan-result
+              '(raster.par/scan out acc 0.0 i n double
+                                (+ acc (double (aget integer-values i))))
+              12)
+        operations (lower/lower-scan node nil)
+        scheduled (lower/scan-kernel-graph
+                   node operations {:array-types {'integer-values :int 'out :double}})]
+    (is (= :int (get-in scheduled [:inputs 0 :dtype])))
+    (is (= :double (get-in scheduled [:outputs 0 :dtype])))
+    (is (= :double (get-in scheduled [:temporaries 0 :dtype])))))

--- a/test/raster/compiler/ir/scan_test.clj
+++ b/test/raster/compiler/ir/scan_test.clj
@@ -1,0 +1,50 @@
+(ns raster.compiler.ir.scan-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.scan :as scan]))
+
+(deftest associative-scan-certification
+  (let [facts (scan/certify {:acc 'acc :init 0.0
+                             :lambda '(+ acc (clojure.core/aget values i))}
+                            :double)]
+    (is (scan/associative-scan? facts))
+    (is (= '+ (:combine facts)))
+    (is (= '(clojure.core/aget values i) (:element facts)))
+    (is (= 0.0 (:identity facts))))
+  (testing "an accumulator cast does not hide the one accumulator position"
+    (is (scan/associative-scan?
+         (scan/certify {:acc 'acc :init 0.0
+                        :lambda '(raster.numeric/+ (float acc) (aget values i))}
+                       :float)))))
+
+(deftest general-recurrences-are-not-relabelled-parallel-scans
+  (testing "an RNN recurrence is sequential unless it is explicitly lifted to an associative algebra"
+    (try
+      (scan/certify {:acc 'h :init 0.0
+                     :lambda '(Math/tanh (+ (* w h) (aget x i)))}
+                    :double)
+      (is false "general recurrence must decline")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :scan-not-associative (:reason (ex-data e)))))))
+  (testing "an unregistered/non-associative combine declines"
+    (try
+      (scan/certify {:acc 'acc :init 0.0 :lambda '(- acc (aget x i))} :double)
+      (is false "subtraction is not an associative scan combine")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :scan-not-associative (:reason (ex-data e))))))))
+
+(deftest block-parallel-scan-requires-the-monoid-identity
+  (try
+    (scan/certify {:acc 'acc :init 2.0 :lambda '(+ acc (aget x i))} :double)
+    (is false "a non-identity init must not be injected independently into every block")
+    (catch clojure.lang.ExceptionInfo e
+      (is (= :scan-nonidentity-init (:reason (ex-data e))))
+      (is (= 0.0 (:identity (ex-data e)))))))
+
+(deftest scan-elements-must-be-proven-pure
+  (try
+    (scan/certify {:acc 'acc :init 0.0
+                   :lambda '(+ acc (mystery-effect! values i))}
+                  :double)
+    (is false "unknown/effectful element calls must not be reordered")
+    (catch clojure.lang.ExceptionInfo e
+      (is (= :scan-element-impure-or-unknown (:reason (ex-data e)))))))

--- a/test/raster/compiler/ir/segop_test.clj
+++ b/test/raster/compiler/ir/segop_test.clj
@@ -177,6 +177,20 @@
       (is (= 2 (count segops)))
       (is (every? #(instance? raster.compiler.ir.segop.SegRed %) segops)))))
 
+(deftest fused-scan-map-declines-until-the-epilogue-is-scheduled
+  (testing "a post-scan map is not silently dropped by scan decomposition"
+    (let [scan-soac (soac/par-form->soac
+                     'prefix
+                     '(raster.par/scan prefix acc 0.0 i n double (+ acc (aget a i)))
+                     0)
+          fused (assoc (soac/soac->screma scan-soac)
+                       :map-lambda '(* 2.0 (aget prefix i)))]
+      (try
+        (lower/lower-scan fused nil)
+        (is false "the fused epilogue must not be discarded")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :scan-fused-map-unimplemented (:reason (ex-data e)))))))))
+
 (deftest lower-nodes-map-test
   (testing "lower-soac-nodes processes all SOAC nodes"
     (let [pairs [['out '(raster.par/map! out i n double (aget a i))]

--- a/test/raster/compiler/segop_boundary_test.clj
+++ b/test/raster/compiler/segop_boundary_test.clj
@@ -55,6 +55,19 @@
     (is (= [:intra-block :block-scan nil]
            (mapv #(get-in % [:operation :phase]) (:nodes scheduled))))))
 
+(deftest a-general-scan-recurrence-declines-parallel-scheduling
+  (let [r (slp/segop-lower-pass
+           '(let* [result (raster.par/scan out h 0.0 i n double
+                                           (Math/tanh (+ (* w h) (aget values i))))]
+                  result)
+           {})
+        d (first (get-in r [:stats :segops-declined]))]
+    (is (zero? (get-in r [:stats :segops-lowered])))
+    (is (zero? (get-in r [:stats :kernel-graphs-lowered])))
+    (is (= :segop (:stage d)))
+    (is (= :scan-not-associative (:reason d)))
+    (is (= :no-segop-metadata-backend-lowers-or-uses-legacy-codegen (:fallback d)))))
+
 (deftest an-unrepresentable-par-form-becomes-a-diagnostic
   (testing "a par form with no lowering rule is the case that used to vanish onto stderr"
     (let [st (stats-of '(let* [o (raster.par/scatter! O IDX V 256)] o))


### PR DESCRIPTION
## Summary

- certify the associative algebra required before a general par/scan recurrence may be parallelized
- give scan an exact uncapped block schedule and preserve storage dtypes in verified KernelGraph buffers
- target-lower single- and three-stage scan graphs to dependency-preserving OpenCL KernelArtifacts with exact ABI and launch contracts
- decline general RNN recurrences and fused scan epilogues instead of silently reassociating or dropping work

This is deliberately the target-emission half of the vertical. It does not wire production runtime graph execution or remove the legacy scan route. The next slice adds a backend-neutral graph runner, graph-owned temporary lifetime, and dependency-ordered KernelCall launches.

## Verification

- focused scan/graph/SegOp/OpenCL suite: 48 tests, 186 assertions
- broader SOAC/Screma/loop-lift/SegOp-consumption/AD laws: 102 tests, 558 assertions
- cljfmt and git diff --check
- all three generated FP32 OpenCL stages compiled locally through ocloc to SPIR-V (4252, 4188, and 2396 bytes)

The generic offline ocloc target rejects FP64 because it does not advertise cl_khr_fp64; FP64 remains represented in the graph and ABI and must be capability-gated by the selected device.