### PR TITLE
Lower portable contraction result transforms

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -926,9 +926,12 @@ The immediate continuation after the verified double-buffered weighted-reduction
    fusion now alpha-rename and compose those regions without duplicating shared scalar work.
    Explicit typed segmented-reduction result transforms now reach contraction store regions without
    compatibility re-lowering; the typed fusion pass discovers adjacent single-use result maps and
-   removes their physical intermediates without rewriting the reduction fold. Hardware-costed
-   multi-consumer placement and result-transform stores in the non-matrix contraction leaves are
-   the next fusion/scheduling coverage steps.
+   removes their physical intermediates without rewriting the reduction fold. Both the matrix
+   schedule and the portable sequential-segment schedule lower that closed transform to typed
+   KernelBody scalar SSA, including capture loads and explicit precision conversions. The latter
+   emits unchanged through OpenCL, CUDA and HIP and is compiled by the hardware-free CUDA/HIP CI
+   gates. Hardware-costed multi-consumer placement and migration of the register-tiled leaf to the
+   same scheduled-body store region are the next fusion/scheduling coverage steps.
    Stable indexed gathers and explicitly unique guarded scatters also use this typed scheduled-map
    route, including resident block transfers. Hardware-costed multi-consumer fusion, nested-region
    JVM scheduling, reducing/atomic scatter variants, the remaining parallel forms, and

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -1058,10 +1058,18 @@
                   :or {kernel-name-prefix "contract" target-dialect :opencl-intel}}]
   (let [kernel-body (kbody/validate! kernel-body)
         parameters (:parameters kernel-body)
-        inputs (vec (map :id (filter #(= :input (:kind %)) parameters)))
+        inputs (vec (map :id (filter #(and (= :input (:kind %))
+                                           (not= :epilogue (:role %))) parameters)))
+        epilogue-operands
+        (vec (map :id (filter #(and (= :input (:kind %))
+                                    (= :epilogue (:role %))) parameters)))
         output-parameter (first (filter #(= :output (:kind %)) parameters))
         output (:id output-parameter)
-        scalar-parameters (vec (filter #(= :scalar (:kind %)) parameters))
+        scalar-parameters (vec (filter #(and (= :scalar (:kind %))
+                                             (not= :epilogue (:role %))) parameters))
+        epilogue-scalars
+        (vec (map :id (filter #(and (= :scalar (:kind %))
+                                    (= :epilogue (:role %))) parameters)))
         scalars (vec (map :id (remove #(= '_nseg (:id %)) scalar-parameters)))
         kernel-name (str kernel-name-prefix "_" (gensym ""))
         parameter-names (into {output "out" '_nseg "_nseg"}
@@ -1087,6 +1095,8 @@
      :abi abi
      :array-params inputs
      :scalar-params scalars
+     :epilogue-operands epilogue-operands
+     :epilogue-scalars epilogue-scalars
      :output output
      :kernel-body kernel-body
      :launch (:launch kernel-body)}))

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -229,12 +229,13 @@
 (declare route-2free-1contract route-quant)
 
 (def ^:private splice-capable-strategies
-  "Strategies whose emitter has a store splice, and can therefore honour an :epilogue.
+  "Strategies whose scheduled body or emitter has a typed store region and can honour an :epilogue.
    A WHITELIST on purpose: refuse by ABSENCE of support, never by a blacklist of shapes — a
    blacklist got this wrong twice, most recently by exempting the only shape production produces.
-   `:dpas` splices through the KernelBody ScalarRegion; the three staged-emitter strategies splice at the store
-   (which is how a quant dequant scale is expressed since :scheme was deleted)."
-  #{:dpas :dp4a :quant-naive :staged-segred})
+   `:dpas` and `:portable-segred` lower through KernelBody ScalarRegion; the three staged-emitter
+   strategies still splice at the store (which is how a quant dequant scale is expressed since
+   :scheme was deleted)."
+  #{:dpas :dp4a :portable-segred :quant-naive :staged-segred})
 
 (def ^:private contraction-families
   "Target schedule families for ordinary scalar typed contractions."
@@ -252,8 +253,8 @@
    :staged-segred :portable})
 
 (defn- epilogue-honoured-or-refused
-  "An :epilogue is a STORE SPLICE, and only the DPAS leaf has one. Every other leaf drops it
-   silently — the consumer's computation vanishes with no error.
+  "An :epilogue is a typed result-store region. A leaf without one would drop the consumer's
+   computation, so refusal is mandatory.
 
    Decided AFTER routing, on the strategy actually chosen, because a pre-routing shape test got this
    wrong twice: a shape blacklist exempted (2 free, 1 contract) — the only shape production produces
@@ -436,33 +437,37 @@
                 portable (contraction-schedule/plan-portable-body contract-facts sr desc)
                 emitted (when (:ok portable)
                           (sco/generate-contraction-kernel-body (:body portable)))
-                {:keys [kernel-name source array-params scalar-params abi]}
+                {:keys [kernel-name source array-params scalar-params abi
+                        epilogue-operands epilogue-scalars]}
                 (or emitted (sco/generate-segmented-reduce-kernel sr out-sym :dtype dtype))
             ;; WHY THIS LEAF AND NOT A FASTER ONE. Only meaningful for the 2-free/1-contract shape,
             ;; where a tensorize leaf was actually attempted; for every other shape no faster leaf
             ;; exists to decline, so an empty vector is the honest answer rather than a fabricated
             ;; "not eligible".
-              declines (when (and (= 2 n-free) (= 1 n-contract))
-                         (::declines (tensorize-plan)))
-              declines (cond-> (vec declines)
-                         (not (:ok portable))
-                         (conj {:leaf :portable-kernel-body
-                                :reason (:reason portable)
-                                :data (:detail portable)}))
-              workgroup-size (or (:workgroup-size portable) 256)]
-          (cond->
-           {:strategy (if (:ok portable) :portable-segred :naive-segred)
-            :declines declines
-            :kernel-name kernel-name :source source :array-params array-params :abi abi
-            :kernel-body (:body portable)
-            :dtype dtype :out-dtype dtype
+                declines (when (and (= 2 n-free) (= 1 n-contract))
+                           (::declines (tensorize-plan)))
+                declines (cond-> (vec declines)
+                           (not (:ok portable))
+                           (conj {:leaf :portable-kernel-body
+                                  :reason (:reason portable)
+                                  :data (:detail portable)}))
+                workgroup-size (or (:workgroup-size portable) 256)]
+            (cond->
+             {:strategy (if (:ok portable) :portable-segred :naive-segred)
+              :declines declines
+              :kernel-name kernel-name :source source :array-params array-params :abi abi
+              :epilogue-operands epilogue-operands
+              :epilogue-scalars epilogue-scalars
+              :fused-epilogue (boolean epilogue)
+              :kernel-body (:body portable)
+              :dtype dtype :out-dtype dtype
          ;; SYMBOLIC axis bounds become int kernel params (the emitter declares them, sorted by
          ;; name); they must be bound BEFORE the trailing count or the launch arity is wrong.
-            :scalar-args (conj (mapv (fn [p] {:type :int :value p}) scalar-params)
-                               {:type :int :value nseg})
-            :out-elems nseg :dims [nseg]
-            :wg [workgroup-size]
-            :grid [(ceil-div nseg workgroup-size)]}
+              :scalar-args (conj (mapv (fn [p] {:type :int :value p}) scalar-params)
+                                 {:type :int :value nseg})
+              :out-elems nseg :dims [nseg]
+              :wg [workgroup-size]
+              :grid [(ceil-div nseg workgroup-size)]}
           ;; the LAST decline is the decisive one — the leaf that would otherwise have taken the
           ;; work. Using the first reported DPAS's generic :not-a-contraction where regtiled's
           ;; specific :symbolic-dims / :non-plus-combine is the actual answer.
@@ -826,7 +831,8 @@
     :inner-stage-accumulator-not-integral :inner-stage-axis-is-not-contiguous
     ;; epilogue legality
     :epilogue-needs-2-free :epilogue-ignores-accumulator :accumulator-used-more-than-once
-    :reduction-in-epilogue :layout-changing-op-in-epilogue})
+    :reduction-in-epilogue :layout-changing-op-in-epilogue
+    :epilogue-unsupported-by-this-leaf})
 
 (defn- decline
   "A structured record of ONE leaf declining. `:data` is the gate's own ex-data minus its `:reason`
@@ -902,7 +908,7 @@
              :scalar-args (mapv (fn [v] {:type :int :value (int v)}) (:dims dpas))  ; [m n k] params
              :dims (:dims dpas)})
       ;; gate rejected (dtype/orientation/pitch) → portable register-tiled kernel when enabled
-          (if register-tiled?
+          (if (and register-tiled? (not (seq epilogue)))
             (let [rt (sco/generate-regtiled-contraction-kernel @sr out-sym :dtype dtype)
                   [bm bn _bk] (:block rt)
                   [M N _L] (:dims rt)]
@@ -919,8 +925,11 @@
                :scalar-args []                             ; regtiled bakes dims → no scalar params
                :dims (:dims rt)})
             (do
-              (note! (decline :regtiled :schedule-family-disabled nil
-                              {:family :register-tiled}))
+              (note! (if register-tiled?
+                       (decline :regtiled :epilogue-unsupported-by-this-leaf nil
+                                {:family :register-tiled})
+                       (decline :regtiled :schedule-family-disabled nil
+                                {:family :register-tiled})))
               {::declines @acc}))))
       (catch clojure.lang.ExceptionInfo e
      ;; whichever tensorize leaf threw, record WHY and let the caller fall through. `decline-of`

--- a/src/raster/compiler/passes/parallel/contraction_body.clj
+++ b/src/raster/compiler/passes/parallel/contraction_body.clj
@@ -5,7 +5,8 @@
    axis as a typed loop-carried fold. It is deliberately simple but fully scheduled: launch
    geometry, segment decomposition, buffer shapes, loads, scalar SSA and the final store are IR.
    Target emitters only choose syntax."
-  (:require [raster.compiler.core.dtype :as dtype]
+  (:require [clojure.set :as set]
+            [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.ir.axis-map :as axis-map]
@@ -13,6 +14,7 @@
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.segop :as segop]
+            [raster.compiler.passes.parallel.scalar-region-lower :as scalar-region-lower]
             [raster.compiler.passes.parallel.segred-body :as segred-body]))
 
 (def ^:private index-operators
@@ -37,7 +39,8 @@
 
 (defn declined?
   [exception]
-  (= :contraction-kernel-body-declined (:reason (ex-data exception))))
+  (or (= :contraction-kernel-body-declined (:reason (ex-data exception)))
+      (scalar-region-lower/declined? exception)))
 
 (defn lower-index
   "Translate verified source index arithmetic into KernelBody index expressions."
@@ -94,8 +97,16 @@
                       "portable contraction body requires at least one free axis"
                       {:segred-id (:id segred)}))
         dtype (dtype/canon (:dtype segred))
