### PR TITLE
Shard the JVM test suite in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ jobs:
 
   test:
     executor: clojure-java24
+    parallelism: 4
     steps:
       - attach_workspace:
           at: ~/
@@ -85,8 +86,8 @@ jobs:
           name: Install OpenBLAS + clang
           command: sudo apt-get update && sudo apt-get install -y libopenblas-dev liblapacke-dev clang
       - run:
-          name: Run tests
-          command: clojure -X:test
+          name: Run deterministic test shard
+          command: scripts/ci-test-shard.sh
 
   emit-gpu-compile-fixtures:
     executor: clojure-java24

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,10 @@ jobs:
       - attach_workspace:
           at: ~/
       - install-clojure
+      - restore_cache:
+          keys:
+            - v2-dependencies-{{ checksum "deps.edn" }}
+            - v2-dependencies-
       - run:
           name: Install OpenBLAS + clang
           command: sudo apt-get update && sudo apt-get install -y libopenblas-dev liblapacke-dev clang

--- a/scripts/ci-test-shard.sh
+++ b/scripts/ci-test-shard.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mode="${1:-run}"
+shard_count="${CIRCLE_NODE_TOTAL:-${RASTER_TEST_SHARDS:-1}}"
+shard_index="${CIRCLE_NODE_INDEX:-${RASTER_TEST_SHARD:-0}}"
+
+if [[ ! "${shard_count}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "shard count must be a positive integer, got: ${shard_count}" >&2
+  exit 2
+fi
+
+if [[ ! "${shard_index}" =~ ^[0-9]+$ ]] || (( shard_index >= shard_count )); then
+  echo "shard index must be in [0, ${shard_count}), got: ${shard_index}" >&2
+  exit 2
+fi
+
+case "${mode}" in
+  run|--list|--plan) ;;
+  *)
+    echo "usage: $0 [run|--list|--plan]" >&2
+    exit 2
+    ;;
+esac
+
+# Greedy largest-processing-time assignment, using source bytes as a stable
+# approximation until CI publishes per-namespace timings.  The file-name tie
+# break keeps the plan reproducible on every machine.
+plan() {
+  find test -type f -name '*_test.clj' -printf '%s\t%p\n' \
+    | sort -t $'\t' -k1,1nr -k2,2 \
+    | awk -F '\t' -v shards="${shard_count}" '
+        BEGIN {
+          for (i = 0; i < shards; i++) load[i] = 0
+        }
+        {
+          selected = 0
+          for (i = 1; i < shards; i++) {
+            if (load[i] < load[selected]) selected = i
+          }
+          load[selected] += $1
+          print selected "\t" $1 "\t" $2
+        }'
+}
+
+namespace_of() {
+  awk '
+    /^\(ns[[:space:]]+/ {
+      sub(/^\(ns[[:space:]]+/, "")
+      split($0, fields, /[[:space:]()]/)
+      print fields[1]
+      exit
+    }' "$1"
+}
+
+if [[ "${mode}" == "--plan" ]]; then
+  while IFS=$'\t' read -r node bytes file; do
+    namespace="$(namespace_of "${file}")"
+    if [[ -z "${namespace}" ]]; then
+      echo "cannot discover test namespace in ${file}" >&2
+      exit 2
+    fi
+    printf '%s\t%s\t%s\t%s\n' "${node}" "${bytes}" "${namespace}" "${file}"
+  done < <(plan)
+  exit 0
+fi
+
+namespaces=()
+estimated_bytes=0
+while IFS=$'\t' read -r node bytes file; do
+  if (( node == shard_index )); then
+    namespace="$(namespace_of "${file}")"
+    if [[ -z "${namespace}" ]]; then
+      echo "cannot discover test namespace in ${file}" >&2
+      exit 2
+    fi
+    namespaces+=("${namespace}")
+    estimated_bytes=$((estimated_bytes + bytes))
+  fi
+done < <(plan)
+
+if (( ${#namespaces[@]} == 0 )); then
+  echo "test shard ${shard_index}/${shard_count} is empty" >&2
+  exit 2
+fi
+
+if [[ "${mode}" == "--list" ]]; then
+  printf '%s\n' "${namespaces[@]}"
+  exit 0
+fi
+
+echo "Running test shard $((shard_index + 1))/${shard_count}: ${#namespaces[@]} namespaces, ${estimated_bytes} estimated source bytes"
+
+runner_args=()
+for namespace in "${namespaces[@]}"; do
+  runner_args+=("-n" "${namespace}")
+done
+
+clojure -M:test "${runner_args[@]}"

--- a/test/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse_test.clj
+++ b/test/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse_test.clj
@@ -1,5 +1,5 @@
 (ns raster.compiler.passes.parallel.segmented-weighted-reduction-fuse-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [deftest is use-fixtures]]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
@@ -11,7 +11,27 @@
             [raster.dl.gsdm :as gsdm]
             [raster.gpu.core :as gpu]
             [raster.gpu.link :as link]
-            [raster.numeric]))
+            [raster.numeric]
+            [raster.runtime.hardware :as hardware]))
+
+;; These are cross-compilation tests.  Own the target facts instead of inheriting a
+;; :ze:0 registration from whichever namespace happened to run first in a monolithic
+;; test JVM.  No device or driver is required to derive and emit these schedules.
+(use-fixtures
+  :once
+  (fn [f]
+    (hardware/reset-hardware!)
+    (hardware/init!)
+    (hardware/register-target-device!
+     :ze:0
+     {:name "Intel(R) Arc(TM) Graphics"
+      :capabilities {:total-eus 64
+                     :threads-per-eu 8
+                     :simd-width 16
+                     :subgroup-sizes [16 32]
+                     :max-workgroup-size 1024
+                     :shared-local-memory 131072}})
+    (f)))
 
 (defn- chain
   []


### PR DESCRIPTION
## Outcome

- split all 287 Clojure test namespaces across four CircleCI nodes
- deterministically balance shards by source size with stable filename tie-breaking
- provide inspectable plan and list modes for local coverage checks
- keep the existing perf exclusion and test-runner semantics

## Local validation

- four-way plan assigns every namespace exactly once: 71/72/72/72 namespaces
- estimated shard sizes: 671933/672676/671949/672773 bytes
- substantive one-namespace execution smoke: 14 tests, 63 assertions
- bash syntax and diff checks pass

The full four-shard suite is intentionally delegated to CircleCI so its result also validates cross-process isolation and actual wall-clock improvement.