### PR TITLE
Cost typed multi-consumer placement

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -943,10 +943,18 @@ The immediate continuation after the verified double-buffered weighted-reduction
    the scheduled body, and hardware-free CI compiles that body with both nvcc and hipcc. A finite
    descending tile family is filtered by the target workgroup and shared-memory limits before
    emission; an explicit infeasible tile or a target with no legal candidate declines honestly.
-   Hardware-costed multi-consumer placement is the next fusion/scheduling coverage step.
+   Hardware-costed multi-consumer placement now uses one target-neutral roofline policy shared by
+   the TypedSOAC and compatibility graph routes. Typed fan-out values carry an explicit,
+   serializable recompute/materialize witness (fanout, dtype, registered scalar work, abstract-
+   machine ridge, threshold and reason); cheap producers may be cloned into consumers while their
+   equation remains live, whereas a proven-expensive producer stays materialized. A host-visible
+   value remains an observable result even when dependency removal subsequently permits one
+   tuple-valued horizontal kernel. Ordinary compilation and direct session scheduling both pass
+   the same device-stripped Abstract Machine into this decision, and a missing machine retains the
+   typed materialization boundary rather than speculating about duplicated work.
    Stable indexed gathers and explicitly unique guarded scatters also use this typed scheduled-map
-   route, including resident block transfers. Hardware-costed multi-consumer fusion, nested-region
-   JVM scheduling, reducing/atomic scatter variants, the remaining parallel forms, and
+   route, including resident block transfers. Nested-region JVM scheduling, reducing/atomic
+   scatter variants, the remaining parallel forms, calibrated whole-graph placement costs, and
    deletion of the remaining graph/backend fallbacks remain.
 6. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a
    read-only distributed track without interrupting the kernel and typed-middle-end verticals.

--- a/src/raster/compiler/passes/parallel/fusion_placement.clj
+++ b/src/raster/compiler/passes/parallel/fusion_placement.clj
@@ -12,22 +12,36 @@
   "Stable identifier recorded with every placement witness."
   :roofline-v1)
 
