### PR TITLE
Plan dispatch tuning across compiled programs

### DIFF
--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_route.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_route.clj
@@ -12,10 +12,14 @@
    {:id :indexed-edge-list-reference :route indexed-leaf/route-dynamic}])
 
 (defn- tuning-contract
-  [plan]
+  [plan dispatch-id]
   (let [{:keys [operands output accumulator-dtype] :as plan} (swr/validate! plan)
         schedule-key (swr/schedule-key plan)]
-    {:schedule-path [:segmented-weighted-reduction :measured-selector]
+    {:schedule-path [:segmented-weighted-reduction :measured-selectors]
+     ;; Dispatch IDs identify emitted candidate sets, independently of the analytic or measured
+     ;; policy selecting among them. Keying the schedule by that stable identity lets one compiled
+     ;; program carry distinct selectors for several structured reductions without collisions.
+     :schedule-key dispatch-id
      :numerical-mode {:operands (mapv :dtype operands)
                       :accumulate accumulator-dtype
                       :output (:dtype output)}
@@ -75,13 +79,14 @@
                                [:segmented-weighted-reduction
                                 :score-reuse-subgroup-multiple]
                                16))
-        measured-selector (get-in schedule
-                                  [:segmented-weighted-reduction :measured-selector])
         components (get-in plan [:value :components])
-        dispatch-key [(swr/algebra-key plan) subgroup-size
-                      (or measured-selector multiple)]
+        ;; Selection policy is deliberately absent. Recompiling with a measured selector must
+        ;; produce the same dispatch identity as the analytic program that was benchmarked.
+        dispatch-key [(swr/schedule-key plan) subgroup-size]
         id (format "raster_segmented_weighted_reduction_dispatch_%08x"
-                   (bit-and 0xffffffff (long (hash dispatch-key))))]
+                   (bit-and 0xffffffff (long (hash dispatch-key))))
+        measured-selector
+        (get-in schedule [:segmented-weighted-reduction :measured-selectors id])]
     (when (and (contains? by-strategy reference)
                (contains? by-strategy score-reuse))
       (let [dispatch
@@ -99,7 +104,7 @@
                            :algebra-plan-id (:id plan)}
               :attributes {:algebra :segmented-weighted-reduction
                            :algebra-key (swr/algebra-key plan)
-                           :tuning (tuning-contract plan)
+                           :tuning (tuning-contract plan id)
                            :selection (if measured-selector
                                         :measured-runtime-shape
                                         :analytic-runtime-shape)}})]

--- a/src/raster/gpu/dispatch_benchmark.clj
+++ b/src/raster/gpu/dispatch_benchmark.clj
@@ -9,7 +9,8 @@
   (:require [clojure.set :as set]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.gpu.core :as gpu]
-            [raster.gpu.dispatch-tuning :as tuning]))
+            [raster.gpu.dispatch-tuning :as tuning]
+            [raster.gpu.program-tuning :as program-tuning]))
 
 (def ^:private reserved-measurement-options
   #{:before-sample! :compile-ms :hashes :timing-source})
@@ -168,14 +169,21 @@
             (throw (ex-info "schedule override requires a DispatchTuning"
                             {:tuning dispatch-tuning})))
         path (get-in dispatch [:attributes :tuning :schedule-path])
+        schedule-key (get-in dispatch [:attributes :tuning :schedule-key])
+        target-path (cond-> path (some? schedule-key) (conj schedule-key))
         selector (:selector dispatch-tuning)]
     (when-not (and (vector? path) (seq path) (every? keyword? path))
       (throw (ex-info "emitted dispatch does not declare a tuning schedule path"
                       {:dispatch-id (:id dispatch) :schedule-path path})))
+    (when-not (or (nil? schedule-key)
+                  (and (string? schedule-key) (not-empty schedule-key))
+                  (keyword? schedule-key))
+      (throw (ex-info "emitted dispatch declares an invalid tuning schedule key"
+                      {:dispatch-id (:id dispatch) :schedule-key schedule-key})))
     ;; Recheck the full device/artifact/ABI/numerical/layout identity before admitting cached or
     ;; transported tuning data into recompilation.
     (tuning/apply-tuning dispatch dispatch-tuning descriptor numerical-mode layout)
