### PR TITLE
Compose certified GPU artifacts before allocation

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -126,9 +126,12 @@ schedule, aliases, target, and outputs. `Compiled` owns that witness and invokes
 never an implicit host round trip. The runtime preserves the certified allocation identities and
 profiles the same stable recorded-graph boundary. Each instance also retains the complete ordered
 specialization environment required by descriptor shape closures, while runtime pointers still
-come only from certified node bindings. The remaining value-layer convergence is to
-compose independently created compiled instances into one plan, where shared node identity removes
-even the device copy, then retire the duplicate legacy whole-program binding API after parity.
+come only from certified node bindings. Independently lowered `Prepared` artifacts now compose
+before allocation through semantic input/output keys. The composition certificate namespaces
+component identities, unifies explicit dataflow and shared constant/input nodes, and re-derives one
+validated plan; one later instantiation therefore removes even the device copy. The remaining
+value-layer cleanup is ranged-view/cross-component ownership composition and retirement of the
+duplicate legacy whole-program binding API after parity.
 
 Pretrained-rstr's batch boundary is the next concrete shape test: weights bind once to shared
 constant nodes, while residual, scratch, position, logits and token storage are lane-local nodes or

--- a/design/link-plan.md
+++ b/design/link-plan.md
@@ -7,6 +7,8 @@ The boundary has three layers:
 
 - `raster.compiler.ir.link-plan` contains immutable compiler values and pure validation;
 - `raster.compiler.ir.resident-plan` certifies the lowering of an ordinary resident descriptor;
+- `raster.compiler.ir.link-composition` certifies namespacing and boundary unification across
+  independently lowered plans;
 - `raster.gpu.link` instantiates a validated plan into resident allocations and one replay graph.
 
 No attention, GEMM, quantization, or model-layer convention exists in the linker. A descriptor step
@@ -21,6 +23,13 @@ omission therefore fails before runtime contact; later layers never reconstruct 
 from ABI spelling. This certificate proves preservation across this structural lowering boundary;
 the earlier obligation that executable kernels implement the source program remains with their own
 dialect conversions and numerical oracles.
+
+`CertifiedLinkComposition` applies the same rule recursively. Ordered certified components are
+namespaced before explicit output→input connections and equal input/constant sharing canonicalize
+node and allocation identities. Its witness records source plan identities, connections, sharing,
+node/allocation/instance mappings and outputs. Verification rechecks every source certificate and
+re-derives the complete target plan. Composition therefore occurs before allocation: an
+intermediate connected by identity cannot acquire an implicit host or device copy at runtime.
 
 ## Values
 
@@ -103,8 +112,12 @@ explicit while still allowing pretrained runtimes to allocate first and publish 
   composite abstract value rather than an implicit tuple convention.
 - The initial dependency schedule is serial. Queue/event partitioning can lower from the same
   proven effects later without changing node or instance identity.
-- A single resident descriptor now has a pure, certified lowering to `LinkPlan`. `Compiled` has not
-  yet been rebased onto that result; its runtime path is the next convergence step.
+- `raster.gpu.compiled/lower` returns an allocation-free `Prepared` value. Independently lowered
+  artifacts compose through semantic input/output keys and only the final Prepared value is passed
+  to `instantiate!`; `compile` remains the single-program lower+instantiate convenience.
+- Composition currently rejects endpoints whose allocation contains several views and rejects
+  cross-component donation. Ranged view unification and ownership threading belong to the next
+  `AbstractValue`/view consolidation rather than an implicit whole-buffer convention.
 
 For paged attention, page allocation, cache relocation, transactional publication, batching and
 request scheduling remain runtime responsibilities. Raster receives borrowed/external node views