-(defn expression-flops
-  "Return the registered flop-equivalent cost of `expressions`.
+(defn expression-cost
+  "Return registered flop-equivalent cost and its completeness for `expressions`.
 
-   Cost facets are attached to semantic operations in op-descriptor.  Unpriced operations add no
-   speculative cost: this policy is decline-only, so incomplete cost information must not invent a
-   loss and disable an otherwise legal fusion."
+   Cost facets are attached to semantic operations in op-descriptor. Array reads and primitive
+   casts are transparent here: memory traffic is priced by the placement policy and casts do not
+   add floating-point work. Every other unpriced call makes the estimate incomplete; unknown work
+   must never look like zero work and enable duplicated computation."
   [expressions]
-  (let [total (volatile! 0)]
+  (let [total (volatile! 0)
+        unknown (volatile! #{})]
     (letfn [(visit [form]
               (when (seq? form)
                 (when-let [operation (descriptor/semantic-op form)]
-                  (when-let [cost (descriptor/cost-facet operation)]
-                    (vswap! total + (long (:flops cost 0)))))
+                  (if-let [cost (descriptor/cost-facet operation)]
+                    (vswap! total + (long (:flops cost 0)))
+                    (when-not (or (descriptor/aget-op? operation)
+                                  (descriptor/cast-op? operation))
+                      (vswap! unknown conj operation))))
                 (run! visit form)))]
       (run! visit expressions))
-    @total))
+    {:flops @total
+     :complete? (empty? @unknown)
+     :unknown-ops (vec (sort-by str @unknown))}))
+
+(defn expression-flops
+  "Return the registered portion of the flop-equivalent cost of `expressions`.
+
+   Call `expression-cost` when completeness affects a decision."
+  [expressions]
+  (:flops (expression-cost expressions)))
 
 (defn placement-decision
   "Choose recomputation or materialization for one typed producer value.
@@ -39,13 +53,12 @@
 
        producer-flops <= element-bytes * ridge(dtype)
 
-   With no Abstract Machine, fan-out remains materialized: the typed pass must not speculate that
-   duplicated computation is cheaper. Missing dtype-specific information on an otherwise present
-   machine abstains in the established decline-only direction (`:recompute`).
+   With incomplete producer cost or no complete Abstract Machine price, fan-out remains
+   materialized: the typed pass must not speculate that duplicated computation is cheaper.
    The returned map is a serializable witness suitable for program facts and tuning records."
   [{:keys [abstract-machine dtype expressions consumer-count]}]
   (let [consumer-count (long consumer-count)
-        flops (expression-flops expressions)
+        {:keys [flops complete? unknown-ops]} (expression-cost expressions)
         element-bytes (when (dtype/known? dtype) (dtype/bytes-of dtype))
         ridge (get-in abstract-machine [:ridge dtype])
         threshold (when (and element-bytes ridge)
@@ -54,6 +67,8 @@
               :consumer-count consumer-count
               :dtype dtype
               :producer-flops-per-element flops
+              :producer-cost-complete? complete?
+              :unknown-cost-ops unknown-ops
               :element-bytes element-bytes
               :ridge-flops-per-byte ridge
               :recompute-threshold-flops threshold}]
@@ -68,15 +83,20 @@
              :reason :no-abstract-machine
              :fuse? false)
 
+      (not complete?)
+      (assoc base :decision :materialize
+             :reason :unknown-producer-cost
+             :fuse? false)
+
       (nil? element-bytes)
-      (assoc base :decision :recompute
+      (assoc base :decision :materialize
              :reason :unknown-element-width
-             :fuse? true)
+             :fuse? false)
 
       (nil? ridge)
-      (assoc base :decision :recompute
+      (assoc base :decision :materialize
              :reason :unknown-roofline-ridge
-             :fuse? true)
+             :fuse? false)
 
       (<= flops threshold)
       (assoc base :decision :recompute

--- a/src/raster/compiler/passes/parallel/fusion_placement.clj
+++ b/src/raster/compiler/passes/parallel/fusion_placement.clj
@@ -1,0 +1,89 @@
+(ns raster.compiler.passes.parallel.fusion-placement
+  "Target-neutral placement policy for a functional value with more than one consumer.
+
+   Fusion legality belongs to the SOAC pass.  This namespace answers the narrower scheduling
+   question that remains once fusion is known to be legal: should a producer be recomputed inside
+   its consumers, or should its intermediate stay materialized?  It reads only Raster's Abstract
+   Machine and typed scalar expressions; vendor/device identities never cross this boundary."
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.op-descriptor :as descriptor]))
+
+(def policy-version
+  "Stable identifier recorded with every placement witness."
+  :roofline-v1)
+
+(defn expression-flops
+  "Return the registered flop-equivalent cost of `expressions`.
+
+   Cost facets are attached to semantic operations in op-descriptor.  Unpriced operations add no
+   speculative cost: this policy is decline-only, so incomplete cost information must not invent a
+   loss and disable an otherwise legal fusion."
+  [expressions]
+  (let [total (volatile! 0)]
+    (letfn [(visit [form]
+              (when (seq? form)
+                (when-let [operation (descriptor/semantic-op form)]
+                  (when-let [cost (descriptor/cost-facet operation)]
+                    (vswap! total + (long (:flops cost 0)))))
+                (run! visit form)))]
+      (run! visit expressions))
+    @total))
+
+(defn placement-decision
+  "Choose recomputation or materialization for one typed producer value.
+
+   `consumer-count` includes equation consumers and externally observable program outputs.  A sole
+   consumer always eliminates the intermediate: its computation moves rather than duplicates.
+   For fan-out, recomputation is profitable when the producer's per-element work fits beneath the
+   roofline cost of reading one materialized element:
+
+       producer-flops <= element-bytes * ridge(dtype)
+
+   With no Abstract Machine, fan-out remains materialized: the typed pass must not speculate that
+   duplicated computation is cheaper. Missing dtype-specific information on an otherwise present
+   machine abstains in the established decline-only direction (`:recompute`).
+   The returned map is a serializable witness suitable for program facts and tuning records."
+  [{:keys [abstract-machine dtype expressions consumer-count]}]
+  (let [consumer-count (long consumer-count)
+        flops (expression-flops expressions)
+        element-bytes (when (dtype/known? dtype) (dtype/bytes-of dtype))
+        ridge (get-in abstract-machine [:ridge dtype])
+        threshold (when (and element-bytes ridge)
+                    (* (long element-bytes) (double ridge)))
+        base {:policy policy-version
+              :consumer-count consumer-count
+              :dtype dtype
+              :producer-flops-per-element flops
+              :element-bytes element-bytes
+              :ridge-flops-per-byte ridge
+              :recompute-threshold-flops threshold}]
+    (cond
+      (<= consumer-count 1)
+      (assoc base :decision :eliminate
+             :reason :sole-consumer
+             :fuse? true)
+
+      (nil? abstract-machine)
+      (assoc base :decision :materialize
+             :reason :no-abstract-machine
+             :fuse? false)
+
+      (nil? element-bytes)
+      (assoc base :decision :recompute
+             :reason :unknown-element-width
+             :fuse? true)
+
+      (nil? ridge)
+      (assoc base :decision :recompute
+             :reason :unknown-roofline-ridge
+             :fuse? true)
+
+      (<= flops threshold)
+      (assoc base :decision :recompute
+             :reason :recompute-cheaper-than-read
+             :fuse? true)
+
+      :else
+      (assoc base :decision :materialize
+             :reason :recompute-more-expensive-than-read
+             :fuse? false))))

--- a/src/raster/compiler/passes/parallel/soac_graph.clj
+++ b/src/raster/compiler/passes/parallel/soac_graph.clj
@@ -12,12 +12,11 @@
     :cons    — consumer mutates array producer reads (anti-dep)"
   (:require [clojure.set :as set]
             [clojure.walk :as walk]
-            [raster.compiler.core.dtype :as dt]
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.soac :as soac]
+            [raster.compiler.passes.parallel.fusion-placement :as placement]
             [raster.compiler.passes.parallel.fusion-support :as fusion-support]
-            [raster.compiler.passes.parallel.schedule-support :as schedule-support]
-            [raster.compiler.core.op-descriptor :as opd]))
+            [raster.compiler.passes.parallel.schedule-support :as schedule-support]))
 
 ;; ================================================================
 ;; FusionGraph record