-    (assoc-in {} path selector)))
+    (assoc-in {} target-path selector)))
 
 (defn- compiled-case-fn
   [session program step-selector case-fn]
@@ -230,3 +238,85 @@
                                                   numerical-mode layout)
      :step-index step-index
      :phase (:phase compiled-step)}))
+
+(defn tune-program-dispatches!
+  "Execute an explicit program tuning plan and return one collision-free schedule override.
+
+   `runtime-values-fn` receives a manifest group. `case-fn` receives that group and one runtime
+   value, and returns the compiled benchmark case accepted by tune-program-dispatch!. Equivalent
+   sites are measured once through their first descriptor step. `:max-measurements` is an optional
+   fail-before-execution upper bound on alternatives × distinct runtime samples across selected
+   groups; cached results may perform fewer physical measurements."
+  [session program descriptor plan runtime-values-fn case-fn
+   & {:keys [max-measurements improvement-threshold force? measurement]
+      :or {improvement-threshold 0.001 force? false}}]
+  (let [plan (program-tuning/validate-plan! plan)]
+    (when-not (ifn? runtime-values-fn)
+      (throw (ex-info "program tuning requires a runtime-values callback"
+                      {:reason :invalid-program-tuning-runtime-values-callback})))
+    (when-not (ifn? case-fn)
+      (throw (ex-info "program tuning requires a benchmark case callback"
+                      {:reason :invalid-program-tuning-case-callback})))
+    (when-not (or (nil? max-measurements)
+                  (and (integer? max-measurements)
+                       (not (neg? (long max-measurements)))))
+      (throw (ex-info "program tuning :max-measurements must be a non-negative integer"
+                      {:reason :invalid-program-tuning-measurement-budget
+                       :max-measurements max-measurements})))
+    (let [jobs
+          (mapv
+           (fn [group]
+             (let [step (:representative-step-index group)
+                   {:keys [dispatch]} (gpu/bound-program-dispatch session program step)
+                   actual-signature (program-tuning/dispatch-signature dispatch)
+                   supplied-runtime-values (runtime-values-fn group)
+                   _runtime-values
+                   (when-not (and (coll? supplied-runtime-values)
+                                  (seq supplied-runtime-values)
+                                  (every? #(and (number? %)
+                                                (Double/isFinite (double %)))
+                                          supplied-runtime-values))
+                     (throw (ex-info "program tuning group requires non-empty finite runtime values"
+                                     {:reason :invalid-program-tuning-runtime-values
+                                      :group-id (:id group)
+                                      :runtime-values supplied-runtime-values})))
+                   runtime-values (vec (sort (distinct supplied-runtime-values)))]
+               (when-not (= (:signature group) actual-signature)
+                 (throw (ex-info "program tuning plan does not match its bound program step"
+                                 {:reason :program-tuning-plan-program-mismatch
+                                  :group-id (:id group) :step-index step
+                                  :planned (:signature group) :actual actual-signature})))
+               {:group group
+                :runtime-values runtime-values
+                :planned-measurements
+                (* (count (get-in group [:signature :artifacts]))
+                   (count runtime-values))}))
+           (:selected-groups plan))
+          planned-measurements (reduce + 0 (map :planned-measurements jobs))]
+      (when (and (some? max-measurements)
+                 (> planned-measurements (long max-measurements)))
+        (throw (ex-info "program tuning plan exceeds its physical measurement budget"
+                        {:reason :program-tuning-measurement-budget-exceeded
+                         :planned-measurements planned-measurements
+                         :max-measurements max-measurements
+                         :groups (mapv (comp :id :group) jobs)})))
+      (let [results
+            (mapv
+             (fn [{:keys [group runtime-values planned-measurements]}]
+               (assoc
+                (tune-program-dispatch!
+                 session program descriptor runtime-values
+                 #(case-fn group %)
+                 :step (:representative-step-index group)
+                 :improvement-threshold improvement-threshold
+                 :force? force?
+                 :measurement measurement)
+                :group-id (:id group)
+                :site-count (:site-count group)
+                :planned-measurements planned-measurements))
+             jobs)]
+        {:plan plan
+         :planned-measurements planned-measurements
+         :results results
+         :schedule-override
+         (program-tuning/merge-schedule-overrides (mapv :schedule-override results))}))))

