### PR TITLE
Execute Compiled through certified LinkPlans

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -119,12 +119,22 @@ attention is the first consumer, not a special compiler pass or linker mode.
 
 The pretrained decoder now composes through declared `ProgramStage` boundaries and `LinkPlan`
 node identities rather than handwritten buffer-name inspection. An ordinary resident descriptor
-also has a pure certifying conversion into a one-instance plan: the checkable witness preserves
+has a pure certifying conversion into a one-instance plan: the checkable witness preserves
 parameter order, pointer/value identity, scalar specialization, roles, realized view contracts,
-schedule, aliases, target, and outputs. The remaining value-layer convergence is runtime-facing:
-make `Compiled` instantiate and invoke that certified plan, then permit independently created
-`Compiled` values to rebind into one plan without host copies. `Compiled` still keeps its session
-internal and its public shape information is flat.
+schedule, aliases, target, and outputs. `Compiled` owns that witness and invokes only its
+`LinkedExecutable`; compatible device inputs use an exact-view no-op or a device-to-device copy,
+never an implicit host round trip. The runtime preserves the certified allocation identities and
+profiles the same stable recorded-graph boundary. Each instance also retains the complete ordered
+specialization environment required by descriptor shape closures, while runtime pointers still
+come only from certified node bindings. The remaining value-layer convergence is to
+compose independently created compiled instances into one plan, where shared node identity removes
+even the device copy, then retire the duplicate legacy whole-program binding API after parity.
+
+Pretrained-rstr's batch boundary is the next concrete shape test: weights bind once to shared
+constant nodes, while residual, scratch, position, logits and token storage are lane-local nodes or
+disjoint views. Packed Q/K/V and attention views already fit LinkPlan. The missing performance work
+is a compiler shape/schedule transform that emits projection, post-attention and head programs with
+a leading logical batch dimension; batching is not a linker convention or an attention special case.
 
 Artifact linking and value rebinding are not runtime conveniences. They are
 compiler primitives required for competitive model execution.

