### PR TITLE
Add selectable subgroup reduction schedule

### DIFF
--- a/src/raster/compiler/backend/gpu/indexed_attention.clj
+++ b/src/raster/compiler/backend/gpu/indexed_attention.clj
@@ -144,8 +144,11 @@
 
 (defn- kernel-name
   [plan shape]
-  (let [identity {:schedule (swr/schedule-key plan) :shape shape}]
-    (format "raster_indexed_attention_ref_%08x"
+  (let [identity {:schedule (swr/schedule-key plan) :shape shape}
+        schedule-name (case (:schedule shape)
+                        :destination-score-reuse "subgroup_score_reuse"
+                        "ref")]
+    (format "raster_indexed_attention_%s_%08x" schedule-name
             (bit-and 0xffffffff (long (hash identity))))))
 
 (defn- source*
@@ -345,6 +348,129 @@
                    :materialized-intermediates []
                    :complexity :quadratic-in-edges-and-head-components}})))
 
+(defn- score-reuse-subgroup-size
+  [desc]
+  (long (or (:subgroup-size desc) 16)))
+
+(defn- score-reuse-source
+  [plan fields subgroup-size name]
+  (let [dtype (:accumulator-dtype plan)
+        ctype (c-type dtype)
+        zero (fp-literal dtype 0.0)
+        one (fp-literal dtype 1.0)
+        bound (fp-literal dtype (double (get-in plan [:score :arguments 2 :value])))
+        epsilon (fp-literal dtype (double (get-in plan [:normalization :epsilon])))
+        scalar-signature (->> fields
+                              (map (fn [{:keys [c-name]}] (str "    long " c-name)))
+                              (str/join ",\n"))]
+    (str (when (= :double dtype)
+           "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n")
+         "__attribute__((intel_reqd_sub_group_size(" subgroup-size ")))\n"
+         "__kernel void " name "(\n"
+         "    __global const " ctype "* q,\n"
+         "    __global const " ctype "* k,\n"
+         "    __global const " ctype "* v,\n"
+         "    __global const long* destination_indices,\n"
+         "    __global const long* source_indices,\n"
+         "    __global " ctype "* output,\n"
+         scalar-signature ") {\n"
+         "  const long lane = (long)get_sub_group_local_id();\n"
+         "  const long component_tile = (long)get_group_id(0);\n"
+         "  const long head = (long)get_group_id(1);\n"
+         "  const long destination = (long)get_group_id(2);\n"
+         "  const long component = component_tile * " subgroup-size "L + lane;\n"
+         "  const long feature = head * n_components + component;\n"
+         "  const int active = component < n_components && feature < total_dim;\n"
+         "  " ctype " numerator = " zero ";\n"
+         "  " ctype " denominator = " zero ";\n"
+         "  int invalid = n_edges < 0L || n_heads <= 0L || n_components <= 0L\n"
+         "        || n_heads > total_dim / n_components;\n"
+         "  for (long edge = 0L; edge < n_edges; ++edge) {\n"
+         "    const long edge_destination = destination_indices[edge];\n"
+         "    const long source = source_indices[edge];\n"
+         "    if (edge_destination < 0L || edge_destination >= n_entities\n"
+         "        || source < 0L || source >= n_entities) invalid = 1;\n"
+         "    const int visible = !invalid && edge_destination == destination;\n"
+         "    " ctype " partial_dot = " zero ";\n"
+         "    if (visible) {\n"
+         "      const long q_base = destination * total_dim + head * n_components;\n"
+         "      const long k_base = source * total_dim + head * n_components;\n"
+         "      for (long x = lane; x < n_components; x += " subgroup-size "L)\n"
+         "        partial_dot += q[q_base + x] * k[k_base + x];\n"
+         "    }\n"
+         "    const " ctype " dot = sub_group_reduce_add(partial_dot);\n"
+         "    " ctype " weight = " zero ";\n"
+         "    if (lane == 0L && visible) {\n"
+         "        const " ctype " scaled = dot * ((" ctype ")" one
+         " / sqrt((" ctype ")n_components));\n"
+         "        const " ctype " score = isnan(scaled) ? scaled\n"
+         "            : fmin((" ctype ")" bound ", fmax(-(" ctype ")" bound ", scaled));\n"
+         "        weight = exp(score);\n"
+         "    }\n"
+         "    weight = sub_group_broadcast(weight, 0);\n"
+         "    denominator += weight;\n"
+         "    if (active && visible)\n"
+         "      numerator += weight * v[source * total_dim + feature];\n"
+         "  }\n"
+         "  if (active) {\n"
+         "    const long output_index = destination * total_dim + feature;\n"
+         "    output[output_index] = invalid ? (" ctype ")NAN\n"
+         "        : (denominator == " zero " ? " zero
+         " : numerator / (denominator + (" ctype ")" epsilon "));\n"
+         "  }\n"
+         "  if (head == 0L && component_tile == 0L) {\n"
+         "    const long active_width = n_heads * n_components;\n"
+         "    for (long tail = active_width + lane; tail < total_dim; tail += "
+         subgroup-size "L)\n"
+         "      output[destination * total_dim + tail] = invalid ? (" ctype ")NAN : " zero ";\n"
+         "  }\n"
+         "}\n")))
+
+(defn emit-dynamic-score-reuse
+  "Emit a 3-D destination/head/component-tile schedule. One hardware subgroup cooperatively
+   reduces each edge score and broadcasts its weight across component lanes. This retains the
+   edge-list ABI while removing the reference leaf's per-output score recomputation."
+  [plan desc]
+  (let [plan (indexed-attention-plan! plan)
+        fields (dynamic-fields plan)
+        values (mapv :value fields)
+        [entities _ _ heads components output-elements] values
+        subgroup-size (score-reuse-subgroup-size desc)
+        name (kernel-name plan {:schedule :destination-score-reuse
+                                :subgroup-size subgroup-size})
+        inputs (swr/ordered-input-ids plan)
+        output (get-in plan [:output :id])
+        dtype (:accumulator-dtype plan)
+        abi (dynamic-abi plan fields)
+        arguments (into (conj inputs output) values)]
+    (kart/make
+     {:kernel-name name
+      :source (score-reuse-source plan fields subgroup-size name)
+      :abi abi
+      :arguments arguments
+      :launch (klaunch/spec
+               {:workgroup-size [subgroup-size 1 1]
+                :group-count [(klaunch/ceil-div components subgroup-size)
+                              (klaunch/runtime-value heads)
+                              (klaunch/runtime-value entities)]})
+      :effects {:kind :segmented-weighted-reduction :reads inputs :writes [output]}
+      :provenance {:operation-id (get-in plan [:provenance :operation-id])
+                   :semantic-op (get-in plan [:provenance :semantic-op])
+                   :algebra-plan-id (:id plan)
+                   :lowering :destination-score-reuse}
+      :attributes {:strategy :indexed-segmented-reduction-subgroup-score-reuse
+                   :optimization-tier :subgroup
+                   :algebra :segmented-weighted-reduction
+                   :algebra-key (swr/algebra-key plan)
+                   :storage-dtype dtype :accumulator-dtype dtype
+                   :membership :edge-list-by-destination
+                   :duplicate-policy :multiset
+                   :dynamic-shape? true
+                   :out-elems output-elements
+                   :score-reuse-width subgroup-size
+                   :materialized-intermediates []
+                   :complexity :destination-head-edge-dot-plus-value}})))
+
 (defn emit-reference
   "Emit the direct indexed-attention correctness schedule for a resolved shape environment."
   [plan shape-env desc]
@@ -431,7 +557,9 @@
                          (if (contains? edge-ids id) edge-elements value-elements))
                         :device role))
         uses (vec (concat (map #(kgraph/->ValueUse % :read) inputs)
-                          [(kgraph/->ValueUse output :write)]))]
+                          [(kgraph/->ValueUse output :write)]))
+        strategy (get-in artifact [:attributes :strategy])
+        reference? (= :reference (get-in artifact [:attributes :optimization-tier]))]
     (kgraph/make
      {:inputs (mapv #(graph-buffer % :input) inputs)
       :outputs [(graph-buffer output :output)]
@@ -441,5 +569,4 @@
       :effects {:kind :segmented-weighted-reduction :materialized-intermediates []}
       :provenance {:operation-id (get-in plan [:provenance :operation-id])
                    :semantic-op (get-in plan [:provenance :semantic-op])}
-      :attributes {:strategy :indexed-segmented-reduction-reference
-                   :reference? true :dynamic-shape? true}})))
+      :attributes {:strategy strategy :reference? reference? :dynamic-shape? true}})))

