### PR TITLE
Route Q4_K row projection through TypedSOAC

### DIFF
--- a/src/raster/quant/kernels_k.clj
+++ b/src/raster/quant/kernels_k.clj
@@ -246,12 +246,12 @@
                        nsub (quot (long in) 32)
                        xiw (quot (long in) 4)
                        wiw (quot (long in) 8)           ; weight int32 words per row (in/2 bytes / 4)
-                       wb (* (long o) wiw)
-                       sbb (* (long o) nsb)
-                       subb (* (long o) nsub)
-                       xb (* row xiw)
-                       xsb-base (* row nsb)
-                       bsum-base (* row nsub)
+                       ^long wb (* (long o) wiw)
+                       ^long sbb (* (long o) nsb)
+                       ^long subb (* (long o) nsub)
+                       ^long xb (* row xiw)
+                       ^long xsb-base (* row nsb)
+                       ^long bsum-base (* row nsub)
                        acc (loop [sb 0 a (float 0.0)]
                              (if (< sb nsb)
                                (let [dav (ra/aget da (+ sbb sb))
@@ -278,7 +278,11 @@
                                               s))]
                                  (recur (inc sb) (+ a (* dact ssum))))
                                a))]
-                   (ra/aset y (+ (* row (long out)) o) acc))))
+                   ;; `ro = row*out + o` by the quotient/remainder definitions above. Keep the
+                   ;; canonical 1:1 destination explicit: TypedSOAC can then certify this effectful
+                   ;; map as a SegMap instead of sending quantized arithmetic through the legacy
+                   ;; map-void emitter.
+                   (ra/aset y ro acc))))
 
 ;; Q6_K work-item-per-row twin of qmatmul-q6k-composable! (symmetric K dot, unsigned+zp32).
 (deftm qmatmul-q6k-gpu!

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -20,11 +20,11 @@
                          [:regtiled :symbolic-dims] 1}}}
 
   :q4k-dp4a-rows-gpu
-  {:route {:backend :opencl :source-dialect :compatibility :typed-validated false
-           :declines {[:segop-lowered-stats :segops-declined :no-lowering-rule] 1}}
+  {:route {:backend :opencl :source-dialect :typed-soac :typed-validated true
+           :declines {}}
    :fusion {:vertical 0 :horizontal 0 :iterations 1 :placements 0}
-   :lowering {:segops 0 :kernel-graphs 0 :typed-reused 0 :typed-scalar-equations 0
-              :backend-reused 0 :backend-relowered 0 :fallback 0}
+   :lowering {:segops 1 :kernel-graphs 0 :typed-reused 1 :typed-scalar-equations 1
+              :backend-reused 1 :backend-relowered 0 :fallback 0}
    :emission {:kernel-count 1 :targets [:opencl-c] :strategies []
               :fallback-reasons [] :declines {}}}
 

--- a/test/raster/quant/kernels_k_test.clj
+++ b/test/raster/quant/kernels_k_test.clj
@@ -4,6 +4,7 @@
    the SAME composable path the legacy Q4_0 uses (and that the GPU/OpenCL path will reuse).
    Single-call correctness; no spin-pool, no Valhalla."
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.report :as report]
             [raster.quant.kernels-k :as qk]
             [raster.compiler.backend.cpu.quant :as q]
             [raster.compiler.pipeline :as pipeline]))
@@ -158,8 +159,10 @@
                                                         :target-device :ze:0 :dtype :float))
         padded-kernels (:kernels (pipeline/show-pipeline #'qk/quant-act-q8k-padded-rows-gpu!
                                                          :target-device :ze:0 :dtype :float))
-        projection-kernels (:kernels (pipeline/show-pipeline #'qk/qmatmul-q4k-dp4a-rows!
-                                                             :target-device :ze:0 :dtype :float))]
+        projection-pipeline (pipeline/show-pipeline #'qk/qmatmul-q4k-dp4a-rows!
+                                                    :target-device :ze:0 :dtype :float)
+        projection-kernels (:kernels projection-pipeline)
+        projection-report (report/from-pipeline projection-pipeline)]
     (is (= 2 (count quant-kernels)) "Q8_K remains an ordered two-phase reduction")
     (is (= '[[[submax :float] [x :float] [_n_bound :int]]
              [[bsums :int] [submax :float] [x :float] [xp :int]
@@ -173,6 +176,16 @@
     (is (every? #(re-find #"col < .*width" (:source %)) padded-kernels)
         "both phases guard dense-row reads and synthesize the padding region")
     (is (= 1 (count projection-kernels)))
+    (is (= {:backend :opencl
+            :source-dialect :typed-soac
+            :typed-validated true
+            :declines []}
+           (:route projection-report))
+        "Q4_K uses the validated typed route rather than compatibility lowering")
+    (is (= {:segops 1 :kernel-graphs 0 :typed-reused 1 :typed-scalar-equations 1
+            :backend-reused 1 :backend-relowered 0 :fallback 0}
+           (:lowering projection-report))
+        "the scheduled SegMap is preserved through OpenCL emission")
     (is (= '[[aq :byte] [bq :byte] [bsums :int] [da :float] [db :float]
              [wp :int] [xp :int] [xs :float] [y :float]
              [in :int] [out :int] [_n_bound :int]]


### PR DESCRIPTION
## Outcome

The production multi-row Q4_K projection now enters the validated TypedSOAC route and preserves its scheduled SegMap through OpenCL emission.

## Changes

- express the output write through its canonical one-to-one `ro` destination
- retain explicit long types for address-offset locals instead of guessing types in an emitter
- ratchet the compatibility ledger from one declined compatibility kernel to one validated/reused TypedSOAC SegMap
- assert the route, unchanged ABI, common `rstr_dp4a` intrinsic, and absence of FP64 promotion

## Focused validation

- `clojure -M:test -n raster.quant.kernels-k-test -n raster.compiler.compatibility-ledger-test`
- 7 tests, 82 assertions, 0 failures/errors
- `clojure -M:format src/raster/quant/kernels_k.clj test/raster/quant/kernels_k_test.clj`
