### PR TITLE
Route scheduled graphs through resident executables

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -85,9 +85,14 @@ explicit fallback for unsupported parallel forms and as a differential oracle. I
 a distinct `scan` equation with an explicit `:inclusive` mode and a checked `AssociativeScan`
 certificate; its caller-owned destination is an alias/effect fact, not part of the functional
 algebra. It lowers directly to a one- or three-node SegScan `KernelGraph` without constructing a
-legacy `SoacScan`. General recurrences and `scan-exclusive` remain outside this typed operation and
-must not borrow its reassociation proof. The remaining parallel forms must join the direct front
-end before the graph fallback can be deleted.
+legacy `SoacScan`. The GPU backend now target-lowers that scheduled value through one fail-loud
+graph-emission boundary, wraps it in the same `KernelDispatch` value used by other selectable
+schedules, and resident descriptor extraction retains it as one executable step. LinkPlan and the
+runtime binder allocate its private temporary and flatten its nodes without reconstructing scan or
+ABI semantics. The ordinary per-call staging function still takes an explicitly counted exact
+sequential fallback until it has a generic graph runner. General recurrences and `scan-exclusive`
+remain outside this typed operation and must not borrow its reassociation proof. The remaining
+parallel forms must join the direct front end before the graph fallback can be deleted.
 
 The first architectural correction is therefore:
 
@@ -800,9 +805,11 @@ The immediate continuation after the verified double-buffered weighted-reduction
    re-lowering. Supported map/reduce programs, including unfused and host-visible intermediates,
    horizontal tuple maps, typed scalar/shape equations, stable tensor captures, and resident
    reduction results and certified inclusive scan now share the direct
-   analyzed-source→TypedSOAC→SegOp production route. Hardware-costed multi-consumer fusion,
-   nested-region JVM scheduling, the remaining parallel forms (including distinct exclusive-scan
-   semantics), and deletion of the remaining graph/backend fallbacks remain.
+   analyzed-source→TypedSOAC→SegOp production route. Inclusive scan additionally reaches an emitted
+   graph-backed resident executable through ordinary dispatch, LinkPlan and binding. A generic
+   per-call staging graph runner, hardware-costed multi-consumer fusion, nested-region JVM
+   scheduling, the remaining parallel forms (including distinct exclusive-scan semantics), and
+   deletion of the remaining graph/backend fallbacks remain.
 6. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a
    read-only distributed track without interrupting the kernel and typed-middle-end verticals.
 

--- a/design/link-plan.md
+++ b/design/link-plan.md
@@ -13,6 +13,9 @@ The boundary has three layers:
 
 No attention, GEMM, quantization, or model-layer convention exists in the linker. A descriptor step
 may select a `KernelArtifact` or `KernelGraph`; both pass through the common executable-step binder.
+This is also the production route for certified inclusive scan: the compiler preserves its emitted
+multi-kernel graph as one descriptor step, while graph-private block totals remain invisible to the
+public LinkPlan value graph and are allocated by the executable binder.
 
 The resident-descriptor conversion is proof-carrying in the compiler sense. It returns a
 `CertifiedResidentPlan` containing the target plan and a `ResidentPlanCertificate`. The witness

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -15,6 +15,7 @@
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.core.op-descriptor :as descriptor]
@@ -301,7 +302,8 @@
                                (or (:array-types (meta source-form)) {})
                                (or (:array-types (meta form)) {}) array-types)
         stats (atom {:ze-maps 0 :ze-reduces 0 :ze-compounds 0 :ze-contracts 0
-                     :ze-structured-reductions 0 :fallback 0})
+                     :ze-structured-reductions 0 :kernel-graphs 0
+                     :graph-staging-fallbacks 0 :fallback 0})
         kernels (atom [])
         dispatches (atom [])
         target-desc (delay
@@ -317,6 +319,40 @@
             (swap! stats update stat-key inc)
             (swap! kernels conj k)
             k))