--- a/src/raster/compiler/passes/parallel/indexed_attention_route.clj
+++ b/src/raster/compiler/passes/parallel/indexed_attention_route.clj
@@ -4,11 +4,12 @@
             [raster.compiler.ir.segmented-weighted-reduction :as swr]))
 
 (defn- decline
-  [plan reason data]
-  {:operation plan
-   :strategy nil
-   :reference? false
-   :declines [{:leaf :indexed-edge-list-reference :reason reason :data data}]})
+  ([plan reason data] (decline plan :indexed-edge-list-reference reason data))
+  ([plan leaf reason data]
+   {:operation plan
+    :strategy nil
+    :reference? false
+    :declines [{:leaf leaf :reason reason :data data}]}))
 
 (defn route
   "Try the direct fused correctness leaf using concrete values for symbolic plan extents."
@@ -104,3 +105,56 @@
        result
        (throw (ex-info "no executable dynamic indexed-attention kernel route"
                        {:reason :indexed-attention-no-kernel-route :route result}))))))
+
+(defn route-dynamic-score-reuse
+  "Route to the destination/head subgroup leaf that shares each score across component lanes."
+  ([plan] (route-dynamic-score-reuse plan nil))
+  ([plan desc]
+   (let [leaf :indexed-edge-list-subgroup-score-reuse]
+     (try
+       (let [{:keys [operands output accumulator-dtype] :as plan} (swr/validate! plan)
+             storage-dtypes (mapv :dtype (conj operands output))
+             subgroup-size (long (or (:subgroup-size desc) 16))
+             max-workgroup-size (long (or (:max-workgroup-size desc) 256))]
+         (cond
+           (not= :subgroup-score-reuse
+                 (:segmented-weighted-reduction-schedule desc))
+           (decline plan leaf :score-reuse-not-selected
+                    {:required :subgroup-score-reuse
+                     :selected (:segmented-weighted-reduction-schedule desc)})
+
+           (and desc (not= :gpu (:device-type desc)))
+           (decline plan leaf :score-reuse-requires-gpu
+                    {:device-type (:device-type desc)})
+
+           (not (contains? #{:float :double} accumulator-dtype))
+           (decline plan leaf :score-reuse-accumulator-unsupported
+                    {:required #{:float :double} :actual accumulator-dtype})
+
+           (not= [accumulator-dtype accumulator-dtype accumulator-dtype
+                  :long :long accumulator-dtype]
+                 storage-dtypes)
+           (decline plan leaf :score-reuse-storage-unsupported
+                    {:required [accumulator-dtype accumulator-dtype accumulator-dtype
+                                :long :long accumulator-dtype]
+                     :actual storage-dtypes})
+
+           (or (not (pos? subgroup-size))
+               (> subgroup-size max-workgroup-size))
+           (decline plan leaf :score-reuse-invalid-subgroup-geometry
+                    {:subgroup-size subgroup-size
+                     :max-workgroup-size max-workgroup-size})
+
+           :else
+           (let [artifact (emit/emit-dynamic-score-reuse plan desc)]
+             {:operation plan :plan plan
+              :strategy :indexed-segmented-reduction-subgroup-score-reuse
+              :reference? false :dynamic-shape? true :declines []
+              :artifact artifact
+              :graph (emit/dynamic-kernel-graph plan artifact)
+              :schedule {:workgroup-size (:workgroup-size (:launch artifact))
+                         :group-count (:group-count (:launch artifact))}})))
+       (catch clojure.lang.ExceptionInfo e
+         (decline plan leaf
+                  (or (:reason (ex-data e)) :indexed-score-reuse-unsupported)
+                  (dissoc (ex-data e) :reason)))))))

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_route.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_route.clj
@@ -7,7 +7,8 @@
             [raster.compiler.passes.parallel.indexed-attention-route :as indexed-leaf]))
 
 (def dynamic-leaves
-  [{:id :indexed-edge-list-reference :route indexed-leaf/route-dynamic}])
+  [{:id :indexed-edge-list-subgroup-score-reuse :route indexed-leaf/route-dynamic-score-reuse}
+   {:id :indexed-edge-list-reference :route indexed-leaf/route-dynamic}])
 
 (defn route-dynamic
   ([plan] (route-dynamic plan nil))

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -1615,6 +1615,13 @@
     (.invokeWithArguments ^MethodHandle (:h-launch bound)
                           ^"[Ljava.lang.Object;" (:launch-args bound))))
 
