### PR TITLE
Route typed contractions behind schedule API

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -326,8 +326,10 @@ component projection supplies host materialization and target routing. Ordinary 
 lower to a canonical `SegRed` whose `ReductionSchedule` records the hardware candidate families,
 workgroup search space and numerical constraints; the validated TypedSOAC equation remains attached
 to its `ProgramEquation`. GPU routing derives its transient verified contraction facts from that
-equation and never reparses the walked source form. Only host materialization and compatibility
-leaves request a generated surface spelling. Staged quantization, decode lambdas,
+equation behind a typed routing API and never reparses the walked source form; the OpenCL pipeline
+therefore knows only the typed program, stable operation ID and certified candidate schedule, not
+the projection used by compatibility leaves. Only host materialization and compatibility leaves
+request a generated surface spelling. Staged quantization, decode lambdas,
 declared physical maps, epilogues and output conversions remain on the certified compatibility
 front door, and may still use `SegContract`, until the typed equation has explicit facts for them;
 admitting them while dropping those contracts would be a miscompile, not migration progress.

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -10,8 +10,6 @@
   (:require [clojure.set :as set]
             [raster.compiler.ir.par :as par]
             [raster.compiler.ir.soac]
-            [raster.compiler.ir.soac-dialect :as soac-dialect]
-            [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
@@ -22,7 +20,6 @@
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.passes.parallel.soac-lower]
-            [raster.compiler.passes.parallel.typed-soac-projection :as typed-projection]
             [raster.compiler.backend.gpu.segop-opencl :as segop-cl]
             [raster.compiler.passes.parallel.contract-route :as croute]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-fuse :as swr-fuse]
@@ -468,40 +465,35 @@
                               stats :segcontract
                               #(instance? raster.compiler.ir.segop.SegContract %)))
                   bound-operation (or bound-sr bound-sc)
-                  typed-facts
+                  typed-algorithm
                   (when bound-sr
-                    (let [algorithm (or *bound-algorithm*
-                                        (throw (ex-info
-                                                "typed contraction SegRed lacks its algorithm"
-                                                {:reason :typed-contraction-algorithm
-                                                 :operation (:id bound-sr)})))
-                          equation (or (some #(when (= (:id bound-sr) (second %)) %)
-                                             (soac-dialect/equations algorithm))
-                                       (throw (ex-info
-                                               "typed contraction algorithm lacks its equation"
-                                               {:reason :typed-contraction-equation
-                                                :operation (:id bound-sr)})))]
-                      (contraction-facts/from-components
-                       (typed-projection/segmented-reduce-contract-components
-                        algorithm equation))))
-                  verified-facts (or typed-facts (:facts bound-sc))
+                    (or *bound-algorithm*
+                        (throw (ex-info
+                                "typed contraction SegRed lacks its algorithm"
+                                {:reason :typed-contraction-algorithm
+                                 :operation (:id bound-sr)}))))
                   _ (when-not bound-operation
                       (swap! stats update :segop-relowered (fnil inc 0)))
+                  target-desc (try ((requiring-resolve
+                                     'raster.compiler.core.hardware/descriptor-for)
+                                    device-id)
+                                   (catch Throwable _ nil))
                   r (ensure-contraction-marker-expressible!
-                     (croute/route-contraction
-                      ;; A scheduled equation routes from its verified facts. The source form is
-                      ;; only the host expression being replaced and is not semantic input again.
-                      (when-not bound-operation form) :dtype dtype
-                      :facts verified-facts
-                      :operation-id (:id bound-operation)
-                      ;; The resolved, feasibility-checked schedule is the single source of tile
-                      ;; geometry.  Previously this option reached opencl-pass but contractions
-                      ;; ignored it and re-derived a default, so a pinned/autotuned :tile changed
-                      ;; neither the KernelBody nor emitted source.
-                      :tile (:tile schedule)
-                      :desc (try ((requiring-resolve 'raster.compiler.core.hardware/descriptor-for)
-                                  device-id)
-                                 (catch Throwable _ nil))))
+                     (if bound-sr
+                       (croute/route-typed-contraction
+                        typed-algorithm (:id bound-sr) (:schedule bound-sr)
+                        :dtype dtype :tile (:tile schedule) :desc target-desc)
+                       (croute/route-contraction
+                        ;; A compatibility equation routes from its verified facts. Without a
+                        ;; scheduled operation, the direct backend door still consumes the form.
+                        (when-not bound-sc form) :dtype dtype
+                        :facts (:facts bound-sc)
+                        :operation-id (:id bound-sc)
+                        ;; The resolved, feasibility-checked schedule is the single source of tile
+                        ;; geometry.  Previously this option reached opencl-pass but contractions
+                        ;; ignored it and re-derived a default, so a pinned/autotuned :tile changed
+                        ;; neither the KernelBody nor emitted source.
+                        :tile (:tile schedule) :desc target-desc)))
                   ;; Every routed single-entry leaf is now a complete executable artifact. Routing
                   ;; diagnostics and tensorization facts live in its attributes/provenance rather
                   ;; than being flattened into the runtime registry namespace.

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -26,7 +26,10 @@
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-launch :as klaunch]
-            [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]))
+            [raster.compiler.ir.reduction :as reduction]
+            [raster.compiler.ir.soac-dialect :as soac-dialect]
+            [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]
+            [raster.compiler.passes.parallel.typed-soac-projection :as typed-projection]))
 
 (defn par-contract-form?
   "Is `form` a (raster.par/contract out free-axes contract-axes body & opts) form?"
@@ -430,6 +433,45 @@
           ;; work. Using the first reported DPAS's generic :not-a-contraction where regtiled's
           ;; specific :symbolic-dims / :non-plus-combine is the actual answer.
             (seq declines) (assoc :fallback-reason (:reason (last declines))))))))))
