### PR TITLE
Make OpenCL device gates honest

### DIFF
--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -87,6 +87,8 @@
 ;; ================================================================
 
 (def ^:private CL_SUCCESS 0)
+(def ^:private CL_DEVICE_NOT_FOUND -1)
+(def ^:private CL_PLATFORM_NOT_FOUND_KHR -1001)
 (def ^:private CL_DEVICE_TYPE_GPU (long 4))
 (def ^:private CL_DEVICE_TYPE_CPU (long 2))
 (def ^:private CL_DEVICE_TYPE_ALL (long 0xFFFFFFFF))
@@ -228,6 +230,13 @@
                       {:function name :error ret})))
     ret))
 
+(defn- check-cl-result!
+  [^String name ret]
+  (when (not= CL_SUCCESS ret)
+    (throw (ex-info (str "OpenCL " name " failed with error " ret)
+                    {:function name :error ret})))
+  ret)
+
 ;; ================================================================
 ;; State management
 ;; ================================================================
@@ -240,6 +249,7 @@
          :queue nil          ;; MemorySegment (cl_command_queue)
          :arena nil          ;; Arena for long-lived allocations
          :device-name nil
+         :device-info nil
          :unified-memory? false
          :buffer-offset-alignment nil ;; bytes; CL_DEVICE_MEM_BASE_ADDR_ALIGN is reported in bits
          :programs {}        ;; source-hash -> cl_program handle
@@ -268,13 +278,14 @@
   (let [arena (Arena/ofConfined)
         size-ret (.allocate arena I64)]
     (try
-      (.invokeWithArguments ^MethodHandle @h-clGetDeviceInfo
-                            (into-array Object [device (int param-name) (long 0)
-                                                MemorySegment/NULL size-ret]))
+      (cl-call! "clGetDeviceInfo"
+                @h-clGetDeviceInfo
+                [device (int param-name) (long 0) MemorySegment/NULL size-ret])
       (let [size (long (.get size-ret I64 0))
             buf (.allocate arena size)]
-        (.invokeWithArguments ^MethodHandle @h-clGetDeviceInfo
-                              (into-array Object [device (int param-name) size buf size-ret]))
+        (cl-call! "clGetDeviceInfo"
+                  @h-clGetDeviceInfo
+                  [device (int param-name) size buf size-ret])
         (let [s (.getString buf 0)]
           (.trim s)))
       (finally (.close arena)))))
@@ -285,8 +296,9 @@
   (let [arena (Arena/ofConfined)
         buf (.allocate arena I32)]
     (try
-      (.invokeWithArguments ^MethodHandle @h-clGetDeviceInfo
-                            (into-array Object [device (int param-name) (long 4) buf MemorySegment/NULL]))
+      (cl-call! "clGetDeviceInfo"
+                @h-clGetDeviceInfo
+                [device (int param-name) (long 4) buf MemorySegment/NULL])
       (long (.get buf I32 0))
       (finally (.close arena)))))
 
@@ -296,8 +308,9 @@
   (let [arena (Arena/ofConfined)
         buf (.allocate arena I64)]
     (try
-      (.invokeWithArguments ^MethodHandle @h-clGetDeviceInfo
-                            (into-array Object [device (int param-name) (long 8) buf MemorySegment/NULL]))
+      (cl-call! "clGetDeviceInfo"
+                @h-clGetDeviceInfo
+                [device (int param-name) (long 8) buf MemorySegment/NULL])
       (long (.get buf I64 0))
       (finally (.close arena)))))
 
@@ -318,6 +331,21 @@
       (throw (ex-info "OpenCL reported an invalid buffer base-address alignment"
                       {:alignment-bits bits})))
     (quot bits 8)))
+
+(defn- device-info
+  [device]
+  {:name (query-device-info-string device CL_DEVICE_NAME)
+   :vendor (query-device-info-string device CL_DEVICE_VENDOR)
+   :version (query-device-info-string device CL_DEVICE_VERSION)
+   :max-compute-units (query-device-info-uint device CL_DEVICE_MAX_COMPUTE_UNITS)
+   :max-work-group-size (query-device-info-size-t device CL_DEVICE_MAX_WORK_GROUP_SIZE)
+   :max-clock-mhz (query-device-info-uint device CL_DEVICE_MAX_CLOCK_FREQUENCY)
+   :global-mem-bytes (query-device-info-ulong device CL_DEVICE_GLOBAL_MEM_SIZE)
+   :buffer-offset-alignment (device-buffer-offset-alignment device)
+   :extensions (query-device-info-string device CL_DEVICE_EXTENSIONS)
+   :integrated? (try
+                  (== 1 (query-device-info-uint device CL_DEVICE_HOST_UNIFIED_MEMORY))
+                  (catch Exception _ false))})
 
 ;; ================================================================
 ;; Initialization
@@ -356,7 +384,10 @@
                        ret (int (.invokeWithArguments ^MethodHandle @h-clGetDeviceIDs
                                                       (into-array Object [plat (long (requested-device-type))
                                                                           (int 0) MemorySegment/NULL num-dev-seg])))]
