### PR TITLE
Make scheduled contraction kernel bodies first class

### DIFF
--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -393,6 +393,12 @@
                      (croute/route-contraction
                       form :dtype dtype
                       :facts (:facts bound-sc)
+                      :operation-id (:id bound-sc)
+                      ;; The resolved, feasibility-checked schedule is the single source of tile
+                      ;; geometry.  Previously this option reached opencl-pass but contractions
+                      ;; ignored it and re-derived a default, so a pinned/autotuned :tile changed
+                      ;; neither the KernelBody nor emitted source.
+                      :tile (:tile schedule)
                       :desc (try ((requiring-resolve 'raster.compiler.core.hardware/descriptor-for)
                                   device-id)
                                  (catch Throwable _ nil))))

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -19,6 +19,7 @@
             [raster.compiler.ir.contraction-facts :as cf]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-body :as kbody]
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.ir.scan :as scan]
@@ -1331,15 +1332,78 @@
      :epilogue-params params
      :epilogue-helpers helpers}))
 
+(defn- emit-dpas-plan
+  "Lower one already-checked DPAS plan.  This remains the shadow target adapter while the
+   `emit-gemm-tiled` template is decomposed into per-operation KernelBody lowering.  All schedule,
+   layout and boundary decisions have already happened before this boundary."
+  [kernel-name row-arr col-arr out-sym [M N L] [i-sym j-sym] tile epilogue kernel-body]
+  (let [sg (long (get-in tile [:matrix :subgroup] 16))
+        ep (when epilogue
+             (epilogue-splice epilogue [i-sym j-sym] (get epilogue :dtype :float)))
+        source (apply codegen/emit-gemm-tiled kernel-name
+                      (concat [:c-dtype :half
+                               :block-m (:block-m tile) :block-n (:block-n tile)
+                               :sg-m (:sg-m tile) :sg-n (:sg-n tile)
+                               :block-k (:block-k tile) :matrix (:matrix tile)
+                               :prefetch (:num-stages tile 3)]
+                              (when ep [:epilogue (:epilogue ep)
+                                        :epilogue-params (:epilogue-params ep)
+                                        :epilogue-helpers (:epilogue-helpers ep)])))]
+    (cond->
+     {:kernel-name kernel-name
+      :source source
+      :array-params [row-arr col-arr]
+      :abi (kabi/validate!
+            (vec (concat
+                  [(kabi/slot row-arr :input :half :c-name "A" :role :operand)
+                   (kabi/slot col-arr :input :half :c-name "B" :role :operand)
+                   (kabi/slot out-sym :output :half :c-name "C" :role :result)
+                   (kabi/slot 'M :scalar :int :role :dimension)
+                   (kabi/slot 'N :scalar :int :role :dimension)
+                   (kabi/slot 'K :scalar :int :role :dimension)]
+                  (for [{:keys [sym dtype] :or {dtype :float}} (:operands epilogue)]
+                    (kabi/slot sym :input dtype :c-name (ce/c-symbol sym) :role :epilogue))
+                  (for [{:keys [sym dtype] :or {dtype :float}} (:scalars epilogue)]
+                    (kabi/slot sym :scalar dtype :c-name (ce/c-symbol sym) :role :epilogue)))))
+      :dims [M N L]
+      :dtype :half
+      :tile tile
+      :epilogue-params (when ep (:epilogue-params ep))
+      :epilogue-operands (when ep (mapv :sym (:operands epilogue)))
+      :epilogue-scalars (when ep (mapv :sym (:scalars epilogue)))
+      :workgroup [(* (quot (:block-m tile) (:sg-m tile))
+                     (quot (:block-n tile) (:sg-n tile))
+                     sg) 1]
+      :tensorized true}
+      kernel-body (assoc :kernel-body kernel-body))))
+
+(defn generate-dpas-kernel-body
+  "Lower a verified, scheduled matrix KernelBody to the Intel OpenCL target.
+
+   This is deliberately a separate boundary from contraction scheduling.  The adapter currently
+   shadows the proven source generator; the body is nevertheless production data and is verified
+   before emission, so subsequent changes can replace one operation at a time without re-parsing
+   the contraction or inventing another schedule."
+  [kernel-body out-sym]
+  (let [kernel-body (kbody/validate! kernel-body)
+        {:keys [kind instruction-family dims bindings epilogue axis-symbols]}
+        (:attributes kernel-body)]
+    (when-not (and (= :matrix-contraction kind) (= :dpas instruction-family))
+      (throw (ex-info "OpenCL DPAS lowering requires a DPAS matrix KernelBody"
+                      {:kind kind :instruction-family instruction-family})))
+    (emit-dpas-plan (str "dpas_contract_" (gensym ""))
+                    (:row bindings) (:col bindings) out-sym dims
+                    (subvec (vec axis-symbols) 0 2)
+                    (:schedule kernel-body) epilogue kernel-body)))
+
 (defn generate-dpas-contraction-kernel
-  "DPAS/XMX-tensorized contraction → OpenCL (PEAK; raster's edge over Futhark's portable
-   ~50-70%-peak tiling). The general, IR-driven contribution is the LEGALITY GATE +
-   operand-orientation analysis (dpas-contraction-legal?); the DPAS BODY is the validated
-   emit-gemm-tiled reused verbatim (f16-in / f32-acc / f16-out, tile-parametric,
-   16 subgroups, K16 mad). The SOAC IR decides WHICH input is the row operand (→ A slot) vs
-   col operand (→ B slot) and the dims to launch with — so a batched or transposed
-   contraction re-tensorizes through the golden's :batched?/:split-k? variants rather than a
-   separate hand kernel. NON-gemm-specific at the IR boundary; peak at the hardware boundary.
+  "Legacy direct entry to the proven DPAS/XMX OpenCL emitter.
+
+   Production canonical f16 contractions now travel through ContractionFacts and a scheduled
+   KernelBody before reaching `generate-dpas-kernel-body`.  This entry remains as the source oracle
+   for the shadow adapter and for opaque epilogue helpers that have not yet become typed scalar IR.
+   Its legality analysis determines operand orientation and launch dimensions; the emitted body is
+   f16 input, f32 accumulation and f16 output with a tile-parametric K16 matrix instruction.
 
    Returns {:kernel-name :source :array-params [row-arr col-arr] :dims [M N L] :dtype :half
             :tensorized true}  — NB: :array-params is in [row col] BINDING order (row's
@@ -1358,66 +1422,9 @@
             ;; `tile` (e.g. an autotune result via hw/gemm-tile-candidates) overrides.
             ;; hw/derive-gemm-tile's own defaults reproduce the Arc 140V config, so passing no
             ;; descriptor is equivalent to the previous literal — with zero magic numbers here.
-            tile (or tile (hw/derive-gemm-tile (or desc {})))
-            sg (long (get-in tile [:matrix :subgroup] 16))
-            ;; EPILOGUE FUSION: fold the consumer expression into the store slot, so a
-            ;; bias/activation/residual/dequant costs no extra kernel and no DRAM round-trip of C.
-            ep (when epilogue
-                 (epilogue-splice epilogue
-                                  [(:i-sym gate) (:j-sym gate)]
-                                  (get epilogue :dtype :float)))
-            source (apply codegen/emit-gemm-tiled kernel-name
-                          (concat [:c-dtype :half
-                                   :block-m (:block-m tile) :block-n (:block-n tile)
-                                   :sg-m (:sg-m tile) :sg-n (:sg-n tile)
-                                   :block-k (:block-k tile) :matrix (:matrix tile)
-                                   ;; PIPELINE DEPTH. Omitting this pinned every routed kernel to
-                                   ;; emit-gemm-tiled's `:or prefetch 3` while the schedule, the
-                                   ;; SLM-capped feasibility filter and the autotuner all believed
-                                   ;; :num-stages was live — so tiles differing ONLY in :num-stages
-                                   ;; emitted identical source, and a tuner "measuring" that axis was
-                                   ;; measuring noise. The resident door has always passed it
-                                   ;; (ze_runtime `:prefetch (:num-stages tile 3)`); this door had
-                                   ;; not, which is the schema-without-emission that CLAUDE.md and
-                                   ;; north-star §10 forbid.
-                                   :prefetch (:num-stages tile 3)]
-                                  (when ep [:epilogue (:epilogue ep)
-                                            :epilogue-params (:epilogue-params ep)
-                                            :epilogue-helpers (:epilogue-helpers ep)])))]
-        {:kernel-name kernel-name
-         :source source
-         :array-params [row-arr col-arr]      ;; [A-slot B-slot] binding order
-         :abi (kabi/validate!
-               (vec (concat
-                     [(kabi/slot row-arr :input :half :c-name "A" :role :operand)
-                      (kabi/slot col-arr :input :half :c-name "B" :role :operand)
-                      (kabi/slot out-sym :output :half :c-name "C" :role :result)
-                      (kabi/slot 'M :scalar :int :role :dimension)
-                      (kabi/slot 'N :scalar :int :role :dimension)
-                      (kabi/slot 'K :scalar :int :role :dimension)]
-                     (for [{:keys [sym dtype] :or {dtype :float}} (:operands epilogue)]
-                       (kabi/slot sym :input dtype :c-name (ce/c-symbol sym) :role :epilogue))
-                     (for [{:keys [sym dtype] :or {dtype :float}} (:scalars epilogue)]
-                       (kabi/slot sym :scalar dtype :c-name (ce/c-symbol sym) :role :epilogue)))))
-         :dims [M N L]
-         :dtype :half
-         :tile tile
-         ;; The epilogue's operand arrays are EXTRA kernel params, appended AFTER the dims.
-         ;; Surfaced so a caller binds them — the signature has them either way, so omitting
-         ;; them from the descriptor would be a launch-arity bug (6 args bound to a 7-arg kernel).
-         :epilogue-params (when ep (:epilogue-params ep))
-         :epilogue-operands (when ep (mapv :sym (:operands epilogue)))
-         ;; …and its SCALARS. epilogue-splice has always emitted these into the signature, but
-         ;; nothing surfaced them, so any epilogue carrying a `:scalars` entry tripped
-         ;; validate-descriptor's scalar count and threw. That unusable capability is exactly why
-         ;; `:scheme` had to invent a private per-tensor scale channel instead of being an
-         ;; epilogue. Surfacing them makes the scale expressible where it belongs.
-         :epilogue-scalars (when ep (mapv :sym (:scalars epilogue)))
-         ;; workgroup = (block-m/sg-m)·(block-n/sg-n) subgroups × the matrix subgroup size
-         :workgroup [(* (quot (:block-m tile) (:sg-m tile))
-                        (quot (:block-n tile) (:sg-n tile))
-                        sg) 1]
-         :tensorized true}))))
+            tile (or tile (hw/derive-gemm-tile (or desc {})))]
+        (emit-dpas-plan kernel-name row-arr col-arr out-sym [M N L]
+                        [(:i-sym gate) (:j-sym gate)] tile epilogue nil)))))
 
 ;; ================================================================
 ;; QUANT (int8) contraction — the SAME skeleton, WIDENING facet

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -1,0 +1,337 @@
+(ns raster.compiler.ir.kernel-body
+  "Target-neutral scheduled kernel bodies.
+
+  SegOps retain algorithmic semantics.  A KernelBody is the result of applying a concrete
+  schedule: hardware indices, named layouts, masks, fragment operations and loop structure are
+  explicit, but target spellings such as Intel DPAS, CUDA WMMA or AMD MFMA are not.  Backends lower
+  these values to their own dialect; they must not recover a schedule by inspecting source text.")
+
+(defrecord KernelParameter [id kind dtype shape memory-space layout role])
+(defrecord IndexBinding [id source axis])
+(defrecord IndexCompute [id expression])
+(defrecord IndexExpr [op arguments])
+(defrecord Predicate [op arguments])
+(defrecord Mask [id predicates])
+(defrecord Fragment [id dtype shape layout])
+(defrecord ScalarRegion [parameters expression operands result-dtype])
+
+(defrecord FragmentInit [fragment value])
+(defrecord TileLoad [fragment buffer coordinates mask cache])
+(defrecord TilePrefetch [buffer coordinates shape layout mask distance])
+(defrecord MatrixMad [accumulator lhs rhs instruction])
+(defrecord Loop [index lower upper step operations attributes])
+(defrecord Guard [mask operations])
+(defrecord TileStore [buffer fragment coordinates mask value-region])
+
+(defrecord KernelBody
+           [id parameters indices masks fragments operations schedule launch provenance attributes])
+
+(def ^:private parameter-kinds #{:input :output :scalar})
+(def ^:private index-sources #{:group :subgroup :lane})
+(def ^:private index-ops #{:add :sub :mul :floor-div :ceil-div :mod :min :max})
+(def ^:private predicate-ops #{:lt :lte :eq :and :or :not})
+(def ^:private cache-policies #{:default :cached :streaming})
+
+(defn- record-kind? [class-name value]
+  (and value (= class-name (.getName (class value)))))
+
+(defn kernel-body? [value]
+  (record-kind? "raster.compiler.ir.kernel_body.KernelBody" value))
+
+(defn expression
+  "Construct explicit target-neutral integer index arithmetic."
+  [op & arguments]
+  (when-not (contains? index-ops op)
+    (throw (ex-info "kernel index expression has an unsupported operation"
+                    {:operation op :arguments arguments})))
+  (->IndexExpr op (vec arguments)))
+
+(defn predicate
+  "Construct an explicit target-neutral bounds predicate."
+  [op & arguments]
+  (when-not (contains? predicate-ops op)
+    (throw (ex-info "kernel predicate has an unsupported operation"
+                    {:operation op :arguments arguments})))
+  (->Predicate op (vec arguments)))
+
+(defn- expression? [value]
+  (cond
+    (or (number? value) (symbol? value)) true
+    (record-kind? "raster.compiler.ir.kernel_body.IndexExpr" value)
+    (and (contains? index-ops (:op value))
+         (seq (:arguments value))
+         (every? expression? (:arguments value)))
+    :else false))
+
+(defn- expression-references [value]
+  (cond
+    (symbol? value) #{value}
+    (number? value) #{}
+    (record-kind? "raster.compiler.ir.kernel_body.IndexExpr" value)
+    (reduce into #{} (map expression-references (:arguments value)))
+    :else #{}))
+
+(defn- predicate? [value]
+  (and (record-kind? "raster.compiler.ir.kernel_body.Predicate" value)
+       (contains? predicate-ops (:op value))
+       (seq (:arguments value))
+       (every? #(or (expression? %) (predicate? %)) (:arguments value))))
+
+(defn- predicate-references [value]
+  (reduce into #{}
+          (map #(if (record-kind? "raster.compiler.ir.kernel_body.Predicate" %)
+                  (predicate-references %)
+                  (expression-references %))
+               (:arguments value))))
+
+(defn- shape! [owner shape]
+  (when-not (and (vector? shape) (seq shape)
+                 (every? #(or (symbol? %) (and (integer? %) (pos? %))) shape))
+    (throw (ex-info (str owner " requires a non-empty shape of positive extents")
+                    {:shape shape}))))
+
+(defn- layout! [owner layout]
+  (when-not (and (map? layout) (keyword? (:kind layout)))
+    (throw (ex-info (str owner " requires a named layout") {:layout layout}))))
+
+(defn- unique-ids! [owner values]
+  (let [ids (mapv :id values)]
+    (when (or (some nil? ids) (not= (count ids) (count (set ids))))
+      (throw (ex-info (str owner " identities must be non-nil and unique") {:ids ids})))))
+
+(defn- operation? [value]
+  (contains? #{"raster.compiler.ir.kernel_body.FragmentInit"
+               "raster.compiler.ir.kernel_body.TileLoad"
+               "raster.compiler.ir.kernel_body.TilePrefetch"
+               "raster.compiler.ir.kernel_body.MatrixMad"
+               "raster.compiler.ir.kernel_body.Loop"
+               "raster.compiler.ir.kernel_body.Guard"
+               "raster.compiler.ir.kernel_body.TileStore"}
+             (some-> value class .getName)))
+
+(declare validate-operations!)
+
+(defn- validate-operation!
+  [operation parameters fragments masks scope]
+  (let [parameter (fn [id]
+                    (or (get parameters id)
+                        (throw (ex-info "kernel operation references an undeclared parameter"
+                                        {:parameter id :operation operation}))))
+        fragment (fn [id]
+                   (or (get fragments id)
+                       (throw (ex-info "kernel operation references an undeclared fragment"
+                                       {:fragment id :operation operation}))))
+        mask (fn [id]
+               (when id
+                 (let [m (or (get masks id)
+                             (throw (ex-info "kernel operation references an undeclared mask"
+                                             {:mask id :operation operation})))
+                       outside (remove scope (mapcat predicate-references (:predicates m)))]
+                   (when (seq outside)
+                     (throw (ex-info "kernel mask references values outside the operation scope"
+                                     {:mask id :references (vec outside)
+                                      :scope scope :operation operation}))))))
+        coordinates! (fn [owner coordinates]
+                       (when-not (and (vector? coordinates) (every? expression? coordinates))
+                         (throw (ex-info (str owner " coordinates must use explicit index expressions")
+                                         {:coordinates coordinates})))
+                       (let [outside (remove scope (mapcat expression-references coordinates))]
+                         (when (seq outside)
+                           (throw (ex-info (str owner " coordinates reference values outside the operation scope")
+                                           {:coordinates coordinates :references (vec outside)
+                                            :scope scope})))))]
+    (cond
+      (record-kind? "raster.compiler.ir.kernel_body.FragmentInit" operation)
+      (let [f (fragment (:fragment operation))]
+        (when-not (= :mma-frag (get-in f [:layout :kind]))
+          (throw (ex-info "only accumulator fragments may be initialized"
+                          {:fragment f :operation operation}))))
+
+      (record-kind? "raster.compiler.ir.kernel_body.TileLoad" operation)
+      (let [f (fragment (:fragment operation))
+            p (parameter (:buffer operation))]
+        (when-not (= :input (:kind p))
+          (throw (ex-info "tile loads require an input buffer" {:buffer p})))
+        (when-not (= :dot-operand (get-in f [:layout :kind]))
+          (throw (ex-info "tile loads must produce a named dot-operand fragment"
+                          {:fragment f})))
+        (coordinates! "tile-load" (:coordinates operation))
+        (mask (:mask operation))
+        (when-not (contains? cache-policies (:cache operation))
+          (throw (ex-info "tile load has an unsupported cache policy"
+                          {:cache (:cache operation)}))))
+
+      (record-kind? "raster.compiler.ir.kernel_body.TilePrefetch" operation)
+      (let [p (parameter (:buffer operation))]
+        (when-not (= :input (:kind p))
+          (throw (ex-info "tile prefetch requires an input buffer" {:buffer p})))
+        (shape! "tile prefetch" (:shape operation))
+        (layout! "tile prefetch" (:layout operation))
+        (coordinates! "tile-prefetch" (:coordinates operation))
+        (when-not (and (integer? (:distance operation)) (not (neg? (:distance operation))))
+          (throw (ex-info "tile-prefetch distance must be a non-negative integer"
+                          {:distance (:distance operation)})))
+        (mask (:mask operation)))
+
+      (record-kind? "raster.compiler.ir.kernel_body.MatrixMad" operation)
+      (let [acc (fragment (:accumulator operation))
+            lhs (fragment (:lhs operation))
+            rhs (fragment (:rhs operation))
+            acc-layout (:layout acc)
+            lhs-layout (:layout lhs)
+            rhs-layout (:layout rhs)
+            matrix (:instruction operation)]
+        (when-not (and (= :mma-frag (:kind acc-layout))
+                       (= :dot-operand (:kind lhs-layout))
+                       (= :dot-operand (:kind rhs-layout))
+                       (= 0 (:op-idx lhs-layout))
+                       (= 1 (:op-idx rhs-layout))
+                       (= (:parent lhs-layout) acc-layout)
+                       (= (:parent rhs-layout) acc-layout)
+                       (= (:matrix acc-layout) matrix))
+          (throw (ex-info "matrix MAD fragment layouts do not agree with its instruction"
+                          {:accumulator acc :lhs lhs :rhs rhs :instruction matrix}))))
+
+      (record-kind? "raster.compiler.ir.kernel_body.Loop" operation)
+      (do
+        (when-not (symbol? (:index operation))
+          (throw (ex-info "kernel loop requires a symbolic induction value"
+                          {:index (:index operation)})))
+        (when-not (and (expression? (:lower operation)) (expression? (:upper operation))
+                       (integer? (:step operation)) (pos? (:step operation)))
+          (throw (ex-info "kernel loop requires explicit bounds and a positive static step"
+                          {:loop operation})))
+        (when-not (map? (:attributes operation))
+          (throw (ex-info "kernel loop attributes must be a map" {:loop operation})))
+        (let [outside (remove scope
+                              (into (expression-references (:lower operation))
+                                    (expression-references (:upper operation))))]
+          (when (seq outside)
+            (throw (ex-info "kernel loop bounds reference values outside their scope"
+                            {:loop operation :references (vec outside) :scope scope}))))
+        (when (contains? scope (:index operation))
+          (throw (ex-info "kernel loop induction value shadows an existing value"
+                          {:index (:index operation) :scope scope})))
+        (validate-operations! (:operations operation) parameters fragments masks
+                              (conj scope (:index operation))))
+
+      (record-kind? "raster.compiler.ir.kernel_body.Guard" operation)
+      (do
+        (mask (:mask operation))
+        (validate-operations! (:operations operation) parameters fragments masks scope))
+
+      (record-kind? "raster.compiler.ir.kernel_body.TileStore" operation)
+      (let [p (parameter (:buffer operation))
+            f (fragment (:fragment operation))]
+        (when-not (= :output (:kind p))
+          (throw (ex-info "tile stores require an output buffer" {:buffer p})))
+        (when-not (= :mma-frag (get-in f [:layout :kind]))
+          (throw (ex-info "tile stores require an accumulator fragment" {:fragment f})))
+        (coordinates! "tile-store" (:coordinates operation))
+        (mask (:mask operation))
+        (when-let [region (:value-region operation)]
+          (when-not (record-kind? "raster.compiler.ir.kernel_body.ScalarRegion" region)
+            (throw (ex-info "tile-store value region must be a ScalarRegion" {:region region})))
+          (when-not (and (vector? (:parameters region)) (seq (:parameters region))
+                         (some? (:expression region)) (keyword? (:result-dtype region)))
+            (throw (ex-info "tile-store scalar region is incomplete" {:region region})))))
+
+      :else
+      (throw (ex-info "kernel body contains an unsupported operation"
+                      {:operation operation :actual (type operation)})))))
+
+(defn- validate-operations! [operations parameters fragments masks scope]
+  (when-not (vector? operations)
+    (throw (ex-info "kernel operations must be an ordered vector" {:operations operations})))
+  (doseq [operation operations]
+    (when-not (operation? operation)
+      (throw (ex-info "kernel body contains a non-operation value" {:operation operation})))
+    (validate-operation! operation parameters fragments masks scope)))
+
+(defn validate!
+  "Verify a scheduled KernelBody and return it unchanged."
+  [body]
+  (when-not (kernel-body? body)
+    (throw (ex-info "kernel body must be a KernelBody value"
+                    {:body body :actual (type body)})))
+  (let [{:keys [id parameters indices masks fragments operations schedule launch provenance
+                attributes]} body]
+    (when (nil? id)
+      (throw (ex-info "kernel body requires a stable identity" {:body body})))
+    (doseq [[field values] [[:parameters parameters] [:indices indices] [:masks masks]
+                            [:fragments fragments] [:operations operations]]]
+      (when-not (vector? values)
+        (throw (ex-info "kernel body sections must be ordered vectors"
+                        {:field field :value values}))))
+    (unique-ids! "kernel parameters" parameters)
+    (unique-ids! "kernel indices" indices)
+    (unique-ids! "kernel masks" masks)
+    (unique-ids! "kernel fragments" fragments)
+    (doseq [p parameters]
+      (when-not (contains? parameter-kinds (:kind p))
+        (throw (ex-info "kernel parameter has an unsupported kind" {:parameter p})))
+      (when-not (keyword? (:dtype p))
+        (throw (ex-info "kernel parameter requires a dtype" {:parameter p})))
+      (when-not (keyword? (:role p))
+        (throw (ex-info "kernel parameter requires a semantic role" {:parameter p})))
+      (if (= :scalar (:kind p))
+        (when (or (seq (:shape p)) (:layout p) (:memory-space p))
+          (throw (ex-info "scalar kernel parameters cannot carry storage layout"
+                          {:parameter p})))
+        (do (shape! "kernel buffer parameter" (:shape p))
+            (layout! "kernel buffer parameter" (:layout p))
+            (when-not (keyword? (:memory-space p))
+              (throw (ex-info "kernel buffer parameter requires a memory space"
+                              {:parameter p}))))))
+    (let [scalar-ids (set (map :id (filter #(= :scalar (:kind %)) parameters)))
+          index-scope
+          (reduce
+           (fn [scope idx]
+             (cond
+               (record-kind? "raster.compiler.ir.kernel_body.IndexBinding" idx)
+               (when-not (and (contains? index-sources (:source idx))
+                              (integer? (:axis idx)) (not (neg? (:axis idx))))
+                 (throw (ex-info "kernel index binding has an invalid hardware source" {:index idx})))
+
+               (record-kind? "raster.compiler.ir.kernel_body.IndexCompute" idx)
+               (do
+                 (when-not (expression? (:expression idx))
+                   (throw (ex-info "computed kernel index must use explicit index IR" {:index idx})))
+                 (let [outside (remove scope (expression-references (:expression idx)))]
+                   (when (seq outside)
+                     (throw (ex-info "computed kernel index references a value before it is defined"
+                                     {:index idx :references (vec outside) :scope scope})))))
+
+               :else
+               (throw (ex-info "kernel body contains an unsupported index value" {:index idx})))
+             (conj scope (:id idx)))
+           scalar-ids indices)]
+      (doseq [m masks]
+        (when-not (and (record-kind? "raster.compiler.ir.kernel_body.Mask" m)
+                       (vector? (:predicates m)) (seq (:predicates m))
+                       (every? predicate? (:predicates m)))
+          (throw (ex-info "kernel mask requires explicit predicates" {:mask m}))))
+      (doseq [f fragments]
+        (when-not (keyword? (:dtype f))
+          (throw (ex-info "kernel fragment requires a dtype" {:fragment f})))
+        (shape! "kernel fragment" (:shape f))
+        (layout! "kernel fragment" (:layout f)))
+      (doseq [[field value] [[:schedule schedule] [:launch launch] [:provenance provenance]
+                             [:attributes attributes]]]
+        (when-not (map? value)
+          (throw (ex-info "kernel body descriptive sections must be maps"
+                          {:field field :value value}))))
+      (validate-operations! operations
+                            (into {} (map (juxt :id identity)) parameters)
+                            (into {} (map (juxt :id identity)) fragments)
+                            (into {} (map (juxt :id identity)) masks)
+                            index-scope)))
+  body)
+
+(defn make
+  "Construct and verify a target-neutral scheduled kernel body."
+  [{:keys [id parameters indices masks fragments operations schedule launch provenance attributes]
+    :or {parameters [] indices [] masks [] fragments [] operations [] schedule {} launch {}
+         provenance {} attributes {}}}]
+  (validate! (->KernelBody id parameters indices masks fragments operations schedule launch
+                           provenance attributes)))

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -24,7 +24,8 @@
             [raster.compiler.ir.contraction-facts :as cf]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
-            [raster.compiler.ir.kernel-launch :as klaunch]))
+            [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]))
 
 (defn par-contract-form?
   "Is `form` a (raster.par/contract out free-axes contract-axes body & opts) form?"
@@ -93,7 +94,7 @@
             :dtype dtype
             :out-dtype out-dtype}
            (select-keys descriptor [:fallback-reason :declines :tile :tensorized :packed
-                                    :fused-epilogue :dims :stages]))}))
+                                    :fused-epilogue :dims :stages :kernel-body]))}))
 
 (defn kernel-signature-params
   "The parameter list of the single __kernel in `src`, split at top-level commas. Used to check a
@@ -244,13 +245,14 @@
   d)
 
 (defn route-contraction
-  "Route a contraction form to the hardware-optimal kernel via the DPAS legality gate.
-   dtype selects the element type of the intended kernel (:half tries DPAS; :byte/:int8 tries
-   the int8 quant leaves — dp4a for the :nt operand layout, quant naive-widening for :nn;
-   anything else, or a gate rejection, falls back to the register-tiled portable kernel).
-   int8 needs no decode descriptor: a scale is an ordinary :epilogue and a zero-point an ordinary
-   per-operand :decode, both carried on the form like any other contraction data."
-  [contract-form & {:keys [dtype prefer-peak? desc tile epilogue stages operands facts]
+  "Route a contraction form through verified facts, an applied hardware schedule and a target leaf.
+
+   Canonical f16 products first become a target-neutral KernelBody and are then lowered by the
+   OpenCL DPAS backend.  Unsupported shapes retain the portable register-tiled route.  Byte/int8
+   products use the quant leaves (dp4a for :nt, widening for :nn) until those instruction families
+   consume the same scheduled body vocabulary.  Quantization remains an operand/decode concern,
+   not a buffer-ownership or graph-composition concern."
+  [contract-form & {:keys [dtype prefer-peak? desc tile epilogue stages operands facts operation-id]
                     :or {dtype :half prefer-peak? false}}]
   (let [out-sym (second contract-form)
         free-axes (nth contract-form 2)
@@ -268,12 +270,14 @@
         ;; a fused contraction carries its epilogue in the form's trailing opts (par-fusion's
         ;; fuse-contract-map puts it there); an explicit :epilogue kwarg overrides.
         form-opts (apply hash-map (drop 5 contract-form))
+        contract-facts (or facts (cf/contraction-facts contract-form :dtype dtype))
         epilogue (or epilogue (:epilogue form-opts))
         stages (or stages (:stages (apply hash-map (drop 5 contract-form))))
         ;; declared operand axis-maps, needed to tensorize a staged inner stage (the gate VERIFIES
         ;; them against the body rather than trusting them)
         operands (or operands (:operands (apply hash-map (drop 5 contract-form))))
-        tensorize-plan (memoize #(route-2free-1contract contract-form out-sym dtype desc tile epilogue))]
+        tensorize-plan (memoize #(route-2free-1contract contract-form out-sym dtype desc tile
+                                                        epilogue contract-facts operation-id))]
     ;; Every descriptor is validated against the kernel it describes before it leaves this fn. The
     ;; failure mode it guards is a LAUNCH-time arity mismatch (valid C, wrong number of bound args),
     ;; which has bitten twice; validating at generation makes it a loud compile-time error instead.
@@ -286,52 +290,52 @@
       ;; format (int32 MAC inside the block, float accumulate across blocks) be expressed in the
       ;; contraction algebra at all. The flat leaves below cannot represent it — they have one
       ;; accumulator. 1 stage is the flat case and is left to them.
-      (and (seq stages) (> (count stages) 1))
-      (let [;; The staged emitter hardwires `+=` at every level, and a lift's linearity argument
+        (and (seq stages) (> (count stages) 1))
+        (let [;; The staged emitter hardwires `+=` at every level, and a lift's linearity argument
             ;; assumes `+`. A form carrying :combine max routed here and was SILENTLY SUMMED —
             ;; contraction-facts surfaces :combine and nothing read it. Refuse rather than ignore.
-            _ (let [cmb (:combine (or facts (cf/contraction-facts contract-form :dtype dtype)))]
-                (when-not (contains? '#{+ clojure.core/+ raster.numeric/+} cmb)
-                  (throw (ex-info (str "staged contraction: only `+` combine is supported (got "
-                                       cmb ") — every accumulator level uses += and a lift's "
-                                       "linearity argument assumes addition")
-                                  {:reason :non-plus-combine-on-staged :combine cmb}))))
+              _ (let [cmb (:combine contract-facts)]
+                  (when-not (contains? '#{+ clojure.core/+ raster.numeric/+} cmb)
+                    (throw (ex-info (str "staged contraction: only `+` combine is supported (got "
+                                         cmb ") — every accumulator level uses += and a lift's "
+                                         "linearity argument assumes addition")
+                                    {:reason :non-plus-combine-on-staged :combine cmb}))))
             ;; PEAK: with declared+verified operand maps, the inner stage tensorizes to dp4a (4 int8
             ;; MACs per int32 op) — the int8 peak leaf, and the same shape llama.cpp hand-writes.
             ;; Only attempted when the caller asked for peak AND the gate passes; a gate rejection
             ;; falls back to the scalar nest, so requesting peak can never yield a wrong kernel.
-            spec {:free-axes free-axes :stages stages
+              spec {:free-axes free-axes :stages stages
                   ;; the axes the FORM declared, read off FACTS — a single derivation whose only
                   ;; input is the form, so there is no separately-computed value to pass
                   ;; inconsistently (which is what made the span rule unfireable)
-                  :contract-axes (:contract-axes (or facts (cf/contraction-facts contract-form :dtype dtype)))
-                  :body (nth contract-form 4)
-                  :inputs (vec (sort-by name (contract-operand-arrays (nth contract-form 4))))
-                  :operands operands
-                  :dtype dtype :out-dtype (or (:out-dtype (apply hash-map (drop 5 contract-form)))
-                                              :float)}
-            tz? (and prefer-peak? (seq operands)
-                     (:ok (sco/staged-inner-dp4a-legal? spec)))
-            k (sco/generate-staged-contraction-kernel
-               (assoc spec :tensorize-inner? (boolean tz?)) out-sym)]
-        {:strategy :staged-segred
-         :kernel-name (:kernel-name k) :source (:source k)
-         :array-params (:array-params k)
-         :abi (:abi k)
+                    :contract-axes (:contract-axes contract-facts)
+                    :body (nth contract-form 4)
+                    :inputs (vec (sort-by name (contract-operand-arrays (nth contract-form 4))))
+                    :operands operands
+                    :dtype dtype :out-dtype (or (:out-dtype (apply hash-map (drop 5 contract-form)))
+                                                :float)}
+              tz? (and prefer-peak? (seq operands)
+                       (:ok (sco/staged-inner-dp4a-legal? spec)))
+              k (sco/generate-staged-contraction-kernel
+                 (assoc spec :tensorize-inner? (boolean tz?)) out-sym)]
+          {:strategy :staged-segred
+           :kernel-name (:kernel-name k) :source (:source k)
+           :array-params (:array-params k)
+           :abi (:abi k)
          ;; the per-stage scale arrays are EXTRA pointer params — surfaced so a caller binds them
-         :lift-operands (:lift-operands k)
-         :dtype (:dtype k) :out-dtype (:out-dtype k)
-         :out-elems (:out-elems k)
-         :stages (:stages k)
+           :lift-operands (:lift-operands k)
+           :dtype (:dtype k) :out-dtype (:out-dtype k)
+           :out-elems (:out-elems k)
+           :stages (:stages k)
          ;; the operand BUFFERS are bound unchanged; only the kernel's view of them widens to int32
-         :tensorized (:tensorized k) :packed (:packed k)
-         :scalar-args [{:type :int :value nseg}]
-         :wg [256 1]
-         :grid [(ceil-div nseg 256) 1]})
+           :tensorized (:tensorized k) :packed (:packed k)
+           :scalar-args [{:type :int :value nseg}]
+           :wg [256 1]
+           :grid [(ceil-div nseg 256) 1]})
 
       ;; int8 → the quant leaves (dp4a for :nt, quant naive-widening for :nn)
-      (#{:byte :int8} dtype)
-      (route-quant contract-form out-sym n-free n-contract nseg prefer-peak?)
+        (#{:byte :int8} dtype)
+        (route-quant contract-form out-sym n-free n-contract nseg prefer-peak?)
 
       ;; 0 FREE axes → a full reduction to a scalar. This is the last cell of contract's
       ;; algebra: (n free, 0 contract) = map, (n, n) = contraction, (0, n) = REDUCTION. The
@@ -339,70 +343,70 @@
       ;; generate-segred-kernel's two-phase tree reduction already consumes, so no new emitter.
       ;; Its launch protocol differs (two phases + a host-side final combine), so the descriptor
       ;; says so with :invoke :reduction rather than pretending it is a 2-D kernel launch.
-      (zero? n-free)
-      (let [sr (cl/contract-form->segred contract-form :dtype dtype)
-            k (sco/generate-segred-kernel sr out-sym :dtype dtype)
-            attrs (:attributes k)
-            red-bound (second (first contract-axes))]
-        {:strategy :full-reduce
-         :invoke :reduction
-         :artifact k
-         :kernel-name (:kernel-name k) :source (:source k)
-         :array-params (:array-params attrs)
-         :abi (:abi k) :arguments (:arguments k)
-         :dtype dtype :out-dtype dtype :out-elems 1
-         :n-phases (:n-phases attrs)
+        (zero? n-free)
+        (let [sr (cl/contract-form->segred contract-form :dtype dtype)
+              k (sco/generate-segred-kernel sr out-sym :dtype dtype)
+              attrs (:attributes k)
+              red-bound (second (first contract-axes))]
+          {:strategy :full-reduce
+           :invoke :reduction
+           :artifact k
+           :kernel-name (:kernel-name k) :source (:source k)
+           :array-params (:array-params attrs)
+           :abi (:abi k) :arguments (:arguments k)
+           :dtype dtype :out-dtype dtype :out-elems 1
+           :n-phases (:n-phases attrs)
          ;; CARRY THE COMBINE for descriptor inspection as well as in the artifact attributes.
          ;; The staging runtime reads the artifact attributes for its host-side final combine.
-         :c-op (:c-op attrs) :identity-val (:identity-val attrs)
-         :reduce-bound red-bound          ; element count the reduction spans
-         :scalar-args [] :dims [1]})
+           :c-op (:c-op attrs) :identity-val (:identity-val attrs)
+           :reduce-bound red-bound          ; element count the reduction spans
+           :scalar-args [] :dims [1]})
 
-      (zero? n-contract)
-      (let [sm (cl/contract-form->segmap contract-form :dtype dtype)
-            {:keys [kernel-name source array-params scalar-params abi]}
-            (sco/generate-segmap-nd-kernel sm out-sym :dtype dtype)]
-        {:strategy :segmap
-         :kernel-name kernel-name :source source :array-params array-params :abi abi
-         :dtype dtype :out-dtype dtype :wg [256 1] :grid [(ceil-div nseg 256) 1]
-         :scalar-args (conj (mapv (fn [p] {:type :int :value p}) scalar-params)
-                            {:type :int :value nseg})
-         :out-elems nseg :dims [nseg]})
+        (zero? n-contract)
+        (let [sm (cl/contract-form->segmap contract-form :dtype dtype)
+              {:keys [kernel-name source array-params scalar-params abi]}
+              (sco/generate-segmap-nd-kernel sm out-sym :dtype dtype)]
+          {:strategy :segmap
+           :kernel-name kernel-name :source source :array-params array-params :abi abi
+           :dtype dtype :out-dtype dtype :wg [256 1] :grid [(ceil-div nseg 256) 1]
+           :scalar-args (conj (mapv (fn [p] {:type :int :value p}) scalar-params)
+                              {:type :int :value nseg})
+           :out-elems nseg :dims [nseg]})
 
       ;; 2 free + 1 contract → the tensorize fast path (DPAS if legal, else regtiled).
       ;; A `{::declines …}` result means BOTH tensorize leaves refused for a documented reason —
       ;; we fall through to the general naive leaf rather than hard-failing a perfectly legal
       ;; contraction, and carry the reasons onto that leaf's descriptor.
-      (and (= 2 n-free) (= 1 n-contract) (:strategy (tensorize-plan)))
-      (tensorize-plan)
+        (and (= 2 n-free) (= 1 n-contract) (:strategy (tensorize-plan)))
+        (tensorize-plan)
 
       ;; everything else (n-free≠2, n≥2 contract axes, or a tensorize-ineligible 2-free form)
       ;; → naive segmented reduce (general: any dtype, symbolic dims, any assoc combine).
       ;; contract-form->segred flattens n≥2 contract axes into one innermost dim.
-      :else
-      (let [sr (cl/contract-form->segred contract-form :dtype dtype)
-            {:keys [kernel-name source array-params scalar-params abi]}
-            (sco/generate-segmented-reduce-kernel sr out-sym :dtype dtype)
+        :else
+        (let [sr (cl/contract-form->segred contract-form :dtype dtype)
+              {:keys [kernel-name source array-params scalar-params abi]}
+              (sco/generate-segmented-reduce-kernel sr out-sym :dtype dtype)
             ;; WHY THIS LEAF AND NOT A FASTER ONE. Only meaningful for the 2-free/1-contract shape,
             ;; where a tensorize leaf was actually attempted; for every other shape no faster leaf
             ;; exists to decline, so an empty vector is the honest answer rather than a fabricated
             ;; "not eligible".
-            declines (when (and (= 2 n-free) (= 1 n-contract))
-                       (::declines (tensorize-plan)))]
-        (cond->
-        {:strategy :naive-segred
-         :declines (vec declines)
-         :kernel-name kernel-name :source source :array-params array-params :abi abi
-         :dtype dtype :out-dtype dtype :wg [256 1] :grid [(ceil-div nseg 256) 1]
+              declines (when (and (= 2 n-free) (= 1 n-contract))
+                         (::declines (tensorize-plan)))]
+          (cond->
+           {:strategy :naive-segred
+            :declines (vec declines)
+            :kernel-name kernel-name :source source :array-params array-params :abi abi
+            :dtype dtype :out-dtype dtype :wg [256 1] :grid [(ceil-div nseg 256) 1]
          ;; SYMBOLIC axis bounds become int kernel params (the emitter declares them, sorted by
          ;; name); they must be bound BEFORE the trailing count or the launch arity is wrong.
-         :scalar-args (conj (mapv (fn [p] {:type :int :value p}) scalar-params)
-                            {:type :int :value nseg})
-         :out-elems nseg :dims [nseg]}
+            :scalar-args (conj (mapv (fn [p] {:type :int :value p}) scalar-params)
+                               {:type :int :value nseg})
+            :out-elems nseg :dims [nseg]}
           ;; the LAST decline is the decisive one — the leaf that would otherwise have taken the
           ;; work. Using the first reported DPAS's generic :not-a-contraction where regtiled's
           ;; specific :symbolic-dims / :non-plus-combine is the actual answer.
-          (seq declines) (assoc :fallback-reason (:reason (last declines))))))))))
+            (seq declines) (assoc :fallback-reason (:reason (last declines))))))))))
 
 (def ^:private decline-reasons
   "The reasons a tensorize leaf may legitimately REFUSE a shape — a WHITELIST.
@@ -423,6 +427,7 @@
     :non-aget-operand :not-a-contraction :not-2-free :body-has-unmodeled-terms
     ;; dtype / orientation / alignment
     :dtype-not-dpas :non-canonical-orientation :n-pitch-unaligned :k-pitch-unaligned
+    :non-zero-matrix-init :partial-matrix-k-fragment :matrix-family-not-lowered
     ;; declared-operand and quant-leaf legality
     :operand-without-a-declared-map :missing-declared-contract-axes
     :declared-operand-not-read-by-the-body :declared-map-does-not-match-the-body-index
@@ -464,57 +469,65 @@
    shape could express neither: a decline is usually LEGITIMATE (symbolic dims, a non-`+` combine and
    a non-product body are all perfectly good contractions that merely are not tiled-leaf shaped), and
    it is always worth REPORTING."
-  [contract-form out-sym dtype desc tile epilogue]
+  [contract-form out-sym dtype desc tile epilogue contract-facts operation-id]
   (let [acc (volatile! [])
         note! (fn [d] (vswap! acc conj d) nil)]
-   (try
-   (let [sr (cl/contract-form->segred contract-form :dtype dtype)
-         dpas (sco/generate-dpas-contraction-kernel sr out-sym :dtype dtype :desc desc :tile tile
-                                                    :epilogue epilogue)]
-    (when-not (:tensorized dpas)
-      ;; the DPAS gate DECLINES by returning {:tensorized false :reason …} rather than throwing,
-      ;; so its reason is available without an exception — record it either way
-      (note! (decline :dpas (:reason dpas) nil (dissoc dpas :tensorized :reason))))
-    (if (:tensorized dpas)
-      (let [[M N _L] (:dims dpas)
-            {:keys [block-m block-n]} (:tile dpas)]
-        {:strategy :dpas
-         :kernel-name (:kernel-name dpas)
-         :source (:source dpas)
-         :array-params (:array-params dpas)          ; [row col] = [A-slot B-slot]
-         :abi (:abi dpas)
-         :dtype :half :out-dtype :half :out-elems (* M N)
-         :tile (:tile dpas)                          ; the DERIVED tile actually emitted
-         :fused-epilogue (boolean epilogue)
+    (try
+      (let [sr (delay (cl/contract-form->segred contract-form :dtype dtype))
+            scheduled (contraction-schedule/plan-matrix-body contract-facts desc tile
+                                                             {:operation-id operation-id})
+         ;; Existing epilogues may still carry an opaque target helper.  They retain the proven
+         ;; emitter until that helper is represented as typed scalar IR; all ordinary expressions
+         ;; take the scheduled KernelBody route now.
+            dpas (if (= :opaque-epilogue-helper (:reason scheduled))
+                   (sco/generate-dpas-contraction-kernel @sr out-sym :dtype dtype :desc desc :tile tile
+                                                         :epilogue epilogue)
+                   (if (:ok scheduled)
+                     (sco/generate-dpas-kernel-body (:body scheduled) out-sym)
+                     {:tensorized false :reason (:reason scheduled) :detail scheduled}))]
+        (when-not (:tensorized dpas)
+          (note! (decline :dpas (:reason dpas) nil (dissoc dpas :tensorized :reason))))
+        (if (:tensorized dpas)
+          (let [[M N _L] (:dims dpas)
+                {:keys [block-m block-n]} (:tile dpas)]
+            {:strategy :dpas
+             :kernel-name (:kernel-name dpas)
+             :source (:source dpas)
+             :array-params (:array-params dpas)          ; [row col] = [A-slot B-slot]
+             :abi (:abi dpas)
+             :dtype :half :out-dtype :half :out-elems (* M N)
+             :tile (:tile dpas)                          ; the DERIVED tile actually emitted
+             :kernel-body (:kernel-body dpas)             ; scheduled target-neutral body, when present
+             :fused-epilogue (boolean epilogue)
          ;; extra kernel args the epilogue needs, in signature order (after out + the dims)
-         :epilogue-operands (:epilogue-operands dpas)
-         :epilogue-scalars (:epilogue-scalars dpas)
-         :epilogue-params (:epilogue-params dpas)
-         :wg (:workgroup dpas)                       ; derived from that tile
-         :grid [(ceil-div N block-n) (ceil-div M block-m)]  ; [gc-n gc-m] (id0=N, id1=M)
-         :scalar-args (mapv (fn [v] {:type :int :value (int v)}) (:dims dpas))  ; [m n k] params
-         :dims (:dims dpas)})
+             :epilogue-operands (:epilogue-operands dpas)
+             :epilogue-scalars (:epilogue-scalars dpas)
+             :epilogue-params (:epilogue-params dpas)
+             :wg (:workgroup dpas)                       ; derived from that tile
+             :grid [(ceil-div N block-n) (ceil-div M block-m)]  ; [gc-n gc-m] (id0=N, id1=M)
+             :scalar-args (mapv (fn [v] {:type :int :value (int v)}) (:dims dpas))  ; [m n k] params
+             :dims (:dims dpas)})
       ;; gate rejected (dtype/orientation/pitch) → portable register-tiled kernel
-      (let [rt (sco/generate-regtiled-contraction-kernel sr out-sym :dtype dtype)
-            [bm bn _bk] (:block rt)
-            [M N _L] (:dims rt)]
-        {:strategy :regtiled
-         :fallback-reason (:reason dpas)             ; kept: existing consumers read it
-         :declines @acc
-         :kernel-name (:kernel-name rt)
-         :source (:source rt)
-         :array-params (:array-params rt)            ; sorted-by-name (dims baked in source)
-         :abi (:abi rt)
-         :dtype (:dtype rt) :out-dtype (:dtype rt) :out-elems (* M N)
-         :wg (:workgroup rt)
-         :grid [(ceil-div N bn) (ceil-div M bm)]
-         :scalar-args []                             ; regtiled bakes dims → no scalar params
-         :dims (:dims rt)})))
-   (catch clojure.lang.ExceptionInfo e
+          (let [rt (sco/generate-regtiled-contraction-kernel @sr out-sym :dtype dtype)
+                [bm bn _bk] (:block rt)
+                [M N _L] (:dims rt)]
+            {:strategy :regtiled
+             :fallback-reason (:reason dpas)             ; kept: existing consumers read it
+             :declines @acc
+             :kernel-name (:kernel-name rt)
+             :source (:source rt)
+             :array-params (:array-params rt)            ; sorted-by-name (dims baked in source)
+             :abi (:abi rt)
+             :dtype (:dtype rt) :out-dtype (:dtype rt) :out-elems (* M N)
+             :wg (:workgroup rt)
+             :grid [(ceil-div N bn) (ceil-div M bm)]
+             :scalar-args []                             ; regtiled bakes dims → no scalar params
+             :dims (:dims rt)})))
+      (catch clojure.lang.ExceptionInfo e
      ;; whichever tensorize leaf threw, record WHY and let the caller fall through. `decline-of`
      ;; rethrows :raster/fatal and :raster/bug — those are not routing decisions.
-     (note! (decline-of (if (seq @acc) :regtiled :dpas) e))
-     {::declines @acc}))))
+        (note! (decline-of (if (seq @acc) :regtiled :dpas) e))
+        {::declines @acc}))))
 
 (defn- operand-map
   "The declared axis-map for `arr` if the form carries :maps, else DERIVE one by checking the

--- a/src/raster/compiler/passes/parallel/contraction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/contraction_schedule.clj
@@ -1,0 +1,276 @@
+(ns raster.compiler.passes.parallel.contraction-schedule
+  "Apply a hardware schedule to verified contraction facts.
+
+  This pass chooses no target syntax.  Its successful result is a KernelBody whose matrix
+  instruction, named operand/accumulator layouts, hardware indices, masks, K loop and stores are
+  all inspectable compiler values.  A backend may decline an instruction family it cannot lower,
+  but it must consume this body rather than reconstructing the schedule from the source form."
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.core.layout :as layout]
+            [raster.compiler.ir.axis-map :as axis-map]
+            [raster.compiler.ir.contraction-facts :as facts]
+            [raster.compiler.ir.kernel-body :as body]))
+
+(defn- decline [reason & [data]]
+  (merge {:ok false :reason reason} data))
+
+(defn- additive? [combine]
+  (contains? '#{+ clojure.core/+ raster.numeric/+} combine))
+
+(defn- zero-init? [init]
+  (and (number? init) (zero? init)))
+
+(defn- tile-valid?
+  [{:keys [block-m block-n block-k sg-m sg-n matrix num-stages]}]
+  (let [{:keys [m n k subgroup]} matrix
+        num-stages (or num-stages 3)]
+    (and (every? #(and (integer? %) (pos? %))
+                 [block-m block-n block-k sg-m sg-n m n k subgroup num-stages])
+         (zero? (mod block-m sg-m))
+         (zero? (mod block-n sg-n))
+         (zero? (mod sg-m m))
+         (zero? (mod sg-n n))
+         (zero? (mod block-k k)))))
+
+(defn- matrix-parameters
+  [row col out M N K row-layout col-layout out-layout epilogue]
+  (vec
+   (concat
+    [(body/->KernelParameter row :input :half [M K] :global row-layout :lhs)
+     (body/->KernelParameter col :input :half [K N] :global col-layout :rhs)
+     (body/->KernelParameter out :output :half [M N] :global out-layout :result)
+     (body/->KernelParameter 'M :scalar :int [] nil nil :dimension)
+     (body/->KernelParameter 'N :scalar :int [] nil nil :dimension)
+     (body/->KernelParameter 'K :scalar :int [] nil nil :dimension)]
+    (for [{:keys [sym dtype map] :or {dtype :float}} (:operands epilogue)]
+      (let [shape (axis-map/shape map)]
+        (body/->KernelParameter sym :input dtype shape :global
+                                (layout/row-major shape dtype) :epilogue)))
+    (for [{:keys [sym dtype] :or {dtype :float}} (:scalars epilogue)]
+      (body/->KernelParameter sym :scalar dtype [] nil nil :epilogue)))))
+
+(defn- scalar-region [epilogue]
+  (when epilogue
+    (body/->ScalarRegion
+     (vec (concat [(:acc epilogue)]
+                  (map :sym (:operands epilogue))
+                  (map :sym (:scalars epilogue))))
+     (:expr epilogue)
+     (vec (:operands epilogue))
+     (get epilogue :dtype :float))))
+
+(defn- fragment-id [prefix a & [b]]
+  (keyword (str prefix "-" a (when (some? b) (str "-" b)))))
+
+(defn- build-matrix-body
+  [contract-facts tile bindings epilogue operation-id]
+  (let [{:keys [out free-axes contract-axes]} contract-facts
+        [[i M] [j N]] free-axes
+        [[k-sym K]] contract-axes
+        row (:row bindings)
+        col (:col bindings)
+        matrix (:matrix tile)
+        desc {:matrix matrix :subgroup-size (:subgroup matrix)}
+        acc-layout (layout/derive-layout :mma-acc :float desc)
+        ;; Dot operands inherit the ACCUMULATOR distribution; their own dtype only controls the
+        ;; packed K width.  Calling derive-layout independently at :half would create a different
+        ;; half-typed parent and make the three fragments look layout-incompatible.
+        k-width (max 1 (quot 32 (layout/dtype-bits :half)))
+        row-layout (layout/dot-operand 0 acc-layout k-width :half)
+        col-layout (layout/dot-operand 1 acc-layout k-width :half)
+        out-layout (layout/row-major [M N] :half)
+        {:keys [block-m block-n block-k sg-m sg-n num-stages]} tile
+        {matrix-m :m matrix-n :n matrix-k :k subgroup :subgroup} matrix
+        subgroup-rows (quot block-m sg-m)
+        subgroup-cols (quot block-n sg-n)
+        m-fragments (quot sg-m matrix-m)
+        n-fragments (quot sg-n matrix-n)
+        group-m 'group-m
+        group-n 'group-n
+        subgroup-id 'subgroup-id
+        lane-id 'lane-id
+        subgroup-row 'subgroup-row
+        subgroup-col 'subgroup-col
+        m-base 'm-base
+        n-base (fn [nn] (symbol (str "n-base-" nn)))
+        add (fn [& xs] (apply body/expression :add xs))
+        mul (fn [& xs] (apply body/expression :mul xs))
+        floor-div (fn [x y] (body/expression :floor-div x y))
+        rem (fn [x y] (body/expression :mod x y))
+        indices
+        (vec
+         (concat
+          [(body/->IndexBinding group-n :group 0)
+           (body/->IndexBinding group-m :group 1)
+           (body/->IndexBinding subgroup-id :subgroup 0)
+           (body/->IndexBinding lane-id :lane 0)
+           (body/->IndexCompute subgroup-row (floor-div subgroup-id subgroup-cols))
+           (body/->IndexCompute subgroup-col (rem subgroup-id subgroup-cols))
+           (body/->IndexCompute m-base (add (mul group-m block-m)
+                                            (mul subgroup-row sg-m)))]
+          (for [nn (range n-fragments)]
+            (body/->IndexCompute
+             (n-base nn)
+             (add (mul group-n block-n) (mul subgroup-col sg-n) (* nn matrix-n))))))
+        masks
+        (vec
+         (concat
+          [(body/->Mask :tile-active
+                        [(body/predicate :lt m-base 'M)
+                         (body/predicate :lt (n-base 0) 'N)])
+           (body/->Mask :k-active [(body/predicate :lt 'k-fragment 'K)])
+           (body/->Mask :prefetch-active
+                        [(body/predicate :lt
+                                         (add 'k-fragment (* num-stages matrix-k)) 'K)])]
+          (for [mm (range m-fragments) nn (range n-fragments)]
+            (body/->Mask
+             (fragment-id "store" mm nn)
+             [(body/predicate :lt (add m-base (* mm matrix-m)) 'M)
+              (body/predicate :lt (add (n-base nn) lane-id) 'N)]))))
+        accumulator-ids (vec (for [mm (range m-fragments) nn (range n-fragments)]
+                               (fragment-id "acc" mm nn)))
+        row-fragment-ids (vec (for [mm (range m-fragments)] (fragment-id "lhs" mm)))
+        col-fragment-ids (vec (for [nn (range n-fragments)] (fragment-id "rhs" nn)))
+        fragments
+        (vec
+         (concat
+          (for [acc accumulator-ids]
+            (body/->Fragment acc :float [matrix-m matrix-n] acc-layout))
+          (for [lhs row-fragment-ids]
+            (body/->Fragment lhs :half [matrix-m matrix-k] row-layout))
+          (for [rhs col-fragment-ids]
+            (body/->Fragment rhs :half [matrix-k matrix-n] col-layout))))
+        k-fragment 'k-fragment
+        one-k-step
+        (vec
+         (concat
+          (for [mm (range m-fragments)]
+            (body/->TilePrefetch
+             row [(add m-base (* mm matrix-m))
+                  (add k-fragment (* num-stages matrix-k))]
+             [matrix-m matrix-k] row-layout :prefetch-active num-stages))
+          (for [nn (range n-fragments)]
+            (body/->TileLoad (fragment-id "rhs" nn) col
+                             [k-fragment (n-base nn)] :k-active :cached))
+          (for [mm (range m-fragments)]
+            (body/->TileLoad (fragment-id "lhs" mm) row
+                             [(add m-base (* mm matrix-m)) k-fragment] :k-active :cached))
+          (for [mm (range m-fragments) nn (range n-fragments)]
+            (body/->MatrixMad (fragment-id "acc" mm nn)
+                              (fragment-id "lhs" mm)
+                              (fragment-id "rhs" nn)
+                              matrix))))
+        init-ops (mapv #(body/->FragmentInit % 0.0) accumulator-ids)
+        fragment-loop (body/->Loop k-fragment 'k-block
+                                   (body/expression :min (add 'k-block block-k) 'K)
+                                   matrix-k one-k-step
+                                   {:unroll true :matrix-step matrix-k})
+        k-loop (body/->Loop 'k-block 0 'K block-k [fragment-loop]
+                            {:unrolled-by (quot block-k matrix-k)
+                             :matrix-step matrix-k
+                             :pipeline-depth num-stages})
+        region (scalar-region epilogue)
+        stores (vec
+                (for [mm (range m-fragments) nn (range n-fragments)]
+                  (body/->TileStore
+                   out (fragment-id "acc" mm nn)
+                   [(add m-base (* mm matrix-m)) (n-base nn)]
+                   (fragment-id "store" mm nn) region)))
+        workgroup-size (* subgroup-rows subgroup-cols subgroup)]
+    (body/make
+     {:id [:contraction (or operation-id out)]
+      :parameters (matrix-parameters row col out M N K row-layout col-layout out-layout epilogue)
+      :indices indices
+      :masks masks
+      :fragments fragments
+      :operations [(body/->Guard :tile-active (vec (concat init-ops [k-loop] stores)))]
+      :schedule tile
+      :launch {:workgroup-size [workgroup-size 1]
+               :group-count [(body/expression :ceil-div 'N block-n)
+                             (body/expression :ceil-div 'M block-m)]}
+      :provenance {:dialect :segcontract :operation-id operation-id}
+      :attributes {:kind :matrix-contraction
+                   :instruction-family (:family matrix)
+                   :dims [M N K]
+                   :axis-symbols [i j k-sym]
+                   :bindings bindings
+                   :boundary-policy {:m :masked :n :masked :k :exact-fragments}
+                   :epilogue epilogue}})))
+
+(defn plan-matrix-body
+  "Apply `tile` to verified contraction facts.
+
+  Returns `{:ok true :body KernelBody :bindings …}` or a structured decline.  The initial family
+  is Intel DPAS f16×f16→f32.  Other families become additional target-lowering rows over this same
+  body vocabulary; they are not new contraction IRs."
+  ([contract-facts desc tile]
+   (plan-matrix-body contract-facts desc tile {}))
+  ([contract-facts desc tile {:keys [operation-id]}]
+   (when-not (facts/facts? contract-facts)
+     (throw (ex-info "contraction scheduling requires verified contraction facts"
+                     {:reason :raster/bug :facts contract-facts})))
+   (let [{:keys [dtype free-axes contract-axes body combine init operands epilogue]}
+         contract-facts
+         raw-tile (or tile (hardware/derive-gemm-tile (or desc {})))
+         matrix (assoc (:matrix raw-tile) :family (or (get-in raw-tile [:matrix :family]) :dpas))
+         tile (assoc raw-tile :matrix matrix :num-stages (or (:num-stages raw-tile) 3))
+         layout-verdict (when (and (= 2 (count free-axes)) (= 1 (count contract-axes)))
+                          (facts/check-layout contract-facts (:dpas facts/leaf-layouts)))
+         bindings (:bindings layout-verdict)
+         M (second (first free-axes))
+         N (second (second free-axes))
+         K (second (first contract-axes))
+         matrix-k (:k matrix)]
+     (cond
+       (or (not (dtype/known? dtype)) (not= :half (dtype/canon dtype)))
+       (decline :dtype-not-dpas {:dtype dtype})
+
+       (not= [2 1] [(count free-axes) (count contract-axes)])
+       (decline :not-2-free)
+
+       (not (additive? combine))
+       (decline :non-plus-combine {:combine combine})
+
+       (not (zero-init? init))
+       (decline :non-zero-matrix-init {:init init})
+
+       (nil? (facts/body-product-of body (map :sym operands)))
+       (decline :body-has-unmodeled-terms)
+
+       (not (:ok layout-verdict))
+       (decline :non-canonical-orientation (dissoc layout-verdict :ok :reason))
+
+       (not (every? number? [M N K]))
+       (decline :symbolic-dims)
+
+       (not= :dpas (:family matrix))
+       (decline :matrix-family-not-lowered {:family (:family matrix)})
+
+       (not (tile-valid? tile))
+       (throw (ex-info "matrix schedule tile is not divisible or contains an invalid extent"
+                       {:reason :raster/bug :tile tile}))
+
+       (not (zero? (mod (* (long N) 2) 16)))
+       (decline :n-pitch-unaligned {:N N})
+
+       (not (zero? (mod (* (long K) 2) 16)))
+       (decline :k-pitch-unaligned {:K K})
+
+      ;; A matrix instruction consumes K values as one indivisible fragment.  The old DPAS gate
+      ;; admitted K%8=0 although the emitted instruction is K16, so K=24 could issue an out-of-
+      ;; bounds final fragment.  Until a zero-filled fragment load exists, refuse it loudly.
+       (not (zero? (mod (long K) (long matrix-k))))
+       (decline :partial-matrix-k-fragment {:K K :matrix-k matrix-k})
+
+      ;; Helpers are target source pasted above the kernel.  Keeping them out is what makes the
+      ;; KernelBody store region typed rather than an opaque C escape hatch.  Existing emission
+      ;; remains available while helper expressions are promoted into the scalar expression IR.
+       (seq (:helpers epilogue))
+       (decline :opaque-epilogue-helper)
+
+       :else
+       {:ok true
+        :bindings bindings
+        :tile tile
+        :body (build-matrix-body contract-facts tile bindings epilogue operation-id)}))))

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -2400,6 +2400,9 @@
                           (when-let [t (field :tile)]
                             (str "  tile=" (:block-m t) "x" (:block-n t) "/" (:sg-m t) "x" (:sg-n t)
                                  " k" (:block-k t) " stages=" (:num-stages t 3)))
+                          (when-let [body (field :kernel-body)]
+                            (str "  body=" (name (get-in body [:attributes :kind])) "/"
+                                 (name (get-in body [:attributes :instruction-family]))))
                           (when-let [occ (field :occupancy-estimate)]
                             (str "  occupancy=" (format "%.0f%%" (* 100.0 (:occupancy occ)))
                                  " limited-by=" (name (:limiting-factor occ))))))

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -1,0 +1,69 @@
+(ns raster.compiler.ir.kernel-body-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.core.layout :as layout]
+            [raster.compiler.ir.kernel-body :as body]))
+
+(def ^:private matrix {:family :dpas :m 8 :n 16 :k 16 :subgroup 16})
+(def ^:private acc-layout (layout/mma-frag matrix :float))
+(def ^:private lhs-layout (layout/dot-operand 0 acc-layout 2 :half))
+(def ^:private rhs-layout (layout/dot-operand 1 acc-layout 2 :half))
+
+(defn- minimal-body []
+  (body/make
+   {:id :matrix
+    :parameters [(body/->KernelParameter 'A :input :half [16 16] :global
+                                         (layout/row-major [16 16] :half) :lhs)
+                 (body/->KernelParameter 'B :input :half [16 16] :global
+                                         (layout/row-major [16 16] :half) :rhs)
+                 (body/->KernelParameter 'C :output :half [16 16] :global
+                                         (layout/row-major [16 16] :half) :result)]
+    :indices [(body/->IndexBinding 'group-x :group 0)]
+    :masks [(body/->Mask :in-bounds [(body/predicate :lt 'group-x 16)])]
+    :fragments [(body/->Fragment :lhs :half [8 16] lhs-layout)
+                (body/->Fragment :rhs :half [16 16] rhs-layout)
+                (body/->Fragment :acc :float [8 16] acc-layout)]
+    :operations [(body/->Guard
+                  :in-bounds
+                  [(body/->FragmentInit :acc 0.0)
+                   (body/->Loop
+                    'k 0 16 16
+                    [(body/->TileLoad :lhs 'A ['group-x 'k] :in-bounds :cached)
+                     (body/->TileLoad :rhs 'B ['k 'group-x] :in-bounds :cached)
+                     (body/->MatrixMad :acc :lhs :rhs matrix)]
+                    {:unroll true})
+                   (body/->TileStore 'C :acc ['group-x 0] :in-bounds nil)])]
+    :schedule {:matrix matrix}
+    :launch {:workgroup-size [16] :group-count [1]}
+    :provenance {:dialect :test}
+    :attributes {:kind :matrix-contraction}}))
+
+(deftest a-kernel-body-makes-schedule-decisions-explicit
+  (let [kernel (minimal-body)
+        guard (first (:operations kernel))
+        loop-op (second (:operations guard))]
+    (is (body/kernel-body? kernel))
+    (is (= :dot-operand (get-in kernel [:fragments 0 :layout :kind])))
+    (is (= :mma-frag (get-in kernel [:fragments 2 :layout :kind])))
+    (is (= 16 (:step loop-op)))
+    (is (= :in-bounds (:mask guard)))
+    (is (= matrix (:instruction (nth (:operations loop-op) 2))))))
+
+(deftest the-verifier-refuses-implicit-or-incompatible-kernel-semantics
+  (testing "opaque list arithmetic cannot hide in coordinates"
+    (let [kernel (minimal-body)
+          bad (assoc-in kernel [:operations 0 :operations 1 :operations 0 :coordinates 0]
+                        '(+ group-x 1))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"explicit index expressions"
+                            (body/validate! bad)))))
+  (testing "matrix operands must inherit the accumulator distribution"
+    (let [kernel (minimal-body)
+          wrong-parent (layout/mma-frag matrix :half)
+          bad (assoc-in kernel [:fragments 0 :layout]
+                        (layout/dot-operand 0 wrong-parent 2 :half))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"fragment layouts do not agree"
+                            (body/validate! bad)))))
+  (testing "all memory guards name declared masks"
+    (let [kernel (minimal-body)
+          bad (assoc-in kernel [:operations 0 :operations 2 :mask] :missing)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"undeclared mask"
+                            (body/validate! bad))))))

--- a/test/raster/compiler/passes/parallel/contraction_schedule_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_schedule_test.clj
@@ -1,0 +1,112 @@
+(ns raster.compiler.passes.parallel.contraction-schedule-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.opencl-pass :as opencl]
+            [raster.compiler.backend.gpu.segop-opencl :as segop-opencl]
+            [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.ir.contraction-facts :as facts]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.parallel-program :as program]
+            [raster.compiler.passes.parallel.contract-lower :as contract-lower]
+            [raster.compiler.passes.parallel.contract-route :as route]
+            [raster.compiler.passes.parallel.contraction-schedule :as schedule]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]))
+
+(defn- matrix-form [m n k & [init]]
+  (concat
+   (list 'raster.par/contract 'C [['i m] ['j n]] [['l k]]
+         (list 'raster.numeric/*
+               (list 'clojure.core/aget 'A
+                     (list 'clojure.core/+ (list 'clojure.core/* 'i k) 'l))
+               (list 'clojure.core/aget 'B
+                     (list 'clojure.core/+ (list 'clojure.core/* 'l n) 'j))))
+   (when (some? init) [:init init])))
+
+(deftest applying-a-matrix-schedule-produces-a-target-neutral-kernel-body
+  (let [contract-facts (facts/contraction-facts (matrix-form 128 128 128) :dtype :half)
+        planned (schedule/plan-matrix-body contract-facts nil nil {:operation-id 41})
+        kernel (:body planned)
+        guard (first (:operations kernel))
+        outer-loop (first (filter #(contains? % :step) (:operations guard)))
+        inner-loop (first (:operations outer-loop))]
+    (is (:ok planned))
+    (is (body/kernel-body? kernel))
+    (is (= [:contraction 41] (:id kernel)))
+    (is (= 41 (get-in kernel [:provenance :operation-id])))
+    (is (= {:row 'A :col 'B} (:bindings planned)))
+    (is (= :dpas (get-in kernel [:attributes :instruction-family])))
+    (is (= {:m :masked :n :masked :k :exact-fragments}
+           (get-in kernel [:attributes :boundary-policy])))
+    (is (= 32 (:step outer-loop)) "the scheduled K block is IR")
+    (is (= 16 (:step inner-loop)) "the hardware fragment step is independently IR")
+    (is (= 3 (get-in inner-loop [:operations 0 :distance]))
+        "pipeline depth reaches the explicit prefetch op")
+    (is (= :dot-operand (get-in kernel [:fragments 8 :layout :kind])))
+    (is (= :mma-frag (get-in kernel [:fragments 0 :layout :kind])))))
+
+(deftest matrix-fragment-boundaries-are-a-legality-policy
+  (testing "K=24 meets the old 16-byte pitch test but cannot form a final K16 instruction"
+    (let [planned (schedule/plan-matrix-body
+                   (facts/contraction-facts (matrix-form 128 128 24) :dtype :half) nil nil)]
+      (is (false? (:ok planned)))
+      (is (= :partial-matrix-k-fragment (:reason planned)))
+      (is (= 16 (:matrix-k planned)))))
+  (testing "a non-zero reduction initializer cannot be dropped by a zero-initialized matrix body"
+    (is (= :non-zero-matrix-init
+           (:reason (schedule/plan-matrix-body
+                     (facts/contraction-facts (matrix-form 128 128 128 1.0) :dtype :half)
+                     nil nil))))))
+
+(deftest the-production-route-carries-the-body-into-the-executable-artifact
+  (let [routed (route/route-contraction (matrix-form 128 128 128) :dtype :half)
+        kernel (:kernel-body routed)]
+    (is (= :dpas (:strategy routed)))
+    (is (body/kernel-body? kernel))
+    (is (= kernel (artifact/attribute (:artifact routed) :kernel-body)))
+    (is (= (:tile routed) (:schedule kernel)))
+    (is (= '[A B] (:array-params routed)))))
+
+(deftest production-lowering-preserves-the-semantic-operation-identity
+  (let [contract (matrix-form 128 128 128)
+        source (list 'let* ['c contract] 'c)
+        lowered (:form (segop-lower/segop-lower-pass
+                        source {:target-device :ze:0 :dtype :half}))
+        semantic-operation (first (program/operations-for-binding lowered 'c contract))
+        compiled (opencl/opencl-pass lowered :dtype :half :min-elements 0)
+        kernel (artifact/attribute (first (:kernels compiled)) :kernel-body)]
+    (is (some? semantic-operation))
+    (is (= [:contraction (:id semantic-operation)] (:id kernel)))
+    (is (= (:id semantic-operation) (get-in kernel [:provenance :operation-id])))))
+
+(deftest kernel-body-lowering-shadows-the-proven-dpas-oracle
+  (let [form (matrix-form 128 128 128)
+        routed (route/route-contraction form :dtype :half)
+        oracle (segop-opencl/generate-dpas-contraction-kernel
+                (contract-lower/contract-form->segred form :dtype :half) 'C)
+        normalize #(str/replace % #"dpas_contract_[0-9]+" "dpas_contract_N")]
+    (is (= (normalize (:source oracle)) (normalize (:source routed))))
+    (is (= (:tile oracle) (:tile routed)))
+    (is (= (:workgroup oracle) (:wg routed)))
+    (is (body/kernel-body? (:kernel-body routed)))))
+
+(deftest a-partial-matrix-fragment-falls-back-with-an-explanation
+  (let [routed (route/route-contraction (matrix-form 128 128 24) :dtype :half)]
+    (is (= :regtiled (:strategy routed)))
+    (is (= :partial-matrix-k-fragment (:fallback-reason routed)))
+    (is (= :partial-matrix-k-fragment (get-in routed [:declines 0 :reason])))))
+
+(deftest opencl-consumes-the-resolved-contraction-tile
+  (let [tile (assoc (hardware/derive-gemm-tile {})
+                    :block-m 64 :block-n 64 :num-stages 2)
+        compiled (opencl/opencl-pass (matrix-form 128 128 128)
+                                     :dtype :half :min-elements 0
+                                     :schedule {:tile tile})
+        artifact (first (:kernels compiled))
+        kernel (artifact/attribute artifact :kernel-body)]
+    (is (= tile (:schedule kernel)))
+    (is (= [64 64] ((juxt :block-m :block-n) (:schedule kernel))))
+    (is (= 2 (get-in kernel [:schedule :num-stages])))
+    (is (re-find #"WG 64x64" (:source artifact)))
+    (is (re-find #"\+ 32;" (:source artifact))
+        "num-stages=2 changes the K16 prefetch distance to 32")))


### PR DESCRIPTION
## Summary

- add a verified, target-neutral KernelBody vocabulary for indices, masks, fragments, loops, prefetches, matrix MADs, scalar store regions, and launch geometry
- schedule canonical f16 ContractionFacts into explicit DPAS bodies while preserving the SegContract operation identity
- route production contractions and artifacts through that body, including resolved tile and pipeline-depth choices
- keep the proven OpenCL template as a byte-identical shadow lowering while direct per-operation lowering is developed
- reject partial K16 fragments and non-zero matrix initializers instead of silently generating invalid DPAS bodies

## Verification

- 9 kernel-body/scheduling tests, 45 assertions
- 39 routing, ABI, spelling, and SOAC tests, 305 assertions
- 10 production/device DPAS tests, 54 assertions
- clj-kondo: 0 errors
- formatting and git diff checks clean

A prior isolated full-suite run on this worktree reached 2,348 tests / 34,437 assertions with two unrelated, non-deterministic GPU failures: the autotune speedup ratchet measured 2.8x against a 4x threshold, and one range-transfer test assumed fresh device memory was zeroed. Both affected namespaces passed when rerun independently; all compiler and contraction coverage passed.