### PR TITLE
Verify shared-memory swizzle layouts

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -174,10 +174,20 @@ overlaps each refill with consumption of the other row, and handles histories of
 through the prior sequential body and even/odd tails through an explicit drain/epilogue. It retains
 the semantic plan, ordered ABI and interval bounds; CSR membership, CSR physical routing and
 unaligned row widths decline to their prior verified schedules. The exact body runs against the
-reference algebra on Intel and compiles through nvcc and hipcc without target hardware. Local
-swizzles and measured stage-depth selection can now collapse more of the tiled graph toward a
-FlashAttention-like single kernel without changing the semantic plan or external ABI. The schedule
-remains opt-in until device measurements and the runtime cost path justify automatic selection.
+reference algebra on Intel and compiles through nvcc and hipcc without target hardware.
+Shared-memory layout is now an explicit verified KernelBody facet. Its finite family consists of
+identity and named 2/4/8/16/32-period row-XOR permutations; the verifier proves static shape,
+in-bounds bijection and exact byte charge, and the shared C-family emitter lowers the same physical
+address transform to OpenCL, CUDA and HIP. Contiguous async copy accepts only the identity member
+until an explicit scatter/tensor-copy operation exists. Hardware descriptors normalize explicit
+bank topology, derive documented CUDA/AMD values and Intel Level Zero's device-dependent current
+default, and abstain for generic OpenCL. The resource model reports allocation feasibility,
+broadcasts and per-bank transaction conflict degree. The current one-dimensional production row
+stages name the verified identity member; non-identity layouts are compiler/source fixtures, not an
+unmeasured performance claim. Measured swizzle and stage-depth selection can now collapse more of
+the tiled graph toward a FlashAttention-like single kernel without changing the semantic plan or
+external ABI. The schedule remains opt-in until device measurements and the runtime cost path
+justify automatic selection.
 
 ### 2.3 Executable steps and resident artifact values compose
 
@@ -743,7 +753,8 @@ The immediate continuation after the verified double-buffered weighted-reduction
 2. **Landed:** carry that dialect in the existing program/value envelope and route one ordinary
    fused reduction through JVM SIMD and GPU `KernelBody` without reconstructing compiler facts from
    source spelling.
-3. Add a finite verified shared-memory swizzle family and bank-conflict/resource model.
+3. **Landed:** add a finite verified shared-memory swizzle family and bank-conflict/resource model;
+   keep the current 1-D attention stages on its identity member until measured 2-D staging lands.
 4. Make stage count and swizzle measured schedule axes, retire the legacy tuner, and remove the
    attention-provenance gate from the generic weighted-reduction matcher.
 5. Migrate the remaining SOAC fusion rules and scalar JVM fallback, then remove compatibility

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -933,16 +933,32 @@
 (defn- emit-storage-index
   [storage coordinates names]
   (let [layout (:layout storage)
-        _ (when-not (contains? #{:row-major :col-major} (:kind layout))
-            (throw (ex-info "OpenCL scalar memory lowering requires a dense strided layout"
-                            {:reason :kernel-body-opencl-layout :storage (:id storage)
-                             :layout layout})))
-        strides (layout/resolve-strides layout)
-        terms (mapv (fn [coordinate stride]
-                      (str "((long)(" (emit-index-expression coordinate names) ") * (long)("
-                           (emit-layout-expression stride names) "))"))
-                    coordinates strides)
-        local-offset (if (seq terms) (str/join " + " terms) "0")
+        dense-offset
+        (fn [dense-layout]
+          (let [strides (layout/resolve-strides dense-layout)
+                terms (mapv (fn [coordinate stride]
+                              (str "((long)(" (emit-index-expression coordinate names)
+                                   ") * (long)(" (emit-layout-expression stride names) "))"))
+                            coordinates strides)]
+            (if (seq terms) (str/join " + " terms) "0")))
+        local-offset
+        (case (:kind layout)
+          (:row-major :col-major) (dense-offset layout)
+          :shared-memory
+          (do
+            (layout/validate-shared-memory! layout)
+            (if (= :identity (:swizzle layout))
+              (dense-offset layout)
+              (let [[row column] coordinates
+                    row-source (emit-index-expression row names)
+                    column-source (emit-index-expression column names)
+                    columns (second (:shape layout))
+                    mask (dec (layout/swizzle-width (:swizzle layout)))]
+                (str "((long)(" row-source ") * (long)(" columns ") + "
+                     "((long)(" column-source ") ^ ((long)(" row-source ") & " mask ")))"))))
+          (throw (ex-info "C-family scalar memory lowering requires a dense strided layout or verified shared layout"
+                          {:reason :kernel-body-opencl-layout :storage (:id storage)
+                           :layout layout})))
         view-offset (some-> storage :view :element-offset)]
     (if view-offset
       (str "((long)(" (emit-index-expression view-offset names) ") + " local-offset ")")

--- a/src/raster/compiler/core/hardware.clj
+++ b/src/raster/compiler/core/hardware.clj
@@ -170,6 +170,45 @@
        best))
    nil candidates))
 