-                   (when (== CL_SUCCESS ret)
+                   (cond
+                     (= CL_DEVICE_NOT_FOUND ret) nil
+                     (not= CL_SUCCESS ret) (check-cl-result! "clGetDeviceIDs" ret)
+                     :else
                      (let [num-dev (read-int num-dev-seg)]
                        (when (> num-dev 0)
                          (let [dev-buf (.allocate arena 8)
@@ -366,6 +397,13 @@
                            [plat dev]))))))
                (range num-plat))
               (throw (ex-info "No OpenCL GPU devices found" {:num-platforms num-plat})))
+
+          ;; Complete all fallible capability queries before allocating a context/queue.  A broken
+          ;; clGetDeviceInfo must not leave native execution resources unreachable.
+          device-info (device-info device)
+          dev-name (:name device-info)
+          unified? (:integrated? device-info)
+          buffer-offset-alignment (:buffer-offset-alignment device-info)
 
           ;; Create context
           err-seg (.allocate arena I32)
@@ -380,12 +418,7 @@
           queue (.invokeWithArguments ^MethodHandle @h-clCreateCommandQueue
                                       (into-array Object [ctx device (long 0) err-seg]))
           _ (when (not= CL_SUCCESS (read-int err-seg))
-              (throw (ex-info "clCreateCommandQueue failed" {:error (read-int err-seg)})))
-
-          dev-name (query-device-info-string device CL_DEVICE_NAME)
-          unified? (try (== 1 (query-device-info-uint device CL_DEVICE_HOST_UNIFIED_MEMORY))
-                        (catch Exception _ false))
-          buffer-offset-alignment (device-buffer-offset-alignment device)]
+              (throw (ex-info "clCreateCommandQueue failed" {:error (read-int err-seg)})))]
 
       (swap! state assoc
              :initialized? true
@@ -395,58 +428,70 @@
              :queue queue
              :arena arena
              :device-name dev-name
+             :device-info device-info
              :unified-memory? unified?
              :buffer-offset-alignment buffer-offset-alignment)
       (println (str "[ocl-runtime] Initialized: " dev-name
                     (when unified? " (unified memory)"))))))
 
 (defn query-devices
-  "Query all OpenCL GPU devices across all platforms.
-  Returns a vector of device info maps."
+  "Query all requested OpenCL devices across all platforms.
+
+   A clean CL_PLATFORM_NOT_FOUND_KHR or per-platform CL_DEVICE_NOT_FOUND is represented by an
+   empty vector. Loader, FFM, driver, and device-info failures propagate: callers must not confuse
+   a broken runtime with an absent device."
   []
-  (try
-    @ocl-lib ;; Force library load
-    (let [arena (Arena/ofConfined)]
-      (try
-        (let [num-plat-seg (.allocate arena I32)
-              _ (cl-call! "clGetPlatformIDs" @h-clGetPlatformIDs
-                          [(int 0) MemorySegment/NULL num-plat-seg])
-              num-plat (read-int num-plat-seg)
-              plat-buf (.allocate arena (* num-plat 8))
-              _ (cl-call! "clGetPlatformIDs" @h-clGetPlatformIDs
-                          [(int num-plat) plat-buf num-plat-seg])]
-          (vec
-           (mapcat
-            (fn [plat-idx]
-              (let [plat (.get plat-buf PTR (* plat-idx 8))
-                    num-dev-seg (.allocate arena I32)
-                    ret (int (.invokeWithArguments ^MethodHandle @h-clGetDeviceIDs
-                                                   (into-array Object [plat (long (requested-device-type))
-                                                                       (int 0) MemorySegment/NULL num-dev-seg])))]
-                (when (== CL_SUCCESS ret)
-                  (let [num-dev (read-int num-dev-seg)
-                        dev-buf (.allocate arena (* num-dev 8))
-                        _ (cl-call! "clGetDeviceIDs" @h-clGetDeviceIDs
-                                    [plat (long (requested-device-type)) (int num-dev) dev-buf num-dev-seg])]
-                    (mapv
-                     (fn [dev-idx]
-                       (let [dev (.get dev-buf PTR (* dev-idx 8))]
-                         {:name (query-device-info-string dev CL_DEVICE_NAME)
-                          :vendor (query-device-info-string dev CL_DEVICE_VENDOR)
-                          :version (query-device-info-string dev CL_DEVICE_VERSION)
-                          :max-compute-units (query-device-info-uint dev CL_DEVICE_MAX_COMPUTE_UNITS)
-                          :max-work-group-size (query-device-info-size-t dev CL_DEVICE_MAX_WORK_GROUP_SIZE)
-                          :max-clock-mhz (query-device-info-uint dev CL_DEVICE_MAX_CLOCK_FREQUENCY)
-                          :global-mem-bytes (query-device-info-ulong dev CL_DEVICE_GLOBAL_MEM_SIZE)
-                          :buffer-offset-alignment (device-buffer-offset-alignment dev)
-                          :extensions (query-device-info-string dev CL_DEVICE_EXTENSIONS)
-                          :integrated? (try (== 1 (query-device-info-uint dev CL_DEVICE_HOST_UNIFIED_MEMORY))
-                                            (catch Exception _ false))}))
-                     (range num-dev))))))
-            (range num-plat))))
-        (finally (.close arena))))
-    (catch Exception _
-      [])))
+  @ocl-lib
+  (let [arena (Arena/ofConfined)]
+    (try
+      (let [num-plat-seg (.allocate arena I32)
+            platform-ret
+            (int (.invokeWithArguments ^MethodHandle @h-clGetPlatformIDs
+                                       (into-array Object [(int 0) MemorySegment/NULL num-plat-seg])))]
+        (if (= CL_PLATFORM_NOT_FOUND_KHR platform-ret)
+          []
+          (let [_ (check-cl-result! "clGetPlatformIDs" platform-ret)
+                num-plat (read-int num-plat-seg)]
+            (if (zero? num-plat)
+              []
+              (let [plat-buf (.allocate arena (* num-plat 8))
+                    _ (cl-call! "clGetPlatformIDs" @h-clGetPlatformIDs
+                                [(int num-plat) plat-buf num-plat-seg])]
+                (vec
+                 (mapcat
+                  (fn [plat-idx]
+                    (let [plat (.get plat-buf PTR (* plat-idx 8))
+                          num-dev-seg (.allocate arena I32)
+                          ret (int (.invokeWithArguments ^MethodHandle @h-clGetDeviceIDs
+                                                         (into-array
+                                                          Object
+                                                          [plat (long (requested-device-type))
+                                                           (int 0) MemorySegment/NULL num-dev-seg])))]
+                      (cond
+                        (= CL_DEVICE_NOT_FOUND ret) []
+                        (not= CL_SUCCESS ret) (check-cl-result! "clGetDeviceIDs" ret)
+                        :else
+                        (let [num-dev (read-int num-dev-seg)]
+                          (if (zero? num-dev)
+                            []
+                            (let [dev-buf (.allocate arena (* num-dev 8))
+                                  _ (cl-call! "clGetDeviceIDs" @h-clGetDeviceIDs
+                                              [plat (long (requested-device-type))
+                                               (int num-dev) dev-buf num-dev-seg])]
+                              (mapv (fn [dev-idx]
+                                      (device-info (.get dev-buf PTR (* dev-idx 8))))
+                                    (range num-dev))))))))
+                  (range num-plat))))))))
+      (finally (.close arena)))))
+
+(defn selected-device-info
+  "Return the exact OpenCL device bound by this singleton runtime.
+
+   Capability gates must use this value rather than searching `query-devices`: the latter may
+   contain devices with capabilities that the initialized context and queue do not have."
+  []
+  (ensure-init!)
+  (:device-info @state))
 
 ;; ================================================================
 ;; DeviceBuffer (OpenCL cl_mem backed)
