### PR TITLE
Add backend-neutral async graph execution

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -309,6 +309,19 @@ graph:
 - graph instantiation/linking without recompiling shared kernels;
 - serialization of all non-live-resource state.
 
+Execution scheduling is a distinct backend-neutral lowering. An `ExecutionPlan`
+assigns operations to logical queue classes and connects them with logical
+wait/completion events. Compiler events are stable identities, never OpenCL,
+Level Zero, MPI, or vendor-library handles. A backend may initially realize the
+plan on one in-order compute queue, but it must retain the dependency DAG so
+later compute/transfer/collective overlap is a scheduling change rather than an
+ABI rewrite.
+
+The runtime event contract is submit, nonblocking status, host wait, and safe
+release. Completion owns the lifetime of every referenced graph, kernel,
+allocation, and view; destruction must first establish completion. Status
+observation alone is not assumed to establish host memory visibility.
+
 Device-to-device binding is the normal path. Host transfer is an explicit graph
 edge with a reason and byte count. The compiler's memory plan owns temporary
 liveness, reuse, alignment, and peak-memory accounting.

--- a/src/raster/compiler/ir/execution_plan.clj
+++ b/src/raster/compiler/ir/execution_plan.clj
@@ -1,0 +1,156 @@
+(ns raster.compiler.ir.execution-plan
+  "Backend-neutral queue and event scheduling for executable operations.
+
+   LogicalQueue and LogicalEvent are compiler values, never driver handles. An ExecutionPlan
+   lowers data dependencies to explicit wait/signal edges while leaving the runtime responsible
+   for mapping queue classes and event identities to OpenCL, Level Zero, MPI, or another executor."
+  (:require [clojure.set :as set]
+            [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.ir.kernel-graph-call :as kgcall]))
+
+(def queue-classes #{:compute :transfer :collective :host})
+(def queue-orderings #{:in-order :out-of-order})
+
+(defrecord LogicalQueue [id class ordinal ordering])
+(defrecord LogicalEvent [id])
+(defrecord ScheduledOperation [id operation queue waits completion])
+(defrecord ExecutionPlan [queues inputs operations outputs])
+
+(defn logical-queue? [x]
+  (and x (= "raster.compiler.ir.execution_plan.LogicalQueue" (.getName (class x)))))
+
+(defn logical-event? [x]
+  (and x (= "raster.compiler.ir.execution_plan.LogicalEvent" (.getName (class x)))))
+
+(defn scheduled-operation? [x]
+  (and x (= "raster.compiler.ir.execution_plan.ScheduledOperation" (.getName (class x)))))
+
+(defn execution-plan? [x]
+  (and x (= "raster.compiler.ir.execution_plan.ExecutionPlan" (.getName (class x)))))
+
+(defn compute-queue
+  "The default target-neutral in-order compute queue."
+  []
+  (->LogicalQueue :compute-0 :compute 0 :in-order))
+
+(defn validate!
+  "Validate and return an ExecutionPlan.
+
+   Every wait must name an input event or an event completed by an earlier operation. Output
+   events must be available after the full plan. This makes the event DAG explicit without
+   admitting native handles or assuming a particular backend queue implementation."
+  [plan]
+  (when-not (execution-plan? plan)
+    (throw (ex-info "execution plan must be an ExecutionPlan value"
+                    {:plan plan :actual (type plan)})))
+  (let [{:keys [queues inputs operations outputs]} plan]
+    (when-not (vector? queues)
+      (throw (ex-info "execution plan queues must be an ordered vector" {:queues queues})))
+    (when-not (vector? inputs)
+      (throw (ex-info "execution plan input events must be an ordered vector" {:inputs inputs})))
+    (when-not (vector? operations)
+      (throw (ex-info "execution plan operations must be an ordered vector"
+                      {:operations operations})))
+    (when-not (vector? outputs)
+      (throw (ex-info "execution plan output events must be an ordered vector" {:outputs outputs})))
+    (doseq [queue queues]
+      (when-not (logical-queue? queue)
+        (throw (ex-info "execution plan contains a non-logical queue" {:queue queue})))
+      (when (nil? (:id queue))
+        (throw (ex-info "logical queue requires an identity" {:queue queue})))
+      (when-not (contains? queue-classes (:class queue))
+        (throw (ex-info "logical queue has an unsupported class" {:queue queue})))
+      (when-not (and (integer? (:ordinal queue)) (not (neg? (:ordinal queue))))
+        (throw (ex-info "logical queue ordinal must be a non-negative integer" {:queue queue})))
+      (when-not (contains? queue-orderings (:ordering queue))
+        (throw (ex-info "logical queue has an unsupported ordering" {:queue queue}))))
+    (let [queue-ids (mapv :id queues)
+          input-ids (mapv :id inputs)]
+      (when-not (= (count queue-ids) (count (set queue-ids)))
+        (throw (ex-info "logical queue identities must be unique" {:ids queue-ids})))
+      (doseq [event inputs]
+        (when-not (logical-event? event)
+          (throw (ex-info "execution plan contains a non-logical input event" {:event event})))
+        (when (nil? (:id event))
+          (throw (ex-info "logical event requires an identity" {:event event}))))
+      (when-not (= (count input-ids) (count (set input-ids)))
+        (throw (ex-info "execution plan input event identities must be unique"
+                        {:ids input-ids})))
+      (loop [remaining operations
+             operation-ids #{}
+             available-events (set input-ids)]
+        (if-let [operation (first remaining)]
+          (do
+            (when-not (scheduled-operation? operation)
+              (throw (ex-info "execution plan contains a non-scheduled operation"
+                              {:operation operation})))
+            (when (or (nil? (:id operation)) (contains? operation-ids (:id operation)))
+              (throw (ex-info "scheduled operation identity must be non-nil and unique"
+                              {:id (:id operation)})))
+            (when (nil? (:operation operation))
+              (throw (ex-info "scheduled operation requires an executable operation"
+                              {:id (:id operation)})))
+            (when-not (contains? (set queues) (:queue operation))
+              (throw (ex-info "scheduled operation references an undeclared queue"
+                              {:id (:id operation) :queue (:queue operation)})))
+            (when-not (vector? (:waits operation))
+              (throw (ex-info "scheduled operation waits must be an ordered vector"
+                              {:id (:id operation) :waits (:waits operation)})))
+            (doseq [event (:waits operation)]
+              (when-not (logical-event? event)
+                (throw (ex-info "scheduled operation contains a non-logical wait"
+                                {:id (:id operation) :event event}))))
+            (let [wait-ids (mapv :id (:waits operation))
+                  completion (:completion operation)]
+              (when-not (= (count wait-ids) (count (set wait-ids)))
+                (throw (ex-info "scheduled operation waits must be unique"
+                                {:id (:id operation) :waits wait-ids})))
+              (when-not (set/subset? (set wait-ids) available-events)
+                (throw (ex-info "scheduled operation wait must name an available event"
+                                {:id (:id operation) :waits wait-ids
+                                 :available available-events})))
+              (when-not (logical-event? completion)
+                (throw (ex-info "scheduled operation requires a logical completion event"
+                                {:id (:id operation) :completion completion})))
+              (when (or (nil? (:id completion))
+                        (contains? available-events (:id completion)))
+                (throw (ex-info "scheduled operation completion identity must be non-nil and unique"
+                                {:id (:id operation) :completion (:id completion)})))
+              (recur (next remaining)
+                     (conj operation-ids (:id operation))
+                     (conj available-events (:id completion)))))
+          (let [output-ids (mapv :id outputs)]
+            (doseq [event outputs]
+              (when-not (logical-event? event)
+                (throw (ex-info "execution plan contains a non-logical output event"
+                                {:event event}))))
+            (when-not (= (count output-ids) (count (set output-ids)))
+              (throw (ex-info "execution plan output event identities must be unique"
+                              {:ids output-ids})))
+            (when-not (set/subset? (set output-ids) available-events)
+              (throw (ex-info "execution plan output must name an available event"
+                              {:outputs output-ids :available available-events})))))))
+    plan))
+
+(defn from-kernel-graph-call
+  "Lower a KernelGraphCall dependency DAG to one target-neutral compute queue and explicit
+   logical wait/completion events. Backends may conservatively serialize this plan while they
+   lack multiple queues, but cannot lose its dependency information."
+  [graph-call]
+  (let [graph-call (kgcall/validate! graph-call)
+        queue (compute-queue)
+        event-by-node (into {} (map (fn [{:keys [id]}]
+                                      [id (->LogicalEvent [:operation-complete id])])
+                                    (:nodes graph-call)))
+        operations (mapv (fn [{:keys [id call dependencies]}]
+                           (kcall/validate! call)
+                           (->ScheduledOperation id call queue
+                                                 (mapv event-by-node dependencies)
+                                                 (get event-by-node id)))
+                         (:nodes graph-call))
+        depended-on (set (mapcat :dependencies (:nodes graph-call)))
+        outputs (mapv event-by-node
+                      (keep (fn [{:keys [id]}]
+                              (when-not (contains? depended-on id) id))
+                            (:nodes graph-call)))]
+    (validate! (->ExecutionPlan [queue] [] operations outputs))))

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -29,6 +29,7 @@
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
             [raster.compiler.core.hardware :as hw]
             [raster.compiler.core.inference :as inf]
+            [raster.compiler.ir.execution-plan :as execution]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-graph :as kgraph]
@@ -286,12 +287,16 @@
   (let [make-arena! (rt-resolve device-id "make-kernel-arena!")
         arena-id (make-arena!)]
     (atom {:device-id device-id
+           :session-id (random-uuid)
            :arena-id  arena-id
            :kernels   {}       ;; {phase-key → [kernel-info ...]}
            :buffers   {}       ;; {buf-key → DeviceBuffer}
            :programs  {}       ;; {program-key → bound resident program (see bind-program!)}
            :kernel-graphs {}    ;; {graph-key → bound emitted KernelGraph}
+           :events {}           ;; {event-id → session-owned asynchronous completion}
            :closed?   false})))
