### PR TITLE
Route pure SOAC fusion through typed programs

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -409,14 +409,22 @@ reduce equations. It verifies ordered SSA definitions, exact typed input/output/
 rank/extent/result contracts, explicit lexical capture binding (including compound stable value
 IDs), tuple-valued maps, and fact-preserving functional fusion. A guarded adapter differentially
 checks map→map, map→reduce and horizontal-map results against the current graph and declines every
-unsupported legacy node or unproved alias. It is intentionally not a backend route yet.
+unsupported legacy node or unproved alias. The first production subset now routes single-consumer
+vertical fusion over pure maps and scalar/full reductions through a `:typed-soac` ParallelProgram.
+It mechanically materializes a compatibility host loop from the typed equation, then derives
+SegMap/SegRed directly from the retained algorithm. JVM SIMD and OpenCL therefore consume the same
+facts without backend re-analysis. Host-visible intermediates, unknown/effectful scalar equations,
+horizontal/multi-result fusion, and any disagreement with the temporary legacy shadow certificate
+decline explicitly.
 
 This representation is shared before backend selection. SOAC fusion changes the program consumed
-by both JVM and accelerator lowerings; SegOp and schedule conversion then specialize it. The JVM
-SIMD backend already consumes certified SegOps from `ParallelProgram`, but current SOAC fusion first
-round-trips through `par` forms and the scalar fallback still expands retained source. Migration is
-complete when JVM SIMD, scalar/JVM and GPU routes consume the same typed SOAC/SegOp facts and no
-backend silently re-lowers an exact source form.
+by both JVM and accelerator lowerings; SegOp and schedule conversion then specialize it. The scalar
+spelling for the migrated subset is now generated from TypedSOAC rather than retained source, and
+JVM SIMD/GPU reuse its certified SegOps. The resident split pipeline remains on the compatibility
+route because its reduce-result device-realization transform still operates between source-form
+pipeline halves. Migration is complete when that transform, horizontal/multi-consumer fusion and
+richer scalar equations operate on the typed envelope and the covered compatibility re-lowerings
+are deleted.
 
 ### 3.3 Schedule and transform IR
 
@@ -763,8 +771,10 @@ The immediate continuation after the verified double-buffered weighted-reduction
    keep the current 1-D attention stages on its identity member until measured 2-D staging lands.
 4. **Landed:** make stage count and swizzle finite measured schedule axes, retire the legacy tuner,
    and remove the attention-provenance gate from routed weighted-reduction lowering.
-5. Migrate the remaining SOAC fusion rules and scalar JVM fallback, then remove compatibility
-   re-lowering for the covered forms.
+5. **In progress:** migrate the remaining SOAC fusion rules and scalar JVM fallback, then remove
+   compatibility re-lowering for the covered forms. Single-consumer pure map→map/map→reduce now has
+   a production typed route shared by JVM SIMD and OpenCL; horizontal/multi-consumer fusion, typed
+   scalar equations and resident reduce-result realization remain.
 6. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a
    read-only distributed track without interrupting the kernel and typed-middle-end verticals.
 

--- a/src/raster/compiler/ir/dialects.clj
+++ b/src/raster/compiler/ir/dialects.clj
@@ -21,6 +21,7 @@
             [raster.compiler.ir.par :as par]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.segop :as segop]
+            [raster.compiler.ir.soac-dialect :as soac-dialect]
             [raster.compiler.core.util :as util]
             [clojure.set :as set]))
 
@@ -509,6 +510,33 @@
     (catch clojure.lang.ExceptionInfo e
       {:fail :segop-program :details (ex-data e) :message (.getMessage e)})))
 
