### PR TITLE
Add stable resident buffer views

### DIFF
--- a/src/raster/compiler/ir/buffer_view.clj
+++ b/src/raster/compiler/ir/buffer_view.clj
@@ -1,0 +1,168 @@
+(ns raster.compiler.ir.buffer-view
+  "Stable physical allocation and view descriptors.
+
+   These values contain no backend handles. BufferAllocation identifies storage and its lifetime/
+   coherence contract; BufferView identifies one typed, shaped byte range within that storage.
+   Semantic AxisMaps and accelerator thread/register layouts remain separate concerns."
+  (:require [raster.compiler.core.dtype :as dtype]))
+
+(def ownership-kinds #{:owned :borrowed :external})
+(def coherence-kinds #{:host-coherent :explicit-transfer :device-only})
+
+(defrecord BufferAllocation
+           [id byte-size memory-space device alignment coherence ownership])
+(defrecord BufferView
+           [id allocation byte-offset byte-length dtype shape strides])
+
+(defn buffer-allocation? [x]
+  (and x (= "raster.compiler.ir.buffer_view.BufferAllocation" (.getName (class x)))))
+
+(defn buffer-view? [x]
+  (and x (= "raster.compiler.ir.buffer_view.BufferView" (.getName (class x)))))
+
+(defn- power-of-two? [n]
+  (and (pos? n) (zero? (bit-and n (dec n)))))
+
+(defn validate-allocation!
+  [allocation]
+  (when-not (buffer-allocation? allocation)
+    (throw (ex-info "buffer allocation must be a BufferAllocation value"
+                    {:allocation allocation :actual (type allocation)})))
+  (let [{:keys [id byte-size memory-space device alignment coherence ownership]} allocation]
+    (when (nil? id)
+      (throw (ex-info "buffer allocation requires a stable identity" {})))
+    (when-not (and (integer? byte-size) (not (neg? byte-size)))
+      (throw (ex-info "buffer allocation byte size must be a non-negative integer"
+                      {:byte-size byte-size})))
+    (when-not (keyword? memory-space)
+      (throw (ex-info "buffer allocation requires a memory-space keyword"
+                      {:memory-space memory-space})))
+    (when-not (or (nil? device) (keyword? device))
+      (throw (ex-info "buffer allocation device must be nil or a device keyword"
+                      {:device device})))
+    (when-not (and (integer? alignment) (power-of-two? alignment))
+      (throw (ex-info "buffer allocation alignment must be a positive power of two"
+                      {:alignment alignment})))
+    (when-not (contains? coherence-kinds coherence)
+      (throw (ex-info "buffer allocation has an invalid coherence contract"
+                      {:coherence coherence :allowed coherence-kinds})))
+    (when-not (contains? ownership-kinds ownership)
+      (throw (ex-info "buffer allocation has an invalid ownership contract"
+                      {:ownership ownership :allowed ownership-kinds}))))
+  allocation)
+
+(defn allocation
+  [{:keys [id byte-size memory-space device alignment coherence ownership]
+    :or {alignment 1 coherence :device-only ownership :owned}}]
+  (validate-allocation!
+   (->BufferAllocation id byte-size memory-space device alignment coherence ownership)))
+
+(defn dense-strides
+  "Contiguous row-major element strides for a realized shape."
+  [shape]
+  (loop [remaining (rseq (vec shape)) stride 1 result ()]
+    (if-let [extent (first remaining)]
+      (recur (next remaining) (* stride extent) (conj result stride))
+      (vec result))))
+
+(defn required-byte-span
+  "Byte span from the first addressed element through the last for shape/element strides."
+  [dtype shape strides]
+  (let [element-bytes (long (dtype/bytes-of dtype))]
+    (if (some zero? shape)
+      0
+      (* element-bytes
+         (inc (reduce + 0 (map (fn [extent stride]
+                                 (* (dec extent) stride))
+                               shape strides)))))))
+
+(defn validate-view!
+  [view]
+  (when-not (buffer-view? view)
+    (throw (ex-info "buffer view must be a BufferView value"
+                    {:view view :actual (type view)})))
+  (let [{:keys [id allocation byte-offset byte-length dtype shape strides]} view
+        allocation (validate-allocation! allocation)]
+    (when (nil? id)
+      (throw (ex-info "buffer view requires a stable identity" {})))
+    (dtype/canon dtype)
+    (when-not (and (vector? shape)
+                   (every? #(and (integer? %) (not (neg? %))) shape))
+      (throw (ex-info "buffer view shape must be a realized non-negative integer vector"
+                      {:shape shape})))
+    (when-not (and (vector? strides) (= (count shape) (count strides))
+                   (every? #(and (integer? %) (not (neg? %))) strides))
+      (throw (ex-info "buffer view strides must be a non-negative integer per shape axis"
+                      {:shape shape :strides strides})))
+    (when-not (and (integer? byte-offset) (not (neg? byte-offset))
+                   (integer? byte-length) (not (neg? byte-length)))
+      (throw (ex-info "buffer view byte offset/length must be non-negative integers"
+                      {:byte-offset byte-offset :byte-length byte-length})))
+    (let [element-bytes (long (dtype/bytes-of dtype))
+          required (required-byte-span dtype shape strides)]
+      (when-not (zero? (mod byte-offset element-bytes))
+        (throw (ex-info "buffer view byte offset is not aligned to its dtype"
+                        {:byte-offset byte-offset :dtype dtype :element-bytes element-bytes})))
+      (when-not (= required byte-length)
+        (throw (ex-info "buffer view byte length differs from its shaped strided span"
+                        {:byte-length byte-length :required required
+                         :shape shape :strides strides :dtype dtype})))
+      (when (> (+ byte-offset byte-length) (:byte-size allocation))
+        (throw (ex-info "buffer view exceeds its allocation"
+                        {:allocation (:id allocation) :allocation-bytes (:byte-size allocation)
+                         :byte-offset byte-offset :byte-length byte-length}))))
+    view))
+
+(defn view
+  "Construct a checked BufferView. `byte-length` defaults to the shaped strided span and
+   `strides` defaults to dense row-major element strides."
+  [allocation {:keys [id byte-offset byte-length dtype shape strides]
+               :or {byte-offset 0}}]
+  (when (nil? shape)
+    (throw (ex-info "buffer view requires an explicit realized shape" {:shape shape})))
+  (let [allocation (validate-allocation! allocation)
+        shape (vec shape)
+        strides (vec (or strides (dense-strides shape)))
+        byte-length (or byte-length (required-byte-span dtype shape strides))]
+    (validate-view!
+     (->BufferView (or id [(:id allocation) byte-offset byte-length dtype shape strides])
+                   allocation byte-offset byte-length (dtype/canon dtype) shape strides))))
+
+(defn byte-end [view]
+  (+ (:byte-offset (validate-view! view)) (:byte-length view)))
+
+(defn overlaps?
+  "True when two views address at least one common byte of the same allocation."
+  [a b]
+  (let [a (validate-view! a) b (validate-view! b)]
+    (and (= (get-in a [:allocation :id]) (get-in b [:allocation :id]))
+         (< (:byte-offset a) (byte-end b))
+         (< (:byte-offset b) (byte-end a)))))
+
+(defn disjoint? [a b] (not (overlaps? a b)))
+
+(defn same-range?
+  [a b]
+  (let [a (validate-view! a) b (validate-view! b)]
+    (and (= (get-in a [:allocation :id]) (get-in b [:allocation :id]))
+         (= (:byte-offset a) (:byte-offset b))
+         (= (:byte-length a) (:byte-length b)))))
+
+(defn contiguous?
+  [view]
+  (let [{:keys [shape strides]} (validate-view! view)]
+    (= strides (dense-strides shape))))
+
+(defn subview
+  "Construct a view whose byte range is contained in `base`. Shape/strides describe the new
+   logical interpretation; `byte-offset` is relative to the base view."
+  [base {:keys [byte-offset] :as opts}]
+  (let [base (validate-view! base)
+        relative (long (or byte-offset 0))
+        child (view (:allocation base)
+                    (assoc opts :byte-offset (+ (:byte-offset base) relative)
+                           :dtype (or (:dtype opts) (:dtype base))))]
+    (when (or (neg? relative) (> (byte-end child) (byte-end base)))
+      (throw (ex-info "buffer subview exceeds its base view"
+                      {:base (:id base) :view (:id child)})))
+    child))

--- a/src/raster/gpu.clj
+++ b/src/raster/gpu.clj
@@ -41,8 +41,11 @@
 ;; ================================================================
 
 (import-vars raster.gpu.core
-             alloc! free-buffer!
+             alloc! register-buffer! free-buffer!
              upload! download
+             upload-range! download-range!
+             upload-ranges! download-ranges!
+             resident-buffer-view? buffer-view sub-buffer-view
              buffer sync-to-arrays!)
 
 ;; ================================================================

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -27,8 +27,10 @@
   (:refer-clojure :exclude [])
   (:require [clojure.string :as str]
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
+            [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.hardware :as hw]
             [raster.compiler.core.inference :as inf]
+            [raster.compiler.ir.buffer-view :as bview]
             [raster.compiler.ir.execution-plan :as execution]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-call :as kcall]
@@ -193,6 +195,28 @@
     (doseq [[_ buf] bufs]
       (free! buf))))
 
+(defn- allocation-contract
+  [device-id session-id key buffer ownership opts]
+  (let [backend (backend-type device-id)]
+    (bview/allocation
+     {:id (or (:allocation-id opts) [session-id key (random-uuid)])
+      :byte-size (:byte-size buffer)
+      :memory-space (or (:memory-space opts) (case backend :ze :shared :ocl :device))
+      :device device-id
+      :alignment (or (:alignment opts) 1)
+      :coherence (or (:coherence opts)
+                     (case backend :ze :host-coherent :ocl :explicit-transfer))
+      :ownership ownership})))
+
+(defn- free-session-buffers!
+  "Free only session-owned allocations. Borrowed/external registrations are detached, never
+   destroyed by Raster."
+  [buffers allocations device-id]
+  (let [free! (rt-resolve device-id "free-buffer!")]
+    (doseq [[key buffer] buffers
+            :when (= :owned (:ownership (get allocations key)))]
+      (free! buffer))))
+
 (defn- alloc-buffers-transactional
   "Allocate buffer specs one at a time and free the successful prefix on failure."
   [buffer-specs device-id]
@@ -291,6 +315,7 @@
            :arena-id  arena-id
            :kernels   {}       ;; {phase-key → [kernel-info ...]}
            :buffers   {}       ;; {buf-key → DeviceBuffer}
+           :allocations {}     ;; {buf-key → backend-neutral BufferAllocation}
            :programs  {}       ;; {program-key → bound resident program (see bind-program!)}
            :kernel-graphs {}    ;; {graph-key → bound emitted KernelGraph}
            :events {}           ;; {event-id → session-owned asynchronous completion}
@@ -312,7 +337,7 @@
       ;; Drain and release every event before tearing any of those resources down.
       (doseq [[_ {:keys [event]}] (:events @sess)]
         (release-event! sess event))
-      (let [{:keys [device-id arena-id buffers prepared graphs programs kernel-graphs]} @sess]
+      (let [{:keys [device-id arena-id buffers allocations prepared graphs programs kernel-graphs]} @sess]
         ;; backend-specific: the bound-dispatch + command-graph path is ze-only, so resolve the
         ;; destroyers nil-safely rather than via rt-resolve (which throws on backends lacking them).
         (let [ns-sym (case (backend-type device-id) :ze 'raster.gpu.ze-runtime :ocl 'raster.gpu.ocl-runtime)
@@ -335,10 +360,10 @@
                 (doseq [b (:scratch-buffers prog)] (try (free! b) (catch Exception _)))))))
         (doseq [[_ graph-entry] kernel-graphs]
           (destroy-kernel-graph-entry! device-id graph-entry))
-        (free-buffers-internal! buffers device-id)
+        (free-session-buffers! buffers allocations device-id)
         (let [close-arena! (rt-resolve device-id "close-kernel-arena!")]
           (close-arena! arena-id))
-        (swap! sess assoc :closed? true :buffers {} :kernels {} :prepared {} :graphs {}
+        (swap! sess assoc :closed? true :buffers {} :allocations {} :kernels {} :prepared {} :graphs {}
                :programs {} :kernel-graphs {} :events {})))))
 
 (defn with-gpu-session*
@@ -418,18 +443,81 @@
    Buffers are merged into the session — call multiple times to add more.
    If allocation fails partway through, already-allocated buffers are freed."
   [sess buffer-specs]
-  (let [device-id (:device-id @sess)
-        new-bufs (alloc-buffers-transactional buffer-specs device-id)]
-    (swap! sess update :buffers merge new-bufs)
-    new-bufs))
+  (locking sess
+    (let [{:keys [device-id session-id buffers closed?]} @sess
+          duplicate-keys (set (filter #(contains? buffers %) (keys buffer-specs)))]
+      (when closed?
+        (throw (ex-info "cannot allocate in a closed GPU session" {})))
+      (when (seq duplicate-keys)
+        (throw (ex-info "session buffer keys must identify one stable allocation lifetime"
+                        {:duplicate-keys duplicate-keys})))
+      (let [new-bufs (alloc-buffers-transactional buffer-specs device-id)]
+        (let [new-allocations
+              (try
+                (into {}
+                      (map (fn [[key buffer]]
+                             [key (allocation-contract device-id session-id key buffer :owned {})]))
+                      new-bufs)
+                (catch Exception e
+                  (free-buffers-internal! new-bufs device-id)
+                  (throw e)))]
+          (swap! sess (fn [state]
+                        (-> state
+                            (update :buffers merge new-bufs)
+                            (update :allocations merge new-allocations))))
+          new-bufs)))))
+
+(defn register-buffer!
+  "Register an existing backend buffer without taking ownership by default.
+
+   This is the safe zero-copy/import seam: callers must first obtain a buffer that the selected
+   backend can legally address (an arbitrary Panama MemorySegment is not necessarily GPU-visible).
+   `opts` may specify :ownership (:external or :borrowed), :memory-space, :coherence, :alignment,
+   and a stable :allocation-id. Raster never frees external/borrowed registrations."
+  ([sess key buffer] (register-buffer! sess key buffer {}))
+  ([sess key buffer opts]
+   (locking sess
+     (let [{:keys [device-id session-id buffers closed?]} @sess
+           ownership (or (:ownership opts) :external)
+           device-buffer? (rt-resolve device-id "device-buffer?")]
+       (when closed?
+         (throw (ex-info "cannot register a buffer in a closed GPU session" {:key key})))
+       (when (contains? buffers key)
+         (throw (ex-info "session buffer key already names a live allocation" {:key key})))
+       (when-not (contains? #{:external :borrowed} ownership)
+         (throw (ex-info "registered buffers must remain caller-owned"
+                         {:key key :ownership ownership})))
+       (when-not (device-buffer? buffer)
+         (throw (ex-info "registered value is not a buffer for this session backend"
+                         {:key key :device-id device-id :actual (type buffer)})))
+       (let [allocation (allocation-contract device-id session-id key buffer ownership opts)]
+         (swap! sess (fn [state]
+                       (-> state
+                           (assoc-in [:buffers key] buffer)
+                           (assoc-in [:allocations key] allocation))))
+         buffer)))))
 
 (defn free-buffer!
-  "Free a specific buffer from the session by key."
+  "Release a specific buffer registration. Raster frees it only when the allocation is owned."
   [sess key]
-  (let [{:keys [device-id buffers]} @sess]
-    (when-let [buf (get buffers key)]
-      ((rt-resolve device-id "free-buffer!") buf)
-      (swap! sess update :buffers dissoc key))))
+  (locking sess
+    (let [{:keys [device-id buffers allocations kernel-graphs]} @sess
+          bound-graphs (->> kernel-graphs
+                            (keep (fn [[graph-key entry]]
+                                    (when (some #(= key (:key %))
+                                                (vals (:resident-views entry)))
+                                      graph-key)))
+                            vec)]
+      (when-let [buf (get buffers key)]
+        (when (seq bound-graphs)
+          (throw (ex-info "cannot release a buffer while a kernel graph holds one of its views"
+                          {:key key :kernel-graphs bound-graphs})))
+        (when (= :owned (:ownership (get allocations key)))
+          ((rt-resolve device-id "free-buffer!") buf))
+        (swap! sess (fn [state]
+                      (-> state
+                          (update :buffers dissoc key)
+                          (update :allocations dissoc key))))))))
 
 ;; ================================================================
 ;; Buffer argument resolution
@@ -641,11 +729,107 @@
                                 {:available (keys buffers)})))]
     ((rt-resolve device-id "buffer->array") buf)))
 
