### PR TITLE
Add measurable asynchronous range transfers

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -456,6 +456,19 @@ release. Completion owns the lifetime of every referenced graph, kernel,
 allocation, and view; destruction must first establish completion. Status
 observation alone is not assumed to establish host memory visibility.
 
+The first transfer realization uses that same public event contract for
+bounds-checked batches of host/resident ranges. A completed transfer reports
+bytes, command count, elapsed time, and timing provenance. OpenCL uses owned
+native staging and device-event timestamps; a caller may reuse upload sources
+after submission, while download destinations become visible only after the
+host wait. Level Zero's current shared allocations complete their Panama copy
+inline and report host-monotonic timing explicitly rather than pretending that
+a device copy event exists. Logical compute and transfer queues initially map
+to one physical in-order OpenCL queue, preserving ordering until execution-plan
+lowering can express and realize cross-queue dependencies safely. Immediate-wait
+measurements are the calibration path; `host-wall-ns` otherwise includes any
+intentional host work between submission and wait.
+
 Device-to-device binding is the normal path. Host transfer is an explicit graph
 edge with a reason and byte count. The compiler's memory plan owns temporary
 liveness, reuse, alignment, and peak-memory accounting.

--- a/src/raster/compiler/ir/execution_plan.clj
+++ b/src/raster/compiler/ir/execution_plan.clj
@@ -33,6 +33,11 @@
   []
   (->LogicalQueue :compute-0 :compute 0 :in-order))
 
+(defn transfer-queue
+  "The default target-neutral in-order host/device transfer queue."
+  []
+  (->LogicalQueue :transfer-0 :transfer 0 :in-order))
+
 (defn validate!
   "Validate and return an ExecutionPlan.
 

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -968,8 +968,19 @@
      (:src-element src-spec) (:dst-element dst-spec) elements)
     dst))
 
+(defn- plan-transfer-ranges
+  "Resolve and validate every range before either synchronous or asynchronous execution."
+  [sess entries direction]
+  (let [device-id (:device-id @sess)
+        plan (rt-resolve device-id "plan-range")]
+    (mapv (fn [[key-or-view host spec]]
+            (let [{:keys [buffer view]} (resolve-resident-binding sess key-or-view)
+                  spec (checked-view-range-spec buffer view spec direction)]
+              [buffer (plan buffer host spec direction) host]))
+          entries)))
+
 (defn- transfer-ranges!
-  "The batched core. VALIDATES EVERY entry (`plan-range`) before EXECUTING ANY. A batch is how a
+  "The synchronous batched core. VALIDATES EVERY entry (`plan-range`) before EXECUTING ANY. A batch is how a
    whole KV cache moves — 36 per-layer buffers for gemma-270m — and a batched API newly makes a
    partial state possible: a bad spec in the 30th entry leaving 29 layers written. All-or-nothing
    on validation removes that class; nothing is copied until every range has been proved in
@@ -977,14 +988,8 @@
    class and is not promised here.)"
   [sess entries direction]
   (let [device-id (:device-id @sess)
-        plan (rt-resolve device-id "plan-range")
         exec (rt-resolve device-id "execute-range!")
-        ;; phase 1: resolve + validate everything, collecting plans in order
-        plans (mapv (fn [[key-or-view host spec]]
-                      (let [{:keys [buffer view]} (resolve-resident-binding sess key-or-view)
-                            spec (checked-view-range-spec buffer view spec direction)]
-                        [buffer (plan buffer host spec direction) host]))
-                    entries)]
+        plans (plan-transfer-ranges sess entries direction)]
     ;; phase 2: execute in order
     (mapv (fn [[buf p host]] (exec buf p direction) (if (= :upload direction) buf host)) plans)))
 
@@ -1025,6 +1030,56 @@
 
 (defn gpu-event? [x]
   (and x (= "raster.gpu.core.GPUEvent" (.getName (class x)))))
