### PR TITLE
Unify device values with buffer views

### DIFF
--- a/src/raster/gpu/compiled.clj
+++ b/src/raster/gpu/compiled.clj
@@ -21,9 +21,10 @@
    here hardcodes `:ze`."
   (:refer-clojure :exclude [compile])
   (:require [clojure.set :as set]
+            [raster.compiler.ir.buffer-view :as bview]
+            [raster.compiler.pipeline :as pl]
             [raster.gpu.core :as gpu]
-            [raster.gpu.value :as v]
-            [raster.compiler.pipeline :as pl]))
+            [raster.gpu.value :as v]))
 
 (declare invoke-compiled)
 
@@ -171,7 +172,10 @@
   (let [k   (gpu/resident-key session handle sym)
         buf (gpu/buffer session k)]
     (cond
-      buf (v/wrap-external buf target (or dtype (:dtype buf)) (or shape [(:n-elements buf)]))
+      buf (let [view (gpu/buffer-view session k
+                                      {:dtype (or dtype (:dtype buf))
+                                       :shape (or shape [(:n-elements buf)])})]
+            (v/wrap-external-view buf target (:view view)))
       (= from :result) nil   ;; documented Void/map-void result — no resident buffer to project
       :else (throw (ex-info (str "invoke: requested output node " key " (" from ") resolved to no "
                                  "resident buffer (key " k ") — the graph did not produce it")
@@ -208,13 +212,19 @@
             (when-let [val (get inputs k)]
               (when (v/device-array? val)
                 (let [s    (get key->sym k)
-                      rbuf (gpu/buffer session (gpu/resident-key session handle s))
-                      node (get in-nodes k)]
-                  (when-not (identical? (:buffer val) rbuf)
+                      resident-key (gpu/resident-key session handle s)
+                      rbuf (gpu/buffer session resident-key)
+                      node (get in-nodes k)
+                      resident-view (gpu/buffer-view
+                                     session resident-key
+                                     {:dtype (or (:dtype node) (:dtype rbuf))
+                                      :shape (or (:shape node) [(:n-elements rbuf)])})]
+                  (when-not (and (identical? (:buffer val) rbuf)
+                                 (bview/same-range? (:view val) (:view resident-view)))
                     (throw (ex-info (str "invoke: donated input " k " is not this artifact's resident "
-                                         "value — the MVP only supports threading the artifact's own "
-                                         "output back into its donated slot; uploading a foreign "
-                                         "device value needs a rebind that is not yet wired")
+                                         "view — the MVP only supports threading the artifact's exact "
+                                         "output view back into its donated slot; a foreign allocation "
+                                         "or subview needs an explicit rebind")
                                     {:key k})))
                   (when (and node (:shape node) (:shape val) (not= (:shape node) (:shape val)))
                     (throw (ex-info (str "invoke: donated input " k " shape " (:shape val)

--- a/src/raster/gpu/value.clj
+++ b/src/raster/gpu/value.clj
@@ -2,9 +2,10 @@
   "The device-value type — `DeviceArray`, a `jax.Array` analogue (S4 §1).
 
    A `DeviceArray` is a first-class value that *is* device residency: it wraps a
-   backend `DeviceBuffer` (ze_runtime/DeviceBuffer or ocl equivalent) and adds the
-   three things a *value* needs that the byte-storage buffer lacks — WHICH device it
-   lives on, its logical SHAPE, and an OWNERSHIP/lifetime discipline. This is the
+   backend `DeviceBuffer` (ze_runtime/DeviceBuffer or ocl equivalent) and a canonical
+   backend-neutral `BufferView`: stable allocation identity, exact checked byte range,
+   logical shape/strides, dtype, and memory properties. It also adds the ownership and
+   lifetime discipline a byte-storage buffer lacks. This is the
    prerequisite for functional artifact invocation (values-in / values-out) and for
    donation-as-residency: without a device value, `:donate` is just today's `:state`
    plus a per-step host copy (the design's C2 finding).
@@ -12,9 +13,6 @@
    Ownership (`owner` field), the lifetime discipline:
      ::owned    — raster allocated it; freed on `free!`, session-close, or GC (Cleaner
                   safety net). The only kind reclaim frees.
-     ::donated  — ownership was transferred INTO a `step` call; the value is marked
-                  consumed (freed? = true) and its buffer now belongs to an output
-                  value. Reads throw; its Cleaner is disarmed (never frees the buffer).
      ::aliased  — a view onto another value's buffer (a KV-cache slice). Never frees on
                   reclaim; the base owner does.
      ::external — wraps a buffer raster did not allocate. Never freed by raster.
@@ -24,6 +22,8 @@
    on the runtime records, never on the session layer — this ns sits at the bottom of
    the GPU dependency graph so `raster.gpu.compiled` / `raster.gpu.core` can build on it
    without a cycle."
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.buffer-view :as bview])
   (:import [java.lang.ref Cleaner]
            [java.util.concurrent.atomic AtomicBoolean]))
 
@@ -57,14 +57,14 @@
 (def ^:private ^Cleaner cleaner (Cleaner/create))
 
 (defn- arm-cleaner!
-  "Register a GC cleaning action that frees `buffer` on `device-id` IF this value is
-   still the live owner when it becomes unreachable. Captures only value-independent
-   state (never the DeviceArray) so the action does not pin the value in memory.
+  "Register a GC cleaning action that frees `buffer` on `device-id` IF `holder` is
+   still the live owner when it becomes unreachable. Captures only holder-independent
+   state (never the DeviceArray or DonatedBuffer) so the action does not pin it.
 
    Idempotent with explicit `free!` and donation via the shared AtomicBoolean:
    whoever wins `compareAndSet(false,true)` performs (or suppresses) the free exactly
-   once. Donation wins the CAS without freeing → the buffer survives on the output
-   value and this Cleaner is disarmed."
+   once. Claiming a donation wins the token's CAS without freeing → the buffer survives
+   on the output value and that token Cleaner is disarmed."
   [holder ^AtomicBoolean freed buffer device-id free-on-reclaim?]
   (.register cleaner holder
              (reify Runnable
@@ -82,7 +82,9 @@
             device      ;; device-id keyword (:ze:0) — which runtime it lives on
             dtype       ;; :float :half :int … (redundant with buffer.dtype; cheap inspection)
             shape       ;; [d0 d1 …] logical shape (the buffer knows only flat n-elements)
-            owner       ;; ::owned | ::donated | ::aliased | ::external
+            view        ;; canonical backend-neutral BufferView; dtype/shape above mirror it for
+                        ;; compatibility and are checked at construction, never independently set
+            owner       ;; ::owned | ::aliased | ::external
             freed       ;; AtomicBoolean — use-after-free / double-free / donation guard
             base])      ;; for ::aliased: the base DeviceArray it views (else nil). Held as a
                         ;; STRONG ref so reachability of an alias keeps the base — and thus the
@@ -91,14 +93,65 @@
 
 (defn device-array? [x] (instance? DeviceArray x))
 
+(defn- allocation-ownership
+  [owner]
+  (case owner
+    ::owned :owned
+    ::aliased :borrowed
+    ::external :external
+    (throw (ex-info "unknown DeviceArray ownership" {:owner owner}))))
+
+(defn- default-view
+  [buffer device-id dtype shape owner]
+  (let [dtype (dtype/canon dtype)
+        byte-size (long (or (:byte-size buffer)
+                            (* (long (:n-elements buffer)) (dtype/bytes-of (:dtype buffer)))))
+        ze? (.startsWith (name device-id) "ze")
+        allocation (bview/allocation
+                    {:id [:device-array (random-uuid)]
+                     :byte-size byte-size
+                     :memory-space (if ze? :shared :device)
+                     :device device-id
+                     :coherence (if ze? :host-coherent :explicit-transfer)
+                     :ownership (allocation-ownership owner)})]
+    (bview/view allocation {:dtype dtype :shape (vec shape)})))
+
+(defn- validate-device-view!
+  [buffer device-id dtype shape view]
+  (let [view (bview/validate-view! view)
+        dtype (dtype/canon dtype)
+        shape (vec shape)
+        buffer-dtype (dtype/canon (:dtype buffer))]
+    (when-not (= dtype (:dtype view))
+      (throw (ex-info "DeviceArray dtype differs from its BufferView"
+                      {:dtype dtype :view-dtype (:dtype view)})))
+    (when-not (= shape (:shape view))
+      (throw (ex-info "DeviceArray shape differs from its BufferView"
+                      {:shape shape :view-shape (:shape view)})))
+    (when-not (= buffer-dtype dtype)
+      (throw (ex-info "DeviceArray cannot reinterpret its backend buffer dtype"
+                      {:buffer-dtype buffer-dtype :dtype dtype})))
+    (when-not (or (nil? (get-in view [:allocation :device]))
+                  (= device-id (get-in view [:allocation :device])))
+      (throw (ex-info "DeviceArray device differs from its BufferAllocation"
+                      {:device device-id :allocation-device (get-in view [:allocation :device])})))
+    view))
+
 (defn- make-device-array
   "Build a DeviceArray over an existing backend buffer, arming the Cleaner for
    ::owned values. Low-level constructor used by `->device` and output projection.
    `base` is non-nil only for ::aliased views (§ alias-of)."
-  ([buffer device-id dtype shape owner] (make-device-array buffer device-id dtype shape owner nil))
+  ([buffer device-id dtype shape owner]
+   (make-device-array buffer device-id dtype shape owner nil nil))
   ([buffer device-id dtype shape owner base]
-   (let [freed (AtomicBoolean. false)
-         da    (->DeviceArray buffer device-id dtype (vec shape) owner freed base)]
+   (make-device-array buffer device-id dtype shape owner base nil))
+  ([buffer device-id dtype shape owner base view]
+   (let [dtype (dtype/canon dtype)
+         shape (vec shape)
+         view (validate-device-view! buffer device-id dtype shape
+                                     (or view (default-view buffer device-id dtype shape owner)))
+         freed (AtomicBoolean. false)
+         da    (->DeviceArray buffer device-id dtype shape view owner freed base)]
      (arm-cleaner! da freed buffer device-id (= owner ::owned))
      da)))
 
@@ -109,7 +162,8 @@
 (defn live?
   "True if the value has not been freed, consumed (donated), or reclaimed."
   [^DeviceArray da]
-  (not (.get ^AtomicBoolean (:freed da))))
+  (and (not (.get ^AtomicBoolean (:freed da)))
+       (if-let [^DeviceArray base (:base da)] (live? base) true)))
 
 (defn- ensure-live!
   [^DeviceArray da op]
@@ -118,13 +172,9 @@
                          " on a value that was already freed, consumed by donation,"
                          " or reclaimed")
                     {:op op :owner (:owner da) :shape (:shape da) :device (:device da)})))
-  ;; an ::aliased view is only as live as its base owner — reading through a freed base is a
-  ;; use-after-free even if the alias's own flag is clear.
+  ;; An alias chain is only as live as its ultimate allocation owner.
   (when-let [^DeviceArray b (:base da)]
-    (when (.get ^AtomicBoolean (:freed b))
-      (throw (ex-info (str "DeviceArray use-after-free: " op
-                           " through an ::aliased view whose base was freed/consumed")
-                      {:op op :owner (:owner da) :shape (:shape da) :device (:device da)}))))
+    (ensure-live! b op))
   da)
 
 ;; ================================================================
@@ -145,19 +195,39 @@
                    ((rt-fn device-id "buffer-of-array") arr))
          n       (:n-elements buffer)
          shape   (or (:shape opts) [n])]
-     (make-device-array buffer device-id (:dtype buffer) shape ::owned))))
+     (try
+       (make-device-array buffer device-id (:dtype buffer) shape ::owned)
+       (catch Throwable e
+         ((rt-fn device-id "free-buffer!") buffer)
+         (throw e))))))
 
 (defn ->host
-  "Download a DeviceArray to a fresh JVM array. Throws if the value is not live.
-   For :half/:float16 returns the encoded short array (matches buffer->array)."
+  "Download a DeviceArray's exact contiguous view to a fresh JVM array. Throws if the
+   value is not live. For :half/:float16 returns the encoded short array."
   [^DeviceArray da]
   (ensure-live! da :->host)
   ;; reachabilityFence: without it the JIT may treat `da` as dead after the (:buffer da) field
-  ;; load, letting GC run its Cleaner and zeMemFree the segment WHILE buffer->array copies from
-  ;; it — a native use-after-free. Keep `da` (and, via its :base field, any aliased base) reachable
-  ;; across the whole native copy.
-  (try ((rt-fn (:device da) "buffer->array") (:buffer da))
-       (finally (java.lang.ref.Reference/reachabilityFence da))))
+  ;; load, letting GC run its Cleaner and free the segment WHILE download-range! copies from it —
+  ;; a native use-after-free. Keep `da` (and, via its :base field, any aliased base) reachable
+  ;; across the whole ranged native copy.
+  (let [view (bview/validate-view! (:view da))
+        dt (:dtype view)
+        element-bytes (long (dtype/bytes-of dt))
+        elements (quot (:byte-length view) element-bytes)
+        out (case dt
+              :float (float-array elements)
+              :double (double-array elements)
+              :int (int-array elements)
+              :long (long-array elements)
+              :half (short-array elements)
+              :byte (byte-array elements))]
+    (when-not (bview/contiguous? view)
+      (throw (ex-info "DeviceArray host transfer requires a contiguous BufferView"
+                      {:view (:id view) :shape (:shape view) :strides (:strides view)})))
+    (try ((rt-fn (:device da) "download-range!")
+          (:buffer da) out {:src-element (quot (:byte-offset view) element-bytes)
+                            :elements elements})
+         (finally (java.lang.ref.Reference/reachabilityFence da)))))
 
 ;; ================================================================
 ;; Explicit free + donation
