### PR TITLE
Add deterministic indexed row reduction

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -151,6 +151,15 @@ zeroes while packing and therefore avoids a materialized padding buffer; the bra
 kernel remains available for already padded layouts. Padding is layout, not quantization-specific
 memory ownership.
 
+Decoder selection is likewise an ordinary indexed row reduction, not an attention or quantization
+primitive. Its first portable schedule reduces parallel 256-element tiles into compiler-owned
+structure-of-arrays `(value,index)` scratch and then merges those products per row. The semantic ABI
+contains only values, output indices, row count and width; ties select the lowest index, and the first
+NaN outranks numeric values so corruption is visible and deterministic. This slice deliberately
+exposes the next general IR requirement: `SegRed` needs typed product/tuple accumulators and a
+workgroup/subgroup schedule. Once that exists, the general scheduled reduction should subsume the
+two-map implementation and lower to target-local shared/shuffle reductions without changing callers.
+
 Artifact linking and value rebinding are not runtime conveniences. They are
 compiler primitives required for competitive model execution.
 

--- a/src/raster/dl/array_ops.clj
+++ b/src/raster/dl/array_ops.clj
@@ -103,6 +103,67 @@
 ;; GENERIC PRIMITIVES
 ;; ================================================================
 
+(deftm argmax-rows!
+  "Write the deterministic argmax of each row in row-major `values[nrows,width]` to
+  `indices[nrows]`. Ties choose the smallest column. NaN is ordered above every numeric value,
+  so a row containing NaNs returns the first NaN column and exposes numerical corruption rather
+  than silently choosing an unrelated finite logit.
+
+  The schedule is a two-stage product reduction: parallel 256-element tiles write compiler-owned
+  `(value,index)` scratch, then one work-item merges the tile results for each row. This avoids the
+  noncompetitive one-work-item-per-vocabulary scan while keeping the public ABI free of scratch.
+  `width` must be positive."
+  [values :- (Array float), indices :- (Array int), nrows :- Long, width :- Long] :- Void
+  (let [tile-size (long 256)
+        tile-count (long (quot (+ width (dec tile-size)) tile-size))
+        partial-values (float-array (* nrows tile-count))
+        partial-indices (int-array (* nrows tile-count))]
+    (par/map-void! tile (* nrows tile-count)
+                   (let [row (quot tile tile-count)
+                         tile-in-row (rem tile tile-count)
+                         start (* tile-in-row tile-size)
+                         end (min width (+ start tile-size))
+                         row-base (* row width)
+                         first-value (aget values (+ row-base start))
+                         first-nan (int (if (== first-value first-value) 0 1))]
+                     (loop [col (long (inc start)) best-index (int start)
+                            best-value (float first-value) best-nan first-nan]
+                       (if (< col end)
+                         (let [candidate (aget values (+ row-base col))
+                               candidate-nan (int (if (== candidate candidate) 0 1))
+                               better (int (if (== candidate-nan 1)
+                                             (if (== best-nan 0) 1 0)
+                                             (if (== best-nan 1)
+                                               0
+                                               (if (> candidate best-value) 1 0))))]
+                           (if (== better 1)
+                             (recur (long (inc col)) (int col) candidate candidate-nan)
+                             (recur (long (inc col)) best-index best-value best-nan)))
+                         (do
+                           (aset partial-values tile best-value)
+                           (aset partial-indices tile best-index))))))
+    (par/map-void! row nrows
+                   (let [base (* row tile-count)
+                         first-value (aget partial-values base)
+                         first-index (aget partial-indices base)
+                         first-nan (int (if (== first-value first-value) 0 1))]
+                     (loop [tile-in-row (long 1) best-index first-index
+                            best-value (float first-value) best-nan first-nan]
+                       (if (< tile-in-row tile-count)
+                         (let [tile (+ base tile-in-row)
+                               candidate (aget partial-values tile)
+                               candidate-index (aget partial-indices tile)
+                               candidate-nan (int (if (== candidate candidate) 0 1))
+                               better (int (if (== candidate-nan 1)
+                                             (if (== best-nan 0) 1 0)
+                                             (if (== best-nan 1)
+                                               0
+                                               (if (> candidate best-value) 1 0))))]
+                           (if (== better 1)
+                             (recur (long (inc tile-in-row)) candidate-index candidate candidate-nan)
+                             (recur (long (inc tile-in-row)) best-index best-value best-nan)))
+                         (aset indices row best-index)))))))
+
 ;; ================================================================
 ;; slice-strided-2d / scatter-strided-2d
 ;;

