### PR TITLE
Add sparse attention visibility

### DIFF
--- a/src/raster/compiler/backend/gpu/attention.clj
+++ b/src/raster/compiler/backend/gpu/attention.clj
@@ -3,7 +3,7 @@
 
    One work-item owns one output component and recomputes QK. This intentionally slow schedule is
    the executable semantic oracle for packed queries, GQA, independent K/V layouts and dimensions,
-   logical causal/window visibility, and physical page routing."
+   logical interval/CSR visibility, and physical page routing."
   (:require [raster.compiler.ir.attention :as attention]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
@@ -23,12 +23,18 @@
   (let [identity (select-keys problem
                               [:batch-size :q-heads :kv-heads :qk-head-dim :value-head-dim
                                :page-size :physical-pages :scale :k-format :v-format
-                               :k-layout :v-layout :visibility])
+                               :k-layout :v-layout])
+        visibility (:visibility problem)
         identity (assoc identity
                         :route-kind (attention/route-kind (:route problem))
                         :route-shape (select-keys (:route problem)
                                                   [:pages-per-sequence
                                                    :page-index-capacity])
+                        :visibility-kind (attention/visibility-kind visibility)
+                        :visibility-shape
+                        (cond-> {:position-filter (into {} (attention/position-filter visibility))}
+                          (attention/csr-visibility? visibility)
+                          (assoc :key-index-capacity (:key-index-capacity visibility)))
                         :total-query-tokens (get-in problem [:query :total-tokens]))]
     (format "raster_attention_fp16_%08x" (bit-and 0xffffffff (long (hash identity))))))
 
@@ -52,6 +58,12 @@
          "    __global const int* page_indices,\n"
          "    __global const int* last_page_lengths,\n"
          "    __global const int* kv_start_positions,\n")))
+
+(defn- visibility-signature
+  [visibility]
+  (when (attention/csr-visibility? visibility)
+    (str "    __global const int* attention_row_offsets,\n"
+         "    __global const int* attention_key_indices,\n")))
 
 (defn- route-initialization
   [{:keys [route page-size]}]
@@ -106,6 +118,29 @@
          (str "    visible = visible && (kv_position <= (long)q_position + "
               window-right "L);\n"))))
 
