### PR TITLE
Select reduction schedules from runtime shapes

### DIFF
--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -12,6 +12,7 @@
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.passes.parallel.soac-lower]
             [raster.compiler.backend.gpu.segop-opencl :as segop-cl]
@@ -270,7 +271,7 @@
      :dtype         — :double or :float (default :double)
      :min-elements  — minimum elements for GPU (default 4096)
      :compile-spirv? — compile to SPIR-V now (default false)"
-  [form & {:keys [device-id dtype min-elements compile-spirv? scalar-types array-types]
+  [form & {:keys [device-id dtype min-elements compile-spirv? scalar-types array-types schedule]
            :or {device-id :ze:0 dtype :double min-elements 4096
                 compile-spirv? false}}]
   ;; DECLARED types from derive-param-types (opts) override the name-heuristic fallback in the
@@ -281,6 +282,12 @@
         stats (atom {:ze-maps 0 :ze-reduces 0 :ze-compounds 0 :ze-contracts 0
                      :ze-structured-reductions 0 :fallback 0})
         kernels (atom [])
+        dispatches (atom [])
+        target-desc (delay
+                      (try ((requiring-resolve
+                             'raster.compiler.core.hardware/descriptor-for)
+                            device-id)
+                           (catch Throwable _ {:device-type :gpu})))
 
         register-kernel!
         (fn [kernel stat-key]
@@ -296,17 +303,42 @@
             ;; === Proven structured segmented weighted reduction ===
             (swr-fuse/marker? form)
             (let [plan (swr-fuse/marker-plan form dtype)
-                  routed (swr-route/route-dynamic!
-                          plan
-                          (try ((requiring-resolve
-                                 'raster.compiler.core.hardware/descriptor-for)
-                                device-id)
-                               (catch Throwable _ {:device-type :gpu})))
-                  artifact (register-kernel! (:artifact routed) :ze-structured-reductions)]
-              ;; Reuse the generic artifact marker: it already transports an arbitrary ordered
-              ;; pointer/scalar ABI and symbolic 2-D launch through staging and Compiled.
-              (list 'raster.gpu.ze-runtime/invoke-registered-contraction!
-                    (:kernel-name artifact) (vec (:arguments artifact))))
+                  strategy (get-in schedule [:segmented-weighted-reduction :strategy] :reference)]
+              (if (= :auto strategy)
+                (if-let [dispatch0 (swr-route/dynamic-dispatch plan @target-desc schedule)]
+                  (let [artifacts (mapv #(maybe-compile-spirv % compile-spirv? device-id)
+                                        (:alternatives dispatch0))
+                        dispatch (kdispatch/validate! (assoc dispatch0 :alternatives artifacts))]
+                    (swap! stats update :ze-structured-reductions inc)
+                    (swap! kernels into artifacts)
+                    (swap! dispatches conj dispatch)
+                    (list 'raster.gpu.ze-runtime/invoke-registered-contraction-dispatch!
+                          (:id dispatch)
+                          (:kernel-name (kdispatch/default-artifact dispatch))
+                          (vec (:arguments (kdispatch/default-artifact dispatch)))))
+                  (let [routed (swr-route/route-dynamic! plan @target-desc)
+                        artifact (register-kernel! (:artifact routed)
+                                                   :ze-structured-reductions)]
+                    (list 'raster.gpu.ze-runtime/invoke-registered-contraction!
+                          (:kernel-name artifact) (vec (:arguments artifact)))))
+                (let [wanted (case strategy
+                               :reference :indexed-segmented-reduction-reference
+                               :subgroup-score-reuse
+                               :indexed-segmented-reduction-subgroup-score-reuse)
+                      routed-set (swr-route/route-dynamic-candidates! plan @target-desc)
+                      routed (some #(when (= wanted (:strategy %)) %) (:candidates routed-set))
+                      _ (when-not routed
+                          (throw (ex-info "pinned segmented weighted-reduction schedule is unavailable"
+                                          {:reason :segmented-weighted-reduction-pinned-schedule-unavailable
+                                           :requested strategy
+                                           :available (mapv :strategy (:candidates routed-set))
+                                           :declines (:declines routed-set)})))
+                      artifact (register-kernel! (:artifact routed)
+                                                 :ze-structured-reductions)]
+                  ;; A pinned schedule remains a plain single-entry marker. Runtime dispatch is
+                  ;; introduced only by :auto and therefore never overrides an explicit policy.
+                  (list 'raster.gpu.ze-runtime/invoke-registered-contraction!
+                        (:kernel-name artifact) (vec (:arguments artifact))))))
 
             ;; === Compound kernel ===
             (and (seq? form) (= 'raster.compiler/compound-kernel (first form)))
@@ -558,4 +590,5 @@
             :else form))]
     {:form (transform form)
      :stats @stats
-     :kernels @kernels}))
+     :kernels @kernels
+     :dispatches @dispatches}))

--- a/src/raster/compiler/core/hardware.clj
+++ b/src/raster/compiler/core/hardware.clj
@@ -140,6 +140,8 @@
                               (when gpu? (:global-memory-bytes caps))
                               (* 16 1024 1024))
              :balance     (if gpu? 60 40)}
+      (:vendor caps)  (assoc :vendor (:vendor caps))
+      (:arch caps)    (assoc :arch (:arch caps))
       bw-gb           (assoc :bandwidth-bytes-s (* (double bw-gb) 1e9))
       (seq peak-flops) (assoc :peak-flops peak-flops)
       (seq cache)     (assoc :cache cache)

