### PR TITLE
Type contraction result transforms

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -332,10 +332,16 @@ contraction facts from that equation behind a typed routing API and never repars
 form; the OpenCL pipeline
 therefore knows only the typed program, stable operation ID and certified candidate schedule, not
 the projection used by compatibility leaves. Only host materialization and compatibility leaves
-request a generated surface spelling. Staged quantization, decode lambdas,
-declared physical maps, epilogues and output conversions remain on the certified compatibility
-front door, and may still use `SegContract`, until the typed equation has explicit facts for them;
-admitting them while dropping those contracts would be a miscompile, not migration progress.
+request a generated surface spelling. A segmented reduction may now carry one typed scalar
+result-transform: its accumulator, expression, result dtype, tensor operands with axis maps/dtypes,
+and uniform scalar captures with dtypes are all verified at the equation boundary. Contraction
+epilogues expressed by that closed contract therefore stay on TypedSOAC and lower through the same
+matrix store region and ordered ABI as the proven compatibility oracle. Discovering a following map
+as such a transform remains separate alias-aware fusion work; it must not rewrite the fold lambda.
+Staged quantization, decode lambdas, declared physical operand maps and output conversions remain on
+the certified compatibility front door, and may still use `SegContract`, until the typed equation
+has explicit facts for them; admitting them while dropping those contracts would be a miscompile,
+not migration progress.
 
 The typed route can also enumerate every legal enabled contraction family without benchmarking or
 choosing among them. Each result retains its pinned `ReductionSchedule`, concrete strategy,
@@ -344,8 +350,9 @@ same compiler products that ordinary execution uses. These alternatives may stil
 physical ABIs and therefore are not falsely packaged as a runtime `KernelDispatch`; ABI
 normalization or graph-private adapters must precede runtime selection through one dispatch.
 For static shapes, one-node candidate graphs now provide exactly that normalization: the logical
-operand/result pointers form the shared external ABI, while leaf-only `M/N/K` or flattened segment
-bounds remain checked graph-private integer scalars. Runtime-dependent private dimensions are
+operand/result pointers and typed result-transform scalars form the shared external ABI, while
+leaf-only `M/N/K` or flattened segment bounds remain checked graph-private integer scalars.
+Runtime-dependent private dimensions are
 refused until they are represented in a shared public scalar ABI, preventing an offline sample from
 being mistaken for a valid dynamic specialization.
 The production OpenCL pass registers those static graphs as one fixed-selector dispatch and invokes
