### PR TITLE
Route exclusive scan through TypedSOAC

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -77,16 +77,19 @@ with typed scalar SSA, stable reads, workgroup allocation, masks, barriers and a
 the same body emits as OpenCL, CUDA and HIP and is compiled by the hardware-free vendor CI gates.
 Unsupported scalar regions decline explicitly to the established verified SegRed OpenCL emitter.
 
-The map/scalar/full-reduction/inclusive-scan front end now constructs TypedSOAC directly from closed analyzed
+The map/scalar/full-reduction/certified-scan front end now constructs TypedSOAC directly from closed analyzed
 source and retained walker type metadata. It establishes stable equation/value identity, types,
 effects, aliases and placement provenance before fusion; no `ir.soac` record or record-to-dialect
 adapter participates in this production route. The old dependency-graph path remains only as an
-explicit fallback for unsupported parallel forms and as a differential oracle. Inclusive scan has
-a distinct `scan` equation with an explicit `:inclusive` mode and a checked `AssociativeScan`
-certificate; its caller-owned destination is an alias/effect fact, not part of the functional
-algebra. It lowers directly to a one- or three-node SegScan `KernelGraph` without constructing a
-legacy `SoacScan`. The GPU backend now target-lowers that scheduled value through one fail-loud
-graph-emission boundary, wraps it in the same `KernelDispatch` value used by other selectable
+explicit fallback for unsupported parallel forms and as a differential oracle. Scan has a distinct
+equation with an explicit `:inclusive` or `:exclusive` result mode and a checked `AssociativeScan`
+certificate; its caller-owned destination and output layout are facts, not part of the functional
+algebra. Both modes lower directly to the same one- or three-node SegScan `KernelGraph` without
+constructing a legacy `SoacScan`. Exclusive mode retains logical traversal extent `n`, records its
+result as `n+1` through checked symbolic integer-expression IR, and specializes scheduled stores to
+materialize the identity at zero and prefixes at `idx+1`. The GPU backend now target-lowers that
+scheduled value through one fail-loud graph-emission boundary, wraps it in the same
+`KernelDispatch` value used by other selectable
 schedules, and resident descriptor extraction retains it as one executable step. LinkPlan and the
 runtime binder allocate its private temporary and flatten its nodes without reconstructing scan or
 ABI semantics. The ordinary per-call compiled function now invokes that same registered
@@ -96,8 +99,9 @@ temporaries, and copies back only declared writes. No duplicate sequential sourc
 is embedded in the emitted form. The public GPU-session compiler now crosses the same direct
 TypedSOAC and scheduled SegOp boundary instead of asking the OpenCL emitter to reconstruct generic
 maps and reductions from walked source. Destination-writing maps retain explicit destination,
-alias, effect and return facts. General recurrences and `scan-exclusive` remain outside this
-typed operation and must not borrow its reassociation proof. The remaining parallel forms must
+alias, effect and return facts. General recurrences remain outside this typed operation and must
+not borrow its reassociation proof. The obsolete raw exclusive-scan GPU generator is no longer a
+backend fallback: unscheduled source fails loudly. The remaining parallel forms must
 join the direct front end before the old dependency-graph fallback can be deleted.
 
 Pointwise maps that read and write their caller-owned destination stay on this same route. The
@@ -462,10 +466,10 @@ SIMD/GPU reuse its certified SegOps. Non-escaping reduction results remain logic
 whose `:resident-scalar-buffer` representation drives one-element device allocation and stable
 consumer loads; dependent scalar equations are inlined as a typed transform. The former raw-source
 resident rewrite and typed-route opt-out are deleted. The analyzed front end now constructs this
-TypedSOAC subset directly. Certified inclusive scan also crosses the same typed algorithm and
-scheduled-program boundary, retaining its explicit destination contract and graph-owned temporary
-storage. Migration is complete when hardware-costed multi-consumer fusion, the remaining parallel
-forms, and covered backend compatibility re-lowerings are deleted. Nested reductions
+TypedSOAC subset directly. Certified inclusive and exclusive scans also cross the same typed
+algorithm and scheduled-program boundary, retaining explicit destination, result-layout, and
+graph-owned temporary-storage contracts. Migration is complete when hardware-costed multi-consumer
+fusion, the remaining parallel forms, and covered backend compatibility re-lowerings are deleted. Nested reductions
 inside a retained map are typed and correctly classified, but the JVM SIMD leaf still lowers those inner
 regions through its established scalar fallback; this is an explicit scheduling boundary rather
 than a loss of semantic facts.
@@ -818,14 +822,14 @@ The immediate continuation after the verified double-buffered weighted-reduction
 5. **In progress:** finish typed parallel coverage and scalar JVM scheduling, then remove compatibility
    re-lowering. Supported map/reduce programs, including unfused and host-visible intermediates,
    horizontal tuple maps, typed scalar/shape equations, stable tensor captures, and resident
