### PR TITLE
Derive contraction schedules from typed semantics

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -322,8 +322,10 @@ constructing the former `SoacContract` record. Ordinary scalar `raster.par/contr
 enters this equation directly; the operation is intentionally not a matmul node, so scientific
 contractions, batched reductions and attention-derived reductions share the same semantic
 vocabulary. Until the tensorization route consumes TypedSOAC itself, one shared mechanical
-projection supplies both host materialization and a `SegContract` schedule view. The GPU emitter
-reuses that scheduled view rather than re-reading source. Staged quantization, decode lambdas,
+component projection supplies host materialization and the verified facts carried by a
+`SegContract` schedule view. Schedule legality and GPU routing consume those components directly;
+only host materialization and compatibility leaves request a generated surface spelling, and no
+walked source form is reparsed. Staged quantization, decode lambdas,
 declared physical maps, epilogues and output conversions remain on the certified compatibility
 front door until the typed equation has explicit facts for them; admitting them while dropping
 those contracts would be a miscompile, not migration progress.

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -452,7 +452,9 @@
                   _ (when-not bound-sc (swap! stats update :segop-relowered (fnil inc 0)))
                   r (ensure-contraction-marker-expressible!
                      (croute/route-contraction
-                      form :dtype dtype
+                      ;; A scheduled equation routes from its verified facts. The source form is
+                      ;; only the host expression being replaced and is not semantic input again.
+                      (when-not bound-sc form) :dtype dtype
                       :facts (:facts bound-sc)
                       :operation-id (:id bound-sc)
                       ;; The resolved, feasibility-checked schedule is the single source of tile

--- a/src/raster/compiler/ir/contraction_facts.clj
+++ b/src/raster/compiler/ir/contraction_facts.clj
@@ -11,9 +11,9 @@
        body — so an extra factor was silently dropped.
 
    Patching each instance leaves the shape intact. This closes it structurally: there is exactly
-   ONE producer of facts, its only input is the FORM, and a checker takes facts — so there is no
-   argument to pass inconsistently. A checker that wants the contract axes cannot be handed a
-   different set; it reads `:contract-axes`, which came from the form's own declaration slot.
+   ONE verified facts constructor, and checkers take its tagged result — so there is no collection
+   of independently derived gate arguments to pass inconsistently. Surface source and validated
+   TypedSOAC equations both enter that constructor through explicit semantic components.
 
    DECLARATIONS ARE EVIDENCE, NOT FACTS. A form may declare operand axis-maps (`:maps`), which is
    what lets a merged/batched operand be understood at all — a derived map cannot guess grouping.
@@ -121,20 +121,33 @@
                        :sym sym :declared (am/index-expr declared) :actual idx})))
     declared))
 
-(defn contraction-facts
-  "Derive the checkable facts of `(raster.par/contract out free-axes contract-axes body & opts)`.
-   The ONLY input is the form (plus the intended element dtype, which is a compilation choice
-   rather than a property of the form). Throws on a malformed form or an unverifiable declaration."
-  [form & {:keys [dtype] :or {dtype :double}}]
-  (when-not (and (seq? form) (= 'raster.par/contract (first form)))
-    (throw (ex-info "contraction-facts: not a par/contract form" {:reason :not-a-contract-form
-                                                                  :form form})))
-  (let [[_ out free-axes contract-axes body] form
-        opts (form-opts form)
+(defn surface-form
+  "Spell contraction components in the temporary `raster.par/contract` target vocabulary."
+  [{:keys [out free-axes contract-axes body opts metadata]}]
+  (with-meta
+    (apply list
+           (concat ['raster.par/contract out free-axes contract-axes body]
+                   (mapcat identity opts)))
+    metadata))
+
+(defn from-components
+  "Construct the sole verified contraction-facts value from explicit semantic components.
+
+   `form` is optional provenance/compatibility spelling. When absent it is generated mechanically;
+   no fact is inferred by parsing that spelling. Throws on malformed axes or an unverifiable
+   physical layout declaration."
+  [{:keys [out free-axes contract-axes body opts dtype form metadata]
+    :or {opts {} dtype :double}}]
+  (let [form (or form (surface-form {:out out :free-axes free-axes
+                                     :contract-axes contract-axes :body body
+                                     :opts opts :metadata metadata}))
+        _ (when-not (symbol? out)
+            (throw (ex-info "contract output must be a symbol" {:reason :malformed-output
+                                                                 :out out})))
         _ (when-not (vector? free-axes)
-            (throw (ex-info "contract form: free-axes must be a vector" {:reason :malformed-free-axes})))
+            (throw (ex-info "contract free-axes must be a vector" {:reason :malformed-free-axes})))
         _ (when-not (vector? contract-axes)
-            (throw (ex-info "contract form: contract-axes must be a vector" {:reason :malformed-contract-axes})))
+            (throw (ex-info "contract contract-axes must be a vector" {:reason :malformed-contract-axes})))
         declared (:maps opts)
         ;; `:decode` is the per-operand LOAD-LAMBDA, an expression in `x` (the raw load). This is
         ;; where a zero-point subtraction belongs — exact on the load path, needing no correction
@@ -174,6 +187,19 @@
       :dims dims
       :opts opts}
      normalized)))
+
+(defn contraction-facts
+  "Derive verified facts from `(raster.par/contract out free-axes contract-axes body & opts)`.
+
+   Source parsing ends here. Typed compiler paths call `from-components` instead, so schedule
+   analysis never has to reconstruct or reparse source syntax."
+  [form & {:keys [dtype] :or {dtype :double}}]
+  (when-not (and (seq? form) (= 'raster.par/contract (first form)))
+    (throw (ex-info "contraction-facts: not a par/contract form" {:reason :not-a-contract-form
+                                                                  :form form})))
+  (let [[_ out free-axes contract-axes body] form]
+    (from-components {:out out :free-axes free-axes :contract-axes contract-axes
+                      :body body :opts (form-opts form) :dtype dtype :form form})))
 
 (defn scalar-reduction-view
   "Project the canonical one-component ProductReduction into the contraction facts needed by

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -249,6 +249,10 @@
 (defn route-contraction
   "Route a contraction form through verified facts, an applied hardware schedule and a target leaf.
 
+   `contract-form` may be nil when verified `:facts` are supplied. In that case any temporary
+   source-shaped spelling needed by a compatibility leaf is generated from those facts; routing
+   and legality never inspect the walked source form.
+
    Canonical f16 products first become a target-neutral KernelBody and are then lowered by the
    OpenCL DPAS backend.  Unsupported shapes retain the portable register-tiled route.  Byte/int8
    products use the quant leaves (dp4a for :nt, widening for :nn) until those instruction families
@@ -256,9 +260,15 @@
    not a buffer-ownership or graph-composition concern."
   [contract-form & {:keys [dtype prefer-peak? desc tile epilogue stages operands facts operation-id]
                     :or {dtype :half prefer-peak? false}}]
-  (let [out-sym (second contract-form)
-        free-axes (nth contract-form 2)
-        contract-axes (nth contract-form 3)
+  (let [contract-facts (or facts (cf/contraction-facts contract-form :dtype dtype))
+        contract-form (or contract-form (:form contract-facts))
+        _ (when-not (and (cf/facts? contract-facts) contract-form)
+            (throw (ex-info "contraction routing requires verified facts and a target spelling"
+                            {:reason :contraction-route-input
+                             :facts contract-facts :form contract-form})))
+        out-sym (:out contract-facts)
+        free-axes (:free-axes contract-facts)
+        contract-axes (:contract-axes contract-facts)
         n-free (count free-axes)
         n-contract (count contract-axes)
         ;; Number of output elements = product of the free-axis bounds. Bounds may be SYMBOLS
@@ -271,13 +281,12 @@
         ;; memoized so the cond's test arm doesn't regenerate the kernel
         ;; a fused contraction carries its epilogue in the form's trailing opts (par-fusion's
         ;; fuse-contract-map puts it there); an explicit :epilogue kwarg overrides.
-        form-opts (apply hash-map (drop 5 contract-form))
-        contract-facts (or facts (cf/contraction-facts contract-form :dtype dtype))
-        epilogue (or epilogue (:epilogue form-opts))
-        stages (or stages (:stages (apply hash-map (drop 5 contract-form))))
+        form-opts (:opts contract-facts)
+        epilogue (or epilogue (:epilogue contract-facts))
+        stages (or stages (:stages contract-facts))
         ;; declared operand axis-maps, needed to tensorize a staged inner stage (the gate VERIFIES
         ;; them against the body rather than trusting them)
-        operands (or operands (:operands (apply hash-map (drop 5 contract-form))))
+        operands (or operands (:operands form-opts))
         tensorize-plan (memoize #(route-2free-1contract contract-form out-sym dtype desc tile
                                                         epilogue contract-facts operation-id))]
     ;; Every descriptor is validated against the kernel it describes before it leaves this fn. The

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -327,8 +327,9 @@
         ;; The equation remains the sole semantic representation.  SegContract is a target
         ;; scheduling view carrying facts derived from the shared mechanical projection; it lets
         ;; DPAS/register-tiled leaves consume the typed front door without re-reading source.
-        (let [form (projection/segmented-reduce-contract-form program equation)
-              facts (contraction-facts/contraction-facts form :dtype output-dtype)]
+        (let [components (projection/segmented-reduce-contract-components program equation)
+              facts (contraction-facts/from-components
+                     (assoc components :dtype output-dtype))]
           [(segop/->SegContract equation-id facts output-dtype device-id)])
         [(segop/->SegRed equation-id space
                          (segop/->SegLevel :thread :virtual)

--- a/src/raster/compiler/passes/parallel/typed_soac_projection.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_projection.clj
@@ -8,6 +8,7 @@
   (:require [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
+            [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.ir.soac-dialect :as dialect]))
 
 (defn- materialize-region
@@ -44,12 +45,11 @@
     {:combine (descriptor/semantic-op expression)
      :element (second arguments)}))
 
-(defn segmented-reduce-contract-form
-  "Project one validated, scalar `segmented-reduce` equation to `raster.par/contract`.
+(defn segmented-reduce-contract-components
+  "Project one validated scalar `segmented-reduce` equation to contraction semantic components.
 
-   This is a compatibility seam for contraction scheduling and host materialization, not a second
-   semantic IR: captures, physical storage, axes, algebra and the scalar region all come from the
-   validated TypedSOAC program."
+   This is not a second IR: captures, physical storage, axes, algebra and the scalar region all
+   come from the validated TypedSOAC program."
   [program equation]
   (let [program (dialect/validate! program)
         [_ equation-id results] equation
@@ -81,12 +81,19 @@
                 locals
                 (util/subst-syms substitutions (first body-results)))
         {:keys [combine element]} (scalar-fold-parts attributes folded)
-        form (list 'raster.par/contract
-                   (first physical-results)
-                   (:segment-axes attributes)
-                   [[(:index attributes) (:extent attributes)]]
-                   element
-                   :init (first (:identities attributes))
-                   :combine combine
-                   :algebra (first (:algebra attributes)))]
-    (with-meta form {:raster.type/elem-type (first (:dtypes attributes))})))
+        contraction-dtype (first (:dtypes attributes))]
+    {:out (first physical-results)
+     :free-axes (:segment-axes attributes)
+     :contract-axes [[(:index attributes) (:extent attributes)]]
+     :body element
+     :opts (array-map :init (first (:identities attributes))
+                      :combine combine
+                      :algebra (first (:algebra attributes)))
+     :dtype contraction-dtype
+     :metadata {:raster.type/elem-type contraction-dtype}}))
+
+(defn segmented-reduce-contract-form
+  "Spell a typed scalar segmented reduction in the temporary host/leaf target vocabulary."
+  [program equation]
+  (contraction-facts/surface-form
+   (segmented-reduce-contract-components program equation)))

--- a/test/raster/compiler/ir/contraction_facts_test.clj
+++ b/test/raster/compiler/ir/contraction_facts_test.clj
@@ -1,10 +1,10 @@
 (ns raster.compiler.ir.contraction-facts-test
-  "FACTS: the single derivation whose only input is the form. Device-free.
+  "FACTS: one verified derivation from source or typed semantic components. Device-free.
 
-   The property under test is structural, not behavioural: because there is one producer and its
-   only input is the form, a checker cannot be handed a value derived from the thing it is meant
-   to check. That shape is what made two silent miscompiles writable — a stage list validated
-   against axes derived from itself, and a body-replacing leaf that never checked the body."
+   The property under test is structural, not behavioural: every checker receives the tagged
+   result of one constructor, rather than separately derived gate arguments. That old shape made
+   two silent miscompiles writable — a stage list validated against axes derived from itself, and
+   a body-replacing leaf that never checked the body."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.contraction-facts :as cf]
             [raster.compiler.ir.axis-map :as am]
@@ -40,6 +40,26 @@
         (is (= [(:index operator) 128] (:flat-contract-axis f)))
         (is (= (:element (cf/scalar-reduction-view f))
                (second (rest (first (:results (reduction/fold-region operator)))))))))))
+
+(deftest source-and-semantic-components-enter-the-same-facts-constructor
+  (let [source (form :init 1 :combine 'clojure.core/+)
+        parsed (cf/contraction-facts source :dtype :byte)
+        components (cf/from-components
+                    {:out 'out :free-axes '[[i 4] [j 6]]
+                     :contract-axes '[[blk 4] [t 32]] :body body
+                     :opts (array-map :init 1 :combine 'clojure.core/+)
+                     :dtype :byte})]
+    (is (cf/facts? components))
+    (is (= (select-keys parsed [:out :free-axes :contract-axes :body :operands
+                                :roles :dims :opts :dtype])
+           (select-keys components [:out :free-axes :contract-axes :body :operands
+                                    :roles :dims :opts :dtype])))
+    (is (= (select-keys (cf/scalar-reduction-view parsed) [:neutral :combine :dtype])
+           (select-keys (cf/scalar-reduction-view components) [:neutral :combine :dtype])))
+    (is (= (:form components)
+           (cf/surface-form {:out 'out :free-axes '[[i 4] [j 6]]
+                             :contract-axes '[[blk 4] [t 32]] :body body
+                             :opts (array-map :init 1 :combine 'clojure.core/+)})))))
 
 (deftest a-stage-list-cannot-supply-the-axes-it-is-checked-against
   (testing "the form's contract axes are independent of its :stages — the two are separate slots,

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -3,6 +3,7 @@
             [raster.compiler.ir.soac :as legacy]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.ir.segop :as segop]
+            [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.passes.parallel.soac-dialect-adapter :as adapter]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-route :as route]))
@@ -190,9 +191,13 @@
         operation (dialect/operation-parts equation)
         routed (route/attempt source :float (:array-types options)
                               {:scalar-types (:scalar-types options)})
-        scheduled ((requiring-resolve
-                    'raster.compiler.passes.parallel.segop-lower-pass/segop-lower-pass)
-                   (:program routed) {:target-device :ze:0 :dtype :float})
+        scheduled
+        (with-redefs [contraction-facts/contraction-facts
+                      (fn [& _]
+                        (throw (ex-info "typed scheduling reparsed source" {})))]
+          ((requiring-resolve
+            'raster.compiler.passes.parallel.segop-lower-pass/segop-lower-pass)
+           (:program routed) {:target-device :ze:0 :dtype :float}))
         segcontract (-> scheduled :form :equations first :operations first)]
     (is (= 'segmented-reduce (:kind operation)))
     (is (= '[[i m] [j n]] (get-in operation [:attributes :segment-axes])))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -6,6 +6,7 @@
             [raster.compiler.ir.kernel-graph :as kernel-graph]
             [raster.compiler.ir.kernel-launch :as kernel-launch]
             [raster.compiler.ir.parallel-program :as parallel-program]
+            [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.pipeline :as pipeline]
@@ -596,8 +597,12 @@
                  :scalar-types {'m :long 'n :long 'k :long}})
         operation (-> form :equations first :operations first)
         algorithm (-> form :equations first :algorithm)
-        emitted (opencl-pass/opencl-pass form :device-id :ocl:0
-                                         :dtype :float :min-elements 0)]
+        emitted
+        (with-redefs [contraction-facts/contraction-facts
+                      (fn [& _]
+                        (throw (ex-info "typed emission reparsed source" {})))]
+          (opencl-pass/opencl-pass form :device-id :ocl:0
+                                     :dtype :float :min-elements 0))]
     (is (= :typed-soac (:source-dialect stats)))
     (is (instance? raster.compiler.ir.segop.SegContract operation))
     (is (= :raster.par/contract


### PR DESCRIPTION
## Summary

- split contraction-facts into one verified component constructor plus a surface-source parser
- derive scheduled contraction facts directly from the validated TypedSOAC segmented-reduce equation
- let contraction routing accept verified facts without consulting the walked source form
- reserve generated raster.par/contract spelling for host materialization and compatibility leaves
- add fail-loud tests that replace the source parser with a throwing function during SegOp lowering and GPU emission

## Validation

- 1,232 compiler tests, 5,748 assertions
- focused contraction/TypedSOAC/device set: 84 tests, 486 assertions
- real Intel Arc contraction routes executed
- git diff --check