### PR TITLE
Retain scheduled scan graphs in GPU sessions

### DIFF
--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -626,7 +626,7 @@
             (par/par-rng-fill-form? form)
             (let [{:keys [seeds n base-seed]} (par/extract-par-rng-fill-info form)
                   k (register-kernel!
-                     (legacy/generate-par-rng-fill-kernel :device-id device-id)
+                     (legacy/generate-par-rng-fill-kernel)
                      :ze-maps)]
               (list 'raster.gpu.ze-runtime/invoke-registered-rng-fill-kernel
                     (:kernel-name k) seeds n base-seed))
@@ -635,7 +635,7 @@
             (par/par-active-ids-form? form)
             (let [{:keys [ids n-active n-agents base-seed]} (par/extract-par-active-ids-info form)
                   k (register-kernel!
-                     (legacy/generate-par-active-ids-kernel :device-id device-id)
+                     (legacy/generate-par-active-ids-kernel)
                      :ze-maps)]
               (list 'raster.gpu.ze-runtime/invoke-registered-active-ids-kernel
                     (:kernel-name k) ids n-active n-agents base-seed))

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -119,7 +119,8 @@
 
 (defn- compile-deftm-internal!
   "Compile a deftm var's par forms to GPU kernels and register them.
-   Returns vector of kernel-info maps."
+   Returns the complete backend result so a session retains first-class dispatches and graphs
+   instead of reconstructing them later from the flat kernel list."
   [v device-id {:keys [dtype min-elements] :or {dtype :float min-elements 0}}]
   (let [walked-body (get-walked-body v dtype)
         resolved (or (resolve-deftm-var v) v)
@@ -147,7 +148,7 @@
                            :min-elements min-elements)]
     (doseq [k (:kernels result)]
       (register! (:kernel-name k) k))
-    (:kernels result)))
+    result))
 
 ;; ================================================================
 ;; Internal: buffer allocation
@@ -368,6 +369,7 @@
            :session-id (random-uuid)
            :arena-id  arena-id
            :kernels   {}       ;; {phase-key → [kernel-info ...]}
+           :dispatches {}      ;; {phase-key → [KernelDispatch ...]}
            :buffers   {}       ;; {buf-key → DeviceBuffer}
            :allocations {}     ;; {buf-key → backend-neutral BufferAllocation}
            :kernel-graphs {}    ;; {graph-key → bound emitted KernelGraph}
@@ -400,8 +402,8 @@
         (free-session-buffers! buffers allocations device-id)
         (let [close-arena! (rt-resolve device-id "close-kernel-arena!")]
           (close-arena! arena-id))
-        (swap! sess assoc :closed? true :buffers {} :allocations {} :kernels {} :prepared {} :graphs {}
-               :kernel-graphs {} :events {})))))
+        (swap! sess assoc :closed? true :buffers {} :allocations {} :kernels {} :dispatches {}
+               :prepared {} :graphs {} :kernel-graphs {} :events {})))))
 
 (defn with-gpu-session*
   "Functional implementation for with-gpu-session macro."
@@ -449,11 +451,15 @@
          ;; the shared module, so distinct phases keep independent arg sets. (e.g. the 18-layer
          ;; gemma forward: 453 steps / ~8 distinct kernels → first token 171s → ~3s.)
          cache-key [v (get opts :dtype :float)]
-         kernels (or (get-in @sess [:kernel-cache cache-key])
-                     (let [ks (compile-deftm-internal! v device-id opts)]
-                       (swap! sess assoc-in [:kernel-cache cache-key] ks)
-                       ks))]
-     (swap! sess assoc-in [:kernels phase-key] kernels)
+         compiled (or (get-in @sess [:kernel-cache cache-key])
+                      (let [result (compile-deftm-internal! v device-id opts)]
+                        (swap! sess assoc-in [:kernel-cache cache-key] result)
+                        result))
+         kernels (:kernels compiled)]
+     (swap! sess (fn [state]
+                   (-> state
+                       (assoc-in [:kernels phase-key] kernels)
+                       (assoc-in [:dispatches phase-key] (:dispatches compiled)))))
      kernels)))
 
 (defn compile-phases!
@@ -746,24 +752,60 @@
       (destroy-prepared-entry! (:device-id @sess) entry)))
   nil)
 
