### PR TITLE
Dispatch across kernel graph schedules

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -218,6 +218,15 @@ rewrite legality → hardware feasibility → analytic rank → measured rank
 A cost model may abstain. A failed legality or resource check is never converted
 to a different semantic program.
 
+Runtime selection and offline tuning operate on an emitted executable
+alternative, not necessarily one kernel. An alternative is either a single
+`KernelArtifact` or an emitted `KernelGraph`. All alternatives in one
+`KernelDispatch` share one ordered external ABI, compiler argument order,
+target, and logical effects; graph topology, entry points, launch geometry,
+derived scalars, and private temporaries are schedule-owned and may differ.
+This is what permits a direct contraction and a split-K partial-plus-combine
+graph to compete without making split-K storage part of the user-visible call.
+
 ### 3.4 Scheduled kernel graph and kernel IR
 
 The scheduled graph contains calls between kernels and explicit resident

--- a/src/raster/compiler/backend/gpu/attention.clj
+++ b/src/raster/compiler/backend/gpu/attention.clj
@@ -390,6 +390,8 @@
     (kgraph/make
      {:inputs (mapv graph-buffer inputs)
       :outputs [(graph-buffer output)]
+      :abi (:abi artifact)
+      :arguments (:arguments artifact)
       :nodes [(kgraph/->ScheduledKernel node-id artifact uses [])]
       :effects {:kind :attention :logical-visibility true :ordered-page-routing true}
       :provenance {:operation-id id :semantic-op :attention}

--- a/src/raster/compiler/backend/gpu/indexed_attention.clj
+++ b/src/raster/compiler/backend/gpu/indexed_attention.clj
@@ -530,6 +530,8 @@
     (kgraph/make
      {:inputs (mapv #(graph-buffer % :input) inputs)
       :outputs [(graph-buffer output :output)]
+      :abi (:abi artifact)
+      :arguments (:arguments artifact)
       :nodes [(kgraph/->ScheduledKernel
                [:segmented-weighted-reduction (:id plan) :indexed-reference] artifact uses [])]
       :effects {:kind :segmented-weighted-reduction :materialized-intermediates []}
@@ -563,6 +565,8 @@
     (kgraph/make
      {:inputs (mapv #(graph-buffer % :input) inputs)
       :outputs [(graph-buffer output :output)]
+      :abi (:abi artifact)
+      :arguments (:arguments artifact)
       :nodes [(kgraph/->ScheduledKernel
                [:segmented-weighted-reduction (:id plan) :indexed-dynamic-reference]
                artifact uses [])]

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -314,8 +314,8 @@
                     (swap! dispatches conj dispatch)
                     (list 'raster.gpu.ze-runtime/invoke-registered-contraction-dispatch!
                           (:id dispatch)
-                          (:kernel-name (kdispatch/default-artifact dispatch))
-                          (vec (:arguments (kdispatch/default-artifact dispatch)))))
+                          (:kernel-name (kdispatch/default-alternative dispatch))
+                          (vec (:arguments (kdispatch/default-alternative dispatch)))))
                   (let [routed (swr-route/route-dynamic! plan @target-desc)
                         artifact (register-kernel! (:artifact routed)
                                                    :ze-structured-reductions)]

--- a/src/raster/compiler/backend/gpu/paged_kv_append.clj
+++ b/src/raster/compiler/backend/gpu/paged_kv_append.clj
@@ -112,6 +112,8 @@
     (graph/make
      {:inputs (into input-buffers output-buffers)
       :outputs output-buffers
+      :abi (:abi emitted)
+      :arguments (:arguments emitted)
       :nodes [(graph/->ScheduledKernel
                [:paged-kv-append id :fp32-to-fp16-reference]
                emitted uses [])]

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -596,8 +596,35 @@
               :temporaries []
               :effects {:kind :scan-stage :phase phase}
               :provenance {:dialect :segscan :segop-id (:id operation) :graph-node id}
-              :attributes {:phase phase :dtype dtype :scan-workgroup scan-workgroup}})))]
-    (-> (kgraph/map-operations graph emit-node)
+              :attributes {:phase phase :dtype dtype :scan-workgroup scan-workgroup}})))
+        emitted (kgraph/map-operations graph emit-node)
+        external-buffers (vec (distinct (concat (:inputs emitted) (:outputs emitted))))
+        scalar-pairs (->> (:nodes emitted)
+                          (mapcat (fn [node]
+                                    (map vector (get-in node [:operation :abi])
+                                         (get-in node [:operation :arguments]))))
+                          (filter (fn [[slot argument]]
+                                    (and (= :scalar (:kind slot)) (symbol? argument))))
+                          vec)
+        scalar-groups (group-by second scalar-pairs)
+        _ (doseq [[argument pairs] scalar-groups]
+            (when-not (apply = (map (comp :kernel-dtype first) pairs))
+              (throw (ex-info "scan graph scalar has inconsistent emitted ABI dtypes"
+                              {:argument argument :slots (mapv first pairs)}))))
+        pointer-abi (mapv (fn [{:keys [id dtype role]}]
+                            (kabi/slot id (if (= :input role) :input :output) dtype))
+                          external-buffers)
+        scalar-arguments (vec (sort-by name (keys scalar-groups)))
+        scalar-abi (mapv (fn [argument]
+                           (let [slots (mapv first (get scalar-groups argument))
+                                 dtype (:kernel-dtype (first slots))
+                                 role (if (some #(= :bound (:role %)) slots)
+                                        :bound :parameter)]
+                             (kabi/slot argument :scalar dtype :role role)))
+                         scalar-arguments)]
+    (-> emitted
+        (assoc :abi (vec (concat pointer-abi scalar-abi))
+               :arguments (vec (concat (map :id external-buffers) scalar-arguments)))
         (assoc-in [:provenance :target-dialect] :opencl-c)
         (assoc-in [:attributes :emitted?] true)
         kgraph/validate!)))

--- a/src/raster/compiler/ir/kernel_dispatch.clj
+++ b/src/raster/compiler/ir/kernel_dispatch.clj
@@ -1,11 +1,11 @@
 (ns raster.compiler.ir.kernel-dispatch
-  "A verified runtime choice among ABI-compatible emitted kernels.
+  "A verified runtime choice among ABI-compatible kernel executables.
 
-   KernelArtifact remains one entry point. KernelDispatch is the scheduling value above it: every
-   alternative implements the same logical call and differs only in emitted schedule/geometry.
-   Selection is pure data evaluated after symbolic ABI scalars become concrete and before a
-   backend binder sees a KernelCall."
-  (:require [raster.compiler.ir.kernel-artifact :as kart]))
+   An alternative may be one KernelArtifact or an emitted KernelGraph. KernelDispatch is the
+   scheduling value above both: every alternative implements the same logical call and differs
+   only in its emitted schedule. Selection is pure data evaluated after symbolic ABI scalars
+   become concrete and before a backend binder sees the selected executable."
+  (:require [raster.compiler.ir.kernel-executable :as kexec]))
 
 (defrecord KernelDispatch
            [id
@@ -21,13 +21,13 @@
   (and x (= "raster.compiler.ir.kernel_dispatch.KernelDispatch"
             (.getName (class x)))))
 
-(defn artifact-strategy
-  [artifact]
-  (get-in (kart/validate! artifact) [:attributes :strategy]))
+(defn alternative-strategy
+  [alternative]
+  (kexec/strategy alternative))
 
 (defn- strategy-map
   [alternatives]
-  (into {} (map (juxt artifact-strategy identity)) alternatives))
+  (into {} (map (juxt alternative-strategy identity)) alternatives))
 
 (defn- finite-number?
   [value]
@@ -90,7 +90,8 @@
   "Validate a dispatch and return it unchanged.
 
    Alternatives must have unique strategy identities and identical target, ABI, compiler argument
-   order, temporaries and effects. Their source and launch geometry may differ—that is the point."
+   order, and logical effects. Their entry points, launch geometry, graph topology, and private
+   temporaries may differ—that is the point."
   [dispatch]
   (when-not (kernel-dispatch? dispatch)
     (throw (ex-info "kernel dispatch must be a KernelDispatch value"
@@ -101,28 +102,36 @@
     (when-not (and (vector? alternatives) (seq alternatives))
       (throw (ex-info "kernel dispatch requires an ordered non-empty alternative vector"
                       {:id id :alternatives alternatives})))
-    (doseq [artifact alternatives] (kart/validate! artifact))
-    (let [strategies (mapv artifact-strategy alternatives)
+    (doseq [alternative alternatives] (kexec/validate! alternative))
+    (let [strategies (mapv alternative-strategy alternatives)
           strategy-set (set strategies)
-          kernel-names (mapv :kernel-name alternatives)
           common (first alternatives)
-          common-view (select-keys common [:target :abi :arguments :temporaries :effects])]
+          common-view (kexec/common-view common)
+          named-artifacts (mapcat (fn [alternative]
+                                    (map (juxt :kernel-name identity)
+                                         (kexec/artifacts alternative)))
+                                  alternatives)]
       (when-not (every? keyword? strategies)
         (throw (ex-info "every kernel dispatch alternative requires a keyword :strategy"
                         {:id id :strategies strategies})))
       (when-not (= (count strategies) (count strategy-set))
         (throw (ex-info "kernel dispatch alternative strategies must be unique"
                         {:id id :strategies strategies})))
-      (when-not (= (count kernel-names) (count (set kernel-names)))
-        (throw (ex-info "kernel dispatch alternatives must have unique emitted entry points"
-                        {:id id :kernel-names kernel-names})))
-      (doseq [artifact (rest alternatives)]
-        (when-not (= common-view
-                     (select-keys artifact [:target :abi :arguments :temporaries :effects]))
+      (doseq [alternative (rest alternatives)]
+        (when-not (= common-view (kexec/common-view alternative))
           (throw (ex-info "kernel dispatch alternatives must share target, ABI and logical effects"
                           {:id id
-                           :common-kernel (:kernel-name common)
-                           :different-kernel (:kernel-name artifact)}))))
+                           :common-strategy (alternative-strategy common)
+                           :different-strategy (alternative-strategy alternative)}))))
+      ;; Graph schedules may deliberately share entry points. Reuse is legal only when the name
+      ;; denotes the same emitted module/signature; otherwise backend registration is ambiguous.
+      (doseq [[kernel-name entries] (group-by first named-artifacts)]
+        (let [implementations (set (map (fn [[_ artifact]]
+                                          (select-keys artifact [:target :source :abi :arguments]))
+                                        entries))]
+          (when-not (= 1 (count implementations))
+            (throw (ex-info "kernel dispatch reuses an entry point for conflicting modules"
+                            {:id id :kernel-name kernel-name})))))
       (when-not (contains? strategy-set default-strategy)
         (throw (ex-info "kernel dispatch default strategy is absent"
                         {:id id :default default-strategy :strategies strategy-set})))
@@ -139,8 +148,8 @@
   (validate!
    (->KernelDispatch id alternatives default-strategy selector provenance attributes)))
 
-(defn artifact
-  "Return the artifact implementing `strategy`, or throw with the legal strategy set."
+(defn alternative
+  "Return the executable implementing `strategy`, or throw with the legal strategy set."
   [dispatch strategy]
   (let [dispatch (validate! dispatch)
         alternatives (strategy-map (:alternatives dispatch))]
@@ -149,10 +158,10 @@
                         {:id (:id dispatch) :strategy strategy
                          :strategies (set (keys alternatives))})))))
 
