### PR TITLE
Make typed product reductions first class

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -154,13 +154,16 @@ kernel remains available for already padded layouts. Padding is layout, not quan
 memory ownership.
 
 Decoder selection is likewise an ordinary indexed row reduction, not an attention or quantization
-primitive. Its first portable schedule reduces parallel 256-element tiles into compiler-owned
-structure-of-arrays `(value,index)` scratch and then merges those products per row. The semantic ABI
+primitive. Scalar reduction is now the one-component case of a canonical typed `ProductReduction`;
+multi-result reductions carry ordered, independently typed components plus distinct element and
+closed binary-combine regions. The first portable `ReductionSchedule` maps a segmented product to
+strided lane folds, a fixed workgroup-local tree and segment stores. Its workgroup is constrained by
+the target thread limit and the sum of every component's local-memory width, while numerical mode
+and tuning candidates remain inspectable data. `argmax-rows!` therefore emits one mixed-type
+`(value,index)` workgroup tree per row with no compiler-visible global scratch. The semantic ABI
 contains only values, output indices, row count and width; ties select the lowest index, and the first
-NaN outranks numeric values so corruption is visible and deterministic. This slice deliberately
-exposes the next general IR requirement: `SegRed` needs typed product/tuple accumulators and a
-workgroup/subgroup schedule. Once that exists, the general scheduled reduction should subsume the
-two-map implementation and lower to target-local shared/shuffle reductions without changing callers.
+NaN outranks numeric values so corruption is visible and deterministic. Subgroup/shuffle and
+multi-workgroup alternatives remain schedule candidates, not new semantic primitives.
 
 Row selection remains a separate generic operation. `gather-rows!` consumes shared row-major source
 storage and `int[B]` indices, writes caller-owned dense `[B,width]` output, and maps every output

--- a/src/raster/compiler/backend/cpu/aot.clj
+++ b/src/raster/compiler/backend/cpu/aot.clj
@@ -47,7 +47,7 @@
     (let [pi  (par/extract-par-reduce-info form)
           dt  (or (:elem-type pi) dtype)
           sym (gensym "red_")
-          sc  (soac/par-form->soac sym form (swap! segop-id inc))]
+          sc  (soac/par-form->soac sym form (swap! segop-id inc) :dtype dt)]
       (first (soac-lower/lower-soac sc :cpu:0 :dtype dt)))
     (catch Exception _ nil)))
 
@@ -421,7 +421,7 @@
         ;; zero-init (= {0}) preserves Clojure array semantics (heap arrays are zeroed);
         ;; clang elides it when the array is fully written before read.
         local-decls (apply str (for [[s size elem] local-buffers]
-                                  (str (elem->ctype elem "double") " " (ce/c-symbol s) "[" size "] = {0};\n  ")))
+                                 (str (elem->ctype elem "double") " " (ce/c-symbol s) "[" size "] = {0};\n  ")))
         ;; array params that the body writes (aset target) are in-place OUTPUT params —
         ;; emit them non-const; read-only input arrays stay const.
         written (written-array-syms stripped)

--- a/src/raster/compiler/backend/cpu/csimd.clj
+++ b/src/raster/compiler/backend/cpu/csimd.clj
@@ -20,6 +20,7 @@
             [raster.compiler.backend.gpu.c-emit :as ce]
             [raster.compiler.core.hardware :as hw]
             [raster.compiler.core.util :as util]
+            [raster.compiler.ir.segop :as segop]
             [clojure.string :as str]
             [clojure.walk :as walk]))
 
@@ -97,7 +98,7 @@
   [segred]
   (let [idx   (ss/seg-idx segred)
         bound (ss/seg-bound segred)
-        {:keys [acc init lambda]} (:reduce-op segred)
+        {:keys [acc init lambda]} (segop/scalar-reduce-op segred)
         lambda (when lambda (ss/normalize-invk (ss/clean-dead-bindings lambda)))]
     (when (and acc init idx bound (seq? lambda) (>= (count lambda) 3))
       (let [op   (first lambda)
@@ -270,58 +271,58 @@
   ([segred isa array-syms] (compile-segred-c segred isa array-syms nil))
   ([segred isa array-syms target]
    (when-let [{:keys [idx bound acc init elem-expr factors]} (reduction-plan segred)]
-    (let [acc (ce/c-symbol (or target acc))
-          elem (vt-of (:dtype segred))
-          ti   (in/simd-type-info isa elem)
-          vadd (in/simd-op isa :+ elem)
-          vfma (in/simd-op isa :fma elem)]
-      (when (and ti vadd (or (nil? factors) vfma))
-        (let [vt    (:vtype ti)
-              lanes (:lanes ti)
-              nacc  (n-accumulators elem)
-              stride (* nacc lanes)
-              accs  (mapv #(str "va" %) (range nacc))
-              n-c   (ce/emit-expr bound nil array-syms "idx")
-              hsum  (hsum-fn elem)
+     (let [acc (ce/c-symbol (or target acc))
+           elem (vt-of (:dtype segred))
+           ti   (in/simd-type-info isa elem)
+           vadd (in/simd-op isa :+ elem)
+           vfma (in/simd-op isa :fma elem)]
+       (when (and ti vadd (or (nil? factors) vfma))
+         (let [vt    (:vtype ti)
+               lanes (:lanes ti)
+               nacc  (n-accumulators elem)
+               stride (* nacc lanes)
+               accs  (mapv #(str "va" %) (range nacc))
+               n-c   (ce/emit-expr bound nil array-syms "idx")
+               hsum  (hsum-fn elem)
               ;; per-accumulator lane-block offset: k*lanes (k=0 → "0")
-              blk   (fn [k] (str (* k lanes)))
+               blk   (fn [k] (str (* k lanes)))
               ;; main loop body: nacc independent FMA/mul-add accumulations
-              step  (str/join
-                     "\n    "
-                     (for [k (range nacc)]
-                       (if factors
-                         (let [[f1 f2] factors
-                               [a1 b1] (ss/aget-form? f1 idx)
-                               [a2 b2] (ss/aget-form? f2 idx)]
-                           (str (accs k) " = " vfma "("
-                                (vec-load ti a1 b1 "j" (blk k) array-syms) ", "
-                                (vec-load ti a2 b2 "j" (blk k) array-syms) ", "
-                                (accs k) ");"))
-                         ;; non-fused: elem is a single affine load → add
-                         (let [[a b] (ss/aget-form? elem-expr idx)]
-                           (str (accs k) " = " vadd "(" (accs k) ", "
-                                (vec-load ti a b "j" (blk k) array-syms) ");")))))
-              ;; combine accumulators pairwise via vadd
-              combine (reduce (fn [a b] (str vadd "(" a ", " b ")")) accs)
-              ;; scalar tail element at counter j
-              tail-elem (if factors
+               step  (str/join
+                      "\n    "
+                      (for [k (range nacc)]
+                        (if factors
                           (let [[f1 f2] factors
                                 [a1 b1] (ss/aget-form? f1 idx)
                                 [a2 b2] (ss/aget-form? f2 idx)]
-                            (str (scalar-aget a1 b1 "j" array-syms) " * "
-                                 (scalar-aget a2 b2 "j" array-syms)))
+                            (str (accs k) " = " vfma "("
+                                 (vec-load ti a1 b1 "j" (blk k) array-syms) ", "
+                                 (vec-load ti a2 b2 "j" (blk k) array-syms) ", "
+                                 (accs k) ");"))
+                         ;; non-fused: elem is a single affine load → add
                           (let [[a b] (ss/aget-form? elem-expr idx)]
-                            (scalar-aget a b "j" array-syms)))]
-          {:includes simd-includes
-           :helpers  simd-helpers
-           :block
-           (str "{\n"
-                "  const int _n = " n-c ";\n"
-                (apply str (for [a accs] (str "  " vt " " a " = " (:setzero ti) "();\n")))
-                "  int j = 0;\n"
-                "  for (; j + " stride " <= _n; j += " stride ") {\n    "
-                step "\n  }\n"
-                "  " vt " _vc = " combine ";\n"
-                "  " acc " = (" init ") + " hsum "(_vc);\n"
-                "  for (; j < _n; j++) " acc " = " acc " + (" tail-elem ");\n"
-                "}")}))))))
+                            (str (accs k) " = " vadd "(" (accs k) ", "
+                                 (vec-load ti a b "j" (blk k) array-syms) ");")))))
+              ;; combine accumulators pairwise via vadd
+               combine (reduce (fn [a b] (str vadd "(" a ", " b ")")) accs)
+              ;; scalar tail element at counter j
+               tail-elem (if factors
+                           (let [[f1 f2] factors
+                                 [a1 b1] (ss/aget-form? f1 idx)
+                                 [a2 b2] (ss/aget-form? f2 idx)]
+                             (str (scalar-aget a1 b1 "j" array-syms) " * "
+                                  (scalar-aget a2 b2 "j" array-syms)))
+                           (let [[a b] (ss/aget-form? elem-expr idx)]
+                             (scalar-aget a b "j" array-syms)))]
+           {:includes simd-includes
+            :helpers  simd-helpers
+            :block
+            (str "{\n"
+                 "  const int _n = " n-c ";\n"
+                 (apply str (for [a accs] (str "  " vt " " a " = " (:setzero ti) "();\n")))
+                 "  int j = 0;\n"
+                 "  for (; j + " stride " <= _n; j += " stride ") {\n    "
+                 step "\n  }\n"
+                 "  " vt " _vc = " combine ";\n"
+                 "  " acc " = (" init ") + " hsum "(_vc);\n"
+                 "  for (; j < _n; j++) " acc " = " acc " + (" tail-elem ");\n"
+                 "}")}))))))

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -152,7 +152,8 @@
           (or (segop-attempt stats :segred form dtype :none
                              #(let [sym (gensym "red_")
                                     soac (raster.compiler.ir.soac/par-form->soac
-                                          sym form (swap! segop-id-counter inc))]
+                                          sym form (swap! segop-id-counter inc)
+                                          :dtype (or dtype :double))]
                                 (first (raster.compiler.passes.parallel.soac-lower/lower-soac
                                         soac (or device-id :ze:0) :dtype (or dtype :double)))))
               (let [decline (last (:segop-declined @stats))]
@@ -434,6 +435,15 @@
                               segred nil :dtype dtype :scalar-types top-scalar-types)
                       k (register-kernel! kernel :ze-reduces)]
                   (emit-reduction-invocation k nil))))
+
+            ;; Typed segmented product reduction. The portable schedule is one deterministic
+            ;; workgroup tree per segment; mixed result components remain separate ABI buffers.
+            (par/par-product-reduce-form? form)
+            (let [segred (par->segred stats form dtype device-id)
+                  kernel (segop-cl/generate-product-reduction-kernel
+                          segred :scalar-types top-scalar-types :array-types top-array-types)
+                  k (register-kernel! kernel :ze-reduces)]
+              (emit-map-void-invocation k))
 
             ;; === Specialized forms — delegate to legacy generators ===
 

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -22,6 +22,7 @@
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.ir.scan :as scan]
+            [raster.compiler.ir.reduction :as reduction]
             [clojure.walk :as walk]
             [clojure.set]
             [raster.compiler.ir.segop :as segop]
@@ -190,6 +191,202 @@
 ;; SegRed → OpenCL kernel (two-phase reduction)
 ;; ================================================================
 
