### PR TITLE
Bound routed attention membership traversal

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -118,7 +118,10 @@ or schedule. Unsupported target semantics fail at this boundary instead of silen
 cast, layout, collective, or reduction-association contract. It is not production-reachable until a
 semantic route constructs the body. The next production vertical is the scheduled routed
 `SegmentedWeightedReductionSchedule -> KernelBody` construction with an invariant external ABI; it
-must not introduce an attention operation into this vocabulary.
+must not introduce an attention operation into this vocabulary. The current handwritten production
+leaf already keeps physical storage and logical membership independent: dense/CSR page routing can
+combine with either bounded contiguous intervals or bounded CSR rows under one cooperative schedule.
+That leaf is the executable behavior and ABI oracle which the KernelBody vertical must replace.
 
 ### 2.3 Executable steps and resident artifact values compose
 

--- a/src/raster/compiler/backend/gpu/attention.clj
+++ b/src/raster/compiler/backend/gpu/attention.clj
@@ -2,9 +2,10 @@
   "FP16-KV leaves for logical attention over dense or CSR paged KV routes.
 
    The direct one-work-item/component leaf remains the executable semantic oracle.  A separately
-   validated SegmentedWeightedReductionSchedule emits one subgroup/query-head for dense routed
-   interval attention, sharing each QK score across lane-strided value accumulators without
-   changing the semantic plan, ordered ABI, storage ownership or graph effects."
+   validated SegmentedWeightedReductionSchedule emits one subgroup/query-head across dense/CSR
+   routes and interval/CSR membership, sharing each QK score across lane-strided value
+   accumulators without changing the semantic plan, ordered ABI, storage ownership or graph
+   effects."
   (:require [raster.compiler.ir.attention :as attention]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
@@ -195,14 +196,31 @@
 
 (defn- visibility-initialization
   [visibility invalid-result]
-  (when (attention/csr-visibility? visibility)
+  (if (attention/csr-visibility? visibility)
     (str "  const int attention_begin = attention_row_offsets[q_token];\n"
          "  const int attention_end = attention_row_offsets[q_token + 1];\n"
          "  if (attention_row_offsets[0] != 0 || attention_begin < 0\n"
          "      || attention_end < attention_begin || attention_end > "
          (:key-index-capacity visibility) ") {\n"
          invalid-result
-         "  }\n")))
+         "  }\n")
+    (let [{:keys [causal? window-left window-right]} visibility]
+      (str "  long attention_begin = 0L;\n"
+           "  long attention_end = (long)length;\n"
+           (when (some? window-left)
+             (str "  attention_begin = max(0L, (long)q_position - " window-left
+                  "L - (long)kv_start_position);\n"
+                  "  attention_begin = min(attention_begin, (long)length);\n"))
+           (cond
+             causal?
+             (str "  attention_end = min(attention_end, (long)q_position"
+                  " - (long)kv_start_position + 1L);\n"
+                  "  attention_end = max(attention_end, 0L);\n")
+
+             (some? window-right)
+             (str "  attention_end = min(attention_end, (long)q_position + " window-right
+                  "L - (long)kv_start_position + 1L);\n"
+                  "  attention_end = max(attention_end, 0L);\n"))))))
 
 (defn- visibility-loop-start
   [visibility invalid-result]
@@ -212,7 +230,7 @@
          "    if (token < 0 || token >= length) {\n"
          invalid-result
          "    }\n")
-    "  for (int token = 0; token < length; ++token) {\n"))
+    "  for (int token = (int)attention_begin; token < (int)attention_end; ++token) {\n"))
 
 (defn- reference-source
   [problem name]
@@ -311,11 +329,15 @@
                       (get-in schedule [:numerical-mode :score-accumulate]))
                    (= (:accumulator-dtype plan)
                       (get-in schedule [:numerical-mode :state-accumulate]))
-                   (= :dense-paged (attention/route-kind (:route problem)))
-                   (= :interval (attention/visibility-kind (:visibility problem)))
                    (= :routed-paged-kv (get-in schedule [:attributes :storage-kind]))
-                   (= :dense-paged (get-in schedule [:attributes :route-kind]))
-                   (= :interval (get-in schedule [:attributes :visibility-kind])))
+                   (= (attention/route-kind (:route problem))
+                      (get-in schedule [:attributes :route-kind]))
+                   (= (attention/visibility-kind (:visibility problem))
+                      (get-in schedule [:attributes :visibility-kind]))
+                   (= (if (attention/csr-visibility? (:visibility problem))
+                        :csr-row
+                        :contiguous-interval)
+                      (:membership-traversal schedule)))
       (throw (ex-info "cooperative attention schedule does not describe this reduction plan"
                       {:reason :attention-cooperative-schedule-plan-mismatch
                        :schedule schedule :plan-id (:id plan)})))