--- a/src/raster/compiler/ir/link_plan.clj
+++ b/src/raster/compiler/ir/link_plan.clj
@@ -17,7 +17,7 @@
 (def binder-roles #{:input :constant :state :output :scratch})
 
 (defrecord LinkNode [id view role source])
-(defrecord LinkInstance [id descriptor bindings scalars schedule roles])
+(defrecord LinkInstance [id descriptor bindings scalars schedule roles arguments])
 (defrecord LinkPlan [id target nodes instances outputs aliases attributes])
 
 (defn link-node? [x]
@@ -140,7 +140,7 @@
   (when-not (link-instance? instance)
     (throw (ex-info "link plan instances must be LinkInstance values"
                     {:reason :link-instance-type :instance instance :actual (type instance)})))
-  (let [{:keys [id descriptor bindings scalars schedule roles]} instance]
+  (let [{:keys [id descriptor bindings scalars schedule roles arguments]} instance]
     (when (nil? id)
       (throw (ex-info "a link instance requires a stable identity" {:reason :link-instance-id})))
     (when-not (and (map? descriptor) (vector? (:steps descriptor))
@@ -158,6 +158,19 @@
       (throw (ex-info "link instance scalars differ from the descriptor scalar parameters"
                       {:reason :link-scalars :instance id
                        :expected (set (:scalar-params descriptor)) :actual (set (keys scalars))})))
+    (when arguments
+      (when-not (and (vector? arguments) (= (count (:all-params descriptor)) (count arguments)))
+        (throw (ex-info "link instance specialization arguments must follow descriptor order"
+                        {:reason :link-instance-arguments :instance id
+                         :parameters (:all-params descriptor)
+                         :expected (count (:all-params descriptor))
+                         :actual (when (sequential? arguments) (count arguments))})))
+      (let [environment (zipmap (:all-params descriptor) arguments)]
+        (when-not (= scalars (select-keys environment (:scalar-params descriptor)))
+          (throw (ex-info "link instance scalars differ from its specialization arguments"
+                          {:reason :link-instance-argument-scalars :instance id
+                           :scalars scalars
+                           :arguments (select-keys environment (:scalar-params descriptor))})))))
     (when-not (or (nil? schedule) (map? schedule))
       (throw (ex-info "link instance schedule must be nil or resolved schedule data"
                       {:reason :link-schedule :instance id :schedule schedule})))
@@ -170,19 +183,24 @@
 (defn instance
   "Construct one descriptor instance. `:bindings` is data—not a name-decoding function—and maps
    every pointer-valued compiler symbol used by the descriptor to a LinkNode identity. `:scalars`
-   supplies exactly the descriptor's scalar parameters."
-  [{:keys [id descriptor bindings scalars schedule roles] :or {scalars {} roles {}}}]
-  (validate-instance! (->LinkInstance id descriptor bindings scalars schedule roles)))
+   supplies exactly the descriptor's scalar parameters. Optional ordered `:arguments` retains the
+   complete compile-time specialization environment for descriptor closures whose shapes depend on
+   array parameters; runtime pointer binding still comes exclusively from `:bindings`."
+  [{:keys [id descriptor bindings scalars schedule roles arguments] :or {scalars {} roles {}}}]
+  (validate-instance! (->LinkInstance id descriptor bindings scalars schedule roles arguments)))
 
 (defn instance-arguments
-  "Build the descriptor's ordered runtime argument vector. Array positions are intentionally nil:
-   resident binding uses LinkNodes, while scalar/shape closures read their named scalar positions."
+  "Return the descriptor's ordered specialization arguments. Explicit arguments retain array
+   values for descriptor shape closures; absent arguments preserve the hand-built-plan
+   shorthand of nil array positions plus exact named scalars. Runtime pointers are never taken
+   from this vector: resident binding uses LinkNodes exclusively."
   [instance]
-  (let [{:keys [descriptor scalars]} (validate-instance! instance)
+  (let [{:keys [descriptor scalars arguments]} (validate-instance! instance)
         array-params (set (:array-params descriptor))]
-    (mapv (fn [parameter]
-            (if (contains? array-params parameter) nil (get scalars parameter)))
-          (:all-params descriptor))))
+    (or arguments
+        (mapv (fn [parameter]
+                (if (contains? array-params parameter) nil (get scalars parameter)))
+              (:all-params descriptor)))))
 
 (defn descriptor-pointer-symbols
   "Return the exact set of compiler symbols that the resident descriptor binds as pointers.
@@ -489,7 +507,7 @@
               expected-elements
               (try (long (size-fn args))
                    (catch Exception e
-                     (throw (ex-info "link descriptor allocation extent did not resolve from scalars"
+                     (throw (ex-info "link descriptor allocation extent did not resolve from its specialization environment"
                                      {:reason :link-allocation-shape :instance id :symbol sym}
                                      e))))
               actual-elements (shape-elements (get-in link-node [:view :shape]))]

--- a/src/raster/compiler/ir/resident_plan.clj
+++ b/src/raster/compiler/ir/resident_plan.clj
@@ -221,7 +221,7 @@
         instance (link-plan/instance
                   {:id (or instance-id [id :instance]) :descriptor descriptor
                    :bindings bindings :scalars scalar-values :schedule (:schedule descriptor)
-                   :roles roles})
+                   :roles roles :arguments (vec arguments)})
         plan (link-plan/make
               {:id id :target target :nodes nodes :instances [instance]
                :outputs (mapv bindings outputs) :aliases aliases

--- a/src/raster/gpu/compiled.clj
+++ b/src/raster/gpu/compiled.clj
@@ -3,10 +3,9 @@
 
    `(r/compile #'train-step args {:target :ze:0 :donate [adapters…] :constants [Wq …]})`
    returns a `Compiled` that implements `IFn`: calling it replays the resident program and
-   returns device values (`raster.gpu.value/DeviceArray`), not host arrays. It wraps today's
-   `bind-program!`/`replay-program!` with ZERO change to the kernel/graph machinery — the
-   executable still lives in the session; `Compiled` lifts the *invocation contract* to
-   values-in / values-out with donation as a boundary write-back shim.
+   returns device values (`raster.gpu.value/DeviceArray`), not host arrays. The resident
+   descriptor is certified into the same LinkPlan used for composition and instantiated as a
+   LinkedExecutable. There is one value/view/runtime path, not an artifact-only binder beside it.
 
    The three artifact primitives, honestly scoped to the whole-program MVP:
      • device value      — outputs are DeviceArrays over resident buffers; no host round-trip.
@@ -22,8 +21,10 @@
   (:refer-clojure :exclude [compile])
   (:require [clojure.set :as set]
             [raster.compiler.ir.buffer-view :as bview]
+            [raster.compiler.ir.resident-plan :as resident-plan]
             [raster.compiler.pipeline :as pl]
             [raster.gpu.core :as gpu]
+            [raster.gpu.link :as gpu-link]
             [raster.gpu.value :as v]))
 
 (declare invoke-compiled)
@@ -33,8 +34,8 @@
 ;; ================================================================
 
 (defrecord Compiled
-           [session      ;; the GPU session atom the executable lives in (MVP: not yet lifted out)
-            handle       ;; the bind-program! handle {::gpu/program-key … :descriptor …}
+           [lowering     ;; CertifiedResidentPlan: checkable descriptor→LinkPlan witness
+            executable  ;; LinkedExecutable: the sole resident runtime representation
             in-tree      ;; ordered [{:key :sym :role :donate? :shape :dtype} …] — the arg spec
             out-tree     ;; ordered [{:key :sym :shape :dtype :from} …] — the result spec (multi-output)
             donated      ;; {in-key → out-key} — the alias plan (JAX input_output_aliases)
@@ -58,8 +59,8 @@
 ;; ================================================================
 
 (defn- derive-roles
-  "Effective {sym → role} for bind-program!: donated → :state, constants → :constant, the rest
-   fall through to the descriptor's derived defaults (read-only→:input, written→:output)."
+  "Effective {sym → role} for certified LinkPlan lowering: donated → :state, constants →
+   :constant, and the rest fall through to the descriptor's derived defaults."
   [descriptor donate constants explicit-roles]
   (let [donate-set   (set donate)
         constant-set (set constants)
@@ -72,41 +73,52 @@
            (into {} (map (fn [s] [s :constant]) constant-set))
            explicit-roles)))
 
-(defn- flat-n
-  "Element count of a JVM array (the flat logical shape for the MVP)."
-  [arr]
-  (when arr (java.lang.reflect.Array/getLength arr)))
-
 (defn- build-in-tree
-  [descriptor argmap donate constants effective-roles]
-  (let [donate-set (set donate)]
+  [lowering descriptor donate]
+  (let [donate-set (set donate)
+        values (:values (:certificate lowering))]
     (vec (for [p (:array-params descriptor)
-               :let [arr (get argmap p)]]
+               :let [{:keys [node role shape dtype]} (get values p)]]
            {:key     (keyword (name p))
             :sym     p
-            :role    (get effective-roles p (get (:array-roles descriptor) p :input))
+            :node    node
+            :role    role
             :donate? (contains? donate-set p)
-            :shape   (when arr [(flat-n arr)])
-            :dtype   (:dtype descriptor)}))))
+            :shape   shape
+            :dtype   dtype}))))
 
 (defn- build-out-tree
   "Out-tree = donated in→out nodes + any explicit :outputs + the functional :result-sym + taps.
    Each projects to a DeviceArray over a resident buffer (§3.4 multi-output)."
-  [descriptor argmap donate outputs result-sym taps dtype]
-  (let [donate-nodes  (for [s donate]
-                        {:key (keyword (str (name s) "'")) :sym s
-                         :shape (when-let [a (get argmap s)] [(flat-n a)]) :dtype dtype
-                         :from :donated})
+  [lowering donate outputs result-sym taps]
+  (let [values (:values (:certificate lowering))
+        output-node (fn [key sym from]
+                      (let [{:keys [node shape dtype]} (get values sym)]
+                        {:key key :sym sym :node node :shape shape :dtype dtype :from from}))
+        donate-nodes  (for [s donate]
+                        (output-node (keyword (str (name s) "'")) s :donated))
         output-nodes  (for [s outputs]
-                        {:key (keyword (name s)) :sym s
-                         :shape (when-let [a (get argmap s)] [(flat-n a)]) :dtype dtype
-                         :from :output})
+                        (output-node (keyword (name s)) s :output))
         result-node   (when result-sym
-                        [{:key (keyword (name result-sym)) :sym result-sym
-                          :shape nil :dtype dtype :from :result}])
+                        [(output-node (keyword (name result-sym)) result-sym :result)])
         tap-nodes     (for [s taps]
-                        {:key (keyword (name s)) :sym s :shape nil :dtype dtype :from :tap})]
+                        (output-node (keyword (name s)) s :tap))]
     (vec (concat donate-nodes output-nodes result-node tap-nodes))))
+
+(defn- compilation-id
+  [fn-var target dtype descriptor args]
+  (let [m (meta fn-var)
+        qualified (symbol (str (ns-name (:ns m))) (str (:name m)))
+        arrays (set (:array-params descriptor))
+        argmap (zipmap (:all-params descriptor) args)
+        signature (mapv (fn [parameter]
+                          (let [value (get argmap parameter)]
+                            (if (contains? arrays parameter)
+                              [:array (.getName (.getComponentType (class value)))
+                               (java.lang.reflect.Array/getLength value)]
+                              value)))
+                        (:all-params descriptor))]
+    [::compiled qualified target dtype signature (:schedule descriptor)]))
 
 ;; ================================================================
 ;; Compile (the public verb)
@@ -121,7 +133,6 @@
             :dtype  :float           element dtype (default :float)
             :donate  [sym …]         resident :state threaded as values (donation)
             :constants [sym …]       frozen, captured once at bind, never per-call
-            :inputs  [sym …]         per-call uploads (default: descriptor-derived)
             :outputs [sym …]         additional written params to project as outputs
             :taps    [sym …]         internal nodes to additionally expose (§5.1)
             :roles   {sym → role}    explicit role override (last word)
@@ -142,60 +153,55 @@
         _ (when-not prog
             (throw (ex-info "compile: compile-gpu-program returned nil — a step fell back to host (non-resident). Pass :on-non-resident :throw to see which."
                             {:fn fn-var :target target})))
-        argmap    (zipmap (:all-params prog) args)
         eff-roles (derive-roles prog donate constants roles)
         result-sym (:result-sym prog)
-        sess    (gpu/make-session target)
-        handle  (try (gpu/bind-program! sess prog args eff-roles
-                                        (cond-> {} profile? (assoc :profile? true)))
-                     (catch Throwable e
-                       ;; don't leak the session's arena/buffers if bind throws (e.g. a
-                       ;; reuse-collision or a non-resident step).
-                       (try (gpu/close-session! sess) (catch Throwable _))
-                       (throw e)))
-        in-tree  (build-in-tree prog argmap donate constants eff-roles)
-        out-tree (build-out-tree prog argmap donate outputs result-sym taps dtype)
+        public-symbols (vec (distinct (concat donate outputs
+                                              (when result-sym [result-sym]) taps)))
+        lowering (resident-plan/lower
+                  {:id (compilation-id fn-var target dtype prog args)
+                   :target target :descriptor prog :arguments args
+                   :roles eff-roles :outputs public-symbols})
+        executable (gpu-link/instantiate! (:plan lowering) {:profile? profile?})
+        in-tree  (build-in-tree lowering prog donate)
+        out-tree (build-out-tree lowering donate outputs result-sym taps)
         donated  (into {} (map (fn [s] [(keyword (name s)) (keyword (str (name s) "'"))]) donate))]
