### PR TITLE
Verify asynchronous workgroup staging

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -112,9 +112,19 @@ wrap/saturate/trap policies. Whole-kernel workgroup allocations now have static 
 layouts, explicit 1–16-byte alignment, and one deterministic packed-memory plan; launch shared-byte
 accounting must match that plan exactly. Full-participation acquire/release workgroup barriers are
 rejected outside workgroup-uniform control flow and lower from the same operation to OpenCL,
-CUDA, and HIP. Masked collectives and asynchronous copies remain absent until a concrete schedule
-supplies enough information to verify their participation, issue/commit/wait lifetime, and target
-capability. An implemented OpenCL
+CUDA, and HIP. Workgroup-cooperative contiguous global-to-workgroup copies now carry explicit
+source/destination coordinates, element and transfer widths, cache intent, full participation, and
+preferred-versus-required overlap. Named commits close the exact copies issued since the previous
+commit; waits consume an oldest group prefix and state the remaining pipeline depth. The verifier
+rejects unstable sources, divergent base addresses, live destination reuse, lifetimes crossing a
+structured-region boundary, and staged-memory consumption before a separate workgroup barrier.
+Required overlap also proves coordinate alignment, projects its base-address alignment through the
+ordered ABI, and direct calls validate resident ranges before launch; preferred CUDA overlap keeps
+a uniform runtime-alignment fallback.
+OpenCL lowers the dependency graph to events, CUDA targets with compute capability 8.0 or newer to
+`cp.async` groups, and older/unknown CUDA or HIP targets report an honest synchronous cooperative
+lowering; those targets reject a schedule that requires overlap. Masked collectives
+remain absent until a concrete schedule supplies verifiable participation. An implemented OpenCL
 target spelling now lowers this general scalar/control vocabulary directly: dense ranked loads and
 stores (including contiguous leading-slice views), SSA expressions, structured branch/loop yields,
 explicit numerical casts, and full-subgroup reductions/broadcasts, without recovering an algorithm
@@ -139,11 +149,13 @@ CUDA and HIP spelling descriptors. The same scheduled cooperative and tiled-hist
 one ordered ABI while OpenCL uses subgroup builtins and CUDA/HIP select explicit shuffle-down trees;
 the emitted artifacts record that target association. CUDA is compiled to PTX and HIP to an RDNA3
 code object in mandatory hardware-free CI jobs, while real Intel execution remains the numerical
-oracle. The compiler fixtures now also stage values through verified workgroup memory and a barrier;
-CUDA/HIP runtime registration, launch and on-device numerical coverage remain deliberately separate
-from source legality. Async copy/commit/wait operations and a schedule that uses the new staging
-substrate can subsequently collapse a multi-kernel tiled graph into a FlashAttention-like single
-kernel without changing the semantic plan or external ABI.
+oracle. The compiler fixtures now stage values through both synchronous workgroup memory and the
+verified async issue/commit/wait contract; the exact async body is compiled to CUDA sm_80 PTX and
+an RDNA3 HIP code object in hardware-free CI. CUDA/HIP runtime registration, launch and on-device
+numerical coverage remain deliberately separate from source legality. The next production step is a
+double-buffered scheduled weighted-reduction body that uses this substrate, followed by local
+swizzles and measured stage-depth selection; this can collapse the tiled graph toward a
+FlashAttention-like single kernel without changing the semantic plan or external ABI.
 
 ### 2.3 Executable steps and resident artifact values compose
 

--- a/src/raster/compiler/backend/gpu/kernel_body_c_dialect.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_c_dialect.clj
@@ -4,7 +4,8 @@
   A dialect never selects a schedule. It only spells verified storage types, hardware indices,
   entry points and subgroup shuffles for one target language. CUDA and HIP intentionally share
   the same structural lowering while retaining distinct collective intrinsics and module targets."