-   reduction results and certified inclusive scan now share the direct
-   analyzed-source→TypedSOAC→SegOp production route. Inclusive scan additionally reaches an emitted
+   reduction results and certified inclusive/exclusive scan now share the direct
+   analyzed-source→TypedSOAC→SegOp production route. Both scan modes additionally reach an emitted
    graph-backed resident executable through ordinary dispatch, LinkPlan and binding, and a generic
    per-call staging graph runner executes the same registered dispatch. Pointwise read/write map
    destinations lower to one physical `:inout` ABI result and execute through both resident and
    staged binding without an aliased compatibility input. Hardware-costed
    multi-consumer fusion, nested-region JVM
-   scheduling, the remaining parallel forms (including distinct exclusive-scan semantics), and
+   scheduling, the remaining parallel forms, and
    deletion of the remaining graph/backend fallbacks remain.
 6. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a
    read-only distributed track without interrupting the kernel and typed-middle-end verticals.

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -527,22 +527,10 @@
 
             ;; par/scan-exclusive
             (par/par-scan-exclusive-form? form)
-            (let [{:keys [bound]} (par/extract-par-scan-exclusive-info form)]
-              (if (and (number? bound) (< bound min-elements))
-                (do (swap! stats update :fallback inc)
-                    (par/expand-par-scan-exclusive form))
-                (let [kernel (legacy/generate-par-scan-exclusive-kernel form
-                                                                        :dtype dtype :device-id device-id)
-                      k (maybe-compile-spirv kernel compile-spirv? device-id)
-                      block-entry (assoc k :kernel-name (:block-kernel-name k))
-                      prop-entry (assoc k :kernel-name (:prop-kernel-name k))]
-                  (swap! stats update :ze-maps inc)
-                  (swap! kernels conj block-entry)
-                  (swap! kernels conj prop-entry)
-                  (let [{:keys [out]} (par/extract-par-scan-exclusive-info form)]
-                    (list 'raster.gpu.ze-runtime/invoke-registered-scan-exclusive-kernel
-                          (:block-kernel-name k) (:prop-kernel-name k)
-                          (vec (:input-arrays k)) out bound)))))
+            (throw (ex-info "GPU exclusive scan must enter the backend as a scheduled TypedSOAC graph"
+                            {:reason :exclusive-scan-requires-typed-schedule
+                             :source form :target-dialect :kernel-graph
+                             :fallback :none}))
 
             ;; par/rng-fill!
             (par/par-rng-fill-form? form)

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -720,6 +720,10 @@
         _ (when-not (scan/associative-scan? algebra)
             (throw (ex-info "scan KernelGraph lacks certified associative algebra"
                             {:reason :uncertified-scan-graph :algebra algebra})))
