### PR TITLE
Schedule routed attention with subgroup score reuse

### DIFF
--- a/src/raster/compiler/backend/gpu/attention.clj
+++ b/src/raster/compiler/backend/gpu/attention.clj
@@ -1,15 +1,17 @@
 (ns raster.compiler.backend.gpu.attention
-  "Portable FP16-KV reference lowering for logical attention over dense or CSR paged KV routes.
+  "FP16-KV leaves for logical attention over dense or CSR paged KV routes.
 
-   One work-item owns one output component and recomputes QK. This intentionally slow schedule is
-   the executable semantic oracle for packed queries, GQA, independent K/V layouts and dimensions,
-   logical interval/CSR visibility, and physical page routing."
+   The direct one-work-item/component leaf remains the executable semantic oracle.  A separately
+   validated SegmentedWeightedReductionSchedule emits one subgroup/query-head for dense routed
+   interval attention, sharing each QK score across lane-strided value accumulators without
+   changing the semantic plan, ordered ABI, storage ownership or graph effects."
   (:require [raster.compiler.ir.attention :as attention]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-launch :as klaunch]
-            [raster.compiler.ir.segmented-weighted-reduction :as swr]))
+            [raster.compiler.ir.segmented-weighted-reduction :as swr]
+            [raster.compiler.ir.segmented-weighted-reduction-schedule :as swr-schedule]))
 
 (defn- attention-problem
   [plan]
@@ -76,24 +78,26 @@
     (long (max 1 (min value-head-dim subgroup maximum)))))
 
 (defn- kernel-name
-  [problem]
-  (let [identity (select-keys problem
-                              [:batch-size :q-heads :kv-heads :qk-head-dim :value-head-dim
-                               :page-size :physical-pages :scale :k-format :v-format
-                               :k-layout :v-layout :q-dtype :output-dtype])
-        visibility (:visibility problem)
-        identity (assoc identity
-                        :route-kind (attention/route-kind (:route problem))
-                        :route-shape (select-keys (:route problem)
-                                                  [:pages-per-sequence
-                                                   :page-index-capacity])
-                        :visibility-kind (attention/visibility-kind visibility)
-                        :visibility-shape
-                        (cond-> {:position-filter (into {} (attention/position-filter visibility))}
-                          (attention/csr-visibility? visibility)
-                          (assoc :key-index-capacity (:key-index-capacity visibility)))
-                        :total-query-tokens (get-in problem [:query :total-tokens]))]
-    (format "raster_attention_fp16_%08x" (bit-and 0xffffffff (long (hash identity))))))
+  ([problem] (kernel-name problem :reference))
+  ([problem schedule-identity]
+   (let [identity (assoc (select-keys problem
+                                      [:batch-size :q-heads :kv-heads :qk-head-dim :value-head-dim
+                                       :page-size :physical-pages :scale :k-format :v-format
+                                       :k-layout :v-layout :q-dtype :output-dtype])
+                         :schedule schedule-identity)
+         visibility (:visibility problem)
+         identity (assoc identity
+                         :route-kind (attention/route-kind (:route problem))
+                         :route-shape (select-keys (:route problem)
+                                                   [:pages-per-sequence
+                                                    :page-index-capacity])
+                         :visibility-kind (attention/visibility-kind visibility)
+                         :visibility-shape
+                         (cond-> {:position-filter (into {} (attention/position-filter visibility))}
+                           (attention/csr-visibility? visibility)
+                           (assoc :key-index-capacity (:key-index-capacity visibility)))
+                         :total-query-tokens (get-in problem [:query :total-tokens]))]
+     (format "raster_attention_fp16_%08x" (bit-and 0xffffffff (long (hash identity)))))))
 
 (defn- opencl-type
   [dtype]
@@ -141,7 +145,7 @@
          "    __global const int* attention_key_indices,\n")))
 
 (defn- route-initialization
-  [{:keys [route page-size output-dtype]}]
+  [{:keys [route page-size]} invalid-result]
   (if (attention/dense-paged-route? route)
     (let [capacity (* (:pages-per-sequence route) page-size)]
       (str "  const int length = kv_lengths[batch];\n"
@@ -149,8 +153,7 @@
            "  if (length < 0 || length > " capacity
            " || kv_start_position < 0\n"
            "      || (long)kv_start_position + (long)length > 2147483648L) {\n"
-           "    output[out_index] = " (store-float output-dtype "NAN") ";\n"
-           "    return;\n"
+           invalid-result
            "  }\n"))
     (let [capacity (:page-index-capacity route)]
       (str "  const int page_begin = page_offsets[batch];\n"
@@ -159,21 +162,18 @@
            "  const int kv_start_position = kv_start_positions[batch];\n"
            "  if (page_offsets[0] != 0 || page_begin < 0 || page_end < page_begin\n"
            "      || page_end > " capacity " || kv_start_position < 0) {\n"
-           "    output[out_index] = " (store-float output-dtype "NAN") ";\n"
-           "    return;\n"
+           invalid-result
            "  }\n"
            "  const int routed_page_count = page_end - page_begin;\n"
            "  if ((routed_page_count == 0 && final_page_length != 0)\n"
            "      || (routed_page_count > 0\n"
            "          && (final_page_length < 1 || final_page_length > " page-size "))) {\n"
-           "    output[out_index] = " (store-float output-dtype "NAN") ";\n"
-           "    return;\n"
+           invalid-result
            "  }\n"
            "  const int length = routed_page_count == 0 ? 0\n"
            "      : (routed_page_count - 1) * " page-size " + final_page_length;\n"
            "  if ((long)kv_start_position + (long)length > 2147483648L) {\n"
-           "    output[out_index] = " (store-float output-dtype "NAN") ";\n"
-           "    return;\n"
+           invalid-result
            "  }\n"))))
 
 (defn- physical-page-expression
@@ -194,29 +194,27 @@
               window-right "L);\n"))))
 
 (defn- visibility-initialization
-  [visibility output-dtype]
+  [visibility invalid-result]
   (when (attention/csr-visibility? visibility)
     (str "  const int attention_begin = attention_row_offsets[q_token];\n"
          "  const int attention_end = attention_row_offsets[q_token + 1];\n"
          "  if (attention_row_offsets[0] != 0 || attention_begin < 0\n"
          "      || attention_end < attention_begin || attention_end > "
          (:key-index-capacity visibility) ") {\n"
-         "    output[out_index] = " (store-float output-dtype "NAN") ";\n"
-         "    return;\n"
+         invalid-result
          "  }\n")))
 
 (defn- visibility-loop-start
-  [visibility output-dtype]
+  [visibility invalid-result]
   (if (attention/csr-visibility? visibility)
     (str "  for (int edge = attention_begin; edge < attention_end; ++edge) {\n"
          "    const int token = attention_key_indices[edge];\n"
          "    if (token < 0 || token >= length) {\n"
-         "      output[out_index] = " (store-float output-dtype "NAN") ";\n"
-         "      return;\n"
+         invalid-result
          "    }\n")
     "  for (int token = 0; token < length; ++token) {\n"))
 