@@ -177,25 +247,50 @@
         ((rt-fn (:device da) "free-buffer!") (:buffer da)))))
   nil)
 
+(defrecord DonatedBuffer [buffer device view owner claimed])
+
+(defn donated-buffer? [x] (instance? DonatedBuffer x))
+
 (defn consume!
-  "Consume a DeviceArray for donation: mark it dead (reads now throw) and hand its
-   buffer to the caller WITHOUT freeing it. Wins the CAS so the input's Cleaner is
-   disarmed — the buffer's ownership moves to the output value the caller builds with
-   `donate-output`. Throws if the value was already freed/consumed."
+  "Consume a DeviceArray for donation and return a single-use DonatedBuffer token carrying its
+   buffer and canonical view. The input becomes dead without freeing storage. Aliases cannot be
+   donated independently because their lifetime remains subordinate to a base owner."
   [^DeviceArray da]
   (ensure-live! da :consume!)
+  (when (= ::aliased (:owner da))
+    (throw (ex-info "an aliased DeviceArray cannot transfer its base allocation ownership"
+                    {:view (get-in da [:view :id])})))
   (let [^AtomicBoolean freed (:freed da)]
     (when-not (.compareAndSet freed false true)
       (throw (ex-info "DeviceArray consumed concurrently"
                       {:owner (:owner da) :shape (:shape da)})))
-    (:buffer da)))
+    (let [claimed (AtomicBoolean. false)
+          donation (->DonatedBuffer (:buffer da) (:device da) (:view da) (:owner da) claimed)]
+      ;; Ownership must remain reclaimable while it is between the consumed input and output.
+      (arm-cleaner! donation claimed (:buffer da) (:device da) (= ::owned (:owner da)))
+      donation)))
 
 (defn donate-output
-  "Build the output DeviceArray of a donated in→out pair: a fresh ::owned value over
-   the consumed input's buffer, with the output's logical shape/dtype. Call `consume!`
-   on the input first (this fn takes the buffer it returned)."
-  [buffer device-id dtype shape]
-  (make-device-array buffer device-id dtype shape ::owned))
+  "Claim a DonatedBuffer exactly once and build its output DeviceArray without losing allocation
+   identity. The output view must fit within the consumed input view."
+  [^DonatedBuffer donation dtype shape]
+  (when-not (donated-buffer? donation)
+    (throw (ex-info "donate-output requires the token returned by consume!"
+                    {:value donation :actual (type donation)})))
+  (let [owner (case (:owner donation)
+                ::owned ::owned
+                ::external ::external
+                (throw (ex-info "donation token has a non-transferable owner"
+                                {:owner (:owner donation)})))
+        dtype (dtype/canon dtype)
+        _ (when-not (= dtype (get-in donation [:view :dtype]))
+            (throw (ex-info "donation cannot reinterpret its backend buffer dtype"
+                            {:dtype dtype :buffer-dtype (get-in donation [:view :dtype])})))
+        view (bview/subview (:view donation) {:dtype dtype :shape (vec shape)})
+        _ (validate-device-view! (:buffer donation) (:device donation) dtype shape view)]
+    (when-not (.compareAndSet ^AtomicBoolean (:claimed donation) false true)
+      (throw (ex-info "donated buffer token was already claimed" {})))
+    (make-device-array (:buffer donation) (:device donation) dtype shape owner nil view)))
 
 ;; ================================================================
 ;; Constructors for the other ownership kinds
