### PR TITLE
Define semantic attention VJP

### DIFF
--- a/src/raster/compiler/ir/attention.clj
+++ b/src/raster/compiler/ir/attention.clj
@@ -153,7 +153,8 @@
                      :field field :storage-dtype storage-dtype :format format})))
   format)
 
-(defn- route-buffer-ids
+(defn route-buffer-ids
+  "Return the physical metadata buffer identities for a checked paged-route variant."
   [route]
   (cond
     (dense-paged-route? route)

--- a/src/raster/compiler/ir/attention_ad.clj
+++ b/src/raster/compiler/ir/attention_ad.clj
@@ -1,0 +1,156 @@
+(ns raster.compiler.ir.attention-ad
+  "Semantic reverse-mode differentiation contract for AttentionProblem.
+
+   Differentiation happens before route scheduling and target emission. Q/K/V are the only
+   differentiable values. Packed row metadata, logical positions, visibility, physical routes,
+   allocation identities and events are discrete. K/V cotangents are physical-cache-shaped
+   routed sums, so shared pages accumulate contributions rather than being overwritten."
+  (:require [clojure.set :as set]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.attention :as attention]))
+
+(defrecord AttentionVJP
+           [id primal output-cotangent cotangents active-values
+            softmax-state-mode saved-lse accumulator-dtype])
+
+(def ^:private differentiable-values #{:query :key :value})
+(def ^:private softmax-state-modes #{:recompute :saved-lse})
+
+(defn attention-vjp?
+  [x]
+  (instance? AttentionVJP x))
+
+(defn differentiable-buffer-ids
+  "Logical differentiable roles and their primal buffer identities."
+  [problem]
+  (let [{:keys [query k-pages v-pages]} (attention/validate! problem)]
+    {:query (:values query) :key k-pages :value v-pages}))
+
+(defn nondifferentiable-buffer-ids
+  "Discrete metadata that must never receive tangents. Visibility is static data and therefore
+   has no buffer identity here; allocation/event state is intentionally absent from AttentionProblem."
+  [problem]
+  (let [{:keys [query route]} (attention/validate! problem)]
+    {:query-row-offsets (:row-offsets query)
+     :query-positions (:positions query)
+     :route (attention/route-buffer-ids route)}))
+
+(defn validate!
+  "Validate an AttentionVJP independently of any target schedule. Activity is an explicit subset
+   of Q/K/V; a detached inference cache therefore requests only `:query`, while training normally
+   requests all three. Quantized storage declines until its decode/gradient rule is declared."
+  [vjp]
+  (when-not (attention-vjp? vjp)
+    (throw (ex-info "attention VJP must be an AttentionVJP"
+                    {:reason :attention-invalid-vjp :actual (type vjp)})))
+  (let [{:keys [id primal output-cotangent cotangents active-values
+                softmax-state-mode saved-lse accumulator-dtype]} vjp
+        {:keys [k-format v-format] :as primal} (attention/validate! primal)
+        active-values (set active-values)]
+    (when (nil? id)
+      (throw (ex-info "attention VJP requires a stable identity"
+                      {:reason :attention-vjp-missing-id})))
+    (when (or (empty? active-values)
+              (not (set/subset? active-values differentiable-values)))
+      (throw (ex-info "attention VJP activity must be a nonempty subset of Q/K/V"
+                      {:reason :attention-invalid-vjp-activity
+                       :active-values active-values
+                       :supported differentiable-values})))
+    (when-not (= active-values (set (keys cotangents)))
+      (throw (ex-info "attention VJP cotangent outputs must exactly match active values"
+                      {:reason :attention-vjp-cotangent-activity-mismatch
+                       :active-values active-values :cotangent-roles (set (keys cotangents))})))
+    (when (some nil? (cons output-cotangent (vals cotangents)))
+      (throw (ex-info "attention VJP requires every active cotangent buffer identity"
+                      {:reason :attention-vjp-missing-buffer
+                       :output-cotangent output-cotangent :cotangents cotangents})))
+    (when-not (contains? softmax-state-modes softmax-state-mode)
+      (throw (ex-info "attention VJP has an unsupported softmax-state policy"
+                      {:reason :attention-invalid-softmax-state-mode
+                       :mode softmax-state-mode :supported softmax-state-modes})))
+    (case softmax-state-mode
+      :recompute
+      (when (some? saved-lse)
+        (throw (ex-info "recomputed attention VJP cannot bind saved LSE"
+                        {:reason :attention-unexpected-saved-lse :saved-lse saved-lse})))
+
+      :saved-lse
+      (when (nil? saved-lse)
+        (throw (ex-info "saved-LSE attention VJP requires its buffer identity"
+                        {:reason :attention-missing-saved-lse}))))
+    (when-not (and (dtype/known? accumulator-dtype)
+                   (dtype/fp-dtype? accumulator-dtype))
+      (throw (ex-info "attention VJP accumulator must be floating point"
+                      {:reason :attention-invalid-vjp-accumulator
+                       :accumulator-dtype accumulator-dtype})))
+    (when (or (not= :none (:quantization k-format))
+              (not= :none (:quantization v-format)))
+      (throw (ex-info "quantized attention requires an explicit decode/gradient rule"
+                      {:reason :attention-quantized-vjp-undeclared
+                       :k-format k-format :v-format v-format})))
+    (let [primal-ids (set (keys (attention/buffer-specs primal)))
+          derivative-ids (vec (concat [output-cotangent] (vals cotangents)
+                                      (when saved-lse [saved-lse])))]
+      (when-not (= (count derivative-ids) (count (distinct derivative-ids)))
+        (throw (ex-info "attention derivative buffer identities must be distinct"
+                        {:reason :attention-duplicate-vjp-buffer-identity
+                         :buffers derivative-ids})))
+      (when-let [aliases (seq (filter primal-ids derivative-ids))]
+        (throw (ex-info "attention derivative buffers cannot alias semantic primal identities"
+                        {:reason :attention-vjp-primal-buffer-alias :buffers (vec aliases)}))))
+    vjp))
+
+(defn make
+  "Construct a checked semantic attention VJP. `cotangents` is keyed by any active subset of
+   `:query`, `:key`, and `:value`. `:recompute` is the default softmax checkpoint policy."
+  [{:keys [id primal output-cotangent cotangents active-values
+           softmax-state-mode saved-lse accumulator-dtype]
+    :or {softmax-state-mode :recompute accumulator-dtype :float}}]
+  (let [active-values (set (or active-values (keys cotangents)))
+        vjp (->AttentionVJP id primal output-cotangent (or cotangents {}) active-values
+                            softmax-state-mode saved-lse (dtype/canon accumulator-dtype))]
+    (validate! vjp)))
+
+(defn differentiation-contract
+  "Machine-readable activity, checkpointing, and accumulation semantics used by AD legalization
+   and later backward scheduling."
+  [vjp]
+  (let [{:keys [primal active-values softmax-state-mode saved-lse]} (validate! vjp)]
+    {:differentiable (differentiable-buffer-ids primal)
+     :active-values active-values
+     :nondifferentiable (nondifferentiable-buffer-ids primal)
+     :cotangent-accumulation
+     (into {}
+           (map (fn [role]
+                  [role (if (= :query role) :write :routed-sum)]))
+           active-values)
+     :softmax-state {:mode softmax-state-mode :buffer saved-lse}
+     :inference-cache-detached?
+     (empty? (set/intersection active-values #{:key :value}))}))
+
+(defn buffer-specs
+  "Backward graph buffers keyed by compiler identity. Primal output is not read by the stable
+   softmax VJP; the output cotangent and optional saved LSE are explicit inputs."
+  [vjp]
+  (let [{:keys [primal output-cotangent cotangents active-values saved-lse accumulator-dtype]}
+        (validate! vjp)
+        {:keys [query output q-dtype k-dtype v-dtype output-dtype]} primal
+        primal-specs (dissoc (attention/buffer-specs primal) output)
+        shapes (attention/layouts primal)
+        elements (fn [shape] (reduce * 1 shape))
+        role-specs {:query {:role :output :dtype q-dtype :shape (:q shapes)
+                            :elements (elements (:q shapes))}
+                    :key {:role :output :dtype k-dtype :shape (:k-pages shapes)
+                          :elements (elements (:k-pages shapes))}
+                    :value {:role :output :dtype v-dtype :shape (:v-pages shapes)
+                            :elements (elements (:v-pages shapes))}}
+        derivative-specs
+        (into {output-cotangent {:role :input :dtype output-dtype :shape (:output shapes)
+                                 :elements (elements (:output shapes))}}
+              (map (fn [role] [(get cotangents role) (get role-specs role)]))
+              active-values)]
+    (cond-> (merge primal-specs derivative-specs)
+      saved-lse
+      (assoc saved-lse {:role :input :dtype accumulator-dtype
+                        :shape [(:total-tokens query) (:q-heads primal)]
+                        :elements (* (:total-tokens query) (:q-heads primal))}))))

--- a/src/raster/compiler/reference/attention.clj
+++ b/src/raster/compiler/reference/attention.clj
@@ -1,0 +1,253 @@
+(ns raster.compiler.reference.attention
+  "Independent host oracle for semantic routed attention and its VJP.
+
+   Values are supplied by compiler buffer identity. The oracle operates in double precision and
+   is deliberately schedule-free: dense and CSR page routes must produce the same logical result.
+   It is a correctness/differential-test implementation, not a runtime fallback."
+  (:require [raster.compiler.ir.attention :as attention]
+            [raster.compiler.ir.attention-ad :as attention-ad]))
+
+(defn- value-vector!
+  [values buffer-id expected-elements]
+  (let [value (get values buffer-id ::missing)]
+    (when (= ::missing value)
+      (throw (ex-info "attention reference is missing a buffer value"
+                      {:reason :attention-reference-missing-value :buffer buffer-id})))
+    (let [value (vec value)]
+      (when-not (= expected-elements (count value))
+        (throw (ex-info "attention reference buffer has the wrong element count"
+                        {:reason :attention-reference-value-shape
+                         :buffer buffer-id :expected expected-elements :actual (count value)})))
+      value)))
+
+(defn- checked-values
+  [problem values extra-specs]
+  (let [specs (merge (dissoc (attention/buffer-specs problem) (:output problem)) extra-specs)]
+    (into {}
+          (map (fn [[buffer-id {:keys [elements]}]]
+                 [buffer-id (value-vector! values buffer-id elements)]))
+          specs)))
+
+(defn- route-values
+  [problem values]
+  (let [route (:route problem)]
+    (if (attention/dense-paged-route? route)
+      {:page-table (get values (:page-table route))
+       :lengths (get values (:lengths route))
+       :start-positions (get values (:start-positions route))}
+      {:page-offsets (get values (:page-offsets route))
+       :page-indices (get values (:page-indices route))
+       :last-page-lengths (get values (:last-page-lengths route))
+       :start-positions (get values (:start-positions route))})))
+
+(defn- prepare
+  [problem values extra-specs]
+  (let [{:keys [query] :as problem} (attention/validate! problem)
+        values (checked-values problem values extra-specs)]
+    (attention/validate-query-values!
+     problem (get values (:row-offsets query)) (get values (:positions query)))
+    (attention/validate-routing! problem (route-values problem values))
+    [problem values]))
+
+(defn- query-batches
+  [problem values]
+  (let [{:keys [query batch-size]} problem
+        offsets (get values (:row-offsets query))
+        result (int-array (:total-tokens query))]
+    (dotimes [batch batch-size]
+      (doseq [token (range (nth offsets batch) (nth offsets (inc batch)))]
+        (aset result token batch)))
+    result))
+
+(defn- route-row
+  [problem values batch]
+  (let [{:keys [route page-size]} problem]
+    (if (attention/dense-paged-route? route)
+      (let [lengths (get values (:lengths route))
+            pages (get values (:page-table route))
+            pages-per-sequence (:pages-per-sequence route)]
+        {:length (nth lengths batch)
+         :start-position (nth (get values (:start-positions route)) batch)
+         :physical-page
+         (fn [logical-page]
+           (nth pages (+ (* batch pages-per-sequence) logical-page)))})
+      (let [offsets (get values (:page-offsets route))
+            indices (get values (:page-indices route))
+            lasts (get values (:last-page-lengths route))
+            page-begin (nth offsets batch)
+            page-end (nth offsets (inc batch))
+            page-count (- page-end page-begin)]
+        {:length (if (zero? page-count)
+                   0
+                   (+ (* (dec page-count) page-size) (nth lasts batch)))
+         :start-position (nth (get values (:start-positions route)) batch)
+         :physical-page (fn [logical-page] (nth indices (+ page-begin logical-page)))}))))
+
+(defn- cache-index
+  [{:keys [physical-pages page-size kv-heads]} layout dim kv-head page token d]
+  (case layout
+    :kv-head-major
+    (+ (* (+ (* (+ (* kv-head physical-pages) page) page-size) token) dim) d)
+
+    :page-major
+    (+ (* (+ (* (+ (* page page-size) token) kv-heads) kv-head) dim) d)))
+
+(defn- visible?
+  [{:keys [causal? window-left window-right]} query-position kv-position]
+  (and (or (not causal?) (<= kv-position query-position))
+       (or (nil? window-left) (>= kv-position (- query-position window-left)))
+       (or (nil? window-right) (<= kv-position (+ query-position window-right)))))
+
+(defn- attention-row
+  [problem values query-token query-head batch]
+  (let [{:keys [query k-pages q-heads kv-heads qk-head-dim page-size scale k-layout
+                visibility]} problem
+        q (get values (:values query))
+        k (get values k-pages)
+        query-position (nth (get values (:positions query)) query-token)
+        kv-head (quot query-head (quot q-heads kv-heads))
+        q-base (* (+ (* query-token q-heads) query-head) qk-head-dim)
+        {:keys [length start-position physical-page]} (route-row problem values batch)
+        tokens
+        (into []
+              (keep (fn [token]
+                      (let [kv-position (+ start-position token)]
+                        (when (visible? visibility query-position kv-position)
+                          (let [page (physical-page (quot token page-size))
+                                page-token (rem token page-size)
+                                k-base (cache-index problem k-layout qk-head-dim
+                                                    kv-head page page-token 0)
+                                logit
+                                (* scale
+                                   (reduce + 0.0
+                                           (map (fn [d]
+                                                  (* (double (nth q (+ q-base d)))
+                                                     (double (nth k (+ k-base d)))))
+                                                (range qk-head-dim))))]
+                            {:token token :page page :page-token page-token :logit logit})))))
+              (range length))]
+    (if (empty? tokens)
+      {:kv-head kv-head :q-base q-base :tokens [] :lse Double/NEGATIVE_INFINITY}
+      (let [maximum (reduce max (map :logit tokens))
+            denominator (reduce + 0.0 (map #(Math/exp (- (double (:logit %)) maximum)) tokens))
+            lse (+ maximum (Math/log denominator))]
+        {:kv-head kv-head :q-base q-base :tokens tokens :lse lse}))))
+
+(defn reference-forward-with-state
+  "Return `{:output double-array :lse double-array}` for host values keyed by compiler buffer ID."
+  [problem raw-values]
+  (let [[{:keys [query v-pages q-heads value-head-dim v-layout] :as problem} values]
+        (prepare problem raw-values {})
+        total-tokens (:total-tokens query)
+        output (double-array (* total-tokens q-heads value-head-dim))
+        lse (double-array (* total-tokens q-heads))
+        batches (query-batches problem values)
+        v (get values v-pages)]
+    (dotimes [query-token total-tokens]
+      (dotimes [query-head q-heads]
+        (let [batch (aget batches query-token)
+              {:keys [kv-head tokens] :as row}
+              (attention-row problem values query-token query-head batch)
+              row-lse (:lse row)
+              out-base (* (+ (* query-token q-heads) query-head) value-head-dim)]
+          (aset lse (+ (* query-token q-heads) query-head) row-lse)
+          (doseq [{:keys [page page-token logit]} tokens
+                  :let [weight (Math/exp (- (double logit) row-lse))
+                        v-base (cache-index problem v-layout value-head-dim
+                                            kv-head page page-token 0)]
+                  d (range value-head-dim)]
+            (aset output (+ out-base d)
+                  (+ (aget output (+ out-base d))
+                     (* weight (double (nth v (+ v-base d))))))))))
+    {:output output :lse lse}))
+
+(defn reference-forward
+  "Return the schedule-free double-precision attention output."
+  [problem values]
+  (:output (reference-forward-with-state problem values)))
+
+(defn reference-vjp
+  "Evaluate the semantic attention VJP. Returned keys are the requested active roles.
+
+   K/V results have physical cache shapes and use addition at every routed write. Consequently,
+   two logical rows that reference one physical page produce the required shared-page sum."
+  [vjp raw-values]
+  (let [{:keys [primal output-cotangent active-values softmax-state-mode saved-lse]
+         :as vjp} (attention-ad/validate! vjp)
+        extra-specs (select-keys (attention-ad/buffer-specs vjp)
+                                 (cond-> [output-cotangent] saved-lse (conj saved-lse)))
+        [{:keys [query k-pages v-pages q-heads qk-head-dim value-head-dim
+                 scale k-layout v-layout]
+          :as problem} values]
+        (prepare primal raw-values extra-specs)
+        total-tokens (:total-tokens query)
+        q (get values (:values query))
+        k (get values k-pages)
+        v (get values v-pages)
+        d-output (get values output-cotangent)
+        saved-lse-values (when saved-lse (get values saved-lse))
+        batches (query-batches problem values)
+        d-query (when (contains? active-values :query)
+                  (double-array (* total-tokens q-heads qk-head-dim)))
+        d-key (when (contains? active-values :key)
+                (double-array (get-in (attention/buffer-specs problem) [k-pages :elements])))
+        d-value (when (contains? active-values :value)
+                  (double-array (get-in (attention/buffer-specs problem) [v-pages :elements])))]
+    (dotimes [query-token total-tokens]
+      (dotimes [query-head q-heads]
+        (let [batch (aget batches query-token)
+              {:keys [kv-head q-base tokens]
+               recomputed-lse :lse}
+              (attention-row problem values query-token query-head batch)
+              lse-index (+ (* query-token q-heads) query-head)
+              lse (if (= :saved-lse softmax-state-mode)
+                    (double (nth saved-lse-values lse-index))
+                    recomputed-lse)
+              out-base (* (+ (* query-token q-heads) query-head) value-head-dim)
+              weighted-output-adjoint
+              (reduce
+               + 0.0
+               (map (fn [{:keys [page page-token logit]}]
+                      (let [weight (Math/exp (- (double logit) lse))
+                            v-base (cache-index problem v-layout value-head-dim
+                                                kv-head page page-token 0)
+                            d-weight
+                            (reduce + 0.0
+                                    (map (fn [d]
+                                           (* (double (nth d-output (+ out-base d)))
+                                              (double (nth v (+ v-base d)))))
+                                         (range value-head-dim)))]
+                        (* weight d-weight)))
+                    tokens))]
+          (doseq [{:keys [page page-token logit]} tokens
+                  :let [weight (Math/exp (- (double logit) lse))
+                        k-base (cache-index problem k-layout qk-head-dim
+                                            kv-head page page-token 0)
+                        v-base (cache-index problem v-layout value-head-dim
+                                            kv-head page page-token 0)
+                        d-weight
+                        (reduce + 0.0
+                                (map (fn [d]
+                                       (* (double (nth d-output (+ out-base d)))
+                                          (double (nth v (+ v-base d)))))
+                                     (range value-head-dim)))
+                        d-logit (* weight (- d-weight weighted-output-adjoint))]]
+            (when d-query
+              (dotimes [d qk-head-dim]
+                (aset d-query (+ q-base d)
+                      (+ (aget d-query (+ q-base d))
+                         (* scale d-logit (double (nth k (+ k-base d))))))))
+            (when d-key
+              (dotimes [d qk-head-dim]
+                (aset d-key (+ k-base d)
+                      (+ (aget d-key (+ k-base d))
+                         (* scale d-logit (double (nth q (+ q-base d))))))))
+            (when d-value
+              (dotimes [d value-head-dim]
+                (aset d-value (+ v-base d)
+                      (+ (aget d-value (+ v-base d))
+                         (* weight (double (nth d-output (+ out-base d))))))))))))
+    (cond-> {}
+      d-query (assoc :query d-query)
+      d-key (assoc :key d-key)
+      d-value (assoc :value d-value))))

--- a/test/raster/compiler/ir/attention_ad_test.clj
+++ b/test/raster/compiler/ir/attention_ad_test.clj
@@ -1,0 +1,86 @@
+(ns raster.compiler.ir.attention-ad-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.attention :as attention]
+            [raster.compiler.ir.attention-ad :as attention-ad]))
+
+(defn- problem
+  [& overrides]
+  (attention/make
+   (merge
+    {:id :attention
+     :query (attention/packed-query-batch
+             {:values 'q :row-offsets 'q-offsets :positions 'q-positions :total-tokens 3})
+     :k-pages 'k :v-pages 'v :output 'output
+     :route (attention/dense-paged-route
+             {:page-table 'pages :lengths 'lengths :start-positions 'starts
+              :pages-per-sequence 2})
+     :batch-size 3 :q-heads 2 :kv-heads 1 :qk-head-dim 2 :value-head-dim 3
+     :page-size 2 :physical-pages 3 :scale (/ 1.0 (Math/sqrt 2.0))
+     :visibility (attention/visibility {:causal? true :window-left 2 :window-right 0})}
+    (apply hash-map overrides))))
+
+(defn- full-vjp
+  [& overrides]
+  (attention-ad/make
+   (merge {:id :attention-vjp :primal (problem) :output-cotangent 'd-output
+           :cotangents {:query 'd-q :key 'd-k :value 'd-v}}
+          (apply hash-map overrides))))
+
+(deftest semantic-vjp-separates-activity-metadata-and-accumulation
+  (let [vjp (full-vjp)
+        contract (attention-ad/differentiation-contract vjp)
+        specs (attention-ad/buffer-specs vjp)]
+    (is (attention-ad/attention-vjp? vjp))
+    (is (= #{:query :key :value} (:active-values contract)))
+    (is (= {:query 'q :key 'k :value 'v} (:differentiable contract)))
+    (is (= {:query-row-offsets 'q-offsets
+            :query-positions 'q-positions
+            :route '[pages lengths starts]}
+           (:nondifferentiable contract)))
+    (is (= {:query :write :key :routed-sum :value :routed-sum}
+           (:cotangent-accumulation contract)))
+    (is (false? (:inference-cache-detached? contract)))
+    (is (= [3 2 2] (get-in specs ['d-q :shape])))
+    (is (= [1 3 2 2] (get-in specs ['d-k :shape])))
+    (is (= [1 3 2 3] (get-in specs ['d-v :shape])))
+    (is (= :input (get-in specs ['d-output :role])))
+    (is (nil? (get specs 'output)))))
+
+(deftest selective-activity-makes-inference-cache-detachment-explicit
+  (let [vjp (attention-ad/make
+             {:id :query-only-vjp :primal (problem) :output-cotangent 'd-output
+              :active-values #{:query} :cotangents {:query 'd-q}})
+        contract (attention-ad/differentiation-contract vjp)]
+    (is (= #{:query} (:active-values vjp)))
+    (is (:inference-cache-detached? contract))
+    (is (= {:query :write} (:cotangent-accumulation contract)))
+    (is (nil? (get (attention-ad/buffer-specs vjp) 'd-k)))))
+
+(deftest checkpoint-policy-and-ad-legality-fail-loud
+  (testing "saved LSE is an explicit backward input"
+    (let [vjp (full-vjp :softmax-state-mode :saved-lse :saved-lse 'lse)]
+      (is (= {:mode :saved-lse :buffer 'lse}
+             (:softmax-state (attention-ad/differentiation-contract vjp))))
+      (is (= [3 2] (get-in (attention-ad/buffer-specs vjp) ['lse :shape])))))
+  (testing "discrete metadata cannot be marked active"
+    (is (= :attention-invalid-vjp-activity
+           (try
+             (full-vjp :active-values #{:query :route})
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))
+  (testing "activity and cotangent outputs agree exactly"
+    (is (= :attention-vjp-cotangent-activity-mismatch
+           (try
+             (full-vjp :active-values #{:query :key})
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))
+  (testing "quantized storage needs a deliberate gradient rule"
+    (is (= :attention-quantized-vjp-undeclared
+           (try
+             (full-vjp
+              :primal (problem :k-dtype :byte
+                               :k-format {:dtype :byte :quantization :int8 :group-size 32}))
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))
+  (testing "derivative buffers cannot masquerade as primals"
+    (is (= :attention-vjp-primal-buffer-alias
+           (try
+             (full-vjp :output-cotangent 'output)
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))))

--- a/test/raster/compiler/reference/attention_test.clj
+++ b/test/raster/compiler/reference/attention_test.clj
@@ -1,0 +1,148 @@
+(ns raster.compiler.reference.attention-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.attention :as attention]
+            [raster.compiler.ir.attention-ad :as attention-ad]
+            [raster.compiler.reference.attention :as reference]))
+
+(def ^:private dims
+  {:batch-size 3 :q-heads 2 :kv-heads 1 :qk-head-dim 2 :value-head-dim 2
+   :page-size 2 :physical-pages 3})
+
+(defn- query
+  []
+  (attention/packed-query-batch
+   {:values 'q :row-offsets 'q-offsets :positions 'q-positions :total-tokens 3}))
+
+(defn- route
+  [kind]
+  (case kind
+    :dense-paged
+    (attention/dense-paged-route
+     {:page-table 'pages :lengths 'lengths :start-positions 'starts
+      :pages-per-sequence 2})
+
+    :csr-paged
+    (attention/csr-paged-route
+     {:page-offsets 'page-offsets :page-indices 'page-indices
+      :last-page-lengths 'lasts :start-positions 'starts :page-index-capacity 5})))
+
+(defn- problem
+  [kind]
+  (attention/make
+   (merge dims
+          {:id [:attention kind] :query (query) :k-pages 'k :v-pages 'v :output 'output
+           :route (route kind) :scale (/ 1.0 (Math/sqrt 2.0))
+           :k-layout :kv-head-major :v-layout :page-major
+           :visibility (attention/visibility
+                        {:causal? true :window-left 2 :window-right 0})})))
+
+(defn- data
+  [kind]
+  (merge
+   {'q [0.12 -0.31, 0.27 0.08, -0.19 0.41,
+        0.33 -0.22, -0.14 0.29, 0.38 0.17]
+    'k [0.11 -0.07, 0.23 0.31,
+        -0.29 0.13, 0.37 -0.17,
+        0.19 0.43, -0.41 0.05]
+    'v [0.17 -0.23, 0.31 0.09,
+        -0.27 0.35, 0.41 -0.11,
+        0.07 0.29, -0.33 0.21]
+    'q-offsets [0 2 2 3]
+    'q-positions [1 2 2]
+    'starts [0 0 0]
+    'd-output [0.21 -0.14, -0.32 0.17,
+               0.09 0.28, -0.16 -0.23,
+               0.34 0.12, -0.27 0.19]}
+   (case kind
+     :dense-paged {'pages [1 2, -1 -1, 1 0] 'lengths [3 0 3]}
+     :csr-paged {'page-offsets [0 2 2 4]
+                 'page-indices [1 2 1 0 -1]
+                 'lasts [1 0 1]})))
+
+(defn- vjp
+  [kind & overrides]
+  (attention-ad/make
+   (merge {:id [:attention-vjp kind] :primal (problem kind)
+           :output-cotangent 'd-output
+           :cotangents {:query 'd-q :key 'd-k :value 'd-v}}
+          (apply hash-map overrides))))
+
+(defn- close?
+  ([a b] (close? a b 1.0e-9))
+  ([a b tolerance]
+   (< (Math/abs (- (double a) (double b))) tolerance)))
+
+(defn- arrays-close?
+  [a b tolerance]
+  (and (= (count a) (count b))
+       (every? true? (map #(close? %1 %2 tolerance) a b))))
+
+(defn- objective
+  [problem values]
+  (reduce + 0.0 (map * (reference/reference-forward problem values) (get values 'd-output))))
+
+(defn- numerical-gradient
+  [problem values buffer-id epsilon]
+  (let [primal (vec (get values buffer-id))]
+    (mapv
+     (fn [index]
+       (let [x (double (nth primal index))
+             plus (assoc primal index (+ x epsilon))
+             minus (assoc primal index (- x epsilon))]
+         (/ (- (objective problem (assoc values buffer-id plus))
+               (objective problem (assoc values buffer-id minus)))
+            (* 2.0 epsilon))))
+     (range (count primal)))))
+
+(deftest dense-and-csr-routes-have-identical-forward-and-vjp-semantics
+  (let [dense-data (data :dense-paged)
+        csr-data (data :csr-paged)
+        dense-output (reference/reference-forward (problem :dense-paged) dense-data)
+        csr-output (reference/reference-forward (problem :csr-paged) csr-data)
+        dense-grads (reference/reference-vjp (vjp :dense-paged) dense-data)
+        csr-grads (reference/reference-vjp (vjp :csr-paged) csr-data)]
+    (is (arrays-close? dense-output csr-output 1.0e-12))
+    (doseq [role [:query :key :value]]
+      (is (arrays-close? (get dense-grads role) (get csr-grads role) 1.0e-12)
+          (str "route-independent " role " cotangent")))))
+
+(deftest routed-vjp-matches-finite-differences-with-gqa-windows-and-empty-packed-row
+  (doseq [kind [:dense-paged :csr-paged]
+          :let [problem (problem kind)
+                values (data kind)
+                analytical (reference/reference-vjp (vjp kind) values)]]
+    (testing (name kind)
+      (doseq [[role buffer-id] [[:query 'q] [:key 'k] [:value 'v]]]
+        (let [numerical (numerical-gradient problem values buffer-id 1.0e-6)]
+          (is (arrays-close? (get analytical role) numerical 2.0e-8)
+              (str role " finite-difference agreement")))))))
+
+(deftest shared-pages-sum-gradient-contributions-and-saved-lse-is-equivalent
+  (let [kind :csr-paged
+        values (data kind)
+        full (reference/reference-vjp (vjp kind) values)
+        dy (vec (get values 'd-output))
+        first-only (assoc values 'd-output (into (subvec dy 0 8) (repeat 4 0.0)))
+        third-only (assoc values 'd-output (into (vec (repeat 8 0.0)) (subvec dy 8 12)))
+        first-grad (reference/reference-vjp (vjp kind) first-only)
+        third-grad (reference/reference-vjp (vjp kind) third-only)
+        {:keys [lse]} (reference/reference-forward-with-state (problem kind) values)
+        saved-vjp (vjp kind :softmax-state-mode :saved-lse :saved-lse 'lse)
+        saved (reference/reference-vjp saved-vjp (assoc values 'lse lse))]
+    (doseq [role [:key :value]]
+      (is (arrays-close? (get full role)
+                         (mapv + (get first-grad role) (get third-grad role))
+                         1.0e-12)
+          (str role " accumulates both logical users of shared page 1")))
+    (doseq [role [:query :key :value]]
+      (is (arrays-close? (get full role) (get saved role) 1.0e-12)
+          (str "saved LSE and recomputation agree for " role)))))
+
+(deftest selective-query-vjp-does-not-materialize-detached-cache-gradients
+  (let [kind :dense-paged
+        query-vjp (attention-ad/make
+                   {:id :query-only :primal (problem kind) :output-cotangent 'd-output
+                    :active-values #{:query} :cotangents {:query 'd-q}})
+        gradients (reference/reference-vjp query-vjp (data kind))]
+    (is (= #{:query} (set (keys gradients))))
+    (is (= 12 (count (:query gradients))))))


### PR DESCRIPTION
## Summary

- add a checked AttentionVJP compiler value with explicit Q/K/V activity
- make query positions, packed offsets, visibility, and physical route metadata nondifferentiable
- distinguish detached fixed-cache inference from training activity
- specify K/V cotangents as routed sums so shared physical pages accumulate all logical contributions
- represent saved-LSE versus recomputation as an explicit backward policy
- reject quantized attention gradients until a decode and gradient rule is declared
- add an independent double-precision dense/CSR forward and VJP oracle

The generic indexed-dot, gather, scatter, and segmented-reduction surface remains intact. AttentionProblem is an optional recognized semantic optimization boundary, not a required opaque frontend API.

## Verification

- focused attention gate: 14 tests, 88 assertions, 0 failures/errors
- exhaustive small finite differences for every Q/K/V element on dense and CSR routes
- shared-page accumulation decomposes exactly into per-sequence contributions
- saved LSE and recomputation agree
- cljfmt and git diff --check clean

No GPU emitter or runtime changed in this slice.