### PR TITLE
Verify pipelined async kernel loops

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1,6 +1,6 @@
 # Raster compiler north star
 
-Status: architectural direction, grounded in the implementation on 2026-07-30.
+Status: architectural direction, reconciled with the implementation on 2026-08-27.
 
 Raster should become a compiler in which a typed Clojure program, its parallel
 algorithm, its schedule, its device placement, and its executable artifact are
@@ -67,9 +67,11 @@ operation/type legality check, and source equality invalidates an equation after
 rewrite. Direct calls to a backend may still use the explicit, counted compatibility re-lowering
 path.
 
-The remaining nominal boundary is earlier: SOAC fusion still works over an S-expression-derived
-graph rather than a first-class typed program, and the scheduled operations do not yet contain a
-general target-neutral kernel body.
+The remaining nominal boundary is earlier: SOAC fusion still constructs records and a dependency
+graph from source-shaped S-expressions, rewrites them, and reconstructs `par` forms before the typed
+program boundary. The problem is not the use of S-expressions; it is that stable value identity,
+types, effects, aliases and dialect legality are recovered from source spelling instead of being
+explicit in a first-class typed SOAC program.
 
 The first architectural correction is therefore:
 
@@ -152,9 +154,14 @@ code object in mandatory hardware-free CI jobs, while real Intel execution remai
 oracle. The compiler fixtures now stage values through both synchronous workgroup memory and the
 verified async issue/commit/wait contract; the exact async body is compiled to CUDA sm_80 PTX and
 an RDNA3 HIP code object in hardware-free CI. CUDA/HIP runtime registration, launch and on-device
-numerical coverage remain deliberately separate from source legality. The next production step is a
-double-buffered scheduled weighted-reduction body that uses this substrate, followed by local
-swizzles and measured stage-depth selection; this can collapse the tiled graph toward a
+numerical coverage remain deliberately separate from source legality. The verifier still forbids
+pending asynchronous state and live staged storage from escaping an ordinary structured region,
+but `PipelinedFor` now carries a complete ordered async queue across loop iterations, verifies each
+rotating stage's layout and lifetime, and requires an explicit exact or separate-epilogue tail
+policy. OpenCL lowers the queue through native event variables; CUDA maps it to `cp.async` groups;
+HIP preserves the same verified schedule with an honest synchronous fallback. The next production
+step is a double-buffered scheduled weighted-reduction body using this representation. Local
+swizzles and measured stage-depth selection then let this collapse the tiled graph toward a
 FlashAttention-like single kernel without changing the semantic plan or external ABI.
 
 ### 2.3 Executable steps and resident artifact values compose
@@ -294,9 +301,9 @@ Every value has an `AbstractValue`:
  :effects      #{}}
 ```
 
-The exact representation may be records or validated maps. The invariant
-matters more than the container: all facets describe the same value identity,
-and a pass cannot update one without revalidation.
+The program envelope and fact tables may be records or validated maps, while operation and region
+syntax may remain compact S-expressions. The invariant matters more than the container: all facets
+describe the same explicit value identity, and a pass cannot update one without revalidation.
 
 Operations use one descriptor/interface system. In addition to the existing
 buffer, device, shape, placement, algebra, comparison, and result facets, an
@@ -337,6 +344,35 @@ Futhark's Haskell representation or uniqueness type system wholesale.
 
 This dialect is hardware-independent. Hardware facts may be supplied to a
 costing or scheduling pass, but must not change the meaning of an operation.
+
+#### 3.2.1 Representation and Pattern integration
+
+Raster keeps the small functional, Lisp-native character of the SOAC IR. The intended form is a
+typed, dialect-validated S-expression program rather than a tools.analyzer-style map AST or a graph
+reconstructed from arbitrary source forms. Conceptually:
+
+```clojure
+(soac-program
+  {:inputs [%x]
+   :values {%x x-value %y y-value %z z-value}}
+  [(= %y (map {:index %i :extent %n} [%x]
+              (lambda [%xi] (* %xi %xi))))
+   (= %z (reduce {:operator + :identity 0.0} [%y]))]
+  [%z])
+```
+
+`../pattern` remains the rewrite engine. Its nanopass dialects declare the accepted S-expression
+grammar and pass arrows; fusion rules match the compact SOAC equations directly. The surrounding
+`ParallelProgram`-style envelope supplies stable value/equation IDs, `AbstractValue`s, effects,
+aliases, consumption, results, diagnostics and provenance. Essential facts are explicit fields or
+table entries keyed by IDs, not Clojure metadata that ordinary list reconstruction can drop.
+
+This representation is shared before backend selection. SOAC fusion changes the program consumed
+by both JVM and accelerator lowerings; SegOp and schedule conversion then specialize it. The JVM
+SIMD backend already consumes certified SegOps from `ParallelProgram`, but current SOAC fusion first
+round-trips through `par` forms and the scalar fallback still expands retained source. Migration is
+complete when JVM SIMD, scalar/JVM and GPU routes consume the same typed SOAC/SegOp facts and no
+backend silently re-lowers an exact source form.
 
 ### 3.3 Schedule and transform IR
 
@@ -461,6 +497,16 @@ The vendor compiler continues to own register allocation, low-level instruction
 scheduling, and binary generation until measurements demonstrate that this
 boundary is the limiting factor.
 
+A direct PTX route, when justified by those measurements, is a late NVIDIA target dialect beneath
+`KernelBody`, not a second scheduling IR and never a shortcut from SOAC. Full conversion first
+legalizes a verified body to NVIDIA address spaces, predicates, cache policies, vector memory
+operations, `cp.async`/`mbarrier`/TMA dependencies, exact MMA/WGMMA operand tuples and resource
+directives; a separate renderer produces PTX and `ptxas` produces cubin. CUDA C remains a broad
+differential backend. PTX gives Raster tighter instruction selection and memory-ordering control,
+but physical registers, spills and final SASS scheduling remain vendor-compiler responsibilities.
+The artifact records `ptxas` register, spill, stack and shared-memory reports so feasibility and
+autotuning can use actual resource outcomes.
+
 ### 3.7 Executable artifact and runtime
 
 `Compiled` evolves from a whole-program wrapper into a composable executable
@@ -560,6 +606,16 @@ program + abstract values + hardware descriptor
     → versioned cache and Compiled artifact
 ```
 
+This is a staged JIT/runtime contract, not only an ahead-of-time compiler pipeline. Static analysis
+may leave symbolic shapes, strides, placement choices and schedule alternatives in a partially
+specialized artifact. At binding or execution time, Raster may propagate newly known shapes,
+residency, allocation/topology, backend capabilities and calibrated measurements back into
+specialization, candidate generation and tuning. Adaptation always returns or selects a newly
+verified immutable artifact; it never mutates a running kernel around type, effect, ownership,
+numerical or resource checks. Logical events, measurements, hardware descriptors, `Compiled`,
+`LinkPlan` and `ExecutionPlan` are the compiler/runtime seam to OpenCL, Level Zero, CUDA/HIP and
+future collective or cluster runtimes.
+
 The search state should include both kernel and graph choices. Per-kernel axes
 include tile, vector width, instruction family, workgroup geometry, layout,
 staging, pipeline depth, and reduction strategy. Graph axes include fusion,
