### PR TITLE
Represent shared scalar work in TypedSOAC regions

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -119,10 +119,15 @@ its caller-owned destination, access mode, and host-return contract. The effect 
 retains its real `nil` host semantics instead of masquerading as a tensor result. The scheduled
 SegMap and its ordered ABI are consumed by staged and resident compilation; unsupported raw
 map-void bodies retain the compatibility generator. The front end refuses duplicate destinations,
-scatter indices, sibling write/read ordering, atomics, and shared local bindings whose projection
-would duplicate computation. The last case needs local SSA inside tuple scalar regions, not source
-substitution. Flat resident `deftm` signatures provide their declared per-buffer dtypes before
-fusion, so a mixed FP32/int8-input, FP32/int32-output map does not inherit a global default dtype.
+scatter indices, sibling write/read ordering, and atomics. Shared scalar work now remains one
+explicit ordered local-SSA spine inside the tuple map's scalar region; each definition has a dtype
+retained from walker/TypedClojure facts, and local binders never become fake program inputs.
+Validation proves definition order and lexical closure, and the front end expands locals only for
+dependency analysis so a local cannot hide sibling write/read ordering. JVM and GPU lowering both
+materialize the same typed spine once around all tuple results. Fusion currently leaves
+local-bearing regions intact until region composition is proved, rather than duplicating their
+work. Flat resident `deftm` signatures provide their declared per-buffer dtypes before fusion, so a
+mixed FP32/int8-input, FP32/int32-output map does not inherit a global default dtype.
 
 The first architectural correction is therefore:
 