--- a/src/raster/compiler/ir/kernel_dispatch.clj
+++ b/src/raster/compiler/ir/kernel_dispatch.clj
@@ -1,0 +1,147 @@
+(ns raster.compiler.ir.kernel-dispatch
+  "A verified runtime choice among ABI-compatible emitted kernels.
+
+   KernelArtifact remains one entry point. KernelDispatch is the scheduling value above it: every
+   alternative implements the same logical call and differs only in emitted schedule/geometry.
+   Selection is pure data evaluated after symbolic ABI scalars become concrete and before a
+   backend binder sees a KernelCall."
+  (:require [raster.compiler.ir.kernel-artifact :as kart]))
+
+(defrecord KernelDispatch
+           [id
+            alternatives
+            default-strategy
+            selector
+            provenance
+            attributes])
+
+(defn kernel-dispatch?
+  "Recognize dispatches across Typed Clojure child classloaders."
+  [x]
+  (and x (= "raster.compiler.ir.kernel_dispatch.KernelDispatch"
+            (.getName (class x)))))
+
+(defn artifact-strategy
+  [artifact]
+  (get-in (kart/validate! artifact) [:attributes :strategy]))
+
+(defn- strategy-map
+  [alternatives]
+  (into {} (map (juxt artifact-strategy identity)) alternatives))
+
+(defn- validate-selector!
+  [dispatch strategies common-arguments]
+  (let [{:keys [kind argument threshold at-least otherwise]} (:selector dispatch)]
+    (when-not (= :runtime-scalar-threshold kind)
+      (throw (ex-info "kernel dispatch has an unsupported selector"
+                      {:id (:id dispatch) :selector (:selector dispatch)})))
+    (when-not (some #(= argument %) common-arguments)
+      (throw (ex-info "kernel dispatch selector argument is absent from the common ABI values"
+                      {:id (:id dispatch) :argument argument
+                       :arguments common-arguments})))
+    (when-not (and (number? threshold) (pos? (double threshold)))
+      (throw (ex-info "kernel dispatch threshold must be positive"
+                      {:id (:id dispatch) :threshold threshold})))
+    (doseq [[branch strategy] [[:at-least at-least] [:otherwise otherwise]]]
+      (when-not (contains? strategies strategy)
+        (throw (ex-info "kernel dispatch selector names an absent strategy"
+                        {:id (:id dispatch) :branch branch :strategy strategy
+                         :strategies (set (keys strategies))}))))))
+
+(defn validate!
+  "Validate a dispatch and return it unchanged.
+
+   Alternatives must have unique strategy identities and identical target, ABI, compiler argument
+   order, temporaries and effects. Their source and launch geometry may differ—that is the point."
+  [dispatch]
+  (when-not (kernel-dispatch? dispatch)
+    (throw (ex-info "kernel dispatch must be a KernelDispatch value"
+                    {:dispatch dispatch :actual (type dispatch)})))
+  (let [{:keys [id alternatives default-strategy provenance attributes]} dispatch]
+    (when-not (and (string? id) (not-empty id))
+      (throw (ex-info "kernel dispatch requires a non-empty string id" {:id id})))
+    (when-not (and (vector? alternatives) (seq alternatives))
+      (throw (ex-info "kernel dispatch requires an ordered non-empty alternative vector"
+                      {:id id :alternatives alternatives})))
+    (doseq [artifact alternatives] (kart/validate! artifact))
+    (let [strategies (mapv artifact-strategy alternatives)
+          strategy-set (set strategies)
+          common (first alternatives)
+          common-view (select-keys common [:target :abi :arguments :temporaries :effects])]
+      (when-not (every? keyword? strategies)
+        (throw (ex-info "every kernel dispatch alternative requires a keyword :strategy"
+                        {:id id :strategies strategies})))
+      (when-not (= (count strategies) (count strategy-set))
+        (throw (ex-info "kernel dispatch alternative strategies must be unique"
+                        {:id id :strategies strategies})))
+      (doseq [artifact (rest alternatives)]
+        (when-not (= common-view
+                     (select-keys artifact [:target :abi :arguments :temporaries :effects]))
+          (throw (ex-info "kernel dispatch alternatives must share target, ABI and logical effects"
+                          {:id id
+                           :common-kernel (:kernel-name common)
+                           :different-kernel (:kernel-name artifact)}))))
+      (when-not (contains? strategy-set default-strategy)
+        (throw (ex-info "kernel dispatch default strategy is absent"
+                        {:id id :default default-strategy :strategies strategy-set})))
+      (validate-selector! dispatch (strategy-map alternatives) (:arguments common)))
+    (doseq [[field value] [[:provenance provenance] [:attributes attributes]]]
+      (when-not (map? value)
+        (throw (ex-info "kernel dispatch metadata must be maps"
+                        {:id id :field field :value value}))))
+    dispatch))
+
+(defn make
+  [{:keys [id alternatives default-strategy selector provenance attributes]
+    :or {provenance {} attributes {}}}]
+  (validate!
+   (->KernelDispatch id alternatives default-strategy selector provenance attributes)))
+
+(defn artifact
+  "Return the artifact implementing `strategy`, or throw with the legal strategy set."
+  [dispatch strategy]
+  (let [dispatch (validate! dispatch)
+        alternatives (strategy-map (:alternatives dispatch))]
+    (or (get alternatives strategy)
+        (throw (ex-info "kernel dispatch strategy is unavailable"
+                        {:id (:id dispatch) :strategy strategy
+                         :strategies (set (keys alternatives))})))))
+
+(defn default-artifact
+  [dispatch]
+  (let [dispatch (validate! dispatch)]
+    (artifact dispatch (:default-strategy dispatch))))
+
+(defn- runtime-number
+  [value]
+  (if (and (map? value) (contains? value :value)) (:value value) value))
+
+(defn select-artifact
+  "Select an artifact from concrete ABI-ordered values.
+
+   `override` is nil/:auto for data-driven selection or an explicit alternative strategy. The
+   runtime threshold selector is intentionally generic: it knows only a compiler argument and a
+   numeric crossover, not which model operation produced them."
+  ([dispatch runtime-arguments] (select-artifact dispatch runtime-arguments nil))
+  ([dispatch runtime-arguments override]
+   (let [dispatch (validate! dispatch)]
+     (if (and override (not= :auto override))
+       (artifact dispatch override)
+       (let [{:keys [argument threshold at-least otherwise]} (:selector dispatch)
+             common-arguments (:arguments (default-artifact dispatch))
+             indexes (keep-indexed (fn [index value] (when (= argument value) index))
+                                   common-arguments)]
+         (when-not (= 1 (count indexes))
+           (throw (ex-info "kernel dispatch selector argument must have one runtime position"
+                           {:id (:id dispatch) :argument argument
+                            :indexes (vec indexes)})))
+         (when-not (= (count common-arguments) (count runtime-arguments))
+           (throw (ex-info "kernel dispatch runtime argument count mismatch"
+                           {:id (:id dispatch) :expected (count common-arguments)
+                            :actual (count runtime-arguments)})))
+         (let [value (runtime-number (nth runtime-arguments (first indexes)))]
+           (when-not (number? value)
+             (throw (ex-info "kernel dispatch selector requires a numeric runtime scalar"
+                             {:id (:id dispatch) :argument argument :value value})))
+           (artifact dispatch (if (>= (double value) (double threshold))
+                                at-least otherwise))))))))

--- a/src/raster/compiler/passes/parallel/indexed_attention_route.clj
+++ b/src/raster/compiler/passes/parallel/indexed_attention_route.clj
@@ -1,6 +1,7 @@
 (ns raster.compiler.passes.parallel.indexed-attention-route
   "Structured routing for recognized indexed graph-attention plans."
-  (:require [raster.compiler.backend.gpu.indexed-attention :as emit]
+  (:require [clojure.string :as str]
+            [raster.compiler.backend.gpu.indexed-attention :as emit]
             [raster.compiler.ir.segmented-weighted-reduction :as swr]))
 
 (defn- decline
@@ -115,17 +116,20 @@
        (let [{:keys [operands output accumulator-dtype] :as plan} (swr/validate! plan)
              storage-dtypes (mapv :dtype (conj operands output))
              subgroup-size (long (or (:subgroup-size desc) 16))
-             max-workgroup-size (long (or (:max-workgroup-size desc) 256))]
+             max-workgroup-size (long (or (:max-workgroup-size desc) 256))
+             vendor (some-> (:vendor desc) str str/lower-case)
+             matrix-family (get-in desc [:matrix :family])
+             known-non-intel? (and (or vendor matrix-family)
+                                   (not (or (= :dpas matrix-family)
+                                            (and vendor (str/includes? vendor "intel")))))]
          (cond
-           (not= :subgroup-score-reuse
-                 (:segmented-weighted-reduction-schedule desc))
-           (decline plan leaf :score-reuse-not-selected
-                    {:required :subgroup-score-reuse
-                     :selected (:segmented-weighted-reduction-schedule desc)})
-
            (and desc (not= :gpu (:device-type desc)))
            (decline plan leaf :score-reuse-requires-gpu
                     {:device-type (:device-type desc)})
+
+           known-non-intel?
+           (decline plan leaf :score-reuse-requires-intel-subgroup-dialect
+                    {:vendor (:vendor desc) :matrix-family matrix-family})
 
            (not (contains? #{:float :double} accumulator-dtype))
            (decline plan leaf :score-reuse-accumulator-unsupported

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_route.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_route.clj
@@ -4,17 +4,87 @@
    Each leaf proves its own representability from plan descriptors. The router composes decline
    trails and never infers a model-level semantic operation from the source spelling."
   (:require [raster.compiler.ir.segmented-weighted-reduction :as swr]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.passes.parallel.indexed-attention-route :as indexed-leaf]))
 
-(def dynamic-leaves
+(def candidate-leaves
   [{:id :indexed-edge-list-subgroup-score-reuse :route indexed-leaf/route-dynamic-score-reuse}
    {:id :indexed-edge-list-reference :route indexed-leaf/route-dynamic}])
+
+(defn- selected-leaves
+  [desc]
+  (if (= :subgroup-score-reuse (:segmented-weighted-reduction-schedule desc))
+    candidate-leaves
+    [(peek candidate-leaves)]))
+
+(defn route-dynamic-candidates
+  "Return every representable dynamic leaf plus the complete decline trail.
+
+   This is the emission seam for runtime dispatch/autotuning. It enumerates schedules but does not
+   pick one; `route-dynamic` remains the single-artifact policy API."
+  ([plan] (route-dynamic-candidates plan nil))
+  ([plan desc]
+   (let [plan (swr/validate! plan)
+         results (mapv (fn [leaf]
+                         (assoc ((:route leaf) plan desc) :leaf (:id leaf)))
+                       candidate-leaves)]
+     {:operation plan
+      :candidates (filterv :strategy results)
+      :declines (into [] (mapcat :declines) results)})))
+
+(defn route-dynamic-candidates!
+  ([plan] (route-dynamic-candidates! plan nil))
+  ([plan desc]
+   (let [result (route-dynamic-candidates plan desc)]
+     (if (seq (:candidates result))
+       result
+       (throw (ex-info "no executable segmented weighted-reduction kernel candidates"
+                       {:reason :segmented-weighted-reduction-no-kernel-candidates
+                        :route result}))))))
+
+(defn dynamic-dispatch
+  "Package compatible dynamic schedules as runtime-selection IR.
+
+   Returns nil when the target has only one legal leaf; callers then retain that ordinary artifact
+   instead of manufacturing a degenerate dispatch."
+  [plan desc schedule]
+  (let [{:keys [candidates]} (route-dynamic-candidates! plan desc)
+        artifacts (mapv :artifact candidates)
+        by-strategy (into {} (map (juxt :strategy identity)) candidates)
+        reference :indexed-segmented-reduction-reference
+        score-reuse :indexed-segmented-reduction-subgroup-score-reuse
+        subgroup-size (long (or (:subgroup-size desc) 16))
+        multiple (long (get-in schedule
+                               [:segmented-weighted-reduction
+                                :score-reuse-subgroup-multiple]
+                               16))
+        components (get-in plan [:value :components])
+        dispatch-key [(swr/algebra-key plan) subgroup-size multiple]
+        id (format "raster_segmented_weighted_reduction_dispatch_%08x"
+                   (bit-and 0xffffffff (long (hash dispatch-key))))]
+    (when (and (contains? by-strategy reference)
+               (contains? by-strategy score-reuse))
+      (kdispatch/make
+       {:id id
+        :alternatives artifacts
+        :default-strategy reference
+        :selector {:kind :runtime-scalar-threshold
+                   :argument components
+                   :threshold (* subgroup-size multiple)
+                   :at-least score-reuse
+                   :otherwise reference}
+        :provenance {:operation-id (get-in plan [:provenance :operation-id])
+                     :semantic-op (get-in plan [:provenance :semantic-op])
+                     :algebra-plan-id (:id plan)}
+        :attributes {:algebra :segmented-weighted-reduction
+                     :algebra-key (swr/algebra-key plan)
+                     :selection :runtime-shape}}))))
 
 (defn route-dynamic
   ([plan] (route-dynamic plan nil))
   ([plan desc]
    (let [plan (swr/validate! plan)]
-     (loop [[leaf & more] dynamic-leaves
+     (loop [[leaf & more] (selected-leaves desc)
             declines []]
        (if-not leaf
          {:operation plan :strategy nil :reference? false :declines declines}

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -31,6 +31,7 @@
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.backend.jvm.par-simd :as par-simd]
             [raster.compiler.backend.wasm.emit :as wasm-emit]
             [raster.compiler.backend.intrinsics :as ix]
@@ -796,6 +797,20 @@
          (catch Exception e
            (println "Warning: could not register GPU kernels:" (.getMessage e))))))))
 
+(defn- register-gpu-dispatches!
+  "Register pure multi-artifact dispatch values beside their target backend's kernel registry."
+  [dispatches device-id]
+  (when (seq dispatches)
+    (let [ns-sym (if (and device-id (.startsWith (name device-id) "ocl"))
+                   'raster.gpu.ocl-runtime
+                   'raster.gpu.ze-runtime)]
+      (try
+        (require ns-sym)
+        (let [register! (resolve (symbol (str ns-sym) "register-kernel-dispatch!"))]
+          (doseq [dispatch dispatches] (register! dispatch)))
+        (catch Exception e
+          (println "Warning: could not register GPU kernel dispatches:" (.getMessage e)))))))
+
 (defn- pass-gpu-plan
   "GPU execution plan: rewrite BLAS calls to GPU GEMM kernels,
   plan DeviceBuffer allocations for persistent GPU execution.
@@ -882,9 +897,12 @@
                      (vary-meta assoc :scalar-types (:scalar-types opts) :array-types (:array-types opts)))
               result (opencl-pass/opencl-pass form
                                               :device-id target-device
-                                              :dtype (:dtype opts))]
+                                              :dtype (:dtype opts)
+                                              :schedule (:schedule opts))]
           (register-gpu-kernels! (:kernels result) target-device)
-          {:form (:form result) :stats (:stats result) :kernels (:kernels result) :backend :opencl})
+          (register-gpu-dispatches! (:dispatches result) target-device)
+          {:form (:form result) :stats (:stats result)
+           :kernels (:kernels result) :dispatches (:dispatches result) :backend :opencl})
 
         :simd
         (let [clean-form (strip-compound-markers form)
@@ -1190,6 +1208,7 @@
      raster.gpu.ze-runtime/invoke-registered-kernel
      raster.gpu.ze-runtime/invoke-registered-reduction-kernel
      raster.gpu.ze-runtime/invoke-registered-contraction!
+     raster.gpu.ze-runtime/invoke-registered-contraction-dispatch!
      raster.gpu.ze-runtime/invoke-registered-scatter-kernel})
 
 (def ^:private gpu-array-alloc-heads
@@ -1325,6 +1344,7 @@
   ;; alpha-beta bug family) and fewer would bind nil into a size/scalar slot. Each arm returns
   ;; nil on an unexpected arity so the caller rejects it BY NAME (:unparseable-kernel-invoke)
   ;; instead of miscompiling. Emit-site arities: map-void=5, map=6, contraction=3,
+  ;; contraction-dispatch=4,
   ;; scatter=6|7, ordered-reduce=3.
   (let [head (first expr)
         argc (count expr)]
@@ -1347,6 +1367,14 @@
         (let [[_ kname arguments] expr]
           (when (vector? arguments)
             {:kernel-name kname :arguments arguments
+             :convention :contract :returns sym})))
+      (= head 'raster.gpu.ze-runtime/invoke-registered-contraction-dispatch!)
+      ;; Default kernel identity keeps generic extraction/alias analysis on the common ABI. The
+      ;; dispatch id is retained and checked against that default artifact during descriptor build.
+      (when (= 4 argc)
+        (let [[_ dispatch-id default-kernel-name arguments] expr]
+          (when (vector? arguments)
+            {:dispatch-id dispatch-id :kernel-name default-kernel-name :arguments arguments
              :convention :contract :returns sym})))
       (= head 'raster.gpu.ze-runtime/invoke-registered-scatter-kernel)
       ;; (invoke-registered-scatter-kernel kname out src index n [stride]). out is the
@@ -1679,7 +1707,8 @@
         array-params (filterv #(contains? array-param-set %) all-params)
         scalar-params (filterv #(not (contains? array-param-set %)) all-params)
         post-opts (cond-> {:inline? true :simd? false :target-device device-id
-                           :active-params active-params :dtype effective-dtype}
+                           :active-params active-params :dtype effective-dtype
+                           :schedule resolved-schedule}
                     param-env (assoc :param-env param-env)
                     source-ns (assoc :source-ns source-ns)
                     gpu-param-types (assoc :scalar-types (:scalar-types gpu-param-types)
@@ -1728,6 +1757,8 @@
                      'raster.gpu.ocl-runtime
                      'raster.gpu.ze-runtime)
         reg-entry (requiring-resolve (symbol (str runtime-ns) "kernel-registry-entry"))
+        dispatch-entry (requiring-resolve
+                        (symbol (str runtime-ns) "kernel-dispatch-registry-entry"))
         extracted (extract-gpu-program form reg-entry)
         prog (if-let [nr (::non-resident extracted)]
                (if (= on-non-resident :throw)
@@ -1812,8 +1843,21 @@
                          :phase (keyword (str "gpu-step-" i))}
 
                         (= :contract (:convention step))
-                        (let [{:keys [kernel-name arguments]} step
-                              artifact (reg-entry kernel-name)
+                        (let [{:keys [kernel-name dispatch-id arguments]} step
+                              dispatch (when dispatch-id
+                                         (or (dispatch-entry dispatch-id)
+                                             (throw (ex-info "resident contraction dispatch is not registered"
+                                                             {:dispatch-id dispatch-id}))))
+                              dispatch (when dispatch (kdispatch/validate! dispatch))
+                              artifact (if dispatch
+                                         (kdispatch/default-artifact dispatch)
+                                         (reg-entry kernel-name))
+                              _ (when (and dispatch
+                                           (not= kernel-name (:kernel-name artifact)))
+                                  (throw (ex-info "contraction marker default differs from its dispatch"
+                                                  {:dispatch-id dispatch-id
+                                                   :marker-kernel kernel-name
+                                                   :dispatch-kernel (:kernel-name artifact)})))
                               _ (when-not (kart/kernel-artifact? artifact)
                                   (throw (ex-info "resident contraction kernel is not a registered KernelArtifact"
                                                   {:kernel-name kernel-name :entry artifact})))
@@ -1827,6 +1871,8 @@
                                                    :result-slots result-slots})))]
                           {:convention :contract
                            :kernel-name kernel-name
+                           :dispatch-id dispatch-id
+                           :dispatch dispatch
                            :artifact artifact
                            :abi abi
                            :argument-specs

--- a/src/raster/gpu/autotune.clj
+++ b/src/raster/gpu/autotune.clj
@@ -14,7 +14,7 @@
             [clojure.java.io :as io])
   (:import [java.io File]))
 
-(def autotune-version 1)
+(def autotune-version 2)
 
 ;; ================================================================
 ;; Coordinate descent (Inductor) — greedy, one neighbourhood step at a time

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -34,6 +34,7 @@
             [raster.compiler.ir.execution-plan :as execution]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-graph-call :as kgcall]
             [raster.compiler.pipeline :as pl]
@@ -1301,7 +1302,10 @@
                  artifact logical-or-physical-args
                  (rt-resolve device-id "expand-pointer-binding"))
                 logical-or-physical-args)
-              call (kcall/make artifact ordered-args
+              selected-artifact (if-let [dispatch (:dispatch step)]
+                                  (kdispatch/select-artifact dispatch ordered-args)
+                                  artifact)
+              call (kcall/make selected-artifact ordered-args
                                (if (= :reduce convention) {:group-count [1]} {}))
               prepared (bind-call-fn call)]
           (swap! sess assoc-in [:prepared phase] prepared))
@@ -1617,6 +1621,8 @@
          ;; back-compat sugar for a descriptor built before the schedule field, or one hand-assoc'd.
          gemm-precision (or (get-in descriptor [:schedule :precision])
                             (:gemm-precision descriptor) :f16-xmx)
+         reduction-strategy
+         (get-in descriptor [:schedule :segmented-weighted-reduction :strategy] :auto)
          effective-roles (merge (:array-roles descriptor) roles)
          argmap (zipmap all-params args)
          dt (if (= dtype :double) :double :float)
@@ -1819,7 +1825,11 @@
                         artifact logical-or-physical-args
                         (rt-resolve device-id "expand-pointer-binding"))
                        logical-or-physical-args)
-                     call (kcall/make artifact ordered-args
+                     selected-artifact (if-let [dispatch (:dispatch step)]
+                                         (kdispatch/select-artifact
+                                          dispatch ordered-args reduction-strategy)
+                                         artifact)
+                     call (kcall/make selected-artifact ordered-args
                                       (if (= :reduce convention) {:group-count [1]} {}))]
                  [(assoc (bind-call-fn call) :phase (:phase step))])
                ;; scatter-add: out[index[e]*stride+d] += src[e*stride+d]. Expands to TWO bound

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -23,6 +23,7 @@
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-launch :as klaunch]))
 
 ;; ================================================================