-  (:require [raster.compiler.core.dtype :as dtype]))
+  (:require [clojure.string :as str]
+            [raster.compiler.core.dtype :as dtype]))
 
 (def ^:private dialects
   {:opencl-intel {:id :opencl-intel :target :opencl-c :family :opencl
@@ -28,6 +29,17 @@
 (defn family [dialect] (:family dialect))
 (defn collective-association [dialect] (:association dialect))
 (defn opencl? [dialect] (= :opencl (family dialect)))
+
+(defn async-copy-mode
+  "Report the physical lowering used for the target-neutral async dependency contract."
+  [dialect]
+  (case (:id dialect)
+    (:opencl-intel :opencl-portable) :native-events
+    :cuda (if (and (vector? (:compute-capability dialect))
+                   (not (neg? (compare (:compute-capability dialect) [8 0]))))
+            :native-cp-async
+            :synchronous-cooperative)
+    :hip :synchronous-cooperative))
 
 (defn type-name
   [dialect type]
@@ -140,6 +152,68 @@
   "Spell the verified full-workgroup acquire/release barrier."
   [dialect]
   (if (opencl? dialect) "barrier(CLK_LOCAL_MEM_FENCE);" "__syncthreads();"))
+
+(defn async-copy
+  "Spell one workgroup-cooperative contiguous global-to-workgroup copy."
+  [dialect {:keys [name source destination elements element-bytes transfer-bytes workgroup-width
+                   overlap]}]
+  (case (async-copy-mode dialect)
+    :native-events
+    (str "event_t " name " = async_work_group_copy(" destination ", " source ", "
+         elements ", (event_t)0);")
+
+    :native-cp-async
+    (let [offset (str name "_byte_offset")
+          shared-address (str name "_shared_address")
+          native-copy
+          (str "for (int " offset " = (" (linear-thread-id) ") * " transfer-bytes
+               "; " offset " < " (* elements element-bytes) "; " offset " += "
+               workgroup-width " * " transfer-bytes ") {\n"
+               "  unsigned int " shared-address
+               " = (unsigned int)__cvta_generic_to_shared((void*)((unsigned char*)"
+               destination " + " offset "));\n"
+               "  asm volatile(\"cp.async.ca.shared.global [%0], [%1], " transfer-bytes
+               ";\\n\" :: \"r\"(" shared-address "), \"l\"((const unsigned char*)"
+               source " + " offset "));\n"
+               "}")
+          fallback-offset (str name "_fallback_element_offset")
+          fallback
+          (str "for (int " fallback-offset " = " (linear-thread-id) "; " fallback-offset
+               " < " elements "; " fallback-offset " += " workgroup-width ") {\n"
+               "  " destination "[" fallback-offset "] = " source "[" fallback-offset "];\n"
+               "}")]
+      (if (= :required overlap)
+        native-copy
+        (str "if ((((uintptr_t)" source " | (uintptr_t)" destination ") & "
+             (dec transfer-bytes) ") == 0) {\n"
+             (str/replace native-copy #"(?m)^" "  ") "\n} else {\n"
+             (str/replace fallback #"(?m)^" "  ") "\n}")))
+
+    :synchronous-cooperative
+    (let [offset (str name "_element_offset")]
+      (str "for (int " offset " = " (linear-thread-id) "; " offset " < " elements
+           "; " offset " += " workgroup-width ") {\n"
+           "  " destination "[" offset "] = " source "[" offset "];\n"
+           "}"))))
+
+(defn async-commit
+  [dialect group]
+  (case (async-copy-mode dialect)
+    :native-cp-async "asm volatile(\"cp.async.commit_group;\\n\" ::);"
+    :native-events (str "/* OpenCL event group " group " committed at issue. */")
+    :synchronous-cooperative (str "/* synchronous async group " group " committed. */")))
+
+(defn async-wait
+  [dialect event-names pending-groups]
+  (case (async-copy-mode dialect)
+    :native-events
+    (str/join "\n" (map #(str "wait_group_events(1, &" % ");") event-names))
+
+    :native-cp-async
+    (str "asm volatile(\"cp.async.wait_group " pending-groups ";\\n\" ::);")
+
+    :synchronous-cooperative
+    "/* synchronous cooperative copies are complete before this wait. */"))
 
 (defn broadcast-expression
   [dialect input source-lane width]

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -685,7 +685,7 @@
 
 (def ^:private scalar-operation-kinds
   #{"ScalarCompute" "ScalarLoad" "ScalarStore" "Yield" "IfRegion" "ForLoop"
-    "Collective" "WorkgroupBarrier"})
+    "Collective" "WorkgroupBarrier" "AsyncWorkgroupCopy" "AsyncCommit" "AsyncWait"})
 
 (defn- scalar-body-operations
   [operations]
@@ -1197,6 +1197,55 @@
     (record-kind? "WorkgroupBarrier" operation)
     [(indent-lines depth (c-dialect/workgroup-barrier *scalar-dialect*)) context]
 
+    (record-kind? "AsyncWorkgroupCopy" operation)
+    (let [mode (c-dialect/async-copy-mode *scalar-dialect*)
+          _ (when (and (= :required (:overlap operation))
+                       (= :synchronous-cooperative mode))
+              (throw (ex-info "target cannot preserve required async-copy overlap"
+                              {:reason :kernel-body-c-async-overlap
+                               :dialect (:id *scalar-dialect*)
+                               :operation operation :lowering mode})))
+          source-storage (get-in context [:storage (:source operation)])
+          destination-storage (get-in context [:storage (:destination operation)])
+          source-base (get-in context [:names (or (some-> source-storage :view :buffer)
+                                                  (:id source-storage))])
+          destination-base (get-in context [:names (:id destination-storage)])
+          source-index (emit-storage-index source-storage (:source-coordinates operation)
+                                           (:names context))
+          destination-index (emit-storage-index destination-storage
+                                                (:destination-coordinates operation)
+                                                (:names context))
+          copy-name (scalar-local-name (:id operation))
+          source (str "(&" source-base "[" source-index "])")
+          destination (str "(&" destination-base "[" destination-index "])")
+          source-code (c-dialect/async-copy
+                       *scalar-dialect*
+                       {:name copy-name :source source :destination destination
+                        :elements (:elements operation)
+                        :element-bytes (dtype/bytes-of (:dtype source-storage))
+                        :transfer-bytes (:transfer-bytes operation)
+                        :overlap (:overlap operation)
+                        :workgroup-width (:workgroup-width context)})]
+      [(indent-lines depth source-code)
+       (-> context
+           (assoc-in [:async-copies (:id operation)] copy-name)
+           (update :async-issued conj (:id operation)))])
+
+    (record-kind? "AsyncCommit" operation)
+    [(indent-lines depth (c-dialect/async-commit *scalar-dialect* (:id operation)))
+     (-> context
+         (assoc :async-issued [])
+         (update :async-groups conj {:id (:id operation) :copies (:copies operation)}))]
+
+    (record-kind? "AsyncWait" operation)
+    (let [group-count (count (:groups operation))
+          waited (subvec (:async-groups context) 0 group-count)
+          event-names (mapv #(get-in context [:async-copies %]) (mapcat :copies waited))]
+      [(indent-lines depth
+                     (c-dialect/async-wait *scalar-dialect* event-names
+                                           (:pending-groups operation)))
+       (assoc context :async-groups (subvec (:async-groups context) group-count))])
+
     (record-kind? "Yield" operation)
     (throw (ex-info "OpenCL scalar lowering found a misplaced Yield"
                     {:reason :raster/bug :operation operation}))
@@ -1276,7 +1325,11 @@
                             {:reason :kernel-body-c-name-collision
                              :dialect (:id *scalar-dialect*) :names names})))
         local-ids (concat (map :id (:allocations kernel-body))
-                          (map :id indices) (scalar-defined-ids (:operations kernel-body)))
+                          (map :id indices) (scalar-defined-ids (:operations kernel-body))
+                          (keep #(when (contains? #{"AsyncWorkgroupCopy" "AsyncCommit"}
+                                                  (some-> % class .getSimpleName))
+                                   (:id %))
+                                operations))
         emitted-local-names (map scalar-local-name local-ids)
         all-emitted-names (concat (vals parameter-names) emitted-local-names)
         _ (when-not (= (count all-emitted-names) (count (set all-emitted-names)))
@@ -1286,7 +1339,9 @@
                              :ids (vec local-ids)})))
         storage (scalar-storage-map kernel-body)
         masks (into {} (map (juxt :id identity)) (:masks kernel-body))
-        context {:names names :types types :storage storage :masks masks}
+        context {:names names :types types :storage storage :masks masks
+                 :workgroup-width (reduce * (get-in kernel-body [:launch :workgroup-size]))
+                 :async-copies {} :async-issued [] :async-groups []}
         allocation-plan (body/workgroup-memory-plan (:allocations kernel-body))
         arena-name "rstr_workgroup_memory"
         allocation-source
@@ -1348,14 +1403,17 @@
   The body already fixes schedules, types, layouts, masks, convergence and numerical conversion
   policies. `parameter-names` may only select ABI spelling; `target-dialect` defaults to the
   production Intel OpenCL row and may select `:opencl-portable`, `:cuda`, or `:hip`. Target
-  selection cannot alter the scheduled body."
+  selection cannot alter the scheduled body. `target-features` may only select a capability-gated
+  physical implementation (for example Ampere `cp.async`) with the same verified semantics."
   ([kernel-name kernel-body]
    (emit-scalar-kernel kernel-name kernel-body {}))
-  ([kernel-name kernel-body {:keys [target-dialect subgroup-attribute] :as options
+  ([kernel-name kernel-body {:keys [target-dialect subgroup-attribute target-features] :as options
                              :or {target-dialect :opencl-intel subgroup-attribute :intel}}]
    (let [target-dialect (if (and (= :opencl-intel target-dialect)
                                  (= :none subgroup-attribute))
                           :opencl-portable
                           target-dialect)]
-     (binding [*scalar-dialect* (c-dialect/resolve! target-dialect)]
+     (binding [*scalar-dialect*
+               (merge (c-dialect/resolve! target-dialect)
+                      (select-keys target-features [:compute-capability :architecture]))]
        (emit-scalar-kernel* kernel-name kernel-body options)))))

--- a/src/raster/compiler/ir/kernel_abi.clj
+++ b/src/raster/compiler/ir/kernel_abi.clj
@@ -12,15 +12,16 @@
 
 (defn slot
   "Construct one ABI slot. Options: :c-name, :kernel-dtype, :role, :binding, :field, and
-  :aliasing.
+  :aliasing, and :alignment.
 
    `:binding` names the logical caller value that supplies a physical pointer slot. It is
    normally absent (and therefore identical to `:name`), but an SoA argument has one physical
    slot per field and all of those slots share the same logical binding.
    `:field` identifies this physical leaf within a composite logical binding.
    `:aliasing :no-write-alias` is an input-pointer precondition: its complete bound range must be
-   disjoint from every output pointer range for the duration of the launch."
-  [nm kind dtype & {:keys [c-name kernel-dtype role binding field aliasing]}]
+   disjoint from every output pointer range for the duration of the launch.
+   `:alignment` is a power-of-two byte alignment required of a pointer binding."
+  [nm kind dtype & {:keys [c-name kernel-dtype role binding field aliasing alignment]}]
   (cond-> {:name nm
            :c-name (or c-name (name nm))
            :kind kind
@@ -29,7 +30,8 @@
     role (assoc :role role)
     binding (assoc :binding binding)
     field (assoc :field field)
-    aliasing (assoc :aliasing aliasing)))
+    aliasing (assoc :aliasing aliasing)
+    alignment (assoc :alignment alignment)))
 
 (defn validate!
   "Validate an ordered ABI and return it unchanged.  A kernel has at least one output;
@@ -63,7 +65,13 @@
                (not (and (= :input (:kind s)) (= :no-write-alias (:aliasing s)))))
       (throw (ex-info "kernel ABI aliasing contract is unsupported for this slot"
                       {:index i :slot s :abi abi
-                       :supported {:kind :input :aliasing :no-write-alias}}))))
+                       :supported {:kind :input :aliasing :no-write-alias}})))
+    (when (and (:alignment s)
+               (not (and (not= :scalar (:kind s))
+                         (integer? (:alignment s)) (pos? (:alignment s))
+                         (zero? (bit-and (:alignment s) (dec (:alignment s)))))))
+      (throw (ex-info "kernel ABI pointer alignment must be a positive power of two"
+                      {:index i :slot s :abi abi}))))
   (when-not (= (count abi) (count (distinct (map :c-name abi))))
     (throw (ex-info "kernel ABI parameter names must be unique" {:abi abi})))
   (let [pointers (vec (remove #(= :scalar (:kind %)) abi))]

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -8,6 +8,7 @@
   (:require [clojure.set :as set]
             [raster.compiler.backend.intrinsics :as intrinsics]
             [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.layout :as layout]
             [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.kernel-launch :as launch]))
 
@@ -40,6 +41,11 @@
 (defrecord Collective
            [result kind scope width input operator source-lane participation association])
 (defrecord WorkgroupBarrier [scope memory-spaces semantics participation])
+(defrecord AsyncWorkgroupCopy
+           [id source source-coordinates destination destination-coordinates elements
+            transfer-bytes cache overlap participation])
+(defrecord AsyncCommit [id copies])
+(defrecord AsyncWait [groups pending-groups semantics participation])
 
 (defrecord FragmentInit [fragment value])
 (defrecord TileLoad [fragment buffer coordinates mask cache])
@@ -65,6 +71,9 @@
 (def ^:private collective-kinds #{:reduce :broadcast})
 (def ^:private workgroup-memory-spaces #{:workgroup})
 (def ^:private barrier-semantics #{:acquire-release})
+(def ^:private async-wait-semantics #{:acquire})
+(def ^:private async-overlap-policies #{:preferred :required})
+(def ^:private async-transfer-widths #{4 8 16})
 
 (defn- record-kind? [class-name value]
   (and value (= class-name (.getName (class value)))))
@@ -209,6 +218,42 @@
     (reduce into #{} (map expression-references (:arguments value)))
     :else #{}))
 
+(defn- gcd-static
+  [left right]
+  (loop [left (abs (long left)) right (abs (long right))]
+    (if (zero? right) left (recur right (mod left right)))))
+
+(defn- expression-divisible?
+  "Conservative proof that every realization of an index expression is divisible by divisor."
+  [value divisor]
+  (cond
+    (= 1 divisor) true
+    (integer? value) (zero? (mod value divisor))
+    (value-id? value) false
+    (not (record-kind? "raster.compiler.ir.kernel_body.IndexExpr" value)) false
+    (contains? #{:add :sub} (:op value))
+    (every? #(expression-divisible? % divisor) (:arguments value))
+    (= :mul (:op value))
+    (some #(expression-divisible? % divisor) (:arguments value))
+    :else false))
+
+(defn- storage-offset-aligned?
+  [storage coordinates alignment]
+  (let [element-bytes (dtype/bytes-of (:dtype storage))
+        strides (layout/resolve-strides (:layout storage))
+        terms (map vector coordinates strides)
+        aligned-term?
+        (fn [[coordinate stride]]
+          (and (integer? stride)
+               (let [coefficient (* element-bytes stride)
+                     remaining (quot alignment (gcd-static coefficient alignment))]
+                 (expression-divisible? coordinate remaining))))
+        view-offset (some-> storage :view :element-offset)]
+    (and (every? aligned-term? terms)
+         (or (nil? view-offset)
+             (expression-divisible?
+              view-offset (quot alignment (gcd-static element-bytes alignment)))))))
+
 (defn- predicate? [value]
   (and (record-kind? "raster.compiler.ir.kernel_body.Predicate" value)
        (contains? predicate-ops (:op value))
@@ -300,7 +345,10 @@
                "raster.compiler.ir.kernel_body.IfRegion"
                "raster.compiler.ir.kernel_body.ForLoop"
                "raster.compiler.ir.kernel_body.Collective"
-               "raster.compiler.ir.kernel_body.WorkgroupBarrier"}
+               "raster.compiler.ir.kernel_body.WorkgroupBarrier"
+               "raster.compiler.ir.kernel_body.AsyncWorkgroupCopy"
+               "raster.compiler.ir.kernel_body.AsyncCommit"
+               "raster.compiler.ir.kernel_body.AsyncWait"}
              (some-> value class .getName)))
 
 (declare validate-operations!)
@@ -627,6 +675,62 @@
                      (= :full (get-in operation [:participation :kind])))
         (throw (ex-info "workgroup barrier has an unsupported synchronization contract"
                         {:reason :kernel-body-workgroup-barrier :operation operation})))
+
+      (record-kind? "raster.compiler.ir.kernel_body.AsyncWorkgroupCopy" operation)
+      (let [source (parameter (:source operation))
+            destination (parameter (:destination operation))
+            elements (:elements operation)
+            transfer-bytes (:transfer-bytes operation)]
+        (coordinates! "async-copy source" (:source-coordinates operation))
+        (coordinates! "async-copy destination" (:destination-coordinates operation))
+        (when-not (and (value-id? (:id operation))
+                       (= :input (:kind source))
+                       (= :global (:memory-space source))
+                       (= :allocation (:kind destination))
+                       (= :workgroup (:memory-space destination))
+                       (= (dtype/canon (:dtype source)) (dtype/canon (:dtype destination)))
+                       (= (count (:shape source)) (count (:source-coordinates operation)))
+                       (= (count (:shape destination))
+                          (count (:destination-coordinates operation)))
+                       (pos-int? elements)
+                       (contains? async-transfer-widths transfer-bytes)
+                       (zero? (mod (* elements (dtype/bytes-of (:dtype source))) transfer-bytes))
+                       (contains? cache-policies (:cache operation))
+                       (contains? async-overlap-policies (:overlap operation))
+                       (or (= :preferred (:overlap operation))
+                           (and (>= (:alignment destination) transfer-bytes)
+                                (storage-offset-aligned?
+                                 source (:source-coordinates operation) transfer-bytes)
+                                (storage-offset-aligned?
+                                 destination (:destination-coordinates operation)
+                                 transfer-bytes)))
+                       (record-kind? "raster.compiler.ir.kernel_body.Participation"
+                                     (:participation operation))
+                       (= :full (get-in operation [:participation :kind])))
+          (throw (ex-info
+                  "async workgroup copy requires a typed contiguous global-to-workgroup transfer"
+                  {:reason :kernel-body-async-copy :operation operation
+                   :source source :destination destination}))))
+
+      (record-kind? "raster.compiler.ir.kernel_body.AsyncCommit" operation)
+      (when-not (and (value-id? (:id operation))
+                     (vector? (:copies operation)) (seq (:copies operation))
+                     (every? value-id? (:copies operation))
+                     (= (count (:copies operation)) (count (set (:copies operation)))))
+        (throw (ex-info "async commit requires a named ordered set of issued copies"
+                        {:reason :kernel-body-async-commit :operation operation})))
+
+      (record-kind? "raster.compiler.ir.kernel_body.AsyncWait" operation)
+      (when-not (and (vector? (:groups operation)) (seq (:groups operation))
+                     (every? value-id? (:groups operation))
+                     (= (count (:groups operation)) (count (set (:groups operation))))
+                     (nat-int? (:pending-groups operation))
+                     (contains? async-wait-semantics (:semantics operation))
+                     (record-kind? "raster.compiler.ir.kernel_body.Participation"
+                                   (:participation operation))
+                     (= :full (get-in operation [:participation :kind])))
+        (throw (ex-info "async wait requires ordered groups and full workgroup participation"
+                        {:reason :kernel-body-async-wait :operation operation})))
 
       :else
       (throw (ex-info "kernel body contains an unsupported operation"
@@ -1064,6 +1168,31 @@
                          :operation operation :control-uniformity control-uniformity})))
       values)
 
+    (record-kind? "raster.compiler.ir.kernel_body.AsyncWorkgroupCopy" operation)
+    (let [_ (static-workgroup-width! launch)
+          coordinate-uniformity
+          (join-uniformity
+           (map #(hash-map :uniformity (expression-uniformity % values))
+                (concat (:source-coordinates operation)
+                        (:destination-coordinates operation))))]
+      (when-not (and (contains? control-uniformity :workgroup)
+                     (contains? coordinate-uniformity :workgroup))
+        (throw (ex-info "async workgroup copy must be issued uniformly by the workgroup"
+                        {:reason :kernel-body-divergent-async-copy
+                         :operation operation
+                         :control-uniformity control-uniformity
+                         :coordinate-uniformity coordinate-uniformity})))
+      values)
+
+    (or (record-kind? "raster.compiler.ir.kernel_body.AsyncCommit" operation)
+        (record-kind? "raster.compiler.ir.kernel_body.AsyncWait" operation))
+    (do
+      (when-not (contains? control-uniformity :workgroup)
+        (throw (ex-info "async commit/wait must execute uniformly across the workgroup"
+                        {:reason :kernel-body-divergent-async-control
+                         :operation operation :control-uniformity control-uniformity})))
+      values)
+
     (record-kind? "raster.compiler.ir.kernel_body.Guard" operation)
     (let [guard-uniformity (mask-uniformity (:mask operation) masks values)]
       (validate-dataflow-operations!
@@ -1093,6 +1222,133 @@
   (reduce (fn [env operation]
             (validate-dataflow-operation! operation env context))
           values operations))
+
+;; Async groups are symbolic schedule dependencies, not scalar SSA values.  Keep their lifetime
+;; verification separate from scalar dataflow so a target can lower the same dependency graph to
+;; OpenCL events, CUDA cp.async groups, or an honest synchronous implementation.
+(defn- nested-operation-regions
+  [operation]
+  (cond
+    (record-kind? "raster.compiler.ir.kernel_body.IfRegion" operation)
+    [(:then-operations operation) (:else-operations operation)]
+
+    (or (record-kind? "raster.compiler.ir.kernel_body.ForLoop" operation)
+        (record-kind? "raster.compiler.ir.kernel_body.Loop" operation)
+        (record-kind? "raster.compiler.ir.kernel_body.Guard" operation))
+    [(:operations operation)]
+
+    :else []))
+
+(defn- validate-async-protocol!
+  [operations storage stable-buffers reserved]
+  (let [claimed (atom reserved)]
+    (letfn [(claim! [id owner operation]
+              (when (contains? @claimed id)
+                (throw (ex-info "async copy/group identity is not globally unique"
+                                {:reason :kernel-body-async-id-collision
+                                 :id id :owner owner :operation operation})))
+              (swap! claimed conj id))
+            (clean-state! [owner state]
+              (when (or (seq (:issued state)) (seq (:committed state))
+                        (seq (:awaiting-barrier state)))
+                (throw (ex-info "async staging lifetime crosses a structured region boundary"
+                                {:reason :kernel-body-async-region-lifetime
+                                 :owner owner :state state}))))
+            (validate-sequence! [owner operations]
+              (let [final-state
+                    (reduce
+                     (fn [{:keys [issued committed awaiting-barrier] :as state} operation]
+                       (cond
+                         (record-kind? "raster.compiler.ir.kernel_body.AsyncWorkgroupCopy" operation)
+                         (let [id (:id operation)
+                               source (get storage (:source operation))
+                               source-root (or (some-> source :view :buffer) (:id source))
+                               destination (:destination operation)]
+                           (claim! id :copy operation)
+                           (when-not (contains? stable-buffers source-root)
+                             (throw (ex-info
+                                     "async copy source requires a whole-kernel stable-read contract"
+                                     {:reason :kernel-body-async-source-stability
+                                      :copy id :source source-root})))
+                           (when (or (some #(= destination (:destination %)) issued)
+                                     (some (fn [group]
+                                             (some #(= destination (:destination %))
+                                                   (:copies group)))
+                                           committed)
+                                     (contains? awaiting-barrier destination))
+                             (throw (ex-info "async copy destination is still live"
+                                             {:reason :kernel-body-async-destination-live
+                                              :copy id :destination destination})))
+                           (update state :issued conj operation))
+
+                         (record-kind? "raster.compiler.ir.kernel_body.AsyncCommit" operation)
+                         (let [group (:id operation)
+                               copy-ids (mapv :id issued)]
+                           (claim! group :group operation)
+                           (when-not (= copy-ids (:copies operation))
+                             (throw (ex-info
+                                     "async commit must close every copy issued since the prior commit"
+                                     {:reason :kernel-body-async-commit-order
+                                      :group group :issued copy-ids
+                                      :committed (:copies operation)})))
+                           (-> state
+                               (assoc :issued [])
+                               (update :committed conj {:id group :copies issued})))
+
+                         (record-kind? "raster.compiler.ir.kernel_body.AsyncWait" operation)
+                         (let [groups (:groups operation)
+                               committed-ids (mapv :id committed)
+                               group-count (count groups)
+                               enough-groups? (<= group-count (count committed))
+                               waited (when enough-groups? (subvec committed 0 group-count))
+                               remaining (when enough-groups? (subvec committed group-count))]
+                           (when-not (and enough-groups?
+                                          (= groups (subvec committed-ids 0 group-count))
+                                          (= (:pending-groups operation) (count remaining)))
+                             (throw (ex-info
+                                     "async wait must consume an oldest prefix and state the remainder"
+                                     {:reason :kernel-body-async-wait-order
+                                      :wait groups :committed committed-ids
+                                      :pending-groups (:pending-groups operation)})))
+                           (-> state
+                               (assoc :committed remaining)
+                               (update :awaiting-barrier into
+                                       (map :destination (mapcat :copies waited)))))
+
+                         (record-kind? "raster.compiler.ir.kernel_body.WorkgroupBarrier" operation)
+                         (assoc state :awaiting-barrier #{})
+
+                         (or (record-kind? "raster.compiler.ir.kernel_body.ScalarLoad" operation)
+                             (record-kind? "raster.compiler.ir.kernel_body.ScalarStore" operation))
+                         (let [buffer (:buffer operation)
+                               incomplete (into (set (map :destination issued))
+                                                (map :destination (mapcat :copies committed)))]
+                           (when (or (contains? incomplete buffer)
+                                     (contains? awaiting-barrier buffer))
+                             (throw (ex-info
+                                     (if (contains? incomplete buffer)
+                                       "staged workgroup memory is consumed before its async wait"
+                                       "staged workgroup memory is consumed before a workgroup barrier")
+                                     {:reason (if (contains? incomplete buffer)
+                                                :kernel-body-async-missing-wait
+                                                :kernel-body-async-missing-barrier)
+                                      :buffer buffer :operation operation})))
+                           state)
+
+                         (seq (nested-operation-regions operation))
+                         (do
+                           (clean-state! owner state)
+                           (doseq [[index region] (map-indexed vector
+                                                               (nested-operation-regions operation))]
+                             (validate-sequence! [owner index] region))
+                           state)
+
+                         :else state))
+                     {:issued [] :committed [] :awaiting-barrier #{}}
+                     operations)]
+                (clean-state! owner final-state)))]
+      (validate-sequence! :kernel operations)
+      (set/difference @claimed reserved))))
 
 (defn validate!
   "Verify a scheduled KernelBody and return it unchanged."
@@ -1282,7 +1538,11 @@
                             (into {} (map (juxt :id identity)) masks)
                             index-scope
                             (mapv :id (filter #(= :epilogue (:role %)) parameters)))
-      (let [initial-values
+      (let [section-reserved (set (concat (keys storage) (map :id indices) (map :id masks)
+                                          (map :id fragments)))
+            async-ids (validate-async-protocol!
+                       operations storage (set (map :buffer stable-reads)) section-reserved)
+            initial-values
             (reduce
              (fn [values idx]
                (let [uniformity
@@ -1301,8 +1561,7 @@
                             :uniformity all-uniform}])
                         (filter #(= :scalar (:kind %)) parameters)))
              indices)
-            reserved (set (concat (keys storage) (map :id indices) (map :id masks)
-                                  (map :id fragments)))
+            reserved (into section-reserved async-ids)
             context {:storage storage
                      :stable-reads (set (map :buffer stable-reads))
                      :masks (into {} (map (juxt :id identity)) masks)
@@ -1313,6 +1572,29 @@
                      :schedule schedule}]
         (validate-dataflow-operations! operations initial-values context))))
   body)
+
+(defn required-async-source-alignments
+  "Return external input alignment preconditions implied by overlap-required async copies.
+
+  Coordinate-offset alignment is proved inside `validate!`; this projection names the root ABI
+  buffer whose base address must satisfy the scheduled transfer width."
+  [kernel-body]
+  (let [kernel-body (validate! kernel-body)
+        view-roots (into {} (map (juxt :id :buffer)) (:views kernel-body))
+        operations (letfn [(walk [operations]
+                             (mapcat (fn [operation]
+                                       (cons operation
+                                             (mapcat walk (nested-operation-regions operation))))
+                                     operations))]
+                     (walk (:operations kernel-body)))]
+    (reduce (fn [requirements operation]
+              (if (and (record-kind?
+                        "raster.compiler.ir.kernel_body.AsyncWorkgroupCopy" operation)
+                       (= :required (:overlap operation)))
+                (update requirements (get view-roots (:source operation) (:source operation))
+                        (fnil max 1) (:transfer-bytes operation))
+                requirements))
+            {} operations)))
 
 (defn make
   "Construct and verify a target-neutral scheduled kernel body."

--- a/src/raster/compiler/ir/kernel_body_abi.clj
+++ b/src/raster/compiler/ir/kernel_body_abi.clj
@@ -16,7 +16,8 @@
   [abi kernel-body]
   (let [abi (kabi/validate! abi)
         kernel-body (kbody/validate! kernel-body)
-        stable-buffers (set (map :buffer (:stable-reads kernel-body)))]
+        stable-buffers (set (map :buffer (:stable-reads kernel-body)))
+        required-alignments (kbody/required-async-source-alignments kernel-body)]
     (doseq [buffer stable-buffers]
       (let [matches (filterv #(and (= :input (:kind %)) (= buffer (:name %))) abi)]
         (when-not (= 1 (count matches))
@@ -24,7 +25,11 @@
                           {:reason :kernel-body-stable-read-abi
                            :buffer buffer :matches matches :abi abi})))))
     (mapv (fn [slot]
-            (if (contains? stable-buffers (:name slot))
-              (assoc slot :aliasing :no-write-alias)
-              slot))
+            (cond-> slot
+              (contains? stable-buffers (:name slot))
+              (assoc :aliasing :no-write-alias)
+
+              (contains? required-alignments (:name slot))
+              (assoc :alignment (max (or (:alignment slot) 1)
+                                     (get required-alignments (:name slot))))))
           abi)))

--- a/src/raster/compiler/ir/kernel_call.clj
+++ b/src/raster/compiler/ir/kernel_call.clj
@@ -143,6 +143,20 @@
       (and left-segment right-segment) (segment-overlaps? left-segment right-segment)
       :else (= left right))))
 
+(defn- pointer-aligned?
+  [value required]
+  (let [view (resident-view value)
+        segment (resident-segment value)]
+    (cond
+      view (and (>= (get-in view [:allocation :alignment]) required)
+                (zero? (mod (:byte-offset view) required)))
+      (and (map? value) (integer? (:alignment value)))
+      (>= (:alignment value) required)
+      segment (try
+                (zero? (mod (.address ^MemorySegment segment) required))
+                (catch UnsupportedOperationException _ false))
+      :else false)))
+
 (defn validate!
   "Validate and return a KernelCall. This is driver-independent: a backend subsequently checks
    that pointer values are its resident buffer representation and match ABI storage dtypes."
@@ -178,9 +192,16 @@
     (doseq [[slot value] (map vector abi arguments)]
       (if (= :scalar (:kind slot))
         (scalar-value! slot value)
-        (when (nil? value)
-          (throw (ex-info "kernel pointer argument cannot be nil"
-                          {:kernel-name (:kernel-name artifact) :slot slot})))))
+        (do
+          (when (nil? value)
+            (throw (ex-info "kernel pointer argument cannot be nil"
+                            {:kernel-name (:kernel-name artifact) :slot slot})))
+          (when (and (:alignment slot)
+                     (not (pointer-aligned? value (:alignment slot))))
+            (throw (ex-info "kernel pointer argument violates its ABI alignment contract"
+                            {:reason :kernel-abi-pointer-alignment
+                             :kernel-name (:kernel-name artifact) :slot slot
+                             :required-alignment (:alignment slot)}))))))
     call))
 
 (defn- runtime-number

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -27,6 +27,7 @@
 (def ^:private targets
   {:cuda {:suffix ".cu"
           :descriptor {:device-type :gpu :backend :cuda :vendor "NVIDIA"
+                       :compute-capability [8 0]
                        :subgroup-size 32 :max-workgroup-size 1024}}
    :hip {:suffix ".hip"
          :descriptor {:device-type :gpu :backend :hip :vendor "AMD"
@@ -68,7 +69,12 @@
            (write-source! directory suffix "workgroup-memory"
                           (body-emit/emit-scalar-kernel
                            "workgroup_memory" (body-fixtures/workgroup-memory-body 32)
-                           {:target-dialect dialect}))]
+                           {:target-dialect dialect}))
+           (write-source! directory suffix "async-staging"
+                          (body-emit/emit-scalar-kernel
+                           "async_staging"
+                           (body-fixtures/async-staging-body 32 :preferred)
+                           {:target-dialect dialect :target-features descriptor}))]
           (map-indexed (fn [index artifact]
                          (write-artifact! directory suffix (str "tiled-" index) artifact))
                        (executable/artifacts tiled)))))

--- a/test/raster/compiler/backend/gpu/kernel_body_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_fixtures.clj
@@ -33,3 +33,34 @@
                           :shared-memory-bytes (* width 4)})
     :provenance {:dialect :compile-gate}
     :attributes {:kind :workgroup-memory}}))
