### PR TITLE
Construct TypedSOAC directly from analyzed source

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -77,12 +77,12 @@ with typed scalar SSA, stable reads, workgroup allocation, masks, barriers and a
 the same body emits as OpenCL, CUDA and HIP and is compiled by the hardware-free vendor CI gates.
 Unsupported scalar regions decline explicitly to the established verified SegRed OpenCL emitter.
 
-The remaining nominal boundary is earlier: the production adapter still constructs `ir.soac`
-records from source-shaped S-expressions before projecting them into TypedSOAC. Supported programs
-are optimized only as TypedSOAC—the old dependency-graph optimizer is no longer a production
-shadow authority—but unsupported forms still take that explicit fallback. The problem is not the
-use of S-expressions; it is that the front end should construct stable value identity, types,
-effects, aliases and dialect legality directly in the first-class typed program.
+The map/scalar/full-reduction front end now constructs TypedSOAC directly from closed analyzed
+source and retained walker type metadata. It establishes stable equation/value identity, types,
+effects, aliases and placement provenance before fusion; no `ir.soac` record or record-to-dialect
+adapter participates in this production route. The old dependency-graph path remains only as an
+explicit fallback for unsupported parallel forms and as a differential oracle. Typed scan and the
+remaining parallel forms must join the direct front end before that fallback can be deleted.
 
 The first architectural correction is therefore:
 
@@ -437,10 +437,10 @@ spelling for the migrated subset is generated from TypedSOAC rather than retaine
 SIMD/GPU reuse its certified SegOps. Non-escaping reduction results remain logical rank-zero values
 whose `:resident-scalar-buffer` representation drives one-element device allocation and stable
 consumer loads; dependent scalar equations are inlined as a typed transform. The former raw-source
-resident rewrite and typed-route opt-out are deleted. Migration is complete when the analyzed front
-end constructs TypedSOAC directly, typed scan and hardware-costed multi-consumer fusion land, and
-the covered graph/backend compatibility re-lowerings are deleted. Nested reductions inside a
-retained map are typed and correctly classified, but the JVM SIMD leaf still lowers those inner
+resident rewrite and typed-route opt-out are deleted. The analyzed front end now constructs this
+TypedSOAC subset directly; migration is complete when typed scan and hardware-costed multi-consumer
+fusion land and the covered graph/backend compatibility re-lowerings are deleted. Nested reductions
+inside a retained map are typed and correctly classified, but the JVM SIMD leaf still lowers those inner
 regions through its established scalar fallback; this is an explicit scheduling boundary rather
 than a loss of semantic facts.
 
@@ -789,12 +789,12 @@ The immediate continuation after the verified double-buffered weighted-reduction
    keep the current 1-D attention stages on its identity member until measured 2-D staging lands.
 4. **Landed:** make stage count and swizzle finite measured schedule axes, retire the legacy tuner,
    and remove the attention-provenance gate from routed weighted-reduction lowering.
-5. **In progress:** finish the typed front end and scalar JVM scheduling, then remove compatibility
+5. **In progress:** finish typed parallel coverage and scalar JVM scheduling, then remove compatibility
    re-lowering. Supported map/reduce programs, including unfused and host-visible intermediates,
    horizontal tuple maps, typed scalar/shape equations, stable tensor captures, and resident