+(declare bind-kernel-executable! run-kernel-graph! release-kernel-graph!)
+
 (defn invoke-scan!
-  "Invoke a compiled Blelloch exclusive-scan kernel pair from the session.
+  "Invoke a compiled exclusive scan through its scheduled KernelExecutable.
 
    sess: session atom
-   phase-key: keyword identifying the scan kernel pair
+   phase-key: keyword identifying the compiled scan dispatch
    input-keys: vector of buffer keys for inputs
    output-key: buffer key for output
    n: number of elements"
   [sess phase-key input-keys output-key n]
-  (let [{:keys [kernels buffers]} @sess
-        kernel-vec (get kernels phase-key)
-        device-id (:device-id @sess)
-        invoke! (rt-resolve device-id "invoke-registered-scan-exclusive-kernel")]
-    (invoke! (:kernel-name (first kernel-vec))
-             (:kernel-name (second kernel-vec))
-             (mapv #(get buffers %) input-keys)
-             (get buffers output-key)
-             n)))
+  (let [dispatches (get-in @sess [:dispatches phase-key])
+        _ (when-not (= 1 (count dispatches))
+            (throw (ex-info "compiled scan phase must retain exactly one KernelDispatch"
+                            {:phase phase-key :dispatch-count (count dispatches)
+                             :reason :compiled-scan-dispatch-missing})))
+        executable (kdispatch/default-alternative (first dispatches))
+        remaining-inputs (volatile! (seq input-keys))
+        arguments
+        (mapv (fn [slot]
+                (cond
+                  (and (= :scalar (:kind slot)) (= :bound (:role slot)))
+                  {:type (:kernel-dtype slot) :value n}
+
+                  (= :scalar (:kind slot))
+                  (throw (ex-info "invoke-scan! cannot guess a captured scalar binding"
+                                  {:phase phase-key :slot slot
+                                   :reason :compiled-scan-captured-scalar-unbound}))
+
+                  (kabi/writable? slot)
+                  output-key
+
+                  (kabi/readable? slot)
+                  (let [key (first @remaining-inputs)]
+                    (when-not key
+                      (throw (ex-info "compiled scan has more input slots than caller bindings"
+                                      {:phase phase-key :slot slot :input-keys input-keys})))
+                    (vswap! remaining-inputs next)
+                    key)
+
+                  :else
+                  (throw (ex-info "compiled scan ABI slot has no runtime binding policy"
+                                  {:phase phase-key :slot slot}))))
+              (kexec/abi executable))
+        _ (when (seq @remaining-inputs)
+            (throw (ex-info "compiled scan caller supplied unused input bindings"
+                            {:phase phase-key :unused (vec @remaining-inputs)})))
+        handle (bind-kernel-executable! sess [:compiled-scan phase-key]
+                                        executable arguments)]
+    (try
+      (run-kernel-graph! sess handle)
+      (get-in @sess [:buffers output-key])
+      (finally
+        (release-kernel-graph! sess handle)))))
 
 (defn invoke-rng-fill!
   "Invoke a compiled parallel RNG fill kernel from the session.

--- a/test/raster/abm/firms/gpu_test.clj
+++ b/test/raster/abm/firms/gpu_test.clj
@@ -6,11 +6,12 @@
 
    test-gpu-vs-cpu: Runs on GPU (if :ze:0 available) and compares
    aggregate stats to CPU results (tolerance for float atomics)."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.test :refer [deftest is testing]]
             [raster.abm.firms :as firms]
             [raster.abm.firms.phases :as phases]
             [raster.abm.firms.gpu :as fgpu]
             [raster.gpu.core :as gpu]
+            [raster.dl.gpu-grad-parity :as gpu-probe]
             [raster.abm.firms.membership :as mem]
             [raster.par :as par]
             [raster.gpu.ze-runtime :as ze]
@@ -19,17 +20,6 @@
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass])
   (:import [raster.abm.firms AgentSoA FirmSoA FirmsConfig]
            [java.util SplittableRandom]))
-
-(def ^:private gpu-available?
-  (delay
-    (try
-      (let [p (.start (ProcessBuilder. ["ocloc" "--help"]))]
-        (.waitFor p)
-        (zero? (.exitValue p)))
-      (catch Exception _ false))))
-
-(use-fixtures :once
-  (fn [f] (if @gpu-available? (f) (println "[SKIP] No GPU/OpenCL compiler (ocloc)"))))
 
 ;; ================================================================
 ;; Helpers
