### PR TITLE
Route certified inclusive scan through TypedSOAC

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -77,12 +77,17 @@ with typed scalar SSA, stable reads, workgroup allocation, masks, barriers and a
 the same body emits as OpenCL, CUDA and HIP and is compiled by the hardware-free vendor CI gates.
 Unsupported scalar regions decline explicitly to the established verified SegRed OpenCL emitter.
 
-The map/scalar/full-reduction front end now constructs TypedSOAC directly from closed analyzed
+The map/scalar/full-reduction/inclusive-scan front end now constructs TypedSOAC directly from closed analyzed
 source and retained walker type metadata. It establishes stable equation/value identity, types,
 effects, aliases and placement provenance before fusion; no `ir.soac` record or record-to-dialect
 adapter participates in this production route. The old dependency-graph path remains only as an
-explicit fallback for unsupported parallel forms and as a differential oracle. Typed scan and the
-remaining parallel forms must join the direct front end before that fallback can be deleted.
+explicit fallback for unsupported parallel forms and as a differential oracle. Inclusive scan has
+a distinct `scan` equation with an explicit `:inclusive` mode and a checked `AssociativeScan`
+certificate; its caller-owned destination is an alias/effect fact, not part of the functional
+algebra. It lowers directly to a one- or three-node SegScan `KernelGraph` without constructing a
+legacy `SoacScan`. General recurrences and `scan-exclusive` remain outside this typed operation and
+must not borrow its reassociation proof. The remaining parallel forms must join the direct front
+end before the graph fallback can be deleted.
 
 The first architectural correction is therefore:
 
@@ -438,8 +443,10 @@ SIMD/GPU reuse its certified SegOps. Non-escaping reduction results remain logic
 whose `:resident-scalar-buffer` representation drives one-element device allocation and stable
 consumer loads; dependent scalar equations are inlined as a typed transform. The former raw-source
 resident rewrite and typed-route opt-out are deleted. The analyzed front end now constructs this
-TypedSOAC subset directly; migration is complete when typed scan and hardware-costed multi-consumer
-fusion land and the covered graph/backend compatibility re-lowerings are deleted. Nested reductions
+TypedSOAC subset directly. Certified inclusive scan also crosses the same typed algorithm and
+scheduled-program boundary, retaining its explicit destination contract and graph-owned temporary
+storage. Migration is complete when hardware-costed multi-consumer fusion, the remaining parallel
+forms, and covered backend compatibility re-lowerings are deleted. Nested reductions
 inside a retained map are typed and correctly classified, but the JVM SIMD leaf still lowers those inner
 regions through its established scalar fallback; this is an explicit scheduling boundary rather
 than a loss of semantic facts.
@@ -792,9 +799,10 @@ The immediate continuation after the verified double-buffered weighted-reduction
 5. **In progress:** finish typed parallel coverage and scalar JVM scheduling, then remove compatibility
    re-lowering. Supported map/reduce programs, including unfused and host-visible intermediates,
    horizontal tuple maps, typed scalar/shape equations, stable tensor captures, and resident
-   reduction results now share the direct analyzed-source→TypedSOAC→SegOp production route. Typed
-   scan, hardware-costed multi-consumer fusion, nested-region JVM scheduling, and deletion of the
-   remaining graph/backend fallbacks remain.
+   reduction results and certified inclusive scan now share the direct
+   analyzed-source→TypedSOAC→SegOp production route. Hardware-costed multi-consumer fusion,
+   nested-region JVM scheduling, the remaining parallel forms (including distinct exclusive-scan
+   semantics), and deletion of the remaining graph/backend fallbacks remain.
 6. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a
    read-only distributed track without interrupting the kernel and typed-middle-end verticals.
 

--- a/src/raster/compiler/ir/par.clj
+++ b/src/raster/compiler/ir/par.clj
@@ -433,6 +433,11 @@
   [form]
   (and (seq? form) (contains? #{'raster.par/reduce 'par/reduce} (first form))))
 
+(defn par-scan-form?
+  "Check if a form is Raster's inclusive, destination-writing parallel scan."
+  [form]
+  (and (seq? form) (contains? #{'raster.par/scan 'par/scan} (first form))))
+
 (defn par-product-reduce-form?
   "Check if a form is a typed segmented product reduction."
   [form]
@@ -837,6 +842,16 @@
     (let [[_ out-sym acc-sym init-expr idx-sym bound-expr cast-fn body-expr] form]
       {:out out-sym :acc acc-sym :init init-expr
        :idx idx-sym :bound bound-expr :cast cast-fn :body body-expr})))
+
+(defn extract-par-scan-info
+  "Extract structured information from an inclusive par/scan form."
+  [form]
+  (when (par-scan-form? form)
+    (let [[_ out-sym acc-sym init-expr idx-sym bound-expr cast-fn body-expr] form
+          elem-type (:raster.type/elem-type (meta form))]
+      (cond-> {:out out-sym :acc acc-sym :init init-expr
+               :idx idx-sym :bound bound-expr :cast cast-fn :body body-expr}
+        elem-type (assoc :elem-type elem-type)))))
 
 (defn extract-par-map-void-info
   "Extract structured info from a par/map-void! form.

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -20,7 +20,13 @@
                     :accumulators [acc ...] :identities [zero ...]
                     :dtypes [:float ...] :algebra [{} ...]}
              [array ...] [capture ...]
-             (lambda [acc ... element ... capture-parameter ...] [step-result ...])))]
+             (lambda [acc ... element ... capture-parameter ...] [step-result ...])))
+        (= equation-id [result]
+           (scan {:mode :inclusive :index i :extent n
+                  :accumulators [acc] :identities [zero]
+                  :dtypes [:float] :algebra [{}]}
+             [array ...] [capture ...]
+             (lambda [acc element ... capture-parameter ...] [step-result])))]
        [program-result ...])
 
    Map lambdas return tuples, so horizontal fusion remains functional rather than encoding
@@ -30,7 +36,8 @@
             [pattern.nanopass.dialect :as dialect
              :refer [def-dialect]]
             [raster.compiler.core.util :as util]
