### PR TITLE
Separate link ownership from value readiness

### DIFF
--- a/design/link-plan.md
+++ b/design/link-plan.md
@@ -75,6 +75,11 @@ kernel storage, materialized view handles, and allocation registrations that it 
 or external plan allocations are supplied as `{allocation-id DeviceBuffer}` through
 `:external-buffers` and are never freed by Raster.
 
+Allocation ownership is deliberately independent of value readiness. Importing external storage
+does not initialize an `:internal` or `:output` node; it still needs an ordered producer. Declare a
+caller-supplied value as `:input`, `:constant`, or `:state` so validation records that semantic
+boundary explicitly.
+
 Owned `:input`/`:constant`/`:state` nodes without a plan initializer are tracked as pending. Replay
 fails until `gpu-link/upload!` initializes them. This makes input and first-use state readiness
 explicit while still allowing pretrained runtimes to allocate first and publish or upload later.

--- a/src/raster/compiler/ir/link_plan.clj
+++ b/src/raster/compiler/ir/link_plan.clj
@@ -510,11 +510,12 @@
                     {:reason :link-target-convention :target target :convention :scatter})))
   (let [step-facts (mapcat #(validate-instance-bindings! nodes %) instances)
         initialized (volatile! (into #{}
-                                     (keep (fn [[id {:keys [role source view]}]]
+                                     (keep (fn [[id {:keys [role source]}]]
+                                             ;; Ownership answers who releases storage, not whether
+                                             ;; the storage contains a value. In particular, an
+                                             ;; imported :internal node still needs an ordered writer.
                                              (when (or source
-                                                       (contains? #{:input :constant :state} role)
-                                                       (contains? #{:borrowed :external}
-                                                                  (get-in view [:allocation :ownership])))
+                                                       (contains? #{:input :constant :state} role))
                                                id)))
                                      nodes))
         written (volatile! #{})]

--- a/test/raster/compiler/ir/link_plan_test.clj
+++ b/test/raster/compiler/ir/link_plan_test.clj
@@ -145,6 +145,18 @@
                                                (instance :producer :x :w0 :hidden)]
                                    :outputs [:out]}))
                                (catch clojure.lang.ExceptionInfo e e))))))))
+  (testing "external storage does not initialize an internal value"
+    (let [hidden (link/node {:id :hidden :dtype :float :shape [16] :device :ze:0
+                             :role :internal :ownership :external})]
+      (is (= :link-read-before-write
+             (:reason (ex-data (try
+                                 (link/make
+                                  {:id :external-order :target :ze:0
+                                   :nodes [(n :w :constant (float-array 16)) hidden
+                                           (n :out :output)]
+                                   :instances [(instance :consumer :hidden :w :out)]
+                                   :outputs [:out]})
+                                 (catch clojure.lang.ExceptionInfo e e))))))))
 
 (deftest physical-view-aliases-are-explicit-and-effect-checked
   (let [allocation (bview/allocation {:id :shared :byte-size 96 :memory-space :device


### PR DESCRIPTION
Summary:
- stop treating borrowed/external storage as an initialized LinkPlan value
- preserve semantic initialization through input, constant, state, or explicit source roles
- document the ownership/readiness distinction and cover external internal scratch with a regression test

Verification:
- focused link-plan suite: 4 tests, 14 assertions, green
- clj-kondo: 0 errors (2 pre-existing unresolved-var warnings)
- full suite: 2297 tests / 34085 assertions; 2 unrelated device-sensitive failures: split-K autotune selected 4 while the test requires at least 8 (measured 7.0x improvement), and OpenCL range-copy observed 1.4E-45 in an untouched destination element instead of 0.0