### PR TITLE
Measure kernel graphs with device events

### DIFF
--- a/src/raster/gpu/compiled.clj
+++ b/src/raster/gpu/compiled.clj
@@ -286,6 +286,16 @@
   [^Compiled c]
   (gpu/profile-program! (:session c) (:handle c) (:args c)))
 
+(defn measure
+  "Explicit offline device-event measurement of a Compiled artifact.
+
+   The artifact must have been compiled with {:profile? true}. Returns a stable Measurement;
+   options are those of gpu/measure-program!, including the required :before-sample! restore hook
+   for stateful programs. This does not choose or cache a schedule by itself."
+  [^Compiled c & {:as opts}]
+  (apply gpu/measure-program! (:session c) (:handle c) (:args c)
+         (mapcat identity opts)))
+
 (defn cache-key
   "The serializable identity of the artifact minus closures (§2b C5): in/out trees, donation,
    schedule, target, and the descriptor's step kinds + concrete shapes. Excludes the non-

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -38,7 +38,8 @@
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-graph-call :as kgcall]
             [raster.compiler.pipeline :as pl]
-            [raster.core :as rcore]))
+            [raster.core :as rcore]
+            [raster.gpu.measurement :as measurement]))
 
 ;; ================================================================
 ;; Backend dispatch
@@ -1581,11 +1582,10 @@
                      differently-named params (rename both onto one key + :reuse-buffers), or
                      keep two same-named params separate (rename one away from the collision).
                      run-program!/upload!/download address the renamed buffer by the new key.
-     :profile?       record the graph in PROFILING mode: a kernel-timestamp device event per
-                     launch (Level-Zero only). profile-program! then returns per-kernel device
-                     times. Opt-in: without it the recorded graph is exactly the fast path
-                     (no events, no overhead); run-program! on a profiled program still works
-                     (it resets the events after each replay).
+     :profile?       record the graph in PROFILING mode: a device-timestamp event per launch.
+                     Level Zero and OpenCL expose the same profile-program! contract. Opt-in:
+                     without it the recorded graph is exactly the fast path (no profiling queue,
+                     events, or overhead); run-program! on a profiled program still works.
 
    :gemm steps bind per the resolved S6 schedule's precision — [:schedule :precision] (set at
    compile time by compile-gpu-program, default :f16-xmx). :gemm-precision on the descriptor is a
@@ -2017,9 +2017,9 @@
                                   ;; (includes inter-kernel gaps = dispatch/barrier overhead)
       :host-wall-ms    double}    ;; System/nanoTime around the replay call, for comparison
 
-   Device kernel times come from Level-Zero kernel-timestamp events (immune to host scheduling
-   and far more stable under platform power-state swings than host wall time). Throws if the
-   program was not bound with {:profile? true}."
+   Device kernel times come from backend timestamp events (Level Zero or OpenCL), immune to host
+   scheduling and far more stable under platform power-state swings than host wall time. Throws
+   if the program was not bound with {:profile? true}."
   [sess prog-or-handle args]
   (let [{:keys [descriptor roles graph param->key result-key profile?]}
         (resolve-program sess prog-or-handle)
@@ -2047,6 +2047,62 @@
        :kernel-total-ms (reduce + 0.0 (map :ms (:kernels prof)))
        :device-wall-ms (:wall-ms prof)
        :host-wall-ms (/ (- t1 t0) 1.0e6)})))
