### PR TITLE
Converge resident reductions on TypedSOAC

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -68,7 +68,8 @@ operation/type legality check, and source equality invalidates an equation after
 rewrite. Direct calls to a backend may still use the explicit, counted compatibility re-lowering
 path.
 
-The first typed vertical is now production-routed for scalar/full reductions. A
+The typed map/reduction vertical is now production-routed for supported programs whether or not a
+fusion fires. A
 `ProgramEquation` owns the alpha-renamed TypedSOAC program and the SegRed mechanically derived from
 its explicit lambda parameters, operands, extent, result, dtype and algebra facts. JVM SIMD consumes
 that SegRed. The GPU schedules eligible scalar regions as one verified workgroup-tree `KernelBody`
@@ -76,11 +77,12 @@ with typed scalar SSA, stable reads, workgroup allocation, masks, barriers and a
 the same body emits as OpenCL, CUDA and HIP and is compiled by the hardware-free vendor CI gates.
 Unsupported scalar regions decline explicitly to the established verified SegRed OpenCL emitter.
 
-The remaining nominal boundary is earlier: SOAC fusion still constructs records and a dependency
-graph from source-shaped S-expressions, rewrites them, and reconstructs `par` forms before the typed
-program boundary. The problem is not the use of S-expressions; it is that stable value identity,
-types, effects, aliases and dialect legality are recovered from source spelling instead of being
-explicit in a first-class typed SOAC program.
+The remaining nominal boundary is earlier: the production adapter still constructs `ir.soac`
+records from source-shaped S-expressions before projecting them into TypedSOAC. Supported programs
+are optimized only as TypedSOAC—the old dependency-graph optimizer is no longer a production
+shadow authority—but unsupported forms still take that explicit fallback. The problem is not the
+use of S-expressions; it is that the front end should construct stable value identity, types,
+effects, aliases and dialect legality directly in the first-class typed program.
 
 The first architectural correction is therefore:
 
@@ -407,15 +409,17 @@ table entries keyed by IDs, not Clojure metadata that ordinary list reconstructi
 The first Pattern-declared dialect now makes this boundary executable for map and scalar/full
 reduce equations. It verifies ordered SSA definitions, exact typed input/output/effect boundaries,
 rank/extent/result contracts, explicit lexical capture binding (including compound stable value
-IDs), tuple-valued maps, and fact-preserving functional fusion. A guarded adapter differentially
-checks map→map, map→reduce and horizontal-map results against the current graph and declines every
-unsupported legacy node or unproved alias. The first production subset now routes single-consumer
-vertical fusion over pure maps and scalar/full reductions through a `:typed-soac` ParallelProgram.
-It mechanically materializes a compatibility host loop from the typed equation, then derives
-SegMap/SegRed directly from the retained algorithm. JVM SIMD and OpenCL therefore consume the same
-facts without backend re-analysis. Host-visible intermediates, unknown/effectful scalar equations,
-horizontal/multi-result fusion, and any disagreement with the temporary legacy shadow certificate
-decline explicitly.
+IDs), tuple-valued maps, and fact-preserving functional fusion. Differential tests compare
+map→map, map→reduce and horizontal-map transformations with the former graph over their overlap,
+but the graph is no longer a production certificate. Supported maps and scalar/full reductions
+route through a `:typed-soac` ParallelProgram even when no fusion fires; host-visible intermediates
+remain materialized typed equations. Horizontal fusion lowers tuple-valued maps to one SegMap whose
+declared outputs and ABI include every write. The route mechanically materializes host control from
+the typed equations, then derives SegMap/SegRed directly from the retained algorithm. JVM SIMD and
+OpenCL therefore consume the same facts without backend re-analysis. Unknown/effectful host scalar
+equations and unsupported parallel forms still decline explicitly at the front-end boundary.
+OpenCL emits the tuple-valued SegMap as one multi-output kernel; the current JVM SIMD leaf consumes
+the same scheduled equation without compatibility re-lowering but scalarizes the secondary store.
 
 Pure host scalar dependencies now use the same ordered SSA spine through a typed `scalar` equation.
 The first production subset covers statically typed literals/aliases and semantic array-length
@@ -429,14 +433,16 @@ while the scheduled operation—not tensor rank—declares whether an ABI value 
 
 This representation is shared before backend selection. SOAC fusion changes the program consumed
 by both JVM and accelerator lowerings; SegOp and schedule conversion then specialize it. The scalar
-spelling for the migrated subset is now generated from TypedSOAC rather than retained source, and
-JVM SIMD/GPU reuse its certified SegOps. The resident split pipeline remains on the compatibility
-route because its reduce-result device-realization transform still operates between source-form
-pipeline halves. Migration is complete when that transform, horizontal/multi-consumer fusion and
-richer scalar equations operate on the typed envelope and the covered compatibility re-lowerings
-are deleted. Nested reductions inside a retained map are typed and correctly classified, but the
-JVM SIMD leaf still lowers those inner regions through its established scalar fallback; this is an
-explicit scheduling boundary rather than a loss of semantic facts.
+spelling for the migrated subset is generated from TypedSOAC rather than retained source, and JVM
+SIMD/GPU reuse its certified SegOps. Non-escaping reduction results remain logical rank-zero values
+whose `:resident-scalar-buffer` representation drives one-element device allocation and stable
+consumer loads; dependent scalar equations are inlined as a typed transform. The former raw-source
+resident rewrite and typed-route opt-out are deleted. Migration is complete when the analyzed front
+end constructs TypedSOAC directly, typed scan and hardware-costed multi-consumer fusion land, and
+the covered graph/backend compatibility re-lowerings are deleted. Nested reductions inside a
+retained map are typed and correctly classified, but the JVM SIMD leaf still lowers those inner
+regions through its established scalar fallback; this is an explicit scheduling boundary rather
+than a loss of semantic facts.
 
 ### 3.3 Schedule and transform IR
 
@@ -783,11 +789,12 @@ The immediate continuation after the verified double-buffered weighted-reduction
    keep the current 1-D attention stages on its identity member until measured 2-D staging lands.
 4. **Landed:** make stage count and swizzle finite measured schedule axes, retire the legacy tuner,
    and remove the attention-provenance gate from routed weighted-reduction lowering.
-5. **In progress:** migrate the remaining SOAC fusion rules and scalar JVM fallback, then remove
-   compatibility re-lowering for the covered forms. Single-consumer pure map→map/map→reduce now has
-   a production typed route shared by JVM SIMD and OpenCL; typed scalar/shape equations and stable
-   tensor capture roles now carry realistic nested-reduction maps as well. Horizontal/multi-
-   consumer fusion, nested-region JVM scheduling and resident reduce-result realization remain.
+5. **In progress:** finish the typed front end and scalar JVM scheduling, then remove compatibility
+   re-lowering. Supported map/reduce programs, including unfused and host-visible intermediates,
+   horizontal tuple maps, typed scalar/shape equations, stable tensor captures, and resident
+   reduction results now share the production TypedSOAC→SegOp route. Direct analyzed-source
+   construction, typed scan, hardware-costed multi-consumer fusion, nested-region JVM scheduling,
+   and deletion of the remaining graph/backend fallbacks remain.
 6. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a
    read-only distributed track without interrupting the kernel and typed-middle-end verticals.
 

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -308,9 +308,10 @@
       (let [value (get values id)]
         (when (and value
                    (not (and (= :tensor (:kind value)) (seq (:shape value)))))
-          (fail! :typed-soac-stable-array-type
-                 "stable array captures must have a non-scalar tensor contract"
-                 {:equation equation-id :id id :value value}))))
+          (when-not (= :resident-scalar-buffer (get-in value [:representation :kind]))
+            (fail! :typed-soac-stable-array-type
+                   "stable captures require tensor storage or an explicit resident scalar buffer"
+                   {:equation equation-id :id id :value value})))))
     (case kind
       scalar
       (doseq [[id dtype] (map vector results (:dtypes attributes))]

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -289,10 +289,67 @@
                    (cond-> (= 'scalar kind)
                      (update :attributes assoc :host-only true)))))
            (:equations form))
