### PR TITLE
Add routed paged attention reference

### DIFF
--- a/src/raster/compiler/backend/gpu/paged_attention.clj
+++ b/src/raster/compiler/backend/gpu/paged_attention.clj
@@ -1,0 +1,145 @@
+(ns raster.compiler.backend.gpu.paged-attention
+  "Portable reference lowering for decode-time paged attention.
+
+   This kernel is an executable semantic oracle, not the eventual fast leaf: one work-item owns
+   one output element and recomputes the query/key dot product for that element. That deliberately
+   simple O(B*Hq*L*D^2) schedule makes page routing, GQA, FP16 storage, FP32 online softmax and the
+   ordered ABI testable through every runtime before flash/persistent schedules are introduced."
+  (:require [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-graph :as kgraph]
+            [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.compiler.ir.paged-attention :as paged]))
+
+(defn reference-workgroup-x
+  "Choose the reference leaf's x workgroup from the hardware resource descriptor."
+  [operation desc]
+  (let [head-dim (:head-dim (paged/validate! operation))
+        subgroup (long (or (:subgroup-size desc) 16))
+        maximum (long (or (:max-workgroup-size desc) 256))]
+    (long (max 1 (min head-dim subgroup maximum)))))
+
+(defn- kernel-name
+  [operation]
+  (let [identity (select-keys operation
+                              [:batch-size :q-heads :kv-heads :head-dim :page-size
+                               :physical-pages :pages-per-sequence :scale :cache-format
+                               :cache-layout])]
+    (format "raster_paged_attention_fp16_%08x" (bit-and 0xffffffff (long (hash identity))))))
+
+(defn- source
+  [operation name]
+  (let [{:keys [batch-size q-heads kv-heads head-dim page-size physical-pages
+                pages-per-sequence scale cache-layout]} operation
+        gqa-ratio (quot q-heads kv-heads)
+        cache-base (case cache-layout
+                     :kv-head-major
+                     (str "(((kv_head * " physical-pages " + physical_page) * "
+                          page-size " + page_token) * " head-dim ")")
+                     :page-major
+                     (str "(((physical_page * " page-size " + page_token) * "
+                          kv-heads " + kv_head) * " head-dim ")"))]
+    (str "#pragma OPENCL EXTENSION cl_khr_fp16 : enable\n"
+         "__kernel void " name "(\n"
+         "    __global const half* q,\n"
+         "    __global const half* k_pages,\n"
+         "    __global const half* v_pages,\n"
+         "    __global const int* page_table,\n"
+         "    __global const int* lengths,\n"
+         "    __global half* output) {\n"
+         "  const int d = (int)get_global_id(0);\n"
+         "  const int q_head = (int)get_global_id(1);\n"
+         "  const int batch = (int)get_global_id(2);\n"
+         "  if (d >= " head-dim " || q_head >= " q-heads " || batch >= " batch-size ") return;\n"
+         "  const int out_index = (batch * " q-heads " + q_head) * " head-dim " + d;\n"
+         "  const int length = lengths[batch];\n"
+         "  if (length < 0 || length > " (* pages-per-sequence page-size) ") {\n"
+         "    output[out_index] = convert_half_rte(NAN);\n"
+         "    return;\n"
+         "  }\n"
+         "  if (length == 0) { output[out_index] = (half)0; return; }\n"
+         "  const int kv_head = q_head / " gqa-ratio ";\n"
+         "  const int q_base = (batch * " q-heads " + q_head) * " head-dim ";\n"
+         "  float maximum = -3.402823466e+38f;\n"
+         "  float denominator = 0.0f;\n"
+         "  float accumulator = 0.0f;\n"
+         "  for (int token = 0; token < length; ++token) {\n"
+         "    const int logical_page = token / " page-size ";\n"
+         "    const int physical_page = page_table[batch * " pages-per-sequence
+         " + logical_page];\n"
+         "    if (physical_page < 0 || physical_page >= " physical-pages ") {\n"
+         "      output[out_index] = convert_half_rte(NAN);\n"
+         "      return;\n"
+         "    }\n"
+         "    const int page_token = token - logical_page * " page-size ";\n"
+         "    const int cache_base = " cache-base ";\n"
+         "    float dot = 0.0f;\n"
+         "    for (int x = 0; x < " head-dim "; ++x) {\n"
+         "      dot += convert_float(q[q_base + x]) * convert_float(k_pages[cache_base + x]);\n"
+         "    }\n"
+         "    const float logit = dot * " (Float/toString (float scale)) "f;\n"
+         "    const float next_maximum = fmax(maximum, logit);\n"
+         "    const float old_weight = exp(maximum - next_maximum);\n"
+         "    const float new_weight = exp(logit - next_maximum);\n"
+         "    accumulator = accumulator * old_weight\n"
+         "                  + convert_float(v_pages[cache_base + d]) * new_weight;\n"
+         "    denominator = denominator * old_weight + new_weight;\n"
+         "    maximum = next_maximum;\n"
+         "  }\n"
+         "  output[out_index] = convert_half_rte(accumulator / denominator);\n"
+         "}\n")))
+
+(defn emit-fp16-reference
+  "Emit the plain-FP16 cache reference leaf as one verified KernelArtifact."
+  [operation desc]
+  (let [{:keys [q k-pages v-pages page-table lengths output batch-size q-heads head-dim]
+         :as operation} (paged/validate! operation)
+        name (kernel-name operation)
+        workgroup-x (reference-workgroup-x operation desc)
+        abi (kabi/validate!
+             [(kabi/slot q :input :half :c-name "q" :role :query)
+              (kabi/slot k-pages :input :half :c-name "k_pages" :role :key-cache)
+              (kabi/slot v-pages :input :half :c-name "v_pages" :role :value-cache)
+              (kabi/slot page-table :input :int :c-name "page_table" :role :page-routing)
+              (kabi/slot lengths :input :int :c-name "lengths" :role :sequence-length)
+              (kabi/slot output :output :half :c-name "output" :role :result)])
+        launch (klaunch/spec
+                {:workgroup-size [workgroup-x 1 1]
+                 :group-count [(long (quot (+ head-dim (dec workgroup-x)) workgroup-x))
+                               q-heads batch-size]})]
+    (kart/make
+     {:kernel-name name
+      :source (source operation name)
+      :abi abi
+      :arguments [q k-pages v-pages page-table lengths output]
+      :launch launch
+      :effects {:kind :paged-attention :reads [q k-pages v-pages page-table lengths]
+                :writes [output]}
+      :provenance {:operation-id (:id operation) :semantic-op :paged-attention
+                   :lowering :fp16-reference}
+      :attributes {:strategy :fp16-reference :optimization-tier :reference
+                   :storage-dtype :half :accumulator-dtype :float
+                   :cache-layout (:cache-layout operation)
+                   :layout (paged/layouts operation)
+                   :complexity :quadratic-in-head-dim}})))
+
+(defn kernel-graph
+  "Wrap the reference artifact in an explicit one-node scheduled graph."
+  [operation artifact]
+  (let [{:keys [q k-pages v-pages page-table lengths output id]} (paged/validate! operation)
+        artifact (kart/validate! artifact)
+        specs (paged/buffer-specs operation)
+        graph-buffer (fn [buffer-id]
+                       (let [{:keys [dtype elements role]} (get specs buffer-id)]
+                         (kgraph/buffer buffer-id dtype elements :device role)))
+        inputs [q k-pages v-pages page-table lengths]
+        uses (vec (concat (map #(kgraph/->ValueUse % :read) inputs)
+                          [(kgraph/->ValueUse output :write)]))
+        node-id [:paged-attention id :fp16-reference]]
+    (kgraph/make
+     {:inputs (mapv graph-buffer inputs)
+      :outputs [(graph-buffer output)]
+      :nodes [(kgraph/->ScheduledKernel node-id artifact uses [])]
+      :effects {:kind :paged-attention :ordered-page-routing true}
+      :provenance {:operation-id id :semantic-op :paged-attention}
+      :attributes {:strategy :fp16-reference :reference? true}})))

--- a/src/raster/compiler/ir/paged_attention.clj
+++ b/src/raster/compiler/ir/paged_attention.clj
@@ -1,0 +1,218 @@
+(ns raster.compiler.ir.paged-attention
+  "Backend-neutral semantic descriptor for decode-time paged grouped-query attention.
+
+   The page table is the routing contract: row `b` lists physical page ids in the logical
+   attention order for sequence `b`. This represents ordinary contiguous caches, arbitrary page
+   placement, shared prefixes, and pinned-prefix + ring layouts without putting an allocator or a
+   native handle in compiler IR. `lengths[b]` clips the final logical page.
+
+   The default storage layout follows the portable JAX/Pallas convention:
+     q          [batch, q-head, head-dim]
+     k/v-pages  [kv-head, physical-page, page-token, head-dim]
+     page-table [batch, pages-per-sequence]
+     lengths    [batch]
+     output     [batch, q-head, head-dim]
+
+   `:page-major` cache storage instead uses [physical-page, page-token, kv-head, head-dim].
+   With page-size 1 this is a zero-copy view of a conventional [token, kv-head, head-dim] cache.
+
+   This first descriptor is deliberately decode-only: one query per sequence, all routed tokens
+   are visible, and RoPE (if used) is already baked into q/k at their true logical positions."
+  (:require [raster.compiler.core.dtype :as dtype]))
+
+(defrecord PagedAttention
+           [id q k-pages v-pages page-table lengths output
+            batch-size q-heads kv-heads head-dim
+            page-size physical-pages pages-per-sequence
+            q-dtype cache-dtype output-dtype accumulator-dtype
+            scale cache-format cache-layout])
+
+(def ^:private cache-layouts #{:kv-head-major :page-major})
+
+(defn paged-attention?
+  [x]
+  (and x (= "raster.compiler.ir.paged_attention.PagedAttention" (.getName (class x)))))
+
+(defn- positive-integer!
+  [owner field value]
+  (when-not (and (integer? value) (pos? value))
+    (throw (ex-info (str owner " requires a positive static " (name field))
+                    {:reason :paged-attention-nonpositive-or-dynamic-extent
+                     :field field :value value})))
+  value)
+
+(defn- finite-positive!
+  [field value]
+  (when-not (and (number? value)
+                 (Double/isFinite (double value))
+                 (pos? (double value)))
+    (throw (ex-info "paged attention scale must be finite and positive"
+                    {:reason :paged-attention-invalid-scale :field field :value value})))
+  value)
+
+(defn- checked-product
+  [field factors]
+  (try
+    (reduce (fn [acc factor] (Math/multiplyExact (long acc) (long factor))) 1 factors)
+    (catch ArithmeticException e
+      (throw (ex-info "paged attention storage extent exceeds signed 64-bit capacity"
+                      {:reason :paged-attention-extent-overflow
+                       :field field :factors (vec factors)} e)))))
+
+(defn validate!
+  "Validate a PagedAttention descriptor. Shapes are static in the reference vertical so GQA and
+   every storage extent are proved before emission; dynamic-shape routing needs a later checked
+   scalar-constraint IR rather than unchecked division inside a kernel."
+  [operation]
+  (when-not (paged-attention? operation)
+    (throw (ex-info "paged attention operation must be a PagedAttention value"
+                    {:operation operation :actual (type operation)})))
+  (let [{:keys [id q k-pages v-pages page-table lengths output
+                batch-size q-heads kv-heads head-dim page-size physical-pages
+                pages-per-sequence q-dtype cache-dtype output-dtype accumulator-dtype
+                scale cache-format cache-layout]} operation
+        buffers [q k-pages v-pages page-table lengths output]]
+    (when (nil? id)
+      (throw (ex-info "paged attention requires a stable identity" {})))
+    (when (some nil? buffers)
+      (throw (ex-info "paged attention requires every logical buffer identity"
+                      {:buffers buffers})))
+    (when-not (= (count buffers) (count (distinct buffers)))
+      (throw (ex-info "paged attention logical buffer identities must be distinct"
+                      {:reason :paged-attention-duplicate-buffer-identity
+                       :buffers buffers})))
+    (doseq [[field value] [[:batch-size batch-size] [:q-heads q-heads]
+                           [:kv-heads kv-heads] [:head-dim head-dim]
+                           [:page-size page-size] [:physical-pages physical-pages]
+                           [:pages-per-sequence pages-per-sequence]]]
+      (positive-integer! "paged attention" field value))
+    (when-not (zero? (mod q-heads kv-heads))
+      (throw (ex-info "paged attention requires q-heads divisible by kv-heads"
+                      {:reason :paged-attention-invalid-gqa-ratio
+                       :q-heads q-heads :kv-heads kv-heads})))
+    (doseq [[field value] [[:q-dtype q-dtype] [:cache-dtype cache-dtype]
+                           [:output-dtype output-dtype]
+                           [:accumulator-dtype accumulator-dtype]]]
+      (when-not (dtype/known? value)
+        (throw (ex-info "paged attention has an unknown dtype"
+                        {:reason :paged-attention-unknown-dtype
+                         :field field :dtype value}))))
+    (when-not (every? dtype/fp-dtype? [q-dtype output-dtype accumulator-dtype])
+      (throw (ex-info "paged attention query, output and accumulator dtypes must be floating point"
+                      {:reason :paged-attention-nonfloating-dtype
+                       :dtypes [q-dtype output-dtype accumulator-dtype]})))
+    (finite-positive! :scale scale)
+    (when-not (map? cache-format)
+      (throw (ex-info "paged attention cache-format must be a map"
+                      {:cache-format cache-format})))
+    (when-not (= (dtype/canon cache-dtype) (dtype/canon (:dtype cache-format)))
+      (throw (ex-info "paged attention cache format dtype differs from cache storage"
+                      {:reason :paged-attention-cache-format-dtype-mismatch
+                       :cache-dtype cache-dtype :cache-format cache-format})))
+    (when-not (keyword? (:quantization cache-format))
+      (throw (ex-info "paged attention cache format requires a quantization mode"
+                      {:reason :paged-attention-cache-format-missing-quantization
+                       :cache-format cache-format})))
+    (when (and (= :none (:quantization cache-format))
+               (not (dtype/fp-dtype? cache-dtype)))
+      (throw (ex-info "plain paged attention cache storage must be floating point"
+                      {:reason :paged-attention-plain-cache-nonfloating
+                       :cache-dtype cache-dtype :cache-format cache-format})))
+    (when-not (contains? cache-layouts cache-layout)
+      (throw (ex-info "paged attention cache layout is unsupported"
+                      {:reason :paged-attention-unsupported-cache-layout
+                       :cache-layout cache-layout :supported cache-layouts})))
+    ;; Prove all allocation sizes fit the extent representation now, not during allocation.
+    (checked-product :q [batch-size q-heads head-dim])
+    (checked-product :cache [kv-heads physical-pages page-size head-dim])
+    (checked-product :page-table [batch-size pages-per-sequence])
+    operation))
+
+(defn make
+  "Construct a checked decode paged-attention descriptor.
+
+   `cache-format` is representation metadata and defaults to plain storage. Quantized formats
+   will extend it with explicit scale buffers/grouping; the FP16 reference route refuses them
+   until that ABI exists."
+  [{:keys [id q k-pages v-pages page-table lengths output
+           batch-size q-heads kv-heads head-dim page-size physical-pages pages-per-sequence
+           q-dtype cache-dtype output-dtype accumulator-dtype scale cache-format cache-layout]
+    :or {q-dtype :half cache-dtype :half output-dtype :half accumulator-dtype :float
+         cache-format nil cache-layout :kv-head-major}}]
+  (let [q-dtype (dtype/canon q-dtype)
+        cache-dtype (dtype/canon cache-dtype)
+        output-dtype (dtype/canon output-dtype)
+        accumulator-dtype (dtype/canon accumulator-dtype)
+        cache-format (or cache-format {:dtype cache-dtype :quantization :none})
+        operation
+        (validate!
+         (->PagedAttention id q k-pages v-pages page-table lengths output
+                           batch-size q-heads kv-heads head-dim page-size physical-pages
+                           pages-per-sequence q-dtype cache-dtype output-dtype accumulator-dtype
+                           scale cache-format cache-layout))]
+    (assoc operation :scale (double scale))))
+
+(defn layouts
+  "Named logical layouts. These are semantic axes, not thread/register layouts."
+  [operation]
+  (let [{:keys [batch-size q-heads kv-heads head-dim page-size physical-pages
+                pages-per-sequence cache-layout]} (validate! operation)
+        cache-shape (case cache-layout
+                      :kv-head-major [kv-heads physical-pages page-size head-dim]
+                      :page-major [physical-pages page-size kv-heads head-dim])]
+    {:q [batch-size q-heads head-dim]
+     :k-pages cache-shape
+     :v-pages cache-shape
+     :page-table [batch-size pages-per-sequence]
+     :lengths [batch-size]
+     :output [batch-size q-heads head-dim]}))
+
+(defn buffer-specs
+  "Graph-buffer metadata keyed by the operation's compiler identities."
+  [operation]
+  (let [{:keys [q k-pages v-pages page-table lengths output
+                q-dtype cache-dtype output-dtype]} (validate! operation)
+        shapes (layouts operation)
+        elements #(checked-product % (get shapes %))]
+    {q {:role :input :dtype q-dtype :shape (:q shapes) :elements (elements :q)}
+     k-pages {:role :input :dtype cache-dtype :shape (:k-pages shapes)
+              :elements (elements :k-pages)}
+     v-pages {:role :input :dtype cache-dtype :shape (:v-pages shapes)
+              :elements (elements :v-pages)}
+     page-table {:role :input :dtype :int :shape (:page-table shapes)
+                 :elements (elements :page-table)}
+     lengths {:role :input :dtype :int :shape (:lengths shapes)
+              :elements (elements :lengths)}
+     output {:role :output :dtype output-dtype :shape (:output shapes)
+             :elements (elements :output)}}))
+
+(defn validate-routing!
+  "Validate host-visible page-table/length contents before upload. Runtime-owned page allocators
+   should call this at route construction; device kernels still guard corrupted resident tables
+   with NaN output rather than performing an out-of-bounds read."
+  [operation page-table-values length-values]
+  (let [{:keys [batch-size physical-pages pages-per-sequence page-size]}
+        (validate! operation)
+        table (vec page-table-values)
+        lengths (vec length-values)
+        table-elements (checked-product :page-table [batch-size pages-per-sequence])
+        max-tokens (checked-product :logical-capacity [pages-per-sequence page-size])]
+    (when-not (= table-elements (count table))
+      (throw (ex-info "paged attention page table has the wrong element count"
+                      {:reason :paged-attention-page-table-shape
+                       :expected table-elements :actual (count table)})))
+    (when-not (= batch-size (count lengths))
+      (throw (ex-info "paged attention lengths have the wrong element count"
+                      {:reason :paged-attention-lengths-shape
+                       :expected batch-size :actual (count lengths)})))
+    (doseq [[index page] (map-indexed vector table)]
+      (when-not (and (integer? page) (<= 0 page) (< page physical-pages))
+        (throw (ex-info "paged attention page table contains an invalid physical page"
+                        {:reason :paged-attention-invalid-physical-page
+                         :index index :page page :physical-pages physical-pages}))))
+    (doseq [[batch length] (map-indexed vector lengths)]
+      (when-not (and (integer? length) (<= 0 length max-tokens))
+        (throw (ex-info "paged attention sequence length exceeds its logical page capacity"
+                        {:reason :paged-attention-invalid-length
+                         :batch batch :length length :max-tokens max-tokens}))))
+    operation))

--- a/src/raster/compiler/passes/parallel/paged_attention_route.clj
+++ b/src/raster/compiler/passes/parallel/paged_attention_route.clj
@@ -1,0 +1,60 @@
+(ns raster.compiler.passes.parallel.paged-attention-route
+  "Structured routing for backend-neutral paged attention descriptors."
+  (:require [raster.compiler.backend.gpu.paged-attention :as emit]
+            [raster.compiler.ir.paged-attention :as paged]))
+
+(defn- decline
+  [operation reason data]
+  {:operation operation
+   :strategy nil
+   :reference? false
+   :declines [{:leaf :fp16-reference :reason reason :data data}]})
+
+(defn route
+  "Try the first executable paged-attention leaf and return a route or structured decline.
+
+   Quantized cache formats stay in semantic IR, but decline until their scale/group ABI is
+   explicit. This prevents a storage tag from smuggling a dequantization convention into codegen."
+  ([operation] (route operation nil))
+  ([operation desc]
+   (let [{:keys [q-dtype cache-dtype output-dtype accumulator-dtype cache-format]
+          :as operation} (paged/validate! operation)]
+     (cond
+       (and desc (not= :gpu (:device-type desc)))
+       (decline operation :paged-attention-requires-gpu
+                {:device-type (:device-type desc)})
+
+       (not= :none (:quantization cache-format))
+       (decline operation :paged-attention-quantized-cache-abi-unimplemented
+                {:cache-format cache-format})
+
+       (not= [:half :half :half]
+             [q-dtype cache-dtype output-dtype])
+       (decline operation :paged-attention-reference-storage-unsupported
+                {:required [:half :half :half]
+                 :actual [q-dtype cache-dtype output-dtype]})
+
+       (not= :float accumulator-dtype)
+       (decline operation :paged-attention-reference-accumulator-unsupported
+                {:required :float :actual accumulator-dtype})
+
+       :else
+       (let [artifact (emit/emit-fp16-reference operation desc)]
+         {:operation operation
+          :strategy :fp16-reference
+          :reference? true
+          :declines []
+          :artifact artifact
+          :graph (emit/kernel-graph operation artifact)
+          :schedule {:workgroup-size (:workgroup-size (:launch artifact))
+                     :group-count (:group-count (:launch artifact))}})))))
+
+(defn route!
+  "Route paged attention or fail with the complete machine-readable decline trail."
+  ([operation] (route! operation nil))
+  ([operation desc]
+   (let [result (route operation desc)]
+     (if (:strategy result)
+       result
+       (throw (ex-info "no executable paged-attention kernel route"
+                       {:reason :paged-attention-no-kernel-route :route result}))))))

--- a/test/raster/compiler/ir/paged_attention_test.clj
+++ b/test/raster/compiler/ir/paged_attention_test.clj
@@ -1,0 +1,75 @@
+(ns raster.compiler.ir.paged-attention-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.paged-attention :as paged]))
+
+(defn- operation
+  [& overrides]
+  (paged/make
+   (merge {:id :decode-attention
+           :q 'q :k-pages 'k-pages :v-pages 'v-pages
+           :page-table 'page-table :lengths 'lengths :output 'output
+           :batch-size 2 :q-heads 4 :kv-heads 2 :head-dim 8
+           :page-size 2 :physical-pages 7 :pages-per-sequence 3
+           :scale (/ 1.0 (Math/sqrt 8.0))}
+          (apply hash-map overrides))))
+
+(deftest descriptor-proves-layout-and-storage-extents
+  (let [op (operation)
+        specs (paged/buffer-specs op)]
+    (is (paged/paged-attention? op))
+    (is (= {:q [2 4 8]
+            :k-pages [2 7 2 8]
+            :v-pages [2 7 2 8]
+            :page-table [2 3]
+            :lengths [2]
+            :output [2 4 8]}
+           (paged/layouts op)))
+    (is (= {:role :input :dtype :half :shape [2 4 8] :elements 64}
+           (get specs 'q)))
+    (is (= 224 (get-in specs ['k-pages :elements])))
+    (is (= {:dtype :half :quantization :none} (:cache-format op)))
+    (is (= :kv-head-major (:cache-layout op)))
+    (is (= {:dtype :float :quantization :none}
+           (:cache-format (operation :cache-dtype :float))))
+    (is (= [7 2 2 8]
+           (:k-pages (paged/layouts (operation :cache-layout :page-major)))))))
+
+(deftest descriptor-refuses-invalid-semantics-before-emission
+  (testing "GQA mapping must be integral"
+    (is (= :paged-attention-invalid-gqa-ratio
+           (try
+             (operation :q-heads 3)
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))
+  (testing "logical buffers cannot alias accidentally"
+    (is (= :paged-attention-duplicate-buffer-identity
+           (try
+             (operation :output 'q)
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))
+  (testing "allocation arithmetic is checked"
+    (is (= :paged-attention-extent-overflow
+           (try
+             (operation :batch-size Long/MAX_VALUE :q-heads 2)
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))
+  (testing "cache stride order is explicit"
+    (is (= :paged-attention-unsupported-cache-layout
+           (try
+             (operation :cache-layout :implicit)
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))))
+
+(deftest host-visible-routing-is-validated-before-upload
+  (let [op (operation)
+        table [4 1 6 2 5 0]
+        lengths [5 3]]
+    (is (= op (paged/validate-routing! op table lengths)))
+    (is (= :paged-attention-page-table-shape
+           (try
+             (paged/validate-routing! op (pop table) lengths)
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+    (is (= :paged-attention-invalid-physical-page
+           (try
+             (paged/validate-routing! op (assoc table 1 7) lengths)
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+    (is (= :paged-attention-invalid-length
+           (try
+             (paged/validate-routing! op table [7 3])
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))))

--- a/test/raster/compiler/passes/parallel/paged_attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/paged_attention_route_test.clj
@@ -1,0 +1,71 @@
+(ns raster.compiler.passes.parallel.paged-attention-route-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-graph :as kgraph]
+            [raster.compiler.ir.paged-attention :as paged]
+            [raster.compiler.passes.parallel.paged-attention-route :as route]))
+
+(defn- operation
+  [& overrides]
+  (paged/make
+   (merge {:id :decode-attention
+           :q 'q :k-pages 'k-pages :v-pages 'v-pages
+           :page-table 'page-table :lengths 'lengths :output 'output
+           :batch-size 2 :q-heads 4 :kv-heads 2 :head-dim 20
+           :page-size 2 :physical-pages 7 :pages-per-sequence 3
+           :scale 0.25}
+          (apply hash-map overrides))))
+
+(deftest fp16-reference-route-is-a-complete-executable-compiler-value
+  (let [{:keys [strategy reference? declines artifact graph schedule]}
+        (route/route! (operation)
+                      {:device-type :gpu :subgroup-size 16 :max-workgroup-size 256})]
+    (is (= :fp16-reference strategy))
+    (is reference?)
+    (is (empty? declines))
+    (is (kart/kernel-artifact? artifact))
+    (is (kgraph/kernel-graph? graph))
+    (is (= '[q k-pages v-pages page-table lengths output]
+           (:arguments artifact)))
+    (is (= ["q" "k_pages" "v_pages" "page_table" "lengths" "output"]
+           (mapv :c-name (:abi artifact))))
+    (is (= [:half :half :half :int :int :half]
+           (mapv :dtype (:abi artifact))))
+    (is (= {:workgroup-size [16 1 1] :group-count [2 4 2]} schedule))
+    (is (= 3 (count (:workgroup-size (:launch artifact)))))
+    (is (= 1 (count (:nodes graph))))
+    (is (= #{'q 'k-pages 'v-pages 'page-table 'lengths}
+           (set (map :id (:inputs graph)))))
+    (is (= ['output] (mapv :id (:outputs graph))))
+    (is (str/includes? (:source artifact) "const int kv_head = q_head / 2;"))
+    (is (str/includes? (:source artifact) "physical_page = page_table"))
+    (is (str/includes? (:source artifact) "float accumulator = 0.0f;"))))
+
+(deftest page-major-cache-layout-is-lowered-without-repacking
+  (let [artifact (:artifact (route/route! (operation :cache-layout :page-major)))]
+    (is (= :page-major (get-in artifact [:attributes :cache-layout])))
+    (is (str/includes? (:source artifact)
+                       "((physical_page * 2 + page_token) * 2 + kv_head) * 20"))))
+
+(deftest unsupported-representations-return-machine-readable-declines
+  (testing "quantization declines on its missing ABI before generic dtype routing"
+    (let [r (route/route
+             (operation :cache-dtype :byte
+                        :cache-format {:dtype :byte :quantization :int8
+                                       :group-size 32}))]
+      (is (nil? (:strategy r)))
+      (is (= :paged-attention-quantized-cache-abi-unimplemented
+             (get-in r [:declines 0 :reason])))))
+  (testing "plain non-FP16 storage declines rather than being silently reinterpreted"
+    (let [r (route/route (operation :q-dtype :float :output-dtype :float))]
+      (is (= :paged-attention-reference-storage-unsupported
+             (get-in r [:declines 0 :reason])))))
+  (testing "a CPU target cannot accidentally receive OpenCL GPU scheduling"
+    (is (= :paged-attention-requires-gpu
+           (get-in (route/route (operation) {:device-type :cpu})
+                   [:declines 0 :reason]))))
+  (is (= :paged-attention-no-kernel-route
+         (try
+           (route/route! (operation) {:device-type :cpu})
+           (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))

--- a/test/raster/gpu/paged_attention_device_test.clj
+++ b/test/raster/gpu/paged_attention_device_test.clj
@@ -1,0 +1,149 @@
+(ns raster.gpu.paged-attention-device-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is]]
+            [raster.compiler.ir.paged-attention :as paged]
+            [raster.compiler.passes.parallel.paged-attention-route :as route]
+            [raster.dl.gpu-grad-parity :as gp]
+            [raster.gpu.core :as gpu]))
+
+(def ^:private ocl-fp16-available?
+  (delay
+    (try
+      (require 'raster.gpu.ocl-runtime)
+      ((resolve 'raster.gpu.ocl-runtime/init!))
+      (boolean
+       (some #(str/includes? (or (:extensions %) "") "cl_khr_fp16")
+             ((resolve 'raster.gpu.ocl-runtime/query-devices))))
+      (catch Throwable _ false))))
+
+(defn- encode-halfs
+  [values]
+  (short-array (map #(Float/floatToFloat16 (float %)) values)))
+
+(defn- decode-half
+  [value]
+  (double (Float/float16ToFloat (short value))))
+
+(defn- make-case
+  [cache-layout]
+  (let [dims {:batch-size 2 :q-heads 4 :kv-heads 2 :head-dim 8
+              :page-size 2 :physical-pages 7 :pages-per-sequence 3}
+        {:keys [batch-size q-heads kv-heads head-dim page-size physical-pages]} dims
+        q-elements (* batch-size q-heads head-dim)
+        cache-elements (* kv-heads physical-pages page-size head-dim)
+        q (encode-halfs
+           (map #(* 0.07 (- (mod (+ (* 3 %) 1) 13) 6)) (range q-elements)))
+        k (encode-halfs
+           (map #(* 0.05 (- (mod (+ (* 5 %) 2) 17) 8)) (range cache-elements)))
+        v (encode-halfs
+           (map #(* 0.04 (- (mod (+ (* 7 %) 3) 19) 9)) (range cache-elements)))
+        table (int-array [4 1 6, 2 5 0])
+        lengths (int-array [5 3])
+        operation (paged/make
+                   (merge dims
+                          {:id :device-reference
+                           :q 'q :k-pages 'k-pages :v-pages 'v-pages
+                           :page-table 'page-table :lengths 'lengths :output 'output
+                           :cache-layout cache-layout
+                           :scale (/ 1.0 (Math/sqrt (double head-dim)))}))]
+    (paged/validate-routing! operation table lengths)
+    {:operation operation :q q :k k :v v :table table :lengths lengths}))
+
+(defn- cache-index
+  [{:keys [physical-pages page-size kv-heads head-dim cache-layout]}
+   kv-head page token d]
+  (case cache-layout
+    :kv-head-major
+    (+ (* (+ (* (+ (* kv-head physical-pages) page) page-size) token) head-dim) d)
+    :page-major
+    (+ (* (+ (* (+ (* page page-size) token) kv-heads) kv-head) head-dim) d)))
+
+(defn- reference
+  [{:keys [operation q k v table lengths]}]
+  (let [{:keys [batch-size q-heads kv-heads head-dim page-size pages-per-sequence scale]}
+        operation
+        output (double-array (* batch-size q-heads head-dim))
+        gqa-ratio (quot q-heads kv-heads)]
+    (dotimes [batch batch-size]
+      (dotimes [q-head q-heads]
+        (let [kv-head (quot q-head gqa-ratio)
+              q-base (* (+ (* batch q-heads) q-head) head-dim)
+              length (aget ^ints lengths batch)
+              logits
+              (mapv
+               (fn [token]
+                 (let [logical-page (quot token page-size)
+                       page (aget ^ints table (+ (* batch pages-per-sequence) logical-page))
+                       page-token (rem token page-size)]
+                   (* scale
+                      (reduce +
+                              (map (fn [d]
+                                     (* (decode-half (aget ^shorts q (+ q-base d)))
+                                        (decode-half
+                                         (aget ^shorts k
+                                               (cache-index operation kv-head page page-token d)))))
+                                   (range head-dim))))))
+               (range length))
+              maximum (reduce max logits)
+              weights (mapv #(Math/exp (- (double %) maximum)) logits)
+              denominator (reduce + weights)]
+          (dotimes [d head-dim]
+            (let [value
+                  (/ (reduce +
+                             (map-indexed
+                              (fn [token weight]
+                                (let [logical-page (quot token page-size)
+                                      page (aget ^ints table
+                                                 (+ (* batch pages-per-sequence) logical-page))
+                                      page-token (rem token page-size)]
+                                  (* weight
+                                     (decode-half
+                                      (aget ^shorts v
+                                            (cache-index operation kv-head page page-token d))))))
+                              weights))
+                     denominator)]
+              (aset output (+ q-base d) value))))))
+    output))
+
+(defn- run-case
+  [device-id cache-layout]
+  (let [{:keys [operation q k v table lengths] :as test-case} (make-case cache-layout)
+        graph (:graph (route/route!
+                       operation {:device-type :gpu :subgroup-size 16
+                                  :max-workgroup-size 256}))
+        expected (reference test-case)
+        specs (paged/buffer-specs operation)]
+    (gpu/with-gpu-session [session device-id]
+      (gpu/alloc! session
+                  {:q [:half (get-in specs ['q :elements]) q]
+                   :k-pages [:half (get-in specs ['k-pages :elements]) k]
+                   :v-pages [:half (get-in specs ['v-pages :elements]) v]
+                   :page-table [:int (get-in specs ['page-table :elements]) table]
+                   :lengths [:int (get-in specs ['lengths :elements]) lengths]
+                   :output [:half (get-in specs ['output :elements]) nil]})
+      (let [handle (gpu/bind-kernel-graph!
+                    session :paged-attention graph
+                    {'q :q 'k-pages :k-pages 'v-pages :v-pages
+                     'page-table :page-table 'lengths :lengths 'output :output}
+                    {})]
+        (try
+          (gpu/run-kernel-graph! session handle)
+          (let [actual-bits ^shorts (gpu/download session :output)
+                actual (mapv decode-half actual-bits)]
+            (is (= (count expected) (count actual)))
+            (is (every? true?
+                        (map (fn [wanted got]
+                               (< (Math/abs (- (double wanted) (double got))) 0.01))
+                             expected actual))))
+          (finally
+            (gpu/release-kernel-graph! session handle)))))))
+
+(deftest level-zero-routed-paged-attention-matches-reference
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "routed FP16 paged attention on Level Zero")
+    (run-case :ze:0 :kv-head-major)))
+
+(deftest opencl-routed-paged-attention-matches-reference
+  (if-not @ocl-fp16-available?
+    (is true "OpenCL FP16 device unavailable")
+    (run-case :ocl:0 :page-major)))


### PR DESCRIPTION
## Summary

- add a backend-neutral decode-time paged GQA descriptor with checked shapes, dtypes, page routing, cache representation, and exact graph buffer extents
- support both JAX-style KV-head-major pages and page-major storage; page-major with page size 1 binds the current pretrained-rstr token-major cache without repacking
- route plain FP16 storage with FP32 online softmax to a verified six-pointer KernelArtifact, uniform 3-D launch, and explicit one-node KernelGraph
- keep quantized cache storage representable but return a structured decline until scale/group/zero-point buffers have an ordered ABI
- validate host-visible page tables and lengths before upload and guard resident routing before cache reads

The emitted leaf is deliberately a correctness oracle, not an optimized attention schedule: one work item owns one output component and recomputes QK, so complexity is quadratic in head dimension. Optimized tiled/flash candidates can now be compared against a stable executable contract.

## Verification

- clojure -M:format on all added files
- pure descriptor/router gate: 6 tests, 39 assertions
- live Arc numeric gate: Level Zero with KV-head-major pages and OpenCL with page-major pages, 2 tests, 4 assertions
- full cold suite with writable user.home: 2186 tests, 32927 assertions, 0 failures, 0 errors

CircleCI has no GPU, so the live Level Zero/OpenCL result is a local gate; CI exercises the pure compiler contracts.