@@ -239,6 +240,10 @@
 (def kernel-registry
   "Global registry mapping kernel-name → kernel info.
   Same structure as raster.gpu.ze-runtime/kernel-registry."
+  (atom {}))
+
+(def kernel-dispatch-registry
+  "Pure compiler dispatch values keyed independently of single-entry native kernels."
   (atom {}))
 
 (def ^:dynamic *current-arena*
@@ -758,7 +763,11 @@
           ;; Host segments are arena-allocated, no explicit free needed
           nil)))
     ;; Remove from registry
-    (swap! kernel-registry #(reduce dissoc % (map first arena-kernels)))))
+    (swap! kernel-registry #(reduce dissoc % (map first arena-kernels)))
+    (swap! kernel-dispatch-registry
+           (fn [dispatches]
+             (into {} (remove (fn [[_ dispatch]] (= arena-id (:arena-id dispatch))))
+                   dispatches)))))
 
 ;; ================================================================
 ;; Kernel registration and compilation
@@ -774,6 +783,18 @@
          info (cond-> kernel-info
                 arena-id (assoc :arena-id arena-id))]
      (swap! kernel-registry assoc kernel-name info))))
+
+(defn register-kernel-dispatch!
+  ([dispatch] (register-kernel-dispatch! dispatch *current-arena*))
+  ([dispatch arena-id]
+   (let [dispatch (cond-> (kdispatch/validate! dispatch)
+                    arena-id (assoc :arena-id arena-id))]
+     (swap! kernel-dispatch-registry assoc (:id dispatch) dispatch)
+     dispatch)))
+
+(defn kernel-dispatch-registry-entry
+  [dispatch-id]
+  (get @kernel-dispatch-registry dispatch-id))
 
 (defn- compile-program!
   "Compile OpenCL C source to a cl_program. Returns the program handle."
@@ -1488,4 +1509,5 @@
                         :queue nil :arena nil :device-name nil :unified-memory? false
                         :buffer-offset-alignment nil
                         :programs {} :kernels {}})