@@ -331,32 +330,6 @@
 ;; fusion set is a subset of the legal set (F_chosen ⊆ F_legal) by construction.
 ;; ================================================================
 
-(defn- lambda-flops
-  "Sum the :cost-facet flop-equivalent weights of every operator APPLICATION in a
-   kernel body. Op heads are qualified semantic symbols (raster.numeric/+,
-   raster.math/exp — the walker emits qualified). Unknown ops contribute 0: an
-   unknown cost must never INFLATE recompute and fabricate a decline, so the
-   conservative direction is to under-count (keep fusing). Portable flop-equiv,
-   priced by the AM, not a hardware instruction count."
-  [body]
-  (let [total (atom 0)]
-    (letfn [(walk [form]
-              (when (seq? form)
-                (let [h (first form)]
-                  (when (symbol? h)
-                    (swap! total + (long (:flops (opd/cost-facet h) 0)))))
-                (doseq [x form] (walk x))))]
-      (walk body))
-    @total))
-
-(defn- elem-bytes
-  "Byte width of the AM's working element dtype (GPU training default :f16), from the ONE dtype
-   registry — the private table this replaces had no :byte branch and priced int8 at 2 bytes.
-   Returns nil for a dtype the compiler cannot spell, so the caller ABSTAINS: this is a cost
-   model, and a cost model may decline to answer but must never throw or fabricate."
-  [dtype]
-  (when (dt/known? dtype) (dt/bytes-of dtype)))
-
 (defn vertical-fusion-profitable?
   "PROFITABILITY (decline-only). A MULTI-consumer vertical fusion inlines the
    producer body into THIS consumer while the producer stays alive for its other
@@ -380,13 +353,13 @@
   (or (nil? am)
       (empty? (other-consumers graph producer-id consumer-id))   ;; sole consumer → pure win
       (let [producer (get (:nodes graph) producer-id)
-            ridge    (get-in am [:ridge dtype])
-            eb       (elem-bytes dtype)]
-        (or (nil? ridge)
-            (nil? eb)                    ; unspellable dtype ⇒ abstain (fuse), never throw
-            (not (instance? raster.compiler.ir.soac.SoacMap producer))
-            (<= (lambda-flops (:lambda producer))
-                (* (long eb) (double ridge)))))))
+            consumer-count (inc (count (other-consumers graph producer-id consumer-id)))]
+        (or (not (instance? raster.compiler.ir.soac.SoacMap producer))
+            (:fuse? (placement/placement-decision
+                     {:abstract-machine am
+                      :dtype dtype
+                      :expressions [(:lambda producer)]
+                      :consumer-count consumer-count}))))))
 
 (defn- reduction-fusion-expressions
   [product]

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -11,7 +11,8 @@
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.axis-map :as axis-map]
-            [raster.compiler.ir.soac-dialect :as dialect]))
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.passes.parallel.fusion-placement :as placement]))
 
 (def ^:private map-equation-rule
   (from-dialect dialect/TypedSOAC
@@ -244,16 +245,17 @@
            :fusion fused-kind
            :fused-equations ids)))
 
+(defn- equation-constituents
+  [equation-id equation-facts]
+  (or (get-in equation-facts [:attributes :fusion/constituents])
+      {equation-id (update equation-facts :attributes dissoc :fusion/constituents)}))
+
 (defn- remove-equation-fact
   [facts removed-id kept-id fused-kind]
   (let [removed (get-in facts [:equations removed-id])
         kept (get-in facts [:equations kept-id])
-        constituent-facts
-        (fn [id equation-facts]
-          (or (get-in equation-facts [:attributes :fusion/constituents])
-              {id (update equation-facts :attributes dissoc :fusion/constituents)}))
-        constituents (merge (constituent-facts kept-id kept)
-                            (constituent-facts removed-id removed))]
+        constituents (merge (equation-constituents kept-id kept)
+                            (equation-constituents removed-id removed))]
     (-> facts
         (update :equations dissoc removed-id)
         (assoc-in [:equations kept-id :attributes :fusion/constituents] constituents)
@@ -261,6 +263,22 @@
                   (merge-provenance
                    (assoc (:provenance kept) :fused-equations [kept-id])
                    (assoc (:provenance removed) :fused-equations [removed-id])
+                   fused-kind)))))
+
+(defn- record-recomputed-fusion
+  "Record that `producer-id` was cloned into one consumer while its materialized equation remains."
+  [facts producer-id consumer-id fused-kind placement-witness]
+  (let [producer (get-in facts [:equations producer-id])
+        consumer (get-in facts [:equations consumer-id])
+        constituents (merge (equation-constituents consumer-id consumer)
+                            (equation-constituents producer-id producer))]
+    (-> facts
+        (assoc-in [:equations consumer-id :attributes :fusion/constituents] constituents)
+        (assoc-in [:equations consumer-id :attributes :fusion/placement] placement-witness)
+        (assoc-in [:equations consumer-id :provenance]
+                  (merge-provenance
+                   (assoc (:provenance consumer) :fused-equations [consumer-id])
+                   (assoc (:provenance producer) :fused-equations [producer-id])
                    fused-kind)))))
 
 (defn- transfer-result-boundary
@@ -476,12 +494,30 @@
                                        (:attributes updated))))]
       (rebuild-boundary program facts equations))))
 
