### PR TITLE
Emit typed multi-row Q4_K projections

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -133,11 +133,15 @@ validated plan; one later instantiation therefore removes even the device copy. 
 value-layer cleanup is ranged-view composition and explicit cross-component ownership transfer;
 the duplicate legacy whole-program binding API is retired.
 
-Pretrained-rstr's batch boundary is the next concrete shape test: weights bind once to shared
+Pretrained-rstr's batch boundary is the current concrete shape test: weights bind once to shared
 constant nodes, while residual, scratch, position, logits and token storage are lane-local nodes or
-disjoint views. Packed Q/K/V and attention views already fit LinkPlan. The missing performance work
-is a compiler shape/schedule transform that emits projection, post-attention and head programs with
-a leading logical batch dimension; batching is not a linker convention or an attention special case.
+disjoint views. Packed Q/K/V and attention views already fit LinkPlan. The first projection slice now
+makes Q8_K activation quantization and Q4_K DP4A projection uniformly row-capable: row count is an
+ordinary outer shape/launch extent, activation leaves are row-major, and packed weight leaves remain
+shared. B=1 is no longer a separate kernel contract. The remaining performance work is to derive
+these projection, post-attention and head programs from the scheduled contraction/SOAC path rather
+than treating the Q4_K source kernel as the final abstraction; batching is not a linker convention
+or an attention special case.
 
 Artifact linking and value rebinding are not runtime conveniences. They are
 compiler primitives required for competitive model execution.

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -55,8 +55,8 @@
   (when (and params tags)
     {:scalar-types (into {} (keep (fn [[p t]]
                                     (case t
-                                      (long longs int ints) [p :int]
-                                      (double doubles float floats) [p :float]
+                                      (long int) [p :int]
+                                      (double float) [p :float]
                                       nil))
                                   (map vector params tags)))
      :array-types (into {} (keep (fn [[p t]]

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -1451,20 +1451,20 @@
    bare nil (the silent-empty-graph footgun)."
   ([form] (extract-gpu-program form nil))
   ([form kernel-info-fn]
-  (if-not (and (seq? form) (#{'let* 'let} (first form)))
-    {::non-resident {:why :not-a-let-form :form (when (seq? form) (first form))}}
-    (let [bindings (partition 2 (second form))
-          body (last form)
-          allocs (volatile! [])
-          steps (volatile! [])
-          scalar-lets (volatile! [])
+   (if-not (and (seq? form) (#{'let* 'let} (first form)))
+     {::non-resident {:why :not-a-let-form :form (when (seq? form) (first form))}}
+     (let [bindings (partition 2 (second form))
+           body (last form)
+           allocs (volatile! [])
+           steps (volatile! [])
+           scalar-lets (volatile! [])
           ;; Intermediate array BINDINGS produced in this program: allocs and
           ;; kernel/GEMM step outputs. These are device-only buffers — a host
           ;; scalar/size-let may NOT read them (see the scalar-let guard below).
           ;; Array PARAMS are deliberately NOT tracked here: the per-call arg-fn
           ;; receives the host arrays, so `(alength W)` on a param stays a valid
           ;; host size expr.
-          device-buffers (volatile! #{})
+           device-buffers (volatile! #{})
           ;; Array aliases: bindings of the form `sym = <bare array symbol>` (e.g. a
           ;; fused-buffer alias `db = hfuse_out`, or a residual/broadcast copy result
           ;; the SOAC fuser rewired to an existing buffer). These carry NO computation —
@@ -1474,75 +1474,75 @@
           ;; binding reaches the array-tag?/reads-device-buffer rejects and defeats an
           ;; otherwise-straight-line resident program (e.g. QLoRA residual base+delta
           ;; backward, where residual-add's two grad copies fuse to one buffer).
-          aliases (volatile! {})
-          ok (volatile! true)
-          reason (volatile! nil)
-          reject! (fn [why sym expr]
-                    (vreset! ok false)
-                    (when-not @reason (vreset! reason {:why why :sym sym :form expr})))]
-      (doseq [[sym expr0] bindings]
-        (let [expr (if (seq @aliases) (util/subst-syms @aliases expr0) expr0)]
-          (cond
+           aliases (volatile! {})
+           ok (volatile! true)
+           reason (volatile! nil)
+           reject! (fn [why sym expr]
+                     (vreset! ok false)
+                     (when-not @reason (vreset! reason {:why why :sym sym :form expr})))]
+       (doseq [[sym expr0] bindings]
+         (let [expr (if (seq @aliases) (util/subst-syms @aliases expr0) expr0)]
+           (cond
           ;; pure array-alias binding (`sym = other-array-symbol`) → copy-propagate.
-            (and (symbol? expr)
-                 (or (contains? @device-buffers expr) (array-tag? sym)))
-            (do (vswap! aliases assoc sym expr)
-                (when (contains? @device-buffers expr) (vswap! device-buffers conj sym)))
-            (and (seq? expr) (contains? gpu-array-alloc-heads (first expr)))
-            (do (vswap! allocs conj {:sym sym :size-expr (second expr)})
-                (vswap! device-buffers conj sym))
+             (and (symbol? expr)
+                  (or (contains? @device-buffers expr) (array-tag? sym)))
+             (do (vswap! aliases assoc sym expr)
+                 (when (contains? @device-buffers expr) (vswap! device-buffers conj sym)))
+             (and (seq? expr) (contains? gpu-array-alloc-heads (first expr)))
+             (do (vswap! allocs conj {:sym sym :size-expr (second expr)})
+                 (vswap! device-buffers conj sym))
           ;; devirtualized array alloc (alloc-like/zeros-like .invk) — a GEMM/kernel output buffer.
-            (alloc-invk? expr)
-            (do (vswap! allocs conj {:sym sym :size-expr (alloc-invk-size expr)})
-                (vswap! device-buffers conj sym))
-            (and (seq? expr) (symbol? (first expr)) (contains? gpu-invoke-heads (first expr)))
-            (if-let [s (parse-gpu-step sym expr)]
-              (let [ordered-result
-                    (when (and (:arguments s) kernel-info-fn)
-                      (let [abi (:abi (kernel-info-fn (:kernel-name s)))
-                            result-indexes (keep-indexed
-                                            (fn [i slot]
-                                              (when (= :result (:role slot)) i))
-                                            abi)]
-                        (when (= 1 (count result-indexes))
-                          {:value (nth (:arguments s) (first result-indexes))})))]
-                (if (and (= :reduce (:convention s)) ordered-result
-                         (nil? (:value ordered-result)))
+             (alloc-invk? expr)
+             (do (vswap! allocs conj {:sym sym :size-expr (alloc-invk-size expr)})
+                 (vswap! device-buffers conj sym))
+             (and (seq? expr) (symbol? (first expr)) (contains? gpu-invoke-heads (first expr)))
+             (if-let [s (parse-gpu-step sym expr)]
+               (let [ordered-result
+                     (when (and (:arguments s) kernel-info-fn)
+                       (let [abi (:abi (kernel-info-fn (:kernel-name s)))
+                             result-indexes (keep-indexed
+                                             (fn [i slot]
+                                               (when (= :result (:role slot)) i))
+                                             abi)]
+                         (when (= 1 (count result-indexes))
+                           {:value (nth (:arguments s) (first result-indexes))})))]
+                 (if (and (= :reduce (:convention s)) ordered-result
+                          (nil? (:value ordered-result)))
                   ;; The explicit nil :result is the host-scalar staging protocol. It cannot be
                   ;; recorded into a resident graph, but must remain a clean non-resident fallback
                   ;; (rather than reaching descriptor construction and throwing there).
-                  (reject! :host-scalar-reduction sym expr)
-                  (do (vswap! steps conj s) (vswap! device-buffers conj sym)
+                   (reject! :host-scalar-reduction sym expr)
+                   (do (vswap! steps conj s) (vswap! device-buffers conj sym)
                   ;; A :map step's runtime VALUE is its out buffer (invoke-registered-kernel
                   ;; returns output-array), so the binding sym is a pure alias of the out
                   ;; array. Copy-propagate it like any other array alias — a later step
                   ;; that reads the binding sym (e.g. the primary of a horizontally-fused
                   ;; multi-output map, whose out is a fusion-materialized buffer) must
                   ;; resolve to the REAL resident buffer at bind time.
-                  (when (and (#{:map :contract :reduce} (:convention s)) ordered-result)
-                    (let [out (:value ordered-result)]
-                      (when (and (symbol? out) (not= sym out))
-                        (vswap! aliases assoc sym out)))))))
-              (reject! :unparseable-kernel-invoke sym expr))
+                       (when (and (#{:map :contract :reduce} (:convention s)) ordered-result)
+                         (let [out (:value ordered-result)]
+                           (when (and (symbol? out) (not= sym out))
+                             (vswap! aliases assoc sym out)))))))
+               (reject! :unparseable-kernel-invoke sym expr))
           ;; devirtualized BLAS GEMM (.invk dgemm*-impl …) → a :gemm step. A non-default
           ;; alpha/beta is NOT representable by the resident GEMM kernels (they compute
           ;; C = A·B and overwrite C) — reject it by NAME instead of silently dropping the
           ;; scalars, which turned an ACCUMULATE (C += A·B, beta=1) into an OVERWRITE on
           ;; GPU while CPU accumulated. See gemm-alpha-beta-default?.
-            (gemm-invk? expr)
-            (if-let [s (parse-gpu-step sym expr)]
-              (if (op/gemm-default-alpha-beta? (:alpha-expr s) (:beta-expr s))
-                (do (vswap! steps conj s) (vswap! device-buffers conj sym))
-                (reject! :unsupported-gemm-alpha-beta sym expr))
-              (reject! :unparseable-gemm sym expr))
+             (gemm-invk? expr)
+             (if-let [s (parse-gpu-step sym expr)]
+               (if (op/gemm-default-alpha-beta? (:alpha-expr s) (:beta-expr s))
+                 (do (vswap! steps conj s) (vswap! device-buffers conj sym))
+                 (reject! :unsupported-gemm-alpha-beta sym expr))
+               (reject! :unparseable-gemm sym expr))
           ;; An ARRAY-tagged binding that reached here is an unlowered device-array op (an
           ;; elementwise/reduction op with no resident kernel, or an array alias the resident path
           ;; can't rewire) — NOT a host scalar-let. Reject the straight-line extraction so the
           ;; caller falls back to the staging fn (rather than eval'ing an array .invk as a scalar
           ;; size closure). E.g. an AD-emitted daxpy-diff-into! or a raw loss reduction that did
           ;; not lower to a par kernel in this composed path.
-            (array-tag? sym)
-            (reject! :unlowered-array-op sym expr)
+             (array-tag? sym)
+             (reject! :unlowered-array-op sym expr)
           ;; A SCALAR binding whose init READS an intermediate device buffer is a
           ;; reduction (device array → scalar), NOT a host size-let — e.g. the
           ;; primal `(.invk mse-loss-impl pred tgt n)` reducing the pred buffer to
@@ -1554,18 +1554,18 @@
           ;; until then, reject so the caller falls back cleanly (non-resident)
           ;; rather than throwing. Reading an array PARAM (host-available, e.g.
           ;; alength) is fine — only intermediate buffers are tracked.
-            (seq (set/intersection (mem/sexp-free-vars expr) @device-buffers))
-            (reject! :scalar-let-reads-device-buffer sym expr)
+             (seq (set/intersection (mem/sexp-free-vars expr) @device-buffers))
+             (reject! :scalar-let-reads-device-buffer sym expr)
           ;; A pure scalar binding (no nested kernel) feeds sizes/counts — keep it.
-            (not (contains-gpu-invoke? expr))
-            (vswap! scalar-lets into [sym expr])
+             (not (contains-gpu-invoke? expr))
+             (vswap! scalar-lets into [sym expr])
           ;; control flow / kernel-result-into-scalar → not straight-line.
-            :else (reject! :control-flow-or-host-scalar sym expr))))
-      (let [body (if (seq @aliases) (util/subst-syms @aliases body) body)]
-        (cond
-          (not @ok)      {::non-resident @reason}
-          (empty? @steps) {::non-resident {:why :no-kernel-steps}}
-          :else {:allocs @allocs :steps @steps :scalar-lets @scalar-lets :result body}))))))
+             :else (reject! :control-flow-or-host-scalar sym expr))))
+       (let [body (if (seq @aliases) (util/subst-syms @aliases body) body)]
+         (cond
+           (not @ok)      {::non-resident @reason}
+           (empty? @steps) {::non-resident {:why :no-kernel-steps}}
+           :else {:allocs @allocs :steps @steps :scalar-lets @scalar-lets :result body}))))))
 
 (defn- strip-meta
   "Drop a symbol's metadata — the walker stamps :tag, and a primitive-initialized local can't
@@ -2235,12 +2235,24 @@
         effective-dtype (or dtype (infer-dtype resolved-var)
                             ;; Scalar-only functions default to double precision
                             :double)
+        source-ns (let [m (meta resolved-var)]
+                    (or (when-let [s (:raster.core/deftm-source-ns m)]
+                          (try (the-ns s) (catch Exception _ nil)))
+                        (when (var? resolved-var) (.ns ^clojure.lang.Var resolved-var))))
         param-env (build-param-env f-var dtype)
+        gpu-param-types (when target-device
+                          (opencl-pass/derive-param-types
+                           (:raster.core/deftm-params (meta resolved-var))
+                           (:raster.core/deftm-tags (meta resolved-var))
+                           effective-dtype))
         opts (cond-> {:inline? inline?
                       :active-params active-params
                       :simd? simd? :target-device target-device
                       :dtype effective-dtype}
-               param-env (assoc :param-env param-env))
+               param-env (assoc :param-env param-env)
+               source-ns (assoc :source-ns source-ns)
+               gpu-param-types (assoc :scalar-types (:scalar-types gpu-param-types)
+                                      :array-types (:array-types gpu-param-types)))
         {:keys [stages stats]} (run-passes-diagnostic raw-form passes opts)
         backend-type (get-in stages [:backend-type])]
     (-> {:walked raw-form

--- a/src/raster/quant/kernels_k.clj
+++ b/src/raster/quant/kernels_k.clj
@@ -1,5 +1,5 @@
 (ns raster.quant.kernels-k
-  "Composable K-quant GEMV kernels — the SAME deftm compiles to CPU-C (gcc auto-vectorizes
+  "Composable K-quant GEMV/GEMM kernels — the SAME deftm compiles to CPU-C (gcc auto-vectorizes
   the dpbusd-able inner loop) and, via the shared c_emit, to OpenCL/GPU. The scalar per-row
   dot mirrors the validated references (raster.compiler.backend.cpu.quant/q4k-q8k-dot,
   q6k-q8k-dot); the fused 8-col-lanes peak SIMD is the orthogonal #27 optimization serving
@@ -79,9 +79,9 @@
     y))
 
 ;; ---- q8_K activation quantizer (the GPU-resident enabler) ----
-;; float activation x[in] → q8_K for the dp4a matmul, ON the GPU: per 256-super-block
+;; float activation x[nrows,in] → q8_K for the dp4a matmul, ON the GPU: per 256-super-block
 ;; d = max|x|/127; int8 quants packed 4-per-int32 element-order (xp); xs = d; bsums = per
-;; 32-sub-block int sum. Output feeds qmatmul-q4k-dp4a! directly (no host round-trip), so
+;; 32-sub-block int sum. Output feeds qmatmul-q4k-dp4a-rows! directly (no host round-trip), so
 ;; norm→quant→matmul chains run entirely on-device in a graph.
 ;;
 ;; 2-PHASE PARALLEL (was: one work-item per super-block, 512-deep serial — the same
@@ -89,49 +89,59 @@
 ;; phase 1 computes per-32-sub-block |max| (nsb*8 items, 32-deep), phase 2 folds the 8
 ;; sibling submaxes (float max is EXACT under reassociation → d is bit-identical to the
 ;; serial scan) and quantizes its 32 elements (nsb*8 items, ~40-deep). `submax` is an
-;; nsb*8 float scratch. The 8 same-value xs writes per super-block are benign.
-(deftm quant-act-q8k-gpu!
+;; nrows*nsb*8 float scratch. The 8 same-value xs writes per super-block are benign.
+(deftm quant-act-q8k-rows-gpu!
+  "Q8_K activation quantization over a row-major [nrows,in] tensor. The physical result is
+  the ordered `(xp,xs,bsums)` representation with row-major leaves; `submax` is transient
+  reduction scratch. Batch is an ordinary outer shape axis and does not affect the format."
   [x :- (Array float), xp :- (Array int), xs :- (Array float), bsums :- (Array int),
-   submax :- (Array float), nsb :- Long] :- Void
+   submax :- (Array float), in :- Long, nrows :- Long] :- Void
   (do
-    (par/map-void! si (* (long nsb) 8)
-      (let [base (* (long si) 32)
-            m (loop [k 0 m 0.0]
-                (if (< k 32)
-                  (let [v (ra/aget x (+ base k))]
-                    (recur (inc k) (max m (max v (- v)))))
-                  m))]
-        (ra/aset submax si (float m))))
-    (par/map-void! sj (* (long nsb) 8)
-      (let [sb (quot sj 8)
-            j (rem sj 8)
-            mx (loop [k 0 m 0.0]
-                 (if (< k 8)
-                   (recur (inc k) (max m (ra/aget submax (+ (* (long sb) 8) k))))
-                   m))
-            d (/ (double mx) 127.0)
-            id (if (> (double d) 0.0) (/ 1.0 (double d)) 0.0)
-            sidx (+ (* (long sb) 8) j)
-            wbase (+ (* (long sb) 64) (* j 8))
-            ebase (+ (* (long sb) 256) (* j 32))]
-        (ra/aset xs sb (float d))
-        (let [bs (loop [w 0 s 0]
-                   (if (< w 8)
+    (par/map-void! si (* (long nrows) (quot (long in) 32))
+                   (let [base (* (long si) 32)
+                         m (loop [k 0 m 0.0]
+                             (if (< k 32)
+                               (let [v (ra/aget x (+ base k))]
+                                 (recur (inc k) (max m (max v (- v)))))
+                               m))]
+                     (ra/aset submax si (float m))))
+    (par/map-void! sj (* (long nrows) (quot (long in) 32))
+                   (let [nsb (quot (long in) 256)
+                         nsub (quot (long in) 32)
+                         row (quot sj nsub)
+                         row-sub (rem sj nsub)
+                         sb (quot row-sub 8)
+                         j (rem row-sub 8)
+                         mx (loop [k 0 m 0.0]
+                              (if (< k 8)
+                                (recur (inc k) (max m (ra/aget submax (+ (* row nsub) (* sb 8) k))))
+                                m))
+                         d (/ (double mx) 127.0)
+                         id (if (> (double d) 0.0) (/ 1.0 (double d)) 0.0)
+                         sidx (+ (* row nsub) (* sb 8) j)
+                         wbase (+ (* row (quot (long in) 4)) (* sb 64) (* j 8))
+                         ebase (+ (* row (long in)) (* sb 256) (* j 32))]
+                     (ra/aset xs (+ (* row nsb) sb) (float d))
+                     (let [bs (loop [w 0 s 0]
+                                (if (< w 8)
                      ;; |x·id| ≤ 127 by construction (id = 127/max|x|), so round lands in
                      ;; int8 range without an explicit clamp; the (long ...) cast types q.
-                     (let [e (+ ebase (* w 4))
-                           q0 (long (Math/round (* (double (ra/aget x e)) id)))
-                           q1 (long (Math/round (* (double (ra/aget x (+ e 1))) id)))
-                           q2 (long (Math/round (* (double (ra/aget x (+ e 2))) id)))
-                           q3 (long (Math/round (* (double (ra/aget x (+ e 3))) id)))
-                           word (bit-or (bit-and q0 0xFF)
-                                        (bit-shift-left (bit-and q1 0xFF) 8)
-                                        (bit-shift-left (bit-and q2 0xFF) 16)
-                                        (bit-shift-left (bit-and q3 0xFF) 24))]
-                       (ra/aset xp (+ wbase w) (int word))
-                       (recur (inc w) (+ s q0 q1 q2 q3)))
-                     s))]
-          (ra/aset bsums sidx (int bs)))))))
+                                  (let [e (+ ebase (* w 4))
+                                        q0 (long (Math/round (* (double (ra/aget x e)) id)))
+                                        q1 (long (Math/round (* (double (ra/aget x (+ e 1))) id)))
+                                        q2 (long (Math/round (* (double (ra/aget x (+ e 2))) id)))
+                                        q3 (long (Math/round (* (double (ra/aget x (+ e 3))) id)))
+                           ;; Keep bit-or binary in the shared IR. The JVM bytecode backend's
+                           ;; primitive bit op is binary; passing four operands used to discard
+                           ;; the high two lanes while OpenCL happened to accept the variadic form.
+                                        word (bit-or (bit-or (bit-and q0 0xFF)
+                                                             (bit-shift-left (bit-and q1 0xFF) 8))
+                                                     (bit-or (bit-shift-left (bit-and q2 0xFF) 16)
+                                                             (bit-shift-left (bit-and q3 0xFF) 24)))]
+                                    (ra/aset xp (+ wbase w) (int word))
+                                    (recur (inc w) (+ s q0 q1 q2 q3)))
+                                  s))]
+                       (ra/aset bsums sidx (int bs)))))))
 
 ;; ---- dp4a int8-GEMV core (the format-agnostic hardware-accelerated path) ----
 ;; int8×int8 GEMV over int32-packed lanes: y[o] = Σ_w dp4a(wp[o*kw+w], xp[w]). par/dp4a
@@ -149,72 +159,46 @@
                                a))]
                    (ra/aset y o (float acc)))))
 
-;; ---- GPU shape: par/map-void! over output rows (one work-item per row) ----
-;; The GPU form the opencl-pass turns into a kernel (work-item o computes y[o]). Same K
-;; dot as the composable CPU deftm; the GPU int8 path needs byte buffers / int32-packing
-;; (dp4a) — see #26. This is the work-item-mapped twin of qmatmul-q4k-composable!.
-(deftm qmatmul-q4k-gpu!
-  [xq :- (Array byte), xs :- (Array float), bsums :- (Array int),
-   wq :- (Array byte), da :- (Array float), db :- (Array float),
-   aq :- (Array byte), bq :- (Array byte),
-   y :- (Array float), in :- Long, out :- Long] :- Void
-  (par/map-void! o out
-                 (let [nsb (quot (long in) 256) nsub (quot (long in) 32) wrow (quot (long in) 2)
-                       wb (* (long o) wrow) sbb (* (long o) nsb) subb (* (long o) nsub)
-                       acc (loop [sb 0 a 0.0]
-                             (if (< sb nsb)
-                               (let [sbase (* sb 256)
-                                     dav (double (ra/aget da (+ sbb sb)))
-                                     dbv (double (ra/aget db (+ sbb sb)))
-                                     dact (double (ra/aget xs sb))
-                                     ssum (loop [j 0 s 0.0]
-                                            (if (< j 8)
-                                              (let [base (+ sbase (* j 32)) sidx (+ (* sb 8) j)
-                                                    aj (* dav (long (ra/aget aq (+ subb sidx))))
-                                                    bj (* dbv (long (ra/aget bq (+ subb sidx))))
-                                                    dp (loop [k 0 d 0]
-                                                         (if (< k 16)
-                                                           (let [bv (bit-and (long (ra/aget wq (+ wb (quot base 2) k))) 0xFF)]
-                                                             (recur (inc k)
-                                                                    (+ d (* (bit-and bv 0xF) (long (ra/aget xq (+ base k))))
-                                                                       (* (bit-shift-right bv 4) (long (ra/aget xq (+ base k 16)))))))
-                                                           d))]
-                                                (recur (inc j) (+ s (* aj (double dp)) (* bj (double (ra/aget bsums sidx))))))
-                                              s))]
-                                 (recur (inc sb) (+ a (* dact ssum))))
-                               a))]
-                   (ra/aset y o (float acc)))))
-
 ;; ---- Q4_K dp4a GPU kernel (the hardware-accelerated path) ----
-;; Same scale/min fold as qmatmul-q4k-gpu!, but the 32-element sub-block dot is computed
+;; Same scale/min fold as qmatmul-q4k-composable!, but the 32-element sub-block dot is computed
 ;; with par/dp4a over int32-packed lanes. Weights uploaded as int32 (wq nibbles reinterpreted
 ;; little-endian): one int read yields 4 low nibbles (wi & 0x0F0F0F0F → elements k..k+3) AND
 ;; 4 high nibbles ((wi>>4) & 0x0F0F0F0F → elements k+16..k+19), the llama.cpp mmvq trick.
 ;; Activation xq packed element-order to int32 (xp). Nibbles 0..15 are positive int8, so the
 ;; signed dp4a equals the unsigned-nibble × signed-act dpbusd of the composable kernel.
-(deftm qmatmul-q4k-dp4a!
+(deftm qmatmul-q4k-dp4a-rows!
+  "Q4_K projection for shared weights and row-major Q8_K activations. Each work-item owns one
+  `(row,output-channel)` pair. Only activation and result leaves carry a row offset; packed
+  weights and their scale/min metadata are shared across rows."
   [xp :- (Array int), xs :- (Array float), bsums :- (Array int),
    wp :- (Array int), da :- (Array float), db :- (Array float),
    aq :- (Array byte), bq :- (Array byte),
-   y :- (Array float), in :- Long, out :- Long] :- Void
-  (par/map-void! o out
-                 (let [nsb (quot (long in) 256)
+   y :- (Array float), in :- Long, out :- Long, nrows :- Long] :- Void
+  (par/map-void! ro (* (long nrows) (long out))
+                 (let [row (quot ro (long out))
+                       o (rem ro (long out))
+                       nsb (quot (long in) 256)
+                       nsub (quot (long in) 32)
+                       xiw (quot (long in) 4)
                        wiw (quot (long in) 8)           ; weight int32 words per row (in/2 bytes / 4)
                        wb (* (long o) wiw)
                        sbb (* (long o) nsb)
-                       subb (* (long o) (quot (long in) 32))
-                       acc (loop [sb 0 a 0.0]
+                       subb (* (long o) nsub)
+                       xb (* row xiw)
+                       xsb-base (* row nsb)
+                       bsum-base (* row nsub)
+                       acc (loop [sb 0 a (float 0.0)]
                              (if (< sb nsb)
-                               (let [dav (double (ra/aget da (+ sbb sb)))
-                                     dbv (double (ra/aget db (+ sbb sb)))
-                                     dact (double (ra/aget xs sb))
+                               (let [dav (ra/aget da (+ sbb sb))
+                                     dbv (ra/aget db (+ sbb sb))
+                                     dact (ra/aget xs (+ xsb-base sb))
                                      wsb (+ wb (* sb 32))   ; 32 int words / super-block
-                                     xsb (* sb 64)          ; 64 act words / super-block
-                                     ssum (loop [j 0 s 0.0]
+                                     xsb (+ xb (* sb 64))   ; 64 act words / super-block
+                                     ssum (loop [j 0 s (float 0.0)]
                                             (if (< j 8)
                                               (let [sidx (+ (* sb 8) j)
-                                                    aj (* dav (long (ra/aget aq (+ subb sidx))))
-                                                    bj (* dbv (long (ra/aget bq (+ subb sidx))))
+                                                    aj (* dav (float (long (ra/aget aq (+ subb sidx)))))
+                                                    bj (* dbv (float (long (ra/aget bq (+ subb sidx)))))
                                                     wj (+ wsb (* j 4)) xj (+ xsb (* j 8))
                                                     dp (loop [r 0 d 0]
                                                          (if (< r 4)
@@ -225,11 +209,11 @@
                                                                  d2 (par/dp4a hi (ra/aget xp (+ xj 4 r)) d1)]
                                                              (recur (inc r) d2))
                                                            d))]
-                                                (recur (inc j) (+ s (* aj (double dp)) (* bj (double (ra/aget bsums sidx))))))
+                                                (recur (inc j) (+ s (* aj (float dp)) (* bj (float (ra/aget bsums (+ bsum-base sidx)))))))
                                               s))]
                                  (recur (inc sb) (+ a (* dact ssum))))
                                a))]
-                   (ra/aset y o (float acc)))))
+                   (ra/aset y (+ (* row (long out)) o) acc))))
 
 ;; Q6_K work-item-per-row twin of qmatmul-q6k-composable! (symmetric K dot, unsigned+zp32).
 (deftm qmatmul-q6k-gpu!
@@ -314,32 +298,32 @@
   [x :- (Array float), xp :- (Array int), xs :- (Array float),
    in :- Long, nrows :- Long] :- Void
   (par/map-void! rb (* nrows (quot in 32))
-    (let [nb (quot in 32)
-          b (rem rb nb)
-          r (quot rb nb)
-          base (+ (* r in) (* b 32))
-          mx (loop [k 0 m 0.0]
-               (if (< k 32)
-                 (let [v (ra/aget x (+ base k))]
-                   (recur (inc k) (max m (max v (- v)))))
-                 m))
-          d (/ (double mx) 127.0)
-          id (if (> (double d) 0.0) (/ 1.0 (double d)) 0.0)]
-      (ra/aset xs rb (float d))
-      (loop [w 0]
-        (if (< w 8)
-          (let [e (+ base (* w 4))
-                q0 (long (Math/round (* (double (ra/aget x e)) id)))
-                q1 (long (Math/round (* (double (ra/aget x (+ e 1))) id)))
-                q2 (long (Math/round (* (double (ra/aget x (+ e 2))) id)))
-                q3 (long (Math/round (* (double (ra/aget x (+ e 3))) id)))
-                word (bit-or (bit-and q0 0xFF)
-                             (bit-shift-left (bit-and q1 0xFF) 8)
-                             (bit-shift-left (bit-and q2 0xFF) 16)
-                             (bit-shift-left (bit-and q3 0xFF) 24))]
-            (ra/aset xp (+ (* rb 8) w) (int word))
-            (recur (inc w)))
-          nil)))))
+                 (let [nb (quot in 32)
+                       b (rem rb nb)
+                       r (quot rb nb)
+                       base (+ (* r in) (* b 32))
+                       mx (loop [k 0 m 0.0]
+                            (if (< k 32)
+                              (let [v (ra/aget x (+ base k))]
+                                (recur (inc k) (max m (max v (- v)))))
+                              m))
+                       d (/ (double mx) 127.0)
+                       id (if (> (double d) 0.0) (/ 1.0 (double d)) 0.0)]
+                   (ra/aset xs rb (float d))
+                   (loop [w 0]
+                     (if (< w 8)
+                       (let [e (+ base (* w 4))
+                             q0 (long (Math/round (* (double (ra/aget x e)) id)))
+                             q1 (long (Math/round (* (double (ra/aget x (+ e 1))) id)))
+                             q2 (long (Math/round (* (double (ra/aget x (+ e 2))) id)))
+                             q3 (long (Math/round (* (double (ra/aget x (+ e 3))) id)))
+                             word (bit-or (bit-or (bit-and q0 0xFF)
+                                                  (bit-shift-left (bit-and q1 0xFF) 8))
+                                          (bit-or (bit-shift-left (bit-and q2 0xFF) 16)
+                                                  (bit-shift-left (bit-and q3 0xFF) 24)))]
+                         (ra/aset xp (+ (* rb 8) w) (int word))
+                         (recur (inc w)))
+                       nil)))))
 
 (deftm qmatmul-i8-gemm!
   "Signed q8_0 x q8_0 GEMM for prefill: one work-item per (token, out-row) —
@@ -350,21 +334,21 @@
    wp :- (Array int), ws :- (Array float), y :- (Array float),
    in :- Long, out :- Long, nrows :- Long] :- Void
   (par/map-void! ot (* nrows out)
-    (let [o (rem ot out)
-          t (quot ot out)
-          nb (quot in 32)
-          ni4 (quot in 4)
-          acc (loop [b 0 a 0.0]
-                (if (< b nb)
-                  (let [dp (loop [k 0 d 0]
-                             (if (< k 8)
-                               (recur (inc k)
-                                      (par/dp4a (ra/aget wp (+ (* o ni4) (* b 8) k))
-                                                (ra/aget xp (+ (* t ni4) (* b 8) k)) d))
-                               d))]
-                    (recur (inc b)
-                           (+ a (* (* (double (ra/aget ws (+ (* o nb) b)))
-                                      (double (ra/aget xs (+ (* t nb) b))))
-                                   (double dp)))))
-                  a))]
-      (ra/aset y (+ (* t out) o) (float acc)))))
+                 (let [o (rem ot out)
+                       t (quot ot out)
+                       nb (quot in 32)
+                       ni4 (quot in 4)
+                       acc (loop [b 0 a 0.0]
+                             (if (< b nb)
+                               (let [dp (loop [k 0 d 0]
+                                          (if (< k 8)
+                                            (recur (inc k)
+                                                   (par/dp4a (ra/aget wp (+ (* o ni4) (* b 8) k))
+                                                             (ra/aget xp (+ (* t ni4) (* b 8) k)) d))
+                                            d))]
+                                 (recur (inc b)
+                                        (+ a (* (* (double (ra/aget ws (+ (* o nb) b)))
+                                                   (double (ra/aget xs (+ (* t nb) b))))
+                                                (double dp)))))
+                               a))]
+                   (ra/aset y (+ (* t out) o) (float acc)))))

--- a/src/raster/quant/pack.clj
+++ b/src/raster/quant/pack.clj
@@ -9,7 +9,7 @@
     - `quantize-one-q8`  → signed q8_0 int32-packed rows {:wp :ws} read by
       qmatmul-i8-gemm! / i8gemv-dp4a!.
     - `q4k-of`           → the Q4_K dp4a buffer set {:wp :da :db :aq :bq}
-      read by qmatmul-q4k-dp4a!, delegating to the validated CPU packer
+      read by qmatmul-q4k-dp4a-rows!, delegating to the validated CPU packer
       (raster.compiler.backend.cpu.quant/quantize-weight-q4k), zero-padding
       rows to in % 256 == 0 and reinterpreting the nibble bytes as int[].
 
@@ -45,7 +45,7 @@
 (defn q4k-of
   "Quantize a row-major [out,in] f32 weight to the Q4_K dp4a buffer set
   {:wp int[] :da :db floats :aq :bq bytes :in <padded in> :out} — the layout
-  qmatmul-q4k-dp4a! reads. Rows are zero-padded to in % 256 == 0."
+  qmatmul-q4k-dp4a-rows! reads. Rows are zero-padded to in % 256 == 0."
   [^floats W ^long out ^long in]
   (let [inp (nextpad in)
         z (cq/quantize-weight-q4k (padw W out in inp) cq/q4-K)]

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -34,6 +34,14 @@
   (first (:kernels (apply opencl-pass/opencl-pass form
                           (concat [:min-elements 0] opts)))))
 
+(deftest declared-gpu-parameter-types-preserve-the-scalar-array-partition
+  (is (= {:scalar-types {'in :int 'scale :float}
+          :array-types {'packed :int 'metadata :byte 'values :float}}
+         (opencl-pass/derive-param-types
+          '[packed metadata values in scale]
+          '[ints bytes floats long float]
+          :float))))
+
 (deftest generate-segmap-kernel-artifact-simple-test
   (testing "Simple element-wise add with OpenCL syntax"
     (let [form '(raster.par/map! out i n double (+ (aget a i) (aget b i)))
@@ -93,8 +101,8 @@
 (deftest generate-par-map-void-ordered-abi-test
   (testing "multi-write/inout map-void ABI follows the emitted signature and preserves dtypes"
     (let [form '(raster.par/map-void! i n
-                  (do (aset y i (* scale (aget x i)))
-                      (aset state i (+ (aget state i) limit))))
+                                      (do (aset y i (* scale (aget x i)))
+                                          (aset state i (+ (aget state i) limit))))
           k (par-opencl/generate-par-map-void-kernel
              form :dtype :float
              :array-types {'state :int 'x :float 'y :float}
@@ -165,8 +173,8 @@
 (deftest opencl-pass-map-void-marker-follows-abi-test
   (testing "the compatibility marker is projected from the ordered ABI"
     (let [form '(raster.par/map-void! i n
-                  (do (aset y i (* scale (aget x i)))
-                      (aset state i (+ (aget state i) limit))))
+                                      (do (aset y i (* scale (aget x i)))
+                                          (aset state i (+ (aget state i) limit))))
           result (opencl-pass/opencl-pass
                   form :device-id :ze:0 :dtype :float
                   :array-types {'state :int 'x :float 'y :float}

--- a/test/raster/dl/decoder_layer_gpu_test.clj
+++ b/test/raster/dl/decoder_layer_gpu_test.clj
@@ -56,28 +56,28 @@
                       :down [:float H nil :scratch] :down2 [:float H nil :scratch] :out [:float H nil :output]
                       :submax [:float (quot IM 32) nil :scratch]}
                      (wbuf "wq" Wq) (wbuf "wk" Wk) (wbuf "wv" Wv) (wbuf "wo" Wo) (wbuf "wg" Wg) (wbuf "wu" Wu) (wbuf "wd" Wd))
-            qa (fn [ph xb xpb xsb bsb nsb] {:op #'qk/quant-act-q8k-gpu! :phase ph :bind {"x" xb "xp" xpb "xs" xsb "bsums" bsb "submax" :submax} :scalars {} :n (* 8 (long nsb))})
-            mm (fn [ph xpb xsb bsb pre yb in n] {:op #'qk/qmatmul-q4k-dp4a! :phase ph :bind {"xp" xpb "xs" xsb "bsums" bsb "wp" (keyword (str pre "p")) "da" (keyword (str pre "da")) "db" (keyword (str pre "db")) "aq" (keyword (str pre "aq")) "bq" (keyword (str pre "bq")) "y" yb} :scalars {"in" in} :n n})
+            qa (fn [ph xb xpb xsb bsb in nrows] {:op #'qk/quant-act-q8k-rows-gpu! :phase ph :bind {"x" xb "xp" xpb "xs" xsb "bsums" bsb "submax" :submax} :scalars {"in" in} :n (* nrows (quot in 32))})
+            mm (fn [ph xpb xsb bsb pre yb in out nrows] {:op #'qk/qmatmul-q4k-dp4a-rows! :phase ph :bind {"xp" xpb "xs" xsb "bsums" bsb "wp" (keyword (str pre "p")) "da" (keyword (str pre "da")) "db" (keyword (str pre "db")) "aq" (keyword (str pre "aq")) "bq" (keyword (str pre "bq")) "y" yb} :scalars {"in" in "out" out} :n (* nrows out)})
             rms (fn [ph xb wb ob rows feat] {:op #'nn/rms-norm! :phase ph :bind {"x" xb "weight" wb "out" ob} :scalars {"eps" eps "features" feat "gain-offset" 1.0} :n rows})
             radd (fn [ph ab bb ob n] {:op #'nn/residual-add! :phase ph :bind {"a" ab "b" bb "out" ob} :scalars {} :n n})
-            steps [(rms :n1 :x :win :xn 1 H) (qa :qx :xn :qxp :qxs :qxb (quot H 256))
-                   (mm :mq :qxp :qxs :qxb "wq" :Q H (* nq hd)) (mm :mk :qxp :qxs :qxb "wk" :K H kvrow) (mm :mv :qxp :qxs :qxb "wv" :V H kvrow)
+            steps [(rms :n1 :x :win :xn 1 H) (qa :qx :xn :qxp :qxs :qxb H 1)
+                   (mm :mq :qxp :qxs :qxb "wq" :Q H (* nq hd) 1) (mm :mk :qxp :qxs :qxb "wk" :K H kvrow 1) (mm :mv :qxp :qxs :qxb "wv" :V H kvrow 1)
                    (rms :qn :Q :wqn :Qn nq hd) (rms :kn :K :wkn :Kn nkv hd)
                    {:op #'attn/rope-pos-gpu! :phase :rq :bind {"x" :Qn "out" :Qr} :scalars {"head-dim" hd "theta" theta "pos-offset" p} :n nq}
                    {:op #'attn/rope-pos-gpu! :phase :rk :bind {"x" :Kn "out" :Kr} :scalars {"head-dim" hd "theta" theta "pos-offset" p} :n nkv}
                    {:op #'attn/kv-append! :phase :ak :bind {"src" :Kr "cache" :cK} :scalars {"pos" p "kvrow" kvrow} :n kvrow}
                    {:op #'attn/kv-append! :phase :av :bind {"src" :V "cache" :cV} :scalars {"pos" p "kvrow" kvrow} :n kvrow}
                    {:op #'attn/gqa-decode-attention-gpu! :phase :att :bind {"q" :Qr "k" :cK "v" :cV "out" :at "sc" :sc} :scalars {"cache-len" clen "group" grp "head-dim" hd "n-kv" nkv "scale" scale} :n nq}
-                   (qa :qaa :at :axp :axs :axb (quot (* nq hd) 256)) (mm :mo :axp :axs :axb "wo" :O (* nq hd) H)
+                   (qa :qaa :at :axp :axs :axb (* nq hd) 1) (mm :mo :axp :axs :axb "wo" :O (* nq hd) H 1)
                    (rms :npa :O :wpa :O2 1 H) (radd :r1 :x :O2 :x1 H)
-                   (rms :npf :x1 :wpf :x1n 1 H) (qa :qf :x1n :fxp :fxs :fxb (quot H 256))
-                   (mm :mg :fxp :fxs :fxb "wg" :gate H IM) (mm :mu :fxp :fxs :fxb "wu" :up H IM)
+                   (rms :npf :x1 :wpf :x1n 1 H) (qa :qf :x1n :fxp :fxs :fxb H 1)
+                   (mm :mg :fxp :fxs :fxb "wg" :gate H IM 1) (mm :mu :fxp :fxs :fxb "wu" :up H IM 1)
                    {:op #'nn/gelu-mul! :phase :ge :bind {"gate" :gate "up" :up "out" :hh} :scalars {} :n IM}
-                   (qa :qh :hh :hxp :hxs :hxb (quot IM 256)) (mm :md :hxp :hxs :hxb "wd" :down IM H)
+                   (qa :qh :hh :hxp :hxs :hxb IM 1) (mm :md :hxp :hxs :hxb "wd" :down IM H 1)
                    (rms :npff :down :wpff :down2 1 H) (radd :r2 :x1 :down2 :out H)]
             sess (gpu/make-session :ze:0)]
         (try (gpu/chain-program! sess buffers steps)
-          (let [o (get (gpu/run-chain! sess {:x x}) :out)]
-            (is (= 25 (count steps)))
-            (is (< (relerr o Oref) 2e-2) "full decoder layer matches CPU Q4_K reference"))
-          (finally (gpu/close-session! sess)))))))
+             (let [o (get (gpu/run-chain! sess {:x x}) :out)]
+               (is (= 25 (count steps)))
+               (is (< (relerr o Oref) 2e-2) "full decoder layer matches CPU Q4_K reference"))
+             (finally (gpu/close-session! sess)))))))

--- a/test/raster/quant/kernels_k_gpu_test.clj
+++ b/test/raster/quant/kernels_k_gpu_test.clj
@@ -1,8 +1,8 @@
 (ns raster.quant.kernels-k-gpu-test
-  "The SAME composable K-quant GEMV deftms (qmatmul-q{4,6}k-gpu!) compile to OpenCL via the
+  "The composable K-quant GEMV/GEMM deftms compile to OpenCL via the
    shared c_emit and run on the GPU (ze:0), byte-exact with the CPU composable kernel on
    identical quantized inputs. Proves the format registry reaches a working GPU kernel through
-   the work-item-per-row par/map-void! twin — int8 weights + float scales + int bsums in one
+   shared par/map-void! path — int8 weights + float scales + int bsums in one
    mixed-dtype kernel. Skipped when no GPU device is present."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.quant.kernels-k :as qk]
@@ -154,30 +154,6 @@
             (is (every? (fn [o] (= (int (aget yref o)) (int (aget ^floats ygpu o)))) (range out))))
           (finally (gpu/close-session! sess)))))))
 
-(deftest q4k-gpu-matches-cpu
-  (when (gpu-available?)
-    (testing "Q4_K work-item-per-row kernel on ze:0 == CPU composable"
-      (let [out 32 in 256
-            W (gen (* out in) 11) x (gen in 22)
-            {:keys [wq da db aq bq]} (q/quantize-weight-q4k W q/q4-K)
-            {:keys [xq xs bsums]}    (q/quantize-act-q8k x in q/q4-K)
-            ycpu (float-array out)
-            _ (qk/qmatmul-q4k-composable! xq xs bsums wq da db aq bq ycpu in out 0 out)
-            sess (gpu/make-session :ze:0)]
-        (try
-          (gpu/compile! sess :q4k #'qk/qmatmul-q4k-gpu!)
-          (gpu/alloc! sess {:xq [:byte (alength xq) xq] :xs [:float (alength xs) xs]
-                            :bsums [:int (alength bsums) bsums] :wq [:byte (alength wq) wq]
-                            :da [:float (alength da) da] :db [:float (alength db) db]
-                            :aq [:byte (alength aq) aq] :bq [:byte (alength bq) bq]
-                            :y [:float out nil]})
-          (gpu/invoke! sess :q4k
-                       {"xq" :xq "xs" :xs "bsums" :bsums "wq" :wq "da" :da "db" :db
-                        "aq" :aq "bq" :bq "y" :y}
-                       [{:type :int :value in}] out)
-          (is (< (maxerr ycpu (gpu/download sess :y)) 1e-3))
-          (finally (gpu/close-session! sess)))))))
-
 (deftest q4k-dp4a-bound-dispatch
   (when (gpu-available?)
     (testing "prepare!/invoke-bound! (sync) and async prepare!+sync! match invoke! result"
@@ -192,18 +168,18 @@
             scal [{:type :int :value in}]
             sess (gpu/make-session :ze:0)]
         (try
-          (gpu/compile! sess :q4kdp #'qk/qmatmul-q4k-dp4a!)
+          (gpu/compile! sess :q4kdp #'qk/qmatmul-q4k-dp4a-rows!)
           (gpu/alloc! sess {:xp [:int (alength xp) xp] :xs [:float (alength xs) xs]
                             :bsums [:int (alength bsums) bsums] :wp [:int (alength wp) wp]
                             :da [:float (alength da) da] :db [:float (alength db) db]
                             :aq [:byte (alength aq) aq] :bq [:byte (alength bq) bq]
                             :y [:float out nil]})
           ;; synchronous bound dispatch
-          (gpu/prepare! sess :q4kdp sym scal out)
+          (gpu/prepare! sess :q4kdp sym (conj scal {:type :int :value out}) out)
           (gpu/invoke-bound! sess :q4kdp)
           (is (< (maxerr ycpu (gpu/download sess :y)) 1e-3) "sync bound")
           ;; async bound dispatch: zero result, batch-launch, sync, then read
-          (gpu/prepare! sess :q4kdp sym scal out {:async? true})
+          (gpu/prepare! sess :q4kdp sym (conj scal {:type :int :value out}) out {:async? true})
           (dotimes [_ 3] (gpu/invoke-bound! sess :q4kdp))
           (gpu/sync! sess)
           (is (< (maxerr ycpu (gpu/download sess :y)) 1e-3) "async bound + sync!")
@@ -227,13 +203,13 @@
             a (mk 11 22) b (mk 99 88)
             sess (gpu/make-session :ze:0)]
         (try
-          (gpu/compile! sess :mm #'qk/qmatmul-q4k-dp4a!)
+          (gpu/compile! sess :mm #'qk/qmatmul-q4k-dp4a-rows!)
           (gpu/alloc! sess {:axp [:int (alength ^ints (:xp a)) (:xp a)] :axs [:float (alength ^floats (:xs a)) (:xs a)] :abs [:int (alength ^ints (:bsums a)) (:bsums a)]
                             :awp [:int (alength ^ints (:wp a)) (:wp a)] :ada [:float (alength ^floats (:da a)) (:da a)] :adb [:float (alength ^floats (:db a)) (:db a)] :aaq [:byte (alength ^bytes (:aq a)) (:aq a)] :abq [:byte (alength ^bytes (:bq a)) (:bq a)] :ay [:float out nil]
                             :bxp [:int (alength ^ints (:xp b)) (:xp b)] :bxs [:float (alength ^floats (:xs b)) (:xs b)] :bbs [:int (alength ^ints (:bsums b)) (:bsums b)]
                             :bwp [:int (alength ^ints (:wp b)) (:wp b)] :bda [:float (alength ^floats (:da b)) (:da b)] :bdb [:float (alength ^floats (:db b)) (:db b)] :baq [:byte (alength ^bytes (:aq b)) (:aq b)] :bbq [:byte (alength ^bytes (:bq b)) (:bq b)] :by [:float out nil]})
-          (gpu/prepare! sess :a {"xp" :axp "xs" :axs "bsums" :abs "wp" :awp "da" :ada "db" :adb "aq" :aaq "bq" :abq "y" :ay} [{:type :int :value in}] out {:kernel-phase :mm})
-          (gpu/prepare! sess :b {"xp" :bxp "xs" :bxs "bsums" :bbs "wp" :bwp "da" :bda "db" :bdb "aq" :baq "bq" :bbq "y" :by} [{:type :int :value in}] out {:kernel-phase :mm})
+          (gpu/prepare! sess :a {"xp" :axp "xs" :axs "bsums" :abs "wp" :awp "da" :ada "db" :adb "aq" :aaq "bq" :abq "y" :ay} [{:type :int :value in} {:type :int :value out}] out {:kernel-phase :mm})
+          (gpu/prepare! sess :b {"xp" :bxp "xs" :bxs "bsums" :bbs "wp" :bwp "da" :bda "db" :bdb "aq" :baq "bq" :bbq "y" :by} [{:type :int :value in} {:type :int :value out}] out {:kernel-phase :mm})
           (gpu/invoke-bound! sess :a)
           (gpu/invoke-bound! sess :b)
           (is (< (maxerr (:ycpu a) (gpu/download sess :ay)) 1e-3) "binding A correct")
@@ -243,7 +219,8 @@
 (deftest q8k-quant-then-matmul-chain
   (when (gpu-available?)
     (testing "GPU q8_K activation quantizer feeds dp4a matmul, all on-device in one graph"
-      ;; The decode enabler: quantize the float activation ON the GPU (quant-act-q8k-gpu!),
+      ;; The decode enabler: quantize the float activation ON the GPU
+      ;; (quant-act-q8k-rows-gpu!),
       ;; then the matmul consumes xp/xs/bsums with NO host round-trip. Recorded as a 2-op graph
       ;; (barrier enforces quant→matmul order). Result must match the CPU dequant reference.
       (let [out 32 in 256 nsb (quot in 256)
@@ -260,8 +237,8 @@
                    y)
             sess (gpu/make-session :ze:0)]
         (try
-          (gpu/compile! sess :quant #'qk/quant-act-q8k-gpu!)
-          (gpu/compile! sess :mm #'qk/qmatmul-q4k-dp4a!)
+          (gpu/compile! sess :quant #'qk/quant-act-q8k-rows-gpu!)
+          (gpu/compile! sess :mm #'qk/qmatmul-q4k-dp4a-rows!)
           (gpu/alloc! sess {:x [:float in x]
                             :xp [:int (quot in 4) nil] :xs [:float nsb nil] :bsums [:int (quot in 32) nil]
                             :submax [:float (* nsb 8) nil]
@@ -271,14 +248,57 @@
           (gpu/prepare! sess :quant {"x" :x "xp" :xp "xs" :xs "bsums" :bsums "submax" :submax}
                         [] (* nsb 8) {:kernel-phase :quant :index 0})
           (gpu/prepare! sess :quant2 {"x" :x "xp" :xp "xs" :xs "bsums" :bsums "submax" :submax}
-                        [] (* nsb 8) {:kernel-phase :quant :index 1})
+                        [{:type :int :value in}] (* nsb 8) {:kernel-phase :quant :index 1})
           (gpu/prepare! sess :mm {"xp" :xp "xs" :xs "bsums" :bsums "wp" :wp "da" :da "db" :db "aq" :aq "bq" :bq "y" :y}
-                        [{:type :int :value in}] out {:kernel-phase :mm})
+                        [{:type :int :value in} {:type :int :value out}] out {:kernel-phase :mm})
           (gpu/record-graph! sess [:quant :quant2 :mm])
           (gpu/replay! sess)
           (let [ygpu (gpu/download sess :y)
                 scale (reduce max 1e-9 (map (fn [v] (Math/abs (double v))) (seq yref)))]
             (is (< (/ (maxerr yref ygpu) scale) 1e-2) "on-device quant→matmul == CPU dequant ref"))
+          (finally (gpu/close-session! sess)))))))
+
+(deftest q8k-quant-then-q4k-projection-batches-independent-rows
+  (when (gpu-available?)
+    (testing "one generated Q4_K path handles B>1 while sharing the packed weight leaves"
+      (let [nrows 3 out 17 in 512 nsb (quot in 256) nsub (quot in 32)
+            W (gen (* out in) 105) x (gen (* nrows in) 106)
+            {:keys [wq da db aq bq]} (q/quantize-weight-q4k W q/q4-K)
+            wp (bytes->ints-le wq)
+            yref (float-array (* nrows out))
+            _ (dotimes [row nrows]
+                (let [xr (float-array in)
+                      _ (System/arraycopy x (* row in) xr 0 in)
+                      {:keys [xq xs bsums]} (q/quantize-act-q8k xr in q/q4-K)
+                      yr (float-array out)]
+                  (qk/qmatmul-q4k-composable! xq xs bsums wq da db aq bq yr in out 0 out)
+                  (System/arraycopy yr 0 yref (* row out) out)))
+            sess (gpu/make-session :ze:0)]
+        (try
+          (gpu/compile! sess :quant-rows #'qk/quant-act-q8k-rows-gpu!)
+          (gpu/compile! sess :q4k-rows #'qk/qmatmul-q4k-dp4a-rows!)
+          (gpu/alloc! sess {:x [:float (* nrows in) x]
+                            :xp [:int (* nrows (quot in 4)) nil]
+                            :xs [:float (* nrows nsb) nil]
+                            :bsums [:int (* nrows nsub) nil]
+                            :submax [:float (* nrows nsub) nil]
+                            :wp [:int (alength wp) wp]
+                            :da [:float (alength da) da] :db [:float (alength db) db]
+                            :aq [:byte (alength aq) aq] :bq [:byte (alength bq) bq]
+                            :y [:float (* nrows out) nil]})
+          (let [bindings {"x" :x "xp" :xp "xs" :xs "bsums" :bsums "submax" :submax}]
+            (gpu/prepare! sess :quant-rows-max bindings [] (* nrows nsub)
+                          {:kernel-phase :quant-rows :index 0})
+            (gpu/prepare! sess :quant-rows-pack bindings [{:type :int :value in}]
+                          (* nrows nsub) {:kernel-phase :quant-rows :index 1}))
+          (gpu/prepare! sess :q4k-rows
+                        {"xp" :xp "xs" :xs "bsums" :bsums "wp" :wp
+                         "da" :da "db" :db "aq" :aq "bq" :bq "y" :y}
+                        [{:type :int :value in} {:type :int :value out}]
+                        (* nrows out) {:kernel-phase :q4k-rows})
+          (gpu/record-graph! sess [:quant-rows-max :quant-rows-pack :q4k-rows])
+          (gpu/replay! sess)
+          (is (< (maxerr yref (gpu/download sess :y)) 1e-3))
           (finally (gpu/close-session! sess)))))))
 
 (deftest q4k-dp4a-command-graph
@@ -295,11 +315,11 @@
             a (mk 11 22) b (mk 77 88)
             sess (gpu/make-session :ze:0)]
         (try
-          (gpu/compile! sess :mm #'qk/qmatmul-q4k-dp4a!)
+          (gpu/compile! sess :mm #'qk/qmatmul-q4k-dp4a-rows!)
           (gpu/alloc! sess {:axp [:int (alength ^ints (:xp a)) (:xp a)] :axs [:float (alength ^floats (:xs a)) (:xs a)] :abs [:int (alength ^ints (:bsums a)) (:bsums a)] :awp [:int (alength ^ints (:wp a)) (:wp a)] :ada [:float (alength ^floats (:da a)) (:da a)] :adb [:float (alength ^floats (:db a)) (:db a)] :aaq [:byte (alength ^bytes (:aq a)) (:aq a)] :abq [:byte (alength ^bytes (:bq a)) (:bq a)] :ay [:float out nil]
                             :bxp [:int (alength ^ints (:xp b)) (:xp b)] :bxs [:float (alength ^floats (:xs b)) (:xs b)] :bbs [:int (alength ^ints (:bsums b)) (:bsums b)] :bwp [:int (alength ^ints (:wp b)) (:wp b)] :bda [:float (alength ^floats (:da b)) (:da b)] :bdb [:float (alength ^floats (:db b)) (:db b)] :baq [:byte (alength ^bytes (:aq b)) (:aq b)] :bbq [:byte (alength ^bytes (:bq b)) (:bq b)] :by [:float out nil]})
-          (gpu/prepare! sess :a {"xp" :axp "xs" :axs "bsums" :abs "wp" :awp "da" :ada "db" :adb "aq" :aaq "bq" :abq "y" :ay} [{:type :int :value in}] out {:kernel-phase :mm})
-          (gpu/prepare! sess :b {"xp" :bxp "xs" :bxs "bsums" :bbs "wp" :bwp "da" :bda "db" :bdb "aq" :baq "bq" :bbq "y" :by} [{:type :int :value in}] out {:kernel-phase :mm})
+          (gpu/prepare! sess :a {"xp" :axp "xs" :axs "bsums" :abs "wp" :awp "da" :ada "db" :adb "aq" :aaq "bq" :abq "y" :ay} [{:type :int :value in} {:type :int :value out}] out {:kernel-phase :mm})
+          (gpu/prepare! sess :b {"xp" :bxp "xs" :bxs "bsums" :bbs "wp" :bwp "da" :bda "db" :bdb "aq" :baq "bq" :bbq "y" :by} [{:type :int :value in} {:type :int :value out}] out {:kernel-phase :mm})
           (gpu/record-graph! sess [:a :b])
           (gpu/replay! sess)
           (is (< (maxerr (:y a) (gpu/download sess :ay)) 1e-3) "graph op A")
@@ -321,7 +341,7 @@
             wp (bytes->ints-le wq) xp (pack-i8 xq)
             sess (gpu/make-session :ze:0)]
         (try
-          (gpu/compile! sess :q4kdp #'qk/qmatmul-q4k-dp4a!)
+          (gpu/compile! sess :q4kdp #'qk/qmatmul-q4k-dp4a-rows!)
           (gpu/alloc! sess {:xp [:int (alength xp) xp] :xs [:float (alength xs) xs]
                             :bsums [:int (alength bsums) bsums] :wp [:int (alength wp) wp]
                             :da [:float (alength da) da] :db [:float (alength db) db]
@@ -330,7 +350,7 @@
           (gpu/invoke! sess :q4kdp
                        {"xp" :xp "xs" :xs "bsums" :bsums "wp" :wp "da" :da "db" :db
                         "aq" :aq "bq" :bq "y" :y}
-                       [{:type :int :value in}] out)
+                       [{:type :int :value in} {:type :int :value out}] out)
           (is (< (maxerr ycpu (gpu/download sess :y)) 1e-3))
           (finally (gpu/close-session! sess)))))))
 

--- a/test/raster/quant/kernels_k_test.clj
+++ b/test/raster/quant/kernels_k_test.clj
@@ -20,6 +20,18 @@
   (let [a (float-array n) r (java.util.Random. seed)]
     (dotimes [i n] (aset a i (float (- (.nextDouble r) 0.5)))) a))
 
+(defn- bytes->ints-le [^bytes values]
+  (let [result (int-array (quot (alength values) 4))
+        buffer (.order (java.nio.ByteBuffer/wrap values) java.nio.ByteOrder/LITTLE_ENDIAN)]
+    (dotimes [i (alength result)]
+      (aset result i (.getInt buffer (* i 4))))
+    result))
+
+(defn- float-row [^floats values row width]
+  (let [result (float-array width)]
+    (System/arraycopy values (* row width) result 0 width)
+    result))
+
 (defn- ref-matmul [^floats W-dq ^floats x-dq out in]
   (let [y (float-array out)]
     (dotimes [o out]
@@ -32,31 +44,94 @@
     (dotimes [k in] (aset d k (float (* dact (aget ^bytes xq k))))) d))
 
 (deftest q4k-composable-c
- (when (clang-available?)
-  (testing "composable Q4_K GEMV → C matches dequant-matmul"
-    (let [out 8 in 256
-          W (gen (* out in) 1) x (gen in 2)
-          {:keys [wq da db aq bq] :as ew} (q/quantize-weight-q4k W q/q4-K)
-          {:keys [xq xs bsums] :as ea} (q/quantize-act-q8k x in q/q4-K)
-          cfn (pipeline/compile-aot #'qk/qmatmul-q4k-composable! :target :c)
-          y (float-array out)]
-      (cfn xq xs bsums wq da db aq bq y in out 0 out)
-      (let [yref (ref-matmul (q/dequant-q4k ew q/q4-K (* out in)) (dequant-act ea in) out in)]
-        (dotimes [o out]
-          (is (< (Math/abs (- (aget y o) (aget yref o))) 1e-2)
-              (str "Q4_K row " o ": C " (aget y o) " vs ref " (aget yref o)))))))))
+  (when (clang-available?)
+    (testing "composable Q4_K GEMV → C matches dequant-matmul"
+      (let [out 8 in 256
+            W (gen (* out in) 1) x (gen in 2)
+            {:keys [wq da db aq bq] :as ew} (q/quantize-weight-q4k W q/q4-K)
+            {:keys [xq xs bsums] :as ea} (q/quantize-act-q8k x in q/q4-K)
+            cfn (pipeline/compile-aot #'qk/qmatmul-q4k-composable! :target :c)
+            y (float-array out)]
+        (cfn xq xs bsums wq da db aq bq y in out 0 out)
+        (let [yref (ref-matmul (q/dequant-q4k ew q/q4-K (* out in)) (dequant-act ea in) out in)]
+          (dotimes [o out]
+            (is (< (Math/abs (- (aget y o) (aget yref o))) 1e-2)
+                (str "Q4_K row " o ": C " (aget y o) " vs ref " (aget yref o)))))))))
 
 (deftest q6k-composable-c
- (when (clang-available?)
-  (testing "composable Q6_K GEMV → C matches dequant-matmul"
-    (let [out 8 in 256
-          W (gen (* out in) 3) x (gen in 4)
-          {:keys [wq sc ds] :as ew} (q/quantize-weight-q6k W q/q6-K)
-          {:keys [xq xs bsums] :as ea} (q/quantize-act-q8k x in q/q6-K)
-          cfn (pipeline/compile-aot #'qk/qmatmul-q6k-composable! :target :c)
-          y (float-array out)]
-      (cfn xq xs bsums wq sc ds y in out 0 out)
-      (let [yref (ref-matmul (q/dequant-q6k ew q/q6-K (* out in)) (dequant-act ea in) out in)]
+  (when (clang-available?)
+    (testing "composable Q6_K GEMV → C matches dequant-matmul"
+      (let [out 8 in 256
+            W (gen (* out in) 3) x (gen in 4)
+            {:keys [wq sc ds] :as ew} (q/quantize-weight-q6k W q/q6-K)
+            {:keys [xq xs bsums] :as ea} (q/quantize-act-q8k x in q/q6-K)
+            cfn (pipeline/compile-aot #'qk/qmatmul-q6k-composable! :target :c)
+            y (float-array out)]
+        (cfn xq xs bsums wq sc ds y in out 0 out)
+        (let [yref (ref-matmul (q/dequant-q6k ew q/q6-K (* out in)) (dequant-act ea in) out in)]
+          (dotimes [o out]
+            (is (< (Math/abs (- (aget y o) (aget yref o))) 1e-2)
+                (str "Q6_K row " o ": C " (aget y o) " vs ref " (aget yref o)))))))))
+
+(deftest q8k-activation-quantization-has-an-ordinary-row-axis
+  (let [nrows 3 in 512 nsb (quot in 256) nsub (quot in 32)
+        x (gen (* nrows in) 71)
+        xp (int-array (* nrows (quot in 4)))
+        xs (float-array (* nrows nsb))
+        bsums (int-array (* nrows nsub))
+        submax (float-array (* nrows nsub))]
+    (qk/quant-act-q8k-rows-gpu! x xp xs bsums submax in nrows)
+    (dotimes [row nrows]
+      (let [{expected-xq :xq expected-xs :xs expected-bsums :bsums}
+            (q/quantize-act-q8k (float-row x row in) in q/q4-K)
+            expected-xp (bytes->ints-le expected-xq)]
+        (is (= (vec expected-xp)
+               (subvec (vec xp) (* row (quot in 4)) (* (inc row) (quot in 4))))
+            (str "packed activation row " row))
+        (is (= (vec expected-xs)
+               (subvec (vec xs) (* row nsb) (* (inc row) nsb)))
+            (str "activation scales row " row))
+        (is (= (vec expected-bsums)
+               (subvec (vec bsums) (* row nsub) (* (inc row) nsub)))
+            (str "activation block sums row " row))))))
+
+(deftest q4k-projection-shares-weights-across-activation-rows
+  (let [nrows 3 in 512 out 11
+        x (gen (* nrows in) 81)
+        W (gen (* out in) 82)
+        {:keys [wq da db aq bq]} (q/quantize-weight-q4k W q/q4-K)
+        wp (bytes->ints-le wq)
+        xp (int-array (* nrows (quot in 4)))
+        xs (float-array (* nrows (quot in 256)))
+        bsums (int-array (* nrows (quot in 32)))
+        submax (float-array (* nrows (quot in 32)))
+        actual (float-array (* nrows out))]
+    (qk/quant-act-q8k-rows-gpu! x xp xs bsums submax in nrows)
+    (qk/qmatmul-q4k-dp4a-rows! xp xs bsums wp da db aq bq actual in out nrows)
+    (dotimes [row nrows]
+      (let [{:keys [xq xs bsums]} (q/quantize-act-q8k (float-row x row in) in q/q4-K)
+            expected (float-array out)]
+        (qk/qmatmul-q4k-composable! xq xs bsums wq da db aq bq expected in out 0 out)
         (dotimes [o out]
-          (is (< (Math/abs (- (aget y o) (aget yref o))) 1e-2)
-              (str "Q6_K row " o ": C " (aget y o) " vs ref " (aget yref o)))))))))
+          (is (< (Math/abs (- (aget actual (+ (* row out) o)) (aget expected o))) 1e-3)
+              (str "Q4_K row " row ", output " o)))))))
+
+(deftest row-capable-q4k-path-lowers-through-the-shared-gpu-pipeline
+  (let [quant-kernels (:kernels (pipeline/show-pipeline #'qk/quant-act-q8k-rows-gpu!
+                                                        :target-device :ze:0 :dtype :float))
+        projection-kernels (:kernels (pipeline/show-pipeline #'qk/qmatmul-q4k-dp4a-rows!
+                                                             :target-device :ze:0 :dtype :float))]
+    (is (= 2 (count quant-kernels)) "Q8_K remains an ordered two-phase reduction")
+    (is (= '[[[submax :float] [x :float] [_n_bound :int]]
+             [[bsums :int] [submax :float] [x :float] [xp :int]
+              [xs :float] [in :int] [_n_bound :int]]]
+           (mapv #(mapv (juxt :name :dtype) (:abi %)) quant-kernels)))
+    (is (= 1 (count projection-kernels)))
+    (is (= '[[aq :byte] [bq :byte] [bsums :int] [da :float] [db :float]
+             [wp :int] [xp :int] [xs :float] [y :float]
+             [in :int] [out :int] [_n_bound :int]]
+           (mapv (juxt :name :dtype) (:abi (first projection-kernels)))))
+    (is (re-find #"rstr_dp4a" (:source (first projection-kernels)))
+        "Q4_K row projection reaches the target-neutral integer-dot intrinsic")
+    (is (not (re-find #"\\bdouble\\b" (:source (first projection-kernels))))
+        "the float projection does not accidentally promote accumulation to FP64")))


### PR DESCRIPTION
## Summary

- replace the separate B=1 Q8_K activation and Q4_K projection contracts with row-capable compiler-generated kernels
- keep packed Q4_K weights shared while row-offsetting activation leaves, block metadata, and outputs
- retain one target-neutral dp4a intrinsic path for native and portable lowering; remove the redundant scalar nibble-loop GPU kernel
- propagate declared parameter types and source namespace through show-pipeline so diagnostic emission agrees with executable compilation
- preserve packed Q8 words across the JVM and accelerator backends by expressing bit packing as binary IR operations

## ABI migration

- quant-act-q8k-gpu! becomes quant-act-q8k-rows-gpu! with logical arguments in and nrows
- qmatmul-q4k-dp4a! becomes qmatmul-q4k-dp4a-rows! with logical arguments in, out, and nrows
- nrows determines launch geometry and is specialized out of the emitted physical ABI; launch bounds are nrows times in/32 and nrows times out

## Verification

- 63 focused compiler, extraction, quantization, GPU graph, and decoder tests; 259 assertions; zero failures/errors
- exact multi-row Q8_K parity and multi-row Q4_K projection parity against independent per-row references
- emitted ABI/source assertions for byte metadata, integer dimensions, dp4a lowering, and FP32-only projection code
- local Level Zero initialization is unavailable, so the real-device paths took their explicit probe-error skip; a B=3 device graph regression is included for GPU CI/hardware runs
- cljfmt and git diff whitespace checks pass