### PR TITLE
Lower resident GEMM to executable graphs

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -79,8 +79,9 @@ The first architectural correction is therefore:
 Raster has schedule data and hardware-aware contraction routes, but there is no
 single stage that applies a schedule to an algorithm and produces the kernel IR
 consumed by every emitter. Several scheduling axes are costed or gated more
-broadly than they are emitted, and GEMM-like leaves still sit partly outside the
-general SegOp route.
+broadly than they are emitted. Resident BLAS GEMM calls now close over compiler-emitted
+scalar/direct/split executable graphs, but their semantic front door still sits outside the
+general SegOp contraction route and the XMX leaf remains a target-specific emitter template.
 
 The required separation is:
 
@@ -226,6 +227,15 @@ target, and logical effects; graph topology, entry points, launch geometry,
 derived scalars, and private temporaries are schedule-owned and may differ.
 This is what permits a direct contraction and a split-K partial-plus-combine
 graph to compete without making split-K storage part of the user-visible call.
+
+The first resident GEMM slice uses this boundary directly. Compilation emits scalar f32, direct
+mixed-precision XMX, and split-K graphs with one `(A B C M N K)` ABI. Checked integer-expression
+IR derives the pitch gate, occupancy decision, private conversion/transpose/partials storage,
+`KC`, and 1–3D launches from shape and schedule data. The resident binder supplies ABI values and
+binds ordinary graph calls; it does not assemble a GEMM algorithm. Constant-only layout/conversion
+nodes are hoisted by a graph-generic cacheable-transform rule. Remaining work is to originate the
+same graphs from the canonical contraction/Screma route, add vendor matrix-instruction leaves, and
+make measured shape tables override the analytic selector.
 
 ### 3.4 Scheduled kernel graph and kernel IR
 