+(defn- product-neutral-c
+  [neutral dtype]
+  (let [dtype (dt/canon dtype)
+        field (when (symbol? neutral) (name neutral))]
+    (cond
+      (and (contains? #{:float :double :half} dtype) (= "POSITIVE_INFINITY" field)) "INFINITY"
+      (and (contains? #{:float :double :half} dtype) (= "NEGATIVE_INFINITY" field)) "-INFINITY"
+      (and (= :int dtype) (= "MAX_VALUE" field)) "INT_MAX"
+      (and (= :int dtype) (= "MIN_VALUE" field)) "INT_MIN"
+      (and (= :long dtype) (= "MAX_VALUE" field)) "LONG_MAX"
+      (and (= :long dtype) (= "MIN_VALUE" field)) "LONG_MIN"
+      (and (number? neutral) (Double/isInfinite (double neutral)))
+      (if (pos? (double neutral)) "INFINITY" "-INFINITY")
+      (number? neutral) (case dtype
+                          :float (str (float neutral) "f")
+                          :double (str (double neutral))
+                          (str (long neutral)))
+      (and (seq? neutral) (= 2 (count neutral)))
+      (product-neutral-c (second neutral) dtype)
+      :else (throw (ex-info "product reduction neutral has no OpenCL literal"
+                            {:reason :product-reduction-neutral-not-emittable
+                             :neutral neutral :dtype dtype})))))
+
+(defn generate-product-reduction-kernel
+  "Lower a typed segmented ProductReduction to one deterministic workgroup tree per segment.
+
+   This is the portable scheduled body. Every lane folds a strided subset, then the declared
+   closed combine region merges lane products in a fixed tree. Mixed component dtypes share no
+   representation assumptions; each gets its own typed local array."
+  [segred & {:keys [kernel-name-prefix scalar-types array-types]
+             :or {kernel-name-prefix "product_reduce" scalar-types {} array-types {}}}]
+  (let [operator (reduction/validate! (:reduction segred))
+        schedule (reduction/validate-schedule! (:schedule segred))
+        _ (when-not (= :segmented-workgroup-tree (:strategy schedule))
+            (throw (ex-info "product reduction schedule has no OpenCL lowering"
+                            {:reason :product-reduction-schedule-not-emittable
+                             :strategy (:strategy schedule)})))
+        _ (when-not (true? (get-in operator [:algebra :associative?]))
+            (throw (ex-info "parallel product schedule requires an explicit associative algebra"
+                            {:reason :product-reduction-not-associative
+                             :algebra (:algebra operator)})))
+        components (:components operator)
+        element (reduction/element-region operator)
+        combine (reduction/combine-region operator)
+        space (:space segred)
+        segment-dims (segop/seg-space-segment-dims space)
+        reduced-dim (segop/seg-space-reduced-dim space)
+        idx (:name reduced-dim)
+        bound (:bound reduced-dim)
+        block-size (:workgroup-size schedule)
+        _ (when-not (and (pos-int? block-size) (zero? (bit-and block-size (dec block-size))))
+            (throw (ex-info "product reduction workgroup size must be a positive power of two"
+                            {:reason :product-reduction-workgroup :block-size block-size})))
+        num-segments (segop/seg-space-num-segments-expr space)
+        launch-segments (let [bounds (mapv :bound segment-dims)]
+                          (case (count bounds)
+                            0 1
+                            1 (klaunch/runtime-value (first bounds))
+                            (apply klaunch/product bounds)))
+        kernel-name (str kernel-name-prefix "_" (gensym ""))
+        input-params (vec (sort-by name (:inputs segred)))
+        output-params (vec (keep :result components))
+        output-dtypes (into {} (keep (fn [{:keys [result dtype]}]
+                                       (when result [result dtype]))) components)
+        bound-syms (reduce clojure.set/union #{}
+                           (map (comp util/free-syms :bound) (segop/seg-space-dims space)))
+        scalar-params (vec (sort-by name (clojure.set/union (:scalars segred) bound-syms)))
+        scalar-types (merge (into {} (map (fn [s] [s :int]) bound-syms)) scalar-types)
+        default-ctype (dt/ctype :opencl (or (:dtype segred) :float))
+        scalar-ctype #(ce/scalar-native-type % scalar-types default-ctype)
+        scalar-dtype (fn [s] (case (scalar-ctype s)
+                               "int" :int "long" :long "double" :double "float" :float))
+        input-dtype #(get array-types % (get array-types (symbol (name %)) (:dtype segred)))
+        input-ctype #(dt/ctype :opencl (input-dtype %))
+        component-ctype #(dt/ctype :opencl (:dtype %))
+        pointer-params
+        (concat
+         (map #(str "__global const " (input-ctype %) "* restrict " (ce/c-symbol %)) input-params)
+         (map #(str "__global " (dt/ctype :opencl (get output-dtypes %)) "* restrict "
+                    (ce/c-symbol %)) output-params))
+        scalar-param-decls (map #(str (scalar-ctype %) " " (ce/c-symbol %)) scalar-params)
+        all-params (str/join ", " (concat pointer-params scalar-param-decls ["int _n_bound"]))
+        array-syms (set (concat input-params output-params))
+        int-vars (into #{idx} (concat (map :name segment-dims)
+                                      (filter #(contains? #{:int :long} (scalar-dtype %)) scalar-params)))
+        emit-index-expr
+        (fn [expr]
+          (binding [ce/*emit-config* ce/opencl-config
+                    ce/*scalar-type* default-ctype
+                    ce/*idx-sym* idx
+                    ce/*int-vars* (into ce/*int-vars* int-vars)]
+            (ce/emit-expr expr idx array-syms (ce/c-symbol idx))))
+        bound-c (emit-index-expr bound)
+        emit-result
+        (fn [region result dtype substitutions]
+          (let [form (list 'let* (:bindings region) result)
+                form (util/subst-syms substitutions (ce/normalize-array-prims form))]
+            (binding [ce/*emit-config* ce/opencl-config
+                      ce/*scalar-type* (dt/ctype :opencl dtype)
+                      ce/*idx-sym* idx
+                      ce/*int-vars* (into ce/*int-vars* int-vars)]
+              (ce/emit-expr (ce/adapt-casts-for-dtype form dtype) idx array-syms (ce/c-symbol idx)))))
+        acc-names (mapv #(str "acc_" %) (range (count components)))
+        elem-names (mapv #(str "elem_" %) (range (count components)))
+        next-names (mapv #(str "next_" %) (range (count components)))
+        shared-names (mapv #(str "shared_" %) (range (count components)))
+        element-lines
+        (mapv (fn [component result elem-name]
+                (str (component-ctype component) " " elem-name " = "
+                     (emit-result element result (:dtype component) {}) ";"))
+              components (:results element) elem-names)
+        combine-lines
+        (fn [left-names right-names destination-names]
+          (let [substitutions
+                (into {}
+                      (mapcat (fn [[[left right] left-name right-name]]
+                                [[left (symbol left-name)] [right (symbol right-name)]])
+                              (map vector (:parameters combine) left-names right-names)))]
+            (mapv (fn [component result destination]
+                    (str (component-ctype component) " " destination " = "
+                         (emit-result combine result (:dtype component) substitutions) ";"))
+                  components (:results combine) destination-names)))
+        segment-decls
+        (loop [dims (reverse segment-dims) remaining "segment" lines []]
+          (if-let [{:keys [name bound]} (first dims)]
+            (let [cname (ce/c-symbol name)
+                  cbound (emit-index-expr bound)]
+              (recur (next dims) (str "(" remaining " / " cbound ")")
+                     (conj lines (str "int " cname " = " remaining " % " cbound ";"))))
+            (str/join "\n    " (reverse lines))))
+        initial-lines (mapv (fn [component acc-name]
+                              (str (component-ctype component) " " acc-name " = "
+                                   (product-neutral-c (:neutral component) (:dtype component)) ";"))
+                            components acc-names)
+        first-combine (combine-lines acc-names elem-names next-names)
+        assign-next (mapv #(str % " = " %2 ";") acc-names next-names)
+        shared-decls (mapv (fn [component shared]
+                             (str "__local " (component-ctype component) " " shared
+                                  "[" block-size "];"))
+                           components shared-names)
+        shared-store (mapv #(str % "[lid] = " %2 ";") shared-names acc-names)
+        tree-left (mapv #(str % "[lid]") shared-names)
+        tree-right (mapv #(str % "[lid + stride]") shared-names)
+        tree-next (mapv #(str "tree_next_" %) (range (count components)))
+        tree-combine (combine-lines tree-left tree-right tree-next)
+        tree-store (mapv #(str % "[lid] = " %2 ";") shared-names tree-next)
+        final-stores (mapv (fn [result shared]
+                             (str (ce/c-symbol result) "[segment] = " shared "[0];"))
+                           output-params
+                           (keep (fn [[component shared]] (when (:result component) shared))
+                                 (map vector components shared-names)))
+        source (str (apply codegen/extension-pragmas (distinct (concat (map :dtype components)
+                                                                       (map input-dtype input-params))))
+                    "__kernel void " kernel-name "(" all-params ") {\n"
+                    "    int segment = get_group_id(0);\n"
+                    "    if (segment >= _n_bound) return;\n"
+                    "    int lid = get_local_id(0);\n    " segment-decls "\n    "
+                    (str/join "\n    " shared-decls) "\n    "
+                    (str/join "\n    " initial-lines) "\n"
+                    "    for (int " (ce/c-symbol idx) " = lid; " (ce/c-symbol idx) " < "
+                    bound-c "; " (ce/c-symbol idx) " += " block-size ") {\n        "
+                    (str/join "\n        " element-lines) "\n        "
+                    (str/join "\n        " first-combine) "\n        "
+                    (str/join "\n        " assign-next) "\n    }\n    "
+                    (str/join "\n    " shared-store) "\n"
+                    "    barrier(CLK_LOCAL_MEM_FENCE);\n"
+                    "    for (int stride = " (/ block-size 2) "; stride > 0; stride >>= 1) {\n"
+                    "        if (lid < stride) {\n            "
+                    (str/join "\n            " tree-combine) "\n            "
+                    (str/join "\n            " tree-store) "\n        }\n"
+                    "        barrier(CLK_LOCAL_MEM_FENCE);\n    }\n"
+                    "    if (lid == 0) {\n        " (str/join "\n        " final-stores)
+                    "\n    }\n}\n")
+        abi (kabi/validate!
+             (vec (concat
+                   (map #(kabi/slot % :input (input-dtype %)
+                                    :c-name (ce/c-symbol %) :role :operand)
+                        input-params)
+                   (map #(kabi/slot % :output (get output-dtypes %)
+                                    :c-name (ce/c-symbol %) :role :effect)
+                        output-params)
+                   (map #(kabi/slot % :scalar (scalar-dtype %)
+                                    :c-name (ce/c-symbol %) :role :parameter)
+                        scalar-params)
+                   [(kabi/slot '_n_bound :scalar :int :c-name "_n_bound" :role :bound)])))
+        arguments (vec (concat input-params output-params scalar-params [num-segments]))]
+    (kart/make
+     {:kernel-name kernel-name :source source :abi abi :arguments arguments
+      :launch (klaunch/spec {:workgroup-size [block-size] :group-count [launch-segments]})
+      :temporaries [] :effects {:kind :product-reduction}
+      :provenance {:dialect :segred :segop-id (:id segred)}
+      :attributes {:array-params (vec (concat input-params output-params))
+                   :scalar-params scalar-params :written-arrays (set output-params)
+                   :component-dtypes (reduction/dtypes operator)
+                   :schedule schedule}})))
+
 (defn generate-segred-kernel
   "Generate OpenCL C reduction kernels from a SegRed record.
 
@@ -208,7 +405,7 @@
                      :or {dtype :double kernel-name-prefix "par_reduce" scalar-types {}}}]
   (let [idx (seg-idx segred)
         bound (seg-bound segred)
-        {:keys [acc init lambda]} (:reduce-op segred)
+        {:keys [acc init lambda]} (segop/scalar-reduce-op segred)
         ;; #55 fix: normalize devirtualized array prims ((.invk aget-impl arr i)
         ;; → canonical aget head) BEFORE any rewrapping, exactly as SegMap does.
         ;; Without it, a parametric-array kernel (qlinear-k) emitted broken
@@ -653,7 +850,7 @@
                             {:space space})))
         dtype (or (:dtype segred) dtype)
         ctype (dt/ctype :opencl dtype)
-        {:keys [acc init lambda]} (:reduce-op segred)
+        {:keys [acc init lambda]} (segop/scalar-reduce-op segred)
         lambda (ce/normalize-array-prims lambda)
         ;; combine op + element detection (mirrors generate-segred-kernel)
         op-sym (when (seq? lambda) (descriptor/semantic-op lambda))
@@ -829,11 +1026,11 @@
         i-sym (:name fi) j-sym (:name fj) l-sym (:name red-dim)
         dtype (or (:dtype segred) dtype)
         ctype (dt/ctype :opencl dtype)
-        {:keys [init lambda]} (:reduce-op segred)
+        {:keys [init lambda]} (segop/scalar-reduce-op segred)
         lambda (ce/normalize-array-prims lambda)
         _ (when-not (#{'+ 'clojure.core/+ 'raster.numeric/+} (descriptor/semantic-op lambda))
             (throw (ex-info "tensorize: combine must be +" {:reason :non-plus-combine :op (descriptor/semantic-op lambda)})))
-        acc-sym (:acc (:reduce-op segred))
+        acc-sym (:acc (segop/scalar-reduce-op segred))
         acc-at? (fn [a] (or (= a acc-sym) (and (seq? a) (= 'double (first a)) (= acc-sym (second a)))))
         op-args (vec (descriptor/call-args lambda))
         elem (let [a0 (nth op-args 0) a1 (nth op-args 1)] (if (acc-at? a0) a1 a0))

--- a/src/raster/compiler/backend/jvm/par_simd.clj
+++ b/src/raster/compiler/backend/jvm/par_simd.clj
@@ -454,7 +454,7 @@
                             (or bound
                                 (do (swap! stats update :segop-relowered (fnil inc 0))
                                     (let [soac (raster.compiler.ir.soac/par-form->soac
-                                                sym form (swap! segop-id-counter inc))
+                                                sym form (swap! segop-id-counter inc) :dtype dtype)
                                           segops (raster.compiler.passes.parallel.soac-lower/lower-soac
                                                   soac :cpu:0 :dtype dtype)]
                                       (first segops)))))

--- a/src/raster/compiler/backend/jvm/segop_simd.clj
+++ b/src/raster/compiler/backend/jvm/segop_simd.clj
@@ -842,7 +842,7 @@
   [segred]
   (let [idx (seg-idx segred)
         bound (seg-bound segred)
-        {:keys [acc init lambda]} (:reduce-op segred)
+        {:keys [acc init lambda]} (segop/scalar-reduce-op segred)
         ;; Scrub dead leaf-alias bindings (params pre-flatten) before emit.
         lambda (when lambda (normalize-invk (clean-dead-bindings lambda)))
         elem-type (or (:dtype segred)
@@ -984,7 +984,7 @@
                         scalar-bcasts (vec (mapcat (fn [[s sv]] [sv (list broadcast species-sym (list cf s))])
                                                    scalar-vec-syms))
                         ;; Scalar tail: desugar .invk for bytecode compiler
-                        raw-lambda (:lambda (:reduce-op segred))
+                        raw-lambda (:lambda (segop/scalar-reduce-op segred))
                         desugared-lambda (bc/desugar-invk raw-lambda)
                         scalar-body (clojure.walk/postwalk (fn [f] (if (= f idx) j-sym f)) desugared-lambda)
                         lanes-op (condp = op

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -200,6 +200,14 @@
                resolved (if (and (symbol? head) (namespace head))
                           (resolve-aliased-symbol head (:source-ns ctx))
                           head)]
+           (= 'raster.par/product-reduce! resolved)))
+    :par-product-reduce
+
+    (and (seq? form)
+         (let [head (first form)
+               resolved (if (and (symbol? head) (namespace head))
+                          (resolve-aliased-symbol head (:source-ns ctx))
+                          head)]
            (= 'raster.par/scan resolved)))
     :par-scan
 
@@ -951,6 +959,58 @@
       (with-meta
         (list 'raster.par/reduce acc-sym walked-init i-sym walked-bound (walk body-expr body-ctx))
         {:tag acc-tag :raster.type/tag acc-tag :raster.type/elem-type elem-type}))))
+
+(defmethod walk-form :par-product-reduce
+  [form ctx]
+  (let [[_ outputs components segment-axes idx-sym bound-expr
+         element-bindings element-results combine-parameters
+         combine-bindings combine-results algebra] form
+        dtype-tag {:float 'float :double 'double :int 'int :long 'long :byte 'byte}
+        acc-env (reduce (fn [env [acc _ dtype]]
+                          (if-let [tag (get dtype-tag dtype)] (ctx-assoc-type env acc tag) env))
+                        ctx components)
+        index-env (reduce (fn [env [segment _]] (ctx-assoc-type env segment 'long))
+                          (ctx-assoc-type acc-env idx-sym 'long)
+                          segment-axes)
+        [element-env walked-element-bindings]
+        (reduce (fn [[env bindings] [sym init]]
+                  (let [walked (walk init env)
+                        tag (or (inf/hint-tag sym) (inf/infer-arg-tag walked (:type-env env)))
+                        env' (if tag (ctx-assoc-type env sym tag) env)]
+                    [env' (conj bindings sym walked)]))
+                [index-env []]
+                (partition 2 element-bindings))
+        combine-env
+        (reduce (fn [env [[left right] [_ _ dtype]]]
+                  (if-let [tag (get dtype-tag dtype)]
+                    (-> env (ctx-assoc-type left tag) (ctx-assoc-type right tag))
+                    env))
+                ctx (map vector combine-parameters components))
+        [combine-result-env walked-combine-bindings]
+        (reduce (fn [[env bindings] [sym init]]
+                  (let [walked (walk init env)
+                        tag (or (inf/hint-tag sym) (inf/infer-arg-tag walked (:type-env env)))
+                        env' (if tag (ctx-assoc-type env sym tag) env)]
+                    [env' (conj bindings sym walked)]))
+                [combine-env []]
+                (partition 2 combine-bindings))
+        hinted-outputs
+        (mapv (fn [out]
+                (if-let [tag (and (symbol? out) (ctx-get-tag ctx out))]
+                  (stamp-type-meta out tag)
+                  out))
+              outputs)]
+    (list 'raster.par/product-reduce!
+          hinted-outputs
+          (mapv (fn [[acc neutral dtype]] [acc (walk neutral ctx) dtype]) components)
+          (mapv (fn [[segment bound]] [segment (walk bound ctx)]) segment-axes)
+          idx-sym (walk bound-expr ctx)
+          (vec walked-element-bindings)
+          (mapv #(walk % element-env) element-results)
+          combine-parameters
+          (vec walked-combine-bindings)
+          (mapv #(walk % combine-result-env) combine-results)
+          algebra)))
 
 (defmethod walk-form :par-scan [form ctx]
   (let [[_ out-sym acc-sym init-expr i-sym bound-expr cast-fn body-expr] form

--- a/src/raster/compiler/ir/par.clj
+++ b/src/raster/compiler/ir/par.clj
@@ -30,13 +30,13 @@
     (list 'let* ['n-active__ (list 'int n-active) 'n-agents__ (list 'long n-agents) 'base__ (list 'long base-seed)]
           (list 'dotimes [i-sym 'n-active__]
                 (list 'let* ['state__ (list 'unchecked-add 'base__
-                                           (list 'unchecked-multiply (list 'long i-sym) SM-GAMMA))
-                            's1__ (list 'bit-xor 'state__ (list 'unsigned-bit-shift-right 'state__ 30))
-                            's2__ (list 'unchecked-multiply 's1__ SM-MIX1)
-                            's3__ (list 'bit-xor 's2__ (list 'unsigned-bit-shift-right 's2__ 27))
-                            's4__ (list 'unchecked-multiply 's3__ SM-MIX2)
-                            's5__ (list 'bit-xor 's4__ (list 'unsigned-bit-shift-right 's4__ 31))
-                            'idx__ (list 'int (list 'mod (list 'bit-and 's5__ Long/MAX_VALUE) 'n-agents__))]
+                                            (list 'unchecked-multiply (list 'long i-sym) SM-GAMMA))
+                             's1__ (list 'bit-xor 'state__ (list 'unsigned-bit-shift-right 'state__ 30))
+                             's2__ (list 'unchecked-multiply 's1__ SM-MIX1)
+                             's3__ (list 'bit-xor 's2__ (list 'unsigned-bit-shift-right 's2__ 27))
+                             's4__ (list 'unchecked-multiply 's3__ SM-MIX2)
+                             's5__ (list 'bit-xor 's4__ (list 'unsigned-bit-shift-right 's4__ 31))
+                             'idx__ (list 'int (list 'mod (list 'bit-and 's5__ Long/MAX_VALUE) 'n-agents__))]
                       (list 'clojure.core/aset ids-arr i-sym 'idx__)))
           ids-arr)))
 
@@ -57,12 +57,12 @@
     (list 'let* ['n__ (list 'int n) 'base__ (list 'long base-seed)]
           (list 'dotimes [i-sym 'n__]
                 (list 'let* ['state__ (list 'unchecked-add 'base__
-                                           (list 'unchecked-multiply (list 'long i-sym) SM-GAMMA))
-                            's1__ (list 'bit-xor 'state__ (list 'unsigned-bit-shift-right 'state__ 30))
-                            's2__ (list 'unchecked-multiply 's1__ SM-MIX1)
-                            's3__ (list 'bit-xor 's2__ (list 'unsigned-bit-shift-right 's2__ 27))
-                            's4__ (list 'unchecked-multiply 's3__ SM-MIX2)
-                            's5__ (list 'bit-xor 's4__ (list 'unsigned-bit-shift-right 's4__ 31))]
+                                            (list 'unchecked-multiply (list 'long i-sym) SM-GAMMA))
+                             's1__ (list 'bit-xor 'state__ (list 'unsigned-bit-shift-right 'state__ 30))
+                             's2__ (list 'unchecked-multiply 's1__ SM-MIX1)
+                             's3__ (list 'bit-xor 's2__ (list 'unsigned-bit-shift-right 's2__ 27))
+                             's4__ (list 'unchecked-multiply 's3__ SM-MIX2)
+                             's5__ (list 'bit-xor 's4__ (list 'unsigned-bit-shift-right 's4__ 31))]
                       (list 'clojure.core/aset seeds-arr i-sym 's5__)))
           seeds-arr)))
 
@@ -269,7 +269,7 @@
                       (list 'let* [idx-sym (list 'clojure.core/aget index i-sym)]
                             (list 'dotimes [d-sym 'stride__]
                                   (list 'let* ['src-pos__ (list '+ (list '* i-sym 'stride__) d-sym)
-                                              'dst-pos__ (list '+ (list '* idx-sym 'stride__) d-sym)]
+                                               'dst-pos__ (list '+ (list '* idx-sym 'stride__) d-sym)]
                                         (list 'clojure.core/aset out 'dst-pos__
                                               (list '+ (list 'clojure.core/aget out 'dst-pos__)
                                                     (list 'clojure.core/aget src 'src-pos__)))))))
@@ -294,7 +294,7 @@
           (list 'let* ['n__ (list 'int n) 'stride__ (list 'int stride)]
                 (list 'dotimes [i-sym 'n__]
                       (list 'let* ['sbase__ (list '* (list 'clojure.core/aget index i-sym) 'stride__)
-                                  'obase__ (list '* i-sym 'stride__)]
+                                   'obase__ (list '* i-sym 'stride__)]
                             (list 'dotimes [d-sym 'stride__]
                                   (list 'clojure.core/aset out (list '+ 'obase__ d-sym)
                                         (list 'clojure.core/aget src (list '+ 'sbase__ d-sym))))))
@@ -308,7 +308,7 @@
     (list 'let* ['n__ (list 'int n)]
           (list 'dotimes [i-sym 'n__]
                 (list 'let* ['k__ (list 'clojure.core/aget keys i-sym)
-                            'v__ (list 'clojure.core/aget vals i-sym)]
+                             'v__ (list 'clojure.core/aget vals i-sym)]
                       (list 'clojure.core/aset output 'k__
                             (list (or op '+) (list 'clojure.core/aget output 'k__) 'v__))))
           output)))
@@ -327,6 +327,9 @@
 
     (and (seq? form) (= 'raster.par/reduce (first form)))
     (expand-par-forms (expand-par-reduce form))
+
+    (and (seq? form) (= 'raster.par/product-reduce! (first form)))
+    (expand-par-forms (macroexpand-1 form))
 
     ;; contract = an annotated redomap; the CPU/correctness fallback is its macro expansion
     ;; (a sequential dotimes over the free space of a per-tuple reduce over the contract axis).
@@ -386,6 +389,7 @@
                     'raster.par/map2! 'par/map2!
                     'raster.par/contract 'par/contract
                     'raster.par/reduce 'par/reduce
+                    'raster.par/product-reduce! 'par/product-reduce!
                     'raster.par/reduce-into 'par/reduce-into
                     'raster.par/scan 'par/scan
                     'raster.par/scan-exclusive 'par/scan-exclusive
@@ -428,6 +432,12 @@
   "Check if a form is a raster.par/reduce parallel reduction."
   [form]
   (and (seq? form) (contains? #{'raster.par/reduce 'par/reduce} (first form))))
+
+(defn par-product-reduce-form?
+  "Check if a form is a typed segmented product reduction."
+  [form]
+  (and (seq? form)
+       (contains? #{'raster.par/product-reduce! 'par/product-reduce!} (first form))))
 
 (defn par-stencil-form?
   "Check if a form is a raster.par/stencil! parallel stencil."
@@ -561,6 +571,55 @@
            :rebuild (fn [[acc' idx'] [body'] [init' bound']]
                       (pl form head acc' init' idx' bound' body'))})
 
+        ;; product-reduce!: output/component/segment vectors are structural. Accumulators,
+        ;; segment indices, the reduction index and local region bindings are all lexical binders.
+        (par-product-reduce-form? form)
+        (let [[_ outputs components segment-axes idx bound
+               element-bindings element-results combine-parameters
+               combine-bindings combine-results algebra] form
+              accs (mapv first components)
+              seg-idxs (mapv first segment-axes)
+              element-locals (vec (take-nth 2 element-bindings))
+              combine-params (vec (mapcat identity combine-parameters))
+              combine-locals (vec (take-nth 2 combine-bindings))
+              scoped (vec (concat accs seg-idxs [idx] element-locals
+                                  combine-params combine-locals))
+              inner (vec (concat (take-nth 2 (rest element-bindings)) element-results
+                                 (take-nth 2 (rest combine-bindings)) combine-results))
+              outer (vec (concat outputs
+                                 (map second components)
+                                 (map second segment-axes)
+                                 [bound algebra]))]
+          {:scoped-syms scoped :inner-exprs inner :outer-exprs outer
+           :rebuild
+           (fn [scoped' inner' outer']
+             (let [ncomp (count components)
+                   nseg (count segment-axes)
+                   nelem-local (count element-locals)
+                   ncombine-param (count combine-params)
+                   ncombine-local (count combine-locals)
+                   [accs' rest-scoped] (split-at ncomp scoped')
+                   [seg-idxs' rest-scoped] (split-at nseg rest-scoped)
+                   idx' (first rest-scoped)
+                   rest-scoped (rest rest-scoped)
+                   [element-locals' rest-scoped] (split-at nelem-local rest-scoped)
+                   [combine-params' combine-locals'] (split-at ncombine-param rest-scoped)
+                   [element-values' rest-inner] (split-at nelem-local inner')
+                   [element-results' rest-inner] (split-at ncomp rest-inner)
+                   [combine-values' combine-results'] (split-at ncombine-local rest-inner)
+                   [outputs' rest-outer] (split-at ncomp outer')
+                   [neutrals' rest-outer] (split-at ncomp rest-outer)
+                   [segment-bounds' [bound' algebra']] (split-at nseg rest-outer)
+                   components' (mapv (fn [acc neutral [_ _ dtype]] [acc neutral dtype])
+                                     accs' neutrals' components)
+                   segment-axes' (mapv vector seg-idxs' segment-bounds')
+                   element-bindings' (vec (mapcat vector element-locals' element-values'))
+                   combine-parameters' (mapv vec (partition 2 combine-params'))
+                   combine-bindings' (vec (mapcat vector combine-locals' combine-values'))]
+               (pl form head (vec outputs') components' segment-axes' idx' bound'
+                   element-bindings' (vec element-results') combine-parameters'
+                   combine-bindings' (vec combine-results') algebra')))})
+
         ;; scan / scan-exclusive: (head out acc init idx bound cast body)
         (or (= n "scan") (= n "scan-exclusive"))
         (let [[_ out acc init idx bound cast body] form]
@@ -614,6 +673,25 @@
         (let [[_ out idx bound cast body] form]
           (cond-> {:out out :idx idx :bound bound :cast cast :body body}
             elem-type (assoc :elem-type elem-type)))))))
+
+(defn extract-par-product-reduce-info
+  "Extract the ordered structural fields of `raster.par/product-reduce!`."
+  [form]
+  (when (par-product-reduce-form? form)
+    (let [[_ outputs components segment-axes idx bound
+           element-bindings element-results combine-parameters
+           combine-bindings combine-results algebra] form]
+      {:outputs (vec outputs)
+       :components (vec components)
+       :segment-axes (vec segment-axes)
+       :idx idx
+       :bound bound
+       :element-bindings (vec element-bindings)
+       :element-results (vec element-results)
+       :combine-parameters (vec combine-parameters)
+       :combine-bindings (vec combine-bindings)
+       :combine-results (vec combine-results)
+       :algebra algebra})))
 
 (defn extract-par-map2-info
   "Extract structured info from a par/map2! form.

--- a/src/raster/compiler/ir/reduction.clj
+++ b/src/raster/compiler/ir/reduction.clj
@@ -1,0 +1,230 @@
+(ns raster.compiler.ir.reduction
+  "Canonical typed reduction operators.
+
+   A scalar reduction is the one-component case.  Product reductions keep accumulator components,
+   neutral values and step results in one ordered record so lowering cannot silently lose a value
+   or guess its dtype.  The operator is semantic: segmentation and target schedules live in SOAC
+   and SegOp layers, while physical scratch is introduced only during scheduling/materialization.")
+
+(defrecord ReductionComponent
+           [id accumulator neutral dtype result attributes])
+
+(defrecord ReductionRegion
+           [bindings results attributes])
+
+(defrecord CombineRegion
+           [parameters bindings results attributes])
+
+(defrecord ProductReduction
+           [components index element combine step algebra attributes])
+
+(defrecord ReductionSchedule
+           [strategy workgroup-size stages tuning-space numerical-mode attributes])
+
+(defn component?
+  [value]
+  (and value
+       (= "raster.compiler.ir.reduction.ReductionComponent" (.getName (class value)))))
+
+(defn product-reduction?
+  [value]
+  (and value
+       (= "raster.compiler.ir.reduction.ProductReduction" (.getName (class value)))))
+
+(defn region?
+  [value]
+  (and value
+       (= "raster.compiler.ir.reduction.ReductionRegion" (.getName (class value)))))
+
+(defn combine-region?
+  [value]
+  (and value
+       (= "raster.compiler.ir.reduction.CombineRegion" (.getName (class value)))))
+
+(defn schedule?
+  [value]
+  (and value
+       (= "raster.compiler.ir.reduction.ReductionSchedule" (.getName (class value)))))
+
+(defn validate-schedule!
+  [schedule]
+  (when-not (schedule? schedule)
+    (throw (ex-info "expected a ReductionSchedule"
+                    {:reason :reduction-schedule-type :schedule schedule})))
+  (let [{:keys [strategy workgroup-size stages tuning-space numerical-mode attributes]} schedule]
+    (when-not (keyword? strategy)
+      (throw (ex-info "reduction schedule strategy must be a keyword"
+                      {:reason :reduction-schedule-strategy :strategy strategy})))
+    (when-not (and (integer? workgroup-size) (pos? workgroup-size)
+                   (zero? (bit-and workgroup-size (dec workgroup-size))))
+      (throw (ex-info "reduction schedule workgroup size must be a positive power of two"
+                      {:reason :reduction-schedule-workgroup :workgroup-size workgroup-size})))
+    (when-not (and (vector? stages) (seq stages) (every? keyword? stages))
+      (throw (ex-info "reduction schedule stages must be an ordered non-empty keyword vector"
+                      {:reason :reduction-schedule-stages :stages stages})))
+    (doseq [[field value] [[:tuning-space tuning-space]
+                           [:numerical-mode numerical-mode]
+                           [:attributes attributes]]]
+      (when-not (map? value)
+        (throw (ex-info "reduction schedule facets must be explicit maps"
+                        {:reason :reduction-schedule-facet :field field :value value})))))
+  schedule)
+
+(defn schedule
+  [{:keys [strategy workgroup-size stages tuning-space numerical-mode attributes]
+    :or {tuning-space {} numerical-mode {} attributes {}}}]
+  (validate-schedule!
+   (->ReductionSchedule strategy workgroup-size (vec stages) tuning-space numerical-mode attributes)))
+
+(defn- distinct-vector?
+  [xs]
+  (and (vector? xs) (= (count xs) (count (distinct xs)))))
+
+(defn validate!
+  "Validate and return a ProductReduction unchanged.
+
+   `result` is either a logical output symbol or nil when the component participates in the
+   reduction but is not externally materialized (argmax's winning value is the common example)."
+  [reduction]
+  (when-not (product-reduction? reduction)
+    (throw (ex-info "expected a ProductReduction"
+                    {:reason :product-reduction-type :value reduction})))
+  (let [{:keys [components index element combine step algebra attributes]} reduction]
+    (when-not (and (vector? components) (seq components) (every? component? components))
+      (throw (ex-info "product reduction requires an ordered non-empty component vector"
+                      {:reason :product-reduction-components :components components})))
+    (doseq [{:keys [id accumulator dtype result attributes] :as component} components]
+      (when (nil? id)
+        (throw (ex-info "reduction component IDs cannot be nil"
+                        {:reason :product-reduction-component-id :component component})))
+      (when-not (symbol? accumulator)
+        (throw (ex-info "reduction accumulators must be symbols"
+                        {:reason :product-reduction-accumulator :component component})))
+      (when-not (keyword? dtype)
+        (throw (ex-info "reduction component dtype must be explicit"
+                        {:reason :product-reduction-dtype :component component})))
+      (when-not (or (nil? result) (symbol? result))
+        (throw (ex-info "reduction component result must be a symbol or nil"
+                        {:reason :product-reduction-result :component component})))
+      (when-not (map? attributes)
+        (throw (ex-info "reduction component attributes must be a map"
+                        {:reason :product-reduction-component-attributes
+                         :component component}))))
+    (doseq [[field values] [[:ids (mapv :id components)]
+                            [:accumulators (mapv :accumulator components)]]]
+      (when-not (distinct-vector? values)
+        (throw (ex-info "reduction component identities must be unique"
+                        {:reason :product-reduction-duplicate :field field :values values}))))
+    (when-not (symbol? index)
+      (throw (ex-info "product reduction index must be a symbol"
+                      {:reason :product-reduction-index :index index})))
+    (when-not (or (and (region? step) (nil? element) (nil? combine))
+                  (and (nil? step) (region? element) (combine-region? combine)))
+      (throw (ex-info "reduction requires either one legacy fold region or element+combine regions"
+                      {:reason :product-reduction-regions
+                       :step step :element element :combine combine})))
+    (doseq [[kind region] (remove (comp nil? second) [[:step step] [:element element]])]
+      (let [{:keys [bindings results attributes]} region]
+        (when-not (and (vector? bindings) (even? (count bindings)))
+          (throw (ex-info "reduction region bindings must be a flat binding vector"
+                          {:reason :product-reduction-region-bindings
+                           :region kind :bindings bindings})))
+        (let [bound-syms (vec (take-nth 2 bindings))]
+          (when-not (and (every? symbol? bound-syms) (distinct-vector? bound-syms))
+            (throw (ex-info "reduction region binding symbols must be unique"
+                            {:reason :product-reduction-region-binders
+                             :region kind :symbols bound-syms}))))
+        (when-not (and (vector? results) (= (count components) (count results)))
+          (throw (ex-info "product reduction step result arity must equal component arity"
+                          {:reason :product-reduction-arity
+                           :region kind :components (count components)
+                           :region-results (count results)})))
+        (when-not (map? attributes)
+          (throw (ex-info "reduction region attributes must be a map"
+                          {:reason :product-reduction-region-attributes
+                           :region kind :attributes attributes})))))
+    (when combine
+      (let [{:keys [parameters bindings results attributes]} combine
+            flat-params (vec (mapcat identity parameters))]
+        (when-not (and (vector? parameters) (= (count components) (count parameters))
+                       (every? #(and (vector? %) (= 2 (count %)) (every? symbol? %)) parameters)
+                       (distinct-vector? flat-params))
+          (throw (ex-info "combine parameters must be one distinct [left right] pair per component"
+                          {:reason :product-reduction-combine-parameters
+                           :parameters parameters :components (count components)})))
+        (when-not (and (vector? bindings) (even? (count bindings)))
+          (throw (ex-info "combine bindings must be a flat binding vector"
+                          {:reason :product-reduction-combine-bindings :bindings bindings})))
+        (when-not (and (vector? results) (= (count components) (count results)))
+          (throw (ex-info "combine result arity must equal component arity"
+                          {:reason :product-reduction-combine-arity
+                           :components (count components) :results (count results)})))
+        (when-not (map? attributes)
+          (throw (ex-info "combine region attributes must be a map"
+                          {:reason :product-reduction-combine-attributes
+                           :attributes attributes})))))
+    (when-not (map? algebra)
+      (throw (ex-info "product reduction algebra facts must be an explicit map"
+                      {:reason :product-reduction-algebra :algebra algebra})))
+    (when-not (map? attributes)
+      (throw (ex-info "product reduction attributes must be a map"
+                      {:reason :product-reduction-attributes :attributes attributes}))))
+  reduction)
+
+(defn make
+  [{:keys [components index step element-bindings element-results combine-parameters
+           combine-bindings combine-results algebra attributes]
+    :or {algebra {} attributes {}}}]
+  (validate!
+   (->ProductReduction
+    (mapv (fn [component]
+            (if (component? component)
+              component
+              (map->ReductionComponent (merge {:attributes {}} component))))
+          components)
+    index
+    (when (some? element-results)
+      (->ReductionRegion (vec element-bindings) (vec element-results) {}))
+    (when (some? combine-results)
+      (->CombineRegion (vec combine-parameters) (vec combine-bindings)
+                       (vec combine-results) {}))
+    step algebra attributes)))
+
+(defn scalar
+  "Construct the canonical one-component representation of `raster.par/reduce`."
+  [{:keys [accumulator neutral dtype result index step-result algebra attributes]
+    :or {algebra {} attributes {}}}]
+  (make {:components [{:id :value
+                       :accumulator accumulator
+                       :neutral neutral
+                       :dtype dtype
+                       :result result}]
+         :index index
+         :step (->ReductionRegion [] [step-result] {})
+         :algebra algebra
+         :attributes attributes}))
+
+(defn scalar?
+  [reduction]
+  (= 1 (count (:components (validate! reduction)))))
+
+(defn accumulators [reduction] (mapv :accumulator (:components (validate! reduction))))
+(defn neutrals [reduction] (mapv :neutral (:components (validate! reduction))))
+(defn dtypes [reduction] (mapv :dtype (:components (validate! reduction))))
+(defn results [reduction] (mapv :result (:components (validate! reduction))))
+(defn fold-region [reduction] (:step (validate! reduction)))
+(defn element-region [reduction] (:element (validate! reduction)))
+(defn combine-region [reduction] (:combine (validate! reduction)))
+
+(defn scalar-op
+  "Project a one-component reduction into the legacy scalar emitter vocabulary.  This is a
+   temporary target adapter, not a second semantic representation."
+  [reduction]
+  (when-not (scalar? reduction)
+    (throw (ex-info "scalar emitter cannot consume a product reduction"
+                    {:reason :product-reduction-needs-schedule
+                     :components (count (:components reduction))})))
+  (let [component (first (:components reduction))]
+    {:acc (:accumulator component)
+     :init (:neutral component)
+     :lambda (first (:results (fold-region reduction)))}))

--- a/src/raster/compiler/ir/segop.clj
+++ b/src/raster/compiler/ir/segop.clj
@@ -13,7 +13,8 @@
   Each SegOp carries a KernelGrid with pre-computed launch config
   based on raster.runtime.hardware device properties."
   (:require [raster.runtime.hardware :as hw]
-            [raster.compiler.core.hardware :as chw]))
+            [raster.compiler.core.hardware :as chw]
+            [raster.compiler.ir.reduction :as reduction]))
 
 ;; ================================================================
 ;; Segmented space and grid config
@@ -53,14 +54,20 @@
            [id          ;; int
             space       ;; SegSpace
             level       ;; SegLevel
-            reduce-op   ;; {:acc sym :init expr :lambda expr}
+            reduction  ;; ProductReduction — ordered typed semantic operator
             lambda      ;; expr — map body before reduction (or nil for direct)
             inputs      ;; #{sym}
             outputs     ;; #{sym}
             scalars     ;; #{sym}
             grid        ;; KernelGrid
             phase       ;; :single | :block-local | :cross-block
+            schedule    ;; ReductionSchedule or nil for the scalar compatibility schedule
             dtype])      ;; :double | :float — element type
+
+(defn scalar-reduce-op
+  "Project a scalar SegRed for emitters that have not yet gained product scheduling."
+  [segred]
+  (reduction/scalar-op (:reduction segred)))
 
 (defrecord SegContract
            [id          ;; int

--- a/src/raster/compiler/ir/soac.clj
+++ b/src/raster/compiler/ir/soac.clj
@@ -12,6 +12,7 @@
     SoacStencil — neighborhood stencil (fixed radius)
     ScalarBinding — non-parallel scalar/allocation binding"
   (:require [raster.compiler.ir.par :as par]
+            [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.form :as form]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
@@ -36,13 +37,11 @@
 (defrecord SoacReduce
            [id          ;; int
             sym         ;; symbol
-            acc         ;; symbol — accumulator variable
-            init        ;; expr — initial accumulator value
-            idx         ;; symbol — loop index variable
+            reduction   ;; ProductReduction — scalar reduce is one component
+            segment-axes ;; ordered [[idx bound] ...], empty for a scalar/full reduction
             bound       ;; expr — iteration count
-            lambda      ;; expr — reduction body
             inputs      ;; #{sym} — array symbols read
-            output      ;; symbol — result symbol (= sym)
+            outputs     ;; ordered logical result symbols (nil components are not materialized)
             scalars])   ;; #{sym} — free scalars
 
 (defrecord SoacScan
@@ -258,10 +257,53 @@
                       :acc-sym (:acc info))
           elem-type (or (:elem-type info)
                         (:raster.type/elem-type (meta expr)))]
-      (cond-> (->SoacReduce id sym (:acc info) (:init info)
-                            (:idx info) (:bound info)
-                            (:body info) inputs sym scalars)
+      (cond-> (->SoacReduce id sym
+                            (reduction/scalar
+                             {:accumulator (:acc info)
+                              :neutral (:init info)
+                              :dtype (or elem-type dtype :double)
+                              :result sym
+                              :index (:idx info)
+                              :step-result (:body info)
+                              :attributes {:source :raster.par/reduce}})
+                            [] (:bound info) inputs [sym] scalars)
         elem-type (assoc :elem-type elem-type)))
+
+    (par/par-product-reduce-form? expr)
+    (let [{:keys [outputs components segment-axes idx bound
+                  element-bindings element-results combine-parameters
+                  combine-bindings combine-results algebra]}
+          (par/extract-par-product-reduce-info expr)
+          component-records
+          (mapv (fn [[component-id [acc neutral dtype] result]]
+                  {:id component-id :accumulator acc :neutral neutral :dtype dtype :result result})
+                (map vector (range) components outputs))
+          region-form (list 'let* element-bindings (vec element-results))
+          combine-form (list 'let* combine-bindings (vec combine-results))
+          accumulators (set (map first components))
+          segment-indices (set (map first segment-axes))
+          inputs (collect-aget-arrays region-form)
+          output-set (set (filter symbol? outputs))
+          excluded (set/union inputs output-set accumulators segment-indices #{idx}
+                              (set (take-nth 2 element-bindings))
+                              (set (mapcat identity combine-parameters))
+                              (set (take-nth 2 combine-bindings))
+                              descriptor/aget-ops descriptor/aset-ops
+                              #{'do 'let 'let* 'if 'double 'float 'int 'long})
+          scalar-uses (set/union (util/free-syms region-form) (util/free-syms combine-form)
+                                 (reduce set/union #{} (map (comp util/free-syms second) components)))
+          scalars (set/difference scalar-uses excluded)
+          operator (reduction/make
+                    {:components component-records
+                     :index idx
+                     :element-bindings element-bindings
+                     :element-results element-results
+                     :combine-parameters combine-parameters
+                     :combine-bindings combine-bindings
+                     :combine-results combine-results
+                     :algebra algebra
+                     :attributes {:source :raster.par/product-reduce!}})]
+      (->SoacReduce id sym operator (vec segment-axes) bound inputs (vec outputs) scalars))
 
     ;; Scan: (raster.par/scan out acc init idx bound cast body)
     (and (seq? expr) (= 'raster.par/scan (first expr)))
@@ -350,8 +392,23 @@
              (:idx soac) (:bound soac) (:cast-fn soac) (:lambda soac)))
 
      SoacReduce
-     (list 'raster.par/reduce (:acc soac) (:init soac)
-           (:idx soac) (:bound soac) (:lambda soac))
+     (if (= :raster.par/product-reduce! (get-in soac [:reduction :attributes :source]))
+       (list 'raster.par/product-reduce!
+             (reduction/results (:reduction soac))
+             (mapv (fn [component]
+                     [(:accumulator component) (:neutral component) (:dtype component)])
+                   (:components (:reduction soac)))
+             (:segment-axes soac)
+             (:index (:reduction soac)) (:bound soac)
+             (:bindings (reduction/element-region (:reduction soac)))
+             (:results (reduction/element-region (:reduction soac)))
+             (:parameters (reduction/combine-region (:reduction soac)))
+             (:bindings (reduction/combine-region (:reduction soac)))
+             (:results (reduction/combine-region (:reduction soac)))
+             (:algebra (:reduction soac)))
+       (let [{:keys [acc init lambda]} (reduction/scalar-op (:reduction soac))]
+         (list 'raster.par/reduce acc init
+               (:index (:reduction soac)) (:bound soac) lambda)))
 
      SoacScan
      (list 'raster.par/scan (:out soac) (:acc soac) (:init soac)
@@ -493,7 +550,7 @@
     #{(:out (:facts node))}
     (cond
       (soac-map? node)     (:outputs node)
-      (soac-reduce? node)  #{(:output node)}
+      (soac-reduce? node)  (set (filter symbol? (:outputs node)))
       (soac-scan? node)    (:outputs node)
       (soac-stencil? node) (:outputs node)
       :else nil)))
@@ -506,7 +563,8 @@
 (defn soac-idx
   "Get the index variable for a SOAC node."
   [node]
-  (when (soac? node) (:idx node)))
+  (when (soac? node)
+    (if (soac-reduce? node) (:index (:reduction node)) (:idx node))))
 
 (defn node-all-free-syms
   "Get all free symbols referenced by a node (inputs + outputs + scalars + bound + init).
@@ -517,10 +575,12 @@
   (if (instance? ScalarBinding node)
     (util/free-syms (:expr node))
     (set/union (or (:inputs node) #{})
-               (if (:pure? node) #{} (or (:outputs node) #{}))
+               (if (:pure? node) #{} (set (filter symbol? (or (:outputs node) #{}))))
                (or (:scalars node) #{})
                (util/free-syms (:bound node))
-               (if (:init node) (util/free-syms (:init node)) #{}))))
+               (if (soac-reduce? node)
+                 (reduce set/union #{} (map util/free-syms (reduction/neutrals (:reduction node))))
+                 (if (:init node) (util/free-syms (:init node)) #{})))))
 
 (defn- expr-written-arrays
   "Arrays written via aset (bare or devirtualized) anywhere in `expr`. Used so a
@@ -593,11 +653,12 @@
                     (:cast-fn soac) [] [] (:lambda soac))
 
           SoacReduce
-          (->Screma (:id soac) (:sym soac) (:idx soac) (:bound soac)
-                    (:inputs soac) #{(:output soac)} (:scalars soac)
-                    nil [] [{:acc (:acc soac) :init (:init soac)
-                             :lambda (:lambda soac)}]
-                    nil)
+          (if (seq (:segment-axes soac))
+            soac
+            (->Screma (:id soac) (:sym soac) (:index (:reduction soac)) (:bound soac)
+                      (:inputs soac) (set (filter symbol? (:outputs soac))) (:scalars soac)
+                      nil [] [(:reduction soac)]
+                      nil))
 
           SoacScan
           (->Screma (:id soac) (:sym soac) (:idx soac) (:bound soac)
@@ -625,9 +686,9 @@
 
           ;; Pure reduce: one reduce, no map-lambda
           (and (empty? (:scans screma)) (= 1 (count (:reduces screma))) (nil? (:map-lambda screma)))
-          (let [r (first (:reduces screma))]
-            (list 'raster.par/reduce (:acc r) (:init r)
-                  (:idx screma) (:bound screma) (:lambda r)))
+          (let [{:keys [acc init lambda]} (reduction/scalar-op (first (:reduces screma)))]
+            (list 'raster.par/reduce acc init
+                  (:idx screma) (:bound screma) lambda))
 
           ;; Pure scan: one scan, no map-lambda
           (and (= 1 (count (:scans screma))) (empty? (:reduces screma)) (nil? (:map-lambda screma)))
@@ -720,7 +781,8 @@
       ;; Map→Reduce
       (and (:map-lambda producer) (seq (:reduces consumer)))
       (assoc consumer
-             :reduces (mapv (fn [r] (update r :lambda substitute)) (:reduces consumer))
+             :reduces (mapv (fn [r] (update-in r [:step :results] #(mapv substitute %)))
+                            (:reduces consumer))
              :inputs new-inputs
              :scalars new-scalars)
 

--- a/src/raster/compiler/passes/parallel/contract_lower.clj
+++ b/src/raster/compiler/passes/parallel/contract_lower.clj
@@ -9,9 +9,10 @@
    later, the BlkRegTiling-style tiling pass consume this SegRed. A contraction is
    represented like a fused map→reduce: the product (map body) lives in the reduce
    combine's element slot `(+ acc <product>)`, so `map-lambda` is nil — matching how a
-   `SoacReduce` fuses its map into the combine (see soac-lower/reduce-op-info)."
+   `SoacReduce` fuses its map into the canonical reduction operator."
   (:require [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.par :as ir-par]
+            [raster.compiler.ir.reduction :as reduction]
             [clojure.set :as set]
             [clojure.walk :as walk]))
 
@@ -65,7 +66,10 @@
         space (segop/make-seg-space-nd (conj free-dims red-dim))
         acc-sym (gensym "acc__")
         ;; fused map→reduce: product sits in the combine's element slot.
-        reduce-op {:acc acc-sym :init init :lambda (list combine acc-sym body)}
+        reduction (reduction/scalar
+                   {:accumulator acc-sym :neutral init :dtype dtype :result out
+                    :index k-sym :step-result (list combine acc-sym body)
+                    :attributes {:source :raster.par/contract}})
         arrays  (set (ir-par/collect-aget-arrays body))
         inputs  (disj arrays out)
         ;; scalars = the symbol-valued axis bounds (the contraction dims). Body-level
@@ -74,13 +78,14 @@
                          (conj (mapv second free-axes) k-bound))]
     (segop/->SegRed id space
                     (segop/->SegLevel :thread :virtual)
-                    reduce-op
+                    reduction
                     nil                 ; map-lambda: nil (product is in the combine)
                     inputs
                     #{out}
                     (set/difference bound-syms arrays #{out})
                     grid
                     :segmented
+                    nil
                     dtype)))
 
 (defn contract-form->segmap

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -13,10 +13,13 @@
          Stage 2: scan of block totals
          Stage 3: carry-in combination (SegMap)"
   (:require [clojure.set :as set]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.hardware :as hardware]
             [raster.compiler.ir.kernel-graph :as kernel-graph]
             [raster.compiler.ir.kernel-launch :as kernel-launch]
             [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.soac :as soac]
+            [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.execution-plan :as execution-plan]))
 
@@ -47,15 +50,44 @@
   [grid]
   (segop/->KernelGrid 1 (:block-size grid) (:shared-mem-bytes grid)))
 
+(defn- floor-power-of-two
+  [n]
+  (loop [power 1]
+    (if (<= (* 2 power) n)
+      (recur (* 2 power))
+      power)))
+
+(defn- product-grid
+  "Constrain a product reduction's workgroup by both the target's thread limit and its SLM
+   budget. Each component has an independent local array, so charging only the primary dtype
+   would make mixed products legal on paper while overcommitting local memory at emission."
+  [device-id planned reduction]
+  (let [descriptor (hardware/descriptor-for device-id)
+        bytes-per-lane (reduce + (map (comp dtype/bytes-of :dtype) (:components reduction)))
+        slm-budget (long (or (get-in descriptor [:cache :slm])
+                             (:shared-memory-per-block descriptor)
+                             65536))
+        max-by-slm (max 1 (quot slm-budget bytes-per-lane))
+        max-workgroup (long (:max-workgroup-size descriptor 1024))
+        workgroup-size (floor-power-of-two
+                        (max 1 (min (long (:block-size planned))
+                                    max-workgroup
+                                    max-by-slm)))]
+    {:grid (segop/->KernelGrid (:num-blocks planned)
+                               workgroup-size
+                               (* workgroup-size bytes-per-lane))
+     :slm-budget slm-budget
+     :bytes-per-lane bytes-per-lane}))
+
 (defn- screma-map-lambda
   [soac]
   (when (soac/screma? soac)
     (:map-lambda soac)))
 
-(defn- reduce-op-info
+(defn- reduction-info
   [soac]
   (if (soac/soac-reduce? soac)
-    {:acc (:acc soac) :init (:init soac) :lambda (:lambda soac)}
+    (:reduction soac)
     (first (:reduces soac))))
 
 (defn- scan-op-info
@@ -74,7 +106,7 @@
   [soac device-id & {:keys [dtype] :or {dtype :double}}]
   (let [dtype (or (:elem-type soac) dtype)
         bound (:bound soac)
-        idx (:idx soac)
+        idx (soac/soac-idx soac)
         space (segop/make-seg-space idx bound)
         level (segop/->SegLevel :thread :virtual)
         grid (phase-grid :map device-id bound dtype)
@@ -103,49 +135,76 @@
 
   Returns a vector of SegRed records (1 or 2 elements)."
   [soac device-id & {:keys [dtype] :or {dtype :double}}]
-  (let [dtype (or (:elem-type soac) dtype)
+  (let [reduction (reduction-info soac)
+        product? (some? (:combine reduction))
+        dtype (or (first (map :dtype (:components reduction))) (:elem-type soac) dtype)
         bound (:bound soac)
-        idx (:idx soac)
-        reduce-op (reduce-op-info soac)
+        idx (soac/soac-idx soac)
         map-lambda (screma-map-lambda soac)
-        space (segop/make-seg-space idx bound)
-        grid-1 (phase-grid :reduce device-id bound dtype)
+        space (segop/make-seg-space-nd
+               (conj (mapv (fn [[name axis-bound]] {:name name :bound axis-bound})
+                           (or (:segment-axes soac) []))
+                     {:name idx :bound bound}))
+        planned-grid (phase-grid :reduce device-id bound dtype)
+        product-grid-info (when product? (product-grid device-id planned-grid reduction))
+        grid-1 (or (:grid product-grid-info) planned-grid)
+        product-schedule
+        (when product?
+          (let [workgroup-size (:block-size grid-1)
+                candidates (filterv #(<= % workgroup-size) [32 64 128 256 512 1024])]
+            (reduction/schedule
+             {:strategy :segmented-workgroup-tree
+              :workgroup-size workgroup-size
+              :stages [:lane-fold :workgroup-tree :segment-store]
+              :tuning-space {:workgroup-size candidates
+                             :elements-per-lane [:runtime-stride]}
+              :numerical-mode (select-keys (:algebra reduction)
+                                           [:order :reassociation :overflow])
+              :attributes {:scratch :workgroup-local
+                           :component-dtypes (reduction/dtypes reduction)
+                           :scratch-bytes-per-lane (:bytes-per-lane product-grid-info)
+                           :slm-budget (:slm-budget product-grid-info)}})))
         execution (execution-plan/reduce-execution bound grid-1)]
-    (case (:strategy execution)
-      :single
-      [(segop/->SegRed (:id soac)
-                       space
-                       (segop/->SegLevel :block :none)
-                       reduce-op
-                       map-lambda
-                       (:inputs soac)
-                       (or (soac-outputs* soac) #{(:sym soac)})
-                       (:scalars soac)
-                       (single-block-grid grid-1)
-                       :single
-                       dtype)]
+    (if product?
+      [(segop/->SegRed (:id soac) space (segop/->SegLevel :block :virtual)
+                       reduction map-lambda (:inputs soac)
+                       (set (filter symbol? (or (:outputs soac) []))) (:scalars soac)
+                       grid-1 :product product-schedule dtype)]
+      (case (:strategy execution)
+        :single
+        [(segop/->SegRed (:id soac)
+                         space
+                         (segop/->SegLevel :block :none)
+                         reduction
+                         map-lambda
+                         (:inputs soac)
+                         (or (soac-outputs* soac) #{(:sym soac)})
+                         (:scalars soac)
+                         (single-block-grid grid-1)
+                         :single nil
+                         dtype)]
 
-      :two-phase
-      (let [level-1 (segop/->SegLevel :block :virtual)
-            phase-1 (segop/->SegRed (:id soac) space level-1
-                                    reduce-op map-lambda
-                                    (:inputs soac)
-                                    (or (soac-outputs* soac) #{(:sym soac)})
-                                    (:scalars soac)
-                                    grid-1 :block-local
-                                    dtype)
-            partials-sym (gensym "partials_")
-            phase-2-idx (gensym "j_")
-            phase-2-space (segop/make-seg-space phase-2-idx (:num-blocks grid-1))
-            grid-2 (single-block-grid grid-1)
-            level-2 (segop/->SegLevel :block :none)
-            phase-2 (segop/->SegRed (+ (:id soac) 1000)
-                                    phase-2-space level-2
-                                    reduce-op nil
-                                    #{partials-sym} #{(:sym soac)}
-                                    #{} grid-2 :cross-block
-                                    dtype)]
-        [phase-1 phase-2]))))
+        :two-phase
+        (let [level-1 (segop/->SegLevel :block :virtual)
+              phase-1 (segop/->SegRed (:id soac) space level-1
+                                      reduction map-lambda
+                                      (:inputs soac)
+                                      (or (soac-outputs* soac) #{(:sym soac)})
+                                      (:scalars soac)
+                                      grid-1 :block-local nil
+                                      dtype)
+              partials-sym (gensym "partials_")
+              phase-2-idx (gensym "j_")
+              phase-2-space (segop/make-seg-space phase-2-idx (:num-blocks grid-1))
+              grid-2 (single-block-grid grid-1)
+              level-2 (segop/->SegLevel :block :none)
+              phase-2 (segop/->SegRed (+ (:id soac) 1000)
+                                      phase-2-space level-2
+                                      reduction nil
+                                      #{partials-sym} #{(:sym soac)}
+                                      #{} grid-2 :cross-block nil
+                                      dtype)]
+          [phase-1 phase-2])))))
 
 ;; ================================================================
 ;; Scan lowering — single or three-stage

--- a/src/raster/compiler/passes/scalar/inline.clj
+++ b/src/raster/compiler/passes/scalar/inline.clj
@@ -1678,6 +1678,45 @@
           new-body (map #(resolve-dispatch-walk % par-env) body-forms)
           r (apply list head acc resolved-init idx resolved-bound new-body)]
       (if-let [m (meta expr)] (with-meta r m) r))
+    ;; product-reduce!: accumulators, segment indices, reduction index and region locals are scoped.
+    (and (symbol? (first expr))
+         (contains? #{'raster.par/product-reduce! 'par/product-reduce!} (first expr)))
+    (let [[head outputs components segment-axes idx bound
+           element-bindings element-results combine-parameters
+           combine-bindings combine-results algebra] expr
+          acc-env (reduce (fn [e [acc init _dtype]]
+                            (if-let [tag (inf/infer-arg-tag init env)] (assoc e acc tag) e))
+                          env components)
+          index-env (into (assoc acc-env idx 'long) (map (fn [[segment _]] [segment 'long]) segment-axes))
+          [element-env element-bindings']
+          (reduce (fn [[e bindings] [sym init]]
+                    (let [resolved (resolve-dispatch-walk init e)
+                          tag (inf/infer-arg-tag resolved e)]
+                      [(if tag (assoc e sym tag) e) (conj bindings sym resolved)]))
+                  [index-env []] (partition 2 element-bindings))
+          combine-env (reduce (fn [e [[left right] [acc _ _]]]
+                                (if-let [tag (get acc-env acc)]
+                                  (assoc e left tag right tag) e))
+                              env (map vector combine-parameters components))
+          [combine-result-env combine-bindings']
+          (reduce (fn [[e bindings] [sym init]]
+                    (let [resolved (resolve-dispatch-walk init e)
+                          tag (inf/infer-arg-tag resolved e)]
+                      [(if tag (assoc e sym tag) e) (conj bindings sym resolved)]))
+                  [combine-env []] (partition 2 combine-bindings))
+          r (list head outputs
+                  (mapv (fn [[acc init dtype]]
+                          [acc (resolve-dispatch-walk init env) dtype]) components)
+                  (mapv (fn [[segment segment-bound]]
+                          [segment (resolve-dispatch-walk segment-bound env)]) segment-axes)
+                  idx (resolve-dispatch-walk bound env)
+                  (vec element-bindings')
+                  (mapv #(resolve-dispatch-walk % element-env) element-results)
+                  combine-parameters
+                  (vec combine-bindings')
+                  (mapv #(resolve-dispatch-walk % combine-result-env) combine-results)
+                  algebra)]
+      (if-let [m (meta expr)] (with-meta r m) r))
     ;; Qualified symbol call: try dispatch resolution then recurse into args
     (and (symbol? (first expr)) (namespace (first expr)))
     (let [;; First recurse into args so nested calls get resolved
@@ -1731,4 +1770,3 @@
    (-> (inline-deftm-calls form max-depth false true)
        inline-invk
        flatten-nested-lets)))
-

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -606,7 +606,8 @@
   scalar math, aliases, constants) MUST carry :raster.type/tag at the fixpoint
   edge."
   [head]
-  (or (contains? '#{raster.par/map-void! par/map-void! dotimes} head)
+  (or (contains? '#{raster.par/map-void! par/map-void!
+                    raster.par/product-reduce! par/product-reduce! dotimes} head)
       (contains? census-exempt-int-arith-heads head)
       (= :vector head)))
 

--- a/src/raster/dl/array_ops.clj
+++ b/src/raster/dl/array_ops.clj
@@ -111,60 +111,34 @@
   so a row containing NaNs returns the first NaN column and exposes numerical corruption rather
   than silently choosing an unrelated finite logit.
 
-  The schedule is a two-stage product reduction: parallel 256-element tiles write compiler-owned
-  `(value,index)` scratch, then one work-item merges the tile results for each row. This avoids the
-  noncompetitive one-work-item-per-vocabulary scan while keeping the public ABI free of scratch.
-  `width` must be positive."
+  The semantics are one typed segmented product reduction over `(value,index)`. The portable GPU
+  schedule assigns one workgroup to each row: lanes fold strided columns and a fixed local-memory
+  tree applies the same associative combine. Quantized storage and physical layouts remain operand
+  concerns rather than reduction or allocation variants. `width` must be positive."
   [values :- (Array float), indices :- (Array int), nrows :- Long, width :- Long] :- Void
-  (let [tile-size (long 256)
-        tile-count (long (quot (+ width (dec tile-size)) tile-size))
-        partial-values (float-array (* nrows tile-count))
-        partial-indices (int-array (* nrows tile-count))]
-    (par/map-void! tile (* nrows tile-count)
-                   (let [row (quot tile tile-count)
-                         tile-in-row (rem tile tile-count)
-                         start (* tile-in-row tile-size)
-                         end (min width (+ start tile-size))
-                         row-base (* row width)
-                         first-value (aget values (+ row-base start))
-                         first-nan (int (if (== first-value first-value) 0 1))]
-                     (loop [col (long (inc start)) best-index (int start)
-                            best-value (float first-value) best-nan first-nan]
-                       (if (< col end)
-                         (let [candidate (aget values (+ row-base col))
-                               candidate-nan (int (if (== candidate candidate) 0 1))
-                               better (int (if (== candidate-nan 1)
-                                             (if (== best-nan 0) 1 0)
-                                             (if (== best-nan 1)
-                                               0
-                                               (if (> candidate best-value) 1 0))))]
-                           (if (== better 1)
-                             (recur (long (inc col)) (int col) candidate candidate-nan)
-                             (recur (long (inc col)) best-index best-value best-nan)))
-                         (do
-                           (aset partial-values tile best-value)
-                           (aset partial-indices tile best-index))))))
-    (par/map-void! row nrows
-                   (let [base (* row tile-count)
-                         first-value (aget partial-values base)
-                         first-index (aget partial-indices base)
-                         first-nan (int (if (== first-value first-value) 0 1))]
-                     (loop [tile-in-row (long 1) best-index first-index
-                            best-value (float first-value) best-nan first-nan]
-                       (if (< tile-in-row tile-count)
-                         (let [tile (+ base tile-in-row)
-                               candidate (aget partial-values tile)
-                               candidate-index (aget partial-indices tile)
-                               candidate-nan (int (if (== candidate candidate) 0 1))
-                               better (int (if (== candidate-nan 1)
-                                             (if (== best-nan 0) 1 0)
-                                             (if (== best-nan 1)
-                                               0
-                                               (if (> candidate best-value) 1 0))))]
-                           (if (== better 1)
-                             (recur (long (inc tile-in-row)) candidate-index candidate candidate-nan)
-                             (recur (long (inc tile-in-row)) best-index best-value best-nan)))
-                         (aset indices row best-index)))))))
+  (par/product-reduce!
+   [nil indices]
+   [[best-value (float Float/NEGATIVE_INFINITY) :float]
+    [best-index (int Integer/MAX_VALUE) :int]]
+   [[row nrows]]
+   col width
+   [candidate (aget values (+ (* row width) col))]
+   [candidate (int col)]
+   [[left-value right-value] [left-index right-index]]
+   [left-nan (int (if (== left-value left-value) 0 1))
+    right-nan (int (if (== right-value right-value) 0 1))
+    better (int (if (== right-nan 1)
+                  (if (== left-nan 1) (if (< right-index left-index) 1 0) 1)
+                  (if (== left-nan 1)
+                    0
+                    (if (> right-value left-value)
+                      1
+                      (if (== right-value left-value)
+                        (if (< right-index left-index) 1 0) 0)))))]
+   [(if (== better 1) right-value left-value)
+    (if (== better 1) right-index left-index)]
+   {:associative? true :commutative? true
+    :order {:nan :highest :tie :lowest-index}}))
 
 (deftm gather-rows!
   "Copy rows selected by `indices[nrows]` from row-major `src[*,width]` into caller-owned

--- a/src/raster/par.clj
+++ b/src/raster/par.clj
@@ -138,6 +138,70 @@
            (recur (inc ~idx-sym) ~body-expr)
            ~acc-sym)))))
 
+(defmacro product-reduce!
+  "Typed segmented product reduction.
+
+  Form:
+    (product-reduce! outputs
+      [[acc neutral dtype] ...]
+      [[segment-index segment-bound] ...]
+      reduce-index reduce-bound
+      [element-local value ...]
+      [element-value ...]
+      [[left right] ...]
+      [combine-local value ...]
+      [combined-value ...]
+      algebra)
+
+  `outputs` is ordered with the components; nil discards a final component.  `algebra` records
+  semantic facts for scheduling and is not a runtime argument.  The interpreted fallback is a
+  deterministic sequential fold per segment; accelerator lowering may choose a parallel tree.
+
+  Example: argmax reduces `[value,index]`, discards the winning value, and writes the index."
+  [outputs components segment-axes idx-sym bound-expr
+   element-bindings element-results combine-parameters combine-bindings combine-results algebra]
+  (assert (vector? outputs) "product-reduce!: outputs must be a vector")
+  (assert (and (vector? components) (seq components)
+               (every? #(and (vector? %) (= 3 (count %))) components))
+          "product-reduce!: components must be [[acc neutral dtype] ...]")
+  (assert (= (count outputs) (count components) (count element-results)
+             (count combine-parameters) (count combine-results))
+          "product-reduce!: outputs, components, element and combine results must have equal arity")
+  (assert (and (vector? segment-axes)
+               (every? #(and (vector? %) (= 2 (count %))) segment-axes))
+          "product-reduce!: segment axes must be [[index bound] ...]")
+  (assert (and (vector? element-bindings) (even? (count element-bindings)))
+          "product-reduce!: element bindings must be a flat binding vector")
+  (assert (and (vector? combine-bindings) (even? (count combine-bindings)))
+          "product-reduce!: combine bindings must be a flat binding vector")
+  (assert (every? #(and (vector? %) (= 2 (count %))) combine-parameters)
+          "product-reduce!: combine parameters must be [[left right] ...]")
+  (assert (map? algebra) "product-reduce!: algebra must be a map")
+  (let [accs (mapv first components)
+        neutrals (mapv second components)
+        n-sym (gensym "n__")
+        flat-index (clojure.core/reduce (fn [flat [segment bound]]
+                                          `(+ (* ~flat (int ~bound)) ~segment))
+                                        0 segment-axes)
+        stores (keep (fn [[out acc]]
+                       (when out `(clojure.core/aset ~out ~flat-index ~acc)))
+                     (clojure.core/map vector outputs accs))
+        fold `(let [~n-sym (long ~bound-expr)]
+                (loop [~idx-sym (long 0)
+                       ~@(mapcat vector accs neutrals)]
+                  (if (< ~idx-sym ~n-sym)
+                    (let [~@element-bindings
+                          ~@(mapcat (fn [[[left right] acc element]]
+                                      [left acc right element])
+                                    (clojure.core/map vector combine-parameters accs element-results))
+                          ~@combine-bindings]
+                      (recur (unchecked-inc ~idx-sym) ~@combine-results))
+                    (do ~@stores nil))))
+        segmented (clojure.core/reduce (fn [body [segment bound]]
+                                         `(dotimes [~segment (int ~bound)] ~body))
+                                       fold (reverse segment-axes))]
+    `(do ~segmented nil)))
+
 (defmacro contract
   "Explicit tensor contraction (SOAC). Declares FREE (parallel/output) axes and
   CONTRACTED (reduced) axes separately — the reliable, unambiguous scheduling signal

--- a/test/raster/compiler/csimd_test.clj
+++ b/test/raster/compiler/csimd_test.clj
@@ -7,7 +7,8 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.cpu.csimd :as cs]
             [raster.compiler.backend.cpu.codegen :as cpu]
-            [raster.compiler.backend.gpu.c-emit :as ce]))
+            [raster.compiler.backend.gpu.c-emit :as ce]
+            [raster.compiler.ir.reduction :as reduction]))
 
 (defn- clang-avx2? []
   (try
@@ -17,19 +18,21 @@
 
 (defn- ssq-segred [dt]
   {:space {:dims [{:name 'i :bound 'n}]} :dtype dt
-   :reduce-op {:acc 'acc :init 0.0
-               :lambda '(.invk raster.numeric/_plus__m_double_double-impl acc
-                          (.invk raster.numeric/_star__m_double_double-impl
-                            (clojure.core/aget x (long i))
-                            (clojure.core/aget x (long i))))}})
+   :reduction (reduction/scalar
+               {:accumulator 'acc :neutral 0.0 :dtype dt :result 'out :index 'i
+                :step-result '(.invk raster.numeric/_plus__m_double_double-impl acc
+                                     (.invk raster.numeric/_star__m_double_double-impl
+                                            (clojure.core/aget x (long i))
+                                            (clojure.core/aget x (long i))))})})
 
 (defn- dot-segred [dt]
   {:space {:dims [{:name 'i :bound 'n}]} :dtype dt
-   :reduce-op {:acc 'acc :init 0.0
-               :lambda '(.invk raster.numeric/_plus__m_double_double-impl acc
-                          (.invk raster.numeric/_star__m_double_double-impl
-                            (clojure.core/aget a (long i))
-                            (clojure.core/aget b (long i))))}})
+   :reduction (reduction/scalar
+               {:accumulator 'acc :neutral 0.0 :dtype dt :result 'out :index 'i
+                :step-result '(.invk raster.numeric/_plus__m_double_double-impl acc
+                                     (.invk raster.numeric/_star__m_double_double-impl
+                                            (clojure.core/aget a (long i))
+                                            (clojure.core/aget b (long i))))})})
 
 (defn- run1 [native arrs n]
   (let [out (first arrs)]
@@ -85,8 +88,8 @@
 (defn- axpy-segmap [dt]
   {:space {:dims [{:name 'L :bound 'n}]} :dtype dt :out-sym 'y :cast-fn (if (= dt :float) 'float 'double)
    :lambda '(.invk raster.numeric/_plus__m_double_double-impl
-              (.invk raster.numeric/_star__m_double_double-impl (clojure.core/aget a (long L)) s)
-              (clojure.core/aget b (long L)))})
+                   (.invk raster.numeric/_star__m_double_double-impl (clojure.core/aget a (long L)) s)
+                   (clojure.core/aget b (long L)))})
 
 (deftest segmap-elementwise-matches-scalar
   (testing "y[L]=a[L]*s+b[L] via compile-segmap-c == scalar, f64 and f32"
@@ -120,11 +123,11 @@
       (println "[csimd-test] clang/AVX2 unavailable — skipping")
       (let [segmap {:space {:dims [{:name 'L :bound 'n}]} :dtype :float :out-sym 'acc :cast-fn 'float
                     :lambda '(.invk raster.numeric/_plus__m_float_float-impl
-                               (clojure.core/aget acc (long L))
-                               (.invk raster.numeric/_star__m_float_float-impl
-                                 (clojure.core/aget scale (long L))
-                                 (float (.invk raster.numeric/_minus__m_long_long-impl
-                                          (long (clojure.core/aget iarr (long L))) k))))}
+                                    (clojure.core/aget acc (long L))
+                                    (.invk raster.numeric/_star__m_float_float-impl
+                                           (clojure.core/aget scale (long L))
+                                           (float (.invk raster.numeric/_minus__m_long_long-impl
+                                                         (long (clojure.core/aget iarr (long L))) k))))}
             {:keys [includes block]}
             (binding [cs/*array-types* '{acc :float scale :float iarr :int}
                       ce/*emit-config* cpu/cpu-config ce/*scalar-type* "float" ce/*int-vars* '#{n k}]

--- a/test/raster/compiler/ir/reduction_test.clj
+++ b/test/raster/compiler/ir/reduction_test.clj
@@ -1,0 +1,148 @@
+(ns raster.compiler.ir.reduction-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [raster.compiler.backend.gpu.segop-opencl :as segop-opencl]
+            [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.ir.par :as par-ir]
+            [raster.compiler.ir.reduction :as reduction]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.ir.soac :as soac]
+            [raster.compiler.passes.parallel.soac-lower :as soac-lower]
+            [raster.par]))
+
+(def argmax-product-form
+  '(raster.par/product-reduce!
+    [nil indices]
+    [[best-value (float Float/NEGATIVE_INFINITY) :float]
+     [best-index (int Integer/MAX_VALUE) :int]]
+    [[row nrows]]
+    col width
+    [candidate (clojure.core/aget values (+ (* row width) col))]
+    [candidate (int col)]
+    [[left-value right-value] [left-index right-index]]
+    [left-nan (int (if (== left-value left-value) 0 1))
+     right-nan (int (if (== right-value right-value) 0 1))
+     better (int (if (== right-nan 1)
+                   (if (== left-nan 1) (if (< right-index left-index) 1 0) 1)
+                   (if (== left-nan 1)
+                     0
+                     (if (> right-value left-value)
+                       1
+                       (if (== right-value left-value)
+                         (if (< right-index left-index) 1 0) 0)))))]
+    [(if (== better 1) right-value left-value)
+     (if (== better 1) right-index left-index)]
+    {:associative? true :commutative? true
+     :order {:nan :highest :tie :lowest-index}}))
+
+(deftest canonical-scalar-is-one-component-product-test
+  (let [operator (reduction/scalar
+                  {:accumulator 'acc :neutral 0.0 :dtype :double :result 'sum
+                   :index 'i :step-result '(+ acc (aget values i))})]
+    (is (reduction/product-reduction? operator))
+    (is (reduction/scalar? operator))
+    (is (= [:double] (reduction/dtypes operator)))
+    (is (= {:acc 'acc :init 0.0 :lambda '(+ acc (aget values i))}
+           (reduction/scalar-op operator)))))
+
+(deftest typed-product-validation-test
+  (let [node (soac/par-form->soac '_ argmax-product-form 7 :dtype :float)
+        operator (:reduction node)]
+    (testing "ordered logical components carry independent dtypes and optional results"
+      (is (reduction/product-reduction? operator))
+      (is (= [:float :int] (reduction/dtypes operator)))
+      (is (= [nil 'indices] (reduction/results operator)))
+      (is (= ['best-value 'best-index] (reduction/accumulators operator))))
+    (testing "element and closed binary combine regions are separate"
+      (is (= '[candidate (clojure.core/aget values (+ (* row width) col))]
+             (:bindings (reduction/element-region operator))))
+      (is (= '[[left-value right-value] [left-index right-index]]
+             (:parameters (reduction/combine-region operator))))
+      (is (= true (get-in operator [:algebra :associative?]))))
+    (testing "segmentation survives SOAC to SegRed lowering"
+      (let [scheduled (first (soac-lower/lower-soac node :cpu:0 :dtype :float))]
+        (is (= :product (:phase scheduled)))
+        (is (= '[row col] (mapv :name (segop/seg-space-dims (:space scheduled)))))
+        (is (= #{'indices} (:outputs scheduled)))
+        (is (= [:float :int] (reduction/dtypes (:reduction scheduled))))
+        (is (= (* 8 (get-in scheduled [:grid :block-size]))
+               (get-in scheduled [:grid :shared-mem-bytes])))
+        (testing "the portable target leaf emits a mixed-dtype workgroup tree"
+          (let [artifact (segop-opencl/generate-product-reduction-kernel
+                          scheduled
+                          :scalar-types {'nrows :int 'width :int}
+                          :array-types {'values :float})
+                source (:source artifact)]
+            (is (= [:float :int]
+                   (get-in artifact [:attributes :component-dtypes])))
+            (is (= [:input :output :scalar :scalar :scalar]
+                   (mapv :kind (:abi artifact))))
+            (is (str/includes? source (str "__local float shared_0["
+                                           (get-in scheduled [:grid :block-size]) "]")))
+            (is (str/includes? source (str "__local int shared_1["
+                                           (get-in scheduled [:grid :block-size]) "]")))
+            (is (str/includes? source "barrier(CLK_LOCAL_MEM_FENCE)"))))))
+    (testing "the schedule accounts for every component against the target SLM budget"
+      (let [descriptor (assoc-in (hardware/descriptor-for :cpu:0) [:cache :slm] 512)
+            scheduled (with-redefs [hardware/descriptor-for (constantly descriptor)]
+                        (first (soac-lower/lower-soac node :cpu:0 :dtype :float)))]
+        (is (= 64 (get-in scheduled [:schedule :workgroup-size])))
+        (is (= 512 (get-in scheduled [:grid :shared-mem-bytes])))
+        (is (= 512 (get-in scheduled [:schedule :attributes :slm-budget])))))
+    (testing "a computed reduction bound survives into target source"
+      (let [scheduled (-> (first (soac-lower/lower-soac node :cpu:0 :dtype :float))
+                          (assoc-in [:space :dims 1 :bound] '(- width 1)))
+            source (:source (segop-opencl/generate-product-reduction-kernel
+                             scheduled
+                             :scalar-types {'nrows :int 'width :int}
+                             :array-types {'values :float}))]
+        (is (str/includes? source "< (width - 1)"))))
+    (testing "arity loss is rejected at construction"
+      (is (thrown-with-msg?
+           Exception #"arity"
+           (reduction/make
+            {:components [{:id :v :accumulator 'v :neutral 0.0 :dtype :float :result nil}
+                          {:id :i :accumulator 'i :neutral 0 :dtype :int :result 'indices}]
+             :index 'col
+             :element-bindings [] :element-results ['candidate]
+             :combine-parameters [['lv 'rv] ['li 'ri]]
+             :combine-bindings [] :combine-results ['rv 'ri]}))))))
+
+(deftest product-reduce-reference-semantics-test
+  (let [values (float-array [1.0 Float/NaN Float/NaN -2.0
+                             4.0 9.0 9.0 3.0])
+        indices (int-array 2)
+        nrows 2
+        width 4]
+    (raster.par/product-reduce!
+     [nil indices]
+     [[best-value (float Float/NEGATIVE_INFINITY) :float]
+      [best-index (int Integer/MAX_VALUE) :int]]
+     [[row nrows]]
+     col width
+     [candidate (aget values (+ (* row width) col))]
+     [candidate (int col)]
+     [[left-value right-value] [left-index right-index]]
+     [left-nan (int (if (== left-value left-value) 0 1))
+      right-nan (int (if (== right-value right-value) 0 1))
+      better (int (if (== right-nan 1)
+                    (if (== left-nan 1) (if (< right-index left-index) 1 0) 1)
+                    (if (== left-nan 1)
+                      0
+                      (if (> right-value left-value)
+                        1
+                        (if (== right-value left-value)
+                          (if (< right-index left-index) 1 0) 0)))))]
+     [(if (== better 1) right-value left-value)
+      (if (== better 1) right-index left-index)]
+     {:associative? true :commutative? true
+      :order {:nan :highest :tie :lowest-index}})
+    (is (= [1 1] (vec indices)))))
+
+(deftest product-reduce-par-scope-test
+  (let [{:keys [scopes outer]} ((requiring-resolve 'raster.compiler.ir.form/scope-info)
+                                argmax-product-form)]
+    (is (contains? (set (:binders (first scopes))) 'col))
+    (is (contains? (set (:binders (first scopes))) 'left-value))
+    (is (some #{'nrows} outer))
+    (is (some #{'width} outer))))

--- a/test/raster/compiler/ir/screma_test.clj
+++ b/test/raster/compiler/ir/screma_test.clj
@@ -1,5 +1,6 @@
 (ns raster.compiler.ir.screma-test
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.soac :as soac]))
 
 ;; ================================================================
@@ -27,8 +28,8 @@
       (is (empty? (:scans screma)))
       (is (= 1 (count (:reduces screma))))
       (let [r (first (:reduces screma))]
-        (is (= 'acc (:acc r)))
-        (is (= 0.0 (:init r)))))))
+        (is (= ['acc] (reduction/accumulators r)))
+        (is (= [0.0] (reduction/neutrals r)))))))
 
 (deftest screma-from-scan-test
   (testing "SoacScan → Screma: pure scan with one scan op"
@@ -79,17 +80,19 @@
 
 (deftest screma-map-reduce-unfused-throws
   (testing "a reduce screma still carrying a :map-lambda is rejected, not silently reduce-only"
-    (let [screma (soac/->Screma 1 'r 'i 'n #{'a 'tmp} #{'r} #{}
-                                nil [] [{:acc 'acc :init 0.0
-                                         :lambda '(+ acc (aget tmp i))}]
+    (let [red (reduction/scalar {:accumulator 'acc :neutral 0.0 :dtype :double
+                                 :result 'r :index 'i :step-result '(+ acc (aget tmp i))})
+          screma (soac/->Screma 1 'r 'i 'n #{'a 'tmp} #{'r} #{}
+                                nil [] [red]
                                 '(* (aget a i) 2.0))]
       (is (thrown-with-msg?
            Exception #"was not inlined into the reduce lambda"
            (soac/screma->par-form screma)))))
   (testing "a properly-fused reduce (no map-lambda) still converts"
-    (let [screma (soac/->Screma 1 'r 'i 'n #{'a} #{'r} #{}
-                                nil [] [{:acc 'acc :init 0.0
-                                         :lambda '(+ acc (aget a i))}]
+    (let [red (reduction/scalar {:accumulator 'acc :neutral 0.0 :dtype :double
+                                 :result 'r :index 'i :step-result '(+ acc (aget a i))})
+          screma (soac/->Screma 1 'r 'i 'n #{'a} #{'r} #{}
+                                nil [] [red]
                                 nil)]
       (is (= 'raster.par/reduce (first (soac/screma->par-form screma)))))))
 

--- a/test/raster/compiler/ir/segop_test.clj
+++ b/test/raster/compiler/ir/segop_test.clj
@@ -107,7 +107,7 @@
     (let [soac (soac/par-form->soac 'result
                                     '(raster.par/reduce acc 0.0 j n (+ acc (aget a j))) 0)
           segops (lower/lower-reduce soac nil)
-          op (:reduce-op (first segops))]
+          op (segop/scalar-reduce-op (first segops))]
       (is (= 'acc (:acc op)))
       (is (= 0.0 (:init op))))))
 

--- a/test/raster/compiler/ir/soac_test.clj
+++ b/test/raster/compiler/ir/soac_test.clj
@@ -1,5 +1,6 @@
 (ns raster.compiler.ir.soac-test
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.soac :as soac]
             [raster.par :as par]))
 
@@ -30,13 +31,13 @@
       (is (instance? raster.compiler.ir.soac.SoacReduce node))
       (is (= 1 (:id node)))
       (is (= 'result (:sym node)))
-      (is (= 'acc (:acc node)))
-      (is (= 0.0 (:init node)))
-      (is (= 'j (:idx node)))
+      (is (= ['acc] (reduction/accumulators (:reduction node))))
+      (is (= [0.0] (reduction/neutrals (:reduction node))))
+      (is (= 'j (:index (:reduction node))))
       (is (= 'n (:bound node)))
-      (is (= '(+ acc (aget a j)) (:lambda node)))
+      (is (= ['(+ acc (aget a j))] (:results (reduction/fold-region (:reduction node)))))
       (is (= #{'a} (:inputs node)))
-      (is (= 'result (:output node))))))
+      (is (= ['result] (:outputs node))))))
 
 (deftest par-scan->soac-test
   (testing "Convert raster.par/scan to SoacScan"

--- a/test/raster/compiler/passes/parallel/contract_lower_test.clj
+++ b/test/raster/compiler/passes/parallel/contract_lower_test.clj
@@ -7,7 +7,7 @@
 (deftest contract-form-to-segred-nn
   (testing "matmul :nn form → segmented SegRed with free segments + reduced contract axis"
     (let [form '(raster.par/contract C [[i m] [j n]] [[l k]]
-                  (* (aget A (+ (* i k) l)) (aget B (+ (* l n) j))))
+                                     (* (aget A (+ (* i k) l)) (aget B (+ (* l n) j))))
           sr (cl/contract-form->segred form :id 5)]
       (is (instance? raster.compiler.ir.segop.SegRed sr))
       (testing "space: free axes are OUTER segment dims, contract axis is INNERMOST reduced"
@@ -17,11 +17,11 @@
         (is (= {:name 'l :bound 'k} (segop/seg-space-reduced-dim (:space sr))))
         (is (= '(* m n) (segop/seg-space-num-segments-expr (:space sr)))))
       (testing "reduce-op: init 0.0, combine +, product in the element slot; map-lambda nil"
-        (is (= 0.0 (:init (:reduce-op sr))))
-        (is (= '+ (first (:lambda (:reduce-op sr)))))
+        (is (= 0.0 (:init (segop/scalar-reduce-op sr))))
+        (is (= '+ (first (:lambda (segop/scalar-reduce-op sr)))))
         ;; combine is (+ acc <product>) — the product is the last operand
         (is (= '(* (aget A (+ (* i k) l)) (aget B (+ (* l n) j)))
-               (last (:lambda (:reduce-op sr)))))
+               (last (:lambda (segop/scalar-reduce-op sr)))))
         (is (nil? (:lambda sr))))
       (testing "inputs {A B}, output {C}, scalars = the dim bounds (not index vars/arrays)"
         (is (= '#{A B} (:inputs sr)))
@@ -35,7 +35,7 @@
 (deftest contract-form-single-free-axis
   (testing "matvec: 1 free axis → 1 segment dim + reduced dim, no phantom segments"
     (let [form '(raster.par/contract y [[i m]] [[l k]]
-                  (* (aget A (+ (* i k) l)) (aget x l)))
+                                     (* (aget A (+ (* i k) l)) (aget x l)))
           sr (cl/contract-form->segred form)]
       (is (= 2 (count (segop/seg-space-dims (:space sr)))))
       (is (= [{:name 'i :bound 'm}] (segop/seg-space-segment-dims (:space sr))))
@@ -47,16 +47,16 @@
 (deftest contract-form-custom-init-combine
   (testing "opts :init/:combine flow into reduce-op (e.g. max-plus semiring)"
     (let [form '(raster.par/contract C [[i m] [j n]] [[l k]]
-                  (+ (aget A (+ (* i k) l)) (aget B (+ (* l n) j)))
-                  :init -1.0e30 :combine max)
+                                     (+ (aget A (+ (* i k) l)) (aget B (+ (* l n) j)))
+                                     :init -1.0e30 :combine max)
           sr (cl/contract-form->segred form)]
-      (is (= -1.0e30 (:init (:reduce-op sr))))
-      (is (= 'max (first (:lambda (:reduce-op sr))))))))
+      (is (= -1.0e30 (:init (segop/scalar-reduce-op sr))))
+      (is (= 'max (first (:lambda (segop/scalar-reduce-op sr))))))))
 
 (deftest contract-form-three-free-axes
   (testing "batched matmul: 3 free axes → 3 segment dims, num-segments = product"
     (let [form '(raster.par/contract C [[b btch] [i m] [j n]] [[l k]]
-                  (* (aget A x) (aget B y)))
+                                     (* (aget A x) (aget B y)))
           sr (cl/contract-form->segred form)]
       (is (= 4 (count (segop/seg-space-dims (:space sr)))))
       (is (= 3 (count (segop/seg-space-segment-dims (:space sr)))))

--- a/test/raster/dl/indexed_reduction_test.clj
+++ b/test/raster/dl/indexed_reduction_test.clj
@@ -55,17 +55,17 @@
       (is (= '[values indices nrows width] (:all-params descriptor)))
       (is (= '[values indices] (:array-params descriptor)))
       (is (= '[nrows width] (:scalar-params descriptor))))
-    (testing "the compiler owns typed product scratch"
-      (is (= ['partial-values 'partial-indices] (mapv :sym allocs)))
-      (is (= [:float :int] (mapv :dtype allocs)))
-      (is (= [12 12] (mapv #((:size-fn %) arguments) allocs))))
-    (testing "the reduction remains two ordered target-neutral map stages"
-      (is (= [:map-void :map-void] (mapv :convention steps)))
-      (is (= 2 (count steps)))
-      (is (= #{'partial-values 'partial-indices}
-             (set (take 2 (get-in steps [0 :artifact :arguments])))))
-      (is (= #{'indices 'partial-indices 'partial-values}
-             (set (take 3 (get-in steps [1 :artifact :arguments]))))))
+    (testing "schedule scratch is local to the emitted product kernel"
+      (is (empty? allocs))
+      (is (= :segmented-workgroup-tree
+             (get-in steps [0 :artifact :attributes :schedule :strategy]))))
+    (testing "the typed product reduction is one resident scheduled step"
+      (is (= [:map-void] (mapv :convention steps)))
+      (is (= 1 (count steps)))
+      (is (= ['values 'indices]
+             (vec (take 2 (get-in steps [0 :artifact :arguments])))))
+      (is (= [:float :int]
+             (get-in steps [0 :artifact :attributes :component-dtypes]))))
     (testing "OpenCL and Level Zero preserve the same typed lowering"
       (is (apply = (map (comp #(mapv :dtype %) :allocs val) descriptors)))
       (is (apply = (map (comp #(mapv :convention %) :steps val) descriptors)))
@@ -73,10 +73,12 @@
                                        (mapv (juxt :kind :dtype :kernel-dtype) (:abi step))) %)
                               :steps val)
                         descriptors))))
-    (testing "OpenCL C preserves integer schedule scalars and portable NaN comparison"
-      (is (str/includes? (first sources) "int tile_count"))
-      (is (str/includes? (first sources) "int tile_size"))
+    (testing "OpenCL C preserves mixed local products and portable NaN comparison"
+      (is (str/includes? (first sources) "__local float shared_0"))
+      (is (str/includes? (first sources) "__local int shared_1"))
+      (is (str/includes? (first sources) "for (int col = lid"))
+      (is (str/includes? (first sources) "barrier(CLK_LOCAL_MEM_FENCE)"))
       (is (every? #(not (str/includes? % "boolean(")) sources))
-      (is (every? #(str/includes? % "(float)(candidate) == (float)(candidate)") sources)))
+      (is (every? #(str/includes? % "(float)(elem_0) == (float)(elem_0)") sources)))
     (testing "the descriptor certifies as a composable LinkPlan before allocation"
       (is (resident-plan/certified-plan? (resident-plan/verify! lowering))))))

--- a/test/raster/dl/row_gather_test.clj
+++ b/test/raster/dl/row_gather_test.clj
@@ -1,6 +1,5 @@
 (ns raster.dl.row-gather-test
-  (:require [clojure.string :as str]
-            [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.resident-plan :as resident-plan]
             [raster.compiler.pipeline :as pipeline]
             [raster.core :refer [deftm]]
@@ -75,11 +74,10 @@
     (testing "selection and lookup compose without a fused attention primitive"
       (is (= [7 400] (vec token-indices)))
       (is (= [21.0 22.0 23.0 1200.0 1201.0 1202.0] (vec rows))))
-    (testing "the compiled graph retains three ordered kernels and only reduction scratch"
-      (is (= [:map-void :map-void :map-void] (mapv :convention (:steps descriptor))))
-      (is (= [true true]
-             (mapv (fn [{:keys [sym]} prefix] (str/starts-with? (name sym) prefix))
-                   (:allocs descriptor) ["partial-values" "partial-indices"])))
-      (is (= [:float :int] (mapv :dtype (:allocs descriptor)))))
+    (testing "the compiled graph retains one scheduled reduction and one independent row gather"
+      (is (= [:map-void :map-void] (mapv :convention (:steps descriptor))))
+      (is (empty? (:allocs descriptor)))
+      (is (= :segmented-workgroup-tree
+             (get-in descriptor [:steps 0 :artifact :attributes :schedule :strategy]))))
     (testing "the ordinary multi-output descriptor certifies before allocation"
       (is (resident-plan/certified-plan? (resident-plan/verify! lowering))))))


### PR DESCRIPTION
This lands roadmap items 2 and 3 as one compiler vertical.

It makes scalar reduction the one-component case of a canonical typed ProductReduction, carries ordered mixed-dtype components and explicit element/combine regions through SOAC and SegRed, and adds a first-class ReductionSchedule. The portable OpenCL lowering emits a hardware-constrained workgroup-local tree with typed component scratch and a stable ordered ABI.

The production consumer is argmax-rows!: it now emits one deterministic value/index product reduction per row, without compiler-visible global scratch or attention/quantization-specific lowering. Ties choose the lowest index and NaNs are ordered first.

Validation:
- isolated full suite: 2,340 tests, 33,772 assertions, 0 failures/errors
- cross-backend/composition matrix: 104 tests, 464 assertions, 0 failures/errors
- real Intel Arc OpenCL resident argmax round trip: pass
- all touched Clojure files pass cljfmt; git diff --check passes

The full-suite run used a writable temporary user.home for compiler caches, which made GPU tests take their skip path. The separate Arc run is the device-execution gate. The repository-wide formatter remains red on unrelated pre-existing files; formatting was checked on every file touched here.