### PR TITLE
Bridge compiled programs to validated dispatch tuning

### DIFF
--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_route.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_route.clj
@@ -11,6 +11,23 @@
   [{:id :indexed-edge-list-subgroup-score-reuse :route indexed-leaf/route-dynamic-score-reuse}
    {:id :indexed-edge-list-reference :route indexed-leaf/route-dynamic}])
 
+(defn- tuning-contract
+  [plan]
+  (let [{:keys [operands output accumulator-dtype] :as plan} (swr/validate! plan)
+        schedule-key (swr/schedule-key plan)]
+    {:schedule-path [:segmented-weighted-reduction :measured-selector]
+     :numerical-mode {:operands (mapv :dtype operands)
+                      :accumulate accumulator-dtype
+                      :output (:dtype output)}
+     ;; This is deliberately the compiler's physical schedule identity, not an attention label.
+     ;; A different storage/membership layout must miss the tuning cache even when its algebra is
+     ;; identical.
+     :layout (assoc (dissoc schedule-key :algebra)
+                    :membership (dissoc (:membership plan) :buffers))
+     ;; Reference interpretation is compiler metadata. The generic GPU benchmark merely exposes
+     ;; it to a caller-supplied oracle and never branches on this kind.
+     :reference {:kind :segmented-weighted-reduction :plan plan}}))
+
 (defn- selected-leaves
   [desc]
   (if (= :subgroup-score-reuse (:segmented-weighted-reduction-schedule desc))
@@ -82,6 +99,7 @@
                            :algebra-plan-id (:id plan)}
               :attributes {:algebra :segmented-weighted-reduction
                            :algebra-key (swr/algebra-key plan)
+                           :tuning (tuning-contract plan)
                            :selection (if measured-selector
                                         :measured-runtime-shape
                                         :analytic-runtime-shape)}})]

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -1879,6 +1879,7 @@
                            (mapv (fn [slot value]
                                    (if (= :scalar (:kind slot))
                                      {:slot slot :kind :scalar :type (:kernel-dtype slot)
+                                      :expression value
                                       :value-fn (expr->arg-fn all-params scalar-lets value)}
                                      {:slot slot :kind (:kind slot) :role (:role slot)
                                       :dtype (:dtype slot) :sym value}))
@@ -1913,6 +1914,7 @@
                                        {:slots (:slots entry) :kind :pointer
                                         :binding (:binding entry) :sym value}
                                        {:slot slot :kind :scalar :type (:kernel-dtype slot)
+                                        :expression value
                                         :value-fn (expr->arg-fn all-params scalar-lets value)})))
                                  plan marker-values)
                            :phase (keyword (str "gpu-step-" i))})
@@ -1946,6 +1948,7 @@
                            (mapv (fn [slot value]
                                    (if (= :scalar (:kind slot))
                                      {:slot slot :kind :scalar :type (:kernel-dtype slot)
+                                      :expression value
                                       :value-fn (expr->arg-fn all-params scalar-lets value)}
                                      {:slot slot :kind (:kind slot) :role (:role slot)
                                       :dtype (:dtype slot) :sym value}))

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -1993,6 +1993,12 @@
                ;; make-buffer) — kept here so close-session! can free it instead of leaking it.
                :scratch-buffers @gemm-scratch
                :param->key param->key
+               :alloc->key alloc->key
+               :buffer-capacities
+               (into {}
+                     (map (fn [buffer-key]
+                            [buffer-key (:n-elements (get buffers buffer-key))]))
+                     (concat (vals param->key) (vals alloc->key)))
                ;; resolved buffer key of the functional :result-sym (may be a scratch alloc,
                ;; hence resolved through THIS program's key-fn, not a raw name->keyword).
                :result-key (when-let [rs (:result-sym descriptor)]
@@ -2019,6 +2025,167 @@
             (throw (ex-info (str "run-program!: session holds " (count programs) " programs — "
                                  "pass the handle bind-program! returned (or a distinct descriptor)")
                             {:bound (keys programs)}))))))))