--- a/test/raster/dl/indexed_reduction_test.clj
+++ b/test/raster/dl/indexed_reduction_test.clj
@@ -1,0 +1,82 @@
+(ns raster.dl.indexed-reduction-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.resident-plan :as resident-plan]
+            [raster.compiler.pipeline :as pipeline]
+            [raster.dl.array-ops :as ops]))
+
+(defn- reduction-rows
+  [nrows width]
+  (float-array
+   (for [row (range nrows)
+         col (range width)]
+     (float
+      (case row
+        0 (if (contains? #{3 256 512} col) 11.0 (- -1000.0 col))
+        1 (if (contains? #{255 257} col) Float/NaN (if (= col 300) 100.0 col))
+        2 (- (Math/abs (- col 411)))
+        3 (if (contains? #{10 400} col) Float/POSITIVE_INFINITY (- col)))))))
+
+(deftest deterministic-argmax-rows-test
+  (let [nrows 4
+        width 600
+        values (reduction-rows nrows width)
+        indices (int-array nrows)]
+    (ops/argmax-rows! values indices nrows width)
+    (testing "ties cross tile boundaries and choose the first column"
+      (is (= 3 (aget indices 0))))
+    (testing "NaN outranks numeric values and chooses the first NaN"
+      (is (= 255 (aget indices 1))))
+    (testing "ordinary negative and infinite rows retain deterministic ordering"
+      (is (= [411 10] (subvec (vec indices) 2))))))
+
+(deftest argmax-rows-resident-lowering-test
+  (let [nrows 4
+        width 600
+        values (reduction-rows nrows width)
+        indices (int-array nrows)
+        arguments [values indices nrows width]
+        descriptors (into {}
+                          (map (fn [target]
+                                 [target (pipeline/compile-gpu-program
+                                          #'ops/argmax-rows! target :dtype :float)]))
+                          [:ocl:0 :ze:0])
+        descriptor (get descriptors :ocl:0)
+        allocs (:allocs descriptor)
+        steps (:steps descriptor)
+        sources (mapv #(get-in % [:artifact :source]) steps)
+        lowering (resident-plan/lower
+                  {:id :indexed-row-reduction
+                   :target :ocl:0
+                   :descriptor descriptor
+                   :arguments arguments
+                   :outputs ['indices]})]
+    (testing "the semantic ABI contains no schedule scratch"
+      (is (= '[values indices nrows width] (:all-params descriptor)))
+      (is (= '[values indices] (:array-params descriptor)))
+      (is (= '[nrows width] (:scalar-params descriptor))))
+    (testing "the compiler owns typed product scratch"
+      (is (= ['partial-values 'partial-indices] (mapv :sym allocs)))
+      (is (= [:float :int] (mapv :dtype allocs)))
+      (is (= [12 12] (mapv #((:size-fn %) arguments) allocs))))
+    (testing "the reduction remains two ordered target-neutral map stages"
+      (is (= [:map-void :map-void] (mapv :convention steps)))
+      (is (= 2 (count steps)))
+      (is (= #{'partial-values 'partial-indices}
+             (set (take 2 (get-in steps [0 :artifact :arguments])))))
+      (is (= #{'indices 'partial-indices 'partial-values}
+             (set (take 3 (get-in steps [1 :artifact :arguments]))))))
+    (testing "OpenCL and Level Zero preserve the same typed lowering"
+      (is (apply = (map (comp #(mapv :dtype %) :allocs val) descriptors)))
+      (is (apply = (map (comp #(mapv :convention %) :steps val) descriptors)))
+      (is (apply = (map (comp #(mapv (fn [step]
+                                       (mapv (juxt :kind :dtype :kernel-dtype) (:abi step))) %)
+                              :steps val)
+                        descriptors))))
+    (testing "OpenCL C preserves integer schedule scalars and portable NaN comparison"
+      (is (str/includes? (first sources) "int tile_count"))
+      (is (str/includes? (first sources) "int tile_size"))
+      (is (every? #(not (str/includes? % "boolean(")) sources))
+      (is (every? #(str/includes? % "(float)(candidate) == (float)(candidate)") sources)))
+    (testing "the descriptor certifies as a composable LinkPlan before allocation"
+      (is (resident-plan/certified-plan? (resident-plan/verify! lowering))))))

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -12,6 +12,7 @@
             [raster.compiler.pipeline :as pl]
             [raster.arrays :as ra]
             [raster.core :refer [deftm]]
+            [raster.dl.array-ops :as ops]
             [raster.gpu.core :as gpu]
             [raster.gpu.descriptor-fixture :as fixture]))
 
@@ -82,6 +83,28 @@
             (let [r2 (fixture/run! program [x y (float 2.0) n])
                   ^floats yg (get r2 'y)]
               (is (< (Math/abs (- (aget yg 100) 200.0)) 1e-3)))))
+        (finally (gpu/close-session! s))))))
+
+(deftest ocl-resident-indexed-row-reduction-roundtrip
+  (if-not @ocl-available?
+    (println "SKIP ocl indexed row reduction (no OpenCL device)")
+    (let [nrows 3
+          width 513
+          values (float-array (* nrows width) (float -10.0))
+          indices (int-array nrows)
+          descriptor (pl/compile-gpu-program #'ops/argmax-rows! :ocl:0 :dtype :float)
+          s (gpu/make-session :ocl:0)]
+      (aset values 3 (float 9.0))
+      (aset values 256 (float 9.0))
+      (aset values 512 (float 9.0))
+      (aset values (+ width 255) Float/NaN)
+      (aset values (+ width 257) Float/NaN)
+      (aset values (+ width 300) (float 100.0))
+      (aset values (+ (* 2 width) 411) (float 8.0))
+      (try
+        (let [program (fixture/instantiate! s descriptor [values indices nrows width])
+              result (get (fixture/run! program [values indices nrows width]) 'indices)]
+          (is (= [3 255 411] (vec result))))
         (finally (gpu/close-session! s))))))
 
 (deftest ocl-resident-segmap-artifact-roundtrip


### PR DESCRIPTION
Summary:
- add a target-neutral two-stage tiled argmax-rows operation with a stable semantic ABI
- keep float/value and int/index scratch compiler-owned and certify the resident LinkPlan
- define deterministic lowest-index ties and first-NaN selection, with OpenCL runtime coverage
- record product accumulators and subgroup/workgroup reduction scheduling as the general SegRed successor

Tests:
- clojure -J-Xmx2g -J-Duser.home=/tmp/raster-codex-home -M:test -n raster.dl.indexed-reduction-test -n raster.gpu.ocl-session-test
- clojure -J-Xmx2g -J-Duser.home=/tmp/raster-codex-home -M:test -n raster.dl.array-ops-test -n raster.compiler.pipeline-extractor-test
- OpenCL runtime test skipped locally because no OpenCL device is available