### PR TITLE
Add semantic resident program stages

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -111,6 +111,12 @@ value over one replay graph. It can also attach to a caller session and import
 borrowed/external allocations without taking ownership, which is the boundary
 needed by paged cache managers.
 
+`ProgramStage` supplies the corresponding replacement seam for external runtime
+effects. A frontend declares stable state/output anchors; Raster derives the
+unique minimal descriptor interval from checked executable ABIs, proves its
+live boundary, and projects ordinary before/selected/after descriptors. Paged
+attention is the first consumer, not a special compiler pass or linker mode.
+
 The remaining value-layer convergence is narrower: port the pretrained decoder
 from handwritten buffer-name inspection, then make ordinary `Compiled` values
 produce and consume the same plan/node interface. `Compiled` still keeps its

--- a/design/link-plan.md
+++ b/design/link-plan.md
@@ -93,3 +93,7 @@ explicit while still allowing pretrained runtimes to allocate first and publish 
 For paged attention, page allocation, cache relocation, transactional publication, batching and
 request scheduling remain runtime responsibilities. Raster receives borrowed/external node views
 and composes routed attention or paged append descriptors exactly like any other semantic program.
+When such a runtime replaces an interval of a compiled descriptor,
+`raster.compiler.ir.program-stage` selects and validates that interval from declared state/output
+effects and projects its before/selected/after descriptors. Those projections remain ordinary
+`LinkInstance` inputs; the linker still contains no attention-specific path.

--- a/design/program-stages.md
+++ b/design/program-stages.md
@@ -1,0 +1,45 @@
+# Semantic stages in resident program descriptors
+
+`raster.compiler.ir.program-stage` defines the narrow boundary for replacing part of an already
+compiled resident descriptor when a runtime owns effects inside that part. Paged cache management
+is the first consumer, but the compiler contract contains no attention vocabulary.
+
+A stage declaration names:
+
+- a stable semantic identity;
+- persistent state written by the stage;
+- ordinary values exported by the stage;
+- optional internal anchors needed to constrain the interval.
+
+Raster derives ordered reads and writes from each step's checked executable ABI. Every anchor must
+have exactly one writer. The unique minimal interval containing those writers is accepted only when
+every value live after the interval is classified as state or output and every declared effect is
+actually written. Selection therefore cannot silently use a first matching kernel name, output
+spelling, or step index.
+
+```clojure
+(require '[raster.compiler.ir.program-stage :as stage])
+
+(def routed-boundary
+  (stage/select layer-descriptor
+                {:id :routed-cache-attention
+                 :state #{'key-cache 'value-cache}
+                 :outputs #{'attention-output}}))
+
+(def layer-parts (stage/partition layer-descriptor routed-boundary))
+;; => {:before descriptor, :selected descriptor, :after descriptor}
+```
+
+The projected descriptors retain the compiler's original parameter order and scalar/size closures,
+while unused scratch-allocation contracts are removed. Each non-empty projection can therefore be
+instantiated as an ordinary `LinkInstance`; no second graph or attention-specific linker exists.
+
+State and outputs may escape the complete descriptor and need not be locally live after the stage.
+They must still be unique anchored writes. Conversely, an internal anchor may not be live outside
+the selected interval. A runtime replacement consumes `ProgramStage.inputs`, supplies its declared
+outputs/state effects, and composes the before/after projections through the same resident views.
+
+This API deliberately does not promise arbitrary binary linking or infer semantic operations from
+kernel names. The application/compiler frontend declares the semantic effect boundary, and Raster
+proves that the emitted descriptor still realizes it. If fusion later moves or combines kernels,
+the contract either resolves to the new unique effect span or fails loudly.