@@ -212,11 +307,22 @@
   [buffer device-id dtype shape]
   (make-device-array buffer device-id dtype shape ::external))
 
+(defn wrap-external-view
+  "Wrap a caller/session-owned backend buffer using an existing canonical BufferView identity."
+  [buffer device-id view]
+  (let [view (bview/validate-view! view)]
+    (make-device-array buffer device-id (:dtype view) (:shape view) ::external nil view)))
+
 (defn alias-of
-  "Build an ::aliased view onto `base`'s buffer with a (possibly different) logical
-   shape — the cross-artifact / KV-slice sharing case. Never frees on reclaim; the
-   base owner's lifetime governs the buffer."
-  ([^DeviceArray base] (alias-of base (:shape base) (:dtype base)))
-  ([^DeviceArray base shape dtype]
+  "Build an ::aliased view onto `base` without allocating or copying.
+
+   The map form accepts :byte-offset (relative to base), :shape, :dtype, :strides, and :id.
+   Aliases retain the base strongly; freeing or consuming any owner in the chain invalidates
+   every descendant."
+  ([^DeviceArray base] (alias-of base {}))
+  ([^DeviceArray base opts]
    (ensure-live! base :alias-of)
-   (make-device-array (:buffer base) (:device base) dtype shape ::aliased base)))
+   (let [opts (merge {:dtype (:dtype base) :shape (:shape base)} opts)
+         view (bview/subview (:view base) opts)]
+     (make-device-array (:buffer base) (:device base) (:dtype view) (:shape view)
+                        ::aliased base view))))

