### PR TITLE
Verify workgroup memory in KernelBody

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -103,14 +103,18 @@ loop-carried regions, and full-participation subgroup reductions/broadcasts. Bra
 are typed products; use-before-definition, identity collisions, divergent collectives, implicit
 masked-load values, conversion policy gaps, and launch/subgroup mismatches fail verification. Body
 launches use the shared `LaunchSpec`, keeping host launch expressions separate from in-kernel index
-arithmetic. Uniform memory facts require an explicit body-level stable-read contract; the checked
+arithmetic. Group, 1–3D local-thread, subgroup, and subgroup-lane indices are distinct hardware
+sources. Uniform memory facts require an explicit body-level stable-read contract; the checked
 KernelBody-to-ABI seam projects it to a no-write-alias precondition, artifacts reject equal compiler
 bindings, direct calls check resident ranges, and graph/link binding retains its stronger
 overlapping-write rejection. Floating narrowing distinguishes IEEE overflow from integral
-wrap/saturate/trap policies. Local allocation,
-barriers, masked collectives, and asynchronous copies remain absent
-until a concrete schedule supplies enough information to verify lifetime, alignment, execution and
-memory scopes, memory semantics, participation, and shared-byte accounting. An implemented OpenCL
+wrap/saturate/trap policies. Whole-kernel workgroup allocations now have static typed shapes, named
+layouts, explicit 1–16-byte alignment, and one deterministic packed-memory plan; launch shared-byte
+accounting must match that plan exactly. Full-participation acquire/release workgroup barriers are
+rejected outside workgroup-uniform control flow and lower from the same operation to OpenCL,
+CUDA, and HIP. Masked collectives and asynchronous copies remain absent until a concrete schedule
+supplies enough information to verify their participation, issue/commit/wait lifetime, and target
+capability. An implemented OpenCL
 target spelling now lowers this general scalar/control vocabulary directly: dense ranked loads and
 stores (including contiguous leading-slice views), SSA expressions, structured branch/loop yields,
 explicit numerical casts, and full-subgroup reductions/broadcasts, without recovering an algorithm
@@ -135,10 +139,11 @@ CUDA and HIP spelling descriptors. The same scheduled cooperative and tiled-hist
 one ordered ABI while OpenCL uses subgroup builtins and CUDA/HIP select explicit shuffle-down trees;
 the emitted artifacts record that target association. CUDA is compiled to PTX and HIP to an RDNA3
 code object in mandatory hardware-free CI jobs, while real Intel execution remains the numerical
-oracle. CUDA/HIP runtime registration, launch and on-device numerical coverage remain deliberately
-separate from source legality. Verified local allocation, barriers and asynchronous copies can
-subsequently collapse a multi-kernel tiled graph into a FlashAttention-like single kernel without
-changing the semantic plan or external ABI.
+oracle. The compiler fixtures now also stage values through verified workgroup memory and a barrier;
+CUDA/HIP runtime registration, launch and on-device numerical coverage remain deliberately separate
+from source legality. Async copy/commit/wait operations and a schedule that uses the new staging
+substrate can subsequently collapse a multi-kernel tiled graph into a FlashAttention-like single
+kernel without changing the semantic plan or external ABI.
 
 ### 2.3 Executable steps and resident artifact values compose
 

--- a/src/raster/compiler/backend/gpu/kernel_body_c_dialect.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_c_dialect.clj
@@ -71,10 +71,12 @@
   (if (opencl? dialect)
     (case source
       :group (str "get_group_id(" axis ")")
+      :local (str "get_local_id(" axis ")")
       :subgroup "get_sub_group_id()"
       :lane "get_sub_group_local_id()")
     (case source
       :group (str "blockIdx." (nth axis-name axis))
+      :local (str "threadIdx." (nth axis-name axis))
       :subgroup (str "(" (linear-thread-id) " / " subgroup-width ")")
       :lane (str "(" (linear-thread-id) " % " subgroup-width ")"))))
 
@@ -110,6 +112,34 @@
 (defn entry-prefix
   [dialect]
   (if (opencl? dialect) "__kernel void " "extern \"C\" __global__ void "))