--- a/src/raster/compiler/ir/kernel_abi.clj
+++ b/src/raster/compiler/ir/kernel_abi.clj
@@ -69,6 +69,22 @@
   [abi]
   (filterv #(= :scalar (:kind %)) (validate! abi)))
 
+(defn logical-pointer-slot-groups
+  "Ordered logical pointer groups over the physical ABI.
+
+   Only adjacent slots carrying an explicit equal `:binding` form one composite logical value.
+   Repeated ordinary `:name` values remain separate groups: an in-place kernel may legally pass
+   the same buffer in distinct input and output positions without claiming a composite ABI."
+  [abi]
+  (reduce (fn [groups slot]
+            (let [binding (or (:binding slot) (:name slot))
+                  previous (peek groups)]
+              (if (and (:binding slot)
+                       (= binding (:binding previous)))
+                (-> groups pop (conj (update previous :slots conj slot)))
+                (conj groups {:binding binding :slots [slot]}))))
+          [] (pointer-slots abi)))
+
 (defn pointer-binding-names
   "Logical caller pointer values, in first physical-signature occurrence order.
 
@@ -76,14 +92,7 @@
    C pointer slots but is supplied by one logical GpuSoA value; those slots carry a shared
    `:binding` and collapse to one name here."
   [abi]
-  (:names
-   (reduce (fn [{:keys [seen] :as acc} slot]
-             (if-let [binding (:binding slot)]
-               (if (contains? seen binding)
-                 acc
-                 (-> acc (update :names conj binding) (update :seen conj binding)))
-               (update acc :names conj (:name slot))))
-           {:names [] :seen #{}} (pointer-slots abi))))
+  (mapv :binding (logical-pointer-slot-groups abi)))
 
 (defn validate-arguments!
   "Check that `arguments` supplies exactly one value per ordered ABI slot."

--- a/src/raster/compiler/ir/link_composition.clj
+++ b/src/raster/compiler/ir/link_composition.clj
@@ -1,0 +1,362 @@
+(ns raster.compiler.ir.link-composition
+  "Certified, allocation-free composition of independently lowered resident programs.
+
+   Composition is a pure LinkPlan rewrite. Component node/allocation/instance identities are
+   namespaced first; explicit dataflow connections and shared boundary values then canonicalize
+   identities; one ordinary LinkPlan is validated last. The runtime therefore allocates and
+   records the composite only once and cannot insert an implicit intermediate copy."
+  (:require [clojure.set :as set]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.buffer-view :as bview]
+            [raster.compiler.ir.link-plan :as link-plan]
+            [raster.compiler.ir.resident-plan :as resident-plan]))
+
+(defrecord LinkCompositionCertificate
+           [source-dialect target-dialect plan-id target component-plan-ids
+            connections shares node-mapping allocation-mapping instance-mapping outputs])
+(defrecord CertifiedLinkComposition [plan certificate components specification])
+
+(defn certificate? [x]
+  (instance? LinkCompositionCertificate x))
+
+(defn certified-composition? [x]
+  (instance? CertifiedLinkComposition x))
+
+(declare verify!)
+
+(defn- verify-component! [component]
+  (cond
+    (resident-plan/certified-plan? component) (resident-plan/verify! component)
+    (certified-composition? component) (verify! component)
+    :else
+    (throw (ex-info "link composition components must carry a verified lowering certificate"
+                    {:reason :link-composition-component-type :actual (type component)}))))
+
+(defn- normalize-components! [components]
+  (let [components (mapv (fn [component]
+                           (when-not (and (map? component) (contains? component :id)
+                                          (contains? component :lowering))
+                             (throw (ex-info "each link component requires :id and :lowering"
+                                             {:reason :link-composition-component
+                                              :component component})))
+                           (update component :lowering verify-component!))
+                         components)
+        ids (mapv :id components)]
+    (when (empty? components)
+      (throw (ex-info "link composition requires at least one certified component"
+                      {:reason :link-composition-components})))
+    (when-not (= (count ids) (count (distinct ids)))
+      (throw (ex-info "link composition component identities must be unique and ordered"
+                      {:reason :link-composition-component-ids :ids ids})))
+    components))
+
+(defn- node-ref! [component-plans [component-id node-id :as reference]]
+  (when-not (and (vector? reference) (= 2 (count reference)))
+    (throw (ex-info "a link composition node reference is [component-id node-id]"
+                    {:reason :link-composition-node-reference :reference reference})))
+  (let [plan (get component-plans component-id)]
+    (when-not plan
+      (throw (ex-info "a link composition node reference names an absent component"
+                      {:reason :link-composition-component-reference
+                       :reference reference :components (set (keys component-plans))})))
+    (when-not (contains? (:nodes plan) node-id)
+      (throw (ex-info "a link composition node reference names an absent component node"
+                      {:reason :link-composition-node-reference :reference reference
+                       :nodes (set (keys (:nodes plan)))})))
+    reference))
+
+(defn- namespace-id [composition-id component-id kind id]
+  [composition-id component-id kind id])
+
+(defn- namespace-node [composition-id component-id node]
+  (let [view (:view node)
+        allocation (:allocation view)]
+    (assoc node
+           :id (namespace-id composition-id component-id :node (:id node))
+           :view (assoc view
+                        :id (namespace-id composition-id component-id :view (:id view))
+                        :allocation
+                        (assoc allocation :id (namespace-id composition-id component-id
+                                                            :allocation (:id allocation)))))))
+
+(defn- namespace-instance [composition-id component-id node-mapping instance]
+  (assoc instance
+         :id (namespace-id composition-id component-id :instance (:id instance))
+         :bindings (update-vals (:bindings instance) node-mapping)))
+
+(defn- endpoint-contract [node]
+  (let [view (:view node)
+        allocation (:allocation view)]
+    {:dtype (dtype/canon (:dtype view))
+     :shape (:shape view)
+     :strides (:strides view)
+     :byte-offset (:byte-offset view)
+     :byte-length (:byte-length view)
+     :allocation (select-keys allocation
+                              [:byte-size :memory-space :device :alignment :coherence
+                               :ownership])}))
+
+(defn- require-equal-contract! [kind references nodes]
+  (let [contracts (mapv (comp endpoint-contract nodes) references)]
+    (when-not (apply = contracts)
+      (throw (ex-info "composed boundary values have different realized view contracts"
+                      {:reason :link-composition-view-contract :kind kind
+                       :references references :contracts contracts})))))
+
+(defn- require-single-node-allocations! [references nodes]
+  ;; Step 4 generalizes this to ranged/subview boundary unification. Rejecting it here is crucial:
+  ;; rebasing one endpoint of a multi-view allocation would silently change the other aliases.
+  (let [counts (frequencies (map #(get-in % [:view :allocation :id]) (vals nodes)))]
+    (doseq [reference references
+            :let [allocation-id (get-in nodes [reference :view :allocation :id])]]
+      (when-not (= 1 (get counts allocation-id))
+        (throw (ex-info "composition across a multi-view allocation requires ranged-view linking"
+                        {:reason :link-composition-ranged-view :node reference
+                         :allocation allocation-id :views (get counts allocation-id)}))))))
+
+(defn- normalize-connections! [connections component-plans component-order]
+  (let [connections
+        (mapv (fn [{:keys [from to] :as connection}]
+                (when-not (= #{:from :to} (set (keys connection)))
+                  (throw (ex-info "a dataflow connection requires exactly :from and :to"
+                                  {:reason :link-composition-connection
+                                   :connection connection})))
+                {:from (node-ref! component-plans from)
+                 :to (node-ref! component-plans to)})
+              connections)
+        targets (mapv :to connections)]
+    (when-not (= (count targets) (count (distinct targets)))
+      (throw (ex-info "a composed consumer node has more than one producer"
+                      {:reason :link-composition-producers :targets targets})))
+    (doseq [{:keys [from to]} connections
+            :let [[from-component from-node] from
+                  [to-component to-node] to
+                  from-plan (get component-plans from-component)
+                  to-plan (get component-plans to-component)]]
+      (when-not (< (get component-order from-component) (get component-order to-component))
+        (throw (ex-info "link dataflow connections must follow component schedule order"
+                        {:reason :link-composition-order :from from :to to})))
+      (when-not (some #{from-node} (:outputs from-plan))
+        (throw (ex-info "a link dataflow producer must be a declared component output"
+                        {:reason :link-composition-producer-boundary :from from
+                         :outputs (:outputs from-plan)})))
+      (when-not (= :input (get-in to-plan [:nodes to-node :role]))
+        (throw (ex-info "a link dataflow consumer must be an input boundary"
+                        {:reason :link-composition-consumer-role :to to
+                         :role (get-in to-plan [:nodes to-node :role])}))))
+    connections))
+
+(defn- normalize-shares! [shares component-plans]
+  (mapv
+   (fn [share]
+     (let [references (mapv #(node-ref! component-plans %) share)]
+       (when-not (<= 2 (count references))
+         (throw (ex-info "a shared boundary group requires at least two nodes"
+                         {:reason :link-composition-share :share share})))
+       (when-not (= (count references) (count (distinct references)))
+         (throw (ex-info "a shared boundary group cannot repeat a node"
+                         {:reason :link-composition-share-duplicates :share share})))
+       (let [roles (mapv (fn [[component-id node-id]]
+                           (get-in component-plans [component-id :nodes node-id :role]))
+                         references)]
+         (when-not (and (apply = roles) (contains? #{:input :constant} (first roles)))
+           (throw (ex-info "shared boundaries must all be inputs or all be constants"
+                           {:reason :link-composition-share-role :share share :roles roles}))))
+       references))
+   shares))
+
+(defn- distinct-groups! [connections shares]
+  (let [connection-refs (set (mapcat (juxt :from :to) connections))
+        share-refs (mapcat identity shares)]
+    (when-not (= (count share-refs) (count (distinct share-refs)))
+      (throw (ex-info "a boundary node occurs in more than one shared group"
+                      {:reason :link-composition-share-overlap :shares shares})))
+    (when-let [overlap (seq (set/intersection connection-refs (set share-refs)))]
+      (throw (ex-info "dataflow and shared-value composition cannot claim the same boundary node"
+                      {:reason :link-composition-boundary-overlap :nodes (set overlap)})))))
+
+(defn- canonical-source [references nodes]
+  (let [sources (keep (comp :source nodes) references)]
+    (when-not (or (<= (count sources) 1)
+                  (every? #(identical? (first sources) %) (rest sources)))
+      (throw (ex-info "shared initialized boundaries must carry the same source object"
+                      {:reason :link-composition-share-source :nodes references})))
+    (first sources)))
+
+(defn- derive-composition
+  [id components {:keys [connections shares outputs attributes]
+                  :or {connections [] shares [] attributes {}} :as specification}]
+  (when (nil? id)
+    (throw (ex-info "link composition requires a stable plan identity"
+                    {:reason :link-composition-id})))
+  (let [components (normalize-components! components)
+        component-plans (into {} (map (juxt :id (comp :plan :lowering))) components)
+        targets (set (map :target (vals component-plans)))
+        _ (when-not (= 1 (count targets))
+            (throw (ex-info "all composed LinkPlans must target the same device"
+                            {:reason :link-composition-targets :targets targets})))
+        target (first targets)
+        component-order (zipmap (map :id components) (range))
+        connections (normalize-connections! connections component-plans component-order)
+        shares (normalize-shares! shares component-plans)
+        _ (distinct-groups! connections shares)
+        outputs (mapv #(node-ref! component-plans %) outputs)
+        _ (when (empty? outputs)
+            (throw (ex-info "link composition requires explicit public outputs"
+                            {:reason :link-composition-outputs})))
+        _ (doseq [[component-id node-id :as output] outputs]
+            (when-not (some #{node-id} (get-in component-plans [component-id :outputs]))
+              (throw (ex-info "a composite output must be a declared component output"
+                              {:reason :link-composition-output-boundary :output output}))))
+        node-mapping0
+        (into {}
+              (mapcat (fn [{component-id :id lowering :lowering}]
+                        (map (fn [node-id]
+                               [[component-id node-id]
+                                (namespace-id id component-id :node node-id)])
+                             (keys (get-in lowering [:plan :nodes]))))
+                      components))
+        nodes0
+        (into {}
+              (mapcat (fn [{component-id :id lowering :lowering}]
+                        (map (fn [[_ node]]
+                               (let [node (namespace-node id component-id node)]
+                                 [(:id node) node]))
+                             (get-in lowering [:plan :nodes])))
+                      components))
+        namespaced-ref #(get node-mapping0 %)
+        connection-pairs (mapv (fn [{:keys [from to]}]
+                                 [(namespaced-ref from) (namespaced-ref to)])
+                               connections)
+        share-groups (mapv #(mapv namespaced-ref %) shares)
+        endpoint-groups (concat connection-pairs share-groups)
+        _ (doseq [group endpoint-groups]
+            (require-equal-contract! :boundary group nodes0)
+            (require-single-node-allocations! group nodes0))
+        _ (doseq [group share-groups] (canonical-source group nodes0))
+        replacements
+        (into {}
+              (concat (map (fn [[source target]] [target source]) connection-pairs)
+                      (mapcat (fn [[canonical & others]]
+                                (map (fn [other] [other canonical]) others))
+                              share-groups)))
+        allocation-replacements
+        (into {}
+              (map (fn [[discarded canonical]]
+                     [(get-in nodes0 [discarded :view :allocation :id])
+                      (get-in nodes0 [canonical :view :allocation :id])]))
+              replacements)
+        connected-sources (set (map first connection-pairs))
+        shared-source-by-node
+        (into {}
+              (mapcat (fn [group]
+                        (let [source (canonical-source group nodes0)]
+                          (map (fn [node-id] [node-id source]) group)))
+                      share-groups))
+        nodes
+        (into {}
+              (keep (fn [[node-id node]]
+                      (when-not (contains? replacements node-id)
+                        (let [allocation (get-in node [:view :allocation])
+                              allocation-id (:id allocation)
+                              allocation-id' (get allocation-replacements allocation-id
+                                                  allocation-id)
+                              node (cond-> (assoc-in node [:view :allocation :id] allocation-id')
+                                     (contains? connected-sources node-id)
+                                     (assoc :role :internal)
+                                     (contains? shared-source-by-node node-id)
+                                     (assoc :source (get shared-source-by-node node-id)))]
+                          [node-id node]))))
+              nodes0)
+        resolve-node #(get replacements % %)
+        node-mapping (into {} (map (fn [[reference node-id]]
+                                     [reference (resolve-node node-id)])) node-mapping0)
+        allocation-mapping
+        (into {}
+              (mapcat (fn [{component-id :id lowering :lowering}]
+                        (for [allocation-id (distinct
+                                             (map #(get-in % [:view :allocation :id])
+                                                  (vals (get-in lowering [:plan :nodes]))))
+                              :let [namespaced (namespace-id id component-id :allocation
+                                                             allocation-id)]]
+                          [[component-id allocation-id]
+                           (get allocation-replacements namespaced namespaced)]))
+                      components))
+        instance-mapping
+        (into {}
+              (mapcat (fn [{component-id :id lowering :lowering}]
+                        (map (fn [instance]
+                               [[component-id (:id instance)]
+                                (namespace-id id component-id :instance (:id instance))])
+                             (get-in lowering [:plan :instances])))
+                      components))
+        instances
+        (vec
+         (mapcat (fn [{component-id :id lowering :lowering}]
+                   (map (fn [instance]
+                          (namespace-instance id component-id
+                                              (comp resolve-node
+                                                    #(get node-mapping0 [component-id %]))
+                                              instance))
+                        (get-in lowering [:plan :instances])))
+                 components))
+        aliases (into #{}
+                      (for [[left-id left] nodes
+                            [right-id right] nodes
+                            :when (neg? (compare (pr-str left-id) (pr-str right-id)))
+                            :when (bview/overlaps? (:view left) (:view right))]
+                        #{left-id right-id}))
+        output-ids (mapv node-mapping outputs)
+        plan (link-plan/make
+              {:id id :target target :nodes nodes :instances instances :outputs output-ids
+               :aliases aliases
+               :attributes (merge attributes
+                                  {:lowered-from :certified-link-composition
+                                   :component-plan-ids
+                                   (mapv (comp :id :plan :lowering) components)})})
+        certificate
+        (->LinkCompositionCertificate
+         :certified-link-plans :link-plan id target
+         (mapv (comp :id :plan :lowering) components)
+         connections shares node-mapping allocation-mapping instance-mapping output-ids)]
+    {:plan plan :certificate certificate :components components
+     :specification (assoc specification :connections connections :shares shares
+                           :outputs outputs :attributes attributes)}))
+
+(defn verify!
+  "Re-derive a certified composition from its certified components and explicit boundary map."
+  [composition]
+  (when-not (certified-composition? composition)
+    (throw (ex-info "expected a CertifiedLinkComposition"
+                    {:reason :link-composition-type :actual (type composition)})))
+  (let [actual (select-keys composition [:plan :certificate :components :specification])
+        expected (derive-composition (get-in composition [:plan :id])
+                                     (:components composition)
+                                     (:specification composition))]
+    (when-not (certificate? (:certificate composition))
+      (throw (ex-info "link composition requires a LinkCompositionCertificate"
+                      {:reason :link-composition-certificate-type
+                       :actual (type (:certificate composition))})))
+    (when-not (= expected actual)
+      (throw (ex-info "link composition certificate does not match its source plans and target"
+                      {:reason :link-composition-certificate
+                       :expected (select-keys expected [:plan :certificate])
+                       :actual (select-keys actual [:plan :certificate])})))
+    composition))
+
+(defn compose
+  "Compose certified LinkPlans before allocation and return a checkable witness.
+
+   `components` is an ordered vector of `{:id component-id :lowering certified-lowering}`.
+   `specification` requires ordered `:outputs` and optionally contains:
+   - `:connections` — `{:from [producer-id output-node] :to [consumer-id input-node]}`;
+   - `:shares` — groups of equal input/constant boundary node references;
+   - `:attributes` — inspectable composite metadata.
+
+   This first contract intentionally rejects endpoints whose allocation has multiple views. The
+   following AbstractValue/view consolidation pass will make ranged boundary composition explicit."
+  [{:keys [id components] :as request}]
+  (let [specification (select-keys request [:connections :shares :outputs :attributes])
+        {:keys [plan certificate components specification]}
+        (derive-composition id components specification)]
+    (verify! (->CertifiedLinkComposition plan certificate components specification))))

--- a/src/raster/compiler/ir/link_plan.clj
+++ b/src/raster/compiler/ir/link_plan.clj
@@ -250,21 +250,18 @@
         args (instance-arguments instance)
         interface (kexec/validate! (step-interface step))
         pointer-specs (filterv #(not= :scalar (:kind %)) (:argument-specs step))
-        pointer-slots (kabi/pointer-slots (kexec/abi interface))
-        logical-names (kabi/pointer-binding-names (kexec/abi interface))
+        slot-groups (kabi/logical-pointer-slot-groups (kexec/abi interface))
+        logical-names (mapv :binding slot-groups)
         spec-syms (mapv :sym pointer-specs)]
     (when-not (= (count spec-syms) (count logical-names))
       (throw (ex-info "link descriptor step pointer plan differs from its executable ABI"
                       {:reason :link-step-abi :instance id :step step-index
                        :phase (:phase step) :argument-symbols spec-syms
                        :abi-bindings logical-names})))
-    (let [slots-by-logical
-          (group-by #(or (:binding %) (:name %)) pointer-slots)
-          facts
-          (mapv (fn [sym logical-name]
+    (let [facts
+          (mapv (fn [sym {:keys [slots]}]
                   (let [node-id (get bindings sym ::missing)
                         node (get nodes node-id)
-                        slots (get slots-by-logical logical-name)
                         slot-dtypes (set (map (comp dtype/canon :dtype) slots))]
                     (when (= ::missing node-id)
                       (throw (ex-info "link instance omits a descriptor pointer binding"
@@ -292,7 +289,7 @@
                                        :actual (get-in node [:view :dtype])})))
                     {:symbol sym :node node-id
                      :access (reduce merge-access nil (map slot-access slots))}))
-                spec-syms logical-names)
+                spec-syms slot-groups)
           runtime-arguments
           (mapv (fn [{:keys [kind type value-fn sym]}]
                   (if (= :scalar kind)

--- a/src/raster/compiler/ir/program_stage.clj
+++ b/src/raster/compiler/ir/program_stage.clj
@@ -73,11 +73,10 @@
                         {:reason :program-stage-scatter :phase (:phase step) :arrays arrays})))
       {output :write source :read index :read})
     (let [interface (kexec/validate! (step-interface step))
-          logical-names (kabi/pointer-binding-names (kexec/abi interface))
+          slot-groups (kabi/logical-pointer-slot-groups (kexec/abi interface))
+          logical-names (mapv :binding slot-groups)
           pointer-specs (filterv #(not= :scalar (:kind %)) (:argument-specs step))
-          symbols (mapv :sym pointer-specs)
-          slots-by-logical (group-by #(or (:binding %) (:name %))
-                                     (kabi/pointer-slots (kexec/abi interface)))]
+          symbols (mapv :sym pointer-specs)]
       (when-not (= (count logical-names) (count symbols))
         (throw (ex-info "program stage pointer plan differs from its executable ABI"
                         {:reason :program-stage-abi :phase (:phase step)
@@ -86,16 +85,16 @@
         (throw (ex-info "program stage pointer plan requires compiler symbols"
                         {:reason :program-stage-symbols :phase (:phase step)
                          :symbols symbols})))
-      (reduce (fn [accesses [symbol logical-name]]
+      (reduce (fn [accesses [symbol {:keys [binding slots]}]]
                 (let [access (reduce merge-access nil
-                                     (map slot-access (get slots-by-logical logical-name)))]
+                                     (map slot-access slots))]
                   (when-not access
                     (throw (ex-info "program stage ABI pointer has no readable or writable effect"
                                     {:reason :program-stage-access :phase (:phase step)
-                                     :symbol symbol :binding logical-name})))
+                                     :symbol symbol :binding binding})))
                   (update accesses symbol merge-access access)))
               {}
-              (map vector symbols logical-names)))))
+              (map vector symbols slot-groups)))))
 
 (defn descriptor-accesses
   "Return the ordered per-step access maps of a resident descriptor."

--- a/src/raster/gpu/compiled.clj
+++ b/src/raster/gpu/compiled.clj
@@ -1,11 +1,11 @@
 (ns raster.gpu.compiled
   "The `Compiled` artifact — a functional, inspectable GPU program value (S4 §2).
 
-   `(r/compile #'train-step args {:target :ze:0 :donate [adapters…] :constants [Wq …]})`
-   returns a `Compiled` that implements `IFn`: calling it replays the resident program and
-   returns device values (`raster.gpu.value/DeviceArray`), not host arrays. The resident
-   descriptor is certified into the same LinkPlan used for composition and instantiated as a
-   LinkedExecutable. There is one value/view/runtime path, not an artifact-only binder beside it.
+   `(r/compile #'train-step args opts)` returns a `Compiled` that implements `IFn`: calling it
+   replays the resident program and returns device values, not host arrays. For composition,
+   `(r/lower ...)` returns an allocation-free `Prepared`; independently lowered values compose
+   through semantic boundaries and only the composite is instantiated. Resident descriptors and
+   compositions are certified into the same LinkPlan/LinkedExecutable path.
 
    The three artifact primitives, honestly scoped to the whole-program MVP:
      • device value      — outputs are DeviceArrays over resident buffers; no host round-trip.
@@ -21,6 +21,7 @@
   (:refer-clojure :exclude [compile])
   (:require [clojure.set :as set]
             [raster.compiler.ir.buffer-view :as bview]
+            [raster.compiler.ir.link-composition :as link-composition]
             [raster.compiler.ir.resident-plan :as resident-plan]
             [raster.compiler.pipeline :as pl]
             [raster.gpu.core :as gpu]
@@ -34,15 +35,15 @@
 ;; ================================================================
 
 (defrecord Compiled
-           [lowering     ;; CertifiedResidentPlan: checkable descriptor→LinkPlan witness
+           [lowering     ;; certified resident or composition lowering into LinkPlan
             executable  ;; LinkedExecutable: the sole resident runtime representation
             in-tree      ;; ordered [{:key :sym :role :donate? :shape :dtype} …] — the arg spec
             out-tree     ;; ordered [{:key :sym :shape :dtype :from} …] — the result spec (multi-output)
             donated      ;; {in-key → out-key} — the alias plan (JAX input_output_aliases)
             schedule     ;; the S6 Schedule map (reserved; nil until S6 fills it)
             target       ;; device-id + (future) HardwareDescriptor
-            descriptor   ;; the raw compile-gpu-program descriptor — inspectable
-            args         ;; captured example args (:all-params order): resident bind contents + shape source
+            descriptor   ;; raw descriptor or inspectable composite descriptor
+            args         ;; captured specialization arguments (empty for a composite)
             live-outputs] ;; atom holding the DeviceArrays projected by the LAST invocation. They
                           ;; alias resident buffers the next replay overwrites, so they are
                           ;; invalidated (marked dead) at the start of the next invoke and at close!
@@ -52,7 +53,11 @@
   (invoke [this] (invoke-compiled this {}))
   (applyTo [this argseq] (apply invoke-compiled this argseq)))
 
+(defrecord Prepared
+           [lowering in-tree out-tree donated schedule target descriptor args])
+
 (defn compiled? [x] (instance? Compiled x))
+(defn prepared? [x] (instance? Prepared x))
 
 ;; ================================================================
 ;; Role derivation (§4.2) and tree construction
@@ -74,9 +79,10 @@
            explicit-roles)))
 
 (defn- build-in-tree
-  [lowering descriptor donate]
+  [lowering descriptor arguments donate]
   (let [donate-set (set donate)
-        values (:values (:certificate lowering))]
+        values (:values (:certificate lowering))
+        argument-map (zipmap (:all-params descriptor) arguments)]
     (vec (for [p (:array-params descriptor)
                :let [{:keys [node role shape dtype]} (get values p)]]
            {:key     (keyword (name p))
@@ -85,7 +91,8 @@
             :role    role
             :donate? (contains? donate-set p)
             :shape   shape
-            :dtype   dtype}))))
+            :dtype   dtype
+            :default (get argument-map p)}))))
 
 (defn- build-out-tree
   "Out-tree = donated in→out nodes + any explicit :outputs + the functional :result-sym + taps.
@@ -121,14 +128,14 @@
     [::compiled qualified target dtype signature (:schedule descriptor)]))
 
 ;; ================================================================
-;; Compile (the public verb)
+;; Pure lowering, composition, and runtime compilation
 ;; ================================================================
 
-(defn compile
-  "Compile a deftm var into a `Compiled` artifact bound on `target`.
+(defn lower
+  "Lower a deftm var into a certified, allocation-free `Prepared` artifact.
 
    args  — example args in the descriptor's :all-params order. Supplies BOTH the shapes
-           compile-gpu-program derives AND the initial resident buffer contents at bind.
+           compile-gpu-program derives AND the eventual resident initializers.
    opts  — {:target :ze:0            device-id (default :ze:0)
             :dtype  :float           element dtype (default :float)
             :donate  [sym …]         resident :state threaded as values (donation)
@@ -138,10 +145,9 @@
             :roles   {sym → role}    explicit role override (last word)
             :gemm-precision :f16-xmx|:f32-scalar
             :on-non-resident :nil|:throw
-            :profile? bool           bind in profiling mode (for r/profile)
             :schedule <map>}         reserved S6 schedule (threaded into the cache key)"
   [fn-var args {:keys [target dtype donate constants outputs taps roles
-                       gemm-precision on-non-resident profile? schedule]
+                       gemm-precision on-non-resident schedule]
                 :or {target :ze:0 dtype :float on-non-resident :nil}}]
   (let [prog (apply pl/compile-gpu-program fn-var target
                     (cond-> [:dtype dtype :on-non-resident on-non-resident]
@@ -161,12 +167,152 @@
                   {:id (compilation-id fn-var target dtype prog args)
                    :target target :descriptor prog :arguments args
                    :roles eff-roles :outputs public-symbols})
-        executable (gpu-link/instantiate! (:plan lowering) {:profile? profile?})
-        in-tree  (build-in-tree lowering prog donate)
+        in-tree  (build-in-tree lowering prog args donate)
         out-tree (build-out-tree lowering donate outputs result-sym taps)
         donated  (into {} (map (fn [s] [(keyword (name s)) (keyword (str (name s) "'"))]) donate))]
-    (->Compiled lowering executable in-tree out-tree donated (:schedule prog) target prog args
-                (atom nil))))
+    (->Prepared lowering in-tree out-tree donated (:schedule prog) target prog args)))
+
+(defn instantiate!
+  "Instantiate one pure Prepared artifact as a callable Compiled value. All component plans have
+   already been composed, so this performs one allocation/binding/graph-recording operation."
+  ([prepared] (instantiate! prepared {}))
+  ([prepared opts]
+   (when-not (prepared? prepared)
+     (throw (ex-info "instantiate! requires an allocation-free Prepared artifact"
+                     {:reason :compiled-prepared-type :actual (type prepared)})))
+   (let [{:keys [lowering in-tree out-tree donated schedule target descriptor args]} prepared
+         executable (gpu-link/instantiate! (:plan lowering) opts)]
+     (->Compiled lowering executable in-tree out-tree donated schedule target descriptor args
+                 (atom nil)))))
+
+(defn- semantic-entry! [components side [component-id key :as reference]]
+  (when-not (and (vector? reference) (= 2 (count reference)))
+    (throw (ex-info "a semantic artifact reference is [component-id key]"
+                    {:reason :compiled-composition-reference :reference reference})))
+  (let [prepared (get components component-id)
+        entries (case side :input (:in-tree prepared) :output (:out-tree prepared))
+        matches (filterv #(= key (:key %)) entries)]
+    (when-not (= 1 (count matches))
+      (throw (ex-info "a semantic artifact reference must resolve exactly once"
+                      {:reason :compiled-composition-reference :side side :reference reference
+                       :available (mapv :key entries)})))
+    (first matches)))
+
+(defn compose
+  "Compose independently lowered Prepared artifacts through semantic boundary keys.
+
+   Request shape:
+   {:id stable-id
+    :components [{:id component-id :program prepared} ...]
+    :connections [{:from [producer-id output-key] :to [consumer-id input-key]} ...]
+    :shares [[[component-id input-or-constant-key] ...] ...]
+    :outputs [{:key composite-output-key :from [component-id output-key]} ...]}
+
+   Remaining component inputs are exposed under `[component-id input-key]`. Composition happens
+   before allocation, so connected intermediates and shared constants have one physical
+   allocation. Donation across independent artifacts is deferred until the ownership/view pass
+   can certify cross-component state threading."
+  [{:keys [id components connections shares outputs attributes]
+    :or {connections [] shares [] attributes {}}}]
+  (let [components (mapv (fn [component]
+                           (when-not (and (map? component) (contains? component :id)
+                                          (prepared? (:program component)))
+                             (throw (ex-info
+                                     "each compiled component requires :id and a Prepared :program"
+                                     {:reason :compiled-composition-component
+                                      :component component})))
+                           component)
+                         components)
+        component-map (into {} (map (juxt :id :program)) components)
+        _ (when-not (= (count components) (count component-map))
+            (throw (ex-info "compiled component identities must be unique"
+                            {:reason :compiled-composition-component-ids
+                             :ids (mapv :id components)})))
+        donated-components (filterv (comp seq :donated :program) components)
+        _ (when (seq donated-components)
+            (throw (ex-info "cross-component donation requires the composite ownership pass"
+                            {:reason :compiled-composition-donation
+                             :components (mapv :id donated-components)})))
+        resolved-connections
+        (mapv (fn [{:keys [from to]}]
+                {:from from :to to
+                 :from-entry (semantic-entry! component-map :output from)
+                 :to-entry (semantic-entry! component-map :input to)})
+              connections)
+        resolved-shares
+        (mapv (fn [group]
+                (mapv (fn [reference]
+                        {:reference reference
+                         :entry (semantic-entry! component-map :input reference)})
+                      group))
+              shares)
+        output-specs
+        (mapv (fn [{:keys [key from] :as output}]
+                (when-not (= #{:key :from} (set (keys output)))
+                  (throw (ex-info "a composite output requires exactly :key and :from"
+                                  {:reason :compiled-composition-output :output output})))
+                {:key key :from from
+                 :entry (semantic-entry! component-map :output from)})
+              outputs)
+        _ (when-not (= (count output-specs) (count (distinct (map :key output-specs))))
+            (throw (ex-info "composite output keys must be unique and ordered"
+                            {:reason :compiled-composition-output-keys
+                             :keys (mapv :key output-specs)})))
+        low-level
+        (link-composition/compose
+         {:id id
+          :components (mapv (fn [{:keys [id program]}]
+                              {:id id :lowering (:lowering program)})
+                            components)
+          :connections (mapv (fn [{:keys [from to from-entry to-entry]}]
+                               {:from [(first from) (:node from-entry)]
+                                :to [(first to) (:node to-entry)]})
+                             resolved-connections)
+          :shares (mapv (fn [group]
+                          (mapv (fn [{:keys [reference entry]}]
+                                  [(first reference) (:node entry)])
+                                group))
+                        resolved-shares)
+          :outputs (mapv (fn [{:keys [from entry]}]
+                           [(first from) (:node entry)])
+                         output-specs)
+          :attributes attributes})
+        node-mapping (get-in low-level [:certificate :node-mapping])
+        mapped-node (fn [component-id node-id]
+                      (or (get node-mapping [component-id node-id])
+                          (throw (ex-info
+                                  "certified semantic node disappeared during composition"
+                                  {:reason :compiled-composition-node
+                                   :component component-id :node node-id}))))
+        consumed-inputs (set (map :to resolved-connections))
+        discarded-shares (set (mapcat (fn [group] (map :reference (rest group)))
+                                      resolved-shares))
+        in-tree
+        (vec
+         (for [{component-id :id program :program} components
+               entry (:in-tree program)
+               :let [reference [component-id (:key entry)]]
+               :when (not (contains? consumed-inputs reference))
+               :when (not (contains? discarded-shares reference))]
+           (assoc entry :key reference :sym [component-id (:sym entry)]
+                  :node (mapped-node component-id (:node entry)))))
+        out-tree
+        (mapv (fn [{:keys [key from entry]}]
+                (assoc entry :key key :sym [(first from) (:sym entry)] :from :composed
+                       :node (mapped-node (first from) (:node entry))))
+              output-specs)
+        descriptor {:all-params [] :array-params [] :scalar-params []
+                    :steps (vec (mapcat (comp :steps :descriptor :program) components))
+                    :result-sym nil :composite? true}
+        schedules (mapv (comp :schedule :program) components)]
+    (->Prepared low-level in-tree out-tree {} schedules (:target (:plan low-level))
+                descriptor [])))
+
+(defn compile
+  "Lower and instantiate a deftm as one callable Compiled artifact. Use `lower`, `compose`, then
+   `instantiate!` when independently compiled programs must share resident values."
+  [fn-var args opts]
+  (instantiate! (lower fn-var args opts) (select-keys opts [:profile?])))
 
 ;; ================================================================
 ;; Functional invocation (§2.3)
@@ -196,12 +342,11 @@
    Mutation of resident :state is invisible: the caller sees fresh output values and the old
    donated inputs invalidated — never a mutation."
   [^Compiled c inputs]
-  (let [{:keys [executable in-tree out-tree donated descriptor target args]} c
+  (let [{:keys [executable in-tree out-tree donated target]} c
         in-nodes     (into {} (map (juxt :key identity)) in-tree)
         input-nodes  (filterv #(= :input (:role %)) in-tree)
         input-keys   (set (map :key input-nodes))
         donated-keys (set (keys donated))
-        captured (zipmap (:all-params descriptor) args)
         ;; 0. VALIDATE inputs: every passed key must be an :input-role param or a donated slot —
         ;;    never a :constant/:state key silently ignored (fail-loud, §7.7).
         _ (doseq [[k _v] inputs]
@@ -213,8 +358,8 @@
         ;; 1. Every dynamic input is refreshed on every invocation, preserving the resident-program
         ;;    contract. gpu-link/write! accepts host values and performs D2D for foreign device
         ;;    values; it never materializes a DeviceArray through v/->host.
-        _ (doseq [{:keys [key sym node]} input-nodes]
-            (gpu-link/write! executable node (get inputs key (get captured sym))))
+        _ (doseq [{:keys [key node default]} input-nodes]
+            (gpu-link/write! executable node (get inputs key default)))
         ;; 2. Donation remains stricter than an ordinary input: the passed value must already be
         ;;    this exact state view. Moving a foreign value and then calling it donation would hide
         ;;    a copy and misrepresent ownership.
@@ -258,11 +403,11 @@
 
 (defn explain
   "Print the artifact's shape: in-tree / out-tree / donation plan / target / schedule and the
-   resident step-kind histogram. Returns the Compiled unchanged."
-  [^Compiled c]
+   resident step-kind histogram. Works before or after instantiation and returns its argument."
+  [c]
   (let [{:keys [in-tree out-tree donated target schedule descriptor]} c
         kinds (frequencies (map :convention (:steps descriptor)))]
-    (println "Compiled artifact")
+    (println (if (prepared? c) "Prepared artifact" "Compiled artifact"))
     (println "  target   :" target)
     (println "  in-tree  :" (mapv (fn [n] [(:key n) (:role n) (when (:donate? n) :donate)]) in-tree))
     (println "  out-tree :" (mapv (fn [n] [(:key n) (:from n)]) out-tree))
@@ -273,24 +418,23 @@
 
 (defn ir
   "Return the descriptor's resident steps (the artifact's lowered IR) for inspection."
-  [^Compiled c]
+  [c]
   (mapv #(select-keys % [:convention :phase :variant :kernel-name]) (:steps (:descriptor c))))
 
 (defn plan
   "Return the validated LinkPlan that is the artifact's public executable representation."
-  [^Compiled c]
+  [c]
   (:plan (:lowering c)))
 
 (defn certificate
-  "Return the checkable resident-descriptor→LinkPlan lowering certificate."
-  [^Compiled c]
+  "Return the checkable resident or composition lowering certificate."
+  [c]
   (:certificate (:lowering c)))
 
 (defn- refresh-captured-inputs!
   [^Compiled c]
-  (let [captured (zipmap (get-in c [:descriptor :all-params]) (:args c))]
-    (doseq [{:keys [sym node role]} (:in-tree c) :when (= :input role)]
-      (gpu-link/write! (:executable c) node (get captured sym))))
+  (doseq [{:keys [node role default]} (:in-tree c) :when (= :input role)]
+    (gpu-link/write! (:executable c) node default))
   c)
 
 (defn profile
@@ -299,22 +443,10 @@
   [^Compiled c]
   (refresh-captured-inputs! c)
   (invalidate-live-outputs! c)
-  (let [descriptor (:descriptor c)
-        certificate (certificate c)
-        roles (:roles certificate)
-        bindings (:bindings certificate)
-        result-sym (:result-sym descriptor)
-        output-symbols (vec (concat (for [sym (:array-params descriptor)
-                                          :when (= :output (get roles sym))]
-                                      sym)
-                                    (when (and result-sym
-                                               (not (some #{result-sym}
-                                                          (:array-params descriptor))))
-                                      [result-sym])))
-        profile-result (gpu-link/profile! (:executable c))
-        result (into {} (map (fn [sym]
-                               [sym (gpu-link/download (:executable c) (get bindings sym))]))
-                     output-symbols)]
+  (let [profile-result (gpu-link/profile! (:executable c))
+        result (into {} (map (fn [{:keys [key node]}]
+                               [key (gpu-link/download (:executable c) node)]))
+                     (:out-tree c))]
     (assoc profile-result :result result)))
 
 (defn measure
@@ -332,7 +464,7 @@
   "The serializable identity of the artifact minus closures (§2b C5): in/out trees, donation,
    schedule, target, and the descriptor's step kinds + concrete shapes. Excludes the non-
    serializable closures (:n-fn/:m-fn/…) and SPIR-V modules."
-  [^Compiled c]
+  [c]
   {:in-tree  (mapv #(select-keys % [:key :role :donate? :shape :dtype]) (:in-tree c))
    :out-tree (mapv #(select-keys % [:key :from :shape :dtype]) (:out-tree c))
    :donated  (:donated c)

--- a/test/raster/compiler/ir/link_composition_test.clj
+++ b/test/raster/compiler/ir/link_composition_test.clj
@@ -1,0 +1,121 @@
+(ns raster.compiler.ir.link-composition-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.link-composition :as composition]
+            [raster.compiler.ir.link-plan :as link]
+            [raster.compiler.ir.resident-plan :as resident]))
+
+(def ^:private kernel
+  (artifact/make
+   {:kernel-name "composition_axpy"
+    :source "__kernel void composition_axpy(float* x, float* w, float* y, long n) {}"
+    :abi [(kabi/slot 'x :input :float)
+          (kabi/slot 'w :input :float)
+          (kabi/slot 'y :output :float)
+          (kabi/slot 'n :scalar :long)]
+    :arguments '[x w y n]
+    :launch (launch/spec {:workgroup-size [64]
+                          :group-count [(launch/ceil-div 'n 64)]})
+    :effects {:kind :map :reads '[x w] :writes '[y]}}))
+
+(defn- descriptor []
+  {:dtype :float
+   :all-params '[x w n]
+   :array-params '[x w]
+   :scalar-params '[n]
+   :array-roles {'x :input 'w :input}
+   :allocs [{:sym 'y :dtype :float :size-fn (fn [args] (long (nth args 2)))}]
+   :steps [{:phase :map :kernel-name "composition_axpy" :convention :map
+            :artifact kernel
+            :argument-specs [{:kind :input :sym 'x}
+                             {:kind :input :sym 'w}
+                             {:kind :output :sym 'y}
+                             {:kind :scalar :type :long
+                              :value-fn (fn [args] (long (nth args 2)))}]}]
+   :result-sym 'y})
+
+(defn- lowered [id x w]
+  (resident/lower {:id id :target :ze:0 :descriptor (descriptor)
+                   :arguments [x w (alength x)] :roles {'w :constant}
+                   :outputs ['y]}))
+
+(defn- value-node [lowering symbol]
+  (get-in lowering [:certificate :values symbol :node]))
+
+(defn- composed [n]
+  (let [weight (float-array n)
+        first (lowered :first (float-array n) weight)
+        second (lowered :second (float-array n) weight)
+        first-y (value-node first 'y)
+        second-x (value-node second 'x)
+        first-w (value-node first 'w)
+        second-w (value-node second 'w)
+        second-y (value-node second 'y)]
+    (composition/compose
+     {:id :two-layers
+      :components [{:id :first :lowering first}
+                   {:id :second :lowering second}]
+      :connections [{:from [:first first-y] :to [:second second-x]}]
+      :shares [[[:first first-w] [:second second-w]]]
+      :outputs [[:second second-y]]})))
+
+(deftest certified-plans-compose-before-allocation-through-one-node-identity
+  (let [lowering (composed 16)
+        plan (:plan lowering)
+        certificate (:certificate lowering)
+        first-y (get (:node-mapping certificate) [:first [:first 'y]])
+        second-x (get (:node-mapping certificate) [:second [:second 'x]])
+        first-w (get (:node-mapping certificate) [:first [:first 'w]])
+        second-w (get (:node-mapping certificate) [:second [:second 'w]])]
+    (is (composition/certified-composition? lowering))
+    (is (identical? lowering (composition/verify! lowering)))
+    (is (link/link-plan? plan))
+    (is (= 2 (count (:instances plan))))
+    (is (= 4 (count (:nodes plan))) "connection and shared weight each remove one allocation")
+    (is (= first-y second-x) "the intermediate is one node, not two buffers plus a copy")
+    (is (= first-w second-w) "shared constants retain one allocation identity")
+    (is (= :internal (get-in plan [:nodes first-y :role])))
+    (is (= first-y (get-in plan [:instances 1 :bindings 'x])))
+    (is (= first-w (get-in plan [:instances 1 :bindings 'w])))
+    (is (= [(get (:node-mapping certificate) [:second [:second 'y]])]
+           (:outputs plan)))))
+
+(deftest composition-is-fail-loud-at-semantic-boundaries
+  (testing "a connected view contract must be exact"
+    (let [weight (float-array 16)
+          producer (lowered :producer (float-array 16) weight)
+          consumer (lowered :consumer (float-array 8) (float-array 8))]
+      (is (= :link-composition-view-contract
+             (:reason
+              (ex-data
+               (try
+                 (composition/compose
+                  {:id :bad-shape
+                   :components [{:id :producer :lowering producer}
+                                {:id :consumer :lowering consumer}]
+                   :connections [{:from [:producer (value-node producer 'y)]
+                                  :to [:consumer (value-node consumer 'x)]}]
+                   :outputs [[:consumer (value-node consumer 'y)]]})
+                 (catch clojure.lang.ExceptionInfo error error))))))))
+  (testing "raw plans cannot bypass source-lowering verification"
+    (let [lowering (lowered :one (float-array 4) (float-array 4))]
+      (is (= :link-composition-component-type
+             (:reason
+              (ex-data
+               (try
+                 (composition/compose
+                  {:id :uncertified
+                   :components [{:id :one :lowering (:plan lowering)}]
+                   :outputs [[:one (value-node lowering 'y)]]})
+                 (catch clojure.lang.ExceptionInfo error error)))))))))
+
+(deftest composition-certificate-detects-target-plan-drift
+  (let [lowering (composed 8)
+        changed (assoc-in lowering [:plan :outputs] [])]
+    (is (= :link-composition-certificate
+           (:reason
+            (ex-data
+             (try (composition/verify! changed)
+                  (catch clojure.lang.ExceptionInfo error error))))))))

--- a/test/raster/compiler/ir/link_plan_test.clj
+++ b/test/raster/compiler/ir/link_plan_test.clj
@@ -65,6 +65,41 @@
     (is (= {'x :input 'w :constant 'y :scratch}
            (link/instance-roles plan (first (:instances plan)))))))
 
+(deftest repeated-ordinary-abi-slots-model-in-place-access-not-a-composite-value
+  (let [in-place-kernel
+        (artifact/make
+         {:kernel-name "link_in_place"
+          :source "__kernel void link_in_place(float* input, float* output, long n) {}"
+          :abi [(kabi/slot 'x :input :float :c-name "input")
+                (kabi/slot 'x :output :float :c-name "output")
+                (kabi/slot 'n :scalar :long)]
+          :arguments '[x x n]
+          :launch (launch/spec {:workgroup-size [64]
+                                :group-count [(launch/ceil-div 'n 64)]})
+          :effects {:kind :map :reads '[x] :writes '[x]}})
+        in-place-descriptor
+        {:dtype :float
+         :all-params '[x n]
+         :array-params '[x]
+         :scalar-params '[n]
+         :array-roles {'x :state}
+         :allocs []
+         :steps [{:phase :in-place :kernel-name "link_in_place" :convention :map
+                  :artifact in-place-kernel
+                  :argument-specs [{:kind :input :sym 'x}
+                                   {:kind :output :sym 'x}
+                                   {:kind :scalar :type :long
+                                    :value-fn (fn [args] (long (nth args 1)))}]}]
+         :result-sym 'x}
+        x (n :x :state (float-array 16))
+        instance (link/instance {:id :in-place :descriptor in-place-descriptor
+                                 :bindings {'x :x} :scalars {'n 16}})]
+    (is (= ['x 'x]
+           (kabi/pointer-binding-names (:abi in-place-kernel))))
+    (is (link/link-plan?
+         (link/make {:id :in-place :target :ze:0 :nodes [x]
+                     :instances [instance] :outputs [:x]})))))
+
 (deftest validation-closes-bindings-shapes-dtypes-and-ordered-effects
   (testing "every pointer symbol is explicitly bound"
     (let [i (assoc (instance :layer :x :w0 :out) :bindings {'x :x 'y :out})]
@@ -144,7 +179,7 @@
                                    :instances [(instance :consumer :hidden :w1 :out)
                                                (instance :producer :x :w0 :hidden)]
                                    :outputs [:out]}))
-                               (catch clojure.lang.ExceptionInfo e e))))))))
+                               (catch clojure.lang.ExceptionInfo e e)))))))
   (testing "external storage does not initialize an internal value"
     (let [hidden (link/node {:id :hidden :dtype :float :shape [16] :device :ze:0
                              :role :internal :ownership :external})]
@@ -156,7 +191,7 @@
                                            (n :out :output)]
                                    :instances [(instance :consumer :hidden :w :out)]
                                    :outputs [:out]})
-                                 (catch clojure.lang.ExceptionInfo e e))))))))
+                                 (catch clojure.lang.ExceptionInfo e e)))))))))
 
 (deftest physical-view-aliases-are-explicit-and-effect-checked
   (let [allocation (bview/allocation {:id :shared :byte-size 96 :memory-space :device

--- a/test/raster/gpu/compiled_composition_test.clj
+++ b/test/raster/gpu/compiled_composition_test.clj
@@ -1,0 +1,81 @@
+(ns raster.gpu.compiled-composition-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.pipeline :as pipeline]
+            [raster.gpu.compiled :as compiled]
+            [raster.gpu.link :as gpu-link]))
+
+(defn component [_x _w _n])
+
+(def ^:private kernel
+  (artifact/make
+   {:kernel-name "compiled_composition_axpy"
+    :source "__kernel void compiled_composition_axpy(float* x, float* w, float* y, long n) {}"
+    :abi [(kabi/slot 'x :input :float)
+          (kabi/slot 'w :input :float)
+          (kabi/slot 'y :output :float)
+          (kabi/slot 'n :scalar :long)]
+    :arguments '[x w y n]
+    :launch (launch/spec {:workgroup-size [64]
+                          :group-count [(launch/ceil-div 'n 64)]})
+    :effects {:kind :map :reads '[x w] :writes '[y]}}))
+
+(defn- descriptor []
+  {:dtype :float
+   :all-params '[x w n]
+   :array-params '[x w]
+   :scalar-params '[n]
+   :array-roles {'x :input 'w :input}
+   :allocs [{:sym 'y :dtype :float :size-fn (fn [args] (long (nth args 2)))}]
+   :steps [{:phase :map :kernel-name "compiled_composition_axpy" :convention :map
+            :artifact kernel
+            :argument-specs [{:kind :input :sym 'x}
+                             {:kind :input :sym 'w}
+                             {:kind :output :sym 'y}
+                             {:kind :scalar :type :long
+                              :value-fn (fn [args] (long (nth args 2)))}]}]
+   :result-sym 'y})
+
+(deftest semantic-artifacts-compose-before-one-runtime-instantiation
+  (let [weight (float-array 16)
+        prepare #(compiled/lower #'component [(float-array 16) weight 16]
+                                 {:target :ze:0 :constants '[w]})
+        [first second]
+        (with-redefs [pipeline/compile-gpu-program (fn [& _] (descriptor))
+                      gpu-link/instantiate! (fn [& _]
+                                              (throw (AssertionError.
+                                                      "lower must not contact the runtime")))]
+          [(prepare) (prepare)])
+        composite
+        (compiled/compose
+         {:id :semantic-two-layers
+          :components [{:id :first :program first}
+                       {:id :second :program second}]
+          :connections [{:from [:first :y] :to [:second :x]}]
+          :shares [[[:first :w] [:second :w]]]
+          :outputs [{:key :result :from [:second :y]}]})
+        plan (compiled/plan composite)
+        first-y (get-in first [:out-tree 0 :node])
+        second-x (get-in second [:in-tree 0 :node])
+        mapping (get-in composite [:lowering :certificate :node-mapping])]
+    (is (compiled/prepared? first))
+    (is (compiled/prepared? composite))
+    (is (= (get mapping [:first first-y]) (get mapping [:second second-x])))
+    (is (= 4 (count (:nodes plan))))
+    (is (= [[:first :x] [:first :w]] (mapv :key (:in-tree composite))))
+    (is (= [:result] (mapv :key (:out-tree composite))))
+    (is (= 2 (count (:instances plan))))
+    (is (= 2 (count (compiled/ir composite))))
+    (is (= {:map 2} (:steps (compiled/cache-key composite))))))
+
+(deftest already-instantiated-artifacts-are-too-late-to-compose-zero-copy
+  (is (= :compiled-composition-component
+         (:reason
+          (ex-data
+           (try
+             (compiled/compose
+              {:id :late :components [{:id :late :program (compiled/map->Compiled {})}]
+               :outputs []})
+             (catch clojure.lang.ExceptionInfo error error)))))))


### PR DESCRIPTION
## Summary
- add recursively certified LinkPlan composition with explicit dataflow connections and shared input/constant identities
- add allocation-free Prepared artifacts plus semantic lower, compose, and instantiate APIs
- distinguish ordinary repeated in-place ABI slots from explicit multi-slot composite bindings
- document the zero-copy composition boundary and its deliberate ranged-view/donation limits

## Validation
- compiler/link/program-stage/composition: 12 tests, 54 assertions
- resident-plan/kernel-ABI: 20 tests, 72 assertions
- live artifact/Gemma gate: 5 tests, 124 assertions; loss 2.800152 -> 0.256915
- focused changed-file formatting and git diff --check