### PR TITLE
Tune kernel dispatches from validated measurements

### DIFF
--- a/src/raster/compiler/ir/kernel_dispatch.clj
+++ b/src/raster/compiler/ir/kernel_dispatch.clj
@@ -29,24 +29,55 @@
   [alternatives]
   (into {} (map (juxt artifact-strategy identity)) alternatives))
 
+(defn- finite-number?
+  [value]
+  (and (number? value) (Double/isFinite (double value))))
+
+(defn- validate-selector-strategy!
+  [dispatch strategies branch strategy]
+  (when-not (contains? strategies strategy)
+    (throw (ex-info "kernel dispatch selector names an absent strategy"
+                    {:id (:id dispatch) :branch branch :strategy strategy
+                     :strategies (set (keys strategies))}))))
+
 (defn- validate-selector!
   [dispatch strategies common-arguments]
-  (let [{:keys [kind argument threshold at-least otherwise]} (:selector dispatch)]
-    (when-not (= :runtime-scalar-threshold kind)
-      (throw (ex-info "kernel dispatch has an unsupported selector"
-                      {:id (:id dispatch) :selector (:selector dispatch)})))
+  (let [{:keys [kind argument threshold at-least otherwise ranges below]}
+        (:selector dispatch)]
     (when-not (some #(= argument %) common-arguments)
       (throw (ex-info "kernel dispatch selector argument is absent from the common ABI values"
                       {:id (:id dispatch) :argument argument
                        :arguments common-arguments})))
-    (when-not (and (number? threshold) (pos? (double threshold)))
-      (throw (ex-info "kernel dispatch threshold must be positive"
-                      {:id (:id dispatch) :threshold threshold})))
-    (doseq [[branch strategy] [[:at-least at-least] [:otherwise otherwise]]]
-      (when-not (contains? strategies strategy)
-        (throw (ex-info "kernel dispatch selector names an absent strategy"
-                        {:id (:id dispatch) :branch branch :strategy strategy
-                         :strategies (set (keys strategies))}))))))
+    (case kind
+      :runtime-scalar-threshold
+      (do
+        (when-not (and (finite-number? threshold) (pos? (double threshold)))
+          (throw (ex-info "kernel dispatch threshold must be finite and positive"
+                          {:id (:id dispatch) :threshold threshold})))
+        (doseq [[branch strategy] [[:at-least at-least] [:otherwise otherwise]]]
+          (validate-selector-strategy! dispatch strategies branch strategy)))
+
+      :runtime-scalar-ranges
+      (do
+        (validate-selector-strategy! dispatch strategies :below below)
+        (when-not (vector? ranges)
+          (throw (ex-info "kernel dispatch ranges must be an ordered vector"
+                          {:id (:id dispatch) :ranges ranges})))
+        (doseq [[index {:keys [at-least strategy] :as range}] (map-indexed vector ranges)]
+          (when-not (= #{:at-least :strategy} (set (keys range)))
+            (throw (ex-info "kernel dispatch range requires exactly :at-least and :strategy"
+                            {:id (:id dispatch) :index index :range range})))
+          (when-not (finite-number? at-least)
+            (throw (ex-info "kernel dispatch range boundary must be finite"
+                            {:id (:id dispatch) :index index :at-least at-least})))
+          (validate-selector-strategy! dispatch strategies [:ranges index] strategy))
+        (when-not (or (< (count ranges) 2)
+                      (apply < (map :at-least ranges)))
+          (throw (ex-info "kernel dispatch range boundaries must be strictly increasing"
+                          {:id (:id dispatch) :ranges ranges}))))
+
+      (throw (ex-info "kernel dispatch has an unsupported selector"
+                      {:id (:id dispatch) :selector (:selector dispatch)})))))
 
 (defn validate!
   "Validate a dispatch and return it unchanged.
@@ -112,6 +143,12 @@
   (let [dispatch (validate! dispatch)]
     (artifact dispatch (:default-strategy dispatch))))
 
+(defn with-selector
+  "Return `dispatch` with a replacement selector, revalidating it against the common ABI and
+   available strategies. Used to bake an offline tuning result into otherwise identical IR."
+  [dispatch selector]
+  (validate! (assoc (validate! dispatch) :selector selector)))
+
 (defn- runtime-number
   [value]
   (if (and (map? value) (contains? value :value)) (:value value) value))
@@ -127,7 +164,8 @@
    (let [dispatch (validate! dispatch)]
      (if (and override (not= :auto override))
        (artifact dispatch override)
-       (let [{:keys [argument threshold at-least otherwise]} (:selector dispatch)
+       (let [{:keys [kind argument threshold at-least otherwise ranges below]}
+             (:selector dispatch)
              common-arguments (:arguments (default-artifact dispatch))
              indexes (keep-indexed (fn [index value] (when (= argument value) index))
                                    common-arguments)]
@@ -143,5 +181,15 @@
            (when-not (number? value)
              (throw (ex-info "kernel dispatch selector requires a numeric runtime scalar"
                              {:id (:id dispatch) :argument argument :value value})))
-           (artifact dispatch (if (>= (double value) (double threshold))
-                                at-least otherwise))))))))
+           (artifact
+            dispatch
+            (case kind
+              :runtime-scalar-threshold
+              (if (>= (double value) (double threshold)) at-least otherwise)
+
+              :runtime-scalar-ranges
+              (reduce (fn [strategy range]
+                        (if (>= (double value) (double (:at-least range)))
+                          (:strategy range)
+                          (reduced strategy)))
+                      below ranges)))))))))

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_route.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_route.clj
@@ -58,27 +58,36 @@
                                [:segmented-weighted-reduction
                                 :score-reuse-subgroup-multiple]
                                16))
+        measured-selector (get-in schedule
+                                  [:segmented-weighted-reduction :measured-selector])
         components (get-in plan [:value :components])
