### PR TITLE
Represent segmented reductions in TypedSOAC

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -314,6 +314,14 @@ contains only values, output indices, row count and width; ties select the lowes
 NaN outranks numeric values so corruption is visible and deterministic. Subgroup/shuffle and
 multi-workgroup alternatives remain schedule candidates, not new semantic primitives.
 
+TypedSOAC now also names the general `segmented-reduce` algebra directly: ordered parallel segment
+axes, one innermost reduction axis, typed accumulator products, dense element operands and stable
+arbitrarily indexed tensor captures. Its extents participate in the typed program boundary and
+alpha-remapping, and it lowers mechanically to canonical `SegRed` without constructing the former
+`SoacContract` record. Moving analyzed `raster.par/contract` source onto this equation is the next
+front-end slice; the operation is intentionally not a matmul node, so scientific contractions,
+batched reductions and attention-derived reductions share the same semantic vocabulary.
+
 Tensor contraction uses that same semantic operator rather than reconstructing `init`, `combine`
 and a fold body in `contract-lower`. The single contraction-facts derivation now owns its canonical
 one-component `ProductReduction`, normalized reduced coordinate and flattened semantic body;

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -32,6 +32,14 @@
              (lambda [acc ... element ... capture-parameter ...]
                (region [(let-value local :dtype init-expr) ...]
                        [step-result ...]))))
+        (= equation-id [result ...]
+           (segmented-reduce {:segment-axes [[row rows] ...]
+                              :index k :extent width
+                              :accumulators [acc ...] :identities [zero ...]
+                              :dtypes [:float ...] :algebra [{} ...]}
+             [array ...] [capture ...]
+             (lambda [acc ... element ... capture-parameter ...]
+               (region [] [step-result ...]))))
         (= equation-id [result]
            (scan {:mode :inclusive :index i :extent n
                   :accumulators [acc] :identities [zero]
@@ -102,6 +110,11 @@
      (if (integer? extent) (inc extent) (list 'clojure.core/inc extent))
      (first (extent-shape extent)))])
 
+(defn segmented-reduce-result-shape
+  "Canonical tensor shape of a segmented reduction's ordered parallel axes."
+  [attributes]
+  (mapv (comp first extent-shape second) (:segment-axes attributes)))
+
 (defn map-attributes?
   [value]
   (and (map? value)
@@ -130,6 +143,20 @@
           (count (:algebra value)))
        (every? keyword? (:dtypes value))
        (every? map? (:algebra value))))
+
+(defn segmented-reduce-attributes?
+  "Attributes for a general segmented reduction. Segment axes are the ordered parallel result
+   space; `:index/:extent` remain the innermost reduced axis shared with ordinary reduce."
+  [value]
+  (let [axes (:segment-axes value)
+        indices (mapv first axes)]
+    (and (reduce-attributes? (dissoc value :segment-axes))
+         (vector? axes) (seq axes)
+         (every? #(and (vector? %) (= 2 (count %))
+                       (symbol? (first %)) (extent? (second %)))
+                 axes)
+         (= (count indices) (count (distinct indices)))
+         (not (contains? (set indices) (:index value))))))
 
 (defn scan-attributes?
   "Attributes for a certified scan dialect operation. The explicit mode is load-bearing because
@@ -179,6 +206,7 @@
              [ma map-attributes?]
              [xa scatter-attributes?]
              [ra reduce-attributes?]
+             [sra segmented-reduce-attributes?]
              [ca scan-attributes?]
              [dt keyword?]
              [facts program-facts?])
