### PR TITLE
Unify direct GEMM through scheduled bodies

### DIFF
--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -6,12 +6,14 @@
    split-K combination. All mixed-precision scratch and derived scheduling scalars are private to
    the graph; callers never bind them and runtimes never reconstruct the algorithm from `:gemm`."
   (:require [clojure.string :as str]
+            [raster.compiler.backend.gpu.kernel-body-opencl :as kernel-body-opencl]
             [raster.compiler.backend.gpu.opencl-codegen :as codegen]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-graph :as kgraph]
-            [raster.compiler.ir.kernel-launch :as klaunch]))
+            [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]))
 
 (def ^:private default-min-split-chunk 1024)
 (def ^:private default-max-splits 64)
@@ -129,8 +131,32 @@
   [{:keys [block-m block-n sg-m sg-n matrix]}]
   (* (quot block-m sg-m) (quot block-n sg-n) (:subgroup matrix 16)))
 
+(defn emit-scheduled-matrix-kernel
+  "Build and directly lower one canonical f16 matrix contraction.
+
+  This is the shared compiler entry for graph-owned, legacy-plan, and resident direct/tiled GEMM
+  front doors.  Caller identities remain the KernelBody ABI identities; OpenCL M/N/K spelling is
+  solely a target concern.  Split-K, batched grid-Z, and opaque source epilogues are not accepted
+  here until their scheduling operations are explicit in KernelBody."
+  [{:keys [kernel-name id a b c m n k tile result-dtype provenance]
+    :or {result-dtype :float provenance {}}}]
+  (let [kernel-body
+        (contraction-schedule/matrix-body
+         {:id (or id [:gemm kernel-name])
+          :row a :col b :out c
+          :dimensions [m n k]
+          :dimension-parameters [m n k]
+          :axis-symbols ['i 'j 'l]
+          :tile tile
+          :bindings {:row a :col b}
+          :result-dtype result-dtype
+          :provenance (merge {:dialect :gemm :lowering :scheduled-matrix} provenance)})]
+    {:source (kernel-body-opencl/emit-matrix-kernel kernel-name kernel-body nil)
+     :kernel-body kernel-body
+     :workgroup-size (get-in kernel-body [:launch :workgroup-size])}))
+
 (defn- gemm-artifact
-  [{:keys [m n k tile]} kernel-name a b c split-k? kc splits phase]
+  [{:keys [id m n k tile]} kernel-name a b c split-k? kc splits phase]
   (let [{:keys [block-m block-n]} tile
         source-args (concat [:c-dtype :float :split-k? split-k?
                              :schedule-splits-arg? split-k?]
@@ -152,15 +178,25 @@
         arguments (cond-> [a b c m n k] split-k? (conj kc splits))
         group-count (cond-> [(klaunch/ceil-div n block-n)
                              (klaunch/ceil-div m block-m)]
-                      split-k? (conj (klaunch/runtime-value splits)))]
+                      split-k? (conj (klaunch/runtime-value splits)))
+        scheduled (when-not split-k?
+                    (emit-scheduled-matrix-kernel
+                     {:kernel-name kernel-name
+                      :id [:gemm id phase]
+                      :a a :b b :c c :m m :n n :k k
+                      :tile tile :result-dtype :float
+                      :provenance {:operation-id id :phase phase}}))]
     (artifact
-     kernel-name (apply codegen/emit-gemm-tiled kernel-name source-args)
+     kernel-name (if scheduled
+                   (:source scheduled)
+                   (apply codegen/emit-gemm-tiled kernel-name source-args))
      abi arguments
-     (klaunch/spec {:workgroup-size (if split-k?
-                                      [(matrix-workgroup-size tile) 1 1]
-                                      [(matrix-workgroup-size tile) 1])
+     (klaunch/spec {:workgroup-size (if scheduled
+                                      (:workgroup-size scheduled)
+                                      [(matrix-workgroup-size tile) 1 1])
                     :group-count group-count})
-     phase {:tile tile :split-k? split-k? :accumulator-dtype :float})))
+     phase (cond-> {:tile tile :split-k? split-k? :accumulator-dtype :float}
+             scheduled (assoc :kernel-body (:kernel-body scheduled))))))
 
 (defn- combine-artifact
   [kernel-name partials c mn splits]

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -12,6 +12,9 @@
   (= (str "raster.compiler.ir.kernel_body." simple-name)
      (some-> value class .getName)))
 