-(defn default-artifact
+(defn default-alternative
   [dispatch]
   (let [dispatch (validate! dispatch)]
-    (artifact dispatch (:default-strategy dispatch))))
+    (alternative dispatch (:default-strategy dispatch))))
 
 (defn with-selector
   "Return `dispatch` with a replacement selector, revalidating it against the common ABI and
@@ -164,20 +173,20 @@
   [value]
   (if (and (map? value) (contains? value :value)) (:value value) value))
 
-(defn select-artifact
-  "Select an artifact from concrete ABI-ordered values.
+(defn select-alternative
+  "Select an executable alternative from concrete ABI-ordered values.
 
    `override` is nil/:auto for data-driven selection or an explicit alternative strategy. The
    runtime threshold selector is intentionally generic: it knows only a compiler argument and a
    numeric crossover, not which model operation produced them."
-  ([dispatch runtime-arguments] (select-artifact dispatch runtime-arguments nil))
+  ([dispatch runtime-arguments] (select-alternative dispatch runtime-arguments nil))
   ([dispatch runtime-arguments override]
    (let [dispatch (validate! dispatch)]
      (if (and override (not= :auto override))
-       (artifact dispatch override)
+       (alternative dispatch override)
        (let [{:keys [kind argument threshold at-least otherwise ranges below]}
              (:selector dispatch)
-             common-arguments (:arguments (default-artifact dispatch))
+             common-arguments (kexec/arguments (default-alternative dispatch))
              indexes (keep-indexed (fn [index value] (when (= argument value) index))
                                    common-arguments)]
          (when-not (= 1 (count indexes))
@@ -192,7 +201,7 @@
            (when-not (number? value)
              (throw (ex-info "kernel dispatch selector requires a numeric runtime scalar"
                              {:id (:id dispatch) :argument argument :value value})))
-           (artifact
+           (alternative
             dispatch
             (case kind
               :runtime-scalar-threshold

--- a/src/raster/compiler/ir/kernel_executable.clj
+++ b/src/raster/compiler/ir/kernel_executable.clj
@@ -1,0 +1,108 @@
+(ns raster.compiler.ir.kernel-executable
+  "The common executable boundary for one emitted kernel or a scheduled emitted kernel graph.
+
+   This namespace does not erase the distinction between the two values. It exposes only the
+   properties that dispatch selection and offline tuning may compare: target, ordered external
+   ABI, compiler arguments, logical effects, strategy, and concrete entry-point artifacts. Graph
+   temporaries, dependencies, and derived scalars remain graph-owned schedule details."
+  (:require [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-graph :as kgraph]))
+
+(defn kernel-executable?
+  [value]
+  (or (kart/kernel-artifact? value) (kgraph/kernel-graph? value)))
+
+(defn kind
+  [executable]
+  (cond
+    (kart/kernel-artifact? executable) :kernel-artifact
+    (kgraph/kernel-graph? executable) :kernel-graph
+    :else nil))
+
+(defn artifacts
+  "Return every concrete entry-point artifact in execution order."
+  [executable]
+  (case (kind executable)
+    :kernel-artifact [(kart/validate! executable)]
+    :kernel-graph (mapv (comp kart/validate! :operation)
+                        (:nodes (kgraph/validate! executable)))
+    (throw (ex-info "kernel executable must be an artifact or graph"
+                    {:executable executable :actual (type executable)}))))
+
+(defn validate!
+  "Validate an emitted executable and return it unchanged."
+  [executable]
+  (case (kind executable)
+    :kernel-artifact (kart/validate! executable)
+    :kernel-graph
+    (let [graph (kgraph/validate! executable)]
+      (when-not (kgraph/has-interface? graph)
+        (throw (ex-info "emitted kernel graph requires an ordered external ABI"
+                        {:graph graph})))
+      (when-not (seq (:nodes graph))
+        (throw (ex-info "emitted kernel graph requires at least one kernel node" {:graph graph})))
+      (let [targets (set (map :target (artifacts graph)))]
+        (when-not (= 1 (count targets))
+          (throw (ex-info "kernel graph nodes must share one target dialect"
+                          {:targets targets}))))
+      graph)
+    (throw (ex-info "kernel executable must be an artifact or graph"
+                    {:executable executable :actual (type executable)}))))
+
+(defn target [executable]
+  (:target (first (artifacts (validate! executable)))))
+
+(defn abi [executable]
+  (:abi (validate! executable)))
+
+(defn arguments [executable]
+  (:arguments (validate! executable)))
+
+(defn effects [executable]
+  (:effects (validate! executable)))
+
+(defn attributes [executable]
+  (:attributes (validate! executable)))
+
+(defn strategy
+  [executable]
+  (get (attributes executable) :strategy))
+
+(defn entry-points
+  [executable]
+  (mapv :kernel-name (artifacts (validate! executable))))
+
+(defn common-view
+  "Return the logical interface that every dispatch alternative must preserve."
+  [executable]
+  (let [executable (validate! executable)]
+    {:target (target executable)
+     :abi (:abi executable)
+     :arguments (:arguments executable)
+     :effects (:effects executable)}))
+
+(defn graph-bindings
+  "Project ABI-ordered runtime arguments into the maps consumed by KernelGraphCall.
+
+   Pointer values remain opaque resident keys/views. External scalar values must already be typed;
+   graph-internal derived integer expressions are resolved later from this scalar environment."
+  [graph runtime-arguments]
+  (let [graph (validate! graph)]
+    (when-not (= :kernel-graph (kind graph))
+      (throw (ex-info "graph bindings require a KernelGraph executable"
+                      {:executable graph :kind (kind graph)})))
+    (kabi/validate-arguments! (:abi graph) runtime-arguments)
+    (reduce (fn [{:keys [buffers scalar-values] :as bindings} [slot argument value]]
+              (if (= :scalar (:kind slot))
+                (do
+                  (when-not (and (map? value) (contains? value :type) (contains? value :value))
+                    (throw (ex-info "kernel graph scalar argument must be explicitly typed"
+                                    {:slot slot :argument argument :value value})))
+                  (when-not (= (:kernel-dtype slot) (:type value))
+                    (throw (ex-info "kernel graph scalar argument has the wrong ABI dtype"
+                                    {:slot slot :argument argument :value value})))
+                  (assoc bindings :scalar-values (assoc scalar-values argument value)))
+                (assoc bindings :buffers (assoc buffers argument value))))
+            {:buffers {} :scalar-values {}}
+            (map vector (:abi graph) (:arguments graph) runtime-arguments))))

--- a/src/raster/compiler/ir/kernel_graph.clj
+++ b/src/raster/compiler/ir/kernel_graph.clj
@@ -6,12 +6,13 @@
    replaces the operation with a KernelArtifact without reconstructing dataflow from marker
    conventions.  Stable GraphBuffer identities make intermediate storage part of the program."
   (:require [clojure.set :as set]
+            [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.segop :as segop]))
 
 (defrecord GraphBuffer [id dtype elements memory-space role])
 (defrecord ValueUse [buffer access])
 (defrecord ScheduledKernel [id operation uses dependencies])
-(defrecord KernelGraph [inputs outputs temporaries nodes effects provenance attributes])
+(defrecord KernelGraph [inputs outputs temporaries nodes abi arguments effects provenance attributes])
 
 (def ^:private buffer-roles #{:input :output :inout :temporary})
 (def ^:private access-modes #{:read :write :read-write})
@@ -67,6 +68,50 @@
         (seq (set/intersection ew lw))
         (seq (set/intersection er lw)))))
 
+(defn has-interface?
+  "Return true when a graph declares an ordered external call interface. Target-neutral graphs
+   may omit it temporarily; every emitted executable graph must provide it."
+  [graph]
+  (and (some? (:abi graph)) (some? (:arguments graph))))
+
+(defn- validate-interface!
+  [graph]
+  (let [{:keys [abi arguments]} graph]
+    (when-not (= (some? abi) (some? arguments))
+      (throw (ex-info "kernel graph ABI and arguments must be declared together"
+                      {:abi abi :arguments arguments})))
+    (when (some? abi)
+      (kabi/validate-arguments! abi arguments)
+      (let [external-by-id (into {} (map (juxt :id identity))
+                                 (concat (:inputs graph) (:outputs graph)))
+            pointer-pairs (filterv (fn [[slot _]] (not= :scalar (:kind slot)))
+                                   (mapv vector abi arguments))
+            pointer-arguments (mapv second pointer-pairs)
+            scalar-arguments (mapv second
+                                   (filterv (fn [[slot _]] (= :scalar (:kind slot)))
+                                            (mapv vector abi arguments)))]
+        (when-not (= (set (keys external-by-id)) (set pointer-arguments))
+          (throw (ex-info "kernel graph pointer interface differs from its external buffers"
+                          {:external (set (keys external-by-id))
+                           :pointer-arguments pointer-arguments})))
+        (when-not (= (count pointer-arguments) (count (set pointer-arguments)))
+          (throw (ex-info "kernel graph pointer interface must name each external buffer once"
+                          {:pointer-arguments pointer-arguments})))
+        (when-not (= (count scalar-arguments) (count (set scalar-arguments)))
+          (throw (ex-info "kernel graph scalar interface arguments must be unique"
+                          {:scalar-arguments scalar-arguments})))
+        (doseq [[slot id] pointer-pairs]
+          (let [{:keys [dtype role]} (get external-by-id id)
+                expected-kind (if (= :input role) :input :output)]
+            (when-not (= dtype (:dtype slot))
+              (throw (ex-info "kernel graph ABI storage dtype differs from its buffer"
+                              {:buffer id :buffer-dtype dtype :slot slot})))
+            (when-not (= expected-kind (:kind slot))
+              (throw (ex-info "kernel graph ABI pointer direction differs from its buffer role"
+                              {:buffer id :role role :slot slot
+                               :expected-kind expected-kind})))))))
+    graph))
+
 (defn validate!
   "Validate a KernelGraph and return it unchanged.
 
@@ -113,6 +158,7 @@
       (when-not (map? value)
         (throw (ex-info "kernel graph descriptive sections must be maps"
                         {:field field :value value}))))
+    (validate-interface! graph)
     (let [declared (set buffer-ids)
           output-ids (set (map :id outputs))
           initially-written (set (map :id (filter #(contains? #{:input :inout} (:role %)) buffers)))]
@@ -187,9 +233,10 @@
 
 (defn make
   "Construct and verify a scheduled KernelGraph from explicit compiler values."
-  [{:keys [inputs outputs temporaries nodes effects provenance attributes]
+  [{:keys [inputs outputs temporaries nodes abi arguments effects provenance attributes]
     :or {inputs [] outputs [] temporaries [] nodes [] effects {} provenance {} attributes {}}}]
-  (validate! (->KernelGraph inputs outputs temporaries nodes effects provenance attributes)))
+  (validate! (->KernelGraph inputs outputs temporaries nodes abi arguments
+                            effects provenance attributes)))
 
 (defn map-operations
   "Replace each scheduled operation while preserving and revalidating graph dataflow. `f` receives

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -1850,7 +1850,7 @@
                                                              {:dispatch-id dispatch-id}))))
                               dispatch (when dispatch (kdispatch/validate! dispatch))
                               artifact (if dispatch
-                                         (kdispatch/default-artifact dispatch)
+                                         (kdispatch/default-alternative dispatch)
                                          (reg-entry kernel-name))
                               _ (when (and dispatch
                                            (not= kernel-name (:kernel-name artifact)))

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -36,7 +36,7 @@
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
-            [raster.compiler.ir.kernel-graph :as kgraph]
+            [raster.compiler.ir.kernel-executable :as kexec]
             [raster.compiler.ir.kernel-graph-call :as kgcall]
             [raster.compiler.pipeline :as pl]
             [raster.core :as rcore]
@@ -1154,74 +1154,81 @@
    The graph owns its temporary allocations and dedicated bound kernel handles. Binding validates
    the complete graph call, lowers dependencies to logical queue/event edges, then records a
    conservative dependency-safe sequence. Current backends map the logical plan to one in-order
-   compute queue; submit-kernel-graph! exposes asynchronous completion without native handles."
-  [sess graph-key graph buffer-keys scalar-values]
-  (let [{:keys [device-id closed?]} @sess
-        graph (kgraph/validate! graph)
-        external-ids (external-graph-buffer-ids graph)]
-    (when closed?
-      (throw (ex-info "cannot bind a kernel graph in a closed GPU session" {:key graph-key})))
-    (when-not (= external-ids (set (keys buffer-keys)))
-      (throw (ex-info "kernel graph external bindings differ from graph inputs/outputs"
-                      {:expected external-ids :bound (set (keys buffer-keys))})))
-    (let [graph-buffer-by-id (into {} (map (juxt :id identity))
-                                   (concat (:inputs graph) (:outputs graph)))
-          external-bindings (into {}
-                                  (map (fn [[id key-or-view]]
-                                         [id (resolve-resident-binding sess key-or-view)]))
-                                  buffer-keys)
-          _ (doseq [[id {:keys [view]}] external-bindings]
-              (validate-external-view! (get graph-buffer-by-id id) view scalar-values))
-          _ (validate-physical-aliases! graph external-bindings)
-          _ (release-graph-events! sess graph-key)
-          temporary-specs (kgcall/temporary-specs graph scalar-values)
-          temporary-buffers (alloc-buffers-transactional temporary-specs device-id)
-          owned-view-buffers (volatile! [])
-          prepareds (volatile! [])
-          runtime-graph (volatile! nil)]
-      (try
-        (let [{:keys [buffers] :as materialized}
-              (materialize-external-buffers! device-id external-bindings)
-              _ (vreset! owned-view-buffers (:owned-view-buffers materialized))
-              all-buffers (merge buffers temporary-buffers)
-              register! (rt-resolve device-id "register-kernel!")
-              bind-call! (rt-resolve device-id "bind-kernel-call")
-              record! (rt-resolve device-id "record-graph!")
-              graph-call (kgcall/make graph all-buffers scalar-values)
-              execution-plan (execution/from-kernel-graph-call graph-call)]
-          (doseq [node (:nodes graph)]
-            (let [artifact (:operation node)]
-              (register! (:kernel-name artifact) artifact)))
-          (doseq [node-call (:nodes graph-call)]
-            (let [prepared (assoc (bind-call! (:call node-call))
-                                  :phase (:id node-call))]
-              (vswap! prepareds conj prepared)))
+   compute queue; submit-kernel-graph! exposes asynchronous completion without native handles.
+
+   Option :profile? records device timestamp events for explicit offline measurement."
+  ([sess graph-key graph buffer-keys scalar-values]
+   (bind-kernel-graph! sess graph-key graph buffer-keys scalar-values {}))
+  ([sess graph-key graph buffer-keys scalar-values {:keys [profile?]
+                                                    :or {profile? false}}]
+   (let [{:keys [device-id closed?]} @sess
+         graph (kexec/validate! graph)
+         external-ids (external-graph-buffer-ids graph)]
+     (when closed?
+       (throw (ex-info "cannot bind a kernel graph in a closed GPU session" {:key graph-key})))
+     (when-not (= external-ids (set (keys buffer-keys)))
+       (throw (ex-info "kernel graph external bindings differ from graph inputs/outputs"
+                       {:expected external-ids :bound (set (keys buffer-keys))})))
+     (let [graph-buffer-by-id (into {} (map (juxt :id identity))
+                                    (concat (:inputs graph) (:outputs graph)))
+           external-bindings (into {}
+                                   (map (fn [[id key-or-view]]
+                                          [id (resolve-resident-binding sess key-or-view)]))
+                                   buffer-keys)
+           _ (doseq [[id {:keys [view]}] external-bindings]
+               (validate-external-view! (get graph-buffer-by-id id) view scalar-values))
+           _ (validate-physical-aliases! graph external-bindings)
+           _ (release-graph-events! sess graph-key)
+           temporary-specs (kgcall/temporary-specs graph scalar-values)
+           temporary-buffers (alloc-buffers-transactional temporary-specs device-id)
+           owned-view-buffers (volatile! [])
+           prepareds (volatile! [])
+           runtime-graph (volatile! nil)]
+       (try
+         (let [{:keys [buffers] :as materialized}
+               (materialize-external-buffers! device-id external-bindings)
+               _ (vreset! owned-view-buffers (:owned-view-buffers materialized))
+               all-buffers (merge buffers temporary-buffers)
+               register! (rt-resolve device-id "register-kernel!")
+               bind-call! (rt-resolve device-id "bind-kernel-call")
+               record! (rt-resolve device-id "record-graph!")
+               graph-call (kgcall/make graph all-buffers scalar-values)
+               execution-plan (execution/from-kernel-graph-call graph-call)]
+           (doseq [node (:nodes graph)]
+             (let [artifact (:operation node)]
+               (register! (:kernel-name artifact) artifact)))
+           (doseq [node-call (:nodes graph-call)]
+             (let [prepared (assoc (bind-call! (:call node-call))
+                                   :phase (:id node-call))]
+               (vswap! prepareds conj prepared)))
           ;; Graph verification proves every dependency names an earlier node and every hazard is
           ;; represented. Serial recording is therefore a safe implementation of that partial
           ;; order on today's single in-order compute queues; the logical plan retains the DAG.
-          (vreset! runtime-graph (record! @prepareds {:barriers? true}))
-          (let [entry {:graph-call graph-call
-                       :execution-plan execution-plan
-                       :runtime-graph @runtime-graph
+           (vreset! runtime-graph (record! @prepareds (cond-> {:barriers? true}
+                                                        profile? (assoc :profile? true))))
+           (let [entry {:graph-call graph-call
+                        :execution-plan execution-plan
+                        :runtime-graph @runtime-graph
+                        :prepareds @prepareds
+                        :owned-view-buffers @owned-view-buffers
+                        :temporary-buffers temporary-buffers
+                        :buffer-keys buffer-keys
+                        :resident-views (into {} (map (fn [[id binding]]
+                                                        [id (:resident binding)]))
+                                              external-bindings)
+                        :outputs (select-keys all-buffers (map :id (:outputs graph)))
+                        :profile? (boolean profile?)}
+                 old (get-in @sess [:kernel-graphs graph-key])]
+             (swap! sess assoc-in [:kernel-graphs graph-key] entry)
+             (when old (destroy-kernel-graph-entry! device-id old))
+             (->KernelGraphHandle graph-key)))
+         (catch Exception e
+           (destroy-kernel-graph-entry!
+            device-id {:runtime-graph @runtime-graph
                        :prepareds @prepareds
                        :owned-view-buffers @owned-view-buffers
-                       :temporary-buffers temporary-buffers
-                       :buffer-keys buffer-keys
-                       :resident-views (into {} (map (fn [[id binding]]
-                                                       [id (:resident binding)]))
-                                             external-bindings)
-                       :outputs (select-keys all-buffers (map :id (:outputs graph)))}
-                old (get-in @sess [:kernel-graphs graph-key])]
-            (swap! sess assoc-in [:kernel-graphs graph-key] entry)
-            (when old (destroy-kernel-graph-entry! device-id old))
-            (->KernelGraphHandle graph-key)))
-        (catch Exception e
-          (destroy-kernel-graph-entry!
-           device-id {:runtime-graph @runtime-graph
-                      :prepareds @prepareds
-                      :owned-view-buffers @owned-view-buffers
-                      :temporary-buffers temporary-buffers})
-          (throw e))))))
+                       :temporary-buffers temporary-buffers})
+           (throw e)))))))
 
 (defn bind-kernel-call!
   "Bind one emitted KernelArtifact over session-resident arguments as a replayable graph.
@@ -1304,6 +1311,29 @@
                        :owned-view-buffers @owned-view-buffers
                        :temporary-buffers {}})
            (throw e)))))))
+
+(defn bind-kernel-executable!
+  "Bind one KernelArtifact or emitted KernelGraph through its common ordered external ABI.
+
+   Graph alternatives project pointer arguments to external GraphBuffer identities and typed
+   scalar arguments to the graph's symbolic scalar environment. Graph-owned temporaries and
+   derived bounds stay private. :group-count is meaningful only for a single artifact."
+  ([sess executable-key executable arguments]
+   (bind-kernel-executable! sess executable-key executable arguments {}))
+  ([sess executable-key executable arguments {:keys [group-count] :as options}]
+   (let [executable (kexec/validate! executable)]
+     (case (kexec/kind executable)
+       :kernel-artifact
+       (bind-kernel-call! sess executable-key executable arguments options)
+
+       :kernel-graph
+       (do
+         (when group-count
+           (throw (ex-info "group-count cannot override a multi-kernel graph schedule"
+                           {:key executable-key :group-count group-count})))
+         (let [{:keys [buffers scalar-values]} (kexec/graph-bindings executable arguments)]
+           (bind-kernel-graph! sess executable-key executable buffers scalar-values
+                               (select-keys options [:profile?]))))))))
 
 (defn kernel-graph-execution-plan
   "Return the pure backend-neutral queue/event plan for a bound KernelGraph."
@@ -1418,7 +1448,7 @@
                  (rt-resolve device-id "expand-pointer-binding"))
                 logical-or-physical-args)
               selected-artifact (if-let [dispatch (:dispatch step)]
-                                  (kdispatch/select-artifact dispatch ordered-args)
+                                  (kdispatch/select-alternative dispatch ordered-args)
                                   artifact)
               call (kcall/make selected-artifact ordered-args
                                (if (= :reduce convention) {:group-count [1]} {}))
@@ -1940,7 +1970,7 @@
                         (rt-resolve device-id "expand-pointer-binding"))
                        logical-or-physical-args)
                      selected-artifact (if-let [dispatch (:dispatch step)]
-                                         (kdispatch/select-artifact
+                                         (kdispatch/select-alternative
                                           dispatch ordered-args reduction-strategy)
                                          artifact)
                      call (kcall/make selected-artifact ordered-args
@@ -2185,7 +2215,7 @@
                      key)))
                (:argument-specs step))
          arguments (physical-program-step-arguments step logical-arguments)