@@ -207,6 +235,7 @@
              (map ?ma [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
              (scatter ?xa [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
              (reduce ?ra [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
+             (segmented-reduce ?sra [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
              (scan ?ca [(?:* ?id:array)] [(?:* ?id:capture)] ?l))
 
   (Equation [q :enforce]
@@ -237,11 +266,22 @@
       (vec (nth operation 2))
       (vec (concat (nth operation 2) (nth operation 3))))))
 
+(declare operation-parts)
+
 (defn operation-extent
   [equation]
   (let [operation (nth equation 3)]
     (when-not (= 'scalar (first operation))
       (:extent (second operation)))))
+
+(defn operation-extents
+  "All ordered iteration extents referenced by an operation. For segmented reductions this is
+   the parallel segment space followed by the innermost reduction extent."
+  [equation]
+  (let [{:keys [kind attributes]} (operation-parts equation)]
+    (if (= 'segmented-reduce kind)
+      (conj (mapv second (:segment-axes attributes)) (:extent attributes))
+      (if-let [extent (:extent attributes)] [extent] []))))
 
 (defn operation-parts
   "Normalize one operation into semantic fields shared by validation and lowering."
@@ -327,7 +367,7 @@
   [equation]
   (let [{:keys [kind attributes arrays captures lambda]} (operation-parts equation)
         parameters (:parameters (lambda-parts lambda))
-        accumulator-count (if (contains? #{'reduce 'scan} kind)
+        accumulator-count (if (contains? #{'reduce 'segmented-reduce 'scan} kind)
                             (count (:accumulators attributes)) 0)
         array-count (count arrays)
         accumulator-end accumulator-count
@@ -379,7 +419,7 @@
         (fail! :typed-soac-region-binders
                "scalar-region parameters and local SSA definitions must be distinct"
                {:equation equation-id :parameters parameters :locals local-ids}))
-      (when (and (contains? #{'map 'scatter 'reduce 'scan} kind)
+      (when (and (contains? #{'map 'scatter 'reduce 'segmented-reduce 'scan} kind)
                  (some #{(:index attributes)} local-ids))
         (fail! :typed-soac-region-binders
                "a scalar-region local cannot shadow its operation index"
@@ -401,7 +441,7 @@
     (when-not (= result-count (count body-results))
       (fail! :typed-soac-result-arity "SOAC result and lambda arity differ"
              {:equation equation-id :results result-count :body-results (count body-results)}))
-    (let [expected-parameter-count (+ (if (contains? #{'reduce 'scan} kind)
+    (let [expected-parameter-count (+ (if (contains? #{'reduce 'segmented-reduce 'scan} kind)
                                         (count (:accumulators attributes))
                                         0)
                                       (count arrays)
@@ -415,8 +455,10 @@
                 :arrays arrays
                 :captures captures})))
     (let [initial-bound (cond-> (set parameters)
-                          (contains? #{'map 'scatter 'reduce 'scan} kind)
-                          (conj (:index attributes)))
+                          (contains? #{'map 'scatter 'reduce 'segmented-reduce 'scan} kind)
+                          (conj (:index attributes))
+                          (= 'segmented-reduce kind)
+                          (into (map first (:segment-axes attributes))))
           final-bound
           (reduce (fn [bound {:keys [id init] :as local}]
                     (let [unbound (util/free-syms init bound)]
@@ -463,6 +505,17 @@
         (when-not (= result-count (count accumulators))
           (fail! :typed-soac-reduce-results
                  "reduce result arity must equal accumulator arity"
+                 {:equation equation-id :results results :accumulators accumulators})))
+
+      segmented-reduce
+      (let [accumulators (:accumulators attributes)]
+        (when-not (= accumulators (vec (take (count accumulators) parameters)))
+          (fail! :typed-soac-segmented-reduce-accumulators
+                 "segmented-reduce accumulator parameters must lead the lambda in declared order"
+                 {:equation equation-id :accumulators accumulators :parameters parameters}))
+        (when-not (= result-count (count accumulators))
+          (fail! :typed-soac-segmented-reduce-results
+                 "segmented-reduce result arity must equal accumulator arity"
                  {:equation equation-id :results results :accumulators accumulators})))
 
       scan
@@ -548,6 +601,18 @@
             (fail! :typed-soac-reduce-result-type
                    "reduce results must be scalar tensors with their declared accumulator dtype"
                    {:equation equation-id :id id :value value :dtype dtype}))))
+
+      segmented-reduce
+      (let [result-shape (segmented-reduce-result-shape attributes)]
+        (doseq [[id dtype] (map vector results (:dtypes attributes))]
+          (let [value (get values id)]
+            (when (and value
+                       (not (and (= :tensor (:kind value)) (= result-shape (:shape value))
+                                 (= dtype (:dtype value)))))
+              (fail! :typed-soac-segmented-reduce-result-type
+                     "segmented-reduce results must match the declared segment space and dtype"
+                     {:equation equation-id :id id :value value
+                      :segment-axes (:segment-axes attributes) :dtype dtype})))))
 
       scan
       (doseq [[id dtype] (map vector results (:dtypes attributes))]
@@ -656,9 +721,8 @@
     (let [definitions (mapcat #(nth % 2) equations)
           definition-set (set definitions)
           references (set (mapcat (fn [equation]
-                                    (cond-> (operation-inputs equation)
-                                      (value-id? (operation-extent equation))
-                                      (conj (operation-extent equation))))
+                                    (into (operation-inputs equation)
+                                          (filter value-id? (operation-extents equation))))
                                   equations))
           external (set/difference references definition-set)
           total-effects (reduce set/union #{}
@@ -684,9 +748,8 @@
              [equation & remaining] equations]
         (when equation
           (let [equation-id (second equation)
-                required (cond-> (set (operation-inputs equation))
-                           (value-id? (operation-extent equation))
-                           (conj (operation-extent equation)))
+                required (into (set (operation-inputs equation))
+                               (filter value-id? (operation-extents equation)))
                 missing (set/difference required available)]
             (when (seq missing)
               (fail! :typed-soac-use-before-definition
@@ -746,6 +809,12 @@
                                                 [:attributes :stable-array-captures]))
                                    (update-in [:attributes :stable-array-captures]
                                               #(mapv rename %)))
+                      attributes (if (= 'segmented-reduce kind)
+                                   (update attributes :segment-axes
+                                           #(mapv (fn [[index extent]]
+                                                    [index (if (value-id? extent)
+                                                             (rename extent) extent)]) %))
+                                   attributes)
                       operation (if (= 'scalar kind)
                                   (list kind attributes (mapv rename captures) lambda)
                                   (list kind (update attributes :extent

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -286,6 +286,9 @@
                                                    algorithm device-id :dtype dtype)}
                              reduce {:operations (soac-lower/lower-typed-reduce
                                                   algorithm device-id :dtype dtype)}
+                             segmented-reduce
+                             {:operations (soac-lower/lower-typed-segmented-reduce
+                                           algorithm device-id :dtype dtype)}
                              scan (soac-lower/lower-typed-scan
                                    algorithm device-id :dtype dtype
                                    :array-types (:array-types opts)))

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -241,6 +241,87 @@
                     :algorithm-equation equation-id)
             (lower-reduce node device-id :dtype accumulator-dtype)))))
 
+(defn typed-segmented-reduce-program?
+  "Whether a validated one-equation TypedSOAC program is a general segmented reduction."
+  [program]
+  (and (soac-dialect/program-form? program)
+       (= 1 (count (soac-dialect/equations program)))
+       (= 'segmented-reduce
+          (soac-dialect/operation-kind (first (soac-dialect/equations program))))))
+
+(defn- flat-segment-coordinate
+  [segment-axes reduced-index reduced-extent]
+  (reduce (fn [coordinate [index extent]]
+            (list 'clojure.core/+ (list 'clojure.core/* coordinate extent) index))
+          0
+          (conj (vec segment-axes) [reduced-index reduced-extent])))
+
+(defn lower-typed-segmented-reduce
+  "Lower one general TypedSOAC segmented reduction directly to SegRed.
+
+   Segment axes are parallel result dimensions and the ordinary `:index/:extent` pair is the
+   innermost reduced dimension. Stable tensor captures retain arbitrary index expressions, which
+   is the general representation used by contractions; ordinary element operands denote dense
+   row-major storage over the complete segment-plus-reduction space."
+  [program device-id & {:keys [dtype] :or {dtype :double}}]
+  (let [program (soac-dialect/validate! program)]
+    (when-not (typed-segmented-reduce-program? program)
+      (throw (ex-info "typed segmented reduction lowering requires one segmented-reduce equation"
+                      {:reason :typed-soac-segmented-reduce-subset :program program})))
+    (let [equation (first (soac-dialect/equations program))
+          [_ equation-id results operation] equation
+          [_ attributes arrays captures lambda] operation
+          {:keys [body-results]} (soac-dialect/lambda-parts lambda)
+          {:keys [accumulators elements capture-parameters]}
+          (soac-dialect/parameter-layout equation)
+          segment-axes (:segment-axes attributes)
+          reduced-index (:index attributes)
+          reduced-extent (:extent attributes)
+          dense-coordinate (flat-segment-coordinate segment-axes reduced-index reduced-extent)
+          substitutions
+          (into (zipmap capture-parameters captures)
+                (map (fn [parameter array]
+                       [parameter (list 'clojure.core/aget array dense-coordinate)])
+                     elements arrays))
+          step-results (mapv #(util/subst-syms substitutions %) body-results)
+          components
+          (mapv (fn [ordinal accumulator neutral component-dtype result]
+                  {:id (keyword (str "component-" ordinal))
+                   :accumulator accumulator :neutral neutral :dtype component-dtype
+                   :result result})
+                (range) accumulators (:identities attributes) (:dtypes attributes) results)
+          operator (reduction/make
+                    {:components components
+                     :index reduced-index
+                     :step (reduction/->ReductionRegion [] step-results {})
+                     :algebra {:components (:algebra attributes)}
+                     :attributes {:source :typed-soac :equation equation-id
+                                  :segmented true}})
+          facts (soac-dialect/facts program)
+          values (:values facts)
+          stable-captures (set (get-in attributes [:attributes :stable-array-captures]))
+          inputs (set/union (set arrays) stable-captures)
+          axis-indices (set (concat (map first segment-axes) [reduced-index]))
+          bound-symbols (reduce set/union #{}
+                                (map util/free-syms
+                                     (conj (mapv second segment-axes) reduced-extent)))
+          body-symbols (reduce set/union #{} (map util/free-syms step-results))
+          scalars (set/difference (set/union bound-symbols body-symbols)
+                                  inputs (set accumulators) axis-indices)
+          space (segop/make-seg-space-nd
+                 (conj (mapv (fn [[index extent]] {:name index :bound extent}) segment-axes)
+                       {:name reduced-index :bound reduced-extent}))
+          output-dtype (or (first (:dtypes attributes)) dtype :double)
+          _ (doseq [input inputs]
+              (when-not (= :tensor (:kind (get values input)))
+                (throw (ex-info "segmented reduction tensor input lacks an AbstractValue"
+                                {:reason :typed-soac-segmented-reduce-input
+                                 :equation equation-id :input input
+                                 :value (get values input)}))))]
+      [(segop/->SegRed equation-id space
+                       (segop/->SegLevel :thread :virtual)
+                       operator nil inputs (set results) scalars nil :segmented nil output-dtype)])))
+
 (defn typed-scan-program?
   "Whether a validated one-equation TypedSOAC program is a certified scan."
   [program]

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -41,6 +41,22 @@
                                 :local-definitions local-definitions
                                 :body-results body-results}))))
 
+(def ^:private segmented-reduce-equation-rule
+  (from-dialect dialect/TypedSOAC
+                (rule '(= ?equation-id [??results]
+                          (segmented-reduce ?attributes [??arrays] [??captures]
+                                            (lambda [??parameters]
+                                                    (region [??local-definitions]
+                                                            [??body-results]))))
+                      (success {:kind :segmented-reduce
+                                :id equation-id
+                                :results results
+                                :attributes attributes
+                                :arrays arrays
+                                :captures captures
+                                :local-definitions local-definitions
+                                :body-results body-results}))))
+
 (def ^:private scatter-equation-rule
   (from-dialect dialect/TypedSOAC
                 (rule '(= ?equation-id [??results]
@@ -95,6 +111,7 @@
                     (map-equation-rule equation)
                     (scatter-equation-rule equation)
                     (reduce-equation-rule equation)
+                    (segmented-reduce-equation-rule equation)
                     (scan-equation-rule equation)])]
     (let [lambda (:lambda (dialect/operation-parts equation))]
       (merge (dissoc matched :local-definitions)
@@ -102,9 +119,8 @@
 
 (defn- equation-references
   [equation]
-  (let [{:keys [arrays captures attributes]} (equation-info equation)]
-    (cond-> (vec (concat arrays captures))
-      (:extent attributes) (conj (:extent attributes)))))
+  (let [{:keys [arrays captures]} (equation-info equation)]
+    (into (vec (concat arrays captures)) (dialect/operation-extents equation))))
 
 (defn- element-symbols
   [n]
@@ -116,7 +132,7 @@
 
 (defn- parameter-parts
   [info]
-  (let [accumulator-count (if (contains? #{:reduce :scan} (:kind info))
+  (let [accumulator-count (if (contains? #{:reduce :segmented-reduce :scan} (:kind info))
                             (count (get-in info [:attributes :accumulators]))
                             0)
         array-count (count (:arrays info))

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -23,9 +23,9 @@
   [program equation]
   (let [equation-id (second equation)
         results (vec (nth equation 2))
-        extent (dialect/operation-extent equation)
-        inputs (cond-> (dialect/operation-inputs equation)
-                 (dialect/value-id? extent) (conj extent))
+        inputs (vec (distinct
+                     (into (dialect/operation-inputs equation)
+                           (filter dialect/value-id? (dialect/operation-extents equation)))))
         source-facts (dialect/facts program)
         equation-facts (get-in source-facts [:equations equation-id])
         value-ids (set (concat inputs results (dialect/physical-results source-facts equation)))

--- a/test/raster/compiler/passes/parallel/typed_segmented_reduction_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_segmented_reduction_test.clj
@@ -1,0 +1,120 @@
+(ns raster.compiler.passes.parallel.typed-segmented-reduction-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.parallel-program :as parallel-program]
+            [raster.compiler.ir.reduction :as reduction]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.ir.soac :as legacy]
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-pass]
+            [raster.compiler.passes.parallel.soac-lower :as lower]
+            [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]))
+
+(defn- tensor [dtype shape]
+  (av/tensor {:dtype dtype :shape shape :representation {:kind :plain}}))
+
+(defn- program []
+  (let [equation
+        '(= contract-equation [C]
+            (segmented-reduce
+             {:segment-axes [[i m] [j n]]
+              :index l :extent k
+              :accumulators [acc] :identities [0.0]
+              :dtypes [:float] :algebra [{}]
+              :attributes {:stable-array-captures [A B]}}
+             [] [A B n k]
+             (lambda [acc lhs rhs width inner]
+               (region []
+                       [(+ acc
+                           (* (aget lhs (+ (* i inner) l))
+                              (aget rhs (+ (* l width) j))))]))))
+        facts
+        (assoc (dialect/default-program-facts
+                {:front-end :typed-segmented-reduction-test})
+               :values {'A (tensor :float '[m k])
+                        'B (tensor :float '[k n])
+                        'm (tensor :long [])
+                        'n (tensor :long [])
+                        'k (tensor :long [])
+                        'C (tensor :float '[m n])}
+               :inputs '[A B m n k]
+               :equations {'contract-equation (dialect/default-equation-facts
+                                                {:source :test})})]
+    (dialect/make facts [equation] '[C])))
+
+(deftest segmented-reduction-is-a-typed-functional-equation
+  (let [program (program)
+        equation (first (dialect/equations program))
+        attributes (:attributes (dialect/operation-parts equation))]
+    (is (= 'segmented-reduce (dialect/operation-kind equation)))
+    (is (= '[[i m] [j n]] (:segment-axes attributes)))
+    (is (= '[m n k] (dialect/operation-extents equation)))
+    (is (= '[A B n k] (dialect/operation-inputs equation)))
+    (is (= '[C] (dialect/outputs program)))))
+
+(deftest generic-fusion-keeps-an-unmatched-segmented-reduction-intact
+  (let [source (program)
+        [result stats] (fusion/fusion-fixpoint source)]
+    (is (= source result))
+    (is (= :segmented-reduce
+           (:kind (fusion/equation-info (first (dialect/equations result))))))
+    (is (= 0 (:vertical stats)))
+    (is (= 0 (:horizontal stats)))))
+
+(deftest segmented-reduction-lowers-directly-to-canonical-segred
+  (with-redefs [legacy/->SoacContract
+                (fn [& _]
+                  (throw (ex-info "legacy SoacContract was constructed" {})))]
+    (let [operation (first (lower/lower-typed-segmented-reduce
+                            (program) :ze:0 :dtype :float))
+          dims (:dims (:space operation))
+          product (:reduction operation)
+          step (first (:results (reduction/fold-region product)))]
+      (is (instance? raster.compiler.ir.segop.SegRed operation))
+      (is (= '[[i m] [j n] [l k]]
+             (mapv (juxt :name :bound) dims)))
+      (is (= '#{A B} (:inputs operation)))
+      (is (= '#{m n k} (:scalars operation)))
+      (is (= '#{C} (:outputs operation)))
+      (is (reduction/product-reduction? product))
+      (is (= :float (first (reduction/dtypes product))))
+      (is (= 'C (first (reduction/results product))))
+      (is (re-find #"A" (pr-str step)))
+      (is (re-find #"B" (pr-str step)))
+      (is (not (re-find #"lhs|rhs|width|inner" (pr-str step)))))))
+
+(deftest value-remapping-includes-every-segment-extent
+  (let [remapped (dialect/remap-values
+                  (program) {'m [:binding 'm] 'n [:binding 'n] 'C [:binding 'C]})
+        equation (first (dialect/equations remapped))]
+    (is (= [['i [:binding 'm]] ['j [:binding 'n]]]
+           (get-in (dialect/operation-parts equation) [:attributes :segment-axes])))
+    (is (= [[:binding 'm] [:binding 'n] 'k]
+           (dialect/operation-extents equation)))
+    (is (= [[:binding 'C]] (dialect/outputs remapped)))))
+
+(deftest typed-parallel-program-schedules-the-equation-without-compatibility-relowering
+  (let [algorithm (program)
+        values (:values (dialect/facts algorithm))
+        source '(raster.par/contract C [[i m] [j n]] [[l k]] body)
+        equation
+        (parallel-program/->ProgramEquation
+         'contract-equation [:binding 'C] source '[A B m n k] '[C]
+         algorithm [(first (dialect/equations algorithm))] #{}
+         {:source-dialect :typed-soac} {})
+        envelope
+        (parallel-program/make
+         {:dialect :typed-soac :source (list 'let* ['C source] 'C)
+          :values values :inputs '[A B m n k] :equations [equation] :outputs '[C]
+          :effects #{} :operation? (constantly true)
+          :algorithm? (fn [_ candidate] (= candidate (dialect/validate! candidate)))})
+        lowered (segop-pass/segop-lower-pass
+                 envelope {:target-device :ze:0 :dtype :float})
+        scheduled-equation (first (:equations (:form lowered)))
+        operation (first (:operations scheduled-equation))]
+    (is (= :segop (:dialect (:form lowered))))
+    (is (= 1 (get-in lowered [:stats :typed-soac-reused])))
+    (is (= 1 (get-in lowered [:stats :segops-lowered])))
+    (is (instance? raster.compiler.ir.segop.SegRed operation))
+    (is (= :typed-soac (get-in scheduled-equation [:provenance :source-dialect])))
+    (is (empty? (:diagnostics (:form lowered))))))


### PR DESCRIPTION
## Summary
- add a general TypedSOAC segmented-reduce equation with ordered parallel segment axes, one innermost reduction axis, and typed product accumulators
- include every segment extent in program boundaries, validation, use ordering, alpha-remapping, and fusion dependency analysis
- lower the equation mechanically to canonical ProductReduction and SegRed without constructing the legacy SoacContract record
- preserve the equation through the generic fusion fixpoint until a declared segmented fusion rule applies

This is deliberately a general SOAC reduction, not a matmul or attention primitive. Stacked on #199; merge #198, #199, then this PR.

## Validation
- 81 tests / 429 assertions across TypedSOAC dialect, frontend, fusion, routing, and SegOp boundary suites
- 5 tests / 29 assertions in the new segmented-reduction suite, including direct ParallelProgram to SegOp lowering and a fail-if-SoacContract-is-constructed guard