### PR TITLE
Make the SegOp program boundary first class

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -51,23 +51,25 @@ Raster is not starting from a toy compiler:
 - The quantized path already covers Q4_0, Q8_0, Q4_K, and Q6_K, including
   staged contraction and DP4A-related work.
 
-These pieces are the foundation. The principal problem is that some of them are
-connected by metadata, duplicated lowering, string-template seams, or
-conventions that the dialect validator cannot actually prove.
+These pieces are the foundation. The SegOp boundary now uses a first-class typed
+`ParallelProgram`; remaining gaps are concentrated in the earlier SOAC program,
+the scheduled kernel-body representation, duplicated lowering, and string-template seams.
 
 ## 2. The load-bearing gaps
 
 ### 2.1 The middle end is not yet a sequence of real dialects
 
-`segop-lower-pass` currently leaves the original S-expression in place and
-attaches SegOps to binding-symbol metadata. Failed conversion is caught, printed
-as a warning, and treated as absence. The OpenCL backend can then reconstruct a
-SegOp on demand. Meanwhile, the `:segop-lowered` and `:gpu-planned` dialect
-validators prove only that the outer `let*` is ordered.
-
-This means the pass arrows are nominal at the most important boundary. A kernel
-can bypass the intended IR, and a failed lowering can quietly select a different
+`segop-lower-pass` now produces a `ParallelProgram` with ordered equations,
+SSA-like result IDs, `AbstractValue` contracts, effects, diagnostics, and provenance.
+GPU and JVM backends consume the recorded operations; the source expression is retained only to
+reconstruct scalar host control around them. The `:segop-lowered` validator performs a full
+operation/type legality check, and source equality invalidates an equation after a backend-local
+rewrite. Direct calls to a backend may still use the explicit, counted compatibility re-lowering
 path.
+
+The remaining nominal boundary is earlier: SOAC fusion still works over an S-expression-derived
+graph rather than a first-class typed program, and the scheduled operations do not yet contain a
+general target-neutral kernel body.
 
 The first architectural correction is therefore:
 

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -13,6 +13,8 @@
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.parallel-program :as parallel-program]
+            [raster.compiler.ir.segop :as segop]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.passes.parallel.soac-lower]
             [raster.compiler.backend.gpu.segop-opencl :as segop-cl]
@@ -102,15 +104,12 @@
       :else (:ok r))))
 
 (def ^:dynamic *bound-segops*
-  "The SegOp records `segop-lower` attached to the binding CURRENTLY being transformed (its
-   `::segops` metadata), or nil in body position / when the pass did not run.
+  "The SegOp records owned by the ParallelProgram equation currently being transformed, or nil
+   when this backend was called directly on an S-expression.
 
    This is the seam that makes the SegOp boundary REAL instead of nominal. `segop-lower` lowered