+
+(defn workgroup-arena-declaration
+  "Spell one statically sized, explicitly aligned workgroup-memory arena."
+  [dialect name bytes alignment]
+  (case (:id dialect)
+    (:opencl-intel :opencl-portable)
+    (let [[backing-type backing-bytes]
+          ({1 ["uchar" 1] 2 ["ushort" 2] 4 ["uint" 4] 8 ["ulong" 8] 16 ["uint4" 16]}
+           alignment)]
+      (str "__local " backing-type " " name "[" (quot bytes backing-bytes) "];"))
+    :cuda
+    (str "__shared__ __align__(" alignment ") unsigned char " name "[" bytes "];")
+    :hip
+    (str "__shared__ __attribute__((aligned(" alignment "))) unsigned char " name "[" bytes "];")))
+
+(defn workgroup-pointer-declaration
+  "Spell a typed pointer into a verified byte offset of the workgroup arena."
+  [dialect type name arena byte-offset]
+  (if (opencl? dialect)
+    (str "__local " (type-name dialect type) "* " name " = (__local "
+         (type-name dialect type) "*)((__local uchar*)" arena " + " byte-offset ");")
+    (str (type-name dialect type) "* " name " = reinterpret_cast<"
+         (type-name dialect type) "*>(" arena " + " byte-offset ");")))
+
+(defn workgroup-barrier
+  "Spell the verified full-workgroup acquire/release barrier."
+  [dialect]
+  (if (opencl? dialect) "barrier(CLK_LOCAL_MEM_FENCE);" "__syncthreads();"))
 
 (defn broadcast-expression
   [dialect input source-lane width]

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -685,7 +685,7 @@
 
 (def ^:private scalar-operation-kinds
   #{"ScalarCompute" "ScalarLoad" "ScalarStore" "Yield" "IfRegion" "ForLoop"
-    "Collective"})
+    "Collective" "WorkgroupBarrier"})
 
 (defn- scalar-body-operations
   [operations]
@@ -1194,6 +1194,9 @@
                                            *scalar-dialect* result-name 0 width) ";")))))))]
       [source next-context])
 
+    (record-kind? "WorkgroupBarrier" operation)
+    [(indent-lines depth (c-dialect/workgroup-barrier *scalar-dialect*)) context]
+
     (record-kind? "Yield" operation)
     (throw (ex-info "OpenCL scalar lowering found a misplaced Yield"
                     {:reason :raster/bug :operation operation}))
@@ -1211,13 +1214,19 @@
 
 (defn- scalar-storage-map
   [kernel-body]
-  (let [parameters (into {} (map (juxt :id identity)) (:parameters kernel-body))]
+  (let [parameters (into {} (map (juxt :id identity)) (:parameters kernel-body))
+        allocations (into {}
+                          (map (fn [allocation]
+                                 [(:id allocation)
+                                  (assoc allocation :kind :allocation
+                                         :memory-space :workgroup)]))
+                          (:allocations kernel-body))]
     (reduce (fn [storage view]
               (let [parent (get parameters (:buffer view))]
                 (assoc storage (:id view)
                        (assoc parent :id (:id view) :shape (:shape view)
                               :layout (:layout view) :view view))))
-            parameters (:views kernel-body))))
+            (merge parameters allocations) (:views kernel-body))))
 
 (defn- emit-scalar-kernel*
   [kernel-name kernel-body {:keys [parameter-names]}]
@@ -1241,6 +1250,10 @@
                                       (or (get parameter-names (:id parameter))
                                           (scalar-local-name (:id parameter)))])
                                    parameters))
