### PR TITLE
Lower matrix result transforms through typed SSA

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -928,7 +928,12 @@ The immediate continuation after the verified double-buffered weighted-reduction
    compatibility re-lowering; the typed fusion pass discovers adjacent single-use result maps and
    removes their physical intermediates without rewriting the reduction fold. Both the matrix
    schedule and the portable sequential-segment schedule lower that closed transform to typed
-   KernelBody scalar SSA, including capture loads and explicit precision conversions. The latter
+   KernelBody scalar SSA, including capture loads and explicit precision conversions. Matrix
+   storage parameters retain dense physical layouts independently from matrix-fragment lane
+   layouts; a transform that reuses A/B refers to the existing compiler identity instead of
+   duplicating its pointer. The matrix target ABI is projected from the verified KernelBody and its
+   stable-read contracts, and its store emitter consumes only typed SSA—no source expression or
+   target-local type inference remains on that path. The portable path
    emits unchanged through OpenCL, CUDA and HIP and is compiled by the hardware-free CUDA/HIP CI
    gates. Hardware-costed multi-consumer placement and migration of the register-tiled leaf to the
    same scheduled-body store region are the next fusion/scheduling coverage steps.

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -146,6 +146,8 @@
      :epilogue-params params
      :region region}))
 
+(declare lower-scalar-ssa-region)
+
 (defn lower-store-region
   "Lower the one verified ScalarRegion shared by all matrix stores to OpenCL scalar syntax.
 
@@ -160,7 +162,9 @@
       (throw (ex-info "all matrix tile stores must carry the same scalar region"
                       {:reason :raster/bug :regions (vec regions)})))
     (when-let [region (first regions)]
-      (lower-scalar-region kernel-body region))))
+      (if (record-kind? "ScalarSSARegion" region)
+        (lower-scalar-ssa-region kernel-body region)
+        (lower-scalar-region kernel-body region)))))
 
 (defn- only!
   [owner values]
@@ -963,6 +967,76 @@
     (if view-offset
       (str "((long)(" (emit-index-expression view-offset names) ") + " local-offset ")")
       (str "(" local-offset ")"))))
+
+(defn- lower-scalar-ssa-region
+  [kernel-body region]
+  (let [storage (into {} (map (juxt :id identity)) (:parameters kernel-body))
+        accumulator (first (:parameters region))
+        [row-id col-id] (:indices region)
+        accumulator-token (str "__acc_" (name (gensym "")))
+        row-token (str "__row_" (name (gensym "")))
+        col-token (str "__col_" (name (gensym "")))
+        parameter-names (into {} (map (fn [id] [id (ce/c-symbol id)]))
+                              (rest (:parameters region)))
+        initial-context
+        {:names (merge parameter-names
+                       {accumulator accumulator-token row-id row-token col-id col-token})
+         :types (merge
+                 (into {} (map (fn [id] [id (dtype/canon (:dtype (get storage id)))]))
+                       (rest (:parameters region)))
+                 {accumulator (dtype/canon (:accumulator-dtype region))
+                  row-id :int col-id :int})}
+        final-context
+        (reduce
+         (fn [context operation]
+           (cond
+             (record-kind? "ScalarCompute" operation)
+             (let [result (:result operation)
+                   expression (emit-scalar-value (:expression operation) context)]
+               (-> context
+                   (assoc-in [:names (:id result)] (str "(" expression ")"))
+                   (assoc-in [:types (:id result)] (dtype/canon (:type result)))))
+
+             (record-kind? "ScalarLoad" operation)
+             (let [result (:result operation)
+                   parameter (get storage (:buffer operation))
+                   index (emit-storage-index parameter (:coordinates operation) (:names context))
+                   load (str (get parameter-names (:buffer operation)) "[" index "]")]
+               (when (:predicate operation)
+                 (throw (ex-info "matrix scalar SSA store regions do not admit masked loads"
+                                 {:reason :kernel-body-matrix-scalar-region-mask
+                                  :operation operation})))
+               (-> context
+                   (assoc-in [:names (:id result)] load)
+                   (assoc-in [:types (:id result)] (dtype/canon (:type result)))))
+
+             :else
+             (throw (ex-info "matrix store region contains unsupported scalar SSA"
+                             {:reason :kernel-body-matrix-scalar-region-operation
+                              :operation operation}))))
+         initial-context (:operations region))
+        emitted (get-in final-context [:names (:result region)])
+        external-parameters (rest (:parameters region))
+        epilogue-parameters
+        (filterv #(= :epilogue (:role (get storage %))) external-parameters)
+        params
+        (apply str
+               (for [id epilogue-parameters
+                     :let [parameter (get storage id)]]
+                 (if (= :scalar (:kind parameter))
+                   (str ", " (dtype/ctype :opencl (:dtype parameter)) " " (ce/c-symbol id))
+                   (str ", __global const " (dtype/ctype :opencl (:dtype parameter))
+                        "* restrict " (ce/c-symbol id)))))]
+    (when-not emitted
+      (throw (ex-info "matrix scalar SSA region has no emitted result"
+                      {:reason :raster/bug :region region})))
+    {:epilogue (fn [accumulator-expression row col]
+                 (-> emitted
+                     (str/replace accumulator-token (str "(" accumulator-expression ")"))
+                     (str/replace row-token row)
+                     (str/replace col-token col)))
+     :epilogue-params params
+     :region region}))
 
 (defn- emit-mask-predicate
   [predicate names]

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -21,6 +21,7 @@
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-body :as kbody]
+            [raster.compiler.ir.kernel-body-abi :as body-abi]
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.ir.scan :as scan]
@@ -1598,6 +1599,23 @@
              (when epilogue
                (epilogue-splice epilogue [i-sym j-sym] (get epilogue :dtype :float))))
         effective-epilogue (or epilogue (get-in kernel-body [:attributes :epilogue]))
