### PR TITLE
Copy resident buffer ranges without host staging

### DIFF
--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -865,6 +865,30 @@
         spec (checked-view-range-spec buffer view spec :download)]
     ((rt-resolve (:device-id @sess) "download-range!") buffer dst spec)))
 
+(defn copy-range!
+  "Copy a contiguous element range between resident buffers or views.
+
+   `spec` requires `:elements`; `:src-element` and `:dst-element` default to
+   zero and are relative to their respective views. Source and destination must
+   belong to this session and have the same storage dtype. The backend performs
+   a direct resident copy without materializing a JVM array. Returns `dst`."
+  [sess src dst {:keys [src-element dst-element elements]
+                 :or {src-element 0 dst-element 0}
+                 :as spec}]
+  (let [{src-buffer :buffer src-view :view} (resolve-resident-binding sess src)
+        {dst-buffer :buffer dst-view :view} (resolve-resident-binding sess dst)
+        src-spec (checked-view-range-spec src-buffer src-view spec :download)
+        dst-spec (checked-view-range-spec dst-buffer dst-view spec :upload)
+        src-dtype (dtype/canon (:dtype src-buffer))
+        dst-dtype (dtype/canon (:dtype dst-buffer))]
+    (when-not (= src-dtype dst-dtype)
+      (throw (ex-info "resident range copy requires identical storage dtypes"
+                      {:source-dtype src-dtype :destination-dtype dst-dtype})))
+    ((rt-resolve (:device-id @sess) "copy-buffer-range!")
+     src-buffer dst-buffer
+     (:src-element src-spec) (:dst-element dst-spec) elements)
+    dst))
+
 (defn- transfer-ranges!
   "The batched core. VALIDATES EVERY entry (`plan-range`) before EXECUTING ANY. A batch is how a
    whole KV cache moves — 36 per-layer buffers for gemma-270m — and a batched API newly makes a

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -181,6 +181,8 @@
   (delay (make-handle "clEnqueueWriteBuffer" (fd I32 PTR PTR I32 I64 I64 PTR I32 PTR PTR))))
 (def ^:private h-clEnqueueReadBuffer
   (delay (make-handle "clEnqueueReadBuffer" (fd I32 PTR PTR I32 I64 I64 PTR I32 PTR PTR))))
+(def ^:private h-clEnqueueCopyBuffer
+  (delay (make-handle "clEnqueueCopyBuffer" (fd I32 PTR PTR PTR I64 I64 I64 I32 PTR PTR))))
 (def ^:private h-clEnqueueFillBuffer
   (delay (make-handle "clEnqueueFillBuffer" (fd I32 PTR PTR PTR I64 I64 I64 I32 PTR PTR))))
 (def ^:private h-clReleaseMemObject
@@ -668,6 +670,24 @@
   [^OclBuffer buf dst spec]
   (execute-range! buf (plan-range buf dst spec :download) :download)
   dst)
+
+(defn copy-buffer-range!
+  "Synchronously enqueue a device-resident OpenCL buffer range copy."
+  [^OclBuffer src ^OclBuffer dst src-element dst-element elements]
+  (when-not (= (:dtype src) (:dtype dst))
+    (throw (ex-info "OpenCL resident copy requires matching dtypes"
+                    {:source-dtype (:dtype src) :destination-dtype (:dtype dst)})))
+  (let [element-bytes (long (get dtype-byte-sizes (:dtype src) 4))
+        src-byte (* (long src-element) element-bytes)
+        dst-byte (* (long dst-element) element-bytes)
+        byte-count (* (long elements) element-bytes)
+        queue (:queue @state)]
+    (cl-call! "clEnqueueCopyBuffer" @h-clEnqueueCopyBuffer
+              [queue (:cl-mem src) (:cl-mem dst)
+               src-byte dst-byte byte-count
+               (int 0) MemorySegment/NULL MemorySegment/NULL])
+    (cl-call! "clFinish" @h-clFinish [queue])
+    dst))
 
 (defn buffer->array
   "Copy an OclBuffer's contents to a new JVM array (device → host)."

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -938,6 +938,21 @@
   (execute-range! buf (plan-range buf dst spec :download) :download)
   dst)
 
