### PR TITLE
Certify logical composite GPU values

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -150,6 +150,16 @@ Consequently, shape polymorphism, layout propagation, aliasing, device
 placement, and future distributed sharding do not share a single checked
 contract.
 
+The first value-layer slice now makes that separation concrete. `AbstractValue` records logical
+dtype/shape/layout, numerical representation, memory space, placement, sharding, ownership and
+effects without containing a buffer or backend handle. `LinkValue` records a later physical layout
+and an ordered set of named `LinkNode` leaves. Kernel ABI field identities certify the flattening,
+and the common resident binder expands the same composite contract for Level Zero and OpenCL. A
+Q4_K value can therefore be represented by packed blocks, scales and sums while allocation remains
+generic byte storage; the allocator does not branch on Q4_K. Existing dense plans receive implicit
+one-leaf values. Value-level cross-component composition and descriptor-owned composite scratch
+allocation remain explicit next slices and currently fail before runtime.
+
 ### 2.5 Workload coverage is broad at the backend edge, not yet through one door
 
 Triton's practical strength is not merely its set of operations. Masks, block

--- a/src/raster/compiler/backend/gpu/par_opencl.clj
+++ b/src/raster/compiler/backend/gpu/par_opencl.clj
@@ -169,6 +169,7 @@
                                              (element-dtype element-tag)
                                              :c-name (ce/c-symbol field-sym)
                                              :binding s
+                                             :field field-name
                                              :role (pointer-role s))))
                               (:fields (get soa-expansions (symbol (name s))))))
                        soa-arr-params)

--- a/src/raster/compiler/ir/abstract_value.clj
+++ b/src/raster/compiler/ir/abstract_value.clj
@@ -1,0 +1,81 @@
+(ns raster.compiler.ir.abstract-value
+  "Backend-neutral logical value contracts.
+
+   An AbstractValue describes program semantics: logical element type and shape, representation,
+   placement and sharding constraints. It deliberately contains no BufferView or backend handle.
+   Physical realization is a later concern; one logical value may become one dense buffer or an
+   ordered tree of packed/scale/index buffers without teaching the allocator its numeric format.")
+
+(def value-kinds #{:tensor :record :opaque})
+
+(defrecord AbstractValue
+           [kind dtype shape logical-layout representation memory-space placement sharding
+            ownership effects attributes])
+
+(defn abstract-value?
+  [value]
+  (and value
+       (= "raster.compiler.ir.abstract_value.AbstractValue" (.getName (class value)))))
+
+(defn- dimension?
+  [dimension]
+  (or (and (integer? dimension) (not (neg? dimension)))
+      (symbol? dimension)
+      (seq? dimension)))
+
+(defn validate!
+  "Validate and return an AbstractValue. Tensor dimensions may remain symbolic; LinkPlan leaf
+   BufferViews are the later realized, integer-shaped storage contract."
+  [value]
+  (when-not (abstract-value? value)
+    (throw (ex-info "expected an AbstractValue"
+                    {:reason :abstract-value-type :value value :actual (type value)})))
+  (let [{:keys [kind dtype shape logical-layout representation memory-space placement sharding
+                ownership effects attributes]}
+        value]
+    (when-not (contains? value-kinds kind)
+      (throw (ex-info "abstract value has an invalid kind"
+                      {:reason :abstract-value-kind :kind kind :allowed value-kinds})))
+    (when (and (= :tensor kind) (nil? dtype))
+      (throw (ex-info "a tensor abstract value requires a logical dtype"
+                      {:reason :abstract-value-dtype :value value})))
+    (when-not (or (nil? dtype) (keyword? dtype) (map? dtype))
+      (throw (ex-info "abstract value dtype must be a keyword, descriptor map, or nil"
+                      {:reason :abstract-value-dtype :dtype dtype})))
+    (when-not (and (vector? shape) (every? dimension? shape))
+      (throw (ex-info "abstract value shape must contain non-negative or symbolic dimensions"
+                      {:reason :abstract-value-shape :shape shape})))
+    (doseq [[field candidate] [[:logical-layout logical-layout]
+                               [:representation representation]
+                               [:placement placement]
+                               [:sharding sharding]]]
+      (when-not (or (nil? candidate) (map? candidate))
+        (throw (ex-info "abstract value facet must be nil or a map"
+                        {:reason :abstract-value-facet :field field :value candidate}))))
+    (when-not (or (nil? memory-space) (keyword? memory-space))
+      (throw (ex-info "abstract value memory space must be a keyword or nil"
+                      {:reason :abstract-value-memory-space :memory-space memory-space})))
+    (when-not (or (nil? ownership) (contains? #{:owned :borrowed :external} ownership))
+      (throw (ex-info "abstract value has an invalid ownership contract"
+                      {:reason :abstract-value-ownership :ownership ownership})))
+    (when-not (set? effects)
+      (throw (ex-info "abstract value effects must be an explicit set"
+                      {:reason :abstract-value-effects :effects effects})))
+    (when-not (map? attributes)
+      (throw (ex-info "abstract value attributes must be a map"
+                      {:reason :abstract-value-attributes :attributes attributes}))))
+  value)
+
+(defn make
+  [{:keys [kind dtype shape logical-layout representation memory-space placement sharding
+           ownership effects attributes]
+    :or {kind :tensor shape [] representation {:kind :plain} effects #{} attributes {}}}]
+  (validate!
+   (->AbstractValue kind dtype (vec shape) logical-layout representation memory-space placement
+                    sharding ownership effects attributes)))
+
+(defn tensor
+  "Construct a tensor AbstractValue. `:representation` records numerical/storage semantics such
+   as `{:kind :quantized :scheme :q4-k}` without prescribing its physical buffer leaves."
+  [opts]
+  (make (assoc opts :kind :tensor)))

--- a/src/raster/compiler/ir/kernel_abi.clj
+++ b/src/raster/compiler/ir/kernel_abi.clj
@@ -11,19 +11,21 @@
 (def ^:private kinds #{:input :output :scalar})
 
 (defn slot
-  "Construct one ABI slot. Options: :c-name, :kernel-dtype, :role, and :binding.
+  "Construct one ABI slot. Options: :c-name, :kernel-dtype, :role, :binding, and :field.
 
    `:binding` names the logical caller value that supplies a physical pointer slot. It is
    normally absent (and therefore identical to `:name`), but an SoA argument has one physical
-   slot per field and all of those slots share the same logical binding."
-  [nm kind dtype & {:keys [c-name kernel-dtype role binding]}]
+   slot per field and all of those slots share the same logical binding.
+   `:field` identifies this physical leaf within a composite logical binding."
+  [nm kind dtype & {:keys [c-name kernel-dtype role binding field]}]
   (cond-> {:name nm
            :c-name (or c-name (name nm))
            :kind kind
            :dtype (dt/canon dtype)
            :kernel-dtype (dt/canon (or kernel-dtype dtype))}
     role (assoc :role role)
-    binding (assoc :binding binding)))
+    binding (assoc :binding binding)
+    field (assoc :field field)))
 
 (defn validate!
   "Validate an ordered ABI and return it unchanged.  A kernel has at least one output;
@@ -46,18 +48,31 @@
                         {:index i :slot s :dtype (get s k)}))))
     (when (and (= :scalar (:kind s)) (:binding s))
       (throw (ex-info "kernel ABI scalar slot cannot have a logical pointer :binding"
+                      {:index i :slot s :abi abi})))
+    (when (and (= :scalar (:kind s)) (:field s))
+      (throw (ex-info "kernel ABI scalar slot cannot name a composite pointer field"
+                      {:index i :slot s :abi abi})))
+    (when (and (:field s) (nil? (:binding s)))
+      (throw (ex-info "kernel ABI composite field requires an explicit logical binding"
                       {:index i :slot s :abi abi}))))
   (when-not (= (count abi) (count (distinct (map :c-name abi))))
     (throw (ex-info "kernel ABI parameter names must be unique" {:abi abi})))
   (let [pointers (vec (remove #(= :scalar (:kind %)) abi))]
     (doseq [binding (distinct (keep :binding pointers))]
-      (let [indexes (keep-indexed (fn [i slot] (when (= binding (:binding slot)) i)) pointers)]
+      (let [bound-slots (filterv #(= binding (:binding %)) pointers)
+            indexes (keep-indexed (fn [i slot] (when (= binding (:binding slot)) i)) pointers)]
         (when-not (= (count indexes) (inc (- (apply max indexes) (apply min indexes))))
           (throw (ex-info "kernel ABI physical slots for one logical binding must be contiguous"
-                          {:binding binding :indexes (vec indexes) :abi abi}))))))
-  (when-not (some #(= :output (:kind %)) abi)
-    (throw (ex-info "kernel ABI must contain at least one output" {:abi abi})))
-  abi)
+                          {:binding binding :indexes (vec indexes) :abi abi})))
+        (when (and (< 1 (count bound-slots))
+                   (not (and (every? :field bound-slots)
+                             (= (count bound-slots)
+                                (count (distinct (map :field bound-slots)))))))
+          (throw (ex-info "composite ABI slots require unique explicit field identities"
+                          {:binding binding :slots bound-slots :abi abi})))))
+    (when-not (some #(= :output (:kind %)) abi)
+      (throw (ex-info "kernel ABI must contain at least one output" {:abi abi})))
+    abi))
 
 (defn pointer-slots
   "Pointer-valued ABI slots, in kernel signature order."
@@ -176,7 +191,7 @@
     {:pairs pairs
      :pointer-pairs (filterv (fn [[slot _]] (not= :scalar (:kind slot))) pairs)
      :scalar-pairs (filterv (fn [[slot _]] (and (= :scalar (:kind slot))
-                                                 (not= :bound (:role slot)))) pairs)
+                                                (not= :bound (:role slot)))) pairs)
      :result-pair (first result-pairs)
      :bound-pair (first bound-pairs)}))
 