-(defn- source
+(defn- reference-source
   [problem name]
   (let [{:keys [query route batch-size q-heads kv-heads qk-head-dim value-head-dim
                 page-size physical-pages scale k-layout v-layout visibility
@@ -224,7 +222,9 @@
         total-query-tokens (:total-tokens query)
         gqa-ratio (quot q-heads kv-heads)
         k-base (cache-base problem k-layout qk-head-dim)
-        v-base (cache-base problem v-layout value-head-dim)]
+        v-base (cache-base problem v-layout value-head-dim)
+        invalid-result (str "    output[out_index] = " (store-float output-dtype "NAN") ";\n"
+                            "    return;\n")]
     (str "#pragma OPENCL EXTENSION cl_khr_fp16 : enable\n"
          "__kernel void " name "(\n"
          "    __global const " (opencl-type q-dtype) "* q,\n"
@@ -257,15 +257,15 @@
          "    output[out_index] = " (store-float output-dtype "NAN") ";\n"
          "    return;\n"
          "  }\n"
-         (route-initialization problem)
-         (visibility-initialization visibility output-dtype)
+         (route-initialization problem invalid-result)
+         (visibility-initialization visibility invalid-result)
          "  const int kv_head = q_head / " gqa-ratio ";\n"
          "  const long q_base = ((long)q_token * " q-heads
          " + q_head) * " qk-head-dim ";\n"
          "  float maximum = -3.402823466e+38f;\n"
          "  float denominator = 0.0f;\n"
          "  float accumulator = 0.0f;\n"
-         (visibility-loop-start visibility output-dtype)
+         (visibility-loop-start visibility invalid-result)
          "    const long kv_position = (long)kv_start_position + token;\n"
          "    int visible = 1;\n"
          (visibility-statements (attention/position-filter visibility))
@@ -296,6 +296,160 @@
          "  output[out_index] = denominator == 0.0f ? "
          (store-float output-dtype "0.0f") "\n"
          "      : " (store-float output-dtype "accumulator / denominator") ";\n"
+         "}\n")))
+
+(defn- cooperative-plan!
+  [plan schedule]
+  (let [plan (reference-plan! plan)
+        schedule (swr-schedule/validate! schedule)
+        problem (attention-problem plan)
+        components (:value-head-dim problem)]
+    (when-not (and (= components (get-in schedule [:value-mapping :components]))
+                   (= (get-in plan [:score :axis :name])
+                      (get-in schedule [:score-reduction :axis]))
+                   (= (:accumulator-dtype plan)
+                      (get-in schedule [:numerical-mode :score-accumulate]))
+                   (= (:accumulator-dtype plan)
+                      (get-in schedule [:numerical-mode :state-accumulate]))
+                   (= :dense-paged (attention/route-kind (:route problem)))
+                   (= :interval (attention/visibility-kind (:visibility problem)))
+                   (= :routed-paged-kv (get-in schedule [:attributes :storage-kind]))
+                   (= :dense-paged (get-in schedule [:attributes :route-kind]))
+                   (= :interval (get-in schedule [:attributes :visibility-kind])))
+      (throw (ex-info "cooperative attention schedule does not describe this reduction plan"
+                      {:reason :attention-cooperative-schedule-plan-mismatch
+                       :schedule schedule :plan-id (:id plan)})))
+    [plan schedule problem]))
+
+(defn- component-code
+  [schedule f]
+  (apply str (map f (range (get-in schedule [:value-mapping :components-per-lane])))))
+
+(defn- cooperative-component-declarations
+  [schedule]
+  (let [subgroup-size (:workgroup-size schedule)]
+    (component-code
+     schedule
+     (fn [slot]
+       (str "  const int d" slot " = (int)lane + " (* slot subgroup-size) ";\n"
+            "  float accumulator" slot " = 0.0f;\n")))))
+
+(defn- cooperative-component-write
+  [problem schedule expression]
+  (component-code
+   schedule
+   (fn [slot]
+     (str "    if (d" slot " < " (:value-head-dim problem) ")\n"
+          "      output[out_base + d" slot "] = "
+          (store-float (:output-dtype problem) (expression slot)) ";\n"))))
+
+(defn- cooperative-component-update
+  [problem schedule]
+  (component-code
+   schedule
+   (fn [slot]
+     (str "    if (d" slot " < " (:value-head-dim problem) ")\n"
+          "      accumulator" slot " = accumulator" slot " * old_weight\n"
+          "          + convert_float(v_pages[v_base + d" slot "]) * new_weight;\n"))))
+
+(defn- cooperative-source
+  [problem schedule name]
+  (let [{:keys [query route batch-size q-heads kv-heads qk-head-dim value-head-dim
+                page-size physical-pages scale k-layout v-layout visibility
+                q-dtype output-dtype]} problem
+        total-query-tokens (:total-tokens query)
+        gqa-ratio (quot q-heads kv-heads)
+        subgroup-size (:workgroup-size schedule)
+        k-base (cache-base problem k-layout qk-head-dim)
+        v-base (cache-base problem v-layout value-head-dim)
+        invalid-result
+        (str (cooperative-component-write problem schedule (constantly "NAN"))
+             "    return;\n")
+        empty-result
+        (str (cooperative-component-write problem schedule (constantly "0.0f"))
+             "    return;\n")]
+    (str "#pragma OPENCL EXTENSION cl_khr_fp16 : enable\n"
+         "__attribute__((intel_reqd_sub_group_size(" subgroup-size ")))\n"
+         "__kernel void " name "(\n"
+         "    __global const " (opencl-type q-dtype) "* q,\n"
+         "    __global const int* q_row_offsets,\n"
+         "    __global const int* q_positions,\n"
+         "    __global const half* k_pages,\n"
+         "    __global const half* v_pages,\n"
+         (route-signature route)
+         "    __global " (opencl-type output-dtype) "* output) {\n"
+         "  const long lane = (long)get_sub_group_local_id();\n"
+         "  const int q_head = (int)get_group_id(0);\n"
+         "  const int q_token = (int)get_group_id(1);\n"
+         "  const long out_base = ((long)q_token * " q-heads
+         " + q_head) * " value-head-dim ";\n"
+         (cooperative-component-declarations schedule)
+         "  int query_metadata_valid = q_row_offsets[0] == 0\n"
+         "      && q_row_offsets[" batch-size "] == " total-query-tokens ";\n"
+         "  int batch = -1;\n"
+         "  for (int b = 0; b < " batch-size "; ++b) {\n"
+         "    const int row_start = q_row_offsets[b];\n"
+         "    const int row_end = q_row_offsets[b + 1];\n"
+         "    query_metadata_valid = query_metadata_valid && row_start >= 0\n"
+         "        && row_end >= row_start && row_end <= " total-query-tokens ";\n"
+         "    if (q_token >= row_start && q_token < row_end) batch = b;\n"
+         "  }\n"
+         "  const int q_position = q_positions[q_token];\n"
+         "  if (!query_metadata_valid || batch < 0 || q_position < 0) {\n"
+         invalid-result
+         "  }\n"
+         (route-initialization problem invalid-result)
+         "  if (length == 0) {\n"
+         empty-result
+         "  }\n"
+         "  const int kv_head = q_head / " gqa-ratio ";\n"
+         "  const long q_base = ((long)q_token * " q-heads
+         " + q_head) * " qk-head-dim ";\n"
+         "  float maximum = -3.402823466e+38f;\n"
+         "  float denominator = 0.0f;\n"
+         "  for (int token = 0; token < length; ++token) {\n"
+         "    const long kv_position = (long)kv_start_position + token;\n"
+         "    int visible = 1;\n"
+         (visibility-statements (attention/position-filter visibility))
+         "    if (!visible) continue;\n"
+         "    const int logical_page = token / " page-size ";\n"
+         "    const int physical_page = " (physical-page-expression route) ";\n"
+         "    if (physical_page < 0 || physical_page >= " physical-pages ") {\n"
+         invalid-result
+         "    }\n"
+         "    const int page_token = token - logical_page * " page-size ";\n"
+         "    const long k_base = " k-base ";\n"
+         "    const long v_base = " v-base ";\n"
+         "    float partial_dot = 0.0f;\n"
+         "    for (int x = (int)lane; x < " qk-head-dim "; x += " subgroup-size ")\n"
+         "      partial_dot += " (load-float q-dtype "q[q_base + x]")
+         " * convert_float(k_pages[k_base + x]);\n"
+         "    const float dot = sub_group_reduce_add(partial_dot);\n"
+         "    const float logit = dot * " (Float/toString (float scale)) "f;\n"
+         "    float old_weight = 0.0f;\n"
+         "    float new_weight = 0.0f;\n"
+         "    if (lane == 0L) {\n"
+         "      if (isnan(maximum) || isnan(logit)) {\n"
+         "        maximum = NAN;\n"
+         "        old_weight = NAN;\n"
+         "        new_weight = NAN;\n"
+         "      } else {\n"
+         "        const float next_maximum = fmax(maximum, logit);\n"
+         "        old_weight = exp(maximum - next_maximum);\n"
+         "        new_weight = exp(logit - next_maximum);\n"
+         "        maximum = next_maximum;\n"
+         "      }\n"
+         "      denominator = denominator * old_weight + new_weight;\n"
+         "    }\n"
+         "    old_weight = sub_group_broadcast(old_weight, 0);\n"
+         "    new_weight = sub_group_broadcast(new_weight, 0);\n"
+         (cooperative-component-update problem schedule)
+         "  }\n"
+         "  denominator = sub_group_broadcast(denominator, 0);\n"
+         (cooperative-component-write
+          problem schedule
+          (fn [slot]
+            (str "denominator == 0.0f ? 0.0f : accumulator" slot " / denominator")))
          "}\n")))
 
 (defn- ordered-inputs
@@ -354,7 +508,7 @@
                                q-heads (:total-tokens query)]})]
     (kart/make
      {:kernel-name name
-      :source (source problem name)
+      :source (reference-source problem name)
       :abi (ordered-abi problem)
       :arguments arguments
       :launch launch
@@ -373,8 +527,47 @@
                    :layout (attention/layouts problem)
                    :complexity :quadratic-in-qk-head-dim}})))
 