+
+(defn measure-graph!
+  "Repeatedly measure a PROFILING runtime graph with backend device events.
+
+   This is the backend-neutral autotune ruler. It delegates sampling discipline and the stable
+   Measurement value to raster.gpu.measurement, while the selected runtime supplies replay and
+   timestamp conversion. It never falls back to host wall time.
+
+   `:before-sample!`, when supplied, runs before EVERY replay (including warmup/probe) and is the
+   explicit restore seam for stateful candidates. Other options are forwarded to
+   measurement/measure!, including :budget-ms, :warmup-iterations, :flush-fn, :cold-warm,
+   :compile-ms, and :hashes."
+  [sess graph & {:keys [before-sample!] :as opts}]
+  (let [device-id (:device-id @sess)
+        replay-fn (rt-resolve device-id "replay-graph!")
+        read-ts-fn (rt-resolve device-id "read-graph-timestamps!")
+        sample-fn (fn []
+                    (when before-sample! (before-sample!))
+                    (replay-fn graph)
+                    (let [wall-ms (:wall-ms (read-ts-fn graph))]
+                      (when-not (and (number? wall-ms)
+                                     (Double/isFinite (double wall-ms))
+                                     (not (neg? (double wall-ms))))
+                        (throw (ex-info "device graph profiler returned no finite wall duration"
+                                        {:device-id device-id :wall-ms wall-ms})))
+                      (* 1.0e6 (double wall-ms))))
+        measurement-opts (-> opts
+                             (dissoc :before-sample!)
+                             (assoc :timing-source :device-event))]
+    (apply measurement/measure! sample-fn (mapcat identity measurement-opts))))
+
+(defn measure-program!
+  "Explicit offline device-event measurement of a bound resident program.
+
+   The program must have been bound with {:profile? true}. Inputs upload once before sampling;
+   output downloads are intentionally absent because they are not part of device timing. The
+   autotuner must validate a candidate against its oracle before calling this function.
+
+   A program with a :state resident role requires :before-sample! so repeated timing cannot
+   silently benchmark successively mutated state. Pure/output-only programs need no restore hook.
+   Returns a raster.gpu.measurement/Measurement."
+  [sess prog-or-handle args & {:keys [before-sample!] :as opts}]
+  (let [{:keys [descriptor roles graph param->key profile?]}
+        (resolve-program sess prog-or-handle)
+        {:keys [all-params array-params]} descriptor
+        argmap (zipmap all-params args)]
+    (when-not profile?
+      (throw (ex-info "measure-program!: program was not bound with {:profile? true}"
+                      {:program (or (::program-key prog-or-handle) :program)})))
+    (when (and (some #(= :state %) (vals roles)) (nil? before-sample!))
+      (throw (ex-info "measure-program!: stateful programs require :before-sample! restoration"
+                      {:state-params (into #{} (keep (fn [[sym role]]
+                                                       (when (= :state role) sym))) roles)})))
+    (doseq [param array-params :when (= :input (get roles param :input))]
+      (upload! sess (get param->key param) (get argmap param)))
+    (apply measure-graph! sess graph (mapcat identity opts))))
 
 (defn sync-to-arrays!
   "Download GPU buffers back into JVM arrays.

--- a/src/raster/gpu/measurement.clj
+++ b/src/raster/gpu/measurement.clj
@@ -1,0 +1,152 @@
+(ns raster.gpu.measurement
+  "Backend-neutral device measurement values and sampling discipline.
+
+   This namespace never launches a kernel and never chooses a schedule. A backend-facing caller
+   supplies `sample-fn`, which must return one DEVICE duration in nanoseconds. Keeping sampling,
+   selection, and execution separate makes autotuning an explicit offline operation and prevents
+   compilation from acquiring hidden device side effects.")
+
+(defrecord Measurement
+           [min-ns
+            median-ns
+            p75-ns
+            mean-ns
+            cv
+            stationary?
+            n
+            warmup-iterations
+            budget-ms
+            cold-warm
+            timing-source
+            compile-ms
+            hashes
+            samples-ns])
+
+(defn measurement?
+  "Recognize measurements across Typed Clojure child classloaders."
+  [x]
+  (and x (= "raster.gpu.measurement.Measurement" (.getName (class x)))))
+
+(defn- finite-nonnegative?
+  [x]
+  (and (number? x)
+       (Double/isFinite (double x))
+       (not (neg? (double x)))))
+
+(defn- percentile
+  "Nearest-rank percentile over an already sorted, non-empty vector."
+  [sorted-samples p]
+  (let [n (count sorted-samples)
+        index (dec (long (Math/ceil (* (double p) n))))]
+    (double (nth sorted-samples (max 0 (min (dec n) index))))))
+
+(defn summarize
+  "Summarize non-empty DEVICE-duration samples (nanoseconds) as a Measurement.
+
+   Options are metadata required to interpret/cache a result. `timing-source` must remain
+   explicit; production autotuning uses `:device-event`, while tests may use `:synthetic`.
+   A result is stationary when population coefficient-of-variation is below `cv-threshold`."
+  [samples-ns & {:keys [cv-threshold warmup-iterations budget-ms cold-warm timing-source
+                        compile-ms hashes]
+                 :or {cv-threshold 0.05
+                      warmup-iterations 0
+                      budget-ms 0
+                      cold-warm :warm
+                      timing-source :device-event
+                      compile-ms 0.0
+                      hashes {}}}]
+  (let [samples (mapv double samples-ns)]
+    (when-not (seq samples)
+      (throw (ex-info "measurement requires at least one device-duration sample" {})))
+    (when-let [invalid (first (remove finite-nonnegative? samples))]
+      (throw (ex-info "measurement samples must be finite, non-negative nanoseconds"
+                      {:sample invalid})))
+    (when-not (and (number? cv-threshold) (not (neg? (double cv-threshold))))
+      (throw (ex-info "measurement cv-threshold must be non-negative"
+                      {:cv-threshold cv-threshold})))
+    (when-not (#{:warm :cold} cold-warm)
+      (throw (ex-info "measurement cold-warm must be :warm or :cold"
+                      {:cold-warm cold-warm})))
+    (when-not (keyword? timing-source)
+      (throw (ex-info "measurement timing-source must be a keyword"
+                      {:timing-source timing-source})))
+    (when-not (map? hashes)
+      (throw (ex-info "measurement hashes must be a map" {:hashes hashes})))
+    (let [n (count samples)
+          sorted (vec (sort samples))
+          mean (/ (reduce + 0.0 samples) (double n))
+          variance (/ (reduce (fn [acc sample]
+                                (let [delta (- sample mean)]
+                                  (+ acc (* delta delta))))
+                              0.0 samples)
+                      (double n))
+          cv (if (pos? mean) (/ (Math/sqrt variance) mean) 0.0)]
+      (->Measurement (first sorted)
+                     (percentile sorted 0.5)
+                     (percentile sorted 0.75)
+                     mean
+                     cv
+                     (<= cv (double cv-threshold))
+                     n
+                     (long warmup-iterations)
+                     (double budget-ms)
+                     cold-warm
+                     timing-source
+                     (double compile-ms)
+                     hashes
+                     samples))))
+
+(defn measure!
+  "Measure an explicit device-sample function under a bounded, do_bench-style discipline.
+
+   `sample-fn` returns one DEVICE duration in nanoseconds; this function never substitutes host
+   wall time. Warmups and five probe samples establish steady state and estimate the iteration
+   count for `budget-ms`. Probe samples are not included in the reported distribution. `flush-fn`,
+   when supplied, runs before every reported sample and owns any synchronization it requires.
+
+   Options: :warmup-iterations (3), :budget-ms (100), :min-samples (3), :max-samples (10000),
+   :cv-threshold (0.05), :flush-fn, :cold-warm, :compile-ms, :hashes, :timing-source."
+  [sample-fn & {:keys [warmup-iterations budget-ms min-samples max-samples cv-threshold flush-fn
+                       cold-warm compile-ms hashes timing-source]
+                :or {warmup-iterations 3
+                     budget-ms 100
+                     min-samples 3
+                     max-samples 10000
+                     cv-threshold 0.05
+                     cold-warm :warm
+                     compile-ms 0.0
+                     hashes {}
+                     timing-source :device-event}}]
+  (doseq [[field value] [[:warmup-iterations warmup-iterations]
+                         [:min-samples min-samples]
+                         [:max-samples max-samples]]]
+    (when-not (and (integer? value) (not (neg? (long value))))
+      (throw (ex-info "measurement iteration bounds must be non-negative integers"
+                      {:field field :value value}))))
+  (when-not (and (number? budget-ms) (pos? (double budget-ms)))
+    (throw (ex-info "measurement budget-ms must be positive" {:budget-ms budget-ms})))
+  (when (or (zero? (long min-samples)) (< (long max-samples) (long min-samples)))
+    (throw (ex-info "measurement requires 0 < min-samples <= max-samples"
+                    {:min-samples min-samples :max-samples max-samples})))
+  (dotimes [_ (long warmup-iterations)]
+    (sample-fn))
+  (let [probe (mapv (fn [_] (double (sample-fn))) (range 5))]
+    (when-let [invalid (first (remove finite-nonnegative? probe))]
+      (throw (ex-info "device sample must be finite, non-negative nanoseconds"
+                      {:sample invalid :phase :probe})))
+    (let [estimate (max 1.0 (/ (reduce + 0.0 probe) (double (count probe))))
+          wanted (long (/ (* (double budget-ms) 1.0e6) estimate))
+          n (max (long min-samples) (min (long max-samples) wanted))
+          samples (mapv (fn [_]
+                          (when flush-fn (flush-fn))
+                          (double (sample-fn)))
+                        (range n))]
+      (summarize samples
+                 :cv-threshold cv-threshold
+                 :warmup-iterations warmup-iterations
+                 :budget-ms budget-ms
+                 :cold-warm cold-warm
+                 :timing-source timing-source
+                 :compile-ms compile-ms
+                 :hashes hashes))))
+

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -102,7 +102,10 @@
 (def ^:private CL_MEM_COPY_HOST_PTR (long 32))
 (def ^:private CL_TRUE (int 1))
 (def ^:private CL_COMPLETE 0)
+(def ^:private CL_QUEUE_PROFILING_ENABLE (long 2))
 (def ^:private CL_EVENT_COMMAND_EXECUTION_STATUS 0x11D3)
+(def ^:private CL_PROFILING_COMMAND_START 0x1282)
+(def ^:private CL_PROFILING_COMMAND_END 0x1283)
 
 ;; clGetDeviceInfo param_name constants
 (def ^:private CL_DEVICE_MAX_COMPUTE_UNITS 0x1002)
@@ -194,6 +197,8 @@
   (delay (make-handle "clWaitForEvents" (fd I32 I32 PTR))))
 (def ^:private h-clGetEventInfo
   (delay (make-handle "clGetEventInfo" (fd I32 PTR I32 I64 PTR PTR))))
+(def ^:private h-clGetEventProfilingInfo
+  (delay (make-handle "clGetEventProfilingInfo" (fd I32 PTR I32 I64 PTR PTR))))
 (def ^:private h-clReleaseEvent
   (delay (make-handle "clReleaseEvent" (fd I32 PTR))))
 
@@ -1346,9 +1351,10 @@
   "Enqueue one pre-bound kernel (no finish)."
   ([bound group-count]
    (enqueue-bound! bound group-count MemorySegment/NULL))
-  ([{:keys [^MemorySegment kernel wg]} group-count event-out]
-   (let [{:keys [queue]} @state
-         arena (Arena/ofConfined)
+  ([bound group-count event-out]
+   (enqueue-bound! bound group-count event-out (:queue @state)))
+  ([{:keys [^MemorySegment kernel wg]} group-count event-out queue]
+   (let [arena (Arena/ofConfined)
          wg (if (vector? wg) wg [(long wg)])
          group-count (if (vector? group-count) group-count [(long group-count)])
          work-dim (count wg)]
@@ -1374,34 +1380,84 @@
 
 (defn record-graph!
   "OpenCL 'graph': capture the ordered pre-bound launches for replay. The
-  in-order queue serializes them (= ze per-kernel barriers)."
+  in-order queue serializes them (= ze per-kernel barriers). Profiling is opt-in: a dedicated
+  CL_QUEUE_PROFILING_ENABLE queue and per-replay events exist only on a profiled graph."
   ([prepareds] (record-graph! prepareds {}))
-  ([prepareds _opts]
-   {:launches (mapv (fn [{:keys [bound group-count]}]
-                      {:bound bound :group-count group-count})
-                    prepareds)}))
+  ([prepareds {:keys [profile?] :or {profile? false}}]
+   (ensure-init!)
+   (let [launches (mapv (fn [{:keys [bound group-count]}]
+                          {:bound bound :group-count group-count})
+                        prepareds)]
+     (if-not profile?
+       {:launches launches}
+       (let [{:keys [context device]} @state
+             arena (Arena/ofConfined)]
+         (try
+           (let [err-seg (.allocate arena I32)
+                 queue (.invokeWithArguments ^MethodHandle @h-clCreateCommandQueue
+                                             (into-array Object
+                                                         [context device
+                                                          CL_QUEUE_PROFILING_ENABLE err-seg]))]
+             (when-not (= CL_SUCCESS (read-int err-seg))
+               (throw (ex-info "clCreateCommandQueue(profile) failed"
+                               {:error (read-int err-seg)})))
+             {:launches launches
+              :profile? true
+              :profile-queue queue
+              :profile-state (atom nil)
+              :kernel-names (mapv #(or (:kernel-name %) "unknown") prepareds)
+              :phases (mapv :phase prepareds)})
+           (finally (.close arena))))))))
+
+(defn- release-native-event!
+  [event]
+  (when (and event (not (.equals ^MemorySegment event MemorySegment/NULL)))
+    (cl-call! "clReleaseEvent" @h-clReleaseEvent [event])))
+
+(defn- clear-profile-state!
+  [graph]
+  (when-let [profile-state (:profile-state graph)]
+    (when-let [{:keys [events ^Arena arena]} @profile-state]
+      (try
+        (doseq [event events] (release-native-event! event))
+        (finally
+          (.close arena)
+          (clojure.core/reset! profile-state nil))))))
 
 (defn submit-graph!
   "Submit an OpenCL graph without waiting. The in-order queue preserves the recorded order and
    the final launch signals a native event held only by this runtime-private token."
   [graph]
-  (let [launches (:launches graph)]
+  (let [launches (:launches graph)
+        profile? (:profile? graph)
+        queue (or (:profile-queue graph) (:queue @state))]
     (if (empty? launches)
       {:complete? true}
       (let [arena (Arena/ofShared)
-            event-out (.allocate arena PTR)
+            event-outs (.allocate arena (* 8 (if profile? (count launches) 1)))
             status-out (.allocate arena I32)]
         (try
+          (when (and profile? @(:profile-state graph))
+            (throw (ex-info "profiled OpenCL graph events must be read or reset before replay"
+                            {})))
           (doseq [[index {:keys [bound group-count]}] (map-indexed vector launches)]
             (enqueue-bound! bound group-count
-                            (if (= index (dec (count launches)))
-                              event-out
-                              MemorySegment/NULL)))
-          (cl-call! "clFlush" @h-clFlush [(:queue @state)])
-          {:event (.get event-out PTR 0)
-           :event-array event-out
-           :status-out status-out
-           :arena arena}
+                            (if (or profile? (= index (dec (count launches))))
+                              (.asSlice event-outs (if profile? (* 8 index) 0) 8)
+                              MemorySegment/NULL)
+                            queue))
+          (cl-call! "clFlush" @h-clFlush [queue])
+          (let [events (when profile?
+                         (mapv #(.get event-outs PTR (* 8 %)) (range (count launches))))
+                final-offset (if profile? (* 8 (dec (count launches))) 0)
+                token {:event (.get event-outs PTR final-offset)
+                       :event-array (.asSlice event-outs final-offset 8)
+                       :status-out status-out
+                       :arena arena
+                       :profile? (boolean profile?)}]
+            (when profile?
+              (clojure.core/reset! (:profile-state graph) {:events events :arena arena}))
+            token)
           (catch Exception e
             (.close arena)
             (throw e)))))))
@@ -1426,12 +1482,16 @@
 
 (defn release-event!
   "Release a runtime-private OpenCL completion token. The caller must establish completion."
-  [{:keys [complete? event ^Arena arena]}]
+  [{:keys [complete? profile? event ^Arena arena]}]
   (when-not complete?
-    (try
-      (cl-call! "clReleaseEvent" @h-clReleaseEvent [event])
-      (finally
-        (.close arena))))
+    ;; A profiled graph retains every event until read-graph-timestamps! (or reset) consumes the
+    ;; sample. The graph owns the shared arena in that interval. Ordinary completion tokens keep
+    ;; the previous immediate-release behavior.
+    (when-not profile?
+      (try
+        (release-native-event! event)
+        (finally
+          (.close arena)))))
   nil)
 
 (defn replay-graph!
@@ -1448,6 +1508,53 @@
   []
   (cl-call! "clFinish" @h-clFinish [(:queue @state)]))
 
+(defn reset-graph-events!
+  "Discard the most recent OpenCL profiling sample and release its native events."
+  [graph]
+  (clear-profile-state! graph)
+  nil)
+
+(defn read-graph-timestamps!
+  "Read and consume one profiled OpenCL graph replay.
+
+   OpenCL event timestamps are nanoseconds in the device time domain. The return shape matches
+   Level Zero's `read-graph-timestamps!`, allowing gpu.core and autotuning to stay backend-neutral."
+  [graph]
+  (when-not (:profile? graph)
+    (throw (ex-info "read-graph-timestamps!: graph was not recorded with :profile? true" {})))
+  (let [profile-state (:profile-state graph)
+        {:keys [events]} @profile-state]
+    (when-not (seq events)
+      (throw (ex-info "read-graph-timestamps!: profiled graph has no completed replay" {})))
+    (let [arena (Arena/ofConfined)]
+      (try
+        (let [value (.allocate arena I64)
+              read-timestamp
+              (fn [event parameter]
+                (cl-call! "clGetEventProfilingInfo" @h-clGetEventProfilingInfo
+                          [event (int parameter) (long 8) value MemorySegment/NULL])
+                (.get value I64 0))
+              rows (mapv (fn [index event]
+                           (let [start (read-timestamp event CL_PROFILING_COMMAND_START)
+                                 end (read-timestamp event CL_PROFILING_COMMAND_END)
+                                 ms (/ (double (- end start)) 1.0e6)]
+                             {:kernel-name (nth (:kernel-names graph) index)
+                              :phase (nth (:phases graph) index)
+                              :ms ms
+                              :context-ms ms
+                              :start-ticks start
+                              :end-ticks end}))
+                         (range (count events)) events)
+              span (when (seq rows)
+                     (- (reduce max (map :end-ticks rows))
+                        (reduce min (map :start-ticks rows))))]
+          {:kernels rows
+           :wall-ms (when span (/ (double span) 1.0e6))
+           :ns-per-tick 1.0})
+        (finally
+          (.close arena)
+          (clear-profile-state! graph))))))
+
 (defn destroy-prepared!
   "Release the dedicated cl_kernel a binding owns."
   [prepared]
@@ -1457,9 +1564,11 @@
          (catch Exception _))))
 
 (defn destroy-graph!
-  "OpenCL graphs hold no driver objects (the launches reference kernels owned
-  by their bindings) — nothing to free."
-  [_graph]
+  "Release profiling-only OpenCL graph resources. Ordinary graphs own no driver objects."
+  [graph]
+  (clear-profile-state! graph)
+  (when-let [queue (:profile-queue graph)]
+    (cl-call! "clReleaseCommandQueue" @h-clReleaseCommandQueue [queue]))
   nil)
 
 (defn bind-registered-gemm!

--- a/test/raster/gpu/measurement_test.clj
+++ b/test/raster/gpu/measurement_test.clj
@@ -1,0 +1,84 @@
+(ns raster.gpu.measurement-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.gpu.core :as gpu]
+            [raster.gpu.measurement :as measurement]))
+
+(deftest summarizes-device-samples
+  (let [m (measurement/summarize [100.0 200.0 300.0 400.0]
+                                 :cv-threshold 1.0
+                                 :warmup-iterations 2
+                                 :budget-ms 25
+                                 :timing-source :synthetic
+                                 :hashes {:artifact "abc"})]
+    (is (measurement/measurement? m))
+    (is (= 100.0 (:min-ns m)))
+    (is (= 200.0 (:median-ns m)) "nearest-rank p50")
+    (is (= 300.0 (:p75-ns m)))
+    (is (= 250.0 (:mean-ns m)))
+    (is (:stationary? m))
+    (is (= 4 (:n m)))
+    (is (= {:artifact "abc"} (:hashes m)))))
+
+(deftest stationarity-is-explicit
+  (is (:stationary? (measurement/summarize [100 101 99] :cv-threshold 0.02)))
+  (is (false? (:stationary? (measurement/summarize [1 100 1] :cv-threshold 0.02)))))
+
+(deftest bounded-device-sampling
+  (let [calls (atom 0)
+        flushes (atom 0)
+        m (measurement/measure! #(do (swap! calls inc) 1000000.0)
+                                :warmup-iterations 2
+                                :budget-ms 4
+                                :min-samples 3
+                                :max-samples 10
+                                :flush-fn #(swap! flushes inc)
+                                :timing-source :synthetic)]
+    (testing "warmup + five probes are excluded from the bounded reported sample set"
+      (is (= 4 (:n m)))
+      (is (= (+ 2 5 4) @calls))
+      (is (= 4 @flushes)))
+    (is (= :synthetic (:timing-source m)))
+    (is (= 1000000.0 (:min-ns m)))))
+
+(deftest rejects-invalid-measurements
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"at least one"
+                        (measurement/summarize [])))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"finite"
+                        (measurement/summarize [Double/POSITIVE_INFINITY])))
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"positive"
+                        (measurement/measure! (constantly 1.0) :budget-ms 0))))
+
+(deftest core-measures-runtime-graphs-with-device-events
+  (let [replays (atom 0)
+        reads (atom 0)
+        session (atom {:device-id :probe})]
+    (with-redefs-fn
+      {#'raster.gpu.core/rt-resolve
+       (fn [_ function-name]
+         (case function-name
+           "replay-graph!" (fn [_] (swap! replays inc))
+           "read-graph-timestamps!" (fn [_]
+                                      (swap! reads inc)
+                                      {:wall-ms 0.001})
+           (throw (ex-info "unexpected runtime function" {:function function-name}))))}
+      #(let [m (gpu/measure-graph! session {:profile? true}
+                                   :warmup-iterations 1
+                                   :budget-ms 3
+                                   :min-samples 3
+                                   :max-samples 3)]
+         (is (= :device-event (:timing-source m)))
+         (is (= 1000.0 (:min-ns m)))
+         (is (= (+ 1 5 3) @replays))
+         (is (= @replays @reads))))))
+
+(deftest stateful-program-measurement-requires-restore
+  (let [descriptor {:all-params [] :array-params []}
+        session (atom {:device-id :probe
+                       :programs {:program {:descriptor descriptor
+                                            :roles {'cache :state}
+                                            :graph {}
+                                            :param->key {}
+                                            :profile? true}}})]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"require :before-sample!"
+                          (gpu/measure-program! session descriptor []
+                                                :budget-ms 1)))))


### PR DESCRIPTION
## Summary

- add a backend-neutral `Measurement` value with bounded warmup/probe/timed sampling, min/median/p75/CV, stationarity, timing provenance, and cache-identity metadata
- expose explicit offline `measure-graph!`, `measure-program!`, and `Compiled/measure` seams that use device timestamps only and require restoration for resident state
- give OpenCL profiling parity with Level Zero using an opt-in profiling queue and per-kernel events, while preserving the ordinary graph fast path

This intentionally does not choose or cache a schedule inside compilation. It supplies the common measurement substrate needed for the next PR's validated, cached `KernelDispatch` tuning.

## Verification

- full cold suite: 2,244 tests, 33,207 assertions, 0 failures/errors
- focused measurement/OpenCL/device-timing gate: 12 tests, 24 assertions, 0 failures/errors
- fresh `Compiled` wrapper load via artifact gate: 4 tests, 31 assertions, 0 failures/errors
- touched-file cljfmt and `git diff --check` clean

The current sandbox exposes neither Level Zero nor an OpenCL device, so live GPU tests skip here. Existing Level Zero timestamp behavior remains covered by its prior device test; the new OpenCL timestamp path is compilation/device-free tested but still needs its first live-device CI/local run.
