### PR TITLE
Represent scalar shapes in TypedSOAC

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -417,6 +417,14 @@ facts without backend re-analysis. Host-visible intermediates, unknown/effectful
 horizontal/multi-result fusion, and any disagreement with the temporary legacy shadow certificate
 decline explicitly.
 
+Pure host scalar dependencies now use the same ordered SSA spine through a typed `scalar` equation.
+The first production subset covers statically typed literals/aliases and semantic array-length
+queries, value-numbers `alength` of a produced tensor to its certified extent, and materializes the
+host spelling mechanically. Map/reduce captures also distinguish pointwise element operands,
+stable tensor reads and true scalar parameters. This lets the ordinary two-layer `predict-fn`
+retain typed dense→ReLU fusion without conflating weights or inner-reduction activations with the
+outer map shape, and preserves buffer versus scalar ABI roles through JVM/OpenCL lowering.
+
 This representation is shared before backend selection. SOAC fusion changes the program consumed
 by both JVM and accelerator lowerings; SegOp and schedule conversion then specialize it. The scalar
 spelling for the migrated subset is now generated from TypedSOAC rather than retained source, and
@@ -424,7 +432,9 @@ JVM SIMD/GPU reuse its certified SegOps. The resident split pipeline remains on 
 route because its reduce-result device-realization transform still operates between source-form
 pipeline halves. Migration is complete when that transform, horizontal/multi-consumer fusion and
 richer scalar equations operate on the typed envelope and the covered compatibility re-lowerings
-are deleted.
+are deleted. Nested reductions inside a retained map are typed and correctly classified, but the
+JVM SIMD leaf still lowers those inner regions through its established scalar fallback; this is an
+explicit scheduling boundary rather than a loss of semantic facts.
 
 ### 3.3 Schedule and transform IR
 
@@ -773,8 +783,9 @@ The immediate continuation after the verified double-buffered weighted-reduction
    and remove the attention-provenance gate from routed weighted-reduction lowering.
 5. **In progress:** migrate the remaining SOAC fusion rules and scalar JVM fallback, then remove
    compatibility re-lowering for the covered forms. Single-consumer pure map→map/map→reduce now has
-   a production typed route shared by JVM SIMD and OpenCL; horizontal/multi-consumer fusion, typed
-   scalar equations and resident reduce-result realization remain.
+   a production typed route shared by JVM SIMD and OpenCL; typed scalar/shape equations and stable
+   tensor capture roles now carry realistic nested-reduction maps as well. Horizontal/multi-
+   consumer fusion, nested-region JVM scheduling and resident reduce-result realization remain.
 6. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a
    read-only distributed track without interrupting the kernel and typed-middle-end verticals.
 

--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -423,7 +423,9 @@ queries, value-numbers `alength` of a produced tensor to its certified extent, a
 host spelling mechanically. Map/reduce captures also distinguish pointwise element operands,
 stable tensor reads and true scalar parameters. This lets the ordinary two-layer `predict-fn`
 retain typed dense→ReLU fusion without conflating weights or inner-reduction activations with the
-outer map shape, and preserves buffer versus scalar ABI roles through JVM/OpenCL lowering.
+outer map shape, and preserves buffer versus scalar ABI roles through JVM/OpenCL lowering. Scalar
+result dtypes come from retained walker/TypedClojure tags; `AbstractValue` transports those dtypes,
+while the scheduled operation—not tensor rank—declares whether an ABI value is a scalar or buffer.
 
 This representation is shared before backend selection. SOAC fusion changes the program consumed
 by both JVM and accelerator lowerings; SegOp and schedule conversion then specialize it. The scalar

--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -446,7 +446,11 @@
            tag (when (symbol? arr) (or (:raster.type/tag (meta arr)) (:tag (meta arr))))]
        (get tag->ctype tag "int"))
 
-     (and (seq? expr) (contains? #{'inc 'dec 'clojure.core/inc 'clojure.core/dec} (first expr)))
+     (and (seq? expr)
+          (contains? #{'inc 'dec 'clojure.core/inc 'clojure.core/dec
+                       'unchecked-inc-int 'unchecked-dec-int
+                       'clojure.core/unchecked-inc-int 'clojure.core/unchecked-dec-int}
+                     (first expr)))
      (let [inner-type (infer-c-type (second expr))]
        (if (= inner-type "int") "int" *scalar-type*))
 
@@ -495,8 +499,6 @@
 ;; ================================================================
 ;; Side effect detection
 ;; ================================================================
-
-
 
 ;; ================================================================
 ;; Backend-specific helpers
@@ -1133,7 +1135,11 @@
            ;; value, not the first loop var (usually the int counter — assigning a
            ;; double accumulator into it would truncate).
            (let [result-var (str (c-symbol (first var-names)) "_res")
-                 result-type (remap-type (if terminal (infer-c-type terminal) *scalar-type*))
+                 ;; A terminal loop variable has the type declared by its initializer. Reusing
+                 ;; that fact avoids guessing the accumulator type from a bare symbol.
+                 result-type (or (get (zipmap var-names var-types) terminal)
+                                 (remap-type
+                                  (if terminal (infer-c-type terminal) *scalar-type*)))
                  loop-body (binding [*loop-result-var* result-var]
                              (emit-loop-body body var-names var-types idx-sym array-syms opencl-idx))]
              (str "({ " decls " " result-type " " result-var "; while (1) { " loop-body " } " result-var "; })"))
@@ -1205,11 +1211,15 @@
 
      ;; unchecked-inc / unchecked-dec as (x + 1) / (x - 1), NOT ++/--
      (and (seq? expr) (= 2 (count expr))
-          (contains? #{'clojure.core/unchecked-inc 'unchecked-inc} (first expr)))
+          (contains? #{'clojure.core/unchecked-inc 'unchecked-inc
+                       'clojure.core/unchecked-inc-int 'unchecked-inc-int}
+                     (first expr)))
      (str "((" (emit-expr (second expr) idx-sym array-syms opencl-idx) ") + 1)")
 
      (and (seq? expr) (= 2 (count expr))
-          (contains? #{'clojure.core/unchecked-dec 'unchecked-dec} (first expr)))
+          (contains? #{'clojure.core/unchecked-dec 'unchecked-dec
+                       'clojure.core/unchecked-dec-int 'unchecked-dec-int}
+                     (first expr)))
      (str "((" (emit-expr (second expr) idx-sym array-syms opencl-idx) ") - 1)")
 
      ;; unchecked-*-int as binary infix

--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -446,11 +446,7 @@
            tag (when (symbol? arr) (or (:raster.type/tag (meta arr)) (:tag (meta arr))))]
        (get tag->ctype tag "int"))
 
