### PR TITLE
Add generic resident row gather

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -160,6 +160,12 @@ exposes the next general IR requirement: `SegRed` needs typed product/tuple accu
 workgroup/subgroup schedule. Once that exists, the general scheduled reduction should subsume the
 two-map implementation and lower to target-local shared/shuffle reductions without changing callers.
 
+Row selection remains a separate generic operation. `gather-rows!` consumes shared row-major source
+storage and `int[B]` indices, writes caller-owned dense `[B,width]` output, and maps every output
+element independently. Consequently greedy decode composes indexed reduction and row gather as
+ordinary graph dataflow; top-k, sampling, beam search, or external token policy can replace the
+producer without changing embedding storage or introducing a decoder-tail compiler primitive.
+
 Artifact linking and value rebinding are not runtime conveniences. They are
 compiler primitives required for competitive model execution.
 

--- a/src/raster/dl/array_ops.clj
+++ b/src/raster/dl/array_ops.clj
@@ -6,6 +6,8 @@
   rrules — compositions auto-differentiate through them.
 
   Core primitives:
+    argmax-rows!     - deterministic indexed row reduction into caller-owned storage
+    gather-rows!     - copy int-indexed rows into caller-owned dense storage
     scatter-add      - scatter values to indexed destinations (adjoint of gather)
     gather           - gather values from indexed sources (adjoint of scatter-add)
     indexed-dot      - batched indexed dot product (multi-head aware)
@@ -163,6 +165,22 @@
                              (recur (long (inc tile-in-row)) candidate-index candidate candidate-nan)
                              (recur (long (inc tile-in-row)) best-index best-value best-nan)))
                          (aset indices row best-index)))))))
+
+(deftm gather-rows!
+  "Copy rows selected by `indices[nrows]` from row-major `src[*,width]` into caller-owned
+  `out[nrows,width]`. Every output element has one writer, and rows of `src` may be selected
+  repeatedly. The operation is a generic indexed layout transform; embedding lookup is one use.
+
+  Indices are intentionally `int`, matching routed attention and indexed reductions. Callers own
+  bounds validation: every index must name a complete source row. `out` must not overlap `src`;
+  parallel output writes are not ordered against source reads."
+  (All [T] [src :- (Array T), indices :- (Array int), out :- (Array T),
+            nrows :- Long, width :- Long] :- Void
+       (par/map-void! i (* nrows width)
+                      (let [row (quot i width)
+                            col (rem i width)
+                            src-row (aget indices row)]
+                        (aset out i (aget src (+ (* src-row width) col)))))))
 
 ;; ================================================================
 ;; slice-strided-2d / scatter-strided-2d

