### PR TITLE
Schedule register-tiled contractions through KernelBody

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -935,8 +935,15 @@ The immediate continuation after the verified double-buffered weighted-reduction
    stable-read contracts, and its store emitter consumes only typed SSA—no source expression or
    target-local type inference remains on that path. The portable path
    emits unchanged through OpenCL, CUDA and HIP and is compiled by the hardware-free CUDA/HIP CI
-   gates. Hardware-costed multi-consumer placement and migration of the register-tiled leaf to the
-   same scheduled-body store region are the next fusion/scheduling coverage steps.
+   gates. The register-tiled family now also consumes verified contraction facts directly and
+   expresses cooperative dense staging, workgroup barriers, its K loops and register microtile as
+   scalar/control KernelBody. Every microtile store receives an alpha-renamed instance of the same
+   typed result transform, while the body-projected ABI deduplicates shared captures. The former
+   handwritten OpenCL register-tiled generator is deleted; its device numerical oracle now invokes
+   the scheduled body, and hardware-free CI compiles that body with both nvcc and hipcc. A finite
+   descending tile family is filtered by the target workgroup and shared-memory limits before
+   emission; an explicit infeasible tile or a target with no legal candidate declines honestly.
+   Hardware-costed multi-consumer placement is the next fusion/scheduling coverage step.
    Stable indexed gathers and explicitly unique guarded scatters also use this typed scheduled-map
    route, including resident block transfers. Hardware-costed multi-consumer fusion, nested-region
    JVM scheduling, reducing/atomic scatter variants, the remaining parallel forms, and

--- a/src/raster/compiler/backend/gpu/kernel_body_c_dialect.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_c_dialect.clj
@@ -69,9 +69,11 @@
                          :dialect (:id dialect) :parameter parameter})))
       (if (opencl? dialect)
         (str "__global " (when (= :input (:kind parameter)) "const ")
-             (type-name dialect (:dtype parameter)) "* " c-name)
+             (type-name dialect (:dtype parameter)) "* "
+             (when (:restrict? parameter) "restrict ") c-name)
         (str (when (= :input (:kind parameter)) "const ")
-             (type-name dialect (:dtype parameter)) "* __restrict__ " c-name)))))
+             (type-name dialect (:dtype parameter)) "* "
+             (when (:restrict? parameter) "__restrict__ ") c-name)))))
 
 (def ^:private axis-name ["x" "y" "z"])
 

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -1614,6 +1614,7 @@
                              (emit-index-expression (:expression index) names) ";"))))))
         [operation-source _] (emit-scalar-operations (:operations kernel-body) context 1)
         storage-declarations (concat parameters (:allocations kernel-body))
+        stable-reads (set (map :buffer (:stable-reads kernel-body)))
         uses-half? (some #(= :half (dtype/canon (:dtype %))) storage-declarations)
         uses-double? (some #(= :double (dtype/canon (:dtype %))) storage-declarations)
         collective (first (filter #(record-kind? "Collective" %) operations))
@@ -1632,7 +1633,10 @@
          (c-dialect/entry-prefix *scalar-dialect*) (target-name kernel-name) "(\n    "
          (str/join ",\n    "
                    (map #(c-dialect/parameter-declaration
-                          *scalar-dialect* % (get parameter-names (:id %)))
+                          *scalar-dialect*
+                          (cond-> % (contains? stable-reads (:id %))
+                            (assoc :restrict? true))
+                          (get parameter-names (:id %)))
                         parameters))
          ") {\n"
          allocation-source index-source operation-source

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -26,6 +26,7 @@
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.reduction :as reduction]
+            [raster.compiler.passes.parallel.register-tiled-body :as register-tiled-body]
             [raster.compiler.passes.parallel.segred-body :as segred-body]
             [clojure.walk :as walk]
             [clojure.set]
@@ -1271,8 +1272,8 @@
 
 (defn- syms-in [expr] (set (filter symbol? (tree-seq coll? seq expr))))
 
-;; analyze-contraction is defined below (next to the register-tiled emitter that also uses it);
-;; declared here because the block-tiled emitter above it shares the same analysis.
+;; Compatibility DPAS source gates still consume this structural analysis while their callers
+;; migrate to contraction facts and scheduled KernelBody values.
 (declare analyze-contraction)
 
 (defn- analyze-contraction
@@ -1344,78 +1345,47 @@
      :row-arr (:arr rowop) :row-idx (:idx rowop)
      :col-arr (:arr colop) :col-idx (:idx colop)}))
 