+
+(defn- submit-transfer-ranges!
+  [sess entries direction]
+  (locking sess
+    (let [{:keys [device-id session-id closed?]} @sess]
+      (when closed?
+        (throw (ex-info "cannot submit a transfer to a closed GPU session"
+                        {:direction direction})))
+      ;; Validation and host-side upload staging both complete before the event becomes visible.
+      ;; The backend owns any native staging until await/release consumes its completion token.
+      (let [plans (plan-transfer-ranges sess entries direction)
+            values (mapv (fn [[buffer _ host]]
+                           (if (= :upload direction) buffer host))
+                         plans)
+            submitted-ns (System/nanoTime)
+            backend-event ((rt-resolve device-id "submit-range-batch!")
+                           (mapv (fn [[buffer plan _]] [buffer plan]) plans)
+                           direction)
+            submit-return-ns (System/nanoTime)
+            event-id (random-uuid)
+            event (->GPUEvent session-id event-id (execution/transfer-queue))]
+        (swap! sess assoc-in [:events event-id]
+               {:event event
+                :kind :transfer
+                :direction direction
+                :status :pending
+                :backend-event backend-event
+                :submitted-ns submitted-ns
+                :submit-return-ns submit-return-ns
+                :value values})
+        event))))
+
+(defn submit-upload-ranges!
+  "Validate and submit a batch of host-to-resident ranges without waiting.
+
+   Returns a session-owned `GPUEvent` on the logical transfer queue. OpenCL owns an immutable
+   native staging copy until the event is awaited/released, so callers may reuse their source after
+   submission. Level Zero shared allocations may complete inline; that distinction is reported by
+   `event-measurement`, not exposed as a different API."
+  [sess entries]
+  (submit-transfer-ranges! sess entries :upload))
+
+(defn submit-download-ranges!
+  "Validate and submit a batch of resident-to-host ranges without waiting.
+
+   Host destinations become observable only after `await-event!`, even if `event-complete?` reports
+   device completion. Returns a session-owned `GPUEvent`; read its measured byte/time provenance
+   with `event-measurement` after awaiting it."
+  [sess entries]
+  (submit-transfer-ranges! sess entries :download))
 
 (defn- external-graph-buffer-ids
   [graph]
@@ -1169,17 +1224,23 @@
 (defn- await-event-under-lock!
   [sess event]
   (let [{:keys [device-id closed?]} @sess
-        {:keys [status backend-event] :as entry} (resolve-event-entry sess event)]
+        {:keys [status backend-event kind submitted-ns submit-return-ns] :as entry}
+        (resolve-event-entry sess event)]
     (when closed?
       (throw (ex-info "cannot use an event from a closed GPU session" {:event event})))
     (if (= :complete status)
       entry
-      (do
-        ;; A successful status query is not necessarily a host memory-synchronization point
-        ;; (notably in OpenCL). Await always calls the backend wait before releasing the token.
-        ((rt-resolve device-id "await-event!") backend-event)
+      ;; A successful status query is not necessarily a host memory-synchronization point
+      ;; (notably in OpenCL). Await always calls the backend wait before releasing the token.
+      (let [backend-completion ((rt-resolve device-id "await-event!") backend-event)
+            completed-ns (System/nanoTime)
+            measurement (when (= :transfer kind)
+                          (merge (when (map? backend-completion) backend-completion)
+                                 {:host-wall-ns (- completed-ns submitted-ns)
+                                  :submit-host-ns (- submit-return-ns submitted-ns)}))]
         ((rt-resolve device-id "release-event!") backend-event)
-        (let [completed (assoc entry :status :complete :backend-event nil)]
+        (let [completed (cond-> (assoc entry :status :complete :backend-event nil)
+                          measurement (assoc :measurement measurement))]
           (swap! sess assoc-in [:events (:id event)] completed)
           completed)))))
 
@@ -1202,6 +1263,23 @@
   [sess event]
   (locking sess
     (:value (await-event-under-lock! sess event))))
+
+(defn event-measurement
+  "Return a completed transfer event's timing and byte-count measurement.
+
+   The event must first be awaited: a nonblocking completion observation does not establish host
+   visibility or finalize download staging. Kernel-graph events do not carry this one-shot transfer
+   measurement; graph profiling remains available through `measure-graph!`."
+  [sess event]
+  (locking sess
+    (let [{:keys [status kind measurement]} (resolve-event-entry sess event)]
+      (when-not (= :transfer kind)
+        (throw (ex-info "event does not describe a transfer submission"
+                        {:event event :kind kind})))
+      (when-not (= :complete status)
+        (throw (ex-info "transfer event must be awaited before reading its measurement"
+                        {:event event :status status})))
+      measurement)))
 
 (defn release-event!
   "Establish completion and remove a session-owned GPUEvent. This is deliberately safe rather

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -103,6 +103,7 @@
     CL_DEVICE_TYPE_GPU))
 (def ^:private CL_MEM_READ_WRITE (long 1))
 (def ^:private CL_MEM_COPY_HOST_PTR (long 32))
