### PR TITLE
Lower scheduled weighted reductions through KernelBody

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -115,13 +115,20 @@ target spelling now lowers this general scalar/control vocabulary directly: dens
 stores (including contiguous leading-slice views), SSA expressions, structured branch/loop yields,
 explicit numerical casts, and full-subgroup reductions/broadcasts, without recovering an algorithm
 or schedule. Unsupported target semantics fail at this boundary instead of silently changing a
-cast, layout, collective, or reduction-association contract. It is not production-reachable until a
-semantic route constructs the body. The next production vertical is the scheduled routed
-`SegmentedWeightedReductionSchedule -> KernelBody` construction with an invariant external ABI; it
-must not introduce an attention operation into this vocabulary. The current handwritten production
-leaf already keeps physical storage and logical membership independent: dense/CSR page routing can
-combine with either bounded contiguous intervals or bounded CSR rows under one cooperative schedule.
-That leaf is the executable behavior and ABI oracle which the KernelBody vertical must replace.
+cast, layout, collective, or reduction-association contract.
+
+The first production route now constructs
+`SegmentedWeightedReductionSchedule -> KernelBody -> OpenCL` and projects the body's stable reads
+onto the invariant ordered ABI. Attention contributes only the routed-paged storage descriptor used
+by this first lowering row; neither KernelBody nor the target emitter contains an attention
+operation. Dense/CSR physical page routing combines independently with bounded contiguous intervals
+or bounded CSR membership. The generated leaf has replaced the handwritten cooperative source and
+is checked against the reference algebra on a real device. Its subgroup builtin is recorded honestly
+as implementation-defined association rather than claiming a fixed tree. The next production work
+is to represent tiled membership traversal and mergeable online-reduction state, then lower subgroup
+collectives through portable OpenCL, CUDA and HIP target dialects. Verified local allocation,
+barriers and asynchronous copies can subsequently collapse a multi-kernel tiled graph into a
+FlashAttention-like single kernel without changing the semantic plan or external ABI.
 
 ### 2.3 Executable steps and resident artifact values compose
 

--- a/src/raster/compiler/backend/gpu/attention.clj
+++ b/src/raster/compiler/backend/gpu/attention.clj
@@ -6,13 +6,16 @@
    routes and interval/CSR membership, sharing each QK score across lane-strided value
    accumulators without changing the semantic plan, ordered ABI, storage ownership or graph
    effects."
-  (:require [raster.compiler.ir.attention :as attention]
+  (:require [raster.compiler.backend.gpu.kernel-body-opencl :as body-opencl]
+            [raster.compiler.ir.attention :as attention]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-body-abi :as body-abi]
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.ir.segmented-weighted-reduction :as swr]
-            [raster.compiler.ir.segmented-weighted-reduction-schedule :as swr-schedule]))
+            [raster.compiler.ir.segmented-weighted-reduction-schedule :as swr-schedule]
+            [raster.compiler.passes.parallel.segmented-weighted-reduction-body :as swr-body]))
 
 (defn- attention-problem
   [plan]
@@ -343,140 +346,6 @@
                        :schedule schedule :plan-id (:id plan)})))
     [plan schedule problem]))
 
-(defn- component-code
-  [schedule f]
-  (apply str (map f (range (get-in schedule [:value-mapping :components-per-lane])))))
-
-(defn- cooperative-component-declarations
-  [schedule]
-  (let [subgroup-size (:workgroup-size schedule)]
-    (component-code
-     schedule
-     (fn [slot]
-       (str "  const int d" slot " = (int)lane + " (* slot subgroup-size) ";\n"
-            "  float accumulator" slot " = 0.0f;\n")))))
-
-(defn- cooperative-component-write
-  [problem schedule expression]
-  (component-code
-   schedule
-   (fn [slot]
-     (str "    if (d" slot " < " (:value-head-dim problem) ")\n"
-          "      output[out_base + d" slot "] = "
-          (store-float (:output-dtype problem) (expression slot)) ";\n"))))
-
-(defn- cooperative-component-update
-  [problem schedule]
-  (component-code
-   schedule
-   (fn [slot]
-     (str "    if (d" slot " < " (:value-head-dim problem) ")\n"
-          "      accumulator" slot " = accumulator" slot " * old_weight\n"
-          "          + convert_float(v_pages[v_base + d" slot "]) * new_weight;\n"))))
-
-(defn- cooperative-source
-  [problem schedule name]
-  (let [{:keys [query route batch-size q-heads kv-heads qk-head-dim value-head-dim
-                page-size physical-pages scale k-layout v-layout visibility
-                q-dtype output-dtype]} problem
-        total-query-tokens (:total-tokens query)
-        gqa-ratio (quot q-heads kv-heads)
-        subgroup-size (:workgroup-size schedule)
-        k-base (cache-base problem k-layout qk-head-dim)
-        v-base (cache-base problem v-layout value-head-dim)
-        invalid-result
-        (str (cooperative-component-write problem schedule (constantly "NAN"))
-             "    return;\n")
-        empty-result
-        (str (cooperative-component-write problem schedule (constantly "0.0f"))
-             "    return;\n")]
-    (str "#pragma OPENCL EXTENSION cl_khr_fp16 : enable\n"
-         "__attribute__((intel_reqd_sub_group_size(" subgroup-size ")))\n"
-         "__kernel void " name "(\n"
-         "    __global const " (opencl-type q-dtype) "* q,\n"
-         "    __global const int* q_row_offsets,\n"
-         "    __global const int* q_positions,\n"
-         "    __global const half* k_pages,\n"
-         "    __global const half* v_pages,\n"
-         (route-signature route)
-         (visibility-signature visibility)
-         "    __global " (opencl-type output-dtype) "* output) {\n"
-         "  const long lane = (long)get_sub_group_local_id();\n"
-         "  const int q_head = (int)get_group_id(0);\n"
-         "  const int q_token = (int)get_group_id(1);\n"
-         "  const long out_base = ((long)q_token * " q-heads
-         " + q_head) * " value-head-dim ";\n"
-         (cooperative-component-declarations schedule)
-         "  int query_metadata_valid = q_row_offsets[0] == 0\n"
-         "      && q_row_offsets[" batch-size "] == " total-query-tokens ";\n"
-         "  int batch = -1;\n"
-         "  for (int b = 0; b < " batch-size "; ++b) {\n"
-         "    const int row_start = q_row_offsets[b];\n"
-         "    const int row_end = q_row_offsets[b + 1];\n"
-         "    query_metadata_valid = query_metadata_valid && row_start >= 0\n"
-         "        && row_end >= row_start && row_end <= " total-query-tokens ";\n"
-         "    if (q_token >= row_start && q_token < row_end) batch = b;\n"
-         "  }\n"
-         "  const int q_position = q_positions[q_token];\n"
-         "  if (!query_metadata_valid || batch < 0 || q_position < 0) {\n"
-         invalid-result
-         "  }\n"
-         (route-initialization problem invalid-result)
-         (visibility-initialization visibility invalid-result)
-         (when (attention/interval-visibility? visibility)
-           (str "  if (attention_begin == attention_end) {\n"
-                empty-result
-                "  }\n"))
-         "  const int kv_head = q_head / " gqa-ratio ";\n"
-         "  const long q_base = ((long)q_token * " q-heads
-         " + q_head) * " qk-head-dim ";\n"
-         "  float maximum = -3.402823466e+38f;\n"
-         "  float denominator = 0.0f;\n"
-         (visibility-loop-start visibility invalid-result)
-         "    const long kv_position = (long)kv_start_position + token;\n"
-         "    int visible = 1;\n"
-         (visibility-statements (attention/position-filter visibility))
-         "    if (!visible) continue;\n"
-         "    const int logical_page = token / " page-size ";\n"
-         "    const int physical_page = " (physical-page-expression route) ";\n"
-         "    if (physical_page < 0 || physical_page >= " physical-pages ") {\n"
-         invalid-result
-         "    }\n"
-         "    const int page_token = token - logical_page * " page-size ";\n"
-         "    const long k_base = " k-base ";\n"
-         "    const long v_base = " v-base ";\n"
-         "    float partial_dot = 0.0f;\n"
-         "    for (int x = (int)lane; x < " qk-head-dim "; x += " subgroup-size ")\n"
-         "      partial_dot += " (load-float q-dtype "q[q_base + x]")
-         " * convert_float(k_pages[k_base + x]);\n"
-         "    const float dot = sub_group_reduce_add(partial_dot);\n"
-         "    const float logit = dot * " (Float/toString (float scale)) "f;\n"
-         "    float old_weight = 0.0f;\n"
-         "    float new_weight = 0.0f;\n"
-         "    if (lane == 0L) {\n"
-         "      if (isnan(maximum) || isnan(logit)) {\n"
-         "        maximum = NAN;\n"
-         "        old_weight = NAN;\n"
-         "        new_weight = NAN;\n"
-         "      } else {\n"
-         "        const float next_maximum = fmax(maximum, logit);\n"
-         "        old_weight = exp(maximum - next_maximum);\n"
-         "        new_weight = exp(logit - next_maximum);\n"
-         "        maximum = next_maximum;\n"
-         "      }\n"
-         "      denominator = denominator * old_weight + new_weight;\n"
-         "    }\n"
-         "    old_weight = sub_group_broadcast(old_weight, 0);\n"
-         "    new_weight = sub_group_broadcast(new_weight, 0);\n"
-         (cooperative-component-update problem schedule)
-         "  }\n"
-         "  denominator = sub_group_broadcast(denominator, 0);\n"
-         (cooperative-component-write
-          problem schedule
-          (fn [slot]
-            (str "denominator == 0.0f ? 0.0f : accumulator" slot " / denominator")))
-         "}\n")))
-
 (defn- ordered-inputs
   [plan]
   (swr/ordered-input-ids plan))