-  (clojure.core/reset! kernel-registry {}))
+  (clojure.core/reset! kernel-registry {})
+  (clojure.core/reset! kernel-dispatch-registry {}))

--- a/src/raster/gpu/schedule.clj
+++ b/src/raster/gpu/schedule.clj
@@ -58,6 +58,11 @@
     ;; fusion / cross-layer-resident schedule flips operands to :resident. The graph-level extension
     ;; for stationary LLMs (operand resident across the recorded decode sequence) lives here.
     :residency {:a :dram :b :dram :c :dram}
+    ;; Dynamic structured reductions keep their extents in the ABI. :auto emits compatible
+    ;; schedules once and selects after those scalar values become concrete. The subgroup multiple
+    ;; is the analytic crossover seed; measurement/autotuning may override it per machine.
+    :segmented-weighted-reduction {:strategy :auto
+                                   :score-reuse-subgroup-multiple 16}
     :meta  {:target (:device-id desc)
             :machine-params (machine-params desc)
             :derived-by :raster.gpu.schedule/derive-default
@@ -78,6 +83,8 @@
 (def ^:private valid-precisions #{:f16-xmx :f32-scalar})
 (def ^:private valid-stage-spaces #{:none :slm :l3 :register})
 (def ^:private valid-grf-modes #{:grf128 :grf256})
+(def ^:private valid-segmented-reduction-strategies
+  #{:auto :reference :subgroup-score-reuse})
 
 (defn resolve
   "Stage 2: deep-merge a user `override` schedule onto the derived default, recording the pinned
@@ -177,7 +184,10 @@
   ;; bind (the #{:f16-xmx :f32-scalar} kwarg check upstream only sees the sugar, not a :schedule).
   (let [prec  (:precision schedule)
         space (get-in schedule [:stage :space] :none)
-        grf   (get-in schedule [:grf :mode] :grf128)]
+        grf   (get-in schedule [:grf :mode] :grf128)
+        reduction-strategy (get-in schedule [:segmented-weighted-reduction :strategy] :auto)
+        score-reuse-multiple
+        (get-in schedule [:segmented-weighted-reduction :score-reuse-subgroup-multiple] 16)]
     (when-not (valid-precisions prec)
       (throw (ex-info (str "schedule: unknown :precision " (pr-str prec) " — expected " valid-precisions)
                       {:precision prec})))
@@ -186,7 +196,14 @@
                       {:space space})))
     (when-not (valid-grf-modes grf)
       (throw (ex-info (str "schedule: unknown :grf :mode " (pr-str grf) " — expected " valid-grf-modes)
-                      {:grf grf}))))
+                      {:grf grf})))
+    (when-not (valid-segmented-reduction-strategies reduction-strategy)
+      (throw (ex-info "schedule: unknown segmented weighted-reduction strategy"
+                      {:strategy reduction-strategy
+                       :expected valid-segmented-reduction-strategies})))
+    (when-not (and (integer? score-reuse-multiple) (pos? score-reuse-multiple))
+      (throw (ex-info "schedule: score-reuse subgroup multiple must be a positive integer"
+                      {:score-reuse-subgroup-multiple score-reuse-multiple}))))
   (let [budget (grf-budget-bytes-per-lane schedule desc)
         acc    (acc-bytes-per-lane schedule)
         staged (register-staged-bytes-per-lane schedule)

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -36,6 +36,7 @@
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-launch :as klaunch]))
 
 ;; ================================================================
