### PR TITLE
Lower scheduled contraction bodies directly

### DIFF
--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -1,0 +1,429 @@
+(ns raster.compiler.backend.gpu.kernel-body-opencl
+  "Direct OpenCL lowering of verified scheduled KernelBody values.
+
+  This namespace is below semantic contraction analysis and hardware scheduling.  It chooses only
+  target spellings: Intel subgroup builtins, OpenCL declarations and a pipelined loop form.  Tile
+  geometry and fragment topology are recovered from explicit index/operation IR, never from the
+  source contraction or a second schedule registry."
+  (:require [clojure.string :as str]
+            [raster.compiler.ir.kernel-body :as body]))
+
+(defn- record-kind? [simple-name value]
+  (= (str "raster.compiler.ir.kernel_body." simple-name)
+     (some-> value class .getName)))
+
+(defn- only!
+  [owner values]
+  (let [values (vec values)]
+    (when-not (= 1 (count values))
+      (throw (ex-info (str "OpenCL KernelBody lowering requires exactly one " owner)
+                      {:reason :raster/bug :owner owner :values values})))
+    (first values)))
+
+(defn- require!
+  [condition message data]
+  (when-not condition
+    (throw (ex-info message (assoc data :reason :kernel-body-opencl-unimplemented)))))
+
+(defn- expression-references [expression]
+  (cond
+    (symbol? expression) #{expression}
+    (number? expression) #{}
+    (record-kind? "IndexExpr" expression)
+    (reduce into #{} (map expression-references (:arguments expression)))
+    :else #{}))
+
+(defn- coefficient
+  "The static linear coefficient of `needle` in the small affine index-expression subset used by
+  scheduled matrix bodies.  Returns nil for nonlinear/unknown expressions."
+  [expression needle]
+  (cond
+    (= expression needle) 1
+    (or (number? expression) (symbol? expression)) 0
+    (not (record-kind? "IndexExpr" expression)) nil
+    (not (contains? (expression-references expression) needle)) 0
+    (= :add (:op expression))
+    (let [coefficients (map #(coefficient % needle) (:arguments expression))]
+      (when (every? some? coefficients) (reduce + 0 coefficients)))
+    (= :sub (:op expression))
+    (let [[head & tail] (map #(coefficient % needle) (:arguments expression))]
+      (when (and (some? head) (every? some? tail)) (reduce - head tail)))
+    (= :mul (:op expression))
+    (let [arguments (:arguments expression)
+          containing (filter #(contains? (expression-references %) needle) arguments)
+          constants (remove #(contains? (expression-references %) needle) arguments)]
+      (when (and (= 1 (count containing)) (every? number? constants))
+        (when-let [inner (coefficient (first containing) needle)]
+          (* inner (reduce * 1 constants)))))
+    :else nil))
+
+(defn- scale-affine [form factor]
+  {:constant (* factor (:constant form))
+   :coefficients (into {} (map (fn [[id value]] [id (* factor value)]))
+                       (:coefficients form))})
+
+(defn- add-affine [lhs rhs]
+  {:constant (+ (:constant lhs) (:constant rhs))
+   :coefficients (merge-with + (:coefficients lhs) (:coefficients rhs))})
+
+(defn- affine-form
+  "Normalize explicit index IR to a linear form.  nil means the expression is outside the affine
+  subset accepted by this target lowering."
+  [expression]
+  (cond
+    (number? expression) {:constant expression :coefficients {}}
+    (symbol? expression) {:constant 0 :coefficients {expression 1}}
+    (not (record-kind? "IndexExpr" expression)) nil
+    (= :add (:op expression))
+    (let [parts (map affine-form (:arguments expression))]
+      (when (every? some? parts)
+        (reduce add-affine {:constant 0 :coefficients {}} parts)))
+    (= :sub (:op expression))
+    (let [[head & tail] (map affine-form (:arguments expression))]
+      (when (and (some? head) (every? some? tail))
+        (reduce #(add-affine %1 (scale-affine %2 -1)) head tail)))
+    (= :mul (:op expression))
+    (let [arguments (:arguments expression)
+          constants (filter number? arguments)
+          nonconstants (remove number? arguments)]
+      (when (= 1 (count nonconstants))
+        (some-> (affine-form (first nonconstants))
+                (scale-affine (reduce * 1 constants)))))
+    :else nil))
+
+(defn- affine=
+  [expression constant coefficients]
+  (= {:constant constant :coefficients coefficients} (affine-form expression)))
+
+(defn- lt-affine?
+  [predicate lhs-constant lhs-coefficients rhs]
+  (and (record-kind? "Predicate" predicate)
+       (= :lt (:op predicate))
+       (= 2 (count (:arguments predicate)))
+       (affine= (first (:arguments predicate)) lhs-constant lhs-coefficients)
+       (= rhs (second (:arguments predicate)))))
+
+(defn- binding-of [indices source axis]
+  (:id (only! (str (name source) " index on axis " axis)
+              (filter #(and (record-kind? "IndexBinding" %)
+                            (= source (:source %)) (= axis (:axis %)))
+                      indices))))
+
+(defn- compute-using [indices op source]
+  (only! (str (name op) " index derived from " source)
+         (filter #(and (record-kind? "IndexCompute" %)
+                       (= op (get-in % [:expression :op]))
+                       (= source (first (get-in % [:expression :arguments]))))
+                 indices)))
+
+(defn- fragment-op-idx [fragments fragment-id]
+  (get-in fragments [fragment-id :layout :op-idx]))
+
+(defn- matrix-plan
+  "Verify the currently lowered DPAS KernelBody subset and derive a target emission plan by walking
+  its indices, fragments and operations.  Every field that affects generated code has an IR witness."
+  [kernel-body]
+  (let [kernel-body (body/validate! kernel-body)
+        {:keys [parameters indices masks fragments operations]} kernel-body
+        parameters-by-role (group-by :role parameters)
+        lhs-param (only! "lhs parameter" (:lhs parameters-by-role))
+        rhs-param (only! "rhs parameter" (:rhs parameters-by-role))
+        out-param (only! "result parameter" (:result parameters-by-role))
+        [[M K] [K' N] [M' N']] (map :shape [lhs-param rhs-param out-param])
+        _ (require! (= [M K N] [M' K' N'])
+                    "matrix parameter shapes do not compose" {:parameters parameters})
+        _ (require! (= #{'M 'N 'K} (set (map :id (:dimension parameters-by-role))))
+                    "matrix body requires the ordered M/N/K dimension ABI"
+                    {:dimensions (:dimension parameters-by-role)})
+        fragment-map (into {} (map (juxt :id identity)) fragments)
+        guard (only! "top-level guard" operations)
+        _ (require! (record-kind? "Guard" guard)
+                    "matrix body must begin with a guarded tile" {:operation guard})
+        guarded (:operations guard)
+        initializers (filter #(record-kind? "FragmentInit" %) guarded)
+        outer-loop (only! "outer K loop" (filter #(record-kind? "Loop" %) guarded))
+        stores (vec (filter #(record-kind? "TileStore" %) guarded))
+        unknown-guarded (remove #(or (record-kind? "FragmentInit" %)
+                                     (record-kind? "Loop" %)
+                                     (record-kind? "TileStore" %))
+                                guarded)
+        _ (require! (empty? unknown-guarded)
+                    "matrix tile contains operations without an OpenCL lowering"
+                    {:operations (vec unknown-guarded)})
+        inner-loop (only! "matrix-fragment loop" (:operations outer-loop))
+        _ (require! (record-kind? "Loop" inner-loop)
+                    "outer K loop must contain the matrix-fragment loop" {:operation inner-loop})
+        inner-ops (:operations inner-loop)
+        prefetches (vec (filter #(record-kind? "TilePrefetch" %) inner-ops))
+        loads (vec (filter #(record-kind? "TileLoad" %) inner-ops))
+        mads (vec (filter #(record-kind? "MatrixMad" %) inner-ops))
+        unknown-inner (remove #(or (record-kind? "TilePrefetch" %)
+                                   (record-kind? "TileLoad" %)
+                                   (record-kind? "MatrixMad" %))
+                              inner-ops)
+        _ (require! (empty? unknown-inner)
+                    "matrix fragment loop contains operations without an OpenCL lowering"
+                    {:operations (vec unknown-inner)})
+        lhs-loads (filterv #(= 0 (fragment-op-idx fragment-map (:fragment %))) loads)
+        rhs-loads (filterv #(= 1 (fragment-op-idx fragment-map (:fragment %))) loads)
+        lhs-ids (mapv :fragment lhs-loads)
+        rhs-ids (mapv :fragment rhs-loads)
+        first-mad (only! "matrix instruction shape" (distinct (map :instruction mads)))
+        {mi :m ni :n ki :k subgroup :subgroup} first-mad
+        _ (require! (and (= :dpas (:family first-mad))
+                         (= 8 mi) (= 16 ki)
+                         (contains? #{8 16} subgroup)
+                         (= ni subgroup))
+                    "Intel OpenCL lowering has no builtin for this matrix instruction"
+                    {:instruction first-mad})
+        _ (require! (= ki (:step inner-loop))
+                    "matrix loop step and instruction K fragment disagree"
+                    {:loop-step (:step inner-loop) :instruction first-mad})
+        block-k (:step outer-loop)
+        outer-index (:index outer-loop)
+        inner-index (:index inner-loop)
+        _ (require! (and (= 0 (:lower outer-loop)) (= 'K (:upper outer-loop))
+                         (= outer-index (:lower inner-loop))
+                         (= :min (get-in inner-loop [:upper :op]))
+                         (affine= (first (get-in inner-loop [:upper :arguments]))
+                                  block-k {outer-index 1})
+                         (= 'K (second (get-in inner-loop [:upper :arguments]))))
+                    "matrix K loops do not describe blocked exact-fragment traversal"
+                    {:outer outer-loop :inner inner-loop})
+        _ (require! (and (seq lhs-loads) (seq rhs-loads)
+                         (= (count prefetches) (count lhs-loads)))
+                    "matrix loop requires one prefetch per lhs fragment and both operand loads"
+                    {:prefetches prefetches :lhs-loads lhs-loads :rhs-loads rhs-loads})
+        mad-by-operands (into {} (map (fn [op] [[(:lhs op) (:rhs op)] op]) mads))
+        expected-pairs (for [lhs lhs-ids rhs rhs-ids] [lhs rhs])
+        _ (require! (= (set expected-pairs) (set (keys mad-by-operands)))
+                    "matrix MAD operations do not cover the lhs/rhs fragment product"
+                    {:expected (vec expected-pairs) :actual (vec (keys mad-by-operands))})
+        accumulator-ids (mapv (comp :accumulator mad-by-operands) expected-pairs)
+        _ (require! (= (set accumulator-ids) (set (map :fragment initializers))
+                       (set accumulator-ids) (set (map :fragment stores)))
+                    "matrix accumulators must each be initialized and stored exactly once"
+                    {:accumulators accumulator-ids :initializers initializers :stores stores})
+        _ (require! (every? #(and (number? (:value %)) (zero? (:value %))) initializers)
+                    "Intel matrix accumulators currently require zero initialization"
+                    {:initializers initializers})
+        prefetch-distance (only! "pipeline distance" (distinct (map :distance prefetches)))
+        _ (require! (and (integer? block-k) (pos? block-k) (zero? (mod block-k ki)))
+                    "outer K step must contain a whole number of matrix fragments"
+                    {:block-k block-k :matrix-k ki})
+        group-n (binding-of indices :group 0)
+        group-m (binding-of indices :group 1)
+        subgroup-id (binding-of indices :subgroup 0)
+        lane-id (binding-of indices :lane 0)
+        subgroup-row (compute-using indices :floor-div subgroup-id)
+        subgroup-col (compute-using indices :mod subgroup-id)
+        ncols (second (get-in subgroup-row [:expression :arguments]))
+        _ (require! (= ncols (second (get-in subgroup-col [:expression :arguments])))
+                    "subgroup row and column decomposition disagree" {:indices indices})
+        computes (filter #(record-kind? "IndexCompute" %) indices)
+        m-base (only! "M tile origin"
+                      (filter #(pos? (or (coefficient (:expression %) group-m) 0)) computes))
+        m-base-id (:id m-base)
+        n-base-ids (mapv (comp second :coordinates) rhs-loads)
+        n-base-computes (mapv (fn [id]
+                                (only! (str "N tile origin " id)
+                                       (filter #(= id (:id %)) computes)))
+                              n-base-ids)
+        block-m (coefficient (:expression m-base) group-m)
+        sg-m (coefficient (:expression m-base) (:id subgroup-row))
+        block-n (coefficient (:expression (first n-base-computes)) group-n)
+        sg-n (coefficient (:expression (first n-base-computes)) (:id subgroup-col))
+        _ (require! (= [sg-m sg-n] [(* (count lhs-ids) mi) (* (count rhs-ids) ni)])
+                    "fragment topology and subgroup tile geometry disagree"
+                    {:derived [sg-m sg-n]
+                     :fragments [(* (count lhs-ids) mi) (* (count rhs-ids) ni)]})
+        _ (require! (= ncols (quot block-n sg-n))
+                    "subgroup decomposition and block geometry disagree"
+                    {:subgroup-columns ncols :block-n block-n :sg-n sg-n})
+        lhs-rows (mapv (comp first :coordinates) lhs-loads)
+        _ (require! (every? true?
+                            (map-indexed #(and (affine= %2 (* %1 mi) {m-base-id 1})
+                                               (= inner-index
+                                                  (second (:coordinates (nth lhs-loads %1)))))
+                                         lhs-rows))
+                    "lhs tile coordinates do not match its matrix fragments"
+                    {:coordinates lhs-rows :origin m-base-id})
+        _ (require! (every? true?
+                            (map #(and (= inner-index (first (:coordinates %)))
+                                       (symbol? (second (:coordinates %))))
+                                 rhs-loads))
+                    "rhs tile coordinates do not match the matrix-fragment loop"
+                    {:loads rhs-loads :loop-index inner-index})
+        _ (require! (and (every? #(= (:id lhs-param) (:buffer %)) lhs-loads)
+                         (every? #(= (:id rhs-param) (:buffer %)) rhs-loads)
+                         (every? #(= (:id out-param) (:buffer %)) stores))
+                    "matrix operations are not connected to their role parameters"
+                    {:lhs lhs-param :rhs rhs-param :out out-param})
+        _ (require! (every?
+                     true?
+                     (map-indexed
+                      #(affine= (:expression %2) (* %1 ni)
+                                {group-n block-n (:id subgroup-col) sg-n})
+                      n-base-computes))
+                    "N tile origins do not match the rhs fragment order"
+                    {:origins n-base-computes})
+        _ (require! (and (integer? prefetch-distance) (pos? prefetch-distance)
+                         (every? #(and (= (:id lhs-param) (:buffer %))
+                                       (= [mi ki] (:shape %)))
+                                 prefetches)
+                         (= (set lhs-rows) (set (map (comp first :coordinates) prefetches)))
+                         (every? #(affine= (second (:coordinates %))
+                                           (* prefetch-distance ki) {inner-index 1})
+                                 prefetches))
+                    "prefetch operations do not describe the matrix pipeline lookahead"
+                    {:prefetches prefetches :distance prefetch-distance})
+        store-by-fragment (into {} (map (juxt :fragment identity)) stores)
+        _ (require! (every?
+                     true?
+                     (for [[m lhs] (map-indexed vector lhs-ids)
+                           [n rhs] (map-indexed vector rhs-ids)
+                           :let [accumulator (:accumulator (get mad-by-operands [lhs rhs]))
+                                 store (get store-by-fragment accumulator)]]
+                       (= [(nth lhs-rows m) (nth n-base-ids n)] (:coordinates store))))
+                    "tile stores do not preserve accumulator fragment coordinates"
+                    {:stores stores})
+        mask-map (into {} (map (juxt :id identity)) masks)
+        predicates-of (fn [mask-id] (:predicates (get mask-map mask-id)))
+        guard-predicates (predicates-of (:mask guard))
+        _ (require! (and (= 2 (count guard-predicates))
+                         (some #(lt-affine? % 0 {m-base-id 1} 'M) guard-predicates)
+                         (some #(lt-affine? % 0 {(first n-base-ids) 1} 'N)
+                               guard-predicates))
+                    "tile guard mask does not cover the M/N tile origins"
+                    {:guard guard :mask (get mask-map (:mask guard))})
+        load-mask (only! "matrix-load mask" (distinct (map :mask loads)))
+        load-predicates (predicates-of load-mask)
+        _ (require! (and (= 1 (count load-predicates))
+                         (lt-affine? (first load-predicates) 0 {inner-index 1} 'K))
+                    "matrix loads require the fragment-index K mask"
+                    {:mask (get mask-map load-mask)})
+        prefetch-mask (only! "matrix-prefetch mask" (distinct (map :mask prefetches)))
+        prefetch-predicates (predicates-of prefetch-mask)
+        _ (require! (and (= 1 (count prefetch-predicates))
+                         (lt-affine? (first prefetch-predicates)
+                                     (* prefetch-distance ki) {inner-index 1} 'K))
+                    "matrix prefetch mask and pipeline distance disagree"
+                    {:mask (get mask-map prefetch-mask) :distance prefetch-distance})
+        _ (require!
+           (every?
+            true?
+            (for [[m lhs] (map-indexed vector lhs-ids)
+                  [n rhs] (map-indexed vector rhs-ids)
+                  :let [accumulator (:accumulator (get mad-by-operands [lhs rhs]))
+                        store (get store-by-fragment accumulator)
+                        predicates (predicates-of (:mask store))]]
+              (and (= 2 (count predicates))
+                   (some #(lt-affine? % (* m mi) {m-base-id 1} 'M) predicates)
+                   (some #(lt-affine? % 0 {(nth n-base-ids n) 1 lane-id 1} 'N)
+                         predicates))))
+           "tile-store masks do not match their fragment coordinates"
+           {:stores stores :masks masks})]
+    {:mi mi :ni ni :ki ki :subgroup subgroup
+     :block-m block-m :block-n block-n :block-k block-k :sg-m sg-m :sg-n sg-n
+     :ncols ncols :lhs-ids lhs-ids :rhs-ids rhs-ids :mad-by-operands mad-by-operands
+     :stores stores :prefetch prefetch-distance}))
+
+(defn- emit-plan
+  [kernel-name {:keys [mi ni ki subgroup block-m block-n block-k sg-m sg-n
+                       ncols lhs-ids rhs-ids mad-by-operands stores prefetch]}
+   {:keys [epilogue epilogue-params]}]
+  (let [nms (count lhs-ids)
+        nns (count rhs-ids)
+        ksteps (quot block-k ki)
+        acc-id (fn [m n] (:accumulator (get mad-by-operands
+                                            [(nth lhs-ids m) (nth rhs-ids n)])))
+        store-by-fragment (into {} (map (juxt :fragment identity)) stores)
+        ms (range nms)
+        ns (range nns)
+        amul (fn [m] (if (zero? m) "m_base" (str "m_base+" (* m mi))))
+        kstep (fn [kpos]
+                (str "        { int pk = " kpos " + " (* prefetch ki) ";\n"
+                     "          if (pk < K) {\n"
+                     (apply str
+                            (for [m ms]
+                              (str "            intel_sub_group_2d_block_prefetch_16b_8r16x1c((__global void*)A, a_wb, M, a_pb, (int2)(pk, " (amul m) "));\n")))
+                     "          } }\n"
+                     (apply str
+                            (for [n ns]
+                              (str "        bp" n " = as_int8(intel_subgroup_block_read_transform_u16_k16((__global void*)B, b_wb, K, b_pb, (int2)(n_base" n ", " kpos ")));\n")))
+                     (apply str
+                            (for [m ms]
+                              (str "        intel_sub_group_2d_block_read_16b_8r16x1c((__global void*)A, a_wb, M, a_pb, (int2)(" kpos ", " (amul m) "), &a" m ");\n")))
+                     (apply str (for [m ms] (str "        sa" m " = as_short8(a" m ");\n")))
+                     (apply str
+                            (for [m ms n ns]
+                              (do
+                                (require! (contains? store-by-fragment (acc-id m n))
+                                          "matrix accumulator has no store operation"
+                                          {:accumulator (acc-id m n)})
+                                (str "        acc" m n " = intel_sub_group_f16_f16_matrix_mad_k16(sa" m ", bp" n ", acc" m n ");\n"))))))]
+    (str
+     "#pragma OPENCL EXTENSION cl_intel_subgroup_matrix_multiply_accumulate : enable\n"
+     "#pragma OPENCL EXTENSION cl_intel_subgroup_2d_block_io : enable\n\n"
+     "// Tiled GEMM (parametric): WG " block-m "x" block-n ", SG " sg-m "x" sg-n
+     ", K " block-k ", DPAS " mi "x" ni "x" ki ", sg " subgroup "\n"
+     "__attribute__((intel_reqd_sub_group_size(" subgroup ")))\n"
+     "__kernel void " kernel-name "(\n"
+     "    __global const half* restrict A,\n    __global const half* restrict B,\n"
+     "    __global half* restrict C,\n    int M, int N, int K"
+     epilogue-params
+     ") {\n"
+     "    int sg_id = get_sub_group_id();\n    int sg_lid = get_sub_group_local_id();\n"
+     "    int sg_row = sg_id / " ncols ";\n    int sg_col = sg_id % " ncols ";\n"
+     "    int m_base = get_group_id(1) * " block-m " + sg_row * " sg-m ";\n"
+     (apply str
+            (for [n ns]
+              (str "    int n_base" n " = get_group_id(0) * " block-n " + sg_col * " sg-n
+                   (when (pos? n) (str " + " (* n ni))) ";\n")))
+     "    if (m_base >= M || n_base0 >= N) return;\n"
+     (apply str
+            (for [m ms]
+              (str "    float" mi " "
+                   (str/join ", " (for [n ns] (str "acc" m n "=0.0f"))) ";\n")))
+     "    int a_wb = K * 2, a_pb = K * 2;\n    int b_wb = N * 2, b_pb = N * 2;\n"
+     "    ushort8 " (str/join ", " (for [m ms] (str "a" m))) ";\n"
+     "    short8 " (str/join ", " (for [m ms] (str "sa" m))) ";\n"
+     "    int8 " (str/join ", " (for [n ns] (str "bp" n))) ";\n"
+     (apply str
+            (for [p (range prefetch)]
+              (str "    if (" (* p ki) " < K) {\n"
+                   (apply str
+                          (for [m ms]
+                            (str "        intel_sub_group_2d_block_prefetch_16b_8r16x1c((__global void*)A, a_wb, M, a_pb, (int2)(" (* p ki) ", " (amul m) "));\n")))
+                   "    }\n")))
+     "    int k = 0;\n"
+     "    for (; k + " (dec block-k) " < K; k += " block-k ") {\n"
+     (apply str
+            (for [ks (range ksteps)]
+              (kstep (if (zero? ks) "k" (str "k + " (* ks ki))))))
+     "    }\n"
+     "    for (; k < K; k += " ki ") {\n"
+     (kstep "k")
+     "    }\n"
+     (apply str
+            (for [m ms i (range mi)]
+              (str "    { int row = m_base + " (+ (* m mi) i) ";\n      if (row < M) {\n"
+                   (apply str
+                          (for [n ns]
+                            (let [acc-expr (str "acc" m n ".s" i)]
+                              (str "        { int col = n_base" n " + sg_lid;\n          if (col < N) "
+                                   (if epilogue
+                                     (str "C[row*N+col] = (half)("
+                                          (epilogue acc-expr "row" "col") ");\n")
+                                     (str "C[row*N+col] = (half)(" acc-expr ");\n"))
+                                   "        }\n"))))
+                   "      }\n    }\n")))
+     "}\n")))
+
+(defn emit-matrix-kernel
+  "Lower a verified f16 DPAS KernelBody directly to OpenCL C.
+
+  `target-store` is the already type-checked scalar-region target spelling
+  `{:epilogue fn :epilogue-params string}`.  It is nil for an identity store."
+  [kernel-name kernel-body target-store]
+  (emit-plan kernel-name (matrix-plan kernel-body) (or target-store {})))

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -7,7 +7,8 @@
 
    This is the GPU counterpart to segop_simd.clj — both consume the
    same SegOp IR but produce different target code."
-  (:require [raster.compiler.backend.gpu.opencl-codegen :as codegen]
+  (:require [raster.compiler.backend.gpu.kernel-body-opencl :as kernel-body-opencl]
+            [raster.compiler.backend.gpu.opencl-codegen :as codegen]
             [raster.compiler.backend.gpu.c-emit :as ce]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
@@ -1283,8 +1284,8 @@
      :acc-regs acc-regs}))
 
 (defn epilogue-splice
-  "Build the (fn [acc-expr row col] -> C-expr) + param-decls + helpers that emit-gemm-tiled's
-   store-splice expects, from a DOMAIN-AGNOSTIC spec. The compiler learns no op names: the spec is
+  "Build the OpenCL scalar-expression spelling consumed by a matrix store region from a
+   DOMAIN-AGNOSTIC spec. The compiler learns no op names: the spec is
    just an EXPRESSION over the accumulator and some operands, each operand carrying its own
    axis-map, so bias / activation / residual / dequant-scale are all the same mechanism and
    COMPOSE by nesting (one bigger expression), per CLAUDE.md's domain-agnostic-passes rule.
@@ -1332,23 +1333,67 @@
      :epilogue-params params
      :epilogue-helpers helpers}))
 
+(defn- nested-kernel-operations [operations]
+  (mapcat (fn [operation]
+            (cons operation
+                  (when-let [nested (:operations operation)]
+                    (nested-kernel-operations nested))))
+          operations))
+
+(defn- kernel-body-store-splice
+  "Lower the typed ScalarRegion attached to KernelBody stores into the existing OpenCL scalar
+  expression vocabulary.  Matrix emission itself never sees the source contraction or epilogue
+  descriptor; its only target-specific input is this spelling of the store region."
+  [kernel-body]
+  (let [stores (filter #(instance? raster.compiler.ir.kernel_body.TileStore %)
+                       (nested-kernel-operations (:operations kernel-body)))
+        regions (distinct (map :value-region stores))]
+    (when-not (= 1 (count regions))
+      (throw (ex-info "all matrix tile stores must carry the same scalar region"
+                      {:reason :raster/bug :regions (vec regions)})))
+    (when-let [region (first regions)]
+      (let [operand-ids (set (map :sym (:operands region)))
+            scalar-ids (remove operand-ids (rest (:parameters region)))
+            parameters (into {} (map (juxt :id identity)) (:parameters kernel-body))
+            scalars (mapv (fn [id]
+                            (let [parameter (or (get parameters id)
+                                                (throw (ex-info "scalar region parameter is absent from the kernel ABI"
+                                                                {:reason :raster/bug
+                                                                 :parameter id})))]
+                              {:sym id :dtype (:dtype parameter)}))
+                          scalar-ids)
+            spec {:acc (first (:parameters region))
+                  :expr (:expression region)
+                  :operands (:operands region)
+                  :scalars scalars}
+            target (epilogue-splice spec
+                                    (subvec (vec (get-in kernel-body [:attributes :axis-symbols])) 0 2)
+                                    (:result-dtype region))]
+        (assoc target :spec spec)))))
+
 (defn- emit-dpas-plan
-  "Lower one already-checked DPAS plan.  This remains the shadow target adapter while the
-   `emit-gemm-tiled` template is decomposed into per-operation KernelBody lowering.  All schedule,
-   layout and boundary decisions have already happened before this boundary."
+  "Lower one already-checked DPAS plan.  A KernelBody takes the direct operation lowerer; nil uses
+  the legacy template solely for the independent oracle and opaque-helper compatibility path."
   [kernel-name row-arr col-arr out-sym [M N L] [i-sym j-sym] tile epilogue kernel-body]
-  (let [sg (long (get-in tile [:matrix :subgroup] 16))
-        ep (when epilogue
-             (epilogue-splice epilogue [i-sym j-sym] (get epilogue :dtype :float)))
-        source (apply codegen/emit-gemm-tiled kernel-name
-                      (concat [:c-dtype :half
-                               :block-m (:block-m tile) :block-n (:block-n tile)
-                               :sg-m (:sg-m tile) :sg-n (:sg-n tile)
-                               :block-k (:block-k tile) :matrix (:matrix tile)
-                               :prefetch (:num-stages tile 3)]
-                              (when ep [:epilogue (:epilogue ep)
-                                        :epilogue-params (:epilogue-params ep)
-                                        :epilogue-helpers (:epilogue-helpers ep)])))]
+  (let [effective-tile (if kernel-body (:schedule kernel-body) tile)
+        sg (long (get-in effective-tile [:matrix :subgroup] 16))
+        ep (if kernel-body
+             (kernel-body-store-splice kernel-body)
+             (when epilogue
+               (epilogue-splice epilogue [i-sym j-sym] (get epilogue :dtype :float))))
+        effective-epilogue (or (:spec ep) epilogue)
+        source (if kernel-body
+                 (kernel-body-opencl/emit-matrix-kernel kernel-name kernel-body ep)
+                 (apply codegen/emit-gemm-tiled kernel-name
+                        (concat [:c-dtype :half
+                                 :block-m (:block-m effective-tile)
+                                 :block-n (:block-n effective-tile)
+                                 :sg-m (:sg-m effective-tile) :sg-n (:sg-n effective-tile)
+                                 :block-k (:block-k effective-tile) :matrix (:matrix effective-tile)
+                                 :prefetch (:num-stages effective-tile 3)]
+                                (when ep [:epilogue (:epilogue ep)
+                                          :epilogue-params (:epilogue-params ep)
+                                          :epilogue-helpers (:epilogue-helpers ep)]))))]
     (cond->
      {:kernel-name kernel-name
       :source source
@@ -1361,29 +1406,30 @@
                    (kabi/slot 'M :scalar :int :role :dimension)
                    (kabi/slot 'N :scalar :int :role :dimension)
                    (kabi/slot 'K :scalar :int :role :dimension)]
-                  (for [{:keys [sym dtype] :or {dtype :float}} (:operands epilogue)]
+                  (for [{:keys [sym dtype] :or {dtype :float}} (:operands effective-epilogue)]
                     (kabi/slot sym :input dtype :c-name (ce/c-symbol sym) :role :epilogue))
-                  (for [{:keys [sym dtype] :or {dtype :float}} (:scalars epilogue)]
+                  (for [{:keys [sym dtype] :or {dtype :float}} (:scalars effective-epilogue)]
                     (kabi/slot sym :scalar dtype :c-name (ce/c-symbol sym) :role :epilogue)))))
       :dims [M N L]
       :dtype :half
-      :tile tile
+      :tile effective-tile
       :epilogue-params (when ep (:epilogue-params ep))
-      :epilogue-operands (when ep (mapv :sym (:operands epilogue)))
-      :epilogue-scalars (when ep (mapv :sym (:scalars epilogue)))
-      :workgroup [(* (quot (:block-m tile) (:sg-m tile))
-                     (quot (:block-n tile) (:sg-n tile))
-                     sg) 1]
+      :epilogue-operands (when ep (mapv :sym (:operands effective-epilogue)))
+      :epilogue-scalars (when ep (mapv :sym (:scalars effective-epilogue)))
+      :workgroup (if kernel-body
+                   (get-in kernel-body [:launch :workgroup-size])
+                   [(* (quot (:block-m effective-tile) (:sg-m effective-tile))
+                       (quot (:block-n effective-tile) (:sg-n effective-tile))
+                       sg) 1])
       :tensorized true}
       kernel-body (assoc :kernel-body kernel-body))))
 
 (defn generate-dpas-kernel-body
   "Lower a verified, scheduled matrix KernelBody to the Intel OpenCL target.
 
-   This is deliberately a separate boundary from contraction scheduling.  The adapter currently
-   shadows the proven source generator; the body is nevertheless production data and is verified
-   before emission, so subsequent changes can replace one operation at a time without re-parsing
-   the contraction or inventing another schedule."
+   This is deliberately a separate boundary from contraction scheduling.  The production path
+   walks explicit body operations and layouts directly.  The legacy source generator remains only
+   behind `generate-dpas-contraction-kernel` as an independent equivalence oracle."
   [kernel-body out-sym]
   (let [kernel-body (kbody/validate! kernel-body)
         {:keys [kind instruction-family dims bindings epilogue axis-symbols]}
@@ -1401,7 +1447,7 @@
 
    Production canonical f16 contractions now travel through ContractionFacts and a scheduled
    KernelBody before reaching `generate-dpas-kernel-body`.  This entry remains as the source oracle
-   for the shadow adapter and for opaque epilogue helpers that have not yet become typed scalar IR.
+   for the direct operation lowerer and for opaque epilogue helpers that have not yet become typed scalar IR.
    Its legality analysis determines operand orientation and launch dimensions; the emitted body is
    f16 input, f32 accumulation and f16 output with a tile-parametric K16 matrix instruction.
 

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -225,7 +225,7 @@
   "Strategies whose emitter has a store splice, and can therefore honour an :epilogue.
    A WHITELIST on purpose: refuse by ABSENCE of support, never by a blacklist of shapes — a
    blacklist got this wrong twice, most recently by exempting the only shape production produces.
-   `:dpas` splices through emit-gemm-tiled; the three staged-emitter strategies splice at the store
+   `:dpas` splices through the KernelBody ScalarRegion; the three staged-emitter strategies splice at the store
    (which is how a quant dequant scale is expressed since :scheme was deleted)."
   #{:dpas :dp4a :quant-naive :staged-segred})
 
@@ -428,6 +428,7 @@
     ;; dtype / orientation / alignment
     :dtype-not-dpas :non-canonical-orientation :n-pitch-unaligned :k-pitch-unaligned
     :non-zero-matrix-init :partial-matrix-k-fragment :matrix-family-not-lowered
+    :matrix-instruction-not-lowered
     ;; declared-operand and quant-leaf legality
     :operand-without-a-declared-map :missing-declared-contract-axes
     :declared-operand-not-read-by-the-body :declared-map-does-not-match-the-body-index

--- a/src/raster/compiler/passes/parallel/contraction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/contraction_schedule.clj
@@ -21,6 +21,11 @@
 (defn- zero-init? [init]
   (and (number? init) (zero? init)))
 
+(defn- lowered-dpas-instruction?
+  [{:keys [family m n k subgroup]}]
+  (and (= :dpas family) (= 8 m) (= 16 k)
+       (contains? #{8 16} subgroup) (= n subgroup)))
+
 (defn- tile-valid?
   [{:keys [block-m block-n block-k sg-m sg-n matrix num-stages]}]
   (let [{:keys [m n k subgroup]} matrix
@@ -246,6 +251,9 @@
 
        (not= :dpas (:family matrix))
        (decline :matrix-family-not-lowered {:family (:family matrix)})
+
+       (not (lowered-dpas-instruction? matrix))
+       (decline :matrix-instruction-not-lowered {:matrix matrix})
 
        (not (tile-valid? tile))
        (throw (ex-info "matrix schedule tile is not divisible or contains an invalid extent"

--- a/test/raster/compiler/passes/parallel/contract_route_device_test.clj
+++ b/test/raster/compiler/passes/parallel/contract_route_device_test.clj
@@ -209,21 +209,21 @@
   ([r bufs] (launch-int8-routed r bufs {}))
   ([r bufs scalars]
    (let [ze (find-ns 'raster.gpu.ze-runtime)
-        [gx gy] (:grid r)
-        o ((ns-resolve ze 'make-buffer) (:out-elems r) :float)]
-    ((ns-resolve ze 'register-kernel!) (:kernel-name r) {:source (:source r) :dtype :byte})
-    (let [{:keys [kernel-handle]} ((ns-resolve ze 'ensure-kernel-loaded!) (:kernel-name r))
-          args (-> (mapv #(:segment (get bufs %)) (:array-params r))
-                   (conj (:segment o))
-                   (into (mapv (fn [sym] {:type :float :value (float (get scalars sym))})
-                               (:epilogue-scalars r)))
-                   (into (:scalar-args r)))]
-      ((ns-resolve ze 'launch-2d!) kernel-handle (:wg r) [gx gy] args)
-      (vec ((ns-resolve ze 'buffer->float-array) o))))))
+         [gx gy] (:grid r)
+         o ((ns-resolve ze 'make-buffer) (:out-elems r) :float)]
+     ((ns-resolve ze 'register-kernel!) (:kernel-name r) {:source (:source r) :dtype :byte})
+     (let [{:keys [kernel-handle]} ((ns-resolve ze 'ensure-kernel-loaded!) (:kernel-name r))
+           args (-> (mapv #(:segment (get bufs %)) (:array-params r))
+                    (conj (:segment o))
+                    (into (mapv (fn [sym] {:type :float :value (float (get scalars sym))})
+                                (:epilogue-scalars r)))
+                    (into (:scalar-args r)))]
+       ((ns-resolve ze 'launch-2d!) kernel-handle (:wg r) [gx gy] args)
+       (vec ((ns-resolve ze 'buffer->float-array) o))))))
 
 (defn- mk-i8 [xs] (let [ze (find-ns 'raster.gpu.ze-runtime)]
                     ((ns-resolve ze 'array->buffer!) ((ns-resolve ze 'make-buffer) (count xs) :byte)
-                     (byte-array (map byte xs)))))
+                                                     (byte-array (map byte xs)))))
 
 (deftest c1-int8-routes-to-quant-leaves
   (if-not @gpu?
@@ -234,7 +234,7 @@
           Aget (fn [i] (nth Ab i)) Bget (fn [i] (nth Bv i))
           close? (fn [xs ys] (every? true? (map #(< (/ (Math/abs (- (double %1) (double %2)))
                                                        (max 1.0 (Math/abs (double %2)))) 1.0e-6)
-                                                 xs ys)))]
+                                                xs ys)))]
       (testing ":nt (B stored [N,K]) → :dp4a peak leaf; int8 matmul dequant == reference"
         (let [form (list 'raster.par/contract 'C [['i M] ['j N]] [['l K]]
                          (list '* (list 'aget 'A (list '+ (list '* 'i K) 'l))
@@ -336,21 +336,21 @@
   (let [strategy (fn [form & opts] (:strategy (apply route/route-contraction form opts)))]
     (testing "0 contract axes → :segmap"
       (is (= :segmap (strategy '(raster.par/contract C [[i 4] [j 3]] []
-                                  (* (aget a i) (aget b j))) :dtype :double))))
+                                                     (* (aget a i) (aget b j))) :dtype :double))))
     (testing "n free ≠ 2 → :naive-segred"
       (is (= :naive-segred (strategy '(raster.par/contract C [[b 2] [i 4] [j 3]] [[l 5]]
-                                        (* (aget A x) (aget B y))) :dtype :double))))
+                                                           (* (aget A x) (aget B y))) :dtype :double))))
     (testing "n ≥ 2 contract axes → :naive-segred (flattened)"
       (is (= :naive-segred (strategy '(raster.par/contract C [[i 4]] [[l1 2] [l2 3]]
-                                        (* (aget A x) (aget V y))) :dtype :double))))
+                                                           (* (aget A x) (aget V y))) :dtype :double))))
     (testing "2 free + 1 contract: f16 canonical → :dpas, f64 → :regtiled"
       (is (= :dpas (strategy (matmul-form 128 128 128) :dtype :half)))
       (is (= :regtiled (strategy (matmul-form 128 128 128) :dtype :double))))
     (testing "int8 :nt → :dp4a, :nn → :quant-naive, :nn + prefer-peak? → :dp4a + transpose"
       (let [nt '(raster.par/contract C [[i 4] [j 4]] [[l 8]]
-                  (* (aget A (+ (* i 8) l)) (aget B (+ (* j 8) l))))
+                                     (* (aget A (+ (* i 8) l)) (aget B (+ (* j 8) l))))
             nn '(raster.par/contract C [[i 4] [j 4]] [[l 8]]
-                  (* (aget A (+ (* i 8) l)) (aget B (+ (* l 4) j))))]
+                                     (* (aget A (+ (* i 8) l)) (aget B (+ (* l 4) j))))]
         (is (= :dp4a (strategy nt :dtype :byte)))
         (is (= :quant-naive (strategy nn :dtype :byte)))
         (let [r (route/route-contraction nn :dtype :byte :prefer-peak? true)]
@@ -383,7 +383,7 @@
         (is (= [256 1] (:wg r)))
         (is (= [4 2] (:grid r)))))                     ; ceil(512/128), ceil(256/128)
     (testing "a part with HALF the GRF and subgroup 8 gets a rescaled tile AND launch geometry"
-      (let [small {:matrix {:m 8 :n 16 :k 16 :subgroup 8} :grf-bytes-per-lane 128}
+      (let [small {:matrix {:m 8 :n 8 :k 16 :subgroup 8} :grf-bytes-per-lane 128}
             r (route/route-contraction mm :dtype :half :desc small)]
         (is (= {:block-m 64 :block-n 64 :sg-m 16 :sg-n 16 :block-k 32}
                (select-keys (:tile r) [:block-m :block-n :sg-m :sg-n :block-k])))
@@ -395,7 +395,7 @@
         (is (= t (:tile r)))
         (is (not= (:block-m (hw {})) (:block-m t)) "the override must actually differ")))
     (testing "the emitted kernel source carries the derived tile, not a constant"
-      (let [small {:matrix {:m 8 :n 16 :k 16 :subgroup 8} :grf-bytes-per-lane 128}
+      (let [small {:matrix {:m 8 :n 8 :k 16 :subgroup 8} :grf-bytes-per-lane 128}
             src (:source (route/route-contraction mm :dtype :half :desc small))]
         (is (re-find #"intel_reqd_sub_group_size\(8\)" src)
             "subgroup size must follow the descriptor into the kernel attribute")))))

--- a/test/raster/compiler/passes/parallel/contraction_schedule_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_schedule_test.clj
@@ -1,9 +1,12 @@
 (ns raster.compiler.passes.parallel.contraction-schedule-test
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
+            [clojure.walk :as walk]
             [raster.compiler.backend.gpu.opencl-pass :as opencl]
+            [raster.compiler.backend.gpu.opencl-codegen :as opencl-codegen]
             [raster.compiler.backend.gpu.segop-opencl :as segop-opencl]
             [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.contraction-facts :as facts]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-body :as body]
@@ -56,7 +59,18 @@
     (is (= :non-zero-matrix-init
            (:reason (schedule/plan-matrix-body
                      (facts/contraction-facts (matrix-form 128 128 128 1.0) :dtype :half)
-                     nil nil))))))
+                     nil nil)))))
+  (testing "matrix N and subgroup width must agree with an implemented DPAS spelling"
+    (let [desc {:matrix {:family :dpas :m 8 :n 16 :k 16 :subgroup 8}}
+          planned (schedule/plan-matrix-body
+                   (facts/contraction-facts (matrix-form 128 128 128) :dtype :half)
+                   desc nil)
+          routed (route/route-contraction (matrix-form 128 128 128)
+                                          :dtype :half :desc desc)]
+      (is (false? (:ok planned)))
+      (is (= :matrix-instruction-not-lowered (:reason planned)))
+      (is (= :regtiled (:strategy routed)))
+      (is (= :matrix-instruction-not-lowered (:fallback-reason routed))))))
 
 (deftest the-production-route-carries-the-body-into-the-executable-artifact
   (let [routed (route/route-contraction (matrix-form 128 128 128) :dtype :half)
@@ -89,6 +103,51 @@
     (is (= (:tile oracle) (:tile routed)))
     (is (= (:workgroup oracle) (:wg routed)))
     (is (body/kernel-body? (:kernel-body routed)))))
+
+(deftest typed-store-regions-lower-identically-to-the-epilogue-oracle
+  (let [epilogue {:acc 'acc
+                  :expr '(raster.numeric/+ acc (clojure.core/aget bias j))
+                  :operands [{:sym 'bias
+                              :map (axis-map/of-axes [['j 128]])
+                              :dtype :float}]}
+        form (concat (matrix-form 128 128 128) [:epilogue epilogue])
+        routed (route/route-contraction form :dtype :half)
+        oracle (segop-opencl/generate-dpas-contraction-kernel
+                (contract-lower/contract-form->segred form :dtype :half) 'C
+                :epilogue epilogue)
+        normalize #(str/replace % #"dpas_contract_[0-9]+" "dpas_contract_N")]
+    (is (= (normalize (:source oracle)) (normalize (:source routed))))
+    (is (= '[bias] (:epilogue-operands routed)))
+    (is (re-find #"bias\[col\]" (:source routed)))
+    (is (some :value-region (get-in routed [:kernel-body :operations 0 :operations])))))
+
+(deftest production-kernel-body-lowering-does-not-call-the-legacy-template
+  (with-redefs [opencl-codegen/emit-gemm-tiled
+                (fn [& _]
+                  (throw (ex-info "legacy template was called" {:reason :test/failure})))]
+    (let [routed (route/route-contraction (matrix-form 128 128 128) :dtype :half)]
+      (is (= :dpas (:strategy routed)))
+      (is (re-find #"intel_sub_group_f16_f16_matrix_mad_k16" (:source routed)))
+      (is (body/kernel-body? (:kernel-body routed))))))
+
+(deftest direct-lowering-refuses-an-operation-coordinate-that-disagrees-with-the-schedule
+  (let [kernel (:body (schedule/plan-matrix-body
+                       (facts/contraction-facts (matrix-form 128 128 128) :dtype :half)
+                       nil nil))
+        changed? (atom false)
+        corrupt (walk/postwalk
+                 (fn [value]
+                   (if (and (not @changed?)
+                            (instance? raster.compiler.ir.kernel_body.TileLoad value))
+                     (do (reset! changed? true)
+                         (update value :coordinates
+                                 #(assoc % 0 (body/expression :add (first %) 1))))
+                     value))
+                 kernel)]
+    (is @changed?)
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"rhs tile coordinates"
+                          (segop-opencl/generate-dpas-kernel-body corrupt 'C)))))
 
 (deftest a-partial-matrix-fragment-falls-back-with-an-explanation
   (let [routed (route/route-contraction (matrix-form 128 128 24) :dtype :half)]


### PR DESCRIPTION
Summary
- lower verified scheduled KernelBody operations directly to Intel OpenCL instead of calling the legacy tiled GEMM template
- lower typed ScalarRegion stores through the existing target scalar spelling and retain the old generator only as an independent oracle and opaque-helper compatibility path
- derive tile geometry, fragment topology, masks, prefetching, loops, launch geometry, and DPAS coverage from explicit body IR
- decline incoherent matrix-instruction descriptions where matrix N differs from subgroup width

Validation
- focused compiler and route suite: 21 tests, 105 assertions, all green
- broader compiler/SOAC suite: 55 tests, 382 assertions, all green
- real-device contraction and DPAS suite: 10 tests, 54 assertions, all green
- full isolated suite: 2,352 tests, 34,453 assertions; 3 known unrelated local GPU assertion failures in stochastic split-K thresholds and fresh-buffer zero initialization, 0 errors
- formatting clean; static analysis has 0 errors