+        scan-mode (or (get-in graph [:attributes :scan-mode]) :inclusive)
+        _ (when-not (contains? #{:inclusive :exclusive} scan-mode)
+            (throw (ex-info "scan KernelGraph has an unsupported result mode"
+                            {:reason :scan-mode-not-emittable :mode scan-mode})))
         _ (when-not (= 1 (count (:outputs graph)))
             (throw (ex-info "scan artifact lowering requires exactly one graph output"
                             {:reason :scan-multi-output-unimplemented
@@ -797,6 +801,7 @@
                     (ce/emit-expr (ce/adapt-casts-for-dtype
                                    (ce/normalize-array-prims element) dtype)
                                   idx (set (map #(symbol (name %)) input-ids)) "idx")))
+                result-index (if (= :exclusive scan-mode) "idx + 1" "idx")
                 source-body
                 (case phase
                   (:single :intra-block)
@@ -817,9 +822,11 @@
                        "        if (tid >= offset) sdata[tid] = " (combine-c "left" "self") ";\n"
                        "        barrier(CLK_LOCAL_MEM_FENCE);\n"
                        "    }\n"
-                       "    if (idx < _n_bound) " out-c "[idx] = sdata[tid];\n"
+                       (when (= :exclusive scan-mode)
+                         (str "    if (block == 0 && tid == 0) " out-c "[0] = " identity-c ";\n"))
+                       "    if (idx < _n_bound) " out-c "[" result-index "] = sdata[tid];\n"
                        (when totals-c
-                         (str "    if (tid == 0) {\n"
+                         (str "    if (tid == 0 && base < _n_bound) {\n"
                               "        int valid = min(" workgroup ", _n_bound - base);\n"
                               "        " totals-c "[block] = sdata[valid - 1];\n"
                               "    }\n")))
@@ -858,8 +865,9 @@
                   (str "    int stride = get_global_size(0);\n"
                        "    for (int idx = get_global_id(0); idx < _n_bound; idx += stride) {\n"
                        "        int block = idx / " scan-workgroup ";\n"
-                       "        if (block > 0) " out-c "[idx] = "
-                       (combine-c (str totals-c "[block - 1]") (str out-c "[idx]")) ";\n"
+                       "        if (block > 0) " out-c "[" result-index "] = "
+                       (combine-c (str totals-c "[block - 1]")
+                                  (str out-c "[" result-index "]")) ";\n"
                        "    }\n")
 
                   (throw (ex-info "scheduled scan node has no target lowering"
@@ -885,7 +893,8 @@
               :temporaries []
               :effects {:kind :scan-stage :phase phase}
               :provenance {:dialect :segscan :segop-id (:id operation) :graph-node id}
-              :attributes {:phase phase :dtype dtype :scan-workgroup scan-workgroup}})))
+              :attributes {:phase phase :dtype dtype :scan-mode scan-mode
+                           :scan-workgroup scan-workgroup}})))
         emitted (kgraph/map-operations graph emit-node)
         external-buffers (vec (distinct (concat (:inputs emitted) (:outputs emitted))))
         scalar-pairs (->> (:nodes emitted)

--- a/src/raster/compiler/ir/kernel_launch.clj
+++ b/src/raster/compiler/ir/kernel_launch.clj
@@ -8,6 +8,7 @@
 (defrecord RuntimeValue [value])
 (defrecord CeilDiv [value divisor])
 (defrecord FloorDiv [value divisor])
+(defrecord Sum [terms])
 (defrecord Product [factors])
 (defrecord AlignUp [value alignment])
 (defrecord Minimum [values])
@@ -45,6 +46,14 @@
   (when-not (or (not (integer? divisor)) (pos? divisor))
     (throw (ex-info "floor-div divisor must be positive" {:value value :divisor divisor})))
   (->FloorDiv value divisor))
+
+(defn sum
+  "A checked sum of integer launch/storage expressions. Sums are explicit IR rather than
+   arbitrary Clojure forms so symbolic view extents remain inspectable and safely realizable."
+  [& terms]
+  (when-not (and (seq terms) (every? some? terms))
+    (throw (ex-info "sum requires one or more non-nil terms" {:terms terms})))
+  (->Sum (vec terms)))
 
 (defn product
   "A checked product of integer launch/storage expressions. Products are explicit IR rather than
@@ -86,6 +95,9 @@
 (defn- floor-div? [x]
   (record-kind? "raster.compiler.ir.kernel_launch.FloorDiv" x))
 
+(defn- sum? [x]
+  (record-kind? "raster.compiler.ir.kernel_launch.Sum" x))
+
 (defn- product? [x]
   (record-kind? "raster.compiler.ir.kernel_launch.Product" x))
 
@@ -105,6 +117,7 @@
     (runtime-value? x) (some? (:value x))
     (ceil-div? x) (and (expression? (:value x)) (expression? (:divisor x)))
     (floor-div? x) (and (expression? (:value x)) (expression? (:divisor x)))
+    (sum? x) (and (seq (:terms x)) (every? expression? (:terms x)))
     (product? x) (and (seq (:factors x)) (every? expression? (:factors x)))
     (align-up? x) (and (expression? (:value x))
                        (integer? (:alignment x)) (pos? (:alignment x)))
@@ -122,6 +135,7 @@
                                  (expression-references (:divisor expression)))
     (floor-div? expression) (into (expression-references (:value expression))
                                   (expression-references (:divisor expression)))
+    (sum? expression) (reduce into #{} (map expression-references (:terms expression)))
     (product? expression) (reduce into #{} (map expression-references (:factors expression)))
     (align-up? expression) (expression-references (:value expression))
     (minimum? expression) (reduce into #{} (map expression-references (:values expression)))
@@ -149,6 +163,7 @@
       (product? x)
       (align-up? x)
       (floor-div? x)
+      (sum? x)
       (minimum? x)))
 
 (defn validate-spec!
@@ -235,9 +250,9 @@
 (defn resolve-expression
   "Resolve one integer launch/storage expression.
 
-   Besides literal integers this understands the explicit `RuntimeValue` and `CeilDiv` records
-   used by launch and graph-buffer contracts. `resolve-value` supplies an integer for an opaque
-   compiler value such as a bound symbol. Keeping this evaluator here prevents graph runners from
+   Besides literal integers this understands the explicit symbolic records declared above and used
+   by launch and graph-buffer contracts. `resolve-value` supplies an integer for an opaque compiler
+   value such as a bound symbol. Keeping this evaluator here prevents graph runners from
    interpreting arbitrary compiler S-expressions."
   [resolve-value dimension]
   (letfn [(resolve* [expression]
@@ -261,6 +276,10 @@
                    (throw (ex-info "floor-div resolved divisor must be positive"
                                    {:expression expression :divisor divisor})))
                  (quot value divisor))
+               (sum? expression)
+               (reduce (fn [acc term]
+                         (Math/addExact (long acc) (long term)))
+                       0 (map resolve* (:terms expression)))
                (product? expression)
                (reduce (fn [acc factor]
                          (Math/multiplyExact (long acc) (long factor)))

--- a/src/raster/compiler/ir/par.clj
+++ b/src/raster/compiler/ir/par.clj
@@ -839,9 +839,11 @@
   "Extract structured info from a par/scan-exclusive form."
   [form]
   (when (par-scan-exclusive-form? form)
-    (let [[_ out-sym acc-sym init-expr idx-sym bound-expr cast-fn body-expr] form]
-      {:out out-sym :acc acc-sym :init init-expr
-       :idx idx-sym :bound bound-expr :cast cast-fn :body body-expr})))
+    (let [[_ out-sym acc-sym init-expr idx-sym bound-expr cast-fn body-expr] form
+          elem-type (:raster.type/elem-type (meta form))]
+      (cond-> {:out out-sym :acc acc-sym :init init-expr
+               :idx idx-sym :bound bound-expr :cast cast-fn :body body-expr}
+        elem-type (assoc :elem-type elem-type)))))
 
 (defn extract-par-scan-info
   "Extract structured information from an inclusive par/scan form."

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -29,7 +29,8 @@
              (lambda [acc element ... capture-parameter ...] [step-result])))]
        [program-result ...])
 
-   Map lambdas return tuples, so horizontal fusion remains functional rather than encoding
+   Scan mode may be `:inclusive` or `:exclusive`; it is an explicit result-layout property. Map
+   lambdas return tuples, so horizontal fusion remains functional rather than encoding
    secondary results as hidden stores. Captures are explicit operands with explicit scalar lambda
    parameters, so stable value IDs never leak into lexical expression binding."
   (:require [clojure.set :as set]
@@ -71,6 +72,17 @@
      (symbol? extent) extent
      :else (list 'value extent))])
 
+(defn scan-result-shape
+  "The functional result shape of a scan operation.
+
+   Inclusive scan produces one value per input element. Raster's public exclusive scan includes
+   the initial identity at element zero, so its result has `extent + 1` elements. The logical
+   traversal extent remains unchanged and is what schedules use for work decomposition."
+  [{:keys [mode extent]}]
+  [(if (= :exclusive mode)
+     (if (integer? extent) (inc extent) (list 'clojure.core/inc extent))
+     (first (extent-shape extent)))])
+
 (defn map-attributes?
   [value]
   (and (map? value)
@@ -96,12 +108,10 @@
        (every? map? (:algebra value))))
 
 (defn scan-attributes?
-  "Attributes for the certified inclusive scan dialect operation.
-
-   The explicit mode is intentionally load-bearing: exclusive scan is a distinct surface
-   primitive and must never enter this schedule by spelling accident."
+  "Attributes for a certified scan dialect operation. The explicit mode is load-bearing because
+   inclusive and exclusive scans have different observable result layouts."
   [value]
-  (and (= :inclusive (:mode value))
+  (and (contains? #{:inclusive :exclusive} (:mode value))
        (reduce-attributes? (dissoc value :mode))
        (every? scan-ir/associative-scan? (:algebra value))))
 
@@ -387,12 +397,12 @@
         (let [value (get values id)]
           (when (and value
                      (not (and (= :tensor (:kind value))
-                               (= (extent-shape extent) (:shape value))
+                               (= (scan-result-shape attributes) (:shape value))
                                (= dtype (:dtype value)))))
             (fail! :typed-soac-scan-result-type
-                   "scan results must be rank-one tensors over the declared extent"
+                   "scan result shape must agree with its explicit inclusive/exclusive mode"
                    {:equation equation-id :id id :value value
-                    :extent extent :dtype dtype}))))
+                    :extent extent :mode (:mode attributes) :dtype dtype}))))
 
       nil)))
 

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -164,7 +164,7 @@
             (lower-reduce node device-id :dtype accumulator-dtype)))))
 
 (defn typed-scan-program?
-  "Whether a validated one-equation TypedSOAC program is a certified inclusive scan."
+  "Whether a validated one-equation TypedSOAC program is a certified scan."
   [program]
   (and (soac-dialect/program-form? program)
        (= 1 (count (soac-dialect/equations program)))
@@ -182,7 +182,7 @@
         destination (get-in facts [:equations equation-id :attributes :destination])
         _ (when-not (and (= 1 (count results)) (= 1 (count accumulators))
                          (= 1 (count body-results)) destination)
-            (throw (ex-info "typed inclusive scan requires one result, accumulator and destination"
+            (throw (ex-info "typed scan requires one result, accumulator and destination"
                             {:reason :typed-soac-scan-subset :equation equation-id
                              :results results :accumulators accumulators
                              :destination destination})))
@@ -205,6 +205,7 @@
      :init (first (:identities attributes))
      :lambda (util/subst-syms substitutions (first body-results))
      :algebra algebra
+     :mode (:mode attributes)
      :bound (:extent attributes)
      :idx index
      :inputs (into (set arrays) (disj stable destination))
@@ -213,7 +214,7 @@
      :elem-type scan-dtype}))
 
 (defn lower-typed-scan
-  "Lower one certified TypedSOAC inclusive scan without reconstructing the legacy SOAC record IR.
+  "Lower one certified TypedSOAC scan without reconstructing the legacy SOAC record IR.
 
    Returns both ordered SegOps and their KernelGraph because temporary storage and dependencies are
    properties of the selected schedule, not of the functional scan equation."
@@ -456,7 +457,8 @@
   (let [dtype (or (:elem-type description) dtype)
         bound (:bound description)
         idx (:idx description)
-        raw-scan-op (select-keys description [:acc :init :lambda :out])
+        mode (or (:mode description) :inclusive)
+        raw-scan-op (assoc (select-keys description [:acc :init :lambda :out]) :mode mode)
         map-lambda (:map-lambda description)
         _ (when map-lambda
             (throw (ex-info "fused scan/map needs an explicit scheduled scan epilogue"
@@ -552,12 +554,18 @@
                                  [id {:dtype dtype :elements temporary-elements
                                       :memory-space :device}]))
                           temporary-ids)
+        output-elements (if (= :exclusive (:mode description))
+                          (kernel-launch/sum (:bound description) 1)
+                          (:bound description))
+        output-ids (set (:outputs description))
         buffer-specs (into {}
                            (map (fn [id]
                                   [id {:dtype (or (get array-types id)
                                                   (get array-types (symbol (name id)))
                                                   dtype)
-                                       :elements (:bound description)}]))
+                                       :elements (if (contains? output-ids id)
+                                                   output-elements
+                                                   (:bound description))}]))
                            external)]
     (kernel-graph/from-segops
      segops
@@ -569,6 +577,7 @@
       :effects {:memory-order :dependency-ordered}
       :provenance {:dialect :segop :algorithm :scan :soac-id (:id description)}
       :attributes {:strategy (if (= 1 (count segops)) :single :three-stage)
+                   :scan-mode (or (:mode description) :inclusive)
                    :scan-algebra (get-in (first segops) [:scan-op :algebra])}})))
 
 (defn scan-soac?

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -1,5 +1,5 @@
 (ns raster.compiler.passes.parallel.typed-soac-frontend
-  "Direct analyzed-source to TypedSOAC construction for the closed map/scalar/reduce/inclusive-scan subset.
+  "Direct analyzed-source to TypedSOAC construction for the closed map/scalar/reduce/certified-scan subset.
 
    This is the production front door for TypedSOAC.  It consumes the retained source form and
    walker type metadata directly; it never constructs the older record graph.  Unsupported
@@ -122,9 +122,14 @@
                          :attributes {:source :raster.par/reduce}})}
              io))
 
