### PR TITLE
Normalize typed contraction candidate ABIs

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -343,6 +343,11 @@ validated executable artifact and family-qualified decline trail, so offline tun
 same compiler products that ordinary execution uses. These alternatives may still have different
 physical ABIs and therefore are not falsely packaged as a runtime `KernelDispatch`; ABI
 normalization or graph-private adapters must precede runtime selection through one dispatch.
+For static shapes, one-node candidate graphs now provide exactly that normalization: the logical
+operand/result pointers form the shared external ABI, while leaf-only `M/N/K` or flattened segment
+bounds remain checked graph-private integer scalars. Runtime-dependent private dimensions are
+refused until they are represented in a shared public scalar ABI, preventing an offline sample from
+being mistaken for a valid dynamic specialization.
 
 Tensor contraction uses that same semantic operator rather than reconstructing `init`, `combine`
 and a fold body in `contract-lower`. The single contraction-facts derivation now owns its canonical

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -25,6 +25,8 @@
             [raster.compiler.ir.contraction-facts :as cf]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.soac-dialect :as soac-dialect]
@@ -568,6 +570,140 @@
       (throw (ex-info "no executable typed contraction candidates"
                       {:reason :typed-contraction-no-candidates
                        :route result})))))
+
+(def ^:private logical-pointer-fields
+  [:kind :dtype :kernel-dtype :role :binding :field])
+
+(defn- artifact-pointer-interface
+  [artifact]
+  (->> (map vector (:abi artifact) (:arguments artifact))
+       (remove (fn [[slot _]] (= :scalar (:kind slot))))
+       vec))
+
+(defn- common-pointer-interface
+  [candidates operation-id]
+  (let [interfaces (mapv (comp artifact-pointer-interface :artifact) candidates)
+        arguments (mapv second (first interfaces))]
+    (doseq [[candidate interface] (map vector candidates interfaces)]
+      (when-not (= arguments (mapv second interface))
+        (throw (ex-info "typed contraction candidates have different logical pointer arguments"
+                        {:reason :typed-contraction-candidate-pointer-arguments
+                         :operation operation-id
+                         :family (:family candidate)
+                         :expected arguments
+                         :actual (mapv second interface)}))))
+    (let [abi
+          (mapv
+           (fn [index argument]
+             (let [slots (mapv #(first (nth % index)) interfaces)
+                   semantic-views (mapv #(select-keys % logical-pointer-fields) slots)
+                   _ (when-not (apply = semantic-views)
+                       (throw (ex-info
+                               "typed contraction candidates have incompatible pointer semantics"
+                               {:reason :typed-contraction-candidate-pointer-semantics
+                                :operation operation-id :argument argument
+                                :slots slots})))
+                   aliasing (when (some #(= :no-write-alias (:aliasing %)) slots)
+                              :no-write-alias)
+                   alignments (keep :alignment slots)
+                   alignment (when (seq alignments) (apply max alignments))]
+               (cond-> (assoc (first slots) :name argument)
+                 aliasing (assoc :aliasing aliasing)
+                 (nil? aliasing) (dissoc :aliasing)
+                 alignment (assoc :alignment alignment)
+                 (nil? alignment) (dissoc :alignment))))
+           (range (count arguments)) arguments)]
+      (kabi/validate! abi)
+      {:abi abi :arguments arguments})))
+
+(defn- static-private-scalars!
+  [candidate operation-id]
+  (doseq [[slot compiler-value] (map vector (get-in candidate [:artifact :abi])
+                                      (get-in candidate [:artifact :arguments]))
+          :when (= :scalar (:kind slot))]
+    (when-not (and (contains? #{:int :long} (:kernel-dtype slot))
+                   (or (integer? compiler-value)
+                       (and (klaunch/expression? compiler-value)
+                            (empty? (klaunch/expression-references compiler-value)))))
+      (throw (ex-info
+              "static typed contraction dispatch has a runtime-dependent private scalar"
+              {:reason :typed-contraction-dispatch-dynamic-scalar
+               :operation operation-id
+               :family (:family candidate)
+               :slot slot
+               :compiler-value compiler-value}))))
+  candidate)
+
+(defn- graph-buffer-role
+  [kind]
+  (case kind
+    :input :input
+    :output :output
+    :inout :inout))
+
+(defn- candidate-graph
+  [candidate operation-id common-abi common-arguments]
+  (let [{:keys [family strategy artifact candidate-schedule]} candidate
+        artifact (kart/validate! artifact)
+        buffers (mapv (fn [slot argument]
+                        [argument
+                         (kgraph/buffer argument (:dtype slot)
+                                        (when (contains? #{:output :inout} (:kind slot))
+                                          (get-in artifact [:attributes :out-elems]))
+                                        :device (graph-buffer-role (:kind slot)))])
+                      common-abi common-arguments)
+        buffer-map (into {} buffers)
+        inputs (into [] (comp (filter #(contains? #{:input :inout} (:kind (first %))))
+                              (map #(get buffer-map (second %))))
+                     (map vector common-abi common-arguments))
+        outputs (into [] (comp (filter #(contains? #{:output :inout} (:kind (first %))))
+                               (map #(get buffer-map (second %))))
+                      (map vector common-abi common-arguments))
+        uses (mapv (fn [slot argument]
+                     (kgraph/->ValueUse argument (kabi/slot-access slot)))
+                   common-abi common-arguments)]
+    (kgraph/make
+     {:inputs inputs
+      :outputs outputs
+      :abi common-abi
+      :arguments common-arguments
+      :nodes [(kgraph/->ScheduledKernel
+               [:typed-contraction operation-id family strategy] artifact uses [])]
+      :effects (:effects artifact)
+      :provenance {:operation-id operation-id
+                   :semantic-op :contraction
+                   :lowering :typed-contraction-candidate}
+      :attributes {:strategy strategy
+                   :candidate-family family
+                   :candidate-schedule candidate-schedule}})))
+
+(defn route-static-typed-contraction-dispatch
+  "Normalize legal static typed contraction leaves behind one logical ABI-compatible dispatch.
+
+   Leaf-only dimensions remain graph-private derived scalars, so matrix, register-tiled and
+   portable kernels can compete through the existing KernelDispatch tuning machinery. This
+   function refuses runtime-dependent private scalars; dynamic-shape dispatch requires those
+   dimensions in a common public scalar ABI rather than silently baking one sample."
+  [program operation-id schedule & options]
+  (let [{:keys [candidates] :as routed}
+        (apply route-typed-contraction-candidates!
+               program operation-id schedule options)
+        candidates (mapv #(static-private-scalars! % operation-id) candidates)
+        {:keys [abi arguments]} (common-pointer-interface candidates operation-id)
+        alternatives (mapv #(candidate-graph % operation-id abi arguments) candidates)
+        default-strategy (:strategy (first candidates))]
+    (kdispatch/make
+     {:id (str "typed-contraction:" (pr-str operation-id))
+      :alternatives alternatives
+      :default-strategy default-strategy
+      :selector {:kind :fixed-strategy :strategy default-strategy}
+      :provenance {:operation-id operation-id
+                   :semantic-op :contraction
+                   :source-dialect :typed-soac}
+      :attributes {:operation-family :typed-contraction
+                   :candidate-schedules
+                   (into {} (map (juxt :strategy :candidate-schedule)) candidates)
+                   :declines (:declines routed)}})))
 
 (def ^:private decline-reasons
   "The reasons a tensorize leaf may legitimately REFUSE a shape — a WHITELIST.

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -240,6 +240,17 @@
   "Target schedule families for ordinary scalar typed contractions."
   #{:matrix :register-tiled :portable})
 
+(def ^:private strategy-family
+  {:dpas :matrix
+   :dp4a :matrix
+   :regtiled :register-tiled
+   :portable-segred :portable
+   :naive-segred :portable
+   :full-reduce :portable
+   :segmap :portable
+   :quant-naive :portable
+   :staged-segred :portable})
+
 (defn- epilogue-honoured-or-refused
   "An :epilogue is a STORE SPLICE, and only the DPAS leaf has one. Every other leaf drops it
    silently — the consumer's computation vanishes with no error.
@@ -502,14 +513,25 @@
                              :operation operation-id
                              :equation-dtype equation-dtype
                              :route-dtype (:dtype options)})))
-        facts (cf/from-components components)]
-    (apply route-contraction nil
-           (mapcat identity
-                   (assoc options
-                          :dtype equation-dtype
-                          :facts facts
-                          :candidate-families families
-                          :operation-id operation-id)))))
+        facts (cf/from-components components)
+        routed (apply route-contraction nil
+                      (mapcat identity
+                              (assoc options
+                                     :dtype equation-dtype
+                                     :facts facts
+                                     :candidate-families families
+                                     :operation-id operation-id)))
+        selected-family (get strategy-family (:strategy routed))]
+    (when-not (contains? (set families) selected-family)
+      (throw (ex-info "selected contraction leaf is outside the enabled schedule families"
+                      {:reason :no-legal-contraction-family
+                       :operation operation-id
+                       :families families
+                       :declines [{:leaf (:strategy routed)
+                                   :reason :strategy-outside-schedule-families
+                                   :data {:selected-family selected-family
+                                          :enabled-families families}}]})))
+    routed))
 
 (defn- enabled-family-decline?
   [decline]
@@ -618,6 +640,13 @@
 
 (defn- static-private-scalars!
   [candidate operation-id]
+  (when (:invoke candidate)
+    (throw (ex-info "typed contraction candidate uses a non-graph leaf invocation protocol"
+                    {:reason :typed-contraction-dispatch-invoke-protocol
+                     :operation operation-id
+                     :family (:family candidate)
+                     :strategy (:strategy candidate)
+                     :invoke (:invoke candidate)})))
   (doseq [[slot compiler-value] (map vector (get-in candidate [:artifact :abi])
                                       (get-in candidate [:artifact :arguments]))
           :when (= :scalar (:kind slot))]

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -731,6 +731,17 @@
     (doseq [alternative alternatives]
       (is (kernel-graph-call/kernel-graph-call?
            (kernel-graph-call/make alternative {'A :a 'B :b 'C :c} {}))))
+    (with-redefs [contract-route/route-contraction (fn [& _] {:strategy :full-reduce})]
+      (try
+        (contract-route/route-typed-contraction
+         algorithm (:id operation)
+         (assoc-in (:schedule operation) [:tuning-space :families] [:matrix])
+         :dtype :half :desc descriptor)
+        (is false "a routed leaf outside the pinned schedule family must be rejected")
+        (catch clojure.lang.ExceptionInfo exception
+          (is (= :no-legal-contraction-family (:reason (ex-data exception))))
+          (is (= :strategy-outside-schedule-families
+                 (get-in (ex-data exception) [:declines 0 :reason]))))))
     (doseq [families [[] [:unknown]]]
       (try
         (contract-route/route-typed-contraction

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -4,6 +4,7 @@
             [raster.compiler.backend.jvm.par-simd :as par-simd]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-graph :as kernel-graph]
+            [raster.compiler.ir.kernel-graph-call :as kernel-graph-call]
             [raster.compiler.ir.kernel-launch :as kernel-launch]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
@@ -629,6 +630,14 @@
     (is (not-any? #(= :schedule-family-disabled (:reason %))
                   (:declines candidate-routes)))
     (try
+      (contract-route/route-static-typed-contraction-dispatch
+       algorithm (:id operation) (:schedule operation)
+       :dtype :float :desc {})
+      (is false "a static dispatch must not bake runtime-dependent contraction dimensions")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :typed-contraction-dispatch-dynamic-scalar
+               (:reason (ex-data exception))))))
+    (try
       (contract-route/route-typed-contraction
        algorithm (:id operation) (:schedule operation) :dtype :double :desc {})
       (is false "a route dtype that disagrees with the typed equation must fail")
@@ -692,7 +701,12 @@
         candidates
         (contract-route/route-typed-contraction-candidates!
          algorithm (:id operation) (:schedule operation)
-         :dtype :half :desc descriptor)]
+         :dtype :half :desc descriptor)
+        dispatch
+        (contract-route/route-static-typed-contraction-dispatch
+         algorithm (:id operation) (:schedule operation)
+         :dtype :half :desc descriptor)
+        alternatives (:alternatives dispatch)]
     (is (= :dpas (:strategy (select-family :matrix))))
     (is (= :regtiled (:strategy (select-family :register-tiled))))
     (is (= :portable-segred (:strategy (select-family :portable))))
@@ -705,6 +719,18 @@
                  (:candidates candidates))))
     (is (every? (comp some? :artifact) (:candidates candidates)))
     (is (empty? (:declines candidates)))
+    (is (= :dpas (:default-strategy dispatch)))
+    (is (= [:dpas :regtiled :portable-segred]
+           (mapv #(get-in % [:attributes :strategy]) alternatives)))
+    (is (every? kernel-graph/kernel-graph? alternatives))
+    (is (apply = (map :abi alternatives)))
+    (is (= '[A B C] (:arguments (first alternatives))))
+    (is (= [6 3 4]
+           (mapv #(count (get-in % [:nodes 0 :operation :abi])) alternatives))
+        "leaf-only shape scalars stay private to each candidate graph")
+    (doseq [alternative alternatives]
+      (is (kernel-graph-call/kernel-graph-call?
+           (kernel-graph-call/make alternative {'A :a 'B :b 'C :c} {}))))
     (doseq [families [[] [:unknown]]]
       (try
         (contract-route/route-typed-contraction


### PR DESCRIPTION
## Summary

- wrap static typed contraction leaves in one-node KernelGraphs with one logical operand/result ABI
- keep leaf-specific shape arguments as checked graph-private integer scalars
- expose matrix, register-tiled, and portable schedules through the existing KernelDispatch boundary
- refuse runtime-dependent private dimensions until they are represented in the common public ABI

## Architecture

This deliberately reuses KernelGraph + KernelDispatch, so contraction candidates can use Raster’s existing validated fixed-selector autotuner. It does not introduce a contraction-specific tuning value.

## Testing

- `clojure -M:test -n raster.compiler.passes.parallel.typed-soac-route-test -n raster.compiler.ir.kernel-dispatch-test -n raster.compiler.ir.kernel-graph-call-test` — 47 tests, 306 assertions