-   every par form with the real target device and stored the result on the binder symbol — and
-   nothing read it: this pass re-lowered each form from scratch with `:ze:0` hardcoded, ignoring
-   both the stored result and its own `device-id` (north-star §2.1, ledger #6/#11). Now the
-   stored SegOp is consumed; re-lowering is the fallback and is COUNTED, so a form that bypasses
-   the pass's output shows up in the stats instead of silently taking a second path."
+   every par form with the real target device. The equation is consumed here; re-lowering remains
+   a counted compatibility path for callers that invoke opencl-pass directly."
   nil)
 
 (defn- take-bound-segop
@@ -277,8 +276,13 @@
   ;; DECLARED types from derive-param-types (opts) override the name-heuristic fallback in the
   ;; kernel generators — e.g. `features` (Long→int) and `gain-offset` (Double→float, whose name
   ;; would otherwise misfire the "offset"→int heuristic). Form-meta types are the base.
-  (let [top-scalar-types (merge (or (:scalar-types (meta form)) {}) scalar-types)
-        top-array-types (merge (or (:array-types (meta form)) {}) array-types)
+  (let [parallel-program (when (parallel-program/parallel-program? form)
+                           (parallel-program/validate! form segop/segop-node?))
+        source-form (if parallel-program (parallel-program/source-form parallel-program) form)
+        top-scalar-types (merge (or (:scalar-types (meta source-form)) {})
+                                (or (:scalar-types (meta form)) {}) scalar-types)
+        top-array-types (merge (or (:array-types (meta source-form)) {})
+                               (or (:array-types (meta form)) {}) array-types)
         stats (atom {:ze-maps 0 :ze-reduces 0 :ze-compounds 0 :ze-contracts 0
                      :ze-structured-reductions 0 :fallback 0})
         kernels (atom [])
@@ -558,22 +562,21 @@
             (and (seq? form) (contains? #{'let 'let*} (first form)))
             (let [[let-sym bindings & body-exprs] form
                   pairs (partition 2 bindings)
-                  ;; the binder symbol carries what segop-lower computed for this init — make it
-                  ;; visible to the par branches so they consume it instead of re-lowering
                   new-bindings (vec (mapcat (fn [[sym expr]]
                                               [sym (binding [*bound-segops*
-                                                             (:raster.compiler.passes.parallel.segop-lower-pass/segops (meta sym))]
+                                                             (when parallel-program
+                                                               (parallel-program/operations-for-binding
+                                                                parallel-program sym expr))]
                                                      (transform expr))])
                                             pairs))
-                  new-body (mapv transform body-exprs)]
+                  new-body (mapv (fn [expr]
+                                   (binding [*bound-segops*
+                                             (when parallel-program
+                                               (parallel-program/operations-for-source
+                                                parallel-program expr))]
+                                     (transform expr)))
+                                 body-exprs)]
               (with-meta (apply list let-sym new-bindings new-body) (meta form)))
-
-            ;; a body-position par form: segop-lower wraps it in (do …) carrying ::body-segops
-            ;; — consume that exactly as a binding's ::segops, so body forms stop re-lowering
-            (and (seq? form) (= 'do (first form))
-                 (:raster.compiler.passes.parallel.segop-lower-pass/body-segops (meta form)))
-            (binding [*bound-segops* (:raster.compiler.passes.parallel.segop-lower-pass/body-segops (meta form))]
-              (with-meta (apply list 'do (mapv transform (rest form))) (meta form)))
 
             (and (seq? form) (= 'do (first form)))
             (with-meta (apply list 'do (mapv transform (rest form))) (meta form))
@@ -588,7 +591,7 @@
                 rebuilt))
 
             :else form))]
-    {:form (transform form)
+    {:form (transform source-form)
      :stats @stats
      :kernels @kernels
      :dispatches @dispatches}))

--- a/src/raster/compiler/backend/jvm/par_simd.clj
+++ b/src/raster/compiler/backend/jvm/par_simd.clj
@@ -23,6 +23,8 @@
             [raster.compiler.ir.soac]
             [raster.compiler.passes.parallel.soac-lower]
             [raster.compiler.ir.par :as par]
+            [raster.compiler.ir.parallel-program :as parallel-program]
+            [raster.compiler.ir.segop :as segop]
             [raster.runtime.hardware :as hw]
             [clojure.set :as set]))
 
@@ -155,12 +157,10 @@
                                        (:body info2))
                           fused-expr (list 'raster.par/map! (:out info2) (:idx info2) (:bound info2)
                                            (:cast info2) inline-body)
-                          ;; sym2's SegOp describes expr2 before body1 was inlined. Keeping that
-                          ;; metadata makes boundary consumption silently emit expr2 alone. The
-                          ;; fused expression did not pass through segop-lower, so invalidate its
-                          ;; stale certificate and let the counted backend re-lowering handle it.
-                          fused-sym (vary-meta sym2 dissoc
-                                               :raster.compiler.passes.parallel.segop-lower-pass/segops)]
+                          ;; The ParallelProgram equation describes expr2 before body1 was inlined.
+                          ;; Its source-equality certificate will reject fused-expr and select the
+                          ;; counted backend re-lowering path.
+                          fused-sym sym2]
                       ;; Skip sym1 binding (tmp is eliminated), replace sym2 with fused
                       (recur (+ i 2) (conj result [fused-sym fused-expr]) true))
                     ;; Not fusable — keep both
@@ -390,9 +390,8 @@
 (def ^:private segop-id-counter (atom 0))
 
 (def ^:dynamic *bound-segops*
-  "SegOps segop-lower attached to the binding currently being transformed (its ::segops metadata),
-   or nil. The JVM SIMD backend used to re-lower every par form on the fly, same as opencl-pass
-   did before PR #98 — the third copy of that seam. Consumption is dtype-guarded."
+  "SegOps owned by the ParallelProgram equation currently being transformed, or nil for direct
+   S-expression callers. Consumption is dtype-guarded."
   nil)
 
 (defn simd-pass
@@ -405,13 +404,17 @@
     :min-elements — minimum elements for SIMD (default 8)"
   [form & {:keys [simd? min-elements] :or {simd? true min-elements nil}}]
   (if-not simd?
-    {:form (par/expand-par-forms form) :stats {:simd? false}}
-    (let [min-elements (or min-elements (effective-min-elements))
+    (let [p (when (parallel-program/parallel-program? form)
+              (parallel-program/validate! form segop/segop-node?))
+          source (if p (parallel-program/source-form p) form)]
+      {:form (par/expand-par-forms source) :stats {:simd? false}})
+    (let [parallel-program (when (parallel-program/parallel-program? form)
+                             (parallel-program/validate! form segop/segop-node?))
+          source-form (if parallel-program (parallel-program/source-form parallel-program) form)
+          min-elements (or min-elements (effective-min-elements))
           stats (atom {:simd-maps 0 :simd-reduces 0 :fallback 0 :fused 0 :skipped-small 0})
-          ;; On-the-fly SegOp computation for any par form
-          ;; the SegOps segop-lower attached to the binding being transformed — same seam as
-          ;; opencl-pass (*bound-segops* there). Consumed only when the dtype matches what this
-          ;; backend would derive, so consumption cannot silently change the SIMD element type.
+            ;; Equation SegOps are consumed only when the dtype matches what this backend derives,
+            ;; so program consumption cannot silently change the SIMD element type.
           take-bound (fn [pred dtype]
                        (when-let [so (first (filter #(and (pred %) (= dtype (:dtype %))) *bound-segops*))]
                          (swap! stats update :segop-reused (fnil inc 0))
@@ -529,10 +532,19 @@
                   (let [pairs (partition 2 bindings)
                         new-bindings (vec (mapcat (fn [[s e]]
                                                     [s (binding [*bound-segops*
-                                                                 (:raster.compiler.passes.parallel.segop-lower-pass/segops (meta s))]
+                                                                 (when parallel-program
+                                                                   (parallel-program/operations-for-binding
+                                                                    parallel-program s e))]
                                                          (transform e))])
                                                   pairs))
-                        new-body (doall (map transform body))]
+                        new-body (doall
+                                  (map (fn [expr]
+                                         (binding [*bound-segops*
+                                                   (when parallel-program
+                                                     (parallel-program/operations-for-source
+                                                      parallel-program expr))]
+                                           (transform expr)))
+                                       body))]
                     (list* let-sym new-bindings new-body))))
 
               ;; do block — recurse explicitly (not via generic seq, for clarity)
@@ -543,5 +555,5 @@
               (seq? form) (apply list (doall (map transform form)))
               (vector? form) (mapv transform form)
               :else form))]
-      {:form (transform form)
+      {:form (transform source-form)
        :stats @stats})))

--- a/src/raster/compiler/ir/dialects.clj
+++ b/src/raster/compiler/ir/dialects.clj
@@ -19,6 +19,8 @@
              :refer [def-dialect def-derived valid? validate]]
             [raster.compiler.ir.form :as form]
             [raster.compiler.ir.par :as par]
+            [raster.compiler.ir.parallel-program :as parallel-program]
+            [raster.compiler.ir.segop :as segop]
             [raster.compiler.core.util :as util]
             [clojure.set :as set]))
 
@@ -491,6 +493,22 @@
 ;; Dialect registry for pipeline integration
 ;; ================================================================
 
