### PR TITLE
Add resident block gather and scatter

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -191,11 +191,18 @@ contains only values, output indices, row count and width; ties select the lowes
 NaN outranks numeric values so corruption is visible and deterministic. Subgroup/shuffle and
 multi-workgroup alternatives remain schedule candidates, not new semantic primitives.
 
-Row selection remains a separate generic operation. `gather-rows!` consumes shared row-major source
-storage and `int[B]` indices, writes caller-owned dense `[B,width]` output, and maps every output
-element independently. Consequently greedy decode composes indexed reduction and row gather as
-ordinary graph dataflow; top-k, sampling, beam search, or external token policy can replace the
-producer without changing embedding storage or introducing a decoder-tail compiler primitive.
+Indexed storage movement remains a separate generic operation. Allocation-free `gather-blocks!`
+and `scatter-blocks!` move contiguous typed blocks between dense staging and routed resident
+storage with one ordinary SOAC map per direction. Routing is an `int[nblocks]` buffer; it does not
+encode pages, attention, cache policy, or quantization. Gather permits repeated sources, while the
+non-reducing scatter contract requires unique destinations. Host validation proves active extents,
+index bounds, non-aliasing and the current 32-bit device-index limit; emitted kernels retain bounds
+guards. FP16 is a bit-preserving short-array storage overload whose physical ABI is `half*`, while
+index arithmetic remains in the ordinary scalar compiler domain. `gather-rows!` remains the
+row-oriented compatibility spelling. Consequently greedy decode composes indexed reduction and
+row gather as ordinary graph dataflow, while chunked paged prefill and cache persistence can compose
+bulk host/device staging with block scatter/gather. Neither path introduces a decoder, attention,
+page-manager, or quantization primitive into the compiler.
 
 Artifact linking and value rebinding are not runtime conveniences. They are
 compiler primitives required for competitive model execution.

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -43,7 +43,10 @@
 
 (def array-tag->dtype
   "Deftm array tag (the Java array-class symbol) → element dtype keyword."
-  {'doubles :double 'floats :float 'longs :long 'ints :int 'bytes :byte})
+  {'doubles :double 'floats :float 'longs :long 'ints :int 'bytes :byte
+   ;; JVM short[] is Raster's bit-preserving FP16 storage carrier. Kernels see `half*`; the
+   ;; semantic pipeline still performs scalar/index arithmetic at a JVM-supported dtype.
+   'shorts :half})
 
 (defn derive-param-types
   "Declared scalar + array element types for the GPU emitter, read from a deftm's params + tags

--- a/src/raster/dl/array_ops.clj
+++ b/src/raster/dl/array_ops.clj
@@ -7,7 +7,9 @@
 
   Core primitives:
     argmax-rows!     - deterministic indexed row reduction into caller-owned storage
-    gather-rows!     - copy int-indexed rows into caller-owned dense storage
+    gather-blocks!   - gather indexed contiguous blocks into dense storage
+    scatter-blocks!  - scatter dense contiguous blocks to unique destinations
+    gather-rows!     - row-oriented compatibility spelling of gather-blocks!
     scatter-add      - scatter values to indexed destinations (adjoint of gather)
     gather           - gather values from indexed sources (adjoint of scatter-add)
     indexed-dot      - batched indexed dot product (multi-head aware)
@@ -140,14 +142,134 @@
    {:associative? true :commutative? true
     :order {:nan :highest :tie :lowest-index}}))
 
-(deftm gather-rows!
-  "Copy rows selected by `indices[nrows]` from row-major `src[*,width]` into caller-owned
-  `out[nrows,width]`. Every output element has one writer, and rows of `src` may be selected
-  repeatedly. The operation is a generic indexed layout transform; embedding lookup is one use.
+(defn validate-block-indices!
+  "Validate the active prefix of an int block-index buffer before resident execution.
 
-  Indices are intentionally `int`, matching routed attention and indexed reductions. Callers own
-  bounds validation: every index must name a complete source row. `out` must not overlap `src`;
-  parallel output writes are not ordered against source reads."
+  `indexed-blocks` is the source capacity for gather or destination capacity for scatter.
+  `duplicate-policy` is `:allow` for gather or `:unique` for non-reducing scatter. The compiled
+  kernels additionally guard every index to preserve device memory safety, but invalid metadata is
+  a host contract error and should be rejected here rather than silently ignored by a kernel."
+  [indices nblocks indexed-blocks duplicate-policy]
+  (when-not (and (integer? nblocks) (not (neg? nblocks))
+                 (integer? indexed-blocks) (not (neg? indexed-blocks))
+                 (contains? #{:allow :unique} duplicate-policy))
+    (throw (ex-info "block-index validation requires nonnegative extents and a duplicate policy"
+                    {:reason :block-index-contract
+                     :nblocks nblocks :indexed-blocks indexed-blocks
+                     :duplicate-policy duplicate-policy})))
+  (when (> nblocks (count indices))
+    (throw (ex-info "block-index buffer is shorter than its active prefix"
+                    {:reason :block-index-count :required nblocks :actual (count indices)})))
+  (let [active (mapv #(long (nth indices %)) (range nblocks))]
+    (when-not (every? #(and (<= 0 %) (< % indexed-blocks) (<= % Integer/MAX_VALUE)) active)
+      (throw (ex-info "block index is outside the indexed block capacity"
+                      {:reason :block-index-out-of-bounds
+                       :indexed-blocks indexed-blocks :indices active})))
+    (when (and (= :unique duplicate-policy)
+               (not= (count active) (count (distinct active))))
+      (throw (ex-info "non-reducing block scatter requires unique destinations"
+                      {:reason :block-index-duplicate-destination :indices active}))))
+  indices)
+
+(defn validate-block-transfer!
+  "Validate host-visible storage and route metadata for a resident block transfer.
+
+  `direction` is `:gather` (`indexed -> dense`) or `:scatter` (`dense -> indexed`). The active
+  buffer extents must fit the supplied primitive arrays and the current 32-bit GPU launch/index
+  ABI. Gather permits repeated source blocks; non-reducing scatter requires unique destinations.
+  The source and destination must be distinct storage. Returns `indices`."
+  [direction src indices out nblocks block-width indexed-blocks]
+  (when-not (and (contains? #{:gather :scatter} direction)
+                 (integer? nblocks) (not (neg? nblocks))
+                 (integer? block-width) (not (neg? block-width))
+                 (integer? indexed-blocks) (not (neg? indexed-blocks)))
+    (throw (ex-info "block transfer requires a direction and nonnegative integral extents"
+                    {:reason :block-transfer-contract :direction direction
+                     :nblocks nblocks :block-width block-width
+                     :indexed-blocks indexed-blocks})))
+  (let [dense-elements (*' nblocks block-width)
+        indexed-elements (*' indexed-blocks block-width)]
+    (when-not (every? #(<= % Integer/MAX_VALUE)
+                      [nblocks block-width indexed-blocks dense-elements indexed-elements])
+      (throw (ex-info "block transfer exceeds the current 32-bit GPU index ABI"
+                      {:reason :block-transfer-index-width :direction direction
+                       :nblocks nblocks :block-width block-width
+                       :indexed-blocks indexed-blocks})))
+    (when (identical? src out)
+      (throw (ex-info "block transfer source and destination must not overlap"
+                      {:reason :block-transfer-overlap :direction direction})))
+    (let [[required-src required-out]
+          (if (= :gather direction)
+            [indexed-elements dense-elements]
+            [dense-elements indexed-elements])]
+      (when (or (< (count src) required-src) (< (count out) required-out))
+        (throw (ex-info "block transfer storage is shorter than its declared extent"
+                        {:reason :block-transfer-buffer-size :direction direction
+                         :required-src required-src :actual-src (count src)
+                         :required-out required-out :actual-out (count out)})))))
+  (validate-block-indices! indices nblocks indexed-blocks
+                           (if (= :scatter direction) :unique :allow)))
+
+(deftm gather-blocks!
+  "Copy blocks selected by `indices[nblocks]` from `src[indexed-blocks,block-width]` into
+  caller-owned dense `out[nblocks,block-width]`. Source blocks may repeat. Every output element
+  has one writer; invalid indices are guarded on device and must be rejected with
+  `validate-block-transfer!` before execution. `out` must not overlap `src`."
+  (All [T] [src :- (Array T), indices :- (Array int), out :- (Array T),
+            nblocks :- Long, block-width :- Long, indexed-blocks :- Long] :- Void
+       (par/map-void! i (* nblocks block-width)
+                      (let [block (quot i block-width)
+                            element (rem i block-width)
+                            source-block (aget indices block)]
+                        (when (and (>= source-block 0) (< source-block indexed-blocks))
+                          (aset out i
+                                (aget src (+ (* source-block block-width) element))))))))
+
+(deftm scatter-blocks!
+  "Copy dense `src[nblocks,block-width]` blocks to indexed locations in
+  `out[indexed-blocks,block-width]`. This is a non-reducing permutation/scatter: active destination
+  indices must be unique, as certified by `validate-block-transfer!`. Invalid indices are guarded
+  on device. `out` must not overlap `src`; unselected destination blocks are unchanged."
+  (All [T] [src :- (Array T), indices :- (Array int), out :- (Array T),
+            nblocks :- Long, block-width :- Long, indexed-blocks :- Long] :- Void
+       (par/map-void! i (* nblocks block-width)
+                      (let [source-block (quot i block-width)
+                            element (rem i block-width)
+                            destination-block (aget indices source-block)]
+                        (when (and (>= destination-block 0)
+                                   (< destination-block indexed-blocks))
+                          (aset out (+ (* destination-block block-width) element)
+                                (aget src i)))))))
+
+;; Float16 is a physical storage type without a JVM primitive scalar. Its arrays are short[] on
+;; the host, so give the bit-preserving layout transforms an explicit storage overload rather than
+;; pretending :half is a semantic arithmetic specialization of `All [T]`.
+(deftm gather-blocks!
+  [src :- (Array short), indices :- (Array int), out :- (Array short),
+   nblocks :- Long, block-width :- Long, indexed-blocks :- Long] :- Void
+  (par/map-void! i (* nblocks block-width)
+                 (let [block (quot i block-width)
+                       element (rem i block-width)
+                       source-block (aget indices block)]
+                   (when (and (>= source-block 0) (< source-block indexed-blocks))
+                     (aset out i
+                           (aget src (+ (* source-block block-width) element)))))))
+
+(deftm scatter-blocks!
+  [src :- (Array short), indices :- (Array int), out :- (Array short),
+   nblocks :- Long, block-width :- Long, indexed-blocks :- Long] :- Void
+  (par/map-void! i (* nblocks block-width)
+                 (let [source-block (quot i block-width)
+                       element (rem i block-width)
+                       destination-block (aget indices source-block)]
+                   (when (and (>= destination-block 0)
+                              (< destination-block indexed-blocks))
+                     (aset out (+ (* destination-block block-width) element)
+                           (aget src i))))))
+
+(deftm gather-rows!
+  "Compatibility spelling for dense row gathering. New layout code should use `gather-blocks!`,
+  whose explicit source-block capacity also provides a device bounds guard."
   (All [T] [src :- (Array T), indices :- (Array int), out :- (Array T),
             nrows :- Long, width :- Long] :- Void
        (par/map-void! i (* nrows width)

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -36,10 +36,10 @@
 
 (deftest declared-gpu-parameter-types-preserve-the-scalar-array-partition
   (is (= {:scalar-types {'in :int 'scale :float}
-          :array-types {'packed :int 'metadata :byte 'values :float}}
+          :array-types {'packed :int 'metadata :byte 'values :float 'cache :half}}
          (opencl-pass/derive-param-types
-          '[packed metadata values in scale]
-          '[ints bytes floats long float]
+          '[packed metadata values cache in scale]
+          '[ints bytes floats shorts long float]
           :float))))
 
 (deftest generate-segmap-kernel-artifact-simple-test

--- a/test/raster/dl/row_gather_test.clj
+++ b/test/raster/dl/row_gather_test.clj
@@ -12,6 +12,20 @@
   (ops/argmax-rows! logits token-indices nrows vocab)
   (ops/gather-rows! table token-indices rows nrows width))
 
+(deftm block-transfer-roundtrip!
+  [src :- (Array float), block-indices :- (Array int), paged :- (Array float),
+   restored :- (Array float), nblocks :- Long, block-width :- Long,
+   paged-blocks :- Long] :- Void
+  (ops/scatter-blocks! src block-indices paged nblocks block-width paged-blocks)
+  (ops/gather-blocks! paged block-indices restored nblocks block-width paged-blocks))
+
+(deftm block-transfer-half-roundtrip!
+  [src :- (Array short), block-indices :- (Array int), paged :- (Array short),
+   restored :- (Array short), nblocks :- Long, block-width :- Long,
+   paged-blocks :- Long] :- Void
+  (ops/scatter-blocks! src block-indices paged nblocks block-width paged-blocks)
+  (ops/gather-blocks! paged block-indices restored nblocks block-width paged-blocks))
+
 (deftest gather-rows-test
   (let [width 4
         table (float-array [0 1 2 3
@@ -26,6 +40,85 @@
               0.0 1.0 2.0 3.0
               20.0 21.0 22.0 23.0]
              (vec rows))))))
+
+(deftest generic-block-gather-and-scatter-test
+  (let [width 3
+        nblocks 3
+        indexed-blocks 6
+        indices (int-array [4 1 5])
+        dense (float-array [10 11 12, 20 21 22, 30 31 32])
+        paged (float-array (* indexed-blocks width) (float -1.0))
+        restored (float-array (* nblocks width))]
+    (ops/validate-block-transfer! :scatter dense indices paged
+                                  nblocks width indexed-blocks)
+    (ops/scatter-blocks! dense indices paged nblocks width indexed-blocks)
+    (ops/validate-block-transfer! :gather paged indices restored
+                                  nblocks width indexed-blocks)
+    (ops/gather-blocks! paged indices restored nblocks width indexed-blocks)
+    (testing "scatter changes only unique selected destination blocks"
+      (is (= [-1.0 -1.0 -1.0, 20.0 21.0 22.0,
+              -1.0 -1.0 -1.0, -1.0 -1.0 -1.0,
+              10.0 11.0 12.0, 30.0 31.0 32.0]
+             (vec paged))))
+    (testing "gather is the inverse for the same block route"
+      (is (= (vec dense) (vec restored))))))
+
+(deftest block-index-contract-test
+  (let [repeated (int-array [2 0 2])]
+    (is (identical? repeated
+                    (ops/validate-block-indices! repeated 3 4 :allow)))
+    (is (= :block-index-duplicate-destination
+           (try
+             (ops/validate-block-indices! repeated 3 4 :unique)
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+    (is (= :block-index-out-of-bounds
+           (try
+             (ops/validate-block-indices! (int-array [0 4]) 2 4 :unique)
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+    (is (= :block-index-count
+           (try
+             (ops/validate-block-indices! (int-array [0]) 2 4 :unique)
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+    (is (= :block-transfer-buffer-size
+           (try
+             (ops/validate-block-transfer! :scatter
+                                           (float-array 5) (int-array [0 1]) (float-array 12)
+                                           2 3 4)
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+    (let [same (float-array 12)]
+      (is (= :block-transfer-overlap
+             (try
+               (ops/validate-block-transfer! :gather
+                                             same (int-array [0 1]) same 2 3 4)
+               (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))))
+
+(deftest block-transfer-resident-lowering-test
+  (let [descriptors (into {}
+                          (map (fn [target]
+                                 [target (pipeline/compile-gpu-program
+                                          #'block-transfer-roundtrip! target :dtype :float)]))
+                          [:ocl:0 :ze:0])
+        descriptor (get descriptors :ocl:0)]
+    (testing "both directions are ordinary allocation-free SOAC maps"
+      (is (= [:map-void :map-void] (mapv :convention (:steps descriptor))))
+      (is (empty? (:allocs descriptor)))
+      (is (= '[src block-indices paged restored nblocks block-width paged-blocks]
+             (:all-params descriptor)))
+      (is (= #{'paged 'restored}
+             (set (mapcat #(get-in % [:artifact :attributes :written-arrays])
+                          (:steps descriptor))))))
+    (testing "OpenCL and Level Zero preserve the same physical ABI"
+      (is (apply = (map (fn [[_ compiled]]
+                          (mapv (comp #(mapv (juxt :kind :dtype :kernel-dtype) %) :abi)
+                                (:steps compiled)))
+                        descriptors))))
+    (testing "FP16 storage is selected from short-array types, independently of scalar arithmetic"
+      (doseq [target [:ocl:0 :ze:0]]
+        (let [compiled (pipeline/compile-gpu-program
+                        #'block-transfer-half-roundtrip! target :dtype :float)]
+          (is (= [:map-void :map-void] (mapv :convention (:steps compiled))))
+          (is (= #{:int :half}
+                 (set (mapcat #(map :dtype (:abi %)) (:steps compiled))))))))))
 
 (deftest gather-rows-resident-lowering-test
   (let [descriptors (into {}

--- a/test/raster/gpu/block_transfer_device_test.clj
+++ b/test/raster/gpu/block_transfer_device_test.clj
@@ -1,0 +1,84 @@
+(ns raster.gpu.block-transfer-device-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.ir.resident-plan :as resident-plan]
+            [raster.compiler.pipeline :as pipeline]
+            [raster.core :as raster :refer [deftm]]
+            [raster.dl.array-ops :as ops]
+            [raster.dl.gpu-grad-parity :as gpu-probe]
+            [raster.gpu.core :as gpu]
+            [raster.gpu.descriptor-fixture :as fixture]
+            [raster.gpu.device-probe :as opencl-probe]))
+
+(deftm block-roundtrip!
+  [src :- (Array float), indices :- (Array int), paged :- (Array float),
+   restored :- (Array float), nblocks :- Long, block-width :- Long,
+   paged-blocks :- Long] :- Void
+  (ops/scatter-blocks! src indices paged nblocks block-width paged-blocks)
+  (ops/gather-blocks! paged indices restored nblocks block-width paged-blocks))
+
+(deftm block-roundtrip-half!
+  [src :- (Array short), indices :- (Array int), paged :- (Array short),
+   restored :- (Array short), nblocks :- Long, block-width :- Long,
+   paged-blocks :- Long] :- Void
+  (ops/scatter-blocks! src indices paged nblocks block-width paged-blocks)
+  (ops/gather-blocks! paged indices restored nblocks block-width paged-blocks))
+
+(defn- storage-array
+  [dtype values]
+  (case dtype
+    :float (float-array (map float values))
+    :half (short-array (map #(Float/floatToFloat16 (float %)) values))))
+
+(defn- run-roundtrip!
+  [device-id dtype]
+  (let [nblocks 4
+        block-width 7
+        paged-blocks 9
+        source (storage-array dtype (map #(- (float %) 13.0)
+                                         (range (* nblocks block-width))))
+        indices (int-array [7 1 5 3])
+        paged (storage-array dtype (repeat (* paged-blocks block-width) 0.0))
+        restored (storage-array dtype (repeat (* nblocks block-width) 0.0))
+        ;; FP16 uses a raw short[] carrier while scalar/index arithmetic remains FP32.
+        semantic-var (raster/resolve-deftm-var
+                      (if (= :half dtype) #'block-roundtrip-half! #'block-roundtrip!)
+                      {:dtype :float})
+        descriptor (pipeline/compile-gpu-program semantic-var device-id :dtype :float)
+        session (gpu/make-session device-id)]
+    (ops/validate-block-transfer! :scatter source indices paged
+                                  nblocks block-width paged-blocks)
+    (ops/validate-block-transfer! :gather paged indices restored
+                                  nblocks block-width paged-blocks)
+    (try
+      (let [program (fixture/instantiate!
+                     session descriptor
+                     [source indices paged restored nblocks block-width paged-blocks])]
+        (try
+          (is (resident-plan/certified-plan? (:lowering program)))
+          (is (= [:map-void :map-void] (mapv :convention (:steps descriptor))))
+          (is (some #{dtype} (mapcat #(map :dtype (:abi %)) (:steps descriptor))))
+          (is (= (vec source)
+                 (vec (get (fixture/run!
+                            program
+                            [source indices paged restored nblocks block-width paged-blocks])
+                           'restored))))
+          (finally
+            (fixture/close! program))))
+      (finally
+        (gpu/close-session! session)))))
+
+(deftest level-zero-resident-block-transfer-roundtrip
+  (if-not @gpu-probe/gpu-available?
+    (gpu-probe/gpu-skip! "resident block scatter/gather on Level Zero")
+    (do
+      (run-roundtrip! :ze:0 :float)
+      (run-roundtrip! :ze:0 :half))))
+
+(deftest opencl-resident-block-transfer-roundtrip
+  (if-not @opencl-probe/opencl-available?
+    (opencl-probe/opencl-skip! "resident block scatter/gather on OpenCL")
+    (do
+      (run-roundtrip! :ocl:0 :float)
+      (if @opencl-probe/opencl-fp16-available?
+        (run-roundtrip! :ocl:0 :half)
+        (opencl-probe/opencl-skip! "FP16 resident block scatter/gather on OpenCL" :fp16)))))


### PR DESCRIPTION
## Summary

- add allocation-free gather-blocks! and scatter-blocks! SOAC operations for dense-to-routed resident storage movement
- keep routing independent of paging, attention, cache policy, and quantization
- preserve FP16 bits through an explicit short-array storage overload lowered to a half-pointer GPU ABI
- validate extents, index width, bounds, non-aliasing, and unique scatter destinations on the host while retaining device bounds guards
- document the chunked paged-prefill and bulk cache-staging seam in the compiler north star

## Verification

- clojure -M:test: 2,408 tests, 34,783 assertions, 0 failures, 0 errors
- Level Zero suite: available, 0 skipped tests
- OpenCL suite: Intel Arc available, 0 skipped tests
- real FP32 and FP16 scatter/gather round trips pass on both Level Zero and OpenCL