### PR TITLE
Add validated resident link plans

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -95,21 +95,27 @@ No schedule key is complete until it is declared, checked, costed, emitted, and
 measured. A key that intentionally models feasibility before emission must be
 labelled as such in the schema and excluded from claims of executable coverage.
 
-### 2.3 Executable steps compose, but artifact values do not yet link
+### 2.3 Executable steps and resident artifact values compose
 
-Descriptor instances now share one executable-step binder: a step may select a
+Descriptor instances share one executable-step binder: a step may select a
 single `KernelArtifact` or a multi-kernel `KernelGraph`, own its private
 temporaries, and flatten with other instances into one resident replay graph.
 This closes the mechanism gap for GEMM-containing layer composition.
 
-The public value layer remains incomplete. `Compiled` keeps its session
-internal, shape information is flat, a foreign `DeviceArray` cannot be rebound,
-and an ordinary device input is currently downloaded and uploaded. There is no
-validated data-valued link plan that proves node shape/view/effects/ownership
-before allocating and instantiating descriptors. These limitations still
-prevent independently compiled transformer layers, prefill/decode artifacts,
-and forward/backward/update artifacts from forming one public zero-copy device
-graph.
+`LinkPlan` lifts that mechanism into a public immutable compiler value. Stable
+typed/shaped nodes replace name-decoding binders; ordered descriptor instances
+carry scalar and schedule environments; pure validation proves views, ranges,
+ownership, aliases and producer/consumer effects before runtime allocation.
+Instantiation allocates internal nodes once and returns an owned executable
+value over one replay graph. It can also attach to a caller session and import
+borrowed/external allocations without taking ownership, which is the boundary
+needed by paged cache managers.
+
+The remaining value-layer convergence is narrower: port the pretrained decoder
+from handwritten buffer-name inspection, then make ordinary `Compiled` values
+produce and consume the same plan/node interface. `Compiled` still keeps its
+session internal and its public shape information is flat, so independently
+created `Compiled` values cannot yet be rebound into one plan directly.
 
 Artifact linking and value rebinding are not runtime conveniences. They are
 compiler primitives required for competitive model execution.

--- a/design/link-plan.md
+++ b/design/link-plan.md
@@ -1,0 +1,95 @@
+# LinkPlan: validated resident program composition
+
+`LinkPlan` is Raster's public, backend-neutral boundary for composing compiled resident program
+descriptors without decoding kernel names or copying intermediate values through the host.
+
+The boundary has two layers:
+
+- `raster.compiler.ir.link-plan` contains immutable compiler values and pure validation;
+- `raster.gpu.link` instantiates a validated plan into resident allocations and one replay graph.
+
+No attention, GEMM, quantization, or model-layer convention exists in the linker. A descriptor step
+may select a `KernelArtifact` or `KernelGraph`; both pass through the common executable-step binder.
+
+## Values
+
+A `LinkNode` identifies one typed, realized `BufferView`, its ownership contract, dataflow role, and
+optional host initializer. Distinct nodes may name disjoint or explicitly aliased ranges of one
+allocation. Node identity, rather than a decoded ABI name, connects producers and consumers.
+
+A `LinkInstance` binds every pointer-valued compiler symbol in one compiled descriptor to a node
+identity. Scalar parameters, resolved schedule data, and residency-role overrides are ordinary
+data. Instance order and descriptor step order define the initial serial schedule.
+
+A `LinkPlan` owns the target, node table, ordered instances, ordered public outputs, explicit alias
+pairs, and inspectable attributes. Constructing it validates, before any driver contact:
+
+- allocation and view bounds, dtype, shape, stride, device and ownership contracts;
+- exact descriptor pointer and scalar environments;
+- descriptor scratch sizes and executable ABI storage dtypes;
+- selected `KernelGraph` external ranges against its resolved scalar environment;
+- producer-before-consumer ordering and read-only roles;
+- declared physical overlap and same-step writable alias hazards;
+- public output identity and availability.
+
+## Example
+
+```clojure
+(require '[raster.compiler.ir.link-plan :as link]
+         '[raster.gpu.link :as gpu-link])
+
+(def plan
+  (link/make
+   {:id :two-layers
+    :target :ze:0
+    :nodes [(link/node {:id :x :dtype :float :shape [16 64]
+                        :device :ze:0 :role :input})
+            (link/node {:id :w0 :dtype :float :shape [64 64]
+                        :device :ze:0 :role :constant :source w0})
+            (link/node {:id :w1 :dtype :float :shape [64 64]
+                        :device :ze:0 :role :constant :source w1})
+            (link/node {:id :hidden :dtype :float :shape [16 64]
+                        :device :ze:0 :role :internal})
+            (link/node {:id :out :dtype :float :shape [16 64]
+                        :device :ze:0 :role :output})]
+    :instances [(link/instance
+                 {:id :layer-0 :descriptor linear-descriptor
+                  :bindings {'x :x, 'W :w0, 'y :hidden}
+                  :scalars {'batch 16, 'in-f 64, 'out-f 64}})
+                (link/instance
+                 {:id :layer-1 :descriptor linear-descriptor
+                  :bindings {'x :hidden, 'W :w1, 'y :out}
+                  :scalars {'batch 16, 'in-f 64, 'out-f 64}})]
+    :outputs [:out]}))
+
+(with-open [executable (gpu-link/instantiate! plan)]
+  (gpu-link/upload! executable :x x)
+  (let [resident-outputs (gpu-link/run! executable)]
+    ;; No host copy occurred. Download only at an explicit host boundary.
+    (gpu-link/download executable :out)))
+```
+
+`instantiate!` may instead receive `{:session session}`. In that form the returned executable does
+not own the caller's session. Its close releases only the recorded graph, prepared phases, private
+kernel storage, materialized view handles, and allocation registrations that it created. Borrowed
+or external plan allocations are supplied as `{allocation-id DeviceBuffer}` through
+`:external-buffers` and are never freed by Raster.
+
+Owned `:input`/`:constant`/`:state` nodes without a plan initializer are tracked as pending. Replay
+fails until `gpu-link/upload!` initializes them. This makes input and first-use state readiness
+explicit while still allowing pretrained runtimes to allocate first and publish or upload later.
+
+## Current deliberate limits
+
+- Runtime kernel pointer bindings are contiguous views. Non-contiguous logical views remain valid
+  compiler values but must receive an explicit layout/materialization schedule before linking.
+- One logical LinkNode represents one flat buffer value. Multi-slot SoA arguments need a future
+  composite abstract value rather than an implicit tuple convention.
+- The initial dependency schedule is serial. Queue/event partitioning can lower from the same
+  proven effects later without changing node or instance identity.
+- A single `Compiled` value has not yet been rebased onto `LinkPlan`; this is the next convergence
+  step after the pretrained decoder uses the semantic boundary.
+
+For paged attention, page allocation, cache relocation, transactional publication, batching and
+request scheduling remain runtime responsibilities. Raster receives borrowed/external node views
+and composes routed attention or paged append descriptors exactly like any other semantic program.