--- a/src/raster/gpu/program_tuning.clj
+++ b/src/raster/gpu/program_tuning.clj
@@ -1,0 +1,207 @@
+(ns raster.gpu.program-tuning
+  "Pure program-level planning for explicit KernelDispatch autotuning.
+
+   A manifest finds tunable dispatch sites in a compiled resident descriptor and groups sites only
+   when their stable dispatch identity, emitted alternatives, numerical/layout contract, and
+   schedule target agree. A tuning plan then selects a deterministic, explicitly bounded subset.
+   Neither operation owns a device or performs measurement."
+  (:require [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.gpu.dispatch-tuning :as tuning]))
+
+(def manifest-version 1)
+(def plan-version 1)
+
+(defn- schedule-target
+  [dispatch]
+  (let [path (get-in dispatch [:attributes :tuning :schedule-path])
+        key (get-in dispatch [:attributes :tuning :schedule-key])]
+    (when-not (and (vector? path) (seq path) (every? keyword? path))
+      (throw (ex-info "tunable dispatch does not declare a tuning schedule path"
+                      {:reason :invalid-tuning-schedule-path
+                       :dispatch-id (:id dispatch) :schedule-path path})))
+    (when-not (or (nil? key)
+                  (and (string? key) (not-empty key))
+                  (keyword? key))
+      (throw (ex-info "tunable dispatch declares an invalid tuning schedule key"
+                      {:reason :invalid-tuning-schedule-key
+                       :dispatch-id (:id dispatch) :schedule-key key})))
+    {:path path :key key}))
+
+(defn dispatch-signature
+  "Stable program-group identity for one tunable dispatch, excluding its current selector policy."
+  [dispatch]
+  (let [dispatch (kdispatch/validate! dispatch)
+        contract (get-in dispatch [:attributes :tuning])]
+    (when-not (map? contract)
+      (throw (ex-info "tunable dispatch contract must be a map"
+                      {:reason :invalid-dispatch-tuning-contract
+                       :dispatch-id (:id dispatch) :contract contract})))
+    (when (nil? (:numerical-mode contract))
+      (throw (ex-info "tunable dispatch contract requires a numerical mode"
+                      {:reason :missing-dispatch-numerical-mode :dispatch-id (:id dispatch)})))
+    (when (nil? (:layout contract))
+      (throw (ex-info "tunable dispatch contract requires a layout"
+                      {:reason :missing-dispatch-layout :dispatch-id (:id dispatch)})))
+    {:dispatch-id (:id dispatch)
+     :default-strategy (:default-strategy dispatch)
+     :selector-argument (get-in dispatch [:selector :argument])
+     :schedule-target (schedule-target dispatch)
+     :numerical-mode (:numerical-mode contract)
+     :layout (:layout contract)
+     :artifacts (mapv tuning/artifact-signature (:alternatives dispatch))}))
+
+(defn- tunable-step?
+  [step]
+  (and (some? (:dispatch step))
+       (some? (get-in step [:dispatch :attributes :tuning]))))
+
+(defn manifest
+  "Describe and deduplicate the tunable KernelDispatch sites in a compiled program descriptor.
+
+   Site and group ordering follows descriptor step order. The first equivalent site is the group's
+   benchmark representative. Reusing a dispatch ID for a different emitted or schedule identity is
+   rejected instead of allowing an unsafe tuning result to leak across operations."
+  [descriptor]
+  (when-not (map? descriptor)
+    (throw (ex-info "program tuning manifest requires a compiled descriptor"
+                    {:reason :invalid-program-descriptor :descriptor descriptor})))
+  (when-not (vector? (:steps descriptor))
+    (throw (ex-info "program tuning manifest requires a descriptor :steps vector"
+                    {:reason :invalid-program-steps :steps (:steps descriptor)})))
+  (let [sites
+        (into []
+              (keep (fn [[step-index step]]
+                      (when (tunable-step? step)
+                        (let [dispatch (kdispatch/validate! (:dispatch step))
+                              signature (dispatch-signature dispatch)]
+                          {:step-index step-index
+                           :phase (:phase step)
+                           :dispatch-id (:id dispatch)
+                           :group-id (:id dispatch)
+                           :signature signature}))))
+              (map-indexed vector (:steps descriptor)))
+        {:keys [order groups]}
+        (reduce
+         (fn [{:keys [order groups] :as state} site]
+           (let [group-id (:group-id site)
+                 prior (get groups group-id)]
+             (if prior
+               (do
+                 (when-not (= (:signature prior) (:signature site))
+                   (throw (ex-info "program reuses a dispatch ID for incompatible tuning sites"
+                                   {:reason :program-dispatch-identity-collision
+                                    :dispatch-id group-id
+                                    :first-step (:representative-step-index prior)
+                                    :different-step (:step-index site)
+                                    :first-signature (:signature prior)
+                                    :different-signature (:signature site)})))
+                 (assoc state :groups
+                        (assoc groups group-id
+                               (-> prior
+                                   (update :step-indices conj (:step-index site))
+                                   (update :phases conj (:phase site))
+                                   (update :site-count inc)))))
+               {:order (conj order group-id)
+                :groups (assoc groups group-id
+                               {:id group-id
+                                :dispatch-id group-id
+                                :representative-step-index (:step-index site)
+                                :step-indices [(:step-index site)]
+                                :phases [(:phase site)]
+                                :site-count 1
+                                :signature (:signature site)})})))
+         {:order [] :groups {}}
+         sites)
+        ordered-groups (mapv groups order)]
+    {:version manifest-version
+     :site-count (count sites)
+     :group-count (count ordered-groups)
+     :sites sites
+     :groups ordered-groups}))
+
+(defn validate-plan!
+  [plan]
+  (when-not (and (map? plan)
+                 (= plan-version (:version plan))
+                 (vector? (:selected-groups plan))
+                 (vector? (:deferred-groups plan)))
+    (throw (ex-info "invalid program dispatch tuning plan"
+                    {:reason :invalid-program-tuning-plan :plan plan})))
+  plan)
+
+(defn tuning-plan
+  "Select a deterministic subset of manifest groups for a later explicit benchmark action.
+
+   Options:
+     :group-ids  collection of stable dispatch/group IDs (default: every group)
+     :max-groups non-negative upper bound after filtering (default: every selected group)
+
+   Unknown group IDs and invalid budgets fail loudly. A zero budget is a valid dry plan."
+  ([manifest] (tuning-plan manifest {}))
+  ([manifest {:keys [group-ids max-groups] :as options}]
+   (when-not (and (map? manifest)
+                  (= manifest-version (:version manifest))
+                  (vector? (:groups manifest)))
+     (throw (ex-info "program tuning plan requires a valid manifest"
+                     {:reason :invalid-program-tuning-manifest :manifest manifest})))
+   (when-not (or (nil? max-groups)
+                 (and (integer? max-groups) (not (neg? (long max-groups)))))
+     (throw (ex-info "program tuning :max-groups must be a non-negative integer"
+                     {:reason :invalid-program-tuning-budget :max-groups max-groups})))
+   (let [known (set (map :id (:groups manifest)))
+         requested (when (some? group-ids) (set group-ids))
+         unknown (when requested (seq (remove known requested)))]
+     (when unknown
+       (throw (ex-info "program tuning plan names unknown dispatch groups"
+                       {:reason :unknown-program-tuning-groups
+                        :unknown (set unknown) :known known})))
+     (let [eligible (if requested
+                      (filterv #(contains? requested (:id %)) (:groups manifest))
+                      (:groups manifest))
+           limit (long (or max-groups (count eligible)))
+           selected (vec (take limit eligible))
+           deferred (vec (drop limit eligible))]
+       (validate-plan!
+        {:version plan-version
+         :manifest-version (:version manifest)
+         :manifest-group-count (:group-count manifest)
+         :budget {:max-groups max-groups
+                  :eligible-groups (count eligible)
+                  :selected-groups (count selected)}
+         :options (select-keys options [:group-ids :max-groups])
+         :selected-groups selected
+         :deferred-groups deferred})))))
+
+(defn- merge-value
+  [left right path]
+  (cond
+    (and (map? left) (map? right))
+    (if (or (contains? left :kind) (contains? right :kind))
+      (if (= left right)
+        left
+        (throw (ex-info "program tuning results conflict at one schedule target"
+                        {:reason :program-tuning-schedule-conflict
+                         :path path :left left :right right})))
+      (reduce-kv (fn [result key value]
+                   (if (contains? result key)
+                     (assoc result key (merge-value (get result key) value (conj path key)))
+                     (assoc result key value)))
+                 left right))
+
+    (= left right) left
+
+    :else
+    (throw (ex-info "program tuning results conflict at one schedule target"
+                    {:reason :program-tuning-schedule-conflict
+                     :path path :left left :right right}))))
+
+(defn merge-schedule-overrides
+  "Merge per-dispatch schedule fragments, rejecting different values at the same leaf."
+  [overrides]
+  (reduce (fn [result override]
+            (when-not (map? override)
+              (throw (ex-info "program tuning schedule override must be a map"
+                              {:reason :invalid-program-tuning-override :override override})))
+            (merge-value result override []))
+          {}
+          overrides))

--- a/src/raster/gpu/schedule.clj
+++ b/src/raster/gpu/schedule.clj
@@ -62,7 +62,8 @@
     ;; schedules once and selects after those scalar values become concrete. The subgroup multiple
     ;; is the analytic crossover seed; measurement/autotuning may override it per machine.
     :segmented-weighted-reduction {:strategy :auto
-                                   :score-reuse-subgroup-multiple 16}
+                                   :score-reuse-subgroup-multiple 16
+                                   :measured-selectors {}}
     :meta  {:target (:device-id desc)
             :machine-params (machine-params desc)
             :derived-by :raster.gpu.schedule/derive-default
@@ -188,8 +189,8 @@
         reduction-strategy (get-in schedule [:segmented-weighted-reduction :strategy] :auto)
         score-reuse-multiple
         (get-in schedule [:segmented-weighted-reduction :score-reuse-subgroup-multiple] 16)
-        measured-selector
-        (get-in schedule [:segmented-weighted-reduction :measured-selector])]
+        measured-selectors
+        (get-in schedule [:segmented-weighted-reduction :measured-selectors] {})]
     (when-not (valid-precisions prec)
       (throw (ex-info (str "schedule: unknown :precision " (pr-str prec) " — expected " valid-precisions)
                       {:precision prec})))
