### PR TITLE
Benchmark validated kernel dispatch candidates

### DIFF
--- a/src/raster/compiler/ir/execution_plan.clj
+++ b/src/raster/compiler/ir/execution_plan.clj
@@ -154,3 +154,18 @@
                               (when-not (contains? depended-on id) id))
                             (:nodes graph-call)))]
     (validate! (->ExecutionPlan [queue] [] operations outputs))))
+
+(defn from-kernel-call
+  "Lower one checked KernelCall to the same target-neutral compute/event contract used by a
+   KernelGraphCall. This is the executable unit used by offline candidate benchmarking: a single
+   emitted alternative still travels through an explicit queue and completion event."
+  ([call] (from-kernel-call :kernel-call call))
+  ([id call]
+   (let [call (kcall/validate! call)
+         queue (compute-queue)
+         completion (->LogicalEvent [:operation-complete id])]
+     (validate!
+      (->ExecutionPlan
+       [queue] []
+       [(->ScheduledOperation id call queue [] completion)]
+       [completion])))))

--- a/src/raster/compiler/ir/kernel_dispatch.clj
+++ b/src/raster/compiler/ir/kernel_dispatch.clj
@@ -41,13 +41,20 @@
                      :strategies (set (keys strategies))}))))
 
 (defn- validate-selector!
-  [dispatch strategies common-arguments]
+  [dispatch strategies common]
   (let [{:keys [kind argument threshold at-least otherwise ranges below]}
-        (:selector dispatch)]
-    (when-not (some #(= argument %) common-arguments)
-      (throw (ex-info "kernel dispatch selector argument is absent from the common ABI values"
+        (:selector dispatch)
+        common-arguments (:arguments common)
+        indexes (keep-indexed (fn [index value] (when (= argument value) index))
+                              common-arguments)]
+    (when-not (= 1 (count indexes))
+      (throw (ex-info "kernel dispatch selector argument must have one common ABI position"
                       {:id (:id dispatch) :argument argument
-                       :arguments common-arguments})))
+                       :arguments common-arguments :indexes (vec indexes)})))
+    (let [slot (nth (:abi common) (first indexes))]
+      (when-not (= :scalar (:kind slot))
+        (throw (ex-info "kernel dispatch selector argument must name a scalar ABI slot"
+                        {:id (:id dispatch) :argument argument :slot slot}))))
     (case kind
       :runtime-scalar-threshold
       (do
@@ -97,6 +104,7 @@
     (doseq [artifact alternatives] (kart/validate! artifact))
     (let [strategies (mapv artifact-strategy alternatives)
           strategy-set (set strategies)
+          kernel-names (mapv :kernel-name alternatives)
           common (first alternatives)
           common-view (select-keys common [:target :abi :arguments :temporaries :effects])]
       (when-not (every? keyword? strategies)
@@ -105,6 +113,9 @@
       (when-not (= (count strategies) (count strategy-set))
         (throw (ex-info "kernel dispatch alternative strategies must be unique"
                         {:id id :strategies strategies})))
+      (when-not (= (count kernel-names) (count (set kernel-names)))
+        (throw (ex-info "kernel dispatch alternatives must have unique emitted entry points"
+                        {:id id :kernel-names kernel-names})))
       (doseq [artifact (rest alternatives)]
         (when-not (= common-view
                      (select-keys artifact [:target :abi :arguments :temporaries :effects]))
@@ -115,7 +126,7 @@
       (when-not (contains? strategy-set default-strategy)
         (throw (ex-info "kernel dispatch default strategy is absent"
                         {:id id :default default-strategy :strategies strategy-set})))
-      (validate-selector! dispatch (strategy-map alternatives) (:arguments common)))
+      (validate-selector! dispatch (strategy-map alternatives) common))
     (doseq [[field value] [[:provenance provenance] [:attributes attributes]]]
       (when-not (map? value)
         (throw (ex-info "kernel dispatch metadata must be maps"

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -33,6 +33,7 @@
             [raster.compiler.ir.buffer-view :as bview]
             [raster.compiler.ir.execution-plan :as execution]
             [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-graph :as kgraph]
@@ -1198,6 +1199,88 @@
                       :temporary-buffers temporary-buffers})
           (throw e))))))
 
+(defn bind-kernel-call!
+  "Bind one emitted KernelArtifact over session-resident arguments as a replayable graph.
+
+   `arguments` follow the artifact's PHYSICAL ABI order. Pointer entries are session buffer keys
+   or ResidentBufferViews; scalar entries are typed values such as `{:type :int :value 4096}`.
+   The resulting KernelCall is checked before driver contact and then recorded through the same
+   queue/event machinery as a multi-kernel graph. This is the generic runtime seam used to
+   validate and device-time one schedule alternative during explicit offline tuning.
+
+   Options: :profile? records device timestamp events; :group-count may override only the realized
+   grid, never the emitted workgroup geometry. Rebinding `call-key` replaces and releases the old
+   recording transactionally after the new recording succeeds."
+  ([sess call-key artifact arguments]
+   (bind-kernel-call! sess call-key artifact arguments {}))
+  ([sess call-key artifact arguments {:keys [profile? group-count]
+                                      :or {profile? false}}]
+   (let [{:keys [device-id closed?]} @sess
+         artifact (kart/validate! artifact)
+         abi (:abi artifact)]
+     (when closed?
+       (throw (ex-info "cannot bind a kernel call in a closed GPU session" {:key call-key})))
+     (when (nil? call-key)
+       (throw (ex-info "bound kernel call requires a non-nil key" {})))
+     (kabi/validate-arguments! abi arguments)
+     (let [pointer-bindings
+           (into {}
+                 (keep-indexed (fn [index [slot value]]
+                                 (when-not (= :scalar (:kind slot))
+                                   [index (resolve-resident-binding sess value)])))
+                 (mapv vector abi arguments))
+           _ (release-graph-events! sess call-key)
+           owned-view-buffers (volatile! [])
+           prepareds (volatile! [])
+           runtime-graph (volatile! nil)]
+       (try
+         (let [{:keys [buffers] :as materialized}
+               (materialize-external-buffers! device-id pointer-bindings)
+               _ (vreset! owned-view-buffers (:owned-view-buffers materialized))
+               runtime-arguments
+               (mapv (fn [index [slot value]]
+                       (if (= :scalar (:kind slot)) value (get buffers index)))
+                     (range) (mapv vector abi arguments))
+               call (kcall/make artifact runtime-arguments
+                                (cond-> {} group-count (assoc :group-count group-count)))
+               execution-plan (execution/from-kernel-call call-key call)
+               register! (rt-resolve device-id "register-kernel!")
+               bind-call! (rt-resolve device-id "bind-kernel-call")
+               record! (rt-resolve device-id "record-graph!")
+               _ (register! (:kernel-name artifact) artifact)
+               prepared (assoc (bind-call! call) :phase call-key)
+               _ (vreset! prepareds [prepared])
+               _ (vreset! runtime-graph
+                          (record! [prepared] {:barriers? true
+                                               :profile? (boolean profile?)}))
+               outputs
+               (into {}
+                     (keep-indexed
+                      (fn [index slot]
+                        (when (= :output (:kind slot))
+                          [(or (:binding slot) (:name slot))
+                           (nth runtime-arguments index)])))
+                     abi)
+               entry {:kernel-call call
+                      :execution-plan execution-plan
+                      :runtime-graph @runtime-graph
+                      :prepareds @prepareds
+                      :owned-view-buffers @owned-view-buffers
+                      :temporary-buffers {}
+                      :outputs outputs
+                      :profile? (boolean profile?)}
+               old (get-in @sess [:kernel-graphs call-key])]
+           (swap! sess assoc-in [:kernel-graphs call-key] entry)
+           (when old (destroy-kernel-graph-entry! device-id old))
+           (->KernelGraphHandle call-key))
+         (catch Exception e
+           (destroy-kernel-graph-entry!
+            device-id {:runtime-graph @runtime-graph
+                       :prepareds @prepareds
+                       :owned-view-buffers @owned-view-buffers
+                       :temporary-buffers {}})
+           (throw e)))))))
+
 (defn kernel-graph-execution-plan
   "Return the pure backend-neutral queue/event plan for a bound KernelGraph."
   [sess handle]
@@ -1239,9 +1322,16 @@
 (defn run-kernel-graph!
   "Submit a bound graph, wait for completion, and return its resident output buffers."
   [sess handle]
-  (let [event (submit-kernel-graph! sess handle)]
+  (let [{:keys [device-id]} @sess
+        {:keys [runtime-graph profile?]} (resolve-kernel-graph-entry sess handle)
+        event (submit-kernel-graph! sess handle)]
     (try
-      (await-event! sess event)
+      (let [outputs (await-event! sess event)]
+        ;; A validation replay of a profiled graph intentionally discards its timestamps. Reset
+        ;; the per-kernel events so a subsequent measure-graph! replay can signal them legally.
+        (when profile?
+          ((rt-resolve device-id "reset-graph-events!") runtime-graph))
+        outputs)
       (finally
         (release-event! sess event)))))
 
@@ -2077,6 +2167,19 @@
                              (dissoc :before-sample!)
                              (assoc :timing-source :device-event))]
     (apply measurement/measure! sample-fn (mapcat identity measurement-opts))))
