### PR TITLE
Execute scheduled graphs through the staging runtime

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -89,10 +89,13 @@ legacy `SoacScan`. The GPU backend now target-lowers that scheduled value throug
 graph-emission boundary, wraps it in the same `KernelDispatch` value used by other selectable
 schedules, and resident descriptor extraction retains it as one executable step. LinkPlan and the
 runtime binder allocate its private temporary and flatten its nodes without reconstructing scan or
-ABI semantics. The ordinary per-call staging function still takes an explicitly counted exact
-sequential fallback until it has a generic graph runner. General recurrences and `scan-exclusive`
-remain outside this typed operation and must not borrow its reassociation proof. The remaining
-parallel forms must join the direct front end before the graph fallback can be deleted.
+ABI semantics. The ordinary per-call compiled function now invokes that same registered
+`KernelDispatch` through a backend-neutral staged `KernelExecutable` runner: its ordered ABI types
+scalars, preserves pointer identity, stages JVM arrays (or borrows resident buffers), owns graph
+temporaries, and copies back only declared writes. No duplicate sequential source implementation
+is embedded in the emitted form. General recurrences and `scan-exclusive` remain outside this
+typed operation and must not borrow its reassociation proof. The remaining parallel forms must
+join the direct front end before the old dependency-graph fallback can be deleted.
 
 The first architectural correction is therefore:
 

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -303,7 +303,7 @@
                                (or (:array-types (meta form)) {}) array-types)
         stats (atom {:ze-maps 0 :ze-reduces 0 :ze-compounds 0 :ze-contracts 0
                      :ze-structured-reductions 0 :kernel-graphs 0
-                     :graph-staging-fallbacks 0 :fallback 0})
+                     :fallback 0})
         kernels (atom [])
         dispatches (atom [])
         target-desc (delay
@@ -321,7 +321,7 @@
             k))
 
         emit-scheduled-graph!