@@ -362,9 +369,10 @@ Tensor contraction uses that same semantic operator rather than reconstructing `
 and a fold body in `contract-lower`. The single contraction-facts derivation now owns its canonical
 one-component `ProductReduction`, normalized reduced coordinate and flattened semantic body;
 ordinary `SegRed` scheduling and peak routing consume those facts unchanged. The compatibility
-`SegContract` projection is now limited to contractions that are not yet in the typed subset. Free axes,
-operand axis maps, decode/storage precision, epilogues and staged accumulator structure remain
-orthogonal contraction facts and schedule choices. Contraction is therefore an ordinary segmented
+`SegContract` projection is now limited to contractions that are not yet in the typed subset. Free
+axes and typed result transforms are part of the functional equation; operand axis maps,
+decode/storage precision and staged accumulator structure remain orthogonal contraction facts and
+schedule choices. Contraction is therefore an ordinary segmented
 TypedSOAC reduction, not a new hard-coded GEMM algebra; matrix, register-tiled and portable kernels
 are competing schedules for that algebra.
 
@@ -912,6 +920,9 @@ The immediate continuation after the verified double-buffered weighted-reduction
    SegMap on resident OpenCL execution. Their shared typed scalar computations use one explicit
    ordered local-SSA region that lowers once through JVM and GPU paths; vertical and horizontal
    fusion now alpha-rename and compose those regions without duplicating shared scalar work.
+   Explicit typed segmented-reduction result transforms now reach contraction store regions without
+   compatibility re-lowering; alias-aware segmented-reduction→map discovery is the next fusion
+   coverage step.
    Stable indexed gathers and explicitly unique guarded scatters also use this typed scheduled-map
    route, including resident block transfers. Hardware-costed multi-consumer fusion, nested-region
    JVM scheduling, reducing/atomic scatter variants, the remaining parallel forms, and

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -65,6 +65,7 @@
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.scan :as scan-ir]))
 
 (defn value-id?
@@ -144,6 +145,56 @@
        (every? keyword? (:dtypes value))
        (every? map? (:algebra value))))
 
+(defn result-transform?
+  "A typed scalar transform applied once to a completed reduction result.
+
+   This is semantic region data, not target epilogue source: every external value has an explicit
+   operand/scalar role and dtype, and operand indexing is a structured axis map.  Schedules may
+   place the region in a tile store, while untiled lowerings retain the same expression."
+  [value]
+  (let [operands (:operands value)
+        scalars (:scalars value)
+        ids (vec (concat (map :value operands) (map :value scalars)))
+        parameters (when (and (seq? (:lambda value))
+                              (= 'lambda (first (:lambda value))))
+                     (second (:lambda value)))
+        [_ _ region] (:lambda value)
+        [_ locals results] region
+        expected-parameters
+        (vec (concat [(first parameters)]
+                     (map :parameter operands) (map :parameter scalars)))
+        axis-map? (fn [value]
+                    (let [groups (:groups value)]
+                      (and (map? value) (vector? groups) (seq groups)
+                           (every? #(and (vector? %) (seq %)
+                                         (every? (fn [pair]
+                                                   (and (vector? pair) (= 2 (count pair))
+                                                        (value-id? (first pair))
+                                                        (extent? (second pair))))
+                                                 %))
+                                   groups))))]
+    (and (map? value)
+         (vector? parameters) (seq parameters) (every? symbol? parameters)
+         (= parameters expected-parameters)
+         (seq? region) (= 'region (first region))
+         (= [] locals) (vector? results) (= 1 (count results))
+         (vector? operands)
+         (every? (fn [{:keys [value parameter dtype map]}]
+                   (and (value-id? value) (symbol? parameter)
+                        (keyword? dtype) (dtype/known? dtype) (= dtype (dtype/canon dtype))
+                        (axis-map? map)))
+                 operands)
+         (vector? scalars)
+         (every? (fn [{:keys [value parameter dtype]}]
+                   (and (value-id? value) (symbol? parameter)
+                        (keyword? dtype) (dtype/known? dtype) (= dtype (dtype/canon dtype))))
+                 scalars)
+         (= (count ids) (count (distinct ids)))
+         (= (count parameters) (count (distinct parameters)))
+         (keyword? (:result-dtype value))
+         (dtype/known? (:result-dtype value))
+         (= (:result-dtype value) (dtype/canon (:result-dtype value))))))
+
 (defn segmented-reduce-attributes?
   "Attributes for a general segmented reduction. Segment axes are the ordered parallel result
    space; `:index/:extent` remain the innermost reduced axis shared with ordinary reduce."
@@ -156,7 +207,10 @@
                        (symbol? (first %)) (extent? (second %)))
                  axes)
          (= (count indices) (count (distinct indices)))
-         (not (contains? (set indices) (:index value))))))
+         (not (contains? (set indices) (:index value)))
+         (or (nil? (:result-transform value))
+             (and (= 1 (count (:accumulators value)))
+                  (result-transform? (:result-transform value)))))))
 
 (defn scan-attributes?
   "Attributes for a certified scan dialect operation. The explicit mode is load-bearing because
@@ -508,7 +562,8 @@
                  {:equation equation-id :results results :accumulators accumulators})))
 
       segmented-reduce
-      (let [accumulators (:accumulators attributes)]
+      (let [accumulators (:accumulators attributes)
+            transform (:result-transform attributes)]
         (when-not (= accumulators (vec (take (count accumulators) parameters)))
           (fail! :typed-soac-segmented-reduce-accumulators
                  "segmented-reduce accumulator parameters must lead the lambda in declared order"
@@ -516,7 +571,35 @@
         (when-not (= result-count (count accumulators))
           (fail! :typed-soac-segmented-reduce-results
                  "segmented-reduce result arity must equal accumulator arity"
-                 {:equation equation-id :results results :accumulators accumulators})))
+                 {:equation equation-id :results results :accumulators accumulators}))
+        (when transform
+          (let [operand-ids (set (map :value (:operands transform)))
+                scalar-ids (set (map :value (:scalars transform)))
+                transform-ids (set/union operand-ids scalar-ids)
+                stable (set (get-in attributes [:attributes :stable-array-captures]))
+                segment-indices (set (map first (:segment-axes attributes)))
+                {:keys [parameters body-results]} (lambda-parts (:lambda transform))
+                bound (set/union (set parameters) segment-indices)
+                unbound (util/free-syms (first body-results) bound)
+                map-axes (set (mapcat (comp axis-map/axes :map) (:operands transform)))]
+            (when-not (set/subset? transform-ids (set captures))
+              (fail! :typed-soac-result-transform-captures
+                     "segmented-reduce result transforms require explicit capture values"
+                     {:equation equation-id :transform-captures transform-ids
+                      :captures captures}))
+            (when-not (set/subset? operand-ids stable)
+              (fail! :typed-soac-result-transform-operands
+                     "result-transform tensor operands must be stable array captures"
+                     {:equation equation-id :operands operand-ids :stable stable}))
+            (when-not (set/subset? map-axes segment-indices)
+              (fail! :typed-soac-result-transform-axis-map
+                     "result-transform operand maps may reference only segment axes"
+                     {:equation equation-id :axes map-axes
+                      :segment-axes segment-indices}))
+            (when (seq unbound)
+              (fail! :typed-soac-result-transform-expression
+                     "result-transform expressions may reference only their typed region boundary"
+                     {:equation equation-id :unbound unbound :transform transform})))))
 
       scan
       (let [accumulators (:accumulators attributes)]
@@ -810,10 +893,19 @@
                                    (update-in [:attributes :stable-array-captures]
                                               #(mapv rename %)))
                       attributes (if (= 'segmented-reduce kind)
-                                   (update attributes :segment-axes
-                                           #(mapv (fn [[index extent]]
-                                                    [index (if (value-id? extent)
-                                                             (rename extent) extent)]) %))
+                                   (-> attributes
+                                       (update :segment-axes
+                                               #(mapv (fn [[index extent]]
+                                                        [index (if (value-id? extent)
+                                                                 (rename extent) extent)]) %))
+                                       (cond-> (:result-transform attributes)
+                                         (update-in [:result-transform :operands]
+                                                    #(mapv (fn [operand]
+                                                             (update operand :value rename)) %))
+                                         (:result-transform attributes)
+                                         (update-in [:result-transform :scalars]
+                                                    #(mapv (fn [scalar]
+                                                             (update scalar :value rename)) %))))
                                    attributes)
                       operation (if (= 'scalar kind)
                                   (list kind attributes (mapv rename captures) lambda)

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -514,13 +514,25 @@
                              :equation-dtype equation-dtype
                              :route-dtype (:dtype options)})))
         facts (cf/from-components components)
-        routed (apply route-contraction nil
-                      (mapcat identity
-                              (assoc options
-                                     :dtype equation-dtype
-                                     :facts facts
-                                     :candidate-families families
-                                     :operation-id operation-id)))
+        routed (try
+                 (apply route-contraction nil
+                        (mapcat identity
+                                (assoc options
+                                       :dtype equation-dtype
+                                       :facts facts
+                                       :candidate-families families
+                                       :operation-id operation-id)))
+                 (catch clojure.lang.ExceptionInfo exception
+                   (let [{:keys [reason strategy] :as data} (ex-data exception)]
+                     (if (= :epilogue-unsupported-by-this-leaf reason)
+                       (throw (ex-info "no enabled contraction family can lower the result transform"
+                                       {:reason :no-legal-contraction-family
+                                        :operation operation-id
+                                        :families families
+                                        :declines [{:leaf strategy :reason reason
+                                                    :data (dissoc data :reason :strategy)}]}
+                                       exception))
+                       (throw exception)))))
         selected-family (get strategy-family (:strategy routed))]
     (when-not (contains? (set families) selected-family)
       (throw (ex-info "selected contraction leaf is outside the enabled schedule families"
@@ -593,23 +605,28 @@
                       {:reason :typed-contraction-no-candidates
                        :route result})))))
 
-(def ^:private logical-pointer-fields
+(def ^:private logical-interface-fields
   [:kind :dtype :kernel-dtype :role :binding :field])
 
-(defn- artifact-pointer-interface
+(defn- public-interface-slot?
+  [slot]
+  (or (not= :scalar (:kind slot))
+      (= :epilogue (:role slot))))
+
+(defn- artifact-logical-interface
   [artifact]
   (->> (map vector (:abi artifact) (:arguments artifact))
-       (remove (fn [[slot _]] (= :scalar (:kind slot))))
+       (filter (comp public-interface-slot? first))
        vec))
 
-(defn- common-pointer-interface
+(defn- common-logical-interface
   [candidates operation-id]
-  (let [interfaces (mapv (comp artifact-pointer-interface :artifact) candidates)
+  (let [interfaces (mapv (comp artifact-logical-interface :artifact) candidates)
         arguments (mapv second (first interfaces))]
     (doseq [[candidate interface] (map vector candidates interfaces)]
       (when-not (= arguments (mapv second interface))
-        (throw (ex-info "typed contraction candidates have different logical pointer arguments"
-                        {:reason :typed-contraction-candidate-pointer-arguments
+        (throw (ex-info "typed contraction candidates have different logical ABI arguments"
+                        {:reason :typed-contraction-candidate-interface-arguments
                          :operation operation-id
                          :family (:family candidate)
                          :expected arguments
@@ -618,11 +635,11 @@
           (mapv
            (fn [index argument]
              (let [slots (mapv #(first (nth % index)) interfaces)
-                   semantic-views (mapv #(select-keys % logical-pointer-fields) slots)
+                   semantic-views (mapv #(select-keys % logical-interface-fields) slots)
                    _ (when-not (apply = semantic-views)
                        (throw (ex-info
-                               "typed contraction candidates have incompatible pointer semantics"
-                               {:reason :typed-contraction-candidate-pointer-semantics
+                               "typed contraction candidates have incompatible logical ABI semantics"
+                               {:reason :typed-contraction-candidate-interface-semantics
                                 :operation operation-id :argument argument
                                 :slots slots})))
                    aliasing (when (some #(= :no-write-alias (:aliasing %)) slots)
@@ -649,7 +666,8 @@
                      :invoke (:invoke candidate)})))
   (doseq [[slot compiler-value] (map vector (get-in candidate [:artifact :abi])
                                       (get-in candidate [:artifact :arguments]))
-          :when (= :scalar (:kind slot))]
+          :when (and (= :scalar (:kind slot))
+                     (not (public-interface-slot? slot)))]
     (when-not (and (contains? #{:int :long} (:kernel-dtype slot))
                    (or (integer? compiler-value)
                        (and (klaunch/expression? compiler-value)
@@ -674,23 +692,25 @@
   [candidate operation-id common-abi common-arguments]
   (let [{:keys [family strategy artifact candidate-schedule]} candidate
         artifact (kart/validate! artifact)
-        buffers (mapv (fn [slot argument]
+        interface (mapv vector common-abi common-arguments)
+        pointer-interface (filterv #(not= :scalar (:kind (first %))) interface)
+        buffers (mapv (fn [[slot argument]]
                         [argument
                          (kgraph/buffer argument (:dtype slot)
                                         (when (contains? #{:output :inout} (:kind slot))
                                           (get-in artifact [:attributes :out-elems]))
                                         :device (graph-buffer-role (:kind slot)))])
-                      common-abi common-arguments)
+                      pointer-interface)
         buffer-map (into {} buffers)
         inputs (into [] (comp (filter #(contains? #{:input :inout} (:kind (first %))))
                               (map #(get buffer-map (second %))))
-                     (map vector common-abi common-arguments))
+                     pointer-interface)
         outputs (into [] (comp (filter #(contains? #{:output :inout} (:kind (first %))))
                                (map #(get buffer-map (second %))))
-                      (map vector common-abi common-arguments))
+                      pointer-interface)
         uses (mapv (fn [slot argument]
                      (kgraph/->ValueUse argument (kabi/slot-access slot)))
-                   common-abi common-arguments)]
+                   (mapv first pointer-interface) (mapv second pointer-interface))]
     (kgraph/make
      {:inputs inputs
       :outputs outputs
@@ -747,16 +767,17 @@
 (defn route-static-typed-contraction-dispatch
   "Normalize legal static typed contraction leaves behind one logical ABI-compatible dispatch.
 
-   Leaf-only dimensions remain graph-private derived scalars, so matrix, register-tiled and
-   portable kernels can compete through the existing KernelDispatch tuning machinery. This
-   function refuses runtime-dependent private scalars; dynamic-shape dispatch requires those
-   dimensions in a common public scalar ABI rather than silently baking one sample."
+   Leaf-only dimensions remain graph-private derived scalars, while typed result-transform scalar
+   captures join operand/result pointers in the shared public ABI. Matrix, register-tiled and
+   portable kernels can therefore compete through the existing KernelDispatch tuning machinery.
+   Runtime-dependent private dimensions are refused until they have a common public ABI rather
+   than silently baking one sample."
   [program operation-id schedule & options]
   (let [{:keys [candidates] :as routed}
         (apply route-typed-contraction-candidates!
                program operation-id schedule options)
         candidates (mapv #(static-private-scalars! % operation-id) candidates)
-        {:keys [abi arguments]} (common-pointer-interface candidates operation-id)
+        {:keys [abi arguments]} (common-logical-interface candidates operation-id)
         default-strategy (:strategy (first candidates))
         dispatch-id (candidate-dispatch-id operation-id candidates)
         candidates (mapv #(deterministic-candidate-entry-point % dispatch-id) candidates)

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -309,8 +309,11 @@
                                 (map util/free-syms
                                      (conj (mapv second segment-axes) reduced-extent)))
           body-symbols (reduce set/union #{} (map util/free-syms step-results))
+          result-transform (:result-transform attributes)
+          transform-scalars (set (map :value (:scalars result-transform)))
           scalars (set/difference (set/union bound-symbols body-symbols)
                                   inputs (set accumulators) axis-indices)
+          scalars (set/union scalars transform-scalars)
           space (segop/make-seg-space-nd
                  (conj (mapv (fn [[index extent]] {:name index :bound extent}) segment-axes)
                        {:name reduced-index :bound reduced-extent}))

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -191,6 +191,36 @@
   [equation-id ordinal]
   [:effect-map equation-id ordinal])
 
+(defn- typed-result-transform
+  "Close a source epilogue descriptor over lexical scalar-region parameters.
+
+   Program value IDs remain on the boundary records; the expression names only lambda parameters
+   and segment indices. This is what makes later ParallelProgram SSA remapping alpha-stable."
+  [epilogue]
+  (when epilogue
+    (let [operands (mapv (fn [ordinal {:keys [sym dtype map]}]
+                           {:value sym
+                            :parameter (symbol (str "%result-operand" ordinal))
+                            :dtype dtype :map map})
+                         (range) (vec (:operands epilogue)))
+          scalars (mapv (fn [ordinal {:keys [sym dtype]}]
+                          {:value sym
+                           :parameter (symbol (str "%result-scalar" ordinal))
+                           :dtype dtype})
+                        (range) (vec (:scalars epilogue)))
+          substitutions
+          (into {}
+                (concat (map (juxt :value :parameter) operands)
+                        (map (juxt :value :parameter) scalars)))
+          accumulator (:acc epilogue)]
+      {:operands operands
+       :scalars scalars
+       :result-dtype (or (:dtype epilogue) :float)
+       :lambda (dialect/lambda-form
+                (vec (concat [accumulator]
+                             (map :parameter operands) (map :parameter scalars)))
+                [(util/subst-syms substitutions (:expr epilogue))])})))
+
 (defn- effect-map-description
   [id symbol index extent {:keys [locals stores]} elem-type]
   (when (and (seq stores) (independent-stores? locals stores))
@@ -290,20 +320,25 @@
     (let [facts (contraction-facts/contraction-facts
                  expression :dtype (or (:raster.type/elem-type (meta expression))
                                        default-dtype :double))
-          {:keys [free-axes contract-axes out opts]} facts]
-      ;; The first direct slice is the ordinary scalar segmented-reduction algebra. Staged
-      ;; quantization and fused epilogues carry additional schedule/store contracts and must not
-      ;; be admitted by dropping those facts.
+          {:keys [free-axes contract-axes out opts]} facts
+          epilogue (:epilogue facts)
+          result-transform (typed-result-transform epilogue)
+          epilogue-arrays (set (map :value (:operands result-transform)))
+          epilogue-scalar-ids (set (map :value (:scalars result-transform)))]
+      ;; The direct slice is scalar segmented-reduction algebra plus an optional closed typed
+      ;; result transform. Staged quantization carries additional schedule/load contracts and must
+      ;; not be admitted by dropping those facts.
       (when (and (seq free-axes) (seq contract-axes)
-                 ;; Decode lambdas, declared physical maps, staged accumulators, epilogues and
-                 ;; output conversions are not scalar fold syntax.  Keep them on the certified
+                 ;; Decode lambdas, declared physical maps, staged accumulators and output
+                 ;; conversions are not scalar fold syntax. Keep them on the certified
                  ;; contraction route until TypedSOAC represents those facts explicitly.
-                 (empty? (apply dissoc opts [:init :combine :algebra]))
+                 (empty? (apply dissoc opts [:init :combine :algebra :epilogue]))
+                 (or (nil? epilogue) (dialect/result-transform? result-transform))
                  (reduction/scalar? (:reduction facts)))
         (let [product (:reduction facts)
               component (first (:components product))
               step-result (first (:results (reduction/fold-region product)))
-              arrays (set (map :sym (:operands facts)))
+              arrays (set/union (set (map :sym (:operands facts))) epilogue-arrays)
               axis-symbols (set (concat (map first free-axes) [(:index product)]))
               bound-symbols (reduce set/union #{}
                                     (map util/free-syms
@@ -311,13 +346,15 @@
                                                  (map second contract-axes))))
               scalars (set/difference
                        (set/union bound-symbols (util/free-syms step-result))
-                       arrays axis-symbols #{(:accumulator component) out})]
+                       arrays axis-symbols epilogue-scalar-ids #{(:accumulator component) out})]
           {:kind :segmented-reduce :id id :sym symbol
            :segment-axes free-axes
            :reduce-index (:index product)
            :reduce-extent (second (:flat-contract-axis facts))
            :results [(effect-result-id id 0)]
-           :product product :inputs arrays :outputs #{out} :scalars scalars
+           :product product :inputs arrays :outputs #{out}
+           :scalars (set/union scalars epilogue-scalar-ids)
+           :result-transform result-transform
            :effect-only? true :host-binding symbol
            :result-storage [{:destination out :access :write :host-return :effect}]})))
 
@@ -613,7 +650,8 @@
                  results)))))
 
 (defn- segmented-reduce-equation
-  [{:keys [id segment-axes reduce-index reduce-extent inputs scalars product results]}]
+  [{:keys [id segment-axes reduce-index reduce-extent inputs scalars product results
+           result-transform]}]
   (let [component (first (:components product))
         stable (vec (sort-by pr-str inputs))
         captures (vec (sort-by pr-str (distinct (concat stable scalars))))
@@ -629,7 +667,8 @@
                  :accumulators [(:accumulator component)]
                  :identities [(:neutral component)]
                  :dtypes [(:dtype component)]
-                 :algebra [(:algebra product)]}
+                 :algebra [(:algebra product)]
+                 :result-transform result-transform}
                 [] captures
                 (dialect/lambda-form
                  (vec (concat [(:accumulator component)] capture-parameters))

--- a/src/raster/compiler/passes/parallel/typed_soac_projection.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_projection.clj
@@ -45,6 +45,25 @@
     {:combine (descriptor/semantic-op expression)
      :element (second arguments)}))
 
+(defn- result-transform-epilogue
+  [transform]
+  (when transform
+    (let [{:keys [parameters body-results]} (dialect/lambda-parts (:lambda transform))
+          accumulator (first parameters)
+          substitutions
+          (into {}
+                (concat (map (juxt :parameter :value) (:operands transform))
+                        (map (juxt :parameter :value) (:scalars transform))))]
+      {:acc accumulator
+       :expr (util/subst-syms substitutions (first body-results))
+       :operands (mapv #(-> % (assoc :sym (:value %))
+                            (dissoc :value :parameter))
+                       (:operands transform))
+       :scalars (mapv #(-> % (assoc :sym (:value %))
+                           (dissoc :value :parameter))
+                      (:scalars transform))
+       :dtype (:result-dtype transform)})))
+
 (defn segmented-reduce-contract-components
   "Project one validated scalar `segmented-reduce` equation to contraction semantic components.
 
@@ -81,14 +100,16 @@
                 locals
                 (util/subst-syms substitutions (first body-results)))
         {:keys [combine element]} (scalar-fold-parts attributes folded)
-        contraction-dtype (first (:dtypes attributes))]
+        contraction-dtype (first (:dtypes attributes))
+        result-transform (result-transform-epilogue (:result-transform attributes))]
     {:out (first physical-results)
      :free-axes (:segment-axes attributes)
      :contract-axes [[(:index attributes) (:extent attributes)]]
      :body element
-     :opts (array-map :init (first (:identities attributes))
-                      :combine combine
-                      :algebra (first (:algebra attributes)))
+     :opts (cond-> (array-map :init (first (:identities attributes))
+                              :combine combine
+                              :algebra (first (:algebra attributes)))
+             result-transform (assoc :epilogue result-transform))
      :dtype contraction-dtype
      :metadata {:raster.type/elem-type contraction-dtype}}))
 

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -217,6 +217,65 @@
     (is (= :typed-soac (get-in (-> scheduled :form :equations first)
                                [:attributes :algorithm-dialect])))))
 
+(deftest explicit-contraction-result-transform-stays-in-typed-soac
+  (let [transform {:acc 'acc
+                   :expr '(raster.numeric/+ acc (clojure.core/aget bias j))
+                   :operands [{:sym 'bias :dtype :float
+                               :map {:groups [[['j 128]]]}}]
+                   :scalars []
+                   :dtype :float}
+        source (list 'let* ['step
+                            (apply list
+                                   (concat
+                                    '(raster.par/contract C [[i 128] [j 128]] [[l 128]]
+                                      (* (clojure.core/aget A (+ (* i 128) l))
+                                         (clojure.core/aget B (+ (* l 128) j))))
+                                    [:epilogue transform]))]
+                     'step)
+        program (frontend/form->program
+                 source {:dtype :half
+                         :array-types {'A :half 'B :half 'C :half 'bias :float}})
+        equation (first (dialect/equations program))
+        attributes (:attributes (dialect/operation-parts equation))
+        typed-transform (:result-transform attributes)]
+    (is (= [{:value 'bias :parameter '%result-operand0 :dtype :float
+             :map {:groups [[['j 128]]]}}]
+           (:operands typed-transform)))
+    (is (= '[acc %result-operand0]
+           (:parameters (dialect/lambda-parts (:lambda typed-transform)))))
+    (is (= '[(raster.numeric/+ acc (clojure.core/aget %result-operand0 j))]
+           (:body-results (dialect/lambda-parts (:lambda typed-transform)))))
+    (is (= '[A B bias] (get-in attributes [:attributes :stable-array-captures])))
+    (is (= '[A B bias] (:inputs (dialect/facts program))))
+    (is (= program (dialect/validate! program)))
+    (let [remapped (dialect/remap-values program {'bias [:binding 'bias]})
+          remapped-transform
+          (get-in (dialect/operation-parts (first (dialect/equations remapped)))
+                  [:attributes :result-transform])]
+      (is (= [:binding 'bias] (get-in remapped-transform [:operands 0 :value])))
+      (is (= (:lambda typed-transform) (:lambda remapped-transform))
+          "SSA value remapping must not rewrite the lexical scalar region")
+      (is (= remapped (dialect/validate! remapped))))))
+
+(deftest contraction-result-transform-cannot-hide-an-untyped-capture
+  (let [transform {:acc 'acc
+                   :expr '(raster.numeric/+ acc undeclared)
+                   :operands [] :scalars [] :dtype :float}
+        contract (apply list
+                        (concat
+                         '(raster.par/contract C [[i 8] [j 8]] [[l 8]]
+                           (* (clojure.core/aget A (+ (* i 8) l))
+                              (clojure.core/aget B (+ (* l 8) j))))
+                         [:epilogue transform]))]
+    (try
+      (frontend/form->program
+       (list 'let* ['step contract] 'step)
+       {:dtype :half :array-types {'A :half 'B :half 'C :half}})
+      (is false "an undeclared result-transform value must not enter TypedSOAC")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :typed-soac-result-transform-expression
+               (:reason (ex-data exception))))))))
+
 (deftest destination-shapes-refine-across-ordered-maps
   (let [program (frontend/form->program
                  '(let* [first-step (raster.par/map! first-out i n float

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -795,6 +795,71 @@
         (catch clojure.lang.ExceptionInfo exception
           (is (= :typed-contraction-families (:reason (ex-data exception)))))))))
 
+(deftest typed-contraction-result-transform-reaches-the-matrix-store
+  (let [transform {:acc 'acc
+                   :expr '(raster.numeric/*
+                           (raster.numeric/+ acc (clojure.core/aget bias j)) scale)
+                   :operands [{:sym 'bias :dtype :float
+                               :map {:groups [[['j 128]]]}}]
+                   :scalars [{:sym 'scale :dtype :float}]
+                   :dtype :float}
+        contract (apply list
+                        (concat
+                         '(raster.par/contract C [[i 128] [j 128]] [[l 128]]
+                           (* (clojure.core/aget A (+ (* i 128) l))
+                              (clojure.core/aget B (+ (* l 128) j))))
+                         [:epilogue transform]))
+        source (list 'let* ['step contract] 'step)
+        {:keys [form stats]}
+        (pipeline/schedule-parallel-form
+         source {:target-device :ocl:0 :dtype :half
+                 :array-types {'A :half 'B :half 'C :half 'bias :float}
+                 :scalar-types {'scale :float}})
+        operation (-> form :equations first :operations first)
+        algorithm (-> form :equations first :algorithm)
+        descriptor {:matrix {:family :dpas :m 8 :n 16 :k 16 :subgroup 16}
+                    :grf-bytes-per-lane 256 :subgroup-size 16
+                    :max-workgroup-size 1024 :shared-local-memory 131072}
+        routed (contract-route/route-typed-contraction
+                algorithm (:id operation)
+                (assoc-in (:schedule operation) [:tuning-space :families] [:matrix])
+                :dtype :half :desc descriptor)
+        emitted (with-redefs [hardware/descriptor-for (constantly descriptor)]
+                  (opencl-pass/opencl-pass form :device-id :ocl:0
+                                           :dtype :half :min-elements 0))
+        emitted-dispatch (first (:dispatches emitted))
+        alternative (first (:alternatives emitted-dispatch))
+        call (kernel-graph-call/make
+              alternative
+              {'A (Object.) 'B (Object.) 'C (Object.) 'bias (Object.)}
+              {'scale {:type :float :value 0.5}})]
+    (is (= :typed-soac (:source-dialect stats)))
+    (is (= :float
+           (get-in (dialect/operation-parts
+                    (first (dialect/equations algorithm)))
+                   [:attributes :result-transform :result-dtype])))
+    (is (= '#{A B bias} (segop/operation-inputs operation)))
+    (is (= '#{scale} (segop/operation-scalars operation)))
+    (is (= :dpas (:strategy routed)))
+    (is (true? (:fused-epilogue routed)))
+    (is (= '[bias] (:epilogue-operands routed)))
+    (is (= '[A B C M N K bias scale] (mapv :name (:abi routed))))
+    (is (re-find #"bias\[col\]" (:source routed)))
+    (is (re-find #"\* scale" (:source routed)))
+    (is (= 1 (get-in emitted [:stats :ze-contracts])))
+    (is (some #(= '[A B C M N K bias scale] (mapv :name (:abi %)))
+              (:kernels emitted)))
+    (is (= [:dpas]
+           (mapv #(get-in % [:attributes :strategy])
+                 (:alternatives emitted-dispatch))))
+    (is (= #{:register-tiled :portable}
+           (set (map :candidate-family
+                     (get-in emitted-dispatch [:attributes :declines])))))
+    (is (kernel-graph-call/kernel-graph-call? call))
+    (is (= {:type :float :value 0.5}
+           (last (-> call :nodes first :call :arguments))))
+    (is (nil? (get-in emitted [:stats :segop-relowered])))))
+
 (deftest resident-reduction-realization-stays-on-the-typed-spine
   (let [source
         '(let* [total (raster.par/reduce acc 0.0 i n


### PR DESCRIPTION
## Summary
- represent a completed segmented-reduction result transform as an alpha-stable typed scalar region with explicit tensor/scalar captures
- preserve and validate operand axis maps, capture dtypes, lexical closure, SSA remapping, and caller-owned output effects
- lower the same transform through contraction facts, KernelBody store regions, ordered ABI emission, and normalized candidate dispatches
- expose semantic epilogue scalars in the logical dispatch ABI while keeping leaf-only shape scalars graph-private
- treat schedule families without a store splice as explicit candidate declines rather than dropping the transform

This remains a general segmented-reduction result transform, not a GEMM or attention semantic opcode. Alias-aware contraction-to-map discovery is intentionally the next fusion slice.

## Verification
- 130 focused tests, 767 assertions, 0 failures/errors
- covers TypedSOAC validation/remapping, segmented reduction lowering, candidate routing, KernelGraph scalar binding, contraction ABI, fail-loud behavior, tuning signatures, and store-region emission

## Stack
- stacked on #209
- #208 also received a separate target-independent test fix after CircleCI correctly excluded DPAS on its device-less descriptor