--- a/test/raster/dl/row_gather_test.clj
+++ b/test/raster/dl/row_gather_test.clj
@@ -1,0 +1,85 @@
+(ns raster.dl.row-gather-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.resident-plan :as resident-plan]
+            [raster.compiler.pipeline :as pipeline]
+            [raster.core :refer [deftm]]
+            [raster.dl.array-ops :as ops]))
+
+(deftm greedy-embedding-tail!
+  [logits :- (Array float), token-indices :- (Array int),
+   table :- (Array float), rows :- (Array float),
+   nrows :- Long, vocab :- Long, width :- Long] :- Void
+  (ops/argmax-rows! logits token-indices nrows vocab)
+  (ops/gather-rows! table token-indices rows nrows width))
+
+(deftest gather-rows-test
+  (let [width 4
+        table (float-array [0 1 2 3
+                            10 11 12 13
+                            20 21 22 23
+                            30 31 32 33])
+        indices (int-array [2 0 2])
+        rows (float-array (* 3 width))]
+    (ops/gather-rows! table indices rows 3 width)
+    (testing "rows use shared source storage and may repeat"
+      (is (= [20.0 21.0 22.0 23.0
+              0.0 1.0 2.0 3.0
+              20.0 21.0 22.0 23.0]
+             (vec rows))))))
+
+(deftest gather-rows-resident-lowering-test
+  (let [descriptors (into {}
+                          (map (fn [target]
+                                 [target (pipeline/compile-gpu-program
+                                          #'ops/gather-rows! target :dtype :float)]))
+                          [:ocl:0 :ze:0])
+        descriptor (get descriptors :ocl:0)
+        step (first (:steps descriptor))]
+    (testing "the ABI is generic storage plus shape, without embedding policy"
+      (is (= '[src indices out nrows width] (:all-params descriptor)))
+      (is (= '[src indices out] (:array-params descriptor)))
+      (is (= '[nrows width] (:scalar-params descriptor)))
+      (is (empty? (:allocs descriptor))))
+    (testing "every output element lowers through one target-neutral map"
+      (is (= [:map-void] (mapv :convention (:steps descriptor))))
+      (is (= '[indices out src width _n_bound] (mapv :name (:abi step))))
+      (is (= [:int :float :float :int :int] (mapv :dtype (:abi step))))
+      (is (= '(clojure.core/* (long nrows) (long width))
+             (last (get-in step [:artifact :arguments])))))
+    (testing "OpenCL and Level Zero preserve the same physical ABI"
+      (is (apply = (map (comp #(mapv (juxt :kind :dtype :kernel-dtype) %)
+                              :abi first :steps val)
+                        descriptors))))))
+
+(deftest indexed-reduction-composes-with-row-gather-test
+  (let [nrows 2
+        vocab 513
+        width 3
+        logits (float-array (* nrows vocab) (float -100.0))
+        token-indices (int-array nrows)
+        table (float-array (map float (range (* vocab width))))
+        rows (float-array (* nrows width))
+        arguments [logits token-indices table rows nrows vocab width]
+        descriptor (pipeline/compile-gpu-program
+                    #'greedy-embedding-tail! :ocl:0 :dtype :float)
+        lowering (resident-plan/lower
+                  {:id :greedy-embedding-tail
+                   :target :ocl:0
+                   :descriptor descriptor
+                   :arguments arguments
+                   :outputs ['token-indices 'rows]})]
+    (aset logits 7 (float 9.0))
+    (aset logits (+ vocab 400) (float 8.0))
+    (greedy-embedding-tail! logits token-indices table rows nrows vocab width)
+    (testing "selection and lookup compose without a fused attention primitive"
+      (is (= [7 400] (vec token-indices)))
+      (is (= [21.0 22.0 23.0 1200.0 1201.0 1202.0] (vec rows))))
+    (testing "the compiled graph retains three ordered kernels and only reduction scratch"
+      (is (= [:map-void :map-void :map-void] (mapv :convention (:steps descriptor))))
+      (is (= [true true]
+             (mapv (fn [{:keys [sym]} prefix] (str/starts-with? (name sym) prefix))
+                   (:allocs descriptor) ["partial-values" "partial-indices"])))
+      (is (= [:float :int] (mapv :dtype (:allocs descriptor)))))
+    (testing "the ordinary multi-output descriptor certifies before allocation"
+      (is (resident-plan/certified-plan? (resident-plan/verify! lowering))))))

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -107,6 +107,25 @@
           (is (= [3 255 411] (vec result))))
         (finally (gpu/close-session! s))))))
 
+(deftest ocl-resident-row-gather-roundtrip
+  (if-not @ocl-available?
+    (println "SKIP ocl row gather (no OpenCL device)")
+    (let [nrows 3
+          width 4
+          table (float-array (map float (range 32)))
+          indices (int-array [5 1 5])
+          rows (float-array (* nrows width))
+          descriptor (pl/compile-gpu-program #'ops/gather-rows! :ocl:0 :dtype :float)
+          s (gpu/make-session :ocl:0)]
+      (try
+        (let [program (fixture/instantiate! s descriptor [table indices rows nrows width])
+              result (get (fixture/run! program [table indices rows nrows width]) 'out)]
+          (is (= [20.0 21.0 22.0 23.0
+                  4.0 5.0 6.0 7.0
+                  20.0 21.0 22.0 23.0]
+                 (vec result))))
+        (finally (gpu/close-session! s))))))
+
 (deftest ocl-resident-segmap-artifact-roundtrip
   (if-not @ocl-available?
     (println "SKIP ocl resident SegMap artifact (no OpenCL device)")


### PR DESCRIPTION
Summary:
- add a generic gather-rows! operation over shared row-major source storage, int routing indices, and caller-owned dense output
- parallelize over every output element instead of serially copying one full row per work-item
- verify identical OpenCL and Level Zero typed ABIs with no compiler scratch
- certify argmax-rows! to gather-rows! as ordinary three-kernel LinkPlan dataflow
- keep sampling policy, embeddings, quantization, and ownership out of the primitive

Tests:
- clojure -J-Xmx2g -J-Duser.home=/tmp/raster-codex-home -M:test -n raster.dl.row-gather-test -n raster.gpu.ocl-session-test
- clojure -J-Xmx2g -J-Duser.home=/tmp/raster-codex-home -M:test -n raster.dl.array-ops-test -n raster.par-gather-test -n raster.compiler.pipeline-extractor-test -n raster.dl.indexed-reduction-test -n raster.dl.row-gather-test
- OpenCL runtime tests skipped locally because no OpenCL device is available