### PR TITLE
Route GPU autotuning through linked executables

### DIFF
--- a/src/raster/gpu/dispatch_benchmark.clj
+++ b/src/raster/gpu/dispatch_benchmark.clj
@@ -11,6 +11,7 @@
             [raster.compiler.ir.kernel-executable :as kexec]
             [raster.gpu.core :as gpu]
             [raster.gpu.dispatch-tuning :as tuning]
+            [raster.gpu.link :as link]
             [raster.gpu.program-tuning :as program-tuning]))
 
 (def ^:private reserved-measurement-options
@@ -186,48 +187,49 @@
     (tuning/apply-tuning dispatch dispatch-tuning descriptor numerical-mode layout)
     (assoc-in {} target-path selector)))
 
-(defn- compiled-case-fn
-  [session program step-selector case-fn]
+(defn- linked-case-fn
+  [executable instance-selector step-selector case-fn]
   (fn [runtime-value]
     (let [case (case-fn runtime-value)]
       (when-not (map? case)
-        (throw (ex-info "compiled dispatch benchmark case must be a map"
+        (throw (ex-info "linked dispatch benchmark case must be a map"
                         {:runtime-value runtime-value :case case})))
-      (when-not (contains? case :program-arguments)
-        (throw (ex-info "compiled dispatch benchmark case requires :program-arguments"
+      (when-not (contains? case :descriptor-arguments)
+        (throw (ex-info "linked dispatch benchmark case requires :descriptor-arguments"
                         {:runtime-value runtime-value :case-keys (set (keys case))})))
-      (let [binding (gpu/program-dispatch-arguments
-                     session program step-selector (:program-arguments case))]
+      (let [binding (link/dispatch-arguments
+                     executable instance-selector step-selector (:descriptor-arguments case))]
         (assoc case
                :arguments (:arguments binding)
                ;; Validation callbacks reach the compiler-owned reference plan and the projected
-               ;; host buffer/scalar environment through (:compiled-binding (:case context)).
-               :compiled-binding (dissoc binding :arguments))))))
+               ;; host buffer/scalar environment through (:linked-binding (:case context)).
+               :linked-binding (dissoc binding :arguments))))))
 
-(defn tune-program-dispatch!
-  "Tune one KernelDispatch embedded in a live compiled resident program.
+(defn tune-linked-dispatch!
+  "Tune one KernelDispatch embedded in a live LinkedExecutable.
 
    This closes the descriptor-to-driver seam without teaching the runtime any operation. Each
-   `case-fn` result supplies `:program-arguments` in descriptor order plus the same :validate!,
+   `case-fn` result supplies `:descriptor-arguments` in descriptor order plus :validate!,
    :before-run!, and :measurement callbacks accepted by tune-dispatch!. The bridge projects the
-   step's ordered :argument-specs onto the program's stable resident buffer keys and typed scalar
-   values. When :step is omitted, the program must contain exactly one dispatch step.
+   step's ordered :argument-specs onto certified resident node views and typed scalar values. When
+   :instance is omitted, the executable must contain exactly one instance; when :step is omitted,
+   that instance must contain exactly one dispatch step.
 
    Numerical mode and layout default to emitter-owned tuning metadata but may be supplied
    explicitly. Returns the DispatchTuning together with a schedule override ready to pass as
    `:schedule` to compile-gpu-program. Compilation remains pure; this function is explicitly an
    offline action."
-  [session program descriptor runtime-values case-fn
-   & {:keys [step numerical-mode layout improvement-threshold force? measurement]
+  [executable descriptor runtime-values case-fn
+   & {:keys [instance step numerical-mode layout improvement-threshold force? measurement]
       :or {improvement-threshold 0.001 force? false}}]
-  (let [{:keys [dispatch step-index] compiled-step :step}
-        (gpu/bound-program-dispatch session program step)
+  (let [{:keys [dispatch step-index instance-id] compiled-step :step}
+        (link/linked-dispatch executable instance step)
         contract (get-in dispatch [:attributes :tuning])
         numerical-mode (or numerical-mode (:numerical-mode contract))
         layout (or layout (:layout contract))
         result (tune-dispatch!
-                session dispatch descriptor runtime-values
-                (compiled-case-fn session program step case-fn)
+                (:session executable) dispatch descriptor runtime-values
+                (linked-case-fn executable instance step case-fn)
                 :numerical-mode numerical-mode
                 :layout layout
                 :improvement-threshold improvement-threshold
@@ -237,19 +239,20 @@
      :selector (:selector result)
      :schedule-override (tuning-schedule-override dispatch result descriptor
                                                   numerical-mode layout)
+     :instance-id instance-id
      :step-index step-index
      :phase (:phase compiled-step)}))
 
-(defn tune-program-dispatches!
+(defn tune-linked-dispatches!
   "Execute an explicit program tuning plan and return one collision-free schedule override.
 
    `runtime-values-fn` receives a manifest group. `case-fn` receives that group and one runtime
-   value, and returns the compiled benchmark case accepted by tune-program-dispatch!. Equivalent
+   value, and returns the compiled benchmark case accepted by tune-linked-dispatch!. Equivalent
    sites are measured once through their first descriptor step. `:max-measurements` is an optional
    fail-before-execution upper bound on alternatives × distinct runtime samples across selected
    groups; cached results may perform fewer physical measurements."
-  [session program descriptor plan runtime-values-fn case-fn
-   & {:keys [max-measurements improvement-threshold force? measurement]
+  [executable descriptor plan runtime-values-fn case-fn
+   & {:keys [instance max-measurements improvement-threshold force? measurement]
       :or {improvement-threshold 0.001 force? false}}]
   (let [plan (program-tuning/validate-plan! plan)]
     (when-not (ifn? runtime-values-fn)
@@ -268,7 +271,7 @@
           (mapv
            (fn [group]
              (let [step (:representative-step-index group)
-                   {:keys [dispatch]} (gpu/bound-program-dispatch session program step)
+                   {:keys [dispatch]} (link/linked-dispatch executable instance step)
                    actual-signature (program-tuning/dispatch-signature dispatch)
                    supplied-runtime-values (runtime-values-fn group)
                    _runtime-values
@@ -305,9 +308,10 @@
             (mapv
              (fn [{:keys [group runtime-values planned-measurements]}]
                (assoc
-                (tune-program-dispatch!
-                 session program descriptor runtime-values
+                (tune-linked-dispatch!
+                 executable descriptor runtime-values
                  #(case-fn group %)
+                 :instance instance
                  :step (:representative-step-index group)
                  :improvement-threshold improvement-threshold
                  :force? force?

--- a/src/raster/gpu/link.clj
+++ b/src/raster/gpu/link.clj
@@ -9,6 +9,8 @@
   (:require [clojure.set :as set]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.buffer-view :as bview]
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.link-plan :as link-plan]
             [raster.gpu.core :as gpu]
             [raster.gpu.value :as value]))
@@ -205,6 +207,205 @@
         (throw (ex-info "linked executable has no such node"
                         {:reason :link-runtime-node :node node-id
                          :nodes (set (keys (:node-views executable)))})))))
+
+(defn- select-instance
+  [plan selector]
+  (let [instances (:instances plan)
+        selected
+        (cond
+          (nil? selector)
+          (when (= 1 (count instances)) (first instances))
+
+          (integer? selector)
+          (when (<= 0 (long selector) (dec (count instances)))
+            (nth instances (long selector)))
+
+          :else
+          (first (filter #(= selector (:id %)) instances)))]
+    (or selected
+        (throw
+         (ex-info
+          (if (nil? selector)
+            "a composed executable requires an explicit instance selector"
+            "linked executable instance selector did not match")
+          {:reason (if (nil? selector)
+                     :ambiguous-linked-instance
+                     :linked-instance-not-found)
+           :selector selector
+           :instances (mapv :id instances)})))))
+
+(defn- select-dispatch-step
+  [descriptor selector]
+  (let [steps (:steps descriptor)
+        indexed (mapv vector (range) steps)
+        selected
+        (cond
+          (nil? selector)
+          (let [matches (filterv (fn [[_ step]] (some? (:dispatch step))) indexed)]
+            (when (= 1 (count matches)) (first matches)))
+
+          (integer? selector)
+          (when (<= 0 (long selector) (dec (count steps)))
+            [(long selector) (nth steps (long selector))])
+
+          (keyword? selector)
+          (first (filterv (fn [[_ step]] (= selector (:phase step))) indexed))
+
+          :else
+          (throw (ex-info "linked dispatch step selector must be nil, an index, or a phase keyword"
+                          {:reason :invalid-linked-dispatch-step-selector
+                           :selector selector})))]
+    (when-not selected
+      (throw (ex-info (if (nil? selector)
+                        "a linked instance requires exactly one dispatch step when the step is omitted"
+                        "linked dispatch step selector did not match")
+                      {:reason (if (nil? selector)
+                                 :ambiguous-linked-dispatch-step
+                                 :linked-dispatch-step-not-found)
+                       :selector selector
+                       :dispatch-phases
+                       (mapv (comp :phase second)
+                             (filterv (fn [[_ step]] (some? (:dispatch step))) indexed))})))
+    (let [[index step] selected]
+      (when-not (:dispatch step)
+        (throw (ex-info "selected linked step has no KernelDispatch"
+                        {:reason :linked-step-has-no-dispatch
+                         :selector selector :index index :phase (:phase step)})))
+      {:step-index index :step step :dispatch (kdispatch/validate! (:dispatch step))})))
+
+(defn linked-dispatch
+  "Return one KernelDispatch from a live certified executable.
+
+   `instance-selector` is nil for a one-instance plan, a zero-based instance index, or a stable
+   LinkInstance id. `step-selector` is nil when that instance has exactly one dispatch, a
+   zero-based step index, or a phase keyword. Composed plans require an explicit instance so
+   compiler inspection never falls back to session registry or symbol-name inference."
+  ([executable]
+   (linked-dispatch executable nil nil))
+  ([executable step-selector]
+   (linked-dispatch executable nil step-selector))
+  ([executable instance-selector step-selector]
+   (let [executable (ensure-live! executable :linked-dispatch)
+         instance (select-instance (:plan executable) instance-selector)]
+     (assoc (select-dispatch-step (:descriptor instance) step-selector)
+            :instance-id (:id instance)
+            :descriptor (:descriptor instance)))))
+
+(defn- physical-step-arguments
+  [step logical-arguments]
+  (if-not (:logical-bindings? step)
+    logical-arguments
+    (vec
+     (mapcat (fn [spec value]
+               (if (= :scalar (:kind spec))
+                 [value]
+                 (let [slots (:slots spec)]
+                   (when-not (= 1 (count slots))
+                     (throw (ex-info
+                             "linked dispatch tuning cannot project a multi-view logical binding"
+                             {:reason :linked-dispatch-multiview-binding
+                              :phase (:phase step) :binding (:binding spec) :slots slots})))
+                   [value])))
+             (:argument-specs step) logical-arguments))))
+
+(defn dispatch-arguments
+  "Project a tuning sample onto one linked instance's resident views and physical kernel ABI.
+
+   `descriptor-arguments` follow the selected descriptor's `:all-params` order. Array values remain
+   host-side reference inputs; device arguments come only from the instance's certified bindings.
+   Samples may use shorter arrays or smaller dynamic scratch extents than the allocated node view,
+   but may never exceed it."
+  ([executable descriptor-arguments]
+   (dispatch-arguments executable nil nil descriptor-arguments))
+  ([executable step-selector descriptor-arguments]
+   (dispatch-arguments executable nil step-selector descriptor-arguments))
+  ([executable instance-selector step-selector descriptor-arguments]
+   (let [executable (ensure-live! executable :dispatch-arguments)
+         plan (:plan executable)
+         instance (select-instance plan instance-selector)
+         descriptor (:descriptor instance)
+         {:keys [step-index step dispatch] :as selected}
+         (select-dispatch-step descriptor step-selector)
+         all-params (:all-params descriptor)
+         _argument-count
+         (when-not (and (sequential? descriptor-arguments)
+                        (= (count all-params) (count descriptor-arguments)))
+           (throw (ex-info "linked dispatch arguments must follow descriptor :all-params"
+                           {:reason :linked-dispatch-argument-count
+                            :instance (:id instance)
+                            :expected (count all-params)
+                            :actual (when (sequential? descriptor-arguments)
+                                      (count descriptor-arguments))
+                            :all-params all-params})))
+         argmap (zipmap all-params descriptor-arguments)
+         bindings (:bindings instance)
+         resident-of
+         (fn [sym]
+           (let [node-id (get bindings sym ::missing)]
+             (when (= ::missing node-id)
+               (throw (ex-info "linked dispatch symbol has no certified node binding"
+                               {:reason :linked-dispatch-binding
+                                :instance (:id instance) :symbol sym})))
+             (node-view executable node-id)))
+         capacity-of
+         (fn [sym]
+           (let [view (:view (resident-of sym))]
+             (quot (:byte-length view) (dtype/bytes-of (:dtype view)))))
+         require-capacity!
+         (fn [sym required]
+           (let [capacity (capacity-of sym)]
+             (when (> (long required) (long capacity))
+               (throw (ex-info "linked dispatch sample exceeds its resident node view"
+                               {:reason :linked-dispatch-buffer-capacity
+                                :instance (:id instance) :step-index step-index
+                                :phase (:phase step) :symbol sym
+                                :required-elements (long required)
+                                :capacity-elements (long capacity)})))))
+         _array-capacities
+         (doseq [sym (:array-params descriptor)]
+           (let [array (get argmap sym)]
+             (when-not (and array (.isArray (class array)))
+               (throw (ex-info "linked dispatch array parameter must be a JVM array"
+                               {:reason :linked-dispatch-array-argument
+                                :instance (:id instance) :symbol sym
+                                :value-type (some-> array class)})))
+             (require-capacity! sym (java.lang.reflect.Array/getLength array))))
+         _scratch-capacities
+         (doseq [{:keys [sym size-fn]} (:allocs descriptor)]
+           (require-capacity! sym (size-fn descriptor-arguments)))
+         logical-arguments
+         (mapv (fn [{:keys [kind sym type value-fn]}]
+                 (if (= :scalar kind)
+                   {:type type :value (value-fn descriptor-arguments)}
+                   (resident-of sym)))
+               (:argument-specs step))
+         arguments (physical-step-arguments step logical-arguments)
+         _abi (kabi/validate-arguments! (:abi (kdispatch/default-alternative dispatch)) arguments)
+         resident-bindings
+         (into {}
+               (keep (fn [[{:keys [kind sym]} value]]
+                       (when-not (= :scalar kind) [sym value])))
+               (map vector (:argument-specs step) logical-arguments))
+         direct-scalars (select-keys argmap (:scalar-params descriptor))
+         derived-scalars
+         (reduce (fn [values [{:keys [kind expression slot]} value]]
+                   (if (= :scalar kind)
+                     (let [raw (:value value)
+                           slot-name (:name slot)]
+                       (cond-> values
+                         slot-name (assoc slot-name raw)
+                         (symbol? expression) (assoc expression raw)))
+                     values))
+                 {}
+                 (map vector (:argument-specs step) logical-arguments))]
+     (assoc selected
+            :instance-id (:id instance)
+            :descriptor descriptor
+            :arguments arguments
+            :resident-bindings resident-bindings
+            :reference-inputs
+            {:buffers (select-keys argmap (:array-params descriptor))
+             :scalars (merge direct-scalars derived-scalars)}))))
 
 (defn outputs
   "Return the plan's ordered output node identities mapped to resident views."

--- a/test/raster/gpu/dispatch_benchmark_test.clj
+++ b/test/raster/gpu/dispatch_benchmark_test.clj
@@ -10,6 +10,7 @@
             [raster.gpu.core :as gpu]
             [raster.gpu.dispatch-benchmark :as benchmark]
             [raster.gpu.dispatch-tuning :as tuning]
+            [raster.gpu.link :as link]
             [raster.gpu.measurement :as measurement]
             [raster.gpu.tuning-cache :as cache])
   (:import [java.nio.file Files]))
@@ -237,10 +238,18 @@
                    {:slot (nth abi 1) :kind :output :sym 'out}
                    {:slot (nth abi 2) :kind :scalar :type :long :expression 'width
                     :value-fn (fn [args] (nth args 1))}]}]}
-        session (atom {:programs {:compiled {:descriptor program-descriptor
-                                             :param->key {'x :resident-x}
-                                             :alloc->key {'out :resident-out}}}
-                       :buffers {:resident-x (Object.) :resident-out (Object.)}})
+        x-view (gpu/->ResidentBufferView :test-session :resident-x
+                                         {:byte-length 4096 :dtype :float})
+        out-view (gpu/->ResidentBufferView :test-session :resident-out
+                                           {:byte-length 4 :dtype :float})
+        executable
+        (link/map->LinkedExecutable
+         {:plan {:instances [{:id :compiled
+                              :descriptor program-descriptor
+                              :bindings {'x :x 'out :out}}]}
+          :session (atom {})
+          :node-views {:x x-view :out out-view}
+          :closed? (atom false)})
         measured-selector {:kind :runtime-scalar-ranges
                            :argument 'width :below :reference
                            :ranges [{:at-least 256 :strategy :subgroup}]}
@@ -262,23 +271,34 @@
                                    :case case
                                    :options (apply hash-map options)}))
                         fake-tuning)]
-          (benchmark/tune-program-dispatch!
-           session program-descriptor descriptor [128 256]
+          (benchmark/tune-linked-dispatch!
+           executable descriptor [128 256]
            (fn [width]
-             {:program-arguments [(float-array 1024) width]
+             {:descriptor-arguments [(float-array 1024) width]
               :validate! (constantly {:passed? true :oracle-hash "compiled-reference"})})))]
-    (is (= [:resident-x :resident-out {:type :long :value 256}]
+    (is (= [x-view out-view {:type :long :value 256}]
            (get-in @observed [:case :arguments])))
     (is (= 256 (get-in @observed
-                       [:case :compiled-binding :reference-inputs :scalars 'width])))
+                       [:case :linked-binding :reference-inputs :scalars 'width])))
     (is (= (:numerical-mode tuning-contract)
            (get-in @observed [:options :numerical-mode])))
     (is (= (:layout tuning-contract) (get-in @observed [:options :layout])))
     (is (= {:generic-reduction
             {:measured-selectors {"resident-benchmark-test" measured-selector}}}
            (:schedule-override result)))
+    (is (= :compiled (:instance-id result)))
     (is (= measured-selector (:selector result)))
-    (is (= :reduce (:phase result)))))
+    (is (= :reduce (:phase result)))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"exceeds its resident node view"
+         (link/dispatch-arguments executable [(float-array 1025) 256])))
+    (let [composed (assoc-in executable [:plan :instances]
+                             [(get-in executable [:plan :instances 0])
+                              (assoc (get-in executable [:plan :instances 0]) :id :second)])]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"requires an explicit instance selector"
+           (link/linked-dispatch composed)))
+      (is (= :second (:instance-id (link/linked-dispatch composed :second nil)))))))
 
 (deftest schedule-override-rejects-dispatch-without-an-emitter-path
   (let [fake-tuning

--- a/test/raster/gpu/indexed_attention_device_test.clj
+++ b/test/raster/gpu/indexed_attention_device_test.clj
@@ -1,6 +1,8 @@
 (ns raster.gpu.indexed-attention-device-test
   (:require [clojure.test :refer [deftest is]]
             [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.resident-plan :as resident-plan]
             [raster.compiler.pipeline :as pipeline]
             [raster.compiler.passes.parallel.indexed-attention-recognize :as recognize]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-route :as route]
@@ -10,6 +12,7 @@
             [raster.dl.gpu-grad-parity :as gp]
             [raster.gpu.core :as gpu]
             [raster.gpu.dispatch-benchmark :as benchmark]
+            [raster.gpu.link :as link]
             [raster.gpu.tuning-cache :as cache]
             [raster.numeric])
   (:import [java.nio.file Files]))
@@ -147,14 +150,24 @@
                   plan {:buffers {'Q q 'K k 'V v 'dst dst 'src src}
                         :scalars shape-env})]
     (gpu/with-gpu-session [session :ocl:0]
-      (let [handle (gpu/bind-program! session descriptor args)
-            selected (get-in @session [:programs :program :bounds 0
-                                       :kernel-call :artifact :attributes :strategy])
-            result (get (gpu/run-program! session handle args) (:result-sym descriptor))
-            max-error (reduce max 0.0
-                              (map #(Math/abs (- (double %1) (double %2)))
-                                   expected result))]
-        {:selected selected :max-error max-error}))))
+      (let [lowering (resident-plan/lower
+                      {:id (random-uuid) :target :ocl:0 :descriptor descriptor
+                       :arguments args :outputs [(:result-sym descriptor)]})
+            executable (link/instantiate! (:plan lowering) {:session session})
+            result-node (get-in lowering [:certificate :bindings (:result-sym descriptor)])]
+        (try
+          (let [binding (link/dispatch-arguments executable args)
+                selected (-> (kdispatch/select-alternative
+                              (:dispatch binding) (:arguments binding))
+                             :attributes :strategy)
+                _ (link/run! executable)
+                result (link/download executable result-node)
+                max-error (reduce max 0.0
+                                  (map #(Math/abs (- (double %1) (double %2)))
+                                       expected result))]
+            {:selected selected :max-error max-error})
+          (finally
+            (link/close! executable)))))))
 
 (defn- temporary-cache-root
   []
@@ -172,39 +185,45 @@
                       #'resident-indexed-attention-probe :ocl:0 :dtype :float)]
       (binding [cache/*cache-root* (temporary-cache-root)]
         (gpu/with-gpu-session [session :ocl:0]
-          (let [handle (gpu/bind-program! session descriptor args)
-                result
-                (benchmark/tune-program-dispatch!
-                 session handle (hardware/descriptor-for :ocl:0) [2]
-                 (fn [components]
-                   {:program-arguments args
-                    :validate!
-                    (fn [{:keys [case]}]
-                      (let [binding (:compiled-binding case)
-                            plan (get-in binding
-                                         [:dispatch :attributes :tuning :reference :plan])
-                            expected (reference/evaluate plan (:reference-inputs binding))
-                            output-key (get-in binding
-                                               [:resident-bindings (:result-sym descriptor)])
-                            actual ^floats (gpu/download session output-key)
-                            max-error
-                            (reduce max 0.0
-                                    (map #(Math/abs (- (double %1) (double %2)))
-                                         expected actual))]
-                        {:passed? (< max-error 2.0e-5)
-                         :oracle-hash (str "compiled-segmented-reference-v1-" components)
-                         :max-error max-error}))
-                    :measurement {:warmup-iterations 0 :budget-ms 1
-                                  :min-samples 3 :max-samples 5
-                                  :cv-threshold 100.0}})
-                 :force? true)]
-            (is (= 2 (count (get-in result [:tuning :measurements]))))
-            (is (= (:selector result)
-                   (get-in result
-                           [:schedule-override :segmented-weighted-reduction
-                            :measured-selectors
-                            (get-in descriptor [:steps 0 :dispatch :id])])))
-            (is (= :gpu-step-0 (:phase result)))))))))
+          (let [lowering (resident-plan/lower
+                          {:id (random-uuid) :target :ocl:0 :descriptor descriptor
+                           :arguments args :outputs [(:result-sym descriptor)]})
+                executable (link/instantiate! (:plan lowering) {:session session})
+                result-node (get-in lowering
+                                    [:certificate :bindings (:result-sym descriptor)])]
+            (try
+              (let [result
+                    (benchmark/tune-linked-dispatch!
+                     executable (hardware/descriptor-for :ocl:0) [2]
+                     (fn [components]
+                       {:descriptor-arguments args
+                        :validate!
+                        (fn [{:keys [case]}]
+                          (let [binding (:linked-binding case)
+                                plan (get-in binding
+                                             [:dispatch :attributes :tuning :reference :plan])
+                                expected (reference/evaluate plan (:reference-inputs binding))
+                                actual ^floats (link/download executable result-node)
+                                max-error
+                                (reduce max 0.0
+                                        (map #(Math/abs (- (double %1) (double %2)))
+                                             expected actual))]
+                            {:passed? (< max-error 2.0e-5)
+                             :oracle-hash (str "compiled-segmented-reference-v1-" components)
+                             :max-error max-error}))
+                        :measurement {:warmup-iterations 0 :budget-ms 1
+                                      :min-samples 3 :max-samples 5
+                                      :cv-threshold 100.0}})
+                     :force? true)]
+                (is (= 2 (count (get-in result [:tuning :measurements]))))
+                (is (= (:selector result)
+                       (get-in result
+                               [:schedule-override :segmented-weighted-reduction
+                                :measured-selectors
+                                (get-in descriptor [:steps 0 :dispatch :id])])))
+                (is (= :gpu-step-0 (:phase result))))
+              (finally
+                (link/close! executable)))))))))
 
 (deftest resident-compiler-selects-from-runtime-component-width
   (if-not @opencl-available?

--- a/test/raster/gpu/program_tuning_test.clj
+++ b/test/raster/gpu/program_tuning_test.clj
@@ -5,6 +5,7 @@
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.gpu.dispatch-benchmark :as benchmark]
+            [raster.gpu.link :as link]
             [raster.gpu.program-tuning :as program-tuning]))
 
 (def ^:private abi
@@ -105,10 +106,12 @@
 (deftest program-runner-checks-budget-before-tuning-and-merges-results
   (let [manifest (program-tuning/manifest descriptor)
         plan (program-tuning/tuning-plan manifest)
-        session (atom {:programs {:program {:descriptor descriptor}}})
+        executable (link/map->LinkedExecutable
+                    {:plan {:instances [{:id :program :descriptor descriptor}]}
+                     :closed? (atom false)})
         calls (atom [])
         fake-tune
-        (fn [_ _ _ runtime-values _ & options]
+        (fn [_ _ runtime-values _ & options]
           (let [step (:step (apply hash-map options))
                 dispatch (get-in descriptor [:steps step :dispatch])
                 id (:id dispatch)
@@ -122,17 +125,17 @@
              {:generic-reduction {:measured-selectors {id selector}}}
              :step-index step
              :phase (get-in descriptor [:steps step :phase])}))]
-    (with-redefs [benchmark/tune-program-dispatch! fake-tune]
+    (with-redefs [benchmark/tune-linked-dispatch! fake-tune]
       (is (thrown-with-msg?
            clojure.lang.ExceptionInfo #"exceeds its physical measurement budget"
-           (benchmark/tune-program-dispatches!
-            session descriptor {} plan
+           (benchmark/tune-linked-dispatches!
+            executable {} plan
             (constantly [256 128 256])
             (fn [& _] {})
             :max-measurements 7)))
       (is (empty? @calls))
-      (let [result (benchmark/tune-program-dispatches!
-                    session descriptor {} plan
+      (let [result (benchmark/tune-linked-dispatches!
+                    executable {} plan
                     (constantly [256 128 256])
                     (fn [& _] {})
                     :max-measurements 8)]


### PR DESCRIPTION
Moves compiled-dispatch inspection and autotuning from the legacy session program registry onto certified LinkedExecutable instances and stable resident node views. Composed executables require explicit instance selection, sampled descriptor arguments are capacity-checked against their linked views, and the public benchmark case no longer exposes legacy program bindings. Migrates the indexed-attention OpenCL correctness/tuning gate to ResidentPlan -> LinkPlan -> LinkedExecutable.\n\nVerified:\n- clojure -M:test -n raster.gpu.dispatch-benchmark-test -n raster.gpu.program-tuning-test (12 tests, 54 assertions)\n- clojure -M:test -n raster.gpu.indexed-attention-device-test (4 tests, 15 assertions, Intel Arc OpenCL)\n- clojure -M:test -n raster.gpu.link-spike-test -n raster.compiler.ir.link-plan-test -n raster.compiler.ir.resident-plan-test -n raster.compiler.ir.link-composition-test (22 tests, 103 assertions)\n- clojure -M:format on changed files