+(def ^:private CL_FALSE (int 0))
 (def ^:private CL_TRUE (int 1))
 (def ^:private CL_COMPLETE 0)
 (def ^:private CL_QUEUE_PROFILING_ENABLE (long 2))
@@ -414,9 +415,12 @@
           _ (when (not= CL_SUCCESS (read-int err-seg))
               (throw (ex-info "clCreateContext failed" {:error (read-int err-seg)})))
 
-          ;; Create in-order command queue (CL 1.x compatible)
+          ;; One physical in-order queue initially realizes the backend-neutral compute and
+          ;; transfer queue classes. Profiling is enabled so transfer GPUEvents have device
+          ;; timestamps without introducing unsynchronized cross-queue execution.
           queue (.invokeWithArguments ^MethodHandle @h-clCreateCommandQueue
-                                      (into-array Object [ctx device (long 0) err-seg]))
+                                      (into-array Object
+                                                  [ctx device CL_QUEUE_PROFILING_ENABLE err-seg]))
           _ (when (not= CL_SUCCESS (read-int err-seg))
               (throw (ex-info "clCreateCommandQueue failed" {:error (read-int err-seg)})))]
 
@@ -1482,6 +1486,94 @@
   (when (and event (not (.equals ^MemorySegment event MemorySegment/NULL)))
     (cl-call! "clReleaseEvent" @h-clReleaseEvent [event])))
 