+(defn- visibility-initialization
+  [visibility]
+  (when (attention/csr-visibility? visibility)
+    (str "  const int attention_begin = attention_row_offsets[q_token];\n"
+         "  const int attention_end = attention_row_offsets[q_token + 1];\n"
+         "  if (attention_row_offsets[0] != 0 || attention_begin < 0\n"
+         "      || attention_end < attention_begin || attention_end > "
+         (:key-index-capacity visibility) ") {\n"
+         "    output[out_index] = convert_half_rte(NAN);\n"
+         "    return;\n"
+         "  }\n")))
+
+(defn- visibility-loop-start
+  [visibility]
+  (if (attention/csr-visibility? visibility)
+    (str "  for (int edge = attention_begin; edge < attention_end; ++edge) {\n"
+         "    const int token = attention_key_indices[edge];\n"
+         "    if (token < 0 || token >= length) {\n"
+         "      output[out_index] = convert_half_rte(NAN);\n"
+         "      return;\n"
+         "    }\n")
+    "  for (int token = 0; token < length; ++token) {\n"))
+
 (defn- source
   [problem name]
   (let [{:keys [query route batch-size q-heads kv-heads qk-head-dim value-head-dim
@@ -122,6 +157,7 @@
          "    __global const half* k_pages,\n"
          "    __global const half* v_pages,\n"
          (route-signature route)
+         (visibility-signature visibility)
          "    __global half* output) {\n"
          "  const int d = (int)get_global_id(0);\n"
          "  const int q_head = (int)get_global_id(1);\n"
@@ -146,16 +182,17 @@
          "    return;\n"
          "  }\n"
          (route-initialization problem)
+         (visibility-initialization visibility)
          "  const int kv_head = q_head / " gqa-ratio ";\n"
          "  const long q_base = ((long)q_token * " q-heads
          " + q_head) * " qk-head-dim ";\n"
          "  float maximum = -3.402823466e+38f;\n"
          "  float denominator = 0.0f;\n"
          "  float accumulator = 0.0f;\n"
-         "  for (int token = 0; token < length; ++token) {\n"
+         (visibility-loop-start visibility)
          "    const long kv_position = (long)kv_start_position + token;\n"
          "    int visible = 1;\n"
-         (visibility-statements visibility)
+         (visibility-statements (attention/position-filter visibility))
          "    if (!visible) continue;\n"
          "    const int logical_page = token / " page-size ";\n"
          "    const int physical_page = " (physical-page-expression route) ";\n"
@@ -185,17 +222,17 @@
 
 (defn- ordered-inputs
   [problem]
-  (let [{:keys [query k-pages v-pages route]} problem
-        common [(:values query) (:row-offsets query) (:positions query) k-pages v-pages]]
-    (into common
-          (if (attention/dense-paged-route? route)
-            [(:page-table route) (:lengths route) (:start-positions route)]
-            [(:page-offsets route) (:page-indices route) (:last-page-lengths route)
-             (:start-positions route)]))))
+  (let [{:keys [query k-pages v-pages route visibility]} problem
+        common [(:values query) (:row-offsets query) (:positions query) k-pages v-pages]
+        route-inputs (if (attention/dense-paged-route? route)
+                       [(:page-table route) (:lengths route) (:start-positions route)]
+                       [(:page-offsets route) (:page-indices route) (:last-page-lengths route)
+                        (:start-positions route)])]
+    (into (into common route-inputs) (attention/visibility-buffer-ids visibility))))
 
 (defn- ordered-abi
   [problem]
-  (let [{:keys [query k-pages v-pages route output]} problem
+  (let [{:keys [query k-pages v-pages route visibility output]} problem
         common [(kabi/slot (:values query) :input :half :c-name "q" :role :query)
                 (kabi/slot (:row-offsets query) :input :int
                            :c-name "q_row_offsets" :role :query-rows)
@@ -218,9 +255,15 @@
            (kabi/slot (:last-page-lengths route) :input :int
                       :c-name "last_page_lengths" :role :last-page-lengths)
            (kabi/slot (:start-positions route) :input :int
-                      :c-name "kv_start_positions" :role :kv-start-positions)])]
+                      :c-name "kv_start_positions" :role :kv-start-positions)])
+        visibility-slots
+        (when (attention/csr-visibility? visibility)
+          [(kabi/slot (:row-offsets visibility) :input :int
+                      :c-name "attention_row_offsets" :role :attention-row-offsets)
+           (kabi/slot (:key-indices visibility) :input :int
+                      :c-name "attention_key_indices" :role :attention-key-indices)])]
     (kabi/validate!
-     (conj (into common route-slots)
+     (conj (into (into common route-slots) visibility-slots)
            (kabi/slot output :output :half :c-name "output" :role :result)))))
 
 (defn emit-fp16-reference
@@ -248,6 +291,7 @@
       :attributes {:strategy :fp16-reference :optimization-tier :reference
                    :storage-dtype :half :accumulator-dtype :float
                    :route-kind (attention/route-kind route)
+                   :visibility-kind (attention/visibility-kind (:visibility problem))
                    :k-layout (:k-layout problem) :v-layout (:v-layout problem)
                    :visibility (:visibility problem)
                    :layout (attention/layouts problem)

--- a/src/raster/compiler/ir/attention.clj
+++ b/src/raster/compiler/ir/attention.clj
@@ -8,7 +8,9 @@
   (:require [raster.compiler.core.dtype :as dtype]))
 
 (defrecord PackedQueryBatch [values row-offsets positions total-tokens])
-(defrecord AttentionVisibility [causal? window-left window-right])
+(defrecord IntervalVisibility [causal? window-left window-right])
+(defrecord CSRVisibility
+           [row-offsets key-indices key-index-capacity duplicate-policy position-filter])
 (defrecord DensePagedRoute [page-table lengths start-positions pages-per-sequence])
 (defrecord CSRPagedRoute
            [page-offsets page-indices last-page-lengths start-positions page-index-capacity])
@@ -27,7 +29,15 @@
 
 (defn visibility?
   [x]
-  (instance? AttentionVisibility x))
+  (or (instance? IntervalVisibility x) (instance? CSRVisibility x)))
+
+(defn interval-visibility?
+  [x]
+  (instance? IntervalVisibility x))
+
+(defn csr-visibility?
+  [x]
+  (instance? CSRVisibility x))
 
 (defn dense-paged-route?
   [x]
@@ -50,6 +60,21 @@
   (cond
     (dense-paged-route? route) :dense-paged
     (csr-paged-route? route) :csr-paged
+    :else nil))
+
+(defn visibility-kind
+  [visibility]
+  (cond
+    (interval-visibility? visibility) :interval
+    (csr-visibility? visibility) :csr
+    :else nil))
+
+(defn position-filter
+  "Return the interval/position component of any supported visibility value."
+  [visibility]
+  (cond
+    (interval-visibility? visibility) visibility
+    (csr-visibility? visibility) (:position-filter visibility)
     :else nil))
 
 (defn- positive-integer!
@@ -108,7 +133,29 @@
    (doseq [[field value] [[:window-left window-left] [:window-right window-right]]]
      (when (some? value)
        (nonnegative-integer! "attention visibility" field value)))
-   (->AttentionVisibility causal? window-left window-right)))
+   (->IntervalVisibility causal? window-left window-right)))
+
+(defn csr-visibility
+  "Construct logical sparse visibility in CSR form. There is one adjacency row per packed query
+   token, and each selected key is a zero-based logical token offset within that query's example.
+   `:set` rejects duplicate keys per row; `:multiset` preserves parallel graph edges. An optional
+   interval position filter intersects adjacency with causal/window semantics."
+  [{:keys [row-offsets key-indices key-index-capacity duplicate-policy position-filter]
+    :or {duplicate-policy :set position-filter nil}}]
+  (when (some nil? [row-offsets key-indices])
+    (throw (ex-info "CSR visibility requires row offsets and logical key indices"
+                    {:reason :attention-csr-visibility-missing-buffer})))
+  (positive-integer! "CSR visibility" :key-index-capacity key-index-capacity)
+  (when-not (contains? #{:set :multiset} duplicate-policy)
+    (throw (ex-info "CSR visibility requires a set or multiset duplicate policy"
+                    {:reason :attention-invalid-duplicate-policy
+                     :duplicate-policy duplicate-policy})))
+  (when (and position-filter (not (interval-visibility? position-filter)))
+    (throw (ex-info "CSR visibility position filter must be interval visibility"
+                    {:reason :attention-invalid-position-filter
+                     :position-filter position-filter})))
+  (->CSRVisibility row-offsets key-indices key-index-capacity duplicate-policy
+                   (or position-filter (visibility))))
 
 (defn dense-paged-route
   "Construct a fixed-width dense page route. Row b lists physical pages in increasing logical KV
@@ -168,6 +215,16 @@
     (throw (ex-info "attention requires a supported KV route"
                     {:reason :attention-unsupported-route :route route :actual (type route)}))))
 