--- a/test/raster/gpu/artifact_test.clj
+++ b/test/raster/gpu/artifact_test.clj
@@ -13,11 +13,12 @@
      A3 — frozen weights are :constant (captured at bind), never per-call inputs.
      A4 — multi-output: the out-tree projects all 14 donated adapters as DeviceArrays."
   (:require [clojure.test :refer [deftest testing is]]
-            [raster.gpu.value :as v]
-            [raster.gpu.compiled :as r]
+            [raster.compiler.ir.buffer-view :as bview]
+            [raster.compiler.pipeline :as pl]
             [raster.dl.gpu-grad-parity :as gp]
             [raster.dl.gemma-train-resident-test :as g]
-            [raster.compiler.pipeline :as pl]))
+            [raster.gpu.compiled :as r]
+            [raster.gpu.value :as v]))
 
 ;; ── access the gemma harness (privates) ──────────────────────────────────────────
 (defn- gv [sym] @(ns-resolve 'raster.dl.gemma-train-resident-test sym))
@@ -32,25 +33,69 @@
   (testing "an ::owned value is live and readable until consumed"
     (let [inp (v/wrap-owned (->FakeBuf 8 :float) :ze:0 :float [2 4])]
       (is (v/live? inp))
-      (let [buf (v/consume! inp)]
-        (is (instance? FakeBuf buf) "consume! returns the buffer for the output value")
+      (let [donation (v/consume! inp)]
+        (is (v/donated-buffer? donation) "consume! returns an opaque donation token")
+        (is (instance? FakeBuf (:buffer donation)) "the token retains the resident buffer")
         (is (not (v/live? inp)) "input is dead after donation")
         (is (thrown? clojure.lang.ExceptionInfo (v/->host inp))
             "reading a consumed value throws use-after-free")
         (is (thrown? clojure.lang.ExceptionInfo (v/consume! inp))
             "double-consume throws")
-        (let [out (v/donate-output buf :ze:0 :float [8])]
+        (let [out (v/donate-output donation :float [8])]
           (is (v/live? out) "output value is live")
-          (is (identical? buf (:buffer out)) "output reuses the donated buffer (no copy)")))))
+          (is (identical? (:buffer donation) (:buffer out)) "output reuses the buffer (no copy)")
+          (is (= (get-in donation [:view :allocation :id])
+                 (get-in out [:view :allocation :id]))
+              "donation preserves allocation identity")
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"already claimed"
+                                (v/donate-output donation :float [8]))
+              "one token cannot create two owners")))))
   (testing "::aliased free! never frees the base buffer"
     (let [base (v/wrap-owned (->FakeBuf 6 :float) :ze:0 :float [6])
-          al   (v/alias-of base [2 3] :float)]
+          al   (v/alias-of base {:shape [2 3] :dtype :float})]
       (is (identical? (:buffer base) (:buffer al)))
+      (is (bview/same-range? (:view base) (:view al)))
       (v/free! al)
       (is (not (v/live? al)))
       (is (v/live? base) "base survives an alias free!")))
