### PR TITLE
Route effect tuple maps through TypedSOAC

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1,6 +1,6 @@
 # Raster compiler north star
 
-Status: architectural direction, reconciled with the implementation on 2026-08-28.
+Status: architectural direction, reconciled with the implementation on 2026-08-30.
 
 Raster should become a compiler in which a typed Clojure program, its parallel
 algorithm, its schedule, its device placement, and its executable artifact are
@@ -111,6 +111,18 @@ identity are therefore orthogonal: resident and staged binders derive transfers 
 while composition identifies the returned value by role. OpenCL and Level Zero staged maps also
 use target-specific invocation markers selected by the emitter, rather than leaking a Level Zero
 runtime call into an OpenCL program.
+
+Effect-only pointwise maps now use the same orthogonal contract for several outputs. `map2!` and
+independent multi-store `map-void!` bodies become one tuple-valued TypedSOAC `map`: fresh logical
+result IDs remain SSA values, while an ordered checked `:result-storage` vector maps each result to
+its caller-owned destination, access mode, and host-return contract. The effect binder therefore
+retains its real `nil` host semantics instead of masquerading as a tensor result. The scheduled
+SegMap and its ordered ABI are consumed by staged and resident compilation; unsupported raw
+map-void bodies retain the compatibility generator. The front end refuses duplicate destinations,
+scatter indices, sibling write/read ordering, atomics, and shared local bindings whose projection
+would duplicate computation. The last case needs local SSA inside tuple scalar regions, not source
+substitution. Flat resident `deftm` signatures provide their declared per-buffer dtypes before
+fusion, so a mixed FP32/int8-input, FP32/int32-output map does not inherit a global default dtype.
 
 The first architectural correction is therefore:
 
@@ -827,9 +839,12 @@ The immediate continuation after the verified double-buffered weighted-reduction
    graph-backed resident executable through ordinary dispatch, LinkPlan and binding, and a generic
    per-call staging graph runner executes the same registered dispatch. Pointwise read/write map
    destinations lower to one physical `:inout` ABI result and execute through both resident and
-   staged binding without an aliased compatibility input. Hardware-costed
+   staged binding without an aliased compatibility input. Independent effect-only tuple maps also
+   carry an ordered logical-result-to-physical-storage contract and compile through their scheduled
+   SegMap on resident OpenCL execution. Hardware-costed
    multi-consumer fusion, nested-region JVM
-   scheduling, the remaining parallel forms, and
+   scheduling, local SSA for shared multi-result scalar regions, indexed/scatter operations, the
+   remaining parallel forms, and
    deletion of the remaining graph/backend fallbacks remain.
 6. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a
    read-only distributed track without interrupting the kernel and typed-middle-end verticals.

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -246,7 +246,7 @@
 (defn- emit-map-void-invocation
   "Render the staging marker from the artifact's logical argument projection. The marker remains
    useful to the host evaluator, but it no longer owns or reconstructs an argument convention."
-  [artifact]
+  [artifact device-id]
   (let [plan (kcall/logical-argument-plan artifact)
         pointer-values (mapv :value (filterv :pointer? plan))
         scalar-entries (filterv (complement :pointer?) plan)
@@ -255,7 +255,9 @@
     (when-not (= 1 (count bound-entries))
       (throw (ex-info "map-void artifact must identify exactly one :bound scalar"
                       {:kernel-name (:kernel-name artifact) :plan plan})))
-    (list 'raster.gpu.ze-runtime/invoke-registered-map-void-kernel
+    (list (if (and device-id (.startsWith (name device-id) "ocl"))
+            'raster.gpu.ocl-runtime/invoke-registered-map-void-kernel
+            'raster.gpu.ze-runtime/invoke-registered-map-void-kernel)
           (:kernel-name artifact)
           pointer-values
           (mapv :value user-scalars)
@@ -265,8 +267,9 @@
   "Pipeline pass: walk S-expression, replace par forms with GPU kernel invocations.
 
    Uses full SegOp conversion for par/map! and par/reduce.
-   Delegates to specialized generators for stencil, scatter,
-   scan, rng-fill, active-ids, reduce-by-key, compound-kernel, map-void).
+   Certified effect-only map-void forms consume their scheduled TypedSOAC SegMap; unsupported
+   bodies and the remaining stencil, scatter, rng, active-id and key-reduction forms retain
+   explicit compatibility generators.
 
    Returns {:form new-form :stats {:ze-maps N :ze-reduces N :fallback N}
             :kernels [{:kernel-name :source ...} ...]}
@@ -508,7 +511,7 @@
                   kernel (segop-cl/generate-product-reduction-kernel
                           segred :scalar-types top-scalar-types :array-types top-array-types)
                   k (register-kernel! kernel :ze-reduces)]
-              (emit-map-void-invocation k))
+              (emit-map-void-invocation k device-id))
 
             ;; === Specialized forms — delegate to legacy generators ===
 
@@ -518,12 +521,22 @@
               (if (and (number? bound) (< bound min-elements))
                 (do (swap! stats update :fallback inc)
                     (par/expand-par-map-void! form))
-                (let [kernel (legacy/generate-par-map-void-kernel form
-                                                                  :dtype dtype :device-id device-id
-                                                                  :array-types top-array-types
-                                                                  :scalar-types top-scalar-types)
+                (let [scheduled (take-bound-segop
+                                 stats :segmap
+                                 #(and (instance? raster.compiler.ir.segop.SegMap %)
+                                       (= :typed-soac (:algorithm-dialect %))))
+                      kernel (if scheduled
+                               (segop-cl/generate-segmap-kernel
+                                scheduled (:out-sym scheduled)
+                                :dtype (:dtype scheduled)
+                                :scalar-types top-scalar-types
+                                :array-types top-array-types)
+                               (legacy/generate-par-map-void-kernel
+                                form :dtype dtype :device-id device-id
+                                :array-types top-array-types
+                                :scalar-types top-scalar-types))
                       k (register-kernel! kernel :ze-maps)]
-                  (emit-map-void-invocation k))))
+                  (emit-map-void-invocation k device-id))))
 
             ;; par/scan-exclusive
             (par/par-scan-exclusive-form? form)
@@ -591,7 +604,7 @@
                          (legacy/generate-par-gather-kernel form
                                                             :dtype dtype :device-id device-id)
                          :ze-maps)]
-                  (emit-map-void-invocation k))))
+                  (emit-map-void-invocation k device-id))))
 
             ;; par/reduce-by-key
             (par/par-reduce-by-key-form? form)

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -31,8 +31,11 @@
 
    Scan mode may be `:inclusive` or `:exclusive`; it is an explicit result-layout property. Map
    lambdas return tuples, so horizontal fusion remains functional rather than encoding
-   secondary results as hidden stores. Captures are explicit operands with explicit scalar lambda
-   parameters, so stable value IDs never leak into lexical expression binding."
+   secondary results as hidden stores. Caller-owned map outputs use an equation-fact
+   `:result-storage` vector aligned with those functional results; logical SSA identity therefore
+   stays separate from physical write identity and host return semantics. Captures are explicit
+   operands with explicit scalar lambda parameters, so stable value IDs never leak into lexical
+   expression binding."
   (:require [clojure.set :as set]
             [pattern.nanopass.dialect :as dialect
              :refer [def-dialect]]
@@ -220,6 +223,28 @@
       (let [[_ attributes arrays captures lambda] operation]
         {:kind kind :attributes attributes :arrays arrays :captures captures :lambda lambda}))))
 
+(defn result-storage
+  "Ordered physical storage contracts for an equation's functional results.
+
+   A map that writes caller-owned buffers still defines fresh functional values. Each entry maps
+   one equation result to the physical destination used when that result is materialized. Absence
+   means the equation owns fresh result storage. The vector is aligned with the equation results;
+   it is deliberately not a destination-name registry reconstructed by a backend."
+  [program-or-facts equation-id]
+  (get-in (if (program-form? program-or-facts)
+            (facts program-or-facts)
+            program-or-facts)
+          [:equations equation-id :attributes :result-storage]))
+
+(defn physical-results
+  "Resolve an equation's ordered logical results to their physical storage identities."
+  [program-or-facts equation]
+  (let [results (vec (nth equation 2))
+        storage (result-storage program-or-facts (second equation))]
+    (if (seq storage)
+      (mapv :destination storage)
+      results)))
+
 (defn parameter-layout
   "Split a SOAC lambda's ordered parameters into semantic roles."
   [equation]
@@ -406,6 +431,57 @@
 
       nil)))
 