+(defn valid-typed-soac-program?
+  [value]
+  (try
+    (and (= :typed-soac (:dialect value))
+         (parallel-program/validate!
+          value
+          (fn [operation]
+            (let [body (when (and (seq? operation) (= '= (first operation))
+                                  (= 4 (count operation)))
+                         (nth operation 3))]
+              (and (seq? body) (contains? #{'map 'reduce} (first body)))))
+          (fn [_ algorithm]
+            (= algorithm (soac-dialect/validate! algorithm))))
+         (valid-let*-ordered? (:source value))
+         true)
+    (catch clojure.lang.ExceptionInfo _ false)))
+
+(defn valid-source-or-typed-soac?
+  [value]
+  (or (valid-let*-ordered? value) (valid-typed-soac-program? value)))
+
+(defn validate-source-or-typed-soac
+  [value]
+  (if (valid-typed-soac-program? value)
+    :ok
+    (validate-let*-ordered value)))
+
 (def dialect-checkers
   "Map from dialect keyword to [valid? validate] function pairs.
   Used by run-passes to validate IR at pass boundaries."
@@ -531,10 +559,10 @@
    :loop-lifted      [valid-let*-ordered? validate-let*-ordered]
    :write-read-fused [valid-let*-ordered? validate-let*-ordered]
    :par-fused        [valid-let*-ordered? validate-let*-ordered]
-   :soac-fused       [valid-let*-ordered? validate-let*-ordered]
-   :materialized     [valid-let*-ordered? validate-let*-ordered]
+   :soac-fused       [valid-source-or-typed-soac? validate-source-or-typed-soac]
+   :materialized     [valid-source-or-typed-soac? validate-source-or-typed-soac]
    :segop-lowered    [valid-segop-program? validate-segop-program]
-   :compound-detected [valid-let*-ordered? validate-let*-ordered]
+   :compound-detected [valid-source-or-typed-soac? validate-source-or-typed-soac]
    :gpu-planned      [valid-let*-ordered? validate-let*-ordered]
    :dtype-remapped   [valid-let*-ordered? validate-let*-ordered]
    :backend-applied  [valid-let*-ordered? validate-let*-ordered]

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -269,46 +269,78 @@
      :target-device — device for launch param computation
      :dtype — element type (:double or :float)"
   [form opts]
-  (if-not (form/binding-form? form)
-    {:form (build-program form [] [] (:target-device opts) (:dtype opts))
-     :stats {:segops-lowered 0 :kernel-graphs-lowered 0}}
-    (let [[let-sym bindings-vec & body-exprs] form
-          pairs (partition 2 bindings-vec)
-          device-id (:target-device opts)
-          dtype (:dtype opts)
-          array-types (:array-types opts)
-          lowered (atom 0)
-          graphs-lowered (atom 0)
+  (if (and (program/parallel-program? form) (= :typed-soac (:dialect form)))
+    (let [device-id (or (:target-device opts) :cpu:0)
+          dtype (or (:dtype opts) :double)
+          equations
+          (mapv
+           (fn [equation]
+             (let [algorithm (:algorithm equation)
+                   kind (soac-dialect/operation-kind
+                         (first (soac-dialect/equations algorithm)))
+                   operations (case kind
+                                map (soac-lower/lower-typed-map algorithm device-id :dtype dtype)
+                                reduce (soac-lower/lower-typed-reduce algorithm device-id :dtype dtype))]
+               (-> equation
+                   (assoc :operations operations)
+                   (update :provenance assoc :target-dialect :segop)
+                   (update :attributes assoc :device device-id))))
+           (:equations form))
+          lowered (assoc form
+                         :dialect :segop
+                         :equations equations
+                         :provenance (assoc (:provenance form)
+                                            :pass :segop-lower :source-dialect :typed-soac
+                                            :device device-id :dtype dtype))]
+      {:form (program/validate!
+              lowered segop/segop-node?
+              (fn [equation algorithm]
+                (and (= algorithm (soac-dialect/validate! algorithm))
+                     (= (:operands equation) (:inputs (soac-dialect/facts algorithm)))
+                     (= (:results equation) (soac-dialect/outputs algorithm)))))
+       :stats {:segops-lowered (count equations)
+               :kernel-graphs-lowered 0
+               :typed-soac-reused (count equations)}})
+    (if-not (form/binding-form? form)
+      {:form (build-program form [] [] (:target-device opts) (:dtype opts))
+       :stats {:segops-lowered 0 :kernel-graphs-lowered 0}}
+      (let [[let-sym bindings-vec & body-exprs] form
+            pairs (partition 2 bindings-vec)
+            device-id (:target-device opts)
+            dtype (:dtype opts)
+            array-types (:array-types opts)
+            lowered (atom 0)
+            graphs-lowered (atom 0)
           ;; Every par form the middle end could NOT represent, as data. Previously these went to
           ;; stderr as `WARNING: …` and vanished — invisible to stats, to explain-pipeline, and to
           ;; anyone diagnosing why a kernel took the legacy path.
-          declined (atom [])
-          attempt (fn [sym init]
-                    (let [r (lower-attempt sym init device-id dtype array-types)]
-                      (when-let [d (:declined r)] (swap! declined conj d))
-                      (when (:segops r) r)))
-          binding-equations
-          (keep-indexed
-           (fn [idx [sym init]]
-             (when-let [lowered-values (attempt sym init)]
-               (swap! lowered inc)
-               (when (:kernel-graph lowered-values) (swap! graphs-lowered inc))
-               (equation idx [:binding sym] sym init lowered-values dtype array-types)))
-           pairs)
-          ;; Also check body expressions for par forms
-          body-equations
-          (keep-indexed
-           (fn [idx expr]
-             (let [tmp-sym (symbol (str "body_parallel_" idx))]
-               (when-let [lowered-values (attempt tmp-sym expr)]
+            declined (atom [])
+            attempt (fn [sym init]
+                      (let [r (lower-attempt sym init device-id dtype array-types)]
+                        (when-let [d (:declined r)] (swap! declined conj d))
+                        (when (:segops r) r)))
+            binding-equations
+            (keep-indexed
+             (fn [idx [sym init]]
+               (when-let [lowered-values (attempt sym init)]
                  (swap! lowered inc)
                  (when (:kernel-graph lowered-values) (swap! graphs-lowered inc))
-                 (equation (+ (count pairs) idx) [:body idx] tmp-sym expr
-                           lowered-values dtype array-types))))
-           body-exprs)
-          equations (vec (concat binding-equations body-equations))]
-      {:form (build-program (list* let-sym bindings-vec body-exprs)
-                            equations @declined device-id dtype)
-       :stats (cond-> {:segops-lowered @lowered
-                       :kernel-graphs-lowered @graphs-lowered}
-                (seq @declined) (assoc :segops-declined @declined))})))
+                 (equation idx [:binding sym] sym init lowered-values dtype array-types)))
+             pairs)
+          ;; Also check body expressions for par forms
+            body-equations
+            (keep-indexed
+             (fn [idx expr]
+               (let [tmp-sym (symbol (str "body_parallel_" idx))]
+                 (when-let [lowered-values (attempt tmp-sym expr)]
+                   (swap! lowered inc)
+                   (when (:kernel-graph lowered-values) (swap! graphs-lowered inc))
+                   (equation (+ (count pairs) idx) [:body idx] tmp-sym expr
+                             lowered-values dtype array-types))))
+             body-exprs)
+            equations (vec (concat binding-equations body-equations))]
+        {:form (build-program (list* let-sym bindings-vec body-exprs)
+                              equations @declined device-id dtype)
+         :stats (cond-> {:segops-lowered @lowered
+                         :kernel-graphs-lowered @graphs-lowered}
+                  (seq @declined) (assoc :segops-declined @declined))}))))

--- a/src/raster/compiler/passes/parallel/soac_dialect_adapter.clj
+++ b/src/raster/compiler/passes/parallel/soac_dialect_adapter.clj
@@ -202,9 +202,10 @@
    - :outputs — logical program results (defaults to the last equation's results)
    - :dtype — fallback element dtype
    - :array-types — symbol-to-dtype overrides
-   - :values — authoritative additional AbstractValues"
-  [nodes {:keys [outputs dtype array-types values]
-          :or {dtype :double array-types {} values {}}}]
+   - :values — authoritative additional AbstractValues
+   - :preserve-scalar-bindings? — allow the caller to retain scalar nodes in a separate envelope"
+  [nodes {:keys [outputs dtype array-types values preserve-scalar-bindings?]
+          :or {dtype :double array-types {} values {} preserve-scalar-bindings? false}}]
   (let [nodes (ordered-nodes nodes)
         physical-outputs (reduce set/union #{}
                                  (keep #(when-not (legacy/scalar-binding? %)
@@ -212,7 +213,8 @@
                                        nodes))
         unsupported (remove #(or (legacy/soac-map? %)
                                  (legacy/soac-reduce? %)
-                                 (generated-scaffolding? % physical-outputs))
+                                 (generated-scaffolding? % physical-outputs)
+                                 (and preserve-scalar-bindings? (legacy/scalar-binding? %)))
                             nodes)]
     (when-let [node (first unsupported)]
       (fail! :unsupported-legacy-node

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -26,6 +26,48 @@
             [raster.compiler.passes.parallel.execution-plan :as execution-plan]))
 
 (declare lower-reduce)
+(declare lower-map)
+
+(defn typed-map-program?
+  "Whether a validated one-equation TypedSOAC program is a map accepted by SegMap lowering."
+  [program]
+  (and (soac-dialect/program-form? program)
+       (= 1 (count (soac-dialect/equations program)))
+       (= 'map (soac-dialect/operation-kind (first (soac-dialect/equations program))))))
+
+(defn lower-typed-map
+  "Lower one functional TypedSOAC map to SegMap from its explicit operands and lambda binders."
+  [program device-id & {:keys [dtype] :or {dtype :double}}]
+  (let [program (soac-dialect/validate! program)]
+    (when-not (typed-map-program? program)
+      (throw (ex-info "typed SegMap lowering requires one map equation"
+                      {:reason :typed-soac-map-subset :program program})))
+    (let [equation (first (soac-dialect/equations program))
+          [_ equation-id results operation] equation
+          [_ attributes arrays captures lambda] operation
+          [_ _ body-results] lambda
+          {:keys [elements capture-parameters]} (soac-dialect/parameter-layout equation)
+          _ (when-not (and (= 1 (count results)) (= 1 (count body-results))
+                           (symbol? (first results)))
+              (throw (ex-info "initial typed SegMap vertical supports one symbolic result"
+                              {:reason :typed-soac-map-subset
+                               :equation equation-id :results results})))
+          index (:index attributes)
+          substitutions
+          (into (zipmap capture-parameters captures)
+                (map (fn [parameter array]
+                       [parameter (list 'clojure.core/aget array index)])
+                     elements arrays))
+          body (util/subst-syms substitutions (first body-results))
+          result (first results)
+          result-dtype (or (:dtype (get-in (soac-dialect/facts program) [:values result]))
+                           dtype :double)
+          node (assoc (soac/->SoacMap equation-id result index (:extent attributes) nil body
+                                      (set arrays) #{result} (set captures))
+                      :elem-type result-dtype :pure? true)]
+      (mapv #(assoc % :algorithm-dialect :typed-soac
+                    :algorithm-equation equation-id)
+            (lower-map node device-id :dtype result-dtype)))))
 
 (defn typed-reduce-program?
   "Whether a validated one-equation TypedSOAC program is the scalar reduction vertical currently

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -1,0 +1,267 @@
+(ns raster.compiler.passes.parallel.typed-soac-route
+  "Production bridge for the first closed TypedSOAC fusion subset.
+
+   Pure maps and scalar/full reductions are fused in the typed dialect.  The resulting functional
+   equations are mechanically materialized into the compatibility host expression and retained as
+   first-class algorithms in a ParallelProgram.  A shadow comparison with the established graph
+   implementation is a temporary migration certificate: disagreement declines to the old route."
+  (:require [clojure.set :as set]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.ir.parallel-program :as parallel-program]
+            [raster.compiler.ir.reduction :as reduction]
+            [raster.compiler.ir.soac :as legacy]
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.passes.parallel.soac-dialect-adapter :as adapter]
+            [raster.compiler.passes.parallel.soac-graph :as graph]
+            [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]
+            [raster.compiler.core.util :as util]))
+
+(def ^:private dtype->allocation
+  {:float ['clojure.core/float-array 'floats 'float]
+   :double ['clojure.core/double-array 'doubles 'double]
+   :int ['clojure.core/int-array 'ints 'int]
+   :long ['clojure.core/long-array 'longs 'long]
+   :byte ['clojure.core/byte-array 'bytes 'byte]})
+
+(defn- provably-pure-host-binding?
+  [expression]
+  (or (not (seq? expression))
+      (and (descriptor/alength-op? (descriptor/semantic-op expression))
+           (= 1 (count (descriptor/call-args expression)))
+           (symbol? (first (descriptor/call-args expression))))))
+
+(defn- supported-node?
+  [node]
+  ;; Unknown calls are not evidence of purity. This first route carries atomic bindings and the
+  ;; compiler's semantically identified array-length query; richer scalar equations belong in the
+  ;; typed program itself.
+  (or (and (legacy/scalar-binding? node) (provably-pure-host-binding? (:expr node)))
+      (and (legacy/soac-map? node) (:pure? node))
+      (and (legacy/soac-reduce? node)
+           (empty? (:segment-axes node))
+           (reduction/scalar? (:reduction node)))))
+
+(defn- normalize-node-extents
+  "Replace `(alength <earlier pure result>)` with that result's already-known typed extent."
+  [nodes]
+  (:nodes
+   (reduce
+    (fn [{:keys [extents] :as state} node]
+      (if (or (legacy/soac-map? node) (legacy/soac-reduce? node))
+        (let [bound (:bound node)
+              array (when (and (seq? bound)
+                               (descriptor/alength-op? (descriptor/semantic-op bound)))
+                      (first (descriptor/call-args bound)))
+              bound' (get extents array bound)
+              node' (assoc node :bound bound')
+              produced (if (legacy/soac-map? node') [(:sym node')] (:outputs node'))]
+          (-> state
+              (update :nodes conj node')
+              (update :extents into (map (fn [result] [result bound']) produced))))
+        (update state :nodes conj node)))
+    {:nodes [] :extents {}}
+    nodes)))
+
+(defn- terminal-results
+  [nodes body]
+  (let [operations (filterv #(or (legacy/soac-map? %) (legacy/soac-reduce? %)) nodes)
+        definitions (set (mapcat (fn [node]
+                                   (if (legacy/soac-map? node) [(:sym node)] (:outputs node)))
+                                 operations))
+        operation-uses (set (mapcat #(concat (or (:inputs %) #{}) (or (:scalars %) #{}))
+                                    operations))
+        host-uses (set/union
+                   (set (mapcat #(when (legacy/scalar-binding? %)
+                                   (util/free-syms (:expr %)))
+                                nodes))
+                   (set (mapcat util/free-syms body)))]
+    (vec (sort-by pr-str
+                  (set/union (set/difference definitions operation-uses)
+                             (set/intersection definitions host-uses))))))
+
+(defn- equation-subprogram
+  [program equation]
+  (let [equation-id (second equation)
+        results (vec (nth equation 2))
+        extent (dialect/operation-extent equation)
+        inputs (cond-> (dialect/operation-inputs equation)
+                 (dialect/value-id? extent) (conj extent))
+        source-facts (dialect/facts program)
+        equation-facts (get-in source-facts [:equations equation-id])
+        value-ids (set (concat inputs results))
+        facts (-> source-facts
+                  (assoc :values (select-keys (:values source-facts) value-ids)
+                         :inputs (vec inputs)
+                         :equations {equation-id equation-facts}
+                         :effects (:effects equation-facts)))]
+    (dialect/make facts [equation] results)))
+
+(defn- scalar-region
+  [equation]
+  (let [[_ _ _ operation] equation
+        [_ attributes arrays captures lambda] operation
+        [_ _ body-results] lambda
+        {:keys [elements capture-parameters]} (dialect/parameter-layout equation)
+        substitutions
+        (into (zipmap capture-parameters captures)
+              (map (fn [parameter array]
+                     [parameter (list 'clojure.core/aget array (:index attributes))])
+                   elements arrays))]
+    (mapv #(util/subst-syms substitutions %) body-results)))
+
+(defn- allocation-pair
+  [values result extent]
+  (let [dtype (:dtype (get values result))
+        [allocation tag] (or (get dtype->allocation dtype)
+                             (throw (ex-info "TypedSOAC materialization has no array allocation"
+                                             {:reason :typed-soac-materialization-dtype
+                                              :result result :dtype dtype})))
+        result' (with-meta result {:tag tag :raster.type/tag tag
+                                   :raster.buffer/hoistable true})]
+    [result' (list allocation extent)]))
+
+(defn- realize-equation
+  [program equation]
+  (let [[_ equation-id results operation] equation
+        [kind attributes _ _ _] operation
+        values (:values (dialect/facts program))
+        bodies (scalar-region equation)
+        placement-facts (get-in (dialect/facts program) [:equations equation-id])
+        constituent-ids (or (some-> placement-facts :attributes :fusion/constituents keys set)
+                            #{(or (get-in placement-facts [:provenance :legacy-soac-id]) equation-id)})
+        placement (apply max constituent-ids)]
+    (case kind
+      map
+      (do
+        (when-not (= 1 (count results))
+          (throw (ex-info "the first production TypedSOAC route requires one map result"
+                          {:reason :typed-soac-production-subset
+                           :equation equation-id :results results})))
+        (let [result (first results)
+              dtype (:dtype (get values result))
+              [_ _ cast] (get dtype->allocation dtype)
+              effect (gensym (str "typed_soac_map_" equation-id "__"))
+              source (with-meta
+                       (list 'raster.par/map! result (:index attributes) (:extent attributes)
+                             cast (first bodies))
+                       {:raster.type/elem-type dtype})]
+          {:equation-id equation-id
+           :placement placement
+           :pairs [(allocation-pair values result (:extent attributes)) [effect source]]
+           :site [:binding effect]
+           :source source}))
+
+      reduce
+      (let [result (first results)
+            accumulator (first (:accumulators attributes))
+            source (list 'raster.par/reduce accumulator (first (:identities attributes))
+                         (:index attributes) (:extent attributes) (first bodies))]
+        {:equation-id equation-id
+         :placement placement
+         :pairs [[result source]]
+         :site [:binding result]
+         :source source}))))
+
+(defn- realize-source
+  [form nodes program]
+  (let [[let-head bindings & body] form
+        original-pairs (vec (partition 2 bindings))
+        realized (mapv #(realize-equation program %) (dialect/equations program))
+        by-placement (group-by :placement realized)
+        operation-id? (set (map :id (remove legacy/scalar-binding? nodes)))
+        pairs
+        (vec
+         (mapcat
+          (fn [id]
+            (concat
+             (when-not (contains? operation-id? id) [(nth original-pairs id)])
+             (mapcat :pairs (get by-placement id))))
+          (range (count original-pairs))))
+        source (with-meta (list* let-head (vec (mapcat identity pairs)) body) (meta form))]
+    {:source source :realized (into {} (map (juxt :equation-id identity)) realized)}))
+
+(defn- equation-operation?
+  [operation]
+  (boolean (fusion/equation-info operation)))
+
+(defn- envelope
+  [typed-program source realized]
+  (let [facts (dialect/facts typed-program)
+        equations
+        (mapv
+         (fn [equation]
+           (let [equation-id (second equation)
+                 subprogram (equation-subprogram typed-program equation)
+                 {:keys [site source]} (get realized equation-id)
+                 equation-facts (get-in facts [:equations equation-id])]
+             (parallel-program/->ProgramEquation
+              equation-id site source
+              (:inputs (dialect/facts subprogram)) (dialect/outputs subprogram)
+              subprogram [equation] (:effects equation-facts)
+              (assoc (:provenance equation-facts) :pass :typed-soac-fusion)
+              (assoc (:attributes equation-facts) :algorithm-dialect :typed-soac))))
+         (dialect/equations typed-program))]
+    (parallel-program/make
+     {:dialect :typed-soac
+      :source source
+      :values (:values facts)
+      :inputs (:inputs facts)
+      :equations equations
+      :outputs (dialect/outputs typed-program)
+      :effects (:effects facts)
+      :diagnostics (:diagnostics facts)
+      :provenance (assoc (:provenance facts) :pass :typed-soac-fusion)
+      :attributes {:host-control :typed-soac-materialization}
+      :operation? equation-operation?
+      :algorithm? (fn [equation algorithm]
+                    (and (= algorithm (dialect/validate! algorithm))
+                         (= (:operands equation) (:inputs (dialect/facts algorithm)))
+                         (= (:results equation) (dialect/outputs algorithm))))})))
+
+(defn attempt
+  "Return a typed production ParallelProgram result, an explicit `:declined` result, or nil when
+   the form is outside this closed subset. The legacy graph is used only as a temporary
+   differential oracle during migration."
+  ([form abstract-machine dtype]
+   (attempt form abstract-machine dtype {}))
+  ([form abstract-machine dtype array-types]
+   (when (and (seq? form) (contains? #{'let 'let*} (first form)))
+     (try
+       (let [[_ bindings & body] form
+             pairs (vec (partition 2 bindings))
+             source-nodes (legacy/let-bindings->nodes pairs)
+             nodes (normalize-node-extents source-nodes)]
+         (when (and (seq nodes) (every? supported-node? nodes))
+           (let [outputs (terminal-results nodes body)
+                 typed-input (adapter/legacy-nodes->program
+                              nodes {:outputs outputs :dtype dtype
+                                     :array-types array-types
+                                     :preserve-scalar-bindings? true})
+                 [typed-result typed-stats] (fusion/fusion-fixpoint typed-input)
+                 source-graph (graph/build-fusion-graph nodes)
+                 [legacy-result _] (graph/fusion-fixpoint source-graph abstract-machine dtype)
+                 shadow (adapter/legacy-nodes->program
+                         (:nodes legacy-result) {:outputs outputs :dtype dtype
+                                                 :array-types array-types
+                                                 :preserve-scalar-bindings? true})]
+             (cond
+               (not (pos? (:vertical typed-stats)))
+               {:declined {:reason :no-certified-vertical-fusion :stats typed-stats}}
+
+               (pos? (:horizontal typed-stats))
+               {:declined {:reason :typed-horizontal-materialization-pending :stats typed-stats}}
+
+               (not= (dialect/equations shadow) (dialect/equations typed-result))
+               {:declined {:reason :fusion-shadow-disagreement :stats typed-stats}}
+
+               :else
+               (let [{:keys [source realized]} (realize-source form source-nodes typed-result)]
+                 {:program (envelope typed-result source realized)
+                  :stats (assoc typed-stats :route :typed-soac
+                                :shadow-certified true)})))))
+       (catch clojure.lang.ExceptionInfo exception
+         (when (contains? #{:raster/fatal :raster/bug} (:reason (ex-data exception)))
+           (throw exception))
+         {:declined {:reason (or (:reason (ex-data exception)) :typed-soac-route-declined)
+                     :message (.getMessage exception)
+                     :details (ex-data exception)}})))))

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -41,6 +41,7 @@
             [raster.compiler.passes.parallel.par-fusion :as par-fusion]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.soac-graph :as soac-graph]
+            [raster.compiler.passes.parallel.typed-soac-route :as typed-soac-route]
             [raster.compiler.backend.gpu.entry :as gpu-entry]
             [raster.compiler.backend.gpu.par-opencl :as par-opencl]
             [raster.compiler.backend.gpu.c-emit :as c-emit]
@@ -759,10 +760,17 @@
   Returns {:form :stats}."
   [form opts]
   (if (form/binding-form? form)
-    (let [[let-sym bindings-vec & body-exprs] form
-          pairs (vec (partition 2 bindings-vec))
-          nodes (soac/let-bindings->nodes pairs)
-          graph (soac-graph/build-fusion-graph nodes)
+    (let [am (when (device/gpu-target? (:target-device opts))
+               (try (core-hw/abstract-machine (core-hw/descriptor-for (:target-device opts)))
+                    (catch Throwable _ nil)))]
+      (let [typed (when (not= false (:typed-soac-fusion? opts))
+                    (typed-soac-route/attempt form am (:dtype opts) (:array-types opts)))]
+        (if (:program typed)
+          {:form (:program typed) :stats (:stats typed)}
+          (let [[let-sym bindings-vec & body-exprs] form
+                pairs (vec (partition 2 bindings-vec))
+                nodes (soac/let-bindings->nodes pairs)
+                graph (soac-graph/build-fusion-graph nodes)
           ;; Hardware-GUIDED fusion: project the target to an Abstract Machine so the
           ;; vertical chooser can DECLINE unprofitable rematerialization (cost model,
           ;; not a device — see soac-graph/vertical-fusion-profitable?). Only for GPU
@@ -770,14 +778,12 @@
           ;; kernels is the documented failure mode; CPU/no-target → am nil → the
           ;; chooser is legality-only, byte-identical to before. Descriptor failure
           ;; degrades to nil (no decline), never breaks compilation.
-          am (when (device/gpu-target? (:target-device opts))
-               (try (core-hw/abstract-machine (core-hw/descriptor-for (:target-device opts)))
-                    (catch Throwable _ nil)))
-          [fused-graph stats] (soac-graph/fusion-fixpoint graph am (:dtype opts))
-          new-pairs (soac/nodes->let-bindings (:nodes fused-graph))
-          new-bindings (vec (mapcat identity new-pairs))]
-      {:form (list* let-sym new-bindings body-exprs)
-       :stats stats})
+                [fused-graph stats] (soac-graph/fusion-fixpoint graph am (:dtype opts))
+                new-pairs (soac/nodes->let-bindings (:nodes fused-graph))
+                new-bindings (vec (mapcat identity new-pairs))]
+            {:form (list* let-sym new-bindings body-exprs)
+             :stats (cond-> stats
+                      (:declined typed) (assoc :typed-soac-declined (:declined typed)))}))))
     ;; Not a let* form — fall back to par-fusion
     (par-fusion/par-fusion-pass form)))
 
@@ -849,7 +855,9 @@
   allocates output buffers and converts them to imperative par/map! forms.
   (=> :soac-fused :materialized)"
   [form opts]
-  (materialize/materialize-pass form opts))
+  (if (parallel-program/parallel-program? form)
+    {:form form :stats {:materialized 0 :typed-soac-preserved true}}
+    (materialize/materialize-pass form opts)))
 
 (defn- pass-segop-lower
   "Lower par forms to typed equations in a first-class SegOp ParallelProgram.
@@ -862,7 +870,9 @@
   and wraps them in raster.compiler/compound-kernel markers.
   Returns {:form :stats}."
   [form opts]
-  (compound-detect/compound-detect-pass form opts))
+  (if (parallel-program/parallel-program? form)
+    {:form form :stats {:compound-kernels 0 :typed-soac-preserved true}}
+    (compound-detect/compound-detect-pass form opts)))
 
 (defn- strip-compound-markers
   "Replace compound-kernel markers with their original dotimes form.
@@ -1704,7 +1714,11 @@
         value-reg   @types/soa-registry
         value-fn?   (boolean (some #(contains? value-reg (:tag %)) param-specs))
         pre-opts (cond-> {:inline? true :simd? false :target-device device-id
-                          :active-params active-params :dtype effective-dtype}
+                          :active-params active-params :dtype effective-dtype
+                          ;; The resident split pipeline still performs reduce-result device
+                          ;; realization between its pre/post halves. Keep it on the compatibility
+                          ;; source route until that transform consumes TypedSOAC equations.
+                          :typed-soac-fusion? false}
                    param-env (assoc :param-env param-env)
                    source-ns (assoc :source-ns source-ns))
         raw-form (if (= 1 (count walked-body)) (first walked-body) (cons 'do walked-body))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1,0 +1,101 @@
+(ns raster.compiler.passes.parallel.typed-soac-route-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
+            [raster.compiler.backend.jvm.par-simd :as par-simd]
+            [raster.compiler.ir.parallel-program :as parallel-program]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.pipeline :as pipeline]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
+            [raster.compiler.passes.parallel.typed-soac-route :as route]))
+
+(def ^:private map-map
+  '(let* [y (raster.par/pmap i n float
+                             (* (clojure.core/aget x i) (clojure.core/aget x i)))
+          z (raster.par/pmap j n float (+ (clojure.core/aget y j) 1.0))]
+         z))
+
+(def ^:private map-reduce
+  '(let* [y (raster.par/pmap i n float
+                             (* (clojure.core/aget x i) (clojure.core/aget x i)))
+          total (raster.par/reduce acc 0.0 j n (+ acc (clojure.core/aget y j)))]
+         total))
+
+(deftest pure-vertical-fusion-becomes-a-first-class-typed-program
+  (let [{:keys [program stats]} (route/attempt map-map nil :float)
+        equation (first (:equations program))]
+    (is (= :typed-soac (:dialect program)))
+    (is (= :typed-soac (:route stats)))
+    (is (:shadow-certified stats))
+    (is (= 1 (:vertical stats)))
+    (is (= 1 (count (:equations program))))
+    (is (= (:algorithm equation) (dialect/validate! (:algorithm equation))))
+    (is (not-any? #{'y} (flatten (:algorithm equation))))
+    (is (not-any? #{'y} (flatten (:source program))))
+    (is (some #{'clojure.core/float-array} (flatten (:source program))))))
+
+(deftest host-visible-intermediate-declines-the-single-consumer-subset
+  (let [source '(let* [y (raster.par/pmap i n float (* (clojure.core/aget x i) 2.0))
+                       z (raster.par/pmap j n float (+ (clojure.core/aget y j) 1.0))]
+                      [y z])]
+    (is (= :typed-soac-unknown-value
+           (get-in (route/attempt source nil :float) [:declined :reason]))
+        "the typed route must not erase a value also consumed by scalar host control")))
+
+(deftest effectful-host-binding-keeps-the-compatibility-route
+  (let [source '(let* [y (raster.par/pmap i n float (* (clojure.core/aget x i) 2.0))
+                       side (println y)
+                       z (raster.par/pmap j n float (+ (clojure.core/aget y j) 1.0))]
+                      z)]
+    (is (nil? (route/attempt source nil :float)))))
+
+(deftest semantic-alength-bounds-normalize-to-the-producing-extent
+  (let [source '(let* [n (clojure.core/alength x)
+                       y (raster.par/pmap i n float (* (clojure.core/aget x i) 2.0))
+                       z (raster.par/pmap j (clojure.core/alength y) float
+                                          (+ (clojure.core/aget y j) 1.0))]
+                      z)
+        program (:program (route/attempt source nil :float {'x :double}))
+        algorithm (get-in program [:equations 0 :algorithm])]
+    (is (= :typed-soac (:dialect program)))
+    (is (= 'n (dialect/operation-extent (first (dialect/equations algorithm)))))
+    (is (= :double (get-in (dialect/facts algorithm) [:values 'x :dtype])))
+    (is (= :float (get-in (dialect/facts algorithm) [:values 'z :dtype])))))
+
+(deftest typed-map-and-reduction-schedule-without-source-relowering
+  (doseq [[label source operation-class stat]
+          [["map" map-map raster.compiler.ir.segop.SegMap :simd-maps]
+           ["reduce" map-reduce raster.compiler.ir.segop.SegRed :simd-reduces]]]
+    (testing label
+      (let [typed (:program (route/attempt source nil :float))
+            {:keys [form stats]} (segop-lower/segop-lower-pass typed {:dtype :float})
+            simd (par-simd/simd-pass form :min-elements 1)]
+        (is (= :segop (:dialect form)))
+        (is (= 1 (:typed-soac-reused stats)))
+        (is (every? #(.isInstance ^Class operation-class %)
+                    (:operations (first (:equations form)))))
+        (is (= 1 (get-in simd [:stats stat])))
+        (is (= 1 (get-in simd [:stats :segop-reused])))
+        (is (nil? (get-in simd [:stats :segop-relowered])))
+        (parallel-program/validate! form segop/segop-node?)))))
+
+(deftest gpu-emission-consumes-the-same-certified-segmap
+  (let [typed (:program (route/attempt map-map nil :float))
+        scheduled (:form (segop-lower/segop-lower-pass
+                          typed {:dtype :float :target-device :ocl:0}))
+        emitted (opencl-pass/opencl-pass scheduled :device-id :ocl:0 :dtype :float)]
+    (is (= 1 (get-in emitted [:stats :ze-maps])))
+    (is (= 1 (get-in emitted [:stats :segop-reused])))
+    (is (nil? (get-in emitted [:stats :segop-relowered])))
+    (is (= 1 (count (:kernels emitted))))))
+
+(deftest production-pass-chain-preserves-the-typed-envelope
+  (let [scheduled (pipeline/run-passes
+                   map-map [:soac-fuse :materialize :compound-detect :segop-lower]
+                   {:dtype :float} :write-read-fused)
+        simd (par-simd/simd-pass scheduled :min-elements 1)]
+    (is (= :segop (:dialect scheduled)))
+    (is (= :typed-soac (get-in scheduled [:provenance :source-dialect])))
+    (is (= :typed-soac (get-in scheduled [:equations 0 :attributes :algorithm-dialect])))
+    (is (= 1 (get-in simd [:stats :segop-reused])))
+    (is (nil? (get-in simd [:stats :segop-relowered])))))


### PR DESCRIPTION
## Summary

- route the first closed production fusion subset (pure single-consumer map→map and map→scalar/full-reduce) through validated TypedSOAC ParallelPrograms
- mechanically realize compatibility host source while retaining the typed algorithm, then lower that same algorithm directly to SegMap/SegRed for JVM SIMD and OpenCL
- preserve explicit compatibility declines for host-visible intermediates, unknown/effectful scalar bindings, horizontal or multi-result fusion, and shadow disagreement
- keep the resident split pipeline on its current source route until reduce-result realization consumes typed equations
- update the compiler north-star with the exact landed and remaining boundaries

## Verification

- focused compiler/backend suite: 180 tests, 588 assertions
- full suite with a 1.4 GiB heap: 2471 tests, 35222 assertions, 0 failures, 0 errors
- OpenCL suite: available Intel Arc device, 0 tests took the skip path
- GPU suite: 1 available device, 0 tests took the skip path
- cljfmt and git diff checks clean

## Follow-up

Typed scalar/shape equations are next, followed by resident reduce-result realization and horizontal/multi-result/multi-consumer fusion. The legacy graph remains a temporary differential certificate until those forms are covered.