### PR TITLE
Lower attention through a shared segmented reduction plan

### DIFF
--- a/src/raster/compiler/backend/gpu/attention.clj
+++ b/src/raster/compiler/backend/gpu/attention.clj
@@ -8,12 +8,69 @@
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-graph :as kgraph]
-            [raster.compiler.ir.kernel-launch :as klaunch]))
+            [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.compiler.ir.segmented-weighted-reduction :as swr]))
+
+(defn- attention-problem
+  [plan]
+  (let [{:keys [source-operation provenance]} (swr/validate! plan)]
+    (when-not (and (= :attention (:semantic-op provenance))
+                   (= :canonical-segmented-weighted-reduction (:lowering provenance)))
+      (throw (ex-info "FP16 attention emission requires an attention-derived reduction plan"
+                      {:reason :attention-emitter-wrong-plan-provenance
+                       :provenance provenance})))
+    (attention/validate! source-operation)))
+
+(defn- reference-plan!
+  [plan]
+  (let [plan (swr/validate! plan)
+        {:keys [id query route output q-heads kv-heads qk-head-dim value-head-dim
+                q-dtype k-dtype v-dtype output-dtype accumulator-dtype scale visibility]
+         :as problem} (attention-problem plan)
+        expected-segments [{:name :query-token :extent (:total-tokens query)}
+                           {:name :query-head :extent q-heads}]
+        expected-score {:kind :dot
+                        :axis {:name :qk-component :extent qk-head-dim}
+                        :head-map {:kind :grouped-query
+                                   :query-heads q-heads :kv-heads kv-heads}
+                        :left {:kind :packed-query :buffer (:values query) :dtype q-dtype}
+                        :right {:kind :routed-key :buffer (:k-pages problem) :dtype k-dtype}}
+        expected-membership {:kind :logical-attention-visibility
+                             :visibility-kind (attention/visibility-kind visibility)
+                             :position-filter (into {} (attention/position-filter visibility))
+                             :duplicate-policy (when (attention/csr-visibility? visibility)
+                                                 (:duplicate-policy visibility))
+                             :buffers (attention/visibility-buffer-ids visibility)}]
+    (when-not (and (swr/online-softmax-algebra? plan)
+                   (= [:segmented-weighted-reduction id] (:id plan))
+                   (= expected-segments (:segment-axes plan))
+                   (= expected-membership (:membership plan))
+                   (= (attention/route-kind route) (get-in plan [:storage :route-kind]))
+                   (= route (get-in plan [:storage :route]))
+                   (= (attention/route-buffer-ids route) (get-in plan [:storage :buffers]))
+                   (= expected-score (select-keys (:score plan)
+                                                  [:kind :axis :head-map :left :right]))
+                   (= (list 'raster.numeric/* 'dot (double scale))
+                      (get-in plan [:score :finalize :body]))
+                   (= {:kind :routed-value :buffer (:v-pages problem)
+                       :dtype v-dtype :components value-head-dim}
+                      (:value plan))
+                   (= accumulator-dtype (:accumulator-dtype plan))
+                   (= (attention/ordered-input-buffer-ids problem)
+                      (swr/ordered-input-ids plan))
+                   (= {:id output :dtype output-dtype
+                       :shape [(:total-tokens query) q-heads value-head-dim]
+                       :elements (* (:total-tokens query) q-heads value-head-dim)}
+                      (:output plan)))
+      (throw (ex-info "FP16 reference leaf cannot preserve this reduction plan exactly"
+                      {:reason :attention-reference-plan-unsupported
+                       :operation-id id :plan-id (:id plan)})))
+    plan))
 
 (defn reference-workgroup-x
   "Choose the reference leaf's x workgroup from output width and hardware resources."
-  [problem desc]
-  (let [value-head-dim (:value-head-dim (attention/validate! problem))
+  [plan desc]
+  (let [value-head-dim (:value-head-dim (attention-problem plan))
         subgroup (long (or (:subgroup-size desc) 16))
         maximum (long (or (:max-workgroup-size desc) 256))]
     (long (max 1 (min value-head-dim subgroup maximum)))))
@@ -221,14 +278,8 @@
          "}\n")))
 
 (defn- ordered-inputs
-  [problem]
-  (let [{:keys [query k-pages v-pages route visibility]} problem
-        common [(:values query) (:row-offsets query) (:positions query) k-pages v-pages]
-        route-inputs (if (attention/dense-paged-route? route)
-                       [(:page-table route) (:lengths route) (:start-positions route)]
-                       [(:page-offsets route) (:page-indices route) (:last-page-lengths route)
-                        (:start-positions route)])]
-    (into (into common route-inputs) (attention/visibility-buffer-ids visibility))))
+  [plan]
+  (swr/ordered-input-ids plan))
 
 (defn- ordered-abi
   [problem]
@@ -268,12 +319,13 @@
 
 (defn emit-fp16-reference
   "Emit a route-specialized plain-FP16 attention reference as a verified KernelArtifact."
-  [problem desc]
-  (let [{:keys [query output q-heads value-head-dim route] :as problem}
-        (attention/validate! problem)
+  [plan desc]
+  (let [plan (reference-plan! plan)
+        {:keys [query output q-heads value-head-dim route] :as problem}
+        (attention-problem plan)
         name (kernel-name problem)
-        workgroup-x (reference-workgroup-x problem desc)
-        inputs (ordered-inputs problem)
+        workgroup-x (reference-workgroup-x plan desc)
+        inputs (ordered-inputs plan)
         arguments (conj inputs output)
         launch (klaunch/spec
                 {:workgroup-size [workgroup-x 1 1]
@@ -287,8 +339,10 @@
       :launch launch
       :effects {:kind :attention :reads inputs :writes [output]}
       :provenance {:operation-id (:id problem) :semantic-op :attention
-                   :lowering :fp16-reference}
+                   :algebra-plan-id (:id plan) :lowering :fp16-reference}
       :attributes {:strategy :fp16-reference :optimization-tier :reference
+                   :algebra :segmented-weighted-reduction
+                   :algebra-key (swr/algebra-key plan)
                    :storage-dtype :half :accumulator-dtype :float
                    :route-kind (attention/route-kind route)
                    :visibility-kind (attention/visibility-kind (:visibility problem))
@@ -299,11 +353,12 @@
 
 (defn kernel-graph
   "Wrap the reference artifact in an explicit one-node scheduled graph."
-  [problem artifact]
-  (let [{:keys [output id] :as problem} (attention/validate! problem)
+  [plan artifact]
+  (let [plan (reference-plan! plan)
+        {:keys [output id] :as problem} (attention-problem plan)
         artifact (kart/validate! artifact)
         specs (attention/buffer-specs problem)
-        inputs (ordered-inputs problem)
+        inputs (ordered-inputs plan)
         graph-buffer (fn [buffer-id]
                        (let [{:keys [dtype elements role]} (get specs buffer-id)]
                          (kgraph/buffer buffer-id dtype elements :device role)))

--- a/src/raster/compiler/ir/attention.clj
+++ b/src/raster/compiler/ir/attention.clj
@@ -215,6 +215,8 @@
     (throw (ex-info "attention requires a supported KV route"
                     {:reason :attention-unsupported-route :route route :actual (type route)}))))
 
+(declare validate!)
+
 (defn visibility-buffer-ids
   "Return runtime logical-visibility buffer identities. Interval visibility is entirely static."
   [visibility]
@@ -224,6 +226,15 @@
     :else
     (throw (ex-info "attention requires supported logical visibility"
                     {:reason :attention-invalid-visibility :visibility visibility}))))
+
+(defn ordered-input-buffer-ids
+  "The single backend-neutral physical input order for an AttentionProblem. Route variants keep
+   distinct native layouts, while logical visibility always follows physical routing."
+  [problem]
+  (let [{:keys [query k-pages v-pages route visibility]} (validate! problem)]
+    (vec (concat [(:values query) (:row-offsets query) (:positions query) k-pages v-pages]
+                 (route-buffer-ids route)
+                 (visibility-buffer-ids visibility)))))
 
 (defn validate!
   "Validate an AttentionProblem's static semantics and storage extents. Runtime route/query values

--- a/src/raster/compiler/ir/segmented_weighted_reduction.clj
+++ b/src/raster/compiler/ir/segmented_weighted_reduction.clj
@@ -1,0 +1,311 @@
+(ns raster.compiler.ir.segmented-weighted-reduction
+  "Backend-neutral algebra for a segmented, normalized weighted reduction.
+
+   For every segment s and visible member e, the plan computes a scalar score, maps it to a
+   weight, reduces `weight*value` and `weight`, then normalizes the two sums. The member traversal
+   and physical value access are explicit descriptors rather than part of the scalar algebra.
+
+   This is deliberately an internal compiler plan, not a new user-facing attention primitive.
+   Canonical attention and a future recognizer for indexed-dot/scatter programs can therefore
+   converge here without making either source spelling opaque or changing its numerics."
+  (:require [clojure.set :as set]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.util :as util]))
+
+(defrecord ScalarRegion [parameters body result-dtype])
+(defrecord Reduction [operator identity map-region])
+(defrecord SegmentedWeightedReductionPlan
+           [id segment-axes membership storage score weight value
+            numerator denominator normalization operands output
+            accumulator-dtype source-operation provenance])
+
+(def ^:private scalar-operators
+  "Closed scalar vocabulary accepted in plan regions. Keeping regions closed makes recognition
+   conservative: an unknown call declines before any reordering or fusion can change effects."
+  '#{raster.numeric/+ raster.numeric/- raster.numeric/* raster.numeric//
+     raster.numeric/min raster.numeric/max raster.numeric/abs raster.numeric/sqrt
+     raster.math/exp raster.math/log
+     clojure.core/+ clojure.core/- clojure.core/* clojure.core//
+     clojure.core/min clojure.core/max clojure.core/abs
+     Math/exp Math/log Math/sqrt})
+
+(defn scalar-region?
+  [x]
+  (instance? ScalarRegion x))
+
+(defn reduction?
+  [x]
+  (instance? Reduction x))
+
+(defn plan?
+  [x]
+  (instance? SegmentedWeightedReductionPlan x))
+
+(defn- scalar-expression?
+  [parameters expression]
+  (cond
+    (or (number? expression) (boolean? expression)) true
+    (symbol? expression) (contains? parameters expression)
+    (seq? expression) (and (contains? scalar-operators (first expression))
+                           (every? #(scalar-expression? parameters %) (rest expression)))
+    :else false))
+
+(defn validate-region!
+  "Validate a closed, side-effect-free scalar region. Parameters are positional SSA-like names;
+   the body may only use those names, numeric literals, and the closed scalar vocabulary above."
+  [owner region]
+  (when-not (scalar-region? region)
+    (throw (ex-info "segmented reduction requires a ScalarRegion"
+                    {:reason :segmented-reduction-invalid-region
+                     :owner owner :region region :actual (type region)})))
+  (let [{:keys [parameters body result-dtype]} region]
+    (when-not (and (vector? parameters)
+                   (every? symbol? parameters)
+                   (= (count parameters) (count (distinct parameters))))
+      (throw (ex-info "scalar region parameters must be an ordered vector of unique symbols"
+                      {:reason :segmented-reduction-invalid-region-parameters
+                       :owner owner :parameters parameters})))
+    (when-not (and (dtype/known? result-dtype) (dtype/fp-dtype? result-dtype))
+      (throw (ex-info "scalar region result dtype must be floating point"
+                      {:reason :segmented-reduction-invalid-region-dtype
+                       :owner owner :dtype result-dtype})))
+    (when (util/effectful? body)
+      (throw (ex-info "scalar region cannot contain effects"
+                      {:reason :segmented-reduction-effectful-region
+                       :owner owner :body body})))
+    (let [free (util/free-syms body)]
+      (when-not (set/subset? free (set parameters))
+        (throw (ex-info "scalar region references an undeclared parameter"
+                        {:reason :segmented-reduction-region-free-symbol
+                         :owner owner :free free :parameters parameters}))))
+    (when-not (scalar-expression? (set parameters) body)
+      (throw (ex-info "scalar region contains an unsupported operation or value"
+                      {:reason :segmented-reduction-unsupported-scalar-expression
+                       :owner owner :body body :supported scalar-operators})))
+    region))
+
+(defn region
+  "Construct a checked scalar region."
+  [{:keys [parameters body result-dtype]}]
+  (validate-region! :region
+                    (->ScalarRegion (vec parameters) body (dtype/canon result-dtype))))
+
+(defn validate-reduction!
+  [owner reduction expected-parameters accumulator-dtype]
+  (when-not (reduction? reduction)
+    (throw (ex-info "segmented reduction requires an explicit Reduction"
+                    {:reason :segmented-reduction-invalid-reducer
+                     :owner owner :reduction reduction :actual (type reduction)})))
+  (let [{:keys [operator identity map-region]} reduction]
+    (when-not (= :sum operator)
+      (throw (ex-info "only additive weighted reductions are currently legal"
+                      {:reason :segmented-reduction-unsupported-reducer
+                       :owner owner :operator operator :supported #{:sum}})))
+    (when-not (and (number? identity) (zero? identity))
+      (throw (ex-info "additive weighted reduction requires numeric zero identity"
+                      {:reason :segmented-reduction-invalid-identity
+                       :owner owner :identity identity})))
+    (validate-region! owner map-region)
+    (when-not (= expected-parameters (:parameters map-region))
+      (throw (ex-info "weighted reduction map region has the wrong positional contract"
+                      {:reason :segmented-reduction-map-arity
+                       :owner owner :expected expected-parameters
+                       :actual (:parameters map-region)})))
+    (when-not (= (dtype/canon accumulator-dtype) (:result-dtype map-region))
+      (throw (ex-info "weighted reduction map must produce the accumulator dtype"
+                      {:reason :segmented-reduction-map-dtype
+                       :owner owner :expected accumulator-dtype
+                       :actual (:result-dtype map-region)})))
+    reduction))
+
+(defn reduction
+  "Construct a checked reduction. The plan validator additionally checks its positional inputs."
+  [{:keys [operator identity map-region] :or {operator :sum identity 0.0}}]
+  (->Reduction operator identity map-region))
+
+(defn- positive-axis!
+  [axis]
+  (when-not (and (map? axis) (keyword? (:name axis))
+                 (integer? (:extent axis)) (pos? (:extent axis)))
+    (throw (ex-info "segment axes require keyword names and positive static extents"
+                    {:reason :segmented-reduction-invalid-segment-axis :axis axis})))
+  axis)
+
+(defn- descriptor!
+  [field descriptor]
+  (when-not (and (map? descriptor) (keyword? (:kind descriptor)))
+    (throw (ex-info "segmented reduction descriptor requires a keyword kind"
+                    {:reason :segmented-reduction-invalid-descriptor
+                     :field field :descriptor descriptor})))
+  descriptor)
+
+(defn- buffer-descriptor!
+  [field descriptor]
+  (when-not (and (map? descriptor)
+                 (some? (:id descriptor))
+                 (dtype/known? (:dtype descriptor))
+                 (vector? (:shape descriptor))
+                 (seq (:shape descriptor))
+                 (every? #(and (integer? %) (pos? %)) (:shape descriptor))
+                 (integer? (:elements descriptor))
+                 (pos? (:elements descriptor))
+                 (= (:elements descriptor) (reduce * 1 (:shape descriptor))))
+    (throw (ex-info "segmented reduction buffer descriptor is incomplete or inconsistent"
+                    {:reason :segmented-reduction-invalid-buffer-descriptor
+                     :field field :descriptor descriptor})))
+  descriptor)
+
+(defn validate!
+  "Validate a segmented weighted-reduction plan independently of target scheduling."
+  [plan]
+  (when-not (plan? plan)
+    (throw (ex-info "segmented weighted reduction must be a plan value"
+                    {:reason :segmented-reduction-invalid-plan
+                     :plan plan :actual (type plan)})))
+  (let [{:keys [id segment-axes membership storage score weight value numerator denominator
+                normalization operands output accumulator-dtype source-operation provenance]} plan]
+    (when (nil? id)
+      (throw (ex-info "segmented weighted reduction requires a stable identity"
+                      {:reason :segmented-reduction-missing-id})))
+    (when-not (and (vector? segment-axes) (seq segment-axes))
+      (throw (ex-info "segmented weighted reduction requires ordered segment axes"
+                      {:reason :segmented-reduction-missing-segment-axes
+                       :segment-axes segment-axes})))
+    (doseq [axis segment-axes] (positive-axis! axis))
+    (when-not (= (count segment-axes) (count (distinct (map :name segment-axes))))
+      (throw (ex-info "segmented reduction axis names must be unique"
+                      {:reason :segmented-reduction-duplicate-axis
+                       :axes (mapv :name segment-axes)})))
+    (doseq [[field descriptor] [[:membership membership] [:storage storage]
+                                [:score score] [:value value]]]
+      (descriptor! field descriptor))
+    (positive-axis! (:axis score))
+    (when-not (and (dtype/known? accumulator-dtype) (dtype/fp-dtype? accumulator-dtype))
+      (throw (ex-info "segmented reduction accumulator must be floating point"
+                      {:reason :segmented-reduction-invalid-accumulator-dtype
+                       :dtype accumulator-dtype})))
+    (let [accumulator-dtype (dtype/canon accumulator-dtype)]
+      (validate-region! :score-combine (:combine score))
+      (validate-region! :score-finalize (:finalize score))
+      (when-not (= ['left 'right] (:parameters (:combine score)))
+        (throw (ex-info "score combine region must accept left and right elements"
+                        {:reason :segmented-reduction-score-combine-arity
+                         :actual (:parameters (:combine score))})))
+      (when-not (= ['dot] (:parameters (:finalize score)))
+        (throw (ex-info "score finalize region must accept the reduced dot value"
+                        {:reason :segmented-reduction-score-finalize-arity
+                         :actual (:parameters (:finalize score))})))
+      (when-not (and (= accumulator-dtype (:result-dtype (:combine score)))
+                     (= accumulator-dtype (:result-dtype (:finalize score))))
+        (throw (ex-info "score regions must produce the accumulator dtype"
+                        {:reason :segmented-reduction-score-dtype
+                         :accumulator-dtype accumulator-dtype
+                         :combine-dtype (:result-dtype (:combine score))
+                         :finalize-dtype (:result-dtype (:finalize score))})))
+      (validate-region! :weight weight)
+      (when-not (and (= ['score] (:parameters weight))
+                     (= accumulator-dtype (:result-dtype weight)))
+        (throw (ex-info "weight region must map one score to the accumulator dtype"
+                        {:reason :segmented-reduction-weight-contract
+                         :parameters (:parameters weight) :dtype (:result-dtype weight)})))
+      (validate-reduction! :numerator numerator ['weight 'value] accumulator-dtype)
+      (validate-reduction! :denominator denominator ['weight] accumulator-dtype))
+    (when-not (and (map? normalization)
+                   (= :divide (:kind normalization))
+                   (number? (:epsilon normalization))
+                   (Double/isFinite (double (:epsilon normalization)))
+                   (not (neg? (double (:epsilon normalization))))
+                   (number? (:empty-result normalization)))
+      (throw (ex-info "normalization requires finite nonnegative epsilon and an empty result"
+                      {:reason :segmented-reduction-invalid-normalization
+                       :normalization normalization})))
+    (when-not (and (vector? operands) (every? map? operands))
+      (throw (ex-info "segmented reduction operands must be an ordered descriptor vector"
+                      {:reason :segmented-reduction-invalid-operands :operands operands})))
+    (doseq [[index operand] (map-indexed vector operands)]
+      (buffer-descriptor! [:operand index] operand))
+    (buffer-descriptor! :output output)
+    (let [ids (mapv :id operands)]
+      (when (or (some nil? ids) (not= (count ids) (count (distinct ids))))
+        (throw (ex-info "segmented reduction operand identities must be non-nil and unique"
+                        {:reason :segmented-reduction-invalid-operand-identities :ids ids})))
+      (when (or (nil? (:id output)) (some #{(:id output)} ids))
+        (throw (ex-info "segmented reduction output must be distinct from every input"
+                        {:reason :segmented-reduction-output-alias
+                         :output (:id output) :inputs ids}))))
+    (when (nil? source-operation)
+      (throw (ex-info "segmented reduction must retain its source operation"
+                      {:reason :segmented-reduction-missing-source-operation})))
+    (when-not (and (map? provenance) (keyword? (:semantic-op provenance)))
+      (throw (ex-info "segmented reduction requires semantic provenance"
+                      {:reason :segmented-reduction-invalid-provenance
+                       :provenance provenance})))
+    plan))
+
+(defn make
+  "Construct and validate an internal segmented weighted-reduction plan."
+  [fields]
+  (validate!
+   (map->SegmentedWeightedReductionPlan
+    (update fields :accumulator-dtype dtype/canon))))
+
+(defn ordered-input-ids
+  [plan]
+  (mapv :id (:operands (validate! plan))))
+
+(defn algebra-key
+  "Buffer- and storage-independent computation identity. Physical page routing and cache layout
+   cannot change this key; logical membership and scalar/reduction semantics can."
+  [plan]
+  (let [{:keys [segment-axes membership score weight value numerator denominator normalization
+                accumulator-dtype]} (validate! plan)]
+    {:segment-axes segment-axes
+     :membership (dissoc membership :buffers)
+     :score (dissoc score :left :right)
+     :weight weight
+     :value (select-keys value [:components])
+     :numerator numerator
+     :denominator denominator
+     :normalization normalization
+     :accumulator-dtype accumulator-dtype}))
+
+(defn schedule-key
+  "Static code-generation identity: algebra plus storage representation, never buffer names."
+  [plan]
+  (let [{:keys [storage score value operands output] :as plan} (validate! plan)]
+    {:algebra (algebra-key plan)
+     :storage (dissoc storage :buffers :route)
+     :score-access (-> score (select-keys [:kind :axis :head-map :left :right])
+                       (update :left dissoc :buffer)
+                       (update :right dissoc :buffer))
+     :value-access (dissoc value :buffer)
+     :operand-dtypes (mapv :dtype operands)
+     :output-dtype (:dtype output)}))
+
+(defn online-softmax-algebra?
+  "True only for the canonical exp-normalized weighted sum that an online-softmax schedule can
+   execute without changing semantics. Score scaling may vary; all other scalar/reduction forms
+   are exact. A future GSDM clamp/epsilon plan therefore declines this leaf unless an emitter
+   explicitly implements those semantics."
+  [plan]
+  (let [{:keys [score weight numerator denominator normalization accumulator-dtype]}
+        (validate! plan)
+        score-finalize (:body (:finalize score))]
+    (and (= :dot (:kind score))
+         (= '(raster.numeric/* left right) (:body (:combine score)))
+         (seq? score-finalize)
+         (= 'raster.numeric/* (first score-finalize))
+         (= 'dot (second score-finalize))
+         (= 3 (count score-finalize))
+         (number? (nth score-finalize 2))
+         (Double/isFinite (double (nth score-finalize 2)))
+         (pos? (double (nth score-finalize 2)))
+         (= '(raster.math/exp score) (:body weight))
+         (= :sum (:operator numerator))
+         (= 0.0 (double (:identity numerator)))
+         (= '(raster.numeric/* weight value) (:body (:map-region numerator)))
+         (= :sum (:operator denominator))
+         (= 0.0 (double (:identity denominator)))
+         (= 'weight (:body (:map-region denominator)))
+         (= {:kind :divide :epsilon 0.0 :empty-result 0.0} normalization)
+         (= accumulator-dtype (:result-dtype weight)))))

--- a/src/raster/compiler/passes/parallel/attention_lower.clj
+++ b/src/raster/compiler/passes/parallel/attention_lower.clj
@@ -1,0 +1,80 @@
+(ns raster.compiler.passes.parallel.attention-lower
+  "Lower canonical AttentionProblem semantics into the shared segmented weighted-reduction plan."
+  (:require [raster.compiler.ir.attention :as attention]
+            [raster.compiler.ir.segmented-weighted-reduction :as swr]))
+
+(defn- scalar-region
+  [parameters body accumulator-dtype]
+  (swr/region {:parameters parameters :body body :result-dtype accumulator-dtype}))
+
+(defn- ordered-operands
+  [problem]
+  (let [specs (attention/buffer-specs problem)]
+    (mapv (fn [id]
+            (let [{:keys [dtype shape elements]} (get specs id)]
+              {:id id :dtype dtype :shape shape :elements elements}))
+          (attention/ordered-input-buffer-ids problem))))
+
+(defn lower
+  "Produce the canonical attention algebra without selecting a GPU schedule.
+
+   Logical visibility is kept apart from physical paged storage. The scalar regions state stable
+   softmax exactly: scaled dot -> exp -> additive numerator/denominator -> divide, with zero for
+   an empty visible row."
+  [problem]
+  (let [{:keys [id query route q-heads kv-heads qk-head-dim value-head-dim
+                q-dtype k-dtype v-dtype output-dtype accumulator-dtype scale
+                k-format v-format k-layout v-layout visibility output]
+         :as problem} (attention/validate! problem)
+        specs (attention/buffer-specs problem)
+        output-spec (get specs output)
+        combine (scalar-region ['left 'right]
+                               '(raster.numeric/* left right) accumulator-dtype)
+        score-finalize (scalar-region ['dot]
+                                      (list 'raster.numeric/* 'dot (double scale))
+                                      accumulator-dtype)
+        weight (scalar-region ['score] '(raster.math/exp score) accumulator-dtype)
+        numerator-map (scalar-region ['weight 'value]
+                                     '(raster.numeric/* weight value) accumulator-dtype)
+        denominator-map (scalar-region ['weight] 'weight accumulator-dtype)]
+    (swr/make
+     {:id [:segmented-weighted-reduction id]
+      :segment-axes [{:name :query-token :extent (:total-tokens query)}
+                     {:name :query-head :extent q-heads}]
+      :membership {:kind :logical-attention-visibility
+                   :visibility-kind (attention/visibility-kind visibility)
+                   :position-filter (into {} (attention/position-filter visibility))
+                   :duplicate-policy (when (attention/csr-visibility? visibility)
+                                       (:duplicate-policy visibility))
+                   :buffers (attention/visibility-buffer-ids visibility)}
+      :storage {:kind :routed-paged-kv
+                :route-kind (attention/route-kind route)
+                :page-size (:page-size problem)
+                :physical-pages (:physical-pages problem)
+                :route-shape (select-keys route [:pages-per-sequence :page-index-capacity])
+                :route route
+                :buffers (attention/route-buffer-ids route)
+                :k-format k-format :v-format v-format
+                :k-layout k-layout :v-layout v-layout}
+      :score {:kind :dot
+              :axis {:name :qk-component :extent qk-head-dim}
+              :head-map {:kind :grouped-query :query-heads q-heads :kv-heads kv-heads}
+              :left {:kind :packed-query :buffer (:values query) :dtype q-dtype}
+              :right {:kind :routed-key :buffer (:k-pages problem) :dtype k-dtype}
+              :combine combine
+              :finalize score-finalize}
+      :weight weight
+      :value {:kind :routed-value :buffer (:v-pages problem)
+              :dtype v-dtype :components value-head-dim}
+      :numerator (swr/reduction {:operator :sum :identity 0.0
+                                 :map-region numerator-map})
+      :denominator (swr/reduction {:operator :sum :identity 0.0
+                                   :map-region denominator-map})
+      :normalization {:kind :divide :epsilon 0.0 :empty-result 0.0}
+      :operands (ordered-operands problem)
+      :output {:id output :dtype output-dtype :shape (:shape output-spec)
+               :elements (:elements output-spec)}
+      :accumulator-dtype accumulator-dtype
+      :source-operation problem
+      :provenance {:semantic-op :attention :operation-id id
+                   :lowering :canonical-segmented-weighted-reduction}})))

--- a/src/raster/compiler/passes/parallel/attention_route.clj
+++ b/src/raster/compiler/passes/parallel/attention_route.clj
@@ -1,7 +1,8 @@
 (ns raster.compiler.passes.parallel.attention-route
   "Structured routing for backend-neutral attention problems."
   (:require [raster.compiler.backend.gpu.attention :as emit]
-            [raster.compiler.ir.attention :as attention]))
+            [raster.compiler.ir.attention :as attention]
+            [raster.compiler.passes.parallel.attention-lower :as lower]))
 
 (defn- decline
   [problem reason data]
@@ -41,13 +42,15 @@
                 {:required :float :actual accumulator-dtype})
 
        :else
-       (let [artifact (emit/emit-fp16-reference problem desc)]
+       (let [plan (lower/lower problem)
+             artifact (emit/emit-fp16-reference plan desc)]
          {:operation problem
+          :plan plan
           :strategy :fp16-reference
           :reference? true
           :declines []
           :artifact artifact
-          :graph (emit/kernel-graph problem artifact)
+          :graph (emit/kernel-graph plan artifact)
           :schedule {:workgroup-size (:workgroup-size (:launch artifact))
                      :group-count (:group-count (:launch artifact))}})))))
 

--- a/test/raster/compiler/passes/parallel/attention_lower_test.clj
+++ b/test/raster/compiler/passes/parallel/attention_lower_test.clj
@@ -1,0 +1,145 @@
+(ns raster.compiler.passes.parallel.attention-lower-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.attention :as attention]
+            [raster.compiler.ir.segmented-weighted-reduction :as swr]
+            [raster.compiler.passes.parallel.attention-lower :as lower]
+            [raster.compiler.passes.parallel.attention-route :as route]))
+
+(defn- query
+  [& [prefix]]
+  (let [prefix (or prefix "")]
+    (attention/packed-query-batch
+     {:values (symbol (str prefix "q"))
+      :row-offsets (symbol (str prefix "q-rows"))
+      :positions (symbol (str prefix "q-positions"))
+      :total-tokens 5})))
+
+(defn- dense-route
+  [& [prefix]]
+  (let [prefix (or prefix "")]
+    (attention/dense-paged-route
+     {:page-table (symbol (str prefix "page-table"))
+      :lengths (symbol (str prefix "kv-lengths"))
+      :start-positions (symbol (str prefix "kv-starts"))
+      :pages-per-sequence 3})))
+
+(defn- csr-route
+  [& [prefix]]
+  (let [prefix (or prefix "")]
+    (attention/csr-paged-route
+     {:page-offsets (symbol (str prefix "page-offsets"))
+      :page-indices (symbol (str prefix "page-indices"))
+      :last-page-lengths (symbol (str prefix "last-page-lengths"))
+      :start-positions (symbol (str prefix "kv-starts"))
+      :page-index-capacity 6})))
+
+(defn- problem
+  [& {:keys [route visibility prefix]
+      :or {prefix ""}}]
+  (attention/make
+   {:id :attention
+    :query (query prefix)
+    :k-pages (symbol (str prefix "k-pages"))
+    :v-pages (symbol (str prefix "v-pages"))
+    :route (or route (dense-route prefix))
+    :output (symbol (str prefix "output"))
+    :batch-size 2 :q-heads 4 :kv-heads 2
+    :qk-head-dim 8 :value-head-dim 6
+    :page-size 2 :physical-pages 7 :scale 0.25
+    :k-layout :kv-head-major :v-layout :page-major
+    :visibility (or visibility
+                    (attention/visibility
+                     {:causal? true :window-left 4 :window-right 0}))}))
+
+(defn- reason
+  [thunk]
+  (try
+    (thunk)
+    nil
+    (catch clojure.lang.ExceptionInfo e
+      (:reason (ex-data e)))))
+
+(deftest canonical-attention-lowers-to-explicit-weighted-reduction-algebra
+  (let [problem (problem)
+        plan (lower/lower problem)]
+    (is (swr/plan? plan))
+    (is (= [{:name :query-token :extent 5}
+            {:name :query-head :extent 4}]
+           (:segment-axes plan)))
+    (is (= :logical-attention-visibility (get-in plan [:membership :kind])))
+    (is (= :routed-paged-kv (get-in plan [:storage :kind])))
+    (is (= :dense-paged (get-in plan [:storage :route-kind])))
+    (is (= {:kind :grouped-query :query-heads 4 :kv-heads 2}
+           (get-in plan [:score :head-map])))
+    (is (= '(raster.numeric/* dot 0.25)
+           (get-in plan [:score :finalize :body])))
+    (is (= '(raster.math/exp score) (get-in plan [:weight :body])))
+    (is (= '(raster.numeric/* weight value)
+           (get-in plan [:numerator :map-region :body])))
+    (is (= 'weight (get-in plan [:denominator :map-region :body])))
+    (is (= {:kind :divide :epsilon 0.0 :empty-result 0.0}
+           (:normalization plan)))
+    (is (= (attention/ordered-input-buffer-ids problem)
+           (swr/ordered-input-ids plan)))
+    (is (= :attention (get-in plan [:provenance :semantic-op])))
+    (is (= problem (:source-operation plan)))))
+
+(deftest logical-algebra-is-independent-of-physical-page-routing
+  (let [dense (lower/lower (problem :route (dense-route)))
+        csr (lower/lower (problem :route (csr-route)))]
+    (is (= (swr/algebra-key dense) (swr/algebra-key csr)))
+    (is (not= (swr/schedule-key dense) (swr/schedule-key csr)))
+    (is (= :dense-paged (get-in dense [:storage :route-kind])))
+    (is (= :csr-paged (get-in csr [:storage :route-kind])))))
+
+(deftest logical-visibility-remains-part-of-the-algebra
+  (let [causal (lower/lower (problem))
+        bidirectional (lower/lower
+                       (problem :visibility (attention/visibility
+                                             {:causal? false
+                                              :window-left nil :window-right nil})))]
+    (is (not= (swr/algebra-key causal) (swr/algebra-key bidirectional)))))
+
+(deftest buffer-renaming-does-not-change-static-plan-identity
+  (let [a (lower/lower (problem :prefix "a-"))
+        b (lower/lower (problem :prefix "b-"))]
+    (is (= (swr/algebra-key a) (swr/algebra-key b)))
+    (is (= (swr/schedule-key a) (swr/schedule-key b)))
+    (is (not= (swr/ordered-input-ids a) (swr/ordered-input-ids b)))))
+
+(deftest scalar-plan-legality-fails-closed
+  (let [plan (lower/lower (problem))]
+    (testing "unknown scalar calls cannot be reordered or fused"
+      (is (= :segmented-reduction-region-free-symbol
+             (reason #(swr/validate!
+                       (assoc-in plan [:weight :body] '(unknown-score-op score)))))))
+    (testing "positional numerator contracts are checked"
+      (is (= :segmented-reduction-map-arity
+             (reason #(swr/validate!
+                       (assoc-in plan [:numerator :map-region :parameters]
+                                 ['value 'weight]))))))
+    (testing "normalization is exact plan semantics, not an emitter default"
+      (is (= :segmented-reduction-invalid-normalization
+             (reason #(swr/validate!
+                       (assoc-in plan [:normalization :epsilon] -1.0))))))))
+
+(deftest executable-attention-routing-consumes-the-shared-plan
+  (let [{:keys [plan artifact graph]} (route/route! (problem))]
+    (is (swr/plan? plan))
+    (is (= (:id plan) (get-in artifact [:provenance :algebra-plan-id])))
+    (is (= :segmented-weighted-reduction
+           (get-in artifact [:attributes :algebra])))
+    (is (= (swr/algebra-key plan)
+           (get-in artifact [:attributes :algebra-key])))
+    (is (= (swr/ordered-input-ids plan)
+           (vec (butlast (:arguments artifact)))))
+    (is (= :attention (get-in graph [:provenance :semantic-op])))))
+
+(deftest reference-emission-cannot-ignore-a-changed-algebra
+  (let [plan (lower/lower (problem))
+        changed (assoc-in plan [:normalization :epsilon] 1.0e-6)]
+    (is (not (swr/online-softmax-algebra? changed)))
+    (is (= :attention-reference-plan-unsupported
+           (reason #((requiring-resolve
+                      'raster.compiler.backend.gpu.attention/emit-fp16-reference)
+                     changed nil))))))

--- a/test/raster/compiler/passes/parallel/attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/attention_route_test.clj
@@ -4,6 +4,7 @@
             [raster.compiler.ir.attention :as attention]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-graph :as kgraph]
+            [raster.compiler.ir.segmented-weighted-reduction :as swr]
             [raster.compiler.passes.parallel.attention-route :as route]))
 
 (defn- query
@@ -45,12 +46,13 @@
           (apply hash-map overrides))))
 
 (deftest dense-reference-is-a-complete-packed-attention-compiler-value
-  (let [{:keys [strategy reference? declines artifact graph schedule]}
+  (let [{:keys [strategy reference? declines plan artifact graph schedule]}
         (route/route! (problem)
                       {:device-type :gpu :subgroup-size 16 :max-workgroup-size 256})]
     (is (= :fp16-reference strategy))
     (is reference?)
     (is (empty? declines))
+    (is (swr/plan? plan))
     (is (kart/kernel-artifact? artifact))
     (is (kgraph/kernel-graph? graph))
     (is (= '[q q-row-offsets q-positions k-pages v-pages


### PR DESCRIPTION
## Summary

- add a checked backend-neutral segmented weighted-reduction plan with closed scalar regions, explicit numerator/denominator reductions, normalization semantics, and distinct algebra/schedule identities
- lower canonical AttentionProblem values through that plan before routing and make the FP16 reference emitter consume it
- fail closed when an emitter cannot preserve a changed algebra, so clamp or denominator-epsilon variants cannot silently execute as ordinary online softmax
- centralize the ordered attention input-buffer contract and preserve logical visibility independently of physical page routing

This intentionally does not add the current GSDM clamp bound or denominator epsilon to the public attention API. A later recognizer can preserve those exact scalar regions in the shared plan while generic indexed/scatter/segment operators remain public.

## Verification

- 25 tests / 150 assertions: attention lowering, routing, IR, AD, and reference oracle
- 77 tests / 401 assertions: existing GSDM, array operators and gradients, kernel ABI/artifact/graph
- 3 live attention device tests / 3 assertions: both available OpenCL cases passed; Level Zero skipped because zeInit returned 0x78000001 during device probing
- cljfmt check passed
- git diff --check passed