@@ -1712,6 +1713,10 @@
   Populated by the pipeline before eval and consumed by the registered ABI binders."
   (atom {}))
 
+(def kernel-dispatch-registry
+  "Pure compiler dispatch values keyed independently of single-entry native kernels."
+  (atom {}))
+
 ;; ----------------------------------------------------------------
 ;; Arena-scoped kernel lifetime management
 ;; ----------------------------------------------------------------
@@ -1738,7 +1743,11 @@
       (doseq [[k v] info]
         (when (instance? MemorySegment v)
           (try (free! v) (catch Exception _)))))
-    (swap! kernel-registry #(reduce dissoc % (map first arena-kernels))))
+    (swap! kernel-registry #(reduce dissoc % (map first arena-kernels)))
+    (swap! kernel-dispatch-registry
+           (fn [dispatches]
+             (into {} (remove (fn [[_ dispatch]] (= arena-id (:arena-id dispatch))))
+                   dispatches))))
   nil)
 
 (defmacro with-gpu-computation
@@ -1802,6 +1811,18 @@
    …). Used by the resident GPU-program binder to map kernel params → resident buffers."
   [kernel-name]
   (get @kernel-registry kernel-name))
+
+(defn register-kernel-dispatch!
+  ([dispatch] (register-kernel-dispatch! dispatch *current-arena*))
+  ([dispatch arena-id]
+   (let [dispatch (cond-> (kdispatch/validate! dispatch)
+                    arena-id (assoc :arena-id arena-id))]
+     (swap! kernel-dispatch-registry assoc (:id dispatch) dispatch)
+     dispatch)))
+
+(defn kernel-dispatch-registry-entry
+  [dispatch-id]
+  (get @kernel-dispatch-registry dispatch-id))
 
 (defn- registered-1d-workgroup-size
   "Read a 1-D workgroup from the canonical artifact launch contract, or from the remaining plain
@@ -3552,6 +3573,26 @@
       (readback-operand! out-seg out out-elems out-half? out-esize))
     out))
 
