### PR TITLE
Certify stable KernelBody memory reads

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -103,7 +103,12 @@ loop-carried regions, and full-participation subgroup reductions/broadcasts. Bra
 are typed products; use-before-definition, identity collisions, divergent collectives, implicit
 masked-load values, conversion policy gaps, and launch/subgroup mismatches fail verification. Body
 launches use the shared `LaunchSpec`, keeping host launch expressions separate from in-kernel index
-arithmetic. Local allocation, barriers, masked collectives, and asynchronous copies remain absent
+arithmetic. Uniform memory facts require an explicit body-level stable-read contract; the checked
+KernelBody-to-ABI seam projects it to a no-write-alias precondition, artifacts reject equal compiler
+bindings, direct calls check resident ranges, and graph/link binding retains its stronger
+overlapping-write rejection. Floating narrowing distinguishes IEEE overflow from integral
+wrap/saturate/trap policies. Local allocation,
+barriers, masked collectives, and asynchronous copies remain absent
 until a concrete schedule supplies enough information to verify lifetime, alignment, execution and
 memory scopes, memory semantics, participation, and shared-byte accounting. The next production
 vertical is scheduled routed `SegmentedWeightedReduction -> KernelBody` with an invariant external

--- a/src/raster/compiler/ir/kernel_abi.clj
+++ b/src/raster/compiler/ir/kernel_abi.clj
@@ -11,13 +11,16 @@
 (def ^:private kinds #{:input :output :scalar})
 
 (defn slot
-  "Construct one ABI slot. Options: :c-name, :kernel-dtype, :role, :binding, and :field.
+  "Construct one ABI slot. Options: :c-name, :kernel-dtype, :role, :binding, :field, and
+  :aliasing.
 
    `:binding` names the logical caller value that supplies a physical pointer slot. It is
    normally absent (and therefore identical to `:name`), but an SoA argument has one physical
    slot per field and all of those slots share the same logical binding.
-   `:field` identifies this physical leaf within a composite logical binding."
-  [nm kind dtype & {:keys [c-name kernel-dtype role binding field]}]
+   `:field` identifies this physical leaf within a composite logical binding.
+   `:aliasing :no-write-alias` is an input-pointer precondition: its complete bound range must be
+   disjoint from every output pointer range for the duration of the launch."
+  [nm kind dtype & {:keys [c-name kernel-dtype role binding field aliasing]}]
   (cond-> {:name nm
            :c-name (or c-name (name nm))
            :kind kind
@@ -25,7 +28,8 @@
            :kernel-dtype (dt/canon (or kernel-dtype dtype))}
     role (assoc :role role)
     binding (assoc :binding binding)
-    field (assoc :field field)))
+    field (assoc :field field)
+    aliasing (assoc :aliasing aliasing)))
 
 (defn validate!
   "Validate an ordered ABI and return it unchanged.  A kernel has at least one output;
@@ -54,7 +58,12 @@
                       {:index i :slot s :abi abi})))
     (when (and (:field s) (nil? (:binding s)))
       (throw (ex-info "kernel ABI composite field requires an explicit logical binding"
-                      {:index i :slot s :abi abi}))))
+                      {:index i :slot s :abi abi})))
+    (when (and (:aliasing s)
+               (not (and (= :input (:kind s)) (= :no-write-alias (:aliasing s)))))
+      (throw (ex-info "kernel ABI aliasing contract is unsupported for this slot"
+                      {:index i :slot s :abi abi
+                       :supported {:kind :input :aliasing :no-write-alias}}))))
   (when-not (= (count abi) (count (distinct (map :c-name abi))))
     (throw (ex-info "kernel ABI parameter names must be unique" {:abi abi})))
   (let [pointers (vec (remove #(= :scalar (:kind %)) abi))]
@@ -119,6 +128,30 @@
     (when-not (= (count abi) (count arguments))
       (throw (ex-info "kernel ABI argument count mismatch"
                       {:expected (count abi) :actual (count arguments) :abi abi})))
+    arguments))
+
+(defn validate-alias-contracts!
+  "Enforce ABI no-write-alias requirements for complete ordered arguments.
+
+  `overlaps?` receives two pointer values and must conservatively report whether their physical
+  ranges overlap. Compiler-symbol validation may use equality; runtime call validation supplies
+  resident-view/range awareness."
+  [abi arguments overlaps?]
+  (when-not (ifn? overlaps?)
+    (throw (ex-info "kernel ABI alias validation requires an overlap predicate"
+                    {:overlaps? overlaps?})))
+  (let [abi (validate! abi)
+        arguments (validate-arguments! abi arguments)
+        pairs (mapv vector abi arguments)
+        stable-inputs (filterv (fn [[slot _]]
+                                 (= :no-write-alias (:aliasing slot))) pairs)
+        outputs (filterv (fn [[slot _]] (= :output (:kind slot))) pairs)]
+    (doseq [[input-slot input] stable-inputs
+            [output-slot output] outputs
+            :when (overlaps? input output)]
+      (throw (ex-info "kernel stable input overlaps a writable output"
+                      {:reason :kernel-abi-no-write-alias
+                       :input-slot input-slot :output-slot output-slot})))
     arguments))
 
 (defn validate-split-binding!

--- a/src/raster/compiler/ir/kernel_artifact.clj
+++ b/src/raster/compiler/ir/kernel_artifact.clj
@@ -48,6 +48,7 @@
       (throw (ex-info "kernel artifact requires a non-blank target module"
                       {:kernel-name kernel-name :target target})))
     (kabi/validate-arguments! abi arguments)
+    (kabi/validate-alias-contracts! abi arguments #(or (identical? %1 %2) (= %1 %2)))
     (case target
       :opencl-c (kabi/validate-source-signature! kernel-name source abi)
       (throw (ex-info "kernel artifact target has no module verifier"

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -13,6 +13,7 @@
 
 (defrecord KernelParameter [id kind dtype shape memory-space layout role])
 (defrecord BufferView [id buffer element-offset shape layout])
+(defrecord StableRead [buffer])
 (defrecord IndexBinding [id source axis])
 (defrecord IndexCompute [id expression])
 (defrecord IndexExpr [op arguments])
@@ -47,7 +48,8 @@
 (defrecord TileStore [buffer fragment coordinates mask value-region])
 
 (defrecord KernelBody
-           [id parameters views indices masks fragments operations schedule launch provenance attributes])
+           [id parameters views stable-reads indices masks fragments operations schedule launch
+            provenance attributes])
 
 (def ^:private parameter-kinds #{:input :output :scalar})
 (def ^:private index-sources #{:group :subgroup :lane})
@@ -57,7 +59,7 @@
 (def ^:private internal-types #{:predicate})
 (def ^:private special-scalar-ops #{:cast :select :isnan})
 (def ^:private cast-rounding-policies #{:toward-zero :nearest-even :up :down :exact})
-(def ^:private cast-overflow-policies #{:wrap :saturate :trap :exact})
+(def ^:private cast-overflow-policies #{:wrap :saturate :trap :exact :ieee})
 (def ^:private collective-kinds #{:reduce :broadcast})
 
 (defn- record-kind? [class-name value]
@@ -116,6 +118,12 @@
   "Every lane in the collective's statically selected subgroup participates."
   []
   (->Participation :full))
+
+(defn stable-read
+  "Require an input buffer to remain disjoint from every writable buffer for the complete kernel
+  execution. This is an external binding precondition, not a load-local optimization hint."
+  [buffer]
+  (->StableRead buffer))
 
 (def ^:private scalar-region-forbidden-ops
   '#{raster.par/scan raster.par/scan-exclusive raster.par/scatter! raster.par/reduce-by-key
@@ -640,6 +648,9 @@
       (let [source-type (:type (first infos))
             source-integral? (contains? #{:byte :int :long} source-type)
             result-integral? (contains? #{:byte :int :long} result-type)
+            both-floating? (and (dtype/fp-dtype? source-type) (dtype/fp-dtype? result-type))
+            narrowing? (and both-floating?
+                            (> (dtype/bytes-of source-type) (dtype/bytes-of result-type)))
             rounding (:rounding options)
             overflow (:overflow options)]
         (when-not (= 1 (count infos))
@@ -655,11 +666,17 @@
           (throw (ex-info "numeric casts cannot create or consume predicates"
                           {:expression expression})))
         ;; Rounding has no meaning when the source is already integral. Wrapping is a
-        ;; representation operation only between integral types; floating conversions must
-        ;; choose an explicit exact, checked, or saturating contract.
+        ;; representation operation only between integral types. FP same-width/widening casts are
+        ;; exact; FP narrowing states an IEEE overflow and directional rounding contract.
         (when-not (and (or (not source-integral?) (= :exact rounding))
                        (or (not= :wrap overflow)
-                           (and source-integral? result-integral?)))
+                           (and source-integral? result-integral?))
+                       (if both-floating?
+                         (if narrowing?
+                           (and (= :ieee overflow)
+                                (contains? #{:nearest-even :toward-zero :up :down} rounding))
+                           (and (= :exact rounding) (= :exact overflow)))
+                         (not= :ieee overflow)))
           (throw (ex-info "scalar cast policies disagree with its source and result dtypes"
                           {:reason :kernel-body-cast-policy
                            :source-type source-type :result-type result-type
@@ -803,7 +820,8 @@
     (reduce * workgroup)))
 
 (defn- validate-dataflow-operation!
-  [operation values {:keys [storage masks claimed reserved control-uniformity launch schedule]
+  [operation values {:keys [storage stable-reads masks claimed reserved control-uniformity launch
+                            schedule]
                      :as context}]
   (cond
     (record-kind? "raster.compiler.ir.kernel_body.ScalarCompute" operation)
@@ -820,8 +838,10 @@
           buffer (get storage (:buffer operation))
           result-type (canonical-type (:type result))
           buffer-type (canonical-type (:dtype buffer))
-          _ (doseq [coordinate (:coordinates operation)]
-              (expression-uniformity coordinate values))
+          coordinate-uniformity
+          (join-uniformity
+           (map #(hash-map :uniformity (expression-uniformity % values))
+                (:coordinates operation)))
           predicate-uniformity (mask-uniformity (:predicate operation) masks values)
           other-info (when (:predicate operation)
                        (scalar-value-info! (:other operation) values))]
@@ -834,11 +854,12 @@
                          :expected result-type :actual (:type other-info)})))
       (assoc values (:id result)
              {:type result-type
-              ;; ABI slots may alias for in-place programs. Neither an :input role nor identical
-              ;; coordinates prove immutability, so loads cannot establish uniform control until
-              ;; the body/ABI seam carries a checked readonly/noalias fact.
-              :uniformity (reduce set/intersection lane-varying
-                                  (cond-> [predicate-uniformity]
+              ;; Only a body-level StableRead contract can establish memory uniformity. Its
+              ;; corresponding ABI slot requires no write alias for the whole parallel launch.
+              :uniformity (reduce set/intersection
+                                  (if (contains? stable-reads (:buffer operation))
+                                    all-uniform lane-varying)
+                                  (cond-> [coordinate-uniformity predicate-uniformity]
                                     other-info (conj (:uniformity other-info))))}))
 
     (record-kind? "raster.compiler.ir.kernel_body.ScalarStore" operation)
@@ -1000,12 +1021,13 @@
   (when-not (kernel-body? body)
     (throw (ex-info "kernel body must be a KernelBody value"
                     {:body body :actual (type body)})))
-  (let [{:keys [id parameters views indices masks fragments operations schedule launch provenance
-                attributes]} body]
+  (let [{:keys [id parameters views stable-reads indices masks fragments operations schedule launch
+                provenance attributes]} body]
     (when (nil? id)
       (throw (ex-info "kernel body requires a stable identity" {:body body})))
-    (doseq [[field values] [[:parameters parameters] [:views views] [:indices indices] [:masks masks]
-                            [:fragments fragments] [:operations operations]]]
+    (doseq [[field values] [[:parameters parameters] [:views views] [:stable-reads stable-reads]
+                            [:indices indices] [:masks masks] [:fragments fragments]
+                            [:operations operations]]]
       (when-not (vector? values)
         (throw (ex-info "kernel body sections must be ordered vectors"
                         {:field field :value values}))))
@@ -1118,6 +1140,18 @@
                              :layout (:layout view) :view view))))
            {} views)
           storage (merge parameter-map view-map)]
+      (let [stable-buffers (mapv :buffer stable-reads)]
+        (when-not (= (count stable-buffers) (count (set stable-buffers)))
+          (throw (ex-info "kernel stable-read requirements must name unique buffers"
+                          {:reason :kernel-body-stable-read-duplicate
+                           :buffers stable-buffers})))
+        (doseq [requirement stable-reads]
+          (let [buffer (get parameter-map (:buffer requirement))]
+            (when-not (and (record-kind? "raster.compiler.ir.kernel_body.StableRead" requirement)
+                           buffer (= :input (:kind buffer)))
+              (throw (ex-info "kernel stable-read requirement must name an input parameter"
+                              {:reason :kernel-body-stable-read-invalid
+                               :requirement requirement :parameter buffer}))))))
       (let [section-ids (vec (concat (map :id parameters) (map :id views) (map :id indices)
                                      (map :id masks) (map :id fragments)))]
         (when-not (= (count section-ids) (count (set section-ids)))
@@ -1167,6 +1201,7 @@
             reserved (set (concat (keys storage) (map :id indices) (map :id masks)
                                   (map :id fragments)))
             context {:storage storage
+                     :stable-reads (set (map :buffer stable-reads))
                      :masks (into {} (map (juxt :id identity)) masks)
                      :claimed (atom #{})
                      :reserved reserved
@@ -1178,8 +1213,9 @@
 
 (defn make
   "Construct and verify a target-neutral scheduled kernel body."
-  [{:keys [id parameters views indices masks fragments operations schedule launch provenance attributes]
-    :or {parameters [] views [] indices [] masks [] fragments [] operations [] schedule {} launch {}
-         provenance {} attributes {}}}]
-  (validate! (->KernelBody id parameters views indices masks fragments operations schedule launch
-                           provenance attributes)))
+  [{:keys [id parameters views stable-reads indices masks fragments operations schedule launch
+           provenance attributes]
+    :or {parameters [] views [] stable-reads [] indices [] masks [] fragments [] operations []
+         schedule {} launch {} provenance {} attributes {}}}]
+  (validate! (->KernelBody id parameters views stable-reads indices masks fragments operations
+                           schedule launch provenance attributes)))

--- a/src/raster/compiler/ir/kernel_body_abi.clj
+++ b/src/raster/compiler/ir/kernel_body_abi.clj
@@ -1,0 +1,30 @@
+(ns raster.compiler.ir.kernel-body-abi
+  "Checked projection from target-neutral KernelBody parameters to target ABI contracts.
+
+  This seam depends on both IRs so the foundational ordered ABI remains independent of the larger
+  scheduled-body vocabulary. Target backends retain control of parameter spelling and physical
+  packing; they cannot drop a semantic memory precondition while doing so."
+  (:require [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-body :as kbody]))
+
+(defn project-contracts
+  "Project verified KernelBody memory preconditions onto an ordered target ABI.
+
+  Every StableRead must have exactly one physical input slot with the same compiler identity.
+  Target parameter spelling remains independent in `:c-name`; this function only carries the
+  semantic no-write-alias fact across lowering."
+  [abi kernel-body]
+  (let [abi (kabi/validate! abi)
+        kernel-body (kbody/validate! kernel-body)
+        stable-buffers (set (map :buffer (:stable-reads kernel-body)))]
+    (doseq [buffer stable-buffers]
+      (let [matches (filterv #(and (= :input (:kind %)) (= buffer (:name %))) abi)]
+        (when-not (= 1 (count matches))
+          (throw (ex-info "kernel stable read does not have exactly one target ABI input"
+                          {:reason :kernel-body-stable-read-abi
+                           :buffer buffer :matches matches :abi abi})))))
+    (mapv (fn [slot]
+            (if (contains? stable-buffers (:name slot))
+              (assoc slot :aliasing :no-write-alias)
+              slot))
+          abi)))

--- a/src/raster/compiler/ir/kernel_call.clj
+++ b/src/raster/compiler/ir/kernel_call.clj
@@ -4,9 +4,11 @@
    KernelArtifact owns target code, ABI and symbolic launch. KernelCall adds runtime values in the
    identical ABI order and a concrete 1-3D LaunchGeometry. Backends consume this value instead of
    reconstructing arguments or launch dimensions from a convention-specific marker."
-  (:require [raster.compiler.ir.kernel-abi :as kabi]
+  (:require [raster.compiler.ir.buffer-view :as bview]
+            [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
-            [raster.compiler.ir.kernel-launch :as klaunch]))
+            [raster.compiler.ir.kernel-launch :as klaunch])
+  (:import [java.lang.foreign MemorySegment]))
 
 (defrecord KernelCall [artifact arguments geometry])
 
@@ -104,6 +106,43 @@
                      :value value})))
   value)
 
+(defn- resident-view
+  [value]
+  (cond
+    (bview/buffer-view? value) value
+    (and (map? value) (bview/buffer-view? (:view value))) (:view value)
+    :else nil))
+
+(defn- resident-segment
+  [value]
+  (cond
+    (instance? MemorySegment value) value
+    (and (map? value) (instance? MemorySegment (:segment value))) (:segment value)
+    :else nil))
+
+(defn- segment-overlaps?
+  [^MemorySegment left ^MemorySegment right]
+  (try
+    (let [left-start (.address left)
+          right-start (.address right)
+          left-end (+ left-start (.byteSize left))
+          right-end (+ right-start (.byteSize right))]
+      (and (< left-start right-end) (< right-start left-end)))
+    (catch UnsupportedOperationException _
+      (identical? left right))))
+
+(defn- pointer-overlaps?
+  [left right]
+  (let [left-view (resident-view left)
+        right-view (resident-view right)
+        left-segment (resident-segment left)
+        right-segment (resident-segment right)]
+    (cond
+      (identical? left right) true
+      (and left-view right-view) (bview/overlaps? left-view right-view)
+      (and left-segment right-segment) (segment-overlaps? left-segment right-segment)
+      :else (= left right))))
+
 (defn validate!
   "Validate and return a KernelCall. This is driver-independent: a backend subsequently checks
    that pointer values are its resident buffer representation and match ABI storage dtypes."
@@ -115,6 +154,7 @@
         artifact (kart/validate! artifact)
         abi (:abi artifact)
         arguments (kabi/validate-arguments! abi arguments)
+        _ (kabi/validate-alias-contracts! abi arguments pointer-overlaps?)
         geometry (klaunch/validate-geometry! geometry)
         spec (:launch artifact)]
     (when-not (= (klaunch/dimensions spec) (klaunch/dimensions geometry))

--- a/test/raster/compiler/ir/kernel_artifact_test.clj
+++ b/test/raster/compiler/ir/kernel_artifact_test.clj
@@ -40,6 +40,13 @@
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo #"argument count mismatch"
          (kart/make (assoc base :arguments '[x out])))))
+  (testing "a stable compiler input cannot also bind a writable output"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"stable input overlaps"
+         (kart/make
+          (-> base
+              (assoc-in [:abi 0 :aliasing] :no-write-alias)
+              (assoc :arguments '[same same n]))))))
   (testing "an entry without executable launch geometry is not a kernel artifact"
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo #"invalid launch contract"

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -126,8 +126,8 @@
                                        (axis-map/of-axes [['group-x 8]]))))))))
 
 (defn- scalar-body
-  [operations & {:keys [masks schedule]
-                 :or {masks [] schedule {:subgroup-size 16}}}]
+  [operations & {:keys [masks stable-reads schedule]
+                 :or {masks [] stable-reads [] schedule {:subgroup-size 16}}}]
   (body/make
    {:id :scalar
     :parameters [(body/->KernelParameter
@@ -139,6 +139,7 @@
     :indices [(body/->IndexBinding 'group :group 0)
               (body/->IndexBinding 'lane :lane 0)]
     :masks masks
+    :stable-reads stable-reads
     :operations operations
     :schedule schedule
     :launch (launch/spec {:workgroup-size [16] :group-count [1]})
@@ -245,7 +246,44 @@
           [(load-x)
            (body/->ScalarCompute
             (body/value 'bad :int)
-            (body/cast-expression 'x-value :int :toward-zero :wrap))])))))
+            (body/cast-expression 'x-value :int :toward-zero :wrap))]))))
+  (testing "FP narrowing states IEEE overflow and nearest-even rounding"
+    (is (body/kernel-body?
+         (scalar-body
+          [(load-x)
+           (body/->ScalarCompute
+            (body/value 'narrowed :half)
+            (body/cast-expression 'x-value :half :nearest-even :ieee))]))))
+  (testing "IEEE overflow is not an integer conversion policy"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"policies disagree"
+         (scalar-body
+          [(load-x)
+           (body/->ScalarCompute
+            (body/value 'bad :int)
+            (body/cast-expression 'x-value :int :toward-zero :ieee))]))))
+  (testing "same-width floating casts are exact rather than fictitious narrowing"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"policies disagree"
+         (scalar-body
+          [(load-x)
+           (body/->ScalarCompute
+            (body/value 'bad :float)
+            (body/cast-expression 'x-value :float :nearest-even :ieee))]))))
+  (testing "floating widening is exact"
+    (is (body/kernel-body?
+         (scalar-body
+          [(body/->ScalarCompute
+            (body/value 'widened :float)
+            (body/cast-expression (body/literal 1.0 :half) :float :exact :exact))]))))
+  (testing "floating narrowing cannot borrow integer saturation semantics"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"policies disagree"
+         (scalar-body
+          [(load-x)
+           (body/->ScalarCompute
+            (body/value 'bad :half)
+            (body/cast-expression 'x-value :half :nearest-even :saturate))])))))
 
 (deftest scalar-memory-is-ranked-masked-and-typed
   (testing "a load cannot silently reinterpret or widen storage"
@@ -353,6 +391,43 @@
           [(reduce-x 'shared-load) (body/->Yield [])]
           [(body/->Yield [])]
           [])]))))
+
+(deftest stable-input-loads-prove-only-their-coordinate-uniformity
+  (let [stable [(body/stable-read 'x)]
+        uniform-branch
+        [(body/->ScalarLoad (body/value 'shared-load :float) 'x ['group]
+                            nil nil :cached)
+         (body/->ScalarCompute
+          (body/value 'condition :predicate)
+          (body/scalar-expression :lt :predicate
+                                  ['shared-load (body/literal 0.0 :float)]))
+         (body/->IfRegion
+          'condition
+          [(reduce-x 'shared-load) (body/->Yield [])]
+          [(body/->Yield [])]
+          [])]]
+    (is (= stable (:stable-reads (scalar-body uniform-branch :stable-reads stable))))
+    (testing "a lane-varying address remains lane-varying"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"lane-divergent"
+           (scalar-body
+            [(load-x)
+             (body/->ScalarCompute
+              (body/value 'condition :predicate)
+              (body/scalar-expression :lt :predicate
+                                      ['x-value (body/literal 0.0 :float)]))
+             (body/->IfRegion
+              'condition
+              [(reduce-x 'x-value) (body/->Yield [])]
+              [(body/->Yield [])]
+              [])]
+            :stable-reads stable))))
+    (testing "the contract names unique input parameters"
+      (doseq [requirements [[(body/stable-read 'y)]
+                            [(body/stable-read 'missing)]
+                            [(body/stable-read 'x) (body/stable-read 'x)]]]
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (scalar-body [] :stable-reads requirements)))))))
 
 (deftest kernel-storage-and-fragments-require-canonical-dtype-facts
   (let [kernel (minimal-body)]

--- a/test/raster/compiler/ir/kernel_call_test.clj
+++ b/test/raster/compiler/ir/kernel_call_test.clj
@@ -1,5 +1,6 @@
 (ns raster.compiler.ir.kernel-call-test
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.buffer-view :as bview]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
@@ -22,6 +23,33 @@
 
 (def ^:private args
   [:resident-x :resident-out {:type :float :value 2.0} {:type :int :value 513}])
+
+(def ^:private stable-artifact
+  (kart/make (assoc-in artifact [:abi 0 :aliasing] :no-write-alias)))
+
+(deftest calls-enforce-stable-input-ranges-without-forbidding-in-place-by-default
+  (let [allocation (bview/allocation {:id :call-alias :byte-size 64 :memory-space :device
+                                      :ownership :borrowed})
+        left (bview/view allocation {:id :left :dtype :float :shape [8]})
+        overlap (bview/view allocation {:id :overlap :byte-offset 16
+                                        :dtype :float :shape [8]})
+        right (bview/view allocation {:id :right :byte-offset 32
+                                      :dtype :float :shape [8]})
+        scalars [{:type :float :value 1.0} {:type :int :value 8}]]
+    (is (kcall/kernel-call? (kcall/make stable-artifact (into [left right] scalars))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"stable input overlaps"
+                          (kcall/make stable-artifact (into [left overlap] scalars))))
+    (is (kcall/kernel-call? (kcall/make artifact (into [left left] scalars)))))
+  (testing "raw resident segments are checked by byte range"
+    (let [segment (java.lang.foreign.MemorySegment/ofArray (float-array 16))
+          left (.asSlice segment 0 32)
+          overlap (.asSlice segment 16 32)
+          right (.asSlice segment 32 32)
+          scalars [{:type :float :value 1.0} {:type :int :value 8}]]
+      (is (kcall/kernel-call? (kcall/make stable-artifact (into [left right] scalars))))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"stable input overlaps"
+                            (kcall/make stable-artifact
+                                        (into [left overlap] scalars)))))))
 
 (deftest call-realizes-artifact-launch-from-ordered-values
   (let [call (kcall/make artifact args)

--- a/test/raster/compiler/kernel_abi_test.clj
+++ b/test/raster/compiler/kernel_abi_test.clj
@@ -1,6 +1,10 @@
 (ns raster.compiler.kernel-abi-test
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.core.layout :as layout]
             [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-body-abi :as body-abi]
+            [raster.compiler.ir.kernel-launch :as launch]
             [raster.gpu.core]
             [raster.gpu.ocl-runtime :as ocl]
             [raster.gpu.ze-runtime :as ze]))
@@ -10,6 +14,48 @@
    (kabi/slot 'out :output :float :role :result)
    (kabi/slot 'scale :scalar :float :role :parameter)
    (kabi/slot '_n_bound :scalar :int :role :bound)])
+
+(defn- stable-body []
+  (body/make
+   {:id :stable-abi
+    :parameters [(body/->KernelParameter 'x :input :float [1] :global
+                                         (layout/row-major [1] :float) :operand)
+                 (body/->KernelParameter 'out :output :float [1] :global
+                                         (layout/row-major [1] :float) :result)]
+    :stable-reads [(body/stable-read 'x)]
+    :launch (launch/spec {:workgroup-size [1] :group-count [1]})}))
+
+(deftest stable-read-contracts-project-to-one-target-input
+  (let [projected (body-abi/project-contracts
+                   [(kabi/slot 'x :input :float :c-name "source")
+                    (kabi/slot 'out :output :float :c-name "destination")]
+                   (stable-body))]
+    (is (= :no-write-alias (get-in projected [0 :aliasing])))
+    (is (nil? (get-in projected [1 :aliasing])))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"exactly one target ABI input"
+         (body-abi/project-contracts
+          [(kabi/slot 'renamed :input :float)
+           (kabi/slot 'out :output :float)]
+          (stable-body)))))
+  (testing "the contract is only legal on input pointers"
+    (doseq [slot [(kabi/slot 'out :output :float :aliasing :no-write-alias)
+                  (kabi/slot 'n :scalar :int :aliasing :no-write-alias)
+                  (kabi/slot 'x :input :float :aliasing :unknown)]]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"aliasing contract"
+                            (kabi/validate! [slot (kabi/slot 'out :output :float)]))))))
+
+(deftest stable-input-aliases-are-checked-against-every-output
+  (let [abi [(kabi/slot 'x :input :float :aliasing :no-write-alias)
+             (kabi/slot 'side :output :float)
+             (kabi/slot 'out :output :float)]]
+    (is (= [:x :side :out]
+           (kabi/validate-alias-contracts! abi [:x :side :out] =)))
+    (let [e (try
+              (kabi/validate-alias-contracts! abi [:same :side :same] =)
+              nil
+              (catch clojure.lang.ExceptionInfo e e))]
+      (is (= :kernel-abi-no-write-alias (:reason (ex-data e)))))))
 
 (deftest generic-abi-allows-ordered-multi-output
   (let [abi [(kabi/slot 'x :input :float)


### PR DESCRIPTION
Summary

- add an explicit StableRead precondition so uniform memory values can participate in verified convergent control
- project body memory contracts through a dedicated KernelBody-to-ABI seam
- reject aliased compiler bindings in artifacts and overlapping BufferView or MemorySegment ranges in direct calls
- distinguish IEEE FP narrowing from integral overflow policies

Verification

- focused compiler, ABI, graph, link, and GEMM tests: 75 tests, 315 assertions
- full suite: 2394 tests, 34040 assertions, 0 failures, 0 errors
- changed source formatting and git diff checks pass