### PR TITLE
Route scalar contractions through TypedSOAC

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -317,10 +317,16 @@ multi-workgroup alternatives remain schedule candidates, not new semantic primit
 TypedSOAC now also names the general `segmented-reduce` algebra directly: ordered parallel segment
 axes, one innermost reduction axis, typed accumulator products, dense element operands and stable
 arbitrarily indexed tensor captures. Its extents participate in the typed program boundary and
-alpha-remapping, and it lowers mechanically to canonical `SegRed` without constructing the former
-`SoacContract` record. Moving analyzed `raster.par/contract` source onto this equation is the next
-front-end slice; the operation is intentionally not a matmul node, so scientific contractions,
-batched reductions and attention-derived reductions share the same semantic vocabulary.
+alpha-remapping, and general equations lower mechanically to canonical `SegRed` without
+constructing the former `SoacContract` record. Ordinary scalar `raster.par/contract` source now
+enters this equation directly; the operation is intentionally not a matmul node, so scientific
+contractions, batched reductions and attention-derived reductions share the same semantic
+vocabulary. Until the tensorization route consumes TypedSOAC itself, one shared mechanical
+projection supplies both host materialization and a `SegContract` schedule view. The GPU emitter
+reuses that scheduled view rather than re-reading source. Staged quantization, decode lambdas,
+declared physical maps, epilogues and output conversions remain on the certified compatibility
+front door until the typed equation has explicit facts for them; admitting them while dropping
+those contracts would be a miscompile, not migration progress.
 
 Tensor contraction uses that same semantic operator rather than reconstructing `init`, `combine`
 and a fold body in `contract-lower`. The single contraction-facts derivation now owns its canonical

--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -322,21 +322,25 @@ constructing the former `SoacContract` record. Ordinary scalar `raster.par/contr
 enters this equation directly; the operation is intentionally not a matmul node, so scientific
 contractions, batched reductions and attention-derived reductions share the same semantic
 vocabulary. Until the tensorization route consumes TypedSOAC itself, one shared mechanical
-component projection supplies host materialization and the verified facts carried by a
-`SegContract` schedule view. Schedule legality and GPU routing consume those components directly;
-only host materialization and compatibility leaves request a generated surface spelling, and no
-walked source form is reparsed. Staged quantization, decode lambdas,
+component projection supplies host materialization and target routing. Ordinary typed contractions
+lower to a canonical `SegRed` whose `ReductionSchedule` records the hardware candidate families,
+workgroup search space and numerical constraints; the validated TypedSOAC equation remains attached
+to its `ProgramEquation`. GPU routing derives its transient verified contraction facts from that
+equation and never reparses the walked source form. Only host materialization and compatibility
+leaves request a generated surface spelling. Staged quantization, decode lambdas,
 declared physical maps, epilogues and output conversions remain on the certified compatibility
-front door until the typed equation has explicit facts for them; admitting them while dropping
-those contracts would be a miscompile, not migration progress.
+front door, and may still use `SegContract`, until the typed equation has explicit facts for them;
+admitting them while dropping those contracts would be a miscompile, not migration progress.
 
 Tensor contraction uses that same semantic operator rather than reconstructing `init`, `combine`
 and a fold body in `contract-lower`. The single contraction-facts derivation now owns its canonical
 one-component `ProductReduction`, normalized reduced coordinate and flattened semantic body;
-`SegContract`, generic `SegRed` fallback and peak routing consume those facts unchanged. Free axes,
+ordinary `SegRed` scheduling and peak routing consume those facts unchanged. The compatibility
+`SegContract` projection is now limited to contractions that are not yet in the typed subset. Free axes,
 operand axis maps, decode/storage precision, epilogues and staged accumulator structure remain
-orthogonal contraction facts and schedule choices. This is the semantic bridge toward representing
-contraction as an ordinary segmented TypedSOAC reduction, not a new hard-coded GEMM algebra.
+orthogonal contraction facts and schedule choices. Contraction is therefore an ordinary segmented
+TypedSOAC reduction, not a new hard-coded GEMM algebra; matrix, register-tiled and portable kernels
+are competing schedules for that algebra.
 
 Indexed storage movement remains a separate generic operation. Allocation-free `gather-blocks!`
 and `scatter-blocks!` move contiguous typed blocks between dense staging and routed resident

--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -322,8 +322,10 @@ constructing the former `SoacContract` record. Ordinary scalar `raster.par/contr
 enters this equation directly; the operation is intentionally not a matmul node, so scientific
 contractions, batched reductions and attention-derived reductions share the same semantic
 vocabulary. Until the tensorization route consumes TypedSOAC itself, one shared mechanical
-projection supplies both host materialization and a `SegContract` schedule view. The GPU emitter
-reuses that scheduled view rather than re-reading source. Staged quantization, decode lambdas,
+component projection supplies host materialization and the verified facts carried by a
+`SegContract` schedule view. Schedule legality and GPU routing consume those components directly;
+only host materialization and compatibility leaves request a generated surface spelling, and no
+walked source form is reparsed. Staged quantization, decode lambdas,
 declared physical maps, epilogues and output conversions remain on the certified compatibility
 front door until the typed equation has explicit facts for them; admitting them while dropping
 those contracts would be a miscompile, not migration progress.

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -452,7 +452,9 @@
                   _ (when-not bound-sc (swap! stats update :segop-relowered (fnil inc 0)))
                   r (ensure-contraction-marker-expressible!
                      (croute/route-contraction
-                      form :dtype dtype
+                      ;; A scheduled equation routes from its verified facts. The source form is
+                      ;; only the host expression being replaced and is not semantic input again.
+                      (when-not bound-sc form) :dtype dtype
                       :facts (:facts bound-sc)
                       :operation-id (:id bound-sc)
                       ;; The resolved, feasibility-checked schedule is the single source of tile

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -10,6 +10,8 @@
   (:require [clojure.set :as set]
             [raster.compiler.ir.par :as par]
             [raster.compiler.ir.soac]
+            [raster.compiler.ir.soac-dialect :as soac-dialect]
+            [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
@@ -20,6 +22,7 @@
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.passes.parallel.soac-lower]
+            [raster.compiler.passes.parallel.typed-soac-projection :as typed-projection]
             [raster.compiler.backend.gpu.segop-opencl :as segop-cl]
             [raster.compiler.passes.parallel.contract-route :as croute]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-fuse :as swr-fuse]
@@ -112,6 +115,11 @@
    This is the seam that makes the SegOp boundary REAL instead of nominal. `segop-lower` lowered
    every par form with the real target device. The equation is consumed here; re-lowering remains
    a counted compatibility path for callers that invoke opencl-pass directly."
+  nil)
+
+(def ^:dynamic *bound-algorithm*
+  "The validated TypedSOAC program associated with `*bound-segops*`. Target scheduling reads the
+   algorithm rather than recovering semantic facts from the host expression being replaced."
   nil)
 
 (defn- take-bound-segop
@@ -444,19 +452,48 @@
                   ;; pass the REAL descriptor: route-contraction fed `(or desc {})` into
                   ;; derive-gemm-tile, so the "hardware-derived" tile was derived from an empty map
                   ;; — Arc constants on every device. device-id is already in scope here.
-                  ;; CONSUME the SegContract segop-lower recorded (its facts were derived and
-                  ;; verified once, at the boundary) — the same take-bound-segop seam map/reduce
-                  ;; use. Without one (door C, no pass run) route from the form and count it.
-                  bound-sc (take-bound-segop stats :segcontract
-                                             #(instance? raster.compiler.ir.segop.SegContract %))
-                  _ (when-not bound-sc (swap! stats update :segop-relowered (fnil inc 0)))
+                  ;; CONSUME the contraction-specialized SegRed recorded by typed lowering. Its
+                  ;; algorithm remains attached to the ParallelProgram equation, so routing can
+                  ;; derive verified facts without hiding them in a second operation record.
+                  ;; SegContract remains only for the compatibility front door; without either
+                  ;; scheduled operation (door C), route from the form and count it.
+                  bound-sr (take-bound-segop
+                            stats :segred-contraction
+                            #(and (instance? raster.compiler.ir.segop.SegRed %)
+                                  (= :contraction (:phase %))
+                                  (= :hardware-contraction-candidates
+                                     (get-in % [:schedule :strategy]))))
+                  bound-sc (when-not bound-sr
+                             (take-bound-segop
+                              stats :segcontract
+                              #(instance? raster.compiler.ir.segop.SegContract %)))
+                  bound-operation (or bound-sr bound-sc)
+                  typed-facts
+                  (when bound-sr
+                    (let [algorithm (or *bound-algorithm*
+                                        (throw (ex-info
+                                                "typed contraction SegRed lacks its algorithm"
+                                                {:reason :typed-contraction-algorithm
+                                                 :operation (:id bound-sr)})))
+                          equation (or (some #(when (= (:id bound-sr) (second %)) %)
+                                             (soac-dialect/equations algorithm))
+                                       (throw (ex-info
+                                               "typed contraction algorithm lacks its equation"
+                                               {:reason :typed-contraction-equation
+                                                :operation (:id bound-sr)})))]
+                      (contraction-facts/from-components
+                       (typed-projection/segmented-reduce-contract-components
+                        algorithm equation))))
+                  verified-facts (or typed-facts (:facts bound-sc))
+                  _ (when-not bound-operation
+                      (swap! stats update :segop-relowered (fnil inc 0)))
                   r (ensure-contraction-marker-expressible!
                      (croute/route-contraction
                       ;; A scheduled equation routes from its verified facts. The source form is
                       ;; only the host expression being replaced and is not semantic input again.
-                      (when-not bound-sc form) :dtype dtype
-                      :facts (:facts bound-sc)
-                      :operation-id (:id bound-sc)
+                      (when-not bound-operation form) :dtype dtype
+                      :facts verified-facts
+                      :operation-id (:id bound-operation)
                       ;; The resolved, feasibility-checked schedule is the single source of tile
                       ;; geometry.  Previously this option reached opencl-pass but contractions
                       ;; ignored it and re-derived a default, so a pinned/autotuned :tile changed
@@ -657,6 +694,10 @@
                                                        (binding [*bound-segops*
                                                                  (when parallel-program
                                                                    (parallel-program/operations-for-binding
+                                                                    parallel-program sym expr))
+                                                                 *bound-algorithm*
+                                                                 (when parallel-program
+                                                                   (parallel-program/algorithm-for-binding
                                                                     parallel-program sym expr))]
                                                          (transform expr)))]))
                                             pairs))
