### PR TITLE
Recognize compositional indexed attention

### DIFF
--- a/src/raster/compiler/ir/segmented_weighted_reduction.clj
+++ b/src/raster/compiler/ir/segmented_weighted_reduction.clj
@@ -126,8 +126,10 @@
 (defn- positive-axis!
   [axis]
   (when-not (and (map? axis) (keyword? (:name axis))
-                 (integer? (:extent axis)) (pos? (:extent axis)))
-    (throw (ex-info "segment axes require keyword names and positive static extents"
+                 (let [extent (:extent axis)]
+                   (or (and (integer? extent) (pos? extent))
+                       (symbol? extent))))
+    (throw (ex-info "segment axes require keyword names and valid extent expressions"
                     {:reason :segmented-reduction-invalid-segment-axis :axis axis})))
   axis)
 
@@ -141,19 +143,48 @@
 
 (defn- buffer-descriptor!
   [field descriptor]
-  (when-not (and (map? descriptor)
-                 (some? (:id descriptor))
-                 (dtype/known? (:dtype descriptor))
-                 (vector? (:shape descriptor))
-                 (seq (:shape descriptor))
-                 (every? #(and (integer? %) (pos? %)) (:shape descriptor))
-                 (integer? (:elements descriptor))
-                 (pos? (:elements descriptor))
-                 (= (:elements descriptor) (reduce * 1 (:shape descriptor))))
-    (throw (ex-info "segmented reduction buffer descriptor is incomplete or inconsistent"
-                    {:reason :segmented-reduction-invalid-buffer-descriptor
-                     :field field :descriptor descriptor})))
-  descriptor)
+  (let [valid-extent? #(or (and (integer? %) (pos? %)) (symbol? %))
+        valid-elements? (fn valid-elements? [expression]
+                          (or (and (integer? expression) (pos? expression))
+                              (symbol? expression)
+                              (and (seq? expression)
+                                   (= 'clojure.core/* (first expression))
+                                   (seq (rest expression))
+                                   (every? valid-elements? (rest expression)))))
+        literal-shape? (every? integer? (:shape descriptor))]
+    (when-not (and (map? descriptor)
+                   (some? (:id descriptor))
+                   (dtype/known? (:dtype descriptor))
+                   (vector? (:shape descriptor))
+                   (seq (:shape descriptor))
+                   (every? valid-extent? (:shape descriptor))
+                   (valid-elements? (:elements descriptor))
+                   (or (not literal-shape?)
+                       (and (integer? (:elements descriptor))
+                            (pos? (:elements descriptor))
+                            (= (:elements descriptor) (reduce * 1 (:shape descriptor))))))
+      (throw (ex-info "segmented reduction buffer descriptor is incomplete or inconsistent"
+                      {:reason :segmented-reduction-invalid-buffer-descriptor
+                       :field field :descriptor descriptor})))
+    descriptor))
+
+(defn- validate-score-argument!
+  [argument]
+  (when-not
+   (and (map? argument)
+        (symbol? (:parameter argument))
+        (case (:kind argument)
+          :literal (and (number? (:value argument))
+                        (Double/isFinite (double (:value argument))))
+          :inverse-sqrt (let [extent (:extent argument)]
+                          (or (and (integer? extent) (pos? extent))
+                              (symbol? extent)))
+          false))
+    (throw (ex-info "score argument requires a supported loop-invariant scalar producer"
+                    {:reason :segmented-reduction-invalid-score-argument
+                     :argument argument
+                     :supported #{:literal :inverse-sqrt}})))
+  argument)
 
 (defn validate!
   "Validate a segmented weighted-reduction plan independently of target scheduling."
@@ -191,10 +222,18 @@
         (throw (ex-info "score combine region must accept left and right elements"
                         {:reason :segmented-reduction-score-combine-arity
                          :actual (:parameters (:combine score))})))
-      (when-not (= ['dot] (:parameters (:finalize score)))
-        (throw (ex-info "score finalize region must accept the reduced dot value"
-                        {:reason :segmented-reduction-score-finalize-arity
-                         :actual (:parameters (:finalize score))})))
+      (let [arguments (:arguments score)]
+        (when-not (vector? arguments)
+          (throw (ex-info "score arguments must be an ordered vector"
+                          {:reason :segmented-reduction-invalid-score-arguments
+                           :arguments arguments})))
+        (doseq [argument arguments] (validate-score-argument! argument))
+        (when-not (= (into ['dot] (map :parameter arguments))
+                     (:parameters (:finalize score)))
+          (throw (ex-info "score finalize parameters must align with its scalar arguments"
+                          {:reason :segmented-reduction-score-finalize-arity
+                           :arguments arguments
+                           :actual (:parameters (:finalize score))}))))
       (when-not (and (= accumulator-dtype (:result-dtype (:combine score)))
                      (= accumulator-dtype (:result-dtype (:finalize score))))
         (throw (ex-info "score regions must produce the accumulator dtype"
@@ -293,6 +332,8 @@
         score-finalize (:body (:finalize score))]
     (and (= :dot (:kind score))
          (= '(raster.numeric/* left right) (:body (:combine score)))
+         (empty? (:arguments score))
+         (= ['dot] (:parameters (:finalize score)))
          (seq? score-finalize)
          (= 'raster.numeric/* (first score-finalize))
          (= 'dot (second score-finalize))

--- a/src/raster/compiler/passes/parallel/attention_lower.clj
+++ b/src/raster/compiler/passes/parallel/attention_lower.clj
@@ -62,6 +62,7 @@
               :left {:kind :packed-query :buffer (:values query) :dtype q-dtype}
               :right {:kind :routed-key :buffer (:k-pages problem) :dtype k-dtype}
               :combine combine
+              :arguments []
               :finalize score-finalize}
       :weight weight
       :value {:kind :routed-value :buffer (:v-pages problem)

--- a/src/raster/compiler/passes/parallel/indexed_attention_recognize.clj
+++ b/src/raster/compiler/passes/parallel/indexed_attention_recognize.clj
@@ -1,0 +1,248 @@
+(ns raster.compiler.passes.parallel.indexed-attention-recognize
+  "Conservative recognition of compositional indexed graph attention.
+
+   This pass recognizes the exact generic-operator chain currently used by GSDM:
+
+     indexed-dot -> scale-clamp-exp -> scatter-add
+                                      -> scatter-mul-add -> segment-div
+
+   It produces the shared SegmentedWeightedReductionPlan without rewriting the source program.
+   Every dimension, edge direction, intermediate-use count, clamp bound and normalization epsilon
+   must agree. A failed proof returns nil; it never guesses that a similar scatter program is
+   attention."
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.ir.segmented-weighted-reduction :as swr]))
+
+(def ^:private indexed-dot-op 'raster.dl.array-ops/indexed-dot)
+(def ^:private scale-clamp-exp-op 'raster.dl.array-ops/scale-clamp-exp)
+(def ^:private scatter-add-op 'raster.dl.array-ops/scatter-add)
+(def ^:private scatter-mul-add-op 'raster.dl.array-ops/scatter-mul-add)
+(def ^:private segment-div-op 'raster.dl.array-ops/segment-div)
+(def ^:private casts
+  '#{double float long int clojure.core/double clojure.core/float
+     clojure.core/long clojure.core/int})
+(def ^:private sqrt-ops '#{raster.numeric/sqrt raster.math/sqrt Math/sqrt})
+
+(defn- strip-cast
+  [expression]
+  (if (and (seq? expression) (= 2 (count expression))
+           (contains? casts (first expression)))
+    (recur (second expression))
+    expression))
+
+(defn- same-value?
+  [left right]
+  (= (strip-cast left) (strip-cast right)))
+
+(defn- call-args
+  [expression operation arity]
+  (when (and (seq? expression)
+             (= operation (descriptor/semantic-op expression)))
+    (let [arguments (vec (descriptor/call-args expression))]
+      (when (= arity (count arguments)) arguments))))
+
+(defn- product-factors
+  [expression]
+  (let [expression (strip-cast expression)]
+    (if (and (seq? expression)
+             (descriptor/multiplication-op? (descriptor/semantic-op expression)))
+      (mapcat product-factors (descriptor/call-args expression))
+      [expression])))
+
+(defn- product-of?
+  [expression factors]
+  (= (frequencies (map strip-cast (product-factors expression)))
+     (frequencies (map strip-cast factors))))
+
+(defn- inverse-sqrt-of?
+  [expression extent]
+  (let [expression (strip-cast expression)]
+    (when (and (seq? expression)
+               (descriptor/division-op? (descriptor/semantic-op expression)))
+      (let [[numerator denominator :as arguments]
+            (vec (descriptor/call-args expression))
+            denominator (strip-cast denominator)]
+        (and (= 2 (count arguments))
+             (number? (strip-cast numerator))
+             (= 1.0 (double (strip-cast numerator)))
+             (seq? denominator)
+             (contains? sqrt-ops (descriptor/semantic-op denominator))
+             (= 1 (count (descriptor/call-args denominator)))
+             (same-value? extent (first (descriptor/call-args denominator))))))))
+
+(defn- product
+  [values]
+  (let [values (vec (remove #(= 1 %) values))]
+    (cond
+      (empty? values) 1
+      (every? number? values) (reduce * values)
+      (= 1 (count values)) (first values)
+      :else (cons 'clojure.core/* values))))
+
+(defn- buffer
+  [id dtype shape]
+  {:id id :dtype dtype :shape (vec shape) :elements (product shape)})
+
+(defn- stable-distinct
+  [descriptors]
+  (second
+   (reduce (fn [[seen result] descriptor]
+             (if (contains? seen (:id descriptor))
+               [seen result]
+               [(conj seen (:id descriptor)) (conj result descriptor)]))
+           [#{} []]
+           descriptors)))
+
+(defn- symbol-uses
+  [expressions symbol]
+  (count (filter #(= symbol %)
+                 (mapcat #(tree-seq coll? seq %) expressions))))
+
+(defn- match-at
+  [form bindings use-expressions output dtype accumulator-dtype]
+  (when-let [[weighted-sum denominator-sum n-nodes total-dim n-heads epsilon]
+             (call-args (get bindings output) segment-div-op 6)]
+    (when-let [[weights values destination-edges source-edges
+                weighted-n-dst weighted-n-src n-edges slice-dim
+                weighted-total-dim weighted-heads]
+               (call-args (get bindings weighted-sum) scatter-mul-add-op 10)]
+      (when-let [[denominator-weights denominator-destination denominator-n-dst
+                  denominator-edges denominator-heads]
+                 (call-args (get bindings denominator-sum) scatter-add-op 5)]
+        (when-let [[raw-scores scale clamp-bound score-elements]
+                   (call-args (get bindings weights) scale-clamp-exp-op 4)]
+          (when-let [[queries keys query-indices key-indices dot-n-a dot-n-b dot-edges
+                      dot-slice-dim dot-total-dim dot-heads]
+                     (call-args (get bindings raw-scores) indexed-dot-op 10)]
+            (let [bound (when (number? (strip-cast clamp-bound))
+                          (double (strip-cast clamp-bound)))
+                  epsilon (when (number? (strip-cast epsilon))
+                            (double (strip-cast epsilon)))
+                  internal [raw-scores weights denominator-sum weighted-sum]
+                  uses [(symbol-uses use-expressions raw-scores)
+                        (symbol-uses use-expressions weights)
+                        (symbol-uses use-expressions denominator-sum)
+                        (symbol-uses use-expressions weighted-sum)]]
+              (when (and (every? symbol? internal)
+                         (= (count internal) (count (distinct internal)))
+                         (= [1 2 1 1] uses)
+                         (same-value? weights denominator-weights)
+                         (same-value? destination-edges denominator-destination)
+                         (same-value? n-nodes denominator-n-dst)
+                         (same-value? n-edges denominator-edges)
+                         (same-value? n-heads denominator-heads)
+                         (same-value? destination-edges query-indices)
+                         (same-value? source-edges key-indices)
+                         (every? true?
+                                 [(same-value? n-nodes weighted-n-dst)
+                                  (same-value? n-nodes weighted-n-src)
+                                  (same-value? n-nodes dot-n-a)
+                                  (same-value? n-nodes dot-n-b)
+                                  (same-value? n-edges dot-edges)
+                                  (same-value? slice-dim dot-slice-dim)
+                                  (same-value? total-dim weighted-total-dim)
+                                  (same-value? total-dim dot-total-dim)
+                                  (same-value? n-heads weighted-heads)
+                                  (same-value? n-heads dot-heads)])
+                         (product-of? score-elements [n-edges n-heads])
+                         (inverse-sqrt-of? scale slice-dim)
+                         (some? bound) (Double/isFinite bound) (pos? bound)
+                         (some? epsilon) (Double/isFinite epsilon) (pos? epsilon))
+                (let [combine (swr/region
+                               {:parameters ['left 'right]
+                                :body '(raster.numeric/* left right)
+                                :result-dtype accumulator-dtype})
+                      score-finalize
+                      (swr/region
+                       {:parameters ['dot 'scale 'lower 'upper]
+                        :body '(raster.numeric/min
+                                upper
+                                (raster.numeric/max lower
+                                                    (raster.numeric/* dot scale)))
+                        :result-dtype accumulator-dtype})
+                      weight (swr/region
+                              {:parameters ['score]
+                               :body '(raster.math/exp score)
+                               :result-dtype accumulator-dtype})
+                      numerator-map (swr/region
+                                     {:parameters ['weight 'value]
+                                      :body '(raster.numeric/* weight value)
+                                      :result-dtype accumulator-dtype})
+                      denominator-map (swr/region
+                                       {:parameters ['weight] :body 'weight
+                                        :result-dtype accumulator-dtype})
+                      value-shape [n-nodes total-dim]
+                      edge-shape [n-edges]
+                      operands (stable-distinct
+                                [(buffer queries dtype value-shape)
+                                 (buffer keys dtype value-shape)
+                                 (buffer values dtype value-shape)
+                                 (buffer destination-edges :long edge-shape)
+                                 (buffer source-edges :long edge-shape)])]
+                  (swr/make
+                   {:id [:segmented-weighted-reduction output]
+                    :segment-axes [{:name :destination :extent n-nodes}
+                                   {:name :head :extent n-heads}]
+                    :membership {:kind :edge-list-by-destination
+                                 :destination-indices destination-edges
+                                 :source-indices source-edges
+                                 :edges n-edges
+                                 :duplicate-policy :multiset
+                                 :buffers [destination-edges source-edges]}
+                    :storage {:kind :indexed-dense-values
+                              :entity-count n-nodes :total-dim total-dim
+                              :buffers [queries keys values]}
+                    :score {:kind :dot
+                            :axis {:name :head-component :extent slice-dim}
+                            :head-map {:kind :identity :heads n-heads}
+                            :left {:kind :indexed-query :buffer queries
+                                   :indices destination-edges :dtype dtype
+                                   :total-dim total-dim}
+                            :right {:kind :indexed-key :buffer keys
+                                    :indices source-edges :dtype dtype
+                                    :total-dim total-dim}
+                            :combine combine
+                            :arguments [{:parameter 'scale :kind :inverse-sqrt
+                                         :extent slice-dim}
+                                        {:parameter 'lower :kind :literal :value (- bound)}
+                                        {:parameter 'upper :kind :literal :value bound}]
+                            :finalize score-finalize}
+                    :weight weight
+                    :value {:kind :indexed-value :buffer values
+                            :indices source-edges :dtype dtype
+                            :entity-count n-nodes :total-dim total-dim
+                            :components slice-dim}
+                    :numerator (swr/reduction
+                                {:operator :sum :identity 0.0
+                                 :map-region numerator-map})
+                    :denominator (swr/reduction
+                                  {:operator :sum :identity 0.0
+                                   :map-region denominator-map})
+                    :normalization {:kind :divide :epsilon epsilon :empty-result 0.0}
+                    :operands operands
+                    :output (buffer output dtype value-shape)
+                    :accumulator-dtype accumulator-dtype
+                    :source-operation {:form form :output output
+                                       :intermediates internal}
+                    :provenance {:semantic-op :indexed-graph-attention
+                                 :operation-id output
+                                 :lowering :recognized-indexed-attention-chain}}))))))))))
+
+(defn recognize
+  "Return every proven indexed-attention chain in a closed-core let* form, in binding order.
+   `dtype` describes Q/K/V/output storage; `accumulator-dtype` describes scalar reductions."
+  [form & {:keys [dtype accumulator-dtype]
+           :or {dtype :double accumulator-dtype :double}}]
+  (let [dtype (dtype/canon dtype)
+        accumulator-dtype (dtype/canon accumulator-dtype)]
+    (if-not (and (seq? form) (= 'let* (first form)) (vector? (second form)))
+      []
+      (let [[_ binding-vector & body] form
+            pairs (mapv vec (partition 2 binding-vector))
+            bindings (into {} pairs)
+            use-expressions (vec (concat (map second pairs) body))]
+        (vec (keep (fn [[output expression]]
+                     (when (= segment-div-op (descriptor/semantic-op expression))
+                       (match-at form bindings use-expressions output dtype accumulator-dtype)))
+                   pairs))))))

--- a/src/raster/compiler/reference/segmented_weighted_reduction.clj
+++ b/src/raster/compiler/reference/segmented_weighted_reduction.clj
@@ -1,0 +1,228 @@
+(ns raster.compiler.reference.segmented-weighted-reduction
+  "Schedule-free double-precision interpreter for segmented weighted-reduction plans.
+
+   The first executable membership/storage pair is indexed graph attention. This evaluator is the
+   oracle for recognition and later fused leaves: it executes the plan's scalar regions and
+   reduction/normalization fields rather than calling the source array operators. Unsupported
+   providers fail explicitly instead of being approximated."
+  (:require [raster.compiler.ir.segmented-weighted-reduction :as swr]))
+
+(defn- fail
+  [message reason data]
+  (throw (ex-info message (assoc data :reason reason))))
+
+(defn- extent
+  [value scalars]
+  (let [resolved (if (symbol? value) (get scalars value ::missing) value)]
+    (when (= ::missing resolved)
+      (fail "segmented reduction is missing a scalar extent"
+            :segmented-reduction-missing-scalar {:extent value}))
+    (when-not (and (integer? resolved) (pos? resolved))
+      (fail "segmented reduction extent must resolve to a positive integer"
+            :segmented-reduction-invalid-runtime-extent
+            {:extent value :resolved resolved}))
+    (long resolved)))
+
+(defn- scalar-call
+  [operator arguments]
+  (cond
+    (contains? '#{raster.numeric/+ clojure.core/+} operator) (reduce + 0.0 arguments)
+    (contains? '#{raster.numeric/* clojure.core/*} operator) (reduce * 1.0 arguments)
+    (contains? '#{raster.numeric/- clojure.core/-} operator)
+    (if (= 1 (count arguments)) (- (double (first arguments))) (reduce - arguments))
+    (contains? '#{raster.numeric// clojure.core//} operator) (reduce / arguments)
+    (contains? '#{raster.numeric/min clojure.core/min} operator)
+    (reduce #(Math/min (double %1) (double %2)) arguments)
+    (contains? '#{raster.numeric/max clojure.core/max} operator)
+    (reduce #(Math/max (double %1) (double %2)) arguments)
+    (contains? '#{raster.numeric/abs clojure.core/abs} operator)
+    (Math/abs (double (first arguments)))
+    (contains? '#{raster.numeric/sqrt Math/sqrt} operator)
+    (Math/sqrt (double (first arguments)))
+    (contains? '#{raster.math/exp Math/exp} operator)
+    (Math/exp (double (first arguments)))
+    (contains? '#{raster.math/log Math/log} operator)
+    (Math/log (double (first arguments)))
+    :else
+    (fail "reference evaluator encountered an unsupported scalar operator"
+          :segmented-reduction-reference-unsupported-scalar-op
+          {:operator operator})))
+
+(defn- scalar-expression
+  [expression environment]
+  (cond
+    (number? expression) (double expression)
+    (symbol? expression)
+    (if (contains? environment expression)
+      (get environment expression)
+      (fail "scalar region references an unbound parameter"
+            :segmented-reduction-reference-unbound-parameter
+            {:parameter expression :available (set (keys environment))}))
+    (seq? expression)
+    (scalar-call (first expression)
+                 (mapv #(scalar-expression % environment) (rest expression)))
+    :else
+    (fail "reference evaluator encountered an unsupported scalar value"
+          :segmented-reduction-reference-unsupported-scalar-value
+          {:expression expression})))
+
+(defn- region-value
+  [region values]
+  (when-not (= (count (:parameters region)) (count values))
+    (fail "scalar region received the wrong number of positional values"
+          :segmented-reduction-reference-region-arity
+          {:parameters (:parameters region) :values values}))
+  (scalar-expression (:body region) (zipmap (:parameters region) values)))
+
+(defn- argument-value
+  [argument scalars]
+  (case (:kind argument)
+    :literal (double (:value argument))
+    :inverse-sqrt (let [n (extent (:extent argument) scalars)]
+                    (/ 1.0 (Math/sqrt (double n))))
+    (fail "reference evaluator encountered an unsupported score argument"
+          :segmented-reduction-reference-unsupported-score-argument
+          {:argument argument})))
+
+(defn- array-length
+  [values]
+  (cond
+    (nil? values) nil
+    (.isArray (class values)) (java.lang.reflect.Array/getLength values)
+    (counted? values) (count values)
+    :else nil))
+
+(defn- element
+  [buffers id index]
+  (let [values (get buffers id ::missing)]
+    (when (= ::missing values)
+      (fail "segmented reduction is missing a buffer"
+            :segmented-reduction-reference-missing-buffer {:buffer id}))
+    (let [length (array-length values)]
+      (when-not (and length (<= 0 index) (< index length))
+        (fail "segmented reduction buffer index is out of bounds"
+              :segmented-reduction-reference-buffer-bounds
+              {:buffer id :index index :length length}))
+      (double (if (.isArray (class values))
+                (java.lang.reflect.Array/get values (int index))
+                (nth values (int index)))))))
+
+(defn- index-element
+  [buffers id index]
+  (let [value (element buffers id index)
+        integer-value (long value)]
+    (when-not (= value (double integer-value))
+      (fail "segmented reduction index buffer contains a non-integral value"
+            :segmented-reduction-reference-nonintegral-index
+            {:buffer id :index index :value value}))
+    integer-value))
+
+(defn- indexed-provider!
+  [plan]
+  (when-not (and (= :edge-list-by-destination (get-in plan [:membership :kind]))
+                 (= :indexed-dense-values (get-in plan [:storage :kind]))
+                 (= :dot (get-in plan [:score :kind]))
+                 (= :indexed-query (get-in plan [:score :left :kind]))
+                 (= :indexed-key (get-in plan [:score :right :kind]))
+                 (= :indexed-value (get-in plan [:value :kind])))
+    (fail "reference evaluator does not implement this membership/storage provider"
+          :segmented-reduction-reference-unsupported-provider
+          {:membership (get-in plan [:membership :kind])
+           :storage (get-in plan [:storage :kind])
+           :score-left (get-in plan [:score :left :kind])
+           :score-right (get-in plan [:score :right :kind])
+           :value (get-in plan [:value :kind])}))
+  plan)
+
+(defn evaluate
+  "Evaluate a checked indexed weighted-reduction plan.
+
+   `buffers` maps compiler buffer identities to primitive arrays or indexed collections.
+   `scalars` resolves symbolic plan extents such as n-nodes, n-edges, emb-dim and n-heads.
+   Returns a double-array in the plan's flat output layout."
+  [plan {:keys [buffers scalars] :or {buffers {} scalars {}}}]
+  (let [{:keys [segment-axes membership score weight value numerator denominator normalization]}
+        (-> plan swr/validate! indexed-provider!)
+        axis-extents (into {} (map (juxt :name #(extent (:extent %) scalars))) segment-axes)
+        n-destinations (get axis-extents :destination)
+        n-heads (get axis-extents :head)
+        n-edges (extent (:edges membership) scalars)
+        components (extent (:components value) scalars)
+        total-dim (extent (:total-dim value) scalars)
+        destination-id (:destination-indices membership)
+        source-id (:source-indices membership)
+        score-arguments (mapv #(argument-value % scalars) (:arguments score))
+        edges-by-destination (vec (repeat n-destinations []))
+        edges-by-destination
+        (reduce (fn [rows edge]
+                  (let [destination (index-element buffers destination-id edge)
+                        source (index-element buffers source-id edge)]
+                    (when-not (and (< -1 destination n-destinations)
+                                   (< -1 source n-destinations))
+                      (fail "indexed attention edge endpoint is out of bounds"
+                            :segmented-reduction-reference-edge-bounds
+                            {:edge edge :source source :destination destination
+                             :entities n-destinations}))
+                    (update rows destination conj [edge source])))
+                edges-by-destination (range n-edges))
+        output (double-array (* n-destinations total-dim))
+        score-components (extent (get-in score [:axis :extent]) scalars)
+        left-id (get-in score [:left :buffer])
+        right-id (get-in score [:right :buffer])
+        value-id (:buffer value)
+        epsilon (double (:epsilon normalization))]
+    (when-not (= components score-components)
+      (fail "indexed reference currently requires equal score and value head slices"
+            :segmented-reduction-reference-unequal-head-components
+            {:score-components score-components :value-components components}))
+    (when (> (* n-heads components) total-dim)
+      (fail "indexed head slices exceed the declared row width"
+            :segmented-reduction-reference-head-layout-overflow
+            {:heads n-heads :components components :total-dim total-dim}))
+    (doseq [destination (range n-destinations)
+            head (range n-heads)]
+      (let [members (nth edges-by-destination destination)
+            weighted-members
+            (mapv
+             (fn [[edge source]]
+               (let [head-offset (* head components)
+                     dot (reduce
+                          (fn [acc component]
+                            (+ acc
+                               (region-value
+                                (:combine score)
+                                [(element buffers left-id
+                                          (+ (* destination total-dim)
+                                             head-offset component))
+                                 (element buffers right-id
+                                          (+ (* source total-dim)
+                                             head-offset component))])))
+                          (double (:identity denominator))
+                          (range score-components))
+                     score-value (region-value (:finalize score)
+                                               (into [dot] score-arguments))
+                     weight-value (region-value weight [score-value])]
+                 {:edge edge :source source :weight weight-value}))
+             members)
+            denominator-value
+            (reduce (fn [acc member]
+                      (+ acc (region-value (:map-region denominator)
+                                           [(:weight member)])))
+                    (double (:identity denominator)) weighted-members)]
+        (doseq [component (range components)]
+          (let [numerator-value
+                (reduce
+                 (fn [acc {:keys [source weight]}]
+                   (+ acc
+                      (region-value
+                       (:map-region numerator)
+                       [weight
+                        (element buffers value-id
+                                 (+ (* source total-dim) (* head components) component))])))
+                 (double (:identity numerator)) weighted-members)
+                result (if (zero? denominator-value)
+                         (double (:empty-result normalization))
+                         (/ numerator-value (+ denominator-value epsilon)))
+                output-index (+ (* destination total-dim) (* head components) component)]
+            (aset output output-index result)))))
+    output))

--- a/test/raster/compiler/passes/parallel/indexed_attention_recognize_test.clj
+++ b/test/raster/compiler/passes/parallel/indexed_attention_recognize_test.clj
@@ -1,0 +1,139 @@
+(ns raster.compiler.passes.parallel.indexed-attention-recognize-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.segmented-weighted-reduction :as swr]
+            [raster.compiler.passes.parallel.indexed-attention-recognize :as recognize]
+            [raster.compiler.pipeline :as pipeline]
+            [raster.compiler.reference.segmented-weighted-reduction :as reference]
+            [raster.dl.array-ops :as array-ops]
+            [raster.dl.gsdm :as gsdm]))
+
+(defn- chain
+  [& {:keys [denominator-destination scale epsilon extra-raw-use?]
+      :or {denominator-destination 'dst
+           scale '(raster.numeric// 1.0 (raster.numeric/sqrt dk))
+           epsilon 1.0e-6
+           extra-raw-use? false}}]
+  (let [bindings
+        ['raw '(raster.dl.array-ops/indexed-dot
+                Q K dst src n-nodes n-nodes n-edges dk emb-dim n-heads)
+         'weights (list 'raster.dl.array-ops/scale-clamp-exp
+                        'raw scale 5.0 '(clojure.core/* n-edges n-heads))
+         'denominator (list 'raster.dl.array-ops/scatter-add
+                            'weights denominator-destination
+                            'n-nodes 'n-edges 'n-heads)
+         'weighted '(raster.dl.array-ops/scatter-mul-add
+                     weights V dst src n-nodes n-nodes n-edges dk emb-dim n-heads)
+         'normalized (list 'raster.dl.array-ops/segment-div
+                           'weighted 'denominator 'n-nodes 'emb-dim 'n-heads epsilon)]]
+    (list 'let*
+          (cond-> bindings extra-raw-use? (into ['raw-copy 'raw]))
+          'normalized)))
+
+(defn- reason
+  [thunk]
+  (try
+    (thunk)
+    nil
+    (catch clojure.lang.ExceptionInfo e
+      (:reason (ex-data e)))))
+
+(deftest exact-indexed-chain-lowers-to-the-shared-plan
+  (let [plans (recognize/recognize (chain))
+        plan (first plans)]
+    (is (= 1 (count plans)))
+    (is (swr/plan? plan))
+    (is (= [{:name :destination :extent 'n-nodes}
+            {:name :head :extent 'n-heads}]
+           (:segment-axes plan)))
+    (is (= {:kind :edge-list-by-destination
+            :destination-indices 'dst :source-indices 'src
+            :edges 'n-edges :duplicate-policy :multiset
+            :buffers '[dst src]}
+           (:membership plan)))
+    (is (= :indexed-dense-values (get-in plan [:storage :kind])))
+    (is (= '(raster.numeric/min
+             upper
+             (raster.numeric/max lower (raster.numeric/* dot scale)))
+           (get-in plan [:score :finalize :body])))
+    (is (= [{:parameter 'scale :kind :inverse-sqrt :extent 'dk}
+            {:parameter 'lower :kind :literal :value -5.0}
+            {:parameter 'upper :kind :literal :value 5.0}]
+           (get-in plan [:score :arguments])))
+    (is (= {:kind :divide :epsilon 1.0e-6 :empty-result 0.0}
+           (:normalization plan)))
+    (is (= '[Q K V dst src] (swr/ordered-input-ids plan)))
+    (is (= '(clojure.core/* n-nodes emb-dim)
+           (get-in plan [:output :elements])))
+    (is (false? (swr/online-softmax-algebra? plan))
+        "clamp and epsilon must not enter the canonical attention emitter")))
+
+(deftest actual-walked-gsdm-body-is-recognized-by-semantic-call-identity
+  (let [walked (first (pipeline/get-walked-body
+                       #'gsdm/graph-attention-multihead :double))
+        plans (recognize/recognize walked)
+        plan (first plans)]
+    (is (= 1 (count plans)))
+    (is (= :indexed-graph-attention (get-in plan [:provenance :semantic-op])))
+    (is (= :recognized-indexed-attention-chain
+           (get-in plan [:provenance :lowering])))
+    (is (= 'dst-edges (get-in plan [:membership :destination-indices])))
+    (is (= 'src-edges (get-in plan [:membership :source-indices])))
+    (is (= 1.0e-6 (get-in plan [:normalization :epsilon])))))
+
+(deftest recognition-declines-any-unproven-chain
+  (testing "an extra consumer prevents elimination of the raw-score intermediate"
+    (is (empty? (recognize/recognize (chain :extra-raw-use? true)))))
+  (testing "normalizer and weighted scatter must segment by the same destination"
+    (is (empty? (recognize/recognize
+                 (chain :denominator-destination 'other-destination)))))
+  (testing "the score scale must be the exact inverse square root of the head slice"
+    (is (empty? (recognize/recognize (chain :scale 0.5)))))
+  (testing "zero epsilon has different empty-row behavior and is not this GSDM contract"
+    (is (empty? (recognize/recognize (chain :epsilon 0.0)))))
+  (is (empty? (recognize/recognize '(let* [x 1] x)))))
+
+(deftest symbolic-plan-shapes-remain-closed-and-checkable
+  (let [plan (first (recognize/recognize (chain)))]
+    (is (= :segmented-reduction-invalid-segment-axis
+           (reason #(swr/validate!
+                     (assoc-in plan [:segment-axes 0 :extent]
+                               '(do (launch-side-effect) n-nodes))))))
+    (is (= :segmented-reduction-invalid-buffer-descriptor
+           (reason #(swr/validate!
+                     (assoc-in plan [:output :elements]
+                               '(clojure.core/+ n-nodes emb-dim))))))))
+
+(deftest plan-reference-is-bit-identical-to-the-compositional-operators
+  (let [plan (first (recognize/recognize (chain)))
+        n-nodes 3
+        n-edges 4
+        emb-dim 5
+        n-heads 2
+        dk 2
+        Q (double-array [1 2 3 4 99, 2 1 0 -1 88, -100 100 80 -80 77])
+        K (double-array [0 1 1 0 66, 1 1 2 -1 55, 100 -100 -90 90 44])
+        V (double-array [1 2 3 4 33, 2 4 6 8 22, -1 1 -2 2 11])
+        dst (long-array [0 0 2 2])
+        src (long-array [1 1 0 2])
+        raw (array-ops/indexed-dot Q K dst src
+                                   n-nodes n-nodes n-edges dk emb-dim n-heads)
+        weights (array-ops/scale-clamp-exp
+                 raw (/ 1.0 (Math/sqrt dk)) 5.0 (* n-edges n-heads))
+        denominator (array-ops/scatter-add weights dst n-nodes n-edges n-heads)
+        weighted (array-ops/scatter-mul-add
+                  weights V dst src n-nodes n-nodes n-edges dk emb-dim n-heads)
+        expected (array-ops/segment-div
+                  weighted denominator n-nodes emb-dim n-heads 1.0e-6)
+        inputs {:buffers {'Q Q 'K K 'V V 'dst dst 'src src}
+                :scalars {'n-nodes n-nodes 'n-edges n-edges
+                          'emb-dim emb-dim 'n-heads n-heads 'dk dk}}
+        actual (reference/evaluate plan inputs)]
+    (is (= (vec expected) (vec actual)))
+    (is (= [0.0 0.0 0.0 0.0 0.0]
+           (subvec (vec actual) emb-dim (* 2 emb-dim)))
+        "an empty destination row stays zero")
+    (is (= 0.0 (aget actual (dec emb-dim)))
+        "the non-head tail preserves the compositional zero initialization")
+    (is (= :segmented-reduction-missing-scalar
+           (reason #(reference/evaluate plan
+                                        (update inputs :scalars dissoc 'dk)))))))


### PR DESCRIPTION
## Summary

- conservatively recognize the exact indexed-dot, scale-clamp-exp, scatter-add, scatter-mul-add, segment-div chain used by GSDM
- follow semantic call metadata through the actual walked/devirtualized body rather than parsing implementation names
- extend the shared weighted-reduction plan with checked symbolic extents and ordered inverse-sqrt/literal score arguments
- add an independent double-precision plan evaluator for indexed graph attention
- keep recognition observational: GSDM and its existing AD templates still execute unchanged, and the canonical attention emitter continues to reject clamp/epsilon plans

The recognizer proves edge direction, shared dimensions, score element count, inverse-sqrt head scaling, clamp and epsilon legality, and exact intermediate use counts. Any mismatch declines.

## Verification

- 85 tests / 505 assertions across recognition, attention lowering/routing/IR/AD/reference, GSDM, array operators and gradients
- final focused cold gate after validator hardening: 17 tests / 99 assertions
- plan evaluator is bit-identical to the original five-operator composition with duplicate edges, an empty destination, saturated scores, and a non-head row tail
- cljfmt check passed
- git diff --check passed

## Scope boundary

This PR does not rewrite GSDM or emit a fused kernel. The next slice can add a fused indexed-attention leaf against this plan oracle, then wire recognition into production scheduling only after parity is proven.