-    (->Compiled sess handle in-tree out-tree donated (:schedule prog) target prog args (atom nil))))
+    (->Compiled lowering executable in-tree out-tree donated (:schedule prog) target prog args
+                (atom nil))))
 
 ;; ================================================================
 ;; Functional invocation (§2.3)
 ;; ================================================================
 
 (defn- project-node
-  "Wrap a resident output node's live session buffer as an ::external DeviceArray (the session
-   owns the buffer's lifetime; the value never frees it). Fail-loud: a requested output node with
-   no resident buffer is an error (a dropped result / tap), NOT a silent omission — the ONE
-   documented exception is a :result node whose deftm returns Void/map-void (no result buffer),
-   which yields nil and is filtered by the caller."
-  [session handle {:keys [sym shape dtype from key] :as node} target]
-  (let [k   (gpu/resident-key session handle sym)
-        buf (gpu/buffer session k)]
-    (cond
-      buf (let [view (gpu/buffer-view session k
-                                      {:dtype (or dtype (:dtype buf))
-                                       :shape (or shape [(:n-elements buf)])})]
-            (v/wrap-external-view buf target (:view view)))
-      (= from :result) nil   ;; documented Void/map-void result — no resident buffer to project
-      :else (throw (ex-info (str "invoke: requested output node " key " (" from ") resolved to no "
-                                 "resident buffer (key " k ") — the graph did not produce it")
-                            {:node node :resident-key k :available (keys (:buffers @session))})))))
+  "Wrap one linked output view as an external DeviceArray. LinkedExecutable retains allocation
+   ownership; the wrapper owns only its value lifetime."
+  [executable {:keys [node]} target]
+  (let [resident (gpu-link/node-view executable node)
+        buffer (gpu/buffer (:session executable) (:key resident))]
+    (v/wrap-external-view buffer target (:view resident))))
+
+(defn- invalidate-live-outputs!
+  [^Compiled c]
+  (when-let [live-outputs (:live-outputs c)]
+    (doseq [device-array @live-outputs] (v/free! device-array))
+    (reset! live-outputs nil))
+  c)
 
 (defn invoke-compiled
   "Replay the artifact and return device values. `inputs` : {in-key → DeviceArray|host-array}.
-     1. consume any donated-slot DeviceArrays passed in (donation-invalidation, §1.3);
-     2. assemble the args vector (captured resident contents; :input keys overridden by inputs);
-     3. replay the ONE recorded graph with NO host download (replay-program!);
-     4. project out-tree nodes as ::external DeviceArrays over the resident buffers.
+     1. write each dynamic input (host upload, exact-view no-op, or device-to-device copy);
+     2. consume exact resident donated values (donation-invalidation, §1.3);
+     3. replay the linked graph with no output download;
+     4. project out-tree nodes as external DeviceArrays over stable LinkPlan views.
    Mutation of resident :state is invisible: the caller sees fresh output values and the old
    donated inputs invalidated — never a mutation."
   [^Compiled c inputs]
-  (let [{:keys [session handle in-tree out-tree donated descriptor target args live-outputs]} c
-        key->sym     (into {} (map (juxt :key :sym)) in-tree)
+  (let [{:keys [executable in-tree out-tree donated descriptor target args]} c
         in-nodes     (into {} (map (juxt :key identity)) in-tree)
-        input-syms   (set (map :sym (filter #(= :input (:role %)) in-tree)))
-        input-keys   (set (map :key (filter #(= :input (:role %)) in-tree)))
+        input-nodes  (filterv #(= :input (:role %)) in-tree)
+        input-keys   (set (map :key input-nodes))
         donated-keys (set (keys donated))
+        captured (zipmap (:all-params descriptor) args)
         ;; 0. VALIDATE inputs: every passed key must be an :input-role param or a donated slot —
         ;;    never a :constant/:state key silently ignored (fail-loud, §7.7).
         _ (doseq [[k _v] inputs]
@@ -204,56 +210,46 @@
                                    (vec input-keys) " or donated slots " (vec donated-keys)
                                    " may be passed; a :constant/:state slot is captured at bind")
                               {:key k :inputs (keys inputs)}))))
-        ;; 1. donation-invalidation. A DeviceArray passed to a donated slot MUST be this artifact's
-        ;;    own resident value threaded back (residency IS the donation; the buffer never moves).
-        ;;    A foreign device buffer would need a rebind that does not exist yet → FAIL LOUD rather
-        ;;    than consume-and-ignore-its-contents (the silent miscompile the review caught).
+        ;; 1. Every dynamic input is refreshed on every invocation, preserving the resident-program
+        ;;    contract. gpu-link/write! accepts host values and performs D2D for foreign device
+        ;;    values; it never materializes a DeviceArray through v/->host.
+        _ (doseq [{:keys [key sym node]} input-nodes]
+            (gpu-link/write! executable node (get inputs key (get captured sym))))
+        ;; 2. Donation remains stricter than an ordinary input: the passed value must already be
+        ;;    this exact state view. Moving a foreign value and then calling it donation would hide
+        ;;    a copy and misrepresent ownership.
         _ (doseq [[k _out] donated]
             (when-let [val (get inputs k)]
-              (when (v/device-array? val)
-                (let [s    (get key->sym k)
-                      resident-key (gpu/resident-key session handle s)
-                      rbuf (gpu/buffer session resident-key)
-                      node (get in-nodes k)
-                      resident-view (gpu/buffer-view
-                                     session resident-key
-                                     {:dtype (or (:dtype node) (:dtype rbuf))
-                                      :shape (or (:shape node) [(:n-elements rbuf)])})]
-                  (when-not (and (identical? (:buffer val) rbuf)
-                                 (bview/same-range? (:view val) (:view resident-view)))
-                    (throw (ex-info (str "invoke: donated input " k " is not this artifact's resident "
-                                         "view — the MVP only supports threading the artifact's exact "
-                                         "output view back into its donated slot; a foreign allocation "
-                                         "or subview needs an explicit rebind")
-                                    {:key k})))
-                  (when (and node (:shape node) (:shape val) (not= (:shape node) (:shape val)))
-                    (throw (ex-info (str "invoke: donated input " k " shape " (:shape val)
-                                         " ≠ bound shape " (:shape node)) {:key k})))
-                  (v/consume! val)))))
-        ;; 2. assemble args: override :input-role syms (a DeviceArray :input is downloaded then
-        ;;    re-uploaded by replay — MVP limitation; device-resident :input rebind is future work).
-        argmap (reduce (fn [m [k val]]
-                         (let [s (get key->sym k)]
-                           (if (and s (contains? input-syms s))
-                             (assoc m s (if (v/device-array? val) (v/->host val) val))
-                             m)))
-                       (zipmap (:all-params descriptor) args)
-                       inputs)
-        call-args (mapv argmap (:all-params descriptor))]
+              (when-not (v/device-array? val)
+                (throw (ex-info (str "invoke: donated input " k " must be a DeviceArray naming "
+                                     "this artifact's exact resident view")
+                                {:key k :actual (type val)})))
+              (let [{node-id :node :as input-node} (get in-nodes k)
+                    resident (gpu-link/node-view executable node-id)
+                    resident-buffer (gpu/buffer (:session executable) (:key resident))]
+                (when-not (and (identical? (:buffer val) resident-buffer)
+                               (bview/same-range? (:view val) (:view resident)))
+                  (throw (ex-info (str "invoke: donated input " k " is not this artifact's resident "
+                                       "view — thread the exact donated output back")
+                                  {:key k :node node-id})))
+                (when-not (= [(:dtype input-node) (:shape input-node)]
+                             [(:dtype val) (:shape val)])
+                  (throw (ex-info (str "invoke: donated input " k " dtype/shape differs from its slot")
+                                  {:key k :expected (select-keys input-node [:dtype :shape])
+                                   :actual (select-keys val [:dtype :shape])})))
+                (v/consume! val))))]
     ;; 3. invalidate the PREVIOUS batch of outputs — they alias resident buffers this replay
     ;;    overwrites, so a retained old wrapper would observe a silent mutation (§2.3). ::external
     ;;    free! only marks the wrapper dead; it never frees the session-owned buffer.
-    (when live-outputs
-      (doseq [da @live-outputs] (v/free! da))
-      (reset! live-outputs nil))
+    (invalidate-live-outputs! c)
     ;; 4. replay, no download.
-    (gpu/replay-program! session handle call-args)
+    (gpu-link/run! executable)
     ;; 5. project outputs as resident device values; record them for next-call invalidation.
-    (let [out (into {} (keep (fn [{:keys [key] :as node}]
-                               (when-let [da (project-node session handle node target)]
-                                 [key da]))
-                             out-tree))]
-      (when live-outputs (reset! live-outputs (vec (vals out))))
+    (let [out (into {} (map (fn [{:keys [key] :as node}]
+                              [key (project-node executable node target)]))
+                    out-tree)]
+      (when-let [live-outputs (:live-outputs c)]
+        (reset! live-outputs (vec (vals out))))
       out)))
 
 ;; ================================================================
@@ -280,21 +276,57 @@
   [^Compiled c]
   (mapv #(select-keys % [:convention :phase :variant :kernel-name]) (:steps (:descriptor c))))
 
-(defn profile
-  "Device-event profile of one replay (delegates to profile-program!). The artifact must have
-   been compiled with {:profile? true}. Returns profile-program!'s map."
+(defn plan
+  "Return the validated LinkPlan that is the artifact's public executable representation."
   [^Compiled c]
-  (gpu/profile-program! (:session c) (:handle c) (:args c)))
+  (:plan (:lowering c)))
+
+(defn certificate
+  "Return the checkable resident-descriptor→LinkPlan lowering certificate."
+  [^Compiled c]
+  (:certificate (:lowering c)))
+
+(defn- refresh-captured-inputs!
+  [^Compiled c]
+  (let [captured (zipmap (get-in c [:descriptor :all-params]) (:args c))]
+    (doseq [{:keys [sym node role]} (:in-tree c) :when (= :input role)]
+      (gpu-link/write! (:executable c) node (get captured sym))))
+  c)
+
+(defn profile
+  "Device-event profile of one linked replay. The artifact must have been compiled with
+   `{:profile? true}`. Returns the historical profile map, including downloaded semantic results."
+  [^Compiled c]
+  (refresh-captured-inputs! c)
+  (invalidate-live-outputs! c)
+  (let [descriptor (:descriptor c)
+        certificate (certificate c)
+        roles (:roles certificate)
+        bindings (:bindings certificate)
+        result-sym (:result-sym descriptor)
+        output-symbols (vec (concat (for [sym (:array-params descriptor)
+                                          :when (= :output (get roles sym))]
+                                      sym)
+                                    (when (and result-sym
+                                               (not (some #{result-sym}
+                                                          (:array-params descriptor))))
+                                      [result-sym])))
+        profile-result (gpu-link/profile! (:executable c))
+        result (into {} (map (fn [sym]
+                               [sym (gpu-link/download (:executable c) (get bindings sym))]))
+                     output-symbols)]
+    (assoc profile-result :result result)))
 
 (defn measure
   "Explicit offline device-event measurement of a Compiled artifact.
 
    The artifact must have been compiled with {:profile? true}. Returns a stable Measurement;
-   options are those of gpu/measure-program!, including the required :before-sample! restore hook
+   options are those of gpu-link/measure!, including the required :before-sample! restore hook
    for stateful programs. This does not choose or cache a schedule by itself."
   [^Compiled c & {:as opts}]
-  (apply gpu/measure-program! (:session c) (:handle c) (:args c)
-         (mapcat identity opts)))
+  (refresh-captured-inputs! c)
+  (invalidate-live-outputs! c)
+  (apply gpu-link/measure! (:executable c) (mapcat identity opts)))
 
 (defn cache-key
   "The serializable identity of the artifact minus closures (§2b C5): in/out trees, donation,
@@ -309,12 +341,10 @@
    :steps    (frequencies (map :convention (:steps (:descriptor c))))})
 
 (defn close!
-  "Release the artifact's session (frees resident buffers + destroys graphs/kernels). Invalidates
+  "Release the artifact's linked executable (buffers + graph + kernels). Invalidates
    any still-live projected output values FIRST, so a `->host` on a value returned before close!
    fails loud (use-after-free) instead of copying from a zeMemFree'd segment (SIGSEGV/garbage)."
   [^Compiled c]
-  (when-let [lo (:live-outputs c)]
-    (doseq [da @lo] (v/free! da))
-    (reset! lo nil))
-  (gpu/close-session! (:session c))
+  (invalidate-live-outputs! c)
+  (gpu-link/close! (:executable c))
   nil)

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -490,7 +490,11 @@
    Topology-aware: uses zero-copy on integrated GPUs, memcpy on discrete.
 
    sess: session atom
-   buffer-specs: {key → [dtype n source-array-or-nil]}
+   buffer-specs: {key → [dtype n source-array-or-nil allocation-opts?]}
+
+   `allocation-opts`, when present, carries the same stable allocation metadata accepted by
+   register-buffer!, including :allocation-id. The fourth element affects the public allocation
+   contract only; allocation and initial upload still use the first three elements.
 
    Buffers are merged into the session — call multiple times to add more.
    If allocation fails partway through, already-allocated buffers are freed."
@@ -508,7 +512,8 @@
               (try
                 (into {}
                       (map (fn [[key buffer]]
-                             [key (allocation-contract device-id session-id key buffer :owned {})]))
+                             [key (allocation-contract device-id session-id key buffer :owned
+                                                       (or (nth (get buffer-specs key) 3 nil) {}))]))
                       new-bufs)
                 (catch Exception e
                   (free-buffers-internal! new-bufs device-id)
@@ -685,8 +690,9 @@
   phase-keys: ordered vector of phase-keys previously bound via prepare!. The kernel sequence
   and buffer pointers are fixed; buffer CONTENTS may change between replays. Stored under :graph
   (or graph-key). Re-record only if the sequence or a buffer is reallocated."
-  ([sess phase-keys] (record-graph! sess phase-keys :graph))
-  ([sess phase-keys graph-key]
+  ([sess phase-keys] (record-graph! sess phase-keys :graph {}))
+  ([sess phase-keys graph-key] (record-graph! sess phase-keys graph-key {}))
+  ([sess phase-keys graph-key {:keys [profile?] :or {profile? false}}]
    (let [device-id (:device-id @sess)
          record-fn (rt-resolve device-id "record-graph!")
          entries (mapv (fn [pk]
@@ -701,14 +707,19 @@
          graph (try
                  (when prologue-graph
                    ((rt-resolve device-id "replay-graph!") prologue-graph))
-                 (record-fn replay-prepareds)
+                 ;; Keep the non-profiling recording on the backend's exact fast path. Profiling
+                 ;; events are a graph-construction property, not a replay flag.
+                 (if profile?
+                   (record-fn replay-prepareds {:barriers? true :profile? true})
+                   (record-fn replay-prepareds))
                  (catch Exception e
                    (destroy-recorded-graph-entry! device-id prologue-graph)
                    (throw e)))
-         entry (if prologue-graph
+         entry (if (or prologue-graph profile?)
                  {::recorded-graph true
                   :replay-graph graph
-                  :prologue-graph prologue-graph}
+                  :prologue-graph prologue-graph
+                  :profile? (boolean profile?)}
                  graph)]
      (destroy-recorded-graph-entry! device-id (get-in @sess [:graphs graph-key]))
      (swap! sess assoc-in [:graphs graph-key] entry)
@@ -722,7 +733,12 @@
          entry (or (get-in @sess [:graphs graph-key])
                    (throw (ex-info (str "No graph: " graph-key " — call record-graph! first") {})))
          graph (if (recorded-graph-entry? entry) (:replay-graph entry) entry)]
-     ((rt-resolve device-id "replay-graph!") graph))))
+     ((rt-resolve device-id "replay-graph!") graph)
+     ;; A normal replay intentionally discards profiling data, just like run-program!. Events
+     ;; must be reset before the next replay; profile-recorded-graph! reads and resets instead.
+     (when (and (recorded-graph-entry? entry) (:profile? entry))
+       (when-let [reset-fn (rt-resolve-soft device-id "reset-graph-events!")]
+         (reset-fn graph))))))
 
 (defn release-recorded-graph!
   "Release one graph recorded by record-graph!. Idempotent. Prepared executable steps and their
@@ -2365,6 +2381,30 @@
        :device-wall-ms (:wall-ms prof)
        :host-wall-ms (/ (- t1 t0) 1.0e6)})))
 
