### PR TITLE
Make ProductReduction canonical for contractions

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -314,6 +314,14 @@ contains only values, output indices, row count and width; ties select the lowes
 NaN outranks numeric values so corruption is visible and deterministic. Subgroup/shuffle and
 multi-workgroup alternatives remain schedule candidates, not new semantic primitives.
 
+Tensor contraction uses that same semantic operator rather than reconstructing `init`, `combine`
+and a fold body in `contract-lower`. The single contraction-facts derivation now owns its canonical
+one-component `ProductReduction`, normalized reduced coordinate and flattened semantic body;
+`SegContract`, generic `SegRed` fallback and peak routing consume those facts unchanged. Free axes,
+operand axis maps, decode/storage precision, epilogues and staged accumulator structure remain
+orthogonal contraction facts and schedule choices. This is the semantic bridge toward representing
+contraction as an ordinary segmented TypedSOAC reduction, not a new hard-coded GEMM algebra.
+
 Indexed storage movement remains a separate generic operation. Allocation-free `gather-blocks!`
 and `scatter-blocks!` move contiguous typed blocks between dense staging and routed resident
 storage through the direct TypedSOAC→SegMap vertical: gather is a stable indexed read in a dense

--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -314,6 +314,14 @@ contains only values, output indices, row count and width; ties select the lowes
 NaN outranks numeric values so corruption is visible and deterministic. Subgroup/shuffle and
 multi-workgroup alternatives remain schedule candidates, not new semantic primitives.
 
+TypedSOAC now also names the general `segmented-reduce` algebra directly: ordered parallel segment
+axes, one innermost reduction axis, typed accumulator products, dense element operands and stable
+arbitrarily indexed tensor captures. Its extents participate in the typed program boundary and
+alpha-remapping, and it lowers mechanically to canonical `SegRed` without constructing the former
+`SoacContract` record. Moving analyzed `raster.par/contract` source onto this equation is the next
+front-end slice; the operation is intentionally not a matmul node, so scientific contractions,
+batched reductions and attention-derived reductions share the same semantic vocabulary.
+
 Tensor contraction uses that same semantic operator rather than reconstructing `init`, `combine`
 and a fold body in `contract-lower`. The single contraction-facts derivation now owns its canonical
 one-component `ProductReduction`, normalized reduced coordinate and flattened semantic body;

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -1052,6 +1052,45 @@
 ;; Segmented reduction (contraction) → OpenCL — the multi-axis SegSpace path
 ;; ================================================================
 