@@ -664,6 +705,10 @@
                                    (binding [*bound-segops*
                                              (when parallel-program
                                                (parallel-program/operations-for-source
+                                                parallel-program expr))
+                                             *bound-algorithm*
+                                             (when parallel-program
+                                               (parallel-program/algorithm-for-source
                                                 parallel-program expr))]
                                      (transform expr)))
                                  body-exprs)]

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -294,9 +294,10 @@
         (when (and parallel-program
                    (= :typed-soac (get-in parallel-program [:provenance :source-dialect])))
           (let [operations (mapcat :operations (:equations parallel-program))
-                arrays (set (mapcat #(concat (or (:inputs %) #{}) (or (:outputs %) #{}))
+                arrays (set (mapcat #(concat (segop/operation-inputs %)
+                                             (segop/operation-outputs %))
                                     operations))
-                scalars (set (mapcat #(or (:scalars %) #{}) operations))
+                scalars (set (mapcat segop/operation-scalars operations))
                 overlap (set/intersection arrays scalars)]
             (when (seq overlap)
               (throw (ex-info "scheduled values have contradictory buffer and scalar ABI roles"

--- a/src/raster/compiler/ir/contraction_facts.clj
+++ b/src/raster/compiler/ir/contraction_facts.clj
@@ -11,9 +11,9 @@
        body — so an extra factor was silently dropped.
 
    Patching each instance leaves the shape intact. This closes it structurally: there is exactly
-   ONE producer of facts, its only input is the FORM, and a checker takes facts — so there is no
-   argument to pass inconsistently. A checker that wants the contract axes cannot be handed a
-   different set; it reads `:contract-axes`, which came from the form's own declaration slot.
+   ONE verified facts constructor, and checkers take its tagged result — so there is no collection
+   of independently derived gate arguments to pass inconsistently. Surface source and validated
+   TypedSOAC equations both enter that constructor through explicit semantic components.
 
    DECLARATIONS ARE EVIDENCE, NOT FACTS. A form may declare operand axis-maps (`:maps`), which is
    what lets a merged/batched operand be understood at all — a derived map cannot guess grouping.
@@ -121,20 +121,33 @@
                        :sym sym :declared (am/index-expr declared) :actual idx})))
     declared))
 
-(defn contraction-facts
-  "Derive the checkable facts of `(raster.par/contract out free-axes contract-axes body & opts)`.
-   The ONLY input is the form (plus the intended element dtype, which is a compilation choice
-   rather than a property of the form). Throws on a malformed form or an unverifiable declaration."
-  [form & {:keys [dtype] :or {dtype :double}}]
-  (when-not (and (seq? form) (= 'raster.par/contract (first form)))
-    (throw (ex-info "contraction-facts: not a par/contract form" {:reason :not-a-contract-form
-                                                                  :form form})))
-  (let [[_ out free-axes contract-axes body] form
-        opts (form-opts form)
+(defn surface-form
+  "Spell contraction components in the temporary `raster.par/contract` target vocabulary."
+  [{:keys [out free-axes contract-axes body opts metadata]}]
+  (with-meta
+    (apply list
+           (concat ['raster.par/contract out free-axes contract-axes body]
+                   (mapcat identity opts)))
+    metadata))
+
+(defn from-components
+  "Construct the sole verified contraction-facts value from explicit semantic components.
+
+   `form` is optional provenance/compatibility spelling. When absent it is generated mechanically;
+   no fact is inferred by parsing that spelling. Throws on malformed axes or an unverifiable
+   physical layout declaration."
+  [{:keys [out free-axes contract-axes body opts dtype form metadata]
+    :or {opts {} dtype :double}}]
+  (let [form (or form (surface-form {:out out :free-axes free-axes
+                                     :contract-axes contract-axes :body body
+                                     :opts opts :metadata metadata}))
+        _ (when-not (symbol? out)
+            (throw (ex-info "contract output must be a symbol" {:reason :malformed-output
+                                                                 :out out})))
         _ (when-not (vector? free-axes)
-            (throw (ex-info "contract form: free-axes must be a vector" {:reason :malformed-free-axes})))
+            (throw (ex-info "contract free-axes must be a vector" {:reason :malformed-free-axes})))
         _ (when-not (vector? contract-axes)
-            (throw (ex-info "contract form: contract-axes must be a vector" {:reason :malformed-contract-axes})))
+            (throw (ex-info "contract contract-axes must be a vector" {:reason :malformed-contract-axes})))
         declared (:maps opts)
         ;; `:decode` is the per-operand LOAD-LAMBDA, an expression in `x` (the raw load). This is
         ;; where a zero-point subtraction belongs — exact on the load path, needing no correction
@@ -174,6 +187,19 @@
       :dims dims
       :opts opts}
      normalized)))
+
+(defn contraction-facts
+  "Derive verified facts from `(raster.par/contract out free-axes contract-axes body & opts)`.
+
+   Source parsing ends here. Typed compiler paths call `from-components` instead, so schedule
+   analysis never has to reconstruct or reparse source syntax."
+  [form & {:keys [dtype] :or {dtype :double}}]
+  (when-not (and (seq? form) (= 'raster.par/contract (first form)))
+    (throw (ex-info "contraction-facts: not a par/contract form" {:reason :not-a-contract-form
+                                                                  :form form})))
+  (let [[_ out free-axes contract-axes body] form]
+    (from-components {:out out :free-axes free-axes :contract-axes contract-axes
+                      :body body :opts (form-opts form) :dtype dtype :form form})))
 
 (defn scalar-reduction-view
   "Project the canonical one-component ProductReduction into the contraction facts needed by

--- a/src/raster/compiler/ir/segop.clj
+++ b/src/raster/compiler/ir/segop.clj
@@ -12,8 +12,10 @@
 
   Each SegOp carries a KernelGrid with pre-computed launch config
   based on raster.runtime.hardware device properties."
-  (:require [raster.runtime.hardware :as hw]
+  (:require [clojure.set :as set]
+            [raster.runtime.hardware :as hw]
             [raster.compiler.core.hardware :as chw]
+            [raster.compiler.core.util :as util]
             [raster.compiler.ir.reduction :as reduction]))
 
 ;; ================================================================
@@ -112,6 +114,38 @@
   [x]
   (or (segop? x)
       (and x (= "raster.compiler.ir.segop.SegContract" (.getName (class x))))))
+
+(defn operation-inputs
+  "Physical tensor inputs of a scheduled operation, including a SegContract schedule view."
+  [operation]
+  (if (instance? SegContract operation)
+    (let [facts (:facts operation)]
+      (disj (set (map :sym (:operands facts))) (:out facts)))
+    (or (:inputs operation) #{})))
+
+(defn operation-outputs
+  "Physical tensor outputs of a scheduled operation, including a SegContract schedule view."
+  [operation]
+  (if (instance? SegContract operation)
+    #{(get-in operation [:facts :out])}
+    (or (:outputs operation) #{})))
+
+(defn operation-scalars
+  "Scalar shape operands of a scheduled operation.
+
+   A SegContract deliberately stores only verified contraction facts, so its scalar ABI is a
+   checked projection of axis bounds rather than a duplicate record field."
+  [operation]
+  (if (instance? SegContract operation)
+    (let [facts (:facts operation)
+          arrays (set/union (operation-inputs operation) (operation-outputs operation))
+          axes (concat (:free-axes facts) (:contract-axes facts))
+          axis-indices (set (map first axes))
+          expressions (conj (mapv second axes) (:body facts))]
+      (set/difference
+       (reduce set/union #{} (map util/free-syms expressions))
+       arrays axis-indices))
+    (or (:scalars operation) #{})))
 
 (defn segop-grid
   "Get the KernelGrid from a SegOp."

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -634,9 +634,9 @@
         {:keys [kind]} (operation-parts equation)
         storage (result-storage program-facts equation-id)]
     (when storage
-      (when-not (contains? #{'map 'scatter} kind)
+      (when-not (contains? #{'map 'scatter 'segmented-reduce} kind)
         (fail! :typed-soac-result-storage-operation
-               "physical result storage is valid only for map/scatter equations"
+               "physical result storage is valid only for map/scatter/segmented-reduce equations"
                {:equation equation-id :operation kind :storage storage}))
       (when-not (and (vector? storage)
                      (= (count results) (count storage))
@@ -646,7 +646,7 @@
                                    (contains? #{:buffer :effect} (:host-return %)))
                              storage))
         (fail! :typed-soac-result-storage
-               "result storage must align every map result with a typed destination contract"
+               "result storage must align every functional result with a typed destination contract"
                {:equation equation-id :results results :storage storage}))
       (let [destinations (mapv :destination storage)
             aliases (get-in program-facts [:equations equation-id :aliases])]

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -249,6 +249,10 @@
 (defn route-contraction
   "Route a contraction form through verified facts, an applied hardware schedule and a target leaf.
 
+   `contract-form` may be nil when verified `:facts` are supplied. In that case any temporary
+   source-shaped spelling needed by a compatibility leaf is generated from those facts; routing
+   and legality never inspect the walked source form.
+
    Canonical f16 products first become a target-neutral KernelBody and are then lowered by the
    OpenCL DPAS backend.  Unsupported shapes retain the portable register-tiled route.  Byte/int8
    products use the quant leaves (dp4a for :nt, widening for :nn) until those instruction families
@@ -256,9 +260,15 @@
    not a buffer-ownership or graph-composition concern."
   [contract-form & {:keys [dtype prefer-peak? desc tile epilogue stages operands facts operation-id]
                     :or {dtype :half prefer-peak? false}}]
-  (let [out-sym (second contract-form)
-        free-axes (nth contract-form 2)
-        contract-axes (nth contract-form 3)
+  (let [contract-facts (or facts (cf/contraction-facts contract-form :dtype dtype))
+        contract-form (or contract-form (:form contract-facts))
+        _ (when-not (and (cf/facts? contract-facts) contract-form)
+            (throw (ex-info "contraction routing requires verified facts and a target spelling"
+                            {:reason :contraction-route-input
+                             :facts contract-facts :form contract-form})))
+        out-sym (:out contract-facts)
+        free-axes (:free-axes contract-facts)
+        contract-axes (:contract-axes contract-facts)
         n-free (count free-axes)
         n-contract (count contract-axes)
         ;; Number of output elements = product of the free-axis bounds. Bounds may be SYMBOLS
@@ -271,13 +281,12 @@
         ;; memoized so the cond's test arm doesn't regenerate the kernel
         ;; a fused contraction carries its epilogue in the form's trailing opts (par-fusion's
         ;; fuse-contract-map puts it there); an explicit :epilogue kwarg overrides.
-        form-opts (apply hash-map (drop 5 contract-form))
-        contract-facts (or facts (cf/contraction-facts contract-form :dtype dtype))
-        epilogue (or epilogue (:epilogue form-opts))
-        stages (or stages (:stages (apply hash-map (drop 5 contract-form))))
+        form-opts (:opts contract-facts)
+        epilogue (or epilogue (:epilogue contract-facts))
+        stages (or stages (:stages contract-facts))
         ;; declared operand axis-maps, needed to tensorize a staged inner stage (the gate VERIFIES
         ;; them against the body rather than trusting them)
-        operands (or operands (:operands (apply hash-map (drop 5 contract-form))))
+        operands (or operands (:operands form-opts))
         tensorize-plan (memoize #(route-2free-1contract contract-form out-sym dtype desc tile
                                                         epilogue contract-facts operation-id))]
     ;; Every descriptor is validated against the kernel it describes before it leaves this fn. The

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -344,9 +344,9 @@
           ;; partial arrays and aliased destinations—must have an AbstractValue contract.
           _ (doseq [equation equations
                     operation (:operations equation)
-                    id (set/union (or (:inputs operation) #{})
-                                  (or (:outputs operation) #{})
-                                  (or (:scalars operation) #{}))]
+                    id (set/union (segop/operation-inputs operation)
+                                  (segop/operation-outputs operation)
+                                  (segop/operation-scalars operation))]
               (when-not (contains? scheduled-values id)
                 (throw (ex-info "scheduled SegOp references an undeclared value"
                                 {:reason :segop-unknown-scheduled-value
@@ -365,7 +365,8 @@
                                     [:equations algorithm-id :aliases])
                     expected (set (map #(get aliases % %) (:results equation)))
                     scheduled-outputs (apply set/union #{}
-                                             (map :outputs (:operations equation)))]
+                                             (map segop/operation-outputs
+                                                  (:operations equation)))]
                 (when-not (set/subset? expected scheduled-outputs)
                   (throw (ex-info "scheduled SegOp does not realize the typed output boundary"
                                   {:reason :segop-output-boundary

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -16,6 +16,7 @@
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.hardware :as hardware]
             [raster.compiler.core.util :as util]
+            [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.ir.kernel-graph :as kernel-graph]
             [raster.compiler.ir.kernel-launch :as kernel-launch]
             [raster.compiler.ir.par :as par]
@@ -24,7 +25,8 @@
             [raster.compiler.ir.soac-dialect :as soac-dialect]
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.segop :as segop]
-            [raster.compiler.passes.parallel.execution-plan :as execution-plan]))
+            [raster.compiler.passes.parallel.execution-plan :as execution-plan]
+            [raster.compiler.passes.parallel.typed-soac-projection :as projection]))
 
 (declare lower-reduce)
 (declare lower-map)
@@ -284,12 +286,15 @@
                        [parameter (list 'clojure.core/aget array dense-coordinate)])
                      elements arrays))
           step-results (mapv #(util/subst-syms substitutions %) body-results)
+          facts (soac-dialect/facts program)
+          physical-results (soac-dialect/physical-results facts equation)
           components
           (mapv (fn [ordinal accumulator neutral component-dtype result]
                   {:id (keyword (str "component-" ordinal))
                    :accumulator accumulator :neutral neutral :dtype component-dtype
                    :result result})
-                (range) accumulators (:identities attributes) (:dtypes attributes) results)
+                (range) accumulators (:identities attributes) (:dtypes attributes)
+                physical-results)
           operator (reduction/make
                     {:components components
                      :index reduced-index
@@ -297,7 +302,6 @@
                      :algebra {:components (:algebra attributes)}
                      :attributes {:source :typed-soac :equation equation-id
                                   :segmented true}})
-          facts (soac-dialect/facts program)
           values (:values facts)
           stable-captures (set (get-in attributes [:attributes :stable-array-captures]))
           inputs (set/union (set arrays) stable-captures)
@@ -318,9 +322,18 @@
                                 {:reason :typed-soac-segmented-reduce-input
                                  :equation equation-id :input input
                                  :value (get values input)}))))]
-      [(segop/->SegRed equation-id space
-                       (segop/->SegLevel :thread :virtual)
-                       operator nil inputs (set results) scalars nil :segmented nil output-dtype)])))
+      (if (= :raster.par/contract
+             (get-in attributes [:attributes :source-operation]))
+        ;; The equation remains the sole semantic representation.  SegContract is a target
+        ;; scheduling view carrying facts derived from the shared mechanical projection; it lets
+        ;; DPAS/register-tiled leaves consume the typed front door without re-reading source.
+        (let [form (projection/segmented-reduce-contract-form program equation)
+              facts (contraction-facts/contraction-facts form :dtype output-dtype)]
+          [(segop/->SegContract equation-id facts output-dtype device-id)])
+        [(segop/->SegRed equation-id space
+                         (segop/->SegLevel :thread :virtual)
+                         operator nil inputs (set physical-results) scalars nil :segmented nil
+                         output-dtype)]))))
 
 (defn typed-scan-program?
   "Whether a validated one-equation TypedSOAC program is a certified scan."

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -16,7 +16,6 @@
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.hardware :as hardware]
             [raster.compiler.core.util :as util]
-            [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.ir.kernel-graph :as kernel-graph]
             [raster.compiler.ir.kernel-launch :as kernel-launch]
             [raster.compiler.ir.par :as par]
@@ -25,13 +24,13 @@
             [raster.compiler.ir.soac-dialect :as soac-dialect]
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.segop :as segop]
-            [raster.compiler.passes.parallel.execution-plan :as execution-plan]
-            [raster.compiler.passes.parallel.typed-soac-projection :as projection]))
+            [raster.compiler.passes.parallel.execution-plan :as execution-plan]))
 
 (declare lower-reduce)
 (declare lower-map)
 (declare lower-scan-description)
 (declare scan-kernel-graph-description)
+(declare phase-grid)
 
 (defn- materialize-region-locals
   [locals body]
@@ -316,25 +315,36 @@
                  (conj (mapv (fn [[index extent]] {:name index :bound extent}) segment-axes)
                        {:name reduced-index :bound reduced-extent}))
           output-dtype (or (first (:dtypes attributes)) dtype :double)
+          contraction? (= :raster.par/contract
+                          (get-in attributes [:attributes :source-operation]))
+          planned-grid (when contraction?
+                         (phase-grid :reduce device-id reduced-extent output-dtype))
+          contraction-schedule
+          (when contraction?
+            (let [workgroup-size (:block-size planned-grid)
+                  candidates (filterv #(<= % workgroup-size) [32 64 128 256 512 1024])]
+              (reduction/schedule
+               {:strategy :hardware-contraction-candidates
+                :workgroup-size workgroup-size
+                :stages [:segment-space :reduction :target-lowering]
+                :tuning-space {:families [:matrix :register-tiled :portable]
+                               :workgroup-size candidates}
+                :numerical-mode (select-keys (first (get-in operator [:algebra :components]))
+                                             [:order :reassociation :overflow])
+                :attributes {:source-operation :raster.par/contract
+                             :device device-id
+                             :selection :target-lowering}})))
           _ (doseq [input inputs]
               (when-not (= :tensor (:kind (get values input)))
                 (throw (ex-info "segmented reduction tensor input lacks an AbstractValue"
                                 {:reason :typed-soac-segmented-reduce-input
                                  :equation equation-id :input input
                                  :value (get values input)}))))]
-      (if (= :raster.par/contract
-             (get-in attributes [:attributes :source-operation]))
-        ;; The equation remains the sole semantic representation.  SegContract is a target
-        ;; scheduling view carrying facts derived from the shared mechanical projection; it lets
-        ;; DPAS/register-tiled leaves consume the typed front door without re-reading source.
-        (let [components (projection/segmented-reduce-contract-components program equation)
-              facts (contraction-facts/from-components
-                     (assoc components :dtype output-dtype))]
-          [(segop/->SegContract equation-id facts output-dtype device-id)])
-        [(segop/->SegRed equation-id space
-                         (segop/->SegLevel :thread :virtual)
-                         operator nil inputs (set physical-results) scalars nil :segmented nil
-                         output-dtype)]))))
+      [(segop/->SegRed equation-id space
+                       (segop/->SegLevel :thread :virtual)
+                       operator nil inputs (set physical-results) scalars planned-grid
+                       (if contraction? :contraction :segmented)
+                       contraction-schedule output-dtype)])))
 
 (defn typed-scan-program?
   "Whether a validated one-equation TypedSOAC program is a certified scan."

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -327,8 +327,9 @@
         ;; The equation remains the sole semantic representation.  SegContract is a target
         ;; scheduling view carrying facts derived from the shared mechanical projection; it lets
         ;; DPAS/register-tiled leaves consume the typed front door without re-reading source.
-        (let [form (projection/segmented-reduce-contract-form program equation)
-              facts (contraction-facts/contraction-facts form :dtype output-dtype)]
+        (let [components (projection/segmented-reduce-contract-components program equation)
+              facts (contraction-facts/from-components
+                     (assoc components :dtype output-dtype))]
           [(segop/->SegContract equation-id facts output-dtype device-id)])
         [(segop/->SegRed equation-id space
                          (segop/->SegLevel :thread :virtual)

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -12,6 +12,7 @@
             [raster.compiler.core.types :as types]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.ir.form :as form]
             [raster.compiler.ir.par :as par]
             [raster.compiler.ir.reduction :as reduction]
@@ -234,7 +235,7 @@
                io)))))
 
 (defn- operation-description
-  [id symbol expression]
+  [id symbol expression default-dtype]
   (cond
     (par/par-map-pure-form? expression)
     (let [{:keys [idx bound cast body elem-type]} (par/extract-par-map-pure-info expression)
@@ -284,6 +285,41 @@
                          :result symbol :index idx :step-result body
                          :attributes {:source :raster.par/reduce}})}
              io))
+
+    (and (seq? expression) (= 'raster.par/contract (first expression)))
+    (let [facts (contraction-facts/contraction-facts
+                 expression :dtype (or (:raster.type/elem-type (meta expression))
+                                       default-dtype :double))
+          {:keys [free-axes contract-axes out opts]} facts]
+      ;; The first direct slice is the ordinary scalar segmented-reduction algebra. Staged
+      ;; quantization and fused epilogues carry additional schedule/store contracts and must not
+      ;; be admitted by dropping those facts.
+      (when (and (seq free-axes) (seq contract-axes)
+                 ;; Decode lambdas, declared physical maps, staged accumulators, epilogues and
+                 ;; output conversions are not scalar fold syntax.  Keep them on the certified
+                 ;; contraction route until TypedSOAC represents those facts explicitly.
+                 (empty? (apply dissoc opts [:init :combine :algebra]))
+                 (reduction/scalar? (:reduction facts)))
+        (let [product (:reduction facts)
+              component (first (:components product))
+              step-result (first (:results (reduction/fold-region product)))
+              arrays (set (map :sym (:operands facts)))
+              axis-symbols (set (concat (map first free-axes) [(:index product)]))
+              bound-symbols (reduce set/union #{}
+                                    (map util/free-syms
+                                         (concat (map second free-axes)
+                                                 (map second contract-axes))))
+              scalars (set/difference
+                       (set/union bound-symbols (util/free-syms step-result))
+                       arrays axis-symbols #{(:accumulator component) out})]
+          {:kind :segmented-reduce :id id :sym symbol
+           :segment-axes free-axes
+           :reduce-index (:index product)
+           :reduce-extent (second (:flat-contract-axis facts))
+           :results [(effect-result-id id 0)]
+           :product product :inputs arrays :outputs #{out} :scalars scalars
+           :effect-only? true :host-binding symbol
+           :result-storage [{:destination out :access :write :host-return :effect}]})))
 
     (or (par/par-scan-form? expression)
         (par/par-scan-exclusive-form? expression))
@@ -392,9 +428,9 @@
     (first (descriptor/call-args expression))))
 
 (defn- source-descriptions
-  [pairs]
+  [pairs default-dtype]
   (mapv (fn [id [symbol expression]]
-          (or (operation-description id symbol expression)
+          (or (operation-description id symbol expression default-dtype)
               (if (par/par-form? expression)
                 {:kind :unsupported :id id :sym symbol :expr expression}
                 {:kind :scalar :id id :sym symbol :expr expression})))
@@ -449,7 +485,7 @@
 (defn- supported-descriptions?
   [descriptions]
   (let [physical-outputs (reduce set/union #{}
-                                 (map #(if (contains? #{:map :scatter :reduce :scan} (:kind %))
+                                 (map #(if (contains? #{:map :scatter :reduce :segmented-reduce :scan} (:kind %))
                                          (:outputs %) #{})
                                       descriptions))]
     (every? (fn [description]
@@ -465,6 +501,8 @@
                               (every? (comp symbol? :destination)
                                       (:result-storage description)))
                 :reduce true
+                :segmented-reduce (and (seq (:segment-axes description))
+                                       (symbol? (get-in description [:result-storage 0 :destination])))
                 :scan (symbol? (:primary-out description))
                 false))
             descriptions)))
@@ -574,6 +612,29 @@
                  (vec (concat [(:accumulator component)] elements capture-parameters))
                  results)))))
 
+(defn- segmented-reduce-equation
+  [{:keys [id segment-axes reduce-index reduce-extent inputs scalars product results]}]
+  (let [component (first (:components product))
+        stable (vec (sort-by pr-str inputs))
+        captures (vec (sort-by pr-str (distinct (concat stable scalars))))
+        capture-parameters (capture-symbols (count captures))
+        step-results (mapv #(util/subst-syms (zipmap captures capture-parameters) %)
+                           (:results (reduction/fold-region product)))]
+    (list '= id results
+          (list 'segmented-reduce
+                {:segment-axes segment-axes
+                 :index reduce-index :extent reduce-extent
+                 :attributes {:stable-array-captures stable
+                              :source-operation :raster.par/contract}
+                 :accumulators [(:accumulator component)]
+                 :identities [(:neutral component)]
+                 :dtypes [(:dtype component)]
+                 :algebra [(:algebra product)]}
+                [] captures
+                (dialect/lambda-form
+                 (vec (concat [(:accumulator component)] capture-parameters))
+                 step-results)))))
+
 (defn- scan-equation
   [{:keys [id sym index extent mode inputs scalars primary-out accumulator identity dtype body]}]
   (let [[pointwise stable] ((juxt filter remove) #(pointwise-input? [body] % index) inputs)
@@ -626,16 +687,18 @@
 
 (defn- terminal-results
   [descriptions body]
-  (let [operations (filter #(contains? #{:map :scatter :reduce :scan} (:kind %)) descriptions)
+  (let [operations (filter #(contains? #{:map :scatter :reduce :segmented-reduce :scan} (:kind %)) descriptions)
         operation-definitions (set (mapcat #(case (:kind %)
                                               (:map :scatter) (:results %)
                                               :scan [(:sym %)]
+                                              :segmented-reduce (:results %)
                                               (:outputs %))
                                            operations))
         terminal-operation-definitions
         (set (mapcat #(case (:kind %)
                         (:map :scatter) (if (:effect-only? %) [] (:results %))
                         :scan [(:sym %)]
+                        :segmented-reduce (if (:effect-only? %) [] (:results %))
                         (:outputs %))
                      operations))
         scalar-definitions (set (keep #(when (= :scalar (:kind %)) (:sym %)) descriptions))
@@ -654,9 +717,9 @@
   (let [by-symbol (into {} (keep #(when (= :scalar (:kind %)) [(:sym %) %])) descriptions)
         roots (set (concat outputs
                            (mapcat (fn [equation]
-                                     (cond-> (dialect/operation-inputs equation)
-                                       (dialect/value-id? (dialect/operation-extent equation))
-                                       (conj (dialect/operation-extent equation))))
+                                     (into (dialect/operation-inputs equation)
+                                           (filter dialect/value-id?
+                                                   (dialect/operation-extents equation))))
                                    operation-equations)))]
     (loop [needed (set/intersection roots (set (keys by-symbol)))]
       (let [dependencies (set (mapcat #(util/free-syms (:expr (get by-symbol %))) needed))
@@ -681,14 +744,16 @@
   (let [[_ _ results] equation
         {:keys [kind attributes arrays captures]} (dialect/operation-parts equation)
         extent (:extent attributes)
+        dimension-ids (set (filter dialect/value-id? (dialect/operation-extents equation)))
         stable (set (get-in attributes [:attributes :stable-array-captures]))
         result-dtypes (case kind
                         scalar (:dtypes attributes)
                         reduce (:dtypes attributes)
+                        segmented-reduce (:dtypes attributes)
                         scan (:dtypes attributes)
                         (map scatter) (map #(value-dtype % default-dtype array-types) results))]
     (merge
-     (if (and extent (dialect/value-id? extent)) {extent (tensor-value :long [])} {})
+     (into {} (map (fn [id] [id (tensor-value :long [])])) dimension-ids)
      (into {} (map (fn [id] [id (tensor-value (value-dtype id default-dtype array-types)
                                               (dialect/extent-shape extent))]) arrays))
      (if (= 'scalar kind)
@@ -702,7 +767,9 @@
                                                (tensor-value declared [])))]
                           [id value]))) captures)
        (into {} (map (fn [id]
-                       [id (or (get known-values id)
+                       [id (or (when (contains? dimension-ids id)
+                                 (tensor-value :long []))
+                               (get known-values id)
                                (if (or (contains? stable id)
                                        (contains? array-types id)
                                        (and (symbol? id)
@@ -717,6 +784,8 @@
                      [id (tensor-value (or result-dtype default-dtype :double)
                                        (case kind
                                          (scalar reduce) []
+                                         segmented-reduce
+                                         (dialect/segmented-reduce-result-shape attributes)
                                          scan (dialect/scan-result-shape attributes)
                                          scatter [(list 'unknown-dimension id)]
                                          (dialect/extent-shape extent)))])
@@ -749,15 +818,16 @@
   (when (and (seq? source) (contains? #{'let 'let*} (first source)))
     (let [[_ bindings & body] source
           pairs (vec (partition 2 bindings))
-          descriptions (normalize-extents (source-descriptions pairs))]
+          descriptions (normalize-extents (source-descriptions pairs dtype))]
       (when (and (even? (count bindings))
                  (seq descriptions)
                  (supported-descriptions? descriptions))
         (let [operation-descriptions
-              (filterv #(contains? #{:map :scatter :reduce :scan} (:kind %)) descriptions)
+              (filterv #(contains? #{:map :scatter :reduce :segmented-reduce :scan} (:kind %)) descriptions)
               operation-equations (mapv #(case (:kind %) :map (map-equation %)
                                                :scatter (scatter-equation %)
                                                :reduce (reduce-equation %)
+                                               :segmented-reduce (segmented-reduce-equation %)
                                                :scan (scan-equation %))
                                         operation-descriptions)
               outputs (terminal-results descriptions body)
@@ -774,13 +844,14 @@
                                   (update :equation-descriptions conj description)
                                   (assoc-in [:scalar-dtypes (:sym description)] result-dtype)))
                             state)
-                          (:map :scatter :reduce :scan)
+                          (:map :scatter :reduce :segmented-reduce :scan)
                           (-> state
                               (update :equations conj
                                       (case (:kind description)
                                         :map (map-equation description)
                                         :scatter (scatter-equation description)
                                         :reduce (reduce-equation description)
+                                        :segmented-reduce (segmented-reduce-equation description)
                                         :scan (scan-equation description)))
                               (update :equation-descriptions conj description))))
                       {:equations [] :equation-descriptions [] :scalar-dtypes {}}
@@ -788,12 +859,12 @@
               equation-info (mapv (fn [equation]
                                     {:results (nth equation 2)
                                      :inputs (dialect/operation-inputs equation)
-                                     :extent (dialect/operation-extent equation)})
+                                     :extents (dialect/operation-extents equation)})
                                   equations)
               definitions (set (mapcat :results equation-info))
-              references (set (mapcat #(cond-> (:inputs %)
-                                         (and (:extent %) (dialect/value-id? (:extent %)))
-                                         (conj (:extent %))) equation-info))
+              references (set (mapcat #(into (:inputs %)
+                                             (filter dialect/value-id? (:extents %)))
+                                      equation-info))
               inputs (vec (sort-by pr-str (set/difference references definitions)))
               logical-result-types
               (into {}

--- a/src/raster/compiler/passes/parallel/typed_soac_projection.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_projection.clj
@@ -1,0 +1,92 @@
+(ns raster.compiler.passes.parallel.typed-soac-projection
+  "Mechanical target projections from validated TypedSOAC equations.
+
+   These functions do not recover semantics from source syntax.  They spell an already validated
+   equation in the temporary surface vocabulary consumed by a target route while that route is
+   migrated to accept the typed equation directly.  Keeping the projection here prevents the
+   execution materializer and SegOp lowering from inventing subtly different forms."
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.util :as util]
+            [raster.compiler.ir.soac-dialect :as dialect]))
+
+(defn- materialize-region
+  [locals body]
+  (if (seq locals)
+    (list 'let*
+          (vec
+           (mapcat (fn [{:keys [id dtype init]}]
+                     (let [tag (dtype/scalar-tag-for-dtype dtype)]
+                       [(with-meta id {:raster.type/tag tag})
+                        (list tag init)]))
+                   locals))
+          body)
+    body))
+
+(defn- flat-coordinate
+  [segment-axes reduced-index reduced-extent]
+  (reduce (fn [coordinate [index extent]]
+            (list 'clojure.core/+ (list 'clojure.core/* coordinate extent) index))
+          0
+          (conj (vec segment-axes) [reduced-index reduced-extent])))
+
+(defn- scalar-fold-parts
+  [attributes expression]
+  (let [accumulator (first (:accumulators attributes))
+        arguments (vec (when (seq? expression) (descriptor/call-args expression)))]
+    ;; `par/contract` spells the fold as (combine accumulator element).  Reversing a merely
+    ;; associative, non-commutative fold here would be a semantic change, so refuse that shape.
+    (when-not (and (seq? expression) (= 2 (count arguments))
+                   (= accumulator (first arguments)))
+      (throw (ex-info "segmented reduction has no ordered scalar contract projection"
+                      {:reason :typed-soac-contract-projection
+                       :accumulator accumulator :expression expression})))
+    {:combine (descriptor/semantic-op expression)
+     :element (second arguments)}))
+
+(defn segmented-reduce-contract-form
+  "Project one validated, scalar `segmented-reduce` equation to `raster.par/contract`.
+
+   This is a compatibility seam for contraction scheduling and host materialization, not a second
+   semantic IR: captures, physical storage, axes, algebra and the scalar region all come from the
+   validated TypedSOAC program."
+  [program equation]
+  (let [program (dialect/validate! program)
+        [_ equation-id results] equation
+        {:keys [kind attributes arrays captures lambda]} (dialect/operation-parts equation)
+        {:keys [locals body-results]} (dialect/lambda-parts lambda)
+        {:keys [accumulators elements capture-parameters]} (dialect/parameter-layout equation)
+        facts (dialect/facts program)
+        storage (dialect/result-storage facts equation-id)
+        physical-results (dialect/physical-results facts equation)
+        _ (when-not (and (= 'segmented-reduce kind)
+                         (= 1 (count results))
+                         (= 1 (count accumulators))
+                         (= 1 (count body-results))
+                         (= 1 (count physical-results))
+                         (= 1 (count storage)))
+            (throw (ex-info "contract projection requires one scalar segmented reduction result"
+                            {:reason :typed-soac-contract-projection
+                             :equation equation-id :kind kind :results results
+                             :physical-results physical-results :storage storage})))
+        coordinate (flat-coordinate (:segment-axes attributes)
+                                    (:index attributes) (:extent attributes))
+        substitutions
+        (into (zipmap capture-parameters captures)
+              (map (fn [parameter array]
+                     [parameter (list 'clojure.core/aget array coordinate)])
+                   elements arrays))
+        locals (mapv #(update % :init (fn [init] (util/subst-syms substitutions init))) locals)
+        folded (materialize-region
+                locals
+                (util/subst-syms substitutions (first body-results)))
+        {:keys [combine element]} (scalar-fold-parts attributes folded)
+        form (list 'raster.par/contract
+                   (first physical-results)
+                   (:segment-axes attributes)
+                   [[(:index attributes) (:extent attributes)]]
+                   element
+                   :init (first (:identities attributes))
+                   :combine combine
+                   :algebra (first (:algebra attributes)))]
+    (with-meta form {:raster.type/elem-type (first (:dtypes attributes))})))

--- a/src/raster/compiler/passes/parallel/typed_soac_projection.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_projection.clj
@@ -8,6 +8,7 @@
   (:require [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
+            [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.ir.soac-dialect :as dialect]))
 
 (defn- materialize-region
@@ -44,12 +45,11 @@
     {:combine (descriptor/semantic-op expression)
      :element (second arguments)}))
 
-(defn segmented-reduce-contract-form
-  "Project one validated, scalar `segmented-reduce` equation to `raster.par/contract`.
+(defn segmented-reduce-contract-components
+  "Project one validated scalar `segmented-reduce` equation to contraction semantic components.
 
-   This is a compatibility seam for contraction scheduling and host materialization, not a second
-   semantic IR: captures, physical storage, axes, algebra and the scalar region all come from the
-   validated TypedSOAC program."
+   This is not a second IR: captures, physical storage, axes, algebra and the scalar region all
+   come from the validated TypedSOAC program."
   [program equation]
   (let [program (dialect/validate! program)
         [_ equation-id results] equation
@@ -81,12 +81,19 @@
                 locals
                 (util/subst-syms substitutions (first body-results)))
         {:keys [combine element]} (scalar-fold-parts attributes folded)
-        form (list 'raster.par/contract
-                   (first physical-results)
-                   (:segment-axes attributes)
-                   [[(:index attributes) (:extent attributes)]]
-                   element
-                   :init (first (:identities attributes))
-                   :combine combine
-                   :algebra (first (:algebra attributes)))]
-    (with-meta form {:raster.type/elem-type (first (:dtypes attributes))})))
+        contraction-dtype (first (:dtypes attributes))]
+    {:out (first physical-results)
+     :free-axes (:segment-axes attributes)
+     :contract-axes [[(:index attributes) (:extent attributes)]]
+     :body element
+     :opts (array-map :init (first (:identities attributes))
+                      :combine combine
+                      :algebra (first (:algebra attributes)))
+     :dtype contraction-dtype
+     :metadata {:raster.type/elem-type contraction-dtype}}))
+
+(defn segmented-reduce-contract-form
+  "Spell a typed scalar segmented reduction in the temporary host/leaf target vocabulary."
+  [program equation]
+  (contraction-facts/surface-form
+   (segmented-reduce-contract-components program equation)))

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -9,6 +9,7 @@
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]
+            [raster.compiler.passes.parallel.typed-soac-projection :as projection]
             [raster.compiler.passes.parallel.typed-soac-resident :as resident]
             [raster.compiler.core.util :as util]))
 
@@ -225,6 +226,16 @@
            :site [:binding result]
            :source source}))
 
+      segmented-reduce
+      (let [host-binding (or (get-in placement-facts [:attributes :host-binding])
+                             (first results))
+            source (projection/segmented-reduce-contract-form program equation)]
+        {:equation-id equation-id
+         :placement placement
+         :pairs [[host-binding source]]
+         :site [:binding host-binding]
+         :source source})
+
       scan
       (let [result (first results)
             mode (:mode attributes)
@@ -342,7 +353,7 @@
                (if resident-reductions?
                  (resident/realize typed-result)
                  [typed-result {:resident-reductions 0 :inlined-scalars 0}])]
-           (if (not-any? #(contains? #{:map :scatter :reduce :scan}
+           (if (not-any? #(contains? #{:map :scatter :reduce :segmented-reduce :scan}
                                      (:kind (fusion/equation-info %)))
                          (dialect/equations typed-result))
              {:declined {:reason :no-certified-parallel-equation

--- a/test/raster/compiler/ir/contraction_facts_test.clj
+++ b/test/raster/compiler/ir/contraction_facts_test.clj
@@ -1,10 +1,10 @@
 (ns raster.compiler.ir.contraction-facts-test
-  "FACTS: the single derivation whose only input is the form. Device-free.
+  "FACTS: one verified derivation from source or typed semantic components. Device-free.
 
-   The property under test is structural, not behavioural: because there is one producer and its
-   only input is the form, a checker cannot be handed a value derived from the thing it is meant
-   to check. That shape is what made two silent miscompiles writable — a stage list validated
-   against axes derived from itself, and a body-replacing leaf that never checked the body."
+   The property under test is structural, not behavioural: every checker receives the tagged
+   result of one constructor, rather than separately derived gate arguments. That old shape made
+   two silent miscompiles writable — a stage list validated against axes derived from itself, and
+   a body-replacing leaf that never checked the body."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.contraction-facts :as cf]
             [raster.compiler.ir.axis-map :as am]
@@ -40,6 +40,26 @@
         (is (= [(:index operator) 128] (:flat-contract-axis f)))
         (is (= (:element (cf/scalar-reduction-view f))
                (second (rest (first (:results (reduction/fold-region operator)))))))))))
+
+(deftest source-and-semantic-components-enter-the-same-facts-constructor
+  (let [source (form :init 1 :combine 'clojure.core/+)
+        parsed (cf/contraction-facts source :dtype :byte)
+        components (cf/from-components
+                    {:out 'out :free-axes '[[i 4] [j 6]]
+                     :contract-axes '[[blk 4] [t 32]] :body body
+                     :opts (array-map :init 1 :combine 'clojure.core/+)
+                     :dtype :byte})]
+    (is (cf/facts? components))
+    (is (= (select-keys parsed [:out :free-axes :contract-axes :body :operands
+                                :roles :dims :opts :dtype])
+           (select-keys components [:out :free-axes :contract-axes :body :operands
+                                    :roles :dims :opts :dtype])))
+    (is (= (select-keys (cf/scalar-reduction-view parsed) [:neutral :combine :dtype])
+           (select-keys (cf/scalar-reduction-view components) [:neutral :combine :dtype])))
+    (is (= (:form components)
+           (cf/surface-form {:out 'out :free-axes '[[i 4] [j 6]]
+                             :contract-axes '[[blk 4] [t 32]] :body body
+                             :opts (array-map :init 1 :combine 'clojure.core/+)})))))
 
 (deftest a-stage-list-cannot-supply-the-axes-it-is-checked-against
   (testing "the form's contract axes are independent of its :stages — the two are separate slots,

--- a/test/raster/compiler/passes/parallel/typed_segmented_reduction_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_segmented_reduction_test.clj
@@ -76,6 +76,8 @@
       (is (= '#{A B} (:inputs operation)))
       (is (= '#{m n k} (:scalars operation)))
       (is (= '#{C} (:outputs operation)))
+      (is (= :segmented (:phase operation)))
+      (is (nil? (:schedule operation)))
       (is (reduction/product-reduction? product))
       (is (= :float (first (reduction/dtypes product))))
       (is (= 'C (first (reduction/results product))))

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -3,6 +3,7 @@
             [raster.compiler.ir.soac :as legacy]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.ir.segop :as segop]
+            [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.passes.parallel.soac-dialect-adapter :as adapter]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-route :as route]))
@@ -190,9 +191,13 @@
         operation (dialect/operation-parts equation)
         routed (route/attempt source :float (:array-types options)
                               {:scalar-types (:scalar-types options)})
-        scheduled ((requiring-resolve
-                    'raster.compiler.passes.parallel.segop-lower-pass/segop-lower-pass)
-                   (:program routed) {:target-device :ze:0 :dtype :float})
+        scheduled
+        (with-redefs [contraction-facts/contraction-facts
+                      (fn [& _]
+                        (throw (ex-info "typed scheduling reparsed source" {})))]
+          ((requiring-resolve
+            'raster.compiler.passes.parallel.segop-lower-pass/segop-lower-pass)
+           (:program routed) {:target-device :ze:0 :dtype :float}))
         segcontract (-> scheduled :form :equations first :operations first)]
     (is (= 'segmented-reduce (:kind operation)))
     (is (= '[[i m] [j n]] (get-in operation [:attributes :segment-axes])))

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.soac :as legacy]
             [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.soac-dialect-adapter :as adapter]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-route :as route]))
@@ -118,6 +119,7 @@
       (is (= :inclusive (get-in (dialect/operation-parts equation) [:attributes :mode])))
       (is (= '{result target} (get-in (dialect/facts program) [:equations 0 :aliases])))
       (is (= #{:memory/write} (:effects (dialect/facts program))))))
+
   (testing "exclusive scan is the same certified operation with a distinct result mode"
     (let [program (frontend/form->program
                    '(let* [result (raster.par/scan-exclusive target acc 0.0 i n float
@@ -173,6 +175,39 @@
       (is (= :read-write
              (get-in facts [:equations 0 :attributes :result-storage 0 :access])))
       (is (= '{step target} (get-in facts [:equations 0 :aliases]))))))
+
+(deftest contraction-enters-as-a-general-typed-segmented-reduction
+  (let [source
+        '(let* [step (raster.par/contract C [[i m] [j n]] [[l k]]
+                       (* (clojure.core/aget A (+ (* i k) l))
+                          (clojure.core/aget B (+ (* l n) j))))]
+               step)
+        options {:dtype :float
+                 :array-types {'A :float 'B :float 'C :float}
+                 :scalar-types {'m :long 'n :long 'k :long}}
+        program (frontend/form->program source options)
+        equation (first (dialect/equations program))
+        operation (dialect/operation-parts equation)
+        routed (route/attempt source :float (:array-types options)
+                              {:scalar-types (:scalar-types options)})
+        scheduled ((requiring-resolve
+                    'raster.compiler.passes.parallel.segop-lower-pass/segop-lower-pass)
+                   (:program routed) {:target-device :ze:0 :dtype :float})
+        segcontract (-> scheduled :form :equations first :operations first)]
+    (is (= 'segmented-reduce (:kind operation)))
+    (is (= '[[i m] [j n]] (get-in operation [:attributes :segment-axes])))
+    (is (= '[m n k] (dialect/operation-extents equation)))
+    (is (= [{:destination 'C :access :write :host-return :effect}]
+           (get-in (dialect/facts program) [:equations 0 :attributes :result-storage])))
+    (is (= '[m n] (:shape (get-in (dialect/facts program)
+                                  [:values (first (nth equation 2))]))))
+    (is (= :analyzed-source (get-in routed [:stats :front-end])))
+    (is (instance? raster.compiler.ir.segop.SegContract segcontract))
+    (is (= 'C (get-in segcontract [:facts :out])))
+    (is (nil? (some #(when (instance? raster.compiler.ir.soac.SoacContract %) %)
+                    (tree-seq coll? seq (:form scheduled)))))
+    (is (= :typed-soac (get-in (-> scheduled :form :equations first)
+                               [:attributes :algorithm-dialect])))))
 
 (deftest destination-shapes-refine-across-ordered-maps
   (let [program (frontend/form->program

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -3,6 +3,7 @@
             [raster.compiler.ir.soac :as legacy]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.ir.segop :as segop]
+            [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.passes.parallel.soac-dialect-adapter :as adapter]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
@@ -198,7 +199,7 @@
           ((requiring-resolve
             'raster.compiler.passes.parallel.segop-lower-pass/segop-lower-pass)
            (:program routed) {:target-device :ze:0 :dtype :float}))
-        segcontract (-> scheduled :form :equations first :operations first)]
+        segred (-> scheduled :form :equations first :operations first)]
     (is (= 'segmented-reduce (:kind operation)))
     (is (= '[[i m] [j n]] (get-in operation [:attributes :segment-axes])))
     (is (= '[m n k] (dialect/operation-extents equation)))
@@ -207,8 +208,10 @@
     (is (= '[m n] (:shape (get-in (dialect/facts program)
                                   [:values (first (nth equation 2))]))))
     (is (= :analyzed-source (get-in routed [:stats :front-end])))
-    (is (instance? raster.compiler.ir.segop.SegContract segcontract))
-    (is (= 'C (get-in segcontract [:facts :out])))
+    (is (instance? raster.compiler.ir.segop.SegRed segred))
+    (is (= :contraction (:phase segred)))
+    (is (= :hardware-contraction-candidates (get-in segred [:schedule :strategy])))
+    (is (= '[C] (reduction/results (:reduction segred))))
     (is (nil? (some #(when (instance? raster.compiler.ir.soac.SoacContract %) %)
                     (tree-seq coll? seq (:form scheduled)))))
     (is (= :typed-soac (get-in (-> scheduled :form :equations first)

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -584,7 +584,7 @@
     (is (= '#{A B} (segop/operation-inputs operation)))
     (is (= '#{C} (segop/operation-outputs operation)))))
 
-(deftest gpu-emission-consumes-the-typed-contraction-schedule-view
+(deftest gpu-emission-consumes-the-scheduled-typed-contraction
   (let [source
         '(let* [step (raster.par/contract C [[i m] [j n]] [[l k]]
                        (* (clojure.core/aget A (+ (* i k) l))
@@ -604,7 +604,9 @@
           (opencl-pass/opencl-pass form :device-id :ocl:0
                                      :dtype :float :min-elements 0))]
     (is (= :typed-soac (:source-dialect stats)))
-    (is (instance? raster.compiler.ir.segop.SegContract operation))
+    (is (instance? raster.compiler.ir.segop.SegRed operation))
+    (is (= :contraction (:phase operation)))
+    (is (= :hardware-contraction-candidates (get-in operation [:schedule :strategy])))
     (is (= :raster.par/contract
            (get-in (dialect/operation-parts (first (dialect/equations algorithm)))
                    [:attributes :attributes :source-operation])))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -6,6 +6,7 @@
             [raster.compiler.ir.kernel-graph :as kernel-graph]
             [raster.compiler.ir.kernel-launch :as kernel-launch]
             [raster.compiler.ir.parallel-program :as parallel-program]
+            [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.pipeline :as pipeline]
@@ -596,8 +597,12 @@
                  :scalar-types {'m :long 'n :long 'k :long}})
         operation (-> form :equations first :operations first)
         algorithm (-> form :equations first :algorithm)
-        emitted (opencl-pass/opencl-pass form :device-id :ocl:0
-                                         :dtype :float :min-elements 0)]
+        emitted
+        (with-redefs [contraction-facts/contraction-facts
+                      (fn [& _]
+                        (throw (ex-info "typed emission reparsed source" {})))]
+          (opencl-pass/opencl-pass form :device-id :ocl:0
+                                     :dtype :float :min-elements 0))]
     (is (= :typed-soac (:source-dialect stats)))
     (is (instance? raster.compiler.ir.segop.SegContract operation))
     (is (= :raster.par/contract

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -566,6 +566,48 @@
     (is (nil? (get-in emitted [:stats :segop-relowered])))
     (is (= 1 (count (:kernels emitted))))))
 
+(deftest typed-contraction-schedule-view-retains-body-scalars
+  (let [source
+        '(let* [step (raster.par/contract C [[i m] [j n]] [[l k]]
+                       (* alpha
+                          (clojure.core/aget A (+ (* i k) l))
+                          (clojure.core/aget B (+ (* l n) j))))]
+               step)
+        {:keys [form]}
+        (pipeline/schedule-parallel-form
+         source {:target-device :ocl:0 :dtype :float
+                 :array-types {'A :float 'B :float 'C :float}
+                 :scalar-types {'m :long 'n :long 'k :long 'alpha :float}})
+        operation (-> form :equations first :operations first)]
+    (is (= '#{m n k alpha} (segop/operation-scalars operation)))
+    (is (= '#{A B} (segop/operation-inputs operation)))
+    (is (= '#{C} (segop/operation-outputs operation)))))
+
+(deftest gpu-emission-consumes-the-typed-contraction-schedule-view
+  (let [source
+        '(let* [step (raster.par/contract C [[i m] [j n]] [[l k]]
+                       (* (clojure.core/aget A (+ (* i k) l))
+                          (clojure.core/aget B (+ (* l n) j))))]
+               step)
+        {:keys [form stats]}
+        (pipeline/schedule-parallel-form
+         source {:target-device :ocl:0 :dtype :float
+                 :array-types {'A :float 'B :float 'C :float}
+                 :scalar-types {'m :long 'n :long 'k :long}})
+        operation (-> form :equations first :operations first)
+        algorithm (-> form :equations first :algorithm)
+        emitted (opencl-pass/opencl-pass form :device-id :ocl:0
+                                         :dtype :float :min-elements 0)]
+    (is (= :typed-soac (:source-dialect stats)))
+    (is (instance? raster.compiler.ir.segop.SegContract operation))
+    (is (= :raster.par/contract
+           (get-in (dialect/operation-parts (first (dialect/equations algorithm)))
+                   [:attributes :attributes :source-operation])))
+    (is (= 1 (get-in emitted [:stats :ze-contracts])))
+    (is (= 1 (get-in emitted [:stats :segop-reused])))
+    (is (nil? (get-in emitted [:stats :segop-relowered])))
+    (is (= 1 (count (:kernels emitted))))))
+
 (deftest resident-reduction-realization-stays-on-the-typed-spine
   (let [source
         '(let* [total (raster.par/reduce acc 0.0 i n


### PR DESCRIPTION
## Summary

- admit ordinary scalar raster.par/contract forms directly as the general TypedSOAC segmented-reduce algebra
- derive one shared mechanical contract projection for host materialization and the existing optimized GPU schedule route
- expose uniform scheduled-operation inputs, outputs, and scalar operands so SegContract participates in typed ABI validation
- preserve the current certified path for staged quantization, decode maps, declared layouts, epilogues, and output conversions until those facts are explicit in TypedSOAC
- update the compiler north-star migration status

## Validation

- 75 tests, 424 assertions across typed frontend/route, SegOp consumption, contraction scheduling, and device pipeline suites
- real Intel Arc contraction/device suites passed in the full hardware-enabled run
- full run completed 2,543 tests and 35,675 assertions; its 2 failures and 13 errors were in unrelated existing GPU runtime tests (Blelloch argument binding, map-void scalar ABI typing, and graph/profile count expectations), with no changed-path failure
- git diff --check