### PR TITLE
Emit typed contraction schedule dispatches

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -348,6 +348,11 @@ operand/result pointers form the shared external ABI, while leaf-only `M/N/K` or
 bounds remain checked graph-private integer scalars. Runtime-dependent private dimensions are
 refused until they are represented in a shared public scalar ABI, preventing an offline sample from
 being mistaken for a valid dynamic specialization.
+The production OpenCL pass registers those static graphs as one fixed-selector dispatch and invokes
+it through the generic scheduled-executable runner. It emits every legal leaf once, preserves the
+current analytic winner as the default, and records dynamic-shape or special-protocol declines
+instead of hiding a fallback. The remaining closed-loop step is a tuning contract that maps a
+validated measured fixed selector back into the resolved schedule/cache on recompilation.
 
 Tensor contraction uses that same semantic operator rather than reconstructing `init`, `combine`
 and a fold body in `contract-lower`. The single contraction-facts derivation now owns its canonical

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -478,37 +478,68 @@
                                      'raster.compiler.core.hardware/descriptor-for)
                                     device-id)
                                    (catch Throwable _ nil))
-                  r (ensure-contraction-marker-expressible!
-                     (if bound-sr
-                       (croute/route-typed-contraction
-                        typed-algorithm (:id bound-sr) (:schedule bound-sr)
-                        :dtype dtype :tile (:tile schedule) :desc target-desc)
-                       (croute/route-contraction
-                        ;; A compatibility equation routes from its verified facts. Without a
-                        ;; scheduled operation, the direct backend door still consumes the form.
-                        (when-not bound-sc form) :dtype dtype
-                        :facts (:facts bound-sc)
-                        :operation-id (:id bound-sc)
-                        ;; The resolved, feasibility-checked schedule is the single source of tile
-                        ;; geometry.  Previously this option reached opencl-pass but contractions
-                        ;; ignored it and re-derived a default, so a pinned/autotuned :tile changed
-                        ;; neither the KernelBody nor emitted source.
-                        :tile (:tile schedule) :desc target-desc)))
-                  ;; Every routed single-entry leaf is now a complete executable artifact. Routing
-                  ;; diagnostics and tensorization facts live in its attributes/provenance rather
-                  ;; than being flattened into the runtime registry namespace.
-                  kernel (:artifact r)
-                  k (register-kernel! kernel
-                                      :ze-contracts)]
-              ;; A full reduction (0 free axes) has its own two-phase launch protocol + a
-              ;; host-side final combine — emit the reduction invoke, not the 2-D contraction one.
-              (if (= :reduction (:invoke r))
-                (emit-reduction-invocation k nil)
-                ;; The staging marker carries only ordered values. Output extent and complete 2-D
-                ;; launch live in the artifact; resident extraction never reconstructs geometry.
-                (list 'raster.gpu.ze-runtime/invoke-registered-contraction!
-                      (:kernel-name k)
-                      (vec (:arguments r)))))
+                  typed-dispatch
+                  (when bound-sr
+                    (try
+                      (croute/route-static-typed-contraction-dispatch
+                       typed-algorithm (:id bound-sr) (:schedule bound-sr)
+                       :dtype dtype :tile (:tile schedule) :desc target-desc)
+                      (catch clojure.lang.ExceptionInfo exception
+                        (let [reason (:reason (ex-data exception))]
+                          (if (contains? #{:typed-contraction-dispatch-dynamic-scalar
+                                           :typed-contraction-dispatch-invoke-protocol}
+                                         reason)
+                            (do
+                              (swap! stats update-in [:typed-contraction-dispatch-declines reason]
+                                     (fnil inc 0))
+                              nil)
+                            (throw exception))))))]
+              (if typed-dispatch
+                (let [dispatch
+                      (-> typed-dispatch
+                          (update :alternatives
+                                  (fn [alternatives]
+                                    (mapv
+                                     (fn [graph]
+                                       (kgraph/map-operations
+                                        graph
+                                        (fn [node]
+                                          (maybe-compile-spirv (:operation node)
+                                                               compile-spirv? device-id))))
+                                     alternatives)))
+                          kdispatch/validate!)
+                      artifacts (mapv :operation (mapcat :nodes (:alternatives dispatch)))
+                      executable (kdispatch/default-alternative dispatch)]
+                  (swap! kernels into artifacts)
+                  (swap! dispatches conj dispatch)
+                  (swap! stats update :ze-contracts inc)
+                  (swap! stats update :kernel-graphs inc)
+                  (list 'raster.compiler.pipeline/invoke-scheduled-executable!
+                        device-id (:id dispatch) (vec (:arguments executable))))
+                (let [r (ensure-contraction-marker-expressible!
+                         (if bound-sr
+                           (croute/route-typed-contraction
+                            typed-algorithm (:id bound-sr) (:schedule bound-sr)
+                            :dtype dtype :tile (:tile schedule) :desc target-desc)
+                           (croute/route-contraction
+                            ;; A compatibility equation routes from its verified facts. Without a
+                            ;; scheduled operation, the direct backend door still consumes the form.
+                            (when-not bound-sc form) :dtype dtype
+                            :facts (:facts bound-sc)
+                            :operation-id (:id bound-sc)
+                            ;; The resolved, feasibility-checked schedule is the single source of
+                            ;; tile geometry. Previously this option reached opencl-pass but
+                            ;; contractions ignored it and re-derived a default.
+                            :tile (:tile schedule) :desc target-desc)))
+                      ;; A non-dispatchable leaf retains its complete executable artifact and
+                      ;; specialized invocation protocol.
+                      kernel (:artifact r)
+                      k (register-kernel! kernel :ze-contracts)]
+                  (if (= :reduction (:invoke r))
+                    (emit-reduction-invocation k nil)
+                    (list 'raster.gpu.ze-runtime/invoke-registered-contraction!
+                          (:kernel-name k)
+                          (vec (:arguments r)))))))
 
             ;; === par/reduce-into — resident SegRed writing a caller-supplied 1-elem buffer ===
             ;; Same SegRed kernel as par/reduce (it already has an `output` param), but the

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -675,6 +675,9 @@
     (is (= 1 (get-in emitted [:stats :ze-contracts])))
     (is (= 1 (get-in emitted [:stats :segop-reused])))
     (is (nil? (get-in emitted [:stats :segop-relowered])))
