### PR TITLE
Fuse typed segmented reduction result maps

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -336,8 +336,12 @@ request a generated surface spelling. A segmented reduction may now carry one ty
 result-transform: its accumulator, expression, result dtype, tensor operands with axis maps/dtypes,
 and uniform scalar captures with dtypes are all verified at the equation boundary. Contraction
 epilogues expressed by that closed contract therefore stay on TypedSOAC and lower through the same
-matrix store region and ordered ABI as the proven compatibility oracle. Discovering a following map
-as such a transform remains separate alias-aware fusion work; it must not rewrite the fold lambda.
+matrix store region and ordered ABI as the proven compatibility oracle. Typed fusion now discovers
+an adjacent, single-use pointwise map over a caller-owned segmented-reduction result as this same
+result-transform. It transfers the map's logical result, physical storage, alias/effect and host
+return boundary to the reduction; removes the dead intermediate; proves each residual/broadcast
+operand's map over the segment axes; and leaves the fold lambda byte-for-byte unchanged. Ambiguous
+indices, observable intermediates, read-write stores and dtype changes decline rather than guessing.
 Staged quantization, decode lambdas, declared physical operand maps and output conversions remain on
 the certified compatibility front door, and may still use `SegContract`, until the typed equation
 has explicit facts for them; admitting them while dropping those contracts would be a miscompile,
@@ -921,8 +925,10 @@ The immediate continuation after the verified double-buffered weighted-reduction
    ordered local-SSA region that lowers once through JVM and GPU paths; vertical and horizontal
    fusion now alpha-rename and compose those regions without duplicating shared scalar work.
    Explicit typed segmented-reduction result transforms now reach contraction store regions without
-   compatibility re-lowering; alias-aware segmented-reduction→map discovery is the next fusion
-   coverage step.
+   compatibility re-lowering; the typed fusion pass discovers adjacent single-use result maps and
+   removes their physical intermediates without rewriting the reduction fold. Hardware-costed
+   multi-consumer placement and result-transform stores in the non-matrix contraction leaves are
+   the next fusion/scheduling coverage steps.
    Stable indexed gathers and explicitly unique guarded scatters also use this typed scheduled-map
    route, including resident block transfers. Hardware-costed multi-consumer fusion, nested-region
    JVM scheduling, reducing/atomic scatter variants, the remaining parallel forms, and

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -145,6 +145,8 @@
        (every? keyword? (:dtypes value))
        (every? map? (:algebra value))))
 
+(declare lambda-form)
+
 (defn result-transform?
   "A typed scalar transform applied once to a completed reduction result.
 
@@ -194,6 +196,36 @@
          (keyword? (:result-dtype value))
          (dtype/known? (:result-dtype value))
          (= (:result-dtype value) (dtype/canon (:result-dtype value))))))
