### PR TITLE
Compose and allocate logical GPU values

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -130,8 +130,8 @@ come only from certified node bindings. Independently lowered `Prepared` artifac
 before allocation through semantic input/output keys. The composition certificate namespaces
 component identities, unifies explicit dataflow and shared constant/input nodes, and re-derives one
 validated plan; one later instantiation therefore removes even the device copy. The remaining
-value-layer cleanup is ranged-view/cross-component ownership composition and retirement of the
-duplicate legacy whole-program binding API after parity.
+value-layer cleanup is ranged-view composition and explicit cross-component ownership transfer;
+the duplicate legacy whole-program binding API is retired.
 
 Pretrained-rstr's batch boundary is the next concrete shape test: weights bind once to shared
 constant nodes, while residual, scratch, position, logits and token storage are lane-local nodes or
@@ -157,8 +157,12 @@ and an ordered set of named `LinkNode` leaves. Kernel ABI field identities certi
 and the common resident binder expands the same composite contract for Level Zero and OpenCL. A
 Q4_K value can therefore be represented by packed blocks, scales and sums while allocation remains
 generic byte storage; the allocator does not branch on Q4_K. Existing dense plans receive implicit
-one-leaf values. Value-level cross-component composition and descriptor-owned composite scratch
-allocation remain explicit next slices and currently fail before runtime.
+one-leaf values. The follow-up slice makes resident parameter and allocation descriptors speak the
+same contract: composite parameters have field initializers, composite scratch has independent
+leaf size closures, and allocation still sees only typed byte ranges. Certified composition now
+unifies and shares whole logical values atomically while retaining both logical and physical
+certificate mappings; public composite outputs must flatten every leaf in field order. The
+remaining value-layer boundary is ranged/subview composition with explicit ownership transfer.
 
 ### 2.5 Workload coverage is broad at the backend edge, not yet through one door
 

--- a/src/raster/compiler/ir/link_composition.clj
+++ b/src/raster/compiler/ir/link_composition.clj
@@ -13,7 +13,8 @@
 
 (defrecord LinkCompositionCertificate
            [source-dialect target-dialect plan-id target component-plan-ids
-            connections shares node-mapping allocation-mapping instance-mapping outputs])
+            connections shares value-mapping node-mapping allocation-mapping instance-mapping
+            outputs])
 (defrecord CertifiedLinkComposition [plan certificate components specification])
 
 (defn certificate? [x]
@@ -39,23 +40,7 @@
                              (throw (ex-info "each link component requires :id and :lowering"
                                              {:reason :link-composition-component
                                               :component component})))
-                           (let [component (update component :lowering verify-component!)
-                                 composite-values
-                                 (into {}
-                                       (filter (fn [[_ value]] (< 1 (count (:leaves value)))))
-                                       (get-in component [:lowering :plan :values]))]
-                             ;; The current composition API connects physical node endpoints. It
-                             ;; cannot yet prove that every leaf of two logical values is unified
-                             ;; atomically, so refusing the whole component is safer than silently
-                             ;; splitting ownership or field order during namespacing.
-                             (when (seq composite-values)
-                               (throw
-                                (ex-info
-                                 "logical composite values require value-level link composition"
-                                 {:reason :link-composition-logical-values
-                                  :component (:id component)
-                                  :values (set (keys composite-values))})))
-                             component))
+                           (update component :lowering verify-component!))
                          components)
         ids (mapv :id components)]
     (when (empty? components)
@@ -66,20 +51,30 @@
                       {:reason :link-composition-component-ids :ids ids})))
     components))
 
-(defn- node-ref! [component-plans [component-id node-id :as reference]]
+(defn- value-ref! [component-plans [component-id value-id :as reference]]
   (when-not (and (vector? reference) (= 2 (count reference)))
-    (throw (ex-info "a link composition node reference is [component-id node-id]"
-                    {:reason :link-composition-node-reference :reference reference})))
+    (throw (ex-info "a link composition value reference is [component-id value-id]"
+                    {:reason :link-composition-value-reference :reference reference})))
   (let [plan (get component-plans component-id)]
     (when-not plan
       (throw (ex-info "a link composition node reference names an absent component"
                       {:reason :link-composition-component-reference
                        :reference reference :components (set (keys component-plans))})))
-    (when-not (contains? (:nodes plan) node-id)
-      (throw (ex-info "a link composition node reference names an absent component node"
-                      {:reason :link-composition-node-reference :reference reference
-                       :nodes (set (keys (:nodes plan)))})))
-    reference))
+    (if (contains? (:values plan) value-id)
+      reference
+      (let [owners (into []
+                         (keep (fn [[candidate value]]
+                                 (when (some #(= value-id (:node %)) (:leaves value))
+                                   candidate)))
+                         (:values plan))]
+        (if (= 1 (count owners))
+          ;; Compatibility for callers holding a physical output identity from an older
+          ;; certificate. Even one leaf resolves to its whole logical value atomically.
+          [component-id (first owners)]
+          (throw (ex-info "a link composition value reference names an absent component value"
+                          {:reason :link-composition-value-reference :reference reference
+                           :physical-owners owners
+                           :values (set (keys (:values plan)))})))))))
 
 (defn- namespace-id [composition-id component-id kind id]
   [composition-id component-id kind id])
@@ -95,10 +90,15 @@
                         (assoc allocation :id (namespace-id composition-id component-id
                                                             :allocation (:id allocation)))))))
 