+(defn visibility-buffer-ids
+  "Return runtime logical-visibility buffer identities. Interval visibility is entirely static."
+  [visibility]
+  (cond
+    (interval-visibility? visibility) []
+    (csr-visibility? visibility) [(:row-offsets visibility) (:key-indices visibility)]
+    :else
+    (throw (ex-info "attention requires supported logical visibility"
+                    {:reason :attention-invalid-visibility :visibility visibility}))))
+
 (defn validate!
   "Validate an AttentionProblem's static semantics and storage extents. Runtime route/query values
    are validated separately before upload and guarded again by the reference kernel."
@@ -185,7 +242,7 @@
       (throw (ex-info "attention requires a PackedQueryBatch"
                       {:reason :attention-invalid-query-batch :query query})))
     (when-not (visibility? visibility)
-      (throw (ex-info "attention requires an AttentionVisibility"
+      (throw (ex-info "attention requires interval or CSR visibility"
                       {:reason :attention-invalid-visibility :visibility visibility})))
     (when-not (paged-route? route)
       (throw (ex-info "attention requires a dense or CSR paged route"
@@ -221,6 +278,7 @@
     (let [buffers (vec (concat [(:values query) (:row-offsets query) (:positions query)
                                 k-pages v-pages]
                                (route-buffer-ids route)
+                               (visibility-buffer-ids visibility)
                                [output]))]
       (when (some nil? buffers)
         (throw (ex-info "attention requires every logical buffer identity"
@@ -248,6 +306,9 @@
       (checked-product :page-table [batch-size (:pages-per-sequence route)])
       (positive-integer! "CSR page route" :page-index-capacity
                          (:page-index-capacity route)))
+    (when (csr-visibility? visibility)
+      (positive-integer! "CSR visibility" :key-index-capacity
+                         (:key-index-capacity visibility)))
     problem))
 
 (defn make
@@ -279,7 +340,7 @@
   "Named logical layouts. These are semantic/storage axes, not thread/register layouts."
   [problem]
   (let [{:keys [query route batch-size q-heads kv-heads qk-head-dim value-head-dim
-                page-size physical-pages k-layout v-layout]} (validate! problem)
+                page-size physical-pages k-layout v-layout visibility]} (validate! problem)
         cache-shape (fn [layout dim]
                       (case layout
                         :kv-head-major [kv-heads physical-pages page-size dim]
@@ -297,7 +358,10 @@
               :kv-lengths [batch-size]}
              {:page-offsets [(inc batch-size)]
               :page-indices [(:page-index-capacity route)]
-              :last-page-lengths [batch-size]}))))
+              :last-page-lengths [batch-size]})
+           (when (csr-visibility? visibility)
+             {:attention-row-offsets [(inc (:total-tokens query))]
+              :attention-key-indices [(:key-index-capacity visibility)]}))))
 
 (defn buffer-specs
   "Graph-buffer metadata keyed by compiler identities, including route-variant metadata."
@@ -321,7 +385,11 @@
               (:lengths route) (spec :input :int :kv-lengths)}
              {(:page-offsets route) (spec :input :int :page-offsets)
               (:page-indices route) (spec :input :int :page-indices)
-              (:last-page-lengths route) (spec :input :int :last-page-lengths)}))))
+              (:last-page-lengths route) (spec :input :int :last-page-lengths)})
+           (when (csr-visibility? (:visibility problem))
+             (let [visibility (:visibility problem)]
+               {(:row-offsets visibility) (spec :input :int :attention-row-offsets)
+                (:key-indices visibility) (spec :input :int :attention-key-indices)})))))
 
 (defn- int32-nonnegative?
   [x]
@@ -457,4 +525,74 @@
                         (if (zero? pages) 0 (+ (* (dec pages) page-size) last))))
                     (range batch-size))]
           (validate-start-positions! batch-size starts lengths))