+
+(defn make-result-transform
+  "Close a post-reduction scalar expression over an alpha-stable typed boundary.
+
+   Operand and scalar `:value` fields are program SSA IDs.  The returned lambda refers only to
+   fresh lexical parameters, its accumulator, and the segmented-reduction axes.  Frontends and
+   fusion rules use this one constructor so target projections never have to rediscover captures
+   from an expression."
+  [{:keys [accumulator expression operands scalars result-dtype]}]
+  (let [operands (mapv (fn [ordinal {:keys [value dtype map]}]
+                         {:value value
+                          :parameter (symbol (str "%result-operand" ordinal))
+                          :dtype dtype :map map})
+                       (range) (vec operands))
+        scalars (mapv (fn [ordinal {:keys [value dtype]}]
+                        {:value value
+                         :parameter (symbol (str "%result-scalar" ordinal))
+                         :dtype dtype})
+                      (range) (vec scalars))
+        substitutions
+        (into {}
+              (concat (map (juxt :value :parameter) operands)
+                      (map (juxt :value :parameter) scalars)))]
+    {:operands operands
+     :scalars scalars
+     :result-dtype result-dtype
+     :lambda (lambda-form
+              (vec (concat [accumulator]
+                           (map :parameter operands) (map :parameter scalars)))
+              [(util/subst-syms substitutions expression)])}))
 
 (defn segmented-reduce-attributes?
   "Attributes for a general segmented reduction. Segment axes are the ordered parallel result

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -198,28 +198,12 @@
    and segment indices. This is what makes later ParallelProgram SSA remapping alpha-stable."
   [epilogue]
   (when epilogue
-    (let [operands (mapv (fn [ordinal {:keys [sym dtype map]}]
-                           {:value sym
-                            :parameter (symbol (str "%result-operand" ordinal))
-                            :dtype dtype :map map})
-                         (range) (vec (:operands epilogue)))
-          scalars (mapv (fn [ordinal {:keys [sym dtype]}]
-                          {:value sym
-                           :parameter (symbol (str "%result-scalar" ordinal))
-                           :dtype dtype})
-                        (range) (vec (:scalars epilogue)))
-          substitutions
-          (into {}
-                (concat (map (juxt :value :parameter) operands)
-                        (map (juxt :value :parameter) scalars)))
-          accumulator (:acc epilogue)]
-      {:operands operands
-       :scalars scalars
-       :result-dtype (or (:dtype epilogue) :float)
-       :lambda (dialect/lambda-form
-                (vec (concat [accumulator]
-                             (map :parameter operands) (map :parameter scalars)))
-                [(util/subst-syms substitutions (:expr epilogue))])})))
+    (dialect/make-result-transform
+     {:accumulator (:acc epilogue)
+      :expression (:expr epilogue)
+      :operands (mapv #(-> % (assoc :value (:sym %)) (dissoc :sym)) (:operands epilogue))
+      :scalars (mapv #(-> % (assoc :value (:sym %)) (dissoc :sym)) (:scalars epilogue))
+      :result-dtype (or (:dtype epilogue) :float)})))
 
 (defn- effect-map-description
   [id symbol index extent {:keys [locals stores]} elem-type]

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -8,7 +8,9 @@
             [pattern.nanopass.dialect :refer [from-dialect]]
             [pattern.r3.core :refer [rule success]]
             [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
+            [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.soac-dialect :as dialect]))
 
 (def ^:private map-equation-rule
@@ -120,7 +122,8 @@
 (defn- equation-references
   [equation]
   (let [{:keys [arrays captures]} (equation-info equation)]
-    (into (vec (concat arrays captures)) (dialect/operation-extents equation))))
+    (into (vec (concat arrays captures))
+          (filter dialect/value-id? (dialect/operation-extents equation)))))
 
 (defn- element-symbols
   [n]
@@ -260,6 +263,24 @@
                    (assoc (:provenance removed) :fused-equations [removed-id])
                    fused-kind)))))
 