+(defn submit-range-batch!
+  "Submit a validated range batch on the profiling-enabled OpenCL queue without waiting.
+
+   Every command owns a private native staging slice until the returned completion token is
+   awaited and released. Upload sources are copied into immutable staging before return; download
+   destinations are populated only by await-event!, after device completion establishes host
+   visibility."
+  [entries direction]
+  (let [active (filterv (fn [[_ plan]] (pos? (long (:n-bytes plan)))) entries)
+        total-bytes (reduce + 0 (map (comp long :n-bytes second) entries))]
+    (if (empty? active)
+      {:complete? true
+       :completion {:timing-source :host-monotonic
+                    :elapsed-ns 0 :bytes total-bytes :commands 0
+                    :direction direction :asynchronous? false}}
+      (let [queue (:queue @state)
+            arena (Arena/ofShared)
+            event-outs (.allocate arena (* 8 (count active)))
+            status-out (.allocate arena I32)
+            enqueued (volatile! 0)]
+        (try
+          (let [copies
+                (mapv
+                 (fn [[index [^OclBuffer buffer
+                              {:keys [buf-off host-off n-bytes host-seg]}]]]
+                   (let [n-bytes (long n-bytes)
+                         staging (.allocate arena n-bytes 64)
+                         event-out (.asSlice event-outs (* 8 index) 8)]
+                     (when (= :upload direction)
+                       (MemorySegment/copy ^MemorySegment host-seg (long host-off)
+                                           staging 0 n-bytes))
+                     (cl-call! (if (= :upload direction)
+                                 "clEnqueueWriteBuffer" "clEnqueueReadBuffer")
+                               (if (= :upload direction)
+                                 @h-clEnqueueWriteBuffer @h-clEnqueueReadBuffer)
+                               [queue (:cl-mem buffer) CL_FALSE (long buf-off) n-bytes
+                                staging (int 0) MemorySegment/NULL event-out])
+                     (vswap! enqueued inc)
+                     {:staging staging :host-seg host-seg :host-off (long host-off)
+                      :n-bytes n-bytes}))
+                 (map-indexed vector active))]
+            (cl-call! "clFlush" @h-clFlush [queue])
+            (let [events (mapv #(.get event-outs PTR (* 8 %)) (range (count active)))
+                  final-offset (* 8 (dec (count active)))]
+              {:transfer? true
+               :queue queue
+               :direction direction
+               :bytes total-bytes
+               :copies copies
+               :events events
+               :event (peek events)
+               :event-array (.asSlice event-outs final-offset 8)
+               :status-out status-out
+               :arena arena}))
+          (catch Exception error
+            ;; A failed enqueue can leave earlier nonblocking commands live. Keep their staging
+            ;; valid until the queue is drained, then release every event written so far.
+            (try (cl-call! "clFinish" @h-clFinish [queue]) (catch Exception _))
+            (doseq [index (range @enqueued)]
+              (try (release-native-event! (.get event-outs PTR (* 8 index)))
+                   (catch Exception _)))
+            (.close arena)
+            (throw error)))))))
+
+(defn- await-transfer!
+  [{:keys [direction bytes copies events]}]
+  (when (= :download direction)
+    (doseq [{:keys [staging host-seg host-off n-bytes]} copies]
+      (MemorySegment/copy ^MemorySegment staging 0 ^MemorySegment host-seg
+                          (long host-off) (long n-bytes))))
+  (let [arena (Arena/ofConfined)]
+    (try
+      (let [value (.allocate arena I64)
+            read-ts (fn [event parameter]
+                      (cl-call! "clGetEventProfilingInfo" @h-clGetEventProfilingInfo
+                                [event (int parameter) (long 8) value MemorySegment/NULL])
+                      (.get value I64 0))
+            start (read-ts (first events) CL_PROFILING_COMMAND_START)
+            end (read-ts (peek events) CL_PROFILING_COMMAND_END)]
+        {:timing-source :device-event
+         :elapsed-ns (- end start)
+         :bytes bytes
+         :commands (count events)
+         :direction direction
+         :asynchronous? true})
+      (finally
+        (.close arena)))))
+
 (defn- clear-profile-state!
   [graph]
   (when-let [profile-state (:profile-state graph)]
@@ -1532,10 +1624,13 @@
 
 (defn await-event!
   "Wait for a runtime-private OpenCL completion token."
-  [{:keys [complete? event-array]}]
+  [{:keys [complete? completion transfer? event-array] :as token}]
   (when-not complete?
     (cl-call! "clWaitForEvents" @h-clWaitForEvents [(int 1) event-array]))
-  nil)
+  (cond
+    complete? completion
+    transfer? (await-transfer! token)
+    :else nil))
 
 (defn event-complete?
   "Nonblocking query of a runtime-private OpenCL completion token."
@@ -1550,14 +1645,16 @@
 
 (defn release-event!
   "Release a runtime-private OpenCL completion token. The caller must establish completion."
-  [{:keys [complete? profile? event ^Arena arena]}]
+  [{:keys [complete? profile? transfer? events event ^Arena arena]}]
   (when-not complete?
     ;; A profiled graph retains every event until read-graph-timestamps! (or reset) consumes the
     ;; sample. The graph owns the shared arena in that interval. Ordinary completion tokens keep
     ;; the previous immediate-release behavior.
     (when-not profile?
       (try
-        (release-native-event! event)
+        (if transfer?
+          (doseq [native-event events] (release-native-event! native-event))
+          (release-native-event! event))
         (finally
           (.close arena)))))
   nil)

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -924,6 +924,28 @@
     :upload   (MemorySegment/copy ^MemorySegment host-seg (long host-off) (:segment buf) (long buf-off) (long n-bytes))
     :download (MemorySegment/copy (:segment buf) (long buf-off) ^MemorySegment host-seg (long host-off) (long n-bytes))))
 
+(defn submit-range-batch!
+  "Execute a validated range batch against Level Zero shared allocations.
+
+   Shared allocations are host coherent, so there is no device copy command to signal: Panama
+   performs the copies before submission returns. The common GPUEvent contract still represents
+   this legal inline completion and reports host-monotonic timing rather than claiming a device
+  event measurement."
+  [entries direction]
+  (let [active (filterv (fn [[_ plan]] (pos? (long (:n-bytes plan)))) entries)
+        started (System/nanoTime)]
+    (doseq [[buffer plan] active]
+      (execute-range! buffer plan direction))
+    (let [elapsed (- (System/nanoTime) started)
+          bytes (reduce + 0 (map (comp long :n-bytes second) entries))]
+      {:complete? true
+       :completion {:timing-source :host-monotonic
+                    :elapsed-ns elapsed
+                    :bytes bytes
+                    :commands (count active)
+                    :direction direction
+                    :asynchronous? false}})))
+
 (defn upload-range!
   "Copy `elements` elements from `src` (JVM array or MemorySegment, starting at element
    `src-element`) into `buf` starting at element `dst-element`. Elements, not bytes: the byte
@@ -2991,24 +3013,29 @@
 
 (defn await-event!
   "Wait for a runtime-private graph completion token."
-  [{:keys [queue]}]
-  (ze-call! "zeCommandQueueSynchronize" @h-zeCommandQueueSynchronize
-            [queue (long -1)])
-  nil)
+  [{:keys [complete? completion queue]}]
+  (if complete?
+    completion
+    (do
+      (ze-call! "zeCommandQueueSynchronize" @h-zeCommandQueueSynchronize
+                [queue (long -1)])
+      nil)))
 
 (defn event-complete?
   "Nonblocking query of a runtime-private graph completion token."
-  [{:keys [queue]}]
-  (let [result (int (.invokeWithArguments
-                     ^MethodHandle @h-zeCommandQueueSynchronize
-                     ^java.util.List (java.util.List/of
-                                      (object-array [queue (long 0)]))))]
-    (cond
-      (= result ZE_RESULT_SUCCESS) true
-      (= result ZE_RESULT_NOT_READY) false
-      :else (throw (ex-info (str "Level Zero error querying graph event: 0x"
-                                 (Integer/toHexString result))
-                            {:result result :context "zeCommandQueueSynchronize"})))))
+  [{:keys [complete? queue]}]
+  (if complete?
+    true
+    (let [result (int (.invokeWithArguments
+                       ^MethodHandle @h-zeCommandQueueSynchronize
+                       ^java.util.List (java.util.List/of
+                                        (object-array [queue (long 0)]))))]
+      (cond
+        (= result ZE_RESULT_SUCCESS) true
+        (= result ZE_RESULT_NOT_READY) false
+        :else (throw (ex-info (str "Level Zero error querying graph event: 0x"
+                                   (Integer/toHexString result))
+                              {:result result :context "zeCommandQueueSynchronize"}))))))
 
 (defn release-event!
   "Release a runtime-private graph completion token. Queue ownership remains with the graph."

--- a/test/raster/compiler/ir/execution_plan_test.clj
+++ b/test/raster/compiler/ir/execution_plan_test.clj
@@ -73,3 +73,10 @@
     (is (= :compute (get-in operation [:queue :class])))
     (is (empty? (:waits operation)))
     (is (= [(:completion operation)] (:outputs plan)))))