--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -1,0 +1,308 @@
+(ns raster.compiler.backend.gpu.gemm
+  "Compiler-owned executable schedules for dense GEMM.
+
+   The public call is uniformly `(A B C M N K)` over f32 resident buffers. A schedule may be one
+   scalar kernel or a graph containing conversion, layout conversion, matrix contraction, and
+   split-K combination. All mixed-precision scratch and derived scheduling scalars are private to
+   the graph; callers never bind them and runtimes never reconstruct the algorithm from `:gemm`."
+  (:require [clojure.string :as str]
+            [raster.compiler.backend.gpu.opencl-codegen :as codegen]
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-graph :as kgraph]
+            [raster.compiler.ir.kernel-launch :as klaunch]))
+
+(def ^:private default-min-split-chunk 1024)
+(def ^:private default-max-splits 64)
+
+(defn- identifier
+  [value]
+  (let [text (str/replace (str value) #"[^A-Za-z0-9_]" "_")]
+    (if (re-find #"^[A-Za-z_]" text) text (str "k_" text))))
+
+(defn- graph-buffer
+  [id dtype elements role]
+  (kgraph/buffer id dtype elements :device role))
+
+(defn- value-use
+  [buffer access]
+  (kgraph/->ValueUse buffer access))
+
+(defn- node
+  [id operation uses dependencies]
+  (kgraph/->ScheduledKernel id operation (vec uses) (vec dependencies)))
+
+(defn- outer-interface
+  [{:keys [a b c m n k]}]
+  {:abi [(kabi/slot a :input :float :c-name "A" :role :lhs)
+         (kabi/slot b :input :float :c-name "B" :role :rhs)
+         (kabi/slot c :output :float :c-name "C" :role :result)
+         (kabi/slot m :scalar :int :c-name "M" :role :extent)
+         (kabi/slot n :scalar :int :c-name "N" :role :extent)
+         (kabi/slot k :scalar :int :c-name "K" :role :extent)]
+   :arguments [a b c m n k]})
+
+(defn- extents
+  [{:keys [m n k variant]}]
+  {:a-elements (if (= :tn variant) (klaunch/product k m) (klaunch/product m k))
+   :b-elements (if (= :nt variant) (klaunch/product n k) (klaunch/product k n))
+   :c-elements (klaunch/product m n)})
+
+(defn- effects
+  [{:keys [a b c]}]
+  {:kind :tensor-contraction :reads [a b] :writes [c]})
+
+(defn- artifact
+  [kernel-name source abi arguments launch phase attributes]
+  (kart/make
+   {:kernel-name kernel-name
+    :source source
+    :abi abi
+    :arguments arguments
+    :launch launch
+    :effects {:kind :tensor-contraction-stage}
+    :provenance {:semantic-op :contraction :lowering :gemm-graph :phase phase}
+    :attributes (merge {:strategy phase} attributes)}))
+
+(defn- scalar-graph
+  [{:keys [id a b c m n k variant] :as spec}]
+  (let [{:keys [abi arguments]} (outer-interface spec)
+        {:keys [a-elements b-elements c-elements]} (extents spec)
+        prefix (identifier (str id "_scalar"))
+        kernel-name (str prefix "_gemm")
+        gemm (artifact
+              kernel-name
+              (codegen/emit-gemm-scalar-kernel kernel-name :variant variant)
+              [(kabi/slot a :input :float :c-name "A")
+               (kabi/slot b :input :float :c-name "B")
+               (kabi/slot c :output :float :c-name "C")
+               (kabi/slot m :scalar :int :c-name "m")
+               (kabi/slot n :scalar :int :c-name "n")
+               (kabi/slot k :scalar :int :c-name "k")]
+              [a b c m n k]
+              (klaunch/spec {:workgroup-size [256]
+                             :group-count [(klaunch/ceil-div c-elements 256)]})
+              :scalar-gemm {:variant variant})]
+    (kgraph/make
+     {:inputs [(graph-buffer a :float a-elements :input)
+               (graph-buffer b :float b-elements :input)]
+      :outputs [(graph-buffer c :float c-elements :output)]
+      :nodes [(node [:gemm id :scalar] gemm
+                    [(value-use a :read) (value-use b :read) (value-use c :write)] [])]
+      :abi abi :arguments arguments
+      :effects (effects spec)
+      :provenance {:semantic-op :contraction :variant variant :lowering :scalar-gemm}
+      :attributes {:strategy :f32-scalar :variant variant :precision :f32}})))
+
+(defn- convert-artifact
+  [kernel-name in out elements vector-width phase]
+  (artifact
+   kernel-name (codegen/emit-f32-to-f16-kernel kernel-name vector-width)
+   [(kabi/slot in :input :float :c-name "in")
+    (kabi/slot out :output :half :c-name "out")
+    (kabi/slot :elements :scalar :int :c-name "n")]
+   [in out elements]
+   (klaunch/spec
+    {:workgroup-size [256]
+     :group-count [(klaunch/ceil-div
+                    (klaunch/ceil-div (klaunch/runtime-value elements) vector-width)
+                    256)]})
+   phase {:vector-width vector-width :from :float :to :half
+          :cacheable-transform? true}))
+
+(defn- transpose-artifact
+  [kernel-name in out rows cols phase]
+  (let [elements (klaunch/product rows cols)]
+    (artifact
+     kernel-name (codegen/emit-transpose-kernel kernel-name :dtype :half)
+     [(kabi/slot in :input :half :c-name "in")
+      (kabi/slot out :output :half :c-name "out")
+      (kabi/slot :rows :scalar :int :c-name "rows")
+      (kabi/slot :cols :scalar :int :c-name "cols")]
+     [in out rows cols]
+     (klaunch/spec {:workgroup-size [256]
+                    :group-count [(klaunch/ceil-div elements 256)]})
+     phase {:layout :transpose :dtype :half :cacheable-transform? true})))
+
+(defn- matrix-workgroup-size
+  [{:keys [block-m block-n sg-m sg-n matrix]}]
+  (* (quot block-m sg-m) (quot block-n sg-n) (:subgroup matrix 16)))
+
+(defn- gemm-artifact
+  [{:keys [m n k tile]} kernel-name a b c split-k? kc splits phase]
+  (let [{:keys [block-m block-n]} tile
+        source-args (concat [:c-dtype :float :split-k? split-k?
+                             :schedule-splits-arg? split-k?]
+                            (mapcat identity
+                                    (select-keys tile
+                                                 [:block-m :block-n :sg-m :sg-n :block-k
+                                                  :matrix :num-stages])))
+        source-args (vec (mapcat (fn [[key value]]
+                                   [(if (= :num-stages key) :prefetch key) value])
+                                 (partition 2 source-args)))
+        abi (cond-> [(kabi/slot a :input :half :c-name "A")
+                     (kabi/slot b :input :half :c-name "B")
+                     (kabi/slot c :output :float :c-name "C")
+                     (kabi/slot m :scalar :int :c-name "M")
+                     (kabi/slot n :scalar :int :c-name "N")
+                     (kabi/slot k :scalar :int :c-name "K")]
+              split-k? (conj (kabi/slot :k-chunk :scalar :int :c-name "KC")
+                             (kabi/slot :splits :scalar :int :c-name "splits")))
+        arguments (cond-> [a b c m n k] split-k? (conj kc splits))
+        group-count (cond-> [(klaunch/ceil-div n block-n)
+                             (klaunch/ceil-div m block-m)]
+                      split-k? (conj (klaunch/runtime-value splits)))]
+    (artifact
+     kernel-name (apply codegen/emit-gemm-tiled kernel-name source-args)
+     abi arguments
+     (klaunch/spec {:workgroup-size (if split-k?
+                                      [(matrix-workgroup-size tile) 1 1]
+                                      [(matrix-workgroup-size tile) 1])
+                    :group-count group-count})
+     phase {:tile tile :split-k? split-k? :accumulator-dtype :float})))
+
+(defn- combine-artifact
+  [kernel-name partials c mn splits]
+  (artifact
+   kernel-name (codegen/emit-gemm-splitk-reduce-kernel kernel-name)
+   [(kabi/slot partials :input :float :c-name "partials")
+    (kabi/slot c :output :float :c-name "C")
+    (kabi/slot :mn :scalar :int :c-name "mn")
+    (kabi/slot :splits :scalar :int :c-name "splits")]
+   [partials c mn splits]
+   (klaunch/spec {:workgroup-size [256]
+                  :group-count [(klaunch/ceil-div (klaunch/runtime-value mn) 256)]})
+   :split-k-combine {:accumulator-dtype :float}))
+
+(defn- xmx-graph
+  [{:keys [id a b c m n k variant tile vector-width requested-splits split-k?] :as spec}]
+  (let [{:keys [abi arguments]} (outer-interface spec)
+        {:keys [a-elements b-elements c-elements]} (extents spec)
+        strategy (if split-k? :xmx-split-k :xmx-direct)
+        prefix (identifier (str id "_" (name strategy)))
+        a16 [:gemm id strategy :a16]
+        b16 [:gemm id strategy :b16]
+        at16 [:gemm id strategy :at16]
+        bt16 [:gemm id strategy :bt16]
+        partials [:gemm id strategy :partials]
+        final-a (if (= :tn variant) at16 a16)
+        final-b (if (= :nt variant) bt16 b16)
+        kc (when split-k?
+             (klaunch/align-up (klaunch/ceil-div k requested-splits) (:block-k tile)))
+        splits (when split-k? (klaunch/ceil-div k kc))
+        partial-elements (when split-k? (klaunch/product splits m n))
+        convert-a-id [:gemm id strategy :convert-a]
+        convert-b-id [:gemm id strategy :convert-b]
+        transpose-a-id [:gemm id strategy :transpose-a]
+        transpose-b-id [:gemm id strategy :transpose-b]
+        contract-id [:gemm id strategy :contract]
+        convert-a (convert-artifact (str prefix "_convert_a") a a16 a-elements vector-width
+                                    :convert-a)
+        convert-b (convert-artifact (str prefix "_convert_b") b b16 b-elements vector-width
+                                    :convert-b)
+        transpose-a (when (= :tn variant)
+                      (transpose-artifact (str prefix "_transpose_a") a16 at16 k m
+                                          :transpose-a))
+        transpose-b (when (= :nt variant)
+                      (transpose-artifact (str prefix "_transpose_b") b16 bt16 n k
+                                          :transpose-b))
+        contract-output (if split-k? partials c)
+        contract (gemm-artifact spec (str prefix "_contract") final-a final-b contract-output
+                                split-k? kc splits :matrix-contract)
+        combine (when split-k?
+                  (combine-artifact (str prefix "_combine") partials c c-elements splits))
+        nodes (cond->
+               [(node convert-a-id convert-a [(value-use a :read) (value-use a16 :write)] [])
+                (node convert-b-id convert-b [(value-use b :read) (value-use b16 :write)] [])]
+                transpose-a
+                (conj (node transpose-a-id transpose-a
+                            [(value-use a16 :read) (value-use at16 :write)] [convert-a-id]))
+                transpose-b
+                (conj (node transpose-b-id transpose-b
+                            [(value-use b16 :read) (value-use bt16 :write)] [convert-b-id]))
+                true
+                (conj (node contract-id contract
+                            [(value-use final-a :read) (value-use final-b :read)
+                             (value-use contract-output :write)]
+                            [(if transpose-a transpose-a-id convert-a-id)
+                             (if transpose-b transpose-b-id convert-b-id)]))
+                combine
+                (conj (node [:gemm id strategy :combine] combine
+                            [(value-use partials :read) (value-use c :write)] [contract-id])))
+        temporaries (cond-> [(graph-buffer a16 :half a-elements :temporary)
+                             (graph-buffer b16 :half b-elements :temporary)]
+                      transpose-a (conj (graph-buffer at16 :half a-elements :temporary))
+                      transpose-b (conj (graph-buffer bt16 :half b-elements :temporary))
+                      split-k? (conj (graph-buffer partials :float partial-elements :temporary)))]
+    (kgraph/make
+     {:inputs [(graph-buffer a :float a-elements :input)
+               (graph-buffer b :float b-elements :input)]
+      :outputs [(graph-buffer c :float c-elements :output)]
+      :temporaries temporaries
+      :nodes nodes
+      :abi abi :arguments arguments
+      :effects (effects spec)
+      :provenance {:semantic-op :contraction :variant variant :lowering :xmx-gemm}
+      :attributes {:strategy strategy :variant variant :precision :mixed-f16-f32
+                   :tile tile :requested-splits requested-splits}})))
+
+(defn requested-splits
+  "Build the generic occupancy expression used by both selection and split-K storage/launches."
+  [{:keys [m n k tile fill-workgroups target-fill-multiple min-split-chunk max-splits]
+    :or {min-split-chunk default-min-split-chunk
+         max-splits default-max-splits
+         target-fill-multiple 4}}]
+  (let [{:keys [block-m block-n]} tile
+        output-workgroups (klaunch/product (klaunch/ceil-div m block-m)
+                                           (klaunch/ceil-div n block-n))
+        target-workgroups (* target-fill-multiple fill-workgroups)
+        ;; Exactly zero once the unsplit output grid fills the machine, one otherwise. This keeps
+        ;; the historic "never split a filling GEMM" legality/policy gate inside the same checked
+        ;; arithmetic IR without introducing an opaque conditional callback.
+        starved (klaunch/minimum 1 (klaunch/floor-div (dec fill-workgroups)
+                                                      output-workgroups))]
+    (klaunch/product
+     starved
+     (klaunch/minimum (klaunch/ceil-div target-workgroups output-workgroups)
+                      (klaunch/floor-div k min-split-chunk)
+                      max-splits))))
+
+(defn emit-executable
+  "Emit the resident GEMM schedule as one graph or a checked runtime dispatch.
+
+   Required keys: :id, :a/:b/:c, :m/:n/:k compiler values, :variant, :precision, :tile,
+   :fill-workgroups. The mixed-precision dispatch handles the XMX pitch gate and low-occupancy
+   split-K choice entirely through generic expression cases."
+  [{:keys [id a b c m n k variant precision tile fill-workgroups vector-width]
+    :or {vector-width 4}
+    :as spec}]
+  (when-not (contains? #{:nn :nt :tn} variant)
+    (throw (ex-info "GEMM executable requires :nn, :nt, or :tn variant"
+                    {:id id :variant variant})))
+  (doseq [[field value] [[:id id] [:a a] [:b b] [:c c] [:m m] [:n n] [:k k]
+                         [:precision precision] [:tile tile] [:fill-workgroups fill-workgroups]]]
+    (when (nil? value)
+      (throw (ex-info "GEMM executable is missing a required field" {:field field :spec spec}))))
+  (let [spec (assoc spec :vector-width vector-width)
+        scalar (scalar-graph spec)]
+    (case precision
+      :f32-scalar scalar
+      :f16-xmx
+      (let [split-expression (requested-splits spec)
+            xmx-spec (assoc spec :requested-splits split-expression)
+            direct (xmx-graph (assoc xmx-spec :split-k? false))
+            split (xmx-graph (assoc xmx-spec :split-k? true))]
+        (kdispatch/make
+         {:id (str id)
+          :alternatives [scalar direct split]
+          :default-strategy :xmx-direct
+          :selector
+          {:kind :runtime-expression-cases
+           :cases [{:expression n :op :< :value 8 :strategy :f32-scalar}
+                   {:expression k :op :< :value 8 :strategy :f32-scalar}
+                   {:expression split-expression :op :>= :value 2 :strategy :xmx-split-k}]
+           :default :xmx-direct}
+          :provenance {:semantic-op :contraction :variant variant :lowering :gemm-schedule}
+          :attributes {:tile tile :precision precision :hardware-aware? true}}))
+      (throw (ex-info "unsupported GEMM precision" {:id id :precision precision})))))

--- a/src/raster/compiler/backend/gpu/opencl_codegen.clj
+++ b/src/raster/compiler/backend/gpu/opencl_codegen.clj
@@ -388,6 +388,33 @@
 ;; Transpose kernel
 ;; ================================================================
 
+(defn emit-f32-to-f16-kernel
+  "Generate the vectorized f32→f16 conversion used by mixed-precision GEMM schedules.
+
+   `vector-width` is the compiler-selected number of elements per work-item and must be 1, 2, or
+   4. The scalar tail preserves correctness for arbitrary extents and for extents below the vector
+   width. Keeping this emitter in compiler codegen lets conversion participate in KernelGraph
+   scheduling instead of being synthesized privately by a runtime registry."
+  [kernel-name vector-width]
+  (let [w (long vector-width)]
+    (when-not (contains? #{1 2 4} w)
+      (throw (ex-info "f32-to-f16 vector width must be 1, 2, or 4"
+                      {:vector-width vector-width})))
+    (if (= 1 w)
+      (str "__kernel void " kernel-name
+           "(__global const float* restrict in, __global half* restrict out, int n) {\n"
+           "  for (int i = get_global_id(0); i < n; i += get_global_size(0)) "
+           "out[i] = (half)in[i];\n}\n")
+      (let [shift (case w 2 1 4 2)]
+        (str "__kernel void " kernel-name
+             "(__global const float* restrict in, __global half* restrict out, int n) {\n"
+             "  int nv = n >> " shift ";\n"
+             "  for (int i = get_global_id(0); i < nv; i += get_global_size(0))\n"
+             "    vstore_half" w "(vload" w "(i, in), i, out);\n"
+             "  for (int i = (nv << " shift ") + get_global_id(0); i < n; "
+             "i += get_global_size(0))\n"
+             "    out[i] = (half)in[i];\n}\n")))))
+
 (defn- render-c-index
   "Render a layout->offset index S-expression to C infix (matches the hand-written kernel strings:
    `(+ (* i cols) j)` → \"i * cols + j\"). Index arithmetic only (+ and *, symbols/ints)."
@@ -633,7 +660,7 @@
    separate emitter keyed by :matrix :family (the one genuine fork). Handles arbitrary M,N,K with
    full boundary checking; supports alpha/beta, c-dtype, split-k? (grid-z partials) and batched?
    (grid-z slabs)."
-  [kernel-name & {:keys [block-m block-n sg-m sg-n block-k matrix alpha beta c-dtype split-k? batched? prefetch
+  [kernel-name & {:keys [block-m block-n sg-m sg-n block-k matrix alpha beta c-dtype split-k? schedule-splits-arg? batched? prefetch
                          epilogue epilogue-params epilogue-helpers]
                   :or {block-m 128 block-n 128 sg-m 32 sg-n 32 block-k 32
                        matrix {:m 8 :n 16 :k 16 :subgroup 16}
@@ -687,7 +714,9 @@
        "__kernel void " kernel-name "(\n"
        "    __global const half* restrict A,\n    __global const half* restrict B,\n"
        "    __global " c-type "* restrict C,\n    int M, int N, int K"
-       (when split-k? ", int KC") (when (not= alpha 1.0) ", float alpha") (when (not= beta 0.0) ", float beta")
+       (when split-k? ", int KC")
+       (when (and split-k? schedule-splits-arg?) ", int splits")
+       (when (not= alpha 1.0) ", float alpha") (when (not= beta 0.0) ", float beta")
        epilogue-params
        ") {\n"
        "    int sg_id = get_sub_group_id();\n    int sg_lid = get_sub_group_local_id();\n"

--- a/src/raster/compiler/ir/kernel_dispatch.clj
+++ b/src/raster/compiler/ir/kernel_dispatch.clj
@@ -5,7 +5,8 @@
    scheduling value above both: every alternative implements the same logical call and differs
    only in its emitted schedule. Selection is pure data evaluated after symbolic ABI scalars
    become concrete and before a backend binder sees the selected executable."
-  (:require [raster.compiler.ir.kernel-executable :as kexec]))
+  (:require [raster.compiler.ir.kernel-executable :as kexec]
+            [raster.compiler.ir.kernel-launch :as klaunch]))
 
 (defrecord KernelDispatch
            [id
@@ -42,30 +43,82 @@
 
 (defn- validate-selector!
   [dispatch strategies common]
-  (let [{:keys [kind argument threshold at-least otherwise ranges below]}
+  (let [{:keys [kind argument expression threshold at-least otherwise ranges below]}
         (:selector dispatch)
         common-arguments (:arguments common)
-        indexes (keep-indexed (fn [index value] (when (= argument value) index))
-                              common-arguments)]
-    (when-not (= 1 (count indexes))
-      (throw (ex-info "kernel dispatch selector argument must have one common ABI position"
-                      {:id (:id dispatch) :argument argument
-                       :arguments common-arguments :indexes (vec indexes)})))
-    (let [slot (nth (:abi common) (first indexes))]
-      (when-not (= :scalar (:kind slot))
-        (throw (ex-info "kernel dispatch selector argument must name a scalar ABI slot"
-                        {:id (:id dispatch) :argument argument :slot slot}))))
+        scalar-arguments (->> (map vector (:abi common) common-arguments)
+                              (keep (fn [[slot compiler-value]]
+                                      (when (= :scalar (:kind slot)) compiler-value)))
+                              set)
+        validate-threshold! (fn []
+                              (when-not (and (finite-number? threshold)
+                                             (pos? (double threshold)))
+                                (throw (ex-info "kernel dispatch threshold must be finite and positive"
+                                                {:id (:id dispatch) :threshold threshold})))
+                              (doseq [[branch strategy] [[:at-least at-least]
+                                                         [:otherwise otherwise]]]
+                                (validate-selector-strategy! dispatch strategies branch strategy)))
+        validate-expression! (fn [owner expression]
+                               (when-not (klaunch/expression? expression)
+                                 (throw (ex-info
+                                         "kernel dispatch selector requires checked integer expression IR"
+                                         {:id (:id dispatch) :owner owner
+                                          :expression expression})))
+                               (let [references (klaunch/expression-references expression)]
+                                 (when-not (every? scalar-arguments references)
+                                   (throw (ex-info
+                                           "kernel dispatch expression reads values outside its scalar ABI"
+                                           {:id (:id dispatch) :owner owner
+                                            :references references
+                                            :scalar-arguments scalar-arguments})))))
+        validate-argument! (fn []
+                             (let [indexes (keep-indexed
+                                            (fn [index value] (when (= argument value) index))
+                                            common-arguments)]
+                               (when-not (= 1 (count indexes))
+                                 (throw (ex-info
+                                         "kernel dispatch selector argument must have one common ABI position"
+                                         {:id (:id dispatch) :argument argument
+                                          :arguments common-arguments :indexes (vec indexes)})))
+                               (let [slot (nth (:abi common) (first indexes))]
+                                 (when-not (= :scalar (:kind slot))
+                                   (throw (ex-info
+                                           "kernel dispatch selector argument must name a scalar ABI slot"
+                                           {:id (:id dispatch) :argument argument :slot slot}))))))]
     (case kind
       :runtime-scalar-threshold
       (do
-        (when-not (and (finite-number? threshold) (pos? (double threshold)))
-          (throw (ex-info "kernel dispatch threshold must be finite and positive"
-                          {:id (:id dispatch) :threshold threshold})))
-        (doseq [[branch strategy] [[:at-least at-least] [:otherwise otherwise]]]
-          (validate-selector-strategy! dispatch strategies branch strategy)))
+        (validate-argument!)
+        (validate-threshold!))
+
+      :runtime-expression-threshold
+      (do
+        (validate-expression! :expression expression)
+        (validate-threshold!))
+
+      :runtime-expression-cases
+      (let [cases (get-in dispatch [:selector :cases])
+            default (get-in dispatch [:selector :default])]
+        (when-not (and (vector? cases) (seq cases))
+          (throw (ex-info "kernel dispatch expression cases must be a non-empty ordered vector"
+                          {:id (:id dispatch) :cases cases})))
+        (validate-selector-strategy! dispatch strategies :default default)
+        (doseq [[index rule] (map-indexed vector cases)]
+          (when-not (= #{:expression :op :value :strategy} (set (keys rule)))
+            (throw (ex-info "kernel dispatch expression case has invalid fields"
+                            {:id (:id dispatch) :index index :rule rule})))
+          (validate-expression! [:cases index] (:expression rule))
+          (when-not (contains? #{:< :<= := :>= :>} (:op rule))
+            (throw (ex-info "kernel dispatch expression case has an invalid comparison"
+                            {:id (:id dispatch) :index index :op (:op rule)})))
+          (when-not (finite-number? (:value rule))
+            (throw (ex-info "kernel dispatch expression case requires a finite comparison value"
+                            {:id (:id dispatch) :index index :value (:value rule)})))
+          (validate-selector-strategy! dispatch strategies [:cases index] (:strategy rule))))
 
       :runtime-scalar-ranges
       (do
+        (validate-argument!)
         (validate-selector-strategy! dispatch strategies :below below)
         (when-not (vector? ranges)
           (throw (ex-info "kernel dispatch ranges must be an ordered vector"
@@ -173,6 +226,15 @@
   [value]
   (if (and (map? value) (contains? value :value)) (:value value) value))
 
+(defn- compare-value?
+  [op actual expected]
+  (case op
+    :< (< actual expected)
+    :<= (<= actual expected)
+    := (= actual expected)
+    :>= (>= actual expected)
+    :> (> actual expected)))
+
 (defn select-alternative
   "Select an executable alternative from concrete ABI-ordered values.
 
@@ -184,21 +246,27 @@
    (let [dispatch (validate! dispatch)]
      (if (and override (not= :auto override))
        (alternative dispatch override)
-       (let [{:keys [kind argument threshold at-least otherwise ranges below]}
+       (let [{:keys [kind argument expression threshold at-least otherwise ranges below]}
              (:selector dispatch)
              common-arguments (kexec/arguments (default-alternative dispatch))
              indexes (keep-indexed (fn [index value] (when (= argument value) index))
                                    common-arguments)]
-         (when-not (= 1 (count indexes))
-           (throw (ex-info "kernel dispatch selector argument must have one runtime position"
-                           {:id (:id dispatch) :argument argument
-                            :indexes (vec indexes)})))
          (when-not (= (count common-arguments) (count runtime-arguments))
            (throw (ex-info "kernel dispatch runtime argument count mismatch"
                            {:id (:id dispatch) :expected (count common-arguments)
                             :actual (count runtime-arguments)})))
-         (let [value (runtime-number (nth runtime-arguments (first indexes)))]
-           (when-not (number? value)
+         (when (contains? #{:runtime-scalar-threshold :runtime-scalar-ranges} kind)
+           (when-not (= 1 (count indexes))
+             (throw (ex-info "kernel dispatch selector argument must have one runtime position"
+                             {:id (:id dispatch) :argument argument
+                              :indexes (vec indexes)}))))
+         (let [environment (zipmap common-arguments (mapv runtime-number runtime-arguments))
+               value (case kind
+                       :runtime-expression-threshold
+                       (klaunch/resolve-expression environment expression)
+                       :runtime-expression-cases nil
+                       (runtime-number (nth runtime-arguments (first indexes))))]
+           (when (and (not= :runtime-expression-cases kind) (not (number? value)))
              (throw (ex-info "kernel dispatch selector requires a numeric runtime scalar"
                              {:id (:id dispatch) :argument argument :value value})))
            (alternative
@@ -206,6 +274,19 @@
             (case kind
               :runtime-scalar-threshold
               (if (>= (double value) (double threshold)) at-least otherwise)
+
+              :runtime-expression-threshold
+              (if (>= (double value) (double threshold)) at-least otherwise)
+
+              :runtime-expression-cases
+              (or (some (fn [{:keys [expression op value strategy]}]
+                          (when (compare-value?
+                                 op
+                                 (klaunch/resolve-expression environment expression)
+                                 value)
+                            strategy))
+                        (get-in dispatch [:selector :cases]))
+                  (get-in dispatch [:selector :default]))
 
               :runtime-scalar-ranges
               (reduce (fn [strategy range]

--- a/src/raster/compiler/ir/kernel_launch.clj
+++ b/src/raster/compiler/ir/kernel_launch.clj
@@ -7,6 +7,10 @@
 
 (defrecord RuntimeValue [value])
 (defrecord CeilDiv [value divisor])
+(defrecord FloorDiv [value divisor])
+(defrecord Product [factors])
+(defrecord AlignUp [value alignment])
+(defrecord Minimum [values])
 (defrecord LaunchSpec [workgroup-size group-count shared-memory-bytes])
 (defrecord LaunchGeometry [workgroup-size group-count shared-memory-bytes])
 
@@ -27,10 +31,45 @@
   [value divisor]
   (when (nil? value)
     (throw (ex-info "ceil-div launch value cannot be nil" {:value value :divisor divisor})))
-  (when-not (and (integer? divisor) (pos? divisor))
-    (throw (ex-info "ceil-div launch divisor must be a positive integer"
+  (when-not (or (not (integer? divisor)) (pos? divisor))
+    (throw (ex-info "ceil-div launch divisor must be positive"
                     {:value value :divisor divisor})))
   (->CeilDiv value divisor))
+
+(defn floor-div
+  "A checked floor division of non-negative integer expressions. The divisor may itself be a
+   symbolic integer expression and is proved positive when the expression is realized."
+  [value divisor]
+  (when (or (nil? value) (nil? divisor))
+    (throw (ex-info "floor-div operands cannot be nil" {:value value :divisor divisor})))
+  (when-not (or (not (integer? divisor)) (pos? divisor))
+    (throw (ex-info "floor-div divisor must be positive" {:value value :divisor divisor})))
+  (->FloorDiv value divisor))
+
+(defn product
+  "A checked product of integer launch/storage expressions. Products are explicit IR rather than
+   arbitrary Clojure forms so graph scratch sizes can remain inspectable and safely realizable."
+  [& factors]
+  (when-not (and (seq factors) (every? some? factors))
+    (throw (ex-info "product requires one or more non-nil factors" {:factors factors})))
+  (->Product (vec factors)))
+
+(defn align-up
+  "Round an integer launch/storage expression up to a positive static alignment."
+  [value alignment]
+  (when (nil? value)
+    (throw (ex-info "align-up value cannot be nil" {:value value :alignment alignment})))
+  (when-not (and (integer? alignment) (pos? alignment))
+    (throw (ex-info "align-up requires a positive integer alignment"
+                    {:value value :alignment alignment})))
+  (->AlignUp value alignment))
+
+(defn minimum
+  "The minimum of one or more integer expressions."
+  [& values]
+  (when-not (and (seq values) (every? some? values))
+    (throw (ex-info "minimum requires one or more non-nil values" {:values values})))
+  (->Minimum (vec values)))
 
 (defn launch-spec? [x]
   (record-kind? "raster.compiler.ir.kernel_launch.LaunchSpec" x))
@@ -43,6 +82,50 @@
 
 (defn- ceil-div? [x]
   (record-kind? "raster.compiler.ir.kernel_launch.CeilDiv" x))
+
+(defn- floor-div? [x]
+  (record-kind? "raster.compiler.ir.kernel_launch.FloorDiv" x))
+
+(defn- product? [x]
+  (record-kind? "raster.compiler.ir.kernel_launch.Product" x))
+
+(defn- align-up? [x]
+  (record-kind? "raster.compiler.ir.kernel_launch.AlignUp" x))
+
+(defn- minimum? [x]
+  (record-kind? "raster.compiler.ir.kernel_launch.Minimum" x))
+
+(defn expression?
+  "True for explicit symbolic integer-expression nodes and literal integers. Opaque compiler
+   values such as symbols are leaves and are therefore also accepted. Sequential Clojure forms
+   are deliberately rejected: callers must construct arithmetic with this namespace."
+  [x]
+  (cond
+    (integer? x) true
+    (runtime-value? x) (some? (:value x))
+    (ceil-div? x) (and (expression? (:value x)) (expression? (:divisor x)))
+    (floor-div? x) (and (expression? (:value x)) (expression? (:divisor x)))
+    (product? x) (and (seq (:factors x)) (every? expression? (:factors x)))
+    (align-up? x) (and (expression? (:value x))
+                       (integer? (:alignment x)) (pos? (:alignment x)))
+    (minimum? x) (and (seq (:values x)) (every? expression? (:values x)))
+    (sequential? x) false
+    :else (some? x)))
+
+(defn expression-references
+  "Return the opaque compiler-value leaves read by an integer expression."
+  [expression]
+  (cond
+    (integer? expression) #{}
+    (runtime-value? expression) #{(:value expression)}
+    (ceil-div? expression) (into (expression-references (:value expression))
+                                 (expression-references (:divisor expression)))
+    (floor-div? expression) (into (expression-references (:value expression))
+                                  (expression-references (:divisor expression)))
+    (product? expression) (reduce into #{} (map expression-references (:factors expression)))
+    (align-up? expression) (expression-references (:value expression))
+    (minimum? expression) (reduce into #{} (map expression-references (:values expression)))
+    :else #{expression}))
 
 (defn- dimension-vector!
   [owner field dimensions pred expected]
@@ -62,7 +145,11 @@
   [x]
   (or (and (integer? x) (pos? x))
       (runtime-value? x)
-      (ceil-div? x)))
+      (ceil-div? x)
+      (product? x)
+      (align-up? x)
+      (floor-div? x)
+      (minimum? x)))
 
 (defn validate-spec!
   "Validate and return a symbolic launch specification."
@@ -153,18 +240,42 @@
    compiler value such as a bound symbol. Keeping this evaluator here prevents graph runners from
    interpreting arbitrary compiler S-expressions."
   [resolve-value dimension]
-  (long
-   (cond
-     (integer? dimension) dimension
-     (runtime-value? dimension)
-     (resolve-integer! resolve-value dimension (:value dimension))
-     (ceil-div? dimension)
-     (let [value (resolve-integer! resolve-value dimension (:value dimension))
-           divisor (:divisor dimension)]
-       ;; This form avoids overflowing `value + divisor - 1` for a large positive value.
-       (+ (quot value divisor) (if (zero? (rem value divisor)) 0 1)))
-     :else (throw (ex-info "unsupported launch dimension expression"
-                           {:dimension dimension :actual (type dimension)})))))
+  (letfn [(resolve* [expression]
+            (long
+             (cond
+               (integer? expression) expression
+               (runtime-value? expression)
+               (resolve-integer! resolve-value expression (:value expression))
+               (ceil-div? expression)
+               (let [value (resolve* (:value expression))
+                     divisor (resolve* (:divisor expression))]
+                 (when-not (pos? divisor)
+                   (throw (ex-info "ceil-div resolved divisor must be positive"
+                                   {:expression expression :divisor divisor})))
+                 ;; This form avoids overflowing `value + divisor - 1` for a large positive value.
+                 (+ (quot value divisor) (if (zero? (rem value divisor)) 0 1)))
+               (floor-div? expression)
+               (let [value (resolve* (:value expression))
+                     divisor (resolve* (:divisor expression))]
+                 (when-not (pos? divisor)
+                   (throw (ex-info "floor-div resolved divisor must be positive"
+                                   {:expression expression :divisor divisor})))
+                 (quot value divisor))
+               (product? expression)
+               (reduce (fn [acc factor]
+                         (Math/multiplyExact (long acc) (long factor)))
+                       1 (map resolve* (:factors expression)))
+               (align-up? expression)
+               (let [value (resolve* (:value expression))
+                     alignment (:alignment expression)
+                     quotient (quot value alignment)]
+                 (Math/multiplyExact
+                  (long (+ quotient (if (zero? (rem value alignment)) 0 1)))
+                  (long alignment)))
+               (minimum? expression)
+               (reduce min (map resolve* (:values expression)))
+               :else (resolve-integer! resolve-value expression expression))))]
+    (resolve* dimension)))
 
 (defn realize
   "Resolve a LaunchSpec into concrete geometry. `resolve-value` maps a compiler value to a number."

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -44,6 +44,7 @@
             [raster.compiler.backend.gpu.par-opencl :as par-opencl]
             [raster.compiler.backend.gpu.c-emit :as c-emit]
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
+            [raster.compiler.backend.gpu.gemm :as gpu-gemm]
             [raster.compiler.passes.parallel.compound-detect :as compound-detect]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.loop-lift :as loop-lift]
@@ -1653,8 +1654,9 @@
    f16 UNDERFLOW (min normal 6.1e-5) is the one hazard a small-magnitude cotangent can hit
    — the remedy is standard AMP loss scaling, and it lives in the CALLER (scale the seed
    cotangent by S, use lr/S), not in this policy: the VJP is linear in the seed.
-   No size heuristics; the XMX hardware pitch gate (n<8 or k<8 → scalar) applies in
-   bind-program! regardless of policy."
+   The XMX pitch gate and direct-vs-split occupancy decision are emitted as checked
+   KernelDispatch expression cases. `bind-program!` selects and binds that compiler value; it does
+   not recognize GEMM shapes or reconstruct conversion/split kernels."
   [f-var device-id & {:keys [dtype on-non-resident gemm-precision schedule]
                       :or {on-non-resident :throw gemm-precision :f16-xmx}}]
   (when-not (contains? #{:f16-xmx :f32-scalar} gemm-precision)
@@ -1665,7 +1667,8 @@
   ;; (:gemm-precision is deprecated sugar → the precision policy), and run the register-budget
   ;; FEASIBILITY GATE before any emission — an infeasible schedule (e.g. register double-buffering
   ;; that would spill the GRF file) is a loud compile error, not a measurement-time regression.
-  (let [resolved-schedule ((requiring-resolve 'raster.gpu.schedule/schedule-for-device)
+  (let [hardware-descriptor (core-hw/descriptor-for device-id)
+        resolved-schedule ((requiring-resolve 'raster.gpu.schedule/schedule-for-device)
                            nil device-id schedule {:precision gemm-precision})
         gemm-precision (:precision resolved-schedule)
         resolved-var (or (resolve-deftm-var f-var dtype) f-var)
@@ -1831,16 +1834,58 @@
        :steps (mapv (fn [i step]
                       (cond
                         (= :gemm (:convention step))
-                        ;; GEMM: carries the A/B/C buffer syms + m/n/k size closures (BLAS arg
-                        ;; order is A B C m k n → keep m/n/k separate). bind-program! expands this
-                        ;; into [convert A→f16][convert B→f16][(transpose)][fp16 XMX gemm → f32 C].
-                        {:convention :gemm
-                         :variant (:variant step)
-                         :A (:A step) :B (:B step) :C (:C step)
-                         :m-fn (expr->arg-fn all-params scalar-lets (:m-expr step))
-                         :n-fn (expr->arg-fn all-params scalar-lets (:n-expr step))
-                         :k-fn (expr->arg-fn all-params scalar-lets (:k-expr step))
-                         :phase (keyword (str "gpu-step-" i))}
+                        ;; GEMM: the compiler closes this step over scalar/direct/split executable
+                        ;; graphs. The ordered argument contract is the sole binding authority;
+                        ;; the resident binder only supplies its concrete values and flattens the
+                        ;; selected graph.
+                        (let [phase (keyword (str "gpu-step-" i))
+                              m-argument (keyword (str (name phase) "-m"))
+                              n-argument (keyword (str (name phase) "-n"))
+                              k-argument (keyword (str (name phase) "-k"))
+                              tile (:tile resolved-schedule)
+                              {:keys [block-m block-n sg-m sg-n matrix]} tile
+                              workgroup-size
+                              (* (quot block-m sg-m) (quot block-n sg-n)
+                                 (:subgroup matrix 16))]
+                          {:convention :gemm
+                           :variant (:variant step)
+                           :A (:A step) :B (:B step) :C (:C step)
+                           :dispatch
+                           (gpu-gemm/emit-executable
+                            {:id (str f-var "-" device-id "-resident-gemm-" i "-"
+                                      (name (:variant step)) "-"
+                                      (Integer/toUnsignedString (hash tile) 16))
+                             :a (:A step) :b (:B step) :c (:C step)
+                             :m m-argument :n n-argument :k k-argument
+                             :variant (:variant step)
+                             ;; Emit the complete legal schedule family. The resolved precision
+                             ;; selects :f32-scalar at bind; :f16-xmx uses the checked cases.
+                             :precision :f16-xmx
+                             :tile tile
+                             :fill-workgroups
+                             (core-hw/fill-workgroups hardware-descriptor workgroup-size)
+                             :target-fill-multiple
+                             (get-in resolved-schedule [:gemm-dispatch :target-fill-multiple])
+                             :min-split-chunk
+                             (get-in resolved-schedule [:gemm-dispatch :min-split-chunk])
+                             :max-splits
+                             (get-in resolved-schedule [:gemm-dispatch :max-splits])})
+                           :argument-specs
+                           [{:kind :input :sym (:A step)}
+                            {:kind :input :sym (:B step)}
+                            {:kind :output :sym (:C step)}
+                            {:kind :scalar :type :int
+                             :value-fn (expr->arg-fn all-params scalar-lets (:m-expr step))}
+                            {:kind :scalar :type :int
+                             :value-fn (expr->arg-fn all-params scalar-lets (:n-expr step))}
+                            {:kind :scalar :type :int
+                             :value-fn (expr->arg-fn all-params scalar-lets (:k-expr step))}]
+                           ;; Generic schedule-path-to-strategy mapping. The binder does not know
+                           ;; which semantic operation owns :precision.
+                           :strategy-selection {:path [:precision]
+                                                :mapping {:f32-scalar :f32-scalar}
+                                                :default :auto}
+                           :phase phase})
 
                         (= :contract (:convention step))
                         (let [{:keys [kernel-name dispatch-id arguments]} step

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -28,7 +28,6 @@
   (:require [clojure.string :as str]
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
             [raster.compiler.core.dtype :as dtype]
-            [raster.compiler.core.hardware :as hw]
             [raster.compiler.core.inference :as inf]
             [raster.compiler.ir.buffer-view :as bview]
             [raster.compiler.ir.execution-plan :as execution]
@@ -363,7 +362,7 @@
               (try (destroy-graph! (:prologue-graph prog)) (catch Exception _)))
             (when destroy-prepared!
               (doseq [b (:bounds prog)] (try (destroy-prepared! b) (catch Exception _))))
-            ;; f16 GEMM-conversion scratch is allocated outside :buffers — free it here.
+            ;; Executable-graph private storage is allocated outside :buffers — free it here.
             (when (seq (:scratch-buffers prog))
               (let [free! (rt-resolve device-id "free-buffer!")]
                 (doseq [b (:scratch-buffers prog)] (try (free! b) (catch Exception _)))))))
@@ -1617,75 +1616,6 @@
 ;; (returns a {:kernel :gc-seg …} bound map over GPU-RESIDENT buffers) collected into
 ;; a vector for ze-runtime/record-graph! (barrier-separated), replayed by replay-graph!.
 
-;; ── split-k schedule knobs (see the `splitk` fn in bind-program!) ──────────────
-;; The XMX GEMM launches ceil(n/128) x ceil(m/128) workgroups of 256 items (= 16
-;; hw threads). This iGPU (64 EU x 8 threads) holds 32 such workgroups, so any GEMM
-;; below that count is OCCUPANCY-bound, not memory- or compute-bound. Splitting k
-;; buys workgroups at constant DRAM traffic; the knobs bound how far.
-
-(def ^:dynamic *gemm-splitk-fill-wgs*
-  "Workgroups that saturate the device. nil = DERIVE it from the target's HardwareDescriptor
-   (machine-lanes / 256 — Arc 140V: 8192/256 = 32); bind to a number to override. A GEMM at
-   or above this count is NOT split.
-
-   This used to be the literal 32, which is this laptop's iGPU and no other machine's." nil)
-
-(def ^:dynamic *gemm-splitk-target-wgs*
-  "Workgroup count a split GEMM aims for — a few waves over the fill count, so memory
-   latency has something to hide behind. nil = 4x the fill count." nil)
-
-(def ^:dynamic *gemm-splitk-min-chunk*
-  "Smallest k-chunk worth giving a workgroup: below this the per-chunk fixed cost (A
-   prefetch, storing a full partial C tile) outweighs the reduction." 1024)
-
-(def ^:dynamic *gemm-splitk-max-splits*
-  "Hard cap on k-chunks — the partials buffer is splits·m·n f32." 64)
-
-(defn gemm-fill-workgroups
-  "Workgroups that fill `device-id` at the XMX GEMM's 256-item workgroup — the bound that
-   decides whether a GEMM is occupancy-starved. From the target's HardwareDescriptor unless
-   *gemm-splitk-fill-wgs* overrides."
-  [device-id]
-  (long (or *gemm-splitk-fill-wgs* (hw/fill-workgroups (hw/descriptor-for device-id) 256))))
-
-(defn gemm-schedule
-  "THE GEMM schedule decision, as a pure function of the shape and the machine width —
-   never of the model. Returns [splits k-chunk]; splits = 1 means the plain XMX GEMM.
-
-   The XMX GEMM tiles C into 128x128 blocks, so its grid is ceil(n/128) x ceil(m/128)
-   workgroups. When that is fewer than `fill-wgs`, the device runs partly EMPTY and no
-   inner-loop tuning can help — the only way to buy workgroups is to split the k-reduction
-   across a third grid dimension and combine the partials afterwards (same operands, same
-   DRAM traffic, same result up to f32 summation order).
-
-   Callers: bind-program! (the binder) and gemm_splitk_test (the executable spec). ONE
-   copy — the policy is not re-implemented anywhere."
-  ([m n k fill-wgs] (gemm-schedule m n k fill-wgs (or *gemm-splitk-target-wgs* (* 4 (long fill-wgs)))))
-  ([m n k fill-wgs target-wgs]
-   (let [{:keys [block-m block-n block-k]}
-         ((requiring-resolve 'raster.compiler.core.hardware/gemm-tile-for)
-          (try ((requiring-resolve 'raster.compiler.core.hardware/descriptor-for)
-                (:device-id @(requiring-resolve 'raster.gpu.ze-runtime/state)))
-               (catch Throwable _ nil)))
-         ;; the split-k policy's occupancy estimate and K-chunk quantum are the SAME tile the
-         ;; kernel is emitted with — they were independent `/128.0` and `*32` literals, so a tile
-         ;; change silently decoupled the policy from the kernel it schedules
-         base (* (Math/ceil (/ (double n) (double block-n)))
-                 (Math/ceil (/ (double m) (double block-m))))]
-     (if (>= base (double fill-wgs))
-       [1 k]                              ;; already fills the machine
-       (let [want (long (Math/ceil (/ (double target-wgs) base)))
-             ;; each chunk must be a multiple of the K-unroll (block-k) and at least
-             ;; *gemm-splitk-min-chunk* long, or the per-chunk fixed cost (A prefetch + the
-             ;; store of a full partial C tile) swamps the reduction it does.
-             cap (quot (long k) (long *gemm-splitk-min-chunk*))
-             s (min want cap (long *gemm-splitk-max-splits*))]
-         (if (< s 2)
-           [1 k]
-           (let [ku (long block-k)
-                 kc (* ku (quot (+ (quot (long k) s) (dec ku)) ku))]
-             [(quot (+ (long k) kc -1) kc) kc])))))))
-
 (defn bind-program!
   "Bind a resident GPU program (a descriptor from pipeline/compile-gpu-program) to this session:
    allocate resident buffers for the array params + intermediate scratch, bind each kernel
@@ -1731,10 +1661,10 @@
                      without it the recorded graph is exactly the fast path (no profiling queue,
                      events, or overhead); run-program! on a profiled program still works.
 
-   :gemm steps bind per the resolved S6 schedule's precision — [:schedule :precision] (set at
-   compile time by compile-gpu-program, default :f16-xmx). :gemm-precision on the descriptor is a
-   back-compat fallback for a hand-built descriptor with no :schedule. A bind-time caller overrides
-   the plain-data descriptor with (assoc-in descriptor [:schedule :precision] …):
+   Compiler-emitted executable steps may map resolved schedule data to a dispatch strategy. GEMM
+   currently maps [:schedule :precision] while its pitch and direct-vs-split decisions remain in
+   the dispatch selector. A bind-time caller may override the plain descriptor with
+   (assoc-in descriptor [:schedule :precision] …):
      :f16-xmx    — convert A/B f32→f16 and run the XMX gemm (f32 accumulate/output): the
                    mixed-precision (AMP) policy — f16 inputs, f32 math. Valid for BACKWARD
                    programs too (measured on the real gemma-3-270m layer VJP: adapter grads
@@ -1761,10 +1691,6 @@
                                   " — bind each program under a distinct :key")
                              {:key pkey :bound (keys (:programs @sess))})))
          {:keys [dtype all-params array-params allocs steps]} descriptor
-         ;; precision reads from the resolved S6 schedule (source of truth); :gemm-precision is
-         ;; back-compat sugar for a descriptor built before the schedule field, or one hand-assoc'd.
-         gemm-precision (or (get-in descriptor [:schedule :precision])
-                            (:gemm-precision descriptor) :f16-xmx)
          reduction-strategy
          (get-in descriptor [:schedule :segmented-weighted-reduction :strategy] :auto)
          effective-roles (merge (:array-roles descriptor) roles)
@@ -1828,31 +1754,16 @@
                                                        (str "scratch " sym)))))
                            allocs)
          info-fn   (rt-resolve device-id "kernel-registry-entry")
+         register-fn (rt-resolve device-id "register-kernel!")
          specialized-bind-fn (rt-resolve device-id "bind-registered-map-void-kernel")
          bind-call-fn (rt-resolve device-id "bind-kernel-call")
-         gemm-fn   (rt-resolve device-id "bind-registered-gemm!")
-         conv-fn   (rt-resolve device-id "bind-registered-convert!")
-         trans-fn  (rt-resolve device-id "bind-registered-transpose!")
          mkbuf-fn  (rt-resolve device-id "make-buffer")
          record-fn (rt-resolve device-id "record-graph!")
-         ;; ── the SCHEDULE seam ────────────────────────────────────────────────
-         ;; Every launch geometry below is a function of (shape, MACHINE WIDTH) and
-         ;; nothing else — never of the model. The machine width comes from the target's
-         ;; HardwareDescriptor, so the same program schedules itself differently on a
-         ;; different GPU instead of inheriting this laptop's iGPU as a literal.
-         desc      (hw/descriptor-for device-id)
-         fill-wgs  (gemm-fill-workgroups device-id)
-         ;; elementwise/convert vector width: widest that still fills the machine.
-         vec-width (fn [n] (hw/stream-vector-width desc n))
-         ;; SPLIT-K: see `gemm-schedule` — a GEMM whose grid is below the machine's fill
-         ;; count is occupancy-bound, and splitting k buys workgroups at constant DRAM
-         ;; traffic. See ze-runtime/bind-registered-gemm-splitk!.
-         splitk (fn [m n k] (gemm-schedule m n k fill-wgs))
          alloc-size-of (fn [sym-kw]
                          (some (fn [{:keys [sym size-fn]}]
                                  (when (= (keyword (name sym)) sym-kw) (long (size-fn args))))
                                allocs))
-         gemm-scratch (atom [])]
+         executable-scratch (atom [])]
      (alloc! sess (merge param-specs alloc-specs))
      (let [buffers (:buffers @sess)
            key-of (fn [sym] (or (get param->key sym) (get alloc->key sym) (keyword (name sym))))
@@ -1860,103 +1771,61 @@
                     (or (get buffers (key-of sym))
                         (throw (ex-info (str "bind-program!: no resident buffer for step array " sym)
                                         {:sym sym :key (key-of sym) :ctx ctx :have (keys buffers)}))))
-           ;; A GEMM operand that is a :constant param (frozen weights) never changes on device,
-           ;; so its f32→f16 conversion — and, for the transposed variants, the transpose of that
-           ;; f16 copy — is the SAME work every replay. Those kernels are recorded into a separate
-           ;; PROLOGUE graph replayed exactly once at bind (see const-prologue? below), not into
-           ;; the per-step graph. The f16 scratch buffers are allocated either way, so this costs
-           ;; no VRAM; it just stops re-converting the weights every step. Measured on the gemma
-           ;; layer VJP (5.6M frozen weight elements vs ~0.2M activation elements): f32_to_f16
-           ;; 7.2 → 0.6 ms, transpose_half 3.2 → 0.2 ms per replay.
-           const-operand? (fn [sym] (= :constant (get effective-roles sym)))
+           bind-graph-executable
+           (fn [executable runtime-arguments phase]
+             (let [executable (kexec/validate! executable)
+                   {:keys [buffers scalar-values]}
+                   (kexec/graph-bindings executable runtime-arguments)
+                   temporary-buffers
+                   (into {}
+                         (map (fn [[id [temporary-dtype elements _]]]
+                                [id (mkbuf-fn elements temporary-dtype)]))
+                         (kgcall/temporary-specs executable scalar-values))
+                   _ (swap! executable-scratch into (vals temporary-buffers))
+                   graph-call (kgcall/make executable
+                                           (merge buffers temporary-buffers)
+                                           scalar-values)
+                   constant-buffers
+                   (into #{}
+                         (keep (fn [{:keys [id]}]
+                                 (when (= :constant (get effective-roles id)) id)))
+                         (:inputs executable))]
+               ;; Constant scheduling is graph-generic: any explicitly cacheable transform whose
+               ;; read set is already constant is hoisted, and its written temporaries become
+               ;; constant for subsequent transforms.
+               (:bounds
+                (reduce
+                 (fn [{:keys [constant-buffers bounds]} [scheduled-node called-node]]
+                   (let [called-artifact (get-in called-node [:call :artifact])
+                         reads (->> (:uses scheduled-node)
+                                    (filter #(contains? #{:read :read-write} (:access %)))
+                                    (map :buffer)
+                                    set)
+                         writes (->> (:uses scheduled-node)
+                                     (filter #(contains? #{:write :read-write} (:access %)))
+                                     (map :buffer)
+                                     set)
+                         constant? (and (true? (get-in called-artifact
+                                                       [:attributes :cacheable-transform?]))
+                                        (every? constant-buffers reads))
+                         _ (register-fn (:kernel-name called-artifact) called-artifact)
+                         prepared (assoc (bind-call-fn (:call called-node))
+                                         :phase (or (:id scheduled-node) phase)
+                                         :const-prologue? constant?)]
+                     {:constant-buffers (if constant?
+                                          (into constant-buffers writes)
+                                          constant-buffers)
+                      :bounds (conj bounds prepared)}))
+                 {:constant-buffers constant-buffers :bounds []}
+                 (map vector (:nodes executable) (:nodes graph-call))))))
            step->bounds
            (fn [{:keys [kernel-name arrays n-fn scalar-specs convention accumulator
                         artifact argument-specs] :as step}]
              (case convention
-               ;; GEMM (Option B): [convert A f32→f16][convert B f32→f16][fp16 XMX gemm → f32 C].
-               ;; A/B are converted into per-GEMM f16 scratch (kept alive on the session); the
-               ;; conversions of :constant operands are hoisted to the bind-time prologue graph.
-               :gemm
-               (let [m (long ((:m-fn step) args)) n (long ((:n-fn step) args)) k (long ((:k-fn step) args))
-                     abuf (buf-of (:A step) :gemm-A) bbuf (buf-of (:B step) :gemm-B)
-                     cbuf (buf-of (:C step) :gemm-C)
-                     a-const? (const-operand? (:A step))
-                     b-const? (const-operand? (:B step))]
-                 (if (or (= :f32-scalar gemm-precision) (< n 8) (< k 8))
-                   ;; Scalar f32 path, taken when (a) the :gemm-precision policy is
-                   ;; :f32-scalar (exact-grad training — see the docstring), or (b) the
-                   ;; XMX hardware pitch gate fires regardless of policy: the XMX
-                   ;; kernel's 2D-block reads need a >=16-byte pitch — the B-operand
-                   ;; VNNI read's pitch is N*2 bytes (fp16) and the A-operand row read's
-                   ;; pitch is K*2 bytes, so N<8 OR K<8 violates it and yields garbage
-                   ;; (relerr ~1; K<8 shows as scrambled + zeroed C rows).
-                   ;; Binds the plain scalar f32 GEMM: it reads the f32 residents
-                   ;; directly, so NO convert/transpose expansion kernels at all.
-                   ;; Resolved lazily — Level-Zero-only for now (like the scatter binder).
-                   (let [scalar-gemm-fn (rt-resolve device-id "bind-registered-gemm-scalar!")]
-                     [{:bound (scalar-gemm-fn abuf bbuf cbuf m n k (:variant step))
-                       :kernel-name (str "gemm_scalar_" (name (:variant step)))
-                       :phase (:phase step)}])
-                   (let [a16 (mkbuf-fn (* m k) :half)
-                     ;; The GEMM proper: one bound kernel, or — when the (m,n) tiling can't
-                     ;; fill the machine — a split-k PAIR (partial GEMM over a 3D grid +
-                     ;; a partials combine), which is a pure SCHEDULE change: same operands,
-                     ;; same DRAM traffic, same result up to f32 summation order.
-                         mk-gemm
-                         (fn [abuf* bbuf*]
-                           (let [[splits kc] (splitk m n k)]
-                             (if (= 1 (long splits))
-                               [["gemm_nonsquare_float" (gemm-fn abuf* bbuf* cbuf m n k :float) false]]
-                               (let [sk-fn (rt-resolve device-id "bind-registered-gemm-splitk!")
-                                     red-fn (rt-resolve device-id "bind-registered-splitk-reduce!")
-                                     parts (mkbuf-fn (* (long splits) m n) :float)]
-                                 (swap! gemm-scratch conj parts)
-                                 [["gemm_nonsquare_splitk"
-                                   (sk-fn abuf* bbuf* parts m n k kc splits) false]
-                                  ["gemm_splitk_reduce"
-                                   (red-fn parts cbuf (* m n) splits) false]]))))
-                     ;; each expansion kernel (convert/transpose/gemm) pre-bakes its FULL gc-seg —
-                     ;; wrap as {:bound bnd} with NO :group-count so record-graph! keeps the grid.
-                     ;; Each entry is [kernel-name bnd const?]: kernel-name so profiling can
-                     ;; attribute device time, const? = "depends only on :constant operands" ⇒
-                     ;; recorded into the bind-time prologue graph instead of the replay graph.
-                         raw
-                         (case (:variant step)
-                       ;; C = A[m,k] · B[k,n]
-                           :nn
-                           (let [b16 (mkbuf-fn (* k n) :half)]
-                             (swap! gemm-scratch conj a16 b16)
-                             (into [["f32_to_f16" (conv-fn abuf a16 (* m k) (vec-width (* m k))) a-const?]
-                                    ["f32_to_f16" (conv-fn bbuf b16 (* k n) (vec-width (* k n))) b-const?]]
-                                   (mk-gemm a16 b16)))
-                       ;; C = A[m,k] · B[n,k]ᵀ — convert B then transpose [n,k]→[k,n], then :nn gemm.
-                       ;; (HF linear weights [out,in] and attention Q·Kᵀ are :nt.)
-                           :nt
-                           (let [b16 (mkbuf-fn (* n k) :half) bt16 (mkbuf-fn (* k n) :half)]
-                             (swap! gemm-scratch conj a16 b16 bt16)
-                             (into [["f32_to_f16" (conv-fn abuf a16 (* m k) (vec-width (* m k))) a-const?]
-                                    ["f32_to_f16" (conv-fn bbuf b16 (* n k) (vec-width (* n k))) b-const?]
-                                    ["transpose_half" (trans-fn b16 bt16 n k :half) b-const?]]
-                                   (mk-gemm a16 bt16)))
-                       ;; C[m,n] = Aᵀ·B — A stored [k,m], B [k,n]. Convert A then transpose
-                       ;; [k,m]→[m,k], convert B ([k,n] already the :nn B layout), then :nn gemm.
-                       ;; (linear-dW = dgemm-tn! : the weight-gradient backward matmul.)
-                           :tn
-                           (let [at16 (mkbuf-fn (* m k) :half) b16 (mkbuf-fn (* k n) :half)]
-                             (swap! gemm-scratch conj a16 at16 b16)
-                             (into [["f32_to_f16" (conv-fn abuf a16 (* k m) (vec-width (* k m))) a-const?]
-                                    ["transpose_half" (trans-fn a16 at16 k m :half) a-const?]
-                                    ["f32_to_f16" (conv-fn bbuf b16 (* k n) (vec-width (* k n))) b-const?]]
-                                   (mk-gemm at16 b16)))
-                           (throw (ex-info (str "GEMM variant not yet wired on resident path: " (:variant step)
-                                                " (only :nn / :nt / :tn)") {:variant (:variant step)})))]
-                     (mapv (fn [[nm b c]] {:bound b :kernel-name nm :phase (:phase step)
-                                           :const-prologue? (boolean c)})
-                           raw))))
                ;; Artifact-backed kernels share the complete executable value: emitted artifact,
                ;; ordered ABI values and realized launch. Reduction's single-group resident
                ;; schedule is explicit here rather than hidden in a special binder.
-               (:map :reduce :map-void :contract)
+               (:map :reduce :map-void :contract :gemm)
                (let [logical-or-physical-args
                      (mapv (fn [{:keys [kind sym type value-fn]}]
                              (if (= :scalar kind)
@@ -1969,13 +1838,23 @@
                         artifact logical-or-physical-args
                         (rt-resolve device-id "expand-pointer-binding"))
                        logical-or-physical-args)
-                     selected-artifact (if-let [dispatch (:dispatch step)]
-                                         (kdispatch/select-alternative
-                                          dispatch ordered-args reduction-strategy)
-                                         artifact)
-                     call (kcall/make selected-artifact ordered-args
-                                      (if (= :reduce convention) {:group-count [1]} {}))]
-                 [(assoc (bind-call-fn call) :phase (:phase step))])
+                     selection-override
+                     (if-let [{:keys [path mapping default]} (:strategy-selection step)]
+                       (get mapping (get-in (:schedule descriptor) path) default)
+                       (when (= :reduce convention) reduction-strategy))
+                     selected (if-let [dispatch (:dispatch step)]
+                                (kdispatch/select-alternative
+                                 dispatch ordered-args selection-override)
+                                artifact)]
+                 (case (kexec/kind selected)
+                   :kernel-artifact
+                   (let [call (kcall/make selected ordered-args
+                                          (if (= :reduce convention)
+                                            {:group-count [1]} {}))]
+                     [(assoc (bind-call-fn call) :phase (:phase step))])
+
+                   :kernel-graph
+                   (bind-graph-executable selected ordered-args (:phase step))))
                ;; scatter-add: out[index[e]*stride+d] += src[e*stride+d]. Expands to TWO bound
                ;; kernels — a zero-fill of the accumulator, then the atomic-add scatter — so the
                ;; recorded graph re-zeroes `out` each replay (zeros-like semantics) and fans
@@ -2021,10 +1900,9 @@
                                     "are wired on the resident path")
                                {:convention convention :kernel kernel-name}))))
            bounds (vec (mapcat step->bounds steps))
-           ;; CONSTANT PROLOGUE: the f16 conversions/transposes of :constant GEMM operands run
-           ;; ONCE, in their own recorded graph replayed here at bind — the per-step graph holds
-           ;; only the kernels whose inputs can actually change between replays. Order within the
-           ;; prologue is preserved (a :nt/:tn transpose still follows its own convert).
+           ;; CONSTANT PROLOGUE: cacheable transforms over constant graph inputs run once in their
+           ;; own recorded graph replayed here at bind. The per-step graph holds only kernels whose
+           ;; inputs can change between replays; transform order remains the KernelGraph order.
            prologue-bounds (filterv :const-prologue? bounds)
            replay-bounds   (filterv (complement :const-prologue?) bounds)
            prologue-graph (when (seq prologue-bounds) (record-fn prologue-bounds))
@@ -2043,9 +1921,10 @@
                :prologue-graph prologue-graph
                :bounds bounds
                :profile? (boolean profile?)
-               ;; per-GEMM f16 conversion scratch (NOT in :buffers — allocated directly via
-               ;; make-buffer) — kept here so close-session! can free it instead of leaking it.
-               :scratch-buffers @gemm-scratch
+               ;; Executable-graph private storage is allocated directly rather than entering the
+               ;; public resident buffer namespace. Keep it with the program for deterministic
+               ;; release; its identities and sizes came from KernelGraph, not runtime convention.
+               :scratch-buffers @executable-scratch
                :param->key param->key
                :alloc->key alloc->key
                :buffer-capacities

--- a/src/raster/gpu/schedule.clj
+++ b/src/raster/gpu/schedule.clj
@@ -2,9 +2,8 @@
   "The schedule layer (S6) — schedule-as-DATA plus the register-budget feasibility gate.
 
    A `Schedule` is an EDN map attached to a compiled artifact (rides on the `Compiled`
-   record's `:schedule` field). It unifies the four scattered representations of today's
-   tuning knobs — the `gemm-schedule` pure fn, the `:gemm-precision` descriptor field, the
-   `*gemm-splitk-*` dynamic vars, and the hardcoded launch geometry — into ONE inspectable,
+   record's `:schedule` field). It unifies the former scattered GEMM precision, split-K policy,
+   and launch-geometry representations into ONE inspectable,
    pinnable structure, and adds the piece all three reference compilers (Halide anderson2021,
    oneDNN, Triton) have and raster lacked: a register-budget feasibility gate that rejects an
    infeasible schedule at COMPILE time instead of discovering it as a measurement-time spill.
@@ -58,6 +57,11 @@
     ;; fusion / cross-layer-resident schedule flips operands to :resident. The graph-level extension
     ;; for stationary LLMs (operand resident across the recorded decode sequence) lives here.
     :residency {:a :dram :b :dram :c :dram}
+    ;; Analytic seed for the generic direct-vs-split executable dispatch. An offline tuner may
+    ;; replace these data without changing a runtime binder or target emitter.
+    :gemm-dispatch {:target-fill-multiple 4
+                    :min-split-chunk 1024
+                    :max-splits 64}
     ;; Dynamic structured reductions keep their extents in the ABI. :auto emits compatible
     ;; schedules once and selects after those scalar values become concrete. The subgroup multiple
     ;; is the analytic crossover seed; measurement/autotuning may override it per machine.
@@ -190,7 +194,9 @@
         score-reuse-multiple
         (get-in schedule [:segmented-weighted-reduction :score-reuse-subgroup-multiple] 16)
         measured-selectors
-        (get-in schedule [:segmented-weighted-reduction :measured-selectors] {})]
+        (get-in schedule [:segmented-weighted-reduction :measured-selectors] {})
+        {:keys [target-fill-multiple min-split-chunk max-splits]}
+        (:gemm-dispatch schedule)]
     (when-not (valid-precisions prec)
       (throw (ex-info (str "schedule: unknown :precision " (pr-str prec) " — expected " valid-precisions)
                       {:precision prec})))
@@ -215,7 +221,14 @@
     (when (and (seq measured-selectors) (not= :auto reduction-strategy))
       (throw (ex-info "schedule: measured selectors require :strategy :auto"
                       {:strategy reduction-strategy
-                       :measured-selectors measured-selectors}))))
+                       :measured-selectors measured-selectors})))
+    (doseq [[field value] [[:target-fill-multiple target-fill-multiple]
+                           [:min-split-chunk min-split-chunk]
+                           [:max-splits max-splits]]]
+      (when-not (and (integer? value) (pos? value))
+        (throw (ex-info "schedule: GEMM dispatch controls must be positive integers"
+                        {:field field :value value
+                         :gemm-dispatch (:gemm-dispatch schedule)})))))
   (let [budget (grf-budget-bytes-per-lane schedule desc)
         acc    (acc-bytes-per-lane schedule)
         staged (register-staged-bytes-per-lane schedule)

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -2436,36 +2436,11 @@
 (def ^:private convert-cache (atom {}))
 
 (defn- convert-source
-  "f32→f16 element-wise convert, `w` elements per work-item (w ∈ #{1 2 4}).
-
-   The scalar form (`out[i] = (half)in[i]`, ONE element per work-item) is REQUEST-RATE
-   bound on this iGPU, not DRAM bound: it moves 6 bytes per work-item and tops out around
-   8 GB/s against a ~78 GB/s streaming ceiling. Widening to w elements cuts the memory
-   requests per lane w-fold at identical DRAM traffic.
-
-   `vstore_halfN` is CORE OpenCL (no cl_khr_fp16 dependency) and converts f32→f16 with the
-   default rounding mode = round-to-nearest-even — the SAME rounding as the `(half)` cast it
-   replaces, so the output is BIT-EXACT, not merely close. The `n & (w-1)` tail keeps the
-   kernel correct for element counts that are not a multiple of w.
-
-   `w` is NOT a constant: past a point, widening costs work-items faster than it saves
-   requests and the launch stops filling the machine. The caller picks it from the hardware
-   descriptor (core.hardware/stream-vector-width)."
+  "Compatibility substrate for raw benchmark callers. Production graph schedules consume the
+   same compiler-owned conversion emitter directly."
   [w]
-  (if (= 1 (long w))
-    (str "__kernel void f32_to_f16(__global const float* restrict in, "
-         "__global half* restrict out, int n) {\n"
-         "  for (int i = get_global_id(0); i < n; i += get_global_size(0)) "
-         "out[i] = (half)in[i];\n}\n")
-    (let [w (long w)
-          sh (case w 2 1 4 2)]                            ;; log2(w), for the >> / << below
-      (str "__kernel void f32_to_f16(__global const float* restrict in, "
-           "__global half* restrict out, int n) {\n"
-           "  int nv = n >> " sh ";\n"
-           "  for (int i = get_global_id(0); i < nv; i += get_global_size(0))\n"
-           "    vstore_half" w "(vload" w "(i, in), i, out);\n"
-           "  for (int i = (nv << " sh ") + get_global_id(0); i < n; i += get_global_size(0))\n"
-           "    out[i] = (half)in[i];\n}\n"))))
+  ((requiring-resolve 'raster.compiler.backend.gpu.opencl-codegen/emit-f32-to-f16-kernel)
+   "f32_to_f16" w))
 
 (defn- ensure-convert-kernel!
   "Lazily compile + cache the f32→f16 convert kernel for vector width `w`. {:module :kernel}."

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -1,0 +1,76 @@
+(ns raster.compiler.backend.gpu.gemm-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.gemm :as gemm]
+            [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.ir.kernel-dispatch :as dispatch]
+            [raster.compiler.ir.kernel-executable :as executable]
+            [raster.compiler.ir.kernel-graph-call :as graph-call]
+            [raster.compiler.ir.kernel-launch :as launch]))
+
+(defn- emitted
+  [variant]
+  (gemm/emit-executable
+   {:id (str "gemm-test-" (name variant))
+    :a 'a :b 'b :c 'c :m 'm :n 'n :k 'k
+    :variant variant :precision :f16-xmx
+    :tile (hardware/derive-gemm-tile {})
+    :fill-workgroups 32}))
+
+(defn- arguments
+  [m n k]
+  [:a-buffer :b-buffer :c-buffer
+   {:type :int :value m} {:type :int :value n} {:type :int :value k}])
+
+(deftest hardware-aware-gemm-selection-is-checked-data
+  (let [scheduled (emitted :nn)
+        select #(dispatch/select-alternative scheduled (apply arguments %))]
+    (is (= [:f32-scalar :xmx-direct :xmx-split-k]
+           (mapv executable/strategy (:alternatives scheduled))))
+    (testing "the matrix-instruction pitch gate is part of the selector, not a runtime binder"
+      (is (= :f32-scalar (executable/strategy (select [32 4 4096]))))
+      (is (= :f32-scalar (executable/strategy (select [32 128 4])))))
+    (testing "a machine-filling shape stays direct"
+      (is (= :xmx-direct (executable/strategy (select [512 512 512])))))
+    (testing "a low-output-occupancy, deep-K shape selects a graph-private split"
+      (is (= :xmx-split-k (executable/strategy (select [13 640 262144])))))))
+
+(deftest split-k-storage-and-launch-use-the-selector-expression
+  (let [scheduled (emitted :nn)
+        runtime-arguments (arguments 13 640 262144)
+        graph (dispatch/select-alternative scheduled runtime-arguments)
+        {:keys [buffers scalar-values]} (executable/graph-bindings graph runtime-arguments)
+        temporary-specs (graph-call/temporary-specs graph scalar-values)
+        partial-spec (some (fn [[id spec]] (when (= :partials (last id)) spec))
+                           temporary-specs)
+        contract (some #(when (= :matrix-contract (get-in % [:operation :attributes :strategy]))
+                          (:operation %))
+                       (:nodes graph))]
+    (is (= :xmx-split-k (executable/strategy graph)))
+    (is (= #{'a 'b 'c} (set (keys buffers))))
+    (is (= [:float (* 26 13 640) nil] partial-spec))
+    (is (= [5 1 26]
+           (:group-count
+            (launch/realize (:launch contract)
+                            #(graph-call/resolve-integer scalar-values %)))))
+    (is (= 4 (count (:nodes graph))))))
+
+(deftest layout-variants-are-graph-topology-not-runtime-conventions
+  (doseq [[variant expected-node-count transpose-phase]
+          [[:nn 3 nil] [:nt 4 :transpose-b] [:tn 4 :transpose-a]]]
+    (let [graph (dispatch/alternative (emitted variant) :xmx-direct)
+          phases (mapv #(get-in % [:operation :attributes :strategy]) (:nodes graph))]
+      (is (= expected-node-count (count (:nodes graph))) (name variant))
+      (when transpose-phase
+        (is (some #{transpose-phase} phases) (name variant))))))
+
+(deftest every-layout-schedule-realizes-to-kernel-calls
+  (let [runtime-arguments (arguments 13 640 262144)]
+    (doseq [variant [:nn :nt :tn]
+            strategy [:xmx-direct :xmx-split-k]]
+      (let [graph (dispatch/alternative (emitted variant) strategy)
+            {:keys [buffers scalar-values]} (executable/graph-bindings graph runtime-arguments)
+            temporary-specs (graph-call/temporary-specs graph scalar-values)
+            temporary-buffers (zipmap (keys temporary-specs) (repeat :temporary-buffer))
+            call (graph-call/make graph (merge buffers temporary-buffers) scalar-values)]
+        (is (graph-call/kernel-graph-call? call) (str (name variant) "/" (name strategy)))
+        (is (= (count (:nodes graph)) (count (:nodes call))))))))

--- a/test/raster/compiler/ir/kernel_dispatch_test.clj
+++ b/test/raster/compiler/ir/kernel_dispatch_test.clj
@@ -112,6 +112,29 @@
                                           :subgroup-score-reuse)))
         "an explicit override remains authoritative over measured selector data")))
 
+(deftest ordered-expression-cases-select-from-checked-shape-arithmetic
+  (let [scheduled
+        (kdispatch/with-selector
+          dispatch
+          {:kind :runtime-expression-cases
+           :cases [{:expression 'width :op :< :value 8 :strategy :reference}
+                   {:expression (klaunch/product 'width 2)
+                    :op :>= :value 512 :strategy :subgroup-score-reuse}]
+           :default :reference})
+        select #(kdispatch/alternative-strategy
+                 (kdispatch/select-alternative
+                  scheduled [:x :out {:type :long :value %}]))]
+    (is (= :reference (select 4)))
+    (is (= :reference (select 128)))
+    (is (= :subgroup-score-reuse (select 256)))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"outside its scalar ABI"
+         (kdispatch/with-selector
+           dispatch
+           {:kind :runtime-expression-cases
+            :cases [{:expression 'not-in-the-abi :op :> :value 0 :strategy :reference}]
+            :default :subgroup-score-reuse})))))
+
 (deftest dispatch-preserves-one-interface-across-single-and-multi-kernel-schedules
   (let [graph (staged-graph)
         mixed (kdispatch/make

--- a/test/raster/compiler/ir/kernel_launch_test.clj
+++ b/test/raster/compiler/ir/kernel_launch_test.clj
@@ -43,6 +43,24 @@
 
 (deftest symbolic-storage-expressions-use-the-same-checked-evaluator
   (is (= 5 (launch/resolve-expression {'n 1025} (launch/ceil-div 'n 256))))
+  (is (= 768
+         (launch/resolve-expression
+          {'m 3 'k 257}
+          (launch/product 'm (launch/align-up (launch/ceil-div 'k 2) 256)))))
+  (let [tiles (launch/product (launch/ceil-div 'm 128) (launch/ceil-div 'n 128))
+        requested-splits (launch/minimum (launch/ceil-div 128 tiles)
+                                         (launch/floor-div 'k 1024)
+                                         32)]
+    (is (= #{'m 'n 'k} (launch/expression-references requested-splits)))
+    (is (= 26 (launch/resolve-expression {'m 13 'n 640 'k 262144}
+                                         requested-splits))))
+  (is (= [3 2]
+         (:group-count
+          (launch/realize
+           (launch/spec {:workgroup-size [256 1]
+                         :group-count [(launch/ceil-div 'n 128)
+                                       (launch/ceil-div 'm 128)]})
+           {'m 129 'n 257}))))
   (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must be an integer"
                         (launch/resolve-expression {} (launch/ceil-div 'n 256)))))
 

--- a/test/raster/dl/gemma_train_resident_test.clj
+++ b/test/raster/dl/gemma_train_resident_test.clj
@@ -325,8 +325,12 @@
 (defn- gemm-dims
   "[{:variant :m :n :k} …] for every :gemm step of a descriptor at `args`."
   [prog args]
-  (mapv (fn [s] {:variant (:variant s)
-                 :m (long ((:m-fn s) args)) :n (long ((:n-fn s) args)) :k (long ((:k-fn s) args))})
+  (mapv (fn [s]
+          (let [[m-spec n-spec k-spec] (take-last 3 (:argument-specs s))]
+            {:variant (:variant s)
+             :m (long ((:value-fn m-spec) args))
+             :n (long ((:value-fn n-spec) args))
+             :k (long ((:value-fn k-spec) args))}))
         (filter #(= :gemm (:convention %)) (:steps prog))))
 
 (defn- run-trajectory!

--- a/test/raster/gpu/gemm_graph_program_test.clj
+++ b/test/raster/gpu/gemm_graph_program_test.clj
@@ -1,0 +1,75 @@
+(ns raster.gpu.gemm-graph-program-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.backend.gpu.gemm :as gemm]
+            [raster.compiler.core.hardware :as hardware]
+            [raster.gpu.core :as gpu]))
+
+(defn- descriptor
+  []
+  (let [tile (hardware/derive-gemm-tile {})]
+    {:dtype :float
+     :gemm-precision :f16-xmx
+     :schedule {:precision :f16-xmx}
+     :all-params ['a 'b 'c 'm 'n 'k]
+     :array-params ['a 'b 'c]
+     :array-roles {'a :input 'b :input 'c :output}
+     :scalar-params ['m 'n 'k]
+     :allocs []
+     :steps
+     [{:convention :gemm :variant :nt :A 'a :B 'b :C 'c
+       :dispatch
+       (gemm/emit-executable
+        {:id "mock-resident-gemm" :a 'a :b 'b :c 'c
+         :m :gemm-m :n :gemm-n :k :gemm-k :variant :nt
+         :precision :f16-xmx :tile tile :fill-workgroups 32})
+       :argument-specs [{:kind :input :sym 'a}
+                        {:kind :input :sym 'b}
+                        {:kind :output :sym 'c}
+                        {:kind :scalar :type :int :value-fn #(nth % 3)}
+                        {:kind :scalar :type :int :value-fn #(nth % 4)}
+                        {:kind :scalar :type :int :value-fn #(nth % 5)}]
+       :strategy-selection {:path [:precision]
+                            :mapping {:f32-scalar :f32-scalar}
+                            :default :auto}
+       :phase :gpu-step-0}]
+     :result-sym 'c}))
+
+(deftest resident-program-flattens-the-selected-executable-graph
+  (let [m 13 n 640 k 262144
+        arguments [(float-array (* m k)) (float-array (* k n)) (float-array (* m n)) m n k]
+        session (atom {:device-id :ze:0 :programs {} :buffers {}})
+        registered (atom [])
+        replayed (atom [])
+        allocate! (fn [sess specs]
+                    (swap! sess update :buffers merge
+                           (into {}
+                                 (map (fn [[key [dtype elements _]]]
+                                        [key {:key key :dtype dtype :n-elements elements}]))
+                                 specs)))
+        runtime-function
+        (fn [_ name]
+          (case name
+            "kernel-registry-entry" (fn [_] nil)
+            "register-kernel!" (fn [name artifact] (swap! registered conj [name artifact]))
+            "bind-registered-map-void-kernel" (fn [& _] (throw (ex-info "unused" {})))
+            "bind-kernel-call" (fn [call] {:bound (:artifact call) :kernel-call call})
+            "make-buffer" (fn [elements dtype] {:dtype dtype :n-elements elements
+                                                :private? true})
+            "record-graph!" (fn [bounds & [options]] {:bounds (vec bounds) :options options})
+            "replay-graph!" (fn [graph] (swap! replayed conj graph))
+            (throw (ex-info "unexpected mocked runtime function" {:name name}))))]
+    (with-redefs-fn
+      {#'gpu/alloc! allocate!
+       (ns-resolve 'raster.gpu.core 'rt-resolve) runtime-function}
+      (fn []
+        (gpu/bind-program! session (descriptor) arguments {'b :constant})
+        (let [{:keys [bounds scratch-buffers prologue-graph graph]}
+              (get-in @session [:programs :program])]
+          (is (= 5 (count bounds)) "convert A/B, transpose B, split contraction, combine")
+          (is (= 4 (count scratch-buffers)) "A16, B16, BT16, and partials are graph-owned")
+          (is (= 5 (count @registered)))
+          (is (= 2 (count (:bounds prologue-graph)))
+              "constant B conversion and its dependent transpose are hoisted")
+          (is (= 3 (count (:bounds graph))))
+          (is (= 1 (count @replayed)))
+          (is (every? #(contains? % :kernel-call) bounds)))))))

--- a/test/raster/gpu/gemm_splitk_test.clj
+++ b/test/raster/gpu/gemm_splitk_test.clj
@@ -12,9 +12,12 @@
      • the split-k GEMM agrees with the plain XMX GEMM (same f16 inputs, f32 accumulate)
        to f32 summation-order noise, across ragged m/n/k and several split counts —
        including a k-range that does not divide evenly and an m below one 8-row DPAS tile;
-     • the split-k DECISION (raster.gpu.core's policy knobs) leaves machine-filling GEMMs
-       alone and splits the low-occupancy ones."
+     • the compiler-emitted split-k schedule expression leaves machine-filling GEMMs alone
+       and splits the low-occupancy ones."
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.gemm :as gemm]
+            [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.ir.kernel-launch :as launch]
             [raster.dl.gpu-grad-parity :as gp]))
 
 (defn- rnd ^floats [n seed]
@@ -112,33 +115,35 @@
           (free! af) (free! h))))))
 
 (deftest split-k-policy-only-fires-on-low-occupancy-gemms
-  ;; Calls the BINDER'S OWN decision (gpu.core/gemm-schedule) — this test used to
-  ;; re-implement the policy by hand, which meant it could not catch a regression in the
-  ;; copy that actually schedules the GEMMs. One policy, one caller, one spec.
-  (require 'raster.gpu.core)
-  (let [core (find-ns 'raster.gpu.core)
-        schedule @(ns-resolve core 'gemm-schedule)
-        max-splits @(ns-resolve core '*gemm-splitk-max-splits*)
+  ;; Realize the compiler IR expression used by both KernelDispatch selection and graph-private
+  ;; split storage. There is no binder copy of this policy anymore.
+  (let [tile (hardware/gemm-tile-for nil)
         fill 32                                   ;; the Arc 140V's 8192 lanes / 256-item wg
-        decide (fn [m n k] (first (schedule m n k fill)))]
+        decide (fn [m n k & [fill-workgroups]]
+                 (launch/resolve-expression
+                  {} (gemm/requested-splits
+                      {:m m :n n :k k :tile tile
+                       :fill-workgroups (or fill-workgroups fill)})))]
     (testing "the tied-embedding backward (5 workgroups, k=262144) is split"
       (is (> (decide 13 640 262144) 1)))
     (testing "a GEMM that already fills the machine is NOT split"
-      (is (= 1 (decide 13 262144 640)))   ;; the head's forward logits: 2048 workgroups
-      (is (= 1 (decide 640 2048 64))))    ;; a :tn weight-gradient: 80 workgroups
+      (is (< (decide 13 262144 640) 2))   ;; the head's forward logits: 2048 workgroups
+      (is (< (decide 640 2048 64) 2)))    ;; a :tn weight-gradient: 80 workgroups
     (testing "a low-occupancy GEMM with a SHORT k is not split (chunks would be tiny)"
-      (is (= 1 (decide 64 640 512))))
+      (is (< (decide 64 640 512) 2)))
     (testing "split count stays within the cap"
-      (is (<= (decide 13 640 (* 1024 1024)) max-splits)))
+      (is (<= (decide 13 640 (* 1024 1024)) 64)))
     (testing "the k-chunk is a multiple of the 32-wide K-unroll and covers all of k"
-      (let [[s kc] (schedule 13 640 262144 fill)]
+      (let [s (decide 13 640 262144)
+            kc (launch/resolve-expression
+                {} (launch/align-up (launch/ceil-div 262144 s) (:block-k tile)))]
         (is (zero? (mod kc 32)))
         (is (>= (* s kc) 262144))))
     (testing "the schedule follows the HARDWARE, not the shape alone"
       ;; the same GEMM on a machine that only needs 4 workgroups to fill is NOT starved,
       ;; so it is not split — the fill count is an input, not a constant.
       (is (> (decide 13 640 262144) 1))
-      (is (= 1 (first (schedule 13 640 262144 4)))))))
+      (is (< (decide 13 640 262144 4) 2)))))
 
 (deftest hardware-derived-launch-geometry
   ;; The machine width is a HardwareDescriptor field, not a literal at each launch site.

--- a/test/raster/gpu/one_tile_source_test.clj
+++ b/test/raster/gpu/one_tile_source_test.clj
@@ -13,7 +13,21 @@
    `emit-gemm-tiled`'s literals exactly, and the split-k policy must produce the same schedule it
    produced from its own constants."
   (:require [clojure.test :refer [deftest is testing]]
-            [raster.compiler.core.hardware :as hw]))
+            [raster.compiler.backend.gpu.gemm :as gemm]
+            [raster.compiler.core.hardware :as hw]
+            [raster.compiler.ir.kernel-launch :as launch]))
+
+(defn- split-schedule
+  [m n k fill-workgroups]
+  (let [tile (hw/gemm-tile-for nil)
+        requested (launch/resolve-expression
+                   {} (gemm/requested-splits
+                       {:m m :n n :k k :tile tile :fill-workgroups fill-workgroups}))]
+    (if (< requested 2)
+      [1 k]
+      (let [kc (launch/resolve-expression
+                {} (launch/align-up (launch/ceil-div k requested) (:block-k tile)))]
+        [(launch/resolve-expression {} (launch/ceil-div k kc)) kc]))))
 
 (deftest default-tile-equals-the-emitters-own-literals
   (testing "gemm-tile-for on no descriptor == emit-gemm-tiled's :or defaults, so adopting the one
@@ -51,10 +65,10 @@
       (is (= (gc 4096 128) (gc 4096 block-n))))))
 
 (deftest split-k-policy-is-unchanged-on-this-device
-  (testing "gemm-schedule now reads block-m/block-n/block-k instead of /128.0 and *32, and must
-            produce the same schedule it did from its own constants"
-    (let [sched (requiring-resolve 'raster.gpu.core/gemm-schedule)]
-      (is (= [1 1024] (sched 128 128 1024 64)) "already fills the machine → no split")
+  (testing "the emitted schedule expression reads block-m/block-n/block-k rather than independent
+            literals and preserves the established policy"
+    (let [sched split-schedule]
+      (is (= [1 1024] (sched 128 128 1024 64)) "short K does not amortize a split")
       (is (= [8 1024] (sched 64 64 8192 64)) "small tile-count, long K → split-k")
       (testing "and every K-chunk is a multiple of the tile's K-unroll, by construction"
         (let [[_ kc] (sched 64 64 8192 64)]

--- a/test/raster/gpu/schedule_test.clj
+++ b/test/raster/gpu/schedule_test.clj
@@ -56,6 +56,9 @@
       (is (= {:strategy :auto :score-reuse-subgroup-multiple 16
               :measured-selectors {}}
              (:segmented-weighted-reduction derived))))
+    (testing "GEMM dispatch policy is explicit, serializable schedule data"
+      (is (= {:target-fill-multiple 4 :min-split-chunk 1024 :max-splits 64}
+             (:gemm-dispatch derived))))
     (testing "a pinned override is recorded in :meta :overrides"
       (is (contains? (get-in (sched/resolve derived {:precision :f32-scalar}) [:meta :overrides])
                      :precision)))))
@@ -149,6 +152,20 @@
                               :measured-selectors
                               {"dispatch-a" {:kind :runtime-scalar-ranges}}}})
                            arc-desc))))
+  (testing "GEMM dispatch controls reject missing, zero, and non-integral policy data"
+    (doseq [invalid [{:max-splits 0}
+                     {:min-split-chunk 1.5}]]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"GEMM dispatch controls must be positive integers"
+           (sched/feasible?
+            (sched/resolve (sched/derive-default nil arc-desc)
+                           {:gemm-dispatch invalid})
+            arc-desc))))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"GEMM dispatch controls must be positive integers"
+         (sched/feasible?
+          (update (sched/derive-default nil arc-desc) :gemm-dispatch dissoc :max-splits)
+          arc-desc))))
   (testing "conflicting :gemm-precision sugar and :precision throw, not silently prefer the deprecated key"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"conflicting"
                           (sched/resolve (sched/derive-default nil arc-desc)


### PR DESCRIPTION
## Summary

- emit scalar FP32, direct mixed-precision XMX, and split-K GEMM as compiler-owned executable graphs behind one ordered A/B/C/M/N/K ABI
- extend checked integer-expression IR and generic dispatch cases so pitch gates, occupancy, private storage, KC, and 1-3D launches remain inspectable compiler data
- bind selected executable graphs generically, including graph-owned temporary lifetime and transitive hoisting of cacheable transforms over constant inputs
- remove resident-core GEMM algorithm reconstruction, dynamic split policy knobs, and duplicate dimension binding closures
- keep the existing low-level registered GEMM helpers only as raw benchmark/compatibility substrate

## Verification

- focused compiler/runtime suite: 58 tests, 347 assertions, zero failures/errors
- full CircleCI command: 2,287 tests, 33,416 assertions, zero failures/errors
- `clojure -T:build jar`
- compiled `raster.dl.nn/linear-nb` descriptor exposes the three graph strategies, generic expression selector, and ordered argument specs with no legacy dimension closures

Live Level Zero execution was unavailable on this host after the earlier system OOM: `zeInit` returns `0x78000001`, so device-dependent cases took their explicit skip path. Pure lowering, every NN/NT/TN direct/split graph realization, and mocked resident binding all ran.

## Follow-up boundary

This deliberately does not claim the final compiler north star. The next convergence slice is to reuse the same executable-graph binder in per-step/program composition and originate GEMM graphs from the canonical contraction/Screma route. Cross-vendor matrix leaves, measured shape-table selection, block quantization, and end-to-end autotuning remain subsequent schedule/emitter work.