-        dispatch-key [(swr/algebra-key plan) subgroup-size multiple]
+        dispatch-key [(swr/algebra-key plan) subgroup-size
+                      (or measured-selector multiple)]
         id (format "raster_segmented_weighted_reduction_dispatch_%08x"
                    (bit-and 0xffffffff (long (hash dispatch-key))))]
     (when (and (contains? by-strategy reference)
                (contains? by-strategy score-reuse))
-      (kdispatch/make
-       {:id id
-        :alternatives artifacts
-        :default-strategy reference
-        :selector {:kind :runtime-scalar-threshold
-                   :argument components
-                   :threshold (* subgroup-size multiple)
-                   :at-least score-reuse
-                   :otherwise reference}
-        :provenance {:operation-id (get-in plan [:provenance :operation-id])
-                     :semantic-op (get-in plan [:provenance :semantic-op])
-                     :algebra-plan-id (:id plan)}
-        :attributes {:algebra :segmented-weighted-reduction
-                     :algebra-key (swr/algebra-key plan)
-                     :selection :runtime-shape}}))))
+      (let [dispatch
+            (kdispatch/make
+             {:id id
+              :alternatives artifacts
+              :default-strategy reference
+              :selector {:kind :runtime-scalar-threshold
+                         :argument components
+                         :threshold (* subgroup-size multiple)
+                         :at-least score-reuse
+                         :otherwise reference}
+              :provenance {:operation-id (get-in plan [:provenance :operation-id])
+                           :semantic-op (get-in plan [:provenance :semantic-op])
+                           :algebra-plan-id (:id plan)}
+              :attributes {:algebra :segmented-weighted-reduction
+                           :algebra-key (swr/algebra-key plan)
+                           :selection (if measured-selector
+                                        :measured-runtime-shape
+                                        :analytic-runtime-shape)}})]
+        (if measured-selector
+          (kdispatch/with-selector dispatch measured-selector)
+          dispatch)))))
 
 (defn route-dynamic
   ([plan] (route-dynamic plan nil))

--- a/src/raster/gpu/autotune.clj
+++ b/src/raster/gpu/autotune.clj
@@ -11,10 +11,9 @@
    bench is the integration seam (lands with the resident/Compiled path)."
   (:require [raster.gpu.schedule :as sched]
             [raster.compiler.core.hardware :as hw]
-            [clojure.java.io :as io])
-  (:import [java.io File]))
+            [raster.gpu.tuning-cache :as cache]))
 
-(def autotune-version 2)
+(def autotune-version 3)
 
 ;; ================================================================
 ;; Coordinate descent (Inductor) — greedy, one neighbourhood step at a time
@@ -49,18 +48,20 @@
 
 (defn schedule-neighbors
   "The moves coordinate-descent explores over an S6 Schedule. Two WIRED axes:
-     :precision — selects the XMX-f16 vs scalar GEMM binder.
-     :tile      — the GEMM tile (T2/T3), a CURATED per-descriptor candidate list
-                  (hw/gemm-tile-candidates) that drives emit-gemm-tiled +
-                  bind-registered-gemm-tiled! (real, priced kernels).
+     :tile — the GEMM tile (T2/T3), a CURATED per-descriptor candidate list
+             (hw/gemm-tile-candidates) that drives emit-gemm-tiled +
+             bind-registered-gemm-tiled! (real, priced kernels).
+
+   Precision is deliberately NOT a default search axis: it changes numerical mode and therefore
+   requires an explicit caller-provided neighborhood plus a distinct cache identity. Searching it
+   as an ordinary performance knob could silently exchange exact f32 math for mixed precision.
    :grf / :stage stay schema-only until the emitter consumes them (the S6 review found nothing
    reads them at emission) — searching an un-wired knob wastes measurements on an identical kernel.
 
-   NB split-k factor (~10× on deep-k occupancy-bound shapes, gemm_autotune_test) is a separate
-   GEMM-level occupancy axis measured directly there; promoting it to an S6 field is the next step."
+  NB split-k factor (~10× on deep-k occupancy-bound shapes, gemm_autotune_test) is a separate
+  GEMM-level occupancy axis measured directly there; promoting it to an S6 field is the next step."
   [desc]
-  {:precision (fn [_] [:f16-xmx :f32-scalar])
-   :tile      (fn [_] (hw/gemm-tile-candidates desc))})
+  {:tile (fn [_] (hw/gemm-tile-candidates desc))})
 
 ;; ================================================================
 ;; Disk cache — keyed by (op × shape-class × descriptor-signature × version)
@@ -73,27 +74,27 @@
   (select-keys descriptor [:device-id :vendor :arch :machine-lanes :grf-bytes-per-lane
                            :bandwidth-bytes-s :peak-flops :subgroup-size]))
 
-(defn cache-key [op-key shape-class descriptor]
-  (pr-str [op-key shape-class (descriptor-signature descriptor) autotune-version]))
+(def ^:private required-cache-identity-keys
+  #{:numerical-mode :emitter-hash :layout})
 
-(defn- cache-file ^File [key-str]
-  (io/file (System/getProperty "user.home") ".raster" "autotune"
-           (str (format "%08x" (hash key-str)) ".edn")))
+(defn- validate-cache-identity!
+  [identity]
+  (when-not (and (map? identity)
+                 (every? #(and (contains? identity %) (some? (get identity %)))
+                         required-cache-identity-keys))
+    (throw (ex-info "autotune cache identity requires numerical mode, emitter hash, and layout"
+                    {:identity identity :required required-cache-identity-keys})))
+  identity)
+
+(defn cache-key [op-key shape-class descriptor identity]
+  (pr-str [op-key shape-class (descriptor-signature descriptor)
+           (validate-cache-identity! identity) autotune-version]))
 
 (defn cache-get [key-str]
-  (let [f (cache-file key-str)]
-    (when (.exists f)
-      (try (let [{:keys [key config]} (read-string (slurp f))]
-             (when (= key key-str) config))
-           (catch Exception _ nil)))))
+  (cache/read-entry key-str))
 
 (defn cache-put! [key-str config]
-  (let [f (cache-file key-str)]
-    (io/make-parents f)
-    (let [tmp (File/createTempFile "atune" ".edn" (.getParentFile f))]
-      (spit tmp (pr-str {:key key-str :config config}))
-      (.renameTo tmp f))
-    config))
+  (cache/write-entry! key-str config))
 
 ;; ================================================================
 ;; The autotune entry — cache-or-search
