### PR TITLE
Route GPU sessions through TypedSOAC scheduling

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -93,7 +93,10 @@ ABI semantics. The ordinary per-call compiled function now invokes that same reg
 `KernelDispatch` through a backend-neutral staged `KernelExecutable` runner: its ordered ABI types
 scalars, preserves pointer identity, stages JVM arrays (or borrows resident buffers), owns graph
 temporaries, and copies back only declared writes. No duplicate sequential source implementation
-is embedded in the emitted form. General recurrences and `scan-exclusive` remain outside this
+is embedded in the emitted form. The public GPU-session compiler now crosses the same direct
+TypedSOAC and scheduled SegOp boundary instead of asking the OpenCL emitter to reconstruct generic
+maps and reductions from walked source. Destination-writing maps retain explicit destination,
+alias, effect and return facts. General recurrences and `scan-exclusive` remain outside this
 typed operation and must not borrow its reassociation proof. The remaining parallel forms must
 join the direct front end before the old dependency-graph fallback can be deleted.
 
@@ -809,8 +812,9 @@ The immediate continuation after the verified double-buffered weighted-reduction
    horizontal tuple maps, typed scalar/shape equations, stable tensor captures, and resident
    reduction results and certified inclusive scan now share the direct
    analyzed-source→TypedSOAC→SegOp production route. Inclusive scan additionally reaches an emitted
-   graph-backed resident executable through ordinary dispatch, LinkPlan and binding. A generic
-   per-call staging graph runner, hardware-costed multi-consumer fusion, nested-region JVM
+   graph-backed resident executable through ordinary dispatch, LinkPlan and binding, and a generic
+   per-call staging graph runner executes the same registered dispatch. Hardware-costed
+   multi-consumer fusion, nested-region JVM
    scheduling, the remaining parallel forms (including distinct exclusive-scan semantics), and
    deletion of the remaining graph/backend fallbacks remain.
 6. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -97,10 +97,12 @@
     (let [{:keys [out idx bound cast body elem-type offset]}
           (par/extract-par-map-info expression)]
       ;; Offset maps are not pointwise in the result coordinate and require an indexed/scatter
-      ;; operation in the typed dialect.  Never silently describe one as an ordinary map.
-      (when-not offset
+      ;; operation in the typed dialect. A binder with the same spelling as the caller-owned
+      ;; destination also needs distinct value/view identity before it can be SSA. Never silently
+      ;; describe either form as an ordinary functional result.
+      (when-not (or offset (= symbol out))
         (merge {:kind :map :id id :sym symbol :index idx :extent bound :cast cast :body body
-                :elem-type elem-type}
+                :primary-out out :destination-return :buffer :elem-type elem-type}
                (extract-io body idx [out]))))
 
     (par/par-reduce-form? expression)
@@ -221,7 +223,7 @@
                 :scalar (or (provably-pure-scalar? (:expr description))
                             (generated-scaffolding? description physical-outputs))
                 :map (or (:pure? description)
-                         (and (:void? description) (symbol? (:primary-out description))))
+                         (symbol? (:primary-out description)))
                 :reduce true
                 :scan (symbol? (:primary-out description))
                 false))