+(defn valid-segop-program?
+  [value]
+  (try
+    (and (= :segop (:dialect value))
+         (parallel-program/validate! value segop/segop-node?)
+         true)
+    (catch clojure.lang.ExceptionInfo _ false)))
+
+(defn validate-segop-program
+  [value]
+  (try
+    (parallel-program/validate! value segop/segop-node?)
+    :ok
+    (catch clojure.lang.ExceptionInfo e
+      {:fail :segop-program :details (ex-data e) :message (.getMessage e)})))
+
 (def dialect-checkers
   "Map from dialect keyword to [valid? validate] function pairs.
   Used by run-passes to validate IR at pass boundaries."
@@ -515,7 +533,7 @@
    :par-fused        [valid-let*-ordered? validate-let*-ordered]
    :soac-fused       [valid-let*-ordered? validate-let*-ordered]
    :materialized     [valid-let*-ordered? validate-let*-ordered]
-   :segop-lowered    [valid-let*-ordered? validate-let*-ordered]
+   :segop-lowered    [valid-segop-program? validate-segop-program]
    :compound-detected [valid-let*-ordered? validate-let*-ordered]
    :gpu-planned      [valid-let*-ordered? validate-let*-ordered]
    :dtype-remapped   [valid-let*-ordered? validate-let*-ordered]

--- a/src/raster/compiler/ir/parallel_program.clj
+++ b/src/raster/compiler/ir/parallel_program.clj
@@ -1,0 +1,155 @@
+(ns raster.compiler.ir.parallel-program
+  "First-class typed program container for parallel compiler dialects.
+
+   ParallelProgram is the ordered value/equation spine shared by the SOAC and SegOp stages.  The
+   current compiler still needs `source` to reconstruct scalar host control around emitted kernel
+   calls, but scheduled operations live in equations, never in Clojure symbol metadata.  As more
+   scalar control becomes explicit, `source` can shrink without changing value or operation IDs."
+  (:require [raster.compiler.ir.abstract-value :as av]))
+
+(defrecord ProgramEquation
+           [id site source operands results operations effects provenance attributes])
+
+(defrecord ParallelProgram
+           [dialect source values inputs equations outputs effects diagnostics provenance attributes])
+
+(defn- record-kind?
+  [record-class value]
+  (and value (= record-class (.getName (class value)))))
+
+(defn equation?
+  [value]
+  (record-kind? "raster.compiler.ir.parallel_program.ProgramEquation" value))
+
+(defn parallel-program?
+  [value]
+  (record-kind? "raster.compiler.ir.parallel_program.ParallelProgram" value))
+
+(defn- distinct-vector?
+  [value]
+  (and (vector? value) (= (count value) (count (distinct value)))))
+
+(defn validate!
+  "Validate a ParallelProgram and return it unchanged.
+
+   `operation?`, when supplied, defines full legality for the declared dialect.  Structural
+   validation remains independent of any concrete SOAC/SegOp namespace, avoiding an IR cycle."
+  ([program] (validate! program (constantly true)))
+  ([program operation?]
+   (when-not (parallel-program? program)
+     (throw (ex-info "expected a ParallelProgram"
+                     {:reason :parallel-program-type :actual (type program)})))
+   (let [{:keys [dialect values inputs equations outputs effects diagnostics provenance attributes]}
+         program]
+     (when-not (keyword? dialect)
+       (throw (ex-info "parallel program requires a dialect keyword"
+                       {:reason :parallel-program-dialect :dialect dialect})))
+     (when-not (map? values)
+       (throw (ex-info "parallel program values must be an id-to-AbstractValue map"
+                       {:reason :parallel-program-values :values values})))
+     (doseq [[id value] values]
+       (when (nil? id)
+         (throw (ex-info "parallel program value IDs cannot be nil"
+                         {:reason :parallel-program-value-id})))
+       (av/validate! value))
+     (doseq [[field ids] [[:inputs inputs] [:outputs outputs]]]
+       (when-not (distinct-vector? ids)
+         (throw (ex-info "parallel program boundary IDs must be a distinct vector"
+                         {:reason :parallel-program-boundary :field field :ids ids})))
+       (doseq [id ids]
+         (when-not (contains? values id)
+           (throw (ex-info "parallel program boundary references an unknown value"
+                           {:reason :parallel-program-unknown-value :field field :id id})))))
+     (when-not (vector? equations)
+       (throw (ex-info "parallel program equations must be an ordered vector"
+                       {:reason :parallel-program-equations :equations equations})))
+     (when-not (= (count equations) (count (distinct (map :id equations))))
+       (throw (ex-info "parallel program equation IDs must be unique"
+                       {:reason :parallel-program-equation-id})))
+     (doseq [equation equations]
+       (when-not (equation? equation)
+         (throw (ex-info "parallel program contains a non-equation"
+                         {:reason :parallel-program-equation-type :equation equation})))
+       (doseq [[field ids] [[:operands (:operands equation)] [:results (:results equation)]]]
+         (when-not (distinct-vector? ids)
+           (throw (ex-info "equation value IDs must be a distinct vector"
+                           {:reason :parallel-program-equation-values
+                            :equation (:id equation) :field field :ids ids})))
+         (doseq [id ids]
+           (when-not (contains? values id)
+             (throw (ex-info "equation references an unknown value"
+                             {:reason :parallel-program-unknown-value
+                              :equation (:id equation) :field field :id id})))))
+       (when-not (and (vector? (:operations equation)) (seq (:operations equation)))
+         (throw (ex-info "equation requires one or more ordered operations"
+                         {:reason :parallel-program-operations :equation (:id equation)})))
+       (doseq [operation (:operations equation)]
+         (when-not (operation? operation)
+           (throw (ex-info "an illegal operation remains after full dialect conversion"
+                           {:reason :illegal-op-remains :target-dialect dialect
+                            :equation (:id equation) :operation operation :fallback :none}))))
+       (when-not (set? (:effects equation))
+         (throw (ex-info "equation effects must be an explicit set"
+                         {:reason :parallel-program-effects :equation (:id equation)})))
+       (when-not (map? (:provenance equation))
+         (throw (ex-info "equation provenance must be a map"
+                         {:reason :parallel-program-provenance :equation (:id equation)})))
+       (when-not (map? (:attributes equation))
+         (throw (ex-info "equation attributes must be a map"
+                         {:reason :parallel-program-attributes :equation (:id equation)}))))
+     (when-not (set? effects)
+       (throw (ex-info "parallel program effects must be an explicit set"
+                       {:reason :parallel-program-effects :effects effects})))
+     (when-not (vector? diagnostics)
+       (throw (ex-info "parallel program diagnostics must be a vector"
+                       {:reason :parallel-program-diagnostics :diagnostics diagnostics})))
+     (when-not (map? provenance)
+       (throw (ex-info "parallel program provenance must be a map"
+                       {:reason :parallel-program-provenance :provenance provenance})))
+     (when-not (map? attributes)
+       (throw (ex-info "parallel program attributes must be a map"
+                       {:reason :parallel-program-attributes :attributes attributes}))))
+   program))
+
+(defn make
+  [{:keys [dialect source values inputs equations outputs effects diagnostics provenance attributes]
+    :or {values {} inputs [] equations [] outputs [] effects #{} diagnostics []
+         provenance {} attributes {}}}]
+  (validate! (->ParallelProgram dialect source values (vec inputs) (vec equations) (vec outputs)
+                                effects (vec diagnostics) provenance attributes)))
+
+(defn source-form
+  "The compatibility host expression surrounding the explicit parallel equations."
+  [program]
+  (:source (validate! program)))
+
+(defn equation-for-binding
+  "Find the equation for a binding only when the current source still matches its certified source.
+   This equality guard invalidates scheduled operations if a later backend-local fusion rewrites the
+   binding before consumption."
+  [program sym source]
+  (some #(when (and (= [:binding sym] (:site %)) (= source (:source %))) %) (:equations program)))
+
+(defn equation-for-source
+  "Find an unambiguous body-position equation for an exact source expression."
+  [program source]
+  (let [matches (filterv #(and (= :body (first (:site %))) (= source (:source %)))
+                         (:equations program))]
+    (when (= 1 (count matches)) (first matches))))
+
+(defn operations-for-binding
+  [program sym source]
+  (:operations (equation-for-binding program sym source)))
+
+(defn result-id-for-binding
+  "The explicit value ID produced by a binding equation, when it has one result."
+  [program sym source]
+  (first (:results (equation-for-binding program sym source))))
+
+(defn operations-for-source
+  [program source]
+  (:operations (equation-for-source program source)))
+
+(defn kernel-graph-for-binding
+  [program sym source]
+  (:kernel-graph (:attributes (equation-for-binding program sym source))))

--- a/src/raster/compiler/ir/segop.clj
+++ b/src/raster/compiler/ir/segop.clj
@@ -99,6 +99,13 @@
                     "raster.compiler.ir.segop.SegScan"}
                   (.getName (class x)))))
 