+(defn- validate-result-storage!
+  [program-facts equation]
+  (let [[_ equation-id results] equation
+        {:keys [kind]} (operation-parts equation)
+        storage (result-storage program-facts equation-id)]
+    (when storage
+      (when-not (= 'map kind)
+        (fail! :typed-soac-result-storage-operation
+               "physical result storage is currently valid only for map equations"
+               {:equation equation-id :operation kind :storage storage}))
+      (when-not (and (vector? storage)
+                     (= (count results) (count storage))
+                     (every? #(and (map? %)
+                                   (value-id? (:destination %))
+                                   (contains? #{:write :read-write} (:access %))
+                                   (contains? #{:buffer :effect} (:host-return %)))
+                             storage))
+        (fail! :typed-soac-result-storage
+               "result storage must align every map result with a typed destination contract"
+               {:equation equation-id :results results :storage storage}))
+      (let [destinations (mapv :destination storage)
+            aliases (get-in program-facts [:equations equation-id :aliases])]
+        (when-not (= (count destinations) (count (distinct destinations)))
+          (fail! :typed-soac-result-storage-alias
+                 "one pointwise equation may write each physical destination only once"
+                 {:equation equation-id :destinations destinations}))
+        (doseq [[result destination] (map vector results destinations)]
+          (when-not (= destination (get aliases result))
+            (fail! :typed-soac-result-storage-alias
+                   "every stored functional result must explicitly alias its physical destination"
+                   {:equation equation-id :result result :destination destination
+                    :aliases aliases})))
+        (when-not (contains? (get-in program-facts [:equations equation-id :effects])
+                             :memory/write)
+          (fail! :typed-soac-result-storage-effect
+                 "physical result storage requires an explicit memory-write effect"
+                 {:equation equation-id :storage storage}))
+        (doseq [[result destination] (map vector results destinations)
+                :let [logical (get-in program-facts [:values result])
+                      physical (get-in program-facts [:values destination])]]
+          (when-not physical
+            (fail! :typed-soac-result-storage-value
+                   "a physical result destination requires an AbstractValue"
+                   {:equation equation-id :result result :destination destination}))
+          (when (and logical physical
+                     (not= (dissoc logical :shape) (dissoc physical :shape)))
+            (fail! :typed-soac-result-storage-type
+                   "logical result and physical destination storage types disagree"
+                   {:equation equation-id :result result :destination destination
+                    :logical logical :physical physical})))))))
+
 (defn validate!
   "Validate syntax, typed value references, ordered SSA definitions and explicit effects.
    Returns the input program unchanged."
@@ -443,7 +519,8 @@
              {:facts equation-fact-ids :equations (set equation-ids)}))
     (doseq [equation equations]
       (validate-equation! equation)
-      (validate-equation-types! values equation))
+      (validate-equation-types! values equation)
+      (validate-result-storage! program-facts equation))
     (let [definitions (mapcat #(nth % 2) equations)
           definition-set (set definitions)
           references (set (mapcat (fn [equation]
@@ -457,11 +534,16 @@
       (when-not (= (count definitions) (count definition-set))
         (fail! :typed-soac-definitions "logical values may be defined by only one equation"
                {:definitions definitions}))
-      (doseq [id (set/union definition-set references (set program-inputs)
-                            (set program-outputs))]
-        (when-not (contains? values id)
-          (fail! :typed-soac-unknown-value "SOAC program references an unknown value"
-                 {:id id})))
+      (let [storage-destinations
+            (set (mapcat (fn [equation]
+                           (map :destination
+                                (or (result-storage program-facts (second equation)) [])))
+                         equations))]
+        (doseq [id (set/union definition-set references storage-destinations
+                              (set program-inputs) (set program-outputs))]
+          (when-not (contains? values id)
+            (fail! :typed-soac-unknown-value "SOAC program references an unknown value"
+                   {:id id}))))
       (when-not (= external (set program-inputs))
         (fail! :typed-soac-input-boundary
                "program inputs must exactly name values used but not defined"
@@ -545,7 +627,14 @@
         equation-facts
         (into {}
               (map (fn [[id equation-facts]]
-                     [id (update equation-facts :aliases rename-aliases)]))
+                     [id (-> equation-facts
+                             (update :aliases rename-aliases)
+                             (cond-> (seq (get-in equation-facts
+                                                  [:attributes :result-storage]))
+                               (update-in [:attributes :result-storage]
+                                          #(mapv (fn [storage]
+                                                   (update storage :destination rename))
+                                                 %))))]))
               (:equations source-facts))
         facts' (assoc source-facts
                       :values values

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -56,9 +56,8 @@
           [_ _ body-results] lambda
           {:keys [elements capture-parameters]} (soac-dialect/parameter-layout equation)
           _ (when-not (and (seq results)
-                           (= (count results) (count body-results))
-                           (every? symbol? results))
-              (throw (ex-info "typed SegMap requires one scalar body result per symbolic output"
+                           (= (count results) (count body-results)))
+              (throw (ex-info "typed SegMap requires one scalar body result per logical output"
                               {:reason :typed-soac-map-subset
                                :equation equation-id :results results})))
           index (:index attributes)
@@ -71,14 +70,16 @@
                             par/expand-par-forms)
                        body-results)
           result (first results)
-          values (:values (soac-dialect/facts program))
+          facts (soac-dialect/facts program)
+          values (:values facts)
+          physical-results (soac-dialect/physical-results facts equation)
           secondary-stores
-          (mapv (fn [secondary-result secondary-body]
-                  (let [secondary-dtype (:dtype (get values secondary-result))
+          (mapv (fn [logical-result secondary-result secondary-body]
+                  (let [secondary-dtype (:dtype (get values logical-result))
                         cast (dtype/scalar-tag-for-dtype secondary-dtype)]
                     (list 'clojure.core/aset secondary-result index
                           (list cast secondary-body))))
-                (rest results) (rest bodies))
+                (rest results) (rest physical-results) (rest bodies))
           body (if (seq secondary-stores)
                  (list* 'do (concat secondary-stores [(first bodies)]))
                  (first bodies))
@@ -87,14 +88,13 @@
           scalar-captures (set (remove stable-array-captures captures))
           result-dtype (or (:dtype (get values result))
                            dtype :double)
-          destination (get-in (soac-dialect/facts program)
-                              [:equations equation-id :attributes :destination])
-          physical-result (or destination result)
+          storage (soac-dialect/result-storage facts equation-id)
+          physical-result (first physical-results)
           node (assoc (soac/->SoacMap equation-id result index (:extent attributes) nil body
                                       (into (set arrays) stable-array-captures)
-                                      (if destination #{physical-result} (set results))
+                                      (set physical-results)
                                       scalar-captures)
-                      :sym physical-result :elem-type result-dtype :pure? (nil? destination))]
+                      :sym physical-result :elem-type result-dtype :pure? (nil? storage))]
       (mapv #(assoc % :algorithm-dialect :typed-soac
                     :algorithm-equation equation-id)
             (lower-map node device-id :dtype result-dtype)))))

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -50,38 +50,104 @@
     (second expression)
     expression))
 