+(defn profile-recorded-graph!
+  "Replay a graph recorded by record-graph! with `{:profile? true}` and return its backend-neutral
+   device-event profile. Unlike replay!, this consumes (and resets) the timestamps instead of
+   discarding them. The graph representation remains private to the session layer."
+  [sess graph-key]
+  (let [device-id (:device-id @sess)
+        entry (or (get-in @sess [:graphs graph-key])
+                  (throw (ex-info (str "No graph: " graph-key " — call record-graph! first")
+                                  {:graph-key graph-key})))
+        graph (if (recorded-graph-entry? entry) (:replay-graph entry) entry)]
+    (when-not (and (recorded-graph-entry? entry) (:profile? entry))
+      (throw (ex-info "recorded graph was not created with {:profile? true}"
+                      {:graph-key graph-key})))
+    (let [replay-fn (rt-resolve device-id "replay-graph!")
+          read-ts-fn (rt-resolve device-id "read-graph-timestamps!")
+          t0 (System/nanoTime)
+          _ (replay-fn graph)
+          t1 (System/nanoTime)
+          prof (read-ts-fn graph)]
+      {:profile (mapv #(select-keys % [:kernel-name :phase :ms :context-ms]) (:kernels prof))
+       :kernel-total-ms (reduce + 0.0 (map :ms (:kernels prof)))
+       :device-wall-ms (:wall-ms prof)
+       :host-wall-ms (/ (- t1 t0) 1.0e6)})))
+
 (defn measure-graph!
   "Repeatedly measure a PROFILING runtime graph with backend device events.
 
@@ -2394,6 +2434,19 @@
                              (dissoc :before-sample!)
                              (assoc :timing-source :device-event))]
     (apply measurement/measure! sample-fn (mapcat identity measurement-opts))))