--- a/src/raster/compiler/ir/link_plan.clj
+++ b/src/raster/compiler/ir/link_plan.clj
@@ -1,0 +1,587 @@
+(ns raster.compiler.ir.link-plan
+  "Pure, backend-neutral composition of compiled resident program descriptors.
+
+   A LinkPlan names storage with stable LinkNodes and binds each descriptor's compiler symbols to
+   those node identities. Validation closes shapes, dtypes, aliases, scalar environments and
+   ordered read/write effects before a runtime session or driver object exists. Runtime allocation,
+   executable selection and graph recording deliberately live in raster.gpu.link."
+  (:require [clojure.set :as set]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.buffer-view :as bview]
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-executable :as kexec]
+            [raster.compiler.ir.kernel-graph-call :as kgcall]))
+
+(def node-roles #{:input :constant :state :output :internal :scratch})
+(def binder-roles #{:input :constant :state :output :scratch})
+
+(defrecord LinkNode [id view role source])
+(defrecord LinkInstance [id descriptor bindings scalars schedule roles])
+(defrecord LinkPlan [id target nodes instances outputs aliases attributes])
+
+(defn link-node? [x]
+  (and x (= "raster.compiler.ir.link_plan.LinkNode" (.getName (class x)))))
+
+(defn link-instance? [x]
+  (and x (= "raster.compiler.ir.link_plan.LinkInstance" (.getName (class x)))))
+
+(defn link-plan? [x]
+  (and x (= "raster.compiler.ir.link_plan.LinkPlan" (.getName (class x)))))
+
+(defn- shape-elements [shape]
+  (reduce * 1 shape))
+
+(defn- primitive-array-dtype [value]
+  (when (and value (.isArray (class value)))
+    (case (.getName (.getComponentType (class value)))
+      "byte" :byte
+      "short" :half
+      "int" :int
+      "long" :long
+      "float" :float
+      "double" :double
+      nil)))
+
+(defn- memory-segment? [value]
+  (instance? java.lang.foreign.MemorySegment value))
+
+(defn- validate-source! [{:keys [id view source] :as node}]
+  (when source
+    (when-not (bview/contiguous? view)
+      (throw (ex-info "a link node initializer requires a contiguous view"
+                      {:reason :link-noncontiguous-initializer :node id :view (:id view)})))
+    (cond
+      (memory-segment? source)
+      (when-not (= (long (.byteSize ^java.lang.foreign.MemorySegment source))
+                   (long (:byte-length view)))
+        (throw (ex-info "a link node MemorySegment initializer has the wrong byte length"
+                        {:reason :link-initializer-size :node id
+                         :expected (:byte-length view)
+                         :actual (.byteSize ^java.lang.foreign.MemorySegment source)})))
+
+      (.isArray (class source))
+      (let [source-dtype (primitive-array-dtype source)
+            expected-dtype (dtype/canon (:dtype view))
+            expected-elements (shape-elements (:shape view))
+            actual-elements (java.lang.reflect.Array/getLength source)]
+        (when-not source-dtype
+          (throw (ex-info "a link node initializer must be a primitive array or MemorySegment"
+                          {:reason :link-initializer-type :node id :actual (type source)})))
+        (when-not (= expected-dtype source-dtype)
+          (throw (ex-info "a link node initializer dtype differs from its view"
+                          {:reason :link-initializer-dtype :node id
+                           :expected expected-dtype :actual source-dtype})))
+        (when-not (= expected-elements actual-elements)
+          (throw (ex-info "a link node initializer length differs from its logical shape"
+                          {:reason :link-initializer-size :node id
+                           :expected expected-elements :actual actual-elements}))))
+
+      :else
+      (throw (ex-info "a link node initializer must be a primitive array or MemorySegment"
+                      {:reason :link-initializer-type :node id :actual (type source)}))))
+  node)
+
+(defn validate-node!
+  [node]
+  (when-not (link-node? node)
+    (throw (ex-info "link plan nodes must be LinkNode values"
+                    {:reason :link-node-type :node node :actual (type node)})))
+  (when (nil? (:id node))
+    (throw (ex-info "a link node requires a stable identity" {:reason :link-node-id})))
+  (bview/validate-view! (:view node))
+  (when-not (contains? node-roles (:role node))
+    (throw (ex-info "a link node has an invalid dataflow role"
+                    {:reason :link-node-role :node (:id node) :role (:role node)
+                     :allowed node-roles})))
+  (when (and (:source node)
+             (contains? #{:borrowed :external} (get-in node [:view :allocation :ownership])))
+    (throw (ex-info "caller-owned link allocations cannot also carry host initializers"
+                    {:reason :link-external-initializer :node (:id node)
+                     :ownership (get-in node [:view :allocation :ownership])})))
+  (validate-source! node))
+
+(defn validate-node-source!
+  "Validate a prospective runtime upload against a LinkNode without changing its ownership or
+   initializer contract. Returns `source`."
+  [node source]
+  (validate-node! node)
+  (validate-source! (assoc node :source source))
+  source)
+
+(defn node
+  "Construct one typed, shaped link node.
+
+   Pass an existing checked `:view`, or describe an allocation with `:dtype`, `:shape`, optional
+   `:strides`/`:byte-offset`/`:byte-size`, `:device`, `:memory-space`, `:ownership`, and
+   `:allocation-id`. Nodes may share an allocation only through views carrying the same allocation
+   identity. `:source` is an optional exact primitive-array/MemorySegment initializer."
+  [{:keys [id view role source dtype shape strides byte-offset byte-size device memory-space
+           ownership allocation-id alignment coherence]
+    :or {role :internal byte-offset 0 memory-space :device ownership :owned}}]
+  (let [view (or view
+                 (let [shape (vec shape)
+                       strides (vec (or strides (bview/dense-strides shape)))
+                       span (bview/required-byte-span dtype shape strides)
+                       allocation (bview/allocation
+                                   {:id (or allocation-id id)
+                                    :byte-size (or byte-size (+ byte-offset span))
+                                    :memory-space memory-space
+                                    :device device
+                                    :alignment (or alignment 1)
+                                    :coherence (or coherence :device-only)
+                                    :ownership ownership})]
+                   (bview/view allocation {:id id :byte-offset byte-offset :dtype dtype
+                                           :shape shape :strides strides})))]
+    (validate-node! (->LinkNode id view role source))))
+
+(defn validate-instance!
+  [instance]
+  (when-not (link-instance? instance)
+    (throw (ex-info "link plan instances must be LinkInstance values"
+                    {:reason :link-instance-type :instance instance :actual (type instance)})))
+  (let [{:keys [id descriptor bindings scalars schedule roles]} instance]
+    (when (nil? id)
+      (throw (ex-info "a link instance requires a stable identity" {:reason :link-instance-id})))
+    (when-not (and (map? descriptor) (vector? (:steps descriptor))
+                   (vector? (:all-params descriptor)) (vector? (:array-params descriptor))
+                   (vector? (:scalar-params descriptor)))
+      (throw (ex-info "a link instance requires a compiled resident program descriptor"
+                      {:reason :link-descriptor :instance id :descriptor descriptor})))
+    (when-not (map? bindings)
+      (throw (ex-info "link instance bindings must map compiler symbols to node identities"
+                      {:reason :link-bindings-type :instance id :bindings bindings})))
+    (when-not (map? scalars)
+      (throw (ex-info "link instance scalars must be a symbol-to-value map"
+                      {:reason :link-scalars-type :instance id :scalars scalars})))
+    (when-not (= (set (:scalar-params descriptor)) (set (keys scalars)))
+      (throw (ex-info "link instance scalars differ from the descriptor scalar parameters"
+                      {:reason :link-scalars :instance id
+                       :expected (set (:scalar-params descriptor)) :actual (set (keys scalars))})))
+    (when-not (or (nil? schedule) (map? schedule))
+      (throw (ex-info "link instance schedule must be nil or resolved schedule data"
+                      {:reason :link-schedule :instance id :schedule schedule})))
+    (when-not (and (map? roles) (every? binder-roles (vals roles)))
+      (throw (ex-info "link instance roles must map compiler symbols to resident roles"
+                      {:reason :link-instance-roles :instance id :roles roles
+                       :allowed binder-roles}))))
+  instance)
+
+(defn instance
+  "Construct one descriptor instance. `:bindings` is data—not a name-decoding function—and maps
+   every pointer-valued compiler symbol used by the descriptor to a LinkNode identity. `:scalars`
+   supplies exactly the descriptor's scalar parameters."
+  [{:keys [id descriptor bindings scalars schedule roles] :or {scalars {} roles {}}}]
+  (validate-instance! (->LinkInstance id descriptor bindings scalars schedule roles)))
+
+(defn instance-arguments
+  "Build the descriptor's ordered runtime argument vector. Array positions are intentionally nil:
+   resident binding uses LinkNodes, while scalar/shape closures read their named scalar positions."
+  [instance]
+  (let [{:keys [descriptor scalars]} (validate-instance! instance)
+        array-params (set (:array-params descriptor))]
+    (mapv (fn [parameter]
+            (if (contains? array-params parameter) nil (get scalars parameter)))
+          (:all-params descriptor))))
+
+(defn- pointer-symbols [descriptor]
+  (into #{}
+        (mapcat (fn [step]
+                  (if (= :scatter (:convention step))
+                    (:arrays step)
+                    (keep (fn [{:keys [kind sym]}]
+                            (when (not= :scalar kind) sym))
+                          (:argument-specs step)))))
+        (:steps descriptor)))
+
+(defn- step-interface [step]
+  (or (:artifact step)
+      (some-> (:dispatch step) kdispatch/default-alternative)
+      (throw (ex-info "a linkable descriptor step has no executable interface"
+                      {:reason :link-step-interface :phase (:phase step)
+                       :convention (:convention step)}))))
+
+(defn- slot-access [{:keys [kind role]}]
+  (cond
+    (= :inout role) :read-write
+    (= :input kind) :read
+    (= :output kind) :write
+    :else nil))
+
+(defn- merge-access [left right]
+  (if (= left right) left
+      (if (or (= :read-write left) (= :read-write right)
+              (and left right))
+        :read-write
+        (or left right))))
+
+(defn- step-selection-override [step schedule]
+  (if-let [{:keys [path mapping default]} (:strategy-selection step)]
+    (get mapping (get-in schedule path) default)
+    (when (= :reduce (:convention step))
+      (get-in schedule [:segmented-weighted-reduction :strategy] :auto))))
+
+(defn- abi-step-facts
+  [nodes instance step-index step]
+  (let [{:keys [id descriptor bindings schedule]} instance
+        args (instance-arguments instance)
+        interface (kexec/validate! (step-interface step))
+        pointer-specs (filterv #(not= :scalar (:kind %)) (:argument-specs step))
+        pointer-slots (kabi/pointer-slots (kexec/abi interface))
+        logical-names (kabi/pointer-binding-names (kexec/abi interface))
+        spec-syms (mapv :sym pointer-specs)]
+    (when-not (= (count spec-syms) (count logical-names))
+      (throw (ex-info "link descriptor step pointer plan differs from its executable ABI"
+                      {:reason :link-step-abi :instance id :step step-index
+                       :phase (:phase step) :argument-symbols spec-syms
+                       :abi-bindings logical-names})))
+    (let [slots-by-logical
+          (group-by #(or (:binding %) (:name %)) pointer-slots)
+          facts
+          (mapv (fn [sym logical-name]
+                  (let [node-id (get bindings sym ::missing)
+                        node (get nodes node-id)
+                        slots (get slots-by-logical logical-name)
+                        slot-dtypes (set (map (comp dtype/canon :dtype) slots))]
+                    (when (= ::missing node-id)
+                      (throw (ex-info "link instance omits a descriptor pointer binding"
+                                      {:reason :link-missing-binding :instance id :symbol sym
+                                       :phase (:phase step)})))
+                    (when-not node
+                      (throw (ex-info "link instance binding names an absent node"
+                                      {:reason :link-absent-node :instance id :symbol sym
+                                       :node node-id :phase (:phase step)})))
+                    (when-not (bview/contiguous? (:view node))
+                      (throw (ex-info "linked kernel ABI bindings currently require contiguous views"
+                                      {:reason :link-noncontiguous-binding :instance id
+                                       :symbol sym :node node-id :phase (:phase step)
+                                       :shape (get-in node [:view :shape])
+                                       :strides (get-in node [:view :strides])})))
+                    (when-not (= 1 (count slots))
+                      (throw (ex-info "one link node cannot represent a multi-slot composite ABI"
+                                      {:reason :link-composite-binding-required :instance id
+                                       :symbol sym :node node-id :slots slots
+                                       :dtypes slot-dtypes})))
+                    (when-not (= (dtype/canon (get-in node [:view :dtype])) (first slot-dtypes))
+                      (throw (ex-info "link node dtype differs from the executable ABI"
+                                      {:reason :link-node-dtype :instance id :symbol sym :node node-id
+                                       :expected (first slot-dtypes)
+                                       :actual (get-in node [:view :dtype])})))
+                    {:symbol sym :node node-id
+                     :access (reduce merge-access nil (map slot-access slots))}))
+                spec-syms logical-names)
+          runtime-arguments
+          (mapv (fn [{:keys [kind type value-fn sym]}]
+                  (if (= :scalar kind)
+                    {:type type :value (value-fn args)}
+                    (get bindings sym)))
+                (:argument-specs step))
+          selected (if-let [dispatch (:dispatch step)]
+                     (kdispatch/select-alternative
+                      dispatch runtime-arguments
+                      (step-selection-override step (or schedule (:schedule descriptor))))
+                     interface)
+          scalar-values
+          (into {}
+                (keep (fn [[slot argument value]]
+                        (when (= :scalar (:kind slot)) [argument value])))
+                (map vector (kexec/abi selected) (kexec/arguments selected) runtime-arguments))
+          node-by-executable-buffer
+          (into {}
+                (keep (fn [[slot argument value]]
+                        (when (not= :scalar (:kind slot)) [argument value])))
+                (map vector (kexec/abi selected) (kexec/arguments selected) runtime-arguments))]
+      (when (= :kernel-graph (kexec/kind selected))
+        (doseq [buffer (concat (:inputs selected) (:outputs selected))
+                :let [node-id (get node-by-executable-buffer (:id buffer))
+                      node (get nodes node-id)
+                      expected (when (some? (:elements buffer))
+                                 (kgcall/resolve-integer scalar-values (:elements buffer)))
+                      capacity (quot (get-in node [:view :byte-length])
+                                     (dtype/bytes-of (get-in node [:view :dtype])))]
+                :when expected]
+          (when (> (long expected) (long capacity))
+            (throw (ex-info "selected kernel graph extent exceeds its linked node view"
+                            {:reason :link-node-range :instance id :step step-index
+                             :phase (:phase step) :buffer (:id buffer) :node node-id
+                             :expected expected :capacity capacity})))))
+      {:instance id :step step-index :phase (:phase step) :facts facts})))
+
+(defn- scatter-step-facts
+  [nodes instance step-index step]
+  (let [{:keys [id bindings]} instance
+        [out-sym src-sym index-sym :as symbols] (:arrays step)
+        args (instance-arguments instance)
+        n (try (long ((:n-fn step) args))
+               (catch Exception e
+                 (throw (ex-info "link scatter bound did not resolve from its scalar environment"
+                                 {:reason :link-scatter-bound :instance id :step step-index
+                                  :phase (:phase step)}
+                                 e))))
+        _ (when-not (= 3 (count symbols))
+            (throw (ex-info "a linked scatter step requires output, source and index buffers"
+                            {:reason :link-scatter-abi :instance id :step step-index
+                             :arrays symbols})))
+        node-for
+        (fn [symbol]
+          (let [node-id (get bindings symbol ::missing)
+                link-node (get nodes node-id)]
+            (when (= ::missing node-id)
+              (throw (ex-info "link instance omits a scatter buffer binding"
+                              {:reason :link-missing-binding :instance id :symbol symbol
+                               :phase (:phase step)})))
+            (when-not link-node
+              (throw (ex-info "link scatter binding names an absent node"
+                              {:reason :link-absent-node :instance id :symbol symbol
+                               :node node-id :phase (:phase step)})))
+            (when-not (bview/contiguous? (:view link-node))
+              (throw (ex-info "linked scatter bindings require contiguous views"
+                              {:reason :link-noncontiguous-binding :instance id :symbol symbol
+                               :node node-id :phase (:phase step)})))
+            [node-id link-node]))
+        [[out-id out] [src-id src] [index-id index]] (mapv node-for symbols)
+        capacity (fn [link-node]
+                   (quot (get-in link-node [:view :byte-length])
+                         (dtype/bytes-of (get-in link-node [:view :dtype]))))]
+    (when-not (= (dtype/canon (get-in out [:view :dtype]))
+                 (dtype/canon (get-in src [:view :dtype])))
+      (throw (ex-info "linked scatter source and output dtypes differ"
+                      {:reason :link-node-dtype :instance id :step step-index
+                       :output out-id :source src-id
+                       :output-dtype (get-in out [:view :dtype])
+                       :source-dtype (get-in src [:view :dtype])})))
+    (when-not (= :int (dtype/canon (get-in index [:view :dtype])))
+      (throw (ex-info "linked scatter index storage must be int32"
+                      {:reason :link-node-dtype :instance id :step step-index
+                       :index index-id :actual (get-in index [:view :dtype])})))
+    (doseq [[node-id link-node] [[src-id src] [index-id index]]]
+      (when (> n (capacity link-node))
+        (throw (ex-info "linked scatter bound exceeds a source view"
+                        {:reason :link-node-range :instance id :step step-index
+                         :node node-id :expected n :capacity (capacity link-node)}))))
+    {:instance id :step step-index :phase (:phase step)
+     :facts [{:symbol out-sym :node out-id :access :write}
+             {:symbol src-sym :node src-id :access :read}
+             {:symbol index-sym :node index-id :access :read}]}))
+
+(defn- instance-step-facts
+  [nodes instance step-index step]
+  (if (= :scatter (:convention step))
+    (scatter-step-facts nodes instance step-index step)
+    (abi-step-facts nodes instance step-index step)))
+
+(defn- canonical-alias-pair [pair]
+  (let [pair (set pair)]
+    (when-not (= 2 (count pair))
+      (throw (ex-info "a link alias declaration must name exactly two distinct nodes"
+                      {:reason :link-alias-pair :alias pair})))
+    pair))
+
+(defn- validate-plan-structure! [plan]
+  (when-not (link-plan? plan)
+    (throw (ex-info "expected a LinkPlan value"
+                    {:reason :link-plan-type :plan plan :actual (type plan)})))
+  (let [{:keys [id target nodes instances outputs aliases attributes]} plan]
+    (when (nil? id)
+      (throw (ex-info "a link plan requires a stable identity" {:reason :link-plan-id})))
+    (when-not (keyword? target)
+      (throw (ex-info "a link plan requires a target device keyword"
+                      {:reason :link-target :target target})))
+    (when-not (and (map? nodes) (seq nodes))
+      (throw (ex-info "a link plan requires a non-empty node map"
+                      {:reason :link-nodes :nodes nodes})))
+    (doseq [[node-id link-node] nodes]
+      (validate-node! link-node)
+      (when-not (= node-id (:id link-node))
+        (throw (ex-info "link node map key differs from the node identity"
+                        {:reason :link-node-map-key :key node-id :node (:id link-node)})))
+      (let [device (get-in link-node [:view :allocation :device])]
+        (when-not (or (nil? device) (= target device))
+          (throw (ex-info "link node allocation belongs to a different device"
+                          {:reason :link-node-device :node node-id
+                           :target target :device device})))))
+    (when-not (and (vector? instances) (seq instances))
+      (throw (ex-info "a link plan requires an ordered non-empty instance vector"
+                      {:reason :link-instances :instances instances})))
+    (doseq [link-instance instances] (validate-instance! link-instance))
+    (when-not (= (count instances) (count (distinct (map :id instances))))
+      (throw (ex-info "link instance identities must be unique"
+                      {:reason :link-instance-ids :ids (mapv :id instances)})))
+    (when-not (and (vector? outputs) (every? #(contains? nodes %) outputs))
+      (throw (ex-info "link plan outputs must be an ordered vector of existing node identities"
+                      {:reason :link-outputs :outputs outputs :nodes (set (keys nodes))})))
+    (when-not (= (count outputs) (count (distinct outputs)))
+      (throw (ex-info "link plan output identities must be unique"
+                      {:reason :link-output-duplicates :outputs outputs})))
+    (when-not (and (set? aliases) (every? set? aliases))
+      (throw (ex-info "link plan aliases must be a set of two-node sets"
+                      {:reason :link-aliases :aliases aliases})))
+    (when-not (map? attributes)
+      (throw (ex-info "link plan attributes must be a map"
+                      {:reason :link-attributes :attributes attributes}))))
+  plan)
+
+(defn- validate-allocations-and-aliases! [{:keys [nodes aliases] :as plan}]
+  (let [by-allocation (group-by #(get-in % [:view :allocation :id]) (vals nodes))]
+    (doseq [[allocation-id allocation-nodes] by-allocation]
+      (let [contracts (set (map #(get-in % [:view :allocation]) allocation-nodes))
+            dtypes (set (map #(dtype/canon (get-in % [:view :dtype])) allocation-nodes))]
+        (when-not (= 1 (count contracts))
+          (throw (ex-info "one link allocation identity has conflicting contracts"
+                          {:reason :link-allocation-contract :allocation allocation-id})))
+        (when-not (= 1 (count dtypes))
+          (throw (ex-info "runtime link allocations cannot be reinterpreted across dtypes"
+                          {:reason :link-allocation-reinterpret :allocation allocation-id
+                           :dtypes dtypes})))))
+    (doseq [[left-id left] nodes
+            [right-id right] nodes
+            :when (neg? (compare (pr-str left-id) (pr-str right-id)))
+            :when (bview/overlaps? (:view left) (:view right))]
+      (let [pair #{left-id right-id}]
+        (when-not (contains? aliases pair)
+          (throw (ex-info "overlapping link nodes require an explicit alias declaration"
+                          {:reason :link-undeclared-alias :nodes pair})))
+        (when (and (:source left) (:source right))
+          (throw (ex-info "overlapping link nodes cannot carry competing initializers"
+                          {:reason :link-alias-initializers :nodes pair})))))
+    (doseq [pair aliases
+            :let [[left-id right-id] (vec (canonical-alias-pair pair))
+                  left (get nodes left-id) right (get nodes right-id)]]
+      (when-not (and left right)
+        (throw (ex-info "link alias declaration names an absent node"
+                        {:reason :link-alias-node :alias pair :nodes (set (keys nodes))})))
+      (when-not (bview/overlaps? (:view left) (:view right))
+        (throw (ex-info "link alias declaration names disjoint views"
+                        {:reason :link-spurious-alias :alias pair}))))
+    plan))
+
+(defn- validate-instance-bindings! [nodes instance]
+  (let [{:keys [id descriptor bindings roles]} instance
+        expected (pointer-symbols descriptor)
+        actual (set (keys bindings))]
+    (when-not (= expected actual)
+      (throw (ex-info "link instance bindings differ from descriptor pointer symbols"
+                      {:reason :link-bindings :instance id :expected expected :actual actual
+                       :missing (set/difference expected actual)
+                       :extra (set/difference actual expected)})))
+    (when-not (set/subset? (set (keys roles)) expected)
+      (throw (ex-info "link instance roles name symbols outside its pointer bindings"
+                      {:reason :link-role-symbols :instance id
+                       :extra (set/difference (set (keys roles)) expected)})))
+    (doseq [[sym node-id] bindings]
+      (when-not (contains? nodes node-id)
+        (throw (ex-info "link instance binding names an absent node"
+                        {:reason :link-absent-node :instance id :symbol sym :node node-id})))
+      (when (and (= :constant (get roles sym))
+                 (not= :constant (get-in nodes [node-id :role])))
+        (throw (ex-info "a constant instance binding requires a constant LinkNode"
+                        {:reason :link-role-mismatch :instance id :symbol sym :node node-id
+                         :node-role (get-in nodes [node-id :role])}))))
+    (let [args (instance-arguments instance)]
+      (doseq [{:keys [sym dtype size-fn]} (:allocs descriptor)]
+        (let [node-id (get bindings sym)
+              link-node (get nodes node-id)
+              expected-elements
+              (try (long (size-fn args))
+                   (catch Exception e
+                     (throw (ex-info "link descriptor allocation extent did not resolve from scalars"
+                                     {:reason :link-allocation-shape :instance id :symbol sym}
+                                     e))))
+              actual-elements (shape-elements (get-in link-node [:view :shape]))]
+          (when-not (= (dtype/canon dtype) (dtype/canon (get-in link-node [:view :dtype])))
+            (throw (ex-info "link internal node dtype differs from its descriptor allocation"
+                            {:reason :link-allocation-dtype :instance id :symbol sym :node node-id
+                             :expected dtype :actual (get-in link-node [:view :dtype])})))
+          (when-not (= expected-elements actual-elements)
+            (throw (ex-info "link internal node shape differs from its descriptor allocation"
+                            {:reason :link-allocation-shape :instance id :symbol sym :node node-id
+                             :expected-elements expected-elements
+                             :actual-elements actual-elements})))))
+      (mapv (fn [[step-index step]]
+              (instance-step-facts nodes instance step-index step))
+            (map-indexed vector (:steps descriptor))))))
+
+(defn- validate-effects! [{:keys [target nodes instances outputs aliases] :as plan}]
+  (when (and (not (let [target-name (name target)]
+                    (or (= "ze" target-name) (.startsWith target-name "ze:"))))
+             (some #(= :scatter (:convention %))
+                   (mapcat (comp :steps :descriptor) instances)))
+    (throw (ex-info "linked scatter execution is not available on this target backend"
+                    {:reason :link-target-convention :target target :convention :scatter})))
+  (let [step-facts (mapcat #(validate-instance-bindings! nodes %) instances)
+        initialized (volatile! (into #{}
+                                     (keep (fn [[id {:keys [role source view]}]]
+                                             (when (or source
+                                                       (contains? #{:input :constant :state} role)
+                                                       (contains? #{:borrowed :external}
+                                                                  (get-in view [:allocation :ownership])))
+                                               id)))
+                                     nodes))
+        written (volatile! #{})]
+    (doseq [{:keys [instance step phase facts]} step-facts]
+      (let [by-node (reduce (fn [m {:keys [node access]}]
+                              (update m node merge-access access)) {} facts)]
+        (doseq [[node-id access] by-node
+                :let [role (get-in nodes [node-id :role])]]
+          (when (and (contains? #{:read :read-write} access)
+                     (not (contains? @initialized node-id)))
+            (throw (ex-info "link plan reads an internal node before an ordered producer writes it"
+                            {:reason :link-read-before-write :instance instance :step step
+                             :phase phase :node node-id})))
+          (when (and (contains? #{:write :read-write} access)
+                     (contains? #{:input :constant} role))
+            (throw (ex-info "link plan writes a read-only node"
+                            {:reason :link-write-read-only :instance instance :step step
+                             :phase phase :node node-id :role role})))
+          (when (contains? #{:write :read-write} access)
+            (vswap! initialized conj node-id)
+            (vswap! written conj node-id)))
+        (doseq [[left-id left-access] by-node
+                [right-id right-access] by-node
+                :when (neg? (compare (pr-str left-id) (pr-str right-id)))
+                :when (contains? aliases #{left-id right-id})
+                :when (or (contains? #{:write :read-write} left-access)
+                          (contains? #{:write :read-write} right-access))]
+          (throw (ex-info "one linked kernel step cannot access overlapping aliases when either writes"
+                          {:reason :link-same-step-alias-hazard :instance instance :step step
+                           :phase phase :nodes #{left-id right-id}})))))
+    (doseq [node-id outputs]
+      (when-not (or (contains? @written node-id)
+                    (contains? @initialized node-id))
+        (throw (ex-info "link plan exports a node with no value"
+                        {:reason :link-unproduced-output :node node-id}))))
+    plan))
+
+(defn validate!
+  "Validate a LinkPlan without allocating storage, registering kernels, or contacting a driver."
+  [plan]
+  (-> plan validate-plan-structure! validate-allocations-and-aliases! validate-effects!))
+
+(defn make
+  "Construct and purely validate a LinkPlan.
+
+   `:nodes` may be a node-id map or an ordered collection of LinkNodes. `:aliases` is an explicit
+   collection of two-node collections for overlapping views; undeclared physical overlap fails.
+   Instance order and each descriptor's step order define the current serial dependency schedule."
+  [{:keys [id target nodes instances outputs aliases attributes]
+    :or {outputs [] aliases #{} attributes {}}}]
+  (let [nodes (if (map? nodes) nodes (into {} (map (juxt :id identity)) nodes))
+        aliases (into #{} (map canonical-alias-pair) aliases)]
+    (validate! (->LinkPlan id target nodes (vec instances) (vec outputs) aliases attributes))))
+
+(defn instance-roles
+  "Resolve compiler-symbol roles for the runtime binder. Only `:constant` affects executable
+   prologue hoisting today; the complete role map remains data for residency/lifetime policy."
+  [plan instance]
+  (when-not (link-plan? plan)
+    (throw (ex-info "instance-roles requires a LinkPlan" {:actual (type plan)})))
+  (validate-instance! instance)
+  (let [nodes (:nodes plan)]
+    (merge
+     (into {}
+           (map (fn [[sym node-id]]
+                  [sym (case (get-in nodes [node-id :role])
+                         :internal :scratch
+                         (get-in nodes [node-id :role]))]))
+           (:bindings instance))
+     (:roles instance))))

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -224,7 +224,7 @@
           (free-buffers-internal! @allocated device-id))
         (throw e)))))
 
-(defrecord BoundExecutableStep [prepareds temporary-buffers])
+(defrecord BoundExecutableStep [prepareds temporary-buffers owned-view-buffers])
 
 (defn- bound-executable-step?
   [value]
@@ -245,6 +245,12 @@
     (when-let [destroy-prepared! (rt-resolve-soft device-id "destroy-prepared!")]
       (doseq [prepared (prepared-bindings entry)]
         (try (destroy-prepared! prepared) (catch Exception _))))
+    ;; Level Zero slices are non-owning pointers. OpenCL sub-buffers are independently
+    ;; reference-counted cl_mem values and follow the executable step that materialized them.
+    (when (and (bound-executable-step? entry) (seq (:owned-view-buffers entry)))
+      (when-let [free! (rt-resolve-soft device-id "free-buffer!")]
+        (doseq [buffer (:owned-view-buffers entry)]
+          (try (free! buffer) (catch Exception _)))))
     (when (and (bound-executable-step? entry) (seq (:temporary-buffers entry)))
       (try (free-buffers-internal! (:temporary-buffers entry) device-id)
            (catch Exception _)))))
@@ -717,6 +723,26 @@
                    (throw (ex-info (str "No graph: " graph-key " — call record-graph! first") {})))
          graph (if (recorded-graph-entry? entry) (:replay-graph entry) entry)]
      ((rt-resolve device-id "replay-graph!") graph))))
+
+(defn release-recorded-graph!
+  "Release one graph recorded by record-graph!. Idempotent. Prepared executable steps and their
+   resident buffers remain live until released separately."
+  [sess graph-key]
+  (locking sess
+    (when-let [entry (get-in @sess [:graphs graph-key])]
+      (swap! sess update :graphs dissoc graph-key)
+      (destroy-recorded-graph-entry! (:device-id @sess) entry)))
+  nil)
+
+(defn release-prepared!
+  "Release one phase prepared by prepare! or bind-step!. Idempotent. A recorded graph referring to
+   the phase must be released first; callers that own both should use that order."
+  [sess phase-key]
+  (locking sess
+    (when-let [entry (get-in @sess [:prepared phase-key])]
+      (swap! sess update :prepared dissoc phase-key)
+      (destroy-prepared-entry! (:device-id @sess) entry)))
+  nil)
 
 (defn invoke-scan!
   "Invoke a compiled Blelloch exclusive-scan kernel pair from the session.
@@ -1501,7 +1527,7 @@
          [(assoc (bind-call! (kcall/make executable runtime-arguments
                                          (cond-> {} group-count
                                                  (assoc :group-count group-count))))
-                 :phase phase)] {}))
+                 :phase phase)] {} []))
 
       :kernel-graph
       (let [{:keys [buffers scalar-values]}
@@ -1536,10 +1562,10 @@
                                  :const-prologue? constant?))
                   (recur (next scheduled-nodes) (next called-nodes)
                          (if constant? (into constants writes) constants)))))
-            (->BoundExecutableStep @prepareds temporary-buffers))
+            (->BoundExecutableStep @prepareds temporary-buffers []))
           (catch Exception e
             (destroy-prepared-entry!
-             device-id (->BoundExecutableStep @prepareds temporary-buffers))
+             device-id (->BoundExecutableStep @prepareds temporary-buffers []))
             (throw e)))))))
 
 (defn- bind-resident-step
@@ -1614,9 +1640,9 @@
             (vswap! prepareds conj
                     (assoc (scatter-bind! kernel-name [out-buf src-buf idx-buf] n stride)
                            :phase phase))
-            (->BoundExecutableStep @prepareds {})
+            (->BoundExecutableStep @prepareds {} [])
             (catch Exception e
-              (destroy-prepared-entry! device-id (->BoundExecutableStep @prepareds {}))
+              (destroy-prepared-entry! device-id (->BoundExecutableStep @prepareds {} []))
               (throw e)))))
 
       (throw (ex-info (str "resident step binder cannot bind a " convention " step ("
@@ -1645,13 +1671,40 @@
   ([sess step args sym->key {:keys [schedule roles] :or {roles {}}}]
    (let [device-id (:device-id @sess)
          {:keys [kernel-name phase]} step
-         bufs (:buffers @sess)
+         materialized (volatile! {})
+         owned-view-buffers (volatile! [])
          resolve-buf (fn [sym]
-                       (let [key (sym->key sym)]
-                         (or (get bufs key)
-                             (throw (ex-info (str "No buffer for kernel arg: " sym " → " key)
-                                             {:kernel kernel-name :available (keys bufs)})))))
-         bound-step (bind-resident-step device-id step args resolve-buf schedule roles)
+                       (let [key-or-view (sym->key sym)]
+                         (if (resident-buffer-view? key-or-view)
+                           (or (get @materialized key-or-view)
+                               (let [{:keys [buffer view]}
+                                     (resolve-resident-binding sess key-or-view)
+                                     _ (when-not (bview/contiguous? view)
+                                         (throw (ex-info
+                                                 "resident descriptor binding requires a contiguous view"
+                                                 {:kernel kernel-name :symbol sym :view (:id view)
+                                                  :shape (:shape view) :strides (:strides view)})))
+                                     {runtime-buffer :buffer owned-view? :owned-view?}
+                                     (runtime-buffer-for-view device-id buffer view)]
+                                 (when owned-view?
+                                   (vswap! owned-view-buffers conj runtime-buffer))
+                                 (vswap! materialized assoc key-or-view runtime-buffer)
+                                 runtime-buffer))
+                           (or (get-in @sess [:buffers key-or-view])
+                               (throw (ex-info (str "No buffer for kernel arg: " sym " → "
+                                                    key-or-view)
+                                               {:kernel kernel-name
+                                                :available (keys (:buffers @sess))}))))))
+         bound-step
+         (try
+           (assoc (bind-resident-step device-id step args resolve-buf schedule roles)
+                  :owned-view-buffers @owned-view-buffers)
+           (catch Exception e
+             (when (seq @owned-view-buffers)
+               (when-let [free! (rt-resolve-soft device-id "free-buffer!")]
+                 (doseq [buffer @owned-view-buffers]
+                   (try (free! buffer) (catch Exception _)))))
+             (throw e)))
          old (get-in @sess [:prepared phase])]
      (swap! sess assoc-in [:prepared phase] bound-step)
      (destroy-prepared-entry! device-id old)

--- a/src/raster/gpu/link.clj
+++ b/src/raster/gpu/link.clj
@@ -1,0 +1,274 @@
+(ns raster.gpu.link
+  "Runtime instantiation of pure compiler LinkPlans.
+
+   The plan is validated completely before a session is created or touched. Instantiation allocates
+   each unique owned allocation once, imports caller-owned allocations explicitly, materializes
+   node views, binds every descriptor through raster.gpu.core/bind-step!, and records one replay
+   graph. Attention, GEMM, reductions and quant kernels are not special cases here."
+  (:refer-clojure :exclude [run!])
+  (:require [clojure.set :as set]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.link-plan :as link-plan]
+            [raster.gpu.core :as gpu]))
+
+(declare close! run!)
+
+(defrecord LinkedExecutable
+           [plan session owns-session? graph-key phases allocation-keys node-views pending-inputs
+            closed?]
+  java.io.Closeable
+  (close [this] (close! this))
+  clojure.lang.IFn
+  (invoke [this] (run! this)))
+
+(defn linked-executable? [x]
+  (and x (= "raster.gpu.link.LinkedExecutable" (.getName (class x)))))
+
+(defn- allocation-groups [plan]
+  (group-by #(get-in % [:view :allocation :id]) (vals (:nodes plan))))
+
+(defn- allocation-key [execution-id allocation-id]
+  [::allocation execution-id allocation-id])
+
+(defn- phase-key [execution-id instance-id step-index]
+  [::phase execution-id instance-id step-index])
+
+(defn- graph-key [execution-id]
+  [::graph execution-id])
+
+(defn- allocation-spec
+  [nodes]
+  (let [view (:view (first nodes))
+        allocation (:allocation view)
+        dt (dtype/canon (:dtype view))
+        bytes (long (:byte-size allocation))
+        element-bytes (long (dtype/bytes-of dt))]
+    (when-not (zero? (mod bytes element-bytes))
+      (throw (ex-info "linked allocation byte size is not integral in its storage dtype"
+                      {:reason :link-allocation-size :allocation (:id allocation)
+                       :byte-size bytes :dtype dt})))
+    [dt (quot bytes element-bytes) nil]))
+
+(defn- cleanup-attached!
+  [session graph-key phases allocation-keys]
+  ;; A failed backend destructor must not strand the resources that follow it. Preserve the first
+  ;; failure for the caller, but attempt the complete reverse-order teardown.
+  (let [failure (volatile! nil)
+        attempt! (fn [f]
+                   (try (f)
+                        (catch Throwable error
+                          (when-not @failure (vreset! failure error)))))]
+    (when graph-key (attempt! #(gpu/release-recorded-graph! session graph-key)))
+    (doseq [phase (reverse phases)] (attempt! #(gpu/release-prepared! session phase)))
+    (doseq [key (reverse allocation-keys)] (attempt! #(gpu/free-buffer! session key)))
+    (when-let [error @failure] (throw error))))
+
+(defn instantiate!
+  "Instantiate a validated LinkPlan as one replayable LinkedExecutable.
+
+   opts:
+   - `:session` attaches to an existing same-device session; otherwise the executable owns one.
+   - `:external-buffers` maps every borrowed/external allocation identity to a backend DeviceBuffer.
+
+   Attached executables own only their phases, graph recording and allocation registrations. Their
+   close does not close the caller session and never frees caller-owned buffers."
+  ([plan] (instantiate! plan {}))
+  ([plan {:keys [session external-buffers] :or {external-buffers {}}}]
+   ;; This is intentionally the first operation. Everything below may contact a backend.
+   (let [plan (link-plan/validate! plan)
+         target (:target plan)
+         owns-session? (nil? session)
+         session (or session (gpu/make-session target))
+         _ (when-not (= target (:device-id @session))
+             (when owns-session? (gpu/close-session! session))
+             (throw (ex-info "link plan target differs from its runtime session"
+                             {:reason :link-session-target :target target
+                              :session-device (:device-id @session)})))
+         execution-id (random-uuid)
+         groups (allocation-groups plan)
+         external-ids
+         (into #{}
+               (keep (fn [[allocation-id nodes]]
+                       (when (contains? #{:borrowed :external}
+                                        (get-in (first nodes) [:view :allocation :ownership]))
+                         allocation-id)))
+               groups)
+         supplied-external-ids (set (keys external-buffers))
+         allocation-keys (volatile! [])
+         phases (volatile! [])
+         recorded-key (volatile! nil)]
+     (when-not (= external-ids supplied-external-ids)
+       (when owns-session? (gpu/close-session! session))
+       (throw (ex-info "external buffer bindings differ from the LinkPlan ownership contract"
+                       {:reason :link-external-bindings :expected external-ids
+                        :actual supplied-external-ids
+                        :missing (set/difference external-ids supplied-external-ids)
+                        :extra (set/difference supplied-external-ids external-ids)})))
+     (try
+       (let [key-by-allocation
+             (into {}
+                   (map (fn [[allocation-id _]]
+                          [allocation-id (allocation-key execution-id allocation-id)]))
+                   groups)
+             owned-specs
+             (into {}
+                   (keep (fn [[allocation-id nodes]]
+                           (when (= :owned (get-in (first nodes) [:view :allocation :ownership]))
+                             [(get key-by-allocation allocation-id) (allocation-spec nodes)])))
+                   groups)]
+         (when (seq owned-specs)
+           (gpu/alloc! session owned-specs)
+           (vswap! allocation-keys into (keys owned-specs)))
+         (doseq [[allocation-id nodes] groups
+                 :let [allocation (get-in (first nodes) [:view :allocation])
+                       ownership (:ownership allocation)]
+                 :when (contains? #{:borrowed :external} ownership)]
+           (let [key (get key-by-allocation allocation-id)]
+             (gpu/register-buffer! session key (get external-buffers allocation-id)
+                                   {:ownership ownership
+                                    :allocation-id allocation-id
+                                    :memory-space (:memory-space allocation)
+                                    :coherence (:coherence allocation)
+                                    :alignment (:alignment allocation)})
+             (vswap! allocation-keys conj key)))
+         (let [node-views
+               (into {}
+                     (map (fn [[node-id {:keys [view]}]]
+                            [node-id
+                             (gpu/buffer-view
+                              session (get key-by-allocation (get-in view [:allocation :id]))
+                              {:id (:id view) :byte-offset (:byte-offset view)
+                               :dtype (:dtype view) :shape (:shape view)
+                               :strides (:strides view)})]))
+                     (:nodes plan))]
+           (doseq [[node-id {:keys [source view]}] (:nodes plan)
+                   :when source]
+             (gpu/upload-range! session (get node-views node-id) source
+                                {:elements (reduce * 1 (:shape view))}))
+           (doseq [instance (:instances plan)
+                   [step-index step] (map-indexed vector (get-in instance [:descriptor :steps]))]
+             (let [phase (phase-key execution-id (:id instance) step-index)
+                   bindings (:bindings instance)]
+               (gpu/bind-step!
+                session (assoc step :phase phase) (link-plan/instance-arguments instance)
+                (fn [symbol]
+                  (or (get node-views (get bindings symbol))
+                      (throw (ex-info "validated link binding disappeared during instantiation"
+                                      {:instance (:id instance) :symbol symbol}))))
+                {:schedule (or (:schedule instance) (get-in instance [:descriptor :schedule]))
+                 :roles (link-plan/instance-roles plan instance)})
+               (vswap! phases conj phase)))
+           (let [gkey (graph-key execution-id)]
+             (gpu/record-graph! session @phases gkey)
+             (vreset! recorded-key gkey)
+             (->LinkedExecutable plan session owns-session? gkey @phases @allocation-keys
+                                 node-views
+                                 (atom (into #{}
+                                             (keep (fn [[node-id {:keys [role source view]}]]
+                                                     (when (and (contains? #{:input :constant :state}
+                                                                           role)
+                                                                (nil? source)
+                                                                (= :owned (get-in view
+                                                                                  [:allocation
+                                                                                   :ownership])))
+                                                       node-id)))
+                                             (:nodes plan)))
+                                 (atom false)))))
+       (catch Throwable error
+         (if owns-session?
+           (try (gpu/close-session! session) (catch Throwable _))
+           (try (cleanup-attached! session @recorded-key @phases @allocation-keys)
+                (catch Throwable _)))
+         (throw error))))))
+
+(defn- ensure-live! [executable operation]
+  (when-not (linked-executable? executable)
+    (throw (ex-info "operation requires a LinkedExecutable"
+                    {:operation operation :actual (type executable)})))
+  (when @(:closed? executable)
+    (throw (ex-info "linked executable is closed"
+                    {:operation operation :plan (get-in executable [:plan :id])})))
+  executable)
+
+(defn node-view
+  "Return a stable ResidentBufferView for one public or internal LinkNode."
+  [executable node-id]
+  (let [executable (ensure-live! executable :node-view)]
+    (or (get (:node-views executable) node-id)
+        (throw (ex-info "linked executable has no such node"
+                        {:reason :link-runtime-node :node node-id
+                         :nodes (set (keys (:node-views executable)))})))))
+
+(defn outputs
+  "Return the plan's ordered output node identities mapped to resident views."
+  [executable]
+  (let [executable (ensure-live! executable :outputs)
+        output-ids (get-in executable [:plan :outputs])
+        rank (zipmap output-ids (range))]
+    ;; Array maps lose insertion order after their small-map threshold. A plan-ranked sorted map
+    ;; keeps the declared order for model boundaries with arbitrarily many outputs.
+    (into (sorted-map-by (fn [left right]
+                           (let [position-order (compare (get rank left Long/MAX_VALUE)
+                                                         (get rank right Long/MAX_VALUE))]
+                             (if (zero? position-order)
+                               (compare (pr-str left) (pr-str right))
+                               position-order))))
+          (map (fn [node-id] [node-id (node-view executable node-id)]))
+          output-ids)))
+
+(defn run!
+  "Replay the linked graph synchronously and return its resident output views. No host copies."
+  [executable]
+  (let [executable (ensure-live! executable :run!)]
+    (when (seq @(:pending-inputs executable))
+      (throw (ex-info "linked executable has owned inputs or state that have not been initialized"
+                      {:reason :link-pending-inputs :plan (get-in executable [:plan :id])
+                       :nodes @(:pending-inputs executable)})))
+    (gpu/replay! (:session executable) (:graph-key executable))
+    (outputs executable)))
+
+(defn upload!
+  "Upload an exact contiguous host value into one live LinkNode view. Returns the executable."
+  [executable node-id source]
+  (let [executable (ensure-live! executable :upload!)
+        node (get-in executable [:plan :nodes node-id])]
+    (when-not node
+      (node-view executable node-id))
+    ;; Reject dtype/length mistakes before the backend copy sees them.
+    (link-plan/validate-node-source! node source)
+    (gpu/upload-range! (:session executable) (node-view executable node-id) source
+                       {:elements (reduce * 1 (get-in node [:view :shape]))})
+    (swap! (:pending-inputs executable) disj node-id)
+    executable))
+
+(defn download
+  "Download one complete contiguous LinkNode view. Debug/host-boundary helper, not invocation."
+  [executable node-id]
+  (let [executable (ensure-live! executable :download)
+        node (get-in executable [:plan :nodes node-id])
+        _ (when-not node (node-view executable node-id))
+        n (reduce * 1 (get-in node [:view :shape]))
+        dt (get-in node [:view :dtype])
+        out (case (dtype/canon dt)
+              :byte (byte-array n)
+              :half (short-array n)
+              :int (int-array n)
+              :long (long-array n)
+              :float (float-array n)
+              :double (double-array n))]
+    (gpu/download-range! (:session executable) (node-view executable node-id) out
+                         {:elements n})
+    out))
+
+(defn close!
+  "Release a LinkedExecutable. Idempotent. An owned session is closed wholesale; an attached
+   executable releases only its recording, phases, and allocation registrations."
+  [executable]
+  (when-not (linked-executable? executable)
+    (throw (ex-info "close! requires a LinkedExecutable" {:actual (type executable)})))
+  (when (compare-and-set! (:closed? executable) false true)
+    (if (:owns-session? executable)
+      (gpu/close-session! (:session executable))
+      (cleanup-attached! (:session executable) (:graph-key executable)
+                         (:phases executable) (:allocation-keys executable))))
+  nil)

--- a/test/raster/compiler/ir/kernel_dispatch_test.clj
+++ b/test/raster/compiler/ir/kernel_dispatch_test.clj
@@ -1,6 +1,7 @@
 (ns raster.compiler.ir.kernel-dispatch-test
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.buffer-view :as bview]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
@@ -310,3 +311,55 @@
         (gpu/record-graph! session [:probe] :linked)
         (is (= 1 (count (filter #(= :graph (first %)) @destroyed)))
             "re-recording releases the superseded command graph")))))
+
+(deftest resident-step-materializes-and-owns-checked-buffer-views
+  (let [root {:root true :dtype :float :n-elements 64 :byte-size 256}
+        allocation (bview/allocation {:id :root :byte-size 256 :memory-space :device
+                                      :device :ocl:0 :coherence :explicit-transfer
+                                      :ownership :owned})
+        session (atom {:device-id :ocl:0 :session-id :view-session
+                       :buffers {:storage root} :allocations {:storage allocation}
+                       :prepared {} :graphs {} :closed? false})
+        x-view (gpu/buffer-view session :storage {:shape [16]})
+        out-view (gpu/buffer-view session :storage {:byte-offset 64 :shape [16]})
+        slices (atom [])
+        freed (atom [])
+        destroyed (atom [])
+        resolver
+        (fn [_ name]
+          (case name
+            "slice-buffer" (fn [buffer byte-offset byte-length dt]
+                             (let [slice {:slice true :buffer buffer :byte-offset byte-offset
+                                          :byte-size byte-length :n-elements (quot byte-length 4)
+                                          :dtype dt}]
+                               (swap! slices conj slice)
+                               slice))
+            "register-kernel!" (fn [& _])
+            "bind-kernel-call" (fn [call] {:call call})
+            (throw (ex-info "unexpected runtime resolution" {:name name}))))
+        soft-resolver
+        (fn [_ name]
+          (case name
+            "destroy-prepared!" #(swap! destroyed conj %)
+            "free-buffer!" #(swap! freed conj %)
+            nil))
+        step {:kernel-name (:kernel-name reference)
+              :phase :view-step
+              :convention :map
+              :artifact reference
+              :argument-specs [{:kind :input :sym 'x}
+                               {:kind :output :sym 'out}
+                               {:kind :scalar :type :long
+                                :value-fn (fn [_] 16)}]}]
+    (with-redefs-fn
+      {#'raster.gpu.core/rt-resolve resolver
+       #'raster.gpu.core/rt-resolve-soft soft-resolver}
+      (fn []
+        (gpu/bind-step! session step {} {'x x-view 'out out-view})
+        (is (= 1 (count @slices)) "the non-zero OpenCL range is one owned cl_mem sub-buffer")
+        (is (= 1 (count (get-in @session [:prepared :view-step :owned-view-buffers]))))
+        (gpu/release-prepared! session :view-step)
+        (is (= 1 (count @destroyed)))
+        (is (= @slices @freed) "view handles follow the bound step lifetime")
+        (is (not-any? #(identical? root %) @freed)
+            "the session-owned root allocation survives step release")))))

--- a/test/raster/compiler/ir/link_plan_test.clj
+++ b/test/raster/compiler/ir/link_plan_test.clj
@@ -1,0 +1,199 @@
+(ns raster.compiler.ir.link-plan-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.buffer-view :as bview]
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.link-plan :as link]))
+
+(def ^:private kernel
+  (artifact/make
+   {:kernel-name "link_axpy"
+    :source (str "__kernel void link_axpy(__global const float* x, "
+                 "__global const float* w, __global float* y, long n) {}")
+    :abi [(kabi/slot 'x :input :float)
+          (kabi/slot 'w :input :float)
+          (kabi/slot 'y :output :float)
+          (kabi/slot 'n :scalar :long)]
+    :arguments '[x w y n]
+    :launch (launch/spec {:workgroup-size [64]
+                          :group-count [(launch/ceil-div 'n 64)]})
+    :effects {:kind :map :reads '[x w] :writes '[y]}
+    :attributes {:strategy :reference}}))
+
+(defn- descriptor []
+  {:dtype :float
+   :all-params '[x w n]
+   :array-params '[x w]
+   :scalar-params '[n]
+   :array-roles {'x :input 'w :input}
+   :allocs [{:sym 'y :dtype :float :size-fn (fn [args] (long (nth args 2)))}]
+   :steps [{:phase :map :kernel-name "link_axpy" :convention :map
+            :artifact kernel
+            :argument-specs [{:kind :input :sym 'x}
+                             {:kind :input :sym 'w}
+                             {:kind :output :sym 'y}
+                             {:kind :scalar :type :long
+                              :value-fn (fn [args] (long (nth args 2)))}]}]
+   :result-sym 'y})
+
+(defn- n [id role & [source]]
+  (link/node {:id id :dtype :float :shape [16] :device :ze:0
+              :role role :source source}))
+
+(defn- instance [id x w y]
+  (link/instance {:id id :descriptor (descriptor)
+                  :bindings {'x x 'w w 'y y}
+                  :scalars {'n 16}}))
+
+(defn- valid-plan []
+  (let [x (float-array 16) w0 (float-array 16) w1 (float-array 16)]
+    (link/make
+     {:id :two-layers :target :ze:0
+      :nodes [(n :x :input x) (n :w0 :constant w0) (n :w1 :constant w1)
+              (n :hidden :internal) (n :out :output)]
+      :instances [(instance :layer-0 :x :w0 :hidden)
+                  (instance :layer-1 :hidden :w1 :out)]
+      :outputs [:out]})))
+
+(deftest data-valued-descriptor-instances-compose-through-stable-node-identities
+  (let [plan (valid-plan)]
+    (is (link/link-plan? plan))
+    (is (= [:layer-0 :layer-1] (mapv :id (:instances plan))))
+    (is (= :hidden (get-in plan [:instances 1 :bindings 'x])))
+    (is (= [nil nil 16] (link/instance-arguments (first (:instances plan)))))
+    (is (= {'x :input 'w :constant 'y :scratch}
+           (link/instance-roles plan (first (:instances plan)))))))
+
+(deftest validation-closes-bindings-shapes-dtypes-and-ordered-effects
+  (testing "every pointer symbol is explicitly bound"
+    (let [i (assoc (instance :layer :x :w0 :out) :bindings {'x :x 'y :out})]
+      (is (= :link-bindings
+             (:reason (ex-data (try
+                                 (link/make {:id :missing :target :ze:0
+                                             :nodes [(n :x :input (float-array 16))
+                                                     (n :w0 :constant (float-array 16))
+                                                     (n :out :output)]
+                                             :instances [i] :outputs [:out]})
+                                 (catch clojure.lang.ExceptionInfo e e))))))))
+  (testing "descriptor allocation shapes are exact"
+    (let [bad-out (link/node {:id :out :dtype :float :shape [15] :device :ze:0 :role :output})]
+      (is (= :link-allocation-shape
+             (:reason (ex-data (try
+                                 (link/make {:id :shape :target :ze:0
+                                             :nodes [(n :x :input (float-array 16))
+                                                     (n :w :constant (float-array 16)) bad-out]
+                                             :instances [(instance :layer :x :w :out)]
+                                             :outputs [:out]})
+                                 (catch clojure.lang.ExceptionInfo e e))))))))
+  (testing "ABI storage dtype is authoritative"
+    (let [bad-x (link/node {:id :x :dtype :int :shape [16] :device :ze:0
+                            :role :input :source (int-array 16)})]
+      (is (= :link-node-dtype
+             (:reason (ex-data (try
+                                 (link/make {:id :dtype :target :ze:0
+                                             :nodes [bad-x (n :w :constant (float-array 16))
+                                                     (n :out :output)]
+                                             :instances [(instance :layer :x :w :out)]
+                                             :outputs [:out]})
+                                 (catch clojure.lang.ExceptionInfo e e))))))))
+  (testing "a flat node cannot silently stand in for a multi-buffer SoA value"
+    (let [soa-kernel
+          (artifact/make
+           {:kernel-name "link_soa"
+            :source "__kernel void link_soa(float* x_a, float* x_b, float* y, long n) {}"
+            :abi [(kabi/slot 'x_a :input :float :binding 'x)
+                  (kabi/slot 'x_b :input :float :binding 'x)
+                  (kabi/slot 'y :output :float)
+                  (kabi/slot 'n :scalar :long)]
+            :arguments '[x_a x_b y n]
+            :launch (launch/spec {:workgroup-size [64]
+                                  :group-count [(launch/ceil-div 'n 64)]})
+            :effects {:kind :map :reads '[x_a x_b] :writes '[y]}})
+          descriptor {:dtype :float
+                      :all-params '[x n]
+                      :array-params '[x]
+                      :scalar-params '[n]
+                      :allocs [{:sym 'y :dtype :float
+                                :size-fn (fn [args] (long (nth args 1)))}]
+                      :steps [{:phase :map :kernel-name "link_soa" :convention :map
+                               :artifact soa-kernel :logical-bindings? true
+                               :argument-specs [{:kind :pointer :sym 'x}
+                                                {:kind :output :sym 'y}
+                                                {:kind :scalar :type :long
+                                                 :value-fn (fn [args] (long (nth args 1)))}]}]
+                      :result-sym 'y}
+          i (link/instance {:id :soa :descriptor descriptor
+                            :bindings {'x :x 'y :out} :scalars {'n 16}})]
+      (is (= :link-composite-binding-required
+             (:reason (ex-data
+                       (try
+                         (link/make {:id :soa :target :ze:0
+                                     :nodes [(n :x :input (float-array 16)) (n :out :output)]
+                                     :instances [i] :outputs [:out]})
+                         (catch clojure.lang.ExceptionInfo e e))))))))
+  (testing "an internal consumer cannot precede its producer"
+    (is (= :link-read-before-write
+           (:reason (ex-data (try
+                               (let [x (float-array 16) w0 (float-array 16) w1 (float-array 16)]
+                                 (link/make
+                                  {:id :order :target :ze:0
+                                   :nodes [(n :x :input x) (n :w0 :constant w0)
+                                           (n :w1 :constant w1) (n :hidden :internal)
+                                           (n :out :output)]
+                                   :instances [(instance :consumer :hidden :w1 :out)
+                                               (instance :producer :x :w0 :hidden)]
+                                   :outputs [:out]}))
+                               (catch clojure.lang.ExceptionInfo e e))))))))
+
+(deftest physical-view-aliases-are-explicit-and-effect-checked
+  (let [allocation (bview/allocation {:id :shared :byte-size 96 :memory-space :device
+                                      :device :ze:0 :ownership :owned})
+        x (link/node {:id :x :view (bview/view allocation
+                                               {:id :x :byte-offset 0 :dtype :float :shape [16]})
+                      :role :input :source (float-array 16)})
+        out (link/node {:id :out :view (bview/view allocation
+                                                   {:id :out :byte-offset 32 :dtype :float
+                                                    :shape [16]})
+                        :role :output})
+        w (n :w :constant (float-array 16))
+        make-plan #(link/make {:id :alias :target :ze:0 :nodes [x w out]
+                               :instances [(instance :layer :x :w :out)]
+                               :outputs [:out] :aliases %})]
+    (is (= :link-undeclared-alias
+           (:reason (ex-data (try (make-plan #{})
+                                  (catch clojure.lang.ExceptionInfo e e))))))
+    (is (= :link-same-step-alias-hazard
+           (:reason (ex-data (try (make-plan #{#{:x :out}})
+                                  (catch clojure.lang.ExceptionInfo e e))))))))
+
+(deftest scatter-expansion-retains-a-pure-link-contract
+  (let [descriptor {:dtype :float
+                    :all-params '[out src index n]
+                    :array-params '[out src index]
+                    :scalar-params '[n]
+                    :array-roles {'out :output 'src :input 'index :input}
+                    :allocs []
+                    :steps [{:phase :scatter :kernel-name "scatter"
+                             :convention :scatter :arrays '[out src index]
+                             :n-fn (fn [args] (long (nth args 3))) :scalar-specs []}]
+                    :result-sym 'out}
+        nodes [(n :out :output)
+               (link/node {:id :src :dtype :float :shape [16] :device :ze:0
+                           :role :input :source (float-array 16)})
+               (link/node {:id :index :dtype :int :shape [16] :device :ze:0
+                           :role :input :source (int-array 16)})]
+        instance (link/instance {:id :scatter :descriptor descriptor
+                                 :bindings {'out :out 'src :src 'index :index}
+                                 :scalars {'n 16}})]
+    (is (link/link-plan? (link/make {:id :scatter :target :ze:0 :nodes nodes
+                                     :instances [instance] :outputs [:out]})))
+    (is (= :link-target-convention
+           (:reason (ex-data
+                     (try
+                       (link/make {:id :scatter-ocl :target :ocl:0
+                                   :nodes (mapv #(update-in % [:view :allocation]
+                                                            assoc :device :ocl:0)
+                                                nodes)
+                                   :instances [instance] :outputs [:out]})
+                       (catch clojure.lang.ExceptionInfo e e))))))))

--- a/test/raster/gpu/link_spike_test.clj
+++ b/test/raster/gpu/link_spike_test.clj
@@ -11,8 +11,11 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.core :refer [deftm]]
             [raster.dl.gpu-grad-parity :as gp]
+            [raster.compiler.ir.link-plan :as link-plan]
             [raster.compiler.pipeline :as pl]
-            [raster.dl.nn :as nn]))
+            [raster.dl.nn :as nn]
+            [raster.gpu.core :as gpu]
+            [raster.gpu.link :as gpu-link]))
 
 ;; A minimal elementwise forward: y = (x + w) * x  (residual-add then hadamard — the proven-
 ;; resident dt-two-step shape). Composing it twice with weights w0,w1 gives the intermediate
@@ -51,6 +54,41 @@
                               actual expected))
         scale (reduce max 1.0 (map #(Math/abs (double %)) expected))]
     (/ absolute scale)))
+
+(deftest public-output-order-is-not-limited-by-array-map-size
+  (let [output-ids (mapv #(keyword (str "output-" %)) (range 12))
+        resident-values (zipmap output-ids (range 12))
+        executable (gpu-link/map->LinkedExecutable
+                    {:plan {:outputs output-ids}
+                     :node-views resident-values
+                     :closed? (atom false)})]
+    (is (= output-ids (vec (keys (gpu-link/outputs executable)))))
+    (is (= (range 12) (vals (gpu-link/outputs executable))))))
+
+(deftest attached-close-attempts-the-entire-reverse-order-teardown
+  (let [calls (atom [])
+        executable (gpu-link/map->LinkedExecutable
+                    {:session ::caller-session
+                     :owns-session? false
+                     :graph-key :graph
+                     :phases [:phase-0 :phase-1]
+                     :allocation-keys [:allocation-0 :allocation-1]
+                     :closed? (atom false)})]
+    (with-redefs [gpu/release-recorded-graph!
+                  (fn [_ graph]
+                    (swap! calls conj [:graph graph])
+                    (throw (ex-info "destructor failed" {})))
+                  gpu/release-prepared!
+                  (fn [_ phase] (swap! calls conj [:phase phase]))
+                  gpu/free-buffer!
+                  (fn [_ allocation] (swap! calls conj [:allocation allocation]))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"destructor failed"
+                            (gpu-link/close! executable))))
+    (is (= [[:graph :graph]
+            [:phase :phase-1] [:phase :phase-0]
+            [:allocation :allocation-1] [:allocation :allocation-0]]
+           @calls))
+    (is (nil? (gpu-link/close! executable)) "close remains idempotent after a destructor failure")))
 
 (deftest spike-two-instance-link
   (if-not @gp/gpu-available?
@@ -116,54 +154,67 @@
 (deftest spike-two-instance-gemm-link
   (if-not @gp/gpu-available?
     (gp/gpu-skip! "C.spike 2-instance executable GEMM link")
-    (let [gpu (do (require 'raster.gpu.core) (find-ns 'raster.gpu.core))
-          make-session   (ns-resolve gpu 'make-session)
-          bind-step!     (ns-resolve gpu 'bind-step!)
-          record-graph!  (ns-resolve gpu 'record-graph!)
-          replay!        (ns-resolve gpu 'replay!)
-          alloc!         (ns-resolve gpu 'alloc!)
-          download       (ns-resolve gpu 'download)
-          close-session! (ns-resolve gpu 'close-session!)
-          rows 16 width 64
+    (let [rows 16 width 64
           x0 (fa (* rows width) 11)
           W0 (fa (* width width) 12)
           W1 (fa (* width width) 13)
-          args [x0 W0 rows width width]
           prog (pl/compile-gpu-program #'nn/linear-nb :ze:0 :dtype :float
                                        :gemm-precision :f16-xmx :on-non-resident :nil)
           _ (is (some? prog) "spike-gemm must extract as one resident contraction")
-          steps (:steps prog)
-          result-sym (:result-sym prog)]
-      (is (= [:gemm] (mapv :convention steps)))
-      (let [sess (make-session :ze:0)]
-        (try
-          (alloc! sess {:x0 [:float (* rows width) x0]
-                        :W0 [:float (* width width) W0]
-                        :W1 [:float (* width width) W1]
-                        :x1 [:float (* rows width) nil]
-                        :x2 [:float (* rows width) nil]})
-          (let [plan {0 {'x :x0 'W :W0 result-sym :x1}
-                      1 {'x :x1 'W :W1 result-sym :x2}}
-                phases
-                (vec
-                 (for [instance [0 1]
-                       step steps]
-                   (let [phase (keyword (str "gemm-i" instance))]
-                     (bind-step! sess (assoc step :phase phase) args (get plan instance)
-                                 {:schedule (:schedule prog) :roles {'W :constant}})
-                     phase)))
-                prepared-count
-                (reduce + (map #(count (get-in @sess [:prepared % :prepareds])) phases))
-                private-count
-                (reduce + (map #(count (get-in @sess [:prepared % :temporary-buffers])) phases))]
-            (is (> prepared-count 2)
-                "each semantic GEMM selects and flattens a multi-kernel schedule")
-            (is (pos? private-count) "conversion/layout storage stays step-private")
-            (record-graph! sess phases :gemm-composite)
-            (replay! sess :gemm-composite)
-            (let [actual (download sess :x2)
-                  expected (cpu-linear (cpu-linear x0 W0 rows width) W1 rows width)]
-              (is (< (relative-max-error actual expected) 2.0e-2)
-                  (str "linked mixed-precision GEMMs must match the CPU composition; relative max "
-                       (relative-max-error actual expected)))))
-          (finally (close-session! sess)))))))
+          result-sym (:result-sym prog)
+          scalar-values {'batch rows 'in-f width 'out-f width}
+          plan
+          (link-plan/make
+           {:id :two-linear-layers
+            :target :ze:0
+            :nodes [(link-plan/node {:id :x0 :dtype :float :shape [rows width]
+                                     :device :ze:0 :role :input})
+                    (link-plan/node {:id :W0 :dtype :float :shape [width width]
+                                     :device :ze:0 :role :constant :source W0})
+                    (link-plan/node {:id :W1 :dtype :float :shape [width width]
+                                     :device :ze:0 :role :constant :source W1})
+                    (link-plan/node {:id :x1 :dtype :float :shape [rows width]
+                                     :device :ze:0 :role :internal})
+                    (link-plan/node {:id :x2 :dtype :float :shape [rows width]
+                                     :device :ze:0 :role :output})]
+            :instances
+            [(link-plan/instance
+              {:id :linear-0 :descriptor prog :scalars scalar-values
+               :bindings {'x :x0 'W :W0 result-sym :x1}})
+             (link-plan/instance
+              {:id :linear-1 :descriptor prog :scalars scalar-values
+               :bindings {'x :x1 'W :W1 result-sym :x2}})]
+            :outputs [:x2]})
+          session (gpu/make-session :ze:0)
+          executable (gpu-link/instantiate! plan {:session session})]
+      (is (= [:gemm] (mapv :convention (:steps prog))))
+      (try
+        (let [session (:session executable)
+              phases (:phases executable)
+              prepared-count
+              (reduce + (map #(count (get-in @session [:prepared % :prepareds])) phases))
+              private-count
+              (reduce + (map #(count (get-in @session [:prepared % :temporary-buffers])) phases))]
+          (is (> prepared-count 2)
+              "each semantic GEMM selects and flattens a multi-kernel schedule")
+          (is (pos? private-count) "conversion/layout storage stays step-private")
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"have not been initialized"
+                                (gpu-link/run! executable))
+              "owned dynamic inputs must be uploaded before the first replay")
+          (gpu-link/upload! executable :x0 x0)
+          (let [resident-outputs (gpu-link/run! executable)
+                actual (gpu-link/download executable :x2)
+                expected (cpu-linear (cpu-linear x0 W0 rows width) W1 rows width)]
+            (is (= [:x2] (vec (keys resident-outputs)))
+                "invocation returns stable resident output views without a host copy")
+            (is (< (relative-max-error actual expected) 2.0e-2)
+                (str "linked mixed-precision GEMMs must match the CPU composition; relative max "
+                     (relative-max-error actual expected)))))
+        (finally
+          (gpu-link/close! executable)
+          (is (false? (:closed? @session))
+              "closing an attached linked executable does not close its caller session")
+          (is (empty? (:prepared @session)) "attached phase bindings are released")
+          (is (empty? (:graphs @session)) "attached graph recordings are released")
+          (is (empty? (:buffers @session)) "attached allocation registrations are released")
+          (gpu/close-session! session))))))


### PR DESCRIPTION
## Summary

- add pure LinkNode, LinkInstance, and LinkPlan values with pre-driver validation of views, ABI/ranges, effects, aliases, ownership, and ordered outputs
- instantiate plans as owned or caller-attached resident executables, including explicit external-buffer import, pending input/state initialization, stable BufferViews, and deterministic lifecycle cleanup
- extend the shared descriptor-step binder to accept checked resident views and own OpenCL sub-buffer handles
- exercise two compiler-emitted multi-kernel GEMM graphs through the public linker with a device-only intermediate; no attention- or GEMM-specific linker path

## Verification

- 17 tests / 74 assertions: LinkPlan, executable dispatch, and live public composition
- 38 tests / 165 assertions: surrounding resident graph, OpenCL session, and range-transfer gates
- full local suite: 2,293 tests / 34,064 assertions; the only failure was the documented pre-existing OpenCL untouched-byte range-copy flake, and its isolated rerun passed 11 tests / 33 assertions
- cljfmt passes on every changed Clojure file
- clj-kondo reports 0 errors; remaining warnings are existing macro/typed-var resolution limitations

CircleCI has no GPU, so local Level Zero/OpenCL execution is the device gate.