@@ -1626,7 +1671,8 @@
         (.close ^Arena arena))
       (clojure.core/reset! state
                            {:initialized? false :platform nil :device nil :context nil
-                            :queue nil :arena nil :device-name nil :unified-memory? false
+                            :queue nil :arena nil :device-name nil :device-info nil
+                            :unified-memory? false
                             :buffer-offset-alignment nil
                             :programs {} :kernels {}}))))
 
@@ -1638,7 +1684,8 @@
       (.close ^Arena arena)))
   (clojure.core/reset! state
                        {:initialized? false :platform nil :device nil :context nil
-                        :queue nil :arena nil :device-name nil :unified-memory? false
+                        :queue nil :arena nil :device-name nil :device-info nil
+                        :unified-memory? false
                         :buffer-offset-alignment nil
                         :programs {} :kernels {}})
   (clojure.core/reset! kernel-registry {})

--- a/src/raster/runtime/hardware.clj
+++ b/src/raster/runtime/hardware.clj
@@ -279,8 +279,11 @@
 ;; ================================================================
 
 (defn- detect-opencl-devices
-  "Detect OpenCL GPU devices via raster.gpu.ocl-runtime.
-  Returns seq of device maps or empty seq."
+  "Detect the OpenCL device the singleton runtime can actually bind.
+
+   `ocl-runtime/query-devices` may enumerate several devices, but the current runtime owns one
+   context/queue and selects the first requested device.  Advertising :ocl:1+ would promise device
+   selection that `gpu.core` cannot preserve."
   []
   (try
     (require 'raster.gpu.ocl-runtime)
@@ -311,7 +314,7 @@
                      :name dev-name
                      :capabilities caps
                      :source source}))