-         _abi (kabi/validate-arguments! (:abi (kdispatch/default-artifact dispatch)) arguments)
+         _abi (kabi/validate-arguments! (:abi (kdispatch/default-alternative dispatch)) arguments)
          resident-bindings
          (into {}
                (keep (fn [[{:keys [kind sym]} value]]

--- a/src/raster/gpu/dispatch_benchmark.clj
+++ b/src/raster/gpu/dispatch_benchmark.clj
@@ -2,12 +2,13 @@
   "Concrete resident execution driver for generic KernelDispatch autotuning.
 
    This namespace contains no operation recognition or schedule policy. A dispatch already owns
-   emitted ABI-compatible alternatives; a benchmark case supplies resident arguments, an
+   emitted ABI-compatible executable alternatives; a benchmark case supplies resident arguments, an
    independent correctness oracle, and (only when necessary) a reset action. Every candidate is
    validated before it is measured, device time comes from profiling events, and DispatchTuning
    remains responsible for selection and caching."
   (:require [clojure.set :as set]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-executable :as kexec]
             [raster.gpu.core :as gpu]
             [raster.gpu.dispatch-tuning :as tuning]
             [raster.gpu.program-tuning :as program-tuning]))
@@ -19,13 +20,13 @@
   [value]
   (if (and (map? value) (contains? value :value)) (:value value) value))
 