+
+(defn- select-dispatch-step
+  [descriptor selector]
+  (let [steps (:steps descriptor)
+        indexed (mapv vector (range) steps)
+        selected
+        (cond
+          (nil? selector)
+          (let [matches (filterv (fn [[_ step]] (some? (:dispatch step))) indexed)]
+            (when-not (= 1 (count matches))
+              (throw (ex-info "bound program requires exactly one dispatch step when :step is omitted"
+                              {:reason :ambiguous-program-dispatch-step
+                               :dispatch-phases (mapv (comp :phase second) matches)})))
+            (first matches))
+
+          (integer? selector)
+          (when (<= 0 (long selector) (dec (count steps)))
+            [(long selector) (nth steps (long selector))])
+
+          (keyword? selector)
+          (first (filterv (fn [[_ step]] (= selector (:phase step))) indexed))
+
+          :else
+          (throw (ex-info "program dispatch step selector must be nil, an index, or a phase keyword"
+                          {:reason :invalid-program-dispatch-step-selector
+                           :selector selector})))]
+    (when-not selected
+      (throw (ex-info "program dispatch step selector did not match a compiled step"
+                      {:reason :program-dispatch-step-not-found
+                       :selector selector :phases (mapv :phase steps)})))
+    (let [[index step] selected]
+      (when-not (:dispatch step)
+        (throw (ex-info "selected compiled program step has no KernelDispatch"
+                        {:reason :program-step-has-no-dispatch
+                         :selector selector :index index :phase (:phase step)})))
+      {:step-index index :step step :dispatch (kdispatch/validate! (:dispatch step))})))
+
+(defn bound-program-dispatch
+  "Return one compiled KernelDispatch step from a live resident program binding.
+
+   `step-selector` is nil (requiring exactly one dispatch step), a zero-based step index, or a
+   phase keyword. This is read-only compiler/runtime metadata; candidate binding remains explicit
+   through program-dispatch-arguments."
+  ([sess prog-or-handle]
+   (bound-program-dispatch sess prog-or-handle nil))
+  ([sess prog-or-handle step-selector]
+   (let [program (resolve-program sess prog-or-handle)]
+     (assoc (select-dispatch-step (:descriptor program) step-selector)
+            :descriptor (:descriptor program)))))
+
+(defn- physical-program-step-arguments
+  [step logical-arguments]
+  (if-not (:logical-bindings? step)
+    logical-arguments
+    (vec
+     (mapcat (fn [spec value]
+               (if (= :scalar (:kind spec))
+                 [value]
+                 (let [slots (:slots spec)]
+                   (when-not (= 1 (count slots))
+                     (throw (ex-info
+                             "offline dispatch tuning cannot project a multi-slot logical resident binding"
+                             {:reason :program-dispatch-multislot-logical-binding
+                              :phase (:phase step) :binding (:binding spec) :slots slots})))
+                   [value])))
+             (:argument-specs step) logical-arguments))))
+
+(defn program-dispatch-arguments
+  "Project one compiled dispatch step onto a bound program's resident buffers.
+
+   `program-arguments` follow the descriptor's :all-params order, just like bind-program!. The
+   returned :arguments are in the selected alternatives' physical ABI order and contain stable
+   session buffer keys plus typed scalar values. :reference-inputs retains the corresponding host
+   buffers and a scalar environment (including compiler scalar lets) for an independent evaluator.
+   Multi-slot logical SoA bindings fail explicitly until the resident program binder models their
+   field allocations as stable views."
+  ([sess prog-or-handle program-arguments]
+   (program-dispatch-arguments sess prog-or-handle nil program-arguments))
+  ([sess prog-or-handle step-selector program-arguments]
+   (let [program (resolve-program sess prog-or-handle)
+         descriptor (:descriptor program)
+         {:keys [step-index step dispatch] :as selected}
+         (select-dispatch-step descriptor step-selector)
+         all-params (:all-params descriptor)
+         _argument-count
+         (when-not (and (sequential? program-arguments)
+                        (= (count all-params) (count program-arguments)))
+           (throw (ex-info "program dispatch arguments must follow descriptor :all-params"
+                           {:reason :program-dispatch-argument-count
+                            :expected (count all-params)
+                            :actual (when (sequential? program-arguments)
+                                      (count program-arguments))
+                            :all-params all-params})))
+         argmap (zipmap all-params program-arguments)
+         key-of (fn [sym]
+                  (or (get (:param->key program) sym)
+                      (get (:alloc->key program) sym)
+                      (keyword (name sym))))
+         capacity-of (fn [key]
+                       (or (get (:buffer-capacities program) key)
+                           (get-in @sess [:buffers key :n-elements])))
+         require-capacity!
+         (fn [sym required]
+           (let [key (key-of sym)
+                 capacity (capacity-of key)]
+             (when (and (some? capacity) (> (long required) (long capacity)))
+               (throw (ex-info "compiled dispatch sample exceeds its resident buffer capacity"
+                               {:reason :program-dispatch-buffer-capacity
+                                :step-index step-index :phase (:phase step)
+                                :sym sym :key key
+                                :required-elements (long required)
+                                :capacity-elements (long capacity)})))))
+         _array-capacities
+         (doseq [sym (:array-params descriptor)]
+           (let [array (get argmap sym)]
+             (when-not (and array (.isArray (class array)))
+               (throw (ex-info "compiled dispatch array parameter must remain a JVM array"
+                               {:reason :program-dispatch-array-argument
+                                :sym sym :value-type (some-> array class)})))
+             (require-capacity! sym (java.lang.reflect.Array/getLength array))))
+         _scratch-capacities
+         (doseq [{:keys [sym size-fn]} (:allocs descriptor)]
+           (require-capacity! sym (size-fn program-arguments)))
+         logical-arguments
+         (mapv (fn [{:keys [kind sym type value-fn]}]
+                 (if (= :scalar kind)
+                   {:type type :value (value-fn program-arguments)}
+                   (let [key (key-of sym)]
+                     (when-not (contains? (:buffers @sess) key)
+                       (throw (ex-info "compiled dispatch argument has no live resident buffer"
+                                       {:reason :program-dispatch-buffer-not-resident
+                                        :step-index step-index :phase (:phase step)
+                                        :sym sym :key key})))
+                     key)))
+               (:argument-specs step))
+         arguments (physical-program-step-arguments step logical-arguments)
+         _abi (kabi/validate-arguments! (:abi (kdispatch/default-artifact dispatch)) arguments)
+         resident-bindings
+         (into {}
+               (keep (fn [[{:keys [kind sym]} value]]
+                       (when-not (= :scalar kind) [sym value])))
+               (map vector (:argument-specs step) logical-arguments))
+         direct-scalars (select-keys argmap (:scalar-params descriptor))
+         derived-scalars
+         (reduce (fn [bindings [{:keys [kind expression slot]} value]]
+                   (if (= :scalar kind)
+                     (let [raw (:value value)
+                           slot-name (:name slot)]
+                       (cond-> bindings
+                         slot-name (assoc slot-name raw)
+                         (symbol? expression) (assoc expression raw)))
+                     bindings))
+                 {}
+                 (map vector (:argument-specs step) logical-arguments))]
+     (assoc selected
+            :descriptor descriptor
+            :arguments arguments
+            :resident-bindings resident-bindings
+            :reference-inputs
+            {:buffers (select-keys argmap (:array-params descriptor))
+             :scalars (merge direct-scalars derived-scalars)}))))
 
 (defn run-program!
   "Replay a bound resident GPU program: refresh ONLY the :input array params (buffer POINTERS are

--- a/src/raster/gpu/dispatch_benchmark.clj
+++ b/src/raster/gpu/dispatch_benchmark.clj
@@ -155,3 +155,78 @@
    :layout layout
    :improvement-threshold improvement-threshold
    :force? force?))