+        problem))))
+
+(defn logical-route-lengths
+  "Return each example's logical KV length after validating host-visible route metadata."
+  [problem values]
+  (let [{:keys [route batch-size page-size] :as problem} (validate! problem)]
+    (validate-routing! problem values)
+    (if (dense-paged-route? route)
+      (vec (:lengths values))
+      (let [offsets (vec (:page-offsets values))
+            lasts (vec (:last-page-lengths values))]
+        (mapv (fn [batch]
+                (let [pages (- (nth offsets (inc batch)) (nth offsets batch))]
+                  (if (zero? pages) 0 (+ (* (dec pages) page-size) (nth lasts batch)))))
+              (range batch-size))))))
+
+(defn validate-visibility-values!
+  "Validate host-visible logical sparse visibility before upload. CSR rows correspond one-to-one
+   with packed query tokens. Key indices are example-local logical KV offsets and are checked
+   against that query's routed length. Unused key-index capacity is ignored."
+  [problem query-row-offset-values routing-values visibility-values]
+  (let [{:keys [query visibility batch-size] :as problem} (validate! problem)]
+    (if (interval-visibility? visibility)
+      problem
+      (let [query-offsets (vec query-row-offset-values)
+            total-tokens (:total-tokens query)
+            row-offsets (vec (:row-offsets visibility-values))
+            key-indices (vec (:key-indices visibility-values))
+            capacity (:key-index-capacity visibility)
+            lengths (logical-route-lengths problem routing-values)]
+        (when-not (and (= (inc batch-size) (count query-offsets))
+                       (= 0 (first query-offsets))
+                       (= total-tokens (peek query-offsets))
+                       (every? int32-nonnegative? query-offsets)
+                       (every? true? (map <= query-offsets (rest query-offsets))))
+          (throw (ex-info "packed query row offsets are invalid for sparse visibility"
+                          {:reason :attention-invalid-query-offsets
+                           :offsets query-offsets :total-tokens total-tokens})))
+        (when-not (= (inc total-tokens) (count row-offsets))
+          (throw (ex-info "attention CSR row offsets have the wrong element count"
+                          {:reason :attention-visibility-row-offset-shape
+                           :expected (inc total-tokens) :actual (count row-offsets)})))
+        (when-not (= capacity (count key-indices))
+          (throw (ex-info "attention CSR key-index buffer has the wrong element count"
+                          {:reason :attention-visibility-key-index-shape
+                           :expected capacity :actual (count key-indices)})))
+        (when-not (and (= 0 (first row-offsets))
+                       (every? int32-nonnegative? row-offsets)
+                       (every? true? (map <= row-offsets (rest row-offsets)))
+                       (<= (peek row-offsets) capacity))
+          (throw (ex-info "attention CSR row offsets must be monotone and capacity-bounded"
+                          {:reason :attention-invalid-visibility-row-offsets
+                           :offsets row-offsets :capacity capacity})))
+        (doseq [batch (range batch-size)
+                query-token (range (nth query-offsets batch) (nth query-offsets (inc batch)))
+                :let [begin (nth row-offsets query-token)
+                      end (nth row-offsets (inc query-token))
+                      row (subvec key-indices begin end)
+                      length (nth lengths batch)]]
+          (doseq [key-index row]
+            (when-not (and (int32-nonnegative? key-index) (< key-index length))
+              (throw (ex-info "attention CSR selects a key outside its example's logical route"
+                              {:reason :attention-invalid-logical-key-index
+                               :batch batch :query-token query-token
+                               :key-index key-index :kv-length length}))))
+          (when (and (= :set (:duplicate-policy visibility))
+                     (not= (count row) (count (distinct row))))
+            (throw (ex-info "set-valued attention CSR cannot contain duplicate keys per row"
+                            {:reason :attention-duplicate-logical-key
+                             :batch batch :query-token query-token :keys row}))))
         problem))))

--- a/src/raster/compiler/ir/attention_ad.clj
+++ b/src/raster/compiler/ir/attention_ad.clj
@@ -30,10 +30,11 @@
   "Discrete metadata that must never receive tangents. Visibility is static data and therefore
    has no buffer identity here; allocation/event state is intentionally absent from AttentionProblem."
   [problem]
-  (let [{:keys [query route]} (attention/validate! problem)]
+  (let [{:keys [query route visibility]} (attention/validate! problem)]
     {:query-row-offsets (:row-offsets query)
      :query-positions (:positions query)
-     :route (attention/route-buffer-ids route)}))
+     :route (attention/route-buffer-ids route)
+     :visibility (attention/visibility-buffer-ids visibility)}))
 
 (defn validate!
   "Validate an AttentionVJP independently of any target schedule. Activity is an explicit subset

--- a/src/raster/compiler/reference/attention.clj
+++ b/src/raster/compiler/reference/attention.clj
@@ -40,6 +40,13 @@
        :last-page-lengths (get values (:last-page-lengths route))
        :start-positions (get values (:start-positions route))})))
 