@@ -277,23 +267,34 @@
         (is (= 'raster.gpu.ze-runtime/invoke-registered-active-ids-kernel (first emitted))
             "Should emit invoke-registered-active-ids-kernel call")))))
 
+(deftest test-active-ids-opencl-compilation-is-owned-by-the-pass
+  (testing "the optional pass boundary compiles generated source exactly once"
+    (let [compilations (atom 0)
+          spv (byte-array [3 2 35 7])]
+      (with-redefs [par-opencl/compile-kernel-to-spirv
+                    (fn [_source & _options]
+                      (swap! compilations inc)
+                      spv)]
+        (let [result (opencl-pass/opencl-pass
+                      '(raster.par/active-ids! ids n-active n-agents base-seed)
+                      :dtype :float
+                      :device-id :ze:0
+                      :compile-spirv? true)]
+          (is (= 1 @compilations)
+              "the generator must not compile before the pass compilation boundary")
+          (is (identical? spv (:spv-bytes (first (:kernels result))))))))))
+
 ;; ================================================================
 ;; Test: GPU active-ids kernel (requires Level Zero)
 ;; ================================================================
 
-(defn- ze-available? []
-  (try (require 'raster.gpu.ze-runtime)
-       (let [qfn (resolve 'raster.gpu.ze-runtime/query-devices)]
-         (and qfn (seq (qfn))))
-       (catch Exception _ false)))
-
-(defmacro when-ze [& body]
-  `(if (ze-available?)
+(defmacro when-ze [label & body]
+  `(if @gpu-probe/gpu-available?
      (do ~@body)
-     (println "  [SKIP] No Level Zero GPU")))
+     (gpu-probe/gpu-skip! ~label)))
 
 (deftest test-active-ids-gpu
-  (when-ze
+  (when-ze "ABM active-id generation"
    (testing "GPU active-ids kernel: all indices in [0, n-agents)"
      (ze/init!)
      (gpu/with-gpu-session [sess :ze:0]
@@ -338,7 +339,7 @@
     out))
 
 (deftest test-gpu-blelloch-scan
-  (when-ze
+  (when-ze "ABM Blelloch scan"
    (ze/init!)
 
    (testing "GPU exclusive scan: all-ones array → identity prefix sums"
@@ -407,7 +408,7 @@
 ;; ================================================================
 
 (deftest test-autotuner
-  (when-ze
+  (when-ze "ABM workgroup autotuning"
    (ze/init!)
 
    (testing "autotune-wg-sweep! returns valid KernelTuning with finite ms"
@@ -491,20 +492,16 @@
   (testing "OpenCL codegen produces valid kernel source for par phases"
     ;; This just tests that emit-opencl-expr handles the control flow
     ;; in the par bodies without errors. Doesn't require GPU.
-    (try
-      (let [;; Simple map-void! with if + aset
-            form '(raster.par/map-void! i n
-                                        (if (== 1 (aget alive i))
-                                          (aset output i (float 1.0))
-                                          (aset output i (float 0.0))))
-            result (opencl-pass/opencl-pass form :dtype :float :compile-spirv? false)]
-        (is (seq (:kernels result))
-            "Should generate at least one kernel")
-        (when (seq (:kernels result))
-          (let [src (:source (first (:kernels result)))]
-            (is (string? src) "Kernel source should be a string")
-            (is (.contains ^String src "__kernel") "Should contain __kernel")
-            (is (.contains ^String src "if") "Should contain if statement"))))
-      (catch Exception e
-        ;; If OpenCL codegen can't be loaded (e.g., missing deps), skip
-        (println "Skipping codegen smoke test:" (.getMessage e))))))
+    (let [;; Simple map-void! with if + aset
+          form '(raster.par/map-void! i n
+                                      (if (== 1 (aget alive i))
+                                        (aset output i (float 1.0))
+                                        (aset output i (float 0.0))))
+          result (opencl-pass/opencl-pass form :dtype :float :compile-spirv? false)]
+      (is (seq (:kernels result))
+          "Should generate at least one kernel")
+      (when (seq (:kernels result))
+        (let [src (:source (first (:kernels result)))]
+          (is (string? src) "Kernel source should be a string")
+          (is (.contains ^String src "__kernel") "Should contain __kernel")
+          (is (.contains ^String src "if") "Should contain if statement"))))))

--- a/test/raster/gpu/compiled_scan_session_test.clj
+++ b/test/raster/gpu/compiled_scan_session_test.clj
@@ -1,0 +1,78 @@
+(ns raster.gpu.compiled-scan-session-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-abi :as kabi]
+            [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.gpu.core :as gpu]))
+
+(defn- scan-artifact
+  []
+  (kart/make
+   {:kernel-name "session_scan"
+    :source (str "__kernel void session_scan(__global const int* input, "
+                 "__global int* output, int _n_bound) {}")
+    :abi [(kabi/slot 'input :input :int :role :operand)
+          (kabi/slot 'output :output :int :role :result)
+          (kabi/slot '_n_bound :scalar :int :role :bound)]
+    :arguments '[input output n]
+    :launch (klaunch/spec {:workgroup-size [64]
+                           :group-count [(klaunch/ceil-div 'n 64)]})
+    :effects {:kind :scan :reads ['input] :writes ['output]}
+    :attributes {:strategy :scheduled-graph}}))
+
+(defn- scan-dispatch
+  []
+  (kdispatch/make
+   {:id "session-scan-dispatch"
+    :alternatives [(scan-artifact)]
+    :default-strategy :scheduled-graph
+    :selector {:kind :fixed-strategy :strategy :scheduled-graph}}))
+
+(deftest compile-retains-first-class-dispatches-beside-flat-kernels
+  (let [session (atom {:device-id :ze:0})
+        compilations (atom 0)
+        compiled {:kernels [:registered-kernel]
+                  :dispatches [(scan-dispatch)]}]
+    (with-redefs-fn
+      {#'raster.gpu.core/compile-deftm-internal!
+       (fn [_ _ _] (swap! compilations inc) compiled)}
+      #(do
+         (is (= [:registered-kernel]
+                (gpu/compile! session :first #'identity)))
+         (is (= [:registered-kernel]
+                (gpu/compile! session :second #'identity)))))
+    (is (= 1 @compilations) "the complete compiled result is cached once")
+    (is (= (:dispatches compiled) (get-in @session [:dispatches :first])))
+    (is (= (:dispatches compiled) (get-in @session [:dispatches :second])))))
+
+(deftest scan-invocation-binds-the-retained-ordered-executable-abi
+  (let [dispatch (scan-dispatch)
+        session (atom {:dispatches {:scan [dispatch]}
+                       :buffers {:output :resident-output}})
+        calls (atom [])]
+    (with-redefs [gpu/bind-kernel-executable!
+                  (fn [actual-session key executable arguments]
+                    (swap! calls conj [:bind actual-session key executable arguments])
+                    ::handle)
+                  gpu/run-kernel-graph!
+                  (fn [actual-session handle]
+                    (swap! calls conj [:run actual-session handle]))
+                  gpu/release-kernel-graph!
+                  (fn [actual-session handle]
+                    (swap! calls conj [:release actual-session handle]))]
+      (is (= :resident-output
+             (gpu/invoke-scan! session :scan [:input] :output 513))))
+    (let [[_ actual-session key executable arguments] (first @calls)]
+      (is (identical? session actual-session))
+      (is (= [:compiled-scan :scan] key))
+      (is (= (kdispatch/default-alternative dispatch) executable))
+      (is (= [:input :output {:type :int :value 513}] arguments)))
+    (is (= [[:run session ::handle]
+            [:release session ::handle]]
+           (subvec @calls 1))))
+  (testing "flat kernels cannot silently stand in for a missing scheduled dispatch"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"exactly one KernelDispatch"
+         (gpu/invoke-scan! (atom {:kernels {:scan [:block :prop]}})
+                           :scan [:input] :output 8)))))


### PR DESCRIPTION
## Outcome

- retain KernelDispatch values produced by session compilation instead of discarding them beside a flat kernel list
- execute compiled scans through their ordered KernelExecutable ABI and common graph binder
- fail loudly when a compiled scan dispatch is missing or its captured scalar cannot be inferred
- remove the ocloc whole-namespace fixture that suppressed ABM CPU parity and codegen tests
- route only real Level Zero tests through the shared honest device probe
- let codegen exceptions fail instead of printing a skip

## Validation

- hardware-free session contract: 2 tests, 12 assertions
- Intel Arc ABM namespace: 12 tests, 272 assertions, including multi-block and single-block exclusive scans
- the recovered test exposed and now prevents the obsolete positional first-two-kernels scan reconstruction

The full sharded suite and CUDA/HIP compile gates are delegated to CircleCI.