+
+(defn tuning-schedule-override
+  "Turn a measured selector into the compiler schedule override declared by its dispatch.
+
+   Emitters own the path because only they know which schedule axis produced their compatible
+   alternatives. This function is generic: it validates the selector against the dispatch and
+   writes no operation-specific key itself."
+  [dispatch dispatch-tuning descriptor numerical-mode layout]
+  (let [dispatch (kdispatch/validate! dispatch)
+        _ (when-not (tuning/dispatch-tuning? dispatch-tuning)
+            (throw (ex-info "schedule override requires a DispatchTuning"
+                            {:tuning dispatch-tuning})))
+        path (get-in dispatch [:attributes :tuning :schedule-path])
+        selector (:selector dispatch-tuning)]
+    (when-not (and (vector? path) (seq path) (every? keyword? path))
+      (throw (ex-info "emitted dispatch does not declare a tuning schedule path"
+                      {:dispatch-id (:id dispatch) :schedule-path path})))
+    ;; Recheck the full device/artifact/ABI/numerical/layout identity before admitting cached or
+    ;; transported tuning data into recompilation.
+    (tuning/apply-tuning dispatch dispatch-tuning descriptor numerical-mode layout)
+    (assoc-in {} path selector)))
+
+(defn- compiled-case-fn
+  [session program step-selector case-fn]
+  (fn [runtime-value]
+    (let [case (case-fn runtime-value)]
+      (when-not (map? case)
+        (throw (ex-info "compiled dispatch benchmark case must be a map"
+                        {:runtime-value runtime-value :case case})))
+      (when-not (contains? case :program-arguments)
+        (throw (ex-info "compiled dispatch benchmark case requires :program-arguments"
+                        {:runtime-value runtime-value :case-keys (set (keys case))})))
+      (let [binding (gpu/program-dispatch-arguments
+                     session program step-selector (:program-arguments case))]
+        (assoc case
+               :arguments (:arguments binding)
+               ;; Validation callbacks reach the compiler-owned reference plan and the projected
+               ;; host buffer/scalar environment through (:compiled-binding (:case context)).
+               :compiled-binding (dissoc binding :arguments))))))
+
+(defn tune-program-dispatch!
+  "Tune one KernelDispatch embedded in a live compiled resident program.
+
+   This closes the descriptor-to-driver seam without teaching the runtime any operation. Each
+   `case-fn` result supplies `:program-arguments` in descriptor order plus the same :validate!,
+   :before-run!, and :measurement callbacks accepted by tune-dispatch!. The bridge projects the
+   step's ordered :argument-specs onto the program's stable resident buffer keys and typed scalar
+   values. When :step is omitted, the program must contain exactly one dispatch step.
+
+   Numerical mode and layout default to emitter-owned tuning metadata but may be supplied
+   explicitly. Returns the DispatchTuning together with a schedule override ready to pass as
+   `:schedule` to compile-gpu-program. Compilation remains pure; this function is explicitly an
+   offline action."
+  [session program descriptor runtime-values case-fn
+   & {:keys [step numerical-mode layout improvement-threshold force? measurement]
+      :or {improvement-threshold 0.001 force? false}}]
+  (let [{:keys [dispatch step-index] compiled-step :step}
+        (gpu/bound-program-dispatch session program step)
+        contract (get-in dispatch [:attributes :tuning])
+        numerical-mode (or numerical-mode (:numerical-mode contract))
+        layout (or layout (:layout contract))
+        result (tune-dispatch!
+                session dispatch descriptor runtime-values
+                (compiled-case-fn session program step case-fn)
+                :numerical-mode numerical-mode
+                :layout layout
+                :improvement-threshold improvement-threshold
+                :force? force?
+                :measurement measurement)]
+    {:tuning result
+     :selector (:selector result)
+     :schedule-override (tuning-schedule-override dispatch result descriptor
+                                                  numerical-mode layout)
+     :step-index step-index
+     :phase (:phase compiled-step)}))

