### PR TITLE
Tile scheduled weighted reductions across history

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -124,9 +124,14 @@ by this first lowering row; neither KernelBody nor the target emitter contains a
 operation. Dense/CSR physical page routing combines independently with bounded contiguous intervals
 or bounded CSR membership. The generated leaf has replaced the handwritten cooperative source and
 is checked against the reference algebra on a real device. Its subgroup builtin is recorded honestly
-as implementation-defined association rather than claiming a fixed tree. The next production work
-is to represent tiled membership traversal and mergeable online-reduction state, then lower subgroup
-collectives through portable OpenCL, CUDA and HIP target dialects. Verified local allocation,
+as implementation-defined association rather than claiming a fixed tree. A second production
+schedule now partitions bounded membership into static contiguous tiles, emits one partial
+KernelBody per segment/tile, and deterministically merges the explicit maximum/denominator/weighted
+value state in increasing tile order. The four typed partial buffers are operation-derived,
+graph-private temporaries; the source operation and external ABI are unchanged. This two-kernel
+schedule is opt-in until measured selection can account for dynamic history length and temporary
+traffic. The next production work is to lower subgroup collectives through portable OpenCL, CUDA
+and HIP target dialects. Verified local allocation,
 barriers and asynchronous copies can subsequently collapse a multi-kernel tiled graph into a
 FlashAttention-like single kernel without changing the semantic plan or external ABI.
 

--- a/src/raster/compiler/backend/gpu/attention.clj
+++ b/src/raster/compiler/backend/gpu/attention.clj
@@ -2,10 +2,10 @@
   "FP16-KV leaves for logical attention over dense or CSR paged KV routes.
 
    The direct one-work-item/component leaf remains the executable semantic oracle.  A separately
-   validated SegmentedWeightedReductionSchedule emits one subgroup/query-head across dense/CSR
-   routes and interval/CSR membership, sharing each QK score across lane-strided value
-   accumulators without changing the semantic plan, ordered ABI, storage ownership or graph
-   effects."
+   validated SegmentedWeightedReductionSchedule either emits one subgroup/query-head or partitions
+   bounded membership into partial online states and a deterministic merge graph. Both schedules
+   share each QK score across lane-strided value accumulators without changing the semantic plan,
+   ordered external ABI, storage ownership or graph effects."
   (:require [raster.compiler.backend.gpu.kernel-body-opencl :as body-opencl]
             [raster.compiler.ir.attention :as attention]
             [raster.compiler.ir.kernel-abi :as kabi]
@@ -469,6 +469,132 @@
                    :kernel-body kernel-body
                    :materialized-intermediates []
                    :complexity :query-head-token-dot-plus-value}})))