-(defn- stateful-artifact?
-  [artifact]
-  (let [{:keys [reads writes]} (:effects artifact)]
+(defn- stateful-executable?
+  [executable]
+  (let [{:keys [reads writes]} (kexec/effects executable)]
     (boolean (seq (set/intersection (set reads) (set writes))))))
 
 (defn- validate-case!
-  [dispatch artifact runtime-value case]
+  [dispatch executable runtime-value case]
   (when-not (map? case)
     (throw (ex-info "dispatch benchmark case must be a map"
                     {:runtime-value runtime-value :case case})))
@@ -33,14 +34,14 @@
         selector-argument (get-in dispatch [:selector :argument])
         indexes (keep-indexed (fn [index value]
                                 (when (= selector-argument value) index))
-                              (:arguments artifact))]
+                              (kexec/arguments executable))]
     (when-not (vector? arguments)
       (throw (ex-info "dispatch benchmark case arguments must be an ABI-ordered vector"
                       {:runtime-value runtime-value :arguments arguments})))
-    (when-not (= (count (:abi artifact)) (count arguments))
-      (throw (ex-info "dispatch benchmark case argument count differs from the artifact ABI"
+    (when-not (= (count (kexec/abi executable)) (count arguments))
+      (throw (ex-info "dispatch benchmark case argument count differs from the executable ABI"
                       {:runtime-value runtime-value
-                       :expected (count (:abi artifact)) :actual (count arguments)})))
+                       :expected (count (kexec/abi executable)) :actual (count arguments)})))
     (when-not (= 1 (count indexes))
       (throw (ex-info "dispatch benchmark selector must have one artifact argument position"
                       {:runtime-value runtime-value :argument selector-argument
@@ -56,9 +57,9 @@
     (when-not (or (nil? before-run!) (ifn? before-run!))
       (throw (ex-info "dispatch benchmark :before-run! must be callable"
                       {:runtime-value runtime-value :before-run! before-run!})))
-    (when (and (stateful-artifact? artifact) (nil? before-run!))
+    (when (and (stateful-executable? executable) (nil? before-run!))
       (throw (ex-info "stateful dispatch candidates require :before-run! restoration"
-                      {:runtime-value runtime-value :effects (:effects artifact)})))
+                      {:runtime-value runtime-value :effects (kexec/effects executable)})))
     (when-not (or (nil? measurement) (map? measurement))
       (throw (ex-info "dispatch benchmark :measurement options must be a map"
                       {:runtime-value runtime-value :measurement measurement})))
@@ -69,15 +70,15 @@
     case))
 
 (defn- validate-oracle-result!
-  [artifact runtime-value validation]
-  (let [source-hash (:source-hash (tuning/artifact-signature artifact))]
+  [executable runtime-value validation]
+  (let [source-hash (:source-hash (tuning/executable-signature executable))]
     (when-not (and (map? validation)
                    (true? (:passed? validation))
                    (string? (:oracle-hash validation))
                    (not-empty (:oracle-hash validation)))
       (throw (ex-info "dispatch candidate failed its oracle before measurement"
                       {:runtime-value runtime-value
-                       :strategy (kdispatch/artifact-strategy artifact)
+                       :strategy (kdispatch/alternative-strategy executable)
                        :validation validation})))
     (assoc validation :candidate-hash source-hash)))
 
@@ -91,39 +92,39 @@
       :before-run! (fn [context] ...)                        ; optional restore
       :measurement {:budget-ms ... :min-samples ...}}        ; optional
 