+(defn launch-geometry!
+  "Bind arguments and launch one checked 1-3D geometry. Artifact-backed staging uses this instead
+   of the legacy dimension-specific launchers so no valid KernelCall axis can be discarded."
+  [kernel workgroup-size group-count kernel-args]
+  (let [bound (bind-kernel! kernel workgroup-size kernel-args)]
+    (launch-bound! bound group-count)))
+
 ;; ================================================================
 ;; Command graph: enqueue-all → execute-once → sync-once (OpenVINO's model)
 ;; The per-op-barrier immediate list pays the ~35-75µs launch floor per kernel;
@@ -3485,7 +3492,7 @@
    `arguments` contains evaluated values in exact ABI order.  The ABI decides which values are
    buffers or scalars, how host buffers are staged, and the scalar type passed to Level Zero.
    Packed kernels therefore retain byte storage while declaring a distinct int32 kernel view.
-   Output extent and 2-D geometry are resolved from the artifact, never marker positions."
+   Output extent and 1-3D geometry are resolved from the artifact, never marker positions."
   [^String kernel-name arguments]
   (let [registered (get @kernel-registry kernel-name)
         _ (when-not registered
@@ -3540,7 +3547,7 @@
         {:keys [kernel-handle]} (ensure-kernel-loaded! kernel-name)
         out @output
         [out-seg out-half? out-esize] @output-seg]
-    (launch-2d! kernel-handle workgroup-size group-count all-args)
+    (launch-geometry! kernel-handle workgroup-size group-count all-args)
     (when-not (device-buffer? out)
       (readback-operand! out-seg out out-elems out-half? out-esize))
     out))

--- a/test/raster/compiler/contraction_marker_abi_test.clj
+++ b/test/raster/compiler/contraction_marker_abi_test.clj
@@ -130,6 +130,18 @@
     (is (= 2 (:expected data)))
     (is (= 1 (:actual data)))))
 
