### PR TITLE
Represent TypedSOAC map destinations as inout

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -100,6 +100,14 @@ alias, effect and return facts. General recurrences and `scan-exclusive` remain 
 typed operation and must not borrow its reassociation proof. The remaining parallel forms must
 join the direct front end before the old dependency-graph fallback can be deleted.
 
+Pointwise maps that read and write their caller-owned destination stay on this same route. The
+typed equation records read/write destination access, and GPU lowering emits that storage exactly
+once as a `KernelABI` `:inout` pointer with semantic role `:result`. Physical access and functional
+identity are therefore orthogonal: resident and staged binders derive transfers from ABI kind,
+while composition identifies the returned value by role. OpenCL and Level Zero staged maps also
+use target-specific invocation markers selected by the emitter, rather than leaking a Level Zero
+runtime call into an OpenCL program.
+
 The first architectural correction is therefore:
 
 > SOAC, scheduled kernel graph, and kernel IR must be first-class program values,
@@ -813,7 +821,9 @@ The immediate continuation after the verified double-buffered weighted-reduction
    reduction results and certified inclusive scan now share the direct
    analyzed-source→TypedSOAC→SegOp production route. Inclusive scan additionally reaches an emitted
    graph-backed resident executable through ordinary dispatch, LinkPlan and binding, and a generic
-   per-call staging graph runner executes the same registered dispatch. Hardware-costed
+   per-call staging graph runner executes the same registered dispatch. Pointwise read/write map
+   destinations lower to one physical `:inout` ABI result and execute through both resident and
+   staged binding without an aliased compatibility input. Hardware-costed
    multi-consumer fusion, nested-region JVM
    scheduling, the remaining parallel forms (including distinct exclusive-scan semantics), and
    deletion of the remaining graph/backend fallbacks remain.

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -38,6 +38,9 @@
 (descriptor/register-op-descriptor!
  'raster.gpu.ze-runtime/invoke-registered-kernel
  {:buffer {:allocates? false :in-place-arg 2}})
+(descriptor/register-op-descriptor!
+ 'raster.gpu.ocl-runtime/invoke-registered-kernel
+ {:buffer {:allocates? false :in-place-arg 2}})
 
 ;; ================================================================
 ;; Single source of declared GPU param types (shared by BOTH compile entries:
@@ -197,8 +200,9 @@
     descriptor))
 
 (defn- emit-map-invocation
-  "Render the compatibility map marker from the emitter-authored ABI and ordered values."
-  [{:keys [kernel-name abi arguments]}]
+  "Render the target-specific compatibility map marker from the emitter-authored ABI and ordered
+   values."
+  [{:keys [kernel-name abi arguments]} device-id]
   (let [arguments (kabi/validate-arguments! abi arguments)
         pairs (mapv vector abi arguments)
         result-pairs (filterv #(= :result (:role (first %))) pairs)
@@ -221,7 +225,9 @@
                                   (and (= :scalar (:kind slot))
                                        (not= :bound (:role slot))))
                                 pairs))]
-      (list 'raster.gpu.ze-runtime/invoke-registered-kernel
+      (list (if (and device-id (.startsWith (name device-id) "ocl"))
+              'raster.gpu.ocl-runtime/invoke-registered-kernel
+              'raster.gpu.ze-runtime/invoke-registered-kernel)
             kernel-name inputs out scalars bound))))
 
 (defn- emit-reduction-invocation
@@ -422,7 +428,7 @@
                               :dtype dtype :scalar-types top-scalar-types
                               :array-types (merge top-array-types (:array-types (meta form))))
                       k (register-kernel! kernel :ze-maps)]