+
+(defn async-staging-body
+  "A workgroup stages one contiguous row, explicitly commits and waits, then consumes it."
+  [width overlap]
+  (body/make
+   {:id :c-family-async-staging-gate
+    :parameters [(body/->KernelParameter
+                  'x :input :float [width] :global
+                  (layout/row-major [width] :float) :input)
+                 (body/->KernelParameter
+                  'y :output :float [width] :global
+                  (layout/row-major [width] :float) :result)]
+    :stable-reads [(body/stable-read 'x)]
+    :allocations [(body/->WorkgroupAllocation
+                   'scratch :float [width] (layout/row-major [width] :float) 16)]
+    :indices [(body/->IndexBinding 'lane :local 0)]
+    :operations [(body/->AsyncWorkgroupCopy
+                  'stage-x 'x [0] 'scratch [0] width 16 :cached overlap
+                  (body/full-participation))
+                 (body/->AsyncCommit 'stage-group ['stage-x])
+                 (body/->AsyncWait ['stage-group] 0 :acquire (body/full-participation))
+                 (body/->WorkgroupBarrier :workgroup #{:workgroup} :acquire-release
+                                          (body/full-participation))
+                 (body/->ScalarLoad (body/value 'staged-value :float)
+                                    'scratch ['lane] nil nil :cached)
+                 (body/->ScalarStore 'y ['lane] 'staged-value nil)]
+    :schedule {:async-staging {:groups 1 :depth 1}}
+    :launch (launch/spec {:workgroup-size [width] :group-count [1]
+                          :shared-memory-bytes (* width 4)})
+    :provenance {:dialect :compile-gate}
+    :attributes {:kind :async-staging}}))

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -94,6 +94,10 @@
   []
   (fixtures/workgroup-memory-body 16))
 
+(defn async-staging-kernel-body
+  ([] (async-staging-kernel-body :preferred))
+  ([overlap] (fixtures/async-staging-body 32 overlap)))
+
 (deftest scalar-kernel-body-lowers-without-recovering-a-schedule
   (let [source (opencl/emit-scalar-kernel
                 "scheduled_scalar"
@@ -243,3 +247,50 @@
         (let [{:keys [exit err]} (shell/sh "clang" "-x" "cl" "-cl-std=CL2.0"
                                            "-fsyntax-only" "-" :in source)]
           (is (zero? exit) err))))))
+
+(deftest async-staging-retains-one-dependency-contract-across-targets
+  (doseq [[target copy commit wait]
+          [[:opencl-portable "async_work_group_copy" "OpenCL event group"
+            "wait_group_events(1, &rstr_stage_x)"]
+           [:cuda "cp.async.ca.shared.global" "cp.async.commit_group"
+            "cp.async.wait_group 0"]
+           [:hip "rstr_stage_x_element_offset" "synchronous async group"
+            "synchronous cooperative copies are complete"]]]
+    (testing (name target)
+      (let [source (opencl/emit-scalar-kernel
+                    "async_staging" (async-staging-kernel-body)
+                    (cond-> {:target-dialect target}
+                      (= :cuda target)
+                      (assoc :target-features {:compute-capability [8 0]})))]
+        (is (str/includes? source copy))
+        (is (str/includes? source commit))
+        (is (str/includes? source wait))
+        (is (str/includes? source (if (= target :opencl-portable)
+                                    "barrier(CLK_LOCAL_MEM_FENCE)"
+                                    "__syncthreads()"))))))
+  (testing "required overlap fails honestly on a synchronous-only target"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"cannot preserve required async-copy overlap"
+         (opencl/emit-scalar-kernel
+          "async_required" (async-staging-kernel-body :required)
+          {:target-dialect :hip}))))
+  (testing "CUDA async instructions are gated by the concrete architecture"
+    (let [source (opencl/emit-scalar-kernel
+                  "async_pre_ampere" (async-staging-kernel-body)
+                  {:target-dialect :cuda
+                   :target-features {:compute-capability [7 5]}})]
+      (is (not (str/includes? source "cp.async")))
+      (is (str/includes? source "synchronous cooperative copies are complete")))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"cannot preserve required async-copy overlap"
+         (opencl/emit-scalar-kernel
+          "async_required_unknown_cuda" (async-staging-kernel-body :required)
+          {:target-dialect :cuda}))))
+  (testing "the native event lowering remains valid OpenCL C"
+    (when (command-available? "clang")
+      (let [source (opencl/emit-scalar-kernel
+                    "async_staging" (async-staging-kernel-body)
+                    {:target-dialect :opencl-portable})
+            {:keys [exit err]} (shell/sh "clang" "-x" "cl" "-cl-std=CL2.0"
+                                         "-fsyntax-only" "-" :in source)]
+        (is (zero? exit) err)))))

--- a/test/raster/compiler/backend/gpu/kernel_body_workgroup_device_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_workgroup_device_test.clj
@@ -30,6 +30,28 @@
       :attributes {:workgroup-memory-bytes
                    (get-in kernel-body [:launch :shared-memory-bytes])}})))
 