-(defn- session-buffer
-  [sess key]
-  (let [{:keys [buffers]} @sess]
-    (or (get buffers key)
-        (throw (ex-info (str "No buffer for key: " key) {:available (keys buffers)})))))
+(defrecord ResidentBufferView [session-id key view])
+
+(defn resident-buffer-view?
+  [x]
+  (and x (= "raster.gpu.core.ResidentBufferView" (.getName (class x)))))
+
+(defn- checked-resident-view
+  [sess resident]
+  (when-not (resident-buffer-view? resident)
+    (throw (ex-info "expected a ResidentBufferView" {:value resident :actual (type resident)})))
+  (let [{current-session :session-id buffers :buffers allocations :allocations closed? :closed?} @sess
+        key (:key resident)
+        current-allocation (get allocations key)]
+    (when closed?
+      (throw (ex-info "cannot use a buffer view from a closed GPU session" {:key key})))
+    (when-not (= current-session (:session-id resident))
+      (throw (ex-info "buffer view belongs to a different GPU session"
+                      {:key key :expected current-session :actual (:session-id resident)})))
+    (when-not (and (contains? buffers key)
+                   current-allocation
+                   (= (:id current-allocation) (get-in resident [:view :allocation :id])))
+      (throw (ex-info "buffer view no longer names its original live allocation"
+                      {:key key :allocation (get-in resident [:view :allocation :id])})))
+    (bview/validate-view! (:view resident))
+    resident))
+
+(defn buffer-view
+  "Return a stable checked view of a session allocation.
+
+   With no opts this is the whole flat buffer. Options describe a typed view and accept
+   :byte-offset, :shape, :strides, and :id. Shape defaults to the remaining one-dimensional
+   capacity. Byte offsets are relative to the allocation, and all bounds are checked now."
+  ([sess key] (buffer-view sess key {}))
+  ([sess key opts]
+   (let [{:keys [session-id buffers allocations closed?]} @sess
+         buffer (get buffers key)
+         allocation (get allocations key)]
+     (when closed?
+       (throw (ex-info "cannot create a buffer view in a closed GPU session" {:key key})))
+     (when-not (and buffer allocation)
+       (throw (ex-info (str "No buffer for key: " key " (or no live allocation contract)")
+                       {:key key :available (keys buffers)})))
+     (let [view-dtype (or (:dtype opts) (:dtype buffer))
+           byte-offset (long (or (:byte-offset opts) 0))
+           element-bytes (long (dtype/bytes-of view-dtype))
+           remaining (- (:byte-size allocation) byte-offset)
+           _ (when (or (neg? byte-offset) (neg? remaining)
+                       (not (zero? (mod remaining element-bytes))))
+               (throw (ex-info "buffer view offset leaves no integral typed capacity"
+                               {:key key :byte-offset byte-offset :dtype view-dtype
+                                :allocation-bytes (:byte-size allocation)})))
+           shape (or (:shape opts) [(quot remaining element-bytes)])
+           descriptor (bview/view allocation
+                                  (assoc opts :byte-offset byte-offset
+                                         :dtype view-dtype
+                                         :shape shape))]
+       (->ResidentBufferView session-id key descriptor)))))
+
+(defn sub-buffer-view
+  "Create a checked resident view contained by `base`; :byte-offset is relative to `base`."
+  [sess base opts]
+  (let [base (checked-resident-view sess base)]
+    (->ResidentBufferView (:session-id base) (:key base)
+                          (bview/subview (:view base) opts))))
+
+(defn- resolve-resident-binding
+  [sess key-or-view]
+  (let [resident (if (resident-buffer-view? key-or-view)
+                   (checked-resident-view sess key-or-view)
+                   (buffer-view sess key-or-view))]
+    {:buffer (get-in @sess [:buffers (:key resident)])
+     :resident resident
+     :view (:view resident)}))
+
+(defn- checked-view-range-spec
+  [buffer view spec direction]
+  (let [view (bview/validate-view! view)
+        raw-dtype (dtype/canon (:dtype buffer))
+        view-dtype (dtype/canon (:dtype view))
+        element-bytes (long (dtype/bytes-of raw-dtype))
+        buffer-field (case direction :upload :dst-element :download :src-element)
+        relative (long (get spec buffer-field 0))
+        elements (:elements spec)
+        capacity (quot (:byte-length view) element-bytes)]
+    (when-not (= raw-dtype view-dtype)
+      (throw (ex-info "ranged transfers cannot reinterpret a resident view's storage dtype"
+                      {:buffer-dtype raw-dtype :view-dtype view-dtype})))
+    (when-not (bview/contiguous? view)
+      (throw (ex-info "ranged transfers require a contiguous resident view"
+                      {:view (:id view) :shape (:shape view) :strides (:strides view)})))
+    (when-not (and (integer? elements) (not (neg? elements)))
+      (throw (ex-info "ranged transfer requires a non-negative integer element count"
+                      {:elements elements})))
+    (when (neg? relative)
+      (throw (ex-info "ranged transfer has a negative buffer-view offset"
+                      {:view (:id view) :offset relative :elements elements})))
+    (when (> (+ relative elements) capacity)
+      (throw (ex-info "ranged transfer exceeds the buffer view"
+                      {:view (:id view) :offset relative :elements elements
+                       :view-elements capacity})))
+    (assoc spec buffer-field (+ (quot (:byte-offset view) element-bytes) relative))))
 
 (defn upload-range!
   "Copy a SUB-RANGE of a host array or MemorySegment into a session buffer.
@@ -659,14 +843,18 @@
    Why this exists: `upload!`/`download` move the WHOLE buffer. A KV cache is allocated at
    `maxpos` positions and position-major, so a continuation of `t` tokens is one contiguous
    prefix — exporting it should move `t` rows, not `maxpos`."
-  [sess key src spec]
-  ((rt-resolve (:device-id @sess) "upload-range!") (session-buffer sess key) src spec))
+  [sess key-or-view src spec]
+  (let [{:keys [buffer view]} (resolve-resident-binding sess key-or-view)
+        spec (checked-view-range-spec buffer view spec :upload)]
+    ((rt-resolve (:device-id @sess) "upload-range!") buffer src spec)))
 
 (defn download-range!
   "Copy a SUB-RANGE of a session buffer into a host array or MemorySegment; mirror of
    `upload-range!`. Returns `dst`."
-  [sess key dst spec]
-  ((rt-resolve (:device-id @sess) "download-range!") (session-buffer sess key) dst spec))
+  [sess key-or-view dst spec]
+  (let [{:keys [buffer view]} (resolve-resident-binding sess key-or-view)
+        spec (checked-view-range-spec buffer view spec :download)]
+    ((rt-resolve (:device-id @sess) "download-range!") buffer dst spec)))
 
 (defn- transfer-ranges!
   "The batched core. VALIDATES EVERY entry (`plan-range`) before EXECUTING ANY. A batch is how a
@@ -680,9 +868,10 @@
         plan (rt-resolve device-id "plan-range")
         exec (rt-resolve device-id "execute-range!")
         ;; phase 1: resolve + validate everything, collecting plans in order
-        plans (mapv (fn [[key host spec]]
-                      (let [buf (session-buffer sess key)]
-                        [buf (plan buf host spec direction) host]))
+        plans (mapv (fn [[key-or-view host spec]]
+                      (let [{:keys [buffer view]} (resolve-resident-binding sess key-or-view)
+                            spec (checked-view-range-spec buffer view spec direction)]
+                        [buffer (plan buffer host spec direction) host]))
                     entries)]
     ;; phase 2: execute in order
     (mapv (fn [[buf p host]] (exec buf p direction) (if (= :upload direction) buf host)) plans)))
