### PR TITLE
Emit fused indexed attention reference

### DIFF
--- a/src/raster/compiler/backend/gpu/indexed_attention.clj
+++ b/src/raster/compiler/backend/gpu/indexed_attention.clj
@@ -1,0 +1,281 @@
+(ns raster.compiler.backend.gpu.indexed-attention
+  "Direct correctness lowering for recognized indexed graph attention.
+
+   One work-item owns one destination/feature output and scans the edge list. The schedule is
+   intentionally simple, but it is genuinely fused: scores, clamped exponential weights,
+   denominator and weighted values remain private scalars and no edge-sized intermediates are
+   materialized."
+  (:require [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-graph :as kgraph]
+            [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.compiler.ir.segmented-weighted-reduction :as swr]))
+
+(defn- fail
+  [message reason data]
+  (throw (ex-info message (assoc data :reason reason))))
+
+(defn- indexed-attention-plan!
+  [plan]
+  (let [{:keys [segment-axes membership storage score weight value numerator denominator
+                normalization operands output accumulator-dtype provenance]
+         :as plan} (swr/validate! plan)
+        [destination-axis head-axis] segment-axes
+        [q k v destination-indices source-indices] operands
+        score-arguments (:arguments score)
+        [scale lower upper] score-arguments
+        bound (:value upper)]
+    (when-not
+     (and (= :indexed-graph-attention (:semantic-op provenance))
+          (= :recognized-indexed-attention-chain (:lowering provenance))
+          (= [:destination :head] (mapv :name segment-axes))
+          (= :edge-list-by-destination (:kind membership))
+          (= :multiset (:duplicate-policy membership))
+          (= [(:id destination-indices) (:id source-indices)] (:buffers membership))
+          (= (:id destination-indices) (:destination-indices membership))
+          (= (:id source-indices) (:source-indices membership))
+          (= :indexed-dense-values (:kind storage))
+          (= [(:id q) (:id k) (:id v)] (:buffers storage))
+          (= (:extent destination-axis) (:entity-count storage))
+          (= :dot (:kind score))
+          (= {:name :head-component :extent (:components value)} (:axis score))
+          (= {:kind :identity :heads (:extent head-axis)} (:head-map score))
+          (= {:kind :indexed-query :buffer (:id q)
+              :indices (:id destination-indices) :dtype (:dtype q)
+              :total-dim (:total-dim storage)}
+             (:left score))
+          (= {:kind :indexed-key :buffer (:id k)
+              :indices (:id source-indices) :dtype (:dtype k)
+              :total-dim (:total-dim storage)}
+             (:right score))
+          (= '(raster.numeric/* left right) (get-in score [:combine :body]))
+          (= ['left 'right] (get-in score [:combine :parameters]))
+          (= [:inverse-sqrt :literal :literal] (mapv :kind score-arguments))
+          (= ['scale 'lower 'upper] (mapv :parameter score-arguments))
+          (= (:components value) (:extent scale))
+          (number? bound) (pos? (double bound))
+          (= (- (double bound)) (double (:value lower)))
+          (= '(raster.numeric/min
+               upper
+               (raster.numeric/max lower (raster.numeric/* dot scale)))
+             (get-in score [:finalize :body]))
+          (= ['dot 'scale 'lower 'upper] (get-in score [:finalize :parameters]))
+          (= '(raster.math/exp score) (:body weight))
+          (= ['score] (:parameters weight))
+          (= :indexed-value (:kind value))
+          (= (:id v) (:buffer value))
+          (= (:id source-indices) (:indices value))
+          (= (:dtype v) (:dtype value))
+          (= (:extent destination-axis) (:entity-count value))
+          (= (:total-dim storage) (:total-dim value))
+          (= :sum (:operator numerator))
+          (zero? (double (:identity numerator)))
+          (= '(raster.numeric/* weight value) (get-in numerator [:map-region :body]))
+          (= :sum (:operator denominator))
+          (zero? (double (:identity denominator)))
+          (= 'weight (get-in denominator [:map-region :body]))
+          (= :divide (:kind normalization))
+          (pos? (double (:epsilon normalization)))
+          (= 0.0 (double (:empty-result normalization)))
+          (= 5 (count operands))
+          (= [:long :long] (mapv :dtype [destination-indices source-indices]))
+          (= [(:extent destination-axis) (:total-dim storage)] (:shape q))
+          (= (:shape q) (:shape k) (:shape v) (:shape output))
+          (= (:dtype q) (:dtype k) (:dtype v) (:dtype output) accumulator-dtype))
+      (fail "indexed-attention leaf cannot preserve this reduction plan exactly"
+            :indexed-attention-reference-plan-unsupported
+            {:plan-id (:id plan) :provenance provenance}))
+    plan))
+
+(defn- resolve-extent
+  [shape-env owner value]
+  (let [resolved (if (integer? value) value (get shape-env value ::missing))
+        valid? pos?]
+    (when (or (= ::missing resolved) (not (integer? resolved)) (not (valid? resolved)))
+      (fail "indexed-attention extent is missing or invalid"
+            :indexed-attention-invalid-shape-extent
+            {:owner owner :extent value :resolved resolved}))
+    (long resolved)))
+
+(defn- resolved-shape
+  [plan shape-env]
+  (let [[destination-axis head-axis] (:segment-axes plan)
+        membership (:membership plan)
+        storage (:storage plan)
+        value (:value plan)]
+    {:entities (resolve-extent shape-env :entities (:extent destination-axis))
+     :heads (resolve-extent shape-env :heads (:extent head-axis))
+     :edges (resolve-extent shape-env :edges (:edges membership))
+     :components (resolve-extent shape-env :components (:components value))
+     :total-dim (resolve-extent shape-env :total-dim (:total-dim storage))}))
+
+(defn- checked-shape!
+  [plan shape-env]
+  (let [{:keys [heads components total-dim] :as shape} (resolved-shape plan shape-env)]
+    (when (> (* heads components) total-dim)
+      (fail "indexed-attention head slices exceed the row width"
+            :indexed-attention-head-layout-overflow shape))
+    shape))
+
+(defn reference-workgroup-x
+  [plan shape-env desc]
+  (let [{:keys [total-dim]} (checked-shape! (indexed-attention-plan! plan) shape-env)
+        subgroup (long (or (:subgroup-size desc) 16))
+        maximum (long (or (:max-workgroup-size desc) 256))]
+    (long (max 1 (min total-dim subgroup maximum)))))
+
+(defn- c-type
+  [dtype]
+  (case dtype :float "float" :double "double"))
+
+(defn- fp-literal
+  [dtype value]
+  (str (if (= :float dtype)
+         (Float/toString (float value))
+         (Double/toString (double value)))
+       (when (= :float dtype) "f")))
+
+(defn- kernel-name
+  [plan shape]
+  (let [identity {:schedule (swr/schedule-key plan) :shape shape}]
+    (format "raster_indexed_attention_ref_%08x"
+            (bit-and 0xffffffff (long (hash identity))))))
+
+(defn- source
+  [plan shape name]
+  (let [{:keys [entities heads edges components total-dim]} shape
+        dtype (:accumulator-dtype plan)
+        ctype (c-type dtype)
+        bound (double (get-in plan [:score :arguments 2 :value]))
+        epsilon (double (get-in plan [:normalization :epsilon]))
+        scale (/ 1.0 (Math/sqrt (double components)))
+        zero (fp-literal dtype 0.0)]
+    (str (when (= :double dtype)
+           "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n")
+         "__kernel void " name "(\n"
+         "    __global const " ctype "* q,\n"
+         "    __global const " ctype "* k,\n"
+         "    __global const " ctype "* v,\n"
+         "    __global const long* destination_indices,\n"
+         "    __global const long* source_indices,\n"
+         "    __global " ctype "* output) {\n"
+         "  const long feature = (long)get_global_id(0);\n"
+         "  const long destination = (long)get_global_id(1);\n"
+         "  if (feature >= " total-dim "L || destination >= " entities "L) return;\n"
+         "  const long output_index = destination * " total-dim "L + feature;\n"
+         "  if (feature >= " (* heads components) "L) {\n"
+         "    output[output_index] = " zero ";\n"
+         "    return;\n"
+         "  }\n"
+         "  const long head = feature / " components "L;\n"
+         "  const long component = feature - head * " components "L;\n"
+         "  " ctype " numerator = " zero ";\n"
+         "  " ctype " denominator = " zero ";\n"
+         "  for (long edge = 0; edge < " edges "L; ++edge) {\n"
+         "    const long edge_destination = destination_indices[edge];\n"
+         "    const long source = source_indices[edge];\n"
+         "    if (edge_destination < 0L || edge_destination >= " entities
+         "L || source < 0L || source >= " entities "L) {\n"
+         "      output[output_index] = (" ctype ")NAN;\n"
+         "      return;\n"
+         "    }\n"
+         "    if (edge_destination != destination) continue;\n"
+         "    const long q_base = destination * " total-dim "L + head * " components "L;\n"
+         "    const long kv_base = source * " total-dim "L + head * " components "L;\n"
+         "    " ctype " dot = " zero ";\n"
+         "    for (long x = 0; x < " components "L; ++x)\n"
+         "      dot += q[q_base + x] * k[kv_base + x];\n"
+         "    const " ctype " scaled = dot * (" ctype ")" (fp-literal dtype scale) ";\n"
+         ;; Java Math/min and Math/max propagate NaN; OpenCL fmin/fmax select the numeric operand.
+         ;; Preserve the recognized source semantics explicitly instead of inheriting that drift.
+         "    const " ctype " score = isnan(scaled) ? scaled\n"
+         "        : fmin((" ctype ")" (fp-literal dtype bound)
+         ", fmax((" ctype ")" (fp-literal dtype (- bound)) ", scaled));\n"
+         "    const " ctype " weight = exp(score);\n"
+         "    numerator += weight * v[kv_base + component];\n"
+         "    denominator += weight;\n"
+         "  }\n"
+         "  output[output_index] = denominator == " zero " ? " zero
+         " : numerator / (denominator + (" ctype ")" (fp-literal dtype epsilon) ");\n"
+         "}\n")))
+
+(defn- ordered-abi
+  [plan]
+  (let [[q k v destination-indices source-indices] (:operands plan)
+        output (:output plan)
+        fp (:accumulator-dtype plan)]
+    (kabi/validate!
+     [(kabi/slot (:id q) :input fp :c-name "q" :role :query)
+      (kabi/slot (:id k) :input fp :c-name "k" :role :key)
+      (kabi/slot (:id v) :input fp :c-name "v" :role :value)
+      (kabi/slot (:id destination-indices) :input :long
+                 :c-name "destination_indices" :role :destination-indices)
+      (kabi/slot (:id source-indices) :input :long
+                 :c-name "source_indices" :role :source-indices)
+      (kabi/slot (:id output) :output fp :c-name "output" :role :result)])))
+
+(defn emit-reference
+  "Emit the direct indexed-attention correctness schedule for a resolved shape environment."
+  [plan shape-env desc]
+  (let [plan (indexed-attention-plan! plan)
+        shape (checked-shape! plan shape-env)
+        {:keys [entities total-dim]} shape
+        workgroup-x (reference-workgroup-x plan shape-env desc)
+        name (kernel-name plan shape)
+        inputs (swr/ordered-input-ids plan)
+        output (get-in plan [:output :id])]
+    (kart/make
+     {:kernel-name name
+      :source (source plan shape name)
+      :abi (ordered-abi plan)
+      :arguments (conj inputs output)
+      :launch (klaunch/spec
+               {:workgroup-size [workgroup-x 1]
+                :group-count [(long (quot (+ total-dim (dec workgroup-x)) workgroup-x))
+                              entities]})
+      :effects {:kind :indexed-attention :reads inputs :writes [output]}
+      :provenance {:operation-id (get-in plan [:provenance :operation-id])
+                   :semantic-op :indexed-graph-attention
+                   :algebra-plan-id (:id plan)
+                   :lowering :direct-reference}
+      :attributes {:strategy :indexed-attention-reference
+                   :optimization-tier :reference
+                   :algebra :segmented-weighted-reduction
+                   :algebra-key (swr/algebra-key plan)
+                   :storage-dtype (:accumulator-dtype plan)
+                   :accumulator-dtype (:accumulator-dtype plan)
+                   :membership :edge-list-by-destination
+                   :duplicate-policy :multiset
+                   :shape shape
+                   :materialized-intermediates []
+                   :complexity :quadratic-in-edges-and-head-components}})))
+
+(defn kernel-graph
+  "Wrap the direct leaf in a one-node graph with resolved external buffer extents."
+  [plan shape-env artifact]
+  (let [plan (indexed-attention-plan! plan)
+        {:keys [entities edges total-dim]} (checked-shape! plan shape-env)
+        artifact (kart/validate! artifact)
+        inputs (swr/ordered-input-ids plan)
+        output (get-in plan [:output :id])
+        descriptors (into {} (map (juxt :id identity))
+                          (conj (:operands plan) (:output plan)))
+        elements (fn [id]
+                   (if (contains? #{(get-in plan [:membership :destination-indices])
+                                    (get-in plan [:membership :source-indices])} id)
+                     edges
+                     (* entities total-dim)))
+        graph-buffer (fn [id role]
+                       (kgraph/buffer id (:dtype (get descriptors id))
+                                      (elements id) :device role))
+        uses (vec (concat (map #(kgraph/->ValueUse % :read) inputs)
+                          [(kgraph/->ValueUse output :write)]))]
+    (kgraph/make
+     {:inputs (mapv #(graph-buffer % :input) inputs)
+      :outputs [(graph-buffer output :output)]
+      :nodes [(kgraph/->ScheduledKernel
+               [:indexed-attention (:id plan) :direct-reference] artifact uses [])]
+      :effects {:kind :indexed-attention :materialized-intermediates []}
+      :provenance {:operation-id (get-in plan [:provenance :operation-id])
+                   :semantic-op :indexed-graph-attention}
+      :attributes {:strategy :indexed-attention-reference :reference? true}})))

--- a/src/raster/compiler/passes/parallel/indexed_attention_route.clj
+++ b/src/raster/compiler/passes/parallel/indexed_attention_route.clj
@@ -1,0 +1,60 @@
+(ns raster.compiler.passes.parallel.indexed-attention-route
+  "Structured routing for recognized indexed graph-attention plans."
+  (:require [raster.compiler.backend.gpu.indexed-attention :as emit]
+            [raster.compiler.ir.segmented-weighted-reduction :as swr]))
+
+(defn- decline
+  [plan reason data]
+  {:operation plan
+   :strategy nil
+   :reference? false
+   :declines [{:leaf :indexed-attention-reference :reason reason :data data}]})
+
+(defn route
+  "Try the direct fused correctness leaf using concrete values for symbolic plan extents."
+  ([plan shape-env] (route plan shape-env nil))
+  ([plan shape-env desc]
+   (try
+     (let [{:keys [operands output accumulator-dtype] :as plan} (swr/validate! plan)
+           storage-dtypes (mapv :dtype (conj operands output))]
+       (cond
+         (and desc (not= :gpu (:device-type desc)))
+         (decline plan :indexed-attention-requires-gpu
+                  {:device-type (:device-type desc)})
+
+         (not (contains? #{:float :double} accumulator-dtype))
+         (decline plan :indexed-attention-accumulator-unsupported
+                  {:required #{:float :double} :actual accumulator-dtype})
+
+         (not= [accumulator-dtype accumulator-dtype accumulator-dtype
+                :long :long accumulator-dtype]
+               storage-dtypes)
+         (decline plan :indexed-attention-storage-unsupported
+                  {:required [accumulator-dtype accumulator-dtype accumulator-dtype
+                              :long :long accumulator-dtype]
+                   :actual storage-dtypes})
+
+         :else
+         (let [artifact (emit/emit-reference plan shape-env desc)]
+           {:operation plan
+            :plan plan
+            :strategy :indexed-attention-reference
+            :reference? true
+            :declines []
+            :artifact artifact
+            :graph (emit/kernel-graph plan shape-env artifact)
+            :schedule {:workgroup-size (:workgroup-size (:launch artifact))
+                       :group-count (:group-count (:launch artifact))}})))
+     (catch clojure.lang.ExceptionInfo e
+       (decline plan (or (:reason (ex-data e)) :indexed-attention-reference-unsupported)
+                (dissoc (ex-data e) :reason))))))
+
+(defn route!
+  "Route indexed attention or fail with its machine-readable decline trail."
+  ([plan shape-env] (route! plan shape-env nil))
+  ([plan shape-env desc]
+   (let [result (route plan shape-env desc)]
+     (if (:strategy result)
+       result
+       (throw (ex-info "no executable indexed-attention kernel route"
+                       {:reason :indexed-attention-no-kernel-route :route result}))))))

--- a/test/raster/compiler/passes/parallel/indexed_attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/indexed_attention_route_test.clj
@@ -1,0 +1,82 @@
+(ns raster.compiler.passes.parallel.indexed-attention-route-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [raster.compiler.passes.parallel.indexed-attention-recognize :as recognize]
+            [raster.compiler.passes.parallel.indexed-attention-route :as route]))
+
+(defn- chain
+  []
+  '(let* [raw (raster.dl.array-ops/indexed-dot
+               Q K dst src n-nodes n-nodes n-edges dk emb-dim n-heads)
+          weights (raster.dl.array-ops/scale-clamp-exp
+                   raw (raster.numeric// 1.0 (raster.numeric/sqrt dk))
+                   5.0 (clojure.core/* n-edges n-heads))
+          denominator (raster.dl.array-ops/scatter-add
+                       weights dst n-nodes n-edges n-heads)
+          weighted (raster.dl.array-ops/scatter-mul-add
+                    weights V dst src n-nodes n-nodes n-edges dk emb-dim n-heads)
+          normalized (raster.dl.array-ops/segment-div
+                      weighted denominator n-nodes emb-dim n-heads 1.0e-6)]
+         normalized))
+
+(def ^:private shape-env
+  {'n-nodes 3 'n-edges 4 'dk 2 'emb-dim 5 'n-heads 2})
+
+(defn- plan
+  ([] (plan :float))
+  ([dtype]
+   (first (recognize/recognize (chain) :dtype dtype :accumulator-dtype dtype))))
+
+(deftest direct-reference-has-one-ordered-resident-abi-and-no-intermediates
+  (let [{:keys [strategy reference? artifact graph schedule declines]}
+        (route/route! (plan) shape-env
+                      {:device-type :gpu :subgroup-size 16 :max-workgroup-size 256})]
+    (is (= :indexed-attention-reference strategy))
+    (is reference?)
+    (is (empty? declines))
+    (is (= '[Q K V dst src normalized] (:arguments artifact)))
+    (is (= '[Q K V dst src normalized] (mapv :name (:abi artifact))))
+    (is (= [:input :input :input :input :input :output]
+           (mapv :kind (:abi artifact))))
+    (is (= [:float :float :float :long :long :float]
+           (mapv :dtype (:abi artifact))))
+    (is (= [5 1] (:workgroup-size schedule)))
+    (is (= [1 3] (:group-count schedule)))
+    (is (= [] (:temporaries artifact)))
+    (is (= [] (get-in artifact [:attributes :materialized-intermediates])))
+    (is (= [] (:temporaries graph)))
+    (is (= [15 15 15 4 4] (mapv :elements (:inputs graph))))
+    (is (= [15] (mapv :elements (:outputs graph))))
+    (let [source (:source artifact)]
+      (is (str/includes? source "for (long edge = 0; edge < 4L; ++edge)"))
+      (is (str/includes? source "fmin((float)5.0f"))
+      (is (str/includes? source "isnan(scaled) ? scaled"))
+      (is (str/includes? source "denominator + (float)1.0E-6f"))
+      (is (str/includes? source "feature >= 4L"))
+      (is (not (str/includes? source "raw_scores")))
+      (is (not (str/includes? source "weights[")))
+      (is (not (str/includes? source "denominator["))))))
+
+(deftest direct-reference-supports-scientific-double-storage
+  (let [artifact (:artifact (route/route! (plan :double) shape-env))]
+    (is (= [:double :double :double :long :long :double]
+           (mapv :dtype (:abi artifact))))
+    (is (str/starts-with? (:source artifact)
+                          "#pragma OPENCL EXTENSION cl_khr_fp64 : enable"))))
+
+(deftest route-declines-unproved-semantics-and-unresolved-shapes
+  (testing "a different scalar region cannot silently enter the specialized leaf"
+    (let [result (route/route (assoc-in (plan) [:normalization :epsilon] 0.0)
+                              shape-env)]
+      (is (nil? (:strategy result)))
+      (is (= :indexed-attention-reference-plan-unsupported
+             (get-in result [:declines 0 :reason])))))
+  (testing "symbolic extents have to be specialized deliberately"
+    (let [result (route/route (plan) (dissoc shape-env 'n-edges))]
+      (is (nil? (:strategy result)))
+      (is (= :indexed-attention-invalid-shape-extent
+             (get-in result [:declines 0 :reason])))))
+  (testing "device placement remains a routing decision"
+    (let [result (route/route (plan) shape-env {:device-type :cpu})]
+      (is (= :indexed-attention-requires-gpu
+             (get-in result [:declines 0 :reason]))))))

--- a/test/raster/gpu/indexed_attention_device_test.clj
+++ b/test/raster/gpu/indexed_attention_device_test.clj
@@ -1,0 +1,88 @@
+(ns raster.gpu.indexed-attention-device-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.passes.parallel.indexed-attention-recognize :as recognize]
+            [raster.compiler.passes.parallel.indexed-attention-route :as route]
+            [raster.compiler.reference.segmented-weighted-reduction :as reference]
+            [raster.dl.gpu-grad-parity :as gp]
+            [raster.gpu.core :as gpu]))
+
+(def ^:private opencl-available?
+  (delay
+    (try
+      (require 'raster.gpu.ocl-runtime)
+      ((resolve 'raster.gpu.ocl-runtime/init!))
+      true
+      (catch Throwable _ false))))
+
+(defn- chain
+  []
+  '(let* [raw (raster.dl.array-ops/indexed-dot
+               Q K dst src n-nodes n-nodes n-edges dk emb-dim n-heads)
+          weights (raster.dl.array-ops/scale-clamp-exp
+                   raw (raster.numeric// 1.0 (raster.numeric/sqrt dk))
+                   5.0 (clojure.core/* n-edges n-heads))
+          denominator (raster.dl.array-ops/scatter-add
+                       weights dst n-nodes n-edges n-heads)
+          weighted (raster.dl.array-ops/scatter-mul-add
+                    weights V dst src n-nodes n-nodes n-edges dk emb-dim n-heads)
+          normalized (raster.dl.array-ops/segment-div
+                      weighted denominator n-nodes emb-dim n-heads 1.0e-6)]
+         normalized))
+
+(defn- test-case
+  []
+  (let [shape-env {'n-nodes 3 'n-edges 4 'emb-dim 5 'n-heads 2 'dk 2}
+        plan (first (recognize/recognize
+                     (chain) :dtype :float :accumulator-dtype :float))
+        q (float-array [1 2 3 4 99, 2 1 0 -1 88, -100 100 80 -80 77])
+        k (float-array [0 1 1 0 66, 1 1 2 -1 55, 100 -100 -90 90 44])
+        v (float-array [1 2 3 4 33, 2 4 6 8 22, -1 1 -2 2 11])
+        dst (long-array [0 0 2 2])
+        src (long-array [1 1 0 2])
+        buffers {'Q q 'K k 'V v 'dst dst 'src src}
+        expected (reference/evaluate plan {:buffers buffers :scalars shape-env})]
+    {:plan plan :shape-env shape-env :buffers buffers :expected expected}))
+
+(defn- run-case
+  [device-id]
+  (let [{:keys [plan shape-env buffers expected]} (test-case)
+        graph (:graph (route/route!
+                       plan shape-env
+                       {:device-type :gpu :subgroup-size 16 :max-workgroup-size 256}))]
+    (gpu/with-gpu-session [session device-id]
+      (gpu/alloc! session
+                  {:q [:float 15 (get buffers 'Q)]
+                   :k [:float 15 (get buffers 'K)]
+                   :v [:float 15 (get buffers 'V)]
+                   :dst [:long 4 (get buffers 'dst)]
+                   :src [:long 4 (get buffers 'src)]
+                   :output [:float 15 nil]})
+      (let [handle (gpu/bind-kernel-graph!
+                    session [:indexed-attention device-id] graph
+                    {'Q :q 'K :k 'V :v 'dst :dst 'src :src 'normalized :output}
+                    {})]
+        (try
+          (gpu/run-kernel-graph! session handle)
+          (let [actual ^floats (gpu/download session :output)]
+            (is (= (count expected) (alength actual)))
+            (is (every? true?
+                        (map (fn [wanted got]
+                               (< (Math/abs (- (double wanted) (double got))) 2.0e-5))
+                             expected actual)))
+            (is (= [0.0 0.0 0.0 0.0 0.0]
+                   (subvec (vec actual) 5 10))
+                "a destination with no incoming edges is zero")
+            (is (= 0.0 (double (aget actual 4)))
+                "the non-head tail is explicitly zeroed"))
+          (finally
+            (gpu/release-kernel-graph! session handle)))))))
+
+(deftest level-zero-indexed-attention-matches-independent-plan-oracle
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "fused indexed attention on Level Zero")
+    (run-case :ze:0)))
+
+(deftest opencl-indexed-attention-matches-independent-plan-oracle
+  (if-not @opencl-available?
+    (is true "OpenCL device unavailable")
+    (run-case :ocl:0)))


### PR DESCRIPTION
## Summary

- emit a checked direct OpenCL-C correctness leaf from the recognized indexed graph-attention reduction plan
- preserve clamp, denominator epsilon, multiset duplicate edges, empty destinations, NaN propagation, and the non-head zero tail without materializing edge scores, weights, denominators, or weighted values
- carry the kernel through one ordered resident ABI and a concrete 2-D one-node KernelGraph, with FP32 and FP64 variants and structured fail-closed routing
- add static ABI/source/decline tests and Level Zero/OpenCL parity tests against the independent schedule-free plan oracle

## Verification

- focused regression gate: 26 tests, 158 assertions, 0 failures/errors
- final recognition/route/device gate after NaN handling: 10 tests, 59 assertions, 0 failures/errors
- generated FP32 and FP64 modules: clang OpenCL 2.0 syntax check passes
- cljfmt check passes

## Device gate

The device tests are present, but this run could not execute them: Level Zero initialization returned 0x78000001 and no OpenCL device was available. The tests took explicit skip paths; CI also has no GPU, so live device parity remains to be rerun when the local driver is available.