### PR TITLE
Lower KernelBody subgroups across GPU dialects

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,9 +101,9 @@ jobs:
             -m raster.compiler.backend.gpu.kernel-body-compile-fixtures
             gpu-compile-gates
       - persist_to_workspace:
-          root: ~/repo
+          root: ~/
           paths:
-            - gpu-compile-gates
+            - repo/gpu-compile-gates
 
   cuda-compile-gate:
     executor: cuda-compiler

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,18 @@ executors:
     environment:
       JAVA_TOOL_OPTIONS: "-Xmx3200m"
 
+  cuda-compiler:
+    docker:
+      - image: nvidia/cuda:12.8.2-devel-ubuntu24.04
+    working_directory: ~/repo
+    resource_class: large
+
+  hip-compiler:
+    docker:
+      - image: rocm/dev-ubuntu-24.04:6.4.3
+    working_directory: ~/repo
+    resource_class: large
+
 jobs:
   setup:
     executor: clojure-java24
@@ -75,6 +87,53 @@ jobs:
       - run:
           name: Run tests
           command: clojure -X:test
+
+  emit-gpu-compile-fixtures:
+    executor: clojure-java24
+    steps:
+      - attach_workspace:
+          at: ~/
+      - install-clojure
+      - run:
+          name: Emit scheduled KernelBody CUDA and HIP sources
+          command: >-
+            clojure -M:gpu-compile-fixtures
+            -m raster.compiler.backend.gpu.kernel-body-compile-fixtures
+            gpu-compile-gates
+      - persist_to_workspace:
+          root: ~/repo
+          paths:
+            - gpu-compile-gates
+
+  cuda-compile-gate:
+    executor: cuda-compiler
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Require the CUDA compiler
+          command: nvcc --version
+      - run:
+          name: Compile scheduled kernels to PTX without a GPU
+          command: |
+            for source in gpu-compile-gates/cuda/*.cu; do
+              nvcc -ptx -arch=sm_80 -o "${source}.ptx" "${source}"
+            done
+
+  hip-compile-gate:
+    executor: hip-compiler
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Require the HIP compiler
+          command: hipcc --version
+      - run:
+          name: Compile scheduled kernels to RDNA3 code objects without a GPU
+          command: |
+            for source in gpu-compile-gates/hip/*.hip; do
+              hipcc --offload-arch=gfx1100 --genco -o "${source}.hsaco" "${source}"
+            done
 
   deploy:
     executor: clojure-java24
@@ -130,6 +189,15 @@ workflows:
       - test:
           requires:
             - build
+      - emit-gpu-compile-fixtures:
+          requires:
+            - build
+      - cuda-compile-gate:
+          requires:
+            - emit-gpu-compile-fixtures
+      - hip-compile-gate:
+          requires:
+            - emit-gpu-compile-fixtures
       - deploy:
           context:
             - clojars-deploy
@@ -138,6 +206,8 @@ workflows:
               only: main
           requires:
             - test
+            - cuda-compile-gate
+            - hip-compile-gate
       - release:
           context:
             - github-token

--- a/deps.edn
+++ b/deps.edn
@@ -42,6 +42,11 @@
         :jvm-opts ["-Dclojure.server.repl={:port,5555,:accept,clojure.core.server/repl}"
                    "--enable-native-access=ALL-UNNAMED"
                    "--add-modules=jdk.incubator.vector"]}
+  :gpu-compile-fixtures
+  {:extra-paths ["test"]
+   :jvm-opts ["--enable-native-access=ALL-UNNAMED"
+              "--add-modules=jdk.incubator.vector"
+              "-Xmx1200m"]}
   :repl {:extra-paths ["test" "dev" "notebooks" "examples"]
          :extra-deps {nrepl/nrepl {:mvn/version "1.3.0"}
                       criterium/criterium {:mvn/version "0.4.6"}

--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -130,10 +130,15 @@ KernelBody per segment/tile, and deterministically merges the explicit maximum/d
 value state in increasing tile order. The four typed partial buffers are operation-derived,
 graph-private temporaries; the source operation and external ABI are unchanged. This two-kernel
 schedule is opt-in until measured selection can account for dynamic history length and temporary
-traffic. The next production work is to lower subgroup collectives through portable OpenCL, CUDA
-and HIP target dialects. Verified local allocation,
-barriers and asynchronous copies can subsequently collapse a multi-kernel tiled graph into a
-FlashAttention-like single kernel without changing the semantic plan or external ABI.
+traffic. Scalar/control KernelBody now has one C-family lowering core with thin portable OpenCL,
+CUDA and HIP spelling descriptors. The same scheduled cooperative and tiled-history bodies retain
+one ordered ABI while OpenCL uses subgroup builtins and CUDA/HIP select explicit shuffle-down trees;
+the emitted artifacts record that target association. CUDA is compiled to PTX and HIP to an RDNA3
+code object in mandatory hardware-free CI jobs, while real Intel execution remains the numerical
+oracle. CUDA/HIP runtime registration, launch and on-device numerical coverage remain deliberately
+separate from source legality. Verified local allocation, barriers and asynchronous copies can
+subsequently collapse a multi-kernel tiled graph into a FlashAttention-like single kernel without
+changing the semantic plan or external ABI.
 
 ### 2.3 Executable steps and resident artifact values compose
 

--- a/src/raster/compiler/backend/gpu/attention.clj
+++ b/src/raster/compiler/backend/gpu/attention.clj
@@ -4,9 +4,10 @@
    The direct one-work-item/component leaf remains the executable semantic oracle.  A separately
    validated SegmentedWeightedReductionSchedule either emits one subgroup/query-head or partitions
    bounded membership into partial online states and a deterministic merge graph. Both schedules
-   share each QK score across lane-strided value accumulators without changing the semantic plan,
-   ordered external ABI, storage ownership or graph effects."
-  (:require [raster.compiler.backend.gpu.kernel-body-opencl :as body-opencl]
+  share each QK score across lane-strided value accumulators without changing the semantic plan,
+  ordered external ABI, storage ownership or graph effects."
+  (:require [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
+            [raster.compiler.backend.gpu.kernel-body-opencl :as body-opencl]
             [raster.compiler.ir.attention :as attention]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
@@ -430,45 +431,52 @@
 
    The artifact preserves the reference leaf's complete ordered ABI and logical effects.  Only
    its target-neutral SegmentedWeightedReductionSchedule, launch mapping and target body differ.
-   The scheduled body is independently verified before this target-only lowering selects OpenCL
-   parameter spelling and Intel's required-subgroup attribute."
-  [plan schedule]
-  (let [[plan schedule {:keys [output route] :as problem}]
-        (cooperative-plan! plan schedule)
-        name (kernel-name problem schedule)
-        inputs (ordered-inputs plan)
-        arguments (conj inputs output)
-        kernel-body (swr-body/lower-routed-paged plan schedule)
-        base-abi (ordered-abi problem)
-        parameter-names (into {} (map (juxt :name :c-name)) base-abi)
-        abi (body-abi/project-contracts base-abi kernel-body)]
-    (kart/make
-     {:kernel-name name
-      :source (body-opencl/emit-scalar-kernel
-               name kernel-body
-               {:parameter-names parameter-names :subgroup-attribute :intel})
-      :abi abi
-      :arguments arguments
-      :launch (:launch kernel-body)
-      :effects {:kind :attention :reads inputs :writes [output]}
-      :provenance {:operation-id (:id problem) :semantic-op :attention
-                   :algebra-plan-id (:id plan)
-                   :lowering :subgroup-online-score-reuse}
-      :attributes {:strategy :routed-paged-subgroup-online-score-reuse
-                   :optimization-tier :subgroup
-                   :algebra :segmented-weighted-reduction
-                   :algebra-key (swr/algebra-key plan)
-                   :segmented-weighted-reduction-schedule schedule
-                   :storage-dtype :half :q-dtype (:q-dtype problem)
-                   :output-dtype (:output-dtype problem) :accumulator-dtype :float
-                   :route-kind (attention/route-kind route)
-                   :visibility-kind (attention/visibility-kind (:visibility problem))
-                   :k-layout (:k-layout problem) :v-layout (:v-layout problem)
-                   :visibility (:visibility problem)
-                   :layout (attention/layouts problem)
-                   :kernel-body kernel-body
-                   :materialized-intermediates []
-                   :complexity :query-head-token-dot-plus-value}})))
+   The scheduled body is independently verified before target-only lowering selects a C-family
+   spelling. The two-argument form retains the production Intel OpenCL route."
+  ([plan schedule]
+   (emit-fp16-cooperative plan schedule :opencl-intel))
+  ([plan schedule target-dialect]
+   (let [dialect (c-dialect/resolve! target-dialect)
+         [plan schedule {:keys [output route] :as problem}]
+         (cooperative-plan! plan schedule)
+         name (kernel-name problem schedule)
+         inputs (ordered-inputs plan)
+         arguments (conj inputs output)
+         kernel-body (swr-body/lower-routed-paged plan schedule)
+         base-abi (ordered-abi problem)
+         parameter-names (into {} (map (juxt :name :c-name)) base-abi)
+         abi (body-abi/project-contracts base-abi kernel-body)]
+     (kart/make
+      {:kernel-name name
+       :target (c-dialect/target dialect)
+       :source (body-opencl/emit-scalar-kernel
+                name kernel-body
+                {:parameter-names parameter-names :target-dialect target-dialect})
+       :abi abi
+       :arguments arguments
+       :launch (:launch kernel-body)
+       :effects {:kind :attention :reads inputs :writes [output]}
+       :provenance {:operation-id (:id problem) :semantic-op :attention
+                    :algebra-plan-id (:id plan)
+                    :lowering :subgroup-online-score-reuse}
+       :attributes {:strategy :routed-paged-subgroup-online-score-reuse
+                    :optimization-tier :subgroup
+                    :algebra :segmented-weighted-reduction
+                    :algebra-key (swr/algebra-key plan)
+                    :segmented-weighted-reduction-schedule schedule
+                    :storage-dtype :half :q-dtype (:q-dtype problem)
+                    :output-dtype (:output-dtype problem) :accumulator-dtype :float
+                    :route-kind (attention/route-kind route)
+                    :visibility-kind (attention/visibility-kind (:visibility problem))
+                    :k-layout (:k-layout problem) :v-layout (:v-layout problem)
+                    :visibility (:visibility problem)
+                    :layout (attention/layouts problem)
+                    :kernel-body kernel-body
+                    :target-dialect target-dialect
+                    :target-collective-association
+                    (c-dialect/collective-association dialect)
+                    :materialized-intermediates []
+                    :complexity :query-head-token-dot-plus-value}}))))
 
 (def ^:private partial-c-names
   {:partial-valid "partial_valid"
@@ -495,14 +503,16 @@
     (body-abi/project-contracts (conj private-inputs output-slot) kernel-body)))
 
 (defn- emitted-body-artifact
-  [problem plan scheduled phase kernel-body abi arguments reads writes]
-  (let [entry-name (str (kernel-name problem [scheduled phase]) "_" (name phase))
+  [problem plan scheduled phase kernel-body abi arguments reads writes target-dialect]
+  (let [dialect (c-dialect/resolve! target-dialect)
+        entry-name (str (kernel-name problem [scheduled phase]) "_" (name phase))
         parameter-names (into {} (map (juxt :name :c-name)) abi)]
     (kart/make
      {:kernel-name entry-name
+      :target (c-dialect/target dialect)
       :source (body-opencl/emit-scalar-kernel
                entry-name kernel-body
-               {:parameter-names parameter-names :subgroup-attribute :intel})
+               {:parameter-names parameter-names :target-dialect target-dialect})
       :abi abi
       :arguments arguments
       :launch (:launch kernel-body)
@@ -515,6 +525,9 @@
       :attributes {:strategy :routed-paged-subgroup-online-tiled-history
                    :optimization-tier :subgroup-tiled
                    :phase phase
+                   :target-dialect target-dialect
+                   :target-collective-association
+                   (c-dialect/collective-association dialect)
                    :segmented-weighted-reduction-schedule scheduled
                    :kernel-body kernel-body}})))
 
@@ -524,77 +537,79 @@
   The external ABI is exactly the original routed attention ABI. Partial states are typed graph
   temporaries, so allocation, dependencies and ownership remain compiler-managed and invisible
   to cache/page scheduling above this layer."
-  [plan scheduled]
-  (let [[plan scheduled {:keys [output id route] :as problem}]
-        (cooperative-plan! plan scheduled)
-        _ (when-not (swr-schedule/tiled? scheduled)
-            (throw (ex-info "tiled-history emission requires a tiled schedule"
-                            {:reason :attention-tiled-history-schedule
-                             :schedule scheduled})))
-        inputs (ordered-inputs plan)
-        partial-specs (swr-body/partial-buffer-specs plan scheduled)
-        partial-ids (mapv :id partial-specs)
-        partial-body (swr-body/lower-routed-paged-partial plan scheduled)
-        merge-body (swr-body/lower-routed-paged-merge plan scheduled)
-        partial-arguments (into inputs partial-ids)
-        merge-arguments (conj partial-ids output)
-        partial-artifact (emitted-body-artifact
-                          problem plan scheduled :partial partial-body
-                          (partial-abi problem partial-specs partial-body) partial-arguments
-                          inputs partial-ids)
-        merge-artifact (emitted-body-artifact
-                        problem plan scheduled :merge merge-body
-                        (merge-abi problem partial-specs merge-body) merge-arguments
-                        partial-ids [output])
-        specs (attention/buffer-specs problem)
-        graph-buffer (fn [buffer-id]
-                       (let [{:keys [dtype elements role]} (get specs buffer-id)]
-                         (kgraph/buffer buffer-id dtype elements :device role)))
-        partial-node [:attention id :tiled-history :partial]
-        merge-node [:attention id :tiled-history :merge]
-        external-abi (ordered-abi problem)]
-    (kgraph/make
-     {:inputs (mapv graph-buffer inputs)
-      :outputs [(graph-buffer output)]
-      :temporaries (mapv (fn [{:keys [id dtype elements]}]
-                           (kgraph/buffer id dtype elements :device :temporary))
-                         partial-specs)
-      :abi external-abi
-      :arguments (conj inputs output)
-      :nodes [(kgraph/->ScheduledKernel
-               partial-node partial-artifact
-               (vec (concat (map #(kgraph/->ValueUse % :read) inputs)
-                            (map #(kgraph/->ValueUse % :write) partial-ids)))
-               [])
-              (kgraph/->ScheduledKernel
-               merge-node merge-artifact
-               (vec (concat (map #(kgraph/->ValueUse % :read) partial-ids)
-                            [(kgraph/->ValueUse output :write)]))
-               [partial-node])]
-      :effects {:kind :attention :logical-visibility true :ordered-page-routing true}
-      :provenance {:operation-id id :semantic-op :attention
-                   :algebra-plan-id (:id plan)
-                   :lowering :subgroup-online-tiled-history}
-      :attributes {:strategy :routed-paged-subgroup-online-tiled-history
-                   :reference? false
-                   :optimization-tier :subgroup-tiled
-                   :algebra :segmented-weighted-reduction
-                   :algebra-key (swr/algebra-key plan)
-                   :storage-dtype :half
-                   :q-dtype (:q-dtype problem)
-                   :output-dtype (:output-dtype problem)
-                   :accumulator-dtype :float
-                   :route-kind (attention/route-kind route)
-                   :visibility-kind (attention/visibility-kind (:visibility problem))
-                   :k-layout (:k-layout problem)
-                   :v-layout (:v-layout problem)
-                   :visibility (:visibility problem)
-                   :layout (attention/layouts problem)
-                   :segmented-weighted-reduction-schedule scheduled
-                   :materialized-intermediates partial-ids
-                   :complexity :parallel-history-tiles-plus-online-state-merge
-                   :private-online-state (mapv #(select-keys % [:id :dtype :shape :role])
-                                               partial-specs)}})))
+  ([plan scheduled]
+   (emit-fp16-tiled-history plan scheduled :opencl-intel))
+  ([plan scheduled target-dialect]
+   (let [[plan scheduled {:keys [output id route] :as problem}]
+         (cooperative-plan! plan scheduled)
+         _ (when-not (swr-schedule/tiled? scheduled)
+             (throw (ex-info "tiled-history emission requires a tiled schedule"
+                             {:reason :attention-tiled-history-schedule
+                              :schedule scheduled})))
+         inputs (ordered-inputs plan)
+         partial-specs (swr-body/partial-buffer-specs plan scheduled)
+         partial-ids (mapv :id partial-specs)
+         partial-body (swr-body/lower-routed-paged-partial plan scheduled)
+         merge-body (swr-body/lower-routed-paged-merge plan scheduled)
+         partial-arguments (into inputs partial-ids)
+         merge-arguments (conj partial-ids output)
+         partial-artifact (emitted-body-artifact
+                           problem plan scheduled :partial partial-body
+                           (partial-abi problem partial-specs partial-body) partial-arguments
+                           inputs partial-ids target-dialect)
+         merge-artifact (emitted-body-artifact
+                         problem plan scheduled :merge merge-body
+                         (merge-abi problem partial-specs merge-body) merge-arguments
+                         partial-ids [output] target-dialect)
+         specs (attention/buffer-specs problem)
+         graph-buffer (fn [buffer-id]
+                        (let [{:keys [dtype elements role]} (get specs buffer-id)]
+                          (kgraph/buffer buffer-id dtype elements :device role)))
+         partial-node [:attention id :tiled-history :partial]
+         merge-node [:attention id :tiled-history :merge]
+         external-abi (ordered-abi problem)]
+     (kgraph/make
+      {:inputs (mapv graph-buffer inputs)
+       :outputs [(graph-buffer output)]
+       :temporaries (mapv (fn [{:keys [id dtype elements]}]
+                            (kgraph/buffer id dtype elements :device :temporary))
+                          partial-specs)
+       :abi external-abi
+       :arguments (conj inputs output)
+       :nodes [(kgraph/->ScheduledKernel
+                partial-node partial-artifact
+                (vec (concat (map #(kgraph/->ValueUse % :read) inputs)
+                             (map #(kgraph/->ValueUse % :write) partial-ids)))
+                [])
+               (kgraph/->ScheduledKernel
+                merge-node merge-artifact
+                (vec (concat (map #(kgraph/->ValueUse % :read) partial-ids)
+                             [(kgraph/->ValueUse output :write)]))
+                [partial-node])]
+       :effects {:kind :attention :logical-visibility true :ordered-page-routing true}
+       :provenance {:operation-id id :semantic-op :attention
+                    :algebra-plan-id (:id plan)
+                    :lowering :subgroup-online-tiled-history}
+       :attributes {:strategy :routed-paged-subgroup-online-tiled-history
+                    :reference? false
+                    :optimization-tier :subgroup-tiled
+                    :algebra :segmented-weighted-reduction
+                    :algebra-key (swr/algebra-key plan)
+                    :storage-dtype :half
+                    :q-dtype (:q-dtype problem)
+                    :output-dtype (:output-dtype problem)
+                    :accumulator-dtype :float
+                    :route-kind (attention/route-kind route)
+                    :visibility-kind (attention/visibility-kind (:visibility problem))
+                    :k-layout (:k-layout problem)
+                    :v-layout (:v-layout problem)
+                    :visibility (:visibility problem)
+                    :layout (attention/layouts problem)
+                    :segmented-weighted-reduction-schedule scheduled
+                    :materialized-intermediates partial-ids
+                    :complexity :parallel-history-tiles-plus-online-state-merge
+                    :private-online-state (mapv #(select-keys % [:id :dtype :shape :role])
+                                                partial-specs)}}))))
 
 (defn kernel-graph
   "Wrap either verified attention leaf in an explicit one-node scheduled graph."

--- a/src/raster/compiler/backend/gpu/kernel_body_c_dialect.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_c_dialect.clj
@@ -1,0 +1,138 @@
+(ns raster.compiler.backend.gpu.kernel-body-c-dialect
+  "Thin target spellings for the scalar/control KernelBody C-family emitter.
+
+  A dialect never selects a schedule. It only spells verified storage types, hardware indices,
+  entry points and subgroup shuffles for one target language. CUDA and HIP intentionally share
+  the same structural lowering while retaining distinct collective intrinsics and module targets."
+  (:require [raster.compiler.core.dtype :as dtype]))
+
+(def ^:private dialects
+  {:opencl-intel {:id :opencl-intel :target :opencl-c :family :opencl
+                  :association :implementation-defined}
+   :opencl-portable {:id :opencl-portable :target :opencl-c :family :opencl
+                     :association :implementation-defined}
+   :cuda {:id :cuda :target :cuda-c :family :cuda
+          :association :explicit-shuffle-down-tree}
+   :hip {:id :hip :target :hip-cpp :family :hip
+         :association :explicit-shuffle-down-tree}})
+
+(defn resolve!
+  "Resolve and validate a target spelling descriptor."
+  [id]
+  (or (get dialects id)
+      (throw (ex-info "KernelBody C-family target dialect is unsupported"
+                      {:reason :kernel-body-c-target-dialect
+                       :dialect id :supported (set (keys dialects))}))))
+
+(defn target [dialect] (:target dialect))
+(defn family [dialect] (:family dialect))
+(defn collective-association [dialect] (:association dialect))
+(defn opencl? [dialect] (= :opencl (family dialect)))
+
+(defn type-name
+  [dialect type]
+  (if (= :predicate type)
+    "bool"
+    (let [type (dtype/canon type)]
+      (cond
+        (opencl? dialect) (dtype/ctype :opencl type)
+        (= :half type) "__half"
+        :else (dtype/ctype :c type)))))
+
+(defn unsigned-type-name
+  [dialect type]
+  (if (opencl? dialect)
+    ({:byte "uchar" :int "uint" :long "ulong"} (dtype/canon type))
+    ({:byte "uint8_t" :int "unsigned int" :long "unsigned long long"}
+     (dtype/canon type))))
+
+(defn parameter-declaration
+  [dialect parameter c-name]
+  (if (= :scalar (:kind parameter))
+    (str (type-name dialect (:dtype parameter)) " " c-name)
+    (do
+      (when-not (= :global (:memory-space parameter))
+        (throw (ex-info "C-family scalar lowering only supports global kernel storage"
+                        {:reason :kernel-body-c-memory-space
+                         :dialect (:id dialect) :parameter parameter})))
+      (if (opencl? dialect)
+        (str "__global " (when (= :input (:kind parameter)) "const ")
+             (type-name dialect (:dtype parameter)) "* " c-name)
+        (str (when (= :input (:kind parameter)) "const ")
+             (type-name dialect (:dtype parameter)) "* __restrict__ " c-name)))))
+
+(def ^:private axis-name ["x" "y" "z"])
+
+(defn- linear-thread-id []
+  "((int)threadIdx.x + (int)blockDim.x * ((int)threadIdx.y + (int)blockDim.y * (int)threadIdx.z))")
+
+(defn index-binding
+  [dialect source axis subgroup-width]
+  (if (opencl? dialect)
+    (case source
+      :group (str "get_group_id(" axis ")")
+      :subgroup "get_sub_group_id()"
+      :lane "get_sub_group_local_id()")
+    (case source
+      :group (str "blockIdx." (nth axis-name axis))
+      :subgroup (str "(" (linear-thread-id) " / " subgroup-width ")")
+      :lane (str "(" (linear-thread-id) " % " subgroup-width ")"))))
+
+(defn subgroup-attribute
+  [dialect subgroup-width uses-subgroups?]
+  (when uses-subgroups?
+    (case (:id dialect)
+      :opencl-intel
+      (str "__attribute__((intel_reqd_sub_group_size(" subgroup-width ")))\n")
+      :opencl-portable
+      (str "__attribute__((reqd_sub_group_size(" subgroup-width ")))\n")
+      (:cuda :hip) "")))
+
+(defn preamble
+  [dialect {:keys [uses-half? uses-double? uses-subgroups?]}]
+  (if (opencl? dialect)
+    (str (when uses-half? "#pragma OPENCL EXTENSION cl_khr_fp16 : enable\n")
+         (when uses-double? "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n")
+         (when uses-subgroups?
+           (str "#if defined(cl_khr_subgroups)\n"
+                "#pragma OPENCL EXTENSION cl_khr_subgroups : enable\n"
+                "#elif defined(cl_intel_subgroups)\n"
+                "#pragma OPENCL EXTENSION cl_intel_subgroups : enable\n"
+                "#endif\n"))
+         (when (or uses-half? uses-double? uses-subgroups?) "\n"))
+    (str "#include <stdint.h>\n#include <math.h>\n"
+         (case (:id dialect)
+           :cuda "#include <cuda_fp16.h>\n"
+           :hip (str "#include <hip/hip_runtime.h>\n"
+                     "#include <hip/hip_fp16.h>\n"))
+         "\n")))
+
+(defn entry-prefix
+  [dialect]
+  (if (opencl? dialect) "__kernel void " "extern \"C\" __global__ void "))
+
+(defn broadcast-expression
+  [dialect input source-lane width]
+  (case (:id dialect)
+    (:opencl-intel :opencl-portable)
+    (str "sub_group_broadcast(" input ", " source-lane ")")
+    :cuda
+    (str "__shfl_sync(__activemask(), " input ", " source-lane ", " width ")")
+    :hip
+    (str "__shfl(" input ", " source-lane ", " width ")")))
+
+(defn shuffle-down-expression
+  [dialect input distance width]
+  (case (:id dialect)
+    :cuda
+    (str "__shfl_down_sync(__activemask(), " input ", " distance ", " width ")")
+    :hip
+    (str "__shfl_down(" input ", " distance ", " width ")")
+    (throw (ex-info "OpenCL subgroup reductions use target builtins, not explicit shuffles"
+                    {:reason :kernel-body-c-shuffle-dialect :dialect (:id dialect)}))))
+
+(defn opencl-reduction-builtin
+  [operator]
+  ({:+ "sub_group_reduce_add"
+    :min "sub_group_reduce_min"
+    :max "sub_group_reduce_max"} operator))

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -1,15 +1,15 @@
 (ns raster.compiler.backend.gpu.kernel-body-opencl
-  "Direct OpenCL lowering of verified scheduled KernelBody values.
+  "C-family lowering of verified scheduled KernelBody values.
 
-  This namespace is below semantic contraction analysis and hardware scheduling.  It chooses only
-  target spellings: Intel subgroup builtins, OpenCL declarations and a pipelined loop form.  Tile
-  geometry and fragment topology are recovered from explicit index/operation IR, never from the
-  source contraction or a second schedule registry."
+  Matrix fragments retain their Intel OpenCL leaf. The general scalar/control path is shared by
+  OpenCL, CUDA and HIP through thin target dialect descriptors; geometry is recovered from explicit
+  index/operation IR, never from the source algorithm or a second schedule registry."
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [clojure.walk :as walk]
             [raster.compiler.backend.intrinsics :as intrinsics]
             [raster.compiler.backend.gpu.c-emit :as ce]
+            [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.core.op-descriptor :as descriptor]
@@ -725,8 +725,12 @@
 (defn- scalar-local-name [id]
   (str "rstr_" (target-name id)))
 
-(defn- opencl-type [type]
-  (if (= :predicate type) "bool" (dtype/ctype :opencl type)))
+(def ^:dynamic *scalar-dialect*
+  "Validated target spelling used by the shared scalar/control emitter."
+  (c-dialect/resolve! :opencl-intel))
+
+(defn- target-type [type]
+  (c-dialect/type-name *scalar-dialect* type))
 
 (defn- emit-floating-literal [value suffix]
   (cond
@@ -738,14 +742,17 @@
 (defn- emit-literal
   [{:keys [value type]}]
   (case (dtype/canon type)
-    :byte (str "(char)" value)
+    :byte (str "(" (target-type :byte) ")" value)
     :int (str value)
-    :long (str value "L")
-    :half (str "(half)(" (emit-floating-literal value "f") ")")
+    :long (str value (if (c-dialect/opencl? *scalar-dialect*) "L" "LL"))
+    :half (if (c-dialect/opencl? *scalar-dialect*)
+            (str "(half)(" (emit-floating-literal value "f") ")")
+            (str "__float2half_rn(" (emit-floating-literal value "f") ")"))
     :float (emit-floating-literal value "f")
     :double (emit-floating-literal value "")
-    (throw (ex-info "OpenCL scalar literal has no target spelling"
-                    {:reason :kernel-body-opencl-unimplemented :literal value :type type}))))
+    (throw (ex-info "C-family scalar literal has no target spelling"
+                    {:reason :kernel-body-c-unimplemented
+                     :dialect (:id *scalar-dialect*) :literal value :type type}))))
 
 (defn- scalar-value-type
   [value types]
@@ -786,28 +793,53 @@
       ;; Same-width and widening FP conversions are exact in the KernelBody contract.
       (and source-fp? result-fp? (not narrowing-fp?)
            (= [:exact :exact] [rounding overflow]))
-      (str "(" (opencl-type result-type) ")(" argument-source ")")
+      (cond
+        (and (not (c-dialect/opencl? *scalar-dialect*))
+             (= source-type :half) (= result-type :float))
+        (str "__half2float(" argument-source ")")
+
+        (and (not (c-dialect/opencl? *scalar-dialect*))
+             (= source-type :half) (= result-type :double))
+        (str "(double)(__half2float(" argument-source "))")
+
+        :else (str "(" (target-type result-type) ")(" argument-source ")"))
 
       ;; OpenCL conversion suffixes state the requested rounding of IEEE narrowing.
       (and narrowing-fp? (= :ieee overflow))
-      (str "convert_" (opencl-type result-type) (cast-suffix rounding overflow)
-           "(" argument-source ")")
+      (if (c-dialect/opencl? *scalar-dialect*)
+        (str "convert_" (target-type result-type) (cast-suffix rounding overflow)
+             "(" argument-source ")")
+        (case [source-type result-type rounding]
+          [:float :half :nearest-even] (str "__float2half_rn(" argument-source ")")
+          [:double :float :nearest-even] (str "__double2float_rn(" argument-source ")")
+          (throw (ex-info "CUDA/HIP cannot preserve this floating narrowing policy"
+                          {:reason :kernel-body-c-cast-policy
+                           :dialect (:id *scalar-dialect*)
+                           :source-type source-type :result-type result-type
+                           :rounding rounding :overflow overflow}))))
 
       ;; Saturating FP->integer conversion and wrapping integral conversion have direct spellings.
       (or (and source-fp? (not result-fp?) (= :saturate overflow))
           (and (not source-fp?) (not result-fp?) (= :wrap overflow)))
-      (str "convert_" (opencl-type result-type) (cast-suffix rounding overflow)
-           "(" argument-source ")")
+      (if (c-dialect/opencl? *scalar-dialect*)
+        (str "convert_" (target-type result-type) (cast-suffix rounding overflow)
+             "(" argument-source ")")
+        (throw (ex-info "CUDA/HIP cannot preserve this saturating or wrapping cast policy"
+                        {:reason :kernel-body-c-cast-policy
+                         :dialect (:id *scalar-dialect*)
+                         :source-type source-type :result-type result-type
+                         :rounding rounding :overflow overflow})))
 
       ;; Integral widening is exact. Narrowing/exact and trapping conversions need a proof or
       ;; runtime check that this target layer does not currently carry.
       (and (not source-fp?) (not result-fp?) (= [:exact :exact] [rounding overflow])
            (<= (dtype/bytes-of source-type) (dtype/bytes-of result-type)))
-      (str "(" (opencl-type result-type) ")(" argument-source ")")
+      (str "(" (target-type result-type) ")(" argument-source ")")
 
       :else
-      (throw (ex-info "OpenCL cannot preserve this KernelBody cast policy"
-                      {:reason :kernel-body-opencl-cast-policy
+      (throw (ex-info "C-family target cannot preserve this KernelBody cast policy"
+                      {:reason :kernel-body-c-cast-policy
+                       :dialect (:id *scalar-dialect*)
                        :source-type source-type :result-type result-type
                        :rounding rounding :overflow overflow})))))
 
@@ -827,13 +859,13 @@
       ;; Signed right shift is not the target-neutral unsigned-shift contract.
       (= :ushr op)
       (let [[value amount] arguments
-            unsigned-type ({:byte "uchar" :int "uint" :long "ulong"} operand-type)]
-        (str "(" (opencl-type operand-type) ")((" unsigned-type ")(" value ") >> "
+            unsigned-type (c-dialect/unsigned-type-name *scalar-dialect* operand-type)]
+        (str "(" (target-type operand-type) ")((" unsigned-type ")(" value ") >> "
              amount ")"))
 
       ;; OpenCL's integral abs returns an unsigned type, while KernelBody currently declares a
       ;; same-signed-type result. Refuse the mismatch until the IR states that representation step.
-      (and integral? (= :abs op))
+      (and (c-dialect/opencl? *scalar-dialect*) integral? (= :abs op))
       (throw (ex-info "OpenCL integral abs disagrees with the KernelBody result type"
                       {:reason :kernel-body-opencl-intrinsic
                        :operation op :operand-type operand-type}))
@@ -956,7 +988,7 @@
     (let [result (:result operation)
           next-context (add-value context result)]
       [(indent-lines depth
-                     (str (opencl-type (get-in next-context [:types (:id result)])) " "
+                     (str (target-type (get-in next-context [:types (:id result)])) " "
                           (get-in next-context [:names (:id result)]) " = "
                           (emit-scalar-value (:expression operation) context) ";"))
        next-context])
@@ -974,7 +1006,7 @@
                         (emit-scalar-value (:other operation) context) ")")
                    load)]
       [(indent-lines depth
-                     (str (opencl-type (get-in next-context [:types (:id result)])) " "
+                     (str (target-type (get-in next-context [:types (:id result)])) " "
                           (get-in next-context [:names (:id result)]) " = " source ";"))
        next-context])
 
@@ -998,7 +1030,7 @@
           declarations (apply str
                               (for [result results]
                                 (indent-lines depth
-                                              (str (opencl-type
+                                              (str (target-type
                                                     (get-in result-context
                                                             [:types (:id result)]))
                                                    " "
@@ -1034,7 +1066,7 @@
           initializers (apply str
                               (map (fn [result arg]
                                      (indent-lines depth
-                                                   (str (opencl-type
+                                                   (str (target-type
                                                          (get-in result-context
                                                                  [:types (:id result)]))
                                                         " "
@@ -1049,7 +1081,7 @@
                           (map (fn [arg result]
                                  (let [binding (:binding arg)]
                                    (indent-lines (inc depth)
-                                                 (str (opencl-type
+                                                 (str (target-type
                                                        (get-in loop-context
                                                                [:types (:id binding)]))
                                                       " "
@@ -1064,7 +1096,7 @@
           yield-op (peek (:operations operation))
           [body-source body-context] (emit-scalar-operations body-operations loop-context
                                                              (inc depth))
-          loop-header (str "for (" (opencl-type (get-in loop-context [:types (:id index)]))
+          loop-header (str "for (" (target-type (get-in loop-context [:types (:id index)]))
                            " " index-name " = "
                            (emit-index-expression (:lower operation) (:names context)) "; "
                            index-name " < "
@@ -1085,29 +1117,82 @@
     (let [result (:result operation)
           next-context (add-value context result)
           input (emit-scalar-value (:input operation) context)
-          expression
+          result-name (get-in next-context [:names (:id result)])
+          result-type (get-in next-context [:types (:id result)])
+          width (:width operation)
+          source
           (case (:kind operation)
-            :broadcast (str "sub_group_broadcast(" input ", " (:source-lane operation) ")")
-            :reduce (let [_ (when-not (= :implementation-defined
-                                         (:association operation))
-                              (throw
-                               (ex-info
-                                "OpenCL subgroup builtin cannot preserve an explicit reduction tree"
-                                {:reason :kernel-body-opencl-collective-association
-                                 :association (:association operation)})))
-                          builtin ({:+ "sub_group_reduce_add"
-                                    :min "sub_group_reduce_min"
-                                    :max "sub_group_reduce_max"}
-                                   (intrinsics/canonical (:operator operation)))]
-                      (when-not builtin
-                        (throw (ex-info "OpenCL has no matching subgroup reduction builtin"
-                                        {:reason :kernel-body-opencl-collective
-                                         :operator (:operator operation)})))
-                      (str builtin "(" input ")")))]
-      [(indent-lines depth
-                     (str (opencl-type (get-in next-context [:types (:id result)])) " "
-                          (get-in next-context [:names (:id result)]) " = " expression ";"))
-       next-context])
+            :broadcast
+            (indent-lines depth
+                          (str (target-type result-type) " " result-name " = "
+                               (c-dialect/broadcast-expression
+                                *scalar-dialect* input (:source-lane operation) width) ";"))
+
+            :reduce
+            (let [operator (intrinsics/canonical (:operator operation))
+                  association (:association operation)]
+              (if (c-dialect/opencl? *scalar-dialect*)
+                (let [_ (when-not (= :implementation-defined association)
+                          (throw
+                           (ex-info
+                            "OpenCL subgroup builtin cannot preserve an explicit reduction tree"
+                            {:reason :kernel-body-opencl-collective-association
+                             :association association})))
+                      builtin (c-dialect/opencl-reduction-builtin operator)]
+                  (when-not builtin
+                    (throw (ex-info "OpenCL has no matching subgroup reduction builtin"
+                                    {:reason :kernel-body-opencl-collective
+                                     :operator (:operator operation)})))
+                  (indent-lines depth
+                                (str (target-type result-type) " " result-name " = "
+                                     builtin "(" input ");")))
+                (let [distances (if (= :implementation-defined association)
+                                  (when (zero? (bit-and width (dec width)))
+                                    (vec (take-while pos?
+                                                     (iterate #(quot % 2) (quot width 2)))))
+                                  (:distances association))
+                      _ (when-not (seq distances)
+                          (throw (ex-info "CUDA/HIP subgroup reduction requires a power-of-two tree"
+                                          {:reason :kernel-body-c-collective-association
+                                           :dialect (:id *scalar-dialect*)
+                                           :width width :association association})))
+                      combine (fn [rhs]
+                                (case operator
+                                  :+ (str result-name " += " rhs ";")
+                                  :* (str result-name " *= " rhs ";")
+                                  :bit-and (str result-name " &= " rhs ";")
+                                  :bit-or (str result-name " |= " rhs ";")
+                                  :bit-xor (str result-name " ^= " rhs ";")
+                                  (:min :max)
+                                  (let [fn-name (case [operator result-type]
+                                                  [:min :float] "fminf"
+                                                  [:max :float] "fmaxf"
+                                                  [:min :double] "fmin"
+                                                  [:max :double] "fmax"
+                                                  nil)]
+                                    (when-not fn-name
+                                      (throw (ex-info "CUDA/HIP min/max collective dtype is unsupported"
+                                                      {:reason :kernel-body-c-collective
+                                                       :dialect (:id *scalar-dialect*)
+                                                       :operator operator :dtype result-type})))
+                                    (str result-name " = " fn-name "(" result-name ", " rhs ");"))
+                                  (throw (ex-info "CUDA/HIP has no matching subgroup reduction"
+                                                  {:reason :kernel-body-c-collective
+                                                   :dialect (:id *scalar-dialect*)
+                                                   :operator operator}))))]
+                  (str (indent-lines depth
+                                     (str (target-type result-type) " " result-name " = " input ";"))
+                       (apply str
+                              (for [distance distances]
+                                (indent-lines depth
+                                              (combine
+                                               (c-dialect/shuffle-down-expression
+                                                *scalar-dialect* result-name distance width)))))
+                       (indent-lines depth
+                                     (str result-name " = "
+                                          (c-dialect/broadcast-expression
+                                           *scalar-dialect* result-name 0 width) ";")))))))]
+      [source next-context])
 
     (record-kind? "Yield" operation)
     (throw (ex-info "OpenCL scalar lowering found a misplaced Yield"
@@ -1134,121 +1219,114 @@
                               :layout (:layout view) :view view))))
             parameters (:views kernel-body))))
 
-(defn- scalar-parameter-declaration
-  [parameter c-name]
-  (if (= :scalar (:kind parameter))
-    (str (opencl-type (dtype/canon (:dtype parameter))) " " c-name)
-    (do
-      (when-not (= :global (:memory-space parameter))
-        (throw (ex-info "OpenCL scalar lowering only supports global kernel storage"
-                        {:reason :kernel-body-opencl-memory-space :parameter parameter})))
-      (str "__global " (when (= :input (:kind parameter)) "const ")
-           (opencl-type (dtype/canon (:dtype parameter))) "* " c-name))))
+(defn- emit-scalar-kernel*
+  [kernel-name kernel-body {:keys [parameter-names]}]
+  (let [kernel-body (body/validate! kernel-body)
+        operations (vec (scalar-body-operations (:operations kernel-body)))
+        unsupported (remove #(contains? scalar-operation-kinds
+                                        (some-> % class .getSimpleName))
+                            operations)
+        _ (when (seq (:fragments kernel-body))
+            (throw (ex-info "scalar OpenCL lowering cannot consume matrix fragments"
+                            {:reason :kernel-body-opencl-unimplemented
+                             :fragments (:fragments kernel-body)})))
+        _ (when (seq unsupported)
+            (throw (ex-info "scalar OpenCL lowering cannot consume legacy tile operations"
+                            {:reason :kernel-body-opencl-unimplemented
+                             :operations (vec unsupported)})))
+        parameters (:parameters kernel-body)
+        parameter-names (into {}
+                              (map (fn [parameter]
+                                     [(:id parameter)
+                                      (or (get parameter-names (:id parameter))
+                                          (scalar-local-name (:id parameter)))])
+                                   parameters))
+        _ (when-not (every? #(re-matches #"[A-Za-z_][A-Za-z0-9_]*" %)
+                            (vals parameter-names))
+            (throw (ex-info "C-family kernel parameter names must be C identifiers"
+                            {:reason :kernel-body-c-parameter-name
+                             :dialect (:id *scalar-dialect*)
+                             :parameter-names parameter-names})))
+        indices (:indices kernel-body)
+        names (reduce (fn [env index]
+                        (assoc env (:id index) (scalar-local-name (:id index))))
+                      parameter-names indices)
+        types (reduce (fn [env index] (assoc env (:id index) :int))
+                      (into {}
+                            (map (fn [parameter]
+                                   [(:id parameter) (dtype/canon (:dtype parameter))])
+                                 (filter #(= :scalar (:kind %)) parameters)))
+                      indices)
+        all-names (vals names)
+        _ (when-not (= (count all-names) (count (set all-names)))
+            (throw (ex-info "C-family parameter and index names collide after target spelling"
+                            {:reason :kernel-body-c-name-collision
+                             :dialect (:id *scalar-dialect*) :names names})))
+        local-ids (concat (map :id indices) (scalar-defined-ids (:operations kernel-body)))
+        emitted-local-names (map scalar-local-name local-ids)
+        all-emitted-names (concat (vals parameter-names) emitted-local-names)
+        _ (when-not (= (count all-emitted-names) (count (set all-emitted-names)))
+            (throw (ex-info "C-family parameter or SSA names collide after target spelling"
+                            {:reason :kernel-body-c-name-collision
+                             :dialect (:id *scalar-dialect*)
+                             :ids (vec local-ids)})))
+        storage (scalar-storage-map kernel-body)
+        masks (into {} (map (juxt :id identity)) (:masks kernel-body))
+        context {:names names :types types :storage storage :masks masks}
+        index-source
+        (apply str
+               (for [index indices]
+                 (let [name (get names (:id index))]
+                   (if (record-kind? "IndexBinding" index)
+                     (indent-lines
+                      1
+                      (str "int " name " = (int)"
+                           (c-dialect/index-binding
+                            *scalar-dialect* (:source index) (:axis index)
+                            (get-in kernel-body [:schedule :subgroup-size]))
+                           ";"))
+                     (indent-lines
+                      1 (str "int " name " = "
+                             (emit-index-expression (:expression index) names) ";"))))))
+        [operation-source _] (emit-scalar-operations (:operations kernel-body) context 1)
+        uses-half? (some #(= :half (dtype/canon (:dtype %))) parameters)
+        uses-double? (some #(= :double (dtype/canon (:dtype %))) parameters)
+        collective (first (filter #(record-kind? "Collective" %) operations))
+        uses-subgroups? (or collective
+                            (some #(and (record-kind? "IndexBinding" %)
+                                        (contains? #{:subgroup :lane} (:source %)))
+                                  indices))
+        subgroup-size (or (some-> collective :width)
+                          (get-in kernel-body [:schedule :subgroup-size]))
+        attribute (c-dialect/subgroup-attribute
+                   *scalar-dialect* subgroup-size uses-subgroups?)]
+    (str (c-dialect/preamble *scalar-dialect*
+                             {:uses-half? uses-half? :uses-double? uses-double?
+                              :uses-subgroups? uses-subgroups?})
+         attribute
+         (c-dialect/entry-prefix *scalar-dialect*) (target-name kernel-name) "(\n    "
+         (str/join ",\n    "
+                   (map #(c-dialect/parameter-declaration
+                          *scalar-dialect* % (get parameter-names (:id %)))
+                        parameters))
+         ") {\n"
+         index-source operation-source
+         "}\n")))
 
 (defn emit-scalar-kernel
-  "Lower a verified scalar/control KernelBody directly to OpenCL C.
+  "Lower a verified scalar/control KernelBody directly to a C-family target dialect.
 
   The body already fixes schedules, types, layouts, masks, convergence and numerical conversion
-  policies. `parameter-names` may only select target ABI spelling; it cannot inject source. Dense
-  global storage and the OpenCL subgroup builtins are the first implemented target row; a
-  production semantic route must still construct this body explicitly."
+  policies. `parameter-names` may only select ABI spelling; `target-dialect` defaults to the
+  production Intel OpenCL row and may select `:opencl-portable`, `:cuda`, or `:hip`. Target
+  selection cannot alter the scheduled body."
   ([kernel-name kernel-body]
    (emit-scalar-kernel kernel-name kernel-body {}))
-  ([kernel-name kernel-body {:keys [parameter-names subgroup-attribute]
-                             :or {subgroup-attribute :intel}}]
-   (let [kernel-body (body/validate! kernel-body)
-         operations (vec (scalar-body-operations (:operations kernel-body)))
-         unsupported (remove #(contains? scalar-operation-kinds
-                                         (some-> % class .getSimpleName))
-                             operations)
-         _ (when (seq (:fragments kernel-body))
-             (throw (ex-info "scalar OpenCL lowering cannot consume matrix fragments"
-                             {:reason :kernel-body-opencl-unimplemented
-                              :fragments (:fragments kernel-body)})))
-         _ (when (seq unsupported)
-             (throw (ex-info "scalar OpenCL lowering cannot consume legacy tile operations"
-                             {:reason :kernel-body-opencl-unimplemented
-                              :operations (vec unsupported)})))
-         parameters (:parameters kernel-body)
-         parameter-names (into {}
-                               (map (fn [parameter]
-                                      [(:id parameter)
-                                       (or (get parameter-names (:id parameter))
-                                           (scalar-local-name (:id parameter)))])
-                                    parameters))
-         _ (when-not (every? #(re-matches #"[A-Za-z_][A-Za-z0-9_]*" %)
-                             (vals parameter-names))
-             (throw (ex-info "OpenCL kernel parameter names must be C identifiers"
-                             {:reason :kernel-body-opencl-parameter-name
-                              :parameter-names parameter-names})))
-         indices (:indices kernel-body)
-         names (reduce (fn [env index]
-                         (assoc env (:id index) (scalar-local-name (:id index))))
-                       parameter-names indices)
-         types (reduce (fn [env index] (assoc env (:id index) :int))
-                       (into {}
-                             (map (fn [parameter]
-                                    [(:id parameter) (dtype/canon (:dtype parameter))])
-                                  (filter #(= :scalar (:kind %)) parameters)))
-                       indices)
-         all-names (vals names)
-         _ (when-not (= (count all-names) (count (set all-names)))
-             (throw (ex-info "OpenCL parameter and index names collide after target spelling"
-                             {:reason :kernel-body-opencl-name-collision :names names})))
-         local-ids (concat (map :id indices) (scalar-defined-ids (:operations kernel-body)))
-         emitted-local-names (map scalar-local-name local-ids)
-         all-emitted-names (concat (vals parameter-names) emitted-local-names)
-         _ (when-not (= (count all-emitted-names) (count (set all-emitted-names)))
-             (throw (ex-info "OpenCL parameter or SSA names collide after target spelling"
-                             {:reason :kernel-body-opencl-name-collision
-                              :ids (vec local-ids)})))
-         storage (scalar-storage-map kernel-body)
-         masks (into {} (map (juxt :id identity)) (:masks kernel-body))
-         context {:names names :types types :storage storage :masks masks}
-         index-source
-         (apply str
-                (for [index indices]
-                  (let [name (get names (:id index))]
-                    (if (record-kind? "IndexBinding" index)
-                      (indent-lines
-                       1
-                       (str "int " name " = (int)"
-                            (case (:source index)
-                              :group (str "get_group_id(" (:axis index) ")")
-                              :subgroup "get_sub_group_id()"
-                              :lane "get_sub_group_local_id()")
-                            ";"))
-                      (indent-lines
-                       1 (str "int " name " = "
-                              (emit-index-expression (:expression index) names) ";"))))))
-         [operation-source _] (emit-scalar-operations (:operations kernel-body) context 1)
-         uses-half? (some #(= :half (dtype/canon (:dtype %))) parameters)
-         uses-double? (some #(= :double (dtype/canon (:dtype %))) parameters)
-         collective (first (filter #(record-kind? "Collective" %) operations))
-         uses-subgroups? (or collective
-                             (some #(and (record-kind? "IndexBinding" %)
-                                         (contains? #{:subgroup :lane} (:source %)))
-                                   indices))
-         subgroup-size (or (some-> collective :width)
-                           (get-in kernel-body [:schedule :subgroup-size]))
-         attribute (when uses-subgroups?
-                     (case subgroup-attribute
-                       :intel (str "__attribute__((intel_reqd_sub_group_size("
-                                   subgroup-size ")))\n")
-                       :none ""
-                       (throw (ex-info "OpenCL subgroup attribute dialect is unsupported"
-                                       {:reason :kernel-body-opencl-subgroup-dialect
-                                        :dialect subgroup-attribute}))))]
-     (str (when uses-half? "#pragma OPENCL EXTENSION cl_khr_fp16 : enable\n")
-          (when uses-double? "#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n")
-          (when uses-subgroups?
-            "#if defined(cl_khr_subgroups)\n#pragma OPENCL EXTENSION cl_khr_subgroups : enable\n#elif defined(cl_intel_subgroups)\n#pragma OPENCL EXTENSION cl_intel_subgroups : enable\n#endif\n")
-          (when (or uses-half? uses-double? uses-subgroups?) "\n")
-          attribute
-          "__kernel void " (target-name kernel-name) "(\n    "
-          (str/join ",\n    "
-                    (map #(scalar-parameter-declaration % (get parameter-names (:id %)))
-                         parameters))
-          ") {\n"
-          index-source operation-source
-          "}\n"))))
+  ([kernel-name kernel-body {:keys [target-dialect subgroup-attribute] :as options
+                             :or {target-dialect :opencl-intel subgroup-attribute :intel}}]
+   (let [target-dialect (if (and (= :opencl-intel target-dialect)
+                                 (= :none subgroup-attribute))
+                          :opencl-portable
+                          target-dialect)]
+     (binding [*scalar-dialect* (c-dialect/resolve! target-dialect)]
+       (emit-scalar-kernel* kernel-name kernel-body options)))))

--- a/src/raster/compiler/backend/gpu/target.clj
+++ b/src/raster/compiler/backend/gpu/target.clj
@@ -6,23 +6,35 @@
    must not use them to constrain otherwise-portable schedules."
   (:require [clojure.string :as str]))
 
+(defn kernel-body-c-dialect
+  "Select the scalar/control KernelBody source dialect proven by a target descriptor.
+
+   CUDA and HIP backends name their native source dialect directly. OpenCL requires an explicit
+   portable subgroup contract unless it is the detected/catalogued Intel path. This predicate is
+   about emission legality; it does not claim that a corresponding runtime launcher is installed."
+  [desc]
+  (let [vendor (some-> (:vendor desc) str str/lower-case)
+        matrix-family (get-in desc [:matrix :family])
+        backend (:backend desc)
+        requested (:subgroup-dialect desc)]
+    (cond
+      (or (nil? desc) (not= :gpu (:device-type desc))) nil
+      (= :cuda backend) :cuda
+      (= :hip backend) :hip
+      (= :cuda requested) :cuda
+      (= :hip requested) :hip
+      (= :opencl-portable requested) :opencl-portable
+      (and (contains? #{nil :ze :ocl :opencl} backend)
+           (or (= :intel-opencl requested)
+               (= :dpas matrix-family)
+               (and vendor (str/includes? vendor "intel"))))
+      :opencl-intel
+      :else nil)))
+
 (defn intel-opencl-subgroup-dialect?
   "True when the current OpenCL leaf may emit Intel subgroup attributes and builtins.
 
    `:subgroup-dialect` is the explicit cross-compile contract. Vendor and DPAS checks retain the
    detected/catalogued Intel path until runtime backend capabilities become a first-class facet."
   [desc]
-  (let [vendor (some-> (:vendor desc) str str/lower-case)
-        matrix-family (get-in desc [:matrix :family])
-        backend (:backend desc)
-        opencl-backend? (or (nil? backend)
-                            (= :ze backend)
-                            (= :ocl backend)
-                            (= :opencl backend))]
-    (boolean
-     (and desc
-          (= :gpu (:device-type desc))
-          opencl-backend?
-          (or (= :intel-opencl (:subgroup-dialect desc))
-              (= :dpas matrix-family)
-              (and vendor (str/includes? vendor "intel")))))))
+  (= :opencl-intel (kernel-body-c-dialect desc)))

--- a/src/raster/compiler/ir/kernel_abi.clj
+++ b/src/raster/compiler/ir/kernel_abi.clj
@@ -236,35 +236,46 @@
         (validate! abi)))
 
 (defn source-signature-shape
-  "Extract ordered C parameter names and pointer/scalar shape for one OpenCL kernel."
-  [kernel-name source]
-  (let [pattern (re-pattern
-                 (str "(?s)__kernel\\s+void\\s+" (java.util.regex.Pattern/quote kernel-name)
-                      "\\s*\\(([^)]*)\\)"))
-        params (second (re-find pattern source))]
-    (when-not params
-      (throw (ex-info "kernel ABI could not find emitted OpenCL signature"
-                      {:kernel-name kernel-name})))
-    (if (str/blank? params)
-      []
-      (mapv (fn [param]
-              (let [param (str/trim param)
+  "Extract ordered C parameter names and pointer/scalar shape for one target kernel."
+  ([kernel-name source]
+   (source-signature-shape :opencl-c kernel-name source))
+  ([target kernel-name source]
+   (let [entry-pattern
+         (case target
+           :opencl-c "__kernel\\s+void\\s+"
+           (:cuda-c :hip-cpp) "extern\\s+\"C\"\\s+__global__\\s+void\\s+"
+           (throw (ex-info "kernel ABI target has no source signature grammar"
+                           {:reason :kernel-abi-source-target :target target})))
+         pattern (re-pattern
+                  (str "(?s)" entry-pattern (java.util.regex.Pattern/quote kernel-name)
+                       "\\s*\\(([^)]*)\\)"))
+         params (second (re-find pattern source))]
+     (when-not params
+       (throw (ex-info "kernel ABI could not find emitted target signature"
+                       {:kernel-name kernel-name :target target})))
+     (if (str/blank? params)
+       []
+       (mapv (fn [param]
+               (let [param (str/trim param)
                     ;; Clojure gensyms in emitted kernels may retain Unicode letters (for example
                     ;; the AD pipeline uses α). Capture the complete final non-whitespace token;
                     ;; an ASCII-only C-identifier regex silently reduced `y_α_42` to `_42`.
-                    c-name (second (re-find #"([^\s*]+)\s*$" param))]
-                (when-not c-name
-                  (throw (ex-info "kernel ABI could not parse emitted OpenCL parameter"
-                                  {:kernel-name kernel-name :parameter param})))
-                {:c-name c-name :pointer? (str/includes? param "*")}))
-            (str/split params #",")))))
+                     c-name (second (re-find #"([^\s*]+)\s*$" param))]
+                 (when-not c-name
+                   (throw (ex-info "kernel ABI could not parse emitted target parameter"
+                                   {:kernel-name kernel-name :target target :parameter param})))
+                 {:c-name c-name :pointer? (str/includes? param "*")}))
+             (str/split params #","))))))
 
 (defn validate-source-signature!
-  "Compare emitted OpenCL parameter order/shape with the ABI before registration."
-  [kernel-name source abi]
-  (let [expected (signature-shape abi)
-        actual (source-signature-shape kernel-name source)]
-    (when-not (= expected actual)
-      (throw (ex-info "emitted OpenCL signature does not match kernel ABI"
-                      {:kernel-name kernel-name :expected expected :actual actual :abi abi})))
-    abi))
+  "Compare emitted target parameter order/shape with the ABI before registration."
+  ([kernel-name source abi]
+   (validate-source-signature! :opencl-c kernel-name source abi))
+  ([target kernel-name source abi]
+   (let [expected (signature-shape abi)
+         actual (source-signature-shape target kernel-name source)]
+     (when-not (= expected actual)
+       (throw (ex-info "emitted target signature does not match kernel ABI"
+                       {:kernel-name kernel-name :target target
+                        :expected expected :actual actual :abi abi})))
+     abi)))

--- a/src/raster/compiler/ir/kernel_artifact.clj
+++ b/src/raster/compiler/ir/kernel_artifact.clj
@@ -13,7 +13,7 @@
 
 (defrecord KernelArtifact
            [kernel-name   ;; emitted entry-point string
-            target        ;; target module dialect, currently :opencl-c
+            target        ;; target module dialect (:opencl-c, :cuda-c, or :hip-cpp)
             source        ;; target module source containing kernel-name
             abi           ;; ordered physical signature
             arguments     ;; compiler values in the identical order
@@ -30,7 +30,7 @@
             (.getName (class x)))))
 
 (defn validate!
-  "Validate `artifact` and return it unchanged.  Validation includes the emitted OpenCL
+  "Validate `artifact` and return it unchanged. Validation includes the emitted target C-family
    signature, so no unverified KernelArtifact can enter a runtime registry."
   [artifact]
   (when-not (kernel-artifact? artifact)
@@ -50,7 +50,8 @@
     (kabi/validate-arguments! abi arguments)
     (kabi/validate-alias-contracts! abi arguments #(or (identical? %1 %2) (= %1 %2)))
     (case target
-      :opencl-c (kabi/validate-source-signature! kernel-name source abi)
+      (:opencl-c :cuda-c :hip-cpp)
+      (kabi/validate-source-signature! target kernel-name source abi)
       (throw (ex-info "kernel artifact target has no module verifier"
                       {:kernel-name kernel-name :target target})))
     (try

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -1,0 +1,69 @@
+(ns raster.compiler.backend.gpu.kernel-body-compile-fixtures
+  "Generate production scheduled KernelBody sources for hardware-free CUDA/HIP CI gates."
+  (:require [clojure.java.io :as io]
+            [raster.compiler.backend.gpu.attention :as attention-emit]
+            [raster.compiler.backend.gpu.target :as gpu-target]
+            [raster.compiler.ir.attention :as attention]
+            [raster.compiler.ir.kernel-executable :as executable]
+            [raster.compiler.passes.parallel.attention-route :as attention-route]
+            [raster.compiler.passes.parallel.segmented-weighted-reduction-schedule :as schedule]))
+
+(defn- problem []
+  (attention/make
+   {:id :c-family-compile-gate
+    :query (attention/packed-query-batch
+            {:values 'q :row-offsets 'q-row-offsets :positions 'q-positions :total-tokens 4})
+    :k-pages 'k-pages :v-pages 'v-pages
+    :route (attention/dense-paged-route
+            {:page-table 'page-table :lengths 'kv-lengths
+             :start-positions 'kv-start-positions :pages-per-sequence 4})
+    :output 'output :batch-size 2 :q-heads 8 :kv-heads 2
+    :qk-head-dim 64 :value-head-dim 64 :page-size 16 :physical-pages 8
+    :scale 0.125 :k-layout :kv-head-major :v-layout :page-major
+    :visibility (attention/visibility {:causal? true :window-left 31 :window-right 0})}))
+
+(def ^:private targets
+  {:cuda {:suffix ".cu"
+          :descriptor {:device-type :gpu :backend :cuda :vendor "NVIDIA"
+                       :subgroup-size 32 :max-workgroup-size 1024}}
+   :hip {:suffix ".hip"
+         :descriptor {:device-type :gpu :backend :hip :vendor "AMD"
+                      :subgroup-size 32 :max-workgroup-size 1024}}})
+
+(defn- write-artifact!
+  [directory suffix label artifact]
+  (let [file (io/file directory (str label suffix))]
+    (spit file (:source artifact))
+    (.getAbsolutePath file)))
+
+(defn emit-target!
+  [root target]
+  (let [{:keys [suffix descriptor]} (get targets target)
+        dialect (gpu-target/kernel-body-c-dialect descriptor)
+        _ (when-not dialect
+            (throw (ex-info "unknown compile-gate target"
+                            {:target target :supported (set (keys targets))})))
+        directory (io/file root (name target))
+        _ (.mkdirs directory)
+        plan (:plan (attention-route/route!
+                     (problem)
+                     (assoc descriptor :segmented-weighted-reduction-schedule :reference)))
+        cooperative-schedule (:schedule (schedule/plan-subgroup-online plan descriptor))
+        tiled-schedule (:schedule
+                        (schedule/plan-subgroup-online-tiled
+                         plan (assoc descriptor
+                                     :segmented-weighted-reduction-history-tile-size 4)))
+        cooperative (attention-emit/emit-fp16-cooperative
+                     plan cooperative-schedule dialect)
+        tiled (attention-emit/emit-fp16-tiled-history plan tiled-schedule dialect)]
+    (into [(write-artifact! directory suffix "cooperative" cooperative)]
+          (map-indexed (fn [index artifact]
+                         (write-artifact! directory suffix (str "tiled-" index) artifact))
+                       (executable/artifacts tiled)))))
+
+(defn -main
+  [& [root]]
+  (let [root (or root "gpu-compile-gates")]
+    (doseq [target [:cuda :hip]
+            file (emit-target! root target)]
+      (println file))))

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -157,3 +157,57 @@
            (opencl/emit-scalar-kernel
             "colliding_names" (scalar-kernel-body)
             {:parameter-names {'x "same" 'bias "same"}}))))))
+
+(defn- command-available? [command]
+  (zero? (:exit (shell/sh "sh" "-c" (str "command -v " command)))))
+
+(defn- compile-c-family-source
+  [target source]
+  (let [suffix (case target :cuda ".cu" :hip ".hip")
+        source-file (java.io.File/createTempFile "raster-kernel-body-" suffix)
+        output-file (str (.getAbsolutePath source-file) ".ptx")]
+    (spit source-file source)
+    (case target
+      :cuda (shell/sh "nvcc" "-ptx" "-arch=sm_80" "-o" output-file
+                      (.getAbsolutePath source-file))
+      :hip (shell/sh "hipcc" "--offload-arch=gfx1100" "--genco"
+                     "-o" (str (.getAbsolutePath source-file) ".hsaco")
+                     (.getAbsolutePath source-file)))))
+
+(deftest one-scheduled-body-lowers-to-cuda-and-hip
+  (doseq [[target compiler shuffle broadcast]
+          [[:cuda "nvcc" "__shfl_down_sync(__activemask()"
+            "__shfl_sync(__activemask()"]
+           [:hip "hipcc" "__shfl_down(" "__shfl("]]]
+    (testing (str (name target) " uses only its thin target spelling")
+      (let [source (opencl/emit-scalar-kernel
+                    "scheduled_scalar" (scalar-kernel-body)
+                    {:target-dialect target
+                     :parameter-names {'x "input_rows" 'bias "row_bias"
+                                       'y "output_rows" 'scale "scale"}})]
+        (is (str/includes? source "extern \"C\" __global__ void scheduled_scalar"))
+        (is (str/includes? source "blockIdx.x"))
+        (is (str/includes? source "threadIdx.x"))
+        (is (str/includes? source shuffle))
+        (is (str/includes? source broadcast))
+        (is (str/includes? source "__half2float("))
+        (is (str/includes? source "__float2half_rn("))
+        (is (not (str/includes? source "get_group_id")))
+        (is (not (str/includes? source "sub_group_reduce")))
+        (testing "the installed host toolchain accepts the emitted device source"
+          (if-not (command-available? compiler)
+            (is true (str compiler " unavailable; source structure remains covered"))
+            (let [{:keys [exit err]} (compile-c-family-source target source)]
+              (is (zero? exit) err))))))))
+
+(deftest portable-opencl-keeps-the-scheduled-subgroup-width
+  (let [source (opencl/emit-scalar-kernel
+                "portable_scalar" (scalar-kernel-body)
+                {:target-dialect :opencl-portable})]
+    (is (str/includes? source "__attribute__((reqd_sub_group_size(16)))"))
+    (is (not (str/includes? source "intel_reqd_sub_group_size")))
+    (if-not (command-available? "clang")
+      (is true "clang unavailable; source structure remains covered")
+      (let [{:keys [exit err]} (shell/sh "clang" "-x" "cl" "-cl-std=CL2.0"
+                                         "-fsyntax-only" "-" :in source)]
+        (is (zero? exit) err)))))

--- a/test/raster/compiler/backend/gpu/target_test.clj
+++ b/test/raster/compiler/backend/gpu/target_test.clj
@@ -1,0 +1,22 @@
+(ns raster.compiler.backend.gpu.target-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.target :as target]))
+
+(deftest descriptors-select-source-dialects-without-claiming-runtime-support
+  (is (= :cuda (target/kernel-body-c-dialect
+                {:device-type :gpu :backend :cuda :vendor "NVIDIA"})))
+  (is (= :hip (target/kernel-body-c-dialect
+               {:device-type :gpu :backend :hip :vendor "AMD"})))
+  (is (= :opencl-intel (target/kernel-body-c-dialect
+                        {:device-type :gpu :backend :ze :vendor "Intel"})))
+  (is (= :opencl-portable (target/kernel-body-c-dialect
+                           {:device-type :gpu :backend :opencl :vendor "AMD"
+                            :subgroup-dialect :opencl-portable})))
+  (testing "vendor names do not override an explicitly different runtime backend"
+    (is (= :cuda (target/kernel-body-c-dialect
+                  {:device-type :gpu :backend :cuda :vendor "Intel"
+                   :matrix {:family :dpas}}))))
+  (testing "generic non-Intel OpenCL must prove portable subgroup support explicitly"
+    (is (nil? (target/kernel-body-c-dialect
+               {:device-type :gpu :backend :opencl :vendor "AMD"}))))
+  (is (nil? (target/kernel-body-c-dialect {:device-type :cpu :backend :cuda}))))

--- a/test/raster/compiler/ir/kernel_artifact_test.clj
+++ b/test/raster/compiler/ir/kernel_artifact_test.clj
@@ -51,3 +51,23 @@
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo #"invalid launch contract"
          (kart/make (assoc base :launch {:dimensions 1}))))))
+
+(deftest c-family-artifacts-share-one-ordered-abi-verifier
+  (doseq [[target source]
+          [[:cuda-c (str "extern \"C\" __global__ void reduce0("
+                         "const float* __restrict__ x, float* __restrict__ out, "
+                         "int _n_bound) {}")]
+           [:hip-cpp (str "extern \"C\" __global__ void reduce0("
+                          "const float* __restrict__ x, float* __restrict__ out, "
+                          "int _n_bound) {}")]]]
+    (let [artifact (kart/make (assoc base :target target :source source))]
+      (is (= target (:target artifact)))
+      (is (= abi (:abi artifact)))))
+  (is (thrown-with-msg?
+       clojure.lang.ExceptionInfo #"signature does not match"
+       (kart/make
+        (assoc base
+               :target :cuda-c
+               :source (str "extern \"C\" __global__ void reduce0("
+                            "float* __restrict__ out, const float* __restrict__ x, "
+                            "int _n_bound) {}"))))))

--- a/test/raster/compiler/passes/parallel/attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/attention_route_test.clj
@@ -149,6 +149,27 @@
           (is (not (str/includes? source "rstr_value_component_16")))
           (is (zero? (:exit result)) (:err result)))))))
 
+(deftest scheduled-attention-artifacts-preserve-the-abi-across-c-family-targets
+  (let [descriptor {:device-type :gpu :subgroup-size 32 :max-workgroup-size 1024}
+        plan (:plan (route/route!
+                     (problem)
+                     (assoc descriptor :segmented-weighted-reduction-schedule :reference)))
+        scheduled (:schedule (schedule-pass/plan-subgroup-online plan descriptor))
+        opencl (attention-emit/emit-fp16-cooperative
+                plan scheduled :opencl-portable)]
+    (doseq [[dialect target]
+            [[:cuda :cuda-c] [:hip :hip-cpp]]]
+      (let [artifact (attention-emit/emit-fp16-cooperative plan scheduled dialect)]
+        (is (= target (:target artifact)))
+        (is (= (:abi opencl) (:abi artifact)))
+        (is (= (:arguments opencl) (:arguments artifact)))
+        (is (= (:effects opencl) (:effects artifact)))
+        (is (= dialect (get-in artifact [:attributes :target-dialect])))
+        (is (= :explicit-shuffle-down-tree
+               (get-in artifact [:attributes :target-collective-association])))
+        (is (str/includes? (:source artifact) "extern \"C\" __global__ void"))
+        (is (str/includes? (:source artifact) "__shfl_down"))))))
+
 (deftest tiled-history-is-a-two-stage-kernel-graph-with-a-stable-external-abi
   (let [desc (assoc intel-desc
                     :segmented-weighted-reduction-schedule


### PR DESCRIPTION
## Summary

- introduce thin portable OpenCL, CUDA, and HIP spelling descriptors beneath the shared verified scalar/control `KernelBody` lowering
- lower 1–3D group/lane/subgroup bindings plus full-subgroup reductions and broadcasts; CUDA/HIP choose and record an explicit shuffle-down tree
- preserve the same scheduled attention ABI in verified `:opencl-c`, `:cuda-c`, and `:hip-cpp` artifacts, while keeping runtime route selection conservative
- generate the production cooperative and tiled-history attention stages for hardware-free compiler gates
- add mandatory CircleCI jobs that compile CUDA sources to PTX and HIP sources to `gfx1100` code objects; deployment now depends on both

## Verification

- focused fresh-process suite: 37 tests, 321 assertions, 0 failures/errors
- `nvcc -ptx -arch=sm_80`: cooperative, tiled partial, and tiled merge stages pass locally without NVIDIA hardware
- `hipcc --offload-arch=gfx1100 --genco`: the same three stages pass locally without AMD hardware
- existing Intel OpenCL source and real-device coverage remains unchanged
- touched-file lint: no errors (only existing analyzer resolution warnings)
- `git diff --check`: clean

The repository-wide local suite was intentionally not run because the host is under memory pressure with swap full; CircleCI remains the full-suite gate.