+(defn- visibility-values
+  [problem values]
+  (let [visibility (:visibility problem)]
+    (when (attention/csr-visibility? visibility)
+      {:row-offsets (get values (:row-offsets visibility))
+       :key-indices (get values (:key-indices visibility))})))
+
 (defn- prepare
   [problem values extra-specs]
   (let [{:keys [query] :as problem} (attention/validate! problem)
@@ -47,6 +54,9 @@
     (attention/validate-query-values!
      problem (get values (:row-offsets query)) (get values (:positions query)))
     (attention/validate-routing! problem (route-values problem values))
+    (attention/validate-visibility-values!
+     problem (get values (:row-offsets query)) (route-values problem values)
+     (visibility-values problem values))
     [problem values]))
 
 (defn- query-batches
@@ -108,11 +118,19 @@
         kv-head (quot query-head (quot q-heads kv-heads))
         q-base (* (+ (* query-token q-heads) query-head) qk-head-dim)
         {:keys [length start-position physical-page]} (route-row problem values batch)
+        logical-tokens
+        (if (attention/csr-visibility? visibility)
+          (let [row-offsets (get values (:row-offsets visibility))
+                key-indices (get values (:key-indices visibility))]
+            (subvec key-indices (nth row-offsets query-token)
+                    (nth row-offsets (inc query-token))))
+          (range length))
+        position-filter (attention/position-filter visibility)
         tokens
         (into []
               (keep (fn [token]
                       (let [kv-position (+ start-position token)]
-                        (when (visible? visibility query-position kv-position)
+                        (when (visible? position-filter query-position kv-position)
                           (let [page (physical-page (quot token page-size))
                                 page-token (rem token page-size)
                                 k-base (cache-index problem k-layout qk-head-dim
@@ -125,7 +143,7 @@
                                                      (double (nth k (+ k-base d)))))
                                                 (range qk-head-dim))))]
                             {:token token :page page :page-token page-token :logit logit})))))
-              (range length))]
+              logical-tokens)]
     (if (empty? tokens)
       {:kv-head kv-head :q-base q-base :tokens [] :lse Double/NEGATIVE_INFINITY}
       (let [maximum (reduce max (map :logit tokens))

--- a/test/raster/compiler/ir/attention_ad_test.clj
+++ b/test/raster/compiler/ir/attention_ad_test.clj
@@ -35,7 +35,8 @@
     (is (= {:query 'q :key 'k :value 'v} (:differentiable contract)))
     (is (= {:query-row-offsets 'q-offsets
             :query-positions 'q-positions
-            :route '[pages lengths starts]}
+            :route '[pages lengths starts]
+            :visibility []}
            (:nondifferentiable contract)))
     (is (= {:query :write :key :routed-sum :value :routed-sum}
            (:cotangent-accumulation contract)))

--- a/test/raster/compiler/ir/attention_test.clj
+++ b/test/raster/compiler/ir/attention_test.clj
@@ -23,6 +23,17 @@
            :start-positions 'kv-start-positions :page-index-capacity 7}
           (apply hash-map overrides))))
 
+(defn- csr-visibility
+  [& overrides]
+  (attention/csr-visibility
+   (merge {:row-offsets 'attention-row-offsets
+           :key-indices 'attention-key-indices
+           :key-index-capacity 7
+           :duplicate-policy :set
+           :position-filter (attention/visibility
+                             {:causal? true :window-left 2 :window-right 0})}
+          (apply hash-map overrides))))
+
 (defn- problem
   [& overrides]
   (attention/make
@@ -101,6 +112,46 @@
                      :last-page-lengths [1 1 1]
                      :start-positions [0 0 8]})
                (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))))