+(defn generate-contraction-kernel-body
+  "Emit one scheduled portable contraction KernelBody through the shared C-family boundary."
+  [kernel-body & {:keys [kernel-name-prefix target-dialect]
+                  :or {kernel-name-prefix "contract" target-dialect :opencl-intel}}]
+  (let [kernel-body (kbody/validate! kernel-body)
+        parameters (:parameters kernel-body)
+        inputs (vec (map :id (filter #(= :input (:kind %)) parameters)))
+        output-parameter (first (filter #(= :output (:kind %)) parameters))
+        output (:id output-parameter)
+        scalar-parameters (vec (filter #(= :scalar (:kind %)) parameters))
+        scalars (vec (map :id (remove #(= '_nseg (:id %)) scalar-parameters)))
+        kernel-name (str kernel-name-prefix "_" (gensym ""))
+        parameter-names (into {output "out" '_nseg "_nseg"}
+                              (map (fn [parameter]
+                                     [(:id parameter) (ce/c-symbol (:id parameter))]))
+                              parameters)
+        source (kernel-body-opencl/emit-scalar-kernel
+                kernel-name kernel-body
+                {:target-dialect target-dialect :parameter-names parameter-names})
+        abi (kabi/validate!
+             (mapv (fn [parameter]
+                     (let [{:keys [id kind dtype role]} parameter]
+                       (kabi/slot
+                        id kind dtype
+                        :c-name (get parameter-names id)
+                        :role (if (= id '_nseg) :bound role)
+                        :aliasing (when (= kind :input) :no-write-alias))))
+                   parameters))]
+    {:kernel-name kernel-name
+     :target (kernel-body-c-dialect/target
+              (kernel-body-c-dialect/resolve! target-dialect))
+     :source source
+     :abi abi
+     :array-params inputs
+     :scalar-params scalars
+     :output output
+     :kernel-body kernel-body
+     :launch (:launch kernel-body)}))
+
 (defn generate-segmented-reduce-kernel
   "NAIVE segmented reduction (a contraction) → OpenCL. One work-item per SEGMENT (free-axis
    tuple); each sequentially folds over the reduced (innermost) axis. segment-dims = the

--- a/src/raster/compiler/ir/contraction_facts.clj
+++ b/src/raster/compiler/ir/contraction_facts.clj
@@ -224,6 +224,35 @@
           rest-perm (permutations (concat (take i xs) (drop (inc i) xs)))]
       (into [(nth xs i)] rest-perm))))
 
+(defn- subsets
+  [values]
+  (if-let [value (first values)]
+    (let [tail (subsets (next values))]
+      (concat tail (map #(cons value %) tail)))
+    (list '())))
+
+(defn operand-axis-map
+  "Return a verified physical AxisMap for one contraction operand.
+
+   Explicit maps were verified while facts were constructed. For ordinary dense operands, infer
+   only a plain permutation/broadcast map whose generated flat index is provably equal to the
+   actual load index. Non-affine gathers and ambiguous layouts return nil and therefore cannot
+   enter a schedule that needs a physical buffer shape."
+  [facts operand]
+  (when-not (facts? facts)
+    (throw (ex-info "operand map inference requires verified contraction facts"
+                    {:reason :raster/bug :facts facts})))
+  (let [operand (if (symbol? operand)
+                  (some #(when (= operand (:sym %)) %) (:operands facts))
+                  operand)]
+    (when operand
+      (or (:map operand)
+          (let [axes (vec (concat (:free-axes facts) (:contract-axes facts)))
+                candidates (for [selection (rest (sort-by count (subsets axes)))
+                                 ordering (permutations selection)]
+                             (am/of-axes ordering))]
+            (first (filter #(am/index-matches? % (:idx operand)) candidates)))))))
+
 ;; ── leaf layout requirements as DATA ────────────────────────────────────────────────
 (def leaf-layouts
   "Each tensorize leaf's required operand layout, as ROLE → the axis roles that index it,

--- a/src/raster/compiler/ir/contraction_facts.clj
+++ b/src/raster/compiler/ir/contraction_facts.clj
@@ -21,8 +21,11 @@
    actual index. A declaration that fails verification does not fall back to derivation; it makes
    the whole extraction fail. Trusting a declared layout while having checked only its axis
    symbols is how a transpose rewrite risked a silent miscompile."
-  (:require [raster.compiler.ir.axis-map :as am]
-            [raster.compiler.core.op-descriptor :as od]))
+  (:require [clojure.walk :as walk]
+            [raster.compiler.core.op-descriptor :as od]
+            [raster.compiler.ir.axis-map :as am]
+            [raster.compiler.ir.contract-stages :as contract-stages]
+            [raster.compiler.ir.reduction :as reduction]))
 
 (def ^:private facts-tag ::facts)
 
@@ -41,6 +44,60 @@
       (throw (ex-info "contract form: trailing options must be key/value pairs"
                       {:reason :malformed-opts :opts (vec tail)})))
     (apply hash-map tail)))
+
+(defn flatten-contract-axes
+  "Normalize one or more contraction axes to the single reduced coordinate consumed by SegRed.
+   Returns `[index extent body]`, with original axis references replaced by row-major coordinate
+   decomposition. This is part of semantic fact construction, not an emitter-specific rewrite."
+  [contract-axes body]
+  (if (= 1 (count contract-axes))
+    (let [[[index extent]] contract-axes]
+      [index extent body])
+    (let [flat-index (gensym "contract_index__")
+          extents (mapv second contract-axes)
+          multiply (fn [values]
+                     (if (every? number? values)
+                       (reduce * values)
+                       (reduce (fn [left right]
+                                 (list 'clojure.core/* left right))
+                               values)))
+          flat-extent (multiply extents)
+          suffix (fn [position]
+                   (let [remaining (subvec extents (inc position))]
+                     (if (empty? remaining) 1 (multiply remaining))))
+          substitutions
+          (into {}
+                (map-indexed
+                 (fn [position [index _]]
+                   [index (list 'clojure.core/rem
+                                (list 'clojure.core/quot flat-index (suffix position))
+                                (nth extents position))])
+                 contract-axes))]
+      [flat-index flat-extent (walk/postwalk-replace substitutions body)])))
+
+(defn- canonical-reduction-facts
+  [out contract-axes body opts dtype]
+  (when (seq contract-axes)
+    (let [stages (:stages opts)
+          semantic-body (if (seq stages)
+                          (contract-stages/flat-equivalent stages body)
+                          body)
+          [index extent flat-body] (flatten-contract-axes contract-axes semantic-body)
+          accumulator (gensym "contract_acc__")
+          operator
+          (reduction/scalar
+           {:accumulator accumulator
+            :neutral (get opts :init 0.0)
+            :dtype (or (:acc-dtype opts) dtype)
+            :result out
+            :index index
+            :step-result (list (get opts :combine '+) accumulator flat-body)
+            :algebra (or (:algebra opts) {})
+            :attributes {:source :raster.par/contract
+                         :contract-axes (mapv vec contract-axes)
+                         :stages stages}})]
+      {:reduction operator
+       :flat-contract-axis [index extent]})))
 
 (defn- aget-terms
   "Every array read the expression makes, as {:sym :idx}, in encounter order.
@@ -93,25 +150,47 @@
         roles (merge (into {} (map-indexed (fn [n [a _]] [(keyword (str "free" n)) a])) free-axes)
                      (into {} (map-indexed (fn [n [a _]] [(keyword (str "contract" n)) a])) contract-axes))
         dims (merge (into {} (map-indexed (fn [n [_ e]] [(keyword (str "free" n)) e])) free-axes)
-                    (into {} (map-indexed (fn [n [_ e]] [(keyword (str "contract" n)) e])) contract-axes))]
-    {facts-tag true
-     :form form
-     :out out
-     :free-axes (mapv vec free-axes)
-     :contract-axes (mapv vec contract-axes)
-     :n-free (count free-axes)
-     :n-contract (count contract-axes)
-     :body body
-     :operands terms
-     :combine (get opts :combine '+)
-     :init (get opts :init 0.0)
-     :dtype dtype
-     :out-dtype (get opts :out-dtype)
-     :stages (:stages opts)
-     :epilogue (:epilogue opts)
-     :roles roles
-     :dims dims
-     :opts opts}))
+                    (into {} (map-indexed (fn [n [_ e]] [(keyword (str "contract" n)) e])) contract-axes))
+        normalized (canonical-reduction-facts out contract-axes body opts dtype)]
+    (merge
+     {facts-tag true
+      :form form
+      :out out
+      :free-axes (mapv vec free-axes)
+      :contract-axes (mapv vec contract-axes)
+      :n-free (count free-axes)
+      :n-contract (count contract-axes)
+      :body body
+      :operands terms
+      ;; Compatibility projections. New semantic and schedule passes consume :reduction; leaf
+      ;; gates still read these until the contraction KernelBody vertical is complete.
+      :combine (get opts :combine '+)
+      :init (get opts :init 0.0)
+      :dtype dtype
+      :out-dtype (get opts :out-dtype)
+      :stages (:stages opts)
+      :epilogue (:epilogue opts)
+      :roles roles
+      :dims dims
+      :opts opts}
+     normalized)))
+
+(defn scalar-reduction-view
+  "Project the canonical one-component ProductReduction into the contraction facts needed by
+   legality and schedule passes. This is a checked view, not a second stored representation."
+  [facts]
+  (when-not (facts? facts)
+    (throw (ex-info "contraction reduction view requires verified facts"
+                    {:reason :raster/bug :facts facts})))
+  (let [{:keys [acc init lambda]} (reduction/scalar-op (:reduction facts))]
+    (when-not (and (seq? lambda) (= 3 (count lambda)) (= acc (second lambda)))
+      (throw (ex-info "canonical contraction reduction is not an accumulator/element fold"
+                      {:reason :raster/bug :accumulator acc :lambda lambda})))
+    {:accumulator acc
+     :neutral init
+     :combine (first lambda)
+     :element (nth lambda 2)
+     :dtype (first (reduction/dtypes (:reduction facts)))}))
 
 ;; ── body shape: what a leaf that DISCARDS the body must first account for ────────────
 (defn body-product-of

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -323,7 +323,12 @@
 
 (defn- shape! [owner shape]
   (when-not (and (vector? shape) (seq shape)
-                 (every? #(or (value-id? %) (and (integer? %) (pos? %))) shape))
+                 (every? #(or (value-id? %)
+                              (and (integer? %) (pos? %))
+                              (and (record-kind?
+                                    "raster.compiler.ir.kernel_body.IndexExpr" %)
+                                   (expression? %)))
+                         shape))
     (throw (ex-info (str owner " requires a non-empty shape of positive extents")
                     {:shape shape}))))
 

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -32,6 +32,14 @@
              (lambda [acc ... element ... capture-parameter ...]
                (region [(let-value local :dtype init-expr) ...]
                        [step-result ...]))))
+        (= equation-id [result ...]
+           (segmented-reduce {:segment-axes [[row rows] ...]
+                              :index k :extent width
+                              :accumulators [acc ...] :identities [zero ...]
+                              :dtypes [:float ...] :algebra [{} ...]}
+             [array ...] [capture ...]
+             (lambda [acc ... element ... capture-parameter ...]
+               (region [] [step-result ...]))))
         (= equation-id [result]
            (scan {:mode :inclusive :index i :extent n
                   :accumulators [acc] :identities [zero]
@@ -102,6 +110,11 @@
      (if (integer? extent) (inc extent) (list 'clojure.core/inc extent))
      (first (extent-shape extent)))])
 
+(defn segmented-reduce-result-shape
+  "Canonical tensor shape of a segmented reduction's ordered parallel axes."
+  [attributes]
+  (mapv (comp first extent-shape second) (:segment-axes attributes)))
+
 (defn map-attributes?
   [value]
   (and (map? value)
@@ -130,6 +143,20 @@
           (count (:algebra value)))
        (every? keyword? (:dtypes value))
        (every? map? (:algebra value))))
+
+(defn segmented-reduce-attributes?
+  "Attributes for a general segmented reduction. Segment axes are the ordered parallel result
+   space; `:index/:extent` remain the innermost reduced axis shared with ordinary reduce."
+  [value]
+  (let [axes (:segment-axes value)
+        indices (mapv first axes)]
+    (and (reduce-attributes? (dissoc value :segment-axes))
+         (vector? axes) (seq axes)
+         (every? #(and (vector? %) (= 2 (count %))
+                       (symbol? (first %)) (extent? (second %)))
+                 axes)
+         (= (count indices) (count (distinct indices)))
+         (not (contains? (set indices) (:index value))))))
 
 (defn scan-attributes?
   "Attributes for a certified scan dialect operation. The explicit mode is load-bearing because
@@ -179,6 +206,7 @@
              [ma map-attributes?]
              [xa scatter-attributes?]
              [ra reduce-attributes?]
+             [sra segmented-reduce-attributes?]
              [ca scan-attributes?]
              [dt keyword?]
              [facts program-facts?])
@@ -207,6 +235,7 @@
              (map ?ma [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
              (scatter ?xa [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
              (reduce ?ra [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
+             (segmented-reduce ?sra [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
              (scan ?ca [(?:* ?id:array)] [(?:* ?id:capture)] ?l))
 
   (Equation [q :enforce]
@@ -237,11 +266,22 @@
       (vec (nth operation 2))
       (vec (concat (nth operation 2) (nth operation 3))))))
 
+(declare operation-parts)
+
 (defn operation-extent
   [equation]
   (let [operation (nth equation 3)]
     (when-not (= 'scalar (first operation))
       (:extent (second operation)))))
+
+(defn operation-extents
+  "All ordered iteration extents referenced by an operation. For segmented reductions this is
+   the parallel segment space followed by the innermost reduction extent."
+  [equation]
+  (let [{:keys [kind attributes]} (operation-parts equation)]
+    (if (= 'segmented-reduce kind)
+      (conj (mapv second (:segment-axes attributes)) (:extent attributes))
+      (if-let [extent (:extent attributes)] [extent] []))))
 
 (defn operation-parts
   "Normalize one operation into semantic fields shared by validation and lowering."
@@ -327,7 +367,7 @@
   [equation]
   (let [{:keys [kind attributes arrays captures lambda]} (operation-parts equation)
         parameters (:parameters (lambda-parts lambda))
-        accumulator-count (if (contains? #{'reduce 'scan} kind)
+        accumulator-count (if (contains? #{'reduce 'segmented-reduce 'scan} kind)
                             (count (:accumulators attributes)) 0)
         array-count (count arrays)
         accumulator-end accumulator-count
@@ -379,7 +419,7 @@
         (fail! :typed-soac-region-binders
                "scalar-region parameters and local SSA definitions must be distinct"
                {:equation equation-id :parameters parameters :locals local-ids}))
-      (when (and (contains? #{'map 'scatter 'reduce 'scan} kind)
+      (when (and (contains? #{'map 'scatter 'reduce 'segmented-reduce 'scan} kind)
                  (some #{(:index attributes)} local-ids))
         (fail! :typed-soac-region-binders
                "a scalar-region local cannot shadow its operation index"
@@ -401,7 +441,7 @@
     (when-not (= result-count (count body-results))
       (fail! :typed-soac-result-arity "SOAC result and lambda arity differ"
              {:equation equation-id :results result-count :body-results (count body-results)}))
-    (let [expected-parameter-count (+ (if (contains? #{'reduce 'scan} kind)
+    (let [expected-parameter-count (+ (if (contains? #{'reduce 'segmented-reduce 'scan} kind)
                                         (count (:accumulators attributes))
                                         0)
                                       (count arrays)
@@ -415,8 +455,10 @@
                 :arrays arrays
                 :captures captures})))
     (let [initial-bound (cond-> (set parameters)
-                          (contains? #{'map 'scatter 'reduce 'scan} kind)
-                          (conj (:index attributes)))
+                          (contains? #{'map 'scatter 'reduce 'segmented-reduce 'scan} kind)
+                          (conj (:index attributes))
+                          (= 'segmented-reduce kind)
+                          (into (map first (:segment-axes attributes))))
           final-bound
           (reduce (fn [bound {:keys [id init] :as local}]
                     (let [unbound (util/free-syms init bound)]
@@ -463,6 +505,17 @@
         (when-not (= result-count (count accumulators))
           (fail! :typed-soac-reduce-results
                  "reduce result arity must equal accumulator arity"
+                 {:equation equation-id :results results :accumulators accumulators})))
+
+      segmented-reduce
+      (let [accumulators (:accumulators attributes)]
+        (when-not (= accumulators (vec (take (count accumulators) parameters)))
+          (fail! :typed-soac-segmented-reduce-accumulators
+                 "segmented-reduce accumulator parameters must lead the lambda in declared order"
+                 {:equation equation-id :accumulators accumulators :parameters parameters}))
+        (when-not (= result-count (count accumulators))
+          (fail! :typed-soac-segmented-reduce-results
+                 "segmented-reduce result arity must equal accumulator arity"
                  {:equation equation-id :results results :accumulators accumulators})))
 
       scan
@@ -548,6 +601,18 @@
             (fail! :typed-soac-reduce-result-type
                    "reduce results must be scalar tensors with their declared accumulator dtype"
                    {:equation equation-id :id id :value value :dtype dtype}))))
+
+      segmented-reduce
+      (let [result-shape (segmented-reduce-result-shape attributes)]
+        (doseq [[id dtype] (map vector results (:dtypes attributes))]
+          (let [value (get values id)]
+            (when (and value
+                       (not (and (= :tensor (:kind value)) (= result-shape (:shape value))
+                                 (= dtype (:dtype value)))))
+              (fail! :typed-soac-segmented-reduce-result-type
+                     "segmented-reduce results must match the declared segment space and dtype"
+                     {:equation equation-id :id id :value value
+                      :segment-axes (:segment-axes attributes) :dtype dtype})))))
 
       scan
       (doseq [[id dtype] (map vector results (:dtypes attributes))]
@@ -656,9 +721,8 @@
     (let [definitions (mapcat #(nth % 2) equations)
           definition-set (set definitions)
           references (set (mapcat (fn [equation]
-                                    (cond-> (operation-inputs equation)
-                                      (value-id? (operation-extent equation))
-                                      (conj (operation-extent equation))))
+                                    (into (operation-inputs equation)
+                                          (filter value-id? (operation-extents equation))))
                                   equations))
           external (set/difference references definition-set)
           total-effects (reduce set/union #{}
@@ -684,9 +748,8 @@
              [equation & remaining] equations]
         (when equation
           (let [equation-id (second equation)
-                required (cond-> (set (operation-inputs equation))
-                           (value-id? (operation-extent equation))
-                           (conj (operation-extent equation)))
+                required (into (set (operation-inputs equation))
+                               (filter value-id? (operation-extents equation)))
                 missing (set/difference required available)]
             (when (seq missing)
               (fail! :typed-soac-use-before-definition
@@ -746,6 +809,12 @@
                                                 [:attributes :stable-array-captures]))
                                    (update-in [:attributes :stable-array-captures]
                                               #(mapv rename %)))
+                      attributes (if (= 'segmented-reduce kind)
+                                   (update attributes :segment-axes
+                                           #(mapv (fn [[index extent]]
+                                                    [index (if (value-id? extent)
+                                                             (rename extent) extent)]) %))
+                                   attributes)
                       operation (if (= 'scalar kind)
                                   (list kind attributes (mapv rename captures) lambda)
                                   (list kind (update attributes :extent

--- a/src/raster/compiler/passes/parallel/contract_lower.clj
+++ b/src/raster/compiler/passes/parallel/contract_lower.clj
@@ -12,9 +12,8 @@
    `SoacReduce` fuses its map into the canonical reduction operator."
   (:require [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.par :as ir-par]
-            [raster.compiler.ir.reduction :as reduction]
-            [clojure.set :as set]
-            [clojure.walk :as walk]))
+            [raster.compiler.ir.contraction-facts :as contraction-facts]
+            [clojure.set :as set]))
 
 (defn flatten-contract-axes
   "Flatten n≥1 contract axes into ONE innermost reduced dim (the A0 convention, endorsed by
@@ -24,52 +23,36 @@
    the flat index: li = (kflat / prod(bounds after i)) mod bound_i. For a single contract axis
    this is the identity. The naive segmented emitter then loops the single k-sym unchanged."
   [contract-axes body]
-  (if (= 1 (count contract-axes))
-    (let [[[k-sym k-bound]] contract-axes] [k-sym k-bound body])
-    (let [flat-sym (gensym "kflat__")
-          bounds   (mapv second contract-axes)
-          k-bound  (if (every? number? bounds) (reduce * bounds)
-                       (reduce (fn [a b] (list 'clojure.core/* a b)) bounds))
-          suffix   (fn [p] (let [after (subvec bounds (inc p))]
-                             (cond (empty? after) 1
-                                   (every? number? after) (reduce * after)
-                                   :else (reduce (fn [a b] (list 'clojure.core/* a b)) after))))
-          subst    (into {} (map-indexed
-                             (fn [p [s _]]
-                               [s (list 'clojure.core/rem
-                                        (list 'clojure.core/quot flat-sym (suffix p))
-                                        (nth bounds p))])
-                             contract-axes))]
-      [flat-sym k-bound (walk/postwalk-replace subst body)])))
+  (contraction-facts/flatten-contract-axes contract-axes body))
 
 (defn contract-form->segred
   "Parse `(raster.par/contract out [[i mi] …] [[k mk]] body & opts)` → a segmented SegRed.
    opts: :init (combine init, default 0.0), :combine (default +). :id/:dtype/:grid via
-   kwargs. Prototype: exactly one contracted axis. Pure + device-free (grid stays the
-   passed value, default nil — the device-aware pass fills it)."
-  [form & {:keys [id dtype grid] :or {id 0 dtype :double grid nil}}]
-  (let [[_ out free-axes contract-axes body & opts] form
-        opts-map (apply hash-map opts)
-        init (get opts-map :init 0.0)
-        combine (get opts-map :combine '+)
+   kwargs. Supports one or more contracted axes. Pure + device-free (grid stays the passed value,
+   default nil — the device-aware pass fills it)."
+  [form & {:keys [id dtype grid facts] :or {id 0 dtype :double grid nil}}]
+  (let [[_ out free-axes contract-axes] form
+        facts (or facts (contraction-facts/contraction-facts form :dtype dtype))
+        _ (when-not (and (contraction-facts/facts? facts)
+                         (= form (:form facts))
+                         (= dtype (:dtype facts)))
+            (throw (ex-info "contract lowering requires facts derived from the same form"
+                            {:reason :contraction-facts-mismatch
+                             :form form :dtype dtype :facts facts})))
         ;; ZERO free axes is legal: the SegSpace then has only the reduced dim, i.e. exactly the
         ;; 1-D shape (segop/seg-space-1d?) that the full-reduction emitter consumes.
         _ (assert (vector? free-axes) "contract-lower: free-axes must be a vector")
         _ (assert (and (vector? contract-axes) (pos? (count contract-axes)))
                   "contract-lower: contract-form->segred needs ≥1 contract axis (0 → contract-form->segmap)")
         _ (assert (symbol? out) "contract-lower: out must be a symbol")
-        ;; n≥2 contract axes → flatten into one innermost reduced dim + substitute indices.
-        [k-sym k-bound body] (flatten-contract-axes contract-axes body)
+        ;; The canonical ProductReduction and flattened axis/body were derived together once.
+        [k-sym k-bound] (:flat-contract-axis facts)
+        body (:element (contraction-facts/scalar-reduction-view facts))
         free-dims (mapv (fn [[s b]] {:name s :bound b}) free-axes)
         red-dim   {:name k-sym :bound k-bound}
         ;; N-D space: free (segment) dims OUTER, contracted (reduced) dim INNERMOST.
         space (segop/make-seg-space-nd (conj free-dims red-dim))
-        acc-sym (gensym "acc__")
-        ;; fused map→reduce: product sits in the combine's element slot.
-        reduction (reduction/scalar
-                   {:accumulator acc-sym :neutral init :dtype dtype :result out
-                    :index k-sym :step-result (list combine acc-sym body)
-                    :attributes {:source :raster.par/contract}})
+        reduction (:reduction facts)
         arrays  (set (ir-par/collect-aget-arrays body))
         inputs  (disj arrays out)
         ;; scalars = the symbol-valued axis bounds (the contraction dims). Body-level

--- a/src/raster/compiler/passes/parallel/contract_lower.clj
+++ b/src/raster/compiler/passes/parallel/contract_lower.clj
@@ -13,6 +13,7 @@
   (:require [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.par :as ir-par]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
+            [raster.compiler.core.util :as util]
             [clojure.set :as set]))
 
 (defn flatten-contract-axes
@@ -55,10 +56,13 @@
         reduction (:reduction facts)
         arrays  (set (ir-par/collect-aget-arrays body))
         inputs  (disj arrays out)
-        ;; scalars = the symbol-valued axis bounds (the contraction dims). Body-level
-        ;; extra scalars (e.g. a scale) are a later refinement.
-        bound-syms (into #{} (filter symbol?)
-                         (conj (mapv second free-axes) k-bound))]
+        ;; Flattening two or more reduction axes makes k-bound a typed arithmetic expression.
+        ;; Preserve every dimension scalar it references; collecting only direct symbol bounds
+        ;; silently omitted l1/l2 from the ABI of an otherwise valid portable contraction.
+        ;; Body-level extra scalars (e.g. a scale) are a later refinement.
+        bound-syms (reduce set/union #{}
+                           (map util/free-syms
+                                (conj (mapv second free-axes) k-bound)))]
     (segop/->SegRed id space
                     (segop/->SegLevel :thread :virtual)
                     reduction

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -10,10 +10,11 @@
    opencl-pass makes when it meets a contraction; kept in ONE place so the gate's hardware
    knowledge lives with the emitters, not scattered across passes.
 
-   Returns a launch-ready descriptor. Strategies: :segmap (0 contract axes), :naive-segred
-   (general), :regtiled (portable tiled), :dpas (f16 peak), :dp4a (int8 peak), :quant-naive
+   Returns a launch-ready descriptor. Strategies: :segmap (0 contract axes), :portable-segred
+   (scheduled general), :naive-segred (explicit migration fallback), :regtiled (portable tiled),
+   :dpas (f16 peak), :dp4a (int8 peak), :quant-naive
    (int8 widening). Keys: :kernel-name :source :array-params (binding order) :dtype :out-dtype
-   :out-elems :wg [x y] :grid [gx gy] :scalar-args [{:type :value}…] :dims, plus optional
+   :out-elems :wg/:grid (uniform 1-3D geometry) :scalar-args [{:type :value}…] :dims, plus optional
    :fallback-reason, :scheme (quant decode) and :pre-steps (inserted layout rearranges)."
   (:require [raster.compiler.core.op-descriptor :as od]
             [clojure.string :as str]
@@ -126,7 +127,7 @@
    descriptor says to bind, which is what this does.
 
    Pointer params must equal (array-params + 1 output + epilogue-operands). Default single-launch
-   leaves must also supply positive 2-D workgroup/grid data; validation closes those fields and the
+   leaves must also supply matching 1-3D workgroup/grid data; validation closes those fields and the
    ordered compiler values into a KernelArtifact. Full reductions already arrive as a verified
    artifact and retain their distinct two-phase invoke protocol, whose scheduler owns geometry.
 
@@ -186,12 +187,13 @@
       (nil? out-elems)
       (throw (ex-info "contract descriptor: :out-elems is required (the artifact sizes the output with it)"
                       {:strategy strategy}))
-      ;; wg/grid belong to the 2-D launch contract only. The reduction invoke computes its own
-      ;; two-phase geometry, so a :reduction descriptor legitimately carries neither — a third
-      ;; protocol difference this validator forced into the open rather than leaving implicit.
+      ;; A single-launch descriptor preserves the schedule's actual dimensionality. The reduction
+      ;; invoke computes its own two-phase geometry, so it legitimately carries neither.
       (and (not= :reduction invoke)
-           (not (and (vector? wg) (= 2 (count wg)) (vector? grid) (= 2 (count grid)))))
-      (throw (ex-info "contract descriptor: :wg and :grid must both be 2-element vectors"
+           (not (and (vector? wg) (vector? grid)
+                     (<= 1 (count wg) 3)
+                     (= (count wg) (count grid)))))
+      (throw (ex-info "contract descriptor: :wg and :grid must have matching 1-3D geometry"
                       {:strategy strategy :wg wg :grid grid}))
       (and (= :reduction invoke) (or (some? wg) (some? grid)))
       (throw (ex-info "contract descriptor: :invoke :reduction must not carry :wg/:grid (the invoke owns the two-phase launch)"
@@ -381,28 +383,40 @@
         (tensorize-plan)
 
       ;; everything else (n-free≠2, n≥2 contract axes, or a tensorize-ineligible 2-free form)
-      ;; → naive segmented reduce (general: any dtype, symbolic dims, any assoc combine).
-      ;; contract-form->segred flattens n≥2 contract axes into one innermost dim.
+      ;; → the portable scheduled KernelBody when its operand layouts are provable. During the
+      ;; migration, unsupported gathers retain the verified source emitter as an explicit decline.
         :else
         (let [sr (cl/contract-form->segred contract-form :dtype dtype :facts contract-facts)
+              portable (contraction-schedule/plan-portable-body contract-facts sr desc)
+              emitted (when (:ok portable)
+                        (sco/generate-contraction-kernel-body (:body portable)))
               {:keys [kernel-name source array-params scalar-params abi]}
-              (sco/generate-segmented-reduce-kernel sr out-sym :dtype dtype)
+              (or emitted (sco/generate-segmented-reduce-kernel sr out-sym :dtype dtype))
             ;; WHY THIS LEAF AND NOT A FASTER ONE. Only meaningful for the 2-free/1-contract shape,
             ;; where a tensorize leaf was actually attempted; for every other shape no faster leaf
             ;; exists to decline, so an empty vector is the honest answer rather than a fabricated
             ;; "not eligible".
               declines (when (and (= 2 n-free) (= 1 n-contract))
-                         (::declines (tensorize-plan)))]
+                         (::declines (tensorize-plan)))
+              declines (cond-> (vec declines)
+                         (not (:ok portable))
+                         (conj {:leaf :portable-kernel-body
+                                :reason (:reason portable)
+                                :data (:detail portable)}))
+              workgroup-size (or (:workgroup-size portable) 256)]
           (cond->
-           {:strategy :naive-segred
-            :declines (vec declines)
+           {:strategy (if (:ok portable) :portable-segred :naive-segred)
+            :declines declines
             :kernel-name kernel-name :source source :array-params array-params :abi abi
-            :dtype dtype :out-dtype dtype :wg [256 1] :grid [(ceil-div nseg 256) 1]
+            :kernel-body (:body portable)
+            :dtype dtype :out-dtype dtype
          ;; SYMBOLIC axis bounds become int kernel params (the emitter declares them, sorted by
          ;; name); they must be bound BEFORE the trailing count or the launch arity is wrong.
             :scalar-args (conj (mapv (fn [p] {:type :int :value p}) scalar-params)
                                {:type :int :value nseg})
-            :out-elems nseg :dims [nseg]}
+            :out-elems nseg :dims [nseg]
+            :wg [workgroup-size]
+            :grid [(ceil-div nseg workgroup-size)]}
           ;; the LAST decline is the decisive one — the leaf that would otherwise have taken the
           ;; work. Using the first reported DPAS's generic :not-a-contraction where regtiled's
           ;; specific :symbolic-dims / :non-plus-combine is the actual answer.

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -294,7 +294,7 @@
         (let [;; The staged emitter hardwires `+=` at every level, and a lift's linearity argument
             ;; assumes `+`. A form carrying :combine max routed here and was SILENTLY SUMMED —
             ;; contraction-facts surfaces :combine and nothing read it. Refuse rather than ignore.
-              _ (let [cmb (:combine contract-facts)]
+              _ (let [cmb (:combine (cf/scalar-reduction-view contract-facts))]
                   (when-not (contains? '#{+ clojure.core/+ raster.numeric/+} cmb)
                     (throw (ex-info (str "staged contraction: only `+` combine is supported (got "
                                          cmb ") — every accumulator level uses += and a lift's "
@@ -344,7 +344,7 @@
       ;; Its launch protocol differs (two phases + a host-side final combine), so the descriptor
       ;; says so with :invoke :reduction rather than pretending it is a 2-D kernel launch.
         (zero? n-free)
-        (let [sr (cl/contract-form->segred contract-form :dtype dtype)
+        (let [sr (cl/contract-form->segred contract-form :dtype dtype :facts contract-facts)
               k (sco/generate-segred-kernel sr out-sym :dtype dtype)
               attrs (:attributes k)
               red-bound (second (first contract-axes))]
@@ -384,7 +384,7 @@
       ;; → naive segmented reduce (general: any dtype, symbolic dims, any assoc combine).
       ;; contract-form->segred flattens n≥2 contract axes into one innermost dim.
         :else
-        (let [sr (cl/contract-form->segred contract-form :dtype dtype)
+        (let [sr (cl/contract-form->segred contract-form :dtype dtype :facts contract-facts)
               {:keys [kernel-name source array-params scalar-params abi]}
               (sco/generate-segmented-reduce-kernel sr out-sym :dtype dtype)
             ;; WHY THIS LEAF AND NOT A FASTER ONE. Only meaningful for the 2-free/1-contract shape,
@@ -474,7 +474,8 @@
   (let [acc (volatile! [])
         note! (fn [d] (vswap! acc conj d) nil)]
     (try
-      (let [sr (delay (cl/contract-form->segred contract-form :dtype dtype))
+      (let [sr (delay (cl/contract-form->segred contract-form :dtype dtype
+                                                  :facts contract-facts))
             scheduled (contraction-schedule/plan-matrix-body contract-facts desc tile
                                                              {:operation-id operation-id})
             dpas (if (:ok scheduled)

--- a/src/raster/compiler/passes/parallel/contraction_body.clj
+++ b/src/raster/compiler/passes/parallel/contraction_body.clj
@@ -1,0 +1,225 @@
+(ns raster.compiler.passes.parallel.contraction-body
+  "Lower a verified scalar contraction schedule to target-neutral KernelBody.
+
+   The portable baseline assigns one output segment to one work-item and represents the reduced
+   axis as a typed loop-carried fold. It is deliberately simple but fully scheduled: launch
+   geometry, segment decomposition, buffer shapes, loads, scalar SSA and the final store are IR.
+   Target emitters only choose syntax."
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.layout :as layout]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.ir.axis-map :as axis-map]
+            [raster.compiler.ir.contraction-facts :as facts]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.passes.parallel.segred-body :as segred-body]))
+
+(def ^:private index-operators
+  {'+ :add, 'clojure.core/+ :add, 'raster.numeric/+ :add
+   '- :sub, 'clojure.core/- :sub, 'raster.numeric/- :sub
+   '* :mul, 'clojure.core/* :mul, 'raster.numeric/* :mul
+   'quot :floor-div, 'clojure.core/quot :floor-div
+   'rem :mod, 'clojure.core/rem :mod
+   'mod :mod, 'clojure.core/mod :mod
+   'min :min, 'clojure.core/min :min
+   'max :max, 'clojure.core/max :max})
+
+(def ^:private index-casts
+  '#{int long clojure.core/int clojure.core/long})
+
+(defn- decline!
+  [rule message data]
+  (throw (ex-info message (assoc data
+                                 :reason :contraction-kernel-body-declined
+                                 :missing-rule rule
+                                 :fallback :verified-segmented-opencl))))
+
+(defn declined?
+  [exception]
+  (= :contraction-kernel-body-declined (:reason (ex-data exception))))
+
+(defn lower-index
+  "Translate verified source index arithmetic into KernelBody index expressions."
+  [expression scope]
+  (let [expression (descriptor/unwrap-int-cast expression)]
+    (cond
+      (integer? expression) expression
+
+      (symbol? expression)
+      (if (contains? scope expression)
+        expression
+        (decline! :unbound-index-symbol
+                  "portable contraction index references an undeclared symbol"
+                  {:expression expression :scope scope}))
+
+      (and (seq? expression) (contains? index-casts (first expression))
+           (= 2 (count expression)))
+      (lower-index (second expression) scope)
+
+      (seq? expression)
+      (let [operator (get index-operators (descriptor/semantic-op expression))
+            arguments (vec (descriptor/call-args expression))]
+        (when-not (and operator (seq arguments)
+                       (or (not= :sub operator) (= 2 (count arguments))))
+          (decline! :index-expression
+                    "portable contraction requires explicit integer affine/decomposition arithmetic"
+                    {:expression expression :operator (descriptor/semantic-op expression)}))
+        (apply body/expression operator (map #(lower-index % scope) arguments)))
+
+      :else
+      (decline! :index-expression
+                "portable contraction index has an unsupported value"
+                {:expression expression :type (type expression)}))))
+
+(defn- product-expression
+  [values]
+  (case (count values)
+    0 1
+    1 (first values)
+    (apply body/expression :mul values)))
+
+(defn lower
+  "Apply a portable one-work-item-per-segment schedule to a verified contraction SegRed."
+  [contract-facts segred {:keys [workgroup-size array-types scalar-types]
+                          :or {workgroup-size 256 array-types {} scalar-types {}}}]
+  (when-not (facts/facts? contract-facts)
+    (throw (ex-info "portable contraction lowering requires verified facts"
+                    {:reason :raster/bug :facts contract-facts})))
+  (let [space (:space segred)
+        segment-dims (segop/seg-space-segment-dims space)
+        reduced-dim (segop/seg-space-reduced-dim space)
+        _ (when (empty? segment-dims)
+            (decline! :no-segments
+                      "portable contraction body requires at least one free axis"
+                      {:segred-id (:id segred)}))
+        dtype (dtype/canon (:dtype segred))
+        arrays (vec (sort-by name (:inputs segred)))
+        scalars (vec (sort-by name (:scalars segred)))
+        scalar-dtype (fn [id] (or (get scalar-types id)
+                                  (get scalar-types (symbol (name id))) :int))
+        array-dtype (fn [id] (dtype/canon
+                              (or (get array-types id)
+                                  (get array-types (symbol (name id))) dtype)))
+        _ (when-not (and (dtype/known? dtype)
+                         (integer? workgroup-size) (pos? workgroup-size)
+                         (zero? (bit-and workgroup-size (dec workgroup-size)))
+                         (every? #(= dtype (array-dtype %)) arrays)
+                         (every? #(contains? #{:int :long} (dtype/canon (scalar-dtype %))) scalars))
+            (decline! :storage-contract
+                      "portable contraction requires uniform operand dtype and integral dimensions"
+                      {:dtype dtype :arrays arrays :array-types array-types
+                       :scalars scalars :scalar-types scalar-types
+                       :workgroup-size workgroup-size}))
+        operand-maps (into {}
+                           (map (fn [array]
+                                  [array (facts/operand-axis-map contract-facts array)]))
+                           arrays)
+        _ (when-let [missing (seq (keep (fn [[array amap]] (when-not amap array)) operand-maps))]
+            (decline! :operand-layout
+                      "portable contraction could not prove a dense physical map for every operand"
+                      {:operands (vec missing)
+                       :indices (mapv (juxt :sym :idx) (:operands contract-facts))}))
+        reduced-index (:name reduced-dim)
+        axis-symbols (set (concat (map :name segment-dims) [reduced-index]))
+        index-scope (into axis-symbols scalars)
+        segment-count-source (segop/seg-space-num-segments-expr space)
+        segment-count (lower-index segment-count-source index-scope)
+        reduced-bound (lower-index (:bound reduced-dim) index-scope)
+        segment-index 'segment-index
+        group-index 'segment-group
+        local-index 'segment-lane
+        active-mask :active-segment
+        decomposition
+        (mapv
+         (fn [position {:keys [name bound]}]
+           (let [following (subvec (vec segment-dims) (inc position))
+                 divisor (product-expression
+                          (mapv #(lower-index (:bound %) index-scope) following))
+                 quotient (if (= 1 divisor)
+                            segment-index
+                            (body/expression :floor-div segment-index divisor))]
+             (body/->IndexCompute
+              name (body/expression :mod quotient (lower-index bound index-scope)))))
+         (range) segment-dims)
+        {:keys [operator identity element]} (segred-body/scalar-plan segred)
+        _ (when-not (number? identity)
+            (decline! :literal-identity
+                      "portable contraction requires a typed numeric reduction identity"
+                      {:identity identity :segred-id (:id segred)}))
+        coordinate-lower #(lower-index % index-scope)
+        {:keys [operations result]}
+        (segred-body/lower-element-operations
+         element {:index reduced-index :coordinate reduced-index :dtype dtype
+                  :arrays (set arrays) :scalars (set scalars)
+                  :coordinate-lower coordinate-lower
+                  :load-predicate active-mask
+                  :load-other (body/literal identity dtype)})
+        accumulator 'segment-accumulator
+        next-accumulator 'next-segment-accumulator
+        reduction-result 'segment-result
+        output (:out contract-facts)
+        physical-extent
+        (fn [array]
+          (lower-index (axis-map/n-elements (get operand-maps array)) index-scope))
+        parameters
+        (vec (concat
+              (map (fn [array]
+                     (let [extent (physical-extent array)]
+                       (body/->KernelParameter
+                        array :input dtype [extent] :global
+                        (layout/row-major [extent] dtype) :operand)))
+                   arrays)
+              [(body/->KernelParameter output :output dtype [segment-count] :global
+                                       (layout/row-major [segment-count] dtype) :result)]
+              (map #(body/->KernelParameter % :scalar (scalar-dtype %) [] nil nil :parameter)
+                   scalars)
+              [(body/->KernelParameter '_nseg :scalar :int [] nil nil :bound)]))]
+    {:kernel-body
+     (body/make
+      {:id [:contraction (:id segred) :portable-sequential]
+       :parameters parameters
+       :stable-reads (mapv body/stable-read arrays)
+       :indices (vec (concat
+                      [(body/->IndexBinding group-index :group 0)
+                       (body/->IndexBinding local-index :local 0)
+                       (body/->IndexCompute
+                        segment-index
+                        (body/expression :add
+                                         (body/expression :mul group-index workgroup-size)
+                                         local-index))]
+                      decomposition))
+       :masks [(body/->Mask active-mask
+                            [(body/predicate :lt segment-index '_nseg)])]
+       :operations
+       [(body/->ForLoop
+         (body/value reduced-index :int)
+         0 reduced-bound 1
+         [(body/->LoopArg (body/value accumulator dtype)
+                          (body/literal identity dtype))]
+         (vec (concat
+               operations
+               [(body/->ScalarCompute
+                 (body/value next-accumulator dtype)
+                 (body/scalar-expression operator dtype [accumulator result]))
+                (body/->Yield [next-accumulator])]))
+         [(body/value reduction-result dtype)]
+         {})
+        (body/->ScalarStore output [segment-index] reduction-result active-mask)]
+       :schedule {:strategy :sequential-segments
+                  :workgroup-size workgroup-size
+                  :reduction-operator operator}
+       :launch (launch/spec
+                {:workgroup-size [workgroup-size]
+                 :group-count [(launch/ceil-div segment-count workgroup-size)]})
+       :provenance {:dialect :kernel-body :source-dialect :segcontract
+                    :segop-id (:id segred)}
+       :attributes {:kind :portable-contraction
+                    :identity identity :operator operator
+                    :segment-count segment-count
+                    :reduced-bound reduced-bound}})
+     :arrays arrays
+     :scalars scalars
+     :output output
+     :segment-count segment-count
+     :workgroup-size workgroup-size}))

--- a/src/raster/compiler/passes/parallel/contraction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/contraction_schedule.clj
@@ -276,8 +276,9 @@
    (when-not (facts/facts? contract-facts)
      (throw (ex-info "contraction scheduling requires verified contraction facts"
                      {:reason :raster/bug :facts contract-facts})))
-   (let [{:keys [dtype free-axes contract-axes body combine init operands epilogue]}
+   (let [{:keys [dtype free-axes contract-axes operands epilogue]}
          contract-facts
+         {:keys [element combine neutral]} (facts/scalar-reduction-view contract-facts)
          authoritative-desc? (and desc (or (:backend desc) (:execution desc)))
          matrix-capability-unavailable? (and authoritative-desc? (nil? (:matrix desc)))
          raw-tile (when-not matrix-capability-unavailable?
@@ -310,10 +311,10 @@
        (not (additive? combine))
        (decline :non-plus-combine {:combine combine})
 
-       (not (zero-init? init))
-       (decline :non-zero-matrix-init {:init init})
+       (not (zero-init? neutral))
+       (decline :non-zero-matrix-init {:init neutral})
 
-       (nil? (facts/body-product-of body (map :sym operands)))
+       (nil? (facts/body-product-of element (map :sym operands)))
        (decline :body-has-unmodeled-terms)
 
        (not (:ok layout-verdict))

--- a/src/raster/compiler/passes/parallel/contraction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/contraction_schedule.clj
@@ -11,7 +11,8 @@
             [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.contraction-facts :as facts]
             [raster.compiler.ir.kernel-body :as body]
-            [raster.compiler.ir.kernel-launch :as launch]))
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.passes.parallel.contraction-body :as contraction-body]))
 
 (defn- decline [reason & [data]]
   (merge {:ok false :reason reason} data))
@@ -366,3 +367,38 @@
                 :bindings bindings
                 :epilogue epilogue
                 :provenance {:dialect :segcontract :operation-id operation-id}})}))))
+
+(defn- portable-workgroup-size
+  [desc]
+  (let [limit (long (or (get-in desc [:execution :max-workgroup-size]) 256))
+        limit (max 1 (min 256 limit))]
+    (loop [width 1]
+      (if (<= (* 2 width) limit) (recur (* 2 width)) width))))
+
+(defn plan-portable-body
+  "Apply the portable sequential-segment schedule to a verified contraction SegRed.
+
+   The descriptor affects only legal launch width. Unsupported semantic/indexing cases return a
+   structured decline so the established source emitter remains available during migration."
+  ([contract-facts segred desc]
+   (plan-portable-body contract-facts segred desc {}))
+  ([contract-facts segred desc {:keys [array-types scalar-types]
+                                :or {array-types {} scalar-types {}}}]
+   (try
+     (let [workgroup-size (portable-workgroup-size desc)
+           lowered (contraction-body/lower
+                    contract-facts segred
+                    {:workgroup-size workgroup-size
+                     :array-types array-types :scalar-types scalar-types})]
+       {:ok true
+        :body (:kernel-body lowered)
+        :workgroup-size workgroup-size
+        :arrays (:arrays lowered)
+        :scalars (:scalars lowered)
+        :segment-count (:segment-count lowered)})
+     (catch clojure.lang.ExceptionInfo exception
+       (if (contraction-body/declined? exception)
+         {:ok false
+          :reason (:missing-rule (ex-data exception))
+          :detail (ex-data exception)}
+         (throw exception))))))

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -286,6 +286,9 @@
                                                    algorithm device-id :dtype dtype)}
                              reduce {:operations (soac-lower/lower-typed-reduce
                                                   algorithm device-id :dtype dtype)}
+                             segmented-reduce
+                             {:operations (soac-lower/lower-typed-segmented-reduce
+                                           algorithm device-id :dtype dtype)}
                              scan (soac-lower/lower-typed-scan
                                    algorithm device-id :dtype dtype
                                    :array-types (:array-types opts)))

--- a/src/raster/compiler/passes/parallel/segred_body.clj
+++ b/src/raster/compiler/passes/parallel/segred_body.clj
@@ -129,8 +129,12 @@
     (second expression)
     expression))
 
-(defn- element-operations
-  [expression {:keys [index coordinate dtype arrays scalars]}]
+(defn lower-element-operations
+  "Lower a scalar reduction element into typed SSA. `coordinate-lower` may translate a verified
+   source-level flat array index into KernelBody index arithmetic; without it, this retains the
+   pointwise full-reduction contract. A predicate requires an explicit typed load fallback."
+  [expression {:keys [index coordinate dtype arrays scalars coordinate-lower
+                      load-predicate load-other]}]
   (let [operations (atom [])
         counter (atom 0)
         fresh (fn [prefix] (symbol (str prefix "-" (swap! counter inc))))
@@ -153,17 +157,24 @@
                   (descriptor/aget-call? expression)
                   (let [arguments (vec (descriptor/call-args expression))
                         array (descriptor/aget-array-sym expression)
-                        source-coordinate (some-> (last arguments) strip-index-cast)]
+                        source-coordinate (some-> (last arguments) strip-index-cast)
+                        lowered-coordinate (if coordinate-lower
+                                             (coordinate-lower source-coordinate)
+                                             (when (= index source-coordinate) coordinate))]
                     (when-not (and (= 2 (count arguments))
                                    (contains? arrays array)
-                                   (= index source-coordinate))
+                                   lowered-coordinate)
                       (decline! :indexed-load
-                                "initial KernelBody reduction supports pointwise array loads"
+                                "KernelBody reduction cannot prove this array load coordinate"
                                 {:expression expression :array array :coordinate source-coordinate
                                  :index index :arrays arrays}))
                     (let [result (fresh "element-load")]
-                      (emit! (body/->ScalarLoad (body/value result dtype) array [coordinate]
-                                                nil nil :cached)
+                      (emit! (body/->ScalarLoad
+                              (body/value result dtype) array [lowered-coordinate]
+                              load-predicate
+                              (when load-predicate
+                                (or load-other (body/literal 0 dtype)))
+                              :cached)
                              result)))
 
                   (and (seq? expression) (contains? cast-heads (first expression))
@@ -238,8 +249,8 @@
         next-lane-accumulator 'next-lane-accumulator
         lane-result 'lane-result
         {:keys [operations result]}
-        (element-operations element {:index index :coordinate element-index :dtype dtype
-                                     :arrays (set arrays) :scalars (set scalars)})
+        (lower-element-operations element {:index index :coordinate element-index :dtype dtype
+                                           :arrays (set arrays) :scalars (set scalars)})
         output (or out-sym 'output)
         group-count (launch-group-count (get-in segred [:grid :num-blocks])
                                         bound workgroup-size)

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -241,6 +241,87 @@
                     :algorithm-equation equation-id)
             (lower-reduce node device-id :dtype accumulator-dtype)))))
 
+(defn typed-segmented-reduce-program?
+  "Whether a validated one-equation TypedSOAC program is a general segmented reduction."
+  [program]
+  (and (soac-dialect/program-form? program)
+       (= 1 (count (soac-dialect/equations program)))
+       (= 'segmented-reduce
+          (soac-dialect/operation-kind (first (soac-dialect/equations program))))))
+
+(defn- flat-segment-coordinate
+  [segment-axes reduced-index reduced-extent]
+  (reduce (fn [coordinate [index extent]]
+            (list 'clojure.core/+ (list 'clojure.core/* coordinate extent) index))
+          0
+          (conj (vec segment-axes) [reduced-index reduced-extent])))
+
+(defn lower-typed-segmented-reduce
+  "Lower one general TypedSOAC segmented reduction directly to SegRed.
+
+   Segment axes are parallel result dimensions and the ordinary `:index/:extent` pair is the
+   innermost reduced dimension. Stable tensor captures retain arbitrary index expressions, which
+   is the general representation used by contractions; ordinary element operands denote dense
+   row-major storage over the complete segment-plus-reduction space."
+  [program device-id & {:keys [dtype] :or {dtype :double}}]
+  (let [program (soac-dialect/validate! program)]
+    (when-not (typed-segmented-reduce-program? program)
+      (throw (ex-info "typed segmented reduction lowering requires one segmented-reduce equation"
+                      {:reason :typed-soac-segmented-reduce-subset :program program})))
+    (let [equation (first (soac-dialect/equations program))
+          [_ equation-id results operation] equation
+          [_ attributes arrays captures lambda] operation
+          {:keys [body-results]} (soac-dialect/lambda-parts lambda)
+          {:keys [accumulators elements capture-parameters]}
+          (soac-dialect/parameter-layout equation)
+          segment-axes (:segment-axes attributes)
+          reduced-index (:index attributes)
+          reduced-extent (:extent attributes)
+          dense-coordinate (flat-segment-coordinate segment-axes reduced-index reduced-extent)
+          substitutions
+          (into (zipmap capture-parameters captures)
+                (map (fn [parameter array]
+                       [parameter (list 'clojure.core/aget array dense-coordinate)])
+                     elements arrays))
+          step-results (mapv #(util/subst-syms substitutions %) body-results)
+          components
+          (mapv (fn [ordinal accumulator neutral component-dtype result]
+                  {:id (keyword (str "component-" ordinal))
+                   :accumulator accumulator :neutral neutral :dtype component-dtype
+                   :result result})
+                (range) accumulators (:identities attributes) (:dtypes attributes) results)
+          operator (reduction/make
+                    {:components components
+                     :index reduced-index
+                     :step (reduction/->ReductionRegion [] step-results {})
+                     :algebra {:components (:algebra attributes)}
+                     :attributes {:source :typed-soac :equation equation-id
+                                  :segmented true}})
+          facts (soac-dialect/facts program)
+          values (:values facts)
+          stable-captures (set (get-in attributes [:attributes :stable-array-captures]))
+          inputs (set/union (set arrays) stable-captures)
+          axis-indices (set (concat (map first segment-axes) [reduced-index]))
+          bound-symbols (reduce set/union #{}
+                                (map util/free-syms
+                                     (conj (mapv second segment-axes) reduced-extent)))
+          body-symbols (reduce set/union #{} (map util/free-syms step-results))
+          scalars (set/difference (set/union bound-symbols body-symbols)
+                                  inputs (set accumulators) axis-indices)
+          space (segop/make-seg-space-nd
+                 (conj (mapv (fn [[index extent]] {:name index :bound extent}) segment-axes)
+                       {:name reduced-index :bound reduced-extent}))
+          output-dtype (or (first (:dtypes attributes)) dtype :double)
+          _ (doseq [input inputs]
+              (when-not (= :tensor (:kind (get values input)))
+                (throw (ex-info "segmented reduction tensor input lacks an AbstractValue"
+                                {:reason :typed-soac-segmented-reduce-input
+                                 :equation equation-id :input input
+                                 :value (get values input)}))))]
+      [(segop/->SegRed equation-id space
+                       (segop/->SegLevel :thread :virtual)
+                       operator nil inputs (set results) scalars nil :segmented nil output-dtype)])))
+
 (defn typed-scan-program?
   "Whether a validated one-equation TypedSOAC program is a certified scan."
   [program]

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -41,6 +41,22 @@
                                 :local-definitions local-definitions
                                 :body-results body-results}))))
 
+(def ^:private segmented-reduce-equation-rule
+  (from-dialect dialect/TypedSOAC
+                (rule '(= ?equation-id [??results]
+                          (segmented-reduce ?attributes [??arrays] [??captures]
+                                            (lambda [??parameters]
+                                                    (region [??local-definitions]
+                                                            [??body-results]))))
+                      (success {:kind :segmented-reduce
+                                :id equation-id
+                                :results results
+                                :attributes attributes
+                                :arrays arrays
+                                :captures captures
+                                :local-definitions local-definitions
+                                :body-results body-results}))))
+
 (def ^:private scatter-equation-rule
   (from-dialect dialect/TypedSOAC
                 (rule '(= ?equation-id [??results]
@@ -95,6 +111,7 @@
                     (map-equation-rule equation)
                     (scatter-equation-rule equation)
                     (reduce-equation-rule equation)
+                    (segmented-reduce-equation-rule equation)
                     (scan-equation-rule equation)])]
     (let [lambda (:lambda (dialect/operation-parts equation))]
       (merge (dissoc matched :local-definitions)
@@ -102,9 +119,8 @@
 
 (defn- equation-references
   [equation]
-  (let [{:keys [arrays captures attributes]} (equation-info equation)]
-    (cond-> (vec (concat arrays captures))
-      (:extent attributes) (conj (:extent attributes)))))
+  (let [{:keys [arrays captures]} (equation-info equation)]
+    (into (vec (concat arrays captures)) (dialect/operation-extents equation))))
 
 (defn- element-symbols
   [n]
@@ -116,7 +132,7 @@
 
 (defn- parameter-parts
   [info]
-  (let [accumulator-count (if (contains? #{:reduce :scan} (:kind info))
+  (let [accumulator-count (if (contains? #{:reduce :segmented-reduce :scan} (:kind info))
                             (count (get-in info [:attributes :accumulators]))
                             0)
         array-count (count (:arrays info))

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -23,9 +23,9 @@
   [program equation]
   (let [equation-id (second equation)
         results (vec (nth equation 2))
-        extent (dialect/operation-extent equation)
-        inputs (cond-> (dialect/operation-inputs equation)
-                 (dialect/value-id? extent) (conj extent))
+        inputs (vec (distinct
+                     (into (dialect/operation-inputs equation)
+                           (filter dialect/value-id? (dialect/operation-extents equation)))))
         source-facts (dialect/facts program)
         equation-facts (get-in source-facts [:equations equation-id])
         value-ids (set (concat inputs results (dialect/physical-results source-facts equation)))

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -2474,8 +2474,10 @@
                             (str "  tile=" (:block-m t) "x" (:block-n t) "/" (:sg-m t) "x" (:sg-n t)
                                  " k" (:block-k t) " stages=" (:num-stages t 3)))
                           (when-let [body (field :kernel-body)]
-                            (str "  body=" (name (get-in body [:attributes :kind])) "/"
-                                 (name (get-in body [:attributes :instruction-family]))))
+                            (let [kind (get-in body [:attributes :kind])
+                                  family (get-in body [:attributes :instruction-family])]
+                              (str "  body=" (name kind)
+                                   (when family (str "/" (name family))))))
                           (when-let [occ (field :occupancy-estimate)]
                             (str "  occupancy=" (format "%.0f%%" (* 100.0 (:occupancy occ)))
                                  " limited-by=" (name (:limiting-factor occ))))))

--- a/src/raster/par.clj
+++ b/src/raster/par.clj
@@ -280,7 +280,7 @@
       ;; flatten-contract-axes collapses n≥2 axes into one flat index k-sym and substitutes
       ;; each original contract index in the body (one source of truth with the compiler path).
       (let [[k-sym k-bound sbody]
-            ((requiring-resolve 'raster.compiler.passes.parallel.contract-lower/flatten-contract-axes)
+            ((requiring-resolve 'raster.compiler.ir.contraction-facts/flatten-contract-axes)
              contract-axes body)]
         `(let [~out-sym ~out ~F-sym ~F-expr]
            (dotimes [~f-sym ~F-sym]

--- a/test/raster/compiler/backend/gpu/contract_pipeline_device_test.clj
+++ b/test/raster/compiler/backend/gpu/contract_pipeline_device_test.clj
@@ -100,7 +100,7 @@
 ;; ── Phase 0: EVERY routed strategy survives the pipeline (descriptor passed through intact) ──
 ;; Before the descriptor fix, only :dpas (3 scalar-args) and :regtiled (0) worked: the invoke
 ;; reconstructed scalar-args from a `case` with no default and destructured [m n k] from :dims,
-;; so :segmap / :naive-segred (1 scalar-arg, :dims [nseg]) crashed, and quant's f32 output was
+;; so :segmap / general SegRed (1 scalar-arg, :dims [nseg]) crashed, and quant's f32 output was
 ;; staged at int8 size (4× undersized).
 (defn- run-form [form dt args-map out-len]
   (let [{:keys [form kernels]} (ocl/opencl-pass form :dtype dt :compile-spirv? false)
@@ -120,7 +120,7 @@
               out (run-form form :double {'a a 'b b} 12)
               ref (vec (for [i (range 4) j (range 3)] (* (aget a i) (aget b j))))]
           (is (= (vec out) ref))))
-      (testing ":naive-segred (3 free axes, batch matmul) through opencl-pass → device"
+      (testing ":portable-segred (3 free axes, batch matmul) through opencl-pass → device"
         (let [B 2 M 3 N 2 K 4
               A (double-array (map #(* 0.1 (double %)) (range (* B M K))))
               Bd (double-array (map #(* 0.2 (double %)) (range (* B K N))))
@@ -153,7 +153,7 @@
           call (kcall/make artifact runtime-arguments)]
       (is (some? (:out-elems r)))
       (is (not (number? (:out-elems r))))            ; carried symbolically
-      (is (contains? #{:regtiled :naive-segred} (:strategy r)))
+      (is (contains? #{:regtiled :portable-segred} (:strategy r)))
       ;; STRENGTHENED: the original assertion only checked that routing did not CRASH, which let a
       ;; real bug through — the descriptor supplied 1 scalar arg where the kernel declares 4
       ;; (int k, int m, int n, int _nseg), so a caller would have mis-bound at launch. The
@@ -163,6 +163,6 @@
       (is (= '[k m n] (mapv :value (butlast (:scalar-args r))))
           "…in the kernel's declared (name-sorted) order")
       (is (= (:out-elems r) (:value (last (:scalar-args r)))))
-      (is (= [256 1] (get-in call [:geometry :workgroup-size])))
-      (is (= [2 1] (get-in call [:geometry :group-count]))
+      (is (= [256] (get-in call [:geometry :workgroup-size])))
+      (is (= [2] (get-in call [:geometry :group-count]))
           "the artifact resolves its symbolic ceil-div grid from ordered ABI values"))))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -7,9 +7,12 @@
             [raster.compiler.backend.gpu.segop-opencl :as segop-emit]
             [raster.compiler.backend.gpu.target :as gpu-target]
             [raster.compiler.ir.attention :as attention]
+            [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.attention-route :as attention-route]
+            [raster.compiler.passes.parallel.contract-lower :as contract-lower]
+            [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-schedule :as schedule]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]))
 
@@ -24,6 +27,20 @@
     (segop-emit/generate-segred-kernel-body
      operation nil :dtype :float :scalar-types {'scale :float}
      :target-dialect dialect :kernel-name-prefix "workgroup_reduce")))
+
+(defn- contraction-artifact
+  [dialect descriptor]
+  (let [form '(raster.par/contract y [[i 64]] [[l 32]]
+                (* (aget A (+ (* i 32) l)) (aget x l)))
+        verified (contraction-facts/contraction-facts form :dtype :float)
+        segred (contract-lower/contract-form->segred
+                form :dtype :float :facts verified)
+        planned (contraction-schedule/plan-portable-body verified segred descriptor)]
+    (when-not (:ok planned)
+      (throw (ex-info "portable contraction compile fixture did not schedule" planned)))
+    (segop-emit/generate-contraction-kernel-body
+     (:body planned) :target-dialect dialect
+     :kernel-name-prefix "portable_contraction")))
 
 (defn- problem []
   (attention/make
@@ -96,6 +113,8 @@
                             swizzled-pipelined)
            (write-artifact! directory suffix "workgroup-reduction"
                             (reduction-artifact dialect))
+           (write-artifact! directory suffix "portable-contraction"
+                            (contraction-artifact dialect descriptor))
            (write-source! directory suffix "workgroup-memory"
                           (body-emit/emit-scalar-kernel
                            "workgroup_memory" (body-fixtures/workgroup-memory-body 32)

--- a/test/raster/compiler/contract_soac_node_test.clj
+++ b/test/raster/compiler/contract_soac_node_test.clj
@@ -18,6 +18,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
             [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.segop-lower-pass :as slp]
             [raster.compiler.ir.parallel-program :as program]
@@ -37,7 +38,8 @@
     (testing "facts are the payload, derived once"
       (is (= '[[i 128] [j 128]] (:free-axes (:facts n))))
       (is (= '[[l 128]] (:contract-axes (:facts n))))
-      (is (= '[A B] (mapv :sym (:operands (:facts n))))))
+      (is (= '[A B] (mapv :sym (:operands (:facts n)))))
+      (is (reduction/product-reduction? (:reduction (:facts n)))))
     (testing "graph projections derive from the facts"
       (is (= '#{A B} (soac/soac-inputs n)))
       (is (= '#{C} (soac/soac-outputs n))))

--- a/test/raster/compiler/contraction_marker_abi_test.clj
+++ b/test/raster/compiler/contraction_marker_abi_test.clj
@@ -4,6 +4,7 @@
             [raster.arrays :as ra]
             [raster.compiler.pipeline :as pipeline]
             [raster.compiler.backend.gpu.opencl-pass :as op]
+            [raster.compiler.core.hardware :as hardware]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
@@ -38,8 +39,9 @@
 (defn- compile-form
   ([contract] (compile-form contract :half))
   ([contract dtype]
-   (op/opencl-pass (list 'let* ['result contract] 'result)
-                   :device-id :ze:0 :dtype dtype :min-elements 0)))
+   (with-redefs [hardware/descriptor-for (constantly nil)]
+     (op/opencl-pass (list 'let* ['result contract] 'result)
+                     :device-id :ze:0 :dtype dtype :min-elements 0))))
 
 (defn- thrown-data [thunk]
   (try

--- a/test/raster/compiler/explain_pipeline_truth_test.clj
+++ b/test/raster/compiler/explain_pipeline_truth_test.clj
@@ -53,7 +53,7 @@
         (is (not (re-find #"DECLINED a conversion" s)) "nothing declines any more"))
       (testing "the kernel section names the leaf, the headline reason, and every leaf that refused"
         (is (re-find #"--- Kernels ---" s))
-        (is (re-find #"strategy=:naive-segred" s))
+        (is (re-find #"strategy=:portable-segred" s))
         (is (re-find #"fallback-reason=:symbolic-dims" s))
         (is (re-find #"declined :dpas: :dtype-not-dpas" s))
         (is (re-find #"declined :regtiled: :symbolic-dims" s))))))

--- a/test/raster/compiler/ir/contraction_facts_test.clj
+++ b/test/raster/compiler/ir/contraction_facts_test.clj
@@ -7,7 +7,8 @@
    against axes derived from itself, and a body-replacing leaf that never checked the body."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.contraction-facts :as cf]
-            [raster.compiler.ir.axis-map :as am]))
+            [raster.compiler.ir.axis-map :as am]
+            [raster.compiler.ir.reduction :as reduction]))
 
 (def ^:private ma (am/of-groups '[[[i 4]] [[blk 4] [t 32]]]))
 (def ^:private mb (am/of-groups '[[[j 6]] [[blk 4] [t 32]]]))
@@ -31,7 +32,14 @@
       (is (= '{:free0 i :free1 j :contract0 blk :contract1 t} (:roles f)))
       (is (= {:free0 4 :free1 6 :contract0 4 :contract1 32} (:dims f))))
     (testing "operands are the body's aget reads"
-      (is (= '[a b] (mapv :sym (:operands f)))))))
+      (is (= '[a b] (mapv :sym (:operands f)))))
+    (testing "one canonical ProductReduction owns fold semantics before scheduling"
+      (let [operator (:reduction f)]
+        (is (reduction/product-reduction? operator))
+        (is (= :byte (first (reduction/dtypes operator))))
+        (is (= [(:index operator) 128] (:flat-contract-axis f)))
+        (is (= (:element (cf/scalar-reduction-view f))
+               (second (rest (first (:results (reduction/fold-region operator)))))))))))
 
 (deftest a-stage-list-cannot-supply-the-axes-it-is-checked-against
   (testing "the form's contract axes are independent of its :stages — the two are separate slots,

--- a/test/raster/compiler/passes/parallel/contract_descriptor_validator_test.clj
+++ b/test/raster/compiler/passes/parallel/contract_descriptor_validator_test.clj
@@ -27,12 +27,20 @@
 ;; ── every strategy's descriptor matches the kernel it describes ───────────────────────
 (deftest every-strategy-descriptor-is-consistent
   ;; route-contraction validates on the way out, so simply routing each shape is the assertion.
-  (testing "the six base strategies"
+  (testing "the base strategies, including the explicit migration fallback"
     (is (= :dpas         (:strategy (route/route-contraction (mm 256 512 128) :dtype :half))))
     (is (= :regtiled     (:strategy (route/route-contraction (mm 96 96 64) :dtype :double))))
     (is (= :segmap       (:strategy (route/route-contraction
                                      '(raster.par/contract C [[i 4] [j 3]] [] (* (aget a i) (aget b j)))
                                      :dtype :double))))
+    (is (= :portable-segred
+           (:strategy (route/route-contraction
+                       '(raster.par/contract C [[b 2] [i 4] [j 3]] [[l 5]]
+                          (* (aget A (+ (* (+ (* b 4) i) 5) l))
+                             (aget B (+ (* (+ (* b 5) l) 3) j))))
+                       :dtype :double))))
+    ;; The source template remains an explicit correctness fallback only where no physical
+    ;; operand layout can be proven (these deliberately unbound gather coordinates model that).
     (is (= :naive-segred (:strategy (route/route-contraction
                                      '(raster.par/contract C [[b 2] [i 4] [j 3]] [[l 5]]
                                                            (* (aget A x) (aget B y))) :dtype :double))))
@@ -77,7 +85,7 @@
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"out-elems"
                             (route/validate-descriptor (dissoc good :out-elems)))))
     (testing "malformed launch geometry"
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"2-element vectors"
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"matching 1-3D geometry"
                             (route/validate-descriptor (assoc good :grid [4])))))))
 
 (deftest validator-models-both-invoke-protocols

--- a/test/raster/compiler/passes/parallel/contract_route_device_test.clj
+++ b/test/raster/compiler/passes/parallel/contract_route_device_test.clj
@@ -102,20 +102,20 @@
     (is (route/par-contract-form? (matmul-form 8 8 8)))
     (is (not (route/par-contract-form? '(raster.par/map! a i 8 body))))))
 
-;; ── A1a: 0-contract (outer product → SegMap) + n-free (batch → naive segred) ──────────
+;; ── A1a: 0-contract (outer product → SegMap) + n-free (batch → portable SegRed) ───────
 (defn- launch-1d-routed
-  "Launch a routed 1-D contraction (segmap / naive-segred) with a trailing nseg count."
+  "Launch a routed 1-D contraction with a trailing nseg count."
   [r bufs out-buf nseg]
   (let [ze (find-ns 'raster.gpu.ze-runtime)
         register! (ns-resolve ze 'register-kernel!)
         ensure-loaded! (ns-resolve ze 'ensure-kernel-loaded!)
-        launch-2d! (ns-resolve ze 'launch-2d!)
+        launch-geometry! (ns-resolve ze 'launch-geometry!)
         buf->doubles (ns-resolve ze 'buffer->double-array)
         _ (register! (:kernel-name r) {:source (:source r) :dtype (:dtype r)})
         {:keys [kernel-handle]} (ensure-loaded! (:kernel-name r))
         args (into (mapv #(:segment (get bufs %)) (:array-params r))
                    [(:segment out-buf) {:type :int :value (int nseg)}])]
-    (launch-2d! kernel-handle (:wg r) (:grid r) args)
+    (launch-geometry! kernel-handle (:wg r) (:grid r) args)
     (vec (buf->doubles out-buf))))
 
 (defn- mk-f64 [xs] (let [ze (find-ns 'raster.gpu.ze-runtime)
@@ -136,10 +136,10 @@
         (is (= :segmap (:strategy r)))
         (is (= gpu cpu))))))
 
-(deftest a1a-n-free-routes-to-naive-segred
+(deftest a1a-n-free-routes-to-portable-segred
   (if-not @gpu?
     (println "[skip] a1a-naive-segred: no GPU")
-    (testing "3 free + 1 contract (batch matmul) → :naive-segred; == reference on device"
+    (testing "3 free + 1 contract (batch matmul) → :portable-segred; == reference on device"
       (let [B 2 M 4 N 3 K 5
             Ad (double-array (map #(* 0.1 (double %)) (range (* B M K))))
             Bd (double-array (map #(* 0.2 (double %)) (range (* B K N))))
@@ -155,13 +155,13 @@
                        (reduce + (for [l (range K)]
                                    (* (aget Ad (+ (* (+ (* bb M) i) K) l))
                                       (aget Bd (+ (* (+ (* bb K) l) N) j)))))))]
-        (is (= :naive-segred (:strategy r)))
+        (is (= :portable-segred (:strategy r)))
         (is (every? true? (map #(< (Math/abs (- (double %1) (double %2))) 1.0e-9) gpu cpu)))))))
 
-(deftest a1c-multi-contract-flattens-and-routes-to-naive-segred
+(deftest a1c-multi-contract-flattens-and-routes-to-portable-segred
   (if-not @gpu?
     (println "[skip] a1c-multi-contract: no GPU")
-    (testing "2 contract axes → flattened → :naive-segred; C[i]=Σ_{l1,l2} A[i,l1,l2]·V[l1,l2] == ref"
+    (testing "2 contract axes → flattened → :portable-segred; C[i]=Σ_{l1,l2} A[i,l1,l2]·V[l1,l2] == ref"
       (let [I 4
             A (double-array (map #(* 0.1 (double %)) (range (* I 2 3))))
             V (double-array (map #(* 0.5 (double %)) (range 6)))
@@ -176,7 +176,7 @@
             cpu (vec (for [i (range I)]
                        (reduce + (for [l1 (range 2) l2 (range 3)]
                                    (* (aget A (+ (* i 6) (* l1 3) l2)) (aget V (+ (* l1 3) l2)))))))]
-        (is (= :naive-segred (:strategy r)))
+        (is (= :portable-segred (:strategy r)))
         (is (every? true? (map #(< (Math/abs (- (double %1) (double %2))) 1.0e-9) gpu cpu)))))))
 
 ;; ── A3: output-axis permutation falls out of free-axis DECLARATION ORDER ──────────────
@@ -337,10 +337,10 @@
     (testing "0 contract axes → :segmap"
       (is (= :segmap (strategy '(raster.par/contract C [[i 4] [j 3]] []
                                                      (* (aget a i) (aget b j))) :dtype :double))))
-    (testing "n free ≠ 2 → :naive-segred"
+    (testing "an unprovable gather retains the verified source fallback"
       (is (= :naive-segred (strategy '(raster.par/contract C [[b 2] [i 4] [j 3]] [[l 5]]
                                                            (* (aget A x) (aget B y))) :dtype :double))))
-    (testing "n ≥ 2 contract axes → :naive-segred (flattened)"
+    (testing "an unprovable gather still falls back after multi-axis flattening"
       (is (= :naive-segred (strategy '(raster.par/contract C [[i 4]] [[l1 2] [l2 3]]
                                                            (* (aget A x) (aget V y))) :dtype :double))))
     (testing "2 free + 1 contract: f16 canonical → :dpas, f64 → :regtiled"

--- a/test/raster/compiler/passes/parallel/contraction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_body_test.clj
@@ -1,0 +1,93 @@
+(ns raster.compiler.passes.parallel.contraction-body-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.segop-opencl :as emit]
+            [raster.compiler.ir.contraction-facts :as facts]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.passes.parallel.contract-lower :as lower]
+            [raster.compiler.passes.parallel.contract-route :as route]
+            [raster.compiler.passes.parallel.contraction-schedule :as schedule]))
+
+(def ^:private matvec
+  '(raster.par/contract y [[i m]] [[l k]]
+     (* (aget A (+ (* i k) l)) (aget x l))))
+
+(defn- portable-plan []
+  (let [verified (facts/contraction-facts matvec :dtype :float)
+        segred (lower/contract-form->segred matvec :dtype :float :facts verified)]
+    (schedule/plan-portable-body verified segred nil)))
+
+(deftest portable-contraction-is-a-complete-scheduled-kernel-body
+  (let [plan (portable-plan)
+        kernel (:body plan)
+        loop (first (:operations kernel))]
+    (is (:ok plan))
+    (is (body/kernel-body? kernel))
+    (is (= :sequential-segments (get-in kernel [:schedule :strategy])))
+    (is (= [256] (get-in kernel [:launch :workgroup-size])))
+    (is (= '[A x y k m _nseg] (mapv :id (:parameters kernel))))
+    (is (= [:input :input :output :scalar :scalar :scalar]
+           (mapv :kind (:parameters kernel))))
+    (is (= 'i (:id (last (:indices kernel))))
+        "the free output coordinate is decomposed from the flat segment index")
+    (is (= 'l (get-in loop [:index :id])))
+    (is (= 'k (:upper loop)))
+    (is (= 1 (:step loop)))
+    (is (= :active-segment (:predicate (last (:operations kernel)))))))
+
+(deftest one-portable-body-emits-through-every-c-family-dialect
+  (let [kernel (:body (portable-plan))]
+    (doseq [[dialect target entry]
+            [[:opencl-portable :opencl-c "__kernel void"]
+             [:cuda :cuda-c "extern \"C\" __global__ void"]
+             [:hip :hip-cpp "extern \"C\" __global__ void"]]]
+      (testing (name dialect)
+        (let [emitted (emit/generate-contraction-kernel-body
+                       kernel :target-dialect dialect)]
+          (is (= target (:target emitted)))
+          (is (str/includes? (:source emitted) entry))
+          (is (str/includes? (:source emitted) "for (int rstr_l = 0"))
+          (is (= '[A x] (:array-params emitted)))
+          (is (= '[k m] (:scalar-params emitted))))))))
+
+(deftest production-general-contraction-route-carries-the-scheduled-body
+  (let [routed (route/route-contraction matvec :dtype :float :desc {})]
+    (is (= :portable-segred (:strategy routed)))
+    (is (body/kernel-body? (:kernel-body routed)))
+    (is (= (:kernel-body routed)
+           (artifact/attribute (:artifact routed) :kernel-body)))
+    (is (= '[A x y k m _nseg] (mapv :name (:abi routed))))
+    (is (= [256] (:wg routed)))
+    (is (= (:launch (:kernel-body routed))
+           (:launch (:artifact routed)))
+        "routing preserves the schedule's actual 1-D launch contract")
+    (is (empty? (:declines routed)))))
+
+(deftest eligible-affine-contractions-never-reenter-the-source-template
+  (with-redefs [emit/generate-segmented-reduce-kernel
+                (fn [& _]
+                  (throw (ex-info "legacy source template was called" {})))]
+    (is (= :portable-segred
+           (:strategy (route/route-contraction matvec :dtype :float :desc {}))))))
+
+(deftest flattened-symbolic-reduction-extents-remain-in-the-typed-abi
+  (let [form '(raster.par/contract y [[i m]] [[l1 k1] [l2 k2]]
+                (* (aget A (+ (* i (* k1 k2)) (* l1 k2) l2))
+                   (aget x (+ (* l1 k2) l2))))
+        routed (route/route-contraction form :dtype :float :desc {})]
+    (is (= :portable-segred (:strategy routed)))
+    (is (= '[k1 k2 m] (mapv :value (butlast (:scalar-args routed)))))
+    (is (= '[A x y k1 k2 m _nseg] (mapv :name (:abi routed))))
+    (is (= #{'k1 'k2 'm}
+           (set (map :id (filter #(= :scalar (:kind %))
+                                (butlast (:parameters (:kernel-body routed))))))))))
+
+(deftest non-affine-gather-declines-without-changing-semantics
+  (let [form '(raster.par/contract y [[i m]] [[l k]]
+                (* (aget A (aget indices i)) (aget x l)))
+        routed (route/route-contraction form :dtype :float :desc {})]
+    (is (= :naive-segred (:strategy routed)))
+    (is (= :operand-layout (:fallback-reason routed)))
+    (is (= :portable-kernel-body (-> routed :declines last :leaf)))
+    (is (nil? (:kernel-body routed)))))

--- a/test/raster/compiler/passes/parallel/contraction_schedule_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_schedule_test.clj
@@ -93,16 +93,17 @@
     (is (= '[A B] (:array-params routed)))))
 
 (deftest production-lowering-preserves-the-semantic-operation-identity
-  (let [contract (matrix-form 128 128 128)
-        source (list 'let* ['c contract] 'c)
-        lowered (:form (segop-lower/segop-lower-pass
-                        source {:target-device :ze:0 :dtype :half}))
-        semantic-operation (first (program/operations-for-binding lowered 'c contract))
-        compiled (opencl/opencl-pass lowered :dtype :half :min-elements 0)
-        kernel (artifact/attribute (first (:kernels compiled)) :kernel-body)]
-    (is (some? semantic-operation))
-    (is (= [:contraction (:id semantic-operation)] (:id kernel)))
-    (is (= (:id semantic-operation) (get-in kernel [:provenance :operation-id])))))
+  (with-redefs [hardware/descriptor-for (constantly nil)]
+    (let [contract (matrix-form 128 128 128)
+          source (list 'let* ['c contract] 'c)
+          lowered (:form (segop-lower/segop-lower-pass
+                          source {:target-device :ze:0 :dtype :half}))
+          semantic-operation (first (program/operations-for-binding lowered 'c contract))
+          compiled (opencl/opencl-pass lowered :dtype :half :min-elements 0)
+          kernel (artifact/attribute (first (:kernels compiled)) :kernel-body)]
+      (is (some? semantic-operation))
+      (is (= [:contraction (:id semantic-operation)] (:id kernel)))
+      (is (= (:id semantic-operation) (get-in kernel [:provenance :operation-id]))))))
 
 (deftest kernel-body-lowering-shadows-the-proven-dpas-oracle
   (let [form (matrix-form 128 128 128)
@@ -182,15 +183,16 @@
 
 (deftest opencl-consumes-the-resolved-contraction-tile
   (let [tile (assoc (hardware/derive-gemm-tile {})
-                    :block-m 64 :block-n 64 :num-stages 2)
-        compiled (opencl/opencl-pass (matrix-form 128 128 128)
-                                     :dtype :half :min-elements 0
-                                     :schedule {:tile tile})
-        artifact (first (:kernels compiled))
-        kernel (artifact/attribute artifact :kernel-body)]
-    (is (= tile (:schedule kernel)))
-    (is (= [64 64] ((juxt :block-m :block-n) (:schedule kernel))))
-    (is (= 2 (get-in kernel [:schedule :num-stages])))
-    (is (re-find #"WG 64x64" (:source artifact)))
-    (is (re-find #"\+ 32;" (:source artifact))
-        "num-stages=2 changes the K16 prefetch distance to 32")))
+                    :block-m 64 :block-n 64 :num-stages 2)]
+    (with-redefs [hardware/descriptor-for (constantly nil)]
+      (let [compiled (opencl/opencl-pass (matrix-form 128 128 128)
+                                         :dtype :half :min-elements 0
+                                         :schedule {:tile tile})
+            artifact (first (:kernels compiled))
+            kernel (artifact/attribute artifact :kernel-body)]
+        (is (= tile (:schedule kernel)))
+        (is (= [64 64] ((juxt :block-m :block-n) (:schedule kernel))))
+        (is (= 2 (get-in kernel [:schedule :num-stages])))
+        (is (re-find #"WG 64x64" (:source artifact)))
+        (is (re-find #"\+ 32;" (:source artifact))
+            "num-stages=2 changes the K16 prefetch distance to 32")))))

--- a/test/raster/compiler/passes/parallel/typed_segmented_reduction_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_segmented_reduction_test.clj
@@ -1,0 +1,120 @@
+(ns raster.compiler.passes.parallel.typed-segmented-reduction-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.parallel-program :as parallel-program]
+            [raster.compiler.ir.reduction :as reduction]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.ir.soac :as legacy]
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-pass]
+            [raster.compiler.passes.parallel.soac-lower :as lower]
+            [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]))
+
+(defn- tensor [dtype shape]
+  (av/tensor {:dtype dtype :shape shape :representation {:kind :plain}}))
+
+(defn- program []
+  (let [equation
+        '(= contract-equation [C]
+            (segmented-reduce
+             {:segment-axes [[i m] [j n]]
+              :index l :extent k
+              :accumulators [acc] :identities [0.0]
+              :dtypes [:float] :algebra [{}]
+              :attributes {:stable-array-captures [A B]}}
+             [] [A B n k]
+             (lambda [acc lhs rhs width inner]
+               (region []
+                       [(+ acc
+                           (* (aget lhs (+ (* i inner) l))
+                              (aget rhs (+ (* l width) j))))]))))
+        facts
+        (assoc (dialect/default-program-facts
+                {:front-end :typed-segmented-reduction-test})
+               :values {'A (tensor :float '[m k])
+                        'B (tensor :float '[k n])
+                        'm (tensor :long [])
+                        'n (tensor :long [])
+                        'k (tensor :long [])
+                        'C (tensor :float '[m n])}
+               :inputs '[A B m n k]
+               :equations {'contract-equation (dialect/default-equation-facts
+                                                {:source :test})})]
+    (dialect/make facts [equation] '[C])))
+
+(deftest segmented-reduction-is-a-typed-functional-equation
+  (let [program (program)
+        equation (first (dialect/equations program))
+        attributes (:attributes (dialect/operation-parts equation))]
+    (is (= 'segmented-reduce (dialect/operation-kind equation)))
+    (is (= '[[i m] [j n]] (:segment-axes attributes)))
+    (is (= '[m n k] (dialect/operation-extents equation)))
+    (is (= '[A B n k] (dialect/operation-inputs equation)))
+    (is (= '[C] (dialect/outputs program)))))
+
+(deftest generic-fusion-keeps-an-unmatched-segmented-reduction-intact
+  (let [source (program)
+        [result stats] (fusion/fusion-fixpoint source)]
+    (is (= source result))
+    (is (= :segmented-reduce
+           (:kind (fusion/equation-info (first (dialect/equations result))))))
+    (is (= 0 (:vertical stats)))
+    (is (= 0 (:horizontal stats)))))
+
+(deftest segmented-reduction-lowers-directly-to-canonical-segred
+  (with-redefs [legacy/->SoacContract
+                (fn [& _]
+                  (throw (ex-info "legacy SoacContract was constructed" {})))]
+    (let [operation (first (lower/lower-typed-segmented-reduce
+                            (program) :ze:0 :dtype :float))
+          dims (:dims (:space operation))
+          product (:reduction operation)
+          step (first (:results (reduction/fold-region product)))]
+      (is (instance? raster.compiler.ir.segop.SegRed operation))
+      (is (= '[[i m] [j n] [l k]]
+             (mapv (juxt :name :bound) dims)))
+      (is (= '#{A B} (:inputs operation)))
+      (is (= '#{m n k} (:scalars operation)))
+      (is (= '#{C} (:outputs operation)))
+      (is (reduction/product-reduction? product))
+      (is (= :float (first (reduction/dtypes product))))
+      (is (= 'C (first (reduction/results product))))
+      (is (re-find #"A" (pr-str step)))
+      (is (re-find #"B" (pr-str step)))
+      (is (not (re-find #"lhs|rhs|width|inner" (pr-str step)))))))
+
+(deftest value-remapping-includes-every-segment-extent
+  (let [remapped (dialect/remap-values
+                  (program) {'m [:binding 'm] 'n [:binding 'n] 'C [:binding 'C]})
+        equation (first (dialect/equations remapped))]
+    (is (= [['i [:binding 'm]] ['j [:binding 'n]]]
+           (get-in (dialect/operation-parts equation) [:attributes :segment-axes])))
+    (is (= [[:binding 'm] [:binding 'n] 'k]
+           (dialect/operation-extents equation)))
+    (is (= [[:binding 'C]] (dialect/outputs remapped)))))
+
+(deftest typed-parallel-program-schedules-the-equation-without-compatibility-relowering
+  (let [algorithm (program)
+        values (:values (dialect/facts algorithm))
+        source '(raster.par/contract C [[i m] [j n]] [[l k]] body)
+        equation
+        (parallel-program/->ProgramEquation
+         'contract-equation [:binding 'C] source '[A B m n k] '[C]
+         algorithm [(first (dialect/equations algorithm))] #{}
+         {:source-dialect :typed-soac} {})
+        envelope
+        (parallel-program/make
+         {:dialect :typed-soac :source (list 'let* ['C source] 'C)
+          :values values :inputs '[A B m n k] :equations [equation] :outputs '[C]
+          :effects #{} :operation? (constantly true)
+          :algorithm? (fn [_ candidate] (= candidate (dialect/validate! candidate)))})
+        lowered (segop-pass/segop-lower-pass
+                 envelope {:target-device :ze:0 :dtype :float})
+        scheduled-equation (first (:equations (:form lowered)))
+        operation (first (:operations scheduled-equation))]
+    (is (= :segop (:dialect (:form lowered))))
+    (is (= 1 (get-in lowered [:stats :typed-soac-reused])))
+    (is (= 1 (get-in lowered [:stats :segops-lowered])))
+    (is (instance? raster.compiler.ir.segop.SegRed operation))
+    (is (= :typed-soac (get-in scheduled-equation [:provenance :source-dialect])))
+    (is (empty? (:diagnostics (:form lowered))))))

--- a/test/raster/compiler/router_declines_test.clj
+++ b/test/raster/compiler/router_declines_test.clj
@@ -52,7 +52,7 @@
             previously recorded NOTHING AT ALL, not even a :fallback-reason key"
     (let [r (route (mm 128 128 128 :sym-dims true) :half)
           by-leaf (into {} (map (juxt :leaf identity)) (:declines r))]
-      (is (= :naive-segred (:strategy r)))
+      (is (= :portable-segred (:strategy r)))
       (is (= #{:dpas :regtiled} (set (keys by-leaf))) "both attempts itemized")
       (is (= :symbolic-dims (:reason (get by-leaf :regtiled))))
       (is (re-find #"literal dims" (str (:message (get by-leaf :regtiled))))
@@ -64,7 +64,7 @@
   (testing "a non-+ combine is a legitimate contraction that simply is not tiled-leaf shaped"
     (let [r (route (mm 128 128 128 :combine 'max) :half)
           by-leaf (into {} (map (juxt :leaf identity)) (:declines r))]
-      (is (= :naive-segred (:strategy r)))
+      (is (= :portable-segred (:strategy r)))
       (is (= :non-plus-combine (:reason (get by-leaf :regtiled))))
       (is (re-find #"combine must be \+" (str (:message (get by-leaf :regtiled))))))))
 
@@ -123,7 +123,12 @@
 
             This is north-star §10's 'no knob without emission', and the resident door had always
             passed it (ze_runtime `:prefetch (:num-stages tile 3)`)."
-    (let [desc (try (chw/descriptor-for :ze:0) (catch Throwable _ nil))
+    ;; This is a compiler test, so use a synthetic target descriptor. Querying :ze:0 made the
+    ;; assertion depend on local driver availability even though neither routing nor emission
+    ;; needs a device.
+    (let [desc {:matrix {:family :dpas :m 8 :n 16 :k 16 :subgroup 16}
+                :grf-bytes-per-lane 256 :subgroup-size 16
+                :max-workgroup-size 1024 :shared-local-memory 131072}
           base (chw/gemm-tile-for desc)
           norm #(clojure.string/replace (str %) #"_\d{3,}" "_N")
           src-for (fn [ns] (norm (:source (cr/route-contraction (mm 256 256 256) :dtype :half

--- a/test/raster/dl/einsum_contract_test.clj
+++ b/test/raster/dl/einsum_contract_test.clj
@@ -36,7 +36,7 @@
     (let [{:keys [kernel-handle]} ((ns-resolve ze 'ensure-kernel-loaded!) (:kernel-name r))
           args (into (mapv #(:segment (get bufs %)) (:array-params r))
                      (into [(:segment o)] (:scalar-args r)))]
-      ((ns-resolve ze 'launch-2d!) kernel-handle (:wg r) (:grid r) args)
+      ((ns-resolve ze 'launch-geometry!) kernel-handle (:wg r) (:grid r) args)
       [(:strategy r) (vec ((ns-resolve ze 'buffer->double-array) o))])))
 
 (deftest einsum-contract-matches-reference-on-device
@@ -57,7 +57,7 @@
         (let [[_ r] (go "ij,jk->ki" {:i 3 :j 4 :k 2} bufs 6)
               ref (for [k (range 2) i (range 3)] (reduce + (for [j (range 4)] (* (aget Ad (+ (* i 4) j)) (aget Bd (+ (* j 2) k))))))]
           (is (close? r ref))))
-      (testing "bij,bjk->bik batch matmul → naive segmented reduce"
+      (testing "bij,bjk->bik batch matmul → scheduled portable reduction"
         (let [B 2 M 3 K 4 N 2
               Abd (double-array (map #(* 0.1 (double %)) (range (* B M K))))
               Bbd (double-array (map #(* 0.2 (double %)) (range (* B K N))))
@@ -66,7 +66,7 @@
               ref (for [b (range B) i (range M) k (range N)]
                     (reduce + (for [j (range K)] (* (aget Abd (+ (* (+ (* b M) i) K) j))
                                                     (aget Bbd (+ (* (+ (* b K) j) N) k))))))]
-          (is (= :naive-segred s))
+          (is (= :portable-segred s))
           (is (close? r ref)))))))
 
 ;; ── Phase 1/2: rearrange (transpose / split / merge) as a MAP application ──────────────


### PR DESCRIPTION
## Summary
- derive one typed ProductReduction together with verified contraction facts
- reuse its flattened axis, element, combine, neutral, and dtype through SegRed lowering and matrix scheduling
- remove the duplicate flattening implementation and make device-free schedule tests independent of local accelerator probes

## Validation
- 32 tests / 168 assertions: contraction facts, lowerings, schedules, and segmented emission
- 48 tests / 329 assertions: ABI, spelling, fail-loud routing, staged contracts, and descriptor validation