+(defn- async-artifact
+  [width]
+  (let [kernel-body (fixtures/async-staging-body width :preferred)
+        abi (body-abi/project-contracts
+             [(kabi/slot 'x :input :float :c-name "rstr_x" :role :input)
+              (kabi/slot 'y :output :float :c-name "rstr_y" :role :result)]
+             kernel-body)]
+    (kart/make
+     {:kernel-name "kernel_body_async_stage"
+      :target :opencl-c
+      :source (body-emit/emit-scalar-kernel
+               "kernel_body_async_stage" kernel-body
+               {:target-dialect :opencl-portable})
+      :abi abi
+      :arguments '[x y]
+      :launch (:launch kernel-body)
+      :effects {:kind :async-workgroup-stage}
+      :provenance {:kernel-body (:id kernel-body)}
+      :attributes {:async-copy-lowering :native-events
+                   :workgroup-memory-bytes
+                   (get-in kernel-body [:launch :shared-memory-bytes])}})))
+
 (deftest workgroup-local-roundtrip-is-correct-on-opencl
   (if-not @device-probe/opencl-available?
     (device-probe/opencl-skip! "KernelBody workgroup-local storage and barrier")
@@ -50,6 +72,30 @@
         (register! (:kernel-name compiled) compiled)
         (launch! (bind-call (kcall/make compiled [x y])))
         (is (= (vec (reverse input)) (vec (buffer->array y))))
+        (finally
+          (free! y)
+          (free! x))))))
+
+(deftest async-workgroup-stage-is-correct-on-opencl
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "KernelBody async workgroup staging")
+    (let [ocl (find-ns 'raster.gpu.ocl-runtime)
+          register! (ns-resolve ocl 'register-kernel!)
+          buffer-of-array (ns-resolve ocl 'buffer-of-array)
+          make-buffer (ns-resolve ocl 'make-buffer)
+          bind-call (ns-resolve ocl 'bind-kernel-call)
+          launch! (ns-resolve ocl 'launch-registered-bound!)
+          buffer->array (ns-resolve ocl 'buffer->array)
+          free! (ns-resolve ocl 'free-buffer!)
+          width 32
+          input (float-array (map float (range width)))
+          compiled (async-artifact width)
+          x (buffer-of-array input :float)
+          y (make-buffer width :float)]
+      (try
+        (register! (:kernel-name compiled) compiled)
+        (launch! (bind-call (kcall/make compiled [x y])))
+        (is (= (vec input) (vec (buffer->array y))))
         (finally
           (free! y)
           (free! x))))))

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -648,3 +648,66 @@
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo #"unsupported synchronization contract"
              (scalar-body [invalid])))))))
+
+(defn- async-stage-copy
+  ([] (async-stage-copy [0]))
+  ([source-coordinates]
+   (body/->AsyncWorkgroupCopy
+    'copy-x 'x source-coordinates 'scratch [0] 16 16 :cached :preferred
+    (body/full-participation))))
+
+(defn- async-stage-operations
+  []
+  [(async-stage-copy)
+   (body/->AsyncCommit 'copy-group ['copy-x])
+   (body/->AsyncWait ['copy-group] 0 :acquire (body/full-participation))
+   (workgroup-barrier)
+   (body/->ScalarLoad (body/value 'staged :float) 'scratch ['lane] nil nil :cached)])
+
+(deftest async-staging-has-verified-issue-commit-wait-lifetimes
+  (let [options [:stable-reads [(body/stable-read 'x)]
+                 :allocations [(scratch-allocation)]
+                 :shared-memory-bytes 64]]
+    (is (body/kernel-body? (apply scalar-body (async-stage-operations) options)))
+    (testing "the source must stay stable for the entire asynchronous lifetime"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"stable-read contract"
+           (scalar-body (async-stage-operations)
+                        :allocations [(scratch-allocation)]
+                        :shared-memory-bytes 64))))
+    (testing "a commit closes exactly the copies issued since the previous commit"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"close every copy"
+           (apply scalar-body
+                  (assoc (async-stage-operations) 1
+                         (body/->AsyncCommit 'copy-group ['different-copy]))
+                  options))))
+    (testing "waits consume the oldest group prefix and state remaining depth"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"consume an oldest prefix"
+           (apply scalar-body
+                  (assoc (async-stage-operations) 2
+                         (body/->AsyncWait ['copy-group] 1 :acquire
+                                           (body/full-participation)))
+                  options))))
+    (testing "wait completion does not silently imply cross-thread visibility"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"before a workgroup barrier"
+           (apply scalar-body
+                  (vec (concat (subvec (async-stage-operations) 0 3)
+                               (subvec (async-stage-operations) 4)))
+                  options))))
+    (testing "staged storage cannot be consumed while its copy group is incomplete"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"before its async wait"
+           (apply scalar-body
+                  [(async-stage-copy)
+                   (body/->ScalarLoad (body/value 'too-early :float)
+                                      'scratch ['lane] nil nil :cached)]
+                  options))))
+    (testing "the cooperative base address must be workgroup-uniform"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"issued uniformly"
+           (apply scalar-body
+                  (assoc (async-stage-operations) 0 (async-stage-copy ['lane]))
+                  options))))))