@@ -103,9 +104,10 @@
   "The best Schedule for (op-key × shape-class × descriptor): from the disk cache, or found by
    coordinate-descent from the derive-default seed priced by `cost-fn` and then cached. `cost-fn`
    takes a candidate Schedule and returns its measured cost (lower better; +Inf = infeasible).
-   opts: :neighbors (override), :force? (ignore cache), :steps (program steps for derive-default)."
-  [op-key shape-class descriptor cost-fn & {:keys [neighbors force? steps]}]
-  (let [k (cache-key op-key shape-class descriptor)]
+   opts: :identity (REQUIRED: numerical mode + emitter hash + layout), :neighbors (override),
+   :force? (ignore cache), :steps (program steps for derive-default)."
+  [op-key shape-class descriptor cost-fn & {:keys [neighbors force? steps identity]}]
+  (let [k (cache-key op-key shape-class descriptor identity)]
     (or (when-not force? (cache-get k))
         (let [seed (sched/derive-default steps descriptor)
               result (coordinate-descent seed (or neighbors (schedule-neighbors descriptor)) cost-fn)]

--- a/src/raster/gpu/dispatch_tuning.clj
+++ b/src/raster/gpu/dispatch_tuning.clj
@@ -1,0 +1,247 @@
+(ns raster.gpu.dispatch-tuning
+  "Explicit offline autotuning for a KernelDispatch.
+
+   Compilation and runtime selection never benchmark. This namespace measures already-emitted,
+   ABI-compatible alternatives through a caller-supplied validated benchmark, converts winners at
+   sampled runtime scalar values into a piecewise selector, and atomically caches that selector.
+   Applying a result rechecks the full identity: device, emitted sources, ABI, numerical mode, and
+   layout. A stale or cross-device result therefore cannot silently select a kernel."
+  (:require [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.gpu.measurement :as measurement]
+            [raster.gpu.tuning-cache :as cache])
+  (:import [java.nio.charset StandardCharsets]
+           [java.security MessageDigest]))
+
+(def tuning-version 1)
+
+(defrecord DispatchTuning
+           [key identity selector measurements])
+
+(defn dispatch-tuning?
+  "Recognize tuning values across Typed Clojure child classloaders."
+  [x]
+  (and x (= "raster.gpu.dispatch_tuning.DispatchTuning" (.getName (class x)))))
+
+(defn- sha256
+  [value]
+  (let [digest (.digest (MessageDigest/getInstance "SHA-256")
+                        (.getBytes (str value) StandardCharsets/UTF_8))]
+    (apply str (map #(format "%02x" (bit-and 0xff (int %))) digest))))
+
+(defn- canonical-data
+  [value]
+  (cond
+    (map? value) (into (sorted-map-by #(compare (pr-str %1) (pr-str %2)))
+                       (map (fn [[key item]] [(canonical-data key) (canonical-data item)]))
+                       value)
+    (set? value) (mapv canonical-data (sort-by pr-str value))
+    (vector? value) (mapv canonical-data value)
+    (sequential? value) (mapv canonical-data value)
+    :else value))
+
+(defn artifact-signature
+  "Stable correctness/performance identity of one emitted alternative."
+  [artifact]
+  {:strategy (kdispatch/artifact-strategy artifact)
+   :target (:target artifact)
+   :kernel-name (:kernel-name artifact)
+   :source-hash (sha256 (:source artifact))
+   :abi-hash (sha256 (pr-str (canonical-data (:abi artifact))))
+   :arguments-hash (sha256 (pr-str (:arguments artifact)))
+   :effects-hash (sha256 (pr-str (canonical-data (:effects artifact))))})
+
+(defn- device-signature
+  [descriptor]
+  (select-keys descriptor
+               [:device-id :device-name :vendor :arch :driver-version
+                :machine-lanes :grf-bytes-per-lane :bandwidth-bytes-s :peak-flops
+                :subgroup-size :max-workgroup-size :matrix]))
+
+(defn tuning-identity
+  "Build the complete identity that guards a dispatch tuning result.
+
+   `numerical-mode` and `layout` are required caller data because neither can be reconstructed
+   safely from a generic kernel name. The sampled runtime values and improvement threshold are
+   policy inputs: changing either must miss the cache. Examples are
+   {:input :f16 :accumulate :f32 :output :f32} and
+   {:edge-list :packed :value :row-major}."
+  [dispatch descriptor runtime-values numerical-mode layout improvement-threshold]
+  (let [dispatch (kdispatch/validate! dispatch)]
+    (when (nil? numerical-mode)
+      (throw (ex-info "dispatch tuning identity requires :numerical-mode" {})))
+    (when (nil? layout)
+      (throw (ex-info "dispatch tuning identity requires :layout" {})))
+    (canonical-data
+     {:version tuning-version
+      :dispatch-id (:id dispatch)
+      :selector-argument (get-in dispatch [:selector :argument])
+      :device (device-signature descriptor)
+      :numerical-mode numerical-mode
+      :layout layout
+      :policy {:runtime-values (vec runtime-values)
+               :improvement-threshold (double improvement-threshold)}
+      :artifacts (mapv artifact-signature (:alternatives dispatch))})))
+
+(defn cache-key
+  [identity]
+  (sha256 (pr-str (canonical-data identity))))
+
+(defn- tuning-from-data
+  [dispatch identity key data]
+  (when (and (= tuning-version (:version data))
+             (= key (:key data))
+             (= identity (:identity data))
+             (map? (:selector data))
+             (vector? (:measurements data)))
+    (kdispatch/with-selector dispatch (:selector data))
+    (->DispatchTuning key identity (:selector data) (:measurements data))))
+
+(defn cache-get
+  "Read and validate a cached result for the exact dispatch identity. Corrupt/stale entries miss."
+  [dispatch identity]
+  (let [key (cache-key identity)]
+    (try
+      (tuning-from-data dispatch identity key (cache/read-entry key))
+      (catch Exception _ nil))))
+
+(defn cache-put!
+  "Atomically persist a DispatchTuning as plain EDN."
+  [tuning]
+  (when-not (dispatch-tuning? tuning)
+    (throw (ex-info "dispatch tuning cache requires a DispatchTuning" {:value tuning})))
+  (let [data {:version tuning-version
+              :key (:key tuning)
+              :identity (:identity tuning)
+              :selector (:selector tuning)
+              :measurements (:measurements tuning)}]
+    (cache/write-entry! (:key tuning) data)
+    tuning))
+
+(def ^:private measurement-fields
+  [:min-ns :median-ns :p75-ns :mean-ns :cv :stationary? :n :warmup-iterations
+   :budget-ms :cold-warm :timing-source :compile-ms :hashes])
+
+(defn- validate-benchmark-result!
+  [artifact runtime-value result]
+  (let [{:keys [measurement validation]} result
+        signature (artifact-signature artifact)]
+    (when-not (measurement/measurement? measurement)
+      (throw (ex-info "dispatch benchmark must return a Measurement"
+                      {:runtime-value runtime-value
+                       :strategy (:strategy signature)
+                       :measurement measurement})))
+    (when-not (= :device-event (:timing-source measurement))
+      (throw (ex-info "dispatch tuning accepts device-event measurements only"
+                      {:runtime-value runtime-value
+                       :strategy (:strategy signature)
+                       :timing-source (:timing-source measurement)})))
+    (when-not (:stationary? measurement)
+      (throw (ex-info "dispatch tuning refuses a non-stationary measurement"
+                      {:runtime-value runtime-value
+                       :strategy (:strategy signature)
+                       :cv (:cv measurement)})))
+    (when-not (and (map? validation)
+                   (true? (:passed? validation))
+                   (string? (:oracle-hash validation))
+                   (not-empty (:oracle-hash validation))
+                   (= (:source-hash signature) (:candidate-hash validation)))
+      (throw (ex-info "dispatch candidate must pass an oracle validation tied to its source hash"
+                      {:runtime-value runtime-value
+                       :strategy (:strategy signature)
+                       :expected-candidate-hash (:source-hash signature)
+                       :validation validation})))
+    {:runtime-value runtime-value
+     :strategy (:strategy signature)
+     :measurement (select-keys measurement measurement-fields)
+     :validation (select-keys validation
+                              [:passed? :oracle-hash :candidate-hash :max-error :rtol :atol])}))
+
+(defn- winner-at
+  [rows default-strategy improvement-threshold]
+  (let [by-strategy (into {} (map (juxt :strategy identity)) rows)
+        default-row (or (get by-strategy default-strategy)
+                        (throw (ex-info "dispatch measurements omit the default strategy"
+                                        {:default-strategy default-strategy
+                                         :strategies (set (keys by-strategy))})))
+        best-row (apply min-key #(get-in % [:measurement :min-ns]) rows)
+        default-cost (double (get-in default-row [:measurement :min-ns]))
+        best-cost (double (get-in best-row [:measurement :min-ns]))]
+    (if (< best-cost (* default-cost (- 1.0 (double improvement-threshold))))
+      (:strategy best-row)
+      default-strategy)))
+
+(defn- measured-selector
+  [dispatch runtime-values rows improvement-threshold]
+  (let [default-strategy (:default-strategy dispatch)
+        choices (mapv (fn [runtime-value]
+                        [runtime-value
+                         (winner-at (filterv #(= runtime-value (:runtime-value %)) rows)
+                                    default-strategy improvement-threshold)])
+                      runtime-values)
+        ranges (second
+                (reduce (fn [[current ranges] [boundary strategy]]
+                          (if (= current strategy)
+                            [current ranges]
+                            [strategy (conj ranges {:at-least boundary :strategy strategy})]))
+                        [default-strategy []]
+                        choices))]
+    {:kind :runtime-scalar-ranges
+     :argument (get-in dispatch [:selector :argument])
+     :below default-strategy
+     :ranges ranges}))
+
+(defn tune!
+  "Measure, validate, and cache a generic KernelDispatch selector OFFLINE.
+
+   `runtime-values` are concrete numeric samples for the dispatch selector argument.
+   `benchmark-fn` is called as (benchmark-fn artifact runtime-value) and must return:
+
+     {:measurement Measurement
+      :validation {:passed? true :oracle-hash string :candidate-hash artifact-source-hash ...}}
+
+   Correctness is therefore established before a timing can influence selection. Every result
+   must be stationary and device-event timed. A candidate must improve on the dispatch default by
+   more than `improvement-threshold` (default 0.1%) at a sample or the default wins that sample.
+   Cache hits do not invoke benchmark-fn."
+  [dispatch descriptor runtime-values benchmark-fn
+   & {:keys [numerical-mode layout improvement-threshold force?]
+      :or {improvement-threshold 0.001 force? false}}]
+  (let [dispatch (kdispatch/validate! dispatch)
+        runtime-values (vec (sort (distinct runtime-values)))]
+    (when-not (and (seq runtime-values) (every? #(and (number? %)
+                                                      (Double/isFinite (double %)))
+                                                runtime-values))
+      (throw (ex-info "dispatch tuning runtime values must be non-empty finite numbers"
+                      {:runtime-values runtime-values})))
+    (when-not (and (number? improvement-threshold)
+                   (<= 0.0 (double improvement-threshold))
+                   (< (double improvement-threshold) 1.0))
+      (throw (ex-info "dispatch improvement-threshold must be in [0,1)"
+                      {:improvement-threshold improvement-threshold})))
+    (let [identity (tuning-identity dispatch descriptor runtime-values numerical-mode layout
+                                    improvement-threshold)
+          key (cache-key identity)]
+      (or (when-not force? (cache-get dispatch identity))
+          (let [rows (mapv (fn [[runtime-value artifact]]
+                             (validate-benchmark-result!
+                              artifact runtime-value (benchmark-fn artifact runtime-value)))
+                           (for [runtime-value runtime-values
+                                 artifact (:alternatives dispatch)]
+                             [runtime-value artifact]))
+                selector (measured-selector dispatch runtime-values rows improvement-threshold)
+                _ (kdispatch/with-selector dispatch selector)
+                tuning (->DispatchTuning key identity selector rows)]
+            (cache-put! tuning))))))
+
+(defn apply-tuning
+  "Bake a tuning selector into a dispatch after rechecking its complete target identity."
+  [dispatch tuning descriptor numerical-mode layout]
+  (when-not (dispatch-tuning? tuning)
+    (throw (ex-info "apply-tuning requires a DispatchTuning" {:tuning tuning})))
+  (let [{:keys [runtime-values improvement-threshold]} (:policy (:identity tuning))
+        identity (tuning-identity dispatch descriptor runtime-values numerical-mode layout
+                                  improvement-threshold)]
+    (when-not (= identity (:identity tuning))
+      (throw (ex-info "dispatch tuning identity differs from the target dispatch"
+                      {:expected identity :actual (:identity tuning)})))
+    (kdispatch/with-selector dispatch (:selector tuning))))

--- a/src/raster/gpu/schedule.clj
+++ b/src/raster/gpu/schedule.clj
@@ -187,7 +187,9 @@
         grf   (get-in schedule [:grf :mode] :grf128)
         reduction-strategy (get-in schedule [:segmented-weighted-reduction :strategy] :auto)
         score-reuse-multiple
-        (get-in schedule [:segmented-weighted-reduction :score-reuse-subgroup-multiple] 16)]
+        (get-in schedule [:segmented-weighted-reduction :score-reuse-subgroup-multiple] 16)
+        measured-selector
+        (get-in schedule [:segmented-weighted-reduction :measured-selector])]
     (when-not (valid-precisions prec)
       (throw (ex-info (str "schedule: unknown :precision " (pr-str prec) " — expected " valid-precisions)
                       {:precision prec})))
@@ -203,7 +205,14 @@
                        :expected valid-segmented-reduction-strategies})))
     (when-not (and (integer? score-reuse-multiple) (pos? score-reuse-multiple))
       (throw (ex-info "schedule: score-reuse subgroup multiple must be a positive integer"
-                      {:score-reuse-subgroup-multiple score-reuse-multiple}))))
+                      {:score-reuse-subgroup-multiple score-reuse-multiple})))
+    (when (and (some? measured-selector) (not (map? measured-selector)))
+      (throw (ex-info "schedule: measured segmented reduction selector must be a map"
+                      {:measured-selector measured-selector})))
+    (when (and (some? measured-selector) (not= :auto reduction-strategy))
+      (throw (ex-info "schedule: a measured selector requires :strategy :auto"
+                      {:strategy reduction-strategy
+                       :measured-selector measured-selector}))))
   (let [budget (grf-budget-bytes-per-lane schedule desc)
         acc    (acc-bytes-per-lane schedule)
         staged (register-staged-bytes-per-lane schedule)

--- a/src/raster/gpu/tuning_cache.clj
+++ b/src/raster/gpu/tuning_cache.clj
@@ -1,0 +1,56 @@
+(ns raster.gpu.tuning-cache
+  "Shared atomic disk storage for offline GPU tuning results.
+
+   Search algorithms own their cache keys and values; this namespace owns exactly one durable
+   mechanism. Entries are guarded by the full unhashed key inside the file, so filename hash
+   collisions become misses rather than wrong schedules."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io])
+  (:import [java.nio.charset StandardCharsets]
+           [java.nio.file AtomicMoveNotSupportedException CopyOption Files StandardCopyOption]
+           [java.security MessageDigest]))
+
+(def ^:dynamic *cache-root*
+  "Root of the shared GPU autotune cache. Bind to a temporary directory in tests."
+  (io/file (System/getProperty "user.home") ".raster" "autotune"))
+
+(defn- sha256
+  [value]
+  (let [digest (.digest (MessageDigest/getInstance "SHA-256")
+                        (.getBytes (str value) StandardCharsets/UTF_8))]
+    (apply str (map #(format "%02x" (bit-and 0xff (int %))) digest))))
+
+(defn entry-file
+  [key]
+  (io/file *cache-root* (str (sha256 key) ".edn")))
+
+(defn read-entry
+  "Return the cached value for exact `key`, or nil for a miss/corrupt entry."
+  [key]
+  (let [file (entry-file key)]
+    (when (.exists file)
+      (try
+        (let [entry (edn/read-string (slurp file))]
+          (when (= key (:key entry)) (:value entry)))
+        (catch Exception _ nil)))))
+
+(defn write-entry!
+  "Atomically store `value` under exact `key` and return value."
+  [key value]
+  (let [directory (.toPath (io/file *cache-root*))
+        target (.toPath (entry-file key))]
+    (Files/createDirectories directory (make-array java.nio.file.attribute.FileAttribute 0))
+    (let [temporary (Files/createTempFile directory "gpu-tuning-" ".edn"
+                                          (make-array java.nio.file.attribute.FileAttribute 0))]
+      (try
+        (spit (.toFile temporary) (pr-str {:key key :value value}))
+        (try
+          (Files/move temporary target
+                      (into-array CopyOption [StandardCopyOption/ATOMIC_MOVE
+                                              StandardCopyOption/REPLACE_EXISTING]))
+          (catch AtomicMoveNotSupportedException _
+            (Files/move temporary target
+                        (into-array CopyOption [StandardCopyOption/REPLACE_EXISTING]))))
+        (finally
+          (Files/deleteIfExists temporary))))
+    value))

--- a/test/raster/compiler/ir/kernel_dispatch_test.clj
+++ b/test/raster/compiler/ir/kernel_dispatch_test.clj
@@ -54,6 +54,26 @@
                                                   :subgroup-score-reuse)))
       "an explicit schedule override is authoritative"))
 
+(deftest measured-runtime-ranges-select-without-runtime-tuning
+  (let [measured (kdispatch/with-selector
+                   dispatch
+                   {:kind :runtime-scalar-ranges
+                    :argument 'width
+                    :below :reference
+                    :ranges [{:at-least 192 :strategy :subgroup-score-reuse}
+                             {:at-least 768 :strategy :reference}]})
+        select #(kdispatch/artifact-strategy
+                 (kdispatch/select-artifact measured [:x :out {:type :long :value %}]))]
+    (is (= :reference (select 128)))
+    (is (= :subgroup-score-reuse (select 192)))
+    (is (= :subgroup-score-reuse (select 512)))
+    (is (= :reference (select 768)))
+    (is (= :subgroup-score-reuse
+           (kdispatch/artifact-strategy
+            (kdispatch/select-artifact measured [:x :out {:type :long :value 1}]
+                                       :subgroup-score-reuse)))
+        "an explicit override remains authoritative over measured selector data")))
+
 (deftest dispatch-rejects-incompatible-or-ambiguous-alternatives
   (testing "an alternative cannot silently change the ordered ABI"
     (is (thrown-with-msg?
@@ -70,7 +90,19 @@
           {:id "duplicate"
            :alternatives [reference (assoc subgroup :attributes {:strategy :reference})]
            :default-strategy :reference
-           :selector (:selector dispatch)})))))
+           :selector (:selector dispatch)}))))
+  (testing "measured range boundaries are ordered and name available strategies"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"strictly increasing"
+         (kdispatch/with-selector
+           dispatch {:kind :runtime-scalar-ranges :argument 'width :below :reference
+                     :ranges [{:at-least 256 :strategy :subgroup-score-reuse}
+                              {:at-least 128 :strategy :reference}]})))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"absent strategy"
+         (kdispatch/with-selector
+           dispatch {:kind :runtime-scalar-ranges :argument 'width :below :unknown
+                     :ranges []})))))
 
 (deftest both-resident-backends-register-the-same-pure-dispatch
   (doseq [[register! entry] [[ze/register-kernel-dispatch!

--- a/test/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse_test.clj
+++ b/test/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse_test.clj
@@ -154,6 +154,41 @@
       (is (nil? (:dispatch step)))
       (is (= emitted (get-in step [:artifact :attributes :strategy]))))))
 
+(deftest compiler-schedule-can-bake-an-offline-measured-selector
+  (let [analytic (pipeline/compile-gpu-program
+                  #'resident-structured-reduction-probe :ze:0 :dtype :float)
+        argument (get-in analytic [:steps 0 :dispatch :selector :argument])
+        selector {:kind :runtime-scalar-ranges
+                  :argument argument
+                  :below :indexed-segmented-reduction-reference
+                  :ranges [{:at-least 3
+                            :strategy
+                            :indexed-segmented-reduction-subgroup-score-reuse}]}
+        descriptor
+        (pipeline/compile-gpu-program
+         #'resident-structured-reduction-probe :ze:0 :dtype :float
+         :schedule {:segmented-weighted-reduction
+                    {:strategy :auto :measured-selector selector}})
+        step (first (:steps descriptor))
+        arguments-for
+        (fn [args]
+          (mapv (fn [{:keys [kind type value-fn]}]
+                  (if (= :scalar kind)
+                    {:type type :value (value-fn args)}
+                    (Object.)))
+                (:argument-specs step)))
+        narrow [(float-array 15) (float-array 15) (float-array 15)
+                (long-array 4) (long-array 4) 3 4 5 2]
+        wide (assoc narrow 7 8)]
+    (is (= selector (get-in step [:dispatch :selector])))
+    (is (= :measured-runtime-shape (get-in step [:dispatch :attributes :selection])))
+    (is (= :indexed-segmented-reduction-reference
+           (kdispatch/artifact-strategy
+            (kdispatch/select-artifact (:dispatch step) (arguments-for narrow)))))
+    (is (= :indexed-segmented-reduction-subgroup-score-reuse
+           (kdispatch/artifact-strategy
+            (kdispatch/select-artifact (:dispatch step) (arguments-for wide)))))))
+
 (deftest actual-gsdm-region-reaches-generic-structured-reduction-stage
   (let [diagnostic (pipeline/show-pipeline
                     #'gsdm/graph-attention-multihead

--- a/test/raster/gpu/autotune_test.clj
+++ b/test/raster/gpu/autotune_test.clj
@@ -3,7 +3,14 @@
    the noise-rejection threshold, and the disk-cache round-trip."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.gpu.autotune :as at]
-            [raster.gpu.schedule :as sched]))
+            [raster.gpu.schedule :as sched]
+            [raster.gpu.tuning-cache :as cache])
+  (:import [java.nio.file Files]))
+
+(defn- temporary-cache-root
+  []
+  (.toFile (Files/createTempDirectory "raster-autotune-"
+                                      (make-array java.nio.file.attribute.FileAttribute 0))))
 
 (deftest coordinate-descent-finds-the-minimum
   ;; landscape minimized at {:a 8 :b :y}; ×2/÷2 moves on :a, two-valued :b
@@ -37,24 +44,51 @@
       (is (= :grf256 (get-in (:config r) [:grf :mode]))))))
 
 (deftest cache-roundtrip
-  (let [desc {:device-id :ze:0 :bandwidth-bytes-s 9.0e10 :peak-flops {:f32 4.0e12}}
-        k (at/cache-key (keyword (gensym "op")) :shape-Z desc)
-        cfg {:precision :f16-xmx :grf {:mode :grf128}}]
-    (is (nil? (at/cache-get k)) "cold miss")
-    (at/cache-put! k cfg)
-    (is (= cfg (at/cache-get k)) "round-trips from disk")
-    (testing "the key includes the measured perf signature — a re-calibrated machine misses"
-      (is (not= k (at/cache-key (keyword "op") :shape-Z (assoc desc :bandwidth-bytes-s 1.37e11)))))))
+  (binding [cache/*cache-root* (temporary-cache-root)]
+    (let [desc {:device-id :ze:0 :bandwidth-bytes-s 9.0e10 :peak-flops {:f32 4.0e12}}
+          identity {:numerical-mode :f32 :emitter-hash "emitter-v1" :layout :row-major}
+          k (at/cache-key :op-Z :shape-Z desc identity)
+          cfg {:precision :f16-xmx :grf {:mode :grf128}}]
+      (is (nil? (at/cache-get k)) "cold miss")
+      (at/cache-put! k cfg)
+      (is (= cfg (at/cache-get k)) "round-trips from disk")
+      (testing "the key includes the measured perf signature — a re-calibrated machine misses"
+        (is (not= k (at/cache-key :op-Z :shape-Z
+                                  (assoc desc :bandwidth-bytes-s 1.37e11)
+                                  identity))))
+      (testing "numerical mode, emitter, and layout are mandatory correctness identity"
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"requires numerical mode"
+                              (at/cache-key :op-Z :shape-Z desc {})))))))
 
 (deftest autotune-schedule-seeds-from-derive-default
-  (let [desc {:device-id :ze:0 :grf-bytes-per-lane 256 :bandwidth-bytes-s 9.0e10 :peak-flops {:f32 4.0e12} :balance 60}
-        ;; cost prefers f32-scalar (opposite of the f16-xmx default) + gates infeasible
-        cost (fn [s] (try (sched/feasible? s desc)
-                          (if (= (:precision s) :f32-scalar) 1.0 2.0)
-                          (catch clojure.lang.ExceptionInfo _ Double/POSITIVE_INFINITY)))
-        op (keyword (gensym "op"))
-        best (at/autotune-schedule op :shape-Q desc cost :force? true)]
-    (is (= :f32-scalar (:precision best)) "search moved off the f16-xmx seed to the cheaper config")
-    (testing "second call hits the cache without re-measuring"
-      (is (= :f32-scalar (:precision (at/autotune-schedule op :shape-Q desc
-                                                           (fn [_] (throw (ex-info "should-not-measure" {}))))))))))
+  (binding [cache/*cache-root* (temporary-cache-root)]
+    (let [desc {:device-id :ze:0 :grf-bytes-per-lane 256 :bandwidth-bytes-s 9.0e10 :peak-flops {:f32 4.0e12} :balance 60}
+          ;; cost prefers a smaller measured crossover multiplier while numerical mode stays fixed
+          cost (fn [s] (try (sched/feasible? s desc)
+                            (if (= 8 (get-in s [:segmented-weighted-reduction
+                                                :score-reuse-subgroup-multiple]))
+                              1.0 2.0)
+                            (catch clojure.lang.ExceptionInfo _ Double/POSITIVE_INFINITY)))
+          op :op-Q
+          identity {:numerical-mode :f16-f32
+                    :emitter-hash "segmented-reduction-v1"
+                    :layout :packed-edge-list}
+          reduction-neighbor
+          {[:segmented-weighted-reduction :score-reuse-subgroup-multiple]
+           (fn [_] [8 16])}
+          best (at/autotune-schedule op :shape-Q desc cost
+                                     :identity identity
+                                     :neighbors reduction-neighbor :force? true)]
+      (is (not (contains? (at/schedule-neighbors desc) :precision))
+          "default search never changes numerical mode")
+      (is (= :f16-xmx (:precision best)) "numerical mode remains fixed")
+      (is (= 8 (get-in best [:segmented-weighted-reduction
+                             :score-reuse-subgroup-multiple])))
+      (testing "second call hits the cache without re-measuring"
+        (is (= 8 (get-in (at/autotune-schedule
+                          op :shape-Q desc
+                          (fn [_] (throw (ex-info "should-not-measure" {})))
+                          :identity identity
+                          :neighbors reduction-neighbor)
+                         [:segmented-weighted-reduction
+                          :score-reuse-subgroup-multiple])))))))

--- a/test/raster/gpu/dispatch_tuning_test.clj
+++ b/test/raster/gpu/dispatch_tuning_test.clj
@@ -1,0 +1,164 @@
+(ns raster.gpu.dispatch-tuning-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.gpu.dispatch-tuning :as tuning]
+            [raster.gpu.measurement :as measurement]
+            [raster.gpu.tuning-cache :as cache])
+  (:import [java.nio.file Files]))
+
+(def ^:private abi
+  [(kabi/slot 'x :input :float :role :operand)
+   (kabi/slot 'out :output :float :role :result)
+   (kabi/slot 'width :scalar :long :role :shape)])
+
+(defn- artifact
+  [name strategy workgroup]
+  (kart/make
+   {:kernel-name name
+    :source (str "__kernel void " name
+                 "(__global const float* x, __global float* out, long width) {}")
+    :abi abi
+    :arguments '[x out width]
+    :launch (klaunch/spec {:workgroup-size [workgroup]
+                           :group-count [(klaunch/ceil-div 'width workgroup)]})
+    :effects {:kind :map :reads ['x] :writes ['out]}
+    :attributes {:strategy strategy}}))
+
+(def ^:private reference (artifact "tune_reference" :reference 64))
+(def ^:private subgroup (artifact "tune_subgroup" :subgroup 16))
+
+(def ^:private dispatch
+  (kdispatch/make
+   {:id "dispatch-tuning-test"
+    :alternatives [reference subgroup]
+    :default-strategy :reference
+    :selector {:kind :runtime-scalar-threshold
+               :argument 'width
+               :threshold 256
+               :at-least :subgroup
+               :otherwise :reference}}))
+
+(def ^:private descriptor
+  {:device-id :ze:0 :vendor "Intel" :arch "xe2" :subgroup-size 16
+   :machine-lanes 8192 :driver-version "test-driver"})
+
+(def ^:private numerical-mode
+  {:input :f32 :accumulate :f32 :output :f32})
+
+(def ^:private layout
+  {:input :row-major :output :row-major})
+
+(defn- stable-measurement
+  [cost]
+  (measurement/summarize [cost cost cost]
+                         :timing-source :device-event
+                         :cv-threshold 0.01))
+
+(defn- validated-result
+  [artifact cost]
+  {:measurement (stable-measurement cost)
+   :validation {:passed? true
+                :oracle-hash "oracle-v1"
+                :candidate-hash (:source-hash (tuning/artifact-signature artifact))
+                :max-error 0.0}})
+
+(defn- temporary-cache-root
+  []
+  (.toFile (Files/createTempDirectory "raster-dispatch-tuning-"
+                                      (make-array java.nio.file.attribute.FileAttribute 0))))
+
+(deftest validated-device-measurements-produce-and-cache-piecewise-selection
+  (binding [cache/*cache-root* (temporary-cache-root)]
+    (let [calls (atom 0)
+          costs {:reference {128 10.0 256 10.0 768 5.0}
+                 :subgroup {128 12.0 256 7.0 768 6.0}}
+          benchmark (fn [artifact runtime-value]
+                      (swap! calls inc)
+                      (validated-result artifact
+                                        (get-in costs [(kdispatch/artifact-strategy artifact)
+                                                       runtime-value])))
+          result (tuning/tune! dispatch descriptor [768 128 256] benchmark
+                               :numerical-mode numerical-mode :layout layout)
+          tuned (tuning/apply-tuning dispatch result descriptor numerical-mode layout)
+          select #(kdispatch/artifact-strategy
+                   (kdispatch/select-artifact tuned [:x :out {:type :long :value %}]))]
+      (is (tuning/dispatch-tuning? result))
+      (is (= {:kind :runtime-scalar-ranges
+              :argument 'width
+              :below :reference
+              :ranges [{:at-least 256 :strategy :subgroup}
+                       {:at-least 768 :strategy :reference}]}
+             (:selector result)))
+      (is (= :reference (select 128)))
+      (is (= :subgroup (select 512)))
+      (is (= :reference (select 768)))
+      (is (= 6 @calls))
+      (testing "an exact cache hit performs no benchmark calls"
+        (let [cached (tuning/tune! dispatch descriptor [128 256 768]
+                                   (fn [& _] (throw (ex-info "must not benchmark" {})))
+                                   :numerical-mode numerical-mode :layout layout)]
+          (is (= (:selector result) (:selector cached)))))
+      (testing "shape samples and noise policy participate in cache identity"
+        (let [base (tuning/tuning-identity dispatch descriptor [128 256 768]
+                                           numerical-mode layout 0.001)
+              other-shapes (tuning/tuning-identity dispatch descriptor [128 256]
+                                                   numerical-mode layout 0.001)
+              other-policy (tuning/tuning-identity dispatch descriptor [128 256 768]
+                                                   numerical-mode layout 0.01)]
+          (is (not= (tuning/cache-key base) (tuning/cache-key other-shapes)))
+          (is (not= (tuning/cache-key base) (tuning/cache-key other-policy)))
+          (is (nil? (tuning/cache-get dispatch other-shapes)))))
+      (testing "layout/numerical/device identity is checked again when applying"
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"identity differs"
+                              (tuning/apply-tuning dispatch result descriptor numerical-mode
+                                                   {:input :column-major})))))))
+
+(deftest default-wins-inside-the-noise-floor
+  (binding [cache/*cache-root* (temporary-cache-root)]
+    (let [result (tuning/tune!
+                  dispatch descriptor [256]
+                  (fn [artifact _]
+                    (validated-result artifact
+                                      (if (= :reference
+                                             (kdispatch/artifact-strategy artifact))
+                                        100.0 99.95)))
+                  :numerical-mode numerical-mode :layout layout :force? true)]
+      (is (= [] (get-in result [:selector :ranges])))
+      (is (= :reference (kdispatch/artifact-strategy
+                         (kdispatch/select-artifact
+                          (tuning/apply-tuning dispatch result descriptor numerical-mode layout)
+                          [:x :out {:type :long :value 4096}])))))))
+
+(deftest invalid-or-noisy-candidates-are-never-cached
+  (doseq [[label benchmark message]
+          [[:wrong
+            (fn [artifact _]
+              (assoc (validated-result artifact 1.0)
+                     :validation {:passed? false
+                                  :oracle-hash "oracle-v1"
+                                  :candidate-hash (:source-hash
+                                                   (tuning/artifact-signature artifact))}))
+            #"must pass an oracle"]
+           [:noisy
+            (fn [artifact _]
+              {:measurement (measurement/summarize [1.0 100.0]
+                                                   :timing-source :device-event
+                                                   :cv-threshold 0.01)
+               :validation {:passed? true
+                            :oracle-hash "oracle-v1"
+                            :candidate-hash (:source-hash
+                                             (tuning/artifact-signature artifact))}})
+            #"non-stationary"]]]
+    (testing (name label)
+      (binding [cache/*cache-root* (temporary-cache-root)]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo message
+             (tuning/tune! dispatch descriptor [256] benchmark
+                           :numerical-mode numerical-mode :layout layout :force? true)))
+        (is (nil? (tuning/cache-get
+                   dispatch
+                   (tuning/tuning-identity dispatch descriptor [256] numerical-mode layout
+                                           0.001))))))))

--- a/test/raster/gpu/schedule_test.clj
+++ b/test/raster/gpu/schedule_test.clj
@@ -132,6 +132,20 @@
                             (sched/derive-default nil arc-desc)
                             {:segmented-weighted-reduction
                              {:score-reuse-subgroup-multiple 0}})
+                           arc-desc)))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must be a map"
+                          (sched/feasible?
+                           (sched/resolve
+                            (sched/derive-default nil arc-desc)
+                            {:segmented-weighted-reduction {:measured-selector :invalid}})
+                           arc-desc)))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"requires :strategy :auto"
+                          (sched/feasible?
+                           (sched/resolve
+                            (sched/derive-default nil arc-desc)
+                            {:segmented-weighted-reduction
+                             {:strategy :reference
+                              :measured-selector {:kind :runtime-scalar-ranges}}})
                            arc-desc))))
   (testing "conflicting :gemm-precision sugar and :precision throw, not silently prefer the deprecated key"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"conflicting"


### PR DESCRIPTION
## Summary

- add explicit offline tuning for generic ABI-compatible kernel dispatches
- require stationary device-event measurements and source-bound oracle validation before a candidate may win
- cache complete device, emitted artifact, ABI, numerical-mode, layout, sample-set, and noise-policy identity atomically
- bake non-monotonic measured crossovers into pure runtime-scalar range selectors
- let segmented weighted reductions consume an optional measured selector without adding an attention-specific compiler pass
- make the older schedule autotuner use the same cache and stop searching precision as an ordinary performance knob

## Correctness boundary

Compilation and runtime dispatch never benchmark. Tuning is an explicit offline operation. Explicit schedule pins remain authoritative, cache identity mismatches fail closed, and invalid or non-stationary candidates are never cached.

## Tests

- focused dispatch/schedule/cache/compiler integration: 28 tests, 128 assertions
- adjacent measurement/ABI/router coverage: 32 tests, 123 assertions
- clj-kondo on touched files: 0 errors (3 pre-existing schedule warnings)
- cljfmt and git diff check clean

The local GPU probe was unavailable for these runs, so device-gated behavior remains skipped; CircleCI is the broad device-free suite gate.