+
+(declare release-event!)
 
 (defn close-session!
   "Free all buffers and kernels in a session. Idempotent and thread-safe.
@@ -302,8 +307,12 @@
   this every session leaks them and the driver eventually aborts (the source of the SIGABRTs)."
   [sess]
   (locking sess
-    (let [{:keys [device-id arena-id buffers prepared graphs programs kernel-graphs closed?]} @sess]
-      (when-not closed?
+    (when-not (:closed? @sess)
+      ;; Completion owns the right to keep graph recordings, bound kernels, and buffers alive.
+      ;; Drain and release every event before tearing any of those resources down.
+      (doseq [[_ {:keys [event]}] (:events @sess)]
+        (release-event! sess event))
+      (let [{:keys [device-id arena-id buffers prepared graphs programs kernel-graphs]} @sess]
         ;; backend-specific: the bound-dispatch + command-graph path is ze-only, so resolve the
         ;; destroyers nil-safely rather than via rt-resolve (which throws on backends lacking them).
         (let [ns-sym (case (backend-type device-id) :ze 'raster.gpu.ze-runtime :ocl 'raster.gpu.ocl-runtime)
@@ -330,7 +339,7 @@
         (let [close-arena! (rt-resolve device-id "close-kernel-arena!")]
           (close-arena! arena-id))
         (swap! sess assoc :closed? true :buffers {} :kernels {} :prepared {} :graphs {}
-               :programs {} :kernel-graphs {})))))
+               :programs {} :kernel-graphs {} :events {})))))
 
 (defn with-gpu-session*
   "Functional implementation for with-gpu-session macro."
@@ -708,9 +717,13 @@
 ;; ================================================================
 
 (defrecord KernelGraphHandle [key])
+(defrecord GPUEvent [session-id id queue])
 
 (defn kernel-graph-handle? [x]
   (and x (= "raster.gpu.core.KernelGraphHandle" (.getName (class x)))))
+
+(defn gpu-event? [x]
+  (and x (= "raster.gpu.core.GPUEvent" (.getName (class x)))))
 
 (defn- external-graph-buffer-ids
   [graph]
@@ -726,6 +739,74 @@
                       {:key (:key handle)
                        :bound (keys (:kernel-graphs @sess))}))))
 
