### PR TITLE
Bind OpenCL kernels through buffer views

### DIFF
--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -203,7 +203,7 @@
       :byte-size (:byte-size buffer)
       :memory-space (or (:memory-space opts) (case backend :ze :shared :ocl :device))
       :device device-id
-      :alignment (or (:alignment opts) 1)
+      :alignment (or (:alignment opts) (:alignment buffer) 1)
       :coherence (or (:coherence opts)
                      (case backend :ze :host-coherent :ocl :explicit-transfer))
       :ownership ownership})))
@@ -232,8 +232,8 @@
 
 (defn- destroy-kernel-graph-entry!
   "Destroy one bound graph's backend recording, dedicated kernel handles and graph-owned
-   temporaries. External buffers remain session-owned and are never freed here."
-  [device-id {:keys [runtime-graph prepareds temporary-buffers]}]
+   temporaries/view handles. External root buffers remain session-owned and are never freed here."
+  [device-id {:keys [runtime-graph prepareds owned-view-buffers temporary-buffers]}]
   (let [destroy-graph! (rt-resolve-soft device-id "destroy-graph!")
         destroy-prepared! (rt-resolve-soft device-id "destroy-prepared!")]
     (when (and destroy-graph! runtime-graph)
@@ -241,6 +241,12 @@
     (when destroy-prepared!
       (doseq [prepared prepareds]
         (try (destroy-prepared! prepared) (catch Exception _))))
+    ;; OpenCL cl_mem sub-buffers are independently reference-counted native objects. Kernel
+    ;; bindings must die first because their argument state still refers to these handles.
+    (when (seq owned-view-buffers)
+      (let [free! (rt-resolve device-id "free-buffer!")]
+        (doseq [buffer owned-view-buffers]
+          (try (free! buffer) (catch Exception _)))))
     (when (seq temporary-buffers)
       (free-buffers-internal! temporary-buffers device-id))))
 
@@ -1000,12 +1006,37 @@
       (throw (ex-info "kernel ABI cannot reinterpret a resident buffer dtype"
                       {:buffer-dtype raw-dtype :view-dtype view-dtype :view (:id view)})))
     (if (zero? (:byte-offset view))
-      buffer
+      {:buffer buffer :owned-view? false}
       (case (backend-type device-id)
-        :ze ((rt-resolve device-id "slice-buffer") buffer (:byte-offset view)
-                                                   (:byte-length view) view-dtype)
-        :ocl (throw (ex-info "OpenCL non-zero-offset kernel views require a legal cl_mem sub-buffer"
-                             {:view (:id view) :byte-offset (:byte-offset view)}))))))
+        :ze {:buffer ((rt-resolve device-id "slice-buffer") buffer (:byte-offset view)
+                                                            (:byte-length view) view-dtype)
+             :owned-view? false}
+        :ocl {:buffer ((rt-resolve device-id "slice-buffer") buffer (:byte-offset view)
+                                                             (:byte-length view) view-dtype)
+              :owned-view? true}))))
+
+(defn- materialize-external-buffers!
+  "Turn checked external BufferViews into backend ABI buffers. Level Zero slices are non-owning
+   pointers. OpenCL slices are owned cl_mem sub-buffers and are transactionally released if any
+   later view fails to materialize."
+  [device-id external-bindings]
+  (let [owned (volatile! [])]
+    (try
+      {:buffers
+       (into {}
+             (map (fn [[id {:keys [buffer view]}]]
+                    (let [{runtime-buffer :buffer owned-view? :owned-view?}
+                          (runtime-buffer-for-view device-id buffer view)]
+                      (when owned-view? (vswap! owned conj runtime-buffer))
+                      [id runtime-buffer])))
+             external-bindings)
+       :owned-view-buffers @owned}
+      (catch Exception e
+        (when (seq @owned)
+          (let [free! (rt-resolve device-id "free-buffer!")]
+            (doseq [buffer @owned]
+              (try (free! buffer) (catch Exception _)))))
+        (throw e)))))
 
 (defn- resolve-kernel-graph-entry
   [sess handle]
@@ -1115,21 +1146,21 @@
           _ (doseq [[id {:keys [view]}] external-bindings]
               (validate-external-view! (get graph-buffer-by-id id) view scalar-values))
           _ (validate-physical-aliases! graph external-bindings)
-          external-buffers (into {}
-                                 (map (fn [[id {:keys [buffer view]}]]
-                                        [id (runtime-buffer-for-view device-id buffer view)]))
-                                 external-bindings)
           _ (release-graph-events! sess graph-key)
           temporary-specs (kgcall/temporary-specs graph scalar-values)
           temporary-buffers (alloc-buffers-transactional temporary-specs device-id)
-          all-buffers (merge external-buffers temporary-buffers)
-          register! (rt-resolve device-id "register-kernel!")
-          bind-call! (rt-resolve device-id "bind-kernel-call")
-          record! (rt-resolve device-id "record-graph!")
+          owned-view-buffers (volatile! [])
           prepareds (volatile! [])
           runtime-graph (volatile! nil)]
       (try
-        (let [graph-call (kgcall/make graph all-buffers scalar-values)
+        (let [{:keys [buffers] :as materialized}
+              (materialize-external-buffers! device-id external-bindings)
+              _ (vreset! owned-view-buffers (:owned-view-buffers materialized))
+              all-buffers (merge buffers temporary-buffers)
+              register! (rt-resolve device-id "register-kernel!")
+              bind-call! (rt-resolve device-id "bind-kernel-call")
+              record! (rt-resolve device-id "record-graph!")
+              graph-call (kgcall/make graph all-buffers scalar-values)
               execution-plan (execution/from-kernel-graph-call graph-call)]
           (doseq [node (:nodes graph)]
             (let [artifact (:operation node)]
@@ -1146,6 +1177,7 @@
                        :execution-plan execution-plan
                        :runtime-graph @runtime-graph
                        :prepareds @prepareds
+                       :owned-view-buffers @owned-view-buffers
                        :temporary-buffers temporary-buffers
                        :buffer-keys buffer-keys
                        :resident-views (into {} (map (fn [[id binding]]
@@ -1160,6 +1192,7 @@
           (destroy-kernel-graph-entry!
            device-id {:runtime-graph @runtime-graph
                       :prepareds @prepareds
+                      :owned-view-buffers @owned-view-buffers
                       :temporary-buffers temporary-buffers})
           (throw e))))))
 

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -109,6 +109,7 @@
 (def ^:private CL_DEVICE_MAX_CLOCK_FREQUENCY 0x100C)
 (def ^:private CL_DEVICE_GLOBAL_MEM_SIZE 0x101F)
 (def ^:private CL_DEVICE_HOST_UNIFIED_MEMORY 0x1035)
+(def ^:private CL_DEVICE_MEM_BASE_ADDR_ALIGN 0x1019)
 (def ^:private CL_DEVICE_NAME 0x102B)
 (def ^:private CL_DEVICE_VENDOR 0x102C)
 (def ^:private CL_DEVICE_EXTENSIONS 0x1030)
@@ -116,6 +117,9 @@
 
 ;; clGetProgramBuildInfo param_name
 (def ^:private CL_PROGRAM_BUILD_LOG 0x1183)
+
+;; cl_buffer_create_type
+(def ^:private CL_BUFFER_CREATE_TYPE_REGION 0x1220)
 
 ;; ================================================================
 ;; Layout helpers
@@ -167,6 +171,8 @@
 ;; Memory
 (def ^:private h-clCreateBuffer
   (delay (make-handle "clCreateBuffer" (fd PTR PTR I64 I64 PTR PTR))))
+(def ^:private h-clCreateSubBuffer
+  (delay (make-handle "clCreateSubBuffer" (fd PTR PTR I64 I32 PTR PTR))))
 (def ^:private h-clEnqueueWriteBuffer
   (delay (make-handle "clEnqueueWriteBuffer" (fd I32 PTR PTR I32 I64 I64 PTR I32 PTR PTR))))
 (def ^:private h-clEnqueueReadBuffer
@@ -226,6 +232,7 @@
          :arena nil          ;; Arena for long-lived allocations
          :device-name nil
          :unified-memory? false
+         :buffer-offset-alignment nil ;; bytes; CL_DEVICE_MEM_BASE_ADDR_ALIGN is reported in bits
          :programs {}        ;; source-hash -> cl_program handle
          :kernels {}}))      ;; [program kernel-name] -> cl_kernel handle
 
@@ -286,6 +293,18 @@
   ^long [^MemorySegment device ^long param-name]
   ;; size_t is 8 bytes on 64-bit
   (query-device-info-ulong device param-name))
+
+(defn- device-buffer-offset-alignment
+  "Return the device's legal clCreateSubBuffer origin alignment in bytes. OpenCL reports this
+   capability in bits and requires it to be a power of two."
+  [device]
+  (let [bits (query-device-info-uint device CL_DEVICE_MEM_BASE_ADDR_ALIGN)]
+    (when-not (and (pos? bits)
+                   (zero? (bit-and bits (dec bits)))
+                   (zero? (mod bits 8)))
+      (throw (ex-info "OpenCL reported an invalid buffer base-address alignment"
+                      {:alignment-bits bits})))
+    (quot bits 8)))
 
 ;; ================================================================
 ;; Initialization
@@ -352,7 +371,8 @@
 
           dev-name (query-device-info-string device CL_DEVICE_NAME)
           unified? (try (== 1 (query-device-info-uint device CL_DEVICE_HOST_UNIFIED_MEMORY))
-                        (catch Exception _ false))]
+                        (catch Exception _ false))
+          buffer-offset-alignment (device-buffer-offset-alignment device)]
 
       (swap! state assoc
              :initialized? true
@@ -362,7 +382,8 @@
              :queue queue
              :arena arena
              :device-name dev-name
-             :unified-memory? unified?)
+             :unified-memory? unified?
+             :buffer-offset-alignment buffer-offset-alignment)
       (println (str "[ocl-runtime] Initialized: " dev-name
                     (when unified? " (unified memory)"))))))
 