@@ -602,10 +658,31 @@ latency, throughput, peak memory, transferred bytes,
 compile/tune budget, energy when measurable, and numerical error
 ```
 
-The first distributed target should be data-parallel training with explicit
-gradient all-reduce, followed by tensor/sequence sharding for a transformer
-block. Pipeline and expert parallelism should wait until the value, sharding,
-and communication IR can state them without runtime side protocols.
+The compiler hierarchy extends upward without making the single-device `LinkPlan` a cluster object:
+
+```text
+semantic program and AD
+    → verified mesh, topology, resource envelope and allocation
+    → distributed schedule with explicit sharding and communication
+    → certified DistributedPlan with shard-local programs and cross-device events
+    → one LinkPlan and ExecutionPlan per device
+    → KernelGraph / KernelBody / target artifacts
+```
+
+`DistributedPlan` is the missing bridge. It owns global-to-shard value mappings, collective groups,
+point-to-point routes, resource claims, per-device plans and a witness for shard coverage,
+replication, ownership, capabilities and collective agreement. Native communicators and event
+handles remain runtime resources. An outer `WorkloadPlan` may handle admission, continuous batching,
+deadlines, retries, checkpoints and safe reallocation for dynamic services; it selects certified
+compiled variants rather than injecting service policy into SOAC or kernel IR.
+
+The first distributed target should be data-parallel training with explicit gradient all-reduce,
+followed by tensor/sequence sharding for a transformer block and a scientific halo-exchange case.
+Pipeline and expert parallelism should wait until the value, sharding, communication and failure
+contracts can state them without runtime side protocols. MPI, NCCL/RCCL, oneCCL, UCX and eventually
+GPU-initiated transports such as NVSHMEM are interchangeable execution backends, not Raster's
+semantic memory model. Datahike may retain durable topology, plan, measurement and decision history;
+it does not replace hot-path allocation or communication.
 
 ## 7. Reflection, structural self-modification, and learning
 
@@ -630,6 +707,36 @@ the trusted verifier stays small.
 ## 8. Landing order
 
 Each increment should be a thin vertical slice with a production-path test.
+
+The immediate continuation after the verified pipelined-loop increment is:
+
+1. Use `PipelinedFor` for the double-buffered segmented weighted-reduction production route.
+2. In parallel, define a typed SOAC S-expression dialect with `../pattern` and differential-test
+   map→map, map→reduce and horizontal-map fusion against the current graph.
+3. Carry that dialect in the existing program/value envelope and route one ordinary fused reduction
+   through JVM SIMD and GPU `KernelBody` without reconstructing compiler facts from source spelling.
+4. Add a finite verified shared-memory swizzle family and bank-conflict/resource model.
+5. Make stage count and swizzle measured schedule axes, retire the legacy tuner, and remove the
+   attention-provenance gate from the generic weighted-reduction matcher.
+6. Migrate the remaining SOAC fusion rules and scalar JVM fallback, then remove compatibility
+   re-lowering for the covered forms.
+7. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a
+   read-only distributed track without interrupting the kernel and typed-middle-end verticals.
+
+The integrated roadmap has six cooperating tracks rather than one backend-only sequence:
+
+| Track | Near-term completion gate | Unlock |
+|---|---|---|
+| Verified device scheduling | Pipelined loop, double-buffered weighted reduction, tails and honest fallbacks | General staged reductions and FlashAttention-like schedules |
+| Typed functional middle end | Pattern-declared typed SOAC program; map/reduce fusion reaches JVM and GPU from one fact set | Reliable fusion, batching, AD and reflection across representations |
+| Portable peak kernels | Verified swizzles/layouts, unified matrix fragments and quant storage descriptors | Competitive GEMM, attention and scientific tiles across Intel/NVIDIA/AMD |
+| Measurement and selection | One tuner over coupled graph/kernel axes with numerical and resource gates | Hardware-aware schedule selection and selective autotuning |
+| Precise target lowering | Format-neutral target modules, differential PTX, later AMD-specific lowering | Exact async/matrix/cache control where portable source is insufficient |
+| Distributed/workload planning | Typed mesh/topology/sharding values, then certified `DistributedPlan` | End-to-end node, cluster and data-center optimization |
+
+The table below is the durable architectural dependency ledger, not a claim that every increment is
+unstarted. ABI, artifact composition and much of the kernel-IR foundation have landed; their stated
+completion gates remain useful for finding legacy paths that have not joined the common route.
 
 | Increment | Work | Completion gate |
 |---|---|---|
@@ -696,6 +803,9 @@ transfer boundaries, and numerical modes.
 | `llama.cpp-new` | quant layout oracle, golden formats, model-driven kernel cases | one bespoke compiler architecture per quant format |
 | JAX/XLA | abstract values, primitive transformation rules, effects, pytrees, donation, sharding contracts, layout constraints | Python retracing behavior or outsourcing Raster's programming model to XLA |
 | MLIR | conversion legality, operation interfaces/traits, pass invalidation, Transform and DataLayout discipline | compulsory native MLIR integration before a concrete backend requires it |
+| Mojo/MAX | one language spanning host and device, parametric low-level GPU libraries, explicit layouts/pipelines, heterogeneous cross-compilation | coupling Raster's semantics to a closed compiler stack or requiring imperative kernels as the main abstraction |
+| TVM Relax/Disco | graph-level tensor distribution, SPMD worker sessions, explicit collective runtime boundary | making a controller/runtime protocol the distributed semantic IR |
+| Legion/DaCe | correctness-independent mapping, topology-aware task/data placement, explicit data movement and transformations | adopting a second user programming model before Raster's value and schedule IRs are complete |
 
 Local source revisions studied for this direction:
 

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -685,6 +685,7 @@
 
 (def ^:private scalar-operation-kinds
   #{"ScalarCompute" "ScalarLoad" "ScalarStore" "Yield" "IfRegion" "ForLoop"
+    "PipelineYield" "PipelinedFor"
     "Collective" "WorkgroupBarrier" "AsyncWorkgroupCopy" "AsyncCommit" "AsyncWait"})
 
 (defn- scalar-body-operations
@@ -695,7 +696,8 @@
              (when (record-kind? "IfRegion" operation)
                (concat (scalar-body-operations (:then-operations operation))
                        (scalar-body-operations (:else-operations operation))))
-             (when (record-kind? "ForLoop" operation)
+             (when (or (record-kind? "ForLoop" operation)
+                       (record-kind? "PipelinedFor" operation))
                (scalar-body-operations (:operations operation)))))
    operations))
 
@@ -714,6 +716,12 @@
                (scalar-defined-ids (:else-operations operation)))
 
        (record-kind? "ForLoop" operation)
+       (concat [(:id (:index operation))]
+               (map (comp :id :binding) (:iter-args operation))
+               (map :id (:results operation))
+               (scalar-defined-ids (:operations operation)))
+
+       (record-kind? "PipelinedFor" operation)
        (concat [(:id (:index operation))]
                (map (comp :id :binding) (:iter-args operation))
                (map :id (:results operation))
@@ -981,6 +989,11 @@
                                    (emit-scalar-value value context) ";")))
               results values)))
 
+(defn- async-group-events
+  [context group]
+  (or (:events group)
+      (mapv #(get-in context [:async-copies %]) (:copies group))))
+
 (defn- emit-scalar-operation
   [operation context depth]
   (cond
@@ -1113,6 +1126,111 @@
             (indent-lines depth "}"))
        result-context])
 
+    (record-kind? "PipelinedFor" operation)
+    (let [results (:results operation)
+          result-context (reduce add-value context results)
+          index (:index operation)
+          loop-context (add-value result-context index)
+          loop-context (reduce (fn [ctx arg] (add-value ctx (:binding arg)))
+                               loop-context (:iter-args operation))
+          initializers
+          (apply str
+                 (map (fn [result arg]
+                        (indent-lines depth
+                                      (str (target-type
+                                            (get-in result-context [:types (:id result)]))
+                                           " " (get-in result-context [:names (:id result)])
+                                           " = " (emit-scalar-value (:initial arg) context) ";")))
+                      results (:iter-args operation)))
+          initial-groups (:async-groups context)
+          native-events? (= :native-events (c-dialect/async-copy-mode *scalar-dialect*))
+          binding-groups
+          (mapv
+           (fn [arg group]
+             (let [binding (:binding arg)
+                   event-count (count (:copies group))
+                   events (mapv #(str (scalar-local-name binding) "_event_" %)
+                                (range event-count))]
+               {:id binding :copies (:copies group) :events events}))
+           (:async-iter-args operation) initial-groups)
+          event-initializers
+          (when native-events?
+            (apply str
+                   (mapcat
+                    (fn [binding-group initial-group]
+                      (map (fn [binding-event initial-event]
+                             (indent-lines depth
+                                           (str "event_t " binding-event " = " initial-event ";")))
+                           (:events binding-group)
+                           (async-group-events context initial-group)))
+                    binding-groups initial-groups)))
+          loop-context (assoc loop-context :async-groups binding-groups)
+          index-name (get-in loop-context [:names (:id index)])
+          scalar-bindings
+          (apply str
+                 (map (fn [arg result]
+                        (let [binding (:binding arg)]
+                          (indent-lines (inc depth)
+                                        (str (target-type
+                                              (get-in loop-context [:types (:id binding)]))
+                                             " " (get-in loop-context [:names (:id binding)])
+                                             " = " (get-in result-context [:names (:id result)])
+                                             ";"))))
+                      (:iter-args operation) results))
+          body-operations (pop (:operations operation))
+          yield-op (peek (:operations operation))
+          [body-source body-context] (emit-scalar-operations body-operations loop-context
+                                                             (inc depth))
+          yielded-by-id (into {} (map (juxt :id identity)) (:async-groups body-context))
+          yielded-groups (mapv yielded-by-id (:groups yield-op))
+          next-event-names
+          (when native-events?
+            (mapv (fn [binding-group group]
+                    (mapv (fn [event-index event]
+                            [(str (scalar-local-name (:id binding-group))
+                                  "_next_event_" event-index)
+                             event])
+                          (range) (async-group-events body-context group)))
+                  binding-groups yielded-groups))
+          event-backedge
+          (when native-events?
+            (str
+             (apply str
+                    (for [[temporary source-event] (mapcat identity next-event-names)]
+                      (indent-lines (inc depth)
+                                    (str "event_t " temporary " = " source-event ";"))))
+             (apply str
+                    (mapcat
+                     (fn [binding-group temporaries]
+                       (map (fn [binding-event [temporary _]]
+                              (indent-lines (inc depth)
+                                            (str binding-event " = " temporary ";")))
+                            (:events binding-group) temporaries))
+                     binding-groups next-event-names))))
+          loop-header (str "for (" (target-type (get-in loop-context [:types (:id index)]))
+                           " " index-name " = "
+                           (emit-index-expression (:lower operation) (:names context)) "; "
+                           index-name " < "
+                           (emit-index-expression (:upper operation) (:names context)) "; "
+                           index-name " += " (:step operation) ") {")
+          output-groups
+          (mapv (fn [result binding-group]
+                  (assoc binding-group :id result))
+                (:async-results operation) binding-groups)
+          next-context (assoc result-context :async-groups output-groups
+                              :async-issued [])]
+      [(str initializers event-initializers
+            (when (get-in operation [:attributes :unroll])
+              (indent-lines depth "#pragma unroll"))
+            (indent-lines depth loop-header)
+            scalar-bindings body-source
+            (emit-yield-assignments results (:values yield-op)
+                                    (update body-context :names merge (:names result-context))
+                                    (inc depth))
+            event-backedge
+            (indent-lines depth "}"))
+       next-context])
+
     (record-kind? "Collective" operation)
     (let [result (:result operation)
           next-context (add-value context result)
@@ -1240,7 +1358,7 @@
     (record-kind? "AsyncWait" operation)
     (let [group-count (count (:groups operation))
           waited (subvec (:async-groups context) 0 group-count)
-          event-names (mapv #(get-in context [:async-copies %]) (mapcat :copies waited))]
+          event-names (mapv identity (mapcat #(async-group-events context %) waited))]
       [(indent-lines depth
                      (c-dialect/async-wait *scalar-dialect* event-names
                                            (:pending-groups operation)))
@@ -1248,6 +1366,10 @@
 
     (record-kind? "Yield" operation)
     (throw (ex-info "OpenCL scalar lowering found a misplaced Yield"
+                    {:reason :raster/bug :operation operation}))
+
+    (record-kind? "PipelineYield" operation)
+    (throw (ex-info "OpenCL scalar lowering found a misplaced PipelineYield"
                     {:reason :raster/bug :operation operation}))
 
     :else

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -37,6 +37,11 @@
 (defrecord IfRegion [condition then-operations else-operations results])
 (defrecord LoopArg [binding initial])
 (defrecord ForLoop [index lower upper step iter-args operations results attributes])
+(defrecord AsyncLoopArg [binding initial])
+(defrecord PipelineYield [values groups])
+(defrecord PipelinedFor
+           [index lower upper step iter-args async-iter-args operations results async-results
+            attributes])
 (defrecord Participation [kind])
 (defrecord Collective
            [result kind scope width input operator source-lane participation association])
@@ -74,6 +79,7 @@
 (def ^:private async-wait-semantics #{:acquire})
 (def ^:private async-overlap-policies #{:preferred :required})
 (def ^:private async-transfer-widths #{4 8 16})
+(def ^:private pipeline-tail-policies #{:exact :separate-epilogue})
 
 (defn- record-kind? [class-name value]
   (and value (= class-name (.getName (class value)))))
@@ -344,6 +350,8 @@
                "raster.compiler.ir.kernel_body.Yield"
                "raster.compiler.ir.kernel_body.IfRegion"
                "raster.compiler.ir.kernel_body.ForLoop"
+               "raster.compiler.ir.kernel_body.PipelineYield"
+               "raster.compiler.ir.kernel_body.PipelinedFor"
                "raster.compiler.ir.kernel_body.Collective"
                "raster.compiler.ir.kernel_body.WorkgroupBarrier"
                "raster.compiler.ir.kernel_body.AsyncWorkgroupCopy"
@@ -633,10 +641,67 @@
         (validate-operations! (:operations operation) storage fragments masks
                               (conj scope (:id index)) epilogue-abi))
 
+      (record-kind? "raster.compiler.ir.kernel_body.PipelinedFor" operation)
+      (let [index (:index operation)
+            async-args (:async-iter-args operation)
+            async-results (:async-results operation)
+            tail-policy (get-in operation [:attributes :tail-policy])]
+        (value-spec! "kernel pipelined-for index" index)
+        (when-not (contains? #{:int :long} (canonical-type (:type index)))
+          (throw (ex-info "kernel pipelined-for index must have an integral dtype"
+                          {:index index})))
+        (when-not (and (expression? (:lower operation)) (expression? (:upper operation))
+                       (integer? (:step operation)) (pos? (:step operation))
+                       (vector? (:iter-args operation))
+                       (every? #(record-kind? "raster.compiler.ir.kernel_body.LoopArg" %)
+                               (:iter-args operation))
+                       (vector? async-args) (seq async-args)
+                       (every? #(record-kind?
+                                 "raster.compiler.ir.kernel_body.AsyncLoopArg" %)
+                               async-args)
+                       (every? #(and (value-id? (:binding %)) (value-id? (:initial %)))
+                               async-args)
+                       (= (count async-args) (count async-results))
+                       (vector? async-results) (every? value-id? async-results)
+                       (= (count async-results) (count (set async-results)))
+                       (vector? (:results operation))
+                       (= (count (:iter-args operation)) (count (:results operation)))
+                       (map? (:attributes operation))
+                       (contains? pipeline-tail-policies tail-policy))
+          (throw (ex-info
+                  "kernel pipelined-for requires scalar and async carries with an explicit tail policy"
+                  {:reason :kernel-body-pipelined-for :loop operation
+                   :supported-tail-policies pipeline-tail-policies})))
+        (doseq [arg (:iter-args operation)]
+          (value-spec! "pipelined loop carried binding" (:binding arg)))
+        (let [uniform-iter-args (get-in operation [:attributes :uniform-iter-args] #{})
+              bindings (set (map (comp :id :binding) (:iter-args operation)))]
+          (when-not (and (set? uniform-iter-args)
+                         (set/subset? uniform-iter-args bindings))
+            (throw (ex-info
+                    "kernel pipelined-for uniform-iter-args must name scalar carried bindings"
+                    {:reason :kernel-body-loop-uniform-iter-args
+                     :uniform-iter-args uniform-iter-args :bindings bindings}))))
+        (doseq [result (:results operation)]
+          (value-spec! "pipelined loop result" result))
+        (when (contains? scope (:id index))
+          (throw (ex-info "kernel pipelined-for induction value shadows an existing value"
+                          {:index index :scope scope})))
+        (validate-operations! (:operations operation) storage fragments masks
+                              (conj scope (:id index)) epilogue-abi))
+
       (record-kind? "raster.compiler.ir.kernel_body.Yield" operation)
       (when-not (vector? (:values operation))
         (throw (ex-info "kernel region yield values must be an ordered vector"
                         {:operation operation})))
+
+      (record-kind? "raster.compiler.ir.kernel_body.PipelineYield" operation)
+      (when-not (and (vector? (:values operation))
+                     (vector? (:groups operation)) (seq (:groups operation))
+                     (every? value-id? (:groups operation))
+                     (= (count (:groups operation)) (count (set (:groups operation)))))
+        (throw (ex-info "pipelined region yield requires scalar values and async groups"
+                        {:reason :kernel-body-pipeline-yield :operation operation})))
 
       (record-kind? "raster.compiler.ir.kernel_body.Collective" operation)
       (do
@@ -956,6 +1021,19 @@
                     {:operations operations})))
   (peek operations))
 
+(defn- terminal-pipeline-yield!
+  [owner operations]
+  (when-not (and (vector? operations) (seq operations)
+                 (record-kind? "raster.compiler.ir.kernel_body.PipelineYield"
+                               (peek operations)))
+    (throw (ex-info (str owner " must terminate in PipelineYield")
+                    {:reason :kernel-body-pipeline-terminator :operations operations})))
+  (when (some #(record-kind? "raster.compiler.ir.kernel_body.PipelineYield" %)
+              (pop operations))
+    (throw (ex-info (str owner " may only pipeline-yield as its terminal operation")
+                    {:reason :kernel-body-pipeline-terminator :operations operations})))
+  (peek operations))
+
 (declare validate-dataflow-operations!)
 
 (defn- validate-region!
@@ -1122,6 +1200,73 @@
                                          (:uniformity yielded-info)]))))
                 values (map vector results yielded initials))))
 
+    (record-kind? "raster.compiler.ir.kernel_body.PipelinedFor" operation)
+    (let [index (:index operation)
+          lower-info (expression-info! (:lower operation) values)
+          upper-info (expression-info! (:upper operation) values)
+          index-type (canonical-type (:type index))
+          loop-control (reduce set/intersection control-uniformity
+                               [(:uniformity lower-info) (:uniformity upper-info)])
+          iter-args (:iter-args operation)
+          uniform-iter-args (get-in operation [:attributes :uniform-iter-args] #{})
+          results (:results operation)
+          initials (mapv #(scalar-value-info! (:initial %) values) iter-args)
+          pipeline-yield (terminal-pipeline-yield!
+                          "kernel pipelined-for body" (:operations operation))]
+      (when-not (= index-type (:type lower-info) (:type upper-info))
+        (throw (ex-info "kernel pipelined-for index and bounds must have one integral type"
+                        {:reason :kernel-body-loop-index-dtype :index index
+                         :lower-type (:type lower-info) :upper-type (:type upper-info)})))
+      (claim-value! claimed reserved values index "kernel pipelined-for index")
+      (doseq [[arg initial] (map vector iter-args initials)]
+        (let [binding (:binding arg)]
+          (claim-value! claimed reserved values binding "kernel pipelined loop-carried binding")
+          (when-not (= (canonical-type (:type binding)) (:type initial))
+            (throw (ex-info "kernel pipelined loop initial value disagrees with its binding"
+                            {:reason :kernel-body-loop-initial :arg arg :initial initial})))))
+      (let [loop-values (into (assoc values (:id index)
+                                     {:type index-type :uniformity loop-control})
+                              (map (fn [arg initial]
+                                     [(:id (:binding arg))
+                                      (if (contains? uniform-iter-args (:id (:binding arg)))
+                                        initial
+                                        (assoc initial :uniformity lane-varying))])
+                                   iter-args initials))
+            body-values (validate-dataflow-operations!
+                         (pop (:operations operation)) loop-values
+                         (assoc context :control-uniformity loop-control))
+            yielded (mapv #(scalar-value-info! % body-values)
+                          (:values pipeline-yield))
+            expected-types (mapv (comp canonical-type :type :binding) iter-args)
+            actual-types (mapv :type yielded)]
+        (when-not (= expected-types actual-types)
+          (throw (ex-info
+                  "kernel pipelined-for scalar yield disagrees with its carried values"
+                  {:reason :kernel-body-yield-mismatch
+                   :expected expected-types :actual actual-types})))
+        (doseq [[arg initial yielded-info] (map vector iter-args initials yielded)
+                :when (contains? uniform-iter-args (:id (:binding arg)))]
+          (when-not (set/subset? (:uniformity initial) (:uniformity yielded-info))
+            (throw (ex-info
+                    "kernel pipelined loop uniform carried value is not preserved by its backedge"
+                    {:reason :kernel-body-loop-uniformity-invariant
+                     :binding (:binding arg)
+                     :initial-uniformity (:uniformity initial)
+                     :yielded-uniformity (:uniformity yielded-info)}))))
+        (reduce (fn [env [result yielded-info initial-info]]
+                  (claim-value! claimed reserved values result "kernel pipelined-for result")
+                  (when-not (= (canonical-type (:type result)) (:type yielded-info))
+                    (throw (ex-info
+                            "kernel pipelined-for result type disagrees with its yielded value"
+                            {:reason :kernel-body-loop-result
+                             :result result :yielded yielded-info})))
+                  (assoc env (:id result)
+                         (assoc yielded-info :uniformity
+                                (reduce set/intersection loop-control
+                                        [(:uniformity initial-info)
+                                         (:uniformity yielded-info)]))))
+                values (map vector results yielded initials))))
+
     (record-kind? "raster.compiler.ir.kernel_body.Collective" operation)
     (let [result (claim-value! claimed reserved values (:result operation) "subgroup collective")
           input (scalar-value-info! (:input operation) values)
@@ -1214,6 +1359,10 @@
     (throw (ex-info "Yield is only legal as a structured region terminator"
                     {:reason :kernel-body-misplaced-yield :operation operation}))
 
+    (record-kind? "raster.compiler.ir.kernel_body.PipelineYield" operation)
+    (throw (ex-info "PipelineYield is only legal as a pipelined-for terminator"
+                    {:reason :kernel-body-misplaced-pipeline-yield :operation operation}))
+
     ;; Matrix fragment operations do not define scalar SSA values.
     :else values))
 
@@ -1233,6 +1382,7 @@
     [(:then-operations operation) (:else-operations operation)]
 
     (or (record-kind? "raster.compiler.ir.kernel_body.ForLoop" operation)
+        (record-kind? "raster.compiler.ir.kernel_body.PipelinedFor" operation)
         (record-kind? "raster.compiler.ir.kernel_body.Loop" operation)
         (record-kind? "raster.compiler.ir.kernel_body.Guard" operation))
     [(:operations operation)]
@@ -1254,100 +1404,179 @@
                 (throw (ex-info "async staging lifetime crosses a structured region boundary"
                                 {:reason :kernel-body-async-region-lifetime
                                  :owner owner :state state}))))
-            (validate-sequence! [owner operations]
-              (let [final-state
-                    (reduce
-                     (fn [{:keys [issued committed awaiting-barrier] :as state} operation]
-                       (cond
-                         (record-kind? "raster.compiler.ir.kernel_body.AsyncWorkgroupCopy" operation)
-                         (let [id (:id operation)
-                               source (get storage (:source operation))
-                               source-root (or (some-> source :view :buffer) (:id source))
-                               destination (:destination operation)]
-                           (claim! id :copy operation)
-                           (when-not (contains? stable-buffers source-root)
-                             (throw (ex-info
-                                     "async copy source requires a whole-kernel stable-read contract"
-                                     {:reason :kernel-body-async-source-stability
-                                      :copy id :source source-root})))
-                           (when (or (some #(= destination (:destination %)) issued)
-                                     (some (fn [group]
-                                             (some #(= destination (:destination %))
-                                                   (:copies group)))
-                                           committed)
-                                     (contains? awaiting-barrier destination))
-                             (throw (ex-info "async copy destination is still live"
-                                             {:reason :kernel-body-async-destination-live
-                                              :copy id :destination destination})))
-                           (update state :issued conj operation))
+            (group-signature [group]
+              (mapv (fn [copy]
+                      [(:destination copy) (:elements copy) (:transfer-bytes copy)])
+                    (:copies group)))
+            (pipeline-state-compatible! [operation incoming outgoing]
+              (let [incoming-widths (mapv (comp count :copies) incoming)
+                    outgoing-widths (mapv (comp count :copies) outgoing)
+                    incoming-stages (mapv group-signature incoming)
+                    outgoing-stages (mapv group-signature outgoing)]
+                (when-not (and (= incoming-widths outgoing-widths)
+                               (= incoming-stages outgoing-stages))
+                  (throw (ex-info
+                          "pipelined-for backedge must preserve its rotating async stages"
+                          {:reason :kernel-body-pipeline-stage-invariant
+                           :operation operation
+                           :incoming (mapv group-signature incoming)
+                           :outgoing (mapv group-signature outgoing)})))))
+            (validate-sequence-state! [owner operations initial-state]
+              (reduce
+               (fn [{:keys [issued committed awaiting-barrier consumed-stages]
+                     :as state} operation]
+                 (cond
+                   (record-kind? "raster.compiler.ir.kernel_body.AsyncWorkgroupCopy" operation)
+                   (let [id (:id operation)
+                         source (get storage (:source operation))
+                         source-root (or (some-> source :view :buffer) (:id source))
+                         destination (:destination operation)]
+                     (claim! id :copy operation)
+                     (when-not (contains? stable-buffers source-root)
+                       (throw (ex-info
+                               "async copy source requires a whole-kernel stable-read contract"
+                               {:reason :kernel-body-async-source-stability
+                                :copy id :source source-root})))
+                     (when (or (some #(= destination (:destination %)) issued)
+                               (some (fn [group]
+                                       (some #(= destination (:destination %))
+                                             (:copies group)))
+                                     committed)
+                               (contains? awaiting-barrier destination)
+                               (contains? consumed-stages destination))
+                       (throw (ex-info "async copy destination is still live"
+                                       {:reason :kernel-body-async-destination-live
+                                        :copy id :destination destination})))
+                     (-> state
+                         (update :readable-stages disj destination)
+                         (update :issued conj operation)))
 
-                         (record-kind? "raster.compiler.ir.kernel_body.AsyncCommit" operation)
-                         (let [group (:id operation)
-                               copy-ids (mapv :id issued)]
-                           (claim! group :group operation)
-                           (when-not (= copy-ids (:copies operation))
-                             (throw (ex-info
-                                     "async commit must close every copy issued since the prior commit"
-                                     {:reason :kernel-body-async-commit-order
-                                      :group group :issued copy-ids
-                                      :committed (:copies operation)})))
-                           (-> state
-                               (assoc :issued [])
-                               (update :committed conj {:id group :copies issued})))
+                   (record-kind? "raster.compiler.ir.kernel_body.AsyncCommit" operation)
+                   (let [group (:id operation)
+                         copy-ids (mapv :id issued)]
+                     (claim! group :group operation)
+                     (when-not (= copy-ids (:copies operation))
+                       (throw (ex-info
+                               "async commit must close every copy issued since the prior commit"
+                               {:reason :kernel-body-async-commit-order
+                                :group group :issued copy-ids
+                                :committed (:copies operation)})))
+                     (-> state
+                         (assoc :issued [])
+                         (update :committed conj {:id group :copies issued})))
 
-                         (record-kind? "raster.compiler.ir.kernel_body.AsyncWait" operation)
-                         (let [groups (:groups operation)
-                               committed-ids (mapv :id committed)
-                               group-count (count groups)
-                               enough-groups? (<= group-count (count committed))
-                               waited (when enough-groups? (subvec committed 0 group-count))
-                               remaining (when enough-groups? (subvec committed group-count))]
-                           (when-not (and enough-groups?
-                                          (= groups (subvec committed-ids 0 group-count))
-                                          (= (:pending-groups operation) (count remaining)))
-                             (throw (ex-info
-                                     "async wait must consume an oldest prefix and state the remainder"
-                                     {:reason :kernel-body-async-wait-order
-                                      :wait groups :committed committed-ids
-                                      :pending-groups (:pending-groups operation)})))
-                           (-> state
-                               (assoc :committed remaining)
-                               (update :awaiting-barrier into
-                                       (map :destination (mapcat :copies waited)))))
+                   (record-kind? "raster.compiler.ir.kernel_body.AsyncWait" operation)
+                   (let [groups (:groups operation)
+                         committed-ids (mapv :id committed)
+                         group-count (count groups)
+                         enough-groups? (<= group-count (count committed))
+                         waited (when enough-groups? (subvec committed 0 group-count))
+                         remaining (when enough-groups? (subvec committed group-count))]
+                     (when-not (and enough-groups?
+                                    (= groups (subvec committed-ids 0 group-count))
+                                    (= (:pending-groups operation) (count remaining)))
+                       (throw (ex-info
+                               "async wait must consume an oldest prefix and state the remainder"
+                               {:reason :kernel-body-async-wait-order
+                                :wait groups :committed committed-ids
+                                :pending-groups (:pending-groups operation)})))
+                     (-> state
+                         (assoc :committed remaining)
+                         (update :awaiting-barrier into
+                                 (map :destination (mapcat :copies waited)))))
 
-                         (record-kind? "raster.compiler.ir.kernel_body.WorkgroupBarrier" operation)
-                         (assoc state :awaiting-barrier #{})
+                   (record-kind? "raster.compiler.ir.kernel_body.WorkgroupBarrier" operation)
+                   (-> state
+                       (update :readable-stages into awaiting-barrier)
+                       (assoc :awaiting-barrier #{} :consumed-stages #{}))
 
-                         (or (record-kind? "raster.compiler.ir.kernel_body.ScalarLoad" operation)
-                             (record-kind? "raster.compiler.ir.kernel_body.ScalarStore" operation))
-                         (let [buffer (:buffer operation)
-                               incomplete (into (set (map :destination issued))
-                                                (map :destination (mapcat :copies committed)))]
-                           (when (or (contains? incomplete buffer)
-                                     (contains? awaiting-barrier buffer))
-                             (throw (ex-info
-                                     (if (contains? incomplete buffer)
-                                       "staged workgroup memory is consumed before its async wait"
-                                       "staged workgroup memory is consumed before a workgroup barrier")
-                                     {:reason (if (contains? incomplete buffer)
-                                                :kernel-body-async-missing-wait
-                                                :kernel-body-async-missing-barrier)
-                                      :buffer buffer :operation operation})))
-                           state)
+                   (or (record-kind? "raster.compiler.ir.kernel_body.ScalarLoad" operation)
+                       (record-kind? "raster.compiler.ir.kernel_body.ScalarStore" operation))
+                   (let [buffer (:buffer operation)
+                         incomplete (into (set (map :destination issued))
+                                          (map :destination (mapcat :copies committed)))]
+                     (when (or (contains? incomplete buffer)
+                               (contains? awaiting-barrier buffer))
+                       (throw (ex-info
+                               (if (contains? incomplete buffer)
+                                 "staged workgroup memory is consumed before its async wait"
+                                 "staged workgroup memory is consumed before a workgroup barrier")
+                               {:reason (if (contains? incomplete buffer)
+                                          :kernel-body-async-missing-wait
+                                          :kernel-body-async-missing-barrier)
+                                :buffer buffer :operation operation})))
+                     (if (contains? (:readable-stages state) buffer)
+                       (update state :consumed-stages conj buffer)
+                       state))
 
-                         (seq (nested-operation-regions operation))
-                         (do
-                           (clean-state! owner state)
-                           (doseq [[index region] (map-indexed vector
-                                                               (nested-operation-regions operation))]
-                             (validate-sequence! [owner index] region))
-                           state)
+                   (record-kind? "raster.compiler.ir.kernel_body.PipelinedFor" operation)
+                   (let [async-args (:async-iter-args operation)
+                         initial-groups (mapv :initial async-args)
+                         committed-ids (mapv :id committed)
+                         pipeline-yield (terminal-pipeline-yield!
+                                         "kernel pipelined-for body"
+                                         (:operations operation))]
+                     (when-not (and (empty? issued) (empty? awaiting-barrier)
+                                    (empty? consumed-stages)
+                                    (= initial-groups committed-ids))
+                       (throw (ex-info
+                               "pipelined-for must carry the complete ordered async queue"
+                               {:reason :kernel-body-pipeline-entry-state
+                                :operation operation :initial-groups initial-groups
+                                :state state})))
+                     (doseq [arg async-args]
+                       (claim! (:binding arg) :pipeline-binding operation))
+                     (doseq [result (:async-results operation)]
+                       (claim! result :pipeline-result operation))
+                     (let [body-incoming
+                           (mapv (fn [arg group] (assoc group :id (:binding arg)))
+                                 async-args committed)
+                           body-final
+                           (validate-sequence-state!
+                            [owner :pipeline-body]
+                            (pop (:operations operation))
+                            {:issued [] :committed body-incoming
+                             :awaiting-barrier #{}
+                             :readable-stages (:readable-stages state)
+                             :consumed-stages #{}})
+                           yielded-groups (:groups pipeline-yield)
+                           yielded-committed (:committed body-final)]
+                       (when-not (and (empty? (:issued body-final))
+                                      (empty? (:awaiting-barrier body-final))
+                                      (empty? (:consumed-stages body-final))
+                                      (= yielded-groups (mapv :id yielded-committed)))
+                         (throw (ex-info
+                                 "pipelined-for must yield its complete ordered async queue after a reuse barrier"
+                                 {:reason :kernel-body-pipeline-backedge-state
+                                  :operation operation :yielded yielded-groups
+                                  :state body-final})))
+                       (pipeline-state-compatible! operation body-incoming yielded-committed)
+                       (assoc body-final :committed
+                              (mapv (fn [result group] (assoc group :id result))
+                                    (:async-results operation) yielded-committed))))
 
-                         :else state))
-                     {:issued [] :committed [] :awaiting-barrier #{}}
-                     operations)]
-                (clean-state! owner final-state)))]
-      (validate-sequence! :kernel operations)
+                   (seq (nested-operation-regions operation))
+                   (do
+                     (clean-state! owner state)
+                     (doseq [[index region] (map-indexed vector
+                                                         (nested-operation-regions operation))]
+                       (let [nested-final
+                             (validate-sequence-state!
+                              [owner index] region
+                              {:issued [] :committed [] :awaiting-barrier #{}
+                               :readable-stages #{} :consumed-stages #{}})]
+                         (clean-state! [owner index] nested-final)))
+                     state)
+
+                   :else state))
+               initial-state
+               operations))]
+      (let [final-state
+            (validate-sequence-state!
+             :kernel operations
+             {:issued [] :committed [] :awaiting-barrier #{}
+              :readable-stages #{} :consumed-stages #{}})]
+        (clean-state! :kernel final-state))
       (set/difference @claimed reserved))))
 
 (defn validate!

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -74,6 +74,11 @@
                           (body-emit/emit-scalar-kernel
                            "async_staging"
                            (body-fixtures/async-staging-body 32 :preferred)
+                           {:target-dialect dialect :target-features descriptor}))
+           (write-source! directory suffix "pipelined-staging"
+                          (body-emit/emit-scalar-kernel
+                           "pipelined_staging"
+                           (body-fixtures/pipelined-staging-body 32 :preferred)
                            {:target-dialect dialect :target-features descriptor}))]
           (map-indexed (fn [index artifact]
                          (write-artifact! directory suffix (str "tiled-" index) artifact))

--- a/test/raster/compiler/backend/gpu/kernel_body_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_fixtures.clj
@@ -64,3 +64,66 @@
                           :shared-memory-bytes (* width 4)})
     :provenance {:dialect :compile-gate}
     :attributes {:kind :async-staging}}))
+
+(defn pipelined-staging-body
+  "Two rotating workgroup stages. Each steady-state half waits and consumes one stage while the
+  refill of the other stage remains pending across useful work and across the loop backedge."
+  [width overlap]
+  (let [barrier #(body/->WorkgroupBarrier :workgroup #{:workgroup} :acquire-release
+                                          (body/full-participation))
+        copy (fn [id destination]
+               (body/->AsyncWorkgroupCopy
+                id 'x [0] destination [0] width 16 :cached overlap
+                (body/full-participation)))]
+    (body/make
+     {:id :c-family-pipelined-staging-gate
+      :parameters [(body/->KernelParameter
+                    'x :input :float [width] :global
+                    (layout/row-major [width] :float) :input)
+                   (body/->KernelParameter
+                    'y :output :float [width] :global
+                    (layout/row-major [width] :float) :result)]
+      :stable-reads [(body/stable-read 'x)]
+      :allocations [(body/->WorkgroupAllocation
+                     'stage-a :float [width] (layout/row-major [width] :float) 16)
+                    (body/->WorkgroupAllocation
+                     'stage-b :float [width] (layout/row-major [width] :float) 16)]
+      :indices [(body/->IndexBinding 'lane :local 0)]
+      :operations
+      [(copy 'warm-a 'stage-a)
+       (body/->AsyncCommit 'warm-group-a ['warm-a])
+       (copy 'warm-b 'stage-b)
+       (body/->AsyncCommit 'warm-group-b ['warm-b])
+       (body/->PipelinedFor
+        (body/value 'pipeline-iteration :int) 0 2 1 []
+        [(body/->AsyncLoopArg 'carry-a 'warm-group-a)
+         (body/->AsyncLoopArg 'carry-b 'warm-group-b)]
+        [(body/->AsyncWait ['carry-a] 1 :acquire (body/full-participation))
+         (barrier)
+         (body/->ScalarLoad (body/value 'stage-a-value :float)
+                            'stage-a ['lane] nil nil :cached)
+         (barrier)
+         (copy 'refill-a 'stage-a)
+         (body/->AsyncCommit 'refill-group-a ['refill-a])
+         (body/->AsyncWait ['carry-b] 1 :acquire (body/full-participation))
+         (barrier)
+         (body/->ScalarLoad (body/value 'stage-b-value :float)
+                            'stage-b ['lane] nil nil :cached)
+         (body/->ScalarCompute
+          (body/value 'combined-stage-value :float)
+          (body/scalar-expression :+ :float ['stage-a-value 'stage-b-value]))
+         (body/->ScalarStore 'y ['lane] 'combined-stage-value nil)
+         (barrier)
+         (copy 'refill-b 'stage-b)
+         (body/->AsyncCommit 'refill-group-b ['refill-b])
+         (body/->PipelineYield [] ['refill-group-a 'refill-group-b])]
+        [] ['pipeline-group-a 'pipeline-group-b]
+        {:tail-policy :exact})
+       (body/->AsyncWait ['pipeline-group-a 'pipeline-group-b] 0 :acquire
+                         (body/full-participation))
+       (barrier)]
+      :schedule {:async-staging {:groups 2 :depth 2 :pipeline-loop true}}
+      :launch (launch/spec {:workgroup-size [width] :group-count [1]
+                            :shared-memory-bytes (* width 8)})
+      :provenance {:dialect :compile-gate}
+      :attributes {:kind :pipelined-staging}})))

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -98,6 +98,10 @@
   ([] (async-staging-kernel-body :preferred))
   ([overlap] (fixtures/async-staging-body 32 overlap)))
 
+(defn pipelined-staging-kernel-body
+  ([] (pipelined-staging-kernel-body :preferred))
+  ([overlap] (fixtures/pipelined-staging-body 32 overlap)))
+
 (deftest scalar-kernel-body-lowers-without-recovering-a-schedule
   (let [source (opencl/emit-scalar-kernel
                 "scheduled_scalar"
@@ -294,3 +298,37 @@
             {:keys [exit err]} (shell/sh "clang" "-x" "cl" "-cl-std=CL2.0"
                                          "-fsyntax-only" "-" :in source)]
         (is (zero? exit) err)))))
+
+(deftest pipelined-for-lowers-loop-carried-async-groups-across-targets
+  (let [opencl-source (opencl/emit-scalar-kernel
+                       "pipelined_staging" (pipelined-staging-kernel-body)
+                       {:target-dialect :opencl-portable})
+        cuda-source (opencl/emit-scalar-kernel
+                     "pipelined_staging" (pipelined-staging-kernel-body)
+                     {:target-dialect :cuda
+                      :target-features {:compute-capability [8 0]}})
+        hip-source (opencl/emit-scalar-kernel
+                    "pipelined_staging" (pipelined-staging-kernel-body)
+                    {:target-dialect :hip})]
+    (testing "OpenCL materializes event-valued loop carries and parallel backedge copies"
+      (is (str/includes? opencl-source
+                         "event_t rstr_carry_a_event_0 = rstr_warm_a"))
+      (is (str/includes? opencl-source
+                         "event_t rstr_carry_a_next_event_0 = rstr_refill_a"))
+      (is (str/includes? opencl-source
+                         "rstr_carry_a_event_0 = rstr_carry_a_next_event_0"))
+      (is (str/includes? opencl-source
+                         "wait_group_events(1, &rstr_carry_a_event_0)")))
+    (testing "CUDA retains the same steady-state loop through native cp.async groups"
+      (is (str/includes? cuda-source "for (int rstr_pipeline_iteration = 0"))
+      (is (str/includes? cuda-source "cp.async.commit_group"))
+      (is (str/includes? cuda-source "cp.async.wait_group 1")))
+    (testing "HIP preserves correctness with an honest synchronous pipeline spelling"
+      (is (str/includes? hip-source "for (int rstr_pipeline_iteration = 0"))
+      (is (str/includes? hip-source "synchronous cooperative copies are complete"))
+      (is (not (str/includes? hip-source "cp.async"))))
+    (testing "the native event pipeline remains valid OpenCL C"
+      (when (command-available? "clang")
+        (let [{:keys [exit err]} (shell/sh "clang" "-x" "cl" "-cl-std=CL2.0"
+                                           "-fsyntax-only" "-" :in opencl-source)]
+          (is (zero? exit) err))))))

--- a/test/raster/compiler/backend/gpu/kernel_body_workgroup_device_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_workgroup_device_test.clj
@@ -52,6 +52,29 @@
                    :workgroup-memory-bytes
                    (get-in kernel-body [:launch :shared-memory-bytes])}})))
 
+(defn- pipelined-artifact
+  [width]
+  (let [kernel-body (fixtures/pipelined-staging-body width :preferred)
+        abi (body-abi/project-contracts
+             [(kabi/slot 'x :input :float :c-name "rstr_x" :role :input)
+              (kabi/slot 'y :output :float :c-name "rstr_y" :role :result)]
+             kernel-body)]
+    (kart/make
+     {:kernel-name "kernel_body_pipelined_stage"
+      :target :opencl-c
+      :source (body-emit/emit-scalar-kernel
+               "kernel_body_pipelined_stage" kernel-body
+               {:target-dialect :opencl-portable})
+      :abi abi
+      :arguments '[x y]
+      :launch (:launch kernel-body)
+      :effects {:kind :pipelined-workgroup-stage}
+      :provenance {:kernel-body (:id kernel-body)}
+      :attributes {:async-copy-lowering :native-events
+                   :pipeline-depth 2
+                   :workgroup-memory-bytes
+                   (get-in kernel-body [:launch :shared-memory-bytes])}})))
+
 (deftest workgroup-local-roundtrip-is-correct-on-opencl
   (if-not @device-probe/opencl-available?
     (device-probe/opencl-skip! "KernelBody workgroup-local storage and barrier")
@@ -96,6 +119,30 @@
         (register! (:kernel-name compiled) compiled)
         (launch! (bind-call (kcall/make compiled [x y])))
         (is (= (vec input) (vec (buffer->array y))))
+        (finally
+          (free! y)
+          (free! x))))))
+
+(deftest pipelined-workgroup-stage-is-correct-on-opencl
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "KernelBody loop-carried async workgroup staging")
+    (let [ocl (find-ns 'raster.gpu.ocl-runtime)
+          register! (ns-resolve ocl 'register-kernel!)
+          buffer-of-array (ns-resolve ocl 'buffer-of-array)
+          make-buffer (ns-resolve ocl 'make-buffer)
+          bind-call (ns-resolve ocl 'bind-kernel-call)
+          launch! (ns-resolve ocl 'launch-registered-bound!)
+          buffer->array (ns-resolve ocl 'buffer->array)
+          free! (ns-resolve ocl 'free-buffer!)
+          width 32
+          input (float-array (map float (range width)))
+          compiled (pipelined-artifact width)
+          x (buffer-of-array input :float)
+          y (make-buffer width :float)]
+      (try
+        (register! (:kernel-name compiled) compiled)
+        (launch! (bind-call (kcall/make compiled [x y])))
+        (is (= (mapv #(* 2.0 %) input) (vec (buffer->array y))))
         (finally
           (free! y)
           (free! x))))))

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -1,5 +1,6 @@
 (ns raster.compiler.ir.kernel-body-test
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.kernel-body-fixtures :as fixtures]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.kernel-body :as body]
@@ -711,3 +712,44 @@
            (apply scalar-body
                   (assoc (async-stage-operations) 0 (async-stage-copy ['lane]))
                   options))))))
+
+(deftest pipelined-for-carries-a-verified-rotating-async-queue
+  (let [kernel (fixtures/pipelined-staging-body 16 :preferred)
+        pipeline-index 4]
+    (is (body/kernel-body? kernel))
+    (is (= :exact (get-in kernel [:operations pipeline-index :attributes :tail-policy])))
+    (is (= ['pipeline-group-a 'pipeline-group-b]
+           (get-in kernel [:operations pipeline-index :async-results])))
+    (testing "the tail policy is part of the scheduled loop contract"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"explicit tail policy"
+           (body/validate! (assoc-in kernel
+                                     [:operations pipeline-index :attributes]
+                                     {})))))
+    (testing "every carried group is the complete ordered queue at loop entry"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"complete ordered async queue"
+           (body/validate!
+            (-> kernel
+                (assoc-in [:operations pipeline-index :async-iter-args]
+                          [(body/->AsyncLoopArg 'carry-a 'warm-group-a)])
+                (assoc-in [:operations pipeline-index :async-results]
+                          ['pipeline-group-a]))))))
+    (testing "a stage cannot be refilled before all workgroup readers finish"
+      (let [pipeline-operations (get-in kernel [:operations pipeline-index :operations])]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"destination is still live"
+             (body/validate!
+              (assoc-in kernel [:operations pipeline-index :operations]
+                        (vec (concat (subvec pipeline-operations 0 3)
+                                     (subvec pipeline-operations 4)))))))))
+    (testing "the backedge preserves each rotating stage position"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"preserve its rotating async stages"
+           (body/validate!
+            (assoc-in kernel [:operations pipeline-index :operations 4 :elements] 8)))))
+    (testing "pending pipeline results must be drained outside the loop"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"lifetime crosses a structured region boundary"
+           (body/validate! (assoc kernel :operations
+                                  (subvec (:operations kernel) 0 5))))))))


### PR DESCRIPTION
## Summary
- add a verified `PipelinedFor`/`PipelineYield` KernelBody contract with scalar and ordered async loop carries
- prove wait/barrier/reuse lifetimes, rotating-stage invariants, and explicit exact/separate-epilogue tail policy
- lower the same scheduled loop to OpenCL event carries, CUDA `cp.async` groups, and an honest HIP synchronous fallback
- add hardware-free CUDA/HIP compile fixtures plus real Intel OpenCL numerical coverage
- reconcile the compiler north star with the staged JIT/runtime seam, typed SOAC direction, target dialects, and distributed planning

## Validation
- `clojure -M:format` on all changed Clojure files
- focused compiler/device suite: 45 tests, 225 assertions, 0 failures/errors
- generated CUDA/HIP compiler fixtures
- `nvcc -ptx -arch=sm_80` for the pipelined CUDA fixture
- `hipcc --offload-arch=gfx1100 --genco` for the pipelined HIP fixture
- full suite: 2,432 tests, 35,023 assertions, 0 failures/errors; Intel OpenCL/GPU probes available with zero suite skips