### PR TITLE
Pipeline scheduled weighted reductions

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -159,10 +159,16 @@ pending asynchronous state and live staged storage from escaping an ordinary str
 but `PipelinedFor` now carries a complete ordered async queue across loop iterations, verifies each
 rotating stage's layout and lifetime, and requires an explicit exact or separate-epilogue tail
 policy. OpenCL lowers the queue through native event variables; CUDA maps it to `cp.async` groups;
-HIP preserves the same verified schedule with an honest synchronous fallback. The next production
-step is a double-buffered scheduled weighted-reduction body using this representation. Local
-swizzles and measured stage-depth selection then let this collapse the tiled graph toward a
-FlashAttention-like single kernel without changing the semantic plan or external ABI.
+HIP preserves the same verified schedule with an honest synchronous fallback. A production
+double-buffered weighted-reduction schedule now stages two dense-paged FP16 K/V membership rows,
+overlaps each refill with consumption of the other row, and handles histories of length zero or one
+through the prior sequential body and even/odd tails through an explicit drain/epilogue. It retains
+the semantic plan, ordered ABI and interval bounds; CSR membership, CSR physical routing and
+unaligned row widths decline to their prior verified schedules. The exact body runs against the
+reference algebra on Intel and compiles through nvcc and hipcc without target hardware. Local
+swizzles and measured stage-depth selection can now collapse more of the tiled graph toward a
+FlashAttention-like single kernel without changing the semantic plan or external ABI. The schedule
+remains opt-in until device measurements and the runtime cost path justify automatic selection.
 
 ### 2.3 Executable steps and resident artifact values compose
 
@@ -708,26 +714,25 @@ the trusted verifier stays small.
 
 Each increment should be a thin vertical slice with a production-path test.
 
-The immediate continuation after the verified pipelined-loop increment is:
+The immediate continuation after the verified double-buffered weighted-reduction route is:
 
-1. Use `PipelinedFor` for the double-buffered segmented weighted-reduction production route.
-2. In parallel, define a typed SOAC S-expression dialect with `../pattern` and differential-test
+1. Define a typed SOAC S-expression dialect with `../pattern` and differential-test
    map→map, map→reduce and horizontal-map fusion against the current graph.
-3. Carry that dialect in the existing program/value envelope and route one ordinary fused reduction
+2. Carry that dialect in the existing program/value envelope and route one ordinary fused reduction
    through JVM SIMD and GPU `KernelBody` without reconstructing compiler facts from source spelling.
-4. Add a finite verified shared-memory swizzle family and bank-conflict/resource model.
-5. Make stage count and swizzle measured schedule axes, retire the legacy tuner, and remove the
+3. Add a finite verified shared-memory swizzle family and bank-conflict/resource model.
+4. Make stage count and swizzle measured schedule axes, retire the legacy tuner, and remove the
    attention-provenance gate from the generic weighted-reduction matcher.
-6. Migrate the remaining SOAC fusion rules and scalar JVM fallback, then remove compatibility
+5. Migrate the remaining SOAC fusion rules and scalar JVM fallback, then remove compatibility
    re-lowering for the covered forms.
-7. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a
+6. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a
    read-only distributed track without interrupting the kernel and typed-middle-end verticals.
 
 The integrated roadmap has six cooperating tracks rather than one backend-only sequence:
 
 | Track | Near-term completion gate | Unlock |
 |---|---|---|
-| Verified device scheduling | Pipelined loop, double-buffered weighted reduction, tails and honest fallbacks | General staged reductions and FlashAttention-like schedules |
+| Verified device scheduling | Add verified swizzles and measured stage depth to the landed double-buffered reduction | General staged reductions and FlashAttention-like schedules |
 | Typed functional middle end | Pattern-declared typed SOAC program; map/reduce fusion reaches JVM and GPU from one fact set | Reliable fusion, batching, AD and reflection across representations |
 | Portable peak kernels | Verified swizzles/layouts, unified matrix fragments and quant storage descriptors | Competitive GEMM, attention and scientific tiles across Intel/NVIDIA/AMD |
 | Measurement and selection | One tuner over coupled graph/kernel axes with numerical and resource gates | Hardware-aware schedule selection and selective autotuning |

--- a/src/raster/compiler/backend/gpu/attention.clj
+++ b/src/raster/compiler/backend/gpu/attention.clj
@@ -478,6 +478,61 @@
                     :materialized-intermediates []
                     :complexity :query-head-token-dot-plus-value}}))))
 
+(defn emit-fp16-pipelined
+  "Emit the double-buffered membership-row schedule for routed FP16 K/V reduction.
+
+   Scheduling and KernelBody lowering remain target-neutral.  The target dialect only chooses
+   the verified asynchronous-copy spelling (including capability-gated CUDA cp.async)."
+  ([plan schedule]
+   (emit-fp16-pipelined plan schedule :opencl-intel {}))
+  ([plan schedule target-dialect]
+   (emit-fp16-pipelined plan schedule target-dialect {}))
+  ([plan schedule target-dialect target-features]
+   (let [dialect (c-dialect/resolve! target-dialect)
+         [plan schedule {:keys [output route] :as problem}]
+         (cooperative-plan! plan schedule)
+         name (kernel-name problem schedule)
+         inputs (ordered-inputs plan)
+         arguments (conj inputs output)
+         kernel-body (swr-body/lower-routed-paged-pipelined plan schedule)
+         base-abi (ordered-abi problem)
+         parameter-names (into {} (map (juxt :name :c-name)) base-abi)
+         abi (body-abi/project-contracts base-abi kernel-body)]
+     (kart/make
+      {:kernel-name name
+       :target (c-dialect/target dialect)
+       :source (body-opencl/emit-scalar-kernel
+                name kernel-body
+                {:parameter-names parameter-names
+                 :target-dialect target-dialect
+                 :target-features target-features})
+       :abi abi
+       :arguments arguments
+       :launch (:launch kernel-body)
+       :effects {:kind :attention :reads inputs :writes [output]}
+       :provenance {:operation-id (:id problem) :semantic-op :attention
+                    :algebra-plan-id (:id plan)
+                    :lowering :subgroup-online-pipelined-history}
+       :attributes {:strategy :routed-paged-subgroup-online-pipelined-history
+                    :optimization-tier :subgroup-pipelined
+                    :algebra :segmented-weighted-reduction
+                    :algebra-key (swr/algebra-key plan)
+                    :segmented-weighted-reduction-schedule schedule
+                    :storage-dtype :half :q-dtype (:q-dtype problem)
+                    :output-dtype (:output-dtype problem) :accumulator-dtype :float
+                    :route-kind (attention/route-kind route)
+                    :visibility-kind (attention/visibility-kind (:visibility problem))
+                    :k-layout (:k-layout problem) :v-layout (:v-layout problem)
+                    :visibility (:visibility problem)
+                    :layout (attention/layouts problem)
+                    :kernel-body kernel-body
+                    :target-dialect target-dialect
+                    :target-features target-features
+                    :target-collective-association
+                    (c-dialect/collective-association dialect)
+                    :materialized-intermediates []
+                    :complexity :pipelined-query-head-token-dot-plus-value}}))))
+
 (def ^:private partial-c-names
   {:partial-valid "partial_valid"
    :partial-maximum "partial_maximum"

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -449,10 +449,14 @@
                      (throw (ex-info "kernel mask references values outside the operation scope"
                                      {:mask id :references (vec outside)
                                       :scope scope :operation operation}))))))