-        (fn [scheduled source]
+        (fn [scheduled]
           ;; KernelDispatch is already the verified selection value above both a single artifact
           ;; and a graph.  A one-alternative dispatch therefore gives scheduled equations the same
           ;; registry/selection seam as tuned GEMM without introducing a second graph registry.
@@ -347,12 +347,11 @@
             (swap! kernels into (mapv :operation (:nodes emitted)))
             (swap! dispatches conj dispatch)
             (swap! stats update :kernel-graphs inc)
-            ;; The ordinary staged function still executes the exact source semantics until the
-            ;; generic staging graph runner lands.  Resident extraction recognizes this generic
-            ;; marker and binds the dispatch directly, so no graph node is reconstructed from it.
-            (swap! stats update :graph-staging-fallbacks inc)
-            (list 'raster.compiler.pipeline/invoke-scheduled-executable-fallback
-                  (:id dispatch) (vec (:arguments emitted)) source)))
+            ;; Staging and resident extraction consume the same registered dispatch and complete
+            ;; ordered executable ABI. The device id chooses only the runtime; it is not part of
+            ;; the executable's semantic call interface.
+            (list 'raster.compiler.pipeline/invoke-scheduled-executable!
+                  device-id (:id dispatch) (vec (:arguments emitted)))))
 
         transform
         (fn transform [form]
@@ -638,7 +637,7 @@
                                                       (parallel-program/kernel-graph-for-binding
                                                        parallel-program sym expr))]
                                                 [sym (if scheduled
-                                                       (emit-scheduled-graph! scheduled expr)
+                                                       (emit-scheduled-graph! scheduled)
                                                        (binding [*bound-segops*
                                                                  (when parallel-program
                                                                    (parallel-program/operations-for-binding

--- a/src/raster/compiler/core/dtype.clj
+++ b/src/raster/compiler/core/dtype.clj
@@ -12,6 +12,7 @@
 ;;   :scalar-tag   primitive dispatch tag for a scalar of this dtype, or nil
 ;;                 when the dtype has no JVM primitive (e.g. :half)
 ;;   :array-tag    dispatch tag for a primitive array of this dtype
+;;   :jvm-array-class-name JVM descriptor for the corresponding primitive-array storage class
 ;;   :vt           wasm / vector value-type keyword
 ;;   :needs-pragma OpenCL extension pragma this type requires, or nil
 ;;   :fp?          floating-point?
@@ -27,22 +28,22 @@
 (def dtype-info
   {:double {:native {:c "double" :opencl "double" :glsl "double"}
             :scalar-tag 'double :array-tag 'doubles :vt :f64 :needs-pragma :cl_khr_fp64 :fp? true
-            :bytes 8 :aliases #{:float64 :f64}}
+            :bytes 8 :jvm-array-class-name "[D" :aliases #{:float64 :f64}}
    :float  {:native {:c "float" :opencl "float" :glsl "float"}
             :scalar-tag 'float :array-tag 'floats :vt :f32 :needs-pragma nil :fp? true
-            :bytes 4 :aliases #{:float32 :f32}}
+            :bytes 4 :jvm-array-class-name "[F" :aliases #{:float32 :f32}}
    :half   {:native {:c "_Float16" :opencl "half" :glsl "float16_t"}
             :scalar-tag nil :array-tag 'shorts :vt :f16 :needs-pragma :cl_khr_fp16 :fp? true
-            :bytes 2 :aliases #{:float16 :f16}}
+            :bytes 2 :jvm-array-class-name "[S" :aliases #{:float16 :f16}}
    :int    {:native {:c "int" :opencl "int" :glsl "int"}
             :scalar-tag 'int :array-tag 'ints :vt :i32 :needs-pragma nil :fp? false
-            :bytes 4 :aliases #{:int32 :i32}}
+            :bytes 4 :jvm-array-class-name "[I" :aliases #{:int32 :i32}}
    :long   {:native {:c "long long" :opencl "long" :glsl "int"}
             :scalar-tag 'long :array-tag 'longs :vt :i64 :needs-pragma nil :fp? false
-            :bytes 8 :aliases #{:int64 :i64}}
+            :bytes 8 :jvm-array-class-name "[J" :aliases #{:int64 :i64}}
    :byte   {:native {:c "int8_t" :opencl "char" :glsl "int"}
             :scalar-tag 'byte :array-tag 'bytes :vt :i32 :needs-pragma nil :fp? false
-            :bytes 1 :aliases #{:int8 :i8}}})
+            :bytes 1 :jvm-array-class-name "[B" :aliases #{:int8 :i8}}})
 
 (def ^:private alias->canonical
   (into {} (for [[k v] dtype-info, a (cons k (:aliases v))] [a k])))
@@ -125,6 +126,20 @@
     (some (fn [[dtype facets]]
             (when (= tag (:array-tag facets)) dtype))
           dtype-info)))
+
+(def ^:private jvm-array-class->dtype
+  (delay
+    (into {}
+          (map (fn [[dtype facets]]
+                 [(Class/forName (:jvm-array-class-name facets)) dtype]))
+          dtype-info)))
+
+(defn dtype-for-jvm-array
+  "Canonical storage dtype for a supported JVM primitive array, or nil.
+
+   This is the runtime reverse projection of `dtype-info`, not a backend-private type table."
+  [value]
+  (when value (get @jvm-array-class->dtype (class value))))
 
 (defn needs-pragma-for
   "The OpenCL extension pragma keyword this dtype requires (e.g. :half →

--- a/src/raster/compiler/ir/kernel_executable.clj
+++ b/src/raster/compiler/ir/kernel_executable.clj
@@ -73,6 +73,40 @@
   [executable]
   (mapv :kernel-name (artifacts (validate! executable))))
 
+(defn- cast-runtime-scalar
+  [dtype value]
+  (case dtype
+    :int (int value)
+    :long (long value)
+    :float (float value)
+    :double (double value)
+    (throw (ex-info "kernel executable has no runtime scalar representation for ABI dtype"
+                    {:dtype dtype :value value}))))
+
+(defn typed-runtime-arguments
+  "Normalize raw caller scalars to the explicit values required by KernelCall/KernelGraphCall.
+
+   Pointer values remain opaque. A caller may also supply an already typed scalar map; its type
+   must agree with the executable ABI. This is the single normalization seam used before runtime
+   dispatch selection and binding."
+  [executable runtime-arguments]
+  (let [executable (validate! executable)
+        abi (:abi executable)
+        runtime-arguments (kabi/validate-arguments! abi runtime-arguments)]
+    (mapv (fn [slot value]
+            (if (= :scalar (:kind slot))
+              (if (and (map? value) (contains? value :type) (contains? value :value))
+                (do
+                  (when-not (= (:kernel-dtype slot) (:type value))
+                    (throw (ex-info "kernel executable scalar argument has the wrong ABI dtype"
+                                    {:slot slot :expected (:kernel-dtype slot)
+                                     :actual (:type value) :value value})))
+                  (update value :value #(cast-runtime-scalar (:kernel-dtype slot) %)))
+                {:type (:kernel-dtype slot)
+                 :value (cast-runtime-scalar (:kernel-dtype slot) value)})
+              value))
+          abi runtime-arguments)))
+
 (defn common-view
   "Return the logical interface that every dispatch alternative must preserve."
   [executable]

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -1233,7 +1233,7 @@
      raster.gpu.ze-runtime/invoke-registered-reduction-kernel
      raster.gpu.ze-runtime/invoke-registered-contraction!
      raster.gpu.ze-runtime/invoke-registered-contraction-dispatch!
-     raster.compiler.pipeline/invoke-scheduled-executable-fallback
+     raster.compiler.pipeline/invoke-scheduled-executable!
      raster.gpu.ze-runtime/invoke-registered-scatter-kernel})
 
 (def ^:private gpu-array-alloc-heads
@@ -1241,12 +1241,14 @@
      clojure.core/double-array clojure.core/float-array
      clojure.core/int-array clojure.core/long-array clojure.core/byte-array})
 
-(defn invoke-scheduled-executable-fallback
-  "Preserve exact source semantics for a scheduled graph in the ordinary staging function until
-   that path has a generic graph runner. Resident extraction recognizes this compiler marker and
-   binds the registered KernelDispatch; this function is therefore not a runtime launch ABI."
-  [_dispatch-id _arguments fallback-value]
-  fallback-value)
+(defn invoke-scheduled-executable!
+  "Ordinary compiled-function entry to the generic staged KernelExecutable runner.
+
+   The indirection avoids a static pipeline -> gpu.core dependency cycle; resident extraction
+   recognizes the same marker and binds its registered dispatch without staging."
+  [device-id dispatch-id arguments]
+  ((requiring-resolve 'raster.gpu.core/invoke-staged-executable!)
+   device-id dispatch-id arguments))
 
 (def ^:private blas-gemm-ops
   "BLAS GEMM ops the resident path recognizes (via :raster.op/original on the devirtualized
@@ -1338,11 +1340,11 @@
           (when (vector? arguments)
             {:dispatch-id dispatch-id :kernel-name default-kernel-name :arguments arguments
              :convention :contract :returns sym})))
-      (= head 'raster.compiler.pipeline/invoke-scheduled-executable-fallback)
-      ;; Generic scheduled-executable marker.  The third operand is the exact sequential source
-      ;; fallback used by non-resident staging and is deliberately not part of the resident ABI.
+      (= head 'raster.compiler.pipeline/invoke-scheduled-executable!)
+      ;; Generic scheduled-executable marker. Resident extraction consumes the same dispatch and
+      ;; ordered arguments as staging; the target device is carried for the staged runtime only.
       (when (= 4 argc)
-        (let [[_ dispatch-id arguments _fallback] expr]
+        (let [[_ _device-id dispatch-id arguments] expr]
           (when (vector? arguments)
             {:dispatch-id dispatch-id :arguments arguments
              :convention :executable :returns sym})))

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -175,8 +175,11 @@
                          :int   (let [ib (as-ibuf buf)]
                                   (.put ib ^ints arr 0 (int n))
                                   buf)
+                         ;; The fast coherent host views are currently specialized for the two
+                         ;; common storage types. All other typed buffers still use the ordinary
+                         ;; backend upload contract; allocation must never guess from dtype.
                          (upload buf arr))
-                       (upload buf arr))
+                         (upload buf arr))
                      buf)))]
     (into {}
           (map (fn [[k [dtype n source-arr]]]
@@ -1491,6 +1494,97 @@
          (let [{:keys [buffers scalar-values]} (kexec/graph-bindings executable arguments)]
            (bind-kernel-graph! sess executable-key executable buffers scalar-values
                                (select-keys options [:profile?]))))))))
+
+(defn- staged-pointer-plan
+  "Validate and group ABI pointer values by object identity before any allocation.
+
+   One host array or resident buffer supplied at several ABI positions receives one session
+   allocation/registration, preserving legal in-place calls and exposing illegal stable-input
+   aliases to the ordinary graph validator."
+  [device-id executable typed-arguments]
+  (let [device-buffer? (rt-resolve device-id "device-buffer?")
+        identities (java.util.IdentityHashMap.)
+        groups (volatile! [])]
+    (doseq [[index [slot value]] (map-indexed vector (map vector (kexec/abi executable)
+                                                          typed-arguments))
+            :when (not= :scalar (:kind slot))]
+      (let [array-dtype (dtype/dtype-for-jvm-array value)
+            resident? (boolean (device-buffer? value))
+            actual-dtype (cond array-dtype array-dtype resident? (dtype/canon (:dtype value)))]
+        (when-not actual-dtype
+          (throw (ex-info "staged kernel executable pointer is not a primitive array or backend buffer"
+                          {:device-id device-id :index index :slot slot
+                           :actual (type value)})))
+        (when-not (= (dtype/canon (:dtype slot)) actual-dtype)
+          (throw (ex-info "staged kernel executable pointer has the wrong storage dtype"
+                          {:device-id device-id :index index :slot slot
+                           :expected (dtype/canon (:dtype slot)) :actual actual-dtype})))
+        (let [existing (.get identities value)
+              read? (or (= :input (:kind slot)) (= :inout (:role slot)))
+              write? (or (= :output (:kind slot)) (= :inout (:role slot)))]
+          (if (some? existing)
+            (vswap! groups update existing
+                    (fn [group]
+                      (-> group
+                          (update :indexes conj index)
+                          (update :read? #(or % read?))
+                          (update :write? #(or % write?)))))
+            (let [group-index (count @groups)
+                  key [:staged-executable-pointer group-index]
+                  elements (if array-dtype
+                             (java.lang.reflect.Array/getLength value)
+                             (:n-elements value))]
+              (.put identities value group-index)
+              (vswap! groups conj {:key key :value value :dtype actual-dtype
+                                   :elements elements :resident? resident?
+                                   :indexes [index] :read? read? :write? write?}))))))
+    (let [groups @groups
+          key-by-index (reduce (fn [result {:keys [key indexes]}]
+                                 (reduce #(assoc %1 %2 key) result indexes))
+                               {} groups)]
+      {:groups groups
+       :arguments (mapv (fn [index [slot value]]
+                          (if (= :scalar (:kind slot)) value (get key-by-index index)))
+                        (range) (map vector (kexec/abi executable) typed-arguments))})))
+
+(declare run-kernel-graph!)
+
+(defn invoke-staged-executable!
+  "Execute a registered KernelDispatch through the common KernelExecutable session machinery.
+
+   This is the ordinary compiled-function staging contract: JVM primitive arrays are copied in
+   and ABI-declared writes are copied back; backend DeviceBuffers are borrowed without copying.
+   Every call owns and closes its graph recording and temporary buffers. Long-lived/replayable
+   execution belongs to compile-gpu-program plus LinkPlan, which uses the same executable binder."
+  [device-id dispatch-id runtime-arguments]
+  (let [dispatch-entry (rt-resolve device-id "kernel-dispatch-registry-entry")
+        dispatch (or (dispatch-entry dispatch-id)
+                     (throw (ex-info "staged kernel executable dispatch is not registered"
+                                     {:device-id device-id :dispatch-id dispatch-id})))
+        dispatch (kdispatch/validate! dispatch)
+        common (kdispatch/default-alternative dispatch)
+        typed-arguments (kexec/typed-runtime-arguments common runtime-arguments)
+        executable (kdispatch/select-alternative dispatch typed-arguments)
+        {:keys [groups arguments]} (staged-pointer-plan device-id executable typed-arguments)
+        result-pairs (filterv (fn [[slot _]] (= :result (:role slot)))
+                              (map vector (kexec/abi executable) typed-arguments))]
+    (when (> (count result-pairs) 1)
+      (throw (ex-info "staged kernel executable has more than one primary result"
+                      {:dispatch-id dispatch-id :result-slots (mapv first result-pairs)})))
+    (with-gpu-session* device-id
+      (fn [session]
+        (doseq [{:keys [key value dtype elements resident? read?]} groups]
+          (if resident?
+            (register-buffer! session key value {:ownership :borrowed})
+            (alloc! session {key [dtype elements (when read? value)]})))
+        (let [handle (bind-kernel-executable! session
+                                              [:staged-executable dispatch-id]
+                                              executable arguments)]
+          (run-kernel-graph! session handle)
+          (doseq [{:keys [key value elements resident? write?]} groups
+                  :when (and write? (not resident?))]
+            (download-range! session key value {:elements elements})))
+        (some-> (first result-pairs) second)))))
 
 (defn kernel-graph-execution-plan
   "Return the pure backend-neutral queue/event plan for a bound KernelGraph."

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -511,21 +511,11 @@
 (defn device-buffer? [x]
   (instance? OclBuffer x))
 
-(defn- jvm-array-dtype [x]
-  (cond
-    (instance? (Class/forName "[D") x) :double
-    (instance? (Class/forName "[F") x) :float
-    (instance? (Class/forName "[I") x) :int
-    (instance? (Class/forName "[J") x) :long
-    (instance? (Class/forName "[S") x) :half
-    (instance? (Class/forName "[B") x) :byte
-    :else nil))
-
 (defn- physical-pointer-dtypes [arrays]
   (mapv #(cond
            (device-buffer? %) (:dtype ^OclBuffer %)
            (instance? MemorySegment %) :opaque
-           :else (jvm-array-dtype %))
+           :else (dt/dtype-for-jvm-array %))
         arrays))
 
 (defn expand-pointer-binding

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -37,6 +37,7 @@
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-executable :as kexec]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.gpu.resident-value :as resident-value]))
 
@@ -782,18 +783,6 @@
 (def ^:private dtype-byte-sizes
   {:double 8 :float 4 :float32 4 :int 4 :long 8 :half 2 :float16 2 :byte 1 :int8 1})
 
-(defn- jvm-array-dtype
-  "Canonical storage dtype of a supported JVM primitive array, or nil."
-  [x]
-  (cond
-    (instance? (Class/forName "[D") x) :double
-    (instance? (Class/forName "[F") x) :float
-    (instance? (Class/forName "[I") x) :int
-    (instance? (Class/forName "[J") x) :long
-    (instance? (Class/forName "[S") x) :half
-    (instance? (Class/forName "[B") x) :byte
-    :else nil))
-
 (defn make-buffer
   "Allocate a persistent shared-memory GPU buffer.
   Returns a DeviceBuffer that survives across kernel launches.
@@ -1188,7 +1177,7 @@
               (gpu-soa? arr) (into dtypes (mapv :dtype (:field-segs ^GpuSoA arr)))
               (device-buffer? arr) (conj dtypes (:dtype ^DeviceBuffer arr))
               (instance? MemorySegment arr) (conj dtypes :opaque)
-              :else (conj dtypes (jvm-array-dtype arr))))
+              :else (conj dtypes (dt/dtype-for-jvm-array arr))))
           [] arrays))
 
 (defn expand-pointer-binding
@@ -2011,7 +2000,7 @@
         _ (doseq [[slot value] pairs :when (not= :scalar (:kind slot))]
             (let [actual (if (device-buffer? value)
                            (dt/canon (:dtype ^DeviceBuffer value))
-                           (jvm-array-dtype value))]
+                           (dt/dtype-for-jvm-array value))]
               (when-not actual
                 (throw (ex-info "map kernel ABI pointer value is not a supported buffer/array"
                                 {:kernel-name kernel-name :slot slot :value-type (type value)})))
@@ -2083,7 +2072,7 @@
                               {:kernel-name kernel-name :slot slot})))
             (let [actual (if (device-buffer? value)
                            (dt/canon (:dtype ^DeviceBuffer value))
-                           (jvm-array-dtype value))]
+                           (dt/dtype-for-jvm-array value))]
               (when-not actual
                 (throw (ex-info "reduction ABI pointer value is not a supported buffer/array"
                                 {:kernel-name kernel-name :slot slot :value-type (type value)})))
@@ -3627,13 +3616,7 @@
                             {:kernel-name kernel-name :registered (keys @kernel-registry)})))
         artifact (kart/validate! registered)
         abi (:abi artifact)