-   reduction results now share the production TypedSOAC→SegOp route. Direct analyzed-source
-   construction, typed scan, hardware-costed multi-consumer fusion, nested-region JVM scheduling,
-   and deletion of the remaining graph/backend fallbacks remain.
+   reduction results now share the direct analyzed-source→TypedSOAC→SegOp production route. Typed
+   scan, hardware-costed multi-consumer fusion, nested-region JVM scheduling, and deletion of the
+   remaining graph/backend fallbacks remain.
 6. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a
    read-only distributed track without interrupting the kernel and typed-middle-end verticals.
 

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -1,0 +1,460 @@
+(ns raster.compiler.passes.parallel.typed-soac-frontend
+  "Direct analyzed-source to TypedSOAC construction for the closed map/scalar/reduce subset.
+
+   This is the production front door for TypedSOAC.  It consumes the retained source form and
+   walker type metadata directly; it never constructs the older record graph.  Unsupported
+   parallel forms return nil so the pipeline can use the explicitly separate compatibility route.
+   Once an operation is accepted, all value, effect and provenance facts are made explicit before
+   fusion or scheduling sees it."
+  (:require [clojure.set :as set]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.types :as types]
+            [raster.compiler.core.util :as util]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.form :as form]
+            [raster.compiler.ir.par :as par]
+            [raster.compiler.ir.reduction :as reduction]
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.passes.parallel.fusion-support :as fusion-support]
+            [raster.compiler.passes.scalar.effects :as effects]))
+
+(def ^:private array-constructor-heads
+  '#{double-array float-array int-array long-array byte-array
+     clojure.core/double-array clojure.core/float-array
+     clojure.core/int-array clojure.core/long-array clojure.core/byte-array})
+
+(defn- fail!
+  [reason message data]
+  (throw (ex-info message (assoc data :reason reason :front-end :analyzed-source))))
+
+(defn- extract-io
+  [body index outputs & {:keys [accumulator]}]
+  (let [inputs (par/collect-aget-arrays body)
+        written (par/collect-aset-arrays body)
+        excluded (set/union inputs (set outputs) written #{index}
+                            (if accumulator #{accumulator} #{})
+                            descriptor/aget-ops descriptor/aset-ops
+                            #{'do 'let 'let* 'if 'double 'float 'int 'long})]
+    {:inputs inputs
+     :outputs (into (set outputs) written)
+     :scalars (set/difference (util/free-syms body) excluded)}))
+
+(defn- strip-index-cast
+  [expression]
+  (if (and (seq? expression)
+           (contains? #{'long 'int 'clojure.core/long 'clojure.core/int}
+                      (first expression))
+           (= 2 (count expression)))
+    (second expression)
+    expression))
+
+(defn- pointwise-map-void
+  "Recognize one pointwise store without erasing or duplicating effects.
+
+   The let-wrapper case is the closed form produced by the walker.  Its initializers must be pure
+   because flattening them into the element expression changes their evaluation placement."
+  [body index]
+  (let [statement (if (and (seq? body) (= 'do (first body)) (= 2 (count body)))
+                    (second body)
+                    body)]
+    (cond
+      (and (seq? statement) (form/let-head? (first statement)))
+      (let [[_ bindings & nested-body] statement]
+        (when (and (= 1 (count nested-body))
+                   (not-any? util/effectful? (take-nth 2 (rest bindings))))
+          (when-let [inner (pointwise-map-void (first nested-body) index)]
+            (update inner :value #(util/subst-syms (util/binding-env bindings) %)))))
+
+      (descriptor/aset-call? statement)
+      (let [arguments (vec (descriptor/call-args statement))]
+        (when (and (= 3 (count arguments))
+                   (= index (strip-index-cast (nth arguments 1))))
+          (let [value (nth arguments 2)
+                cast? (and (seq? value)
+                           (contains? #{'float 'double 'int 'long
+                                        'clojure.core/float 'clojure.core/double}
+                                      (first value))
+                           (= 2 (count value)))]
+            {:out (descriptor/aset-array-sym statement)
+             :value (if cast? (second value) value)
+             :cast (when cast? (first value))})))
+
+      :else nil)))
+
+(defn- operation-description
+  [id symbol expression]
+  (cond
+    (par/par-map-pure-form? expression)
+    (let [{:keys [idx bound cast body elem-type]} (par/extract-par-map-pure-info expression)
+          io (extract-io body idx [symbol])]
+      (merge {:kind :map :id id :sym symbol :index idx :extent bound :cast cast :body body
+              :pure? true :elem-type elem-type}
+             io))
+
+    (par/par-map-form? expression)
+    (let [{:keys [out idx bound cast body elem-type offset]}
+          (par/extract-par-map-info expression)]
+      ;; Offset maps are not pointwise in the result coordinate and require an indexed/scatter
+      ;; operation in the typed dialect.  Never silently describe one as an ordinary map.
+      (when-not offset
+        (merge {:kind :map :id id :sym symbol :index idx :extent bound :cast cast :body body
+                :elem-type elem-type}
+               (extract-io body idx [out]))))
+
+    (par/par-reduce-form? expression)
+    (let [{:keys [acc init idx bound body elem-type]} (par/extract-par-reduce-info expression)
+          io (extract-io body idx [symbol] :accumulator acc)]
+      (merge {:kind :reduce :id id :sym symbol :index idx :extent bound
+              :product (reduction/scalar
+                        ;; The walker stamps contextual FP narrowing on the par form.  Without
+                        ;; that retained fact, Clojure's scalar reduction semantics are double;
+                        ;; the target's preferred array dtype is not permission to narrow it.
+                        {:accumulator acc :neutral init :dtype (or elem-type :double)
+                         :result symbol :index idx :step-result body
+                         :attributes {:source :raster.par/reduce}})}
+             io))
+
+    (par/par-map-void-form? expression)
+    (let [{:keys [idx bound body elem-type]} (par/extract-par-map-void-info expression)]
+      (when-let [{:keys [out value cast]} (pointwise-map-void body idx)]
+        (merge {:kind :map :id id :sym symbol :index idx :extent bound :cast cast :body value
+                :void? true :primary-out out :elem-type elem-type}
+               (extract-io value idx [out]))))
+
+    :else nil))
+
+(defn- provably-pure-scalar?
+  [expression]
+  (or (effects/removable-expr? expression)
+      (and (descriptor/alength-op? (descriptor/semantic-op expression))
+           (= 1 (count (descriptor/call-args expression)))
+           (symbol? (first (descriptor/call-args expression))))))
+
+(defn- alength-array
+  [expression]
+  (when (and (seq? expression)
+             (descriptor/alength-op? (descriptor/semantic-op expression))
+             (= 1 (count (descriptor/call-args expression))))
+    (first (descriptor/call-args expression))))
+
+(defn- source-descriptions
+  [pairs]
+  (mapv (fn [id [symbol expression]]
+          (or (operation-description id symbol expression)
+              (if (par/par-form? expression)
+                {:kind :unsupported :id id :sym symbol :expr expression}
+                {:kind :scalar :id id :sym symbol :expr expression})))
+        (range) pairs))
+
+(defn- normalize-extents
+  [descriptions]
+  (:descriptions
+   (reduce
+    (fn [{:keys [extents scalar-representatives] :as state} description]
+      (case (:kind description)
+        :scalar
+        (let [expression (:expr description)
+              array (alength-array expression)
+              representative (cond
+                               (and array (contains? extents array)) (get extents array)
+                               (symbol? expression)
+                               (get scalar-representatives expression expression)
+                               (integer? expression) expression
+                               :else (:sym description))]
+          (-> state
+              (update :descriptions conj
+                      (assoc description :expr (if (= representative (:sym description))
+                                                 expression representative)))
+              (assoc-in [:scalar-representatives (:sym description)] representative)))
+
+        (:map :reduce)
+        (let [extent (descriptor/unwrap-int-cast (:extent description))
+              array (alength-array extent)
+              extent' (cond
+                        (and array (contains? extents array)) (get extents array)
+                        (symbol? extent) (get scalar-representatives extent extent)
+                        :else extent)
+              description' (assoc description :extent extent')]
+          (cond-> (update state :descriptions conj description')
+            (= :map (:kind description')) (assoc-in [:extents (:sym description')] extent')))
+
+        (update state :descriptions conj description)))
+    {:descriptions [] :extents {} :scalar-representatives {}}
+    descriptions)))
+
+(defn- generated-scaffolding?
+  [description physical-outputs]
+  (and (= :scalar (:kind description))
+       (let [expression (:expr description)]
+         (or (and (symbol? expression) (contains? physical-outputs expression))
+             (and (contains? physical-outputs (:sym description))
+                  (seq? expression)
+                  (contains? array-constructor-heads (first expression)))))))
+
+(defn- supported-descriptions?
+  [descriptions]
+  (let [physical-outputs (reduce set/union #{}
+                                 (map #(if (contains? #{:map :reduce} (:kind %))
+                                         (:outputs %) #{})
+                                      descriptions))]
+    (every? (fn [description]
+              (case (:kind description)
+                :scalar (or (provably-pure-scalar? (:expr description))
+                            (generated-scaffolding? description physical-outputs))
+                :map (or (:pure? description)
+                         (and (:void? description) (symbol? (:primary-out description))))
+                :reduce true
+                false))
+            descriptions)))
+
+(defn- element-symbols [n] (mapv #(symbol (str "%element" %)) (range n)))
+(defn- capture-symbols [n] (mapv #(symbol (str "%capture" %)) (range n)))
+
+(defn- pointwise-input?
+  [expressions array index]
+  (let [reads (filter (fn [{:keys [sym]}]
+                        (and (symbol? sym) (= (name array) (name sym))))
+                      (mapcat descriptor/aget-reads expressions))]
+    (and (seq reads)
+         (every? #(= index (descriptor/unwrap-int-cast (:idx %))) reads))))
+
+(defn- elementize
+  [expressions arrays parameters index]
+  (mapv (fn [expression]
+          (reduce (fn [body [array parameter]]
+                    (fusion-support/substitute-aget body array index index parameter))
+                  expression (map vector arrays parameters)))
+        expressions))
+
+(defn- map-equation
+  [description]
+  (let [{:keys [id sym index extent cast body inputs primary-out void?]} description
+        expression (if cast (list cast body) body)
+        [pointwise stable] ((juxt filter remove) #(pointwise-input? [expression] % index) inputs)
+        arrays (vec (sort-by pr-str pointwise))
+        stable (cond-> (set stable) void? (conj primary-out))
+        captures (vec (sort-by pr-str (distinct (concat stable (:scalars description)))))
+        parameters (element-symbols (count arrays))
+        capture-parameters (capture-symbols (count captures))
+        body-result (util/subst-syms
+                     (zipmap captures capture-parameters)
+                     (first (elementize [expression] arrays parameters index)))]
+    (list '= id [sym]
+          (list 'map {:index index :extent extent
+                      :attributes {:stable-array-captures (vec (sort-by pr-str stable))}}
+                arrays captures
+                (list 'lambda (vec (concat parameters capture-parameters)) [body-result])))))
+
+(defn- reduce-equation
+  [{:keys [id extent inputs scalars product]}]
+  (let [component (first (:components product))
+        expressions (:results (reduction/fold-region product))
+        index (:index product)
+        [pointwise stable] ((juxt filter remove) #(pointwise-input? expressions % index) inputs)
+        arrays (vec (sort-by pr-str pointwise))
+        captures (vec (sort-by pr-str (distinct (concat stable scalars))))
+        elements (element-symbols (count arrays))
+        capture-parameters (capture-symbols (count captures))
+        results (->> (elementize expressions arrays elements index)
+                     (mapv #(util/subst-syms (zipmap captures capture-parameters) %)))]
+    (list '= id (vec (filter some? (reduction/results product)))
+          (list 'reduce {:index index :extent extent
+                         :attributes {:stable-array-captures (vec (sort-by pr-str stable))}
+                         :accumulators [(:accumulator component)]
+                         :identities [(:neutral component)]
+                         :dtypes [(:dtype component)]
+                         :algebra [(:algebra product)]}
+                arrays captures
+                (list 'lambda
+                      (vec (concat [(:accumulator component)] elements capture-parameters))
+                      results)))))
+
+(defn- scalar-dtype
+  [{:keys [sym expr]} scalar-dtypes scalar-types]
+  (let [expression-tag (when (instance? clojure.lang.IObj expr)
+                         (or (:raster.type/tag (meta expr)) (:tag (meta expr))))]
+    (or (get scalar-types sym)
+        (when (symbol? expr) (get scalar-dtypes expr))
+        (dtype/dtype-for-scalar-tag (types/sym-type-tag sym))
+        (dtype/dtype-for-scalar-tag expression-tag))))
+
+(defn- scalar-equation
+  [description scalar-dtypes scalar-types]
+  (let [{:keys [id sym expr]} description
+        captures (vec (sort-by pr-str (util/free-syms expr)))
+        parameters (capture-symbols (count captures))
+        result-dtype (scalar-dtype description scalar-dtypes scalar-types)]
+    (when-not result-dtype
+      (fail! :unsupported-scalar-binding
+             "typed scalar equations require a retained result dtype"
+             {:binding id :symbol sym :expression expr}))
+    (list '= id [sym]
+          (list 'scalar {:dtypes [result-dtype]} captures
+                (list 'lambda parameters
+                      [(util/subst-syms (zipmap captures parameters) expr)])))))
+
+(defn- terminal-results
+  [descriptions body]
+  (let [operations (filter #(contains? #{:map :reduce} (:kind %)) descriptions)
+        operation-definitions (set (mapcat #(if (= :map (:kind %))
+                                              [(:sym %)] (:outputs %))
+                                           operations))
+        scalar-definitions (set (keep #(when (= :scalar (:kind %)) (:sym %)) descriptions))
+        all-definitions (set/union operation-definitions scalar-definitions)
+        operation-uses (set (concat (mapcat #(concat (:inputs %) (:scalars %)) operations)
+                                    (mapcat #(when (= :scalar (:kind %))
+                                               (util/free-syms (:expr %)))
+                                            descriptions)))
+        body-uses (set (mapcat util/free-syms body))]
+    (vec (sort-by pr-str
+                  (set/union (set/difference operation-definitions operation-uses)
+                             (set/intersection all-definitions body-uses))))))
+
+(defn- selected-scalars
+  [descriptions operation-equations outputs]
+  (let [by-symbol (into {} (keep #(when (= :scalar (:kind %)) [(:sym %) %])) descriptions)
+        roots (set (concat outputs
+                           (mapcat (fn [equation]
+                                     (cond-> (dialect/operation-inputs equation)
+                                       (dialect/value-id? (dialect/operation-extent equation))
+                                       (conj (dialect/operation-extent equation))))
+                                   operation-equations)))]
+    (loop [needed (set/intersection roots (set (keys by-symbol)))]
+      (let [dependencies (set (mapcat #(util/free-syms (:expr (get by-symbol %))) needed))
+            needed' (set/union needed (set/intersection dependencies (set (keys by-symbol))))]
+        (if (= needed needed') needed (recur needed'))))))
+
+(defn- tensor-value [dtype shape]
+  (av/tensor {:dtype dtype :shape shape :representation {:kind :plain}}))
+
+(defn- value-dtype [id default-dtype array-types]
+  (or (get array-types id)
+      (when (symbol? id) (get array-types (symbol (name id))))
+      default-dtype :double))
+
+(defn- equation-values
+  [equation default-dtype array-types known-values]
+  (let [[_ _ results] equation
+        {:keys [kind attributes arrays captures]} (dialect/operation-parts equation)
+        extent (:extent attributes)
+        stable (set (get-in attributes [:attributes :stable-array-captures]))
+        result-dtypes (case kind
+                        scalar (:dtypes attributes)
+                        reduce (:dtypes attributes)
+                        (repeat (count results) default-dtype))]
+    (merge
+     (if (and extent (dialect/value-id? extent)) {extent (tensor-value :long [])} {})
+     (into {} (map (fn [id] [id (tensor-value (value-dtype id default-dtype array-types)
+                                              (dialect/extent-shape extent))]) arrays))
+     (if (= 'scalar kind)
+       (into {} (keep (fn [id]
+                        (when-let [value (or (get known-values id)
+                                             (when-let [declared (and (symbol? id)
+                                                                      (dtype/dtype-for-scalar-tag
+                                                                       (types/sym-type-tag id)))]
+                                               (tensor-value declared [])))]
+                          [id value]))) captures)
+       (into {} (map (fn [id]
+                       [id (or (get known-values id)
+                               (if (or (contains? stable id)
+                                       (contains? array-types id)
+                                       (and (symbol? id)
+                                            (contains? array-types (symbol (name id)))))
+                                 (tensor-value (value-dtype id default-dtype array-types)
+                                               [(list 'unknown-dimension id)])
+                                 (tensor-value (value-dtype id default-dtype array-types) [])))])
+                     captures)))
+     (into {} (map (fn [id result-dtype]
+                     [id (tensor-value (or result-dtype default-dtype :double)
+                                       (if (contains? #{'scalar 'reduce} kind) []
+                                           (dialect/extent-shape extent)))])
+                   results result-dtypes)))))
+
+(defn- merge-value
+  [values id contract]
+  (if-let [prior (get values id)]
+    (if (= prior contract) values
+        (fail! :source-value-conflict
+               "source bindings imply incompatible AbstractValues for one logical value"
+               {:id id :first prior :second contract}))
+    (assoc values id contract)))
+
+(defn form->program
+  "Construct and validate TypedSOAC directly from a closed let form.
+
+   Returns nil when any binding is outside the certified source subset. Type/effect/value
+   contradictions throw ExceptionInfo because falling through after accepting them would hide a
+   compiler correctness defect."
+  [source {:keys [dtype array-types scalar-types values]
+           :or {dtype :double array-types {} scalar-types {} values {}}}]
+  (when (and (seq? source) (contains? #{'let 'let*} (first source)))
+    (let [[_ bindings & body] source
+          pairs (vec (partition 2 bindings))
+          descriptions (normalize-extents (source-descriptions pairs))]
+      (when (and (even? (count bindings))
+                 (seq descriptions)
+                 (supported-descriptions? descriptions))
+        (let [operation-descriptions (filterv #(contains? #{:map :reduce} (:kind %)) descriptions)
+              operation-equations (mapv #(case (:kind %) :map (map-equation %)
+                                               :reduce (reduce-equation %))
+                                        operation-descriptions)
+              outputs (terminal-results descriptions body)
+              required-scalars (selected-scalars descriptions operation-equations outputs)
+              {:keys [equations equation-descriptions]}
+              (reduce (fn [{:keys [scalar-dtypes] :as state} description]
+                        (case (:kind description)
+                          :scalar
+                          (if (contains? required-scalars (:sym description))
+                            (let [equation (scalar-equation description scalar-dtypes scalar-types)
+                                  result-dtype (first (:dtypes (second (nth equation 3))))]
+                              (-> state
+                                  (update :equations conj equation)
+                                  (update :equation-descriptions conj description)
+                                  (assoc-in [:scalar-dtypes (:sym description)] result-dtype)))
+                            state)
+                          (:map :reduce)
+                          (-> state
+                              (update :equations conj
+                                      (if (= :map (:kind description))
+                                        (map-equation description)
+                                        (reduce-equation description)))
+                              (update :equation-descriptions conj description))))
+                      {:equations [] :equation-descriptions [] :scalar-dtypes {}}
+                      descriptions)
+              equation-info (mapv (fn [equation]
+                                    {:results (nth equation 2)
+                                     :inputs (dialect/operation-inputs equation)
+                                     :extent (dialect/operation-extent equation)})
+                                  equations)
+              definitions (set (mapcat :results equation-info))
+              references (set (mapcat #(cond-> (:inputs %)
+                                         (and (:extent %) (dialect/value-id? (:extent %)))
+                                         (conj (:extent %))) equation-info))
+              inputs (vec (sort-by pr-str (set/difference references definitions)))
+              inferred-values (reduce (fn [contracts equation]
+                                        (reduce-kv merge-value contracts
+                                                   (equation-values equation dtype array-types
+                                                                    contracts)))
+                                      {} equations)
+              values (reduce-kv merge-value inferred-values values)
+              equation-facts
+              (into {}
+                    (map (fn [description]
+                           (let [destination (when (:void? description) (:primary-out description))]
+                             [(:id description)
+                              (cond-> (dialect/default-equation-facts
+                                       {:front-end :analyzed-source
+                                        :source-binding-id (:id description)})
+                                destination
+                                (assoc :effects #{:memory/write}
+                                       :aliases {(:sym description) destination}
+                                       :attributes {:destination destination}))]))
+                         equation-descriptions))
+              total-effects (reduce set/union #{} (map :effects (vals equation-facts)))
+              facts (dialect/default-program-facts
+                     {:values values :inputs inputs :equations equation-facts
+                      :effects total-effects
+                      :provenance {:front-end :analyzed-source}
+                      :attributes {:source-dialect :closed-clojure}})]
+          (dialect/make facts equations outputs))))))

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -4,14 +4,9 @@
    Supported programs are represented and fused in the typed dialect whether or not a fusion
    fires. The resulting functional equations are mechanically projected into the surrounding host
    control expression and retained as first-class algorithms in a ParallelProgram."
-  (:require [clojure.set :as set]
-            [raster.compiler.core.op-descriptor :as descriptor]
-            [raster.compiler.ir.parallel-program :as parallel-program]
-            [raster.compiler.ir.reduction :as reduction]
-            [raster.compiler.ir.soac :as legacy]
+  (:require [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.soac-dialect :as dialect]
-            [raster.compiler.passes.scalar.effects :as effects]
-            [raster.compiler.passes.parallel.soac-dialect-adapter :as adapter]
+            [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]
             [raster.compiler.passes.parallel.typed-soac-resident :as resident]
             [raster.compiler.core.util :as util]))
@@ -22,95 +17,6 @@
    :int ['clojure.core/int-array 'ints 'int]
    :long ['clojure.core/long-array 'longs 'long]
    :byte ['clojure.core/byte-array 'bytes 'byte]})
-
-(defn- provably-pure-host-binding?
-  [expression]
-  ;; Beichte is the general conservative purity authority. Array length is also a closed compiler
-  ;; intrinsic identified through the canonical semantic descriptor (including devirtualized
-  ;; `.invk` spellings), not through a function-name/type registry. Typed scalar equations retain
-  ;; the walker's result tag separately, so this effect verdict never infers a result type.
-  (or (effects/removable-expr? expression)
-      (and (descriptor/alength-op? (descriptor/semantic-op expression))
-           (= 1 (count (descriptor/call-args expression)))
-           (symbol? (first (descriptor/call-args expression))))))
-
-(defn- supported-node?
-  [node]
-  ;; Unknown calls are not evidence of purity. This first route carries atomic bindings and the
-  ;; compiler's semantically identified array-length query; richer scalar equations belong in the
-  ;; typed program itself.
-  (or (and (legacy/scalar-binding? node) (provably-pure-host-binding? (:expr node)))
-      (and (legacy/soac-map? node)
-           (or (:pure? node)
-               (and (:void? node) (symbol? (:primary-out node)))))
-      (and (legacy/soac-reduce? node)
-           (empty? (:segment-axes node))
-           (reduction/scalar? (:reduction node)))))
-
-(defn- alength-array
-  [expression]
-  (when (and (seq? expression)
-             (descriptor/alength-op? (descriptor/semantic-op expression))
-             (= 1 (count (descriptor/call-args expression))))
-    (first (descriptor/call-args expression))))
-
-(defn- normalize-node-extents
-  "Value-number pure scalar extents and replace `alength` of a known result with its certified
-   producer extent. Scalar names remain distinct values; only their operation uses are canonical."
-  [nodes]
-  (:nodes
-   (reduce
-    (fn [{:keys [extents scalar-representatives] :as state} node]
-      (cond
-        (legacy/scalar-binding? node)
-        (let [expression (:expr node)
-              array (alength-array expression)
-              representative (cond
-                               (and array (contains? extents array)) (get extents array)
-                               (symbol? expression)
-                               (get scalar-representatives expression expression)
-                               (integer? expression) expression
-                               :else (:sym node))
-              expression' (if (= representative (:sym node)) expression representative)]
-          (-> state
-              (update :nodes conj (assoc node :expr expression'))
-              (assoc-in [:scalar-representatives (:sym node)] representative)))
-
-        (or (legacy/soac-map? node) (legacy/soac-reduce? node))
-        (let [bound (descriptor/unwrap-int-cast (:bound node))
-              array (alength-array bound)
-              bound' (cond
-                       (and array (contains? extents array)) (get extents array)
-                       (symbol? bound) (get scalar-representatives bound bound)
-                       :else bound)
-              node' (assoc node :bound bound')]
-          (cond-> (update state :nodes conj node')
-            (legacy/soac-map? node') (assoc-in [:extents (:sym node')] bound')))
-
-        :else
-        (update state :nodes conj node)))
-    {:nodes [] :extents {} :scalar-representatives {}}
-    nodes)))
-
-(defn- terminal-results
-  [nodes body]
-  (let [operations (filterv #(or (legacy/soac-map? %) (legacy/soac-reduce? %)) nodes)
-        operation-definitions (set (mapcat (fn [node]
-                                             (if (legacy/soac-map? node)
-                                               [(:sym node)] (:outputs node)))
-                                           operations))
-        scalar-definitions (set (keep #(when (legacy/scalar-binding? %) (:sym %)) nodes))
-        all-definitions (set/union operation-definitions scalar-definitions)
-        operation-uses (set (concat
-                             (mapcat #(concat (or (:inputs %) #{}) (or (:scalars %) #{}))
-                                     operations)
-                             (mapcat #(when (legacy/scalar-binding? %)
-                                        (util/free-syms (:expr %)))
-                                     nodes)))
-        body-uses (set (mapcat util/free-syms body))]
-    (vec (sort-by pr-str
-                  (set/union (set/difference operation-definitions operation-uses)
-                             (set/intersection all-definitions body-uses))))))
 
 (defn- equation-subprogram
   [program equation]
@@ -160,7 +66,9 @@
         bodies (scalar-region equation)
         placement-facts (get-in (dialect/facts program) [:equations equation-id])
         constituent-ids (or (some-> placement-facts :attributes :fusion/constituents keys set)
-                            #{(or (get-in placement-facts [:provenance :legacy-soac-id]) equation-id)})
+                            #{(or (get-in placement-facts [:provenance :source-binding-id])
+                                  (get-in placement-facts [:provenance :legacy-soac-id])
+                                  equation-id)})
         placement (apply max constituent-ids)]
     (case kind
       scalar
@@ -310,30 +218,23 @@
                             :or {resident-reductions? false}}]
    (when (and (seq? form) (contains? #{'let 'let*} (first form)))
      (try
-       (let [[_ bindings & body] form
-             pairs (vec (partition 2 bindings))
-             source-nodes (legacy/let-bindings->nodes pairs)
-             nodes (normalize-node-extents source-nodes)]
-         (when (and (seq nodes) (every? supported-node? nodes))
-           (let [outputs (terminal-results nodes body)
-                 typed-input (adapter/legacy-nodes->program
-                              nodes {:outputs outputs :dtype dtype
-                                     :array-types array-types
-                                     :include-scalar-bindings? true})
-                 [typed-result typed-stats] (fusion/fusion-fixpoint typed-input)
-                 [typed-result resident-stats]
-                 (if resident-reductions?
-                   (resident/realize typed-result)
-                   [typed-result {:resident-reductions 0 :inlined-scalars 0}])]
-             (if (not-any? #(contains? #{:map :reduce}
-                                       (:kind (fusion/equation-info %)))
-                           (dialect/equations typed-result))
-               {:declined {:reason :no-certified-parallel-equation
-                           :stats (merge typed-stats resident-stats)}}
-               (let [{:keys [source realized]} (realize-source form typed-result)]
-                 {:program (envelope typed-result source realized)
-                  :stats (merge typed-stats resident-stats
-                                {:route :typed-soac :typed-validated true})})))))
+       (when-let [typed-input (frontend/form->program
+                               form {:dtype dtype :array-types array-types})]
+         (let [[typed-result typed-stats] (fusion/fusion-fixpoint typed-input)
+               [typed-result resident-stats]
+               (if resident-reductions?
+                 (resident/realize typed-result)
+                 [typed-result {:resident-reductions 0 :inlined-scalars 0}])]
+           (if (not-any? #(contains? #{:map :reduce}
+                                     (:kind (fusion/equation-info %)))
+                         (dialect/equations typed-result))
+             {:declined {:reason :no-certified-parallel-equation
+                         :stats (merge typed-stats resident-stats)}}
+             (let [{:keys [source realized]} (realize-source form typed-result)]
+               {:program (envelope typed-result source realized)
+                :stats (merge typed-stats resident-stats
+                              {:route :typed-soac :typed-validated true
+                               :front-end :analyzed-source})}))))
        (catch clojure.lang.ExceptionInfo exception
          (when (contains? #{:raster/fatal :raster/bug} (:reason (ex-data exception)))
            (throw exception))

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -1,0 +1,51 @@
+(ns raster.compiler.passes.parallel.typed-soac-frontend-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.soac :as legacy]
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.passes.parallel.soac-dialect-adapter :as adapter]
+            [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
+            [raster.compiler.passes.parallel.typed-soac-route :as route]))
+
+(def ^:private source
+  '(let* [^long n (clojure.core/alength x)
+          y (raster.par/pmap i n float (* (clojure.core/aget x i) 2.0))
+          total (raster.par/reduce acc 0.0 j n (+ acc (clojure.core/aget y j)))]
+         total))
+
+(deftest direct-front-end-matches-the-compatibility-projection-on-the-overlap
+  (let [[_ bindings] source
+        nodes (legacy/let-bindings->nodes (partition 2 bindings))
+        projected (adapter/legacy-nodes->program
+                   nodes {:outputs '[total] :dtype :float :array-types {'x :float}
+                          :include-scalar-bindings? true})
+        direct (frontend/form->program source {:dtype :float :array-types {'x :float}})]
+    (is (= (dialect/equations projected) (dialect/equations direct)))
+    (is (= (:values (dialect/facts projected)) (:values (dialect/facts direct))))
+    (is (= (:inputs (dialect/facts projected)) (:inputs (dialect/facts direct))))
+    (is (= (dialect/outputs projected) (dialect/outputs direct)))
+    (is (= :analyzed-source (get-in (dialect/facts direct) [:provenance :front-end])))
+    (is (every? #(contains? (:provenance %) :source-binding-id)
+                (vals (:equations (dialect/facts direct)))))))
+
+(deftest production-route-does-not-load-the-record-adapter-as-its-front-door
+  (let [aliases (ns-aliases 'raster.compiler.passes.parallel.typed-soac-route)]
+    (is (= 'raster.compiler.passes.parallel.typed-soac-frontend
+           (ns-name (get aliases 'frontend))))
+    (is (not (contains? aliases 'legacy)))
+    (is (not (contains? aliases 'adapter)))
+    (is (= :analyzed-source
+           (get-in (route/attempt source :float {'x :float}) [:stats :front-end])))))
+
+(deftest unsupported-parallel-semantics-decline-before-typed-construction
+  (testing "scan needs a typed scan operation"
+    (is (nil? (frontend/form->program
+               '(let* [out (raster.par/scan target acc 0.0 i n float
+                                            (+ acc (clojure.core/aget x i)))]
+                      out)
+               {:dtype :float :array-types {'x :float}}))))
+  (testing "imperative map output identity is not disguised as a functional result"
+    (is (nil? (frontend/form->program
+               '(let* [step (raster.par/map! target i n float
+                                             (+ (clojure.core/aget x i) 1.0))]
+                      step)
+               {:dtype :float :array-types {'x :float 'target :float}})))))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -31,6 +31,7 @@
         equation (first (:equations program))]
     (is (= :typed-soac (:dialect program)))
     (is (= :typed-soac (:route stats)))
+    (is (= :analyzed-source (:front-end stats)))
     (is (:typed-validated stats))
     (is (= 1 (:vertical stats)))
     (is (= 1 (count (:equations program))))


### PR DESCRIPTION
## Summary

- add a direct analyzed-source to TypedSOAC front end for the certified map, scalar, and full-reduction subset
- remove the production fusion route's dependency on the legacy SOAC record graph and compatibility adapter
- retain walker/TypedClojure type facts, explicit effects, aliases, value contracts, and source-binding provenance
- decline unsupported scans, offset maps, and imperative destination semantics before typed construction
- add differential parity and architecture tests, and update the compiler north star

## Verification

- focused compiler vertical: 54 tests, 243 assertions, 0 failures/errors
- direct front-end plus route: 17 tests, 112 assertions, 0 failures/errors
- targeted cljfmt check
- git diff --check

The host is currently under unrelated memory pressure with swap full, so the clean full suite and CUDA/HIP compile gates are delegated to CircleCI.