### PR TITLE
Persist typed contraction tuning selectors

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -351,8 +351,12 @@ being mistaken for a valid dynamic specialization.
 The production OpenCL pass registers those static graphs as one fixed-selector dispatch and invokes
 it through the generic scheduled-executable runner. It emits every legal leaf once, preserves the
 current analytic winner as the default, and records dynamic-shape or special-protocol declines
-instead of hiding a fallback. The remaining closed-loop step is a tuning contract that maps a
-validated measured fixed selector back into the resolved schedule/cache on recompilation.
+instead of hiding a fallback. Each dispatch carries the generic tuning contract that maps a
+validated measured fixed selector into `[:typed-contraction :measured-selectors <dispatch-id>]` in
+the resolved schedule. Its ID and entry points are derived deterministically from canonical emitted
+candidates, so recompilation reproduces the executable identity and can consume a cache hit without
+benchmarking. Measurement remains an explicit runtime action guarded by the existing oracle,
+device-event, stationarity, numerical-mode and layout checks.
 
 Tensor contraction uses that same semantic operator rather than reconstructing `init`, `combine`
 and a fold body in `contract-lower`. The single contraction-facts derivation now owns its canonical

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -495,7 +495,15 @@
                               nil)
                             (throw exception))))))]
               (if typed-dispatch
-                (let [dispatch
+                (let [measured-selector
+                      (get-in schedule [:typed-contraction :measured-selectors
+                                        (:id typed-dispatch)])
+                      typed-dispatch
+                      (if measured-selector
+                        (-> (kdispatch/with-selector typed-dispatch measured-selector)
+                            (assoc-in [:attributes :selection] :measured-fixed))
+                        typed-dispatch)
+                      dispatch
                       (-> typed-dispatch
                           (update :alternatives
                                   (fn [alternatives]

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -706,6 +706,44 @@
                    :candidate-family family
                    :candidate-schedule candidate-schedule}})))
 
+(defn- candidate-dispatch-id
+  [operation-id candidates]
+  (let [identity
+        [operation-id
+         (mapv (fn [{:keys [family strategy artifact]}]
+                 (let [kernel-name (:kernel-name artifact)]
+                   {:family family
+                    :strategy strategy
+                    :artifact (-> (select-keys artifact
+                                               [:target :source :abi :arguments :launch :effects])
+                                  (update :source str/replace kernel-name "<entry-point>"))}))
+               candidates)]]
+    (format "raster_typed_contraction_dispatch_%08x"
+            (bit-and 0xffffffff (long (hash identity))))))
+
+(defn- deterministic-candidate-entry-point
+  [candidate dispatch-id]
+  (let [artifact (kart/validate! (:artifact candidate))
+        old-name (:kernel-name artifact)
+        strategy-name (str/replace (name (:strategy candidate)) #"[^A-Za-z0-9_]" "_")
+        new-name (str dispatch-id "_" strategy-name)]
+    (assoc candidate :artifact
+           (kart/validate!
+            (-> artifact
+                (assoc :kernel-name new-name)
+                (update :source str/replace old-name new-name))))))
+
+(defn- typed-contraction-tuning-contract
+  [schedule dispatch-id abi]
+  (let [interface (mapv #(select-keys % [:kind :dtype :kernel-dtype :role
+                                         :aliasing :alignment])
+                        abi)]
+    {:schedule-path [:typed-contraction :measured-selectors]
+     :schedule-key dispatch-id
+     :numerical-mode {:reduction (:numerical-mode schedule)
+                      :interface interface}
+     :layout {:external-interface interface}}))
+
 (defn route-static-typed-contraction-dispatch
   "Normalize legal static typed contraction leaves behind one logical ABI-compatible dispatch.
 
@@ -719,10 +757,12 @@
                program operation-id schedule options)
         candidates (mapv #(static-private-scalars! % operation-id) candidates)
         {:keys [abi arguments]} (common-pointer-interface candidates operation-id)
-        alternatives (mapv #(candidate-graph % operation-id abi arguments) candidates)
-        default-strategy (:strategy (first candidates))]
+        default-strategy (:strategy (first candidates))
+        dispatch-id (candidate-dispatch-id operation-id candidates)
+        candidates (mapv #(deterministic-candidate-entry-point % dispatch-id) candidates)
+        alternatives (mapv #(candidate-graph % operation-id abi arguments) candidates)]
     (kdispatch/make
-     {:id (str "typed-contraction:" (pr-str operation-id))
+     {:id dispatch-id
       :alternatives alternatives
       :default-strategy default-strategy
       :selector {:kind :fixed-strategy :strategy default-strategy}
@@ -732,7 +772,9 @@
       :attributes {:operation-family :typed-contraction
                    :candidate-schedules
                    (into {} (map (juxt :strategy :candidate-schedule)) candidates)
-                   :declines (:declines routed)}})))
+                   :declines (:declines routed)
+                   :tuning (typed-contraction-tuning-contract schedule dispatch-id abi)
+                   :selection :analytic-fixed}})))
 
 (def ^:private decline-reasons
   "The reasons a tensorize leaf may legitimately REFUSE a shape — a WHITELIST.

--- a/src/raster/gpu/schedule.clj
+++ b/src/raster/gpu/schedule.clj
@@ -68,6 +68,10 @@
     :segmented-weighted-reduction {:strategy :auto
                                    :score-reuse-subgroup-multiple 16
                                    :measured-selectors {}}
+    ;; Static typed contractions emit ABI-normalized schedule alternatives. Offline fixed-shape
+    ;; tuning writes the validated selector here; recompilation consumes it without benchmarking.
+    :typed-contraction {:strategy :auto
+                        :measured-selectors {}}
     :meta  {:target (:device-id desc)
             :machine-params (machine-params desc)
             :derived-by :raster.gpu.schedule/derive-default
@@ -90,6 +94,7 @@
 (def ^:private valid-grf-modes #{:grf128 :grf256})
 (def ^:private valid-segmented-reduction-strategies
   #{:auto :reference :subgroup-score-reuse})
+(def ^:private valid-typed-contraction-strategies #{:auto})
 
 (defn resolve
   "Stage 2: deep-merge a user `override` schedule onto the derived default, recording the pinned
@@ -195,6 +200,10 @@
         (get-in schedule [:segmented-weighted-reduction :score-reuse-subgroup-multiple] 16)
         measured-selectors
         (get-in schedule [:segmented-weighted-reduction :measured-selectors] {})
+        typed-contraction-strategy
+        (get-in schedule [:typed-contraction :strategy] :auto)
+        typed-contraction-selectors
+        (get-in schedule [:typed-contraction :measured-selectors] {})
         {:keys [target-fill-multiple min-split-chunk max-splits]}
         (:gemm-dispatch schedule)]
     (when-not (valid-precisions prec)
@@ -222,6 +231,17 @@
       (throw (ex-info "schedule: measured selectors require :strategy :auto"
                       {:strategy reduction-strategy
                        :measured-selectors measured-selectors})))
+    (when-not (valid-typed-contraction-strategies typed-contraction-strategy)
+      (throw (ex-info "schedule: unknown typed contraction strategy"
+                      {:strategy typed-contraction-strategy
+                       :expected valid-typed-contraction-strategies})))
+    (when-not (and (map? typed-contraction-selectors)
+                   (every? #(and (string? %) (not-empty %))
+                           (keys typed-contraction-selectors))
+                   (every? map? (vals typed-contraction-selectors)))
+      (throw (ex-info
+              "schedule: measured typed contraction selectors must map dispatch IDs to selector maps"
+              {:measured-selectors typed-contraction-selectors})))
     (doseq [[field value] [[:target-fill-multiple target-fill-multiple]
                            [:min-split-chunk min-split-chunk]
                            [:max-splits max-splits]]]

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -14,7 +14,9 @@
             [raster.compiler.pipeline :as pipeline]
             [raster.compiler.passes.parallel.contract-route :as contract-route]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
-            [raster.compiler.passes.parallel.typed-soac-route :as route]))
+            [raster.compiler.passes.parallel.typed-soac-route :as route]
+            [raster.gpu.dispatch-tuning :as dispatch-tuning]
+            [raster.gpu.program-tuning :as program-tuning]))
 
 (def ^:private map-map
   '(let* [y (raster.par/pmap i n float
@@ -714,7 +716,15 @@
         emitted (with-redefs [hardware/descriptor-for (constantly descriptor)]
                   (opencl-pass/opencl-pass form :device-id :ocl:0
                                            :dtype :half :min-elements 0))
-        emitted-dispatch (first (:dispatches emitted))]
+        emitted-dispatch (first (:dispatches emitted))
+        measured-selector {:kind :fixed-strategy :strategy :portable-segred}
+        measured-emitted
+        (with-redefs [hardware/descriptor-for (constantly descriptor)]
+          (opencl-pass/opencl-pass
+           form :device-id :ocl:0 :dtype :half :min-elements 0
+           :schedule {:typed-contraction
+                      {:measured-selectors {(:id emitted-dispatch) measured-selector}}}))
+        measured-dispatch (first (:dispatches measured-emitted))]
     (is (= :dpas (:strategy (select-family :matrix))))
     (is (= :regtiled (:strategy (select-family :register-tiled))))
     (is (= :portable-segred (:strategy (select-family :portable))))
@@ -728,6 +738,15 @@
     (is (every? (comp some? :artifact) (:candidates candidates)))
     (is (empty? (:declines candidates)))
     (is (= :dpas (:default-strategy dispatch)))
+    (is (re-matches #"raster_typed_contraction_dispatch_[0-9a-f]{8}" (:id dispatch)))
+    (is (= [:typed-contraction :measured-selectors]
+           (get-in dispatch [:attributes :tuning :schedule-path])))
+    (is (= (:id dispatch) (get-in dispatch [:attributes :tuning :schedule-key])))
+    (is (map? (get-in dispatch [:attributes :tuning :numerical-mode])))
+    (is (map? (get-in dispatch [:attributes :tuning :layout])))
+    (is (= {:path [:typed-contraction :measured-selectors]
+            :key (:id dispatch)}
+           (get-in (program-tuning/dispatch-signature dispatch) [:schedule-target])))
     (is (= [:dpas :regtiled :portable-segred]
            (mapv #(get-in % [:attributes :strategy]) alternatives)))
     (is (every? kernel-graph/kernel-graph? alternatives))
@@ -749,6 +768,12 @@
     (is (= 3 (count (:kernels emitted))))
     (is (= 1 (get-in emitted [:stats :ze-contracts])))
     (is (= 1 (get-in emitted [:stats :kernel-graphs])))
+    (is (= (:id emitted-dispatch) (:id measured-dispatch)))
+    (is (= (mapv dispatch-tuning/executable-signature (:alternatives emitted-dispatch))
+           (mapv dispatch-tuning/executable-signature (:alternatives measured-dispatch)))
+        "counter-based emitter names must not invalidate the tuning cache on recompilation")
+    (is (= measured-selector (:selector measured-dispatch)))
+    (is (= :measured-fixed (get-in measured-dispatch [:attributes :selection])))
     (with-redefs [contract-route/route-contraction (fn [& _] {:strategy :full-reduce})]
       (try
         (contract-route/route-typed-contraction

--- a/test/raster/gpu/schedule_test.clj
+++ b/test/raster/gpu/schedule_test.clj
@@ -56,6 +56,9 @@
       (is (= {:strategy :auto :score-reuse-subgroup-multiple 16
               :measured-selectors {}}
              (:segmented-weighted-reduction derived))))
+    (testing "static typed contractions default to analytic fixed selection"
+      (is (= {:strategy :auto :measured-selectors {}}
+             (:typed-contraction derived))))
     (testing "GEMM dispatch policy is explicit, serializable schedule data"
       (is (= {:target-fill-multiple 4 :min-split-chunk 1024 :max-splits 64}
              (:gemm-dispatch derived))))
@@ -151,6 +154,18 @@
                              {:strategy :reference
                               :measured-selectors
                               {"dispatch-a" {:kind :runtime-scalar-ranges}}}})
+                           arc-desc))))
+  (testing "typed contraction selectors are validated as persistent schedule data"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"unknown typed contraction strategy"
+                          (sched/feasible?
+                           (sched/resolve (sched/derive-default nil arc-desc)
+                                          {:typed-contraction {:strategy :matrix}})
+                           arc-desc)))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"measured typed contraction selectors must map dispatch IDs"
+                          (sched/feasible?
+                           (sched/resolve (sched/derive-default nil arc-desc)
+                                          {:typed-contraction {:measured-selectors :invalid}})
                            arc-desc))))
   (testing "GEMM dispatch controls reject missing, zero, and non-integral policy data"
     (doseq [invalid [{:max-splits 0}


### PR DESCRIPTION
## Summary

- derive stable dispatch IDs from canonical emitted candidates and replace counter-based leaf names with deterministic entry points
- attach Raster’s generic tuning contract to typed contraction dispatches
- persist fixed measured selectors under the resolved schedule and consume them on recompilation
- validate typed-contraction selector schedule data in the common feasibility gate

## Correctness boundary

Benchmarking remains explicit. Existing oracle validation, device-event timing, stationarity, numerical-mode, layout, device, ABI, and source identity gates remain authoritative. Compilation only consumes an already validated selector.

## Testing

- typed route, schedule, program tuning, dispatch tuning/benchmark, and pipeline suites
- 82 tests, 482 assertions