+
+(defn measure-recorded-graph!
+  "Repeatedly measure a session graph recorded with `{:profile? true}`. This is the stable-key
+   counterpart to measure-graph! and keeps backend graph handles out of compiler/runtime APIs."
+  [sess graph-key & {:as opts}]
+  (let [entry (or (get-in @sess [:graphs graph-key])
+                  (throw (ex-info (str "No graph: " graph-key " — call record-graph! first")
+                                  {:graph-key graph-key})))
+        graph (if (recorded-graph-entry? entry) (:replay-graph entry) entry)]
+    (when-not (and (recorded-graph-entry? entry) (:profile? entry))
+      (throw (ex-info "recorded graph was not created with {:profile? true}"
+                      {:graph-key graph-key})))
+    (apply measure-graph! sess graph (mapcat identity opts))))
 
 (defn measure-bound-kernel-graph!
   "Device-event measurement of a bound KernelGraphHandle.

--- a/src/raster/gpu/link.clj
+++ b/src/raster/gpu/link.clj
@@ -8,14 +8,16 @@
   (:refer-clojure :exclude [run!])
   (:require [clojure.set :as set]
             [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.buffer-view :as bview]
             [raster.compiler.ir.link-plan :as link-plan]
-            [raster.gpu.core :as gpu]))
+            [raster.gpu.core :as gpu]
+            [raster.gpu.value :as value]))
 
 (declare close! run!)
 
 (defrecord LinkedExecutable
            [plan session owns-session? graph-key phases allocation-keys node-views pending-inputs
-            closed?]
+            profile? closed?]
   java.io.Closeable
   (close [this] (close! this))
   clojure.lang.IFn
@@ -47,7 +49,11 @@
       (throw (ex-info "linked allocation byte size is not integral in its storage dtype"
                       {:reason :link-allocation-size :allocation (:id allocation)
                        :byte-size bytes :dtype dt})))