--- a/src/raster/compiler/ir/program_stage.clj
+++ b/src/raster/compiler/ir/program_stage.clj
@@ -1,0 +1,242 @@
+(ns raster.compiler.ir.program-stage
+  "Pure semantic staging for compiled resident program descriptors.
+
+   A caller declares a stable stage identity plus the state and value effects that form its public
+   boundary. Raster finds the unique minimal ordered step interval implementing those effects,
+   derives its inputs and internal writes from checked executable ABIs, and rejects ambiguous or
+   leaking boundaries. This is operation-neutral: attention, solvers, collectives and external I/O
+   use the same effect contract."
+  (:refer-clojure :exclude [partition])
+  (:require [clojure.set :as set]
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-executable :as kexec]))
+
+(defrecord ProgramStage [id start end inputs outputs state internal writes steps attributes])
+
+(defn program-stage?
+  [value]
+  (and value (= "raster.compiler.ir.program_stage.ProgramStage"
+                (.getName (class value)))))
+
+(defn- validate-descriptor!
+  [descriptor]
+  (when-not (and (map? descriptor) (vector? (:steps descriptor)) (seq (:steps descriptor))
+                 (vector? (:all-params descriptor)) (vector? (:array-params descriptor))
+                 (vector? (:scalar-params descriptor)))
+    (throw (ex-info "program staging requires a compiled resident program descriptor"
+                    {:reason :program-stage-descriptor :descriptor descriptor})))
+  descriptor)
+
+(defn- slot-access
+  [{:keys [kind role]}]
+  (cond
+    (= :inout role) :read-write
+    (= :input kind) :read
+    (= :output kind) :write
+    :else nil))
+
+(defn- merge-access
+  [left right]
+  (cond
+    (nil? left) right
+    (nil? right) left
+    (= left right) left
+    :else :read-write))
+
+(defn- reads?
+  [access]
+  (contains? #{:read :read-write} access))
+
+(defn- writes?
+  [access]
+  (contains? #{:write :read-write} access))
+
+(defn- step-interface
+  [step]
+  (or (:artifact step)
+      (some-> (:dispatch step) kdispatch/default-alternative)
+      (throw (ex-info "program stage step has no executable interface"
+                      {:reason :program-stage-interface
+                       :phase (:phase step) :convention (:convention step)}))))
+
+(defn step-accesses
+  "Return `{compiler-symbol :read|:write|:read-write}` for one descriptor step.
+
+   Access comes from the executable ABI, not parameter spelling conventions. Scatter retains its
+   explicit three-buffer contract until it is represented by an ordinary executable ABI."
+  [step]
+  (if (= :scatter (:convention step))
+    (let [[output source index :as arrays] (:arrays step)]
+      (when-not (and (= 3 (count arrays)) (every? symbol? arrays))
+        (throw (ex-info "program stage scatter requires output, source and index symbols"
+                        {:reason :program-stage-scatter :phase (:phase step) :arrays arrays})))
+      {output :write source :read index :read})
+    (let [interface (kexec/validate! (step-interface step))
+          logical-names (kabi/pointer-binding-names (kexec/abi interface))
+          pointer-specs (filterv #(not= :scalar (:kind %)) (:argument-specs step))
+          symbols (mapv :sym pointer-specs)
+          slots-by-logical (group-by #(or (:binding %) (:name %))
+                                     (kabi/pointer-slots (kexec/abi interface)))]
+      (when-not (= (count logical-names) (count symbols))
+        (throw (ex-info "program stage pointer plan differs from its executable ABI"
+                        {:reason :program-stage-abi :phase (:phase step)
+                         :symbols symbols :abi-bindings logical-names})))
+      (when-not (every? symbol? symbols)
+        (throw (ex-info "program stage pointer plan requires compiler symbols"
+                        {:reason :program-stage-symbols :phase (:phase step)
+                         :symbols symbols})))
+      (reduce (fn [accesses [symbol logical-name]]
+                (let [access (reduce merge-access nil
+                                     (map slot-access (get slots-by-logical logical-name)))]
+                  (when-not access
+                    (throw (ex-info "program stage ABI pointer has no readable or writable effect"
+                                    {:reason :program-stage-access :phase (:phase step)
+                                     :symbol symbol :binding logical-name})))
+                  (update accesses symbol merge-access access)))
+              {}
+              (map vector symbols logical-names)))))
+
+(defn descriptor-accesses
+  "Return the ordered per-step access maps of a resident descriptor."
+  [descriptor]
+  (mapv step-accesses (:steps (validate-descriptor! descriptor))))
+
+(defn- symbols-read
+  [accesses]
+  (into #{} (keep (fn [[symbol access]] (when (reads? access) symbol))) accesses))
+
+(defn- symbols-written
+  [accesses]
+  (into #{} (keep (fn [[symbol access]] (when (writes? access) symbol))) accesses))
+
+(defn- stage-inputs
+  [accesses]
+  (:inputs
+   (reduce (fn [{:keys [written] :as state} step]
+             (let [reads (symbols-read step)
+                   writes (symbols-written step)]
+               (-> state
+                   (update :inputs into (set/difference reads written))
+                   (update :written into writes))))
+           {:inputs #{} :written #{}}
+           accesses)))
+
+(defn select
+  "Select and validate one replaceable semantic stage.
+
+   Contract keys:
+   - `:id` is the stable semantic identity.
+   - `:state` names externally persistent values written by the stage.
+   - `:outputs` names ordinary values exported to later steps or the program result.
+   - `:internal` names uniquely-written values used only to constrain the interval.
+   - `:anchors` may override the union of those three effect classes.
+   - `:attributes` is inspectable caller metadata.
+
+   Every anchor must have exactly one writer. The minimal span containing those writers must
+   classify every live value escaping the span as state or output; otherwise selection fails
+   rather than silently cutting through a dependency."
+  [descriptor {:keys [id state outputs internal anchors attributes]
+               :or {state #{} outputs #{} internal #{} attributes {}}}]
+  (let [descriptor (validate-descriptor! descriptor)
+        state (set state)
+        outputs (set outputs)
+        internal (set internal)
+        classified (set/union state outputs internal)
+        anchors (set (or anchors classified))
+        accesses (descriptor-accesses descriptor)]
+    (when (nil? id)
+      (throw (ex-info "program stage requires a stable identity"
+                      {:reason :program-stage-id})))
+    (when-not (and (every? symbol? state) (every? symbol? outputs) (every? symbol? internal)
+                   (every? symbol? anchors) (map? attributes))
+      (throw (ex-info "program stage effects must be symbol sets and attributes must be a map"
+                      {:reason :program-stage-contract :state state :outputs outputs
+                       :internal internal :anchors anchors :attributes attributes})))
+    (when-not (= (+ (count state) (count outputs) (count internal)) (count classified))
+      (throw (ex-info "program stage state, outputs and internal anchors must be disjoint"
+                      {:reason :program-stage-effect-overlap
+                       :state state :outputs outputs :internal internal})))
+    (when-not (and (seq anchors) (set/subset? classified anchors))
+      (throw (ex-info "program stage anchors must include every classified effect"
+                      {:reason :program-stage-anchors :anchors anchors
+                       :required classified})))
+    (when-let [unclassified (seq (set/difference anchors classified))]
+      (throw (ex-info "program stage anchors must be classified as state, output or internal"
+                      {:reason :program-stage-unclassified-anchor :anchors (set unclassified)})))
+    (let [writers-by-symbol
+          (into {}
+                (map (fn [symbol]
+                       [symbol
+                        (into []
+                              (keep-indexed (fn [index step]
+                                              (when (writes? (get step symbol)) index)))
+                              accesses)]))
+                anchors)]
+      (doseq [[symbol writers] writers-by-symbol]
+        (when-not (= 1 (count writers))
+          (throw (ex-info "program stage anchor must have exactly one ordered writer"
+                          {:reason :program-stage-ambiguous-anchor :stage id
+                           :symbol symbol :writers writers}))))
+      (let [writer-indexes (mapv (comp first val) writers-by-symbol)
+            start (apply min writer-indexes)
+            end (inc (apply max writer-indexes))
+            selected-accesses (subvec accesses start end)
+            after-accesses (subvec accesses end)
+            writes (into #{} (mapcat symbols-written) selected-accesses)
+            reads-after (into #{} (mapcat symbols-read) after-accesses)
+            result-write (let [result (:result-sym descriptor)]
+                           (if (and (symbol? result) (contains? writes result)) #{result} #{}))
+            boundary-writes (set/union (set/intersection writes reads-after)
+                                       result-write)
+            declared-boundary (set/union state outputs)
+            missing-boundary (set/difference boundary-writes declared-boundary)
+            unwritten-effects (set/difference classified writes)]
+        ;; Declared state/outputs may intentionally escape the whole descriptor and therefore be
+        ;; dead under descriptor-local liveness. They must be written; every locally live write,
+        ;; however, must be classified.
+        (when (or (seq missing-boundary) (seq unwritten-effects))
+          (throw (ex-info "program stage boundary effects differ from its declared state and outputs"
+                          {:reason :program-stage-boundary :stage id
+                           :declared declared-boundary :live boundary-writes
+                           :missing missing-boundary :unwritten unwritten-effects
+                           :range [start end]})))
+        (->ProgramStage id start end (stage-inputs selected-accesses) outputs state internal writes
+                        (subvec (:steps descriptor) start end) attributes)))))
+
+(defn- projected-descriptor
+  [descriptor stage part [start end]]
+  (when (< start end)
+    (let [steps (subvec (:steps descriptor) start end)
+          used-symbols (into #{} (mapcat (comp keys step-accesses)) steps)]
+      (-> descriptor
+          (assoc :steps steps
+                 :allocs (filterv #(contains? used-symbols (:sym %)) (:allocs descriptor))
+                 :array-roles (select-keys (:array-roles descriptor) used-symbols)
+                 :stage {:id (:id stage) :part part :source-range [start end]
+                         :inputs (:inputs stage) :outputs (:outputs stage)
+                         :state (:state stage) :internal (:internal stage)
+                         :attributes (:attributes stage)})))))
+
+(defn partition
+  "Project a descriptor into optional `:before`, non-empty `:selected`, and optional `:after`
+   descriptors around a validated ProgramStage. Scalar/all-parameter order is preserved so the
+   compiler-authored size and scalar closures remain valid; unused scratch allocation contracts
+   are removed from each projection."
+  [descriptor stage]
+  (let [descriptor (validate-descriptor! descriptor)
+        stage (if (program-stage? stage)
+                stage
+                (throw (ex-info "program stage partition requires a ProgramStage"
+                                {:reason :program-stage-type :actual (type stage)})))
+        n (count (:steps descriptor))
+        start (:start stage)
+        end (:end stage)]
+    (when-not (and (<= 0 start) (< start end) (<= end n)
+                   (= (:steps stage) (subvec (:steps descriptor) start end)))
+      (throw (ex-info "program stage does not identify this descriptor interval"
+                      {:reason :program-stage-mismatch :stage (:id stage)
+                       :range [start end] :step-count n})))
+    {:before (projected-descriptor descriptor stage :before [0 start])
+     :selected (projected-descriptor descriptor stage :selected [start end])
+     :after (projected-descriptor descriptor stage :after [end n])}))

--- a/test/raster/compiler/ir/program_stage_test.clj
+++ b/test/raster/compiler/ir/program_stage_test.clj
@@ -1,0 +1,114 @@
+(ns raster.compiler.ir.program-stage-test
+  (:require [clojure.set :as set]
+            [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.link-plan :as link]
+            [raster.compiler.ir.program-stage :as stage]
+            [raster.compiler.pipeline :as pipeline]
+            [raster.core :refer [deftm]]
+            [raster.dl.attention :as attention]
+            [raster.dl.nn :as nn]))
+
+(deftm staged-attention!
+  [q :- (Array float) qr :- (Array float) k :- (Array float) v :- (Array float)
+   kc :- (Array float) vc :- (Array float) at :- (Array float) sc :- (Array float)
+   output :- (Array float)
+   pos :- (Array long) context-length :- (Array long)
+   max-position :- Long scale :- Float] :- Void
+  (nn/residual-add! q q qr 4)
+  (attention/kv-append-buf! k kc 4 pos)
+  (attention/kv-append-buf! v vc 4 pos)
+  (attention/gqa-decode-attention-buf!
+   qr kc vc at sc context-length 1 1 1 4 max-position scale)
+  (nn/residual-add! at q output 4))
+
+(defn- descriptor []
+  (pipeline/compile-gpu-program #'staged-attention! :ze:0 :dtype :float))
+
+(defn- projection-bindings
+  [descriptor]
+  (let [symbols (into #{} (mapcat (comp keys stage/step-accesses)) (:steps descriptor))]
+    (into {} (map (fn [symbol] [symbol (keyword (name symbol))])) symbols)))
+
+(deftest semantic-stage-is-selected-by-declared-effects-not-step-or-kernel-names
+  (let [program (descriptor)
+        selected (stage/select program {:id :routed-cache-attention
+                                        :state #{'kc 'vc}
+                                        :outputs #{'at}
+                                        :attributes {:replacement :routed}})
+        parts (stage/partition program selected)]
+    (is (stage/program-stage? selected))
+    (is (= :routed-cache-attention (:id selected)))
+    (is (set/subset? #{'k 'v 'qr 'pos 'context-length} (:inputs selected)))
+    (is (= #{'kc 'vc} (:state selected)))
+    (is (= #{'at} (:outputs selected)))
+    (is (seq (get-in parts [:before :steps])))
+    (is (seq (get-in parts [:selected :steps])))
+    (is (seq (get-in parts [:after :steps])))
+    (is (= (count (:steps program))
+           (reduce + (map #(count (:steps %)) (vals parts)))))
+    (is (= {:id :routed-cache-attention :part :selected
+            :source-range [(:start selected) (:end selected)]
+            :inputs (:inputs selected) :outputs #{'at} :state #{'kc 'vc}
+            :internal #{}
+            :attributes {:replacement :routed}}
+           (:stage (:selected parts))))
+    (testing "a stage output may escape the complete descriptor rather than feed a later step"
+      (let [tail (stage/select program {:id :external-output :outputs #{'output}})]
+        (is (= (count (:steps program)) (:end tail)))
+        (is (nil? (:after (stage/partition program tail))))))
+    (testing "the projected descriptors compose through the ordinary public LinkPlan"
+      (let [nodes [(link/node {:id :q :dtype :float :shape [4] :device :ze:0
+                               :role :input :source (float-array 4)})
+                   (link/node {:id :qr :dtype :float :shape [4] :device :ze:0
+                               :role :internal})
+                   (link/node {:id :k :dtype :float :shape [4] :device :ze:0
+                               :role :input :source (float-array 4)})
+                   (link/node {:id :v :dtype :float :shape [4] :device :ze:0
+                               :role :input :source (float-array 4)})
+                   (link/node {:id :kc :dtype :float :shape [32] :device :ze:0
+                               :role :state :source (float-array 32)})
+                   (link/node {:id :vc :dtype :float :shape [32] :device :ze:0
+                               :role :state :source (float-array 32)})
+                   (link/node {:id :at :dtype :float :shape [4] :device :ze:0
+                               :role :internal})
+                   (link/node {:id :sc :dtype :float :shape [8] :device :ze:0
+                               :role :internal})
+                   (link/node {:id :output :dtype :float :shape [4] :device :ze:0
+                               :role :output})
+                   (link/node {:id :pos :dtype :long :shape [1] :device :ze:0
+                               :role :input :source (long-array [0])})
+                   (link/node {:id :context-length :dtype :long :shape [1] :device :ze:0
+                               :role :input :source (long-array [1])})]
+            scalars {'max-position 8 'scale (float 0.5)}
+            instances (mapv (fn [[id descriptor]]
+                              (link/instance {:id id :descriptor descriptor
+                                              :bindings (projection-bindings descriptor)
+                                              :scalars scalars}))
+                            [[:pre (:before parts)]
+                             [:replaceable (:selected parts)]
+                             [:post (:after parts)]])]
+        (is (link/link-plan?
+             (link/make {:id :staged-attention :target :ze:0 :nodes nodes
+                         :instances instances :outputs [:output]})))))))
+
+(deftest staging-fails-loudly-on-ambiguous-or-leaking-effect-contracts
+  (let [program (descriptor)]
+    (testing "an anchor may not be selected by first/last name-search heuristics"
+      (let [at-step (some #(when (= :write (get (stage/step-accesses %) 'at)) %) (:steps program))
+            ambiguous (update program :steps conj at-step)]
+        (is (= :program-stage-ambiguous-anchor
+               (:reason
+                (ex-data
+                 (try
+                   (stage/select ambiguous {:id :ambiguous
+                                            :state #{'kc 'vc} :outputs #{'at}})
+                   (catch clojure.lang.ExceptionInfo error error))))))))
+    (testing "every external write crossing the interval is part of the semantic contract"
+      (is (= :program-stage-unclassified-anchor
+             (:reason
+              (ex-data
+               (try
+                 (stage/select program {:id :missing-state
+                                        :state #{'kc} :outputs #{'at}
+                                        :anchors #{'kc 'vc 'at}})
+                 (catch clojure.lang.ExceptionInfo error error)))))))))


### PR DESCRIPTION
## Summary

- add pure ProgramStage values that select a stable semantic descriptor interval from declared state/output/internal effects
- derive ordered reads and writes from checked executable ABIs, requiring unique writers and rejecting ambiguous, unwritten, or leaking boundaries
- project optional before/after plus selected resident descriptors while preserving compiler parameter/scalar closures and filtering unused scratch contracts
- prove each projection composes through the ordinary LinkPlan API; no attention-specific linker or compiler pass

## Pretrained proof

Against pretrained-rstr origin/main, the actual generated Gemma layer contract with state kc/vc and output at resolves to 10 pre steps, a unique 5-step replaceable interval, and 14 post steps. Its input interface is derived as kr, posbuf, v, qr, and clenbuf. This replaces the current raw ABI output-name scan after squash.

## Verification

- focused ProgramStage tests: real compiler-emitted append/attention chain, LinkPlan projection composition, external outputs, ambiguous anchors, and unclassified effects
- broader compiler/link/runtime gate: 50 tests / 263 assertions, including live Level Zero GEMM composition and OpenCL attention execution
- cljfmt passes on every changed Clojure file
- clj-kondo reports 0 errors; one expected TypedClojure macro-resolution warning remains

CircleCI has no GPU; local Level Zero/OpenCL execution remains the device gate.