@@ -728,6 +917,95 @@
 (defn- external-graph-buffer-ids
   [graph]
   (set (map :id (concat (:inputs graph) (:outputs graph)))))
+
+(defn- write-access?
+  [access]
+  (contains? #{:write :read-write} access))
+
+(defn- resolve-graph-elements
+  [scalar-values expression]
+  (let [bound (get scalar-values expression ::not-bound)
+        value (if (= ::not-bound bound)
+                (kgcall/resolve-integer scalar-values expression)
+                (if (and (map? bound) (contains? bound :value)) (:value bound) bound))]
+    (when-not (and (integer? value) (not (neg? value)))
+      (throw (ex-info "kernel graph buffer extent must resolve to a non-negative integer"
+                      {:expression expression :resolved value})))
+    (long value)))
+
+(defn- validate-external-view!
+  [graph-buffer view scalar-values]
+  (let [view (bview/validate-view! view)
+        expected-dtype (dtype/canon (:dtype graph-buffer))
+        actual-dtype (dtype/canon (:dtype view))
+        expected-elements (when (some? (:elements graph-buffer))
+                            (resolve-graph-elements scalar-values (:elements graph-buffer)))
+        capacity (quot (:byte-length view) (dtype/bytes-of actual-dtype))]
+    (when-not (= expected-dtype actual-dtype)
+      (throw (ex-info "kernel graph buffer dtype differs from its resident view"
+                      {:graph-buffer (:id graph-buffer) :expected expected-dtype
+                       :actual actual-dtype :view (:id view)})))
+    (when (and expected-elements (> expected-elements capacity))
+      (throw (ex-info "kernel graph buffer extent exceeds its resident view"
+                      {:graph-buffer (:id graph-buffer) :elements expected-elements
+                       :view-elements capacity :view (:id view)})))
+    (when-not (bview/contiguous? view)
+      (throw (ex-info "kernel ABI binding currently requires a contiguous resident view"
+                      {:graph-buffer (:id graph-buffer) :view (:id view)
+                       :shape (:shape view) :strides (:strides view)})))
+    view))
+
+(defn- node-physical-hazard?
+  [external-bindings earlier later]
+  (boolean
+   (some (fn [earlier-use]
+           (some (fn [later-use]
+                   (let [earlier-view (get-in external-bindings [(:buffer earlier-use) :view])
+                         later-view (get-in external-bindings [(:buffer later-use) :view])]
+                     (and earlier-view later-view
+                          (bview/overlaps? earlier-view later-view)
+                          (or (write-access? (:access earlier-use))
+                              (write-access? (:access later-use))))))
+                 (:uses later)))
+         (:uses earlier))))
+
+(defn- validate-physical-aliases!
+  "Prove hazards introduced when distinct graph identities are bound to overlapping views. The
+   symbolic graph validator cannot see these aliases, so binding must reject same-kernel writable
+   aliases and require the same explicit dependency rule across kernels."
+  [graph external-bindings]
+  (doseq [node (:nodes graph)
+          [index left] (map-indexed vector (:uses node))
+          right (drop (inc index) (:uses node))]
+    (let [left-view (get-in external-bindings [(:buffer left) :view])
+          right-view (get-in external-bindings [(:buffer right) :view])]
+      (when (and left-view right-view
+                 (bview/overlaps? left-view right-view)
+                 (or (write-access? (:access left)) (write-access? (:access right))))
+        (throw (ex-info "one kernel cannot bind overlapping writable graph buffer views"
+                        {:node (:id node) :left (:buffer left) :right (:buffer right)})))))
+  (doseq [[later-index later] (map-indexed vector (:nodes graph))
+          earlier (take later-index (:nodes graph))
+          :when (node-physical-hazard? external-bindings earlier later)
+          :when (not (contains? (set (:dependencies later)) (:id earlier)))]
+    (throw (ex-info "kernel graph omits a dependency introduced by overlapping resident views"
+                    {:node (:id later) :missing (:id earlier)})))
+  external-bindings)
+
+(defn- runtime-buffer-for-view
+  [device-id buffer view]
+  (let [raw-dtype (dtype/canon (:dtype buffer))
+        view-dtype (dtype/canon (:dtype view))]
+    (when-not (= raw-dtype view-dtype)
+      (throw (ex-info "kernel ABI cannot reinterpret a resident buffer dtype"
+                      {:buffer-dtype raw-dtype :view-dtype view-dtype :view (:id view)})))
+    (if (zero? (:byte-offset view))
+      buffer
+      (case (backend-type device-id)
+        :ze ((rt-resolve device-id "slice-buffer") buffer (:byte-offset view)
+                                                   (:byte-length view) view-dtype)
+        :ocl (throw (ex-info "OpenCL non-zero-offset kernel views require a legal cl_mem sub-buffer"
+                             {:view (:id view) :byte-offset (:byte-offset view)}))))))
 
 (defn- resolve-kernel-graph-entry
   [sess handle]
@@ -810,17 +1088,17 @@
 (defn bind-kernel-graph!
   "Bind an emitted KernelGraph for repeated resident execution.
 
-   `buffer-keys` maps every external GraphBuffer identity to an existing session-buffer key.
-   Distinct graph identities may not alias one session key until stable BufferView/range analysis
-   exists. `scalar-values` maps symbolic compiler values to explicitly typed runtime scalars, e.g.
-   `{'n {:type :int :value 4096}}`.
+   `buffer-keys` maps every external GraphBuffer identity to an existing session-buffer key or a
+   ResidentBufferView. Distinct graph identities may share an allocation when their physical
+   ranges and declared accesses are legal. `scalar-values` maps symbolic compiler values to
+   explicitly typed runtime scalars, e.g. `{'n {:type :int :value 4096}}`.
 
    The graph owns its temporary allocations and dedicated bound kernel handles. Binding validates
    the complete graph call, lowers dependencies to logical queue/event edges, then records a
    conservative dependency-safe sequence. Current backends map the logical plan to one in-order
    compute queue; submit-kernel-graph! exposes asynchronous completion without native handles."
   [sess graph-key graph buffer-keys scalar-values]
-  (let [{:keys [device-id buffers closed?]} @sess
+  (let [{:keys [device-id closed?]} @sess
         graph (kgraph/validate! graph)
         external-ids (external-graph-buffer-ids graph)]
     (when closed?
@@ -828,18 +1106,20 @@
     (when-not (= external-ids (set (keys buffer-keys)))
       (throw (ex-info "kernel graph external bindings differ from graph inputs/outputs"
                       {:expected external-ids :bound (set (keys buffer-keys))})))
-    (when-not (= (count (vals buffer-keys)) (count (set (vals buffer-keys))))
-      (throw (ex-info "distinct graph buffers cannot alias before BufferView range analysis"
-                      {:buffer-keys buffer-keys})))
-    (release-graph-events! sess graph-key)
-    (let [external-buffers
-          (into {}
-                (map (fn [[id key]]
-                       [id (or (get buffers key)
-                               (throw (ex-info "kernel graph external session buffer is missing"
-                                               {:graph-buffer id :session-key key
-                                                :available (keys buffers)})))]))
-                buffer-keys)
+    (let [graph-buffer-by-id (into {} (map (juxt :id identity))
+                                   (concat (:inputs graph) (:outputs graph)))
+          external-bindings (into {}
+                                  (map (fn [[id key-or-view]]
+                                         [id (resolve-resident-binding sess key-or-view)]))
+                                  buffer-keys)
+          _ (doseq [[id {:keys [view]}] external-bindings]
+              (validate-external-view! (get graph-buffer-by-id id) view scalar-values))
+          _ (validate-physical-aliases! graph external-bindings)
+          external-buffers (into {}
+                                 (map (fn [[id {:keys [buffer view]}]]
+                                        [id (runtime-buffer-for-view device-id buffer view)]))
+                                 external-bindings)
+          _ (release-graph-events! sess graph-key)
           temporary-specs (kgcall/temporary-specs graph scalar-values)
           temporary-buffers (alloc-buffers-transactional temporary-specs device-id)
           all-buffers (merge external-buffers temporary-buffers)
@@ -868,6 +1148,9 @@
                        :prepareds @prepareds
                        :temporary-buffers temporary-buffers
                        :buffer-keys buffer-keys
+                       :resident-views (into {} (map (fn [[id binding]]
+                                                       [id (:resident binding)]))
+                                             external-bindings)
                        :outputs (select-keys all-buffers (map :id (:outputs graph)))}
                 old (get-in @sess [:kernel-graphs graph-key])]
             (swap! sess assoc-in [:kernel-graphs graph-key] entry)

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -811,6 +811,26 @@
   [^DeviceBuffer buf]
   (make-buffer (:n-elements buf) (:dtype buf)))
 
+(defn slice-buffer
+  "Create a non-owning typed pointer view into a DeviceBuffer. The returned record must never be
+   freed independently: its MemorySegment is a slice of the base allocation and exists only for
+   ABI binding. Bounds and dtype alignment are established by the backend-neutral BufferView."
+  [^DeviceBuffer buf byte-offset byte-length dtype]
+  (let [byte-offset (long byte-offset)
+        byte-length (long byte-length)
+        element-size (get dtype-byte-sizes dtype)]
+    (when-not element-size
+      (throw (ex-info "cannot slice a Level Zero buffer with an unknown dtype" {:dtype dtype})))
+    (let [element-bytes (long element-size)]
+      (when (or (neg? byte-offset) (neg? byte-length)
+                (> (+ byte-offset byte-length) (:byte-size buf))
+                (not (zero? (mod byte-length element-bytes))))
+        (throw (ex-info "Level Zero buffer slice is out of bounds or misaligned"
+                        {:byte-offset byte-offset :byte-length byte-length
+                         :buffer-bytes (:byte-size buf) :dtype dtype})))
+      (->DeviceBuffer (.asSlice ^MemorySegment (:segment buf) byte-offset byte-length)
+                      (quot byte-length element-bytes) byte-length dtype))))
+
 (defn free-buffer!
   "Free a DeviceBuffer's GPU memory."
   [^DeviceBuffer buf]

--- a/test/raster/compiler/ir/buffer_view_test.clj
+++ b/test/raster/compiler/ir/buffer_view_test.clj
@@ -1,0 +1,45 @@
+(ns raster.compiler.ir.buffer-view-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.buffer-view :as view]))
+
+(def allocation
+  (view/allocation {:id :kv-cache :byte-size 4096 :memory-space :device
+                    :device :ze:0 :alignment 64 :coherence :host-coherent
+                    :ownership :owned}))
+
+(deftest shaped-views-have-stable-byte-ranges
+  (let [whole (view/view allocation {:id :whole :dtype :float :shape [16 64]})
+        prefix (view/subview whole {:id :prefix :dtype :float :shape [4 64]})
+        tail (view/subview whole {:id :tail :byte-offset (* 4 4 64)
+                                  :shape [12 64]})]
+    (is (= [64 1] (:strides whole)))
+    (is (= 4096 (:byte-length whole)))
+    (is (view/overlaps? whole prefix))
+    (is (view/disjoint? prefix tail))
+    (is (view/contiguous? prefix))
+    (is (view/same-range? whole
+                          (view/view allocation {:id :other-name :dtype :float
+                                                 :shape [1024]})))))
+
+(deftest strided-views-state-their-physical-span
+  (let [columns (view/view allocation {:id :columns :dtype :float
+                                       :shape [4 8] :strides [64 2]})]
+    (is (= (* 4 (inc (+ (* 3 64) (* 7 2)))) (:byte-length columns)))
+    (is (not (view/contiguous? columns)))))
+
+(deftest views-fail-loud-on-invalid-physical-claims
+  (testing "shape is never inferred implicitly in the physical IR"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"explicit realized shape"
+                          (view/view allocation {:dtype :float}))))
+  (testing "shape cannot exceed allocation"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"exceeds its allocation"
+                          (view/view allocation {:dtype :float :shape [1025]}))))
+  (testing "byte length cannot contradict shape and strides"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"differs"
+                          (view/view allocation {:dtype :float :shape [4]
+                                                 :byte-length 12}))))
+  (testing "subviews are contained by their base, not merely by the allocation"
+    (let [prefix (view/view allocation {:id :prefix :dtype :float :shape [16]})]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"exceeds its base"
+                            (view/subview prefix {:byte-offset 32 :dtype :float
+                                                  :shape [16]}))))))