+(defn emit-fp16-cooperative
+  "Emit one subgroup per query segment for dense routed FP16 K/V attention.
+
+   The artifact preserves the reference leaf's complete ordered ABI and logical effects.  Only
+   its target-neutral SegmentedWeightedReductionSchedule, launch mapping and target body differ."
+  [plan schedule]
+  (let [[plan schedule {:keys [query output q-heads route] :as problem}]
+        (cooperative-plan! plan schedule)
+        subgroup-size (:workgroup-size schedule)
+        name (kernel-name problem schedule)
+        inputs (ordered-inputs plan)
+        arguments (conj inputs output)]
+    (kart/make
+     {:kernel-name name
+      :source (cooperative-source problem schedule name)
+      :abi (ordered-abi problem)
+      :arguments arguments
+      :launch (klaunch/spec
+               {:workgroup-size [subgroup-size 1]
+                :group-count [q-heads (:total-tokens query)]})
+      :effects {:kind :attention :reads inputs :writes [output]}
+      :provenance {:operation-id (:id problem) :semantic-op :attention
+                   :algebra-plan-id (:id plan)
+                   :lowering :subgroup-online-score-reuse}
+      :attributes {:strategy :routed-paged-subgroup-online-score-reuse
+                   :optimization-tier :subgroup
+                   :algebra :segmented-weighted-reduction
+                   :algebra-key (swr/algebra-key plan)
+                   :segmented-weighted-reduction-schedule schedule
+                   :storage-dtype :half :q-dtype (:q-dtype problem)
+                   :output-dtype (:output-dtype problem) :accumulator-dtype :float
+                   :route-kind (attention/route-kind route)
+                   :visibility-kind (attention/visibility-kind (:visibility problem))
+                   :k-layout (:k-layout problem) :v-layout (:v-layout problem)
+                   :visibility (:visibility problem)
+                   :layout (attention/layouts problem)
+                   :materialized-intermediates []
+                   :complexity :query-head-token-dot-plus-value}})))
+
 (defn kernel-graph
-  "Wrap the reference artifact in an explicit one-node scheduled graph."
+  "Wrap either verified attention leaf in an explicit one-node scheduled graph."
   [plan artifact]
   (let [plan (reference-plan! plan)
         {:keys [output id] :as problem} (attention-problem plan)
@@ -386,7 +579,9 @@
                          (kgraph/buffer buffer-id dtype elements :device role)))
         uses (vec (concat (map #(kgraph/->ValueUse % :read) inputs)
                           [(kgraph/->ValueUse output :write)]))
-        node-id [:attention id :fp16-reference]]
+        strategy (get-in artifact [:attributes :strategy])
+        reference? (= :reference (get-in artifact [:attributes :optimization-tier]))
+        node-id [:attention id strategy]]
     (kgraph/make
      {:inputs (mapv graph-buffer inputs)
       :outputs [(graph-buffer output)]
@@ -395,5 +590,5 @@
       :nodes [(kgraph/->ScheduledKernel node-id artifact uses [])]
       :effects {:kind :attention :logical-visibility true :ordered-page-routing true}
       :provenance {:operation-id id :semantic-op :attention}
-      :attributes {:strategy :fp16-reference :reference? true
+      :attributes {:strategy strategy :reference? reference?
                    :route-kind (attention/route-kind (:route problem))}})))

