### PR TITLE
Formalize inactive paged append lanes

### DIFF
--- a/src/raster/compiler/ir/paged_kv_append.clj
+++ b/src/raster/compiler/ir/paged_kv_append.clj
@@ -1,8 +1,9 @@
 (ns raster.compiler.ir.paged-kv-append
   "Backend-neutral assignment of projected K/V rows into physical cache slots.
 
-  The operation is deliberately narrower than scatter-add: every batch lane
-  names one unique physical slot and overwrites its complete key and value rows.
+  The operation is deliberately narrower than scatter-add: every active batch
+  lane names one unique physical slot and overwrites its complete key and value
+  rows. Slot -1 marks an inactive lane and performs no write.
   Page allocation and reservation remain runtime responsibilities; this IR owns
   only checked tensor geometry, dtype conversion semantics, and write effects."
   (:require [raster.compiler.core.dtype :as dtype]))
@@ -131,9 +132,11 @@
 (defn validate-slot-values!
   "Validate one host-visible physical slot vector and return it unchanged.
 
-  Slots must be unique because assignment has no atomic conflict resolution.
-  This check belongs before descriptor upload; the device kernel separately
-  bounds-checks slots so corrupted descriptor memory cannot overwrite pages."
+  Active slots must be unique because assignment has no atomic conflict
+  resolution. `-1` is the inactive-lane sentinel and may occur repeatedly. This
+  check belongs before descriptor upload; the device kernel separately ignores
+  negative slots and bounds-checks active ones so corrupted descriptor memory
+  cannot overwrite pages."
   [problem slots]
   (let [{:keys [batch-size]} (validate! problem)
         capacity (physical-slots problem)
@@ -142,10 +145,11 @@
       (throw (ex-info "Paged K/V append slot vector has the wrong lane count"
                       {:expected batch-size :actual (count values)})))
     (doseq [[lane slot] (map-indexed vector values)]
-      (when-not (and (integer? slot) (<= 0 (long slot)) (< (long slot) capacity))
+      (when-not (and (integer? slot) (<= -1 (long slot)) (< (long slot) capacity))
         (throw (ex-info "Paged K/V append slot is outside the physical pool"
                         {:lane lane :slot slot :physical-slots capacity}))))
-    (when-not (= (count values) (count (set values)))
-      (throw (ex-info "Paged K/V append requires unique destination slots"
-                      {:slots values})))
+    (let [active (remove #(= -1 (long %)) values)]
+      (when-not (= (count active) (count (set active)))
+        (throw (ex-info "Paged K/V append requires unique destination slots"
+                        {:slots values}))))
     slots))

--- a/test/raster/compiler/passes/parallel/paged_kv_append_route_test.clj
+++ b/test/raster/compiler/passes/parallel/paged_kv_append_route_test.clj
@@ -30,11 +30,15 @@
     (is (= {:dtype :half :elements 160 :role :inout} (get specs 'key-pages)))
     (is (= {:dtype :half :elements 120 :role :inout} (get specs 'value-pages)))))
 
-(deftest slot-values-must-be-unique-and-in-bounds
+(deftest active-slot-values-must-be-unique-and-in-bounds
   (let [value (problem)]
     (is (= [19 0 7] (append/validate-slot-values! value [19 0 7])))
+    (is (= [-1 -1 7] (append/validate-slot-values! value [-1 -1 7]))
+        "inactive lanes may share the no-write sentinel")
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"unique destination"
                           (append/validate-slot-values! value [1 1 2])))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"outside the physical pool"
+                          (append/validate-slot-values! value [1 -2 2])))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"outside the physical pool"
                           (append/validate-slot-values! value [1 2 20])))))
 
@@ -44,6 +48,7 @@
     (is (= :fp32-to-fp16-reference strategy))
     (is (str/includes? source "key_pages[dst] = convert_half_rte(key_rows[src]);"))
     (is (str/includes? source "value_pages[dst] = convert_half_rte(value_rows[src]);"))
+    (is (str/includes? source "if (slot < 0"))
     (is (not (str/includes? source "atomic")))
     (is (= ['key-rows 'value-rows 'slots 'key-pages 'value-pages]
            (:arguments artifact)))

--- a/test/raster/gpu/paged_kv_append_device_test.clj
+++ b/test/raster/gpu/paged_kv_append_device_test.clj
@@ -30,7 +30,7 @@
         physical-slots (* page-size physical-pages)
         key-rows (float-array [1.1 -2.2 3.3 -4.4, 5.5 -6.6 7.7 -8.8])
         value-rows (float-array [0.25 -0.5 0.75, 1.25 -1.5 1.75])
-        slots (int-array [5 1])
+        slots (int-array [5 -1])
         sentinel (half-bits 42.0)
         key-pages (short-array (repeat (* physical-slots key-width) sentinel))
         value-pages (short-array (repeat (* physical-slots value-width) sentinel))
@@ -64,7 +64,7 @@
             (doseq [slot (range physical-slots)
                     component (range key-width)]
               (let [index (+ (* slot key-width) component)
-                    lane ({5 0, 1 1} slot)
+                    lane ({5 0} slot)
                     expected (if lane
                                (half-bits (aget key-rows (+ (* lane key-width) component)))
                                sentinel)]
@@ -72,7 +72,7 @@
             (doseq [slot (range physical-slots)
                     component (range value-width)]
               (let [index (+ (* slot value-width) component)
-                    lane ({5 0, 1 1} slot)
+                    lane ({5 0} slot)
                     expected (if lane
                                (half-bits (aget value-rows (+ (* lane value-width) component)))
                                sentinel)]


### PR DESCRIPTION
## Summary

- define physical slot -1 as the no-write sentinel for inactive batch lanes
- require uniqueness only among active append destinations
- retain device-side bounds protection for malformed descriptors
- verify inactive lanes leave every K/V page byte unchanged on OpenCL

This makes fixed-capacity paged graphs safe for scheduler lane refill without dummy continuations or wasted KV pages.

## Validation

Focused IR and Level Zero/OpenCL device suite: 6 tests, 108 assertions, zero failures or errors.