--- a/src/raster/compiler/ir/link_composition.clj
+++ b/src/raster/compiler/ir/link_composition.clj
@@ -39,7 +39,23 @@
                              (throw (ex-info "each link component requires :id and :lowering"
                                              {:reason :link-composition-component
                                               :component component})))
-                           (update component :lowering verify-component!))
+                           (let [component (update component :lowering verify-component!)
+                                 composite-values
+                                 (into {}
+                                       (filter (fn [[_ value]] (< 1 (count (:leaves value)))))
+                                       (get-in component [:lowering :plan :values]))]
+                             ;; The current composition API connects physical node endpoints. It
+                             ;; cannot yet prove that every leaf of two logical values is unified
+                             ;; atomically, so refusing the whole component is safer than silently
+                             ;; splitting ownership or field order during namespacing.
+                             (when (seq composite-values)
+                               (throw
+                                (ex-info
+                                 "logical composite values require value-level link composition"
+                                 {:reason :link-composition-logical-values
+                                  :component (:id component)
+                                  :values (set (keys composite-values))})))
+                             component))
                          components)
         ids (mapv :id components)]
     (when (empty? components)

--- a/src/raster/compiler/ir/link_plan.clj
+++ b/src/raster/compiler/ir/link_plan.clj
@@ -7,6 +7,7 @@
    executable selection and graph recording deliberately live in raster.gpu.link."
   (:require [clojure.set :as set]
             [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.buffer-view :as bview]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
@@ -17,8 +18,9 @@
 (def binder-roles #{:input :constant :state :output :scratch})
 
 (defrecord LinkNode [id view role source])
+(defrecord LinkValue [id abstract physical-layout leaves])
 (defrecord LinkInstance [id descriptor bindings scalars schedule roles arguments])
-(defrecord LinkPlan [id target nodes instances outputs aliases attributes])
+(defrecord LinkPlan [id target nodes values instances outputs aliases attributes])
 
 (defn link-node? [x]
   (and x (= "raster.compiler.ir.link_plan.LinkNode" (.getName (class x)))))
@@ -28,6 +30,9 @@
 
 (defn link-plan? [x]
   (and x (= "raster.compiler.ir.link_plan.LinkPlan" (.getName (class x)))))
+
+(defn link-value? [x]
+  (and x (= "raster.compiler.ir.link_plan.LinkValue" (.getName (class x)))))
 
 (defn- shape-elements [shape]
   (reduce * 1 shape))
@@ -134,6 +139,92 @@
                    (bview/view allocation {:id id :byte-offset byte-offset :dtype dtype
                                            :shape shape :strides strides})))]
     (validate-node! (->LinkNode id view role source))))
