### PR TITLE
Unify buffered RoPE across decode rows

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -143,6 +143,13 @@ these projection, post-attention and head programs from the scheduled contractio
 than treating the Q4_K source kernel as the final abstraction; batching is not a linker convention
 or an attention special case.
 
+Buffered RoPE follows the same rule: one kernel consumes row-major `[B,heads,head-dim]` values and
+the routed attention `int positions[B]` buffer, so B=1 and B>1 neither select different kernels nor
+upload duplicate position representations. Dense semantic rows whose logical width differs from a
+quantized contraction's padded width still need an explicit layout transform. The preferred first
+implementation is a generated padded-row quantization adapter that synthesizes zeroes while packing,
+avoiding a materialized padding buffer; padding is layout, not quantization-specific memory ownership.
+
 Artifact linking and value rebinding are not runtime conveniences. They are
 compiler primitives required for competitive model execution.
 

--- a/src/raster/dl/attention.clj
+++ b/src/raster/dl/attention.clj
@@ -383,30 +383,6 @@
                                                           a))))))
                                           0)))
 
-;; Decode RoPE (single token), par/map-void! over heads — the same NeoX/HF rotate-half as
-;; rope-pos with seq-len=1 (each head rotates its head-dim/2 pairs at absolute position
-;; pos-offset). Lowers to OpenCL and SIMD-vectorizes on CPU. Index math clojure.core; trig
-;; via raster.math. out is caller-provided (in-place-safe: reads x, writes out).
-(deftm rope-pos-gpu! (All [T] [x :- (Array T) out :- (Array T)
-                               heads :- Long head-dim :- Long
-                               theta :- Double pos-offset :- Long] :- Void
-                          (raster.par/map-void! h heads
-                                                (let [hdim2 (quot head-dim 2)
-                                                      base (clojure.core/* h head-dim)
-                                                      ln-theta (m/log theta)
-                                                      pos (double pos-offset)]
-                                                  (loop [i 0]
-                                                    (if (< i hdim2)
-                                                      (let [freq (m/exp (* (/ (* -2.0 (double i)) (double head-dim)) ln-theta))
-                                                            ang (* pos freq)
-                                                            c (m/cos ang) s (m/sin ang)
-                                                            x0 (aget x (clojure.core/+ base i))
-                                                            x1 (aget x (clojure.core/+ (clojure.core/+ base i) hdim2))]
-                                                        (aset out (clojure.core/+ base i) (- (* x0 c) (* x1 s)))
-                                                        (aset out (clojure.core/+ (clojure.core/+ base i) hdim2) (+ (* x1 c) (* x0 s)))
-                                                        (recur (inc i)))
-                                                      nil))))))
-
 ;; KV-cache append (decode): write the current token's K (or V) slab of length kvrow = n_kv*head_dim
 ;; into the cache at absolute position `pos` (offset pos*kvrow). par/map-void! over kvrow — the
 ;; on-device equivalent of the CPU System/arraycopy append. Index math clojure.core (integer).
@@ -470,32 +446,36 @@
                                                                       (recur (inc d)))
                                                                   nil))))))
 
-;; ── Device-side-pos decode variants (#32): pos / cache_len come from 1-element DEVICE
-;; buffers read INSIDE the par body (so each is a kernel array param, not a host scalar baked at
-;; prepare!). The resident graph then binds ONCE and per token the host just writes posbuf/clenbuf
-;; + replays — no re-prepare / re-record. Reading the buffer inside the kernel (vs passing
-;; (aget posbuf 0) as a scalar arg) avoids the CSE-hoist that would otherwise pull the read out to
-;; a host-evaluated scalar-let.
-;; Flattened over heads×(head-dim/2) so the grid is heads*hdim2 work-items (one rotation each)
-;; instead of `heads` threads each looping hdim2 serially — the n=4 serial version wasted ~98% of
-;; the GPU (low occupancy is the dominant decode cost, NOT dispatch ~2µs nor kernel count).
-(deftm rope-pos-buf! (All [T] [x :- (Array T) out :- (Array T)
-                               heads :- Long head-dim :- Long
-                               theta :- Double posbuf :- (Array long)] :- Void
-                          (raster.par/map-void! idx (clojure.core/* heads (quot head-dim 2))
-                                                (let [hdim2 (quot head-dim 2)
-                                                      h (quot idx hdim2)
-                                                      i (rem idx hdim2)
-                                                      base (clojure.core/* h head-dim)
-                                                      ln-theta (m/log theta)
-                                                      pos (double (aget posbuf 0))
-                                                      freq (m/exp (* (/ (* -2.0 (double i)) (double head-dim)) ln-theta))
-                                                      ang (* pos freq)
-                                                      c (m/cos ang) s (m/sin ang)
-                                                      x0 (aget x (clojure.core/+ base i))
-                                                      x1 (aget x (clojure.core/+ (clojure.core/+ base i) hdim2))]
-                                                  (aset out (clojure.core/+ base i) (- (* x0 c) (* x1 s)))
-                                                  (aset out (clojure.core/+ (clojure.core/+ base i) hdim2) (+ (* x1 c) (* x0 s)))))))
+;; ── Device-side-position decode RoPE (#32) ──
+;; x/out are row-major [nrows,heads,head-dim], while positions is one device-resident absolute
+;; position per row. The graph therefore binds once and updates positions between replays without
+;; host scalar rebinding. Flattening every rotary pair across rows keeps batch an ordinary launch
+;; axis and exposes enough work for the GPU even at small head counts.
+(deftm rope-pos-rows-buf!
+  "NeoX/HF rotate-half RoPE over row-major `[nrows,heads,head-dim]` values. `positions[row]`
+  selects each row's absolute position; x and out may alias because each work-item reads its pair
+  before writing either element."
+  (All [T] [x :- (Array T) out :- (Array T)
+            nrows :- Long heads :- Long head-dim :- Long
+            theta :- Double positions :- (Array int)] :- Void
+       (raster.par/map-void! idx (clojure.core/* nrows (clojure.core/* heads (quot head-dim 2)))
+                             (let [hdim2 (quot head-dim 2)
+                                   row-pairs (clojure.core/* heads hdim2)
+                                   row (quot idx row-pairs)
+                                   within-row (rem idx row-pairs)
+                                   h (quot within-row hdim2)
+                                   i (rem within-row hdim2)
+                                   base (clojure.core/+ (clojure.core/* row (clojure.core/* heads head-dim))
+                                                        (clojure.core/* h head-dim))
+                                   ln-theta (m/log theta)
+                                   pos (double (aget positions row))
+                                   freq (m/exp (* (/ (* -2.0 (double i)) (double head-dim)) ln-theta))
+                                   ang (* pos freq)
+                                   c (m/cos ang) s (m/sin ang)
+                                   x0 (aget x (clojure.core/+ base i))
+                                   x1 (aget x (clojure.core/+ (clojure.core/+ base i) hdim2))]
+                               (aset out (clojure.core/+ base i) (- (* x0 c) (* x1 s)))
+                               (aset out (clojure.core/+ (clojure.core/+ base i) hdim2) (+ (* x1 c) (* x0 s)))))))
 
 (deftm kv-append-buf! (All [T] [src :- (Array T) cache :- (Array T) kvrow :- Long posbuf :- (Array long)] :- Void
                            (raster.par/map-void! i kvrow

--- a/test/raster/dl/attention_test.clj
+++ b/test/raster/dl/attention_test.clj
@@ -287,6 +287,28 @@
                          (* (double (aget got i1)) (aget got i1)))]
             (is (< (Math/abs (- n-in n-out)) 1e-4) (str "pair " p))))))))
 
+(deftest rope-pos-rows-buffered-test
+  (let [nrows 3 heads 2 head-dim 8 theta 10000.0
+        positions (int-array [0 7 31])
+        x (float-array (map #(float (/ (- % 17) 13.0))
+                            (range (* nrows heads head-dim))))
+        out (float-array (alength x))]
+    (attn/rope-pos-rows-buf! x out nrows heads head-dim theta positions)
+    (dotimes [row nrows]
+      (let [offset (* row heads head-dim)
+            input-row (float-array (* heads head-dim))]
+        (System/arraycopy x offset input-row 0 (alength input-row))
+        (let [expected (attn/rope-pos input-row 1 heads head-dim theta (aget positions row))]
+          (dotimes [i (alength input-row)]
+            (is (< (Math/abs (- (double (aget ^floats expected i))
+                                (double (aget out (+ offset i)))))
+                   1.0e-5)
+                (str "row " row ", element " i))))))
+    (let [in-place (aclone x)]
+      (attn/rope-pos-rows-buf! in-place in-place nrows heads head-dim theta positions)
+      (is (java.util.Arrays/equals out ^floats in-place)
+          "each work-item reads its pair before an in-place write"))))
+
 ;; ================================================================
 ;; Decode attention with weight capture (timestamp alignment signal)
 ;; ================================================================

--- a/test/raster/dl/decoder_layer_gpu_test.clj
+++ b/test/raster/dl/decoder_layer_gpu_test.clj
@@ -54,6 +54,7 @@
                       :gate [:float IM nil :scratch] :up [:float IM nil :scratch] :hh [:float IM nil :scratch]
                       :hxp [:int (quot IM 4) nil :scratch] :hxs [:float (quot IM 256) nil :scratch] :hxb [:int (quot IM 32) nil :scratch]
                       :down [:float H nil :scratch] :down2 [:float H nil :scratch] :out [:float H nil :output]
+                      :positions [:int 1 (int-array [p]) :input]
                       :submax [:float (quot IM 32) nil :scratch]}
                      (wbuf "wq" Wq) (wbuf "wk" Wk) (wbuf "wv" Wv) (wbuf "wo" Wo) (wbuf "wg" Wg) (wbuf "wu" Wu) (wbuf "wd" Wd))
             qa (fn [ph xb xpb xsb bsb in nrows] {:op #'qk/quant-act-q8k-rows-gpu! :phase ph :bind {"x" xb "xp" xpb "xs" xsb "bsums" bsb "submax" :submax} :scalars {"in" in} :n (* nrows (quot in 32))})
@@ -63,8 +64,8 @@
             steps [(rms :n1 :x :win :xn 1 H) (qa :qx :xn :qxp :qxs :qxb H 1)
                    (mm :mq :qxp :qxs :qxb "wq" :Q H (* nq hd) 1) (mm :mk :qxp :qxs :qxb "wk" :K H kvrow 1) (mm :mv :qxp :qxs :qxb "wv" :V H kvrow 1)
                    (rms :qn :Q :wqn :Qn nq hd) (rms :kn :K :wkn :Kn nkv hd)
-                   {:op #'attn/rope-pos-gpu! :phase :rq :bind {"x" :Qn "out" :Qr} :scalars {"head-dim" hd "theta" theta "pos-offset" p} :n nq}
-                   {:op #'attn/rope-pos-gpu! :phase :rk :bind {"x" :Kn "out" :Kr} :scalars {"head-dim" hd "theta" theta "pos-offset" p} :n nkv}
+                   {:op #'attn/rope-pos-rows-buf! :phase :rq :bind {"x" :Qn "out" :Qr "positions" :positions} :scalars {"head-dim" hd "heads" nq "theta" theta} :n (* nq (quot hd 2))}
+                   {:op #'attn/rope-pos-rows-buf! :phase :rk :bind {"x" :Kn "out" :Kr "positions" :positions} :scalars {"head-dim" hd "heads" nkv "theta" theta} :n (* nkv (quot hd 2))}
                    {:op #'attn/kv-append! :phase :ak :bind {"src" :Kr "cache" :cK} :scalars {"pos" p "kvrow" kvrow} :n kvrow}
                    {:op #'attn/kv-append! :phase :av :bind {"src" :V "cache" :cV} :scalars {"pos" p "kvrow" kvrow} :n kvrow}
                    {:op #'attn/gqa-decode-attention-gpu! :phase :att :bind {"q" :Qr "k" :cK "v" :cV "out" :at "sc" :sc} :scalars {"cache-len" clen "group" grp "head-dim" hd "n-kv" nkv "scale" scale} :n nq}

--- a/test/raster/quant/kernels_k_gpu_test.clj
+++ b/test/raster/quant/kernels_k_gpu_test.clj
@@ -9,6 +9,7 @@
             [raster.dl.nn :as nn]
             [raster.dl.attention :as attn]
             [raster.compiler.backend.cpu.quant :as q]
+            [raster.compiler.pipeline :as pipeline]
             [raster.par :as par]
             [raster.gpu.core :as gpu]))
 
@@ -87,20 +88,34 @@
           (is (< (maxerr ra-ref (gpu/download sess :rao)) 1e-5) "residual-add")
           (finally (gpu/close-session! sess)))))))
 
-(deftest rope-pos-gpu-lowers
+(deftest rope-pos-rows-buffered-lowers
+  (let [kernels (:kernels (pipeline/show-pipeline #'attn/rope-pos-rows-buf!
+                                                  :target-device :ze:0 :dtype :float))]
+    (is (= 1 (count kernels)))
+    (is (= '[[out :float] [positions :int] [x :float]
+             [head-dim :int] [heads :int] [theta :float] [_n_bound :int]]
+           (mapv (juxt :name :dtype) (:abi (first kernels))))
+        "row count shapes the launch but is specialized out of the physical ABI"))
   (when (gpu-available?)
-    (testing "decode RoPE (rope-pos-gpu!, par over heads) lowers to OpenCL == CPU rope-pos"
-      (let [heads 8 hd 64 theta 10000.0 pos 5 n (* heads hd)
+    (testing "buffered RoPE lowers one independent position per row"
+      (let [nrows 3 heads 8 hd 64 theta 10000.0 positions (int-array [0 5 29])
+            row-width (* heads hd) n (* nrows row-width)
             x (gen n 1)
-            ycpu (attn/rope-pos x 1 heads hd theta pos)
+            ycpu (float-array n)
+            _ (dotimes [row nrows]
+                (let [xr (float-array row-width)]
+                  (System/arraycopy x (* row row-width) xr 0 row-width)
+                  (System/arraycopy (attn/rope-pos xr 1 heads hd theta (aget positions row))
+                                    0 ycpu (* row row-width) row-width)))
             sess (gpu/make-session :ze:0)]
         (try
-          (gpu/compile! sess :rope #'attn/rope-pos-gpu!)
-          (gpu/alloc! sess {:x [:float n x] :out [:float n nil]})
-          ;; scalars by name: head-dim pos-offset theta ; par bound = heads
-          (gpu/prepare! sess :rope {"x" :x "out" :out}
-                        [{:type :int :value hd} {:type :int :value pos} {:type :float :value theta}]
-                        heads {:kernel-phase :rope})
+          (gpu/compile! sess :rope #'attn/rope-pos-rows-buf!)
+          (gpu/alloc! sess {:x [:float n x] :out [:float n nil]
+                            :positions [:int nrows positions]})
+          ;; scalars by name: head-dim heads theta; nrows is represented in the launch bound.
+          (gpu/prepare! sess :rope {"x" :x "out" :out "positions" :positions}
+                        [{:type :int :value hd} {:type :int :value heads} {:type :float :value theta}]
+                        (* nrows heads (quot hd 2)) {:kernel-phase :rope})
           (gpu/invoke-bound! sess :rope)
           (is (< (maxerr ycpu (gpu/download sess :out)) 1e-4))
           (finally (gpu/close-session! sess)))))))


### PR DESCRIPTION
## Summary

- replace the separate scalar-position and B=1 buffered RoPE GPU entry points with one row-capable compiler-generated kernel
- consume row-major B by heads by head-dim values and the routed-attention int positions[B] buffer
- flatten rotary pairs across rows and heads so B=1 and B>1 share one high-occupancy launch contract
- remove the legacy rope-pos-gpu! and rope-pos-buf! Vars rather than preserving parallel ABIs
- record the padded semantic-row constraint and zero-synthesizing quantization-adapter direction in the compiler north-star

## ABI migration

- rope-pos-buf! x out heads head-dim theta long-posbuf becomes rope-pos-rows-buf! x out nrows heads head-dim theta int-positions
- rope-pos-gpu! callers use the same replacement with a one-element int position buffer
- nrows shapes the launch and is specialized out of the physical kernel ABI; launch bound is nrows times heads times head-dim/2

## Verification

- 76 focused compiler extraction, attention IR/lowering, RoPE, quant GPU graph, and decoder graph tests; 812 assertions; zero failures/errors
- pure B=3 parity against independent rope-pos rows with distinct positions
- exact in-place versus out-of-place parity
- emitted ABI assertion proves int positions, integer shape scalars, and one generated kernel
- real B=3 GPU execution regression is included; local Level Zero initialization is unavailable, so device bodies took their explicit probe-error skip
- cljfmt and git diff whitespace checks pass