@@ -377,6 +399,7 @@
          "    __global const half* k_pages,\n"
          "    __global const half* v_pages,\n"
          (route-signature route)
+         (visibility-signature visibility)
          "    __global " (opencl-type output-dtype) "* output) {\n"
          "  const long lane = (long)get_sub_group_local_id();\n"
          "  const int q_head = (int)get_group_id(0);\n"
@@ -399,15 +422,17 @@
          invalid-result
          "  }\n"
          (route-initialization problem invalid-result)
-         "  if (length == 0) {\n"
-         empty-result
-         "  }\n"
+         (visibility-initialization visibility invalid-result)
+         (when (attention/interval-visibility? visibility)
+           (str "  if (attention_begin == attention_end) {\n"
+                empty-result
+                "  }\n"))
          "  const int kv_head = q_head / " gqa-ratio ";\n"
          "  const long q_base = ((long)q_token * " q-heads
          " + q_head) * " qk-head-dim ";\n"
          "  float maximum = -3.402823466e+38f;\n"
          "  float denominator = 0.0f;\n"
-         "  for (int token = 0; token < length; ++token) {\n"
+         (visibility-loop-start visibility invalid-result)
          "    const long kv_position = (long)kv_start_position + token;\n"
          "    int visible = 1;\n"
          (visibility-statements (attention/position-filter visibility))
@@ -528,7 +553,7 @@
                    :complexity :quadratic-in-qk-head-dim}})))
 
 (defn emit-fp16-cooperative
-  "Emit one subgroup per query segment for dense routed FP16 K/V attention.
+  "Emit one subgroup per query segment for routed FP16 K/V attention.
 
    The artifact preserves the reference leaf's complete ordered ABI and logical effects.  Only
    its target-neutral SegmentedWeightedReductionSchedule, launch mapping and target body differ."

--- a/src/raster/compiler/ir/segmented_weighted_reduction_schedule.clj
+++ b/src/raster/compiler/ir/segmented_weighted_reduction_schedule.clj
@@ -35,10 +35,11 @@
       (throw (ex-info "cooperative weighted reduction requires one workgroup per segment"
                       {:reason :segmented-weighted-reduction-segment-mapping
                        :segment-mapping segment-mapping})))