+
+(deftest logical-csr-visibility-is-independent-of-physical-page-routing
+  (let [sparse-problem (problem :visibility (csr-visibility))
+        query-offsets [0 2 2 4]
+        routing {:page-table [4 1 6, -1 -1 -1, 2 5 0]
+                 :lengths [5 0 5]
+                 :start-positions [0 0 8]}
+        visibility {:row-offsets [0 2 3 3 6]
+                    :key-indices [0 2, 4, 0 1 4, -1]}]
+    (is (= :csr (attention/visibility-kind (:visibility sparse-problem))))
+    (is (= :dense-paged (attention/route-kind (:route sparse-problem))))
+    (is (= [5] (:attention-row-offsets (attention/layouts sparse-problem))))
+    (is (= [7] (:attention-key-indices (attention/layouts sparse-problem))))
+    (is (= sparse-problem
+           (attention/validate-visibility-values!
+            sparse-problem query-offsets routing visibility)))
+    (testing "unused key-index capacity may contain a sentinel"
+      (is (= :attention-invalid-logical-key-index
+             (try
+               (attention/validate-visibility-values!
+                sparse-problem query-offsets routing
+                {:row-offsets [0 2 3 3 7]
+                 :key-indices [0 2, 4, 0 1 4 -1]})
+               (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))
+    (testing "set adjacency rejects duplicates per query row"
+      (is (= :attention-duplicate-logical-key
+             (try
+               (attention/validate-visibility-values!
+                sparse-problem query-offsets routing
+                {:row-offsets [0 2 3 3 6]
+                 :key-indices [0 0, 4, 0 1 4, -1]})
+               (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))
+    (testing "graph multiset adjacency preserves parallel edges"
+      (let [multiset-problem (problem :visibility
+                                      (csr-visibility :duplicate-policy :multiset))]
+        (is (= multiset-problem
+               (attention/validate-visibility-values!
+                multiset-problem query-offsets routing
+                {:row-offsets [0 2 3 3 6]
+                 :key-indices [0 0, 4, 0 1 4, -1]})))))))
 
 (deftest invalid-static-semantics-fail-before-emission
   (testing "GQA mapping must be integral"

--- a/test/raster/compiler/passes/parallel/attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/attention_route_test.clj
@@ -24,6 +24,14 @@
     :last-page-lengths 'last-page-lengths :start-positions 'kv-start-positions
     :page-index-capacity 6}))
 
+(defn- csr-visibility
+  []
+  (attention/csr-visibility
+   {:row-offsets 'attention-row-offsets :key-indices 'attention-key-indices
+    :key-index-capacity 8 :duplicate-policy :multiset
+    :position-filter (attention/visibility
+                      {:causal? true :window-left 2 :window-right 0})}))
+
 (defn- problem
   [& overrides]
   (attention/make
@@ -73,6 +81,24 @@
            (subvec (mapv :c-name (:abi artifact)) 5 8)))
     (is (str/includes? (:source artifact) "page_indices[page_begin + logical_page]"))
     (is (str/includes? (:source artifact) "routed_page_count == 0"))))
+
+(deftest logical-csr-visibility-composes-with-physical-route-as-distinct-abi-slots
+  (let [artifact (:artifact (route/route!
+                             (problem :visibility (csr-visibility))))]
+    (is (= :dense-paged (get-in artifact [:attributes :route-kind])))
+    (is (= :csr (get-in artifact [:attributes :visibility-kind])))
+    (is (= '[q q-row-offsets q-positions k-pages v-pages
+             page-table kv-lengths kv-start-positions
+             attention-row-offsets attention-key-indices output]
+           (:arguments artifact)))
+    (is (= ["attention_row_offsets" "attention_key_indices"]
+           (subvec (mapv :c-name (:abi artifact)) 8 10)))
+    (is (str/includes? (:source artifact)
+                       "for (int edge = attention_begin; edge < attention_end; ++edge)"))
+    (is (str/includes? (:source artifact)
+                       "const int token = attention_key_indices[edge]"))
+    (is (str/includes? (:source artifact) "token < 0 || token >= length"))
+    (is (str/includes? (:source artifact) "kv_position <= (long)q_position"))))
 
 (deftest independent-k-and-v-layouts-are-lowered-without-repacking
   (let [source (:source (:artifact (route/route! (problem))))]

--- a/test/raster/compiler/reference/attention_test.clj
+++ b/test/raster/compiler/reference/attention_test.clj
@@ -27,14 +27,25 @@
       :last-page-lengths 'lasts :start-positions 'starts :page-index-capacity 5})))
 
 (defn- problem
-  [kind]
-  (attention/make
-   (merge dims
-          {:id [:attention kind] :query (query) :k-pages 'k :v-pages 'v :output 'output
-           :route (route kind) :scale (/ 1.0 (Math/sqrt 2.0))
-           :k-layout :kv-head-major :v-layout :page-major
-           :visibility (attention/visibility
-                        {:causal? true :window-left 2 :window-right 0})})))
+  ([kind]
+   (problem kind (attention/visibility
+                  {:causal? true :window-left 2 :window-right 0})))
+  ([kind visibility]
+   (attention/make
+    (merge dims
+           {:id [:attention kind (attention/visibility-kind visibility)]
+            :query (query) :k-pages 'k :v-pages 'v :output 'output
+            :route (route kind) :scale (/ 1.0 (Math/sqrt 2.0))
+            :k-layout :kv-head-major :v-layout :page-major
+            :visibility visibility}))))
+
+(defn- sparse-visibility
+  [duplicate-policy capacity]
+  (attention/csr-visibility
+   {:row-offsets 'attention-row-offsets :key-indices 'attention-key-indices
+    :key-index-capacity capacity :duplicate-policy duplicate-policy
+    :position-filter (attention/visibility
+                      {:causal? true :window-left 2 :window-right 0})}))
 
 (defn- data
   [kind]
@@ -66,6 +77,13 @@
            :output-cotangent 'd-output
            :cotangents {:query 'd-q :key 'd-k :value 'd-v}}
           (apply hash-map overrides))))