-(defn- namespace-instance [composition-id component-id node-mapping instance]
+(defn- namespace-value [composition-id component-id node-mapping value]
+  (assoc value
+         :id (namespace-id composition-id component-id :value (:id value))
+         :leaves (mapv #(update % :node node-mapping) (:leaves value))))
+
+(defn- namespace-instance [composition-id component-id value-mapping instance]
   (assoc instance
          :id (namespace-id composition-id component-id :instance (:id instance))
-         :bindings (update-vals (:bindings instance) node-mapping)))
+         :bindings (update-vals (:bindings instance) value-mapping)))
 
 (defn- endpoint-contract [node]
   (let [view (:view node)
@@ -112,23 +112,37 @@
                               [:byte-size :memory-space :device :alignment :coherence
                                :ownership])}))
 
-(defn- require-equal-contract! [kind references nodes]
-  (let [contracts (mapv (comp endpoint-contract nodes) references)]
+(defn- value-contract [value nodes]
+  {:abstract (:abstract value)
+   :physical-layout (:physical-layout value)
+   :leaves (mapv (fn [{:keys [name node]}]
+                   {:name name :view (endpoint-contract (get nodes node))})
+                 (:leaves value))})
+
+(defn- require-equal-contract! [kind references values nodes]
+  (let [contracts (mapv #(value-contract (get values %) nodes) references)]
     (when-not (apply = contracts)
       (throw (ex-info "composed boundary values have different realized view contracts"
                       {:reason :link-composition-view-contract :kind kind
                        :references references :contracts contracts})))))
 
-(defn- require-single-node-allocations! [references nodes]
+(defn- require-single-node-allocations! [references values nodes]
   ;; Step 4 generalizes this to ranged/subview boundary unification. Rejecting it here is crucial:
   ;; rebasing one endpoint of a multi-view allocation would silently change the other aliases.
   (let [counts (frequencies (map #(get-in % [:view :allocation :id]) (vals nodes)))]
     (doseq [reference references
-            :let [allocation-id (get-in nodes [reference :view :allocation :id])]]
+            node-id (map :node (:leaves (get values reference)))
+            :let [allocation-id (get-in nodes [node-id :view :allocation :id])]]
       (when-not (= 1 (get counts allocation-id))
         (throw (ex-info "composition across a multi-view allocation requires ranged-view linking"
-                        {:reason :link-composition-ranged-view :node reference
+                        {:reason :link-composition-ranged-view :value reference :node node-id
                          :allocation allocation-id :views (get counts allocation-id)}))))))
+
+(defn- value-role [plan value-id]
+  (get-in plan [:nodes (get-in plan [:values value-id :leaves 0 :node]) :role]))
+
+(defn- public-output-value? [plan value-id]
+  (contains? (set (link-plan/output-value-ids plan)) value-id))
 
 (defn- normalize-connections! [connections component-plans component-order]
   (let [connections
@@ -137,43 +151,43 @@
                   (throw (ex-info "a dataflow connection requires exactly :from and :to"
                                   {:reason :link-composition-connection
                                    :connection connection})))
-                {:from (node-ref! component-plans from)
-                 :to (node-ref! component-plans to)})
+                {:from (value-ref! component-plans from)
+                 :to (value-ref! component-plans to)})
               connections)
         targets (mapv :to connections)]
     (when-not (= (count targets) (count (distinct targets)))
       (throw (ex-info "a composed consumer node has more than one producer"
                       {:reason :link-composition-producers :targets targets})))
     (doseq [{:keys [from to]} connections
-            :let [[from-component from-node] from
-                  [to-component to-node] to
+            :let [[from-component from-value] from
+                  [to-component to-value] to
                   from-plan (get component-plans from-component)
                   to-plan (get component-plans to-component)]]
       (when-not (< (get component-order from-component) (get component-order to-component))
         (throw (ex-info "link dataflow connections must follow component schedule order"
                         {:reason :link-composition-order :from from :to to})))
-      (when-not (some #{from-node} (:outputs from-plan))
-        (throw (ex-info "a link dataflow producer must be a declared component output"
+      (when-not (public-output-value? from-plan from-value)
+        (throw (ex-info "a link dataflow producer must be a declared logical component output"
                         {:reason :link-composition-producer-boundary :from from
                          :outputs (:outputs from-plan)})))
-      (when-not (= :input (get-in to-plan [:nodes to-node :role]))
-        (throw (ex-info "a link dataflow consumer must be an input boundary"
+      (when-not (= :input (value-role to-plan to-value))
+        (throw (ex-info "a link dataflow consumer must be a logical input boundary"
                         {:reason :link-composition-consumer-role :to to
-                         :role (get-in to-plan [:nodes to-node :role])}))))
+                         :role (value-role to-plan to-value)}))))
     connections))
 
 (defn- normalize-shares! [shares component-plans]
   (mapv
    (fn [share]
-     (let [references (mapv #(node-ref! component-plans %) share)]
+     (let [references (mapv #(value-ref! component-plans %) share)]
        (when-not (<= 2 (count references))
          (throw (ex-info "a shared boundary group requires at least two nodes"
                          {:reason :link-composition-share :share share})))
        (when-not (= (count references) (count (distinct references)))
          (throw (ex-info "a shared boundary group cannot repeat a node"
                          {:reason :link-composition-share-duplicates :share share})))
-       (let [roles (mapv (fn [[component-id node-id]]
-                           (get-in component-plans [component-id :nodes node-id :role]))
+       (let [roles (mapv (fn [[component-id value-id]]
+                           (value-role (get component-plans component-id) value-id))
                          references)]
          (when-not (and (apply = roles) (contains? #{:input :constant} (first roles)))
            (throw (ex-info "shared boundaries must all be inputs or all be constants"
@@ -199,6 +213,13 @@
                       {:reason :link-composition-share-source :nodes references})))
     (first sources)))
 
+(defn- leaf-groups [value-groups values]
+  (mapcat
+   (fn [group]
+     (let [leaf-vectors (mapv #(get-in values [% :leaves]) group)]
+       (apply mapv (fn [& leaves] (mapv :node leaves)) leaf-vectors)))
+   value-groups))
+
 (defn- derive-composition
   [id components {:keys [connections shares outputs attributes]
                   :or {connections [] shares [] attributes {}} :as specification}]
@@ -216,13 +237,13 @@
         connections (normalize-connections! connections component-plans component-order)
         shares (normalize-shares! shares component-plans)
         _ (distinct-groups! connections shares)
-        outputs (mapv #(node-ref! component-plans %) outputs)
+        outputs (mapv #(value-ref! component-plans %) outputs)
         _ (when (empty? outputs)
             (throw (ex-info "link composition requires explicit public outputs"
                             {:reason :link-composition-outputs})))
-        _ (doseq [[component-id node-id :as output] outputs]
-            (when-not (some #{node-id} (get-in component-plans [component-id :outputs]))
-              (throw (ex-info "a composite output must be a declared component output"
+        _ (doseq [[component-id value-id :as output] outputs]
+            (when-not (public-output-value? (get component-plans component-id) value-id)
+              (throw (ex-info "a composite output must be a declared logical component output"
                               {:reason :link-composition-output-boundary :output output}))))
         node-mapping0
         (into {}
@@ -240,17 +261,43 @@
                                  [(:id node) node]))
                              (get-in lowering [:plan :nodes])))
                       components))
-        namespaced-ref #(get node-mapping0 %)
+        value-mapping0
+        (into {}
+              (mapcat (fn [{component-id :id lowering :lowering}]
+                        (map (fn [value-id]
+                               [[component-id value-id]
+                                (namespace-id id component-id :value value-id)])
+                             (keys (get-in lowering [:plan :values]))))
+                      components))
+        values0
+        (into {}
+              (mapcat (fn [{component-id :id lowering :lowering}]
+                        (map (fn [[_ value]]
+                               (let [value (namespace-value
+                                            id component-id
+                                            #(get node-mapping0 [component-id %]) value)]
+                                 [(:id value) value]))
+                             (get-in lowering [:plan :values])))
+                      components))
+        namespaced-value-ref #(get value-mapping0 %)
         connection-pairs (mapv (fn [{:keys [from to]}]
-                                 [(namespaced-ref from) (namespaced-ref to)])
+                                 [(namespaced-value-ref from) (namespaced-value-ref to)])
                                connections)
-        share-groups (mapv #(mapv namespaced-ref %) shares)
-        endpoint-groups (concat connection-pairs share-groups)
-        _ (doseq [group endpoint-groups]
-            (require-equal-contract! :boundary group nodes0)
-            (require-single-node-allocations! group nodes0))
-        _ (doseq [group share-groups] (canonical-source group nodes0))
-        replacements
+        share-groups (mapv #(mapv namespaced-value-ref %) shares)
+        value-groups (concat connection-pairs share-groups)
+        _ (doseq [group value-groups]
+            (require-equal-contract! :boundary group values0 nodes0)
+            (require-single-node-allocations! group values0 nodes0))
+        connection-leaf-pairs (vec (leaf-groups connection-pairs values0))
+        share-leaf-groups (vec (leaf-groups share-groups values0))
+        _ (doseq [group share-leaf-groups] (canonical-source group nodes0))
+        node-replacements
+        (into {}
+              (concat (map (fn [[source target]] [target source]) connection-leaf-pairs)
+                      (mapcat (fn [[canonical & others]]
+                                (map (fn [other] [other canonical]) others))
+                              share-leaf-groups)))
+        value-replacements
         (into {}
               (concat (map (fn [[source target]] [target source]) connection-pairs)
                       (mapcat (fn [[canonical & others]]
@@ -261,18 +308,18 @@
               (map (fn [[discarded canonical]]
                      [(get-in nodes0 [discarded :view :allocation :id])
                       (get-in nodes0 [canonical :view :allocation :id])]))
-              replacements)
-        connected-sources (set (map first connection-pairs))
+              node-replacements)
+        connected-sources (set (map first connection-leaf-pairs))
         shared-source-by-node
         (into {}
               (mapcat (fn [group]
                         (let [source (canonical-source group nodes0)]
                           (map (fn [node-id] [node-id source]) group)))
-                      share-groups))
+                      share-leaf-groups))
         nodes
         (into {}
               (keep (fn [[node-id node]]
-                      (when-not (contains? replacements node-id)
+                      (when-not (contains? node-replacements node-id)
                         (let [allocation (get-in node [:view :allocation])
                               allocation-id (:id allocation)
                               allocation-id' (get allocation-replacements allocation-id
@@ -284,9 +331,20 @@
                                      (assoc :source (get shared-source-by-node node-id)))]
                           [node-id node]))))
               nodes0)
-        resolve-node #(get replacements % %)
+        resolve-node #(get node-replacements % %)
+        resolve-value #(get value-replacements % %)
+        values
+        (into {}
+              (keep (fn [[value-id value]]
+                      (when-not (contains? value-replacements value-id)
+                        [value-id (update value :leaves
+                                          (fn [leaves]
+                                            (mapv #(update % :node resolve-node) leaves)))])))
+              values0)
         node-mapping (into {} (map (fn [[reference node-id]]
                                      [reference (resolve-node node-id)])) node-mapping0)
+        value-mapping (into {} (map (fn [[reference value-id]]
+                                      [reference (resolve-value value-id)])) value-mapping0)
         allocation-mapping
         (into {}
               (mapcat (fn [{component-id :id lowering :lowering}]
@@ -311,8 +369,8 @@
          (mapcat (fn [{component-id :id lowering :lowering}]
                    (map (fn [instance]
                           (namespace-instance id component-id
-                                              (comp resolve-node
-                                                    #(get node-mapping0 [component-id %]))
+                                              (comp resolve-value
+                                                    #(get value-mapping0 [component-id %]))
                                               instance))
                         (get-in lowering [:plan :instances])))
                  components))
@@ -322,9 +380,11 @@
                             :when (neg? (compare (pr-str left-id) (pr-str right-id)))
                             :when (bview/overlaps? (:view left) (:view right))]
                         #{left-id right-id}))
-        output-ids (mapv node-mapping outputs)
+        output-value-ids (mapv value-mapping outputs)
+        output-ids (vec (mapcat #(map :node (get-in values [% :leaves])) output-value-ids))
         plan (link-plan/make
-              {:id id :target target :nodes nodes :instances instances :outputs output-ids
+              {:id id :target target :nodes nodes :values values
+               :instances instances :outputs output-ids
                :aliases aliases
                :attributes (merge attributes
                                   {:lowered-from :certified-link-composition
@@ -334,7 +394,8 @@
         (->LinkCompositionCertificate
          :certified-link-plans :link-plan id target
          (mapv (comp :id :plan :lowering) components)
-         connections shares node-mapping allocation-mapping instance-mapping output-ids)]
+         connections shares value-mapping node-mapping allocation-mapping instance-mapping
+         output-ids)]
     {:plan plan :certificate certificate :components components
      :specification (assoc specification :connections connections :shares shares
                            :outputs outputs :attributes attributes)}))
@@ -365,12 +426,12 @@
 
    `components` is an ordered vector of `{:id component-id :lowering certified-lowering}`.
    `specification` requires ordered `:outputs` and optionally contains:
-   - `:connections` — `{:from [producer-id output-node] :to [consumer-id input-node]}`;
-   - `:shares` — groups of equal input/constant boundary node references;
+   - `:connections` — `{:from [producer-id output-value] :to [consumer-id input-value]}`;
+   - `:shares` — groups of equal input/constant logical value references;
    - `:attributes` — inspectable composite metadata.
 
-   This first contract intentionally rejects endpoints whose allocation has multiple views. The
-   following AbstractValue/view consolidation pass will make ranged boundary composition explicit."
+   Composite values unify atomically across their ordered leaves. Endpoints whose individual
+   physical allocations have multiple views remain rejected until ranged composition is explicit."
   [{:keys [id components] :as request}]
   (let [specification (select-keys request [:connections :shares :outputs :attributes])
         {:keys [plan certificate components specification]}

--- a/src/raster/compiler/ir/link_plan.clj
+++ b/src/raster/compiler/ir/link_plan.clj
@@ -226,6 +226,19 @@
                        :values (set (keys (:values plan)))})))
     (mapv :node (:leaves link-value))))
 
+(defn output-value-ids
+  "Return public logical value identities in physical output order. LinkPlan validation guarantees
+   that each selected value contributes all of its leaves contiguously and in field order."
+  [plan]
+  (let [positions (zipmap (:outputs plan) (range))]
+    (->> (:values plan)
+         (keep (fn [[value-id value]]
+                 (let [leaf-positions (mapv positions (map :node (:leaves value)))]
+                   (when (every? some? leaf-positions)
+                     [value-id (first leaf-positions)]))))
+         (sort-by second)
+         (mapv first))))
+
 (defn validate-instance!
   [instance]
   (when-not (link-instance? instance)
@@ -273,7 +286,7 @@
 
 (defn instance
   "Construct one descriptor instance. `:bindings` is data—not a name-decoding function—and maps
-   every pointer-valued compiler symbol used by the descriptor to a LinkNode identity. `:scalars`
+   every pointer-valued compiler symbol used by the descriptor to a LinkValue identity. `:scalars`
    supplies exactly the descriptor's scalar parameters. Optional ordered `:arguments` retains the
    complete compile-time specialization environment for descriptor closures whose shapes depend on
    array parameters; runtime pointer binding still comes exclusively from `:bindings`."
@@ -284,7 +297,7 @@
   "Return the descriptor's ordered specialization arguments. Explicit arguments retain array
    values for descriptor shape closures; absent arguments preserve the hand-built-plan
    shorthand of nil array positions plus exact named scalars. Runtime pointers are never taken
-   from this vector: resident binding uses LinkNodes exclusively."
+   from this vector: resident binding uses certified LinkValue leaves exclusively."
   [instance]
   (let [{:keys [descriptor scalars arguments]} (validate-instance! instance)
         array-params (set (:array-params descriptor))]
@@ -307,6 +320,28 @@
                             (when (not= :scalar kind) sym))
                           (:argument-specs step)))))
         (:steps descriptor)))
+
+(defn descriptor-allocation-leaves
+  "Return one descriptor allocation's ordered physical leaf specifications. Legacy flat
+   allocations become a single `:value` leaf; composite allocations declare `:leaves` containing
+   `:field`, `:dtype`, and `:size-fn`."
+  ([allocation] (descriptor-allocation-leaves allocation nil))
+  ([{:keys [sym dtype size-fn leaves] :as allocation} default-dtype]
+   (let [leaves (if (contains? allocation :leaves)
+                  leaves
+                  [{:field :value :dtype (or dtype default-dtype) :size-fn size-fn}])]
+     (when-not (and (vector? leaves) (seq leaves))
+       (throw (ex-info "descriptor allocation requires ordered physical leaves"
+                       {:reason :link-allocation-leaves :symbol sym :leaves leaves})))
+     (doseq [{:keys [field dtype size-fn] :as leaf} leaves]
+       (when (or (nil? field) (nil? dtype) (not (ifn? size-fn)))
+         (throw (ex-info "descriptor allocation leaf requires :field, :dtype, and :size-fn"
+                         {:reason :link-allocation-leaf :symbol sym :leaf leaf}))))
+     (let [fields (mapv :field leaves)]
+       (when-not (= (count fields) (count (distinct fields)))
+         (throw (ex-info "descriptor allocation fields must be unique and ordered"
+                         {:reason :link-allocation-fields :symbol sym :fields fields}))))
+     leaves)))
 
 (defn- step-interface [step]
   (or (:artifact step)
@@ -610,6 +645,18 @@
     (when-not (= (count outputs) (count (distinct outputs)))
       (throw (ex-info "link plan output identities must be unique"
                       {:reason :link-output-duplicates :outputs outputs})))
+    (let [positions (zipmap outputs (range))]
+      (doseq [[value-id link-value] values
+              :let [leaf-nodes (mapv :node (:leaves link-value))
+                    leaf-positions (vec (keep positions leaf-nodes))]
+              :when (seq leaf-positions)]
+        (when-not (and (= (count leaf-nodes) (count leaf-positions))
+                       (= leaf-positions
+                          (vec (range (first leaf-positions)
+                                      (+ (first leaf-positions) (count leaf-positions))))))
+          (throw (ex-info "public outputs must flatten whole logical values in field order"
+                          {:reason :link-output-value :value value-id :leaves leaf-nodes
+                           :positions leaf-positions :outputs outputs})))))
     (when-not (and (set? aliases) (every? set? aliases))
       (throw (ex-info "link plan aliases must be a set of two-node sets"
                       {:reason :link-aliases :aliases aliases})))
@@ -677,31 +724,40 @@
                          :value-role (get-in nodes [(-> values (get value-id) :leaves first :node)
                                                     :role])}))))
     (let [args (instance-arguments instance)]
-      (doseq [{:keys [sym dtype size-fn]} (:allocs descriptor)]
+      (doseq [{:keys [sym] :as allocation} (:allocs descriptor)]
         (let [value-id (get bindings sym)
               leaves (get-in values [value-id :leaves])
-              _ (when-not (= 1 (count leaves))
-                  (throw (ex-info "descriptor flat allocation cannot realize a composite value"
-                                  {:reason :link-composite-allocation-required :instance id
-                                   :symbol sym :value value-id :leaves leaves})))
-              node-id (:node (first leaves))
-              link-node (get nodes node-id)
-              expected-elements
-              (try (long (size-fn args))
-                   (catch Exception e
-                     (throw (ex-info "link descriptor allocation extent did not resolve from its specialization environment"
-                                     {:reason :link-allocation-shape :instance id :symbol sym}
-                                     e))))
-              actual-elements (shape-elements (get-in link-node [:view :shape]))]
-          (when-not (= (dtype/canon dtype) (dtype/canon (get-in link-node [:view :dtype])))
-            (throw (ex-info "link internal node dtype differs from its descriptor allocation"
-                            {:reason :link-allocation-dtype :instance id :symbol sym :node node-id
-                             :expected dtype :actual (get-in link-node [:view :dtype])})))
-          (when-not (= expected-elements actual-elements)
-            (throw (ex-info "link internal node shape differs from its descriptor allocation"
-                            {:reason :link-allocation-shape :instance id :symbol sym :node node-id
-                             :expected-elements expected-elements
-                             :actual-elements actual-elements})))))
+              specs (descriptor-allocation-leaves allocation (:dtype descriptor))]
+          (when-not (= (count specs) (count leaves))
+            (throw (ex-info "descriptor allocation leaf count differs from its logical value"
+                            {:reason :link-allocation-leaf-count :instance id :symbol sym
+                             :value value-id :specs specs :leaves leaves})))
+          (doseq [[{:keys [field dtype size-fn]} {:keys [name node]}]
+                  (map vector specs leaves)]
+            (let [link-node (get nodes node)
+                  expected-elements
+                  (try (long (size-fn args))
+                       (catch Exception e
+                         (throw
+                          (ex-info
+                           "link descriptor allocation extent did not resolve from its specialization environment"
+                           {:reason :link-allocation-shape :instance id :symbol sym :field field}
+                           e))))
+                  actual-elements (shape-elements (get-in link-node [:view :shape]))]
+              (when-not (= field name)
+                (throw (ex-info "descriptor allocation field differs from its logical leaf"
+                                {:reason :link-allocation-field :instance id :symbol sym
+                                 :expected field :actual name :node node})))
+              (when-not (= (dtype/canon dtype) (dtype/canon (get-in link-node [:view :dtype])))
+                (throw (ex-info "link internal node dtype differs from its descriptor allocation"
+                                {:reason :link-allocation-dtype :instance id :symbol sym
+                                 :field field :node node :expected dtype
+                                 :actual (get-in link-node [:view :dtype])})))
+              (when-not (= expected-elements actual-elements)
+                (throw (ex-info "link internal node shape differs from its descriptor allocation"
+                                {:reason :link-allocation-shape :instance id :symbol sym
+                                 :field field :node node :expected-elements expected-elements
+                                 :actual-elements actual-elements})))))))
       (mapv (fn [[step-index step]]
               (instance-step-facts nodes values instance step-index step))
             (map-indexed vector (:steps descriptor))))))

--- a/src/raster/compiler/ir/resident_plan.clj
+++ b/src/raster/compiler/ir/resident_plan.clj
@@ -8,6 +8,7 @@
    facts from symbols, buffer names, or emitted kernels."
   (:require [clojure.set :as set]
             [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.abstract-value :as abstract-value]
             [raster.compiler.ir.link-plan :as link-plan]))
 
 (defrecord ResidentPlanCertificate
@@ -85,9 +86,82 @@
                  (if parameter? :input :internal))]
     (if (= :scratch role) :internal role)))
 
-(defn- value-contract [symbol origin node]
-  {:symbol symbol
-   :origin origin
+(defn- physical-option [options symbol field default]
+  (get options [symbol field] (get options symbol default)))
+
+(defn- validate-value-spec! [symbol {:keys [abstract physical-layout leaves] :as spec}]
+  (when-not (and (map? spec) (vector? leaves) (seq leaves))
+    (throw (ex-info "resident logical value specification requires ordered leaves"
+                    {:reason :resident-plan-value-spec :symbol symbol :spec spec})))
+  (when-not abstract
+    (throw (ex-info "resident composite value specification requires an AbstractValue"
+                    {:reason :resident-plan-value-abstract :symbol symbol})))
+  (abstract-value/validate! abstract)
+  (when-not (or (nil? physical-layout) (map? physical-layout))
+    (throw (ex-info "resident value physical layout must be a descriptor map"
+                    {:reason :resident-plan-value-layout :symbol symbol
+                     :physical-layout physical-layout})))
+  (let [fields (mapv :field leaves)]
+    (when (or (some nil? fields) (not= (count fields) (count (distinct fields))))
+      (throw (ex-info "resident value fields must be present, unique, and ordered"
+                      {:reason :resident-plan-value-fields :symbol symbol :fields fields}))))
+  spec)
+
+(defn- parameter-leaves [symbol argument value-spec]
+  (if value-spec
+    (let [{:keys [leaves]} (validate-value-spec! symbol value-spec)
+          fields (mapv :field leaves)]
+      (when-not (and (map? argument) (= (set fields) (set (keys argument))))
+        (throw (ex-info "resident composite argument must map every declared field to storage"
+                        {:reason :resident-plan-composite-argument :symbol symbol
+                         :expected (set fields) :actual (when (map? argument)
+                                                          (set (keys argument)))})))
+      (mapv (fn [{:keys [field dtype] :as leaf}]
+              (let [source (get argument field)
+                    actual-dtype (primitive-array-dtype source)]
+                (when-not actual-dtype
+                  (throw (ex-info "resident composite fields must be primitive JVM arrays"
+                                  {:reason :resident-plan-array-argument :symbol symbol
+                                   :field field :actual (some-> source type)})))
+                (when (and dtype (not= (dtype/canon dtype) actual-dtype))
+                  (throw (ex-info "resident composite field dtype differs from its specification"
+                                  {:reason :resident-plan-field-dtype :symbol symbol :field field
+                                   :expected dtype :actual actual-dtype})))
+                (assoc leaf :dtype actual-dtype :elements (array-length symbol source)
+                       :source source)))
+            leaves))
+    [{:field :value :dtype (primitive-array-dtype argument)
+      :elements (array-length symbol argument) :source argument}]))
+
+(defn- allocation-leaves [symbol allocation default-dtype arguments]
+  (mapv (fn [{:keys [field dtype size-fn] :as leaf}]
+          (let [elements
+                (try (long (size-fn arguments))
+                     (catch Exception error
+                       (throw (ex-info "resident allocation shape did not resolve"
+                                       {:reason :resident-plan-allocation-shape
+                                        :symbol symbol :field field}
+                                       error))))]
+            (assoc leaf :dtype (dtype/canon dtype) :elements elements :source nil)))
+        (link-plan/descriptor-allocation-leaves allocation default-dtype)))
+
+(defn- leaf-node-id [plan-id node-ids value-id symbol field leaf-count]
+  (if (= 1 leaf-count)
+    value-id
+    (get node-ids [symbol field] [plan-id symbol field])))
+
+(defn- leaf-shape [shapes symbol field leaf-count elements]
+  (let [shape (vec (or (get shapes [symbol field])
+                       (when (= 1 leaf-count) (get shapes symbol))
+                       [elements]))]
+    (when-not (= elements (reduce * 1 shape))
+      (throw (ex-info "resident value shape differs from its storage extent"
+                      {:reason :resident-plan-shape :symbol symbol :field field
+                       :elements elements :shape shape})))
+    shape))
+
+(defn- leaf-contract [name node]
+  {:name name
    :node (:id node)
    :dtype (dtype/canon (get-in node [:view :dtype]))
    :shape (get-in node [:view :shape])
@@ -97,19 +171,33 @@
    :ownership (get-in node [:view :allocation :ownership])
    :role (:role node)})
 
+(defn- value-contract [symbol origin value nodes]
+  (let [leaves (mapv (fn [{:keys [name node]}]
+                       (leaf-contract name (get nodes node)))
+                     (:leaves value))
+        flat (when (= 1 (count leaves)) (first leaves))]
+    (merge {:symbol symbol
+            :origin origin
+            :value (:id value)
+            :abstract (:abstract value)
+            :physical-layout (:physical-layout value)
+            :leaves leaves}
+           ;; Preserve the original certificate query surface for one-leaf descriptors.
+           (dissoc flat :name))))
+
 (defn- derive-certificate [plan]
   (let [instance (first (:instances plan))
         descriptor (:descriptor instance)
-        symbol-by-node (set/map-invert (:bindings instance))
         alloc-symbols (set (map :sym (:allocs descriptor)))
         values (into {}
-                     (map (fn [[node-id node]]
-                            (let [symbol (get symbol-by-node node-id)]
-                              [symbol (value-contract symbol
-                                                      (if (contains? alloc-symbols symbol)
-                                                        :allocation :parameter)
-                                                      node)])))
-                     (:nodes plan))]
+                     (map (fn [[symbol value-id]]
+                            [symbol (value-contract
+                                     symbol
+                                     (if (contains? alloc-symbols symbol)
+                                       :allocation :parameter)
+                                     (get-in plan [:values value-id])
+                                     (:nodes plan))]))
+                     (:bindings instance))]
     (->ResidentPlanCertificate
      :resident-program :link-plan (:id plan) (:target plan) (:id instance)
      (:all-params descriptor) (:array-params descriptor) (:scalar-params descriptor)
@@ -145,14 +233,17 @@
    - `:id`, `:target`, `:descriptor`, and ordered `:arguments` are required;
    - `:roles` overrides descriptor array roles;
    - `:outputs` is an ordered vector of public output symbols (default: `:result-sym`);
-   - `:shapes` may refine the default flat parameter/allocation shapes;
-   - `:node-ids` supplies stable public identities (default `[plan-id symbol]`);
+   - descriptor `:value-specs` describes composite array parameters as an AbstractValue, physical
+     layout, and ordered leaves; composite `:allocs` use the same facets plus leaf size closures;
+   - `:shapes` may refine flat values by symbol or physical leaves by `[symbol field]`;
+   - `:node-ids` supplies logical identities by symbol and optional physical identities by
+     `[symbol field]`;
    - `:ownership`, `:memory-space`, `:aliases`, and `:attributes` refine LinkPlan storage.
 
-   Host array arguments remain exact initializers for owned parameter allocations, including
-   output/state parameters. Borrowed/external allocations use the arguments only to specialize
-   dtype and shape; their storage and readiness are supplied explicitly at instantiation. This
-   preserves resident initial-value semantics without confusing ownership with readiness."
+   Flat arguments remain primitive arrays. Composite arguments are field-to-primitive-array maps.
+   They remain exact initializers for owned parameter leaves, including output/state parameters.
+   Borrowed/external allocations use them only to specialize dtype and shape; their storage and
+   readiness are supplied explicitly at instantiation."
   [{:keys [id target descriptor arguments roles outputs shapes node-ids ownership memory-space
            aliases attributes instance-id]
     :or {roles {} shapes {} node-ids {} ownership {} memory-space {}
@@ -182,49 +273,74 @@
         output-symbols (set outputs)
         scalar-values (select-keys argument-map (:scalar-params descriptor))
         ordered-symbols (vec (concat (:array-params descriptor) (map :sym (:allocs descriptor))))
-        resolved-node-ids (mapv #(node-id-for id node-ids %) ordered-symbols)
-        _ (unique-vector! :resident-plan-node-ids "resident-plan node identities"
-                          resolved-node-ids)
-        nodes
+        value-specs (or (:value-specs descriptor) {})
+        _ (when-not (set/subset? (set (keys value-specs)) array-symbols)
+            (throw (ex-info "resident descriptor value specs must name array parameters"
+                            {:reason :resident-plan-value-spec-symbols
+                             :specs (set (keys value-specs)) :arrays array-symbols})))
+        value-descriptors
         (mapv
          (fn [symbol]
            (let [parameter? (contains? array-symbols symbol)
-                 argument (when parameter? (get argument-map symbol))
                  allocation (get alloc-map symbol)
-                 default-elements (if parameter?
-                                    (array-length symbol argument)
-                                    (try (long ((:size-fn allocation) arguments))
-                                         (catch Exception error
-                                           (throw (ex-info
-                                                   "resident allocation shape did not resolve"
-                                                   {:reason :resident-plan-allocation-shape
-                                                    :symbol symbol}
-                                                   error)))))
-                 shape (vec (get shapes symbol [default-elements]))
-                 _ (when-not (= default-elements (reduce * 1 shape))
-                     (throw (ex-info "resident value shape differs from its storage extent"
-                                     {:reason :resident-plan-shape :symbol symbol
-                                      :elements default-elements :shape shape})))
-                 storage-dtype (if parameter?
-                                 (primitive-array-dtype argument)
-                                 (or (:dtype allocation) (:dtype descriptor)))
-                 node-id (node-id-for id node-ids symbol)
-                 value-ownership (get ownership symbol :owned)]
-             (link-plan/node
-              {:id node-id :allocation-id node-id :dtype storage-dtype :shape shape
-               :device target :memory-space (get memory-space symbol :device)
-               :ownership value-ownership
-               :role (node-role symbol parameter? descriptor roles output-symbols)
-               :source (when (= :owned value-ownership) argument)})))
+                 value-spec (if parameter? (get value-specs symbol)
+                                (when (contains? allocation :leaves) allocation))
+                 _ (when value-spec (validate-value-spec! symbol value-spec))
+                 leaves (if parameter?
+                          (parameter-leaves symbol (get argument-map symbol) value-spec)
+                          (allocation-leaves symbol allocation (:dtype descriptor) arguments))
+                 value-id (node-id-for id node-ids symbol)
+                 leaf-count (count leaves)
+                 leaves (mapv (fn [{:keys [field] :as leaf}]
+                                (assoc leaf :node-id
+                                       (leaf-node-id id node-ids value-id symbol field leaf-count)))
+                              leaves)]
+             {:symbol symbol :parameter? parameter? :allocation allocation
+              :value-spec value-spec :value-id value-id :leaves leaves
+              :role (node-role symbol parameter? descriptor roles output-symbols)}))
          ordered-symbols)
-        bindings (zipmap ordered-symbols resolved-node-ids)
+        _ (unique-vector! :resident-plan-node-ids "resident-plan value identities"
+                          (mapv :value-id value-descriptors))
+        _ (unique-vector! :resident-plan-node-ids "resident-plan node identities"
+                          (mapv :node-id (mapcat :leaves value-descriptors)))
+        nodes
+        (vec
+         (mapcat
+          (fn [{:keys [symbol parameter? role leaves]}]
+            (let [leaf-count (count leaves)]
+              (mapv
+               (fn [{:keys [field dtype elements source node-id]}]
+                 (let [value-ownership (physical-option ownership symbol field :owned)]
+                   (link-plan/node
+                    {:id node-id :allocation-id node-id :dtype dtype
+                     :shape (leaf-shape shapes symbol field leaf-count elements)
+                     :device target
+                     :memory-space (physical-option memory-space symbol field :device)
+                     :ownership value-ownership :role role
+                     :source (when (and parameter? (= :owned value-ownership)) source)})))
+               leaves)))
+          value-descriptors))
+        logical-values
+        (vec
+         (keep (fn [{:keys [value-id value-spec leaves]}]
+                 (when value-spec
+                   (link-plan/value
+                    {:id value-id :abstract (:abstract value-spec)
+                     :physical-layout (:physical-layout value-spec)
+                     :leaves (mapv (fn [{:keys [field node-id]}]
+                                     {:name field :node node-id})
+                                   leaves)})))
+               value-descriptors))
+        value-by-symbol (into {} (map (juxt :symbol identity)) value-descriptors)
+        bindings (into {} (map (juxt :symbol :value-id)) value-descriptors)
         instance (link-plan/instance
                   {:id (or instance-id [id :instance]) :descriptor descriptor
                    :bindings bindings :scalars scalar-values :schedule (:schedule descriptor)
                    :roles roles :arguments (vec arguments)})
         plan (link-plan/make
-              {:id id :target target :nodes nodes :instances [instance]
-               :outputs (mapv bindings outputs) :aliases aliases
+              {:id id :target target :nodes nodes :values logical-values :instances [instance]
+               :outputs (vec (mapcat #(map :node-id (:leaves (get value-by-symbol %))) outputs))
+               :aliases aliases
                :attributes (assoc attributes :lowered-from :resident-program)})
         lowering (->CertifiedResidentPlan plan (derive-certificate plan))]
     (verify! lowering)))

--- a/src/raster/gpu/link.clj
+++ b/src/raster/gpu/link.clj
@@ -58,6 +58,18 @@
       :coherence (:coherence allocation)
       :alignment (:alignment allocation)}]))
 
+(defn- resident-link-value [plan node-views value-id]
+  (let [link-value (get-in plan [:values value-id])
+        fields (mapv (fn [{:keys [name node]}]
+                       {:name name :value (get node-views node)})
+                     (:leaves link-value))]
+    (when-not (and link-value (every? :value fields))
+      (throw (ex-info "validated link value disappeared during instantiation"
+                      {:reason :link-runtime-value :value value-id})))
+    (if (= 1 (count fields))
+      (:value (first fields))
+      (resident-value/composite value-id fields))))
+
 (defn- cleanup-attached!
   [session graph-key phases allocation-keys]
   ;; A failed backend destructor must not strand the resources that follow it. Preserve the first
@@ -161,18 +173,13 @@
                (gpu/bind-step!
                 session (assoc step :phase phase) (link-plan/instance-arguments instance)
                 (fn [symbol]
-                  (let [value-id (get bindings symbol)
-                        link-value (get-in plan [:values value-id])
-                        fields (mapv (fn [{:keys [name node]}]
-                                       {:name name :value (get node-views node)})
-                                     (:leaves link-value))]
-                    (when-not (and link-value (every? :value fields))
-                      (throw (ex-info "validated link value disappeared during instantiation"
-                                      {:instance (:id instance) :symbol symbol
-                                       :value value-id})))
-                    (if (= 1 (count fields))
-                      (:value (first fields))
-                      (resident-value/composite value-id fields))))
+                  (let [value-id (get bindings symbol)]
+                    (try (resident-link-value plan node-views value-id)
+                         (catch clojure.lang.ExceptionInfo error
+                           (throw (ex-info (.getMessage error)
+                                           (assoc (ex-data error)
+                                                  :instance (:id instance) :symbol symbol)
+                                           error))))))
                 {:schedule (or (:schedule instance) (get-in instance [:descriptor :schedule]))
                  :roles (link-plan/instance-roles plan instance)})
                (vswap! phases conj phase)))
@@ -217,6 +224,13 @@
         (throw (ex-info "linked executable has no such node"
                         {:reason :link-runtime-node :node node-id
                          :nodes (set (keys (:node-views executable)))})))))
+
+(defn value-view
+  "Return one logical resident value. Dense values return their ResidentBufferView; composite
+   values return an ordered ResidentComposite whose field identities match the certified ABI."
+  [executable value-id]
+  (let [executable (ensure-live! executable :value-view)]
+    (resident-link-value (:plan executable) (:node-views executable) value-id)))
 
 (defn- select-instance
   [plan selector]
@@ -310,13 +324,42 @@
                (if (= :scalar (:kind spec))
                  [value]
                  (let [slots (:slots spec)]
-                   (when-not (= 1 (count slots))
-                     (throw (ex-info
-                             "linked dispatch tuning cannot project a multi-view logical binding"
-                             {:reason :linked-dispatch-multiview-binding
-                              :phase (:phase step) :binding (:binding spec) :slots slots})))
-                   [value])))
+                   (if (resident-value/resident-composite? value)
+                     (let [fields (:fields value)]
+                       (when-not (= (count slots) (count fields))
+                         (throw (ex-info "linked dispatch composite differs from its ABI"
+                                         {:reason :linked-dispatch-composite-count
+                                          :phase (:phase step) :binding (:binding spec)
+                                          :slots slots :fields fields})))
+                       (mapv (fn [slot field]
+                               (let [view (:view (:value field))]
+                                 (when (and (:field slot)
+                                            (not= (:field slot) (:name field)))
+                                   (throw
+                                    (ex-info "linked dispatch composite field order differs from its ABI"
+                                             {:reason :linked-dispatch-composite-field
+                                              :phase (:phase step) :slot slot :field field})))
+                                 (when-not (= (dtype/canon (:dtype slot))
+                                              (dtype/canon (:dtype view)))
+                                   (throw
+                                    (ex-info "linked dispatch composite dtype differs from its ABI"
+                                             {:reason :linked-dispatch-composite-dtype
+                                              :phase (:phase step) :slot slot :field field})))
+                                 (:value field)))
+                             slots fields))
+                     (do
+                       (when-not (= 1 (count slots))
+                         (throw (ex-info
+                                 "linked dispatch multi-slot binding requires a composite value"
+                                 {:reason :linked-dispatch-multiview-binding
+                                  :phase (:phase step) :binding (:binding spec) :slots slots})))
+                       [value])))))
              (:argument-specs step) logical-arguments))))
+
+(defn- resident-fields [value]
+  (if (resident-value/resident-composite? value)
+    (:fields value)
+    [{:name :value :value value}]))
 
 (defn dispatch-arguments
   "Project a tuning sample onto one linked instance's resident views and physical kernel ABI.
@@ -351,38 +394,69 @@
          bindings (:bindings instance)
          resident-of
          (fn [sym]
-           (let [node-id (get bindings sym ::missing)]
-             (when (= ::missing node-id)
-               (throw (ex-info "linked dispatch symbol has no certified node binding"
+           (let [value-id (get bindings sym ::missing)]
+             (when (= ::missing value-id)
+               (throw (ex-info "linked dispatch symbol has no certified value binding"
                                {:reason :linked-dispatch-binding
                                 :instance (:id instance) :symbol sym})))
-             (node-view executable node-id)))
-         capacity-of
-         (fn [sym]
-           (let [view (:view (resident-of sym))]
-             (quot (:byte-length view) (dtype/bytes-of (:dtype view)))))
+             (if (contains? (get-in executable [:plan :values]) value-id)
+               (value-view executable value-id)
+               ;; Compatibility for synthetic dispatch fixtures predating LinkValue. A validated
+               ;; production plan always takes the branch above.
+               (node-view executable value-id))))
          require-capacity!
-         (fn [sym required]
-           (let [capacity (capacity-of sym)]
+         (fn [sym field resident required]
+           (let [view (:view resident)
+                 capacity (quot (:byte-length view) (dtype/bytes-of (:dtype view)))]
              (when (> (long required) (long capacity))
                (throw (ex-info "linked dispatch sample exceeds its resident node view"
                                {:reason :linked-dispatch-buffer-capacity
                                 :instance (:id instance) :step-index step-index
-                                :phase (:phase step) :symbol sym
+                                :phase (:phase step) :symbol sym :field field
                                 :required-elements (long required)
                                 :capacity-elements (long capacity)})))))
          _array-capacities
          (doseq [sym (:array-params descriptor)]
-           (let [array (get argmap sym)]
-             (when-not (and array (.isArray (class array)))
-               (throw (ex-info "linked dispatch array parameter must be a JVM array"
-                               {:reason :linked-dispatch-array-argument
-                                :instance (:id instance) :symbol sym
-                                :value-type (some-> array class)})))
-             (require-capacity! sym (java.lang.reflect.Array/getLength array))))
+           (let [argument (get argmap sym)
+                 spec (get-in descriptor [:value-specs sym])
+                 fields (resident-fields (resident-of sym))]
+             (if spec
+               (let [expected (mapv :field (:leaves spec))]
+                 (when-not (and (map? argument) (= (set expected) (set (keys argument)))
+                                (= expected (mapv :name fields)))
+                   (throw (ex-info "linked dispatch composite parameter differs from its value spec"
+                                   {:reason :linked-dispatch-composite-argument
+                                    :instance (:id instance) :symbol sym
+                                    :expected expected :argument argument :fields fields})))
+                 (doseq [[field resident] (map vector expected (map :value fields))
+                         :let [array (get argument field)]]
+                   (when-not (and array (.isArray (class array)))
+                     (throw (ex-info "linked dispatch composite field must be a JVM array"
+                                     {:reason :linked-dispatch-array-argument
+                                      :instance (:id instance) :symbol sym :field field
+                                      :value-type (some-> array class)})))
+                   (require-capacity! sym field resident
+                                      (java.lang.reflect.Array/getLength array))))
+               (do
+                 (when-not (and argument (.isArray (class argument)))
+                   (throw (ex-info "linked dispatch array parameter must be a JVM array"
+                                   {:reason :linked-dispatch-array-argument
+                                    :instance (:id instance) :symbol sym
+                                    :value-type (some-> argument class)})))
+                 (require-capacity! sym :value (:value (first fields))
+                                    (java.lang.reflect.Array/getLength argument))))))
          _scratch-capacities
-         (doseq [{:keys [sym size-fn]} (:allocs descriptor)]
-           (require-capacity! sym (size-fn descriptor-arguments)))
+         (doseq [{:keys [sym] :as allocation} (:allocs descriptor)
+                 :let [fields (resident-fields (resident-of sym))
+                       specs (link-plan/descriptor-allocation-leaves
+                              allocation (:dtype descriptor))]
+                 [spec field] (map vector specs fields)]
+           (when-not (= (:field spec) (:name field))
+             (throw (ex-info "linked dispatch allocation fields differ from the resident value"
+                             {:reason :linked-dispatch-allocation-field :symbol sym
+                              :expected (:field spec) :actual (:name field)})))
+           (require-capacity! sym (:field spec) (:value field)
+                              ((:size-fn spec) descriptor-arguments)))
          logical-arguments
          (mapv (fn [{:keys [kind sym type value-fn]}]
                  (if (= :scalar kind)
@@ -433,6 +507,21 @@
                                position-order))))
           (map (fn [node-id] [node-id (node-view executable node-id)]))
           output-ids)))
+
+(defn output-values
+  "Return the plan's public logical values in declared output order without copying to the host."
+  [executable]
+  (let [executable (ensure-live! executable :output-values)
+        value-ids (link-plan/output-value-ids (:plan executable))
+        rank (zipmap value-ids (range))]
+    (into (sorted-map-by (fn [left right]
+                           (let [position-order (compare (get rank left Long/MAX_VALUE)
+                                                         (get rank right Long/MAX_VALUE))]
+                             (if (zero? position-order)
+                               (compare (pr-str left) (pr-str right))
+                               position-order))))
+          (map (fn [value-id] [value-id (value-view executable value-id)]))
+          value-ids)))
 
 (defn run!
   "Replay the linked graph synchronously and return its resident output views. No host copies."

--- a/test/raster/compiler/ir/link_composition_test.clj
+++ b/test/raster/compiler/ir/link_composition_test.clj
@@ -1,5 +1,6 @@
 (ns raster.compiler.ir.link-composition-test
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-launch :as launch]
@@ -44,6 +45,74 @@
 (defn- value-node [lowering symbol]
   (get-in lowering [:certificate :values symbol :node]))
 
+(defn- composite-abstract []
+  (av/tensor {:dtype :float :shape ['n]
+              :representation {:kind :test-split}}))
+
+(defn- composite-layout []
+  {:kind :ordered-fields :field-order [:data :index]})
+
+(def ^:private split-kernel
+  (artifact/make
+   {:kernel-name "composition_split"
+    :source "__kernel void composition_split(const float* x, float* out_data, int* out_index, long n) {}"
+    :abi [(kabi/slot 'x :input :float)
+          (kabi/slot 'out_data :output :float :binding 'out :field :data)
+          (kabi/slot 'out_index :output :int :binding 'out :field :index)
+          (kabi/slot 'n :scalar :long)]
+    :arguments '[x out_data out_index n]
+    :launch (launch/spec {:workgroup-size [64]
+                          :group-count [(launch/ceil-div 'n 64)]})
+    :effects {:kind :map :reads '[x] :writes '[out_data out_index]}}))
+
+(def ^:private join-kernel
+  (artifact/make
+   {:kernel-name "composition_join"
+    :source "__kernel void composition_join(const float* in_data, const int* in_index, float* y, long n) {}"
+    :abi [(kabi/slot 'in_data :input :float :binding 'in :field :data)
+          (kabi/slot 'in_index :input :int :binding 'in :field :index)
+          (kabi/slot 'y :output :float)
+          (kabi/slot 'n :scalar :long)]
+    :arguments '[in_data in_index y n]
+    :launch (launch/spec {:workgroup-size [64]
+                          :group-count [(launch/ceil-div 'n 64)]})
+    :effects {:kind :map :reads '[in_data in_index] :writes '[y]}}))
+
+(defn- split-descriptor []
+  {:dtype :float
+   :all-params '[x n] :array-params '[x] :scalar-params '[n]
+   :array-roles {'x :input}
+   :allocs [{:sym 'out :abstract (composite-abstract)
+             :physical-layout (composite-layout)
+             :leaves [{:field :data :dtype :float
+                       :size-fn (fn [args] (long (nth args 1)))}
+                      {:field :index :dtype :int
+                       :size-fn (fn [args] (long (nth args 1)))}]}]
+   :steps [{:phase :split :convention :map :artifact split-kernel
+            :logical-bindings? true
+            :argument-specs [{:kind :input :sym 'x}
+                             {:kind :output :sym 'out}
+                             {:kind :scalar :type :long
+                              :value-fn (fn [args] (long (nth args 1)))}]}]
+   :result-sym 'out})
+
+(defn- join-descriptor []
+  {:dtype :float
+   :all-params '[in n] :array-params '[in] :scalar-params '[n]
+   :array-roles {'in :input}
+   :value-specs {'in {:abstract (composite-abstract)
+                      :physical-layout (composite-layout)
+                      :leaves [{:field :data :dtype :float}
+                               {:field :index :dtype :int}]}}
+   :allocs [{:sym 'y :dtype :float :size-fn (fn [args] (long (nth args 1)))}]
+   :steps [{:phase :join :convention :map :artifact join-kernel
+            :logical-bindings? true
+            :argument-specs [{:kind :input :sym 'in}
+                             {:kind :output :sym 'y}
+                             {:kind :scalar :type :long
+                              :value-fn (fn [args] (long (nth args 1)))}]}]
+   :result-sym 'y})
+
 (defn- composed [n]
   (let [weight (float-array n)
         first (lowered :first (float-array n) weight)
@@ -65,6 +134,8 @@
   (let [lowering (composed 16)
         plan (:plan lowering)
         certificate (:certificate lowering)
+        first-y-value (get (:value-mapping certificate) [:first [:first 'y]])
+        first-w-value (get (:value-mapping certificate) [:first [:first 'w]])
         first-y (get (:node-mapping certificate) [:first [:first 'y]])
         second-x (get (:node-mapping certificate) [:second [:second 'x]])
         first-w (get (:node-mapping certificate) [:first [:first 'w]])
@@ -77,10 +148,89 @@
     (is (= first-y second-x) "the intermediate is one node, not two buffers plus a copy")
     (is (= first-w second-w) "shared constants retain one allocation identity")
     (is (= :internal (get-in plan [:nodes first-y :role])))
-    (is (= first-y (get-in plan [:instances 1 :bindings 'x])))
-    (is (= first-w (get-in plan [:instances 1 :bindings 'w])))
+    (is (= first-y-value (get-in plan [:instances 1 :bindings 'x])))
+    (is (= first-w-value (get-in plan [:instances 1 :bindings 'w])))
     (is (= [(get (:node-mapping certificate) [:second [:second 'y]])]
            (:outputs plan)))))
+
+(deftest composite-values-compose-atomically-before-allocation
+  (let [n 16
+        producer (resident/lower {:id :split :target :ze:0
+                                  :descriptor (split-descriptor)
+                                  :arguments [(float-array n) n]})
+        consumer (resident/lower {:id :join :target :ze:0
+                                  :descriptor (join-descriptor)
+                                  :arguments [{:data (float-array n)
+                                               :index (int-array n)} n]})
+        producer-value (get-in producer [:certificate :bindings 'out])
+        consumer-value (get-in consumer [:certificate :bindings 'in])
+        producer-leaves (get-in producer [:plan :values producer-value :leaves])
+        consumer-leaves (get-in consumer [:plan :values consumer-value :leaves])
+        lowering (composition/compose
+                  {:id :split-join
+                   :components [{:id :producer :lowering producer}
+                                {:id :consumer :lowering consumer}]
+                   :connections [{:from [:producer producer-value]
+                                  :to [:consumer consumer-value]}]
+                   :outputs [[:consumer (get-in consumer [:certificate :bindings 'y])]]})
+        plan (:plan lowering)
+        certificate (:certificate lowering)
+        canonical-value (get (:value-mapping certificate) [:producer producer-value])]
+    (is (= [:data :index] (mapv :name producer-leaves)))
+    (is (= 2 (count (get-in producer [:certificate :values 'out :leaves]))))
+    (is (= canonical-value
+           (get (:value-mapping certificate) [:consumer consumer-value])))
+    (is (= canonical-value (get-in plan [:instances 1 :bindings 'in])))
+    (is (= (mapv #(get (:node-mapping certificate) [:producer (:node %)]) producer-leaves)
+           (mapv #(get (:node-mapping certificate) [:consumer (:node %)]) consumer-leaves)))
+    (is (= 4 (count (:nodes plan)))
+        "the two consumer leaves are unified with producer storage, never copied")
+    (is (= :internal
+           (get-in plan [:nodes (-> plan :values (get canonical-value) :leaves first :node)
+                         :role])))
+    (is (composition/certified-composition? (composition/verify! lowering)))))
+
+(deftest composite-constant-leaves-share-one-atomic-value
+  (let [n 8
+        data (float-array n)
+        index (int-array n)
+        argument {:data data :index index}
+        left (resident/lower {:id :left :target :ze:0 :descriptor (join-descriptor)
+                              :arguments [argument n] :roles {'in :constant}})
+        right (resident/lower {:id :right :target :ze:0 :descriptor (join-descriptor)
+                               :arguments [argument n] :roles {'in :constant}})
+        left-in (get-in left [:certificate :bindings 'in])
+        right-in (get-in right [:certificate :bindings 'in])
+        lowering (composition/compose
+                  {:id :shared-composite
+                   :components [{:id :left :lowering left} {:id :right :lowering right}]
+                   :shares [[[:left left-in] [:right right-in]]]
+                   :outputs [[:left (get-in left [:certificate :bindings 'y])]
+                             [:right (get-in right [:certificate :bindings 'y])]]})
+        plan (:plan lowering)
+        certificate (:certificate lowering)
+        canonical (get (:value-mapping certificate) [:left left-in])]
+    (is (= canonical (get (:value-mapping certificate) [:right right-in])))
+    (is (= canonical (get-in plan [:instances 1 :bindings 'in])))
+    (is (= 4 (count (:nodes plan))) "two physical constant leaves are allocated only once")
+    (is (= [data index]
+           (mapv #(get-in plan [:nodes (:node %) :source])
+                 (get-in plan [:values canonical :leaves]))))))
+
+(deftest certified-compositions-remain-logical-components
+  (let [pair (composed 8)
+        third (lowered :third (float-array 8) (float-array 8))
+        pair-output (first (link/output-value-ids (:plan pair)))
+        third-input (get-in third [:certificate :bindings 'x])
+        third-output (get-in third [:certificate :bindings 'y])
+        lowering (composition/compose
+                  {:id :three-layers
+                   :components [{:id :pair :lowering pair} {:id :third :lowering third}]
+                   :connections [{:from [:pair pair-output] :to [:third third-input]}]
+                   :outputs [[:third third-output]]})]
+    (is (= 3 (count (get-in lowering [:plan :instances]))))
+    (is (= 1 (count (link/output-value-ids (:plan lowering)))))
+    (is (identical? lowering (composition/verify! lowering)))))
 
 (deftest composition-is-fail-loud-at-semantic-boundaries
   (testing "a connected view contract must be exact"

--- a/test/raster/compiler/ir/link_plan_test.clj
+++ b/test/raster/compiler/ir/link_plan_test.clj
@@ -175,6 +175,11 @@
       (is (= [:x-a :x-b] (link/value-node-ids plan :x)))
       (is (= :soa-test (get-in plan [:values :x :abstract :representation :kind])))
       (is (= [:a :b] (get-in plan [:values :x :physical-layout :field-order])))
+      (is (= :link-output-value
+             (:reason
+              (ex-data
+               (try (link/validate! (assoc plan :outputs [:x-a]))
+                    (catch clojure.lang.ExceptionInfo error error))))))
       (is (= :link-value-abstract-ownership
              (:reason
               (ex-data

--- a/test/raster/gpu/link_spike_test.clj
+++ b/test/raster/gpu/link_spike_test.clj
@@ -17,10 +17,12 @@
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.link-plan :as link-plan]
+            [raster.compiler.ir.resident-plan :as resident-plan]
             [raster.compiler.pipeline :as pl]
             [raster.dl.nn :as nn]
             [raster.gpu.core :as gpu]
             [raster.gpu.link :as gpu-link]
+            [raster.gpu.resident-value :as resident-value]
             [raster.gpu.value :as value])
   (:import [java.util.concurrent.atomic AtomicBoolean]))
 
@@ -72,31 +74,88 @@
     (is (= output-ids (vec (keys (gpu-link/outputs executable)))))
     (is (= (range 12) (vals (gpu-link/outputs executable))))))
 
+(deftest public-logical-outputs-preserve-composite-field-order
+  (let [composite (link-plan/value
+                   {:id :pair
+                    :abstract (av/tensor {:dtype :float :shape [4]})
+                    :physical-layout {:kind :ordered-fields :field-order [:data :scale]}
+                    :leaves [{:name :data :node :data} {:name :scale :node :scale}]})
+        dense (link-plan/value
+               {:id :dense :abstract (av/tensor {:dtype :float :shape [4]})
+                :leaves [{:name :value :node :dense-node}]})
+        executable (gpu-link/map->LinkedExecutable
+                    {:plan {:outputs [:data :scale :dense-node]
+                            :values {:pair composite :dense dense}}
+                     :node-views {:data :data-view :scale :scale-view :dense-node :dense-view}
+                     :closed? (atom false)})
+        outputs (gpu-link/output-values executable)]
+    (is (= [:pair :dense] (vec (keys outputs))))
+    (is (= :dense-view (:dense outputs)))
+    (is (= [:data :scale] (mapv :name (get-in outputs [:pair :fields]))))
+    (is (= [:data-view :scale-view] (mapv :value (get-in outputs [:pair :fields]))))))
+
+(deftest composite-dispatch-projection-preserves-certified-physical-abi
+  (let [allocation-a (bview/allocation {:id :a :byte-size 16 :memory-space :device
+                                        :device :ze:0})
+        allocation-b (bview/allocation {:id :b :byte-size 16 :memory-space :device
+                                        :device :ze:0})
+        view-a (gpu/->ResidentBufferView :session :a
+                                         (bview/view allocation-a {:dtype :float :shape [4]}))
+        view-b (gpu/->ResidentBufferView :session :b
+                                         (bview/view allocation-b {:dtype :int :shape [4]}))
+        composite (resident-value/composite
+                   :pair [{:name :data :value view-a} {:name :index :value view-b}])
+        slots [(kabi/slot 'pair_data :input :float :binding 'pair :field :data)
+               (kabi/slot 'pair_index :input :int :binding 'pair :field :index)]
+        step {:phase :dispatch :logical-bindings? true
+              :argument-specs [{:kind :pointer :binding 'pair :slots slots}
+                               {:kind :scalar}]}
+        scalar {:type :long :value 4}]
+    (is (= [view-a view-b scalar]
+           (#'gpu-link/physical-step-arguments step [composite scalar])))))
+
 (deftest linked-composite-value-expands-through-the-common-runtime
   (if-not @gp/gpu-available?
     (gp/gpu-skip! "LinkValue composite ABI expansion")
     (let [n 16
           x-a (float-array (map float (range n)))
           x-b (float-array (map #(float (* 2 %)) (range n)))
-          expected (float-array (map + x-a x-b))
+          expected-sum (float-array (map + x-a x-b))
+          expected-difference (float-array (map - x-a x-b))
           kernel
           (artifact/make
            {:kernel-name "linked_composite_add"
             :source (str "__kernel void linked_composite_add("
                          "__global const float* x_a, __global const float* x_b, "
-                         "__global float* y, long n) { "
-                         "long i = get_global_id(0); if (i < n) y[i] = x_a[i] + x_b[i]; }")
+                         "__global float* y_sum, __global float* y_difference, long n) { "
+                         "long i = get_global_id(0); if (i < n) { "
+                         "y_sum[i] = x_a[i] + x_b[i]; "
+                         "y_difference[i] = x_a[i] - x_b[i]; } }")
             :abi [(kabi/slot 'x_a :input :float :binding 'x :field :a)
                   (kabi/slot 'x_b :input :float :binding 'x :field :b)
-                  (kabi/slot 'y :output :float)
+                  (kabi/slot 'y_sum :output :float :binding 'y :field :sum)
+                  (kabi/slot 'y_difference :output :float :binding 'y :field :difference)
                   (kabi/slot 'n :scalar :long)]
-            :arguments '[x_a x_b y n]
+            :arguments '[x_a x_b y_sum y_difference n]
             :launch (launch/spec {:workgroup-size [64]
                                   :group-count [(launch/ceil-div 'n 64)]})})
           descriptor
           {:dtype :float :all-params '[x n] :array-params '[x] :scalar-params '[n]
            :array-roles {'x :input}
-           :allocs [{:sym 'y :dtype :float :size-fn (fn [args] (long (nth args 1)))}]
+           :value-specs
+           {'x {:abstract (av/tensor {:dtype :float :shape ['n]
+                                      :representation {:kind :two-input-fields}})
+                :physical-layout {:kind :ordered-fields :field-order [:a :b]}
+                :leaves [{:field :a :dtype :float} {:field :b :dtype :float}]}}
+           :allocs
+           [{:sym 'y
+             :abstract (av/tensor {:dtype :float :shape ['n]
+                                   :representation {:kind :two-output-fields}})
+             :physical-layout {:kind :ordered-fields :field-order [:sum :difference]}
+             :leaves [{:field :sum :dtype :float
+                       :size-fn (fn [args] (long (nth args 1)))}
+                      {:field :difference :dtype :float
+                       :size-fn (fn [args] (long (nth args 1)))}]}]
            :steps [{:phase :add :kernel-name "linked_composite_add" :convention :map
                     :artifact kernel :logical-bindings? true
                     :argument-specs [{:kind :pointer :sym 'x}
@@ -104,24 +163,17 @@
                                      {:kind :scalar :type :long
                                       :value-fn (fn [args] (long (nth args 1)))}]}]
            :result-sym 'y}
-          node (fn [id role source]
-                 (link-plan/node {:id id :dtype :float :shape [n] :device :ze:0
-                                  :role role :source source}))
-          nodes [(node :x-a :input x-a) (node :x-b :input x-b) (node :y :output nil)]
-          composite (link-plan/value
-                     {:id :x
-                      :abstract (av/tensor {:dtype :float :shape [n]
-                                            :representation {:kind :soa-test}})
-                      :leaves [{:name :a :node :x-a} {:name :b :node :x-b}]})
-          instance (link-plan/instance
-                    {:id :add :descriptor descriptor :bindings {'x :x 'y :y}
-                     :scalars {'n n} :arguments [nil n]})
-          plan (link-plan/make {:id :composite-add :target :ze:0 :nodes nodes
-                                :values [composite] :instances [instance] :outputs [:y]})
-          executable (gpu-link/instantiate! plan)]
+          lowering (resident-plan/lower
+                    {:id :composite-add :target :ze:0 :descriptor descriptor
+                     :arguments [{:a x-a :b x-b} n]})
+          executable (gpu-link/instantiate! (:plan lowering))
+          sum-node [:composite-add 'y :sum]
+          difference-node [:composite-add 'y :difference]]
       (try
         (gpu-link/run! executable)
-        (is (= (vec expected) (vec (gpu-link/download executable :y))))
+        (is (= (vec expected-sum) (vec (gpu-link/download executable sum-node))))
+        (is (= (vec expected-difference)
+               (vec (gpu-link/download executable difference-node))))
         (finally (gpu-link/close! executable))))))
 
 (deftest attached-close-attempts-the-entire-reverse-order-teardown


### PR DESCRIPTION
## Summary

- compose certified GPU programs through logical `LinkValue`s, atomically unifying every physical leaf of composite values
- support backend-neutral composite resident parameters and scratch allocations while preserving the dense descriptor path
- expose logical resident outputs and project composite values to physical ABI arguments only at dispatch
- retain both value and node mappings in composition certificates for semantic APIs and inspectable physical ranges

This deliberately contains no Q4_K-specific allocation or linking logic. Quantized formats are represented by an `AbstractValue`, ordered physical layout, and ordinary leaf contracts.

## Validation

- all compiler IR tests: 155 tests, 766 assertions, 0 failures
- compiled/program/runtime regressions: 42 tests, 204 assertions, 0 failures
- dispatch benchmark and segmented weighted reduction: 17 tests, 93 assertions, 0 failures
- focused link spike: 10 tests, 31 assertions, 0 failures
- targeted formatting and `git diff --check`

The host recently OOMed and the local Level Zero probe now returns `zeInit: 0x78000001`, so eight GPU-gated assertions skip explicitly. The new live composite allocation test is present for CI/device validation; all pure composition, allocation, ABI projection, and runtime-order tests pass locally.