--- a/test/raster/gpu/buffer_view_test.clj
+++ b/test/raster/gpu/buffer_view_test.clj
@@ -1,0 +1,83 @@
+(ns raster.gpu.buffer-view-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.buffer-view :as bview]
+            [raster.compiler.ir.kernel-graph :as kgraph]
+            [raster.gpu.core :as gpu]))
+
+(defn- allocation [id bytes ownership]
+  (bview/allocation {:id id :byte-size bytes :memory-space :shared :device :ze:0
+                     :coherence :host-coherent :ownership ownership}))
+
+(defn- mock-session [buffer allocation]
+  (atom {:device-id :ze:0 :session-id :session :buffers {:cache buffer}
+         :allocations {:cache allocation} :kernel-graphs {} :events {} :closed? false}))
+
+(deftest resident-views-translate-ranges-and-expire-with-the-allocation
+  (let [buffer {:dtype :float :n-elements 16 :byte-size 64}
+        sess (mock-session buffer (allocation :cache-v1 64 :owned))
+        uploaded (atom nil)
+        resolver (fn [_ name]
+                   (case name
+                     "upload-range!" (fn [actual _ spec]
+                                       (reset! uploaded [actual spec])
+                                       actual)
+                     "free-buffer!" (fn [_])
+                     (throw (ex-info "unexpected runtime function" {:name name}))))]
+    (with-redefs-fn
+      {(ns-resolve 'raster.gpu.core 'rt-resolve) resolver}
+      (fn []
+        (let [middle (gpu/buffer-view sess :cache {:byte-offset 16 :shape [8]})]
+          (is (gpu/resident-buffer-view? middle))
+          (gpu/upload-range! sess middle (float-array 2)
+                             {:src-element 0 :dst-element 1 :elements 2})
+          (is (= [buffer {:src-element 0 :dst-element 5 :elements 2}] @uploaded))
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"exceeds the buffer view"
+                                (gpu/upload-range! sess middle (float-array 2)
+                                                   {:dst-element 7 :elements 2})))
+          (gpu/free-buffer! sess :cache)
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"no longer names"
+                                (gpu/sub-buffer-view sess middle
+                                                     {:dtype :float :shape [1]}))))))))
+
+(deftest external-registrations-are-never-freed-by-raster
+  (let [buffer {:dtype :float :n-elements 4 :byte-size 16}
+        sess (atom {:device-id :ze:0 :session-id :session :buffers {} :allocations {}
+                    :closed? false})
+        freed (atom [])
+        resolver (fn [_ name]
+                   (case name
+                     "device-buffer?" map?
+                     "free-buffer!" #(swap! freed conj %)
+                     (throw (ex-info "unexpected runtime function" {:name name}))))]
+    (with-redefs-fn
+      {(ns-resolve 'raster.gpu.core 'rt-resolve) resolver}
+      (fn []
+        (gpu/register-buffer! sess :foreign buffer {:allocation-id :foreign-allocation})
+        (is (= :external (get-in @sess [:allocations :foreign :ownership])))
+        (gpu/free-buffer! sess :foreign)
+        (is (empty? @freed))
+        (is (empty? (:buffers @sess)))))))
+
+(deftest physical-aliases-use-ranges-and-scheduled-accesses
+  (let [allocation (allocation :shared 64 :owned)
+        left (bview/view allocation {:id :left :dtype :float :shape [8]})
+        right (bview/view allocation {:id :right :byte-offset 32 :dtype :float :shape [8]})
+        overlap (bview/view allocation {:id :overlap :byte-offset 16 :dtype :float :shape [8]})
+        use (fn [id access] (kgraph/->ValueUse id access))
+        node (fn [id uses deps] (kgraph/->ScheduledKernel id :mock uses deps))
+        validate! (ns-resolve 'raster.gpu.core 'validate-physical-aliases!)]
+    (testing "disjoint views of one allocation are legal"
+      (is (map? (validate! {:nodes [(node :one [(use :a :read) (use :b :write)] [])]}
+                           {:a {:view left} :b {:view right}}))))
+    (testing "one kernel cannot receive contradictory overlapping writable identities"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"overlapping writable"
+                            (validate! {:nodes [(node :one [(use :a :read) (use :b :write)] [])]}
+                                       {:a {:view left} :b {:view overlap}}))))
+    (testing "an alias-induced cross-kernel hazard needs an edge"
+      (let [first-node (node :first [(use :a :write)] [])
+            unsafe (node :second [(use :b :read)] [])
+            safe (assoc unsafe :dependencies [:first])
+            bindings {:a {:view left} :b {:view overlap}}]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"omits a dependency"
+                              (validate! {:nodes [first-node unsafe]} bindings)))
+        (is (map? (validate! {:nodes [first-node safe]} bindings)))))))