-        arguments (kabi/validate-arguments! abi arguments)
-        typed-arguments
-        (mapv (fn [{:keys [kind kernel-dtype]} value]
-                (if (= :scalar kind)
-                  (if (map? value) value {:type kernel-dtype :value value})
-                  value))
-              abi arguments)
+        typed-arguments (kexec/typed-runtime-arguments artifact arguments)
         call (kcall/make artifact typed-arguments)
         out-elems-expr (kart/attribute artifact :out-elems)
         out-elems (long (if (number? out-elems-expr)

--- a/test/raster/compiler/core/dtype_test.clj
+++ b/test/raster/compiler/core/dtype_test.clj
@@ -9,3 +9,11 @@
   (testing "an absent type fact remains absent"
     (is (nil? (dtype/dtype-for-scalar-tag nil)))
     (is (nil? (dtype/dtype-for-array-tag nil)))))
+
+(deftest jvm-array-storage-is-another-canonical-dtype-projection
+  (is (= [:double :float :half :int :long :byte]
+         (mapv dtype/dtype-for-jvm-array
+               [(double-array 0) (float-array 0) (short-array 0)
+                (int-array 0) (long-array 0) (byte-array 0)])))
+  (is (nil? (dtype/dtype-for-jvm-array (object-array 0))))
+  (is (nil? (dtype/dtype-for-jvm-array nil))))

--- a/test/raster/compiler/ir/kernel_dispatch_test.clj
+++ b/test/raster/compiler/ir/kernel_dispatch_test.clj
@@ -224,6 +224,77 @@
     (register! dispatch)
     (is (identical? dispatch (entry (:id dispatch))))))
 