@@ -248,11 +250,11 @@
 
 (defn- map-equation
   [description]
-  (let [{:keys [id sym index extent cast body inputs primary-out void?]} description
+  (let [{:keys [id sym index extent cast body inputs primary-out]} description
         expression (if cast (list cast body) body)
         [pointwise stable] ((juxt filter remove) #(pointwise-input? [expression] % index) inputs)
         arrays (vec (sort-by pr-str pointwise))
-        stable (cond-> (set stable) void? (conj primary-out))
+        stable (cond-> (set stable) primary-out (conj primary-out))
         captures (vec (sort-by pr-str (distinct (concat stable (:scalars description)))))
         parameters (element-symbols (count arrays))
         capture-parameters (capture-symbols (count captures))
@@ -420,10 +422,17 @@
 (defn- merge-value
   [values id contract]
   (if-let [prior (get values id)]
-    (if (= prior contract) values
+    (let [unknown-shape? (fn [value]
+                           (= [(list 'unknown-dimension id)] (:shape value)))
+          same-nonshape-contract? (= (dissoc prior :shape) (dissoc contract :shape))]
+      (cond
+        (= prior contract) values
+        (and same-nonshape-contract? (unknown-shape? prior)) (assoc values id contract)
+        (and same-nonshape-contract? (unknown-shape? contract)) values
+        :else
         (fail! :source-value-conflict
                "source bindings imply incompatible AbstractValues for one logical value"
-               {:id id :first prior :second contract}))
+               {:id id :first prior :second contract})))
     (assoc values id contract)))
 
 (defn form->program
@@ -489,7 +498,7 @@
               equation-facts
               (into {}
                     (map (fn [description]
-                           (let [destination (when (or (:void? description)
+                           (let [destination (when (or (:primary-out description)
                                                        (= :scan (:kind description)))
                                                (:primary-out description))]
                              [(:id description)
@@ -499,7 +508,10 @@
                                 destination
                                 (assoc :effects #{:memory/write}
                                        :aliases {(:sym description) destination}
-                                       :attributes {:destination destination}))]))
+                                       :attributes (cond-> {:destination destination}
+                                                     (:destination-return description)
+                                                     (assoc :destination-return
+                                                            (:destination-return description)))))]))
                          equation-descriptions))
               total-effects (reduce set/union #{} (map :effects (vals equation-facts)))
               facts (dialect/default-program-facts

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -95,15 +95,18 @@
 
     (par/par-map-form? expression)
     (let [{:keys [out idx bound cast body elem-type offset]}
-          (par/extract-par-map-info expression)]
+          (par/extract-par-map-info expression)
+          io (extract-io body idx [out])]
       ;; Offset maps are not pointwise in the result coordinate and require an indexed/scatter
       ;; operation in the typed dialect. A binder with the same spelling as the caller-owned
-      ;; destination also needs distinct value/view identity before it can be SSA. Never silently
-      ;; describe either form as an ordinary functional result.
-      (when-not (or offset (= symbol out))
+      ;; destination also needs distinct value/view identity before it can be SSA. Reading and
+      ;; writing the same destination likewise needs one explicit inout operand, which the current
+      ;; map dialect cannot yet express without duplicating the physical pointer in the kernel ABI.
+      ;; Keep all three forms on the compatibility route rather than inventing false alias facts.
+      (when-not (or offset (= symbol out) (contains? (:inputs io) out))
         (merge {:kind :map :id id :sym symbol :index idx :extent bound :cast cast :body body
                 :primary-out out :destination-return :buffer :elem-type elem-type}
-               (extract-io body idx [out]))))
+               io)))
 
     (par/par-reduce-form? expression)
     (let [{:keys [acc init idx bound body elem-type]} (par/extract-par-reduce-info expression)
@@ -250,11 +253,14 @@
 
 (defn- map-equation
   [description]
-  (let [{:keys [id sym index extent cast body inputs primary-out]} description
+  (let [{:keys [id sym index extent cast body inputs primary-out void?]} description
         expression (if cast (list cast body) body)
         [pointwise stable] ((juxt filter remove) #(pointwise-input? [expression] % index) inputs)
         arrays (vec (sort-by pr-str pointwise))
-        stable (cond-> (set stable) primary-out (conj primary-out))
+        ;; map-void's destination remains a lexical stable capture in the existing dialect.
+        ;; A destination-returning map carries its write-only destination in equation facts; making
+        ;; it a capture would also make it a kernel input and duplicate the output pointer.
+        stable (cond-> (set stable) void? (conj primary-out))
         captures (vec (sort-by pr-str (distinct (concat stable (:scalars description)))))
         parameters (element-symbols (count arrays))
         capture-parameters (capture-symbols (count captures))
@@ -489,11 +495,20 @@
                                          (and (:extent %) (dialect/value-id? (:extent %)))
                                          (conj (:extent %))) equation-info))
               inputs (vec (sort-by pr-str (set/difference references definitions)))
+              destination-values
+              (into {}
+                    (keep (fn [description]
+                            (when-let [destination (:primary-out description)]
+                              [destination
+                               (tensor-value
+                                (value-dtype destination dtype array-types)
+                                [(list 'unknown-dimension destination)])])))
+                    equation-descriptions)
               inferred-values (reduce (fn [contracts equation]
                                         (reduce-kv merge-value contracts
                                                    (equation-values equation dtype array-types
                                                                     contracts)))
-                                      {} equations)
+                                      destination-values equations)
               values (reduce-kv merge-value inferred-values values)
               equation-facts
               (into {}

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -112,12 +112,17 @@
               body (if (seq secondary-stores)
                      (list* 'do (concat secondary-stores [(first bodies)]))
                      (first bodies))
+              destination-return (get-in placement-facts
+                                         [:attributes :destination-return])
               effect (gensym (str "typed_soac_map_" equation-id "__"))
               source (with-meta
                        (if destination
-                         (list 'raster.par/map-void! (:index attributes) (:extent attributes)
-                               (list 'clojure.core/aset destination (:index attributes)
-                                     (list cast body)))
+                         (if (= :buffer destination-return)
+                           (list 'raster.par/map! destination (:index attributes)
+                                 (:extent attributes) cast body)
+                           (list 'raster.par/map-void! (:index attributes) (:extent attributes)
+                                 (list 'clojure.core/aset destination (:index attributes)
+                                       (list cast body))))
                          (list 'raster.par/map! result (:index attributes) (:extent attributes)
                                cast body))
                        {:raster.type/elem-type (first result-dtypes)})]
@@ -236,12 +241,13 @@
    (attempt form dtype {}))
   ([form dtype array-types]
    (attempt form dtype array-types {}))
-  ([form dtype array-types {:keys [resident-reductions?]
+  ([form dtype array-types {:keys [resident-reductions? scalar-types values]
                             :or {resident-reductions? false}}]
    (when (and (seq? form) (contains? #{'let 'let*} (first form)))
      (try
        (when-let [typed-input (frontend/form->program
-                               form {:dtype dtype :array-types array-types})]
+                               form {:dtype dtype :array-types array-types
+                                     :scalar-types scalar-types :values values})]
          (let [[typed-result typed-stats] (fusion/fusion-fixpoint typed-input)
                [typed-result resident-stats]
                (if resident-reductions?

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -185,14 +185,30 @@
 (defn- realize-source
   [form program]
   (let [[let-head bindings & body] form
+        original-pairs (vec (partition 2 bindings))
         realized (mapv #(realize-equation program %) (dialect/equations program))
         by-placement (group-by :placement realized)
+        physical-destinations
+        (into #{}
+              (keep (fn [[_ equation-facts]]
+                      (get-in equation-facts [:attributes :destination])))
+              (:equations (dialect/facts program)))
         pairs
         (vec
          (mapcat
           (fn [id]
-            (mapcat :pairs (get by-placement id)))
-          (range (count (partition 2 bindings)))))
+            (let [[symbol :as original-pair] (nth original-pairs id)]
+              (concat
+               ;; A destination may be a caller-owned input or a locally allocated buffer. The
+               ;; typed algorithm records the physical write boundary but does not own host-side
+               ;; allocation. Preserve a defining source binding when one exists; dropping it
+               ;; leaves CPU-C/JVM materialization with an unbound destination and also loses a
+               ;; resident scratch allocation before GPU extraction.
+               (when (and (contains? physical-destinations symbol)
+                          (empty? (get by-placement id)))
+                 [original-pair])
+               (mapcat :pairs (get by-placement id)))))
+          (range (count original-pairs))))
         source (with-meta (list* let-head (vec (mapcat identity pairs)) body) (meta form))]
     {:source source :realized (into {} (map (juxt :equation-id identity)) realized)}))
 

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -763,7 +763,8 @@
   (if (form/binding-form? form)
     (let [typed (typed-soac-route/attempt
                  form (:dtype opts) (:array-types opts)
-                 {:resident-reductions? (true? (:resident-reductions? opts))})]
+                 {:resident-reductions? (true? (:resident-reductions? opts))
+                  :scalar-types (:scalar-types opts)})]
       (if (:program typed)
         {:form (:program typed) :stats (:stats typed)}
         (let [am (when (device/gpu-target? (:target-device opts))
@@ -1022,6 +1023,45 @@
                 (validate-dialect! to f' pass-key opts)
                 [f' to]))
             [form start-dialect] passes))))
+
+(defn- top-level-binding-form
+  [source]
+  (cond
+    (form/binding-form? source)
+    source
+
+    (and (seq? source) (= 'do (first source)) (seq (rest source)))
+    (let [pairs (mapv (fn [expression]
+                        [(gensym "parallel_step_") expression])
+                      (rest source))]
+      (with-meta (list 'let* (vec (mapcat identity pairs)) (ffirst (rseq pairs)))
+        (meta source)))
+
+    :else
+    (let [result (gensym "parallel_result_")]
+      (with-meta (list 'let* [result source] result) (meta source)))))
+
+(defn schedule-parallel-form
+  "Construct the same TypedSOAC/SegOp boundary used by the ordinary compiler for an already
+   walked form whose caller needs scheduled kernels rather than a compiled host function.
+
+   GPU sessions use this entry to compile a `deftm`'s kernels without bypassing the functional
+   middle end. A top-level expression is given an explicit result binder so the analyzed-source
+   frontend sees the same ordered program shape as `compile-aot`. Unsupported parallel forms stay
+   in the counted compatibility `ParallelProgram`; supported map/reduce/scan forms retain their
+   validated TypedSOAC algorithm and are scheduled exactly once before backend emission."
+  [source {:keys [dtype array-types scalar-types target-device] :as opts}]
+  (let [source (top-level-binding-form source)
+        typed (typed-soac-route/attempt source dtype array-types
+                                        {:scalar-types scalar-types})
+        semantic (or (:program typed) source)
+        scheduled (segop-lower/segop-lower-pass
+                   semantic (assoc opts :dtype dtype :target-device target-device))]
+    (update scheduled :stats merge
+            (cond-> {:parallel-scheduling :shared}
+              (:program typed) (assoc :source-dialect :typed-soac
+                                      :typed-soac (:stats typed))
+              (:declined typed) (assoc :typed-soac-declined (:declined typed))))))
 
 ;; ================================================================
 ;; Mode configurations (declarative pass vectors)

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -134,9 +134,14 @@
                    f (if (seq scalar-types) (vary-meta f assoc :scalar-types scalar-types) f)
                    f (if (seq array-types)  (vary-meta f assoc :array-types array-types) f)]
                f)
+        scheduled (:form (pl/schedule-parallel-form
+                          form {:target-device device-id
+                                :dtype dtype
+                                :array-types array-types
+                                :scalar-types scalar-types}))
         par-opencl opencl-pass/opencl-pass
         register!  (rt-resolve device-id "register-kernel!")
-        result (par-opencl form
+        result (par-opencl scheduled
                            :device-id device-id
                            :dtype dtype
                            :min-elements min-elements)]

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -64,9 +64,32 @@
       (is false "an uncertified recurrence must decline")
       (catch clojure.lang.ExceptionInfo exception
         (is (= :scan-not-associative (:reason (ex-data exception)))))))
-  (testing "imperative map output identity is not disguised as a functional result"
+  (testing "destination-writing map identity and effects are explicit compiler facts"
+    (let [program (frontend/form->program
+                   '(let* [step (raster.par/map! target i n float
+                                                 (+ (clojure.core/aget x i) 1.0))]
+                          step)
+                   {:dtype :float :array-types {'x :float 'target :float}})
+          facts (dialect/facts program)]
+      (is (= 'map (dialect/operation-kind (first (dialect/equations program)))))
+      (is (= '{step target} (get-in facts [:equations 0 :aliases])))
+      (is (= :buffer (get-in facts [:equations 0 :attributes :destination-return])))
+      (is (= #{:memory/write} (:effects facts)))))
+  (testing "a source binder and destination still require distinct SSA identities"
     (is (nil? (frontend/form->program
-               '(let* [step (raster.par/map! target i n float
-                                             (+ (clojure.core/aget x i) 1.0))]
-                      step)
+               '(let* [target (raster.par/map! target i n float
+                                               (+ (clojure.core/aget x i) 1.0))]
+                      target)
                {:dtype :float :array-types {'x :float 'target :float}})))))
+
+(deftest destination-shapes-refine-across-ordered-maps
+  (let [program (frontend/form->program
+                 '(let* [first-step (raster.par/map! first-out i n float
+                                                     (+ (clojure.core/aget x i) 1.0))
+                         second-step (raster.par/map! second-out j n float
+                                                      (* (clojure.core/aget first-out j) 2.0))]
+                        second-step)
+                 {:dtype :float
+                  :array-types {'x :float 'first-out :float 'second-out :float}})]
+    (is (= '[n] (get-in (dialect/facts program) [:values 'first-out :shape])))
+    (is (= 2 (count (dialect/equations program))))))

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -72,15 +72,25 @@
                    {:dtype :float :array-types {'x :float 'target :float}})
           facts (dialect/facts program)]
       (is (= 'map (dialect/operation-kind (first (dialect/equations program)))))
+      (is (= '[x] (dialect/operation-inputs (first (dialect/equations program))))
+          "a write-only destination is not duplicated as a semantic read operand")
       (is (= '{step target} (get-in facts [:equations 0 :aliases])))
       (is (= :buffer (get-in facts [:equations 0 :attributes :destination-return])))
+      (is (some? (get-in facts [:values 'target]))
+          "the physical output boundary retains its own value contract")
       (is (= #{:memory/write} (:effects facts)))))
   (testing "a source binder and destination still require distinct SSA identities"
     (is (nil? (frontend/form->program
                '(let* [target (raster.par/map! target i n float
                                                (+ (clojure.core/aget x i) 1.0))]
                       target)
-               {:dtype :float :array-types {'x :float 'target :float}})))))
+               {:dtype :float :array-types {'x :float 'target :float}}))))
+  (testing "a read/write destination waits for an explicit single-slot inout role"
+    (is (nil? (frontend/form->program
+               '(let* [step (raster.par/map! target i n float
+                                             (+ (clojure.core/aget target i) 1.0))]
+                      step)
+               {:dtype :float :array-types {'target :float}})))))
 
 (deftest destination-shapes-refine-across-ordered-maps
   (let [program (frontend/form->program

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -75,6 +75,18 @@
                    (tree-seq coll? seq (:source form))))
         "top-level do is an ordered binding spine before semantic analysis")))
 
+(deftest local-destination-allocation-survives-typed-materialization
+  (let [source '(let* [target (clojure.core/float-array n)
+                       step (raster.par/map! target i n float
+                                             (+ (clojure.core/aget x i) 1.0))]
+                      step)
+        {:keys [program stats]} (route/attempt source :float {'x :float 'target :float})
+        materialized-bindings (apply hash-map (second (:source program)))]
+    (is (= :typed-soac (:route stats)))
+    (is (= '(clojure.core/float-array n) (get materialized-bindings 'target))
+        "the typed algorithm owns the write boundary, not host-side buffer allocation")
+    (is (= 'raster.par/map! (first (get materialized-bindings 'step))))))
+
 (deftest pure-vertical-fusion-becomes-a-first-class-typed-program
   (let [{:keys [program stats]} (route/attempt map-map :float)
         equation (first (:equations program))]

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -33,6 +33,48 @@
                                   (+ acc (clojure.core/aget x i)))]
          result))
 
+(deftest gpu-session-scheduling-enters-the-shared-typed-boundary
+  (let [source '(raster.par/map! target i n float
+                                 (+ (clojure.core/aget x i) 1.0))
+        {:keys [form stats]}
+        (pipeline/schedule-parallel-form
+         source {:target-device :ocl:0 :dtype :float
+                 :array-types {'x :float 'target :float}})
+        equation (first (:equations form))
+        emitted (opencl-pass/opencl-pass form :device-id :ocl:0
+                                         :dtype :float :min-elements 0)
+        realized-expression (-> form :source second second)]
+    (testing "the top-level session expression has a typed algorithm and explicit destination"
+      (is (= :segop (:dialect form)))
+      (is (= :typed-soac (get-in form [:provenance :source-dialect])))
+      (is (= :typed-soac (:source-dialect stats)))
+      (is (= :typed-soac (get-in equation [:attributes :algorithm-dialect])))
+      (is (= 'target (get-in equation [:attributes :destination])))
+      (is (= :buffer (get-in equation [:attributes :destination-return])))
+      (is (= 'raster.par/map! (first realized-expression))
+          "materialization preserves map!'s destination-returning semantics"))
+    (testing "the emitter consumes the scheduled SegMap instead of reconstructing source"
+      (is (= 1 (get-in emitted [:stats :segop-reused])))
+      (is (nil? (get-in emitted [:stats :segop-relowered])))
+      (is (= 1 (get-in emitted [:stats :ze-maps]))))))
+
+(deftest gpu-session-scheduling-exposes-each-top-level-do-step
+  (let [{:keys [form stats]}
+        (pipeline/schedule-parallel-form
+         '(do (raster.par/map! first-out i n float
+                               (+ (clojure.core/aget x i) 1.0))
+              (raster.par/map! second-out j n float
+                               (* (clojure.core/aget first-out j) 2.0)))
+         {:target-device :ocl:0 :dtype :float
+          :array-types {'x :float 'first-out :float 'second-out :float}})]
+    (is (= :typed-soac (:source-dialect stats)))
+    (is (= :typed-soac (get-in form [:provenance :source-dialect])))
+    (is (every? #(= :typed-soac (get-in % [:attributes :algorithm-dialect]))
+                (:equations form)))
+    (is (not (some #(and (seq? %) (= 'do (first %)))
+                   (tree-seq coll? seq (:source form))))
+        "top-level do is an ordered binding spine before semantic analysis")))
+
 (deftest pure-vertical-fusion-becomes-a-first-class-typed-program
   (let [{:keys [program stats]} (route/attempt map-map :float)
         equation (first (:equations program))]


### PR DESCRIPTION
## Summary
- route the public GPU-session compiler through the same TypedSOAC to SegOp scheduling boundary as ordinary compilation
- represent destination-writing map aliases, effects, return semantics, and safe unknown-shape refinement explicitly
- normalize top-level session expressions and ordered do bodies before semantic analysis
- pass retained scalar type facts into the direct TypedSOAC frontend
- update the compiler north-star status

## Validation
- 23 focused TypedSOAC tests, 160 assertions: green
- SegOp boundary/pipeline/walked-body tests: 18 tests, 79 assertions: green
- real Intel Arc OpenCL session suite: 10 tests, 18 assertions: green
- diff check: clean
- full host-access suite advanced through ABM GPU/cache, AD, CPU AOT, CUDA compile, DP4A/DPAS, and into GEMM tests without a failure, then the host process disappeared under system memory pressure; CI is the authoritative full-suite/vendor gate for this PR

## Follow-up
Once this public bypass is removed, the next convergence slice can make direct generic OpenCL emission scheduled-only and delete its legacy map/reduce re-lowering path.