### PR TITLE
Normalize cross-vendor execution capabilities

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -461,6 +461,13 @@ its isolated emitter test passes.
 ## 5. Hardware-aware compilation and autotuning
 
 Raster's existing hardware descriptor and schedule cache form the right base.
+Runtime probes and catalogues may retain backend-native names, but their compiler projection
+must normalize the execution hierarchy. In particular, the descriptor records a set of supported
+subgroup/warp/wave widths separately from its preferred width, maximum workgroup geometry, and
+per-field provenance. A schedule chooses one supported width; it must never inherit another
+vendor's default. Matrix-operation scope remains an independent capability because a device may
+support several subgroup widths while one DPAS, MMA, or MFMA operation requires exactly one.
+
 The closed loop is:
 
 ```text

--- a/src/raster/compiler/backend/gpu/target.clj
+++ b/src/raster/compiler/backend/gpu/target.clj
@@ -1,0 +1,28 @@
+(ns raster.compiler.backend.gpu.target
+  "Backend-emitter capability predicates.
+
+   Hardware descriptors state what a device can execute. These predicates state which concrete
+   source dialect the currently selected backend leaf can emit; schedule-neutral compiler passes
+   must not use them to constrain otherwise-portable schedules."
+  (:require [clojure.string :as str]))
+
+(defn intel-opencl-subgroup-dialect?
+  "True when the current OpenCL leaf may emit Intel subgroup attributes and builtins.
+
+   `:subgroup-dialect` is the explicit cross-compile contract. Vendor and DPAS checks retain the
+   detected/catalogued Intel path until runtime backend capabilities become a first-class facet."
+  [desc]
+  (let [vendor (some-> (:vendor desc) str str/lower-case)
+        matrix-family (get-in desc [:matrix :family])
+        backend (:backend desc)
+        opencl-backend? (or (nil? backend)
+                            (= :ze backend)
+                            (= :ocl backend)
+                            (= :opencl backend))]
+    (boolean
+     (and desc
+          (= :gpu (:device-type desc))
+          opencl-backend?
+          (or (= :intel-opencl (:subgroup-dialect desc))
+              (= :dpas matrix-family)
+              (and vendor (str/includes? vendor "intel")))))))

--- a/src/raster/compiler/core/hardware.clj
+++ b/src/raster/compiler/core/hardware.clj
@@ -70,18 +70,250 @@
 (defn- amd-cdna? [caps]
   (let [a (gpu-arch-str caps)]
     (or (= :mfma (get-in caps [:matrix :family]))
-        (.startsWith a "gfx9")            ;; CDNA: gfx908 (MI100), gfx90a (MI200), gfx942 (MI300)
-        (.startsWith a "gfx94"))))
+        (.startsWith a "gfx908")          ;; MI100
+        (.startsWith a "gfx90a")          ;; MI200
+        (.startsWith a "gfx94")           ;; MI300
+        (.startsWith a "gfx95"))))        ;; later CDNA
+
+(defn- amd-rdna? [caps]
+  (let [a (gpu-arch-str caps)]
+    (or (.startsWith a "gfx10")
+        (.startsWith a "gfx11")
+        (.startsWith a "gfx12"))))
+
+(defn- matrix-capability
+  "Finalize the current single matrix-operation capability before execution validation.
+   This remains one record for compatibility; the portable descriptor will grow this into a
+   collection when operand distributions and warp-group operations land."
+  [caps]
+  (or (:matrix caps)
+      (when (and (:compute-capability caps)
+                 (>= (long (first (:compute-capability caps))) 7))
+        {:family :mma :m 16 :n 16 :k 16 :subgroup 32})
+      (when (amd-cdna? caps)
+        {:family :mfma :m 16 :n 16 :k 16 :subgroup 64})))
+
+(defn- supported-widths
+  [value]
+  (let [values (cond
+                 (nil? value) []
+                 (coll? value) value
+                 :else [value])]
+    (when-not (every? #(and (integer? %) (pos? (long %))) values)
+      (throw (ex-info "subgroup widths must be positive integers"
+                      {:reason :hardware-subgroup-width-invalid :value value})))
+    (set (map long values))))
+
+(defn- preferred-width
+  [value]
+  (when (some? value)
+    (when-not (and (integer? value) (pos? (long value)))
+      (throw (ex-info "preferred subgroup width must be one positive integer"
+                      {:reason :hardware-preferred-subgroup-invalid :value value})))
+    (long value)))
+
+(defn- positive-limit
+  [field value]
+  (when-not (and (integer? value) (pos? (long value)))
+    (throw (ex-info "hardware execution limit must be a positive integer"
+                    {:reason :hardware-execution-limit-invalid
+                     :field field :value value})))
+  (long value))
+
+(defn- positive-dimensions
+  [value]
+  (when (some? value)
+    (when-not (and (coll? value)
+                   (seq value)
+                   (every? #(and (integer? %) (pos? (long %))) value))
+      (throw (ex-info "maximum workgroup dimensions must be positive integers"
+                      {:reason :hardware-workgroup-dimensions-invalid :value value})))
+    (mapv long value)))
+
+(defn- source-of
+  [source capability default]
+  (or (get source capability) (:all source) default))
+
+(defn- provenance-rank
+  [provenance]
+  (case provenance
+    :measured 6
+    :user 5
+    (:observed :detected) 4
+    :catalogued 3
+    :derived 2
+    :unavailable 0
+    1))
+
+(defn- best-capability
+  "Select among equivalent backend-native keys by provenance, with candidate order breaking ties.
+   A detected/user alias must override a differently-spelled catalogue key."
+  [caps source candidates]
+  (reduce
+   (fn [best capability]
+     (if-some [value (get caps capability)]
+       (let [candidate [capability value]
+             candidate-rank (provenance-rank (source-of source capability :derived))
+             best-rank (if best
+                         (provenance-rank (source-of source (first best) :derived))
+                         -1)]
+         (cond
+           (> candidate-rank best-rank) candidate
+           (and (= candidate-rank best-rank)
+                (not= value (second best)))
+           (throw (ex-info "equivalent hardware capability keys disagree"
+                           {:reason :hardware-capability-alias-conflict
+                            :capabilities [(first best) capability]
+                            :values [(second best) value]
+                            :provenance (source-of source capability :derived)}))
+           :else best))
+       best))
+   nil candidates))
+
+(defn- execution-capabilities
+  "Normalize backend-specific execution hierarchy keys at the runtime/compiler boundary.
+
+   Runtime probes and catalogues retain their native vocabulary (`:warp-size`,
+   `:wavefront-size`, `:simd-width`, and three workgroup-limit spellings). Schedulers consume this
+   one facet: a SET of legal cooperative widths plus a distinct preferred width. A preference is
+   not a hardware invariant and a schedule must still record the concrete width it selected."
+  [target-type caps source]
+  (let [[widths-key widths-value]
+        (best-capability caps source [:subgroup-sizes :supported-subgroup-sizes
+                                      :wavefront-sizes :wave-sizes])
+        [preferred-key preferred-value]
+        (best-capability
+         caps source
+         (case target-type
+           :cuda [:preferred-subgroup-size :warp-size]
+           :hip [:preferred-subgroup-size :wavefront-size :wave-size]
+           [:preferred-subgroup-size :simd-width]))
+        derived-widths
+        (case target-type
+          :cuda #{32}
+          :hip (cond
+                 (amd-cdna? caps) #{64}
+                 (amd-rdna? caps) #{32 64}
+                 :else #{})
+          #{})
+        explicit-widths (supported-widths widths-value)
+        explicit-preferred (preferred-width preferred-value)
+        subgroup-sizes (cond-> (if (seq explicit-widths)
+                                 explicit-widths
+                                 derived-widths)
+                         (and (empty? explicit-widths) explicit-preferred)
+                         (conj explicit-preferred))
+        preferred-subgroup-size
+        (or explicit-preferred
+            (case target-type
+              :cuda (when (contains? subgroup-sizes 32) 32)
+              :hip (cond
+                     (and (amd-cdna? caps) (contains? subgroup-sizes 64)) 64
+                     (contains? subgroup-sizes 32) 32
+                     :else (first (sort subgroup-sizes)))
+              (first (sort subgroup-sizes))))
+        [maximum-key maximum-value]
+        (best-capability caps source [:max-workgroup-size :max-work-group-size
+                                      :max-threads-per-block])
+        maximum-workgroup-size
+        (positive-limit
+         :max-workgroup-size
+         (or maximum-value
+             (case target-type
+               (:cuda :hip) 1024
+               256)))
+        [dimensions-key dimensions]
+        (best-capability caps source [:max-workgroup-dims :max-work-group-dims
+                                      :max-work-item-sizes])
+        dimensions (positive-dimensions dimensions)
+        [scratchpad-key scratchpad]
+        (best-capability caps source [:shared-local-memory :shared-memory-per-block
+                                      :local-memory-bytes :local-mem-bytes])
+        preferred-source (if preferred-key
+                           (source-of source preferred-key :derived)
+                           :derived)
+        widths-source (cond
+                        widths-key (source-of source widths-key :derived)
+                        preferred-key preferred-source
+                        (seq derived-widths) :derived
+                        :else :unavailable)
+        provenance (cond->
+                    {:subgroup-sizes widths-source
+                     :preferred-subgroup-size preferred-source
+                     :max-workgroup-size (if maximum-key
+                                           (source-of source maximum-key :derived)
+                                           :derived)}
+                     dimensions-key
+                     (assoc :max-workgroup-dims
+                            (source-of source dimensions-key :derived))
+                     scratchpad-key
+                     (assoc :scratchpad-bytes
+                            (source-of source scratchpad-key :derived)))
+        execution (cond->
+                   {:subgroup-kind (case target-type
+                                     :cuda :warp
+                                     :hip :wavefront
+                                     :subgroup)
+                    :subgroup-sizes subgroup-sizes
+                    :preferred-subgroup-size preferred-subgroup-size
+                    :max-workgroup-size maximum-workgroup-size
+                    :provenance provenance}
+                    dimensions (assoc :max-workgroup-dims dimensions)
+                    scratchpad (assoc :scratchpad-bytes
+                                      (positive-limit :scratchpad-bytes scratchpad)))]
+    (when (and preferred-subgroup-size
+               (not (contains? subgroup-sizes preferred-subgroup-size)))
+      (throw (ex-info "preferred subgroup width is not a supported hardware width"
+                      {:reason :hardware-preferred-subgroup-unsupported
+                       :preferred preferred-subgroup-size
+                       :supported subgroup-sizes})))
+    (when (and preferred-subgroup-size
+               (> preferred-subgroup-size maximum-workgroup-size))
+      (throw (ex-info "preferred subgroup exceeds the maximum workgroup size"
+                      {:reason :hardware-subgroup-exceeds-workgroup
+                       :preferred preferred-subgroup-size
+                       :maximum maximum-workgroup-size})))
+    (when-let [matrix-width (get-in caps [:matrix :subgroup])]
+      (when (and (seq subgroup-sizes)
+                 (not (contains? subgroup-sizes (long matrix-width))))
+        (throw (ex-info "matrix operation requires an unsupported subgroup width"
+                        {:reason :hardware-matrix-subgroup-unsupported
+                         :matrix (:matrix caps)
+                         :supported subgroup-sizes})))
+      (when (> (long matrix-width) maximum-workgroup-size)
+        (throw (ex-info "matrix operation scope exceeds the maximum workgroup size"
+                        {:reason :hardware-matrix-subgroup-exceeds-workgroup
+                         :matrix (:matrix caps)
+                         :maximum maximum-workgroup-size}))))
+    execution))
+
+(defn preferred-subgroup-size
+  "The descriptor's preferred cooperative width, including the temporary flat compatibility key."
+  [desc]
+  (or (get-in desc [:execution :preferred-subgroup-size])
+      (:subgroup-size desc)))
+
+(defn supported-subgroup-sizes
+  "The set of cooperative widths the descriptor reports as legal."
+  [desc]
+  (or (get-in desc [:execution :subgroup-sizes])
+      (:subgroup-sizes desc)))
+
+(defn maximum-workgroup-size
+  "The descriptor's normalized maximum number of work-items in one workgroup/block."
+  [desc]
+  (or (get-in desc [:execution :max-workgroup-size])
+      (:max-workgroup-size desc)))
 
 (defn- gpu-reg-budget-per-lane
   "Per-lane register-file budget the schedule/tile GRF gate charges against — vendor-specific
    (differ ~4×, so a single formula mis-sizes tiles cross-vendor). Intel Xe grf128 = 128 regs × 32 B
    / subgroup; NVIDIA = 255 regs × 4 B (per-thread WMMA fragment); AMD CDNA = 256 VGPRs × 4 B. Keyed
    off probed caps (compute-capability → NVIDIA; a gfx9 arch / :mfma matrix → AMD; else Intel)."
-  [caps flanes]
+  [target-type caps flanes]
   (cond
-    (:compute-capability caps) 1020
-    (amd-cdna? caps)           1024
+    (or (= :cuda target-type) (:compute-capability caps)) 1020
+    (or (= :hip target-type) (amd-cdna? caps) (amd-rdna? caps)) 1024
     :else (long (quot (* 128 32) (max 1 flanes)))))
 
 (defn- build-descriptor
@@ -93,11 +325,17 @@
    GPU global mem); balance uses Halide-style defaults. The :measured layer is overlaid by
    descriptor-for (below)."
   [device-id]
-  (let [caps   (:capabilities (rt/device device-id))
-        gpu?   (not= (rt/device-type device-id) :cpu)
-        flanes (long (if gpu? (rt/subgroup-size device-id)
-                         (rt/simd-lanes device-id :float)))   ;; f32 lanes / subgroup
-        vbits  (* flanes 32)
+  (let [device (rt/device device-id)
+        raw-caps (:capabilities device)
+        target-type (or (:type device) (rt/device-type device-id))
+        gpu?   (not= target-type :cpu)
+        matrix (when gpu? (matrix-capability raw-caps))
+        caps (cond-> raw-caps matrix (assoc :matrix matrix))
+        execution (when gpu? (execution-capabilities target-type caps (:source device)))
+        gpu-width (:preferred-subgroup-size execution)
+        flanes (if gpu? gpu-width
+                   (long (rt/simd-lanes device-id :float)))   ;; f32 lanes / subgroup
+        vbits  (when flanes (* (long flanes) 32))
         ;; PERFORMANCE quantities — bandwidth / per-dtype peak-flops / cache hierarchy — projected
         ;; from whatever the probe or the shipped catalogue supplied (runtime.hardware merges the
         ;; catalogue into caps). These are the roofline inputs (balance-for / roofline-time-ns).
@@ -105,26 +343,29 @@
         ;; ABSENT here and the analytic fns fall back to :balance; the :measured layer (Phase 1)
         ;; fills them from a microbenchmark and OVERWRITES the analytic guess.
         bw-gb  (:memory-bandwidth-gb-s caps)
+        global-memory-bytes (or (:global-memory-bytes caps) (:global-mem-bytes caps))
+        compute-units (or (:compute-units caps) (:max-compute-units caps))
         peak-flops (into {} (remove (comp nil? val))
                          {:f32 (:peak-flops-sp caps) :float (:peak-flops-sp caps)
                           :f64 (:peak-flops-dp caps) :double (:peak-flops-dp caps)
                           :f16 (:peak-flops-hp caps) :half (:peak-flops-hp caps)})
         cache  (into {} (remove (comp nil? val))
                      {:l1 (:cache-l1 caps) :l2 (:cache-l2 caps) :l3 (:cache-l3 caps)
-                      :slm (when gpu? (:shared-local-memory caps))})
+                      :slm (when gpu? (:scratchpad-bytes execution))})
         ;; GPU occupancy inputs the launch-geometry derivations (workgroup-size / group-count /
         ;; block-size / grid-size) read — present-only, projected from caps. Intel Level-Zero uses
         ;; :total-eus/:threads-per-eu; NVIDIA CUDA uses :sm-count/:max-warps-per-sm/:max-blocks-per-sm.
         gpu-geo (when gpu?
                   (into {} (remove (comp nil? val))
                         {:total-eus (:total-eus caps) :threads-per-eu (:threads-per-eu caps)
+                         :compute-units compute-units
                          :sm-count (:sm-count caps) :fpus-per-core (:fpus-per-core caps)
                          :max-warps-per-sm (:max-warps-per-sm caps) :max-blocks-per-sm (:max-blocks-per-sm caps)
                          :registers-per-block (:registers-per-block caps)
-                         :shared-memory-per-block (:shared-memory-per-block caps)}))]
+                         :shared-memory-per-block (:scratchpad-bytes execution)}))]
     (cond-> {:device-type (if gpu? :gpu :cpu)
              :device-id   device-id
-             :vector-bits vbits
+             :backend     target-type
              :has-native-dot-reduce
              (if gpu? true
                  ;; x86 has a widening int-dot-reduce ONLY with AVX-VNNI (vpdpbusd). Prefer the
@@ -135,18 +376,21 @@
                    (if feats
                      (boolean (some feats [:avx-vnni :avx512-vnni :vnni]))
                      (boolean (or (.contains a "amd64") (.contains a "x86"))))))
-             :num-vector-registers (if gpu? 128 (if (>= vbits 512) 32 16))
+             :num-vector-registers (if gpu? 128 (if (>= (long vbits) 512) 32 16))
              :llc-bytes   (or (:cache-l3 caps)
-                              (when gpu? (:global-memory-bytes caps))
+                              (when gpu? global-memory-bytes)
                               (* 16 1024 1024))
              :balance     (if gpu? 60 40)}
+      vbits (assoc :vector-bits vbits)
       (:vendor caps)  (assoc :vendor (:vendor caps))
       (:arch caps)    (assoc :arch (:arch caps))
       bw-gb           (assoc :bandwidth-bytes-s (* (double bw-gb) 1e9))
       (seq peak-flops) (assoc :peak-flops peak-flops)
       (seq cache)     (assoc :cache cache)
+      (and gpu? global-memory-bytes) (assoc :global-memory-bytes global-memory-bytes)
       gpu? (assoc :integrated? (boolean (:integrated? caps))
-                  :subgroup-size flanes
+                  :execution execution
+                  :subgroup-sizes (:subgroup-sizes execution)
                   ;; GRF budget per LANE = grf-regs/thread × reg-bytes / subgroup-size. INTEL Xe/Xe2
                   ;; grf128 model: 128 GRF registers/thread of 32 B (256-bit); per SIMD lane that is
                   ;; 128×32/subgroup. Arc 140V (subgroup 16): 256 B/lane — the budget the schedule
@@ -157,23 +401,17 @@
                   ;; the tile cross-vendor (the budgets differ ~4×), so derive-gemm-tile GRF-bounds
                   ;; against the right register file per family. (Supersedes the earlier Intel-only
                   ;; 128×32 placeholder that #75's HIP/CUDA NOTE flagged for exactly this follow-up.)
-                  :grf-bytes-per-lane (gpu-reg-budget-per-lane caps flanes)
-                  :max-workgroup-size (long (or (:max-workgroup-size caps) 256)))
+                  :max-workgroup-size (:max-workgroup-size execution)
+                  :capability-provenance (:source device))
+      (and gpu? flanes)
+      (assoc :subgroup-size (long flanes)
+             :grf-bytes-per-lane
+             (gpu-reg-budget-per-lane target-type caps (long flanes)))
       ;; MATRIX UNIT (systolic array) — the hardware matrix-multiply shape {:family :m :n :k
       ;; :subgroup}, e.g. Intel XMX DPAS 8×16×16. A catalogue fact (not always probeable); the
       ;; GEMM tile generator (derive-gemm-tile) reads it to size the accumulator tile + K-unroll,
       ;; and the emitter keys its instruction family off :family (:dpas vs a WGMMA/MFMA fork).
-      (and gpu? (:matrix caps)) (assoc :matrix (:matrix caps))
-      ;; NVIDIA: derive the WMMA matrix shape from compute capability — every cc≥7.0 part has Tensor
-      ;; Cores with the universal 16×16×16 f16 WMMA fragment (warp 32), so it need not be catalogued
-      ;; per-part. (An explicit :matrix in caps wins — this only fills the gap.)
-      (and gpu? (nil? (:matrix caps)) (:compute-capability caps)
-           (>= (long (first (:compute-capability caps))) 7))
-      (assoc :matrix {:family :mma :m 16 :n 16 :k 16 :subgroup 32})
-      ;; AMD CDNA (gfx9): Matrix Cores with the f16 16×16×16 MFMA (v_mfma_f32_16x16x16f16),
-      ;; wavefront 64. Derived from the gfx arch when not explicitly catalogued.
-      (and gpu? (nil? (:matrix caps)) (amd-cdna? caps))
-      (assoc :matrix {:family :mfma :m 16 :n 16 :k 16 :subgroup 64})
+      matrix (assoc :matrix matrix)
       (seq gpu-geo) (merge gpu-geo)
       ;; MACHINE WIDTH — work-items in flight when the device is full: EUs x hw threads per
       ;; EU x SIMD lanes. Every GPU launch geometry is a function of this and the problem
@@ -184,11 +422,10 @@
       ;; to 1 would silently yield machine-lanes=16 — split-k would never fire and every
       ;; elementwise kernel would mis-vectorize, with no error anywhere. A missing value
       ;; leaves the key ABSENT, and the derivations below fall back to a documented default.
-      (and gpu? (:total-eus caps) (:threads-per-eu caps)
-           (or (:simd-width caps) (rt/subgroup-size device-id)))
+      (and gpu? (:total-eus caps) (:threads-per-eu caps) gpu-width)
       (assoc :machine-lanes (* (long (:total-eus caps))
                                (long (:threads-per-eu caps))
-                               (long (or (:simd-width caps) (rt/subgroup-size device-id))))))))
+                               (long gpu-width))))))
 
 (defn descriptor-for
   "The HardwareDescriptor for `device-id`: the probed/analytic model (build-descriptor) with the
@@ -488,7 +725,8 @@
      - per-subgroup accumulator tile (sg-m×sg-n) is GRF-BOUND: it holds sg-m·sg-n/subgroup f32
        accumulators per lane, so sg-m·sg-n ≤ grf-bytes-per-lane·subgroup/4. Take the largest square
        tile under that cap, rounded DOWN to the matrix M_i/N_i granularity.
-     - workgroup tile is `wg-subgroups` (default 16 = a 4×4 subgroup grid) copies of the sg-tile.
+     - workgroup tile is `wg-subgroups` (default 16 = a 4×4 subgroup grid) copies of the sg-tile,
+       capped by the target's maximum workgroup size.
      - K-unroll is 2× the matrix K (double-buffered DPAS depth).
 
    On the Arc 140V descriptor (matrix 8×16×16, GRF 256 B/lane, subgroup 16) this yields exactly the
@@ -511,7 +749,9 @@
                       (* 4 (max (long m) (long n))))
          sg-m    (* m (max 1 (quot side m)))         ;; round down to M_i multiple
          sg-n    (* n (max 1 (quot side n)))         ;; round down to N_i multiple
-         wg-sub  (long (:wg-subgroups opts 16))
+         max-wg (long (:max-workgroup-size desc 1024))
+         max-wg-subgroups (max 1 (quot max-wg sg))
+         wg-sub  (min (long (:wg-subgroups opts 16)) max-wg-subgroups)
          side-sg (max 1 (long (Math/sqrt (double wg-sub))))]
      {:block-m (* sg-m side-sg)
       :block-n (* sg-n side-sg)

--- a/src/raster/compiler/passes/parallel/attention_route.clj
+++ b/src/raster/compiler/passes/parallel/attention_route.clj
@@ -1,6 +1,7 @@
 (ns raster.compiler.passes.parallel.attention-route
   "Structured routing for backend-neutral attention problems."
   (:require [raster.compiler.backend.gpu.attention :as emit]
+            [raster.compiler.backend.gpu.target :as gpu-target]
             [raster.compiler.ir.attention :as attention]
             [raster.compiler.passes.parallel.attention-lower :as lower]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-schedule :as swr-schedule]))
@@ -78,13 +79,19 @@
 
            (or (= :auto policy) (contains? cooperative-policies policy))
            (let [{:keys [ok schedule reason] :as scheduled}
-                 (swr-schedule/plan-subgroup-online plan desc)]
-             (if ok
+                 (swr-schedule/plan-subgroup-online plan desc)
+                 emitter-supported? (gpu-target/intel-opencl-subgroup-dialect? desc)]
+             (if (and ok emitter-supported?)
                (success problem plan (emit/emit-fp16-cooperative plan schedule) [])
                (let [cooperative-decline
                      {:leaf :routed-paged-subgroup-online-score-reuse
-                      :reason reason
-                      :data (dissoc scheduled :ok :reason)}]
+                      :reason (if ok
+                                :score-reuse-requires-intel-subgroup-dialect
+                                reason)
+                      :data (if ok
+                              {:vendor (:vendor desc)
+                               :matrix-family (get-in desc [:matrix :family])}
+                              (dissoc scheduled :ok :reason))}]
                  (if (= :auto policy)
                    (success problem plan (emit/emit-fp16-reference plan desc)
                             [cooperative-decline])

--- a/src/raster/compiler/passes/parallel/contraction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/contraction_schedule.clj
@@ -276,9 +276,15 @@
                      {:reason :raster/bug :facts contract-facts})))
    (let [{:keys [dtype free-axes contract-axes body combine init operands epilogue]}
          contract-facts
-         raw-tile (or tile (hardware/derive-gemm-tile (or desc {})))
-         matrix (assoc (:matrix raw-tile) :family (or (get-in raw-tile [:matrix :family]) :dpas))
-         tile (assoc raw-tile :matrix matrix :num-stages (or (:num-stages raw-tile) 3))
+         authoritative-desc? (and desc (or (:backend desc) (:execution desc)))
+         matrix-capability-unavailable? (and authoritative-desc? (nil? (:matrix desc)))
+         raw-tile (when-not matrix-capability-unavailable?
+                    (or tile (hardware/derive-gemm-tile (or desc {}))))
+         matrix (when raw-tile
+                  (assoc (:matrix raw-tile)
+                         :family (or (get-in raw-tile [:matrix :family]) :dpas)))
+         tile (when raw-tile
+                (assoc raw-tile :matrix matrix :num-stages (or (:num-stages raw-tile) 3)))
          layout-verdict (when (and (= 2 (count free-axes)) (= 1 (count contract-axes)))
                           (facts/check-layout contract-facts (:dpas facts/leaf-layouts)))
          bindings (:bindings layout-verdict)
@@ -287,6 +293,12 @@
          K (second (first contract-axes))
          matrix-k (:k matrix)]
      (cond
+       matrix-capability-unavailable?
+       (decline :matrix-capability-unavailable
+                {:backend (:backend desc)
+                 :supported-subgroup-sizes
+                 (hardware/supported-subgroup-sizes desc)})
+
        (or (not (dtype/known? dtype)) (not= :half (dtype/canon dtype)))
        (decline :dtype-not-dpas {:dtype dtype})
 

--- a/src/raster/compiler/passes/parallel/indexed_attention_route.clj
+++ b/src/raster/compiler/passes/parallel/indexed_attention_route.clj
@@ -1,7 +1,8 @@
 (ns raster.compiler.passes.parallel.indexed-attention-route
   "Structured routing for recognized indexed graph-attention plans."
-  (:require [clojure.string :as str]
-            [raster.compiler.backend.gpu.indexed-attention :as emit]
+  (:require [raster.compiler.backend.gpu.indexed-attention :as emit]
+            [raster.compiler.backend.gpu.target :as gpu-target]
+            [raster.compiler.core.hardware :as hardware]
             [raster.compiler.ir.segmented-weighted-reduction :as swr]))
 
 (defn- decline
@@ -115,21 +116,31 @@
      (try
        (let [{:keys [operands output accumulator-dtype] :as plan} (swr/validate! plan)
              storage-dtypes (mapv :dtype (conj operands output))
-             subgroup-size (long (or (:subgroup-size desc) 16))
-             max-workgroup-size (long (or (:max-workgroup-size desc) 256))
-             vendor (some-> (:vendor desc) str str/lower-case)
+             subgroup-size (hardware/preferred-subgroup-size desc)
+             max-workgroup-size (hardware/maximum-workgroup-size desc)
+             supported-widths (hardware/supported-subgroup-sizes desc)
              matrix-family (get-in desc [:matrix :family])
-             known-non-intel? (and (or vendor matrix-family)
-                                   (not (or (= :dpas matrix-family)
-                                            (and vendor (str/includes? vendor "intel")))))]
+             intel-dialect? (gpu-target/intel-opencl-subgroup-dialect? desc)]
          (cond
            (and desc (not= :gpu (:device-type desc)))
            (decline plan leaf :score-reuse-requires-gpu
                     {:device-type (:device-type desc)})
 
-           known-non-intel?
+           (not intel-dialect?)
            (decline plan leaf :score-reuse-requires-intel-subgroup-dialect
                     {:vendor (:vendor desc) :matrix-family matrix-family})
+
+           (or (not (integer? subgroup-size))
+               (not (integer? max-workgroup-size)))
+           (decline plan leaf :score-reuse-missing-execution-capability
+                    {:subgroup-size subgroup-size
+                     :max-workgroup-size max-workgroup-size})
+
+           (and (seq supported-widths)
+                (not (contains? (set supported-widths) subgroup-size)))
+           (decline plan leaf :score-reuse-subgroup-width-unsupported
+                    {:subgroup-size subgroup-size
+                     :supported-subgroup-sizes (set supported-widths)})
 
            (not (contains? #{:float :double} accumulator-dtype))
            (decline plan leaf :score-reuse-accumulator-unsupported
@@ -143,8 +154,8 @@
                                 :long :long accumulator-dtype]
                      :actual storage-dtypes})
 
-           (or (not (pos? subgroup-size))
-               (> subgroup-size max-workgroup-size))
+           (or (not (pos? (long subgroup-size)))
+               (> (long subgroup-size) (long max-workgroup-size)))
            (decline plan leaf :score-reuse-invalid-subgroup-geometry
                     {:subgroup-size subgroup-size
                      :max-workgroup-size max-workgroup-size})

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_schedule.clj
@@ -1,6 +1,6 @@
 (ns raster.compiler.passes.parallel.segmented-weighted-reduction-schedule
   "Apply cooperative hardware schedules to schedule-neutral segmented weighted reductions."
-  (:require [clojure.string :as str]
+  (:require [raster.compiler.core.hardware :as hardware]
             [raster.compiler.ir.segmented-weighted-reduction :as swr]
             [raster.compiler.ir.segmented-weighted-reduction-schedule :as schedule]))
 
@@ -17,22 +17,26 @@
   ([plan desc]
    (let [{:keys [membership storage score value operands output accumulator-dtype] :as plan}
          (swr/validate! plan)
-         subgroup-size (long (or (:subgroup-size desc) 16))
-         max-workgroup-size (long (or (:max-workgroup-size desc) 256))
-         vendor (some-> (:vendor desc) str str/lower-case)
-         matrix-family (get-in desc [:matrix :family])
-         known-non-intel? (and (or vendor matrix-family)
-                               (not (or (= :dpas matrix-family)
-                                        (and vendor (str/includes? vendor "intel")))))
+         subgroup-size (hardware/preferred-subgroup-size desc)
+         max-workgroup-size (hardware/maximum-workgroup-size desc)
+         supported-widths (hardware/supported-subgroup-sizes desc)
          components (:components value)
          operand-dtypes (mapv :dtype operands)]
      (cond
        (and desc (not= :gpu (:device-type desc)))
        (decline :score-reuse-requires-gpu {:device-type (:device-type desc)})
 
-       known-non-intel?
-       (decline :score-reuse-requires-intel-subgroup-dialect
-                {:vendor (:vendor desc) :matrix-family matrix-family})
+       (or (not (integer? subgroup-size))
+           (not (integer? max-workgroup-size)))
+       (decline :score-reuse-missing-execution-capability
+                {:subgroup-size subgroup-size
+                 :max-workgroup-size max-workgroup-size})
+
+       (and (seq supported-widths)
+            (not (contains? (set supported-widths) subgroup-size)))
+       (decline :score-reuse-subgroup-width-unsupported
+                {:subgroup-size subgroup-size
+                 :supported-subgroup-sizes (set supported-widths)})
 
        (not (swr/online-softmax-algebra? plan))
        (decline :score-reuse-requires-online-softmax-algebra)
@@ -69,30 +73,33 @@
        (or (not (integer? components)) (not (pos? components)))
        (decline :score-reuse-static-value-width-required {:components components})
 
-       (or (not (pos? subgroup-size)) (> subgroup-size max-workgroup-size))
+       (or (not (pos? (long subgroup-size)))
+           (> (long subgroup-size) (long max-workgroup-size)))
        (decline :score-reuse-invalid-subgroup-geometry
                 {:subgroup-size subgroup-size :max-workgroup-size max-workgroup-size})
 
        ;; A static cap makes register-state feasibility explicit. Gemma D=256/SG16 uses 16.
-       (> (quot (+ components (dec subgroup-size)) subgroup-size) 32)
+       (> (quot (+ components (dec (long subgroup-size))) (long subgroup-size)) 32)
        (decline :score-reuse-register-state-too-wide
                 {:components components :subgroup-size subgroup-size
-                 :components-per-lane (quot (+ components (dec subgroup-size)) subgroup-size)})
+                 :components-per-lane
+                 (quot (+ components (dec (long subgroup-size))) (long subgroup-size))})
 
        :else
        {:ok true
         :schedule
         (schedule/make
          {:strategy :subgroup-online-score-reuse
-          :workgroup-size subgroup-size
+          :workgroup-size (long subgroup-size)
           :segment-mapping :one-workgroup-per-segment
           :membership-traversal :sequential
-          :score-reduction {:kind :subgroup :width subgroup-size
+          :score-reduction {:kind :subgroup :width (long subgroup-size)
                             :axis (get-in score [:axis :name])}
           :value-mapping {:kind :lane-strided
                           :components components
                           :components-per-lane
-                          (quot (+ components (dec subgroup-size)) subgroup-size)}
+                          (quot (+ components (dec (long subgroup-size)))
+                                (long subgroup-size))}
           :state {:kind :online-normalized-weighted-sum
                   :components [:maximum :denominator :weighted-values]}
           :numerical-mode {:score-accumulate accumulator-dtype

--- a/src/raster/runtime/hardware.clj
+++ b/src/raster/runtime/hardware.clj
@@ -246,12 +246,14 @@
           (mapv (fn [idx dev-info]
                   (let [dev-name (:name dev-info)
                         catalogue-spec (catalogue/find-gpu-spec dev-name)
-                        probed (select-keys dev-info
-                                            [:total-eus :threads-per-eu :simd-width
-                                             :subgroup-sizes :max-workgroup-size
-                                             :shared-local-memory :global-memory-bytes
-                                             :memory-bandwidth-gb-s :core-clock-mhz
-                                             :device-id-hex :integrated?])
+                        probed (into {}
+                                     (remove (comp nil? val))
+                                     (select-keys dev-info
+                                                  [:total-eus :threads-per-eu :simd-width
+                                                   :subgroup-sizes :max-workgroup-size
+                                                   :shared-local-memory :global-memory-bytes
+                                                   :memory-bandwidth-gb-s :core-clock-mhz
+                                                   :device-id-hex :integrated?]))
                         caps (merge (when catalogue-spec catalogue-spec) probed)
                         ;; PER-FIELD provenance. This used to stamp {:all :detected} over the
                         ;; whole map, which was false for every catalogued field (bandwidth,
@@ -288,19 +290,27 @@
           (mapv (fn [idx dev-info]
                   (let [dev-name (:name dev-info)
                         catalogue-spec (catalogue/find-gpu-spec dev-name)
-                        caps (merge
-                              (when catalogue-spec catalogue-spec)
-                              (select-keys dev-info
-                                           [:max-compute-units :max-work-group-size
-                                            :global-mem-bytes :max-clock-mhz
-                                            :extensions :vendor :version
-                                            :integrated?]))]
+                        probed (into {}
+                                     (remove (comp nil? val))
+                                     (select-keys dev-info
+                                                  [:max-compute-units :max-work-group-size
+                                                   :max-workgroup-size :subgroup-sizes :simd-width
+                                                   :global-mem-bytes :global-memory-bytes
+                                                   :shared-local-memory :local-memory-bytes
+                                                   :max-clock-mhz :extensions :vendor :version
+                                                   :integrated?]))
+                        caps (merge (when catalogue-spec catalogue-spec) probed)
+                        source (merge
+                                (into {} (map (fn [k] [k :catalogued]))
+                                      (keys catalogue-spec))
+                                (into {} (map (fn [k] [k :detected]))
+                                      (keys probed)))]
                     {:id (keyword (str "ocl:" idx))
                      :type :ocl
                      :index idx
                      :name dev-name
                      :capabilities caps
-                     :source {:all :detected}}))
+                     :source source}))
                 (range) devices))))
     (catch Exception e
       (when (System/getenv "ROMEO_DEBUG")
@@ -380,24 +390,36 @@
   Capabilities are merged with catalogue data if available."
   [device-id spec]
   (ensure-init!)
-  (let [dev-name (:name spec)
+  (let [target-type (device-type device-id)
+        claimed-type (:type spec)
+        _ (when (and claimed-type (not= target-type claimed-type))
+            (throw (ex-info "target device type disagrees with its device id"
+                            {:reason :target-device-type-mismatch
+                             :device-id device-id :id-type target-type
+                             :claimed-type claimed-type})))
+        dev-name (:name spec)
         catalogue-spec (when dev-name (catalogue/find-gpu-spec dev-name))
         idx (or (:index spec)
                 (when-let [m (re-find #":(\d+)$" (name device-id))]
                   (Long/parseLong (second m)))
                 0)
-        ;; Merge capabilities: catalogue provides defaults, user spec overrides
-        merged-caps (merge (or catalogue-spec {})
-                           (or (:capabilities spec) {}))
+        user-caps (or (:capabilities spec) {})
+        ;; Merge capabilities: catalogue provides defaults, user spec overrides. Provenance is
+        ;; recorded per field so a cross-compiler can distinguish an observed/user constraint
+        ;; from a catalogue estimate instead of treating the entire merged row as `:user`.
+        merged-caps (merge (or catalogue-spec {}) user-caps)
+        source (merge
+                (into {} (map (fn [k] [k :catalogued])) (keys catalogue-spec))
+                (into {} (map (fn [k] [k :user])) (keys user-caps)))
         device (merge
+                ;; User descriptive fields remain extensible, but identity, normalized type,
+                ;; provenance, and the merged capability row are owned by this boundary.
+                (dissoc spec :id :type :index :source :capabilities)
                 {:id device-id
-                 :type (device-type device-id)
+                 :type target-type
                  :index idx
-                 :source {:all :user}}
-                 ;; User spec (without :capabilities, which we merge separately)
-                (dissoc spec :capabilities)
-                 ;; Merged capabilities
-                {:capabilities merged-caps})]
+                 :source source
+                 :capabilities merged-caps})]
     (swap! device-registry assoc device-id device)
     device))
 

--- a/test/raster/compiler/core/cross_vendor_descriptor_test.clj
+++ b/test/raster/compiler/core/cross_vendor_descriptor_test.clj
@@ -10,16 +10,24 @@
 (deftest per-vendor-matrix-and-register-budget
   (rt/init!)
   (rt/register-target-device! :cuda:test
-    {:type :cuda :name "synthetic-nvidia" :capabilities {:compute-capability [8 0] :warp-size 32 :total-eus 64}})
+                              {:type :cuda :name "synthetic-nvidia" :capabilities {:compute-capability [8 0] :warp-size 32 :total-eus 64}})
   (rt/register-target-device! :hip:test
-    {:type :hip :name "synthetic-amd" :capabilities {:gfx-arch :gfx90a :total-eus 64}})
+                              {:type :hip :name "synthetic-amd" :capabilities {:gfx-arch :gfx90a :total-eus 64}})
   (let [nv  (hw/descriptor-for :cuda:test)
         amd (hw/descriptor-for :hip:test)]
     (testing "NVIDIA: compute-capability ≥7 → WMMA :mma 16×16×16 warp32; register file 255×4"
       (is (= {:family :mma :m 16 :n 16 :k 16 :subgroup 32} (:matrix nv)))
+      (is (= :warp (get-in nv [:execution :subgroup-kind])))
+      (is (= #{32} (:subgroup-sizes nv)))
+      (is (= 32 (:subgroup-size nv)))
+      (is (= 1024 (:max-workgroup-size nv)))
       (is (= 1020 (:grf-bytes-per-lane nv))))
     (testing "AMD CDNA (gfx9): Matrix Cores :mfma 16×16×16 wavefront64; 256 VGPRs×4"
       (is (= {:family :mfma :m 16 :n 16 :k 16 :subgroup 64} (:matrix amd)))
+      (is (= :wavefront (get-in amd [:execution :subgroup-kind])))
+      (is (= #{64} (:subgroup-sizes amd)))
+      (is (= 64 (:subgroup-size amd)))
+      (is (= 1024 (:max-workgroup-size amd)))
       (is (= 1024 (:grf-bytes-per-lane amd))))
     (testing "the tile is sized against the vendor register file but CAPPED (not register-filling)"
       ;; both NVIDIA and AMD have ~4× Intel's register file; the cap keeps the warp tile at
@@ -28,3 +36,190 @@
       (is (= 64 (:sg-m (hw/derive-gemm-tile amd))))
       (is (<= (* (:sg-m (hw/derive-gemm-tile nv)) (:sg-n (hw/derive-gemm-tile nv)))
               (quot (* (:grf-bytes-per-lane nv) 32) 4)) "still fits the register budget"))))
+
+(deftest catalogue-targets-normalize-execution-hierarchy-and-provenance
+  (rt/register-target-device! :cuda:a100 {:name "NVIDIA A100"})
+  (rt/register-target-device! :ze:arc {:name "Intel(R) Arc(TM) Graphics"})
+  (let [a100-device (rt/device :cuda:a100)
+        a100 (hw/descriptor-for :cuda:a100)
+        arc (hw/descriptor-for :ze:arc)
+        tile (hw/derive-gemm-tile a100)
+        tile-threads (* (quot (:block-m tile) (:sg-m tile))
+                        (quot (:block-n tile) (:sg-n tile))
+                        (:subgroup-size a100))]
+    (testing "CUDA catalogue keys do not leak Level Zero defaults"
+      (is (= :cuda (:backend a100)))
+      (is (= #{32} (get-in a100 [:execution :subgroup-sizes])))
+      (is (= 32 (get-in a100 [:execution :preferred-subgroup-size])))
+      (is (= 1024 (get-in a100 [:execution :max-workgroup-size])))
+      (is (<= tile-threads (:max-workgroup-size a100))))
+    (testing "catalogue versus user provenance remains visible per capability"
+      (is (= :catalogued (get-in a100-device [:source :warp-size])))
+      (is (= :catalogued
+             (get-in a100 [:execution :provenance :preferred-subgroup-size])))
+      (is (= :catalogued
+             (get-in a100 [:execution :provenance :max-workgroup-size]))))
+    (testing "Intel retains several supported widths and a distinct preference"
+      (is (= #{16 32} (get-in arc [:execution :subgroup-sizes])))
+      (is (= 16 (get-in arc [:execution :preferred-subgroup-size])))
+      (is (= :subgroup (get-in arc [:execution :subgroup-kind]))))))
+
+(deftest explicit-capabilities-override-catalogue-per-field
+  (let [device (rt/register-target-device!
+                :cuda:a100-user
+                {:name "NVIDIA A100"
+                 :capabilities {:max-threads-per-block 512}})
+        desc (hw/descriptor-for :cuda:a100-user)]
+    (is (= 32 (:subgroup-size desc)))
+    (is (= 512 (:max-workgroup-size desc)))
+    (is (= :catalogued (get-in device [:source :warp-size])))
+    (is (= :user (get-in device [:source :max-threads-per-block])))
+    (is (= :user (get-in desc [:execution :provenance :max-workgroup-size])))))
+
+(deftest backend-native-capability-aliases-project-once
+  (rt/register-target-device!
+   :hip:rdna
+   {:type :hip :name "synthetic-rdna"
+    :capabilities {:gfx-arch :gfx1100
+                   :wavefront-sizes [32 64]
+                   :wavefront-size 32
+                   :max-work-group-size 1024
+                   :local-memory-bytes 65536}})
+  (rt/register-target-device!
+   :ocl:portable
+   {:type :ocl :name "synthetic-opencl"
+    :capabilities {:subgroup-sizes [8 16 32]
+                   :simd-width 16
+                   :max-work-group-size 512
+                   :local-memory-bytes 32768}})
+  (let [rdna (hw/descriptor-for :hip:rdna)
+        opencl (hw/descriptor-for :ocl:portable)]
+    (is (= #{32 64} (:subgroup-sizes rdna)))
+    (is (= 32 (:subgroup-size rdna)))
+    (is (= 1024 (:max-workgroup-size rdna)))
+    (is (= 65536 (get-in rdna [:cache :slm])))
+    (is (= #{8 16 32} (:subgroup-sizes opencl)))
+    (is (= 16 (:subgroup-size opencl)))
+    (is (= 512 (:max-workgroup-size opencl)))
+    (is (= 32768 (get-in opencl [:cache :slm])))))
+
+(deftest authoritative-aliases-override-catalogue-spellings
+  (let [device (rt/register-target-device!
+                :ze:alias-priority
+                {:name "Intel(R) Arc(TM) Graphics"
+                 :capabilities {:max-work-group-size 512
+                                :local-memory-bytes 32768}})
+        desc (hw/descriptor-for :ze:alias-priority)]
+    (is (= 512 (:max-workgroup-size desc)))
+    (is (= 32768 (get-in desc [:cache :slm])))
+    (is (= :user (get-in desc [:execution :provenance :max-workgroup-size])))
+    (is (= :user (get-in desc [:execution :provenance :scratchpad-bytes])))
+    (is (= :catalogued (get-in device [:source :max-workgroup-size])))
+    (is (= :user (get-in device [:source :max-work-group-size])))))
+
+(deftest unknown-opencl-target-keeps-noncollective-capabilities
+  (rt/register-target-device!
+   :ocl:no-subgroup
+   {:name "portable-ocl"
+    :capabilities {:max-work-group-size 256
+                   :max-compute-units 12
+                   :global-mem-bytes 1048576}})
+  (let [desc (hw/descriptor-for :ocl:no-subgroup)]
+    (is (= #{} (:subgroup-sizes desc)))
+    (is (nil? (:subgroup-size desc)))
+    (is (nil? (:vector-bits desc)))
+    (is (= 256 (:max-workgroup-size desc)))
+    (is (= 12 (:compute-units desc)))
+    (is (= 1048576 (:global-memory-bytes desc)))))
+
+(deftest matrix-scope-must-be-supported-by-the-execution-hierarchy
+  (rt/register-target-device!
+   :cuda:bad-matrix
+   {:type :cuda :name "bad-matrix-nvidia"
+    :capabilities {:compute-capability [8 0]
+                   :warp-size 32
+                   :matrix {:family :mma :m 16 :n 16 :k 16 :subgroup 64}}})
+  (is (= :hardware-matrix-subgroup-unsupported
+         (try
+           (hw/descriptor-for :cuda:bad-matrix)
+           (catch clojure.lang.ExceptionInfo e
+             (:reason (ex-data e)))))))
+
+(deftest inferred-matrix-scope-is-validated-after-capability-finalization
+  (doseq [[device-id spec]
+          [[:cuda:bad-inferred-mma
+            {:type :cuda :name "bad-inferred-mma"
+             :capabilities {:compute-capability [8 0]
+                            :subgroup-sizes [64]}}]
+           [:hip:bad-inferred-mfma
+            {:type :hip :name "bad-inferred-mfma"
+             :capabilities {:gfx-arch :gfx90a
+                            :wavefront-sizes [32]
+                            :wavefront-size 32}}]]]
+    (rt/register-target-device! device-id spec)
+    (is (= :hardware-matrix-subgroup-unsupported
+           (try
+             (hw/descriptor-for device-id)
+             (catch clojure.lang.ExceptionInfo e
+               (:reason (ex-data e))))))))
+
+(deftest target-identity-and-provenance-are-authoritative
+  (is (= :target-device-type-mismatch
+         (try
+           (rt/register-target-device! :cuda:type-conflict
+                                       {:type :hip :name "wrong-family"})
+           (catch clojure.lang.ExceptionInfo e
+             (:reason (ex-data e))))))
+  (let [device (rt/register-target-device!
+                :cuda:source-override
+                {:name "NVIDIA A100"
+                 :source {:warp-size :measured}})]
+    (is (= :cuda (:type device)))
+    (is (= :catalogued (get-in device [:source :warp-size])))))
+
+(deftest workgroup-derived-matrix-tile-respects-the-thread-limit
+  (rt/register-target-device!
+   :cuda:small-block
+   {:type :cuda :name "small-block-nvidia"
+    :capabilities {:compute-capability [8 0]
+                   :warp-size 32
+                   :max-threads-per-block 256}})
+  (let [desc (hw/descriptor-for :cuda:small-block)
+        tile (hw/derive-gemm-tile desc)
+        threads (* (quot (:block-m tile) (:sg-m tile))
+                   (quot (:block-n tile) (:sg-n tile))
+                   (:subgroup-size desc))]
+    (is (<= threads 256))))
+
+(deftest pre-cdna-gfx9-does-not-acquire-mfma-by-prefix
+  (rt/register-target-device!
+   :hip:gfx900
+   {:type :hip :name "Vega gfx900" :capabilities {:gfx-arch :gfx900}})
+  (let [desc (hw/descriptor-for :hip:gfx900)]
+    (is (nil? (:matrix desc)))
+    (is (nil? (:subgroup-size desc)))))
+
+(deftest equal-authority-alias-conflicts-fail-loudly
+  (rt/register-target-device!
+   :ocl:alias-conflict
+   {:type :ocl :name "conflicting-opencl"
+    :capabilities {:max-workgroup-size 256 :max-work-group-size 512
+                   :subgroup-sizes [16] :simd-width 16}})
+  (is (= :hardware-capability-alias-conflict
+         (try
+           (hw/descriptor-for :ocl:alias-conflict)
+           (catch clojure.lang.ExceptionInfo e
+             (:reason (ex-data e)))))))
+
+(deftest contradictory-width-capabilities-fail-loudly
+  (rt/register-target-device!
+   :cuda:contradictory
+   {:type :cuda :name "contradictory-nvidia"
+    :capabilities {:compute-capability [8 0]
+                   :subgroup-sizes [16]
+                   :warp-size 32}})
+  (is (= :hardware-preferred-subgroup-unsupported
+         (try
+           (hw/descriptor-for :cuda:contradictory)
+           (catch clojure.lang.ExceptionInfo e
+             (:reason (ex-data e)))))))

--- a/test/raster/compiler/passes/parallel/attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/attention_route_test.clj
@@ -51,6 +51,10 @@
                         {:causal? true :window-left 2 :window-right 0})}
           (apply hash-map overrides))))
 
+(def ^:private intel-desc
+  {:device-type :gpu :vendor "Intel" :subgroup-size 16
+   :max-workgroup-size 256})
+
 (deftest dense-reference-is-a-complete-packed-attention-compiler-value
   (let [{:keys [strategy reference? declines plan artifact graph schedule]}
         (route/route! (problem)
@@ -151,18 +155,47 @@
              (attention-emit/emit-fp16-cooperative
               plan (assoc-in schedule [:score-reduction :axis] :wrong-axis))
              (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
-    (is (= :score-reuse-requires-intel-subgroup-dialect
+    (let [nvidia-desc {:device-type :gpu :vendor "NVIDIA" :subgroup-size 32
+                       :max-workgroup-size 1024}
+          nvidia-schedule (schedule-pass/plan-subgroup-online plan nvidia-desc)
+          nvidia-route (route/route (problem) nvidia-desc)]
+      (is (:ok nvidia-schedule)
+          "the schedule is portable even while the current optimized emitter is not")
+      (is (= 32 (get-in nvidia-schedule [:schedule :workgroup-size])))
+      (is (:reference? nvidia-route))
+      (is (= :score-reuse-requires-intel-subgroup-dialect
+             (get-in nvidia-route [:declines 0 :reason]))))
+    (let [spoofed-intel {:device-type :gpu :backend :cuda :vendor "Intel"
+                         :subgroup-size 32 :max-workgroup-size 1024
+                         :matrix {:family :dpas :m 8 :n 16 :k 16 :subgroup 32}}
+          routed (route/route (problem) spoofed-intel)]
+      (is (:reference? routed))
+      (is (= :score-reuse-requires-intel-subgroup-dialect
+             (get-in routed [:declines 0 :reason]))))
+    (is (= :score-reuse-missing-execution-capability
+           (:reason (schedule-pass/plan-subgroup-online plan nil)))
+        "an absent descriptor cannot prove a cooperative schedule")
+    (is (= :score-reuse-missing-execution-capability
            (:reason
             (schedule-pass/plan-subgroup-online
-             plan {:device-type :gpu :vendor "NVIDIA" :subgroup-size 32
-                   :max-workgroup-size 1024}))))
+             plan {:device-type :gpu :vendor "Intel"
+                   :execution {:subgroup-sizes #{}
+                               :preferred-subgroup-size nil
+                               :max-workgroup-size 256}}))))
+    (is (= :score-reuse-subgroup-width-unsupported
+           (:reason
+            (schedule-pass/plan-subgroup-online
+             plan {:device-type :gpu :vendor "Intel"
+                   :execution {:subgroup-sizes #{32}
+                               :preferred-subgroup-size 16
+                               :max-workgroup-size 256}}))))
     (is (:reference? too-wide))
     (is (= :score-reuse-register-state-too-wide
            (get-in too-wide [:declines 0 :reason])))))
 
 (deftest csr-route-has-native-compact-page-abi
   (let [{:keys [artifact reference? declines]}
-        (route/route! (problem :route (csr-route)))]
+        (route/route! (problem :route (csr-route)) intel-desc)]
     (is reference?)
     (is (= :score-reuse-route-unsupported (get-in declines [0 :reason])))
     (is (= :csr-paged (get-in artifact [:attributes :route-kind])))
@@ -176,7 +209,7 @@
 
 (deftest logical-csr-visibility-composes-with-physical-route-as-distinct-abi-slots
   (let [{:keys [artifact reference? declines]}
-        (route/route! (problem :visibility (csr-visibility)))]
+        (route/route! (problem :visibility (csr-visibility)) intel-desc)]
     (is reference?)
     (is (= :score-reuse-visibility-unsupported (get-in declines [0 :reason])))
     (is (= :dense-paged (get-in artifact [:attributes :route-kind])))
@@ -202,9 +235,10 @@
                        "((long)physical_page * 2 + page_token) * 2 + kv_head) * 6"))))
 
 (deftest fp32-query-and-output-compose-with-fp16-kv-storage
-  (let [fp16-artifact (:artifact (route/route! (problem)))
+  (let [fp16-artifact (:artifact (route/route! (problem) intel-desc))
         artifact (:artifact (route/route!
-                             (problem :q-dtype :float :output-dtype :float)))
+                             (problem :q-dtype :float :output-dtype :float)
+                             intel-desc))
         source (:source artifact)]
     (is (not= (:kernel-name fp16-artifact) (:kernel-name artifact)))
     (is (= [:float :int :int :half :half :int :int :int :float]

--- a/test/raster/compiler/passes/parallel/contraction_schedule_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_schedule_test.clj
@@ -72,6 +72,17 @@
       (is (= :regtiled (:strategy routed)))
       (is (= :matrix-instruction-not-lowered (:fallback-reason routed))))))
 
+(deftest authoritative-targets-without-matrix-capabilities-do-not-inherit-dpas
+  (let [desc {:device-type :gpu :backend :ocl
+              :execution {:subgroup-sizes #{}
+                          :preferred-subgroup-size nil
+                          :max-workgroup-size 256}}
+        planned (schedule/plan-matrix-body
+                 (facts/contraction-facts (matrix-form 128 128 128) :dtype :half)
+                 desc nil)]
+    (is (false? (:ok planned)))
+    (is (= :matrix-capability-unavailable (:reason planned)))))
+
 (deftest the-production-route-carries-the-body-into-the-executable-artifact
   (let [routed (route/route-contraction (matrix-form 128 128 128) :dtype :half)
         kernel (:kernel-body routed)]

--- a/test/raster/compiler/passes/parallel/indexed_attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/indexed_attention_route_test.clj
@@ -111,6 +111,7 @@
         {:keys [leaf strategy reference? artifact graph]}
         (swr-route/route-dynamic!
          generic-plan {:device-type :gpu
+                       :vendor "Intel"
                        :subgroup-size 16
                        :max-workgroup-size 256
                        :segmented-weighted-reduction-schedule :subgroup-score-reuse})
@@ -144,6 +145,7 @@
   (let [{:keys [leaf strategy]}
         (swr-route/route-dynamic!
          (plan) {:device-type :gpu
+                 :vendor "Intel"
                  :subgroup-size 16
                  :max-workgroup-size 0
                  :segmented-weighted-reduction-schedule :subgroup-score-reuse})]
@@ -174,6 +176,7 @@
       (let [source (get-in
                     (swr-route/route-dynamic!
                      (plan) {:device-type :gpu
+                             :vendor "Intel"
                              :subgroup-size 16
                              :max-workgroup-size 256
                              :segmented-weighted-reduction-schedule :subgroup-score-reuse})

--- a/test/raster/gpu/indexed_attention_device_test.clj
+++ b/test/raster/gpu/indexed_attention_device_test.clj
@@ -77,6 +77,7 @@
         graph (:graph (route/route-dynamic!
                        plan
                        {:device-type :gpu
+                        :vendor "Intel"
                         :subgroup-size 16
                         :max-workgroup-size 256
                         :segmented-weighted-reduction-schedule :subgroup-score-reuse}))


### PR DESCRIPTION
## Summary

- normalize CUDA, HIP, Level Zero, and OpenCL execution capabilities into one compiler-facing descriptor with field provenance
- distinguish supported and preferred subgroup widths and validate workgroup and matrix-scope geometry
- keep cooperative schedules target-neutral while moving Intel OpenCL dialect eligibility into the emitter boundary
- make contraction scheduling fail closed when an authoritative target lacks matrix capabilities

This is the first cross-vendor lowering slice in the compiler roadmap. It does not add PTX or HIP emitters yet; it establishes the safe target contract those emitters will consume.

## Verification

- clojure -J-Duser.home=/tmp/raster-full-suite-home -M:test
- 2,380 tests, 33,983 assertions
- 0 failures, 0 errors
- changed Clojure sources pass the formatter
- git diff --check passes