-    (when-not (= :sequential membership-traversal)
-      (throw (ex-info "initial cooperative weighted reduction requires sequential membership traversal"
+    (when-not (contains? #{:contiguous-interval :csr-row} membership-traversal)
+      (throw (ex-info "cooperative weighted reduction requires a bounded membership traversal"
                       {:reason :segmented-weighted-reduction-membership-traversal
-                       :membership-traversal membership-traversal})))
+                       :membership-traversal membership-traversal
+                       :supported #{:contiguous-interval :csr-row}})))
     (when-not (and (= :subgroup (:kind score-reduction))
                    (= workgroup-size (:width score-reduction))
                    (some? (:axis score-reduction)))

--- a/src/raster/compiler/passes/parallel/attention_route.clj
+++ b/src/raster/compiler/passes/parallel/attention_route.clj
@@ -38,8 +38,8 @@
   "Route packed/routed attention through a cooperative schedule or its semantic oracle.
 
    Quantized K/V formats stay semantic values but decline until their scale/group operands are
-   explicit. Dense and CSR routing are both reference leaves with deliberately distinct ABIs;
-   dense interval visibility additionally admits a one-subgroup online-softmax schedule."
+   explicit. Dense and CSR physical routing retain deliberately distinct ABIs while interval and
+   CSR logical membership both admit the same one-subgroup online-softmax schedule."
   ([problem] (route problem nil))
   ([problem desc]
    (let [{:keys [q-dtype k-dtype v-dtype output-dtype accumulator-dtype

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_schedule.clj
@@ -11,8 +11,9 @@
 (defn plan-subgroup-online
   "Plan one subgroup per segment with one shared score and lane-strided value accumulators.
 
-   The first executable storage row is dense paged FP16 KV with interval visibility.  Those are
-   legality constraints of this schedule, not new semantic operation kinds."
+   The first executable storage rows are dense or CSR paged FP16 KV with either contiguous
+   interval or explicitly indexed CSR membership. Those are legality constraints of this
+   schedule, not new semantic operation kinds."
   ([plan] (plan-subgroup-online plan nil))
   ([plan desc]
    (let [{:keys [membership storage score value operands output accumulator-dtype] :as plan}
@@ -44,14 +45,14 @@
        (not= :logical-attention-visibility (:kind membership))
        (decline :score-reuse-membership-unsupported {:membership (:kind membership)})
 
-       (not= :interval (:visibility-kind membership))
+       (not (contains? #{:interval :csr} (:visibility-kind membership)))
        (decline :score-reuse-visibility-unsupported
                 {:visibility-kind (:visibility-kind membership)})
 
        (not= :routed-paged-kv (:kind storage))
        (decline :score-reuse-storage-unsupported {:storage (:kind storage)})
 
-       (not= :dense-paged (:route-kind storage))
+       (not (contains? #{:dense-paged :csr-paged} (:route-kind storage)))
        (decline :score-reuse-route-unsupported {:route-kind (:route-kind storage)})
 
        (or (not= :none (get-in storage [:k-format :quantization]))
@@ -62,11 +63,17 @@
        (not= :float accumulator-dtype)
        (decline :score-reuse-accumulator-unsupported {:actual accumulator-dtype})
 
-       (not (and (= 8 (count operand-dtypes))
-                 (contains? #{:half :float} (first operand-dtypes))
-                 (= [:int :int :half :half :int :int :int]
-                    (subvec operand-dtypes 1 8))
-                 (contains? #{:half :float} (:dtype output))))
+       (let [route-operands (case (:route-kind storage)
+                              :dense-paged 3
+                              :csr-paged 4)
+             visibility-operands (if (= :csr (:visibility-kind membership)) 2 0)
+             expected-count (+ 5 route-operands visibility-operands)]
+         (not (and (= expected-count (count operand-dtypes))
+                   (contains? #{:half :float} (first operand-dtypes))
+                   (= [:int :int :half :half]
+                      (subvec operand-dtypes 1 5))
+                   (every? #(= :int %) (subvec operand-dtypes 5))
+                   (contains? #{:half :float} (:dtype output)))))
        (decline :score-reuse-storage-dtypes-unsupported
                 {:operand-dtypes operand-dtypes :output-dtype (:dtype output)})
 
@@ -92,7 +99,9 @@
          {:strategy :subgroup-online-score-reuse
           :workgroup-size (long subgroup-size)
           :segment-mapping :one-workgroup-per-segment
-          :membership-traversal :sequential
+          :membership-traversal (case (:visibility-kind membership)
+                                  :interval :contiguous-interval
+                                  :csr :csr-row)
           :score-reduction {:kind :subgroup :width (long subgroup-size)
                             :axis (get-in score [:axis :name])}
           :value-mapping {:kind :lane-strided

--- a/test/raster/compiler/passes/parallel/attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/attention_route_test.clj
@@ -98,6 +98,7 @@
     (is (empty? declines))
     (is (swr-schedule/schedule? swr-schedule))
     (is (= :one-workgroup-per-segment (:segment-mapping swr-schedule)))
+    (is (= :contiguous-interval (:membership-traversal swr-schedule)))
     (is (= {:kind :lane-strided :components 6 :components-per-lane 1}
            (:value-mapping swr-schedule)))
     (is (= {:workgroup-size [16 1] :group-count [4 4]} schedule))
@@ -110,7 +111,9 @@
     (is (str/includes? source "const float dot = sub_group_reduce_add(partial_dot)"))
     (is (str/includes? source "old_weight = sub_group_broadcast(old_weight, 0)"))
     (is (str/includes? source "const int kv_head = q_head / 2"))
-    (is (str/includes? source "if (length == 0)"))
+    (is (str/includes? source "if (attention_begin == attention_end)"))
+    (is (str/includes? source
+                       "for (int token = (int)attention_begin; token < (int)attention_end"))
     (is (str/includes? source "float maximum"))
     (is (str/includes? source "accumulator0 = accumulator0 * old_weight"))))
 
@@ -118,18 +121,24 @@
   (let [clang? (zero? (:exit (shell/sh "sh" "-c" "command -v clang")))]
     (if-not clang?
       (is true "clang unavailable")
-      (let [source (get-in
-                    (route/route!
-                     (problem :qk-head-dim 256 :value-head-dim 256)
-                     {:device-type :gpu :vendor "Intel"
-                      :subgroup-size 16 :max-workgroup-size 256})
-                    [:artifact :source])
-            result (shell/sh "clang" "-x" "cl" "-cl-std=CL2.0"
-                             "-fsyntax-only" "-" :in source)]
-        (is (str/includes? source "const int d15 = (int)lane + 240;"))
-        (is (str/includes? source "float accumulator15 = 0.0f;"))
-        (is (not (str/includes? source "accumulator16")))
-        (is (zero? (:exit result)) (:err result))))))
+      (doseq [[physical-route visibility]
+              [[(dense-route) (attention/visibility)]
+               [(dense-route) (csr-visibility)]
+               [(csr-route) (attention/visibility)]
+               [(csr-route) (csr-visibility)]]]
+        (let [source (get-in
+                      (route/route!
+                       (problem :route physical-route :visibility visibility
+                                :qk-head-dim 256 :value-head-dim 256)
+                       {:device-type :gpu :vendor "Intel"
+                        :subgroup-size 16 :max-workgroup-size 256})
+                      [:artifact :source])
+              result (shell/sh "clang" "-x" "cl" "-cl-std=CL2.0"
+                               "-fsyntax-only" "-" :in source)]
+          (is (str/includes? source "const int d15 = (int)lane + 240;"))
+          (is (str/includes? source "float accumulator15 = 0.0f;"))
+          (is (not (str/includes? source "accumulator16")))
+          (is (zero? (:exit result)) (:err result)))))))
 
 (deftest cooperative-schedule-is-validated-and-target-legality-is-explicit
   (let [desc {:device-type :gpu :vendor "Intel"
@@ -149,6 +158,11 @@
            (try
              (swr-schedule/validate!
               (assoc-in schedule [:value-mapping :components-per-lane] 2))
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+    (is (= :segmented-weighted-reduction-membership-traversal
+           (try
+             (swr-schedule/validate!
+              (assoc schedule :membership-traversal :sequential))
              (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
     (is (= :attention-cooperative-schedule-plan-mismatch
            (try
@@ -193,25 +207,28 @@
     (is (= :score-reuse-register-state-too-wide
            (get-in too-wide [:declines 0 :reason])))))
 
-(deftest csr-route-has-native-compact-page-abi
+(deftest csr-route-has-native-compact-page-abi-and-cooperative-schedule
   (let [{:keys [artifact reference? declines]}
         (route/route! (problem :route (csr-route)) intel-desc)]
-    (is reference?)
-    (is (= :score-reuse-route-unsupported (get-in declines [0 :reason])))
+    (is (false? reference?))
+    (is (empty? declines))
     (is (= :csr-paged (get-in artifact [:attributes :route-kind])))
     (is (= '[q q-row-offsets q-positions k-pages v-pages page-offsets page-indices
              last-page-lengths kv-start-positions output]
            (:arguments artifact)))
     (is (= ["page_offsets" "page_indices" "last_page_lengths"]
            (subvec (mapv :c-name (:abi artifact)) 5 8)))
+    (is (= :contiguous-interval
+           (get-in artifact [:attributes :segmented-weighted-reduction-schedule
+                             :membership-traversal])))
     (is (str/includes? (:source artifact) "page_indices[page_begin + logical_page]"))
     (is (str/includes? (:source artifact) "routed_page_count == 0"))))
 
 (deftest logical-csr-visibility-composes-with-physical-route-as-distinct-abi-slots
   (let [{:keys [artifact reference? declines]}
         (route/route! (problem :visibility (csr-visibility)) intel-desc)]
-    (is reference?)
-    (is (= :score-reuse-visibility-unsupported (get-in declines [0 :reason])))
+    (is (false? reference?))
+    (is (empty? declines))
     (is (= :dense-paged (get-in artifact [:attributes :route-kind])))
     (is (= :csr (get-in artifact [:attributes :visibility-kind])))
     (is (= '[q q-row-offsets q-positions k-pages v-pages
@@ -220,6 +237,9 @@
            (:arguments artifact)))
     (is (= ["attention_row_offsets" "attention_key_indices"]
            (subvec (mapv :c-name (:abi artifact)) 8 10)))
+    (is (= :csr-row
+           (get-in artifact [:attributes :segmented-weighted-reduction-schedule
+                             :membership-traversal])))
     (is (str/includes? (:source artifact)
                        "for (int edge = attention_begin; edge < attention_end; ++edge)"))
     (is (str/includes? (:source artifact)
@@ -252,22 +272,32 @@
     (is (str/includes? source
                        "output[out_base + d0] = denominator == 0.0f ? 0.0f"))))
 
-(deftest pinned-cooperative-policy-declines-instead-of-silently-changing-schedule
+(deftest pinned-cooperative-policy-selects-csr-membership-without-changing-semantics
   (let [result (route/route
                 (problem :visibility (csr-visibility))
                 {:device-type :gpu :vendor "Intel" :subgroup-size 16
                  :max-workgroup-size 256
                  :segmented-weighted-reduction-schedule :subgroup-score-reuse})]
-    (is (nil? (:strategy result)))
-    (is (= :score-reuse-visibility-unsupported (get-in result [:declines 0 :reason])))
-    (is (= :attention-no-kernel-route
-           (try
-             (route/route!
-              (problem :visibility (csr-visibility))
-              {:device-type :gpu :vendor "Intel" :subgroup-size 16
-               :max-workgroup-size 256
-               :segmented-weighted-reduction-schedule :subgroup-score-reuse})
-             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))))
+    (is (= :routed-paged-subgroup-online-score-reuse (:strategy result)))
+    (is (empty? (:declines result)))
+    (is (= :csr-row
+           (get-in result [:artifact :attributes :segmented-weighted-reduction-schedule
+                           :membership-traversal])))))
+
+(deftest physical-routing-and-logical-membership-vary-independently
+  (doseq [[physical-route visibility traversal]
+          [[(dense-route) (attention/visibility) :contiguous-interval]
+           [(dense-route) (csr-visibility) :csr-row]
+           [(csr-route) (attention/visibility) :contiguous-interval]
+           [(csr-route) (csr-visibility) :csr-row]]]
+    (let [{:keys [strategy reference? declines artifact]}
+          (route/route! (problem :route physical-route :visibility visibility) intel-desc)]
+      (is (= :routed-paged-subgroup-online-score-reuse strategy))
+      (is (false? reference?))
+      (is (empty? declines))
+      (is (= traversal
+             (get-in artifact [:attributes :segmented-weighted-reduction-schedule
+                               :membership-traversal]))))))
 
 (deftest unsupported-representations-return-machine-readable-declines
   (testing "quantization declines before generic dtype routing"

--- a/test/raster/gpu/attention_device_test.clj
+++ b/test/raster/gpu/attention_device_test.clj
@@ -330,9 +330,17 @@
 (deftest opencl-packed-csr-attention-matches-reference
   (if-not @device-probe/opencl-fp16-available?
     (device-probe/opencl-skip! "packed CSR attention" :fp16)
-    (run-case :ocl:0 :csr-paged :interval :auto :fp16-reference)))
+    (run-case :ocl:0 :csr-paged :interval :auto
+              :routed-paged-subgroup-online-score-reuse)))
 
 (deftest opencl-logical-csr-visibility-over-dense-pages-matches-reference
   (if-not @device-probe/opencl-fp16-available?
     (device-probe/opencl-skip! "logical CSR visibility over dense pages" :fp16)
-    (run-case :ocl:0 :dense-paged :csr :auto :fp16-reference)))
+    (run-case :ocl:0 :dense-paged :csr :auto
+              :routed-paged-subgroup-online-score-reuse)))
+
+(deftest opencl-logical-csr-visibility-over-csr-pages-matches-reference
+  (if-not @device-probe/opencl-fp16-available?
+    (device-probe/opencl-skip! "logical CSR visibility over CSR pages" :fp16)
+    (run-case :ocl:0 :csr-paged :csr :auto
+              :routed-paged-subgroup-online-score-reuse)))


### PR DESCRIPTION
## Summary

- make bounded contiguous intervals and bounded CSR rows explicit target-neutral segmented-weighted-reduction schedule choices
- run the cooperative score-reuse leaf across independent dense/CSR page routing and interval/CSR logical membership
- derive interval loop bounds before traversal and preserve the routed AttentionProblem ABI and semantic oracle
- cover all four route/membership combinations with Clang emission checks and real Intel Arc execution

This deliberately leaves the existing GSDM unsorted edge-list/multiset representation unchanged. The handwritten attention leaf remains the executable behavior/ABI oracle for the planned SegmentedWeightedReductionSchedule -> KernelBody vertical.

## Verification

- `clojure -M:test`
- 2,403 tests, 34,750 assertions
- 0 failures, 0 errors
- GPU suite: available, 0 skips
- OpenCL suite: Intel Arc, 0 skips