+(defn- resolve-event-entry
+  [sess event]
+  (when-not (gpu-event? event)
+    (throw (ex-info "GPU event operation requires a GPUEvent"
+                    {:event event :actual (type event)})))
+  (when-not (= (:session-id @sess) (:session-id event))
+    (throw (ex-info "GPU event belongs to a different session"
+                    {:event event :session-id (:session-id @sess)})))
+  (or (get-in @sess [:events (:id event)])
+      (throw (ex-info "GPU event is no longer owned by this session"
+                      {:event event :events (keys (:events @sess))}))))
+
+(defn- await-event-under-lock!
+  [sess event]
+  (let [{:keys [device-id closed?]} @sess
+        {:keys [status backend-event] :as entry} (resolve-event-entry sess event)]
+    (when closed?
+      (throw (ex-info "cannot use an event from a closed GPU session" {:event event})))
+    (if (= :complete status)
+      entry
+      (do
+        ;; A successful status query is not necessarily a host memory-synchronization point
+        ;; (notably in OpenCL). Await always calls the backend wait before releasing the token.
+        ((rt-resolve device-id "await-event!") backend-event)
+        ((rt-resolve device-id "release-event!") backend-event)
+        (let [completed (assoc entry :status :complete :backend-event nil)]
+          (swap! sess assoc-in [:events (:id event)] completed)
+          completed)))))
+
+(defn event-complete?
+  "Return true when a GPUEvent has completed, without blocking. This is a status query, not a
+   substitute for await-event!: native handles remain live until a host wait establishes memory
+   visibility or release-event! safely consumes the event."
+  [sess event]
+  (locking sess
+    (let [{:keys [device-id closed?]} @sess
+          {:keys [status backend-event]} (resolve-event-entry sess event)]
+      (when closed?
+        (throw (ex-info "cannot use an event from a closed GPU session" {:event event})))
+      (or (= :complete status)
+          ((rt-resolve device-id "event-complete?") backend-event)))))
+
+(defn await-event!
+  "Block until a GPUEvent completes and return the submission's value. For a KernelGraph this is
+   its resident output-buffer map. Waiting is idempotent until release-event! consumes the event."
+  [sess event]
+  (locking sess
+    (:value (await-event-under-lock! sess event))))
+
+(defn release-event!
+  "Establish completion and remove a session-owned GPUEvent. This is deliberately safe rather
+   than cancellation-like: releasing an in-flight event waits before permitting its graph or
+   buffers to be destroyed."
+  [sess event]
+  (locking sess
+    (await-event-under-lock! sess event)
+    (swap! sess update :events dissoc (:id event)))
+  nil)
+
+(defn- release-graph-events!
+  [sess graph-key]
+  (doseq [event (->> (:events @sess)
+                     vals
+                     (filter #(= graph-key (:graph-key %)))
+                     (map :event)
+                     vec)]
+    (release-event! sess event)))
+
 (defn bind-kernel-graph!
   "Bind an emitted KernelGraph for repeated resident execution.
 
@@ -735,9 +816,9 @@
    `{'n {:type :int :value 4096}}`.
 
    The graph owns its temporary allocations and dedicated bound kernel handles. Binding validates
-   the complete graph call before recording a conservative dependency-safe sequence. Both current
-   backends execute that sequence synchronously; the later queue/event contract can replace the
-   serialization without changing KernelGraphCall or buffer ownership."
+   the complete graph call, lowers dependencies to logical queue/event edges, then records a
+   conservative dependency-safe sequence. Current backends map the logical plan to one in-order
+   compute queue; submit-kernel-graph! exposes asynchronous completion without native handles."
   [sess graph-key graph buffer-keys scalar-values]
   (let [{:keys [device-id buffers closed?]} @sess
         graph (kgraph/validate! graph)
@@ -750,6 +831,7 @@
     (when-not (= (count (vals buffer-keys)) (count (set (vals buffer-keys))))
       (throw (ex-info "distinct graph buffers cannot alias before BufferView range analysis"
                       {:buffer-keys buffer-keys})))
+    (release-graph-events! sess graph-key)
     (let [external-buffers
           (into {}
                 (map (fn [[id key]]
@@ -767,7 +849,8 @@
           prepareds (volatile! [])
           runtime-graph (volatile! nil)]
       (try
-        (let [graph-call (kgcall/make graph all-buffers scalar-values)]
+        (let [graph-call (kgcall/make graph all-buffers scalar-values)
+              execution-plan (execution/from-kernel-graph-call graph-call)]
           (doseq [node (:nodes graph)]
             (let [artifact (:operation node)]
               (register! (:kernel-name artifact) artifact)))
@@ -777,9 +860,10 @@
               (vswap! prepareds conj prepared)))
           ;; Graph verification proves every dependency names an earlier node and every hazard is
           ;; represented. Serial recording is therefore a safe implementation of that partial
-          ;; order on today's synchronous/in-order backends.
+          ;; order on today's single in-order compute queues; the logical plan retains the DAG.
           (vreset! runtime-graph (record! @prepareds {:barriers? true}))
           (let [entry {:graph-call graph-call
+                       :execution-plan execution-plan
                        :runtime-graph @runtime-graph
                        :prepareds @prepareds
                        :temporary-buffers temporary-buffers
@@ -796,23 +880,62 @@
                       :temporary-buffers temporary-buffers})
           (throw e))))))
 
-(defn run-kernel-graph!
-  "Replay a bound graph once and return its resident output buffers by graph identity."
+(defn kernel-graph-execution-plan
+  "Return the pure backend-neutral queue/event plan for a bound KernelGraph."
   [sess handle]
-  (let [{:keys [device-id closed?]} @sess]
-    (when closed?
-      (throw (ex-info "cannot run a kernel graph in a closed GPU session" {:handle handle})))
-    (let [{:keys [runtime-graph outputs]} (resolve-kernel-graph-entry sess handle)]
-      ((rt-resolve device-id "replay-graph!") runtime-graph)
-      outputs)))
+  (:execution-plan (resolve-kernel-graph-entry sess handle)))
+
+(defn submit-kernel-graph!
+  "Submit a bound graph without waiting and return a session-owned GPUEvent.
+
+   One submission per graph may be in flight. This common guarantee matches Level Zero's
+   replayable command-list ownership and remains correct on OpenCL's in-order queue. Await or
+   release the prior event before submitting the same graph again."
+  [sess handle]
+  (locking sess
+    (let [{:keys [device-id session-id closed? events]} @sess]
+      (when closed?
+        (throw (ex-info "cannot submit a kernel graph in a closed GPU session" {:handle handle})))
+      (let [{:keys [runtime-graph outputs execution-plan]}
+            (resolve-kernel-graph-entry sess handle)
+            pending (some (fn [[_ entry]]
+                            (when (and (= (:key handle) (:graph-key entry))
+                                       (= :pending (:status entry)))
+                              (:event entry)))
+                          events)]
+        (when pending
+          (throw (ex-info "kernel graph already has an in-flight submission"
+                          {:handle handle :event pending})))
+        (let [backend-event ((rt-resolve device-id "submit-graph!") runtime-graph)
+              event-id (random-uuid)
+              queue (first (:queues execution-plan))
+              event (->GPUEvent session-id event-id queue)]
+          (swap! sess assoc-in [:events event-id]
+                 {:event event
+                  :graph-key (:key handle)
+                  :status :pending
+                  :backend-event backend-event
+                  :value outputs})
+          event)))))
+
+(defn run-kernel-graph!
+  "Submit a bound graph, wait for completion, and return its resident output buffers."
+  [sess handle]
+  (let [event (submit-kernel-graph! sess handle)]
+    (try
+      (await-event! sess event)
+      (finally
+        (release-event! sess event)))))
 
 (defn release-kernel-graph!
-  "Release one bound graph and its graph-owned temporaries. External session buffers survive."
+  "Release one bound graph and its graph-owned temporaries. External session buffers survive.
+   Any in-flight submission is completed and released before its resources are destroyed."
   [sess handle]
   (when-not (kernel-graph-handle? handle)
     (throw (ex-info "release-kernel-graph! requires a KernelGraphHandle"
                     {:handle handle :actual (type handle)})))
   (locking sess
+    (release-graph-events! sess (:key handle))
     (when-let [entry (get-in @sess [:kernel-graphs (:key handle)])]
       (swap! sess update :kernel-graphs dissoc (:key handle))
       (destroy-kernel-graph-entry! (:device-id @sess) entry)))

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -100,6 +100,8 @@
 (def ^:private CL_MEM_READ_WRITE (long 1))
 (def ^:private CL_MEM_COPY_HOST_PTR (long 32))
 (def ^:private CL_TRUE (int 1))
+(def ^:private CL_COMPLETE 0)
+(def ^:private CL_EVENT_COMMAND_EXECUTION_STATUS 0x11D3)
 
 ;; clGetDeviceInfo param_name constants
 (def ^:private CL_DEVICE_MAX_COMPUTE_UNITS 0x1002)
@@ -179,6 +181,14 @@
   (delay (make-handle "clEnqueueNDRangeKernel" (fd I32 PTR PTR I32 PTR PTR PTR I32 PTR PTR))))
 (def ^:private h-clFinish
   (delay (make-handle "clFinish" (fd I32 PTR))))
+(def ^:private h-clFlush
+  (delay (make-handle "clFlush" (fd I32 PTR))))
+(def ^:private h-clWaitForEvents
+  (delay (make-handle "clWaitForEvents" (fd I32 I32 PTR))))
+(def ^:private h-clGetEventInfo
+  (delay (make-handle "clGetEventInfo" (fd I32 PTR I32 I64 PTR PTR))))
+(def ^:private h-clReleaseEvent
+  (delay (make-handle "clReleaseEvent" (fd I32 PTR))))
 
 ;; Cleanup
 (def ^:private h-clReleaseKernel
@@ -1235,25 +1245,27 @@
 
 (defn- enqueue-bound!
   "Enqueue one pre-bound kernel (no finish)."
-  [{:keys [^MemorySegment kernel wg]} group-count]
-  (let [{:keys [queue]} @state
-        arena (Arena/ofConfined)
-        wg (if (vector? wg) wg [(long wg)])
-        group-count (if (vector? group-count) group-count [(long group-count)])
-        work-dim (count wg)]
-    (when-not (= work-dim (count group-count))
-      (throw (ex-info "bound OpenCL workgroup and grid dimensionality differ"
-                      {:workgroup wg :grid group-count})))
-    (try
-      (let [g (.allocate ^Arena arena (* 8 work-dim))
-            l (.allocate ^Arena arena (* 8 work-dim))]
-        (doseq [i (range work-dim)]
-          (.set g I64 (long (* 8 i)) (* (long (nth group-count i)) (long (nth wg i))))
-          (.set l I64 (long (* 8 i)) (long (nth wg i))))
-        (cl-call! "clEnqueueNDRangeKernel" @h-clEnqueueNDRangeKernel
-                  [queue kernel (int work-dim) MemorySegment/NULL g l
-                   (int 0) MemorySegment/NULL MemorySegment/NULL]))
-      (finally (.close arena)))))
+  ([bound group-count]
+   (enqueue-bound! bound group-count MemorySegment/NULL))
+  ([{:keys [^MemorySegment kernel wg]} group-count event-out]
+   (let [{:keys [queue]} @state
+         arena (Arena/ofConfined)
+         wg (if (vector? wg) wg [(long wg)])
+         group-count (if (vector? group-count) group-count [(long group-count)])
+         work-dim (count wg)]
+     (when-not (= work-dim (count group-count))
+       (throw (ex-info "bound OpenCL workgroup and grid dimensionality differ"
+                       {:workgroup wg :grid group-count})))
+     (try
+       (let [g (.allocate ^Arena arena (* 8 work-dim))
+             l (.allocate ^Arena arena (* 8 work-dim))]
+         (doseq [i (range work-dim)]
+           (.set g I64 (long (* 8 i)) (* (long (nth group-count i)) (long (nth wg i))))
+           (.set l I64 (long (* 8 i)) (long (nth wg i))))
+         (cl-call! "clEnqueueNDRangeKernel" @h-clEnqueueNDRangeKernel
+                   [queue kernel (int work-dim) MemorySegment/NULL g l
+                    (int 0) MemorySegment/NULL event-out]))
+       (finally (.close arena))))))
 
 (defn launch-registered-bound!
   "Dispatch a pre-bound kernel. Synchronous."
@@ -1270,12 +1282,67 @@
                       {:bound bound :group-count group-count})
                     prepareds)}))
 
-(defn replay-graph!
-  "Enqueue every recorded launch in order, then clFinish. Synchronous."
+(defn submit-graph!
+  "Submit an OpenCL graph without waiting. The in-order queue preserves the recorded order and
+   the final launch signals a native event held only by this runtime-private token."
   [graph]
-  (doseq [{:keys [bound group-count]} (:launches graph)]
-    (enqueue-bound! bound group-count))
-  (cl-call! "clFinish" @h-clFinish [(:queue @state)]))
+  (let [launches (:launches graph)]
+    (if (empty? launches)
+      {:complete? true}
+      (let [arena (Arena/ofShared)
+            event-out (.allocate arena PTR)
+            status-out (.allocate arena I32)]
+        (try
+          (doseq [[index {:keys [bound group-count]}] (map-indexed vector launches)]
+            (enqueue-bound! bound group-count
+                            (if (= index (dec (count launches)))
+                              event-out
+                              MemorySegment/NULL)))
+          (cl-call! "clFlush" @h-clFlush [(:queue @state)])
+          {:event (.get event-out PTR 0)
+           :event-array event-out
+           :status-out status-out
+           :arena arena}
+          (catch Exception e
+            (.close arena)
+            (throw e)))))))
+
+(defn await-event!
+  "Wait for a runtime-private OpenCL completion token."
+  [{:keys [complete? event-array]}]
+  (when-not complete?
+    (cl-call! "clWaitForEvents" @h-clWaitForEvents [(int 1) event-array]))
+  nil)
+
+(defn event-complete?
+  "Nonblocking query of a runtime-private OpenCL completion token."
+  [{:keys [complete? event status-out]}]
+  (if complete?
+    true
+    (do
+      (cl-call! "clGetEventInfo" @h-clGetEventInfo
+                [event (int CL_EVENT_COMMAND_EXECUTION_STATUS) (long 4)
+                 status-out MemorySegment/NULL])
+      (= CL_COMPLETE (.get ^MemorySegment status-out I32 0)))))
+
+(defn release-event!
+  "Release a runtime-private OpenCL completion token. The caller must establish completion."
+  [{:keys [complete? event ^Arena arena]}]
+  (when-not complete?
+    (try
+      (cl-call! "clReleaseEvent" @h-clReleaseEvent [event])
+      (finally
+        (.close arena))))
+  nil)
+
+(defn replay-graph!
+  "Enqueue every recorded launch and wait for completion."
+  [graph]
+  (let [event (submit-graph! graph)]
+    (try
+      (await-event! event)
+      (finally
+        (release-event! event)))))
 
 (defn synchronize-async!
   "Block until all enqueued work completes."

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -108,6 +108,9 @@
 (def ^:private ZE_MODULE_FORMAT_IL_SPIRV 0x00)
 (def ^:private ZE_MODULE_FORMAT_NATIVE 0x01)
 (def ^:private ZE_RESULT_SUCCESS 0)
+(def ^:private ZE_RESULT_NOT_READY 1)
+(def ^:private ZE_COMMAND_QUEUE_MODE_SYNCHRONOUS 1)
+(def ^:private ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS 2)
 
 ;; Device-event kernel timing (profiling)
 (def ^:private ZE_STRUCTURE_TYPE_EVENT_POOL_DESC 0x10)
@@ -344,7 +347,7 @@
                   ;; zeCommandListCreateImmediate (synchronous mode)
                   cq-desc (.allocate arena 40)
                   _ (.set cq-desc I32 0 (int ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC))
-                  _ (.set cq-desc I32 28 (int 1)) ;; ZE_COMMAND_QUEUE_MODE_SYNCHRONOUS
+                  _ (.set cq-desc I32 28 (int ZE_COMMAND_QUEUE_MODE_SYNCHRONOUS))
                   cmd-out (ptr-seg arena)
                   _ (ze-call! "zeCommandListCreateImmediate" @h-zeCommandListCreateImmediate
                               [context device cq-desc cmd-out])
@@ -385,7 +388,7 @@
       (let [{:keys [arena context device]} @state
             cq-desc (.allocate ^Arena arena 40)
             _ (.set cq-desc I32 0 (int ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC))
-            _ (.set cq-desc I32 28 (int 0)) ;; ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS
+            _ (.set cq-desc I32 28 (int ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS))
             cmd-out (ptr-seg arena)
             _ (ze-call! "zeCommandListCreateImmediate" @h-zeCommandListCreateImmediate
                         [context device cq-desc cmd-out])
@@ -1628,7 +1631,7 @@
   (let [{:keys [arena context device]} @state
         cq-desc (.allocate ^Arena arena 40)
         _ (.set cq-desc I32 0 (int ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC))
-        _ (.set cq-desc I32 28 (int 1)) ;; SYNCHRONOUS: execute blocks until list completes
+        _ (.set cq-desc I32 28 (int ZE_COMMAND_QUEUE_MODE_SYNCHRONOUS))
         q-out (ptr-seg arena)
         _ (ze-call! "zeCommandQueueCreate" @h-zeCommandQueueCreate [context device cq-desc q-out])
         queue (read-ptr q-out)
@@ -2775,7 +2778,9 @@
    (let [{:keys [arena context device]} @state
          cq-desc (.allocate ^Arena arena 40)
          _ (.set cq-desc I32 0 (int ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC))
-         _ (.set cq-desc I32 28 (int 1)) ;; SYNCHRONOUS: execute blocks until the list completes
+         ;; The public replay path still waits, but submit-graph! can now return immediately and
+         ;; expose queue completion through the backend-neutral runtime event contract.
+         _ (.set cq-desc I32 28 (int ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS))
          q-out (ptr-seg arena)
          _ (ze-call! "zeCommandQueueCreate" @h-zeCommandQueueCreate
                      [context device cq-desc q-out])
@@ -2848,11 +2853,49 @@
                        :kernel-names (mapv #(or (:kernel-name %) "unknown") prepareds)
                        :phases (mapv :phase prepareds)))))))
 
-(defn replay-graph!
-  "Execute a recorded command graph once. Synchronous (the queue blocks until complete)."
+(defn submit-graph!
+  "Submit a recorded graph without waiting. Returns a runtime-private completion token.
+   The token contains a Level Zero queue handle, but it never enters compiler IR or the public
+   gpu.core event value. A graph permits one in-flight submission at a time at the core layer."
   [graph]
   (ze-call! "zeCommandQueueExecuteCommandLists" @h-zeCommandQueueExecuteCommandLists
-            [(:queue graph) (int 1) (:lists-arr graph) MemorySegment/NULL]))
+            [(:queue graph) (int 1) (:lists-arr graph) MemorySegment/NULL])
+  {:queue (:queue graph)})
+
+(defn await-event!
+  "Wait for a runtime-private graph completion token."
+  [{:keys [queue]}]
+  (ze-call! "zeCommandQueueSynchronize" @h-zeCommandQueueSynchronize
+            [queue (long -1)])
+  nil)
+
+(defn event-complete?
+  "Nonblocking query of a runtime-private graph completion token."
+  [{:keys [queue]}]
+  (let [result (int (.invokeWithArguments
+                     ^MethodHandle @h-zeCommandQueueSynchronize
+                     ^java.util.List (java.util.List/of
+                                      (object-array [queue (long 0)]))))]
+    (cond
+      (= result ZE_RESULT_SUCCESS) true
+      (= result ZE_RESULT_NOT_READY) false
+      :else (throw (ex-info (str "Level Zero error querying graph event: 0x"
+                                 (Integer/toHexString result))
+                            {:result result :context "zeCommandQueueSynchronize"})))))
+
+(defn release-event!
+  "Release a runtime-private graph completion token. Queue ownership remains with the graph."
+  [_event]
+  nil)
+
+(defn replay-graph!
+  "Execute a recorded command graph once and wait for completion."
+  [graph]
+  (let [event (submit-graph! graph)]
+    (try
+      (await-event! event)
+      (finally
+        (release-event! event)))))
 
 (defn- destroy-handle!
   [^MethodHandle mh ^MemorySegment seg]

--- a/test/raster/compiler/ir/execution_plan_test.clj
+++ b/test/raster/compiler/ir/execution_plan_test.clj
@@ -1,0 +1,47 @@
+(ns raster.compiler.ir.execution-plan-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.segop-opencl :as emit]
+            [raster.compiler.ir.execution-plan :as execution]
+            [raster.compiler.ir.kernel-graph-call :as graph-call]
+            [raster.compiler.ir.soac :as soac]
+            [raster.compiler.passes.parallel.soac-lower :as lower]))
+
+(defn- emitted-graph []
+  (let [node (soac/par-form->soac
+              'scan-result
+              '(raster.par/scan out acc 0.0 i n float (+ acc (aget values i)))
+              93)
+        operations (lower/lower-scan node nil :dtype :float)]
+    (emit/generate-scan-kernel-graph
+     (lower/scan-kernel-graph
+      node operations {:array-types {'values :float 'out :float}}))))
+
+(deftest kernel-graph-dependencies-become-logical-event-edges
+  (let [graph (emitted-graph)
+        ids (set (map :id (concat (:inputs graph) (:outputs graph) (:temporaries graph))))
+        call (graph-call/make graph (zipmap ids (repeatedly #(Object.)))
+                              {'n {:type :int :value 1025}})
+        plan (execution/from-kernel-graph-call call)
+        [intra block carry] (:operations plan)]
+    (is (execution/execution-plan? plan))
+    (is (= [:compute :compute :compute]
+           (mapv (comp :class :queue) (:operations plan))))
+    (is (empty? (:waits intra)))
+    (is (= [(:completion intra)] (:waits block)))
+    (is (= [(:completion intra) (:completion block)] (:waits carry)))
+    (is (= [(:completion carry)] (:outputs plan)))
+    (testing "compiler events contain identities, never native handles"
+      (is (every? execution/logical-event?
+                  (concat (:outputs plan) (mapcat :waits (:operations plan))))))))
+
+(deftest execution-plan-rejects-forward-event-dependencies
+  (let [queue (execution/compute-queue)
+        later (execution/->LogicalEvent :later)
+        done (execution/->LogicalEvent :done)]
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"available event"
+         (execution/validate!
+          (execution/->ExecutionPlan
+           [queue] []
+           [(execution/->ScheduledOperation :first :operation queue [later] done)]
+           [done]))))))

--- a/test/raster/gpu/kernel_graph_device_test.clj
+++ b/test/raster/gpu/kernel_graph_device_test.clj
@@ -36,8 +36,14 @@
                     sess :inclusive-scan graph {'values :values 'out :out}
                     {'n {:type :int :value n}})]
         (try
-          (gpu/run-kernel-graph! sess handle)
-          (gpu/download sess :out)
+          (let [event (gpu/submit-kernel-graph! sess handle)]
+            (try
+              (is (boolean? (gpu/event-complete? sess event)))
+              (gpu/await-event! sess event)
+              (is (gpu/event-complete? sess event))
+              (gpu/download sess :out)
+              (finally
+                (gpu/release-event! sess event))))
           (finally
             (gpu/release-kernel-graph! sess handle)))))))
 

