### PR TITLE
Lower typed contractions as scheduled SegRed

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -322,21 +322,25 @@ constructing the former `SoacContract` record. Ordinary scalar `raster.par/contr
 enters this equation directly; the operation is intentionally not a matmul node, so scientific
 contractions, batched reductions and attention-derived reductions share the same semantic
 vocabulary. Until the tensorization route consumes TypedSOAC itself, one shared mechanical
-component projection supplies host materialization and the verified facts carried by a
-`SegContract` schedule view. Schedule legality and GPU routing consume those components directly;
-only host materialization and compatibility leaves request a generated surface spelling, and no
-walked source form is reparsed. Staged quantization, decode lambdas,
+component projection supplies host materialization and target routing. Ordinary typed contractions
+lower to a canonical `SegRed` whose `ReductionSchedule` records the hardware candidate families,
+workgroup search space and numerical constraints; the validated TypedSOAC equation remains attached
+to its `ProgramEquation`. GPU routing derives its transient verified contraction facts from that
+equation and never reparses the walked source form. Only host materialization and compatibility
+leaves request a generated surface spelling. Staged quantization, decode lambdas,
 declared physical maps, epilogues and output conversions remain on the certified compatibility
-front door until the typed equation has explicit facts for them; admitting them while dropping
-those contracts would be a miscompile, not migration progress.
+front door, and may still use `SegContract`, until the typed equation has explicit facts for them;
+admitting them while dropping those contracts would be a miscompile, not migration progress.
 
 Tensor contraction uses that same semantic operator rather than reconstructing `init`, `combine`
 and a fold body in `contract-lower`. The single contraction-facts derivation now owns its canonical
 one-component `ProductReduction`, normalized reduced coordinate and flattened semantic body;
-`SegContract`, generic `SegRed` fallback and peak routing consume those facts unchanged. Free axes,
+ordinary `SegRed` scheduling and peak routing consume those facts unchanged. The compatibility
+`SegContract` projection is now limited to contractions that are not yet in the typed subset. Free axes,
 operand axis maps, decode/storage precision, epilogues and staged accumulator structure remain
-orthogonal contraction facts and schedule choices. This is the semantic bridge toward representing
-contraction as an ordinary segmented TypedSOAC reduction, not a new hard-coded GEMM algebra.
+orthogonal contraction facts and schedule choices. Contraction is therefore an ordinary segmented
+TypedSOAC reduction, not a new hard-coded GEMM algebra; matrix, register-tiled and portable kernels
+are competing schedules for that algebra.
 
 Indexed storage movement remains a separate generic operation. Allocation-free `gather-blocks!`
 and `scatter-blocks!` move contiguous typed blocks between dense staging and routed resident

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -10,6 +10,8 @@
   (:require [clojure.set :as set]
             [raster.compiler.ir.par :as par]
             [raster.compiler.ir.soac]
+            [raster.compiler.ir.soac-dialect :as soac-dialect]
+            [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
@@ -20,6 +22,7 @@
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.passes.parallel.soac-lower]
+            [raster.compiler.passes.parallel.typed-soac-projection :as typed-projection]
             [raster.compiler.backend.gpu.segop-opencl :as segop-cl]
             [raster.compiler.passes.parallel.contract-route :as croute]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-fuse :as swr-fuse]
@@ -112,6 +115,11 @@
    This is the seam that makes the SegOp boundary REAL instead of nominal. `segop-lower` lowered
    every par form with the real target device. The equation is consumed here; re-lowering remains
    a counted compatibility path for callers that invoke opencl-pass directly."
+  nil)
+
+(def ^:dynamic *bound-algorithm*
+  "The validated TypedSOAC program associated with `*bound-segops*`. Target scheduling reads the
+   algorithm rather than recovering semantic facts from the host expression being replaced."
   nil)
 
 (defn- take-bound-segop
@@ -444,19 +452,48 @@
                   ;; pass the REAL descriptor: route-contraction fed `(or desc {})` into
                   ;; derive-gemm-tile, so the "hardware-derived" tile was derived from an empty map
                   ;; — Arc constants on every device. device-id is already in scope here.
-                  ;; CONSUME the SegContract segop-lower recorded (its facts were derived and
-                  ;; verified once, at the boundary) — the same take-bound-segop seam map/reduce
-                  ;; use. Without one (door C, no pass run) route from the form and count it.
-                  bound-sc (take-bound-segop stats :segcontract
-                                             #(instance? raster.compiler.ir.segop.SegContract %))
-                  _ (when-not bound-sc (swap! stats update :segop-relowered (fnil inc 0)))
+                  ;; CONSUME the contraction-specialized SegRed recorded by typed lowering. Its
+                  ;; algorithm remains attached to the ParallelProgram equation, so routing can
+                  ;; derive verified facts without hiding them in a second operation record.
+                  ;; SegContract remains only for the compatibility front door; without either
+                  ;; scheduled operation (door C), route from the form and count it.
+                  bound-sr (take-bound-segop
+                            stats :segred-contraction
+                            #(and (instance? raster.compiler.ir.segop.SegRed %)
+                                  (= :contraction (:phase %))
+                                  (= :hardware-contraction-candidates
+                                     (get-in % [:schedule :strategy]))))
+                  bound-sc (when-not bound-sr
+                             (take-bound-segop
+                              stats :segcontract
+                              #(instance? raster.compiler.ir.segop.SegContract %)))
+                  bound-operation (or bound-sr bound-sc)
+                  typed-facts
+                  (when bound-sr
+                    (let [algorithm (or *bound-algorithm*
+                                        (throw (ex-info
+                                                "typed contraction SegRed lacks its algorithm"
+                                                {:reason :typed-contraction-algorithm
+                                                 :operation (:id bound-sr)})))
+                          equation (or (some #(when (= (:id bound-sr) (second %)) %)
+                                             (soac-dialect/equations algorithm))
+                                       (throw (ex-info
+                                               "typed contraction algorithm lacks its equation"
+                                               {:reason :typed-contraction-equation
+                                                :operation (:id bound-sr)})))]
+                      (contraction-facts/from-components
+                       (typed-projection/segmented-reduce-contract-components
+                        algorithm equation))))
+                  verified-facts (or typed-facts (:facts bound-sc))
+                  _ (when-not bound-operation
+                      (swap! stats update :segop-relowered (fnil inc 0)))
                   r (ensure-contraction-marker-expressible!
                      (croute/route-contraction
                       ;; A scheduled equation routes from its verified facts. The source form is
                       ;; only the host expression being replaced and is not semantic input again.
-                      (when-not bound-sc form) :dtype dtype
-                      :facts (:facts bound-sc)
-                      :operation-id (:id bound-sc)
+                      (when-not bound-operation form) :dtype dtype
+                      :facts verified-facts
+                      :operation-id (:id bound-operation)
                       ;; The resolved, feasibility-checked schedule is the single source of tile
                       ;; geometry.  Previously this option reached opencl-pass but contractions
                       ;; ignored it and re-derived a default, so a pinned/autotuned :tile changed
@@ -657,6 +694,10 @@
                                                        (binding [*bound-segops*
                                                                  (when parallel-program
                                                                    (parallel-program/operations-for-binding
+                                                                    parallel-program sym expr))
+                                                                 *bound-algorithm*
+                                                                 (when parallel-program
+                                                                   (parallel-program/algorithm-for-binding
                                                                     parallel-program sym expr))]
                                                          (transform expr)))]))
                                             pairs))
@@ -664,6 +705,10 @@
                                    (binding [*bound-segops*
                                              (when parallel-program
                                                (parallel-program/operations-for-source
+                                                parallel-program expr))
+                                             *bound-algorithm*
+                                             (when parallel-program
+                                               (parallel-program/algorithm-for-source
                                                 parallel-program expr))]
                                      (transform expr)))
                                  body-exprs)]

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -16,7 +16,6 @@
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.hardware :as hardware]
             [raster.compiler.core.util :as util]
-            [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.ir.kernel-graph :as kernel-graph]
             [raster.compiler.ir.kernel-launch :as kernel-launch]
             [raster.compiler.ir.par :as par]
@@ -25,13 +24,13 @@
             [raster.compiler.ir.soac-dialect :as soac-dialect]
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.segop :as segop]
-            [raster.compiler.passes.parallel.execution-plan :as execution-plan]
-            [raster.compiler.passes.parallel.typed-soac-projection :as projection]))
+            [raster.compiler.passes.parallel.execution-plan :as execution-plan]))
 
 (declare lower-reduce)
 (declare lower-map)
 (declare lower-scan-description)
 (declare scan-kernel-graph-description)
+(declare phase-grid)
 
 (defn- materialize-region-locals
   [locals body]
@@ -316,25 +315,36 @@
                  (conj (mapv (fn [[index extent]] {:name index :bound extent}) segment-axes)
                        {:name reduced-index :bound reduced-extent}))
           output-dtype (or (first (:dtypes attributes)) dtype :double)
+          contraction? (= :raster.par/contract
+                          (get-in attributes [:attributes :source-operation]))
+          planned-grid (when contraction?
+                         (phase-grid :reduce device-id reduced-extent output-dtype))
+          contraction-schedule
+          (when contraction?
+            (let [workgroup-size (:block-size planned-grid)
+                  candidates (filterv #(<= % workgroup-size) [32 64 128 256 512 1024])]
+              (reduction/schedule
+               {:strategy :hardware-contraction-candidates
+                :workgroup-size workgroup-size
+                :stages [:segment-space :reduction :target-lowering]
+                :tuning-space {:families [:matrix :register-tiled :portable]
+                               :workgroup-size candidates}
+                :numerical-mode (select-keys (first (get-in operator [:algebra :components]))
+                                             [:order :reassociation :overflow])
+                :attributes {:source-operation :raster.par/contract
+                             :device device-id
+                             :selection :target-lowering}})))
           _ (doseq [input inputs]
               (when-not (= :tensor (:kind (get values input)))
                 (throw (ex-info "segmented reduction tensor input lacks an AbstractValue"
                                 {:reason :typed-soac-segmented-reduce-input
                                  :equation equation-id :input input
                                  :value (get values input)}))))]
-      (if (= :raster.par/contract
-             (get-in attributes [:attributes :source-operation]))
-        ;; The equation remains the sole semantic representation.  SegContract is a target
-        ;; scheduling view carrying facts derived from the shared mechanical projection; it lets
-        ;; DPAS/register-tiled leaves consume the typed front door without re-reading source.
-        (let [components (projection/segmented-reduce-contract-components program equation)
-              facts (contraction-facts/from-components
-                     (assoc components :dtype output-dtype))]
-          [(segop/->SegContract equation-id facts output-dtype device-id)])
-        [(segop/->SegRed equation-id space
-                         (segop/->SegLevel :thread :virtual)
-                         operator nil inputs (set physical-results) scalars nil :segmented nil
-                         output-dtype)]))))
+      [(segop/->SegRed equation-id space
+                       (segop/->SegLevel :thread :virtual)
+                       operator nil inputs (set physical-results) scalars planned-grid
+                       (if contraction? :contraction :segmented)
+                       contraction-schedule output-dtype)])))
 
 (defn typed-scan-program?
   "Whether a validated one-equation TypedSOAC program is a certified scan."

--- a/test/raster/compiler/passes/parallel/typed_segmented_reduction_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_segmented_reduction_test.clj
@@ -76,6 +76,8 @@
       (is (= '#{A B} (:inputs operation)))
       (is (= '#{m n k} (:scalars operation)))
       (is (= '#{C} (:outputs operation)))
+      (is (= :segmented (:phase operation)))
+      (is (nil? (:schedule operation)))
       (is (reduction/product-reduction? product))
       (is (= :float (first (reduction/dtypes product))))
       (is (= 'C (first (reduction/results product))))

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -3,6 +3,7 @@
             [raster.compiler.ir.soac :as legacy]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.ir.segop :as segop]
+            [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.passes.parallel.soac-dialect-adapter :as adapter]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
@@ -198,7 +199,7 @@
           ((requiring-resolve
             'raster.compiler.passes.parallel.segop-lower-pass/segop-lower-pass)
            (:program routed) {:target-device :ze:0 :dtype :float}))
-        segcontract (-> scheduled :form :equations first :operations first)]
+        segred (-> scheduled :form :equations first :operations first)]
     (is (= 'segmented-reduce (:kind operation)))
     (is (= '[[i m] [j n]] (get-in operation [:attributes :segment-axes])))
     (is (= '[m n k] (dialect/operation-extents equation)))
@@ -207,8 +208,10 @@
     (is (= '[m n] (:shape (get-in (dialect/facts program)
                                   [:values (first (nth equation 2))]))))
     (is (= :analyzed-source (get-in routed [:stats :front-end])))
-    (is (instance? raster.compiler.ir.segop.SegContract segcontract))
-    (is (= 'C (get-in segcontract [:facts :out])))
+    (is (instance? raster.compiler.ir.segop.SegRed segred))
+    (is (= :contraction (:phase segred)))
+    (is (= :hardware-contraction-candidates (get-in segred [:schedule :strategy])))
+    (is (= '[C] (reduction/results (:reduction segred))))
     (is (nil? (some #(when (instance? raster.compiler.ir.soac.SoacContract %) %)
                     (tree-seq coll? seq (:form scheduled)))))
     (is (= :typed-soac (get-in (-> scheduled :form :equations first)

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -584,7 +584,7 @@
     (is (= '#{A B} (segop/operation-inputs operation)))
     (is (= '#{C} (segop/operation-outputs operation)))))
 
-(deftest gpu-emission-consumes-the-typed-contraction-schedule-view
+(deftest gpu-emission-consumes-the-scheduled-typed-contraction
   (let [source
         '(let* [step (raster.par/contract C [[i m] [j n]] [[l k]]
                        (* (clojure.core/aget A (+ (* i k) l))
@@ -604,7 +604,9 @@
           (opencl-pass/opencl-pass form :device-id :ocl:0
                                      :dtype :float :min-elements 0))]
     (is (= :typed-soac (:source-dialect stats)))
-    (is (instance? raster.compiler.ir.segop.SegContract operation))
+    (is (instance? raster.compiler.ir.segop.SegRed operation))
+    (is (= :contraction (:phase operation)))
+    (is (= :hardware-contraction-candidates (get-in operation [:schedule :strategy])))
     (is (= :raster.par/contract
            (get-in (dialect/operation-parts (first (dialect/equations algorithm)))
                    [:attributes :attributes :source-operation])))


### PR DESCRIPTION
## Summary
- lower ordinary typed scalar contractions as canonical SegRed operations with explicit hardware candidate schedules
- retain the validated TypedSOAC program on the scheduled equation and derive transient verified routing facts from it by stable operation ID
- keep SegContract only as the compatibility route for staged, quantized, epilogue, and other contracts outside the typed subset

## Correctness
- ordinary GPU emission is tested with the source-form contraction parser replaced by a throwing function
- general segmented reductions remain unspecialized SegRed operations
- the compatibility path remains available for semantics not yet represented by TypedSOAC

## Tests
- focused TypedSOAC suites: 48 tests, 323 assertions
- complete compiler suite: 1232 tests, 5754 assertions