+(deftest staged-artifact-launch-preserves-all-three-geometry-axes
+  (let [seen (atom [])]
+    (with-redefs [ze/bind-kernel! (fn [kernel workgroup arguments]
+                                    (swap! seen conj [:bind kernel workgroup arguments])
+                                    :bound)
+                  ze/launch-bound! (fn [bound groups]
+                                     (swap! seen conj [:launch bound groups]))]
+      (ze/launch-geometry! :kernel [64 1 1] [2 3 4] [:a :b]))
+    (is (= [[:bind :kernel [64 1 1] [:a :b]]
+            [:launch :bound [2 3 4]]]
+           @seen))))
+
 (deftest resident-binders-validate-ordered-values-before-touching-a-driver
   (let [abi [{:name 'A :c-name "A" :kind :input :dtype :float :kernel-dtype :float}
              {:name 'alpha :c-name "alpha" :kind :scalar :dtype :float :kernel-dtype :float}

--- a/test/raster/compiler/passes/parallel/indexed_attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/indexed_attention_route_test.clj
@@ -1,10 +1,12 @@
 (ns raster.compiler.passes.parallel.indexed-attention-route-test
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
+            [clojure.java.shell :as shell]
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-graph-call :as kgcall]
             [raster.compiler.passes.parallel.indexed-attention-recognize :as recognize]
-            [raster.compiler.passes.parallel.indexed-attention-route :as route]))
+            [raster.compiler.passes.parallel.indexed-attention-route :as route]
+            [raster.compiler.passes.parallel.segmented-weighted-reduction-route :as swr-route]))
 
 (defn- chain
   []
@@ -102,6 +104,73 @@
     (is (= :indexed-segmented-reduction-reference strategy))
     (is (= :generic-segmented-weighted-reduction
            (get-in artifact [:provenance :semantic-op])))))
+
+(deftest generic-router-prefers-3d-subgroup-score-reuse
+  (let [generic-plan (assoc-in (plan) [:provenance :semantic-op]
+                               :generic-segmented-weighted-reduction)
+        {:keys [leaf strategy reference? artifact graph]}
+        (swr-route/route-dynamic!
+         generic-plan {:device-type :gpu
+                       :subgroup-size 16
+                       :max-workgroup-size 256
+                       :segmented-weighted-reduction-schedule :subgroup-score-reuse})
+        runtime-values (vec (concat (repeat 6 (Object.))
+                                    (map (fn [value] {:type :long :value value})
+                                         [3 4 5 2 2 15])))
+        call (kcall/make artifact runtime-values)
+        wide-values (vec (concat (repeat 6 (Object.))
+                                 (map (fn [value] {:type :long :value value})
+                                      [3 4 260 2 128 780])))
+        wide-call (kcall/make artifact wide-values)
+        source (:source artifact)]
+    (is (= :indexed-edge-list-subgroup-score-reuse leaf))
+    (is (= :indexed-segmented-reduction-subgroup-score-reuse strategy))
+    (is (false? reference?))
+    (is (= [16 1 1] (get-in call [:geometry :workgroup-size])))
+    (is (= [1 2 3] (get-in call [:geometry :group-count])))
+    (is (= [8 2 3] (get-in wide-call [:geometry :group-count]))
+        "components wider than one subgroup become tiles")
+    (is (= strategy (get-in graph [:attributes :strategy])))
+    (is (= :generic-segmented-weighted-reduction
+           (get-in artifact [:provenance :semantic-op])))
+    (is (str/includes? source "get_group_id(2)"))
+    (is (str/includes? source "sub_group_reduce_add"))
+    (is (str/includes? source "sub_group_broadcast"))
+    (is (str/includes? source "intel_reqd_sub_group_size(16)"))
+    (is (= 1 (count (re-seq #"for \(long x" source)))
+        "one score loop is shared across the component tile")))
+
+(deftest score-reuse-decline-falls-through-to-reference
+  (let [{:keys [leaf strategy]}
+        (swr-route/route-dynamic!
+         (plan) {:device-type :gpu
+                 :subgroup-size 16
+                 :max-workgroup-size 0
+                 :segmented-weighted-reduction-schedule :subgroup-score-reuse})]
+    (is (= :indexed-edge-list-reference leaf))
+    (is (= :indexed-segmented-reduction-reference strategy))))
+
+(deftest generic-router-keeps-reference-default-without-a-measured-selection
+  (let [{:keys [leaf strategy]}
+        (swr-route/route-dynamic!
+         (plan) {:device-type :gpu :subgroup-size 16 :max-workgroup-size 256})]
+    (is (= :indexed-edge-list-reference leaf))
+    (is (= :indexed-segmented-reduction-reference strategy))))
+
+(deftest score-reuse-source-is-valid-opencl
+  (let [clang? (zero? (:exit (shell/sh "sh" "-c" "command -v clang")))]
+    (if-not clang?
+      (is true "clang unavailable")
+      (let [source (get-in
+                    (swr-route/route-dynamic!
+                     (plan) {:device-type :gpu
+                             :subgroup-size 16
+                             :max-workgroup-size 256
+                             :segmented-weighted-reduction-schedule :subgroup-score-reuse})
+                    [:artifact :source])
+            result (shell/sh "clang" "-x" "cl" "-cl-std=CL2.0"
+                             "-fsyntax-only" "-" :in source)]
+        (is (zero? (:exit result)) (:err result))))))
 
 (deftest route-declines-unproved-semantics-and-unresolved-shapes
   (testing "a different scalar region cannot silently enter the specialized leaf"

--- a/test/raster/gpu/indexed_attention_device_test.clj
+++ b/test/raster/gpu/indexed_attention_device_test.clj
@@ -1,7 +1,7 @@
 (ns raster.gpu.indexed-attention-device-test
   (:require [clojure.test :refer [deftest is]]
             [raster.compiler.passes.parallel.indexed-attention-recognize :as recognize]
-            [raster.compiler.passes.parallel.indexed-attention-route :as route]
+            [raster.compiler.passes.parallel.segmented-weighted-reduction-route :as route]
             [raster.compiler.reference.segmented-weighted-reduction :as reference]
             [raster.dl.gpu-grad-parity :as gp]
             [raster.gpu.core :as gpu]))
@@ -48,7 +48,10 @@
   (let [{:keys [plan shape-env buffers expected]} (test-case)
         graph (:graph (route/route-dynamic!
                        plan
-                       {:device-type :gpu :subgroup-size 16 :max-workgroup-size 256}))
+                       {:device-type :gpu
+                        :subgroup-size 16
+                        :max-workgroup-size 256
+                        :segmented-weighted-reduction-schedule :subgroup-score-reuse}))
         output-elements (get-in plan [:output :elements])
         scalar-values
         (assoc (into {} (map (fn [[name value]]


### PR DESCRIPTION
## Summary
- emit a generic 3-D subgroup score-reuse leaf for edge-list segmented weighted reductions
- preserve full 1-3D launch geometry through the staged Level Zero ABI path
- keep the reference schedule as the default and select the measured leaf explicitly through the scheduling descriptor
- exercise generated OpenCL, generic routing, fallback, graph metadata, and device correctness

## Measurement
Intel Arc OpenCL host-synchronized medians show a workload-dependent crossover: width 2-128 remains faster on the reference leaf, while width 256 reaches 1.22x at 512 edges and 1.36x at 4096 edges. Maximum observed FP32 difference was 4.33e-7. This is why the leaf is selectable rather than an unconditional default. Both FP32 and FP64 sources compile on the installed Intel OpenCL compiler.

## Tests
- 54 tests, 284 assertions, 0 failures/errors
- real OpenCL result matches the independent plan oracle
- Level Zero device test skipped locally because zeInit reports no usable device