+  (testing "an alias can name a checked byte range of its base"
+    (let [base (v/wrap-owned (->FakeBuf 8 :float) :ze:0 :float [6])
+          slice (v/alias-of base {:byte-offset 8 :shape [3]})]
+      (is (= 8 (get-in slice [:view :byte-offset])))
+      (is (= [3] (:shape slice)))
+      (is (= (get-in base [:view :allocation :id])
+             (get-in slice [:view :allocation :id])))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"exceeds its base"
+                            (v/alias-of base {:byte-offset 20 :shape [2]})))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"cannot transfer"
+                            (v/consume! slice)))))
+  (testing "a failed ->device shape contract releases the allocation it just made"
+    (let [buffer (->FakeBuf 2 :float)
+          freed (atom [])
+          resolver (fn [_ name]
+                     (case name
+                       "buffer-of-array" (fn [_] buffer)
+                       "free-buffer!" #(swap! freed conj %)
+                       (throw (ex-info "unexpected runtime call" {:name name}))))]
+      (with-redefs-fn
+        {(ns-resolve 'raster.gpu.value 'rt-fn) resolver}
+        (fn []
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"exceeds its allocation"
+                                (v/->device (float-array 2) :ze:0 {:shape [3]})))
+          (is (= [buffer] @freed))))))
   (testing "unknown backend fails loud"
     (is (thrown? clojure.lang.ExceptionInfo (v/->device (float-array 3) :cuda:0)))))