-                  (emit-map-invocation k))))
+                  (emit-map-invocation k device-id))))
 
             ;; === par/contract — tensor contraction, routed through the DPAS legality gate ===
             ;; The routing brain (contract-route) chooses the hardware-optimal kernel: DPAS/XMX

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -82,9 +82,20 @@
         ;; positional arg order matches the C signature); an input that is also
         ;; written (read+write buffer) likewise loses const.
         written (set (map #(symbol (name %)) (:outputs segmap)))
-        input-params (vec (sort-by name (:inputs segmap)))
-        input-name-set (set (map #(symbol (name %)) input-params))
         out-name (when out-sym (symbol (name out-sym)))
+        all-input-params (vec (sort-by name (:inputs segmap)))
+        input-name-set (set (map #(symbol (name %)) all-input-params))
+        primary-inout? (contains? input-name-set out-name)
+        ;; The mapped result may also be read pointwise. Keep that physical value in the dedicated
+        ;; result position and rewrite its scalar-region reads to the emitted `out` parameter;
+        ;; passing it once as an input and again as the result violates both ABI identity and C
+        ;; restrict aliasing.
+        input-params (if primary-inout?
+                       (filterv #(not= out-name (symbol (name %))) all-input-params)
+                       all-input-params)
+        result-c-name (if primary-inout? "inout_result" "out")
+        result-symbol (symbol result-c-name)
+        body (if primary-inout? (util/subst-syms {out-sym result-symbol} body) body)
         extra-outs (vec (sort-by name
                                  (remove #(or (= % out-name)
                                               (contains? input-name-set %))
@@ -107,20 +118,21 @@
         scl-param-str (str/join ", "
                                 (map (fn [s] (str (scl-type s) " " (ce/c-symbol s)))
                                      scl-params))
-        out-param (str "__global " out-ctype "* restrict out")
+        out-param (str "__global " out-ctype "* restrict " result-c-name)
         all-params (str/join ", "
                              (remove empty?
                                      [arr-param-str out-param scl-param-str "int _n_bound"]))
         ;; Emit body as C expression
         adapted-body (ce/adapt-casts-for-dtype body out-dtype)
-        arr-sym-set (set (map #(symbol (name %)) arr-params))
+        arr-sym-set (cond-> (set (map #(symbol (name %)) arr-params))
+                      primary-inout? (conj result-symbol))
         body-str (binding [ce/*emit-config* ce/opencl-config
                            ce/*scalar-type* out-ctype
                            ce/*idx-sym* idx
                            ce/*int-vars* (into ce/*int-vars* int-scalar-syms)]
                    (ce/emit-expr adapted-body idx arr-sym-set))
         cast-str (if cast-fn (str "(" (name cast-fn) ")(" body-str ")") body-str)
-        scalar-body-str (str "out[idx] = " cast-str ";")
+        scalar-body-str (str result-c-name "[idx] = " cast-str ";")
         ;; Affine-index vectorization (shared c_emit): a SegMap store is `out[idx] = f(..)`,
         ;; expressed here as the synthetic aset the vectorizer analyzes. The store target
         ;; is the literal `out` param (not c-symbol-mangled), so pass :store-name. nil ⇒
@@ -130,9 +142,10 @@
                               ce/*idx-sym* idx
                               ce/*int-vars* (into ce/*int-vars* int-scalar-syms)]
                       (ce/emit-vectorized-elementwise-loop
-                       (list 'aset 'out idx (if cast-fn (list cast-fn adapted-body) adapted-body))
-                       idx (conj arr-sym-set 'out) "idx" scalar-body-str
-                       {:n-bound "_n_bound" :store-name "out"}))
+                       (list 'aset result-symbol idx
+                             (if cast-fn (list cast-fn adapted-body) adapted-body))
+                       idx (conj arr-sym-set result-symbol) "idx" scalar-body-str
+                       {:n-bound "_n_bound" :store-name result-c-name}))
         ;; pragmas cover the output dtype AND every input array's dtype
         scalar-dtype (fn [s]
                        (case (scl-type s)
@@ -146,13 +159,16 @@
                           (let [written? (contains? written (symbol (name s)))
                                 extra-output? (and written? (not (contains? input-name-set
                                                                             (symbol (name s)))))]
-                            (kabi/slot s (if extra-output? :output :input) (arr-dtype s)
+                            (kabi/slot s (cond extra-output? :output
+                                               written? :inout
+                                               :else :input)
+                                       (arr-dtype s)
                                        :c-name (ce/c-symbol s)
-                                       :role (cond extra-output? :secondary-result
-                                                   written? :inout
+                                       :role (cond written? :secondary-result
                                                    :else :operand))))
                         arr-params)
-                   [(kabi/slot out-sym :output out-dtype :c-name "out" :role :result)]
+                   [(kabi/slot out-sym (if primary-inout? :inout :output) out-dtype
+                               :c-name result-c-name :role :result)]
                    (map #(kabi/slot % :scalar (scalar-dtype %)
                                     :c-name (ce/c-symbol %) :role :parameter)
                         scl-params)
@@ -735,12 +751,15 @@
                 (mapv (fn [{:keys [buffer access]}]
                         (let [spec (get buffers buffer)
                               output? (contains? #{:write :read-write} access)]
-                          (kabi/slot buffer (if output? :output :input) (:dtype spec)
+                          (kabi/slot buffer (case access
+                                              :read :input
+                                              :write :output
+                                              :read-write :inout)
+                                     (:dtype spec)
                                      :c-name (ce/c-symbol buffer)
                                      :role (cond
                                              (contains? temporary-ids buffer) :temporary
                                              (and output? (contains? output-ids buffer)) :result
-                                             (= :read-write access) :inout
                                              :else :operand))))
                       uses)
                 scalar-slots (mapv #(kabi/slot % :scalar (scalar-dtype %)

--- a/src/raster/compiler/ir/kernel_abi.clj
+++ b/src/raster/compiler/ir/kernel_abi.clj
@@ -8,7 +8,7 @@
   (:require [clojure.string :as str]
             [raster.compiler.core.dtype :as dt]))
 
-(def ^:private kinds #{:input :output :scalar})
+(def ^:private kinds #{:input :output :inout :scalar})
 
 (defn slot
   "Construct one ABI slot. Options: :c-name, :kernel-dtype, :role, :binding, :field, and
@@ -33,8 +33,32 @@
     aliasing (assoc :aliasing aliasing)
     alignment (assoc :alignment alignment)))
 
+(defn slot-access
+  "Return the physical memory access declared by one ABI slot.
+
+   `:kind` owns access; `:role` owns semantic identity such as `:result` or `:temporary`.
+   The role-derived `:inout` case remains readable for already-emitted artifacts while new ABIs
+   use the unambiguous `:kind :inout` spelling."
+  [{:keys [kind role]}]
+  (cond
+    (= :scalar kind) nil
+    (or (= :inout kind) (= :inout role)) :read-write
+    (= :input kind) :read
+    (= :output kind) :write
+    :else nil))
+
+(defn readable?
+  "Whether an ABI slot may read its bound pointer."
+  [slot]
+  (contains? #{:read :read-write} (slot-access slot)))
+
+(defn writable?
+  "Whether an ABI slot may write its bound pointer."
+  [slot]
+  (contains? #{:write :read-write} (slot-access slot)))
+
 (defn validate!
-  "Validate an ordered ABI and return it unchanged.  A kernel has at least one output;
+  "Validate an ordered ABI and return it unchanged. A kernel has at least one writable pointer;
    multi-output maps represent every independently written result in signature order."
   [abi]
   (when-not (vector? abi)
@@ -87,8 +111,8 @@
                                 (count (distinct (map :field bound-slots)))))))
           (throw (ex-info "composite ABI slots require unique explicit field identities"
                           {:binding binding :slots bound-slots :abi abi})))))
-    (when-not (some #(= :output (:kind %)) abi)
-      (throw (ex-info "kernel ABI must contain at least one output" {:abi abi})))
+    (when-not (some writable? abi)
+      (throw (ex-info "kernel ABI must contain at least one writable pointer" {:abi abi})))
     abi))
 
 (defn pointer-slots
@@ -153,7 +177,7 @@
         pairs (mapv vector abi arguments)
         stable-inputs (filterv (fn [[slot _]]
                                  (= :no-write-alias (:aliasing slot))) pairs)
-        outputs (filterv (fn [[slot _]] (= :output (:kind slot))) pairs)]
+        outputs (filterv (fn [[slot _]] (writable? slot)) pairs)]
     (doseq [[input-slot input] stable-inputs
             [output-slot output] outputs
             :when (overlaps? input output)]
@@ -220,8 +244,8 @@
     (when-not (= 1 (count result-pairs))
       (throw (ex-info "reduction ABI must identify exactly one :result slot"
                       {:abi abi :result-slots (mapv first result-pairs)})))
-    (when-not (= :output (:kind (ffirst result-pairs)))
-      (throw (ex-info "reduction ABI :result slot must be an output pointer"
+    (when-not (writable? (ffirst result-pairs))
+      (throw (ex-info "reduction ABI :result slot must be writable"
                       {:abi abi :result-slot (ffirst result-pairs)})))
     (when-not (= 1 (count bound-pairs))
       (throw (ex-info "reduction ABI must identify exactly one :bound slot"

--- a/src/raster/compiler/ir/link_plan.clj
+++ b/src/raster/compiler/ir/link_plan.clj
@@ -350,13 +350,6 @@
                       {:reason :link-step-interface :phase (:phase step)
                        :convention (:convention step)}))))
 
-(defn- slot-access [{:keys [kind role]}]
-  (cond
-    (= :inout role) :read-write
-    (= :input kind) :read
-    (= :output kind) :write
-    :else nil))
-
 (defn- merge-access [left right]
   (if (= left right) left
       (if (or (= :read-write left) (= :read-write right)
@@ -432,7 +425,7 @@
                                                   :expected (:dtype slot)
                                                   :actual (get-in link-node [:view :dtype])})))
                                {:symbol sym :value value-id :node node
-                                :field name :access (slot-access slot)}))
+                                :field name :access (kabi/slot-access slot)}))
                            slots leaves)]
                       {:symbol sym :value value-id :slots slots :leaves leaves
                        :facts leaf-facts})))

--- a/src/raster/compiler/ir/program_stage.clj
+++ b/src/raster/compiler/ir/program_stage.clj
@@ -28,14 +28,6 @@
                     {:reason :program-stage-descriptor :descriptor descriptor})))
   descriptor)
 
-(defn- slot-access
-  [{:keys [kind role]}]
-  (cond
-    (= :inout role) :read-write
-    (= :input kind) :read
-    (= :output kind) :write
-    :else nil))
-
 (defn- merge-access
   [left right]
   (cond
@@ -87,7 +79,7 @@
                          :symbols symbols})))
       (reduce (fn [accesses [symbol {:keys [binding slots]}]]
                 (let [access (reduce merge-access nil
-                                     (map slot-access slots))]
+                                     (map kabi/slot-access slots))]
                   (when-not access
                     (throw (ex-info "program stage ABI pointer has no readable or writable effect"
                                     {:reason :program-stage-access :phase (:phase step)

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -99,13 +99,14 @@
           io (extract-io body idx [out])]
       ;; Offset maps are not pointwise in the result coordinate and require an indexed/scatter
       ;; operation in the typed dialect. A binder with the same spelling as the caller-owned
-      ;; destination also needs distinct value/view identity before it can be SSA. Reading and
-      ;; writing the same destination likewise needs one explicit inout operand, which the current
-      ;; map dialect cannot yet express without duplicating the physical pointer in the kernel ABI.
-      ;; Keep all three forms on the compatibility route rather than inventing false alias facts.
-      (when-not (or offset (= symbol out) (contains? (:inputs io) out))
+      ;; destination also needs distinct value/view identity before it can be SSA. A pointwise read
+      ;; of the destination is an explicit read/write operand; scheduling must retain it as one
+      ;; physical inout value rather than manufacturing separate aliased input/output pointers.
+      (when-not (or offset (= symbol out))
         (merge {:kind :map :id id :sym symbol :index idx :extent bound :cast cast :body body
-                :primary-out out :destination-return :buffer :elem-type elem-type}
+                :primary-out out :destination-return :buffer
+                :destination-access (if (contains? (:inputs io) out) :read-write :write)
+                :elem-type elem-type}
                io)))
 
     (par/par-reduce-form? expression)
@@ -524,6 +525,9 @@
                                 (assoc :effects #{:memory/write}
                                        :aliases {(:sym description) destination}
                                        :attributes (cond-> {:destination destination}
+                                                     (:destination-access description)
+                                                     (assoc :destination-access
+                                                            (:destination-access description))
                                                      (:destination-return description)
                                                      (assoc :destination-return
                                                             (:destination-return description)))))]))

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -1270,6 +1270,7 @@
 (def ^:private gpu-invoke-heads
   '#{raster.gpu.ze-runtime/invoke-registered-map-void-kernel
      raster.gpu.ze-runtime/invoke-registered-kernel
+     raster.gpu.ocl-runtime/invoke-registered-kernel
      raster.gpu.ze-runtime/invoke-registered-reduction-kernel
      raster.gpu.ze-runtime/invoke-registered-contraction!
      raster.gpu.ze-runtime/invoke-registered-contraction-dispatch!
@@ -1358,7 +1359,9 @@
         (let [[_ kname arrays scalars n] expr]
           {:kernel-name kname :arrays (vec arrays) :scalars (vec scalars) :n-expr n
            :convention :map-void :returns sym}))
-      (= head 'raster.gpu.ze-runtime/invoke-registered-kernel)
+      (contains? '#{raster.gpu.ze-runtime/invoke-registered-kernel
+                    raster.gpu.ocl-runtime/invoke-registered-kernel}
+                 head)
       (when (= 6 argc)
         (let [[_ kname inputs out scalars n] expr]
           {:kernel-name kname
@@ -1807,8 +1810,7 @@
                                                                    (kexec/abi ki)
                                                                    (:abi ki)))]
                                                     (map #(or (:binding %) (:name %))
-                                                         (filter #(or (= :output (:kind %))
-                                                                      (= :inout (:role %)))
+                                                         (filter kabi/writable?
                                                                  (kabi/pointer-slots abi)))
                                                     (:written-arrays ki)))))))
                                  #{} (:steps prog)))
@@ -1829,8 +1831,7 @@
                                                          (kexec/abi ki)
                                                          (:abi ki)))))]
                                       (reduce (fn [m slot]
-                                                (if (or (= :output (:kind slot))
-                                                        (= :inout (:role slot)))
+                                                (if (kabi/writable? slot)
                                                   (assoc m (:name slot) (:dtype slot))
                                                   m))
                                               m (kabi/pointer-slots abi))

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -1453,7 +1453,7 @@
                (into {}
                      (keep-indexed
                       (fn [index slot]
-                        (when (= :output (:kind slot))
+                        (when (kabi/writable? slot)
                           [(or (:binding slot) (:name slot))
                            (nth runtime-arguments index)])))
                      abi)
@@ -1525,8 +1525,8 @@
                           {:device-id device-id :index index :slot slot
                            :expected (dtype/canon (:dtype slot)) :actual actual-dtype})))
         (let [existing (.get identities value)
-              read? (or (= :input (:kind slot)) (= :inout (:role slot)))
-              write? (or (= :output (:kind slot)) (= :inout (:role slot)))]
+              read? (kabi/readable? slot)
+              write? (kabi/writable? slot)]
           (if (some? existing)
             (vswap! groups update existing
                     (fn [group]

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -1060,8 +1060,7 @@
          expanded-entries
          (if abi
            (mapv (fn [entry slot]
-                   (assoc entry :write? (or (= :output (:kind slot))
-                                            (= :inout (:role slot)))))
+                   (assoc entry :write? (kabi/writable? slot)))
                  expanded-entries (kabi/pointer-slots abi))
            expanded-entries)
 
@@ -1110,6 +1109,33 @@
                                (into-array Object [cl-mem]))))
 
      nil)))
+
+(defn invoke-registered-kernel
+  "Pipeline-friendly value-returning map invocation for OpenCL.
+
+   The emitter-authored ABI is still authoritative; this wrapper only projects the compatibility
+   `(inputs, result, scalars, bound)` marker into the existing ordered OpenCL staging path and
+   returns the declared result value."
+  [^String kernel-name input-arrays output-array scalar-args n]
+  (let [registered (or (get @kernel-registry kernel-name)
+                       (throw (ex-info (str "Kernel not registered: " kernel-name)
+                                       {:kernel-name kernel-name
+                                        :registered (keys @kernel-registry)})))
+        abi (or (:abi registered)
+                (throw (ex-info "registered map kernel has no ordered ABI"
+                                {:kernel-name kernel-name :registry-entry registered
+                                 :fallback :none})))
+        arguments (vec (concat input-arrays [output-array] scalar-args [n]))
+        pairs (mapv vector (kabi/validate! abi)
+                    (kabi/validate-arguments! abi arguments))
+        result-pairs (filterv #(= :result (:role (first %))) pairs)]
+    (when-not (= 1 (count result-pairs))
+      (throw (ex-info "map kernel ABI must identify exactly one result"
+                      {:kernel-name kernel-name :result-slots (mapv first result-pairs)})))
+    (invoke-registered-map-void-kernel kernel-name
+                                       (vec (concat input-arrays [output-array]))
+                                       scalar-args n)
+    (second (first result-pairs))))
 
 (defn invoke-registered-scan-exclusive-kernel
   "Invoke Blelloch exclusive scan. Same multi-pass algorithm as ze_runtime.

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -2028,7 +2028,7 @@
                       (let [host (MemorySegment/ofArray value)
                             n-bytes (.byteSize host)
                             seg (ensure-seg kernel-name (keyword (str "abi-arg-" idx)) n-bytes)]
-                        (when (or (= :input (:kind slot)) (= :inout (:role slot)))
+                        (when (kabi/readable? slot)
                           (MemorySegment/copy host 0 seg 0 n-bytes))
                         {:arg seg :value value :host host :n-bytes n-bytes :slot slot}))))
                 (range) pairs)
@@ -2040,10 +2040,10 @@
         wg (registered-1d-workgroup-size loaded)
         group-count (long (Math/ceil (/ (double n) wg)))]
     (launch! kernel-handle group-count wg all-args)
-    ;; ABI output and inout roles are the single source of copy-back truth. DeviceBuffers are
-    ;; already resident and therefore need no host copy.
+    ;; Writable ABI kinds are the single source of copy-back truth. DeviceBuffers are already
+    ;; resident and therefore need no host copy.
     (doseq [{:keys [arg host n-bytes slot]} staged
-            :when (and host (or (= :output (:kind slot)) (= :inout (:role slot))))]
+            :when (and host (kabi/writable? slot))]
       (MemorySegment/copy ^MemorySegment arg 0 ^MemorySegment host 0 (long n-bytes)))
     (or (some (fn [[slot value]] (when (= :result (:role slot)) value)) pairs)
         output-array)))
@@ -2685,8 +2685,7 @@
          expanded-entries
          (if abi
            (mapv (fn [entry slot]
-                   (assoc entry :write? (or (= :output (:kind slot))
-                                            (= :inout (:role slot)))))
+                   (assoc entry :write? (kabi/writable? slot)))
                  expanded-entries (kabi/pointer-slots abi))
            expanded-entries)
          dev-segs (mapv :seg expanded-entries)

--- a/test/raster/compiler/kernel_abi_test.clj
+++ b/test/raster/compiler/kernel_abi_test.clj
@@ -160,6 +160,17 @@
              (:pointer-bindings
               (kabi/validate-split-binding! abi [:x-in :other :x-out] [])))))))
 
+(deftest access-kind-and-semantic-role-are-orthogonal
+  (let [slot (kabi/slot 'state :inout :float :c-name "out" :role :result)
+        abi [slot (kabi/slot '_n_bound :scalar :int :role :bound)]]
+    (is (= abi (kabi/validate! abi)))
+    (is (= :read-write (kabi/slot-access slot)))
+    (is (kabi/readable? slot))
+    (is (kabi/writable? slot))
+    (is (= '[state] (kabi/pointer-binding-names abi)))
+    (is (= '[state]
+           (:pointer-bindings (kabi/validate-split-binding! abi [:state] []))))))
+
 (deftest ordered-reduction-binding-is-derived-from-roles
   (let [abi [(kabi/slot 'x :input :float :role :operand)
              (kabi/slot 'out :output :float :role :result)

--- a/test/raster/compiler/kernel_call_pipeline_test.clj
+++ b/test/raster/compiler/kernel_call_pipeline_test.clj
@@ -11,6 +11,10 @@
   [x :- (Array float) out :- (Array float) scale :- Float n :- Long] :- (Array float)
   (raster.par/map! out i n float (* scale (ra/aget x i))))
 
+(deftm resident-kernel-call-inout
+  [state :- (Array float) scale :- Float n :- Long] :- (Array float)
+  (raster.par/map! state i n float (* scale (ra/aget state i))))
+
 (deftm resident-kernel-call-reduce
   [x :- (Array float) out :- (Array float) scale :- Double n :- Long] :- Void
   (let [sum (raster.par/reduce acc 0.0 i n
@@ -65,6 +69,20 @@
            (mapv :kind (:argument-specs step))))
     (is (= [256] (get-in call [:geometry :workgroup-size])))
     (is (= [3] (get-in call [:geometry :group-count])))))
+
+(deftest resident-segmap-inout-is-one-physical-result-slot
+  (let [descriptor (pipeline/compile-gpu-program #'resident-kernel-call-inout
+                                                 :ze:0 :dtype :float)
+        step (first (:steps descriptor))]
+    (is (= :map (:convention step)))
+    (is (= '[state scale _n_bound]
+           (mapv (comp :name :slot) (:argument-specs step))))
+    (is (= [:inout :scalar :scalar]
+           (mapv :kind (:argument-specs step))))
+    (is (= [:result :parameter :bound]
+           (mapv (comp :role :slot) (:argument-specs step))))
+    (is (= {'state :output} (:array-roles descriptor)))
+    (is (= :state (:output step)))))
 
 (deftest resident-segred-schedule-is-an-explicit-kernel-call-override
   (let [descriptor (pipeline/compile-gpu-program #'resident-kernel-call-reduce

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -85,12 +85,18 @@
                                                (+ (clojure.core/aget x i) 1.0))]
                       target)
                {:dtype :float :array-types {'x :float 'target :float}}))))
-  (testing "a read/write destination waits for an explicit single-slot inout role"
-    (is (nil? (frontend/form->program
-               '(let* [step (raster.par/map! target i n float
-                                             (+ (clojure.core/aget target i) 1.0))]
-                      step)
-               {:dtype :float :array-types {'target :float}})))))
+  (testing "a read/write destination is one explicit typed operand"
+    (let [program (frontend/form->program
+                   '(let* [step (raster.par/map! target i n float
+                                                 (+ (clojure.core/aget target i) 1.0))]
+                          step)
+                   {:dtype :float :array-types {'target :float}})
+          equation (first (dialect/equations program))
+          facts (dialect/facts program)]
+      (is (= '[target] (dialect/operation-inputs equation)))
+      (is (= :read-write
+             (get-in facts [:equations 0 :attributes :destination-access])))
+      (is (= '{step target} (get-in facts [:equations 0 :aliases]))))))
 
 (deftest destination-shapes-refine-across-ordered-maps
   (let [program (frontend/form->program

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -58,6 +58,47 @@
       (is (nil? (get-in emitted [:stats :segop-relowered])))
       (is (= 1 (get-in emitted [:stats :ze-maps]))))))
 
+(deftest destination-read-lowers-to-one-inout-result-slot
+  (let [source '(raster.par/map! target i n float
+                                 (+ (clojure.core/aget target i) 1.0))
+        {:keys [form stats]}
+        (pipeline/schedule-parallel-form
+         source {:target-device :ocl:0 :dtype :float
+                 :array-types {'target :float}})
+        equation (first (:equations form))
+        emitted (opencl-pass/opencl-pass form :device-id :ocl:0
+                                         :dtype :float :min-elements 0)
+        artifact (first (:kernels emitted))
+        pointer-slots (filterv #(not= :scalar (:kind %)) (:abi artifact))]
+    (is (= :typed-soac (:source-dialect stats)))
+    (is (= :read-write (get-in equation [:attributes :destination-access])))
+    (is (= ['target] (mapv :name pointer-slots)))
+    (is (= [:inout] (mapv :kind pointer-slots)))
+    (is (= [:result] (mapv :role pointer-slots)))
+    (is (= '[target n] (:arguments artifact)))
+    (is (re-find #"inout_result\[idx\]" (:source artifact))
+        "the scalar-region read is projected through the sole result parameter")
+    (is (some #{'raster.gpu.ocl-runtime/invoke-registered-kernel}
+              (tree-seq coll? seq (:form emitted))))
+    (is (not (some #{'raster.gpu.ze-runtime/invoke-registered-kernel}
+                   (tree-seq coll? seq (:form emitted))))
+        "an OpenCL program must not leak a Level Zero staging call")))
+
+(deftest typed-inout-preserves-sequential-jvm-semantics
+  (let [source '(let* [step (raster.par/map! target i n float
+                                             (* (clojure.core/aget target i) 2.0))]
+                      step)
+        typed (:program (route/attempt source :float {'target :float}))
+        scheduled (:form (segop-lower/segop-lower-pass typed {:dtype :float}))
+        jvm (par-simd/simd-pass scheduled :min-elements 1)
+        execute (eval (list 'fn '[target n] (:form jvm)))
+        target (float-array [1.0 2.0 3.0 4.0])
+        result (execute target 4)]
+    (is (identical? target result))
+    (is (= [2.0 4.0 6.0 8.0] (mapv double result)))
+    (is (= 1 (get-in jvm [:stats :segop-reused])))
+    (is (nil? (get-in jvm [:stats :segop-relowered])))))
+
 (deftest gpu-session-scheduling-exposes-each-top-level-do-step
   (let [{:keys [form stats]}
         (pipeline/schedule-parallel-form

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -31,6 +31,10 @@
   [x :- (Array float) y :- (Array float) a :- Float n :- Long] :- (Array float)
   (raster.par/map! y i n float (* a (ra/aget x i))))
 
+(deftm ocl-session-inout
+  [state :- (Array float) a :- Float n :- Long] :- (Array float)
+  (raster.par/map! state i n float (* a (ra/aget state i))))
+
 (deftm ocl-session-contract
   [A :- (Array float) B :- (Array float)] :- (Array float)
   (let [C (ra/alloc-like A 64)]
@@ -182,6 +186,38 @@
                                  1e-3))
                       (range n))))
         (finally (gpu/close-session! s))))))
+
+(deftest ocl-resident-typed-inout-roundtrip
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "resident typed inout SegMap")
+    (let [descriptor (pl/compile-gpu-program #'ocl-session-inout :ocl:0 :dtype :float)
+          n 4096
+          state (float-array (map #(float (inc %)) (range n)))
+          s (gpu/make-session :ocl:0)]
+      (try
+        (is (= [:inout :scalar :scalar]
+               (mapv :kind (:argument-specs (first (:steps descriptor))))))
+        (let [program (fixture/instantiate! s descriptor [state (float 2.0) n]
+                                            {'state :state})]
+          (fixture/run! program [state (float 2.0) n])
+          (let [^floats once (fixture/download program 'state)]
+            (is (= (float (* 2.0 513.0)) (aget once 512))))
+          (fixture/run! program [state (float 2.0) n])
+          (let [^floats twice (fixture/download program 'state)]
+            (is (= (float (* 4.0 513.0)) (aget twice 512))
+                "resident state is read and written through one ABI pointer on replay")))
+        (finally (gpu/close-session! s))))))
+
+(deftest ocl-staged-typed-inout-roundtrip
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "staged typed inout SegMap")
+    (let [n 1024
+          execute (pl/compile-aot #'ocl-session-inout
+                                  :target-device :ocl:0 :dtype :float)
+          state (float-array (map #(float (inc %)) (range n)))
+          result (execute state (float 3.0) n)]
+      (is (identical? state result))
+      (is (= (float (* 3.0 513.0)) (aget state 512))))))
 
 (deftest ocl-resident-contraction-roundtrip
   (if-not @device-probe/opencl-available?


### PR DESCRIPTION
## Summary
- keep pointwise read/write map destinations on the direct analyzed-source to TypedSOAC to SegOp route
- make KernelABI access kind orthogonal to semantic role and bind a destination once as an inout result
- share readable/writable interpretation across composition and resident/staged runtimes
- select the staged generic-map marker by backend so OpenCL programs do not call the Level Zero runtime

## Verification
- focused compiler/runtime gate: 53 tests, 267 assertions (five Level Zero device tests skipped because this host has no Level Zero device)
- TypedSOAC route gate: 22 tests, 154 assertions
- local Intel Arc OpenCL gate: 12 tests, 23 assertions, including resident replay and staged inout execution
- targeted cljfmt and git diff check

The broader formatter reports pre-existing drift in untouched regions of segop_opencl.clj, core.clj, and kernel_abi_test.clj; this PR leaves those unrelated mechanical rewrites out.