+
+(def ^:private partial-c-names
+  {:partial-valid "partial_valid"
+   :partial-maximum "partial_maximum"
+   :partial-denominator "partial_denominator"
+   :partial-weighted-values "partial_weighted_values"})
+
+(defn- private-state-slots
+  [kind partial-specs]
+  (mapv (fn [{:keys [id dtype role]}]
+          (kabi/slot id kind dtype :c-name (get partial-c-names role) :role role))
+        partial-specs))
+
+(defn- partial-abi
+  [problem partial-specs kernel-body]
+  (let [external-inputs (vec (butlast (ordered-abi problem)))
+        private-outputs (private-state-slots :output partial-specs)]
+    (body-abi/project-contracts (into external-inputs private-outputs) kernel-body)))
+
+(defn- merge-abi
+  [problem partial-specs kernel-body]
+  (let [private-inputs (private-state-slots :input partial-specs)
+        output-slot (peek (ordered-abi problem))]
+    (body-abi/project-contracts (conj private-inputs output-slot) kernel-body)))
+
+(defn- emitted-body-artifact
+  [problem plan scheduled phase kernel-body abi arguments reads writes]
+  (let [entry-name (str (kernel-name problem [scheduled phase]) "_" (name phase))
+        parameter-names (into {} (map (juxt :name :c-name)) abi)]
+    (kart/make
+     {:kernel-name entry-name
+      :source (body-opencl/emit-scalar-kernel
+               entry-name kernel-body
+               {:parameter-names parameter-names :subgroup-attribute :intel})
+      :abi abi
+      :arguments arguments
+      :launch (:launch kernel-body)
+      :effects {:kind :segmented-weighted-reduction-phase
+                :phase phase :reads reads :writes writes}
+      :provenance {:operation-id (:id problem)
+                   :semantic-op :attention
+                   :algebra-plan-id (:id plan)
+                   :lowering (keyword (str "subgroup-online-tiled-history-" (name phase)))}
+      :attributes {:strategy :routed-paged-subgroup-online-tiled-history
+                   :optimization-tier :subgroup-tiled
+                   :phase phase
+                   :segmented-weighted-reduction-schedule scheduled
+                   :kernel-body kernel-body}})))
+
+(defn emit-fp16-tiled-history
+  "Emit a two-kernel tiled-history graph with graph-owned mergeable online state.
+
+  The external ABI is exactly the original routed attention ABI. Partial states are typed graph
+  temporaries, so allocation, dependencies and ownership remain compiler-managed and invisible
+  to cache/page scheduling above this layer."
+  [plan scheduled]
+  (let [[plan scheduled {:keys [output id route] :as problem}]
+        (cooperative-plan! plan scheduled)
+        _ (when-not (swr-schedule/tiled? scheduled)
+            (throw (ex-info "tiled-history emission requires a tiled schedule"
+                            {:reason :attention-tiled-history-schedule
+                             :schedule scheduled})))
+        inputs (ordered-inputs plan)
+        partial-specs (swr-body/partial-buffer-specs plan scheduled)
+        partial-ids (mapv :id partial-specs)
+        partial-body (swr-body/lower-routed-paged-partial plan scheduled)
+        merge-body (swr-body/lower-routed-paged-merge plan scheduled)
+        partial-arguments (into inputs partial-ids)
+        merge-arguments (conj partial-ids output)
+        partial-artifact (emitted-body-artifact
+                          problem plan scheduled :partial partial-body
+                          (partial-abi problem partial-specs partial-body) partial-arguments
+                          inputs partial-ids)
+        merge-artifact (emitted-body-artifact
+                        problem plan scheduled :merge merge-body
+                        (merge-abi problem partial-specs merge-body) merge-arguments
+                        partial-ids [output])
+        specs (attention/buffer-specs problem)
+        graph-buffer (fn [buffer-id]
+                       (let [{:keys [dtype elements role]} (get specs buffer-id)]
+                         (kgraph/buffer buffer-id dtype elements :device role)))
+        partial-node [:attention id :tiled-history :partial]
+        merge-node [:attention id :tiled-history :merge]
+        external-abi (ordered-abi problem)]
+    (kgraph/make
+     {:inputs (mapv graph-buffer inputs)
+      :outputs [(graph-buffer output)]
+      :temporaries (mapv (fn [{:keys [id dtype elements]}]
+                           (kgraph/buffer id dtype elements :device :temporary))
+                         partial-specs)
+      :abi external-abi
+      :arguments (conj inputs output)
+      :nodes [(kgraph/->ScheduledKernel
+               partial-node partial-artifact
+               (vec (concat (map #(kgraph/->ValueUse % :read) inputs)
+                            (map #(kgraph/->ValueUse % :write) partial-ids)))
+               [])
+              (kgraph/->ScheduledKernel
+               merge-node merge-artifact
+               (vec (concat (map #(kgraph/->ValueUse % :read) partial-ids)
+                            [(kgraph/->ValueUse output :write)]))
+               [partial-node])]
+      :effects {:kind :attention :logical-visibility true :ordered-page-routing true}
+      :provenance {:operation-id id :semantic-op :attention
+                   :algebra-plan-id (:id plan)
+                   :lowering :subgroup-online-tiled-history}
+      :attributes {:strategy :routed-paged-subgroup-online-tiled-history
+                   :reference? false
+                   :optimization-tier :subgroup-tiled
+                   :algebra :segmented-weighted-reduction
+                   :algebra-key (swr/algebra-key plan)
+                   :storage-dtype :half
+                   :q-dtype (:q-dtype problem)
+                   :output-dtype (:output-dtype problem)
+                   :accumulator-dtype :float
+                   :route-kind (attention/route-kind route)
+                   :visibility-kind (attention/visibility-kind (:visibility problem))
+                   :k-layout (:k-layout problem)
+                   :v-layout (:v-layout problem)
+                   :visibility (:visibility problem)
+                   :layout (attention/layouts problem)
+                   :segmented-weighted-reduction-schedule scheduled
+                   :materialized-intermediates partial-ids
+                   :complexity :parallel-history-tiles-plus-online-state-merge
+                   :private-online-state (mapv #(select-keys % [:id :dtype :shape :role])
+                                               partial-specs)}})))
 
 (defn kernel-graph
   "Wrap either verified attention leaf in an explicit one-node scheduled graph."

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -1231,7 +1231,7 @@
                                    indices))
          subgroup-size (or (some-> collective :width)
                            (get-in kernel-body [:schedule :subgroup-size]))
-         attribute (when collective
+         attribute (when uses-subgroups?
                      (case subgroup-attribute
                        :intel (str "__attribute__((intel_reqd_sub_group_size("
                                    subgroup-size ")))\n")

--- a/src/raster/compiler/ir/segmented_weighted_reduction_schedule.clj
+++ b/src/raster/compiler/ir/segmented_weighted_reduction_schedule.clj
@@ -7,7 +7,50 @@
 
 (defrecord SegmentedWeightedReductionSchedule
            [strategy workgroup-size segment-mapping membership-traversal score-reduction
-            value-mapping state numerical-mode attributes])
+            membership-tiling value-mapping state numerical-mode attributes])
+
+(def ^:private online-state-components
+  [:maximum :denominator :weighted-values])
+
+(def ^:private online-state-merge
+  {:kind :maximum-rescale-sum
+   :order :increasing-membership-tile
+   :nan-policy :propagate
+   :empty-policy :identity})
+
+(defn online-state
+  "The explicit mergeable state carried by sequential and tiled online schedules.
+
+  This is scheduled reduction state, not an attention semantic.  Its merge law lets a later
+  lowering partition any normalized exponential weighted reduction without exposing partial
+  buffers through the source operation or public ABI."
+  []
+  {:kind :online-normalized-weighted-sum
+   :components online-state-components
+   :merge online-state-merge})
+
+(declare validate!)
+
+(defn tiled?
+  [schedule]
+  (= :static-contiguous-tiles (get-in (validate! schedule) [:membership-tiling :kind])))
+
+(defn- valid-membership-tiling?
+  [membership-tiling]
+  (case (:kind membership-tiling)
+    :sequential
+    (= {:kind :sequential} membership-tiling)
+
+    :static-contiguous-tiles
+    (let [{:keys [tile-size tile-count membership-capacity merge-order]} membership-tiling]
+      (and (pos-int? tile-size)
+           (<= tile-size Integer/MAX_VALUE)
+           (pos-int? tile-count)
+           (pos-int? membership-capacity)
+           (= tile-count (quot (+ membership-capacity (dec tile-size)) tile-size))
+           (= :increasing-membership-tile merge-order)))
+
+    false))
 
 (defn schedule?
   [value]
@@ -22,8 +65,10 @@
                     {:reason :segmented-weighted-reduction-schedule-type
                      :schedule schedule})))
   (let [{:keys [strategy workgroup-size segment-mapping membership-traversal score-reduction
-                value-mapping state numerical-mode attributes]} schedule]
-    (when-not (= :subgroup-online-score-reuse strategy)
+                membership-tiling value-mapping state numerical-mode attributes]} schedule]
+    (when-not (contains? #{:subgroup-online-score-reuse
+                           :subgroup-online-tiled-history}
+                         strategy)
       (throw (ex-info "segmented weighted-reduction schedule has an unsupported strategy"
                       {:reason :segmented-weighted-reduction-schedule-strategy
                        :strategy strategy})))
@@ -31,10 +76,15 @@
       (throw (ex-info "segmented weighted-reduction workgroup size must be positive"
                       {:reason :segmented-weighted-reduction-schedule-workgroup
                        :workgroup-size workgroup-size})))
