### PR TITLE
Model grid-Z GEMM slices in KernelBody

### DIFF
--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -12,6 +12,7 @@
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-graph :as kgraph]
+            [raster.compiler.ir.kernel-body :as kbody]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]))
 
@@ -127,18 +128,17 @@
                     :group-count [(klaunch/ceil-div elements 256)]})
      phase {:layout :transpose :dtype :half :cacheable-transform? true})))
 
-(defn- matrix-workgroup-size
-  [{:keys [block-m block-n sg-m sg-n matrix]}]
-  (* (quot block-m sg-m) (quot block-n sg-n) (:subgroup matrix 16)))
-
 (defn emit-scheduled-matrix-kernel
   "Build and directly lower one canonical f16 matrix contraction.
 
   This is the shared compiler entry for graph-owned, legacy-plan, and resident direct/tiled GEMM
-  front doors.  Caller identities remain the KernelBody ABI identities; OpenCL M/N/K spelling is
-  solely a target concern.  Split-K, batched grid-Z, and opaque source epilogues are not accepted
-  here until their scheduling operations are explicit in KernelBody."
-  [{:keys [kernel-name id a b c m n k tile result-dtype provenance]
+  front doors. Caller identities remain the KernelBody ABI identities; OpenCL parameter spelling
+  is solely a target concern. Optional views, hardware indices, and K bounds are explicit schedule
+  values used by the split-K and batched wrappers below. Opaque source epilogues remain outside
+  this route until their scalar regions are typed."
+  [{:keys [kernel-name id a b c m n k tile result-dtype provenance
+           additional-parameters additional-indices buffer-shapes buffer-views operation-buffers
+           k-range launch-group-count attributes parameter-names]
     :or {result-dtype :float provenance {}}}]
   (let [kernel-body
         (contraction-schedule/matrix-body
@@ -150,23 +150,74 @@
           :tile tile
           :bindings {:row a :col b}
           :result-dtype result-dtype
+          :additional-parameters additional-parameters
+          :additional-indices additional-indices
+          :buffer-shapes buffer-shapes
+          :buffer-views buffer-views
+          :operation-buffers operation-buffers
+          :k-range k-range
+          :launch-group-count launch-group-count
+          :attributes attributes
           :provenance (merge {:dialect :gemm :lowering :scheduled-matrix} provenance)})]
-    {:source (kernel-body-opencl/emit-matrix-kernel kernel-name kernel-body nil)
+    {:source (kernel-body-opencl/emit-matrix-kernel
+              kernel-name kernel-body {:parameter-names parameter-names})
      :kernel-body kernel-body
      :workgroup-size (get-in kernel-body [:launch :workgroup-size])}))
+
+(defn emit-scheduled-split-k-kernel
+  "Lower a grid-Z partition of the K reduction into disjoint f32 output views."
+  [{:keys [kernel-name id a b c m n k kc splits tile provenance]}]
+  (let [z 'k-slice
+        c-view 'split-result-view
+        k-lower (kbody/expression :mul z kc)
+        k-upper (kbody/expression :min (kbody/expression :add k-lower kc) k)]
+    (emit-scheduled-matrix-kernel
+     {:kernel-name kernel-name :id id :a a :b b :c c :m m :n n :k k
+      :tile tile :result-dtype :float :provenance provenance
+      :additional-parameters [(kbody/->KernelParameter kc :scalar :int [] nil nil :schedule)
+                              (kbody/->KernelParameter splits :scalar :int [] nil nil :schedule)]
+      :additional-indices [(kbody/->IndexBinding z :group 2)]
+      :buffer-shapes {c [splits m n]}
+      :buffer-views [{:id c-view :buffer c
+                      :element-offset (kbody/expression :mul z m n)
+                      :shape [m n]}]
+      :operation-buffers {c c-view}
+      :k-range [k-lower k-upper]
+      :launch-group-count [(kbody/expression :ceil-div n (:block-n tile))
+                           (kbody/expression :ceil-div m (:block-m tile))
+                           splits]
+      :attributes {:grid-z {:index z :extent splits :purpose :reduction-partition}}
+      :parameter-names {kc "KC" splits "splits"}})))
+
+(defn emit-scheduled-batched-matrix-kernel
+  "Lower independent dense matrix slabs as grid-Z-selected contiguous buffer views."
+  [{:keys [kernel-name id a b c m n k batch tile provenance]}]
+  (let [z 'slab
+        a-view 'batch-lhs-view
+        b-view 'batch-rhs-view
+        c-view 'batch-result-view]
+    (emit-scheduled-matrix-kernel
+     {:kernel-name kernel-name :id id :a a :b b :c c :m m :n n :k k
+      :tile tile :result-dtype :float :provenance provenance
+      :additional-parameters [(kbody/->KernelParameter batch :scalar :int [] nil nil :schedule)]
+      :additional-indices [(kbody/->IndexBinding z :group 2)]
+      :buffer-shapes {a [batch m k] b [batch k n] c [batch m n]}
+      :buffer-views [{:id a-view :buffer a
+                      :element-offset (kbody/expression :mul z m k) :shape [m k]}
+                     {:id b-view :buffer b
+                      :element-offset (kbody/expression :mul z k n) :shape [k n]}
+                     {:id c-view :buffer c
+                      :element-offset (kbody/expression :mul z m n) :shape [m n]}]
+      :operation-buffers {a a-view b b-view c c-view}
+      :launch-group-count [(kbody/expression :ceil-div n (:block-n tile))
+                           (kbody/expression :ceil-div m (:block-m tile))
+                           batch]
+      :attributes {:grid-z {:index z :extent batch :purpose :independent-slices}}
+      :parameter-names {batch "batch"}})))
 
 (defn- gemm-artifact
   [{:keys [id m n k tile]} kernel-name a b c split-k? kc splits phase]
   (let [{:keys [block-m block-n]} tile
-        source-args (concat [:c-dtype :float :split-k? split-k?
-                             :schedule-splits-arg? split-k?]
-                            (mapcat identity
-                                    (select-keys tile
-                                                 [:block-m :block-n :sg-m :sg-n :block-k
-                                                  :matrix :num-stages])))
-        source-args (vec (mapcat (fn [[key value]]
-                                   [(if (= :num-stages key) :prefetch key) value])
-                                 (partition 2 source-args)))
         abi (cond-> [(kabi/slot a :input :half :c-name "A")
                      (kabi/slot b :input :half :c-name "B")
                      (kabi/slot c :output :float :c-name "C")
@@ -179,21 +230,19 @@
         group-count (cond-> [(klaunch/ceil-div n block-n)
                              (klaunch/ceil-div m block-m)]
                       split-k? (conj (klaunch/runtime-value splits)))
-        scheduled (when-not split-k?
-                    (emit-scheduled-matrix-kernel
-                     {:kernel-name kernel-name
-                      :id [:gemm id phase]
-                      :a a :b b :c c :m m :n n :k k
-                      :tile tile :result-dtype :float
-                      :provenance {:operation-id id :phase phase}}))]
+        emit-args {:kernel-name kernel-name
+                   :id [:gemm id phase]
+                   :a a :b b :c c :m m :n n :k k
+                   :tile tile :result-dtype :float
+                   :provenance {:operation-id id :phase phase}}
+        scheduled (if split-k?
+                    (emit-scheduled-split-k-kernel
+                     (assoc emit-args :kc :k-chunk :splits :splits))
+                    (emit-scheduled-matrix-kernel emit-args))]
     (artifact
-     kernel-name (if scheduled
-                   (:source scheduled)
-                   (apply codegen/emit-gemm-tiled kernel-name source-args))
+     kernel-name (:source scheduled)
      abi arguments
-     (klaunch/spec {:workgroup-size (if scheduled
-                                      (:workgroup-size scheduled)
-                                      [(matrix-workgroup-size tile) 1 1])
+     (klaunch/spec {:workgroup-size (:workgroup-size scheduled)
                     :group-count group-count})
      phase (cond-> {:tile tile :split-k? split-k? :accumulator-dtype :float}
              scheduled (assoc :kernel-body (:kernel-body scheduled))))))

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -15,6 +15,47 @@
 (defn- value-id? [value]
   (or (symbol? value) (keyword? value)))
 
+(defn- target-name [value]
+  (-> (name value)
+      (str/replace #"[^A-Za-z0-9_]" "_")
+      (str/replace #"^[^A-Za-z_]" "_$0")))
+
+(declare emit-index-expression)
+
+(defn- emit-infix [operator arguments env]
+  (str "(" (str/join (str " " operator " ")
+                     (map #(emit-index-expression % env) arguments)) ")"))
+
+(defn- emit-index-expression
+  [expression env]
+  (cond
+    (number? expression) (str expression)
+    (value-id? expression) (or (get env expression) (target-name expression))
+    (record-kind? "IndexExpr" expression)
+    (let [arguments (:arguments expression)]
+      (case (:op expression)
+        :add (emit-infix "+" arguments env)
+        :sub (emit-infix "-" arguments env)
+        :mul (emit-infix "*" arguments env)
+        :floor-div (emit-infix "/" arguments env)
+        :mod (emit-infix "%" arguments env)
+        :min (str "min(" (str/join ", " (map #(emit-index-expression % env) arguments)) ")")
+        :max (str "max(" (str/join ", " (map #(emit-index-expression % env) arguments)) ")")
+        :ceil-div (let [[numerator denominator] arguments]
+                    (str "((" (emit-index-expression numerator env) " + "
+                         (emit-index-expression denominator env) " - 1) / "
+                         (emit-index-expression denominator env) ")"))))
+    :else (throw (ex-info "OpenCL lowering cannot spell kernel index expression"
+                          {:reason :kernel-body-opencl-unimplemented
+                           :expression expression}))))
+
+(defn- emit-wide-expression
+  [expression env]
+  (if (and (record-kind? "IndexExpr" expression) (= :mul (:op expression)))
+    (str/join " * " (map #(str "(long)" (emit-index-expression % env))
+                         (:arguments expression)))
+    (str "(long)" (emit-index-expression expression env))))
+
 (defn- only!
   [owner values]
   (let [values (vec values)]
@@ -127,13 +168,30 @@
   its indices, fragments and operations.  Every field that affects generated code has an IR witness."
   [kernel-body]
   (let [kernel-body (body/validate! kernel-body)
-        {:keys [parameters indices masks fragments operations attributes]} kernel-body
+        {:keys [parameters views indices masks fragments operations attributes]} kernel-body
         parameters-by-role (group-by :role parameters)
         lhs-param (only! "lhs parameter" (:lhs parameters-by-role))
         rhs-param (only! "rhs parameter" (:rhs parameters-by-role))
         out-param (only! "result parameter" (:result parameters-by-role))
+        view-map (into {} (map (juxt :id identity)) views)
+        operation-buffers (:operation-buffers attributes)
+        lhs-storage-id (get operation-buffers :row (:id lhs-param))
+        rhs-storage-id (get operation-buffers :col (:id rhs-param))
+        out-storage-id (get operation-buffers :out (:id out-param))
+        storage-entry (fn [storage-id parameter]
+                        (if (= storage-id (:id parameter))
+                          parameter
+                          (let [view (get view-map storage-id)]
+                            (require! (and view (= (:id parameter) (:buffer view)))
+                                      "matrix buffer view does not derive from its role parameter"
+                                      {:storage storage-id :parameter parameter :view view})
+                            (assoc parameter :id storage-id :shape (:shape view)
+                                   :layout (:layout view) :view view))))
+        lhs-storage (storage-entry lhs-storage-id lhs-param)
+        rhs-storage (storage-entry rhs-storage-id rhs-param)
+        out-storage (storage-entry out-storage-id out-param)
         [[m-extent k-extent] [k-extent' n-extent] [m-extent' n-extent']]
-        (map :shape [lhs-param rhs-param out-param])
+        (map :shape [lhs-storage rhs-storage out-storage])
         _ (require! (= [m-extent k-extent n-extent]
                        [m-extent' k-extent' n-extent'])
                     "matrix parameter shapes do not compose" {:parameters parameters})
@@ -141,6 +199,11 @@
         m-parameter (:m dimension-parameters)
         n-parameter (:n dimension-parameters)
         k-parameter (:k dimension-parameters)
+        schedule-parameters (filterv #(= :schedule (:role %)) parameters)
+        _ (require! (every? #(and (= :scalar (:kind %)) (= :int (:dtype %)))
+                            schedule-parameters)
+                    "matrix schedule parameters must be scalar integers"
+                    {:parameters schedule-parameters})
         _ (require! (= #{m-parameter n-parameter k-parameter}
                        (set (map :id (:dimension parameters-by-role))))
                     "matrix body dimension roles and parameter identities disagree"
@@ -198,12 +261,14 @@
         block-k (:step outer-loop)
         outer-index (:index outer-loop)
         inner-index (:index inner-loop)
-        _ (require! (and (= 0 (:lower outer-loop)) (= k-parameter (:upper outer-loop))
+        [k-lower k-upper] (get-in attributes [:iteration-range :k]
+                                  [(:lower outer-loop) (:upper outer-loop)])
+        _ (require! (and (= k-lower (:lower outer-loop)) (= k-upper (:upper outer-loop))
                          (= outer-index (:lower inner-loop))
                          (= :min (get-in inner-loop [:upper :op]))
                          (affine= (first (get-in inner-loop [:upper :arguments]))
                                   block-k {outer-index 1})
-                         (= k-parameter (second (get-in inner-loop [:upper :arguments]))))
+                         (= k-upper (second (get-in inner-loop [:upper :arguments]))))
                     "matrix K loops do not describe blocked exact-fragment traversal"
                     {:outer outer-loop :inner inner-loop})
         _ (require! (and (seq lhs-loads) (seq rhs-loads)
@@ -270,11 +335,11 @@
                                  rhs-loads))
                     "rhs tile coordinates do not match the matrix-fragment loop"
                     {:loads rhs-loads :loop-index inner-index})
-        _ (require! (and (every? #(= (:id lhs-param) (:buffer %)) lhs-loads)
-                         (every? #(= (:id rhs-param) (:buffer %)) rhs-loads)
-                         (every? #(= (:id out-param) (:buffer %)) stores))
+        _ (require! (and (every? #(= lhs-storage-id (:buffer %)) lhs-loads)
+                         (every? #(= rhs-storage-id (:buffer %)) rhs-loads)
+                         (every? #(= out-storage-id (:buffer %)) stores))
                     "matrix operations are not connected to their role parameters"
-                    {:lhs lhs-param :rhs rhs-param :out out-param})
+                    {:lhs lhs-storage :rhs rhs-storage :out out-storage})
         _ (require! (every?
                      true?
                      (map-indexed
@@ -284,7 +349,7 @@
                     "N tile origins do not match the rhs fragment order"
                     {:origins n-base-computes})
         _ (require! (and (integer? prefetch-distance) (pos? prefetch-distance)
-                         (every? #(and (= (:id lhs-param) (:buffer %))
+                         (every? #(and (= lhs-storage-id (:buffer %))
                                        (= [mi ki] (:shape %)))
                                  prefetches)
                          (= (set lhs-rows) (set (map (comp first :coordinates) prefetches)))
@@ -306,23 +371,29 @@
         mask-map (into {} (map (juxt :id identity)) masks)
         predicates-of (fn [mask-id] (:predicates (get mask-map mask-id)))
         guard-predicates (predicates-of (:mask guard))
-        _ (require! (and (= 2 (count guard-predicates))
+        sliced-k? (not= [0 k-parameter] [k-lower k-upper])
+        range-predicate? (fn [predicate]
+                           (and (record-kind? "Predicate" predicate)
+                                (= :lt (:op predicate))
+                                (= [k-lower k-upper] (:arguments predicate))))
+        _ (require! (and (= (if sliced-k? 3 2) (count guard-predicates))
                          (some #(lt-affine? % 0 {m-base-id 1} m-parameter) guard-predicates)
                          (some #(lt-affine? % 0 {(first n-base-ids) 1} n-parameter)
-                               guard-predicates))
+                               guard-predicates)
+                         (or (not sliced-k?) (some range-predicate? guard-predicates)))
                     "tile guard mask does not cover the M/N tile origins"
                     {:guard guard :mask (get mask-map (:mask guard))})
         load-mask (only! "matrix-load mask" (distinct (map :mask loads)))
         load-predicates (predicates-of load-mask)
         _ (require! (and (= 1 (count load-predicates))
-                         (lt-affine? (first load-predicates) 0 {inner-index 1} k-parameter))
+                         (lt-affine? (first load-predicates) 0 {inner-index 1} k-upper))
                     "matrix loads require the fragment-index K mask"
                     {:mask (get mask-map load-mask)})
         prefetch-mask (only! "matrix-prefetch mask" (distinct (map :mask prefetches)))
         prefetch-predicates (predicates-of prefetch-mask)
         _ (require! (and (= 1 (count prefetch-predicates))
                          (lt-affine? (first prefetch-predicates)
-                                     (* prefetch-distance ki) {inner-index 1} k-parameter))
+                                     (* prefetch-distance ki) {inner-index 1} k-upper))
                     "matrix prefetch mask and pipeline distance disagree"
                     {:mask (get mask-map prefetch-mask) :distance prefetch-distance})
         _ (require!
@@ -342,12 +413,24 @@
     {:mi mi :ni ni :ki ki :subgroup subgroup
      :block-m block-m :block-n block-n :block-k block-k :sg-m sg-m :sg-n sg-n
      :ncols ncols :lhs-ids lhs-ids :rhs-ids rhs-ids :mad-by-operands mad-by-operands
-     :stores stores :prefetch prefetch-distance :result-dtype (:dtype out-param)}))
+     :stores stores :prefetch prefetch-distance :result-dtype (:dtype out-param)
+     :dimension-parameters dimension-parameters
+     :schedule-parameters schedule-parameters
+     :group-z (some #(when (and (record-kind? "IndexBinding" %)
+                                (= :group (:source %)) (= 2 (:axis %)))
+                       (:id %))
+                    indices)
+     :k-lower k-lower :k-upper k-upper
+     :buffer-offsets {:lhs (some-> lhs-storage :view :element-offset)
+                      :rhs (some-> rhs-storage :view :element-offset)
+                      :result (some-> out-storage :view :element-offset)}}))
 
 (defn- emit-plan
   [kernel-name {:keys [mi ni ki subgroup block-m block-n block-k sg-m sg-n
-                       ncols lhs-ids rhs-ids mad-by-operands stores prefetch result-dtype]}
-   {:keys [epilogue epilogue-params]}]
+                       ncols lhs-ids rhs-ids mad-by-operands stores prefetch result-dtype
+                       dimension-parameters schedule-parameters group-z k-lower k-upper
+                       buffer-offsets]}
+   {:keys [epilogue epilogue-params parameter-names]}]
   (let [nms (count lhs-ids)
         nns (count rhs-ids)
         ksteps (quot block-k ki)
@@ -359,9 +442,38 @@
         amul (fn [m] (if (zero? m) "m_base" (str "m_base+" (* m mi))))
         c-type (case result-dtype :float "float" :half "half")
         store-cast (if (= :half result-dtype) "(half)" "")
+        parameter-names (merge (zipmap [(:m dimension-parameters)
+                                        (:n dimension-parameters)
+                                        (:k dimension-parameters)]
+                                       ["M" "N" "K"])
+                               (into {} (map (fn [parameter]
+                                               [(:id parameter) (target-name (:id parameter))])
+                                             schedule-parameters))
+                               parameter-names)
+        index-names (cond-> parameter-names group-z (assoc group-z (target-name group-z)))
+        sliced-k? (not= [0 (:k dimension-parameters)] [k-lower k-upper])
+        k-begin (if sliced-k? "k_begin" "0")
+        k-end (if sliced-k? "k_end" "K")
+        scalar-params (apply str
+                             (for [parameter schedule-parameters]
+                               (str ", int " (get parameter-names (:id parameter)))))
+        grid-z-line (when group-z
+                      (str "    int " (get index-names group-z)
+                           " = (int)get_group_id(2);\n"))
+        offset-line (fn [pointer role]
+                      (when-let [offset (get buffer-offsets role)]
+                        (when-not (and (number? offset) (zero? offset))
+                          (str "    " pointer " += "
+                               (emit-wide-expression offset index-names) ";\n"))))
+        k-range-lines (when sliced-k?
+                        (str "    int k_begin = "
+                             (emit-index-expression k-lower index-names) ";\n"
+                             "    int k_end = "
+                             (emit-index-expression k-upper index-names) ";\n"
+                             "    if (k_begin >= k_end) return;\n"))
         kstep (fn [kpos]
                 (str "        { int pk = " kpos " + " (* prefetch ki) ";\n"
-                     "          if (pk < K) {\n"
+                     "          if (pk < " k-end ") {\n"
                      (apply str
                             (for [m ms]
                               (str "            intel_sub_group_2d_block_prefetch_16b_8r16x1c((__global void*)A, a_wb, M, a_pb, (int2)(pk, " (amul m) "));\n")))
@@ -389,6 +501,7 @@
      "__kernel void " kernel-name "(\n"
      "    __global const half* restrict A,\n    __global const half* restrict B,\n"
      "    __global " c-type "* restrict C,\n    int M, int N, int K"
+     scalar-params
      epilogue-params
      ") {\n"
      "    int sg_id = get_sub_group_id();\n    int sg_lid = get_sub_group_local_id();\n"
@@ -399,6 +512,11 @@
               (str "    int n_base" n " = get_group_id(0) * " block-n " + sg_col * " sg-n
                    (when (pos? n) (str " + " (* n ni))) ";\n")))
      "    if (m_base >= M || n_base0 >= N) return;\n"
+     grid-z-line
+     k-range-lines
+     (offset-line "A" :lhs)
+     (offset-line "B" :rhs)
+     (offset-line "C" :result)
      (apply str
             (for [m ms]
               (str "    float" mi " "
@@ -408,19 +526,24 @@
      "    short8 " (str/join ", " (for [m ms] (str "sa" m))) ";\n"
      "    int8 " (str/join ", " (for [n ns] (str "bp" n))) ";\n"
      (apply str
-            (for [p (range prefetch)]
-              (str "    if (" (* p ki) " < K) {\n"
+            (for [p (range prefetch)
+                  :let [position (if sliced-k?
+                                   (if (zero? p)
+                                     k-begin
+                                     (str k-begin " + " (* p ki)))
+                                   (str (* p ki)))]]
+              (str "    if (" position " < " k-end ") {\n"
                    (apply str
                           (for [m ms]
-                            (str "        intel_sub_group_2d_block_prefetch_16b_8r16x1c((__global void*)A, a_wb, M, a_pb, (int2)(" (* p ki) ", " (amul m) "));\n")))
+                            (str "        intel_sub_group_2d_block_prefetch_16b_8r16x1c((__global void*)A, a_wb, M, a_pb, (int2)(" position ", " (amul m) "));\n")))
                    "    }\n")))
-     "    int k = 0;\n"
-     "    for (; k + " (dec block-k) " < K; k += " block-k ") {\n"
+     "    int k = " k-begin ";\n"
+     "    for (; k + " (dec block-k) " < " k-end "; k += " block-k ") {\n"
      (apply str
             (for [ks (range ksteps)]
               (kstep (if (zero? ks) "k" (str "k + " (* ks ki))))))
      "    }\n"
-     "    for (; k < K; k += " ki ") {\n"
+     "    for (; k < " k-end "; k += " ki ") {\n"
      (kstep "k")
      "    }\n"
      (apply str

--- a/src/raster/compiler/backend/gpu/opencl_codegen.clj
+++ b/src/raster/compiler/backend/gpu/opencl_codegen.clj
@@ -650,11 +650,11 @@
 ;; ================================================================
 
 (defn emit-gemm-tiled
-  "Legacy tile-parametric XMX GEMM oracle and specialized grid-Z generator.
+  "Legacy tile-parametric XMX GEMM oracle and opaque-epilogue generator.
 
-   Ordinary direct/tiled GEMM lowers from a verified KernelBody. This independent generator stays
-   executable for source-equivalence checks and for split-K, batched, and opaque-helper epilogues
-   until those schedules have explicit KernelBody operations.
+   Ordinary direct/tiled, split-K, and batched GEMM lower from a verified KernelBody. This
+   independent generator stays executable for source-equivalence checks and opaque-helper
+   epilogues until those helpers become typed scalar regions.
 
    Computes C = A·B with FP16 inputs and FP32 accumulation. The tile geometry
    (workgroup BLOCK_M×BLOCK_N, per-subgroup SG_M×SG_N, K-step BLOCK_K, prefetch depth) is COMPUTED,

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -7,6 +7,7 @@
   these values to their own dialect; they must not recover a schedule by inspecting source text.")
 
 (defrecord KernelParameter [id kind dtype shape memory-space layout role])
+(defrecord BufferView [id buffer element-offset shape layout])
 (defrecord IndexBinding [id source axis])
 (defrecord IndexCompute [id expression])
 (defrecord IndexExpr [op arguments])
@@ -24,7 +25,7 @@
 (defrecord TileStore [buffer fragment coordinates mask value-region])
 
 (defrecord KernelBody
-           [id parameters indices masks fragments operations schedule launch provenance attributes])
+           [id parameters views indices masks fragments operations schedule launch provenance attributes])
 
 (def ^:private parameter-kinds #{:input :output :scalar})
 (def ^:private index-sources #{:group :subgroup :lane})
@@ -115,9 +116,9 @@
 (declare validate-operations!)
 
 (defn- validate-operation!
-  [operation parameters fragments masks scope]
+  [operation storage fragments masks scope]
   (let [parameter (fn [id]
-                    (or (get parameters id)
+                    (or (get storage id)
                         (throw (ex-info "kernel operation references an undeclared parameter"
                                         {:parameter id :operation operation}))))
         fragment (fn [id]
@@ -215,13 +216,13 @@
         (when (contains? scope (:index operation))
           (throw (ex-info "kernel loop induction value shadows an existing value"
                           {:index (:index operation) :scope scope})))
-        (validate-operations! (:operations operation) parameters fragments masks
+        (validate-operations! (:operations operation) storage fragments masks
                               (conj scope (:index operation))))
 
       (record-kind? "raster.compiler.ir.kernel_body.Guard" operation)
       (do
         (mask (:mask operation))
-        (validate-operations! (:operations operation) parameters fragments masks scope))
+        (validate-operations! (:operations operation) storage fragments masks scope))
 
       (record-kind? "raster.compiler.ir.kernel_body.TileStore" operation)
       (let [p (parameter (:buffer operation))
@@ -243,13 +244,13 @@
       (throw (ex-info "kernel body contains an unsupported operation"
                       {:operation operation :actual (type operation)})))))
 
-(defn- validate-operations! [operations parameters fragments masks scope]
+(defn- validate-operations! [operations storage fragments masks scope]
   (when-not (vector? operations)
     (throw (ex-info "kernel operations must be an ordered vector" {:operations operations})))
   (doseq [operation operations]
     (when-not (operation? operation)
       (throw (ex-info "kernel body contains a non-operation value" {:operation operation})))
-    (validate-operation! operation parameters fragments masks scope)))
+    (validate-operation! operation storage fragments masks scope)))
 
 (defn validate!
   "Verify a scheduled KernelBody and return it unchanged."
@@ -257,16 +258,17 @@
   (when-not (kernel-body? body)
     (throw (ex-info "kernel body must be a KernelBody value"
                     {:body body :actual (type body)})))
-  (let [{:keys [id parameters indices masks fragments operations schedule launch provenance
+  (let [{:keys [id parameters views indices masks fragments operations schedule launch provenance
                 attributes]} body]
     (when (nil? id)
       (throw (ex-info "kernel body requires a stable identity" {:body body})))
-    (doseq [[field values] [[:parameters parameters] [:indices indices] [:masks masks]
+    (doseq [[field values] [[:parameters parameters] [:views views] [:indices indices] [:masks masks]
                             [:fragments fragments] [:operations operations]]]
       (when-not (vector? values)
         (throw (ex-info "kernel body sections must be ordered vectors"
                         {:field field :value values}))))
     (unique-ids! "kernel parameters" parameters)
+    (unique-ids! "kernel buffer views" views)
     (unique-ids! "kernel indices" indices)
     (unique-ids! "kernel masks" masks)
     (unique-ids! "kernel fragments" fragments)
@@ -286,7 +288,8 @@
             (when-not (keyword? (:memory-space p))
               (throw (ex-info "kernel buffer parameter requires a memory space"
                               {:parameter p}))))))
-    (let [scalar-ids (set (map :id (filter #(= :scalar (:kind %)) parameters)))
+    (let [parameter-map (into {} (map (juxt :id identity)) parameters)
+          scalar-ids (set (map :id (filter #(= :scalar (:kind %)) parameters)))
           index-scope
           (reduce
            (fn [scope idx]
@@ -308,7 +311,64 @@
                :else
                (throw (ex-info "kernel body contains an unsupported index value" {:index idx})))
              (conj scope (:id idx)))
-           scalar-ids indices)]
+           scalar-ids indices)
+          group-axes (into {} (keep #(when (and (record-kind?
+                                                 "raster.compiler.ir.kernel_body.IndexBinding" %)
+                                                (= :group (:source %)))
+                                       [(:id %) (:axis %)]))
+                           indices)
+          view-map
+          (reduce
+           (fn [resolved view]
+             (when-not (record-kind? "raster.compiler.ir.kernel_body.BufferView" view)
+               (throw (ex-info "kernel body contains an unsupported buffer view" {:view view})))
+             (when (or (contains? parameter-map (:id view)) (contains? resolved (:id view)))
+               (throw (ex-info "kernel buffer view identity collides with storage"
+                               {:view (:id view)})))
+             (let [parent (or (get parameter-map (:buffer view))
+                              (throw (ex-info "kernel buffer view references undeclared storage"
+                                              {:view view :buffer (:buffer view)})))]
+               (when (= :scalar (:kind parent))
+                 (throw (ex-info "kernel buffer view cannot derive from scalar storage"
+                                 {:view view :buffer parent})))
+               (when-not (expression? (:element-offset view))
+                 (throw (ex-info "kernel buffer view requires an explicit element offset"
+                                 {:view view})))
+               (let [outside (remove index-scope
+                                     (expression-references (:element-offset view)))]
+                 (when (seq outside)
+                   (throw (ex-info "kernel buffer view offset references values outside its scope"
+                                   {:view view :references (vec outside) :scope index-scope}))))
+               (shape! "kernel buffer view" (:shape view))
+               (layout! "kernel buffer view" (:layout view))
+               (let [parent-shape (:shape parent)
+                     view-shape (:shape view)
+                     prefix-rank (- (count parent-shape) (count view-shape))
+                     offset (:element-offset view)
+                     offset-arguments (when (and (record-kind?
+                                                  "raster.compiler.ir.kernel_body.IndexExpr" offset)
+                                                 (= :mul (:op offset)))
+                                        (:arguments offset))
+                     slice-index (first offset-arguments)
+                     group-axis (get group-axes slice-index)]
+                 (when-not (and (= 1 prefix-rank)
+                                (= view-shape (subvec (vec parent-shape) 1))
+                                (= (vec offset-arguments) (into [slice-index] view-shape))
+                                (integer? group-axis)
+                                (< group-axis (count (:group-count launch)))
+                                (= (first parent-shape)
+                                   (nth (:group-count launch) group-axis)))
+                   (throw (ex-info
+                           "kernel buffer view is not a launch-bounded contiguous leading slice"
+                           {:view view :parent parent :launch launch
+                            :required {:parent-shape '[extent & view-shape]
+                                       :element-offset '[group-index & view-shape]
+                                       :group-count 'extent}}))))
+               (assoc resolved (:id view)
+                      (assoc parent :id (:id view) :shape (:shape view)
+                             :layout (:layout view) :view view))))
+           {} views)
+          storage (merge parameter-map view-map)]
       (doseq [m masks]
         (when-not (and (record-kind? "raster.compiler.ir.kernel_body.Mask" m)
                        (vector? (:predicates m)) (seq (:predicates m))
@@ -325,7 +385,7 @@
           (throw (ex-info "kernel body descriptive sections must be maps"
                           {:field field :value value}))))
       (validate-operations! operations
-                            (into {} (map (juxt :id identity)) parameters)
+                            storage
                             (into {} (map (juxt :id identity)) fragments)
                             (into {} (map (juxt :id identity)) masks)
                             index-scope)))
@@ -333,8 +393,8 @@
 
 (defn make
   "Construct and verify a target-neutral scheduled kernel body."
-  [{:keys [id parameters indices masks fragments operations schedule launch provenance attributes]
-    :or {parameters [] indices [] masks [] fragments [] operations [] schedule {} launch {}
+  [{:keys [id parameters views indices masks fragments operations schedule launch provenance attributes]
+    :or {parameters [] views [] indices [] masks [] fragments [] operations [] schedule {} launch {}
          provenance {} attributes {}}}]
-  (validate! (->KernelBody id parameters indices masks fragments operations schedule launch
+  (validate! (->KernelBody id parameters views indices masks fragments operations schedule launch
                            provenance attributes)))

--- a/src/raster/compiler/passes/parallel/contraction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/contraction_schedule.clj
@@ -42,16 +42,21 @@
          (zero? (mod block-k k)))))
 
 (defn- matrix-parameters
-  [row col out M N K dimension-parameters row-layout col-layout out-layout result-dtype epilogue]
+  [row col out M N K dimension-parameters row-layout col-layout out-layout result-dtype epilogue
+   buffer-shapes additional-parameters]
   (let [[m-parameter n-parameter k-parameter] dimension-parameters]
     (vec
      (concat
-      [(body/->KernelParameter row :input :half [M K] :global row-layout :lhs)
-       (body/->KernelParameter col :input :half [K N] :global col-layout :rhs)
-       (body/->KernelParameter out :output result-dtype [M N] :global out-layout :result)
+      [(body/->KernelParameter row :input :half (get buffer-shapes row [M K])
+                               :global row-layout :lhs)
+       (body/->KernelParameter col :input :half (get buffer-shapes col [K N])
+                               :global col-layout :rhs)
+       (body/->KernelParameter out :output result-dtype (get buffer-shapes out [M N])
+                               :global out-layout :result)
        (body/->KernelParameter m-parameter :scalar :int [] nil nil :dimension)
        (body/->KernelParameter n-parameter :scalar :int [] nil nil :dimension)
        (body/->KernelParameter k-parameter :scalar :int [] nil nil :dimension)]
+      additional-parameters
       (for [{:keys [sym dtype map] :or {dtype :float}} (:operands epilogue)]
         (let [shape (axis-map/shape map)]
           (body/->KernelParameter sym :input dtype shape :global
@@ -80,11 +85,18 @@
   symbolic resident graphs share one body without renaming caller values.  The current matrix
   instruction is f16×f16→f32; `result-dtype` controls only the final store representation."
   [{:keys [id row col out dimensions dimension-parameters axis-symbols tile bindings epilogue
-           result-dtype provenance]
+           result-dtype provenance additional-parameters additional-indices buffer-shapes
+           buffer-views operation-buffers k-range launch-group-count attributes]
     :or {dimension-parameters ['M 'N 'K]
          axis-symbols ['i 'j 'k]
          result-dtype :half
-         provenance {}}}]
+         provenance {}
+         additional-parameters []
+         additional-indices []
+         buffer-shapes {}
+         buffer-views []
+         operation-buffers {}
+         attributes {}}}]
   (let [tile (assoc tile :num-stages (or (:num-stages tile) 3))
         _ (when-not (and (= 3 (count dimension-parameters))
                          (every? compiler-id? dimension-parameters)
@@ -94,6 +106,10 @@
                              :dimension-parameters dimension-parameters})))
         [M N K] dimensions
         [m-parameter n-parameter k-parameter] dimension-parameters
+        [k-lower k-upper] (or k-range [0 k-parameter])
+        row-buffer (get operation-buffers row row)
+        col-buffer (get operation-buffers col col)
+        out-buffer (get operation-buffers out out)
         [i j k-sym] axis-symbols
         matrix (:matrix tile)
         desc {:matrix matrix :subgroup-size (:subgroup matrix)}
@@ -105,6 +121,15 @@
         row-layout (layout/dot-operand 0 acc-layout k-width :half)
         col-layout (layout/dot-operand 1 acc-layout k-width :half)
         out-layout (layout/row-major [M N] result-dtype)
+        buffer-layouts {row row-layout col col-layout out out-layout}
+        buffer-views (mapv (fn [view]
+                             (if (instance? raster.compiler.ir.kernel_body.BufferView view)
+                               view
+                               (body/->BufferView (:id view) (:buffer view)
+                                                  (:element-offset view) (:shape view)
+                                                  (or (:layout view)
+                                                      (get buffer-layouts (:buffer view))))))
+                           buffer-views)
         {:keys [block-m block-n block-k sg-m sg-n num-stages]} tile
         {matrix-m :m matrix-n :n matrix-k :k subgroup :subgroup} matrix
         subgroup-rows (quot block-m sg-m)
@@ -142,12 +167,14 @@
         (vec
          (concat
           [(body/->Mask :tile-active
-                        [(body/predicate :lt m-base m-parameter)
-                         (body/predicate :lt (n-base 0) n-parameter)])
-           (body/->Mask :k-active [(body/predicate :lt 'k-fragment k-parameter)])
+                        (cond-> [(body/predicate :lt m-base m-parameter)
+                                 (body/predicate :lt (n-base 0) n-parameter)]
+                          (not= [0 k-parameter] [k-lower k-upper])
+                          (conj (body/predicate :lt k-lower k-upper))))
+           (body/->Mask :k-active [(body/predicate :lt 'k-fragment k-upper)])
            (body/->Mask :prefetch-active
                         [(body/predicate :lt
-                                         (add 'k-fragment (* num-stages matrix-k)) k-parameter)])]
+                                         (add 'k-fragment (* num-stages matrix-k)) k-upper)])]
           (for [mm (range m-fragments) nn (range n-fragments)]
             (body/->Mask
              (fragment-id "store" mm nn)
@@ -172,14 +199,14 @@
          (concat
           (for [mm (range m-fragments)]
             (body/->TilePrefetch
-             row [(add m-base (* mm matrix-m))
-                  (add k-fragment (* num-stages matrix-k))]
+             row-buffer [(add m-base (* mm matrix-m))
+                         (add k-fragment (* num-stages matrix-k))]
              [matrix-m matrix-k] row-layout :prefetch-active num-stages))
           (for [nn (range n-fragments)]
-            (body/->TileLoad (fragment-id "rhs" nn) col
+            (body/->TileLoad (fragment-id "rhs" nn) col-buffer
                              [k-fragment (n-base nn)] :k-active :cached))
           (for [mm (range m-fragments)]
-            (body/->TileLoad (fragment-id "lhs" mm) row
+            (body/->TileLoad (fragment-id "lhs" mm) row-buffer
                              [(add m-base (* mm matrix-m)) k-fragment] :k-active :cached))
           (for [mm (range m-fragments) nn (range n-fragments)]
             (body/->MatrixMad (fragment-id "acc" mm nn)
@@ -188,10 +215,10 @@
                               matrix))))
         init-ops (mapv #(body/->FragmentInit % 0.0) accumulator-ids)
         fragment-loop (body/->Loop k-fragment 'k-block
-                                   (body/expression :min (add 'k-block block-k) k-parameter)
+                                   (body/expression :min (add 'k-block block-k) k-upper)
                                    matrix-k one-k-step
                                    {:unroll true :matrix-step matrix-k})
-        k-loop (body/->Loop 'k-block 0 k-parameter block-k [fragment-loop]
+        k-loop (body/->Loop 'k-block k-lower k-upper block-k [fragment-loop]
                             {:unrolled-by (quot block-k matrix-k)
                              :matrix-step matrix-k
                              :pipeline-depth num-stages})
@@ -199,31 +226,41 @@
         stores (vec
                 (for [mm (range m-fragments) nn (range n-fragments)]
                   (body/->TileStore
-                   out (fragment-id "acc" mm nn)
+                   out-buffer (fragment-id "acc" mm nn)
                    [(add m-base (* mm matrix-m)) (n-base nn)]
                    (fragment-id "store" mm nn) region)))
-        workgroup-size (* subgroup-rows subgroup-cols subgroup)]
+        workgroup-size (* subgroup-rows subgroup-cols subgroup)
+        group-count (or launch-group-count
+                        [(body/expression :ceil-div n-parameter block-n)
+                         (body/expression :ceil-div m-parameter block-m)])]
     (body/make
      {:id id
       :parameters (matrix-parameters row col out M N K dimension-parameters
-                                     row-layout col-layout out-layout result-dtype epilogue)
-      :indices indices
+                                     row-layout col-layout out-layout result-dtype epilogue
+                                     buffer-shapes additional-parameters)
+      :views (vec buffer-views)
+      :indices (into (vec additional-indices) indices)
       :masks masks
       :fragments fragments
       :operations [(body/->Guard :tile-active (vec (concat init-ops [k-loop] stores)))]
       :schedule tile
-      :launch {:workgroup-size [workgroup-size 1]
-               :group-count [(body/expression :ceil-div n-parameter block-n)
-                             (body/expression :ceil-div m-parameter block-m)]}
+      :launch {:workgroup-size (into [workgroup-size] (repeat (dec (count group-count)) 1))
+               :group-count group-count}
       :provenance provenance
-      :attributes {:kind :matrix-contraction
-                   :instruction-family (:family matrix)
-                   :dims [M N K]
-                   :dimension-parameters {:m m-parameter :n n-parameter :k k-parameter}
-                   :axis-symbols [i j k-sym]
-                   :bindings bindings
-                   :boundary-policy {:m :masked :n :masked :k :exact-fragments}
-                   :epilogue epilogue}})))
+      :attributes (merge
+                   {:kind :matrix-contraction
+                    :instruction-family (:family matrix)
+                    :dims [M N K]
+                    :dimension-parameters {:m m-parameter :n n-parameter :k k-parameter}
+                    :axis-symbols [i j k-sym]
+                    :bindings bindings
+                    :operation-buffers {:row row-buffer :col col-buffer :out out-buffer}
+                    :iteration-range {:k [k-lower k-upper]}
+                    :boundary-policy {:m :masked :n :masked
+                                      :k (if (= [0 k-parameter] [k-lower k-upper])
+                                           :exact-fragments :sliced-fragments)}
+                    :epilogue epilogue}
+                   attributes)})))
 
 (defn plan-matrix-body
   "Apply `tile` to verified contraction facts.

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -1316,6 +1316,26 @@
     :tile tile :result-dtype c-dtype
     :provenance {:dialect :resident-runtime}}))
 
+(defn- emit-scheduled-split-k-gemm
+  "Ask the compiler for a grid-Z sliced K reduction over resident buffers."
+  [kernel-name tile]
+  ((requiring-resolve 'raster.compiler.backend.gpu.gemm/emit-scheduled-split-k-kernel)
+   {:kernel-name kernel-name
+    :id [:resident-gemm kernel-name]
+    :a 'A :b 'B :c 'C :m 'M :n 'N :k 'K :kc 'KC :splits 'splits
+    :tile tile
+    :provenance {:dialect :resident-runtime}}))
+
+(defn- emit-scheduled-batched-gemm
+  "Ask the compiler for grid-Z-selected independent resident matrix views."
+  [kernel-name tile]
+  ((requiring-resolve 'raster.compiler.backend.gpu.gemm/emit-scheduled-batched-matrix-kernel)
+   {:kernel-name kernel-name
+    :id [:resident-gemm kernel-name]
+    :a 'A :b 'B :c 'C :m 'M :n 'N :k 'K :batch 'batch
+    :tile tile
+    :provenance {:dialect :resident-runtime}}))
+
 (declare gemm-tile)
 
 (def ^:private gemm-cache
@@ -2285,16 +2305,18 @@
   (ensure-init!)
   (when (nil? @gemm-splitk-cache)
     (let [kname "gemm_nonsquare_splitk"
-          cl-src (do (require 'raster.compiler.backend.gpu.opencl-codegen)
-                     ((resolve 'raster.compiler.backend.gpu.opencl-codegen/emit-gemm-tiled)
-                      kname :c-dtype :float :split-k? true))
+          tile (gemm-tile)
+          emitted (emit-scheduled-split-k-gemm kname tile)
+          cl-src (:source emitted)
           spv (do (require 'raster.compiler.support.spirv-cache)
                   ((resolve 'raster.compiler.support.spirv-cache/compile-opencl-to-spirv)
                    cl-src :device (:device-id-hex @state)))
           module (load-module! spv)
           kernel (create-kernel module kname)]
       (clojure.core/reset! gemm-splitk-cache
-                           {:module module :kernel kernel :kernel-name kname})))
+                           {:module module :kernel kernel :kernel-name kname :tile tile
+                            :kernel-body (:kernel-body emitted)
+                            :workgroup (:workgroup-size emitted)})))
   @gemm-splitk-cache)
 
 (defn- ensure-splitk-reduce-kernel!
@@ -2322,16 +2344,18 @@
   z-slice reduces (must be a multiple of 32 so no interior chunk hits the k-remainder
   path; the LAST chunk clamps to k). Pair with bind-registered-splitk-reduce!."
   [a b partials m n k kc splits]
-  (let [{:keys [module kernel-name]} (ensure-gemm-splitk-kernel!)
+  (let [{:keys [module kernel-name tile workgroup]} (ensure-gemm-splitk-kernel!)
+        {:keys [block-m block-n]} tile
         kh (create-kernel-fresh module kernel-name)
         m (long m) n (long n) k (long k) kc (long kc) splits (long splits)
         args [(:segment a) (:segment b) (:segment partials)
               {:type :int :value (int m)} {:type :int :value (int n)}
-              {:type :int :value (int k)} {:type :int :value (int kc)}]
-        bnd (bind-kernel! kh [256 1] args)
+              {:type :int :value (int k)} {:type :int :value (int kc)}
+              {:type :int :value (int splits)}]
+        bnd (bind-kernel! kh workgroup args)
         gc ^MemorySegment (:gc-seg bnd)]
-    (.set gc I32 0 (int (Math/ceil (/ (double n) 128.0))))   ;; X = gc-n
-    (.set gc I32 4 (int (Math/ceil (/ (double m) 128.0))))   ;; Y = gc-m
+    (.set gc I32 0 (int (Math/ceil (/ (double n) (double block-n))))) ;; X = gc-n
+    (.set gc I32 4 (int (Math/ceil (/ (double m) (double block-m))))) ;; Y = gc-m
     (.set gc I32 8 (int splits))                             ;; Z = k-chunks
     bnd))
 
@@ -2368,16 +2392,18 @@
   (ensure-init!)
   (when (nil? @gemm-batched-cache)
     (let [kname "gemm_nonsquare_batched"
-          cl-src (do (require 'raster.compiler.backend.gpu.opencl-codegen)
-                     ((resolve 'raster.compiler.backend.gpu.opencl-codegen/emit-gemm-tiled)
-                      kname :c-dtype :float :batched? true))
+          tile (gemm-tile)
+          emitted (emit-scheduled-batched-gemm kname tile)
+          cl-src (:source emitted)
           spv (do (require 'raster.compiler.support.spirv-cache)
                   ((resolve 'raster.compiler.support.spirv-cache/compile-opencl-to-spirv)
                    cl-src :device (:device-id-hex @state)))
           module (load-module! spv)
           kernel (create-kernel module kname)]
       (clojure.core/reset! gemm-batched-cache
-                           {:module module :kernel kernel :kernel-name kname})))
+                           {:module module :kernel kernel :kernel-name kname :tile tile
+                            :kernel-body (:kernel-body emitted)
+                            :workgroup (:workgroup-size emitted)})))
   @gemm-batched-cache)
 
 (defn bind-registered-gemm-batched!
@@ -2387,16 +2413,17 @@
   f32, all contiguous. Fresh kernel handle per bind (LZ kernel args are mutable
   handle state)."
   [a b c m n k batch]
-  (let [{:keys [module kernel-name]} (ensure-gemm-batched-kernel!)
+  (let [{:keys [module kernel-name tile workgroup]} (ensure-gemm-batched-kernel!)
+        {:keys [block-m block-n]} tile
         kh (create-kernel-fresh module kernel-name)
         m (long m) n (long n) k (long k) batch (long batch)
         args [(:segment a) (:segment b) (:segment c)
               {:type :int :value (int m)} {:type :int :value (int n)}
-              {:type :int :value (int k)}]
-        bnd (bind-kernel! kh [256 1] args)
+              {:type :int :value (int k)} {:type :int :value (int batch)}]
+        bnd (bind-kernel! kh workgroup args)
         gc ^MemorySegment (:gc-seg bnd)]
-    (.set gc I32 0 (int (Math/ceil (/ (double n) 128.0))))   ;; X = gc-n
-    (.set gc I32 4 (int (Math/ceil (/ (double m) 128.0))))   ;; Y = gc-m
+    (.set gc I32 0 (int (Math/ceil (/ (double n) (double block-n))))) ;; X = gc-n
+    (.set gc I32 4 (int (Math/ceil (/ (double m) (double block-m))))) ;; Y = gc-m
     (.set gc I32 8 (int batch))                              ;; Z = slabs
     bnd))
 

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -51,7 +51,10 @@
         temporary-specs (graph-call/temporary-specs graph scalar-values)
         partial-spec (some (fn [[id spec]] (when (= :partials (last id)) spec))
                            temporary-specs)
-        contract (matrix-contract graph)]
+        contract (matrix-contract graph)
+        kernel-body (artifact/attribute contract :kernel-body)
+        outer-loop (first (filter #(instance? raster.compiler.ir.kernel_body.Loop %)
+                                  (get-in kernel-body [:operations 0 :operations])))]
     (is (= :xmx-split-k (executable/strategy graph)))
     (is (= #{'a 'b 'c} (set (keys buffers))))
     (is (= [:float (* 26 13 640) nil] partial-spec))
@@ -59,7 +62,13 @@
            (:group-count
             (launch/realize (:launch contract)
                             #(graph-call/resolve-integer scalar-values %)))))
-    (is (= 4 (count (:nodes graph))))))
+    (is (= 4 (count (:nodes graph))))
+    (is (body/kernel-body? kernel-body))
+    (is (= 1 (count (:views kernel-body))))
+    (is (= [:splits :m :n] (:shape (first (filter #(= :result (:role %))
+                                                  (:parameters kernel-body))))))
+    (is (= 3 (count (get-in kernel-body [:launch :group-count]))))
+    (is (not= 0 (:lower outer-loop)) "the K partition is an explicit loop bound")))
 
 (deftest direct-xmx-graphs-carry-the-shared-scheduled-body
   (let [tile (hardware/derive-gemm-tile {})
@@ -93,6 +102,28 @@
       (is (re-find #"__global float\* restrict C" (:source emitted)))
       (is (= (get-in emitted [:kernel-body :launch :workgroup-size])
              (:workgroup-size emitted))))))
+
+(deftest grid-z-matrix-emission-does-not-call-the-legacy-template
+  (let [tile (hardware/derive-gemm-tile {})]
+    (with-redefs [opencl-codegen/emit-gemm-tiled
+                  (fn [& _]
+                    (throw (ex-info "legacy template was called" {:reason :test/failure})))]
+      (let [split (gemm/emit-scheduled-split-k-kernel
+                   {:kernel-name "body_split"
+                    :a 'a :b 'b :c 'partials :m 'm :n 'n :k 'k
+                    :kc 'kc :splits 'splits :tile tile})
+            batched (gemm/emit-scheduled-batched-matrix-kernel
+                     {:kernel-name "body_batched"
+                      :a 'a :b 'b :c 'c :m 'm :n 'n :k 'k
+                      :batch 'batch :tile tile})]
+        (is (body/kernel-body? (:kernel-body split)))
+        (is (= 1 (count (get-in split [:kernel-body :views]))))
+        (is (re-find #"int KC, int splits" (:source split)))
+        (is (re-find #"int k_begin" (:source split)))
+        (is (= 3 (count (get-in batched [:kernel-body :views]))))
+        (is (re-find #"int batch" (:source batched)))
+        (is (every? #(re-find (re-pattern (str % " \\+= ")) (:source batched))
+                    ["A" "B" "C"]))))))
 
 (deftest layout-variants-are-graph-topology-not-runtime-conventions
   (doseq [[variant expected-node-count transpose-phase]

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -67,3 +67,28 @@
           bad (assoc-in kernel [:operations 0 :operations 2 :mask] :missing)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"undeclared mask"
                             (body/validate! bad))))))
+
+(deftest buffer-views-retain-parent-ownership-and-explicit-offsets
+  (let [kernel (minimal-body)
+        kernel (-> kernel
+                   (assoc-in [:parameters 0 :shape] [16 16 16])
+                   (assoc-in [:launch :group-count] [16]))
+        view (body/->BufferView 'A-slab 'A
+                                (body/expression :mul 'group-x 16 16)
+                                [16 16] (:layout (first (:parameters kernel))))
+        viewed (-> kernel
+                   (assoc :views [view])
+                   (assoc-in [:operations 0 :operations 1 :operations 0 :buffer] 'A-slab))]
+    (is (= viewed (body/validate! viewed)))
+    (testing "a view may only reference declared storage"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"undeclared storage"
+                            (body/validate! (assoc viewed :views [(assoc view :buffer 'missing)])))))
+    (testing "its offset is checked in the scalar/index scope"
+      (let [unknown-offset (assoc view :element-offset
+                                  (body/expression :mul 'unknown 256))]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"outside its scope"
+                              (body/validate!
+                               (assoc viewed :views [unknown-offset]))))))
+    (testing "the parent extent is tied to the hardware axis launch bound"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"launch-bounded"
+                            (body/validate! (assoc-in viewed [:launch :group-count 0] 15)))))))

--- a/test/raster/dl/dv_batched_gemm_spike.clj
+++ b/test/raster/dl/dv_batched_gemm_spike.clj
@@ -11,8 +11,8 @@
    tiles = 128 workgroups, which FILL the ~32-workgroup iGPU where one slab (2 wg)
    starves it.
 
-   Kernel: raster.gpu.ze-runtime/bind-registered-gemm-batched! (emit-gemm-tiled
-   :batched? true). This is the batched NN primitive C[b]=A[b]·B[b]; the -tn layout
+   Kernel: raster.gpu.ze-runtime/bind-registered-gemm-batched!, lowered from three explicit
+   grid-Z-selected KernelBody buffer views. This is the batched NN primitive C[b]=A[b]·B[b]; the -tn layout
    (Wᵀ) is staged host-side here (transpose each W slab → A) to isolate the GEMM lever
    the GATE measures.
 

--- a/test/raster/gpu/one_tile_source_test.clj
+++ b/test/raster/gpu/one_tile_source_test.clj
@@ -81,6 +81,23 @@
                (:workgroup-size emitted)))
         (is (re-find #"__global float\* restrict C" (:source emitted)))))))
 
+(deftest resident-grid-z-sources-use-the-scheduled-body
+  (let [ze (do (require 'raster.gpu.ze-runtime) (find-ns 'raster.gpu.ze-runtime))
+        emit-split (ns-resolve ze 'emit-scheduled-split-k-gemm)
+        emit-batched (ns-resolve ze 'emit-scheduled-batched-gemm)
+        tile (hw/gemm-tile-for nil)]
+    (with-redefs [opencl-codegen/emit-gemm-tiled
+                  (fn [& _]
+                    (throw (ex-info "legacy template was called" {:reason :test/failure})))]
+      (let [split (emit-split "resident_split_body" tile)
+            batched (emit-batched "resident_batched_body" tile)]
+        (is (= [256 1 1] (:workgroup-size split)))
+        (is (= 1 (count (get-in split [:kernel-body :views]))))
+        (is (re-find #"int KC, int splits" (:source split)))
+        (is (= [256 1 1] (:workgroup-size batched)))
+        (is (= 3 (count (get-in batched [:kernel-body :views]))))
+        (is (re-find #"int batch" (:source batched)))))))
+
 (deftest split-k-policy-is-unchanged-on-this-device
   (testing "the emitted schedule expression reads block-m/block-n/block-k rather than independent
             literals and preserves the established policy"


### PR DESCRIPTION
## Summary

- add checked, launch-bounded contiguous BufferViews plus explicit hardware group indices and K iteration ranges to KernelBody
- lower split-K and batched GEMM through the same scheduled matrix body and OpenCL lowerer as direct GEMM
- route compiler graphs and resident Level Zero binders through the shared body-owned ABI, workgroup, and 3D launch geometry
- retain the independent legacy generator only as the direct-source oracle/body-less fallback and for opaque source epilogues

This is deliberately schedule-generic: KernelBody represents sliced storage and reduction ranges, without adding batched-GEMM, attention, or quantization opcodes.

## Validation

- focused compiler/IR/resident tests: 16 tests, 87 assertions, green after final review
- broader compiler, composition, and AD subsets: green
- real GPU split-K correctness across ragged shapes and split counts: green
- real GPU batched GEMM: 1241.3 GFLOP/s, 15.7x scalar, relative error 3.17e-4
- split-K autotuning in the full suite: 1327.91 GFLOP/s, 13.2x baseline
- full suite: 2358 tests, 34490 assertions, 1 known unrelated range-transfer baseline failure, 0 errors
- scoped formatter and git diff --check: green

The remaining legacy boundary is opaque source epilogues; moving those into typed scalar regions is the next cleanup slice.