-   The context contains :session, :dispatch, :artifact, :runtime-value, :case, and after the
+   The context contains :session, :dispatch, :executable, :runtime-value, :case, and after the
    validation replay, :outputs. The driver supplies :candidate-hash itself, so a callback cannot
    accidentally validate one source and bless another."
-  [session dispatch artifact runtime-value case-fn & {:keys [measurement]}]
+  [session dispatch executable runtime-value case-fn & {:keys [measurement]}]
   (let [dispatch (kdispatch/validate! dispatch)
-        strategy (kdispatch/artifact-strategy artifact)
-        expected (kdispatch/artifact dispatch strategy)
-        _ (when-not (= expected artifact)
-            (throw (ex-info "dispatch benchmark artifact is not the registered alternative"
-                            {:strategy strategy :expected expected :artifact artifact})))
+        strategy (kdispatch/alternative-strategy executable)
+        expected (kdispatch/alternative dispatch strategy)
+        _ (when-not (= expected executable)
+            (throw (ex-info "dispatch benchmark executable is not the registered alternative"
+                            {:strategy strategy :expected expected :executable executable})))
         _ (when-not (or (nil? measurement) (map? measurement))
             (throw (ex-info "dispatch benchmark global :measurement options must be a map"
                             {:measurement measurement})))
-        case (validate-case! dispatch artifact runtime-value (case-fn runtime-value))
+        case (validate-case! dispatch executable runtime-value (case-fn runtime-value))
         measurement-options (merge measurement (:measurement case))
         reserved (set/intersection reserved-measurement-options
                                    (set (keys measurement-options)))]
     (when (seq reserved)
       (throw (ex-info "dispatch benchmark measurement options contain driver-owned fields"
                       {:runtime-value runtime-value :reserved reserved})))
-    (let [key [::candidate runtime-value (kdispatch/artifact-strategy artifact) (random-uuid)]
+    (let [key [::candidate runtime-value (kdispatch/alternative-strategy executable) (random-uuid)]
           started (System/nanoTime)
-          handle (gpu/bind-kernel-call! session key artifact (:arguments case)
-                                        {:profile? true
-                                         :group-count (:group-count case)})
+          handle (gpu/bind-kernel-executable! session key executable (:arguments case)
+                                              {:profile? true
+                                               :group-count (:group-count case)})
           compile-ms (/ (- (System/nanoTime) started) 1.0e6)
-          base-context {:session session :dispatch dispatch :artifact artifact
+          base-context {:session session :dispatch dispatch :executable executable
                         :runtime-value runtime-value :case case}]
       (try
         (when-let [before-run! (:before-run! case)] (before-run! base-context))
         (let [outputs (gpu/run-kernel-graph! session handle)
               validation (validate-oracle-result!
-                          artifact runtime-value
+                          executable runtime-value
                           ((:validate! case) (assoc base-context :outputs outputs)))
               before-sample! (when-let [before-run! (:before-run! case)]
                                #(before-run! base-context))
@@ -149,8 +150,8 @@
       :or {improvement-threshold 0.001 force? false}}]
   (tuning/tune!
    dispatch descriptor runtime-values
-   (fn [artifact runtime-value]
-     (benchmark-candidate! session dispatch artifact runtime-value case-fn
+   (fn [executable runtime-value]
+     (benchmark-candidate! session dispatch executable runtime-value case-fn
                            :measurement measurement))
    :numerical-mode numerical-mode
    :layout layout
@@ -289,7 +290,7 @@
                {:group group
                 :runtime-values runtime-values
                 :planned-measurements
-                (* (count (get-in group [:signature :artifacts]))
+                (* (count (get-in group [:signature :alternatives]))
                    (count runtime-values))}))
            (:selected-groups plan))
           planned-measurements (reduce + 0 (map :planned-measurements jobs))]

--- a/src/raster/gpu/dispatch_tuning.clj
+++ b/src/raster/gpu/dispatch_tuning.clj
@@ -2,17 +2,18 @@
   "Explicit offline autotuning for a KernelDispatch.
 
    Compilation and runtime selection never benchmark. This namespace measures already-emitted,
-   ABI-compatible alternatives through a caller-supplied validated benchmark, converts winners at
-   sampled runtime scalar values into a piecewise selector, and atomically caches that selector.
+   ABI-compatible executable alternatives through a caller-supplied validated benchmark, converts
+   winners at sampled runtime scalar values into a piecewise selector, and atomically caches it.
    Applying a result rechecks the full identity: device, emitted sources, ABI, numerical mode, and
    layout. A stale or cross-device result therefore cannot silently select a kernel."
   (:require [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-executable :as kexec]
             [raster.gpu.measurement :as measurement]
             [raster.gpu.tuning-cache :as cache])
   (:import [java.nio.charset StandardCharsets]
            [java.security MessageDigest]))
 
-(def tuning-version 1)
+(def tuning-version 2)
 
 (defrecord DispatchTuning
            [key identity selector measurements])
@@ -39,16 +40,37 @@
     (sequential? value) (mapv canonical-data value)
     :else value))
 
-(defn artifact-signature
-  "Stable correctness/performance identity of one emitted alternative."
-  [artifact]
-  {:strategy (kdispatch/artifact-strategy artifact)
-   :target (:target artifact)
-   :kernel-name (:kernel-name artifact)
-   :source-hash (sha256 (:source artifact))
-   :abi-hash (sha256 (pr-str (canonical-data (:abi artifact))))
-   :arguments-hash (sha256 (pr-str (:arguments artifact)))
-   :effects-hash (sha256 (pr-str (canonical-data (:effects artifact))))})
+(defn executable-signature
+  "Stable correctness/performance identity of one emitted executable alternative.
+
+   For a graph, the source hash covers node order, dependencies, uses, launch contracts, private
+   buffers, and every emitted module. A schedule change therefore cannot reuse stale tuning data
+   merely because its public ABI stayed constant."
+  [executable]
+  (let [executable (kexec/validate! executable)
+        graph? (= :kernel-graph (kexec/kind executable))
+        schedule (if graph?
+                   {:buffers {:inputs (:inputs executable)
+                              :outputs (:outputs executable)
+                              :temporaries (:temporaries executable)}
+                    :nodes (mapv (fn [node]
+                                   {:id (:id node)
+                                    :uses (:uses node)
+                                    :dependencies (:dependencies node)
+                                    :artifact (select-keys (:operation node)
+                                                           [:kernel-name :target :source :abi
+                                                            :arguments :launch :temporaries])})
+                                 (:nodes executable))}
+                   (select-keys executable
+                                [:kernel-name :target :source :launch :temporaries]))]
+    {:kind (kexec/kind executable)
+     :strategy (kdispatch/alternative-strategy executable)
+     :target (kexec/target executable)
+     :entry-points (kexec/entry-points executable)
+     :source-hash (sha256 (pr-str (canonical-data schedule)))
+     :abi-hash (sha256 (pr-str (canonical-data (kexec/abi executable))))
+     :arguments-hash (sha256 (pr-str (kexec/arguments executable)))
+     :effects-hash (sha256 (pr-str (canonical-data (kexec/effects executable))))}))
 
 (defn- device-signature
   [descriptor]
@@ -80,7 +102,7 @@
       :layout layout
       :policy {:runtime-values (vec runtime-values)
                :improvement-threshold (double improvement-threshold)}
-      :artifacts (mapv artifact-signature (:alternatives dispatch))})))
+      :alternatives (mapv executable-signature (:alternatives dispatch))})))
 
 (defn cache-key
   [identity]
@@ -122,9 +144,9 @@
    :budget-ms :cold-warm :timing-source :compile-ms :hashes])
 
 (defn- validate-benchmark-result!
-  [artifact runtime-value result]
+  [executable runtime-value result]
   (let [{:keys [measurement validation]} result
-        signature (artifact-signature artifact)]
+        signature (executable-signature executable)]
     (when-not (measurement/measurement? measurement)
       (throw (ex-info "dispatch benchmark must return a Measurement"
                       {:runtime-value runtime-value
@@ -194,10 +216,10 @@
   "Measure, validate, and cache a generic KernelDispatch selector OFFLINE.
 
    `runtime-values` are concrete numeric samples for the dispatch selector argument.
-   `benchmark-fn` is called as (benchmark-fn artifact runtime-value) and must return:
+   `benchmark-fn` is called as (benchmark-fn executable runtime-value) and must return:
 
      {:measurement Measurement
-      :validation {:passed? true :oracle-hash string :candidate-hash artifact-source-hash ...}}
+      :validation {:passed? true :oracle-hash string :candidate-hash executable-source-hash ...}}
 
    Correctness is therefore established before a timing can influence selection. Every result
    must be stationary and device-event timed. A candidate must improve on the dispatch default by

--- a/src/raster/gpu/program_tuning.clj
+++ b/src/raster/gpu/program_tuning.clj
@@ -48,7 +48,7 @@
      :schedule-target (schedule-target dispatch)
      :numerical-mode (:numerical-mode contract)
      :layout (:layout contract)
-     :artifacts (mapv tuning/artifact-signature (:alternatives dispatch))}))
+     :alternatives (mapv tuning/executable-signature (:alternatives dispatch))}))
 
 (defn- tunable-step?
   [step]

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -3599,13 +3599,13 @@
                                      {:dispatch-id dispatch-id
                                       :registered (keys @kernel-dispatch-registry)})))
         dispatch (kdispatch/validate! dispatch)