-(defn- vertical-candidate
-  [program]
+(defn- producer-placement-witness
+  [program infos uses producer produced abstract-machine]
+  (let [consumer-ids (->> infos
+                          (filter #(some #{produced} (equation-references
+                                                      (emit-equation %))))
+                          (mapv :id))
+        witness (placement/placement-decision
+                 {:abstract-machine abstract-machine
+                  :dtype (value-scalar-dtype program produced)
+                  :expressions (concat (map :init (:locals producer))
+                                       (:body-results producer))
+                  :consumer-count (get uses produced 0)})]
+    (assoc witness
+           :producer (:id producer)
+           :value produced
+           :consumers consumer-ids
+           :externally-visible? (contains? (set (dialect/outputs program)) produced))))
+
+(defn- vertical-candidates
+  [program abstract-machine]
   (let [equations (dialect/equations program)
         infos (mapv equation-info equations)
         uses (value-use-counts program)]
-    (first
+    (vec
      (for [producer-index (range (count infos))
            consumer-index (range (inc producer-index) (count infos))
            :let [producer (nth infos producer-index)
@@ -500,17 +536,20 @@
                      (and (empty? (:locals producer)) (empty? (:locals consumer)))
                      (some? (value-scalar-dtype program produced)))
            :when (= (:extent (:attributes producer)) (:extent (:attributes consumer)))
-           :when (= 1 (get uses produced 0))
+           :when (pos? (get uses produced 0))
            :when (some #{produced} (:arrays consumer))
            :when (fusible-equation? program (:id producer))
-           :when (fusible-equation? program (:id consumer))]
+           :when (fusible-equation? program (:id consumer))
+           :let [placement-witness (producer-placement-witness
+                                    program infos uses producer produced abstract-machine)]]
        {:producer-index producer-index :consumer-index consumer-index
-        :producer producer :consumer consumer :produced produced}))))
+        :producer producer :consumer consumer :produced produced
+        :use-count (get uses produced 0)
+        :placement placement-witness}))))
 
-(defn- fuse-vertical-once
-  [program]
-  (when-let [{:keys [producer-index consumer-index producer consumer produced]}
-             (vertical-candidate program)]
+(defn- fuse-vertical-candidate
+  [program {:keys [producer-index consumer-index producer consumer produced use-count]
+            placement-witness :placement}]
     (let [producer (freshen-parameters producer "producer")
           consumer (freshen-parameters consumer "consumer")
           producer-parameters (parameter-parts producer)
@@ -577,14 +616,22 @@
                                                   (:capture-parameters canonical)))
                          :locals (:locals canonical)
                          :body-results (:body-results canonical))
-          equations (-> (dialect/equations program)
-                        (assoc consumer-index (emit-equation updated))
-                        (->> (keep-indexed (fn [index equation]
-                                             (when-not (= index producer-index) equation)))
-                             vec))
-          facts (remove-equation-fact (dialect/facts program) (:id producer) (:id consumer)
-                                      (keyword (str "map-" (name (:kind consumer)))))]
-      (rebuild-boundary program facts equations))))
+          retain-producer? (> use-count 1)
+          fused-kind (keyword (str "map-" (name (:kind consumer))))
+          equations (assoc (dialect/equations program) consumer-index (emit-equation updated))
+          equations (if retain-producer?
+                      equations
+                      (->> equations
+                           (keep-indexed (fn [index equation]
+                                           (when-not (= index producer-index) equation)))
+                           vec))
+          facts (if retain-producer?
+                  (record-recomputed-fusion (dialect/facts program)
+                                            (:id producer) (:id consumer)
+                                            fused-kind placement-witness)
+                  (remove-equation-fact (dialect/facts program)
+                                        (:id producer) (:id consumer) fused-kind))]
+      (rebuild-boundary program facts equations)))
 
 (defn- horizontal-candidate
   [program]
@@ -664,20 +711,63 @@
                                       :horizontal-map)]
       (rebuild-boundary program facts equations))))
 