-(defn generate-regtiled-contraction-kernel
-  "REGISTER-TILED + __local-staged contraction → OpenCL (Futhark BlkRegTiling, register
-   level). Block tile BM×BN over the output, BK contraction chunk; each thread owns a
-   TM×TN register micro-tile of outputs (workgroup (BM/TM)×(BN/TN) threads). Cooperative
-   flattened staging of A/B into __local, then a register-blocked inner MAC (acc[TM][TN] +=
-   a[TM]·b[TN]). Zero-padded loads + guarded store handle non-divisible dims. The register
-   tile is precisely the fragment a DPAS/tensorize step (step 4) will consume.
+(defn generate-register-tiled-kernel-body
+  "Emit the verified cooperative register-tiled schedule through the shared C-family backend.
 
-   Prototype scope as analyze-contraction. Requires a 2-D launch: workgroup [BN/TN BM/TM],
-   grid [ceil(N/BN) ceil(M/BM)]. Returns {:kernel-name :source :array-params :dtype :block
-   [BM BN BK] :micro [TM TN] :workgroup [x y] :dims [M N L]}."
-  [segred out-sym & {:keys [dtype bm bn bk tm tn]
-                     :or {dtype :double bm 64 bn 64 bk 16 tm 4 tn 4}}]
-  (let [{:keys [M N L i-sym j-sym l-sym ctype init arr-params row-load col-load]}
-        (analyze-contraction segred dtype)
-        _ (assert (and (zero? (rem bm tm)) (zero? (rem bn tn)))
-                  "regtiled: BM%TM and BN%TN must be 0")
-        nt-row (quot bm tm) nt-col (quot bn tn) NT (* nt-row nt-col)
-        i-c (ce/c-symbol i-sym) j-c (ce/c-symbol j-sym) l-c (ce/c-symbol l-sym)
+   It consumes contraction facts, preserves a typed result transform and derives its ABI from
+   KernelBody; no target source is reconstructed from a compatibility SegRed."
+  [contract-facts out-sym & {:keys [tile descriptor operation-id]}]
+  (let [{:keys [kernel-body bindings dims tile]}
+        (register-tiled-body/lower
+         contract-facts (cond-> {:operation-id operation-id :descriptor descriptor}
+                          tile (assoc :tile tile)))
+        row (:row bindings)
+        col (:col bindings)
         kernel-name (str "regtiled_contract_" (gensym ""))
-        arr-param-str (str/join ", " (map (fn [s] (str "__global const " ctype "* restrict " (ce/c-symbol s))) arr-params))
-        src (str (codegen/extension-pragmas (or (:dtype segred) dtype))
-                 "__kernel void " kernel-name "(" arr-param-str ", __global " ctype "* restrict out) {\n"
-                 "    __local " ctype " As[" bm "][" bk "];\n"
-                 "    __local " ctype " Bs[" bk "][" bn "];\n"
-                 "    int tr = get_local_id(1);\n"
-                 "    int tc = get_local_id(0);\n"
-                 "    int tid = tr * " nt-col " + tc;\n"
-                 "    int block_i = get_group_id(1) * " bm ";\n"
-                 "    int block_j = get_group_id(0) * " bn ";\n"
-                 "    " ctype " acc[" tm "][" tn "];\n"
-                 "    for (int m = 0; m < " tm "; m++) for (int n = 0; n < " tn "; n++) acc[m][n] = " (str init) ";\n"
-                 "    for (int l0 = 0; l0 < " L "; l0 += " bk ") {\n"
-                 "        for (int idx = tid; idx < " (* bm bk) "; idx += " NT ") {\n"
-                 "            int r = idx / " bk "; int c = idx % " bk ";\n"
-                 "            int " i-c " = block_i + r; int " l-c " = l0 + c;\n"
-                 "            As[r][c] = ((" i-c " < " M ") && (" l-c " < " L ")) ? " row-load " : 0.0;\n"
-                 "        }\n"
-                 "        for (int idx = tid; idx < " (* bk bn) "; idx += " NT ") {\n"
-                 "            int r = idx / " bn "; int c = idx % " bn ";\n"
-                 "            int " l-c " = l0 + r; int " j-c " = block_j + c;\n"
-                 "            Bs[r][c] = ((" l-c " < " L ") && (" j-c " < " N ")) ? " col-load " : 0.0;\n"
-                 "        }\n"
-                 "        barrier(CLK_LOCAL_MEM_FENCE);\n"
-                 "        for (int t = 0; t < " bk "; t++) {\n"
-                 "            " ctype " a[" tm "]; " ctype " b[" tn "];\n"
-                 "            for (int m = 0; m < " tm "; m++) a[m] = As[tr*" tm "+m][t];\n"
-                 "            for (int n = 0; n < " tn "; n++) b[n] = Bs[t][tc*" tn "+n];\n"
-                 "            for (int m = 0; m < " tm "; m++) for (int n = 0; n < " tn "; n++) acc[m][n] = acc[m][n] + a[m] * b[n];\n"
-                 "        }\n"
-                 "        barrier(CLK_LOCAL_MEM_FENCE);\n"
-                 "    }\n"
-                 "    for (int m = 0; m < " tm "; m++) for (int n = 0; n < " tn "; n++) {\n"
-                 "        int gr = block_i + tr*" tm " + m; int gc = block_j + tc*" tn " + n;\n"
-                 "        if ((gr < " M ") && (gc < " N ")) out[gr * " N " + gc] = acc[m][n];\n"
-                 "    }\n"
-                 "}\n")]
+        parameter-names (merge (into {} (map (fn [parameter]
+                                                [(:id parameter)
+                                                 (ce/c-symbol (:id parameter))]))
+                                     (:parameters kernel-body))
+                               {row "A" col "B" out-sym "out"})
+        source (kernel-body-opencl/emit-scalar-kernel
+                kernel-name kernel-body {:parameter-names parameter-names})
+        abi
+        (body-abi/project-contracts
+         (mapv (fn [{:keys [id kind dtype role]}]
+                 (kabi/slot id kind dtype
+                            :c-name (or (get parameter-names id) (ce/c-symbol id))
+                            :role (if (contains? #{:lhs :rhs} role) :operand role)))
+               (:parameters kernel-body))
+         kernel-body)
+        epilogue-slots (filterv #(= :epilogue (:role %)) abi)]
     {:kernel-name kernel-name
-     :source src
-     :array-params arr-params
-     :abi (kabi/validate!
-           (vec (concat
-                 (map #(kabi/slot % :input (or (:dtype segred) dtype)
-                                  :c-name (ce/c-symbol %) :role :operand)
-                      arr-params)
-                 [(kabi/slot out-sym :output (or (:dtype segred) dtype)
-                             :c-name "out" :role :result)])))
-     :dtype (or (:dtype segred) dtype)
-     :block [bm bn bk]
-     :micro [tm tn]
-     :workgroup [nt-col nt-row]
-     :dims [M N L]}))
+     :source source
+     :array-params [row col]
+     :abi abi
+     :dtype (:dtype contract-facts)
+     :block [(:block-m tile) (:block-n tile) (:block-k tile)]
+     :micro [(:thread-m tile) (:thread-n tile)]
+     :workgroup (get-in kernel-body [:launch :workgroup-size])
+     :dims dims
+     :kernel-body kernel-body
+     :epilogue-operands (mapv :name (filter #(= :input (:kind %)) epilogue-slots))
+     :epilogue-scalars (mapv :name (filter #(= :scalar (:kind %)) epilogue-slots))}))
 
 ;; ================================================================
 ;; DPAS/XMX-tensorized contraction (PEAK) — raster's edge over Futhark

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -239,10 +239,10 @@
   "Strategies whose scheduled body or emitter has a typed store region and can honour an :epilogue.
    A WHITELIST on purpose: refuse by ABSENCE of support, never by a blacklist of shapes — a
    blacklist got this wrong twice, most recently by exempting the only shape production produces.
-   `:dpas` and `:portable-segred` lower through KernelBody ScalarRegion; the three staged-emitter
+   `:dpas`, `:regtiled` and `:portable-segred` lower through typed KernelBody storage; the three staged-emitter
    strategies still splice at the store (which is how a quant dequant scale is expressed since
    :scheme was deleted)."
-  #{:dpas :dp4a :portable-segred :quant-naive :staged-segred})
+  #{:dpas :dp4a :regtiled :portable-segred :quant-naive :staged-segred})
 
 (def ^:private contraction-families
   "Target schedule families for ordinary scalar typed contractions."
@@ -839,7 +839,8 @@
     ;; epilogue legality
     :epilogue-needs-2-free :epilogue-ignores-accumulator :accumulator-used-more-than-once
     :reduction-in-epilogue :layout-changing-op-in-epilogue
-    :epilogue-unsupported-by-this-leaf})
+    :epilogue-unsupported-by-this-leaf
+    :register-tiled-kernel-body-declined :scalar-region-kernel-body-declined})
 
 (defn- decline
   "A structured record of ONE leaf declining. `:data` is the gate's own ex-data minus its `:reason`
@@ -855,9 +856,15 @@
    reason; RETHROWS anything else — an unrecognized or absent reason is the compiler saying
    something is wrong, and a violated invariant is not a routing decision."
   [leaf ^clojure.lang.ExceptionInfo e]
-  (let [reason (:reason (ex-data e))]
+  (let [data (ex-data e)
+        reason (:reason data)
+        reported-reason (if (contains? #{:register-tiled-kernel-body-declined
+                                         :scalar-region-kernel-body-declined}
+                                       reason)
+                          (:missing-rule data)
+                          reason)]
     (when-not (contains? decline-reasons reason) (throw e))
-    (decline leaf reason (.getMessage e) (dissoc (ex-data e) :reason))))
+    (decline leaf reported-reason (.getMessage e) (dissoc data :reason :missing-rule))))
 
 (defn- route-2free-1contract
   "The tensorize fast path: DPAS if the gate accepts, else the register-tiled portable kernel.
@@ -878,9 +885,7 @@
         matrix? (contains? candidate-families :matrix)
         register-tiled? (contains? candidate-families :register-tiled)]
     (try
-      (let [sr (delay (cl/contract-form->segred contract-form :dtype dtype
-                                                  :facts contract-facts))
-            scheduled (when matrix?
+      (let [scheduled (when matrix?
                         (contraction-schedule/plan-matrix-body
                          contract-facts desc tile {:operation-id operation-id}))
             dpas (cond
@@ -915,8 +920,9 @@
              :scalar-args (mapv (fn [v] {:type :int :value (int v)}) (:dims dpas))  ; [m n k] params
              :dims (:dims dpas)})
       ;; gate rejected (dtype/orientation/pitch) → portable register-tiled kernel when enabled
-          (if (and register-tiled? (not (seq epilogue)))
-            (let [rt (sco/generate-regtiled-contraction-kernel @sr out-sym :dtype dtype)
+          (if register-tiled?
+            (let [rt (sco/generate-register-tiled-kernel-body
+                      contract-facts out-sym :operation-id operation-id :descriptor desc)
                   [bm bn _bk] (:block rt)
                   [M N _L] (:dims rt)]
               {:strategy :regtiled
@@ -924,19 +930,20 @@
                :declines @acc
                :kernel-name (:kernel-name rt)
                :source (:source rt)
-               :array-params (:array-params rt)            ; sorted-by-name (dims baked in source)
+               :array-params (:array-params rt)
                :abi (:abi rt)
                :dtype (:dtype rt) :out-dtype (:dtype rt) :out-elems (* M N)
+               :kernel-body (:kernel-body rt)
+               :fused-epilogue (boolean epilogue)
+               :epilogue-operands (:epilogue-operands rt)
+               :epilogue-scalars (:epilogue-scalars rt)
                :wg (:workgroup rt)
                :grid [(ceil-div N bn) (ceil-div M bm)]
                :scalar-args []                             ; regtiled bakes dims → no scalar params
                :dims (:dims rt)})
             (do
-              (note! (if register-tiled?
-                       (decline :regtiled :epilogue-unsupported-by-this-leaf nil
-                                {:family :register-tiled})
-                       (decline :regtiled :schedule-family-disabled nil
-                                {:family :register-tiled})))
+              (note! (decline :regtiled :schedule-family-disabled nil
+                              {:family :register-tiled}))
               {::declines @acc}))))
       (catch clojure.lang.ExceptionInfo e
      ;; whichever tensorize leaf threw, record WHY and let the caller fall through. `decline-of`

--- a/src/raster/compiler/passes/parallel/register_tiled_body.clj
+++ b/src/raster/compiler/passes/parallel/register_tiled_body.clj
@@ -1,0 +1,394 @@
+(ns raster.compiler.passes.parallel.register-tiled-body
+  "Lower a verified dense contraction to a cooperative register-tiled KernelBody.
+
+   This is a schedule, not a GEMM operation: contraction facts retain the additive reduction,
+   operand maps and result transform. The body makes workgroup staging, barriers, the scalar
+   microtile and 2-D launch explicit so every C-family target consumes the same scheduled value."
+  (:require [clojure.walk :as walk]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.layout :as layout]
+            [raster.compiler.ir.axis-map :as axis-map]
+            [raster.compiler.ir.contraction-facts :as facts]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.passes.parallel.contraction-body :as contraction-body]
+            [raster.compiler.passes.parallel.scalar-region-lower :as scalar-region-lower]))
+
+(def default-tile
+  {:block-m 64 :block-n 64 :block-k 16 :thread-m 4 :thread-n 4})
+
+(def ^:private tile-candidates
+  [default-tile
+   {:block-m 32 :block-n 32 :block-k 16 :thread-m 4 :thread-n 4}
+   {:block-m 16 :block-n 16 :block-k 8 :thread-m 4 :thread-n 4}
+   {:block-m 8 :block-n 8 :block-k 8 :thread-m 2 :thread-n 2}])
+
+(defn- decline!
+  [rule message data]
+  (throw (ex-info message (assoc data
+                                 :reason :register-tiled-kernel-body-declined
+                                 :missing-rule rule))))
+
+(defn declined?
+  [exception]
+  (or (= :register-tiled-kernel-body-declined (:reason (ex-data exception)))
+      (scalar-region-lower/declined? exception)))
+
+(defn- tile-resources
+  [tile storage-dtype]
+  (let [{:keys [block-m block-n block-k thread-m thread-n]} tile]
+    {:workgroup-size (* (quot block-m thread-m) (quot block-n thread-n))
+     :shared-memory-bytes (* block-k (+ block-m block-n)
+                             (dtype/bytes-of storage-dtype))}))
+
+(defn- valid-tile?
+  [tile]
+  (let [{:keys [block-m block-n block-k thread-m thread-n]} tile]
+    (and (every? pos-int? [block-m block-n block-k thread-m thread-n])
+         (zero? (mod block-m thread-m))
+         (zero? (mod block-n thread-n)))))
+
+(defn- resource-limits
+  [descriptor]
+  {:workgroup-size (long (or (get-in descriptor [:execution :max-workgroup-size])
+                             (:max-workgroup-size descriptor) Long/MAX_VALUE))
+   :shared-memory-bytes (long (or (:shared-local-memory descriptor)
+                                  (get-in descriptor [:memory :shared-local-memory])
+                                  (get-in descriptor [:memory :local-bytes])
+                                  Long/MAX_VALUE))})
+
+(defn- feasible-tile?
+  [tile storage-dtype limits]
+  (let [resources (tile-resources tile storage-dtype)]
+    (and (<= (:workgroup-size resources) (:workgroup-size limits))
+         (<= (:shared-memory-bytes resources) (:shared-memory-bytes limits)))))
+
+(defn- select-tile
+  [requested descriptor storage-dtype]
+  (let [limits (resource-limits descriptor)]
+    (if requested
+      (cond
+        (not (valid-tile? requested))
+        (throw (ex-info "register-tiled schedule has invalid tile divisibility"
+                        {:reason :raster/bug :tile requested}))
+
+        (feasible-tile? requested storage-dtype limits)
+        requested
+
+        :else
+        (decline! :target-resources
+                  "register-tiled schedule exceeds target workgroup or shared-memory limits"
+                  {:tile requested :resources (tile-resources requested storage-dtype)
+                   :limits limits}))
+      (or (first (filter #(feasible-tile? % storage-dtype limits) tile-candidates))
+          (decline! :target-resources
+                    "target cannot host any register-tiled schedule candidate"
+                    {:candidates (mapv #(assoc % :resources
+                                               (tile-resources % storage-dtype))
+                                       tile-candidates)
+                     :limits limits})))))
+
+(defn- additive?
+  [combine]
+  (contains? '#{+ clojure.core/+ raster.numeric/+} combine))
+
+(defn- identifier
+  [prefix & parts]
+  (symbol (apply str prefix (map #(str "-" %) parts))))
+
+(defn- add [& values] (apply body/expression :add values))
+(defn- mul [& values] (apply body/expression :mul values))
+(defn- div [left right] (body/expression :floor-div left right))
+(defn- modulo [left right] (body/expression :mod left right))
+
+(defn- barrier
+  []
+  (body/->WorkgroupBarrier
+   :workgroup #{:workgroup} :acquire-release (body/full-participation)))
+
+(defn- transform-parameters
+  [result-transform base-parameters]
+  (let [base-ids (set (map :id base-parameters))]
+    (vec
+     (concat
+      (for [{:keys [sym dtype map] :or {dtype :float}} (:operands result-transform)
+            :when (not (contains? base-ids sym))]
+        (let [shape (axis-map/shape map)]
+          (body/->KernelParameter sym :input (dtype/canon dtype) shape :global
+                                  (layout/row-major shape dtype) :epilogue)))
+      (for [{:keys [sym dtype] :or {dtype :float}} (:scalars result-transform)
+            :when (not (contains? base-ids sym))]
+        (body/->KernelParameter sym :scalar (dtype/canon dtype) [] nil nil :epilogue))))))
+
+(defn- staging-loop
+  [{:keys [id buffer allocation dtype elements thread-id workgroup-width
+           row-coordinate col-coordinate source-coordinates valid-mask]}]
+  (let [index (identifier id "index")
+        value (identifier id "value")]
+    (body/->ForLoop
+     (body/value index :int) thread-id elements workgroup-width []
+     [(body/->ScalarLoad (body/value value dtype) buffer
+                         (source-coordinates index) valid-mask
+                         (body/literal 0 dtype) :cached)
+      (body/->ScalarStore allocation
+                          [(row-coordinate index) (col-coordinate index)] value nil)
+      (body/->Yield [])]
+     [] {:unroll false})))
+
+(defn lower
+  "Apply one static cooperative register-tiled schedule to verified contraction facts."
+  [contract-facts {:keys [tile descriptor operation-id]}]
+  (when-not (facts/facts? contract-facts)
+    (throw (ex-info "register-tiled scheduling requires verified contraction facts"
+                    {:reason :raster/bug :facts contract-facts})))
+  (let [{:keys [dtype free-axes contract-axes epilogue out]} contract-facts
+        dtype (dtype/canon dtype)
+        _ (when-not (dtype/known? dtype)
+            (decline! :storage-dtype
+                      "register-tiled schedule requires a known storage dtype"
+                      {:dtype dtype}))
+        tile (select-tile tile descriptor dtype)
+        {:keys [combine neutral]} (facts/scalar-reduction-view contract-facts)
+        {:keys [block-m block-n block-k thread-m thread-n]} tile
+        _ (when-not (= [2 1] [(count free-axes) (count contract-axes)])
+            (decline! :not-2-free
+                      "register-tiled schedule requires exactly two free axes and one reduction axis"
+                      {:free-axes free-axes :contract-axes contract-axes}))
+        _ (when-not (every? number? (concat (map second free-axes)
+                                            (map second contract-axes)))
+            (decline! :symbolic-dims
+                      "register-tiled schedule requires literal dims"
+                      {:free-axes free-axes :contract-axes contract-axes}))
+        _ (when-not (additive? combine)
+            (decline! :non-plus-combine
+                      "register-tiled contraction combine must be +"
+                      {:combine combine}))
+        _ (when-not (and (number? neutral) (zero? neutral))
+            (decline! :non-zero-matrix-init
+                      "register-tiled contraction requires a zero reduction identity"
+                      {:neutral neutral}))
+        layout-verdict (facts/check-layout contract-facts (:dpas facts/leaf-layouts))
+        _ (when-not (:ok layout-verdict)
+            (decline! :dense-row-major-operands
+                      "register-tiled schedule requires dense A(i,k) and B(k,j) operands"
+                      layout-verdict))
+        {:keys [row col]} (:bindings layout-verdict)
+        [[i M] [j N]] free-axes
+        [[k K]] contract-axes
+        row-shape [M K]
+        col-shape [K N]
+        out-shape [M N]
+        row-layout (layout/row-major row-shape dtype)
+        col-layout (layout/row-major col-shape dtype)
+        out-layout (layout/row-major out-shape dtype)
+        base-parameters
+        [(body/->KernelParameter row :input dtype row-shape :global row-layout :lhs)
+         (body/->KernelParameter col :input dtype col-shape :global col-layout :rhs)
+         (body/->KernelParameter out :output dtype out-shape :global out-layout :result)]
+        parameters (into (vec base-parameters) (transform-parameters epilogue base-parameters))
+        parameter-map (into {} (map (juxt :id identity)) parameters)
+        row-allocation 'register-tile-a
+        col-allocation 'register-tile-b
+        allocations
+        [(body/->WorkgroupAllocation row-allocation dtype [block-m block-k]
+                                     (layout/row-major [block-m block-k] dtype)
+                                     (dtype/bytes-of dtype))
+         (body/->WorkgroupAllocation col-allocation dtype [block-k block-n]
+                                     (layout/row-major [block-k block-n] dtype)
+                                     (dtype/bytes-of dtype))]
+        workgroup-by-row (quot block-m thread-m)
+        workgroup-by-col (quot block-n thread-n)
+        workgroup-width (* workgroup-by-row workgroup-by-col)
+        local-col 'register-local-col
+        local-row 'register-local-row
+        group-col 'register-group-col
+        group-row 'register-group-row
+        thread-id 'register-thread-id
+        block-row 'register-block-row
+        block-col 'register-block-col
+        indices
+        [(body/->IndexBinding local-col :local 0)
+         (body/->IndexBinding local-row :local 1)
+         (body/->IndexBinding group-col :group 0)
+         (body/->IndexBinding group-row :group 1)
+         (body/->IndexCompute thread-id (add (mul local-row workgroup-by-col) local-col))
+         (body/->IndexCompute block-row (mul group-row block-m))
+         (body/->IndexCompute block-col (mul group-col block-n))]
+        row-stage-index 'register-a-index
+        col-stage-index 'register-b-index
+        row-stage-row #(div % block-k)
+        row-stage-col #(modulo % block-k)
+        col-stage-row #(div % block-n)
+        col-stage-col #(modulo % block-n)
+        k-block 'register-k-block
+        row-valid-mask :register-a-valid
+        col-valid-mask :register-b-valid
+        masks
+        (vec
+         (concat
+          [(body/->Mask
+            row-valid-mask
+            [(body/predicate :lt (add block-row (row-stage-row row-stage-index)) M)
+             (body/predicate :lt (add k-block (row-stage-col row-stage-index)) K)])
+           (body/->Mask
+            col-valid-mask
+            [(body/predicate :lt (add k-block (col-stage-row col-stage-index)) K)
+             (body/predicate :lt (add block-col (col-stage-col col-stage-index)) N)])]
+          (for [mm (range thread-m) nn (range thread-n)]
+            (body/->Mask
+             (keyword (str "register-store-" mm "-" nn))
+             [(body/predicate :lt (add block-row (mul local-row thread-m) mm) M)
+              (body/predicate :lt (add block-col (mul local-col thread-n) nn) N)]))))
+        outer-accumulator-bindings
+        (vec (for [mm (range thread-m) nn (range thread-n)]
+               (identifier "register-outer-acc" mm nn)))
+        inner-accumulator-bindings
+        (vec (for [mm (range thread-m) nn (range thread-n)]
+               (identifier "register-inner-acc" mm nn)))
+        accumulator-results
+        (vec (for [mm (range thread-m) nn (range thread-n)]
+               (identifier "register-result" mm nn)))
+        inner-results
+        (vec (for [mm (range thread-m) nn (range thread-n)]
+               (identifier "register-inner-result" mm nn)))
+        inner-index 'register-k-inner
+        inner-operations
+        (vec
+         (concat
+          (mapcat
+           (fn [mm]
+             (let [loaded (identifier "register-a" mm)]
+               [(body/->ScalarLoad
+                 (body/value loaded dtype) row-allocation
+                 [(add (mul local-row thread-m) mm) inner-index] nil nil :cached)]))
+           (range thread-m))
+          (mapcat
+           (fn [nn]
+             (let [loaded (identifier "register-b" nn)]
+               [(body/->ScalarLoad
+                 (body/value loaded dtype) col-allocation
+                 [inner-index (add (mul local-col thread-n) nn)] nil nil :cached)]))
+           (range thread-n))
+          (mapcat
+           (fn [[mm nn]]
+             (let [product (identifier "register-product" mm nn)
+                   next-accumulator (identifier "register-next" mm nn)
+                   accumulator (identifier "register-inner-acc" mm nn)]
+               [(body/->ScalarCompute
+                 (body/value product dtype)
+                 (body/scalar-expression :* dtype
+                                         [(identifier "register-a" mm)
+                                          (identifier "register-b" nn)]))
+                (body/->ScalarCompute
+                 (body/value next-accumulator dtype)
+                 (body/scalar-expression :+ dtype [accumulator product]))]))
+           (for [mm (range thread-m) nn (range thread-n)] [mm nn]))
+          [(body/->Yield
+            (vec (for [mm (range thread-m) nn (range thread-n)]
+                   (identifier "register-next" mm nn))))]))
+        inner-loop
+        (body/->ForLoop
+         (body/value inner-index :int) 0 block-k 1
+         (mapv (fn [binding initial]
+                 (body/->LoopArg (body/value binding dtype) initial))
+               inner-accumulator-bindings outer-accumulator-bindings)
+         inner-operations
+         (mapv #(body/value % dtype) inner-results)
+         {:unroll true})
+        stage-row
+        (staging-loop
+         {:id "register-a" :buffer row :allocation row-allocation :dtype dtype
+          :elements (* block-m block-k) :thread-id thread-id
+          :workgroup-width workgroup-width
+          :row-coordinate row-stage-row :col-coordinate row-stage-col
+          :source-coordinates
+          (fn [index]
+            [(add block-row (row-stage-row index))
+             (add k-block (row-stage-col index))])
+          :valid-mask row-valid-mask})
+        stage-col
+        (staging-loop
+         {:id "register-b" :buffer col :allocation col-allocation :dtype dtype
+          :elements (* block-k block-n) :thread-id thread-id
+          :workgroup-width workgroup-width
+          :row-coordinate col-stage-row :col-coordinate col-stage-col
+          :source-coordinates
+          (fn [index]
+            [(add k-block (col-stage-row index))
+             (add block-col (col-stage-col index))])
+          :valid-mask col-valid-mask})
+        outer-loop
+        (body/->ForLoop
+         (body/value k-block :int) 0 K block-k
+         (mapv (fn [binding]
+                 (body/->LoopArg (body/value binding dtype) (body/literal 0 dtype)))
+               outer-accumulator-bindings)
+         [stage-row stage-col (barrier) inner-loop (barrier)
+          (body/->Yield inner-results)]
+         (mapv #(body/value % dtype) accumulator-results)
+         {})
+        semantic-region (scalar-region-lower/make-region epilogue)
+        stores
+        (vec
+         (mapcat
+          (fn [mm]
+            (mapcat
+             (fn [nn]
+               (let [position (+ (* mm thread-n) nn)
+                     accumulator (nth accumulator-results position)
+                     store-mask (keyword (str "register-store-" mm "-" nn))
+                     row-source (list '+ block-row (list '* local-row thread-m) mm)
+                     col-source (list '+ block-col (list '* local-col thread-n) nn)
+                     coordinates [(contraction-body/lower-index
+                                   row-source #{block-row block-col local-row local-col})
+                                  (contraction-body/lower-index
+                                   col-source #{block-row block-col local-row local-col})]
+                     lowered
+                     (when semantic-region
+                       (scalar-region-lower/lower
+                        semantic-region
+                        {:accumulator accumulator
+                         :accumulator-dtype dtype
+                         :store-dtype dtype
+                         :parameters parameter-map
+                         :id-prefix (str "register-store-" mm "-" nn)
+                         :coordinate-lower
+                         #(mapv (fn [coordinate]
+                                  (contraction-body/lower-index
+                                   (walk/postwalk-replace
+                                    {i row-source j col-source} coordinate)
+                                   #{block-row block-col local-row local-col}))
+                                (axis-map/coordinate-exprs %))
+                         :predicate store-mask}))]
+                 (concat (:operations lowered)
+                         [(body/->ScalarStore out coordinates
+                                              (or (:result lowered) accumulator)
+                                              store-mask)])))
+             (range thread-n)))
+          (range thread-m)))
+        memory-plan (body/workgroup-memory-plan allocations)]
+    {:kernel-body
+     (body/make
+      {:id [:contraction (or operation-id out) :register-tiled]
+       :parameters parameters
+       :stable-reads (mapv body/stable-read
+                           (distinct (concat [row col] (map :sym (:operands epilogue)))))
+       :allocations allocations
+       :indices indices
+       :masks masks
+       :operations (into [outer-loop] stores)
+       :schedule (assoc tile :strategy :register-tiled)
+       :launch (launch/spec
+                {:workgroup-size [workgroup-by-col workgroup-by-row]
+                 :group-count [(launch/ceil-div N block-n)
+                               (launch/ceil-div M block-m)]
+                 :shared-memory-bytes (:bytes memory-plan)})
+       :provenance {:dialect :kernel-body :operation-id operation-id}
+       :attributes {:kind :register-tiled-contraction
+                    :dims [M N K]
+                    :axis-symbols [i j k]
+                    :bindings (:bindings layout-verdict)
+                    :result-transform epilogue}})
+     :bindings (:bindings layout-verdict)
+     :dims [M N K]
+     :tile tile}))

--- a/src/raster/compiler/passes/parallel/scalar_region_lower.clj
+++ b/src/raster/compiler/passes/parallel/scalar_region_lower.clj
@@ -57,14 +57,17 @@
    `parameters` maps region scalar/operand IDs to KernelParameters. `coordinate-lower` translates
    a declared operand axis-map to one or more scheduled storage coordinates. The returned `:result` is cast to
    `store-dtype`, so ScalarStore remains completely typed."
-  [region {:keys [accumulator accumulator-dtype store-dtype parameters coordinate-lower predicate]}]
+  [region {:keys [accumulator accumulator-dtype store-dtype parameters coordinate-lower predicate
+                  id-prefix]}]
   (let [result-dtype (dtype/canon (:result-dtype region))
         accumulator-id (first (:parameters region))
         operand-by-id (into {} (map (juxt :sym identity)) (:operands region))
         scalar-ids (vec (drop (inc (count operand-by-id)) (:parameters region)))
         operations (atom [])
         counter (atom 0)
-        fresh (fn [prefix] (symbol (str prefix "-" (swap! counter inc))))
+        fresh (fn [prefix]
+                (symbol (str (when id-prefix (str id-prefix "-"))
+                             prefix "-" (swap! counter inc))))
         emit! (fn [operation value value-dtype]
                 (swap! operations conj operation)
                 {:value value :dtype value-dtype})]

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -14,6 +14,7 @@
             [raster.compiler.passes.parallel.attention-route :as attention-route]
             [raster.compiler.passes.parallel.contract-lower :as contract-lower]
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]
+            [raster.compiler.passes.parallel.register-tiled-body :as register-tiled-body]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-schedule :as schedule]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]))
 
@@ -51,6 +52,28 @@
     (segop-emit/generate-contraction-kernel-body
      (:body planned) :target-dialect dialect
      :kernel-name-prefix "portable_contraction")))
+
+(defn- register-tiled-contraction-source
+  [dialect]
+  (let [epilogue {:acc 'acc
+                  :expr '(raster.numeric/*
+                          (raster.numeric/+ acc (clojure.core/aget bias j)) scale)
+                  :operands [{:sym 'bias :dtype :float
+                              :map (axis-map/of-axes [['j 64]])}]
+                  :scalars [{:sym 'scale :dtype :float}]
+                  :dtype :float}
+        facts (contraction-facts/from-components
+               {:out 'C
+                :free-axes [['i 64] ['j 64]]
+                :contract-axes [['k 32]]
+                :body '(raster.numeric/*
+                        (clojure.core/aget A (clojure.core/+ (clojure.core/* i 32) k))
+                        (clojure.core/aget B (clojure.core/+ (clojure.core/* k 64) j)))
+                :opts {:epilogue epilogue}
+                :dtype :float})
+        kernel-body (:kernel-body (register-tiled-body/lower facts {}))]
+    (body-emit/emit-scalar-kernel
+     "register_tiled_contraction" kernel-body {:target-dialect dialect})))
 
 (defn- problem []
   (attention/make
@@ -125,6 +148,8 @@
                             (reduction-artifact dialect))
            (write-artifact! directory suffix "portable-contraction"
                             (contraction-artifact dialect descriptor))
+           (write-source! directory suffix "register-tiled-contraction"
+                          (register-tiled-contraction-source dialect))
            (write-source! directory suffix "workgroup-memory"
                           (body-emit/emit-scalar-kernel
                            "workgroup_memory" (body-fixtures/workgroup-memory-body 32)

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -111,7 +111,7 @@
                 (scalar-kernel-body)
                 {:parameter-names {'x "input_rows" 'bias "row_bias"
                                    'y "output_rows" 'scale "scale"}})]
-    (is (str/includes? source "__global const half* input_rows"))
+    (is (str/includes? source "__global const half* restrict input_rows"))
     (is (str/includes? source
                        "input_rows[((long)((rstr_query_row * 16)) + ((long)(rstr_lane)"))
     (is (str/includes? source "((rstr_lane < 16)) ? input_rows"))
@@ -120,7 +120,8 @@
     (is (str/includes? source "sub_group_broadcast(rstr_subgroup_sum, 0)"))
     (is (str/includes? source "convert_half_rte(rstr_shared_sum)"))
     (is (str/includes? source "if (((rstr_lane == 0)))"))
-    (is (not (str/includes? source "restrict")))
+    (is (not (str/includes? source "__global half* restrict output_rows"))
+        "only body-proven stable reads acquire a target no-alias qualifier")
     (testing "the emitted target program is valid OpenCL C"
       (if-not (zero? (:exit (shell/sh "sh" "-c" "command -v clang")))
         (is true "clang unavailable")

--- a/test/raster/compiler/backend/gpu/tiled_contract_device_test.clj
+++ b/test/raster/compiler/backend/gpu/tiled_contract_device_test.clj
@@ -3,7 +3,7 @@
    emitter (Arc GPU). Tests BOTH tile-divisible and non-divisible dims (boundary padding).
    Uses launch-2d! (workgroup [T T], grid [ceil(N/T) ceil(M/T)]). Gated on a real GPU."
   (:require [clojure.test :refer [deftest is testing]]
-            [raster.compiler.passes.parallel.contract-lower :as cl]
+            [raster.compiler.ir.contraction-facts :as facts]
             [raster.compiler.backend.gpu.segop-opencl :as sco])
   (:import [java.lang.foreign MemorySegment]))
 
@@ -44,9 +44,9 @@
         form (list 'raster.par/contract 'C [['i m] ['j n]] [['l k]]
                    (list '* (list 'aget 'A (list '+ (list '* 'i k) 'l))
                          (list 'aget 'B (list '+ (list '* 'l n) 'j))))
-        sr (cl/contract-form->segred form)
+        verified (facts/contraction-facts form :dtype :double)
         {:keys [kernel-name source block micro workgroup]}
-        (sco/generate-regtiled-contraction-kernel sr 'C)
+        (sco/generate-register-tiled-kernel-body verified 'C)
         [bm bn _] block
         [wgx wgy] workgroup
         _ (register! kernel-name {:source source :dtype :double})

--- a/test/raster/compiler/fail_loud_contraction_test.clj
+++ b/test/raster/compiler/fail_loud_contraction_test.clj
@@ -114,15 +114,15 @@
           "the identity must be the op's, not 0.0 — summing max-partials from 0.0 is wrong for
            all-negative data"))))
 
-(deftest fp64-result-transform-uses-the-typed-portable-store
-  (testing "an f64 two-free/one-contract result transform executes on the portable leaf"
+(deftest fp64-result-transform-uses-the-typed-register-tiled-store
+  (testing "an f64 two-free/one-contract result transform executes on the register-tiled leaf"
     (let [form (list 'raster.par/contract 'C [['i 4] ['j 4]] [['l 8]]
                      (list 'raster.numeric/*
                            (list 'aget 'A (list 'clojure.core/+ (list 'clojure.core/* 'i 8) 'l))
                            (list 'aget 'B (list 'clojure.core/+ (list 'clojure.core/* 'l 4) 'j)))
                      :epilogue {:acc 'acc :expr '(raster.numeric/* acc 2.0)})
           routed (cr/route-contraction form :dtype :double)]
-      (is (= :portable-segred (:strategy routed)))
+      (is (= :regtiled (:strategy routed)))
       (is (true? (:fused-epilogue routed)))
       (is (re-find #"\* 2\.0" (:source routed))))))
 

--- a/test/raster/compiler/passes/parallel/attention_route_test.clj
+++ b/test/raster/compiler/passes/parallel/attention_route_test.clj
@@ -589,7 +589,7 @@
            (mapv :dtype (:abi artifact))))
     (is (= :float (get-in artifact [:attributes :q-dtype])))
     (is (= :float (get-in artifact [:attributes :output-dtype])))
-    (is (str/includes? source "__global const float* q"))
+    (is (str/includes? source "__global const float* restrict q"))
     (is (str/includes? source "__global float* output"))
     (is (str/includes? source
                        "float rstr_qk_product = (rstr_query_float * rstr_key_float)"))

--- a/test/raster/compiler/passes/parallel/contraction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_body_test.clj
@@ -121,16 +121,17 @@
     (is (empty? (:epilogue-operands routed)))
     (is (= '[A B] (mapv :buffer (get-in routed [:kernel-body :stable-reads]))))))
 
-(deftest result-transforms-fall-through-an-ineligible-matrix-and-register-tiled-leaf
+(deftest result-transforms-use-the-register-tiled-body-when-matrix-is-ineligible
   (let [descriptor {:device-type :gpu :backend :ocl
                     :execution {:subgroup-sizes #{}
                                 :preferred-subgroup-size nil
                                 :max-workgroup-size 256}}
         routed (route/route-contraction (portable-result-transform-form)
                                         :dtype :half :desc descriptor)]
-    (is (= :portable-segred (:strategy routed)))
+    (is (= :regtiled (:strategy routed)))
     (is (true? (:fused-epilogue routed)))
-    (is (= [:matrix-capability-unavailable :epilogue-unsupported-by-this-leaf]
+    (is (body/kernel-body? (:kernel-body routed)))
+    (is (= [:matrix-capability-unavailable]
            (mapv :reason (:declines routed))))))
 
 (deftest production-general-contraction-route-carries-the-scheduled-body

--- a/test/raster/compiler/passes/parallel/register_tiled_body_test.clj
+++ b/test/raster/compiler/passes/parallel/register_tiled_body_test.clj
@@ -1,0 +1,98 @@
+(ns raster.compiler.passes.parallel.register-tiled-body-test
+  (:require [clojure.java.shell :as shell]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.kernel-body-opencl :as body-emit]
+            [raster.compiler.backend.gpu.segop-opencl :as segop-emit]
+            [raster.compiler.ir.axis-map :as axis-map]
+            [raster.compiler.ir.contraction-facts :as facts]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.passes.parallel.register-tiled-body :as register-tiled]))
+
+(def ^:private small-tile
+  {:block-m 4 :block-n 4 :block-k 2 :thread-m 2 :thread-n 2})
+
+(defn- contraction
+  [& [epilogue]]
+  (facts/from-components
+   {:out 'C
+    :free-axes [['i 8] ['j 8]]
+    :contract-axes [['k 8]]
+    :body '(raster.numeric/*
+            (clojure.core/aget A (clojure.core/+ (clojure.core/* i 8) k))
+            (clojure.core/aget B (clojure.core/+ (clojure.core/* k 8) j)))
+    :opts (cond-> {} epilogue (assoc :epilogue epilogue))
+    :dtype :float}))
+
+(defn- operation-kinds
+  [operations]
+  (mapcat
+   (fn [operation]
+     (concat [(some-> operation class .getSimpleName)]
+             (when (instance? raster.compiler.ir.kernel_body.ForLoop operation)
+               (operation-kinds (:operations operation)))))
+   operations))
+
+(deftest cooperative-register-tile-is-a-verified-scalar-kernel-body
+  (let [kernel-body (:kernel-body
+                     (register-tiled/lower (contraction) {:tile small-tile}))
+        kinds (frequencies (operation-kinds (:operations kernel-body)))
+        opencl (body-emit/emit-scalar-kernel "register_tile" kernel-body)
+        cuda (body-emit/emit-scalar-kernel
+              "register_tile" kernel-body {:target-dialect :cuda})
+        hip (body-emit/emit-scalar-kernel
+             "register_tile" kernel-body {:target-dialect :hip})]
+    (is (body/kernel-body? kernel-body))
+    (is (= [[4 2] [2 4]] (mapv :shape (:allocations kernel-body))))
+    (is (= [2 2] (get-in kernel-body [:launch :workgroup-size])))
+    (is (= [2 2] (mapv #(launch/resolve-expression {} %)
+                       (get-in kernel-body [:launch :group-count]))))
+    (is (= 4 (get kinds "ForLoop")) "outer K, inner K and two cooperative staging loops are explicit")
+    (is (= 2 (get kinds "WorkgroupBarrier")))
+    (is (str/includes? opencl "__local"))
+    (is (str/includes? opencl "barrier(CLK_LOCAL_MEM_FENCE)"))
+    (is (str/includes? cuda "__shared__"))
+    (is (str/includes? cuda "__syncthreads()"))
+    (is (str/includes? hip "__shared__"))
+    (is (str/includes? hip "__syncthreads()"))
+    (testing "the nested cooperative schedule is valid OpenCL C"
+      (if-not (zero? (:exit (shell/sh "sh" "-c" "command -v clang")))
+        (is true "clang unavailable")
+        (let [compiled (shell/sh "clang" "-x" "cl" "-cl-std=CL2.0"
+                                 "-fsyntax-only" "-" :in opencl)]
+          (is (zero? (:exit compiled)) (:err compiled)))))))
+
+(deftest result-transform-is-alpha-renamed-per-microtile-store
+  (let [epilogue {:acc 'acc
+                  :expr '(raster.numeric/*
+                          (raster.numeric/+ acc (clojure.core/aget bias j)) scale)
+                  :operands [{:sym 'bias :dtype :float
+                              :map (axis-map/of-axes [['j 8]])}]
+                  :scalars [{:sym 'scale :dtype :float}]
+                  :dtype :float}
+        emitted (segop-emit/generate-register-tiled-kernel-body
+                 (contraction epilogue) 'C :tile small-tile)
+        kernel-body (:kernel-body emitted)]
+    (is (body/kernel-body? kernel-body))
+    (is (= '[A B C bias scale] (mapv :name (:abi emitted))))
+    (is (= '[bias] (:epilogue-operands emitted)))
+    (is (= '[scale] (:epilogue-scalars emitted)))
+    (is (= '[A B bias] (mapv :buffer (:stable-reads kernel-body))))
+    (is (str/includes? (:source emitted) "bias["))
+    (is (str/includes? (:source emitted) "* scale"))))
+
+(deftest target-resource-limits-select-or-refuse-a-finite-tile
+  (let [lowered (register-tiled/lower
+                 (contraction)
+                 {:descriptor {:execution {:max-workgroup-size 64}
+                               :shared-local-memory 4096}})]
+    (is (= {:block-m 32 :block-n 32 :block-k 16 :thread-m 4 :thread-n 4}
+           (:tile lowered)))
+    (is (= [8 8] (get-in lowered [:kernel-body :launch :workgroup-size]))))
+  (is (thrown-with-msg?
+       clojure.lang.ExceptionInfo #"cannot host any register-tiled"
+       (register-tiled/lower
+        (contraction)
+        {:descriptor {:execution {:max-workgroup-size 8}
+                      :shared-local-memory 128}}))))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -885,12 +885,10 @@
     (is (= 1 (get-in emitted [:stats :ze-contracts])))
     (is (some #(= '[A B C M N K bias scale] (mapv :name (:abi %)))
               (:kernels emitted)))
-    (is (= [:dpas :portable-segred]
+    (is (= [:dpas :regtiled :portable-segred]
            (mapv #(get-in % [:attributes :strategy])
                  (:alternatives emitted-dispatch))))
-    (is (= #{:register-tiled}
-           (set (map :candidate-family
-                     (get-in emitted-dispatch [:attributes :declines])))))
+    (is (empty? (get-in emitted-dispatch [:attributes :declines])))
     (is (kernel-graph-call/kernel-graph-call? call))
     (is (= {:type :float :value 0.5}
            (last (-> call :nodes first :call :arguments))))


### PR DESCRIPTION
This removes the handwritten OpenCL register-tiled contraction leaf and makes register tiling another schedule of verified contraction facts.

- represent cooperative A/B staging, workgroup allocations, barriers, K loops and register microtiles in scalar/control KernelBody
- lower typed result transforms at every microtile store with explicit store-site alpha-renaming
- derive the ordered ABI and stable-read no-alias facts from KernelBody
- select a finite descending tile family against target workgroup and shared-memory limits
- emit the same body through OpenCL, CUDA and HIP
- move the existing on-device numerical oracle to the scheduled body and delete the old template generator
- emit target restrict qualifiers only for body-proven stable reads

Validation:
- focused compiler/routing/source gates: 72 tests, 656 assertions
- affected full-suite failures rechecked: 29 tests, 294 assertions
- bounded full suite completed: 2560 tests, 35183 assertions; all six reported failures were stale routing/source oracles introduced by this change, then updated and individually rechecked green
- clang accepts the generated OpenCL nested cooperative body
- nvcc emits sm_80 PTX for the generated CUDA body
- hipcc emits a gfx1100 code object for the generated HIP body
- parent PR #213 is fully green.