--- a/src/raster/compiler/ir/segmented_weighted_reduction_schedule.clj
+++ b/src/raster/compiler/ir/segmented_weighted_reduction_schedule.clj
@@ -1,0 +1,83 @@
+(ns raster.compiler.ir.segmented-weighted-reduction-schedule
+  "Target-neutral schedules for segmented normalized weighted reductions.
+
+   The semantic operation remains SegmentedWeightedReductionPlan.  This value records how one
+   legal implementation maps segments, score components, visible members and value components to
+   cooperative hardware execution; it contains no attention buffer identities or target syntax.")
+
+(defrecord SegmentedWeightedReductionSchedule
+           [strategy workgroup-size segment-mapping membership-traversal score-reduction
+            value-mapping state numerical-mode attributes])
+
+(defn schedule?
+  [value]
+  (and value
+       (= "raster.compiler.ir.segmented_weighted_reduction_schedule.SegmentedWeightedReductionSchedule"
+          (.getName (class value)))))
+
+(defn validate!
+  [schedule]
+  (when-not (schedule? schedule)
+    (throw (ex-info "expected a SegmentedWeightedReductionSchedule"
+                    {:reason :segmented-weighted-reduction-schedule-type
+                     :schedule schedule})))
+  (let [{:keys [strategy workgroup-size segment-mapping membership-traversal score-reduction
+                value-mapping state numerical-mode attributes]} schedule]
+    (when-not (= :subgroup-online-score-reuse strategy)
+      (throw (ex-info "segmented weighted-reduction schedule has an unsupported strategy"
+                      {:reason :segmented-weighted-reduction-schedule-strategy
+                       :strategy strategy})))
+    (when-not (and (integer? workgroup-size) (pos? workgroup-size))
+      (throw (ex-info "segmented weighted-reduction workgroup size must be positive"
+                      {:reason :segmented-weighted-reduction-schedule-workgroup
+                       :workgroup-size workgroup-size})))
+    (when-not (= :one-workgroup-per-segment segment-mapping)
+      (throw (ex-info "cooperative weighted reduction requires one workgroup per segment"
+                      {:reason :segmented-weighted-reduction-segment-mapping
+                       :segment-mapping segment-mapping})))
+    (when-not (= :sequential membership-traversal)
+      (throw (ex-info "initial cooperative weighted reduction requires sequential membership traversal"
+                      {:reason :segmented-weighted-reduction-membership-traversal
+                       :membership-traversal membership-traversal})))
+    (when-not (and (= :subgroup (:kind score-reduction))
+                   (= workgroup-size (:width score-reduction))
+                   (some? (:axis score-reduction)))
+      (throw (ex-info "score reduction must occupy the schedule's complete hardware subgroup"
+                      {:reason :segmented-weighted-reduction-score-reduction
+                       :score-reduction score-reduction
+                       :workgroup-size workgroup-size})))
+    (when-not (and (= :lane-strided (:kind value-mapping))
+                   (integer? (:components value-mapping))
+                   (pos? (:components value-mapping))
+                   (integer? (:components-per-lane value-mapping))
+                   (= (:components-per-lane value-mapping)
+                      (quot (+ (:components value-mapping) (dec workgroup-size))
+                            workgroup-size)))
+      (throw (ex-info "value mapping must cover every component by lane-strided register state"
+                      {:reason :segmented-weighted-reduction-value-mapping
+                       :value-mapping value-mapping
+                       :workgroup-size workgroup-size})))
+    (when-not (= {:kind :online-normalized-weighted-sum
+                  :components [:maximum :denominator :weighted-values]}
+                 state)
+      (throw (ex-info "cooperative weighted reduction requires explicit online softmax state"
+                      {:reason :segmented-weighted-reduction-online-state :state state})))
+    (when-not (and (map? numerical-mode)
+                   (keyword? (:score-accumulate numerical-mode))
+                   (keyword? (:state-accumulate numerical-mode))
+                   (= :subgroup-tree (:dot-order numerical-mode))
+                   (true? (:online-rescale? numerical-mode))
+                   (map? attributes))
+      (throw (ex-info "segmented weighted-reduction numerical and attribute facets are incomplete"
+                      {:reason :segmented-weighted-reduction-schedule-facets
+                       :numerical-mode numerical-mode :attributes attributes}))))
+  schedule)
+
+(defn make
+  [{:keys [strategy workgroup-size segment-mapping membership-traversal score-reduction
+           value-mapping state numerical-mode attributes]
+    :or {attributes {}}}]
+  (validate!
+   (->SegmentedWeightedReductionSchedule
+    strategy workgroup-size segment-mapping membership-traversal score-reduction value-mapping
+    state numerical-mode attributes)))

--- a/src/raster/compiler/passes/parallel/attention_route.clj
+++ b/src/raster/compiler/passes/parallel/attention_route.clj
@@ -2,7 +2,8 @@
   "Structured routing for backend-neutral attention problems."
   (:require [raster.compiler.backend.gpu.attention :as emit]
             [raster.compiler.ir.attention :as attention]
-            [raster.compiler.passes.parallel.attention-lower :as lower]))
+            [raster.compiler.passes.parallel.attention-lower :as lower]
+            [raster.compiler.passes.parallel.segmented-weighted-reduction-schedule :as swr-schedule]))
 
 (defn- decline
   [problem reason data]
@@ -11,11 +12,33 @@
    :reference? false
    :declines [{:leaf :fp16-reference :reason reason :data data}]})
 