-    [dt (quot bytes element-bytes) nil]))
+    [dt (quot bytes element-bytes) nil
+     {:allocation-id (:id allocation)
+      :memory-space (:memory-space allocation)
+      :coherence (:coherence allocation)
+      :alignment (:alignment allocation)}]))
 
 (defn- cleanup-attached!
   [session graph-key phases allocation-keys]
@@ -73,7 +79,7 @@
    Attached executables own only their phases, graph recording and allocation registrations. Their
    close does not close the caller session and never frees caller-owned buffers."
   ([plan] (instantiate! plan {}))
-  ([plan {:keys [session external-buffers] :or {external-buffers {}}}]
+  ([plan {:keys [session external-buffers profile?] :or {external-buffers {} profile? false}}]
    ;; This is intentionally the first operation. Everything below may contact a backend.
    (let [plan (link-plan/validate! plan)
          target (:target plan)
@@ -159,7 +165,7 @@
                  :roles (link-plan/instance-roles plan instance)})
                (vswap! phases conj phase)))
            (let [gkey (graph-key execution-id)]
-             (gpu/record-graph! session @phases gkey)
+             (gpu/record-graph! session @phases gkey {:profile? profile?})
              (vreset! recorded-key gkey)
              (->LinkedExecutable plan session owns-session? gkey @phases @allocation-keys
                                  node-views
@@ -173,6 +179,7 @@
                                                                                    :ownership])))
                                                        node-id)))
                                              (:nodes plan)))
+                                 (boolean profile?)
                                  (atom false)))))
        (catch Throwable error
          (if owns-session?
@@ -240,6 +247,125 @@
                        {:elements (reduce * 1 (get-in node [:view :shape]))})
     (swap! (:pending-inputs executable) disj node-id)
     executable))
+
+(defn- same-buffer-range?
+  [left-buffer left-view right-buffer right-view]
+  (and (identical? left-buffer right-buffer)
+       (= (:byte-offset left-view) (:byte-offset right-view))
+       (= (:byte-length left-view) (:byte-length right-view))))
+
+(defn- overlapping-buffer-range?
+  [left-buffer left-view right-buffer right-view]
+  (and (identical? left-buffer right-buffer)
+       (< (:byte-offset left-view) (bview/byte-end right-view))
+       (< (:byte-offset right-view) (bview/byte-end left-view))))
+
+(defn write!
+  "Initialize or replace one complete contiguous LinkNode from a host value or DeviceArray.
+
+   Host values use upload!. A compatible DeviceArray already naming the exact destination range
+   is accepted without a copy; every other compatible resident value uses a backend device copy,
+   never device→host→device. Partially overlapping ranges fail explicitly because backend
+   overlap semantics are not a portable memory contract. Returns the executable."
+  [executable node-id source]
+  (if-not (value/device-array? source)
+    (upload! executable node-id source)
+    (let [executable (ensure-live! executable :write!)
+          node (get-in executable [:plan :nodes node-id])
+          _ (when-not node (node-view executable node-id))
+          _ (when-not (value/live? source)
+              (throw (ex-info "cannot write from a consumed or freed DeviceArray"
+                              {:reason :link-device-input-lifetime :node node-id})))
+          _ (when-not (= (:device source) (get-in executable [:plan :target]))
+              (throw (ex-info "DeviceArray target differs from linked executable target"
+                              {:reason :link-device-input-target :node node-id
+                               :source (:device source)
+                               :target (get-in executable [:plan :target])})))
+          source-view (bview/validate-view! (:view source))
+          destination (node-view executable node-id)
+          destination-view (:view destination)
+          _ (when-not (= [(:dtype destination-view) (:shape destination-view)]
+                         [(:dtype source-view) (:shape source-view)])
+              (throw (ex-info "DeviceArray dtype/shape differs from LinkNode"
+                              {:reason :link-device-input-contract :node node-id
+                               :source {:dtype (:dtype source-view) :shape (:shape source-view)}
+                               :destination {:dtype (:dtype destination-view)
+                                             :shape (:shape destination-view)}})))
+          _ (when-not (and (bview/contiguous? source-view)
+                           (bview/contiguous? destination-view))
+              (throw (ex-info "linked DeviceArray writes require contiguous views"
+                              {:reason :link-device-input-layout :node node-id})))
+          session (:session executable)
+          destination-buffer (gpu/buffer session (:key destination))
+          source-buffer (:buffer source)
+          elements (reduce * 1 (:shape destination-view))]
+      (cond
+        (same-buffer-range? source-buffer source-view destination-buffer destination-view)
+        nil
+
+        (overlapping-buffer-range? source-buffer source-view destination-buffer destination-view)
+        (throw (ex-info "linked DeviceArray write has partially overlapping source/destination"
+                        {:reason :link-device-input-overlap :node node-id}))
+
+        (identical? source-buffer destination-buffer)
+        (let [source-resident
+              (gpu/buffer-view session (:key destination)
+                               {:id (:id source-view)
+                                :byte-offset (:byte-offset source-view)
+                                :dtype (:dtype source-view)
+                                :shape (:shape source-view)
+                                :strides (:strides source-view)})]
+          (gpu/copy-range! session source-resident destination {:elements elements}))
+
+        :else
+        (let [temporary-key [::device-input (random-uuid)]
+              allocation (:allocation source-view)]
+          (gpu/register-buffer! session temporary-key source-buffer
+                                {:ownership :borrowed
+                                 :allocation-id [::device-input-allocation (random-uuid)]
+                                 :memory-space (:memory-space allocation)
+                                 :coherence (:coherence allocation)
+                                 :alignment (:alignment allocation)})
+          (try
+            (let [source-resident
+                  (gpu/buffer-view session temporary-key
+                                   {:id (:id source-view)
+                                    :byte-offset (:byte-offset source-view)
+                                    :dtype (:dtype source-view)
+                                    :shape (:shape source-view)
+                                    :strides (:strides source-view)})]
+              (gpu/copy-range! session source-resident destination {:elements elements}))
+            (finally
+              ;; Borrowed registrations are detached, never freed.
+              (gpu/free-buffer! session temporary-key)))))
+      (swap! (:pending-inputs executable) disj node-id)
+      executable)))
+
+(defn profile!
+  "Profile one replay of an executable instantiated with `{:profile? true}`. Inputs must be ready."
+  [executable]
+  (let [executable (ensure-live! executable :profile!)]
+    (when (seq @(:pending-inputs executable))
+      (throw (ex-info "linked executable has inputs or state that have not been initialized"
+                      {:reason :link-pending-inputs :nodes @(:pending-inputs executable)})))
+    (gpu/profile-recorded-graph! (:session executable) (:graph-key executable))))
+
+(defn measure!
+  "Measure a profiled LinkedExecutable with device events. Stateful plans require the explicit
+   `:before-sample!` restore hook so repeated samples cannot silently measure mutated state."
+  [executable & {:keys [before-sample!] :as opts}]
+  (let [executable (ensure-live! executable :measure!)
+        state-nodes (into #{} (keep (fn [[node-id node]]
+                                      (when (= :state (:role node)) node-id)))
+                          (get-in executable [:plan :nodes]))]
+    (when (seq @(:pending-inputs executable))
+      (throw (ex-info "linked executable has inputs or state that have not been initialized"
+                      {:reason :link-pending-inputs :nodes @(:pending-inputs executable)})))
+    (when (and (seq state-nodes) (nil? before-sample!))
+      (throw (ex-info "stateful linked executables require :before-sample! restoration"
+                      {:reason :link-stateful-measurement :state-nodes state-nodes})))
+    (apply gpu/measure-recorded-graph! (:session executable) (:graph-key executable)
+           (mapcat identity opts))))
 
 (defn download
   "Download one complete contiguous LinkNode view. Debug/host-boundary helper, not invocation."

--- a/test/raster/compiler/ir/resident_plan_test.clj
+++ b/test/raster/compiler/ir/resident_plan_test.clj
@@ -97,6 +97,20 @@
     (is (= [(get-in lowering [:certificate :bindings (:result-sym descriptor)])]
            (get-in lowering [:plan :outputs])))))
 
