### PR TITLE
Certify resident program LinkPlan lowering

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -117,11 +117,14 @@ unique minimal descriptor interval from checked executable ABIs, proves its
 live boundary, and projects ordinary before/selected/after descriptors. Paged
 attention is the first consumer, not a special compiler pass or linker mode.
 
-The remaining value-layer convergence is narrower: port the pretrained decoder
-from handwritten buffer-name inspection, then make ordinary `Compiled` values
-produce and consume the same plan/node interface. `Compiled` still keeps its
-session internal and its public shape information is flat, so independently
-created `Compiled` values cannot yet be rebound into one plan directly.
+The pretrained decoder now composes through declared `ProgramStage` boundaries and `LinkPlan`
+node identities rather than handwritten buffer-name inspection. An ordinary resident descriptor
+also has a pure certifying conversion into a one-instance plan: the checkable witness preserves
+parameter order, pointer/value identity, scalar specialization, roles, realized view contracts,
+schedule, aliases, target, and outputs. The remaining value-layer convergence is runtime-facing:
+make `Compiled` instantiate and invoke that certified plan, then permit independently created
+`Compiled` values to rebind into one plan without host copies. `Compiled` still keeps its session
+internal and its public shape information is flat.
 
 Artifact linking and value rebinding are not runtime conveniences. They are
 compiler primitives required for competitive model execution.

--- a/design/link-plan.md
+++ b/design/link-plan.md
@@ -3,13 +3,24 @@
 `LinkPlan` is Raster's public, backend-neutral boundary for composing compiled resident program
 descriptors without decoding kernel names or copying intermediate values through the host.
 
-The boundary has two layers:
+The boundary has three layers:
 
 - `raster.compiler.ir.link-plan` contains immutable compiler values and pure validation;
+- `raster.compiler.ir.resident-plan` certifies the lowering of an ordinary resident descriptor;
 - `raster.gpu.link` instantiates a validated plan into resident allocations and one replay graph.
 
 No attention, GEMM, quantization, or model-layer convention exists in the linker. A descriptor step
 may select a `KernelArtifact` or `KernelGraph`; both pass through the common executable-step binder.
+
+The resident-descriptor conversion is proof-carrying in the compiler sense. It returns a
+`CertifiedResidentPlan` containing the target plan and a `ResidentPlanCertificate`. The witness
+records the source parameter order, pointer/value identity mapping, scalar specialization, roles,
+resolved schedule, target, realized value contracts, aliases, and public outputs. `verify!`
+independently re-derives those facts from the target plan and its embedded descriptor. Mutation or
+omission therefore fails before runtime contact; later layers never reconstruct this information
+from ABI spelling. This certificate proves preservation across this structural lowering boundary;
+the earlier obligation that executable kernels implement the source program remains with their own
+dialect conversions and numerical oracles.
 
 ## Values
 
@@ -92,8 +103,8 @@ explicit while still allowing pretrained runtimes to allocate first and publish 
   composite abstract value rather than an implicit tuple convention.
 - The initial dependency schedule is serial. Queue/event partitioning can lower from the same
   proven effects later without changing node or instance identity.
-- A single `Compiled` value has not yet been rebased onto `LinkPlan`; this is the next convergence
-  step after the pretrained decoder uses the semantic boundary.
+- A single resident descriptor now has a pure, certified lowering to `LinkPlan`. `Compiled` has not
+  yet been rebased onto that result; its runtime path is the next convergence step.
 
 For paged attention, page allocation, cache relocation, transactional publication, batching and
 request scheduling remain runtime responsibilities. Raster receives borrowed/external node views

--- a/src/raster/compiler/ir/link_plan.clj
+++ b/src/raster/compiler/ir/link_plan.clj
@@ -184,7 +184,12 @@
             (if (contains? array-params parameter) nil (get scalars parameter)))
           (:all-params descriptor))))
 