+
+(defn value
+  "Construct one logical value realized by ordered physical LinkNode leaves.
+
+   Each leaf is `{:name field-id :node node-id}`. The order is the physical ABI order; names are
+   independently checked against KernelABI `:field` identities so equal-dtype fields cannot be
+   silently swapped. `:physical-layout` identifies the realized packing independently of the
+   AbstractValue's logical layout and numerical representation."
+  [{:keys [id abstract physical-layout leaves]}]
+  (when (nil? id)
+    (throw (ex-info "a link value requires a stable identity" {:reason :link-value-id})))
+  (av/validate! abstract)
+  (when-not (or (nil? physical-layout) (map? physical-layout))
+    (throw (ex-info "link value physical layout must be a descriptor map or nil"
+                    {:reason :link-value-physical-layout :value id
+                     :physical-layout physical-layout})))
+  (when-not (and (vector? leaves) (seq leaves)
+                 (every? #(and (map? %) (:name %) (contains? % :node)) leaves))
+    (throw (ex-info "a link value requires ordered named physical leaves"
+                    {:reason :link-value-leaves :value id :leaves leaves})))
+  (let [names (mapv :name leaves)
+        nodes (mapv :node leaves)]
+    (when-not (= (count names) (count (distinct names)))
+      (throw (ex-info "link value leaf names must be unique"
+                      {:reason :link-value-leaf-names :value id :names names})))
+    (when-not (= (count nodes) (count (distinct nodes)))
+      (throw (ex-info "one link value cannot repeat a physical node"
+                      {:reason :link-value-leaf-nodes :value id :nodes nodes}))))
+  (->LinkValue id abstract
+               (or physical-layout {:kind (if (= 1 (count leaves)) :dense :ordered-fields)})
+               leaves))
+
+(defn- node-abstract-value
+  [node]
+  (let [view (bview/validate-view! (:view node))
+        allocation (:allocation view)]
+    (av/tensor {:dtype (:dtype view)
+                :shape (:shape view)
+                :logical-layout {:strides (:strides view)}
+                :memory-space (:memory-space allocation)
+                :placement {:device (:device allocation)}
+                :ownership (:ownership allocation)})))
+
+(defn- implicit-value
+  [node]
+  (value {:id (:id node)
+          :abstract (node-abstract-value node)
+          :leaves [{:name :value :node (:id node)}]}))
+
+(defn- normalize-values
+  [nodes values]
+  (let [explicit (cond
+                   (nil? values) {}
+                   (map? values) values
+                   :else (into {} (map (juxt :id identity)) values))
+        _ (doseq [[value-id link-value] explicit]
+            (when-not (link-value? link-value)
+              (throw (ex-info "link plan values must be LinkValue records"
+                              {:reason :link-value-type :value value-id
+                               :actual (type link-value)})))
+            (when-not (= value-id (:id link-value))
+              (throw (ex-info "link value map key differs from the value identity"
+                              {:reason :link-value-map-key :key value-id
+                               :value (:id link-value)})))
+            (value link-value))
+        claimed (mapcat (fn [[_ link-value]] (map :node (:leaves link-value))) explicit)
+        frequencies (frequencies claimed)]
+    (when-let [[node-id count] (first (filter (fn [[_ count]] (< 1 count)) frequencies))]
+      (throw (ex-info "one physical node cannot belong to multiple logical values"
+                      {:reason :link-value-overlap :node node-id :claims count})))
+    (merge explicit
+           (into {}
+                 (keep (fn [[node-id link-node]]
+                         (when-not (contains? frequencies node-id)
+                           [node-id (implicit-value link-node)])))
+                 nodes))))
+
+(defn value-node-ids
+  "Ordered physical LinkNode identities realizing `value-id`."
+  [plan value-id]
+  (let [link-value (get (:values plan) value-id)]
+    (when-not link-value
+      (throw (ex-info "link value identity is absent"
+                      {:reason :link-absent-value :value value-id
+                       :values (set (keys (:values plan)))})))
+    (mapv :node (:leaves link-value))))
 
 (defn validate-instance!
   [instance]
@@ -245,7 +336,7 @@
       (get-in schedule [:segmented-weighted-reduction :strategy] :auto))))
 
 (defn- abi-step-facts
-  [nodes instance step-index step]
+  [nodes values instance step-index step]
   (let [{:keys [id descriptor bindings schedule]} instance
         args (instance-arguments instance)
         interface (kexec/validate! (step-interface step))
@@ -258,44 +349,71 @@
                       {:reason :link-step-abi :instance id :step step-index
                        :phase (:phase step) :argument-symbols spec-syms
                        :abi-bindings logical-names})))