+(defn segop-node?
+  "Any operation legal in the SegOp dialect, including a semantic SegContract that must be routed
+   before it can become an executable KernelGraph operation."
+  [x]
+  (or (segop? x)
+      (and x (= "raster.compiler.ir.segop.SegContract" (.getName (class x))))))
+
 (defn segop-grid
   "Get the KernelGrid from a SegOp."
   [segop]

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -1,19 +1,20 @@
 (ns raster.compiler.passes.parallel.segop-lower-pass
   "Pipeline pass: lower par forms to SegOp records.
 
-   Walks let* bindings and converts raster.par/* forms to SegOp IR via
-   SOAC intermediate. SegOp records are attached as metadata on binding
-   symbols for downstream backend consumption.
+   Walks let* bindings and converts raster.par/* forms to SegOp IR via the SOAC intermediate.
+   The result is a first-class ParallelProgram whose typed equations own the SegOps.  Binding
+   metadata is not an IR transport.
 
    This decouples hardware-aware execution planning from backend codegen:
    - Lowering decides phase decomposition, launch params, accumulator count
    - Backend translates SegOp to target code (SIMD, OpenCL, scalar)"
   (:require [raster.compiler.ir.par :as par]
             [raster.compiler.ir.soac :as soac]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.parallel-program :as program]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
-            [raster.compiler.passes.parallel.device :as device]
-            [raster.runtime.hardware :as hw]
-            [raster.compiler.ir.form :as form]))
+            [raster.compiler.ir.form :as form]
+            [clojure.set :as set]))
 
 (def ^:private id-counter (atom 0))
 
@@ -36,7 +37,7 @@
    :reason (or (:reason (ex-data e)) :no-lowering-rule)
    :message (.getMessage e)
    ;; a fallback is a stated outcome, not the absence of one
-   :fallback :no-segop-metadata-backend-lowers-or-uses-legacy-codegen})
+   :fallback :backend-relowers-or-uses-specialized-codegen})
 
 (defn- lower-attempt
   "Lower a par form to SegOp records via the SOAC intermediate.
@@ -82,7 +83,7 @@
                                                       :dtype (or dtype :double)))]
           (cond
             (:err segops) (decline :segop (:err segops))
-            (seq (:ok segops)) (cond-> {:segops (:ok segops)}
+            (seq (:ok segops)) (cond-> {:soac (:ok soac) :segops (:ok segops)}
                                  (soac-lower/scan-soac? (:ok soac))
                                  (assoc :kernel-graph
                                         (soac-lower/scan-kernel-graph
@@ -91,27 +92,141 @@
                                                     (ex-info "lower-soac produced no SegOps" {})
                                                     device-id dtype)})))))))
 
-(defn- annotate-binding
-  "Attach scheduled compiler values to a binding symbol."
-  [sym {:keys [segops kernel-graph]}]
-  (cond-> (vary-meta sym assoc ::segops segops)
-    kernel-graph (vary-meta assoc ::kernel-graph kernel-graph)))
+(defn- unknown-vector-shape [] ['?])
 
-(defn get-segops
-  "Retrieve SegOp records from a binding symbol's metadata."
-  [sym]
-  (::segops (meta sym)))
+(defn- result-shape
+  [node]
+  (cond
+    (soac/soac-reduce? node) []
+    (and (soac/screma? node) (seq (:reduces node)) (empty? (:scans node))) []
+    ;; An imperative map/scan binding aliases a caller-provided output buffer. Its iteration domain
+    ;; is not proof of the buffer's physical/logical extent (padded rows and strided views are common).
+    :else (unknown-vector-shape)))
 
-(defn get-kernel-graph
-  "Retrieve a scheduled KernelGraph from a binding symbol's metadata."
-  [sym]
-  (::kernel-graph (meta sym)))
+(defn- value-contract
+  [id node dtype array-types result?]
+  (let [array-ids (set/union (or (soac/soac-inputs node) #{})
+                             (or (soac/soac-outputs node) #{}))
+        shape (cond
+                result? (result-shape node)
+                (contains? array-ids id) (unknown-vector-shape)
+                :else [])
+        value-dtype (or (get array-types id)
+                        (when (symbol? id) (get array-types (symbol (name id))))
+                        (:elem-type node)
+                        dtype
+                        :double)]
+    (av/tensor {:dtype value-dtype
+                :shape shape
+                :representation {:kind :plain}
+                :effects #{}})))
+
+(defn- equation
+  [equation-id site sym source {:keys [soac segops kernel-graph]} dtype array-types]
+  (let [operands (-> (soac/node-all-free-syms soac) (disj sym) (->> (sort-by str) vec))
+        result-ids (if (= :binding (first site)) [sym] [])
+        effects (cond-> #{:memory/read}
+                  (seq (soac/soac-outputs soac)) (conj :memory/write))
+        operand-values (into {}
+                             (map (fn [id]
+                                    [id (value-contract id soac dtype array-types false)]))
+                             operands)
+        result-values (into {}
+                            (map (fn [id]
+                                   [id (value-contract id soac dtype array-types true)]))
+                            result-ids)
+        eq (program/->ProgramEquation
+            equation-id site source operands result-ids (vec segops) effects
+            {:source-dialect :soac :target-dialect :segop :soac-id (:id soac)}
+            (cond-> {:device (:device-id (first segops))}
+              kernel-graph (assoc :kernel-graph kernel-graph)))]
+    {:equation eq :operand-values operand-values :result-values result-values}))
+
+(defn- merge-values
+  "Merge independently inferred value contracts and reject inconsistent views of one value ID."
+  [left right]
+  (reduce-kv
+   (fn [values id contract]
+     (if-let [prior (get values id)]
+       (if (= prior contract)
+         values
+         (throw (ex-info "parallel equations inferred incompatible contracts for one value"
+                         {:reason :parallel-program-value-conflict
+                          :id id :first prior :second contract})))
+       (assoc values id contract)))
+   left right))
+
+(defn- ensure-use-compatible!
+  [id definition inferred-use]
+  (let [facets [:kind :dtype :representation]
+        defined (select-keys definition facets)
+        inferred (select-keys inferred-use facets)]
+    (when-not (= defined inferred)
+      (throw (ex-info "parallel equation use is incompatible with its defining value"
+                      {:reason :parallel-program-use-type-conflict
+                       :id id :definition defined :use inferred}))))
+  definition)
+
+(defn- build-program
+  [source lowered-equations declined device-id dtype]
+  (let [{:keys [equations values]}
+        (reduce
+         (fn [{:keys [environment] :as state}
+              {:keys [equation operand-values result-values]}]
+           (let [source-results (:results equation)
+                 operands (mapv #(get environment % %) (:operands equation))
+                 ;; Source binders and pre-existing buffers may share a spelling in imperative IR.
+                 ;; Give equation results their own SSA-like IDs so a scalar binding can never
+                 ;; collide with an array operand of the same name.
+                 results (mapv (fn [source-id] [:binding source-id]) source-results)
+                 values-with-operands
+                 (reduce (fn [values [source-id value-id]]
+                           ;; A mapped operand already has the defining equation's authoritative
+                           ;; contract. Only infer contracts for external program inputs here.
+                           (if-let [definition (get values value-id)]
+                             (do (ensure-use-compatible! value-id definition
+                                                         (get operand-values source-id))
+                                 values)
+                             (merge-values values {value-id (get operand-values source-id)})))
+                         (:values state)
+                         (map vector (:operands equation) operands))
+                 values-with-results
+                 (reduce (fn [values [source-id value-id]]
+                           (merge-values values {value-id (get result-values source-id)}))
+                         values-with-operands
+                         (map vector source-results results))
+                 equation' (-> equation
+                               (assoc :operands operands :results results)
+                               (update :attributes assoc :source-results source-results))]
+             (-> state
+                 (assoc :values values-with-results)
+                 (update :equations conj equation')
+                 (update :environment into (map vector source-results results)))))
+         {:environment {} :values {} :equations []}
+         lowered-equations)
+        result-ids (set (mapcat :results equations))
+        operand-ids (set (mapcat :operands equations))
+        inputs (->> (set/difference operand-ids result-ids) (sort-by str) vec)
+        outputs (->> equations (mapcat :results) distinct vec)
+        effects (reduce set/union #{} (map :effects equations))]
+    (program/make
+     {:dialect :segop
+      :source source
+      :values values
+      :inputs inputs
+      :equations equations
+      :outputs outputs
+      :effects effects
+      :diagnostics declined
+      :provenance {:pass :segop-lower :device (or device-id :cpu:0) :dtype (or dtype :double)}
+      :attributes {:host-control :source-expression}})))
 
 (defn segop-lower-pass
   "Pipeline pass: convert par forms in let* bindings to SegOp records.
 
-   Walks the form's let* bindings. For each par/map!, par/reduce, par/scan!
-   binding, converts to SegOp and attaches as metadata on the binding symbol.
+   Walks the form's let* bindings. For each par/map!, par/reduce, par/scan! binding, converts to a
+   typed ProgramEquation containing ordered SegOps. The returned `:form` is a ParallelProgram;
+   its `:source` is the undecorated host expression consumed around those equations.
 
    Scan decomposition additionally records one verified KernelGraph with its intermediate buffers
    and dependencies. Returns both `:segops-lowered` and `:kernel-graphs-lowered` stats.
@@ -121,7 +236,8 @@
      :dtype — element type (:double or :float)"
   [form opts]
   (if-not (form/binding-form? form)
-    {:form form :stats {:segops-lowered 0 :kernel-graphs-lowered 0}}
+    {:form (build-program form [] [] (:target-device opts) (:dtype opts))
+     :stats {:segops-lowered 0 :kernel-graphs-lowered 0}}
     (let [[let-sym bindings-vec & body-exprs] form
           pairs (partition 2 bindings-vec)
           device-id (:target-device opts)
@@ -137,29 +253,28 @@
                     (let [r (lower-attempt sym init device-id dtype array-types)]
                       (when-let [d (:declined r)] (swap! declined conj d))
                       (when (:segops r) r)))
-          ;; Annotate bindings with SegOp metadata
-          new-pairs
-          (mapv (fn [[sym init]]
-                  (if-let [lowered-values (attempt sym init)]
-                    (do (swap! lowered inc)
-                        (when (:kernel-graph lowered-values) (swap! graphs-lowered inc))
-                        [(annotate-binding sym lowered-values) init])
-                    [sym init]))
-                pairs)
+          binding-equations
+          (keep-indexed
+           (fn [idx [sym init]]
+             (when-let [lowered-values (attempt sym init)]
+               (swap! lowered inc)
+               (when (:kernel-graph lowered-values) (swap! graphs-lowered inc))
+               (equation idx [:binding sym] sym init lowered-values dtype array-types)))
+           pairs)
           ;; Also check body expressions for par forms
-          new-body
-          (mapv (fn [expr]
-                  (let [tmp-sym (gensym "body_par_")]
-                    (if-let [{:keys [segops kernel-graph]} (attempt tmp-sym expr)]
-                      (do (swap! lowered inc)
-                          (when kernel-graph (swap! graphs-lowered inc))
-                          (with-meta (list 'do expr)
-                            (cond-> {::body-segops segops}
-                              kernel-graph (assoc ::body-kernel-graph kernel-graph))))
-                      expr)))
-                body-exprs)
-          new-bindings (vec (mapcat identity new-pairs))]
-      {:form (list* let-sym new-bindings new-body)
+          body-equations
+          (keep-indexed
+           (fn [idx expr]
+             (let [tmp-sym (symbol (str "body_parallel_" idx))]
+               (when-let [lowered-values (attempt tmp-sym expr)]
+                 (swap! lowered inc)
+                 (when (:kernel-graph lowered-values) (swap! graphs-lowered inc))
+                 (equation (+ (count pairs) idx) [:body idx] tmp-sym expr
+                           lowered-values dtype array-types))))
+           body-exprs)
+          equations (vec (concat binding-equations body-equations))]
+      {:form (build-program (list* let-sym bindings-vec body-exprs)
+                            equations @declined device-id dtype)
        :stats (cond-> {:segops-lowered @lowered
                        :kernel-graphs-lowered @graphs-lowered}
                 (seq @declined) (assoc :segops-declined @declined))})))

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -32,6 +32,7 @@
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.backend.jvm.par-simd :as par-simd]
             [raster.compiler.backend.wasm.emit :as wasm-emit]
             [raster.compiler.backend.intrinsics :as ix]
@@ -850,9 +851,8 @@
   (materialize/materialize-pass form opts))
 
 (defn- pass-segop-lower
-  "Lower par forms to SegOp records via SOAC intermediate.
-  SegOp records are attached as metadata on binding symbols.
-  (=> :materialized :segop-lowered)"
+  "Lower par forms to typed equations in a first-class SegOp ParallelProgram.
+  (=> :compound-detected :segop-lowered)"
   [form opts]
   (segop-lower/segop-lower-pass form opts))
 
@@ -867,12 +867,14 @@
   "Replace compound-kernel markers with their original dotimes form.
   Used by non-GPU backends (SIMD, scalar) that don't process compound markers."
   [form]
-  (walk/postwalk
-   (fn [f]
-     (if (and (seq? f) (= 'raster.compiler/compound-kernel (first f)))
-       (nth f 2)  ;; (compound-kernel metadata original-dotimes) → original-dotimes
-       f))
-   form))
+  (if (parallel-program/parallel-program? form)
+    (assoc form :source (strip-compound-markers (:source form)))
+    (walk/postwalk
+     (fn [f]
+       (if (and (seq? f) (= 'raster.compiler/compound-kernel (first f)))
+         (nth f 2)  ;; (compound-kernel metadata original-dotimes) → original-dotimes
+         f))
+     form)))
 
 (defn- pass-backend
   "Backend-specific optimization. Dispatches to SIMD, CUDA, OpenCL, or scalar.
@@ -884,7 +886,9 @@
       ;; CPU-C SIMD path: leave par/map!/par/reduce forms INTACT (neither scalarize
       ;; nor JVM-Vector-API lower) so the monolithic C backend can consume the same
       ;; SegRed/SegMap the JVM path builds, but emit __m256 intrinsics instead.
-      {:form (strip-compound-markers form) :stats nil :backend :par-preserve}
+      {:form (let [clean (strip-compound-markers form)]
+               (if (parallel-program/parallel-program? clean) (:source clean) clean))
+       :stats nil :backend :par-preserve}
       (case (device/select-runtime-backend target-device simd? nil)
         :cuda
         (throw (ex-info "CUDA backend not yet reimplemented (use :opencl)" {:target target-device}))
@@ -911,7 +915,9 @@
           {:form form :stats stats :backend :simd})
 
       ;; :scalar
-        {:form (par/expand-par-forms (strip-compound-markers form)) :stats nil :backend :scalar}))))
+        (let [clean (strip-compound-markers form)
+              source (if (parallel-program/parallel-program? clean) (:source clean) clean)]
+          {:form (par/expand-par-forms source) :stats nil :backend :scalar})))))
 
 (defn- pass-resolve-alength
   "Resolve (alength hoistable-buf) to original allocation size.
@@ -954,9 +960,12 @@
    :write-read-fuse  {:from :loop-lifted       :to :write-read-fused  :fn pass-write-read-fuse}
    :soac-fuse        {:from :write-read-fused  :to :soac-fused        :fn pass-soac-fuse}
    :materialize      {:from :soac-fused        :to :materialized      :fn pass-materialize}
-   :segop-lower      {:from :materialized      :to :segop-lowered     :fn pass-segop-lower}
-   :compound-detect  {:from :segop-lowered     :to :compound-detected :fn pass-compound-detect}
-   :backend          {:from :compound-detected :to :backend-applied   :fn pass-backend}
+   ;; Compound recognition still consumes the host/SOAC expression. SegOp conversion is the final
+   ;; middle-end boundary immediately before backend consumption, so no S-expression pass needs to
+   ;; tunnel scheduled operations through metadata.
+   :compound-detect  {:from :materialized      :to :compound-detected :fn pass-compound-detect}
+   :segop-lower      {:from :compound-detected :to :segop-lowered     :fn pass-segop-lower}
+   :backend          {:from :segop-lowered     :to :backend-applied   :fn pass-backend}
    :resolve-alength  {:from :backend-applied   :to :alength-resolved  :fn pass-resolve-alength}
    :mem-merge        {:from :alength-resolved  :to :mem-merged        :fn pass-mem-merge}
    ;; Building blocks for custom/GPU pipelines
@@ -1005,12 +1014,12 @@
 ;; ================================================================
 
 (def forward-passes
-  "Forward: lower → fixpoint → DCE → buffer-fuse → late-cleanup → loop-lift → write-read-fuse → soac-fuse → segop-lower → compound-detect → backend → resolve-alength → mem-merge.
+  "Forward: lower → fixpoint → DCE → buffer-fuse → late-cleanup → loop-lift → write-read-fuse → soac-fuse → compound-detect → segop-lower → backend → resolve-alength → mem-merge.
    fixpoint loops expand+normalize+rewalk until stable, handling composable AD inlining.
    loop-lift recovers par structure from dotimes/loop forms (e.g. SGD inlined to dotimes).
    write-read-fuse eliminates intermediate buffers by fusing 2D producers into 1D consumers (dW+SGD).
-   segop-lower converts par forms to SegOp IR for unified backend consumption."
-  [:lower :structured-reduction-fuse :fixpoint :dce :buffer-fuse :late-cleanup :loop-lift :write-read-fuse :soac-fuse :materialize :segop-lower :compound-detect :backend :resolve-alength :mem-merge])
+   segop-lower converts par forms to a typed SegOp ParallelProgram for unified backend consumption."
+  [:lower :structured-reduction-fuse :fixpoint :dce :buffer-fuse :late-cleanup :loop-lift :write-read-fuse :soac-fuse :materialize :compound-detect :segop-lower :backend :resolve-alength :mem-merge])
 
 (def gpu-resident-pre-soa-passes
   "forward-passes up to (and including) :materialize. The resident GPU path splits here so
@@ -1020,8 +1029,8 @@
   [:lower :structured-reduction-fuse :fixpoint :dce :buffer-fuse :late-cleanup :loop-lift :write-read-fuse :soac-fuse :materialize])
 
 (def gpu-resident-post-soa-passes
-  "forward-passes from :segop-lower onward — resumed (from :materialized) after soa-lower."
-  [:segop-lower :compound-detect :backend :resolve-alength :mem-merge])
+  "forward-passes from :compound-detect onward — resumed (from :materialized) after soa-lower."
+  [:compound-detect :segop-lower :backend :resolve-alength :mem-merge])
 
 ;; ================================================================
 ;; Diagnostic runner for show-pipeline

--- a/test/raster/compiler/contract_soac_node_test.clj
+++ b/test/raster/compiler/contract_soac_node_test.clj
@@ -20,14 +20,15 @@
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.segop-lower-pass :as slp]
+            [raster.compiler.ir.parallel-program :as program]
             [raster.compiler.backend.gpu.opencl-pass :as op]
             [raster.compiler.pipeline :as pl]
             [raster.linalg.contract]))
 
 (def ^:private cform
   '(raster.par/contract C [[i 128] [j 128]] [[l 128]]
-     (raster.numeric/* (clojure.core/aget A (clojure.core/+ (clojure.core/* i 128) l))
-                       (clojure.core/aget B (clojure.core/+ (clojure.core/* l 128) j)))))
+                        (raster.numeric/* (clojure.core/aget A (clojure.core/+ (clojure.core/* i 128) l))
+                                          (clojure.core/aget B (clojure.core/+ (clojure.core/* l 128) j)))))
 (def ^:private bound (list 'let* ['c cform] 'c))
 
 (deftest a-contraction-is-a-soac-node-carrying-its-facts
@@ -50,7 +51,9 @@
 
 (deftest segop-lower-records-a-segcontract-instead-of-declining
   (let [r (slp/segop-lower-pass bound {:target-device :ze:0 :dtype :double})
-        so (slp/get-segops (first (second (:form r))))]
+        p (:form r)
+        source (second (second bound))
+        so (program/operations-for-binding p 'c source)]
     (is (= 1 (:segops-lowered (:stats r))))
     (is (empty? (:segops-declined (:stats r))) "was {:reason :no-lowering-rule}")
     (is (instance? raster.compiler.ir.segop.SegContract (first so)))

--- a/test/raster/compiler/explain_pipeline_truth_test.clj
+++ b/test/raster/compiler/explain_pipeline_truth_test.clj
@@ -3,9 +3,8 @@
    pins the four ways the tool lied before Phase 0:
 
      * it reported the HOST CPU as 'Hardware:' for a :ze:0 compile;
-     * a metadata-only pass (segop-lower recording a decline) left the form `=` to the previous
-       stage, and the `[unchanged]` short-circuit dropped its stats — hiding the diagnostic exactly
-       when it existed;
+     * the former metadata-only segop pass could leave the form `=` to the previous stage, and the
+       `[unchanged]` short-circuit dropped its stats — hiding the diagnostic exactly when it existed;
      * three live passes had no label and fell out of a hand-maintained table that carried three
        dead ones — a fourth disagreeing description of the pipeline, in the tool meant to be the
        truth;
@@ -48,9 +47,8 @@
   (if-not @gp/gpu-available?
     (gp/gpu-skip! "explain-pipeline: declines")
     (let [s (explain #'raster.linalg.contract/contract-mm :target-device :ze:0)]
-      (testing "segop-lower RECORDS the contraction as a SegContract (Phase 1c made it a SOAC
-                node; this stage used to print a decline). A metadata-only pass leaves the form
-                unchanged, and the stage must still print its stats instead of collapsing"
+      (testing "segop-lower records the contraction as a first-class SegContract equation; this
+                stage used to print a decline, and its stats must remain visible"
         (is (re-find #":segops-lowered 1" s))
         (is (not (re-find #"DECLINED a conversion" s)) "nothing declines any more"))
       (testing "the kernel section names the leaf, the headline reason, and every leaf that refused"

--- a/test/raster/compiler/ir/parallel_program_test.clj
+++ b/test/raster/compiler/ir/parallel_program_test.clj
@@ -1,0 +1,47 @@
+(ns raster.compiler.ir.parallel-program-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.parallel-program :as program]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]))
+
+(def ^:private reduce-source
+  '(raster.par/reduce acc 0.0 i n (clojure.core/+ acc (clojure.core/aget values i))))
+
+(defn- lowered-program []
+  (:form (segop-lower/segop-lower-pass (list 'let* ['total reduce-source] 'total)
+                                       {:target-device :cpu:0 :dtype :double
+                                        :array-types {'values :double}})))
+
+(deftest segops-are-first-class-typed-equations
+  (let [p (lowered-program)
+        equation (first (:equations p))]
+    (is (program/parallel-program? p))
+    (is (= :segop (:dialect p)))
+    (is (= [:binding 'total] (:site equation)))
+    (is (= ['n 'values] (:inputs p)))
+    (is (= [[:binding 'total]] (:outputs p)))
+    (is (= [reduce-source] (mapv :source (:equations p))))
+    (is (every? av/abstract-value? (vals (:values p))))
+    (is (= ['?] (:shape (get (:values p) 'values))))
+    (is (= [] (:shape (get (:values p) [:binding 'total]))))
+    (is (seq (:operations equation)))
+    (testing "the source binder is ordinary Clojure data, not an IR side channel"
+      (is (nil? (meta (first (second (:source p)))))))))
+
+(deftest equation-consumption-is-invalidated-by-a-source-rewrite
+  (let [p (lowered-program)]
+    (is (seq (program/operations-for-binding p 'total reduce-source)))
+    (is (nil? (program/operations-for-binding
+               p 'total
+               '(raster.par/reduce acc 1.0 i n
+                                   (clojure.core/+ acc (clojure.core/aget values i))))))))
+
+(deftest dialect-validation-is-a-full-conversion
+  (let [p (lowered-program)]
+    (try
+      (program/validate! p (constantly false))
+      (is false "an illegal remaining operation must fail validation")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :illegal-op-remains (:reason (ex-data e))))
+        (is (= :segop (:target-dialect (ex-data e))))
+        (is (= :none (:fallback (ex-data e))))))))

--- a/test/raster/compiler/ir/segop_test.clj
+++ b/test/raster/compiler/ir/segop_test.clj
@@ -39,6 +39,9 @@
                                   #{'a} #{'out} #{} grid
                                   :double 'out nil)]
       (is (segop/segop? seg-map))
+      (is (segop/segop-node? (segop/->SegContract 1 {} :double :ze:0)))
+      (is (not (segop/segop? (segop/->SegContract 1 {} :double :ze:0)))
+          "a contract is legal SegOp dialect input but not yet a scheduled KernelGraph operation")
       (is (not (segop/segop? {:not "a segop"}))))))
 
 ;; ================================================================

--- a/test/raster/compiler/segop_boundary_test.clj
+++ b/test/raster/compiler/segop_boundary_test.clj
@@ -19,6 +19,7 @@
    operation with no alternate emitter."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.kernel-graph :as kernel-graph]
+            [raster.compiler.ir.parallel-program :as program]
             [raster.compiler.passes.parallel.segop-lower-pass :as slp]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
             [raster.compiler.ir.soac :as soac]))
@@ -46,8 +47,10 @@
                                            (+ acc (aget values i)))]
                   result)
            {})
-        binding (first (second (:form r)))
-        scheduled (slp/get-kernel-graph binding)]
+        p (:form r)
+        scheduled (program/kernel-graph-for-binding
+                   p 'result '(raster.par/scan out acc 0.0 i n double
+                                               (+ acc (aget values i))))]
     (is (= 1 (get-in r [:stats :segops-lowered])))
     (is (= 1 (get-in r [:stats :kernel-graphs-lowered])))
     (is (kernel-graph/kernel-graph? scheduled))
@@ -66,7 +69,7 @@
     (is (zero? (get-in r [:stats :kernel-graphs-lowered])))
     (is (= :segop (:stage d)))
     (is (= :scan-not-associative (:reason d)))
-    (is (= :no-segop-metadata-backend-lowers-or-uses-legacy-codegen (:fallback d)))))
+    (is (= :backend-relowers-or-uses-specialized-codegen (:fallback d)))))
 
 (deftest an-unrepresentable-par-form-becomes-a-diagnostic
   (testing "a par form with no lowering rule is the case that used to vanish onto stderr"

--- a/test/raster/compiler/segop_consumption_test.clj
+++ b/test/raster/compiler/segop_consumption_test.clj
@@ -2,11 +2,9 @@
   "THE SEGOP BOUNDARY IS REAL: GPU and JVM SIMD backends CONSUME what segop-lower computed.
    Device-free.
 
-   `segop-lower` lowered every par form with the real target device and attached the SegOp to
-   the binder symbol as `::segops`. Nothing read it (north-star §2.1: 'the pass arrows are nominal
-   at the most important boundary'). `opencl-pass` re-lowered each form from scratch with `:ze:0`
-   HARDCODED — ignoring both the stored result and its own `device-id`. Two lowerings of one form,
-   one of them on the wrong device, and no way to tell which a kernel came from.
+   `segop-lower` lowers every par form with the real target device into a first-class typed equation.
+   `opencl-pass` used to re-lower each form from scratch with `:ze:0` hardcoded. The equation is now
+   consumed directly, with no binder metadata and no second lowering.
 
    Now the stored SegOp is consumed; re-lowering is the fallback, with the real device-id, and
    both paths are COUNTED (`:segop-reused` / `:segop-relowered`) so a form that bypasses the
@@ -65,12 +63,11 @@
       (is (= [:ze:1] @calls) (str "lower-soac was called with " @calls ", not the pass's device-id")))))
 
 (deftest a-body-position-form-is-consumed-too
-  (testing "segop-lower wraps a body-position par form in (do …) carrying ::body-segops; that
-            must be consumed exactly like a binding's ::segops"
+  (testing "a body-position equation is consumed exactly like a binding equation"
     (let [form '(let* [n 8192] (raster.par/map! O i n nil (clojure.core/* (clojure.core/aget X i) 2.0)))
           st (:stats (run (lowered form)))]
       (is (= 1 (:ze-maps st)))
-      (is (= 1 (:segop-reused st)) "consumed from ::body-segops")
+      (is (= 1 (:segop-reused st)) "consumed from the first-class equation")
       (is (nil? (:segop-relowered st))))))
 
 (deftest jvm-simd-consumes-the-boundary-too


### PR DESCRIPTION
## Summary
- introduce a typed ParallelProgram with ordered equations, SSA-like result IDs, effects, diagnostics, and provenance
- replace binder/body SegOp metadata with explicit GPU and JVM program consumption
- validate the SegOp stage as a full operation conversion and keep source-equality invalidation for backend-local rewrites
- run compound detection before the new program boundary and document the remaining SOAC/kernel-body work

## Verification
- cold targeted gate: 102 tests, 385 assertions, 0 failures/errors
- follow-up cold SIMD/pipeline gate: 23 tests, 82 assertions, 0 failures/errors
- git diff --check