### PR TITLE
Fuse dense row padding into Q8_K packing

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -146,9 +146,10 @@ or an attention special case.
 Buffered RoPE follows the same rule: one kernel consumes row-major `[B,heads,head-dim]` values and
 the routed attention `int positions[B]` buffer, so B=1 and B>1 neither select different kernels nor
 upload duplicate position representations. Dense semantic rows whose logical width differs from a
-quantized contraction's padded width still need an explicit layout transform. The preferred first
-implementation is a generated padded-row quantization adapter that synthesizes zeroes while packing,
-avoiding a materialized padding buffer; padding is layout, not quantization-specific memory ownership.
+quantized contraction's padded width use a generated padded-row quantization adapter. It synthesizes
+zeroes while packing and therefore avoids a materialized padding buffer; the branch-free equal-width
+kernel remains available for already padded layouts. Padding is layout, not quantization-specific
+memory ownership.
 
 Artifact linking and value rebinding are not runtime conveniences. They are
 compiler primitives required for competitive model execution.

--- a/src/raster/quant/kernels_k.clj
+++ b/src/raster/quant/kernels_k.clj
@@ -143,6 +143,71 @@
                                   s))]
                        (ra/aset bsums sidx (int bs)))))))
 
+(deftm quant-act-q8k-padded-rows-gpu!
+  "Quantize dense row-major `[nrows,width]` activations into Q8_K leaves laid out at
+  `padded-in`. Elements in `[width,padded-in)` are synthesized as zero while packing, so callers
+  do not allocate or copy a padded activation tensor. `padded-in` must be a multiple of 256 and
+  at least `width`."
+  [x :- (Array float), xp :- (Array int), xs :- (Array float), bsums :- (Array int),
+   submax :- (Array float), width :- Long, padded-in :- Long, nrows :- Long] :- Void
+  (do
+    (par/map-void! si (* (long nrows) (quot (long padded-in) 32))
+                   (let [nsub (quot (long padded-in) 32)
+                         row (quot si nsub)
+                         row-sub (rem si nsub)
+                         col-base (* row-sub 32)
+                         xbase (* row (long width))
+                         m (loop [k 0 m 0.0]
+                             (if (< k 32)
+                               (let [col (+ col-base k)]
+                                 (if (< col (long width))
+                                   (let [v (ra/aget x (+ xbase col))]
+                                     (recur (inc k) (max m (max v (- v)))))
+                                   (recur (inc k) m)))
+                               m))]
+                     (ra/aset submax si (float m))))
+    (par/map-void! sj (* (long nrows) (quot (long padded-in) 32))
+                   (let [nsb (quot (long padded-in) 256)
+                         nsub (quot (long padded-in) 32)
+                         row (quot sj nsub)
+                         row-sub (rem sj nsub)
+                         sb (quot row-sub 8)
+                         j (rem row-sub 8)
+                         mx (loop [k 0 m 0.0]
+                              (if (< k 8)
+                                (recur (inc k) (max m (ra/aget submax (+ (* row nsub) (* sb 8) k))))
+                                m))
+                         d (/ (double mx) 127.0)
+                         id (if (> (double d) 0.0) (/ 1.0 (double d)) 0.0)
+                         sidx (+ (* row nsub) (* sb 8) j)
+                         wbase (+ (* row (quot (long padded-in) 4)) (* sb 64) (* j 8))
+                         col-base (+ (* sb 256) (* j 32))
+                         xbase (* row (long width))]
+                     (ra/aset xs (+ (* row nsb) sb) (float d))
+                     (let [bs (loop [w 0 s 0]
+                                (if (< w 8)
+                                  (let [col (+ col-base (* w 4))
+                                        q0 (if (< col (long width))
+                                             (long (Math/round (* (double (ra/aget x (+ xbase col))) id)))
+                                             0)
+                                        q1 (if (< (+ col 1) (long width))
+                                             (long (Math/round (* (double (ra/aget x (+ xbase col 1))) id)))
+                                             0)
+                                        q2 (if (< (+ col 2) (long width))
+                                             (long (Math/round (* (double (ra/aget x (+ xbase col 2))) id)))
+                                             0)
+                                        q3 (if (< (+ col 3) (long width))
+                                             (long (Math/round (* (double (ra/aget x (+ xbase col 3))) id)))
+                                             0)
+                                        word (bit-or (bit-or (bit-and q0 0xFF)
+                                                             (bit-shift-left (bit-and q1 0xFF) 8))
+                                                     (bit-or (bit-shift-left (bit-and q2 0xFF) 16)
+                                                             (bit-shift-left (bit-and q3 0xFF) 24)))]
+                                    (ra/aset xp (+ wbase w) (int word))
+                                    (recur (inc w) (+ s q0 q1 q2 q3)))
+                                  s))]
+                       (ra/aset bsums sidx (int bs)))))))
+
 ;; ---- dp4a int8-GEMV core (the format-agnostic hardware-accelerated path) ----
 ;; int8×int8 GEMV over int32-packed lanes: y[o] = Σ_w dp4a(wp[o*kw+w], xp[w]). par/dp4a
 ;; lowers to the portable rstr_dp4a helper which the OpenCL/C compiler pattern-matches to