-    (let [facts
+    (let [binding-facts
           (mapv (fn [sym {:keys [slots]}]
-                  (let [node-id (get bindings sym ::missing)
-                        node (get nodes node-id)
-                        slot-dtypes (set (map (comp dtype/canon :dtype) slots))]
-                    (when (= ::missing node-id)
+                  (let [value-id (get bindings sym ::missing)
+                        link-value (get values value-id)
+                        leaves (:leaves link-value)]
+                    (when (= ::missing value-id)
                       (throw (ex-info "link instance omits a descriptor pointer binding"
                                       {:reason :link-missing-binding :instance id :symbol sym
                                        :phase (:phase step)})))
-                    (when-not node
-                      (throw (ex-info "link instance binding names an absent node"
-                                      {:reason :link-absent-node :instance id :symbol sym
-                                       :node node-id :phase (:phase step)})))
-                    (when-not (bview/contiguous? (:view node))
-                      (throw (ex-info "linked kernel ABI bindings currently require contiguous views"
-                                      {:reason :link-noncontiguous-binding :instance id
-                                       :symbol sym :node node-id :phase (:phase step)
-                                       :shape (get-in node [:view :shape])
-                                       :strides (get-in node [:view :strides])})))
-                    (when-not (= 1 (count slots))
-                      (throw (ex-info "one link node cannot represent a multi-slot composite ABI"
-                                      {:reason :link-composite-binding-required :instance id
-                                       :symbol sym :node node-id :slots slots
-                                       :dtypes slot-dtypes})))
-                    (when-not (= (dtype/canon (get-in node [:view :dtype])) (first slot-dtypes))
-                      (throw (ex-info "link node dtype differs from the executable ABI"
-                                      {:reason :link-node-dtype :instance id :symbol sym :node node-id
-                                       :expected (first slot-dtypes)
-                                       :actual (get-in node [:view :dtype])})))
-                    {:symbol sym :node node-id
-                     :access (reduce merge-access nil (map slot-access slots))}))
+                    (when-not link-value
+                      (throw (ex-info "link instance binding names an absent logical value"
+                                      {:reason :link-absent-value :instance id :symbol sym
+                                       :value value-id :phase (:phase step)})))
+                    (when-not (= (count slots) (count leaves))
+                      (throw (ex-info "logical value leaf count differs from its physical ABI group"
+                                      {:reason :link-value-abi-leaves :instance id :symbol sym
+                                       :value value-id :slots slots :leaves leaves})))
+                    (when (and (< 1 (count leaves)) (not (:logical-bindings? step)))
+                      (throw (ex-info "composite link value requires logical descriptor binding"
+                                      {:reason :link-composite-binding-mode :instance id
+                                       :symbol sym :value value-id :phase (:phase step)})))
+                    (let [leaf-facts
+                          (mapv
+                           (fn [slot {:keys [name node] :as leaf}]
+                             (let [link-node (get nodes node)]
+                               (when-not link-node
+                                 (throw (ex-info "link value leaf names an absent physical node"
+                                                 {:reason :link-value-leaf-node :instance id
+                                                  :symbol sym :value value-id :leaf leaf})))
+                               (when-not (bview/contiguous? (:view link-node))
+                                 (throw (ex-info "linked kernel ABI bindings currently require contiguous views"
+                                                 {:reason :link-noncontiguous-binding :instance id
+                                                  :symbol sym :node node :phase (:phase step)
+                                                  :shape (get-in link-node [:view :shape])
+                                                  :strides (get-in link-node [:view :strides])})))
+                               (when (and (:field slot) (not= (:field slot) name))
+                                 (throw (ex-info "link value physical field order differs from its ABI"
+                                                 {:reason :link-value-abi-field :instance id
+                                                  :symbol sym :value value-id :node node
+                                                  :expected (:field slot) :actual name})))
+                               (when-not (= (dtype/canon (get-in link-node [:view :dtype]))
+                                            (dtype/canon (:dtype slot)))
+                                 (throw (ex-info "link node dtype differs from the executable ABI"
+                                                 {:reason :link-node-dtype :instance id :symbol sym
+                                                  :value value-id :node node
+                                                  :expected (:dtype slot)
+                                                  :actual (get-in link-node [:view :dtype])})))
+                               {:symbol sym :value value-id :node node
+                                :field name :access (slot-access slot)}))
+                           slots leaves)]
+                      {:symbol sym :value value-id :slots slots :leaves leaves
+                       :facts leaf-facts})))
                 spec-syms slot-groups)
+          physical-pointers (vec (mapcat (comp (partial map :node) :leaves) binding-facts))
+          scalar-arguments
+          (mapv (fn [{:keys [type value-fn]}] {:type type :value (value-fn args)})
+                (filterv #(= :scalar (:kind %)) (:argument-specs step)))
           runtime-arguments
-          (mapv (fn [{:keys [kind type value-fn sym]}]
-                  (if (= :scalar kind)
-                    {:type type :value (value-fn args)}
-                    (get bindings sym)))
-                (:argument-specs step))
+          (loop [slots (kexec/abi interface)
+                 pointers physical-pointers scalars scalar-arguments result []]
+            (if-let [slot (first slots)]
+              (if (= :scalar (:kind slot))
+                (recur (next slots) pointers (next scalars) (conj result (first scalars)))
+                (recur (next slots) (next pointers) scalars (conj result (first pointers))))
+              (vec result)))
           selected (if-let [dispatch (:dispatch step)]
                      (kdispatch/select-alternative
                       dispatch runtime-arguments
@@ -325,7 +443,8 @@
                             {:reason :link-node-range :instance id :step step-index
                              :phase (:phase step) :buffer (:id buffer) :node node-id
                              :expected expected :capacity capacity})))))
-      {:instance id :step step-index :phase (:phase step) :facts facts})))
+      {:instance id :step step-index :phase (:phase step)
+       :facts (vec (mapcat :facts binding-facts))})))
 
 (defn- scatter-step-facts
   [nodes instance step-index step]
@@ -385,10 +504,10 @@
              {:symbol index-sym :node index-id :access :read}]}))
 
 (defn- instance-step-facts
-  [nodes instance step-index step]
+  [nodes values instance step-index step]
   (if (= :scatter (:convention step))
     (scatter-step-facts nodes instance step-index step)
-    (abi-step-facts nodes instance step-index step)))
+    (abi-step-facts nodes values instance step-index step)))
 
 (defn- canonical-alias-pair [pair]
   (let [pair (set pair)]
@@ -401,7 +520,7 @@
   (when-not (link-plan? plan)
     (throw (ex-info "expected a LinkPlan value"
                     {:reason :link-plan-type :plan plan :actual (type plan)})))
-  (let [{:keys [id target nodes instances outputs aliases attributes]} plan]
+  (let [{:keys [id target nodes values instances outputs aliases attributes]} plan]
     (when (nil? id)
       (throw (ex-info "a link plan requires a stable identity" {:reason :link-plan-id})))
     (when-not (keyword? target)
@@ -420,6 +539,64 @@
           (throw (ex-info "link node allocation belongs to a different device"
                           {:reason :link-node-device :node node-id
                            :target target :device device})))))
+    (when-not (and (map? values) (seq values))
+      (throw (ex-info "a link plan requires a non-empty logical value map"
+                      {:reason :link-values :values values})))
+    (let [claimed (volatile! #{})]
+      (doseq [[value-id link-value] values]
+        (value link-value)
+        (when-not (= value-id (:id link-value))
+          (throw (ex-info "link value map key differs from the value identity"
+                          {:reason :link-value-map-key :key value-id
+                           :value (:id link-value)})))
+        (let [leaf-nodes (mapv :node (:leaves link-value))
+              leaf-records (mapv nodes leaf-nodes)
+              roles (set (map :role leaf-records))
+              ownerships (set (map #(get-in % [:view :allocation :ownership]) leaf-records))
+              memory-spaces (set (map #(get-in % [:view :allocation :memory-space]) leaf-records))
+              devices (set (map #(get-in % [:view :allocation :device]) leaf-records))]
+          (when-not (every? some? leaf-records)
+            (throw (ex-info "link value leaf names an absent physical node"
+                            {:reason :link-value-leaf-node :value value-id
+                             :leaves leaf-nodes :nodes (set (keys nodes))})))
+          (when-let [overlap (seq (set/intersection @claimed (set leaf-nodes)))]
+            (throw (ex-info "one physical node cannot belong to multiple logical values"
+                            {:reason :link-value-overlap :value value-id :nodes (set overlap)})))
+          (vswap! claimed into leaf-nodes)
+          (when-not (= 1 (count roles))
+            (throw (ex-info "one logical value requires one dataflow role across its leaves"
+                            {:reason :link-value-roles :value value-id :roles roles})))
+          (when-not (= 1 (count ownerships))
+            (throw (ex-info "one logical value requires atomic ownership across its leaves"
+                            {:reason :link-value-ownership :value value-id
+                             :ownerships ownerships})))
+          (when-not (= 1 (count memory-spaces))
+            (throw (ex-info "one logical value requires one memory space across its leaves"
+                            {:reason :link-value-memory-spaces :value value-id
+                             :memory-spaces memory-spaces})))
+          (when-not (= 1 (count devices))
+            (throw (ex-info "one logical value cannot span devices before sharding lowering"
+                            {:reason :link-value-devices :value value-id :devices devices})))
+          (let [abstract (:abstract link-value)
+                abstract-device (get-in abstract [:placement :device])]
+            (when (and (:ownership abstract)
+                       (not= #{(:ownership abstract)} ownerships))
+              (throw (ex-info "logical ownership differs from its physical realization"
+                              {:reason :link-value-abstract-ownership :value value-id
+                               :abstract (:ownership abstract) :physical ownerships})))
+            (when (and (:memory-space abstract)
+                       (not= #{(:memory-space abstract)} memory-spaces))
+              (throw (ex-info "logical memory space differs from its physical realization"
+                              {:reason :link-value-abstract-memory-space :value value-id
+                               :abstract (:memory-space abstract) :physical memory-spaces})))
+            (when (and abstract-device (not= #{abstract-device} devices))
+              (throw (ex-info "logical placement differs from its physical realization"
+                              {:reason :link-value-abstract-device :value value-id
+                               :abstract abstract-device :physical devices}))))))
+      (when-not (= @claimed (set (keys nodes)))
+        (throw (ex-info "every physical LinkNode must realize exactly one logical value"
+                        {:reason :link-value-coverage :claimed @claimed
+                         :nodes (set (keys nodes))}))))
     (when-not (and (vector? instances) (seq instances))
       (throw (ex-info "a link plan requires an ordered non-empty instance vector"
                       {:reason :link-instances :instances instances})))
@@ -475,7 +652,7 @@
                         {:reason :link-spurious-alias :alias pair}))))
     plan))
 
-(defn- validate-instance-bindings! [nodes instance]
+(defn- validate-instance-bindings! [nodes values instance]
   (let [{:keys [id descriptor bindings roles]} instance
         expected (descriptor-pointer-symbols descriptor)
         actual (set (keys bindings))]
@@ -488,18 +665,26 @@
       (throw (ex-info "link instance roles name symbols outside its pointer bindings"
                       {:reason :link-role-symbols :instance id
                        :extra (set/difference (set (keys roles)) expected)})))
-    (doseq [[sym node-id] bindings]
-      (when-not (contains? nodes node-id)
-        (throw (ex-info "link instance binding names an absent node"
-                        {:reason :link-absent-node :instance id :symbol sym :node node-id})))
+    (doseq [[sym value-id] bindings]
+      (when-not (contains? values value-id)
+        (throw (ex-info "link instance binding names an absent logical value"
+                        {:reason :link-absent-value :instance id :symbol sym :value value-id})))
       (when (and (= :constant (get roles sym))
-                 (not= :constant (get-in nodes [node-id :role])))
-        (throw (ex-info "a constant instance binding requires a constant LinkNode"
-                        {:reason :link-role-mismatch :instance id :symbol sym :node node-id
-                         :node-role (get-in nodes [node-id :role])}))))
+                 (not= :constant (get-in nodes [(-> values (get value-id) :leaves first :node)
+                                                :role])))
+        (throw (ex-info "a constant instance binding requires a constant logical value"
+                        {:reason :link-role-mismatch :instance id :symbol sym :value value-id
+                         :value-role (get-in nodes [(-> values (get value-id) :leaves first :node)
+                                                    :role])}))))
     (let [args (instance-arguments instance)]
       (doseq [{:keys [sym dtype size-fn]} (:allocs descriptor)]
-        (let [node-id (get bindings sym)
+        (let [value-id (get bindings sym)
+              leaves (get-in values [value-id :leaves])
+              _ (when-not (= 1 (count leaves))
+                  (throw (ex-info "descriptor flat allocation cannot realize a composite value"
+                                  {:reason :link-composite-allocation-required :instance id
+                                   :symbol sym :value value-id :leaves leaves})))
+              node-id (:node (first leaves))
               link-node (get nodes node-id)
               expected-elements
               (try (long (size-fn args))
@@ -518,17 +703,17 @@
                              :expected-elements expected-elements
                              :actual-elements actual-elements})))))
       (mapv (fn [[step-index step]]
-              (instance-step-facts nodes instance step-index step))
+              (instance-step-facts nodes values instance step-index step))
             (map-indexed vector (:steps descriptor))))))
 
-(defn- validate-effects! [{:keys [target nodes instances outputs aliases] :as plan}]
+(defn- validate-effects! [{:keys [target nodes values instances outputs aliases] :as plan}]
   (when (and (not (let [target-name (name target)]
                     (or (= "ze" target-name) (.startsWith target-name "ze:"))))
              (some #(= :scatter (:convention %))
                    (mapcat (comp :steps :descriptor) instances)))
     (throw (ex-info "linked scatter execution is not available on this target backend"
                     {:reason :link-target-convention :target target :convention :scatter})))
-  (let [step-facts (mapcat #(validate-instance-bindings! nodes %) instances)
+  (let [step-facts (mapcat #(validate-instance-bindings! nodes values %) instances)
         initialized (volatile! (into #{}
                                      (keep (fn [[id {:keys [role source]}]]
                                              ;; Ownership answers who releases storage, not whether
@@ -581,14 +766,17 @@
 (defn make
   "Construct and purely validate a LinkPlan.
 
-   `:nodes` may be a node-id map or an ordered collection of LinkNodes. `:aliases` is an explicit
-   collection of two-node collections for overlapping views; undeclared physical overlap fails.
-   Instance order and each descriptor's step order define the current serial dependency schedule."
-  [{:keys [id target nodes instances outputs aliases attributes]
+   `:nodes` may be a node-id map or an ordered collection of LinkNodes. Optional `:values` groups
+   nodes into ordered logical LinkValues; every unclaimed node receives an implicit one-leaf value
+   with the same identity. `:aliases` explicitly declares overlapping views. Instance order and
+   each descriptor's step order define the current serial dependency schedule."
+  [{:keys [id target nodes values instances outputs aliases attributes]
     :or {outputs [] aliases #{} attributes {}}}]
   (let [nodes (if (map? nodes) nodes (into {} (map (juxt :id identity)) nodes))
+        values (normalize-values nodes values)
         aliases (into #{} (map canonical-alias-pair) aliases)]
-    (validate! (->LinkPlan id target nodes (vec instances) (vec outputs) aliases attributes))))
+    (validate! (->LinkPlan id target nodes values (vec instances) (vec outputs) aliases
+                           attributes))))
 
 (defn instance-roles
   "Resolve compiler-symbol roles for the runtime binder. Only `:constant` affects executable
@@ -597,12 +785,14 @@
   (when-not (link-plan? plan)
     (throw (ex-info "instance-roles requires a LinkPlan" {:actual (type plan)})))
   (validate-instance! instance)
-  (let [nodes (:nodes plan)]
+  (let [nodes (:nodes plan)
+        values (:values plan)]
     (merge
      (into {}
-           (map (fn [[sym node-id]]
-                  [sym (case (get-in nodes [node-id :role])
-                         :internal :scratch
-                         (get-in nodes [node-id :role]))]))
-           (:bindings instance))
+           (map (fn [[sym value-id]]
+                  (let [node-id (get-in values [value-id :leaves 0 :node])]
+                    [sym (case (get-in nodes [node-id :role])
+                           :internal :scratch
+                           (get-in nodes [node-id :role]))]))
+                (:bindings instance)))
      (:roles instance))))

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -39,7 +39,8 @@
             [raster.compiler.ir.kernel-graph-call :as kgcall]
             [raster.compiler.pipeline :as pl]
             [raster.core :as rcore]
-            [raster.gpu.measurement :as measurement]))
+            [raster.gpu.measurement :as measurement]
+            [raster.gpu.resident-value :as resident-value]))
 
 ;; ================================================================
 ;; Backend dispatch
@@ -1664,28 +1665,33 @@
          {:keys [kernel-name phase]} step
          materialized (volatile! {})
          owned-view-buffers (volatile! [])
-         resolve-buf (fn [sym]
-                       (let [key-or-view (sym->key sym)]
-                         (if (resident-buffer-view? key-or-view)
-                           (or (get @materialized key-or-view)
-                               (let [{:keys [buffer view]}
-                                     (resolve-resident-binding sess key-or-view)
-                                     _ (when-not (bview/contiguous? view)
-                                         (throw (ex-info
-                                                 "resident descriptor binding requires a contiguous view"
-                                                 {:kernel kernel-name :symbol sym :view (:id view)
-                                                  :shape (:shape view) :strides (:strides view)})))
-                                     {runtime-buffer :buffer owned-view? :owned-view?}
-                                     (runtime-buffer-for-view device-id buffer view)]
-                                 (when owned-view?
-                                   (vswap! owned-view-buffers conj runtime-buffer))
-                                 (vswap! materialized assoc key-or-view runtime-buffer)
-                                 runtime-buffer))
-                           (or (get-in @sess [:buffers key-or-view])
-                               (throw (ex-info (str "No buffer for kernel arg: " sym " → "
-                                                    key-or-view)
-                                               {:kernel kernel-name
-                                                :available (keys (:buffers @sess))}))))))
+         materialize
+         (fn materialize [sym key-or-view]
+           (cond
+             (resident-value/resident-composite? key-or-view)
+             (resident-value/map-values #(materialize sym %) key-or-view)
+
+             (resident-buffer-view? key-or-view)
+             (or (get @materialized key-or-view)
+                 (let [{:keys [buffer view]} (resolve-resident-binding sess key-or-view)
+                       _ (when-not (bview/contiguous? view)
+                           (throw (ex-info
+                                   "resident descriptor binding requires a contiguous view"
+                                   {:kernel kernel-name :symbol sym :view (:id view)
+                                    :shape (:shape view) :strides (:strides view)})))
+                       {runtime-buffer :buffer owned-view? :owned-view?}
+                       (runtime-buffer-for-view device-id buffer view)]
+                   (when owned-view?
+                     (vswap! owned-view-buffers conj runtime-buffer))
+                   (vswap! materialized assoc key-or-view runtime-buffer)
+                   runtime-buffer))
+
+             :else
+             (or (get-in @sess [:buffers key-or-view])
+                 (throw (ex-info (str "No buffer for kernel arg: " sym " → " key-or-view)
+                                 {:kernel kernel-name
+                                  :available (keys (:buffers @sess))})))))
+         resolve-buf (fn [sym] (materialize sym (sym->key sym)))
          bound-step
          (try
            (assoc (bind-resident-step device-id step args resolve-buf schedule roles)

--- a/src/raster/gpu/link.clj
+++ b/src/raster/gpu/link.clj
@@ -13,6 +13,7 @@
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.link-plan :as link-plan]
             [raster.gpu.core :as gpu]
+            [raster.gpu.resident-value :as resident-value]
             [raster.gpu.value :as value]))
 
 (declare close! run!)
@@ -160,9 +161,18 @@
                (gpu/bind-step!
                 session (assoc step :phase phase) (link-plan/instance-arguments instance)
                 (fn [symbol]
-                  (or (get node-views (get bindings symbol))
-                      (throw (ex-info "validated link binding disappeared during instantiation"
-                                      {:instance (:id instance) :symbol symbol}))))
+                  (let [value-id (get bindings symbol)
+                        link-value (get-in plan [:values value-id])
+                        fields (mapv (fn [{:keys [name node]}]
+                                       {:name name :value (get node-views node)})
+                                     (:leaves link-value))]
+                    (when-not (and link-value (every? :value fields))
+                      (throw (ex-info "validated link value disappeared during instantiation"
+                                      {:instance (:id instance) :symbol symbol
+                                       :value value-id})))
+                    (if (= 1 (count fields))
+                      (:value (first fields))
+                      (resident-value/composite value-id fields))))
                 {:schedule (or (:schedule instance) (get-in instance [:descriptor :schedule]))
                  :roles (link-plan/instance-roles plan instance)})
                (vswap! phases conj phase)))

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -24,7 +24,8 @@
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
-            [raster.compiler.ir.kernel-launch :as klaunch]))
+            [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.gpu.resident-value :as resident-value]))
 
 ;; ================================================================
 ;; Library loading
@@ -479,17 +480,19 @@
         arrays))
 
 (defn expand-pointer-binding
-  "Expand one logical artifact pointer binding into OpenCL physical resident values. OpenCL's
-   current resident representation is one OclBuffer per logical value; multi-slot SoA bindings
-   fail here explicitly until an OpenCL SoA view is introduced. Driver state is not touched."
-  [{:keys [binding slots]} value]
-  (when-not (= 1 (count slots))
-    (throw (ex-info "OpenCL has no resident representation for a multi-slot logical pointer"
-                    {:binding binding :slots slots :value-type (type value)})))
-  (when-not (or (device-buffer? value) (instance? MemorySegment value))
-    (throw (ex-info "OpenCL logical pointer requires OclBuffer/MemorySegment"
-                    {:binding binding :slot (first slots) :value-type (type value)})))
-  [value])
+  "Expand one logical artifact pointer binding into OpenCL physical resident values. Driver state
+   is not touched; composite validation is shared with the Level Zero backend."
+  [{:keys [binding slots] :as group} value]
+  (if (resident-value/resident-composite? value)
+    (resident-value/expand group value)
+    (do
+      (when-not (= 1 (count slots))
+        (throw (ex-info "multi-slot logical pointer requires a resident composite value"
+                        {:binding binding :slots slots :value-type (type value)})))
+      (when-not (or (device-buffer? value) (instance? MemorySegment value))
+        (throw (ex-info "OpenCL logical pointer requires OclBuffer/MemorySegment"
+                        {:binding binding :slot (first slots) :value-type (type value)})))
+      [value])))
 
 (defn- kernel-info-value
   "Read a compiler-owned emitter attribute from an artifact or a remaining specialized entry."

--- a/src/raster/gpu/resident_value.clj
+++ b/src/raster/gpu/resident_value.clj
@@ -1,0 +1,59 @@
+(ns raster.gpu.resident-value
+  "Backend-neutral resident composite values used while flattening a logical KernelABI binding.
+
+   Fields remain ordered because physical kernel arguments are positional. A field value may be a
+   checked ResidentBufferView before materialization or a backend buffer afterwards."
+  (:require [raster.compiler.core.dtype :as dtype]))
+
+(defrecord ResidentComposite [id fields])
+
+(defn resident-composite?
+  [value]
+  (and value (= "raster.gpu.resident_value.ResidentComposite" (.getName (class value)))))
+
+(defn composite
+  [id fields]
+  (let [fields (vec fields)
+        names (mapv :name fields)]
+    (when-not (seq fields)
+      (throw (ex-info "resident composite requires at least one physical field"
+                      {:reason :resident-composite-empty :id id})))
+    (when-not (every? #(and (map? %) (:name %) (contains? % :value)) fields)
+      (throw (ex-info "resident composite fields require :name and :value"
+                      {:reason :resident-composite-field :id id :fields fields})))
+    (when-not (= (count names) (count (distinct names)))
+      (throw (ex-info "resident composite field names must be unique and ordered"
+                      {:reason :resident-composite-fields :id id :fields names})))
+    (->ResidentComposite id fields)))
+
+(defn map-values
+  [f composite-value]
+  (when-not (resident-composite? composite-value)
+    (throw (ex-info "map-values requires a ResidentComposite"
+                    {:actual (type composite-value)})))
+  (composite (:id composite-value)
+             (mapv #(update % :value f) (:fields composite-value))))
+
+(defn expand
+  "Validate and flatten a ResidentComposite against one ordered logical ABI group. Backend
+   buffers share the `:dtype` contract, so field identity and storage type are checked once here
+   before either Level Zero or OpenCL sees physical pointer arguments."
+  [{:keys [binding slots]} composite-value]
+  (when-not (resident-composite? composite-value)
+    (throw (ex-info "expand requires a ResidentComposite"
+                    {:binding binding :actual (type composite-value)})))
+  (let [fields (:fields composite-value)]
+    (when-not (= (count slots) (count fields))
+      (throw (ex-info "resident composite field count differs from its artifact binding"
+                      {:binding binding :expected (count slots) :actual (count fields)
+                       :slots slots :fields (mapv :name fields)})))
+    (doseq [[slot field] (map vector slots fields)]
+      (when (and (:field slot) (not= (:field slot) (:name field)))
+        (throw (ex-info "resident composite field order differs from its physical ABI slot"
+                        {:binding binding :slot slot :field (:name field)})))
+      (when-not (= (dtype/canon (:dtype slot))
+                   (dtype/canon (:dtype (:value field))))
+        (throw (ex-info "resident composite field dtype differs from its physical ABI slot"
+                        {:binding binding :slot slot :field (:name field)
+                         :expected (:dtype slot) :actual (:dtype (:value field))}))))
+    (mapv :value fields)))

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -37,7 +37,8 @@
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
-            [raster.compiler.ir.kernel-launch :as klaunch]))
+            [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.gpu.resident-value :as resident-value]))
 
 ;; ================================================================
 ;; Library loading
@@ -1170,10 +1171,13 @@
 
 (defn expand-pointer-binding
   "Expand one logical artifact pointer binding into Level Zero's physical resident values.
-   A GpuSoA supplies one checked field segment per ABI slot; ordinary resident buffers supply one
-   slot. This function is driver-free and is called before KernelCall construction."
-  [{:keys [binding slots]} value]
+   A ResidentComposite or legacy GpuSoA supplies one checked value per ABI field; ordinary resident
+   buffers supply one slot. This function is driver-free and runs before KernelCall construction."
+  [{:keys [binding slots] :as group} value]
   (cond
+    (resident-value/resident-composite? value)
+    (resident-value/expand group value)
+
     (gpu-soa? value)
     (let [fields (:field-segs ^GpuSoA value)]
       (when-not (= (count slots) (count fields))
@@ -1193,7 +1197,7 @@
       (mapv :seg fields))
 
     (not= 1 (count slots))
-    (throw (ex-info "multi-slot logical pointer requires a GpuSoA resident value"
+    (throw (ex-info "multi-slot logical pointer requires a resident composite or GpuSoA value"
                     {:binding binding :slots slots :value-type (type value)}))
 
     (or (device-buffer? value) (instance? MemorySegment value))

--- a/test/raster/compiler/ir/abstract_value_test.clj
+++ b/test/raster/compiler/ir/abstract_value_test.clj
@@ -1,0 +1,32 @@
+(ns raster.compiler.ir.abstract-value-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.abstract-value :as av]))
+
+(deftest logical-values-do-not-prescribe-physical-buffer-count
+  (let [value (av/tensor {:dtype :float
+                          :shape ['batch 4096]
+                          :logical-layout {:order [0 1]}
+                          :representation {:kind :quantized :scheme :q4-k}
+                          :memory-space :device
+                          :placement {:device :gpu}
+                          :ownership :borrowed
+                          :effects #{:read}})]
+    (is (av/abstract-value? value))
+    (is (= ['batch 4096] (:shape value)))
+    (is (= :q4-k (get-in value [:representation :scheme])))
+    (is (= :borrowed (:ownership value)))
+    (is (= #{:read} (:effects value)))
+    (is (not (contains? value :view)))
+    (is (not (contains? value :buffer)))))
+
+(deftest abstract-value-validation-is-fail-loud
+  (testing "tensor semantics require a dtype"
+    (is (= :abstract-value-dtype
+           (:reason (ex-data
+                     (try (av/make {:kind :tensor :shape [8]})
+                          (catch clojure.lang.ExceptionInfo error error)))))))
+  (testing "negative realized extents are never legal"
+    (is (= :abstract-value-shape
+           (:reason (ex-data
+                     (try (av/tensor {:dtype :float :shape [-1]})
+                          (catch clojure.lang.ExceptionInfo error error))))))))

--- a/test/raster/compiler/ir/kernel_call_test.clj
+++ b/test/raster/compiler/ir/kernel_call_test.clj
@@ -5,6 +5,7 @@
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.gpu.ocl-runtime :as ocl]
+            [raster.gpu.resident-value :as resident-value]
             [raster.gpu.ze-runtime :as ze]))
 
 (def ^:private artifact
@@ -79,8 +80,10 @@
           :source (str "__kernel void logical_soa_contract_test("
                        "__global const float* particles_x, "
                        "__global const int* particles_id, __global float* out, int n) {}")
-          :abi [(kabi/slot 'particles_x :input :float :binding 'particles :role :operand)
-                (kabi/slot 'particles_id :input :int :binding 'particles :role :operand)
+          :abi [(kabi/slot 'particles_x :input :float :binding 'particles :field :x
+                           :role :operand)
+                (kabi/slot 'particles_id :input :int :binding 'particles :field :id
+                           :role :operand)
                 (kabi/slot 'out :output :float :role :effect)
                 (kabi/slot 'n :scalar :int :role :bound)]
           :arguments '[particles_x particles_id out n]
@@ -108,6 +111,14 @@
             (ze/->GpuSoA 'Particle 'ParticleSoA 65
                          [{:name "x" :dtype :float :seg :seg-x}
                           {:name "id" :dtype :int :seg :seg-id}]))))
+    (let [resident (resident-value/composite
+                    :particles
+                    [{:name :x :value {:dtype :float :resident :x}}
+                     {:name :id :value {:dtype :int :resident :id}}])]
+      (is (= [{:dtype :float :resident :x} {:dtype :int :resident :id}]
+             (ze/expand-pointer-binding (first plan) resident)))
+      (is (= [{:dtype :float :resident :x} {:dtype :int :resident :id}]
+             (ocl/expand-pointer-binding (first plan) resident))))
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo #"field order/name"
          (ze/expand-pointer-binding

--- a/test/raster/compiler/ir/link_plan_test.clj
+++ b/test/raster/compiler/ir/link_plan_test.clj
@@ -1,5 +1,6 @@
 (ns raster.compiler.ir.link-plan-test
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.buffer-view :as bview]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as artifact]
@@ -132,13 +133,13 @@
                                              :instances [(instance :layer :x :w :out)]
                                              :outputs [:out]})
                                  (catch clojure.lang.ExceptionInfo e e))))))))
-  (testing "a flat node cannot silently stand in for a multi-buffer SoA value"
+  (testing "one logical value binds an explicitly ordered multi-buffer ABI"
     (let [soa-kernel
           (artifact/make
            {:kernel-name "link_soa"
             :source "__kernel void link_soa(float* x_a, float* x_b, float* y, long n) {}"
-            :abi [(kabi/slot 'x_a :input :float :binding 'x)
-                  (kabi/slot 'x_b :input :float :binding 'x)
+            :abi [(kabi/slot 'x_a :input :float :binding 'x :field :a)
+                  (kabi/slot 'x_b :input :float :binding 'x :field :b)
                   (kabi/slot 'y :output :float)
                   (kabi/slot 'n :scalar :long)]
             :arguments '[x_a x_b y n]
@@ -159,14 +160,46 @@
                                                  :value-fn (fn [args] (long (nth args 1)))}]}]
                       :result-sym 'y}
           i (link/instance {:id :soa :descriptor descriptor
-                            :bindings {'x :x 'y :out} :scalars {'n 16}})]
-      (is (= :link-composite-binding-required
-             (:reason (ex-data
-                       (try
-                         (link/make {:id :soa :target :ze:0
-                                     :nodes [(n :x :input (float-array 16)) (n :out :output)]
-                                     :instances [i] :outputs [:out]})
-                         (catch clojure.lang.ExceptionInfo e e))))))))
+                            :bindings {'x :x 'y :out} :scalars {'n 16}})
+          x-a (n :x-a :input (float-array 16))
+          x-b (n :x-b :input (float-array 16))
+          x (link/value {:id :x
+                         :abstract (av/tensor {:dtype :float :shape [16]
+                                               :representation {:kind :soa-test}})
+                         :physical-layout {:kind :soa :field-order [:a :b]}
+                         :leaves [{:name :a :node :x-a}
+                                  {:name :b :node :x-b}]})
+          plan (link/make {:id :soa :target :ze:0
+                           :nodes [x-a x-b (n :out :output)]
+                           :values [x] :instances [i] :outputs [:out]})]
+      (is (= [:x-a :x-b] (link/value-node-ids plan :x)))
+      (is (= :soa-test (get-in plan [:values :x :abstract :representation :kind])))
+      (is (= [:a :b] (get-in plan [:values :x :physical-layout :field-order])))
+      (is (= :link-value-abstract-ownership
+             (:reason
+              (ex-data
+               (try
+                 (link/make {:id :soa-ownership :target :ze:0
+                             :nodes [x-a x-b (n :out :output)]
+                             :values [(link/value
+                                       {:id :x
+                                        :abstract (assoc (:abstract x) :ownership :borrowed)
+                                        :leaves (:leaves x)})]
+                             :instances [i] :outputs [:out]})
+                 (catch clojure.lang.ExceptionInfo error error))))))
+      (is (= :link-value-abi-field
+             (:reason
+              (ex-data
+               (try
+                 (link/make {:id :soa-swapped :target :ze:0
+                             :nodes [x-a x-b (n :out :output)]
+                             :values [(link/value
+                                       {:id :x
+                                        :abstract (:abstract x)
+                                        :leaves [{:name :b :node :x-a}
+                                                 {:name :a :node :x-b}]})]
+                             :instances [i] :outputs [:out]})
+                 (catch clojure.lang.ExceptionInfo error error))))))))
   (testing "an internal consumer cannot precede its producer"
     (is (= :link-read-before-write
            (:reason (ex-data (try

--- a/test/raster/compiler/kernel_abi_test.clj
+++ b/test/raster/compiler/kernel_abi_test.clj
@@ -48,8 +48,8 @@
                                                       [{:type :int :value 2}]))))
 
 (deftest soa-physical-slots-collapse-to-one-logical-binding
-  (let [abi [(kabi/slot 'particles_x :output :float :binding 'particles :role :inout)
-             (kabi/slot 'particles_id :output :int :binding 'particles :role :inout)
+  (let [abi [(kabi/slot 'particles_x :output :float :binding 'particles :field :x :role :inout)
+             (kabi/slot 'particles_id :output :int :binding 'particles :field :id :role :inout)
              (kabi/slot '_n_bound :scalar :int :role :bound)]]
     (is (= '[particles] (kabi/pointer-binding-names abi)))
     (is (= '[particles]
@@ -62,10 +62,11 @@
                           (kabi/validate-physical-pointer-dtypes! abi [:float :float]))))
   (testing "a logical SoA cannot be split around another physical binding"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must be contiguous"
-          (kabi/validate!
-           [(kabi/slot 'particles_x :output :float :binding 'particles)
-            (kabi/slot 'other :input :float)
-            (kabi/slot 'particles_id :output :int :binding 'particles)])))))
+                          (kabi/validate!
+                           [(kabi/slot 'particles_x :output :float :binding 'particles :field :x)
+                            (kabi/slot 'other :input :float)
+                            (kabi/slot 'particles_id :output :int :binding 'particles
+                                       :field :id)])))))
 
 (deftest repeated-unbound-name-remains-positional
   (testing "an in-place generic map may bind the same value as an input and the result"

--- a/test/raster/gpu/link_spike_test.clj
+++ b/test/raster/gpu/link_spike_test.clj
@@ -11,7 +11,11 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.core :refer [deftm]]
             [raster.dl.gpu-grad-parity :as gp]
+            [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.buffer-view :as bview]
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.link-plan :as link-plan]
             [raster.compiler.pipeline :as pl]
             [raster.dl.nn :as nn]
@@ -67,6 +71,58 @@
                      :closed? (atom false)})]
     (is (= output-ids (vec (keys (gpu-link/outputs executable)))))
     (is (= (range 12) (vals (gpu-link/outputs executable))))))
+
+(deftest linked-composite-value-expands-through-the-common-runtime
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "LinkValue composite ABI expansion")
+    (let [n 16
+          x-a (float-array (map float (range n)))
+          x-b (float-array (map #(float (* 2 %)) (range n)))
+          expected (float-array (map + x-a x-b))
+          kernel
+          (artifact/make
+           {:kernel-name "linked_composite_add"
+            :source (str "__kernel void linked_composite_add("
+                         "__global const float* x_a, __global const float* x_b, "
+                         "__global float* y, long n) { "
+                         "long i = get_global_id(0); if (i < n) y[i] = x_a[i] + x_b[i]; }")
+            :abi [(kabi/slot 'x_a :input :float :binding 'x :field :a)
+                  (kabi/slot 'x_b :input :float :binding 'x :field :b)
+                  (kabi/slot 'y :output :float)
+                  (kabi/slot 'n :scalar :long)]
+            :arguments '[x_a x_b y n]
+            :launch (launch/spec {:workgroup-size [64]
+                                  :group-count [(launch/ceil-div 'n 64)]})})
+          descriptor
+          {:dtype :float :all-params '[x n] :array-params '[x] :scalar-params '[n]
+           :array-roles {'x :input}
+           :allocs [{:sym 'y :dtype :float :size-fn (fn [args] (long (nth args 1)))}]
+           :steps [{:phase :add :kernel-name "linked_composite_add" :convention :map
+                    :artifact kernel :logical-bindings? true
+                    :argument-specs [{:kind :pointer :sym 'x}
+                                     {:kind :output :sym 'y}
+                                     {:kind :scalar :type :long
+                                      :value-fn (fn [args] (long (nth args 1)))}]}]
+           :result-sym 'y}
+          node (fn [id role source]
+                 (link-plan/node {:id id :dtype :float :shape [n] :device :ze:0
+                                  :role role :source source}))
+          nodes [(node :x-a :input x-a) (node :x-b :input x-b) (node :y :output nil)]
+          composite (link-plan/value
+                     {:id :x
+                      :abstract (av/tensor {:dtype :float :shape [n]
+                                            :representation {:kind :soa-test}})
+                      :leaves [{:name :a :node :x-a} {:name :b :node :x-b}]})
+          instance (link-plan/instance
+                    {:id :add :descriptor descriptor :bindings {'x :x 'y :y}
+                     :scalars {'n n} :arguments [nil n]})
+          plan (link-plan/make {:id :composite-add :target :ze:0 :nodes nodes
+                                :values [composite] :instances [instance] :outputs [:y]})
+          executable (gpu-link/instantiate! plan)]
+      (try
+        (gpu-link/run! executable)
+        (is (= (vec expected) (vec (gpu-link/download executable :y))))
+        (finally (gpu-link/close! executable))))))
 
 (deftest attached-close-attempts-the-entire-reverse-order-teardown
   (let [calls (atom [])


### PR DESCRIPTION
## Summary

- introduce a backend-neutral `AbstractValue` contract for logical dtype/shape/layout, representation, placement, sharding, ownership and effects
- let one `LinkValue` realize that contract as ordered named physical `LinkNode` leaves with an explicit physical layout
- add stable KernelABI field identities and certify composite leaf count, order, dtype, role, ownership, memory space, placement and effects before allocation
- materialize composite values through the shared resident binder and flatten the same contract on Level Zero and OpenCL
- preserve existing dense plans through implicit one-leaf values

This is the first value-layer landing slice for quantization-neutral batching. A Q4_K value can later bind packed blocks/scales/sums without teaching LinkPlan allocation about Q4_K. Value-level cross-component composition and descriptor-owned composite scratch allocation deliberately remain fail-loud next slices.

## Verification

- all `raster.compiler.ir.*` namespaces: 153 tests, 753 assertions
- logical value / ABI / link / resident focused gate: 32 tests, 134 assertions
- KernelABI + SoA gate: 31 tests, 80 assertions
- compiled/resident artifact gate: 16 tests, 86 assertions
- OpenCL codegen/session gate: 32 tests, 157 assertions
- targeted cljfmt and `git diff --check`

The live Level Zero composite LinkValue launch passed before the host OOMed during the monolithic all-namespace suite. After recovery, Level Zero initialization returned `0x78000001`, so repeated device gates took their explicit probe-error skip path. The monolithic suite had progressed through frontend, AD, CPU, quant, DP4A/DPAS, contraction, compiler passes, decoder, and model tests without a code failure before the system OOM; isolated cold runs above are capped at 4 GiB.