+(defn- value-id? [value]
+  (or (symbol? value) (keyword? value)))
+
 (defn- only!
   [owner values]
   (let [values (vec values)]
@@ -27,7 +30,7 @@
 
 (defn- expression-references [expression]
   (cond
-    (symbol? expression) #{expression}
+    (value-id? expression) #{expression}
     (number? expression) #{}
     (record-kind? "IndexExpr" expression)
     (reduce into #{} (map expression-references (:arguments expression)))
@@ -39,7 +42,7 @@
   [expression needle]
   (cond
     (= expression needle) 1
-    (or (number? expression) (symbol? expression)) 0
+    (or (number? expression) (value-id? expression)) 0
     (not (record-kind? "IndexExpr" expression)) nil
     (not (contains? (expression-references expression) needle)) 0
     (= :add (:op expression))
@@ -72,7 +75,7 @@
   [expression]
   (cond
     (number? expression) {:constant expression :coefficients {}}
-    (symbol? expression) {:constant 0 :coefficients {expression 1}}
+    (value-id? expression) {:constant 0 :coefficients {expression 1}}
     (not (record-kind? "IndexExpr" expression)) nil
     (= :add (:op expression))
     (let [parts (map affine-form (:arguments expression))]
@@ -124,17 +127,30 @@
   its indices, fragments and operations.  Every field that affects generated code has an IR witness."
   [kernel-body]
   (let [kernel-body (body/validate! kernel-body)
-        {:keys [parameters indices masks fragments operations]} kernel-body
+        {:keys [parameters indices masks fragments operations attributes]} kernel-body
         parameters-by-role (group-by :role parameters)
         lhs-param (only! "lhs parameter" (:lhs parameters-by-role))
         rhs-param (only! "rhs parameter" (:rhs parameters-by-role))
         out-param (only! "result parameter" (:result parameters-by-role))
-        [[M K] [K' N] [M' N']] (map :shape [lhs-param rhs-param out-param])
-        _ (require! (= [M K N] [M' K' N'])
+        [[m-extent k-extent] [k-extent' n-extent] [m-extent' n-extent']]
+        (map :shape [lhs-param rhs-param out-param])
+        _ (require! (= [m-extent k-extent n-extent]
+                       [m-extent' k-extent' n-extent'])
                     "matrix parameter shapes do not compose" {:parameters parameters})
-        _ (require! (= #{'M 'N 'K} (set (map :id (:dimension parameters-by-role))))
-                    "matrix body requires the ordered M/N/K dimension ABI"
-                    {:dimensions (:dimension parameters-by-role)})
+        dimension-parameters (:dimension-parameters attributes)
+        m-parameter (:m dimension-parameters)
+        n-parameter (:n dimension-parameters)
+        k-parameter (:k dimension-parameters)
+        _ (require! (= #{m-parameter n-parameter k-parameter}
+                       (set (map :id (:dimension parameters-by-role))))
+                    "matrix body dimension roles and parameter identities disagree"
+                    {:dimension-parameters dimension-parameters
+                     :parameters (:dimension parameters-by-role)})
+        _ (require! (and (= :half (:dtype lhs-param)) (= :half (:dtype rhs-param))
+                         (contains? #{:half :float} (:dtype out-param)))
+                    "Intel matrix lowering requires f16 inputs and an f16 or f32 result"
+                    {:lhs-dtype (:dtype lhs-param) :rhs-dtype (:dtype rhs-param)
+                     :result-dtype (:dtype out-param)})
         fragment-map (into {} (map (juxt :id identity)) fragments)
         guard (only! "top-level guard" operations)
         _ (require! (record-kind? "Guard" guard)
@@ -182,12 +198,12 @@
         block-k (:step outer-loop)
         outer-index (:index outer-loop)
         inner-index (:index inner-loop)
-        _ (require! (and (= 0 (:lower outer-loop)) (= 'K (:upper outer-loop))
+        _ (require! (and (= 0 (:lower outer-loop)) (= k-parameter (:upper outer-loop))
                          (= outer-index (:lower inner-loop))
                          (= :min (get-in inner-loop [:upper :op]))
                          (affine= (first (get-in inner-loop [:upper :arguments]))
                                   block-k {outer-index 1})
-                         (= 'K (second (get-in inner-loop [:upper :arguments]))))
+                         (= k-parameter (second (get-in inner-loop [:upper :arguments]))))
                     "matrix K loops do not describe blocked exact-fragment traversal"
                     {:outer outer-loop :inner inner-loop})
         _ (require! (and (seq lhs-loads) (seq rhs-loads)
@@ -291,22 +307,22 @@
         predicates-of (fn [mask-id] (:predicates (get mask-map mask-id)))
         guard-predicates (predicates-of (:mask guard))
         _ (require! (and (= 2 (count guard-predicates))
-                         (some #(lt-affine? % 0 {m-base-id 1} 'M) guard-predicates)
-                         (some #(lt-affine? % 0 {(first n-base-ids) 1} 'N)
+                         (some #(lt-affine? % 0 {m-base-id 1} m-parameter) guard-predicates)
+                         (some #(lt-affine? % 0 {(first n-base-ids) 1} n-parameter)
                                guard-predicates))
                     "tile guard mask does not cover the M/N tile origins"
                     {:guard guard :mask (get mask-map (:mask guard))})
         load-mask (only! "matrix-load mask" (distinct (map :mask loads)))
         load-predicates (predicates-of load-mask)
         _ (require! (and (= 1 (count load-predicates))
-                         (lt-affine? (first load-predicates) 0 {inner-index 1} 'K))
+                         (lt-affine? (first load-predicates) 0 {inner-index 1} k-parameter))
                     "matrix loads require the fragment-index K mask"
                     {:mask (get mask-map load-mask)})
         prefetch-mask (only! "matrix-prefetch mask" (distinct (map :mask prefetches)))
         prefetch-predicates (predicates-of prefetch-mask)
         _ (require! (and (= 1 (count prefetch-predicates))
                          (lt-affine? (first prefetch-predicates)
-                                     (* prefetch-distance ki) {inner-index 1} 'K))
+                                     (* prefetch-distance ki) {inner-index 1} k-parameter))
                     "matrix prefetch mask and pipeline distance disagree"
                     {:mask (get mask-map prefetch-mask) :distance prefetch-distance})
         _ (require!
@@ -318,19 +334,19 @@
                         store (get store-by-fragment accumulator)
                         predicates (predicates-of (:mask store))]]
               (and (= 2 (count predicates))
-                   (some #(lt-affine? % (* m mi) {m-base-id 1} 'M) predicates)
-                   (some #(lt-affine? % 0 {(nth n-base-ids n) 1 lane-id 1} 'N)
+                   (some #(lt-affine? % (* m mi) {m-base-id 1} m-parameter) predicates)
+                   (some #(lt-affine? % 0 {(nth n-base-ids n) 1 lane-id 1} n-parameter)
                          predicates))))
            "tile-store masks do not match their fragment coordinates"
            {:stores stores :masks masks})]
     {:mi mi :ni ni :ki ki :subgroup subgroup
      :block-m block-m :block-n block-n :block-k block-k :sg-m sg-m :sg-n sg-n
      :ncols ncols :lhs-ids lhs-ids :rhs-ids rhs-ids :mad-by-operands mad-by-operands
-     :stores stores :prefetch prefetch-distance}))
+     :stores stores :prefetch prefetch-distance :result-dtype (:dtype out-param)}))
 
 (defn- emit-plan
   [kernel-name {:keys [mi ni ki subgroup block-m block-n block-k sg-m sg-n
-                       ncols lhs-ids rhs-ids mad-by-operands stores prefetch]}
+                       ncols lhs-ids rhs-ids mad-by-operands stores prefetch result-dtype]}
    {:keys [epilogue epilogue-params]}]
   (let [nms (count lhs-ids)
         nns (count rhs-ids)
@@ -341,6 +357,8 @@
         ms (range nms)
         ns (range nns)
         amul (fn [m] (if (zero? m) "m_base" (str "m_base+" (* m mi))))
+        c-type (case result-dtype :float "float" :half "half")
+        store-cast (if (= :half result-dtype) "(half)" "")
         kstep (fn [kpos]
                 (str "        { int pk = " kpos " + " (* prefetch ki) ";\n"
                      "          if (pk < K) {\n"
@@ -370,7 +388,7 @@
      "__attribute__((intel_reqd_sub_group_size(" subgroup ")))\n"
      "__kernel void " kernel-name "(\n"
      "    __global const half* restrict A,\n    __global const half* restrict B,\n"
-     "    __global half* restrict C,\n    int M, int N, int K"
+     "    __global " c-type "* restrict C,\n    int M, int N, int K"
      epilogue-params
      ") {\n"
      "    int sg_id = get_sub_group_id();\n    int sg_lid = get_sub_group_local_id();\n"
@@ -413,9 +431,9 @@
                             (let [acc-expr (str "acc" m n ".s" i)]
                               (str "        { int col = n_base" n " + sg_lid;\n          if (col < N) "
                                    (if epilogue
-                                     (str "C[row*N+col] = (half)("
+                                     (str "C[row*N+col] = " store-cast "("
                                           (epilogue acc-expr "row" "col") ");\n")
-                                     (str "C[row*N+col] = (half)(" acc-expr ");\n"))
+                                     (str "C[row*N+col] = " store-cast "(" acc-expr ");\n"))
                                    "        }\n"))))
                    "      }\n    }\n")))
      "}\n")))

--- a/src/raster/compiler/backend/gpu/opencl_codegen.clj
+++ b/src/raster/compiler/backend/gpu/opencl_codegen.clj
@@ -650,7 +650,13 @@
 ;; ================================================================
 
 (defn emit-gemm-tiled
-  "Tile-PARAMETRIC XMX GEMM generator (C = A·B, FP16 in, FP32 accumulate). The tile geometry
+  "Legacy tile-parametric XMX GEMM oracle and specialized grid-Z generator.
+
+   Ordinary direct/tiled GEMM lowers from a verified KernelBody. This independent generator stays
+   executable for source-equivalence checks and for split-K, batched, and opaque-helper epilogues
+   until those schedules have explicit KernelBody operations.
+
+   Computes C = A·B with FP16 inputs and FP32 accumulation. The tile geometry
    (workgroup BLOCK_M×BLOCK_N, per-subgroup SG_M×SG_N, K-step BLOCK_K, prefetch depth) is COMPUTED,
    not hardcoded; the DPAS instruction shape (M_i×N_i×K_i) + subgroup size come from the :matrix
    descriptor. The Arc default (128×128, 32×32, K 32, DPAS 8×16×16, subgroup 16) reproduces the

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -1376,6 +1376,10 @@
   the legacy template solely for the independent oracle and opaque-helper compatibility path."
   [kernel-name row-arr col-arr out-sym [M N L] [i-sym j-sym] tile epilogue kernel-body]
   (let [effective-tile (if kernel-body (:schedule kernel-body) tile)
+        result-dtype (if kernel-body
+                       (:dtype (first (filter #(= :result (:role %))
+                                              (:parameters kernel-body))))
+                       :half)
         sg (long (get-in effective-tile [:matrix :subgroup] 16))
         ep (if kernel-body
              (kernel-body-store-splice kernel-body)
@@ -1402,7 +1406,7 @@
             (vec (concat
                   [(kabi/slot row-arr :input :half :c-name "A" :role :operand)
                    (kabi/slot col-arr :input :half :c-name "B" :role :operand)
-                   (kabi/slot out-sym :output :half :c-name "C" :role :result)
+                   (kabi/slot out-sym :output result-dtype :c-name "C" :role :result)
                    (kabi/slot 'M :scalar :int :role :dimension)
                    (kabi/slot 'N :scalar :int :role :dimension)
                    (kabi/slot 'K :scalar :int :role :dimension)]
@@ -1411,7 +1415,7 @@
                   (for [{:keys [sym dtype] :or {dtype :float}} (:scalars effective-epilogue)]
                     (kabi/slot sym :scalar dtype :c-name (ce/c-symbol sym) :role :epilogue)))))
       :dims [M N L]
-      :dtype :half
+      :dtype result-dtype
       :tile effective-tile
       :epilogue-params (when ep (:epilogue-params ep))
       :epilogue-operands (when ep (mapv :sym (:operands effective-epilogue)))

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -38,6 +38,9 @@
 (defn kernel-body? [value]
   (record-kind? "raster.compiler.ir.kernel_body.KernelBody" value))
 
+(defn- value-id? [value]
+  (or (symbol? value) (keyword? value)))
+
 (defn expression
   "Construct explicit target-neutral integer index arithmetic."
   [op & arguments]
@@ -56,7 +59,7 @@
 
 (defn- expression? [value]
   (cond
-    (or (number? value) (symbol? value)) true
+    (or (number? value) (value-id? value)) true
     (record-kind? "raster.compiler.ir.kernel_body.IndexExpr" value)
     (and (contains? index-ops (:op value))
          (seq (:arguments value))
@@ -65,7 +68,7 @@
 
 (defn- expression-references [value]
   (cond
-    (symbol? value) #{value}
+    (value-id? value) #{value}
     (number? value) #{}
     (record-kind? "raster.compiler.ir.kernel_body.IndexExpr" value)
     (reduce into #{} (map expression-references (:arguments value)))
@@ -86,7 +89,7 @@
 
 (defn- shape! [owner shape]
   (when-not (and (vector? shape) (seq shape)
-                 (every? #(or (symbol? %) (and (integer? %) (pos? %))) shape))
+                 (every? #(or (value-id? %) (and (integer? %) (pos? %))) shape))
     (throw (ex-info (str owner " requires a non-empty shape of positive extents")
                     {:shape shape}))))
 

--- a/src/raster/compiler/passes/parallel/contraction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/contraction_schedule.clj
@@ -21,6 +21,9 @@
 (defn- zero-init? [init]
   (and (number? init) (zero? init)))
 
+(defn- compiler-id? [value]
+  (or (symbol? value) (keyword? value)))
+
 (defn- lowered-dpas-instruction?
   [{:keys [family m n k subgroup]}]
   (and (= :dpas family) (= 8 m) (= 16 k)
@@ -39,21 +42,22 @@
          (zero? (mod block-k k)))))
 
 (defn- matrix-parameters
-  [row col out M N K row-layout col-layout out-layout epilogue]
-  (vec
-   (concat
-    [(body/->KernelParameter row :input :half [M K] :global row-layout :lhs)
-     (body/->KernelParameter col :input :half [K N] :global col-layout :rhs)
-     (body/->KernelParameter out :output :half [M N] :global out-layout :result)
-     (body/->KernelParameter 'M :scalar :int [] nil nil :dimension)
-     (body/->KernelParameter 'N :scalar :int [] nil nil :dimension)
-     (body/->KernelParameter 'K :scalar :int [] nil nil :dimension)]
-    (for [{:keys [sym dtype map] :or {dtype :float}} (:operands epilogue)]
-      (let [shape (axis-map/shape map)]
-        (body/->KernelParameter sym :input dtype shape :global
-                                (layout/row-major shape dtype) :epilogue)))
-    (for [{:keys [sym dtype] :or {dtype :float}} (:scalars epilogue)]
-      (body/->KernelParameter sym :scalar dtype [] nil nil :epilogue)))))
+  [row col out M N K dimension-parameters row-layout col-layout out-layout result-dtype epilogue]
+  (let [[m-parameter n-parameter k-parameter] dimension-parameters]
+    (vec
+     (concat
+      [(body/->KernelParameter row :input :half [M K] :global row-layout :lhs)
+       (body/->KernelParameter col :input :half [K N] :global col-layout :rhs)
+       (body/->KernelParameter out :output result-dtype [M N] :global out-layout :result)
+       (body/->KernelParameter m-parameter :scalar :int [] nil nil :dimension)
+       (body/->KernelParameter n-parameter :scalar :int [] nil nil :dimension)
+       (body/->KernelParameter k-parameter :scalar :int [] nil nil :dimension)]
+      (for [{:keys [sym dtype map] :or {dtype :float}} (:operands epilogue)]
+        (let [shape (axis-map/shape map)]
+          (body/->KernelParameter sym :input dtype shape :global
+                                  (layout/row-major shape dtype) :epilogue)))
+      (for [{:keys [sym dtype] :or {dtype :float}} (:scalars epilogue)]
+        (body/->KernelParameter sym :scalar dtype [] nil nil :epilogue))))))
 
 (defn- scalar-region [epilogue]
   (when epilogue
@@ -68,13 +72,29 @@
 (defn- fragment-id [prefix a & [b]]
   (keyword (str prefix "-" a (when (some? b) (str "-" b)))))
 
-(defn- build-matrix-body
-  [contract-facts tile bindings epilogue operation-id]
-  (let [{:keys [out free-axes contract-axes]} contract-facts
-        [[i M] [j N]] free-axes
-        [[k-sym K]] contract-axes
-        row (:row bindings)
-        col (:col bindings)
+(defn matrix-body
+  "Construct one target-neutral scheduled matrix body from an already chosen canonical layout.
+
+  `dimensions` are semantic tensor extents while `dimension-parameters` are the ordered compiler
+  identities bound to the emitted M/N/K ABI.  Keeping both makes static contraction facts and
+  symbolic resident graphs share one body without renaming caller values.  The current matrix
+  instruction is f16×f16→f32; `result-dtype` controls only the final store representation."
+  [{:keys [id row col out dimensions dimension-parameters axis-symbols tile bindings epilogue
+           result-dtype provenance]
+    :or {dimension-parameters ['M 'N 'K]
+         axis-symbols ['i 'j 'k]
+         result-dtype :half
+         provenance {}}}]
+  (let [tile (assoc tile :num-stages (or (:num-stages tile) 3))
+        _ (when-not (and (= 3 (count dimension-parameters))
+                         (every? compiler-id? dimension-parameters)
+                         (= 3 (count (set dimension-parameters))))
+            (throw (ex-info "matrix body requires three distinct compiler dimension identities"
+                            {:reason :raster/bug
+                             :dimension-parameters dimension-parameters})))
+        [M N K] dimensions
+        [m-parameter n-parameter k-parameter] dimension-parameters
+        [i j k-sym] axis-symbols
         matrix (:matrix tile)
         desc {:matrix matrix :subgroup-size (:subgroup matrix)}
         acc-layout (layout/derive-layout :mma-acc :float desc)
@@ -84,7 +104,7 @@
         k-width (max 1 (quot 32 (layout/dtype-bits :half)))
         row-layout (layout/dot-operand 0 acc-layout k-width :half)
         col-layout (layout/dot-operand 1 acc-layout k-width :half)
-        out-layout (layout/row-major [M N] :half)
+        out-layout (layout/row-major [M N] result-dtype)
         {:keys [block-m block-n block-k sg-m sg-n num-stages]} tile
         {matrix-m :m matrix-n :n matrix-k :k subgroup :subgroup} matrix
         subgroup-rows (quot block-m sg-m)
@@ -122,17 +142,17 @@
         (vec
          (concat
           [(body/->Mask :tile-active
-                        [(body/predicate :lt m-base 'M)
-                         (body/predicate :lt (n-base 0) 'N)])
-           (body/->Mask :k-active [(body/predicate :lt 'k-fragment 'K)])
+                        [(body/predicate :lt m-base m-parameter)
+                         (body/predicate :lt (n-base 0) n-parameter)])
+           (body/->Mask :k-active [(body/predicate :lt 'k-fragment k-parameter)])
            (body/->Mask :prefetch-active
                         [(body/predicate :lt
-                                         (add 'k-fragment (* num-stages matrix-k)) 'K)])]
+                                         (add 'k-fragment (* num-stages matrix-k)) k-parameter)])]
           (for [mm (range m-fragments) nn (range n-fragments)]
             (body/->Mask
              (fragment-id "store" mm nn)
-             [(body/predicate :lt (add m-base (* mm matrix-m)) 'M)
-              (body/predicate :lt (add (n-base nn) lane-id) 'N)]))))
+             [(body/predicate :lt (add m-base (* mm matrix-m)) m-parameter)
+              (body/predicate :lt (add (n-base nn) lane-id) n-parameter)]))))
         accumulator-ids (vec (for [mm (range m-fragments) nn (range n-fragments)]
                                (fragment-id "acc" mm nn)))
         row-fragment-ids (vec (for [mm (range m-fragments)] (fragment-id "lhs" mm)))
@@ -168,10 +188,10 @@
                               matrix))))
         init-ops (mapv #(body/->FragmentInit % 0.0) accumulator-ids)
         fragment-loop (body/->Loop k-fragment 'k-block
-                                   (body/expression :min (add 'k-block block-k) 'K)
+                                   (body/expression :min (add 'k-block block-k) k-parameter)
                                    matrix-k one-k-step
                                    {:unroll true :matrix-step matrix-k})
-        k-loop (body/->Loop 'k-block 0 'K block-k [fragment-loop]
+        k-loop (body/->Loop 'k-block 0 k-parameter block-k [fragment-loop]
                             {:unrolled-by (quot block-k matrix-k)
                              :matrix-step matrix-k
                              :pipeline-depth num-stages})
@@ -184,20 +204,22 @@
                    (fragment-id "store" mm nn) region)))
         workgroup-size (* subgroup-rows subgroup-cols subgroup)]
     (body/make
-     {:id [:contraction (or operation-id out)]
-      :parameters (matrix-parameters row col out M N K row-layout col-layout out-layout epilogue)
+     {:id id
+      :parameters (matrix-parameters row col out M N K dimension-parameters
+                                     row-layout col-layout out-layout result-dtype epilogue)
       :indices indices
       :masks masks
       :fragments fragments
       :operations [(body/->Guard :tile-active (vec (concat init-ops [k-loop] stores)))]
       :schedule tile
       :launch {:workgroup-size [workgroup-size 1]
-               :group-count [(body/expression :ceil-div 'N block-n)
-                             (body/expression :ceil-div 'M block-m)]}
-      :provenance {:dialect :segcontract :operation-id operation-id}
+               :group-count [(body/expression :ceil-div n-parameter block-n)
+                             (body/expression :ceil-div m-parameter block-m)]}
+      :provenance provenance
       :attributes {:kind :matrix-contraction
                    :instruction-family (:family matrix)
                    :dims [M N K]
+                   :dimension-parameters {:m m-parameter :n n-parameter :k k-parameter}
                    :axis-symbols [i j k-sym]
                    :bindings bindings
                    :boundary-policy {:m :masked :n :masked :k :exact-fragments}
@@ -281,4 +303,15 @@
        {:ok true
         :bindings bindings
         :tile tile
-        :body (build-matrix-body contract-facts tile bindings epilogue operation-id)}))))
+        :body (matrix-body
+               {:id [:contraction (or operation-id (:out contract-facts))]
+                :row (:row bindings)
+                :col (:col bindings)
+                :out (:out contract-facts)
+                :dimensions [M N K]
+                :axis-symbols (vec (concat (map first free-axes)
+                                           (map first contract-axes)))
+                :tile tile
+                :bindings bindings
+                :epilogue epilogue
+                :provenance {:dialect :segcontract :operation-id operation-id}})}))))

--- a/src/raster/compiler/passes/parallel/gemm_recognize.clj
+++ b/src/raster/compiler/passes/parallel/gemm_recognize.clj
@@ -3,7 +3,7 @@
    language as a nested map over C[i,j] with an inner k-reduction of the product
    of two array reads. It extracts the SAME descriptor the BLAS-name-match
    (gpu-plan/match-gemm-call) emits — {:variant :A :B :C :m :k :n :alpha :beta} —
-   so both front doors converge on ONE emission path (emit-gemm-tiled) instead of
+   so both front doors converge on ONE scheduled KernelBody emission path instead of
    the redomap falling through to the naive per-element SegOp kernel.
 
    This is Futhark's `isTileableRedomap`: the register-tiling precondition is that
@@ -196,7 +196,8 @@
    never a false positive). CONSERVATIVE proven-or-nil: a false positive would emit a
    tiled XMX kernel for a non-GEMM SoacMap (a silent miscompile). The descriptor is the
    GEMM *schedule payload* — the resident pass attaches it as a `:gemm` facet on this
-   SoacMap (Design S), which then dispatches to emit-gemm-tiled while staying a SOAC."
+   SoacMap (Design S), which then dispatches through the shared matrix-body scheduler while staying
+   a SOAC."
   [node]
   (when (and (instance? raster.compiler.ir.soac.SoacMap node)
              (= 1 (count (:outputs node))))

--- a/src/raster/compiler/passes/parallel/gpu_plan.clj
+++ b/src/raster/compiler/passes/parallel/gpu_plan.clj
@@ -17,7 +17,9 @@
      :stats {:gemm-rewrites :map-rewrites :reduce-rewrites ...}}"
   (:require
    [clojure.set :as set]
+   [raster.compiler.backend.gpu.gemm :as gpu-gemm]
    [raster.compiler.core.op-descriptor :as op]
+   [raster.compiler.core.hardware :as hardware]
    [raster.compiler.passes.parallel.device :as device]
    [raster.compiler.passes.parallel.patterns :as patterns]
    [raster.compiler.passes.parallel.gemm-recognize :as gemm-recognize]
@@ -136,11 +138,21 @@
   Returns {:kernel-name :source :launch-config-fn :dtype}."
   [gemm-info dtype kernel-counter]
   (let [kname (str "gemm_" (name (:variant gemm-info)) "_" (swap! kernel-counter inc))
-        ;; Tile-parametric XMX GEMM (handles arbitrary M,N,K)
-        ;; XMX GEMM takes FP16 in, FP32 accum. Output dtype matches storage.
-        source (codegen/emit-gemm-tiled kname :c-dtype :float)]
+        tile (hardware/gemm-tile-for nil)
+        emitted (gpu-gemm/emit-scheduled-matrix-kernel
+                 {:kernel-name kname
+                  :id [:gpu-plan kname]
+                  :a (:A gemm-info) :b (:B gemm-info) :c (:C gemm-info)
+                  ;; This legacy registry entry binds dimensions positionally at invocation, so
+                  ;; its scheduled body owns stable internal ABI identities independent of whether
+                  ;; the caller supplies symbols, literals, or scalar expressions.
+                  :m 'M :n 'N :k 'K
+                  :tile tile :result-dtype :float
+                  :provenance {:dialect :gpu-plan :variant (:variant gemm-info)}})]
     {:kernel-name kname
-     :source source
+     :source (:source emitted)
+     :kernel-body (:kernel-body emitted)
+     :workgroup-size (first (:workgroup-size emitted))
      :dtype dtype
      :type :gemm
      :variant (:variant gemm-info)}))
@@ -177,8 +189,9 @@
       :tn
       ;; A^T @ B: transpose A first, then nn-GEMM
       (let [t-kernel (gen-transpose-kernel dtype kernel-counter)
-            gemm-kernel (gen-gemm-kernel (assoc gemm-info :variant :nn) dtype kernel-counter)
-            At-sym (with-meta (gensym "At_buf__") {:raster.buffer/hoistable true})]
+            At-sym (with-meta (gensym "At_buf__") {:raster.buffer/hoistable true})
+            gemm-kernel (gen-gemm-kernel (assoc gemm-info :variant :nn :A At-sym)
+                                         dtype kernel-counter)]
         {:bindings
          [[At-sym (device/alloc-expr dtype (list '* m k))]
           [(gensym "_gpu_") (list 'raster.gpu.ze-runtime/invoke-registered-transpose!
@@ -192,8 +205,9 @@
       :nt
       ;; A @ B^T: transpose B first, then nn-GEMM
       (let [t-kernel (gen-transpose-kernel dtype kernel-counter)
-            gemm-kernel (gen-gemm-kernel (assoc gemm-info :variant :nn) dtype kernel-counter)
-            Bt-sym (with-meta (gensym "Bt_buf__") {:raster.buffer/hoistable true})]
+            Bt-sym (with-meta (gensym "Bt_buf__") {:raster.buffer/hoistable true})
+            gemm-kernel (gen-gemm-kernel (assoc gemm-info :variant :nn :B Bt-sym)
+                                         dtype kernel-counter)]
         {:bindings
          [[Bt-sym (device/alloc-expr dtype (list '* k n))]
           [(gensym "_gpu_") (list 'raster.gpu.ze-runtime/invoke-registered-transpose!
@@ -267,7 +281,7 @@
                  (conj acc [sym expr]))
 
                 ;; GEMM REDOMAP (matmul written in the raster language, no BLAS call) →
-                ;; the SAME rewrite-gemm/emit-gemm-tiled path. #38: the redomap front door
+                ;; the SAME rewrite-gemm/scheduled-matrix-body path. #38: the redomap front door
                 ;; converges with the BLAS-name-match instead of falling through to the
                 ;; naive per-element SegOp kernel. gemm-info carries the identical
                 ;; {:variant :A :B :C :m :k :n :alpha :beta :result-sym} contract.

--- a/src/raster/gpu/autotune.clj
+++ b/src/raster/gpu/autotune.clj
@@ -49,7 +49,7 @@
 (defn schedule-neighbors
   "The moves coordinate-descent explores over an S6 Schedule. Two WIRED axes:
      :tile — the GEMM tile (T2/T3), a CURATED per-descriptor candidate list
-             (hw/gemm-tile-candidates) that drives emit-gemm-tiled +
+             (hw/gemm-tile-candidates) that drives scheduled KernelBody emission +
              bind-registered-gemm-tiled! (real, priced kernels).
 
    Precision is deliberately NOT a default search axis: it changes numerical mode and therefore

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -885,14 +885,14 @@
   [what have-elements offset elements elem-size other-bytes]
   (let [have-elements (long have-elements) offset (long offset) elements (long elements)
         elem-size (long elem-size) other-bytes (long other-bytes)]
-  (when (or (neg? offset) (neg? elements))
-    (throw (ex-info (str what ": negative offset or length") {:offset offset :elements elements})))
-  (when (> (+ offset elements) have-elements)
-    (throw (ex-info (str what ": range exceeds the buffer")
-                    {:offset offset :elements elements :buffer-elements have-elements})))
-  (when (> (* elements elem-size) other-bytes)
-    (throw (ex-info (str what ": range exceeds the host-side array/segment")
-                    {:needed-bytes (* elements elem-size) :available-bytes other-bytes})))))
+    (when (or (neg? offset) (neg? elements))
+      (throw (ex-info (str what ": negative offset or length") {:offset offset :elements elements})))
+    (when (> (+ offset elements) have-elements)
+      (throw (ex-info (str what ": range exceeds the buffer")
+                      {:offset offset :elements elements :buffer-elements have-elements})))
+    (when (> (* elements elem-size) other-bytes)
+      (throw (ex-info (str what ": range exceeds the host-side array/segment")
+                      {:needed-bytes (* elements elem-size) :available-bytes other-bytes})))))
 
 (defn plan-range
   "Validate one ranged transfer and return its byte-level PLAN, without copying anything:
@@ -1306,6 +1306,18 @@
 ;; GPU GEMM (non-square XMX)
 ;; ================================================================
 
+(defn- emit-scheduled-gemm
+  "Ask the compiler for the shared scheduled matrix body and its direct OpenCL lowering."
+  [kernel-name c-dtype tile]
+  ((requiring-resolve 'raster.compiler.backend.gpu.gemm/emit-scheduled-matrix-kernel)
+   {:kernel-name kernel-name
+    :id [:resident-gemm kernel-name]
+    :a 'A :b 'B :c 'C :m 'M :n 'N :k 'K
+    :tile tile :result-dtype c-dtype
+    :provenance {:dialect :resident-runtime}}))
+
+(declare gemm-tile)
+
 (def ^:private gemm-cache
   "Cache for compiled GEMM kernels, keyed by C-output dtype (:half | :float).
    Each entry is {:module :kernel :kernel-name}. (A/B are always fp16 in.)"
@@ -1318,16 +1330,18 @@
   (ensure-init!)
   (or (get @gemm-cache c-dtype)
       (let [kname (str "gemm_nonsquare_" (name c-dtype))
-            cl-src (do (require 'raster.compiler.backend.gpu.opencl-codegen)
-                       ((resolve 'raster.compiler.backend.gpu.opencl-codegen/emit-gemm-tiled)
-                        kname :c-dtype c-dtype))
+            tile (gemm-tile)
+            emitted (emit-scheduled-gemm kname c-dtype tile)
+            cl-src (:source emitted)
             device-hex (:device-id-hex @state)
             spv (do (require 'raster.compiler.support.spirv-cache)
                     ((resolve 'raster.compiler.support.spirv-cache/compile-opencl-to-spirv)
                      cl-src :device device-hex))
             module (load-module! spv)
             kernel (create-kernel module kname)
-            entry {:module module :kernel kernel :kernel-name kname}]
+            entry {:module module :kernel kernel :kernel-name kname
+                   :tile tile :kernel-body (:kernel-body emitted)
+                   :workgroup (:workgroup-size emitted)}]
         (swap! gemm-cache assoc c-dtype entry)
         entry)))
 
@@ -1350,16 +1364,15 @@
 
   Returns C."
   [a b c m n k]
-  (let [{:keys [kernel]} (ensure-gemm-kernel! :half)
-        {:keys [block-m block-n]} (gemm-tile)
+  (let [{:keys [kernel tile workgroup]} (ensure-gemm-kernel! :half)
+        {:keys [block-m block-n]} tile
         gc-m (int (Math/ceil (/ (double m) (double block-m))))
         gc-n (int (Math/ceil (/ (double n) (double block-n))))
         args [(:segment a) (:segment b) (:segment c)
               {:type :int :value (int m)}
               {:type :int :value (int n)}
               {:type :int :value (int k)}]]
-    ;; 256 work-items per workgroup (16 subgroups × 16 lanes)
-    (launch-2d! kernel [256 1] [gc-n gc-m] args)
+    (launch-2d! kernel workgroup [gc-n gc-m] args)
     c))
 
 ;; ================================================================
@@ -2137,24 +2150,23 @@
                             " — a mismatched write reads back as garbage. Allocate C as " c-dtype
                             " or pass the matching c-dtype.")
                        {:buffer-dtype bd :kernel-c-dtype c-dtype}))))
-   (let [{:keys [module kernel-name]} (ensure-gemm-kernel! c-dtype)
+   (let [{:keys [module kernel-name tile workgroup]} (ensure-gemm-kernel! c-dtype)
          kh (create-kernel-fresh module kernel-name)
          m (long m) n (long n) k (long k)
          args [(:segment a) (:segment b) (:segment c)
                {:type :int :value (int m)} {:type :int :value (int n)} {:type :int :value (int k)}]
-         bnd (bind-kernel! kh [256 1] args)
+         bnd (bind-kernel! kh workgroup args)
          gc ^MemorySegment (:gc-seg bnd)]
-     (.set gc I32 0 (int (Math/ceil (/ (double n) (double (:block-n (gemm-tile)))))))   ;; X = gc-n
-     (.set gc I32 4 (int (Math/ceil (/ (double m) (double (:block-m (gemm-tile)))))))   ;; Y = gc-m
+     (.set gc I32 0 (int (Math/ceil (/ (double n) (double (:block-n tile))))))   ;; X = gc-n
+     (.set gc I32 4 (int (Math/ceil (/ (double m) (double (:block-m tile))))))   ;; Y = gc-m
      (.set gc I32 8 (int 1))
      bnd)))
 
 ;; ── TILE-PARAMETRIC GEMM (autotune-facing) ─────────────────────────────────────
-;; The default bind-registered-gemm! above emits the derived-default tile (hardcoded 128/256
-;; launch). This path takes an EXPLICIT tile map (from schedule/derive-gemm-tile or an autotune
-;; candidate) and DERIVES the launch geometry from it — the regular form: workgroup = subgroups ×
-;; subgroup-size, grid = ceil(n/block-n) × ceil(m/block-m). At the derived-default tile it produces
-;; the identical launch, so this is a strict generalization of the hardcoded path.
+;; The default bind-registered-gemm! above schedules the device-derived default tile. This path
+;; takes an EXPLICIT tile map (from schedule/derive-gemm-tile or an autotune candidate) through the
+;; same KernelBody scheduler and derives launch geometry from that body. At the default tile it
+;; produces identical source and launch geometry.
 
 (def ^:private gemm-tiled-cache
   "Compiled tile-parametric GEMM kernels, keyed by [c-dtype tile-map]. Distinct tiles are distinct
@@ -2171,15 +2183,15 @@
   (ensure-init!)
   (or (get @gemm-tiled-cache [c-dtype tile])
       (let [kname (str "gemm_tiled_" (name c-dtype) "_" (tile-signature tile))
-            emit  (do (require 'raster.compiler.backend.gpu.opencl-codegen)
-                      (resolve 'raster.compiler.backend.gpu.opencl-codegen/emit-gemm-tiled))
-            cl-src (apply emit kname :c-dtype c-dtype :prefetch (:num-stages tile 3)
-                          (mapcat identity (select-keys tile [:block-m :block-n :sg-m :sg-n :block-k :matrix])))
+            emitted (emit-scheduled-gemm kname c-dtype tile)
+            cl-src (:source emitted)
             spv (do (require 'raster.compiler.support.spirv-cache)
                     ((resolve 'raster.compiler.support.spirv-cache/compile-opencl-to-spirv)
                      cl-src :device (:device-id-hex @state)))
             module (load-module! spv)
-            entry {:module module :kernel-name kname :tile tile}]
+            entry {:module module :kernel-name kname :tile tile
+                   :kernel-body (:kernel-body emitted)
+                   :workgroup (:workgroup-size emitted)}]
         (swap! gemm-tiled-cache assoc [c-dtype tile] entry)
         entry)))
 
@@ -2192,15 +2204,12 @@
     (when (not= bd c-dtype)
       (throw (ex-info (str "bind-registered-gemm-tiled!: output buffer dtype " bd " ≠ kernel dtype " c-dtype)
                       {:buffer-dtype bd :kernel-c-dtype c-dtype}))))
-  (let [{:keys [module kernel-name]} (ensure-gemm-kernel-tiled! c-dtype tile)
-        {:keys [block-m block-n sg-m sg-n matrix]} tile
-        sg   (long (:subgroup matrix 16))
-        n-subgroups (* (quot (long block-m) (long sg-m)) (quot (long block-n) (long sg-n)))
-        wg   (* n-subgroups sg)
+  (let [{:keys [module kernel-name workgroup]} (ensure-gemm-kernel-tiled! c-dtype tile)
+        {:keys [block-m block-n]} tile
         kh   (create-kernel-fresh module kernel-name)
         args [(:segment a) (:segment b) (:segment c)
               {:type :int :value (int m)} {:type :int :value (int n)} {:type :int :value (int k)}]
-        bnd  (bind-kernel! kh [wg 1] args)
+        bnd  (bind-kernel! kh workgroup args)
         gc ^MemorySegment (:gc-seg bnd)]
     (.set gc I32 0 (int (Math/ceil (/ (double n) (double block-n)))))   ;; X = gc-n
     (.set gc I32 4 (int (Math/ceil (/ (double m) (double block-m)))))   ;; Y = gc-m
@@ -3477,29 +3486,29 @@
   [kernel-name k], converting to f16 when `half?`. Returns the MemorySegment."
   ^MemorySegment [^String kernel-name k arr nel half? esize]
   (let [nel (long nel) esize (long esize)]
-   (if half?
-    (let [shorts (ensure-arr kernel-name (keyword (str (name k) "-sh")) nel)
-          seg (ensure-seg kernel-name k (* nel 2))]
-      (if (instance? (Class/forName "[F") arr)
-        (let [^floats af arr] (dotimes [i nel] (aset shorts i (short (Float/floatToFloat16 (aget af i))))))
-        (let [^doubles ad arr] (dotimes [i nel] (aset shorts i (short (Float/floatToFloat16 (float (aget ad i))))))))
-      (MemorySegment/copy (MemorySegment/ofArray shorts) 0 seg 0 (* nel 2))
-      seg)
-    (let [seg (ensure-seg kernel-name k (* nel esize))]
-      (MemorySegment/copy (MemorySegment/ofArray arr) 0 seg 0 (* nel esize))
-      seg))))
+    (if half?
+      (let [shorts (ensure-arr kernel-name (keyword (str (name k) "-sh")) nel)
+            seg (ensure-seg kernel-name k (* nel 2))]
+        (if (instance? (Class/forName "[F") arr)
+          (let [^floats af arr] (dotimes [i nel] (aset shorts i (short (Float/floatToFloat16 (aget af i))))))
+          (let [^doubles ad arr] (dotimes [i nel] (aset shorts i (short (Float/floatToFloat16 (float (aget ad i))))))))
+        (MemorySegment/copy (MemorySegment/ofArray shorts) 0 seg 0 (* nel 2))
+        seg)
+      (let [seg (ensure-seg kernel-name k (* nel esize))]
+        (MemorySegment/copy (MemorySegment/ofArray arr) 0 seg 0 (* nel esize))
+        seg))))
 
 (defn- readback-operand!
   "Copy `nel` elements from shared segment `seg` back into host array `out`, converting from
   f16 when `half?`."
   [^MemorySegment seg out nel half? esize]
   (let [nel (long nel) esize (long esize)]
-   (if half?
-    (if (instance? (Class/forName "[F") out)
-      (let [^floats of out] (dotimes [i nel] (aset of i (Float/float16ToFloat (.get seg ValueLayout/JAVA_SHORT (long (* i 2)))))))
-      (let [^doubles od out] (dotimes [i nel] (aset od i (double (Float/float16ToFloat (.get seg ValueLayout/JAVA_SHORT (long (* i 2)))))))))
-    (MemorySegment/copy seg 0 (MemorySegment/ofArray out) 0 (* nel esize)))
-  out))
+    (if half?
+      (if (instance? (Class/forName "[F") out)
+        (let [^floats of out] (dotimes [i nel] (aset of i (Float/float16ToFloat (.get seg ValueLayout/JAVA_SHORT (long (* i 2)))))))
+        (let [^doubles od out] (dotimes [i nel] (aset od i (double (Float/float16ToFloat (.get seg ValueLayout/JAVA_SHORT (long (* i 2)))))))))
+      (MemorySegment/copy seg 0 (MemorySegment/ofArray out) 0 (* nel esize)))
+    out))
 
 (defn invoke-registered-contraction!
   "Launch a routed contraction by its registered executable artifact.

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -1,17 +1,26 @@
 (ns raster.compiler.backend.gpu.gemm-test
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.gemm :as gemm]
+            [raster.compiler.backend.gpu.opencl-codegen :as opencl-codegen]
             [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-dispatch :as dispatch]
             [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.kernel-graph-call :as graph-call]
             [raster.compiler.ir.kernel-launch :as launch]))
 
+(defn- matrix-contract
+  [graph]
+  (some #(when (= :matrix-contract (get-in % [:operation :attributes :strategy]))
+           (:operation %))
+        (:nodes graph)))
+
 (defn- emitted
   [variant]
   (gemm/emit-executable
    {:id (str "gemm-test-" (name variant))
-    :a 'a :b 'b :c 'c :m 'm :n 'n :k 'k
+    :a 'a :b 'b :c 'c :m :m :n :n :k :k
     :variant variant :precision :f16-xmx
     :tile (hardware/derive-gemm-tile {})
     :fill-workgroups 32}))
@@ -42,9 +51,7 @@
         temporary-specs (graph-call/temporary-specs graph scalar-values)
         partial-spec (some (fn [[id spec]] (when (= :partials (last id)) spec))
                            temporary-specs)
-        contract (some #(when (= :matrix-contract (get-in % [:operation :attributes :strategy]))
-                          (:operation %))
-                       (:nodes graph))]
+        contract (matrix-contract graph)]
     (is (= :xmx-split-k (executable/strategy graph)))
     (is (= #{'a 'b 'c} (set (keys buffers))))
     (is (= [:float (* 26 13 640) nil] partial-spec))
@@ -53,6 +60,39 @@
             (launch/realize (:launch contract)
                             #(graph-call/resolve-integer scalar-values %)))))
     (is (= 4 (count (:nodes graph))))))
+
+(deftest direct-xmx-graphs-carry-the-shared-scheduled-body
+  (let [tile (hardware/derive-gemm-tile {})
+        graph (dispatch/alternative (emitted :nn) :xmx-direct)
+        contract (matrix-contract graph)
+        kernel-body (artifact/attribute contract :kernel-body)
+        dimensions (filter #(= :dimension (:role %)) (:parameters kernel-body))
+        result (first (filter #(= :result (:role %)) (:parameters kernel-body)))
+        oracle (apply opencl-codegen/emit-gemm-tiled (:kernel-name contract)
+                      :c-dtype :float :prefetch (:num-stages tile)
+                      (mapcat identity
+                              (select-keys tile
+                                           [:block-m :block-n :sg-m :sg-n :block-k :matrix])))]
+    (is (body/kernel-body? kernel-body))
+    (is (= [:m :n :k] (mapv :id dimensions))
+        "the body retains graph ABI identities instead of a parallel M/N/K convention")
+    (is (= :float (:dtype result)))
+    (is (= (:source contract) oracle)
+        "direct KernelBody lowering preserves the proven f32 GEMM source exactly")))
+
+(deftest shared-direct-emission-does-not-call-the-legacy-template
+  (with-redefs [opencl-codegen/emit-gemm-tiled
+                (fn [& _]
+                  (throw (ex-info "legacy template was called" {:reason :test/failure})))]
+    (let [emitted (gemm/emit-scheduled-matrix-kernel
+                   {:kernel-name "body_direct"
+                    :a 'a :b 'b :c 'c :m 'm :n 'n :k 'k
+                    :tile (hardware/derive-gemm-tile {})
+                    :result-dtype :float})]
+      (is (body/kernel-body? (:kernel-body emitted)))
+      (is (re-find #"__global float\* restrict C" (:source emitted)))
+      (is (= (get-in emitted [:kernel-body :launch :workgroup-size])
+             (:workgroup-size emitted))))))
 
 (deftest layout-variants-are-graph-topology-not-runtime-conventions
   (doseq [[variant expected-node-count transpose-phase]

--- a/test/raster/compiler/backend/gpu/gemm_tiled_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_tiled_test.clj
@@ -1,6 +1,5 @@
 (ns raster.compiler.backend.gpu.gemm-tiled-test
-  "Correctness of the tile-parametric XMX GEMM generator (raster...opencl-codegen/emit-gemm-tiled),
-   which replaced the hand-unrolled kernel. Two guards:
+  "Correctness of tile-parametric scheduled XMX GEMM lowering. Two guards:
 
      (1) ABSOLUTE correctness — the resident GEMM (default Arc tile, launched through the production
          bind-registered-gemm! path) matches an independent CPU f32-accumulate reference over
@@ -13,7 +12,8 @@
          generator is bit-invariant across tile geometry. This is the guard the T2/T3 autotune work
          (which VARIES the tile) rests on — a tile bug that changes results at all trips it.
 
-   Device-free structural checks live in raster.dl.gsdm-test/gemm-tiled-kernel-test."
+   The old string generator remains an independent cross-tile oracle in this test. Device-free
+   body/source checks live in raster.compiler.backend.gpu.gemm-test."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.dl.gpu-grad-parity :as gp]))
 
@@ -104,8 +104,8 @@
         (RP (RG [{:bound (bind a16 b16 c m n k :float tile epi) :kernel-name "gemm_epi_bias_float"}]))
         (let [gpu (BA c) h (fn [x] (Float/float16ToFloat (Float/floatToFloat16 (float x)))) ref (float-array (* m n))]
           (dotimes [i m] (dotimes [j n]
-            (let [s (loop [p 0 acc 0.0] (if (< p k) (recur (inc p) (+ acc (* (double (h (aget A (+ (* i k) p)))) (double (h (aget B (+ (* p n) j))))))) acc))]
-              (aset ref (+ (* i n) j) (float (+ s (double (h (aget bias j)))))))))
+                           (let [s (loop [p 0 acc 0.0] (if (< p k) (recur (inc p) (+ acc (* (double (h (aget A (+ (* i k) p)))) (double (h (aget B (+ (* p n) j))))))) acc))]
+                             (aset ref (+ (* i n) j) (float (+ s (double (h (aget bias j)))))))))
           (let [maxrel (reduce max 0.0 (map (fn [a b] (/ (Math/abs (- (double a) (double b))) (+ 0.05 (Math/abs (double b))))) gpu ref))]
             (is (< maxrel 1.0e-3) (str "fused C=A·B+bias must match CPU ref within f16 tol (max-rel " maxrel ")"))))
         (finally (FB a16) (FB b16) (FB biasbuf) (FB c))))))

--- a/test/raster/compiler/passes/parallel/gpu_plan_test.clj
+++ b/test/raster/compiler/passes/parallel/gpu_plan_test.clj
@@ -1,5 +1,6 @@
 (ns raster.compiler.passes.parallel.gpu-plan-test
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.passes.parallel.gpu-plan :as gpu-plan]
             [raster.compiler.passes.parallel.patterns :as patterns]))
 
@@ -57,10 +58,14 @@
                                              (recur (+ acc (* (aget A (+ (* i k) p)) (aget B (+ (* p n) j)))) (inc p))
                                              acc)))))
                                C)]
-                  out)
+                      out)
           {:keys [form kernels stats]} (gpu-plan/gpu-plan-pass form :dtype :float)]
       (is (= 1 (:gemm-rewrites stats)) "the redomap counts as a GEMM rewrite, like a BLAS call")
       (is (= 1 (count kernels)))
+      (is (body/kernel-body? (:kernel-body (first kernels)))
+          "the legacy plan front door retains the same scheduled body as graph GEMM")
+      (is (= :float (:dtype (first (filter #(= :result (:role %))
+                                           (get-in kernels [0 :kernel-body :parameters]))))))
       (is (re-find #"invoke-registered-gemm!" (pr-str form))
           "emits the same registered-GEMM invocation the BLAS path uses"))))
 
@@ -75,6 +80,6 @@
                                              (recur (+ acc (aget A (+ (* i k) p))) (inc p))
                                              acc)))))
                                C)]
-                  out)
+                      out)
           {:keys [stats]} (gpu-plan/gpu-plan-pass form :dtype :float)]
       (is (= 0 (:gemm-rewrites stats)) "not a matmul → no GEMM offload (sound)"))))

--- a/test/raster/gpu/one_tile_source_test.clj
+++ b/test/raster/gpu/one_tile_source_test.clj
@@ -14,7 +14,9 @@
    produced from its own constants."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.gemm :as gemm]
+            [raster.compiler.backend.gpu.opencl-codegen :as opencl-codegen]
             [raster.compiler.core.hardware :as hw]
+            [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]))
 
 (defn- split-schedule
@@ -63,6 +65,21 @@
       ;; the pre-unification literal and the derived value agree on THIS device, which is what
       ;; makes the change safe here and correct elsewhere
       (is (= (gc 4096 128) (gc 4096 block-n))))))
+
+(deftest resident-direct-and-autotune-sources-use-the-scheduled-body
+  (let [emit-resident (do (require 'raster.gpu.ze-runtime)
+                          (ns-resolve 'raster.gpu.ze-runtime 'emit-scheduled-gemm))
+        tile (hw/gemm-tile-for nil)]
+    (with-redefs [opencl-codegen/emit-gemm-tiled
+                  (fn [& _]
+                    (throw (ex-info "legacy template was called" {:reason :test/failure})))]
+      (let [emitted (emit-resident "resident_body" :float tile)]
+        (is (body/kernel-body? (:kernel-body emitted)))
+        (is (= :float (:dtype (first (filter #(= :result (:role %))
+                                             (get-in emitted [:kernel-body :parameters]))))))
+        (is (= (get-in emitted [:kernel-body :launch :workgroup-size])
+               (:workgroup-size emitted)))
+        (is (re-find #"__global float\* restrict C" (:source emitted)))))))
 
 (deftest split-k-policy-is-unchanged-on-this-device
   (testing "the emitted schedule expression reads block-m/block-n/block-k rather than independent


### PR DESCRIPTION
## Outcome

Ordinary direct and tiled GEMM now use the same scheduled, typed KernelBody route across compiler graph emission, the legacy GPU-plan front door, and resident/autotuned execution.

## What changed

- make scheduled matrix KernelBody construction public and preserve explicit compiler dimension identities
- allow symbol or keyword value identities so bodies compose with real resident ABI scalar slots
- derive OpenCL dimension references and f16/f32 result emission from the KernelBody contract
- route compiler-owned direct GEMM and resident plain/tiled/autotuned GEMM through that shared lowering
- retain the KernelBody artifact and take launch workgroup geometry from its schedule
- verify byte-identical f32 source against the independent legacy oracle and exercise the real resident LinkPlan pipeline

## Deliberate boundary

Split-K and batched grid-Z GEMM still use the specialized generator because KernelBody does not yet represent grid-Z slicing/offsets. Opaque source epilogues also remain legacy until typed scalar regions can express them. The old generator is therefore retained visibly as an oracle and for those variants; this PR does not claim that all legacy GEMM paths are gone.

## Validation

- focused compiler/resident certification: 78 tests, 495 assertions, all green
- full suite: 2355 tests, 34468 assertions, 3 known local GPU failures and 0 errors
  - stochastic split-K autotune threshold selected split 2 and measured 1.99x on this run
  - resident range-copy test assumed a fresh device buffer was zero-filled
- direct/tiled device GEMM, resident graph replay, Gemma training (56 GEMMs across nn/nt/tn), GPT-2, GSDM, AD, quantization, and scientific solver suites passed
- formatter and diff checks clean; clj-kondo reports no errors