@@ -430,13 +435,16 @@ reconstructed from arbitrary source forms. Conceptually:
    :values {%x x-value %y y-value %z z-value}}
   [(= map-0 [%y]
       (map {:index %i :extent %n} [%x] []
-           (lambda [%xi] [(* %xi %xi)])))
+           (lambda [%xi]
+             (region [(let-value %squared :float (* %xi %xi))]
+                     [%squared]))))
    (= reduce-0 [%z]
       (reduce {:index %i :extent %n
                :accumulators [%acc] :identities [0.0]
                :dtypes [:float] :algebra [{:associative? true}]}
               [%y] []
-              (lambda [%acc %yi] [(+ %acc %yi)])))]
+              (lambda [%acc %yi]
+                (region [] [(+ %acc %yi)]))))]
   [%z])
 ```
 
@@ -841,9 +849,11 @@ The immediate continuation after the verified double-buffered weighted-reduction
    destinations lower to one physical `:inout` ABI result and execute through both resident and
    staged binding without an aliased compatibility input. Independent effect-only tuple maps also
    carry an ordered logical-result-to-physical-storage contract and compile through their scheduled
-   SegMap on resident OpenCL execution. Hardware-costed
+   SegMap on resident OpenCL execution. Their shared typed scalar computations use one explicit
+   ordered local-SSA region that lowers once through JVM and GPU paths; fusion declines those
+   regions until composition is proved. Hardware-costed
    multi-consumer fusion, nested-region JVM
-   scheduling, local SSA for shared multi-result scalar regions, indexed/scatter operations, the
+   scheduling, local-region fusion, indexed/scatter operations, the
    remaining parallel forms, and
    deletion of the remaining graph/backend fallbacks remain.
 6. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -11,22 +11,30 @@
      (soac-program facts
        [(= equation-id [result ...]
            (scalar {:dtypes [:long ...]} [capture ...]
-             (lambda [capture-parameter ...] [result-expr ...])))
+             (lambda [capture-parameter ...]
+               (region [(let-value local :dtype init-expr) ...]
+                       [result-expr ...]))))
         (= equation-id [result ...]
            (map {:index i :extent n} [array ...] [capture ...]
-             (lambda [element ... capture-parameter ...] [result-expr ...])))
+             (lambda [element ... capture-parameter ...]
+               (region [(let-value local :dtype init-expr) ...]
+                       [result-expr ...]))))
         (= equation-id [result ...]
            (reduce {:index i :extent n
                     :accumulators [acc ...] :identities [zero ...]
                     :dtypes [:float ...] :algebra [{} ...]}
              [array ...] [capture ...]
-             (lambda [acc ... element ... capture-parameter ...] [step-result ...])))
+             (lambda [acc ... element ... capture-parameter ...]
+               (region [(let-value local :dtype init-expr) ...]
+                       [step-result ...]))))
         (= equation-id [result]
            (scan {:mode :inclusive :index i :extent n
                   :accumulators [acc] :identities [zero]
                   :dtypes [:float] :algebra [{}]}
              [array ...] [capture ...]
-             (lambda [acc element ... capture-parameter ...] [step-result])))]
+             (lambda [acc element ... capture-parameter ...]
+               (region [(let-value local :dtype init-expr) ...]
+                       [step-result]))))]
        [program-result ...])
 
    Scan mode may be `:inclusive` or `:exclusive`; it is an explicit result-layout property. Map
@@ -35,10 +43,13 @@
    `:result-storage` vector aligned with those functional results; logical SSA identity therefore
    stays separate from physical write identity and host return semantics. Captures are explicit
    operands with explicit scalar lambda parameters, so stable value IDs never leak into lexical
-   expression binding."
+   expression binding. Lambda regions have one typed, ordered local-SSA spine. A local initializer
+   may reference parameters, the map index, and earlier locals; results may reference all locals.
+   This represents shared scalar work once without smuggling type inference into an emitter."
   (:require [clojure.set :as set]
             [pattern.nanopass.dialect :as dialect
              :refer [def-dialect]]
+            [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.scan :as scan-ir]))
@@ -158,6 +169,7 @@
              [ma map-attributes?]
              [ra reduce-attributes?]
              [ca scan-attributes?]
+             [dt keyword?]
              [facts program-facts?])
 
   (Scalar [s :enforce]
@@ -169,8 +181,14 @@
           (.invk ?sym:impl (?:* s:args))
           (& (?sym:f (?:* s:args)) (? _ seq?)))
 
+  (Local [d :enforce]
+         (let-value ?sym:binding ?dt ?s:init))
+
+  (Region [r :enforce]
+          (region [(?:* d)] [(?:+ s)]))
+
   (Lambda [l :enforce]
-          (lambda [(?:* ?sym:parameter)] [(?:+ s)]))
+          (lambda [(?:* ?sym:parameter)] ?r))
 
   (Operation [o :enforce]
              (scalar ?sa [(?:* ?id:capture)] ?l)
@@ -223,6 +241,41 @@
       (let [[_ attributes arrays captures lambda] operation]
         {:kind kind :attributes attributes :arrays arrays :captures captures :lambda lambda}))))
 
+(defn local-value
+  "Construct one explicitly typed scalar-region SSA definition."
+  [id dtype init]
+  (list 'let-value id dtype init))
+
+(defn lambda-region
+  "Construct the canonical scalar region used by every TypedSOAC lambda."
+  [locals results]
+  (list 'region (vec locals) (vec results)))
+
+(defn lambda-form
+  "Construct a canonical TypedSOAC lambda, with an optional ordered local-SSA spine."
+  ([parameters results]
+   (lambda-form parameters [] results))
+  ([parameters locals results]
+   (list 'lambda (vec parameters) (lambda-region locals results))))
+
+(defn lambda-parts
+  "Project a canonical lambda into parameters, typed locals, and ordered result expressions.
+
+   Locals are returned as maps so compiler passes do not independently parse their S-expression
+   spelling. The TypedSOAC form remains the sole serialized representation."
+  [lambda]
+  (let [[_ parameters [_ local-forms body-results]] lambda]
+    {:parameters (vec parameters)
+     :locals (mapv (fn [[_ id dtype init]]
+                     {:id id :dtype dtype :init init})
+                   local-forms)
+     :body-results (vec body-results)}))
+
+(defn emit-locals
+  "Return local-value forms for normalized local maps."
+  [locals]
+  (mapv (fn [{:keys [id dtype init]}] (local-value id dtype init)) locals))
+
 (defn result-storage
   "Ordered physical storage contracts for an equation's functional results.
 
@@ -249,7 +302,7 @@
   "Split a SOAC lambda's ordered parameters into semantic roles."
   [equation]
   (let [{:keys [kind attributes arrays captures lambda]} (operation-parts equation)
-        parameters (vec (second lambda))
+        parameters (:parameters (lambda-parts lambda))
         accumulator-count (if (contains? #{'reduce 'scan} kind)
                             (count (:accumulators attributes)) 0)
         array-count (count arrays)
@@ -271,7 +324,7 @@
   [equation]
   (let [[_ equation-id results operation] equation
         {:keys [kind attributes arrays captures lambda]} (operation-parts equation)
-        [_ parameters body-results] lambda
+        {:keys [parameters locals body-results]} (lambda-parts lambda)
         result-count (count results)]
     (when-not (distinct-vector? results)
       (fail! :typed-soac-equation-results "SOAC equation results must be distinct"
@@ -296,6 +349,31 @@
     (when-not (every? symbol? parameters)
       (fail! :typed-soac-lambda-parameters "SOAC lambda parameters must be symbols"
              {:equation equation-id :parameters parameters}))
+    (let [local-ids (mapv :id locals)
+          lexical-ids (vec (concat parameters local-ids))]
+      (when-not (= (count lexical-ids) (count (distinct lexical-ids)))
+        (fail! :typed-soac-region-binders
+               "scalar-region parameters and local SSA definitions must be distinct"
+               {:equation equation-id :parameters parameters :locals local-ids}))
+      (when (and (contains? #{'map 'reduce 'scan} kind)
+                 (some #{(:index attributes)} local-ids))
+        (fail! :typed-soac-region-binders
+               "a scalar-region local cannot shadow its operation index"
+               {:equation equation-id :index (:index attributes) :locals local-ids})))
+    (doseq [{:keys [dtype] :as local} locals]
+      ;; Region locals are currently materialized as typed JVM scalar bindings before the common
+      ;; CPU/GPU scalar emitters see them. Reuse the compiler's authoritative dtype facets here;
+      ;; accepting :half or an unknown keyword would only fail later in target lowering.
+      (when-not (and (dtype/known? dtype)
+                     (= dtype (dtype/canon dtype))
+                     (:scalar-tag (dtype/info dtype)))
+        (fail! :typed-soac-local-dtype
+               "scalar-region locals require a supported JVM scalar dtype"
+               {:equation equation-id :local local :dtype dtype})))
+    (when (and (seq locals) (not= 'map kind))
+      (fail! :typed-soac-region-operation
+             "typed local SSA is currently admitted only in map scalar regions"
+             {:equation equation-id :operation kind :locals locals}))
     (when-not (= result-count (count body-results))
       (fail! :typed-soac-result-arity "SOAC result and lambda arity differ"
              {:equation equation-id :results result-count :body-results (count body-results)}))
@@ -312,14 +390,23 @@
                 :actual (count parameters)
                 :arrays arrays
                 :captures captures})))
-    (doseq [body body-results
-            :let [bound (cond-> (set parameters)
+    (let [initial-bound (cond-> (set parameters)
                           (contains? #{'map 'reduce 'scan} kind) (conj (:index attributes)))
-                  unbound (util/free-syms body bound)]
-            :when (seq unbound)]
-      (fail! :typed-soac-unbound-scalar
-             "scalar regions may reference only their explicit lambda parameters"
-             {:equation equation-id :unbound unbound :body body}))
+          final-bound
+          (reduce (fn [bound {:keys [id init] :as local}]
+                    (let [unbound (util/free-syms init bound)]
+                      (when (seq unbound)
+                        (fail! :typed-soac-unbound-local
+                               "local SSA initializers may reference only parameters and earlier locals"
+                               {:equation equation-id :local local :unbound unbound}))
+                      (conj bound id)))
+                  initial-bound locals)]
+      (doseq [body body-results
+              :let [unbound (util/free-syms body final-bound)]
+              :when (seq unbound)]
+        (fail! :typed-soac-unbound-scalar
+               "scalar-region results may reference only parameters and local SSA values"
+               {:equation equation-id :unbound unbound :body body})))
     (case kind
       scalar
       (when-not (= result-count (count (:dtypes attributes)))

--- a/src/raster/compiler/passes/parallel/soac_dialect_adapter.clj
+++ b/src/raster/compiler/passes/parallel/soac_dialect_adapter.clj
@@ -127,7 +127,8 @@
           (list 'map {:index (:idx node) :extent (:bound node)
                       :attributes {:stable-array-captures (vec (sort-by pr-str stable))}}
                 arrays captures
-                (list 'lambda (vec (concat parameters capture-parameters)) body-results)))))
+                (dialect/lambda-form (vec (concat parameters capture-parameters))
+                                     body-results)))))
 
 (defn- reduce-equation
   [node]
@@ -160,10 +161,10 @@
                       :algebra [(:algebra product)]}]
       (list '= (:id node) (vec (filter some? (reduction/results product)))
             (list 'reduce attributes arrays captures
-                  (list 'lambda
-                        (vec (concat [(:accumulator component)]
-                                     element-parameters capture-parameters))
-                        body-results))))))
+                  (dialect/lambda-form
+                   (vec (concat [(:accumulator component)]
+                                element-parameters capture-parameters))
+                   body-results))))))
 
 (defn- scalar-dtype
   [node scalar-dtypes scalar-types]
@@ -189,8 +190,9 @@
              {:node (:id node) :symbol (:sym node) :expression expression}))
     (list '= (:id node) [(:sym node)]
           (list 'scalar {:dtypes [dtype]} captures
-                (list 'lambda parameters
-                      [(util/subst-syms (zipmap captures parameters) expression)])))))
+                (dialect/lambda-form
+                 parameters
+                 [(util/subst-syms (zipmap captures parameters) expression)])))))
 
 (defn- operation-equation
   [node aliases]

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -31,6 +31,19 @@
 (declare lower-scan-description)
 (declare scan-kernel-graph-description)
 
+(defn- materialize-region-locals
+  [locals body]
+  (if (seq locals)
+    (list 'let*
+          (vec
+           (mapcat (fn [{:keys [id dtype init]}]
+                     (let [tag (dtype/scalar-tag-for-dtype dtype)]
+                       [(with-meta id {:raster.type/tag tag})
+                        (list tag init)]))
+                   locals))
+          body)
+    body))
+
 (defn typed-map-program?
   "Whether a validated one-equation TypedSOAC program is a map accepted by SegMap lowering."
   [program]
@@ -53,7 +66,7 @@
     (let [equation (first (soac-dialect/equations program))
           [_ equation-id results operation] equation
           [_ attributes arrays captures lambda] operation
-          [_ _ body-results] lambda
+          {:keys [locals body-results]} (soac-dialect/lambda-parts lambda)
           {:keys [elements capture-parameters]} (soac-dialect/parameter-layout equation)
           _ (when-not (and (seq results)
                            (= (count results) (count body-results)))
@@ -66,6 +79,11 @@
                 (map (fn [parameter array]
                        [parameter (list 'clojure.core/aget array index)])
                      elements arrays))
+          locals (mapv #(update % :init
+                                (fn [init]
+                                  (-> (util/subst-syms substitutions init)
+                                      par/expand-par-forms)))
+                       locals)
           bodies (mapv #(-> (util/subst-syms substitutions %)
                             par/expand-par-forms)
                        body-results)
@@ -80,9 +98,11 @@
                     (list 'clojure.core/aset secondary-result index
                           (list cast secondary-body))))
                 (rest results) (rest physical-results) (rest bodies))
-          body (if (seq secondary-stores)
-                 (list* 'do (concat secondary-stores [(first bodies)]))
-                 (first bodies))
+          body (materialize-region-locals
+                locals
+                (if (seq secondary-stores)
+                  (list* 'do (concat secondary-stores [(first bodies)]))
+                  (first bodies)))
           stable-array-captures (set (get-in attributes
                                              [:attributes :stable-array-captures]))
           scalar-captures (set (remove stable-array-captures captures))
@@ -121,7 +141,7 @@
     (let [equation (first (soac-dialect/equations program))
           [_ equation-id results operation] equation
           [_ attributes arrays captures lambda] operation
-          [_ _ body-results] lambda
+          {:keys [body-results]} (soac-dialect/lambda-parts lambda)
           {:keys [accumulators elements capture-parameters]}
           (soac-dialect/parameter-layout equation)
           _ (when-not (and (= 1 (count results))
@@ -175,7 +195,7 @@
   (let [equation (first (soac-dialect/equations program))
         [_ equation-id results operation] equation
         [_ attributes arrays captures lambda] operation
-        [_ _ body-results] lambda
+        {:keys [body-results]} (soac-dialect/lambda-parts lambda)
         {:keys [accumulators elements capture-parameters]}
         (soac-dialect/parameter-layout equation)
         facts (soac-dialect/facts program)

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -50,13 +50,20 @@
     (second expression)
     expression))
 
-(defn- pointwise-stores
-  "Recognize an ordered body made exclusively of pointwise stores.
+(defn- retained-local-dtype
+  [binding init]
+  (let [init-tag (when (instance? clojure.lang.IObj init)
+                   (or (:raster.type/tag (meta init)) (:tag (meta init))))]
+    (or (dtype/dtype-for-scalar-tag (types/sym-type-tag binding))
+        (dtype/dtype-for-scalar-tag init-tag))))
 
-   Pure let bindings are substituted into every result expression. That projection is semantic,
-   not permission to reorder stores: callers additionally prove that destinations are distinct
-   and no result reads a sibling destination. Bodies with atomics, scatter indices, duplicate
-   destinations, or other effects return nil and remain on the compatibility route."
+(defn- pointwise-region
+  "Recognize an ordered, pure local-SSA spine ending exclusively in pointwise stores.
+
+   Local types come only from retained walker/TypedClojure facts. Nested local scopes and missing
+   local types decline; guessing them in this source recognizer or a C emitter would make the
+   region only nominally typed. Store legality is checked separately after local dependencies are
+   expanded for analysis."
   [body index]
   (cond
     (and (seq? body) (form/let-head? (first body)))
@@ -64,40 +71,36 @@
       (when (and (even? (count bindings))
                  (seq nested-body)
                  (not-any? util/effectful? (take-nth 2 (rest bindings))))
-        (when-let [stores (pointwise-stores (list* 'do nested-body) index)]
-          (let [binding-initializers (into {} (map vec) (partition 2 bindings))
-                binding-symbols (set (keys binding-initializers))
-                dependencies
-                (fn [expression]
-                  (loop [pending (set/intersection binding-symbols
-                                                   (util/free-syms expression))
-                         seen #{}]
-                    (if-let [binding (first pending)]
-                      (let [nested (set/intersection
-                                    binding-symbols
-                                    (util/free-syms (get binding-initializers binding)))]
-                        (recur (set/union (disj pending binding)
-                                          (set/difference nested seen))
-                               (conj seen binding)))
-                      seen)))
-                store-dependencies (mapv #(dependencies (:value %)) stores)
-                shared? (some (fn [binding]
-                                (< 1 (count (filter #(contains? % binding)
-                                                    store-dependencies))))
-                              binding-symbols)]
-            ;; TypedSOAC's current tuple-map region has no shared local binding spine. Duplicating
-            ;; a common initializer into several results is semantically valid but a performance
-            ;; regression, so retain that body unchanged until scalar regions own local SSA.
-            (when-not shared?
-              (let [environment (util/binding-env bindings)]
-                (mapv #(update % :value (fn [value]
-                                          (util/subst-syms environment value)))
-                      stores)))))))
+        (when-let [{nested-locals :locals stores :stores}
+                   (pointwise-region (list* 'do nested-body) index)]
+          ;; Flattening nested lexical scopes needs alpha-renaming across each scope. Keep this
+          ;; first production slice to the ANF shape the walker emits: one local spine around the
+          ;; store sequence.
+          (when (empty? nested-locals)
+            (let [pairs (vec (partition 2 bindings))
+                  typed (mapv (fn [[binding init]]
+                                [binding init (retained-local-dtype binding init)])
+                              pairs)]
+              (when (every? (comp some? #(nth % 2)) typed)
+                (let [{:keys [locals substitutions]}
+                      (reduce (fn [{:keys [locals substitutions]} [binding init local-dtype]]
+                                (let [id (symbol (str "rstr_local_" (count locals)))]
+                                  {:locals (conj locals
+                                                 {:id id :dtype local-dtype
+                                                  :init (util/subst-syms substitutions init)})
+                                   :substitutions (assoc substitutions binding id)}))
+                              {:locals [] :substitutions {}} typed)]
+                  {:locals locals
+                   :stores (mapv #(update % :value
+                                          (fn [value]
+                                            (util/subst-syms substitutions value)))
+                                 stores)})))))))
 
     (and (seq? body) (= 'do (first body)))
-    (let [groups (mapv #(pointwise-stores % index) (rest body))]
-      (when (and (seq groups) (every? seq groups))
-        (vec (mapcat identity groups))))
+    (let [groups (mapv #(pointwise-region % index) (rest body))]
+      (when (and (seq groups) (every? some? groups)
+                 (every? (comp empty? :locals) groups))
+        {:locals [] :stores (vec (mapcat :stores groups))}))
 
     (descriptor/aset-call? body)
     (let [arguments (vec (descriptor/call-args body))]
@@ -109,20 +112,28 @@
                                       'clojure.core/float 'clojure.core/double}
                                     (first value))
                          (= 2 (count value)))]
-          [{:out (descriptor/aset-array-sym body)
-            :value (if cast? (second value) value)
-            :cast (when cast? (first value))}])))
+          {:locals []
+           :stores [{:out (descriptor/aset-array-sym body)
+                     :value (if cast? (second value) value)
+                     :cast (when cast? (first value))}]})))
 
     :else nil))
 
+(defn- expanded-local-expression
+  [locals expression]
+  (reduce (fn [body {:keys [id init]}]
+            (util/subst-syms {id init} body))
+          expression (reverse locals)))
+
 (defn- independent-pointwise-stores?
-  [stores]
+  [locals stores]
   (let [destinations (mapv :out stores)
         destination-set (set destinations)]
     (and (= (count destinations) (count destination-set))
          (every? (fn [{:keys [out value]}]
                    (empty? (disj (set/intersection destination-set
-                                                   (par/collect-aget-arrays value))
+                                                   (par/collect-aget-arrays
+                                                    (expanded-local-expression locals value)))
                                  out)))
                  stores))))
 
@@ -131,14 +142,16 @@
   [:effect-map equation-id ordinal])
 
 (defn- effect-map-description
-  [id symbol index extent stores elem-type]
-  (when (and (seq stores) (independent-pointwise-stores? stores))
+  [id symbol index extent {:keys [locals stores]} elem-type]
+  (when (and (seq stores) (independent-pointwise-stores? locals stores))
     (let [destinations (mapv :out stores)
           values (mapv :value stores)
-          io (extract-io (list* 'do values) index destinations)
+          analysis-values (concat (map :init locals) values)
+          io (update (extract-io (list* 'do analysis-values) index destinations)
+                     :scalars set/difference (set (map :id locals)))
           results (mapv #(effect-result-id id %) (range (count stores)))]
       (merge {:kind :map :id id :sym symbol :index index :extent extent
-              :results results :bodies values :casts (mapv :cast stores)
+              :results results :locals locals :bodies values :casts (mapv :cast stores)
               :effect-only? true :host-binding symbol :elem-type elem-type
               :result-storage
               (mapv (fn [destination]
@@ -156,7 +169,7 @@
     (let [{:keys [idx bound cast body elem-type]} (par/extract-par-map-pure-info expression)
           io (extract-io body idx [symbol])]
       (merge {:kind :map :id id :sym symbol :results [symbol]
-              :index idx :extent bound :casts [cast] :bodies [body]
+              :index idx :extent bound :locals [] :casts [cast] :bodies [body]
               :pure? true :elem-type elem-type}
              io))
 
@@ -171,7 +184,7 @@
       ;; physical inout value rather than manufacturing separate aliased input/output pointers.
       (when-not (or offset (= symbol out))
         (merge {:kind :map :id id :sym symbol :results [symbol]
-                :index idx :extent bound :casts [cast] :bodies [body]
+                :index idx :extent bound :locals [] :casts [cast] :bodies [body]
                 :result-storage [{:destination out
                                   :access (if (contains? (:inputs io) out) :read-write :write)
                                   :host-return :buffer}]
@@ -183,8 +196,9 @@
     (let [{:keys [out1 out2 idx bound cast body1 body2 elem-type]}
           (par/extract-par-map2-info expression)]
       (effect-map-description id symbol idx bound
-                              [{:out out1 :value body1 :cast cast}
-                               {:out out2 :value body2 :cast cast}]
+                              {:locals []
+                               :stores [{:out out1 :value body1 :cast cast}
+                                        {:out out2 :value body2 :cast cast}]}
                               elem-type))
 
     (par/par-reduce-form? expression)
@@ -223,8 +237,8 @@
 
     (par/par-map-void-form? expression)
     (let [{:keys [idx bound body elem-type]} (par/extract-par-map-void-info expression)]
-      (when-let [stores (pointwise-stores body idx)]
-        (effect-map-description id symbol idx bound stores elem-type)))
+      (when-let [region (pointwise-region body idx)]
+        (effect-map-description id symbol idx bound region elem-type)))
 
     :else nil))
 
@@ -337,20 +351,31 @@
 
 (defn- map-equation
   [description]
-  (let [{:keys [id index extent casts bodies inputs results]} description
+  (let [{:keys [id index extent locals casts bodies inputs results]} description
         expressions (mapv (fn [cast body] (if cast (list cast body) body)) casts bodies)
-        [pointwise stable] ((juxt filter remove) #(pointwise-input? expressions % index) inputs)
+        all-expressions (into (mapv :init locals) expressions)
+        [pointwise stable] ((juxt filter remove) #(pointwise-input? all-expressions % index) inputs)
         arrays (vec (sort-by pr-str pointwise))
         captures (vec (sort-by pr-str (distinct (concat stable (:scalars description)))))
         parameters (element-symbols (count arrays))
         capture-parameters (capture-symbols (count captures))
+        substitutions (zipmap captures capture-parameters)
+        local-forms
+        (->> locals
+             (mapv (fn [{:keys [id dtype init]}]
+                     (dialect/local-value
+                      id dtype
+                      (util/subst-syms
+                       substitutions
+                       (first (elementize [init] arrays parameters index)))))))
         body-results (mapv #(util/subst-syms (zipmap captures capture-parameters) %)
                            (elementize expressions arrays parameters index))]
     (list '= id results
           (list 'map {:index index :extent extent
                       :attributes {:stable-array-captures (vec (sort-by pr-str stable))}}
                 arrays captures
-                (list 'lambda (vec (concat parameters capture-parameters)) body-results)))))
+                (dialect/lambda-form (vec (concat parameters capture-parameters))
+                                     local-forms body-results)))))
 
 (defn- reduce-equation
   [{:keys [id extent inputs scalars product]}]
@@ -372,9 +397,9 @@
                          :dtypes [(:dtype component)]
                          :algebra [(:algebra product)]}
                 arrays captures
-                (list 'lambda
-                      (vec (concat [(:accumulator component)] elements capture-parameters))
-                      results)))))
+                (dialect/lambda-form
+                 (vec (concat [(:accumulator component)] elements capture-parameters))
+                 results)))))
 
 (defn- scan-equation
   [{:keys [id sym index extent mode inputs scalars primary-out accumulator identity dtype body]}]
@@ -397,9 +422,9 @@
                        :dtypes [dtype]
                        :algebra [algebra]}
                 arrays captures
-                (list 'lambda
-                      (vec (concat [accumulator] elements capture-parameters))
-                      [result])))))
+                (dialect/lambda-form
+                 (vec (concat [accumulator] elements capture-parameters))
+                 [result])))))
 
 (defn- scalar-dtype
   [{:keys [sym expr]} scalar-dtypes scalar-types]
@@ -422,8 +447,9 @@
              {:binding id :symbol sym :expression expr}))
     (list '= id [sym]
           (list 'scalar {:dtypes [result-dtype]} captures
-                (list 'lambda parameters
-                      [(util/subst-syms (zipmap captures parameters) expr)])))))
+                (dialect/lambda-form
+                 parameters
+                 [(util/subst-syms (zipmap captures parameters) expr)])))))
 
 (defn- terminal-results
   [descriptions body]

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -14,66 +14,74 @@
   (from-dialect dialect/TypedSOAC
                 (rule '(= ?equation-id [??results]
                           (map ?attributes [??arrays] [??captures]
-                               (lambda [??parameters] [??body-results])))
+                               (lambda [??parameters]
+                                       (region [??local-definitions] [??body-results]))))
                       (success {:kind :map
                                 :id equation-id
                                 :results results
                                 :attributes attributes
                                 :arrays arrays
                                 :captures captures
-                                :parameters parameters
+                                :local-definitions local-definitions
                                 :body-results body-results}))))
 
 (def ^:private reduce-equation-rule
   (from-dialect dialect/TypedSOAC
                 (rule '(= ?equation-id [??results]
                           (reduce ?attributes [??arrays] [??captures]
-                                  (lambda [??parameters] [??body-results])))
+                                  (lambda [??parameters]
+                                          (region [??local-definitions] [??body-results]))))
                       (success {:kind :reduce
                                 :id equation-id
                                 :results results
                                 :attributes attributes
                                 :arrays arrays
                                 :captures captures
-                                :parameters parameters
+                                :local-definitions local-definitions
                                 :body-results body-results}))))
 
 (def ^:private scalar-equation-rule
   (from-dialect dialect/TypedSOAC
                 (rule '(= ?equation-id [??results]
                           (scalar ?attributes [??captures]
-                                  (lambda [??parameters] [??body-results])))
+                                  (lambda [??parameters]
+                                          (region [??local-definitions] [??body-results]))))
                       (success {:kind :scalar
                                 :id equation-id
                                 :results results
                                 :attributes attributes
                                 :arrays []
                                 :captures captures
-                                :parameters parameters
+                                :local-definitions local-definitions
                                 :body-results body-results}))))
 
 (def ^:private scan-equation-rule
   (from-dialect dialect/TypedSOAC
                 (rule '(= ?equation-id [??results]
                           (scan ?attributes [??arrays] [??captures]
-                                (lambda [??parameters] [??body-results])))
+                                (lambda [??parameters]
+                                        (region [??local-definitions] [??body-results]))))
                       (success {:kind :scan
                                 :id equation-id
                                 :results results
                                 :attributes attributes
                                 :arrays arrays
                                 :captures captures
-                                :parameters parameters
+                                :local-definitions local-definitions
                                 :body-results body-results}))))
 
 (defn equation-info
   "Return a normalized equation description, using Pattern as the dialect matcher."
   [equation]
-  (some #(when (map? %) %)
-        [(scalar-equation-rule equation)
-         (map-equation-rule equation)
-         (reduce-equation-rule equation)
-         (scan-equation-rule equation)]))
+  (when-let [matched
+             (some #(when (map? %) %)
+                   [(scalar-equation-rule equation)
+                    (map-equation-rule equation)
+                    (reduce-equation-rule equation)
+                    (scan-equation-rule equation)])]
+    (let [lambda (:lambda (dialect/operation-parts equation))]
+      (merge (dissoc matched :local-definitions)
+             (dialect/lambda-parts lambda)))))
 
 (defn- equation-references
   [equation]
@@ -103,7 +111,7 @@
 
 (defn- canonical-operands
   "Sort/deduplicate operands and alpha-rename both element and capture parameters."
-  [arrays element-parameters captures capture-parameters body-results]
+  [arrays element-parameters captures capture-parameters locals body-results]
   (let [canonical-arrays (vec (sort-by pr-str (distinct arrays)))
         canonical-elements (element-symbols (count canonical-arrays))
         element-for (zipmap canonical-arrays canonical-elements)
@@ -121,6 +129,7 @@
      :elements canonical-elements
      :captures canonical-captures
      :capture-parameters canonical-capture-parameters
+     :locals (mapv #(update % :init (fn [init] (util/subst-syms substitutions init))) locals)
      :body-results (mapv #(util/subst-syms substitutions %) body-results)}))
 
 (defn- stable-array-captures
@@ -133,24 +142,34 @@
             (vec (filter stable captures))))
 
 (defn- freshen-parameters
-  "Give one equation's element and capture binders private names before scopes are combined."
+  "Give one equation's parameters and local SSA definitions private names before scopes combine."
   [info prefix]
   (let [{:keys [accumulators elements capture-parameters]} (parameter-parts info)
         fresh-elements (mapv #(symbol (str "%" prefix "-element" %))
                              (range (count elements)))
         fresh-captures (mapv #(symbol (str "%" prefix "-capture" %))
                              (range (count capture-parameters)))
-        substitutions (merge (zipmap elements fresh-elements)
-                             (zipmap capture-parameters fresh-captures))]
+        parameter-substitutions (merge (zipmap elements fresh-elements)
+                                       (zipmap capture-parameters fresh-captures))
+        {:keys [locals substitutions]}
+        (reduce (fn [{:keys [locals substitutions]} {:keys [id dtype init]}]
+                  (let [fresh-id (symbol (str "rstr_" prefix "_local_" (count locals)))]
+                    {:locals (conj locals {:id fresh-id :dtype dtype
+                                           :init (util/subst-syms substitutions init)})
+                     :substitutions (assoc substitutions id fresh-id)}))
+                {:locals [] :substitutions parameter-substitutions}
+                (:locals info))]
     (assoc info
            :parameters (vec (concat accumulators fresh-elements fresh-captures))
+           :locals locals
            :body-results (mapv #(util/subst-syms substitutions %) (:body-results info)))))
 
 (defn- emit-equation
-  [{:keys [kind id results attributes arrays captures parameters body-results]}]
+  [{:keys [kind id results attributes arrays captures parameters locals body-results]}]
   (list '= id (vec results)
         (list (symbol (name kind)) attributes (vec arrays) (vec captures)
-              (list 'lambda (vec parameters) (vec body-results)))))
+              (dialect/lambda-form (vec parameters) (dialect/emit-locals locals)
+                                   (vec body-results)))))
 
 (defn- fusible-equation?
   [program equation-id]
@@ -225,6 +244,8 @@
            :when (= :map (:kind producer))
            :when (= 1 (count (:results producer)))
            :when (= 1 (count (:body-results producer)))
+           :when (empty? (:locals producer))
+           :when (empty? (:locals consumer))
            :when (contains? #{:map :reduce} (:kind consumer))
            :when (= (:extent (:attributes producer)) (:extent (:attributes consumer)))
            :when (= 1 (get uses produced 0))
@@ -263,7 +284,7 @@
           (vec (concat (:capture-parameters producer-parameters)
                        (:capture-parameters consumer-parameters)))
           canonical (canonical-operands raw-arrays raw-elements
-                                        raw-captures raw-capture-parameters inlined-body)
+                                        raw-captures raw-capture-parameters [] inlined-body)
           stable (set/union (stable-array-captures producer)
                             (stable-array-captures consumer))
           updated (assoc consumer
@@ -274,6 +295,7 @@
                          :parameters (vec (concat (:accumulators consumer-parameters)
                                                   (:elements canonical)
                                                   (:capture-parameters canonical)))
+                         :locals (:locals canonical)
                          :body-results (:body-results canonical))
           equations (-> (dialect/equations program)
                         (assoc consumer-index (emit-equation updated))
@@ -303,6 +325,8 @@
                  right-uses (set (concat (:arrays right) (:captures right)
                                          [(:extent (:attributes right))]))]
            :when (= :map (:kind left) (:kind right))
+           :when (empty? (:locals left))
+           :when (empty? (:locals right))
            :when (= (:extent (:attributes left)) (:extent (:attributes right)))
            :when (empty? (set/intersection left-results right-uses))
            :when (empty? (set/intersection right-results left-uses))
@@ -330,6 +354,7 @@
                      (vec (concat (:captures left) (:captures right)))
                      (vec (concat (:capture-parameters left-parameters)
                                   (:capture-parameters right-parameters)))
+                     []
                      (vec (concat (:body-results left) (:body-results right))))
           stable (set/union (stable-array-captures left) (stable-array-captures right))
           updated (assoc left
@@ -340,6 +365,7 @@
                          :captures (:captures canonical)
                          :parameters (vec (concat (:elements canonical)
                                                   (:capture-parameters canonical)))
+                         :locals (:locals canonical)
                          :body-results (:body-results canonical))
           equations (-> (dialect/equations program)
                         (assoc left-index (emit-equation updated))

--- a/src/raster/compiler/passes/parallel/typed_soac_resident.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_resident.clj
@@ -36,10 +36,11 @@
      :capture-parameters (subvec (vec parameters) element-end)}))
 
 (defn- emit-equation
-  [{:keys [kind id results attributes arrays captures parameters body-results]}]
+  [{:keys [kind id results attributes arrays captures parameters locals body-results]}]
   (list '= id (vec results)
         (list (symbol (name kind)) attributes (vec arrays) (vec captures)
-              (list 'lambda (vec parameters) (vec body-results)))))
+              (dialect/lambda-form (vec parameters) (dialect/emit-locals locals)
+                                   (vec body-results)))))
 
 (defn- use-sites
   [equations]
@@ -114,10 +115,15 @@
                         (scalar-expression scalar-defs dependent roots capture)
                         :else capture)]))
               (map vector capture-parameters (:captures info)))
+        global-locals (mapv #(update % :init
+                                     (fn [init]
+                                       (util/subst-syms capture-substitutions init)))
+                            (:locals info))
         global-bodies (mapv #(util/subst-syms capture-substitutions %) (:body-results info))
         bound (set (concat accumulators elements [(get-in info [:attributes :index])]))
         stable-before (set (get-in info [:attributes :attributes :stable-array-captures]))
-        referenced-values (->> (concat (mapcat #(util/free-syms % bound) global-bodies)
+        referenced-values (->> (concat (mapcat #(util/free-syms (:init %) bound) global-locals)
+                                       (mapcat #(util/free-syms % bound) global-bodies)
                                        stable-before)
                                (filter #(contains? values %)) distinct (sort-by pr-str) vec)
         new-parameters (mapv #(symbol (str "%capture" %)) (range (count referenced-values)))
@@ -128,6 +134,10 @@
     (assoc info
            :captures referenced-values
            :parameters (vec (concat accumulators elements new-parameters))
+           :locals (mapv #(update % :init
+                                  (fn [init]
+                                    (util/subst-syms body-substitutions init)))
+                         global-locals)
            :body-results (mapv #(util/subst-syms body-substitutions %) global-bodies)
            :attributes (assoc-in (:attributes info) [:attributes :stable-array-captures]
                                  (vec (filter stable-after referenced-values))))))

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -4,7 +4,8 @@
    Supported programs are represented and fused in the typed dialect whether or not a fusion
    fires. The resulting functional equations are mechanically projected into the surrounding host
    control expression and retained as first-class algorithms in a ParallelProgram."
-  (:require [raster.compiler.ir.parallel-program :as parallel-program]
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]
@@ -38,14 +39,29 @@
 (defn- scalar-region
   [equation]
   (let [{:keys [attributes arrays captures lambda]} (dialect/operation-parts equation)
-        [_ _ body-results] lambda
+        {:keys [locals body-results]} (dialect/lambda-parts lambda)
         {:keys [elements capture-parameters]} (dialect/parameter-layout equation)
         substitutions
         (into (zipmap capture-parameters captures)
               (map (fn [parameter array]
                      [parameter (list 'clojure.core/aget array (:index attributes))])
                    elements arrays))]
-    (mapv #(util/subst-syms substitutions %) body-results)))
+    {:locals (mapv #(update % :init (fn [init] (util/subst-syms substitutions init)))
+                   locals)
+     :bodies (mapv #(util/subst-syms substitutions %) body-results)}))
+
+(defn- materialize-region
+  [locals body]
+  (if (seq locals)
+    (list 'let*
+          (vec
+           (mapcat (fn [{:keys [id dtype init]}]
+                     (let [tag (dtype/scalar-tag-for-dtype dtype)]
+                       [(with-meta id {:raster.type/tag tag})
+                        (list tag init)]))
+                   locals))
+          body)
+    body))
 
 (defn- allocation-pair
   [values result extent]
@@ -63,7 +79,7 @@
   (let [[_ equation-id results] equation
         {:keys [kind attributes]} (dialect/operation-parts equation)
         values (:values (dialect/facts program))
-        bodies (scalar-region equation)
+        {region-locals :locals bodies :bodies} (scalar-region equation)
         placement-facts (get-in (dialect/facts program) [:equations equation-id])
         constituent-ids (or (some-> placement-facts :attributes :fusion/constituents keys set)
                             #{(or (get-in placement-facts [:provenance :source-binding-id])
@@ -77,7 +93,7 @@
                                 {:reason :typed-soac-production-subset
                                  :equation equation-id :results results})))
             result (first results)
-            source (first bodies)]
+            source (materialize-region region-locals (first bodies))]
         {:equation-id equation-id
          :placement placement
          :pairs [[result source]]
@@ -114,24 +130,29 @@
                       (list 'clojure.core/aset secondary (:index attributes)
                             (list secondary-cast body)))
                     (rest physical-results) (rest casts) (rest bodies))
-              body (if (seq secondary-stores)
-                     (list* 'do (concat secondary-stores [(first bodies)]))
-                     (first bodies))
+              body (materialize-region
+                    region-locals
+                    (if (seq secondary-stores)
+                      (list* 'do (concat secondary-stores [(first bodies)]))
+                      (first bodies)))
               effect (gensym (str "typed_soac_map_" equation-id "__"))
               source (with-meta
                        (cond
                          (= #{:effect} host-returns)
                          (list 'raster.par/map-void! (:index attributes) (:extent attributes)
-                               (list* 'do
-                                      (map (fn [destination result-cast result-body]
-                                             (list 'clojure.core/aset destination
-                                                   (:index attributes)
-                                                   (list result-cast result-body)))
-                                           physical-results casts bodies)))
+                               (materialize-region
+                                region-locals
+                                (list* 'do
+                                       (map (fn [destination result-cast result-body]
+                                              (list 'clojure.core/aset destination
+                                                    (:index attributes)
+                                                    (list result-cast result-body)))
+                                            physical-results casts bodies))))
 
                          (= #{:buffer} host-returns)
                          (list 'raster.par/map! (first physical-results) (:index attributes)
-                               (:extent attributes) cast (first bodies))
+                               (:extent attributes) cast
+                               (materialize-region region-locals (first bodies)))
 
                          :else
                          (list 'raster.par/map! result (:index attributes) (:extent attributes)
@@ -150,14 +171,15 @@
       (let [result (first results)
             accumulator (first (:accumulators attributes))
             resident? (resident/resident-scalar-value? (get values result))
+            body (materialize-region region-locals (first bodies))
             source (if resident?
                      ;; reduce-into owns its explicit one-element destination first. The
                      ;; functional reduction algorithm itself remains unchanged.
                      (list 'raster.par/reduce-into result accumulator
                            (first (:identities attributes)) (:index attributes)
-                           (:extent attributes) (first bodies))
+                           (:extent attributes) body)
                      (list 'raster.par/reduce accumulator (first (:identities attributes))
-                           (:index attributes) (:extent attributes) (first bodies)))]
+                           (:index attributes) (:extent attributes) body))]
         (if resident?
           (let [effect (gensym (str "typed_soac_reduce_" equation-id "__"))]
             {:equation-id equation-id
@@ -189,7 +211,7 @@
                            (first (:identities attributes))
                            (:index attributes) (:extent attributes)
                            (nth (get dtype->allocation (first (:dtypes attributes))) 2 nil)
-                           (first bodies))
+                           (materialize-region region-locals (first bodies)))
                      {:raster.type/elem-type (first (:dtypes attributes))})]
         {:equation-id equation-id
          :placement placement

--- a/test/raster/compiler/ir/soac_dialect_test.clj
+++ b/test/raster/compiler/ir/soac_dialect_test.clj
@@ -27,7 +27,7 @@
       :effects effects})
     [(list '= 'map-0 '[y]
            (list 'map {:index 'i :extent 'n} '[x] []
-                 (list 'lambda '[x-element] [body])))]
+                 (dialect/lambda-form '[x-element] [body])))]
     '[y])))
 
 (deftest typed-soac-is-a-pattern-declared-recursive-dialect
@@ -45,8 +45,8 @@
                  {:destination 'b :access :read-write :host-return :effect}]
         equation (list '= 'map-0 [left right]
                        (list 'map {:index 'i :extent 'n} '[x b] []
-                             (list 'lambda '[x-element b-element]
-                                   '[x-element (+ b-element 1.0)])))
+                             (dialect/lambda-form '[x-element b-element]
+                                                  '[x-element (+ b-element 1.0)])))
         equation-facts (assoc (dialect/default-equation-facts)
                               :effects #{:memory/write}
                               :aliases {left 'a right 'b}
@@ -90,6 +90,67 @@
         (catch clojure.lang.ExceptionInfo exception
           (is (= :typed-soac-result-storage-value (:reason (ex-data exception)))))))))
 
+(deftest scalar-region-locals-are-explicit-typed-and-ordered-ssa
+  (let [equation
+        (list '= 'map-0 '[y]
+              (list 'map {:index 'i :extent 'n} '[x] []
+                    (dialect/lambda-form
+                     '[element]
+                     [(dialect/local-value 'shifted :float '(+ element 1.0))
+                      (dialect/local-value 'squared :float '(* shifted shifted))]
+                     '[squared])))
+        facts (dialect/default-program-facts
+               {:values {'n extent 'x tensor 'y tensor}
+                :inputs '[n x]
+                :equations {'map-0 (dialect/default-equation-facts)}})
+        program (dialect/make facts [equation] '[y])
+        parts (dialect/lambda-parts (:lambda (dialect/operation-parts equation)))]
+    (is (= [{:id 'shifted :dtype :float :init '(+ element 1.0)}
+            {:id 'squared :dtype :float :init '(* shifted shifted)}]
+           (:locals parts)))
+    (is (= program (dialect/validate! program)))
+    (testing "a local initializer cannot read a later SSA definition"
+      (let [bad-equation
+            (list '= 'map-0 '[y]
+                  (list 'map {:index 'i :extent 'n} '[x] []
+                        (dialect/lambda-form
+                         '[element]
+                         [(dialect/local-value 'shifted :float '(+ squared 1.0))
+                          (dialect/local-value 'squared :float '(* element element))]
+                         '[shifted])))]
+        (try
+          (dialect/make facts [bad-equation] '[y])
+          (is false "use-before-definition inside a region must fail")
+          (catch clojure.lang.ExceptionInfo exception
+            (is (= :typed-soac-unbound-local (:reason (ex-data exception))))))))
+    (testing "a local cannot shadow a lambda parameter"
+      (let [bad-equation
+            (list '= 'map-0 '[y]
+                  (list 'map {:index 'i :extent 'n} '[x] []
+                        (dialect/lambda-form
+                         '[element]
+                         [(dialect/local-value 'element :float '(+ element 1.0))]
+                         '[element])))]
+        (try
+          (dialect/make facts [bad-equation] '[y])
+          (is false "lexical SSA binders must be unique")
+          (catch clojure.lang.ExceptionInfo exception
+            (is (= :typed-soac-region-binders (:reason (ex-data exception))))))))
+    (testing "a local dtype is checked against the authoritative dtype facets"
+      (doseq [unsupported [:made-up :half :f32]]
+        (let [bad-equation
+              (list '= 'map-0 '[y]
+                    (list 'map {:index 'i :extent 'n} '[x] []
+                          (dialect/lambda-form
+                           '[element]
+                           [(dialect/local-value 'local unsupported '(+ element 1.0))]
+                           '[local])))]
+          (try
+            (dialect/make facts [bad-equation] '[y])
+            (is false "unsupported scalar-region dtype must fail at the IR boundary")
+            (catch clojure.lang.ExceptionInfo exception
+              (is (= :typed-soac-local-dtype (:reason (ex-data exception)))))))))))
+
 (deftest scan-mode-has-a-distinct-typed-and-effectful-contract
   (let [out (av/tensor {:dtype :float :shape '[(unknown-dimension out)]})
         algebra (scan/->AssociativeScan 'acc 0.0 '+ 'element '(float 0.0) :float)
@@ -111,8 +172,8 @@
                                :dtypes [:float] :algebra [algebra]
                                :attributes {:stable-array-captures '[out]}}
                               '[x] '[out]
-                              (list 'lambda '[acc element destination]
-                                    '[(+ acc element)])))]
+                              (dialect/lambda-form '[acc element destination]
+                                                   '[(+ acc element)])))]
                  '[result])
         equation (first (dialect/equations program))]
     (is (= program (dialect/validate! program)))
@@ -155,10 +216,10 @@
                        'map-0 (dialect/default-equation-facts)}})
          [(list '= 'shape '[n]
                 (list 'scalar {:dtypes [:long]} '[x]
-                      (list 'lambda '[array] '[(clojure.core/alength array)])))
+                      (dialect/lambda-form '[array] '[(clojure.core/alength array)])))
           (list '= 'map-0 '[y]
                 (list 'map {:index 'i :extent 'n} '[x] []
-                      (list 'lambda '[element] '[(* element 2.0)])))]
+                      (dialect/lambda-form '[element] '[(* element 2.0)])))]
          '[y])
         scalar-equation (first (dialect/equations program))]
     (is (= program (dialect/validate! program)))
@@ -180,8 +241,9 @@
                 (list 'map {:index 'i :extent 'n
                             :attributes {:stable-array-captures '[weights]}}
                       '[x] '[weights]
-                      (list 'lambda '[element weights-value]
-                            '[(+ element (clojure.core/aget weights-value i))])))]
+                      (dialect/lambda-form
+                       '[element weights-value]
+                       '[(+ element (clojure.core/aget weights-value i))])))]
          '[y])
         remapped (dialect/remap-values program
                                        {'weights [:argument :weights]
@@ -253,10 +315,10 @@
         equations
         [(list '= 'use-a '[b]
                (list 'map {:index 'i :extent 'n} '[a] []
-                     (list 'lambda '[a-element] '[(* a-element 2.0)])))
+                     (dialect/lambda-form '[a-element] '[(* a-element 2.0)])))
          (list '= 'define-a '[a]
                (list 'map {:index 'i :extent 'n} '[x] []
-                     (list 'lambda '[x-element] '[(* x-element x-element)])))]]
+                     (dialect/lambda-form '[x-element] '[(* x-element x-element)])))]]
     (try
       (dialect/make facts equations '[b])
       (is false "an equation cannot consume a result defined later")
@@ -274,8 +336,8 @@
            :equations {'map-0 (dialect/default-equation-facts)}})
          [(list '= 'map-0 '[y]
                 (list 'map {:index 'i :extent 'n} '[x] [scale-id]
-                      (list 'lambda '[x-element scale]
-                            '[(* x-element scale)])))]
+                      (dialect/lambda-form '[x-element scale]
+                                           '[(* x-element scale)])))]
          '[y])]
     (is (= {:accumulators []
             :elements '[x-element]
@@ -300,7 +362,7 @@
            :equations {'map-0 (dialect/default-equation-facts)}})
          [(list '= 'map-0 '[y]
                 (list 'map {:index 'i :extent extent-id} '[x] []
-                      (list 'lambda '[x-element] '[(* x-element 2.0)])))]
+                      (dialect/lambda-form '[x-element] '[(* x-element 2.0)])))]
          '[y])]
     (is (= [(list 'value extent-id)] (:shape (get-in (dialect/facts program)
                                                      [:values 'x]))))))
@@ -315,7 +377,7 @@
            :equations {'map-0 (dialect/default-equation-facts)}})
          [(list '= 'map-0 '[y]
                 (list 'map {:index 'i :extent 8} '[x] []
-                      (list 'lambda '[x-element] '[(* x-element 2.0)])))]
+                      (dialect/lambda-form '[x-element] '[(* x-element 2.0)])))]
          '[y])
         remapped (dialect/remap-values program {'x [:argument 0] 'y [:result 0]})
         equation (first (dialect/equations remapped))]

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -143,6 +143,31 @@
         (is (= [] (dialect/outputs program))
             "the host nil result is not mislabeled as a tensor result")))))
 
+(deftest typed-shared-locals-become-one-region-ssa-spine
+  (let [expression
+        '(raster.par/map-void!
+          i n
+          (let* [^float shifted (+ (clojure.core/aget x i) 1.0)
+                 ^float squared (* shifted shifted)]
+                (clojure.core/aset a i (float shifted))
+                (clojure.core/aset b i (float squared))))
+        program (frontend/form->program
+                 (list 'let* ['effect expression] 'effect)
+                 {:dtype :float :array-types {'x :float 'a :float 'b :float}})
+        equation (first (dialect/equations program))
+        {:keys [locals body-results]}
+        (dialect/lambda-parts (:lambda (dialect/operation-parts equation)))]
+    (is (= [{:id 'rstr_local_0 :dtype :float
+             :init '(+ %element0 1.0)}
+            {:id 'rstr_local_1 :dtype :float
+             :init '(* rstr_local_0 rstr_local_0)}]
+           locals))
+    (is (= '[(float rstr_local_0) (float rstr_local_1)] body-results))
+    (is (= '[n x] (:inputs (dialect/facts program))))
+    (is (not-any? #{'rstr_local_0 'rstr_local_1}
+                  (keys (:values (dialect/facts program))))
+        "region-local SSA values are lexical, not fake program inputs")))
+
 (deftest ordered-or-nonpointwise-void-bodies-decline-the-functional-tuple-map
   (doseq [[label body]
           [["one destination written twice"
@@ -151,11 +176,15 @@
            ["a later store observes an earlier sibling write"
             '(do (clojure.core/aset a i (float (clojure.core/aget x i)))
                  (clojure.core/aset b i (float (clojure.core/aget a i))))]
-           ["shared local computation has no tuple-region SSA representation yet"
+           ["a typed local cannot hide a sibling destination dependency"
+            '(let* [^float observed (clojure.core/aget a i)]
+                   (clojure.core/aset a i (float (clojure.core/aget x i)))
+                   (clojure.core/aset b i (float observed)))]
+           ["an untyped shared local cannot enter a typed region"
             '(let* [v (+ (clojure.core/aget x i) 1.0)]
                    (clojure.core/aset a i (float v))
                    (clojure.core/aset b i (float (* v v))))]
-           ["transitively shared local computation also declines"
+           ["transitively shared locals without retained types also decline"
             '(let* [u (+ (clojure.core/aget x i) 1.0)
                     v (* u 2.0)]
                    (clojure.core/aset a i (float v))

--- a/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
@@ -57,24 +57,26 @@
   (let [{:keys [legacy-result typed-result typed-stats]}
         (differential-fusion horizontal-map-pairs '[u v])
         equation (first (dialect/equations typed-result))
-        lambda (nth (nth equation 3) 4)]
+        lambda (nth (nth equation 3) 4)
+        region (dialect/lambda-parts lambda)]
     (is (= (dialect/equations legacy-result) (dialect/equations typed-result)))
     (is (= {:vertical 0 :horizontal 1 :iterations 2} typed-stats))
     (is (= '[u v] (nth equation 2)))
     (is (= '[%element0 %element1] (second lambda)))
-    (is (= '[(* %element0 2.0) (+ %element1 1.0)] (nth lambda 2)))))
+    (is (= '[(* %element0 2.0) (+ %element1 1.0)] (:body-results region)))))
 
 (deftest captured-map-fusion-matches-current-graph
   (let [{:keys [legacy-result typed-result typed-stats]}
         (differential-fusion captured-map-map-pairs '[z])
         equation (first (dialect/equations typed-result))
         operation (nth equation 3)
-        lambda (nth operation 4)]
+        lambda (nth operation 4)
+        region (dialect/lambda-parts lambda)]
     (is (= (dialect/equations legacy-result) (dialect/equations typed-result)))
     (is (= {:vertical 1 :horizontal 0 :iterations 2} typed-stats))
     (is (= '[bias scale] (nth operation 3)))
     (is (= '[%element0 %capture0 %capture1] (second lambda)))
-    (is (= '[(+ (* %element0 %capture1) %capture0)] (nth lambda 2)))))
+    (is (= '[(+ (* %element0 %capture1) %capture0)] (:body-results region)))))
 
 (deftest current-graph-rewrites-the-canonical-reduction-region
   (let [pairs [['tmp '(raster.par/map! tmp i n float (* (aget x i) 2.0))]
@@ -106,6 +108,28 @@
                                                {:outputs '[z] :dtype :float})
         facts (assoc-in (dialect/facts program) [:equations 0 :aliases] {'y 'x})
         program (dialect/make facts (dialect/equations program) (dialect/outputs program))
+        [result stats] (typed-fusion/fusion-fixpoint program)]
+    (is (= program result))
+    (is (= {:vertical 0 :horizontal 0 :iterations 1} stats))))
+
+(deftest local-ssa-equations-decline-fusion-until-region-composition-is-proved
+  (let [legacy-graph (graph/build-fusion-graph (legacy/let-bindings->nodes map-map-pairs))
+        program (adapter/legacy-nodes->program (:nodes legacy-graph)
+                                               {:outputs '[z] :dtype :float})
+        equations (dialect/equations program)
+        producer (first equations)
+        operation (dialect/operation-parts producer)
+        {:keys [parameters body-results]} (dialect/lambda-parts (:lambda operation))
+        producer (list '= (second producer) (nth producer 2)
+                       (list 'map (:attributes operation) (:arrays operation)
+                             (:captures operation)
+                             (dialect/lambda-form
+                              parameters
+                              [(dialect/local-value 'shared :float (first body-results))]
+                              '[shared])))
+        program (dialect/make (dialect/facts program)
+                              (assoc equations 0 producer)
+                              (dialect/outputs program))
         [result stats] (typed-fusion/fusion-fixpoint program)]
     (is (= program result))
     (is (= {:vertical 0 :horizontal 0 :iterations 1} stats))))
@@ -159,13 +183,14 @@
            :effects #{:memory/read}})
          [(list '= 'left '[left-value]
                 (list 'map {:index 'i :extent 'n} '[x] []
-                      (list 'lambda '[x-element] '[(* x-element 2.0)])))
+                      (dialect/lambda-form '[x-element] '[(* x-element 2.0)])))
           (list '= 'middle '[middle-value]
                 (list 'map {:index 'i :extent 'n} '[z] []
-                      (list 'lambda '[z-element] '[(+ z-element 1.0)])))
+                      (dialect/lambda-form '[z-element] '[(+ z-element 1.0)])))
           (list '= 'right '[right-value]
                 (list 'map {:index 'i :extent 'n} '[middle-value] []
-                      (list 'lambda '[middle-element] '[(* middle-element 3.0)])))]
+                      (dialect/lambda-form '[middle-element]
+                                           '[(* middle-element 3.0)])))]
          '[left-value right-value])
         [result stats] (typed-fusion/fusion-fixpoint program)]
     (is (= program result))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -138,6 +138,33 @@
     (is (= [2.0 3.0 4.0 5.0] (mapv double a)))
     (is (= [12.0 22.0 32.0 42.0] (mapv double b)))))
 
+(deftest shared-tuple-work-stays-single-copy-through-jvm-and-gpu-lowering
+  (let [source '(let* [effect
+                       (raster.par/map-void!
+                        i n
+                        (let* [^float shifted (+ (clojure.core/aget x i) 1.0)
+                               ^float squared (* shifted shifted)]
+                              (clojure.core/aset a i (float shifted))
+                              (clojure.core/aset b i (float squared))))]
+                      effect)
+        typed (:program (route/attempt source :float {'x :float 'a :float 'b :float}))
+        scheduled (:form (segop-lower/segop-lower-pass
+                          typed {:dtype :float :target-device :ocl:0}))
+        emitted (opencl-pass/opencl-pass scheduled :device-id :ocl:0
+                                         :dtype :float :min-elements 0)
+        kernel-source (:source (first (:kernels emitted)))
+        jvm (par-simd/simd-pass scheduled :min-elements 1)
+        execute (eval (list 'fn '[x a b n] (:form jvm)))
+        x (float-array [1.0 2.0 3.0 4.0])
+        a (float-array 4)
+        b (float-array 4)]
+    (is (= 1 (count (re-seq #"x\[idx\]" kernel-source)))
+        "the shared producer is emitted once, not projected into both results")
+    (is (re-find #"float rstr_local_0" kernel-source))
+    (is (nil? (execute x a b 4)))
+    (is (= [2.0 3.0 4.0 5.0] (mapv double a)))
+    (is (= [4.0 9.0 16.0 25.0] (mapv double b)))))
+
 (deftest typed-inout-preserves-sequential-jvm-semantics
   (let [source '(let* [step (raster.par/map! target i n float
                                              (* (clojure.core/aget target i) 2.0))]

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -50,6 +50,15 @@
    (do (ra/aset y i (float (* (ra/aget x i) 2.0)))
        (ra/aset labels i (int (+ (int (ra/aget q i)) 7))))))
 
+(deftm ocl-session-effect-shared-local
+  [x :- (Array float) a :- (Array float) b :- (Array float) n :- Long] :- Void
+  (raster.par/map-void!
+   i n
+   (let [shifted (float (+ (ra/aget x i) 1.0))
+         squared (float (* shifted shifted))]
+     (ra/aset a i shifted)
+     (ra/aset b i squared))))
+
 (deftm ocl-session-contract
   [A :- (Array float) B :- (Array float)] :- (Array float)
   (let [C (ra/alloc-like A 64)]
@@ -168,6 +177,30 @@
               ^ints actual-labels (get result 'labels)]
           (is (= (float (* 2.0 (aget x 256))) (aget actual-y 256)))
           (is (= (+ 7 (int (aget q 256))) (aget actual-labels 256))))
+        (finally (gpu/close-session! session))))))
+
+(deftest ocl-resident-typed-region-ssa-shares-tuple-work
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "resident typed scalar-region SSA")
+    (let [descriptor (pl/compile-gpu-program #'ocl-session-effect-shared-local
+                                             :ocl:0 :dtype :float)
+          source (get-in descriptor [:steps 0 :artifact :source])
+          n 513
+          x (float-array (map float (range n)))
+          a (float-array n)
+          b (float-array n)
+          session (gpu/make-session :ocl:0)]
+      (try
+        (is (= :segmap (get-in descriptor [:steps 0 :artifact :provenance :dialect])))
+        (is (= 1 (count (re-seq #"x\[idx\]" source)))
+            "the live kernel computes its shared tuple producer once")
+        (let [program (fixture/instantiate! session descriptor [x a b n]
+                                            {'x :input 'a :output 'b :output})
+              result (fixture/run! program [x a b n])
+              ^floats actual-a (get result 'a)
+              ^floats actual-b (get result 'b)]
+          (is (= 513.0 (double (aget actual-a 512))))
+          (is (= (* 513.0 513.0) (double (aget actual-b 512)))))
         (finally (gpu/close-session! session))))))
 
 (deftest ocl-resident-typed-scan-runs-through-the-compiled-graph-step


### PR DESCRIPTION
## Summary

- make every TypedSOAC lambda own one canonical typed scalar `region` with ordered local SSA definitions
- retain walker/TypedClojure local dtypes without emitter-side inference or a new type registry, and prove lexical/order/destination independence at the dialect boundary
- lower shared tuple work once through JVM and SegMap/OpenCL paths while conservatively declining local-region fusion until composition is proved
- update the compiler north star and add differential, lowering, source, and real resident-device coverage

## Testing

- `clojure -J-Xmx1400m -M:test -n raster.compiler.ir.soac-dialect-test -n raster.compiler.passes.parallel.typed-soac-frontend-test -n raster.compiler.passes.parallel.typed-soac-fusion-test -n raster.compiler.passes.parallel.typed-soac-route-test` — 62 tests, 332 assertions, green
- CUDA/HIP hardware-free compiler gates — 12 tests, 149 assertions, green
- Intel Arc OpenCL resident suite — 16 tests, 40 assertions, green, including shared-region compile/bind/replay/download
- full local suite — 2,525 tests, 35,550 assertions, 0 assertion failures; 13 inherited Level Zero device errors in the ABM scan/legacy scalar-ABI tests. A pristine `origin/main` worktree reproduces the same failure classes in the same three namespaces; CI has no Level Zero device and exercises their skip path.