@@ -514,8 +383,12 @@
            (kabi/slot (:key-indices visibility) :input :int
                       :c-name "attention_key_indices" :role :attention-key-indices)])]
     (kabi/validate!
-     (conj (into (into common route-slots) visibility-slots)
-           (kabi/slot output :output output-dtype :c-name "output" :role :result)))))
+     (mapv #(if (= :input (:kind %))
+              (assoc % :aliasing :no-write-alias)
+              %)
+           (conj (into (into common route-slots) visibility-slots)
+                 (kabi/slot output :output output-dtype
+                            :c-name "output" :role :result))))))
 
 (defn emit-fp16-reference
   "Emit route-specialized attention with FP16 K/V storage as a verified KernelArtifact."
@@ -556,22 +429,27 @@
   "Emit one subgroup per query segment for routed FP16 K/V attention.
 
    The artifact preserves the reference leaf's complete ordered ABI and logical effects.  Only
-   its target-neutral SegmentedWeightedReductionSchedule, launch mapping and target body differ."
+   its target-neutral SegmentedWeightedReductionSchedule, launch mapping and target body differ.
+   The scheduled body is independently verified before this target-only lowering selects OpenCL
+   parameter spelling and Intel's required-subgroup attribute."
   [plan schedule]
-  (let [[plan schedule {:keys [query output q-heads route] :as problem}]
+  (let [[plan schedule {:keys [output route] :as problem}]
         (cooperative-plan! plan schedule)
-        subgroup-size (:workgroup-size schedule)
         name (kernel-name problem schedule)
         inputs (ordered-inputs plan)
-        arguments (conj inputs output)]
+        arguments (conj inputs output)
+        kernel-body (swr-body/lower-routed-paged plan schedule)
+        base-abi (ordered-abi problem)
+        parameter-names (into {} (map (juxt :name :c-name)) base-abi)
+        abi (body-abi/project-contracts base-abi kernel-body)]
     (kart/make
      {:kernel-name name
-      :source (cooperative-source problem schedule name)
-      :abi (ordered-abi problem)
+      :source (body-opencl/emit-scalar-kernel
+               name kernel-body
+               {:parameter-names parameter-names :subgroup-attribute :intel})
+      :abi abi
       :arguments arguments
-      :launch (klaunch/spec
-               {:workgroup-size [subgroup-size 1]
-                :group-count [q-heads (:total-tokens query)]})
+      :launch (:launch kernel-body)
       :effects {:kind :attention :reads inputs :writes [output]}
       :provenance {:operation-id (:id problem) :semantic-op :attention
                    :algebra-plan-id (:id plan)
@@ -588,6 +466,7 @@
                    :k-layout (:k-layout problem) :v-layout (:v-layout problem)
                    :visibility (:visibility problem)
                    :layout (attention/layouts problem)
+                   :kernel-body kernel-body
                    :materialized-intermediates []
                    :complexity :query-head-token-dot-plus-value}})))
 

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -531,6 +531,15 @@
                           {:loop operation})))
         (doseq [arg (:iter-args operation)]
           (value-spec! "loop carried binding" (:binding arg)))
