### PR TITLE
Route typed SOAC reductions through KernelBody

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -52,8 +52,9 @@ Raster is not starting from a toy compiler:
   staged contraction and DP4A-related work.
 
 These pieces are the foundation. The SegOp boundary now uses a first-class typed
-`ParallelProgram`; remaining gaps are concentrated in the earlier SOAC program,
-the scheduled kernel-body representation, duplicated lowering, and string-template seams.
+`ParallelProgram`; its equations can retain a validated functional algorithm beside the ordered
+scheduled operations. Remaining gaps are concentrated in migrating the full earlier SOAC program,
+the remaining scheduled kernel-body representation, duplicated lowering, and string-template seams.
 
 ## 2. The load-bearing gaps
 
@@ -66,6 +67,14 @@ reconstruct scalar host control around them. The `:segop-lowered` validator perf
 operation/type legality check, and source equality invalidates an equation after a backend-local
 rewrite. Direct calls to a backend may still use the explicit, counted compatibility re-lowering
 path.
+
+The first typed vertical is now production-routed for scalar/full reductions. A
+`ProgramEquation` owns the alpha-renamed TypedSOAC program and the SegRed mechanically derived from
+its explicit lambda parameters, operands, extent, result, dtype and algebra facts. JVM SIMD consumes
+that SegRed. The GPU schedules eligible scalar regions as one verified workgroup-tree `KernelBody`
+with typed scalar SSA, stable reads, workgroup allocation, masks, barriers and an ordered result ABI;
+the same body emits as OpenCL, CUDA and HIP and is compiled by the hardware-free vendor CI gates.
+Unsupported scalar regions decline explicitly to the established verified SegRed OpenCL emitter.
 
 The remaining nominal boundary is earlier: SOAC fusion still constructs records and a dependency
 graph from source-shaped S-expressions, rewrites them, and reconstructs `par` forms before the typed
@@ -731,8 +740,9 @@ The immediate continuation after the verified double-buffered weighted-reduction
 
 1. **Landed:** define a typed SOAC S-expression dialect with `../pattern` and differential-test
    map→map, map→reduce and horizontal-map fusion against the current graph.
-2. Carry that dialect in the existing program/value envelope and route one ordinary fused reduction
-   through JVM SIMD and GPU `KernelBody` without reconstructing compiler facts from source spelling.
+2. **Landed:** carry that dialect in the existing program/value envelope and route one ordinary
+   fused reduction through JVM SIMD and GPU `KernelBody` without reconstructing compiler facts from
+   source spelling.
 3. Add a finite verified shared-memory swizzle family and bank-conflict/resource model.
 4. Make stage count and swizzle measured schedule axes, retire the legacy tuner, and remove the
    attention-provenance gate from the generic weighted-reduction matcher.

--- a/src/raster/compiler/backend/gpu/kernel_body_c_dialect.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_c_dialect.clj
@@ -83,11 +83,13 @@
   (if (opencl? dialect)
     (case source
       :group (str "get_group_id(" axis ")")
+      :group-count (str "get_num_groups(" axis ")")
       :local (str "get_local_id(" axis ")")
       :subgroup "get_sub_group_id()"
       :lane "get_sub_group_local_id()")
     (case source
       :group (str "blockIdx." (nth axis-name axis))
+      :group-count (str "gridDim." (nth axis-name axis))
       :local (str "threadIdx." (nth axis-name axis))
       :subgroup (str "(" (linear-thread-id) " / " subgroup-width ")")
       :lane (str "(" (linear-thread-id) " % " subgroup-width ")"))))

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -429,7 +429,8 @@
             (let [{:keys [out-buf reduce-form]} (par/extract-par-reduce-into-info form)
                   segred (par->segred stats reduce-form dtype device-id)
                   kernel (segop-cl/generate-segred-kernel
-                          segred out-buf :dtype dtype :scalar-types top-scalar-types)
+                          segred out-buf :dtype dtype :scalar-types top-scalar-types
+                          :array-types top-array-types)
                   k (register-kernel! kernel :ze-reduces)]
               (emit-reduction-invocation k out-buf))
 
@@ -441,7 +442,8 @@
                     (par/expand-par-reduce form))
                 (let [segred (par->segred stats form dtype device-id)
                       kernel (segop-cl/generate-segred-kernel
-                              segred nil :dtype dtype :scalar-types top-scalar-types)
+                              segred nil :dtype dtype :scalar-types top-scalar-types
+                              :array-types top-array-types)
                       k (register-kernel! kernel :ze-reduces)]
                   (emit-reduction-invocation k nil))))
 

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -8,6 +8,7 @@
    This is the GPU counterpart to segop_simd.clj — both consume the
    same SegOp IR but produce different target code."
   (:require [raster.compiler.backend.gpu.kernel-body-opencl :as kernel-body-opencl]
+            [raster.compiler.backend.gpu.kernel-body-c-dialect :as kernel-body-c-dialect]
             [raster.compiler.backend.gpu.opencl-codegen :as codegen]
             [raster.compiler.backend.gpu.c-emit :as ce]
             [raster.compiler.core.op-descriptor :as descriptor]
@@ -24,6 +25,7 @@
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.reduction :as reduction]
+            [raster.compiler.passes.parallel.segred-body :as segred-body]
             [clojure.walk :as walk]
             [clojure.set]
             [raster.compiler.ir.segop :as segop]
@@ -388,6 +390,62 @@
                    :component-dtypes (reduction/dtypes operator)
                    :schedule schedule}})))
 