+        allocation-names (into {}
+                               (map (fn [allocation]
+                                      [(:id allocation) (scalar-local-name (:id allocation))]))
+                               (:allocations kernel-body))
         _ (when-not (every? #(re-matches #"[A-Za-z_][A-Za-z0-9_]*" %)
                             (vals parameter-names))
             (throw (ex-info "C-family kernel parameter names must be C identifiers"
@@ -1250,7 +1263,7 @@
         indices (:indices kernel-body)
         names (reduce (fn [env index]
                         (assoc env (:id index) (scalar-local-name (:id index))))
-                      parameter-names indices)
+                      (merge parameter-names allocation-names) indices)
         types (reduce (fn [env index] (assoc env (:id index) :int))
                       (into {}
                             (map (fn [parameter]
@@ -1262,7 +1275,8 @@
             (throw (ex-info "C-family parameter and index names collide after target spelling"
                             {:reason :kernel-body-c-name-collision
                              :dialect (:id *scalar-dialect*) :names names})))
-        local-ids (concat (map :id indices) (scalar-defined-ids (:operations kernel-body)))
+        local-ids (concat (map :id (:allocations kernel-body))
+                          (map :id indices) (scalar-defined-ids (:operations kernel-body)))
         emitted-local-names (map scalar-local-name local-ids)
         all-emitted-names (concat (vals parameter-names) emitted-local-names)
         _ (when-not (= (count all-emitted-names) (count (set all-emitted-names)))
@@ -1273,6 +1287,20 @@
         storage (scalar-storage-map kernel-body)
         masks (into {} (map (juxt :id identity)) (:masks kernel-body))
         context {:names names :types types :storage storage :masks masks}
+        allocation-plan (body/workgroup-memory-plan (:allocations kernel-body))
+        arena-name "rstr_workgroup_memory"
+        allocation-source
+        (when (seq (:allocations kernel-body))
+          (str (indent-lines
+                1 (c-dialect/workgroup-arena-declaration
+                   *scalar-dialect* arena-name (:bytes allocation-plan)
+                   (:alignment allocation-plan)))
+               (apply str
+                      (for [{:keys [allocation byte-offset]} (:allocations allocation-plan)]
+                        (indent-lines
+                         1 (c-dialect/workgroup-pointer-declaration
+                            *scalar-dialect* (:dtype allocation)
+                            (get allocation-names (:id allocation)) arena-name byte-offset))))))
         index-source
         (apply str
                (for [index indices]
@@ -1289,8 +1317,9 @@
                       1 (str "int " name " = "
                              (emit-index-expression (:expression index) names) ";"))))))
         [operation-source _] (emit-scalar-operations (:operations kernel-body) context 1)
-        uses-half? (some #(= :half (dtype/canon (:dtype %))) parameters)
-        uses-double? (some #(= :double (dtype/canon (:dtype %))) parameters)
+        storage-declarations (concat parameters (:allocations kernel-body))
+        uses-half? (some #(= :half (dtype/canon (:dtype %))) storage-declarations)
+        uses-double? (some #(= :double (dtype/canon (:dtype %))) storage-declarations)
         collective (first (filter #(record-kind? "Collective" %) operations))
         uses-subgroups? (or collective
                             (some #(and (record-kind? "IndexBinding" %)
@@ -1310,7 +1339,7 @@
                           *scalar-dialect* % (get parameter-names (:id %)))
                         parameters))
          ") {\n"
-         index-source operation-source
+         allocation-source index-source operation-source
          "}\n")))
 
 (defn emit-scalar-kernel

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -14,6 +14,7 @@
 (defrecord KernelParameter [id kind dtype shape memory-space layout role])
 (defrecord BufferView [id buffer element-offset shape layout])
 (defrecord StableRead [buffer])
+(defrecord WorkgroupAllocation [id dtype shape layout alignment])
 (defrecord IndexBinding [id source axis])
 (defrecord IndexCompute [id expression])
 (defrecord IndexExpr [op arguments])
@@ -38,6 +39,7 @@
 (defrecord Participation [kind])
 (defrecord Collective
            [result kind scope width input operator source-lane participation association])
+(defrecord WorkgroupBarrier [scope memory-spaces semantics participation])
 
 (defrecord FragmentInit [fragment value])
 (defrecord TileLoad [fragment buffer coordinates mask cache])
@@ -48,11 +50,11 @@
 (defrecord TileStore [buffer fragment coordinates mask value-region])
 
 (defrecord KernelBody
-           [id parameters views stable-reads indices masks fragments operations schedule launch
-            provenance attributes])
+           [id parameters views stable-reads allocations indices masks fragments operations
+            schedule launch provenance attributes])
 
 (def ^:private parameter-kinds #{:input :output :scalar})
-(def ^:private index-sources #{:group :subgroup :lane})
+(def ^:private index-sources #{:group :local :subgroup :lane})
 (def ^:private index-ops #{:add :sub :mul :floor-div :ceil-div :mod :min :max})
 (def ^:private predicate-ops #{:lt :lte :eq :and :or :not})
 (def ^:private cache-policies #{:default :cached :streaming})
@@ -61,6 +63,8 @@
 (def ^:private cast-rounding-policies #{:toward-zero :nearest-even :up :down :exact})
 (def ^:private cast-overflow-policies #{:wrap :saturate :trap :exact :ieee})
 (def ^:private collective-kinds #{:reduce :broadcast})
+(def ^:private workgroup-memory-spaces #{:workgroup})
+(def ^:private barrier-semantics #{:acquire-release})
 
 (defn- record-kind? [class-name value]
   (and value (= class-name (.getName (class value)))))
@@ -124,6 +128,39 @@
   execution. This is an external binding precondition, not a load-local optimization hint."
   [buffer]
   (->StableRead buffer))
+
+(defn- align-up-static
+  [value alignment]
+  (* (quot (+ value (dec alignment)) alignment) alignment))
+
+(defn workgroup-memory-plan
+  "Deterministically pack statically shaped workgroup allocations.
+
+  Returns `{:allocations [{:allocation a :byte-offset n :byte-size n} ...]
+            :bytes n :alignment n}`. The verifier ties `:bytes` exactly to the launch resource
+  charge; C-family emitters consume this same plan instead of independently laying storage out."
+  [allocations]
+  (loop [remaining allocations offset 0 max-alignment 1 packed []]
+    (if-let [allocation (first remaining)]
+      (let [{:keys [dtype shape alignment]} allocation]
+        (when-not (and (record-kind?
+                        "raster.compiler.ir.kernel_body.WorkgroupAllocation" allocation)
+                       (dtype/known? dtype)
+                       (vector? shape) (seq shape) (every? pos-int? shape)
+                       (contains? #{1 2 4 8 16} alignment)
+                       (>= alignment (dtype/bytes-of dtype)))
+          (throw (ex-info
+                  "workgroup allocation requires a known dtype, static shape, and supported alignment"
+                  {:reason :kernel-body-workgroup-allocation :allocation allocation})))
+        (let [byte-offset (align-up-static offset alignment)
+              byte-size (* (reduce * shape) (dtype/bytes-of dtype))]
+          (recur (next remaining) (+ byte-offset byte-size) (max max-alignment alignment)
+                 (conj packed {:allocation allocation
+                               :byte-offset byte-offset
+                               :byte-size byte-size}))))
+      {:allocations packed
+       :bytes (align-up-static offset max-alignment)
+       :alignment max-alignment})))
 
 (def ^:private scalar-region-forbidden-ops
   '#{raster.par/scan raster.par/scan-exclusive raster.par/scatter! raster.par/reduce-by-key
@@ -262,7 +299,8 @@
                "raster.compiler.ir.kernel_body.Yield"
                "raster.compiler.ir.kernel_body.IfRegion"
                "raster.compiler.ir.kernel_body.ForLoop"
-               "raster.compiler.ir.kernel_body.Collective"}
+               "raster.compiler.ir.kernel_body.Collective"
+               "raster.compiler.ir.kernel_body.WorkgroupBarrier"}
              (some-> value class .getName)))
 
 (declare validate-operations!)
@@ -577,6 +615,18 @@
                          (expression? (:source-lane operation)))
             (throw (ex-info "subgroup broadcast requires a source lane and no reduction association"
                             {:operation operation})))))
+
+      (record-kind? "raster.compiler.ir.kernel_body.WorkgroupBarrier" operation)
+      (when-not (and (= :workgroup (:scope operation))
+                     (set? (:memory-spaces operation))
+                     (seq (:memory-spaces operation))
+                     (set/subset? (:memory-spaces operation) workgroup-memory-spaces)
+                     (contains? barrier-semantics (:semantics operation))
+                     (record-kind? "raster.compiler.ir.kernel_body.Participation"
+                                   (:participation operation))
+                     (= :full (get-in operation [:participation :kind])))
+        (throw (ex-info "workgroup barrier has an unsupported synchronization contract"
+                        {:reason :kernel-body-workgroup-barrier :operation operation})))
 
       :else
       (throw (ex-info "kernel body contains an unsupported operation"
@@ -1006,6 +1056,14 @@
                              :source-lane lane :width width})))))
       (assoc values (:id result) {:type result-type :uniformity subgroup-uniform}))
 
+    (record-kind? "raster.compiler.ir.kernel_body.WorkgroupBarrier" operation)
+    (do
+      (when-not (contains? control-uniformity :workgroup)
+        (throw (ex-info "workgroup barrier appears in divergent control flow"
+                        {:reason :kernel-body-divergent-workgroup-barrier
+                         :operation operation :control-uniformity control-uniformity})))
+      values)
+
     (record-kind? "raster.compiler.ir.kernel_body.Guard" operation)
     (let [guard-uniformity (mask-uniformity (:mask operation) masks values)]
       (validate-dataflow-operations!
@@ -1042,18 +1100,19 @@
   (when-not (kernel-body? body)
     (throw (ex-info "kernel body must be a KernelBody value"
                     {:body body :actual (type body)})))
-  (let [{:keys [id parameters views stable-reads indices masks fragments operations schedule launch
-                provenance attributes]} body]
+  (let [{:keys [id parameters views stable-reads allocations indices masks fragments operations
+                schedule launch provenance attributes]} body]
     (when (nil? id)
       (throw (ex-info "kernel body requires a stable identity" {:body body})))
     (doseq [[field values] [[:parameters parameters] [:views views] [:stable-reads stable-reads]
-                            [:indices indices] [:masks masks] [:fragments fragments]
-                            [:operations operations]]]
+                            [:allocations allocations] [:indices indices] [:masks masks]
+                            [:fragments fragments] [:operations operations]]]
       (when-not (vector? values)
         (throw (ex-info "kernel body sections must be ordered vectors"
                         {:field field :value values}))))
     (unique-ids! "kernel parameters" parameters)
     (unique-ids! "kernel buffer views" views)
+    (unique-ids! "kernel workgroup allocations" allocations)
     (unique-ids! "kernel indices" indices)
     (unique-ids! "kernel masks" masks)
     (unique-ids! "kernel fragments" fragments)
@@ -1076,6 +1135,13 @@
               (throw (ex-info "kernel buffer parameter requires a memory space"
                               {:parameter p}))))))
     (let [parameter-map (into {} (map (juxt :id identity)) parameters)
+          allocation-plan (workgroup-memory-plan allocations)
+          allocation-map (into {}
+                               (map (fn [allocation]
+                                      [(:id allocation)
+                                       (assoc allocation :kind :allocation
+                                              :memory-space :workgroup)]))
+                               allocations)
           scalar-ids (set (map :id (filter #(= :scalar (:kind %)) parameters)))
           launch-dimensions (launch/dimensions launch)
           index-scope
@@ -1086,7 +1152,7 @@
                (when-not (and (contains? index-sources (:source idx))
                               (integer? (:axis idx))
                               (case (:source idx)
-                                :group (< -1 (:axis idx) launch-dimensions)
+                                (:group :local) (< -1 (:axis idx) launch-dimensions)
                                 (:subgroup :lane) (zero? (:axis idx))))
                  (throw (ex-info "kernel index binding has an invalid hardware source" {:index idx})))
 
@@ -1160,7 +1226,21 @@
                       (assoc parent :id (:id view) :shape (:shape view)
                              :layout (:layout view) :view view))))
            {} views)
-          storage (merge parameter-map view-map)]
+          storage (merge parameter-map allocation-map view-map)]
+      (doseq [allocation allocations]
+        (layout! "workgroup allocation" (:layout allocation))
+        (when-not (and (= (:shape allocation) (get-in allocation [:layout :shape]))
+                       (= (dtype/canon (:dtype allocation))
+                          (dtype/canon (get-in allocation [:layout :dtype]))))
+          (throw (ex-info "workgroup allocation shape and dtype must agree with its layout"
+                          {:reason :kernel-body-workgroup-layout
+                           :allocation allocation}))))
+      (when (and (seq allocations)
+                 (not= (:bytes allocation-plan) (:shared-memory-bytes launch)))
+        (throw (ex-info "workgroup allocations and launch shared-memory charge disagree"
+                        {:reason :kernel-body-workgroup-byte-accounting
+                         :allocation-bytes (:bytes allocation-plan)
+                         :launch-shared-memory-bytes (:shared-memory-bytes launch)})))
       (let [stable-buffers (mapv :buffer stable-reads)]
         (when-not (= (count stable-buffers) (count (set stable-buffers)))
           (throw (ex-info "kernel stable-read requirements must name unique buffers"
@@ -1173,7 +1253,8 @@
               (throw (ex-info "kernel stable-read requirement must name an input parameter"
                               {:reason :kernel-body-stable-read-invalid
                                :requirement requirement :parameter buffer}))))))
-      (let [section-ids (vec (concat (map :id parameters) (map :id views) (map :id indices)
+      (let [section-ids (vec (concat (map :id parameters) (map :id views)
+                                     (map :id allocations) (map :id indices)
                                      (map :id masks) (map :id fragments)))]
         (when-not (= (count section-ids) (count (set section-ids)))
           (throw (ex-info "kernel storage, index, mask, and fragment identities must be globally unique"
@@ -1208,6 +1289,7 @@
                      (if (record-kind? "raster.compiler.ir.kernel_body.IndexBinding" idx)
                        (case (:source idx)
                          :group all-uniform
+                         :local lane-varying
                          :subgroup subgroup-uniform
                          :lane lane-varying)
                        (expression-uniformity (:expression idx) values))]
@@ -1234,9 +1316,9 @@
 
 (defn make
   "Construct and verify a target-neutral scheduled kernel body."
-  [{:keys [id parameters views stable-reads indices masks fragments operations schedule launch
-           provenance attributes]
-    :or {parameters [] views [] stable-reads [] indices [] masks [] fragments [] operations []
-         schedule {} launch {} provenance {} attributes {}}}]
-  (validate! (->KernelBody id parameters views stable-reads indices masks fragments operations
-                           schedule launch provenance attributes)))
+  [{:keys [id parameters views stable-reads allocations indices masks fragments operations schedule
+           launch provenance attributes]
+    :or {parameters [] views [] stable-reads [] allocations [] indices [] masks [] fragments []
+         operations [] schedule {} launch {} provenance {} attributes {}}}]
+  (validate! (->KernelBody id parameters views stable-reads allocations indices masks fragments
+                           operations schedule launch provenance attributes)))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -2,6 +2,8 @@
   "Generate production scheduled KernelBody sources for hardware-free CUDA/HIP CI gates."
   (:require [clojure.java.io :as io]
             [raster.compiler.backend.gpu.attention :as attention-emit]
+            [raster.compiler.backend.gpu.kernel-body-fixtures :as body-fixtures]
+            [raster.compiler.backend.gpu.kernel-body-opencl :as body-emit]
             [raster.compiler.backend.gpu.target :as gpu-target]
             [raster.compiler.ir.attention :as attention]
             [raster.compiler.ir.kernel-executable :as executable]
@@ -36,6 +38,12 @@
     (spit file (:source artifact))
     (.getAbsolutePath file)))
 
+(defn- write-source!
+  [directory suffix label source]
+  (let [file (io/file directory (str label suffix))]
+    (spit file source)
+    (.getAbsolutePath file)))
+
 (defn emit-target!
   [root target]
   (let [{:keys [suffix descriptor]} (get targets target)
@@ -56,7 +64,11 @@
         cooperative (attention-emit/emit-fp16-cooperative
                      plan cooperative-schedule dialect)
         tiled (attention-emit/emit-fp16-tiled-history plan tiled-schedule dialect)]
-    (into [(write-artifact! directory suffix "cooperative" cooperative)]
+    (into [(write-artifact! directory suffix "cooperative" cooperative)
+           (write-source! directory suffix "workgroup-memory"
+                          (body-emit/emit-scalar-kernel
+                           "workgroup_memory" (body-fixtures/workgroup-memory-body 32)
+                           {:target-dialect dialect}))]
           (map-indexed (fn [index artifact]
                          (write-artifact! directory suffix (str "tiled-" index) artifact))
                        (executable/artifacts tiled)))))

--- a/test/raster/compiler/backend/gpu/kernel_body_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_fixtures.clj
@@ -1,0 +1,35 @@
+(ns raster.compiler.backend.gpu.kernel-body-fixtures
+  "Shared verifier, source-compile, and device fixtures for scheduled KernelBody operations."
+  (:require [raster.compiler.core.layout :as layout]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-launch :as launch]))
+
+(defn workgroup-memory-body
+  "A workgroup reverses one row through explicitly allocated local storage and a barrier."
+  [width]
+  (body/make
+   {:id :c-family-workgroup-memory-gate
+    :parameters [(body/->KernelParameter
+                  'x :input :float [width] :global
+                  (layout/row-major [width] :float) :input)
+                 (body/->KernelParameter
+                  'y :output :float [width] :global
+                  (layout/row-major [width] :float) :result)]
+    :stable-reads [(body/stable-read 'x)]
+    :allocations [(body/->WorkgroupAllocation
+                   'scratch :float [width] (layout/row-major [width] :float) 16)]
+    :indices [(body/->IndexBinding 'lane :local 0)]
+    :operations [(body/->ScalarLoad (body/value 'input-value :float)
+                                    'x ['lane] nil nil :cached)
+                 (body/->ScalarStore 'scratch ['lane] 'input-value nil)
+                 (body/->WorkgroupBarrier :workgroup #{:workgroup} :acquire-release
+                                          (body/full-participation))
+                 (body/->ScalarLoad
+                  (body/value 'mirrored-value :float) 'scratch
+                  [(body/expression :sub (dec width) 'lane)] nil nil :cached)
+                 (body/->ScalarStore 'y ['lane] 'mirrored-value nil)]
+    :schedule {}
+    :launch (launch/spec {:workgroup-size [width] :group-count [1]
+                          :shared-memory-bytes (* width 4)})
+    :provenance {:dialect :compile-gate}
+    :attributes {:kind :workgroup-memory}}))

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.java.shell :as shell]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.kernel-body-fixtures :as fixtures]
             [raster.compiler.backend.gpu.kernel-body-opencl :as opencl]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.ir.kernel-body :as body]
@@ -87,6 +88,11 @@
       :launch (launch/spec {:workgroup-size [16] :group-count [2]})
       :provenance {:dialect :test}
       :attributes {:kind :scalar}})))
+
+(defn workgroup-kernel-body
+  "Small production-shaped fixture shared with the hardware-free vendor compiler gates."
+  []
+  (fixtures/workgroup-memory-body 16))
 
 (deftest scalar-kernel-body-lowers-without-recovering-a-schedule
   (let [source (opencl/emit-scalar-kernel
@@ -211,3 +217,29 @@
       (let [{:keys [exit err]} (shell/sh "clang" "-x" "cl" "-cl-std=CL2.0"
                                          "-fsyntax-only" "-" :in source)]
         (is (zero? exit) err)))))
+
+(deftest workgroup-memory-and-barriers-share-one-c-family-lowering
+  (doseq [[target arena barrier pointer]
+          [[:opencl-intel "__local uint4 rstr_workgroup_memory[4]"
+            "barrier(CLK_LOCAL_MEM_FENCE);" "__local float* rstr_scratch"]
+           [:cuda "__shared__ __align__(16) unsigned char rstr_workgroup_memory[64]"
+            "__syncthreads();" "float* rstr_scratch = reinterpret_cast<float*>"]
+           [:hip "__shared__ __attribute__((aligned(16))) unsigned char rstr_workgroup_memory[64]"
+            "__syncthreads();" "float* rstr_scratch = reinterpret_cast<float*>"]]]
+    (testing (name target)
+      (let [source (opencl/emit-scalar-kernel
+                    "workgroup_memory" (workgroup-kernel-body)
+                    {:target-dialect target})]
+        (is (str/includes? source arena))
+        (is (str/includes? source pointer))
+        (is (str/includes? source barrier))
+        (is (str/includes? source "rstr_scratch[(((long)(rstr_lane) * (long)(1)))]")))))
+  (testing "the portable OpenCL source remains valid OpenCL C"
+    (let [source (opencl/emit-scalar-kernel
+                  "workgroup_memory" (workgroup-kernel-body)
+                  {:target-dialect :opencl-portable})]
+      (if-not (command-available? "clang")
+        (is true "clang unavailable; source structure remains covered")
+        (let [{:keys [exit err]} (shell/sh "clang" "-x" "cl" "-cl-std=CL2.0"
+                                           "-fsyntax-only" "-" :in source)]
+          (is (zero? exit) err))))))

--- a/test/raster/compiler/backend/gpu/kernel_body_workgroup_device_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_workgroup_device_test.clj
@@ -1,0 +1,55 @@
+(ns raster.compiler.backend.gpu.kernel-body-workgroup-device-test
+  "Numerical OpenCL oracle for verified workgroup storage and synchronization."
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.backend.gpu.kernel-body-fixtures :as fixtures]
+            [raster.compiler.backend.gpu.kernel-body-opencl :as body-emit]
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-body-abi :as body-abi]
+            [raster.compiler.ir.kernel-call :as kcall]
+            [raster.gpu.device-probe :as device-probe]))
+
+(defn- artifact
+  [width]
+  (let [kernel-body (fixtures/workgroup-memory-body width)
+        abi (body-abi/project-contracts
+             [(kabi/slot 'x :input :float :c-name "rstr_x" :role :input)
+              (kabi/slot 'y :output :float :c-name "rstr_y" :role :result)]
+             kernel-body)]
+    (kart/make
+     {:kernel-name "kernel_body_workgroup_reverse"
+      :target :opencl-c
+      :source (body-emit/emit-scalar-kernel
+               "kernel_body_workgroup_reverse" kernel-body
+               {:target-dialect :opencl-portable})
+      :abi abi
+      :arguments '[x y]
+      :launch (:launch kernel-body)
+      :effects {:kind :workgroup-permutation}
+      :provenance {:kernel-body (:id kernel-body)}
+      :attributes {:workgroup-memory-bytes
+                   (get-in kernel-body [:launch :shared-memory-bytes])}})))
+
+(deftest workgroup-local-roundtrip-is-correct-on-opencl
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "KernelBody workgroup-local storage and barrier")
+    (let [ocl (find-ns 'raster.gpu.ocl-runtime)
+          register! (ns-resolve ocl 'register-kernel!)
+          buffer-of-array (ns-resolve ocl 'buffer-of-array)
+          make-buffer (ns-resolve ocl 'make-buffer)
+          bind-call (ns-resolve ocl 'bind-kernel-call)
+          launch! (ns-resolve ocl 'launch-registered-bound!)
+          buffer->array (ns-resolve ocl 'buffer->array)
+          free! (ns-resolve ocl 'free-buffer!)
+          width 16
+          input (float-array (map float (range width)))
+          compiled (artifact width)
+          x (buffer-of-array input :float)
+          y (make-buffer width :float)]
+      (try
+        (register! (:kernel-name compiled) compiled)
+        (launch! (bind-call (kcall/make compiled [x y])))
+        (is (= (vec (reverse input)) (vec (buffer->array y))))
+        (finally
+          (free! y)
+          (free! x))))))

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -126,8 +126,9 @@
                                        (axis-map/of-axes [['group-x 8]]))))))))
 
 (defn- scalar-body
-  [operations & {:keys [masks stable-reads schedule]
-                 :or {masks [] stable-reads [] schedule {:subgroup-size 16}}}]
+  [operations & {:keys [masks stable-reads allocations schedule shared-memory-bytes]
+                 :or {masks [] stable-reads [] allocations [] schedule {:subgroup-size 16}
+                      shared-memory-bytes 0}}]
   (body/make
    {:id :scalar
     :parameters [(body/->KernelParameter
@@ -140,9 +141,11 @@
               (body/->IndexBinding 'lane :lane 0)]
     :masks masks
     :stable-reads stable-reads
+    :allocations allocations
     :operations operations
     :schedule schedule
-    :launch (launch/spec {:workgroup-size [16] :group-count [1]})
+    :launch (launch/spec {:workgroup-size [16] :group-count [1]
+                          :shared-memory-bytes shared-memory-bytes})
     :provenance {:dialect :test}
     :attributes {:kind :scalar}}))
 
@@ -578,3 +581,70 @@
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo #"invalid hardware source"
          (body/validate! (assoc-in kernel [:indices 1 :axis] 1))))))
+
+(defn- scratch-allocation
+  ([] (scratch-allocation 'scratch :float [16] 16))
+  ([id dtype shape alignment]
+   (body/->WorkgroupAllocation id dtype shape (layout/row-major shape dtype) alignment)))
+
+(defn- workgroup-barrier []
+  (body/->WorkgroupBarrier :workgroup #{:workgroup} :acquire-release
+                           (body/full-participation)))
+
+(deftest workgroup-storage-has-exact-static-resource-accounting
+  (let [allocations [(scratch-allocation 'bytes :byte [3] 1)
+                     (scratch-allocation 'values :float [4] 16)]
+        plan (body/workgroup-memory-plan allocations)
+        kernel (scalar-body
+                [(body/->ScalarStore 'values [0] (body/literal 1.0 :float) nil)
+                 (workgroup-barrier)
+                 (body/->ScalarLoad (body/value 'loaded :float) 'values [0] nil nil :cached)]
+                :allocations allocations :shared-memory-bytes 32)]
+    (is (= [{:allocation (first allocations) :byte-offset 0 :byte-size 3}
+            {:allocation (second allocations) :byte-offset 16 :byte-size 16}]
+           (:allocations plan)))
+    (is (= 32 (:bytes plan)))
+    (is (= 16 (:alignment plan)))
+    (is (body/kernel-body? kernel))
+    (testing "the launch charge cannot under- or over-state the packed arena"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"shared-memory charge disagree"
+           (scalar-body [] :allocations allocations :shared-memory-bytes 31))))
+    (testing "dynamic allocation shapes are rejected before target lowering"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"static shape"
+           (scalar-body []
+                        :allocations [(scratch-allocation 'dynamic :float ['n] 16)]
+                        :shared-memory-bytes 0))))
+    (testing "the allocation layout cannot drift from its storage contract"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"agree with its layout"
+           (scalar-body []
+                        :allocations [(assoc (scratch-allocation) :layout
+                                             (layout/row-major [8] :float))]
+                        :shared-memory-bytes 64))))))
+
+(deftest workgroup-barriers-require-full-convergent-participation
+  (let [barrier (workgroup-barrier)]
+    (is (body/kernel-body? (scalar-body [barrier])))
+    (testing "a lane-varying branch cannot contain a workgroup barrier"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"divergent control flow"
+           (scalar-body
+            [(load-x)
+             (body/->ScalarCompute
+              (body/value 'negative? :predicate)
+              (body/scalar-expression :lt :predicate
+                                      ['x-value (body/literal 0.0 :float)]))
+             (body/->IfRegion 'negative?
+                              [barrier (body/->Yield [])]
+                              [(body/->Yield [])]
+                              [])]))))
+    (testing "barrier scope, memory semantics, and participation are explicit"
+      (doseq [invalid [(assoc barrier :scope :subgroup)
+                       (assoc barrier :memory-spaces #{:global})
+                       (assoc barrier :semantics :relaxed)
+                       (assoc barrier :participation (body/->Participation :masked))]]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"unsupported synchronization contract"
+             (scalar-body [invalid])))))))


### PR DESCRIPTION
## Summary
- add explicit 1–3D workgroup-local thread indices, statically shaped/aligned workgroup allocations, and full-participation acquire/release barriers to KernelBody
- verify deterministic shared-memory packing, exact launch byte accounting for allocation-backed bodies, and reject divergent barriers
- lower the same verified body to portable/Intel OpenCL, CUDA, and HIP, including a hardware-free vendor compile fixture
- add an optional OpenCL numerical oracle and update the compiler north star

## Validation
- 23 focused tests, 128 assertions: green
- latest workgroup fixture compiled with `nvcc -ptx -arch=sm_80`
- latest workgroup fixture compiled with `hipcc --offload-arch=gfx1100 --genco`
- portable OpenCL source accepted by clang
- exact artifact executed through POCL and produced the expected cross-lane reverse
- clj-kondo: 0 errors (existing analyzer warnings only)
- cljfmt and `git diff --check`: clean

The full local suite was left to CI because this host has exhausted swap; the wider selected run also exposed the checkout's current no-`/dev/dri` DPAS fixture dependence, unrelated to this change.