+        result-transform (:epilogue contract-facts)
+        result-region (scalar-region-lower/make-region result-transform)
+        transform-operands (vec (:operands result-transform))
+        transform-scalars (vec (:scalars result-transform))
         arrays (vec (sort-by name (:inputs segred)))
         scalars (vec (sort-by name (:scalars segred)))
+        transform-only-operands
+        (filterv #(not (contains? (set arrays) (:sym %))) transform-operands)
+        transform-only-scalars
+        (filterv #(not (contains? (set scalars) (:sym %))) transform-scalars)
         scalar-dtype (fn [id] (or (get scalar-types id)
                                   (get scalar-types (symbol (name id))) :int))
         array-dtype (fn [id] (dtype/canon
@@ -162,6 +173,18 @@
         physical-extent
         (fn [array]
           (lower-index (axis-map/n-elements (get operand-maps array)) index-scope))
+        transform-operand-parameters
+        (mapv (fn [{:keys [sym dtype map]}]
+                (let [dtype (dtype/canon dtype)
+                      extent (lower-index (axis-map/n-elements map) index-scope)]
+                  (body/->KernelParameter
+                   sym :input dtype [extent] :global
+                   (layout/row-major [extent] dtype) :epilogue)))
+              transform-only-operands)
+        transform-scalar-parameters
+        (mapv (fn [{:keys [sym dtype]}]
+                (body/->KernelParameter sym :scalar (dtype/canon dtype) [] nil nil :epilogue))
+              transform-only-scalars)
         parameters
         (vec (concat
               (map (fn [array]
@@ -174,52 +197,73 @@
                                        (layout/row-major [segment-count] dtype) :result)]
               (map #(body/->KernelParameter % :scalar (scalar-dtype %) [] nil nil :parameter)
                    scalars)
+              transform-operand-parameters
+              transform-scalar-parameters
               [(body/->KernelParameter '_nseg :scalar :int [] nil nil :bound)]))]
-    {:kernel-body
-     (body/make
-      {:id [:contraction (:id segred) :portable-sequential]
-       :parameters parameters
-       :stable-reads (mapv body/stable-read arrays)
-       :indices (vec (concat
-                      [(body/->IndexBinding group-index :group 0)
-                       (body/->IndexBinding local-index :local 0)
-                       (body/->IndexCompute
-                        segment-index
-                        (body/expression :add
-                                         (body/expression :mul group-index workgroup-size)
-                                         local-index))]
-                      decomposition))
-       :masks [(body/->Mask active-mask
-                            [(body/predicate :lt segment-index '_nseg)])]
-       :operations
-       [(body/->ForLoop
-         (body/value reduced-index :int)
-         0 reduced-bound 1
-         [(body/->LoopArg (body/value accumulator dtype)
-                          (body/literal identity dtype))]
-         (vec (concat
-               operations
-               [(body/->ScalarCompute
-                 (body/value next-accumulator dtype)
-                 (body/scalar-expression operator dtype [accumulator result]))
-                (body/->Yield [next-accumulator])]))
-         [(body/value reduction-result dtype)]
-         {})
-        (body/->ScalarStore output [segment-index] reduction-result active-mask)]
-       :schedule {:strategy :sequential-segments
-                  :workgroup-size workgroup-size
-                  :reduction-operator operator}
-       :launch (launch/spec
-                {:workgroup-size [workgroup-size]
-                 :group-count [(launch/ceil-div segment-count workgroup-size)]})
-       :provenance {:dialect :kernel-body :source-dialect :segcontract
-                    :segop-id (:id segred)}
-       :attributes {:kind :portable-contraction
-                    :identity identity :operator operator
-                    :segment-count segment-count
-                    :reduced-bound reduced-bound}})
-     :arrays arrays
-     :scalars scalars
-     :output output
-     :segment-count segment-count
-     :workgroup-size workgroup-size}))
+    (let [parameter-map (into {} (map (juxt :id clojure.core/identity)) parameters)
+          lowered-transform
+          (when result-region
+            (scalar-region-lower/lower
+             result-region
+             {:accumulator reduction-result
+              :accumulator-dtype dtype
+              :store-dtype dtype
+              :parameters parameter-map
+              :coordinate-lower coordinate-lower
+              :predicate active-mask}))
+          stored-result (or (:result lowered-transform) reduction-result)]
+      {:kernel-body
+       (body/make
+        {:id [:contraction (:id segred) :portable-sequential]
+         :parameters parameters
+         :stable-reads (mapv body/stable-read
+                             (distinct (concat arrays (map :sym transform-operands))))
+         :indices (vec (concat
+                        [(body/->IndexBinding group-index :group 0)
+                         (body/->IndexBinding local-index :local 0)
+                         (body/->IndexCompute
+                          segment-index
+                          (body/expression :add
+                                           (body/expression :mul group-index workgroup-size)
+                                           local-index))]
+                        decomposition))
+         :masks [(body/->Mask active-mask
+                              [(body/predicate :lt segment-index '_nseg)])]
+         :operations
+         (vec
+          (concat
+           [(body/->ForLoop
+             (body/value reduced-index :int)
+             0 reduced-bound 1
+             [(body/->LoopArg (body/value accumulator dtype)
+                              (body/literal identity dtype))]
+             (vec (concat
+                   operations
+                   [(body/->ScalarCompute
+                     (body/value next-accumulator dtype)
+                     (body/scalar-expression operator dtype [accumulator result]))
+                    (body/->Yield [next-accumulator])]))
+             [(body/value reduction-result dtype)]
+             {})]
+           (:operations lowered-transform)
+           [(body/->ScalarStore output [segment-index] stored-result active-mask)]))
+         :schedule {:strategy :sequential-segments
+                    :workgroup-size workgroup-size
+                    :reduction-operator operator}
+         :launch (launch/spec
+                  {:workgroup-size [workgroup-size]
+                   :group-count [(launch/ceil-div segment-count workgroup-size)]})
+         :provenance {:dialect :kernel-body :source-dialect :segcontract
+                      :segop-id (:id segred)}
+         :attributes {:kind :portable-contraction
+                      :identity identity :operator operator
+                      :segment-count segment-count
+                      :reduced-bound reduced-bound
+                      :axis-symbols (vec (concat (map :name segment-dims)
+                                                 [reduced-index]))
+                      :result-transform result-transform}})
+       :arrays arrays
+       :scalars scalars
+       :output output
+       :segment-count segment-count
+       :workgroup-size workgroup-size})))

--- a/src/raster/compiler/passes/parallel/contraction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/contraction_schedule.clj
@@ -12,7 +12,8 @@
             [raster.compiler.ir.contraction-facts :as facts]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
-            [raster.compiler.passes.parallel.contraction-body :as contraction-body]))
+            [raster.compiler.passes.parallel.contraction-body :as contraction-body]
+            [raster.compiler.passes.parallel.scalar-region-lower :as scalar-region-lower]))
 
 (defn- decline [reason & [data]]
   (merge {:ok false :reason reason} data))
@@ -65,16 +66,6 @@
                                   (layout/row-major shape dtype) :epilogue)))
       (for [{:keys [sym dtype] :or {dtype :float}} (:scalars epilogue)]
         (body/->KernelParameter sym :scalar dtype [] nil nil :epilogue))))))
-
-(defn- scalar-region [epilogue]
-  (when epilogue
-    (body/->ScalarRegion
-     (vec (concat [(:acc epilogue)]
-                  (map :sym (:operands epilogue))
-                  (map :sym (:scalars epilogue))))
-     (:expr epilogue)
-     (vec (:operands epilogue))
-     (get epilogue :dtype :float))))
 
 (defn- fragment-id [prefix a & [b]]
   (keyword (str prefix "-" a (when (some? b) (str "-" b)))))
@@ -224,7 +215,7 @@
                             {:unrolled-by (quot block-k matrix-k)
                              :matrix-step matrix-k
                              :pipeline-depth num-stages})