-    (when-not (= :one-workgroup-per-segment segment-mapping)
-      (throw (ex-info "cooperative weighted reduction requires one workgroup per segment"
+    (let [expected-mapping (if (= :subgroup-online-tiled-history strategy)
+                             {:partial :one-workgroup-per-segment-tile
+                              :merge :one-workgroup-per-segment}
+                             :one-workgroup-per-segment)]
+      (when-not (= expected-mapping segment-mapping)
+        (throw (ex-info "cooperative weighted reduction has an invalid segment mapping"
                       {:reason :segmented-weighted-reduction-segment-mapping
-                       :segment-mapping segment-mapping})))
+                       :strategy strategy :segment-mapping segment-mapping
+                       :expected expected-mapping}))))
     (when-not (contains? #{:contiguous-interval :csr-row} membership-traversal)
       (throw (ex-info "cooperative weighted reduction requires a bounded membership traversal"
                       {:reason :segmented-weighted-reduction-membership-traversal
@@ -47,6 +97,12 @@
                       {:reason :segmented-weighted-reduction-score-reduction
                        :score-reduction score-reduction
                        :workgroup-size workgroup-size})))
+    (when-not (and (valid-membership-tiling? membership-tiling)
+                   (= (= :subgroup-online-tiled-history strategy)
+                      (= :static-contiguous-tiles (:kind membership-tiling))))
+      (throw (ex-info "weighted-reduction membership tiling is incomplete or inconsistent"
+                      {:reason :segmented-weighted-reduction-membership-tiling
+                       :strategy strategy :membership-tiling membership-tiling})))
     (when-not (and (= :lane-strided (:kind value-mapping))
                    (integer? (:components value-mapping))
                    (pos? (:components value-mapping))
@@ -58,9 +114,7 @@
                       {:reason :segmented-weighted-reduction-value-mapping
                        :value-mapping value-mapping
                        :workgroup-size workgroup-size})))
-    (when-not (= {:kind :online-normalized-weighted-sum
-                  :components [:maximum :denominator :weighted-values]}
-                 state)
+    (when-not (= (online-state) state)
       (throw (ex-info "cooperative weighted reduction requires explicit online softmax state"
                       {:reason :segmented-weighted-reduction-online-state :state state})))
     (when-not (and (map? numerical-mode)
@@ -68,6 +122,10 @@
                    (keyword? (:state-accumulate numerical-mode))
                    (= :implementation-defined (:dot-order numerical-mode))
                    (true? (:online-rescale? numerical-mode))
+                   (= (if (= :subgroup-online-tiled-history strategy)
+                        :increasing-members-within-tile-then-increasing-tile-left-fold
+                        :increasing-membership)
+                      (:online-state-order numerical-mode))
                    (map? attributes))
       (throw (ex-info "segmented weighted-reduction numerical and attribute facets are incomplete"
                       {:reason :segmented-weighted-reduction-schedule-facets
@@ -76,9 +134,9 @@
 
 (defn make
   [{:keys [strategy workgroup-size segment-mapping membership-traversal score-reduction
-           value-mapping state numerical-mode attributes]
+           membership-tiling value-mapping state numerical-mode attributes]
     :or {attributes {}}}]
   (validate!
    (->SegmentedWeightedReductionSchedule
-    strategy workgroup-size segment-mapping membership-traversal score-reduction value-mapping
-    state numerical-mode attributes)))
+    strategy workgroup-size segment-mapping membership-traversal score-reduction
+    membership-tiling value-mapping state numerical-mode attributes)))

--- a/src/raster/compiler/passes/parallel/attention_route.clj
+++ b/src/raster/compiler/passes/parallel/attention_route.clj
@@ -14,7 +14,8 @@
    :declines [{:leaf :fp16-reference :reason reason :data data}]})
 
 (def ^:private cooperative-policies
-  #{:subgroup-score-reuse :subgroup-online-score-reuse})
+  #{:subgroup-score-reuse :subgroup-online-score-reuse
+    :subgroup-online-tiled-history})
 
 (defn- requested-policy
   [desc]
@@ -23,23 +24,43 @@
 (defn- success
   [problem plan artifact declines]
   (let [strategy (get-in artifact [:attributes :strategy])
-        reference? (= :reference (get-in artifact [:attributes :optimization-tier]))]
+        reference? (= :reference (get-in artifact [:attributes :optimization-tier]))
+        graph (emit/kernel-graph plan artifact)]
     {:operation problem
      :plan plan
      :strategy strategy
      :reference? reference?
      :declines declines
      :artifact artifact
-     :graph (emit/kernel-graph plan artifact)
+     :graph graph
+     :executable graph
      :schedule {:workgroup-size (:workgroup-size (:launch artifact))
                 :group-count (:group-count (:launch artifact))}}))
