### PR TITLE
Introduce typed functional SOAC dialect

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps {org.clojure/clojure {:mvn/version "1.12.0"}
         org.clojure/data.json {:mvn/version "2.5.1"}
         org.typedclojure/typed.clj.checker {:mvn/version "1.4.0"}
-        org.replikativ/pattern {:mvn/version "1.0.449"}
+        org.replikativ/pattern {:mvn/version "1.0.452"}
         org.replikativ/beichte {:mvn/version "0.2.7"}}
  :aliases
  {:test {:extra-paths ["test"]

--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1,6 +1,6 @@
 # Raster compiler north star
 
-Status: architectural direction, reconciled with the implementation on 2026-08-27.
+Status: architectural direction, reconciled with the implementation on 2026-08-28.
 
 Raster should become a compiler in which a typed Clojure program, its parallel
 algorithm, its schedule, its device placement, and its executable artifact are
@@ -361,9 +361,15 @@ reconstructed from arbitrary source forms. Conceptually:
 (soac-program
   {:inputs [%x]
    :values {%x x-value %y y-value %z z-value}}
-  [(= %y (map {:index %i :extent %n} [%x]
-              (lambda [%xi] (* %xi %xi))))
-   (= %z (reduce {:operator + :identity 0.0} [%y]))]
+  [(= map-0 [%y]
+      (map {:index %i :extent %n} [%x] []
+           (lambda [%xi] [(* %xi %xi)])))
+   (= reduce-0 [%z]
+      (reduce {:index %i :extent %n
+               :accumulators [%acc] :identities [0.0]
+               :dtypes [:float] :algebra [{:associative? true}]}
+              [%y] []
+              (lambda [%acc %yi] [(+ %acc %yi)])))]
   [%z])
 ```
 
@@ -372,6 +378,13 @@ grammar and pass arrows; fusion rules match the compact SOAC equations directly.
 `ParallelProgram`-style envelope supplies stable value/equation IDs, `AbstractValue`s, effects,
 aliases, consumption, results, diagnostics and provenance. Essential facts are explicit fields or
 table entries keyed by IDs, not Clojure metadata that ordinary list reconstruction can drop.
+
+The first Pattern-declared dialect now makes this boundary executable for map and scalar/full
+reduce equations. It verifies ordered SSA definitions, exact typed input/output/effect boundaries,
+rank/extent/result contracts, explicit lexical capture binding (including compound stable value
+IDs), tuple-valued maps, and fact-preserving functional fusion. A guarded adapter differentially
+checks map→map, map→reduce and horizontal-map results against the current graph and declines every
+unsupported legacy node or unproved alias. It is intentionally not a backend route yet.
 
 This representation is shared before backend selection. SOAC fusion changes the program consumed
 by both JVM and accelerator lowerings; SegOp and schedule conversion then specialize it. The JVM
@@ -716,7 +729,7 @@ Each increment should be a thin vertical slice with a production-path test.
 
 The immediate continuation after the verified double-buffered weighted-reduction route is:
 
-1. Define a typed SOAC S-expression dialect with `../pattern` and differential-test
+1. **Landed:** define a typed SOAC S-expression dialect with `../pattern` and differential-test
    map→map, map→reduce and horizontal-map fusion against the current graph.
 2. Carry that dialect in the existing program/value envelope and route one ordinary fused reduction
    through JVM SIMD and GPU `KernelBody` without reconstructing compiler facts from source spelling.

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -1,0 +1,378 @@
+(ns raster.compiler.ir.soac-dialect
+  "Typed, functional S-expression view of Raster's SOAC middle end.
+
+   The expression spine is deliberately small and pattern-friendly.  Stable value/equation
+   identity and compiler facts live in the explicit program envelope, never in Clojure metadata.
+   This namespace does not replace ParallelProgram yet; it is the verified dialect boundary that
+   the next vertical will carry in that existing envelope.
+
+   Canonical forms:
+
+     (soac-program facts
+       [(= equation-id [result ...]
+           (map {:index i :extent n} [array ...] [capture ...]
+             (lambda [element ... capture-parameter ...] [result-expr ...])))
+        (= equation-id [result ...]
+           (reduce {:index i :extent n
+                    :accumulators [acc ...] :identities [zero ...]
+                    :dtypes [:float ...] :algebra [{} ...]}
+             [array ...] [capture ...]
+             (lambda [acc ... element ... capture-parameter ...] [step-result ...])))]
+       [program-result ...])
+
+   Map lambdas return tuples, so horizontal fusion remains functional rather than encoding
+   secondary results as hidden stores. Captures are explicit operands with explicit scalar lambda
+   parameters, so stable value IDs never leak into lexical expression binding."
+  (:require [clojure.set :as set]
+            [pattern.nanopass.dialect :as dialect
+             :refer [def-dialect]]
+            [raster.compiler.core.util :as util]
+            [raster.compiler.ir.abstract-value :as av]))
+
+(defn value-id?
+  "Stable logical value IDs. Vector IDs are used by existing SSA-like program envelopes."
+  [value]
+  (or (symbol? value) (keyword? value) (vector? value)))
+
+(defn equation-id?
+  [value]
+  (or (integer? value) (value-id? value)))
+
+(defn scalar-literal?
+  [value]
+  (or (nil? value)
+      (number? value)
+      (boolean? value)
+      (string? value)
+      (keyword? value)))
+
+(defn extent-shape
+  "Canonical rank-one shape for an extent value ID.
+
+   AbstractValue dimensions already accept symbolic S-expressions. Compound stable IDs therefore
+   use an explicit `(value id)` dimension instead of being confused with shape structure."
+  [extent]
+  [(if (symbol? extent) extent (list 'value extent))])
+
+(defn map-attributes?
+  [value]
+  (and (map? value)
+       (symbol? (:index value))
+       (value-id? (:extent value))
+       (or (nil? (:attributes value)) (map? (:attributes value)))))
+
+(defn reduce-attributes?
+  [value]
+  (and (map-attributes? value)
+       (vector? (:accumulators value))
+       (seq (:accumulators value))
+       (every? symbol? (:accumulators value))
+       (= (count (:accumulators value)) (count (distinct (:accumulators value))))
+       (vector? (:identities value))
+       (vector? (:dtypes value))
+       (vector? (:algebra value))
+       (= (count (:accumulators value))
+          (count (:identities value))
+          (count (:dtypes value))
+          (count (:algebra value)))
+       (every? keyword? (:dtypes value))
+       (every? map? (:algebra value))))
+
+(defn equation-facts?
+  [value]
+  (and (map? value)
+       (set? (:effects value))
+       (map? (:aliases value))
+       (map? (:provenance value))
+       (map? (:attributes value))))
+
+(defn program-facts?
+  [value]
+  (and (map? value)
+       (map? (:values value))
+       (every? value-id? (keys (:values value)))
+       (every? av/abstract-value? (vals (:values value)))
+       (vector? (:inputs value))
+       (map? (:equations value))
+       (every? equation-id? (keys (:equations value)))
+       (every? equation-facts? (vals (:equations value)))
+       (set? (:effects value))
+       (vector? (:diagnostics value))
+       (map? (:provenance value))
+       (map? (:attributes value))))
+
+(def-dialect TypedSOAC
+  (terminals [id value-id?]
+             [eid equation-id?]
+             [sym symbol?]
+             [lit scalar-literal?]
+             [ma map-attributes?]
+             [ra reduce-attributes?]
+             [facts program-facts?])
+
+  (Scalar [s :enforce]
+          ?sym ?lit
+          (if ?s:test ?s:then ?s:else)
+          (do (?:+ s))
+          (let* [(?:* ?sym:binding ?s:init)] ?s:body)
+          [(?:* s)]
+          (& (?sym:f (?:* s:args)) (? _ seq?)))
+
+  (Lambda [l :enforce]
+          (lambda [(?:* ?sym:parameter)] [(?:+ s)]))
+
+  (Operation [o :enforce]
+             (map ?ma [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
+             (reduce ?ra [(?:* ?id:array)] [(?:* ?id:capture)] ?l))
+
+  (Equation [q :enforce]
+            (= ?eid [(?:+ ?id:result)] ?o))
+
+  (Program [p :enforce]
+           (soac-program ?facts [(?:* q)] [(?:* ?id:output)]))
+
+  (entry Program))
+
+(defn program-form?
+  [value]
+  (and (seq? value) (= 'soac-program (first value)) (= 4 (count value))))
+
+(defn facts [program] (second program))
+(defn equations [program] (nth program 2))
+(defn outputs [program] (nth program 3))
+
+(defn operation-kind
+  [equation]
+  (first (nth equation 3)))
+
+(defn operation-inputs
+  "Ordered array and capture operands of an equation. Extent is a separate scalar operand."
+  [equation]
+  (let [operation (nth equation 3)]
+    (vec (concat (nth operation 2) (nth operation 3)))))
+
+(defn operation-extent
+  [equation]
+  (:extent (second (nth equation 3))))
+
+(defn parameter-layout
+  "Split a SOAC lambda's ordered parameters into semantic roles."
+  [equation]
+  (let [[_ _ _ operation] equation
+        [kind attributes arrays captures lambda] operation
+        parameters (vec (second lambda))
+        accumulator-count (if (= 'reduce kind) (count (:accumulators attributes)) 0)
+        array-count (count arrays)
+        accumulator-end accumulator-count
+        element-end (+ accumulator-end array-count)]
+    {:accumulators (subvec parameters 0 accumulator-end)
+     :elements (subvec parameters accumulator-end element-end)
+     :capture-parameters (subvec parameters element-end)}))
+
+(defn- distinct-vector?
+  [value]
+  (and (vector? value) (= (count value) (count (distinct value)))))
+
+(defn- fail!
+  [reason message data]
+  (throw (ex-info message (assoc data :reason reason :dialect :typed-soac))))
+
+(defn- validate-equation!
+  [equation]
+  (let [[_ equation-id results operation] equation
+        [_ attributes arrays captures lambda] operation
+        [_ parameters body-results] lambda
+        kind (first operation)
+        result-count (count results)]
+    (when-not (distinct-vector? results)
+      (fail! :typed-soac-equation-results "SOAC equation results must be distinct"
+             {:equation equation-id :results results}))
+    (doseq [[field ids] [[:arrays arrays] [:captures captures]]]
+      (when-not (distinct-vector? ids)
+        (fail! :typed-soac-operands "SOAC operands must be ordered and distinct"
+               {:equation equation-id :field field :ids ids})))
+    (when (seq (set/intersection (set arrays) (set captures)))
+      (fail! :typed-soac-operand-role "one value cannot be both an element input and a capture"
+             {:equation equation-id :arrays arrays :captures captures}))
+    (when-not (distinct-vector? parameters)
+      (fail! :typed-soac-lambda-parameters "SOAC lambda parameters must be distinct"
+             {:equation equation-id :parameters parameters}))
+    (when-not (every? symbol? parameters)
+      (fail! :typed-soac-lambda-parameters "SOAC lambda parameters must be symbols"
+             {:equation equation-id :parameters parameters}))
+    (when-not (= result-count (count body-results))
+      (fail! :typed-soac-result-arity "SOAC result and lambda arity differ"
+             {:equation equation-id :results result-count :body-results (count body-results)}))
+    (let [expected-parameter-count (+ (if (= 'reduce kind)
+                                        (count (:accumulators attributes))
+                                        0)
+                                      (count arrays)
+                                      (count captures))]
+      (when-not (= expected-parameter-count (count parameters))
+        (fail! :typed-soac-lambda-arity
+               "lambda parameters must cover accumulators, elements and captures in order"
+               {:equation equation-id
+                :expected expected-parameter-count
+                :actual (count parameters)
+                :arrays arrays
+                :captures captures})))
+    (doseq [body body-results
+            :let [unbound (util/free-syms body (set parameters))]
+            :when (seq unbound)]
+      (fail! :typed-soac-unbound-scalar
+             "scalar regions may reference only their explicit lambda parameters"
+             {:equation equation-id :unbound unbound :body body}))
+    (case kind
+      map
+      nil
+
+      reduce
+      (let [accumulators (:accumulators attributes)]
+        (when-not (= accumulators (vec (take (count accumulators) parameters)))
+          (fail! :typed-soac-reduce-accumulators
+                 "reduce accumulator parameters must lead the lambda in declared order"
+                 {:equation equation-id :accumulators accumulators :parameters parameters}))
+        (when-not (= result-count (count accumulators))
+          (fail! :typed-soac-reduce-results
+                 "reduce result arity must equal accumulator arity"
+                 {:equation equation-id :results results :accumulators accumulators})))
+
+      (fail! :typed-soac-operation "unknown SOAC operation"
+             {:equation equation-id :operation kind}))
+    equation))
+
+(defn- validate-equation-types!
+  [values equation]
+  (let [[_ equation-id results operation] equation
+        [kind attributes arrays] operation
+        extent (:extent attributes)]
+    (doseq [id arrays]
+      (let [value (get values id)]
+        ;; Unknown IDs receive the more precise boundary diagnostic below.
+        (when (and value
+                   (not (and (= :tensor (:kind value)) (= (extent-shape extent) (:shape value)))))
+          (fail! :typed-soac-array-type
+                 "SOAC element operands must be rank-one tensors over the declared extent"
+                 {:equation equation-id :id id :value value :extent extent}))))
+    (case kind
+      map
+      (doseq [id results]
+        (let [value (get values id)]
+          (when (and value
+                     (not (and (= :tensor (:kind value))
+                               (= (extent-shape extent) (:shape value)))))
+            (fail! :typed-soac-map-result-type
+                   "map results must be rank-one tensors over the declared extent"
+                   {:equation equation-id :id id :value value :extent extent}))))
+
+      reduce
+      (doseq [[id dtype] (map vector results (:dtypes attributes))]
+        (let [value (get values id)]
+          (when (and value
+                     (not (and (= :tensor (:kind value)) (= [] (:shape value))
+                               (= dtype (:dtype value)))))
+            (fail! :typed-soac-reduce-result-type
+                   "reduce results must be scalar tensors with their declared accumulator dtype"
+                   {:equation equation-id :id id :value value :dtype dtype}))))
+
+      nil)))
+
+(defn validate!
+  "Validate syntax, typed value references, ordered SSA definitions and explicit effects.
+   Returns the input program unchanged."
+  [program]
+  (when-not (program-form? program)
+    (fail! :typed-soac-program "expected a soac-program form" {:program program}))
+  (when-not (dialect/valid? TypedSOAC program)
+    (fail! :typed-soac-syntax "program does not conform to the TypedSOAC pattern dialect"
+           {:details (dialect/validate TypedSOAC program)}))
+  (let [program-facts (facts program)
+        values (:values program-facts)
+        program-inputs (:inputs program-facts)
+        program-outputs (outputs program)
+        equations (equations program)
+        equation-ids (mapv second equations)
+        equation-fact-ids (set (keys (:equations program-facts)))]
+    (doseq [[id value] values]
+      (try
+        (av/validate! value)
+        (catch clojure.lang.ExceptionInfo exception
+          (fail! :typed-soac-value "invalid AbstractValue in typed SOAC program"
+                 {:id id :cause (ex-data exception)}))))
+    (when-not (distinct-vector? program-inputs)
+      (fail! :typed-soac-inputs "program inputs must be an ordered distinct vector"
+             {:inputs program-inputs}))
+    (when-not (distinct-vector? program-outputs)
+      (fail! :typed-soac-outputs "program outputs must be an ordered distinct vector"
+             {:outputs program-outputs}))
+    (when-not (= (count equation-ids) (count (distinct equation-ids)))
+      (fail! :typed-soac-equation-ids "equation IDs must be unique"
+             {:equations equation-ids}))
+    (when-not (= equation-fact-ids (set equation-ids))
+      (fail! :typed-soac-equation-facts
+             "equation fact keys must exactly match the expression spine"
+             {:facts equation-fact-ids :equations (set equation-ids)}))
+    (doseq [equation equations]
+      (validate-equation! equation)
+      (validate-equation-types! values equation))
+    (let [definitions (mapcat #(nth % 2) equations)
+          definition-set (set definitions)
+          references (set (mapcat (fn [equation]
+                                    (conj (operation-inputs equation)
+                                          (operation-extent equation)))
+                                  equations))
+          external (set/difference references definition-set)
+          total-effects (reduce set/union #{}
+                                (map :effects (vals (:equations program-facts))))]
+      (when-not (= (count definitions) (count definition-set))
+        (fail! :typed-soac-definitions "logical values may be defined by only one equation"
+               {:definitions definitions}))
+      (doseq [id (set/union definition-set references (set program-inputs)
+                            (set program-outputs))]
+        (when-not (contains? values id)
+          (fail! :typed-soac-unknown-value "SOAC program references an unknown value"
+                 {:id id})))
+      (when-not (= external (set program-inputs))
+        (fail! :typed-soac-input-boundary
+               "program inputs must exactly name values used but not defined"
+               {:declared (set program-inputs) :inferred external}))
+      (loop [available (set program-inputs)
+             [equation & remaining] equations]
+        (when equation
+          (let [equation-id (second equation)
+                required (conj (set (operation-inputs equation))
+                               (operation-extent equation))
+                missing (set/difference required available)]
+            (when (seq missing)
+              (fail! :typed-soac-use-before-definition
+                     "equations may use only program inputs or earlier equation results"
+                     {:equation equation-id :missing missing :available available}))
+            (recur (into available (nth equation 2)) remaining))))
+      (when-not (set/subset? (set program-outputs) definition-set)
+        (fail! :typed-soac-output-boundary "program outputs must be equation results"
+               {:outputs program-outputs :definitions definition-set}))
+      (when-not (= total-effects (:effects program-facts))
+        (fail! :typed-soac-effects "program effects must equal the union of equation effects"
+               {:declared (:effects program-facts) :inferred total-effects}))))
+  program)
+
+(defn make
+  "Construct and validate a typed SOAC program."
+  [program-facts equation-forms program-outputs]
+  (validate! (list 'soac-program program-facts (vec equation-forms) (vec program-outputs))))
+
+(defn default-equation-facts
+  ([] (default-equation-facts {}))
+  ([provenance]
+   {:effects #{} :aliases {} :provenance provenance :attributes {}}))
+
+(defn default-program-facts
+  [{:keys [values inputs equations effects diagnostics provenance attributes]
+    :or {values {} inputs [] equations {} effects #{} diagnostics [] provenance {} attributes {}}}]
+  {:values values
+   :inputs (vec inputs)
+   :equations equations
+   :effects effects
+   :diagnostics (vec diagnostics)
+   :provenance provenance
+   :attributes attributes})

--- a/src/raster/compiler/passes/parallel/soac_dialect_adapter.clj
+++ b/src/raster/compiler/passes/parallel/soac_dialect_adapter.clj
@@ -1,0 +1,252 @@
+(ns raster.compiler.passes.parallel.soac-dialect-adapter
+  "Guarded compatibility projection from the current record SOAC graph to TypedSOAC.
+
+   This is a differential-testing bridge, not a backend route. It accepts only maps, scalar/full
+   reductions and the allocation/alias scaffolding produced by current horizontal fusion. Every
+  unsupported legacy shape declines loudly so the bridge cannot silently erase compiler facts."
+  (:require [clojure.set :as set]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.util :as util]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.reduction :as reduction]
+            [raster.compiler.ir.soac :as legacy]
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.passes.parallel.fusion-support :as fusion-support]))
+
+(def ^:private array-constructor-heads
+  '#{double-array float-array int-array long-array
+     clojure.core/double-array clojure.core/float-array
+     clojure.core/int-array clojure.core/long-array})
+
+(defn- fail!
+  [reason message data]
+  (throw (ex-info message (assoc data :reason reason :adapter :legacy-soac->typed-soac))))
+
+(defn- ordered-nodes
+  [nodes]
+  (->> (if (map? nodes) (vals nodes) nodes)
+       (sort-by :id)
+       vec))
+
+(defn- generated-scaffolding?
+  [node physical-outputs]
+  (and (legacy/scalar-binding? node)
+       (let [expression (:expr node)]
+         (or (and (symbol? expression) (contains? physical-outputs expression))
+             (and (contains? physical-outputs (:sym node))
+                  (seq? expression)
+                  (contains? array-constructor-heads (first expression)))))))
+
+(defn- logical-aliases
+  [nodes]
+  (into {}
+        (keep (fn [node]
+                (when (and (legacy/scalar-binding? node) (symbol? (:expr node)))
+                  [(:expr node) (:sym node)])))
+        nodes))
+
+(defn- element-symbols
+  [n]
+  (mapv #(symbol (str "%element" %)) (range n)))
+
+(defn- capture-symbols
+  [n]
+  (mapv #(symbol (str "%capture" %)) (range n)))
+
+(defn- elementize
+  [expressions arrays parameters index]
+  (mapv (fn [expression]
+          (reduce (fn [body [array parameter]]
+                    (fusion-support/substitute-aget body array index index parameter))
+                  expression
+                  (map vector arrays parameters)))
+        expressions))
+
+(defn- cast-result
+  [cast expression]
+  (if cast (list cast expression) expression))
+
+(defn- horizontal-map-parts
+  [node aliases]
+  (let [body (:lambda node)]
+    (if (and (seq? body) (= 'do (first body)))
+      (let [statements (vec (rest body))
+            primary-expression (peek statements)
+            side-effects (pop statements)
+            sides
+            (mapv (fn [statement]
+                    (when-not (descriptor/aset-call? statement)
+                      (fail! :unsupported-legacy-map-body
+                             "multi-result legacy map contains a non-aset side effect"
+                             {:node (:id node) :statement statement}))
+                    (let [arguments (vec (descriptor/call-args statement))
+                          buffer (descriptor/aset-array-sym statement)]
+                      (when-not (and (= 3 (count arguments)) (= (:idx node) (nth arguments 1)))
+                        (fail! :unsupported-legacy-map-index
+                               "horizontal map store is not pointwise in the map index"
+                               {:node (:id node) :statement statement}))
+                      {:result (get aliases buffer buffer)
+                       :expression (nth arguments 2)}))
+                  side-effects)]
+        {:results (vec (cons (:sym node) (map :result sides)))
+         :expressions (vec (cons (cast-result (:cast-fn node) primary-expression)
+                                 (map :expression sides)))})
+      {:results [(:sym node)]
+       :expressions [(cast-result (:cast-fn node) body)]})))
+
+(defn- map-equation
+  [node aliases]
+  (let [arrays (vec (sort-by pr-str (:inputs node)))
+        captures (vec (sort-by pr-str (:scalars node)))
+        parameters (element-symbols (count arrays))
+        capture-parameters (capture-symbols (count captures))
+        {:keys [results expressions]} (horizontal-map-parts node aliases)
+        body-results (->> (elementize expressions arrays parameters (:idx node))
+                          (mapv #(util/subst-syms (zipmap captures capture-parameters) %)))]
+    (list '= (:id node) results
+          (list 'map {:index (:idx node) :extent (:bound node)}
+                arrays captures
+                (list 'lambda (vec (concat parameters capture-parameters)) body-results)))))
+
+(defn- reduce-equation
+  [node]
+  (when (seq (:segment-axes node))
+    (fail! :unsupported-segmented-reduction
+           "legacy adapter covers scalar/full reductions only"
+           {:node (:id node) :segment-axes (:segment-axes node)}))
+  (let [product (:reduction node)]
+    (when-not (reduction/scalar? product)
+      (fail! :unsupported-product-reduction
+             "legacy adapter covers one-component reductions only"
+             {:node (:id node) :components (count (:components product))}))
+    (let [component (first (:components product))
+          arrays (vec (sort-by pr-str (:inputs node)))
+          captures (vec (sort-by pr-str (:scalars node)))
+          element-parameters (element-symbols (count arrays))
+          capture-parameters (capture-symbols (count captures))
+          body-results (->> (elementize (:results (reduction/fold-region product))
+                                        arrays element-parameters (:index product))
+                            (mapv #(util/subst-syms (zipmap captures capture-parameters) %)))
+          attributes {:index (:index product)
+                      :extent (:bound node)
+                      :accumulators [(:accumulator component)]
+                      :identities [(:neutral component)]
+                      :dtypes [(:dtype component)]
+                      :algebra [(:algebra product)]}]
+      (list '= (:id node) (vec (filter some? (reduction/results product)))
+            (list 'reduce attributes arrays captures
+                  (list 'lambda
+                        (vec (concat [(:accumulator component)]
+                                     element-parameters capture-parameters))
+                        body-results))))))
+
+(defn- operation-equation
+  [node aliases]
+  (cond
+    (legacy/soac-map? node) (map-equation node aliases)
+    (legacy/soac-reduce? node) (reduce-equation node)
+    :else
+    (fail! :unsupported-legacy-soac
+           "legacy adapter supports only map and scalar/full reduce nodes"
+           {:node (:id node) :type (.getName (class node))})))
+
+(defn- tensor-value
+  [dtype shape]
+  (av/tensor {:dtype dtype :shape shape :representation {:kind :plain}}))
+
+(defn- value-dtype
+  [id default-dtype array-types]
+  (or (get array-types id)
+      (when (symbol? id) (get array-types (symbol (name id))))
+      default-dtype
+      :double))
+
+(defn- equation-values
+  [equation default-dtype array-types]
+  (let [[_ _ results operation] equation
+        [kind attributes arrays captures] operation
+        extent (:extent attributes)
+        result-dtypes (if (= 'reduce kind)
+                        (:dtypes attributes)
+                        (repeat (count results) default-dtype))]
+    (merge
+     {extent (tensor-value :long [])}
+     (into {} (map (fn [id]
+                     [id (tensor-value (value-dtype id default-dtype array-types)
+                                       (dialect/extent-shape extent))])
+                   arrays))
+     (into {} (map (fn [id]
+                     [id (tensor-value (value-dtype id default-dtype array-types) [])])
+                   captures))
+     (into {} (map (fn [id dtype]
+                     [id (tensor-value (or dtype default-dtype :double)
+                                       (if (= 'reduce kind) []
+                                           (dialect/extent-shape extent)))])
+                   results result-dtypes)))))
+
+(defn- merge-value
+  [values id contract]
+  (if-let [prior (get values id)]
+    (if (= prior contract)
+      values
+      (fail! :legacy-value-conflict
+             "legacy nodes infer incompatible AbstractValues for one logical ID"
+             {:id id :first prior :second contract}))
+    (assoc values id contract)))
+
+(defn legacy-nodes->program
+  "Project current map/reduce nodes into a verified TypedSOAC program.
+
+   Options:
+   - :outputs — logical program results (defaults to the last equation's results)
+   - :dtype — fallback element dtype
+   - :array-types — symbol-to-dtype overrides
+   - :values — authoritative additional AbstractValues"
+  [nodes {:keys [outputs dtype array-types values]
+          :or {dtype :double array-types {} values {}}}]
+  (let [nodes (ordered-nodes nodes)
+        physical-outputs (reduce set/union #{}
+                                 (keep #(when-not (legacy/scalar-binding? %)
+                                          (legacy/soac-outputs %))
+                                       nodes))
+        unsupported (remove #(or (legacy/soac-map? %)
+                                 (legacy/soac-reduce? %)
+                                 (generated-scaffolding? % physical-outputs))
+                            nodes)]
+    (when-let [node (first unsupported)]
+      (fail! :unsupported-legacy-node
+             "legacy graph contains a node outside the differential adapter subset"
+             {:node (:id node) :type (.getName (class node))}))
+    (let [aliases (logical-aliases nodes)
+          operation-nodes (filterv #(or (legacy/soac-map? %) (legacy/soac-reduce? %)) nodes)
+          equations (mapv #(operation-equation % aliases) operation-nodes)
+          equation-infos (mapv (fn [equation]
+                                 {:id (second equation)
+                                  :results (nth equation 2)
+                                  :inputs (dialect/operation-inputs equation)
+                                  :extent (dialect/operation-extent equation)})
+                               equations)
+          definitions (set (mapcat :results equation-infos))
+          references (set (mapcat #(conj (:inputs %) (:extent %)) equation-infos))
+          inputs (vec (sort-by pr-str (set/difference references definitions)))
+          outputs (vec (or outputs (:results (peek equation-infos)) []))
+          inferred-values (reduce (fn [contracts equation]
+                                    (reduce-kv merge-value contracts
+                                               (equation-values equation dtype array-types)))
+                                  {}
+                                  equations)
+          values (reduce-kv merge-value inferred-values values)
+          equation-facts (into {}
+                               (map (fn [node]
+                                      [(:id node)
+                                       (dialect/default-equation-facts
+                                        {:adapter :legacy-soac
+                                         :legacy-soac-id (:id node)})]))
+                               operation-nodes)
+          facts (dialect/default-program-facts
+                 {:values values
+                  :inputs inputs
+                  :equations equation-facts
+                  :provenance {:adapter :legacy-soac}
+                  :attributes {:compatibility-view true}})]
+      (dialect/make facts equations outputs))))

--- a/src/raster/compiler/passes/parallel/soac_graph.clj
+++ b/src/raster/compiler/passes/parallel/soac_graph.clj
@@ -10,12 +10,14 @@
     :dep     — consumer reads producer's array output (fusible)
     :inf-dep — consumer reads producer's scalar output (infusible)
     :cons    — consumer mutates array producer reads (anti-dep)"
-  (:require [raster.compiler.core.dtype :as dt]
+  (:require [clojure.set :as set]
+            [clojure.walk :as walk]
+            [raster.compiler.core.dtype :as dt]
+            [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.fusion-support :as fusion-support]
             [raster.compiler.passes.parallel.schedule-support :as schedule-support]
-            [raster.compiler.core.op-descriptor :as opd]
-            [clojure.set :as set]))
+            [raster.compiler.core.op-descriptor :as opd]))
 
 ;; ================================================================
 ;; FusionGraph record
@@ -202,7 +204,7 @@
   (let [;; First resolve aliases in all symbols
         alias-resolved (if (nil? alias-map)
                          bound-expr
-                         (clojure.walk/postwalk
+                         (walk/postwalk
                           (fn [form]
                             (if (and (symbol? form) (contains? alias-map form))
                               (get alias-map form)
@@ -386,6 +388,47 @@
             (<= (lambda-flops (:lambda producer))
                 (* (long eb) (double ridge)))))))
 
+(defn- reduction-fusion-expressions
+  [product]
+  (cond
+    (:step product) (:results (reduction/fold-region product))
+    (:element product) (:results (reduction/element-region product))
+    :else nil))
+
+(defn- assoc-reduction-fusion-expressions
+  [product expressions]
+  (cond
+    (:step product) (assoc-in product [:step :results] (vec expressions))
+    (:element product) (assoc-in product [:element :results] (vec expressions))
+    :else product))
+
+(defn- fusion-expressions
+  "Canonical scalar expressions into which a pointwise producer may be substituted."
+  [node]
+  (cond
+    (soac/soac-reduce? node) (reduction-fusion-expressions (:reduction node))
+    (soac/screma? node) (cond
+                          (:map-lambda node) [(:map-lambda node)]
+                          (= 1 (count (:reduces node)))
+                          (reduction-fusion-expressions (first (:reduces node)))
+                          :else nil)
+    (:lambda node) [(:lambda node)]
+    :else nil))
+
+(defn- assoc-fusion-expressions
+  [node expressions]
+  (cond
+    (soac/soac-reduce? node)
+    (update node :reduction assoc-reduction-fusion-expressions expressions)
+
+    (and (soac/screma? node) (:map-lambda node))
+    (assoc node :map-lambda (first expressions))
+
+    (and (soac/screma? node) (= 1 (count (:reduces node))))
+    (update-in node [:reduces 0] assoc-reduction-fusion-expressions expressions)
+
+    :else (assoc node :lambda (first expressions))))
+
 (defn can-fuse-vertically?
   "Check if producer can be vertically fused into consumer.
 
@@ -411,28 +454,36 @@
   ([graph producer-id consumer-id]
    (can-fuse-vertically? graph producer-id consumer-id nil nil))
   ([graph producer-id consumer-id am dtype]
-  (let [nodes (:nodes graph)
-        producer (get nodes producer-id)
-        consumer (get nodes consumer-id)
-        alias-map (:alias-map graph)]
-    (and
+   (let [nodes (:nodes graph)
+         producer (get nodes producer-id)
+         consumer (get nodes consumer-id)
+         alias-map (:alias-map graph)]
+     (and
       ;; 1. Both are SOACs
-     (soac/soac? producer)
-     (soac/soac? consumer)
+      (soac/soac? producer)
+      (soac/soac? consumer)
       ;; 2. :dep edge exists
-     (seq (dep-edges-between graph producer-id consumer-id))
+      (seq (dep-edges-between graph producer-id consumer-id))
       ;; 3. No :inf-dep edges between pair
-     (empty? (inf-dep-edges-between graph producer-id consumer-id))
+      (empty? (inf-dep-edges-between graph producer-id consumer-id))
       ;; 4. Same bound (after alias + size normalization)
-     (let [{:keys [array-equiv scalar-bound]} (build-size-equiv nodes alias-map)]
-       (= (normalize-bound (soac/soac-bound producer) alias-map array-equiv scalar-bound)
-          (normalize-bound (soac/soac-bound consumer) alias-map array-equiv scalar-bound)))
+      (let [{:keys [array-equiv scalar-bound]} (build-size-equiv nodes alias-map)]
+        (= (normalize-bound (soac/soac-bound producer) alias-map array-equiv scalar-bound)
+           (normalize-bound (soac/soac-bound consumer) alias-map array-equiv scalar-bound)))
       ;; 5. Producer is a Map or Scan (can inline its body)
       ;; Map→X: substitute aget with producer body (eliminates intermediate array)
       ;; Scan→Map: fold consumer body into scan loop as side-effect aset
-     (or (instance? raster.compiler.ir.soac.SoacMap producer)
-         (and (instance? raster.compiler.ir.soac.SoacScan producer)
-              (instance? raster.compiler.ir.soac.SoacMap consumer)))
+      (or (and (soac/soac-map? producer)
+              ;; Current dependency edges do not retain which output of a multi-result map was
+              ;; consumed. Choosing `(first outputs)` is unordered and can substitute the wrong
+              ;; value; decline until typed equation edges carry precise value identity.
+               (= 1 (count (soac/soac-outputs producer))))
+          (and (soac/soac-scan? producer)
+               (soac/soac-map? consumer)))
+      ;; The consumer must expose canonical scalar expressions. Associating a synthetic :lambda
+      ;; onto a reduction record does not update its ProductReduction and silently leaves a read of
+      ;; the eliminated intermediate behind.
+      (seq (fusion-expressions consumer))
       ;; 6. Value-flow ordering: the producer must PRECEDE the consumer in the
      ;; original program order (`:id` = the sequential let*-binding index). A
      ;; genuine read-after-write `:dep` (the consumer reads a value the producer
@@ -449,16 +500,16 @@
      ;; forward-reference that the :soac-fused dialect validator rejects loudly).
      ;; This guard is domain-agnostic — it queries only node identity/order, no
      ;; op names — and declines exactly the spurious backwards fusions.
-     (< (:id producer) (:id consumer))
+      (< (:id producer) (:id consumer))
       ;; 7. The producer must NOT be a reduce-broadcast node (see depends-on-reduce?).
       ;; Pinning it keeps the reduce→broadcast→map boundary materialized — without this,
       ;; introducing a par/reduce (matching the element bound) lets the broadcast map smear
       ;; the reduce-derived scalar across consumers and cascade into monster kernels.
-     (not (depends-on-reduce? graph producer-id))
+      (not (depends-on-reduce? graph producer-id))
       ;; 8. PROFITABILITY (decline-only): with an AM supplied, decline a legal fusion
       ;; the locality roofline says loses (expensive multi-consumer rematerialization).
       ;; Last conjunct → can only turn a true into false, never the reverse.
-     (vertical-fusion-profitable? graph producer-id consumer-id am dtype)))))
+      (vertical-fusion-profitable? graph producer-id consumer-id am dtype)))))
 
 (defn- fuse-vertical-scan-map
   "Fuse Scan producer into Map consumer by folding the map's body into
@@ -563,25 +614,31 @@
           prod-sym (:sym producer)
           others (other-consumers graph producer-id consumer-id)
           keep-producer? (seq others)
-        ;; Inline producer body into consumer lambda.
+        ;; Inline producer body into the consumer's canonical scalar region(s). A map cast is part
+        ;; of the materialized intermediate's semantics and must travel with the inlined value.
         ;; Try both the output buffer sym and the producer's binding sym
         ;; (alias), since consumers may read through either name.
         ;; E.g., producer: h = (par/map! out__ ...), consumer reads (aget h ...)
-          new-lambda (let [subst1 (fusion-support/substitute-aget
-                                   (:lambda consumer) prod-out
-                                   (:idx producer) (:idx consumer)
-                                   (:lambda producer))]
-                       (if (= subst1 (:lambda consumer))
-                       ;; First substitution was a no-op — try the alias sym
-                         (fusion-support/substitute-aget
-                          (:lambda consumer) prod-sym
-                          (:idx producer) (:idx consumer)
-                          (:lambda producer))
-                         subst1))
+          producer-expression (if-let [cast (:cast-fn producer)]
+                                (list cast (:lambda producer))
+                                (:lambda producer))
+          new-expressions
+          (mapv (fn [expression]
+                  (let [substituted (fusion-support/substitute-aget
+                                     expression prod-out
+                                     (:idx producer) (soac/soac-idx consumer)
+                                     producer-expression)]
+                    (if (= substituted expression)
+                      (fusion-support/substitute-aget
+                       expression prod-sym
+                       (:idx producer) (soac/soac-idx consumer)
+                       producer-expression)
+                      substituted)))
+                (fusion-expressions consumer))
         ;; Merge inputs: consumer inputs + producer inputs - producer output
-          new-inputs (set/union (disj (:inputs consumer) prod-out)
+          new-inputs (set/union (disj (:inputs consumer) prod-out prod-sym)
                                 (:inputs producer))
-          new-scalars (set/union (disj (:scalars consumer) prod-out)
+          new-scalars (set/union (disj (:scalars consumer) prod-out prod-sym)
                                  (:scalars producer))
         ;; When fusing a pure producer (no output buffer), the consumer's bound
         ;; may reference (alength prod-sym) which becomes dangling after removal.
@@ -593,11 +650,11 @@
                                          array-equiv scalar-bound))
                       (:bound consumer))
         ;; Create updated consumer
-          updated-consumer (assoc consumer
-                                  :lambda new-lambda
-                                  :inputs new-inputs
-                                  :scalars new-scalars
-                                  :bound new-bound)
+          updated-consumer (-> consumer
+                               (assoc-fusion-expressions new-expressions)
+                               (assoc :inputs new-inputs
+                                      :scalars new-scalars
+                                      :bound new-bound))
         ;; Update nodes
           new-nodes (if keep-producer?
                     ;; Multi-consumer: keep producer, update consumer
@@ -891,17 +948,17 @@
   independent same-bound maps and never duplicates compute."
   ([graph] (fusion-fixpoint graph nil nil))
   ([graph am dtype]
-  (loop [g graph
-         total-v 0
-         total-h 0
-         iters 0]
-    (let [[g1 v-count] (apply-vertical-fusions g am dtype)
-          [g2 h-count] (apply-horizontal-fusions g1)]
-      (if (and (zero? v-count) (zero? h-count))
-        [g2 {:vertical (+ total-v v-count)
-             :horizontal (+ total-h h-count)
-             :iterations (inc iters)}]
-        (recur g2
-               (+ total-v v-count)
-               (+ total-h h-count)
-               (inc iters)))))))
+   (loop [g graph
+          total-v 0
+          total-h 0
+          iters 0]
+     (let [[g1 v-count] (apply-vertical-fusions g am dtype)
+           [g2 h-count] (apply-horizontal-fusions g1)]
+       (if (and (zero? v-count) (zero? h-count))
+         [g2 {:vertical (+ total-v v-count)
+              :horizontal (+ total-h h-count)
+              :iterations (inc iters)}]
+         (recur g2
+                (+ total-v v-count)
+                (+ total-h h-count)
+                (inc iters)))))))

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -1,0 +1,314 @@
+(ns raster.compiler.passes.parallel.typed-soac-fusion
+  "Pattern-declared fusion over the typed functional SOAC dialect.
+
+   The pattern library recognizes the compact equation grammar. Raster code performs the legality
+   checks and fact-table updates explicitly; failed candidates leave the immutable program intact.
+   This first slice covers map→map, map→reduce and horizontal map fusion."
+  (:require [clojure.set :as set]
+            [pattern.nanopass.dialect :refer [from-dialect]]
+            [pattern.r3.core :refer [rule success]]
+            [raster.compiler.core.util :as util]
+            [raster.compiler.ir.soac-dialect :as dialect]))
+
+(def ^:private map-equation-rule
+  (from-dialect dialect/TypedSOAC
+                (rule '(= ?equation-id [??results]
+                          (map ?attributes [??arrays] [??captures]
+                               (lambda [??parameters] [??body-results])))
+                      (success {:kind :map
+                                :id equation-id
+                                :results results
+                                :attributes attributes
+                                :arrays arrays
+                                :captures captures
+                                :parameters parameters
+                                :body-results body-results}))))
+
+(def ^:private reduce-equation-rule
+  (from-dialect dialect/TypedSOAC
+                (rule '(= ?equation-id [??results]
+                          (reduce ?attributes [??arrays] [??captures]
+                                  (lambda [??parameters] [??body-results])))
+                      (success {:kind :reduce
+                                :id equation-id
+                                :results results
+                                :attributes attributes
+                                :arrays arrays
+                                :captures captures
+                                :parameters parameters
+                                :body-results body-results}))))
+
+(defn equation-info
+  "Return a normalized equation description, using Pattern as the dialect matcher."
+  [equation]
+  (let [map-result (map-equation-rule equation)]
+    (if (map? map-result)
+      map-result
+      (let [reduce-result (reduce-equation-rule equation)]
+        (when (map? reduce-result) reduce-result)))))
+
+(defn- element-symbols
+  [n]
+  (mapv #(symbol (str "%element" %)) (range n)))
+
+(defn- capture-symbols
+  [n]
+  (mapv #(symbol (str "%capture" %)) (range n)))
+
+(defn- parameter-parts
+  [info]
+  (let [accumulator-count (if (= :reduce (:kind info))
+                            (count (get-in info [:attributes :accumulators]))
+                            0)
+        array-count (count (:arrays info))
+        parameters (vec (:parameters info))
+        element-end (+ accumulator-count array-count)]
+    {:accumulators (subvec parameters 0 accumulator-count)
+     :elements (subvec parameters accumulator-count element-end)
+     :capture-parameters (subvec parameters element-end)}))
+
+(defn- canonical-operands
+  "Sort/deduplicate operands and alpha-rename both element and capture parameters."
+  [arrays element-parameters captures capture-parameters body-results]
+  (let [canonical-arrays (vec (sort-by pr-str (distinct arrays)))
+        canonical-elements (element-symbols (count canonical-arrays))
+        element-for (zipmap canonical-arrays canonical-elements)
+        canonical-captures (vec (sort-by pr-str (distinct captures)))
+        canonical-capture-parameters (capture-symbols (count canonical-captures))
+        capture-for (zipmap canonical-captures canonical-capture-parameters)
+        substitutions
+        (into {}
+              (concat
+               (map (fn [[array parameter]] [parameter (get element-for array)])
+                    (map vector arrays element-parameters))
+               (map (fn [[capture parameter]] [parameter (get capture-for capture)])
+                    (map vector captures capture-parameters))))]
+    {:arrays canonical-arrays
+     :elements canonical-elements
+     :captures canonical-captures
+     :capture-parameters canonical-capture-parameters
+     :body-results (mapv #(util/subst-syms substitutions %) body-results)}))
+
+(defn- freshen-parameters
+  "Give one equation's element and capture binders private names before scopes are combined."
+  [info prefix]
+  (let [{:keys [accumulators elements capture-parameters]} (parameter-parts info)
+        fresh-elements (mapv #(symbol (str "%" prefix "-element" %))
+                             (range (count elements)))
+        fresh-captures (mapv #(symbol (str "%" prefix "-capture" %))
+                             (range (count capture-parameters)))
+        substitutions (merge (zipmap elements fresh-elements)
+                             (zipmap capture-parameters fresh-captures))]
+    (assoc info
+           :parameters (vec (concat accumulators fresh-elements fresh-captures))
+           :body-results (mapv #(util/subst-syms substitutions %) (:body-results info)))))
+
+(defn- emit-equation
+  [{:keys [kind id results attributes arrays captures parameters body-results]}]
+  (list '= id (vec results)
+        (list (symbol (name kind)) attributes (vec arrays) (vec captures)
+              (list 'lambda (vec parameters) (vec body-results)))))
+
+(defn- fusible-equation?
+  [program equation-id]
+  (let [facts (get-in (dialect/facts program) [:equations equation-id])]
+    (and (empty? (:effects facts))
+         ;; Alias-aware fusion can be added once legality is proved. Until then, equation results
+         ;; are treated as fresh SSA values and any explicit alias contract declines fusion.
+         (empty? (:aliases facts)))))
+
+(defn- value-use-counts
+  [program]
+  (frequencies
+   (concat
+    (mapcat (fn [equation]
+              (let [{:keys [arrays captures attributes]} (equation-info equation)]
+                (concat arrays captures [(:extent attributes)])))
+            (dialect/equations program))
+    (dialect/outputs program))))
+
+(defn- merge-provenance
+  [left right fused-kind]
+  (let [ids (vec (distinct (concat (:fused-equations left)
+                                   (:fused-equations right))))]
+    (assoc (merge left right)
+           :fusion fused-kind
+           :fused-equations ids)))
+
+(defn- remove-equation-fact
+  [facts removed-id kept-id fused-kind]
+  (let [removed (get-in facts [:equations removed-id])
+        kept (get-in facts [:equations kept-id])
+        constituent-facts
+        (fn [id equation-facts]
+          (or (get-in equation-facts [:attributes :fusion/constituents])
+              {id (update equation-facts :attributes dissoc :fusion/constituents)}))
+        constituents (merge (constituent-facts kept-id kept)
+                            (constituent-facts removed-id removed))]
+    (-> facts
+        (update :equations dissoc removed-id)
+        (assoc-in [:equations kept-id :attributes :fusion/constituents] constituents)
+        (assoc-in [:equations kept-id :provenance]
+                  (merge-provenance
+                   (assoc (:provenance kept) :fused-equations [kept-id])
+                   (assoc (:provenance removed) :fused-equations [removed-id])
+                   fused-kind)))))
+
+(defn- rebuild-boundary
+  [program facts equations]
+  (let [definitions (set (mapcat #(nth % 2) equations))
+        references (set (mapcat (fn [equation]
+                                  (let [{:keys [arrays captures attributes]}
+                                        (equation-info equation)]
+                                    (concat arrays captures [(:extent attributes)])))
+                                equations))
+        inputs (vec (sort-by pr-str (set/difference references definitions)))
+        live-values (set/union definitions references (set (dialect/outputs program)))
+        facts (-> facts
+                  (assoc :inputs inputs)
+                  (update :values select-keys live-values))]
+    (dialect/make facts equations (dialect/outputs program))))
+
+(defn- vertical-candidate
+  [program]
+  (let [equations (dialect/equations program)
+        infos (mapv equation-info equations)
+        uses (value-use-counts program)]
+    (first
+     (for [producer-index (range (count infos))
+           consumer-index (range (inc producer-index) (count infos))
+           :let [producer (nth infos producer-index)
+                 consumer (nth infos consumer-index)
+                 produced (first (:results producer))]
+           :when (= :map (:kind producer))
+           :when (= 1 (count (:results producer)))
+           :when (= 1 (count (:body-results producer)))
+           :when (contains? #{:map :reduce} (:kind consumer))
+           :when (= (:extent (:attributes producer)) (:extent (:attributes consumer)))
+           :when (= 1 (get uses produced 0))
+           :when (some #{produced} (:arrays consumer))
+           :when (fusible-equation? program (:id producer))
+           :when (fusible-equation? program (:id consumer))]
+       {:producer-index producer-index :consumer-index consumer-index
+        :producer producer :consumer consumer :produced produced}))))
+
+(defn- fuse-vertical-once
+  [program]
+  (when-let [{:keys [producer-index consumer-index producer consumer produced]}
+             (vertical-candidate program)]
+    (let [producer (freshen-parameters producer "producer")
+          consumer (freshen-parameters consumer "consumer")
+          producer-parameters (parameter-parts producer)
+          consumer-parameters (parameter-parts consumer)
+          consumed-index (.indexOf ^java.util.List (:arrays consumer) produced)
+          consumer-elements (:elements consumer-parameters)
+          consumed-parameter (nth consumer-elements consumed-index)
+          inlined-body (mapv #(util/subst-syms
+                               {consumed-parameter (first (:body-results producer))} %)
+                             (:body-results consumer))
+          raw-arrays (vec (concat (subvec (vec (:arrays consumer)) 0 consumed-index)
+                                  (:arrays producer)
+                                  (subvec (vec (:arrays consumer)) (inc consumed-index))))
+          raw-elements (vec (concat (subvec consumer-elements 0 consumed-index)
+                                    (:elements producer-parameters)
+                                    (subvec consumer-elements (inc consumed-index))))
+          raw-captures (vec (concat (:captures producer) (:captures consumer)))
+          raw-capture-parameters
+          (vec (concat (:capture-parameters producer-parameters)
+                       (:capture-parameters consumer-parameters)))
+          canonical (canonical-operands raw-arrays raw-elements
+                                        raw-captures raw-capture-parameters inlined-body)
+          updated (assoc consumer
+                         :arrays (:arrays canonical)
+                         :captures (:captures canonical)
+                         :parameters (vec (concat (:accumulators consumer-parameters)
+                                                  (:elements canonical)
+                                                  (:capture-parameters canonical)))
+                         :body-results (:body-results canonical))
+          equations (-> (dialect/equations program)
+                        (assoc consumer-index (emit-equation updated))
+                        (->> (keep-indexed (fn [index equation]
+                                             (when-not (= index producer-index) equation)))
+                             vec))
+          facts (remove-equation-fact (dialect/facts program) (:id producer) (:id consumer)
+                                      (keyword (str "map-" (name (:kind consumer)))))]
+      (rebuild-boundary program facts equations))))
+
+(defn- horizontal-candidate
+  [program]
+  (let [equations (dialect/equations program)
+        infos (mapv equation-info equations)
+        producer-index (into {}
+                             (mapcat (fn [[index info]]
+                                       (map (fn [result] [result index]) (:results info)))
+                                     (map-indexed vector infos)))]
+    (first
+     (for [left-index (range (count infos))
+           right-index (range (inc left-index) (count infos))
+           :let [left (nth infos left-index)
+                 right (nth infos right-index)
+                 left-results (set (:results left))
+                 right-results (set (:results right))
+                 left-uses (set (concat (:arrays left) (:captures left)))
+                 right-uses (set (concat (:arrays right) (:captures right)
+                                         [(:extent (:attributes right))]))]
+           :when (= :map (:kind left) (:kind right))
+           :when (= (:extent (:attributes left)) (:extent (:attributes right)))
+           :when (empty? (set/intersection left-results right-uses))
+           :when (empty? (set/intersection right-results left-uses))
+           ;; Moving the right equation to the left's position must not move it before an
+           ;; intervening producer. Program inputs have no producer index and are always ready.
+           :when (every? (fn [value]
+                           (let [index (get producer-index value)]
+                             (or (nil? index) (< index left-index))))
+                         right-uses)
+           :when (fusible-equation? program (:id left))
+           :when (fusible-equation? program (:id right))]
+       {:left-index left-index :right-index right-index :left left :right right}))))
+
+(defn- fuse-horizontal-once
+  [program]
+  (when-let [{:keys [left-index right-index left right]} (horizontal-candidate program)]
+    (let [left (freshen-parameters left "left")
+          right (freshen-parameters right "right")
+          left-parameters (parameter-parts left)
+          right-parameters (parameter-parts right)
+          canonical (canonical-operands
+                     (vec (concat (:arrays left) (:arrays right)))
+                     (vec (concat (:elements left-parameters)
+                                  (:elements right-parameters)))
+                     (vec (concat (:captures left) (:captures right)))
+                     (vec (concat (:capture-parameters left-parameters)
+                                  (:capture-parameters right-parameters)))
+                     (vec (concat (:body-results left) (:body-results right))))
+          updated (assoc left
+                         :results (vec (concat (:results left) (:results right)))
+                         :arrays (:arrays canonical)
+                         :captures (:captures canonical)
+                         :parameters (vec (concat (:elements canonical)
+                                                  (:capture-parameters canonical)))
+                         :body-results (:body-results canonical))
+          equations (-> (dialect/equations program)
+                        (assoc left-index (emit-equation updated))
+                        (->> (keep-indexed (fn [index equation]
+                                             (when-not (= index right-index) equation)))
+                             vec))
+          facts (remove-equation-fact (dialect/facts program) (:id right) (:id left)
+                                      :horizontal-map)]
+      (rebuild-boundary program facts equations))))
+
+(defn fusion-fixpoint
+  "Fuse legal typed SOAC equations to a fixpoint. Returns [program stats]."
+  [program]
+  (dialect/validate! program)
+  (loop [program program
+         vertical 0
+         horizontal 0
+         iterations 0]
+    (if-let [fused (fuse-vertical-once program)]
+      (recur fused (inc vertical) horizontal (inc iterations))
+      (if-let [fused (fuse-horizontal-once program)]
+        (recur fused vertical (inc horizontal) (inc iterations))
+        [program {:vertical vertical
+                  :horizontal horizontal
+                  :iterations (inc iterations)}]))))

--- a/test/raster/compiler/ir/soac_dialect_test.clj
+++ b/test/raster/compiler/ir/soac_dialect_test.clj
@@ -1,0 +1,132 @@
+(ns raster.compiler.ir.soac-dialect-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [pattern.nanopass.dialect :as pattern-dialect]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.soac-dialect :as dialect]))
+
+(def ^:private tensor
+  (av/tensor {:dtype :float :shape '[n]}))
+
+(def ^:private extent
+  (av/tensor {:dtype :long :shape []}))
+
+(defn- map-program
+  ([] (map-program {}))
+  ([{:keys [values inputs equation-facts effects body]
+     :or {values {'x tensor 'y tensor 'n extent}
+          inputs '[n x]
+          equation-facts (dialect/default-equation-facts)
+          effects #{}
+          body '(* x-element x-element)}}]
+   (dialect/make
+    (dialect/default-program-facts
+     {:values values
+      :inputs inputs
+      :equations {'map-0 equation-facts}
+      :effects effects})
+    [(list '= 'map-0 '[y]
+           (list 'map {:index 'i :extent 'n} '[x] []
+                 (list 'lambda '[x-element] [body])))]
+    '[y])))
+
+(deftest typed-soac-is-a-pattern-declared-recursive-dialect
+  (let [program (map-program)]
+    (is (pattern-dialect/valid? dialect/TypedSOAC program))
+    (is (= program (dialect/validate! program)))
+    (is (= :map (keyword (name (dialect/operation-kind
+                                (first (dialect/equations program)))))))
+    (is (= '[x] (dialect/operation-inputs (first (dialect/equations program)))))))
+
+(deftest scalar-regions-are-recursively-validated
+  (testing "a non-language object cannot hide inside a scalar call"
+    (let [bad-body (list '* 'x-element (Object.))]
+      (try
+        (map-program {:body bad-body})
+        (is false "invalid scalar child must be rejected")
+        (catch clojure.lang.ExceptionInfo exception
+          (is (= :typed-soac-syntax (:reason (ex-data exception)))))))))
+
+(deftest value-and-effect-side-tables-are-authoritative
+  (testing "every expression-spine value requires an AbstractValue"
+    (try
+      (map-program {:values {'y tensor 'n extent}})
+      (is false "unknown array operand must be rejected")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :typed-soac-unknown-value (:reason (ex-data exception)))))))
+
+  (testing "program effects equal the union of equation effects"
+    (try
+      (map-program {:equation-facts
+                    (assoc (dialect/default-equation-facts) :effects #{:memory/read})})
+      (is false "an unstated equation effect must be rejected")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :typed-soac-effects (:reason (ex-data exception)))))))
+
+  (testing "stated effects validate without changing functional syntax"
+    (let [program (map-program
+                   {:equation-facts
+                    (assoc (dialect/default-equation-facts) :effects #{:memory/read})
+                    :effects #{:memory/read}})]
+      (is (= #{:memory/read} (:effects (dialect/facts program)))))))
+
+(deftest equations-are-ordered-ssa
+  (let [values {'x tensor 'a tensor 'b tensor 'n extent}
+        facts (dialect/default-program-facts
+               {:values values
+                :inputs '[n x]
+                :equations {'use-a (dialect/default-equation-facts)
+                            'define-a (dialect/default-equation-facts)}})
+        equations
+        [(list '= 'use-a '[b]
+               (list 'map {:index 'i :extent 'n} '[a] []
+                     (list 'lambda '[a-element] '[(* a-element 2.0)])))
+         (list '= 'define-a '[a]
+               (list 'map {:index 'i :extent 'n} '[x] []
+                     (list 'lambda '[x-element] '[(* x-element x-element)])))]]
+    (try
+      (dialect/make facts equations '[b])
+      (is false "an equation cannot consume a result defined later")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :typed-soac-use-before-definition (:reason (ex-data exception))))))))
+
+(deftest captures-have-explicit-lexical-parameters
+  (let [scale-id [:model :scale]
+        scalar (av/tensor {:dtype :float :shape []})
+        program
+        (dialect/make
+         (dialect/default-program-facts
+          {:values {'x tensor 'y tensor 'n extent scale-id scalar}
+           :inputs ['n 'x scale-id]
+           :equations {'map-0 (dialect/default-equation-facts)}})
+         [(list '= 'map-0 '[y]
+                (list 'map {:index 'i :extent 'n} '[x] [scale-id]
+                      (list 'lambda '[x-element scale]
+                            '[(* x-element scale)])))]
+         '[y])]
+    (is (= {:accumulators []
+            :elements '[x-element]
+            :capture-parameters '[scale]}
+           (dialect/parameter-layout (first (dialect/equations program))))))
+
+  (testing "the expression spine cannot hide an undeclared dependency"
+    (try
+      (map-program {:body '(* x-element scale)})
+      (is false "free scalar symbols require capture operands and parameters")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :typed-soac-unbound-scalar (:reason (ex-data exception))))))))
+
+(deftest compound-stable-extent-ids-have-an-unambiguous-shape-reference
+  (let [extent-id [:batch :rows]
+        shaped (av/tensor {:dtype :float :shape (dialect/extent-shape extent-id)})
+        program
+        (dialect/make
+         (dialect/default-program-facts
+          {:values {extent-id extent 'x shaped 'y shaped}
+           :inputs [extent-id 'x]
+           :equations {'map-0 (dialect/default-equation-facts)}})
+         [(list '= 'map-0 '[y]
+                (list 'map {:index 'i :extent extent-id} '[x] []
+                      (list 'lambda '[x-element] '[(* x-element 2.0)])))]
+         '[y])]
+    (is (= [(list 'value extent-id)] (:shape (get-in (dialect/facts program)
+                                                     [:values 'x]))))))

--- a/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
@@ -1,0 +1,182 @@
+(ns raster.compiler.passes.parallel.typed-soac-fusion-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.soac :as legacy]
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.passes.parallel.soac-dialect-adapter :as adapter]
+            [raster.compiler.passes.parallel.soac-graph :as graph]
+            [raster.compiler.passes.parallel.typed-soac-fusion :as typed-fusion]))
+
+(def ^:private map-map-pairs
+  [['y '(raster.par/map! y i n nil (* (aget x i) (aget x i)))]
+   ['z '(raster.par/map! z j n nil (+ (aget y j) 1.0))]])
+
+(def ^:private map-reduce-pairs
+  [['y '(raster.par/map! y i n nil (* (aget x i) (aget x i)))]
+   ['sum '(raster.par/reduce acc 0.0 j n (+ acc (aget y j)))]])
+
+(def ^:private horizontal-map-pairs
+  [['u '(raster.par/map! u i n nil (* (aget a i) 2.0))]
+   ['v '(raster.par/map! v j n nil (+ (aget b j) 1.0))]])
+
+(def ^:private captured-map-map-pairs
+  [['y '(raster.par/map! y i n nil (* (aget x i) scale))]
+   ['z '(raster.par/map! z j n nil (+ (aget y j) bias))]])
+
+(defn- differential-fusion
+  [pairs outputs]
+  (let [legacy-graph (graph/build-fusion-graph (legacy/let-bindings->nodes pairs))
+        typed-input (adapter/legacy-nodes->program (:nodes legacy-graph)
+                                                   {:outputs outputs :dtype :float})
+        [legacy-fused legacy-stats] (graph/fusion-fixpoint legacy-graph)
+        legacy-result (adapter/legacy-nodes->program (:nodes legacy-fused)
+                                                     {:outputs outputs :dtype :float})
+        [typed-result typed-stats] (typed-fusion/fusion-fixpoint typed-input)]
+    {:legacy-result legacy-result
+     :typed-result typed-result
+     :legacy-stats legacy-stats
+     :typed-stats typed-stats}))
+
+(deftest map-map-fusion-matches-current-graph
+  (let [{:keys [legacy-result typed-result typed-stats]}
+        (differential-fusion map-map-pairs '[z])]
+    (is (= (dialect/equations legacy-result) (dialect/equations typed-result)))
+    (is (= {:vertical 1 :horizontal 0 :iterations 2} typed-stats))
+    (is (= '[n x] (:inputs (dialect/facts typed-result))))
+    (is (not (contains? (:values (dialect/facts typed-result)) 'y)))))
+
+(deftest map-reduce-fusion-matches-current-graph
+  (let [{:keys [legacy-result typed-result typed-stats]}
+        (differential-fusion map-reduce-pairs '[sum])]
+    (is (= (dialect/equations legacy-result) (dialect/equations typed-result)))
+    (is (= {:vertical 1 :horizontal 0 :iterations 2} typed-stats))
+    (is (= 'reduce (first (nth (first (dialect/equations typed-result)) 3))))
+    (is (not-any? #{'y} (flatten (dialect/equations typed-result))))))
+
+(deftest horizontal-map-fusion-matches-current-graph
+  (let [{:keys [legacy-result typed-result typed-stats]}
+        (differential-fusion horizontal-map-pairs '[u v])
+        equation (first (dialect/equations typed-result))
+        lambda (nth (nth equation 3) 4)]
+    (is (= (dialect/equations legacy-result) (dialect/equations typed-result)))
+    (is (= {:vertical 0 :horizontal 1 :iterations 2} typed-stats))
+    (is (= '[u v] (nth equation 2)))
+    (is (= '[%element0 %element1] (second lambda)))
+    (is (= '[(* %element0 2.0) (+ %element1 1.0)] (nth lambda 2)))))
+
+(deftest captured-map-fusion-matches-current-graph
+  (let [{:keys [legacy-result typed-result typed-stats]}
+        (differential-fusion captured-map-map-pairs '[z])
+        equation (first (dialect/equations typed-result))
+        operation (nth equation 3)
+        lambda (nth operation 4)]
+    (is (= (dialect/equations legacy-result) (dialect/equations typed-result)))
+    (is (= {:vertical 1 :horizontal 0 :iterations 2} typed-stats))
+    (is (= '[bias scale] (nth operation 3)))
+    (is (= '[%element0 %capture0 %capture1] (second lambda)))
+    (is (= '[(+ (* %element0 %capture1) %capture0)] (nth lambda 2)))))
+
+(deftest current-graph-rewrites-the-canonical-reduction-region
+  (let [pairs [['tmp '(raster.par/map! tmp i n float (* (aget x i) 2.0))]
+               ['sum '(raster.par/reduce acc 0.0 j n (+ acc (aget tmp j)))]]
+        source-graph (graph/build-fusion-graph (legacy/let-bindings->nodes pairs))
+        [fused _] (graph/fusion-fixpoint source-graph)
+        reduce-node (first (filter legacy/soac-reduce? (vals (:nodes fused))))
+        reconstructed (legacy/soac->par-form reduce-node)]
+    (is (not-any? #{'tmp} (flatten reconstructed))
+        "the eliminated map result cannot survive in ProductReduction")
+    (is (some #{'float} (flatten reconstructed))
+        "the materialized map cast is part of the inlined value semantics")))
+
+(deftest effectful-equations-do-not-fuse
+  (let [legacy-graph (graph/build-fusion-graph (legacy/let-bindings->nodes map-map-pairs))
+        program (adapter/legacy-nodes->program (:nodes legacy-graph)
+                                               {:outputs '[z] :dtype :float})
+        facts (-> (dialect/facts program)
+                  (update-in [:equations 0 :effects] conj :memory/write)
+                  (assoc :effects #{:memory/write}))
+        program (dialect/make facts (dialect/equations program) (dialect/outputs program))
+        [result stats] (typed-fusion/fusion-fixpoint program)]
+    (is (= program result))
+    (is (= {:vertical 0 :horizontal 0 :iterations 1} stats))))
+
+(deftest aliased-equations-decline-unproved-fusion
+  (let [legacy-graph (graph/build-fusion-graph (legacy/let-bindings->nodes map-map-pairs))
+        program (adapter/legacy-nodes->program (:nodes legacy-graph)
+                                               {:outputs '[z] :dtype :float})
+        facts (assoc-in (dialect/facts program) [:equations 0 :aliases] {'y 'x})
+        program (dialect/make facts (dialect/equations program) (dialect/outputs program))
+        [result stats] (typed-fusion/fusion-fixpoint program)]
+    (is (= program result))
+    (is (= {:vertical 0 :horizontal 0 :iterations 1} stats))))
+
+(deftest fusion-preserves-constituent-equation-facts
+  (let [legacy-graph (graph/build-fusion-graph (legacy/let-bindings->nodes map-map-pairs))
+        program (adapter/legacy-nodes->program (:nodes legacy-graph)
+                                               {:outputs '[z] :dtype :float})
+        facts (-> (dialect/facts program)
+                  (assoc-in [:equations 0 :attributes] {:source :producer})
+                  (assoc-in [:equations 1 :attributes] {:source :consumer}))
+        program (dialect/make facts (dialect/equations program) (dialect/outputs program))
+        [result _] (typed-fusion/fusion-fixpoint program)
+        constituents (get-in (dialect/facts result)
+                             [:equations 1 :attributes :fusion/constituents])]
+    (is (= #{0 1} (set (keys constituents))))
+    (is (= {:source :producer} (get-in constituents [0 :attributes])))
+    (is (= {:source :consumer} (get-in constituents [1 :attributes])))))
+
+(deftest adapter-declines-unsupported-soacs
+  (let [scan (legacy/par-form->soac
+              'out '(raster.par/scan out acc 0.0 i n nil (+ acc (aget x i))) 0)]
+    (try
+      (adapter/legacy-nodes->program [scan] {:outputs '[out]})
+      (is false "scan must not be silently projected through the differential subset")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :unsupported-legacy-node (:reason (ex-data exception))))))))
+
+(deftest adapter-declines-arbitrary-scalar-bindings
+  (let [binding (legacy/->ScalarBinding 0 'scale 2.0)]
+    (try
+      (adapter/legacy-nodes->program [binding] {})
+      (is false "the differential adapter must not erase arbitrary scalar computation")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :unsupported-legacy-node (:reason (ex-data exception))))))))
+
+(deftest horizontal-fusion-does-not-move-across-a-late-producer
+  (let [tensor (av/tensor {:dtype :float :shape '[n]})
+        extent (av/tensor {:dtype :long :shape []})
+        equation-facts {'left (dialect/default-equation-facts)
+                        'middle (assoc (dialect/default-equation-facts)
+                                       :effects #{:memory/read})
+                        'right (dialect/default-equation-facts)}
+        program
+        (dialect/make
+         (dialect/default-program-facts
+          {:values {'x tensor 'z tensor 'left-value tensor 'middle-value tensor
+                    'right-value tensor 'n extent}
+           :inputs '[n x z]
+           :equations equation-facts
+           :effects #{:memory/read}})
+         [(list '= 'left '[left-value]
+                (list 'map {:index 'i :extent 'n} '[x] []
+                      (list 'lambda '[x-element] '[(* x-element 2.0)])))
+          (list '= 'middle '[middle-value]
+                (list 'map {:index 'i :extent 'n} '[z] []
+                      (list 'lambda '[z-element] '[(+ z-element 1.0)])))
+          (list '= 'right '[right-value]
+                (list 'map {:index 'i :extent 'n} '[middle-value] []
+                      (list 'lambda '[middle-element] '[(* middle-element 3.0)])))]
+         '[left-value right-value])
+        [result stats] (typed-fusion/fusion-fixpoint program)]
+    (is (= program result))
+    (is (= {:vertical 0 :horizontal 0 :iterations 1} stats))))
+
+(deftest legacy-vertical-fusion-declines-ambiguous-multi-result-map
+  (let [producer (-> (legacy/par-form->soac
+                      'u '(raster.par/map! u i n nil (* (aget x i) 2.0)) 0)
+                     (assoc :outputs #{'u 'v}))
+        consumer (legacy/par-form->soac
+                  'z '(raster.par/map! z j n nil (+ (aget u j) 1.0)) 1)
+        graph (graph/build-fusion-graph [producer consumer])]
+    (is (false? (boolean (graph/can-fuse-vertically? graph 0 1)))
+        "legacy dependency edges do not identify which tuple component was consumed")))


### PR DESCRIPTION
## Summary

- add a Pattern-declared typed functional SOAC program with ordered SSA values, explicit capture binding, AbstractValue contracts, effects, aliases, provenance, and tuple-valued maps
- add fact-preserving map-to-map, map-to-reduce, and horizontal map fusion plus a guarded differential adapter for the current SOAC graph
- correct legacy map-to-reduce substitution so it rewrites the canonical ProductReduction region and preserves materialized casts
- update Pattern to 1.0.452 and record typed SOAC step 1 in the compiler north star

## Verification

- focused published-dependency suite: 79 tests, 231 assertions, all passing
- bounded full suite: 2453 tests, 34425 assertions, 0 failures; one sandbox-only read-only ~/.raster SPIR-V cache error
- affected namespace rerun with normal cache access: 12 tests, 272 assertions, all passing
- Pattern 1.0.452 release suite and CI are green