-    (par/par-scan-form? expression)
-    (let [{:keys [out acc init idx bound cast body elem-type]}
-          (par/extract-par-scan-info expression)
+    (or (par/par-scan-form? expression)
+        (par/par-scan-exclusive-form? expression))
+    (let [mode (if (par/par-scan-exclusive-form? expression) :exclusive :inclusive)
+          {:keys [out acc init idx bound cast body elem-type]}
+          ((if (= :exclusive mode)
+             par/extract-par-scan-exclusive-info
+             par/extract-par-scan-info)
+           expression)
           scan-dtype (or elem-type
                          (dtype/dtype-for-scalar-tag cast)
                          :double)]
@@ -133,7 +138,7 @@
       ;; the typed route instead of pretending the destination is both an input and a definition.
       (when-not (= symbol out)
         (let [algebra (scan/certify {:acc acc :init init :lambda body :out out} scan-dtype)]
-          (merge {:kind :scan :id id :sym symbol :index idx :extent bound
+          (merge {:kind :scan :id id :sym symbol :index idx :extent bound :mode mode
                   :primary-out out :accumulator acc :identity init :dtype scan-dtype
                   :algebra algebra :body body}
                  (extract-io body idx [out] :accumulator acc)))))
@@ -299,7 +304,7 @@
                       results)))))
 
 (defn- scan-equation
-  [{:keys [id sym index extent inputs scalars primary-out accumulator identity dtype body]}]
+  [{:keys [id sym index extent mode inputs scalars primary-out accumulator identity dtype body]}]
   (let [[pointwise stable] ((juxt filter remove) #(pointwise-input? [body] % index) inputs)
         arrays (vec (sort-by pr-str pointwise))
         stable (conj (set stable) primary-out)
@@ -312,7 +317,7 @@
         algebra (scan/certify {:acc accumulator :init identity :lambda result
                                :out primary-out} dtype)]
     (list '= id [sym]
-          (list 'scan {:mode :inclusive :index index :extent extent
+          (list 'scan {:mode mode :index index :extent extent
                        :attributes {:stable-array-captures (vec (sort-by pr-str stable))}
                        :accumulators [accumulator]
                        :identities [identity]
@@ -422,8 +427,10 @@
                      captures)))
      (into {} (map (fn [id result-dtype]
                      [id (tensor-value (or result-dtype default-dtype :double)
-                                       (if (contains? #{'scalar 'reduce} kind) []
-                                           (dialect/extent-shape extent)))])
+                                       (case kind
+                                         (scalar reduce) []
+                                         scan (dialect/scan-result-shape attributes)
+                                         (dialect/extent-shape extent)))])
                    results result-dtypes)))))
 
 (defn- merge-value

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -162,14 +162,18 @@
 
       scan
       (let [result (first results)
+            mode (:mode attributes)
             destination (get-in placement-facts [:attributes :destination])
             _ (when-not (and (= 1 (count results)) destination)
-                (throw (ex-info "typed inclusive scan requires one caller-owned destination"
+                (throw (ex-info "typed scan requires one caller-owned destination"
                                 {:reason :typed-soac-production-subset
                                  :equation equation-id :results results
                                  :destination destination})))
             source (with-meta
-                     (list 'raster.par/scan destination
+                     (list (case mode
+                             :inclusive 'raster.par/scan
+                             :exclusive 'raster.par/scan-exclusive)
+                           destination
                            (first (:accumulators attributes))
                            (first (:identities attributes))
                            (:index attributes) (:extent attributes)

--- a/test/raster/compiler/ir/kernel_launch_test.clj
+++ b/test/raster/compiler/ir/kernel_launch_test.clj
@@ -47,6 +47,9 @@
          (launch/resolve-expression
           {'m 3 'k 257}
           (launch/product 'm (launch/align-up (launch/ceil-div 'k 2) 256)))))
+  (let [padded-extent (launch/sum 'n 1)]
+    (is (= #{'n} (launch/expression-references padded-extent)))
+    (is (= 1026 (launch/resolve-expression {'n 1025} padded-extent))))
   (let [tiles (launch/product (launch/ceil-div 'm 128) (launch/ceil-div 'n 128))
         requested-splits (launch/minimum (launch/ceil-div 128 tiles)
                                          (launch/floor-div 'k 1024)

--- a/test/raster/compiler/ir/soac_dialect_test.clj
+++ b/test/raster/compiler/ir/soac_dialect_test.clj
@@ -38,7 +38,7 @@
                                 (first (dialect/equations program)))))))
     (is (= '[x] (dialect/operation-inputs (first (dialect/equations program)))))))
 
-(deftest inclusive-scan-has-a-distinct-typed-and-effectful-contract
+(deftest scan-mode-has-a-distinct-typed-and-effectful-contract
   (let [out (av/tensor {:dtype :float :shape '[(unknown-dimension out)]})
         algebra (scan/->AssociativeScan 'acc 0.0 '+ 'element '(float 0.0) :float)
         facts (dialect/default-program-facts
@@ -70,14 +70,26 @@
             :capture-parameters '[destination]}
            (dialect/parameter-layout equation)))
     (is (= '[x out] (dialect/operation-inputs equation)))
-    (testing "exclusive semantics cannot enter by omitting or changing the mode"
+    (testing "exclusive mode requires its n+1 result contract"
+      (let [[_ attributes arrays captures lambda] (nth equation 3)
+            exclusive-result (av/tensor {:dtype :float :shape '[(clojure.core/inc n)]})
+            exclusive-facts (assoc-in facts [:values 'result] exclusive-result)
+            exclusive-equation (list '= 'scan-0 '[result]
+                                     (list 'scan (assoc attributes :mode :exclusive)
+                                           arrays captures lambda))]
+        (is (= :exclusive
+               (get-in (dialect/operation-parts
+                        (first (dialect/equations
+                                (dialect/make exclusive-facts [exclusive-equation] '[result]))))
+                       [:attributes :mode])))))
+    (testing "unknown scan modes cannot enter the typed dialect"
       (let [[_ attributes arrays captures lambda] (nth equation 3)
             bad-equation (list '= 'scan-0 '[result]
-                               (list 'scan (assoc attributes :mode :exclusive)
+                               (list 'scan (assoc attributes :mode :unknown)
                                      arrays captures lambda))]
         (try
           (dialect/make facts [bad-equation] '[result])
-          (is false "exclusive mode must fail TypedSOAC syntax validation")
+          (is false "unknown mode must fail TypedSOAC syntax validation")
           (catch clojure.lang.ExceptionInfo exception
             (is (= :typed-soac-syntax (:reason (ex-data exception))))))))))
 

--- a/test/raster/compiler/kernel_call_pipeline_test.clj
+++ b/test/raster/compiler/kernel_call_pipeline_test.clj
@@ -4,6 +4,7 @@
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-graph :as kernel-graph]
+            [raster.compiler.ir.kernel-launch :as kernel-launch]
             [raster.compiler.pipeline :as pipeline]
             [raster.core :refer [deftm]]))
 
@@ -31,6 +32,10 @@
   [x :- (Array float) out :- (Array float) n :- Long] :- (Array float)
   (raster.par/scan out acc 0.0 i n float (+ acc (ra/aget x i))))
 
+(deftm resident-kernel-call-exclusive-scan
+  [x :- (Array float) out :- (Array float) n :- Long] :- (Array float)
+  (raster.par/scan-exclusive out acc 0.0 i n float (+ acc (ra/aget x i))))
+
 (deftest resident-typed-scan-is-one-graph-backed-executable-step
   (let [descriptor (pipeline/compile-gpu-program #'resident-kernel-call-scan
                                                  :ze:0 :dtype :float)
@@ -48,6 +53,16 @@
            (mapv (fn [{:keys [kind sym expression]}]
                    (if (= :scalar kind) expression sym))
                  (:argument-specs step))))))
+
+(deftest resident-exclusive-scan-preserves-its-n-plus-one-result-contract
+  (let [descriptor (pipeline/compile-gpu-program #'resident-kernel-call-exclusive-scan
+                                                 :ze:0 :dtype :float)
+        step (first (:steps descriptor))
+        executable (:artifact step)]
+    (is (= [:executable] (mapv :convention (:steps descriptor))))
+    (is (= :exclusive (get-in executable [:attributes :scan-mode])))
+    (is (= (kernel-launch/sum 'n 1) (:elements (first (:outputs executable)))))
+    (is (empty? (:allocs descriptor)))))
 
 (deftest resident-segmap-step-carries-one-executable-call-template
   (let [descriptor (pipeline/compile-gpu-program #'resident-kernel-call-map

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -48,12 +48,17 @@
       (is (= :inclusive (get-in (dialect/operation-parts equation) [:attributes :mode])))
       (is (= '{result target} (get-in (dialect/facts program) [:equations 0 :aliases])))
       (is (= #{:memory/write} (:effects (dialect/facts program))))))
-  (testing "exclusive scan remains a distinct, unsupported semantic operation"
-    (is (nil? (frontend/form->program
-               '(let* [result (raster.par/scan-exclusive target acc 0.0 i n float
-                                                         (+ acc (clojure.core/aget x i)))]
-                      result)
-               {:dtype :float :array-types {'x :float 'target :float}}))))
+  (testing "exclusive scan is the same certified operation with a distinct result mode"
+    (let [program (frontend/form->program
+                   '(let* [result (raster.par/scan-exclusive target acc 0.0 i n float
+                                                             (+ acc (clojure.core/aget x i)))]
+                          result)
+                   {:dtype :float :array-types {'x :float 'target :float}})
+          equation (first (dialect/equations program))]
+      (is (= 'scan (dialect/operation-kind equation)))
+      (is (= :exclusive (get-in (dialect/operation-parts equation) [:attributes :mode])))
+      (is (= '[(clojure.core/inc n)]
+             (:shape (get-in (dialect/facts program) [:values 'result]))))))
   (testing "a general recurrence cannot be mislabeled as an associative scan"
     (try
       (frontend/form->program

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -4,6 +4,7 @@
             [raster.compiler.backend.jvm.par-simd :as par-simd]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-graph :as kernel-graph]
+            [raster.compiler.ir.kernel-launch :as kernel-launch]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as dialect]
@@ -31,6 +32,11 @@
 (def ^:private inclusive-scan
   '(let* [result (raster.par/scan out acc 0.0 i n float
                                   (+ acc (clojure.core/aget x i)))]
+         result))
+
+(def ^:private exclusive-scan
+  '(let* [result (raster.par/scan-exclusive out acc 0.0 i n float
+                                            (+ acc (clojure.core/aget x i)))]
          result))
 
 (deftest gpu-session-scheduling-enters-the-shared-typed-boundary
@@ -329,6 +335,75 @@
     (is (= [1.0 3.0 6.0 10.0 15.0] (mapv double result)))
     (is (nil? (get-in jvm [:stats :segop-relowered]))
         "JVM keeps the exact inclusive recurrence until a certified vector scan schedule lands")))
+
+(deftest typed-exclusive-scan-keeps-one-algorithm-and-specializes-its-result-layout
+  (let [{:keys [program stats]} (route/attempt exclusive-scan :float
+                                               {'x :float 'out :float})
+        scheduled (:form (segop-lower/segop-lower-pass
+                          program {:dtype :float :target-device :ocl:0
+                                   :array-types {'x :float 'out :float}}))
+        equation (first (:equations scheduled))
+        graph (get-in equation [:attributes :kernel-graph])
+        emitted (opencl-pass/opencl-pass scheduled :device-id :ocl:0 :dtype :float)
+        [intra _ carry] (:kernels emitted)]
+    (is (= :typed-soac (:route stats)))
+    (is (= :exclusive
+           (get-in (dialect/operation-parts
+                    (first (dialect/equations (:algorithm equation))))
+                   [:attributes :mode])))
+    (is (= :exclusive (get-in graph [:attributes :scan-mode])))
+    (is (= (kernel-launch/sum 'n 1) (:elements (first (:outputs graph)))))
+    (is (= 3 (count (:nodes graph))))
+    (is (re-find #"\[0\] = 0.0f" (:source intra)))
+    (is (re-find #"\[idx \+ 1\] = sdata\[tid\]" (:source intra)))
+    (is (re-find #"\[idx \+ 1\]" (:source carry)))
+    (is (= 1 (get-in emitted [:stats :kernel-graphs])))
+    (is (nil? (get-in emitted [:stats :segop-relowered])))))
+
+(deftest typed-exclusive-scan-preserves-exact-sequential-jvm-semantics
+  (let [typed (:program (route/attempt exclusive-scan :float
+                                       {'x :float 'out :float}))
+        scheduled (:form (segop-lower/segop-lower-pass typed {:dtype :float}))
+        jvm (par-simd/simd-pass scheduled :min-elements 1)
+        execute (eval (list 'fn '[out x n] (:form jvm)))
+        out (float-array 6)
+        result (execute out (float-array [1.0 2.0 3.0 4.0 5.0]) 5)]
+    (is (identical? out result))
+    (is (= [0.0 1.0 3.0 6.0 10.0 15.0] (mapv double result)))
+    (is (nil? (get-in jvm [:stats :segop-relowered]))
+        "JVM retains the exact exclusive recurrence without rebuilding its algorithm")))
+
+(deftest raw-exclusive-scan-cannot-enter-the-gpu-backend-around-typed-scheduling
+  (try
+    (opencl-pass/opencl-pass
+     '(raster.par/scan-exclusive out acc 0.0 i n float
+                                 (+ acc (clojure.core/aget x i)))
+     :device-id :ocl:0 :dtype :float)
+    (is false "raw source must not select the obsolete backend-local scan generator")
+    (catch clojure.lang.ExceptionInfo exception
+      (is (= :exclusive-scan-requires-typed-schedule
+             (:reason (ex-data exception)))))))
+
+(deftest zero-length-exclusive-scan-still-materializes-the-identity
+  (let [source '(let* [result (raster.par/scan-exclusive out acc 0.0 i 0 float
+                                                         (+ acc 1.0))]
+                      result)
+        typed (:program (route/attempt source :float {'out :float}))
+        scheduled (:form (segop-lower/segop-lower-pass
+                          typed {:dtype :float :target-device :ocl:0
+                                 :array-types {'out :float}}))
+        graph (get-in scheduled [:equations 0 :attributes :kernel-graph])
+        emitted (opencl-pass/opencl-pass scheduled :device-id :ocl:0 :dtype :float)
+        artifact (first (:kernels emitted))
+        jvm (par-simd/simd-pass scheduled :min-elements 1)
+        execute (eval (list 'fn '[out] (:form jvm)))
+        out (float-array 1)]
+    (is (= 1 (count (:nodes graph))))
+    (is (= (kernel-launch/sum 0 1) (:elements (first (:outputs graph)))))
+    (is (= [1] (get-in artifact [:launch :group-count])))
+    (is (re-find #"\[0\] = 0.0f" (:source artifact)))
+    (is (identical? out (execute out)))
+    (is (= 0.0 (double (aget out 0))))))
 
 (deftest typed-horizontal-fusion-lowers-to-one-explicit-multi-output-segmap
   (let [{:keys [program stats]} (route/attempt

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -56,6 +56,11 @@
   (raster.par/scan out acc 0.0 i n float
                    (clojure.core/+ acc (ra/aget x i))))
 
+(deftm ocl-session-exclusive-scan
+  [x :- (Array float) out :- (Array float) n :- Long] :- (Array float)
+  (raster.par/scan-exclusive out acc 0.0 i n float
+                             (clojure.core/+ acc (ra/aget x i))))
+
 (deftest ocl-map-void-mixed-storage-abi-roundtrip
   (if-not @device-probe/opencl-available?
     (device-probe/opencl-skip! "mixed-storage map-void")
@@ -128,6 +133,32 @@
       (is (= (float n) (aget out (dec n))))
       (is (every? (fn [i] (= (float (inc i)) (aget out i)))
                   [0 1 255 256 511 512 1024])))))
+
+(deftest ocl-resident-and-staged-exclusive-scan-use-the-same-typed-graph
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "resident and staged typed exclusive scan graph")
+    (let [n 1025
+          x (float-array (repeat n 1.0))
+          descriptor (pl/compile-gpu-program #'ocl-session-exclusive-scan
+                                             :ocl:0 :dtype :float)
+          session (gpu/make-session :ocl:0)]
+      (try
+        (is (= :exclusive
+               (get-in descriptor [:steps 0 :artifact :attributes :scan-mode])))
+        (let [out (float-array (inc n))
+              program (fixture/instantiate! session descriptor [x out n]
+                                            {'x :input 'out :output})
+              ^floats scanned (get (fixture/run! program [x out n]) 'out)]
+          (is (every? (fn [i] (= (float i) (aget scanned i)))
+                      [0 1 255 256 257 512 1024 1025])))
+        (let [execute (pl/compile-aot #'ocl-session-exclusive-scan
+                                      :target-device :ocl:0 :dtype :float)
+              out (float-array (inc n))
+              result (execute x out n)]
+          (is (identical? out result))
+          (is (every? (fn [i] (= (float i) (aget out i)))
+                      [0 1 255 256 257 512 1024 1025])))
+        (finally (gpu/close-session! session))))))
 
 (deftest ocl-resident-indexed-row-reduction-roundtrip
   (if-not @device-probe/opencl-available?


### PR DESCRIPTION
## Summary
- represent inclusive and exclusive prefix scans as one certified TypedSOAC scan operation with an explicit result-layout mode
- retain logical traversal extent n while recording exclusive result storage as checked n+1 integer-expression IR
- specialize the verified SegScan graph emitter to materialize the identity at zero and prefixes at idx+1
- preserve exact JVM semantics and execute the same graph through resident and staged OpenCL paths
- remove the backend-local raw exclusive-scan production route; unscheduled GPU source now fails loudly

## Verification
- focused scan/compiler/composition gate: 78 tests, 443 assertions
- focused TypedSOAC and descriptor gate: 40 tests, 267 assertions
- Intel Arc OpenCL session suite: 13 tests, 27 assertions, including n=1025 cross-block resident and staged exclusive scans
- zero-length exclusive identity coverage
- targeted cljfmt and git diff check

The full memory-heavy suite is delegated to CircleCI.