-        expected-default (:kernel-name (kdispatch/default-artifact dispatch))
+        expected-default (:kernel-name (kdispatch/default-alternative dispatch))
         _ (when-not (= expected-default default-kernel-name)
             (throw (ex-info "contraction dispatch marker default differs from its registry"
                             {:dispatch-id dispatch-id
                              :expected expected-default
                              :actual default-kernel-name})))
-        selected (kdispatch/select-artifact dispatch arguments)]
+        selected (kdispatch/select-alternative dispatch arguments)]
     (invoke-registered-contraction! (:kernel-name selected) arguments)))
 
 (defn invoke-gpu-transpose!

--- a/test/raster/compiler/ir/kernel_dispatch_test.clj
+++ b/test/raster/compiler/ir/kernel_dispatch_test.clj
@@ -1,8 +1,11 @@
 (ns raster.compiler.ir.kernel-dispatch-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-executable :as kexec]
+            [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.gpu.core :as gpu]
             [raster.gpu.ocl-runtime :as ocl]
@@ -43,15 +46,50 @@
                :at-least :subgroup-score-reuse
                :otherwise :reference}}))
 
+(defn- staged-graph
+  []
+  (let [temporary 'dispatch-temporary
+        stage (fn [kernel-name input output]
+                (kart/make
+                 {:kernel-name kernel-name
+                  :source (str "__kernel void " kernel-name
+                               "(__global const float* " input ", __global float* " output
+                               ", long width) {}")
+                  :abi [(kabi/slot input :input :float)
+                        (kabi/slot output :output :float)
+                        (kabi/slot 'width :scalar :long)]
+                  :arguments [input output 'width]
+                  :launch (klaunch/spec {:workgroup-size [64]
+                                         :group-count [(klaunch/ceil-div 'width 64)]})
+                  :effects {:kind :stage}}))
+        first-stage (stage "dispatch_stage_one" 'x temporary)
+        second-stage (stage "dispatch_stage_two" temporary 'out)]
+    (kgraph/make
+     {:inputs [(kgraph/buffer 'x :float 'width :device :input)]
+      :outputs [(kgraph/buffer 'out :float 'width :device :output)]
+      :temporaries [(kgraph/buffer temporary :float 'width :device :temporary)]
+      :abi abi
+      :arguments '[x out width]
+      :nodes [(kgraph/->ScheduledKernel
+               :stage-one first-stage
+               [(kgraph/->ValueUse 'x :read)
+                (kgraph/->ValueUse temporary :write)] [])
+              (kgraph/->ScheduledKernel
+               :stage-two second-stage
+               [(kgraph/->ValueUse temporary :read)
+                (kgraph/->ValueUse 'out :write)] [:stage-one])]
+      :effects (:effects reference)
+      :attributes {:strategy :two-stage}})))
+
 (deftest runtime-scalars-select-an-abi-compatible-artifact
   (is (kdispatch/kernel-dispatch? dispatch))
   (is (= "dispatch_reference"
-         (:kernel-name (kdispatch/select-artifact dispatch [:x :out {:type :long :value 128}]))))
+         (:kernel-name (kdispatch/select-alternative dispatch [:x :out {:type :long :value 128}]))))
   (is (= "dispatch_subgroup"
-         (:kernel-name (kdispatch/select-artifact dispatch [:x :out {:type :long :value 256}]))))
+         (:kernel-name (kdispatch/select-alternative dispatch [:x :out {:type :long :value 256}]))))
   (is (= "dispatch_subgroup"
-         (:kernel-name (kdispatch/select-artifact dispatch [:x :out {:type :long :value 2}]
-                                                  :subgroup-score-reuse)))
+         (:kernel-name (kdispatch/select-alternative dispatch [:x :out {:type :long :value 2}]
+                                                     :subgroup-score-reuse)))
       "an explicit schedule override is authoritative"))
 
 (deftest measured-runtime-ranges-select-without-runtime-tuning
@@ -62,17 +100,35 @@
                     :below :reference
                     :ranges [{:at-least 192 :strategy :subgroup-score-reuse}
                              {:at-least 768 :strategy :reference}]})
-        select #(kdispatch/artifact-strategy
-                 (kdispatch/select-artifact measured [:x :out {:type :long :value %}]))]
+        select #(kdispatch/alternative-strategy
+                 (kdispatch/select-alternative measured [:x :out {:type :long :value %}]))]
     (is (= :reference (select 128)))
     (is (= :subgroup-score-reuse (select 192)))
     (is (= :subgroup-score-reuse (select 512)))
     (is (= :reference (select 768)))
     (is (= :subgroup-score-reuse
-           (kdispatch/artifact-strategy
-            (kdispatch/select-artifact measured [:x :out {:type :long :value 1}]
-                                       :subgroup-score-reuse)))
+           (kdispatch/alternative-strategy
+            (kdispatch/select-alternative measured [:x :out {:type :long :value 1}]
+                                          :subgroup-score-reuse)))
         "an explicit override remains authoritative over measured selector data")))
+
+(deftest dispatch-preserves-one-interface-across-single-and-multi-kernel-schedules
+  (let [graph (staged-graph)
+        mixed (kdispatch/make
+               {:id "mixed-executable-dispatch"
+                :alternatives [reference graph]
+                :default-strategy :reference
+                :selector {:kind :runtime-scalar-threshold
+                           :argument 'width :threshold 256
+                           :at-least :two-stage :otherwise :reference}})]
+    (is (= :kernel-artifact
+           (kexec/kind (kdispatch/select-alternative
+                        mixed [:x :out {:type :long :value 128}]))))
+    (is (= :kernel-graph
+           (kexec/kind (kdispatch/select-alternative
+                        mixed [:x :out {:type :long :value 256}]))))
+    (is (= '[x out width] (kexec/arguments graph)))
+    (is (= ['dispatch-temporary] (mapv :id (:temporaries graph))))))
 
 (deftest dispatch-rejects-incompatible-or-ambiguous-alternatives
   (testing "an alternative cannot silently change the ordered ABI"
@@ -112,14 +168,27 @@
            :default-strategy :reference
            :selector {:kind :runtime-scalar-threshold :argument 'x :threshold 1
                       :at-least :subgroup-score-reuse :otherwise :reference}}))))
-  (testing "alternatives need distinct runtime registry entry points"
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo #"unique emitted entry points"
+  (testing "shared entry points are legal when they name the same module"
+    (is (kdispatch/kernel-dispatch?
          (kdispatch/make
-          {:id "duplicate-entry-point"
+          {:id "shared-entry-point"
            :alternatives [reference
                           (assoc subgroup :kernel-name (:kernel-name reference)
                                  :source (:source reference))]
+           :default-strategy :reference
+           :selector (:selector dispatch)}))))
+  (testing "one entry point cannot name conflicting emitted modules"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"conflicting modules"
+         (kdispatch/make
+          {:id "duplicate-entry-point"
+           :alternatives
+           [reference
+            (assoc subgroup
+                   :kernel-name (:kernel-name reference)
+                   :source (-> (:source subgroup)
+                               (str/replace "dispatch_subgroup" "dispatch_reference")
+                               (str/replace "{}" "{ long gid = get_global_id(0); }")))]
            :default-strategy :reference
            :selector (:selector dispatch)})))))
 

--- a/test/raster/compiler/ir/kernel_graph_call_test.clj
+++ b/test/raster/compiler/ir/kernel_graph_call_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.segop-opencl :as emit]
             [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.kernel-graph-call :as graph-call]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.soac-lower :as lower]))
@@ -42,3 +43,13 @@
                                            {'n {:type :int :value 1025}})))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"explicitly typed"
                           (graph-call/make graph buffers {'n 1025})))))
+
+(deftest emitted-graph-projects-one-ordered-public-call-to-runtime-binding-maps
+  (let [graph (emitted-graph)
+        n {:type :int :value 1025}
+        bindings (executable/graph-bindings graph [:values-resident :out-resident n])]
+    (is (= '[values out n] (:arguments graph)))
+    (is (= {'values :values-resident 'out :out-resident} (:buffers bindings)))
+    (is (= {'n n} (:scalar-values bindings)))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"explicitly typed"
+                          (executable/graph-bindings graph [:values :out 1025])))))

--- a/test/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse_test.clj
+++ b/test/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse_test.clj
@@ -136,11 +136,11 @@
            (mapv (comp :kind :slot) (:argument-specs step))))
     (is (= [1 3] (get-in call [:geometry :group-count])))
     (is (= :indexed-segmented-reduction-reference
-           (kdispatch/artifact-strategy
-            (kdispatch/select-artifact (:dispatch step) call-arguments))))
+           (kdispatch/alternative-strategy
+            (kdispatch/select-alternative (:dispatch step) call-arguments))))
     (is (= :indexed-segmented-reduction-subgroup-score-reuse
-           (kdispatch/artifact-strategy
-            (kdispatch/select-artifact (:dispatch step) wide-call-arguments))))
+           (kdispatch/alternative-strategy
+            (kdispatch/select-alternative (:dispatch step) wide-call-arguments))))
     (is (= (:sym (first (:allocs descriptor))) (:result-sym descriptor)))))
 
 (deftest compiler-schedule-can-pin-either-dispatch-alternative
@@ -187,11 +187,11 @@
     (is (= selector (get-in step [:dispatch :selector])))
     (is (= :measured-runtime-shape (get-in step [:dispatch :attributes :selection])))
     (is (= :indexed-segmented-reduction-reference
-           (kdispatch/artifact-strategy
-            (kdispatch/select-artifact (:dispatch step) (arguments-for narrow)))))
+           (kdispatch/alternative-strategy
+            (kdispatch/select-alternative (:dispatch step) (arguments-for narrow)))))
     (is (= :indexed-segmented-reduction-subgroup-score-reuse
-           (kdispatch/artifact-strategy
-            (kdispatch/select-artifact (:dispatch step) (arguments-for wide)))))))
+           (kdispatch/alternative-strategy
+            (kdispatch/select-alternative (:dispatch step) (arguments-for wide)))))))
 
 (deftest compiled-dispatch-projects-resident-abi-and-reference-environment
   (let [descriptor (pipeline/compile-gpu-program

--- a/test/raster/gpu/dispatch_benchmark_device_test.clj
+++ b/test/raster/gpu/dispatch_benchmark_device_test.clj
@@ -1,10 +1,13 @@
 (ns raster.gpu.dispatch-benchmark-device-test
   (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.backend.gpu.segop-opencl :as emit]
             [raster.compiler.core.hardware :as hardware]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.soac :as soac]
+            [raster.compiler.passes.parallel.soac-lower :as lower]
             [raster.dl.gpu-grad-parity :as gpu-probe]
             [raster.gpu.core :as gpu]
             [raster.gpu.dispatch-benchmark :as benchmark]
@@ -95,6 +98,64 @@
     (is (every? #(true? (get-in % [:validation :passed?])) (:measurements result)))
     (is (= :runtime-scalar-ranges (get-in result [:selector :kind])))))
 
+(defn- scan-graph
+  []
+  (let [node (soac/par-form->soac
+              'scan-result
+              '(raster.par/scan out acc 0.0 i n float (+ acc (aget values i)))
+              175)
+        operations (lower/lower-scan node nil :dtype :float)]
+    (emit/generate-scan-kernel-graph
+     (lower/scan-kernel-graph
+      node operations {:array-types {'values :float 'out :float}}))))
+
+(defn- tune-scan-graph!
+  [device-id]
+  (let [n 1025
+        graph (scan-graph)
+        strategy (get-in graph [:attributes :strategy])
+        graph-dispatch
+        (kdispatch/make
+         {:id "device-scan-graph-dispatch"
+          :alternatives [graph]
+          :default-strategy strategy
+          :selector {:kind :runtime-scalar-threshold :argument 'n :threshold 2
+                     :at-least strategy :otherwise strategy}})]
+    (binding [cache/*cache-root* (temporary-cache-root)]
+      (gpu/with-gpu-session*
+        device-id
+        (fn [session]
+          (gpu/alloc! session {:values [:float n (float-array n 1.0)]
+                               :out [:float n nil]})
+          (benchmark/tune-dispatch!
+           session graph-dispatch (hardware/descriptor-for device-id) [n]
+           (fn [runtime-n]
+             {:arguments [:values :out {:type :int :value runtime-n}]
+              :validate!
+              (fn [_]
+                (let [actual ^floats (gpu/download session :out)
+                      max-error
+                      (reduce max 0.0
+                              (map-indexed
+                               (fn [index value]
+                                 (Math/abs (- (double value) (double (inc index)))))
+                               actual))]
+                  {:passed? (< max-error 1.0e-5)
+                   :oracle-hash "inclusive-scan-f32-v1"
+                   :max-error max-error}))
+              :measurement {:warmup-iterations 0 :budget-ms 1
+                            :min-samples 3 :max-samples 5 :cv-threshold 100.0}})
+           :numerical-mode {:input :f32 :accumulate :f32 :output :f32}
+           :layout {:input :contiguous :output :contiguous}
+           :force? true))))))
+
+(defn- assert-graph-tuning!
+  [device-id]
+  (let [result (tune-scan-graph! device-id)]
+    (is (= 1 (count (:measurements result))))
+    (is (true? (get-in result [:measurements 0 :validation :passed?])))
+    (is (= :runtime-scalar-ranges (get-in result [:selector :kind])))))
+
 (deftest level-zero-validates-and-measures-emitted-dispatch-alternatives
   (if-not @gpu-probe/gpu-available?
     (gpu-probe/gpu-skip! "validated KernelDispatch benchmark on Level Zero")
@@ -104,3 +165,13 @@
   (if-not @opencl-available?
     (is true "OpenCL device unavailable")
     (assert-device-tuning! :ocl:0)))
+
+(deftest level-zero-validates-and-measures-a-multi-kernel-dispatch-alternative
+  (if-not @gpu-probe/gpu-available?
+    (gpu-probe/gpu-skip! "validated multi-kernel dispatch benchmark on Level Zero")
+    (assert-graph-tuning! :ze:0)))
+
+(deftest opencl-validates-and-measures-a-multi-kernel-dispatch-alternative
+  (if-not @opencl-available?
+    (is true "OpenCL device unavailable")
+    (assert-graph-tuning! :ocl:0)))

--- a/test/raster/gpu/dispatch_benchmark_test.clj
+++ b/test/raster/gpu/dispatch_benchmark_test.clj
@@ -1,9 +1,12 @@
 (ns raster.gpu.dispatch-benchmark-test
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.segop-opencl :as emit]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.soac :as soac]
+            [raster.compiler.passes.parallel.soac-lower :as lower]
             [raster.gpu.core :as gpu]
             [raster.gpu.dispatch-benchmark :as benchmark]
             [raster.gpu.dispatch-tuning :as tuning]
@@ -50,6 +53,17 @@
   (.toFile (Files/createTempDirectory "raster-dispatch-benchmark-"
                                       (make-array java.nio.file.attribute.FileAttribute 0))))
 
+(defn- scan-graph
+  []
+  (let [node (soac/par-form->soac
+              'scan-result
+              '(raster.par/scan out acc 0.0 i n float (+ acc (aget values i)))
+              174)
+        operations (lower/lower-scan node nil :dtype :float)]
+    (emit/generate-scan-kernel-graph
+     (lower/scan-kernel-graph
+      node operations {:array-types {'values :float 'out :float}}))))
+
 (deftest resident-driver-validates-before-device-measurement
   (let [actions (atom [])
         result
@@ -80,11 +94,52 @@
                            {:passed? true :oracle-hash "host-reference-v1"})})))]
     (is (= :device-event (get-in result [:measurement :timing-source])))
     (is (= "host-reference-v1" (get-in result [:validation :oracle-hash])))
-    (is (= (:source-hash (tuning/artifact-signature reference))
+    (is (= (:source-hash (tuning/executable-signature reference))
            (get-in result [:validation :candidate-hash])))
     (is (= [:bind :restore :validate-run :measure :restore :release]
            (mapv first @actions)))
     (is (number? (get-in result [:measurement :compile-ms])))))
+
+(deftest resident-driver-binds-and-measures-a-multi-kernel-alternative
+  (let [graph (scan-graph)
+        strategy (get-in graph [:attributes :strategy])
+        graph-dispatch
+        (kdispatch/make
+         {:id "graph-benchmark-test"
+          :alternatives [graph]
+          :default-strategy strategy
+          :selector {:kind :runtime-scalar-threshold
+                     :argument 'n :threshold 2
+                     :at-least strategy :otherwise strategy}})
+        bound (atom nil)
+        n {:type :int :value 1025}
+        result
+        (with-redefs [gpu/bind-kernel-graph!
+                      (fn [session key candidate buffers scalars options]
+                        (reset! bound {:session session :key key :candidate candidate
+                                       :buffers buffers :scalars scalars :options options})
+                        {:candidate candidate})
+                      gpu/run-kernel-graph! (fn [& _] {'out :resident-output})
+                      gpu/measure-bound-kernel-graph!
+                      (fn [_ _ & {:keys [compile-ms hashes]}]
+                        (measurement/summarize [20 20 20]
+                                               :timing-source :device-event
+                                               :compile-ms compile-ms :hashes hashes))
+                      gpu/release-kernel-graph! (fn [& _])]
+          (benchmark/benchmark-candidate!
+           :session graph-dispatch graph 1025
+           (fn [_]
+             {:arguments [:values-resident :out-resident n]
+              :validate! (fn [{:keys [outputs executable]}]
+                           (is (identical? graph executable))
+                           (is (= {'out :resident-output} outputs))
+                           {:passed? true :oracle-hash "scan-reference-v1"})})))]
+    (is (= {'values :values-resident 'out :out-resident} (:buffers @bound)))
+    (is (= {'n n} (:scalars @bound)))
+    (is (= {:profile? true} (:options @bound)))
+    (is (= (:source-hash (tuning/executable-signature graph))
+           (get-in result [:validation :candidate-hash])))
+    (is (= :device-event (get-in result [:measurement :timing-source])))))
 
 (deftest failed-oracle-is-never-measured-and-always-releases
   (let [measured? (atom false)
@@ -132,7 +187,7 @@
                     (fn [_ {:keys [candidate runtime-value]}
                          & {:keys [compile-ms hashes before-sample!]}]
                       (when before-sample! (before-sample!))
-                      (let [cost (get-in costs [(kdispatch/artifact-strategy candidate)
+                      (let [cost (get-in costs [(kdispatch/alternative-strategy candidate)
                                                 runtime-value])]
                         (measurement/summarize [cost cost cost]
                                                :timing-source :device-event

--- a/test/raster/gpu/dispatch_tuning_test.clj
+++ b/test/raster/gpu/dispatch_tuning_test.clj
@@ -62,7 +62,7 @@
   {:measurement (stable-measurement cost)
    :validation {:passed? true
                 :oracle-hash "oracle-v1"
-                :candidate-hash (:source-hash (tuning/artifact-signature artifact))
+                :candidate-hash (:source-hash (tuning/executable-signature artifact))
                 :max-error 0.0}})
 
 (defn- temporary-cache-root
@@ -78,13 +78,13 @@
           benchmark (fn [artifact runtime-value]
                       (swap! calls inc)
                       (validated-result artifact
-                                        (get-in costs [(kdispatch/artifact-strategy artifact)
+                                        (get-in costs [(kdispatch/alternative-strategy artifact)
                                                        runtime-value])))
           result (tuning/tune! dispatch descriptor [768 128 256] benchmark
                                :numerical-mode numerical-mode :layout layout)
           tuned (tuning/apply-tuning dispatch result descriptor numerical-mode layout)
-          select #(kdispatch/artifact-strategy
-                   (kdispatch/select-artifact tuned [:x :out {:type :long :value %}]))]
+          select #(kdispatch/alternative-strategy
+                   (kdispatch/select-alternative tuned [:x :out {:type :long :value %}]))]
       (is (tuning/dispatch-tuning? result))
       (is (= {:kind :runtime-scalar-ranges
               :argument 'width
@@ -123,12 +123,12 @@
                   (fn [artifact _]
                     (validated-result artifact
                                       (if (= :reference
-                                             (kdispatch/artifact-strategy artifact))
+                                             (kdispatch/alternative-strategy artifact))
                                         100.0 99.95)))
                   :numerical-mode numerical-mode :layout layout :force? true)]
       (is (= [] (get-in result [:selector :ranges])))
-      (is (= :reference (kdispatch/artifact-strategy
-                         (kdispatch/select-artifact
+      (is (= :reference (kdispatch/alternative-strategy
+                         (kdispatch/select-alternative
                           (tuning/apply-tuning dispatch result descriptor numerical-mode layout)
                           [:x :out {:type :long :value 4096}])))))))
 
@@ -140,7 +140,7 @@
                      :validation {:passed? false
                                   :oracle-hash "oracle-v1"
                                   :candidate-hash (:source-hash
-                                                   (tuning/artifact-signature artifact))}))
+                                                   (tuning/executable-signature artifact))}))
             #"must pass an oracle"]
            [:noisy
             (fn [artifact _]
@@ -150,7 +150,7 @@
                :validation {:passed? true
                             :oracle-hash "oracle-v1"
                             :candidate-hash (:source-hash
-                                             (tuning/artifact-signature artifact))}})
+                                             (tuning/executable-signature artifact))}})
             #"non-stationary"]]]
     (testing (name label)
       (binding [cache/*cache-root* (temporary-cache-root)]

--- a/test/raster/gpu/kernel_graph_runner_test.clj
+++ b/test/raster/gpu/kernel_graph_runner_test.clj
@@ -107,6 +107,7 @@
             "await-event!" #(swap! awaited conj %)
             "event-complete?" (constantly true)
             "release-event!" #(swap! released-events conj %)
+            "reset-graph-events!" (fn [_])
             (throw (ex-info "unexpected mocked runtime function" {:name name}))))
         soft-resolver
         (fn [_device-id name]
@@ -120,7 +121,7 @@
       (fn []
         (let [handle (gpu/bind-kernel-graph!
                       sess :prefix graph {'values :values 'out :out}
-                      {'n {:type :int :value 1025}})
+                      {'n {:type :int :value 1025}} {:profile? true})
               event (gpu/submit-kernel-graph! sess handle)
               _ (is (gpu/gpu-event? event))
               _ (is (gpu/event-complete? sess event))
@@ -138,7 +139,7 @@
           (is (= 3 (count @registered)))
           (is (= 3 (count @bound)))
           (is (= 1 (count @recorded)))
-          (is (= {:barriers? true} (get-in @recorded [0 :opts])))
+          (is (= {:barriers? true :profile? true} (get-in @recorded [0 :opts])))
           (is (= 2 (count @submitted)))
           (is (= @submitted @awaited @released-events))
           (is (empty? (:events @sess)))


### PR DESCRIPTION
## Summary

- give emitted KernelGraph values a stable ordered public ABI
- allow KernelDispatch alternatives to be either one KernelArtifact or a multi-node KernelGraph
- bind, benchmark, validate, and cache tuning identities through the common executable boundary
- keep graph topology, derived scalars, launches, and private temporaries schedule-owned

This is the compiler/runtime seam needed for direct GEMM and split-K partial/combine graphs to compete without exposing schedule storage in the user ABI.

## Verification

- focused compiler/runtime suite: 78 tests, 425 assertions
- device dispatch suite: 4 tests, 12 assertions, including multi-kernel scan tuning on available Level Zero/OpenCL devices
- full suite: 2,281 tests, 33,367 assertions, 0 failures; the single initial error was the read-only sandbox blocking ~/.raster/spirv-cache, and that namespace passed with a writable user.home (12 tests, 248 assertions)
- format check and git diff --check pass
- clj-kondo reports no errors in changed/new files

## Next

Lower resident direct and split-K GEMM choices to these graph alternatives, then converge the flat resident program descriptor onto the canonical emitted graph and typed semantic-region composition used by pretrained-rstr.