+
+(defn route-typed-contraction
+  "Route one scheduled scalar TypedSOAC contraction without exposing a source-form or facts adapter
+   to the backend.
+
+   The validated equation is the semantic input. `schedule` certifies that SegOp scheduling chose
+   the contraction candidate family; this target route then selects and verifies the concrete
+   matrix, register-tiled or portable leaf against the device descriptor. The temporary verified
+   contraction facts remain private to this migration adapter until those leaves accept the typed
+   reduction and operand maps directly."
+  [program operation-id schedule & options]
+  (let [program (soac-dialect/validate! program)
+        schedule (reduction/validate-schedule! schedule)
+        _ (when-not (= :hardware-contraction-candidates (:strategy schedule))
+            (throw (ex-info "typed contraction requires a contraction candidate schedule"
+                            {:reason :typed-contraction-schedule
+                             :operation operation-id :schedule schedule})))
+        equation (or (some #(when (= operation-id (second %)) %)
+                           (soac-dialect/equations program))
+                     (throw (ex-info "typed contraction program lacks its scheduled equation"
+                                     {:reason :typed-contraction-equation
+                                      :operation operation-id})))
+        components (typed-projection/segmented-reduce-contract-components program equation)
+        equation-dtype (:dtype components)
+        options (apply hash-map options)
+        _ (when (and (contains? options :dtype)
+                     (not= equation-dtype (:dtype options)))
+            (throw (ex-info "typed contraction route dtype disagrees with its equation"
+                            {:reason :typed-contraction-dtype
+                             :operation operation-id
+                             :equation-dtype equation-dtype
+                             :route-dtype (:dtype options)})))
+        facts (cf/from-components components)]
+    (apply route-contraction nil
+           (mapcat identity
+                   (assoc options
+                          :dtype equation-dtype
+                          :facts facts
+                          :operation-id operation-id)))))
 
 (def ^:private decline-reasons
   "The reasons a tensorize leaf may legitimately REFUSE a shape — a WHITELIST.

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -10,6 +10,7 @@
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.pipeline :as pipeline]
+            [raster.compiler.passes.parallel.contract-route :as contract-route]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.typed-soac-route :as route]))
 
@@ -597,6 +598,13 @@
                  :scalar-types {'m :long 'n :long 'k :long}})
         operation (-> form :equations first :operations first)
         algorithm (-> form :equations first :algorithm)
+        directly-routed
+        (with-redefs [contraction-facts/contraction-facts
+                      (fn [& _]
+                        (throw (ex-info "typed routing reparsed source" {})))]
+          (contract-route/route-typed-contraction
+           algorithm (:id operation) (:schedule operation)
+           :dtype :float :desc {}))
         emitted
         (with-redefs [contraction-facts/contraction-facts
                       (fn [& _]
@@ -607,6 +615,20 @@
     (is (instance? raster.compiler.ir.segop.SegRed operation))
     (is (= :contraction (:phase operation)))
     (is (= :hardware-contraction-candidates (get-in operation [:schedule :strategy])))
+    (is (some? (:artifact directly-routed)))
+    (try
+      (contract-route/route-typed-contraction
+       algorithm (:id operation) (:schedule operation) :dtype :double :desc {})
+      (is false "a route dtype that disagrees with the typed equation must fail")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :typed-contraction-dtype (:reason (ex-data exception))))))
+    (try
+      (contract-route/route-typed-contraction
+       algorithm (:id operation) (assoc (:schedule operation) :strategy :workgroup-tree)
+       :dtype :float :desc {})
+      (is false "a non-contraction reduction schedule must fail")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :typed-contraction-schedule (:reason (ex-data exception))))))
     (is (= :raster.par/contract
            (get-in (dialect/operation-parts (first (dialect/equations algorithm)))
                    [:attributes :attributes :source-operation])))


### PR DESCRIPTION
## Summary
- add a typed contraction routing entry point that consumes the validated TypedSOAC program, stable operation ID, and certified ReductionSchedule
- keep transient contraction-facts construction private to the target router while compatibility leaves are migrated
- remove TypedSOAC projection and contraction-facts knowledge from the OpenCL/Level Zero pipeline
- reject schedule-family and dtype mismatches before target emission

## Tests
- focused contraction and schedule suites: 67 tests, 521 assertions
- complete compiler suite: 1232 tests, 5757 assertions