+(defn- shared-memory-bank-capability
+  "Normalize an explicitly reported topology or derive the documented current vendor default.
+
+   CUDA shared memory and modern AMD LDS have 32 four-byte banks. Intel's current oneAPI guide
+   documents 16 four-byte SLM banks while warning that the count is device-dependent, so only the
+   Intel-specific Level Zero backend receives that derived value. Generic OpenCL abstains unless
+   its device reports both fields. Explicit probe/catalogue facts always override these defaults."
+  [target-type caps source]
+  (let [[count-key count-value]
+        (best-capability caps source [:shared-memory-bank-count :slm-bank-count :lds-bank-count])
+        [word-key word-value]
+        (best-capability caps source [:shared-memory-bank-word-bytes :slm-bank-word-bytes
+                                      :lds-bank-word-bytes])]
+    (when (not= (some? count-value) (some? word-value))
+      (throw (ex-info "shared-memory bank topology must report count and word width together"
+                      {:reason :hardware-shared-memory-bank-topology-incomplete
+                       :count count-value :word-bytes word-value})))
+    (cond
+      count-value
+      {:count (positive-limit :shared-memory-bank-count count-value)
+       :word-bytes (positive-limit :shared-memory-bank-word-bytes word-value)
+       :provenance (let [count-source (source-of source count-key :derived)
+                         word-source (source-of source word-key :derived)]
+                     ;; The tuple is only as authoritative as its weaker field.
+                     (if (<= (provenance-rank count-source) (provenance-rank word-source))
+                       count-source word-source))}
+
+      (= :cuda target-type)
+      {:count 32 :word-bytes 4 :provenance :derived :family :cuda-shared-memory}
+
+      (= :hip target-type)
+      {:count 32 :word-bytes 4 :provenance :derived :family :amd-lds}
+
+      (= :ze target-type)
+      {:count 16 :word-bytes 4 :provenance :derived :family :intel-slm
+       :device-dependent? true}
+
+      :else nil)))
+
 (defn- execution-capabilities
   "Normalize backend-specific execution hierarchy keys at the runtime/compiler boundary.
 
@@ -229,6 +268,7 @@
         [scratchpad-key scratchpad]
         (best-capability caps source [:shared-local-memory :shared-memory-per-block
                                       :local-memory-bytes :local-mem-bytes])
+        shared-memory-banks (shared-memory-bank-capability target-type caps source)
         preferred-source (if preferred-key
                            (source-of source preferred-key :derived)
                            :derived)
@@ -248,7 +288,9 @@
                             (source-of source dimensions-key :derived))
                      scratchpad-key
                      (assoc :scratchpad-bytes
-                            (source-of source scratchpad-key :derived)))
+                            (source-of source scratchpad-key :derived))
+                     shared-memory-banks
+                     (assoc :shared-memory-banks (:provenance shared-memory-banks)))
         execution (cond->
                    {:subgroup-kind (case target-type
                                      :cuda :warp
@@ -260,7 +302,8 @@
                     :provenance provenance}
                     dimensions (assoc :max-workgroup-dims dimensions)
                     scratchpad (assoc :scratchpad-bytes
-                                      (positive-limit :scratchpad-bytes scratchpad)))]
+                                      (positive-limit :scratchpad-bytes scratchpad))
+                    shared-memory-banks (assoc :shared-memory-banks shared-memory-banks))]
     (when (and preferred-subgroup-size
                (not (contains? subgroup-sizes preferred-subgroup-size)))
       (throw (ex-info "preferred subgroup width is not a supported hardware width"
@@ -304,6 +347,12 @@
   [desc]
   (or (get-in desc [:execution :max-workgroup-size])
       (:max-workgroup-size desc)))
+
+(defn shared-memory-bank-model
+  "Return the normalized workgroup-memory bank topology, or nil when the target cannot support a
+   trustworthy static conflict estimate."
+  [desc]
+  (get-in desc [:execution :shared-memory-banks]))
 
 (defn- gpu-reg-budget-per-lane
   "Per-lane register-file budget the schedule/tile GRF gate charges against — vendor-specific

--- a/src/raster/compiler/core/layout.clj
+++ b/src/raster/compiler/core/layout.clj
@@ -102,6 +102,76 @@
 (defn col-major [shape dtype]
   (assoc (row-major shape dtype) :kind :col-major :perm (vec (reverse (range (count shape))))))
 
+;; --- verified workgroup/shared-memory layouts ---
+
+(def shared-memory-swizzles
+  "The complete, deliberately finite shared-memory swizzle dialect.  `:xor-N` permutes the
+   low log2(N) column bits by the low row bits.  Named members keep schedule search bounded and
+   make compiled artifacts/caches stable; adding a member is an IR change, not an arbitrary
+   user-supplied bit program."
+  #{:identity :xor-2 :xor-4 :xor-8 :xor-16 :xor-32})
+
+(defn shared-memory-swizzle?
+  [value]
+  (contains? shared-memory-swizzles value))
+
+(defn swizzle-width
+  "Return the named XOR period, or one for the identity member."
+  [swizzle]
+  (case swizzle
+    :identity 1
+    :xor-2 2
+    :xor-4 4
+    :xor-8 8
+    :xor-16 16
+    :xor-32 32
+    (throw (ex-info "unknown shared-memory swizzle"
+                    {:reason :shared-memory-swizzle-unknown :swizzle swizzle
+                     :supported shared-memory-swizzles}))))
+
+(defn validate-shared-memory!
+  "Verify the finite shared-memory layout family and return the descriptor unchanged.
+
+   Identity is legal for one- or two-dimensional static storage. XOR members are 2-D row-major
+   permutations whose column extent is a multiple of their period. That condition proves the
+   transform remains within every period-sized column block and is a bijection (XOR is its own
+   inverse); no padding or hidden resource charge is introduced."
+  [descriptor]
+  (let [{:keys [kind rank shape dtype base swizzle]} descriptor
+        width (swizzle-width swizzle)]
+    (when-not (and (= :shared-memory kind)
+                   (= :row-major base)
+                   (contains? #{1 2} rank)
+                   (= rank (count shape))
+                   (vector? shape)
+                   (every? pos-int? shape)
+                   (keyword? dtype)
+                   width
+                   (or (= :identity swizzle)
+                       (and (= 2 rank)
+                            (zero? (mod (long (second shape)) width)))))
+      (throw (ex-info "invalid shared-memory layout"
+                      {:reason :shared-memory-layout-invalid
+                       :layout descriptor
+                       :requirements {:rank #{1 2}
+                                      :static-positive-shape true
+                                      :base :row-major
+                                      :swizzles shared-memory-swizzles
+                                      :xor-column-multiple width}})))
+    descriptor))
+
+(defn shared-memory
+  "Construct a verified statically shaped workgroup/shared-memory layout."
+  ([shape dtype] (shared-memory shape dtype :identity))
+  ([shape dtype swizzle]
+   (validate-shared-memory!
+    {:kind :shared-memory :rank (count shape) :shape (vec shape) :dtype dtype
+     :base :row-major :swizzle swizzle})))
+
+(defn shared-memory-layout?
+  [descriptor]
+  (= :shared-memory (:kind descriptor)))
+
 (defn transpose-layout
   "A layout viewing `l` transposed — flip the physical major order (:perm). The ONLY thing a
    transpose changes; the data does not move (that's what makes a transpose potentially free)."
@@ -121,7 +191,12 @@
    the innermost physical axis (perm[n-1]) has stride 1, perm[k] has the product of physical
    extents after k. Numeric when shape is numeric, else an S-expression (clojure.core * — index
    arithmetic stays clojure.core per project convention). An explicit :strides overrides."
-  [{:keys [shape perm strides]}]
+  [{:keys [shape perm strides] :as descriptor}]
+  (when (shared-memory-layout? descriptor)
+    (validate-shared-memory! descriptor)
+    (when-not (= :identity (:swizzle descriptor))
+      (throw (ex-info "a non-identity shared-memory swizzle is not affine-strided"
+                      {:reason :shared-memory-layout-non-affine :layout descriptor}))))
   (or strides
       (let [n     (count shape)
             perm  (or perm (vec (range n)))
@@ -134,20 +209,63 @@
         (reduce (fn [m k] (assoc m (nth perm k) (nth pstr k)))
                 (vec (repeat n 1)) (range n)))))
 
+(defn- add-expression [left right]
+  (cond (= left 0) right
+        (= right 0) left
+        (and (number? left) (number? right)) (+ left right)
+        :else (list '+ left right)))
+
+(defn- multiply-expression [left right]
+  (cond (or (= left 0) (= right 0)) 0
+        (= left 1) right
+        (= right 1) left
+        (and (number? left) (number? right)) (* left right)
+        :else (list '* left right)))
+
+(defn- bit-and-expression [left right]
+  (if (and (integer? left) (integer? right))
+    (bit-and left right)
+    (list 'bit-and left right)))
+
+(defn- bit-xor-expression [left right]
+  (if (and (integer? left) (integer? right))
+    (bit-xor left right)
+    (list 'bit-xor left right)))
+
+(defn- shared-memory-offset
+  [descriptor coords]
+  (validate-shared-memory! descriptor)
+  (when-not (= (:rank descriptor) (count coords))
+    (throw (ex-info "shared-memory coordinates must match the layout rank"
+                    {:reason :shared-memory-layout-coordinate-rank
+                     :layout descriptor :coordinates coords})))
+  (if (= 1 (:rank descriptor))
+    (first coords)
+    (let [[row column] coords
+          columns (second (:shape descriptor))
+          width (swizzle-width (:swizzle descriptor))
+          physical-column (if (= 1 width)
+                            column
+                            (bit-xor-expression
+                             column (bit-and-expression row (dec width))))]
+      (add-expression (multiply-expression row columns) physical-column))))
+
 (defn layout->offset
   "Physical element offset of logical `coords` under `layout` — Σ coord_i · stride_i, as a numeric
    value or an S-expression. Zero-stride (broadcast) axes drop out; unit strides are bare."
   [layout coords]
-  (let [st (resolve-strides layout)
-        terms (keep (fn [[c s]]
-                      (cond (= s 0) nil (= s 1) c
-                            (and (number? c) (number? s)) (* c s)
-                            :else (list '* c s)))
-                    (map vector coords st))]
-    (case (count terms)
-      0 0
-      1 (first terms)
-      (reduce (fn [a b] (if (and (number? a) (number? b)) (+ a b) (list '+ a b))) terms))))
+  (if (shared-memory-layout? layout)
+    (shared-memory-offset layout coords)
+    (let [st (resolve-strides layout)
+          terms (keep (fn [[c s]]
+                        (cond (= s 0) nil (= s 1) c
+                              (and (number? c) (number? s)) (* c s)
+                              :else (list '* c s)))
+                      (map vector coords st))]
+      (case (count terms)
+        0 0
+        1 (first terms)
+        (reduce (fn [a b] (if (and (number? a) (number? b)) (+ a b) (list '+ a b))) terms)))))
 
 (defn offset->coords
   "Inverse of layout->offset for a DENSE strided layout (numeric strides) — recover logical coords

--- a/src/raster/compiler/core/shared_memory.clj
+++ b/src/raster/compiler/core/shared_memory.clj
@@ -1,0 +1,110 @@
+(ns raster.compiler.core.shared-memory
+  "Static resource and bank-conflict analysis for verified shared-memory layouts.
+
+  This is a schedule cost model, not a target rewrite.  Layouts determine physical addresses;
+  hardware descriptors determine bank topology; an access sample determines conflicts.  When a
+  target does not expose a topology the model abstains explicitly instead of borrowing another
+  vendor's constants."
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.layout :as layout]))
+
+(defn- bank-model!
+  [model]
+  (when-not (and (map? model)
+                 (pos-int? (:count model))
+                 (pos-int? (:word-bytes model))
+                 (keyword? (:provenance model)))
+    (throw (ex-info "shared-memory bank topology is incomplete"
+                    {:reason :shared-memory-bank-model-invalid :model model})))
+  model)
+
+(defn- physical-byte-address
+  [descriptor coordinates]
+  (* (long (layout/layout->offset descriptor coordinates))
+     (long (dtype/bytes-of (:dtype descriptor)))))
+
+(defn analyze-access
+  "Analyze one scalar access per active lane.
+
+   `coordinates` is an ordered vector of numeric logical coordinates, one entry per lane.
+   Exact-address reads may broadcast; distinct element addresses remain distinct transactions even
+   when they occupy one bank word, which is a conservative cross-vendor rule. Elements wider than
+   one bank word contribute a transaction to every word/bank they touch. Writes also retain exact
+   address identity because overlapping writes are not a portable broadcast. The result reports
+   the maximum number of distinct transactions serialized by any bank.
+   A nil topology returns a structured abstention."
+  ([bank-model descriptor coordinates]
+   (analyze-access bank-model descriptor coordinates :read))
+  ([bank-model descriptor coordinates access]
+   (layout/validate-shared-memory! descriptor)
+   (when-not (contains? #{:read :write} access)
+     (throw (ex-info "shared-memory access model requires :read or :write"
+                     {:reason :shared-memory-access-kind-invalid :access access})))
+   (when-not (and (vector? coordinates)
+                  (every? #(and (vector? %)
+                                (= (:rank descriptor) (count %))
+                                (every? nat-int? %)
+                                (every? true? (map < % (:shape descriptor))))
+                          coordinates))
+     (throw (ex-info "shared-memory conflict analysis requires numeric per-lane coordinates"
+                     {:reason :shared-memory-access-coordinates-invalid
+                      :layout descriptor :coordinates coordinates})))
+   (if-not bank-model
+     {:status :unavailable
+      :reason :shared-memory-bank-topology-unavailable
+      :lanes (count coordinates)
+      :swizzle (:swizzle descriptor)}
+     (let [{:keys [word-bytes] :as bank-model} (bank-model! bank-model)
+           bank-count (:count bank-model)
+           element-bytes (dtype/bytes-of (:dtype descriptor))
+           byte-addresses (mapv #(physical-byte-address descriptor %) coordinates)
+           word-addresses-per-lane
+           (mapv (fn [byte-address]
+                   (vec (range (quot byte-address word-bytes)
+                               (inc (quot (+ byte-address (dec element-bytes)) word-bytes)))))
+                 byte-addresses)
+           banks-per-lane (mapv #(mapv (fn [word] (mod word bank-count)) %)
+                                word-addresses-per-lane)
+           bank-transactions
+           (mapcat (fn [byte-address word-addresses]
+                     (map (fn [word-address]
+                            [(mod word-address bank-count) [word-address byte-address]])
+                          word-addresses))
+                   byte-addresses word-addresses-per-lane)
+           transactions-by-bank
+           (reduce (fn [result [bank transaction]]
+                     (update result bank (fnil conj #{}) transaction))
+                   {} bank-transactions)
+           conflict-degrees (into {} (map (fn [[bank addresses]] [bank (count addresses)]))
+                                  transactions-by-bank)
+           broadcasts (->> byte-addresses frequencies (filter (fn [[_ lanes]] (> lanes 1)))
+                           (into {}))]
+       {:status :modeled
+        :access access
+        :lanes (count coordinates)
+        :swizzle (:swizzle descriptor)
+        :bank-model bank-model
+        :physical-byte-addresses byte-addresses
+        :banks-per-lane banks-per-lane
+        :banks (when (every? #(= 1 (count %)) banks-per-lane)
+                 (mapv first banks-per-lane))
+        :transactions-by-bank conflict-degrees
+        :max-conflict-degree (reduce max 0 (vals conflict-degrees))
+        :broadcast-address-groups broadcasts}))))
+
+(defn resource-model
+  "Combine exact allocation charge with an optional bank-access estimate.
+
+   XOR members are in-place bijections, so logical and physical bytes are identical. `capacity`
+   may be the descriptor's per-workgroup scratchpad limit; feasibility is omitted when unknown."
+  [bank-model descriptor coordinates & {:keys [access capacity] :or {access :read}}]
+  (layout/validate-shared-memory! descriptor)
+  (let [elements (reduce * (:shape descriptor))
+        bytes (* elements (dtype/bytes-of (:dtype descriptor)))]
+    (cond-> {:layout descriptor
+             :elements elements
+             :logical-bytes bytes
+             :physical-bytes bytes
+             :padding-bytes 0
+             :access (analyze-access bank-model descriptor coordinates access)}
+      (some? capacity) (assoc :capacity-bytes capacity :feasible? (<= bytes capacity)))))

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -329,7 +329,9 @@
 
 (defn- layout! [owner layout]
   (when-not (and (map? layout) (keyword? (:kind layout)))
-    (throw (ex-info (str owner " requires a named layout") {:layout layout}))))
+    (throw (ex-info (str owner " requires a named layout") {:layout layout})))
+  (when (layout/shared-memory-layout? layout)
+    (layout/validate-shared-memory! layout)))
 
 (defn- unique-ids! [owner values]
   (let [ids (mapv :id values)]
@@ -760,6 +762,11 @@
                        (= :global (:memory-space source))
                        (= :allocation (:kind destination))
                        (= :workgroup (:memory-space destination))
+                       ;; AsyncWorkgroupCopy denotes one contiguous transfer. A physical XOR
+                       ;; permutation needs an explicit scatter/tensor-copy operation; treating it
+                       ;; as contiguous would silently populate the wrong logical coordinates.
+                       (or (not (layout/shared-memory-layout? (:layout destination)))
+                           (= :identity (get-in destination [:layout :swizzle])))
                        (= (dtype/canon (:dtype source)) (dtype/canon (:dtype destination)))
                        (= (count (:shape source)) (count (:source-coordinates operation)))
                        (= (count (:shape destination))
@@ -1652,6 +1659,10 @@
                           {:parameter p})))
         (do (shape! "kernel buffer parameter" (:shape p))
             (layout! "kernel buffer parameter" (:layout p))
+            (when (layout/shared-memory-layout? (:layout p))
+              (throw (ex-info "shared-memory layouts are restricted to workgroup allocations"
+                              {:reason :kernel-body-shared-layout-memory-space
+                               :parameter p})))
             (when-not (keyword? (:memory-space p))
               (throw (ex-info "kernel buffer parameter requires a memory space"
                               {:parameter p}))))))
@@ -1719,6 +1730,10 @@
                                    {:view view :references (vec outside) :scope index-scope}))))
                (shape! "kernel buffer view" (:shape view))
                (layout! "kernel buffer view" (:layout view))
+               (when (layout/shared-memory-layout? (:layout view))
+                 (throw (ex-info "shared-memory layouts cannot decorate global buffer views"
+                                 {:reason :kernel-body-shared-layout-memory-space
+                                  :view view})))
                (let [parent-shape (:shape parent)
                      view-shape (:shape view)
                      prefix-rank (- (count parent-shape) (count view-shape))

--- a/src/raster/compiler/ir/segmented_weighted_reduction_schedule.clj
+++ b/src/raster/compiler/ir/segmented_weighted_reduction_schedule.clj
@@ -3,7 +3,8 @@
 
    The semantic operation remains SegmentedWeightedReductionPlan.  This value records how one
    legal implementation maps segments, score components, visible members and value components to
-   cooperative hardware execution; it contains no attention buffer identities or target syntax.")
+   cooperative hardware execution; it contains no attention buffer identities or target syntax."
+  (:require [raster.compiler.core.layout :as layout]))
 
 (defrecord SegmentedWeightedReductionSchedule
            [strategy workgroup-size segment-mapping membership-traversal score-reduction
@@ -63,6 +64,7 @@
          (pos-int? (:value-elements staging))
          (contains? #{4 8 16} (:transfer-bytes staging))
          (contains? #{:preferred :required} (:overlap staging))
+         (layout/shared-memory-swizzle? (:layout-swizzle staging))
          (= :separate-epilogue (:tail-policy staging))
          (pos-int? (:shared-memory-bytes staging))
          (= (:shared-memory-bytes staging)

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_body.clj
@@ -1160,16 +1160,20 @@
         allocations
         [(body/->WorkgroupAllocation
           'pipeline-key-stage-a :half [(:qk-head-dim problem)]
-          (layout/row-major [(:qk-head-dim problem)] :half) 16)
+          (layout/shared-memory [(:qk-head-dim problem)] :half
+                                (:layout-swizzle staging)) 16)
          (body/->WorkgroupAllocation
           'pipeline-value-stage-a :half [(:value-head-dim problem)]
-          (layout/row-major [(:value-head-dim problem)] :half) 16)
+          (layout/shared-memory [(:value-head-dim problem)] :half
+                                (:layout-swizzle staging)) 16)
          (body/->WorkgroupAllocation
           'pipeline-key-stage-b :half [(:qk-head-dim problem)]
-          (layout/row-major [(:qk-head-dim problem)] :half) 16)
+          (layout/shared-memory [(:qk-head-dim problem)] :half
+                                (:layout-swizzle staging)) 16)
          (body/->WorkgroupAllocation
           'pipeline-value-stage-b :half [(:value-head-dim problem)]
-          (layout/row-major [(:value-head-dim problem)] :half) 16)]
+          (layout/shared-memory [(:value-head-dim problem)] :half
+                                (:layout-swizzle staging)) 16)]
         initial-ops
         (flatten-operations
          [query-ops

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_schedule.clj
@@ -54,6 +54,10 @@
                   :value-elements components
                   :transfer-bytes 16
                   :overlap :preferred
+                  ;; The finite layout member is explicit even before autotuning selects a
+                  ;; non-identity member. Current row stages are 1-D, so identity is the only
+                  ;; meaningful/copy-contiguous choice; swizzle search remains a later axis.
+                  :layout-swizzle :identity
                   :tail-policy :separate-epilogue
                   :shared-memory-bytes shared-memory-bytes}
                  {:kind :none})

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -92,6 +92,11 @@
                           (body-emit/emit-scalar-kernel
                            "workgroup_memory" (body-fixtures/workgroup-memory-body 32)
                            {:target-dialect dialect}))
+           (write-source! directory suffix "swizzled-workgroup-memory"
+                          (body-emit/emit-scalar-kernel
+                           "swizzled_workgroup_memory"
+                           (body-fixtures/swizzled-workgroup-memory-body 32)
+                           {:target-dialect dialect}))
            (write-source! directory suffix "async-staging"
                           (body-emit/emit-scalar-kernel
                            "async_staging"

--- a/test/raster/compiler/backend/gpu/kernel_body_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_fixtures.clj
@@ -34,6 +34,37 @@
     :provenance {:dialect :compile-gate}
     :attributes {:kind :workgroup-memory}}))
 
+(defn swizzled-workgroup-memory-body
+  "A 2-D XOR-layout fixture. Each lane accesses one logical column element; source compilation
+   proves that OpenCL/CUDA/HIP share the verified address transform without choosing a schedule."
+  [width]
+  (body/make
+   {:id :c-family-swizzled-workgroup-memory-gate
+    :parameters [(body/->KernelParameter
+                  'x :input :float [width] :global
+                  (layout/row-major [width] :float) :input)
+                 (body/->KernelParameter
+                  'y :output :float [width] :global
+                  (layout/row-major [width] :float) :result)]
+    :stable-reads [(body/stable-read 'x)]
+    :allocations [(body/->WorkgroupAllocation
+                   'scratch :float [width width]
+                   (layout/shared-memory [width width] :float :xor-32) 16)]
+    :indices [(body/->IndexBinding 'lane :local 0)]
+    :operations [(body/->ScalarLoad (body/value 'input-value :float)
+                                    'x ['lane] nil nil :cached)
+                 (body/->ScalarStore 'scratch ['lane 0] 'input-value nil)
+                 (body/->WorkgroupBarrier :workgroup #{:workgroup} :acquire-release
+                                          (body/full-participation))
+                 (body/->ScalarLoad (body/value 'staged-value :float)
+                                    'scratch ['lane 0] nil nil :cached)
+                 (body/->ScalarStore 'y ['lane] 'staged-value nil)]
+    :schedule {:shared-memory-layout :xor-32}
+    :launch (launch/spec {:workgroup-size [width] :group-count [1]
+                          :shared-memory-bytes (* width width 4)})
+    :provenance {:dialect :compile-gate}
+    :attributes {:kind :swizzled-workgroup-memory}}))
+
 (defn async-staging-body
   "A workgroup stages one contiguous row, explicitly commits and waits, then consumes it."
   [width overlap]

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -94,6 +94,9 @@
   []
   (fixtures/workgroup-memory-body 16))
 
+(defn swizzled-workgroup-kernel-body []
+  (fixtures/swizzled-workgroup-memory-body 32))
+
 (defn async-staging-kernel-body
   ([] (async-staging-kernel-body :preferred))
   ([overlap] (fixtures/async-staging-body 32 overlap)))
@@ -245,6 +248,24 @@
   (testing "the portable OpenCL source remains valid OpenCL C"
     (let [source (opencl/emit-scalar-kernel
                   "workgroup_memory" (workgroup-kernel-body)
+                  {:target-dialect :opencl-portable})]
+      (if-not (command-available? "clang")
+        (is true "clang unavailable; source structure remains covered")
+        (let [{:keys [exit err]} (shell/sh "clang" "-x" "cl" "-cl-std=CL2.0"
+                                           "-fsyntax-only" "-" :in source)]
+          (is (zero? exit) err))))))
+
+(deftest verified-xor-layout-shares-one-c-family-address-transform
+  (doseq [target [:opencl-portable :cuda :hip]]
+    (let [source (opencl/emit-scalar-kernel
+                  "swizzled_workgroup_memory" (swizzled-workgroup-kernel-body)
+                  {:target-dialect target})]
+      (is (str/includes? source
+                         "((long)(rstr_lane) * (long)(32) + ((long)(0) ^ ((long)(rstr_lane) & 31)))")
+          (name target))))
+  (testing "the portable source remains valid OpenCL C"
+    (let [source (opencl/emit-scalar-kernel
+                  "swizzled_workgroup_memory" (swizzled-workgroup-kernel-body)
                   {:target-dialect :opencl-portable})]
       (if-not (command-available? "clang")
         (is true "clang unavailable; source structure remains covered")

--- a/test/raster/compiler/backend/gpu/kernel_body_workgroup_device_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_workgroup_device_test.clj
@@ -75,6 +75,28 @@
                    :workgroup-memory-bytes
                    (get-in kernel-body [:launch :shared-memory-bytes])}})))
 
+(defn- swizzled-artifact
+  [width]
+  (let [kernel-body (fixtures/swizzled-workgroup-memory-body width)
+        abi (body-abi/project-contracts
+             [(kabi/slot 'x :input :float :c-name "rstr_x" :role :input)
+              (kabi/slot 'y :output :float :c-name "rstr_y" :role :result)]
+             kernel-body)]
+    (kart/make
+     {:kernel-name "kernel_body_swizzled_stage"
+      :target :opencl-c
+      :source (body-emit/emit-scalar-kernel
+               "kernel_body_swizzled_stage" kernel-body
+               {:target-dialect :opencl-portable})
+      :abi abi
+      :arguments '[x y]
+      :launch (:launch kernel-body)
+      :effects {:kind :swizzled-workgroup-stage}
+      :provenance {:kernel-body (:id kernel-body)}
+      :attributes {:shared-memory-layout :xor-32
+                   :workgroup-memory-bytes
+                   (get-in kernel-body [:launch :shared-memory-bytes])}})))
+
 (deftest workgroup-local-roundtrip-is-correct-on-opencl
   (if-not @device-probe/opencl-available?
     (device-probe/opencl-skip! "KernelBody workgroup-local storage and barrier")
@@ -113,6 +135,30 @@
           width 32
           input (float-array (map float (range width)))
           compiled (async-artifact width)
+          x (buffer-of-array input :float)
+          y (make-buffer width :float)]
+      (try
+        (register! (:kernel-name compiled) compiled)
+        (launch! (bind-call (kcall/make compiled [x y])))
+        (is (= (vec input) (vec (buffer->array y))))
+        (finally
+          (free! y)
+          (free! x))))))
+
+(deftest swizzled-workgroup-stage-is-correct-on-opencl
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "KernelBody verified XOR workgroup layout")
+    (let [ocl (find-ns 'raster.gpu.ocl-runtime)
+          register! (ns-resolve ocl 'register-kernel!)
+          buffer-of-array (ns-resolve ocl 'buffer-of-array)
+          make-buffer (ns-resolve ocl 'make-buffer)
+          bind-call (ns-resolve ocl 'bind-kernel-call)
+          launch! (ns-resolve ocl 'launch-registered-bound!)
+          buffer->array (ns-resolve ocl 'buffer->array)
+          free! (ns-resolve ocl 'free-buffer!)
+          width 32
+          input (float-array (map float (range width)))
+          compiled (swizzled-artifact width)
           x (buffer-of-array input :float)
           y (make-buffer width :float)]
       (try

--- a/test/raster/compiler/core/cross_vendor_descriptor_test.clj
+++ b/test/raster/compiler/core/cross_vendor_descriptor_test.clj
@@ -21,6 +21,9 @@
       (is (= #{32} (:subgroup-sizes nv)))
       (is (= 32 (:subgroup-size nv)))
       (is (= 1024 (:max-workgroup-size nv)))
+      (is (= {:count 32 :word-bytes 4 :provenance :derived
+              :family :cuda-shared-memory}
+             (hw/shared-memory-bank-model nv)))
       (is (= 1020 (:grf-bytes-per-lane nv))))
     (testing "AMD CDNA (gfx9): Matrix Cores :mfma 16×16×16 wavefront64; 256 VGPRs×4"
       (is (= {:family :mfma :m 16 :n 16 :k 16 :subgroup 64} (:matrix amd)))
@@ -28,6 +31,8 @@
       (is (= #{64} (:subgroup-sizes amd)))
       (is (= 64 (:subgroup-size amd)))
       (is (= 1024 (:max-workgroup-size amd)))
+      (is (= {:count 32 :word-bytes 4 :provenance :derived :family :amd-lds}
+             (hw/shared-memory-bank-model amd)))
       (is (= 1024 (:grf-bytes-per-lane amd))))
     (testing "the tile is sized against the vendor register file but CAPPED (not register-filling)"
       ;; both NVIDIA and AMD have ~4× Intel's register file; the cap keeps the warp tile at
@@ -62,6 +67,9 @@
     (testing "Intel retains several supported widths and a distinct preference"
       (is (= #{16 32} (get-in arc [:execution :subgroup-sizes])))
       (is (= 16 (get-in arc [:execution :preferred-subgroup-size])))
+      (is (= {:count 16 :word-bytes 4 :provenance :derived :family :intel-slm
+              :device-dependent? true}
+             (hw/shared-memory-bank-model arc)))
       (is (= :subgroup (get-in arc [:execution :subgroup-kind]))))))
 
 (deftest explicit-capabilities-override-catalogue-per-field
@@ -101,7 +109,20 @@
     (is (= #{8 16 32} (:subgroup-sizes opencl)))
     (is (= 16 (:subgroup-size opencl)))
     (is (= 512 (:max-workgroup-size opencl)))
-    (is (= 32768 (get-in opencl [:cache :slm])))))
+    (is (= 32768 (get-in opencl [:cache :slm])))
+    (is (nil? (hw/shared-memory-bank-model opencl))
+        "generic OpenCL does not inherit Intel/NVIDIA/AMD bank topology")))
+
+(deftest explicit-bank-topology-overrides-derived-vendor-defaults
+  (rt/register-target-device!
+   :cuda:explicit-banks
+   {:type :cuda :name "synthetic-future-nvidia"
+    :capabilities {:shared-memory-bank-count 64
+                   :shared-memory-bank-word-bytes 8}})
+  (let [desc (hw/descriptor-for :cuda:explicit-banks)]
+    (is (= {:count 64 :word-bytes 8 :provenance :user}
+           (hw/shared-memory-bank-model desc)))
+    (is (= :user (get-in desc [:execution :provenance :shared-memory-banks])))))
 
 (deftest authoritative-aliases-override-catalogue-spellings
   (let [device (rt/register-target-device!

--- a/test/raster/compiler/core/shared_memory_test.clj
+++ b/test/raster/compiler/core/shared_memory_test.clj
@@ -1,0 +1,58 @@
+(ns raster.compiler.core.shared-memory-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.core.layout :as layout]
+            [raster.compiler.core.shared-memory :as shared]))
+
+(def banks32 {:count 32 :word-bytes 4 :provenance :test})
+
+(deftest finite-xor-layouts-are-exact-bijections
+  (is (= #{:identity :xor-2 :xor-4 :xor-8 :xor-16 :xor-32}
+         layout/shared-memory-swizzles))
+  (doseq [swizzle layout/shared-memory-swizzles]
+    (let [descriptor (layout/shared-memory [32 64] :float swizzle)
+          offsets (for [row (range 32) column (range 64)]
+                    (layout/layout->offset descriptor [row column]))]
+      (is (= (set (range (* 32 64))) (set offsets)) (name swizzle))))
+  (testing "the family cannot be extended by arbitrary masks or invalid tile periods"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"unknown shared-memory swizzle"
+                          (layout/shared-memory [32 32] :float :xor-user)))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"invalid shared-memory layout"
+                          (layout/shared-memory [8 24] :float :xor-16)))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"invalid shared-memory layout"
+                          (layout/shared-memory [32] :float :xor-32)))))
+
+(deftest xor-layout-removes-a-modeled-column-bank-conflict
+  (let [column-access (mapv #(vector % 0) (range 32))
+        dense (shared/analyze-access banks32
+                                      (layout/shared-memory [32 32] :float :identity)
+                                      column-access)
+        swizzled (shared/analyze-access banks32
+                                         (layout/shared-memory [32 32] :float :xor-32)
+                                         column-access)]
+    (is (= 32 (:max-conflict-degree dense)))
+    (is (= 1 (:max-conflict-degree swizzled)))
+    (is (= (set (range 32)) (set (:banks swizzled))))))
+
+(deftest broadcasts-resource-charge-and-abstention-are-explicit
+  (let [descriptor (layout/shared-memory [32 32] :float :xor-32)
+        broadcast (shared/analyze-access banks32 descriptor (vec (repeat 32 [0 0])))
+        report (shared/resource-model banks32 descriptor
+                                      (mapv #(vector % 0) (range 32))
+                                      :capacity 2048)]
+    (is (= 1 (:max-conflict-degree broadcast)))
+    (is (= {0 32} (:broadcast-address-groups broadcast)))
+    (is (= 4096 (:physical-bytes report)))
+    (is (= 0 (:padding-bytes report)))
+    (is (false? (:feasible? report)))
+    (is (= {:status :unavailable
+            :reason :shared-memory-bank-topology-unavailable
+            :lanes 1 :swizzle :xor-32}
+           (shared/analyze-access nil descriptor [[0 0]])))))
+
+(deftest wide-elements-account-for-every-bank-word-touched
+  (let [descriptor (layout/shared-memory [2] :double :identity)
+        report (shared/analyze-access banks32 descriptor [[0] [1]])]
+    (is (= [[0 1] [2 3]] (:banks-per-lane report)))
+    (is (nil? (:banks report)))
+    (is (= {0 1, 1 1, 2 1, 3 1} (:transactions-by-bank report)))
+    (is (= 1 (:max-conflict-degree report)))))

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -625,6 +625,26 @@
                                              (layout/row-major [8] :float))]
                         :shared-memory-bytes 64))))))
 
+(deftest shared-memory-layouts-have-an-explicit-storage-and-copy-boundary
+  (is (body/kernel-body? (fixtures/swizzled-workgroup-memory-body 32)))
+  (testing "a shared layout cannot leak onto a global ABI parameter"
+    (let [kernel (scalar-body [])]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"restricted to workgroup allocations"
+           (body/validate!
+            (assoc-in kernel [:parameters 0 :layout]
+                      (layout/shared-memory [16] :float :identity)))))))
+  (testing "contiguous async copy does not pretend to implement a physical scatter"
+    (let [kernel (-> (fixtures/async-staging-body 32 :preferred)
+                     (assoc-in [:allocations 0 :shape] [32 32])
+                     (assoc-in [:allocations 0 :layout]
+                               (layout/shared-memory [32 32] :float :xor-32))
+                     (assoc-in [:operations 0 :destination-coordinates] [0 0])
+                     (assoc-in [:launch :shared-memory-bytes] 4096))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"contiguous global-to-workgroup transfer"
+                            (body/validate! kernel))))))
+
 (deftest workgroup-barriers-require-full-convergent-participation
   (let [barrier (workgroup-barrier)]
     (is (body/kernel-body? (scalar-body [barrier])))

--- a/test/raster/compiler/passes/parallel/attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/attention_route_test.clj
@@ -153,10 +153,14 @@
     (is (= {:kind :double-buffered-membership-rows
             :stages 2 :members-per-iteration 2 :element-dtype :half
             :key-elements 8 :value-elements 8 :transfer-bytes 16
-            :overlap :preferred :tail-policy :separate-epilogue
+            :overlap :preferred :layout-swizzle :identity
+            :tail-policy :separate-epilogue
             :shared-memory-bytes 64}
            (:staging scheduled)))
     (is (= 4 (count (:allocations kernel-body))))
+    (is (every? #(= {:kind :shared-memory :swizzle :identity}
+                    (select-keys (:layout %) [:kind :swizzle]))
+                (:allocations kernel-body)))
     (is (= 64 (get-in kernel-body [:launch :shared-memory-bytes])))
     (is (= :scheduled-pipelined-kernel-body
            (get-in kernel-body [:provenance :lowering])))


### PR DESCRIPTION
## Summary

- add a finite verified shared-memory layout family with identity and named XOR periods
- normalize target bank topology and add exact resource/bank-conflict analysis with explicit abstention
- lower verified shared layouts through the shared OpenCL/CUDA/HIP KernelBody emitter
- route pipelined weighted-reduction staging through the verified identity member without claiming an unmeasured swizzle optimization
- compile the non-identity fixture to CUDA PTX and an AMD code object, and execute it on Intel OpenCL

## Safety boundary

`AsyncWorkgroupCopy` remains contiguous and therefore accepts only the identity shared layout. Non-identity layouts require a future explicit scatter/tensor-copy operation. Swizzle selection remains a measured schedule axis for the next landing step.

## Verification

- full suite: 2,466 tests / 35,182 assertions / 0 failures / 0 errors
- Intel Arc OpenCL: 4 workgroup-memory tests / 4 assertions / 0 skips
- focused compiler suite: 63 tests / 502 assertions
- nvcc: swizzled fixture compiled to sm_80 PTX
- hipcc: swizzled fixture compiled to gfx1100 code object
- clj-kondo: 0 errors (existing unresolved-var/unused warnings only)