--- a/test/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse_test.clj
+++ b/test/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse_test.clj
@@ -5,9 +5,11 @@
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-fuse :as fuse]
             [raster.compiler.pipeline :as pipeline]
+            [raster.compiler.reference.segmented-weighted-reduction :as reference]
             [raster.core :refer [deftm]]
             [raster.dl.array-ops :as array-ops]
             [raster.dl.gsdm :as gsdm]
+            [raster.gpu.core :as gpu]
             [raster.numeric]))
 
 (defn- chain
@@ -188,6 +190,59 @@
     (is (= :indexed-segmented-reduction-subgroup-score-reuse
            (kdispatch/artifact-strategy
             (kdispatch/select-artifact (:dispatch step) (arguments-for wide)))))))
+
+(deftest compiled-dispatch-projects-resident-abi-and-reference-environment
+  (let [descriptor (pipeline/compile-gpu-program
+                    #'resident-structured-reduction-probe :ze:0 :dtype :float)
+        args [(float-array 15) (float-array 15) (float-array 15)
+              (long-array 4) (long-array 4) 3 4 5 2]
+        param->key (into {} (map (fn [sym] [sym (keyword (str "resident-" (name sym)))]))
+                         (:array-params descriptor))
+        alloc->key (into {} (map (fn [{:keys [sym]}] [sym (keyword (str "scratch-" (name sym)))])
+                                 (:allocs descriptor)))
+        buffers (into {} (map (fn [key] [key (Object.)]))
+                      (concat (vals param->key) (vals alloc->key)))
+        capacities
+        (merge (into {} (map (fn [sym]
+                               [(param->key sym)
+                                (alength (get (zipmap (:all-params descriptor) args) sym))]))
+                     (:array-params descriptor))
+               (into {} (map (fn [{:keys [sym size-fn]}]
+                               [(alloc->key sym) (size-fn args)]))
+                     (:allocs descriptor)))
+        session (atom {:programs {:probe {:descriptor descriptor
+                                          :param->key param->key
+                                          :alloc->key alloc->key
+                                          :buffer-capacities capacities}}
+                       :buffers buffers})
+        projected (gpu/program-dispatch-arguments session descriptor args)
+        contract (get-in projected [:dispatch :attributes :tuning])
+        expected (reference/evaluate (get-in contract [:reference :plan])
+                                     (:reference-inputs projected))]
+    (is (= 0 (:step-index projected)))
+    (is (= (mapv param->key (take 5 (:array-params descriptor)))
+           (subvec (:arguments projected) 0 5)))
+    (is (= (alloc->key (:result-sym descriptor)) (nth (:arguments projected) 5)))
+    (is (= (alloc->key (:result-sym descriptor))
+           (get-in projected [:resident-bindings (:result-sym descriptor)])))
+    (is (= [3 4 5 2 2 15]
+           (mapv :value (subvec (:arguments projected) 6))))
+    (is (identical? (first args)
+                    (get-in projected [:reference-inputs :buffers 'Q])))
+    (is (= {'n-nodes 3 'n-edges 4 'emb-dim 5 'n-heads 2 'dk 2}
+           (select-keys (get-in projected [:reference-inputs :scalars])
+                        '[n-nodes n-edges emb-dim n-heads dk])))
+    (is (= [:segmented-weighted-reduction :measured-selector]
+           (:schedule-path contract)))
+    (is (= :segmented-weighted-reduction (get-in contract [:reference :kind])))
+    (is (= :float (get-in contract [:numerical-mode :accumulate])))
+    (is (= :indexed-dense-values (get-in contract [:layout :storage :kind])))
+    (is (= :edge-list-by-destination (get-in contract [:layout :membership :kind])))
+    (is (= 15 (alength ^doubles expected)))
+    (is (every? zero? expected))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"exceeds its resident buffer capacity"
+         (gpu/program-dispatch-arguments session descriptor (assoc args 7 512))))))
 
 (deftest actual-gsdm-region-reaches-generic-structured-reduction-stage
   (let [diagnostic (pipeline/show-pipeline

--- a/test/raster/gpu/dispatch_benchmark_test.clj
+++ b/test/raster/gpu/dispatch_benchmark_test.clj
@@ -160,3 +160,75 @@
                           :layout {:input :row-major :output :row-major})]
               (is (= (:selector result) (:selector cached)))
               (is (= 6 @binds @releases)))))))))
+
+(deftest compiled-program-bridge-projects-a-case-and-returns-recompilation-data
+  (let [tuning-contract
+        {:schedule-path [:generic-reduction :measured-selector]
+         :numerical-mode {:input :f32 :accumulate :f32 :output :f32}
+         :layout {:input :contiguous :output :contiguous}}
+        compiled-dispatch (assoc-in dispatch [:attributes :tuning] tuning-contract)
+        program-descriptor
+        {:all-params '[x width]
+         :array-params '[x]
+         :scalar-params '[width]
+         :steps [{:phase :reduce
+                  :convention :contract
+                  :dispatch compiled-dispatch
+                  :artifact reference
+                  :abi abi
+                  :argument-specs
+                  [{:slot (nth abi 0) :kind :input :sym 'x}
+                   {:slot (nth abi 1) :kind :output :sym 'out}
+                   {:slot (nth abi 2) :kind :scalar :type :long :expression 'width
+                    :value-fn (fn [args] (nth args 1))}]}]}
+        session (atom {:programs {:compiled {:descriptor program-descriptor
+                                             :param->key {'x :resident-x}
+                                             :alloc->key {'out :resident-out}}}
+                       :buffers {:resident-x (Object.) :resident-out (Object.)}})
+        measured-selector {:kind :runtime-scalar-ranges
+                           :argument 'width :below :reference
+                           :ranges [{:at-least 256 :strategy :subgroup}]}
+        tuning-identity (tuning/tuning-identity
+                         compiled-dispatch descriptor [128 256]
+                         (:numerical-mode tuning-contract) (:layout tuning-contract) 0.001)
+        fake-tuning (tuning/->DispatchTuning
+                     (tuning/cache-key tuning-identity) tuning-identity measured-selector [])
+        observed (atom nil)
+        result
+        (with-redefs [benchmark/tune-dispatch!
+                      (fn [_ passed-dispatch passed-descriptor runtime-values passed-case-fn
+                           & options]
+                        (let [case (passed-case-fn 256)]
+                          (reset! observed
+                                  {:dispatch passed-dispatch
+                                   :descriptor passed-descriptor
+                                   :runtime-values runtime-values
+                                   :case case
+                                   :options (apply hash-map options)}))
+                        fake-tuning)]
+          (benchmark/tune-program-dispatch!
+           session program-descriptor descriptor [128 256]
+           (fn [width]
+             {:program-arguments [(float-array 1024) width]
+              :validate! (constantly {:passed? true :oracle-hash "compiled-reference"})})))]
+    (is (= [:resident-x :resident-out {:type :long :value 256}]
+           (get-in @observed [:case :arguments])))
+    (is (= 256 (get-in @observed
+                       [:case :compiled-binding :reference-inputs :scalars 'width])))
+    (is (= (:numerical-mode tuning-contract)
+           (get-in @observed [:options :numerical-mode])))
+    (is (= (:layout tuning-contract) (get-in @observed [:options :layout])))
+    (is (= {:generic-reduction {:measured-selector measured-selector}}
+           (:schedule-override result)))
+    (is (= measured-selector (:selector result)))
+    (is (= :reduce (:phase result)))))
+
+(deftest schedule-override-rejects-dispatch-without-an-emitter-path
+  (let [fake-tuning
+        (tuning/->DispatchTuning
+         "key" {} {:kind :runtime-scalar-ranges :argument 'width
+                   :below :reference :ranges []} [])]
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"does not declare a tuning schedule path"
+         (benchmark/tuning-schedule-override dispatch fake-tuning descriptor
+                                             {:input :f32} {:input :contiguous})))))

--- a/test/raster/gpu/indexed_attention_device_test.clj
+++ b/test/raster/gpu/indexed_attention_device_test.clj
@@ -1,5 +1,6 @@
 (ns raster.gpu.indexed-attention-device-test
   (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.core.hardware :as hardware]
             [raster.compiler.pipeline :as pipeline]
             [raster.compiler.passes.parallel.indexed-attention-recognize :as recognize]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-route :as route]
@@ -8,7 +9,10 @@
             [raster.dl.array-ops :as array-ops]
             [raster.dl.gpu-grad-parity :as gp]
             [raster.gpu.core :as gpu]
-            [raster.numeric]))
+            [raster.gpu.dispatch-benchmark :as benchmark]
+            [raster.gpu.tuning-cache :as cache]
+            [raster.numeric])
+  (:import [java.nio.file Files]))
 
 (def ^:private opencl-available?
   (delay
@@ -151,6 +155,55 @@
                               (map #(Math/abs (- (double %1) (double %2)))
                                    expected result))]
         {:selected selected :max-error max-error}))))
+
+(defn- temporary-cache-root
+  []
+  (.toFile (Files/createTempDirectory
+            "raster-compiled-dispatch-benchmark-"
+            (make-array java.nio.file.attribute.FileAttribute 0))))
+
+(deftest compiled-resident-dispatch-tunes-and-returns-a-baked-schedule
+  (if-not @opencl-available?
+    (is true "OpenCL device unavailable")
+    (let [{:keys [buffers]} (test-case)
+          args [(get buffers 'Q) (get buffers 'K) (get buffers 'V)
+                (get buffers 'dst) (get buffers 'src) 3 4 5 2]
+          descriptor (pipeline/compile-gpu-program
+                      #'resident-indexed-attention-probe :ocl:0 :dtype :float)]
+      (binding [cache/*cache-root* (temporary-cache-root)]
+        (gpu/with-gpu-session [session :ocl:0]
+          (let [handle (gpu/bind-program! session descriptor args)
+                result
+                (benchmark/tune-program-dispatch!
+                 session handle (hardware/descriptor-for :ocl:0) [2]
+                 (fn [components]
+                   {:program-arguments args
+                    :validate!
+                    (fn [{:keys [case]}]
+                      (let [binding (:compiled-binding case)
+                            plan (get-in binding
+                                         [:dispatch :attributes :tuning :reference :plan])
+                            expected (reference/evaluate plan (:reference-inputs binding))
+                            output-key (get-in binding
+                                               [:resident-bindings (:result-sym descriptor)])
+                            actual ^floats (gpu/download session output-key)
+                            max-error
+                            (reduce max 0.0
+                                    (map #(Math/abs (- (double %1) (double %2)))
+                                         expected actual))]
+                        {:passed? (< max-error 2.0e-5)
+                         :oracle-hash (str "compiled-segmented-reference-v1-" components)
+                         :max-error max-error}))
+                    :measurement {:warmup-iterations 0 :budget-ms 1
+                                  :min-samples 3 :max-samples 5
+                                  :cv-threshold 100.0}})
+                 :force? true)]
+            (is (= 2 (count (get-in result [:tuning :measurements]))))
+            (is (= (:selector result)
+                   (get-in result
+                           [:schedule-override :segmented-weighted-reduction
+                            :measured-selector])))
+            (is (= :gpu-step-0 (:phase result)))))))))
 
 (deftest resident-compiler-selects-from-runtime-component-width
   (if-not @opencl-available?


### PR DESCRIPTION
## Summary

- project a compiled resident dispatch step onto its bound program's stable buffer keys and typed scalar ABI values
- carry emitter-owned tuning metadata for numerical mode, physical layout, reference-plan context, and the schedule writeback path
- expose host buffer/scalar environments (including compiler-derived scalar lets) to independent reference evaluators
- validate candidates, device-event tune them, recheck the full tuning identity, and return a schedule override ready for recompilation
- reject ambiguous steps, unsupported multi-slot logical bindings, missing resident buffers, and shape samples that exceed bound parameter or scratch capacity before driver contact

The runtime remains operation-neutral. Segmented weighted reduction only contributes compiler metadata; the generic bridge does not branch on attention or reduction kinds.

## Verification

- focused compiler/runtime/OpenCL vertical: 20 tests, 95 assertions, 0 failures
- real OpenCL run validates both emitted segmented-reduction alternatives against the compiler-carried reference plan, measures device events, and produces the baked schedule selector
- `git diff --check`
- clj-kondo on changed non-macro sources/tests: 0 errors (four pre-existing warnings in `raster.gpu.core`)
- full suite: 2260 tests, 33815 assertions; bridge tests green, with 4 unrelated existing failures in `raster.compiler.explain-pipeline-truth-test`

The four full-suite failures reproduce in that namespace alone on the local Arc GPU. The test expects symbolic GEMM routing to decline to `:naive-segred`; the current compiler instead successfully emits a generic contraction, so the expected fallback/decline text is absent. This path is unrelated to the files changed here and is skipped when no Level Zero device is available.