+(defn invoke-registered-contraction-dispatch!
+  "Select one ABI-compatible contraction artifact from concrete scalar values, then use the
+   ordinary artifact staging path. `default-kernel-name` is compiler-carried redundancy checked
+   against the registered dispatch; it lets resident extraction inspect the common ABI without
+   interpreting dispatch internals."
+  [^String dispatch-id ^String default-kernel-name arguments]
+  (let [dispatch (or (get @kernel-dispatch-registry dispatch-id)
+                     (throw (ex-info "Kernel dispatch not registered"
+                                     {:dispatch-id dispatch-id
+                                      :registered (keys @kernel-dispatch-registry)})))
+        dispatch (kdispatch/validate! dispatch)
+        expected-default (:kernel-name (kdispatch/default-artifact dispatch))
+        _ (when-not (= expected-default default-kernel-name)
+            (throw (ex-info "contraction dispatch marker default differs from its registry"
+                            {:dispatch-id dispatch-id
+                             :expected expected-default
+                             :actual default-kernel-name})))
+        selected (kdispatch/select-artifact dispatch arguments)]
+    (invoke-registered-contraction! (:kernel-name selected) arguments)))
+
 (defn invoke-gpu-transpose!
   "Transpose matrix on GPU via registered kernel. Zero CPU↔GPU copies.
   in-buf: DeviceBuffer [rows x cols] row-major
@@ -3680,6 +3721,7 @@
         (when (instance? MemorySegment v)
           (try (free! v) (catch Exception _)))))
     (clojure.core/reset! kernel-registry {})