+(def ^:private cooperative-policies
+  #{:subgroup-score-reuse :subgroup-online-score-reuse})
+
+(defn- requested-policy
+  [desc]
+  (or (:segmented-weighted-reduction-schedule desc) :auto))
+
+(defn- success
+  [problem plan artifact declines]
+  (let [strategy (get-in artifact [:attributes :strategy])
+        reference? (= :reference (get-in artifact [:attributes :optimization-tier]))]
+    {:operation problem
+     :plan plan
+     :strategy strategy
+     :reference? reference?
+     :declines declines
+     :artifact artifact
+     :graph (emit/kernel-graph plan artifact)
+     :schedule {:workgroup-size (:workgroup-size (:launch artifact))
+                :group-count (:group-count (:launch artifact))}}))
+
 (defn route
-  "Try the executable packed/routed attention reference or return a structured decline.
+  "Route packed/routed attention through a cooperative schedule or its semantic oracle.
 
    Quantized K/V formats stay semantic values but decline until their scale/group operands are
-   explicit. Dense and CSR routing are both reference leaves with deliberately distinct ABIs."
+   explicit. Dense and CSR routing are both reference leaves with deliberately distinct ABIs;
+   dense interval visibility additionally admits a one-subgroup online-softmax schedule."
   ([problem] (route problem nil))
   ([problem desc]
    (let [{:keys [q-dtype k-dtype v-dtype output-dtype accumulator-dtype
@@ -48,16 +71,38 @@
 
        :else
        (let [plan (lower/lower problem)
-             artifact (emit/emit-fp16-reference plan desc)]
-         {:operation problem
-          :plan plan
-          :strategy :fp16-reference
-          :reference? true
-          :declines []
-          :artifact artifact
-          :graph (emit/kernel-graph plan artifact)
-          :schedule {:workgroup-size (:workgroup-size (:launch artifact))
-                     :group-count (:group-count (:launch artifact))}})))))
+             policy (requested-policy desc)]
+         (cond
+           (= :reference policy)
+           (success problem plan (emit/emit-fp16-reference plan desc) [])
+
+           (or (= :auto policy) (contains? cooperative-policies policy))
+           (let [{:keys [ok schedule reason] :as scheduled}
+                 (swr-schedule/plan-subgroup-online plan desc)]
+             (if ok
+               (success problem plan (emit/emit-fp16-cooperative plan schedule) [])
+               (let [cooperative-decline
+                     {:leaf :routed-paged-subgroup-online-score-reuse
+                      :reason reason
+                      :data (dissoc scheduled :ok :reason)}]
+                 (if (= :auto policy)
+                   (success problem plan (emit/emit-fp16-reference plan desc)
+                            [cooperative-decline])
+                   {:operation problem
+                    :plan plan
+                    :strategy nil
+                    :reference? false
+                    :declines [cooperative-decline]}))))
+
+           :else
+           {:operation problem
+            :plan plan
+            :strategy nil
+            :reference? false
+            :declines [{:leaf :attention-schedule-policy
+                        :reason :attention-schedule-policy-unsupported
+                        :data {:requested policy
+                               :supported (into [:auto :reference] cooperative-policies)}}]}))))))
 
 (defn route!
   "Route attention or fail with the complete machine-readable decline trail."

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_schedule.clj
@@ -1,0 +1,104 @@
+(ns raster.compiler.passes.parallel.segmented-weighted-reduction-schedule
+  "Apply cooperative hardware schedules to schedule-neutral segmented weighted reductions."
+  (:require [clojure.string :as str]
+            [raster.compiler.ir.segmented-weighted-reduction :as swr]
+            [raster.compiler.ir.segmented-weighted-reduction-schedule :as schedule]))
+
+(defn- decline
+  [reason & [data]]
+  (merge {:ok false :reason reason} data))
+
+(defn plan-subgroup-online
+  "Plan one subgroup per segment with one shared score and lane-strided value accumulators.
+
+   The first executable storage row is dense paged FP16 KV with interval visibility.  Those are
+   legality constraints of this schedule, not new semantic operation kinds."
+  ([plan] (plan-subgroup-online plan nil))
+  ([plan desc]
+   (let [{:keys [membership storage score value operands output accumulator-dtype] :as plan}
+         (swr/validate! plan)
+         subgroup-size (long (or (:subgroup-size desc) 16))
+         max-workgroup-size (long (or (:max-workgroup-size desc) 256))
+         vendor (some-> (:vendor desc) str str/lower-case)
+         matrix-family (get-in desc [:matrix :family])
+         known-non-intel? (and (or vendor matrix-family)
+                               (not (or (= :dpas matrix-family)
+                                        (and vendor (str/includes? vendor "intel")))))
+         components (:components value)
+         operand-dtypes (mapv :dtype operands)]
+     (cond
+       (and desc (not= :gpu (:device-type desc)))
+       (decline :score-reuse-requires-gpu {:device-type (:device-type desc)})
+
+       known-non-intel?
+       (decline :score-reuse-requires-intel-subgroup-dialect
+                {:vendor (:vendor desc) :matrix-family matrix-family})
+
+       (not (swr/online-softmax-algebra? plan))
+       (decline :score-reuse-requires-online-softmax-algebra)
+
+       (not= :logical-attention-visibility (:kind membership))
+       (decline :score-reuse-membership-unsupported {:membership (:kind membership)})
+
+       (not= :interval (:visibility-kind membership))
+       (decline :score-reuse-visibility-unsupported
+                {:visibility-kind (:visibility-kind membership)})
+
+       (not= :routed-paged-kv (:kind storage))
+       (decline :score-reuse-storage-unsupported {:storage (:kind storage)})
+
+       (not= :dense-paged (:route-kind storage))
+       (decline :score-reuse-route-unsupported {:route-kind (:route-kind storage)})
+
+       (or (not= :none (get-in storage [:k-format :quantization]))
+           (not= :none (get-in storage [:v-format :quantization])))
+       (decline :score-reuse-quantized-kv-unimplemented
+                {:k-format (:k-format storage) :v-format (:v-format storage)})
+
+       (not= :float accumulator-dtype)
+       (decline :score-reuse-accumulator-unsupported {:actual accumulator-dtype})
+
+       (not (and (= 8 (count operand-dtypes))
+                 (contains? #{:half :float} (first operand-dtypes))
+                 (= [:int :int :half :half :int :int :int]
+                    (subvec operand-dtypes 1 8))
+                 (contains? #{:half :float} (:dtype output))))
+       (decline :score-reuse-storage-dtypes-unsupported
+                {:operand-dtypes operand-dtypes :output-dtype (:dtype output)})
+
+       (or (not (integer? components)) (not (pos? components)))
+       (decline :score-reuse-static-value-width-required {:components components})
+
+       (or (not (pos? subgroup-size)) (> subgroup-size max-workgroup-size))
+       (decline :score-reuse-invalid-subgroup-geometry
+                {:subgroup-size subgroup-size :max-workgroup-size max-workgroup-size})
+
+       ;; A static cap makes register-state feasibility explicit. Gemma D=256/SG16 uses 16.
+       (> (quot (+ components (dec subgroup-size)) subgroup-size) 32)
+       (decline :score-reuse-register-state-too-wide
+                {:components components :subgroup-size subgroup-size
+                 :components-per-lane (quot (+ components (dec subgroup-size)) subgroup-size)})
+
+       :else
+       {:ok true
+        :schedule
+        (schedule/make
+         {:strategy :subgroup-online-score-reuse
+          :workgroup-size subgroup-size
+          :segment-mapping :one-workgroup-per-segment
+          :membership-traversal :sequential
+          :score-reduction {:kind :subgroup :width subgroup-size
+                            :axis (get-in score [:axis :name])}
+          :value-mapping {:kind :lane-strided
+                          :components components
+                          :components-per-lane
+                          (quot (+ components (dec subgroup-size)) subgroup-size)}
+          :state {:kind :online-normalized-weighted-sum
+                  :components [:maximum :denominator :weighted-values]}
+          :numerical-mode {:score-accumulate accumulator-dtype
+                           :state-accumulate accumulator-dtype
+                           :dot-order :subgroup-tree
+                           :online-rescale? true}
+          :attributes {:storage-kind (:kind storage)
+                       :route-kind (:route-kind storage)
+                       :visibility-kind (:visibility-kind membership)}})}))))

--- a/test/raster/compiler/passes/parallel/attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/attention_route_test.clj
@@ -1,11 +1,17 @@
 (ns raster.compiler.passes.parallel.attention-route-test
   (:require [clojure.string :as str]
+            [clojure.java.shell :as shell]
             [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.attention :as attention-emit]
             [raster.compiler.ir.attention :as attention]
             [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-executable :as kexec]
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.segmented-weighted-reduction :as swr]
-            [raster.compiler.passes.parallel.attention-route :as route]))
+            [raster.compiler.ir.segmented-weighted-reduction-schedule :as swr-schedule]
+            [raster.compiler.passes.parallel.attention-route :as route]
+            [raster.compiler.passes.parallel.segmented-weighted-reduction-schedule
+             :as schedule-pass]))
 
 (defn- query
   []
@@ -48,7 +54,8 @@
 (deftest dense-reference-is-a-complete-packed-attention-compiler-value
   (let [{:keys [strategy reference? declines plan artifact graph schedule]}
         (route/route! (problem)
-                      {:device-type :gpu :subgroup-size 16 :max-workgroup-size 256})]
+                      {:device-type :gpu :subgroup-size 16 :max-workgroup-size 256
+                       :segmented-weighted-reduction-schedule :reference})]
     (is (= :fp16-reference strategy))
     (is reference?)
     (is (empty? declines))
@@ -73,8 +80,91 @@
     (is (str/includes? (:source artifact) "physical_page = page_table"))
     (is (str/includes? (:source artifact) "const long v_base"))))
 
+(deftest dense-interval-attention-uses-the-shared-score-online-schedule
+  (let [desc {:device-type :gpu :vendor "Intel" :subgroup-size 16
+              :max-workgroup-size 256}
+        optimized (route/route! (problem) desc)
+        reference (route/route! (problem)
+                                (assoc desc :segmented-weighted-reduction-schedule :reference))
+        {:keys [strategy reference? declines artifact graph schedule]} optimized
+        swr-schedule (get-in artifact [:attributes :segmented-weighted-reduction-schedule])
+        source (:source artifact)]
+    (is (= :routed-paged-subgroup-online-score-reuse strategy))
+    (is (false? reference?))
+    (is (empty? declines))
+    (is (swr-schedule/schedule? swr-schedule))
+    (is (= :one-workgroup-per-segment (:segment-mapping swr-schedule)))
+    (is (= {:kind :lane-strided :components 6 :components-per-lane 1}
+           (:value-mapping swr-schedule)))
+    (is (= {:workgroup-size [16 1] :group-count [4 4]} schedule))
+    (is (= strategy (get-in graph [:attributes :strategy])))
+    (is (false? (get-in graph [:attributes :reference?])))
+    (is (= (kexec/common-view (:artifact reference))
+           (kexec/common-view artifact)))
+    (is (not= (:kernel-name (:artifact reference)) (:kernel-name artifact)))
+    (is (str/includes? source "intel_reqd_sub_group_size(16)"))
+    (is (str/includes? source "const float dot = sub_group_reduce_add(partial_dot)"))
+    (is (str/includes? source "old_weight = sub_group_broadcast(old_weight, 0)"))
+    (is (str/includes? source "const int kv_head = q_head / 2"))
+    (is (str/includes? source "if (length == 0)"))
+    (is (str/includes? source "float maximum"))
+    (is (str/includes? source "accumulator0 = accumulator0 * old_weight"))))
+
+(deftest cooperative-attention-source-is-valid-opencl
+  (let [clang? (zero? (:exit (shell/sh "sh" "-c" "command -v clang")))]
+    (if-not clang?
+      (is true "clang unavailable")
+      (let [source (get-in
+                    (route/route!
+                     (problem :qk-head-dim 256 :value-head-dim 256)
+                     {:device-type :gpu :vendor "Intel"
+                      :subgroup-size 16 :max-workgroup-size 256})
+                    [:artifact :source])
+            result (shell/sh "clang" "-x" "cl" "-cl-std=CL2.0"
+                             "-fsyntax-only" "-" :in source)]
+        (is (str/includes? source "const int d15 = (int)lane + 240;"))
+        (is (str/includes? source "float accumulator15 = 0.0f;"))
+        (is (not (str/includes? source "accumulator16")))
+        (is (zero? (:exit result)) (:err result))))))
+
+(deftest cooperative-schedule-is-validated-and-target-legality-is-explicit
+  (let [desc {:device-type :gpu :vendor "Intel"
+              :subgroup-size 16 :max-workgroup-size 256}
+        plan (:plan (route/route!
+                     (problem) (assoc desc :segmented-weighted-reduction-schedule :reference)))
+        {:keys [schedule]} (schedule-pass/plan-subgroup-online
+                            plan desc)
+        too-wide (route/route! (problem :value-head-dim 513) desc)]
+    (is (swr-schedule/schedule? schedule))
+    (is (= {:kind :subgroup :width 16 :axis :qk-component}
+           (:score-reduction schedule)))
+    (is (= {:score-accumulate :float :state-accumulate :float
+            :dot-order :subgroup-tree :online-rescale? true}
+           (:numerical-mode schedule)))
+    (is (= :segmented-weighted-reduction-value-mapping
+           (try
+             (swr-schedule/validate!
+              (assoc-in schedule [:value-mapping :components-per-lane] 2))
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+    (is (= :attention-cooperative-schedule-plan-mismatch
+           (try
+             (attention-emit/emit-fp16-cooperative
+              plan (assoc-in schedule [:score-reduction :axis] :wrong-axis))
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+    (is (= :score-reuse-requires-intel-subgroup-dialect
+           (:reason
+            (schedule-pass/plan-subgroup-online
+             plan {:device-type :gpu :vendor "NVIDIA" :subgroup-size 32
+                   :max-workgroup-size 1024}))))
+    (is (:reference? too-wide))
+    (is (= :score-reuse-register-state-too-wide
+           (get-in too-wide [:declines 0 :reason])))))
+
 (deftest csr-route-has-native-compact-page-abi
-  (let [artifact (:artifact (route/route! (problem :route (csr-route))))]
+  (let [{:keys [artifact reference? declines]}
+        (route/route! (problem :route (csr-route)))]
+    (is reference?)
+    (is (= :score-reuse-route-unsupported (get-in declines [0 :reason])))
     (is (= :csr-paged (get-in artifact [:attributes :route-kind])))
     (is (= '[q q-row-offsets q-positions k-pages v-pages page-offsets page-indices
              last-page-lengths kv-start-positions output]
@@ -85,8 +175,10 @@
     (is (str/includes? (:source artifact) "routed_page_count == 0"))))
 
 (deftest logical-csr-visibility-composes-with-physical-route-as-distinct-abi-slots
-  (let [artifact (:artifact (route/route!
-                             (problem :visibility (csr-visibility))))]
+  (let [{:keys [artifact reference? declines]}
+        (route/route! (problem :visibility (csr-visibility)))]
+    (is reference?)
+    (is (= :score-reuse-visibility-unsupported (get-in declines [0 :reason])))
     (is (= :dense-paged (get-in artifact [:attributes :route-kind])))
     (is (= :csr (get-in artifact [:attributes :visibility-kind])))
     (is (= '[q q-row-offsets q-positions k-pages v-pages
@@ -122,8 +214,26 @@
     (is (str/includes? source "__global const float* q"))
     (is (str/includes? source "__global float* output"))
     (is (str/includes? source "dot += q[q_base + x] * convert_float(k_pages"))
-    (is (str/includes? source "output[out_index] = NAN;"))
-    (is (str/includes? source "output[out_index] = denominator == 0.0f ? 0.0f"))))
+    (is (str/includes? source "output[out_base + d0] = NAN;"))
+    (is (str/includes? source
+                       "output[out_base + d0] = denominator == 0.0f ? 0.0f"))))
+
+(deftest pinned-cooperative-policy-declines-instead-of-silently-changing-schedule
+  (let [result (route/route
+                (problem :visibility (csr-visibility))
+                {:device-type :gpu :vendor "Intel" :subgroup-size 16
+                 :max-workgroup-size 256
+                 :segmented-weighted-reduction-schedule :subgroup-score-reuse})]
+    (is (nil? (:strategy result)))
+    (is (= :score-reuse-visibility-unsupported (get-in result [:declines 0 :reason])))
+    (is (= :attention-no-kernel-route
+           (try
+             (route/route!
+              (problem :visibility (csr-visibility))
+              {:device-type :gpu :vendor "Intel" :subgroup-size 16
+               :max-workgroup-size 256
+               :segmented-weighted-reduction-schedule :subgroup-score-reuse})
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))))
 
 (deftest unsupported-representations-return-machine-readable-declines
   (testing "quantization declines before generic dtype routing"

--- a/test/raster/gpu/attention_device_test.clj
+++ b/test/raster/gpu/attention_device_test.clj
@@ -39,7 +39,9 @@
            (map #(* 0.05 (- (mod (+ (* 5 %) 2) 17) 8)) (range k-elements)))
         v (encode-halfs
            (map #(* 0.04 (- (mod (+ (* 7 %) 3) 19) 9)) (range v-elements)))
-        q-offsets (int-array [0 2 2 4])
+        ;; Batch row 1 owns a query but has no resident KV tokens.  This exercises the cooperative
+        ;; schedule's zero-length early exit independently from packed rows 0 and 2.
+        q-offsets (int-array [0 2 3 4])
         q-positions (int-array [3 4 10 12])
         starts (int-array [0 0 8])
         query (attention/packed-query-batch


### PR DESCRIPTION
## Outcome

Adds the first performant schedule for the existing attention-derived SegmentedWeightedReductionPlan without changing AttentionProblem or the routed-page ABI.

- introduces a validated target-neutral SegmentedWeightedReductionSchedule
- maps one subgroup to each packed query-token/query-head segment
- computes each QK score once with subgroup reduction and shares online-softmax weights across lane-strided value accumulators
- preserves GQA, interval visibility/windows, dynamic per-row lengths and start positions, independent K/V layouts, and FP16/FP32 query/output
- exits zero-length rows early and retains the direct reference leaf for unsupported schedules
- makes auto routing fall back with machine-readable declines for CSR routing/visibility, quantized KV, non-Intel subgroup dialects, and excessive register state
- proves reference and optimized artifacts have the same ordered ABI, arguments, and logical effects

## Validation

- full suite: 2,367 tests, 33,916 assertions, 0 failures/errors
- focused attention/compiler gate: 54 tests, 316 assertions
- expanded route gate: 10 tests, 84 assertions
- Clang OpenCL 2.0 syntax gate for Gemma-shaped Dqk=Dv=256, SIMD16, 16 FP32 accumulators/lane
- touched-file cljfmt and git diff checks clean

Live Level Zero execution was attempted, but this host currently reports zeInit 0x78000001; all GPU namespaces consistently took their existing probe-error skip path. The packed device case was strengthened so a query-bearing batch row has zero KV length, ready for the next live Arc run.