### PR TITLE
Route structured reductions through generic fusion

### DIFF
--- a/src/raster/compiler/backend/gpu/indexed_attention.clj
+++ b/src/raster/compiler/backend/gpu/indexed_attention.clj
@@ -5,7 +5,8 @@
    intentionally simple, but it is genuinely fused: scores, clamped exponential weights,
    denominator and weighted values remain private scalars and no edge-sized intermediates are
    materialized."
-  (:require [raster.compiler.ir.kernel-abi :as kabi]
+  (:require [clojure.string :as str]
+            [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-launch :as klaunch]
@@ -26,9 +27,7 @@
         [scale lower upper] score-arguments
         bound (:value upper)]
     (when-not
-     (and (= :indexed-graph-attention (:semantic-op provenance))
-          (= :recognized-indexed-attention-chain (:lowering provenance))
-          (= [:destination :head] (mapv :name segment-axes))
+     (and (= [:destination :head] (mapv :name segment-axes))
           (= :edge-list-by-destination (:kind membership))
           (= :multiset (:duplicate-policy membership))
           (= [(:id destination-indices) (:id source-indices)] (:buffers membership))
@@ -82,8 +81,8 @@
           (= [(:extent destination-axis) (:total-dim storage)] (:shape q))
           (= (:shape q) (:shape k) (:shape v) (:shape output))
           (= (:dtype q) (:dtype k) (:dtype v) (:dtype output) accumulator-dtype))
-      (fail "indexed-attention leaf cannot preserve this reduction plan exactly"
-            :indexed-attention-reference-plan-unsupported
+      (fail "indexed edge-list leaf cannot preserve this reduction plan exactly"
+            :indexed-segmented-reduction-plan-unsupported
             {:plan-id (:id plan) :provenance provenance}))
     plan))
 
@@ -135,20 +134,33 @@
          (Double/toString (double value)))
        (when (= :float dtype) "f")))
 
+(defn- long-expression
+  [value]
+  (if (number? value) (str value "L") (str "(" value ")")))
+
+(defn- fp-expression
+  [dtype value]
+  (if (number? value) (fp-literal dtype value) (str value)))
+
 (defn- kernel-name
   [plan shape]
   (let [identity {:schedule (swr/schedule-key plan) :shape shape}]
     (format "raster_indexed_attention_ref_%08x"
             (bit-and 0xffffffff (long (hash identity))))))
 
-(defn- source
-  [plan shape name]
-  (let [{:keys [entities heads edges components total-dim]} shape
+(defn- source*
+  [plan {:keys [entities edges components total-dim active-width scale bound epsilon
+                scalar-signature invalid-shape]} name]
+  (let [entities (long-expression entities)
+        edges (long-expression edges)
+        components (long-expression components)
+        total-dim (long-expression total-dim)
+        active-width (long-expression active-width)
         dtype (:accumulator-dtype plan)
         ctype (c-type dtype)
-        bound (double (get-in plan [:score :arguments 2 :value]))
-        epsilon (double (get-in plan [:normalization :epsilon]))
-        scale (/ 1.0 (Math/sqrt (double components)))
+        bound (fp-expression dtype bound)
+        epsilon (fp-expression dtype epsilon)
+        scale (fp-expression dtype scale)
         zero (fp-literal dtype 0.0)]
     (str (when (= :double dtype)
            "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n")
@@ -158,46 +170,63 @@
          "    __global const " ctype "* v,\n"
          "    __global const long* destination_indices,\n"
          "    __global const long* source_indices,\n"
-         "    __global " ctype "* output) {\n"
+         "    __global " ctype "* output"
+         (when (seq scalar-signature) (str ",\n" scalar-signature))
+         ") {\n"
          "  const long feature = (long)get_global_id(0);\n"
          "  const long destination = (long)get_global_id(1);\n"
-         "  if (feature >= " total-dim "L || destination >= " entities "L) return;\n"
-         "  const long output_index = destination * " total-dim "L + feature;\n"
-         "  if (feature >= " (* heads components) "L) {\n"
+         "  if (feature >= " total-dim " || destination >= " entities ") return;\n"
+         "  const long output_index = destination * " total-dim " + feature;\n"
+         (when invalid-shape
+           (str "  if (" invalid-shape ") {\n"
+                "    output[output_index] = (" ctype ")NAN;\n"
+                "    return;\n"
+                "  }\n"))
+         "  if (feature >= " active-width ") {\n"
          "    output[output_index] = " zero ";\n"
          "    return;\n"
          "  }\n"
-         "  const long head = feature / " components "L;\n"
-         "  const long component = feature - head * " components "L;\n"
+         "  const long head = feature / " components ";\n"
+         "  const long component = feature - head * " components ";\n"
          "  " ctype " numerator = " zero ";\n"
          "  " ctype " denominator = " zero ";\n"
-         "  for (long edge = 0; edge < " edges "L; ++edge) {\n"
+         "  for (long edge = 0; edge < " edges "; ++edge) {\n"
          "    const long edge_destination = destination_indices[edge];\n"
          "    const long source = source_indices[edge];\n"
          "    if (edge_destination < 0L || edge_destination >= " entities
-         "L || source < 0L || source >= " entities "L) {\n"
+         " || source < 0L || source >= " entities ") {\n"
          "      output[output_index] = (" ctype ")NAN;\n"
          "      return;\n"
          "    }\n"
          "    if (edge_destination != destination) continue;\n"
-         "    const long q_base = destination * " total-dim "L + head * " components "L;\n"
-         "    const long kv_base = source * " total-dim "L + head * " components "L;\n"
+         "    const long q_base = destination * " total-dim " + head * " components ";\n"
+         "    const long kv_base = source * " total-dim " + head * " components ";\n"
          "    " ctype " dot = " zero ";\n"
-         "    for (long x = 0; x < " components "L; ++x)\n"
+         "    for (long x = 0; x < " components "; ++x)\n"
          "      dot += q[q_base + x] * k[kv_base + x];\n"
-         "    const " ctype " scaled = dot * (" ctype ")" (fp-literal dtype scale) ";\n"
+         "    const " ctype " scaled = dot * (" ctype ")" scale ";\n"
          ;; Java Math/min and Math/max propagate NaN; OpenCL fmin/fmax select the numeric operand.
          ;; Preserve the recognized source semantics explicitly instead of inheriting that drift.
          "    const " ctype " score = isnan(scaled) ? scaled\n"
-         "        : fmin((" ctype ")" (fp-literal dtype bound)
-         ", fmax((" ctype ")" (fp-literal dtype (- bound)) ", scaled));\n"
+         "        : fmin((" ctype ")" bound
+         ", fmax(-(" ctype ")" bound ", scaled));\n"
          "    const " ctype " weight = exp(score);\n"
          "    numerator += weight * v[kv_base + component];\n"
          "    denominator += weight;\n"
          "  }\n"
          "  output[output_index] = denominator == " zero " ? " zero
-         " : numerator / (denominator + (" ctype ")" (fp-literal dtype epsilon) ");\n"
+         " : numerator / (denominator + (" ctype ")" epsilon ");\n"
          "}\n")))
+
+(defn- source
+  [plan {:keys [heads components] :as shape} name]
+  (source* plan
+           (assoc shape
+                  :active-width (* heads components)
+                  :scale (/ 1.0 (Math/sqrt (double components)))
+                  :bound (double (get-in plan [:score :arguments 2 :value]))
+                  :epsilon (double (get-in plan [:normalization :epsilon])))
+           name))
 
 (defn- ordered-abi
   [plan]
@@ -213,6 +242,108 @@
       (kabi/slot (:id source-indices) :input :long
                  :c-name "source_indices" :role :source-indices)
       (kabi/slot (:id output) :output fp :c-name "output" :role :result)])))
