### PR TITLE
Lower typed GEMM epilogues from KernelBody

### DIFF
--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -134,11 +134,11 @@
   This is the shared compiler entry for graph-owned, legacy-plan, and resident direct/tiled GEMM
   front doors. Caller identities remain the KernelBody ABI identities; OpenCL parameter spelling
   is solely a target concern. Optional views, hardware indices, and K bounds are explicit schedule
-  values used by the split-K and batched wrappers below. Opaque source epilogues remain outside
-  this route until their scalar regions are typed."
+  values used by the split-K and batched wrappers below. An optional epilogue becomes a typed
+  ScalarRegion on every store and is lowered as part of the body."
   [{:keys [kernel-name id a b c m n k tile result-dtype provenance
            additional-parameters additional-indices buffer-shapes buffer-views operation-buffers
-           k-range launch-group-count attributes parameter-names]
+           k-range launch-group-count attributes parameter-names epilogue]
     :or {result-dtype :float provenance {}}}]
   (let [kernel-body
         (contraction-schedule/matrix-body
@@ -149,6 +149,7 @@
           :axis-symbols ['i 'j 'l]
           :tile tile
           :bindings {:row a :col b}
+          :epilogue epilogue
           :result-dtype result-dtype
           :additional-parameters additional-parameters
           :additional-indices additional-indices

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -5,7 +5,13 @@
   target spellings: Intel subgroup builtins, OpenCL declarations and a pipelined loop form.  Tile
   geometry and fragment topology are recovered from explicit index/operation IR, never from the
   source contraction or a second schedule registry."
-  (:require [clojure.string :as str]
+  (:require [clojure.set :as set]
+            [clojure.string :as str]
+            [clojure.walk :as walk]
+            [raster.compiler.backend.gpu.c-emit :as ce]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.kernel-body :as body]))
 
 (defn- record-kind? [simple-name value]
@@ -55,6 +61,104 @@
     (str/join " * " (map #(str "(long)" (emit-index-expression % env))
                          (:arguments expression)))
     (str "(long)" (emit-index-expression expression env))))
+
+(defn- nested-operations [operations]
+  (mapcat (fn [operation]
+            (cons operation
+                  (when-let [nested (:operations operation)]
+                    (nested-operations nested))))
+          operations))
+
+(def ^:private scalar-builtins
+  (into #{"float" "double" "half" "int" "long" "short" "char"
+          "uint" "ulong" "ushort" "uchar" "if"}
+        (comp (filter string?) (filter #(re-matches #"[A-Za-z_][A-Za-z0-9_]*" %)))
+        (vals ce/op-map)))
+
+(defn- validate-emitted-scalar-calls!
+  [region emitted]
+  (let [calls (into #{} (map second) (re-seq #"\b([A-Za-z_][A-Za-z0-9_]*)\s*\(" emitted))
+        ;; rstr_dp4a is accompanied by a helper in general kernels, but matrix store regions do not
+        ;; inject helper source. Keep the scalar-region target vocabulary self-contained.
+        unsupported (set/difference calls (disj scalar-builtins "rstr_dp4a"))]
+    (when (seq unsupported)
+      (throw (ex-info "OpenCL scalar region contains calls without a typed target lowering"
+                      {:reason :scalar-region-opencl-call-unsupported
+                       :calls (vec (sort unsupported)) :region region})))
+    emitted))
+
+(defn- scalar-tag [dtype]
+  (symbol (name dtype)))
+
+(defn- array-tag [dtype]
+  (symbol (str (name dtype) "s")))
+
+(defn- lower-scalar-region
+  [kernel-body region]
+  (let [parameters (into {} (map (juxt :id identity)) (:parameters kernel-body))
+        operand-ids (set (map :sym (:operands region)))
+        scalar-ids (remove operand-ids (rest (:parameters region)))
+        free-syms (subvec (vec (get-in kernel-body [:attributes :axis-symbols])) 0 2)
+        [i-sym j-sym] free-syms
+        ctype (dtype/ctype :opencl (:result-dtype region))
+        array-syms (set (map (comp #(symbol (name %)) :sym) (:operands region)))
+        int-vars (into #{} (map #(symbol (name %))) free-syms)
+        indices (into {} (map (juxt :sym (comp axis-map/index-expr :map)))
+                      (:operands region))
+        expression (descriptor/rewrite-aget-indices (:expression region) indices)
+        accumulator (first (:parameters region))
+        accumulator-token (str "__acc_" (name (gensym "")))
+        typed-parameters
+        (into {}
+              (for [id (rest (:parameters region))
+                    :let [parameter (get parameters id)]]
+                [id (with-meta (symbol (name id))
+                      {:raster.type/tag (if (= :scalar (:kind parameter))
+                                          (scalar-tag (:dtype parameter))
+                                          (array-tag (:dtype parameter)))})]))
+        replacements (assoc typed-parameters accumulator
+                            (with-meta (symbol accumulator-token)
+                              {:raster.type/tag (scalar-tag (:result-dtype region))}))
+        emitted (validate-emitted-scalar-calls!
+                 region
+                 (binding [ce/*emit-config* ce/opencl-config
+                           ce/*scalar-type* ctype
+                           ce/*int-vars* (into ce/*int-vars* int-vars)]
+                   (ce/emit-expr
+                    (walk/postwalk-replace replacements expression)
+                    (gensym "z__") array-syms)))
+        params (apply str
+                      (concat
+                       (for [{:keys [sym dtype] :or {dtype :float}} (:operands region)]
+                         (str ", __global const " (dtype/ctype :opencl dtype)
+                              "* restrict " (ce/c-symbol sym)))
+                       (for [id scalar-ids
+                             :let [parameter (get parameters id)]]
+                         (str ", " (dtype/ctype :opencl (:dtype parameter))
+                              " " (ce/c-symbol id)))))]
+    {:epilogue (fn [accumulator-expression row col]
+                 (-> emitted
+                     (str/replace accumulator-token (str "(" accumulator-expression ")"))
+                     (str/replace (re-pattern (str "\\b" (ce/c-symbol i-sym) "\\b")) row)
+                     (str/replace (re-pattern (str "\\b" (ce/c-symbol j-sym) "\\b")) col)))
+     :epilogue-params params
+     :region region}))
+
+(defn lower-store-region
+  "Lower the one verified ScalarRegion shared by all matrix stores to OpenCL scalar syntax.
+
+  Returns nil for identity stores. This is a target lowering of typed KernelBody data: callers
+  never supply source callbacks, parameter declaration strings, or helper source."
+  [kernel-body]
+  (let [kernel-body (body/validate! kernel-body)
+        stores (filter #(record-kind? "TileStore" %)
+                       (nested-operations (:operations kernel-body)))
+        regions (distinct (map :value-region stores))]
+    (when-not (= 1 (count regions))
+      (throw (ex-info "all matrix tile stores must carry the same scalar region"
+                      {:reason :raster/bug :regions (vec regions)})))
+    (when-let [region (first regions)]
+      (lower-scalar-region kernel-body region))))
 
 (defn- only!
   [owner values]
@@ -564,7 +668,11 @@
 (defn emit-matrix-kernel
   "Lower a verified f16 DPAS KernelBody directly to OpenCL C.
 
-  `target-store` is the already type-checked scalar-region target spelling
-  `{:epilogue fn :epilogue-params string}`.  It is nil for an identity store."
-  [kernel-name kernel-body target-store]
-  (emit-plan kernel-name (matrix-plan kernel-body) (or target-store {})))
+  ScalarRegion stores are lowered as part of this boundary. The optional target map contains only
+  target naming policy; it cannot inject source or replace the store expression."
+  ([kernel-name kernel-body]
+   (emit-matrix-kernel kernel-name kernel-body {}))
+  ([kernel-name kernel-body {:keys [parameter-names]}]
+   (emit-plan kernel-name (matrix-plan kernel-body)
+              (assoc (or (lower-store-region kernel-body) {})
+                     :parameter-names parameter-names))))

--- a/src/raster/compiler/backend/gpu/opencl_codegen.clj
+++ b/src/raster/compiler/backend/gpu/opencl_codegen.clj
@@ -650,11 +650,11 @@
 ;; ================================================================
 
 (defn emit-gemm-tiled
-  "Legacy tile-parametric XMX GEMM oracle and opaque-epilogue generator.
+  "Independent tile-parametric XMX GEMM source oracle.
 
    Ordinary direct/tiled, split-K, and batched GEMM lower from a verified KernelBody. This
-   independent generator stays executable for source-equivalence checks and opaque-helper
-   epilogues until those helpers become typed scalar regions.
+   independent generator stays executable for source-equivalence checks. Production compiler and
+   resident routes lower verified KernelBody values instead.
 
    Computes C = A·B with FP16 inputs and FP32 accumulation. The tile geometry
    (workgroup BLOCK_M×BLOCK_N, per-subgroup SG_M×SG_N, K-step BLOCK_K, prefetch depth) is COMPUTED,
@@ -667,7 +667,7 @@
    full boundary checking; supports alpha/beta, c-dtype, split-k? (grid-z partials) and batched?
    (grid-z slabs)."
   [kernel-name & {:keys [block-m block-n sg-m sg-n block-k matrix alpha beta c-dtype split-k? schedule-splits-arg? batched? prefetch
-                         epilogue epilogue-params epilogue-helpers]
+                         epilogue epilogue-params]
                   :or {block-m 128 block-n 128 sg-m 32 sg-n 32 block-k 32
                        matrix {:m 8 :n 16 :k 16 :subgroup 16}
                        alpha 1.0 beta 0.0 c-dtype :half split-k? false batched? false prefetch 3}}]
@@ -675,9 +675,8 @@
   ;; transforms the accumulator value into the stored value — a bias/activation/residual/dequant
   ;; folded into the store slot (which already has row/col in scope), eliminating a separate
   ;; elementwise kernel + a DRAM round-trip of C. `epilogue-params` is a C param-decl string for the
-  ;; epilogue's operand arrays (e.g. ", __global const float* restrict bias"); `epilogue-helpers` is
-  ;; C source prepended (e.g. a silu_f definition). When `epilogue` is nil the emitted string is
-  ;; byte-identical to the plain GEMM. Mutually exclusive with beta≠0 (an accumulating store).
+  ;; epilogue's operand arrays (e.g. ", __global const float* restrict bias"). When `epilogue` is nil
+  ;; the emitted string is byte-identical to the plain GEMM. Mutually exclusive with beta≠0.
   (let [{mi :m ni :n ki :k sg :subgroup} matrix]
     (doseq [[nm a b] [["sg-m/M_i" sg-m mi] ["sg-n/N_i" sg-n ni] ["block-m/sg-m" block-m sg-m]
                       ["block-n/sg-n" block-n sg-n] ["block-k/K_i" block-k ki]]]
@@ -713,7 +712,6 @@
       (str
        "#pragma OPENCL EXTENSION cl_intel_subgroup_matrix_multiply_accumulate : enable\n"
        "#pragma OPENCL EXTENSION cl_intel_subgroup_2d_block_io : enable\n\n"
-       (when epilogue-helpers (str epilogue-helpers "\n"))
        "// Tiled GEMM (parametric): WG " block-m "x" block-n ", SG " sg-m "x" sg-n ", K " block-k
        ", DPAS " mi "x" ni "x" ki ", sg " sg "\n"
        "__attribute__((intel_reqd_sub_group_size(" sg ")))\n"

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -13,7 +13,6 @@
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
             [raster.compiler.core.dtype :as dt]
-            [raster.compiler.backend.intrinsics :as intrinsics]
             [raster.compiler.core.hardware :as hw]
             [raster.compiler.ir.axis-map :as am]
             [raster.compiler.ir.contract-stages :as cstage]
@@ -1206,15 +1205,6 @@
         (catch clojure.lang.ExceptionInfo e
           {:ok false :reason :not-a-contraction :msg (.getMessage e)})))))
 
-(def ^:private epilogue-forbidden-ops
-  "Ops that cannot appear in a store-spliced epilogue because they force a distribution/layout
-   change of the accumulator (Triton's blocked-only / anchor set): a scan, a NON-associative
-   reduction, a permuting reshape, or an atomic. An associative reduction is not forbidden outright
-   — it is a RE-TILING decision (distribute the accumulator so the reduction is warp-local) which
-   we do not implement yet, so it is refused here with its own reason."
-  '#{raster.par/scan raster.par/scan-exclusive raster.par/scatter! raster.par/reduce-by-key
-     raster.par/reduce raster.par/reduce-into raster.par/contract})
-
 (defn epilogue-legal?
   "Legality of splicing `expr` into the contraction's STORE slot. Returns {:ok true} or
    {:ok false :reason kw}. Distilled from Halide / XLA / Triton / MLIR-linalg:
@@ -1229,19 +1219,8 @@
        with :reduction-in-epilogue rather than silently miscompiled.
      • the accumulator must appear exactly ONCE: more than one use duplicates the reduction result
        through the epilogue expression, which is the recompute case the ceilings guard against."
-  [{:keys [acc expr]}]
-  (let [nodes (tree-seq coll? seq expr)
-        heads (into #{} (keep #(when (seq? %) (first %))) nodes)
-        acc-uses (count (filter #(= acc %) nodes))]
-    (cond
-      (zero? acc-uses)                     {:ok false :reason :epilogue-ignores-accumulator}
-      (> acc-uses 1)                       {:ok false :reason :accumulator-used-more-than-once}
-      (some #{'raster.par/reduce 'raster.par/reduce-into} heads)
-      {:ok false :reason :reduction-in-epilogue}
-      (seq (clojure.set/intersection heads epilogue-forbidden-ops))
-      {:ok false :reason :layout-changing-op-in-epilogue
-       :ops (clojure.set/intersection heads epilogue-forbidden-ops)}
-      :else {:ok true})))
+  [epilogue]
+  (kbody/scalar-region-legal? epilogue))
 
 (defn epilogue-cost
   "Byte-traffic model for splicing an epilogue into the contraction's store, and the register
@@ -1293,13 +1272,15 @@
      {:acc  acc            ;; symbol standing for the contraction's accumulator
       :expr <s-expr>       ;; e.g. (raster.numeric/* (raster.numeric/+ acc (aget bias j)) s)
       :operands [{:sym bias :map <axis-map over the FREE axes> :dtype :float}]
-      :scalars  [{:sym s :dtype :float}]      ;; optional uniform scalars
-      :helpers  <C source string>}  ;; optional, prepended (e.g. a silu_f definition)
+      :scalars  [{:sym s :dtype :float}]}      ;; optional uniform scalars
 
    `free-syms` are the contraction's two free-axis symbols, bound to the store slot's `row`/`col`
    C variables — so an operand's axis-map generates its index exactly as in the kernel body.
-   Returns {:epilogue fn :epilogue-params str :epilogue-helpers str|nil}."
+   Returns {:epilogue fn :epilogue-params str}. Raw target helper source is not an IR."
   [{:keys [acc expr operands scalars helpers] :as spec} [i-sym j-sym] dtype]
+  (when (seq helpers)
+    (throw (ex-info "epilogue helper source has no typed scalar-region representation"
+                    {:reason :opaque-epilogue-helper})))
   (let [legal (epilogue-legal? spec)
         _ (when-not (:ok legal)
             (throw (ex-info (str "epilogue-splice: illegal epilogue (" (:reason legal) ")")
@@ -1330,50 +1311,11 @@
                      (str/replace acc-token (str "(" acc-expr ")"))
                      (str/replace (re-pattern (str "\\b" (ce/c-symbol i-sym) "\\b")) row)
                      (str/replace (re-pattern (str "\\b" (ce/c-symbol j-sym) "\\b")) col)))
-     :epilogue-params params
-     :epilogue-helpers helpers}))
-
-(defn- nested-kernel-operations [operations]
-  (mapcat (fn [operation]
-            (cons operation
-                  (when-let [nested (:operations operation)]
-                    (nested-kernel-operations nested))))
-          operations))
-
-(defn- kernel-body-store-splice
-  "Lower the typed ScalarRegion attached to KernelBody stores into the existing OpenCL scalar
-  expression vocabulary.  Matrix emission itself never sees the source contraction or epilogue
-  descriptor; its only target-specific input is this spelling of the store region."
-  [kernel-body]
-  (let [stores (filter #(instance? raster.compiler.ir.kernel_body.TileStore %)
-                       (nested-kernel-operations (:operations kernel-body)))
-        regions (distinct (map :value-region stores))]
-    (when-not (= 1 (count regions))
-      (throw (ex-info "all matrix tile stores must carry the same scalar region"
-                      {:reason :raster/bug :regions (vec regions)})))
-    (when-let [region (first regions)]
-      (let [operand-ids (set (map :sym (:operands region)))
-            scalar-ids (remove operand-ids (rest (:parameters region)))
-            parameters (into {} (map (juxt :id identity)) (:parameters kernel-body))
-            scalars (mapv (fn [id]
-                            (let [parameter (or (get parameters id)
-                                                (throw (ex-info "scalar region parameter is absent from the kernel ABI"
-                                                                {:reason :raster/bug
-                                                                 :parameter id})))]
-                              {:sym id :dtype (:dtype parameter)}))
-                          scalar-ids)
-            spec {:acc (first (:parameters region))
-                  :expr (:expression region)
-                  :operands (:operands region)
-                  :scalars scalars}
-            target (epilogue-splice spec
-                                    (subvec (vec (get-in kernel-body [:attributes :axis-symbols])) 0 2)
-                                    (:result-dtype region))]
-        (assoc target :spec spec)))))
+     :epilogue-params params}))
 
 (defn- emit-dpas-plan
-  "Lower one already-checked DPAS plan.  A KernelBody takes the direct operation lowerer; nil uses
-  the legacy template solely for the independent oracle and opaque-helper compatibility path."
+  "Lower one already-checked DPAS plan. A KernelBody takes the direct operation lowerer; nil is
+  reserved for the independent source oracle."
   [kernel-name row-arr col-arr out-sym [M N L] [i-sym j-sym] tile epilogue kernel-body]
   (let [effective-tile (if kernel-body (:schedule kernel-body) tile)
         result-dtype (if kernel-body
@@ -1382,12 +1324,12 @@
                        :half)
         sg (long (get-in effective-tile [:matrix :subgroup] 16))
         ep (if kernel-body
-             (kernel-body-store-splice kernel-body)
+             (kernel-body-opencl/lower-store-region kernel-body)
              (when epilogue
                (epilogue-splice epilogue [i-sym j-sym] (get epilogue :dtype :float))))
-        effective-epilogue (or (:spec ep) epilogue)
+        effective-epilogue (or epilogue (get-in kernel-body [:attributes :epilogue]))
         source (if kernel-body
-                 (kernel-body-opencl/emit-matrix-kernel kernel-name kernel-body ep)
+                 (kernel-body-opencl/emit-matrix-kernel kernel-name kernel-body)
                  (apply codegen/emit-gemm-tiled kernel-name
                         (concat [:c-dtype :half
                                  :block-m (:block-m effective-tile)
@@ -1396,8 +1338,7 @@
                                  :block-k (:block-k effective-tile) :matrix (:matrix effective-tile)
                                  :prefetch (:num-stages effective-tile 3)]
                                 (when ep [:epilogue (:epilogue ep)
-                                          :epilogue-params (:epilogue-params ep)
-                                          :epilogue-helpers (:epilogue-helpers ep)]))))]
+                                          :epilogue-params (:epilogue-params ep)]))))]
     (cond->
      {:kernel-name kernel-name
       :source source
@@ -1450,8 +1391,8 @@
   "Legacy direct entry to the proven DPAS/XMX OpenCL emitter.
 
    Production canonical f16 contractions now travel through ContractionFacts and a scheduled
-   KernelBody before reaching `generate-dpas-kernel-body`.  This entry remains as the source oracle
-   for the direct operation lowerer and for opaque epilogue helpers that have not yet become typed scalar IR.
+   KernelBody before reaching `generate-dpas-kernel-body`. This entry remains only as the
+   independent source oracle for the direct operation lowerer.
    Its legality analysis determines operand orientation and launch dimensions; the emitted body is
    f16 input, f32 accumulation and f16 output with a tile-parametric K16 matrix instruction.
 
@@ -1740,7 +1681,6 @@
                  ;; registry-driven, not `(intrinsics/descriptor 'dp4a)`: define every intrinsic
                  ;; helper this body actually calls — the same scan every other emitter uses
              (ce/intrinsic-helper-sources nest)
-             (when ep (:epilogue-helpers ep))
              "__kernel void " kernel-name "(" params ") {\n"
              "    int seg = get_global_id(0);\n"
              "    if (seg >= _nseg) return;\n"

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -4,7 +4,9 @@
   SegOps retain algorithmic semantics.  A KernelBody is the result of applying a concrete
   schedule: hardware indices, named layouts, masks, fragment operations and loop structure are
   explicit, but target spellings such as Intel DPAS, CUDA WMMA or AMD MFMA are not.  Backends lower
-  these values to their own dialect; they must not recover a schedule by inspecting source text.")
+  these values to their own dialect; they must not recover a schedule by inspecting source text."
+  (:require [clojure.set :as set]
+            [raster.compiler.ir.axis-map :as axis-map]))
 
 (defrecord KernelParameter [id kind dtype shape memory-space layout role])
 (defrecord BufferView [id buffer element-offset shape layout])
@@ -57,6 +59,36 @@
     (throw (ex-info "kernel predicate has an unsupported operation"
                     {:operation op :arguments arguments})))
   (->Predicate op (vec arguments)))
+
+(def ^:private scalar-region-forbidden-ops
+  '#{raster.par/scan raster.par/scan-exclusive raster.par/scatter! raster.par/reduce-by-key
+     raster.par/reduce raster.par/reduce-into raster.par/contract})
+
+(defn scalar-region-legal?
+  "Check whether a scalar expression can execute once in a tile store without changing layout.
+
+  Accepts either a ScalarRegion or the source epilogue descriptor used before scheduling."
+  [region]
+  (let [accumulator (or (:acc region) (first (:parameters region)))
+        expression (or (:expr region) (:expression region))
+        nodes (tree-seq coll? seq expression)
+        heads (into #{} (keep #(when (seq? %) (first %))) nodes)
+        accumulator-uses (count (filter #(= accumulator %) nodes))]
+    (cond
+      (zero? accumulator-uses)
+      {:ok false :reason :epilogue-ignores-accumulator}
+
+      (> accumulator-uses 1)
+      {:ok false :reason :accumulator-used-more-than-once}
+
+      (some #{'raster.par/reduce 'raster.par/reduce-into} heads)
+      {:ok false :reason :reduction-in-epilogue}
+
+      (seq (set/intersection heads scalar-region-forbidden-ops))
+      {:ok false :reason :layout-changing-op-in-epilogue
+       :ops (set/intersection heads scalar-region-forbidden-ops)}
+
+      :else {:ok true})))
 
 (defn- expression? [value]
   (cond
@@ -115,8 +147,76 @@
 
 (declare validate-operations!)
 
+(defn- axis-map!
+  [operand]
+  (let [groups (get-in operand [:map :groups])]
+    (when-not (and (vector? groups) (seq groups)
+                   (every? #(and (vector? %) (seq %)
+                                 (every? (fn [pair]
+                                           (and (vector? pair) (= 2 (count pair))
+                                                (value-id? (first pair))
+                                                (or (value-id? (second pair))
+                                                    (and (integer? (second pair))
+                                                         (pos? (second pair))))))
+                                         %))
+                           groups))
+      (throw (ex-info "scalar-region operand requires a structured axis map"
+                      {:operand operand})))
+    (axis-map/shape (:map operand))))
+
+(defn- validate-scalar-region!
+  [region storage epilogue-abi]
+  (when-not (record-kind? "raster.compiler.ir.kernel_body.ScalarRegion" region)
+    (throw (ex-info "tile-store value region must be a ScalarRegion" {:region region})))
+  (let [parameters (:parameters region)
+        operands (:operands region)
+        operand-ids (when (vector? operands) (mapv :sym operands))]
+    (when-not (and (vector? parameters) (seq parameters)
+                   (every? symbol? parameters)
+                   (= (count parameters) (count (set parameters)))
+                   (vector? operands)
+                   (<= (inc (count operand-ids)) (count parameters))
+                   (some? (:expression region))
+                   (keyword? (:result-dtype region)))
+      (throw (ex-info "tile-store scalar region is incomplete or has ambiguous parameters"
+                      {:region region})))
+    (let [accumulator (first parameters)
+          scalar-ids (subvec parameters (inc (count operand-ids)))]
+      (when-not (and (= operand-ids (subvec parameters 1 (inc (count operand-ids))))
+                     (= (count operand-ids) (count (set operand-ids))))
+        (throw (ex-info "scalar-region operands must be an ordered prefix of its ABI parameters"
+                        {:region region :operand-ids operand-ids})))
+      (when (contains? storage accumulator)
+        (throw (ex-info "scalar-region accumulator must be region-local"
+                        {:accumulator accumulator})))
+      (when-not (= epilogue-abi (vec (rest parameters)))
+        (throw (ex-info "scalar-region parameters and the epilogue ABI disagree"
+                        {:parameters (vec (rest parameters))
+                         :epilogue-abi epilogue-abi})))
+      (doseq [operand operands]
+        (let [id (:sym operand)
+              parameter (get storage id)
+              shape (axis-map! operand)]
+          (when-not (and parameter (= :input (:kind parameter))
+                         (= :epilogue (:role parameter))
+                         (= (:dtype operand :float) (:dtype parameter))
+                         (= shape (:shape parameter)))
+            (throw (ex-info "scalar-region operand and its kernel ABI slot disagree"
+                            {:operand operand :parameter parameter :shape shape})))))
+      (doseq [id scalar-ids]
+        (let [parameter (get storage id)]
+          (when-not (and parameter (= :scalar (:kind parameter))
+                         (= :epilogue (:role parameter)))
+            (throw (ex-info "scalar-region scalar and its kernel ABI slot disagree"
+                            {:scalar id :parameter parameter})))))
+      (let [legal (scalar-region-legal? region)]
+        (when-not (:ok legal)
+          (throw (ex-info "tile-store scalar region is not store-local"
+                          (assoc legal :region region)))))
+      region)))
+
 (defn- validate-operation!
-  [operation storage fragments masks scope]
+  [operation storage fragments masks scope epilogue-abi]
   (let [parameter (fn [id]
                     (or (get storage id)
                         (throw (ex-info "kernel operation references an undeclared parameter"
@@ -217,12 +317,12 @@
           (throw (ex-info "kernel loop induction value shadows an existing value"
                           {:index (:index operation) :scope scope})))
         (validate-operations! (:operations operation) storage fragments masks
-                              (conj scope (:index operation))))
+                              (conj scope (:index operation)) epilogue-abi))
 
       (record-kind? "raster.compiler.ir.kernel_body.Guard" operation)
       (do
         (mask (:mask operation))
-        (validate-operations! (:operations operation) storage fragments masks scope))
+        (validate-operations! (:operations operation) storage fragments masks scope epilogue-abi))
 
       (record-kind? "raster.compiler.ir.kernel_body.TileStore" operation)
       (let [p (parameter (:buffer operation))
@@ -234,23 +334,19 @@
         (coordinates! "tile-store" (:coordinates operation))
         (mask (:mask operation))
         (when-let [region (:value-region operation)]
-          (when-not (record-kind? "raster.compiler.ir.kernel_body.ScalarRegion" region)
-            (throw (ex-info "tile-store value region must be a ScalarRegion" {:region region})))
-          (when-not (and (vector? (:parameters region)) (seq (:parameters region))
-                         (some? (:expression region)) (keyword? (:result-dtype region)))
-            (throw (ex-info "tile-store scalar region is incomplete" {:region region})))))
+          (validate-scalar-region! region storage epilogue-abi)))
 
       :else
       (throw (ex-info "kernel body contains an unsupported operation"
                       {:operation operation :actual (type operation)})))))
 
-(defn- validate-operations! [operations storage fragments masks scope]
+(defn- validate-operations! [operations storage fragments masks scope epilogue-abi]
   (when-not (vector? operations)
     (throw (ex-info "kernel operations must be an ordered vector" {:operations operations})))
   (doseq [operation operations]
     (when-not (operation? operation)
       (throw (ex-info "kernel body contains a non-operation value" {:operation operation})))
-    (validate-operation! operation storage fragments masks scope)))
+    (validate-operation! operation storage fragments masks scope epilogue-abi)))
 
 (defn validate!
   "Verify a scheduled KernelBody and return it unchanged."
@@ -388,7 +484,8 @@
                             storage
                             (into {} (map (juxt :id identity)) fragments)
                             (into {} (map (juxt :id identity)) masks)
-                            index-scope)))
+                            index-scope
+                            (mapv :id (filter #(= :epilogue (:role %)) parameters)))))
   body)
 
 (defn make

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -477,15 +477,9 @@
       (let [sr (delay (cl/contract-form->segred contract-form :dtype dtype))
             scheduled (contraction-schedule/plan-matrix-body contract-facts desc tile
                                                              {:operation-id operation-id})
-         ;; Existing epilogues may still carry an opaque target helper.  They retain the proven
-         ;; emitter until that helper is represented as typed scalar IR; all ordinary expressions
-         ;; take the scheduled KernelBody route now.
-            dpas (if (= :opaque-epilogue-helper (:reason scheduled))
-                   (sco/generate-dpas-contraction-kernel @sr out-sym :dtype dtype :desc desc :tile tile
-                                                         :epilogue epilogue)
-                   (if (:ok scheduled)
-                     (sco/generate-dpas-kernel-body (:body scheduled) out-sym)
-                     {:tensorized false :reason (:reason scheduled) :detail scheduled}))]
+            dpas (if (:ok scheduled)
+                   (sco/generate-dpas-kernel-body (:body scheduled) out-sym)
+                   {:tensorized false :reason (:reason scheduled) :detail scheduled})]
         (when-not (:tensorized dpas)
           (note! (decline :dpas (:reason dpas) nil (dissoc dpas :tensorized :reason))))
         (if (:tensorized dpas)

--- a/src/raster/compiler/passes/parallel/contraction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/contraction_schedule.clj
@@ -330,9 +330,8 @@
        (not (zero? (mod (long K) (long matrix-k))))
        (decline :partial-matrix-k-fragment {:K K :matrix-k matrix-k})
 
-      ;; Helpers are target source pasted above the kernel.  Keeping them out is what makes the
-      ;; KernelBody store region typed rather than an opaque C escape hatch.  Existing emission
-      ;; remains available while helper expressions are promoted into the scalar expression IR.
+      ;; Helper strings are target source pasted above a kernel and have no KernelBody meaning.
+      ;; Refuse them so callers express the computation in the typed scalar expression instead.
        (seq (:helpers epilogue))
        (decline :opaque-epilogue-helper)
 

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -1308,12 +1308,12 @@
 
 (defn- emit-scheduled-gemm
   "Ask the compiler for the shared scheduled matrix body and its direct OpenCL lowering."
-  [kernel-name c-dtype tile]
+  [kernel-name c-dtype tile epilogue]
   ((requiring-resolve 'raster.compiler.backend.gpu.gemm/emit-scheduled-matrix-kernel)
    {:kernel-name kernel-name
     :id [:resident-gemm kernel-name]
     :a 'A :b 'B :c 'C :m 'M :n 'N :k 'K
-    :tile tile :result-dtype c-dtype
+    :tile tile :result-dtype c-dtype :epilogue epilogue
     :provenance {:dialect :resident-runtime}}))
 
 (defn- emit-scheduled-split-k-gemm
@@ -1351,7 +1351,7 @@
   (or (get @gemm-cache c-dtype)
       (let [kname (str "gemm_nonsquare_" (name c-dtype))
             tile (gemm-tile)
-            emitted (emit-scheduled-gemm kname c-dtype tile)
+            emitted (emit-scheduled-gemm kname c-dtype tile nil)
             cl-src (:source emitted)
             device-hex (:device-id-hex @state)
             spv (do (require 'raster.compiler.support.spirv-cache)
@@ -2203,7 +2203,7 @@
   (ensure-init!)
   (or (get @gemm-tiled-cache [c-dtype tile])
       (let [kname (str "gemm_tiled_" (name c-dtype) "_" (tile-signature tile))
-            emitted (emit-scheduled-gemm kname c-dtype tile)
+            emitted (emit-scheduled-gemm kname c-dtype tile nil)
             cl-src (:source emitted)
             spv (do (require 'raster.compiler.support.spirv-cache)
                     ((resolve 'raster.compiler.support.spirv-cache/compile-opencl-to-spirv)
@@ -2236,50 +2236,99 @@
     (.set gc I32 8 (int 1))
     bnd))
 
-;; ── FUSED-EPILOGUE GEMM (feature 4 — C = epilogue(A·B, row, col)) ───────────────
-;; One kernel for GEMM + a same-position elementwise consumer (bias/act/residual), the
-;; training-M win (~15-18% at M≥512, measured). The epilogue is BAKED into the kernel at
-;; emit time (emit-gemm-tiled :epilogue) and its operand buffers appended to the launch args.
+;; ── FUSED-EPILOGUE GEMM (C = ScalarRegion(A·B, row, col)) ──────────────────────
+;; One typed KernelBody for GEMM + a same-position elementwise consumer (bias/act/residual), the
+;; training-M win (~15-18% at M≥512, measured). Runtime bindings remain separate from the scalar
+;; program so cache identity and ABI order come from compiler data rather than source strings.
 (def ^:private gemm-epilogue-cache (atom {}))
 
+(defn- resident-epilogue-program
+  [epilogue]
+  (let [allowed #{:acc :expr :operands :scalars :dtype :bindings}
+        unsupported (seq (remove allowed (keys epilogue)))]
+    (when unsupported
+      (throw (ex-info "resident GEMM epilogue contains unsupported fields"
+                      {:unsupported (vec unsupported) :allowed allowed})))
+    (when-not (map? (:bindings epilogue))
+      (throw (ex-info "resident GEMM epilogue requires explicit runtime bindings"
+                      {:epilogue epilogue})))
+    (dissoc epilogue :bindings)))
+
 (defn- ensure-gemm-epilogue-kernel!
-  "Compile + cache a GEMM kernel with a fused epilogue, keyed by [c-dtype tile epi-key].
-   `epilogue` is {:key :params :fn :helpers} (the emit-gemm-tiled :epilogue* args)."
-  [c-dtype tile {:keys [key params fn helpers]}]
+  "Compile and cache a typed ScalarRegion GEMM by its structural program, output dtype and tile."
+  [c-dtype tile epilogue]
   (ensure-init!)
-  (or (get @gemm-epilogue-cache [c-dtype tile key])
-      (let [kname (str "gemm_epi_" (name key) "_" (name c-dtype) "_" (tile-signature tile))
-            emit  (do (require 'raster.compiler.backend.gpu.opencl-codegen)
-                      (resolve 'raster.compiler.backend.gpu.opencl-codegen/emit-gemm-tiled))
-            cl-src (apply emit kname :c-dtype c-dtype :prefetch (:num-stages tile 3)
-                          :epilogue fn :epilogue-params params :epilogue-helpers helpers
-                          (mapcat identity (select-keys tile [:block-m :block-n :sg-m :sg-n :block-k :matrix])))
-            spv (do (require 'raster.compiler.support.spirv-cache)
-                    ((resolve 'raster.compiler.support.spirv-cache/compile-opencl-to-spirv)
-                     cl-src :device (:device-id-hex @state)))
-            module (load-module! spv)
-            entry {:module module :kernel-name kname}]
-        (swap! gemm-epilogue-cache assoc [c-dtype tile key] entry)
-        entry)))
+  (let [program (resident-epilogue-program epilogue)
+        cache-key [c-dtype tile program]]
+    (or (get @gemm-epilogue-cache cache-key)
+        (let [program-id (Integer/toUnsignedString (hash program) 16)
+              kname (str "gemm_epi_" program-id "_" (name c-dtype) "_" (tile-signature tile))
+              emitted (emit-scheduled-gemm kname c-dtype tile program)
+              cl-src (:source emitted)
+              spv (do (require 'raster.compiler.support.spirv-cache)
+                      ((resolve 'raster.compiler.support.spirv-cache/compile-opencl-to-spirv)
+                       cl-src :device (:device-id-hex @state)))
+              module (load-module! spv)
+              entry {:module module :kernel-name kname :tile tile :program program
+                     :kernel-body (:kernel-body emitted)
+                     :workgroup (:workgroup-size emitted)}]
+          (swap! gemm-epilogue-cache assoc cache-key entry)
+          entry))))
+
+(defn- resident-epilogue-argument
+  [parameter value]
+  (case (:kind parameter)
+    :input
+    (do
+      (when-not (instance? DeviceBuffer value)
+        (throw (ex-info "resident epilogue buffer binding is not a DeviceBuffer"
+                        {:parameter parameter :actual (type value)})))
+      (when-not (= (dt/canon (:dtype parameter)) (dt/canon (:dtype value)))
+        (throw (ex-info "resident epilogue buffer dtype differs from its KernelBody ABI"
+                        {:parameter parameter :actual (:dtype value)})))
+      (:segment value))
+
+    :scalar
+    {:type (case (dt/canon (:dtype parameter))
+             :int8 :byte
+             :byte :byte
+             :half :half
+             :float :float
+             :double :double
+             :int :int
+             :long :long
+             (throw (ex-info "resident epilogue scalar dtype is unsupported"
+                             {:parameter parameter})))
+     :value value}
+
+    (throw (ex-info "resident epilogue ABI slot must be input or scalar"
+                    {:parameter parameter}))))
 
 (defn bind-registered-gemm-epilogue!
-  "Bind a fused-epilogue GEMM: C = epilogue(A·B, row, col). `epilogue` is {:key :params :fn :helpers
-   :operands [buffers]} — the operand buffers (bias/residual) are appended to the launch args after
-   (A B C M N K), matching :params. Same launch geometry as bind-registered-gemm-tiled!."
+  "Bind C = ScalarRegion(A·B) using the same typed epilogue descriptor as the compiler.
+
+   `epilogue` contains :acc, :expr, ordered :operands/:scalars, and a :bindings map from each
+   operand/scalar identity to its resident buffer or scalar value. KernelBody owns the physical
+   ABI and launch geometry; target source callbacks and declaration strings are not accepted."
   [a b c m n k c-dtype tile epilogue]
   (when-let [bd (:dtype c)]
     (when (not= bd c-dtype)
       (throw (ex-info (str "bind-registered-gemm-epilogue!: output buffer dtype " bd " ≠ kernel dtype " c-dtype) {}))))
-  (let [{:keys [module kernel-name]} (ensure-gemm-epilogue-kernel! c-dtype tile epilogue)
-        {:keys [block-m block-n sg-m sg-n matrix]} tile
-        sg   (long (:subgroup matrix 16))
-        n-subgroups (* (quot (long block-m) (long sg-m)) (quot (long block-n) (long sg-n)))
-        wg   (* n-subgroups sg)
+  (let [{:keys [module kernel-name kernel-body workgroup]}
+        (ensure-gemm-epilogue-kernel! c-dtype tile epilogue)
+        {:keys [block-m block-n]} tile
+        parameters (filterv #(= :epilogue (:role %)) (:parameters kernel-body))
+        expected (mapv :id parameters)
+        bindings (:bindings epilogue)
+        provided (set (keys bindings))
+        _ (when-not (= (set expected) provided)
+            (throw (ex-info "resident epilogue bindings differ from the KernelBody ABI"
+                            {:expected expected :provided (vec (keys bindings))})))
         kh   (create-kernel-fresh module kernel-name)
         args (vec (concat [(:segment a) (:segment b) (:segment c)
                            {:type :int :value (int m)} {:type :int :value (int n)} {:type :int :value (int k)}]
-                          (map :segment (:operands epilogue))))
-        bnd  (bind-kernel! kh [wg 1] args)
+                          (map #(resident-epilogue-argument % (get bindings (:id %))) parameters)))
+        bnd  (bind-kernel! kh workgroup args)
         gc ^MemorySegment (:gc-seg bnd)]
     (.set gc I32 0 (int (Math/ceil (/ (double n) (double block-n)))))
     (.set gc I32 4 (int (Math/ceil (/ (double m) (double block-m)))))

--- a/test/raster/compiler/backend/gpu/dpas_contract_device_test.clj
+++ b/test/raster/compiler/backend/gpu/dpas_contract_device_test.clj
@@ -7,6 +7,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
             [raster.compiler.passes.parallel.contract-lower :as cl]
+            [raster.compiler.passes.parallel.contract-route :as route]
             [raster.compiler.backend.gpu.segop-opencl :as sco])
   (:import [java.lang.foreign MemorySegment]))
 
@@ -145,11 +146,13 @@
           Ad (double-array (map #(* 0.05 (- (double (mod % 7)) 3.0)) (range (* M K))))
           Bd (double-array (map #(* 0.05 (- (double (mod % 5)) 2.0)) (range (* K N))))
           biasd (float-array (map #(float (* 0.01 (- (mod % 9) 4))) (range N)))
-          sr (cl/contract-form->segred (matmul-form M N K) :dtype :half)
           ep {:acc 'acc
-              :expr (list 'silu_f (list 'raster.numeric/+ 'acc (list 'aget 'bias 'j)))
-              :operands [{:sym 'bias :map (am [['j N]]) :dtype :float}]
-              :helpers "inline float silu_f(float x){ return x / (1.0f + native_exp(-x)); }"}
+              :expr '(let [x (raster.numeric/+ acc (aget bias j))]
+                       (raster.numeric//
+                        x
+                        (raster.numeric/+ 1.0
+                                          (raster.math/exp (raster.numeric/* -1.0 x)))))
+              :operands [{:sym 'bias :map (am [['j N]]) :dtype :float}]}
           run (fn [k extra-args out]
                 (register! (:kernel-name k) {:source (:source k) :dtype :half})
                 (let [{:keys [kernel-handle]} (ensure! (:kernel-name k))
@@ -163,15 +166,18 @@
                                (long (Math/ceil (/ (double M) (:block-m (:tile k)))))]
                               args)
                   (vec (buf->d out))))
-          plain-k (sco/generate-dpas-contraction-kernel sr 'C)
-          fused-k (sco/generate-dpas-contraction-kernel sr 'C :epilogue ep)
+          plain-route (route/route-contraction (matmul-form M N K) :dtype :half)
+          plain-k (assoc plain-route :workgroup (:wg plain-route))
+          fused-route (route/route-contraction
+                       (concat (matmul-form M N K) [:epilogue ep]) :dtype :half)
+          fused-k (assoc fused-route :workgroup (:wg fused-route))
           bias-buf (arr->buf! (make-buffer N :float) biasd)
           unfused (run plain-k [] (make-buffer (* M N) :half))
           fused   (run fused-k [(:segment bias-buf)] (make-buffer (* M N) :half))]
-      (testing "the fused kernel gains the operand param and the helper"
+      (testing "the fused KernelBody gains the operand ABI and a typed scalar region"
         (is (str/includes? (:source fused-k) "restrict bias"))
-        (is (str/includes? (:source fused-k) "silu_f(float x)"))
-        (is (str/includes? (:source fused-k) "silu_f(((acc00.s0) + bias[col]))")
+        (is (not (str/includes? (:source fused-k) "silu_f")))
+        (is (str/includes? (:source fused-k) "float x = ((acc00.s0) + bias[col])")
             "the axis-map's j must bind to the store slot's col"))
       (testing "fused result == unfused GEMM followed by a separate bias+silu pass"
         ;; the two-pass reference: read C back, then apply the epilogue on the host
@@ -202,7 +208,7 @@
              (:reason (sco/epilogue-legal? {:acc 'acc :expr (list 'raster.par/scan 'o 'a 0.0 'i 8 nil 'acc)})))))
     (testing "epilogue-splice itself enforces legality (fails loud, never silently miscompiles)"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"illegal epilogue"
-            (sco/epilogue-splice {:acc 'acc :expr (list 'raster.numeric/* 'acc 'acc)} '[i j] :float))))))
+                            (sco/epilogue-splice {:acc 'acc :expr (list 'raster.numeric/* 'acc 'acc)} '[i j] :float))))))
 
 (deftest epilogue-cost-reflects-the-eliminated-round-trip
   (let [hw (requiring-resolve 'raster.compiler.core.hardware/derive-gemm-tile)
@@ -230,7 +236,7 @@
                        (list 'aget 'B (list '+ (list '* 'l N) 'j))))
         bindings ['C mm
                   'out (list 'raster.par/map! 'out 't (* M N) nil
-                             (list 'silu_f (list 'aget 'C 't)))]]
+                             (list 'raster.math/exp (list 'aget 'C 't)))]]
     (testing "contract + elementwise map collapse into ONE contract carrying an :epilogue"
       (let [r (pf bindings [])
             fused (second (:bindings r))
@@ -240,13 +246,13 @@
         (is (= 'raster.par/contract (first fused)))
         (is (= 'out (second fused)) "the fused contraction writes the map's target directly")
         (is (some? (:epilogue opts)))
-        (is (= (list 'silu_f (:acc (:epilogue opts))) (:expr (:epilogue opts)))
+        (is (= (list 'raster.math/exp (:acc (:epilogue opts))) (:expr (:epilogue opts)))
             "the map body becomes the epilogue, with (aget C t) → the accumulator")))
     (testing "the routed descriptor reports the fusion and splices it into the store"
       (let [fused (second (:bindings (pf bindings [])))
             r (route fused :dtype :half)]
         (is (:fused-epilogue r))
-        (is (str/includes? (:source r) "silu_f((acc00.s0))")
+        (is (re-find #"exp\(.*acc00\.s0" (:source r))
             "the epilogue must appear in the STORE slot, not a second kernel")))
     (testing "a body reading OTHER arrays now fuses too (flat-index→free-axis decomposition)"
       ;; This assertion previously required a REFUSAL. That limitation is gone: an operand's flat

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -3,6 +3,7 @@
             [raster.compiler.backend.gpu.gemm :as gemm]
             [raster.compiler.backend.gpu.opencl-codegen :as opencl-codegen]
             [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-dispatch :as dispatch]
@@ -102,6 +103,43 @@
       (is (re-find #"__global float\* restrict C" (:source emitted)))
       (is (= (get-in emitted [:kernel-body :launch :workgroup-size])
              (:workgroup-size emitted))))))
+
+(deftest typed-epilogue-is-lowered-from-the-shared-body
+  (with-redefs [opencl-codegen/emit-gemm-tiled
+                (fn [& _]
+                  (throw (ex-info "legacy template was called" {:reason :test/failure})))]
+    (let [emitted (gemm/emit-scheduled-matrix-kernel
+                   {:kernel-name "body_epilogue"
+                    :a 'a :b 'b :c 'c :m 'm :n 'n :k 'k
+                    :tile (hardware/derive-gemm-tile {})
+                    :result-dtype :float
+                    :epilogue {:acc 'acc
+                               :expr '(raster.numeric/*
+                                       (raster.numeric/+ acc (aget bias j)) scale)
+                               :operands [{:sym 'bias
+                                           :map (axis-map/of-axes [['j 'n]])
+                                           :dtype :half}]
+                               :scalars [{:sym 'scale :dtype :float}]}})
+          kernel-body (:kernel-body emitted)
+          epilogue-parameters (filterv #(= :epilogue (:role %)) (:parameters kernel-body))
+          region (:value-region
+                  (first (filter #(instance? raster.compiler.ir.kernel_body.TileStore %)
+                                 (tree-seq coll? seq kernel-body))))]
+      (is (= [['bias :input :half] ['scale :scalar :float]]
+             (mapv (juxt :id :kind :dtype) epilogue-parameters)))
+      (is (= ['acc 'bias 'scale] (:parameters region)))
+      (is (re-find #"restrict bias, float scale" (:source emitted)))
+      (is (re-find #"bias\[col\].*scale" (:source emitted))))))
+
+(deftest unresolved-source-helper-calls-are-not-scalar-ir
+  (is (thrown-with-msg?
+       clojure.lang.ExceptionInfo #"without a typed target lowering"
+       (gemm/emit-scheduled-matrix-kernel
+        {:kernel-name "body_undefined_helper"
+         :a 'a :b 'b :c 'c :m 'm :n 'n :k 'k
+         :tile (hardware/derive-gemm-tile {})
+         :result-dtype :float
+         :epilogue {:acc 'acc :expr '(source_helper acc)}}))))
 
 (deftest grid-z-matrix-emission-does-not-call-the-legacy-template
   (let [tile (hardware/derive-gemm-tile {})]

--- a/test/raster/compiler/backend/gpu/gemm_tiled_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_tiled_test.clj
@@ -15,6 +15,7 @@
    The old string generator remains an independent cross-tile oracle in this test. Device-free
    body/source checks live in raster.compiler.backend.gpu.gemm-test."
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.axis-map :as axis-map]
             [raster.dl.gpu-grad-parity :as gp]))
 
 (defn- cpu-gemm-ref
@@ -98,14 +99,18 @@
           mk (fn [s] (let [a (float-array s)] (dotimes [i s] (aset a i (float (* 0.1 (.nextGaussian rng))))) a))
           A (mk (* m k)) B (mk (* k n)) bias (mk n)
           a16 (f16 A) b16 (f16 B) biasbuf (f16 bias) c (MB (* m n) :float)
-          epi {:key :bias :params ", __global const half* restrict bias"
-               :fn (fn [acc _row col] (str acc " + (float)bias[" col "]")) :operands [biasbuf]}]
+          epi {:acc 'acc
+               :expr '(raster.numeric/* (raster.numeric/+ acc (aget bias j)) scale)
+               :operands [{:sym 'bias :map (axis-map/of-axes [['j n]]) :dtype :half}]
+               :scalars [{:sym 'scale :dtype :float}]
+               :bindings {'bias biasbuf 'scale 0.5}}]
       (try
         (RP (RG [{:bound (bind a16 b16 c m n k :float tile epi) :kernel-name "gemm_epi_bias_float"}]))
         (let [gpu (BA c) h (fn [x] (Float/float16ToFloat (Float/floatToFloat16 (float x)))) ref (float-array (* m n))]
           (dotimes [i m] (dotimes [j n]
                            (let [s (loop [p 0 acc 0.0] (if (< p k) (recur (inc p) (+ acc (* (double (h (aget A (+ (* i k) p)))) (double (h (aget B (+ (* p n) j))))))) acc))]
-                             (aset ref (+ (* i n) j) (float (+ s (double (h (aget bias j)))))))))
+                             (aset ref (+ (* i n) j)
+                                   (float (* 0.5 (+ s (double (h (aget bias j))))))))))
           (let [maxrel (reduce max 0.0 (map (fn [a b] (/ (Math/abs (- (double a) (double b))) (+ 0.05 (Math/abs (double b))))) gpu ref))]
             (is (< maxrel 1.0e-3) (str "fused C=A·B+bias must match CPU ref within f16 tol (max-rel " maxrel ")"))))
         (finally (FB a16) (FB b16) (FB biasbuf) (FB c))))))

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -1,6 +1,7 @@
 (ns raster.compiler.ir.kernel-body-test
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.core.layout :as layout]
+            [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.kernel-body :as body]))
 
 (def ^:private matrix {:family :dpas :m 8 :n 16 :k 16 :subgroup 16})
@@ -92,3 +93,33 @@
     (testing "the parent extent is tied to the hardware axis launch bound"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"launch-bounded"
                             (body/validate! (assoc-in viewed [:launch :group-count 0] 15)))))))
+
+(deftest scalar-regions-are-checked-against-the-ordered-kernel-abi
+  (let [region (body/->ScalarRegion
+                ['value 'bias 'scale]
+                '(raster.numeric/* (raster.numeric/+ value (aget bias group-x)) scale)
+                [{:sym 'bias :map (axis-map/of-axes [['group-x 16]]) :dtype :half}]
+                :float)
+        kernel (-> (minimal-body)
+                   (update :parameters into
+                           [(body/->KernelParameter
+                             'bias :input :half [16] :global
+                             (layout/row-major [16] :half) :epilogue)
+                            (body/->KernelParameter 'scale :scalar :float [] nil nil :epilogue)])
+                   (assoc-in [:operations 0 :operations 2 :value-region] region))]
+    (is (= kernel (body/validate! kernel)))
+    (testing "operand identities occupy the ordered prefix after the accumulator"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"ordered prefix"
+                            (body/validate!
+                             (assoc-in kernel [:operations 0 :operations 2 :value-region
+                                               :parameters]
+                                       ['value 'scale 'bias])))))
+    (testing "every region parameter has exactly one epilogue ABI slot"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"epilogue ABI disagree"
+                            (body/validate! (update kernel :parameters pop)))))
+    (testing "an operand map and physical ABI shape cannot drift"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"operand and its kernel ABI slot disagree"
+                            (body/validate!
+                             (assoc-in kernel [:operations 0 :operations 2 :value-region
+                                               :operands 0 :map]
+                                       (axis-map/of-axes [['group-x 8]]))))))))

--- a/test/raster/compiler/passes/parallel/contract_descriptor_validator_test.clj
+++ b/test/raster/compiler/passes/parallel/contract_descriptor_validator_test.clj
@@ -35,20 +35,20 @@
                                      :dtype :double))))
     (is (= :naive-segred (:strategy (route/route-contraction
                                      '(raster.par/contract C [[b 2] [i 4] [j 3]] [[l 5]]
-                                        (* (aget A x) (aget B y))) :dtype :double))))
+                                                           (* (aget A x) (aget B y))) :dtype :double))))
     (is (= :full-reduce  (:strategy (route/route-contraction
                                      '(raster.par/contract O [] [[i 8]] (* (aget A i) (aget B i)))
                                      :dtype :double))))
     (is (= :dp4a         (:strategy (route/route-contraction
                                      '(raster.par/contract C [[i 4] [j 4]] [[l 8]]
-                                        (* (aget A (+ (* i 8) l)) (aget B (+ (* j 8) l))))
+                                                           (* (aget A (+ (* i 8) l)) (aget B (+ (* j 8) l))))
                                      :dtype :byte))))
     (is (= :quant-naive  (:strategy (route/route-contraction
                                      '(raster.par/contract C [[i 4] [j 4]] [[l 8]]
-                                        (* (aget A (+ (* i 8) l)) (aget B (+ (* l 4) j))))
+                                                           (* (aget A (+ (* i 8) l)) (aget B (+ (* l 4) j))))
                                      :dtype :byte)))))
   (testing "fused epilogues, including the operand-carrying shapes"
-    (doseq [[label body] [[:activation (list 'silu_f (list 'aget 'C 't))]
+    (doseq [[label body] [[:activation (list 'raster.math/exp (list 'aget 'C 't))]
                           [:bias  (list 'raster.numeric/+ (list 'aget 'C 't)
                                         (list 'aget 'bias (list 'mod 't 256)))]
                           [:resid (list 'raster.numeric/+ (list 'aget 'C 't) (list 'aget 'R 't))]
@@ -64,21 +64,21 @@
                                       :dtype :half)]
     (testing "bug 2: dropping the epilogue's operand under-describes the kernel"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"pointer params"
-            (route/validate-descriptor (assoc good :epilogue-operands [])))))
+                            (route/validate-descriptor (assoc good :epilogue-operands [])))))
     (testing "bug 1: a scalar-arg count that disagrees with the signature"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"scalar params"
-            (route/validate-descriptor (update good :scalar-args conj {:type :int :value 1}))))
+                            (route/validate-descriptor (update good :scalar-args conj {:type :int :value 1}))))
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"scalar params"
-            (route/validate-descriptor (assoc good :scalar-args [])))))
+                            (route/validate-descriptor (assoc good :scalar-args [])))))
     (testing "the same counts in the wrong order are still an ABI mismatch"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"ordered ABI"
-            (route/validate-descriptor (update good :abi #(vec (reverse %)))))))
+                            (route/validate-descriptor (update good :abi #(vec (reverse %)))))))
     (testing "a missing :out-elems (the invoke sizes the output with it)"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"out-elems"
-            (route/validate-descriptor (dissoc good :out-elems)))))
+                            (route/validate-descriptor (dissoc good :out-elems)))))
     (testing "malformed launch geometry"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"2-element vectors"
-            (route/validate-descriptor (assoc good :grid [4])))))))
+                            (route/validate-descriptor (assoc good :grid [4])))))))
 
 (deftest validator-models-both-invoke-protocols
   (let [red (route/route-contraction '(raster.par/contract O [] [[i 8]] (* (aget A i) (aget B i)))
@@ -93,11 +93,11 @@
       (is (= '[A B O 8] (:arguments red))))
     (testing "…and the validator enforces each of those, so the protocol cannot drift"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must not carry"
-            (route/validate-descriptor (assoc red :wg [256 1]))))
+                            (route/validate-descriptor (assoc red :wg [256 1]))))
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"ordered :abi is required"
-            (route/validate-descriptor (dissoc red :abi))))
+                            (route/validate-descriptor (dissoc red :abi))))
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"requires :reduce-bound"
-            (route/validate-descriptor (dissoc red :reduce-bound)))))))
+                            (route/validate-descriptor (dissoc red :reduce-bound)))))))
 
 (deftest signature-parser-handles-the-real-kernels
   (testing "the parser finds every param of a multi-line DPAS signature"
@@ -108,6 +108,6 @@
   (testing "ABI C names use the emitter's symbol mangling"
     (let [d (route/route-contraction
              '(raster.par/contract out-buffer [[row-index 4]] []
-                (aget input-buffer row-index))
+                                   (aget input-buffer row-index))
              :dtype :double)]
       (is (= ["input_buffer" "out" "_nseg"] (mapv :c-name (:abi d)))))))

--- a/test/raster/compiler/passes/parallel/contraction_schedule_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_schedule_test.clj
@@ -130,6 +130,20 @@
       (is (re-find #"intel_sub_group_f16_f16_matrix_mad_k16" (:source routed)))
       (is (body/kernel-body? (:kernel-body routed))))))
 
+(deftest raw-epilogue-helper-source-never-enters-production-lowering
+  (let [epilogue {:acc 'acc
+                  :expr '(silu_f acc)
+                  :helpers "inline float silu_f(float x) { return x; }"}
+        form (concat (matrix-form 128 128 128) [:epilogue epilogue])
+        scheduled (schedule/plan-matrix-body
+                   (facts/contraction-facts form :dtype :half) nil nil)]
+    (is (= {:ok false :reason :opaque-epilogue-helper} scheduled))
+    (with-redefs [opencl-codegen/emit-gemm-tiled
+                  (fn [& _]
+                    (throw (ex-info "legacy template was called" {:reason :test/failure})))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"has no store splice"
+                            (route/route-contraction form :dtype :half))))))
+
 (deftest direct-lowering-refuses-an-operation-coordinate-that-disagrees-with-the-schedule
   (let [kernel (:body (schedule/plan-matrix-body
                        (facts/contraction-facts (matrix-form 128 128 128) :dtype :half)

--- a/test/raster/compiler/passes/parallel/epilogue_operand_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/epilogue_operand_fusion_test.clj
@@ -69,7 +69,7 @@
           {:keys [store]} (store-line (:form f))]
       (is (str/includes? store "rs[row]"))))
   (testing "an activation-only body still fuses, with no operands"
-    (let [f (fuse (list 'silu_f (list 'aget 'C 't)))
+    (let [f (fuse (list 'raster.math/exp (list 'aget 'C 't)))
           {:keys [epi-ops]} (store-line (:form f))]
       (is (empty? (:operands (:epilogue f))))
       (is (empty? epi-ops)))))

--- a/test/raster/gpu/one_tile_source_test.clj
+++ b/test/raster/gpu/one_tile_source_test.clj
@@ -16,6 +16,7 @@
             [raster.compiler.backend.gpu.gemm :as gemm]
             [raster.compiler.backend.gpu.opencl-codegen :as opencl-codegen]
             [raster.compiler.core.hardware :as hw]
+            [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]))
 
@@ -73,13 +74,39 @@
     (with-redefs [opencl-codegen/emit-gemm-tiled
                   (fn [& _]
                     (throw (ex-info "legacy template was called" {:reason :test/failure})))]
-      (let [emitted (emit-resident "resident_body" :float tile)]
+      (let [emitted (emit-resident "resident_body" :float tile nil)]
         (is (body/kernel-body? (:kernel-body emitted)))
         (is (= :float (:dtype (first (filter #(= :result (:role %))
                                              (get-in emitted [:kernel-body :parameters]))))))
         (is (= (get-in emitted [:kernel-body :launch :workgroup-size])
                (:workgroup-size emitted)))
         (is (re-find #"__global float\* restrict C" (:source emitted)))))))
+
+(deftest resident-epilogues-use-typed-programs-and-body-owned-abi
+  (let [ze (do (require 'raster.gpu.ze-runtime) (find-ns 'raster.gpu.ze-runtime))
+        emit-resident (ns-resolve ze 'emit-scheduled-gemm)
+        resident-program (ns-resolve ze 'resident-epilogue-program)
+        tile (hw/gemm-tile-for nil)
+        program {:acc 'acc
+                 :expr '(raster.numeric/+ acc (aget bias j))
+                 :operands [{:sym 'bias
+                             :map (axis-map/of-axes [['j 'N]])
+                             :dtype :half}]}
+        descriptor (assoc program :bindings {'bias :resident-buffer})]
+    (with-redefs [opencl-codegen/emit-gemm-tiled
+                  (fn [& _]
+                    (throw (ex-info "legacy template was called" {:reason :test/failure})))]
+      (let [emitted (emit-resident "resident_typed_epilogue" :float tile program)]
+        (is (= program (resident-program descriptor)))
+        (is (= [['bias :input :half :epilogue]]
+               (mapv (juxt :id :kind :dtype :role)
+                     (filter #(= :epilogue (:role %))
+                             (get-in emitted [:kernel-body :parameters])))))
+        (is (re-find #"restrict bias" (:source emitted)))
+        (is (re-find #"bias\[col\]" (:source emitted)))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"unsupported fields"
+                          (resident-program {:key :bias :fn identity :params "raw"
+                                             :bindings {}})))))
 
 (deftest resident-grid-z-sources-use-the-scheduled-body
   (let [ze (do (require 'raster.gpu.ze-runtime) (find-ns 'raster.gpu.ze-runtime))


### PR DESCRIPTION
## Summary

- validate ScalarRegion legality, structured operand maps, and exact ordered KernelBody epilogue ABI
- lower typed scalar store regions inside the OpenCL KernelBody backend, rejecting opaque helper/source injection
- bind resident fused GEMM operands and scalars from the same structural program while keeping runtime values out of compiler cache identity
- remove the production fallback to the legacy direct emitter; retain it only as an independent source oracle

## Validation

- 73 compiler/quant/device tests, 379 assertions
- 11 GEMM autotune/source tests, 54 assertions
- real-device typed DPAS activation and resident bias-plus-scale epilogues
- full suite exercised compiler, AD, attention, Gemma/GPT-2/GSDM, and resident training through the late GPU runtime tests; it found one missed tiled-GEMM emitter arity, fixed and covered by the focused autotune rerun
- formatter and git diff checks clean