+    (clojure.core/reset! kernel-dispatch-registry {})
     (doseq [[_ k] (:kernels @state)]
       (try (.invokeWithArguments ^MethodHandle @h-zeKernelDestroy
                                  ^java.util.List (java.util.List/of (object-array [k])))

--- a/test/raster/compiler/contraction_marker_abi_test.clj
+++ b/test/raster/compiler/contraction_marker_abi_test.clj
@@ -6,6 +6,7 @@
             [raster.compiler.backend.gpu.opencl-pass :as op]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.passes.parallel.contract-route :as route]
             [raster.compiler.passes.parallel.par-fusion :as fusion]
@@ -140,6 +141,46 @@
       (ze/launch-geometry! :kernel [64 1 1] [2 3 4] [:a :b]))
     (is (= [[:bind :kernel [64 1 1] [:a :b]]
             [:launch :bound [2 3 4]]]
+           @seen))))
+
+(deftest staged-dispatch-selects-after-abi-scalars-are-concrete
+  (let [abi [{:name 'A :c-name "A" :kind :input :dtype :float :kernel-dtype :float}
+             {:name 'C :c-name "C" :kind :output :dtype :float :kernel-dtype :float
+              :role :result}
+             {:name 'width :c-name "width" :kind :scalar :dtype :long :kernel-dtype :long}]
+        make-artifact
+        (fn [kernel-name strategy]
+          (kart/make
+           {:kernel-name kernel-name
+            :source (str "__kernel void " kernel-name
+                         "(__global float* A, __global float* C, long width) {}")
+            :abi abi
+            :arguments '[A C width]
+            :launch (klaunch/spec {:workgroup-size [1] :group-count [1]})
+            :effects {:kind :probe}
+            :attributes {:strategy strategy}}))
+        reference (make-artifact "staged_dispatch_reference" :reference)
+        subgroup (make-artifact "staged_dispatch_subgroup" :subgroup)
+        dispatch (kdispatch/make
+                  {:id "staged_dispatch_probe"
+                   :alternatives [reference subgroup]
+                   :default-strategy :reference
+                   :selector {:kind :runtime-scalar-threshold
+                              :argument 'width :threshold 256
+                              :at-least :subgroup :otherwise :reference}})
+        seen (atom [])]
+    (doseq [artifact [reference subgroup]]
+      (ze/register-kernel! (:kernel-name artifact) artifact))
+    (ze/register-kernel-dispatch! dispatch)
+    (with-redefs [ze/invoke-registered-contraction!
+                  (fn [kernel-name arguments]
+                    (swap! seen conj [kernel-name arguments]))]
+      (ze/invoke-registered-contraction-dispatch!
+       (:id dispatch) (:kernel-name reference) [:a :c 128])
+      (ze/invoke-registered-contraction-dispatch!
+       (:id dispatch) (:kernel-name reference) [:a :c 256]))
+    (is (= [["staged_dispatch_reference" [:a :c 128]]
+            ["staged_dispatch_subgroup" [:a :c 256]]]
            @seen))))
 
 (deftest resident-binders-validate-ordered-values-before-touching-a-driver

--- a/test/raster/compiler/ir/kernel_dispatch_test.clj
+++ b/test/raster/compiler/ir/kernel_dispatch_test.clj
@@ -1,0 +1,107 @@
+(ns raster.compiler.ir.kernel-dispatch-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.gpu.core :as gpu]
+            [raster.gpu.ocl-runtime :as ocl]
+            [raster.gpu.ze-runtime :as ze]))
+
+(def ^:private abi
+  [(kabi/slot 'x :input :float :role :operand)
+   (kabi/slot 'out :output :float :role :result)
+   (kabi/slot 'width :scalar :long :role :shape)])
+
+(defn- artifact
+  [name strategy workgroup]
+  (kart/make
+   {:kernel-name name
+    :source (str "__kernel void " name
+                 "(__global const float* x, __global float* out, long width) {}")
+    :abi abi
+    :arguments '[x out width]
+    :launch (klaunch/spec {:workgroup-size [workgroup]
+                           :group-count [(klaunch/ceil-div 'width workgroup)]})
+    :effects {:kind :map :reads ['x] :writes ['out]}
+    :attributes {:strategy strategy}}))
+
+(def ^:private reference
+  (artifact "dispatch_reference" :reference 64))
+
+(def ^:private subgroup
+  (artifact "dispatch_subgroup" :subgroup-score-reuse 16))
+
+(def ^:private dispatch
+  (kdispatch/make
+   {:id "dispatch-test"
+    :alternatives [reference subgroup]
+    :default-strategy :reference
+    :selector {:kind :runtime-scalar-threshold
+               :argument 'width
+               :threshold 256
+               :at-least :subgroup-score-reuse
+               :otherwise :reference}}))
+
+(deftest runtime-scalars-select-an-abi-compatible-artifact
+  (is (kdispatch/kernel-dispatch? dispatch))
+  (is (= "dispatch_reference"
+         (:kernel-name (kdispatch/select-artifact dispatch [:x :out {:type :long :value 128}]))))
+  (is (= "dispatch_subgroup"
+         (:kernel-name (kdispatch/select-artifact dispatch [:x :out {:type :long :value 256}]))))
+  (is (= "dispatch_subgroup"
+         (:kernel-name (kdispatch/select-artifact dispatch [:x :out {:type :long :value 2}]
+                                                  :subgroup-score-reuse)))
+      "an explicit schedule override is authoritative"))
+
+(deftest dispatch-rejects-incompatible-or-ambiguous-alternatives
+  (testing "an alternative cannot silently change the ordered ABI"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"share target, ABI"
+         (kdispatch/make
+          {:id "bad-abi"
+           :alternatives [reference (assoc subgroup :arguments '[out x width])]
+           :default-strategy :reference
+           :selector (:selector dispatch)}))))
+  (testing "strategy identity is unique"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"strategies must be unique"
+         (kdispatch/make
+          {:id "duplicate"
+           :alternatives [reference (assoc subgroup :attributes {:strategy :reference})]
+           :default-strategy :reference
+           :selector (:selector dispatch)})))))
+
+(deftest both-resident-backends-register-the-same-pure-dispatch
+  (doseq [[register! entry] [[ze/register-kernel-dispatch!
+                              ze/kernel-dispatch-registry-entry]
+                             [ocl/register-kernel-dispatch!
+                              ocl/kernel-dispatch-registry-entry]]]
+    (register! dispatch)
+    (is (identical? dispatch (entry (:id dispatch))))))
+
+(deftest resident-step-selects-before-the-backend-binder
+  (let [step {:kernel-name (:kernel-name reference)
+              :phase :probe
+              :convention :contract
+              :artifact reference
+              :dispatch dispatch
+              :argument-specs [{:kind :input :sym 'x}
+                               {:kind :output :sym 'out}
+                               {:kind :scalar :type :long
+                                :value-fn (fn [args] (:width args))}]}
+        selected
+        (fn [width]
+          (let [session (atom {:device-id :probe
+                               :buffers {'x :resident-x 'out :resident-out}})]
+            (with-redefs-fn
+              {#'raster.gpu.core/rt-resolve
+               (fn [_ function-name]
+                 (case function-name
+                   "bind-kernel-call" identity
+                   (throw (ex-info "unexpected runtime resolution"
+                                   {:function function-name}))))}
+              #(gpu/bind-step! session step {:width width} identity))
+            (get-in @session [:prepared :probe :artifact :attributes :strategy])))]
+    (is (= :reference (selected 128)))
+    (is (= :subgroup-score-reuse (selected 256)))))

--- a/test/raster/compiler/passes/parallel/indexed_attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/indexed_attention_route_test.clj
@@ -150,6 +150,16 @@
     (is (= :indexed-edge-list-reference leaf))
     (is (= :indexed-segmented-reduction-reference strategy))))
 
+(deftest intel-subgroup-source-is-not-offered-to-a-known-different-vendor
+  (let [{:keys [candidates declines]}
+        (swr-route/route-dynamic-candidates
+         (plan) {:device-type :gpu :vendor "Advanced Micro Devices"
+                 :subgroup-size 64 :max-workgroup-size 1024})]
+    (is (= [:indexed-segmented-reduction-reference]
+           (mapv :strategy candidates)))
+    (is (= :score-reuse-requires-intel-subgroup-dialect
+           (:reason (first declines))))))
+
 (deftest generic-router-keeps-reference-default-without-a-measured-selection
   (let [{:keys [leaf strategy]}
         (swr-route/route-dynamic!

--- a/test/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse_test.clj
+++ b/test/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is]]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-fuse :as fuse]
             [raster.compiler.pipeline :as pipeline]
             [raster.core :refer [deftm]]
@@ -112,10 +113,18 @@
                   {:type type :value (value-fn args)}
                   (Object.)))
               (:argument-specs step))
+        wide-args (assoc args 7 512)
+        wide-call-arguments
+        (mapv (fn [{:keys [kind type value-fn]}]
+                (if (= :scalar kind)
+                  {:type type :value (value-fn wide-args)}
+                  (Object.)))
+              (:argument-specs step))
         call (kcall/make (:artifact step) call-arguments)]
     (is (= 1 (count (:steps descriptor))))
     (is (= 1 (count (:allocs descriptor))))
     (is (= :contract (:convention step)))
+    (is (kdispatch/kernel-dispatch? (:dispatch step)))
     (is (kart/kernel-artifact? (:artifact step)))
     (is (= :indexed-segmented-reduction-reference
            (get-in step [:artifact :attributes :strategy])))
@@ -124,7 +133,26 @@
             :scalar :scalar :scalar :scalar :scalar :scalar]
            (mapv (comp :kind :slot) (:argument-specs step))))
     (is (= [1 3] (get-in call [:geometry :group-count])))
+    (is (= :indexed-segmented-reduction-reference
+           (kdispatch/artifact-strategy
+            (kdispatch/select-artifact (:dispatch step) call-arguments))))
+    (is (= :indexed-segmented-reduction-subgroup-score-reuse
+           (kdispatch/artifact-strategy
+            (kdispatch/select-artifact (:dispatch step) wide-call-arguments))))
     (is (= (:sym (first (:allocs descriptor))) (:result-sym descriptor)))))
+
+(deftest compiler-schedule-can-pin-either-dispatch-alternative
+  (doseq [[requested emitted]
+          [[:reference :indexed-segmented-reduction-reference]
+           [:subgroup-score-reuse
+            :indexed-segmented-reduction-subgroup-score-reuse]]]
+    (let [descriptor
+          (pipeline/compile-gpu-program
+           #'resident-structured-reduction-probe :ze:0 :dtype :float
+           :schedule {:segmented-weighted-reduction {:strategy requested}})
+          step (first (:steps descriptor))]
+      (is (nil? (:dispatch step)))
+      (is (= emitted (get-in step [:artifact :attributes :strategy]))))))
 
 (deftest actual-gsdm-region-reaches-generic-structured-reduction-stage
   (let [diagnostic (pipeline/show-pipeline

--- a/test/raster/gpu/indexed_attention_device_test.clj
+++ b/test/raster/gpu/indexed_attention_device_test.clj
@@ -1,10 +1,14 @@
 (ns raster.gpu.indexed-attention-device-test
   (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.pipeline :as pipeline]
             [raster.compiler.passes.parallel.indexed-attention-recognize :as recognize]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-route :as route]
             [raster.compiler.reference.segmented-weighted-reduction :as reference]
+            [raster.core :refer [deftm]]
+            [raster.dl.array-ops :as array-ops]
             [raster.dl.gpu-grad-parity :as gp]
-            [raster.gpu.core :as gpu]))
+            [raster.gpu.core :as gpu]
+            [raster.numeric]))
 
 (def ^:private opencl-available?
   (delay
@@ -28,6 +32,23 @@
           normalized (raster.dl.array-ops/segment-div
                       weighted denominator n-nodes emb-dim n-heads 1.0e-6)]
          normalized))
+
+(deftm resident-indexed-attention-probe
+  [Q :- (Array float) K :- (Array float) V :- (Array float)
+   dst :- (Array long) src :- (Array long)
+   n-nodes :- Long n-edges :- Long emb-dim :- Long n-heads :- Long]
+  :- (Array float)
+  (let [dk (quot emb-dim n-heads)
+        raw (array-ops/indexed-dot
+             Q K dst src n-nodes n-nodes n-edges dk emb-dim n-heads)
+        weights (array-ops/scale-clamp-exp
+                 raw (/ 1.0 (raster.numeric/sqrt dk)) 5.0 (* n-edges n-heads))
+        denominator (array-ops/scatter-add weights dst n-nodes n-edges n-heads)
+        weighted (array-ops/scatter-mul-add
+                  weights V dst src n-nodes n-nodes n-edges dk emb-dim n-heads)
+        normalized (array-ops/segment-div
+                    weighted denominator n-nodes emb-dim n-heads 1.0e-6)]
+    normalized))
 
 (defn- test-case
   []
@@ -95,3 +116,50 @@
   (if-not @opencl-available?
     (is true "OpenCL device unavailable")
     (run-case :ocl:0)))
+
+(defn- production-case
+  [descriptor total-dim]
+  (let [entities 3
+        edges 4
+        heads 2
+        components (quot total-dim heads)
+        elements (* entities total-dim)
+        values (fn [offset]
+                 (float-array
+                  (map (fn [i]
+                         (float (* 0.01 (- (mod (+ i offset) 17) 8))))
+                       (range elements))))
+        q (values 0)
+        k (values 3)
+        v (values 7)
+        dst (long-array [0 0 2 2])
+        src (long-array [1 1 0 2])
+        args [q k v dst src entities edges total-dim heads]
+        shape-env {'n-nodes entities 'n-edges edges 'emb-dim total-dim
+                   'n-heads heads 'dk components}
+        plan (first (recognize/recognize (chain) :dtype :float
+                                         :accumulator-dtype :float))
+        expected (reference/evaluate
+                  plan {:buffers {'Q q 'K k 'V v 'dst dst 'src src}
+                        :scalars shape-env})]
+    (gpu/with-gpu-session [session :ocl:0]
+      (let [handle (gpu/bind-program! session descriptor args)
+            selected (get-in @session [:programs :program :bounds 0
+                                       :kernel-call :artifact :attributes :strategy])
+            result (get (gpu/run-program! session handle args) (:result-sym descriptor))
+            max-error (reduce max 0.0
+                              (map #(Math/abs (- (double %1) (double %2)))
+                                   expected result))]
+        {:selected selected :max-error max-error}))))
+
+(deftest resident-compiler-selects-from-runtime-component-width
+  (if-not @opencl-available?
+    (is true "OpenCL device unavailable")
+    (let [descriptor (pipeline/compile-gpu-program
+                      #'resident-indexed-attention-probe :ocl:0 :dtype :float)
+          small (production-case descriptor 4)
+          wide (production-case descriptor 512)]
+      (is (= :indexed-segmented-reduction-reference (:selected small)))
+      (is (= :indexed-segmented-reduction-subgroup-score-reuse (:selected wide)))
+      (is (< (:max-error small) 2.0e-5))
+      (is (< (:max-error wide) 2.0e-5)))))

--- a/test/raster/gpu/schedule_test.clj
+++ b/test/raster/gpu/schedule_test.clj
@@ -52,6 +52,9 @@
           "sugar and explicit override produce byte-identical schedules"))
     (testing "the default policy is f16-xmx (training AMP)"
       (is (= :f16-xmx (:precision derived))))
+    (testing "dynamic segmented reductions default to runtime shape selection"
+      (is (= {:strategy :auto :score-reuse-subgroup-multiple 16}
+             (:segmented-weighted-reduction derived))))
     (testing "a pinned override is recorded in :meta :overrides"
       (is (contains? (get-in (sched/resolve derived {:precision :f32-scalar}) [:meta :overrides])
                      :precision)))))