+(deftest array-dependent-specialization-closures-survive-link-lowering
+  (let [x (float-array 12)
+        w (float-array 12)
+        descriptor (assoc-in (descriptor) [:allocs 0 :size-fn]
+                             (fn [arguments]
+                               (java.lang.reflect.Array/getLength (nth arguments 0))))
+        lowering (resident/lower
+                  {:id :array-shaped :target :ze:0 :descriptor descriptor
+                   :arguments [x w 12]})
+        instance (first (get-in lowering [:plan :instances]))]
+    (is (identical? x (first (link/instance-arguments instance))))
+    (is (= [12] (get-in lowering [:plan :nodes [:array-shaped 'y] :view :shape])))
+    (is (resident/certified-plan? lowering))))
+
 (deftest generated-gemm-descriptor-crosses-the-same-certified-boundary
   (let [rows 4
         width 16

--- a/test/raster/gpu/artifact_test.clj
+++ b/test/raster/gpu/artifact_test.clj
@@ -13,11 +13,16 @@
      A3 — frozen weights are :constant (captured at bind), never per-call inputs.
      A4 — multi-output: the out-tree projects all 14 donated adapters as DeviceArrays."
   (:require [clojure.test :refer [deftest testing is]]
+            [raster.core :refer [deftm]]
             [raster.compiler.ir.buffer-view :as bview]
+            [raster.compiler.ir.resident-plan :as resident-plan]
             [raster.compiler.pipeline :as pl]
             [raster.dl.gpu-grad-parity :as gp]
             [raster.dl.gemma-train-resident-test :as g]
+            [raster.dl.nn :as nn]
             [raster.gpu.compiled :as r]
+            [raster.gpu.core :as gpu]
+            [raster.gpu.link :as gpu-link]
             [raster.gpu.value :as v]))
 
 ;; ── access the gemma harness (privates) ──────────────────────────────────────────
@@ -28,6 +33,11 @@
 ;; ════════════════════════════════════════════════════════════════════════════════
 
 (defrecord ^:private FakeBuf [n-elements dtype])
+
+(deftm artifact-two-step
+  [x :- (Array float) bias :- (Array float) n :- Long] :- (Array float)
+  (let [sum (nn/residual-add x bias n)]
+    (nn/hadamard sum x n)))
 
 (deftest a2-donation-invalidation
   (testing "an ::owned value is live and readable until consumed"
@@ -97,6 +107,35 @@
           (v/free! slice)
           (v/free! base))))))
 
+(deftest compiled-device-input-never-round-trips-through-host
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "Compiled LinkedExecutable device input")
+    (let [n 64
+          bias (float-array (repeat n 2.0))
+          initial (float-array n)
+          input (v/->device (float-array (repeat n 3.0)) :ze:0)
+          compiled (r/compile #'artifact-two-step [initial bias n]
+                              {:target :ze:0 :constants '[bias]
+                               :on-non-resident :throw :profile? true})]
+      (try
+        (let [result (with-redefs [v/->host
+                                   (fn [_]
+                                     (throw (AssertionError.
+                                             "Compiled must not download a device input")))]
+                       (compiled {:x input}))
+              output (get result (keyword (name (:result-sym (:descriptor compiled)))))]
+          (is (every? #(= 15.0 (double %)) (v/->host output)))
+          (is (empty? (:programs @(:session (:executable compiled))))
+              "the invocation is a LinkPlan graph, not bind-program!")
+          (let [profile (r/profile compiled)]
+            (is (= 2 (count (:profile profile))))
+            (is (pos? (:device-wall-ms profile)))
+            (is (not (v/live? output))
+                "profiling invalidates an earlier output whose resident storage it overwrites")))
+        (finally
+          (v/free! input)
+          (r/close! compiled))))))
+
 ;; ════════════════════════════════════════════════════════════════════════════════
 ;; A5 — inspection over a Compiled record (CPU, no device)
 ;; ════════════════════════════════════════════════════════════════════════════════
@@ -109,7 +148,7 @@
                     :dtype :float
                     :steps [{:convention :map} {:convention :gemm} {:convention :map}]}
         c (r/map->Compiled
-           {:session nil :handle nil
+           {:lowering nil :executable nil
             :in-tree  [{:key :a :sym 'a :role :input :donate? false :shape [4] :dtype :float}]
             :out-tree [{:key :b' :sym 'b :shape [4] :dtype :float :from :donated}]
             :donated  {:a :a'}
@@ -172,6 +211,12 @@
                            :donate adapters :constants frozen-syms
                            :gemm-precision :f32-scalar})]
       (try
+        (testing "Compiled is the certified LinkPlan API, not a parallel resident binder"
+          (is (resident-plan/certified-plan? (:lowering step)))
+          (is (gpu-link/linked-executable? (:executable step)))
+          (is (= (r/plan step) (:plan (:executable step))))
+          (is (empty? (:programs @(:session (:executable step))))
+              "Compiled must not register a legacy bind-program! executable"))
         (testing "A3: frozen weights are :constant, never per-call inputs"
           (let [roles (into {} (map (juxt :sym :role)) (:in-tree step))]
             (is (every? #(= :constant (roles %)) frozen-syms)
@@ -194,11 +239,14 @@
             (doseq [{:keys [key sym]} (:out-tree step)
                     :let [da (get last-out key)]
                     :when da]
-              (let [resident-key ((ns-resolve gpu 'resident-key)
-                                  (:session step) (:handle step) sym)]
-                (is (= (get-in @(:session step) [:allocations resident-key :id])
+              (let [node (get-in (r/certificate step) [:bindings sym])
+                    resident (gpu-link/node-view (:executable step) node)
+                    session (:session (:executable step))]
+                (is (= (get-in @session [:allocations (:key resident) :id])
                        (get-in da [:view :allocation :id]))
-                    (str key " shares the session allocation identity")))))
+                    (str key " shares the certified LinkPlan allocation identity"))
+                (is (= node (get-in da [:view :allocation :id]))
+                    (str key " preserves the LinkPlan allocation identity at runtime")))))
           (testing "A1/A6: the value path is BIT-IDENTICAL to the raw run-program! path"
             (doseq [s adapters]
               (let [art (v/->host (get last-out (keyword (str (name s) "'"))))

--- a/test/raster/gpu/link_spike_test.clj
+++ b/test/raster/gpu/link_spike_test.clj
@@ -11,11 +11,14 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.core :refer [deftm]]
             [raster.dl.gpu-grad-parity :as gp]
+            [raster.compiler.ir.buffer-view :as bview]
             [raster.compiler.ir.link-plan :as link-plan]
             [raster.compiler.pipeline :as pl]
             [raster.dl.nn :as nn]
             [raster.gpu.core :as gpu]
-            [raster.gpu.link :as gpu-link]))
+            [raster.gpu.link :as gpu-link]
+            [raster.gpu.value :as value])
+  (:import [java.util.concurrent.atomic AtomicBoolean]))
 
 ;; A minimal elementwise forward: y = (x + w) * x  (residual-add then hadamard — the proven-
 ;; resident dt-two-step shape). Composing it twice with weights w0,w1 gives the intermediate
@@ -89,6 +92,111 @@
             [:allocation :allocation-1] [:allocation :allocation-0]]
            @calls))
     (is (nil? (gpu-link/close! executable)) "close remains idempotent after a destructor failure")))
+
+(deftest linked-device-input-is-zero-copy-or-device-to-device
+  (let [destination-buffer (Object.)
+        source-buffer (Object.)
+        destination-allocation
+        (bview/allocation {:id :destination :byte-size 16 :memory-space :device
+                           :device :ze:0 :ownership :owned})
+        source-allocation
+        (bview/allocation {:id :source :byte-size 16 :memory-space :device
+                           :device :ze:0 :ownership :external})
+        destination-view (bview/view destination-allocation {:dtype :float :shape [4]})
+        source-view (bview/view source-allocation {:dtype :float :shape [4]})
+        resident (gpu/->ResidentBufferView :session :destination-key destination-view)
+        executable (gpu-link/map->LinkedExecutable
+                    {:plan {:target :ze:0
+                            :nodes {:destination {:id :destination :role :input
+                                                  :view destination-view}}}
+                     :session ::session
+                     :node-views {:destination resident}
+                     :pending-inputs (atom #{:destination})
+                     :closed? (atom false)})
+        device-array (fn [buffer view]
+                       (value/map->DeviceArray
+                        {:buffer buffer :device :ze:0 :dtype :float :shape [4] :view view
+                         :owner ::value/external :freed (AtomicBoolean. false)}))]
+    (testing "the exact destination view is a zero-copy readiness transition"
+      (with-redefs [gpu/buffer (fn [_ _] destination-buffer)
+                    gpu/copy-range! (fn [& _] (throw (AssertionError. "unexpected copy")))
+                    gpu/register-buffer! (fn [& _] (throw (AssertionError. "unexpected import")))]
+        (is (identical? executable
+                        (gpu-link/write! executable :destination
+                                         (device-array destination-buffer destination-view))))
+        (is (empty? @(:pending-inputs executable)))))
+    (testing "a foreign compatible DeviceArray is copied resident-to-resident and detached"
+      (reset! (:pending-inputs executable) #{:destination})
+      (let [calls (atom [])
+            imported (gpu/->ResidentBufferView :session :temporary-key source-view)]
+        (with-redefs [gpu/buffer (fn [_ _] destination-buffer)
+                      gpu/register-buffer! (fn [_ key buffer opts]
+                                             (swap! calls conj [:register key buffer opts]))
+                      gpu/buffer-view (fn [_ key _]
+                                        (is (some? key))
+                                        imported)
+                      gpu/copy-range! (fn [_ src dst spec]
+                                        (swap! calls conj [:copy src dst spec]))
+                      gpu/free-buffer! (fn [_ key] (swap! calls conj [:detach key]))]
+          (gpu-link/write! executable :destination (device-array source-buffer source-view)))
+        (is (= [:register :copy :detach] (mapv first @calls)))
+        (is (= {:elements 4} (-> @calls second last)))
+        (is (empty? @(:pending-inputs executable)))))))
+
+(deftest owned-runtime-allocation-preserves-the-certified-identity
+  (let [session (atom {:device-id :ze:0 :session-id :session
+                       :buffers {} :allocations {} :closed? false})
+        buffer {:byte-size 16 :alignment 64 :dtype :float :n-elements 4}]
+    (with-redefs-fn
+      {(ns-resolve 'raster.gpu.core 'alloc-buffers-transactional)
+       (fn [specs _device]
+         (is (= {:node [:float 4 nil {:allocation-id :certified
+                                      :memory-space :device
+                                      :coherence :device-only
+                                      :alignment 64}]}
+                specs))
+         {:node buffer})}
+      (fn []
+        (gpu/alloc! session
+                    {:node [:float 4 nil {:allocation-id :certified
+                                          :memory-space :device
+                                          :coherence :device-only
+                                          :alignment 64}]})))
+    (is (= :certified (get-in @session [:allocations :node :id])))
+    (is (= :device (get-in @session [:allocations :node :memory-space])))
+    (is (= :device-only (get-in @session [:allocations :node :coherence])))
+    (is (= 64 (get-in @session [:allocations :node :alignment])))))
+
+(deftest stable-recorded-graph-profiling-keeps-backend-handles-private
+  (let [graph (Object.)
+        session (atom {:device-id :ze:0
+                       :graphs {:profiled {::gpu/recorded-graph true
+                                           :replay-graph graph :profile? true}}})
+        calls (atom [])
+        resolver (fn [_device name]
+                   (case name
+                     "replay-graph!" (fn [actual]
+                                       (is (identical? graph actual))
+                                       (swap! calls conj :replay))
+                     "read-graph-timestamps!"
+                     (fn [actual]
+                       (is (identical? graph actual))
+                       (swap! calls conj :read)
+                       {:wall-ms 1.5
+                        :kernels [{:kernel-name "k0" :phase :p0 :ms 1.0
+                                   :context-ms 0.25}]})
+                     (throw (ex-info "unexpected runtime resolution" {:name name}))))]
+    (with-redefs-fn {(ns-resolve 'raster.gpu.core 'rt-resolve) resolver}
+      (fn []
+        (let [profile (gpu/profile-recorded-graph! session :profiled)]
+          (is (= [:replay :read] @calls))
+          (is (= 1.0 (:kernel-total-ms profile)))
+          (is (= 1.5 (:device-wall-ms profile)))
+          (is (= [{:kernel-name "k0" :phase :p0 :ms 1.0 :context-ms 0.25}]
+                 (:profile profile))))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not created"
+                          (gpu/profile-recorded-graph!
+                           (atom {:device-id :ze:0 :graphs {:plain graph}}) :plain)))))
 
 (deftest spike-two-instance-link
   (if-not @gp/gpu-available?


### PR DESCRIPTION
## Summary
- make Compiled own the certified resident lowering and execute only through LinkedExecutable
- preserve certified allocation identities and full descriptor specialization environments through runtime instantiation
- accept device inputs through exact-view zero-copy or synchronous device-to-device copies, never implicit host materialization
- profile and measure the same stable recorded graph while preserving fail-loud output lifetimes
- record the pretrained-rstr batching boundary: shared weights, lane-local mutable views, and leading-batch emission as later kernel work

## Correctness
- pointer addresses come only from LinkNode bindings; retained specialization arguments are used solely by descriptor scalar and shape closures
- donation remains exact-view-only and foreign values fail loud
- normal profiled replay resets events; explicit profile and measurement consume device timestamps
- owned runtime allocations retain the identity certified in LinkPlan

## Tests
- LinkPlan and resident-plan IR: 11 tests, 47 assertions
- live linked elementwise and f16-XMX GEMM gate: 7 tests, 39 assertions
- live Compiled D2D input and graph profiling: 1 test, 5 assertions
- artifact donation and inspection CPU gates: 2 tests, 29 assertions
- focused cljfmt and git diff check

The memory-heavy 25-step Gemma artifact parity gate was not rerun locally because the host has about 3.2 GiB available and no swap; the smaller production and live gates pass.