+(defn generate-segred-kernel-body
+  "Lower an eligible scalar SegRed through verified KernelBody and a thin C-family dialect.
+
+   This function is public so CUDA/HIP compiler fixtures can validate the exact same scheduled
+   body without a device. It throws only structured `:segred-kernel-body-declined` exceptions for
+   unsupported scalar regions; verified-body or emitter failures remain compiler errors."
+  [segred out-sym & {:keys [dtype kernel-name-prefix scalar-types array-types target-dialect]
+                     :or {dtype :double kernel-name-prefix "par_reduce" scalar-types {}
+                          array-types {} target-dialect :opencl-intel}}]
+  (let [{:keys [kernel-body operator identity arrays scalars output bound]}
+        (segred-body/lower segred out-sym :dtype dtype :array-types array-types
+                           :scalar-types scalar-types)
+        dtype (or (:dtype segred) dtype)
+        kernel-name (str kernel-name-prefix "_" (gensym ""))
+        parameter-names (into {output "output" '_n_bound "_n_bound"}
+                              (map (fn [id] [id (ce/c-symbol id)]))
+                              (concat arrays scalars))
+        source (kernel-body-opencl/emit-scalar-kernel
+                kernel-name kernel-body
+                {:target-dialect target-dialect :parameter-names parameter-names})
+        scalar-dtype (fn [id]
+                       (or (get scalar-types id)
+                           (get scalar-types (symbol (name id)))
+                           dtype))
+        result-name (or out-sym 'output)
+        abi (kabi/validate!
+             (vec (concat
+                   (map #(kabi/slot % :input dtype :c-name (ce/c-symbol %) :role :operand
+                                    :aliasing :no-write-alias)
+                        arrays)
+                   [(kabi/slot result-name :output dtype :c-name "output" :role :result)]
+                   (map #(kabi/slot % :scalar (scalar-dtype %)
+                                    :c-name (ce/c-symbol %) :role :parameter)
+                        scalars)
+                   [(kabi/slot '_n_bound :scalar :int :role :bound)])))
+        c-op ({:+ "+" :* "*" :min "fmin" :max "fmax"} operator)]
+    (kart/make
+     {:kernel-name kernel-name
+      :target (kernel-body-c-dialect/target (kernel-body-c-dialect/resolve! target-dialect))
+      :source source
+      :abi abi
+      :arguments (vec (concat arrays [out-sym] scalars [bound]))
+      :launch (:launch kernel-body)
+      :temporaries []
+      :effects {:kind :pure-reduction}
+      :provenance {:dialect :segred :segop-id (:id segred)}
+      :attributes {:array-params arrays
+                   :scalar-params scalars
+                   :dtype dtype
+                   :n-phases 2
+                   :identity-val identity
+                   :c-op c-op
+                   :kernel-body kernel-body
+                   :emission-route :kernel-body
+                   :target-dialect target-dialect}})))
+
 (defn generate-segred-kernel
   "Generate OpenCL C reduction kernels from a SegRed record.
 
@@ -402,9 +460,21 @@
    `out-sym` is nil for the host-scalar staging protocol: the ordered :arguments vector then
    carries nil at the single :result slot, which the runtime replaces with its partial-results
    buffer.  Resident reduce-into supplies the real output buffer symbol at that same ABI position."
-  [segred out-sym & {:keys [dtype kernel-name-prefix scalar-types]
-                     :or {dtype :double kernel-name-prefix "par_reduce" scalar-types {}}}]
-  (let [idx (seg-idx segred)
+  [segred out-sym & {:keys [dtype kernel-name-prefix scalar-types array-types target-dialect]
+                     :or {dtype :double kernel-name-prefix "par_reduce" scalar-types {}
+                          array-types {} target-dialect :opencl-intel}}]
+  (let [kernel-body-attempt
+        (try
+          {:artifact
+           (generate-segred-kernel-body
+            segred out-sym :dtype dtype :kernel-name-prefix kernel-name-prefix
+            :scalar-types scalar-types :array-types array-types :target-dialect target-dialect)}
+          (catch clojure.lang.ExceptionInfo exception
+            (when-not (segred-body/declined? exception) (throw exception))
+            {:decline (ex-data exception)}))]
+    (or
+     (:artifact kernel-body-attempt)
+     (let [idx (seg-idx segred)
         bound (seg-bound segred)
         {:keys [acc init lambda]} (segop/scalar-reduce-op segred)
         ;; #55 fix: normalize devirtualized array prims ((.invk aget-impl arr i)
@@ -580,7 +650,9 @@
                    :dtype dtype
                    :n-phases 2
                    :identity-val identity-val
-                   :c-op c-op}})))
+                   :c-op c-op
+                   :emission-route :verified-segred-opencl
+                   :kernel-body-decline (:decline kernel-body-attempt)}})))))
 
 ;; ================================================================
 ;; KernelGraph scan → OpenCL KernelArtifacts

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -65,7 +65,7 @@
             schedule launch provenance attributes])
 
 (def ^:private parameter-kinds #{:input :output :scalar})
-(def ^:private index-sources #{:group :local :subgroup :lane})
+(def ^:private index-sources #{:group :group-count :local :subgroup :lane})
 (def ^:private index-ops #{:add :sub :mul :floor-div :ceil-div :mod :min :max})
 (def ^:private predicate-ops #{:lt :lte :eq :and :or :not})
 (def ^:private cache-policies #{:default :cached :streaming})
@@ -1673,7 +1673,7 @@
                (when-not (and (contains? index-sources (:source idx))
                               (integer? (:axis idx))
                               (case (:source idx)
-                                (:group :local) (< -1 (:axis idx) launch-dimensions)
+                                (:group :group-count :local) (< -1 (:axis idx) launch-dimensions)
                                 (:subgroup :lane) (zero? (:axis idx))))
                  (throw (ex-info "kernel index binding has an invalid hardware source" {:index idx})))
 
@@ -1813,7 +1813,7 @@
                (let [uniformity
                      (if (record-kind? "raster.compiler.ir.kernel_body.IndexBinding" idx)
                        (case (:source idx)
-                         :group all-uniform
+                         (:group :group-count) all-uniform
                          :local lane-varying
                          :subgroup subgroup-uniform
                          :lane lane-varying)

--- a/src/raster/compiler/ir/parallel_program.clj
+++ b/src/raster/compiler/ir/parallel_program.clj
@@ -8,7 +8,7 @@
   (:require [raster.compiler.ir.abstract-value :as av]))
 
 (defrecord ProgramEquation
-           [id site source operands results operations effects provenance attributes])
+           [id site source operands results algorithm operations effects provenance attributes])
 
 (defrecord ParallelProgram
            [dialect source values inputs equations outputs effects diagnostics provenance attributes])
@@ -32,10 +32,13 @@
 (defn validate!
   "Validate a ParallelProgram and return it unchanged.
 
-   `operation?`, when supplied, defines full legality for the declared dialect.  Structural
-   validation remains independent of any concrete SOAC/SegOp namespace, avoiding an IR cycle."
-  ([program] (validate! program (constantly true)))
-  ([program operation?]
+   `operation?`, when supplied, defines full legality for the declared scheduled dialect.
+   `algorithm?` receives `[equation algorithm]`, so a caller can validate an optional semantic
+   dialect and its boundary. Structural validation remains independent of concrete SOAC/SegOp
+   namespaces, avoiding an IR cycle."
+  ([program] (validate! program (constantly true) (fn [_ _] true)))
+  ([program operation?] (validate! program operation? (fn [_ _] true)))
+  ([program operation? algorithm?]
    (when-not (parallel-program? program)
      (throw (ex-info "expected a ParallelProgram"
                      {:reason :parallel-program-type :actual (type program)})))
@@ -88,6 +91,13 @@
            (throw (ex-info "an illegal operation remains after full dialect conversion"
                            {:reason :illegal-op-remains :target-dialect dialect
                             :equation (:id equation) :operation operation :fallback :none}))))
+       (when (and (some? (:algorithm equation))
+                  (not (algorithm? equation (:algorithm equation))))
+         (throw (ex-info "equation contains an illegal algorithm value"
+                         {:reason :parallel-program-algorithm
+                          :target-dialect dialect
+                          :equation (:id equation)
+                          :algorithm (:algorithm equation)})))
        (when-not (set? (:effects equation))
          (throw (ex-info "equation effects must be an explicit set"
                          {:reason :parallel-program-effects :equation (:id equation)})))
@@ -112,11 +122,13 @@
    program))
 
 (defn make
-  [{:keys [dialect source values inputs equations outputs effects diagnostics provenance attributes]
+  [{:keys [dialect source values inputs equations outputs effects diagnostics provenance attributes
+           operation? algorithm?]
     :or {values {} inputs [] equations [] outputs [] effects #{} diagnostics []
-         provenance {} attributes {}}}]
+         provenance {} attributes {} operation? (constantly true) algorithm? (fn [_ _] true)}}]
   (validate! (->ParallelProgram dialect source values (vec inputs) (vec equations) (vec outputs)
-                                effects (vec diagnostics) provenance attributes)))
+                                effects (vec diagnostics) provenance attributes)
+             operation? algorithm?))
 
 (defn source-form
   "The compatibility host expression surrounding the explicit parallel equations."
@@ -141,6 +153,10 @@
   [program sym source]
   (:operations (equation-for-binding program sym source)))
 
+(defn algorithm-for-binding
+  [program sym source]
+  (:algorithm (equation-for-binding program sym source)))
+
 (defn result-id-for-binding
   "The explicit value ID produced by a binding equation, when it has one result."
   [program sym source]
@@ -149,6 +165,10 @@
 (defn operations-for-source
   [program source]
   (:operations (equation-for-source program source)))
+
+(defn algorithm-for-source
+  [program source]
+  (:algorithm (equation-for-source program source)))
 
 (defn kernel-graph-for-binding
   [program sym source]

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -3,8 +3,8 @@
 
    The expression spine is deliberately small and pattern-friendly.  Stable value/equation
    identity and compiler facts live in the explicit program envelope, never in Clojure metadata.
-   This namespace does not replace ParallelProgram yet; it is the verified dialect boundary that
-   the next vertical will carry in that existing envelope.
+   ParallelProgram equations retain this verified functional program as their semantic algorithm;
+   scheduled SegOps remain a separate ordered field.
 
    Canonical forms:
 
@@ -38,6 +38,10 @@
   [value]
   (or (integer? value) (value-id? value)))
 
+(defn extent?
+  [value]
+  (or (value-id? value) (and (integer? value) (not (neg? value)))))
+
 (defn scalar-literal?
   [value]
   (or (nil? value)
@@ -52,13 +56,16 @@
    AbstractValue dimensions already accept symbolic S-expressions. Compound stable IDs therefore
    use an explicit `(value id)` dimension instead of being confused with shape structure."
   [extent]
-  [(if (symbol? extent) extent (list 'value extent))])
+  [(cond
+     (integer? extent) extent
+     (symbol? extent) extent
+     :else (list 'value extent))])
 
 (defn map-attributes?
   [value]
   (and (map? value)
        (symbol? (:index value))
-       (value-id? (:extent value))
+       (extent? (:extent value))
        (or (nil? (:attributes value)) (map? (:attributes value)))))
 
 (defn reduce-attributes?
@@ -116,6 +123,7 @@
           (do (?:+ s))
           (let* [(?:* ?sym:binding ?s:init)] ?s:body)
           [(?:* s)]
+          (.invk ?sym:impl (?:* s:args))
           (& (?sym:f (?:* s:args)) (? _ seq?)))
 
   (Lambda [l :enforce]
@@ -318,8 +326,9 @@
     (let [definitions (mapcat #(nth % 2) equations)
           definition-set (set definitions)
           references (set (mapcat (fn [equation]
-                                    (conj (operation-inputs equation)
-                                          (operation-extent equation)))
+                                    (cond-> (operation-inputs equation)
+                                      (value-id? (operation-extent equation))
+                                      (conj (operation-extent equation))))
                                   equations))
           external (set/difference references definition-set)
           total-effects (reduce set/union #{}
@@ -340,8 +349,9 @@
              [equation & remaining] equations]
         (when equation
           (let [equation-id (second equation)
-                required (conj (set (operation-inputs equation))
-                               (operation-extent equation))
+                required (cond-> (set (operation-inputs equation))
+                           (value-id? (operation-extent equation))
+                           (conj (operation-extent equation)))
                 missing (set/difference required available)]
             (when (seq missing)
               (fail! :typed-soac-use-before-definition
@@ -360,6 +370,59 @@
   "Construct and validate a typed SOAC program."
   [program-facts equation-forms program-outputs]
   (validate! (list 'soac-program program-facts (vec equation-forms) (vec program-outputs))))
+
+(defn remap-values
+  "Alpha-rename stable value IDs throughout a TypedSOAC program.
+
+   Lambda parameters are lexical binders and are deliberately untouched. This is the bridge used
+   when a typed algorithm enters ParallelProgram's SSA envelope: logical source binders become the
+   envelope's authoritative value IDs without reparsing the scalar region or losing its facts."
+  [program value-map]
+  (let [program (validate! program)
+        rename #(get value-map % %)
+        rename-dimension
+        (fn [dimension]
+          (cond
+            (contains? value-map dimension)
+            (let [id (rename dimension)]
+              (if (symbol? id) id (list 'value id)))
+
+            (and (seq? dimension) (= 'value (first dimension)) (= 2 (count dimension))
+                 (contains? value-map (second dimension)))
+            (list 'value (rename (second dimension)))
+
+            :else dimension))
+        rename-value (fn [value] (update value :shape #(mapv rename-dimension %)))
+        source-facts (facts program)
+        values (reduce-kv (fn [result id value]
+                            (let [id' (rename id)]
+                              (when (contains? result id')
+                                (fail! :typed-soac-remap-collision
+                                       "value remapping collapses distinct TypedSOAC IDs"
+                                       {:target id' :mapping value-map}))
+                              (assoc result id' (rename-value value))))
+                          {} (:values source-facts))
+        equation-forms
+        (mapv (fn [[equals equation-id results operation]]
+                (let [[kind attributes arrays captures lambda] operation]
+                  (list equals equation-id (mapv rename results)
+                        (list kind (update attributes :extent
+                                           #(if (value-id? %) (rename %) %))
+                              (mapv rename arrays) (mapv rename captures) lambda))))
+              (equations program))
+        rename-aliases
+        (fn [aliases]
+          (into {} (map (fn [[left right]] [(rename left) (rename right)])) aliases))
+        equation-facts
+        (into {}
+              (map (fn [[id equation-facts]]
+                     [id (update equation-facts :aliases rename-aliases)]))
+              (:equations source-facts))
+        facts' (assoc source-facts
+                      :values values
+                      :inputs (mapv rename (:inputs source-facts))
+                      :equations equation-facts)]
+    (make facts' equation-forms (mapv rename (outputs program)))))
 
 (defn default-equation-facts
   ([] (default-equation-facts {}))

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -10,8 +10,12 @@
    - Backend translates SegOp to target code (SIMD, OpenCL, scalar)"
   (:require [raster.compiler.ir.par :as par]
             [raster.compiler.ir.soac :as soac]
+            [raster.compiler.ir.soac-dialect :as soac-dialect]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.parallel-program :as program]
+            [raster.compiler.ir.reduction :as reduction]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.passes.parallel.soac-dialect-adapter :as soac-adapter]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
             [raster.compiler.ir.form :as form]
             [clojure.set :as set]))
@@ -79,15 +83,32 @@
                                           device-id dtype)})
 
         :else
-        (let [segops (attempt #(soac-lower/lower-soac (:ok soac) (or device-id :cpu:0)
-                                                      :dtype (or dtype :double)))]
+        (let [legacy-node (:ok soac)
+              typed? (and (soac/soac-reduce? legacy-node)
+                          (empty? (:segment-axes legacy-node))
+                          (reduction/scalar? (:reduction legacy-node))
+                          ;; TypedSOAC deliberately names extents with stable values (or static
+                          ;; literals). Older source-shaped bounds such as `(alength x)` remain on
+                          ;; the compatibility route until bound expressions have their own SSA
+                          ;; equation; do not smuggle executable host forms into the typed dialect.
+                          (soac-dialect/extent? (:bound legacy-node)))
+              algorithm (when typed?
+                          (soac-adapter/legacy-nodes->program
+                           [legacy-node] {:outputs (:outputs legacy-node)
+                                          :dtype (or dtype :double)
+                                          :array-types array-types}))
+              segops (attempt #(if algorithm
+                                 (soac-lower/lower-typed-reduce
+                                  algorithm (or device-id :cpu:0) :dtype (or dtype :double))
+                                 (soac-lower/lower-soac legacy-node (or device-id :cpu:0)
+                                                        :dtype (or dtype :double))))]
           (cond
             (:err segops) (decline :segop (:err segops))
-            (seq (:ok segops)) (cond-> {:soac (:ok soac) :segops (:ok segops)}
-                                 (soac-lower/scan-soac? (:ok soac))
+            (seq (:ok segops)) (cond-> {:soac legacy-node :algorithm algorithm :segops (:ok segops)}
+                                 (soac-lower/scan-soac? legacy-node)
                                  (assoc :kernel-graph
                                         (soac-lower/scan-kernel-graph
-                                         (:ok soac) (:ok segops) {:array-types array-types})))
+                                         legacy-node (:ok segops) {:array-types array-types})))
             :else (when par? {:declined (diagnostic sym form :segop
                                                     (ex-info "lower-soac produced no SegOps" {})
                                                     device-id dtype)})))))))
@@ -122,8 +143,11 @@
                 :effects #{}})))
 
 (defn- equation
-  [equation-id site sym source {:keys [soac segops kernel-graph]} dtype array-types]
-  (let [operands (-> (soac/node-all-free-syms soac) (disj sym) (->> (sort-by str) vec))
+  [equation-id site sym source {:keys [soac algorithm segops kernel-graph]} dtype array-types]
+  (let [;; Body-position equations currently have no ParallelProgram result ID; retain the typed
+        ;; algorithm only where its result has an authoritative envelope identity.
+        algorithm (when (= :binding (first site)) algorithm)
+        operands (-> (soac/node-all-free-syms soac) (disj sym) (->> (sort-by str) vec))
         result-ids (if (= :binding (first site)) [sym] [])
         effects (cond-> #{:memory/read}
                   (seq (soac/soac-outputs soac)) (conj :memory/write))
@@ -136,7 +160,7 @@
                                    [id (value-contract id soac dtype array-types true)]))
                             result-ids)
         eq (program/->ProgramEquation
-            equation-id site source operands result-ids (vec segops) effects
+            equation-id site source operands result-ids algorithm (vec segops) effects
             {:source-dialect :soac :target-dialect :segop :soac-id (:id soac)}
             (cond-> {:device (:device-id (first segops))}
               kernel-graph (assoc :kernel-graph kernel-graph)))]
@@ -195,8 +219,12 @@
                            (merge-values values {value-id (get result-values source-id)}))
                          values-with-operands
                          (map vector source-results results))
+                 value-remap (into (zipmap source-results results)
+                                   (map vector (:operands equation) operands))
+                 algorithm' (when-let [algorithm (:algorithm equation)]
+                              (soac-dialect/remap-values algorithm value-remap))
                  equation' (-> equation
-                               (assoc :operands operands :results results)
+                               (assoc :operands operands :results results :algorithm algorithm')
                                (update :attributes assoc :source-results source-results))]
              (-> state
                  (assoc :values values-with-results)
@@ -219,7 +247,13 @@
       :effects effects
       :diagnostics declined
       :provenance {:pass :segop-lower :device (or device-id :cpu:0) :dtype (or dtype :double)}
-      :attributes {:host-control :source-expression}})))
+      :attributes {:host-control :source-expression}
+      :operation? segop/segop-node?
+      :algorithm? (fn [equation algorithm]
+                    (and (soac-dialect/program-form? algorithm)
+                         (= algorithm (soac-dialect/validate! algorithm))
+                         (= (:operands equation) (:inputs (soac-dialect/facts algorithm)))
+                         (= (:results equation) (soac-dialect/outputs algorithm))))})))
 
 (defn segop-lower-pass
   "Pipeline pass: convert par forms in let* bindings to SegOp records.

--- a/src/raster/compiler/passes/parallel/segred_body.clj
+++ b/src/raster/compiler/passes/parallel/segred_body.clj
@@ -1,0 +1,348 @@
+(ns raster.compiler.passes.parallel.segred-body
+  "Schedule an ordinary scalar SegRed as target-neutral KernelBody data.
+
+   This first production slice deliberately models the same portable workgroup tree used by the
+   established OpenCL emitter: occupancy-capped workgroups, a per-lane sequential chunk, identity
+   padding, workgroup scratch, a barrier-separated binary tree, and one partial result per
+   workgroup. Scalar expressions become typed SSA operations; target emitters never recover either
+   the algorithm or schedule from Clojure source spelling. Unsupported scalar regions decline
+   structurally to the established emitter."
+  (:require [raster.compiler.backend.intrinsics :as intrinsics]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.layout :as layout]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.util :as util]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.segop :as segop]))
+
+(def ^:private associative-operators #{:+ :* :min :max})
+(def ^:private cast-heads
+  {'byte :byte, 'clojure.core/byte :byte
+   'int :int, 'clojure.core/int :int
+   'long :long, 'clojure.core/long :long
+   'float :float, 'clojure.core/float :float
+   'double :double, 'clojure.core/double :double})
+
+(defn- decline!
+  [rule message data]
+  (throw (ex-info message (assoc data
+                                 :reason :segred-kernel-body-declined
+                                 :missing-rule rule
+                                 :fallback :verified-segred-opencl))))
+
+(defn declined?
+  [exception]
+  (= :segred-kernel-body-declined (:reason (ex-data exception))))
+
+(defn- inline-scalar-bindings
+  [expression]
+  (if (and (seq? expression) (contains? #{'let 'let*} (first expression)))
+    (let [[_ bindings & body] expression
+          initializers (vec (take-nth 2 (rest bindings)))]
+      (when-not (= 1 (count body))
+        (decline! :multi-expression-let
+                  "KernelBody scalar reduction requires a single-expression let region"
+                  {:expression expression}))
+      (when (some util/effectful? initializers)
+        (decline! :effectful-scalar-binding
+                  "KernelBody scalar reduction cannot inline effectful scalar bindings"
+                  {:expression expression}))
+      (recur (util/subst-syms (util/binding-env bindings) (first body))))
+    expression))
+
+(defn- accumulator-use?
+  [accumulator expression]
+  (or (= accumulator expression)
+      (and (seq? expression)
+           (contains? (set (keys cast-heads)) (first expression))
+           (= 2 (count expression))
+           (= accumulator (second expression)))))
+
+(defn scalar-plan
+  "Project one scalar SegRed into an explicit combine operator, identity and element expression."
+  [segred]
+  (let [{:keys [acc init lambda]} (segop/scalar-reduce-op segred)
+        expression (inline-scalar-bindings lambda)
+        operator (when (seq? expression)
+                   (intrinsics/canonical (descriptor/semantic-op expression)))
+        arguments (vec (when (seq? expression) (descriptor/call-args expression)))]
+    (when-not (and acc (some? init) (contains? associative-operators operator)
+                   (= 2 (count arguments)))
+      (decline! :scalar-combine
+                "KernelBody reduction requires a binary associative scalar combine"
+                {:segred-id (:id segred) :accumulator acc :identity init
+                 :operator operator :arguments arguments :lambda lambda}))
+    (let [[left right] arguments
+          left-accumulator? (accumulator-use? acc left)
+          right-accumulator? (accumulator-use? acc right)
+          element (if left-accumulator? right left)]
+      (when (= left-accumulator? right-accumulator?)
+        (decline! :accumulator-position
+                  "KernelBody reduction combine does not contain its accumulator exactly once"
+                  {:segred-id (:id segred) :accumulator acc :arguments arguments}))
+      {:operator operator :identity init :element element :accumulator acc})))
+
+(defn- literal-value
+  [value]
+  (case value
+    Double/POSITIVE_INFINITY Double/POSITIVE_INFINITY
+    Double/NEGATIVE_INFINITY Double/NEGATIVE_INFINITY
+    Float/POSITIVE_INFINITY Float/POSITIVE_INFINITY
+    Float/NEGATIVE_INFINITY Float/NEGATIVE_INFINITY
+    value))
+
+(defn- launch-group-count
+  "Translate SegRed's historical capped-grid expression into inspectable launch IR.
+
+   `compute-launch-params` predates KernelLaunch and represents the reduction grid as
+   `(min occupancy-cap (int (Math/ceil (/ (double bound) block-size))))`.  Do not carry that
+   executable host form into KernelBody: recognize the exact producer contract and rebuild it
+   from the authoritative SegSpace bound and workgroup size."
+  [grid-expression bound workgroup-size]
+  (cond
+    (and (integer? grid-expression) (pos? grid-expression))
+    grid-expression
+
+    (symbol? grid-expression)
+    (launch/runtime-value grid-expression)
+
+    (and (seq? grid-expression)
+         (contains? '#{min clojure.core/min} (first grid-expression))
+         (= 3 (count grid-expression))
+         (integer? (second grid-expression))
+         (pos? (second grid-expression)))
+    (launch/minimum (second grid-expression)
+                    (launch/ceil-div bound workgroup-size))
+
+    :else
+    (decline! :launch-grid
+              "KernelBody scalar reduction requires an explicit or canonical capped SegRed grid"
+              {:grid-expression grid-expression :bound bound
+               :workgroup-size workgroup-size})))
+
+(defn- strip-index-cast
+  [expression]
+  (if (and (seq? expression)
+           (contains? #{'int 'long 'clojure.core/int 'clojure.core/long} (first expression))
+           (= 2 (count expression)))
+    (second expression)
+    expression))
+
+(defn- element-operations
+  [expression {:keys [index coordinate dtype arrays scalars]}]
+  (let [operations (atom [])
+        counter (atom 0)
+        fresh (fn [prefix] (symbol (str prefix "-" (swap! counter inc))))
+        emit! (fn [operation result]
+                (swap! operations conj operation)
+                result)]
+    (letfn [(lower [expression]
+              (let [expression (inline-scalar-bindings expression)]
+                (cond
+                  (number? expression)
+                  (body/literal expression dtype)
+
+                  (symbol? expression)
+                  (if (contains? scalars expression)
+                    expression
+                    (decline! :unbound-scalar
+                              "KernelBody element expression references an undeclared scalar"
+                              {:expression expression :scalars scalars}))
+
+                  (descriptor/aget-call? expression)
+                  (let [arguments (vec (descriptor/call-args expression))
+                        array (descriptor/aget-array-sym expression)
+                        source-coordinate (some-> (last arguments) strip-index-cast)]
+                    (when-not (and (= 2 (count arguments))
+                                   (contains? arrays array)
+                                   (= index source-coordinate))
+                      (decline! :indexed-load
+                                "initial KernelBody reduction supports pointwise array loads"
+                                {:expression expression :array array :coordinate source-coordinate
+                                 :index index :arrays arrays}))
+                    (let [result (fresh "element-load")]
+                      (emit! (body/->ScalarLoad (body/value result dtype) array [coordinate]
+                                                nil nil :cached)
+                             result)))
+
+                  (and (seq? expression) (contains? cast-heads (first expression))
+                       (= 2 (count expression)))
+                  (let [target (get cast-heads (first expression))]
+                    (when-not (= (dtype/canon target) (dtype/canon dtype))
+                      (decline! :scalar-cast
+                                "initial KernelBody reduction requires element casts to its dtype"
+                                {:expression expression :source-dtype dtype :target-dtype target}))
+                    (lower (second expression)))
+
+                  (seq? expression)
+                  (let [operator (intrinsics/canonical (descriptor/semantic-op expression))
+                        descriptor (intrinsics/descriptor operator)
+                        arguments (vec (descriptor/call-args expression))]
+                    (when-not (and descriptor
+                                   (= (:arity descriptor) (count arguments))
+                                   (intrinsics/accepts-scalar-dtype? operator dtype)
+                                   (not= :cmp (:kind descriptor)))
+                      (decline! :scalar-expression
+                                "KernelBody element expression contains an unsupported scalar operation"
+                                {:expression expression :operator operator :dtype dtype}))
+                    (let [inputs (mapv lower arguments)
+                          result (fresh "element-value")]
+                      (emit! (body/->ScalarCompute
+                              (body/value result dtype)
+                              (body/scalar-expression operator dtype inputs))
+                             result)))
+
+                  :else
+                  (decline! :scalar-expression
+                            "KernelBody element expression has an unsupported value"
+                            {:expression expression :type (type expression)}))))]
+      (let [result (lower expression)]
+        {:operations @operations :result result}))))
+
+(defn lower
+  "Lower an eligible scalar SegRed to one verified portable workgroup-tree KernelBody.
+
+   `array-types` and `scalar-types` are authoritative ABI facts. This vertical initially accepts
+   the uniform-dtype storage contract already implemented by the scalar SegRed runtime."
+  [segred out-sym & {:keys [dtype array-types scalar-types]
+                     :or {dtype :double array-types {} scalar-types {}}}]
+  (let [dtype (or (:dtype segred) dtype)
+        index (:name (segop/seg-space-reduced-dim (:space segred)))
+        bound (:bound (segop/seg-space-reduced-dim (:space segred)))
+        workgroup-size (get-in segred [:grid :block-size])
+        arrays (vec (sort-by name (:inputs segred)))
+        scalars (vec (sort-by name (:scalars segred)))
+        scalar-dtype (fn [id] (or (get scalar-types id)
+                                  (get scalar-types (symbol (name id))) dtype))
+        array-dtype (fn [id] (or (get array-types id)
+                                 (get array-types (symbol (name id))) dtype))
+        _ (when-not (and (contains? #{:float :double} (dtype/canon dtype))
+                         (integer? workgroup-size) (pos? workgroup-size)
+                         (zero? (bit-and workgroup-size (dec workgroup-size)))
+                         (or (and (integer? bound) (pos? bound)) (symbol? bound))
+                         (every? #(= (dtype/canon dtype) (dtype/canon (array-dtype %))) arrays)
+                         (every? #(= (dtype/canon dtype) (dtype/canon (scalar-dtype %))) scalars))
+            (decline! :uniform-scalar-storage
+                      "KernelBody scalar reduction requires a static power-of-two workgroup and uniform scalar storage"
+                      {:segred-id (:id segred) :dtype dtype :bound bound
+                       :workgroup-size workgroup-size :arrays arrays :scalars scalars}))
+        {:keys [operator identity element]} (scalar-plan segred)
+        identity (literal-value identity)
+        _ (when-not (number? identity)
+            (decline! :literal-identity
+                      "KernelBody scalar reduction requires a numeric identity"
+                      {:segred-id (:id segred) :identity identity}))
+        element-index 'element-index
+        lane-accumulator 'lane-accumulator
+        next-lane-accumulator 'next-lane-accumulator
+        lane-result 'lane-result
+        {:keys [operations result]}
+        (element-operations element {:index index :coordinate element-index :dtype dtype
+                                     :arrays (set arrays) :scalars (set scalars)})
+        output (or out-sym 'output)
+        group-count (launch-group-count (get-in segred [:grid :num-blocks])
+                                        bound workgroup-size)
+        scratch 'workgroup-reduction-scratch
+        barrier (fn [] (body/->WorkgroupBarrier
+                        :workgroup #{:workgroup} :acquire-release (body/full-participation)))
+        tree-stages
+        (mapcat
+         (fn [stride]
+           (let [mask (keyword (str "reduce-stride-" stride))
+                 left (symbol (str "tree-left-" stride))
+                 right (symbol (str "tree-right-" stride))
+                 combined (symbol (str "tree-combined-" stride))]
+             [(body/->ScalarLoad (body/value left dtype) scratch ['local-index]
+                                 mask (body/literal identity dtype) :cached)
+              (body/->ScalarLoad
+               (body/value right dtype) scratch
+               [(body/expression :add 'local-index stride)]
+               mask (body/literal identity dtype) :cached)
+              (body/->ScalarCompute
+               (body/value combined dtype)
+               (body/scalar-expression operator dtype [left right]))
+              (body/->ScalarStore scratch ['local-index] combined mask)
+              (barrier)]))
+         (take-while pos? (iterate #(quot % 2) (quot workgroup-size 2))))
+        final-value 'workgroup-result
+        parameters
+        (vec (concat
+              (map #(body/->KernelParameter
+                     % :input dtype [bound] :global (layout/row-major [bound] dtype) :operand)
+                   arrays)
+              [(body/->KernelParameter output :output dtype ['partial-count] :global
+                                       (layout/row-major ['partial-count] dtype) :result)]
+              (map #(body/->KernelParameter % :scalar (scalar-dtype %) [] nil nil :parameter)
+                   scalars)
+              [(body/->KernelParameter '_n_bound :scalar :int [] nil nil :bound)]))
+        kernel-body
+        (body/make
+         {:id [:segred (:id segred) :workgroup-tree]
+          :parameters parameters
+          :stable-reads (mapv body/stable-read arrays)
+          :allocations [(body/->WorkgroupAllocation
+                         scratch dtype [workgroup-size]
+                         (layout/row-major [workgroup-size] dtype)
+                         (dtype/bytes-of dtype))]
+          :indices [(body/->IndexBinding 'group-index :group 0)
+                    (body/->IndexBinding 'group-count :group-count 0)
+                    (body/->IndexBinding 'local-index :local 0)
+                    (body/->IndexCompute
+                     'group-chunk
+                     (body/expression :ceil-div '_n_bound 'group-count))
+                    (body/->IndexCompute
+                     'group-start (body/expression :mul 'group-index 'group-chunk))
+                    (body/->IndexCompute
+                     'group-end
+                     (body/expression :min '_n_bound
+                                      (body/expression :add 'group-start 'group-chunk)))
+                    (body/->IndexCompute
+                     'global-index (body/expression :add 'group-start 'local-index))]
+          :masks (vec (concat
+                       [(body/->Mask :lane-zero [(body/predicate :eq 'local-index 0)])]
+                       (map (fn [stride]
+                              (body/->Mask (keyword (str "reduce-stride-" stride))
+                                           [(body/predicate :lt 'local-index stride)]))
+                            (take-while pos?
+                                        (iterate #(quot % 2) (quot workgroup-size 2))))))
+          :operations (vec (concat
+                            [(body/->ForLoop
+                              (body/value element-index :int)
+                              'global-index 'group-end workgroup-size
+                              [(body/->LoopArg (body/value lane-accumulator dtype)
+                                               (body/literal identity dtype))]
+                              (vec (concat
+                                    operations
+                                    [(body/->ScalarCompute
+                                      (body/value next-lane-accumulator dtype)
+                                      (body/scalar-expression
+                                       operator dtype [lane-accumulator result]))
+                                     (body/->Yield [next-lane-accumulator])]))
+                              [(body/value lane-result dtype)]
+                              {})
+                             (body/->ScalarStore scratch ['local-index] lane-result nil)
+                             (barrier)]
+                            tree-stages
+                            [(body/->ScalarLoad (body/value final-value dtype) scratch [0]
+                                                :lane-zero (body/literal identity dtype) :cached)
+                             (body/->ScalarStore output ['group-index] final-value :lane-zero)]))
+          :schedule {:strategy :workgroup-tree
+                     :workgroup-size workgroup-size
+                     :reduction-operator operator}
+          :launch (launch/spec
+                   {:workgroup-size [workgroup-size]
+                    :group-count [group-count]
+                    :shared-memory-bytes (* workgroup-size (dtype/bytes-of dtype))})
+          :provenance {:dialect :kernel-body :source-dialect :segred
+                       :segop-id (:id segred)
+                       :algorithm-dialect (:algorithm-dialect segred)}
+          :attributes {:kind :scalar-reduction :identity identity
+                       :operator operator}})]
+    {:kernel-body kernel-body
+     :operator operator
+     :identity identity
+     :arrays arrays
+     :scalars scalars
+     :output output
+     :bound bound}))

--- a/src/raster/compiler/passes/parallel/soac_dialect_adapter.clj
+++ b/src/raster/compiler/passes/parallel/soac_dialect_adapter.clj
@@ -1,9 +1,10 @@
 (ns raster.compiler.passes.parallel.soac-dialect-adapter
   "Guarded compatibility projection from the current record SOAC graph to TypedSOAC.
 
-   This is a differential-testing bridge, not a backend route. It accepts only maps, scalar/full
-   reductions and the allocation/alias scaffolding produced by current horizontal fusion. Every
-  unsupported legacy shape declines loudly so the bridge cannot silently erase compiler facts."
+   This guarded bridge feeds both differential tests and the first production scalar-reduction
+   vertical. It accepts only maps, scalar/full reductions and the allocation/alias scaffolding
+   produced by current horizontal fusion. Every unsupported legacy shape declines loudly so the
+   bridge cannot silently erase compiler facts."
   (:require [clojure.set :as set]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
@@ -170,7 +171,7 @@
                         (:dtypes attributes)
                         (repeat (count results) default-dtype))]
     (merge
-     {extent (tensor-value :long [])}
+     (if (dialect/value-id? extent) {extent (tensor-value :long [])} {})
      (into {} (map (fn [id]
                      [id (tensor-value (value-dtype id default-dtype array-types)
                                        (dialect/extent-shape extent))])
@@ -227,7 +228,9 @@
                                   :extent (dialect/operation-extent equation)})
                                equations)
           definitions (set (mapcat :results equation-infos))
-          references (set (mapcat #(conj (:inputs %) (:extent %)) equation-infos))
+          references (set (mapcat #(cond-> (:inputs %)
+                                     (dialect/value-id? (:extent %)) (conj (:extent %)))
+                                  equation-infos))
           inputs (vec (sort-by pr-str (set/difference references definitions)))
           outputs (vec (or outputs (:results (peek equation-infos)) []))
           inferred-values (reduce (fn [contracts equation]

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -15,13 +15,76 @@
   (:require [clojure.set :as set]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.core.util :as util]
             [raster.compiler.ir.kernel-graph :as kernel-graph]
             [raster.compiler.ir.kernel-launch :as kernel-launch]
             [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.soac :as soac]
+            [raster.compiler.ir.soac-dialect :as soac-dialect]
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.execution-plan :as execution-plan]))
+
+(declare lower-reduce)
+
+(defn typed-reduce-program?
+  "Whether a validated one-equation TypedSOAC program is the scalar reduction vertical currently
+   accepted by SegRed lowering."
+  [program]
+  (and (soac-dialect/program-form? program)
+       (= 1 (count (soac-dialect/equations program)))
+       (= 'reduce (soac-dialect/operation-kind (first (soac-dialect/equations program))))))
+
+(defn lower-typed-reduce
+  "Lower one functional TypedSOAC reduction to SegRed without inspecting its source spelling.
+
+   TypedSOAC keeps element values and captures as lexical lambda parameters. SegRed's temporary
+   scalar-region adapter still spells element reads as `aget`; this conversion is a mechanical
+   projection from the validated parameter layout, not a second analysis of the host form."
+  [program device-id & {:keys [dtype] :or {dtype :double}}]
+  (let [program (soac-dialect/validate! program)]
+    (when-not (typed-reduce-program? program)
+      (throw (ex-info "typed SegRed lowering requires one reduce equation"
+                      {:reason :typed-soac-reduce-subset :program program})))
+    (let [equation (first (soac-dialect/equations program))
+          [_ equation-id results operation] equation
+          [_ attributes arrays captures lambda] operation
+          [_ _ body-results] lambda
+          {:keys [accumulators elements capture-parameters]}
+          (soac-dialect/parameter-layout equation)
+          _ (when-not (and (= 1 (count results))
+                           (= 1 (count accumulators))
+                           (= 1 (count body-results))
+                           (symbol? (first results)))
+              (throw (ex-info "initial typed SegRed vertical supports one symbolic result"
+                              {:reason :typed-soac-reduce-subset
+                               :equation equation-id :results results
+                               :accumulators accumulators})))
+          index (:index attributes)
+          substitutions
+          (into (zipmap capture-parameters captures)
+                (map (fn [parameter array]
+                       [parameter (list 'clojure.core/aget array index)])
+                     elements arrays))
+          step-result (util/subst-syms substitutions (first body-results))
+          result (first results)
+          accumulator (first accumulators)
+          accumulator-dtype (or (first (:dtypes attributes)) dtype :double)
+          operator (reduction/scalar
+                    {:accumulator accumulator
+                     :neutral (first (:identities attributes))
+                     :dtype accumulator-dtype
+                     :result result
+                     :index index
+                     :step-result step-result
+                     :algebra (or (first (:algebra attributes)) {})
+                     :attributes {:source :typed-soac :equation equation-id}})
+          node (cond-> (soac/->SoacReduce equation-id result operator []
+                                          (:extent attributes) (set arrays) results (set captures))
+                 accumulator-dtype (assoc :elem-type accumulator-dtype))]
+      (mapv #(assoc % :algorithm-dialect :typed-soac
+                    :algorithm-equation equation-id)
+            (lower-reduce node device-id :dtype accumulator-dtype)))))
 
 ;; ================================================================
 ;; Lowering helpers

--- a/test/raster/compiler/backend/gpu/gpu_correctness_test.clj
+++ b/test/raster/compiler/backend/gpu/gpu_correctness_test.clj
@@ -172,7 +172,9 @@
         (is (str/includes? src "__local"))
         (is (str/includes? src "barrier"))
         (is (str/includes? src "get_local_id"))
-        (is (str/includes? src "get_local_size"))))))
+        (is (str/includes? src "rstr_tree_combined_"))
+        (is (not (str/includes? src "get_local_size"))
+            "the emitted target must not reconstruct the static KernelBody schedule")))))
 
 ;; ---- 1.7 Scan kernel structure ----
 

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -4,11 +4,26 @@
             [raster.compiler.backend.gpu.attention :as attention-emit]
             [raster.compiler.backend.gpu.kernel-body-fixtures :as body-fixtures]
             [raster.compiler.backend.gpu.kernel-body-opencl :as body-emit]
+            [raster.compiler.backend.gpu.segop-opencl :as segop-emit]
             [raster.compiler.backend.gpu.target :as gpu-target]
             [raster.compiler.ir.attention :as attention]
             [raster.compiler.ir.kernel-executable :as executable]
+            [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.attention-route :as attention-route]
-            [raster.compiler.passes.parallel.segmented-weighted-reduction-schedule :as schedule]))
+            [raster.compiler.passes.parallel.segmented-weighted-reduction-schedule :as schedule]
+            [raster.compiler.passes.parallel.soac-lower :as soac-lower]))
+
+(defn- reduction-artifact
+  [dialect]
+  (let [form (with-meta
+               '(raster.par/reduce acc 0.0 i n
+                                   (+ acc (* scale (clojure.core/aget values i))))
+               {:raster.type/elem-type :float})
+        node (soac/par-form->soac 'result form 901 :dtype :float)
+        operation (first (soac-lower/lower-reduce node nil :dtype :float))]
+    (segop-emit/generate-segred-kernel-body
+     operation nil :dtype :float :scalar-types {'scale :float}
+     :target-dialect dialect :kernel-name-prefix "workgroup_reduce")))
 
 (defn- problem []
   (attention/make
@@ -71,6 +86,8 @@
         tiled (attention-emit/emit-fp16-tiled-history plan tiled-schedule dialect)]
     (into [(write-artifact! directory suffix "cooperative" cooperative)
            (write-artifact! directory suffix "pipelined-attention" pipelined)
+           (write-artifact! directory suffix "workgroup-reduction"
+                            (reduction-artifact dialect))
            (write-source! directory suffix "workgroup-memory"
                           (body-emit/emit-scalar-kernel
                            "workgroup_memory" (body-fixtures/workgroup-memory-body 32)

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -138,15 +138,19 @@
       (is (string? (:source kernel)))
       ;; OpenCL-specific syntax
       (is (str/includes? (:source kernel) "__kernel void"))
-      (is (str/includes? (:source kernel) "__local double sdata"))
+      (is (str/includes? (:source kernel) "__local double* rstr_workgroup_reduction_scratch"))
       (is (str/includes? (:source kernel) "barrier(CLK_LOCAL_MEM_FENCE)"))
       (is (str/includes? (:source kernel) "get_group_id(0)"))
-      ;; Subgroup extension
-      (is (str/includes? (:source kernel) "cl_intel_subgroups"))
+      ;; The portable workgroup tree does not depend on a vendor subgroup dialect.
+      (is (not (str/includes? (:source kernel) "cl_intel_subgroups")))
       ;; Must NOT have CUDA
       (is (not (str/includes? (:source kernel) "__syncthreads()")))
       (is (= :segred (get-in kernel [:provenance :dialect])))
-      (is (= [256] (get-in kernel [:launch :workgroup-size]))))))
+      (is (= :kernel-body (get-in kernel [:attributes :emission-route])))
+      (let [workgroup-size (first (get-in kernel [:launch :workgroup-size]))]
+        (is (pos-int? workgroup-size))
+        (is (= (* workgroup-size 8)
+               (get-in kernel [:launch :shared-memory-bytes])))))))
 
 ;; ================================================================
 ;; Pipeline pass: opencl-pass

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -9,6 +9,7 @@
    emitted x[i] (decoder-gpu)."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.soac :as soac]
+            [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-launch :as klaunch]
@@ -99,7 +100,9 @@
          Exception #"only a binary \(op acc elem\) combine"
          (segred-source '(+ acc (clojure.core/aget a j) (clojure.core/aget b j))))))
   (testing "the ordinary binary combine still lowers unchanged"
-    (is (re-find #"val = " (segred-source '(+ acc (clojure.core/aget a j)))))))
+    (let [source (segred-source '(+ acc (clojure.core/aget a j)))]
+      (is (re-find #"tree_combined_.* = .* \+ " source))
+      (is (re-find #"output\[" source)))))
 
 (deftest segred-multistatement-lambda-rejected
   (testing "a reduce lambda with a multi-statement let body is rejected, not (last bdy)-dropped"
@@ -144,19 +147,38 @@
       (is (= [:float :float :float :int] (mapv :kernel-dtype (:abi k))))
       (is (= [:operand :result :parameter :bound] (mapv :role (:abi k))))
       (is (= '[a result-buffer scale n] (:arguments k)))
-      (is (re-find #"\(.*a,.*output, float scale, int _n_bound\)" (:source k))))
+      (is (= (kabi/signature-shape (:abi k))
+             (kabi/source-signature-shape (:kernel-name k) (:source k))))
+      (is (= :no-write-alias (get-in k [:abi 0 :aliasing]))))
     (testing "launch and semantic origin are part of the value"
       (is (klaunch/launch-spec? (:launch k)))
       (is (= [256] (get-in k [:launch :workgroup-size])))
       (is (= 1024 (get-in k [:launch :shared-memory-bytes])))
       (is (= {:dialect :segred :segop-id (:id segred)} (:provenance k)))
-      (is (= :float (get-in k [:attributes :dtype])))))
+      (is (= :float (get-in k [:attributes :dtype])))
+      (is (= :kernel-body (get-in k [:attributes :emission-route])))
+      (is (some? (get-in k [:attributes :kernel-body])))))
   (testing "host-scalar staging retains the result position as an explicit nil placeholder"
     (let [form '(raster.par/reduce acc 0.0 i n (+ acc (clojure.core/aget a i)))
           s (soac/par-form->soac 'result form 0)
           k (sg/generate-segred-kernel (first (lower/lower-reduce s nil)) nil :dtype :float)]
       (is (= '[a output _n_bound] (mapv :name (:abi k))))
       (is (= '[a nil n] (:arguments k))))))
+
+(deftest segred-kernel-body-decline-is-retained-in-the-fallback-artifact
+  (let [form '(raster.par/reduce acc 0.0 i n
+                                 (+ acc (clojure.core/aget a (+ i offset))))
+        node (soac/par-form->soac 'result form 22 :dtype :float)
+        operation (first (lower/lower-reduce node nil :dtype :float))
+        artifact (sg/generate-segred-kernel
+                  operation nil :dtype :float :scalar-types {'offset :int})]
+    (is (= :verified-segred-opencl (get-in artifact [:attributes :emission-route])))
+    (is (= :segred-kernel-body-declined
+           (get-in artifact [:attributes :kernel-body-decline :reason])))
+    (is (= :uniform-scalar-storage
+           (get-in artifact [:attributes :kernel-body-decline :missing-rule])))
+    (is (= :verified-segred-opencl
+           (get-in artifact [:attributes :kernel-body-decline :fallback])))))
 
 ;; ================================================================
 ;; Horizontally-fused multi-output SegMap: the SECONDARY output (written

--- a/test/raster/compiler/ir/parallel_program_test.clj
+++ b/test/raster/compiler/ir/parallel_program_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.parallel-program :as program]
+            [raster.compiler.ir.soac-dialect :as soac-dialect]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]))
 
 (def ^:private reduce-source
@@ -25,6 +26,12 @@
     (is (= ['?] (:shape (get (:values p) 'values))))
     (is (= [] (:shape (get (:values p) [:binding 'total]))))
     (is (seq (:operations equation)))
+    (is (soac-dialect/program-form? (:algorithm equation)))
+    (is (= (:operands equation) (:inputs (soac-dialect/facts (:algorithm equation)))))
+    (is (= (:results equation) (soac-dialect/outputs (:algorithm equation))))
+    (is (= '[n] (get-in (soac-dialect/facts (:algorithm equation))
+                        [:values 'values :shape])))
+    (is (= :typed-soac (:algorithm-dialect (first (:operations equation)))))
     (testing "the source binder is ordinary Clojure data, not an IR side channel"
       (is (nil? (meta (first (second (:source p)))))))))
 
@@ -45,3 +52,15 @@
         (is (= :illegal-op-remains (:reason (ex-data e))))
         (is (= :segop (:target-dialect (ex-data e))))
         (is (= :none (:fallback (ex-data e))))))))
+
+(deftest source-shaped-bound-expressions-stay-on-the-compatibility-route
+  (let [source '(raster.par/reduce acc 0.0 i (clojure.core/alength values)
+                                    (+ acc (clojure.core/aget values i)))
+        p (:form (segop-lower/segop-lower-pass
+                  (list 'let* ['total source] 'total)
+                  {:target-device :cpu:0 :dtype :double
+                   :array-types {'values :double}}))
+        equation (first (:equations p))]
+    (is (nil? (:algorithm equation)))
+    (is (seq (:operations equation)))
+    (is (= [:binding 'total] (:site equation)))))

--- a/test/raster/compiler/ir/soac_dialect_test.clj
+++ b/test/raster/compiler/ir/soac_dialect_test.clj
@@ -38,6 +38,12 @@
     (is (= '[x] (dialect/operation-inputs (first (dialect/equations program)))))))
 
 (deftest scalar-regions-are-recursively-validated
+  (testing "walker-devirtualized scalar calls remain explicit functional expressions"
+    (let [program (map-program
+                   {:body '(.invk raster.numeric/_star__m_float_float-impl
+                                  x-element x-element)})]
+      (is (= program (dialect/validate! program)))))
+
   (testing "a non-language object cannot hide inside a scalar call"
     (let [bad-body (list '* 'x-element (Object.))]
       (try
@@ -130,3 +136,24 @@
          '[y])]
     (is (= [(list 'value extent-id)] (:shape (get-in (dialect/facts program)
                                                      [:values 'x]))))))
+
+(deftest alpha-remapping-preserves-static-extents-and-renames-value-facts
+  (let [static-tensor (av/tensor {:dtype :float :shape [8]})
+        program
+        (dialect/make
+         (dialect/default-program-facts
+          {:values {'x static-tensor 'y static-tensor}
+           :inputs '[x]
+           :equations {'map-0 (dialect/default-equation-facts)}})
+         [(list '= 'map-0 '[y]
+                (list 'map {:index 'i :extent 8} '[x] []
+                      (list 'lambda '[x-element] '[(* x-element 2.0)])))]
+         '[y])
+        remapped (dialect/remap-values program {'x [:argument 0] 'y [:result 0]})
+        equation (first (dialect/equations remapped))]
+    (is (= [[:argument 0]] (:inputs (dialect/facts remapped))))
+    (is (= [[:result 0]] (dialect/outputs remapped)))
+    (is (= 8 (dialect/operation-extent equation)))
+    (is (= [[:argument 0]] (dialect/operation-inputs equation)))
+    (is (= [8] (:shape (get-in (dialect/facts remapped)
+                               [:values [:result 0]]))))))

--- a/test/raster/compiler/segop_consumption_test.clj
+++ b/test/raster/compiler/segop_consumption_test.clj
@@ -14,7 +14,8 @@
             [raster.compiler.passes.parallel.segop-lower-pass :as slp]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.backend.gpu.opencl-pass :as op]
-            [raster.compiler.backend.jvm.par-simd :as par-simd]))
+            [raster.compiler.backend.jvm.par-simd :as par-simd]
+            [raster.compiler.passes.parallel.par-fusion :as par-fusion]))
 
 (def ^:private map-form
   '(let* [o (raster.par/map! O i 8192 nil (clojure.core/* (clojure.core/aget X i) 2.0))] o))
@@ -70,6 +71,18 @@
       (is (= 1 (:segop-reused st)) "consumed from the first-class equation")
       (is (nil? (:segop-relowered st))))))
 
+(deftest a-body-position-reduction-keeps-the-existing-resultless-envelope
+  (let [form '(let* [n 8192]
+                    (raster.par/reduce acc 0.0 i n
+                                       (+ acc (clojure.core/aget X i))))
+        program (lowered form)
+        equation (first (:equations program))
+        st (:stats (run program))]
+    (is (empty? (:results equation)))
+    (is (nil? (:algorithm equation)))
+    (is (= 1 (:segop-reused st)))
+    (is (= 1 (:ze-reduces st)))))
+
 (deftest jvm-simd-consumes-the-boundary-too
   (testing "matching map/reduce SegOps are reused rather than independently re-derived"
     (doseq [[label form stat-key]
@@ -108,3 +121,33 @@
                   (fn [& _] (throw (NullPointerException. "simulated SIMD lowering bug")))]
       (is (thrown-with-msg? NullPointerException #"simulated SIMD lowering bug"
                             (run-simd map-form))))))
+
+(deftest fused-reduction-crosses-typed-soac-and-both-scheduled-backends
+  (let [source '(let* [tmp (raster.par/map! TMP i n nil
+                                            (* (clojure.core/aget X i)
+                                               (clojure.core/aget X i)))
+                       total (raster.par/reduce acc 0.0 j n
+                                                (+ acc (clojure.core/aget TMP j)))]
+                      total)
+        fused (:form (par-fusion/par-fusion-pass source))
+        gpu-program (lowered fused)
+        cpu-program (lowered-cpu fused :double)
+        equation (first (:equations gpu-program))
+        gpu (run gpu-program)
+        simd (run-simd cpu-program)
+        artifact (first (:kernels gpu))]
+    (testing "fusion is preserved as a typed functional algorithm in the common envelope"
+      (is (= 1 (count (:equations gpu-program))))
+      (is (some? (:algorithm equation)))
+      (is (not-any? #{'TMP 'tmp} (flatten (:algorithm equation))))
+      (is (= :typed-soac (:algorithm-dialect (first (:operations equation))))))
+    (testing "JVM SIMD consumes the SegRed derived from that algorithm"
+      (is (= 1 (get-in simd [:stats :segop-reused])))
+      (is (= 1 (get-in simd [:stats :simd-reduces]))))
+    (testing "GPU emission consumes the same SegRed through verified KernelBody"
+      (is (= 1 (get-in gpu [:stats :segop-reused])))
+      (is (= :kernel-body (get-in artifact [:attributes :emission-route])))
+      (is (= :typed-soac (get-in artifact [:attributes :kernel-body
+                                           :provenance :algorithm-dialect])))
+      (is (re-find #"element_value_.* = .* \* " (:source artifact)))
+      (is (not (str/includes? (:source artifact) "TMP"))))))


### PR DESCRIPTION
## Summary

- retain alpha-renamed TypedSOAC algorithms beside scheduled operations in ParallelProgram
- lower eligible fused scalar reductions directly from TypedSOAC to SegRed and a target-neutral workgroup-tree KernelBody
- preserve occupancy-capped scheduling with explicit launch IR and emit the same body as OpenCL, CUDA, or HIP
- retain structured fallback to the verified legacy SegRed OpenCL route for unsupported regions
- compile the generated reduction in the existing hardware-free NVIDIA and AMD CI gates

## Verification

- full suite: 2458 tests, 34468 assertions, 0 failures/errors
- focused compiler/device suite: 64 tests, 348 assertions, 0 failures/errors
- real Intel Arc OpenCL session: 8 tests, 12 assertions, 0 failures/errors
- generated CUDA reduction compiled with nvcc to sm_80 PTX
- generated HIP reduction compiled with hipcc to gfx1100 code object