+
+(defn- dynamic-fields
+  [plan]
+  (let [[destination-axis head-axis] (:segment-axes plan)
+        membership (:membership plan)
+        storage (:storage plan)
+        value (:value plan)
+        output-elements (:elements (:output plan))]
+    [{:name 'n_entities :c-name "n_entities" :value (:extent destination-axis)}
+     {:name 'n_edges :c-name "n_edges" :value (:edges membership)}
+     {:name 'total_dim :c-name "total_dim" :value (:total-dim storage)}
+     {:name 'n_heads :c-name "n_heads" :value (:extent head-axis)}
+     {:name 'n_components :c-name "n_components" :value (:components value)}
+     {:name 'output_elements :c-name "output_elements" :value output-elements}]))
+
+(defn- dynamic-workgroup-x
+  [desc]
+  (long (max 1 (min (long (or (:subgroup-size desc) 16))
+                    (long (or (:max-workgroup-size desc) 256))))))
+
+(defn- dynamic-abi
+  [plan fields]
+  (let [[q k v destination-indices source-indices] (:operands plan)
+        output (:output plan)
+        fp (:accumulator-dtype plan)]
+    (kabi/validate!
+     (into
+      [(kabi/slot (:id q) :input fp :c-name "q" :role :query)
+       (kabi/slot (:id k) :input fp :c-name "k" :role :key)
+       (kabi/slot (:id v) :input fp :c-name "v" :role :value)
+       (kabi/slot (:id destination-indices) :input :long
+                  :c-name "destination_indices" :role :destination-indices)
+       (kabi/slot (:id source-indices) :input :long
+                  :c-name "source_indices" :role :source-indices)
+       (kabi/slot (:id output) :output fp :c-name "output" :role :result)]
+      (map (fn [{:keys [name c-name]}]
+             (kabi/slot name :scalar :long :c-name c-name :role :shape))
+           fields)))))
+
+(defn emit-dynamic-reference
+  "Emit one shape-polymorphic indexed-attention artifact.
+
+   Extents remain ordered int64 ABI values and drive the symbolic 2-D launch. Clamp and epsilon
+   are proven model semantics and stay embedded constants. `:out-elems` names an explicit scalar
+   argument so the staging path can allocate/read back without interpreting product forms."
+  [plan desc]
+  (let [plan (indexed-attention-plan! plan)
+        fields (dynamic-fields plan)
+        values (mapv :value fields)
+        field-code (into {} (map (juxt :name :c-name)) fields)
+        [entities _ total-dim _ _ output-elements] values
+        workgroup-x (dynamic-workgroup-x desc)
+        name (kernel-name plan :dynamic)
+        inputs (swr/ordered-input-ids plan)
+        output (get-in plan [:output :id])
+        dtype (:accumulator-dtype plan)
+        ctype (c-type dtype)
+        scalar-signature
+        (->> fields
+             (map (fn [{:keys [c-name]}] (str "    long " c-name)))
+             (str/join ",\n"))
+        code {:entities (get field-code 'n_entities)
+              :edges (get field-code 'n_edges)
+              :total-dim (get field-code 'total_dim)
+              :heads (get field-code 'n_heads)
+              :components (get field-code 'n_components)
+              :active-width (str (get field-code 'n_heads) " * "
+                                 (get field-code 'n_components))
+              :scale (str "((" ctype ")" (fp-literal dtype 1.0)
+                          " / sqrt((" ctype ")" (get field-code 'n_components) "))")
+              :bound (double (get-in plan [:score :arguments 2 :value]))
+              :epsilon (double (get-in plan [:normalization :epsilon]))
+              :scalar-signature scalar-signature
+              :invalid-shape
+              "n_edges < 0L || n_heads <= 0L || n_components <= 0L || n_heads > total_dim / n_components"}
+        abi (dynamic-abi plan fields)
+        arguments (into (conj inputs output) values)]
+    (kart/make
+     {:kernel-name name
+      :source (source* plan code name)
+      :abi abi
+      :arguments arguments
+      :launch (klaunch/spec
+               {:workgroup-size [workgroup-x 1]
+                :group-count [(klaunch/ceil-div total-dim workgroup-x)
+                              (klaunch/runtime-value entities)]})
+      :effects {:kind :segmented-weighted-reduction :reads inputs :writes [output]}
+      :provenance {:operation-id (get-in plan [:provenance :operation-id])
+                   :semantic-op (get-in plan [:provenance :semantic-op])
+                   :algebra-plan-id (:id plan)
+                   :lowering :direct-dynamic-reference}
+      :attributes {:strategy :indexed-segmented-reduction-reference
+                   :optimization-tier :reference
+                   :algebra :segmented-weighted-reduction
+                   :algebra-key (swr/algebra-key plan)
+                   :storage-dtype dtype :accumulator-dtype dtype
+                   :membership :edge-list-by-destination
+                   :duplicate-policy :multiset
+                   :dynamic-shape? true
+                   :out-elems output-elements
+                   :materialized-intermediates []
+                   :complexity :quadratic-in-edges-and-head-components}})))
 
 (defn emit-reference
   "Emit the direct indexed-attention correctness schedule for a resolved shape environment."
@@ -233,12 +364,12 @@
                {:workgroup-size [workgroup-x 1]
                 :group-count [(long (quot (+ total-dim (dec workgroup-x)) workgroup-x))
                               entities]})
-      :effects {:kind :indexed-attention :reads inputs :writes [output]}
+      :effects {:kind :segmented-weighted-reduction :reads inputs :writes [output]}
       :provenance {:operation-id (get-in plan [:provenance :operation-id])
-                   :semantic-op :indexed-graph-attention
+                   :semantic-op (get-in plan [:provenance :semantic-op])
                    :algebra-plan-id (:id plan)
                    :lowering :direct-reference}
-      :attributes {:strategy :indexed-attention-reference
+      :attributes {:strategy :indexed-segmented-reduction-reference
                    :optimization-tier :reference
                    :algebra :segmented-weighted-reduction
                    :algebra-key (swr/algebra-key plan)
@@ -274,8 +405,41 @@
      {:inputs (mapv #(graph-buffer % :input) inputs)
       :outputs [(graph-buffer output :output)]
       :nodes [(kgraph/->ScheduledKernel
-               [:indexed-attention (:id plan) :direct-reference] artifact uses [])]
-      :effects {:kind :indexed-attention :materialized-intermediates []}
+               [:segmented-weighted-reduction (:id plan) :indexed-reference] artifact uses [])]
+      :effects {:kind :segmented-weighted-reduction :materialized-intermediates []}
       :provenance {:operation-id (get-in plan [:provenance :operation-id])
-                   :semantic-op :indexed-graph-attention}
-      :attributes {:strategy :indexed-attention-reference :reference? true}})))
+                   :semantic-op (get-in plan [:provenance :semantic-op])}
+      :attributes {:strategy :indexed-segmented-reduction-reference :reference? true}})))
+
+(defn dynamic-kernel-graph
+  "Wrap a dynamic artifact while retaining runtime-resolvable external buffer ranges."
+  [plan artifact]
+  (let [plan (indexed-attention-plan! plan)
+        artifact (kart/validate! artifact)
+        inputs (swr/ordered-input-ids plan)
+        output (get-in plan [:output :id])
+        descriptors (into {} (map (juxt :id identity))
+                          (conj (:operands plan) (:output plan)))
+        edge-ids #{(get-in plan [:membership :destination-indices])
+                   (get-in plan [:membership :source-indices])}
+        edge-elements (:edges (:membership plan))
+        value-elements (:elements (:output plan))
+        graph-buffer (fn [id role]
+                       (kgraph/buffer
+                        id (:dtype (get descriptors id))
+                        (klaunch/runtime-value
+                         (if (contains? edge-ids id) edge-elements value-elements))
+                        :device role))
+        uses (vec (concat (map #(kgraph/->ValueUse % :read) inputs)
+                          [(kgraph/->ValueUse output :write)]))]
+    (kgraph/make
+     {:inputs (mapv #(graph-buffer % :input) inputs)
+      :outputs [(graph-buffer output :output)]
+      :nodes [(kgraph/->ScheduledKernel
+               [:segmented-weighted-reduction (:id plan) :indexed-dynamic-reference]
+               artifact uses [])]
+      :effects {:kind :segmented-weighted-reduction :materialized-intermediates []}
+      :provenance {:operation-id (get-in plan [:provenance :operation-id])
+                   :semantic-op (get-in plan [:provenance :semantic-op])}
+      :attributes {:strategy :indexed-segmented-reduction-reference
+                   :reference? true :dynamic-shape? true}})))

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -16,6 +16,8 @@
             [raster.compiler.passes.parallel.soac-lower]
             [raster.compiler.backend.gpu.segop-opencl :as segop-cl]
             [raster.compiler.passes.parallel.contract-route :as croute]
+            [raster.compiler.passes.parallel.segmented-weighted-reduction-fuse :as swr-fuse]
+            [raster.compiler.passes.parallel.segmented-weighted-reduction-route :as swr-route]
             [raster.compiler.backend.gpu.par-opencl :as legacy]
             [raster.compiler.support.spirv-cache :as spirv-cache]
             [raster.runtime.hardware :as hw]))
@@ -276,7 +278,8 @@
   ;; would otherwise misfire the "offset"→int heuristic). Form-meta types are the base.
   (let [top-scalar-types (merge (or (:scalar-types (meta form)) {}) scalar-types)
         top-array-types (merge (or (:array-types (meta form)) {}) array-types)
-        stats (atom {:ze-maps 0 :ze-reduces 0 :ze-compounds 0 :ze-contracts 0 :fallback 0})
+        stats (atom {:ze-maps 0 :ze-reduces 0 :ze-compounds 0 :ze-contracts 0
+                     :ze-structured-reductions 0 :fallback 0})
         kernels (atom [])
 
         register-kernel!
@@ -290,6 +293,21 @@
         transform
         (fn transform [form]
           (cond
+            ;; === Proven structured segmented weighted reduction ===
+            (swr-fuse/marker? form)
+            (let [plan (swr-fuse/marker-plan form dtype)
+                  routed (swr-route/route-dynamic!
+                          plan
+                          (try ((requiring-resolve
+                                 'raster.compiler.core.hardware/descriptor-for)
+                                device-id)
+                               (catch Throwable _ {:device-type :gpu})))
+                  artifact (register-kernel! (:artifact routed) :ze-structured-reductions)]
+              ;; Reuse the generic artifact marker: it already transports an arbitrary ordered
+              ;; pointer/scalar ABI and symbolic 2-D launch through staging and Compiled.
+              (list 'raster.gpu.ze-runtime/invoke-registered-contraction!
+                    (:kernel-name artifact) (vec (:arguments artifact))))
+
             ;; === Compound kernel ===
             (and (seq? form) (= 'raster.compiler/compound-kernel (first form)))
             (let [[_ metadata original-dotimes] form

--- a/src/raster/compiler/core/op_descriptor.clj
+++ b/src/raster/compiler/core/op_descriptor.clj
@@ -1063,6 +1063,7 @@
    so false positives just trigger an extra (harmless) rewalk."
   [sym]
   (and (symbol? sym)
+       (not (get-in (get-op-descriptor sym) [:compiler-ir?]))
        (when-let [ns-str (namespace sym)]
          (and (not (.contains ^String (name sym) "_m_"))
               (not (.startsWith ^String ns-str "clojure."))

--- a/src/raster/compiler/ir/dialects.clj
+++ b/src/raster/compiler/ir/dialects.clj
@@ -496,6 +496,7 @@
   Used by run-passes to validate IR at pass boundaries."
   {:walked           [valid-walked?       validate-walked]
    :lowered          [valid-walked?      validate-walked]
+   :structured-reductions [valid-walked? validate-walked]
    :ad-transformed   [valid-ad-transformed? validate-ad-transformed]
    :flattened        [valid-flattened?    validate-flattened]
    :cse-eliminated   [valid-let*?         validate-let*]

--- a/src/raster/compiler/ir/invariants.clj
+++ b/src/raster/compiler/ir/invariants.clj
@@ -331,9 +331,10 @@
   I-T3 (dtype closure) THROWS — it guards against the f64-in-f32 silent
   miscompile class. It runs on the STAMPED dialects only (post-rewalk,
   pre-backend); it is skipped at:
-    :lowered — the :lower pass splices AD templates whose stamps
+    :lowered and :structured-reductions — the :lower pass splices AD templates whose stamps
       (:raster.type/tag, :raster.op/original) are only (re)established by the
-      :fixpoint rewalk; pre-rewalk IR is half-stamped by design (probed: an
+      :fixpoint rewalk; structured-reduction recognition also runs before that rewalk and preserves
+      all unmatched forms unchanged. Pre-rewalk IR is half-stamped by design (probed: an
       AD-spliced mse-loss .invk carries a bare {:tag double} at :lowered and
       the full stamps at :fixpointed);
     :backend-applied and later — the :backend pass CONSUMES the stamps and
@@ -343,7 +344,8 @@
   their corpora are clean."
   [dialect-key form pass-key {:keys [params dtype param-env]}]
   (when (and (= dtype :float)
-             (not (contains? #{:lowered :backend-applied :alength-resolved
+             (not (contains? #{:lowered :structured-reductions
+                               :backend-applied :alength-resolved
                                :mem-merged}
                              dialect-key)))
     (when-let [{:keys [sym tag init]} (dtype-closure-violation form (or param-env {}) dtype)]

--- a/src/raster/compiler/ir/segmented_weighted_reduction.clj
+++ b/src/raster/compiler/ir/segmented_weighted_reduction.clj
@@ -9,6 +9,7 @@
    Canonical attention and a future recognizer for indexed-dot/scatter programs can therefore
    converge here without making either source spelling opaque or changing its numerics."
   (:require [clojure.set :as set]
+            [clojure.walk :as walk]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.util :as util]))
 
@@ -17,7 +18,7 @@
 (defrecord SegmentedWeightedReductionPlan
            [id segment-axes membership storage score weight value
             numerator denominator normalization operands output
-            accumulator-dtype source-operation provenance])
+            accumulator-dtype source-operation provenance runtime-parameters])
 
 (def ^:private scalar-operators
   "Closed scalar vocabulary accepted in plan regions. Keeping regions closed makes recognition
@@ -194,7 +195,8 @@
                     {:reason :segmented-reduction-invalid-plan
                      :plan plan :actual (type plan)})))
   (let [{:keys [id segment-axes membership storage score weight value numerator denominator
-                normalization operands output accumulator-dtype source-operation provenance]} plan]
+                normalization operands output accumulator-dtype source-operation provenance
+                runtime-parameters]} plan]
     (when (nil? id)
       (throw (ex-info "segmented weighted reduction requires a stable identity"
                       {:reason :segmented-reduction-missing-id})))
@@ -279,6 +281,11 @@
       (throw (ex-info "segmented reduction requires semantic provenance"
                       {:reason :segmented-reduction-invalid-provenance
                        :provenance provenance})))
+    (when-not (and (vector? runtime-parameters)
+                   (every? some? runtime-parameters))
+      (throw (ex-info "segmented reduction runtime parameters must be ordered expressions"
+                      {:reason :segmented-reduction-invalid-runtime-parameters
+                       :runtime-parameters runtime-parameters})))
     plan))
 
 (defn make
@@ -286,11 +293,61 @@
   [fields]
   (validate!
    (map->SegmentedWeightedReductionPlan
-    (update fields :accumulator-dtype dtype/canon))))
+    (-> fields
+        (update :accumulator-dtype dtype/canon)
+        (update :runtime-parameters #(vec (or % [])))))))
 
 (defn ordered-input-ids
   [plan]
   (mapv :id (:operands (validate! plan))))
+
+(defn runtime-parameter-values
+  "Ordered dynamic scalar values transported by a protected reduction marker. These are semantic
+   shape parameters, not a kernel ABI: a schedule may derive additional ABI scalars such as an
+   output element count from the rebound plan."
+  [plan]
+  (:runtime-parameters (validate! plan)))
+
+(def ^:private integral-casts
+  '#{long int clojure.core/long clojure.core/int})
+
+(defn- canonical-runtime-value
+  [value]
+  (if (and (seq? value) (= 2 (count value)) (contains? integral-casts (first value)))
+    (recur (second value))
+    value))
+
+(defn rebind
+  "Rebind a validated plan after ordinary compiler substitution rewrites its inputs and dynamic
+   scalar parameters. This is the generic bridge from a protected structured-reduction marker
+   back to schedule-neutral IR; no attention role or storage layout is assumed here."
+  [template output inputs runtime-values source-form]
+  (let [template (validate! template)
+        old-inputs (ordered-input-ids template)
+        old-runtime (runtime-parameter-values template)
+        runtime-values (mapv canonical-runtime-value runtime-values)]
+    (when-not (= (count old-runtime) (count (distinct old-runtime)))
+      (throw (ex-info "segmented reduction template has ambiguous runtime parameters"
+                      {:reason :segmented-reduction-duplicate-runtime-parameters
+                       :runtime-parameters old-runtime})))
+    (when-not (= (count old-inputs) (count inputs))
+      (throw (ex-info "segmented reduction marker has the wrong input arity"
+                      {:reason :segmented-reduction-marker-input-arity
+                       :expected (count old-inputs) :actual (count inputs)})))
+    (when-not (= (count old-runtime) (count runtime-values))
+      (throw (ex-info "segmented reduction marker has the wrong runtime-parameter arity"
+                      {:reason :segmented-reduction-marker-runtime-arity
+                       :expected (count old-runtime) :actual (count runtime-values)})))
+    (let [substitutions (into {(get-in template [:output :id]) output}
+                              (concat (map vector old-inputs inputs)
+                                      (map vector old-runtime runtime-values)))
+          rebound (walk/postwalk-replace substitutions template)]
+      (validate!
+       (-> rebound
+           (assoc :id [:segmented-weighted-reduction output]
+                  :runtime-parameters (vec runtime-values)
+                  :source-operation {:form source-form :output output :intermediates []})
+           (assoc-in [:provenance :operation-id] output))))))
 
 (defn algebra-key
   "Buffer- and storage-independent computation identity. Physical page routing and cache layout

--- a/src/raster/compiler/passes/parallel/indexed_attention_recognize.clj
+++ b/src/raster/compiler/passes/parallel/indexed_attention_recognize.clj
@@ -223,6 +223,7 @@
                     :operands operands
                     :output (buffer output dtype value-shape)
                     :accumulator-dtype accumulator-dtype
+                    :runtime-parameters [n-nodes n-edges total-dim n-heads slice-dim]
                     :source-operation {:form form :output output
                                        :intermediates internal}
                     :provenance {:semantic-op :indexed-graph-attention

--- a/src/raster/compiler/passes/parallel/indexed_attention_route.clj
+++ b/src/raster/compiler/passes/parallel/indexed_attention_route.clj
@@ -8,7 +8,7 @@
   {:operation plan
    :strategy nil
    :reference? false
-   :declines [{:leaf :indexed-attention-reference :reason reason :data data}]})
+   :declines [{:leaf :indexed-edge-list-reference :reason reason :data data}]})
 
 (defn route
   "Try the direct fused correctness leaf using concrete values for symbolic plan extents."
@@ -38,7 +38,7 @@
          (let [artifact (emit/emit-reference plan shape-env desc)]
            {:operation plan
             :plan plan
-            :strategy :indexed-attention-reference
+            :strategy :indexed-segmented-reduction-reference
             :reference? true
             :declines []
             :artifact artifact
@@ -46,7 +46,7 @@
             :schedule {:workgroup-size (:workgroup-size (:launch artifact))
                        :group-count (:group-count (:launch artifact))}})))
      (catch clojure.lang.ExceptionInfo e
-       (decline plan (or (:reason (ex-data e)) :indexed-attention-reference-unsupported)
+       (decline plan (or (:reason (ex-data e)) :indexed-segmented-reduction-unsupported)
                 (dissoc (ex-data e) :reason))))))
 
 (defn route!
@@ -57,4 +57,50 @@
      (if (:strategy result)
        result
        (throw (ex-info "no executable indexed-attention kernel route"
+                       {:reason :indexed-attention-no-kernel-route :route result}))))))
+
+(defn route-dynamic
+  "Route a recognized plan to the shape-polymorphic resident/staging artifact."
+  ([plan] (route-dynamic plan nil))
+  ([plan desc]
+   (try
+     (let [{:keys [operands output accumulator-dtype] :as plan} (swr/validate! plan)
+           storage-dtypes (mapv :dtype (conj operands output))]
+       (cond
+         (and desc (not= :gpu (:device-type desc)))
+         (decline plan :indexed-attention-requires-gpu
+                  {:device-type (:device-type desc)})
+
+         (not (contains? #{:float :double} accumulator-dtype))
+         (decline plan :indexed-attention-accumulator-unsupported
+                  {:required #{:float :double} :actual accumulator-dtype})
+
+         (not= [accumulator-dtype accumulator-dtype accumulator-dtype
+                :long :long accumulator-dtype]
+               storage-dtypes)
+         (decline plan :indexed-attention-storage-unsupported
+                  {:required [accumulator-dtype accumulator-dtype accumulator-dtype
+                              :long :long accumulator-dtype]
+                   :actual storage-dtypes})
+
+         :else
+         (let [artifact (emit/emit-dynamic-reference plan desc)]
+           {:operation plan :plan plan
+            :strategy :indexed-segmented-reduction-reference
+            :reference? true :dynamic-shape? true :declines []
+            :artifact artifact
+            :graph (emit/dynamic-kernel-graph plan artifact)
+            :schedule {:workgroup-size (:workgroup-size (:launch artifact))
+                       :group-count (:group-count (:launch artifact))}})))
+     (catch clojure.lang.ExceptionInfo e
+       (decline plan (or (:reason (ex-data e)) :indexed-segmented-reduction-unsupported)
+                (dissoc (ex-data e) :reason))))))
+
+(defn route-dynamic!
+  ([plan] (route-dynamic! plan nil))
+  ([plan desc]
+   (let [result (route-dynamic plan desc)]
+     (if (:strategy result)
+       result
+       (throw (ex-info "no executable dynamic indexed-attention kernel route"
                        {:reason :indexed-attention-no-kernel-route :route result}))))))

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse.clj
@@ -1,0 +1,124 @@
+(ns raster.compiler.passes.parallel.segmented-weighted-reduction-fuse
+  "Protect proven segmented weighted reductions as one schedule-neutral compiler operation.
+
+   Recognition rules prove source algebra; this pass only coordinates disjoint plans and raises
+   them. The marker deliberately says nothing about attention, graph topology, cache layout, or a
+   target schedule. Backends consume the validated plan and independently select a legal leaf."
+  (:require [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.ir.segmented-weighted-reduction :as swr]
+            [raster.compiler.passes.parallel.indexed-attention-recognize :as indexed-rule]))
+
+(def marker-op 'raster.compiler/segmented-weighted-reduction!)
+(def ^:private plan-key ::plan)
+
+(descriptor/register-op-descriptor!
+ marker-op
+ {:compiler-ir? true
+  :buffer {:allocates? false :in-place-arg 0}
+  :effects {:pure? false :mutating? true}})
+
+(def recognition-rules
+  "Ordered algebraic recognition rules. Adding a source spelling extends this table; it does not
+   add a compiler pass or backend semantic operation."
+  [{:id :indexed-dot-scatter-normalize
+    :recognize (fn [form dtype]
+                 (indexed-rule/recognize form :dtype dtype :accumulator-dtype dtype))}])
+
+(defn marker?
+  [form]
+  (and (seq? form) (= marker-op (first form))))
+
+(defn marker-plan
+  "Recover and validate the schedule-neutral plan after intervening compiler substitutions."
+  [marker emitted-dtype]
+  (when-not (and (marker? marker) (= 4 (count marker))
+                 (vector? (nth marker 2)) (vector? (nth marker 3)))
+    (throw (ex-info "segmented weighted-reduction marker has the wrong shape"
+                    {:reason :segmented-reduction-invalid-marker :marker marker})))
+  (let [[_ output inputs runtime-values] marker
+        template (get (meta marker) plan-key)]
+    (when-not (swr/plan? template)
+      (throw (ex-info "segmented weighted-reduction marker lost its proof"
+                      {:reason :segmented-reduction-marker-missing-plan :marker marker})))
+    (when-not (= emitted-dtype (:accumulator-dtype template))
+      (throw (ex-info "segmented weighted-reduction marker dtype differs from its proof"
+                      {:reason :segmented-reduction-marker-dtype-mismatch
+                       :expected (:accumulator-dtype template) :actual emitted-dtype})))
+    (swr/rebind template output inputs runtime-values marker)))
+
+(defn- array-constructor
+  [dtype]
+  (case dtype
+    :float 'clojure.core/float-array
+    :double 'clojure.core/double-array
+    (throw (ex-info "structured reduction output storage is unsupported"
+                    {:reason :segmented-reduction-output-dtype-unsupported :dtype dtype}))))
+
+(defn- array-tag
+  [dtype]
+  (case dtype :float 'floats :double 'doubles))
+
+(defn- fresh-storage-symbol
+  [used output]
+  (loop [candidate (symbol (str (name output) "__segmented_reduction_out"))
+         suffix 2]
+    (if (contains? used candidate)
+      (recur (symbol (str (name output) "__segmented_reduction_out_" suffix)) (inc suffix))
+      candidate)))
+
+(defn- marker-form
+  [plan storage]
+  (with-meta
+    (list marker-op storage (swr/ordered-input-ids plan)
+          (swr/runtime-parameter-values plan))
+    {plan-key plan}))
+
+(defn- recognize
+  [form dtype rules]
+  (mapcat (fn [{:keys [recognize]}] (recognize form dtype)) rules))
+
+(defn- unresolved-ad-boundary?
+  "A protected marker has no VJP of its own. If semantic AD operators are still present, leave the
+   compositional program visible so the fixpoint can differentiate it first. Already-expanded
+   backward code is safe: recognizers still have to prove exclusive uses of every intermediate."
+  [form]
+  (boolean
+   (some (fn [node]
+           (when (seq? node)
+             (let [operation (first node)
+                   ns-name (when (symbol? operation) (namespace operation))]
+               (and ns-name (.startsWith ^String ns-name "raster.ad")))))
+         (tree-seq coll? seq form))))
+
+(defn fuse
+  "Raise disjoint proven reductions. Failed recognition leaves the identical source form intact."
+  ([form dtype] (fuse form dtype recognition-rules))
+  ([form dtype rules]
+   (let [ad-boundary? (unresolved-ad-boundary? form)
+         plans (if ad-boundary? [] (vec (recognize form dtype rules)))]
+     (if (empty? plans)
+       {:form form :stats (cond-> {:segmented-weighted-reductions-fused 0}
+                            ad-boundary? (assoc :declined-unresolved-ad-boundary 1))}
+       (let [[let-sym bindings & body] form
+             pairs (mapv vec (partition 2 bindings))
+             plan-by-output (into {} (map (juxt #(get-in % [:output :id]) identity)) plans)
+             removed (into #{} (mapcat #(get-in % [:source-operation :intermediates])) plans)
+             used (set (map first pairs))
+             rewritten
+             (mapcat
+              (fn [[sym init]]
+                (cond
+                  (contains? removed sym) []
+                  (contains? plan-by-output sym)
+                  (let [plan (get plan-by-output sym)
+                        dtype (get-in plan [:output :dtype])
+                        storage (fresh-storage-symbol used sym)
+                        tag (array-tag dtype)
+                        storage (with-meta storage {:tag tag :raster.type/tag tag})
+                        result (with-meta sym (merge (meta sym) {:tag tag :raster.type/tag tag}))]
+                    [storage (list (array-constructor dtype) (get-in plan [:output :elements]))
+                     result (marker-form plan storage)])
+                  :else [sym init]))
+              pairs)]
+         {:form (with-meta (apply list let-sym (vec rewritten) body) (meta form))
+          :stats {:segmented-weighted-reductions-fused (count plans)}})))))

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_route.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_route.clj
@@ -1,0 +1,33 @@
+(ns raster.compiler.passes.parallel.segmented-weighted-reduction-route
+  "Backend routing for schedule-neutral segmented weighted reductions.
+
+   Each leaf proves its own representability from plan descriptors. The router composes decline
+   trails and never infers a model-level semantic operation from the source spelling."
+  (:require [raster.compiler.ir.segmented-weighted-reduction :as swr]
+            [raster.compiler.passes.parallel.indexed-attention-route :as indexed-leaf]))
+
+(def dynamic-leaves
+  [{:id :indexed-edge-list-reference :route indexed-leaf/route-dynamic}])
+
+(defn route-dynamic
+  ([plan] (route-dynamic plan nil))
+  ([plan desc]
+   (let [plan (swr/validate! plan)]
+     (loop [[leaf & more] dynamic-leaves
+            declines []]
+       (if-not leaf
+         {:operation plan :strategy nil :reference? false :declines declines}
+         (let [result ((:route leaf) plan desc)]
+           (if (:strategy result)
+             (assoc result :leaf (:id leaf))
+             (recur more (into declines (:declines result))))))))))
+
+(defn route-dynamic!
+  ([plan] (route-dynamic! plan nil))
+  ([plan desc]
+   (let [result (route-dynamic plan desc)]
+     (if (:strategy result)
+       result
+       (throw (ex-info "no executable segmented weighted-reduction kernel route"
+                       {:reason :segmented-weighted-reduction-no-kernel-route
+                        :route result}))))))

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -6,7 +6,7 @@
   runner validates arrow compatibility at composition time.
 
   Single unified pipeline (GPU/SIMD):
-    [:lower :fixpoint :dce :buffer-fuse :resolve-alength :soac-fuse :compound-detect :backend :mem-merge]
+    [:lower :structured-reduction-fuse :fixpoint :dce :buffer-fuse :resolve-alength :soac-fuse :compound-detect :backend :mem-merge]
 
   AD is handled by inlining value+grad calls during the fixpoint pass.
   Training, gradients, and higher-order derivatives all go through the
@@ -48,6 +48,7 @@
             [raster.compiler.passes.parallel.loop-lift :as loop-lift]
             [raster.compiler.passes.parallel.write-read-fuse :as write-read-fuse]
             [raster.compiler.passes.parallel.materialize :as materialize]
+            [raster.compiler.passes.parallel.segmented-weighted-reduction-fuse :as swr-fuse]
             [raster.compiler.passes.parallel.gpu-plan :as gpu-plan]
             [raster.compiler.passes.scalar.mem-merge :as mem-merge]
             [raster.compiler.passes.scalar.resolve-alength :as resolve-alength]
@@ -344,6 +345,13 @@
                    (list 'let* [] result))]
     ;; Tag binding symbols with inferred types
     (tag-binding-types let-form (:param-env opts))))
+
+(defn- pass-structured-reduction-fuse
+  "Protect proven structured reductions as schedule-neutral internal markers on GPU targets."
+  [form opts]
+  (if (device/gpu-target? (:target-device opts))
+    (swr-fuse/fuse form (:dtype opts))
+    {:form form :stats {:segmented-weighted-reductions-fused 0}}))
 
 (defn- pass-expand
   "Expand template-backed ops for backend optimization.
@@ -918,7 +926,9 @@
   flat let* form). The :from tag is set to the most common input."
   {;; Core pipeline passes (used in forward-passes)
    :lower            {:from :walked            :to :lowered           :fn pass-lower}
-   :fixpoint         {:from :lowered           :to :fixpointed        :fn pass-fixpoint}
+   :structured-reduction-fuse
+   {:from :lowered :to :structured-reductions :fn pass-structured-reduction-fuse}
+   :fixpoint         {:from :structured-reductions :to :fixpointed    :fn pass-fixpoint}
    :dce              {:from :*                 :to :dce-cleaned       :fn pass-dce}
    :buffer-fuse      {:from :dce-cleaned       :to :buffer-fused      :fn pass-buffer-fuse}
    :loop-lift        {:from :late-cleaned      :to :loop-lifted       :fn pass-loop-lift}
@@ -981,14 +991,14 @@
    loop-lift recovers par structure from dotimes/loop forms (e.g. SGD inlined to dotimes).
    write-read-fuse eliminates intermediate buffers by fusing 2D producers into 1D consumers (dW+SGD).
    segop-lower converts par forms to SegOp IR for unified backend consumption."
-  [:lower :fixpoint :dce :buffer-fuse :late-cleanup :loop-lift :write-read-fuse :soac-fuse :materialize :segop-lower :compound-detect :backend :resolve-alength :mem-merge])
+  [:lower :structured-reduction-fuse :fixpoint :dce :buffer-fuse :late-cleanup :loop-lift :write-read-fuse :soac-fuse :materialize :segop-lower :compound-detect :backend :resolve-alength :mem-merge])
 
 (def gpu-resident-pre-soa-passes
   "forward-passes up to (and including) :materialize. The resident GPU path splits here so
    soa-lower can explode value-type (Params container) params into per-field arrays at the
    :materialized boundary — BEFORE the :backend pass emits kernels (the JVM bytecode backend
    keeps Valhalla value-classes native, so soa-lower is per-backend, not a shared pass)."
-  [:lower :fixpoint :dce :buffer-fuse :late-cleanup :loop-lift :write-read-fuse :soac-fuse :materialize])
+  [:lower :structured-reduction-fuse :fixpoint :dce :buffer-fuse :late-cleanup :loop-lift :write-read-fuse :soac-fuse :materialize])
 
 (def gpu-resident-post-soa-passes
   "forward-passes from :segop-lower onward — resumed (from :materialized) after soa-lower."

--- a/test/raster/compiler/passes/parallel/indexed_attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/indexed_attention_route_test.clj
@@ -1,6 +1,8 @@
 (ns raster.compiler.passes.parallel.indexed-attention-route-test
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.ir.kernel-graph-call :as kgcall]
             [raster.compiler.passes.parallel.indexed-attention-recognize :as recognize]
             [raster.compiler.passes.parallel.indexed-attention-route :as route]))
 
@@ -31,7 +33,7 @@
   (let [{:keys [strategy reference? artifact graph schedule declines]}
         (route/route! (plan) shape-env
                       {:device-type :gpu :subgroup-size 16 :max-workgroup-size 256})]
-    (is (= :indexed-attention-reference strategy))
+    (is (= :indexed-segmented-reduction-reference strategy))
     (is reference?)
     (is (empty? declines))
     (is (= '[Q K V dst src normalized] (:arguments artifact)))
@@ -64,12 +66,49 @@
     (is (str/starts-with? (:source artifact)
                           "#pragma OPENCL EXTENSION cl_khr_fp64 : enable"))))
 
+(deftest dynamic-reference-carries-shapes-through-the-ordered-abi
+  (let [{:keys [artifact graph]}
+        (route/route-dynamic! (plan)
+                              {:device-type :gpu :subgroup-size 16
+                               :max-workgroup-size 256})
+        runtime-values (vec (concat (repeat 6 (Object.))
+                                    (map (fn [value] {:type :long :value value})
+                                         [3 4 5 2 2 15])))
+        call (kcall/make artifact runtime-values)
+        output-elements (get-in (plan) [:output :elements])
+        graph-output (first (:outputs graph))]
+    (is (= '[Q K V dst src normalized
+             n_entities n_edges total_dim n_heads n_components output_elements]
+           (mapv :name (:abi artifact))))
+    (is (= '[Q K V dst src normalized
+             n-nodes n-edges emb-dim n-heads dk
+             (clojure.core/* n-nodes emb-dim)]
+           (:arguments artifact)))
+    (is (= [16 1] (get-in call [:geometry :workgroup-size])))
+    (is (= [1 3] (get-in call [:geometry :group-count])))
+    (is (= output-elements (get-in artifact [:attributes :out-elems])))
+    (is (= 15 (kgcall/resolve-integer
+               {output-elements {:type :long :value 15}}
+               (:elements graph-output))))
+    (is (str/includes? (:source artifact) "long n_entities"))
+    (is (str/includes? (:source artifact) "sqrt((float)n_components)"))))
+
+(deftest leaf-selection-depends-on-plan-descriptors-not-attention-provenance
+  (let [generic-plan (-> (plan)
+                         (assoc-in [:provenance :semantic-op]
+                                   :generic-segmented-weighted-reduction)
+                         (assoc-in [:provenance :lowering] :algebraic-diamond-recognition))
+        {:keys [strategy artifact]} (route/route-dynamic! generic-plan)]
+    (is (= :indexed-segmented-reduction-reference strategy))
+    (is (= :generic-segmented-weighted-reduction
+           (get-in artifact [:provenance :semantic-op])))))
+
 (deftest route-declines-unproved-semantics-and-unresolved-shapes
   (testing "a different scalar region cannot silently enter the specialized leaf"
     (let [result (route/route (assoc-in (plan) [:normalization :epsilon] 0.0)
                               shape-env)]
       (is (nil? (:strategy result)))
-      (is (= :indexed-attention-reference-plan-unsupported
+      (is (= :indexed-segmented-reduction-plan-unsupported
              (get-in result [:declines 0 :reason])))))
   (testing "symbolic extents have to be specialized deliberately"
     (let [result (route/route (plan) (dissoc shape-env 'n-edges))]

--- a/test/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse_test.clj
+++ b/test/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse_test.clj
@@ -1,0 +1,142 @@
+(ns raster.compiler.passes.parallel.segmented-weighted-reduction-fuse-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.passes.parallel.segmented-weighted-reduction-fuse :as fuse]
+            [raster.compiler.pipeline :as pipeline]
+            [raster.core :refer [deftm]]
+            [raster.dl.array-ops :as array-ops]
+            [raster.dl.gsdm :as gsdm]
+            [raster.numeric]))
+
+(defn- chain
+  []
+  '(let* [raw (raster.dl.array-ops/indexed-dot
+               Q K dst src n-nodes n-nodes n-edges dk emb-dim n-heads)
+          weights (raster.dl.array-ops/scale-clamp-exp
+                   raw (raster.numeric// 1.0 (raster.numeric/sqrt dk))
+                   5.0 (clojure.core/* n-edges n-heads))
+          denominator (raster.dl.array-ops/scatter-add
+                       weights dst n-nodes n-edges n-heads)
+          weighted (raster.dl.array-ops/scatter-mul-add
+                    weights V dst src n-nodes n-nodes n-edges dk emb-dim n-heads)
+          normalized (raster.dl.array-ops/segment-div
+                      weighted denominator n-nodes emb-dim n-heads 1.0e-6)]
+         normalized))
+
+(deftm resident-structured-reduction-probe
+  [Q :- (Array float) K :- (Array float) V :- (Array float)
+   dst :- (Array long) src :- (Array long)
+   n-nodes :- Long n-edges :- Long emb-dim :- Long n-heads :- Long]
+  :- (Array float)
+  (let [dk (quot emb-dim n-heads)
+        raw (array-ops/indexed-dot
+             Q K dst src n-nodes n-nodes n-edges dk emb-dim n-heads)
+        weights (array-ops/scale-clamp-exp
+                 raw (/ 1.0 (raster.numeric/sqrt dk)) 5.0 (* n-edges n-heads))
+        denominator (array-ops/scatter-add weights dst n-nodes n-edges n-heads)
+        weighted (array-ops/scatter-mul-add
+                  weights V dst src n-nodes n-nodes n-edges dk emb-dim n-heads)
+        normalized (array-ops/segment-div
+                    weighted denominator n-nodes emb-dim n-heads 1.0e-6)]
+    normalized))
+
+(deftest proven-region-becomes-one-schedule-neutral-marker
+  (let [{:keys [form stats]} (fuse/fuse (chain) :float)
+        pairs (mapv vec (partition 2 (second form)))
+        marker (second (last pairs))
+        plan (fuse/marker-plan marker :float)]
+    (is (= {:segmented-weighted-reductions-fused 1} stats))
+    (is (= 2 (count pairs)) "one allocation plus one fused call replace five operations")
+    (is (= 'normalized (ffirst (take-last 1 pairs))))
+    (is (fuse/marker? marker))
+    (is (= '[Q K V dst src] (mapv :id (:operands plan))))
+    (is (= '[n-nodes n-edges emb-dim n-heads dk]
+           (:runtime-parameters plan)))
+    (is (= (first (first pairs)) (get-in plan [:output :id])))
+    (is (= :recognized-indexed-attention-chain
+           (get-in plan [:provenance :lowering])))))
+
+(deftest marker-rebinds-generic-operands-and-runtime-parameters
+  (let [{:keys [form]} (fuse/fuse (chain) :float)
+        marker (second (last (mapv vec (partition 2 (second form)))))
+        rebound (with-meta
+                  (list fuse/marker-op 'out2 '[q2 k2 v2 dst2 src2]
+                        '[(long entities2) edges2 width2 heads2 components2])
+                  (meta marker))
+        plan (fuse/marker-plan rebound :float)]
+    (is (= '[q2 k2 v2 dst2 src2] (mapv :id (:operands plan))))
+    (is (= 'out2 (get-in plan [:output :id])))
+    (is (= '[entities2 edges2 width2 heads2 components2]
+           (:runtime-parameters plan)))
+    (is (= 'entities2 (get-in plan [:segment-axes 0 :extent])))
+    (is (= 'width2 (get-in plan [:storage :total-dim])))))
+
+(deftest an-unproved-chain-remains-the-identical-fallback-form
+  (let [original (chain)
+        mismatched (assoc (vec (second original)) 7
+                          '(raster.dl.array-ops/scatter-add
+                            weights other-dst n-nodes n-edges n-heads))
+        original (list 'let* mismatched 'normalized)
+        result (fuse/fuse original :float)]
+    (is (identical? original (:form result)))
+    (is (= 0 (get-in result [:stats :segmented-weighted-reductions-fused])))))
+
+(deftest unresolved-ad-keeps-the-compositional-region-visible
+  (let [[op bindings] (chain)
+        original (list op bindings '(raster.ad.reverse/value-and-grad normalized))
+        result (fuse/fuse original :float)]
+    (is (identical? original (:form result)))
+    (is (= {:segmented-weighted-reductions-fused 0
+            :declined-unresolved-ad-boundary 1}
+           (:stats result)))))
+
+(deftest compiler-pass-is-gpu-only
+  (let [opts {:inline? false :simd? false :dtype :float}
+        cpu (pipeline/run-passes (chain) [:lower :structured-reduction-fuse] opts)
+        gpu (pipeline/run-passes (chain) [:lower :structured-reduction-fuse]
+                                 (assoc opts :target-device :ze:0))
+        marker-count #(count (filter fuse/marker? (tree-seq coll? seq %)))]
+    (is (zero? (marker-count cpu)))
+    (is (= 1 (marker-count gpu)))))
+
+(deftest compiled-production-path-selects-one-artifact-backed-step
+  (let [descriptor (pipeline/compile-gpu-program
+                    #'resident-structured-reduction-probe :ze:0 :dtype :float)
+        step (first (:steps descriptor))
+        args [(float-array 15) (float-array 15) (float-array 15)
+              (long-array 4) (long-array 4) 3 4 5 2]
+        call-arguments
+        (mapv (fn [{:keys [kind type value-fn]}]
+                (if (= :scalar kind)
+                  {:type type :value (value-fn args)}
+                  (Object.)))
+              (:argument-specs step))
+        call (kcall/make (:artifact step) call-arguments)]
+    (is (= 1 (count (:steps descriptor))))
+    (is (= 1 (count (:allocs descriptor))))
+    (is (= :contract (:convention step)))
+    (is (kart/kernel-artifact? (:artifact step)))
+    (is (= :indexed-segmented-reduction-reference
+           (get-in step [:artifact :attributes :strategy])))
+    (is (= [] (get-in step [:artifact :attributes :materialized-intermediates])))
+    (is (= [:input :input :input :input :input :output
+            :scalar :scalar :scalar :scalar :scalar :scalar]
+           (mapv (comp :kind :slot) (:argument-specs step))))
+    (is (= [1 3] (get-in call [:geometry :group-count])))
+    (is (= (:sym (first (:allocs descriptor))) (:result-sym descriptor)))))
+
+(deftest actual-gsdm-region-reaches-generic-structured-reduction-stage
+  (let [diagnostic (pipeline/show-pipeline
+                    #'gsdm/graph-attention-multihead
+                    :dtype :float :simd? false :target-device :ze:0)
+        kernels
+        (filterv #(= :indexed-segmented-reduction-reference
+                     (get-in % [:attributes :strategy]))
+                 (:kernels diagnostic))]
+    (is (= 1 (get-in diagnostic
+                     [:structured-reductions-stats
+                      :segmented-weighted-reductions-fused])))
+    (is (= 1 (count kernels)))
+    (is (true? (get-in (first kernels) [:attributes :dynamic-shape?])))
+    (is (= [] (get-in (first kernels) [:attributes :materialized-intermediates])))))

--- a/test/raster/gpu/indexed_attention_device_test.clj
+++ b/test/raster/gpu/indexed_attention_device_test.clj
@@ -46,9 +46,15 @@
 (defn- run-case
   [device-id]
   (let [{:keys [plan shape-env buffers expected]} (test-case)
-        graph (:graph (route/route!
-                       plan shape-env
-                       {:device-type :gpu :subgroup-size 16 :max-workgroup-size 256}))]
+        graph (:graph (route/route-dynamic!
+                       plan
+                       {:device-type :gpu :subgroup-size 16 :max-workgroup-size 256}))
+        output-elements (get-in plan [:output :elements])
+        scalar-values
+        (assoc (into {} (map (fn [[name value]]
+                               [name {:type :long :value value}])
+                             shape-env))
+               output-elements {:type :long :value 15})]
     (gpu/with-gpu-session [session device-id]
       (gpu/alloc! session
                   {:q [:float 15 (get buffers 'Q)]
@@ -60,7 +66,7 @@
       (let [handle (gpu/bind-kernel-graph!
                     session [:indexed-attention device-id] graph
                     {'Q :q 'K :k 'V :v 'dst :dst 'src :src 'normalized :output}
-                    {})]
+                    scalar-values)]
         (try
           (gpu/run-kernel-graph! session handle)
           (let [actual ^floats (gpu/download session :output)]


### PR DESCRIPTION
## Outcome

Raises proven segmented weighted-reduction regions through a generic compiler marker and router. The indexed-dot/scatter GSDM spelling is one recognition rule; backend legality and selection depend on plan descriptors and scalar algebra, not attention provenance.

## Included

- shape-polymorphic ordered buffer/scalar ABI and symbolic 2-D launch
- generic plan rebinding after compiler substitutions
- generic leaf registry with composed decline trails
- conservative unresolved-AD boundary that preserves compositional source
- direct fused reference leaf with no score/weight/denominator intermediates
- actual GSDM resident production-path coverage

## Scope

This is the correctness/reference schedule and extensible fusion seam. CSR destination routing, subgroup/shared-memory score reuse, online normalization, dense contraction/tensor-core routing, quantized leaves, and autotuned hardware selection remain subsequent schedule work.

## Verification

- 31 structured-reduction/attention/device tests, 172 cold-JVM assertions, green; GPU test explicitly skipped when cold Level Zero probe failed
- same focused suite through the persistent REPL: 178 assertions, green, including successful Arc device initialization
- 9 op-descriptor/kernel-call/resident-extractor tests, 47 assertions, green
- clj-kondo: no errors in touched focused files
- git diff --check: clean
- targeted formatting: new and focused files clean; repository-wide formatter still reports pre-existing unrelated files and two pre-existing large-file regions