@@ -404,6 +425,7 @@
                           :max-work-group-size (query-device-info-size-t dev CL_DEVICE_MAX_WORK_GROUP_SIZE)
                           :max-clock-mhz (query-device-info-uint dev CL_DEVICE_MAX_CLOCK_FREQUENCY)
                           :global-mem-bytes (query-device-info-ulong dev CL_DEVICE_GLOBAL_MEM_SIZE)
+                          :buffer-offset-alignment (device-buffer-offset-alignment dev)
                           :extensions (query-device-info-string dev CL_DEVICE_EXTENSIONS)
                           :integrated? (try (== 1 (query-device-info-uint dev CL_DEVICE_HOST_UNIFIED_MEMORY))
                                             (catch Exception _ false))}))
@@ -421,7 +443,8 @@
                       ^MemorySegment cl-mem      ;; cl_mem handle
                       ^long n-elements
                       ^long byte-size
-                      dtype])
+                      dtype
+                      ^long alignment])          ;; legal kernel-view origin alignment in bytes
 
 (defn device-buffer? [x]
   (instance? OclBuffer x))
@@ -463,6 +486,8 @@
     (get (:attributes kernel-info) k default)
     (get kernel-info k default)))
 
+(declare buffer-offset-alignment)
+
 (defn make-buffer
   "Allocate a persistent GPU buffer via clCreateBuffer."
   ([n] (make-buffer n :float))
@@ -479,7 +504,61 @@
              (throw (ex-info "clCreateBuffer failed" {:error (read-int err-seg) :size byte-size})))
          ;; Host staging buffer for data transfer
          host-seg (.allocate ^Arena arena byte-size)]