+
+(defn- sparse-vjp
+  [kind visibility]
+  (attention-ad/make
+   {:id [:sparse-vjp kind] :primal (problem kind visibility)
+    :output-cotangent 'd-output
+    :cotangents {:query 'd-q :key 'd-k :value 'd-v}}))
 
 (defn- close?
   ([a b] (close? a b 1.0e-9))
@@ -146,3 +164,41 @@
         gradients (reference/reference-vjp query-vjp (data kind))]
     (is (= #{:query} (set (keys gradients))))
     (is (= 12 (count (:query gradients))))))
+
+(deftest per-example-logical-csr-masks-compose-with-either-physical-route
+  (let [visibility (sparse-visibility :set 5)
+        sparse-data {'attention-row-offsets [0 2 2 4]
+                     'attention-key-indices [0 1, 0 2, -1]}
+        dense-data (merge (data :dense-paged) sparse-data)
+        csr-data (merge (data :csr-paged) sparse-data)
+        dense-problem (problem :dense-paged visibility)
+        csr-problem (problem :csr-paged visibility)
+        dense-output (reference/reference-forward dense-problem dense-data)
+        csr-output (reference/reference-forward csr-problem csr-data)
+        dense-grads (reference/reference-vjp (sparse-vjp :dense-paged visibility) dense-data)
+        csr-grads (reference/reference-vjp (sparse-vjp :csr-paged visibility) csr-data)]
+    (is (arrays-close? dense-output csr-output 1.0e-12))
+    (doseq [role [:query :key :value]]
+      (is (arrays-close? (get dense-grads role) (get csr-grads role) 1.0e-12)))
+    (testing "the second packed query has its own empty mask row"
+      (is (every? zero? (subvec (vec dense-output) 4 8))))
+    (testing "logical visibility buffers are discrete VJP inputs"
+      (is (= '[attention-row-offsets attention-key-indices]
+             (get-in (attention-ad/differentiation-contract
+                      (sparse-vjp :dense-paged visibility))
+                     [:nondifferentiable :visibility]))))))
+
+(deftest sparse-multiset-vjp-preserves-parallel-edges-and-matches-finite-differences
+  (doseq [kind [:dense-paged :csr-paged]
+          :let [visibility (sparse-visibility :multiset 8)
+                values (merge (data kind)
+                              {'attention-row-offsets [0 3 5 7]
+                               'attention-key-indices [0 0 1, 0 2, 0 2, -1]})
+                problem (problem kind visibility)
+                analytical (reference/reference-vjp (sparse-vjp kind visibility) values)]]
+    (testing (name kind)
+      (doseq [[role buffer-id] [[:query 'q] [:key 'k] [:value 'v]]]
+        (is (arrays-close? (get analytical role)
+                           (numerical-gradient problem values buffer-id 1.0e-6)
+                           2.0e-8)
+            (str role " sparse multiset finite-difference agreement"))))))

--- a/test/raster/gpu/attention_device_test.clj
+++ b/test/raster/gpu/attention_device_test.clj
@@ -25,7 +25,7 @@
   (double (Float/float16ToFloat (short value))))
 
 (defn- make-case
-  [route-kind]
+  [route-kind visibility-kind]
   (let [dims {:batch-size 3 :q-heads 4 :kv-heads 2 :qk-head-dim 8
               :value-head-dim 6 :page-size 2 :physical-pages 7}
         {:keys [q-heads kv-heads qk-head-dim value-head-dim page-size physical-pages]} dims
@@ -69,23 +69,39 @@
            {:page-offsets 'page-offsets :page-indices 'page-indices
             :last-page-lengths 'last-page-lengths
             :start-positions 'kv-start-positions :page-index-capacity 7}))
+        visibility-values
+        (when (= :csr visibility-kind)
+          {:row-offsets (int-array [0 2 3 5 8])
+           :key-indices (int-array [1 3, 2, 0 2, 2 3 4, -1])})
+        attention-visibility
+        (case visibility-kind
+          :interval
+          (attention/visibility {:causal? true :window-left 2 :window-right 0})
+
+          :csr
+          (attention/csr-visibility
+           {:row-offsets 'attention-row-offsets :key-indices 'attention-key-indices
+            :key-index-capacity 9 :duplicate-policy :set
+            :position-filter (attention/visibility
+                              {:causal? true :window-left 2 :window-right 0})}))
         [k-layout v-layout] (if (= :dense-paged route-kind)
                               [:kv-head-major :page-major]
                               [:page-major :kv-head-major])
         problem (attention/make
                  (merge dims
-                        {:id [:device-reference route-kind]
+                        {:id [:device-reference route-kind visibility-kind]
                          :query query :k-pages 'k-pages :v-pages 'v-pages
                          :route kv-route :output 'output
                          :k-layout k-layout :v-layout v-layout
-                         :visibility (attention/visibility
-                                      {:causal? true :window-left 2 :window-right 0})
+                         :visibility attention-visibility
                          :scale (/ 1.0 (Math/sqrt (double qk-head-dim)))}))]
     (attention/validate-query-values! problem q-offsets q-positions)
     (attention/validate-routing! problem route-values)
+    (attention/validate-visibility-values!
+     problem q-offsets route-values visibility-values)
     {:problem problem :q q :k k :v v
      :q-offsets q-offsets :q-positions q-positions
-     :route-values route-values}))
+     :route-values route-values :visibility-values visibility-values}))
 
 (defn- cache-index
   [{:keys [physical-pages page-size kv-heads]} layout dim kv-head page token d]
@@ -122,6 +138,15 @@
        (or (nil? window-left) (>= kv-position (- q-position window-left)))
        (or (nil? window-right) (<= kv-position (+ q-position window-right)))))
 
+(defn- logical-tokens
+  [{:keys [problem visibility-values]} q-token length]
+  (let [visibility (:visibility problem)]
+    (if (attention/csr-visibility? visibility)
+      (let [begin (aget ^ints (:row-offsets visibility-values) q-token)
+            end (aget ^ints (:row-offsets visibility-values) (inc q-token))]
+        (mapv #(aget ^ints (:key-indices visibility-values) %) (range begin end)))
+      (range length))))
+
 (defn- reference
   [{:keys [problem q k v q-offsets q-positions route-values] :as test-case}]
   (let [{:keys [query q-heads kv-heads qk-head-dim value-head-dim page-size scale
@@ -136,8 +161,9 @@
         (dotimes [q-head q-heads]
           (let [kv-head (quot q-head gqa-ratio)
                 q-base (* (+ (* q-token q-heads) q-head) qk-head-dim)
-                visible-tokens (filterv #(visible? visibility q-position (+ kv-start %))
-                                        (range length))
+                visible-tokens (filterv #(visible? (attention/position-filter visibility)
+                                                   q-position (+ kv-start %))
+                                        (logical-tokens test-case q-token length))
                 logits
                 (mapv
                  (fn [token]
@@ -193,6 +219,15 @@
        :kv-start-positions [:int (alength ^ints (:start-positions route-values))
                             (:start-positions route-values)]})))
 
+(defn- visibility-buffer-data
+  [{:keys [visibility-values]}]
+  (if visibility-values
+    {:attention-row-offsets [:int (alength ^ints (:row-offsets visibility-values))
+                             (:row-offsets visibility-values)]
+     :attention-key-indices [:int (alength ^ints (:key-indices visibility-values))
+                             (:key-indices visibility-values)]}
+    {}))
+
 (defn- graph-bindings
   [problem]
   (let [{:keys [query route]} problem
@@ -205,11 +240,15 @@
            (if (attention/dense-paged-route? route)
              {(:page-table route) :page-table (:lengths route) :kv-lengths}
              {(:page-offsets route) :page-offsets (:page-indices route) :page-indices
-              (:last-page-lengths route) :last-page-lengths}))))
+              (:last-page-lengths route) :last-page-lengths})
+           (when (attention/csr-visibility? (:visibility problem))
+             {(:row-offsets (:visibility problem)) :attention-row-offsets
+              (:key-indices (:visibility problem)) :attention-key-indices}))))
 
 (defn- run-case
-  [device-id route-kind]
-  (let [{:keys [problem q k v q-offsets q-positions] :as test-case} (make-case route-kind)
+  [device-id route-kind visibility-kind]
+  (let [{:keys [problem q k v q-offsets q-positions] :as test-case}
+        (make-case route-kind visibility-kind)
         graph (:graph (route/route!
                        problem {:device-type :gpu :subgroup-size 16
                                 :max-workgroup-size 256}))
@@ -222,7 +261,8 @@
                 :k-pages [:half (get-in specs ['k-pages :elements]) k]
                 :v-pages [:half (get-in specs ['v-pages :elements]) v]
                 :output [:half (get-in specs ['output :elements]) nil]}
-               (route-buffer-data test-case))]
+               (route-buffer-data test-case)
+               (visibility-buffer-data test-case))]
     (gpu/with-gpu-session [session device-id]
       (gpu/alloc! session allocations)
       (let [handle (gpu/bind-kernel-graph!
@@ -242,9 +282,14 @@
 (deftest level-zero-packed-dense-attention-matches-reference
   (if-not @gp/gpu-available?
     (gp/gpu-skip! "packed dense-routed FP16 attention on Level Zero")
-    (run-case :ze:0 :dense-paged)))
+    (run-case :ze:0 :dense-paged :interval)))
 
 (deftest opencl-packed-csr-attention-matches-reference
   (if-not @ocl-fp16-available?
     (is true "OpenCL FP16 device unavailable")
-    (run-case :ocl:0 :csr-paged)))
+    (run-case :ocl:0 :csr-paged :interval)))
+
+(deftest opencl-logical-csr-visibility-over-dense-pages-matches-reference
+  (if-not @ocl-fp16-available?
+    (is true "OpenCL FP16 device unavailable")
+    (run-case :ocl:0 :dense-paged :csr)))


### PR DESCRIPTION
## Summary

- replace the single visibility record with checked interval and logical CSR visibility variants
- give every packed query token an independent sparse adjacency row
- use example-local logical key indices, allowing different graph sizes and masks without padding
- distinguish set masks from graph multisets with parallel edges
- intersect sparse adjacency with optional causal/window position filtering
- keep logical CSR slots independent of dense or CSR physical page routing
- extend the FP16 GPU reference ABI and kernel to traverse selected logical keys safely
- extend the double-precision forward/VJP oracle, including shared-page gradient accumulation

Generic indexed-dot, gather, scatter, and segmented reductions remain first-class. This does not yet rewrite GSDM graph attention because clamp, epsilon normalization, and edge-aligned score/value semantics remain explicit future contract work.

## Verification

- pure attention gate: 18 tests, 116 assertions, 0 failures/errors
- exhaustive Q/K/V finite differences for sparse multiset visibility over both physical route variants
- dense-page and CSR-page forward/VJP equivalence with per-query sparse masks and empty rows
- live Arc gate: 3 tests, 6 assertions, 0 failures/errors
  - Level Zero dense pages plus interval visibility
  - OpenCL CSR pages plus interval visibility
  - OpenCL logical CSR visibility plus dense pages
- cljfmt and git diff --check clean

The live JVM was capped at 1.6 GB to avoid the earlier host OOM.