### PR TITLE
Execute verified kernel graphs

### DIFF
--- a/src/raster/compiler/ir/kernel_graph_call.clj
+++ b/src/raster/compiler/ir/kernel_graph_call.clj
@@ -1,0 +1,151 @@
+(ns raster.compiler.ir.kernel-graph-call
+  "A backend-neutral executable call of an emitted KernelGraph.
+
+   KernelGraph owns stable buffers, node uses and dependencies. KernelGraphCall supplies one
+   resident value for every graph buffer and turns each emitted node into a checked KernelCall.
+   Driver allocation, registration, recording and events remain runtime concerns."
+  (:require [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.ir.kernel-graph :as kgraph]
+            [raster.compiler.ir.kernel-launch :as klaunch]))
+
+(defrecord ScheduledKernelCall [id call dependencies])
+(defrecord KernelGraphCall [graph buffers scalar-values nodes])
+
+(defn scheduled-kernel-call? [x]
+  (and x (= "raster.compiler.ir.kernel_graph_call.ScheduledKernelCall"
+            (.getName (class x)))))
+
+(defn kernel-graph-call? [x]
+  (and x (= "raster.compiler.ir.kernel_graph_call.KernelGraphCall"
+            (.getName (class x)))))
+
+(defn- graph-buffers
+  [graph]
+  (concat (:inputs graph) (:outputs graph) (:temporaries graph)))
+
+(defn- declared-buffer-ids
+  [graph]
+  (set (map :id (graph-buffers graph))))
+
+(defn- scalar-number
+  [scalar-values value]
+  (let [resolved (if (contains? scalar-values value)
+                   (get scalar-values value)
+                   value)
+        resolved (if (and (map? resolved) (contains? resolved :value))
+                   (:value resolved)
+                   resolved)]
+    (when-not (integer? resolved)
+      (throw (ex-info "graph extent expression did not resolve to an integer"
+                      {:expression value :resolved resolved})))
+    resolved))
+
+(defn resolve-integer
+  "Resolve a graph extent or derived bound without evaluating arbitrary Clojure forms."
+  [scalar-values expression]
+  (klaunch/resolve-expression #(scalar-number scalar-values %) expression))
+
+(defn temporary-specs
+  "Resolve graph-owned temporary storage to core allocation specs: `{id [dtype elements nil]}`."
+  [graph scalar-values]
+  (let [graph (kgraph/validate! graph)]
+    (into {}
+          (map (fn [{:keys [id dtype elements]}]
+                 (let [n (resolve-integer scalar-values elements)]
+                   (when (neg? n)
+                     (throw (ex-info "graph temporary extent must be non-negative"
+                                     {:buffer id :elements elements :resolved n})))
+                   [id [dtype n nil]])))
+          (:temporaries graph))))
+
+(defn- cast-scalar
+  [dtype value]
+  (case dtype
+    :int (int value)
+    :long (long value)
+    (throw (ex-info "derived graph scalar is only defined for integer ABI slots"
+                    {:dtype dtype :value value}))))
+
+(defn- scalar-argument
+  [scalar-values slot compiler-value]
+  (if (contains? scalar-values compiler-value)
+    (let [value (get scalar-values compiler-value)]
+      (when-not (and (map? value) (contains? value :type) (contains? value :value))
+        (throw (ex-info "graph symbolic scalar requires an explicitly typed runtime value"
+                        {:compiler-value compiler-value :slot slot :value value})))
+      value)
+    (let [value (resolve-integer scalar-values compiler-value)]
+      {:type (:kernel-dtype slot)
+       :value (cast-scalar (:kernel-dtype slot) value)})))
+
+(defn validate!
+  "Validate and return a KernelGraphCall."
+  [graph-call]
+  (when-not (kernel-graph-call? graph-call)
+    (throw (ex-info "kernel graph call must be a KernelGraphCall value"
+                    {:call graph-call :actual (type graph-call)})))
+  (let [{:keys [graph buffers scalar-values nodes]} graph-call
+        graph (kgraph/validate! graph)
+        declared (declared-buffer-ids graph)]
+    (when-not (map? buffers)
+      (throw (ex-info "kernel graph call buffers must be a map" {:buffers buffers})))
+    (when-not (= declared (set (keys buffers)))
+      (throw (ex-info "kernel graph call buffer bindings differ from graph declarations"
+                      {:declared declared :bound (set (keys buffers))})))
+    (when (some nil? (vals buffers))
+      (throw (ex-info "kernel graph call buffer cannot be nil" {})))
+    (when-not (map? scalar-values)
+      (throw (ex-info "kernel graph call scalar values must be a map"
+                      {:scalar-values scalar-values})))
+    (when-not (vector? nodes)
+      (throw (ex-info "kernel graph call nodes must be an ordered vector" {:nodes nodes})))
+    (when-not (= (count (:nodes graph)) (count nodes))
+      (throw (ex-info "kernel graph call node count differs from its graph"
+                      {:expected (count (:nodes graph)) :actual (count nodes)})))
+    (doseq [[scheduled called] (map vector (:nodes graph) nodes)]
+      (when-not (scheduled-kernel-call? called)
+        (throw (ex-info "kernel graph call contains a non-node call" {:node called})))
+      (when-not (= (:id scheduled) (:id called))
+        (throw (ex-info "kernel graph node call identity differs from its schedule"
+                        {:scheduled (:id scheduled) :called (:id called)})))
+      (when-not (= (:dependencies scheduled) (:dependencies called))
+        (throw (ex-info "kernel graph node call dependencies differ from its schedule"
+                        {:node (:id scheduled)
+                         :scheduled (:dependencies scheduled)
+                         :called (:dependencies called)})))
+      (let [call (kcall/validate! (:call called))]
+        (when-not (= (:operation scheduled) (:artifact call))
+          (throw (ex-info "kernel graph node call uses a different artifact"
+                          {:node (:id scheduled)
+                           :scheduled (:operation scheduled)
+                           :called (:artifact call)})))))
+    graph-call))
+
+(defn make
+  "Construct a checked graph call from an emitted graph, complete resident buffer map, and typed
+   symbolic scalar values. Derived integer arguments such as a block-count CeilDiv are resolved
+   from the typed scalar environment and receive the ABI slot's integer type."
+  [graph buffers scalar-values]
+  (let [graph (kgraph/validate! graph)
+        declared (declared-buffer-ids graph)
+        scalar-values (or scalar-values {})]
+    (when-not (= declared (set (keys buffers)))
+      (throw (ex-info "kernel graph call requires exactly every declared graph buffer"
+                      {:declared declared :bound (set (keys buffers))})))
+    (let [nodes
+          (mapv
+           (fn [{:keys [id operation dependencies]}]
+             (let [artifact (kart/validate! operation)
+                   arguments
+                   (mapv (fn [slot compiler-value]
+                           (if (= :scalar (:kind slot))
+                             (scalar-argument scalar-values slot compiler-value)
+                             (or (get buffers compiler-value)
+                                 (throw (ex-info "kernel pointer argument is not a graph buffer"
+                                                 {:node id :compiler-value compiler-value
+                                                  :declared declared})))))
+                         (:abi artifact) (:arguments artifact))]
+               (->ScheduledKernelCall id (kcall/make artifact arguments) dependencies)))
+           (:nodes graph))]
+      (validate! (->KernelGraphCall graph buffers scalar-values nodes)))))

--- a/src/raster/compiler/ir/kernel_launch.clj
+++ b/src/raster/compiler/ir/kernel_launch.clj
@@ -145,7 +145,13 @@
                       {:expression expression :value value :resolved resolved})))
     resolved))
 