-            [raster.compiler.ir.abstract-value :as av]))
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.scan :as scan-ir]))
 
 (defn value-id?
   "Stable logical value IDs. Vector IDs are used by existing SSA-like program envelopes."
@@ -88,6 +95,16 @@
        (every? keyword? (:dtypes value))
        (every? map? (:algebra value))))
 
+(defn scan-attributes?
+  "Attributes for the certified inclusive scan dialect operation.
+
+   The explicit mode is intentionally load-bearing: exclusive scan is a distinct surface
+   primitive and must never enter this schedule by spelling accident."
+  [value]
+  (and (= :inclusive (:mode value))
+       (reduce-attributes? (dissoc value :mode))
+       (every? scan-ir/associative-scan? (:algebra value))))
+
 (defn scalar-attributes?
   [value]
   (and (map? value)
@@ -127,6 +144,7 @@
              [sa scalar-attributes?]
              [ma map-attributes?]
              [ra reduce-attributes?]
+             [ca scan-attributes?]
              [facts program-facts?])
 
   (Scalar [s :enforce]
@@ -144,7 +162,8 @@
   (Operation [o :enforce]
              (scalar ?sa [(?:* ?id:capture)] ?l)
              (map ?ma [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
-             (reduce ?ra [(?:* ?id:array)] [(?:* ?id:capture)] ?l))
+             (reduce ?ra [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
+             (scan ?ca [(?:* ?id:array)] [(?:* ?id:capture)] ?l))
 
   (Equation [q :enforce]
             (= ?eid [(?:+ ?id:result)] ?o))
@@ -196,7 +215,8 @@
   [equation]
   (let [{:keys [kind attributes arrays captures lambda]} (operation-parts equation)
         parameters (vec (second lambda))
-        accumulator-count (if (= 'reduce kind) (count (:accumulators attributes)) 0)
+        accumulator-count (if (contains? #{'reduce 'scan} kind)
+                            (count (:accumulators attributes)) 0)
         array-count (count arrays)
         accumulator-end accumulator-count
         element-end (+ accumulator-end array-count)]
@@ -244,7 +264,7 @@
     (when-not (= result-count (count body-results))
       (fail! :typed-soac-result-arity "SOAC result and lambda arity differ"
              {:equation equation-id :results result-count :body-results (count body-results)}))
-    (let [expected-parameter-count (+ (if (= 'reduce kind)
+    (let [expected-parameter-count (+ (if (contains? #{'reduce 'scan} kind)
                                         (count (:accumulators attributes))
                                         0)
                                       (count arrays)
@@ -259,7 +279,7 @@
                 :captures captures})))
     (doseq [body body-results
             :let [bound (cond-> (set parameters)
-                          (contains? #{'map 'reduce} kind) (conj (:index attributes)))
+                          (contains? #{'map 'reduce 'scan} kind) (conj (:index attributes)))
                   unbound (util/free-syms body bound)]
             :when (seq unbound)]
       (fail! :typed-soac-unbound-scalar
@@ -285,6 +305,25 @@
           (fail! :typed-soac-reduce-results
                  "reduce result arity must equal accumulator arity"
                  {:equation equation-id :results results :accumulators accumulators})))
+
+      scan
+      (let [accumulators (:accumulators attributes)]
+        (when-not (= accumulators (vec (take (count accumulators) parameters)))
+          (fail! :typed-soac-scan-accumulators
+                 "scan accumulator parameters must lead the lambda in declared order"
+                 {:equation equation-id :accumulators accumulators :parameters parameters}))
+        (when-not (= result-count (count accumulators))
+          (fail! :typed-soac-scan-results
+                 "scan result arity must equal accumulator arity"
+                 {:equation equation-id :results results :accumulators accumulators}))
+        (doseq [[accumulator identity dtype certificate result]
+                (map vector accumulators (:identities attributes) (:dtypes attributes)
+                     (:algebra attributes) body-results)]
+          (let [derived (scan-ir/certify {:acc accumulator :init identity :lambda result} dtype)]
+            (when-not (= certificate derived)
+              (fail! :typed-soac-scan-certificate
+                     "scan algebra certificate disagrees with its scalar region"
+                     {:equation equation-id :declared certificate :derived derived})))))
 
       (fail! :typed-soac-operation "unknown SOAC operation"
              {:equation equation-id :operation kind}))
@@ -342,6 +381,18 @@
             (fail! :typed-soac-reduce-result-type
                    "reduce results must be scalar tensors with their declared accumulator dtype"
                    {:equation equation-id :id id :value value :dtype dtype}))))
+
+      scan
+      (doseq [[id dtype] (map vector results (:dtypes attributes))]
+        (let [value (get values id)]
+          (when (and value
+                     (not (and (= :tensor (:kind value))
+                               (= (extent-shape extent) (:shape value))
+                               (= dtype (:dtype value)))))
+            (fail! :typed-soac-scan-result-type
+                   "scan results must be rank-one tensors over the declared extent"
+                   {:equation equation-id :id id :value value
+                    :extent extent :dtype dtype}))))
 
       nil)))
 

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -278,14 +278,22 @@
              (let [algorithm (:algorithm equation)
                    kind (soac-dialect/operation-kind
                          (first (soac-dialect/equations algorithm)))
-                   operations (case kind
-                                scalar []
-                                map (soac-lower/lower-typed-map algorithm device-id :dtype dtype)
-                                reduce (soac-lower/lower-typed-reduce algorithm device-id :dtype dtype))]
+                   lowered (case kind
+                             scalar {:operations []}
+                             map {:operations (soac-lower/lower-typed-map
+                                               algorithm device-id :dtype dtype)}
+                             reduce {:operations (soac-lower/lower-typed-reduce
+                                                  algorithm device-id :dtype dtype)}
+                             scan (soac-lower/lower-typed-scan
+                                   algorithm device-id :dtype dtype
+                                   :array-types (:array-types opts)))
+                   operations (:operations lowered)]
                (-> equation
                    (assoc :operations operations)
                    (update :provenance assoc :target-dialect :segop)
                    (update :attributes assoc :device device-id)
+                   (cond-> (:kernel-graph lowered)
+                     (update :attributes assoc :kernel-graph (:kernel-graph lowered)))
                    (cond-> (= 'scalar kind)
                      (update :attributes assoc :host-only true)))))
            (:equations form))
@@ -295,22 +303,36 @@
           scheduled-values
           (reduce
            (fn [values equation]
-             (reduce
-              (fn [values operation]
-                (if (and (instance? raster.compiler.ir.segop.SegRed operation)
-                         (= :block-local (:phase operation)))
-                  (reduce (fn [values id]
-                            (if (contains? values id)
-                              values
-                              (assoc values id
-                                     (av/tensor
-                                      {:dtype (:dtype operation)
-                                       :shape [(:num-blocks (:grid operation))]
-                                       :representation {:kind :plain}
-                                       :memory-space :device}))))
-                          values (:outputs operation))
-                  values))
-              values (:operations equation)))
+             (let [values
+                   (reduce (fn [values temporary]
+                             (let [id (:id temporary)]
+                               (if (contains? values id)
+                                 values
+                                 (assoc values id
+                                        (av/tensor
+                                         {:dtype (:dtype temporary)
+                                          :shape (soac-dialect/extent-shape
+                                                  (:elements temporary))
+                                          :representation {:kind :plain}
+                                          :memory-space (:memory-space temporary)})))))
+                           values
+                           (get-in equation [:attributes :kernel-graph :temporaries]))]
+               (reduce
+                (fn [values operation]
+                  (if (and (instance? raster.compiler.ir.segop.SegRed operation)
+                           (= :block-local (:phase operation)))
+                    (reduce (fn [values id]
+                              (if (contains? values id)
+                                values
+                                (assoc values id
+                                       (av/tensor
+                                        {:dtype (:dtype operation)
+                                         :shape [(:num-blocks (:grid operation))]
+                                         :representation {:kind :plain}
+                                         :memory-space :device}))))
+                            values (:outputs operation))
+                    values))
+                values (:operations equation))))
            (:values form) equations)
           ;; Scheduled operations are not exempt from SSA validation merely because they are
           ;; records nested inside an equation. Every physical operand/result—including generated
@@ -347,6 +369,7 @@
                                    :scheduled scheduled-outputs})))))
           parallel-equation-count (count (remove #(get-in % [:attributes :host-only]) equations))
           scalar-equation-count (- (count equations) parallel-equation-count)
+          kernel-graph-count (count (filter #(get-in % [:attributes :kernel-graph]) equations))
           lowered (assoc form
                          :dialect :segop
                          :values scheduled-values
@@ -361,7 +384,7 @@
                      (= (:operands equation) (:inputs (soac-dialect/facts algorithm)))
                      (= (:results equation) (soac-dialect/outputs algorithm)))))
        :stats {:segops-lowered parallel-equation-count
-               :kernel-graphs-lowered 0
+               :kernel-graphs-lowered kernel-graph-count
                :typed-soac-reused parallel-equation-count
                :typed-scalar-equations scalar-equation-count}})
     (if-not (form/binding-form? form)

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -28,6 +28,8 @@
 
 (declare lower-reduce)
 (declare lower-map)
+(declare lower-scan-description)
+(declare scan-kernel-graph-description)
 
 (defn typed-map-program?
   "Whether a validated one-equation TypedSOAC program is a map accepted by SegMap lowering."
@@ -161,6 +163,75 @@
                     :algorithm-equation equation-id)
             (lower-reduce node device-id :dtype accumulator-dtype)))))
 