+    (is (= 1 (get-in emitted [:stats :typed-contraction-dispatch-declines
+                              :typed-contraction-dispatch-dynamic-scalar])))
+    (is (empty? (:dispatches emitted)))
     (is (= 1 (count (:kernels emitted))))))
 
 (deftest typed-contraction-schedule-families-control-leaf-selection
@@ -706,7 +709,10 @@
         (contract-route/route-static-typed-contraction-dispatch
          algorithm (:id operation) (:schedule operation)
          :dtype :half :desc descriptor)
-        alternatives (:alternatives dispatch)]
+        alternatives (:alternatives dispatch)
+        emitted (opencl-pass/opencl-pass form :device-id :ocl:0
+                                             :dtype :half :min-elements 0)
+        emitted-dispatch (first (:dispatches emitted))]
     (is (= :dpas (:strategy (select-family :matrix))))
     (is (= :regtiled (:strategy (select-family :register-tiled))))
     (is (= :portable-segred (:strategy (select-family :portable))))
@@ -731,6 +737,16 @@
     (doseq [alternative alternatives]
       (is (kernel-graph-call/kernel-graph-call?
            (kernel-graph-call/make alternative {'A :a 'B :b 'C :c} {}))))
+    (is (= 1 (count (:dispatches emitted))))
+    (is (= [:dpas :regtiled :portable-segred]
+           (mapv #(get-in % [:attributes :strategy])
+                 (:alternatives emitted-dispatch))))
+    (is (some #(and (seq? %)
+                    (= 'raster.compiler.pipeline/invoke-scheduled-executable! (first %)))
+              (tree-seq coll? seq (:form emitted))))
+    (is (= 3 (count (:kernels emitted))))
+    (is (= 1 (get-in emitted [:stats :ze-contracts])))
+    (is (= 1 (get-in emitted [:stats :kernel-graphs])))
     (with-redefs [contract-route/route-contraction (fn [& _] {:strategy :full-reduce})]
       (try
         (contract-route/route-typed-contraction

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
             [raster.compiler.backend.jvm.par-simd :as par-simd]
+            [raster.compiler.core.hardware :as hardware]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-graph :as kernel-graph]
             [raster.compiler.ir.kernel-graph-call :as kernel-graph-call]
@@ -710,8 +711,9 @@
          algorithm (:id operation) (:schedule operation)
          :dtype :half :desc descriptor)
         alternatives (:alternatives dispatch)
-        emitted (opencl-pass/opencl-pass form :device-id :ocl:0
-                                             :dtype :half :min-elements 0)
+        emitted (with-redefs [hardware/descriptor-for (constantly descriptor)]
+                  (opencl-pass/opencl-pass form :device-id :ocl:0
+                                           :dtype :half :min-elements 0))
         emitted-dispatch (first (:dispatches emitted))]
     (is (= :dpas (:strategy (select-family :matrix))))
     (is (= :regtiled (:strategy (select-family :register-tiled))))


### PR DESCRIPTION
## Summary

- emit eligible static TypedSOAC contractions as ABI-compatible KernelDispatch alternatives in the production OpenCL pass
- register matrix, register-tiled, and portable graph leaves once and invoke them through the generic scheduled-executable runner
- preserve the current analytic winner as the fixed default
- retain dynamic-shape and specialized-protocol leaves on their explicit paths with structured decline statistics

## Testing

- focused typed route/dispatch/graph suites
- pipeline, kernel-call pipeline, and SegOp consumption suites
- 86 tests, 455 assertions