+(defn- placement-key
+  [{:keys [producer value decision]}]
+  [producer value decision])
+
+(defn- remember-placement
+  [placements witness]
+  (if (> (:consumer-count witness) 1)
+    (assoc placements (placement-key witness) witness)
+    placements))
+
+(defn- attach-placement-facts
+  [program placements]
+  (if (seq placements)
+    (let [ordered (->> (vals placements)
+                       (sort-by (juxt (comp pr-str :producer)
+                                      (comp pr-str :value)
+                                      (comp name :decision)))
+                       vec)
+          facts (assoc-in (dialect/facts program)
+                          [:attributes :fusion/placements] ordered)]
+      [(dialect/make facts (dialect/equations program) (dialect/outputs program)) ordered])
+    [program []]))
+
 (defn fusion-fixpoint
-  "Fuse legal typed SOAC equations to a fixpoint. Returns [program stats]."
-  [program]
-  (dialect/validate! program)
-  (loop [program program
-         vertical 0
-         horizontal 0
-         iterations 0]
-    (if-let [fused (fuse-vertical-once program)]
-      (recur fused (inc vertical) horizontal (inc iterations))
-      (if-let [fused (fuse-segmented-reduce-result-map-once program)]
-        (recur fused (inc vertical) horizontal (inc iterations))
-        (if-let [fused (fuse-horizontal-once program)]
-          (recur fused vertical (inc horizontal) (inc iterations))
-          [program {:vertical vertical
-                    :horizontal horizontal
-                    :iterations (inc iterations)}])))))
+  "Fuse legal typed SOAC equations to a fixpoint. Returns [program stats].
+
+   With an Abstract Machine, legal multi-consumer map fusion is selected by the shared placement
+   policy. Decisions are retained in program facts and stats; no device/vendor identity enters the
+   typed dialect. The one-argument form preserves the existing single-consumer rewrites and keeps
+   fan-out materialized when no target performance description can justify recomputation."
+  ([program]
+   (fusion-fixpoint program nil))
+  ([program abstract-machine]
+   (dialect/validate! program)
+   (loop [program program
+          vertical 0
+          horizontal 0
+          iterations 0
+          placements {}]
+     (let [candidates (vertical-candidates program abstract-machine)
+           candidate (first (filter (comp :fuse? :placement) candidates))]
+       (if candidate
+         (recur (fuse-vertical-candidate program candidate)
+                (inc vertical) horizontal (inc iterations)
+                (remember-placement placements (:placement candidate)))
+         (if-let [fused (fuse-segmented-reduce-result-map-once program)]
+           (recur fused (inc vertical) horizontal (inc iterations) placements)
+           (if-let [fused (fuse-horizontal-once program)]
+             (recur fused vertical (inc horizontal) (inc iterations) placements)
+             (let [placements
+                   (reduce remember-placement placements
+                           (map :placement
+                                (filter (comp not :fuse? :placement) candidates)))
+                   [program ordered-placements] (attach-placement-facts program placements)
+                   stats {:vertical vertical
+                          :horizontal horizontal
+                          :iterations (inc iterations)}]
+               [program (cond-> stats
+                          (seq ordered-placements)
+                          (assoc :placements ordered-placements))]))))))))

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -326,7 +326,7 @@
       :effects (:effects facts)
       :diagnostics (:diagnostics facts)
       :provenance (assoc (:provenance facts) :pass :typed-soac-fusion)