-     (->OclBuffer host-seg cl-mem (long n) byte-size dtype))))
+     (->OclBuffer host-seg cl-mem (long n) byte-size dtype
+                  (long (buffer-offset-alignment))))))
+
+(defn buffer-offset-alignment
+  "Minimum byte alignment for a clCreateSubBuffer origin on the selected OpenCL device."
+  []
+  (ensure-init!)
+  (:buffer-offset-alignment @state))
+
+(defn slice-buffer
+  "Create an independently reference-counted cl_mem sub-buffer over an exact byte range.
+
+   Unlike Level Zero's non-owning sliced pointer, the returned OclBuffer owns one native
+   cl_mem reference and MUST be passed to free-buffer!. `byte-offset` is relative to the root
+   buffer and must satisfy CL_DEVICE_MEM_BASE_ADDR_ALIGN; dtype reinterpretation is forbidden."
+  [^OclBuffer buf byte-offset byte-length dtype]
+  (ensure-init!)
+  (let [byte-offset (long byte-offset)
+        byte-length (long byte-length)
+        dtype (dt/canon dtype)
+        raw-dtype (dt/canon (:dtype buf))
+        element-bytes (long (dt/bytes-of dtype))
+        alignment (long (buffer-offset-alignment))]
+    (when-not (= raw-dtype dtype)
+      (throw (ex-info "OpenCL sub-buffer cannot reinterpret its parent dtype"
+                      {:buffer-dtype raw-dtype :dtype dtype})))
+    (when (or (neg? byte-offset) (not (pos? byte-length))
+              (> (+ byte-offset byte-length) (:byte-size buf))
+              (not (zero? (mod byte-offset element-bytes)))
+              (not (zero? (mod byte-length element-bytes))))
+      (throw (ex-info "OpenCL sub-buffer range is invalid"
+                      {:byte-offset byte-offset :byte-length byte-length
+                       :buffer-bytes (:byte-size buf) :dtype dtype})))
+    (when-not (zero? (mod byte-offset alignment))
+      (throw (ex-info "OpenCL sub-buffer origin violates the device alignment requirement"
+                      {:byte-offset byte-offset :required-alignment alignment})))
+    (let [arena (Arena/ofConfined)]
+      (try
+        (let [region (.allocate arena (long 16) (long 8))
+              err-seg (.allocate arena I32)
+              _ (.set region I64 0 byte-offset)
+              _ (.set region I64 8 byte-length)
+              cl-mem (.invokeWithArguments
+                      ^MethodHandle @h-clCreateSubBuffer
+                      (into-array Object [(:cl-mem buf) (long CL_MEM_READ_WRITE)
+                                          (int CL_BUFFER_CREATE_TYPE_REGION) region err-seg]))
+              error (read-int err-seg)]
+          (when-not (= CL_SUCCESS error)
+            (throw (ex-info "clCreateSubBuffer failed"
+                            {:error error :byte-offset byte-offset :byte-length byte-length
+                             :required-alignment alignment})))
+          (->OclBuffer (.asSlice ^MemorySegment (:segment buf) byte-offset byte-length)
+                       cl-mem (quot byte-length element-bytes) byte-length dtype alignment))
+        (finally
+          (.close arena))))))
 
 (defn free-buffer!
   "Free an OclBuffer's cl_mem."
@@ -525,14 +604,14 @@
   [what have-elements offset elements elem-size other-bytes]
   (let [have-elements (long have-elements) offset (long offset) elements (long elements)
         elem-size (long elem-size) other-bytes (long other-bytes)]
-  (when (or (neg? offset) (neg? elements))
-    (throw (ex-info (str what ": negative offset or length") {:offset offset :elements elements})))
-  (when (> (+ offset elements) have-elements)
-    (throw (ex-info (str what ": range exceeds the buffer")
-                    {:offset offset :elements elements :buffer-elements have-elements})))
-  (when (> (* elements elem-size) other-bytes)
-    (throw (ex-info (str what ": range exceeds the host-side array/segment")
-                    {:needed-bytes (* elements elem-size) :available-bytes other-bytes})))))
+    (when (or (neg? offset) (neg? elements))
+      (throw (ex-info (str what ": negative offset or length") {:offset offset :elements elements})))
+    (when (> (+ offset elements) have-elements)
+      (throw (ex-info (str what ": range exceeds the buffer")
+                      {:offset offset :elements elements :buffer-elements have-elements})))
+    (when (> (* elements elem-size) other-bytes)
+      (throw (ex-info (str what ": range exceeds the host-side array/segment")
+                      {:needed-bytes (* elements elem-size) :available-bytes other-bytes})))))
 
 (defn plan-range
   "Validate one ranged transfer and return its byte-level plan without copying. Same contract as
@@ -1107,7 +1186,6 @@
 ;; Lifecycle
 ;; ================================================================
 
-
 ;; ================================================================
 ;; Resident session layer (ports of the ze_runtime bound/graph API)
 ;; OpenCL has no command graphs in core: record-graph! stores the ordered
@@ -1396,6 +1474,7 @@
       (clojure.core/reset! state
                            {:initialized? false :platform nil :device nil :context nil
                             :queue nil :arena nil :device-name nil :unified-memory? false
+                            :buffer-offset-alignment nil
                             :programs {} :kernels {}}))))
 
 (defn reset!
@@ -1407,5 +1486,6 @@
   (clojure.core/reset! state
                        {:initialized? false :platform nil :device nil :context nil
                         :queue nil :arena nil :device-name nil :unified-memory? false
+                        :buffer-offset-alignment nil
                         :programs {} :kernels {}})
   (clojure.core/reset! kernel-registry {}))