+
+(deftest logical-transfer-queue-is-backend-neutral
+  (let [queue (execution/transfer-queue)]
+    (is (execution/logical-queue? queue))
+    (is (= :transfer (:class queue)))
+    (is (= :in-order (:ordering queue)))
+    (is (not= queue (execution/compute-queue)))))

--- a/test/raster/gpu/range_transfer_test.clj
+++ b/test/raster/gpu/range_transfer_test.clj
@@ -12,10 +12,60 @@
    The second invariant: out-of-range is an ERROR, never a clamp. `array->buffer!` clamps to
    `(min buf src)` bytes, which is fine for a whole-buffer copy and exactly wrong for a range."
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.buffer-view :as bview]
             [raster.dl.gpu-grad-parity :as gp]
             [raster.gpu.core :as g]
             [raster.gpu.device-probe :as device-probe])
   (:import [java.lang.foreign Arena MemorySegment ValueLayout]))
+
+(deftest asynchronous-transfer-batches-use-the-common-event-contract
+  (let [buffer {:dtype :float :n-elements 8 :byte-size 32}
+        allocation (bview/allocation
+                    {:id :buffer-allocation :byte-size 32 :memory-space :device
+                     :device :ze:0 :coherence :host-coherent :ownership :owned})
+        session (atom {:device-id :ze:0 :session-id :transfer-session
+                       :buffers {:buffer buffer} :allocations {:buffer allocation}
+                       :kernel-graphs {} :events {} :closed? false})
+        source (float-array 8)
+        submitted (atom [])
+        awaited (atom [])
+        released (atom [])
+        resolver
+        (fn [_ name]
+          (case name
+            "plan-range" (fn [_ host {:keys [elements] :as spec} direction]
+                           {:host host :spec spec :direction direction
+                            :n-bytes (* 4 elements)})
+            "submit-range-batch!" (fn [entries direction]
+                                    (let [token {:entries entries :direction direction}]
+                                      (swap! submitted conj token)
+                                      token))
+            "event-complete?" (constantly false)
+            "await-event!" (fn [token]
+                             (swap! awaited conj token)
+                             {:timing-source :device-event :elapsed-ns 40
+                              :bytes 32 :commands 1 :direction :upload
+                              :asynchronous? true})
+            "release-event!" #(swap! released conj %)
+            (throw (ex-info "unexpected mocked runtime function" {:name name}))))]
+    (with-redefs-fn
+      {(ns-resolve 'raster.gpu.core 'rt-resolve) resolver}
+      (fn []
+        (let [event (g/submit-upload-ranges!
+                     session [[:buffer source {:elements 8}]])]
+          (is (g/gpu-event? event))
+          (is (= :transfer (get-in event [:queue :class])))
+          (is (false? (g/event-complete? session event)))
+          (is (thrown-with-msg? clojure.lang.ExceptionInfo #"must be awaited"
+                                (g/event-measurement session event)))
+          (is (= [buffer] (g/await-event! session event)))
+          (let [measurement (g/event-measurement session event)]
+            (is (= :device-event (:timing-source measurement)))
+            (is (= 32 (:bytes measurement)))
+            (is (<= 0 (:submit-host-ns measurement) (:host-wall-ns measurement))))
+          (g/release-event! session event)
+          (is (= @submitted @awaited @released))
+          (is (empty? (:events @session))))))))
 
 ;; gemma-270m's real KV shape: 2048 positions x (1 kv-head x 256 head-dim)
 (def ^:private maxpos 2048)