--- a/test/raster/gpu/kernel_graph_runner_test.clj
+++ b/test/raster/gpu/kernel_graph_runner_test.clj
@@ -46,13 +46,17 @@
         registered (atom [])
         bound (atom [])
         recorded (atom [])
-        replayed (atom [])
+        submitted (atom [])
+        awaited (atom [])
+        released-events (atom [])
         destroyed-graphs (atom [])
         destroyed-prepareds (atom [])
         freed (atom [])
         sess (atom {:device-id :ze:0
+                    :session-id :test-session
                     :buffers {:values values-buffer :out output-buffer}
                     :kernel-graphs {}
+                    :events {}
                     :closed? false})
         resolver
         (fn [_device-id name]
@@ -72,7 +76,13 @@
                               (let [recording {:prepareds prepareds :opts opts}]
                                 (swap! recorded conj recording)
                                 recording))
-            "replay-graph!" #(swap! replayed conj %)
+            "submit-graph!" (fn [graph]
+                              (let [event {:submitted graph}]
+                                (swap! submitted conj event)
+                                event))
+            "await-event!" #(swap! awaited conj %)
+            "event-complete?" (constantly true)
+            "release-event!" #(swap! released-events conj %)
             (throw (ex-info "unexpected mocked runtime function" {:name name}))))
         soft-resolver
         (fn [_device-id name]
@@ -87,6 +97,16 @@
         (let [handle (gpu/bind-kernel-graph!
                       sess :prefix graph {'values :values 'out :out}
                       {'n {:type :int :value 1025}})
+              event (gpu/submit-kernel-graph! sess handle)
+              _ (is (gpu/gpu-event? event))
+              _ (is (gpu/event-complete? sess event))
+              _ (is (empty? @released-events)
+                    "a positive status query is not a host wait and must not consume the event")
+              _ (is (thrown-with-msg? clojure.lang.ExceptionInfo #"in-flight submission"
+                                      (gpu/submit-kernel-graph! sess handle)))
+              async-outputs (gpu/await-event! sess event)
+              _ (is (gpu/event-complete? sess event))
+              _ (gpu/release-event! sess event)
               outputs (gpu/run-kernel-graph! sess handle)
               temporary (first (vals (get-in @sess [:kernel-graphs :prefix
                                                     :temporary-buffers])))]
@@ -95,9 +115,17 @@
           (is (= 3 (count @bound)))
           (is (= 1 (count @recorded)))
           (is (= {:barriers? true} (get-in @recorded [0 :opts])))
-          (is (= 1 (count @replayed)))
+          (is (= 2 (count @submitted)))
+          (is (= @submitted @awaited @released-events))
+          (is (empty? (:events @sess)))
+          (is (identical? output-buffer (get async-outputs 'out)))
           (is (identical? output-buffer (get outputs 'out)))
+          (gpu/submit-kernel-graph! sess handle)
           (gpu/release-kernel-graph! sess handle)
+          (is (= 3 (count @submitted)))
+          (is (= @submitted @awaited @released-events)
+              "graph release waits and releases an in-flight submission")
+          (is (empty? (:events @sess)))
           (is (empty? (:kernel-graphs @sess)))
           (is (= 1 (count @destroyed-graphs)))
           (is (= 3 (count @destroyed-prepareds)))


### PR DESCRIPTION
## Summary

- add a driver-free `ExecutionPlan` with logical compute/transfer/collective/host queues and explicit wait/completion event edges lowered from `KernelGraphCall` dependencies
- add session-owned `GPUEvent` values plus `submit-kernel-graph!`, nonblocking `event-complete?`, `await-event!`, and safe `release-event!`; keep `run-kernel-graph!` as submit/await/release compatibility
- enforce completion before graph rebind/release or session teardown, so in-flight work retains its graph, kernels, buffers, and temporaries
- implement real nonblocking submission: OpenCL signals and flushes a final `cl_event`; Level Zero records on an explicitly asynchronous queue and queries queue completion with a zero timeout
- correct the older Level Zero async immediate path from driver-default queue mode `0` to the actual asynchronous enum `2`
- document the boundary: compiler IR contains logical identities only; native handles remain runtime-private

Current KernelGraphs still realize their plan on one in-order compute queue, conservatively serializing the verified DAG. Multiple physical queues, copies, and collectives can now be added as scheduling/runtime work without changing `KernelCall` or its ABI. Status observation deliberately does not consume an event or claim host memory visibility; await/release performs the synchronization.

## Verification

- focused execution-plan, graph-call, graph-runner, and Level Zero device-timing coverage: 7 tests, 68 assertions
- live Arc gate on both `:ze:0` and `:ocl:0`: 2 tests, 8 assertions; the three-stage 1,025-element inclusive FP32 scan is exact through submit/status/await
- both runtime namespaces cold-load successfully
- `git diff --check`

A broader local suite attempt reached the known GPU-dependent `explain_pipeline_truth_test` baseline mismatch recorded in correctness-ledger entry 38; the focused and live gates above are clean.