-                (range) devices))))
+                (range) (take 1 devices)))))
     (catch Exception e
       (when (System/getenv "ROMEO_DEBUG")
         (println "OpenCL detection failed:" (.getMessage e)))

--- a/test/raster/gpu/attention_device_test.clj
+++ b/test/raster/gpu/attention_device_test.clj
@@ -1,20 +1,11 @@
 (ns raster.gpu.attention-device-test
-  (:require [clojure.string :as str]
-            [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.core.hardware :as hardware]
             [raster.compiler.ir.attention :as attention]
             [raster.compiler.passes.parallel.attention-route :as route]
             [raster.dl.gpu-grad-parity :as gp]
-            [raster.gpu.core :as gpu]))
-
-(def ^:private ocl-fp16-available?
-  (delay
-    (try
-      (require 'raster.gpu.ocl-runtime)
-      ((resolve 'raster.gpu.ocl-runtime/init!))
-      (boolean
-       (some #(str/includes? (or (:extensions %) "") "cl_khr_fp16")
-             ((resolve 'raster.gpu.ocl-runtime/query-devices))))
-      (catch Throwable _ false))))
+            [raster.gpu.core :as gpu]
+            [raster.gpu.device-probe :as device-probe]))
 
 (defn- encode-halfs
   [values]
@@ -249,12 +240,15 @@
               (:key-indices (:visibility problem)) :attention-key-indices}))))
 
 (defn- run-case
-  [device-id route-kind visibility-kind]
+  [device-id route-kind visibility-kind policy expected-strategy]
   (let [{:keys [problem q k v q-offsets q-positions] :as test-case}
         (make-case route-kind visibility-kind)
-        graph (:graph (route/route!
-                       problem {:device-type :gpu :subgroup-size 16
-                                :max-workgroup-size 256}))
+        descriptor (assoc (hardware/descriptor-for device-id)
+                          :segmented-weighted-reduction-schedule policy)
+        routed (route/route! problem descriptor)
+        _ (is (= expected-strategy (:strategy routed))
+              "the device test must execute the intended attention leaf")
+        graph (:graph routed)
         expected (reference test-case)
         specs (attention/buffer-specs problem)
         allocations
@@ -283,14 +277,17 @@
             (gpu/release-kernel-graph! session handle)))))))
 
 (defn- run-mixed-io-case
-  [device-id]
+  [device-id policy expected-strategy]
   (let [{:keys [problem q k v q-offsets q-positions] :as test-case}
         (make-case :dense-paged :interval)
         expected (reference test-case)
         problem (assoc problem :q-dtype :float :output-dtype :float)
-        graph (:graph (route/route!
-                       problem {:device-type :gpu :subgroup-size 16
-                                :max-workgroup-size 256}))
+        descriptor (assoc (hardware/descriptor-for device-id)
+                          :segmented-weighted-reduction-schedule policy)
+        routed (route/route! problem descriptor)
+        _ (is (= expected-strategy (:strategy routed))
+              "the device test must execute the intended attention leaf")
+        graph (:graph routed)
         specs (attention/buffer-specs problem)
         float-q (float-array (map decode-half q))
         allocations
@@ -319,19 +316,23 @@
 (deftest level-zero-packed-dense-attention-matches-reference
   (if-not @gp/gpu-available?
     (gp/gpu-skip! "packed dense-routed FP16 attention on Level Zero")
-    (run-case :ze:0 :dense-paged :interval)))
+    (do
+      (run-case :ze:0 :dense-paged :interval :reference :fp16-reference)
+      (run-case :ze:0 :dense-paged :interval :subgroup-score-reuse
+                :routed-paged-subgroup-online-score-reuse))))
 
 (deftest level-zero-fp32-query-and-output-with-fp16-kv-matches-reference
   (if-not @gp/gpu-available?
     (gp/gpu-skip! "FP32-I/O packed attention over FP16 KV on Level Zero")
-    (run-mixed-io-case :ze:0)))
+    (run-mixed-io-case :ze:0 :subgroup-score-reuse
+                       :routed-paged-subgroup-online-score-reuse)))
 
 (deftest opencl-packed-csr-attention-matches-reference
-  (if-not @ocl-fp16-available?
-    (is true "OpenCL FP16 device unavailable")
-    (run-case :ocl:0 :csr-paged :interval)))
+  (if-not @device-probe/opencl-fp16-available?
+    (device-probe/opencl-skip! "packed CSR attention" :fp16)
+    (run-case :ocl:0 :csr-paged :interval :auto :fp16-reference)))
 
 (deftest opencl-logical-csr-visibility-over-dense-pages-matches-reference
-  (if-not @ocl-fp16-available?
-    (is true "OpenCL FP16 device unavailable")
-    (run-case :ocl:0 :dense-paged :csr)))
+  (if-not @device-probe/opencl-fp16-available?
+    (device-probe/opencl-skip! "logical CSR visibility over dense pages" :fp16)
+    (run-case :ocl:0 :dense-paged :csr :auto :fp16-reference)))