-     (and (seq? expr)
-          (contains? #{'inc 'dec 'clojure.core/inc 'clojure.core/dec
-                       'unchecked-inc-int 'unchecked-dec-int
-                       'clojure.core/unchecked-inc-int 'clojure.core/unchecked-dec-int}
-                     (first expr)))
+     (and (seq? expr) (contains? #{'inc 'dec 'clojure.core/inc 'clojure.core/dec} (first expr)))
      (let [inner-type (infer-c-type (second expr))]
        (if (= inner-type "int") "int" *scalar-type*))
 

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -7,8 +7,10 @@
 
    This is the GPU counterpart of simd-pass — both consume the same
    par form vocabulary but produce different target code."
-  (:require [raster.compiler.ir.par :as par]
+  (:require [clojure.set :as set]
+            [raster.compiler.ir.par :as par]
             [raster.compiler.ir.soac]
+            [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
@@ -41,13 +43,6 @@
 ;; raster.gpu.core/compile-deftm-internal! and the pipeline's pass-backend).
 ;; ================================================================
 
-(def array-tag->dtype
-  "Deftm array tag (the Java array-class symbol) → element dtype keyword."
-  {'doubles :double 'floats :float 'longs :long 'ints :int 'bytes :byte
-   ;; JVM short[] is Raster's bit-preserving FP16 storage carrier. Kernels see `half*`; the
-   ;; semantic pipeline still performs scalar/index arithmetic at a JVM-supported dtype.
-   'shorts :half})
-
 (defn derive-param-types
   "Declared scalar + array element types for the GPU emitter, read from a deftm's params + tags
   (the typed-dispatch system already knows these — we read them instead of letting the emitter
@@ -59,13 +54,13 @@
   [params tags dtype]
   (when (and params tags)
     {:scalar-types (into {} (keep (fn [[p t]]
-                                    (case t
-                                      (long int) [p :int]
-                                      (double float) [p :float]
+                                    (case (dtype/dtype-for-scalar-tag t)
+                                      (:long :int) [p :int]
+                                      (:double :float) [p :float]
                                       nil))
                                   (map vector params tags)))
      :array-types (into {} (keep (fn [[p t]]
-                                   (when-let [dt (array-tag->dtype t)]
+                                   (when-let [dt (dtype/dtype-for-array-tag t)]
                                      [p (if (#{:float :double} dt) dtype dt)]))
                                  (map vector params tags)))}))
 
@@ -283,13 +278,22 @@
   (let [parallel-program (when (parallel-program/parallel-program? form)
                            (parallel-program/validate! form segop/segop-node?))
         source-form (if parallel-program (parallel-program/source-form parallel-program) form)
-        ;; The TypedSOAC route's AbstractValues are declared source facts. Compatibility SegOp
-        ;; envelopes still infer some host scalars at element dtype and must retain their existing
-        ;; metadata/name fallback until that adapter is retired.
-        program-types (when (and parallel-program
-                                 (= :typed-soac
-                                    (get-in parallel-program [:provenance :source-dialect])))
-                        (parallel-program/declared-parameter-types parallel-program))
+        ;; Typed values supply dtypes; scheduled SegOps supply ABI roles. Logical rank cannot choose
+        ;; pass-by-value versus buffer because a rank-zero result may be resident in either form.
+        program-types
+        (when (and parallel-program
+                   (= :typed-soac (get-in parallel-program [:provenance :source-dialect])))
+          (let [operations (mapcat :operations (:equations parallel-program))
+                arrays (set (mapcat #(concat (or (:inputs %) #{}) (or (:outputs %) #{}))
+                                    operations))
+                scalars (set (mapcat #(or (:scalars %) #{}) operations))
+                overlap (set/intersection arrays scalars)]
+            (when (seq overlap)
+              (throw (ex-info "scheduled values have contradictory buffer and scalar ABI roles"
+                              {:reason :parallel-program-parameter-role-conflict
+                               :values overlap})))
+            {:scalar-types (parallel-program/declared-value-types parallel-program scalars)
+             :array-types (parallel-program/declared-value-types parallel-program arrays)}))
         top-scalar-types (merge (or (:scalar-types program-types) {})
                                 (or (:scalar-types (meta source-form)) {})
                                 (or (:scalar-types (meta form)) {}) scalar-types)

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -283,9 +283,18 @@
   (let [parallel-program (when (parallel-program/parallel-program? form)
                            (parallel-program/validate! form segop/segop-node?))
         source-form (if parallel-program (parallel-program/source-form parallel-program) form)
-        top-scalar-types (merge (or (:scalar-types (meta source-form)) {})
+        ;; The TypedSOAC route's AbstractValues are declared source facts. Compatibility SegOp
+        ;; envelopes still infer some host scalars at element dtype and must retain their existing
+        ;; metadata/name fallback until that adapter is retired.
+        program-types (when (and parallel-program
+                                 (= :typed-soac
+                                    (get-in parallel-program [:provenance :source-dialect])))
+                        (parallel-program/declared-parameter-types parallel-program))
+        top-scalar-types (merge (or (:scalar-types program-types) {})
+                                (or (:scalar-types (meta source-form)) {})
                                 (or (:scalar-types (meta form)) {}) scalar-types)
-        top-array-types (merge (or (:array-types (meta source-form)) {})
+        top-array-types (merge (or (:array-types program-types) {})
+                               (or (:array-types (meta source-form)) {})
                                (or (:array-types (meta form)) {}) array-types)
         stats (atom {:ze-maps 0 :ze-reduces 0 :ze-compounds 0 :ze-contracts 0
                      :ze-structured-reductions 0 :fallback 0})

--- a/src/raster/compiler/core/dtype.clj
+++ b/src/raster/compiler/core/dtype.clj
@@ -99,11 +99,32 @@
 
 (defn array-tag-for-dtype
   "Primitive-array dispatch tag for a dtype (e.g. :float → 'floats). Throws on
-   an unknown dtype."
+  an unknown dtype."
   [dtype]
   (or (:array-tag (get dtype-info dtype))
       (throw (ex-info (str "array-tag-for-dtype: unknown dtype `" dtype "`.")
                       {:dtype dtype}))))
+
+(defn dtype-for-scalar-tag
+  "Compiler dtype declared by a JVM scalar dispatch tag, or nil when the tag is not a supported
+   primitive scalar. This is the reverse projection of the `:scalar-tag` facet, not a second type
+   table."
+  [tag]
+  ;; `:half` deliberately has no JVM primitive scalar tag.  An absent source
+  ;; fact must therefore remain absent, not compare equal to that nil facet.
+  (when tag
+    (some (fn [[dtype facets]]
+            (when (= tag (:scalar-tag facets)) dtype))
+          dtype-info)))
+
+(defn dtype-for-array-tag
+  "Compiler element dtype declared by a JVM primitive-array dispatch tag, or nil. This is the
+   reverse projection of the canonical `:array-tag` facet."
+  [tag]
+  (when tag
+    (some (fn [[dtype facets]]
+            (when (= tag (:array-tag facets)) dtype))
+          dtype-info)))
 
 (defn needs-pragma-for
   "The OpenCL extension pragma keyword this dtype requires (e.g. :half →

--- a/src/raster/compiler/ir/dialects.clj
+++ b/src/raster/compiler/ir/dialects.clj
@@ -520,7 +520,7 @@
             (let [body (when (and (seq? operation) (= '= (first operation))
                                   (= 4 (count operation)))
                          (nth operation 3))]
-              (and (seq? body) (contains? #{'map 'reduce} (first body)))))
+              (and (seq? body) (contains? #{'scalar 'map 'reduce} (first body)))))
           (fn [_ algorithm]
             (= algorithm (soac-dialect/validate! algorithm))))
          (valid-let*-ordered? (:source value))

--- a/src/raster/compiler/ir/parallel_program.clj
+++ b/src/raster/compiler/ir/parallel_program.clj
@@ -83,9 +83,16 @@
              (throw (ex-info "equation references an unknown value"
                              {:reason :parallel-program-unknown-value
                               :equation (:id equation) :field field :id id})))))
-       (when-not (and (vector? (:operations equation)) (seq (:operations equation)))
-         (throw (ex-info "equation requires one or more ordered operations"
+       (when-not (and (vector? (:operations equation))
+                      (or (seq (:operations equation))
+                          (true? (get-in equation [:attributes :host-only]))))
+         (throw (ex-info "equation requires ordered operations or an explicit host-only contract"
                          {:reason :parallel-program-operations :equation (:id equation)})))
+       (when (and (true? (get-in equation [:attributes :host-only]))
+                  (seq (:operations equation)))
+         (throw (ex-info "host-only equations cannot carry scheduled operations"
+                         {:reason :parallel-program-host-only-operations
+                          :equation (:id equation)})))
        (doseq [operation (:operations equation)]
          (when-not (operation? operation)
            (throw (ex-info "an illegal operation remains after full dialect conversion"
@@ -134,6 +141,28 @@
   "The compatibility host expression surrounding the explicit parallel equations."
   [program]
   (:source (validate! program)))
+
+(defn declared-parameter-types
+  "Project backend parameter dtypes from a validated program's value contracts.
+
+   Scalar tensors have shape `[]`; tensor values with one or more dimensions are buffers. Only
+   symbol IDs can name parameters in the compatibility host expression. Explicit backend options
+   may still override this projection, but a typed program never needs to rediscover an index dtype
+   from a spelling such as `cols`."
+  [program]
+  (let [values (:values (validate! program))
+        typed-symbols (keep (fn [[id value]]
+                              (when (and (symbol? id)
+                                         (= :tensor (:kind value))
+                                         (keyword? (:dtype value)))
+                                [id value]))
+                            values)]
+    {:scalar-types (into {} (keep (fn [[id value]]
+                                    (when (empty? (:shape value)) [id (:dtype value)])))
+                         typed-symbols)
+     :array-types (into {} (keep (fn [[id value]]
+                                   (when (seq (:shape value)) [id (:dtype value)])))
+                        typed-symbols)}))
 
 (defn equation-for-binding
   "Find the equation for a binding only when the current source still matches its certified source.

--- a/src/raster/compiler/ir/parallel_program.clj
+++ b/src/raster/compiler/ir/parallel_program.clj
@@ -142,27 +142,23 @@
   [program]
   (:source (validate! program)))
 
-(defn declared-parameter-types
-  "Project backend parameter dtypes from a validated program's value contracts.
+(defn declared-value-types
+  "Project declared dtypes for an explicit collection of value IDs.
 
-   Scalar tensors have shape `[]`; tensor values with one or more dimensions are buffers. Only
-   symbol IDs can name parameters in the compatibility host expression. Explicit backend options
-   may still override this projection, but a typed program never needs to rediscover an index dtype
-   from a spelling such as `cols`."
-  [program]
-  (let [values (:values (validate! program))
-        typed-symbols (keep (fn [[id value]]
-                              (when (and (symbol? id)
-                                         (= :tensor (:kind value))
-                                         (keyword? (:dtype value)))
-                                [id value]))
-                            values)]
-    {:scalar-types (into {} (keep (fn [[id value]]
-                                    (when (empty? (:shape value)) [id (:dtype value)])))
-                         typed-symbols)
-     :array-types (into {} (keep (fn [[id value]]
-                                   (when (seq (:shape value)) [id (:dtype value)])))
-                        typed-symbols)}))
+   The caller supplies ABI/storage roles from its scheduled operation. Logical rank is deliberately
+   not used to guess whether a value is passed by value or by buffer: a rank-zero tensor may later
+   be realized either way."
+  [program ids]
+  (let [values (:values (validate! program))]
+    (into {}
+          (map (fn [id]
+                 (let [value (get values id)]
+                   (when-not (and (symbol? id) value (keyword? (:dtype value)))
+                     (throw (ex-info "scheduled parameter lacks a declared symbolic value dtype"
+                                     {:reason :parallel-program-parameter-dtype
+                                      :id id :value value})))
+                   [id (:dtype value)])))
+          ids)))
 
 (defn equation-for-binding
   "Find the equation for a binding only when the current source still matches its certified source.

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -10,6 +10,9 @@
 
      (soac-program facts
        [(= equation-id [result ...]
+           (scalar {:dtypes [:long ...]} [capture ...]
+             (lambda [capture-parameter ...] [result-expr ...])))
+        (= equation-id [result ...]
            (map {:index i :extent n} [array ...] [capture ...]
              (lambda [element ... capture-parameter ...] [result-expr ...])))
         (= equation-id [result ...]
@@ -85,6 +88,14 @@
        (every? keyword? (:dtypes value))
        (every? map? (:algebra value))))
 
+(defn scalar-attributes?
+  [value]
+  (and (map? value)
+       (vector? (:dtypes value))
+       (seq (:dtypes value))
+       (every? keyword? (:dtypes value))
+       (or (nil? (:attributes value)) (map? (:attributes value)))))
+
 (defn equation-facts?
   [value]
   (and (map? value)
@@ -113,6 +124,7 @@
              [eid equation-id?]
              [sym symbol?]
              [lit scalar-literal?]
+             [sa scalar-attributes?]
              [ma map-attributes?]
              [ra reduce-attributes?]
              [facts program-facts?])
@@ -130,6 +142,7 @@
           (lambda [(?:* ?sym:parameter)] [(?:+ s)]))
 
   (Operation [o :enforce]
+             (scalar ?sa [(?:* ?id:capture)] ?l)
              (map ?ma [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
              (reduce ?ra [(?:* ?id:array)] [(?:* ?id:capture)] ?l))
 
@@ -157,17 +170,31 @@
   "Ordered array and capture operands of an equation. Extent is a separate scalar operand."
   [equation]
   (let [operation (nth equation 3)]
-    (vec (concat (nth operation 2) (nth operation 3)))))
+    (if (= 'scalar (first operation))
+      (vec (nth operation 2))
+      (vec (concat (nth operation 2) (nth operation 3))))))
 
 (defn operation-extent
   [equation]
-  (:extent (second (nth equation 3))))
+  (let [operation (nth equation 3)]
+    (when-not (= 'scalar (first operation))
+      (:extent (second operation)))))
+
+(defn operation-parts
+  "Normalize one operation into semantic fields shared by validation and lowering."
+  [equation]
+  (let [operation (nth equation 3)
+        kind (first operation)]
+    (if (= 'scalar kind)
+      (let [[_ attributes captures lambda] operation]
+        {:kind kind :attributes attributes :arrays [] :captures captures :lambda lambda})
+      (let [[_ attributes arrays captures lambda] operation]
+        {:kind kind :attributes attributes :arrays arrays :captures captures :lambda lambda}))))
 
 (defn parameter-layout
   "Split a SOAC lambda's ordered parameters into semantic roles."
   [equation]
-  (let [[_ _ _ operation] equation
-        [kind attributes arrays captures lambda] operation
+  (let [{:keys [kind attributes arrays captures lambda]} (operation-parts equation)
         parameters (vec (second lambda))
         accumulator-count (if (= 'reduce kind) (count (:accumulators attributes)) 0)
         array-count (count arrays)
@@ -188,9 +215,8 @@
 (defn- validate-equation!
   [equation]
   (let [[_ equation-id results operation] equation
-        [_ attributes arrays captures lambda] operation
+        {:keys [kind attributes arrays captures lambda]} (operation-parts equation)
         [_ parameters body-results] lambda
-        kind (first operation)
         result-count (count results)]
     (when-not (distinct-vector? results)
       (fail! :typed-soac-equation-results "SOAC equation results must be distinct"
@@ -202,6 +228,13 @@
     (when (seq (set/intersection (set arrays) (set captures)))
       (fail! :typed-soac-operand-role "one value cannot be both an element input and a capture"
              {:equation equation-id :arrays arrays :captures captures}))
+    (let [stable-array-captures (get-in attributes [:attributes :stable-array-captures] [])]
+      (when-not (and (distinct-vector? stable-array-captures)
+                     (set/subset? (set stable-array-captures) (set captures)))
+        (fail! :typed-soac-stable-array-captures
+               "stable array capture roles must be an ordered subset of captures"
+               {:equation equation-id :stable-array-captures stable-array-captures
+                :captures captures})))
     (when-not (distinct-vector? parameters)
       (fail! :typed-soac-lambda-parameters "SOAC lambda parameters must be distinct"
              {:equation equation-id :parameters parameters}))
@@ -225,12 +258,20 @@
                 :arrays arrays
                 :captures captures})))
     (doseq [body body-results
-            :let [unbound (util/free-syms body (set parameters))]
+            :let [bound (cond-> (set parameters)
+                          (contains? #{'map 'reduce} kind) (conj (:index attributes)))
+                  unbound (util/free-syms body bound)]
             :when (seq unbound)]
       (fail! :typed-soac-unbound-scalar
              "scalar regions may reference only their explicit lambda parameters"
              {:equation equation-id :unbound unbound :body body}))
     (case kind
+      scalar
+      (when-not (= result-count (count (:dtypes attributes)))
+        (fail! :typed-soac-scalar-results
+               "scalar result arity must equal its declared dtype arity"
+               {:equation equation-id :results results :dtypes (:dtypes attributes)}))
+
       map
       nil
 
@@ -251,9 +292,10 @@
 
 (defn- validate-equation-types!
   [values equation]
-  (let [[_ equation-id results operation] equation
-        [kind attributes arrays] operation
-        extent (:extent attributes)]
+  (let [[_ equation-id results] equation
+        {:keys [kind attributes arrays]} (operation-parts equation)
+        extent (:extent attributes)
+        stable-array-captures (get-in attributes [:attributes :stable-array-captures] [])]
     (doseq [id arrays]
       (let [value (get values id)]
         ;; Unknown IDs receive the more precise boundary diagnostic below.
@@ -262,7 +304,24 @@
           (fail! :typed-soac-array-type
                  "SOAC element operands must be rank-one tensors over the declared extent"
                  {:equation equation-id :id id :value value :extent extent}))))
+    (doseq [id stable-array-captures]
+      (let [value (get values id)]
+        (when (and value
+                   (not (and (= :tensor (:kind value)) (seq (:shape value)))))
+          (fail! :typed-soac-stable-array-type
+                 "stable array captures must have a non-scalar tensor contract"
+                 {:equation equation-id :id id :value value}))))
     (case kind
+      scalar
+      (doseq [[id dtype] (map vector results (:dtypes attributes))]
+        (let [value (get values id)]
+          (when (and value
+                     (not (and (= :tensor (:kind value)) (= [] (:shape value))
+                               (= dtype (:dtype value)))))
+            (fail! :typed-soac-scalar-result-type
+                   "scalar results must be scalar tensors with their declared dtype"
+                   {:equation equation-id :id id :value value :dtype dtype}))))
+
       map
       (doseq [id results]
         (let [value (get values id)]
@@ -387,9 +446,10 @@
             (let [id (rename dimension)]
               (if (symbol? id) id (list 'value id)))
 
-            (and (seq? dimension) (= 'value (first dimension)) (= 2 (count dimension))
+            (and (seq? dimension) (contains? #{'value 'unknown-dimension} (first dimension))
+                 (= 2 (count dimension))
                  (contains? value-map (second dimension)))
-            (list 'value (rename (second dimension)))
+            (list (first dimension) (rename (second dimension)))
 
             :else dimension))
         rename-value (fn [value] (update value :shape #(mapv rename-dimension %)))
@@ -403,12 +463,19 @@
                               (assoc result id' (rename-value value))))
                           {} (:values source-facts))
         equation-forms
-        (mapv (fn [[equals equation-id results operation]]
-                (let [[kind attributes arrays captures lambda] operation]
-                  (list equals equation-id (mapv rename results)
-                        (list kind (update attributes :extent
-                                           #(if (value-id? %) (rename %) %))
-                              (mapv rename arrays) (mapv rename captures) lambda))))
+        (mapv (fn [[equals equation-id results :as equation]]
+                (let [{:keys [kind attributes arrays captures lambda]} (operation-parts equation)
+                      attributes (cond-> attributes
+                                   (seq (get-in attributes
+                                                [:attributes :stable-array-captures]))
+                                   (update-in [:attributes :stable-array-captures]
+                                              #(mapv rename %)))
+                      operation (if (= 'scalar kind)
+                                  (list kind attributes (mapv rename captures) lambda)
+                                  (list kind (update attributes :extent
+                                                     #(if (value-id? %) (rename %) %))
+                                        (mapv rename arrays) (mapv rename captures) lambda))]
+                  (list equals equation-id (mapv rename results) operation)))
               (equations program))
         rename-aliases
         (fn [aliases]

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -279,13 +279,18 @@
                    kind (soac-dialect/operation-kind
                          (first (soac-dialect/equations algorithm)))
                    operations (case kind
+                                scalar []
                                 map (soac-lower/lower-typed-map algorithm device-id :dtype dtype)
                                 reduce (soac-lower/lower-typed-reduce algorithm device-id :dtype dtype))]
                (-> equation
                    (assoc :operations operations)
                    (update :provenance assoc :target-dialect :segop)
-                   (update :attributes assoc :device device-id))))
+                   (update :attributes assoc :device device-id)
+                   (cond-> (= 'scalar kind)
+                     (update :attributes assoc :host-only true)))))
            (:equations form))
+          parallel-equation-count (count (remove #(get-in % [:attributes :host-only]) equations))
+          scalar-equation-count (- (count equations) parallel-equation-count)
           lowered (assoc form
                          :dialect :segop
                          :equations equations
@@ -298,9 +303,10 @@
                 (and (= algorithm (soac-dialect/validate! algorithm))
                      (= (:operands equation) (:inputs (soac-dialect/facts algorithm)))
                      (= (:results equation) (soac-dialect/outputs algorithm)))))
-       :stats {:segops-lowered (count equations)
+       :stats {:segops-lowered parallel-equation-count
                :kernel-graphs-lowered 0
-               :typed-soac-reused (count equations)}})
+               :typed-soac-reused parallel-equation-count
+               :typed-scalar-equations scalar-equation-count}})
     (if-not (form/binding-form? form)
       {:form (build-program form [] [] (:target-device opts) (:dtype opts))
        :stats {:segops-lowered 0 :kernel-graphs-lowered 0}}

--- a/src/raster/compiler/passes/parallel/soac_dialect_adapter.clj
+++ b/src/raster/compiler/passes/parallel/soac_dialect_adapter.clj
@@ -63,6 +63,14 @@
                   (map vector arrays parameters)))
         expressions))
 
+(defn- pointwise-input?
+  [expressions array index]
+  (let [reads (filter (fn [{:keys [sym]}]
+                        (and (symbol? sym) (= (name array) (name sym))))
+                      (mapcat descriptor/aget-reads expressions))]
+    (and (seq reads)
+         (every? #(= index (descriptor/unwrap-int-cast (:idx %))) reads))))
+
 (defn- cast-result
   [cast expression]
   (if cast (list cast expression) expression))
@@ -97,15 +105,19 @@
 
 (defn- map-equation
   [node aliases]
-  (let [arrays (vec (sort-by pr-str (:inputs node)))
-        captures (vec (sort-by pr-str (:scalars node)))
+  (let [{:keys [results expressions]} (horizontal-map-parts node aliases)
+        [pointwise stable] ((juxt filter remove)
+                            #(pointwise-input? expressions % (:idx node))
+                            (:inputs node))
+        arrays (vec (sort-by pr-str pointwise))
+        captures (vec (sort-by pr-str (distinct (concat stable (:scalars node)))))
         parameters (element-symbols (count arrays))
         capture-parameters (capture-symbols (count captures))
-        {:keys [results expressions]} (horizontal-map-parts node aliases)
         body-results (->> (elementize expressions arrays parameters (:idx node))
                           (mapv #(util/subst-syms (zipmap captures capture-parameters) %)))]
     (list '= (:id node) results
-          (list 'map {:index (:idx node) :extent (:bound node)}
+          (list 'map {:index (:idx node) :extent (:bound node)
+                      :attributes {:stable-array-captures (vec (sort-by pr-str stable))}}
                 arrays captures
                 (list 'lambda (vec (concat parameters capture-parameters)) body-results)))))
 
@@ -121,15 +133,19 @@
              "legacy adapter covers one-component reductions only"
              {:node (:id node) :components (count (:components product))}))
     (let [component (first (:components product))
-          arrays (vec (sort-by pr-str (:inputs node)))
-          captures (vec (sort-by pr-str (:scalars node)))
+          expressions (:results (reduction/fold-region product))
+          [pointwise stable] ((juxt filter remove)
+                              #(pointwise-input? expressions % (:index product))
+                              (:inputs node))
+          arrays (vec (sort-by pr-str pointwise))
+          captures (vec (sort-by pr-str (distinct (concat stable (:scalars node)))))
           element-parameters (element-symbols (count arrays))
           capture-parameters (capture-symbols (count captures))
-          body-results (->> (elementize (:results (reduction/fold-region product))
-                                        arrays element-parameters (:index product))
+          body-results (->> (elementize expressions arrays element-parameters (:index product))
                             (mapv #(util/subst-syms (zipmap captures capture-parameters) %)))
           attributes {:index (:index product)
                       :extent (:bound node)
+                      :attributes {:stable-array-captures (vec (sort-by pr-str stable))}
                       :accumulators [(:accumulator component)]
                       :identities [(:neutral component)]
                       :dtypes [(:dtype component)]
@@ -141,6 +157,32 @@
                                      element-parameters capture-parameters))
                         body-results))))))
 
+(defn- scalar-dtype
+  [expression scalar-dtypes scalar-types]
+  (cond
+    (and (seq? expression)
+         (descriptor/alength-op? (descriptor/semantic-op expression))) :long
+    (symbol? expression) (or (get scalar-dtypes expression) (get scalar-types expression))
+    (instance? Float expression) :float
+    (number? expression) (if (integer? expression) :long :double)
+    (boolean? expression) :boolean
+    :else nil))
+
+(defn- scalar-equation
+  [node scalar-dtypes scalar-types]
+  (let [expression (:expr node)
+        captures (vec (sort-by pr-str (util/free-syms expression)))
+        parameters (capture-symbols (count captures))
+        dtype (scalar-dtype expression scalar-dtypes scalar-types)]
+    (when-not dtype
+      (fail! :unsupported-scalar-binding
+             "typed scalar equations require a statically known result dtype"
+             {:node (:id node) :symbol (:sym node) :expression expression}))
+    (list '= (:id node) [(:sym node)]
+          (list 'scalar {:dtypes [dtype]} captures
+                (list 'lambda parameters
+                      [(util/subst-syms (zipmap captures parameters) expression)])))))
+
 (defn- operation-equation
   [node aliases]
   (cond
@@ -150,6 +192,20 @@
     (fail! :unsupported-legacy-soac
            "legacy adapter supports only map and scalar/full reduce nodes"
            {:node (:id node) :type (.getName (class node))})))
+
+(defn- selected-scalar-symbols
+  [nodes operation-equations outputs]
+  (let [by-symbol (into {} (keep #(when (legacy/scalar-binding? %) [(:sym %) %])) nodes)
+        roots (set (concat outputs
+                           (mapcat (fn [equation]
+                                     (cond-> (dialect/operation-inputs equation)
+                                       (dialect/value-id? (dialect/operation-extent equation))
+                                       (conj (dialect/operation-extent equation))))
+                                   operation-equations)))]
+    (loop [needed (set/intersection roots (set (keys by-symbol)))]
+      (let [dependencies (set (mapcat #(util/free-syms (:expr (get by-symbol %))) needed))
+            needed' (set/union needed (set/intersection dependencies (set (keys by-symbol))))]
+        (if (= needed needed') needed (recur needed'))))))
 
 (defn- tensor-value
   [dtype shape]
@@ -163,25 +219,36 @@
       :double))
 
 (defn- equation-values
-  [equation default-dtype array-types]
+  [equation default-dtype array-types known-values]
   (let [[_ _ results operation] equation
-        [kind attributes arrays captures] operation
+        {:keys [kind attributes arrays captures]} (dialect/operation-parts equation)
         extent (:extent attributes)
-        result-dtypes (if (= 'reduce kind)
-                        (:dtypes attributes)
+        stable-array-captures (set (get-in attributes [:attributes :stable-array-captures]))
+        result-dtypes (case kind
+                        scalar (:dtypes attributes)
+                        reduce (:dtypes attributes)
                         (repeat (count results) default-dtype))]
     (merge
-     (if (dialect/value-id? extent) {extent (tensor-value :long [])} {})
+     (if (and extent (dialect/value-id? extent)) {extent (tensor-value :long [])} {})
      (into {} (map (fn [id]
                      [id (tensor-value (value-dtype id default-dtype array-types)
                                        (dialect/extent-shape extent))])
                    arrays))
-     (into {} (map (fn [id]
-                     [id (tensor-value (value-dtype id default-dtype array-types) [])])
-                   captures))
+     (if (= 'scalar kind)
+       {}
+       (into {} (map (fn [id]
+                       [id (or (get known-values id)
+                               (if (or (contains? stable-array-captures id)
+                                       (contains? array-types id)
+                                       (and (symbol? id)
+                                            (contains? array-types (symbol (name id)))))
+                                 (tensor-value (value-dtype id default-dtype array-types)
+                                               [(list 'unknown-dimension id)])
+                                 (tensor-value (value-dtype id default-dtype array-types) [])))])
+                     captures)))
      (into {} (map (fn [id dtype]
                      [id (tensor-value (or dtype default-dtype :double)
-                                       (if (= 'reduce kind) []
+                                       (if (contains? #{'scalar 'reduce} kind) []
                                            (dialect/extent-shape extent)))])
                    results result-dtypes)))))
 
@@ -203,9 +270,13 @@
    - :dtype — fallback element dtype
    - :array-types — symbol-to-dtype overrides
    - :values — authoritative additional AbstractValues
-   - :preserve-scalar-bindings? — allow the caller to retain scalar nodes in a separate envelope"
-  [nodes {:keys [outputs dtype array-types values preserve-scalar-bindings?]
-          :or {dtype :double array-types {} values {} preserve-scalar-bindings? false}}]
+   - :scalar-types — symbol-to-dtype overrides for scalar equations
+   - :include-scalar-bindings? — emit needed pure scalar bindings as typed equations
+   - :preserve-scalar-bindings? — compatibility option that allows but omits scalar bindings"
+  [nodes {:keys [outputs dtype array-types scalar-types values include-scalar-bindings?
+                 preserve-scalar-bindings?]
+          :or {dtype :double array-types {} scalar-types {} values {}
+               include-scalar-bindings? false preserve-scalar-bindings? false}}]
   (let [nodes (ordered-nodes nodes)
         physical-outputs (reduce set/union #{}
                                  (keep #(when-not (legacy/scalar-binding? %)
@@ -214,7 +285,8 @@
         unsupported (remove #(or (legacy/soac-map? %)
                                  (legacy/soac-reduce? %)
                                  (generated-scaffolding? % physical-outputs)
-                                 (and preserve-scalar-bindings? (legacy/scalar-binding? %)))
+                                 (and (or include-scalar-bindings? preserve-scalar-bindings?)
+                                      (legacy/scalar-binding? %)))
                             nodes)]
     (when-let [node (first unsupported)]
       (fail! :unsupported-legacy-node
@@ -222,7 +294,32 @@
              {:node (:id node) :type (.getName (class node))}))
     (let [aliases (logical-aliases nodes)
           operation-nodes (filterv #(or (legacy/soac-map? %) (legacy/soac-reduce? %)) nodes)
-          equations (mapv #(operation-equation % aliases) operation-nodes)
+          operation-equations (mapv #(operation-equation % aliases) operation-nodes)
+          requested-outputs (vec (or outputs
+                                     (some-> operation-equations peek (nth 2)) []))
+          selected-scalars (if include-scalar-bindings?
+                             (selected-scalar-symbols nodes operation-equations requested-outputs)
+                             #{})
+          {:keys [equations equation-nodes]}
+          (reduce
+           (fn [{:keys [scalar-dtypes] :as state} node]
+             (cond
+               (and (legacy/scalar-binding? node) (contains? selected-scalars (:sym node)))
+               (let [equation (scalar-equation node scalar-dtypes scalar-types)
+                     dtype (first (:dtypes (second (nth equation 3))))]
+                 (-> state
+                     (update :equations conj equation)
+                     (update :equation-nodes conj node)
+                     (assoc-in [:scalar-dtypes (:sym node)] dtype)))
+
+               (or (legacy/soac-map? node) (legacy/soac-reduce? node))
+               (-> state
+                   (update :equations conj (operation-equation node aliases))
+                   (update :equation-nodes conj node))
+
+               :else state))
+           {:equations [] :equation-nodes [] :scalar-dtypes {}}
+           nodes)
           equation-infos (mapv (fn [equation]
                                  {:id (second equation)
                                   :results (nth equation 2)
@@ -231,13 +328,15 @@
                                equations)
           definitions (set (mapcat :results equation-infos))
           references (set (mapcat #(cond-> (:inputs %)
-                                     (dialect/value-id? (:extent %)) (conj (:extent %)))
+                                     (and (:extent %) (dialect/value-id? (:extent %)))
+                                     (conj (:extent %)))
                                   equation-infos))
           inputs (vec (sort-by pr-str (set/difference references definitions)))
-          outputs (vec (or outputs (:results (peek equation-infos)) []))
+          outputs requested-outputs
           inferred-values (reduce (fn [contracts equation]
                                     (reduce-kv merge-value contracts
-                                               (equation-values equation dtype array-types)))
+                                               (equation-values equation dtype array-types
+                                                                contracts)))
                                   {}
                                   equations)
           values (reduce-kv merge-value inferred-values values)
@@ -247,7 +346,7 @@
                                        (dialect/default-equation-facts
                                         {:adapter :legacy-soac
                                          :legacy-soac-id (:id node)})]))
-                               operation-nodes)
+                               equation-nodes)
           facts (dialect/default-program-facts
                  {:values values
                   :inputs inputs

--- a/src/raster/compiler/passes/parallel/soac_dialect_adapter.clj
+++ b/src/raster/compiler/passes/parallel/soac_dialect_adapter.clj
@@ -6,7 +6,9 @@
    produced by current horizontal fusion. Every unsupported legacy shape declines loudly so the
    bridge cannot silently erase compiler facts."
   (:require [clojure.set :as set]
+            [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.types :as types]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.reduction :as reduction]
@@ -158,22 +160,23 @@
                         body-results))))))
 
 (defn- scalar-dtype
-  [expression scalar-dtypes scalar-types]
-  (cond
-    (and (seq? expression)
-         (descriptor/alength-op? (descriptor/semantic-op expression))) :long
-    (symbol? expression) (or (get scalar-dtypes expression) (get scalar-types expression))
-    (instance? Float expression) :float
-    (number? expression) (if (integer? expression) :long :double)
-    (boolean? expression) :boolean
-    :else nil))
+  [node scalar-dtypes scalar-types]
+  (let [result (:sym node)
+        expression (:expr node)
+        result-tag (types/sym-type-tag result)
+        expression-tag (when (instance? clojure.lang.IObj expression)
+                         (or (:raster.type/tag (meta expression)) (:tag (meta expression))))]
+    (or (get scalar-types result)
+        (when (symbol? expression) (get scalar-dtypes expression))
+        (dtype/dtype-for-scalar-tag result-tag)
+        (dtype/dtype-for-scalar-tag expression-tag))))
 
 (defn- scalar-equation
   [node scalar-dtypes scalar-types]
   (let [expression (:expr node)
         captures (vec (sort-by pr-str (util/free-syms expression)))
         parameters (capture-symbols (count captures))
-        dtype (scalar-dtype expression scalar-dtypes scalar-types)]
+        dtype (scalar-dtype node scalar-dtypes scalar-types)]
     (when-not dtype
       (fail! :unsupported-scalar-binding
              "typed scalar equations require a statically known result dtype"

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -18,6 +18,7 @@
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.kernel-graph :as kernel-graph]
             [raster.compiler.ir.kernel-launch :as kernel-launch]
+            [raster.compiler.ir.par :as par]
             [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.ir.soac-dialect :as soac-dialect]
@@ -58,12 +59,17 @@
                 (map (fn [parameter array]
                        [parameter (list 'clojure.core/aget array index)])
                      elements arrays))
-          body (util/subst-syms substitutions (first body-results))
+          body (-> (util/subst-syms substitutions (first body-results))
+                   par/expand-par-forms)
           result (first results)
+          stable-array-captures (set (get-in attributes
+                                             [:attributes :stable-array-captures]))
+          scalar-captures (set (remove stable-array-captures captures))
           result-dtype (or (:dtype (get-in (soac-dialect/facts program) [:values result]))
                            dtype :double)
           node (assoc (soac/->SoacMap equation-id result index (:extent attributes) nil body
-                                      (set arrays) #{result} (set captures))
+                                      (into (set arrays) stable-array-captures)
+                                      #{result} scalar-captures)
                       :elem-type result-dtype :pure? true)]
       (mapv #(assoc % :algorithm-dialect :typed-soac
                     :algorithm-equation equation-id)
@@ -112,6 +118,9 @@
           result (first results)
           accumulator (first accumulators)
           accumulator-dtype (or (first (:dtypes attributes)) dtype :double)
+          stable-array-captures (set (get-in attributes
+                                             [:attributes :stable-array-captures]))
+          scalar-captures (set (remove stable-array-captures captures))
           operator (reduction/scalar
                     {:accumulator accumulator
                      :neutral (first (:identities attributes))
@@ -122,7 +131,9 @@
                      :algebra (or (first (:algebra attributes)) {})
                      :attributes {:source :typed-soac :equation equation-id}})
           node (cond-> (soac/->SoacReduce equation-id result operator []
-                                          (:extent attributes) (set arrays) results (set captures))
+                                          (:extent attributes)
+                                          (into (set arrays) stable-array-captures)
+                                          results scalar-captures)
                  accumulator-dtype (assoc :elem-type accumulator-dtype))]
       (mapv #(assoc % :algorithm-dialect :typed-soac
                     :algorithm-equation equation-id)

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -38,14 +38,33 @@
                                 :parameters parameters
                                 :body-results body-results}))))
 
+(def ^:private scalar-equation-rule
+  (from-dialect dialect/TypedSOAC
+                (rule '(= ?equation-id [??results]
+                          (scalar ?attributes [??captures]
+                                  (lambda [??parameters] [??body-results])))
+                      (success {:kind :scalar
+                                :id equation-id
+                                :results results
+                                :attributes attributes
+                                :arrays []
+                                :captures captures
+                                :parameters parameters
+                                :body-results body-results}))))
+
 (defn equation-info
   "Return a normalized equation description, using Pattern as the dialect matcher."
   [equation]
-  (let [map-result (map-equation-rule equation)]
-    (if (map? map-result)
-      map-result
-      (let [reduce-result (reduce-equation-rule equation)]
-        (when (map? reduce-result) reduce-result)))))
+  (some #(when (map? %) %)
+        [(scalar-equation-rule equation)
+         (map-equation-rule equation)
+         (reduce-equation-rule equation)]))
+
+(defn- equation-references
+  [equation]
+  (let [{:keys [arrays captures attributes]} (equation-info equation)]
+    (cond-> (vec (concat arrays captures))
+      (:extent attributes) (conj (:extent attributes)))))
 
 (defn- element-symbols
   [n]
@@ -89,6 +108,15 @@
      :capture-parameters canonical-capture-parameters
      :body-results (mapv #(util/subst-syms substitutions %) body-results)}))
 
+(defn- stable-array-captures
+  [info]
+  (set (get-in info [:attributes :attributes :stable-array-captures])))
+
+(defn- with-stable-array-captures
+  [attributes captures stable]
+  (assoc-in attributes [:attributes :stable-array-captures]
+            (vec (filter stable captures))))
+
 (defn- freshen-parameters
   "Give one equation's element and capture binders private names before scopes are combined."
   [info prefix]
@@ -121,10 +149,7 @@
   [program]
   (frequencies
    (concat
-    (mapcat (fn [equation]
-              (let [{:keys [arrays captures attributes]} (equation-info equation)]
-                (concat arrays captures [(:extent attributes)])))
-            (dialect/equations program))
+    (mapcat equation-references (dialect/equations program))
     (dialect/outputs program))))
 
 (defn- merge-provenance
@@ -157,11 +182,7 @@
 (defn- rebuild-boundary
   [program facts equations]
   (let [definitions (set (mapcat #(nth % 2) equations))
-        references (set (mapcat (fn [equation]
-                                  (let [{:keys [arrays captures attributes]}
-                                        (equation-info equation)]
-                                    (concat arrays captures [(:extent attributes)])))
-                                equations))
+        references (set (mapcat equation-references equations))
         inputs (vec (sort-by pr-str (set/difference references definitions)))
         live-values (set/union definitions references (set (dialect/outputs program)))
         facts (-> facts
@@ -203,8 +224,12 @@
           consumed-index (.indexOf ^java.util.List (:arrays consumer) produced)
           consumer-elements (:elements consumer-parameters)
           consumed-parameter (nth consumer-elements consumed-index)
+          producer-expression (util/subst-syms
+                               {(get-in producer [:attributes :index])
+                                (get-in consumer [:attributes :index])}
+                               (first (:body-results producer)))
           inlined-body (mapv #(util/subst-syms
-                               {consumed-parameter (first (:body-results producer))} %)
+                               {consumed-parameter producer-expression} %)
                              (:body-results consumer))
           raw-arrays (vec (concat (subvec (vec (:arrays consumer)) 0 consumed-index)
                                   (:arrays producer)
@@ -218,7 +243,11 @@
                        (:capture-parameters consumer-parameters)))
           canonical (canonical-operands raw-arrays raw-elements
                                         raw-captures raw-capture-parameters inlined-body)
+          stable (set/union (stable-array-captures producer)
+                            (stable-array-captures consumer))
           updated (assoc consumer
+                         :attributes (with-stable-array-captures
+                                       (:attributes consumer) (:captures canonical) stable)
                          :arrays (:arrays canonical)
                          :captures (:captures canonical)
                          :parameters (vec (concat (:accumulators consumer-parameters)
@@ -281,7 +310,10 @@
                      (vec (concat (:capture-parameters left-parameters)
                                   (:capture-parameters right-parameters)))
                      (vec (concat (:body-results left) (:body-results right))))
+          stable (set/union (stable-array-captures left) (stable-array-captures right))
           updated (assoc left
+                         :attributes (with-stable-array-captures
+                                       (:attributes left) (:captures canonical) stable)
                          :results (vec (concat (:results left) (:results right)))
                          :arrays (:arrays canonical)
                          :captures (:captures canonical)

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -41,43 +41,70 @@
            (empty? (:segment-axes node))
            (reduction/scalar? (:reduction node)))))
 
+(defn- alength-array
+  [expression]
+  (when (and (seq? expression)
+             (descriptor/alength-op? (descriptor/semantic-op expression))
+             (= 1 (count (descriptor/call-args expression))))
+    (first (descriptor/call-args expression))))
+
 (defn- normalize-node-extents
-  "Replace `(alength <earlier pure result>)` with that result's already-known typed extent."
+  "Value-number pure scalar extents and replace `alength` of a known result with its certified
+   producer extent. Scalar names remain distinct values; only their operation uses are canonical."
   [nodes]
   (:nodes
    (reduce
-    (fn [{:keys [extents] :as state} node]
-      (if (or (legacy/soac-map? node) (legacy/soac-reduce? node))
-        (let [bound (:bound node)
-              array (when (and (seq? bound)
-                               (descriptor/alength-op? (descriptor/semantic-op bound)))
-                      (first (descriptor/call-args bound)))
-              bound' (get extents array bound)
-              node' (assoc node :bound bound')
-              produced (if (legacy/soac-map? node') [(:sym node')] (:outputs node'))]
+    (fn [{:keys [extents scalar-representatives] :as state} node]
+      (cond
+        (legacy/scalar-binding? node)
+        (let [expression (:expr node)
+              array (alength-array expression)
+              representative (cond
+                               (and array (contains? extents array)) (get extents array)
+                               (symbol? expression)
+                               (get scalar-representatives expression expression)
+                               (integer? expression) expression
+                               :else (:sym node))
+              expression' (if (= representative (:sym node)) expression representative)]
           (-> state
-              (update :nodes conj node')
-              (update :extents into (map (fn [result] [result bound']) produced))))
+              (update :nodes conj (assoc node :expr expression'))
+              (assoc-in [:scalar-representatives (:sym node)] representative)))
+
+        (or (legacy/soac-map? node) (legacy/soac-reduce? node))
+        (let [bound (:bound node)
+              array (alength-array bound)
+              bound' (cond
+                       (and array (contains? extents array)) (get extents array)
+                       (symbol? bound) (get scalar-representatives bound bound)
+                       :else bound)
+              node' (assoc node :bound bound')]
+          (cond-> (update state :nodes conj node')
+            (legacy/soac-map? node') (assoc-in [:extents (:sym node')] bound')))
+
+        :else
         (update state :nodes conj node)))
-    {:nodes [] :extents {}}
+    {:nodes [] :extents {} :scalar-representatives {}}
     nodes)))
 
 (defn- terminal-results
   [nodes body]
   (let [operations (filterv #(or (legacy/soac-map? %) (legacy/soac-reduce? %)) nodes)
-        definitions (set (mapcat (fn [node]
-                                   (if (legacy/soac-map? node) [(:sym node)] (:outputs node)))
-                                 operations))
-        operation-uses (set (mapcat #(concat (or (:inputs %) #{}) (or (:scalars %) #{}))
-                                    operations))
-        host-uses (set/union
-                   (set (mapcat #(when (legacy/scalar-binding? %)
-                                   (util/free-syms (:expr %)))
-                                nodes))
-                   (set (mapcat util/free-syms body)))]
+        operation-definitions (set (mapcat (fn [node]
+                                             (if (legacy/soac-map? node)
+                                               [(:sym node)] (:outputs node)))
+                                           operations))
+        scalar-definitions (set (keep #(when (legacy/scalar-binding? %) (:sym %)) nodes))
+        all-definitions (set/union operation-definitions scalar-definitions)
+        operation-uses (set (concat
+                             (mapcat #(concat (or (:inputs %) #{}) (or (:scalars %) #{}))
+                                     operations)
+                             (mapcat #(when (legacy/scalar-binding? %)
+                                        (util/free-syms (:expr %)))
+                                     nodes)))
+        body-uses (set (mapcat util/free-syms body))]
     (vec (sort-by pr-str
-                  (set/union (set/difference definitions operation-uses)
-                             (set/intersection definitions host-uses))))))
+                  (set/union (set/difference operation-definitions operation-uses)
+                             (set/intersection all-definitions body-uses))))))
 
 (defn- equation-subprogram
   [program equation]
@@ -98,8 +125,7 @@
 
 (defn- scalar-region
   [equation]
-  (let [[_ _ _ operation] equation
-        [_ attributes arrays captures lambda] operation
+  (let [{:keys [attributes arrays captures lambda]} (dialect/operation-parts equation)
         [_ _ body-results] lambda
         {:keys [elements capture-parameters]} (dialect/parameter-layout equation)
         substitutions
@@ -122,8 +148,8 @@
 
 (defn- realize-equation
   [program equation]
-  (let [[_ equation-id results operation] equation
-        [kind attributes _ _ _] operation
+  (let [[_ equation-id results] equation
+        {:keys [kind attributes]} (dialect/operation-parts equation)
         values (:values (dialect/facts program))
         bodies (scalar-region equation)
         placement-facts (get-in (dialect/facts program) [:equations equation-id])
@@ -131,6 +157,19 @@
                             #{(or (get-in placement-facts [:provenance :legacy-soac-id]) equation-id)})
         placement (apply max constituent-ids)]
     (case kind
+      scalar
+      (let [_ (when-not (= 1 (count results))
+                (throw (ex-info "the production scalar route requires one scalar result"
+                                {:reason :typed-soac-production-subset
+                                 :equation equation-id :results results})))
+            result (first results)
+            source (first bodies)]
+        {:equation-id equation-id
+         :placement placement
+         :pairs [[result source]]
+         :site [:binding result]
+         :source source})
+
       map
       (do
         (when-not (= 1 (count results))
@@ -163,20 +202,16 @@
          :source source}))))
 
 (defn- realize-source
-  [form nodes program]
+  [form program]
   (let [[let-head bindings & body] form
-        original-pairs (vec (partition 2 bindings))
         realized (mapv #(realize-equation program %) (dialect/equations program))
         by-placement (group-by :placement realized)
-        operation-id? (set (map :id (remove legacy/scalar-binding? nodes)))
         pairs
         (vec
          (mapcat
           (fn [id]
-            (concat
-             (when-not (contains? operation-id? id) [(nth original-pairs id)])
-             (mapcat :pairs (get by-placement id))))
-          (range (count original-pairs))))
+            (mapcat :pairs (get by-placement id)))
+          (range (count (partition 2 bindings)))))
         source (with-meta (list* let-head (vec (mapcat identity pairs)) body) (meta form))]
     {:source source :realized (into {} (map (juxt :equation-id identity)) realized)}))
 
@@ -236,14 +271,14 @@
                  typed-input (adapter/legacy-nodes->program
                               nodes {:outputs outputs :dtype dtype
                                      :array-types array-types
-                                     :preserve-scalar-bindings? true})
+                                     :include-scalar-bindings? true})
                  [typed-result typed-stats] (fusion/fusion-fixpoint typed-input)
                  source-graph (graph/build-fusion-graph nodes)
                  [legacy-result _] (graph/fusion-fixpoint source-graph abstract-machine dtype)
                  shadow (adapter/legacy-nodes->program
                          (:nodes legacy-result) {:outputs outputs :dtype dtype
                                                  :array-types array-types
-                                                 :preserve-scalar-bindings? true})]
+                                                 :include-scalar-bindings? true})]
              (cond
                (not (pos? (:vertical typed-stats)))
                {:declined {:reason :no-certified-vertical-fusion :stats typed-stats}}
@@ -255,7 +290,7 @@
                {:declined {:reason :fusion-shadow-disagreement :stats typed-stats}}
 
                :else
-               (let [{:keys [source realized]} (realize-source form source-nodes typed-result)]
+               (let [{:keys [source realized]} (realize-source form typed-result)]
                  {:program (envelope typed-result source realized)
                   :stats (assoc typed-stats :route :typed-soac
                                 :shadow-certified true)})))))

--- a/test/raster/compiler/backend/gpu/gpu_correctness_test.clj
+++ b/test/raster/compiler/backend/gpu/gpu_correctness_test.clj
@@ -80,6 +80,9 @@
     (is (str/includes? (emit '(clojure.core// a b)) "/")))
   (testing "Unary negation"
     (is (str/includes? (emit '(clojure.core/- x)) "-")))
+  (testing "JVM integer increments remain arithmetic in C-family scalar regions"
+    (is (= "((idx) + 1)" (emit '(clojure.core/unchecked-inc-int i))))
+    (is (= "((idx) - 1)" (emit '(clojure.core/unchecked-dec-int i)))))
   (testing "Math functions → C math functions"
     (is (str/includes? (emit '(Math/sin x)) "sin("))
     (is (str/includes? (emit '(Math/cos x)) "cos("))

--- a/test/raster/compiler/core/dtype_test.clj
+++ b/test/raster/compiler/core/dtype_test.clj
@@ -1,0 +1,11 @@
+(ns raster.compiler.core.dtype-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.core.dtype :as dtype]))
+
+(deftest canonical-tag-reverse-projection
+  (testing "declared JVM tags project through the canonical dtype facets"
+    (is (= :float (dtype/dtype-for-scalar-tag 'float)))
+    (is (= :int (dtype/dtype-for-array-tag 'ints))))
+  (testing "an absent type fact remains absent"
+    (is (nil? (dtype/dtype-for-scalar-tag nil)))
+    (is (nil? (dtype/dtype-for-array-tag nil)))))

--- a/test/raster/compiler/ir/parallel_program_test.clj
+++ b/test/raster/compiler/ir/parallel_program_test.clj
@@ -25,6 +25,9 @@
     (is (every? av/abstract-value? (vals (:values p))))
     (is (= ['?] (:shape (get (:values p) 'values))))
     (is (= [] (:shape (get (:values p) [:binding 'total]))))
+    (is (= {:scalar-types {'n :int}
+            :array-types {'values :double}}
+           (program/declared-parameter-types (assoc-in p [:values 'n :dtype] :int))))
     (is (seq (:operations equation)))
     (is (soac-dialect/program-form? (:algorithm equation)))
     (is (= (:operands equation) (:inputs (soac-dialect/facts (:algorithm equation)))))
@@ -53,9 +56,31 @@
         (is (= :segop (:target-dialect (ex-data e))))
         (is (= :none (:fallback (ex-data e))))))))
 
+(deftest host-only-equations-require-an-explicit-empty-schedule-contract
+  (let [p (lowered-program)
+        equation (first (:equations p))
+        host-only (assoc p :equations [(-> equation
+                                           (assoc :operations [])
+                                           (assoc-in [:attributes :host-only] true))])]
+    (is (= host-only (program/validate! host-only (constantly false))))
+    (testing "an empty schedule cannot arise accidentally"
+      (try
+        (program/validate! (assoc p :equations [(assoc equation :operations [])]))
+        (is false "empty operations without :host-only must be rejected")
+        (catch clojure.lang.ExceptionInfo exception
+          (is (= :parallel-program-operations (:reason (ex-data exception)))))))
+    (testing "host-only equations cannot also claim scheduled operations"
+      (try
+        (program/validate! (assoc p :equations [(assoc-in equation
+                                                          [:attributes :host-only] true)]))
+        (is false "host-only plus scheduled operations is contradictory")
+        (catch clojure.lang.ExceptionInfo exception
+          (is (= :parallel-program-host-only-operations
+                 (:reason (ex-data exception)))))))))
+
 (deftest source-shaped-bound-expressions-stay-on-the-compatibility-route
   (let [source '(raster.par/reduce acc 0.0 i (clojure.core/alength values)
-                                    (+ acc (clojure.core/aget values i)))
+                                   (+ acc (clojure.core/aget values i)))
         p (:form (segop-lower/segop-lower-pass
                   (list 'let* ['total source] 'total)
                   {:target-device :cpu:0 :dtype :double

--- a/test/raster/compiler/ir/parallel_program_test.clj
+++ b/test/raster/compiler/ir/parallel_program_test.clj
@@ -25,9 +25,9 @@
     (is (every? av/abstract-value? (vals (:values p))))
     (is (= ['?] (:shape (get (:values p) 'values))))
     (is (= [] (:shape (get (:values p) [:binding 'total]))))
-    (is (= {:scalar-types {'n :int}
-            :array-types {'values :double}}
-           (program/declared-parameter-types (assoc-in p [:values 'n :dtype] :int))))
+    (is (= {'n :int 'values :double}
+           (program/declared-value-types (assoc-in p [:values 'n :dtype] :int)
+                                         ['n 'values])))
     (is (seq (:operations equation)))
     (is (soac-dialect/program-form? (:algorithm equation)))
     (is (= (:operands equation) (:inputs (soac-dialect/facts (:algorithm equation)))))

--- a/test/raster/compiler/ir/soac_dialect_test.clj
+++ b/test/raster/compiler/ir/soac_dialect_test.clj
@@ -37,6 +37,66 @@
                                 (first (dialect/equations program)))))))
     (is (= '[x] (dialect/operation-inputs (first (dialect/equations program)))))))
 
+(deftest pure-scalar-shape-equations-are-ordered-typed-ssa
+  (let [program
+        (dialect/make
+         (dialect/default-program-facts
+          {:values {'x tensor 'n extent 'y tensor}
+           :inputs '[x]
+           :equations {'shape (dialect/default-equation-facts)
+                       'map-0 (dialect/default-equation-facts)}})
+         [(list '= 'shape '[n]
+                (list 'scalar {:dtypes [:long]} '[x]
+                      (list 'lambda '[array] '[(clojure.core/alength array)])))
+          (list '= 'map-0 '[y]
+                (list 'map {:index 'i :extent 'n} '[x] []
+                      (list 'lambda '[element] '[(* element 2.0)])))]
+         '[y])
+        scalar-equation (first (dialect/equations program))]
+    (is (= program (dialect/validate! program)))
+    (is (= 'scalar (dialect/operation-kind scalar-equation)))
+    (is (= '[x] (dialect/operation-inputs scalar-equation)))
+    (is (nil? (dialect/operation-extent scalar-equation)))
+    (is (= {:accumulators [] :elements [] :capture-parameters '[array]}
+           (dialect/parameter-layout scalar-equation)))))
+
+(deftest stable-array-capture-role-is-typed-and-validated
+  (let [weights (av/tensor {:dtype :float :shape '[(unknown-dimension weights)]})
+        program
+        (dialect/make
+         (dialect/default-program-facts
+          {:values {'x tensor 'weights weights 'n extent 'y tensor}
+           :inputs '[n weights x]
+           :equations {'map-0 (dialect/default-equation-facts)}})
+         [(list '= 'map-0 '[y]
+                (list 'map {:index 'i :extent 'n
+                            :attributes {:stable-array-captures '[weights]}}
+                      '[x] '[weights]
+                      (list 'lambda '[element weights-value]
+                            '[(+ element (clojure.core/aget weights-value i))])))]
+         '[y])
+        remapped (dialect/remap-values program
+                                       {'weights [:argument :weights]
+                                        'x [:argument :x]
+                                        'n [:shape :n]
+                                        'y [:result :y]})
+        remapped-equation (first (dialect/equations remapped))]
+    (is (= program (dialect/validate! program)))
+    (is (= [[:argument :weights]]
+           (get-in (dialect/operation-parts remapped-equation)
+                   [:attributes :attributes :stable-array-captures])))
+    (is (= [(list 'unknown-dimension [:argument :weights])]
+           (:shape (get-in (dialect/facts remapped)
+                           [:values [:argument :weights]]))))
+    (try
+      (dialect/make
+       (assoc-in (dialect/facts program) [:values 'weights]
+                 (av/tensor {:dtype :float :shape []}))
+       (dialect/equations program) (dialect/outputs program))
+      (is false "a scalar value cannot satisfy a stable tensor capture role")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :typed-soac-stable-array-type (:reason (ex-data exception))))))))
+
 (deftest scalar-regions-are-recursively-validated
   (testing "walker-devirtualized scalar calls remain explicit functional expressions"
     (let [program (map-program

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -56,11 +56,81 @@
                                           (+ (clojure.core/aget y j) 1.0))]
                       z)
         program (:program (route/attempt source nil :float {'x :double}))
-        algorithm (get-in program [:equations 0 :algorithm])]
+        scalar-equation (some #(when (= 'scalar
+                                        (dialect/operation-kind
+                                         (first (dialect/equations (:algorithm %))))) %)
+                              (:equations program))
+        map-equation (some #(when (= 'map
+                                     (dialect/operation-kind
+                                      (first (dialect/equations (:algorithm %))))) %)
+                           (:equations program))
+        algorithm (:algorithm map-equation)]
     (is (= :typed-soac (:dialect program)))
+    (is (= [:binding 'n] (:site scalar-equation)))
+    (is (= '(clojure.core/alength x)
+           (:source scalar-equation)))
     (is (= 'n (dialect/operation-extent (first (dialect/equations algorithm)))))
     (is (= :double (get-in (dialect/facts algorithm) [:values 'x :dtype])))
     (is (= :float (get-in (dialect/facts algorithm) [:values 'z :dtype])))))
+
+(deftest scalar-shapes-and-stable-tensor-captures-route-a-nested-reduction
+  (let [source
+        '(let* [rows (clojure.core/alength b1)
+                cols (clojure.core/alength x)
+                h (raster.par/pmap i rows double
+                                   (+ (clojure.core/aget b1 i)
+                                      (raster.par/reduce
+                                       acc 0.0 j cols
+                                       (+ acc (* (clojure.core/aget W1 (+ (* i cols) j))
+                                                 (clojure.core/aget x j))))))
+                a (raster.par/pmap k (clojure.core/alength h) double
+                                   (max 0.0 (clojure.core/aget h k)))
+                out-rows (clojure.core/alength b2)
+                reused-cols (clojure.core/alength a)
+                out (raster.par/pmap o out-rows double
+                                     (+ (clojure.core/aget b2 o)
+                                        (raster.par/reduce
+                                         acc 0.0 j reused-cols
+                                         (+ acc (* (clojure.core/aget W2
+                                                                      (+ (* o reused-cols) j))
+                                                   (clojure.core/aget a j))))))]
+               out)
+        {:keys [program stats]} (route/attempt
+                                 source nil :double
+                                 {'W1 :double 'W2 :double 'b1 :double 'b2 :double 'x :double})
+        scheduled (:form (segop-lower/segop-lower-pass
+                          program {:dtype :double :target-device :ocl:0}))
+        emitted (opencl-pass/opencl-pass scheduled :device-id :ocl:0
+                                         :dtype :double :min-elements 1)
+        equation-kinds (mapv #(dialect/operation-kind
+                               (first (dialect/equations (:algorithm %))))
+                             (:equations program))
+        scheduled-lambdas (->> (:equations scheduled)
+                               (mapcat :operations)
+                               (filter #(instance? raster.compiler.ir.segop.SegMap %))
+                               (map :lambda))
+        argument-kinds (mapv (fn [kernel]
+                               (into {} (map (juxt :name :kind)) (:abi kernel)))
+                             (:kernels emitted))
+        kernel-sources (mapv :source (:kernels emitted))]
+    (is (= :typed-soac (:route stats)))
+    (is (:shadow-certified stats))
+    (is (= 1 (:vertical stats)))
+    (is (= ['scalar 'scalar 'map 'scalar 'scalar 'map] equation-kinds))
+    (is (= 'rows (get-in program [:equations 4 :source]))
+        "alength of the produced activation is value-numbered to its certified extent")
+    (is (not-any? #{'raster.par/reduce} (mapcat flatten scheduled-lambdas))
+        "nested functional reductions become scalar-region control in the scheduled IR")
+    (is (some #{'loop*} (mapcat flatten scheduled-lambdas)))
+    (is (every? #(not (re-find #"unchecked_inc_int|raster\.par/reduce" %)) kernel-sources))
+    (is (every? #(re-find #"int (cols|reused_cols)" %) kernel-sources)
+        "typed scalar shape facts, rather than dtype/name heuristics, determine the kernel ABI")
+    (is (= 2 (get-in emitted [:stats :segop-reused])))
+    (is (= :input (get (first argument-kinds) 'W1)))
+    (is (= :input (get (first argument-kinds) 'x)))
+    (is (= :input (get (second argument-kinds) 'W2)))
+    (is (= :input (get (second argument-kinds) 'a)))
+    (is (= :scalar (get (second argument-kinds) 'reused-cols)))))
 
 (deftest typed-map-and-reduction-schedule-without-source-relowering
   (doseq [[label source operation-class stat]

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -49,8 +49,17 @@
                       z)]
     (is (nil? (route/attempt source nil :float)))))
 
-(deftest semantic-alength-bounds-normalize-to-the-producing-extent
+(deftest scalar-equations-require-retained-source-type-facts
   (let [source '(let* [n (clojure.core/alength x)
+                       y (raster.par/pmap i n float (* (clojure.core/aget x i) 2.0))
+                       z (raster.par/pmap j n float (+ (clojure.core/aget y j) 1.0))]
+                      z)]
+    (is (= :unsupported-scalar-binding
+           (get-in (route/attempt source nil :float {'x :float}) [:declined :reason]))
+        "the compatibility adapter must not reconstruct a missing TypedClojure result type")))
+
+(deftest semantic-alength-bounds-normalize-to-the-producing-extent
+  (let [source '(let* [^long n (clojure.core/alength x)
                        y (raster.par/pmap i n float (* (clojure.core/aget x i) 2.0))
                        z (raster.par/pmap j (clojure.core/alength y) float
                                           (+ (clojure.core/aget y j) 1.0))]
@@ -75,8 +84,8 @@
 
 (deftest scalar-shapes-and-stable-tensor-captures-route-a-nested-reduction
   (let [source
-        '(let* [rows (clojure.core/alength b1)
-                cols (clojure.core/alength x)
+        '(let* [^long rows (clojure.core/alength b1)
+                ^long cols (clojure.core/alength x)
                 h (raster.par/pmap i rows double
                                    (+ (clojure.core/aget b1 i)
                                       (raster.par/reduce
@@ -85,8 +94,8 @@
                                                  (clojure.core/aget x j))))))
                 a (raster.par/pmap k (clojure.core/alength h) double
                                    (max 0.0 (clojure.core/aget h k)))
-                out-rows (clojure.core/alength b2)
-                reused-cols (clojure.core/alength a)
+                ^long out-rows (clojure.core/alength b2)
+                ^long reused-cols (clojure.core/alength a)
                 out (raster.par/pmap o out-rows double
                                      (+ (clojure.core/aget b2 o)
                                         (raster.par/reduce

--- a/test/raster/compiler/pipeline_quality_test.clj
+++ b/test/raster/compiler/pipeline_quality_test.clj
@@ -74,7 +74,11 @@
       (is (not (form-contains-name? (:fixpointed stages) "raster.nn/"))
           "All nn/ calls should be inlined in fixpointed stage")
       (is (pos? (:vertical (:soac-fused-stats stages)))
-          "SOAC should report vertical fusion (dense→relu)"))))
+          "SOAC should report vertical fusion (dense→relu)")
+      (is (= :typed-soac (get-in stages [:soac-fused-stats :route]))
+          "the realistic dense pipeline should retain its typed fusion program")
+      (is (= 4 (get-in stages [:segop-lowered-stats :typed-scalar-equations]))
+          "row/column alength dependencies should remain explicit scalar equations"))))
 
 ;; ================================================================
 ;; Bytecode quality — catches loop/comparison/checkcast regressions


### PR DESCRIPTION
Summary:
- add ordered typed scalar/shape equations and value-number semantic tensor extents
- distinguish pointwise element inputs, stable tensor captures, and scalar ABI parameters through fusion and SegOp lowering
- lower nested functional reductions to scheduled scalar loops and consume typed value dtypes during OpenCL emission

Verification:
- full suite: 2475 tests, 35256 assertions, zero failures/errors
- OpenCL/GPU suite: Intel Arc available, zero skip paths
- production-shaped float dense/relu kernel compiles to SPIR-V with ocloc
- touched-file formatting and git diff checks pass