+          ;; A multi-phase schedule introduces physical SSA values that do not exist in the
+          ;; functional algorithm. They still require explicit contracts; an emitter must never
+          ;; infer their dtype or extent from a generated name.
+          scheduled-values
+          (reduce
+           (fn [values equation]
+             (reduce
+              (fn [values operation]
+                (if (and (instance? raster.compiler.ir.segop.SegRed operation)
+                         (= :block-local (:phase operation)))
+                  (reduce (fn [values id]
+                            (if (contains? values id)
+                              values
+                              (assoc values id
+                                     (av/tensor
+                                      {:dtype (:dtype operation)
+                                       :shape [(:num-blocks (:grid operation))]
+                                       :representation {:kind :plain}
+                                       :memory-space :device}))))
+                          values (:outputs operation))
+                  values))
+              values (:operations equation)))
+           (:values form) equations)
+          ;; Scheduled operations are not exempt from SSA validation merely because they are
+          ;; records nested inside an equation. Every physical operand/result—including generated
+          ;; partial arrays and aliased destinations—must have an AbstractValue contract.
+          _ (doseq [equation equations
+                    operation (:operations equation)
+                    id (set/union (or (:inputs operation) #{})
+                                  (or (:outputs operation) #{})
+                                  (or (:scalars operation) #{}))]
+              (when-not (contains? scheduled-values id)
+                (throw (ex-info "scheduled SegOp references an undeclared value"
+                                {:reason :segop-unknown-scheduled-value
+                                 :equation (:id equation)
+                                 :operation (:id operation)
+                                 :value id}))))
+          ;; A typed equation's alias facts define its physical output boundary. This is
+          ;; particularly load-bearing for map-void: the semantic result aliases the resident
+          ;; destination, and the scheduled store must name that destination explicitly.
+          _ (doseq [equation equations
+                    :when (seq (:operations equation))]
+              (let [algorithm (:algorithm equation)
+                    algorithm-equation (first (soac-dialect/equations algorithm))
+                    algorithm-id (second algorithm-equation)
+                    aliases (get-in (soac-dialect/facts algorithm)
+                                    [:equations algorithm-id :aliases])
+                    expected (set (map #(get aliases % %) (:results equation)))
+                    scheduled-outputs (apply set/union #{}
+                                             (map :outputs (:operations equation)))]
+                (when-not (set/subset? expected scheduled-outputs)
+                  (throw (ex-info "scheduled SegOp does not realize the typed output boundary"
+                                  {:reason :segop-output-boundary
+                                   :equation (:id equation)
+                                   :expected expected
+                                   :scheduled scheduled-outputs})))))
           parallel-equation-count (count (remove #(get-in % [:attributes :host-only]) equations))
           scalar-equation-count (- (count equations) parallel-equation-count)
           lowered (assoc form
                          :dialect :segop
+                         :values scheduled-values
                          :equations equations
                          :provenance (assoc (:provenance form)
                                             :pass :segop-lower :source-dialect :typed-soac

--- a/src/raster/compiler/passes/parallel/soac_dialect_adapter.clj
+++ b/src/raster/compiler/passes/parallel/soac_dialect_adapter.clj
@@ -108,10 +108,16 @@
 (defn- map-equation
   [node aliases]
   (let [{:keys [results expressions]} (horizontal-map-parts node aliases)
+        ;; Imperative map-void is represented as a functional map result plus an explicit
+        ;; equation-level destination contract.  The destination is an unused stable capture here
+        ;; so it participates in the typed boundary; scheduling, not the scalar lambda, owns the
+        ;; write.  This keeps mutation out of the functional body.
+        destination (when (:void? node) (:primary-out node))
         [pointwise stable] ((juxt filter remove)
                             #(pointwise-input? expressions % (:idx node))
                             (:inputs node))
         arrays (vec (sort-by pr-str pointwise))
+        stable (cond-> (set stable) destination (conj destination))
         captures (vec (sort-by pr-str (distinct (concat stable (:scalars node)))))
         parameters (element-symbols (count arrays))
         capture-parameters (capture-symbols (count captures))
@@ -238,7 +244,15 @@
                                        (dialect/extent-shape extent))])
                    arrays))
      (if (= 'scalar kind)
-       {}
+       (into {} (keep (fn [id]
+                        (when-let [value (or (get known-values id)
+                                             (when-let [declared
+                                                        (and (symbol? id)
+                                                             (dtype/dtype-for-scalar-tag
+                                                              (types/sym-type-tag id)))]
+                                               (tensor-value declared [])))]
+                          [id value])))
+             captures)
        (into {} (map (fn [id]
                        [id (or (get known-values id)
                                (if (or (contains? stable-array-captures id)
@@ -343,17 +357,25 @@
                                   {}
                                   equations)
           values (reduce-kv merge-value inferred-values values)
-          equation-facts (into {}
-                               (map (fn [node]
-                                      [(:id node)
-                                       (dialect/default-equation-facts
-                                        {:adapter :legacy-soac
-                                         :legacy-soac-id (:id node)})]))
-                               equation-nodes)
+          equation-facts
+          (into {}
+                (map (fn [node]
+                       (let [destination (when (and (legacy/soac-map? node) (:void? node))
+                                           (:primary-out node))]
+                         [(:id node)
+                          (cond-> (dialect/default-equation-facts
+                                   {:adapter :legacy-soac :legacy-soac-id (:id node)})
+                            destination
+                            (assoc :effects #{:memory/write}
+                                   :aliases {(:sym node) destination}
+                                   :attributes {:destination destination}))])))
+                equation-nodes)
+          total-effects (reduce set/union #{} (map :effects (vals equation-facts)))
           facts (dialect/default-program-facts
                  {:values values
                   :inputs inputs
                   :equations equation-facts
+                  :effects total-effects
                   :provenance {:adapter :legacy-soac}
                   :attributes {:compatibility-view true}})]
       (dialect/make facts equations outputs))))

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -37,7 +37,12 @@
        (= 'map (soac-dialect/operation-kind (first (soac-dialect/equations program))))))
 
 (defn lower-typed-map
-  "Lower one functional TypedSOAC map to SegMap from its explicit operands and lambda binders."
+  "Lower one functional TypedSOAC map to SegMap from its explicit operands and lambda binders.
+
+   A horizontally fused map has several logical results. SegMap keeps the first result in its
+   structural output slot and spells the remaining stores explicitly in the scalar region; all
+   results remain declared outputs, so the ABI and memory contracts do not infer writes from the
+   generated expression."
   [program device-id & {:keys [dtype] :or {dtype :double}}]
   (let [program (soac-dialect/validate! program)]
     (when-not (typed-map-program? program)
@@ -48,9 +53,10 @@
           [_ attributes arrays captures lambda] operation
           [_ _ body-results] lambda
           {:keys [elements capture-parameters]} (soac-dialect/parameter-layout equation)
-          _ (when-not (and (= 1 (count results)) (= 1 (count body-results))
-                           (symbol? (first results)))
-              (throw (ex-info "initial typed SegMap vertical supports one symbolic result"
+          _ (when-not (and (seq results)
+                           (= (count results) (count body-results))
+                           (every? symbol? results))
+              (throw (ex-info "typed SegMap requires one scalar body result per symbolic output"
                               {:reason :typed-soac-map-subset
                                :equation equation-id :results results})))
           index (:index attributes)
@@ -59,18 +65,34 @@
                 (map (fn [parameter array]
                        [parameter (list 'clojure.core/aget array index)])
                      elements arrays))
-          body (-> (util/subst-syms substitutions (first body-results))
-                   par/expand-par-forms)
+          bodies (mapv #(-> (util/subst-syms substitutions %)
+                            par/expand-par-forms)
+                       body-results)
           result (first results)
+          values (:values (soac-dialect/facts program))
+          secondary-stores
+          (mapv (fn [secondary-result secondary-body]
+                  (let [secondary-dtype (:dtype (get values secondary-result))
+                        cast (dtype/scalar-tag-for-dtype secondary-dtype)]
+                    (list 'clojure.core/aset secondary-result index
+                          (list cast secondary-body))))
+                (rest results) (rest bodies))
+          body (if (seq secondary-stores)
+                 (list* 'do (concat secondary-stores [(first bodies)]))
+                 (first bodies))
           stable-array-captures (set (get-in attributes
                                              [:attributes :stable-array-captures]))
           scalar-captures (set (remove stable-array-captures captures))
-          result-dtype (or (:dtype (get-in (soac-dialect/facts program) [:values result]))
+          result-dtype (or (:dtype (get values result))
                            dtype :double)
+          destination (get-in (soac-dialect/facts program)
+                              [:equations equation-id :attributes :destination])
+          physical-result (or destination result)
           node (assoc (soac/->SoacMap equation-id result index (:extent attributes) nil body
                                       (into (set arrays) stable-array-captures)
-                                      #{result} scalar-captures)
-                      :elem-type result-dtype :pure? true)]
+                                      (if destination #{physical-result} (set results))
+                                      scalar-captures)
+                      :sym physical-result :elem-type result-dtype :pure? (nil? destination))]
       (mapv #(assoc % :algorithm-dialect :typed-soac
                     :algorithm-equation equation-id)
             (lower-map node device-id :dtype result-dtype)))))
@@ -302,14 +324,14 @@
 
         :two-phase
         (let [level-1 (segop/->SegLevel :block :virtual)
+              partials-sym (gensym "partials_")
               phase-1 (segop/->SegRed (:id soac) space level-1
                                       reduction map-lambda
                                       (:inputs soac)
-                                      (or (soac-outputs* soac) #{(:sym soac)})
+                                      #{partials-sym}
                                       (:scalars soac)
                                       grid-1 :block-local nil
                                       dtype)
-              partials-sym (gensym "partials_")
               phase-2-idx (gensym "j_")
               phase-2-space (segop/make-seg-space phase-2-idx (:num-blocks grid-1))
               grid-2 (single-block-grid grid-1)

--- a/src/raster/compiler/passes/parallel/typed_soac_resident.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_resident.clj
@@ -1,0 +1,215 @@
+(ns raster.compiler.passes.parallel.typed-soac-resident
+  "Realize non-escaping TypedSOAC reduction scalars as resident one-element buffers.
+
+   Logical reduction results remain rank-zero AbstractValues.  Their representation records the
+   physical resident realization, scheduled reductions own the buffer output role, and consuming
+   scalar regions load element zero through an explicit stable capture.  Pure scalar equations
+   depending on a resident reduction are beta-reduced into their parallel consumers, so no device
+   value is reconstructed or synchronized through host scalar control."
+  (:require [clojure.set :as set]
+            [raster.compiler.core.util :as util]
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]))
+
+(def resident-representation :resident-scalar-buffer)
+
+(defn resident-scalar-value?
+  [value]
+  (= resident-representation (get-in value [:representation :kind])))
+
+(defn- operation-info
+  [equation]
+  (or (fusion/equation-info equation)
+      (throw (ex-info "resident realization received an unknown TypedSOAC equation"
+                      {:reason :typed-soac-resident-equation :equation equation}))))
+
+(defn- parameter-parts
+  [{:keys [kind attributes arrays parameters]}]
+  (let [accumulator-count (if (= :reduce kind)
+                            (count (:accumulators attributes))
+                            0)
+        array-count (count arrays)
+        accumulator-end accumulator-count
+        element-end (+ accumulator-count array-count)]
+    {:accumulators (subvec (vec parameters) 0 accumulator-end)
+     :elements (subvec (vec parameters) accumulator-end element-end)
+     :capture-parameters (subvec (vec parameters) element-end)}))
+
+(defn- emit-equation
+  [{:keys [kind id results attributes arrays captures parameters body-results]}]
+  (list '= id (vec results)
+        (list (symbol (name kind)) attributes (vec arrays) (vec captures)
+              (list 'lambda (vec parameters) (vec body-results)))))
+
+(defn- use-sites
+  [equations]
+  (reduce
+   (fn [uses equation]
+     (let [{:keys [id arrays captures attributes]} (operation-info equation)]
+       (-> uses
+           (into (map (fn [value] [value {:equation id :role :array}]) arrays))
+           (into (map (fn [value] [value {:equation id :role :capture}]) captures))
+           (cond-> (dialect/value-id? (:extent attributes))
+             (conj [(:extent attributes) {:equation id :role :extent}])))))
+   [] equations))
+
+(defn- scalar-definitions
+  [equations]
+  (into {}
+        (keep (fn [equation]
+                (let [info (operation-info equation)]
+                  (when (and (= :scalar (:kind info))
+                             (= 1 (count (:results info)))
+                             (= 1 (count (:body-results info))))
+                    [(first (:results info)) info]))))
+        equations))
+
+(defn- dependent-scalars
+  [scalar-defs roots]
+  (loop [dependent #{}]
+    (let [known (set/union roots dependent)
+          dependent'
+          (into dependent
+                (keep (fn [[result {:keys [captures]}]]
+                        (when (some known captures) result)))
+                scalar-defs)]
+      (if (= dependent dependent') dependent (recur dependent')))))
+
+(defn- scalar-expression
+  [scalar-defs dependent roots id]
+  (letfn [(expand [value visiting]
+            (cond
+              (contains? roots value)
+              (list 'clojure.core/aget value 0)
+
+              (contains? dependent value)
+              (do
+                (when (contains? visiting value)
+                  (throw (ex-info "resident scalar equations contain a dependency cycle"
+                                  {:reason :typed-soac-resident-scalar-cycle :value value})))
+                (let [{:keys [captures parameters body-results]} (get scalar-defs value)
+                      expression (util/subst-syms (zipmap parameters captures)
+                                                  (first body-results))
+                      substitutions (into {}
+                                          (keep (fn [capture]
+                                                  (when (or (contains? roots capture)
+                                                            (contains? dependent capture))
+                                                    [capture (expand capture (conj visiting value))])))
+                                          captures)]
+                  (util/subst-syms substitutions expression)))
+
+              :else value))]
+    (expand id #{})))
+
+(defn- rewrite-consumer
+  [info values scalar-defs dependent roots]
+  (let [{:keys [accumulators elements capture-parameters]} (parameter-parts info)
+        capture-substitutions
+        (into {}
+              (map (fn [[parameter capture]]
+                     [parameter
+                      (cond
+                        (contains? roots capture) (list 'clojure.core/aget capture 0)
+                        (contains? dependent capture)
+                        (scalar-expression scalar-defs dependent roots capture)
+                        :else capture)]))
+              (map vector capture-parameters (:captures info)))
+        global-bodies (mapv #(util/subst-syms capture-substitutions %) (:body-results info))
+        bound (set (concat accumulators elements [(get-in info [:attributes :index])]))
+        stable-before (set (get-in info [:attributes :attributes :stable-array-captures]))
+        referenced-values (->> (concat (mapcat #(util/free-syms % bound) global-bodies)
+                                       stable-before)
+                               (filter #(contains? values %)) distinct (sort-by pr-str) vec)
+        new-parameters (mapv #(symbol (str "%capture" %)) (range (count referenced-values)))
+        body-substitutions (zipmap referenced-values new-parameters)
+        stable-after (set (filter #(or (contains? stable-before %)
+                                       (resident-scalar-value? (get values %)))
+                                  referenced-values))]
+    (assoc info
+           :captures referenced-values
+           :parameters (vec (concat accumulators elements new-parameters))
+           :body-results (mapv #(util/subst-syms body-substitutions %) global-bodies)
+           :attributes (assoc-in (:attributes info) [:attributes :stable-array-captures]
+                                 (vec (filter stable-after referenced-values))))))
+
+(defn realize
+  "Return `[program stats]`, realizing every eligible non-escaping scalar reduction.
+
+   A root declines realization when it is a program result or is used as an element array/extent.
+   Scalar chains depending on eligible roots must likewise remain internal and capture-only."
+  [program]
+  (let [program (dialect/validate! program)
+        equations (dialect/equations program)
+        infos (mapv operation-info equations)
+        outputs (set (dialect/outputs program))
+        uses (group-by first (use-sites equations))
+        candidate-roots
+        (set (mapcat (fn [{:keys [kind results]}]
+                       (when (= :reduce kind)
+                         (filter (fn [result]
+                                   (and (not (contains? outputs result))
+                                        (every? #(= :capture (get-in % [1 :role]))
+                                                (get uses result []))))
+                                 results)))
+                     infos))
+        scalar-defs (scalar-definitions equations)
+        dependent (dependent-scalars scalar-defs candidate-roots)
+        escaping-dependent
+        (set (filter (fn [value]
+                       (or (contains? outputs value)
+                           (not-every? #(= :capture (get-in % [1 :role]))
+                                       (get uses value []))))
+                     dependent))
+        blocked-roots
+        (set (filter (fn [root]
+                       (some (fn [value]
+                               (let [expression (scalar-expression scalar-defs dependent
+                                                                   candidate-roots value)]
+                                 (contains? (util/free-syms expression) root)))
+                             escaping-dependent))
+                     candidate-roots))
+        roots (set/difference candidate-roots blocked-roots)
+        dependent (dependent-scalars scalar-defs roots)
+        removed-scalars (set/difference dependent escaping-dependent)]
+    (if (empty? roots)
+      [program {:resident-reductions 0 :inlined-scalars 0}]
+      (let [facts (dialect/facts program)
+            values (reduce (fn [vs root]
+                             (-> vs
+                                 (assoc-in [root :representation]
+                                           {:kind resident-representation :elements 1})
+                                 (assoc-in [root :memory-space] :device)))
+                           (:values facts) roots)
+            rewritten
+            (->> infos
+                 (remove #(and (= :scalar (:kind %))
+                               (some removed-scalars (:results %))))
+                 (mapv #(rewrite-consumer % values scalar-defs removed-scalars roots))
+                 (mapv emit-equation))
+            equation-ids (set (map second rewritten))
+            definitions (set (mapcat #(nth % 2) rewritten))
+            references (set (mapcat (fn [equation]
+                                      (cond-> (dialect/operation-inputs equation)
+                                        (dialect/value-id? (dialect/operation-extent equation))
+                                        (conj (dialect/operation-extent equation))))
+                                    rewritten))
+            inputs (vec (sort-by pr-str (set/difference references definitions)))
+            live-values (set/union definitions references outputs)
+            facts (-> facts
+                      (assoc :values (select-keys values live-values)
+                             :inputs inputs)
+                      (update :equations select-keys equation-ids)
+                      (update :equations
+                              (fn [equation-facts]
+                                (reduce (fn [m equation]
+                                          (let [id (second equation)
+                                                results (set (nth equation 2))]
+                                            (if (seq (set/intersection roots results))
+                                              (assoc-in m [id :attributes :resident-realization]
+                                                        {:kind resident-representation :elements 1})
+                                              m)))
+                                        equation-facts rewritten)))
+                      (assoc-in [:attributes :resident-reductions] (vec (sort-by pr-str roots))))
+            result (dialect/make facts rewritten (dialect/outputs program))]
+        [result {:resident-reductions (count roots)
+                 :inlined-scalars (count removed-scalars)}]))))

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -1,19 +1,19 @@
 (ns raster.compiler.passes.parallel.typed-soac-route
-  "Production bridge for the first closed TypedSOAC fusion subset.
+  "Production route for the closed TypedSOAC map/scalar/reduction subset.
 
-   Pure maps and scalar/full reductions are fused in the typed dialect.  The resulting functional
-   equations are mechanically materialized into the compatibility host expression and retained as
-   first-class algorithms in a ParallelProgram.  A shadow comparison with the established graph
-   implementation is a temporary migration certificate: disagreement declines to the old route."
+   Supported programs are represented and fused in the typed dialect whether or not a fusion
+   fires. The resulting functional equations are mechanically projected into the surrounding host
+   control expression and retained as first-class algorithms in a ParallelProgram."
   (:require [clojure.set :as set]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.soac :as legacy]
             [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.passes.scalar.effects :as effects]
             [raster.compiler.passes.parallel.soac-dialect-adapter :as adapter]
-            [raster.compiler.passes.parallel.soac-graph :as graph]
             [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]
+            [raster.compiler.passes.parallel.typed-soac-resident :as resident]
             [raster.compiler.core.util :as util]))
 
 (def ^:private dtype->allocation
@@ -25,7 +25,11 @@
 
 (defn- provably-pure-host-binding?
   [expression]
-  (or (not (seq? expression))
+  ;; Beichte is the general conservative purity authority. Array length is also a closed compiler
+  ;; intrinsic identified through the canonical semantic descriptor (including devirtualized
+  ;; `.invk` spellings), not through a function-name/type registry. Typed scalar equations retain
+  ;; the walker's result tag separately, so this effect verdict never infers a result type.
+  (or (effects/removable-expr? expression)
       (and (descriptor/alength-op? (descriptor/semantic-op expression))
            (= 1 (count (descriptor/call-args expression)))
            (symbol? (first (descriptor/call-args expression))))))
@@ -36,7 +40,9 @@
   ;; compiler's semantically identified array-length query; richer scalar equations belong in the
   ;; typed program itself.
   (or (and (legacy/scalar-binding? node) (provably-pure-host-binding? (:expr node)))
-      (and (legacy/soac-map? node) (:pure? node))
+      (and (legacy/soac-map? node)
+           (or (:pure? node)
+               (and (:void? node) (symbol? (:primary-out node)))))
       (and (legacy/soac-reduce? node)
            (empty? (:segment-axes node))
            (reduction/scalar? (:reduction node)))))
@@ -71,7 +77,7 @@
               (assoc-in [:scalar-representatives (:sym node)] representative)))
 
         (or (legacy/soac-map? node) (legacy/soac-reduce? node))
-        (let [bound (:bound node)
+        (let [bound (descriptor/unwrap-int-cast (:bound node))
               array (alength-array bound)
               bound' (cond
                        (and array (contains? extents array)) (get extents array)
@@ -172,34 +178,74 @@
 
       map
       (do
-        (when-not (= 1 (count results))
-          (throw (ex-info "the first production TypedSOAC route requires one map result"
+        (when-not (and (seq results) (= (count results) (count bodies)))
+          (throw (ex-info "the production TypedSOAC route requires one body per map result"
                           {:reason :typed-soac-production-subset
                            :equation equation-id :results results})))
         (let [result (first results)
-              dtype (:dtype (get values result))
-              [_ _ cast] (get dtype->allocation dtype)
+              result-dtypes (mapv #(:dtype (get values %)) results)
+              casts (mapv #(nth (get dtype->allocation %) 2 nil) result-dtypes)
+              _ (when (some nil? casts)
+                  (throw (ex-info "TypedSOAC materialization has no scalar cast for map output"
+                                  {:reason :typed-soac-materialization-dtype
+                                   :results results :dtypes result-dtypes})))
+              cast (first casts)
+              destination (get-in placement-facts [:attributes :destination])
+              _ (when (and destination (not= 1 (count results)))
+                  (throw (ex-info "an effectful map destination cannot have fused logical outputs"
+                                  {:reason :typed-soac-production-subset
+                                   :equation equation-id :results results
+                                   :destination destination})))
+              secondary-stores
+              (mapv (fn [secondary secondary-cast body]
+                      (list 'clojure.core/aset secondary (:index attributes)
+                            (list secondary-cast body)))
+                    (rest results) (rest casts) (rest bodies))
+              body (if (seq secondary-stores)
+                     (list* 'do (concat secondary-stores [(first bodies)]))
+                     (first bodies))
               effect (gensym (str "typed_soac_map_" equation-id "__"))
               source (with-meta
-                       (list 'raster.par/map! result (:index attributes) (:extent attributes)
-                             cast (first bodies))
-                       {:raster.type/elem-type dtype})]
+                       (if destination
+                         (list 'raster.par/map-void! (:index attributes) (:extent attributes)
+                               (list 'clojure.core/aset destination (:index attributes)
+                                     (list cast body)))
+                         (list 'raster.par/map! result (:index attributes) (:extent attributes)
+                               cast body))
+                       {:raster.type/elem-type (first result-dtypes)})]
           {:equation-id equation-id
            :placement placement
-           :pairs [(allocation-pair values result (:extent attributes)) [effect source]]
-           :site [:binding effect]
+           :pairs (if destination
+                    [[result source]]
+                    (conj (mapv #(allocation-pair values % (:extent attributes)) results)
+                          [effect source]))
+           :site [:binding (if destination result effect)]
            :source source}))
 
       reduce
       (let [result (first results)
             accumulator (first (:accumulators attributes))
-            source (list 'raster.par/reduce accumulator (first (:identities attributes))
-                         (:index attributes) (:extent attributes) (first bodies))]
-        {:equation-id equation-id
-         :placement placement
-         :pairs [[result source]]
-         :site [:binding result]
-         :source source}))))
+            resident? (resident/resident-scalar-value? (get values result))
+            source (if resident?
+                     ;; reduce-into owns its explicit one-element destination first. The
+                     ;; functional reduction algorithm itself remains unchanged.
+                     (list 'raster.par/reduce-into result accumulator
+                           (first (:identities attributes)) (:index attributes)
+                           (:extent attributes) (first bodies))
+                     (list 'raster.par/reduce accumulator (first (:identities attributes))
+                           (:index attributes) (:extent attributes) (first bodies)))]
+        (if resident?
+          (let [effect (gensym (str "typed_soac_reduce_" equation-id "__"))]
+            {:equation-id equation-id
+             :placement placement
+             :pairs [(allocation-pair values result 1) [effect source]]
+             :site [:binding effect]
+             :source source})
+          {:equation-id equation-id
+           :placement placement
+           :pairs [[result source]]
+           :site [:binding result]
+           :source source})))))
 
 (defn- realize-source
   [form program]
@@ -255,11 +301,13 @@
 
 (defn attempt
   "Return a typed production ParallelProgram result, an explicit `:declined` result, or nil when
-   the form is outside this closed subset. The legacy graph is used only as a temporary
-   differential oracle during migration."
-  ([form abstract-machine dtype]
-   (attempt form abstract-machine dtype {}))
-  ([form abstract-machine dtype array-types]
+   the form is outside this closed subset."
+  ([form dtype]
+   (attempt form dtype {}))
+  ([form dtype array-types]
+   (attempt form dtype array-types {}))
+  ([form dtype array-types {:keys [resident-reductions?]
+                            :or {resident-reductions? false}}]
    (when (and (seq? form) (contains? #{'let 'let*} (first form)))
      (try
        (let [[_ bindings & body] form
@@ -273,27 +321,19 @@
                                      :array-types array-types
                                      :include-scalar-bindings? true})
                  [typed-result typed-stats] (fusion/fusion-fixpoint typed-input)
-                 source-graph (graph/build-fusion-graph nodes)
-                 [legacy-result _] (graph/fusion-fixpoint source-graph abstract-machine dtype)
-                 shadow (adapter/legacy-nodes->program
-                         (:nodes legacy-result) {:outputs outputs :dtype dtype
-                                                 :array-types array-types
-                                                 :include-scalar-bindings? true})]
-             (cond
-               (not (pos? (:vertical typed-stats)))
-               {:declined {:reason :no-certified-vertical-fusion :stats typed-stats}}
-
-               (pos? (:horizontal typed-stats))
-               {:declined {:reason :typed-horizontal-materialization-pending :stats typed-stats}}
-
-               (not= (dialect/equations shadow) (dialect/equations typed-result))
-               {:declined {:reason :fusion-shadow-disagreement :stats typed-stats}}
-
-               :else
+                 [typed-result resident-stats]
+                 (if resident-reductions?
+                   (resident/realize typed-result)
+                   [typed-result {:resident-reductions 0 :inlined-scalars 0}])]
+             (if (not-any? #(contains? #{:map :reduce}
+                                       (:kind (fusion/equation-info %)))
+                           (dialect/equations typed-result))
+               {:declined {:reason :no-certified-parallel-equation
+                           :stats (merge typed-stats resident-stats)}}
                (let [{:keys [source realized]} (realize-source form typed-result)]
                  {:program (envelope typed-result source realized)
-                  :stats (assoc typed-stats :route :typed-soac
-                                :shadow-certified true)})))))
+                  :stats (merge typed-stats resident-stats
+                                {:route :typed-soac :typed-validated true})})))))
        (catch clojure.lang.ExceptionInfo exception
          (when (contains? #{:raster/fatal :raster/bug} (:reason (ex-data exception)))
            (throw exception))

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -760,17 +760,19 @@
   Returns {:form :stats}."
   [form opts]
   (if (form/binding-form? form)
-    (let [am (when (device/gpu-target? (:target-device opts))
-               (try (core-hw/abstract-machine (core-hw/descriptor-for (:target-device opts)))
-                    (catch Throwable _ nil)))]
-      (let [typed (when (not= false (:typed-soac-fusion? opts))
-                    (typed-soac-route/attempt form am (:dtype opts) (:array-types opts)))]
-        (if (:program typed)
-          {:form (:program typed) :stats (:stats typed)}
-          (let [[let-sym bindings-vec & body-exprs] form
-                pairs (vec (partition 2 bindings-vec))
-                nodes (soac/let-bindings->nodes pairs)
-                graph (soac-graph/build-fusion-graph nodes)
+    (let [typed (typed-soac-route/attempt
+                 form (:dtype opts) (:array-types opts)
+                 {:resident-reductions? (true? (:resident-reductions? opts))})]
+      (if (:program typed)
+        {:form (:program typed) :stats (:stats typed)}
+        (let [am (when (device/gpu-target? (:target-device opts))
+                   (try (core-hw/abstract-machine
+                         (core-hw/descriptor-for (:target-device opts)))
+                        (catch Throwable _ nil)))
+              [let-sym bindings-vec & body-exprs] form
+              pairs (vec (partition 2 bindings-vec))
+              nodes (soac/let-bindings->nodes pairs)
+              graph (soac-graph/build-fusion-graph nodes)
           ;; Hardware-GUIDED fusion: project the target to an Abstract Machine so the
           ;; vertical chooser can DECLINE unprofitable rematerialization (cost model,
           ;; not a device — see soac-graph/vertical-fusion-profitable?). Only for GPU
@@ -778,12 +780,12 @@
           ;; kernels is the documented failure mode; CPU/no-target → am nil → the
           ;; chooser is legality-only, byte-identical to before. Descriptor failure
           ;; degrades to nil (no decline), never breaks compilation.
-                [fused-graph stats] (soac-graph/fusion-fixpoint graph am (:dtype opts))
-                new-pairs (soac/nodes->let-bindings (:nodes fused-graph))
-                new-bindings (vec (mapcat identity new-pairs))]
-            {:form (list* let-sym new-bindings body-exprs)
-             :stats (cond-> stats
-                      (:declined typed) (assoc :typed-soac-declined (:declined typed)))}))))
+              [fused-graph stats] (soac-graph/fusion-fixpoint graph am (:dtype opts))
+              new-pairs (soac/nodes->let-bindings (:nodes fused-graph))
+              new-bindings (vec (mapcat identity new-pairs))]
+          {:form (list* let-sym new-bindings body-exprs)
+           :stats (cond-> stats
+                    (:declined typed) (assoc :typed-soac-declined (:declined typed)))})))
     ;; Not a let* form — fall back to par-fusion
     (par-fusion/par-fusion-pass form)))
 
@@ -1284,76 +1286,6 @@
   [sym]
   (contains? array-tags (:tag (meta sym))))
 
-;; --- Stage A: functional reduce → resident-buffer fusion ------------------------------------
-;; A par/reduce result is a SCALAR in the materialized IR, but on the resident GPU path it must
-;; live in device memory (a 1-element buffer) so the per-token graph never syncs to host. This
-;; pass (Futhark's reduce→broadcast→map fusion) realizes each non-escaping reduce result as a
-;; 1-element buffer written by `par/reduce-into`, and FORWARD-INLINES the pure scalar chain that
-;; depends on it (e.g. rms-norm's `ms`/`inv`) into the consuming kernel bodies, with the reduce
-;; result read back as `(aget buf 0)`. The existing SegMap aget-array path (#37) then consumes
-;; the buffer with NO new machinery. Escape analysis is the accept predicate: a reduce result
-;; that reaches the host result (or any non-kernel binding — e.g. a buffer alloc size) is NOT
-;; realizable, so the whole form is left unchanged (host-roundtrip fallback path).
-
-(defn- pure-scalar-init?
-  "init is a pure scalar expr — a candidate to forward-inline into a consuming kernel body —
-   i.e. not a par form, a buffer alloc, or a kernel invoke."
-  [init]
-  (not (and (seq? init)
-            (or (par/par-form? init)
-                (and (symbol? (first init))
-                     (or (contains? gpu-array-alloc-heads (first init))
-                         (contains? gpu-invoke-heads (first init))))))))
-
-(defn- reduce-buffer-alloc-head [dtype]
-  (if (= dtype :double) 'clojure.core/double-array 'clojure.core/float-array))
-
-(defn fuse-reduce-results
-  "See block comment above. Returns the fused let* form, or the input form UNCHANGED when there
-   is no realizable reduce (no par/reduce, or a reduce result genuinely escapes to host). `dtype`
-   selects the 1-element buffer element type. Operates on the materialized IR (par/reduce +
-   par/map! still present), so it must run before the SegOp/backend lowering."
-  [form dtype]
-  (if-not (and (seq? form) (#{'let* 'let} (first form)))
-    form
-    (let [pairs      (vec (partition 2 (second form)))
-          body-forms (drop 2 form)
-          body-expr  (if (= 1 (count body-forms)) (first body-forms) (cons 'do body-forms))]
-      (loop [ps (seq pairs), subst {}, realized #{}, rbufs #{}, out []]
-        (if-not ps
-          (let [body' (util/subst-syms subst body-expr)
-                ;; Soundness guard: an (aget rbuf 0) may appear ONLY inside par-form bodies
-                ;; (device kernels). If a reduce buffer leaks into the host result or any
-                ;; non-par kept binding (e.g. an alloc size), the reduce result genuinely
-                ;; escapes — bail entirely (no fusion), preserving the host-roundtrip path.
-                leaks-at-host? (fn [e] (boolean (some #(contains? (mem/sexp-free-vars e) %) rbufs)))
-                leaked? (or (leaks-at-host? body')
-                            (some (fn [[_ i]] (and (not (par/par-form? i)) (leaks-at-host? i))) out))]
-            (if (or (empty? rbufs) leaked?)
-              form
-              (apply list (first form) (vec (mapcat identity out)) [body'])))
-          (let [[sym init] (first ps)
-                init' (util/subst-syms subst init)]
-            (cond
-              ;; reduce result → realize as a 1-element device buffer + a reduce-into step
-              (par/par-reduce-form? init')
-              (let [[_ acc init0 idx bound rbody] init'
-                    buf     (gensym (str (name sym) "__rbuf"))
-                    alloc-b [buf (list (reduce-buffer-alloc-head dtype) 1)]
-                    red-b   [(gensym "_red__")
-                             (list 'raster.par/reduce-into buf acc init0 idx bound rbody)]]
-                (recur (next ps)
-                       (assoc subst sym (list 'clojure.core/aget buf 0))
-                       (conj realized sym) (conj rbufs buf)
-                       (conj out alloc-b red-b)))
-              ;; pure scalar depending on a realized value → forward-inline (drop the binding)
-              (and (pure-scalar-init? init')
-                   (seq (set/intersection (mem/sexp-free-vars init) realized)))
-              (recur (next ps) (assoc subst sym init') (conj realized sym) rbufs out)
-              ;; everything else (allocs, par/map! consumers, kernels): keep, subst applied
-              :else
-              (recur (next ps) subst realized rbufs (conj out [sym init'])))))))))
-
 (defn- parse-gpu-step
   "One invoke-registered-* binding → a step record. Artifact-backed map/reduction steps retain a
    complete `:arguments` vector; specialized compatibility markers retain their explicit fields.
@@ -1715,10 +1647,10 @@
         value-fn?   (boolean (some #(contains? value-reg (:tag %)) param-specs))
         pre-opts (cond-> {:inline? true :simd? false :target-device device-id
                           :active-params active-params :dtype effective-dtype
-                          ;; The resident split pipeline still performs reduce-result device
-                          ;; realization between its pre/post halves. Keep it on the compatibility
-                          ;; source route until that transform consumes TypedSOAC equations.
-                          :typed-soac-fusion? false}
+                          ;; Resident reduction realization is a TypedSOAC transform. The logical
+                          ;; scalar remains rank zero while its explicit representation and SegOp
+                          ;; roles keep the physical one-element buffer resident.
+                          :resident-reductions? true}
                    param-env (assoc :param-env param-env)
                    source-ns (assoc :source-ns source-ns))
         raw-form (if (= 1 (count walked-body)) (first walked-body) (cons 'do walked-body))
@@ -1740,15 +1672,6 @@
                     source-ns (assoc :source-ns source-ns)
                     gpu-param-types (assoc :scalar-types (:scalar-types gpu-param-types)
                                            :array-types (:array-types gpu-param-types)))
-        ;; Stage A: realize non-escaping par/reduce results as device-resident 1-elem buffers and
-        ;; fuse their dependent scalar chains into consuming kernels (before SegOp/backend lowering).
-        _pre-fuse form-soa
-        form-soa (fuse-reduce-results form-soa effective-dtype)
-        _ (when (System/getProperty "raster.debug.fuse")
-            (binding [*out* *err*]
-              (println "=== MATERIALIZED (pre-fuse) ===") (println (pr-str _pre-fuse))
-              (println "=== POST-FUSE ===") (println (pr-str form-soa))
-              (println "=== END-FUSE-DUMP ===")))
         form (run-passes form-soa gpu-resident-post-soa-passes post-opts :materialized)
         ;; Final DCE before resident extraction. The pre-SOA :dce runs right after AD
         ;; lowering, while the value+grad result vector [loss dx ... dA dB] still makes

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -21,12 +21,17 @@
           total (raster.par/reduce acc 0.0 j n (+ acc (clojure.core/aget y j)))]
          total))
 
+(def ^:private horizontal-maps
+  '(let* [u (raster.par/pmap i n float (* (clojure.core/aget a i) 2.0))
+          v (raster.par/pmap j n float (+ (clojure.core/aget b j) 1.0))]
+         [u v]))
+
 (deftest pure-vertical-fusion-becomes-a-first-class-typed-program
-  (let [{:keys [program stats]} (route/attempt map-map nil :float)
+  (let [{:keys [program stats]} (route/attempt map-map :float)
         equation (first (:equations program))]
     (is (= :typed-soac (:dialect program)))
     (is (= :typed-soac (:route stats)))
-    (is (:shadow-certified stats))
+    (is (:typed-validated stats))
     (is (= 1 (:vertical stats)))
     (is (= 1 (count (:equations program))))
     (is (= (:algorithm equation) (dialect/validate! (:algorithm equation))))
@@ -34,20 +39,24 @@
     (is (not-any? #{'y} (flatten (:source program))))
     (is (some #{'clojure.core/float-array} (flatten (:source program))))))
 
-(deftest host-visible-intermediate-declines-the-single-consumer-subset
+(deftest host-visible-intermediate-remains-materialized-on-the-typed-route
   (let [source '(let* [y (raster.par/pmap i n float (* (clojure.core/aget x i) 2.0))
                        z (raster.par/pmap j n float (+ (clojure.core/aget y j) 1.0))]
-                      [y z])]
-    (is (= :typed-soac-unknown-value
-           (get-in (route/attempt source nil :float) [:declined :reason]))
-        "the typed route must not erase a value also consumed by scalar host control")))
+                      [y z])
+        {:keys [program stats]} (route/attempt source :float {'x :float})]
+    (is (= :typed-soac (:dialect program)))
+    (is (:typed-validated stats))
+    (is (zero? (:vertical stats)))
+    (is (= 2 (count (:equations program))))
+    (is (= '[y z] (:outputs program))
+        "a host-visible producer is retained, not erased by vertical fusion")))
 
 (deftest effectful-host-binding-keeps-the-compatibility-route
   (let [source '(let* [y (raster.par/pmap i n float (* (clojure.core/aget x i) 2.0))
                        side (println y)
                        z (raster.par/pmap j n float (+ (clojure.core/aget y j) 1.0))]
                       z)]
-    (is (nil? (route/attempt source nil :float)))))
+    (is (nil? (route/attempt source :float)))))
 
 (deftest scalar-equations-require-retained-source-type-facts
   (let [source '(let* [n (clojure.core/alength x)
@@ -55,7 +64,7 @@
                        z (raster.par/pmap j n float (+ (clojure.core/aget y j) 1.0))]
                       z)]
     (is (= :unsupported-scalar-binding
-           (get-in (route/attempt source nil :float {'x :float}) [:declined :reason]))
+           (get-in (route/attempt source :float {'x :float}) [:declined :reason]))
         "the compatibility adapter must not reconstruct a missing TypedClojure result type")))
 
 (deftest semantic-alength-bounds-normalize-to-the-producing-extent
@@ -64,7 +73,7 @@
                        z (raster.par/pmap j (clojure.core/alength y) float
                                           (+ (clojure.core/aget y j) 1.0))]
                       z)
-        program (:program (route/attempt source nil :float {'x :double}))
+        program (:program (route/attempt source :float {'x :double}))
         scalar-equation (some #(when (= 'scalar
                                         (dialect/operation-kind
                                          (first (dialect/equations (:algorithm %))))) %)
@@ -105,7 +114,7 @@
                                                    (clojure.core/aget a j))))))]
                out)
         {:keys [program stats]} (route/attempt
-                                 source nil :double
+                                 source :double
                                  {'W1 :double 'W2 :double 'b1 :double 'b2 :double 'x :double})
         scheduled (:form (segop-lower/segop-lower-pass
                           program {:dtype :double :target-device :ocl:0}))
@@ -123,7 +132,7 @@
                              (:kernels emitted))
         kernel-sources (mapv :source (:kernels emitted))]
     (is (= :typed-soac (:route stats)))
-    (is (:shadow-certified stats))
+    (is (:typed-validated stats))
     (is (= 1 (:vertical stats)))
     (is (= ['scalar 'scalar 'map 'scalar 'scalar 'map] equation-kinds))
     (is (= 'rows (get-in program [:equations 4 :source]))
@@ -146,7 +155,7 @@
           [["map" map-map raster.compiler.ir.segop.SegMap :simd-maps]
            ["reduce" map-reduce raster.compiler.ir.segop.SegRed :simd-reduces]]]
     (testing label
-      (let [typed (:program (route/attempt source nil :float))
+      (let [typed (:program (route/attempt source :float))
             {:keys [form stats]} (segop-lower/segop-lower-pass typed {:dtype :float})
             simd (par-simd/simd-pass form :min-elements 1)]
         (is (= :segop (:dialect form)))
@@ -158,8 +167,43 @@
         (is (nil? (get-in simd [:stats :segop-relowered])))
         (parallel-program/validate! form segop/segop-node?)))))
 
+(deftest typed-horizontal-fusion-lowers-to-one-explicit-multi-output-segmap
+  (let [{:keys [program stats]} (route/attempt
+                                 horizontal-maps :float {'a :float 'b :float})
+        scheduled (:form (segop-lower/segop-lower-pass
+                          program {:dtype :float :target-device :ocl:0}))
+        operation (first (:operations (first (:equations scheduled))))
+        jvm (par-simd/simd-pass scheduled :min-elements 1)
+        emitted (opencl-pass/opencl-pass scheduled :device-id :ocl:0
+                                         :dtype :float :min-elements 1)
+        kernel (first (:kernels emitted))]
+    (is (= :typed-soac (:dialect program)))
+    (is (:typed-validated stats))
+    (is (= 1 (:horizontal stats)))
+    (is (= '[u v] (dialect/outputs (get-in program [:equations 0 :algorithm]))))
+    (is (= #{'u 'v} (:outputs operation)))
+    (is (= 'u (:out-sym operation)))
+    (is (some #{'clojure.core/aset} (flatten (:lambda operation))))
+    (is (nil? (get-in jvm [:stats :segop-relowered])))
+    (is (= [:input :input :output :output :scalar]
+           (mapv :kind (:abi kernel))))
+    (is (re-find #"__global float\* restrict [uv]" (:source kernel)))))
+
+(deftest unfused-map-also-uses-the-typed-production-route
+  (let [source '(let* [y (raster.par/pmap i n float
+                                          (* (clojure.core/aget x i) 2.0))]
+                      y)
+        {:keys [program stats]} (route/attempt source :float {'x :float})]
+    (is (= :typed-soac (:dialect program)))
+    (is (:typed-validated stats))
+    (is (zero? (:vertical stats)))
+    (is (zero? (:horizontal stats)))
+    (is (= 'map (dialect/operation-kind
+                 (first (dialect/equations
+                         (get-in program [:equations 0 :algorithm]))))))))
+
 (deftest gpu-emission-consumes-the-same-certified-segmap
-  (let [typed (:program (route/attempt map-map nil :float))
+  (let [typed (:program (route/attempt map-map :float))
         scheduled (:form (segop-lower/segop-lower-pass
                           typed {:dtype :float :target-device :ocl:0}))
         emitted (opencl-pass/opencl-pass scheduled :device-id :ocl:0 :dtype :float)]
@@ -167,6 +211,88 @@
     (is (= 1 (get-in emitted [:stats :segop-reused])))
     (is (nil? (get-in emitted [:stats :segop-relowered])))
     (is (= 1 (count (:kernels emitted))))))
+
+(deftest resident-reduction-realization-stays-on-the-typed-spine
+  (let [source
+        '(let* [total (raster.par/reduce acc 0.0 i n
+                                         (+ acc (* ^double scale
+                                                   (clojure.core/aget a i))))
+                ^float scaled (* total ^float gain)
+                result (raster.par/map-void!
+                        j (long n)
+                        (clojure.core/aset out j
+                                           (float (* (clojure.core/aget a j)
+                                                     scaled))))]
+               result)
+        {:keys [program stats]} (route/attempt
+                                 source :float
+                                 {'a :float 'out :float}
+                                 {:resident-reductions? true})
+        scheduled (:form (segop-lower/segop-lower-pass
+                          program {:dtype :float :target-device :ze:0}))
+        reductions (->> (:equations scheduled)
+                        (mapcat :operations)
+                        (filter #(instance? raster.compiler.ir.segop.SegRed %))
+                        vec)
+        phase-one (some #(when (= :block-local (:phase %)) %) reductions)
+        phase-two (some #(when (= :cross-block (:phase %)) %) reductions)
+        partial (first (:outputs phase-one))]
+    (is (= :typed-soac (:dialect program)))
+    (is (= :typed-soac (:route stats)))
+    (is (:typed-validated stats))
+    (is (= 1 (:resident-reductions stats)))
+    (is (= 1 (:inlined-scalars stats)))
+    (is (= [] (get-in program [:values 'total :shape])))
+    (is (= :resident-scalar-buffer
+           (get-in program [:values 'total :representation :kind])))
+    (is (some #{'raster.par/reduce-into} (flatten (:source program))))
+    (is (not-any? #{'scaled} (flatten (:source program))))
+    (is (= #{:memory/write}
+           (get-in (dialect/facts (get-in program [:equations 1 :algorithm]))
+                   [:equations 2 :effects])))
+    (is (= 'out
+           (get-in (dialect/facts (get-in program [:equations 1 :algorithm]))
+                   [:equations 2 :attributes :destination])))
+    (is (= 2 (count reductions)))
+    (is (= #{partial} (:inputs phase-two)))
+    (is (= :double (get-in scheduled [:values partial :dtype])))))
+
+(deftest host-visible-reduction-is-not-represented-as-resident-storage
+  (let [source
+        '(let* [y (raster.par/pmap i n float
+                                   (* (clojure.core/aget x i) 2.0))
+                total (raster.par/reduce acc 0.0 j n
+                                         (+ acc (clojure.core/aget y j)))]
+               total)
+        {:keys [program stats]} (route/attempt
+                                 source :float {'x :float}
+                                 {:resident-reductions? true})]
+    (is (= :typed-soac (:dialect program)))
+    (is (= 1 (:vertical stats)))
+    (is (zero? (:resident-reductions stats)))
+    (is (= :plain (get-in program [:values 'total :representation :kind])))
+    (is (some #{'raster.par/reduce} (flatten (:source program))))
+    (is (not-any? #{'raster.par/reduce-into} (flatten (:source program))))))
+
+(deftest host-visible-dependent-scalar-blocks-its-resident-root
+  (let [source
+        '(let* [total (raster.par/reduce acc 0.0 i n
+                                         (+ acc (clojure.core/aget a i)))
+                ^double scaled (* total ^double gain)
+                result (raster.par/map-void!
+                        j n (clojure.core/aset out j
+                                               (float (* (clojure.core/aget a j)
+                                                         scaled))))]
+               [scaled result])
+        {:keys [program stats]} (route/attempt
+                                 source :float {'a :float 'out :float}
+                                 {:resident-reductions? true})]
+    (is (= :typed-soac (:dialect program)))
+    (is (zero? (:resident-reductions stats)))
+    (is (= :plain (get-in program [:values 'total :representation :kind])))
+    (is (= [:binding 'scaled] (get-in program [:equations 1 :site])))
+    (is (some #{'raster.par/reduce} (flatten (:source program))))
+    (is (not-any? #{'raster.par/reduce-into} (flatten (:source program))))))
 
 (deftest production-pass-chain-preserves-the-typed-envelope
   (let [scheduled (pipeline/run-passes

--- a/test/raster/dl/gpu_ad_gemm_test.clj
+++ b/test/raster/dl/gpu_ad_gemm_test.clj
@@ -209,7 +209,7 @@
 (deftest gpu-reduce-step-program-binds-and-replays
   ;; The former resident whole-program binder wired only :map/:map-void/:gemm/
   ;; :scatter step kinds; a program containing a par/reduce whose result stays resident
-  ;; (the #42 resident-reduce work: fuse-reduce-results gives it a device 1-elem out-buf)
+  ;; (the resident TypedSOAC realization gives it a device one-element output buffer)
   ;; threw at bind time even though bind-step! already handled :reduce. This pins the
   ;; wiring: scale*sum(a) (a captured reduction scalar) feeding an elementwise scale compiles to
   ;; [:reduce :map] steps, binds its full ordered ABI,


### PR DESCRIPTION
## Summary

- route supported unfused, vertically fused, horizontally fused, host-visible, and in-place map/reduction programs through one TypedSOAC to SegOp production path
- realize non-escaping reduction scalars as explicit resident-scalar-buffer representations and delete the raw source fuse-reduce-results rewrite and typed-route opt-out
- lower tuple-valued maps to one explicit multi-output SegMap and remove the legacy graph as a production shadow authority
- certify generated reduction partial values and aliased physical output boundaries before emission
- update the compiler north star with the remaining bounded legacy work

## Verification

- full suite: 2482 tests, 35306 assertions, 0 failures, 0 errors
- GPU suite probe available: 1 device, 0 tests took the skip path
- OpenCL suite probe available: Intel Arc Graphics, 0 tests took the skip path
- formatter and git diff checks clean
- production Gemma resident gate: 138 stages, mixed-precision 56-GEMM backward path, GPU/CPU loss parity