-(defn- pointer-symbols [descriptor]
+(defn descriptor-pointer-symbols
+  "Return the exact set of compiler symbols that the resident descriptor binds as pointers.
+
+   This is part of the public descriptor-to-LinkPlan conversion boundary. Consumers must use it
+   instead of independently reconstructing pointer membership from names or parameter roles."
+  [descriptor]
   (into #{}
         (mapcat (fn [step]
                   (if (= :scatter (:convention step))
@@ -457,7 +462,7 @@
 
 (defn- validate-instance-bindings! [nodes instance]
   (let [{:keys [id descriptor bindings roles]} instance
-        expected (pointer-symbols descriptor)
+        expected (descriptor-pointer-symbols descriptor)
         actual (set (keys bindings))]
     (when-not (= expected actual)
       (throw (ex-info "link instance bindings differ from descriptor pointer symbols"

--- a/src/raster/compiler/ir/resident_plan.clj
+++ b/src/raster/compiler/ir/resident_plan.clj
@@ -1,0 +1,230 @@
+(ns raster.compiler.ir.resident-plan
+  "Certifying conversion from one compiled resident descriptor to a one-instance LinkPlan.
+
+   `compile-gpu-program` is the source dialect: it owns ordered parameters, executable ABIs,
+   scalar/shape closures and default roles. `LinkPlan` is the target dialect: it owns stable value
+   identities, realized views, ownership and ordered effects. This namespace is the only conversion
+   between those contracts. It returns a checkable witness rather than asking a runtime to recover
+   facts from symbols, buffer names, or emitted kernels."
+  (:require [clojure.set :as set]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.link-plan :as link-plan]))
+
+(defrecord ResidentPlanCertificate
+           [source-dialect target-dialect plan-id target instance-id parameter-order
+            array-parameters scalar-parameters bindings scalars roles schedule values outputs
+            aliases])
+(defrecord CertifiedResidentPlan [plan certificate])
+
+(defn certificate? [x]
+  (instance? ResidentPlanCertificate x))
+
+(defn certified-plan? [x]
+  (instance? CertifiedResidentPlan x))
+
+(defn- primitive-array-dtype [value]
+  (when (and value (.isArray (class value)))
+    (case (.getName (.getComponentType (class value)))
+      "byte" :byte
+      "short" :half
+      "int" :int
+      "long" :long
+      "float" :float
+      "double" :double
+      nil)))
+
+(defn- array-length [symbol value]
+  (when-not (primitive-array-dtype value)
+    (throw (ex-info "resident program array arguments must be primitive JVM arrays"
+                    {:reason :resident-plan-array-argument :symbol symbol
+                     :actual (some-> value type)})))
+  (java.lang.reflect.Array/getLength value))
+
+(defn- unique-vector! [reason label values]
+  (let [values (vec values)]
+    (when-not (= (count values) (count (distinct values)))
+      (throw (ex-info (str label " must be unique and ordered")
+                      {:reason reason :values values})))
+    values))
+
+(defn- descriptor-environment!
+  [descriptor arguments]
+  (let [{:keys [all-params array-params scalar-params allocs]} descriptor]
+    (when-not (and (map? descriptor) (vector? all-params) (vector? array-params)
+                   (vector? scalar-params) (vector? allocs) (vector? (:steps descriptor)))
+      (throw (ex-info "resident-plan lowering requires a complete resident descriptor"
+                      {:reason :resident-plan-descriptor :descriptor descriptor})))
+    (unique-vector! :resident-plan-parameters "resident descriptor parameters" all-params)
+    (when-not (= (count all-params) (count arguments))
+      (throw (ex-info "resident-plan arguments differ from the descriptor parameter order"
+                      {:reason :resident-plan-arguments :parameters all-params
+                       :expected (count all-params) :actual (count arguments)})))
+    (let [parameter-set (set all-params)
+          array-set (set array-params)
+          scalar-set (set scalar-params)]
+      (when-not (and (set/subset? array-set parameter-set)
+                     (set/subset? scalar-set parameter-set)
+                     (empty? (set/intersection array-set scalar-set))
+                     (= parameter-set (set/union array-set scalar-set)))
+        (throw (ex-info "resident descriptor array/scalar parameters do not partition its ABI"
+                        {:reason :resident-plan-parameter-partition :parameters parameter-set
+                         :arrays array-set :scalars scalar-set})))
+      (when-not (= (count allocs) (count (distinct (map :sym allocs))))
+        (throw (ex-info "resident descriptor allocation symbols must be unique"
+                        {:reason :resident-plan-allocation-symbols
+                         :symbols (mapv :sym allocs)})))
+      (zipmap all-params arguments))))
+
+(defn- node-id-for [plan-id node-ids symbol]
+  (get node-ids symbol [plan-id symbol]))
+
+(defn- node-role [symbol parameter? descriptor roles output-symbols]
+  (let [role (or (get roles symbol)
+                 (when parameter? (get (:array-roles descriptor) symbol))
+                 (when (contains? output-symbols symbol) :output)
+                 (if parameter? :input :internal))]
+    (if (= :scratch role) :internal role)))
+
+(defn- value-contract [symbol origin node]
+  {:symbol symbol
+   :origin origin
+   :node (:id node)
+   :dtype (dtype/canon (get-in node [:view :dtype]))
+   :shape (get-in node [:view :shape])
+   :strides (get-in node [:view :strides])
+   :memory-space (get-in node [:view :allocation :memory-space])
+   :device (get-in node [:view :allocation :device])
+   :ownership (get-in node [:view :allocation :ownership])
+   :role (:role node)})
+
+(defn- derive-certificate [plan]
+  (let [instance (first (:instances plan))
+        descriptor (:descriptor instance)
+        symbol-by-node (set/map-invert (:bindings instance))
+        alloc-symbols (set (map :sym (:allocs descriptor)))
+        values (into {}
+                     (map (fn [[node-id node]]
+                            (let [symbol (get symbol-by-node node-id)]
+                              [symbol (value-contract symbol
+                                                      (if (contains? alloc-symbols symbol)
+                                                        :allocation :parameter)
+                                                      node)])))
+                     (:nodes plan))]
+    (->ResidentPlanCertificate
+     :resident-program :link-plan (:id plan) (:target plan) (:id instance)
+     (:all-params descriptor) (:array-params descriptor) (:scalar-params descriptor)
+     (:bindings instance) (:scalars instance) (link-plan/instance-roles plan instance)
+     (:schedule instance) values (:outputs plan) (:aliases plan))))
+
+(defn verify!
+  "Verify and return a CertifiedResidentPlan.
+
+   Verification revalidates the target plan and independently derives every witnessed fact from
+   that plan's resident descriptor, stable bindings, scalar environment and views. A stale or
+   modified certificate therefore fails before runtime instantiation."
+  [lowering]
+  (when-not (certified-plan? lowering)
+    (throw (ex-info "expected a CertifiedResidentPlan"
+                    {:reason :resident-plan-lowering-type :actual (type lowering)})))
+  (let [plan (link-plan/validate! (:plan lowering))
+        certificate (:certificate lowering)
+        expected (derive-certificate plan)]
+    (when-not (certificate? certificate)
+      (throw (ex-info "resident-plan lowering requires a ResidentPlanCertificate"
+                      {:reason :resident-plan-certificate-type :actual (type certificate)})))
+    (when-not (= expected certificate)
+      (throw (ex-info "resident-program to LinkPlan certificate does not match its target"
+                      {:reason :resident-plan-certificate
+                       :expected expected :actual certificate})))
+    lowering))
+
+(defn lower
+  "Lower one resident descriptor and its specialization arguments to a certified LinkPlan.
+
+   Options:
+   - `:id`, `:target`, `:descriptor`, and ordered `:arguments` are required;
+   - `:roles` overrides descriptor array roles;
+   - `:outputs` is an ordered vector of public output symbols (default: `:result-sym`);
+   - `:shapes` may refine the default flat parameter/allocation shapes;
+   - `:node-ids` supplies stable public identities (default `[plan-id symbol]`);
+   - `:ownership`, `:memory-space`, `:aliases`, and `:attributes` refine LinkPlan storage.
+
+   Host array arguments remain exact initializers for owned parameter allocations, including
+   output/state parameters. Borrowed/external allocations use the arguments only to specialize
+   dtype and shape; their storage and readiness are supplied explicitly at instantiation. This
+   preserves `bind-program!`'s initial-value semantics without confusing ownership with readiness."
+  [{:keys [id target descriptor arguments roles outputs shapes node-ids ownership memory-space
+           aliases attributes instance-id]
+    :or {roles {} shapes {} node-ids {} ownership {} memory-space {}
+         aliases #{} attributes {}}}]
+  (when (nil? id)
+    (throw (ex-info "resident-plan lowering requires a stable plan identity"
+                    {:reason :resident-plan-id})))
+  (let [argument-map (descriptor-environment! descriptor arguments)
+        pointer-symbols (link-plan/descriptor-pointer-symbols descriptor)
+        array-symbols (set (:array-params descriptor))
+        alloc-map (into {} (map (juxt :sym identity)) (:allocs descriptor))
+        known-pointers (set/union array-symbols (set (keys alloc-map)))
+        _ (when-not (= pointer-symbols known-pointers)
+            (throw (ex-info "resident descriptor pointer ABI has no exact value contract"
+                            {:reason :resident-plan-pointer-contract
+                             :pointers pointer-symbols :parameters array-symbols
+                             :allocations (set (keys alloc-map))
+                             :missing (set/difference pointer-symbols known-pointers)
+                             :unused (set/difference known-pointers pointer-symbols)})))
+        outputs (unique-vector!
+                 :resident-plan-outputs "resident-plan output symbols"
+                 (or outputs (when-let [result (:result-sym descriptor)] [result])))
+        _ (when-not (set/subset? (set outputs) pointer-symbols)
+            (throw (ex-info "resident-plan outputs must name descriptor pointer values"
+                            {:reason :resident-plan-output-symbols :outputs outputs
+                             :pointers pointer-symbols})))
+        output-symbols (set outputs)
+        scalar-values (select-keys argument-map (:scalar-params descriptor))
+        ordered-symbols (vec (concat (:array-params descriptor) (map :sym (:allocs descriptor))))
+        resolved-node-ids (mapv #(node-id-for id node-ids %) ordered-symbols)
+        _ (unique-vector! :resident-plan-node-ids "resident-plan node identities"
+                          resolved-node-ids)
+        nodes
+        (mapv
+         (fn [symbol]
+           (let [parameter? (contains? array-symbols symbol)
+                 argument (when parameter? (get argument-map symbol))
+                 allocation (get alloc-map symbol)
+                 default-elements (if parameter?
+                                    (array-length symbol argument)
+                                    (try (long ((:size-fn allocation) arguments))
+                                         (catch Exception error
+                                           (throw (ex-info
+                                                   "resident allocation shape did not resolve"
+                                                   {:reason :resident-plan-allocation-shape
+                                                    :symbol symbol}
+                                                   error)))))
+                 shape (vec (get shapes symbol [default-elements]))
+                 _ (when-not (= default-elements (reduce * 1 shape))
+                     (throw (ex-info "resident value shape differs from its storage extent"
+                                     {:reason :resident-plan-shape :symbol symbol
+                                      :elements default-elements :shape shape})))
+                 storage-dtype (if parameter?
+                                 (primitive-array-dtype argument)
+                                 (or (:dtype allocation) (:dtype descriptor)))
+                 node-id (node-id-for id node-ids symbol)
+                 value-ownership (get ownership symbol :owned)]
+             (link-plan/node
+              {:id node-id :allocation-id node-id :dtype storage-dtype :shape shape
+               :device target :memory-space (get memory-space symbol :device)
+               :ownership value-ownership
+               :role (node-role symbol parameter? descriptor roles output-symbols)
+               :source (when (= :owned value-ownership) argument)})))
+         ordered-symbols)
+        bindings (zipmap ordered-symbols resolved-node-ids)
+        instance (link-plan/instance
+                  {:id (or instance-id [id :instance]) :descriptor descriptor
+                   :bindings bindings :scalars scalar-values :schedule (:schedule descriptor)
+                   :roles roles})
+        plan (link-plan/make
+              {:id id :target target :nodes nodes :instances [instance]
+               :outputs (mapv bindings outputs) :aliases aliases
+               :attributes (assoc attributes :lowered-from :resident-program)})
+        lowering (->CertifiedResidentPlan plan (derive-certificate plan))]
+    (verify! lowering)))

--- a/test/raster/compiler/ir/resident_plan_test.clj
+++ b/test/raster/compiler/ir/resident_plan_test.clj
@@ -1,0 +1,153 @@
+(ns raster.compiler.ir.resident-plan-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.arrays :as arrays]
+            [raster.compiler.pipeline :as pipeline]
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.link-plan :as link]
+            [raster.compiler.ir.resident-plan :as resident]
+            [raster.core :refer [deftm]]
+            [raster.dl.nn :as nn]))
+
+(deftm production-map
+  [x :- (Array float) out :- (Array float) scale :- Float n :- Long] :- (Array float)
+  (raster.par/map! out i n float (* scale (arrays/aget x i))))
+
+(def ^:private kernel
+  (artifact/make
+   {:kernel-name "resident_axpy"
+    :source "__kernel void resident_axpy(const float* x, const float* w, float* y, long n) {}"
+    :abi [(kabi/slot 'x :input :float)
+          (kabi/slot 'w :input :float)
+          (kabi/slot 'y :output :float)
+          (kabi/slot 'n :scalar :long)]
+    :arguments '[x w y n]
+    :launch (launch/spec {:workgroup-size [64]
+                          :group-count [(launch/ceil-div 'n 64)]})
+    :effects {:kind :map :reads '[x w] :writes '[y]}}))
+
+(defn- descriptor []
+  {:dtype :float
+   :all-params '[x w n]
+   :array-params '[x w]
+   :scalar-params '[n]
+   :array-roles {'x :input 'w :input}
+   :allocs [{:sym 'y :dtype :float :size-fn (fn [args] (long (nth args 2)))}]
+   :steps [{:phase :map :convention :map :artifact kernel
+            :argument-specs [{:kind :input :sym 'x}
+                             {:kind :input :sym 'w}
+                             {:kind :output :sym 'y}
+                             {:kind :scalar :type :long
+                              :value-fn (fn [args] (long (nth args 2)))}]}]
+   :result-sym 'y})
+
+(defn- reason-of [thunk]
+  (try
+    (thunk)
+    nil
+    (catch clojure.lang.ExceptionInfo error
+      (:reason (ex-data error)))))
+
+(deftest resident-descriptor-lowers-once-to-a-certified-plan
+  (let [x (float-array 32)
+        w (float-array 32)
+        lowering (resident/lower
+                  {:id :axpy :target :ze:0 :descriptor (descriptor) :arguments [x w 32]
+                   :roles {'w :constant} :shapes {'x [4 8] 'w [4 8] 'y [4 8]}
+                   :node-ids {'x :x 'w :weight 'y :result}})
+        plan (:plan lowering)
+        certificate (:certificate lowering)]
+    (is (resident/certified-plan? lowering))
+    (is (identical? lowering (resident/verify! lowering)))
+    (is (link/link-plan? plan))
+    (is (= '[x w n] (:parameter-order certificate)) "the source ABI order is witnessed")
+    (is (= :ze:0 (:target certificate)))
+    (is (= {'x :x 'w :weight 'y :result} (:bindings certificate)))
+    (is (= {'n 32} (:scalars certificate)))
+    (is (= {'x :input 'w :constant 'y :output} (:roles certificate)))
+    (is (= [:result] (:outputs plan)))
+    (is (= [4 8] (get-in plan [:nodes :x :view :shape])))
+    (is (identical? x (get-in plan [:nodes :x :source])))
+    (is (= :allocation (get-in certificate [:values 'y :origin])))))
+
+(deftest external-ownership-is-not-mistaken-for-host-initialization
+  (let [lowering (resident/lower
+                  {:id :external :target :ze:0 :descriptor (descriptor)
+                   :arguments [(float-array 8) (float-array 8) 8]
+                   :ownership {'x :external}})
+        x-node (get-in lowering [:plan :nodes [:external 'x]])]
+    (is (= :external (get-in x-node [:view :allocation :ownership])))
+    (is (nil? (:source x-node)))
+    (is (= :input (:role x-node)))
+    (is (resident/certified-plan? lowering))))
+
+(deftest production-compiler-descriptor-crosses-the-same-certified-boundary
+  (let [n 64
+        descriptor (pipeline/compile-gpu-program #'production-map :ze:0
+                                                 :dtype :float :on-non-resident :throw)
+        lowering (resident/lower
+                  {:id :production-map :target :ze:0 :descriptor descriptor
+                   :arguments [(float-array n) (float-array n) (float 2.0) n]})]
+    (is (resident/certified-plan? lowering))
+    (is (= (:all-params descriptor)
+           (get-in lowering [:certificate :parameter-order])))
+    (is (= (set (link/descriptor-pointer-symbols descriptor))
+           (set (keys (get-in lowering [:certificate :bindings])))))
+    (is (= [(get-in lowering [:certificate :bindings (:result-sym descriptor)])]
+           (get-in lowering [:plan :outputs])))))
+
+(deftest generated-gemm-descriptor-crosses-the-same-certified-boundary
+  (let [rows 4
+        width 16
+        descriptor (pipeline/compile-gpu-program #'nn/linear-nb :ze:0
+                                                 :dtype :float :on-non-resident :throw)
+        lowering (resident/lower
+                  {:id :production-gemm :target :ze:0 :descriptor descriptor
+                   :arguments [(float-array (* rows width))
+                               (float-array (* width width)) rows width width]
+                   :shapes {'x [rows width] 'W [width width]
+                            (:result-sym descriptor) [rows width]}})]
+    (is (= [:gemm] (mapv :convention (:steps descriptor))))
+    (is (resident/certified-plan? lowering))
+    (is (= [rows width]
+           (get-in lowering [:certificate :values (:result-sym descriptor) :shape])))
+    (is (= (:schedule descriptor) (get-in lowering [:certificate :schedule])))))
+
+(deftest the-certificate-detects-lowering-drift
+  (let [lowering (resident/lower
+                  {:id :axpy :target :ze:0 :descriptor (descriptor)
+                   :arguments [(float-array 8) (float-array 8) 8]})]
+    (testing "a modified witness is rejected"
+      (is (= :resident-plan-certificate
+             (reason-of #(resident/verify!
+                          (assoc-in lowering [:certificate :scalars 'n] 9))))))
+    (testing "a modified target still passes its own structural checks but not the source witness"
+      (is (= :resident-plan-certificate
+             (reason-of #(resident/verify!
+                          (assoc-in lowering [:plan :id] :changed-plan))))))))
+
+(deftest conversion-fails-closed-before-runtime-contact
+  (testing "arguments must exactly follow the descriptor ABI"
+    (is (= :resident-plan-arguments
+           (reason-of #(resident/lower
+                        {:id :bad :target :ze:0 :descriptor (descriptor)
+                         :arguments [(float-array 8) (float-array 8)]})))))
+  (testing "logical shapes must preserve the realized storage extent"
+    (is (= :resident-plan-shape
+           (reason-of #(resident/lower
+                        {:id :bad :target :ze:0 :descriptor (descriptor)
+                         :arguments [(float-array 8) (float-array 8) 8]
+                         :shapes {'x [3 3]}})))))
+  (testing "every executable pointer requires exactly one parameter/allocation contract"
+    (let [bad (update (descriptor) :allocs empty)]
+      (is (= :resident-plan-pointer-contract
+             (reason-of #(resident/lower
+                          {:id :bad :target :ze:0 :descriptor bad
+                           :arguments [(float-array 8) (float-array 8) 8]}))))))
+  (testing "stable identities cannot accidentally alias two semantic values"
+    (is (= :resident-plan-node-ids
+           (reason-of #(resident/lower
+                        {:id :bad :target :ze:0 :descriptor (descriptor)
+                         :arguments [(float-array 8) (float-array 8) 8]
+                         :node-ids {'x :same 'w :same}}))))))


### PR DESCRIPTION
## Summary
- add the single pure conversion from a compiled resident descriptor to a one-instance LinkPlan
- return a checkable ResidentPlanCertificate covering ordered parameters, pointer/value identities, scalar specialization, roles, schedule, target, views, ownership, aliases, and outputs
- fail closed on missing contracts, shape drift, duplicate identities, or witness drift before runtime contact
- update the LinkPlan and compiler north-star documents after the completed pretrained decoder port

## Correctness scope
This certificate proves preservation across the resident-descriptor to LinkPlan structural boundary. Executable-kernel semantic correctness remains an obligation of the earlier dialect conversions and numerical oracles.

## Tests
- resident-plan namespace: 6 tests, 30 assertions
- focused LinkPlan, ProgramStage, Compiled, and live-link gate: 19 tests, 176 assertions; includes 25-step Gemma resident training and two linked generated GEMMs
- formatting check passes for all changed Clojure files

The complete suite was not launched locally because the machine currently has exhausted swap and about 6 GiB available after the earlier system OOM; CircleCI should run the device-free full gate. The live Level Zero focused gate passed locally.