+        (let [uniform-iter-args (get-in operation [:attributes :uniform-iter-args] #{})
+              bindings (set (map (comp :id :binding) (:iter-args operation)))]
+          (when-not (and (set? uniform-iter-args)
+                         (set/subset? uniform-iter-args bindings))
+            (throw (ex-info
+                    "kernel loop uniform-iter-args must name carried bindings"
+                    {:reason :kernel-body-loop-uniform-iter-args
+                     :uniform-iter-args uniform-iter-args
+                     :bindings bindings}))))
         (doseq [result (:results operation)] (value-spec! "loop result" result))
         (when (contains? scope (get-in operation [:index :id]))
           (throw (ex-info "kernel for-loop induction value shadows an existing value"
@@ -906,6 +915,7 @@
           loop-control (reduce set/intersection control-uniformity
                                [lower-uniformity upper-uniformity])
           iter-args (:iter-args operation)
+          uniform-iter-args (get-in operation [:attributes :uniform-iter-args] #{})
           results (:results operation)
           initials (mapv #(scalar-value-info! (:initial %) values) iter-args)]
       (when-not (= index-type (:type lower-info) (:type upper-info))
@@ -923,15 +933,26 @@
                                      {:type (canonical-type (:type index))
                                       :uniformity loop-control})
                               (map (fn [arg initial]
-                                     ;; Backedge values may become lane-varying after iteration
-                                     ;; one.  Until we compute a region fixed point, this is the
-                                     ;; conservative fact available inside the loop.
                                      [(:id (:binding arg))
-                                      (assoc initial :uniformity lane-varying)])
+                                      (if (contains? uniform-iter-args (:id (:binding arg)))
+                                        ;; This is an inductive claim, checked against the
+                                        ;; backedge yield below. Unclaimed carries remain
+                                        ;; conservative because a later iteration may diverge.
+                                        initial
+                                        (assoc initial :uniformity lane-varying))])
                                    iter-args initials))
             yielded (validate-region! "kernel for-loop body" (:operations operation)
                                       (mapv :binding iter-args) loop-values
                                       (assoc context :control-uniformity loop-control))]
+        (doseq [[arg initial yielded-info] (map vector iter-args initials yielded)
+                :when (contains? uniform-iter-args (:id (:binding arg)))]
+          (when-not (set/subset? (:uniformity initial) (:uniformity yielded-info))
+            (throw (ex-info
+                    "kernel loop uniform carried value is not preserved by its backedge"
+                    {:reason :kernel-body-loop-uniformity-invariant
+                     :binding (:binding arg)
+                     :initial-uniformity (:uniformity initial)
+                     :yielded-uniformity (:uniformity yielded-info)}))))
         (reduce (fn [env [result yielded-info initial-info]]
                   (claim-value! claimed reserved values result "kernel for-loop result")
                   (when-not (= (canonical-type (:type result)) (:type yielded-info))

--- a/src/raster/compiler/ir/segmented_weighted_reduction_schedule.clj
+++ b/src/raster/compiler/ir/segmented_weighted_reduction_schedule.clj
@@ -66,7 +66,7 @@
     (when-not (and (map? numerical-mode)
                    (keyword? (:score-accumulate numerical-mode))
                    (keyword? (:state-accumulate numerical-mode))
-                   (= :subgroup-tree (:dot-order numerical-mode))
+                   (= :implementation-defined (:dot-order numerical-mode))
                    (true? (:online-rescale? numerical-mode))
                    (map? attributes))
       (throw (ex-info "segmented weighted-reduction numerical and attribute facets are incomplete"

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_body.clj
@@ -1,0 +1,660 @@
+(ns raster.compiler.passes.parallel.segmented-weighted-reduction-body
+  "Apply a verified cooperative schedule to a segmented weighted reduction.
+
+  The first production storage row is routed paged K/V with interval or CSR membership. The
+  resulting KernelBody contains all scalar/control, memory, loop-carried online state, and
+  subgroup-reduction structure. It contains no OpenCL spelling and preserves the source plan's
+  buffer identities so the ordered ABI can be projected independently."
+  (:require [raster.compiler.core.layout :as layout]
+            [raster.compiler.ir.attention :as attention]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.segmented-weighted-reduction :as swr]
+            [raster.compiler.ir.segmented-weighted-reduction-schedule :as schedule]))
+
+(defn- lit [value type]
+  (body/literal value type))
+
+(defn- expr [op type & arguments]
+  (body/scalar-expression op type arguments))
+
+(defn- select-expr [condition if-true if-false type]
+  (body/scalar-expression :select type [condition if-true if-false]))
+
+(defn- and-expr [left right]
+  (select-expr left right (lit false :predicate) :predicate))
+
+(defn- or-expr [left right]
+  (select-expr left (lit true :predicate) right :predicate))
+
+(defn- not-expr [value]
+  (select-expr value (lit false :predicate) (lit true :predicate) :predicate))
+
+(defn- true-expr []
+  (expr :eq :predicate (lit 0 :int) (lit 0 :int)))
+
+(defn- all-expr
+  [values]
+  (reduce and-expr (lit true :predicate) values))
+
+(defn- compute [id type expression]
+  (body/->ScalarCompute (body/value id type) expression))
+
+(defn- load-value
+  ([id type buffer coordinates]
+   (load-value id type buffer coordinates nil nil))
+  ([id type buffer coordinates predicate other]
+   (body/->ScalarLoad (body/value id type) buffer (vec coordinates)
+                      predicate other :cached)))
+
+(defn- cast-expr [value type]
+  (body/cast-expression value type :exact :exact))
+
+(defn- half-or-float->float [value type]
+  (if (= :float type)
+    (expr :+ :float value (lit 0.0 :float))
+    (cast-expr value :float)))
+
+(defn- output-value [value type]
+  (if (= :float type)
+    (expr :+ :float value (lit 0.0 :float))
+    (body/cast-expression value :half :nearest-even :ieee)))
+
+(defn- role-map
+  [{:keys [query route k-pages v-pages output visibility]}]
+  (merge {(:values query) :query
+          (:row-offsets query) :query-rows
+          (:positions query) :query-positions
+          k-pages :key-cache
+          v-pages :value-cache
+          (:start-positions route) :kv-start-positions
+          output :result}
+         (if (attention/dense-paged-route? route)
+           {(:page-table route) :page-routing
+            (:lengths route) :kv-lengths}
+           {(:page-offsets route) :page-row-offsets
+            (:page-indices route) :page-routing
+            (:last-page-lengths route) :last-page-lengths})
+         (when (attention/csr-visibility? visibility)
+           {(:row-offsets visibility) :attention-row-offsets
+            (:key-indices visibility) :attention-key-indices})))
+
+(defn- parameters
+  [plan problem]
+  (let [specs (attention/buffer-specs problem)
+        roles (role-map problem)
+        ids (conj (swr/ordered-input-ids plan) (get-in plan [:output :id]))]
+    (mapv (fn [id]
+            (let [{:keys [dtype shape role]} (get specs id)]
+              (body/->KernelParameter
+               id role dtype shape :global (layout/row-major shape dtype) (get roles id role))))
+          ids)))
+
+(defn- query-metadata-operations
+  [{:keys [query batch-size]}]
+  (let [offsets (:row-offsets query)
+        total (:total-tokens query)]
+    [(load-value 'first-query-offset :int offsets [0])
+     (load-value 'final-query-offset :int offsets [batch-size])
+     (compute 'first-query-offset-valid :predicate
+              (expr :eq :predicate 'first-query-offset (lit 0 :int)))
+     (compute 'final-query-offset-valid :predicate
+              (expr :eq :predicate 'final-query-offset (lit total :int)))
+     (compute 'query-metadata-initial-valid :predicate
+              (and-expr 'first-query-offset-valid 'final-query-offset-valid))
+     (body/->ForLoop
+      (body/value 'query-row :int) 0 batch-size 1
+      [(body/->LoopArg (body/value 'query-valid-state :predicate)
+                       'query-metadata-initial-valid)
+       (body/->LoopArg (body/value 'query-batch-state :int) (lit -1 :int))]
+      [(load-value 'query-row-start :int offsets ['query-row])
+       (load-value 'query-row-end :int offsets
+                   [(body/expression :add 'query-row 1)])
+       (compute 'query-row-start-valid :predicate
+                (expr :ge :predicate 'query-row-start (lit 0 :int)))
+       (compute 'query-row-order-valid :predicate
+                (expr :ge :predicate 'query-row-end 'query-row-start))
+       (compute 'query-row-end-valid :predicate
+                (expr :le :predicate 'query-row-end (lit total :int)))
+       (compute 'query-row-valid :predicate
+                (all-expr ['query-row-start-valid 'query-row-order-valid
+                           'query-row-end-valid]))
+       (compute 'query-next-valid :predicate
+                (and-expr 'query-valid-state 'query-row-valid))
+       (compute 'query-after-row-start :predicate
+                (expr :ge :predicate 'query-token 'query-row-start))
+       (compute 'query-before-row-end :predicate
+                (expr :lt :predicate 'query-token 'query-row-end))
+       (compute 'query-in-row :predicate
+                (and-expr 'query-after-row-start 'query-before-row-end))
+       (compute 'query-next-batch :int
+                (select-expr 'query-in-row 'query-row 'query-batch-state :int))
+       (body/->Yield ['query-next-valid 'query-next-batch])]
+      [(body/value 'query-metadata-valid :predicate)
+       (body/value 'query-batch :int)]
+      {:uniform-iter-args #{'query-valid-state 'query-batch-state}})]))
+
+(defn- dense-route-operations
+  [{:keys [route page-size]}]
+  (let [capacity (* (:pages-per-sequence route) page-size)]
+    [(load-value 'kv-length :int (:lengths route) ['safe-query-batch])
+     (load-value 'kv-start-position :int (:start-positions route) ['safe-query-batch])
+     (compute 'kv-length-nonnegative :predicate
+              (expr :ge :predicate 'kv-length (lit 0 :int)))
+     (compute 'kv-length-bounded :predicate
+              (expr :le :predicate 'kv-length (lit capacity :int)))
+     (compute 'kv-start-nonnegative :predicate
+              (expr :ge :predicate 'kv-start-position (lit 0 :int)))
+     (compute 'kv-start-long :long (cast-expr 'kv-start-position :long))
+     (compute 'kv-length-long :long (cast-expr 'kv-length :long))
+     (compute 'kv-end-long :long (expr :+ :long 'kv-start-long 'kv-length-long))
+     (compute 'kv-end-bounded :predicate
+              (expr :le :predicate 'kv-end-long (lit 2147483648 :long)))
+     (compute 'route-valid :predicate
+              (all-expr ['kv-length-nonnegative 'kv-length-bounded
+                         'kv-start-nonnegative 'kv-end-bounded]))
+     (compute 'safe-kv-length :int
+              (expr :min :int
+                    (expr :max :int 'kv-length (lit 0 :int))
+                    (lit capacity :int)))]))
+
+(defn- csr-route-operations
+  [{:keys [route page-size]}]
+  (let [capacity (:page-index-capacity route)
+        token-capacity (* capacity page-size)]
+    [(load-value 'page-offset-zero :int (:page-offsets route) [0])
+     (load-value 'page-begin :int (:page-offsets route) ['safe-query-batch])
+     (load-value 'page-end :int (:page-offsets route)
+                 [(body/expression :add 'safe-query-batch 1)])
+     (load-value 'final-page-length :int (:last-page-lengths route) ['safe-query-batch])
+     (load-value 'kv-start-position :int (:start-positions route) ['safe-query-batch])
+     (compute 'page-zero-valid :predicate
+              (expr :eq :predicate 'page-offset-zero (lit 0 :int)))
+     (compute 'page-begin-nonnegative :predicate
+              (expr :ge :predicate 'page-begin (lit 0 :int)))
+     (compute 'page-order-valid :predicate
+              (expr :ge :predicate 'page-end 'page-begin))
+     (compute 'page-end-bounded :predicate
+              (expr :le :predicate 'page-end (lit capacity :int)))
+     (compute 'kv-start-nonnegative :predicate
+              (expr :ge :predicate 'kv-start-position (lit 0 :int)))
+     (compute 'routed-page-count :int (expr :- :int 'page-end 'page-begin))
+     (compute 'has-routed-pages :predicate
+              (expr :gt :predicate 'routed-page-count (lit 0 :int)))
+     (compute 'empty-last-page-valid :predicate
+              (expr :eq :predicate 'final-page-length (lit 0 :int)))
+     (compute 'last-page-positive :predicate
+              (expr :ge :predicate 'final-page-length (lit 1 :int)))
+     (compute 'last-page-bounded :predicate
+              (expr :le :predicate 'final-page-length (lit page-size :int)))
+     (compute 'nonempty-last-page-valid :predicate
+              (and-expr 'last-page-positive 'last-page-bounded))
+     (compute 'last-page-valid :predicate
+              (select-expr 'has-routed-pages 'nonempty-last-page-valid
+                           'empty-last-page-valid :predicate))
+     (compute 'computed-kv-length :int
+              (expr :+ :int
+                    (expr :* :int
+                          (expr :- :int 'routed-page-count (lit 1 :int))
+                          (lit page-size :int))
+                    'final-page-length))
+     (compute 'kv-length :int
+              (select-expr 'has-routed-pages 'computed-kv-length (lit 0 :int) :int))
+     (compute 'kv-start-long :long (cast-expr 'kv-start-position :long))
+     (compute 'kv-length-long :long (cast-expr 'kv-length :long))
+     (compute 'kv-end-long :long (expr :+ :long 'kv-start-long 'kv-length-long))
+     (compute 'kv-end-bounded :predicate
+              (expr :le :predicate 'kv-end-long (lit 2147483648 :long)))
+     (compute 'route-valid :predicate
+              (all-expr ['page-zero-valid 'page-begin-nonnegative 'page-order-valid
+                         'page-end-bounded 'kv-start-nonnegative 'last-page-valid
+                         'kv-end-bounded]))
+     (compute 'safe-page-begin :int
+              (expr :min :int
+                    (expr :max :int 'page-begin (lit 0 :int))
+                    (lit (dec capacity) :int)))
+     (compute 'safe-kv-length :int
+              (expr :min :int
+                    (expr :max :int 'kv-length (lit 0 :int))
+                    (lit token-capacity :int)))]))
+
+(defn- interval-membership-operations
+  [{:keys [visibility]}]
+  (let [{:keys [causal? window-left window-right]} visibility
+        begin-expression
+        (if (some? window-left)
+          (expr :min :long
+                (expr :max :long
+                      (expr :- :long
+                            (expr :- :long 'query-position-long (lit window-left :long))
+                            'kv-start-long)
+                      (lit 0 :long))
+                'safe-kv-length-long)
+          (lit 0 :long))
+        end-expression
+        (cond
+          causal?
+          (expr :max :long
+                (expr :min :long 'safe-kv-length-long
+                      (expr :+ :long
+                            (expr :- :long 'query-position-long 'kv-start-long)
+                            (lit 1 :long)))
+                (lit 0 :long))
+
+          (some? window-right)
+          (expr :max :long
+                (expr :min :long 'safe-kv-length-long
+                      (expr :+ :long
+                            (expr :- :long
+                                  (expr :+ :long 'query-position-long
+                                        (lit window-right :long))
+                                  'kv-start-long)
+                            (lit 1 :long)))
+                (lit 0 :long))
+
+          :else 'safe-kv-length-long)]
+    [(compute 'safe-kv-length-long :long (cast-expr 'safe-kv-length :long))
+     (compute 'attention-begin :long
+              (expr :+ :long begin-expression (lit 0 :long)))
+     (compute 'attention-end :long
+              (expr :+ :long end-expression (lit 0 :long)))
+     (compute 'membership-valid :predicate (true-expr))]))
+
+(defn- csr-membership-operations
+  [{:keys [visibility]}]
+  (let [capacity (:key-index-capacity visibility)]
+    [(load-value 'attention-offset-zero :int (:row-offsets visibility) [0])
+     (load-value 'raw-attention-begin :int (:row-offsets visibility) ['query-token])
+     (load-value 'raw-attention-end :int (:row-offsets visibility)
+                 [(body/expression :add 'query-token 1)])
+     (compute 'attention-zero-valid :predicate
+              (expr :eq :predicate 'attention-offset-zero (lit 0 :int)))
+     (compute 'attention-begin-nonnegative :predicate
+              (expr :ge :predicate 'raw-attention-begin (lit 0 :int)))
+     (compute 'attention-order-valid :predicate
+              (expr :ge :predicate 'raw-attention-end 'raw-attention-begin))
+     (compute 'attention-end-bounded :predicate
+              (expr :le :predicate 'raw-attention-end (lit capacity :int)))
+     (compute 'membership-valid :predicate
+              (all-expr ['attention-zero-valid 'attention-begin-nonnegative
+                         'attention-order-valid 'attention-end-bounded]))
+     (compute 'attention-begin :int
+              (expr :min :int
+                    (expr :max :int 'raw-attention-begin (lit 0 :int))
+                    (lit capacity :int)))
+     (compute 'attention-end :int
+              (expr :min :int
+                    (expr :max :int 'raw-attention-end (lit 0 :int))
+                    (lit capacity :int)))]))
+
+(defn- position-visible-expression
+  [{:keys [causal? window-left window-right]}]
+  (all-expr
+   (cond-> []
+     causal?
+     (conj (expr :le :predicate 'kv-position 'query-position-long))
+
+     (some? window-left)
+     (conj (expr :ge :predicate 'kv-position
+                 (expr :- :long 'query-position-long (lit window-left :long))))
+
+     (some? window-right)
+     (conj (expr :le :predicate 'kv-position
+                 (expr :+ :long 'query-position-long (lit window-right :long)))))))
+
+(defn- cache-coordinates
+  [layout kv-head physical-page page-token component]
+  (case layout
+    :kv-head-major [kv-head physical-page page-token component]
+    :page-major [physical-page page-token kv-head component]))
+
+(defn- member-token-operations
+  [{:keys [visibility]} member]
+  (if (attention/csr-visibility? visibility)
+    [(load-value 'logical-token :int (:key-indices visibility) [member])
+     (compute 'logical-token-nonnegative :predicate
+              (expr :ge :predicate 'logical-token (lit 0 :int)))
+     (compute 'logical-token-bounded :predicate
+              (expr :lt :predicate 'logical-token 'safe-kv-length))
+     (compute 'logical-token-valid :predicate
+              (and-expr 'logical-token-nonnegative 'logical-token-bounded))
+     (compute 'logical-token-long :long (cast-expr 'logical-token :long))]
+    [(compute 'logical-token-long :long
+              (expr :+ :long member (lit 0 :long)))
+     (compute 'logical-token-valid :predicate (true-expr))]))
+
+(defn- physical-page-operations
+  [{:keys [route page-size physical-pages]}]
+  (if (attention/dense-paged-route? route)
+    [(compute 'logical-page :long
+              (expr :quot :long 'logical-token-long (lit page-size :long)))
+     (compute 'safe-logical-page :long
+              (expr :min :long
+                    (expr :max :long 'logical-page (lit 0 :long))
+                    (lit (dec (:pages-per-sequence route)) :long)))
+     (load-value 'physical-page :int (:page-table route)
+                 ['safe-query-batch 'safe-logical-page])
+     (compute 'page-token :long
+              (expr :- :long 'logical-token-long
+                    (expr :* :long 'safe-logical-page (lit page-size :long))))
+     (compute 'physical-page-nonnegative :predicate
+              (expr :ge :predicate 'physical-page (lit 0 :int)))
+     (compute 'physical-page-bounded :predicate
+              (expr :lt :predicate 'physical-page (lit physical-pages :int)))]
+    (let [capacity (:page-index-capacity route)]
+      [(compute 'logical-page :long
+                (expr :quot :long 'logical-token-long (lit page-size :long)))
+       (compute 'safe-page-begin-long :long (cast-expr 'safe-page-begin :long))
+       (compute 'raw-page-index :long
+                (expr :+ :long 'safe-page-begin-long 'logical-page))
+       (compute 'safe-page-index :long
+                (expr :min :long
+                      (expr :max :long 'raw-page-index (lit 0 :long))
+                      (lit (dec capacity) :long)))
+       (load-value 'physical-page :int (:page-indices route) ['safe-page-index])
+       (compute 'page-token :long
+                (expr :- :long 'logical-token-long
+                      (expr :* :long 'logical-page (lit page-size :long))))
+       (compute 'physical-page-nonnegative :predicate
+                (expr :ge :predicate 'physical-page (lit 0 :int)))
+       (compute 'physical-page-bounded :predicate
+                (expr :lt :predicate 'physical-page (lit physical-pages :int)))])))
+
+(defn- dot-operations
+  [{:keys [query k-pages qk-head-dim q-dtype k-dtype k-layout] :as problem}
+   subgroup-size]
+  [(body/->ForLoop
+    (body/value 'qk-component :int) 'lane qk-head-dim subgroup-size
+    [(body/->LoopArg (body/value 'partial-dot-state :float) (lit 0.0 :float))]
+    [(load-value 'query-element q-dtype (:values query)
+                 ['query-token 'query-head 'qk-component])
+     (load-value 'key-element k-dtype k-pages
+                 (cache-coordinates k-layout 'kv-head 'safe-physical-page
+                                    'page-token 'qk-component))
+     (compute 'query-float :float (half-or-float->float 'query-element q-dtype))
+     (compute 'key-float :float (half-or-float->float 'key-element k-dtype))
+     (compute 'qk-product :float (expr :* :float 'query-float 'key-float))
+     (compute 'partial-dot-next :float
+              (expr :+ :float 'partial-dot-state 'qk-product))
+     (body/->Yield ['partial-dot-next])]
+    [(body/value 'partial-dot :float)]
+    {})
+   (body/->Collective
+    (body/value 'dot :float) :reduce :subgroup subgroup-size 'partial-dot :+ nil
+    (body/full-participation) :implementation-defined)
+   (compute 'logit :float (expr :* :float 'dot (lit (:scale problem) :float)))])
+
+(defn- value-load-operations
+  [{:keys [v-pages v-dtype v-layout]} slots]
+  (mapcat
+   (fn [{:keys [safe-id mask-id]}]
+     [(load-value (symbol (str "value-element-" (name safe-id))) v-dtype v-pages
+                  (cache-coordinates v-layout 'kv-head 'safe-physical-page
+                                     'page-token safe-id)
+                  mask-id (lit 0.0 v-dtype))
+      (compute (symbol (str "value-float-" (name safe-id))) :float
+               (half-or-float->float
+                (symbol (str "value-element-" (name safe-id))) v-dtype))])
+   slots))
+
+(defn- online-update-region
+  [slots]
+  (let [next-accs (mapv :next-id slots)]
+    [(compute 'maximum-is-nan :predicate
+              (body/scalar-expression :isnan :predicate ['maximum-state]))
+     (compute 'logit-is-nan :predicate
+              (body/scalar-expression :isnan :predicate ['logit]))
+     (compute 'online-state-is-nan :predicate
+              (or-expr 'maximum-is-nan 'logit-is-nan))
+     (body/->IfRegion
+      'online-state-is-nan
+      [(body/->Yield [(lit Double/NaN :float)
+                      (lit Double/NaN :float)
+                      (lit Double/NaN :float)])]
+      [(compute 'next-maximum-valid :float (expr :max :float 'maximum-state 'logit))
+       (compute 'old-weight-valid :float
+                (expr :exp :float (expr :- :float 'maximum-state 'next-maximum-valid)))
+       (compute 'new-weight-valid :float
+                (expr :exp :float (expr :- :float 'logit 'next-maximum-valid)))
+       (body/->Yield ['next-maximum-valid 'old-weight-valid 'new-weight-valid])]
+      [(body/value 'next-maximum :float)
+       (body/value 'old-weight :float)
+       (body/value 'new-weight :float)])
+     (compute 'next-denominator :float
+              (expr :+ :float
+                    (expr :* :float 'denominator-state 'old-weight)
+                    'new-weight))
+     (vec
+      (mapcat
+       (fn [{:keys [binding-id safe-id next-id]}]
+         [(compute next-id :float
+                   (expr :+ :float
+                         (expr :* :float binding-id 'old-weight)
+                         (expr :* :float
+                               (symbol (str "value-float-" (name safe-id)))
+                               'new-weight)))])
+       slots))
+     (body/->Yield (vec (concat ['member-valid-next 'next-maximum 'next-denominator]
+                                next-accs)))]))
+
+(defn- flatten-operations
+  [operations]
+  (vec (mapcat #(if (and (vector? %) (not (record? %))) % [%]) operations)))
+
+(defn- membership-loop
+  [problem schedule slots]
+  (let [csr? (attention/csr-visibility? (:visibility problem))
+        member (if csr? 'membership-edge 'membership-token)
+        member-type (if csr? :int :long)
+        acc-bindings (mapv :binding-id slots)
+        acc-results (mapv :result-id slots)
+        state-bindings (vec (concat [(body/value 'member-valid-state :predicate)
+                                     (body/value 'maximum-state :float)
+                                     (body/value 'denominator-state :float)]
+                                    (map #(body/value % :float) acc-bindings)))
+        state-initials (vec (concat ['initial-valid
+                                     (lit -3.402823466e38 :float)
+                                     (lit 0.0 :float)]
+                                    (repeat (count slots) (lit 0.0 :float))))
+        state-results (vec (concat [(body/value 'final-valid :predicate)
+                                    (body/value 'final-maximum :float)
+                                    (body/value 'final-denominator :float)]
+                                   (map #(body/value % :float) acc-results)))
+        token-ops (member-token-operations problem member)
+        page-ops (physical-page-operations problem)
+        filter-expr (position-visible-expression
+                     (attention/position-filter (:visibility problem)))
+        dot-ops (dot-operations problem (:workgroup-size schedule))
+        value-ops (value-load-operations problem slots)
+        update-region (flatten-operations (online-update-region slots))
+        unchanged (vec (concat ['member-valid-next 'maximum-state 'denominator-state]
+                               acc-bindings))
+        body-ops
+        (flatten-operations
+         (concat
+          token-ops
+          [(compute 'kv-position :long
+                    (expr :+ :long 'kv-start-long 'logical-token-long))
+           (compute 'position-visible :predicate
+                    (and-expr filter-expr (true-expr)))]
+          page-ops
+          [(compute 'physical-page-valid :predicate
+                    (and-expr 'physical-page-nonnegative 'physical-page-bounded))
+           (compute 'member-applies :predicate
+                    (all-expr ['member-valid-state 'logical-token-valid
+                               'position-visible 'physical-page-valid]))
+           (compute 'member-invalid :predicate
+                    (or-expr (not-expr 'logical-token-valid)
+                             (and-expr 'position-visible
+                                       (not-expr 'physical-page-valid))))
+           (compute 'member-valid-next :predicate
+                    (and-expr 'member-valid-state (not-expr 'member-invalid)))
+           (compute 'safe-physical-page :int
+                    (expr :min :int
+                          (expr :max :int 'physical-page (lit 0 :int))
+                          (lit (dec (:physical-pages problem)) :int)))]
+          dot-ops value-ops
+          [(body/->IfRegion
+            'member-applies update-region
+            [(body/->Yield unchanged)]
+            (vec (concat [(body/value 'member-valid-result :predicate)
+                          (body/value 'maximum-result :float)
+                          (body/value 'denominator-result :float)]
+                         (map #(body/value % :float)
+                              (map :iteration-result-id slots)))))
+           (body/->Yield
+            (vec (concat ['member-valid-result 'maximum-result 'denominator-result]
+                         (map :iteration-result-id slots))))]))]
+    (body/->ForLoop
+     (body/value member member-type) 'attention-begin 'attention-end 1
+     (mapv body/->LoopArg state-bindings state-initials)
+     body-ops state-results {})))
+
+(defn- component-slots
+  [schedule]
+  (mapv (fn [slot]
+          {:slot slot
+           :id (symbol (str "value-component-" slot))
+           :safe-id (symbol (str "safe-value-component-" slot))
+           :mask-id (keyword (str "active-value-component-" slot))
+           :binding-id (symbol (str "weighted-value-state-" slot))
+           :next-id (symbol (str "weighted-value-next-" slot))
+           :iteration-result-id (symbol (str "weighted-value-iteration-" slot))
+           :result-id (symbol (str "weighted-value-result-" slot))})
+        (range (get-in schedule [:value-mapping :components-per-lane]))))
+
+(defn- output-operations
+  [problem slots]
+  (flatten-operations
+   (concat
+    [(compute 'denominator-is-zero :predicate
+              (expr :eq :predicate 'final-denominator (lit 0.0 :float)))]
+    (mapcat
+     (fn [{:keys [slot id mask-id result-id]}]
+       (let [normalized (symbol (str "normalized-value-" slot))
+             valid-value (symbol (str "valid-output-value-" slot))
+             stored (symbol (str "stored-output-value-" slot))]
+         [(compute normalized :float
+                   (select-expr 'denominator-is-zero (lit 0.0 :float)
+                                (expr :div :float result-id 'final-denominator) :float))
+          (compute valid-value :float
+                   (select-expr 'final-valid normalized (lit Double/NaN :float) :float))
+          (compute stored (:output-dtype problem)
+                   (output-value valid-value (:output-dtype problem)))
+          (body/->ScalarStore (:output problem)
+                              ['query-token 'query-head id] stored mask-id)]))
+     slots))))
+
+(defn- lowering-row!
+  [plan scheduled problem]
+  (let [visibility-kind (attention/visibility-kind (:visibility problem))
+        expected-traversal (if (= :csr visibility-kind)
+                             :csr-row
+                             :contiguous-interval)]
+    (when-not
+     (and (swr/online-softmax-algebra? plan)
+          (= :attention (get-in plan [:provenance :semantic-op]))
+          (= :canonical-segmented-weighted-reduction
+             (get-in plan [:provenance :lowering]))
+          (= (attention/ordered-input-buffer-ids problem)
+             (swr/ordered-input-ids plan))
+          (= (:value-head-dim problem) (get-in plan [:value :components]))
+          (= (:qk-head-dim problem) (get-in plan [:score :axis :extent]))
+          (= (get-in plan [:score :axis :name])
+             (get-in scheduled [:score-reduction :axis]))
+          (= (:accumulator-dtype plan)
+             (get-in scheduled [:numerical-mode :score-accumulate])
+             (get-in scheduled [:numerical-mode :state-accumulate]))
+          (= (:value-head-dim problem)
+             (get-in scheduled [:value-mapping :components]))
+          (= :routed-paged-kv (get-in scheduled [:attributes :storage-kind]))
+          (= (attention/route-kind (:route problem))
+             (get-in scheduled [:attributes :route-kind]))
+          (= visibility-kind (get-in scheduled [:attributes :visibility-kind]))
+          (= expected-traversal (:membership-traversal scheduled))
+          (= (:output problem) (get-in plan [:output :id])))
+      (throw (ex-info
+              "scheduled weighted-reduction body does not match its semantic plan"
+              {:reason :segmented-weighted-reduction-body-plan-mismatch
+               :plan-id (:id plan)
+               :schedule scheduled
+               :operation-id (:id problem)})))
+    [plan scheduled problem]))
+
+(defn lower-routed-paged
+  "Construct the verified KernelBody for the routed paged online schedule.
+
+  This pass accepts the generic SWR plan and schedule values. The initial storage lowering is
+  deliberately strict: it recognizes only the already-validated routed-paged descriptor emitted
+  by canonical attention lowering and otherwise fails before target emission."
+  [plan scheduled]
+  (let [plan (swr/validate! plan)
+        scheduled (schedule/validate! scheduled)
+        problem (attention/validate! (:source-operation plan))
+        _ (lowering-row! plan scheduled problem)
+        subgroup-size (:workgroup-size scheduled)
+        slots (component-slots scheduled)
+        query-ops (query-metadata-operations problem)
+        route-ops (if (attention/dense-paged-route? (:route problem))
+                    (dense-route-operations problem)
+                    (csr-route-operations problem))
+        membership-ops (if (attention/interval-visibility? (:visibility problem))
+                         (interval-membership-operations problem)
+                         (csr-membership-operations problem))
+        slot-indices
+        (mapcat (fn [{:keys [slot id safe-id]}]
+                  [(body/->IndexCompute
+                    id (body/expression :add 'lane (* slot subgroup-size)))
+                   (body/->IndexCompute
+                    safe-id (body/expression :min id (dec (:value-head-dim problem))))])
+                slots)
+        masks (mapv (fn [{:keys [id mask-id]}]
+                      (body/->Mask mask-id
+                                   [(body/predicate :lt id (:value-head-dim problem))]))
+                    slots)
+        initial-ops
+        (flatten-operations
+         (concat
+          query-ops
+          [(load-value 'query-position :int (get-in problem [:query :positions])
+                       ['query-token])
+           (compute 'query-position-valid :predicate
+                    (expr :ge :predicate 'query-position (lit 0 :int)))
+           (compute 'query-batch-valid :predicate
+                    (expr :ge :predicate 'query-batch (lit 0 :int)))
+           (compute 'safe-query-batch :int
+                    (expr :min :int
+                          (expr :max :int 'query-batch (lit 0 :int))
+                          (lit (dec (:batch-size problem)) :int)))
+           (compute 'query-position-long :long (cast-expr 'query-position :long))]
+          route-ops membership-ops
+          [(compute 'initial-valid :predicate
+                    (all-expr ['query-metadata-valid 'query-position-valid
+                               'query-batch-valid 'route-valid 'membership-valid]))
+           (compute 'kv-head :int
+                    (expr :quot :int 'query-head
+                          (lit (quot (:q-heads problem) (:kv-heads problem)) :int)))
+           (membership-loop problem scheduled slots)]
+          (output-operations problem slots)))
+        launch (launch/spec {:workgroup-size [subgroup-size 1]
+                             :group-count [(:q-heads problem)
+                                           (get-in problem [:query :total-tokens])]})]
+    (body/make
+     {:id [:segmented-weighted-reduction-body (:id plan) scheduled]
+      :parameters (parameters plan problem)
+      :stable-reads (mapv body/stable-read (swr/ordered-input-ids plan))
+      :indices (vec (concat [(body/->IndexBinding 'query-head :group 0)
+                             (body/->IndexBinding 'query-token :group 1)
+                             (body/->IndexBinding 'lane :lane 0)]
+                            slot-indices))
+      :masks masks
+      :operations initial-ops
+      :schedule (assoc scheduled :subgroup-size subgroup-size)
+      :launch launch
+      :provenance {:operation-id (:id problem)
+                   :semantic-op :segmented-weighted-reduction
+                   :algebra-plan-id (:id plan)
+                   :lowering :scheduled-kernel-body}
+      :attributes {:storage-kind :routed-paged-kv
+                   :route-kind (attention/route-kind (:route problem))
+                   :visibility-kind (attention/visibility-kind (:visibility problem))}})))

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_schedule.clj
@@ -113,7 +113,10 @@
                   :components [:maximum :denominator :weighted-values]}
           :numerical-mode {:score-accumulate accumulator-dtype
                            :state-accumulate accumulator-dtype
-                           :dot-order :subgroup-tree
+                           ;; The OpenCL subgroup builtin fixes neither its association tree nor
+                           ;; bitwise result. A target with an explicit shuffle tree may choose a
+                           ;; stricter schedule later; this row records exactly what it emits.
+                           :dot-order :implementation-defined
                            :online-rescale? true}
           :attributes {:storage-kind (:kind storage)
                        :route-kind (:route-kind storage)

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -459,6 +459,54 @@
                                       ['x-value (body/literal 0.0 :float)]))
              (body/->Yield ['next?])]
             [(body/value 'finished? :predicate)] {})]))))
+  (testing "an explicit inductive invariant admits a genuinely uniform carry"
+    (is (body/kernel-body?
+         (scalar-body
+          [(load-x)
+           (body/->ForLoop
+            (body/value 'i :int) 0 4 1
+            [(body/->LoopArg (body/value 'continue? :predicate)
+                             (body/literal true :predicate))]
+            [(body/->IfRegion
+              'continue?
+              [(reduce-x 'x-value) (body/->Yield [])]
+              [(body/->Yield [])]
+              [])
+             (body/->Yield [(body/literal true :predicate)])]
+            [(body/value 'finished? :predicate)]
+            {:uniform-iter-args #{'continue?}})]))))
+  (testing "the verifier checks rather than trusts the claimed backedge invariant"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"not preserved by its backedge"
+         (scalar-body
+          [(load-x)
+           (body/->ForLoop
+            (body/value 'i :int) 0 4 1
+            [(body/->LoopArg (body/value 'continue? :predicate)
+                             (body/literal true :predicate))]
+            [(body/->IfRegion
+              'continue?
+              [(reduce-x 'x-value) (body/->Yield [])]
+              [(body/->Yield [])]
+              [])
+             (body/->ScalarCompute
+              (body/value 'next? :predicate)
+              (body/scalar-expression :lt :predicate
+                                      ['x-value (body/literal 0.0 :float)]))
+             (body/->Yield ['next?])]
+            [(body/value 'finished? :predicate)]
+            {:uniform-iter-args #{'continue?}})]))))
+  (testing "uniformity annotations can name only carried bindings"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"must name carried bindings"
+         (scalar-body
+          [(body/->ForLoop
+            (body/value 'i :int) 0 1 1
+            [(body/->LoopArg (body/value 'carry :predicate)
+                             (body/literal true :predicate))]
+            [(body/->Yield [(body/literal true :predicate)])]
+            [(body/value 'result :predicate)]
+            {:uniform-iter-args #{'missing}})]))))
   (testing "a zero-trip loop result retains its initial value's variation"
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo #"lane-divergent"

--- a/test/raster/compiler/passes/parallel/attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/attention_route_test.clj
@@ -5,11 +5,13 @@
             [raster.compiler.backend.gpu.attention :as attention-emit]
             [raster.compiler.ir.attention :as attention]
             [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-body :as kbody]
             [raster.compiler.ir.kernel-executable :as kexec]
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.segmented-weighted-reduction :as swr]
             [raster.compiler.ir.segmented-weighted-reduction-schedule :as swr-schedule]
             [raster.compiler.passes.parallel.attention-route :as route]
+            [raster.compiler.passes.parallel.segmented-weighted-reduction-body :as swr-body]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-schedule
              :as schedule-pass]))
 
@@ -92,6 +94,7 @@
                                 (assoc desc :segmented-weighted-reduction-schedule :reference))
         {:keys [strategy reference? declines artifact graph schedule]} optimized
         swr-schedule (get-in artifact [:attributes :segmented-weighted-reduction-schedule])
+        kernel-body (get-in artifact [:attributes :kernel-body])
         source (:source artifact)]
     (is (= :routed-paged-subgroup-online-score-reuse strategy))
     (is (false? reference?))
@@ -107,15 +110,18 @@
     (is (= (kexec/common-view (:artifact reference))
            (kexec/common-view artifact)))
     (is (not= (:kernel-name (:artifact reference)) (:kernel-name artifact)))
+    (is (kbody/kernel-body? kernel-body))
+    (is (= :scheduled-kernel-body (get-in kernel-body [:provenance :lowering])))
     (is (str/includes? source "intel_reqd_sub_group_size(16)"))
-    (is (str/includes? source "const float dot = sub_group_reduce_add(partial_dot)"))
-    (is (str/includes? source "old_weight = sub_group_broadcast(old_weight, 0)"))
-    (is (str/includes? source "const int kv_head = q_head / 2"))
-    (is (str/includes? source "if (attention_begin == attention_end)"))
     (is (str/includes? source
-                       "for (int token = (int)attention_begin; token < (int)attention_end"))
-    (is (str/includes? source "float maximum"))
-    (is (str/includes? source "accumulator0 = accumulator0 * old_weight"))))
+                       "float rstr_dot = sub_group_reduce_add(rstr_partial_dot)"))
+    (is (not (str/includes? source "sub_group_broadcast"))
+        "identical online state is computed by every lane")
+    (is (str/includes? source "int rstr_kv_head = (rstr_query_head / 2)"))
+    (is (str/includes? source
+                       "for (long rstr_membership_token = rstr_attention_begin"))
+    (is (str/includes? source "float rstr_final_maximum"))
+    (is (str/includes? source "float rstr_weighted_value_next_0"))))
 
 (deftest cooperative-attention-source-is-valid-opencl
   (let [clang? (zero? (:exit (shell/sh "sh" "-c" "command -v clang")))]
@@ -135,9 +141,11 @@
                       [:artifact :source])
               result (shell/sh "clang" "-x" "cl" "-cl-std=CL2.0"
                                "-fsyntax-only" "-" :in source)]
-          (is (str/includes? source "const int d15 = (int)lane + 240;"))
-          (is (str/includes? source "float accumulator15 = 0.0f;"))
-          (is (not (str/includes? source "accumulator16")))
+          (is (str/includes? source
+                             "int rstr_value_component_15 = (rstr_lane + 240);"))
+          (is (str/includes? source
+                             "float rstr_weighted_value_result_15 = 0.0f;"))
+          (is (not (str/includes? source "rstr_value_component_16")))
           (is (zero? (:exit result)) (:err result)))))))
 
 (deftest cooperative-schedule-is-validated-and-target-legality-is-explicit
@@ -152,7 +160,7 @@
     (is (= {:kind :subgroup :width 16 :axis :qk-component}
            (:score-reduction schedule)))
     (is (= {:score-accumulate :float :state-accumulate :float
-            :dot-order :subgroup-tree :online-rescale? true}
+            :dot-order :implementation-defined :online-rescale? true}
            (:numerical-mode schedule)))
     (is (= :segmented-weighted-reduction-value-mapping
            (try
@@ -167,6 +175,11 @@
     (is (= :attention-cooperative-schedule-plan-mismatch
            (try
              (attention-emit/emit-fp16-cooperative
+              plan (assoc-in schedule [:score-reduction :axis] :wrong-axis))
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+    (is (= :segmented-weighted-reduction-body-plan-mismatch
+           (try
+             (swr-body/lower-routed-paged
               plan (assoc-in schedule [:score-reduction :axis] :wrong-axis))
              (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
     (let [nvidia-desc {:device-type :gpu :vendor "NVIDIA" :subgroup-size 32
@@ -221,8 +234,9 @@
     (is (= :contiguous-interval
            (get-in artifact [:attributes :segmented-weighted-reduction-schedule
                              :membership-traversal])))
-    (is (str/includes? (:source artifact) "page_indices[page_begin + logical_page]"))
-    (is (str/includes? (:source artifact) "routed_page_count == 0"))))
+    (is (str/includes? (:source artifact) "page_indices["))
+    (is (str/includes? (:source artifact)
+                       "rstr_empty_last_page_valid = (rstr_final_page_length == 0)"))))
 
 (deftest logical-csr-visibility-composes-with-physical-route-as-distinct-abi-slots
   (let [{:keys [artifact reference? declines]}
@@ -241,11 +255,12 @@
            (get-in artifact [:attributes :segmented-weighted-reduction-schedule
                              :membership-traversal])))
     (is (str/includes? (:source artifact)
-                       "for (int edge = attention_begin; edge < attention_end; ++edge)"))
+                       "for (int rstr_membership_edge = rstr_attention_begin"))
     (is (str/includes? (:source artifact)
-                       "const int token = attention_key_indices[edge]"))
-    (is (str/includes? (:source artifact) "token < 0 || token >= length"))
-    (is (str/includes? (:source artifact) "kv_position <= (long)q_position"))))
+                       "rstr_logical_token = attention_key_indices["))
+    (is (str/includes? (:source artifact) "rstr_logical_token_nonnegative"))
+    (is (str/includes? (:source artifact)
+                       "rstr_kv_position <= rstr_query_position_long"))))
 
 (deftest independent-k-and-v-layouts-are-lowered-without-repacking
   (let [source (:source (:artifact (route/route! (problem))))]
@@ -267,10 +282,11 @@
     (is (= :float (get-in artifact [:attributes :output-dtype])))
     (is (str/includes? source "__global const float* q"))
     (is (str/includes? source "__global float* output"))
-    (is (str/includes? source "dot += q[q_base + x] * convert_float(k_pages"))
-    (is (str/includes? source "output[out_base + d0] = NAN;"))
     (is (str/includes? source
-                       "output[out_base + d0] = denominator == 0.0f ? 0.0f"))))
+                       "float rstr_qk_product = (rstr_query_float * rstr_key_float)"))
+    (is (str/includes? source
+                       "rstr_valid_output_value_0 = (rstr_final_valid"))
+    (is (str/includes? source "output["))))
 
 (deftest pinned-cooperative-policy-selects-csr-membership-without-changing-semantics
   (let [result (route/route
@@ -297,7 +313,15 @@
       (is (empty? declines))
       (is (= traversal
              (get-in artifact [:attributes :segmented-weighted-reduction-schedule
-                               :membership-traversal]))))))
+                               :membership-traversal])))
+      (let [kernel-body (get-in artifact [:attributes :kernel-body])]
+        (is (kbody/kernel-body? kernel-body))
+        (is (= (:arguments artifact) (mapv :id (:parameters kernel-body))))
+        (is (= (vec (butlast (:arguments artifact)))
+               (mapv :buffer (:stable-reads kernel-body))))
+        (is (every? #(or (= :output (:kind %))
+                         (= :no-write-alias (:aliasing %)))
+                    (:abi artifact)))))))
 
 (deftest unsupported-representations-return-machine-readable-declines
   (testing "quantization declines before generic dtype routing"


### PR DESCRIPTION
## Summary

- lower routed paged SegmentedWeightedReduction schedules into verified target-neutral KernelBody scalar/control IR
- emit the production cooperative OpenCL kernel through the common KernelBody emitter and remove the handwritten source path
- preserve the ordered attention ABI while projecting stable-read no-write-alias contracts
- add checked loop-carried uniformity invariants and record subgroup reduction association honestly
- update the compiler north star with the landed vertical and tiled-reduction follow-up

## Verification

- focused verifier/emitter/ABI/device set: 48 tests, 286 assertions, 0 failures/errors
- full suite: 2412 tests, 34838 assertions, 0 failures/errors
- GPU suite: available, 0 skip-path tests
- OpenCL suite: Intel Arc available, 0 skip-path tests
- generated dense/CSR route x interval/CSR visibility kernels pass Clang and real-device differential checks