--- a/src/raster/gpu/value.clj
+++ b/src/raster/gpu/value.clj
@@ -112,6 +112,7 @@
                      :byte-size byte-size
                      :memory-space (if ze? :shared :device)
                      :device device-id
+                     :alignment (or (:alignment buffer) 1)
                      :coherence (if ze? :host-coherent :explicit-transfer)
                      :ownership (allocation-ownership owner)})]
     (bview/view allocation {:dtype dtype :shape (vec shape)})))

--- a/test/raster/gpu/kernel_graph_device_test.clj
+++ b/test/raster/gpu/kernel_graph_device_test.clj
@@ -88,3 +88,47 @@
   (if-not @ocl-available?
     (is true "OpenCL device unavailable")
     (assert-prefix! :ocl:0)))
+
+(deftest opencl-kernel-graph-binds-aligned-disjoint-views-of-one-allocation
+  (if-not @ocl-available?
+    (is true "OpenCL device unavailable")
+    (let [n 1025
+          n-bytes (* 4 n)
+          alignment ((resolve 'raster.gpu.ocl-runtime/buffer-offset-alignment))
+          output-offset (* alignment (quot (+ n-bytes (dec alignment)) alignment))
+          graph (emitted-graph)
+          storage (float-array (quot (+ output-offset n-bytes 4) 4))]
+      (is (zero? (mod output-offset alignment)))
+      (dotimes [i n] (aset storage i 1.0))
+      (gpu/with-gpu-session [sess :ocl:0]
+        (gpu/alloc! sess {:storage [:float (alength storage) storage]})
+        (is (= alignment (get-in @sess [:allocations :storage :alignment]))
+            "the canonical allocation exposes the queried OpenCL alignment")
+        (let [input (gpu/buffer-view sess :storage {:shape [n]})
+              output (gpu/buffer-view sess :storage
+                                      {:byte-offset output-offset :shape [n]})
+              handle (gpu/bind-kernel-graph!
+                      sess :opencl-view-scan graph {'values input 'out output}
+                      {'n {:type :int :value n}})]
+          (try
+            (gpu/run-kernel-graph! sess handle)
+            (let [result (float-array n)]
+              (gpu/download-range! sess output result {:elements n})
+              (is (= 1025.0 (double (aget result 1024))))
+              (is (every? true?
+                          (map-indexed (fn [i value] (= (double (inc i)) (double value)))
+                                       result))))
+            (finally
+              (gpu/release-kernel-graph! sess handle)))
+          (when (> alignment 4)
+            (let [misaligned-output (gpu/buffer-view
+                                     sess :storage
+                                     {:byte-offset (+ output-offset 4) :shape [n]})]
+              (is (thrown-with-msg?
+                   clojure.lang.ExceptionInfo #"alignment requirement"
+                   (gpu/bind-kernel-graph!
+                    sess :misaligned-view-scan graph
+                    {'values input 'out misaligned-output}
+                    {'n {:type :int :value n}})))
+              (is (empty? (:kernel-graphs @sess))
+                  "misaligned binding leaves no graph-owned resources"))))))))

--- a/test/raster/gpu/kernel_graph_runner_test.clj
+++ b/test/raster/gpu/kernel_graph_runner_test.clj
@@ -140,3 +140,83 @@
           (is (not-any? #(or (identical? values-buffer %)
                              (identical? output-buffer %))
                         @freed)))))))
+
+(deftest opencl-sub-buffer-handles-follow-the-graph-lifetime
+  (let [n 1025
+        n-bytes (* 4 n)
+        output-offset 4224
+        graph (emitted-graph)
+        root-buffer {:root true :dtype :float
+                     :n-elements (quot (+ output-offset n-bytes) 4)
+                     :byte-size (+ output-offset n-bytes)}
+        allocation (bview/allocation
+                    {:id :shared-allocation :byte-size (:byte-size root-buffer)
+                     :memory-space :device :device :ocl:0 :coherence :explicit-transfer
+                     :ownership :owned})
+        sess (atom {:device-id :ocl:0 :session-id :test-session
+                    :buffers {:storage root-buffer}
+                    :allocations {:storage allocation}
+                    :kernel-graphs {} :events {} :closed? false})
+        input (gpu/buffer-view sess :storage {:shape [n]})
+        output (gpu/buffer-view sess :storage {:byte-offset output-offset :shape [n]})
+        slices (atom [])
+        freed (atom [])
+        fail-bind? (atom false)
+        resolver
+        (fn [_device-id name]
+          (case name
+            "make-buffer" (fn [elements dtype]
+                            {:temporary true :n-elements elements
+                             :byte-size (* elements 4) :dtype dtype})
+            "array->buffer!" (fn [buffer _] buffer)
+            "buffer-as-float-buffer" identity
+            "buffer-as-int-buffer" identity
+            "slice-buffer" (fn [buffer byte-offset byte-length dtype]
+                             (let [slice {:sub-buffer true :parent buffer
+                                          :byte-offset byte-offset :byte-size byte-length
+                                          :n-elements (quot byte-length 4) :dtype dtype}]
+                               (swap! slices conj slice)
+                               slice))
+            "free-buffer!" #(swap! freed conj %)
+            "register-kernel!" (fn [& _])
+            "bind-kernel-call" (fn [call]
+                                 (when @fail-bind?
+                                   (throw (ex-info "mock bind failure" {})))
+                                 {:mock-call call})
+            "record-graph!" (fn [prepareds opts] {:prepareds prepareds :opts opts})
+            (throw (ex-info "unexpected mocked runtime function" {:name name}))))
+        soft-resolver (fn [_device-id name]
+                        (case name
+                          "destroy-graph!" (fn [_])
+                          "destroy-prepared!" (fn [_])
+                          nil))]
+    (with-redefs-fn
+      {(ns-resolve 'raster.gpu.core 'rt-resolve) resolver
+       (ns-resolve 'raster.gpu.core 'rt-resolve-soft) soft-resolver}
+      (fn []
+        (let [handle (gpu/bind-kernel-graph!
+                      sess :view-scan graph {'values input 'out output}
+                      {'n {:type :int :value n}})
+              sub-buffer (first @slices)
+              temporary (first (vals (get-in @sess [:kernel-graphs :view-scan
+                                                    :temporary-buffers])))]
+          (is (= 1 (count @slices)) "only the nonzero view needs a cl_mem sub-buffer")
+          (is (identical? sub-buffer (get-in @sess [:kernel-graphs :view-scan
+                                                    :outputs 'out])))
+          (gpu/release-kernel-graph! sess handle)
+          (is (= #{sub-buffer temporary} (set @freed)))
+          (is (not-any? #(identical? root-buffer %) @freed)
+              "the session-owned root allocation survives graph release"))
+        (reset! slices [])
+        (reset! freed [])
+        (reset! fail-bind? true)
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"mock bind failure"
+                              (gpu/bind-kernel-graph!
+                               sess :failed-view-scan graph {'values input 'out output}
+                               {'n {:type :int :value n}})))
+        (is (= 1 (count @slices)))
+        (is (= 2 (count @freed))
+            "failed binding releases both its created sub-buffer and temporary")
+        (is (some :sub-buffer @freed))
+        (is (some :temporary @freed))
+        (is (empty? (:kernel-graphs @sess)))))))


### PR DESCRIPTION
## Summary

- query `CL_DEVICE_MEM_BASE_ADDR_ALIGN`, propagate it into OpenCL buffers and canonical allocation descriptors, and create checked `clCreateSubBuffer` regions for nonzero kernel views
- make OpenCL sub-buffer handles graph-owned and transactionally release them on partial materialization or later bind failure
- preserve backend ownership semantics: Level Zero slices are non-owning; OpenCL kernel bindings are destroyed before their sub-buffer references
- execute an aligned disjoint-view scan from one allocation on live OpenCL and reject a hardware-misaligned view without leaking resources

## Validation

- `clojure -M:format src/raster/gpu/ocl_runtime.clj src/raster/gpu/core.clj src/raster/gpu/value.clj test/raster/gpu/kernel_graph_runner_test.clj test/raster/gpu/kernel_graph_device_test.clj`
- `clojure -M:test -n raster.gpu.buffer-view-test -n raster.gpu.kernel-graph-runner-test -n raster.gpu.kernel-graph-device-test -n raster.gpu.range-transfer-test -n raster.gpu.artifact-test`
  - 23 tests, 191 assertions, zero failures/errors
  - live Level Zero and Intel Arc OpenCL coverage
  - Gemma 25-step loss remains 2.800152 -> 0.256915