+
+(defn- success-graph
+  [problem plan graph declines]
+  (let [strategy (get-in graph [:attributes :strategy])]
+    {:operation problem
+     :plan plan
+     :strategy strategy
+     :reference? false
+     :declines declines
+     :artifact nil
+     :graph graph
+     :executable graph
+     :schedule {:stages
+                (mapv (fn [node]
+                        {:id (:id node)
+                         :workgroup-size (get-in node [:operation :launch :workgroup-size])
+                         :group-count (get-in node [:operation :launch :group-count])})
+                      (:nodes graph))}}))
 
 (defn route
   "Route packed/routed attention through a cooperative schedule or its semantic oracle.
 
    Quantized K/V formats stay semantic values but decline until their scale/group operands are
    explicit. Dense and CSR physical routing retain deliberately distinct ABIs while interval and
-   CSR logical membership both admit the same one-subgroup online-softmax schedule."
+   CSR logical membership admit both the one-subgroup schedule and its opt-in tiled-history graph."
   ([problem] (route problem nil))
   ([problem desc]
    (let [{:keys [q-dtype k-dtype v-dtype output-dtype accumulator-dtype
@@ -79,12 +100,19 @@
 
            (or (= :auto policy) (contains? cooperative-policies policy))
            (let [{:keys [ok schedule reason] :as scheduled}
-                 (swr-schedule/plan-subgroup-online plan desc)
+                 (if (= :subgroup-online-tiled-history policy)
+                   (swr-schedule/plan-subgroup-online-tiled plan desc)
+                   (swr-schedule/plan-subgroup-online plan desc))
                  emitter-supported? (gpu-target/intel-opencl-subgroup-dialect? desc)]
              (if (and ok emitter-supported?)
-               (success problem plan (emit/emit-fp16-cooperative plan schedule) [])
+               (if (= :subgroup-online-tiled-history policy)
+                 (success-graph problem plan
+                                (emit/emit-fp16-tiled-history plan schedule) [])
+                 (success problem plan (emit/emit-fp16-cooperative plan schedule) []))
                (let [cooperative-decline
-                     {:leaf :routed-paged-subgroup-online-score-reuse
+                     {:leaf (if (= :subgroup-online-tiled-history policy)
+                              :routed-paged-subgroup-online-tiled-history
+                              :routed-paged-subgroup-online-score-reuse)
                       :reason (if ok
                                 :score-reuse-requires-intel-subgroup-dialect
                                 reason)

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_body.clj
@@ -90,6 +90,76 @@
                id role dtype shape :global (layout/row-major shape dtype) (get roles id role))))
           ids)))
 
+(defn partial-buffer-ids
+  "Stable graph-local identities derived from the semantic reduction identity.
+
+  Derivation matters when several tiled reductions are linked into one larger program: private
+  buffers from distinct reductions must never become equal merely because they share a phase."
+  [plan]
+  (let [plan-id (:id (swr/validate! plan))]
+    {:valid [:segmented-weighted-reduction plan-id :partial-valid]
+     :maximum [:segmented-weighted-reduction plan-id :partial-maximum]
+     :denominator [:segmented-weighted-reduction plan-id :partial-denominator]
+     :weighted-values [:segmented-weighted-reduction plan-id :partial-weighted-values]}))
+
+(defn- checked-elements
+  [owner extents]
+  (try
+    (reduce (fn [result extent]
+              (Math/multiplyExact (long result) (long extent)))
+            1 extents)
+    (catch ArithmeticException cause
+      (throw (ex-info "tiled weighted-reduction temporary extent exceeds signed 64-bit capacity"
+                      {:reason :segmented-weighted-reduction-partial-extent-overflow
+                       :owner owner :extents (vec extents)}
+                      cause)))))
+
+(defn partial-buffer-specs
+  "Graph-private storage required by a tiled online weighted-reduction schedule."
+  [plan scheduled]
+  (let [plan (swr/validate! plan)
+        scheduled (schedule/validate! scheduled)
+        problem (attention/validate! (:source-operation plan))]
+    (when-not (schedule/tiled? scheduled)
+      (throw (ex-info "partial buffers require a tiled weighted-reduction schedule"
+                      {:reason :segmented-weighted-reduction-partial-schedule
+                       :schedule scheduled})))
+    (let [tile-count (get-in scheduled [:membership-tiling :tile-count])
+          ids (partial-buffer-ids plan)
+          prefix [(get-in problem [:query :total-tokens]) (:q-heads problem) tile-count]
+          scalar-elements (checked-elements :scalar-state prefix)
+          weighted-elements (checked-elements :weighted-values
+                                               (conj prefix (:value-head-dim problem)))]
+      [{:id (:valid ids) :dtype :int :shape prefix :elements scalar-elements
+        :role :partial-valid}
+       {:id (:maximum ids) :dtype :float :shape prefix :elements scalar-elements
+        :role :partial-maximum}
+       {:id (:denominator ids) :dtype :float :shape prefix :elements scalar-elements
+        :role :partial-denominator}
+       {:id (:weighted-values ids) :dtype :float
+        :shape (conj prefix (:value-head-dim problem))
+        :elements weighted-elements
+        :role :partial-weighted-values}])))
+
+(defn- partial-parameters
+  [plan problem scheduled]
+  (into (mapv #(assoc % :kind :input) (butlast (parameters plan problem)))
+        (map (fn [{:keys [id dtype shape role]}]
+               (body/->KernelParameter id :output dtype shape :global
+                                       (layout/row-major shape dtype) role)))
+        (partial-buffer-specs plan scheduled)))
+
+(defn- merge-parameters
+  [plan problem scheduled]
+  (let [{:keys [dtype shape role]} (get (attention/buffer-specs problem) (:output problem))]
+    (conj
+     (mapv (fn [{:keys [id dtype shape role]}]
+             (body/->KernelParameter id :input dtype shape :global
+                                     (layout/row-major shape dtype) role))
+           (partial-buffer-specs plan scheduled))
+     (body/->KernelParameter (:output problem) :output dtype shape :global
+                             (layout/row-major shape dtype) role))))
+
 (defn- query-metadata-operations
   [{:keys [query batch-size]}]
   (let [offsets (:row-offsets query)
@@ -442,7 +512,7 @@
   (vec (mapcat #(if (and (vector? %) (not (record? %))) % [%]) operations)))
 
 (defn- membership-loop
-  [problem schedule slots]
+  [problem schedule slots lower upper]
   (let [csr? (attention/csr-visibility? (:visibility problem))
         member (if csr? 'membership-edge 'membership-token)
         member-type (if csr? :int :long)
@@ -506,7 +576,7 @@
             (vec (concat ['member-valid-result 'maximum-result 'denominator-result]
                          (map :iteration-result-id slots))))]))]
     (body/->ForLoop
-     (body/value member member-type) 'attention-begin 'attention-end 1
+     (body/value member member-type) lower upper 1
      (mapv body/->LoopArg state-bindings state-initials)
      body-ops state-results {})))
 
@@ -522,6 +592,24 @@
            :iteration-result-id (symbol (str "weighted-value-iteration-" slot))
            :result-id (symbol (str "weighted-value-result-" slot))})
         (range (get-in schedule [:value-mapping :components-per-lane]))))
+
+(defn- slot-indices
+  [problem scheduled slots]
+  (mapcat (fn [{:keys [slot id safe-id]}]
+            [(body/->IndexCompute
+              id (body/expression :add 'lane (* slot (:workgroup-size scheduled))))
+             (body/->IndexCompute
+              safe-id (body/expression :min id (dec (:value-head-dim problem))))])
+          slots))
+
+(defn- slot-masks
+  [problem slots]
+  (mapv (fn [{:keys [id mask-id]}]
+          (body/->Mask mask-id [(body/predicate :lt id (:value-head-dim problem))]))
+        slots))
+
+(defn- lane-zero-mask []
+  (body/->Mask :lane-zero [(body/predicate :eq 'lane 0)]))
 
 (defn- output-operations
   [problem slots]
@@ -581,6 +669,24 @@
                :operation-id (:id problem)})))
     [plan scheduled problem]))
 
+(defn- sequential-lowering-row!
+  [plan scheduled problem]
+  (lowering-row! plan scheduled problem)
+  (when (schedule/tiled? scheduled)
+    (throw (ex-info "single-body weighted reduction cannot consume a tiled schedule"
+                    {:reason :segmented-weighted-reduction-body-schedule-phase
+                     :expected :sequential :schedule scheduled})))
+  [plan scheduled problem])
+
+(defn- tiled-lowering-row!
+  [plan scheduled problem]
+  (lowering-row! plan scheduled problem)
+  (when-not (schedule/tiled? scheduled)
+    (throw (ex-info "partial/merge bodies require a tiled weighted-reduction schedule"
+                    {:reason :segmented-weighted-reduction-body-schedule-phase
+                     :expected :tiled :schedule scheduled})))
+  [plan scheduled problem])
+
 (defn lower-routed-paged
   "Construct the verified KernelBody for the routed paged online schedule.
 
@@ -591,7 +697,7 @@
   (let [plan (swr/validate! plan)
         scheduled (schedule/validate! scheduled)
         problem (attention/validate! (:source-operation plan))
-        _ (lowering-row! plan scheduled problem)
+        _ (sequential-lowering-row! plan scheduled problem)
         subgroup-size (:workgroup-size scheduled)
         slots (component-slots scheduled)
         query-ops (query-metadata-operations problem)
@@ -601,17 +707,8 @@
         membership-ops (if (attention/interval-visibility? (:visibility problem))
                          (interval-membership-operations problem)
                          (csr-membership-operations problem))
-        slot-indices
-        (mapcat (fn [{:keys [slot id safe-id]}]
-                  [(body/->IndexCompute
-                    id (body/expression :add 'lane (* slot subgroup-size)))
-                   (body/->IndexCompute
-                    safe-id (body/expression :min id (dec (:value-head-dim problem))))])
-                slots)
-        masks (mapv (fn [{:keys [id mask-id]}]
-                      (body/->Mask mask-id
-                                   [(body/predicate :lt id (:value-head-dim problem))]))
-                    slots)
+        slot-indices (slot-indices problem scheduled slots)
+        masks (slot-masks problem slots)
         initial-ops
         (flatten-operations
          (concat
@@ -634,7 +731,7 @@
            (compute 'kv-head :int
                     (expr :quot :int 'query-head
                           (lit (quot (:q-heads problem) (:kv-heads problem)) :int)))
-           (membership-loop problem scheduled slots)]
+           (membership-loop problem scheduled slots 'attention-begin 'attention-end)]
           (output-operations problem slots)))
         launch (launch/spec {:workgroup-size [subgroup-size 1]
                              :group-count [(:q-heads problem)
@@ -658,3 +755,244 @@
       :attributes {:storage-kind :routed-paged-kv
                    :route-kind (attention/route-kind (:route problem))
                    :visibility-kind (attention/visibility-kind (:visibility problem))}})))
+
+(defn- tile-bound-operations
+  [problem scheduled]
+  (let [csr? (attention/csr-visibility? (:visibility problem))
+        type (if csr? :int :long)
+        tile-size (get-in scheduled [:membership-tiling :tile-size])
+        offset (if csr? 'history-tile-offset-int 'history-tile-offset)]
+    (vec
+     (concat
+      [(compute 'history-tile-offset-int :int
+                (expr :* :int 'history-tile (lit tile-size :int)))]
+      (when-not csr?
+        [(compute 'history-tile-offset :long
+                  (cast-expr 'history-tile-offset-int :long))])
+      [(compute 'membership-count type
+                (expr :- type 'attention-end 'attention-begin))
+       (compute 'tile-relative-begin type
+                (expr :min type 'membership-count offset))
+       (compute 'tile-membership-begin type
+                (expr :+ type 'attention-begin 'tile-relative-begin))
+       (compute 'tile-membership-remaining type
+                (expr :- type 'membership-count 'tile-relative-begin))
+       (compute 'tile-membership-width type
+                (expr :min type 'tile-membership-remaining (lit tile-size type)))
+       (compute 'tile-membership-end type
+                (expr :+ type 'tile-membership-begin 'tile-membership-width))]))))
+
+(defn- partial-store-operations
+  [partial-ids slots]
+  (flatten-operations
+   (concat
+    [(compute 'partial-valid-int :int
+              (select-expr 'final-valid (lit 1 :int) (lit 0 :int) :int))
+     (body/->ScalarStore (:valid partial-ids)
+                         ['query-token 'query-head 'history-tile]
+                         'partial-valid-int :lane-zero)
+     (body/->ScalarStore (:maximum partial-ids)
+                         ['query-token 'query-head 'history-tile]
+                         'final-maximum :lane-zero)
+     (body/->ScalarStore (:denominator partial-ids)
+                         ['query-token 'query-head 'history-tile]
+                         'final-denominator :lane-zero)]
+    (mapcat
+     (fn [{:keys [id mask-id result-id]}]
+       [(body/->ScalarStore (:weighted-values partial-ids)
+                            ['query-token 'query-head 'history-tile id]
+                            result-id mask-id)])
+     slots))))
+
+(defn lower-routed-paged-partial
+  "Lower each statically bounded membership tile to a private mergeable online state."
+  [plan scheduled]
+  (let [plan (swr/validate! plan)
+        scheduled (schedule/validate! scheduled)
+        problem (attention/validate! (:source-operation plan))
+        _ (tiled-lowering-row! plan scheduled problem)
+        subgroup-size (:workgroup-size scheduled)
+        tile-count (get-in scheduled [:membership-tiling :tile-count])
+        slots (component-slots scheduled)
+        partial-ids (partial-buffer-ids plan)
+        query-ops (query-metadata-operations problem)
+        route-ops (if (attention/dense-paged-route? (:route problem))
+                    (dense-route-operations problem)
+                    (csr-route-operations problem))
+        membership-ops (if (attention/interval-visibility? (:visibility problem))
+                         (interval-membership-operations problem)
+                         (csr-membership-operations problem))
+        initial-ops
+        (flatten-operations
+         (concat
+          query-ops
+          [(load-value 'query-position :int (get-in problem [:query :positions])
+                       ['query-token])
+           (compute 'query-position-valid :predicate
+                    (expr :ge :predicate 'query-position (lit 0 :int)))
+           (compute 'query-batch-valid :predicate
+                    (expr :ge :predicate 'query-batch (lit 0 :int)))
+           (compute 'safe-query-batch :int
+                    (expr :min :int
+                          (expr :max :int 'query-batch (lit 0 :int))
+                          (lit (dec (:batch-size problem)) :int)))
+           (compute 'query-position-long :long (cast-expr 'query-position :long))]
+          route-ops membership-ops (tile-bound-operations problem scheduled)
+          [(compute 'initial-valid :predicate
+                    (all-expr ['query-metadata-valid 'query-position-valid
+                               'query-batch-valid 'route-valid 'membership-valid]))
+           (compute 'kv-head :int
+                    (expr :quot :int 'query-head
+                          (lit (quot (:q-heads problem) (:kv-heads problem)) :int)))
+           (membership-loop problem scheduled slots
+                            'tile-membership-begin 'tile-membership-end)]
+          (partial-store-operations partial-ids slots)))
+        launch (launch/spec {:workgroup-size [subgroup-size 1 1]
+                             :group-count [(:q-heads problem)
+                                           (get-in problem [:query :total-tokens])
+                                           tile-count]})]
+    (body/make
+     {:id [:segmented-weighted-reduction-partial-body (:id plan) scheduled]
+      :parameters (partial-parameters plan problem scheduled)
+      :stable-reads (mapv body/stable-read (swr/ordered-input-ids plan))
+      :indices (vec (concat [(body/->IndexBinding 'query-head :group 0)
+                             (body/->IndexBinding 'query-token :group 1)
+                             (body/->IndexBinding 'history-tile :group 2)
+                             (body/->IndexBinding 'lane :lane 0)]
+                            (slot-indices problem scheduled slots)))
+      :masks (into [(lane-zero-mask)] (slot-masks problem slots))
+      :operations initial-ops
+      :schedule (assoc scheduled :subgroup-size subgroup-size :phase :partial)
+      :launch launch
+      :provenance {:operation-id (:id problem)
+                   :semantic-op :segmented-weighted-reduction
+                   :algebra-plan-id (:id plan)
+                   :lowering :scheduled-partial-kernel-body}
+      :attributes {:storage-kind :routed-paged-kv
+                   :route-kind (attention/route-kind (:route problem))
+                   :visibility-kind (attention/visibility-kind (:visibility problem))
+                   :history-tiles tile-count}})))
+
+(defn- merge-update-region
+  [slots]
+  (let [next-accs (mapv :next-id slots)]
+    [(compute 'merge-maximum-is-nan :predicate
+              (body/scalar-expression :isnan :predicate ['maximum-state]))
+     (compute 'tile-maximum-is-nan :predicate
+              (body/scalar-expression :isnan :predicate ['tile-maximum]))
+     (compute 'merge-state-is-nan :predicate
+              (or-expr 'merge-maximum-is-nan 'tile-maximum-is-nan))
+     (body/->IfRegion
+      'merge-state-is-nan
+      [(body/->Yield [(lit Double/NaN :float)
+                      (lit Double/NaN :float)
+                      (lit Double/NaN :float)])]
+      [(compute 'merged-maximum-valid :float
+                (expr :max :float 'maximum-state 'tile-maximum))
+       (compute 'old-state-weight-valid :float
+                (expr :exp :float
+                      (expr :- :float 'maximum-state 'merged-maximum-valid)))
+       (compute 'tile-state-weight-valid :float
+                (expr :exp :float
+                      (expr :- :float 'tile-maximum 'merged-maximum-valid)))
+       (body/->Yield ['merged-maximum-valid
+                      'old-state-weight-valid 'tile-state-weight-valid])]
+      [(body/value 'next-maximum :float)
+       (body/value 'old-weight :float)
+       (body/value 'new-weight :float)])
+     (compute 'next-denominator :float
+              (expr :+ :float
+                    (expr :* :float 'denominator-state 'old-weight)
+                    (expr :* :float 'tile-denominator 'new-weight)))
+     (vec
+      (mapcat
+       (fn [{:keys [binding-id next-id tile-value-id]}]
+         [(compute next-id :float
+                   (expr :+ :float
+                         (expr :* :float binding-id 'old-weight)
+                         (expr :* :float tile-value-id 'new-weight)))])
+       slots))
+     (body/->Yield
+      (vec (concat ['next-valid 'next-maximum 'next-denominator] next-accs)))]))
+
+(defn- merge-loop
+  [scheduled partial-ids slots]
+  (let [acc-bindings (mapv :binding-id slots)
+        acc-results (mapv :result-id slots)
+        state-bindings (vec (concat [(body/value 'merge-valid-state :predicate)
+                                     (body/value 'maximum-state :float)
+                                     (body/value 'denominator-state :float)]
+                                    (map #(body/value % :float) acc-bindings)))
+        state-initials (vec (concat [(true-expr)
+                                     (lit -3.402823466e38 :float)
+                                     (lit 0.0 :float)]
+                                    (repeat (count slots) (lit 0.0 :float))))
+        state-results (vec (concat [(body/value 'final-valid :predicate)
+                                    (body/value 'final-maximum :float)
+                                    (body/value 'final-denominator :float)]
+                                   (map #(body/value % :float) acc-results)))
+        tile-loads
+        (flatten-operations
+         (concat
+          [(load-value 'tile-valid-int :int (:valid partial-ids)
+                       ['query-token 'query-head 'merge-tile])
+           (load-value 'tile-maximum :float (:maximum partial-ids)
+                       ['query-token 'query-head 'merge-tile])
+           (load-value 'tile-denominator :float (:denominator partial-ids)
+                       ['query-token 'query-head 'merge-tile])
+           (compute 'tile-valid :predicate
+                    (expr :eq :predicate 'tile-valid-int (lit 1 :int)))
+           (compute 'next-valid :predicate
+                    (and-expr 'merge-valid-state 'tile-valid))]
+          (mapcat
+           (fn [{:keys [id mask-id tile-value-id]}]
+             [(load-value tile-value-id :float (:weighted-values partial-ids)
+                          ['query-token 'query-head 'merge-tile id]
+                          mask-id (lit 0.0 :float))])
+           slots)
+          (merge-update-region slots)))]
+    (body/->ForLoop
+     (body/value 'merge-tile :int) 0
+     (get-in scheduled [:membership-tiling :tile-count]) 1
+     (mapv body/->LoopArg state-bindings state-initials)
+     tile-loads state-results
+     {:uniform-iter-args #{'merge-valid-state 'maximum-state 'denominator-state}})))
+
+(defn lower-routed-paged-merge
+  "Merge private tile states in increasing tile order and materialize the semantic output."
+  [plan scheduled]
+  (let [plan (swr/validate! plan)
+        scheduled (schedule/validate! scheduled)
+        problem (attention/validate! (:source-operation plan))
+        _ (tiled-lowering-row! plan scheduled problem)
+        subgroup-size (:workgroup-size scheduled)
+        partial-ids (partial-buffer-ids plan)
+        slots (mapv #(assoc % :tile-value-id
+                            (symbol (str "tile-weighted-value-" (:slot %))))
+                    (component-slots scheduled))
+        launch (launch/spec {:workgroup-size [subgroup-size 1]
+                             :group-count [(:q-heads problem)
+                                           (get-in problem [:query :total-tokens])]})]
+    (body/make
+     {:id [:segmented-weighted-reduction-merge-body (:id plan) scheduled]
+      :parameters (merge-parameters plan problem scheduled)
+      :stable-reads (mapv (comp body/stable-read :id)
+                          (partial-buffer-specs plan scheduled))
+      :indices (vec (concat [(body/->IndexBinding 'query-head :group 0)
+                             (body/->IndexBinding 'query-token :group 1)
+                             (body/->IndexBinding 'lane :lane 0)]
+                            (slot-indices problem scheduled slots)))
+      :masks (slot-masks problem slots)
+      :operations (flatten-operations
+                   [(merge-loop scheduled partial-ids slots)
+                    (output-operations problem slots)])
+      :schedule (assoc scheduled :subgroup-size subgroup-size :phase :merge)
+      :launch launch
+      :provenance {:operation-id (:id problem)
+                   :semantic-op :segmented-weighted-reduction
+                   :algebra-plan-id (:id plan)
+                   :lowering :scheduled-merge-kernel-body}
+      :attributes {:storage-kind :private-online-state
+                   :merge-kind (get-in scheduled [:state :merge :kind])
+                   :merge-order (get-in scheduled [:state :merge :order])
+                   :history-tiles (get-in scheduled [:membership-tiling :tile-count])}})))

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_schedule.clj
@@ -8,15 +8,65 @@
   [reason & [data]]
   (merge {:ok false :reason reason} data))
 
-(defn plan-subgroup-online
+(defn- membership-capacity
+  [{:keys [membership storage source-operation]}]
+  (if (= :csr (:visibility-kind membership))
+    (get-in source-operation [:visibility :key-index-capacity])
+    (let [page-size (:page-size storage)]
+      (* page-size
+         (case (:route-kind storage)
+           :dense-paged (get-in storage [:route-shape :pages-per-sequence])
+           :csr-paged (get-in storage [:route-shape :page-index-capacity]))))))
+
+(defn- schedule-value
+  [plan subgroup-size membership-tiling strategy]
+  (let [{:keys [membership storage score value accumulator-dtype]} plan
+        components (:components value)]
+    (schedule/make
+     {:strategy strategy
+      :workgroup-size (long subgroup-size)
+      :segment-mapping (if (= :subgroup-online-tiled-history strategy)
+                         {:partial :one-workgroup-per-segment-tile
+                          :merge :one-workgroup-per-segment}
+                         :one-workgroup-per-segment)
+      :membership-traversal (case (:visibility-kind membership)
+                              :interval :contiguous-interval
+                              :csr :csr-row)
+      :score-reduction {:kind :subgroup :width (long subgroup-size)
+                        :axis (get-in score [:axis :name])}
+      :membership-tiling membership-tiling
+      :value-mapping {:kind :lane-strided
+                      :components components
+                      :components-per-lane
+                      (quot (+ components (dec (long subgroup-size)))
+                            (long subgroup-size))}
+      :state (schedule/online-state)
+      :numerical-mode {:score-accumulate accumulator-dtype
+                       :state-accumulate accumulator-dtype
+                       ;; The OpenCL subgroup builtin fixes neither its association tree nor
+                       ;; bitwise result. A target with an explicit shuffle tree may choose a
+                       ;; stricter schedule later; this row records exactly what it emits.
+                       :dot-order :implementation-defined
+                       ;; Tiling is a legal floating reduction reassociation, but not bitwise the
+                       ;; same association as the sequential online update. Record the exact order
+                       ;; so differential tests and future strict modes can distinguish them.
+                       :online-state-order
+                       (if (= :subgroup-online-tiled-history strategy)
+                         :increasing-members-within-tile-then-increasing-tile-left-fold
+                         :increasing-membership)
+                       :online-rescale? true}
+      :attributes {:storage-kind (:kind storage)
+                   :route-kind (:route-kind storage)
+                   :visibility-kind (:visibility-kind membership)}})))
+
+(defn- plan-subgroup-online*
   "Plan one subgroup per segment with one shared score and lane-strided value accumulators.
 
    The first executable storage rows are dense or CSR paged FP16 KV with either contiguous
    interval or explicitly indexed CSR membership. Those are legality constraints of this
    schedule, not new semantic operation kinds."
-  ([plan] (plan-subgroup-online plan nil))
-  ([plan desc]
-   (let [{:keys [membership storage score value operands output accumulator-dtype] :as plan}
+  [plan desc strategy tile-size]
+   (let [{:keys [membership storage value operands output accumulator-dtype] :as plan}
          (swr/validate! plan)
          subgroup-size (hardware/preferred-subgroup-size desc)
          max-workgroup-size (hardware/maximum-workgroup-size desc)
@@ -92,32 +142,36 @@
                  :components-per-lane
                  (quot (+ components (dec (long subgroup-size))) (long subgroup-size))})
 
+       (and (= :subgroup-online-tiled-history strategy)
+            (not (and (pos-int? tile-size) (<= tile-size Integer/MAX_VALUE))))
+       (decline :score-reuse-invalid-history-tile-size {:tile-size tile-size})
+
        :else
-       {:ok true
-        :schedule
-        (schedule/make
-         {:strategy :subgroup-online-score-reuse
-          :workgroup-size (long subgroup-size)
-          :segment-mapping :one-workgroup-per-segment
-          :membership-traversal (case (:visibility-kind membership)
-                                  :interval :contiguous-interval
-                                  :csr :csr-row)
-          :score-reduction {:kind :subgroup :width (long subgroup-size)
-                            :axis (get-in score [:axis :name])}
-          :value-mapping {:kind :lane-strided
-                          :components components
-                          :components-per-lane
-                          (quot (+ components (dec (long subgroup-size)))
-                                (long subgroup-size))}
-          :state {:kind :online-normalized-weighted-sum
-                  :components [:maximum :denominator :weighted-values]}
-          :numerical-mode {:score-accumulate accumulator-dtype
-                           :state-accumulate accumulator-dtype
-                           ;; The OpenCL subgroup builtin fixes neither its association tree nor
-                           ;; bitwise result. A target with an explicit shuffle tree may choose a
-                           ;; stricter schedule later; this row records exactly what it emits.
-                           :dot-order :implementation-defined
-                           :online-rescale? true}
-          :attributes {:storage-kind (:kind storage)
-                       :route-kind (:route-kind storage)
-                       :visibility-kind (:visibility-kind membership)}})}))))
+       (let [capacity (membership-capacity plan)
+             membership-tiling
+             (if (= :subgroup-online-tiled-history strategy)
+               {:kind :static-contiguous-tiles
+                :tile-size tile-size
+                :tile-count (quot (+ capacity (dec tile-size)) tile-size)
+                :membership-capacity capacity
+                :merge-order :increasing-membership-tile}
+               {:kind :sequential})]
+         {:ok true
+          :schedule (schedule-value plan subgroup-size membership-tiling strategy)}))))
+
+(defn plan-subgroup-online
+  "Plan one subgroup per segment with one shared score and lane-strided value accumulators."
+  ([plan] (plan-subgroup-online plan nil))
+  ([plan desc]
+   (plan-subgroup-online* plan desc :subgroup-online-score-reuse nil)))
+
+(defn plan-subgroup-online-tiled
+  "Plan independent, statically bounded history tiles followed by an ordered online-state merge.
+
+  The capacity is a compile-time storage/membership bound. Runtime visibility still clips every
+  tile, while the tile count makes graph-owned partial storage and launch geometry explicit."
+  ([plan] (plan-subgroup-online-tiled plan nil))
+  ([plan desc]
+   (plan-subgroup-online*
+    plan desc :subgroup-online-tiled-history
+    (or (:segmented-weighted-reduction-history-tile-size desc) 256))))

--- a/test/raster/compiler/passes/parallel/attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/attention_route_test.clj
@@ -1,5 +1,6 @@
 (ns raster.compiler.passes.parallel.attention-route-test
   (:require [clojure.string :as str]
+            [clojure.set :as set]
             [clojure.java.shell :as shell]
             [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.attention :as attention-emit]
@@ -148,6 +149,106 @@
           (is (not (str/includes? source "rstr_value_component_16")))
           (is (zero? (:exit result)) (:err result)))))))
 
+(deftest tiled-history-is-a-two-stage-kernel-graph-with-a-stable-external-abi
+  (let [desc (assoc intel-desc
+                    :segmented-weighted-reduction-schedule
+                    :subgroup-online-tiled-history
+                    :segmented-weighted-reduction-history-tile-size 2)
+        reference (route/route!
+                   (problem) (assoc intel-desc
+                                    :segmented-weighted-reduction-schedule :reference))
+        {:keys [strategy reference? artifact graph executable schedule]}
+        (route/route! (problem) desc)
+        other-graph (:graph (route/route! (problem :id :other-attention) desc))
+        scheduled (get-in graph [:attributes :segmented-weighted-reduction-schedule])
+        [partial merge] (:nodes graph)
+        partial-body (get-in partial [:operation :attributes :kernel-body])
+        merge-body (get-in merge [:operation :attributes :kernel-body])]
+    (is (= :routed-paged-subgroup-online-tiled-history strategy))
+    (is (false? reference?))
+    (is (nil? artifact) "a multi-kernel executable is not disguised as one artifact")
+    (is (identical? graph executable))
+    (is (= (kexec/common-view (:graph reference)) (kexec/common-view graph)))
+    (is (= {:kind :static-contiguous-tiles :tile-size 2 :tile-count 3
+            :membership-capacity 6 :merge-order :increasing-membership-tile}
+           (:membership-tiling scheduled)))
+    (is (= {:kind :maximum-rescale-sum
+            :order :increasing-membership-tile
+            :nan-policy :propagate :empty-policy :identity}
+           (get-in scheduled [:state :merge])))
+    (is (= :increasing-members-within-tile-then-increasing-tile-left-fold
+           (get-in scheduled [:numerical-mode :online-state-order])))
+    (is (= 2 (count (:nodes graph))))
+    (is (= 4 (count (:temporaries graph))))
+    (is (= (mapv :id (:temporaries graph))
+           (get-in graph [:attributes :materialized-intermediates])))
+    (is (empty? (set/intersection
+                 (set (map :id (:temporaries graph)))
+                 (set (map :id (:temporaries other-graph)))))
+        "linked tiled reductions retain disjoint graph-private identities")
+    (is (= #{:partial-valid :partial-maximum :partial-denominator
+             :partial-weighted-values}
+           (set (map :role (get-in graph [:attributes :private-online-state])))))
+    (is (= [4 4 3] (get-in partial [:operation :launch :group-count])))
+    (is (= [4 4] (get-in merge [:operation :launch :group-count])))
+    (is (= [(:id partial)] (:dependencies merge)))
+    (is (= {:stages
+            [{:id (:id partial) :workgroup-size [16 1 1] :group-count [4 4 3]}
+             {:id (:id merge) :workgroup-size [16 1] :group-count [4 4]}]}
+           schedule))
+    (is (kbody/kernel-body? partial-body))
+    (is (kbody/kernel-body? merge-body))
+    (is (= :scheduled-partial-kernel-body (get-in partial-body [:provenance :lowering])))
+    (is (= :scheduled-merge-kernel-body (get-in merge-body [:provenance :lowering])))
+    (is (= :partial (get-in partial-body [:schedule :phase])))
+    (is (= :merge (get-in merge-body [:schedule :phase])))
+    (is (every? #(str/includes? (get-in % [:operation :source])
+                                "intel_reqd_sub_group_size(16)")
+                [partial merge])
+        "lane-mapped merge kernels retain their required subgroup geometry without a collective")
+    (is (str/includes? (get-in partial [:operation :source])
+                       "rstr_tile_membership_begin"))
+    (is (str/includes? (get-in merge [:operation :source])
+                       "for (int rstr_merge_tile = 0; rstr_merge_tile < 3"))
+    (let [nvidia (route/route
+                  (problem)
+                  {:device-type :gpu :vendor "NVIDIA" :subgroup-size 32
+                   :max-workgroup-size 1024
+                   :segmented-weighted-reduction-schedule
+                   :subgroup-online-tiled-history})]
+      (is (nil? (:strategy nvidia)))
+      (is (= :routed-paged-subgroup-online-tiled-history
+             (get-in nvidia [:declines 0 :leaf])))
+      (is (= :score-reuse-requires-intel-subgroup-dialect
+             (get-in nvidia [:declines 0 :reason]))))
+    (is (= :score-reuse-invalid-history-tile-size
+           (get-in (route/route
+                    (problem)
+                    (assoc desc :segmented-weighted-reduction-history-tile-size 0))
+                   [:declines 0 :reason])))))
+
+(deftest tiled-history-sources-cover-route-and-visibility-products
+  (let [clang? (zero? (:exit (shell/sh "sh" "-c" "command -v clang")))
+        desc (assoc intel-desc
+                    :segmented-weighted-reduction-schedule
+                    :subgroup-online-tiled-history
+                    :segmented-weighted-reduction-history-tile-size 2)]
+    (if-not clang?
+      (is true "clang unavailable")
+      (doseq [[physical-route visibility]
+              [[(dense-route) (attention/visibility)]
+               [(dense-route) (csr-visibility)]
+               [(csr-route) (attention/visibility)]
+               [(csr-route) (csr-visibility)]]
+              node (get-in (route/route!
+                            (problem :route physical-route :visibility visibility)
+                            desc)
+                           [:graph :nodes])]
+        (let [source (get-in node [:operation :source])
+              result (shell/sh "clang" "-x" "cl" "-cl-std=CL2.0"
+                               "-fsyntax-only" "-" :in source)]
+          (is (zero? (:exit result)) (:err result)))))))
+
 (deftest cooperative-schedule-is-validated-and-target-legality-is-explicit
   (let [desc {:device-type :gpu :vendor "Intel"
               :subgroup-size 16 :max-workgroup-size 256}
@@ -160,7 +261,9 @@
     (is (= {:kind :subgroup :width 16 :axis :qk-component}
            (:score-reduction schedule)))
     (is (= {:score-accumulate :float :state-accumulate :float
-            :dot-order :implementation-defined :online-rescale? true}
+            :dot-order :implementation-defined
+            :online-state-order :increasing-membership
+            :online-rescale? true}
            (:numerical-mode schedule)))
     (is (= :segmented-weighted-reduction-value-mapping
            (try
@@ -172,6 +275,18 @@
              (swr-schedule/validate!
               (assoc schedule :membership-traversal :sequential))
              (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+    (is (= :segmented-weighted-reduction-partial-schedule
+           (try
+             (swr-body/partial-buffer-specs plan schedule)
+             (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+    (let [tiled (:schedule (schedule-pass/plan-subgroup-online-tiled
+                            plan (assoc desc
+                                        :segmented-weighted-reduction-history-tile-size 2)))]
+      (is (= :segmented-weighted-reduction-membership-tiling
+             (try
+               (swr-schedule/validate!
+                (assoc-in tiled [:membership-tiling :tile-count] 2))
+               (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))
     (is (= :attention-cooperative-schedule-plan-mismatch
            (try
              (attention-emit/emit-fp16-cooperative

--- a/test/raster/gpu/attention_device_test.clj
+++ b/test/raster/gpu/attention_device_test.clj
@@ -243,8 +243,10 @@
   [device-id route-kind visibility-kind policy expected-strategy]
   (let [{:keys [problem q k v q-offsets q-positions] :as test-case}
         (make-case route-kind visibility-kind)
-        descriptor (assoc (hardware/descriptor-for device-id)
-                          :segmented-weighted-reduction-schedule policy)
+        descriptor (cond-> (assoc (hardware/descriptor-for device-id)
+                                  :segmented-weighted-reduction-schedule policy)
+                     (= :subgroup-online-tiled-history policy)
+                     (assoc :segmented-weighted-reduction-history-tile-size 2))
         routed (route/route! problem descriptor)
         _ (is (= expected-strategy (:strategy routed))
               "the device test must execute the intended attention leaf")
@@ -319,7 +321,9 @@
     (do
       (run-case :ze:0 :dense-paged :interval :reference :fp16-reference)
       (run-case :ze:0 :dense-paged :interval :subgroup-score-reuse
-                :routed-paged-subgroup-online-score-reuse))))
+                :routed-paged-subgroup-online-score-reuse)
+      (run-case :ze:0 :dense-paged :interval :subgroup-online-tiled-history
+                :routed-paged-subgroup-online-tiled-history))))
 
 (deftest level-zero-fp32-query-and-output-with-fp16-kv-matches-reference
   (if-not @gp/gpu-available?
@@ -344,3 +348,15 @@
     (device-probe/opencl-skip! "logical CSR visibility over CSR pages" :fp16)
     (run-case :ocl:0 :csr-paged :csr :auto
               :routed-paged-subgroup-online-score-reuse)))
+
+(deftest opencl-tiled-history-route-and-visibility-products-match-reference
+  (if-not @device-probe/opencl-fp16-available?
+    (device-probe/opencl-skip! "two-stage tiled routed attention" :fp16)
+    (doseq [[route-kind visibility-kind]
+            [[:dense-paged :interval]
+             [:dense-paged :csr]
+             [:csr-paged :interval]
+             [:csr-paged :csr]]]
+      (run-case :ocl:0 route-kind visibility-kind
+                :subgroup-online-tiled-history
+                :routed-paged-subgroup-online-tiled-history))))


### PR DESCRIPTION
## Summary

- extend the target-neutral segmented weighted-reduction schedule with bounded membership tiling, explicit mergeable online state, and honest floating association
- lower routed paged reductions into partial and deterministic merge/finalize KernelBodies connected by typed graph-private temporaries
- expose an opt-in two-kernel history schedule without changing AttentionProblem or its external ABI; retain automatic short-history routing and target decline honesty
- require subgroup width for lane-mapped bodies even when the merge stage contains no collective

## Verification

- fresh focused run: 42 tests, 319 assertions, 0 failures/errors
- clang validates partial and merge OpenCL for dense/CSR routing crossed with interval/CSR visibility
- real Intel GPU differential coverage passes through both Level Zero and OpenCL, including multi-tile merge and empty lanes
- final full suite was started and passed the changed compiler/routing sections, then intentionally stopped under host memory pressure; CI is the repository-wide gate