### PR TITLE
Add routed paged KV append kernel

### DIFF
--- a/src/raster/compiler/backend/gpu/paged_kv_append.clj
+++ b/src/raster/compiler/backend/gpu/paged_kv_append.clj
@@ -1,0 +1,120 @@
+(ns raster.compiler.backend.gpu.paged-kv-append
+  "Portable OpenCL-C reference lowering for paged FP32-to-FP16 K/V assignment."
+  (:require [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.paged-kv-append :as append]))
+
+(defn- kernel-name
+  [problem]
+  (let [identity (select-keys problem
+                              [:batch-size :key-elements-per-token
+                               :value-elements-per-token :page-size :physical-pages
+                               :key-input-dtype :value-input-dtype
+                               :key-storage-dtype :value-storage-dtype :rounding-mode])]
+    (format "raster_paged_kv_append_%08x"
+            (bit-and 0xffffffff (long (hash identity))))))
+
+(defn reference-workgroup-x
+  "Choose the reference kernel's x workgroup from row width and device limits."
+  [problem desc]
+  (let [{:keys [key-elements-per-token value-elements-per-token]}
+        (append/validate! problem)
+        width (max key-elements-per-token value-elements-per-token)
+        subgroup (long (or (:subgroup-size desc) 16))
+        maximum (long (or (:max-workgroup-size desc) 256))]
+    (long (max 1 (min width subgroup maximum)))))
+
+(defn- source
+  [problem name]
+  (let [{:keys [batch-size key-elements-per-token value-elements-per-token]}
+        (append/validate! problem)
+        slots (append/physical-slots problem)]
+    (str "#pragma OPENCL EXTENSION cl_khr_fp16 : enable\n"
+         "__kernel void " name "(\n"
+         "    __global const float* key_rows,\n"
+         "    __global const float* value_rows,\n"
+         "    __global const int* slot_mapping,\n"
+         "    __global half* key_pages,\n"
+         "    __global half* value_pages) {\n"
+         "  const int component = (int)get_global_id(0);\n"
+         "  const int lane = (int)get_global_id(1);\n"
+         "  if (lane >= " batch-size ") return;\n"
+         "  const int slot = slot_mapping[lane];\n"
+         "  if (slot < 0 || (long)slot >= " slots "L) return;\n"
+         "  if (component < " key-elements-per-token ") {\n"
+         "    const long src = (long)lane * " key-elements-per-token " + component;\n"
+         "    const long dst = (long)slot * " key-elements-per-token " + component;\n"
+         "    key_pages[dst] = convert_half_rte(key_rows[src]);\n"
+         "  }\n"
+         "  if (component < " value-elements-per-token ") {\n"
+         "    const long src = (long)lane * " value-elements-per-token " + component;\n"
+         "    const long dst = (long)slot * " value-elements-per-token " + component;\n"
+         "    value_pages[dst] = convert_half_rte(value_rows[src]);\n"
+         "  }\n"
+         "}\n")))
+
+(defn- ordered-abi
+  [problem]
+  (let [{:keys [key-rows value-rows slot-mapping key-pages value-pages]}
+        (append/validate! problem)]
+    (kabi/validate!
+     [(kabi/slot key-rows :input :float :c-name "key_rows" :role :key-rows)
+      (kabi/slot value-rows :input :float :c-name "value_rows" :role :value-rows)
+      (kabi/slot slot-mapping :input :int :c-name "slot_mapping" :role :slot-mapping)
+      (kabi/slot key-pages :output :half :c-name "key_pages" :role :key-pages)
+      (kabi/slot value-pages :output :half :c-name "value_pages" :role :value-pages)])))
+
+(defn emit-fp32-to-fp16-reference
+  "Emit the portable assignment kernel as a verified KernelArtifact."
+  [problem desc]
+  (let [{:keys [id batch-size key-elements-per-token value-elements-per-token]
+         :as problem} (append/validate! problem)
+        name (kernel-name problem)
+        workgroup-x (reference-workgroup-x problem desc)
+        width (max key-elements-per-token value-elements-per-token)
+        inputs (append/ordered-input-buffer-ids problem)
+        outputs (append/ordered-output-buffer-ids problem)]
+    (artifact/make
+     {:kernel-name name
+      :source (source problem name)
+      :abi (ordered-abi problem)
+      :arguments (into inputs outputs)
+      :launch (launch/spec
+               {:workgroup-size [workgroup-x 1]
+                :group-count [(long (quot (+ width (dec workgroup-x)) workgroup-x))
+                              batch-size]})
+      :effects {:kind :paged-kv-append :reads inputs :writes outputs}
+      :provenance {:operation-id id :semantic-op :paged-kv-append
+                   :lowering :fp32-to-fp16-reference}
+      :attributes {:strategy :fp32-to-fp16-reference
+                   :optimization-tier :reference
+                   :assignment :unique-slot
+                   :rounding-mode :round-to-nearest-even
+                   :input-dtype :float :storage-dtype :half}})))
+
+(defn kernel-graph
+  "Wrap one append artifact in a verified graph with explicit in-place page effects."
+  [problem emitted]
+  (let [{:keys [id] :as problem} (append/validate! problem)
+        emitted (artifact/validate! emitted)
+        specs (append/buffer-specs problem)
+        inputs (append/ordered-input-buffer-ids problem)
+        outputs (append/ordered-output-buffer-ids problem)
+        buffer (fn [buffer-id]
+                 (let [{:keys [dtype elements role]} (get specs buffer-id)]
+                   (graph/buffer buffer-id dtype elements :device role)))
+        input-buffers (mapv buffer inputs)
+        output-buffers (mapv buffer outputs)
+        uses (vec (concat (map #(graph/->ValueUse % :read) inputs)
+                          (map #(graph/->ValueUse % :write) outputs)))]
+    (graph/make
+     {:inputs (into input-buffers output-buffers)
+      :outputs output-buffers
+      :nodes [(graph/->ScheduledKernel
+               [:paged-kv-append id :fp32-to-fp16-reference]
+               emitted uses [])]
+      :effects {:kind :paged-kv-append :assignment :unique-slot}
+      :provenance {:operation-id id :semantic-op :paged-kv-append}
+      :attributes {:strategy :fp32-to-fp16-reference :reference? true}})))

--- a/src/raster/compiler/ir/paged_kv_append.clj
+++ b/src/raster/compiler/ir/paged_kv_append.clj
@@ -1,0 +1,151 @@
+(ns raster.compiler.ir.paged-kv-append
+  "Backend-neutral assignment of projected K/V rows into physical cache slots.
+
+  The operation is deliberately narrower than scatter-add: every batch lane
+  names one unique physical slot and overwrites its complete key and value rows.
+  Page allocation and reservation remain runtime responsibilities; this IR owns
+  only checked tensor geometry, dtype conversion semantics, and write effects."
+  (:require [raster.compiler.core.dtype :as dtype]))
+
+(defrecord PagedKVAppend
+           [id key-rows value-rows slot-mapping key-pages value-pages
+            batch-size key-elements-per-token value-elements-per-token
+            page-size physical-pages key-input-dtype value-input-dtype
+            key-storage-dtype value-storage-dtype rounding-mode])
+
+(declare validate!)
+
+(defn paged-kv-append?
+  "Return true when `value` is a paged K/V append problem."
+  [value]
+  (and value
+       (= "raster.compiler.ir.paged_kv_append.PagedKVAppend"
+          (.getName (class value)))))
+
+(defn- positive-integer!
+  [field value]
+  (when-not (and (integer? value) (pos? value))
+    (throw (ex-info "Paged K/V append extents must be positive integers"
+                    {:field field :value value})))
+  (long value))
+
+(defn physical-slots
+  "Return the checked number of addressable token slots in `problem`."
+  [problem]
+  (let [{:keys [page-size physical-pages]} (validate! problem)]
+    (try
+      (Math/multiplyExact (long page-size) (long physical-pages))
+      (catch ArithmeticException error
+        (throw (ex-info "Paged K/V append slot extent exceeds signed 64-bit capacity"
+                        {:page-size page-size :physical-pages physical-pages}
+                        error))))))
+
+(defn validate!
+  "Validate a paged K/V append problem and return it unchanged."
+  [problem]
+  (when-not (paged-kv-append? problem)
+    (throw (ex-info "Paged K/V append must be a PagedKVAppend value"
+                    {:problem problem :actual (type problem)})))
+  (let [{:keys [id key-rows value-rows slot-mapping key-pages value-pages
+                batch-size key-elements-per-token value-elements-per-token
+                page-size physical-pages key-input-dtype value-input-dtype
+                key-storage-dtype value-storage-dtype rounding-mode]} problem
+        buffers [key-rows value-rows slot-mapping key-pages value-pages]]
+    (when (nil? id)
+      (throw (ex-info "Paged K/V append requires an identity" {:problem problem})))
+    (when (some nil? buffers)
+      (throw (ex-info "Paged K/V append requires every buffer identity"
+                      {:buffers buffers})))
+    (when-not (= (count buffers) (count (set buffers)))
+      (throw (ex-info "Paged K/V append buffer identities must be distinct"
+                      {:buffers buffers})))
+    (doseq [[field value] [[:batch-size batch-size]
+                           [:key-elements-per-token key-elements-per-token]
+                           [:value-elements-per-token value-elements-per-token]
+                           [:page-size page-size]
+                           [:physical-pages physical-pages]]]
+      (positive-integer! field value))
+    (doseq [[field value] [[:key-input-dtype key-input-dtype]
+                           [:value-input-dtype value-input-dtype]
+                           [:key-storage-dtype key-storage-dtype]
+                           [:value-storage-dtype value-storage-dtype]]]
+      (when-not (dtype/known? value)
+        (throw (ex-info "Paged K/V append dtype is unknown"
+                        {:field field :value value}))))
+    (when-not (= :round-to-nearest-even rounding-mode)
+      (throw (ex-info "Paged K/V append requires explicit round-to-nearest-even conversion"
+                      {:rounding-mode rounding-mode})))
+    problem))
+
+(defn make
+  "Construct a checked paged K/V append problem.
+
+  Input rows default to FP32 and page storage defaults to FP16. Conversion uses
+  round-to-nearest-even. All extents and buffer identities are static compiler
+  values; only row contents and physical slot values vary between submissions."
+  [{:keys [key-input-dtype value-input-dtype key-storage-dtype value-storage-dtype
+           rounding-mode]
+    :or {key-input-dtype :float value-input-dtype :float
+         key-storage-dtype :half value-storage-dtype :half
+         rounding-mode :round-to-nearest-even}
+    :as opts}]
+  (validate!
+   (map->PagedKVAppend
+    (assoc opts
+           :key-input-dtype (dtype/canon key-input-dtype)
+           :value-input-dtype (dtype/canon value-input-dtype)
+           :key-storage-dtype (dtype/canon key-storage-dtype)
+           :value-storage-dtype (dtype/canon value-storage-dtype)
+           :rounding-mode rounding-mode))))
+
+(defn ordered-input-buffer-ids
+  "Return source and slot buffers in their semantic order."
+  [problem]
+  (let [{:keys [key-rows value-rows slot-mapping]} (validate! problem)]
+    [key-rows value-rows slot-mapping]))
+
+(defn ordered-output-buffer-ids
+  "Return mutated page pools in key/value order."
+  [problem]
+  (let [{:keys [key-pages value-pages]} (validate! problem)]
+    [key-pages value-pages]))
+
+(defn buffer-specs
+  "Return exact dtype, element count, and graph role for every problem buffer."
+  [problem]
+  (let [{:keys [key-rows value-rows slot-mapping key-pages value-pages batch-size
+                key-elements-per-token value-elements-per-token key-input-dtype
+                value-input-dtype key-storage-dtype value-storage-dtype]}
+        (validate! problem)
+        slots (physical-slots problem)]
+    {key-rows {:dtype key-input-dtype
+               :elements (* batch-size key-elements-per-token) :role :input}
+     value-rows {:dtype value-input-dtype
+                 :elements (* batch-size value-elements-per-token) :role :input}
+     slot-mapping {:dtype :int :elements batch-size :role :input}
+     key-pages {:dtype key-storage-dtype
+                :elements (* slots key-elements-per-token) :role :inout}
+     value-pages {:dtype value-storage-dtype
+                  :elements (* slots value-elements-per-token) :role :inout}}))
+
+(defn validate-slot-values!
+  "Validate one host-visible physical slot vector and return it unchanged.
+
+  Slots must be unique because assignment has no atomic conflict resolution.
+  This check belongs before descriptor upload; the device kernel separately
+  bounds-checks slots so corrupted descriptor memory cannot overwrite pages."
+  [problem slots]
+  (let [{:keys [batch-size]} (validate! problem)
+        capacity (physical-slots problem)
+        values (vec slots)]
+    (when-not (= batch-size (count values))
+      (throw (ex-info "Paged K/V append slot vector has the wrong lane count"
+                      {:expected batch-size :actual (count values)})))
+    (doseq [[lane slot] (map-indexed vector values)]
+      (when-not (and (integer? slot) (<= 0 (long slot)) (< (long slot) capacity))
+        (throw (ex-info "Paged K/V append slot is outside the physical pool"
+                        {:lane lane :slot slot :physical-slots capacity}))))
+    (when-not (= (count values) (count (set values)))
+      (throw (ex-info "Paged K/V append requires unique destination slots"
+                      {:slots values})))
+    slots))

--- a/src/raster/compiler/passes/parallel/paged_kv_append_route.clj
+++ b/src/raster/compiler/passes/parallel/paged_kv_append_route.clj
@@ -1,0 +1,54 @@
+(ns raster.compiler.passes.parallel.paged-kv-append-route
+  "Structured routing for backend-neutral paged K/V append problems."
+  (:require [raster.compiler.backend.gpu.paged-kv-append :as emit]
+            [raster.compiler.ir.paged-kv-append :as append]))
+
+(defn- decline
+  [problem reason data]
+  {:operation problem :strategy nil :reference? false
+   :declines [{:leaf :fp32-to-fp16-reference :reason reason :data data}]})
+
+(defn route
+  "Try the portable FP32-to-FP16 assignment leaf or return a structured decline."
+  ([problem] (route problem nil))
+  ([problem desc]
+   (let [{:keys [key-input-dtype value-input-dtype key-storage-dtype
+                 value-storage-dtype rounding-mode]
+          :as problem} (append/validate! problem)]
+     (cond
+       (and desc (not= :gpu (:device-type desc)))
+       (decline problem :paged-kv-append-requires-gpu
+                {:device-type (:device-type desc)})
+
+       (not= [:float :float :half :half]
+             [key-input-dtype value-input-dtype key-storage-dtype value-storage-dtype])
+       (decline problem :paged-kv-append-dtype-unsupported
+                {:required [:float :float :half :half]
+                 :actual [key-input-dtype value-input-dtype
+                          key-storage-dtype value-storage-dtype]})
+
+       (not= :round-to-nearest-even rounding-mode)
+       (decline problem :paged-kv-append-rounding-unsupported
+                {:rounding-mode rounding-mode})
+
+       :else
+       (let [artifact (emit/emit-fp32-to-fp16-reference problem desc)]
+         {:operation problem
+          :strategy :fp32-to-fp16-reference
+          :reference? true
+          :declines []
+          :artifact artifact
+          :graph (emit/kernel-graph problem artifact)
+          :schedule {:workgroup-size (:workgroup-size (:launch artifact))
+                     :group-count (:group-count (:launch artifact))}})))))
+
+(defn route!
+  "Route paged K/V append or fail with the machine-readable decline trail."
+  ([problem] (route! problem nil))
+  ([problem desc]
+   (let [result (route problem desc)]
+     (if (:strategy result)
+       result
+       (throw (ex-info "no executable paged K/V append kernel route"
+                       {:reason :paged-kv-append-no-kernel-route
+                        :route result}))))))

--- a/test/raster/compiler/passes/parallel/paged_kv_append_route_test.clj
+++ b/test/raster/compiler/passes/parallel/paged_kv_append_route_test.clj
@@ -1,0 +1,63 @@
+(ns raster.compiler.passes.parallel.paged-kv-append-route-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.paged-kv-append :as append]
+            [raster.compiler.passes.parallel.paged-kv-append-route :as route]))
+
+(defn- problem
+  ([] (problem {}))
+  ([opts]
+   (append/make
+    (merge {:id :append :key-rows 'key-rows :value-rows 'value-rows
+            :slot-mapping 'slots :key-pages 'key-pages :value-pages 'value-pages
+            :batch-size 3 :key-elements-per-token 8 :value-elements-per-token 6
+            :page-size 4 :physical-pages 5}
+           opts))))
+
+(defn- reason
+  [thunk]
+  (try (thunk) nil
+       (catch clojure.lang.ExceptionInfo error (:reason (ex-data error)))))
+
+(deftest problem-exposes-exact-buffer-geometry
+  (let [value (problem)
+        specs (append/buffer-specs value)]
+    (is (= 20 (append/physical-slots value)))
+    (is (= {:dtype :float :elements 24 :role :input} (get specs 'key-rows)))
+    (is (= {:dtype :float :elements 18 :role :input} (get specs 'value-rows)))
+    (is (= {:dtype :int :elements 3 :role :input} (get specs 'slots)))
+    (is (= {:dtype :half :elements 160 :role :inout} (get specs 'key-pages)))
+    (is (= {:dtype :half :elements 120 :role :inout} (get specs 'value-pages)))))
+
+(deftest slot-values-must-be-unique-and-in-bounds
+  (let [value (problem)]
+    (is (= [19 0 7] (append/validate-slot-values! value [19 0 7])))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"unique destination"
+                          (append/validate-slot-values! value [1 1 2])))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"outside the physical pool"
+                          (append/validate-slot-values! value [1 2 20])))))
+
+(deftest routed-artifact-is-assignment-with-in-place-page-effects
+  (let [{:keys [artifact graph strategy]} (route/route! (problem))
+        source (:source artifact)]
+    (is (= :fp32-to-fp16-reference strategy))
+    (is (str/includes? source "key_pages[dst] = convert_half_rte(key_rows[src]);"))
+    (is (str/includes? source "value_pages[dst] = convert_half_rte(value_rows[src]);"))
+    (is (not (str/includes? source "atomic")))
+    (is (= ['key-rows 'value-rows 'slots 'key-pages 'value-pages]
+           (:arguments artifact)))
+    (is (= :paged-kv-append (get-in graph [:provenance :semantic-op])))
+    (is (= #{'key-pages 'value-pages}
+           (set (map :id (:outputs graph)))))
+    (is (every? #(= :inout (:role %)) (:outputs graph)))
+    (is (graph/kernel-graph? graph))))
+
+(deftest unsupported-storage-declines-before-emission
+  (let [result (route/route (problem {:key-storage-dtype :float}))]
+    (is (nil? (:strategy result)))
+    (is (= :paged-kv-append-dtype-unsupported
+           (get-in result [:declines 0 :reason]))))
+  (testing "a failed route retains a stable top-level reason"
+    (is (= :paged-kv-append-no-kernel-route
+           (reason #(route/route! (problem {:value-storage-dtype :double})))))))

--- a/test/raster/gpu/paged_kv_append_device_test.clj
+++ b/test/raster/gpu/paged_kv_append_device_test.clj
@@ -1,0 +1,91 @@
+(ns raster.gpu.paged-kv-append-device-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is]]
+            [raster.compiler.ir.paged-kv-append :as append]
+            [raster.compiler.passes.parallel.paged-kv-append-route :as route]
+            [raster.dl.gpu-grad-parity :as gp]
+            [raster.gpu.core :as gpu]))
+
+(def ^:private ocl-fp16-available?
+  (delay
+    (try
+      (require 'raster.gpu.ocl-runtime)
+      ((resolve 'raster.gpu.ocl-runtime/init!))
+      (boolean
+       (some #(str/includes? (or (:extensions %) "") "cl_khr_fp16")
+             ((resolve 'raster.gpu.ocl-runtime/query-devices))))
+      (catch Throwable _ false))))
+
+(defn- half-bits
+  [value]
+  (Float/floatToFloat16 (float value)))
+
+(defn- run-case
+  [device-id]
+  (let [batch-size 2
+        key-width 4
+        value-width 3
+        page-size 2
+        physical-pages 3
+        physical-slots (* page-size physical-pages)
+        key-rows (float-array [1.1 -2.2 3.3 -4.4, 5.5 -6.6 7.7 -8.8])
+        value-rows (float-array [0.25 -0.5 0.75, 1.25 -1.5 1.75])
+        slots (int-array [5 1])
+        sentinel (half-bits 42.0)
+        key-pages (short-array (repeat (* physical-slots key-width) sentinel))
+        value-pages (short-array (repeat (* physical-slots value-width) sentinel))
+        problem (append/make
+                 {:id [:device device-id]
+                  :key-rows 'key-rows :value-rows 'value-rows
+                  :slot-mapping 'slots :key-pages 'key-pages :value-pages 'value-pages
+                  :batch-size batch-size :key-elements-per-token key-width
+                  :value-elements-per-token value-width
+                  :page-size page-size :physical-pages physical-pages})
+        graph (:graph (route/route!
+                       problem {:device-type :gpu :subgroup-size 16
+                                :max-workgroup-size 256}))]
+    (append/validate-slot-values! problem slots)
+    (gpu/with-gpu-session [session device-id]
+      (gpu/alloc! session
+                  {:key-rows [:float (alength key-rows) key-rows]
+                   :value-rows [:float (alength value-rows) value-rows]
+                   :slots [:int (alength slots) slots]
+                   :key-pages [:half (alength key-pages) key-pages :state]
+                   :value-pages [:half (alength value-pages) value-pages :state]})
+      (let [handle (gpu/bind-kernel-graph!
+                    session :paged-kv-append graph
+                    {'key-rows :key-rows 'value-rows :value-rows 'slots :slots
+                     'key-pages :key-pages 'value-pages :value-pages}
+                    {})]
+        (try
+          (gpu/run-kernel-graph! session handle)
+          (let [actual-key ^shorts (gpu/download session :key-pages)
+                actual-value ^shorts (gpu/download session :value-pages)]
+            (doseq [slot (range physical-slots)
+                    component (range key-width)]
+              (let [index (+ (* slot key-width) component)
+                    lane ({5 0, 1 1} slot)
+                    expected (if lane
+                               (half-bits (aget key-rows (+ (* lane key-width) component)))
+                               sentinel)]
+                (is (= expected (aget actual-key index)))))
+            (doseq [slot (range physical-slots)
+                    component (range value-width)]
+              (let [index (+ (* slot value-width) component)
+                    lane ({5 0, 1 1} slot)
+                    expected (if lane
+                               (half-bits (aget value-rows (+ (* lane value-width) component)))
+                               sentinel)]
+                (is (= expected (aget actual-value index))))))
+          (finally
+            (gpu/release-kernel-graph! session handle)))))))
+
+(deftest level-zero-paged-kv-append-assigns-rte-halfs
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "paged K/V assignment on Level Zero")
+    (run-case :ze:0)))
+
+(deftest opencl-paged-kv-append-assigns-rte-halfs
+  (if-not @ocl-fp16-available?
+    (is true "OpenCL FP16 device unavailable")
+    (run-case :ocl:0)))


### PR DESCRIPTION
## Summary

- add a backend-neutral paged K/V append IR with checked geometry, buffer roles, and unique-slot validation
- lower FP32 projected rows to direct FP16 page-pool assignment with explicit round-to-nearest-even conversion
- expose the mutation as a verified kernel graph whose key/value page pools are explicit in-place inputs and outputs
- add route/ABI tests and device coverage for both Level Zero and generic OpenCL execution

This is deliberately assignment rather than scatter-add: each batch lane owns one reserved physical slot. Allocation remains the serving runtime's responsibility, while Raster owns tensor geometry, conversion semantics, and device write ordering. The semantic operation is backend-neutral so CUDA/HIP-specific lowerings can be added without changing callers.

## Validation

- `clojure -M:test -n raster.compiler.passes.parallel.paged-kv-append-route-test` (4 tests, 21 assertions)
- `clojure -M:test -n raster.gpu.paged-kv-append-device-test` (2 tests, 84 assertions; Level Zero and OpenCL)
- `clojure -M:format <five changed files>`
- `clj-kondo --lint <four non-macro changed files>`
- REPL inspection of graph roles, launch geometry, effects, and duplicate-slot rejection

The full repository suite completed 2,255 tests / 33,864 assertions with 5 failures in existing hardware-sensitive checks; one observed failure was the GEMM split-K benchmark measuring 2.9x against a >4x threshold. The paged-K/V focused suites pass.