@@ -204,6 +254,60 @@
             (let [k (keyword (str kind l)) tag (* 1e6 (+ 1 (* 2 l) (if (= kind "vc") 1 0)))]
               (is (every? (fn [i] (== (aget ^floats (get outs k) i) (float (+ tag i)))) (range n))
                   (str k " carries ITS OWN layer's prefix, not a neighbour's")))))))))
+
+(defn- asynchronous-mixed-storage-roundtrip!
+  [device-id expected-timing-source]
+  (let [n 257
+        float-source (float-array (map #(float (+ 1 %)) (range n)))
+        half-source (short-array (map #(Float/floatToFloat16 (float (+ 1 %))) (range n)))
+        expected-float (aclone float-source)
+        expected-half (aclone half-source)
+        float-destination (float-array n)
+        half-destination (short-array n)
+        session (g/make-session device-id)]
+    (try
+      (g/alloc! session {:float-buffer [:float n nil]
+                         :half-buffer [:half n nil]})
+      (let [event (g/submit-upload-ranges!
+                   session [[:float-buffer float-source {:elements n}]
+                            [:half-buffer half-source {:elements n}]])]
+        ;; Upload owns its staging at return: caller mutation cannot change the submitted payload.
+        (dotimes [i n]
+          (aset float-source i (float -1.0))
+          (aset half-source i (short 0)))
+        (is (= [n n] (mapv :n-elements (g/await-event! session event))))
+        (let [measurement (g/event-measurement session event)]
+          (is (= expected-timing-source (:timing-source measurement)))
+          (is (= (+ (* 4 n) (* 2 n)) (:bytes measurement)))
+          (is (= 2 (:commands measurement)))
+          (is (<= 0 (:elapsed-ns measurement))))
+        (g/release-event! session event))
+      (let [event (g/submit-download-ranges!
+                   session [[:float-buffer float-destination {:elements n}]
+                            [:half-buffer half-destination {:elements n}]])]
+        (when (= :device-event expected-timing-source)
+          (is (every? zero? float-destination)
+              "OpenCL download staging is not host-visible before await")
+          (is (every? zero? half-destination)))
+        (is (= [float-destination half-destination]
+               (g/await-event! session event)))
+        (is (= expected-timing-source
+               (:timing-source (g/event-measurement session event))))
+        (g/release-event! session event))
+      (is (= (vec expected-float) (vec float-destination)))
+      (is (= (vec expected-half) (vec half-destination)))
+      (finally
+        (g/close-session! session)))))
+
+(deftest level-zero-asynchronous-batch-has-honest-host-timing
+  (if-not @gp/gpu-available?
+    (gp/gpu-skip! "asynchronous mixed-storage range batch on Level Zero")
+    (asynchronous-mixed-storage-roundtrip! :ze:0 :host-monotonic)))
+
+(deftest opencl-asynchronous-batch-has-device-event-timing
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "asynchronous mixed-storage range batch on OpenCL")
+    (asynchronous-mixed-storage-roundtrip! :ocl:0 :device-event)))
 
 (deftest a-bad-entry-anywhere-leaves-the-whole-cache-untouched
   (if-not @gp/gpu-available?


### PR DESCRIPTION
## Summary

- add backend-neutral transfer queue events for validated upload/download range batches
- use owned nonblocking OpenCL staging with device-event timing, while reporting honest host timing for Level Zero shared-memory copies
- preserve compute/transfer ordering on one physical OpenCL queue until cross-queue dependencies are lowered explicitly
- cover the event contract in pure tests and mixed FP32/FP16 round trips on real Level Zero and OpenCL devices

## Verification

- `clojure -X:test`
- 2,412 tests, 34,817 assertions
- 0 failures, 0 errors
- GPU suite: 0 skipped hardware tests
- OpenCL suite: 0 skipped hardware tests
- `clj-kondo` on changed Clojure files: 0 errors (pre-existing warnings only)
- `git diff --check`