### PR TITLE
Route indexed block transfers through TypedSOAC

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -119,14 +119,18 @@ its caller-owned destination, access mode, and host-return contract. The effect 
 retains its real `nil` host semantics instead of masquerading as a tensor result. The scheduled
 SegMap and its ordered ABI are consumed by staged and resident compilation; unsupported raw
 map-void bodies retain the compatibility generator. The front end refuses duplicate destinations,
-scatter indices, sibling write/read ordering, and atomics. Shared scalar work now remains one
+uncontracted scatter indices, sibling write/read ordering, and atomics. A destination wrapped in
+`par/unique-index` carries an explicit caller proof of conflict freedom into a TypedSOAC `scatter`;
+the marker is consumed before scalar lowering, while the checked read/write storage contract and
+guarded indexed store remain visible to scheduling and ABI construction. Shared scalar work now remains one
 explicit ordered local-SSA spine inside the tuple map's scalar region; each definition has a dtype
 retained from walker/TypedClojure facts, and local binders never become fake program inputs.
 Validation proves definition order and lexical closure, and the front end expands locals only for
 dependency analysis so a local cannot hide sibling write/read ordering. JVM and GPU lowering both
-materialize the same typed spine once around all tuple results. Fusion currently leaves
-local-bearing regions intact until region composition is proved, rather than duplicating their
-work. Flat resident `deftm` signatures provide their declared per-buffer dtypes before fusion, so a
+materialize the same typed spine once around all tuple results. Vertical and horizontal fusion
+alpha-rename and compose these regions while preserving definition order; a typed producer-result
+bridge is introduced only when reuse requires it, so fusion does not duplicate scalar work. Flat
+resident `deftm` signatures provide their declared per-buffer dtypes before fusion, so a
 mixed FP32/int8-input, FP32/int32-output map does not inherit a global default dtype.
 
 The first architectural correction is therefore:
@@ -312,7 +316,9 @@ multi-workgroup alternatives remain schedule candidates, not new semantic primit
 
 Indexed storage movement remains a separate generic operation. Allocation-free `gather-blocks!`
 and `scatter-blocks!` move contiguous typed blocks between dense staging and routed resident
-storage with one ordinary SOAC map per direction. Routing is an `int[nblocks]` buffer; it does not
+storage through the direct TypedSOAC→SegMap vertical: gather is a stable indexed read in a dense
+`map`, while scatter is an explicit guarded `scatter` with unique destinations. Compound launch
+extents are hoisted into typed scalar SSA before scheduling. Routing is an `int[nblocks]` buffer; it does not
 encode pages, attention, cache policy, or quantization. Gather permits repeated sources, while the
 non-reducing scatter contract requires unique destinations. Host validation proves active extents,
 index bounds, non-aliasing and the current 32-bit device-index limit; emitted kernels retain bounds
@@ -850,11 +856,11 @@ The immediate continuation after the verified double-buffered weighted-reduction
    staged binding without an aliased compatibility input. Independent effect-only tuple maps also
    carry an ordered logical-result-to-physical-storage contract and compile through their scheduled
    SegMap on resident OpenCL execution. Their shared typed scalar computations use one explicit
