### PR TITLE
Enumerate typed contraction schedule candidates

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -337,6 +337,13 @@ declared physical maps, epilogues and output conversions remain on the certified
 front door, and may still use `SegContract`, until the typed equation has explicit facts for them;
 admitting them while dropping those contracts would be a miscompile, not migration progress.
 
+The typed route can also enumerate every legal enabled contraction family without benchmarking or
+choosing among them. Each result retains its pinned `ReductionSchedule`, concrete strategy,
+validated executable artifact and family-qualified decline trail, so offline tuning measures the
+same compiler products that ordinary execution uses. These alternatives may still have different
+physical ABIs and therefore are not falsely packaged as a runtime `KernelDispatch`; ABI
+normalization or graph-private adapters must precede runtime selection through one dispatch.
+
 Tensor contraction uses that same semantic operator rather than reconstructing `init`, `combine`
 and a fold body in `contract-lower`. The single contraction-facts derivation now owns its canonical
 one-component `ProductReduction`, normalized reduced coordinate and flattened semantic body;

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -455,6 +455,19 @@
           ;; specific :symbolic-dims / :non-plus-combine is the actual answer.
               (seq declines) (assoc :fallback-reason (:reason (last declines)))))))))))
 
+(defn- validated-typed-contraction-families
+  [schedule operation-id]
+  (let [families (get-in schedule [:tuning-space :families])]
+    (when-not (and (vector? families) (seq families)
+                   (= (count families) (count (distinct families)))
+                   (every? contraction-families families))
+      (throw (ex-info "typed contraction schedule requires known distinct candidate families"
+                      {:reason :typed-contraction-families
+                       :operation operation-id
+                       :families families
+                       :allowed contraction-families})))
+    families))
+
 (defn route-typed-contraction
   "Route one scheduled scalar TypedSOAC contraction without exposing a source-form or facts adapter
    to the backend.
@@ -471,15 +484,7 @@
             (throw (ex-info "typed contraction requires a contraction candidate schedule"
                             {:reason :typed-contraction-schedule
                              :operation operation-id :schedule schedule})))
-        families (get-in schedule [:tuning-space :families])
-        _ (when-not (and (vector? families) (seq families)
-                         (= (count families) (count (distinct families)))
-                         (every? contraction-families families))
-            (throw (ex-info "typed contraction schedule requires known distinct candidate families"
-                            {:reason :typed-contraction-families
-                             :operation operation-id
-                             :families families
-                             :allowed contraction-families})))
+        families (validated-typed-contraction-families schedule operation-id)
         equation (or (some #(when (= operation-id (second %)) %)
                            (soac-dialect/equations program))
                      (throw (ex-info "typed contraction program lacks its scheduled equation"
@@ -503,6 +508,66 @@
                           :facts facts
                           :candidate-families families
                           :operation-id operation-id)))))