-(defn- resolved-dimension
+(defn resolve-expression
+  "Resolve one integer launch/storage expression.
+
+   Besides literal integers this understands the explicit `RuntimeValue` and `CeilDiv` records
+   used by launch and graph-buffer contracts. `resolve-value` supplies an integer for an opaque
+   compiler value such as a bound symbol. Keeping this evaluator here prevents graph runners from
+   interpreting arbitrary compiler S-expressions."
   [resolve-value dimension]
   (long
    (cond
@@ -165,6 +171,6 @@
   [launch-spec resolve-value]
   (let [{:keys [workgroup-size group-count shared-memory-bytes]}
         (validate-spec! launch-spec)]
-    (geometry {:workgroup-size (mapv #(resolved-dimension resolve-value %) workgroup-size)
-               :group-count (mapv #(resolved-dimension resolve-value %) group-count)
+    (geometry {:workgroup-size (mapv #(resolve-expression resolve-value %) workgroup-size)
+               :group-count (mapv #(resolve-expression resolve-value %) group-count)
                :shared-memory-bytes shared-memory-bytes})))

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -14,6 +14,7 @@
          Stage 3: carry-in combination (SegMap)"
   (:require [clojure.set :as set]
             [raster.compiler.ir.kernel-graph :as kernel-graph]
+            [raster.compiler.ir.kernel-launch :as kernel-launch]
             [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.ir.segop :as segop]
@@ -38,8 +39,7 @@
   (let [planned (phase-grid :scan device-id bound-expr dtype)
         block-size (:block-size planned)]
     (segop/->KernelGrid
-     (list 'int (list 'Math/ceil
-                      (list '/ (list 'double bound-expr) (double block-size))))
+     (kernel-launch/ceil-div bound-expr block-size)
      block-size
      (:shared-mem-bytes planned))))
 
@@ -261,7 +261,8 @@
                             (map (fn [id]
                                    [id {:dtype (or (get array-types id)
                                                    (get array-types (symbol (name id)))
-                                                   dtype)}]))
+                                                   dtype)
+                                        :elements (:bound soac)}]))
                             external)]
      (kernel-graph/from-segops
       segops

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -31,6 +31,8 @@
             [raster.compiler.core.inference :as inf]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.ir.kernel-graph :as kgraph]