-      :attributes {:host-control :typed-soac-materialization}
+      :attributes (assoc (:attributes facts) :host-control :typed-soac-materialization)
       :operation? equation-operation?
       :algorithm? (fn [equation algorithm]
                     (and (= algorithm (dialect/validate! algorithm))
@@ -340,7 +340,7 @@
    (attempt form dtype {}))
   ([form dtype array-types]
    (attempt form dtype array-types {}))
-  ([form dtype array-types {:keys [resident-reductions? scalar-types values]
+  ([form dtype array-types {:keys [resident-reductions? scalar-types values abstract-machine]
                             :or {resident-reductions? false}}]
    (when (and (seq? form) (contains? #{'let 'let*} (first form)))
      (let [form (frontend/normalize-source form)]
@@ -348,7 +348,7 @@
         (when-let [typed-input (frontend/form->program
                                 form {:dtype dtype :array-types array-types
                                       :scalar-types scalar-types :values values})]
-         (let [[typed-result typed-stats] (fusion/fusion-fixpoint typed-input)
+         (let [[typed-result typed-stats] (fusion/fusion-fixpoint typed-input abstract-machine)
                [typed-result resident-stats]
                (if resident-reductions?
                  (resident/realize typed-result)

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -757,6 +757,17 @@
 
 (declare top-level-binding-form)
 
+(defn- abstract-machine-for-target
+  "Project a GPU target to the target-neutral cost surface used by typed scheduling.
+
+   A missing descriptor is an honest abstention: typed fan-out retains its materialization boundary
+   rather than making compilation depend on optional probing/catalogue data."
+  [target-device]
+  (when (device/gpu-target? target-device)
+    (try
+      (core-hw/abstract-machine (core-hw/descriptor-for target-device))
+      (catch Throwable _ nil))))
+
 (defn- pass-soac-fuse
   "SOAC graph-based fusion: vertical (map→map, map→reduce, map→scan),
   horizontal (independent same-bound maps), iterated to fixpoint.
@@ -764,17 +775,15 @@
   Returns {:form :stats}."
   [form opts]
   (if (form/binding-form? form)
-    (let [typed (typed-soac-route/attempt
+    (let [am (abstract-machine-for-target (:target-device opts))
+          typed (typed-soac-route/attempt
                  form (:dtype opts) (:array-types opts)
                  {:resident-reductions? (true? (:resident-reductions? opts))
-                  :scalar-types (:scalar-types opts)})]
+                  :scalar-types (:scalar-types opts)
+                  :abstract-machine am})]
       (if (:program typed)
         {:form (:program typed) :stats (:stats typed)}
-        (let [am (when (device/gpu-target? (:target-device opts))
-                   (try (core-hw/abstract-machine
-                         (core-hw/descriptor-for (:target-device opts)))
-                        (catch Throwable _ nil)))
-              [let-sym bindings-vec & body-exprs] form
+        (let [[let-sym bindings-vec & body-exprs] form
               pairs (vec (partition 2 bindings-vec))
               nodes (soac/let-bindings->nodes pairs)
               graph (soac-graph/build-fusion-graph nodes)
@@ -795,10 +804,12 @@
     ;; Normalize it only HERE, after fixpoint/type analysis, and retain the wrapper only when the
     ;; typed route accepts it. Unsupported forms must reach compatibility lowering unchanged.
     (let [source (top-level-binding-form form)
+          am (abstract-machine-for-target (:target-device opts))
           typed (typed-soac-route/attempt
                  source (:dtype opts) (:array-types opts)
                  {:resident-reductions? (true? (:resident-reductions? opts))
-                  :scalar-types (:scalar-types opts)})]
+                  :scalar-types (:scalar-types opts)
+                  :abstract-machine am})]
       (if (:program typed)
         {:form (:program typed) :stats (:stats typed)}
         (let [fallback (par-fusion/par-fusion-pass form)]
@@ -1068,7 +1079,9 @@
   [source {:keys [dtype array-types scalar-types target-device] :as opts}]
   (let [source (top-level-binding-form source)
         typed (typed-soac-route/attempt source dtype array-types
-                                        {:scalar-types scalar-types})
+                                        {:scalar-types scalar-types
+                                         :abstract-machine
+                                         (abstract-machine-for-target target-device)})
         semantic (or (:program typed) source)
         scheduled (segop-lower/segop-lower-pass
                    semantic (assoc opts :dtype dtype :target-device target-device))]

--- a/test/raster/compiler/passes/parallel/fusion_placement_test.clj
+++ b/test/raster/compiler/passes/parallel/fusion_placement_test.clj
@@ -14,6 +14,8 @@
       (is (= :materialize (:decision poor)))
       (is (false? (:fuse? poor)))
       (is (= 30 (:producer-flops-per-element poor)))
+      (is (:producer-cost-complete? poor))
+      (is (empty? (:unknown-cost-ops poor)))
       (is (= 4 (:element-bytes poor)))
       (is (= 8.0 (:recompute-threshold-flops poor)))
       (is (= :recompute-more-expensive-than-read (:reason poor))))
@@ -28,7 +30,7 @@
   (let [arguments {:dtype :float :expressions '[(exp x)] :consumer-count 3}]
     (is (= {:decision :materialize :reason :no-abstract-machine}
            (select-keys (placement/placement-decision arguments) [:decision :reason])))
-    (is (= {:decision :recompute :reason :unknown-roofline-ridge}
+    (is (= {:decision :materialize :reason :unknown-roofline-ridge}
            (select-keys (placement/placement-decision
                          (assoc arguments :abstract-machine {:ridge {:half 4.0}}))
                         [:decision :reason])))
@@ -36,3 +38,24 @@
            (select-keys (placement/placement-decision
                          (assoc arguments :consumer-count 1))
                         [:decision :reason])))))
+
+(deftest incomplete-placement-prices-never-enable-duplicated-work
+  (let [machine {:ridge {:float 100.0}}
+        unknown-op (placement/placement-decision
+                    {:abstract-machine machine :dtype :float
+                     :expressions '[(arbitrary-user-call x)] :consumer-count 2})
+        unknown-width (placement/placement-decision
+                       {:abstract-machine {:ridge {:mystery 100.0}} :dtype :mystery
+                        :expressions '[(+ x 1)] :consumer-count 2})
+        unknown-ridge (placement/placement-decision
+                       {:abstract-machine {:ridge {:half 100.0}} :dtype :float
+                        :expressions '[(+ x 1)] :consumer-count 2})]
+    (is (= {:decision :materialize :reason :unknown-producer-cost
+            :producer-cost-complete? false
+            :unknown-cost-ops '[arbitrary-user-call]}
+           (select-keys unknown-op [:decision :reason :producer-cost-complete?
+                                    :unknown-cost-ops])))
+    (is (= {:decision :materialize :reason :unknown-element-width}
+           (select-keys unknown-width [:decision :reason])))
+    (is (= {:decision :materialize :reason :unknown-roofline-ridge}
+           (select-keys unknown-ridge [:decision :reason])))))

--- a/test/raster/compiler/passes/parallel/fusion_placement_test.clj
+++ b/test/raster/compiler/passes/parallel/fusion_placement_test.clj
@@ -1,0 +1,38 @@
+(ns raster.compiler.passes.parallel.fusion-placement-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.passes.parallel.fusion-placement :as placement]))
+
+(deftest roofline-placement-witness-is-target-neutral-and-complete
+  (let [expressions '[(exp (exp (exp x)))]
+        poor (placement/placement-decision
+              {:abstract-machine {:ridge {:float 2.0}}
+               :dtype :float :expressions expressions :consumer-count 2})
+        rich (placement/placement-decision
+              {:abstract-machine {:ridge {:float 100.0}}
+               :dtype :float :expressions expressions :consumer-count 2})]
+    (testing "an expensive fan-out remains materialized when recomputation costs more than a read"
+      (is (= :materialize (:decision poor)))
+      (is (false? (:fuse? poor)))
+      (is (= 30 (:producer-flops-per-element poor)))
+      (is (= 4 (:element-bytes poor)))
+      (is (= 8.0 (:recompute-threshold-flops poor)))
+      (is (= :recompute-more-expensive-than-read (:reason poor))))
+    (testing "the same algorithm recomputes on a compute-rich abstract machine"
+      (is (= :recompute (:decision rich)))
+      (is (:fuse? rich))
+      (is (= 400.0 (:recompute-threshold-flops rich)))
+      (is (= :recompute-cheaper-than-read (:reason rich))))
+    (is (not-any? #(contains? poor %) [:device :vendor :backend]))))
+
+(deftest placement-abstains-in-the-compatibility-preserving-direction
+  (let [arguments {:dtype :float :expressions '[(exp x)] :consumer-count 3}]
+    (is (= {:decision :materialize :reason :no-abstract-machine}
+           (select-keys (placement/placement-decision arguments) [:decision :reason])))
+    (is (= {:decision :recompute :reason :unknown-roofline-ridge}
+           (select-keys (placement/placement-decision
+                         (assoc arguments :abstract-machine {:ridge {:half 4.0}}))
+                        [:decision :reason])))
+    (is (= {:decision :eliminate :reason :sole-consumer}
+           (select-keys (placement/placement-decision
+                         (assoc arguments :consumer-count 1))
+                        [:decision :reason])))))

--- a/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
@@ -25,6 +25,11 @@
   [['y '(raster.par/map! y i n nil (* (aget x i) scale))]
    ['z '(raster.par/map! z j n nil (+ (aget y j) bias))]])
 
+(def ^:private expensive-fanout-pairs
+  [['a '(raster.par/map! a i n nil (Math/exp (Math/exp (Math/exp (aget x i)))))]
+   ['b '(raster.par/map! b j n nil (* (aget a j) 2.0))]
+   ['c '(raster.par/reduce acc 0.0 k n (+ acc (aget a k)))]])
+
 (defn- differential-fusion
   [pairs outputs]
   (let [legacy-graph (graph/build-fusion-graph (legacy/let-bindings->nodes pairs))
@@ -79,6 +84,32 @@
     (is (= '[bias scale] (nth operation 3)))
     (is (= '[%element0 %capture0 %capture1] (second lambda)))
     (is (= '[(+ (* %element0 %capture1) %capture0)] (:body-results region)))))
+
+(deftest typed-multi-consumer-placement-is-hardware-costed
+  (let [program (-> expensive-fanout-pairs
+                    legacy/let-bindings->nodes
+                    graph/build-fusion-graph
+                    :nodes
+                    (adapter/legacy-nodes->program {:outputs '[b c] :dtype :float}))
+        poor-am {:ridge {:float 2.0}}
+        rich-am {:ridge {:float 100.0}}
+        [materialized materialized-stats] (typed-fusion/fusion-fixpoint program poor-am)
+        [recomputed recomputed-stats] (typed-fusion/fusion-fixpoint program rich-am)
+        materialized-witness (-> materialized-stats :placements first)
+        recomputed-witness (-> recomputed-stats :placements first)]
+    (is (= 0 (:vertical materialized-stats)))
+    (is (= 3 (count (dialect/equations materialized))))
+    (is (= :materialize (:decision materialized-witness)))
+    (is (= '[1 2] (:consumers materialized-witness)))
+    (is (= (:placements materialized-stats)
+           (get-in (dialect/facts materialized) [:attributes :fusion/placements])))
+
+    (is (= 2 (:vertical recomputed-stats)))
+    (is (= 2 (count (dialect/equations recomputed))))
+    (is (= :recompute (:decision recomputed-witness)))
+    (is (= 2 (:consumer-count recomputed-witness)))
+    (is (not-any? #{'a} (mapcat #(nth % 2) (dialect/equations recomputed))))
+    (is (= recomputed (dialect/validate! recomputed)))))
 
 (deftest current-graph-rewrites-the-canonical-reduction-region
   (let [pairs [['tmp '(raster.par/map! tmp i n float (* (aget x i) 2.0))]

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -35,6 +35,30 @@
           v (raster.par/pmap j n float (+ (clojure.core/aget b j) 1.0))]
          [u v]))
 
+(def ^:private expensive-fanout
+  '(let* [shared (raster.par/pmap i n float
+                                  (Math/exp (Math/exp (Math/exp
+                                                       (clojure.core/aget x i)))))
+          mapped (raster.par/pmap j n float (* (clojure.core/aget shared j) 2.0))
+          reduced (raster.par/reduce acc 0.0 k n
+                                      (+ acc (clojure.core/aget shared k)))]
+         [mapped reduced]))
+
+(deftest production-route-retains-hardware-costed-placement-witnesses
+  (let [poor (route/attempt expensive-fanout :float {'x :float}
+                            {:abstract-machine {:ridge {:float 2.0}}})
+        rich (route/attempt expensive-fanout :float {'x :float}
+                            {:abstract-machine {:ridge {:float 100.0}}})
+        poor-witness (-> poor :stats :placements first)
+        rich-witness (-> rich :stats :placements first)]
+    (is (= :materialize (:decision poor-witness)))
+    (is (= 3 (count (get-in poor [:program :equations]))))
+    (is (= (:placements (:stats poor))
+           (get-in poor [:program :attributes :fusion/placements])))
+    (is (= :recompute (:decision rich-witness)))
+    (is (= 2 (count (get-in rich [:program :equations]))))
+    (is (= :typed-soac (get-in rich [:stats :route])))))
+
 (def ^:private inclusive-scan
   '(let* [result (raster.par/scan out acc 0.0 i n float
                                   (+ acc (clojure.core/aget x i)))]
@@ -269,13 +293,20 @@
   (let [source '(let* [y (raster.par/pmap i n float (* (clojure.core/aget x i) 2.0))
                        z (raster.par/pmap j n float (+ (clojure.core/aget y j) 1.0))]
                       [y z])
-        {:keys [program stats]} (route/attempt source :float {'x :float})]
+        {:keys [program stats]} (route/attempt source :float {'x :float})
+        hardware-guided (route/attempt source :float {'x :float}
+                                       {:abstract-machine {:ridge {:float 100.0}}})]
     (is (= :typed-soac (:dialect program)))
     (is (:typed-validated stats))
     (is (zero? (:vertical stats)))
     (is (= 2 (count (:equations program))))
     (is (= '[y z] (:outputs program))
-        "a host-visible producer is retained, not erased by vertical fusion")))
+        "a host-visible producer is retained, not erased by vertical fusion")
+    (is (= 1 (get-in hardware-guided [:stats :vertical])))
+    (is (= 1 (count (get-in hardware-guided [:program :equations])))
+        "removing the read lets horizontal fusion produce both observable values in one map")
+    (is (= '[y z] (-> hardware-guided :program :equations first :results)))
+    (is (= '[y z] (get-in hardware-guided [:program :outputs])))))
 
 (deftest effectful-host-binding-keeps-the-compatibility-route
   (let [source '(let* [y (raster.par/pmap i n float (* (clojure.core/aget x i) 2.0))

--- a/test/raster/gpu/artifact_test.clj
+++ b/test/raster/gpu/artifact_test.clj
@@ -124,7 +124,7 @@
               output (get result (keyword (name (:result-sym (:descriptor compiled)))))]
           (is (every? #(= 15.0 (double %)) (v/->host output)))
           (let [profile (r/profile compiled)]
-            (is (= 2 (count (:profile profile))))
+            (is (= 1 (count (:profile profile))))
             (is (pos? (:device-wall-ms profile)))
             (is (not (v/live? output))
                 "profiling invalidates an earlier output whose resident storage it overwrites")))

--- a/test/raster/gpu/link_spike_test.clj
+++ b/test/raster/gpu/link_spike_test.clj
@@ -26,8 +26,9 @@
             [raster.gpu.value :as value])
   (:import [java.util.concurrent.atomic AtomicBoolean]))
 
-;; A minimal elementwise forward: y = (x + w) * x  (residual-add then hadamard — the proven-
-;; resident dt-two-step shape). Composing it twice with weights w0,w1 gives the intermediate
+;; A minimal elementwise forward: y = (x + w) * x. Typed placement and horizontal fusion lower the
+;; residual-add/hadamard source to one tuple-free elementwise step. Composing it twice with weights
+;; w0,w1 gives the intermediate
 ;; x1 = (x+w0)*x as a device-resident internal node the link shares between the two instances.
 (deftm spike-had
   [x :- (Array float) w :- (Array float) n :- Long] :- (Array float)
@@ -326,8 +327,8 @@
           result-sym (:result-sym prog)
           scratch-sym (first (remove #(= % result-sym) (map :sym (:allocs prog))))
           x-sym 'x w-sym 'w]
-      (testing "the descriptor is a clean 2-step elementwise chain"
-        (is (= 2 (count steps)))
+      (testing "the descriptor retains the optimally fused elementwise step"
+        (is (= 1 (count steps)))
         (is (every? #(= :map (:convention %)) steps)))
       (let [sess (make-session :ze:0)]
         (try


### PR DESCRIPTION
This lands the next TypedSOAC fusion/scheduling slice.

- factors the existing roofline crossover out of the legacy graph into one target-neutral placement policy
- lets typed single-result map producers with fan-out choose recomputation or materialization from the Abstract Machine
- retains producers until their last use and preserves host-visible results
- records serializable policy witnesses in TypedSOAC facts, route attributes, and pass stats
- threads the device-stripped Abstract Machine through ordinary compilation and direct kernel scheduling
- updates two live-GPU stage-count oracles that were already stale on main after elementwise fusion

Validation:
- focused compiler/hardware group: 107 tests, 547 assertions, green
- isolated linked-artifact GPU group: 15 tests, 168 assertions, green
- monolithic local suite: 2564 tests, 35900 assertions; live Level Zero order-dependent failures remain. The decoder ABI failure reproduces unchanged on origin/main in a fresh worktree. CircleCI remains the isolated authoritative suite, including CUDA/HIP compile gates.