--- a/test/raster/gpu/kernel_graph_device_test.clj
+++ b/test/raster/gpu/kernel_graph_device_test.clj
@@ -59,6 +59,31 @@
     (gp/gpu-skip! "Level Zero KernelGraph inclusive scan")
     (assert-prefix! :ze:0)))
 
+(deftest level-zero-kernel-graph-binds-disjoint-views-of-one-allocation
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "Level Zero KernelGraph BufferView aliases")
+    (let [n 1025
+          graph (emitted-graph)
+          storage (float-array (* 2 n))]
+      (dotimes [i n] (aset storage i 1.0))
+      (gpu/with-gpu-session [sess :ze:0]
+        (gpu/alloc! sess {:storage [:float (* 2 n) storage]})
+        (let [input (gpu/buffer-view sess :storage {:shape [n]})
+              output (gpu/buffer-view sess :storage {:byte-offset (* 4 n) :shape [n]})
+              handle (gpu/bind-kernel-graph!
+                      sess :view-scan graph {'values input 'out output}
+                      {'n {:type :int :value n}})]
+          (try
+            (gpu/run-kernel-graph! sess handle)
+            (let [result (float-array n)]
+              (gpu/download-range! sess output result {:elements n})
+              (is (= 1025.0 (double (aget result 1024))))
+              (is (every? true?
+                          (map-indexed (fn [i value] (= (double (inc i)) (double value)))
+                                       result))))
+            (finally
+              (gpu/release-kernel-graph! sess handle))))))))
+
 (deftest opencl-kernel-graph-inclusive-scan
   (if-not @ocl-available?
     (is true "OpenCL device unavailable")

--- a/test/raster/gpu/kernel_graph_runner_test.clj
+++ b/test/raster/gpu/kernel_graph_runner_test.clj
@@ -1,6 +1,7 @@
 (ns raster.gpu.kernel-graph-runner-test
   (:require [clojure.test :refer [deftest is]]
             [raster.compiler.backend.gpu.segop-opencl :as emit]
+            [raster.compiler.ir.buffer-view :as bview]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.soac-lower :as lower]
             [raster.gpu.core :as gpu]
@@ -41,8 +42,12 @@
 
 (deftest session-runner-owns-only-graph-temporaries-and-bound-driver-objects
   (let [graph (emitted-graph)
-        values-buffer (Object.)
-        output-buffer (Object.)
+        values-buffer {:dtype :float :n-elements 1025 :byte-size 4100}
+        output-buffer {:dtype :float :n-elements 1025 :byte-size 4100}
+        allocation (fn [id]
+                     (bview/allocation {:id id :byte-size 4100 :memory-space :shared
+                                        :device :ze:0 :coherence :host-coherent
+                                        :ownership :owned}))
         registered (atom [])
         bound (atom [])
         recorded (atom [])
@@ -55,6 +60,8 @@
         sess (atom {:device-id :ze:0
                     :session-id :test-session
                     :buffers {:values values-buffer :out output-buffer}
+                    :allocations {:values (allocation :values-allocation)
+                                  :out (allocation :out-allocation)}
                     :kernel-graphs {}
                     :events {}
                     :closed? false})

--- a/test/raster/gpu/range_transfer_test.clj
+++ b/test/raster/gpu/range_transfer_test.clj
@@ -25,11 +25,10 @@
   "A session whose :kc0 buffer holds value=index at every element, so any disturbance is visible."
   [f]
   (let [s (g/make-session :ze:0)
-        ze (find-ns 'raster.gpu.ze-runtime)
-        buf ((ns-resolve ze 'make-buffer) N :float)]
+        a (float-array N)]
     (try
-      (swap! s assoc-in [:buffers :kc0] buf)
-      (let [a (float-array N)] (dotimes [i N] (aset a i (float i))) (g/upload! s :kc0 a))
+      (dotimes [i N] (aset a i (float i)))
+      (g/alloc! s {:kc0 [:float N a]})
       (f s)
       (finally (g/close-session! s)))))
 
@@ -65,6 +64,21 @@
                 (is (region-is-identity? back 0 at) "positions before the import")
                 (is (region-is-identity? back (+ at n) N) "positions after the import")))
             (finally (.close arena))))))))
+
+(deftest a-resident-view-makes-range-offsets-relative
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "ranged transfers: resident view")
+    (with-filled-session
+      (fn [s]
+        (let [at (* 64 kvrow)
+              n (* 8 kvrow)
+              view (g/buffer-view s :kc0 {:byte-offset (* 4 at) :shape [n]})
+              out (float-array n)]
+          (g/download-range! s view out {:elements n})
+          (is (every? (fn [i] (== (aget out i) (float (+ at i)))) (range n)))
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"exceeds the buffer view"
+                                (g/download-range! s view out
+                                                   {:src-element (dec n) :elements 2}))))))))
 
 (deftest a-jvm-array-and-a-memory-segment-take-the-same-path
   (if-not @gp/gpu-available?
@@ -125,15 +139,13 @@
   "A session with `layers` kc/vc pairs, each holding value = (layer-tag + index) so a write to the
    wrong layer is as visible as a write to the wrong position."
   [layers f]
-  (let [s (g/make-session :ze:0)
-        make (ns-resolve (find-ns 'raster.gpu.ze-runtime) 'make-buffer)]
+  (let [s (g/make-session :ze:0)]
     (try
       (doseq [l (range layers) kind ["kc" "vc"]]
         (let [k (keyword (str kind l)) tag (float (* 1e6 (+ 1 (* 2 l) (if (= kind "vc") 1 0))))
               a (float-array N)]
           (dotimes [i N] (aset a i (+ tag (float i))))
-          (swap! s assoc-in [:buffers k] (make N :float))
-          (g/upload! s k a)))
+          (g/alloc! s {k [:float N a]})))
       (f s)
       (finally (g/close-session! s)))))
 


### PR DESCRIPTION
## Summary

- add backend-neutral BufferAllocation and BufferView IR with checked dtype, shape, strides, byte ranges, placement, coherence, and ownership
- give session allocations stable identities; support external or borrowed backend-buffer registration without taking ownership; reject stale views and live-key replacement
- make ranged and batched transfers relative to resident views while preserving validate-all-before-copy behavior
- bind KernelGraphs through views and validate physical overlap hazards from scheduled read and write uses
- bind nonzero Level Zero views as non-owning sliced USM pointers; fail loudly on OpenCL until legal cl_mem sub-buffer lifetime and alignment are implemented

## Verification

- focused and live gate: 23 tests, 158 assertions, zero failures and errors
- includes exact 1,025-element Level Zero scan with input and output as disjoint views of one allocation
- existing OpenCL and Level Zero graph scan, ranged Panama transfer, ownership, and Compiled or DeviceArray regressions pass
- changed files pass cljfmt and git diff check

A local full-suite attempt reached the existing read-only sandbox home cache error under ~/.raster/spirv-cache. CircleCI runs the same test command with a writable home.