-        region (scalar-region epilogue)
+        region (scalar-region-lower/make-region epilogue)
         stores (vec
                 (for [mm (range m-fragments) nn (range n-fragments)]
                   (body/->TileStore

--- a/src/raster/compiler/passes/parallel/scalar_region_lower.clj
+++ b/src/raster/compiler/passes/parallel/scalar_region_lower.clj
@@ -1,0 +1,166 @@
+(ns raster.compiler.passes.parallel.scalar-region-lower
+  "Lower a closed KernelBody ScalarRegion to typed scalar SSA operations.
+
+   The region boundary already owns value IDs, dtypes and tensor axis maps. This pass uses only
+   the central intrinsic table and explicit KernelBody casts; target emitters receive no source
+   expression to re-infer."
+  (:require [raster.compiler.backend.intrinsics :as intrinsics]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.ir.axis-map :as axis-map]
+            [raster.compiler.ir.kernel-body :as body]))
+
+(defn make-region
+  "Convert the target-neutral result-transform descriptor into KernelBody region data."
+  [transform]
+  (when transform
+    (body/->ScalarRegion
+     (vec (concat [(:acc transform)]
+                  (map :sym (:operands transform))
+                  (map :sym (:scalars transform))))
+     (:expr transform)
+     (vec (:operands transform))
+     (get transform :dtype :float))))
+
+(defn- decline!
+  [rule message data]
+  (throw (ex-info message (assoc data
+                                 :reason :scalar-region-kernel-body-declined
+                                 :missing-rule rule))))
+
+(defn declined?
+  [exception]
+  (= :scalar-region-kernel-body-declined (:reason (ex-data exception))))
+
+(defn- cast-policy
+  [source target]
+  (let [source (dtype/canon source)
+        target (dtype/canon target)]
+    (cond
+      (= source target) nil
+      (and (dtype/fp-dtype? source) (dtype/fp-dtype? target)
+           (< (dtype/bytes-of source) (dtype/bytes-of target)))
+      [:exact :exact]
+
+      (and (dtype/fp-dtype? source) (dtype/fp-dtype? target)
+           (> (dtype/bytes-of source) (dtype/bytes-of target)))
+      [:nearest-even :ieee]
+
+      :else
+      (decline! :result-transform-cast
+                "portable result transform requires an explicit supported floating conversion"
+                {:source source :target target}))))
+
+(defn lower
+  "Lower `region` once per completed scalar reduction result.
+
+   `parameters` maps region scalar/operand IDs to KernelParameters. `coordinate-lower` translates
+   the declared operand axis-map to scheduled index arithmetic. The returned `:result` is cast to
+   `store-dtype`, so ScalarStore remains completely typed."
+  [region {:keys [accumulator accumulator-dtype store-dtype parameters coordinate-lower predicate]}]
+  (let [result-dtype (dtype/canon (:result-dtype region))
+        accumulator-id (first (:parameters region))
+        operand-by-id (into {} (map (juxt :sym identity)) (:operands region))
+        scalar-ids (vec (drop (inc (count operand-by-id)) (:parameters region)))
+        operations (atom [])
+        counter (atom 0)
+        fresh (fn [prefix] (symbol (str prefix "-" (swap! counter inc))))
+        emit! (fn [operation value value-dtype]
+                (swap! operations conj operation)
+                {:value value :dtype value-dtype})]
+    (letfn [(cast [{:keys [value dtype] :as typed} target]
+              (let [dtype (dtype/canon dtype)
+                    target (dtype/canon target)]
+                (if (= dtype target)
+                  typed
+                  (let [[rounding overflow] (cast-policy dtype target)
+                        result (fresh "result-transform-cast")]
+                    (emit! (body/->ScalarCompute
+                            (body/value result target)
+                            (body/cast-expression value target rounding overflow))
+                           result target)))))
+
+            (load-operand [id]
+              (let [{:keys [dtype map] :as operand} (get operand-by-id id)
+                    parameter (get parameters id)]
+                (when-not (and operand parameter (= :input (:kind parameter))
+                               (contains? #{:operand :epilogue} (:role parameter))
+                               (= (dtype/canon dtype) (dtype/canon (:dtype parameter))))
+                  (decline! :result-transform-operand
+                            "result-transform operand lacks its typed KernelBody parameter"
+                            {:operand operand :parameter parameter}))
+                (let [result (fresh "result-transform-load")
+                      coordinate (coordinate-lower (axis-map/index-expr map))]
+                  (cast
+                   (emit! (body/->ScalarLoad
+                           (body/value result (dtype/canon dtype)) id [coordinate]
+                           predicate
+                           (when predicate (body/literal 0 (dtype/canon dtype)))
+                           :cached)
+                          result (dtype/canon dtype))
+                   result-dtype))))
+
+            (lower-expression [expression]
+              (cond
+                (number? expression)
+                {:value (body/literal expression result-dtype) :dtype result-dtype}
+
+                (= accumulator-id expression)
+                (cast {:value accumulator :dtype accumulator-dtype} result-dtype)
+
+                (contains? (set scalar-ids) expression)
+                (let [parameter (get parameters expression)]
+                  (when-not (and parameter (= :scalar (:kind parameter))
+                                 (contains? #{:parameter :epilogue} (:role parameter)))
+                    (decline! :result-transform-scalar
+                              "result-transform scalar lacks its typed KernelBody parameter"
+                              {:scalar expression :parameter parameter}))
+                  (cast {:value expression :dtype (:dtype parameter)} result-dtype))
+
+                (descriptor/aget-call? expression)
+                (let [operand (descriptor/aget-array-sym expression)]
+                  (when-not (contains? operand-by-id operand)
+                    (decline! :result-transform-load
+                              "result-transform reads an undeclared tensor operand"
+                              {:expression expression :operand operand}))
+                  (load-operand operand))
+
+                (and (seq? expression) (descriptor/cast-op? (first expression))
+                     (= 2 (count expression)))
+                (let [target (dtype/dtype-for-scalar-tag
+                              (descriptor/cast-result-tag (first expression)))]
+                  (when-not (= target result-dtype)
+                    (decline! :result-transform-explicit-cast
+                              "portable result transform requires casts to its declared result dtype"
+                              {:expression expression :target target
+                               :result-dtype result-dtype}))
+                  (cast (lower-expression (second expression)) target))
+
+                (seq? expression)
+                (let [operator (intrinsics/canonical (descriptor/semantic-op expression))
+                      intrinsic (intrinsics/descriptor operator)
+                      arguments (vec (descriptor/call-args expression))]
+                  (when-not (and intrinsic
+                                 (= (:arity intrinsic) (count arguments))
+                                 (not= :cmp (:kind intrinsic))
+                                 (intrinsics/accepts-scalar-dtype? operator result-dtype))
+                    (decline! :result-transform-expression
+                              "result-transform expression has no typed portable scalar lowering"
+                              {:expression expression :operator operator
+                               :result-dtype result-dtype}))
+                  (let [inputs (mapv (comp :value lower-expression) arguments)
+                        result (fresh "result-transform-value")]
+                    (emit! (body/->ScalarCompute
+                            (body/value result result-dtype)
+                            (body/scalar-expression operator result-dtype inputs))
+                           result result-dtype)))
+
+                :else
+                (decline! :result-transform-expression
+                          "result-transform expression references an unbound or unsupported value"
+                          {:expression expression})))]
+      (let [typed-result (lower-expression (:expression region))
+            stored-result (cast typed-result store-dtype)]
+        {:operations @operations
+         :result (:value stored-result)
+         :result-dtype (:dtype stored-result)}))))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -7,6 +7,7 @@
             [raster.compiler.backend.gpu.segop-opencl :as segop-emit]
             [raster.compiler.backend.gpu.target :as gpu-target]
             [raster.compiler.ir.attention :as attention]
+            [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.ir.kernel-executable :as executable]
             [raster.compiler.ir.soac :as soac]
@@ -30,11 +31,20 @@
 
 (defn- contraction-artifact
   [dialect descriptor]
-  (let [form '(raster.par/contract y [[i 64]] [[l 32]]
-                (* (aget A (+ (* i 32) l)) (aget x l)))
-        verified (contraction-facts/contraction-facts form :dtype :float)
+  (let [epilogue {:acc 'acc
+                  :expr '(raster.numeric/*
+                          (raster.numeric/+ acc (clojure.core/aget bias i)) scale)
+                  :operands [{:sym 'bias :dtype :float
+                              :map (axis-map/of-axes [['i 64]])}]
+                  :scalars [{:sym 'scale :dtype :float}]
+                  :dtype :float}
+        form (concat
+              '(raster.par/contract y [[i 64]] [[l 32]]
+                                    (* (aget A (+ (* i 32) l)) (aget x l)))
+              [:epilogue epilogue])
+        verified (contraction-facts/contraction-facts form :dtype :half)
         segred (contract-lower/contract-form->segred
-                form :dtype :float :facts verified)
+                form :dtype :half :facts verified)
         planned (contraction-schedule/plan-portable-body verified segred descriptor)]
     (when-not (:ok planned)
       (throw (ex-info "portable contraction compile fixture did not schedule" planned)))

--- a/test/raster/compiler/fail_loud_contraction_test.clj
+++ b/test/raster/compiler/fail_loud_contraction_test.clj
@@ -49,17 +49,16 @@
                         'out))]
       (is (re-find #"cl_khr_fp64" src)))))
 
-(deftest a-leaf-without-a-store-splice-refuses-an-epilogue
-  (testing "an :epilogue reaching :segmap or the :else fallback was silently DROPPED — the
-            consumer's computation vanished with no error. fuse-contract-map already produces such
-            forms (it has no rank restriction) and is one line from being wired."
+(deftest the-portable-leaf-keeps-a-multidimensional-result-transform
+  (testing "a three-free-axis contraction carries its result transform through typed scalar SSA"
     (let [ep {:acc 'acc :expr '(raster.numeric/* acc 2.0)}
-          ;; 3 free axes → the universal fallback, which has no store splice
           form (concat (list 'raster.par/contract 'out [['b 2] ['i 2] ['j 2]] [['l 4]]
                              (list 'raster.numeric/* (list 'aget 'a 'l) (list 'aget 'c 'l)))
-                       [:epilogue ep])]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"silently dropped"
-                            (cr/route-contraction form :dtype :double))))))
+                       [:epilogue ep])
+          routed (cr/route-contraction form :dtype :double)]
+      (is (= :portable-segred (:strategy routed)))
+      (is (true? (:fused-epilogue routed)))
+      (is (re-find #"\* 2\.0" (:source routed))))))
 
 (deftest the-decompose-is-row-major-and-distinguishably-so
   ;; MUTATION-PROVEN INADEQUATE, and this is the replacement. The previous version asserted
@@ -115,18 +114,17 @@
           "the identity must be the op's, not 0.0 — summing max-partials from 0.0 is wrong for
            all-negative data"))))
 
-(deftest epilogue-refused-on-the-shape-production-actually-produces
-  ;; The first version of this guard blacklisted shapes and so exempted (2 free, 1 contract) — the
-  ;; ONLY shape production produces. The form fell through to :regtiled, which has no store splice,
-  ;; and the epilogue was dropped. Refuse by ABSENCE of splice support instead.
-  (testing "an epilogue on an f64 2-free/1-contract contraction is refused, not dropped"
+(deftest fp64-result-transform-uses-the-typed-portable-store
+  (testing "an f64 two-free/one-contract result transform executes on the portable leaf"
     (let [form (list 'raster.par/contract 'C [['i 4] ['j 4]] [['l 8]]
                      (list 'raster.numeric/*
                            (list 'aget 'A (list 'clojure.core/+ (list 'clojure.core/* 'i 8) 'l))
                            (list 'aget 'B (list 'clojure.core/+ (list 'clojure.core/* 'l 4) 'j)))
-                     :epilogue {:acc 'acc :expr '(raster.numeric/* acc 2.0)})]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"silently dropped"
-                            (cr/route-contraction form :dtype :double))))))
+                     :epilogue {:acc 'acc :expr '(raster.numeric/* acc 2.0)})
+          routed (cr/route-contraction form :dtype :double)]
+      (is (= :portable-segred (:strategy routed)))
+      (is (true? (:fused-epilogue routed)))
+      (is (re-find #"\* 2\.0" (:source routed))))))
 
 (deftest dp4a-refuses-a-decode-it-would-discard
   ;; The dp4a leaf replaces the whole summand with one hardware op, so a per-operand :decode — the

--- a/test/raster/compiler/passes/parallel/contraction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_body_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.segop-opencl :as emit]
+            [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.contraction-facts :as facts]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-body :as body]
@@ -16,6 +17,26 @@
 (defn- portable-plan []
   (let [verified (facts/contraction-facts matvec :dtype :float)
         segred (lower/contract-form->segred matvec :dtype :float :facts verified)]
+    (schedule/plan-portable-body verified segred nil)))
+
+(defn- portable-result-transform-form []
+  (let [epilogue {:acc 'acc
+                  :expr '(raster.numeric/*
+                          (raster.numeric/+ acc (clojure.core/aget bias j)) scale)
+                  :operands [{:sym 'bias :dtype :float
+                              :map (axis-map/of-axes [['j 8]])}]
+                  :scalars [{:sym 'scale :dtype :float}]
+                  :dtype :float}
+        form '(raster.par/contract C [[i 4] [j 8]] [[l 16]]
+                                    (raster.numeric/*
+                                     (clojure.core/aget A (clojure.core/+ (clojure.core/* i 16) l))
+                                     (clojure.core/aget B (clojure.core/+ (clojure.core/* l 8) j))))]
+    (concat form [:epilogue epilogue])))
+
+(defn- portable-result-transform-plan []
+  (let [form (portable-result-transform-form)
+        verified (facts/contraction-facts form :dtype :half)
+        segred (lower/contract-form->segred form :dtype :half :facts verified)]
     (schedule/plan-portable-body verified segred nil)))
 
 (deftest portable-contraction-is-a-complete-scheduled-kernel-body
@@ -50,6 +71,67 @@
           (is (str/includes? (:source emitted) "for (int rstr_l = 0"))
           (is (= '[A x] (:array-params emitted)))
           (is (= '[k m] (:scalar-params emitted))))))))
+
+(deftest portable-result-transform-is-typed-scalar-ssa-on-every-c-family-target
+  (let [plan (portable-result-transform-plan)
+        kernel (:body plan)
+        operations (:operations kernel)
+        epilogue-operations (subvec operations 1 (dec (count operations)))
+        classes (mapv #(some-> % class .getSimpleName) epilogue-operations)]
+    (is (:ok plan))
+    (is (= '[A B C bias scale _nseg] (mapv :id (:parameters kernel))))
+    (is (= [:operand :operand :result :epilogue :epilogue :bound]
+           (mapv :role (:parameters kernel))))
+    (is (= ["ScalarCompute" "ScalarLoad" "ScalarCompute" "ScalarCompute" "ScalarCompute"]
+           classes)
+        "widen accumulator, load bias, add, scale and narrow are explicit SSA")
+    (is (= [:float :float :float :float :half]
+           (mapv #(get-in % [:result :type]) epilogue-operations)))
+    (is (= 'C (:buffer (last operations))))
+    (doseq [dialect [:opencl-portable :cuda :hip]]
+      (testing (name dialect)
+        (let [emitted (emit/generate-contraction-kernel-body
+                       kernel :target-dialect dialect)]
+          (is (= '[A B] (:array-params emitted)))
+          (is (= '[bias] (:epilogue-operands emitted)))
+          (is (= '[scale] (:epilogue-scalars emitted)))
+          (is (= '[A B C bias scale _nseg] (mapv :name (:abi emitted))))
+          (is (str/includes? (:source emitted) "bias["))
+          (is (str/includes? (:source emitted) "scale")))))))
+
+(deftest a-result-transform-can-reuse-one-contraction-operand-without-a-second-abi-slot
+  (let [epilogue {:acc 'acc
+                  :expr '(raster.numeric/+ acc (clojure.core/aget A
+                                                                  (clojure.core/+
+                                                                   (clojure.core/* i 8) j)))
+                  :operands [{:sym 'A :dtype :half
+                              :map (axis-map/of-axes [['i 4] ['j 8]])}]
+                  :dtype :half}
+        form (concat
+              '(raster.par/contract C [[i 4] [j 8]] [[l 16]]
+                                    (raster.numeric/*
+                                     (clojure.core/aget A (clojure.core/+ (clojure.core/* i 16) l))
+                                     (clojure.core/aget B (clojure.core/+ (clojure.core/* l 8) j))))
+              [:epilogue epilogue])
+        routed (route/route-contraction form :dtype :half :desc {}
+                                        :candidate-families #{:portable})]
+    (is (= :portable-segred (:strategy routed)))
+    (is (= '[A B C _nseg] (mapv :name (:abi routed))))
+    (is (= '[A B] (:array-params routed)))
+    (is (empty? (:epilogue-operands routed)))
+    (is (= '[A B] (mapv :buffer (get-in routed [:kernel-body :stable-reads]))))))
+
+(deftest result-transforms-fall-through-an-ineligible-matrix-and-register-tiled-leaf
+  (let [descriptor {:device-type :gpu :backend :ocl
+                    :execution {:subgroup-sizes #{}
+                                :preferred-subgroup-size nil
+                                :max-workgroup-size 256}}
+        routed (route/route-contraction (portable-result-transform-form)
+                                        :dtype :half :desc descriptor)]
+    (is (= :portable-segred (:strategy routed)))
+    (is (true? (:fused-epilogue routed)))
+    (is (= [:matrix-capability-unavailable :epilogue-unsupported-by-this-leaf]
+           (mapv :reason (:declines routed))))))
 
 (deftest production-general-contraction-route-carries-the-scheduled-body
   (let [routed (route/route-contraction matvec :dtype :float :desc {})]

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -885,10 +885,10 @@
     (is (= 1 (get-in emitted [:stats :ze-contracts])))
     (is (some #(= '[A B C M N K bias scale] (mapv :name (:abi %)))
               (:kernels emitted)))
-    (is (= [:dpas]
+    (is (= [:dpas :portable-segred]
            (mapv #(get-in % [:attributes :strategy])
                  (:alternatives emitted-dispatch))))
-    (is (= #{:register-tiled :portable}
+    (is (= #{:register-tiled}
            (set (map :candidate-family
                      (get-in emitted-dispatch [:attributes :declines])))))
     (is (kernel-graph-call/kernel-graph-call? call))


### PR DESCRIPTION
## Summary

- lower closed contraction result transforms to portable KernelBody scalar SSA
- preserve mixed-precision capture loads, arithmetic, casts, stores, and one ordered ABI across OpenCL/CUDA/HIP
- let result transforms fall through unsupported register-tiled schedules to the portable schedule
- compile the mixed-precision portable contraction fixture with the hardware-free CUDA/HIP CI gates

## Correctness

- result-transform expressions use the central intrinsic and primitive-cast contracts; emitters do not infer types from source forms
- reduction folds remain unchanged and the transform runs exactly once after the completed scalar reduction
- transform-only captures receive epilogue ABI roles, while a value reused by the reduction and transform keeps one input slot
- unsupported scalar operations or conversions decline structurally instead of being dropped

## Verification

- `clojure -M:test -n raster.compiler.passes.parallel.contraction-body-test -n raster.compiler.passes.parallel.contraction-schedule-test -n raster.compiler.passes.parallel.typed-soac-route-test -n raster.compiler.passes.parallel.contract-descriptor-validator-test -n raster.compiler.backend.gpu.kernel-body-opencl-test -n raster.compiler.ir.kernel-body-test`
  - 87 tests, 626 assertions
- generated all hardware-free GPU compile fixtures
- compiled the mixed-precision portable contraction locally with:
  - `nvcc -ptx -arch=sm_80`
  - `hipcc --offload-arch=gfx1100 --genco`
- `git diff --check`

Stacked on #211.