+
+(deftest a2-device-alias-downloads-only-its-view
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "DeviceArray ranged alias")
+    (let [base (v/->device (float-array [0.0 1.0 2.0 3.0 4.0 5.0]) :ze:0)
+          slice (v/alias-of base {:byte-offset 8 :shape [3]})]
+      (try
+        (is (= [2.0 3.0 4.0] (vec (v/->host slice))))
+        (finally
+          (v/free! slice)
+          (v/free! base))))))
 
 ;; ════════════════════════════════════════════════════════════════════════════════
 ;; A5 — inspection over a Compiled record (CPU, no device)
@@ -145,7 +190,15 @@
             (is (>= (count (keys last-out)) (count adapters))
                 "multi-output: at least one node per donated adapter")
             (is (every? v/device-array? (vals last-out))
-                "every output is a DeviceArray (device-resident, not a host array)"))
+                "every output is a DeviceArray (device-resident, not a host array)")
+            (doseq [{:keys [key sym]} (:out-tree step)
+                    :let [da (get last-out key)]
+                    :when da]
+              (let [resident-key ((ns-resolve gpu 'resident-key)
+                                  (:session step) (:handle step) sym)]
+                (is (= (get-in @(:session step) [:allocations resident-key :id])
+                       (get-in da [:view :allocation :id]))
+                    (str key " shares the session allocation identity")))))
           (testing "A1/A6: the value path is BIT-IDENTICAL to the raw run-program! path"
             (doseq [s adapters]
               (let [art (v/->host (get last-out (keyword (str (name s) "'"))))
@@ -166,6 +219,16 @@
                   lN (host-loss cfg final-st)]
               (println "  [S4 artifact] loss" (format "%.6f → %.6f" l0 lN))
               (is (< lN (* 0.7 l0)) (str "final " lN " vs initial " l0))))
+          (testing "a projected value threads through its exact donated view"
+            (let [in-key (keyword (name (first adapters)))
+                  out-key (keyword (str (name (first adapters)) "'"))
+                  prior (step {})
+                  input (get prior out-key)
+                  allocation-id (get-in input [:view :allocation :id])
+                  next (step {in-key input})]
+              (is (not (v/live? input)) "the donated input view is consumed")
+              (is (= allocation-id (get-in next [out-key :view :allocation :id]))
+                  "the fresh output preserves the session allocation identity")))
           (testing "S4 boundary contract (M4): a retained prior output is invalidated by the next call"
             (let [prev    (step {})
                   prev-da (get prev (keyword (str (name (first adapters)) "'")))]
@@ -180,7 +243,7 @@
                 "a non-param key throws instead of being dropped")
             (let [foreign (v/->device (float-array (java.lang.reflect.Array/getLength ^floats (st0 (first adapters))))
                                       :ze:0)]
-              (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not this artifact's resident value"
+              (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not this artifact's resident view"
                                     (step {(keyword (name (first adapters))) foreign}))
                   "a foreign device value donated to a slot throws instead of being consumed-and-ignored")
               (v/free! foreign))))


### PR DESCRIPTION
## Summary

- make every `DeviceArray` carry a validated canonical `BufferView`, including bounded ranged aliases and exact ranged host downloads
- introduce single-use donation tokens that preserve allocation identity and close the ownership gap between consumed inputs and outputs
- project `Compiled` outputs through the session allocation/view and require exact resident ranges for donated cross-call threading

## Validation

- `clojure -M:format src/raster/gpu/value.clj src/raster/gpu/compiled.clj test/raster/gpu/artifact_test.clj`
- `clojure -M:test -n raster.gpu.buffer-view-test -n raster.gpu.kernel-graph-runner-test -n raster.gpu.kernel-graph-device-test -n raster.gpu.range-transfer-test -n raster.gpu.artifact-test`
  - 21 tests, 175 assertions, zero failures/errors
  - live Level Zero/OpenCL coverage
  - Gemma 25-step loss: 2.800152 -> 0.256915