+
+(defn- enabled-family-decline?
+  [decline]
+  (not= :schedule-family-disabled (:reason decline)))
+
+(defn- candidate-declines
+  [family declines]
+  (into []
+        (comp (filter enabled-family-decline?)
+              (map #(assoc % :candidate-family family)))
+        declines))
+
+(defn route-typed-contraction-candidates
+  "Emit every representable family enabled by one typed contraction schedule.
+
+   Compilation remains pure: this function neither benchmarks nor chooses. Each candidate is a
+   complete validated artifact with its concrete leaf strategy; real legality failures are retained
+   with their candidate family, while leaves disabled deliberately by a single-family probe are not
+   reported as failures. Different physical ABIs are permitted here because offline compile-time
+   selection measures each candidate independently; a runtime KernelDispatch requires a later
+   common-interface normalization."
+  [program operation-id schedule & options]
+  (let [schedule (reduction/validate-schedule! schedule)
+        families (validated-typed-contraction-families schedule operation-id)
+        results
+        (mapv
+         (fn [family]
+           (let [pinned (assoc-in schedule [:tuning-space :families] [family])]
+             (try
+               (-> (apply route-typed-contraction program operation-id pinned options)
+                   (assoc :family family)
+                   (assoc :candidate-schedule pinned)
+                   (update :declines #(candidate-declines family %)))
+               (catch clojure.lang.ExceptionInfo exception
+                 (let [{:keys [reason declines] :as data} (ex-data exception)]
+                   (if (= :no-legal-contraction-family reason)
+                      {:family family
+                      :strategy nil
+                      :candidate-schedule pinned
+                      :declines (candidate-declines family declines)
+                      :reason reason
+                      :detail (dissoc data :declines)}
+                     (throw exception)))))))
+         families)
+        candidates (filterv :strategy results)]
+    {:operation-id operation-id
+     :schedule schedule
+     :candidates candidates
+     :declines (into [] (mapcat :declines) results)}))
+
+(defn route-typed-contraction-candidates!
+  "Emit typed contraction candidates or fail when no enabled family has a legal target leaf."
+  [program operation-id schedule & options]
+  (let [result (apply route-typed-contraction-candidates
+                      program operation-id schedule options)]
+    (if (seq (:candidates result))
+      result
+      (throw (ex-info "no executable typed contraction candidates"
+                      {:reason :typed-contraction-no-candidates
+                       :route result})))))
 
 (def ^:private decline-reasons
   "The reasons a tensorize leaf may legitimately REFUSE a shape — a WHITELIST.

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -605,6 +605,13 @@
           (contract-route/route-typed-contraction
            algorithm (:id operation) (:schedule operation)
            :dtype :float :desc {}))
+        candidate-routes
+        (with-redefs [contraction-facts/contraction-facts
+                      (fn [& _]
+                        (throw (ex-info "candidate routing reparsed source" {})))]
+          (contract-route/route-typed-contraction-candidates!
+           algorithm (:id operation) (:schedule operation)
+           :dtype :float :desc {}))
         emitted
         (with-redefs [contraction-facts/contraction-facts
                       (fn [& _]
@@ -616,6 +623,11 @@
     (is (= :contraction (:phase operation)))
     (is (= :hardware-contraction-candidates (get-in operation [:schedule :strategy])))
     (is (some? (:artifact directly-routed)))
+    (is (= [:portable] (mapv :family (:candidates candidate-routes))))
+    (is (= #{:matrix :register-tiled}
+           (set (map :candidate-family (:declines candidate-routes)))))
+    (is (not-any? #(= :schedule-family-disabled (:reason %))
+                  (:declines candidate-routes)))
     (try
       (contract-route/route-typed-contraction
        algorithm (:id operation) (:schedule operation) :dtype :double :desc {})
@@ -637,6 +649,17 @@
       (is false "a pinned family that cannot lower the equation must fail")
       (catch clojure.lang.ExceptionInfo exception
         (is (= :no-legal-contraction-family (:reason (ex-data exception))))))
+    (try
+      (contract-route/route-typed-contraction-candidates!
+       algorithm (:id operation)
+       (assoc-in (:schedule operation) [:tuning-space :families] [:matrix])
+       :dtype :float :desc {})
+      (is false "candidate enumeration must fail when every enabled family declines")
+      (catch clojure.lang.ExceptionInfo exception
+        (let [{:keys [reason route]} (ex-data exception)]
+          (is (= :typed-contraction-no-candidates reason))
+          (is (empty? (:candidates route)))
+          (is (= #{:matrix} (set (map :candidate-family (:declines route))))))))
     (is (= :raster.par/contract
            (get-in (dialect/operation-parts (first (dialect/equations algorithm)))
                    [:attributes :attributes :source-operation])))
@@ -665,10 +688,23 @@
           (contract-route/route-typed-contraction
            algorithm (:id operation)
            (assoc-in (:schedule operation) [:tuning-space :families] [family])
-           :dtype :half :desc descriptor))]
+           :dtype :half :desc descriptor))
+        candidates
+        (contract-route/route-typed-contraction-candidates!
+         algorithm (:id operation) (:schedule operation)
+         :dtype :half :desc descriptor)]
     (is (= :dpas (:strategy (select-family :matrix))))
     (is (= :regtiled (:strategy (select-family :register-tiled))))
     (is (= :portable-segred (:strategy (select-family :portable))))
+    (is (= [:matrix :register-tiled :portable]
+           (mapv :family (:candidates candidates))))
+    (is (= [:dpas :regtiled :portable-segred]
+           (mapv :strategy (:candidates candidates))))
+    (is (= [[:matrix] [:register-tiled] [:portable]]
+           (mapv #(get-in % [:candidate-schedule :tuning-space :families])
+                 (:candidates candidates))))
+    (is (every? (comp some? :artifact) (:candidates candidates)))
+    (is (empty? (:declines candidates)))
     (doseq [families [[] [:unknown]]]
       (try
         (contract-route/route-typed-contraction


### PR DESCRIPTION
## Summary

- enumerate every legal family enabled by a typed contraction schedule as a complete executable candidate
- retain each pinned schedule and family-qualified legality decline trail without benchmarking or selecting during compilation
- fail loudly on an empty candidate set and document why differing physical ABIs cannot yet form one runtime KernelDispatch

## Testing

- `clojure -M:test -n raster.compiler.passes.parallel.typed-soac-route-test` — 33 tests, 235 assertions
- related contraction/SOAC suite — 82 tests, 500 assertions
- `clojure -M:test` reached 2,545 tests / 35,705 assertions; the hardware-enabled monolithic run reported 2 failures and 13 errors in unrelated stateful device tests after an early Level Zero context failure. The touched compiler namespaces stayed green, and current `origin/main` is green across all CircleCI jobs.