--- a/test/raster/compiler/ir/kernel_call_test.clj
+++ b/test/raster/compiler/ir/kernel_call_test.clj
@@ -51,6 +51,21 @@
                             (kcall/make stable-artifact
                                         (into [left overlap] scalars)))))))
 
+(deftest calls-enforce-pointer-alignment-carried-by-the-abi
+  (let [aligned-artifact (kart/make (assoc-in artifact [:abi 0 :alignment] 16))
+        allocation (bview/allocation {:id :call-alignment :byte-size 64
+                                      :memory-space :device :alignment 16
+                                      :ownership :borrowed})
+        aligned (bview/view allocation {:id :aligned :byte-offset 0
+                                        :dtype :float :shape [4]})
+        misaligned (bview/view allocation {:id :misaligned :byte-offset 4
+                                           :dtype :float :shape [4]})
+        suffix [:resident-out {:type :float :value 1.0} {:type :int :value 4}]]
+    (is (kcall/kernel-call? (kcall/make aligned-artifact (into [aligned] suffix))))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"violates its ABI alignment contract"
+         (kcall/make aligned-artifact (into [misaligned] suffix))))))
+
 (deftest call-realizes-artifact-launch-from-ordered-values
   (let [call (kcall/make artifact args)
         plan (kcall/binding-plan call)]

--- a/test/raster/compiler/kernel_abi_test.clj
+++ b/test/raster/compiler/kernel_abi_test.clj
@@ -45,6 +45,40 @@
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"aliasing contract"
                             (kabi/validate! [slot (kabi/slot 'out :output :float)]))))))
 
+(deftest required-async-overlap-projects-pointer-alignment
+  (let [kernel-body
+        (body/make
+         {:id :async-alignment-abi
+          :parameters [(body/->KernelParameter 'x :input :float [16] :global
+                                               (layout/row-major [16] :float) :operand)
+                       (body/->KernelParameter 'out :output :float [16] :global
+                                               (layout/row-major [16] :float) :result)]
+          :stable-reads [(body/stable-read 'x)]
+          :allocations [(body/->WorkgroupAllocation
+                         'scratch :float [16] (layout/row-major [16] :float) 16)]
+          :operations [(body/->AsyncWorkgroupCopy
+                        'copy 'x [0] 'scratch [0] 16 16 :cached :required
+                        (body/full-participation))
+                       (body/->AsyncCommit 'group ['copy])
+                       (body/->AsyncWait ['group] 0 :acquire (body/full-participation))
+                       (body/->WorkgroupBarrier :workgroup #{:workgroup} :acquire-release
+                                                (body/full-participation))]
+          :launch (launch/spec {:workgroup-size [16] :group-count [1]
+                                :shared-memory-bytes 64})})
+        projected (body-abi/project-contracts
+                   [(kabi/slot 'x :input :float)
+                    (kabi/slot 'out :output :float)]
+                   kernel-body)]
+    (is (= 16 (get-in projected [0 :alignment])))
+    (is (= :no-write-alias (get-in projected [0 :aliasing])))
+    (is (nil? (get-in projected [1 :alignment])))
+    (testing "alignment is a pointer-only power-of-two ABI contract"
+      (doseq [slot [(kabi/slot 'n :scalar :int :alignment 16)
+                    (kabi/slot 'x :input :float :alignment 3)]]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"positive power of two"
+             (kabi/validate! [slot (kabi/slot 'out :output :float)])))))))
+
 (deftest stable-input-aliases-are-checked-against-every-output
   (let [abi [(kabi/slot 'x :input :float :aliasing :no-write-alias)
              (kabi/slot 'side :output :float)


### PR DESCRIPTION
Adds a target-neutral KernelBody issue/commit/wait contract for cooperative global-to-workgroup staging.

- verifies full participation, stable sources, ordered groups, pipeline depth, destination lifetime, barriers, and structured-region boundaries
- projects overlap-required alignment into the ordered ABI and validates resident bindings
- lowers to OpenCL events, capability-gated CUDA cp.async, and an honest HIP/older-CUDA cooperative fallback
- adds shared OpenCL/CUDA/HIP fixtures, offline vendor compiler gates, a POCL numerical oracle, and north-star documentation

Validation:
- 49 tests, 241 assertions
- native POCL numerical execution
- all generated CUDA fixtures compile to sm_80 PTX
- all generated HIP fixtures compile to gfx1100 code objects