+(defn copy-buffer-range!
+  "Synchronously copy an element range between resident Level Zero buffers."
+  [^DeviceBuffer src ^DeviceBuffer dst src-element dst-element elements]
+  (when-not (= (:dtype src) (:dtype dst))
+    (throw (ex-info "Level Zero resident copy requires matching dtypes"
+                    {:source-dtype (:dtype src) :destination-dtype (:dtype dst)})))
+  (let [element-bytes (long (get dtype-byte-sizes (:dtype src) 4))
+        src-byte (* (long src-element) element-bytes)
+        dst-byte (* (long dst-element) element-bytes)
+        byte-count (* (long elements) element-bytes)]
+    (synchronize-async!)
+    (MemorySegment/copy (:segment src) src-byte
+                        (:segment dst) dst-byte byte-count)
+    dst))
+
 (defn buffer->array
   "Copy a DeviceBuffer's contents to a new JVM array.
   For :float16/:half, returns a short array of encoded FP16 values.

--- a/test/raster/gpu/range_transfer_test.clj
+++ b/test/raster/gpu/range_transfer_test.clj
@@ -21,6 +21,13 @@
 (def ^:private kvrow 256)
 (def ^:private N (* maxpos kvrow))
 
+(def ^:private opencl-available?
+  (delay
+    (try
+      ((requiring-resolve 'raster.gpu.ocl-runtime/init!))
+      true
+      (catch Throwable _ false))))
+
 (defn- with-filled-session
   "A session whose :kc0 buffer holds value=index at every element, so any disturbance is visible."
   [f]
@@ -79,6 +86,43 @@
           (is (thrown-with-msg? clojure.lang.ExceptionInfo #"exceeds the buffer view"
                                 (g/download-range! s view out
                                                    {:src-element (dec n) :elements 2}))))))))
+
+(deftest resident-range-copy-stays-between-checked-views
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "resident range copy")
+    (let [session (g/make-session :ze:0)
+          values (float-array (map float (range 16)))]
+      (try
+        (g/alloc! session {:source [:float 16 values]
+                           :destination [:float 16 nil]})
+        (let [source (g/buffer-view session :source
+                                    {:byte-offset (* 4 3) :shape [5]})
+              destination (g/buffer-view session :destination
+                                         {:byte-offset (* 4 7) :shape [5]})]
+          (is (identical? destination
+                          (g/copy-range! session source destination {:elements 5})))
+          (is (= [0.0 0.0 0.0 0.0 0.0 0.0 0.0
+                  3.0 4.0 5.0 6.0 7.0 0.0 0.0 0.0 0.0]
+                 (vec (g/download session :destination))))
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"exceeds the buffer view"
+                                (g/copy-range! session source destination
+                                               {:src-element 4 :elements 2}))))
+        (finally
+          (g/close-session! session))))))
+
+(deftest opencl-resident-range-copy-uses-the-device-buffer-path
+  (if-not @opencl-available?
+    (is true "OpenCL device unavailable")
+    (let [session (g/make-session :ocl:0)]
+      (try
+        (g/alloc! session {:source [:float 6 (float-array [1 2 3 4 5 6])]
+                           :destination [:float 6 nil]})
+        (g/copy-range! session :source :destination
+                       {:src-element 2 :dst-element 1 :elements 3})
+        (is (= [0.0 3.0 4.0 5.0 0.0 0.0]
+               (vec (g/download session :destination))))
+        (finally
+          (g/close-session! session))))))
 
 (deftest a-jvm-array-and-a-memory-segment-take-the-same-path
   (if-not @gp/gpu-available?


### PR DESCRIPTION
Summary:
- Add a checked backend-neutral resident range-copy API for buffers and views.
- Use direct unified-allocation copies on Level Zero.
- Use clEnqueueCopyBuffer on OpenCL, including NVIDIA and AMD devices.
- Validate dtype, view lifetime, contiguity, offsets, and bounds before copying.

Why:
Paged KV copy-on-write and other resident graph workflows must duplicate partial pages without downloading into JVM arrays and uploading again.

Validation:
- Level Zero resident view-to-view copy: 3 assertions, 0 failures.
- OpenCL device-buffer copy: 1 assertion, 0 failures.
- git diff check passes.

The repository formatter still reports unrelated pre-existing drift in ze_runtime.clj; the added section is formatted and no unrelated lines are changed.