### PR TITLE
Restore scan and GEMM topology coverage

### DIFF
--- a/test/raster/compiler/backend/gpu/gpu_correctness_test.clj
+++ b/test/raster/compiler/backend/gpu/gpu_correctness_test.clj
@@ -14,6 +14,10 @@
             [raster.compiler.backend.gpu.par-opencl :as par-opencl]
             [raster.compiler.backend.gpu.c-emit :as c-emit]
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
+            [raster.compiler.backend.gpu.segop-opencl :as segop-opencl]
+            [raster.compiler.ir.kernel-graph :as kernel-graph]
+            [raster.compiler.ir.soac :as soac]
+            [raster.compiler.passes.parallel.soac-lower :as soac-lower]
             [raster.runtime.hardware :as hw]))
 
 ;; ================================================================
@@ -173,19 +177,23 @@
 ;; ---- 1.7 Scan kernel structure ----
 
 (deftest codegen-scan-test
-  (testing "Scan kernel pair generated"
-    (try
-      (let [result (par-opencl/generate-par-scan-exclusive-kernel
-                    '(raster.par/scan-exclusive! out totals i n (clojure.core/+ acc (aget a i)) 0))]
-        (when result
-          (is (vector? result))
-          (is (>= (count result) 2) "Should produce at least 2 kernels (scan + carry)")
-          (doseq [k result]
-            (is (string? (:source k)))
-            (is (str/includes? (:source k) "__kernel")))))
-      (catch Exception e
-        ;; Scan kernel API may have different form structure
-        (println "  [SKIP] Scan kernel generation:" (.getMessage e))))))
+  (testing "the production SoacScan path emits its certified three-stage kernel graph"
+    (let [node (soac/par-form->soac
+                'out
+                '(raster.par/scan out acc 0.0 i n double
+                                  (clojure.core/+ acc (clojure.core/aget a i)))
+                0)
+          operations (soac-lower/lower-scan node nil)
+          scheduled (soac-lower/scan-kernel-graph node operations {})
+          emitted (segop-opencl/generate-scan-kernel-graph scheduled)
+          artifacts (mapv :operation (:nodes emitted))]
+      (is (kernel-graph/kernel-graph? emitted))
+      (is (= [:intra-block :block-scan :carry-in]
+             (mapv #(get-in % [:attributes :phase]) artifacts)))
+      (is (= [[] [(:id (first (:nodes emitted)))]
+              (mapv :id (take 2 (:nodes emitted)))]
+             (mapv :dependencies (:nodes emitted))))
+      (is (every? #(str/includes? (:source %) "__kernel") artifacts)))))
 
 ;; ---- 1.8 Mixed operations ----
 
@@ -248,7 +256,7 @@
            out (int-array n)
            kernel (par-opencl/generate-par-map-void-kernel
                    '(raster.par/map-void! i n
-                      (aset out i (+ (int (aget q i)) limit)))
+                                          (aset out i (+ (int (aget q i)) limit)))
                    :dtype :float
                    :array-types {'out :int 'q :byte}
                    :scalar-types {'limit :int})

--- a/test/raster/gpu/gemm_link_topology_test.clj
+++ b/test/raster/gpu/gemm_link_topology_test.clj
@@ -1,0 +1,122 @@
+(ns raster.gpu.gemm-link-topology-test
+  "Model-free reachability for the public LinkPlan GEMM path.
+
+   A semantic GEMM may select a conversion/layout/split graph.  This test pins the exact
+   flattening and constant-prologue boundary without loading a driver or allocating the large
+   logical buffers that make split-K profitable."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.gemm :as gemm]
+            [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.ir.link-plan :as link-plan]
+            [raster.gpu.core :as gpu]
+            [raster.gpu.link :as gpu-link]))
+
+(defn- split-gemm-descriptor
+  []
+  (let [tile (hardware/derive-gemm-tile {})]
+    {:dtype :float
+     :gemm-precision :f16-xmx
+     :schedule {:precision :f16-xmx}
+     :all-params '[a b c m n k]
+     :array-params '[a b c]
+     :array-roles {'a :input 'b :input 'c :output}
+     :scalar-params '[m n k]
+     :allocs []
+     :steps
+     [{:convention :gemm :variant :nt :A 'a :B 'b :C 'c
+       :dispatch
+       (gemm/emit-executable
+        {:id "mock-linked-gemm" :a 'a :b 'b :c 'c
+         :m :gemm-m :n :gemm-n :k :gemm-k :variant :nt
+         :precision :f16-xmx :tile tile :fill-workgroups 32})
+       :argument-specs [{:kind :input :sym 'a}
+                        {:kind :input :sym 'b}
+                        {:kind :output :sym 'c}
+                        {:kind :scalar :type :int :value-fn #(nth % 3)}
+                        {:kind :scalar :type :int :value-fn #(nth % 4)}
+                        {:kind :scalar :type :int :value-fn #(nth % 5)}]
+       :strategy-selection {:path [:precision]
+                            :mapping {:f32-scalar :f32-scalar}
+                            :default :auto}
+       :phase :gemm}]
+     :result-sym 'c}))
+
+(defn- split-gemm-plan
+  [descriptor m n k]
+  (link-plan/make
+   {:id :split-gemm-topology
+    :target :ze:0
+    :nodes [(link-plan/node {:id :a :dtype :float :shape [m k]
+                             :device :ze:0 :role :input})
+            (link-plan/node {:id :b :dtype :float :shape [n k]
+                             :device :ze:0 :role :constant})
+            (link-plan/node {:id :c :dtype :float :shape [m n]
+                             :device :ze:0 :role :output})]
+    :instances [(link-plan/instance
+                 {:id :projection
+                  :descriptor descriptor
+                  :bindings {'a :a 'b :b 'c :c}
+                  :scalars {'m m 'n n 'k k}})]
+    :outputs [:c]}))
+
+(defn- element-bytes
+  [dtype]
+  (case dtype
+    (:byte :int8) 1
+    (:half :short) 2
+    (:double :long) 8
+    4))
+
+(deftest link-plan-flattens-selected-gemm-graph-and-hoists-constant-transforms
+  (let [m 13 n 640 k 262144
+        descriptor (split-gemm-descriptor)
+        plan (split-gemm-plan descriptor m n k)
+        session (atom {:device-id :ze:0 :session-id :mock-session
+                       :buffers {} :allocations {} :prepared {} :graphs {}
+                       :kernel-graphs {} :events {} :closed? false})
+        registered (atom [])
+        recorded (atom [])
+        replayed (atom [])
+        runtime-function
+        (fn [_ name]
+          (case name
+            "make-buffer"
+            (fn [elements dtype]
+              {:dtype dtype :n-elements elements
+               :byte-size (* (long elements) (element-bytes dtype))
+               :alignment 64})
+
+            "array->buffer!" (fn [buffer _] buffer)
+            "buffer-as-float-buffer" (fn [& _] (throw (AssertionError. "unused")))
+            "buffer-as-int-buffer" (fn [& _] (throw (AssertionError. "unused")))
+            "register-kernel!" (fn [name artifact] (swap! registered conj [name artifact]))
+            "bind-kernel-call" (fn [call] {:kernel-call call})
+            "record-graph!" (fn [bounds & [options]]
+                              (let [graph {:bounds (vec bounds) :options options}]
+                                (swap! recorded conj graph)
+                                graph))
+            "replay-graph!" (fn [graph] (swap! replayed conj graph))
+            (throw (ex-info "unexpected mocked runtime function" {:name name}))))]
+    (with-redefs-fn
+      {(ns-resolve 'raster.gpu.core 'rt-resolve) runtime-function}
+      (fn []
+        (let [executable (gpu-link/instantiate! plan {:session session})
+              phase (first (:phases executable))
+              bound (get-in @session [:prepared phase])
+              prepareds (:prepareds bound)
+              graph-entry (get-in @session [:graphs (:graph-key executable)])]
+          (testing "the selected schedule is flattened behind one semantic LinkPlan step"
+            (is (= 1 (count (:phases executable))))
+            (is (= 5 (count prepareds))
+                "A/B conversion, B transpose, split contraction, and combine are all reachable")
+            (is (= 4 (count (:temporary-buffers bound)))
+                "A16, B16, transposed B16, and split partials remain graph-private")
+            (is (= 5 (count @registered)))
+            (is (every? #(contains? % :kernel-call) prepareds)))
+          (testing "only transforms derived entirely from the constant weight enter the prologue"
+            (is (= [2 3] (mapv (comp count :bounds) @recorded)))
+            (is (= 2 (count (filter :const-prologue? prepareds))))
+            (is (= 3 (count (remove :const-prologue? prepareds))))
+            (is (= 1 (count @replayed)) "the constant prologue executes once at instantiation")
+            (is (= 2 (count (:bounds (:prologue-graph graph-entry)))))
+            (is (= 3 (count (:bounds (:replay-graph graph-entry)))))))))))


### PR DESCRIPTION
## Summary

- replace the catch-and-skip scan test with an always-on SoacScan to certified SegScan graph to verified OpenCL artifact test
- restore model-free exact-topology coverage for the public LinkPlan GEMM path removed with the legacy resident runtime
- pin five flattened kernels, four graph-private temporaries, the two-kernel constant prologue, and the three-kernel replay graph

## Verification

- focused fresh JVM: 14 tests, 68 assertions, 0 failures, 0 errors
- full suite: 2,401 tests, 34,714 assertions, 0 failures, 0 errors
- Intel Arc: zero OpenCL and Level Zero skip paths

This is intentionally a test-only slice. Destination-bounded indexed-attention traversal follows separately so the pretrained-rstr demo work remains general and reviewable.