--- a/test/raster/gpu/device_probe.clj
+++ b/test/raster/gpu/device_probe.clj
@@ -1,0 +1,160 @@
+(ns raster.gpu.device-probe
+  "Structured test gates for the OpenCL runtime.
+
+   A missing device is a legitimate, visible skip on generic CI.  A namespace load failure is a
+   test failure.  Driver/query failures are visible skips unless RASTER_EXPECT_OPENCL declares
+   that this lane must execute OpenCL.  Capability decisions always inspect the exact device bound
+   by the singleton runtime, never some other enumerated device."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [is]]))
+
+(defn- truthy-environment?
+  [name]
+  (contains? #{"1" "true" "yes" "on"}
+             (some-> (System/getenv name) str/lower-case)))
+
+(def ^:dynamic *expect-opencl?*
+  (truthy-environment? "RASTER_EXPECT_OPENCL"))
+
+(defn probe-opencl-with
+  "Classify an OpenCL runtime using injectable operations.  Public for the gate's unit tests."
+  [{:keys [load! query-devices init! selected-device-info]}]
+  (let [loaded (try
+                 (load!)
+                 {:ok true}
+                 (catch Throwable error
+                   {:ok false :error error}))]
+    (if-not (:ok loaded)
+      {:backend :opencl :status :load-failed :error (:error loaded)}
+      (try
+        (let [devices (query-devices)]
+          (if-not (seq devices)
+            {:backend :opencl :status :no-device}
+            (do
+              (init!)
+              (let [device (selected-device-info)]
+                (when-not (map? device)
+                  (throw (ex-info "OpenCL runtime did not identify its selected device"
+                                  {:selected device})))
+                {:backend :opencl
+                 :status :available
+                 :n-devices (count devices)
+                 :device device}))))
+        (catch Throwable error
+          {:backend :opencl :status :probe-error :error error})))))
+
+(defn- runtime-api
+  []
+  (require 'raster.gpu.ocl-runtime)
+  (let [api {:load! (constantly true)
+             :query-devices (resolve 'raster.gpu.ocl-runtime/query-devices)
+             :init! (resolve 'raster.gpu.ocl-runtime/init!)
+             :selected-device-info (resolve 'raster.gpu.ocl-runtime/selected-device-info)}]
+    (doseq [[operation f] (dissoc api :load!)]
+      (when-not (ifn? f)
+        (throw (ex-info "OpenCL runtime API is incomplete" {:operation operation}))))
+    api))
+
+(def opencl-status
+  (delay
+    (let [loaded (try
+                   {:ok true :api (runtime-api)}
+                   (catch Throwable error
+                     {:ok false :error error}))]
+      (if (:ok loaded)
+        (probe-opencl-with (:api loaded))
+        {:backend :opencl :status :load-failed :error (:error loaded)}))))
+
+(defn- extension-set
+  [device]
+  (into #{} (remove str/blank?) (str/split (or (:extensions device) "") #"\s+")))
+
+(defn capability-supported?
+  [device capability]
+  (case capability
+    :fp16 (contains? (extension-set device) "cl_khr_fp16")
+    (throw (ex-info "Unknown OpenCL test capability" {:capability capability}))))
+
+(defn opencl-status-for
+  [capability]
+  (let [status @opencl-status]
+    (if (and (= :available (:status status))
+             capability
+             (not (capability-supported? (:device status) capability)))
+      (assoc status :status :missing-capability :capability capability)
+      status)))
+
+(def opencl-available?
+  (delay (= :available (:status @opencl-status))))
+
+(def opencl-fp16-available?
+  (delay (= :available (:status (opencl-status-for :fp16)))))
+
+(defonce ^:private opencl-skip-log (atom {}))
+
+(defonce ^:private opencl-summary-hook
+  (delay
+    (.addShutdownHook
+     (Runtime/getRuntime)
+     (Thread.
+      (fn []
+        (let [status @opencl-status
+              skips @opencl-skip-log
+              total (reduce + 0 (vals skips))]
+          (println
+           (format "  [OPENCL SUITE] probe=%s%s | %d test(s) took the skip path%s"
+                   (name (:status status))
+                   (if-let [device (get-in status [:device :name])]
+                     (str " (" device ")")
+                     "")
+                   total
+                   (if (pos? total) (str " " (pr-str skips)) "")))))))
+    true))
+
+(defn opencl-skip!
+  "Record one visible OpenCL skip marker, or fail when the runtime is broken/required.
+
+   `capability` is currently nil or :fp16.  Missing optional capabilities remain honest skips;
+   RASTER_EXPECT_OPENCL requires a usable device but does not imply every optional extension."
+  ([test-label] (opencl-skip! test-label nil))
+  ([test-label capability]
+   @opencl-summary-hook
+   (let [{:keys [status error device] :as result} (opencl-status-for capability)]
+     (swap! opencl-skip-log update (or capability status) (fnil inc 0))
+     (case status
+       :load-failed
+       (is false
+           (str "[OPENCL LOAD FAILED] " test-label " — " (some-> error .getMessage)
+                ". This is a runtime breakage, not an absent device."))
+
+       :probe-error
+       (if *expect-opencl?*
+         (is false
+             (str "[OPENCL PROBE FAILED] " test-label " — " (some-> error .getMessage)
+                  ". RASTER_EXPECT_OPENCL requires this lane to execute OpenCL."))
+         (do
+           (println (str "  [OPENCL SKIP/WARN] " test-label " — "
+                         (some-> error .getMessage)))
+           (is true "opencl-skip-marker")))
+
+       :no-device
+       (if *expect-opencl?*
+         (is false
+             (str "[OPENCL DEVICE MISSING] " test-label
+                  " — RASTER_EXPECT_OPENCL requires an OpenCL device."))
+         (do
+           (println (str "  [OPENCL SKIP] " test-label " — no requested OpenCL device"))
+           (is true "opencl-skip-marker")))
+
+       :missing-capability
+       (do
+         (println (str "  [OPENCL SKIP] " test-label " — selected device " (:name device)
+                       " lacks " (name capability)))
+         (is true "opencl-skip-marker"))
+
+       :available
+       (throw
+        (IllegalStateException.
+         (str "opencl-skip! called for " test-label " while OpenCL is available")))
+
+       (throw (ex-info "Unknown OpenCL probe status" {:result result}))))))

--- a/test/raster/gpu/device_probe_test.clj
+++ b/test/raster/gpu/device_probe_test.clj
@@ -1,0 +1,66 @@
+(ns raster.gpu.device-probe-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.gpu.device-probe :as probe]))
+
+(defn- api
+  [& {:keys [load! query-devices init! selected-device-info]
+      :or {load! (constantly true)
+           query-devices (constantly [{:name "enumerated"}])
+           init! (constantly true)
+           selected-device-info (constantly {:name "selected"})}}]
+  {:load! load!
+   :query-devices query-devices
+   :init! init!
+   :selected-device-info selected-device-info})
+
+(deftest opencl-probe-distinguishes-absence-from-breakage
+  (is (= :load-failed
+         (:status
+          (probe/probe-opencl-with
+           (api :load! #(throw (Exception. "load")))))))
+  (is (= :probe-error
+         (:status
+          (probe/probe-opencl-with
+           (api :query-devices #(throw (Exception. "query")))))))
+  (let [initialized? (atom false)
+        result (probe/probe-opencl-with
+                (api :query-devices (constantly [])
+                     :init! #(reset! initialized? true)))]
+    (is (= :no-device (:status result)))
+    (is (false? @initialized?) "absence must not initialize a context")))
+
+(deftest capability-gates-use-the-exact-selected-device
+  (let [selected {:name "selected-without-fp16" :extensions "cl_khr_fp64"}
+        result (probe/probe-opencl-with
+                (api :query-devices
+                     (constantly [{:name "other" :extensions "cl_khr_fp16"} selected])
+                     :selected-device-info (constantly selected)))]
+    (is (= :available (:status result)))
+    (is (= selected (:device result)))
+    (is (false? (probe/capability-supported? (:device result) :fp16))))
+  (is (probe/capability-supported?
+       {:extensions "cl_khr_fp64 cl_khr_fp16 cl_khr_subgroups"} :fp16)))
+
+(defn- capture-skip
+  [status expected?]
+  (let [events (atom [])
+        skip-log (var-get (ns-resolve 'raster.gpu.device-probe 'opencl-skip-log))
+        prior-log @skip-log]
+    (try
+      (binding [probe/*expect-opencl?* expected?]
+        (with-redefs [probe/opencl-status (delay status)
+                      clojure.test/report (fn [event]
+                                            (swap! events conj (:type event)))]
+          (probe/opencl-skip! "probe-test")))
+      @events
+      (finally
+        (reset! skip-log prior-log)))))
+
+(deftest expected-opencl-mode-turns-absence-and-probe-errors-red
+  (testing "ordinary CPU-only CI records a visible passing marker"
+    (is (= [:pass] (capture-skip {:status :no-device} false))))
+  (testing "an expected OpenCL lane fails on absence"
+    (is (= [:fail] (capture-skip {:status :no-device} true))))
+  (testing "an expected OpenCL lane fails on driver/query errors"
+    (is (= [:fail]
+           (capture-skip {:status :probe-error :error (Exception. "driver")} true)))))

--- a/test/raster/gpu/dispatch_benchmark_device_test.clj
+++ b/test/raster/gpu/dispatch_benchmark_device_test.clj
@@ -10,17 +10,10 @@
             [raster.compiler.passes.parallel.soac-lower :as lower]
             [raster.dl.gpu-grad-parity :as gpu-probe]
             [raster.gpu.core :as gpu]
+            [raster.gpu.device-probe :as device-probe]
             [raster.gpu.dispatch-benchmark :as benchmark]
             [raster.gpu.tuning-cache :as cache])
   (:import [java.nio.file Files]))
-
-(def ^:private opencl-available?
-  (delay
-    (try
-      (require 'raster.gpu.ocl-runtime)
-      ((resolve 'raster.gpu.ocl-runtime/init!))
-      true
-      (catch Throwable _ false))))
 
 (def ^:private abi
   [(kabi/slot 'x :input :float :role :operand)
@@ -162,8 +155,8 @@
     (assert-device-tuning! :ze:0)))
 
 (deftest opencl-validates-and-measures-emitted-dispatch-alternatives
-  (if-not @opencl-available?
-    (is true "OpenCL device unavailable")
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "validated KernelDispatch benchmark")
     (assert-device-tuning! :ocl:0)))
 
 (deftest level-zero-validates-and-measures-a-multi-kernel-dispatch-alternative
@@ -172,6 +165,6 @@
     (assert-graph-tuning! :ze:0)))
 
 (deftest opencl-validates-and-measures-a-multi-kernel-dispatch-alternative
-  (if-not @opencl-available?
-    (is true "OpenCL device unavailable")
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "validated multi-kernel dispatch benchmark")
     (assert-graph-tuning! :ocl:0)))

--- a/test/raster/gpu/indexed_attention_device_test.clj
+++ b/test/raster/gpu/indexed_attention_device_test.clj
@@ -11,19 +11,12 @@
             [raster.dl.array-ops :as array-ops]
             [raster.dl.gpu-grad-parity :as gp]
             [raster.gpu.core :as gpu]
+            [raster.gpu.device-probe :as device-probe]
             [raster.gpu.dispatch-benchmark :as benchmark]
             [raster.gpu.link :as link]
             [raster.gpu.tuning-cache :as cache]
             [raster.numeric])
   (:import [java.nio.file Files]))
-
-(def ^:private opencl-available?
-  (delay
-    (try
-      (require 'raster.gpu.ocl-runtime)
-      ((resolve 'raster.gpu.ocl-runtime/init!))
-      true
-      (catch Throwable _ false))))
 
 (defn- chain
   []
@@ -121,8 +114,8 @@
     (run-case :ze:0)))
 
 (deftest opencl-indexed-attention-matches-independent-plan-oracle
-  (if-not @opencl-available?
-    (is true "OpenCL device unavailable")
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "indexed attention plan oracle")
     (run-case :ocl:0)))
 
 (defn- production-case
@@ -177,8 +170,8 @@
             (make-array java.nio.file.attribute.FileAttribute 0))))
 
 (deftest compiled-resident-dispatch-tunes-and-returns-a-baked-schedule
-  (if-not @opencl-available?
-    (is true "OpenCL device unavailable")
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "compiled resident dispatch tuning")
     (let [{:keys [buffers]} (test-case)
           args [(get buffers 'Q) (get buffers 'K) (get buffers 'V)
                 (get buffers 'dst) (get buffers 'src) 3 4 5 2]
@@ -227,8 +220,8 @@
                 (link/close! executable)))))))))
 
 (deftest resident-compiler-selects-from-runtime-component-width
-  (if-not @opencl-available?
-    (is true "OpenCL device unavailable")
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "runtime component-width dispatch")
     (let [descriptor (pipeline/compile-gpu-program
                       #'resident-indexed-attention-probe :ocl:0 :dtype :float)
           small (production-case descriptor 4)

--- a/test/raster/gpu/kernel_graph_device_test.clj
+++ b/test/raster/gpu/kernel_graph_device_test.clj
@@ -4,15 +4,8 @@
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.soac-lower :as lower]
             [raster.dl.gpu-grad-parity :as gp]
-            [raster.gpu.core :as gpu]))
-
-(def ^:private ocl-available?
-  (delay
-    (try
-      (require 'raster.gpu.ocl-runtime)
-      ((resolve 'raster.gpu.ocl-runtime/init!))
-      true
-      (catch Throwable _ false))))
+            [raster.gpu.core :as gpu]
+            [raster.gpu.device-probe :as device-probe]))
 
 (defn- emitted-graph []
   (let [node (soac/par-form->soac
@@ -85,13 +78,13 @@
               (gpu/release-kernel-graph! sess handle))))))))
 
 (deftest opencl-kernel-graph-inclusive-scan
-  (if-not @ocl-available?
-    (is true "OpenCL device unavailable")
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "OpenCL KernelGraph inclusive scan")
     (assert-prefix! :ocl:0)))
 
 (deftest opencl-kernel-graph-binds-aligned-disjoint-views-of-one-allocation
-  (if-not @ocl-available?
-    (is true "OpenCL device unavailable")
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "OpenCL KernelGraph BufferView aliases")
     (let [n 1025
           n-bytes (* 4 n)
           alignment ((resolve 'raster.gpu.ocl-runtime/buffer-offset-alignment))

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -14,13 +14,8 @@
             [raster.core :refer [deftm]]
             [raster.dl.array-ops :as ops]
             [raster.gpu.core :as gpu]
+            [raster.gpu.device-probe :as device-probe]
             [raster.gpu.descriptor-fixture :as fixture]))
-
-(def ^:private ocl-available?
-  (delay (try (require 'raster.gpu.ocl-runtime)
-              ((resolve 'raster.gpu.ocl-runtime/init!))
-              true
-              (catch Throwable _ false))))
 
 (deftest opencl-max-work-group-size-selector
   (require 'raster.gpu.ocl-runtime)
@@ -53,8 +48,8 @@
                           (ra/aset out j (clojure.core/* (ra/aget x j) s)))))
 
 (deftest ocl-map-void-mixed-storage-abi-roundtrip
-  (if-not @ocl-available?
-    (println "SKIP ocl mixed-storage map-void (no OpenCL device)")
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "mixed-storage map-void")
     (let [n 64
           q (byte-array (map #(byte (- (mod % 31) 15)) (range n)))
           out (int-array n)
@@ -71,8 +66,8 @@
       (is (every? true? (map-indexed (fn [i v] (= v (+ 7 (aget q i)))) out))))))
 
 (deftest ocl-resident-session-roundtrip
-  (if-not @ocl-available?
-    (println "SKIP ocl-session test (no OpenCL device)")
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "resident session")
     (let [p (pl/compile-gpu-program #'ocl-session-ax! :ocl:0 :dtype :float)
           n 4096
           x (float-array (map float (range n)))
@@ -93,8 +88,8 @@
         (finally (gpu/close-session! s))))))
 
 (deftest ocl-resident-indexed-row-reduction-roundtrip
-  (if-not @ocl-available?
-    (println "SKIP ocl indexed row reduction (no OpenCL device)")
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "indexed row reduction")
     (let [nrows 3
           width 513
           values (float-array (* nrows width) (float -10.0))
@@ -115,8 +110,8 @@
         (finally (gpu/close-session! s))))))
 
 (deftest ocl-resident-row-gather-roundtrip
-  (if-not @ocl-available?
-    (println "SKIP ocl row gather (no OpenCL device)")
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "row gather")
     (let [nrows 3
           width 4
           table (float-array (map float (range 32)))
@@ -134,8 +129,8 @@
         (finally (gpu/close-session! s))))))
 
 (deftest ocl-resident-segmap-artifact-roundtrip
-  (if-not @ocl-available?
-    (println "SKIP ocl resident SegMap artifact (no OpenCL device)")
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "resident SegMap artifact")
     (let [descriptor (pl/compile-gpu-program #'ocl-session-map :ocl:0 :dtype :float)
           n 4096
           x (float-array (map float (range n)))
@@ -151,8 +146,8 @@
         (finally (gpu/close-session! s))))))
 
 (deftest ocl-resident-contraction-roundtrip
-  (if-not @ocl-available?
-    (println "SKIP ocl resident contraction (no OpenCL device)")
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "resident contraction")
     (let [descriptor (pl/compile-gpu-program #'ocl-session-contract :ocl:0 :dtype :float)
           A (float-array (map float (range 64)))
           B (float-array (repeat 64 (float 1.0)))
@@ -168,8 +163,8 @@
         (finally (gpu/close-session! s))))))
 
 (deftest ocl-resident-reduction-ordered-abi-roundtrip
-  (if-not @ocl-available?
-    (println "SKIP ocl resident reduction (no OpenCL device)")
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "resident reduction")
     (let [descriptor (pl/compile-gpu-program #'ocl-session-reduce :ocl:0 :dtype :float)
           n 1024
           scale 0.75

--- a/test/raster/gpu/paged_kv_append_device_test.clj
+++ b/test/raster/gpu/paged_kv_append_device_test.clj
@@ -1,20 +1,10 @@
 (ns raster.gpu.paged-kv-append-device-test
-  (:require [clojure.string :as str]
-            [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [deftest is]]
             [raster.compiler.ir.paged-kv-append :as append]
             [raster.compiler.passes.parallel.paged-kv-append-route :as route]
             [raster.dl.gpu-grad-parity :as gp]
-            [raster.gpu.core :as gpu]))
-
-(def ^:private ocl-fp16-available?
-  (delay
-    (try
-      (require 'raster.gpu.ocl-runtime)
-      ((resolve 'raster.gpu.ocl-runtime/init!))
-      (boolean
-       (some #(str/includes? (or (:extensions %) "") "cl_khr_fp16")
-             ((resolve 'raster.gpu.ocl-runtime/query-devices))))
-      (catch Throwable _ false))))
+            [raster.gpu.core :as gpu]
+            [raster.gpu.device-probe :as device-probe]))
 
 (defn- half-bits
   [value]
@@ -86,6 +76,6 @@
     (run-case :ze:0)))
 
 (deftest opencl-paged-kv-append-assigns-rte-halfs
-  (if-not @ocl-fp16-available?
-    (is true "OpenCL FP16 device unavailable")
+  (if-not @device-probe/opencl-fp16-available?
+    (device-probe/opencl-skip! "paged K/V assignment" :fp16)
     (run-case :ocl:0)))

--- a/test/raster/gpu/range_transfer_test.clj
+++ b/test/raster/gpu/range_transfer_test.clj
@@ -13,20 +13,14 @@
    `(min buf src)` bytes, which is fine for a whole-buffer copy and exactly wrong for a range."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.dl.gpu-grad-parity :as gp]
-            [raster.gpu.core :as g])
+            [raster.gpu.core :as g]
+            [raster.gpu.device-probe :as device-probe])
   (:import [java.lang.foreign Arena MemorySegment ValueLayout]))
 
 ;; gemma-270m's real KV shape: 2048 positions x (1 kv-head x 256 head-dim)
 (def ^:private maxpos 2048)
 (def ^:private kvrow 256)
 (def ^:private N (* maxpos kvrow))
-
-(def ^:private opencl-available?
-  (delay
-    (try
-      ((requiring-resolve 'raster.gpu.ocl-runtime/init!))
-      true
-      (catch Throwable _ false))))
 
 (defn- with-filled-session
   "A session whose :kc0 buffer holds value=index at every element, so any disturbance is visible."
@@ -111,8 +105,8 @@
           (g/close-session! session))))))
 
 (deftest opencl-resident-range-copy-uses-the-device-buffer-path
-  (if-not @opencl-available?
-    (is true "OpenCL device unavailable")
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "resident range copy")
     (let [session (g/make-session :ocl:0)]
       (try
         (g/alloc! session {:source [:float 6 (float-array [1 2 3 4 5 6])]


### PR DESCRIPTION
## Summary

- distinguish specified OpenCL absence from loader, FFM, driver, and device-query failures
- gate capabilities on the exact device bound by the singleton runtime and advertise only that bindable device
- add a structured OpenCL test probe with visible skips and an expected-device mode
- migrate the OpenCL device suites away from broad catch-and-skip gates
- execute and assert both the reference and cooperative routed-attention strategies on real hardware

## Verification

- full suite: 2,400 tests, 34,699 assertions, 0 failures, 0 errors
- Intel Arc: zero OpenCL and Level Zero device-test skip paths
- focused fresh-process OpenCL run: 40 tests, 198 assertions, 0 failures, 0 errors
- CPU OpenCL expected-device experiment correctly selected the non-FP16 PoCL device and exposed 14 real kernel compiler errors; clinfo independently fails on the same local PoCL installation, so this PR does not add a knowingly red PoCL CI lane

## Scope

This deliberately leaves legacy Level Zero gate migration, the fake scan-codegen skip, and lost exact GEMM topology coverage for the next coverage-restoration change.