+
+        emit-scheduled-graph!
+        (fn [scheduled source]
+          ;; KernelDispatch is already the verified selection value above both a single artifact
+          ;; and a graph.  A one-alternative dispatch therefore gives scheduled equations the same
+          ;; registry/selection seam as tuned GEMM without introducing a second graph registry.
+          ;; Scan is the first graph target-lowering; later graph families extend this backend
+          ;; dispatcher rather than adding source/runtime conventions per operation.
+          (let [emitted0 (segop-cl/generate-kernel-graph
+                          scheduled :scalar-types top-scalar-types)
+                emitted (-> emitted0
+                            (kgraph/map-operations
+                             (fn [node]
+                               (maybe-compile-spirv (:operation node)
+                                                    compile-spirv? device-id)))
+                            (assoc-in [:attributes :strategy] :scheduled-graph)
+                            kgraph/validate!)
+                dispatch (kdispatch/make
+                          {:id (str "scheduled-graph-"
+                                    (Integer/toUnsignedString (hash emitted) 16))
+                           :alternatives [emitted]
+                           :default-strategy :scheduled-graph
+                           :selector {:kind :fixed-strategy :strategy :scheduled-graph}
+                           :provenance {:pass :opencl :source-dialect :segop}
+                           :attributes {:operation-family :scheduled-graph}})]
+            (swap! kernels into (mapv :operation (:nodes emitted)))
+            (swap! dispatches conj dispatch)
+            (swap! stats update :kernel-graphs inc)
+            ;; The ordinary staged function still executes the exact source semantics until the
+            ;; generic staging graph runner lands.  Resident extraction recognizes this generic
+            ;; marker and binds the dispatch directly, so no graph node is reconstructed from it.
+            (swap! stats update :graph-staging-fallbacks inc)
+            (list 'raster.compiler.pipeline/invoke-scheduled-executable-fallback
+                  (:id dispatch) (vec (:arguments emitted)) source)))
 
         transform
         (fn transform [form]
@@ -597,11 +633,17 @@
             (let [[let-sym bindings & body-exprs] form
                   pairs (partition 2 bindings)
                   new-bindings (vec (mapcat (fn [[sym expr]]
-                                              [sym (binding [*bound-segops*
-                                                             (when parallel-program
-                                                               (parallel-program/operations-for-binding
-                                                                parallel-program sym expr))]
-                                                     (transform expr))])
+                                              (let [scheduled
+                                                    (when parallel-program
+                                                      (parallel-program/kernel-graph-for-binding
+                                                       parallel-program sym expr))]
+                                                [sym (if scheduled
+                                                       (emit-scheduled-graph! scheduled expr)
+                                                       (binding [*bound-segops*
+                                                                 (when parallel-program
+                                                                   (parallel-program/operations-for-binding
+                                                                    parallel-program sym expr))]
+                                                         (transform expr)))]))
                                             pairs))
                   new-body (mapv (fn [expr]
                                    (binding [*bound-segops*

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -882,7 +882,11 @@
               (throw (ex-info "scan graph scalar has inconsistent emitted ABI dtypes"
                               {:argument argument :slots (mapv first pairs)}))))
         pointer-abi (mapv (fn [{:keys [id dtype role]}]
-                            (kabi/slot id (if (= :input role) :input :output) dtype))
+                            (kabi/slot id (if (= :input role) :input :output) dtype
+                                       :role (case role
+                                               :input :operand
+                                               :output :result
+                                               :inout :inout)))
                           external-buffers)
         scalar-arguments (vec (sort-by name (keys scalar-groups)))
         scalar-abi (mapv (fn [argument]
@@ -898,6 +902,25 @@
         (assoc-in [:provenance :target-dialect] :opencl-c)
         (assoc-in [:attributes :emitted?] true)
         kgraph/validate!)))
+
+(defn generate-kernel-graph
+  "Target-lower one scheduled KernelGraph through the backend's single graph-emission boundary.
+
+   Operation-family recognition is confined here and must be proved by graph attributes established
+   by scheduling. Unsupported graph families fail loudly; callers never fall back to reconstructing
+   an operation from source spelling or node names."
+  [graph & {:as opts}]
+  (let [graph (kgraph/validate! graph)]
+    (cond
+      (scan/associative-scan? (get-in graph [:attributes :scan-algebra]))
+      (apply generate-scan-kernel-graph graph (mapcat identity opts))
+
+      :else
+      (throw (ex-info "OpenCL backend has no target lowering for scheduled KernelGraph"
+                      {:reason :kernel-graph-target-lowering-missing
+                       :target :opencl-c
+                       :provenance (:provenance graph)
+                       :attributes (:attributes graph)})))))
 
 ;; ================================================================
 ;; Segmented reduction (contraction) → OpenCL — the multi-axis SegSpace path

--- a/src/raster/compiler/ir/dialects.clj
+++ b/src/raster/compiler/ir/dialects.clj
@@ -520,7 +520,7 @@
             (let [body (when (and (seq? operation) (= '= (first operation))
                                   (= 4 (count operation)))
                          (nth operation 3))]
-              (and (seq? body) (contains? #{'scalar 'map 'reduce} (first body)))))
+              (and (seq? body) (contains? #{'scalar 'map 'reduce 'scan} (first body)))))
           (fn [_ algorithm]
             (= algorithm (soac-dialect/validate! algorithm))))
          (valid-let*-ordered? (:source value))

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -32,6 +32,7 @@
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-executable :as kexec]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.backend.jvm.par-simd :as par-simd]
             [raster.compiler.backend.wasm.emit :as wasm-emit]
@@ -1232,12 +1233,20 @@
      raster.gpu.ze-runtime/invoke-registered-reduction-kernel
      raster.gpu.ze-runtime/invoke-registered-contraction!
      raster.gpu.ze-runtime/invoke-registered-contraction-dispatch!
+     raster.compiler.pipeline/invoke-scheduled-executable-fallback
      raster.gpu.ze-runtime/invoke-registered-scatter-kernel})
 
 (def ^:private gpu-array-alloc-heads
   '#{double-array float-array int-array long-array byte-array
      clojure.core/double-array clojure.core/float-array
      clojure.core/int-array clojure.core/long-array clojure.core/byte-array})
+
+(defn invoke-scheduled-executable-fallback
+  "Preserve exact source semantics for a scheduled graph in the ordinary staging function until
+   that path has a generic graph runner. Resident extraction recognizes this compiler marker and
+   binds the registered KernelDispatch; this function is therefore not a runtime launch ABI."
+  [_dispatch-id _arguments fallback-value]
+  fallback-value)
 
 (def ^:private blas-gemm-ops
   "BLAS GEMM ops the resident path recognizes (via :raster.op/original on the devirtualized
@@ -1329,6 +1338,14 @@
           (when (vector? arguments)
             {:dispatch-id dispatch-id :kernel-name default-kernel-name :arguments arguments
              :convention :contract :returns sym})))
+      (= head 'raster.compiler.pipeline/invoke-scheduled-executable-fallback)
+      ;; Generic scheduled-executable marker.  The third operand is the exact sequential source
+      ;; fallback used by non-resident staging and is deliberately not part of the resident ABI.
+      (when (= 4 argc)
+        (let [[_ dispatch-id arguments _fallback] expr]
+          (when (vector? arguments)
+            {:dispatch-id dispatch-id :arguments arguments
+             :convention :executable :returns sym})))
       (= head 'raster.gpu.ze-runtime/invoke-registered-scatter-kernel)
       ;; (invoke-registered-scatter-kernel kname out src index n [stride]). out is the
       ;; accumulator buffer (a zeros-like intermediate), written in-place via atomic +=.
@@ -1737,10 +1754,16 @@
                                    (if (= :gemm (:convention s))
                                      ;; a GEMM writes its C (out-buf) in place
                                      (conj acc (symbol (name (:out-buf s))))
-                                     (let [ki (reg-entry (:kernel-name s))]
+                                     (let [ki (if-let [dispatch-id (:dispatch-id s)]
+                                                (some-> (dispatch-entry dispatch-id)
+                                                        kdispatch/default-alternative)
+                                                (reg-entry (:kernel-name s)))]
                                        (into acc
                                              (map (comp symbol name)
-                                                  (if-let [abi (:abi ki)]
+                                                  (if-let [abi (when ki
+                                                                 (if (kexec/kernel-executable? ki)
+                                                                   (kexec/abi ki)
+                                                                   (:abi ki)))]
                                                     (map #(or (:binding %) (:name %))
                                                          (filter #(or (= :output (:kind %))
                                                                       (= :inout (:role %)))
@@ -1754,7 +1777,15 @@
                         (reduce (fn [m s]
                                   (if (= :gemm (:convention s))
                                     (assoc m (:C s) effective-dtype)
-                                    (if-let [abi (:abi (reg-entry (:kernel-name s)))]
+                                    (if-let [abi (if-let [dispatch-id (:dispatch-id s)]
+                                                   (some-> (dispatch-entry dispatch-id)
+                                                           kdispatch/default-alternative
+                                                           kexec/abi)
+                                                   (let [ki (reg-entry (:kernel-name s))]
+                                                     (when ki
+                                                       (if (kexec/kernel-executable? ki)
+                                                         (kexec/abi ki)
+                                                         (:abi ki)))))]
                                       (reduce (fn [m slot]
                                                 (if (or (= :output (:kind slot))
                                                         (= :inout (:role slot)))
@@ -1876,6 +1907,40 @@
                                      {:slot slot :kind (:kind slot) :role (:role slot)
                                       :dtype (:dtype slot) :sym value}))
                                  abi arguments)
+                           :phase (keyword (str "gpu-step-" i))})
+
+                        (= :executable (:convention step))
+                        (let [{:keys [dispatch-id arguments]} step
+                              dispatch (or (dispatch-entry dispatch-id)
+                                           (throw (ex-info "resident executable dispatch is not registered"
+                                                           {:dispatch-id dispatch-id})))
+                              dispatch (kdispatch/validate! dispatch)
+                              executable (kdispatch/default-alternative dispatch)
+                              executable (kexec/validate! executable)
+                              abi (kexec/abi executable)
+                              _ (kabi/validate-arguments! abi arguments)
+                              result-pairs (filterv (fn [[slot _]] (= :result (:role slot)))
+                                                    (map vector abi arguments))
+                              ;; A generic graph may be effect-only or multi-output. `:output` is
+                              ;; retained solely as compatibility sugar for the one-result case;
+                              ;; LinkPlan derives every write from the complete executable ABI.
+                              output (when (= 1 (count result-pairs))
+                                       (second (first result-pairs)))]
+                          {:convention :executable
+                           :dispatch-id dispatch-id
+                           :dispatch dispatch
+                           :artifact executable
+                           :abi abi
+                           :argument-specs
+                           (mapv (fn [slot value]
+                                   (if (= :scalar (:kind slot))
+                                     {:slot slot :kind :scalar :type (:kernel-dtype slot)
+                                      :expression value
+                                      :value-fn (expr->arg-fn all-params scalar-lets value)}
+                                     {:slot slot :kind (:kind slot) :role (:role slot)
+                                      :dtype (:dtype slot) :sym value}))
+                                 abi arguments)
+                           :output (when output (keyword (name output)))
                            :phase (keyword (str "gpu-step-" i))})
 
                         (= :map-void (:convention step))

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -1648,7 +1648,7 @@
   (let [{:keys [kernel-name phase convention artifact argument-specs arrays n-fn scalar-specs]}
         step]
     (case convention
-      (:map :reduce :map-void :contract :gemm)
+      (:map :reduce :map-void :contract :gemm :executable)
       (let [logical-or-physical-args
             (mapv (fn [{:keys [kind sym type value-fn]}]
                     (if (= :scalar kind)

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -72,7 +72,7 @@
                           typed {:dtype :float :target-device :ocl:0
                                  :array-types {'values :float 'out :float}}))
         graph (get-in scheduled [:equations 0 :attributes :kernel-graph])
-        emitted (sg/generate-scan-kernel-graph graph)]
+        emitted (sg/generate-kernel-graph graph)]
     (is (= :typed-soac (get-in scheduled [:provenance :source-dialect])))
     (is (= 3 (count (:nodes emitted))))
     (is (every? kart/kernel-artifact? (map :operation (:nodes emitted))))

--- a/test/raster/compiler/kernel_call_pipeline_test.clj
+++ b/test/raster/compiler/kernel_call_pipeline_test.clj
@@ -3,6 +3,7 @@
             [raster.arrays :as ra]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
+            [raster.compiler.ir.kernel-graph :as kernel-graph]
             [raster.compiler.pipeline :as pipeline]
             [raster.core :refer [deftm]]))
 
@@ -21,6 +22,28 @@
   [x :- (Array float) out :- (Array float) scale :- Float n :- Long] :- Void
   (raster.par/map-void! i n
                         (ra/aset out i (* scale (ra/aget x i)))))
+
+(deftm resident-kernel-call-scan
+  [x :- (Array float) out :- (Array float) n :- Long] :- (Array float)
+  (raster.par/scan out acc 0.0 i n float (+ acc (ra/aget x i))))
+
+(deftest resident-typed-scan-is-one-graph-backed-executable-step
+  (let [descriptor (pipeline/compile-gpu-program #'resident-kernel-call-scan
+                                                 :ze:0 :dtype :float)
+        step (first (:steps descriptor))
+        executable (:artifact step)]
+    (is (= 1 (count (:steps descriptor))))
+    (is (= :executable (:convention step)))
+    (is (kernel-graph/kernel-graph? executable))
+    (is (= 3 (count (:nodes executable))))
+    (is (= 1 (count (:temporaries executable))))
+    (is (empty? (:allocs descriptor))
+        "graph-private scan storage must not leak into program allocations")
+    (is (= (:abi executable) (:abi step)))
+    (is (= (:arguments executable)
+           (mapv (fn [{:keys [kind sym expression]}]
+                   (if (= :scalar kind) expression sym))
+                 (:argument-specs step))))))
 
 (deftest resident-segmap-step-carries-one-executable-call-template
   (let [descriptor (pipeline/compile-gpu-program #'resident-kernel-call-map

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -2,6 +2,8 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
             [raster.compiler.backend.jvm.par-simd :as par-simd]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-graph :as kernel-graph]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as dialect]
@@ -195,6 +197,32 @@
     (is (= #{'out} (set (map :id (:outputs graph)))))
     (is (= 1 (count (:temporaries graph))))
     (parallel-program/validate! scheduled segop/segop-node?)))
+
+(deftest typed-inclusive-scan-target-lowers-to-one-executable-dispatch
+  (let [typed (:program (route/attempt inclusive-scan :float
+                                       {'x :float 'out :float}))
+        scheduled (:form (segop-lower/segop-lower-pass
+                          typed {:dtype :float :target-device :ocl:0
+                                 :array-types {'x :float 'out :float}}))
+        emitted (opencl-pass/opencl-pass scheduled :device-id :ocl:0 :dtype :float)
+        dispatch (first (:dispatches emitted))
+        executable (kdispatch/default-alternative dispatch)
+        binding-expr (nth (second (:form emitted)) 1)
+        execute (eval (list 'fn '[out x n] (:form emitted)))
+        out (float-array 5)
+        fallback-result (execute out (float-array [1.0 2.0 3.0 4.0 5.0]) 5)]
+    (is (= 1 (get-in emitted [:stats :kernel-graphs])))
+    (is (= 1 (get-in emitted [:stats :graph-staging-fallbacks])))
+    (is (= 3 (count (:kernels emitted))))
+    (is (= 1 (count (:dispatches emitted))))
+    (is (kernel-graph/kernel-graph? executable))
+    (is (= executable (kdispatch/select-alternative dispatch [] :scheduled-graph)))
+    (is (= 'raster.compiler.pipeline/invoke-scheduled-executable-fallback
+           (first binding-expr)))
+    (is (= (:arguments executable) (nth binding-expr 2)))
+    (is (= (get-in scheduled [:equations 0 :source]) (nth binding-expr 3)))
+    (is (identical? out fallback-result))
+    (is (= [1.0 3.0 6.0 10.0 15.0] (mapv double fallback-result)))))
 
 (deftest typed-inclusive-scan-preserves-exact-sequential-jvm-semantics
   (let [typed (:program (route/attempt inclusive-scan :float

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -47,6 +47,11 @@
     (raster.par/map-void! j n
                           (ra/aset out j (clojure.core/* (ra/aget x j) s)))))
 
+(deftm ocl-session-scan
+  [x :- (Array float) out :- (Array float) n :- Long] :- (Array float)
+  (raster.par/scan out acc 0.0 i n float
+                   (clojure.core/+ acc (ra/aget x i))))
+
 (deftest ocl-map-void-mixed-storage-abi-roundtrip
   (if-not @device-probe/opencl-available?
     (device-probe/opencl-skip! "mixed-storage map-void")
@@ -86,6 +91,25 @@
                   ^floats yg (get r2 'y)]
               (is (< (Math/abs (- (aget yg 100) 200.0)) 1e-3)))))
         (finally (gpu/close-session! s))))))
+
+(deftest ocl-resident-typed-scan-runs-through-the-compiled-graph-step
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "resident typed scan graph")
+    (let [n 1025
+          descriptor (pl/compile-gpu-program #'ocl-session-scan :ocl:0 :dtype :float)
+          x (float-array (repeat n 1.0))
+          out (float-array n)
+          session (gpu/make-session :ocl:0)]
+      (try
+        (is (= [:executable] (mapv :convention (:steps descriptor))))
+        (let [program (fixture/instantiate! session descriptor [x out n]
+                                            {'x :input 'out :output})
+              result (fixture/run! program [x out n])
+              ^floats scanned (get result 'out)]
+          (is (= (float n) (aget scanned (dec n))))
+          (is (every? (fn [i] (= (float (inc i)) (aget scanned i)))
+                      [0 1 255 256 511 512 1024])))
+        (finally (gpu/close-session! session))))))
 
 (deftest ocl-resident-indexed-row-reduction-roundtrip
   (if-not @device-probe/opencl-available?


### PR DESCRIPTION
## Summary

- target-lower scheduled KernelGraphs through one fail-loud backend boundary and represent them with the existing KernelDispatch executable union
- preserve certified inclusive scan as one graph-backed resident descriptor step, including its ordered ABI and graph-private temporaries
- keep the ordinary staged path semantically exact with an explicit counted fallback until a generic staged graph runner lands
- accept typed scan at the formal dialect boundary and document the remaining convergence work

## Verification

- focused compiler, graph, dispatch, resident-plan, and linker suites: green
- live Intel Arc OpenCL resident scan: 1,025-element multi-block prefix sum, green
- full suite: 2,492 tests / 34,687 assertions, 0 failures; the sole error was the managed sandbox denying write access to ~/.raster/spirv-cache
- rerun of that affected namespace with its cache writable: 12 tests / 272 assertions, green