+        matrix-abi
+        (when kernel-body
+          (let [dimensions (filterv #(= :dimension (:role %)) (:parameters kernel-body))
+                dimension-names (zipmap (map :id dimensions) ["M" "N" "K"])
+                c-name (fn [{:keys [id role]}]
+                         (case role
+                           :lhs "A"
+                           :rhs "B"
+                           :result "C"
+                           (or (get dimension-names id) (ce/c-symbol id))))]
+            (body-abi/project-contracts
+             (mapv (fn [{:keys [id kind dtype role] :as parameter}]
+                     (kabi/slot id kind dtype
+                                :c-name (c-name parameter)
+                                :role (if (contains? #{:lhs :rhs} role) :operand role)))
+                   (:parameters kernel-body))
+             kernel-body)))
         source (if kernel-body
                  (kernel-body-opencl/emit-matrix-kernel kernel-name kernel-body)
                  (apply codegen/emit-gemm-tiled kernel-name
@@ -1613,18 +1631,19 @@
      {:kernel-name kernel-name
       :source source
       :array-params [row-arr col-arr]
-      :abi (kabi/validate!
-            (vec (concat
-                  [(kabi/slot row-arr :input :half :c-name "A" :role :operand)
-                   (kabi/slot col-arr :input :half :c-name "B" :role :operand)
-                   (kabi/slot out-sym :output result-dtype :c-name "C" :role :result)
-                   (kabi/slot 'M :scalar :int :role :dimension)
-                   (kabi/slot 'N :scalar :int :role :dimension)
-                   (kabi/slot 'K :scalar :int :role :dimension)]
-                  (for [{:keys [sym dtype] :or {dtype :float}} (:operands effective-epilogue)]
-                    (kabi/slot sym :input dtype :c-name (ce/c-symbol sym) :role :epilogue))
-                  (for [{:keys [sym dtype] :or {dtype :float}} (:scalars effective-epilogue)]
-                    (kabi/slot sym :scalar dtype :c-name (ce/c-symbol sym) :role :epilogue)))))
+      :abi (or matrix-abi
+               (kabi/validate!
+                (vec (concat
+                      [(kabi/slot row-arr :input :half :c-name "A" :role :operand)
+                       (kabi/slot col-arr :input :half :c-name "B" :role :operand)
+                       (kabi/slot out-sym :output result-dtype :c-name "C" :role :result)
+                       (kabi/slot 'M :scalar :int :role :dimension)
+                       (kabi/slot 'N :scalar :int :role :dimension)
+                       (kabi/slot 'K :scalar :int :role :dimension)]
+                      (for [{:keys [sym dtype] :or {dtype :float}} (:operands effective-epilogue)]
+                        (kabi/slot sym :input dtype :c-name (ce/c-symbol sym) :role :epilogue))
+                      (for [{:keys [sym dtype] :or {dtype :float}} (:scalars effective-epilogue)]
+                        (kabi/slot sym :scalar dtype :c-name (ce/c-symbol sym) :role :epilogue))))))
       :dims [M N L]
       :dtype result-dtype
       :tile effective-tile

--- a/src/raster/compiler/ir/axis_map.clj
+++ b/src/raster/compiler/ir/axis_map.clj
@@ -95,6 +95,16 @@
   (rowmajor (for [g (:groups amap)]
               [(rowmajor (for [[a e] g] [a e])) (group-extent g)])))
 
+(defn coordinate-exprs
+  "Return one row-major coordinate expression per physical axis-map group.
+
+  Unlike `index-expr`, this preserves physical rank for scheduled storage whose KernelParameter
+  is not flattened. A merged group still becomes one coordinate."
+  [amap]
+  (mapv (fn [group]
+          (rowmajor (for [[axis extent] group] [axis extent])))
+        (:groups amap)))
+
 ;; ── layout relations (what the gate and the rearrange-inserter ask) ──────────────────
 (defn canonical?
   "Is this map the plain row-major layout over `expected-axes` (in that order, unmerged)?

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -23,6 +23,8 @@
 (defrecord Mask [id predicates])
 (defrecord Fragment [id dtype shape layout])
 (defrecord ScalarRegion [parameters expression operands result-dtype])
+(defrecord ScalarSSARegion
+           [parameters operands indices accumulator-dtype operations result result-dtype])
 
 ;; General scalar/control kernel vocabulary.  Results are SSA values; :predicate is an internal
 ;; control type rather than a public storage dtype.  Memory operations remain element/rank aware,
@@ -385,10 +387,8 @@
                       {:operand operand})))
     (axis-map/shape (:map operand))))
 
-(defn- validate-scalar-region!
-  [region storage epilogue-abi]
-  (when-not (record-kind? "raster.compiler.ir.kernel_body.ScalarRegion" region)
-    (throw (ex-info "tile-store value region must be a ScalarRegion" {:region region})))
+(defn- validate-scalar-region-boundary!
+  [region storage epilogue-abi operand-roles scalar-roles]
   (let [parameters (:parameters region)
         operands (:operands region)
         operand-ids (when (vector? operands) (mapv :sym operands))]
@@ -396,13 +396,15 @@
                    (every? symbol? parameters)
                    (= (count parameters) (count (set parameters)))
                    (vector? operands)
-                   (<= (inc (count operand-ids)) (count parameters))
-                   (some? (:expression region))
-                   (keyword? (:result-dtype region)))
+                   (<= (inc (count operand-ids)) (count parameters)))
       (throw (ex-info "tile-store scalar region is incomplete or has ambiguous parameters"
                       {:region region})))
     (let [accumulator (first parameters)
-          scalar-ids (subvec parameters (inc (count operand-ids)))]
+          scalar-ids (subvec parameters (inc (count operand-ids)))
+          external-ids (vec (rest parameters))
+          missing-external-ids (filterv #(not (contains? storage %)) external-ids)
+          region-epilogue-ids
+          (filterv #(= :epilogue (:role (get storage %))) external-ids)]
       (when-not (and (= operand-ids (subvec parameters 1 (inc (count operand-ids))))
                      (= (count operand-ids) (count (set operand-ids))))
         (throw (ex-info "scalar-region operands must be an ordered prefix of its ABI parameters"
@@ -410,31 +412,75 @@
       (when (contains? storage accumulator)
         (throw (ex-info "scalar-region accumulator must be region-local"
                         {:accumulator accumulator})))
-      (when-not (= epilogue-abi (vec (rest parameters)))
+      (when (seq missing-external-ids)
         (throw (ex-info "scalar-region parameters and the epilogue ABI disagree"
-                        {:parameters (vec (rest parameters))
+                        {:parameters external-ids
+                         :missing-parameters missing-external-ids
+                         :epilogue-abi epilogue-abi})))
+      (when-not (= epilogue-abi region-epilogue-ids)
+        (throw (ex-info "scalar-region parameters and the epilogue ABI disagree"
+                        {:parameters external-ids
+                         :region-epilogue-parameters region-epilogue-ids
                          :epilogue-abi epilogue-abi})))
       (doseq [operand operands]
         (let [id (:sym operand)
               parameter (get storage id)
               shape (axis-map! operand)]
           (when-not (and parameter (= :input (:kind parameter))
-                         (= :epilogue (:role parameter))
-                         (= (:dtype operand :float) (:dtype parameter))
+                         (contains? operand-roles (:role parameter))
+                         (= (dtype/canon (:dtype operand :float))
+                            (dtype/canon (:dtype parameter)))
                          (= shape (:shape parameter)))
             (throw (ex-info "scalar-region operand and its kernel ABI slot disagree"
                             {:operand operand :parameter parameter :shape shape})))))
       (doseq [id scalar-ids]
         (let [parameter (get storage id)]
           (when-not (and parameter (= :scalar (:kind parameter))
-                         (= :epilogue (:role parameter)))
+                         (contains? scalar-roles (:role parameter)))
             (throw (ex-info "scalar-region scalar and its kernel ABI slot disagree"
                             {:scalar id :parameter parameter})))))
-      (let [legal (scalar-region-legal? region)]
-        (when-not (:ok legal)
-          (throw (ex-info "tile-store scalar region is not store-local"
-                          (assoc legal :region region)))))
       region)))
+
+(defn- validate-scalar-region!
+  [region storage epilogue-abi]
+  (when-not (record-kind? "raster.compiler.ir.kernel_body.ScalarRegion" region)
+    (throw (ex-info "tile-store value region must be a ScalarRegion" {:region region})))
+  (when-not (and (some? (:expression region))
+                 (dtype/known? (:result-dtype region)))
+    (throw (ex-info "tile-store scalar region is incomplete or has ambiguous parameters"
+                    {:region region})))
+  (validate-scalar-region-boundary! region storage epilogue-abi #{:epilogue} #{:epilogue})
+  (let [legal (scalar-region-legal? region)]
+    (when-not (:ok legal)
+      (throw (ex-info "tile-store scalar region is not store-local"
+                      (assoc legal :region region)))))
+  region)
+
+(defn- validate-scalar-ssa-region!
+  [region storage masks scope epilogue-abi]
+  (when-not (record-kind? "raster.compiler.ir.kernel_body.ScalarSSARegion" region)
+    (throw (ex-info "tile-store value region must be typed scalar SSA" {:region region})))
+  (let [parameters (:parameters region)
+        indices (:indices region)
+        operations (:operations region)]
+    (validate-scalar-region-boundary!
+     region storage epilogue-abi #{:operand :lhs :rhs :epilogue} #{:parameter :epilogue})
+    (when-not (and (vector? indices) (every? symbol? indices)
+                   (= (count indices) (count (set indices)))
+                   (not-any? (set parameters) indices)
+                   (dtype/known? (:accumulator-dtype region))
+                   (vector? operations)
+                   (every? #(contains? #{"raster.compiler.ir.kernel_body.ScalarCompute"
+                                         "raster.compiler.ir.kernel_body.ScalarLoad"}
+                                       (some-> % class .getName))
+                           operations)
+                   (value-id? (:result region))
+                   (dtype/known? (:result-dtype region)))
+      (throw (ex-info "tile-store scalar SSA region is incomplete"
+                      {:reason :kernel-body-scalar-ssa-region :region region})))
+    (validate-operations! operations storage {} masks
+                          (into scope (concat parameters indices)) epilogue-abi)
+    region))
 
 (defn- validate-operation!
   [operation storage fragments masks scope epilogue-abi]
@@ -559,7 +605,9 @@
         (coordinates! "tile-store" (:coordinates operation))
         (mask (:mask operation))
         (when-let [region (:value-region operation)]
-          (validate-scalar-region! region storage epilogue-abi)))
+          (if (record-kind? "raster.compiler.ir.kernel_body.ScalarSSARegion" region)
+            (validate-scalar-ssa-region! region storage masks scope epilogue-abi)
+            (validate-scalar-region! region storage epilogue-abi))))
 
       (record-kind? "raster.compiler.ir.kernel_body.ScalarCompute" operation)
       (do
@@ -1417,6 +1465,42 @@
 
     :else []))
 
+(defn- scalar-ssa-store-regions
+  [operations]
+  (mapcat
+   (fn [operation]
+     (concat
+      (when (and (record-kind? "raster.compiler.ir.kernel_body.TileStore" operation)
+                 (record-kind? "raster.compiler.ir.kernel_body.ScalarSSARegion"
+                               (:value-region operation)))
+        [(:value-region operation)])
+      (mapcat scalar-ssa-store-regions (nested-operation-regions operation))))
+   operations))
+
+(defn- validate-scalar-ssa-dataflow!
+  [region values context]
+  (let [accumulator (first (:parameters region))
+        region-values
+        (into (assoc values accumulator
+                     {:type (canonical-type (:accumulator-dtype region))
+                      :uniformity lane-varying})
+              (map (fn [index] [index {:type :int :uniformity lane-varying}]))
+              (:indices region))
+        boundary-ids (set (concat (:parameters region) (:indices region)))
+        region-context (-> context
+                           (assoc :claimed (atom #{}))
+                           (update :reserved into boundary-ids)
+                           (assoc :control-uniformity lane-varying))
+        final-values (validate-dataflow-operations!
+                      (:operations region) region-values region-context)
+        result (get final-values (:result region))]
+    (when-not (= (canonical-type (:result-dtype region)) (:type result))
+      (throw (ex-info "scalar SSA store-region result has the wrong dtype"
+                      {:reason :kernel-body-scalar-region-result-dtype
+                       :result (:result region) :declared (:result-dtype region)
+                       :actual (:type result)})))
+    region))
+
 (defn- validate-async-protocol!
   [operations storage stable-buffers reserved]
   (let [claimed (atom reserved)]
@@ -1887,6 +1971,8 @@
                      :control-uniformity all-uniform
                      :launch launch
                      :schedule schedule}]
+        (doseq [region (scalar-ssa-store-regions operations)]
+          (validate-scalar-ssa-dataflow! region initial-values context))
         (validate-dataflow-operations! operations initial-values context))))
   body)
 

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -131,7 +131,8 @@
    7-arg kernel. Both are mechanically detectable by comparing the emitted signature with what the
    descriptor says to bind, which is what this does.
 
-   Pointer params must equal (array-params + 1 output + epilogue-operands). Default single-launch
+   Pointer params must equal the distinct bound inputs plus one output; a result transform may
+   reuse a contraction input by compiler identity without adding a second ABI slot. Default single-launch
    leaves must also supply matching 1-3D workgroup/grid data; validation closes those fields and the
    ordered compiler values into a KernelArtifact. Full reductions already arrive as a verified
    artifact and retain their distinct two-phase invoke protocol, whose scheduler owns geometry.
@@ -154,16 +155,20 @@
         ;; EXTRA operand arrays are pointer params too, whichever seam declared them: an
         ;; epilogue's (bias/residual/scale, appended after the dims) or a staged contraction's
         ;; lift operands (the per-block scales, bound between the operands and the output).
-        expect-ptr (+ (count array-params) 1 (count epilogue-operands) (count lift-operands))
+        distinct-pointer-inputs
+        (distinct (concat array-params epilogue-operands lift-operands))
+        expect-ptr (inc (count distinct-pointer-inputs))
         ;; Full reduction carries a complete ordered ABI. Other leaves still construct their
         ;; compiler argument values from descriptor scalars here, exactly once, before artifact
         ;; validation eliminates the positional convention from all runtime paths.
         ;; an epilogue's SCALARS are kernel scalar params too — they are emitted into the
         ;; signature by epilogue-splice, so a descriptor that omits them under-counts and the
         ;; capability becomes unusable (which is what pushed `:scheme` into a private channel)
+        abi-epilogue-scalars
+        (count (filter #(and (= :scalar (:kind %)) (= :epilogue (:role %))) abi))
         expect-scalar (if (= :reduction invoke)
                         (count (when abi (kabi/scalar-slots abi)))
-                        (+ (count scalar-args) (count epilogue-scalars)))]
+                        (+ (count scalar-args) abi-epilogue-scalars))]
     (cond
       (nil? abi)
       (throw (ex-info "contract descriptor: the ordered :abi is required"
@@ -176,9 +181,11 @@
       (throw (ex-info (str "contract descriptor: kernel takes " n-ptr " pointer params but the "
                            "descriptor binds " expect-ptr " (" (count array-params) " operands + out"
                            (when (seq epilogue-operands)
-                             (str " + " (count epilogue-operands) " epilogue"))
+                             (str " + distinct transform inputs from "
+                                  (count epilogue-operands) " references"))
                            (when (seq lift-operands)
-                             (str " + " (count lift-operands) " lift")) ")")
+                             (str " + distinct lift inputs from "
+                                  (count lift-operands) " references")) ")")
                       {:strategy strategy :kernel-name kernel-name :params params
                        :array-params array-params :epilogue-operands epilogue-operands
                        :lift-operands lift-operands}))

--- a/src/raster/compiler/passes/parallel/contraction_body.clj
+++ b/src/raster/compiler/passes/parallel/contraction_body.clj
@@ -158,7 +158,7 @@
             (decline! :literal-identity
                       "portable contraction requires a typed numeric reduction identity"
                       {:identity identity :segred-id (:id segred)}))
-        coordinate-lower #(lower-index % index-scope)
+        coordinate-lower #(lower-index (axis-map/index-expr %) index-scope)
         {:keys [operations result]}
         (segred-body/lower-element-operations
          element {:index reduced-index :coordinate reduced-index :dtype dtype

--- a/src/raster/compiler/passes/parallel/contraction_schedule.clj
+++ b/src/raster/compiler/passes/parallel/contraction_schedule.clj
@@ -47,24 +47,31 @@
 (defn- matrix-parameters
   [row col out M N K dimension-parameters row-layout col-layout out-layout result-dtype epilogue
    buffer-shapes additional-parameters]
-  (let [[m-parameter n-parameter k-parameter] dimension-parameters]
+  (let [[m-parameter n-parameter k-parameter] dimension-parameters
+        base-parameters
+        (vec
+         (concat
+          [(body/->KernelParameter row :input :half (get buffer-shapes row [M K])
+                                   :global row-layout :lhs)
+           (body/->KernelParameter col :input :half (get buffer-shapes col [K N])
+                                   :global col-layout :rhs)
+           (body/->KernelParameter out :output result-dtype (get buffer-shapes out [M N])
+                                   :global out-layout :result)
+           (body/->KernelParameter m-parameter :scalar :int [] nil nil :dimension)
+           (body/->KernelParameter n-parameter :scalar :int [] nil nil :dimension)
+           (body/->KernelParameter k-parameter :scalar :int [] nil nil :dimension)]
+          additional-parameters))
+        base-ids (set (map :id base-parameters))]
     (vec
      (concat
-      [(body/->KernelParameter row :input :half (get buffer-shapes row [M K])
-                               :global row-layout :lhs)
-       (body/->KernelParameter col :input :half (get buffer-shapes col [K N])
-                               :global col-layout :rhs)
-       (body/->KernelParameter out :output result-dtype (get buffer-shapes out [M N])
-                               :global out-layout :result)
-       (body/->KernelParameter m-parameter :scalar :int [] nil nil :dimension)
-       (body/->KernelParameter n-parameter :scalar :int [] nil nil :dimension)
-       (body/->KernelParameter k-parameter :scalar :int [] nil nil :dimension)]
-      additional-parameters
-      (for [{:keys [sym dtype map] :or {dtype :float}} (:operands epilogue)]
+      base-parameters
+      (for [{:keys [sym dtype map] :or {dtype :float}} (:operands epilogue)
+            :when (not (contains? base-ids sym))]
         (let [shape (axis-map/shape map)]
           (body/->KernelParameter sym :input dtype shape :global
                                   (layout/row-major shape dtype) :epilogue)))
-      (for [{:keys [sym dtype] :or {dtype :float}} (:scalars epilogue)]
+      (for [{:keys [sym dtype] :or {dtype :float}} (:scalars epilogue)
+            :when (not (contains? base-ids sym))]
         (body/->KernelParameter sym :scalar dtype [] nil nil :epilogue))))))
 
 (defn- fragment-id [prefix a & [b]]
@@ -113,8 +120,10 @@
         k-width (max 1 (quot 32 (layout/dtype-bits :half)))
         row-layout (layout/dot-operand 0 acc-layout k-width :half)
         col-layout (layout/dot-operand 1 acc-layout k-width :half)
-        out-layout (layout/row-major [M N] result-dtype)
-        buffer-layouts {row row-layout col col-layout out out-layout}
+        row-storage-layout (layout/row-major (get buffer-shapes row [M K]) :half)
+        col-storage-layout (layout/row-major (get buffer-shapes col [K N]) :half)
+        out-layout (layout/row-major (get buffer-shapes out [M N]) result-dtype)
+        buffer-layouts {row row-storage-layout col col-storage-layout out out-layout}
         buffer-views (mapv (fn [view]
                              (if (instance? raster.compiler.ir.kernel_body.BufferView view)
                                view
@@ -215,7 +224,26 @@
                             {:unrolled-by (quot block-k matrix-k)
                              :matrix-step matrix-k
                              :pipeline-depth num-stages})
-        region (scalar-region-lower/make-region epilogue)
+        parameters (matrix-parameters row col out M N K dimension-parameters
+                                      row-storage-layout col-storage-layout out-layout
+                                      result-dtype epilogue
+                                      buffer-shapes additional-parameters)
+        semantic-region (scalar-region-lower/make-region epilogue)
+        region
+        (when semantic-region
+          (scalar-region-lower/lower-region
+           semantic-region
+           {:accumulator (first (:parameters semantic-region))
+            :accumulator-dtype :float
+            :store-dtype result-dtype
+            :indices [i j]
+            :parameters (into {} (map (juxt :id identity)) parameters)
+            :coordinate-lower
+            #(mapv (fn [coordinate]
+                     (contraction-body/lower-index
+                      coordinate (set (concat axis-symbols dimension-parameters))))
+                   (axis-map/coordinate-exprs %))
+            :predicate nil}))
         stores (vec
                 (for [mm (range m-fragments) nn (range n-fragments)]
                   (body/->TileStore
@@ -228,10 +256,10 @@
                          (launch/ceil-div (launch/runtime-value m-parameter) block-m)])]
     (body/make
      {:id id
-      :parameters (matrix-parameters row col out M N K dimension-parameters
-                                     row-layout col-layout out-layout result-dtype epilogue
-                                     buffer-shapes additional-parameters)
+      :parameters parameters
       :views (vec buffer-views)
+      :stable-reads (mapv body/stable-read
+                          (map :id (filter #(= :input (:kind %)) parameters)))
       :indices (into (vec additional-indices) indices)
       :masks masks
       :fragments fragments

--- a/src/raster/compiler/passes/parallel/scalar_region_lower.clj
+++ b/src/raster/compiler/passes/parallel/scalar_region_lower.clj
@@ -55,7 +55,7 @@
   "Lower `region` once per completed scalar reduction result.
 
    `parameters` maps region scalar/operand IDs to KernelParameters. `coordinate-lower` translates
-   the declared operand axis-map to scheduled index arithmetic. The returned `:result` is cast to
+   a declared operand axis-map to one or more scheduled storage coordinates. The returned `:result` is cast to
    `store-dtype`, so ScalarStore remains completely typed."
   [region {:keys [accumulator accumulator-dtype store-dtype parameters coordinate-lower predicate]}]
   (let [result-dtype (dtype/canon (:result-dtype region))
@@ -81,23 +81,25 @@
                            result target)))))
 
             (load-operand [id]
-              (let [{:keys [dtype map] :as operand} (get operand-by-id id)
+              (let [{:keys [map] :as operand} (get operand-by-id id)
+                    operand-dtype (dtype/canon (get operand :dtype :float))
                     parameter (get parameters id)]
                 (when-not (and operand parameter (= :input (:kind parameter))
-                               (contains? #{:operand :epilogue} (:role parameter))
-                               (= (dtype/canon dtype) (dtype/canon (:dtype parameter))))
+                               (contains? #{:operand :lhs :rhs :epilogue} (:role parameter))
+                               (= operand-dtype (dtype/canon (:dtype parameter))))
                   (decline! :result-transform-operand
                             "result-transform operand lacks its typed KernelBody parameter"
                             {:operand operand :parameter parameter}))
                 (let [result (fresh "result-transform-load")
-                      coordinate (coordinate-lower (axis-map/index-expr map))]
+                      coordinates (coordinate-lower map)
+                      coordinates (if (vector? coordinates) coordinates [coordinates])]
                   (cast
                    (emit! (body/->ScalarLoad
-                           (body/value result (dtype/canon dtype)) id [coordinate]
+                           (body/value result operand-dtype) id coordinates
                            predicate
-                           (when predicate (body/literal 0 (dtype/canon dtype)))
+                           (when predicate (body/literal 0 operand-dtype))
                            :cached)
-                          result (dtype/canon dtype))
+                          result operand-dtype)
                    result-dtype))))
 
             (lower-expression [expression]
@@ -164,3 +166,11 @@
         {:operations @operations
          :result (:value stored-result)
          :result-dtype (:dtype stored-result)}))))
+
+(defn lower-region
+  "Close a semantic ScalarRegion as validated, target-neutral scalar SSA for a store site."
+  [region {:keys [accumulator accumulator-dtype store-dtype indices] :as options}]
+  (let [{:keys [operations result result-dtype]} (lower region options)]
+    (body/->ScalarSSARegion
+     (:parameters region) (:operands region) (vec indices) (dtype/canon accumulator-dtype)
+     operations result result-dtype)))

--- a/test/raster/compiler/backend/gpu/dpas_contract_device_test.clj
+++ b/test/raster/compiler/backend/gpu/dpas_contract_device_test.clj
@@ -177,7 +177,8 @@
       (testing "the fused KernelBody gains the operand ABI and a typed scalar region"
         (is (str/includes? (:source fused-k) "restrict bias"))
         (is (not (str/includes? (:source fused-k) "silu_f")))
-        (is (str/includes? (:source fused-k) "float x = ((acc00.s0) + bias[col])")
+        (is (re-find #"float x = \(\(acc00\.s0\) \+ .*bias\[[^]]*col"
+                     (:source fused-k))
             "the axis-map's j must bind to the store slot's col"))
       (testing "fused result == unfused GEMM followed by a separate bias+silu pass"
         ;; the two-pass reference: read C back, then apply the epilogue on the host

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -129,11 +129,11 @@
              (mapv (juxt :id :kind :dtype) epilogue-parameters)))
       (is (= ['acc 'bias 'scale] (:parameters region)))
       (is (re-find #"restrict bias, float scale" (:source emitted)))
-      (is (re-find #"bias\[col\].*scale" (:source emitted))))))
+      (is (re-find #"bias\[.*col.*\].*scale" (:source emitted))))))
 
 (deftest unresolved-source-helper-calls-are-not-scalar-ir
   (is (thrown-with-msg?
-       clojure.lang.ExceptionInfo #"without a typed target lowering"
+       clojure.lang.ExceptionInfo #"typed portable scalar lowering"
        (gemm/emit-scheduled-matrix-kernel
         {:kernel-name "body_undefined_helper"
          :a 'a :b 'b :c 'c :m 'm :n 'n :k 'k

--- a/test/raster/compiler/ir/axis_map_test.clj
+++ b/test/raster/compiler/ir/axis_map_test.clj
@@ -36,6 +36,8 @@
     (let [m (am/of-groups '[[[b 2]] [[c 3] [h 4]] [[w 5]]])]
       (is (= [2 12 5] (am/shape m)))                       ; group extent = 3*4
       (is (= 120 (am/n-elements m)))
+      (is (= '[b (clojure.core/+ (clojure.core/* c 4) h) w]
+             (am/coordinate-exprs m)))
       ;; index = b*(12*5) + (c*4 + h)*5 + w
       (is (= '(clojure.core/+ (clojure.core/* b 60)
                               (clojure.core/* (clojure.core/+ (clojure.core/* c 4) h) 5)

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -126,6 +126,48 @@
                                                :operands 0 :map]
                                        (axis-map/of-axes [['group-x 8]]))))))))
 
+(deftest typed-scalar-store-regions-have-closed-ssa-and-a-shared-buffer-abi
+  (let [region
+        (body/->ScalarSSARegion
+         ['value 'A] [{:sym 'A :map (axis-map/of-axes [['i 16] ['j 16]]) :dtype :half}]
+         ['i 'j] :half
+         [(body/->ScalarLoad (body/value 'loaded :half) 'A ['i 'j] nil nil :cached)
+          (body/->ScalarCompute
+           (body/value 'sum :half)
+           (body/scalar-expression :+ :half ['value 'loaded]))]
+         'sum :half)
+        kernel (-> (minimal-body)
+                   (assoc :stable-reads [(body/stable-read 'A)])
+                   (assoc-in [:operations 0 :operations 2 :value-region] region))]
+    (is (= kernel (body/validate! kernel)))
+    (testing "a shared contraction input does not need a second epilogue ABI slot"
+      (is (= ['A 'B 'C] (mapv :id (:parameters kernel)))))
+    (testing "uses must follow definitions inside the closed region"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"before it is defined"
+           (body/validate!
+            (assoc-in kernel [:operations 0 :operations 2 :value-region :operations]
+                      [(body/->ScalarCompute
+                        (body/value 'sum :half)
+                        (body/scalar-expression :+ :half ['value 'loaded]))])))))
+    (testing "the declared region result dtype is checked against typed SSA"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"wrong dtype"
+           (body/validate!
+            (assoc-in kernel [:operations 0 :operations 2 :value-region :result-dtype]
+                      :float)))))
+    (testing "the nested region admits only its small scalar/load vocabulary"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"incomplete"
+           (body/validate!
+            (update-in kernel [:operations 0 :operations 2 :value-region :operations]
+                       conj (body/->ScalarStore 'C ['i 'j] 'sum nil))))))
+    (testing "unclaimed epilogue slots cannot drift outside the region boundary"
+      (let [bias (body/->KernelParameter 'bias :scalar :float [] nil nil :epilogue)]
+        (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"epilogue ABI disagree"
+             (body/validate! (update kernel :parameters conj bias))))))))
+
 (defn- scalar-body
   [operations & {:keys [masks stable-reads allocations schedule shared-memory-bytes]
                  :or {masks [] stable-reads [] allocations [] schedule {:subgroup-size 16}

--- a/test/raster/compiler/passes/parallel/contraction_schedule_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_schedule_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [clojure.walk :as walk]
+            [raster.compiler.backend.gpu.c-emit :as c-emit]
             [raster.compiler.backend.gpu.opencl-pass :as opencl]
             [raster.compiler.backend.gpu.opencl-codegen :as opencl-codegen]
             [raster.compiler.backend.gpu.segop-opencl :as segop-opencl]
@@ -116,22 +117,42 @@
     (is (= (:workgroup oracle) (:wg routed)))
     (is (body/kernel-body? (:kernel-body routed)))))
 
-(deftest typed-store-regions-lower-identically-to-the-epilogue-oracle
+(deftest typed-store-regions-lower-from-scheduled-scalar-ssa
   (let [epilogue {:acc 'acc
                   :expr '(raster.numeric/+ acc (clojure.core/aget bias j))
                   :operands [{:sym 'bias
                               :map (axis-map/of-axes [['j 128]])
                               :dtype :float}]}
         form (concat (matrix-form 128 128 128) [:epilogue epilogue])
-        routed (route/route-contraction form :dtype :half)
-        oracle (segop-opencl/generate-dpas-contraction-kernel
-                (contract-lower/contract-form->segred form :dtype :half) 'C
-                :epilogue epilogue)
-        normalize #(str/replace % #"dpas_contract_[0-9]+" "dpas_contract_N")]
-    (is (= (normalize (:source oracle)) (normalize (:source routed))))
+        routed
+        (with-redefs [c-emit/emit-expr
+                      (fn [& _]
+                        (throw (ex-info "matrix store reparsed a source expression" {})))]
+          (route/route-contraction form :dtype :half))
+        region (some :value-region (get-in routed [:kernel-body :operations 0 :operations]))]
+    (is (instance? raster.compiler.ir.kernel_body.ScalarSSARegion region))
+    (is (= ["ScalarLoad" "ScalarCompute" "ScalarCompute"]
+           (mapv #(some-> % class .getSimpleName) (:operations region))))
+    (is (= :half (:result-dtype region)))
     (is (= '[bias] (:epilogue-operands routed)))
-    (is (re-find #"bias\[col\]" (:source routed)))
-    (is (some :value-region (get-in routed [:kernel-body :operations 0 :operations])))))
+    (is (re-find #"bias\[.*col" (:source routed)))
+    (is (re-find #"convert_half_rte" (:source routed)))))
+
+(deftest typed-store-regions-reuse-existing-contraction-inputs-by-identity
+  (let [epilogue {:acc 'acc
+                  :expr '(raster.numeric/+ acc (clojure.core/aget A
+                                                                  (clojure.core/+ (clojure.core/* i 128) j)))
+                  :operands [{:sym 'A
+                              :map (axis-map/of-axes [['i 128] ['j 128]])
+                              :dtype :half}]}
+        routed (route/route-contraction
+                (concat (matrix-form 128 128 128) [:epilogue epilogue]) :dtype :half)
+        parameter-ids (mapv :id (get-in routed [:kernel-body :parameters]))]
+    (is (= 1 (count (filter #{'A} parameter-ids))))
+    (is (empty? (filter #(= :epilogue (:role %))
+                        (get-in routed [:kernel-body :parameters]))))
+    (is (= '[A] (:epilogue-operands routed)))
+    (is (= 1 (count (re-seq #"__global const half\* restrict A" (:source routed)))))))
 
 (deftest production-kernel-body-lowering-does-not-call-the-legacy-template
   (with-redefs [opencl-codegen/emit-gemm-tiled

--- a/test/raster/compiler/passes/parallel/epilogue_operand_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/epilogue_operand_fusion_test.clj
@@ -55,19 +55,19 @@
           {:keys [store epi-ops declares]} (store-line (:form f))]
       (is (= '[bias] (mapv :sym (:operands (:epilogue f)))))
       (is (= (am/of-axes [['j N]]) (:map (first (:operands (:epilogue f))))))
-      (is (str/includes? store "bias[col]"))
+      (is (re-find #"bias\[[^]]*col" store))
       (is (= '[bias] epi-ops) "the descriptor must surface the extra kernel arg")
       (is (declares "bias") "…and the signature must declare it")))
   (testing "elementwise residual: full map, emitted index is R[row*N+col]"
     (let [f (fuse (list 'raster.numeric/+ (list 'aget 'C 't) (list 'aget 'R 't)))
           {:keys [store epi-ops]} (store-line (:form f))]
       (is (= (am/of-axes [['i M] ['j N]]) (:map (first (:operands (:epilogue f))))))
-      (is (str/includes? store (str "R[((row * " N ") + col)]")))
+      (is (re-find (re-pattern (str "R\\[[^]]*row[^]]*" N "[^]]*col")) store))
       (is (= '[R] epi-ops))))
   (testing "per-row scale: operand map is [i], emitted index is rs[row]"
     (let [f (fuse (list 'raster.numeric/* (list 'aget 'C 't) (list 'aget 'rs (list 'quot 't N))))
           {:keys [store]} (store-line (:form f))]
-      (is (str/includes? store "rs[row]"))))
+      (is (re-find #"rs\[[^]]*row" store))))
   (testing "an activation-only body still fuses, with no operands"
     (let [f (fuse (list 'raster.math/exp (list 'aget 'C 't)))
           {:keys [epi-ops]} (store-line (:form f))]

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -880,7 +880,7 @@
     (is (true? (:fused-epilogue routed)))
     (is (= '[bias] (:epilogue-operands routed)))
     (is (= '[A B C M N K bias scale] (mapv :name (:abi routed))))
-    (is (re-find #"bias\[col\]" (:source routed)))
+    (is (re-find #"bias\[.*col" (:source routed)))
     (is (re-find #"\* scale" (:source routed)))
     (is (= 1 (get-in emitted [:stats :ze-contracts])))
     (is (some #(= '[A B C M N K bias scale] (mapv :name (:abi %)))

--- a/test/raster/gpu/one_tile_source_test.clj
+++ b/test/raster/gpu/one_tile_source_test.clj
@@ -103,7 +103,7 @@
                      (filter #(= :epilogue (:role %))
                              (get-in emitted [:kernel-body :parameters])))))
         (is (re-find #"restrict bias" (:source emitted)))
-        (is (re-find #"bias\[col\]" (:source emitted)))))
+        (is (re-find #"bias\[[^]]*col" (:source emitted)))))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"unsupported fields"
                           (resident-program {:key :bias :fn identity :params "raw"
                                              :bindings {}})))))


### PR DESCRIPTION
This advances the typed contraction vertical through the matrix-accelerator leaf.

- close matrix result transforms into a verified ScalarSSARegion before target emission
- distinguish dense external storage layouts from subgroup matrix-fragment layouts
- lower rank-preserving AxisMap coordinates into typed ScalarLoad operations
- project the ordered ABI and stable-read contracts directly from KernelBody
- reuse shared contraction inputs by compiler identity without duplicate ABI slots
- retain the legacy ScalarRegion emitter only as an explicit compatibility boundary

Validation:
- focused compiler and source gate: 102 tests, 621 assertions
- GPU/source group with writable cache home: 161 tests, 703 assertions
- bounded full suite before the final oracle update: 2557 tests, 35156 assertions; its only semantic failure was the updated source-spelling oracle, and its only error was the sandbox home cache path. Both affected groups pass with a writable temporary home.
- parent PR #212 is green, including CUDA and HIP compile gates.