+        coordinates-syntax! (fn [owner coordinates]
+                              (when-not (and (vector? coordinates)
+                                             (every? expression? coordinates))
+                                (throw (ex-info
+                                        (str owner " coordinates must use explicit index expressions")
+                                        {:coordinates coordinates}))))
         coordinates! (fn [owner coordinates]
-                       (when-not (and (vector? coordinates) (every? expression? coordinates))
-                         (throw (ex-info (str owner " coordinates must use explicit index expressions")
-                                         {:coordinates coordinates})))
+                       (coordinates-syntax! owner coordinates)
                        (let [outside (remove scope (mapcat expression-references coordinates))]
                          (when (seq outside)
                            (throw (ex-info (str owner " coordinates reference values outside the operation scope")
@@ -746,8 +750,11 @@
             destination (parameter (:destination operation))
             elements (:elements operation)
             transfer-bytes (:transfer-bytes operation)]
-        (coordinates! "async-copy source" (:source-coordinates operation))
-        (coordinates! "async-copy destination" (:destination-coordinates operation))
+        ;; Async-copy coordinates are scalar SSA expressions, unlike the legacy tile vocabulary
+        ;; whose coordinates are restricted to kernel index bindings.  Their references and
+        ;; workgroup uniformity are checked by the typed SSA verifier below.
+        (coordinates-syntax! "async-copy source" (:source-coordinates operation))
+        (coordinates-syntax! "async-copy destination" (:destination-coordinates operation))
         (when-not (and (value-id? (:id operation))
                        (= :input (:kind source))
                        (= :global (:memory-space source))
@@ -1404,6 +1411,13 @@
                 (throw (ex-info "async staging lifetime crosses a structured region boundary"
                                 {:reason :kernel-body-async-region-lifetime
                                  :owner owner :state state}))))
+            (active-staging? [state]
+              (or (seq (:issued state)) (seq (:committed state))
+                  (seq (:awaiting-barrier state))
+                  (seq (:readable-stages state))
+                  (seq (:consumed-stages state))))
+            (queue-state [state]
+              (select-keys state [:issued :committed :awaiting-barrier :readable-stages]))
             (group-signature [group]
               (mapv (fn [copy]
                       [(:destination copy) (:elements copy) (:transfer-bytes copy)])
@@ -1556,17 +1570,39 @@
                                     (:async-results operation) yielded-committed))))
 
                    (seq (nested-operation-regions operation))
-                   (do
-                     (clean-state! owner state)
-                     (doseq [[index region] (map-indexed vector
-                                                         (nested-operation-regions operation))]
-                       (let [nested-final
-                             (validate-sequence-state!
-                              [owner index] region
-                              {:issued [] :committed [] :awaiting-barrier #{}
-                               :readable-stages #{} :consumed-stages #{}})]
-                         (clean-state! [owner index] nested-final)))
-                     state)
+                   (let [regions (nested-operation-regions operation)]
+                     (if-not (active-staging? state)
+                       (do
+                         (clean-state! owner state)
+                         (doseq [[index region] (map-indexed vector regions)]
+                           (let [nested-final
+                                 (validate-sequence-state!
+                                  [owner index] region
+                                  {:issued [] :committed [] :awaiting-barrier #{}
+                                   :readable-stages #{} :consumed-stages #{}})]
+                             (clean-state! [owner index] nested-final)))
+                         state)
+                       (if (record-kind? "raster.compiler.ir.kernel_body.IfRegion" operation)
+                         (let [branch-states
+                               (mapv (fn [index region]
+                                       (validate-sequence-state! [owner index] region state))
+                                     (range) regions)]
+                           (when-not (apply = branch-states)
+                             (throw (ex-info
+                                     "structured branches disagree on live async staging state"
+                                     {:reason :kernel-body-async-branch-state
+                                      :owner owner :operation operation
+                                      :branch-states branch-states})))
+                           (first branch-states))
+                         (let [nested-final
+                               (validate-sequence-state! [owner 0] (first regions) state)]
+                           (when-not (= (queue-state state) (queue-state nested-final))
+                             (throw (ex-info
+                                     "ordinary structured loop changes live async queue state"
+                                     {:reason :kernel-body-async-loop-state
+                                      :owner owner :operation operation
+                                      :initial state :final nested-final})))
+                           nested-final))))
 
                    :else state))
                initial-state

--- a/src/raster/compiler/ir/segmented_weighted_reduction_schedule.clj
+++ b/src/raster/compiler/ir/segmented_weighted_reduction_schedule.clj
@@ -7,7 +7,7 @@
 
 (defrecord SegmentedWeightedReductionSchedule
            [strategy workgroup-size segment-mapping membership-traversal score-reduction
-            membership-tiling value-mapping state numerical-mode attributes])
+            membership-tiling value-mapping state staging numerical-mode attributes])
 
 (def ^:private online-state-components
   [:maximum :denominator :weighted-values])
@@ -52,6 +52,23 @@
 
     false))
 
+(defn- valid-staging?
+  [strategy staging]
+  (if (= :subgroup-online-pipelined-history strategy)
+    (and (= :double-buffered-membership-rows (:kind staging))
+         (= 2 (:stages staging))
+         (= 2 (:members-per-iteration staging))
+         (= :half (:element-dtype staging))
+         (pos-int? (:key-elements staging))
+         (pos-int? (:value-elements staging))
+         (contains? #{4 8 16} (:transfer-bytes staging))
+         (contains? #{:preferred :required} (:overlap staging))
+         (= :separate-epilogue (:tail-policy staging))
+         (pos-int? (:shared-memory-bytes staging))
+         (= (:shared-memory-bytes staging)
+            (* 2 (+ (:key-elements staging) (:value-elements staging)) 2)))
+    (= {:kind :none} staging)))
+
 (defn schedule?
   [value]
   (and value
@@ -65,8 +82,9 @@
                     {:reason :segmented-weighted-reduction-schedule-type
                      :schedule schedule})))
   (let [{:keys [strategy workgroup-size segment-mapping membership-traversal score-reduction
-                membership-tiling value-mapping state numerical-mode attributes]} schedule]
+                membership-tiling value-mapping state staging numerical-mode attributes]} schedule]
     (when-not (contains? #{:subgroup-online-score-reuse
+                           :subgroup-online-pipelined-history
                            :subgroup-online-tiled-history}
                          strategy)
       (throw (ex-info "segmented weighted-reduction schedule has an unsupported strategy"
@@ -82,9 +100,9 @@
                              :one-workgroup-per-segment)]
       (when-not (= expected-mapping segment-mapping)
         (throw (ex-info "cooperative weighted reduction has an invalid segment mapping"
-                      {:reason :segmented-weighted-reduction-segment-mapping
-                       :strategy strategy :segment-mapping segment-mapping
-                       :expected expected-mapping}))))
+                        {:reason :segmented-weighted-reduction-segment-mapping
+                         :strategy strategy :segment-mapping segment-mapping
+                         :expected expected-mapping}))))
     (when-not (contains? #{:contiguous-interval :csr-row} membership-traversal)
       (throw (ex-info "cooperative weighted reduction requires a bounded membership traversal"
                       {:reason :segmented-weighted-reduction-membership-traversal
@@ -117,6 +135,10 @@
     (when-not (= (online-state) state)
       (throw (ex-info "cooperative weighted reduction requires explicit online softmax state"
                       {:reason :segmented-weighted-reduction-online-state :state state})))
+    (when-not (valid-staging? strategy staging)
+      (throw (ex-info "cooperative weighted reduction has an invalid workgroup staging contract"
+                      {:reason :segmented-weighted-reduction-staging
+                       :strategy strategy :staging staging})))
     (when-not (and (map? numerical-mode)
                    (keyword? (:score-accumulate numerical-mode))
                    (keyword? (:state-accumulate numerical-mode))
@@ -134,9 +156,9 @@
 
 (defn make
   [{:keys [strategy workgroup-size segment-mapping membership-traversal score-reduction
-           membership-tiling value-mapping state numerical-mode attributes]
-    :or {attributes {}}}]
+           membership-tiling value-mapping state staging numerical-mode attributes]
+    :or {staging {:kind :none} attributes {}}}]
   (validate!
    (->SegmentedWeightedReductionSchedule
     strategy workgroup-size segment-mapping membership-traversal score-reduction
-    membership-tiling value-mapping state numerical-mode attributes)))
+    membership-tiling value-mapping state staging numerical-mode attributes)))

--- a/src/raster/compiler/passes/parallel/attention_route.clj
+++ b/src/raster/compiler/passes/parallel/attention_route.clj
@@ -15,7 +15,7 @@
 
 (def ^:private cooperative-policies
   #{:subgroup-score-reuse :subgroup-online-score-reuse
-    :subgroup-online-tiled-history})
+    :subgroup-online-tiled-history :subgroup-online-pipelined-history})
 
 (defn- requested-policy
   [desc]
@@ -100,18 +100,36 @@
 
            (or (= :auto policy) (contains? cooperative-policies policy))
            (let [{:keys [ok schedule reason] :as scheduled}
-                 (if (= :subgroup-online-tiled-history policy)
+                 (cond
+                   (= :subgroup-online-tiled-history policy)
                    (swr-schedule/plan-subgroup-online-tiled plan desc)
+
+                   (= :subgroup-online-pipelined-history policy)
+                   (swr-schedule/plan-subgroup-online-pipelined plan desc)
+
+                   (= :auto policy)
+                   (swr-schedule/plan-subgroup-online plan desc)
+
+                   :else
                    (swr-schedule/plan-subgroup-online plan desc))
                  emitter-supported? (gpu-target/intel-opencl-subgroup-dialect? desc)]
              (if (and ok emitter-supported?)
-               (if (= :subgroup-online-tiled-history policy)
+               (cond
+                 (= :subgroup-online-tiled-history (:strategy schedule))
                  (success-graph problem plan
                                 (emit/emit-fp16-tiled-history plan schedule) [])
+
+                 (= :subgroup-online-pipelined-history (:strategy schedule))
+                 (success problem plan (emit/emit-fp16-pipelined plan schedule) [])
+
+                 :else
                  (success problem plan (emit/emit-fp16-cooperative plan schedule) []))
                (let [cooperative-decline
-                     {:leaf (if (= :subgroup-online-tiled-history policy)
+                     {:leaf (case policy
+                              :subgroup-online-tiled-history
                               :routed-paged-subgroup-online-tiled-history
+                              :subgroup-online-pipelined-history
+                              :routed-paged-subgroup-online-pipelined-history
                               :routed-paged-subgroup-online-score-reuse)
                       :reason (if ok
                                 :score-reuse-requires-intel-subgroup-dialect

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_body.clj
@@ -129,7 +129,7 @@
           prefix [(get-in problem [:query :total-tokens]) (:q-heads problem) tile-count]
           scalar-elements (checked-elements :scalar-state prefix)
           weighted-elements (checked-elements :weighted-values
-                                               (conj prefix (:value-head-dim problem)))]
+                                              (conj prefix (:value-head-dim problem)))]
       [{:id (:valid ids) :dtype :int :shape prefix :elements scalar-elements
         :role :partial-valid}
        {:id (:maximum ids) :dtype :float :shape prefix :elements scalar-elements
@@ -612,26 +612,391 @@
   (body/->Mask :lane-zero [(body/predicate :eq 'lane 0)]))
 
 (defn- output-operations
-  [problem slots]
-  (flatten-operations
-   (concat
-    [(compute 'denominator-is-zero :predicate
-              (expr :eq :predicate 'final-denominator (lit 0.0 :float)))]
-    (mapcat
-     (fn [{:keys [slot id mask-id result-id]}]
-       (let [normalized (symbol (str "normalized-value-" slot))
-             valid-value (symbol (str "valid-output-value-" slot))
-             stored (symbol (str "stored-output-value-" slot))]
-         [(compute normalized :float
-                   (select-expr 'denominator-is-zero (lit 0.0 :float)
-                                (expr :div :float result-id 'final-denominator) :float))
-          (compute valid-value :float
-                   (select-expr 'final-valid normalized (lit Double/NaN :float) :float))
-          (compute stored (:output-dtype problem)
-                   (output-value valid-value (:output-dtype problem)))
-          (body/->ScalarStore (:output problem)
-                              ['query-token 'query-head id] stored mask-id)]))
-     slots))))
+  ([problem slots]
+   (output-operations
+    problem slots
+    {:valid 'final-valid
+     :denominator 'final-denominator
+     :weighted-values (mapv :result-id slots)}))
+  ([problem slots {:keys [valid denominator weighted-values]}]
+   (flatten-operations
+    (concat
+     [(compute 'denominator-is-zero :predicate
+               (expr :eq :predicate denominator (lit 0.0 :float)))]
+     (mapcat
+      (fn [{:keys [slot id mask-id]} weighted-value]
+        (let [normalized (symbol (str "normalized-value-" slot))
+              valid-value (symbol (str "valid-output-value-" slot))
+              stored (symbol (str "stored-output-value-" slot))]
+          [(compute normalized :float
+                    (select-expr 'denominator-is-zero (lit 0.0 :float)
+                                 (expr :div :float weighted-value denominator) :float))
+           (compute valid-value :float
+                    (select-expr valid normalized (lit Double/NaN :float) :float))
+           (compute stored (:output-dtype problem)
+                    (output-value valid-value (:output-dtype problem)))
+           (body/->ScalarStore (:output problem)
+                               ['query-token 'query-head id] stored mask-id)]))
+      slots weighted-values)))))
+
+(defn- tagged-id
+  [tag id]
+  (symbol (str (name tag) "-" (name id))))
+
+(defn- pipeline-state
+  [tag slots]
+  {:valid (tagged-id tag :valid)
+   :maximum (tagged-id tag :maximum)
+   :denominator (tagged-id tag :denominator)
+   :weighted-values (mapv #(tagged-id tag (keyword (str "weighted-" (:slot %)))) slots)})
+
+(defn- pipeline-state-values
+  [{:keys [valid maximum denominator weighted-values]}]
+  (vec (concat [valid maximum denominator] weighted-values)))
+
+(defn- pipeline-state-specs
+  [state]
+  (mapv body/value (pipeline-state-values state)
+        (concat [:predicate :float :float]
+                (repeat (count (:weighted-values state)) :float))))
+
+(defn- initial-online-state
+  [initial-valid slots]
+  (vec (concat [initial-valid
+                (lit -3.402823466e38 :float)
+                (lit 0.0 :float)]
+               (repeat (count slots) (lit 0.0 :float)))))
+
+(defn- workgroup-barrier
+  []
+  (body/->WorkgroupBarrier :workgroup #{:workgroup} :acquire-release
+                           (body/full-participation)))
+
+(defn- dense-member-route
+  [problem tag member]
+  (let [logical-page (tagged-id tag :logical-page)
+        safe-logical-page (tagged-id tag :safe-logical-page)
+        physical-page (tagged-id tag :physical-page)
+        page-token (tagged-id tag :page-token)
+        physical-page-nonnegative (tagged-id tag :physical-page-nonnegative)
+        physical-page-bounded (tagged-id tag :physical-page-bounded)
+        physical-page-valid (tagged-id tag :physical-page-valid)
+        safe-physical-page (tagged-id tag :safe-physical-page)
+        page-size (:page-size problem)]
+    {:physical-page-valid physical-page-valid
+     :safe-physical-page safe-physical-page
+     :page-token page-token
+     :operations
+     [(compute logical-page :long
+               (expr :quot :long member (lit page-size :long)))
+      (compute safe-logical-page :long
+               (expr :min :long
+                     (expr :max :long logical-page (lit 0 :long))
+                     (lit (dec (get-in problem [:route :pages-per-sequence])) :long)))
+      (load-value physical-page :int (get-in problem [:route :page-table])
+                  ['safe-query-batch safe-logical-page])
+      (compute page-token :long
+               (expr :- :long member
+                     (expr :* :long safe-logical-page (lit page-size :long))))
+      (compute physical-page-nonnegative :predicate
+               (expr :ge :predicate physical-page (lit 0 :int)))
+      (compute physical-page-bounded :predicate
+               (expr :lt :predicate physical-page (lit (:physical-pages problem) :int)))
+      (compute physical-page-valid :predicate
+               (and-expr physical-page-nonnegative physical-page-bounded))
+      (compute safe-physical-page :int
+               (expr :min :int
+                     (expr :max :int physical-page (lit 0 :int))
+                     (lit (dec (:physical-pages problem)) :int)))]}))
+
+(defn- stage-member-row
+  [problem scheduled tag member {:keys [key value]}]
+  (let [{:keys [operations safe-physical-page page-token]}
+        (dense-member-route problem tag member)
+        staging (:staging scheduled)
+        key-copy (tagged-id tag :key-copy)
+        value-copy (tagged-id tag :value-copy)
+        group (tagged-id tag :group)
+        transfer-bytes (:transfer-bytes staging)
+        overlap (:overlap staging)]
+    {:group group
+     :operations
+     (vec
+      (concat
+       operations
+       [(body/->AsyncWorkgroupCopy
+         key-copy (:k-pages problem)
+         (cache-coordinates (:k-layout problem) 'kv-head safe-physical-page page-token 0)
+         key [0] (:qk-head-dim problem) transfer-bytes :cached overlap
+         (body/full-participation))
+        (body/->AsyncWorkgroupCopy
+         value-copy (:v-pages problem)
+         (cache-coordinates (:v-layout problem) 'kv-head safe-physical-page page-token 0)
+         value [0] (:value-head-dim problem) transfer-bytes :cached overlap
+         (body/full-participation))
+        (body/->AsyncCommit group [key-copy value-copy])]))}))
+
+(defn- staged-dot
+  [problem scheduled tag key-stage]
+  (let [component (tagged-id tag :qk-component)
+        partial-state (tagged-id tag :partial-dot-state)
+        query-element (tagged-id tag :query-element)
+        key-element (tagged-id tag :key-element)
+        query-float (tagged-id tag :query-float)
+        key-float (tagged-id tag :key-float)
+        product (tagged-id tag :qk-product)
+        partial-next (tagged-id tag :partial-dot-next)
+        partial-dot (tagged-id tag :partial-dot)
+        dot (tagged-id tag :dot)
+        logit (tagged-id tag :logit)]
+    {:logit logit
+     :operations
+     [(body/->ForLoop
+       (body/value component :int) 'lane (:qk-head-dim problem) (:workgroup-size scheduled)
+       [(body/->LoopArg (body/value partial-state :float) (lit 0.0 :float))]
+       [(load-value query-element (:q-dtype problem) (get-in problem [:query :values])
+                    ['query-token 'query-head component])
+        (load-value key-element :half key-stage [component])
+        (compute query-float :float
+                 (half-or-float->float query-element (:q-dtype problem)))
+        (compute key-float :float (half-or-float->float key-element :half))
+        (compute product :float (expr :* :float query-float key-float))
+        (compute partial-next :float (expr :+ :float partial-state product))
+        (body/->Yield [partial-next])]
+       [(body/value partial-dot :float)] {})
+      (body/->Collective
+       (body/value dot :float) :reduce :subgroup (:workgroup-size scheduled)
+       partial-dot :+ nil (body/full-participation) :implementation-defined)
+      (compute logit :float (expr :* :float dot (lit (:scale problem) :float)))]}))
+
+(defn- staged-values
+  [slots tag value-stage]
+  (let [values (mapv #(tagged-id tag (keyword (str "value-float-" (:slot %)))) slots)]
+    {:values values
+     :operations
+     (vec
+      (mapcat
+       (fn [{:keys [slot safe-id mask-id]} value-id]
+         (let [element (tagged-id tag (keyword (str "value-element-" slot)))]
+           [(load-value element :half value-stage [safe-id] mask-id (lit 0.0 :half))
+            (compute value-id :float (half-or-float->float element :half))]))
+       slots values))}))
+
+(defn- staged-online-update
+  [slots tag input-state output-state valid-next logit staged-value-ids]
+  (let [maximum-is-nan (tagged-id tag :maximum-is-nan)
+        logit-is-nan (tagged-id tag :logit-is-nan)
+        state-is-nan (tagged-id tag :state-is-nan)
+        maximum-valid (tagged-id tag :maximum-valid)
+        old-weight-valid (tagged-id tag :old-weight-valid)
+        new-weight-valid (tagged-id tag :new-weight-valid)
+        next-maximum (tagged-id tag :next-maximum)
+        old-weight (tagged-id tag :old-weight)
+        new-weight (tagged-id tag :new-weight)
+        next-denominator (tagged-id tag :next-denominator)
+        next-weighted (mapv #(tagged-id tag (keyword (str "next-weighted-" (:slot %))))
+                            slots)]
+    (flatten-operations
+     [(compute maximum-is-nan :predicate
+               (body/scalar-expression :isnan :predicate [(:maximum input-state)]))
+      (compute logit-is-nan :predicate
+               (body/scalar-expression :isnan :predicate [logit]))
+      (compute state-is-nan :predicate (or-expr maximum-is-nan logit-is-nan))
+      (body/->IfRegion
+       state-is-nan
+       [(body/->Yield [(lit Double/NaN :float)
+                       (lit Double/NaN :float)
+                       (lit Double/NaN :float)])]
+       [(compute maximum-valid :float (expr :max :float (:maximum input-state) logit))
+        (compute old-weight-valid :float
+                 (expr :exp :float (expr :- :float (:maximum input-state) maximum-valid)))
+        (compute new-weight-valid :float
+                 (expr :exp :float (expr :- :float logit maximum-valid)))
+        (body/->Yield [maximum-valid old-weight-valid new-weight-valid])]
+       [(body/value next-maximum :float)
+        (body/value old-weight :float)
+        (body/value new-weight :float)])
+      (compute next-denominator :float
+               (expr :+ :float
+                     (expr :* :float (:denominator input-state) old-weight)
+                     new-weight))
+      (vec
+       (map (fn [input-weight staged-value output-weight]
+              (compute output-weight :float
+                       (expr :+ :float
+                             (expr :* :float input-weight old-weight)
+                             (expr :* :float staged-value new-weight))))
+            (:weighted-values input-state) staged-value-ids next-weighted))
+      (body/->Yield
+       (pipeline-state-values
+        (assoc output-state
+               :valid valid-next
+               :maximum next-maximum
+               :denominator next-denominator
+               :weighted-values next-weighted)))])))
+
+(defn- consume-staged-member
+  [problem scheduled slots tag member stage input-state]
+  (let [{route-ops :operations physical-page-valid :physical-page-valid}
+        (dense-member-route problem (keyword (str (name tag) "-route")) member)
+        member-valid-next (tagged-id tag :member-valid-next)
+        member-applies (tagged-id tag :member-applies)
+        {dot-ops :operations logit :logit}
+        (staged-dot problem scheduled (keyword (str (name tag) "-dot")) (:key stage))
+        {value-ops :operations staged-value-ids :values}
+        (staged-values slots (keyword (str (name tag) "-value")) (:value stage))
+        output-state (pipeline-state (keyword (str (name tag) "-result")) slots)
+        update-ops (staged-online-update
+                    slots (keyword (str (name tag) "-online")) input-state output-state
+                    member-valid-next logit staged-value-ids)]
+    {:state output-state
+     :operations
+     (flatten-operations
+      [route-ops
+       (compute member-valid-next :predicate
+                (and-expr (:valid input-state) physical-page-valid))
+       (compute member-applies :predicate
+                (and-expr (:valid input-state) physical-page-valid))
+       dot-ops value-ops
+       (body/->IfRegion
+        member-applies
+        update-ops
+        [(body/->Yield
+          (pipeline-state-values
+           (assoc input-state :valid member-valid-next)))]
+        (pipeline-state-specs output-state))])}))
+
+(defn- pipelined-membership
+  [problem scheduled slots]
+  (let [stage-a {:key 'pipeline-key-stage-a :value 'pipeline-value-stage-a}
+        stage-b {:key 'pipeline-key-stage-b :value 'pipeline-value-stage-b}
+        initial-state (initial-online-state 'initial-valid slots)
+        loop-state (pipeline-state :pipeline-loop slots)
+        steady-state (pipeline-state :pipeline-steady slots)
+        final-state (pipeline-state :pipeline-final slots)
+        warm-a-member 'pipeline-warm-a-member
+        warm-b-member 'pipeline-warm-b-member
+        warm-a (stage-member-row problem scheduled :pipeline-warm-a warm-a-member stage-a)
+        warm-b (stage-member-row problem scheduled :pipeline-warm-b warm-b-member stage-b)
+        pair-index 'pipeline-pair
+        current-a 'pipeline-current-a-member
+        current-b 'pipeline-current-b-member
+        next-a 'pipeline-next-a-member
+        next-b 'pipeline-next-b-member
+        consume-a (consume-staged-member problem scheduled slots :pipeline-a current-a
+                                         stage-a loop-state)
+        refill-a (stage-member-row problem scheduled :pipeline-refill-a next-a stage-a)
+        consume-b (consume-staged-member problem scheduled slots :pipeline-b current-b
+                                         stage-b (:state consume-a))
+        refill-b (stage-member-row problem scheduled :pipeline-refill-b next-b stage-b)
+        epilogue-a-member 'pipeline-epilogue-a-member
+        epilogue-b-member 'pipeline-epilogue-b-member
+        epilogue-a (consume-staged-member problem scheduled slots :pipeline-epilogue-a
+                                          epilogue-a-member stage-a steady-state)
+        epilogue-b (consume-staged-member problem scheduled slots :pipeline-epilogue-b
+                                          epilogue-b-member stage-b (:state epilogue-a))
+        odd-member 'pipeline-odd-member
+        odd-stage (stage-member-row problem scheduled :pipeline-odd-stage odd-member stage-a)
+        odd-consume (consume-staged-member problem scheduled slots :pipeline-odd odd-member
+                                           stage-a (:state epilogue-b))
+        tail-state (pipeline-state :pipeline-tail slots)
+        pipeline
+        (body/->PipelinedFor
+         (body/value pair-index :long) 'pipeline-zero 'pipeline-refill-pairs 1
+         (mapv body/->LoopArg (pipeline-state-specs loop-state) initial-state)
+         [(body/->AsyncLoopArg 'pipeline-carry-a (:group warm-a))
+          (body/->AsyncLoopArg 'pipeline-carry-b (:group warm-b))]
+         (flatten-operations
+          [(compute current-a :long
+                    (expr :+ :long 'attention-begin
+                          (expr :* :long pair-index (lit 2 :long))))
+           (compute current-b :long (expr :+ :long current-a (lit 1 :long)))
+           (body/->AsyncWait ['pipeline-carry-a] 1 :acquire
+                             (body/full-participation))
+           (workgroup-barrier)
+           (:operations consume-a)
+           (workgroup-barrier)
+           (compute next-a :long (expr :+ :long current-a (lit 2 :long)))
+           (:operations refill-a)
+           (body/->AsyncWait ['pipeline-carry-b] 1 :acquire
+                             (body/full-participation))
+           (workgroup-barrier)
+           (:operations consume-b)
+           (workgroup-barrier)
+           (compute next-b :long (expr :+ :long current-b (lit 2 :long)))
+           (:operations refill-b)
+           (body/->PipelineYield (pipeline-state-values (:state consume-b))
+                                 [(:group refill-a) (:group refill-b)])])
+         (pipeline-state-specs steady-state)
+         ['pipeline-final-group-a 'pipeline-final-group-b]
+         {:tail-policy (get-in scheduled [:staging :tail-policy])})
+        fallback-loop (membership-loop problem scheduled slots 'attention-begin 'attention-end)
+        fallback-state {:valid 'final-valid
+                        :maximum 'final-maximum
+                        :denominator 'final-denominator
+                        :weighted-values (mapv :result-id slots)}]
+    {:state final-state
+     :operations
+     (flatten-operations
+      [(compute 'pipeline-membership-count :long
+                (expr :- :long 'attention-end 'attention-begin))
+       (compute 'pipeline-zero :long
+                (expr :- :long 'attention-begin 'attention-begin))
+       (compute 'pipeline-pair-count :long
+                (expr :quot :long 'pipeline-membership-count (lit 2 :long)))
+       (compute 'pipeline-refill-pairs :long
+                (expr :max :long
+                      (expr :- :long 'pipeline-pair-count (lit 1 :long))
+                      (lit 0 :long)))
+       (compute 'pipeline-has-pair :predicate
+                (expr :ge :predicate 'pipeline-membership-count (lit 2 :long)))
+       (body/->IfRegion
+        'pipeline-has-pair
+        (flatten-operations
+         [(compute warm-a-member :long
+                   (expr :+ :long 'attention-begin (lit 0 :long)))
+          (compute warm-b-member :long
+                   (expr :+ :long 'attention-begin (lit 1 :long)))
+          (:operations warm-a)
+          (:operations warm-b)
+          pipeline
+          (body/->AsyncWait ['pipeline-final-group-a 'pipeline-final-group-b]
+                            0 :acquire (body/full-participation))
+          (workgroup-barrier)
+          (compute 'pipeline-final-pair :long
+                   (expr :- :long 'pipeline-pair-count (lit 1 :long)))
+          (compute epilogue-a-member :long
+                   (expr :+ :long 'attention-begin
+                         (expr :* :long 'pipeline-final-pair (lit 2 :long))))
+          (compute epilogue-b-member :long
+                   (expr :+ :long epilogue-a-member (lit 1 :long)))
+          (:operations epilogue-a)
+          (:operations epilogue-b)
+          (compute 'pipeline-has-odd :predicate
+                   (expr :eq :predicate
+                         (expr :rem :long 'pipeline-membership-count (lit 2 :long))
+                         (lit 1 :long)))
+          (compute odd-member :long
+                   (expr :+ :long 'attention-begin
+                         (expr :* :long 'pipeline-pair-count (lit 2 :long))))
+          (body/->IfRegion
+           'pipeline-has-odd
+           (flatten-operations
+            [(workgroup-barrier)
+             (:operations odd-stage)
+             (body/->AsyncWait [(:group odd-stage)] 0 :acquire
+                               (body/full-participation))
+             (workgroup-barrier)
+             (:operations odd-consume)
+             (workgroup-barrier)
+             (body/->Yield (pipeline-state-values (:state odd-consume)))])
+           [(workgroup-barrier)
+            (body/->Yield (pipeline-state-values (:state epilogue-b)))]
+           (pipeline-state-specs tail-state))
+          (body/->Yield (pipeline-state-values tail-state))])
+        [fallback-loop
+         (body/->Yield (pipeline-state-values fallback-state))]
+        (pipeline-state-specs final-state))])}))
 
 (defn- lowering-row!
   [plan scheduled problem]
@@ -672,8 +1037,9 @@
 (defn- sequential-lowering-row!
   [plan scheduled problem]
   (lowering-row! plan scheduled problem)
-  (when (schedule/tiled? scheduled)
-    (throw (ex-info "single-body weighted reduction cannot consume a tiled schedule"
+  (when (or (schedule/tiled? scheduled)
+            (not= {:kind :none} (:staging scheduled)))
+    (throw (ex-info "sequential weighted-reduction body requires an unstaged, untiled schedule"
                     {:reason :segmented-weighted-reduction-body-schedule-phase
                      :expected :sequential :schedule scheduled})))
   [plan scheduled problem])
@@ -685,6 +1051,23 @@
     (throw (ex-info "partial/merge bodies require a tiled weighted-reduction schedule"
                     {:reason :segmented-weighted-reduction-body-schedule-phase
                      :expected :tiled :schedule scheduled})))
+  [plan scheduled problem])
+
+(defn- pipelined-lowering-row!
+  [plan scheduled problem]
+  (lowering-row! plan scheduled problem)
+  (let [staging (:staging scheduled)]
+    (when-not (and (= :subgroup-online-pipelined-history (:strategy scheduled))
+                   (= :dense-paged (attention/route-kind (:route problem)))
+                   (= :interval (attention/visibility-kind (:visibility problem)))
+                   (= :double-buffered-membership-rows (:kind staging))
+                   (= (:qk-head-dim problem) (:key-elements staging))
+                   (= (:value-head-dim problem) (:value-elements staging)))
+      (throw (ex-info "pipelined weighted-reduction body has no matching storage lowering"
+                      {:reason :segmented-weighted-reduction-pipelined-lowering
+                       :plan-id (:id plan) :schedule scheduled
+                       :route-kind (attention/route-kind (:route problem))
+                       :visibility-kind (attention/visibility-kind (:visibility problem))}))))
   [plan scheduled problem])
 
 (defn lower-routed-paged
@@ -755,6 +1138,91 @@
       :attributes {:storage-kind :routed-paged-kv
                    :route-kind (attention/route-kind (:route problem))
                    :visibility-kind (attention/visibility-kind (:visibility problem))}})))
+
+(defn lower-routed-paged-pipelined
+  "Construct a verified two-stage routed-row pipeline for an interval weighted reduction.
+
+  Histories of length zero or one use the scalar scheduled loop. Longer histories stage two
+  contiguous K/V rows, overlap each refill with useful work on the other row, and consume the last
+  staged pair in an explicit epilogue. Semantic order and the public ABI are unchanged."
+  [plan scheduled]
+  (let [plan (swr/validate! plan)
+        scheduled (schedule/validate! scheduled)
+        problem (attention/validate! (:source-operation plan))
+        _ (pipelined-lowering-row! plan scheduled problem)
+        subgroup-size (:workgroup-size scheduled)
+        slots (component-slots scheduled)
+        query-ops (query-metadata-operations problem)
+        route-ops (dense-route-operations problem)
+        membership-ops (interval-membership-operations problem)
+        staged (pipelined-membership problem scheduled slots)
+        staging (:staging scheduled)
+        allocations
+        [(body/->WorkgroupAllocation
+          'pipeline-key-stage-a :half [(:qk-head-dim problem)]
+          (layout/row-major [(:qk-head-dim problem)] :half) 16)
+         (body/->WorkgroupAllocation
+          'pipeline-value-stage-a :half [(:value-head-dim problem)]
+          (layout/row-major [(:value-head-dim problem)] :half) 16)
+         (body/->WorkgroupAllocation
+          'pipeline-key-stage-b :half [(:qk-head-dim problem)]
+          (layout/row-major [(:qk-head-dim problem)] :half) 16)
+         (body/->WorkgroupAllocation
+          'pipeline-value-stage-b :half [(:value-head-dim problem)]
+          (layout/row-major [(:value-head-dim problem)] :half) 16)]
+        initial-ops
+        (flatten-operations
+         [query-ops
+          (load-value 'query-position :int (get-in problem [:query :positions])
+                      ['query-token])
+          (compute 'query-position-valid :predicate
+                   (expr :ge :predicate 'query-position (lit 0 :int)))
+          (compute 'query-batch-valid :predicate
+                   (expr :ge :predicate 'query-batch (lit 0 :int)))
+          (compute 'safe-query-batch :int
+                   (expr :min :int
+                         (expr :max :int 'query-batch (lit 0 :int))
+                         (lit (dec (:batch-size problem)) :int)))
+          (compute 'query-position-long :long (cast-expr 'query-position :long))
+          route-ops membership-ops
+          (compute 'initial-valid :predicate
+                   (all-expr ['query-metadata-valid 'query-position-valid
+                              'query-batch-valid 'route-valid 'membership-valid]))
+          (compute 'kv-head :int
+                   (expr :quot :int 'query-head
+                         (lit (quot (:q-heads problem) (:kv-heads problem)) :int)))
+          (:operations staged)
+          (output-operations
+           problem slots
+           {:valid (get-in staged [:state :valid])
+            :denominator (get-in staged [:state :denominator])
+            :weighted-values (get-in staged [:state :weighted-values])})])
+        launch (launch/spec {:workgroup-size [subgroup-size 1]
+                             :group-count [(:q-heads problem)
+                                           (get-in problem [:query :total-tokens])]
+                             :shared-memory-bytes (:shared-memory-bytes staging)})]
+    (body/make
+     {:id [:segmented-weighted-reduction-pipelined-body (:id plan) scheduled]
+      :parameters (parameters plan problem)
+      :stable-reads (mapv body/stable-read (swr/ordered-input-ids plan))
+      :allocations allocations
+      :indices (vec (concat [(body/->IndexBinding 'query-head :group 0)
+                             (body/->IndexBinding 'query-token :group 1)
+                             (body/->IndexBinding 'lane :lane 0)]
+                            (slot-indices problem scheduled slots)))
+      :masks (slot-masks problem slots)
+      :operations initial-ops
+      :schedule (assoc scheduled :subgroup-size subgroup-size)
+      :launch launch
+      :provenance {:operation-id (:id problem)
+                   :semantic-op :segmented-weighted-reduction
+                   :algebra-plan-id (:id plan)
+                   :lowering :scheduled-pipelined-kernel-body}
+      :attributes {:storage-kind :routed-paged-kv
+                   :route-kind :dense-paged
+                   :visibility-kind :interval
+                   :pipeline-stages 2
+                   :tail-policy (:tail-policy staging)}})))
 
 (defn- tile-bound-operations
   [problem scheduled]

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_schedule.clj
@@ -21,7 +21,11 @@
 (defn- schedule-value
   [plan subgroup-size membership-tiling strategy]
   (let [{:keys [membership storage score value accumulator-dtype]} plan
-        components (:components value)]
+        components (:components value)
+        pipelined? (= :subgroup-online-pipelined-history strategy)
+        key-elements (get-in score [:axis :extent])
+        shared-memory-bytes (when pipelined?
+                              (* 2 (+ key-elements components) 2))]
     (schedule/make
      {:strategy strategy
       :workgroup-size (long subgroup-size)
@@ -41,6 +45,18 @@
                       (quot (+ components (dec (long subgroup-size)))
                             (long subgroup-size))}
       :state (schedule/online-state)
+      :staging (if pipelined?
+                 {:kind :double-buffered-membership-rows
+                  :stages 2
+                  :members-per-iteration 2
+                  :element-dtype :half
+                  :key-elements key-elements
+                  :value-elements components
+                  :transfer-bytes 16
+                  :overlap :preferred
+                  :tail-policy :separate-epilogue
+                  :shared-memory-bytes shared-memory-bytes}
+                 {:kind :none})
       :numerical-mode {:score-accumulate accumulator-dtype
                        :state-accumulate accumulator-dtype
                        ;; The OpenCL subgroup builtin fixes neither its association tree nor
@@ -66,98 +82,129 @@
    interval or explicitly indexed CSR membership. Those are legality constraints of this
    schedule, not new semantic operation kinds."
   [plan desc strategy tile-size]
-   (let [{:keys [membership storage value operands output accumulator-dtype] :as plan}
-         (swr/validate! plan)
-         subgroup-size (hardware/preferred-subgroup-size desc)
-         max-workgroup-size (hardware/maximum-workgroup-size desc)
-         supported-widths (hardware/supported-subgroup-sizes desc)
-         components (:components value)
-         operand-dtypes (mapv :dtype operands)]
-     (cond
-       (and desc (not= :gpu (:device-type desc)))
-       (decline :score-reuse-requires-gpu {:device-type (:device-type desc)})
+  (let [{:keys [membership storage score value operands output accumulator-dtype] :as plan}
+        (swr/validate! plan)
+        subgroup-size (hardware/preferred-subgroup-size desc)
+        max-workgroup-size (hardware/maximum-workgroup-size desc)
+        supported-widths (hardware/supported-subgroup-sizes desc)
+        components (:components value)
+        operand-dtypes (mapv :dtype operands)]
+    (cond
+      (and desc (not= :gpu (:device-type desc)))
+      (decline :score-reuse-requires-gpu {:device-type (:device-type desc)})
 
-       (or (not (integer? subgroup-size))
-           (not (integer? max-workgroup-size)))
-       (decline :score-reuse-missing-execution-capability
-                {:subgroup-size subgroup-size
-                 :max-workgroup-size max-workgroup-size})
+      (or (not (integer? subgroup-size))
+          (not (integer? max-workgroup-size)))
+      (decline :score-reuse-missing-execution-capability
+               {:subgroup-size subgroup-size
+                :max-workgroup-size max-workgroup-size})
 
-       (and (seq supported-widths)
-            (not (contains? (set supported-widths) subgroup-size)))
-       (decline :score-reuse-subgroup-width-unsupported
-                {:subgroup-size subgroup-size
-                 :supported-subgroup-sizes (set supported-widths)})
+      (and (seq supported-widths)
+           (not (contains? (set supported-widths) subgroup-size)))
+      (decline :score-reuse-subgroup-width-unsupported
+               {:subgroup-size subgroup-size
+                :supported-subgroup-sizes (set supported-widths)})
 
-       (not (swr/online-softmax-algebra? plan))
-       (decline :score-reuse-requires-online-softmax-algebra)
+      (not (swr/online-softmax-algebra? plan))
+      (decline :score-reuse-requires-online-softmax-algebra)
 
-       (not= :logical-attention-visibility (:kind membership))
-       (decline :score-reuse-membership-unsupported {:membership (:kind membership)})
+      (not= :logical-attention-visibility (:kind membership))
+      (decline :score-reuse-membership-unsupported {:membership (:kind membership)})
 
-       (not (contains? #{:interval :csr} (:visibility-kind membership)))
-       (decline :score-reuse-visibility-unsupported
-                {:visibility-kind (:visibility-kind membership)})
+      (not (contains? #{:interval :csr} (:visibility-kind membership)))
+      (decline :score-reuse-visibility-unsupported
+               {:visibility-kind (:visibility-kind membership)})
 
-       (not= :routed-paged-kv (:kind storage))
-       (decline :score-reuse-storage-unsupported {:storage (:kind storage)})
+      (not= :routed-paged-kv (:kind storage))
+      (decline :score-reuse-storage-unsupported {:storage (:kind storage)})
 
-       (not (contains? #{:dense-paged :csr-paged} (:route-kind storage)))
-       (decline :score-reuse-route-unsupported {:route-kind (:route-kind storage)})
+      (not (contains? #{:dense-paged :csr-paged} (:route-kind storage)))
+      (decline :score-reuse-route-unsupported {:route-kind (:route-kind storage)})
 
-       (or (not= :none (get-in storage [:k-format :quantization]))
-           (not= :none (get-in storage [:v-format :quantization])))
-       (decline :score-reuse-quantized-kv-unimplemented
-                {:k-format (:k-format storage) :v-format (:v-format storage)})
+      (or (not= :none (get-in storage [:k-format :quantization]))
+          (not= :none (get-in storage [:v-format :quantization])))
+      (decline :score-reuse-quantized-kv-unimplemented
+               {:k-format (:k-format storage) :v-format (:v-format storage)})
 
-       (not= :float accumulator-dtype)
-       (decline :score-reuse-accumulator-unsupported {:actual accumulator-dtype})
+      (not= :float accumulator-dtype)
+      (decline :score-reuse-accumulator-unsupported {:actual accumulator-dtype})
 
-       (let [route-operands (case (:route-kind storage)
-                              :dense-paged 3
-                              :csr-paged 4)
-             visibility-operands (if (= :csr (:visibility-kind membership)) 2 0)
-             expected-count (+ 5 route-operands visibility-operands)]
-         (not (and (= expected-count (count operand-dtypes))
-                   (contains? #{:half :float} (first operand-dtypes))
-                   (= [:int :int :half :half]
-                      (subvec operand-dtypes 1 5))
-                   (every? #(= :int %) (subvec operand-dtypes 5))
-                   (contains? #{:half :float} (:dtype output)))))
-       (decline :score-reuse-storage-dtypes-unsupported
-                {:operand-dtypes operand-dtypes :output-dtype (:dtype output)})
+      (let [route-operands (case (:route-kind storage)
+                             :dense-paged 3
+                             :csr-paged 4)
+            visibility-operands (if (= :csr (:visibility-kind membership)) 2 0)
+            expected-count (+ 5 route-operands visibility-operands)]
+        (not (and (= expected-count (count operand-dtypes))
+                  (contains? #{:half :float} (first operand-dtypes))
+                  (= [:int :int :half :half]
+                     (subvec operand-dtypes 1 5))
+                  (every? #(= :int %) (subvec operand-dtypes 5))
+                  (contains? #{:half :float} (:dtype output)))))
+      (decline :score-reuse-storage-dtypes-unsupported
+               {:operand-dtypes operand-dtypes :output-dtype (:dtype output)})
 
-       (or (not (integer? components)) (not (pos? components)))
-       (decline :score-reuse-static-value-width-required {:components components})
+      (or (not (integer? components)) (not (pos? components)))
+      (decline :score-reuse-static-value-width-required {:components components})
 
-       (or (not (pos? (long subgroup-size)))
-           (> (long subgroup-size) (long max-workgroup-size)))
-       (decline :score-reuse-invalid-subgroup-geometry
-                {:subgroup-size subgroup-size :max-workgroup-size max-workgroup-size})
+      (or (not (pos? (long subgroup-size)))
+          (> (long subgroup-size) (long max-workgroup-size)))
+      (decline :score-reuse-invalid-subgroup-geometry
+               {:subgroup-size subgroup-size :max-workgroup-size max-workgroup-size})
 
        ;; A static cap makes register-state feasibility explicit. Gemma D=256/SG16 uses 16.
-       (> (quot (+ components (dec (long subgroup-size))) (long subgroup-size)) 32)
-       (decline :score-reuse-register-state-too-wide
-                {:components components :subgroup-size subgroup-size
-                 :components-per-lane
-                 (quot (+ components (dec (long subgroup-size))) (long subgroup-size))})
+      (> (quot (+ components (dec (long subgroup-size))) (long subgroup-size)) 32)
+      (decline :score-reuse-register-state-too-wide
+               {:components components :subgroup-size subgroup-size
+                :components-per-lane
+                (quot (+ components (dec (long subgroup-size))) (long subgroup-size))})
 
-       (and (= :subgroup-online-tiled-history strategy)
-            (not (and (pos-int? tile-size) (<= tile-size Integer/MAX_VALUE))))
-       (decline :score-reuse-invalid-history-tile-size {:tile-size tile-size})
+      (and (= :subgroup-online-pipelined-history strategy)
+           (not= :dense-paged (:route-kind storage)))
+      (decline :pipelined-history-requires-dense-paged-route
+               {:route-kind (:route-kind storage)})
 
-       :else
-       (let [capacity (membership-capacity plan)
-             membership-tiling
-             (if (= :subgroup-online-tiled-history strategy)
-               {:kind :static-contiguous-tiles
-                :tile-size tile-size
-                :tile-count (quot (+ capacity (dec tile-size)) tile-size)
-                :membership-capacity capacity
-                :merge-order :increasing-membership-tile}
-               {:kind :sequential})]
-         {:ok true
-          :schedule (schedule-value plan subgroup-size membership-tiling strategy)}))))
+      (and (= :subgroup-online-pipelined-history strategy)
+           (not= :interval (:visibility-kind membership)))
+      (decline :pipelined-history-requires-interval-membership
+               {:visibility-kind (:visibility-kind membership)})
+
+      (and (= :subgroup-online-pipelined-history strategy)
+           (or (not (zero? (mod (* 2 (get-in score [:axis :extent])) 16)))
+               (not (zero? (mod (* 2 components) 16)))))
+      (decline :pipelined-history-row-transfer-width-unsupported
+               {:transfer-bytes 16
+                :key-elements (get-in score [:axis :extent])
+                :value-elements components})
+
+      (and (= :subgroup-online-pipelined-history strategy)
+           (> (* 2 (+ (get-in score [:axis :extent]) components) 2)
+              (long (or (get-in desc [:execution :scratchpad-bytes])
+                        (get-in desc [:cache :slm])
+                        (:shared-local-memory desc)
+                        65536))))
+      (decline :pipelined-history-shared-memory-exceeded
+               {:required (* 2 (+ (get-in score [:axis :extent]) components) 2)
+                :available (long (or (get-in desc [:execution :scratchpad-bytes])
+                                     (get-in desc [:cache :slm])
+                                     (:shared-local-memory desc)
+                                     65536))})
+
+      (and (= :subgroup-online-tiled-history strategy)
+           (not (and (pos-int? tile-size) (<= tile-size Integer/MAX_VALUE))))
+      (decline :score-reuse-invalid-history-tile-size {:tile-size tile-size})
+
+      :else
+      (let [capacity (membership-capacity plan)
+            membership-tiling
+            (if (= :subgroup-online-tiled-history strategy)
+              {:kind :static-contiguous-tiles
+               :tile-size tile-size
+               :tile-count (quot (+ capacity (dec tile-size)) tile-size)
+               :membership-capacity capacity
+               :merge-order :increasing-membership-tile}
+              {:kind :sequential})]
+        {:ok true
+         :schedule (schedule-value plan subgroup-size membership-tiling strategy)}))))
 
 (defn plan-subgroup-online
   "Plan one subgroup per segment with one shared score and lane-strided value accumulators."
@@ -175,3 +222,14 @@
    (plan-subgroup-online*
     plan desc :subgroup-online-tiled-history
     (or (:segmented-weighted-reduction-history-tile-size desc) 256))))
+
+(defn plan-subgroup-online-pipelined
+  "Plan two rotating workgroup K/V rows while preserving increasing membership order.
+
+  The first lowering row deliberately requires dense physical pages and interval membership. The
+  schedule remains a segmented weighted reduction; routed storage is merely the proven way this
+  implementation obtains two contiguous rows for cooperative staging."
+  ([plan] (plan-subgroup-online-pipelined plan nil))
+  ([plan desc]
+   (plan-subgroup-online*
+    plan desc :subgroup-online-pipelined-history nil)))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -58,14 +58,19 @@
                      (problem)
                      (assoc descriptor :segmented-weighted-reduction-schedule :reference)))
         cooperative-schedule (:schedule (schedule/plan-subgroup-online plan descriptor))
+        pipelined-schedule (:schedule
+                            (schedule/plan-subgroup-online-pipelined plan descriptor))
         tiled-schedule (:schedule
                         (schedule/plan-subgroup-online-tiled
                          plan (assoc descriptor
                                      :segmented-weighted-reduction-history-tile-size 4)))
         cooperative (attention-emit/emit-fp16-cooperative
                      plan cooperative-schedule dialect)
+        pipelined (attention-emit/emit-fp16-pipelined
+                   plan pipelined-schedule dialect descriptor)
         tiled (attention-emit/emit-fp16-tiled-history plan tiled-schedule dialect)]
     (into [(write-artifact! directory suffix "cooperative" cooperative)
+           (write-artifact! directory suffix "pipelined-attention" pipelined)
            (write-source! directory suffix "workgroup-memory"
                           (body-emit/emit-scalar-kernel
                            "workgroup_memory" (body-fixtures/workgroup-memory-body 32)

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -711,6 +711,22 @@
            clojure.lang.ExceptionInfo #"issued uniformly"
            (apply scalar-body
                   (assoc (async-stage-operations) 0 (async-stage-copy ['lane]))
+                  options))))
+    (testing "async coordinates may use prior uniform scalar SSA values"
+      (is (body/kernel-body?
+           (apply scalar-body
+                  (into [(body/->ScalarCompute
+                          (body/value 'source-base :int)
+                          (body/scalar-expression
+                           :+ :int ['group (body/literal 0 :int)]))]
+                        (assoc (async-stage-operations) 0
+                               (async-stage-copy ['source-base])))
+                  options))))
+    (testing "undefined async coordinate SSA values still fail in the typed verifier"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"before it is defined"
+           (apply scalar-body
+                  (assoc (async-stage-operations) 0 (async-stage-copy ['missing-base]))
                   options))))))
 
 (deftest pipelined-for-carries-a-verified-rotating-async-queue

--- a/test/raster/compiler/passes/parallel/attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/attention_route_test.clj
@@ -58,6 +58,14 @@
   {:device-type :gpu :vendor "Intel" :subgroup-size 16
    :max-workgroup-size 256})
 
+(defn- operation-tree
+  [operations]
+  (letfn [(children [operation]
+            (vec (concat (:operations operation)
+                         (:then-operations operation)
+                         (:else-operations operation))))]
+    (mapcat #(tree-seq (comp seq children) children %) operations)))
+
 (deftest dense-reference-is-a-complete-packed-attention-compiler-value
   (let [{:keys [strategy reference? declines plan artifact graph schedule]}
         (route/route! (problem)
@@ -124,6 +132,76 @@
     (is (str/includes? source "float rstr_final_maximum"))
     (is (str/includes? source "float rstr_weighted_value_next_0"))))
 
+(deftest aligned-dense-history-selects-a-verified-double-buffered-schedule
+  (let [problem (problem :value-head-dim 8)
+        descriptor (assoc intel-desc
+                          :segmented-weighted-reduction-schedule
+                          :subgroup-online-pipelined-history)
+        reference (route/route!
+                   problem (assoc intel-desc
+                                  :segmented-weighted-reduction-schedule :reference))
+        {:keys [strategy reference? declines artifact]} (route/route! problem descriptor)
+        scheduled (get-in artifact [:attributes :segmented-weighted-reduction-schedule])
+        kernel-body (get-in artifact [:attributes :kernel-body])
+        operations (operation-tree (:operations kernel-body))
+        source (:source artifact)]
+    (is (= :routed-paged-subgroup-online-pipelined-history strategy))
+    (is (false? reference?))
+    (is (empty? declines))
+    (is (= (kexec/common-view (:artifact reference))
+           (kexec/common-view artifact)))
+    (is (= {:kind :double-buffered-membership-rows
+            :stages 2 :members-per-iteration 2 :element-dtype :half
+            :key-elements 8 :value-elements 8 :transfer-bytes 16
+            :overlap :preferred :tail-policy :separate-epilogue
+            :shared-memory-bytes 64}
+           (:staging scheduled)))
+    (is (= 4 (count (:allocations kernel-body))))
+    (is (= 64 (get-in kernel-body [:launch :shared-memory-bytes])))
+    (is (= :scheduled-pipelined-kernel-body
+           (get-in kernel-body [:provenance :lowering])))
+    (is (some #(instance? raster.compiler.ir.kernel_body.PipelinedFor %) operations))
+    (is (some #(instance? raster.compiler.ir.kernel_body.AsyncWorkgroupCopy %) operations))
+    (is (str/includes? source "async_work_group_copy"))
+    (is (str/includes? source "rstr_pipeline_has_odd"))
+    (is (str/includes? source "rstr_pipeline_membership_count >= 2"))
+    (is (= :routed-paged-subgroup-online-score-reuse
+           (:strategy (route/route! problem intel-desc)))
+        "unmeasured double buffering remains opt-in")))
+
+(deftest pipelined-history-legality-is-storage-and-resource-explicit
+  (let [aligned-problem (problem :value-head-dim 8)
+        plan (:plan (route/route!
+                     aligned-problem
+                     (assoc intel-desc
+                            :segmented-weighted-reduction-schedule :reference)))]
+    (is (= :pipelined-history-requires-dense-paged-route
+           (:reason
+            (schedule-pass/plan-subgroup-online-pipelined
+             (:plan (route/route!
+                     (problem :route (csr-route) :value-head-dim 8)
+                     (assoc intel-desc
+                            :segmented-weighted-reduction-schedule :reference)))
+             intel-desc))))
+    (is (= :pipelined-history-requires-interval-membership
+           (:reason
+            (schedule-pass/plan-subgroup-online-pipelined
+             (:plan (route/route!
+                     (problem :visibility (csr-visibility) :value-head-dim 8)
+                     (assoc intel-desc
+                            :segmented-weighted-reduction-schedule :reference)))
+             intel-desc))))
+    (is (= :pipelined-history-row-transfer-width-unsupported
+           (:reason (schedule-pass/plan-subgroup-online-pipelined
+                     (:plan (route/route!
+                             (problem)
+                             (assoc intel-desc
+                                    :segmented-weighted-reduction-schedule :reference)))
+                     intel-desc))))
+    (is (= :pipelined-history-shared-memory-exceeded
+           (:reason (schedule-pass/plan-subgroup-online-pipelined
+                     plan (assoc-in intel-desc [:cache :slm] 32)))))))
+
 (deftest cooperative-attention-source-is-valid-opencl
   (let [clang? (zero? (:exit (shell/sh "sh" "-c" "command -v clang")))]
     (if-not clang?
@@ -169,6 +247,35 @@
                (get-in artifact [:attributes :target-collective-association])))
         (is (str/includes? (:source artifact) "extern \"C\" __global__ void"))
         (is (str/includes? (:source artifact) "__shfl_down"))))))
+
+(deftest pipelined-attention-preserves-one-body-and-abi-across-c-family-targets
+  (let [descriptor {:device-type :gpu :subgroup-size 32 :max-workgroup-size 1024}
+        plan (:plan (route/route!
+                     (problem :value-head-dim 8)
+                     (assoc descriptor :segmented-weighted-reduction-schedule :reference)))
+        scheduled (:schedule
+                   (schedule-pass/plan-subgroup-online-pipelined plan descriptor))
+        opencl (attention-emit/emit-fp16-pipelined
+                plan scheduled :opencl-portable)
+        cuda (attention-emit/emit-fp16-pipelined
+              plan scheduled :cuda {:compute-capability [8 0]})
+        hip (attention-emit/emit-fp16-pipelined plan scheduled :hip)]
+    (doseq [artifact [cuda hip]]
+      (is (= (:abi opencl) (:abi artifact)))
+      (is (= (:arguments opencl) (:arguments artifact)))
+      (is (= (:effects opencl) (:effects artifact)))
+      (is (= (select-keys (get-in opencl [:attributes :kernel-body])
+                          [:id :parameters :allocations :indices :schedule :launch
+                           :provenance :attributes])
+             (select-keys (get-in artifact [:attributes :kernel-body])
+                          [:id :parameters :allocations :indices :schedule :launch
+                           :provenance :attributes]))))
+    (is (= :cuda-c (:target cuda)))
+    (is (str/includes? (:source cuda) "cp.async.ca.shared.global"))
+    (is (str/includes? (:source cuda) "cp.async.wait_group 1"))
+    (is (= :hip-cpp (:target hip)))
+    (is (str/includes? (:source hip) "synchronous cooperative copies are complete"))
+    (is (not (str/includes? (:source hip) "cp.async")))))
 
 (deftest tiled-history-is-a-two-stage-kernel-graph-with-a-stable-external-abi
   (let [desc (assoc intel-desc

--- a/test/raster/gpu/attention_device_test.clj
+++ b/test/raster/gpu/attention_device_test.clj
@@ -16,11 +16,16 @@
   (double (Float/float16ToFloat (short value))))
 
 (defn- make-case
-  [route-kind visibility-kind]
-  (let [dims {:batch-size 3 :q-heads 4 :kv-heads 2 :qk-head-dim 8
-              :value-head-dim 6 :page-size 2 :physical-pages 7}
+  [route-kind visibility-kind & [options]]
+  (let [{:keys [value-head-dim query-offset-values query-position-values window-left]
+         :or {value-head-dim 6
+              query-offset-values [0 2 3 4]
+              query-position-values [3 4 10 12]
+              window-left 2}} (or options {})
+        dims {:batch-size 3 :q-heads 4 :kv-heads 2 :qk-head-dim 8
+              :value-head-dim value-head-dim :page-size 2 :physical-pages 7}
         {:keys [q-heads kv-heads qk-head-dim value-head-dim page-size physical-pages]} dims
-        total-query-tokens 4
+        total-query-tokens (count query-position-values)
         q-elements (* total-query-tokens q-heads qk-head-dim)
         k-elements (* kv-heads physical-pages page-size qk-head-dim)
         v-elements (* kv-heads physical-pages page-size value-head-dim)
@@ -32,8 +37,8 @@
            (map #(* 0.04 (- (mod (+ (* 7 %) 3) 19) 9)) (range v-elements)))
         ;; Batch row 1 owns a query but has no resident KV tokens.  This exercises the cooperative
         ;; schedule's zero-length early exit independently from packed rows 0 and 2.
-        q-offsets (int-array [0 2 3 4])
-        q-positions (int-array [3 4 10 12])
+        q-offsets (int-array query-offset-values)
+        q-positions (int-array query-position-values)
         starts (int-array [0 0 8])
         query (attention/packed-query-batch
                {:values 'q :row-offsets 'q-row-offsets :positions 'q-positions
@@ -70,7 +75,7 @@
         attention-visibility
         (case visibility-kind
           :interval
-          (attention/visibility {:causal? true :window-left 2 :window-right 0})
+          (attention/visibility {:causal? true :window-left window-left :window-right 0})
 
           :csr
           (attention/csr-visibility
@@ -240,9 +245,9 @@
               (:key-indices (:visibility problem)) :attention-key-indices}))))
 
 (defn- run-case
-  [device-id route-kind visibility-kind policy expected-strategy]
+  [device-id route-kind visibility-kind policy expected-strategy & [case-options]]
   (let [{:keys [problem q k v q-offsets q-positions] :as test-case}
-        (make-case route-kind visibility-kind)
+        (make-case route-kind visibility-kind (or case-options {}))
         descriptor (cond-> (assoc (hardware/descriptor-for device-id)
                                   :segmented-weighted-reduction-schedule policy)
                      (= :subgroup-online-tiled-history policy)
@@ -322,6 +327,13 @@
       (run-case :ze:0 :dense-paged :interval :reference :fp16-reference)
       (run-case :ze:0 :dense-paged :interval :subgroup-score-reuse
                 :routed-paged-subgroup-online-score-reuse)
+      (run-case :ze:0 :dense-paged :interval :subgroup-online-pipelined-history
+                :routed-paged-subgroup-online-pipelined-history
+                {:value-head-dim 8
+                 ;; Membership counts are 1, 2, 3, 4, 0, and 5 across these packed rows.
+                 :query-offset-values [0 4 5 6]
+                 :query-position-values [0 1 2 3 10 12]
+                 :window-left 100})
       (run-case :ze:0 :dense-paged :interval :subgroup-online-tiled-history
                 :routed-paged-subgroup-online-tiled-history))))
 


### PR DESCRIPTION
## Summary

- add a verified double-buffered SegmentedWeightedReduction schedule and target-neutral KernelBody lowering
- model staged asynchronous copies, barriers, tails, exact shared-memory accounting, and ABI memory contracts
- emit the same scheduled body through OpenCL, CUDA, and HIP, while retaining the established route unless the pipelined policy is explicitly selected
- cover zero through five history members on Intel Arc and compile production fixtures with nvcc and hipcc
- advance the compiler north-star roadmap toward typed SOAC fusion

## Validation

- clojure -X:test: 2435 tests, 35060 assertions, 0 failures, 0 errors
- GPU suite: 1 device available, 0 skip-path tests
- OpenCL suite: Intel Arc available, 0 skip-path tests
- nvcc PTX compile for sm_80
- hipcc code-object compile for gfx1100
- git diff --check