+(defn typed-scan-program?
+  "Whether a validated one-equation TypedSOAC program is a certified inclusive scan."
+  [program]
+  (and (soac-dialect/program-form? program)
+       (= 1 (count (soac-dialect/equations program)))
+       (= 'scan (soac-dialect/operation-kind (first (soac-dialect/equations program))))))
+
+(defn- typed-scan-description
+  [program dtype]
+  (let [equation (first (soac-dialect/equations program))
+        [_ equation-id results operation] equation
+        [_ attributes arrays captures lambda] operation
+        [_ _ body-results] lambda
+        {:keys [accumulators elements capture-parameters]}
+        (soac-dialect/parameter-layout equation)
+        facts (soac-dialect/facts program)
+        destination (get-in facts [:equations equation-id :attributes :destination])
+        _ (when-not (and (= 1 (count results)) (= 1 (count accumulators))
+                         (= 1 (count body-results)) destination)
+            (throw (ex-info "typed inclusive scan requires one result, accumulator and destination"
+                            {:reason :typed-soac-scan-subset :equation equation-id
+                             :results results :accumulators accumulators
+                             :destination destination})))
+        index (:index attributes)
+        substitutions
+        (into (zipmap capture-parameters captures)
+              (map (fn [parameter array]
+                     [parameter (list 'clojure.core/aget array index)])
+                   elements arrays))
+        stable (set (get-in attributes [:attributes :stable-array-captures]))
+        scalar-captures (set (remove stable captures))
+        scan-dtype (or (first (:dtypes attributes)) dtype :double)
+        substitutions (assoc substitutions index index)
+        algebra (update (first (:algebra attributes)) :element
+                        #(util/subst-syms substitutions %))]
+    {:id equation-id
+     :sym destination
+     :out destination
+     :acc (first accumulators)
+     :init (first (:identities attributes))
+     :lambda (util/subst-syms substitutions (first body-results))
+     :algebra algebra
+     :bound (:extent attributes)
+     :idx index
+     :inputs (into (set arrays) (disj stable destination))
+     :outputs #{destination}
+     :scalars scalar-captures
+     :elem-type scan-dtype}))
+
+(defn lower-typed-scan
+  "Lower one certified TypedSOAC inclusive scan without reconstructing the legacy SOAC record IR.
+
+   Returns both ordered SegOps and their KernelGraph because temporary storage and dependencies are
+   properties of the selected schedule, not of the functional scan equation."
+  [program device-id & {:keys [dtype array-types]
+                        :or {dtype :double array-types {}}}]
+  (let [program (soac-dialect/validate! program)]
+    (when-not (typed-scan-program? program)
+      (throw (ex-info "typed SegScan lowering requires one scan equation"
+                      {:reason :typed-soac-scan-subset :program program})))
+    (let [description (typed-scan-description program dtype)
+          operations (mapv #(assoc % :algorithm-dialect :typed-soac
+                                   :algorithm-equation (:id description))
+                           (lower-scan-description description device-id
+                                                   :dtype (:elem-type description)))]
+      {:operations operations
+       :kernel-graph (scan-kernel-graph-description description operations
+                                                    {:array-types array-types})})))
+
 ;; ================================================================
 ;; Lowering helpers
 ;; ================================================================
@@ -234,6 +305,23 @@
     {:acc (:acc soac) :init (:init soac)
      :lambda (:lambda soac) :out (:out soac)}
     (first (:scans soac))))
+
+(defn- legacy-scan-description
+  [node]
+  (let [raw (scan-op-info node)]
+    {:id (:id node)
+     :sym (:sym node)
+     :out (:out raw)
+     :acc (:acc raw)
+     :init (:init raw)
+     :lambda (:lambda raw)
+     :bound (:bound node)
+     :idx (:idx node)
+     :inputs (or (:inputs node) #{})
+     :outputs (or (soac-outputs* node) #{})
+     :scalars (or (:scalars node) #{})
+     :elem-type (:elem-type node)
+     :map-lambda (screma-map-lambda node)}))
 
 ;; ================================================================
 ;; Map lowering
@@ -361,30 +449,34 @@
 
   Returns a vector of SegScan/SegMap records."
   [soac device-id & {:keys [dtype] :or {dtype :double}}]
-  (let [dtype (or (:elem-type soac) dtype)
-        bound (:bound soac)
-        idx (:idx soac)
-        raw-scan-op (scan-op-info soac)
-        map-lambda (screma-map-lambda soac)
+  (lower-scan-description (legacy-scan-description soac) device-id :dtype dtype))
+
+(defn- lower-scan-description
+  [description device-id & {:keys [dtype] :or {dtype :double}}]
+  (let [dtype (or (:elem-type description) dtype)
+        bound (:bound description)
+        idx (:idx description)
+        raw-scan-op (select-keys description [:acc :init :lambda :out])
+        map-lambda (:map-lambda description)
         _ (when map-lambda
             (throw (ex-info "fused scan/map needs an explicit scheduled scan epilogue"
                             {:reason :scan-fused-map-unimplemented
                              :scan-op raw-scan-op :map-lambda map-lambda})))
-        scan-facts (scan/certify raw-scan-op dtype)
+        scan-facts (or (:algebra description) (scan/certify raw-scan-op dtype))
         scan-op (assoc raw-scan-op :algebra scan-facts)
         space (segop/make-seg-space idx bound)
         grid-1 (scan-grid device-id bound dtype)
         execution (execution-plan/scan-execution bound grid-1)]
     (case (:strategy execution)
       :single
-      [(segop/->SegScan (:id soac)
+      [(segop/->SegScan (:id description)
                         space
                         (segop/->SegLevel :block :none)
                         scan-op
                         map-lambda
-                        (:inputs soac)
-                        (soac-outputs* soac)
-                        (:scalars soac)
+                        (:inputs description)
+                        (:outputs description)
+                        (:scalars description)
                         (single-block-grid grid-1)
                         :single
                         dtype)]
@@ -392,18 +484,18 @@
       :three-stage
       (let [level-1 (segop/->SegLevel :block :virtual)
             totals-sym (gensym "block_totals_")
-            stage-1 (segop/->SegScan (:id soac) space level-1
+            stage-1 (segop/->SegScan (:id description) space level-1
                                      scan-op map-lambda
-                                     (:inputs soac)
-                                     (conj (soac-outputs* soac) totals-sym)
-                                     (:scalars soac)
+                                     (:inputs description)
+                                     (conj (:outputs description) totals-sym)
+                                     (:scalars description)
                                      grid-1 :intra-block
                                      dtype)
             stage-2-idx (gensym "k_")
             stage-2-space (segop/make-seg-space stage-2-idx (:num-blocks grid-1))
             grid-2 (single-block-grid grid-1)
             level-2 (segop/->SegLevel :block :none)
-            stage-2 (segop/->SegScan (+ (:id soac) 2000)
+            stage-2 (segop/->SegScan (+ (:id description) 2000)
                                      stage-2-space level-2
                                      scan-op nil
                                      #{totals-sym} #{totals-sym}
@@ -413,7 +505,7 @@
             carry-space (segop/make-seg-space carry-idx bound)
             grid-3 (phase-grid :map device-id bound dtype)
             level-3 (segop/->SegLevel :thread :virtual)
-            out-sym (or (:out scan-op) (first (soac-outputs* soac)))
+            out-sym (or (:out scan-op) (first (:outputs description)))
             block-idx-expr (list 'clojure.core/quot carry-idx (:block-size grid-1))
             combine (:combine scan-facts)
             carry-lambda (list 'if (list '> block-idx-expr 0)
@@ -422,7 +514,7 @@
                                            (list 'clojure.core/- block-idx-expr 1))
                                      (list 'aget out-sym carry-idx))
                                (list 'aget out-sym carry-idx))
-            stage-3 (segop/->SegMap (+ (:id soac) 3000)
+            stage-3 (segop/->SegMap (+ (:id description) 3000)
                                     carry-space level-3
                                     carry-lambda
                                     #{out-sym totals-sym}
@@ -439,39 +531,45 @@
   ([soac segops]
    (scan-kernel-graph soac segops {}))
   ([soac segops {:keys [array-types] :or {array-types {}}}]
-   (let [external (set/union (or (:inputs soac) #{}) (or (soac-outputs* soac) #{}))
-         used (reduce set/union #{}
-                      (map #(set/union (or (segop/segop-inputs %) #{})
-                                       (or (segop/segop-outputs %) #{}))
-                           segops))
-         temporary-ids (set/difference used external)
-         block-stage (some #(when (= :block-scan (:phase %)) %) segops)
-         temporary-elements (when block-stage
-                              (:bound (segop/seg-space-reduced-dim (:space block-stage))))
-         dtype (or (:elem-type soac) (:dtype (first segops)) :double)
-         temporaries (into {}
+   (scan-kernel-graph-description (legacy-scan-description soac) segops
+                                  {:array-types array-types})))
+
+(defn- scan-kernel-graph-description
+  [description segops {:keys [array-types] :or {array-types {}}}]
+  (let [external (set/union (or (:inputs description) #{})
+                            (or (:outputs description) #{}))
+        used (reduce set/union #{}
+                     (map #(set/union (or (segop/segop-inputs %) #{})
+                                      (or (segop/segop-outputs %) #{}))
+                          segops))
+        temporary-ids (set/difference used external)
+        block-stage (some #(when (= :block-scan (:phase %)) %) segops)
+        temporary-elements (when block-stage
+                             (:bound (segop/seg-space-reduced-dim (:space block-stage))))
+        dtype (or (:elem-type description) (:dtype (first segops)) :double)
+        temporaries (into {}
+                          (map (fn [id]
+                                 [id {:dtype dtype :elements temporary-elements
+                                      :memory-space :device}]))
+                          temporary-ids)
+        buffer-specs (into {}
                            (map (fn [id]
-                                  [id {:dtype dtype :elements temporary-elements
-                                       :memory-space :device}]))
-                           temporary-ids)
-         buffer-specs (into {}
-                            (map (fn [id]
-                                   [id {:dtype (or (get array-types id)
-                                                   (get array-types (symbol (name id)))
-                                                   dtype)
-                                        :elements (:bound soac)}]))
-                            external)]
-     (kernel-graph/from-segops
-      segops
-      {:inputs (or (:inputs soac) #{})
-       :outputs (or (soac-outputs* soac) #{})
-       :temporaries temporaries
-       :buffer-specs buffer-specs
-       :dtype dtype
-       :effects {:memory-order :dependency-ordered}
-       :provenance {:dialect :segop :algorithm :scan :soac-id (:id soac)}
-       :attributes {:strategy (if (= 1 (count segops)) :single :three-stage)
-                    :scan-algebra (get-in (first segops) [:scan-op :algebra])}}))))
+                                  [id {:dtype (or (get array-types id)
+                                                  (get array-types (symbol (name id)))
+                                                  dtype)
+                                       :elements (:bound description)}]))
+                           external)]
+    (kernel-graph/from-segops
+     segops
+     {:inputs (or (:inputs description) #{})
+      :outputs (or (:outputs description) #{})
+      :temporaries temporaries
+      :buffer-specs buffer-specs
+      :dtype dtype
+      :effects {:memory-order :dependency-ordered}
+      :provenance {:dialect :segop :algorithm :scan :soac-id (:id description)}
+      :attributes {:strategy (if (= 1 (count segops)) :single :three-stage)
+                   :scan-algebra (get-in (first segops) [:scan-op :algebra])}})))
 
 (defn scan-soac?
   "True when a SOAC/Screma node selects scan decomposition."

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -1,5 +1,5 @@
 (ns raster.compiler.passes.parallel.typed-soac-frontend
-  "Direct analyzed-source to TypedSOAC construction for the closed map/scalar/reduce subset.
+  "Direct analyzed-source to TypedSOAC construction for the closed map/scalar/reduce/inclusive-scan subset.
 
    This is the production front door for TypedSOAC.  It consumes the retained source form and
    walker type metadata directly; it never constructs the older record graph.  Unsupported
@@ -15,6 +15,7 @@
             [raster.compiler.ir.form :as form]
             [raster.compiler.ir.par :as par]
             [raster.compiler.ir.reduction :as reduction]
+            [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.passes.parallel.fusion-support :as fusion-support]
             [raster.compiler.passes.scalar.effects :as effects]))
@@ -115,6 +116,22 @@
                          :attributes {:source :raster.par/reduce}})}
              io))
 
+    (par/par-scan-form? expression)
+    (let [{:keys [out acc init idx bound cast body elem-type]}
+          (par/extract-par-scan-info expression)
+          scan-dtype (or elem-type
+                         (dtype/dtype-for-scalar-tag cast)
+                         :double)]
+      ;; A source binder with the same spelling as the caller-owned destination needs an explicit
+      ;; value/view identity before it can be SSA. Keep that uncommon compatibility form outside
+      ;; the typed route instead of pretending the destination is both an input and a definition.
+      (when-not (= symbol out)
+        (let [algebra (scan/certify {:acc acc :init init :lambda body :out out} scan-dtype)]
+          (merge {:kind :scan :id id :sym symbol :index idx :extent bound
+                  :primary-out out :accumulator acc :identity init :dtype scan-dtype
+                  :algebra algebra :body body}
+                 (extract-io body idx [out] :accumulator acc)))))
+
     (par/par-map-void-form? expression)
     (let [{:keys [idx bound body elem-type]} (par/extract-par-map-void-info expression)]
       (when-let [{:keys [out value cast]} (pointwise-map-void body idx)]
@@ -168,7 +185,7 @@
                                                  expression representative)))
               (assoc-in [:scalar-representatives (:sym description)] representative)))
 
-        (:map :reduce)
+        (:map :reduce :scan)
         (let [extent (descriptor/unwrap-int-cast (:extent description))
               array (alength-array extent)
               extent' (cond
@@ -177,7 +194,8 @@
                         :else extent)
               description' (assoc description :extent extent')]
           (cond-> (update state :descriptions conj description')
-            (= :map (:kind description')) (assoc-in [:extents (:sym description')] extent')))
+            (contains? #{:map :scan} (:kind description'))
+            (assoc-in [:extents (:sym description')] extent')))
 
         (update state :descriptions conj description)))
     {:descriptions [] :extents {} :scalar-representatives {}}
@@ -195,7 +213,7 @@
 (defn- supported-descriptions?
   [descriptions]
   (let [physical-outputs (reduce set/union #{}
-                                 (map #(if (contains? #{:map :reduce} (:kind %))
+                                 (map #(if (contains? #{:map :reduce :scan} (:kind %))
                                          (:outputs %) #{})
                                       descriptions))]
     (every? (fn [description]
@@ -205,6 +223,7 @@
                 :map (or (:pure? description)
                          (and (:void? description) (symbol? (:primary-out description))))
                 :reduce true
+                :scan (symbol? (:primary-out description))
                 false))
             descriptions)))
 
@@ -270,6 +289,31 @@
                       (vec (concat [(:accumulator component)] elements capture-parameters))
                       results)))))
 
+(defn- scan-equation
+  [{:keys [id sym index extent inputs scalars primary-out accumulator identity dtype body]}]
+  (let [[pointwise stable] ((juxt filter remove) #(pointwise-input? [body] % index) inputs)
+        arrays (vec (sort-by pr-str pointwise))
+        stable (conj (set stable) primary-out)
+        captures (vec (sort-by pr-str (distinct (concat stable scalars))))
+        elements (element-symbols (count arrays))
+        capture-parameters (capture-symbols (count captures))
+        result (util/subst-syms
+                (zipmap captures capture-parameters)
+                (first (elementize [body] arrays elements index)))
+        algebra (scan/certify {:acc accumulator :init identity :lambda result
+                               :out primary-out} dtype)]
+    (list '= id [sym]
+          (list 'scan {:mode :inclusive :index index :extent extent
+                       :attributes {:stable-array-captures (vec (sort-by pr-str stable))}
+                       :accumulators [accumulator]
+                       :identities [identity]
+                       :dtypes [dtype]
+                       :algebra [algebra]}
+                arrays captures
+                (list 'lambda
+                      (vec (concat [accumulator] elements capture-parameters))
+                      [result])))))
+
 (defn- scalar-dtype
   [{:keys [sym expr]} scalar-dtypes scalar-types]
   (let [expression-tag (when (instance? clojure.lang.IObj expr)
@@ -296,9 +340,10 @@
 
 (defn- terminal-results
   [descriptions body]
-  (let [operations (filter #(contains? #{:map :reduce} (:kind %)) descriptions)
-        operation-definitions (set (mapcat #(if (= :map (:kind %))
-                                              [(:sym %)] (:outputs %))
+  (let [operations (filter #(contains? #{:map :reduce :scan} (:kind %)) descriptions)
+        operation-definitions (set (mapcat #(case (:kind %)
+                                              (:map :scan) [(:sym %)]
+                                              (:outputs %))
                                            operations))
         scalar-definitions (set (keep #(when (= :scalar (:kind %)) (:sym %)) descriptions))
         all-definitions (set/union operation-definitions scalar-definitions)
@@ -342,6 +387,7 @@
         result-dtypes (case kind
                         scalar (:dtypes attributes)
                         reduce (:dtypes attributes)
+                        scan (:dtypes attributes)
                         (repeat (count results) default-dtype))]
     (merge
      (if (and extent (dialect/value-id? extent)) {extent (tensor-value :long [])} {})
@@ -395,9 +441,10 @@
       (when (and (even? (count bindings))
                  (seq descriptions)
                  (supported-descriptions? descriptions))
-        (let [operation-descriptions (filterv #(contains? #{:map :reduce} (:kind %)) descriptions)
+        (let [operation-descriptions (filterv #(contains? #{:map :reduce :scan} (:kind %)) descriptions)
               operation-equations (mapv #(case (:kind %) :map (map-equation %)
-                                               :reduce (reduce-equation %))
+                                               :reduce (reduce-equation %)
+                                               :scan (scan-equation %))
                                         operation-descriptions)
               outputs (terminal-results descriptions body)
               required-scalars (selected-scalars descriptions operation-equations outputs)
@@ -413,12 +460,13 @@
                                   (update :equation-descriptions conj description)
                                   (assoc-in [:scalar-dtypes (:sym description)] result-dtype)))
                             state)
-                          (:map :reduce)
+                          (:map :reduce :scan)
                           (-> state
                               (update :equations conj
-                                      (if (= :map (:kind description))
-                                        (map-equation description)
-                                        (reduce-equation description)))
+                                      (case (:kind description)
+                                        :map (map-equation description)
+                                        :reduce (reduce-equation description)
+                                        :scan (scan-equation description)))
                               (update :equation-descriptions conj description))))
                       {:equations [] :equation-descriptions [] :scalar-dtypes {}}
                       descriptions)
@@ -441,7 +489,9 @@
               equation-facts
               (into {}
                     (map (fn [description]
-                           (let [destination (when (:void? description) (:primary-out description))]
+                           (let [destination (when (or (:void? description)
+                                                       (= :scan (:kind description)))
+                                               (:primary-out description))]
                              [(:id description)
                               (cond-> (dialect/default-equation-facts
                                        {:front-end :analyzed-source

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -52,13 +52,28 @@
                                 :parameters parameters
                                 :body-results body-results}))))
 
+(def ^:private scan-equation-rule
+  (from-dialect dialect/TypedSOAC
+                (rule '(= ?equation-id [??results]
+                          (scan ?attributes [??arrays] [??captures]
+                                (lambda [??parameters] [??body-results])))
+                      (success {:kind :scan
+                                :id equation-id
+                                :results results
+                                :attributes attributes
+                                :arrays arrays
+                                :captures captures
+                                :parameters parameters
+                                :body-results body-results}))))
+
 (defn equation-info
   "Return a normalized equation description, using Pattern as the dialect matcher."
   [equation]
   (some #(when (map? %) %)
         [(scalar-equation-rule equation)
          (map-equation-rule equation)
-         (reduce-equation-rule equation)]))
+         (reduce-equation-rule equation)
+         (scan-equation-rule equation)]))
 
 (defn- equation-references
   [equation]
@@ -76,7 +91,7 @@
 
 (defn- parameter-parts
   [info]
-  (let [accumulator-count (if (= :reduce (:kind info))
+  (let [accumulator-count (if (contains? #{:reduce :scan} (:kind info))
                             (count (get-in info [:attributes :accumulators]))
                             0)
         array-count (count (:arrays info))

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -153,7 +153,29 @@
            :placement placement
            :pairs [[result source]]
            :site [:binding result]
-           :source source})))))
+           :source source}))
+
+      scan
+      (let [result (first results)
+            destination (get-in placement-facts [:attributes :destination])
+            _ (when-not (and (= 1 (count results)) destination)
+                (throw (ex-info "typed inclusive scan requires one caller-owned destination"
+                                {:reason :typed-soac-production-subset
+                                 :equation equation-id :results results
+                                 :destination destination})))
+            source (with-meta
+                     (list 'raster.par/scan destination
+                           (first (:accumulators attributes))
+                           (first (:identities attributes))
+                           (:index attributes) (:extent attributes)
+                           (nth (get dtype->allocation (first (:dtypes attributes))) 2 nil)
+                           (first bodies))
+                     {:raster.type/elem-type (first (:dtypes attributes))})]
+        {:equation-id equation-id
+         :placement placement
+         :pairs [[result source]]
+         :site [:binding result]
+         :source source}))))
 
 (defn- realize-source
   [form program]
@@ -225,7 +247,7 @@
                (if resident-reductions?
                  (resident/realize typed-result)
                  [typed-result {:resident-reductions 0 :inlined-scalars 0}])]
-           (if (not-any? #(contains? #{:map :reduce}
+           (if (not-any? #(contains? #{:map :reduce :scan}
                                      (:kind (fusion/equation-info %)))
                          (dialect/equations typed-result))
              {:declined {:reason :no-certified-parallel-equation

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -13,7 +13,9 @@
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.soac-lower :as lower]
+            [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
             [raster.compiler.backend.gpu.segop-opencl :as sg]))
 
 (defn- segred-source [body-expr]
@@ -59,6 +61,23 @@
       (is (= [(:id intra-node)] (:dependencies block-node)))
       (is (= (mapv :id [intra-node block-node]) (:dependencies carry-node))
           "target lowering preserves the verified schedule"))))
+
+(deftest typed-scan-schedule-target-lowers-without-a-legacy-soac-node
+  (let [source '(let* [result (raster.par/scan out acc 0.0 i n float
+                                               (+ acc (clojure.core/aget values i)))]
+                      result)
+        typed (:program (typed-route/attempt source :float
+                                             {'values :float 'out :float}))
+        scheduled (:form (segop-lower/segop-lower-pass
+                          typed {:dtype :float :target-device :ocl:0
+                                 :array-types {'values :float 'out :float}}))
+        graph (get-in scheduled [:equations 0 :attributes :kernel-graph])
+        emitted (sg/generate-scan-kernel-graph graph)]
+    (is (= :typed-soac (get-in scheduled [:provenance :source-dialect])))
+    (is (= 3 (count (:nodes emitted))))
+    (is (every? kart/kernel-artifact? (map :operation (:nodes emitted))))
+    (is (= [:intra-block :block-scan :carry-in]
+           (mapv #(get-in % [:operation :attributes :phase]) (:nodes emitted))))))
 
 (deftest segscan-artifact-abi-preserves-mixed-input-storage
   (let [emitted (emitted-scan-graph

--- a/test/raster/compiler/ir/soac_dialect_test.clj
+++ b/test/raster/compiler/ir/soac_dialect_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [pattern.nanopass.dialect :as pattern-dialect]
             [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.soac-dialect :as dialect]))
 
 (def ^:private tensor
@@ -36,6 +37,49 @@
     (is (= :map (keyword (name (dialect/operation-kind
                                 (first (dialect/equations program)))))))
     (is (= '[x] (dialect/operation-inputs (first (dialect/equations program)))))))
+
+(deftest inclusive-scan-has-a-distinct-typed-and-effectful-contract
+  (let [out (av/tensor {:dtype :float :shape '[(unknown-dimension out)]})
+        algebra (scan/->AssociativeScan 'acc 0.0 '+ 'element '(float 0.0) :float)
+        facts (dialect/default-program-facts
+               {:values {'n extent 'x tensor 'out out 'result tensor}
+                :inputs '[n out x]
+                :equations
+                {'scan-0 (assoc (dialect/default-equation-facts)
+                                :effects #{:memory/write}
+                                :aliases '{result out}
+                                :attributes {:destination 'out})}
+                :effects #{:memory/write}})
+        program (dialect/make
+                 facts
+                 [(list '= 'scan-0 '[result]
+                        (list 'scan
+                              {:mode :inclusive :index 'i :extent 'n
+                               :accumulators '[acc] :identities [0.0]
+                               :dtypes [:float] :algebra [algebra]
+                               :attributes {:stable-array-captures '[out]}}
+                              '[x] '[out]
+                              (list 'lambda '[acc element destination]
+                                    '[(+ acc element)])))]
+                 '[result])
+        equation (first (dialect/equations program))]
+    (is (= program (dialect/validate! program)))
+    (is (= 'scan (dialect/operation-kind equation)))
+    (is (= {:accumulators '[acc]
+            :elements '[element]
+            :capture-parameters '[destination]}
+           (dialect/parameter-layout equation)))
+    (is (= '[x out] (dialect/operation-inputs equation)))
+    (testing "exclusive semantics cannot enter by omitting or changing the mode"
+      (let [[_ attributes arrays captures lambda] (nth equation 3)
+            bad-equation (list '= 'scan-0 '[result]
+                               (list 'scan (assoc attributes :mode :exclusive)
+                                     arrays captures lambda))]
+        (try
+          (dialect/make facts [bad-equation] '[result])
+          (is false "exclusive mode must fail TypedSOAC syntax validation")
+          (catch clojure.lang.ExceptionInfo exception
+            (is (= :typed-soac-syntax (:reason (ex-data exception))))))))))
 
 (deftest pure-scalar-shape-equations-are-ordered-typed-ssa
   (let [program

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -36,13 +36,34 @@
     (is (= :analyzed-source
            (get-in (route/attempt source :float {'x :float}) [:stats :front-end])))))
 
-(deftest unsupported-parallel-semantics-decline-before-typed-construction
-  (testing "scan needs a typed scan operation"
+(deftest parallel-semantics-enter-only-their-exact-typed-operation
+  (testing "a certified inclusive scan is represented directly, with destination facts"
+    (let [program (frontend/form->program
+                   '(let* [result (raster.par/scan target acc 0.0 i n float
+                                                   (+ acc (clojure.core/aget x i)))]
+                          result)
+                   {:dtype :float :array-types {'x :float 'target :float}})
+          equation (first (dialect/equations program))]
+      (is (= 'scan (dialect/operation-kind equation)))
+      (is (= :inclusive (get-in (dialect/operation-parts equation) [:attributes :mode])))
+      (is (= '{result target} (get-in (dialect/facts program) [:equations 0 :aliases])))
+      (is (= #{:memory/write} (:effects (dialect/facts program))))))
+  (testing "exclusive scan remains a distinct, unsupported semantic operation"
     (is (nil? (frontend/form->program
-               '(let* [out (raster.par/scan target acc 0.0 i n float
-                                            (+ acc (clojure.core/aget x i)))]
-                      out)
-               {:dtype :float :array-types {'x :float}}))))
+               '(let* [result (raster.par/scan-exclusive target acc 0.0 i n float
+                                                         (+ acc (clojure.core/aget x i)))]
+                      result)
+               {:dtype :float :array-types {'x :float 'target :float}}))))
+  (testing "a general recurrence cannot be mislabeled as an associative scan"
+    (try
+      (frontend/form->program
+       '(let* [result (raster.par/scan target h 0.0 i n float
+                                       (Math/tanh (+ h (clojure.core/aget x i))))]
+              result)
+       {:dtype :float :array-types {'x :float 'target :float}})
+      (is false "an uncertified recurrence must decline")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :scan-not-associative (:reason (ex-data exception)))))))
   (testing "imperative map output identity is not disguised as a functional result"
     (is (nil? (frontend/form->program
                '(let* [step (raster.par/map! target i n float

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -26,6 +26,11 @@
           v (raster.par/pmap j n float (+ (clojure.core/aget b j) 1.0))]
          [u v]))
 
+(def ^:private inclusive-scan
+  '(let* [result (raster.par/scan out acc 0.0 i n float
+                                  (+ acc (clojure.core/aget x i)))]
+         result))
+
 (deftest pure-vertical-fusion-becomes-a-first-class-typed-program
   (let [{:keys [program stats]} (route/attempt map-map :float)
         equation (first (:equations program))]
@@ -167,6 +172,42 @@
         (is (= 1 (get-in simd [:stats :segop-reused])))
         (is (nil? (get-in simd [:stats :segop-relowered])))
         (parallel-program/validate! form segop/segop-node?)))))
+
+(deftest typed-inclusive-scan-owns-one-certified-scheduled-graph
+  (let [{:keys [program stats]} (route/attempt inclusive-scan :float
+                                               {'x :float 'out :float})
+        lowered (segop-lower/segop-lower-pass
+                 program {:dtype :float :target-device :ocl:0
+                          :array-types {'x :float 'out :float}})
+        scheduled (:form lowered)
+        equation (first (:equations scheduled))
+        graph (get-in equation [:attributes :kernel-graph])]
+    (is (= :typed-soac (:route stats)))
+    (is (= 'scan (dialect/operation-kind
+                  (first (dialect/equations (:algorithm equation))))))
+    (is (= #{:memory/write} (:effects equation)))
+    (is (= 1 (get-in lowered [:stats :typed-soac-reused])))
+    (is (= 1 (get-in lowered [:stats :kernel-graphs-lowered])))
+    (is (= [:intra-block :block-scan nil]
+           (mapv :phase (:operations equation))))
+    (is (= 3 (count (:nodes graph))))
+    (is (= :typed-soac (get-in (first (:operations equation)) [:algorithm-dialect])))
+    (is (= #{'out} (set (map :id (:outputs graph)))))
+    (is (= 1 (count (:temporaries graph))))
+    (parallel-program/validate! scheduled segop/segop-node?)))
+
+(deftest typed-inclusive-scan-preserves-exact-sequential-jvm-semantics
+  (let [typed (:program (route/attempt inclusive-scan :float
+                                       {'x :float 'out :float}))
+        scheduled (:form (segop-lower/segop-lower-pass typed {:dtype :float}))
+        jvm (par-simd/simd-pass scheduled :min-elements 1)
+        execute (eval (list 'fn '[out x n] (:form jvm)))
+        out (float-array 5)
+        result (execute out (float-array [1.0 2.0 3.0 4.0 5.0]) 5)]
+    (is (identical? out result))
+    (is (= [1.0 3.0 6.0 10.0 15.0] (mapv double result)))
+    (is (nil? (get-in jvm [:stats :segop-relowered]))
+        "JVM keeps the exact inclusive recurrence until a certified vector scan schedule lands")))
 
 (deftest typed-horizontal-fusion-lowers-to-one-explicit-multi-output-segmap
   (let [{:keys [program stats]} (route/attempt


### PR DESCRIPTION
## Summary
- add a distinct certified inclusive scan operation to the TypedSOAC dialect
- construct scan equations directly from analyzed source with explicit destination alias/effect facts
- lower typed scan into the existing one- or three-stage SegScan KernelGraph without constructing a legacy SoacScan
- preserve exact sequential JVM semantics and target-lower the same graph to verified OpenCL artifacts
- keep general recurrences and scan-exclusive outside the inclusive reassociation proof

## Validation
- clojure -M:test
- 2,489 tests, 35,346 assertions, 0 failures/errors
- live Intel Arc OpenCL/GPU suites available; 0 device-test skips
- focused TypedSOAC/frontend/route/emission and surrounding legacy scan/graph suites
- cljfmt and git diff --check