+
+(defn measure-bound-kernel-graph!
+  "Device-event measurement of a bound KernelGraphHandle.
+
+   The graph must have been recorded with `:profile? true` (currently supplied by
+   bind-kernel-call!). This keeps runtime graph representations private while exposing the same
+   bounded Measurement contract to generic offline tuning code."
+  [sess handle & {:as opts}]
+  (let [{:keys [runtime-graph profile?]} (resolve-kernel-graph-entry sess handle)]
+    (when-not profile?
+      (throw (ex-info "bound kernel graph was not recorded with :profile? true"
+                      {:handle handle})))
+    (apply measure-graph! sess runtime-graph (mapcat identity opts))))
 
 (defn measure-program!
   "Explicit offline device-event measurement of a bound resident program.

--- a/src/raster/gpu/dispatch_benchmark.clj
+++ b/src/raster/gpu/dispatch_benchmark.clj
@@ -1,0 +1,157 @@
+(ns raster.gpu.dispatch-benchmark
+  "Concrete resident execution driver for generic KernelDispatch autotuning.
+
+   This namespace contains no operation recognition or schedule policy. A dispatch already owns
+   emitted ABI-compatible alternatives; a benchmark case supplies resident arguments, an
+   independent correctness oracle, and (only when necessary) a reset action. Every candidate is
+   validated before it is measured, device time comes from profiling events, and DispatchTuning
+   remains responsible for selection and caching."
+  (:require [clojure.set :as set]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.gpu.core :as gpu]
+            [raster.gpu.dispatch-tuning :as tuning]))
+
+(def ^:private reserved-measurement-options
+  #{:before-sample! :compile-ms :hashes :timing-source})
+
+(defn- runtime-number
+  [value]
+  (if (and (map? value) (contains? value :value)) (:value value) value))
+
+(defn- stateful-artifact?
+  [artifact]
+  (let [{:keys [reads writes]} (:effects artifact)]
+    (boolean (seq (set/intersection (set reads) (set writes))))))
+
+(defn- validate-case!
+  [dispatch artifact runtime-value case]
+  (when-not (map? case)
+    (throw (ex-info "dispatch benchmark case must be a map"
+                    {:runtime-value runtime-value :case case})))
+  (let [{:keys [arguments validate! before-run! measurement]} case
+        selector-argument (get-in dispatch [:selector :argument])
+        indexes (keep-indexed (fn [index value]
+                                (when (= selector-argument value) index))
+                              (:arguments artifact))]
+    (when-not (vector? arguments)
+      (throw (ex-info "dispatch benchmark case arguments must be an ABI-ordered vector"
+                      {:runtime-value runtime-value :arguments arguments})))
+    (when-not (= (count (:abi artifact)) (count arguments))
+      (throw (ex-info "dispatch benchmark case argument count differs from the artifact ABI"
+                      {:runtime-value runtime-value
+                       :expected (count (:abi artifact)) :actual (count arguments)})))
+    (when-not (= 1 (count indexes))
+      (throw (ex-info "dispatch benchmark selector must have one artifact argument position"
+                      {:runtime-value runtime-value :argument selector-argument
+                       :indexes (vec indexes)})))
+    (let [actual (runtime-number (nth arguments (first indexes)))]
+      (when-not (= runtime-value actual)
+        (throw (ex-info "dispatch benchmark case does not bind its sampled runtime value"
+                        {:selector-argument selector-argument
+                         :sampled runtime-value :bound actual}))))
+    (when-not (ifn? validate!)
+      (throw (ex-info "dispatch benchmark case requires a :validate! oracle callback"
+                      {:runtime-value runtime-value})))
+    (when-not (or (nil? before-run!) (ifn? before-run!))
+      (throw (ex-info "dispatch benchmark :before-run! must be callable"
+                      {:runtime-value runtime-value :before-run! before-run!})))
+    (when (and (stateful-artifact? artifact) (nil? before-run!))
+      (throw (ex-info "stateful dispatch candidates require :before-run! restoration"
+                      {:runtime-value runtime-value :effects (:effects artifact)})))
+    (when-not (or (nil? measurement) (map? measurement))
+      (throw (ex-info "dispatch benchmark :measurement options must be a map"
+                      {:runtime-value runtime-value :measurement measurement})))
+    (when-let [reserved (seq (set/intersection reserved-measurement-options
+                                               (set (keys measurement))))]
+      (throw (ex-info "dispatch benchmark measurement options contain driver-owned fields"
+                      {:runtime-value runtime-value :reserved (set reserved)})))
+    case))
+
+(defn- validate-oracle-result!
+  [artifact runtime-value validation]
+  (let [source-hash (:source-hash (tuning/artifact-signature artifact))]
+    (when-not (and (map? validation)
+                   (true? (:passed? validation))
+                   (string? (:oracle-hash validation))
+                   (not-empty (:oracle-hash validation)))
+      (throw (ex-info "dispatch candidate failed its oracle before measurement"
+                      {:runtime-value runtime-value
+                       :strategy (kdispatch/artifact-strategy artifact)
+                       :validation validation})))
+    (assoc validation :candidate-hash source-hash)))
+
+(defn benchmark-candidate!
+  "Validate and device-time one emitted dispatch alternative at one sampled runtime value.
+
+   `case-fn` is called as `(case-fn runtime-value)` and returns:
+
+     {:arguments   [buffer-key-or-view ... typed-scalars ...] ; physical ABI order
+      :validate!   (fn [context] {:passed? true :oracle-hash string ...})
+      :before-run! (fn [context] ...)                        ; optional restore
+      :measurement {:budget-ms ... :min-samples ...}}        ; optional
+
+   The context contains :session, :dispatch, :artifact, :runtime-value, :case, and after the
+   validation replay, :outputs. The driver supplies :candidate-hash itself, so a callback cannot
+   accidentally validate one source and bless another."
+  [session dispatch artifact runtime-value case-fn & {:keys [measurement]}]
+  (let [dispatch (kdispatch/validate! dispatch)
+        strategy (kdispatch/artifact-strategy artifact)
+        expected (kdispatch/artifact dispatch strategy)
+        _ (when-not (= expected artifact)
+            (throw (ex-info "dispatch benchmark artifact is not the registered alternative"
+                            {:strategy strategy :expected expected :artifact artifact})))
+        _ (when-not (or (nil? measurement) (map? measurement))
+            (throw (ex-info "dispatch benchmark global :measurement options must be a map"
+                            {:measurement measurement})))
+        case (validate-case! dispatch artifact runtime-value (case-fn runtime-value))
+        measurement-options (merge measurement (:measurement case))
+        reserved (set/intersection reserved-measurement-options
+                                   (set (keys measurement-options)))]
+    (when (seq reserved)
+      (throw (ex-info "dispatch benchmark measurement options contain driver-owned fields"
+                      {:runtime-value runtime-value :reserved reserved})))
+    (let [key [::candidate runtime-value (kdispatch/artifact-strategy artifact) (random-uuid)]
+          started (System/nanoTime)
+          handle (gpu/bind-kernel-call! session key artifact (:arguments case)
+                                        {:profile? true
+                                         :group-count (:group-count case)})
+          compile-ms (/ (- (System/nanoTime) started) 1.0e6)
+          base-context {:session session :dispatch dispatch :artifact artifact
+                        :runtime-value runtime-value :case case}]
+      (try
+        (when-let [before-run! (:before-run! case)] (before-run! base-context))
+        (let [outputs (gpu/run-kernel-graph! session handle)
+              validation (validate-oracle-result!
+                          artifact runtime-value
+                          ((:validate! case) (assoc base-context :outputs outputs)))
+              before-sample! (when-let [before-run! (:before-run! case)]
+                               #(before-run! base-context))
+              hashes {:candidate (:candidate-hash validation)
+                      :oracle (:oracle-hash validation)}
+              opts (cond-> measurement-options
+                     before-sample! (assoc :before-sample! before-sample!)
+                     true (assoc :compile-ms compile-ms :hashes hashes))
+              measured (apply gpu/measure-bound-kernel-graph!
+                              session handle (mapcat identity opts))]
+          {:measurement measured :validation validation})
+        (finally
+          (gpu/release-kernel-graph! session handle))))))
+
+(defn tune-dispatch!
+  "Tune an emitted KernelDispatch through resident validation and device-event measurement.
+
+   This is an explicit offline action. Compilation and ordinary dispatch remain pure and never
+   acquire a benchmark side effect. Options are DispatchTuning identity/policy fields plus a
+   global :measurement option map; an individual benchmark case may refine those sampling bounds."
+  [session dispatch descriptor runtime-values case-fn
+   & {:keys [numerical-mode layout improvement-threshold force? measurement]
+      :or {improvement-threshold 0.001 force? false}}]
+  (tuning/tune!
+   dispatch descriptor runtime-values
+   (fn [artifact runtime-value]
+     (benchmark-candidate! session dispatch artifact runtime-value case-fn
+                           :measurement measurement))
+   :numerical-mode numerical-mode
+   :layout layout
+   :improvement-threshold improvement-threshold
+   :force? force?))

--- a/test/raster/compiler/ir/execution_plan_test.clj
+++ b/test/raster/compiler/ir/execution_plan_test.clj
@@ -2,9 +2,27 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.segop-opencl :as emit]
             [raster.compiler.ir.execution-plan :as execution]
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-call :as kernel-call]
+            [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.kernel-graph-call :as graph-call]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.soac-lower :as lower]))
+
+(defn- one-call
+  []
+  (let [artifact
+        (artifact/make
+         {:kernel-name "execution_plan_probe"
+          :source "__kernel void execution_plan_probe(__global float* out, int n) {}"
+          :abi [(kabi/slot 'out :output :float :role :result)
+                (kabi/slot 'n :scalar :int :role :bound)]
+          :arguments '[out n]
+          :launch (launch/spec {:workgroup-size [64]
+                                :group-count [(launch/ceil-div 'n 64)]})
+          :effects {:kind :elementwise-map :writes ['out]}})]
+    (kernel-call/make artifact [(Object.) {:type :int :value 128}])))
 
 (defn- emitted-graph []
   (let [node (soac/par-form->soac
@@ -45,3 +63,13 @@
            [queue] []
            [(execution/->ScheduledOperation :first :operation queue [later] done)]
            [done]))))))
+
+(deftest one-kernel-call-uses-the-same-logical-execution-contract
+  (let [call (one-call)
+        plan (execution/from-kernel-call :candidate call)
+        operation (first (:operations plan))]
+    (is (execution/execution-plan? plan))
+    (is (= call (:operation operation)))
+    (is (= :compute (get-in operation [:queue :class])))
+    (is (empty? (:waits operation)))
+    (is (= [(:completion operation)] (:outputs plan)))))

--- a/test/raster/compiler/ir/kernel_dispatch_test.clj
+++ b/test/raster/compiler/ir/kernel_dispatch_test.clj
@@ -102,7 +102,26 @@
          clojure.lang.ExceptionInfo #"absent strategy"
          (kdispatch/with-selector
            dispatch {:kind :runtime-scalar-ranges :argument 'width :below :unknown
-                     :ranges []})))))
+                     :ranges []}))))
+  (testing "a runtime selector must name exactly one scalar ABI position"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"must name a scalar"
+         (kdispatch/make
+          {:id "pointer-selector"
+           :alternatives [reference subgroup]
+           :default-strategy :reference
+           :selector {:kind :runtime-scalar-threshold :argument 'x :threshold 1
+                      :at-least :subgroup-score-reuse :otherwise :reference}}))))
+  (testing "alternatives need distinct runtime registry entry points"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"unique emitted entry points"
+         (kdispatch/make
+          {:id "duplicate-entry-point"
+           :alternatives [reference
+                          (assoc subgroup :kernel-name (:kernel-name reference)
+                                 :source (:source reference))]
+           :default-strategy :reference
+           :selector (:selector dispatch)})))))
 
 (deftest both-resident-backends-register-the-same-pure-dispatch
   (doseq [[register! entry] [[ze/register-kernel-dispatch!

--- a/test/raster/gpu/dispatch_benchmark_device_test.clj
+++ b/test/raster/gpu/dispatch_benchmark_device_test.clj
@@ -1,0 +1,106 @@
+(ns raster.gpu.dispatch-benchmark-device-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.dl.gpu-grad-parity :as gpu-probe]
+            [raster.gpu.core :as gpu]
+            [raster.gpu.dispatch-benchmark :as benchmark]
+            [raster.gpu.tuning-cache :as cache])
+  (:import [java.nio.file Files]))
+
+(def ^:private opencl-available?
+  (delay
+    (try
+      (require 'raster.gpu.ocl-runtime)
+      ((resolve 'raster.gpu.ocl-runtime/init!))
+      true
+      (catch Throwable _ false))))
+
+(def ^:private abi
+  [(kabi/slot 'x :input :float :role :operand)
+   (kabi/slot 'out :output :float :role :result)
+   (kabi/slot 'n :scalar :int :role :shape)])
+
+(defn- affine-artifact
+  [kernel-name strategy workgroup]
+  (artifact/make
+   {:kernel-name kernel-name
+    :source
+    (str "__kernel void " kernel-name
+         "(__global const float* x, __global float* out, int n) {\n"
+         "  for (int i = get_global_id(0); i < n; i += get_global_size(0))\n"
+         "    out[i] = 2.0f * x[i] + 1.0f;\n"
+         "}\n")
+    :abi abi
+    :arguments '[x out n]
+    :launch (launch/spec {:workgroup-size [workgroup]
+                          :group-count [(launch/ceil-div 'n workgroup)]})
+    :effects {:kind :elementwise-map :reads ['x] :writes ['out]}
+    :attributes {:strategy strategy}}))
+
+(def ^:private dispatch
+  (kdispatch/make
+   {:id "device-affine-dispatch"
+    :alternatives [(affine-artifact "device_affine_wg64" :wg64 64)
+                   (affine-artifact "device_affine_wg128" :wg128 128)]
+    :default-strategy :wg64
+    :selector {:kind :runtime-scalar-threshold :argument 'n :threshold 512
+               :at-least :wg128 :otherwise :wg64}}))
+
+(defn- temporary-cache-root
+  []
+  (.toFile (Files/createTempDirectory "raster-device-dispatch-benchmark-"
+                                      (make-array java.nio.file.attribute.FileAttribute 0))))
+
+(defn- tune-affine!
+  [device-id]
+  (let [capacity 1024
+        input (float-array (map #(float (* 0.25 %)) (range capacity)))]
+    (binding [cache/*cache-root* (temporary-cache-root)]
+      (gpu/with-gpu-session*
+        device-id
+        (fn [session]
+          (gpu/alloc! session {:x [:float capacity input]
+                               :out [:float capacity nil]})
+          (benchmark/tune-dispatch!
+           session dispatch (hardware/descriptor-for device-id) [127 capacity]
+           (fn [n]
+             {:arguments [:x :out {:type :int :value n}]
+              :validate!
+              (fn [_]
+                (let [actual ^floats (gpu/download session :out)
+                      max-error
+                      (reduce max 0.0
+                              (map (fn [index]
+                                     (Math/abs
+                                      (- (double (aget actual index))
+                                         (+ (* 2.0 (double (aget input index))) 1.0))))
+                                   (range n)))]
+                  {:passed? (< max-error 1.0e-6)
+                   :oracle-hash (str "affine-f32-v1-" n)
+                   :max-error max-error}))
+              :measurement {:warmup-iterations 0 :budget-ms 1
+                            :min-samples 3 :max-samples 5 :cv-threshold 100.0}})
+           :numerical-mode {:input :f32 :accumulate :f32 :output :f32}
+           :layout {:input :contiguous :output :contiguous}
+           :force? true))))))
+
+(defn- assert-device-tuning!
+  [device-id]
+  (let [result (tune-affine! device-id)]
+    (is (= 4 (count (:measurements result))))
+    (is (every? #(true? (get-in % [:validation :passed?])) (:measurements result)))
+    (is (= :runtime-scalar-ranges (get-in result [:selector :kind])))))
+
+(deftest level-zero-validates-and-measures-emitted-dispatch-alternatives
+  (if-not @gpu-probe/gpu-available?
+    (gpu-probe/gpu-skip! "validated KernelDispatch benchmark on Level Zero")
+    (assert-device-tuning! :ze:0)))
+
+(deftest opencl-validates-and-measures-emitted-dispatch-alternatives
+  (if-not @opencl-available?
+    (is true "OpenCL device unavailable")
+    (assert-device-tuning! :ocl:0)))

--- a/test/raster/gpu/dispatch_benchmark_test.clj
+++ b/test/raster/gpu/dispatch_benchmark_test.clj
@@ -1,0 +1,162 @@
+(ns raster.gpu.dispatch-benchmark-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.gpu.core :as gpu]
+            [raster.gpu.dispatch-benchmark :as benchmark]
+            [raster.gpu.dispatch-tuning :as tuning]
+            [raster.gpu.measurement :as measurement]
+            [raster.gpu.tuning-cache :as cache])
+  (:import [java.nio.file Files]))
+
+(def ^:private abi
+  [(kabi/slot 'x :input :float :role :operand)
+   (kabi/slot 'out :output :float :role :result)
+   (kabi/slot 'width :scalar :long :role :shape)])
+
+(defn- emitted
+  [kernel-name strategy workgroup]
+  (artifact/make
+   {:kernel-name kernel-name
+    :source (str "__kernel void " kernel-name
+                 "(__global const float* x, __global float* out, long width) {}")
+    :abi abi
+    :arguments '[x out width]
+    :launch (launch/spec {:workgroup-size [workgroup]
+                          :group-count [(launch/ceil-div 'width workgroup)]})
+    :effects {:kind :elementwise-map :reads ['x] :writes ['out]}
+    :attributes {:strategy strategy}}))
+
+(def ^:private reference (emitted "benchmark_reference" :reference 64))
+(def ^:private subgroup (emitted "benchmark_subgroup" :subgroup 16))
+
+(def ^:private dispatch
+  (kdispatch/make
+   {:id "resident-benchmark-test"
+    :alternatives [reference subgroup]
+    :default-strategy :reference
+    :selector {:kind :runtime-scalar-threshold
+               :argument 'width :threshold 256
+               :at-least :subgroup :otherwise :reference}}))
+
+(def ^:private descriptor
+  {:device-id :ze:0 :vendor "Intel" :arch "test" :driver-version "test-driver"
+   :machine-lanes 8192 :subgroup-size 16})
+
+(defn- temporary-cache-root
+  []
+  (.toFile (Files/createTempDirectory "raster-dispatch-benchmark-"
+                                      (make-array java.nio.file.attribute.FileAttribute 0))))
+
+(deftest resident-driver-validates-before-device-measurement
+  (let [actions (atom [])
+        result
+        (with-redefs [gpu/bind-kernel-call!
+                      (fn [_ key candidate arguments opts]
+                        (swap! actions conj [:bind key candidate arguments opts])
+                        {:candidate candidate})
+                      gpu/run-kernel-graph!
+                      (fn [_ handle]
+                        (swap! actions conj [:validate-run (:candidate handle)])
+                        {'out :resident-output})
+                      gpu/measure-bound-kernel-graph!
+                      (fn [_ handle & {:keys [before-sample! compile-ms hashes]}]
+                        (swap! actions conj [:measure (:candidate handle) compile-ms hashes])
+                        (when before-sample! (before-sample!))
+                        (measurement/summarize [10 10 10]
+                                               :timing-source :device-event
+                                               :compile-ms compile-ms :hashes hashes))
+                      gpu/release-kernel-graph!
+                      (fn [_ handle] (swap! actions conj [:release (:candidate handle)]))]
+          (benchmark/benchmark-candidate!
+           (atom {}) dispatch reference 128
+           (fn [_]
+             {:arguments [:x :out {:type :long :value 128}]
+              :before-run! #(swap! actions conj [:restore (:runtime-value %)])
+              :validate! (fn [{:keys [outputs]}]
+                           (is (= {'out :resident-output} outputs))
+                           {:passed? true :oracle-hash "host-reference-v1"})})))]
+    (is (= :device-event (get-in result [:measurement :timing-source])))
+    (is (= "host-reference-v1" (get-in result [:validation :oracle-hash])))
+    (is (= (:source-hash (tuning/artifact-signature reference))
+           (get-in result [:validation :candidate-hash])))
+    (is (= [:bind :restore :validate-run :measure :restore :release]
+           (mapv first @actions)))
+    (is (number? (get-in result [:measurement :compile-ms])))))
+
+(deftest failed-oracle-is-never-measured-and-always-releases
+  (let [measured? (atom false)
+        released? (atom false)]
+    (with-redefs [gpu/bind-kernel-call! (fn [& _] :handle)
+                  gpu/run-kernel-graph! (fn [& _] {})
+                  gpu/measure-bound-kernel-graph! (fn [& _] (reset! measured? true))
+                  gpu/release-kernel-graph! (fn [& _] (reset! released? true))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"failed its oracle"
+           (benchmark/benchmark-candidate!
+            (atom {}) dispatch reference 128
+            (fn [_]
+              {:arguments [:x :out {:type :long :value 128}]
+               :validate! (constantly {:passed? false :oracle-hash "host-reference-v1"})}))))
+      (is (false? @measured?))
+      (is @released?))))
+
+(deftest explicit-reset-is-required-for-read-write-candidates
+  (let [effects {:kind :stateful :reads ['out] :writes ['out]}
+        stateful (assoc reference :effects effects)
+        stateful-dispatch (assoc dispatch :alternatives
+                                 [stateful (assoc subgroup :effects effects)])]
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"require :before-run!"
+         (benchmark/benchmark-candidate!
+          (atom {}) stateful-dispatch stateful 128
+          (fn [_]
+            {:arguments [:x :out {:type :long :value 128}]
+             :validate! (constantly {:passed? true :oracle-hash "oracle"})}))))))
+
+(deftest end-to-end-driver-produces-a-nonmonotonic-measured-selector
+  (binding [cache/*cache-root* (temporary-cache-root)]
+    (let [costs {:reference {128 10.0 256 10.0 768 5.0}
+                 :subgroup {128 12.0 256 7.0 768 6.0}}
+          binds (atom 0)
+          releases (atom 0)]
+      (with-redefs [gpu/bind-kernel-call!
+                    (fn [_ _ candidate arguments _]
+                      (swap! binds inc)
+                      {:candidate candidate
+                       :runtime-value (get-in arguments [2 :value])})
+                    gpu/run-kernel-graph! (fn [& _] {'out :resident-output})
+                    gpu/measure-bound-kernel-graph!
+                    (fn [_ {:keys [candidate runtime-value]}
+                         & {:keys [compile-ms hashes before-sample!]}]
+                      (when before-sample! (before-sample!))
+                      (let [cost (get-in costs [(kdispatch/artifact-strategy candidate)
+                                                runtime-value])]
+                        (measurement/summarize [cost cost cost]
+                                               :timing-source :device-event
+                                               :compile-ms compile-ms :hashes hashes)))
+                    gpu/release-kernel-graph! (fn [& _] (swap! releases inc))]
+        (let [result
+              (benchmark/tune-dispatch!
+               (atom {}) dispatch descriptor [768 128 256]
+               (fn [runtime-value]
+                 {:arguments [:x :out {:type :long :value runtime-value}]
+                  :validate! (constantly {:passed? true
+                                          :oracle-hash (str "oracle-" runtime-value)})})
+               :numerical-mode {:input :f32 :accumulate :f32 :output :f32}
+               :layout {:input :row-major :output :row-major}
+               :force? true)]
+          (is (= [{:at-least 256 :strategy :subgroup}
+                  {:at-least 768 :strategy :reference}]
+                 (get-in result [:selector :ranges])))
+          (is (= 6 @binds @releases))
+          (testing "cached result bypasses resident execution"
+            (let [cached (benchmark/tune-dispatch!
+                          (atom {}) dispatch descriptor [128 256 768]
+                          (fn [_] (throw (ex-info "must not construct a case" {})))
+                          :numerical-mode {:input :f32 :accumulate :f32 :output :f32}
+                          :layout {:input :row-major :output :row-major})]
+              (is (= (:selector result) (:selector cached)))
+              (is (= 6 @binds @releases)))))))))

--- a/test/raster/gpu/kernel_graph_runner_test.clj
+++ b/test/raster/gpu/kernel_graph_runner_test.clj
@@ -2,10 +2,27 @@
   (:require [clojure.test :refer [deftest is]]
             [raster.compiler.backend.gpu.segop-opencl :as emit]
             [raster.compiler.ir.buffer-view :as bview]
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.soac-lower :as lower]
             [raster.gpu.core :as gpu]
             [raster.runtime.hardware :as hardware]))
+
+(defn- probe-artifact
+  []
+  (artifact/make
+   {:kernel-name "bound_call_probe"
+    :source (str "__kernel void bound_call_probe(__global const float* x, "
+                 "__global float* out, int n) {}")
+    :abi [(kabi/slot 'x :input :float :role :operand)
+          (kabi/slot 'out :output :float :role :result)
+          (kabi/slot 'n :scalar :int :role :bound)]
+    :arguments '[x out n]
+    :launch (launch/spec {:workgroup-size [64]
+                          :group-count [(launch/ceil-div 'n 64)]})
+    :effects {:kind :elementwise-map :reads ['x] :writes ['out]}}))
 
 (defn- emitted-graph []
   (let [node (soac/par-form->soac
@@ -140,6 +157,65 @@
           (is (not-any? #(or (identical? values-buffer %)
                              (identical? output-buffer %))
                         @freed)))))))
+
+(deftest one-kernel-call-binds-validates-and-measures-through-the-graph-runtime
+  (let [input-buffer {:dtype :float :n-elements 128 :byte-size 512}
+        output-buffer {:dtype :float :n-elements 128 :byte-size 512}
+        allocation (fn [id]
+                     (bview/allocation {:id id :byte-size 512 :memory-space :shared
+                                        :device :ze:0 :coherence :host-coherent
+                                        :ownership :owned}))
+        session (atom {:device-id :ze:0 :session-id :call-session
+                       :buffers {:x input-buffer :out output-buffer}
+                       :allocations {:x (allocation :x) :out (allocation :out)}
+                       :kernel-graphs {} :events {} :closed? false})
+        registered (atom [])
+        resets (atom 0)
+        replays (atom 0)
+        destroyed (atom [])
+        resolver
+        (fn [_ name]
+          (case name
+            "register-kernel!" (fn [kernel-name emitted]
+                                 (swap! registered conj [kernel-name emitted]))
+            "bind-kernel-call" (fn [call] {:kernel-call call})
+            "record-graph!" (fn [prepared opts]
+                              {:prepared prepared :profile? (:profile? opts)})
+            "submit-graph!" (fn [graph] {:graph graph})
+            "await-event!" identity
+            "event-complete?" (constantly true)
+            "release-event!" identity
+            "reset-graph-events!" (fn [_] (swap! resets inc))
+            "replay-graph!" (fn [_] (swap! replays inc))
+            "read-graph-timestamps!" (fn [_] {:wall-ms 0.001})
+            (throw (ex-info "unexpected mocked runtime function" {:name name}))))
+        soft-resolver
+        (fn [_ name]
+          (case name
+            "destroy-graph!" #(swap! destroyed conj [:graph %])
+            "destroy-prepared!" #(swap! destroyed conj [:prepared %])
+            nil))]
+    (with-redefs-fn
+      {(ns-resolve 'raster.gpu.core 'rt-resolve) resolver
+       (ns-resolve 'raster.gpu.core 'rt-resolve-soft) soft-resolver}
+      (fn []
+        (let [emitted (probe-artifact)
+              handle (gpu/bind-kernel-call!
+                      session :candidate emitted
+                      [:x :out {:type :int :value 128}]
+                      {:profile? true})
+              outputs (gpu/run-kernel-graph! session handle)
+              measured (gpu/measure-bound-kernel-graph!
+                        session handle :warmup-iterations 1 :budget-ms 1
+                        :min-samples 3 :max-samples 3)]
+          (is (= [["bound_call_probe" emitted]] @registered))
+          (is (identical? output-buffer (get outputs 'out)))
+          (is (= 1 @resets) "validation replay resets discarded profiling events")
+          (is (= :device-event (:timing-source measured)))
+          (is (= 1000.0 (:min-ns measured)))
+          (is (= (+ 1 5 3) @replays))
+          (gpu/release-kernel-graph! session handle)
+          (is (= 2 (count @destroyed))))))))
 
 (deftest opencl-sub-buffer-handles-follow-the-graph-lifetime
   (let [n 1025


### PR DESCRIPTION
## Summary

- bind one emitted KernelArtifact as a fully checked resident KernelCall and replayable profiling graph
- lower single calls through the same backend-neutral queue/event ExecutionPlan used by multi-kernel graphs
- add a generic offline driver that validates every dispatch candidate against an independent oracle before device-event measurement
- automatically bind validation to the candidate source hash and require restoration for declared read/write state
- feed measured candidates into the existing DispatchTuning cache and piecewise runtime selector
- tighten KernelDispatch invariants: selectors must reference exactly one scalar ABI slot and alternatives need unique runtime entry points

## Compiler boundary

This adds no attention-, contraction-, or reduction-specific tuning pass. The compiler emits ABI-compatible alternatives into KernelDispatch; the offline runtime driver binds resident arguments, validates outputs, measures the alternatives, and returns ordinary selector data. Compilation and normal execution still never benchmark.

## Correctness and lifecycle

- failed oracle validation aborts before measurement and cannot enter the cache
- the driver owns candidate hashes, timing-source metadata, and compile-time metadata
- profiling events reset between the validation replay and timed samples
- graph recordings, dedicated kernel handles, and temporary view handles release on success or failure
- read/write candidates require an explicit before-run restoration callback

## Tests

- full suite: 2,257 tests, 33,270 assertions, 0 failures/errors
- focused compiler/runtime/tuning regression set: 45 tests, 213 assertions
- cljfmt clean
- clj-kondo: 0 errors; touched legacy files retain their existing unresolved-var warnings

The local Level Zero probe currently fails during zeInit and OpenCL is unavailable, so hardware-gated cases skipped. The new hardware test is present for a machine with either backend; CircleCI remains a device-free gate.