--- a/test/raster/quant/kernels_k_gpu_test.clj
+++ b/test/raster/quant/kernels_k_gpu_test.clj
@@ -275,24 +275,24 @@
 
 (deftest q8k-quant-then-q4k-projection-batches-independent-rows
   (when (gpu-available?)
-    (testing "one generated Q4_K path handles B>1 while sharing the packed weight leaves"
-      (let [nrows 3 out 17 in 512 nsb (quot in 256) nsub (quot in 32)
-            W (gen (* out in) 105) x (gen (* nrows in) 106)
+    (testing "dense B>1 rows synthesize layout padding while sharing the packed weight leaves"
+      (let [nrows 3 out 17 width 640 in 768 nsb (quot in 256) nsub (quot in 32)
+            W (gen (* out in) 105) x (gen (* nrows width) 106)
             {:keys [wq da db aq bq]} (q/quantize-weight-q4k W q/q4-K)
             wp (bytes->ints-le wq)
             yref (float-array (* nrows out))
             _ (dotimes [row nrows]
                 (let [xr (float-array in)
-                      _ (System/arraycopy x (* row in) xr 0 in)
+                      _ (System/arraycopy x (* row width) xr 0 width)
                       {:keys [xq xs bsums]} (q/quantize-act-q8k xr in q/q4-K)
                       yr (float-array out)]
                   (qk/qmatmul-q4k-composable! xq xs bsums wq da db aq bq yr in out 0 out)
                   (System/arraycopy yr 0 yref (* row out) out)))
             sess (gpu/make-session :ze:0)]
         (try
-          (gpu/compile! sess :quant-rows #'qk/quant-act-q8k-rows-gpu!)
+          (gpu/compile! sess :quant-rows #'qk/quant-act-q8k-padded-rows-gpu!)
           (gpu/compile! sess :q4k-rows #'qk/qmatmul-q4k-dp4a-rows!)
-          (gpu/alloc! sess {:x [:float (* nrows in) x]
+          (gpu/alloc! sess {:x [:float (* nrows width) x]
                             :xp [:int (* nrows (quot in 4)) nil]
                             :xs [:float (* nrows nsb) nil]
                             :bsums [:int (* nrows nsub) nil]
@@ -302,9 +302,11 @@
                             :aq [:byte (alength aq) aq] :bq [:byte (alength bq) bq]
                             :y [:float (* nrows out) nil]})
           (let [bindings {"x" :x "xp" :xp "xs" :xs "bsums" :bsums "submax" :submax}]
-            (gpu/prepare! sess :quant-rows-max bindings [] (* nrows nsub)
+            (gpu/prepare! sess :quant-rows-max bindings
+                          [{:type :int :value in} {:type :int :value width}] (* nrows nsub)
                           {:kernel-phase :quant-rows :index 0})
-            (gpu/prepare! sess :quant-rows-pack bindings [{:type :int :value in}]
+            (gpu/prepare! sess :quant-rows-pack bindings
+                          [{:type :int :value in} {:type :int :value width}]
                           (* nrows nsub) {:kernel-phase :quant-rows :index 1}))
           (gpu/prepare! sess :q4k-rows
                         {"xp" :xp "xs" :xs "bsums" :bsums "wp" :wp

--- a/test/raster/quant/kernels_k_test.clj
+++ b/test/raster/quant/kernels_k_test.clj
@@ -32,6 +32,12 @@
     (System/arraycopy values (* row width) result 0 width)
     result))
 
+(defn- pad-rows [^floats values nrows width padded-width]
+  (let [result (float-array (* nrows padded-width))]
+    (dotimes [row nrows]
+      (System/arraycopy values (* row width) result (* row padded-width) width))
+    result))
+
 (defn- ref-matmul [^floats W-dq ^floats x-dq out in]
   (let [y (float-array out)]
     (dotimes [o out]
@@ -95,6 +101,37 @@
                (subvec (vec bsums) (* row nsub) (* (inc row) nsub)))
             (str "activation block sums row " row))))))
 
+(deftest q8k-padded-row-quantization-does-not-materialize-layout-padding
+  (let [nrows 3 width 640 padded-in 768
+        nsub (quot padded-in 32) nsb (quot padded-in 256)
+        dense (gen (* nrows width) 73)
+        padded (pad-rows dense nrows width padded-in)
+        expected-xp (int-array (* nrows (quot padded-in 4)))
+        expected-xs (float-array (* nrows nsb))
+        expected-bsums (int-array (* nrows nsub))
+        expected-submax (float-array (* nrows nsub))
+        actual-xp (int-array (alength expected-xp))
+        actual-xs (float-array (alength expected-xs))
+        actual-bsums (int-array (alength expected-bsums))
+        actual-submax (float-array (alength expected-submax))]
+    (qk/quant-act-q8k-rows-gpu! padded expected-xp expected-xs expected-bsums expected-submax
+                                padded-in nrows)
+    (qk/quant-act-q8k-padded-rows-gpu! dense actual-xp actual-xs actual-bsums actual-submax
+                                       width padded-in nrows)
+    (is (= (vec expected-xp) (vec actual-xp)) "packed words equal explicit zero padding")
+    (is (= (vec expected-xs) (vec actual-xs)) "super-block scales equal explicit zero padding")
+    (is (= (vec expected-bsums) (vec actual-bsums)) "sub-block sums equal explicit zero padding")
+    (is (= (vec expected-submax) (vec actual-submax)) "reduction scratch preserves row boundaries")
+    (let [equal-xp (int-array (alength expected-xp))
+          equal-xs (float-array (alength expected-xs))
+          equal-bsums (int-array (alength expected-bsums))
+          equal-submax (float-array (alength expected-submax))]
+      (qk/quant-act-q8k-padded-rows-gpu! padded equal-xp equal-xs equal-bsums equal-submax
+                                         padded-in padded-in nrows)
+      (is (= (vec expected-xp) (vec equal-xp)) "equal-width adapter agrees with branch-free packing")
+      (is (= (vec expected-xs) (vec equal-xs)) "equal-width adapter agrees on scales")
+      (is (= (vec expected-bsums) (vec equal-bsums)) "equal-width adapter agrees on sums"))))
+
 (deftest q4k-projection-shares-weights-across-activation-rows
   (let [nrows 3 in 512 out 11
         x (gen (* nrows in) 81)
@@ -119,6 +156,8 @@
 (deftest row-capable-q4k-path-lowers-through-the-shared-gpu-pipeline
   (let [quant-kernels (:kernels (pipeline/show-pipeline #'qk/quant-act-q8k-rows-gpu!
                                                         :target-device :ze:0 :dtype :float))
+        padded-kernels (:kernels (pipeline/show-pipeline #'qk/quant-act-q8k-padded-rows-gpu!
+                                                         :target-device :ze:0 :dtype :float))
         projection-kernels (:kernels (pipeline/show-pipeline #'qk/qmatmul-q4k-dp4a-rows!
                                                              :target-device :ze:0 :dtype :float))]
     (is (= 2 (count quant-kernels)) "Q8_K remains an ordered two-phase reduction")
@@ -126,6 +165,13 @@
              [[bsums :int] [submax :float] [x :float] [xp :int]
               [xs :float] [in :int] [_n_bound :int]]]
            (mapv #(mapv (juxt :name :dtype) (:abi %)) quant-kernels)))
+    (is (= '[[[submax :float] [x :float] [padded-in :int] [width :int] [_n_bound :int]]
+             [[bsums :int] [submax :float] [x :float] [xp :int] [xs :float]
+              [padded-in :int] [width :int] [_n_bound :int]]]
+           (mapv #(mapv (juxt :name :dtype) (:abi %)) padded-kernels))
+        "the adapter changes layout indexing without changing the two-phase Q8_K representation")
+    (is (every? #(re-find #"col < .*width" (:source %)) padded-kernels)
+        "both phases guard dense-row reads and synthesize the padding region")
     (is (= 1 (count projection-kernels)))
     (is (= '[[aq :byte] [bq :byte] [bsums :int] [da :float] [db :float]
              [wp :int] [xp :int] [xs :float] [y :float]


### PR DESCRIPTION
## Summary

- add quant-act-q8k-padded-rows-gpu! for dense row-major B by width activations whose quantized contraction uses padded-in
- synthesize zeroes in width through padded-in during both max reduction and packing, avoiding a materialized B by padded-in buffer and copy
- keep quant-act-q8k-rows-gpu! as the branch-free producer for inputs that already have the packed physical width
- emit the same ordered row-major xp, xs, and bsums Q8_K leaves consumed by qmatmul-q4k-dp4a-rows!
- exercise the concrete pretrained Gemma layout boundary B by 640 to B by 768

## Contract

quant-act-q8k-padded-rows-gpu!
  x xp xs bsums submax width padded-in nrows

padded-in must be at least width and divisible by 256. Row count shapes the launch and is specialized out of the physical ABI; width and padded-in remain typed int scalar slots. Buffer ownership and quantization representation are unchanged.

## Verification

- 55 focused compiler, extraction, quantization, GPU graph, and decoder tests; 225 assertions; zero failures/errors
- exact B=3, width=640, padded-in=768 equality against explicitly materialized zero-padded rows for packed words, scales, block sums, and scratch
- equal-width adapter parity against the branch-free producer
- emitted two-phase ABI and guarded-source assertions
- real B=3 dense-quantization to shared-weight Q4_K projection graph regression included; local Level Zero initialization is unavailable, so device bodies took their explicit probe-error skip
- cljfmt and git diff whitespace checks pass