-   ordered local-SSA region that lowers once through JVM and GPU paths; fusion declines those
-   regions until composition is proved. Hardware-costed
-   multi-consumer fusion, nested-region JVM
-   scheduling, local-region fusion, indexed/scatter operations, the
-   remaining parallel forms, and
+   ordered local-SSA region that lowers once through JVM and GPU paths; vertical and horizontal
+   fusion now alpha-rename and compose those regions without duplicating shared scalar work.
+   Stable indexed gathers and explicitly unique guarded scatters also use this typed scheduled-map
+   route, including resident block transfers. Hardware-costed multi-consumer fusion, nested-region
+   JVM scheduling, reducing/atomic scatter variants, the remaining parallel forms, and
    deletion of the remaining graph/backend fallbacks remain.
 6. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a
    read-only distributed track without interrupting the kernel and typed-middle-end verticals.

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -526,11 +526,17 @@
                                  #(and (instance? raster.compiler.ir.segop.SegMap %)
                                        (= :typed-soac (:algorithm-dialect %))))
                       kernel (if scheduled
-                               (segop-cl/generate-segmap-kernel
-                                scheduled (:out-sym scheduled)
-                                :dtype (:dtype scheduled)
-                                :scalar-types top-scalar-types
-                                :array-types top-array-types)
+                               (if (:out-sym scheduled)
+                                 (segop-cl/generate-segmap-kernel
+                                  scheduled (:out-sym scheduled)
+                                  :dtype (:dtype scheduled)
+                                  :scalar-types top-scalar-types
+                                  :array-types top-array-types)
+                                 (segop-cl/generate-explicit-segmap-kernel
+                                  scheduled
+                                  :dtype (:dtype scheduled)
+                                  :scalar-types top-scalar-types
+                                  :array-types top-array-types))
                                (legacy/generate-par-map-void-kernel
                                 form :dtype dtype :device-id device-id
                                 :array-types top-array-types

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -44,6 +44,104 @@
 ;; SegMap → OpenCL kernel
 ;; ================================================================
 
+(defn generate-explicit-segmap-kernel
+  "Emit an explicit-store SegMap without reconstructing a source `map-void!` form.
+
+   Unique-destination scatter schedules use this shape: the scalar region owns its indexed aset
+   statements, while SegMap owns the iteration geometry and the typed input/output boundary."
+  [segmap & {:keys [dtype kernel-name-prefix scalar-types array-types]
+             :or {dtype :float kernel-name-prefix "segmap_effect"
+                  scalar-types {} array-types {}}}]
+  (let [idx (seg-idx segmap)
+        bound (seg-bound segmap)
+        body (ce/normalize-array-prims (:lambda segmap))
+        inputs (set (:inputs segmap))
+        outputs (set (:outputs segmap))
+        pointers (vec (sort-by name (clojure.set/union inputs outputs)))
+        scalars (vec (sort-by name (:scalars segmap)))
+        default-dtype (or (:dtype segmap) dtype)
+        default-ctype (dt/ctype :opencl default-dtype)
+        meta-types (ce/collect-array-types-from-meta body)
+        array-types (merge meta-types array-types)
+        pointer-dtype (fn [symbol]
+                        (or (get array-types symbol)
+                            (get array-types (clojure.core/symbol (name symbol)))
+                            default-dtype))
+        pointer-ctype #(dt/ctype :opencl (pointer-dtype %))
+        written? #(contains? outputs %)
+        read? #(contains? inputs %)
+        pointer-kind (fn [symbol]
+                       (cond
+                         (and (read? symbol) (written? symbol)) :inout
+                         (written? symbol) :output
+                         :else :input))
+        scalar-ctype #(ce/scalar-native-type % scalar-types default-ctype)
+        scalar-dtype (fn [symbol]
+                       (case (scalar-ctype symbol)
+                         "int" :int
+                         "long" :long
+                         "double" :double
+                         "float" :float))
+        pointer-params
+        (str/join ", "
+                  (map (fn [symbol]
+                         (str "__global "
+                              (when-not (written? symbol) "const ")
+                              (pointer-ctype symbol) "* "
+                              (when-not (written? symbol) "restrict ")
+                              (ce/c-symbol symbol)))
+                       pointers))
+        scalar-params (str/join ", "
+                                (map #(str (scalar-ctype %) " " (ce/c-symbol %)) scalars))
+        parameter-list (str/join ", "
+                                 (remove empty? [pointer-params scalar-params "int _n_bound"]))
+        array-symbols (set (map #(clojure.core/symbol (name %)) pointers))
+        int-scalars (into #{idx} (filter #(= "int" (scalar-ctype %)) scalars))
+        adapted-body (ce/adapt-casts-for-dtype body default-dtype)
+        body-source (binding [ce/*emit-config* ce/opencl-config
+                              ce/*scalar-type* default-ctype
+                              ce/*idx-sym* idx
+                              ce/*int-vars* (into ce/*int-vars* int-scalars)]
+                      (ce/emit-stmt adapted-body idx array-symbols "idx"))
+        kernel-name (str kernel-name-prefix "_" (gensym ""))
+        abi (kabi/validate!
+             (vec (concat
+                   (map (fn [symbol]
+                          (kabi/slot symbol (pointer-kind symbol) (pointer-dtype symbol)
+                                     :c-name (ce/c-symbol symbol)
+                                     :role (if (written? symbol) :effect :operand)))
+                        pointers)
+                   (map (fn [symbol]
+                          (kabi/slot symbol :scalar (scalar-dtype symbol)
+                                     :c-name (ce/c-symbol symbol) :role :parameter))
+                        scalars)
+                   [(kabi/slot '_n_bound :scalar :int :role :bound)])))
+        source (str (apply codegen/extension-pragmas
+                           default-dtype (map pointer-dtype pointers))
+                    (ce/intrinsic-helper-sources body-source)
+                    "__kernel void " kernel-name "(" parameter-list ") {\n"
+                    "    for (int idx = get_global_id(0); idx < _n_bound; "
+                    "idx += get_global_size(0)) {\n"
+                    "        " body-source "\n"
+                    "    }\n}\n")]
+    (kabi/validate-source-signature! kernel-name source abi)
+    (kart/make
+     {:kernel-name kernel-name
+      :source source
+      :abi abi
+      :arguments (vec (concat pointers scalars [bound]))
+      :launch (klaunch/spec {:workgroup-size [256]
+                             :group-count [(klaunch/ceil-div bound 256)]})
+      :temporaries []
+      :effects {:kind :side-effect-map :write-conflict :unique}
+      :provenance {:dialect :segmap :segop-id (:id segmap)}
+      :attributes {:array-params pointers
+                   :scalar-params scalars
+                   :written-arrays (vec (sort-by name outputs))
+                   :array-types array-types
+                   :dtype default-dtype
+                   :explicit-stores true}})))
+
 (defn generate-segmap-kernel
   "Generate an OpenCL C kernel from a SegMap record.
 

--- a/src/raster/compiler/ir/dialects.clj
+++ b/src/raster/compiler/ir/dialects.clj
@@ -520,7 +520,8 @@
             (let [body (when (and (seq? operation) (= '= (first operation))
                                   (= 4 (count operation)))
                          (nth operation 3))]
-              (and (seq? body) (contains? #{'scalar 'map 'reduce 'scan} (first body)))))
+              (and (seq? body)
+                   (contains? #{'scalar 'map 'scatter 'reduce 'scan} (first body)))))
           (fn [_ algorithm]
             (= algorithm (soac-dialect/validate! algorithm))))
          (valid-let*-ordered? (:source value))

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -20,6 +20,11 @@
                (region [(let-value local :dtype init-expr) ...]
                        [result-expr ...]))))
         (= equation-id [result ...]
+           (scatter {:index i :extent n :conflict :unique} [array ...] [capture ...]
+             (lambda [element ... capture-parameter ...]
+               (region [(let-value local :dtype init-expr) ...]
+                       [(write destination-index predicate value) ...]))))
+        (= equation-id [result ...]
            (reduce {:index i :extent n
                     :accumulators [acc ...] :identities [zero ...]
                     :dtypes [:float ...] :algebra [{} ...]}
@@ -104,6 +109,11 @@
        (extent? (:extent value))
        (or (nil? (:attributes value)) (map? (:attributes value)))))
 
+(defn scatter-attributes?
+  [value]
+  (and (map-attributes? value)
+       (= :unique (:conflict value))))
+
 (defn reduce-attributes?
   [value]
   (and (map-attributes? value)
@@ -167,6 +177,7 @@
              [lit scalar-literal?]
              [sa scalar-attributes?]
              [ma map-attributes?]
+             [xa scatter-attributes?]
              [ra reduce-attributes?]
              [ca scan-attributes?]
              [dt keyword?]
@@ -177,6 +188,7 @@
           (if ?s:test ?s:then ?s:else)
           (do (?:+ s))
           (let* [(?:* ?sym:binding ?s:init)] ?s:body)
+          (write ?s:destination-index ?s:predicate ?s:value)
           [(?:* s)]
           (.invk ?sym:impl (?:* s:args))
           (& (?sym:f (?:* s:args)) (? _ seq?)))
@@ -193,6 +205,7 @@
   (Operation [o :enforce]
              (scalar ?sa [(?:* ?id:capture)] ?l)
              (map ?ma [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
+             (scatter ?xa [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
              (reduce ?ra [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
              (scan ?ca [(?:* ?id:array)] [(?:* ?id:capture)] ?l))
 
@@ -240,6 +253,17 @@
         {:kind kind :attributes attributes :arrays [] :captures captures :lambda lambda})
       (let [[_ attributes arrays captures lambda] operation]
         {:kind kind :attributes attributes :arrays arrays :captures captures :lambda lambda}))))
+
+(defn write-form?
+  "Whether a scatter-region result is one explicit conditional indexed write."
+  [value]
+  (and (seq? value) (= 'write (first value)) (= 4 (count value))))
+
+(defn write-parts
+  [value]
+  (when (write-form? value)
+    (let [[_ destination-index predicate written-value] value]
+      {:destination-index destination-index :predicate predicate :value written-value})))
 
 (defn local-value
   "Construct one explicitly typed scalar-region SSA definition."
@@ -355,7 +379,7 @@
         (fail! :typed-soac-region-binders
                "scalar-region parameters and local SSA definitions must be distinct"
                {:equation equation-id :parameters parameters :locals local-ids}))
-      (when (and (contains? #{'map 'reduce 'scan} kind)
+      (when (and (contains? #{'map 'scatter 'reduce 'scan} kind)
                  (some #{(:index attributes)} local-ids))
         (fail! :typed-soac-region-binders
                "a scalar-region local cannot shadow its operation index"
@@ -370,9 +394,9 @@
         (fail! :typed-soac-local-dtype
                "scalar-region locals require a supported JVM scalar dtype"
                {:equation equation-id :local local :dtype dtype})))
-    (when (and (seq locals) (not= 'map kind))
+    (when (and (seq locals) (not (contains? #{'map 'scatter} kind)))
       (fail! :typed-soac-region-operation
-             "typed local SSA is currently admitted only in map scalar regions"
+             "typed local SSA is currently admitted only in map/scatter scalar regions"
              {:equation equation-id :operation kind :locals locals}))
     (when-not (= result-count (count body-results))
       (fail! :typed-soac-result-arity "SOAC result and lambda arity differ"
@@ -391,7 +415,8 @@
                 :arrays arrays
                 :captures captures})))
     (let [initial-bound (cond-> (set parameters)
-                          (contains? #{'map 'reduce 'scan} kind) (conj (:index attributes)))
+                          (contains? #{'map 'scatter 'reduce 'scan} kind)
+                          (conj (:index attributes)))
           final-bound
           (reduce (fn [bound {:keys [id init] :as local}]
                     (let [unbound (util/free-syms init bound)]
@@ -402,11 +427,14 @@
                       (conj bound id)))
                   initial-bound locals)]
       (doseq [body body-results
-              :let [unbound (util/free-syms body final-bound)]
+              expression (if (= 'scatter kind)
+                           (vals (write-parts body))
+                           [body])
+              :let [unbound (util/free-syms expression final-bound)]
               :when (seq unbound)]
         (fail! :typed-soac-unbound-scalar
                "scalar-region results may reference only parameters and local SSA values"
-               {:equation equation-id :unbound unbound :body body})))
+               {:equation equation-id :unbound unbound :body body :expression expression})))
     (case kind
       scalar
       (when-not (= result-count (count (:dtypes attributes)))
@@ -415,7 +443,16 @@
                {:equation equation-id :results results :dtypes (:dtypes attributes)}))
 
       map
-      nil
+      (when (some write-form? body-results)
+        (fail! :typed-soac-map-write
+               "functional map results cannot contain indexed writes"
+               {:equation equation-id :results body-results}))
+
+      scatter
+      (when-not (every? write-form? body-results)
+        (fail! :typed-soac-scatter-write
+               "scatter results must be explicit conditional indexed writes"
+               {:equation equation-id :results body-results}))
 
       reduce
       (let [accumulators (:accumulators attributes)]
@@ -494,6 +531,14 @@
                    "map results must be rank-one tensors over the declared extent"
                    {:equation equation-id :id id :value value :extent extent}))))
 
+      scatter
+      (doseq [id results]
+        (let [value (get values id)]
+          (when (and value (not= :tensor (:kind value)))
+            (fail! :typed-soac-scatter-result-type
+                   "scatter results require tensor storage contracts"
+                   {:equation equation-id :id id :value value}))))
+
       reduce
       (doseq [[id dtype] (map vector results (:dtypes attributes))]
         (let [value (get values id)]
@@ -524,9 +569,9 @@
         {:keys [kind]} (operation-parts equation)
         storage (result-storage program-facts equation-id)]
     (when storage
-      (when-not (= 'map kind)
+      (when-not (contains? #{'map 'scatter} kind)
         (fail! :typed-soac-result-storage-operation
-               "physical result storage is currently valid only for map equations"
+               "physical result storage is valid only for map/scatter equations"
                {:equation equation-id :operation kind :storage storage}))
       (when-not (and (vector? storage)
                      (= (count results) (count storage))

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -282,6 +282,8 @@
                              scalar {:operations []}
                              map {:operations (soac-lower/lower-typed-map
                                                algorithm device-id :dtype dtype)}
+                             scatter {:operations (soac-lower/lower-typed-scatter
+                                                   algorithm device-id :dtype dtype)}
                              reduce {:operations (soac-lower/lower-typed-reduce
                                                   algorithm device-id :dtype dtype)}
                              scan (soac-lower/lower-typed-scan

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -119,6 +119,64 @@
                     :algorithm-equation equation-id)
             (lower-map node device-id :dtype result-dtype)))))
 
+(defn lower-typed-scatter
+  "Lower one unique-destination TypedSOAC scatter to an explicit-store SegMap.
+
+   The SegMap has no implicit primary result store (`out-sym` is nil); its typed scalar region
+   contains every conditional indexed write. Physical destinations remain both inputs and outputs
+   because an indexed update preserves unselected elements."
+  [program device-id & {:keys [dtype] :or {dtype :double}}]
+  (let [program (soac-dialect/validate! program)
+        equation (first (soac-dialect/equations program))]
+    (when-not (and (= 1 (count (soac-dialect/equations program)))
+                   (= 'scatter (soac-dialect/operation-kind equation)))
+      (throw (ex-info "typed scatter lowering requires one scatter equation"
+                      {:reason :typed-soac-scatter-subset :program program})))
+    (let [[_ equation-id results operation] equation
+          [_ attributes arrays captures lambda] operation
+          {:keys [locals body-results]} (soac-dialect/lambda-parts lambda)
+          {:keys [elements capture-parameters]} (soac-dialect/parameter-layout equation)
+          substitutions
+          (into (zipmap capture-parameters captures)
+                (map (fn [parameter array]
+                       [parameter (list 'clojure.core/aget array (:index attributes))])
+                     elements arrays))
+          locals (mapv #(update % :init
+                                (fn [init]
+                                  (-> (util/subst-syms substitutions init)
+                                      par/expand-par-forms)))
+                       locals)
+          writes (mapv #(some-> % soac-dialect/write-parts
+                                (update-vals (fn [expression]
+                                               (-> (util/subst-syms substitutions expression)
+                                                   par/expand-par-forms))))
+                       body-results)
+          facts (soac-dialect/facts program)
+          physical-results (soac-dialect/physical-results facts equation)
+          _ (when-not (and (= (count results) (count writes) (count physical-results))
+                           (every? some? writes))
+              (throw (ex-info "typed scatter requires one write per physical result"
+                              {:reason :typed-soac-scatter-subset :equation equation-id
+                               :results results :writes writes
+                               :physical-results physical-results})))
+          statements
+          (mapv (fn [destination {:keys [destination-index predicate value]}]
+                  (let [store (list 'clojure.core/aset destination destination-index value)]
+                    (if (contains? #{true 1} predicate) store (list 'if predicate store))))
+                physical-results writes)
+          body (materialize-region-locals locals (list* 'do statements))
+          stable (set (get-in attributes [:attributes :stable-array-captures]))
+          scalar-captures (set (remove stable captures))
+          result-dtype (or (:dtype (get-in facts [:values (first results)])) dtype :double)
+          node (assoc (soac/->SoacMap equation-id nil (:index attributes)
+                                      (:extent attributes) nil body
+                                      (into (set arrays) stable)
+                                      (set physical-results) scalar-captures)
+                      :elem-type result-dtype :pure? false)]
+      (mapv #(assoc % :algorithm-dialect :typed-soac
+                    :algorithm-equation equation-id)
+            (lower-map node device-id :dtype result-dtype)))))
+
 (defn typed-reduce-program?
   "Whether a validated one-equation TypedSOAC program is the scalar reduction vertical currently
    accepted by SegRed lowering."

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -359,15 +359,26 @@
           normalized
           (mapcat
            (fn [ordinal [symbol expression]]
-             (let [extent (parallel-extent expression)]
-               (if (and extent
-                        (not (dialect/extent? extent))
-                        (provably-pure-scalar? extent))
+             (let [extent (parallel-extent expression)
+                   canonical-extent (some-> extent descriptor/unwrap-int-cast)]
+               (cond
+                 (nil? extent)
+                 [[symbol expression]]
+
+                 ;; Integral casts are representation noise, not new semantic dimensions.
+                 ;; Keeping their underlying value identity also prevents one array from
+                 ;; acquiring incompatible [n] and [(long n)] shapes across operations.
+                 (dialect/extent? canonical-extent)
+                 [[symbol (replace-parallel-extent expression canonical-extent)]]
+
+                 (provably-pure-scalar? canonical-extent)
                  (let [extent-id (with-meta
                                    (clojure.core/symbol (str "rstr_extent_" ordinal))
                                    {:tag 'long :raster.type/tag 'long})]
-                   [[extent-id extent]
+                   [[extent-id canonical-extent]
                     [symbol (replace-parallel-extent expression extent-id)]])
+
+                 :else
                  [[symbol expression]])))
            (range) pairs)]
       (with-meta (list* head (vec (mapcat identity normalized)) body) (meta source)))

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -50,6 +50,19 @@
     (second expression)
     expression))
 
+(def ^:private unique-index-ops
+  '#{raster.par/unique-index unique-index})
+
+(defn- unique-index-expression
+  "Return the inner destination expression when `expression` carries Raster's explicit
+   uniqueness contract. The marker may be a direct source call or a walker-devirtualized call;
+   semantic-op/call-args are the only sanctioned way to look through the latter."
+  [expression]
+  (when (and (seq? expression)
+             (contains? unique-index-ops (descriptor/semantic-op expression))
+             (= 1 (count (descriptor/call-args expression))))
+    (first (descriptor/call-args expression))))
+
 (defn- retained-local-dtype
   [binding init]
   (let [init-tag (when (instance? clojure.lang.IObj init)
@@ -58,7 +71,7 @@
         (dtype/dtype-for-scalar-tag init-tag))))
 
 (defn- pointwise-region
-  "Recognize an ordered, pure local-SSA spine ending exclusively in pointwise stores.
+  "Recognize an ordered, pure local-SSA spine ending exclusively in indexed stores.
 
    Local types come only from retained walker/TypedClojure facts. Nested local scopes and missing
    local types decline; guessing them in this source recognizer or a C emitter would make the
@@ -91,9 +104,11 @@
                                    :substitutions (assoc substitutions binding id)}))
                               {:locals [] :substitutions {}} typed)]
                   {:locals locals
-                   :stores (mapv #(update % :value
-                                          (fn [value]
-                                            (util/subst-syms substitutions value)))
+                   :stores (mapv (fn [store]
+                                   (reduce (fn [store field]
+                                             (update store field
+                                                     #(util/subst-syms substitutions %)))
+                                           store [:index :predicate :value]))
                                  stores)})))))))
 
     (and (seq? body) (= 'do (first body)))
@@ -113,30 +128,30 @@
                  (or (nil? else-expression)
                      (and else-region (empty? (:locals else-region))))
                  (or (nil? else-region)
-                     (= (mapv :out (:stores then-region))
-                        (mapv :out (:stores else-region)))))
+                     (= (mapv (juxt :out :index) (:stores then-region))
+                        (mapv (juxt :out :index) (:stores else-region)))))
         {:locals []
          :stores
          (mapv (fn [ordinal then-store]
                  (let [else-store (when else-region (nth (:stores else-region) ordinal))]
-                   (update then-store :value
-                           (fn [then-value]
-                             (list 'if predicate then-value
-                                   (if else-store
-                                     (:value else-store)
-                                     ;; A guarded pointwise write semantically preserves the
-                                     ;; caller-owned destination when its predicate is false.
-                                     ;; Making that read explicit turns gather-with-bounds-guard
-                                     ;; into an ordinary inout map; no hidden effect reaches the
-                                     ;; scheduler or emitter.
-                                     (list 'clojure.core/aget (:out then-store) index)))))))
+                   (if else-store
+                     (assoc then-store
+                            :value (list 'if predicate (:value then-store) (:value else-store))
+                            :predicate (list 'if predicate
+                                             (:predicate then-store)
+                                             (:predicate else-store)))
+                     (update then-store :predicate
+                             #(if (contains? #{true 1} %)
+                                predicate
+                                (list 'if predicate % 0))))))
                (range) (:stores then-region))}))
 
     (descriptor/aset-call? body)
     (let [arguments (vec (descriptor/call-args body))]
-      (when (and (= 3 (count arguments))
-                 (= index (strip-index-cast (nth arguments 1))))
-        (let [value (nth arguments 2)
+      (when (= 3 (count arguments))
+        (let [raw-index (nth arguments 1)
+              unique-index (unique-index-expression raw-index)
+              value (nth arguments 2)
               cast? (and (seq? value)
                          (contains? #{'float 'double 'int 'long
                                       'clojure.core/float 'clojure.core/double}
@@ -144,6 +159,9 @@
                          (= 2 (count value)))]
           {:locals []
            :stores [{:out (descriptor/aset-array-sym body)
+                     :index (strip-index-cast (or unique-index raw-index))
+                     :conflict (when unique-index :unique)
+                     :predicate 1
                      :value (if cast? (second value) value)
                      :cast (when cast? (first value))}]})))
 
@@ -155,15 +173,16 @@
             (util/subst-syms {id init} body))
           expression (reverse locals)))
 
-(defn- independent-pointwise-stores?
+(defn- independent-stores?
   [locals stores]
   (let [destinations (mapv :out stores)
         destination-set (set destinations)]
     (and (= (count destinations) (count destination-set))
-         (every? (fn [{:keys [out value]}]
+         (every? (fn [{:keys [out index predicate value]}]
                    (empty? (disj (set/intersection destination-set
                                                    (par/collect-aget-arrays
-                                                    (expanded-local-expression locals value)))
+                                                    (expanded-local-expression
+                                                     locals (list 'do index predicate value))))
                                  out)))
                  stores))))
 
@@ -173,24 +192,46 @@
 
 (defn- effect-map-description
   [id symbol index extent {:keys [locals stores]} elem-type]
-  (when (and (seq stores) (independent-pointwise-stores? locals stores))
-    (let [destinations (mapv :out stores)
+  (when (and (seq stores) (independent-stores? locals stores))
+    (let [stores (mapv #(merge {:index index :predicate 1} %) stores)
+          pointwise? (every? #(= index (:index %)) stores)
+          stores (if pointwise?
+                   (mapv (fn [{:keys [out predicate value] :as store}]
+                           (assoc store :value
+                                  (if (contains? #{true 1} predicate)
+                                    value
+                                    ;; A guarded dense write preserves its caller-owned
+                                    ;; destination. Making that read explicit yields an ordinary
+                                    ;; inout map instead of a hidden conditional effect.
+                                    (list 'if predicate value
+                                          (list 'clojure.core/aget out index)))))
+                         stores)
+                   stores)
+          conflict (when (every? #(= :unique (:conflict %)) stores) :unique)
+          destinations (mapv :out stores)
           values (mapv :value stores)
-          analysis-values (concat (map :init locals) values)
+          write-indices (mapv :index stores)
+          predicates (mapv :predicate stores)
+          analysis-values (concat (map :init locals) write-indices predicates values)
           io (update (extract-io (list* 'do analysis-values) index destinations)
                      :scalars set/difference (set (map :id locals)))
           results (mapv #(effect-result-id id %) (range (count stores)))]
-      (merge {:kind :map :id id :sym symbol :index index :extent extent
+      (when (or pointwise? (= :unique conflict))
+        (merge {:kind (if pointwise? :map :scatter)
+              :id id :sym symbol :index index :extent extent
               :results results :locals locals :bodies values :casts (mapv :cast stores)
+              :write-indices write-indices :predicates predicates
+              :conflict (when-not pointwise? conflict)
               :effect-only? true :host-binding symbol :elem-type elem-type
               :result-storage
               (mapv (fn [destination]
                       {:destination destination
-                       :access (if (contains? (:inputs io) destination)
+                       :access (if (or (not pointwise?)
+                                       (contains? (:inputs io) destination))
                                  :read-write :write)
                        :host-return :effect})
                     destinations)}
-             io))))
+               io)))))
 
 (defn- operation-description
   [id symbol expression]
@@ -266,7 +307,8 @@
                  (extract-io body idx [out] :accumulator acc)))))
 
     (par/par-map-void-form? expression)
-    (let [{:keys [idx bound body elem-type]} (par/extract-par-map-void-info expression)]
+    (let [{:keys [idx bound body elem-type]}
+          (par/extract-par-map-void-info expression)]
       (when-let [region (pointwise-region body idx)]
         (effect-map-description id symbol idx bound region elem-type)))
 
@@ -368,7 +410,7 @@
                                                  expression representative)))
               (assoc-in [:scalar-representatives (:sym description)] representative)))
 
-        (:map :reduce :scan)
+        (:map :scatter :reduce :scan)
         (let [extent (descriptor/unwrap-int-cast (:extent description))
               array (alength-array extent)
               extent' (cond
@@ -377,7 +419,7 @@
                         :else extent)
               description' (assoc description :extent extent')]
           (cond-> (update state :descriptions conj description')
-            (contains? #{:map :scan} (:kind description'))
+            (contains? #{:map :scatter :scan} (:kind description'))
             (assoc-in [:extents (:sym description')] extent')))
 
         (update state :descriptions conj description)))
@@ -396,7 +438,7 @@
 (defn- supported-descriptions?
   [descriptions]
   (let [physical-outputs (reduce set/union #{}
-                                 (map #(if (contains? #{:map :reduce :scan} (:kind %))
+                                 (map #(if (contains? #{:map :scatter :reduce :scan} (:kind %))
                                          (:outputs %) #{})
                                       descriptions))]
     (every? (fn [description]
@@ -407,6 +449,10 @@
                          (and (seq (:result-storage description))
                               (every? (comp symbol? :destination)
                                       (:result-storage description))))
+                :scatter (and (seq (:result-storage description))
+                              (= :unique (:conflict description))
+                              (every? (comp symbol? :destination)
+                                      (:result-storage description)))
                 :reduce true
                 :scan (symbol? (:primary-out description))
                 false))
@@ -458,6 +504,40 @@
                 arrays captures
                 (dialect/lambda-form (vec (concat parameters capture-parameters))
                                      local-forms body-results)))))
+
+(defn- scatter-equation
+  [description]
+  (let [{:keys [id index extent locals casts bodies inputs results result-storage
+                write-indices predicates conflict]} description
+        values (mapv (fn [cast body] (if cast (list cast body) body)) casts bodies)
+        destinations (mapv :destination result-storage)
+        semantic-inputs (into (set inputs) destinations)
+        all-expressions (vec (concat (map :init locals) write-indices predicates values))
+        [pointwise stable]
+        ((juxt filter remove) #(pointwise-input? all-expressions % index) semantic-inputs)
+        arrays (vec (sort-by pr-str pointwise))
+        captures (vec (sort-by pr-str (distinct (concat stable (:scalars description)))))
+        parameters (element-symbols (count arrays))
+        capture-parameters (capture-symbols (count captures))
+        substitutions (zipmap captures capture-parameters)
+        transform (fn [expression]
+                    (util/subst-syms
+                     substitutions
+                     (first (elementize [expression] arrays parameters index))))
+        local-forms (mapv (fn [{:keys [id dtype init]}]
+                            (dialect/local-value id dtype (transform init)))
+                          locals)
+        writes (mapv (fn [destination-index predicate value]
+                       (list 'write (transform destination-index)
+                             (transform predicate) (transform value)))
+                     write-indices predicates values)]
+    (list '= id results
+          (list 'scatter {:index index :extent extent :conflict conflict
+                          :attributes {:stable-array-captures
+                                       (vec (sort-by pr-str stable))}}
+                arrays captures
+                (dialect/lambda-form (vec (concat parameters capture-parameters))
+                                     local-forms writes)))))
 
 (defn- reduce-equation
   [{:keys [id extent inputs scalars product]}]
@@ -535,15 +615,15 @@
 
 (defn- terminal-results
   [descriptions body]
-  (let [operations (filter #(contains? #{:map :reduce :scan} (:kind %)) descriptions)
+  (let [operations (filter #(contains? #{:map :scatter :reduce :scan} (:kind %)) descriptions)
         operation-definitions (set (mapcat #(case (:kind %)
-                                              :map (:results %)
+                                              (:map :scatter) (:results %)
                                               :scan [(:sym %)]
                                               (:outputs %))
                                            operations))
         terminal-operation-definitions
         (set (mapcat #(case (:kind %)
-                        :map (if (:effect-only? %) [] (:results %))
+                        (:map :scatter) (if (:effect-only? %) [] (:results %))
                         :scan [(:sym %)]
                         (:outputs %))
                      operations))
@@ -595,7 +675,7 @@
                         scalar (:dtypes attributes)
                         reduce (:dtypes attributes)
                         scan (:dtypes attributes)
-                        map (map #(value-dtype % default-dtype array-types) results))]
+                        (map scatter) (map #(value-dtype % default-dtype array-types) results))]
     (merge
      (if (and extent (dialect/value-id? extent)) {extent (tensor-value :long [])} {})
      (into {} (map (fn [id] [id (tensor-value (value-dtype id default-dtype array-types)
@@ -627,6 +707,7 @@
                                        (case kind
                                          (scalar reduce) []
                                          scan (dialect/scan-result-shape attributes)
+                                         scatter [(list 'unknown-dimension id)]
                                          (dialect/extent-shape extent)))])
                    results result-dtypes)))))
 
@@ -661,8 +742,10 @@
       (when (and (even? (count bindings))
                  (seq descriptions)
                  (supported-descriptions? descriptions))
-        (let [operation-descriptions (filterv #(contains? #{:map :reduce :scan} (:kind %)) descriptions)
+        (let [operation-descriptions
+              (filterv #(contains? #{:map :scatter :reduce :scan} (:kind %)) descriptions)
               operation-equations (mapv #(case (:kind %) :map (map-equation %)
+                                               :scatter (scatter-equation %)
                                                :reduce (reduce-equation %)
                                                :scan (scan-equation %))
                                         operation-descriptions)
@@ -680,11 +763,12 @@
                                   (update :equation-descriptions conj description)
                                   (assoc-in [:scalar-dtypes (:sym description)] result-dtype)))
                             state)
-                          (:map :reduce :scan)
+                          (:map :scatter :reduce :scan)
                           (-> state
                               (update :equations conj
                                       (case (:kind description)
                                         :map (map-equation description)
+                                        :scatter (scatter-equation description)
                                         :reduce (reduce-equation description)
                                         :scan (scan-equation description)))
                               (update :equation-descriptions conj description))))

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -102,6 +102,36 @@
                  (every? (comp empty? :locals) groups))
         {:locals [] :stores (vec (mapcat :stores groups))}))
 
+    (and (seq? body)
+         (contains? #{'if 'clojure.core/if} (first body))
+         (<= 3 (count body) 4))
+    (let [[_ predicate then-expression else-expression] body
+          then-region (pointwise-region then-expression index)
+          else-region (when else-expression (pointwise-region else-expression index))]
+      (when (and then-region
+                 (empty? (:locals then-region))
+                 (or (nil? else-expression)
+                     (and else-region (empty? (:locals else-region))))
+                 (or (nil? else-region)
+                     (= (mapv :out (:stores then-region))
+                        (mapv :out (:stores else-region)))))
+        {:locals []
+         :stores
+         (mapv (fn [ordinal then-store]
+                 (let [else-store (when else-region (nth (:stores else-region) ordinal))]
+                   (update then-store :value
+                           (fn [then-value]
+                             (list 'if predicate then-value
+                                   (if else-store
+                                     (:value else-store)
+                                     ;; A guarded pointwise write semantically preserves the
+                                     ;; caller-owned destination when its predicate is false.
+                                     ;; Making that read explicit turns gather-with-bounds-guard
+                                     ;; into an ordinary inout map; no hidden effect reaches the
+                                     ;; scheduler or emitter.
+                                     (list 'clojure.core/aget (:out then-store) index)))))))
+               (range) (:stores then-region))}))
+
     (descriptor/aset-call? body)
     (let [arguments (vec (descriptor/call-args body))]
       (when (and (= 3 (count arguments))
@@ -248,6 +278,58 @@
       (and (descriptor/alength-op? (descriptor/semantic-op expression))
            (= 1 (count (descriptor/call-args expression)))
            (symbol? (first (descriptor/call-args expression))))))
+
+(defn- parallel-extent
+  [expression]
+  (cond
+    (par/par-map-pure-form? expression) (nth expression 2)
+    (par/par-map-form? expression) (nth expression 3)
+    (par/par-map2-form? expression) (nth expression 4)
+    (par/par-reduce-form? expression) (nth expression 4)
+    (or (par/par-scan-form? expression) (par/par-scan-exclusive-form? expression))
+    (nth expression 5)
+    (par/par-map-void-form? expression) (nth expression 2)
+    :else nil))
+
+(defn- replace-parallel-extent
+  [expression extent]
+  (let [position (cond
+                   (par/par-map-pure-form? expression) 2
+                   (par/par-map-form? expression) 3
+                   (par/par-map2-form? expression) 4
+                   (par/par-reduce-form? expression) 4
+                   (or (par/par-scan-form? expression)
+                       (par/par-scan-exclusive-form? expression)) 5
+                   (par/par-map-void-form? expression) 2)]
+    (when position
+      (with-meta (apply list (assoc (vec expression) position extent)) (meta expression)))))
+
+(defn normalize-source
+  "Give pure compound parallel extents stable scalar SSA identities before dialect construction.
+
+   TypedSOAC operations name extents; executable host expressions never leak into schedule fields.
+   This normalization inserts an ordinary typed scalar binding immediately before its operation,
+   so the same expression remains visible to JVM materialization and runtime specialization."
+  [source]
+  (if (and (seq? source) (contains? #{'let 'let*} (first source)))
+    (let [[head bindings & body] source
+          pairs (vec (partition 2 bindings))
+          normalized
+          (mapcat
+           (fn [ordinal [symbol expression]]
+             (let [extent (parallel-extent expression)]
+               (if (and extent
+                        (not (dialect/extent? extent))
+                        (provably-pure-scalar? extent))
+                 (let [extent-id (with-meta
+                                   (clojure.core/symbol (str "rstr_extent_" ordinal))
+                                   {:tag 'long :raster.type/tag 'long})]
+                   [[extent-id extent]
+                    [symbol (replace-parallel-extent expression extent-id)]])
+                 [[symbol expression]])))
+           (range) pairs)]
+      (with-meta (list* head (vec (mapcat identity normalized)) body) (meta source)))
+    source))
 
 (defn- alength-array
   [expression]
@@ -498,8 +580,13 @@
       (when (symbol? id) (get array-types (symbol (name id))))
       default-dtype :double))
 
+(defn- declared-type
+  [types id]
+  (or (get types id)
+      (when (symbol? id) (get types (clojure.core/symbol (name id))))))
+
 (defn- equation-values
-  [equation default-dtype array-types known-values]
+  [equation default-dtype array-types scalar-types known-values]
   (let [[_ _ results] equation
         {:keys [kind attributes arrays captures]} (dialect/operation-parts equation)
         extent (:extent attributes)
@@ -516,6 +603,8 @@
      (if (= 'scalar kind)
        (into {} (keep (fn [id]
                         (when-let [value (or (get known-values id)
+                                             (when-let [declared (declared-type scalar-types id)]
+                                               (tensor-value declared []))
                                              (when-let [declared (and (symbol? id)
                                                                       (dtype/dtype-for-scalar-tag
                                                                        (types/sym-type-tag id)))]
@@ -529,7 +618,9 @@
                                             (contains? array-types (symbol (name id)))))
                                  (tensor-value (value-dtype id default-dtype array-types)
                                                [(list 'unknown-dimension id)])
-                                 (tensor-value (value-dtype id default-dtype array-types) [])))])
+                                 (tensor-value (or (declared-type scalar-types id)
+                                                   (value-dtype id default-dtype array-types))
+                                               [])))])
                      captures)))
      (into {} (map (fn [id result-dtype]
                      [id (tensor-value (or result-dtype default-dtype :double)
@@ -632,6 +723,7 @@
               inferred-values (reduce (fn [contracts equation]
                                         (reduce-kv merge-value contracts
                                                    (equation-values equation dtype array-types'
+                                                                    scalar-types
                                                                     contracts)))
                                       destination-values equations)
               values (reduce-kv merge-value inferred-values values)

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -41,6 +41,21 @@
                                 :local-definitions local-definitions
                                 :body-results body-results}))))
 
+(def ^:private scatter-equation-rule
+  (from-dialect dialect/TypedSOAC
+                (rule '(= ?equation-id [??results]
+                          (scatter ?attributes [??arrays] [??captures]
+                                   (lambda [??parameters]
+                                           (region [??local-definitions] [??body-results]))))
+                      (success {:kind :scatter
+                                :id equation-id
+                                :results results
+                                :attributes attributes
+                                :arrays arrays
+                                :captures captures
+                                :local-definitions local-definitions
+                                :body-results body-results}))))
+
 (def ^:private scalar-equation-rule
   (from-dialect dialect/TypedSOAC
                 (rule '(= ?equation-id [??results]
@@ -78,6 +93,7 @@
              (some #(when (map? %) %)
                    [(scalar-equation-rule equation)
                     (map-equation-rule equation)
+                    (scatter-equation-rule equation)
                     (reduce-equation-rule equation)
                     (scan-equation-rule equation)])]
     (let [lambda (:lambda (dialect/operation-parts equation))]

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -300,10 +300,11 @@
   ([form dtype array-types {:keys [resident-reductions? scalar-types values]
                             :or {resident-reductions? false}}]
    (when (and (seq? form) (contains? #{'let 'let*} (first form)))
-     (try
-       (when-let [typed-input (frontend/form->program
-                               form {:dtype dtype :array-types array-types
-                                     :scalar-types scalar-types :values values})]
+     (let [form (frontend/normalize-source form)]
+       (try
+        (when-let [typed-input (frontend/form->program
+                                form {:dtype dtype :array-types array-types
+                                      :scalar-types scalar-types :values values})]
          (let [[typed-result typed-stats] (fusion/fusion-fixpoint typed-input)
                [typed-result resident-stats]
                (if resident-reductions?
@@ -319,9 +320,9 @@
                 :stats (merge typed-stats resident-stats
                               {:route :typed-soac :typed-validated true
                                :front-end :analyzed-source})}))))
-       (catch clojure.lang.ExceptionInfo exception
-         (when (contains? #{:raster/fatal :raster/bug} (:reason (ex-data exception)))
-           (throw exception))
-         {:declined {:reason (or (:reason (ex-data exception)) :typed-soac-route-declined)
-                     :message (.getMessage exception)
-                     :details (ex-data exception)}})))))
+        (catch clojure.lang.ExceptionInfo exception
+          (when (contains? #{:raster/fatal :raster/bug} (:reason (ex-data exception)))
+            (throw exception))
+          {:declined {:reason (or (:reason (ex-data exception)) :typed-soac-route-declined)
+                      :message (.getMessage exception)
+                      :details (ex-data exception)}}))))))

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -167,6 +167,38 @@
            :site [:binding (if storage host-binding effect)]
            :source source}))
 
+      scatter
+      (let [storage (dialect/result-storage (dialect/facts program) equation-id)
+            physical-results (dialect/physical-results (dialect/facts program) equation)
+            host-binding (or (get-in placement-facts [:attributes :host-binding])
+                             (first results))
+            result-dtypes (mapv #(:dtype (get values %)) results)
+            casts (mapv #(nth (get dtype->allocation %) 2 nil) result-dtypes)
+            writes (mapv dialect/write-parts bodies)
+            _ (when-not (and (= (count results) (count writes) (count physical-results))
+                             (every? some? writes)
+                             (every? some? casts)
+                             (= #{:effect} (set (map :host-return storage))))
+                (throw (ex-info "the production scatter route requires typed effect writes"
+                                {:reason :typed-soac-production-subset
+                                 :equation equation-id :results results
+                                 :storage storage :writes writes :dtypes result-dtypes})))
+            statements
+            (mapv (fn [destination cast {:keys [destination-index predicate value]}]
+                    (let [store (list 'clojure.core/aset destination destination-index
+                                      (list cast value))]
+                      (if (contains? #{true 1} predicate) store (list 'if predicate store))))
+                  physical-results casts writes)
+            source (with-meta
+                     (list 'raster.par/map-void! (:index attributes) (:extent attributes)
+                           (materialize-region region-locals (list* 'do statements)))
+                     {:raster.type/elem-type (first result-dtypes)})]
+        {:equation-id equation-id
+         :placement placement
+         :pairs [[host-binding source]]
+         :site [:binding host-binding]
+         :source source})
+
       reduce
       (let [result (first results)
             accumulator (first (:accumulators attributes))
@@ -310,7 +342,7 @@
                (if resident-reductions?
                  (resident/realize typed-result)
                  [typed-result {:resident-reductions 0 :inlined-scalars 0}])]
-           (if (not-any? #(contains? #{:map :reduce :scan}
+           (if (not-any? #(contains? #{:map :scatter :reduce :scan}
                                      (:kind (fusion/equation-info %)))
                          (dialect/equations typed-result))
              {:declined {:reason :no-certified-parallel-equation

--- a/src/raster/dl/array_ops.clj
+++ b/src/raster/dl/array_ops.clj
@@ -221,9 +221,10 @@
                       (let [block (quot i block-width)
                             element (rem i block-width)
                             source-block (aget indices block)]
-                        (when (and (>= source-block 0) (< source-block indexed-blocks))
-                          (aset out i
-                                (aget src (+ (* source-block block-width) element))))))))
+                        (when (>= source-block 0)
+                          (when (< source-block indexed-blocks)
+                            (aset out i
+                                  (aget src (+ (* source-block block-width) element)))))))))
 
 (deftm scatter-blocks!
   "Copy dense `src[nblocks,block-width]` blocks to indexed locations in
@@ -236,10 +237,11 @@
                       (let [source-block (quot i block-width)
                             element (rem i block-width)
                             destination-block (aget indices source-block)]
-                        (when (and (>= destination-block 0)
-                                   (< destination-block indexed-blocks))
-                          (aset out (+ (* destination-block block-width) element)
-                                (aget src i)))))))
+                        (when (>= destination-block 0)
+                          (when (< destination-block indexed-blocks)
+                            (aset out (par/unique-index
+                                       (+ (* destination-block block-width) element))
+                                  (aget src i))))))))
 
 ;; Float16 is a physical storage type without a JVM primitive scalar. Its arrays are short[] on
 ;; the host, so give the bit-preserving layout transforms an explicit storage overload rather than
@@ -251,9 +253,10 @@
                  (let [block (quot i block-width)
                        element (rem i block-width)
                        source-block (aget indices block)]
-                   (when (and (>= source-block 0) (< source-block indexed-blocks))
-                     (aset out i
-                           (aget src (+ (* source-block block-width) element)))))))
+                   (when (>= source-block 0)
+                     (when (< source-block indexed-blocks)
+                       (aset out i
+                             (aget src (+ (* source-block block-width) element))))))))
 
 (deftm scatter-blocks!
   [src :- (Array short), indices :- (Array int), out :- (Array short),
@@ -262,10 +265,11 @@
                  (let [source-block (quot i block-width)
                        element (rem i block-width)
                        destination-block (aget indices source-block)]
-                   (when (and (>= destination-block 0)
-                              (< destination-block indexed-blocks))
-                     (aset out (+ (* destination-block block-width) element)
-                           (aget src i))))))
+                   (when (>= destination-block 0)
+                     (when (< destination-block indexed-blocks)
+                       (aset out (par/unique-index
+                                  (+ (* destination-block block-width) element))
+                             (aget src i)))))))
 
 (deftm gather-rows!
   "Compatibility spelling for dense row gathering. New layout code should use `gather-blocks!`,

--- a/src/raster/par.clj
+++ b/src/raster/par.clj
@@ -442,6 +442,14 @@
          ~body-expr)
        nil)))
 
+(deftm ^:no-inline unique-index
+  "Assert that an indexed-write destination is unique over its enclosing parallel iteration.
+
+   Runtime semantics are identity. The typed compiler consumes this marker as a conflict contract;
+   callers must establish uniqueness before dispatch (for example with validate-block-indices!)."
+  [index :- Long] :- Long
+  index)
+
 (defmacro collect!
   "Atomically claim a slot in count-arr and write values to SoA arrays.
   Useful for building output queues in parallel kernels.

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -78,6 +78,34 @@
            (first (:body-results
                    (dialect/lambda-parts (:lambda (dialect/operation-parts equation)))))))))
 
+(deftest unique-indexed-write-is-a-typed-scatter
+  (let [scatter '(raster.par/map-void!
+                  i n
+                  (clojure.core/aset out
+                                     (raster.par/unique-index
+                                      (clojure.core/aget indices i))
+                                     (clojure.core/aget src i)))
+        source (list 'let* ['step scatter] 'step)
+        program (frontend/form->program
+                 source {:dtype :float
+                         :array-types {'indices :int 'src :float 'out :float}
+                         :scalar-types {'n :long}})
+        equation (first (dialect/equations program))
+        operation (dialect/operation-parts equation)
+        write (dialect/write-parts
+               (first (:body-results (dialect/lambda-parts (:lambda operation)))))]
+    (is (= 'scatter (:kind operation)))
+    (is (= :unique (get-in operation [:attributes :conflict])))
+    (is (= '[indices src out] (dialect/operation-inputs equation)))
+    (is (= {:destination-index '%element0 :predicate 1 :value '%element1} write))
+    (is (= [{:destination 'out :access :read-write :host-return :effect}]
+           (get-in (dialect/facts program) [:equations 0 :attributes :result-storage])))
+    (is (= :analyzed-source
+           (get-in (route/attempt source :float
+                                  {'indices :int 'src :float 'out :float}
+                                  {:scalar-types {'n :long}})
+                   [:stats :front-end])))))
+
 (deftest parallel-semantics-enter-only-their-exact-typed-operation
   (testing "a certified inclusive scan is represented directly, with destination facts"
     (let [program (frontend/form->program
@@ -210,7 +238,7 @@
                   (keys (:values (dialect/facts program))))
         "region-local SSA values are lexical, not fake program inputs")))
 
-(deftest ordered-or-nonpointwise-void-bodies-decline-the-functional-tuple-map
+(deftest ordered-void-bodies-decline-the-functional-tuple-map
   (doseq [[label body]
           [["one destination written twice"
             '(do (clojure.core/aset a i (float 1.0))
@@ -231,7 +259,7 @@
                     v (* u 2.0)]
                    (clojure.core/aset a i (float v))
                    (clojure.core/aset b i (float u)))]
-           ["scatter index"
+           ["an indexed write without an explicit conflict contract"
             '(clojure.core/aset a (clojure.core/aget indices i)
                                 (float (clojure.core/aget x i)))]]]
     (testing label

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -36,6 +36,48 @@
     (is (= :analyzed-source
            (get-in (route/attempt source :float {'x :float}) [:stats :front-end])))))
 
+(deftest compound-parallel-extents-become-typed-scalar-ssa
+  (let [source '(let* [step (raster.par/map! target i
+                                              (clojure.core/* nrows width)
+                                              float (clojure.core/aget x i))]
+                        step)
+        normalized (frontend/normalize-source source)
+        program (frontend/form->program
+                 normalized
+                 {:dtype :float
+                  :array-types {'x :float 'target :float}
+                  :scalar-types {'nrows :long 'width :long}})
+        equations (dialect/equations program)]
+    (is (= '[rstr_extent_0 step] (mapv (comp first #(nth % 2)) equations)))
+    (is (= ['scalar 'map] (mapv dialect/operation-kind equations)))
+    (is (= 'rstr_extent_0 (dialect/operation-extent (second equations))))
+    (is (= :long (:dtype (get-in (dialect/facts program) [:values 'rstr_extent_0]))))
+    (is (= :analyzed-source
+           (get-in (route/attempt source :float {'x :float 'target :float}
+                                  {:scalar-types {'nrows :long 'width :long}})
+                   [:stats :front-end])))))
+
+(deftest guarded-dense-write-is-an-explicit-inout-map
+  (let [program
+        (frontend/form->program
+         '(let* [step (raster.par/map-void! i n
+                                             (if (< i limit)
+                                               (clojure.core/aset
+                                                out i (clojure.core/aget src i))))]
+                step)
+         {:dtype :float
+          :array-types {'src :float 'out :float}
+          :scalar-types {'n :long 'limit :long}})
+        equation (first (dialect/equations program))
+        facts (dialect/facts program)]
+    (is (= 'map (dialect/operation-kind equation)))
+    (is (= '[out src limit] (dialect/operation-inputs equation)))
+    (is (= [{:destination 'out :access :read-write :host-return :effect}]
+           (get-in facts [:equations 0 :attributes :result-storage])))
+    (is (= '(if (< i %capture0) %element1 %element0)
+           (first (:body-results
+                   (dialect/lambda-parts (:lambda (dialect/operation-parts equation)))))))))
+
 (deftest parallel-semantics-enter-only-their-exact-typed-operation
   (testing "a certified inclusive scan is represented directly, with destination facts"
     (let [program (frontend/form->program

--- a/test/raster/dl/row_gather_test.clj
+++ b/test/raster/dl/row_gather_test.clj
@@ -98,9 +98,18 @@
                                  [target (pipeline/compile-gpu-program
                                           #'block-transfer-roundtrip! target :dtype :float)]))
                           [:ocl:0 :ze:0])
-        descriptor (get descriptors :ocl:0)]
+        descriptor (get descriptors :ocl:0)
+        gather-descriptor (pipeline/compile-gpu-program
+                           #'ops/gather-blocks! :ocl:0 :dtype :float)]
     (testing "both directions are ordinary allocation-free SOAC maps"
       (is (= [:map-void :map-void] (mapv :convention (:steps descriptor))))
+      (is (= [:map-void :map-void]
+             (mapv #(get-in % [:artifact :provenance :dialect]) (:steps descriptor)))
+          "the closed-program route declines while its dynamic scatter remains unsupported")
+      (is (= [:segmap]
+             (mapv #(get-in % [:artifact :provenance :dialect])
+                   (:steps gather-descriptor)))
+          "bounded block gather independently enters TypedSOAC as an inout map")
       (is (empty? (:allocs descriptor)))
       (is (= '[src block-indices paged restored nblocks block-width paged-blocks]
              (:all-params descriptor)))
@@ -135,10 +144,14 @@
       (is (empty? (:allocs descriptor))))
     (testing "every output element lowers through one target-neutral map"
       (is (= [:map-void] (mapv :convention (:steps descriptor))))
-      (is (= '[indices out src width _n_bound] (mapv :name (:abi step))))
+      (is (= :segmap (get-in step [:artifact :provenance :dialect])))
+      (is (= '[indices src out width _n_bound] (mapv :name (:abi step))))
       (is (= [:int :float :float :int :int] (mapv :dtype (:abi step))))
-      (is (= '(clojure.core/* (long nrows) (long width))
-             (last (get-in step [:artifact :arguments])))))
+      (is (= 'rstr_extent_0 (last (get-in step [:artifact :arguments])))
+          "the schedule names the typed scalar extent instead of embedding host code")
+      (is (= 15 ((:value-fn (last (:argument-specs step)))
+                 [nil nil nil 3 5]))
+          "the resident binder evaluates the scalar SSA definition from external arguments"))
     (testing "OpenCL and Level Zero preserve the same physical ABI"
       (is (apply = (map (comp #(mapv (juxt :kind :dtype :kernel-dtype) %)
                               :abi first :steps val)

--- a/test/raster/dl/row_gather_test.clj
+++ b/test/raster/dl/row_gather_test.clj
@@ -103,9 +103,13 @@
                            #'ops/gather-blocks! :ocl:0 :dtype :float)]
     (testing "both directions are ordinary allocation-free SOAC maps"
       (is (= [:map-void :map-void] (mapv :convention (:steps descriptor))))
-      (is (= [:map-void :map-void]
+      (is (= [:segmap :segmap]
              (mapv #(get-in % [:artifact :provenance :dialect]) (:steps descriptor)))
-          "the closed-program route declines while its dynamic scatter remains unsupported")
+          "scatter and gather share the typed scheduled-map vertical")
+      (is (= [true nil]
+             (mapv #(get-in % [:artifact :attributes :explicit-stores])
+                   (:steps descriptor)))
+          "scatter owns explicit indexed stores; gather retains the implicit dense result")
       (is (= [:segmap]
              (mapv #(get-in % [:artifact :provenance :dialect])
                    (:steps gather-descriptor)))
@@ -114,8 +118,10 @@
       (is (= '[src block-indices paged restored nblocks block-width paged-blocks]
              (:all-params descriptor)))
       (is (= #{'paged 'restored}
-             (set (mapcat #(get-in % [:artifact :attributes :written-arrays])
-                          (:steps descriptor))))))
+             (set (for [step (:steps descriptor)
+                        slot (:abi step)
+                        :when (contains? #{:output :inout} (:kind slot))]
+                    (:name slot))))))
     (testing "OpenCL and Level Zero preserve the same physical ABI"
       (is (apply = (map (fn [[_ compiled]]
                           (mapv (comp #(mapv (juxt :kind :dtype :kernel-dtype) %) :abi)


### PR DESCRIPTION
## Outcome

Routes both directions of allocation-free resident block transfer through the direct typed compiler vertical.

- hoists pure compound launch extents into typed scalar SSA
- represents guarded gather as a dense TypedSOAC map with stable indexed reads
- adds a TypedSOAC scatter operation for explicitly unique indexed writes
- consumes the typed par/unique-index legality marker before scalar lowering
- lowers scatter to an explicit-store SegMap with an ordered inout ABI
- keeps uncontracted dynamic writes on the declining compatibility boundary
- updates the compiler north-star status

The routing buffer and transfer dtype remain orthogonal: the same operation covers FP32/FP64/FP16-bit storage and does not encode paging, attention, cache policy, or quantization.

## Verification

- cold focused suite: 16 tests, 103 assertions, 0 failures/errors
- checks source/signature and ordered ABI construction for OpenCL and Level Zero artifacts
- exercises CPU block-transfer validation and semantics

A full local suite was not launched because the host had only about 1.6 GiB available with swap full; CI is the PR-boundary full gate to avoid another host OOM.