-(defn- pointwise-map-void
-  "Recognize one pointwise store without erasing or duplicating effects.
+(defn- pointwise-stores
+  "Recognize an ordered body made exclusively of pointwise stores.
 
-   The let-wrapper case is the closed form produced by the walker.  Its initializers must be pure
-   because flattening them into the element expression changes their evaluation placement."
+   Pure let bindings are substituted into every result expression. That projection is semantic,
+   not permission to reorder stores: callers additionally prove that destinations are distinct
+   and no result reads a sibling destination. Bodies with atomics, scatter indices, duplicate
+   destinations, or other effects return nil and remain on the compatibility route."
   [body index]
-  (let [statement (if (and (seq? body) (= 'do (first body)) (= 2 (count body)))
-                    (second body)
-                    body)]
-    (cond
-      (and (seq? statement) (form/let-head? (first statement)))
-      (let [[_ bindings & nested-body] statement]
-        (when (and (= 1 (count nested-body))
-                   (not-any? util/effectful? (take-nth 2 (rest bindings))))
-          (when-let [inner (pointwise-map-void (first nested-body) index)]
-            (update inner :value #(util/subst-syms (util/binding-env bindings) %)))))
+  (cond
+    (and (seq? body) (form/let-head? (first body)))
+    (let [[_ bindings & nested-body] body]
+      (when (and (even? (count bindings))
+                 (seq nested-body)
+                 (not-any? util/effectful? (take-nth 2 (rest bindings))))
+        (when-let [stores (pointwise-stores (list* 'do nested-body) index)]
+          (let [binding-initializers (into {} (map vec) (partition 2 bindings))
+                binding-symbols (set (keys binding-initializers))
+                dependencies
+                (fn [expression]
+                  (loop [pending (set/intersection binding-symbols
+                                                   (util/free-syms expression))
+                         seen #{}]
+                    (if-let [binding (first pending)]
+                      (let [nested (set/intersection
+                                    binding-symbols
+                                    (util/free-syms (get binding-initializers binding)))]
+                        (recur (set/union (disj pending binding)
+                                          (set/difference nested seen))
+                               (conj seen binding)))
+                      seen)))
+                store-dependencies (mapv #(dependencies (:value %)) stores)
+                shared? (some (fn [binding]
+                                (< 1 (count (filter #(contains? % binding)
+                                                    store-dependencies))))
+                              binding-symbols)]
+            ;; TypedSOAC's current tuple-map region has no shared local binding spine. Duplicating
+            ;; a common initializer into several results is semantically valid but a performance
+            ;; regression, so retain that body unchanged until scalar regions own local SSA.
+            (when-not shared?
+              (let [environment (util/binding-env bindings)]
+                (mapv #(update % :value (fn [value]
+                                          (util/subst-syms environment value)))
+                      stores)))))))
 
-      (descriptor/aset-call? statement)
-      (let [arguments (vec (descriptor/call-args statement))]
-        (when (and (= 3 (count arguments))
-                   (= index (strip-index-cast (nth arguments 1))))
-          (let [value (nth arguments 2)
-                cast? (and (seq? value)
-                           (contains? #{'float 'double 'int 'long
-                                        'clojure.core/float 'clojure.core/double}
-                                      (first value))
-                           (= 2 (count value)))]
-            {:out (descriptor/aset-array-sym statement)
-             :value (if cast? (second value) value)
-             :cast (when cast? (first value))})))
+    (and (seq? body) (= 'do (first body)))
+    (let [groups (mapv #(pointwise-stores % index) (rest body))]
+      (when (and (seq groups) (every? seq groups))
+        (vec (mapcat identity groups))))
 
-      :else nil)))
+    (descriptor/aset-call? body)
+    (let [arguments (vec (descriptor/call-args body))]
+      (when (and (= 3 (count arguments))
+                 (= index (strip-index-cast (nth arguments 1))))
+        (let [value (nth arguments 2)
+              cast? (and (seq? value)
+                         (contains? #{'float 'double 'int 'long
+                                      'clojure.core/float 'clojure.core/double}
+                                    (first value))
+                         (= 2 (count value)))]
+          [{:out (descriptor/aset-array-sym body)
+            :value (if cast? (second value) value)
+            :cast (when cast? (first value))}])))
+
+    :else nil))
+
+(defn- independent-pointwise-stores?
+  [stores]
+  (let [destinations (mapv :out stores)
+        destination-set (set destinations)]
+    (and (= (count destinations) (count destination-set))
+         (every? (fn [{:keys [out value]}]
+                   (empty? (disj (set/intersection destination-set
+                                                   (par/collect-aget-arrays value))
+                                 out)))
+                 stores))))
+
+(defn- effect-result-id
+  [equation-id ordinal]
+  [:effect-map equation-id ordinal])
+
+(defn- effect-map-description
+  [id symbol index extent stores elem-type]
+  (when (and (seq stores) (independent-pointwise-stores? stores))
+    (let [destinations (mapv :out stores)
+          values (mapv :value stores)
+          io (extract-io (list* 'do values) index destinations)
+          results (mapv #(effect-result-id id %) (range (count stores)))]
+      (merge {:kind :map :id id :sym symbol :index index :extent extent
+              :results results :bodies values :casts (mapv :cast stores)
+              :effect-only? true :host-binding symbol :elem-type elem-type
+              :result-storage
+              (mapv (fn [destination]
+                      {:destination destination
+                       :access (if (contains? (:inputs io) destination)
+                                 :read-write :write)
+                       :host-return :effect})
+                    destinations)}
+             io))))
 
 (defn- operation-description
   [id symbol expression]
@@ -89,7 +155,8 @@
     (par/par-map-pure-form? expression)
     (let [{:keys [idx bound cast body elem-type]} (par/extract-par-map-pure-info expression)
           io (extract-io body idx [symbol])]
-      (merge {:kind :map :id id :sym symbol :index idx :extent bound :cast cast :body body
+      (merge {:kind :map :id id :sym symbol :results [symbol]
+              :index idx :extent bound :casts [cast] :bodies [body]
               :pure? true :elem-type elem-type}
              io))
 
@@ -103,11 +170,22 @@
       ;; of the destination is an explicit read/write operand; scheduling must retain it as one
       ;; physical inout value rather than manufacturing separate aliased input/output pointers.
       (when-not (or offset (= symbol out))
-        (merge {:kind :map :id id :sym symbol :index idx :extent bound :cast cast :body body
-                :primary-out out :destination-return :buffer
-                :destination-access (if (contains? (:inputs io) out) :read-write :write)
+        (merge {:kind :map :id id :sym symbol :results [symbol]
+                :index idx :extent bound :casts [cast] :bodies [body]
+                :result-storage [{:destination out
+                                  :access (if (contains? (:inputs io) out) :read-write :write)
+                                  :host-return :buffer}]
+                :host-binding symbol
                 :elem-type elem-type}
                io)))
+
+    (par/par-map2-form? expression)
+    (let [{:keys [out1 out2 idx bound cast body1 body2 elem-type]}
+          (par/extract-par-map2-info expression)]
+      (effect-map-description id symbol idx bound
+                              [{:out out1 :value body1 :cast cast}
+                               {:out out2 :value body2 :cast cast}]
+                              elem-type))
 
     (par/par-reduce-form? expression)
     (let [{:keys [acc init idx bound body elem-type]} (par/extract-par-reduce-info expression)
@@ -145,10 +223,8 @@
 
     (par/par-map-void-form? expression)
     (let [{:keys [idx bound body elem-type]} (par/extract-par-map-void-info expression)]
-      (when-let [{:keys [out value cast]} (pointwise-map-void body idx)]
-        (merge {:kind :map :id id :sym symbol :index idx :extent bound :cast cast :body value
-                :void? true :primary-out out :elem-type elem-type}
-               (extract-io value idx [out]))))
+      (when-let [stores (pointwise-stores body idx)]
+        (effect-map-description id symbol idx bound stores elem-type)))
 
     :else nil))
 
@@ -232,7 +308,9 @@
                 :scalar (or (provably-pure-scalar? (:expr description))
                             (generated-scaffolding? description physical-outputs))
                 :map (or (:pure? description)
-                         (symbol? (:primary-out description)))
+                         (and (seq (:result-storage description))
+                              (every? (comp symbol? :destination)
+                                      (:result-storage description))))
                 :reduce true
                 :scan (symbol? (:primary-out description))
                 false))
@@ -259,25 +337,20 @@
 
 (defn- map-equation
   [description]
-  (let [{:keys [id sym index extent cast body inputs primary-out void?]} description
-        expression (if cast (list cast body) body)
-        [pointwise stable] ((juxt filter remove) #(pointwise-input? [expression] % index) inputs)
+  (let [{:keys [id index extent casts bodies inputs results]} description
+        expressions (mapv (fn [cast body] (if cast (list cast body) body)) casts bodies)
+        [pointwise stable] ((juxt filter remove) #(pointwise-input? expressions % index) inputs)
         arrays (vec (sort-by pr-str pointwise))
-        ;; map-void's destination remains a lexical stable capture in the existing dialect.
-        ;; A destination-returning map carries its write-only destination in equation facts; making
-        ;; it a capture would also make it a kernel input and duplicate the output pointer.
-        stable (cond-> (set stable) void? (conj primary-out))
         captures (vec (sort-by pr-str (distinct (concat stable (:scalars description)))))
         parameters (element-symbols (count arrays))
         capture-parameters (capture-symbols (count captures))
-        body-result (util/subst-syms
-                     (zipmap captures capture-parameters)
-                     (first (elementize [expression] arrays parameters index)))]
-    (list '= id [sym]
+        body-results (mapv #(util/subst-syms (zipmap captures capture-parameters) %)
+                           (elementize expressions arrays parameters index))]
+    (list '= id results
           (list 'map {:index index :extent extent
                       :attributes {:stable-array-captures (vec (sort-by pr-str stable))}}
                 arrays captures
-                (list 'lambda (vec (concat parameters capture-parameters)) [body-result])))))
+                (list 'lambda (vec (concat parameters capture-parameters)) body-results)))))
 
 (defn- reduce-equation
   [{:keys [id extent inputs scalars product]}]
@@ -356,9 +429,16 @@
   [descriptions body]
   (let [operations (filter #(contains? #{:map :reduce :scan} (:kind %)) descriptions)
         operation-definitions (set (mapcat #(case (:kind %)
-                                              (:map :scan) [(:sym %)]
+                                              :map (:results %)
+                                              :scan [(:sym %)]
                                               (:outputs %))
                                            operations))
+        terminal-operation-definitions
+        (set (mapcat #(case (:kind %)
+                        :map (if (:effect-only? %) [] (:results %))
+                        :scan [(:sym %)]
+                        (:outputs %))
+                     operations))
         scalar-definitions (set (keep #(when (= :scalar (:kind %)) (:sym %)) descriptions))
         all-definitions (set/union operation-definitions scalar-definitions)
         operation-uses (set (concat (mapcat #(concat (:inputs %) (:scalars %)) operations)
@@ -367,7 +447,7 @@
                                             descriptions)))
         body-uses (set (mapcat util/free-syms body))]
     (vec (sort-by pr-str
-                  (set/union (set/difference operation-definitions operation-uses)
+                  (set/union (set/difference terminal-operation-definitions operation-uses)
                              (set/intersection all-definitions body-uses))))))
 
 (defn- selected-scalars
@@ -402,7 +482,7 @@
                         scalar (:dtypes attributes)
                         reduce (:dtypes attributes)
                         scan (:dtypes attributes)
-                        (repeat (count results) default-dtype))]
+                        map (map #(value-dtype % default-dtype array-types) results))]
     (merge
      (if (and extent (dialect/value-id? extent)) {extent (tensor-value :long [])} {})
      (into {} (map (fn [id] [id (tensor-value (value-dtype id default-dtype array-types)
@@ -503,27 +583,38 @@
                                          (and (:extent %) (dialect/value-id? (:extent %)))
                                          (conj (:extent %))) equation-info))
               inputs (vec (sort-by pr-str (set/difference references definitions)))
+              logical-result-types
+              (into {}
+                    (mapcat (fn [description]
+                              (map (fn [result storage]
+                                     [result (value-dtype (:destination storage)
+                                                          dtype array-types)])
+                                   (:results description)
+                                   (:result-storage description))))
+                    (filter :result-storage equation-descriptions))
+              array-types' (merge array-types logical-result-types)
               destination-values
               (into {}
-                    (keep (fn [description]
-                            (when-let [destination (:primary-out description)]
-                              [destination
-                               (tensor-value
-                                (value-dtype destination dtype array-types)
-                                [(list 'unknown-dimension destination)])])))
+                    (mapcat (fn [description]
+                              (map (fn [{:keys [destination]}]
+                                     [destination
+                                      (tensor-value
+                                       (value-dtype destination dtype array-types)
+                                       [(list 'unknown-dimension destination)])])
+                                   (:result-storage description))))
                     equation-descriptions)
               inferred-values (reduce (fn [contracts equation]
                                         (reduce-kv merge-value contracts
-                                                   (equation-values equation dtype array-types
+                                                   (equation-values equation dtype array-types'
                                                                     contracts)))
                                       destination-values equations)
               values (reduce-kv merge-value inferred-values values)
               equation-facts
               (into {}
                     (map (fn [description]
-                           (let [destination (when (or (:primary-out description)
-                                                       (= :scan (:kind description)))
-                                               (:primary-out description))]
+                           (let [destination (when (= :scan (:kind description))
+                                               (:primary-out description))
+                                 storage (:result-storage description)]
                              [(:id description)
                               (cond-> (dialect/default-equation-facts
                                        {:front-end :analyzed-source
@@ -531,13 +622,16 @@
                                 destination
                                 (assoc :effects #{:memory/write}
                                        :aliases {(:sym description) destination}
-                                       :attributes (cond-> {:destination destination}
-                                                     (:destination-access description)
-                                                     (assoc :destination-access
-                                                            (:destination-access description))
-                                                     (:destination-return description)
-                                                     (assoc :destination-return
-                                                            (:destination-return description)))))]))
+                                       :attributes {:destination destination})
+                                storage
+                                (assoc :effects #{:memory/write}
+                                       :aliases (into {}
+                                                      (map (fn [result {:keys [destination]}]
+                                                             [result destination])
+                                                           (:results description) storage))
+                                       :attributes {:result-storage storage
+                                                    :host-binding
+                                                    (:host-binding description)}))]))
                          equation-descriptions))
               total-effects (reduce set/union #{} (map :effects (vals equation-facts)))
               facts (dialect/default-program-facts

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -199,7 +199,13 @@
   (let [definitions (set (mapcat #(nth % 2) equations))
         references (set (mapcat equation-references equations))
         inputs (vec (sort-by pr-str (set/difference references definitions)))
-        live-values (set/union definitions references (set (dialect/outputs program)))
+        storage-destinations
+        (set (mapcat (fn [equation]
+                       (map :destination
+                            (or (dialect/result-storage facts (second equation)) [])))
+                     equations))
+        live-values (set/union definitions references storage-destinations
+                               (set (dialect/outputs program)))
         facts (-> facts
                   (assoc :inputs inputs)
                   (update :values select-keys live-values))]

--- a/src/raster/compiler/passes/parallel/typed_soac_resident.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_resident.clj
@@ -194,7 +194,12 @@
                                         (conj (dialect/operation-extent equation))))
                                     rewritten))
             inputs (vec (sort-by pr-str (set/difference references definitions)))
-            live-values (set/union definitions references outputs)
+            storage-destinations
+            (set (mapcat (fn [equation]
+                           (map :destination
+                                (or (dialect/result-storage facts (second equation)) [])))
+                         rewritten))
+            live-values (set/union definitions references storage-destinations outputs)
             facts (-> facts
                       (assoc :values (select-keys values live-values)
                              :inputs inputs)

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -27,7 +27,7 @@
                  (dialect/value-id? extent) (conj extent))
         source-facts (dialect/facts program)
         equation-facts (get-in source-facts [:equations equation-id])
-        value-ids (set (concat inputs results))
+        value-ids (set (concat inputs results (dialect/physical-results source-facts equation)))
         facts (-> source-facts
                   (assoc :values (select-keys (:values source-facts) value-ids)
                          :inputs (vec inputs)
@@ -98,41 +98,52 @@
                                   {:reason :typed-soac-materialization-dtype
                                    :results results :dtypes result-dtypes})))
               cast (first casts)
-              destination (get-in placement-facts [:attributes :destination])
-              _ (when (and destination (not= 1 (count results)))
-                  (throw (ex-info "an effectful map destination cannot have fused logical outputs"
+              storage (dialect/result-storage (dialect/facts program) equation-id)
+              physical-results (dialect/physical-results (dialect/facts program) equation)
+              host-binding (or (get-in placement-facts [:attributes :host-binding]) result)
+              host-returns (set (map :host-return storage))
+              _ (when (and storage
+                           (not (or (= #{:effect} host-returns)
+                                    (and (= 1 (count storage))
+                                         (= #{:buffer} host-returns)))))
+                  (throw (ex-info "stored map results require one coherent host return contract"
                                   {:reason :typed-soac-production-subset
-                                   :equation equation-id :results results
-                                   :destination destination})))
+                                   :equation equation-id :storage storage})))
               secondary-stores
               (mapv (fn [secondary secondary-cast body]
                       (list 'clojure.core/aset secondary (:index attributes)
                             (list secondary-cast body)))
-                    (rest results) (rest casts) (rest bodies))
+                    (rest physical-results) (rest casts) (rest bodies))
               body (if (seq secondary-stores)
                      (list* 'do (concat secondary-stores [(first bodies)]))
                      (first bodies))
-              destination-return (get-in placement-facts
-                                         [:attributes :destination-return])
               effect (gensym (str "typed_soac_map_" equation-id "__"))
               source (with-meta
-                       (if destination
-                         (if (= :buffer destination-return)
-                           (list 'raster.par/map! destination (:index attributes)
-                                 (:extent attributes) cast body)
-                           (list 'raster.par/map-void! (:index attributes) (:extent attributes)
-                                 (list 'clojure.core/aset destination (:index attributes)
-                                       (list cast body))))
+                       (cond
+                         (= #{:effect} host-returns)
+                         (list 'raster.par/map-void! (:index attributes) (:extent attributes)
+                               (list* 'do
+                                      (map (fn [destination result-cast result-body]
+                                             (list 'clojure.core/aset destination
+                                                   (:index attributes)
+                                                   (list result-cast result-body)))
+                                           physical-results casts bodies)))
+
+                         (= #{:buffer} host-returns)
+                         (list 'raster.par/map! (first physical-results) (:index attributes)
+                               (:extent attributes) cast (first bodies))
+
+                         :else
                          (list 'raster.par/map! result (:index attributes) (:extent attributes)
                                cast body))
                        {:raster.type/elem-type (first result-dtypes)})]
           {:equation-id equation-id
            :placement placement
-           :pairs (if destination
-                    [[result source]]
+           :pairs (if storage
+                    [[host-binding source]]
                     (conj (mapv #(allocation-pair values % (:extent attributes)) results)
                           [effect source]))
-           :site [:binding (if destination result effect)]
+           :site [:binding (if storage host-binding effect)]
            :source source}))
 
       reduce
@@ -194,8 +205,11 @@
         by-placement (group-by :placement realized)
         physical-destinations
         (into #{}
-              (keep (fn [[_ equation-facts]]
-                      (get-in equation-facts [:attributes :destination])))
+              (mapcat (fn [[_ equation-facts]]
+                        (concat
+                         (keep identity [(get-in equation-facts [:attributes :destination])])
+                         (map :destination
+                              (get-in equation-facts [:attributes :result-storage])))))
               (:equations (dialect/facts program)))
         pairs
         (vec

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -595,7 +595,7 @@
   Phase 0/2 of .internal/ad_typed_emission_plan.md), keyed by census-rhs-head:
 
     1. void-returning SOAC/effect STATEMENT bindings (raster.par/map-void!,
-       dotimes) — the binding exists only to sequence an effect; there is no
+       raster.par/map2!, dotimes) — the binding exists only to sequence an effect; there is no
        result VALUE to tag (the census's untagged-binding-pairs already excludes
        fn* pullback closures and loop*/dotimes BINDERS for the same reason).
     2. clojure.core integer scalar arithmetic on Long dims/indices — see
@@ -609,6 +609,7 @@
   edge."
   [head]
   (or (contains? '#{raster.par/map-void! par/map-void!
+                    raster.par/map2! par/map2!
                     raster.par/product-reduce! par/product-reduce! dotimes} head)
       (contains? census-exempt-int-arith-heads head)
       (= :vector head)))
@@ -754,6 +755,8 @@
     (write-read-fuse/fuse-write-read form)
     {:form form :stats {:write-read-fused 0}}))
 
+(declare top-level-binding-form)
+
 (defn- pass-soac-fuse
   "SOAC graph-based fusion: vertical (map→map, map→reduce, map→scan),
   horizontal (independent same-bound maps), iterated to fixpoint.
@@ -788,8 +791,20 @@
           {:form (list* let-sym new-bindings body-exprs)
            :stats (cond-> stats
                     (:declined typed) (assoc :typed-soac-declined (:declined typed)))})))
-    ;; Not a let* form — fall back to par-fusion
-    (par-fusion/par-fusion-pass form)))
+    ;; A bare top-level parallel expression has no binding site for the direct SSA front end.
+    ;; Normalize it only HERE, after fixpoint/type analysis, and retain the wrapper only when the
+    ;; typed route accepts it. Unsupported forms must reach compatibility lowering unchanged.
+    (let [source (top-level-binding-form form)
+          typed (typed-soac-route/attempt
+                 source (:dtype opts) (:array-types opts)
+                 {:resident-reductions? (true? (:resident-reductions? opts))
+                  :scalar-types (:scalar-types opts)})]
+      (if (:program typed)
+        {:form (:program typed) :stats (:stats typed)}
+        (let [fallback (par-fusion/par-fusion-pass form)]
+          (cond-> fallback
+            (:declined typed)
+            (assoc-in [:stats :typed-soac-declined] (:declined typed))))))))
 
 (defn- register-gpu-kernels!
   "Register generated GPU kernels eagerly so they're available at eval time.
@@ -1269,6 +1284,7 @@
 
 (def ^:private gpu-invoke-heads
   '#{raster.gpu.ze-runtime/invoke-registered-map-void-kernel
+     raster.gpu.ocl-runtime/invoke-registered-map-void-kernel
      raster.gpu.ze-runtime/invoke-registered-kernel
      raster.gpu.ocl-runtime/invoke-registered-kernel
      raster.gpu.ze-runtime/invoke-registered-reduction-kernel
@@ -1354,7 +1370,9 @@
   (let [head (first expr)
         argc (count expr)]
     (cond
-      (= head 'raster.gpu.ze-runtime/invoke-registered-map-void-kernel)
+      (contains? '#{raster.gpu.ze-runtime/invoke-registered-map-void-kernel
+                    raster.gpu.ocl-runtime/invoke-registered-map-void-kernel}
+                 head)
       (when (= 5 argc)
         (let [[_ kname arrays scalars n] expr]
           {:kernel-name kname :arrays (vec arrays) :scalars (vec scalars) :n-expr n
@@ -1707,6 +1725,13 @@
                           d-params* d-tags*)
         value-reg   @types/soa-registry
         value-fn?   (boolean (some #(contains? value-reg (:tag %)) param-specs))
+        pre-gpu-param-types
+        ;; Flat signatures already have their authoritative walker/deftm parameter tags. Give
+        ;; TypedSOAC those facts before fusion instead of defaulting every resident array to the
+        ;; program dtype. Value-type signatures are derived only after SoA expansion below.
+        (when-not value-fn?
+          (opencl-pass/derive-param-types
+           (mapv :sym param-specs) (mapv :tag param-specs) effective-dtype))
         pre-opts (cond-> {:inline? true :simd? false :target-device device-id
                           :active-params active-params :dtype effective-dtype
                           ;; Resident reduction realization is a TypedSOAC transform. The logical
@@ -1714,7 +1739,10 @@
                           ;; roles keep the physical one-element buffer resident.
                           :resident-reductions? true}
                    param-env (assoc :param-env param-env)
-                   source-ns (assoc :source-ns source-ns))
+                   source-ns (assoc :source-ns source-ns)
+                   pre-gpu-param-types
+                   (assoc :scalar-types (:scalar-types pre-gpu-param-types)
+                          :array-types (:array-types pre-gpu-param-types)))
         raw-form (if (= 1 (count walked-body)) (first walked-body) (cons 'do walked-body))
         form-mat (run-passes raw-form gpu-resident-pre-soa-passes pre-opts)
         {form-soa :body eff-param-specs :params}

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -176,19 +176,22 @@
 
 (deftest opencl-pass-map-void-marker-follows-abi-test
   (testing "the compatibility marker is projected from the ordered ABI"
-    (let [form '(raster.par/map-void! i n
-                                      (do (aset y i (* scale (aget x i)))
-                                          (aset state i (+ (aget state i) limit))))
-          result (opencl-pass/opencl-pass
-                  form :device-id :ze:0 :dtype :float
-                  :array-types {'state :int 'x :float 'y :float}
-                  :scalar-types {'limit :int 'scale :float})
-          marker (:form result)
-          abi (:abi (first (:kernels result)))]
-      (is (= 'raster.gpu.ze-runtime/invoke-registered-map-void-kernel (first marker)))
-      (is (= (kabi/pointer-binding-names abi) (nth marker 2)))
-      (is (= '[limit scale] (nth marker 3)))
-      (is (= 'n (nth marker 4))))))
+    (doseq [[device expected-head]
+            [[:ze:0 'raster.gpu.ze-runtime/invoke-registered-map-void-kernel]
+             [:ocl:0 'raster.gpu.ocl-runtime/invoke-registered-map-void-kernel]]]
+      (let [form '(raster.par/map-void! i n
+                                        (do (aset y i (* scale (aget x i)))
+                                            (aset state i (+ (aget state i) limit))))
+            result (opencl-pass/opencl-pass
+                    form :device-id device :dtype :float
+                    :array-types {'state :int 'x :float 'y :float}
+                    :scalar-types {'limit :int 'scale :float})
+            marker (:form result)
+            abi (:abi (first (:kernels result)))]
+        (is (= expected-head (first marker)))
+        (is (= (kabi/pointer-binding-names abi) (nth marker 2)))
+        (is (= '[limit scale] (nth marker 3)))
+        (is (= 'n (nth marker 4)))))))
 
 (deftest opencl-pass-fallback-test
   (testing "Small arrays fall back to scalar expansion"

--- a/test/raster/compiler/ir/soac_dialect_test.clj
+++ b/test/raster/compiler/ir/soac_dialect_test.clj
@@ -38,6 +38,58 @@
                                 (first (dialect/equations program)))))))
     (is (= '[x] (dialect/operation-inputs (first (dialect/equations program)))))))
 
+(deftest tuple-map-storage-is-ordered-typed-and-effectful
+  (let [left [:effect-map 0 0]
+        right [:effect-map 0 1]
+        storage [{:destination 'a :access :write :host-return :effect}
+                 {:destination 'b :access :read-write :host-return :effect}]
+        equation (list '= 'map-0 [left right]
+                       (list 'map {:index 'i :extent 'n} '[x b] []
+                             (list 'lambda '[x-element b-element]
+                                   '[x-element (+ b-element 1.0)])))
+        equation-facts (assoc (dialect/default-equation-facts)
+                              :effects #{:memory/write}
+                              :aliases {left 'a right 'b}
+                              :attributes {:result-storage storage})
+        facts (dialect/default-program-facts
+               {:values {'n extent 'x tensor 'a tensor 'b tensor
+                         left tensor right tensor}
+                :inputs '[b n x]
+                :equations {'map-0 equation-facts}
+                :effects #{:memory/write}})
+        program (dialect/make facts [equation] [])
+        remapped (dialect/remap-values
+                  program
+                  {left [:logical :left]
+                   right [:logical :right]
+                   'a [:storage :a]
+                   'b [:storage :b]
+                   'x [:argument :x]
+                   'n [:shape :n]})
+        remapped-equation (first (dialect/equations remapped))]
+    (is (= ['a 'b] (dialect/physical-results program equation)))
+    (is (= storage (dialect/result-storage program 'map-0)))
+    (is (= [[:storage :a] [:storage :b]]
+           (dialect/physical-results remapped remapped-equation))
+        "value remapping retains the ordered physical storage identity")
+    (is (= {[:logical :left] [:storage :a]
+            [:logical :right] [:storage :b]}
+           (get-in (dialect/facts remapped) [:equations 'map-0 :aliases])))
+    (testing "storage cannot drift from result order"
+      (try
+        (dialect/make
+         (assoc-in facts [:equations 'map-0 :aliases right] 'a)
+         [equation] [])
+        (is false "misaligned storage aliases must fail")
+        (catch clojure.lang.ExceptionInfo exception
+          (is (= :typed-soac-result-storage-alias (:reason (ex-data exception)))))))
+    (testing "storage destinations require their own AbstractValue"
+      (try
+        (dialect/make (update facts :values dissoc 'b) [equation] [])
+        (is false "unknown physical storage must fail")
+        (catch clojure.lang.ExceptionInfo exception
+          (is (= :typed-soac-result-storage-value (:reason (ex-data exception)))))))))
+
 (deftest scan-mode-has-a-distinct-typed-and-effectful-contract
   (let [out (av/tensor {:dtype :float :shape '[(unknown-dimension out)]})
         algebra (scan/->AssociativeScan 'acc 0.0 '+ 'element '(float 0.0) :float)

--- a/test/raster/compiler/kernel_call_pipeline_test.clj
+++ b/test/raster/compiler/kernel_call_pipeline_test.clj
@@ -135,6 +135,7 @@
     (is (= :map-void (:convention step)))
     (is (:logical-bindings? step))
     (is (kart/kernel-artifact? (:artifact step)))
-    (is (= '[out x scale]
+    (is (= :segmap (get-in step [:artifact :provenance :dialect])))
+    (is (= '[x out scale]
            (subvec (kcall/logical-arguments (:artifact step)) 0 3)))
     (is (= [3] (get-in call [:geometry :group-count])))))

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -80,7 +80,8 @@
       (is (= '[x] (dialect/operation-inputs (first (dialect/equations program))))
           "a write-only destination is not duplicated as a semantic read operand")
       (is (= '{step target} (get-in facts [:equations 0 :aliases])))
-      (is (= :buffer (get-in facts [:equations 0 :attributes :destination-return])))
+      (is (= [{:destination 'target :access :write :host-return :buffer}]
+             (get-in facts [:equations 0 :attributes :result-storage])))
       (is (some? (get-in facts [:values 'target]))
           "the physical output boundary retains its own value contract")
       (is (= #{:memory/write} (:effects facts)))))
@@ -100,7 +101,7 @@
           facts (dialect/facts program)]
       (is (= '[target] (dialect/operation-inputs equation)))
       (is (= :read-write
-             (get-in facts [:equations 0 :attributes :destination-access])))
+             (get-in facts [:equations 0 :attributes :result-storage 0 :access])))
       (is (= '{step target} (get-in facts [:equations 0 :aliases]))))))
 
 (deftest destination-shapes-refine-across-ordered-maps
@@ -114,3 +115,56 @@
                   :array-types {'x :float 'first-out :float 'second-out :float}})]
     (is (= '[n] (get-in (dialect/facts program) [:values 'first-out :shape])))
     (is (= 2 (count (dialect/equations program))))))
+
+(deftest effect-only-pointwise-writes-have-logical-results-and-physical-storage
+  (doseq [[label expression]
+          [["map2"
+            '(raster.par/map2! a b i n float
+                               (+ (clojure.core/aget x i) 1.0)
+                               (* (clojure.core/aget y i) 2.0))]
+           ["independent multi-store map-void"
+            '(raster.par/map-void!
+              i n
+              (do (clojure.core/aset a i (float (+ (clojure.core/aget x i) 1.0)))
+                  (clojure.core/aset b i (float (* (clojure.core/aget y i) 2.0)))))]]]
+    (testing label
+      (let [program (frontend/form->program
+                     (list 'let* ['effect expression] 'effect)
+                     {:dtype :float
+                      :array-types {'x :float 'y :float 'a :float 'b :float}})
+            equation (first (dialect/equations program))
+            facts (dialect/facts program)
+            results (vec (nth equation 2))]
+        (is (= [[:effect-map 0 0] [:effect-map 0 1]] results))
+        (is (= ['a 'b] (dialect/physical-results program equation)))
+        (is (= [:write :write]
+               (mapv :access (dialect/result-storage program 0))))
+        (is (= #{:memory/write} (:effects facts)))
+        (is (= [] (dialect/outputs program))
+            "the host nil result is not mislabeled as a tensor result")))))
+
+(deftest ordered-or-nonpointwise-void-bodies-decline-the-functional-tuple-map
+  (doseq [[label body]
+          [["one destination written twice"
+            '(do (clojure.core/aset a i (float 1.0))
+                 (clojure.core/aset a i (float 2.0)))]
+           ["a later store observes an earlier sibling write"
+            '(do (clojure.core/aset a i (float (clojure.core/aget x i)))
+                 (clojure.core/aset b i (float (clojure.core/aget a i))))]
+           ["shared local computation has no tuple-region SSA representation yet"
+            '(let* [v (+ (clojure.core/aget x i) 1.0)]
+                   (clojure.core/aset a i (float v))
+                   (clojure.core/aset b i (float (* v v))))]
+           ["transitively shared local computation also declines"
+            '(let* [u (+ (clojure.core/aget x i) 1.0)
+                    v (* u 2.0)]
+                   (clojure.core/aset a i (float v))
+                   (clojure.core/aset b i (float u)))]
+           ["scatter index"
+            '(clojure.core/aset a (clojure.core/aget indices i)
+                                (float (clojure.core/aget x i)))]]]
+    (testing label
+      (is (nil? (frontend/form->program
+                 (list 'let* ['effect (list 'raster.par/map-void! 'i 'n body)] 'effect)
+                 {:dtype :float
+                  :array-types {'x :float 'a :float 'b :float 'indices :int}}))))))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -55,8 +55,8 @@
       (is (= :typed-soac (get-in form [:provenance :source-dialect])))
       (is (= :typed-soac (:source-dialect stats)))
       (is (= :typed-soac (get-in equation [:attributes :algorithm-dialect])))
-      (is (= 'target (get-in equation [:attributes :destination])))
-      (is (= :buffer (get-in equation [:attributes :destination-return])))
+      (is (= [{:destination 'target :access :write :host-return :buffer}]
+             (get-in equation [:attributes :result-storage])))
       (is (= 'raster.par/map! (first realized-expression))
           "materialization preserves map!'s destination-returning semantics"))
     (testing "the emitter consumes the scheduled SegMap instead of reconstructing source"
@@ -77,7 +77,7 @@
         artifact (first (:kernels emitted))
         pointer-slots (filterv #(not= :scalar (:kind %)) (:abi artifact))]
     (is (= :typed-soac (:source-dialect stats)))
-    (is (= :read-write (get-in equation [:attributes :destination-access])))
+    (is (= :read-write (get-in equation [:attributes :result-storage 0 :access])))
     (is (= ['target] (mapv :name pointer-slots)))
     (is (= [:inout] (mapv :kind pointer-slots)))
     (is (= [:result] (mapv :role pointer-slots)))
@@ -89,6 +89,54 @@
     (is (not (some #{'raster.gpu.ze-runtime/invoke-registered-kernel}
                    (tree-seq coll? seq (:form emitted))))
         "an OpenCL program must not leak a Level Zero staging call")))
+
+(deftest tuple-map-deduplicates-a-read-write-physical-result
+  (let [source '(raster.par/map-void!
+                 i n
+                 (do (clojure.core/aset a i (clojure.core/aget x i))
+                     (clojure.core/aset b i
+                                        (+ (clojure.core/aget b i) 2.0))))
+        {:keys [form stats]}
+        (pipeline/schedule-parallel-form
+         source {:target-device :ocl:0 :dtype :float
+                 :array-types {'x :float 'a :float 'b :float}})
+        equation (first (:equations form))
+        emitted (opencl-pass/opencl-pass form :device-id :ocl:0
+                                         :dtype :float :min-elements 0)
+        artifact (first (:kernels emitted))
+        pointer-slots (filterv #(not= :scalar (:kind %)) (:abi artifact))]
+    (is (= :typed-soac (:source-dialect stats)))
+    (is (= [:write :read-write]
+           (mapv :access (get-in equation [:attributes :result-storage]))))
+    (is (= ['b 'x 'a] (mapv :name pointer-slots)))
+    (is (= [:inout :input :output] (mapv :kind pointer-slots)))
+    (is (= 1 (count (filter #(= 'b (:name %)) pointer-slots)))
+        "a read/write destination is one physical ABI value, not aliased input and output slots")
+    (is (= #{'a 'b} (:outputs (first (:operations equation)))))
+    (is (re-find #"b\[idx\] = \(float\)" (:source artifact)))
+    (is (re-find #"out\[idx\]" (:source artifact)))))
+
+(deftest typed-tuple-map-preserves-effect-semantics-on-the-jvm
+  (let [source '(let* [effect
+                       (raster.par/map-void!
+                        i n
+                        (do (clojure.core/aset a i
+                                               (float (+ (clojure.core/aget x i) 1.0)))
+                            (clojure.core/aset b i
+                                               (float (+ (clojure.core/aget b i) 2.0)))))]
+                      effect)
+        typed (:program (route/attempt source :float
+                                       {'x :float 'a :float 'b :float}))
+        scheduled (:form (segop-lower/segop-lower-pass typed {:dtype :float}))
+        jvm (par-simd/simd-pass scheduled :min-elements 1)
+        execute (eval (list 'fn '[x a b n] (:form jvm)))
+        x (float-array [1.0 2.0 3.0 4.0])
+        a (float-array 4)
+        b (float-array [10.0 20.0 30.0 40.0])]
+    (is (nil? (execute x a b 4))
+        "the source effect binder remains nil after TypedSOAC materialization")
+    (is (= [2.0 3.0 4.0 5.0] (mapv double a)))
+    (is (= [12.0 22.0 32.0 42.0] (mapv double b)))))
 
 (deftest typed-inout-preserves-sequential-jvm-semantics
   (let [source '(let* [step (raster.par/map! target i n float
@@ -427,6 +475,47 @@
            (mapv :kind (:abi kernel))))
     (is (re-find #"__global float\* restrict [uv]" (:source kernel)))))
 
+(deftest effect-only-tuple-map-lowers-to-one-explicit-multi-output-segmap
+  (let [source
+        '(let* [effect
+                (raster.par/map-void!
+                 i n
+                 (do (clojure.core/aset a i
+                                        (float (+ (clojure.core/aget x i) 1.0)))
+                     (clojure.core/aset b i
+                                        (float (* (clojure.core/aget y i) 2.0)))))]
+               [a b])
+        {:keys [program stats]}
+        (route/attempt source :float {'x :float 'y :float 'a :float 'b :float})
+        equation (first (:equations program))
+        algorithm (:algorithm equation)
+        scheduled (:form (segop-lower/segop-lower-pass
+                          program {:dtype :float :target-device :ocl:0}))
+        operation (first (:operations (first (:equations scheduled))))
+        jvm (par-simd/simd-pass scheduled :min-elements 1)
+        emitted (opencl-pass/opencl-pass scheduled :device-id :ocl:0
+                                         :dtype :float :min-elements 1)
+        kernel (first (:kernels emitted))]
+    (is (= :typed-soac (:dialect program)))
+    (is (:typed-validated stats))
+    (is (= [] (:outputs program))
+        "the effect binder keeps its host nil semantics")
+    (is (= [[:effect-map 0 0] [:effect-map 0 1]]
+           (dialect/outputs algorithm)))
+    (is (= ['a 'b]
+           (dialect/physical-results algorithm
+                                     (first (dialect/equations algorithm)))))
+    (is (= #{'a 'b} (:outputs operation)))
+    (is (= 'a (:out-sym operation)))
+    (is (some #{'clojure.core/aset} (flatten (:lambda operation))))
+    (is (nil? (get-in jvm [:stats :segop-relowered])))
+    (is (= [:input :input :output :output :scalar]
+           (mapv :kind (:abi kernel))))
+    (is (= ['x 'y 'b 'a 'n] (:arguments kernel)))
+    (is (= 1 (get-in emitted [:stats :ze-maps])))
+    (is (= 1 (get-in emitted [:stats :segop-reused])))
+    (is (nil? (get-in emitted [:stats :segop-relowered])))))
+
 (deftest unfused-map-also-uses-the-typed-production-route
   (let [source '(let* [y (raster.par/pmap i n float
                                           (* (clojure.core/aget x i) 2.0))]
@@ -490,7 +579,7 @@
                    [:equations 2 :effects])))
     (is (= 'out
            (get-in (dialect/facts (get-in program [:equations 1 :algorithm]))
-                   [:equations 2 :attributes :destination])))
+                   [:equations 2 :attributes :result-storage 0 :destination])))
     (is (= 2 (count reductions)))
     (is (= #{partial} (:inputs phase-two)))
     (is (= :double (get-in scheduled [:values partial :dtype])))))

--- a/test/raster/compiler/pipeline_extractor_test.clj
+++ b/test/raster/compiler/pipeline_extractor_test.clj
@@ -18,14 +18,14 @@
 (defn- why [form] (get-in (pipeline/extract-gpu-program form) [nr-key :why]))
 
 (deftest map-void-arity
-  (testing "a correct 5-wide map-void invoke extracts to one step, no rejection"
-    (let [r (pipeline/extract-gpu-program
-             '(let* [out (raster.gpu.ze-runtime/invoke-registered-map-void-kernel
-                          "k" [a b] [s] 10)]
-                    out))]
-      (is (nil? (nr-key r)))
-      (is (= 1 (count (:steps r))))
-      (is (= :map-void (:convention (first (:steps r)))))))
+  (doseq [head '[raster.gpu.ze-runtime/invoke-registered-map-void-kernel
+                 raster.gpu.ocl-runtime/invoke-registered-map-void-kernel]]
+    (testing (str "a correct target-specific 5-wide map-void invoke extracts: " head)
+      (let [r (pipeline/extract-gpu-program
+               (list 'let* ['out (list head "k" '[a b] '[s] 10)] 'out))]
+        (is (nil? (nr-key r)))
+        (is (= 1 (count (:steps r))))
+        (is (= :map-void (:convention (first (:steps r))))))))
   (testing "an EXTRA operand is rejected by name, not silently dropped"
     (is (= :unparseable-kernel-invoke
            (why '(let* [out (raster.gpu.ze-runtime/invoke-registered-map-void-kernel
@@ -101,14 +101,14 @@
     (testing "nil at the ABI result role is an explicit host-scalar staging fallback"
       (let [r (pipeline/extract-gpu-program
                '(let* [out (raster.gpu.ze-runtime/invoke-registered-reduction-kernel
-                             "k" [a nil scale n])]
+                            "k" [a nil scale n])]
                       out)
                info)]
         (is (= :host-scalar-reduction (get-in r [nr-key :why])))))
     (testing "a concrete result buffer remains resident and aliases the marker binding"
       (let [r (pipeline/extract-gpu-program
                '(let* [out (raster.gpu.ze-runtime/invoke-registered-reduction-kernel
-                             "k" [a obuf scale n])]
+                            "k" [a obuf scale n])]
                       out)
                info)]
         (is (nil? (nr-key r)))

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -35,6 +35,21 @@
   [state :- (Array float) a :- Float n :- Long] :- (Array float)
   (raster.par/map! state i n float (* a (ra/aget state i))))
 
+(deftm ocl-session-map2
+  [x :- (Array float) y :- (Array float)
+   a :- (Array float) b :- (Array float) n :- Long] :- Void
+  (raster.par/map2! a b i n float
+                    (+ (ra/aget x i) 1.0)
+                    (* (ra/aget y i) 2.0)))
+
+(deftm ocl-session-effect-mixed
+  [x :- (Array float) q :- (Array byte)
+   y :- (Array float) labels :- (Array int) n :- Long] :- Void
+  (raster.par/map-void!
+   i n
+   (do (ra/aset y i (float (* (ra/aget x i) 2.0)))
+       (ra/aset labels i (int (+ (int (ra/aget q i)) 7))))))
+
 (deftm ocl-session-contract
   [A :- (Array float) B :- (Array float)] :- (Array float)
   (let [C (ra/alloc-like A 64)]
@@ -100,6 +115,60 @@
                   ^floats yg (get r2 'y)]
               (is (< (Math/abs (- (aget yg 100) 200.0)) 1e-3)))))
         (finally (gpu/close-session! s))))))
+
+(deftest ocl-resident-typed-effect-tuple-map-roundtrip
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "resident typed effect tuple map")
+    (let [descriptor (pl/compile-gpu-program #'ocl-session-map2 :ocl:0 :dtype :float)
+          n 1024
+          x (float-array (map float (range n)))
+          y (float-array (map #(float (+ 10 %)) (range n)))
+          a (float-array n)
+          b (float-array n)
+          session (gpu/make-session :ocl:0)]
+      (try
+        (is (= [:map-void] (mapv :convention (:steps descriptor)))
+            "host control retains the nil-returning effect convention")
+        (is (= :segmap (get-in descriptor [:steps 0 :artifact :provenance :dialect]))
+            "kernel generation consumes the scheduled TypedSOAC SegMap")
+        (is (= [:input :input :output :output :scalar]
+               (mapv :kind (get-in descriptor [:steps 0 :abi]))))
+        (let [program (fixture/instantiate! session descriptor [x y a b n]
+                                            {'x :input 'y :input
+                                             'a :output 'b :output})
+              result (fixture/run! program [x y a b n])
+              ^floats actual-a (get result 'a)
+              ^floats actual-b (get result 'b)]
+          (is (every? (fn [i] (= (float (inc i)) (aget actual-a i)))
+                      [0 1 255 256 1023]))
+          (is (every? (fn [i] (= (float (* 2.0 (+ 10 i))) (aget actual-b i)))
+                      [0 1 255 256 1023])))
+        (finally (gpu/close-session! session))))))
+
+(deftest ocl-resident-typed-effect-tuple-map-preserves-mixed-storage
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "resident typed mixed effect tuple map")
+    (let [descriptor (pl/compile-gpu-program #'ocl-session-effect-mixed
+                                             :ocl:0 :dtype :float)
+          n 257
+          x (float-array (map #(float (/ % 8.0)) (range n)))
+          q (byte-array (map #(byte (- (mod % 17) 8)) (range n)))
+          y (float-array n)
+          labels (int-array n)
+          session (gpu/make-session :ocl:0)]
+      (try
+        (is (= :segmap (get-in descriptor [:steps 0 :artifact :provenance :dialect])))
+        (is (= [:byte :float :int :float :int]
+               (mapv :dtype (get-in descriptor [:steps 0 :abi]))))
+        (let [program (fixture/instantiate! session descriptor [x q y labels n]
+                                            {'x :input 'q :input
+                                             'y :output 'labels :output})
+              result (fixture/run! program [x q y labels n])
+              ^floats actual-y (get result 'y)
+              ^ints actual-labels (get result 'labels)]
+          (is (= (float (* 2.0 (aget x 256))) (aget actual-y 256)))
+          (is (= (+ 7 (int (aget q 256))) (aget actual-labels 256))))
+        (finally (gpu/close-session! session))))))
 
 (deftest ocl-resident-typed-scan-runs-through-the-compiled-graph-step
   (if-not @device-probe/opencl-available?


### PR DESCRIPTION
Summary

- Represent map2! and independent multi-store map-void! as tuple-valued TypedSOAC maps with ordered logical-result to physical-storage contracts.
- Lower and materialize those maps through one scheduled multi-output SegMap while preserving nil host semantics and deduplicating read/write destinations in KernelABI.
- Route bare top-level parallel forms through the typed boundary, preserve declared mixed buffer dtypes, and use target-correct OpenCL/Level Zero staging markers.

Legality boundary

- Declines duplicate destinations, scatter indices, sibling destination dependencies, atomics/other effects, and shared local SSA that would duplicate work.
- Keeps unsupported forms on the compatibility generator.
- CUDA/HIP remain compile-validated leaves; this PR does not claim they are wired through compile-gpu-program.

Validation

- 78 focused compiler tests, 449 assertions.
- 15 live Intel Arc OpenCL tests, 36 assertions.
- 11 device-free CUDA/HIP legality tests, 141 assertions.
- cljfmt and git diff --check.

The full suite is left to CircleCI because the local host is under memory pressure with swap exhausted.