+            [raster.compiler.ir.kernel-graph-call :as kgcall]
             [raster.compiler.pipeline :as pl]
             [raster.core :as rcore]))
 
@@ -154,6 +156,11 @@
   (let [hw-topo  (try ((requiring-resolve 'raster.runtime.hardware/memory-topology) device-id)
                       (catch Exception _ {:model :discrete :integrated? false}))
         unified? (= :unified (:model hw-topo))
+        ;; Level Zero's integrated allocation is genuinely host-coherent. OpenCL's OclBuffer,
+        ;; however, always owns a cl_mem plus a separate host staging segment: writing that segment
+        ;; is not an upload even when the physical GPU shares system memory. Treating topology
+        ;; `:unified` as API-level coherence left newly allocated OpenCL inputs full of zeroes.
+        coherent-host-view? (and unified? (= :ze (backend-type device-id)))
         mk       (rt-resolve device-id "make-buffer")
         upload   (rt-resolve device-id "array->buffer!")
         as-fbuf  (rt-resolve device-id "buffer-as-float-buffer")
@@ -162,7 +169,7 @@
         buf-of (fn [arr dtype n]
                  (let [buf (mk n dtype)]
                    (if arr
-                     (if unified?
+                     (if coherent-host-view?
                        (case dtype
                          :float (let [fb (as-fbuf buf)]
                                   (.put fb ^floats arr 0 (int n))
@@ -184,6 +191,33 @@
   (let [free! (rt-resolve device-id "free-buffer!")]
     (doseq [[_ buf] bufs]
       (free! buf))))
+
+(defn- alloc-buffers-transactional
+  "Allocate buffer specs one at a time and free the successful prefix on failure."
+  [buffer-specs device-id]
+  (let [allocated (volatile! {})]
+    (try
+      (doseq [[key spec] buffer-specs]
+        (vswap! allocated merge (alloc-buffers-internal {key spec} device-id)))
+      @allocated
+      (catch Exception e
+        (when (seq @allocated)
+          (free-buffers-internal! @allocated device-id))
+        (throw e)))))
+
+(defn- destroy-kernel-graph-entry!
+  "Destroy one bound graph's backend recording, dedicated kernel handles and graph-owned
+   temporaries. External buffers remain session-owned and are never freed here."
+  [device-id {:keys [runtime-graph prepareds temporary-buffers]}]
+  (let [destroy-graph! (rt-resolve-soft device-id "destroy-graph!")
+        destroy-prepared! (rt-resolve-soft device-id "destroy-prepared!")]
+    (when (and destroy-graph! runtime-graph)
+      (try (destroy-graph! runtime-graph) (catch Exception _)))
+    (when destroy-prepared!
+      (doseq [prepared prepareds]
+        (try (destroy-prepared! prepared) (catch Exception _))))
+    (when (seq temporary-buffers)
+      (free-buffers-internal! temporary-buffers device-id))))
 
 (def ^:private array-tag->dtype
   {'doubles :double
@@ -256,6 +290,7 @@
            :kernels   {}       ;; {phase-key → [kernel-info ...]}
            :buffers   {}       ;; {buf-key → DeviceBuffer}
            :programs  {}       ;; {program-key → bound resident program (see bind-program!)}
+           :kernel-graphs {}    ;; {graph-key → bound emitted KernelGraph}
            :closed?   false})))
 
 (defn close-session!
@@ -267,7 +302,7 @@
   this every session leaks them and the driver eventually aborts (the source of the SIGABRTs)."
   [sess]
   (locking sess
-    (let [{:keys [device-id arena-id buffers prepared graphs programs closed?]} @sess]
+    (let [{:keys [device-id arena-id buffers prepared graphs programs kernel-graphs closed?]} @sess]
       (when-not closed?
         ;; backend-specific: the bound-dispatch + command-graph path is ze-only, so resolve the
         ;; destroyers nil-safely rather than via rt-resolve (which throws on backends lacking them).
@@ -289,10 +324,13 @@
             (when (seq (:scratch-buffers prog))
               (let [free! (rt-resolve device-id "free-buffer!")]
                 (doseq [b (:scratch-buffers prog)] (try (free! b) (catch Exception _)))))))
+        (doseq [[_ graph-entry] kernel-graphs]
+          (destroy-kernel-graph-entry! device-id graph-entry))
         (free-buffers-internal! buffers device-id)
         (let [close-arena! (rt-resolve device-id "close-kernel-arena!")]
           (close-arena! arena-id))
-        (swap! sess assoc :closed? true :buffers {} :kernels {} :prepared {} :graphs {} :programs {})))))
+        (swap! sess assoc :closed? true :buffers {} :kernels {} :prepared {} :graphs {}
+               :programs {} :kernel-graphs {})))))
 
 (defn with-gpu-session*
   "Functional implementation for with-gpu-session macro."
@@ -372,19 +410,7 @@
    If allocation fails partway through, already-allocated buffers are freed."
   [sess buffer-specs]
   (let [device-id (:device-id @sess)
-        ;; Allocate one-by-one so we can free on partial failure.
-        ;; alloc-buffers-internal uses `into` which is eager, so a failure
-        ;; partway through would leak already-allocated buffers.
-        allocated (volatile! {})
-        new-bufs (try
-                   (doseq [[k spec] buffer-specs]
-                     (let [single (alloc-buffers-internal {k spec} device-id)]
-                       (vswap! allocated merge single)))
-                   @allocated
-                   (catch Exception e
-                     (when (seq @allocated)
-                       (free-buffers-internal! @allocated device-id))
-                     (throw e)))]
+        new-bufs (alloc-buffers-transactional buffer-specs device-id)]
     (swap! sess update :buffers merge new-bufs)
     new-bufs))
 
@@ -676,6 +702,121 @@
   "Get a DeviceBuffer from the session by key."
   [sess key]
   (get-in @sess [:buffers key]))
+
+;; ================================================================
+;; Executable KernelGraphs
+;; ================================================================
+
+(defrecord KernelGraphHandle [key])
+
+(defn kernel-graph-handle? [x]
+  (and x (= "raster.gpu.core.KernelGraphHandle" (.getName (class x)))))
+
+(defn- external-graph-buffer-ids
+  [graph]
+  (set (map :id (concat (:inputs graph) (:outputs graph)))))
+
+(defn- resolve-kernel-graph-entry
+  [sess handle]
+  (when-not (kernel-graph-handle? handle)
+    (throw (ex-info "kernel graph runner requires a KernelGraphHandle"
+                    {:handle handle :actual (type handle)})))
+  (or (get-in @sess [:kernel-graphs (:key handle)])
+      (throw (ex-info "kernel graph is not bound in this session"
+                      {:key (:key handle)
+                       :bound (keys (:kernel-graphs @sess))}))))
+
+(defn bind-kernel-graph!
+  "Bind an emitted KernelGraph for repeated resident execution.
+
+   `buffer-keys` maps every external GraphBuffer identity to an existing session-buffer key.
+   Distinct graph identities may not alias one session key until stable BufferView/range analysis
+   exists. `scalar-values` maps symbolic compiler values to explicitly typed runtime scalars, e.g.
+   `{'n {:type :int :value 4096}}`.
+
+   The graph owns its temporary allocations and dedicated bound kernel handles. Binding validates
+   the complete graph call before recording a conservative dependency-safe sequence. Both current
+   backends execute that sequence synchronously; the later queue/event contract can replace the
+   serialization without changing KernelGraphCall or buffer ownership."
+  [sess graph-key graph buffer-keys scalar-values]
+  (let [{:keys [device-id buffers closed?]} @sess
+        graph (kgraph/validate! graph)
+        external-ids (external-graph-buffer-ids graph)]
+    (when closed?
+      (throw (ex-info "cannot bind a kernel graph in a closed GPU session" {:key graph-key})))
+    (when-not (= external-ids (set (keys buffer-keys)))
+      (throw (ex-info "kernel graph external bindings differ from graph inputs/outputs"
+                      {:expected external-ids :bound (set (keys buffer-keys))})))
+    (when-not (= (count (vals buffer-keys)) (count (set (vals buffer-keys))))
+      (throw (ex-info "distinct graph buffers cannot alias before BufferView range analysis"
+                      {:buffer-keys buffer-keys})))
+    (let [external-buffers
+          (into {}
+                (map (fn [[id key]]
+                       [id (or (get buffers key)
+                               (throw (ex-info "kernel graph external session buffer is missing"
+                                               {:graph-buffer id :session-key key
+                                                :available (keys buffers)})))]))
+                buffer-keys)
+          temporary-specs (kgcall/temporary-specs graph scalar-values)
+          temporary-buffers (alloc-buffers-transactional temporary-specs device-id)
+          all-buffers (merge external-buffers temporary-buffers)
+          register! (rt-resolve device-id "register-kernel!")
+          bind-call! (rt-resolve device-id "bind-kernel-call")
+          record! (rt-resolve device-id "record-graph!")
+          prepareds (volatile! [])
+          runtime-graph (volatile! nil)]
+      (try
+        (let [graph-call (kgcall/make graph all-buffers scalar-values)]
+          (doseq [node (:nodes graph)]
+            (let [artifact (:operation node)]
+              (register! (:kernel-name artifact) artifact)))
+          (doseq [node-call (:nodes graph-call)]
+            (let [prepared (assoc (bind-call! (:call node-call))
+                                  :phase (:id node-call))]
+              (vswap! prepareds conj prepared)))
+          ;; Graph verification proves every dependency names an earlier node and every hazard is
+          ;; represented. Serial recording is therefore a safe implementation of that partial
+          ;; order on today's synchronous/in-order backends.
+          (vreset! runtime-graph (record! @prepareds {:barriers? true}))
+          (let [entry {:graph-call graph-call
+                       :runtime-graph @runtime-graph
+                       :prepareds @prepareds
+                       :temporary-buffers temporary-buffers
+                       :buffer-keys buffer-keys
+                       :outputs (select-keys all-buffers (map :id (:outputs graph)))}
+                old (get-in @sess [:kernel-graphs graph-key])]
+            (swap! sess assoc-in [:kernel-graphs graph-key] entry)
+            (when old (destroy-kernel-graph-entry! device-id old))
+            (->KernelGraphHandle graph-key)))
+        (catch Exception e
+          (destroy-kernel-graph-entry!
+           device-id {:runtime-graph @runtime-graph
+                      :prepareds @prepareds
+                      :temporary-buffers temporary-buffers})
+          (throw e))))))
+
+(defn run-kernel-graph!
+  "Replay a bound graph once and return its resident output buffers by graph identity."
+  [sess handle]
+  (let [{:keys [device-id closed?]} @sess]
+    (when closed?
+      (throw (ex-info "cannot run a kernel graph in a closed GPU session" {:handle handle})))
+    (let [{:keys [runtime-graph outputs]} (resolve-kernel-graph-entry sess handle)]
+      ((rt-resolve device-id "replay-graph!") runtime-graph)
+      outputs)))
+
+(defn release-kernel-graph!
+  "Release one bound graph and its graph-owned temporaries. External session buffers survive."
+  [sess handle]
+  (when-not (kernel-graph-handle? handle)
+    (throw (ex-info "release-kernel-graph! requires a KernelGraphHandle"
+                    {:handle handle :actual (type handle)})))
+  (locking sess
+    (when-let [entry (get-in @sess [:kernel-graphs (:key handle)])]
+      (swap! sess update :kernel-graphs dissoc (:key handle))
+      (destroy-kernel-graph-entry! (:device-id @sess) entry)))
+  nil)
 
 ;; ================================================================
 ;; Resident GPU programs (Option A: pipeline → bound-dispatch path)

--- a/test/raster/compiler/ir/kernel_graph_call_test.clj
+++ b/test/raster/compiler/ir/kernel_graph_call_test.clj
@@ -1,0 +1,44 @@
+(ns raster.compiler.ir.kernel-graph-call-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.segop-opencl :as emit]
+            [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.ir.kernel-graph-call :as graph-call]
+            [raster.compiler.ir.soac :as soac]
+            [raster.compiler.passes.parallel.soac-lower :as lower]))
+
+(defn- emitted-graph []
+  (let [node (soac/par-form->soac
+              'scan-result
+              '(raster.par/scan out acc 0.0 i n float (+ acc (aget values i)))
+              91)
+        operations (lower/lower-scan node nil :dtype :float)]
+    (emit/generate-scan-kernel-graph
+     (lower/scan-kernel-graph
+      node operations {:array-types {'values :float 'out :float}}))))
+
+(deftest emitted-graph-becomes-an-ordered-vector-of-kernel-calls
+  (let [graph (emitted-graph)
+        ids (set (map :id (concat (:inputs graph) (:outputs graph) (:temporaries graph))))
+        buffers (zipmap ids (repeatedly #(Object.)))
+        scalars {'n {:type :int :value 1025}}
+        call (graph-call/make graph buffers scalars)
+        [intra block carry] (mapv :call (:nodes call))]
+    (is (graph-call/kernel-graph-call? call))
+    (is (every? kcall/kernel-call? [intra block carry]))
+    (is (= [[5] [1] [5]]
+           (mapv #(get-in % [:geometry :group-count]) [intra block carry])))
+    (testing "the totals extent and stage-2 bound share one checked CeilDiv value"
+      (is (= 5 (second (first (vals (graph-call/temporary-specs graph scalars))))))
+      (is (= {:type :int :value 5} (last (:arguments block)))))
+    (is (= (mapv :dependencies (:nodes graph))
+           (mapv :dependencies (:nodes call))))))
+
+(deftest graph-call-fails-before-a-driver-sees-incomplete-bindings
+  (let [graph (emitted-graph)
+        ids (set (map :id (concat (:inputs graph) (:outputs graph) (:temporaries graph))))
+        buffers (zipmap ids (repeatedly #(Object.)))]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"exactly every declared graph buffer"
+                          (graph-call/make graph (dissoc buffers (first ids))
+                                           {'n {:type :int :value 1025}})))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"explicitly typed"
+                          (graph-call/make graph buffers {'n 1025})))))

--- a/test/raster/compiler/ir/kernel_graph_test.clj
+++ b/test/raster/compiler/ir/kernel_graph_test.clj
@@ -93,4 +93,6 @@
                    node operations {:array-types {'integer-values :int 'out :double}})]
     (is (= :int (get-in scheduled [:inputs 0 :dtype])))
     (is (= :double (get-in scheduled [:outputs 0 :dtype])))
-    (is (= :double (get-in scheduled [:temporaries 0 :dtype])))))
+    (is (= :double (get-in scheduled [:temporaries 0 :dtype])))
+    (is (= 'n (get-in scheduled [:inputs 0 :elements])))
+    (is (= 'n (get-in scheduled [:outputs 0 :elements])))))

--- a/test/raster/compiler/ir/kernel_launch_test.clj
+++ b/test/raster/compiler/ir/kernel_launch_test.clj
@@ -41,6 +41,11 @@
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must be an integer"
                             (launch/realize spec {'groups 1.5}))))))
 
+(deftest symbolic-storage-expressions-use-the-same-checked-evaluator
+  (is (= 5 (launch/resolve-expression {'n 1025} (launch/ceil-div 'n 256))))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must be an integer"
+                        (launch/resolve-expression {} (launch/ceil-div 'n 256)))))
+
 (deftest concrete-geometry-rejects-invalid-backend-launches
   (is (thrown-with-msg? clojure.lang.ExceptionInfo #"positive integer"
                         (launch/geometry {:workgroup-size [0] :group-count [1]})))

--- a/test/raster/gpu/kernel_graph_device_test.clj
+++ b/test/raster/gpu/kernel_graph_device_test.clj
@@ -1,0 +1,59 @@
+(ns raster.gpu.kernel-graph-device-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.backend.gpu.segop-opencl :as emit]
+            [raster.compiler.ir.soac :as soac]
+            [raster.compiler.passes.parallel.soac-lower :as lower]
+            [raster.dl.gpu-grad-parity :as gp]
+            [raster.gpu.core :as gpu]))
+
+(def ^:private ocl-available?
+  (delay
+    (try
+      (require 'raster.gpu.ocl-runtime)
+      ((resolve 'raster.gpu.ocl-runtime/init!))
+      true
+      (catch Throwable _ false))))
+
+(defn- emitted-graph []
+  (let [node (soac/par-form->soac
+              'scan-result
+              '(raster.par/scan out acc 0.0 i n float (+ acc (aget values i)))
+              103)
+        operations (lower/lower-scan node nil :dtype :float)]
+    (emit/generate-scan-kernel-graph
+     (lower/scan-kernel-graph
+      node operations {:array-types {'values :float 'out :float}}))))
+
+(defn- run-inclusive-scan
+  [device-id]
+  (let [n 1025
+        graph (emitted-graph)
+        input (float-array n 1.0)]
+    (gpu/with-gpu-session [sess device-id]
+      (gpu/alloc! sess {:values [:float n input]
+                        :out [:float n nil]})
+      (let [handle (gpu/bind-kernel-graph!
+                    sess :inclusive-scan graph {'values :values 'out :out}
+                    {'n {:type :int :value n}})]
+        (try
+          (gpu/run-kernel-graph! sess handle)
+          (gpu/download sess :out)
+          (finally
+            (gpu/release-kernel-graph! sess handle)))))))
+
+(defn- assert-prefix!
+  [device-id]
+  (let [result (run-inclusive-scan device-id)]
+    (is (= 1025.0 (double (aget ^floats result 1024))))
+    (is (every? true?
+                (map-indexed (fn [i value] (= (double (inc i)) (double value))) result)))))
+
+(deftest level-zero-kernel-graph-inclusive-scan
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "Level Zero KernelGraph inclusive scan")
+    (assert-prefix! :ze:0)))
+
+(deftest opencl-kernel-graph-inclusive-scan
+  (if-not @ocl-available?
+    (is true "OpenCL device unavailable")
+    (assert-prefix! :ocl:0)))

--- a/test/raster/gpu/kernel_graph_runner_test.clj
+++ b/test/raster/gpu/kernel_graph_runner_test.clj
@@ -1,0 +1,107 @@
+(ns raster.gpu.kernel-graph-runner-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.backend.gpu.segop-opencl :as emit]
+            [raster.compiler.ir.soac :as soac]
+            [raster.compiler.passes.parallel.soac-lower :as lower]
+            [raster.gpu.core :as gpu]
+            [raster.runtime.hardware :as hardware]))
+
+(defn- emitted-graph []
+  (let [node (soac/par-form->soac
+              'scan-result
+              '(raster.par/scan out acc 0.0 i n float (+ acc (aget values i)))
+              92)
+        operations (lower/lower-scan node nil :dtype :float)]
+    (emit/generate-scan-kernel-graph
+     (lower/scan-kernel-graph
+      node operations {:array-types {'values :float 'out :float}}))))
+
+(deftest integrated-opencl-allocation-still-uploads-through-cl-mem
+  (let [source (float-array [1.0 2.0])
+        uploaded (atom [])
+        mock-buffer (Object.)
+        resolver (fn [_device-id name]
+                   (case name
+                     "make-buffer" (fn [_n _dtype] mock-buffer)
+                     "array->buffer!" (fn [buffer array]
+                                        (swap! uploaded conj [buffer array])
+                                        buffer)
+                     "buffer-as-float-buffer"
+                     (fn [_] (throw (ex-info "OpenCL staging is not coherent cl_mem" {})))
+                     "buffer-as-int-buffer"
+                     (fn [_] (throw (ex-info "OpenCL staging is not coherent cl_mem" {})))))]
+    (with-redefs-fn
+      {#'hardware/memory-topology (constantly {:model :unified :integrated? true})
+       (ns-resolve 'raster.gpu.core 'rt-resolve) resolver}
+      (fn []
+        (let [allocated ((ns-resolve 'raster.gpu.core 'alloc-buffers-internal)
+                         {:input [:float 2 source]} :ocl:0)]
+          (is (identical? mock-buffer (:input allocated)))
+          (is (= [[mock-buffer source]] @uploaded)))))))
+
+(deftest session-runner-owns-only-graph-temporaries-and-bound-driver-objects
+  (let [graph (emitted-graph)
+        values-buffer (Object.)
+        output-buffer (Object.)
+        registered (atom [])
+        bound (atom [])
+        recorded (atom [])
+        replayed (atom [])
+        destroyed-graphs (atom [])
+        destroyed-prepareds (atom [])
+        freed (atom [])
+        sess (atom {:device-id :ze:0
+                    :buffers {:values values-buffer :out output-buffer}
+                    :kernel-graphs {}
+                    :closed? false})
+        resolver
+        (fn [_device-id name]
+          (case name
+            "make-buffer" (fn [n dtype] {:temporary true :elements n :dtype dtype})
+            "array->buffer!" (fn [buffer _] buffer)
+            "buffer-as-float-buffer" identity
+            "buffer-as-int-buffer" identity
+            "free-buffer!" #(swap! freed conj %)
+            "register-kernel!" (fn [kernel-name artifact]
+                                 (swap! registered conj [kernel-name artifact]))
+            "bind-kernel-call" (fn [call]
+                                 (let [prepared {:mock-call call}]
+                                   (swap! bound conj prepared)
+                                   prepared))
+            "record-graph!" (fn [prepareds opts]
+                              (let [recording {:prepareds prepareds :opts opts}]
+                                (swap! recorded conj recording)
+                                recording))
+            "replay-graph!" #(swap! replayed conj %)
+            (throw (ex-info "unexpected mocked runtime function" {:name name}))))
+        soft-resolver
+        (fn [_device-id name]
+          (case name
+            "destroy-graph!" #(swap! destroyed-graphs conj %)
+            "destroy-prepared!" #(swap! destroyed-prepareds conj %)
+            nil))]
+    (with-redefs-fn
+      {(ns-resolve 'raster.gpu.core 'rt-resolve) resolver
+       (ns-resolve 'raster.gpu.core 'rt-resolve-soft) soft-resolver}
+      (fn []
+        (let [handle (gpu/bind-kernel-graph!
+                      sess :prefix graph {'values :values 'out :out}
+                      {'n {:type :int :value 1025}})
+              outputs (gpu/run-kernel-graph! sess handle)
+              temporary (first (vals (get-in @sess [:kernel-graphs :prefix
+                                                    :temporary-buffers])))]
+          (is (gpu/kernel-graph-handle? handle))
+          (is (= 3 (count @registered)))
+          (is (= 3 (count @bound)))
+          (is (= 1 (count @recorded)))
+          (is (= {:barriers? true} (get-in @recorded [0 :opts])))
+          (is (= 1 (count @replayed)))
+          (is (identical? output-buffer (get outputs 'out)))
+          (gpu/release-kernel-graph! sess handle)
+          (is (empty? (:kernel-graphs @sess)))
+          (is (= 1 (count @destroyed-graphs)))
+          (is (= 3 (count @destroyed-prepareds)))
+          (is (= [temporary] @freed))
+          (is (not-any? #(or (identical? values-buffer %)
+                             (identical? output-buffer %))
+                        @freed)))))))


### PR DESCRIPTION
## Summary

- add backend-neutral KernelGraphCall values containing complete resident graph-buffer bindings and one checked KernelCall per emitted node
- resolve temporary extents and derived bounds through explicit RuntimeValue/CeilDiv compiler values rather than evaluating Clojure forms
- add a public session runner with transactional graph-owned temporary allocation, common artifact registration/binding, dependency-safe recording, resident outputs, replay, release, and session-close cleanup
- execute the three-stage inclusive FP32 scan exactly on live OpenCL and Level Zero
- fix integrated OpenCL allocation incorrectly writing only the host staging segment without uploading to cl_mem

The current backend implementation conservatively serializes the verified dependency order and remains synchronous. Queue/event contracts deliberately stay outside KernelCall and KernelGraphCall for the next slice. Distinct graph buffer identities cannot alias until stable BufferView/range analysis exists.

This does not delete the legacy user-callable scan route: front-door graph projection and exclusive-scan SOAC/SegOp semantics remain open.

## Verification

- focused graph/ABI/scan/OpenCL/range compatibility: 76 tests, 297 assertions
- broader SOAC/Screma/loop-lift/SegOp-consumption/AD/role coverage: 103 tests, 560 assertions
- live device gate: 2 tests, 4 assertions; 1,025-element inclusive scan has last=1025 and max-error=0 on both :ocl:0 and :ze:0
- cljfmt and git diff --check