+(deftest staged-executable-normalizes-the-abi-and-uses-the-common-graph-runner
+  (let [graph (staged-graph)
+        graph-dispatch (kdispatch/make
+                        {:id "staged-graph-dispatch"
+                         :alternatives [graph]
+                         :default-strategy :two-stage
+                         :selector {:kind :fixed-strategy :strategy :two-stage}})
+        x (float-array [1.0 2.0 3.0])
+        out (float-array 3)
+        calls (atom [])
+        session (atom {:device-id :probe})]
+    (with-redefs-fn
+      {#'raster.gpu.core/rt-resolve
+       (fn [_ function-name]
+         (case function-name
+           "kernel-dispatch-registry-entry" #(when (= % "staged-graph-dispatch")
+                                                graph-dispatch)
+           "device-buffer?" (constantly false)
+           (throw (ex-info "unexpected runtime resolution" {:function function-name}))))
+       #'gpu/with-gpu-session*
+       (fn [device-id body]
+         (swap! calls conj [:session device-id])
+         (body session))
+       #'gpu/alloc!
+       (fn [_ specs] (swap! calls conj [:alloc specs]))
+       #'gpu/bind-kernel-executable!
+       (fn [_ key executable arguments]
+         (swap! calls conj [:bind key executable arguments])
+         :handle)
+       #'gpu/run-kernel-graph!
+       (fn [_ handle] (swap! calls conj [:run handle]))
+       #'gpu/download-range!
+       (fn [_ key dst spec]
+         (swap! calls conj [:download key dst spec])
+         (dotimes [i (alength ^floats dst)] (aset ^floats dst i (float (inc i))))
+         dst)}
+      (fn []
+        (is (identical? out
+                        (gpu/invoke-staged-executable!
+                         :probe "staged-graph-dispatch" [x out 3])))
+        (is (= [1.0 2.0 3.0] (mapv double out)))
+        (let [[_ _ bound-executable bound-arguments]
+              (first (filter #(= :bind (first %)) @calls))]
+          (is (identical? graph bound-executable))
+          (is (= [:staged-executable-pointer 0] (first bound-arguments)))
+          (is (= [:staged-executable-pointer 1] (second bound-arguments)))
+          (is (= {:type :long :value 3} (nth bound-arguments 2))))
+        (is (= 2 (count (filter #(= :alloc (first %)) @calls))))
+        (is (= 1 (count (filter #(= :download (first %)) @calls))))))))
+
+(deftest staged-executable-preserves-pointer-identity-for-in-place-calls
+  (let [same (float-array 3)
+        calls (atom [])]
+    (with-redefs-fn
+      {#'raster.gpu.core/rt-resolve
+       (fn [_ function-name]
+         (case function-name
+           "kernel-dispatch-registry-entry" (constantly dispatch)
+           "device-buffer?" (constantly false)))
+       #'gpu/with-gpu-session* (fn [_ body] (body (atom {:device-id :probe})))
+       #'gpu/alloc! (fn [_ specs] (swap! calls conj [:alloc specs]))
+       #'gpu/bind-kernel-executable!
+       (fn [_ _ _ arguments] (swap! calls conj [:arguments arguments]) :handle)
+       #'gpu/run-kernel-graph! (fn [_ _])
+       #'gpu/download-range! (fn [_ _ dst _] dst)}
+      (fn []
+        (gpu/invoke-staged-executable! :probe "dispatch-test" [same same 3])
+        (let [arguments (second (first (filter #(= :arguments (first %)) @calls)))]
+          (is (= (first arguments) (second arguments))))
+        (is (= 1 (count (filter #(= :alloc (first %)) @calls))))))))
+
 (deftest resident-step-selects-before-the-backend-binder
   (let [step {:kernel-name (:kernel-name reference)
               :phase :probe

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -207,22 +207,20 @@
         emitted (opencl-pass/opencl-pass scheduled :device-id :ocl:0 :dtype :float)
         dispatch (first (:dispatches emitted))
         executable (kdispatch/default-alternative dispatch)
-        binding-expr (nth (second (:form emitted)) 1)
-        execute (eval (list 'fn '[out x n] (:form emitted)))
-        out (float-array 5)
-        fallback-result (execute out (float-array [1.0 2.0 3.0 4.0 5.0]) 5)]
+        binding-expr (nth (second (:form emitted)) 1)]
     (is (= 1 (get-in emitted [:stats :kernel-graphs])))
-    (is (= 1 (get-in emitted [:stats :graph-staging-fallbacks])))
+    (is (not (contains? (:stats emitted) :graph-staging-fallbacks)))
     (is (= 3 (count (:kernels emitted))))
     (is (= 1 (count (:dispatches emitted))))
     (is (kernel-graph/kernel-graph? executable))
     (is (= executable (kdispatch/select-alternative dispatch [] :scheduled-graph)))
-    (is (= 'raster.compiler.pipeline/invoke-scheduled-executable-fallback
+    (is (= 'raster.compiler.pipeline/invoke-scheduled-executable!
            (first binding-expr)))
-    (is (= (:arguments executable) (nth binding-expr 2)))
-    (is (= (get-in scheduled [:equations 0 :source]) (nth binding-expr 3)))
-    (is (identical? out fallback-result))
-    (is (= [1.0 3.0 6.0 10.0 15.0] (mapv double fallback-result)))))
+    (is (= :ocl:0 (nth binding-expr 1)))
+    (is (= (:id dispatch) (nth binding-expr 2)))
+    (is (= (:arguments executable) (nth binding-expr 3)))
+    (is (= 4 (count binding-expr))
+        "the emitted form carries no duplicate sequential source implementation")))
 
 (deftest typed-inclusive-scan-preserves-exact-sequential-jvm-semantics
   (let [typed (:program (route/attempt inclusive-scan :float

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -111,6 +111,20 @@
                       [0 1 255 256 511 512 1024])))
         (finally (gpu/close-session! session))))))
 
+(deftest ocl-staged-typed-scan-runs-the-same-compiled-graph
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "staged typed scan graph")
+    (let [n 1025
+          execute (pl/compile-aot #'ocl-session-scan
+                                  :target-device :ocl:0 :dtype :float)
+          x (float-array (repeat n 1.0))
+          out (float-array n)
+          result (execute x out n)]
+      (is (identical? out result))
+      (is (= (float n) (aget out (dec n))))
+      (is (every? (fn [i] (= (float (inc i)) (aget out i)))
+                  [0 1 255 256 511 512 1024])))))
+
 (deftest ocl-resident-indexed-row-reduction-roundtrip
   (if-not @device-probe/opencl-available?
     (device-probe/opencl-skip! "indexed row reduction")


### PR DESCRIPTION
## Summary

- replace the TypedSOAC scheduled-graph sequential source fallback with a generic staged KernelExecutable invocation
- use the same KernelDispatch selection, ABI typing, graph binding, temporary ownership, and execution machinery in staged and resident modes
- preserve pointer identity, borrow resident buffers, and stage/copy back JVM arrays according to ABI effects
- centralize JVM primitive-array dtype projection in the canonical dtype table and reuse executable scalar normalization in the Level Zero contraction path
- update the compiler north-star status and add device-free plus live Intel Arc coverage

## Verification

- full suite: 2,496 tests, 35,384 assertions, 0 failures, 0 errors
- GPU suite: Intel Arc available, 0 skips
- OpenCL suite: Intel Arc available, 0 skips
- live staged 1,025-element multi-block TypedSOAC scan through compile-aot
- CUDA and HIP compile gates exercised by the full suite