+(defn- transfer-result-boundary
+  "Keep `producer-id`'s fused provenance, but make the consumer's observable store its boundary."
+  [facts producer-id consumer-id]
+  (let [consumer (get-in facts [:equations consumer-id])
+        facts (remove-equation-fact facts consumer-id producer-id
+                                    :segmented-reduce-result-map)
+        producer (get-in facts [:equations producer-id])
+        boundary-attributes (select-keys (:attributes consumer)
+                                         [:result-storage :host-binding])
+        facts (assoc-in facts [:equations producer-id]
+                        (assoc producer
+                               :effects (:effects consumer)
+                               :aliases (:aliases consumer)
+                               :attributes (merge (:attributes producer)
+                                                  boundary-attributes)))]
+    (assoc facts :effects
+           (reduce set/union #{} (map :effects (vals (:equations facts)))))))
+
 (defn- rebuild-boundary
   [program facts equations]
   (let [definitions (set (mapcat #(nth % 2) equations))
@@ -276,6 +297,184 @@
                   (assoc :inputs inputs)
                   (update :values select-keys live-values))]
     (dialect/make facts equations (dialect/outputs program))))
+
+(defn- single-write-boundary?
+  [facts equation-id result destination]
+  (let [equation-facts (get-in facts [:equations equation-id])
+        storage (get-in equation-facts [:attributes :result-storage])]
+    (and (= #{:memory/write} (:effects equation-facts))
+         (= {result destination} (:aliases equation-facts))
+         (= 1 (count storage))
+         (= destination (:destination (first storage)))
+         (= :write (:access (first storage))))))
+
+(defn- result-map-transform
+  "Translate one pointwise map region into a typed post-reduction scalar region.
+
+   Pointwise arrays become full-segment operands. Stable captures retain only an axis map proven
+   from their flat map index. Uniform captures become typed scalars. Any ambiguous array read
+  declines the candidate rather than guessing an address."
+  [program producer consumer consumed-destination]
+  (let [segment-axes (get-in producer [:attributes :segment-axes])
+        output-map (axis-map/of-axes segment-axes)
+        output-extent (axis-map/n-elements output-map)
+        flat-index (axis-map/index-expr output-map)
+        map-index (get-in consumer [:attributes :index])
+        producer-parameters (parameter-parts producer)
+        consumer-parameters (parameter-parts consumer)
+        accumulator (first (:accumulators producer-parameters))
+        arrays (:arrays consumer)
+        elements (:elements consumer-parameters)
+        captures (:captures consumer)
+        capture-parameters (:capture-parameters consumer-parameters)
+        stable-values (stable-array-captures consumer)
+        consumed-indices (keep-indexed #(when (= %2 consumed-destination) %1) arrays)
+        consumed-index (first consumed-indices)
+        expression (first (:body-results consumer))
+        reads (descriptor/aget-reads expression)
+        capture-bindings (mapv vector captures capture-parameters)
+        stable-bindings (filterv #(contains? stable-values (first %)) capture-bindings)
+        scalar-bindings (remove #(contains? stable-values (first %)) capture-bindings)
+        indexed-operands
+        (mapv (fn [[value parameter]]
+                (let [indices (->> reads
+                                   (keep #(when (= parameter (:sym %)) (:idx %)))
+                                   distinct vec)]
+                  (when (= 1 (count indices))
+                    (when-let [operand-map
+                               (axis-map/flat-index->map (first indices) map-index segment-axes)]
+                      {:value value :dtype (value-scalar-dtype program value)
+                       :map operand-map}))))
+              stable-bindings)
+        pointwise-operands
+        (mapv (fn [index value]
+                (when-not (= index consumed-index)
+                  {:value value :dtype (value-scalar-dtype program value)
+                   :map output-map}))
+              (range) arrays)
+        pointwise-operands (vec (remove nil? pointwise-operands))
+        operands (vec (concat pointwise-operands indexed-operands))
+        scalars (mapv (fn [[value _]]
+                        {:value value :dtype (value-scalar-dtype program value)})
+                      scalar-bindings)
+        element-substitutions
+        (into {}
+              (map-indexed
+               (fn [index parameter]
+                 [parameter
+                  (if (= index consumed-index)
+                    accumulator
+                    (list 'clojure.core/aget (nth arrays index) flat-index))])
+               elements))
+        capture-substitutions (into {} (map (fn [[value parameter]] [parameter value])
+                                            capture-bindings))
+        expression (->> expression
+                        (util/subst-syms (merge element-substitutions
+                                                capture-substitutions
+                                                {map-index flat-index})))]
+    (when (and (= output-extent (get-in consumer [:attributes :extent]))
+               (= 1 (count consumed-indices))
+               (every? some? indexed-operands)
+               (every? :dtype operands)
+               (every? :dtype scalars)
+               (= (count (concat (map :value operands) (map :value scalars)))
+                  (count (distinct (concat (map :value operands) (map :value scalars)))))
+               (some? (value-scalar-dtype program (first (:results consumer)))))
+      (dialect/make-result-transform
+       {:accumulator accumulator
+        :expression expression
+        :operands operands
+        :scalars scalars
+        :result-dtype (value-scalar-dtype program (first (:results consumer)))}))))
+
+(defn- segmented-reduce-result-map-candidate
+  [program]
+  (let [equations (dialect/equations program)
+        infos (mapv equation-info equations)
+        facts (dialect/facts program)
+        uses (value-use-counts program)]
+    (first
+     (for [producer-index (range (dec (count infos)))
+           :let [consumer-index (inc producer-index)
+                 producer (nth infos producer-index)
+                 consumer (nth infos consumer-index)]
+           :when (= :segmented-reduce (:kind producer))
+           :when (= :map (:kind consumer))
+           :let [produced (first (:results producer))
+                 consumed-destination
+                 (get-in facts [:equations (:id producer)
+                                :attributes :result-storage 0 :destination])
+                 consumer-result (first (:results consumer))
+                 consumer-destination
+                 (get-in facts [:equations (:id consumer)
+                                :attributes :result-storage 0 :destination])
+                 transform (when (and consumed-destination consumer-destination)
+                             (result-map-transform program producer consumer
+                                                   consumed-destination))]
+           :when (= 1 (count (:results producer)) (count (:body-results producer))
+                    (count (:results consumer)) (count (:body-results consumer)))
+           :when (= 1 (count (get-in producer [:attributes :accumulators])))
+           :when (nil? (get-in producer [:attributes :result-transform]))
+           :when (= (first (get-in producer [:attributes :dtypes]))
+                    (value-scalar-dtype program consumer-result))
+           :when (empty? (:locals consumer))
+           :when (= 1 (get uses consumed-destination 0))
+           :when (zero? (get uses produced 0))
+           :when (not (contains? (set (dialect/outputs program)) produced))
+           :when (not (contains? (set (dialect/outputs program)) consumed-destination))
+           :when (= 1 (count (filter #(= consumed-destination %)
+                                     (:arrays consumer))))
+           :when (single-write-boundary? facts (:id producer) produced consumed-destination)
+           :when (single-write-boundary? facts (:id consumer) consumer-result
+                                         consumer-destination)
+           :when (empty? (set/intersection
+                          #{consumed-destination consumer-destination}
+                          (set (map :value (:operands transform)))))
+           :when transform]
+       {:producer-index producer-index :consumer-index consumer-index
+        :producer producer :consumer consumer :transform transform}))))
+
+(defn- fuse-segmented-reduce-result-map-once
+  [program]
+  (when-let [{:keys [producer-index consumer-index producer consumer transform]}
+             (segmented-reduce-result-map-candidate program)]
+    (let [producer-parameters (parameter-parts producer)
+          transform-values (vec (concat (map :value (:operands transform))
+                                        (map :value (:scalars transform))))
+          fresh-transform-parameters
+          (mapv #(symbol (str "%fused-result-capture" %)) (range (count transform-values)))
+          canonical (canonical-operands
+                     (:arrays producer) (:elements producer-parameters)
+                     (vec (concat (:captures producer) transform-values))
+                     (vec (concat (:capture-parameters producer-parameters)
+                                  fresh-transform-parameters))
+                     (:locals producer) (:body-results producer))
+          stable (set/union (stable-array-captures producer)
+                            (set (map :value (:operands transform))))
+          updated (assoc producer
+                         :results (:results consumer)
+                         :attributes (-> (:attributes producer)
+                                         (with-stable-array-captures (:captures canonical) stable)
+                                         (assoc :result-transform transform))
+                         :arrays (:arrays canonical)
+                         :captures (:captures canonical)
+                         :parameters (vec (concat (:accumulators producer-parameters)
+                                                  (:elements canonical)
+                                                  (:capture-parameters canonical)))
+                         :locals (:locals canonical)
+                         :body-results (:body-results canonical))
+          equations (-> (dialect/equations program)
+                        (assoc producer-index (emit-equation updated))
+                        (->> (keep-indexed (fn [index equation]
+                                             (when-not (= index consumer-index) equation)))
+                             vec))
+          facts (-> (transfer-result-boundary (dialect/facts program)
+                                              (:id producer) (:id consumer))
+                    (update-in [:values (first (:results consumer))]
+                               assoc
+                               :shape (dialect/segmented-reduce-result-shape
+                                       (:attributes updated))))]
+      (rebuild-boundary program facts equations))))
 
 (defn- vertical-candidate
   [program]
@@ -475,8 +674,10 @@
          iterations 0]
     (if-let [fused (fuse-vertical-once program)]
       (recur fused (inc vertical) horizontal (inc iterations))
-      (if-let [fused (fuse-horizontal-once program)]
-        (recur fused vertical (inc horizontal) (inc iterations))
-        [program {:vertical vertical
-                  :horizontal horizontal
-                  :iterations (inc iterations)}]))))
+      (if-let [fused (fuse-segmented-reduce-result-map-once program)]
+        (recur fused (inc vertical) horizontal (inc iterations))
+        (if-let [fused (fuse-horizontal-once program)]
+          (recur fused vertical (inc horizontal) (inc iterations))
+          [program {:vertical vertical
+                    :horizontal horizontal
+                    :iterations (inc iterations)}])))))

--- a/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
@@ -1,10 +1,12 @@
 (ns raster.compiler.passes.parallel.typed-soac-fusion-test
   (:require [clojure.test :refer [deftest is]]
             [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.soac :as legacy]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.passes.parallel.soac-dialect-adapter :as adapter]
             [raster.compiler.passes.parallel.soac-graph :as graph]
+            [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
             [raster.compiler.passes.parallel.typed-soac-fusion :as typed-fusion]))
 
 (def ^:private map-map-pairs
@@ -249,3 +251,73 @@
         graph (graph/build-fusion-graph [producer consumer])]
     (is (false? (boolean (graph/can-fuse-vertically? graph 0 1)))
         "legacy dependency edges do not identify which tuple component was consumed")))
+
+(defn- contract-result-map-program
+  [map-expression]
+  (frontend/form->program
+   (list 'let*
+         ['contract-step
+          '(raster.par/contract
+            C [[i 4] [j 8]] [[l 16]]
+            (* (clojure.core/aget A (+ (* i 16) l))
+               (clojure.core/aget B (+ (* l 8) j))))
+          'map-step
+          (list 'raster.par/map! 'D 't 32 nil map-expression)]
+         'map-step)
+   {:dtype :float
+    :array-types '{A :float B :float C :float D :float bias :float residual :float}
+    :scalar-types '{scale :float}}))
+
+(deftest segmented-reduce-result-map-becomes-a-typed-result-transform
+  (let [program (contract-result-map-program
+                 '(* (+ (clojure.core/aget C t)
+                        (clojure.core/aget bias (mod t 8))
+                        (clojure.core/aget residual t))
+                     scale))
+        fold-before (-> program dialect/equations first typed-fusion/equation-info :body-results)
+        [result stats] (typed-fusion/fusion-fixpoint program)
+        equation (first (dialect/equations result))
+        operation (dialect/operation-parts equation)
+        transform (get-in operation [:attributes :result-transform])
+        transform-region (dialect/lambda-parts (:lambda transform))
+        facts (dialect/facts result)]
+    (is (= {:vertical 1 :horizontal 0 :iterations 2} stats))
+    (is (= 1 (count (dialect/equations result))))
+    (is (= '[map-step] (nth equation 2)))
+    (is (= '[map-step] (dialect/outputs result)))
+    (is (= '[A B bias residual scale] (:inputs facts)))
+    (is (= 'D (get-in facts [:equations 0 :attributes :result-storage 0 :destination])))
+    (is (= {'map-step 'D} (get-in facts [:equations 0 :aliases])))
+    (is (not-any? #{'C [:effect-map 0 0]} (keys (:values facts))))
+    (is (= '[4 8] (get-in facts [:values 'map-step :shape])))
+    (is (= fold-before (:body-results (dialect/lambda-parts (:lambda operation))))
+        "post-reduction fusion must never rewrite the reduction fold")
+    (is (= '[residual bias] (mapv :value (:operands transform))))
+    (is (= '#{i j}
+           (-> transform :operands first :map axis-map/axes set)))
+    (is (= '#{j}
+           (-> transform :operands second :map axis-map/axes set)))
+    (is (= '[scale] (mapv :value (:scalars transform))))
+    (is (not-any? #{'C 't} (flatten (:body-results transform-region))))
+    (is (= result (dialect/validate! result)))))
+
+(deftest segmented-reduce-result-map-refuses-an-unproved-operand-index
+  (let [program (contract-result-map-program
+                 '(+ (clojure.core/aget C t)
+                     (clojure.core/aget bias (+ t 1))))
+        [result stats] (typed-fusion/fusion-fixpoint program)]
+    (is (= program result))
+    (is (= {:vertical 0 :horizontal 0 :iterations 1} stats))
+    (is (= 2 (count (dialect/equations result))))))
+
+(deftest segmented-reduce-result-map-retains-an-externally-live-intermediate
+  (let [program (contract-result-map-program
+                 '(+ (clojure.core/aget C t) 1.0))
+        produced (-> program dialect/equations first (nth 2) first)
+        program (dialect/make (dialect/facts program)
+                              (dialect/equations program)
+                              [produced 'map-step])
+        [result stats] (typed-fusion/fusion-fixpoint program)]
+    (is (= program result))
+    (is (= {:vertical 0 :horizontal 0 :iterations 1} stats))
+    (is (= 2 (count (dialect/equations result))))))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -45,6 +45,42 @@
                                             (+ acc (clojure.core/aget x i)))]
          result))
 
+(def ^:private contraction-result-map
+  '(let* [contract-step
+          (raster.par/contract
+           C [[i 4] [j 8]] [[l 16]]
+           (* (clojure.core/aget A (+ (* i 16) l))
+              (clojure.core/aget B (+ (* l 8) j))))
+          map-step
+          (raster.par/map! D t 32 nil
+                           (* (+ (clojure.core/aget C t)
+                                 (clojure.core/aget bias (mod t 8)))
+                              scale))]
+         map-step))
+
+(deftest contraction-result-map-fuses-on-the-production-typed-route
+  (let [{:keys [form stats]}
+        (pipeline/schedule-parallel-form
+         contraction-result-map
+         {:target-device :ocl:0 :dtype :float
+          :array-types {'A :float 'B :float 'C :float 'D :float 'bias :float}
+          :scalar-types {'scale :float}})
+        equation (first (:equations form))
+        algorithm (:algorithm equation)
+        typed-equation (first (dialect/equations algorithm))
+        transform (get-in (dialect/operation-parts typed-equation)
+                          [:attributes :result-transform])]
+    (is (= :typed-soac (:source-dialect stats)))
+    (is (= 1 (get-in stats [:typed-soac :vertical])))
+    (is (= 1 (count (:equations form))))
+    (is (= '[A B bias scale] (:operands equation)))
+    (is (= '[map-step] (:results equation)))
+    (is (= 'D (get-in equation [:attributes :result-storage 0 :destination])))
+    (is (= '[bias] (mapv :value (:operands transform))))
+    (is (= '[scale] (mapv :value (:scalars transform))))
+    (is (not-any? #{'C [:effect-map 0 0]}
+                  (keys (:values (dialect/facts algorithm)))))))
+
 (deftest gpu-session-scheduling-enters-the-shared-typed-boundary
   (let [source '(raster.par/map! target i n float
                                  (+ (clojure.core/aget x i) 1.0))


### PR DESCRIPTION
## Outcome

A pointwise map immediately consuming a single-use typed segmented-reduction result can now become that reduction's typed result-transform. The rule is domain-neutral: it transfers the consumer's logical/physical result boundary, proves tensor operand axis maps, retains typed scalar captures, deletes the dead intermediate, and never rewrites the reduction fold.

## Correctness boundaries

- Requires an adjacent single-result `segmented-reduce -> map` with one physical write boundary each.
- Requires the intermediate to be single-use and not externally observable.
- Proves full, row, or column operand maps through the shared axis-map representation.
- Refuses ambiguous indices, read-write stores, destination aliases, and dtype changes.
- Centralizes alpha-stable result-transform construction in the TypedSOAC dialect.
- Filters literal extents out of rebuilt program inputs.

## Verification

- Post-rebase typed compiler gate: 77 tests / 488 assertions.
- Broader contraction, ABI, KernelGraph, dispatch, tuning, and scheduling gate: 148 tests / 840 assertions.
- Production route test proves analyzed source becomes one scheduled SegRed with `[A B bias scale] -> D`.

Stacked on #210.