@@ -206,13 +207,15 @@
     (when-not (and (integer? score-reuse-multiple) (pos? score-reuse-multiple))
       (throw (ex-info "schedule: score-reuse subgroup multiple must be a positive integer"
                       {:score-reuse-subgroup-multiple score-reuse-multiple})))
-    (when (and (some? measured-selector) (not (map? measured-selector)))
-      (throw (ex-info "schedule: measured segmented reduction selector must be a map"
-                      {:measured-selector measured-selector})))
-    (when (and (some? measured-selector) (not= :auto reduction-strategy))
-      (throw (ex-info "schedule: a measured selector requires :strategy :auto"
+    (when-not (and (map? measured-selectors)
+                   (every? #(and (string? %) (not-empty %)) (keys measured-selectors))
+                   (every? map? (vals measured-selectors)))
+      (throw (ex-info "schedule: measured segmented reduction selectors must map dispatch IDs to selector maps"
+                      {:measured-selectors measured-selectors})))
+    (when (and (seq measured-selectors) (not= :auto reduction-strategy))
+      (throw (ex-info "schedule: measured selectors require :strategy :auto"
                       {:strategy reduction-strategy
-                       :measured-selector measured-selector}))))
+                       :measured-selectors measured-selectors}))))
   (let [budget (grf-budget-bytes-per-lane schedule desc)
         acc    (acc-bytes-per-lane schedule)
         staged (register-staged-bytes-per-lane schedule)

--- a/test/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse_test.clj
+++ b/test/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse_test.clj
@@ -160,6 +160,7 @@
   (let [analytic (pipeline/compile-gpu-program
                   #'resident-structured-reduction-probe :ze:0 :dtype :float)
         argument (get-in analytic [:steps 0 :dispatch :selector :argument])
+        dispatch-id (get-in analytic [:steps 0 :dispatch :id])
         selector {:kind :runtime-scalar-ranges
                   :argument argument
                   :below :indexed-segmented-reduction-reference
@@ -170,7 +171,7 @@
         (pipeline/compile-gpu-program
          #'resident-structured-reduction-probe :ze:0 :dtype :float
          :schedule {:segmented-weighted-reduction
-                    {:strategy :auto :measured-selector selector}})
+                    {:strategy :auto :measured-selectors {dispatch-id selector}}})
         step (first (:steps descriptor))
         arguments-for
         (fn [args]
@@ -182,6 +183,7 @@
         narrow [(float-array 15) (float-array 15) (float-array 15)
                 (long-array 4) (long-array 4) 3 4 5 2]
         wide (assoc narrow 7 8)]
+    (is (= dispatch-id (get-in step [:dispatch :id])))
     (is (= selector (get-in step [:dispatch :selector])))
     (is (= :measured-runtime-shape (get-in step [:dispatch :attributes :selection])))
     (is (= :indexed-segmented-reduction-reference
@@ -232,8 +234,9 @@
     (is (= {'n-nodes 3 'n-edges 4 'emb-dim 5 'n-heads 2 'dk 2}
            (select-keys (get-in projected [:reference-inputs :scalars])
                         '[n-nodes n-edges emb-dim n-heads dk])))
-    (is (= [:segmented-weighted-reduction :measured-selector]
+    (is (= [:segmented-weighted-reduction :measured-selectors]
            (:schedule-path contract)))
+    (is (= (get-in descriptor [:steps 0 :dispatch :id]) (:schedule-key contract)))
     (is (= :segmented-weighted-reduction (get-in contract [:reference :kind])))
     (is (= :float (get-in contract [:numerical-mode :accumulate])))
     (is (= :indexed-dense-values (get-in contract [:layout :storage :kind])))

--- a/test/raster/gpu/dispatch_benchmark_test.clj
+++ b/test/raster/gpu/dispatch_benchmark_test.clj
@@ -163,7 +163,8 @@
 
 (deftest compiled-program-bridge-projects-a-case-and-returns-recompilation-data
   (let [tuning-contract
-        {:schedule-path [:generic-reduction :measured-selector]
+        {:schedule-path [:generic-reduction :measured-selectors]
+         :schedule-key "resident-benchmark-test"
          :numerical-mode {:input :f32 :accumulate :f32 :output :f32}
          :layout {:input :contiguous :output :contiguous}}
         compiled-dispatch (assoc-in dispatch [:attributes :tuning] tuning-contract)
@@ -218,7 +219,8 @@
     (is (= (:numerical-mode tuning-contract)
            (get-in @observed [:options :numerical-mode])))
     (is (= (:layout tuning-contract) (get-in @observed [:options :layout])))
-    (is (= {:generic-reduction {:measured-selector measured-selector}}
+    (is (= {:generic-reduction
+            {:measured-selectors {"resident-benchmark-test" measured-selector}}}
            (:schedule-override result)))
     (is (= measured-selector (:selector result)))
     (is (= :reduce (:phase result)))))

--- a/test/raster/gpu/indexed_attention_device_test.clj
+++ b/test/raster/gpu/indexed_attention_device_test.clj
@@ -202,7 +202,8 @@
             (is (= (:selector result)
                    (get-in result
                            [:schedule-override :segmented-weighted-reduction
-                            :measured-selector])))
+                            :measured-selectors
+                            (get-in descriptor [:steps 0 :dispatch :id])])))
             (is (= :gpu-step-0 (:phase result)))))))))
 
 (deftest resident-compiler-selects-from-runtime-component-width

--- a/test/raster/gpu/program_tuning_test.clj
+++ b/test/raster/gpu/program_tuning_test.clj
@@ -1,0 +1,146 @@
+(ns raster.gpu.program-tuning-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.gpu.dispatch-benchmark :as benchmark]
+            [raster.gpu.program-tuning :as program-tuning]))
+
+(def ^:private abi
+  [(kabi/slot 'x :input :float :role :operand)
+   (kabi/slot 'out :output :float :role :result)
+   (kabi/slot 'width :scalar :long :role :shape)])
+
+(defn- emitted
+  [kernel-name strategy workgroup]
+  (artifact/make
+   {:kernel-name kernel-name
+    :source (str "__kernel void " kernel-name
+                 "(__global const float* x, __global float* out, long width) {}")
+    :abi abi
+    :arguments '[x out width]
+    :launch (launch/spec {:workgroup-size [workgroup]
+                          :group-count [(launch/ceil-div 'width workgroup)]})
+    :effects {:kind :elementwise-map :reads ['x] :writes ['out]}
+    :attributes {:strategy strategy}}))
+
+(def ^:private alternatives
+  [(emitted "program_tuning_reference" :reference 64)
+   (emitted "program_tuning_subgroup" :subgroup 16)])
+
+(defn- dispatch
+  [id]
+  (kdispatch/make
+   {:id id
+    :alternatives alternatives
+    :default-strategy :reference
+    :selector {:kind :runtime-scalar-threshold
+               :argument 'width :threshold 256
+               :at-least :subgroup :otherwise :reference}
+    :attributes
+    {:tuning {:schedule-path [:generic-reduction :measured-selectors]
+              :schedule-key id
+              :numerical-mode {:input :f32 :accumulate :f32 :output :f32}
+              :layout {:input :contiguous :output :contiguous}}}}))
+
+(def ^:private dispatch-a (dispatch "dispatch-a"))
+(def ^:private dispatch-b (dispatch "dispatch-b"))
+
+(def ^:private descriptor
+  {:steps [{:phase :first-a :dispatch dispatch-a}
+           {:phase :only-b :dispatch dispatch-b}
+           {:phase :second-a :dispatch dispatch-a}
+           {:phase :ordinary-kernel}]})
+
+(deftest manifest-groups-equivalent-sites-in-program-order
+  (let [manifest (program-tuning/manifest descriptor)]
+    (is (= 3 (:site-count manifest)))
+    (is (= 2 (:group-count manifest)))
+    (is (= ["dispatch-a" "dispatch-b"] (mapv :id (:groups manifest))))
+    (is (= [0 2] (get-in manifest [:groups 0 :step-indices])))
+    (is (= [:first-a :second-a] (get-in manifest [:groups 0 :phases])))
+    (is (= 2 (get-in manifest [:groups 0 :site-count])))
+    (is (= 1 (get-in manifest [:groups 1 :representative-step-index])))))
+
+(deftest manifest-rejects-a-reused-id-with-a-different-contract
+  (let [different (assoc-in dispatch-a [:attributes :tuning :layout]
+                            {:input :strided :output :contiguous})]
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"incompatible tuning sites"
+         (program-tuning/manifest
+          {:steps [{:phase :first :dispatch dispatch-a}
+                   {:phase :different :dispatch different}]})))))
+
+(deftest tuning-plan-is-deterministic-and-explicitly-bounded
+  (let [manifest (program-tuning/manifest descriptor)
+        plan (program-tuning/tuning-plan manifest {:max-groups 1})]
+    (is (= ["dispatch-a"] (mapv :id (:selected-groups plan))))
+    (is (= ["dispatch-b"] (mapv :id (:deferred-groups plan))))
+    (is (= 1 (get-in plan [:budget :selected-groups])))
+    (testing "manifest order wins over caller collection order"
+      (is (= ["dispatch-a" "dispatch-b"]
+             (mapv :id (:selected-groups
+                        (program-tuning/tuning-plan
+                         manifest {:group-ids ["dispatch-b" "dispatch-a"]}))))))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"unknown dispatch groups"
+         (program-tuning/tuning-plan manifest {:group-ids ["absent"]})))
+    (is (empty? (:selected-groups
+                 (program-tuning/tuning-plan manifest {:max-groups 0}))))))
+
+(deftest schedule-fragments-merge-by-dispatch-key-and-conflicts-fail
+  (is (= {:generic-reduction {:measured-selectors
+                              {"dispatch-a" :selector-a
+                               "dispatch-b" :selector-b}}}
+         (program-tuning/merge-schedule-overrides
+          [{:generic-reduction {:measured-selectors {"dispatch-a" :selector-a}}}
+           {:generic-reduction {:measured-selectors {"dispatch-b" :selector-b}}}])))
+  (is (thrown-with-msg?
+       clojure.lang.ExceptionInfo #"conflict"
+       (program-tuning/merge-schedule-overrides
+        [{:generic-reduction {:measured-selectors {"dispatch-a" :selector-a}}}
+         {:generic-reduction {:measured-selectors {"dispatch-a" :selector-b}}}]))))
+
+(deftest program-runner-checks-budget-before-tuning-and-merges-results
+  (let [manifest (program-tuning/manifest descriptor)
+        plan (program-tuning/tuning-plan manifest)
+        session (atom {:programs {:program {:descriptor descriptor}}})
+        calls (atom [])
+        fake-tune
+        (fn [_ _ _ runtime-values _ & options]
+          (let [step (:step (apply hash-map options))
+                dispatch (get-in descriptor [:steps step :dispatch])
+                id (:id dispatch)
+                selector {:kind :runtime-scalar-ranges
+                          :argument 'width :below :reference
+                          :ranges [{:at-least 256 :strategy :subgroup}]}]
+            (swap! calls conj [id runtime-values step])
+            {:tuning :fake
+             :selector selector
+             :schedule-override
+             {:generic-reduction {:measured-selectors {id selector}}}
+             :step-index step
+             :phase (get-in descriptor [:steps step :phase])}))]
+    (with-redefs [benchmark/tune-program-dispatch! fake-tune]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"exceeds its physical measurement budget"
+           (benchmark/tune-program-dispatches!
+            session descriptor {} plan
+            (constantly [256 128 256])
+            (fn [& _] {})
+            :max-measurements 7)))
+      (is (empty? @calls))
+      (let [result (benchmark/tune-program-dispatches!
+                    session descriptor {} plan
+                    (constantly [256 128 256])
+                    (fn [& _] {})
+                    :max-measurements 8)]
+        (is (= 8 (:planned-measurements result)))
+        (is (= [["dispatch-a" [128 256] 0]
+                ["dispatch-b" [128 256] 1]]
+               @calls))
+        (is (= #{"dispatch-a" "dispatch-b"}
+               (set (keys (get-in result
+                                  [:schedule-override :generic-reduction
+                                   :measured-selectors])))))))))

--- a/test/raster/gpu/schedule_test.clj
+++ b/test/raster/gpu/schedule_test.clj
@@ -53,7 +53,8 @@
     (testing "the default policy is f16-xmx (training AMP)"
       (is (= :f16-xmx (:precision derived))))
     (testing "dynamic segmented reductions default to runtime shape selection"
-      (is (= {:strategy :auto :score-reuse-subgroup-multiple 16}
+      (is (= {:strategy :auto :score-reuse-subgroup-multiple 16
+              :measured-selectors {}}
              (:segmented-weighted-reduction derived))))
     (testing "a pinned override is recorded in :meta :overrides"
       (is (contains? (get-in (sched/resolve derived {:precision :f32-scalar}) [:meta :overrides])
@@ -133,19 +134,20 @@
                             {:segmented-weighted-reduction
                              {:score-reuse-subgroup-multiple 0}})
                            arc-desc)))
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must be a map"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must map dispatch IDs"
                           (sched/feasible?
                            (sched/resolve
                             (sched/derive-default nil arc-desc)
-                            {:segmented-weighted-reduction {:measured-selector :invalid}})
+                            {:segmented-weighted-reduction {:measured-selectors :invalid}})
                            arc-desc)))
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"requires :strategy :auto"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"require :strategy :auto"
                           (sched/feasible?
                            (sched/resolve
                             (sched/derive-default nil arc-desc)
                             {:segmented-weighted-reduction
                              {:strategy :reference
-                              :measured-selector {:kind :runtime-scalar-ranges}}})
+                              :measured-selectors
+                              {"dispatch-a" {:kind :runtime-scalar-ranges}}}})
                            arc-desc))))
   (testing "conflicting :gemm-precision sugar and :precision throw, not silently prefer the deprecated key"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"conflicting"


### PR DESCRIPTION
Summary:
- make structured-reduction dispatch identity independent of analytic or measured selector policy and key schedule writeback by stable dispatch ID
- add a pure deterministic program tuning manifest and bounded plan that deduplicate equivalent compiled sites and reject identity collisions
- add explicit resident program tuning with preflight candidate-measurement budgets and collision-free schedule merging

Verification:
- focused compiler/tuning suite: 26 tests, 144 assertions, all green
- compiled resident OpenCL tuning integration on Intel Arc: green
- full suite: 2,272 tests, 33,947 assertions; 4 known unrelated Arc-specific explain-pipeline-truth expectation failures, 0 errors