@@ -117,6 +120,19 @@
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"unknown :stage :space"
                           (sched/feasible? (sched/resolve (sched/derive-default nil arc-desc)
                                                           {:stage {:space :regsiter}}) arc-desc))))
+  (testing "structured-reduction strategy and crossover are validated as schedule data"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"unknown segmented"
+                          (sched/feasible?
+                           (sched/resolve (sched/derive-default nil arc-desc)
+                                          {:segmented-weighted-reduction {:strategy :guess}})
+                           arc-desc)))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"positive integer"
+                          (sched/feasible?
+                           (sched/resolve
+                            (sched/derive-default nil arc-desc)
+                            {:segmented-weighted-reduction
+                             {:score-reuse-subgroup-multiple 0}})
+                           arc-desc))))
   (testing "conflicting :gemm-precision sugar and :precision throw, not silently prefer the deprecated key"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"conflicting"
                           (sched/resolve (sched/derive-default nil arc-desc)


### PR DESCRIPTION
## Summary
- add a first-class `KernelDispatch` compiler value for ABI-compatible emitted alternatives
- enumerate generic segmented weighted-reduction leaves without embedding attention semantics in selection
- carry dispatches through OpenCL lowering, backend registries, staged calls, resident extraction, and pre-record binding
- select reference vs subgroup score reuse after symbolic component width becomes concrete
- support explicit schedule pinning and collapse to the portable reference on known non-Intel targets

## Policy
The automatic crossover seed is schedule data: `score-reuse-subgroup-multiple` defaults to 16, so subgroup score reuse starts at 16 times the emitted subgroup width. This matches the measured Arc crossover from #127 and is directly overridable/tunable. Existing autotune caches are invalidated by a version bump.

## Tests
- 80 tests, 378 assertions, 0 failures/errors with a writable temporary autotune cache
- pure validation covers incompatible alternatives, registries, staged dispatch, resident pre-binder selection, explicit pins, and vendor fallback
- a two-shape resident OpenCL test proves the same descriptor selects both sides and matches the independent oracle when a device is available
- `/dev/dri` is unavailable in the current sandbox, so live device tests took their explicit skip path; the emitted subgroup kernel was device-validated in #127