### PR TITLE
Move head layout and contractions onto direct TypedSOAC

### DIFF
--- a/src/raster/compiler/backend/jvm/par_simd.clj
+++ b/src/raster/compiler/backend/jvm/par_simd.clj
@@ -524,10 +524,16 @@
               ;; In particular, a typed segmented contraction projects back to par/contract for
               ;; host execution. Generic sequence recursion would leave its free/contract axis
               ;; binders as unresolved bytecode symbols. Expand through raster.par's canonical
-              ;; sequential semantics and retain the counted schedule debt instead.
+              ;; sequential semantics and retain the counted schedule debt instead. Ordinary
+              ;; macroexpand is deliberately wrong here: it rewrites the walker's `.invk` nodes
+              ;; into interop forms before the bytecode backend consumes them.
               (par/par-form? form)
               (do (swap! stats update :fallback inc)
-                  (macroexpand/macroexpand-all-preserving form))
+                  (macroexpand/macroexpand-all-preserving
+                   form
+                   ;; Preserve the walker's devirtualized typed calls. Unlike macroexpand-core,
+                   ;; this intentionally expands raster.par macros at the correctness boundary.
+                   #(and (symbol? %) (.startsWith (name %) "."))))
 
               ;; let/let* — check for fusable consecutive maps
               (and (seq? form) (contains? #{'let 'let*} (first form)))

--- a/src/raster/compiler/backend/jvm/par_simd.clj
+++ b/src/raster/compiler/backend/jvm/par_simd.clj
@@ -17,7 +17,8 @@
 
   Size guard: skip SIMD for statically-known n < 8 (overhead > benefit).
   For dynamic sizes, emit both paths with runtime branch on n."
-  (:require [raster.compiler.core.op-descriptor :as descriptor]
+  (:require [raster.compiler.core.macroexpand :as macroexpand]
+            [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.backend.jvm.segop-simd :as segop-simd]
             [raster.compiler.backend.jvm.bytecode :as bc]
             [raster.compiler.ir.soac]
@@ -518,6 +519,15 @@
                           (par/expand-par-gather! form))))
                   (do (swap! stats update :fallback inc)
                       (par/expand-par-gather! form))))
+
+              ;; Correctness boundary for a parallel primitive without a JVM SIMD schedule.
+              ;; In particular, a typed segmented contraction projects back to par/contract for
+              ;; host execution. Generic sequence recursion would leave its free/contract axis
+              ;; binders as unresolved bytecode symbols. Expand through raster.par's canonical
+              ;; sequential semantics and retain the counted schedule debt instead.
+              (par/par-form? form)
+              (do (swap! stats update :fallback inc)
+                  (macroexpand/macroexpand-all-preserving form))
 
               ;; let/let* — check for fusable consecutive maps
               (and (seq? form) (contains? #{'let 'let*} (first form)))

--- a/src/raster/compiler/ir/dialects.clj
+++ b/src/raster/compiler/ir/dialects.clj
@@ -521,7 +521,8 @@
                                   (= 4 (count operation)))
                          (nth operation 3))]
               (and (seq? body)
-                   (contains? #{'scalar 'map 'scatter 'reduce 'scan} (first body)))))
+                   (contains? #{'scalar 'map 'scatter 'reduce 'segmented-reduce 'scan}
+                              (first body)))))
           (fn [_ algorithm]
             (= algorithm (soac-dialect/validate! algorithm))))
          (valid-let*-ordered? (:source value))

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -21,11 +21,6 @@
             [raster.compiler.passes.parallel.fusion-support :as fusion-support]
             [raster.compiler.passes.scalar.effects :as effects]))
 
-(def ^:private array-constructor-heads
-  '#{double-array float-array int-array long-array byte-array
-     clojure.core/double-array clojure.core/float-array
-     clojure.core/int-array clojure.core/long-array clojure.core/byte-array})
-
 (defn- fail!
   [reason message data]
   (throw (ex-info message (assoc data :reason reason :front-end :analyzed-source))))
@@ -501,14 +496,18 @@
          (or (and (symbol? expression) (contains? physical-outputs expression))
              (and (contains? physical-outputs (:sym description))
                   (seq? expression)
-                  (contains? array-constructor-heads (first expression)))))))
+                  (descriptor/alloc-op? (descriptor/semantic-op expression)))))))
+
+(defn- physical-output-symbols
+  [descriptions]
+  (reduce set/union #{}
+          (map #(if (contains? #{:map :scatter :reduce :segmented-reduce :scan} (:kind %))
+                  (:outputs %) #{})
+               descriptions)))
 
 (defn- supported-descriptions?
   [descriptions]
-  (let [physical-outputs (reduce set/union #{}
-                                 (map #(if (contains? #{:map :scatter :reduce :segmented-reduce :scan} (:kind %))
-                                         (:outputs %) #{})
-                                      descriptions))]
+  (let [physical-outputs (physical-output-symbols descriptions)]
     (every? (fn [description]
               (case (:kind description)
                 :scalar (or (provably-pure-scalar? (:expr description))
@@ -710,7 +709,8 @@
 
 (defn- terminal-results
   [descriptions body]
-  (let [operations (filter #(contains? #{:map :scatter :reduce :segmented-reduce :scan} (:kind %)) descriptions)
+  (let [physical-outputs (physical-output-symbols descriptions)
+        operations (filter #(contains? #{:map :scatter :reduce :segmented-reduce :scan} (:kind %)) descriptions)
         operation-definitions (set (mapcat #(case (:kind %)
                                               (:map :scatter) (:results %)
                                               :scan [(:sym %)]
@@ -724,7 +724,11 @@
                         :segmented-reduce (if (:effect-only? %) [] (:results %))
                         (:outputs %))
                      operations))
-        scalar-definitions (set (keep #(when (= :scalar (:kind %)) (:sym %)) descriptions))
+        scalar-definitions
+        (set (keep #(when (and (= :scalar (:kind %))
+                               (not (generated-scaffolding? % physical-outputs)))
+                      (:sym %))
+                   descriptions))
         all-definitions (set/union operation-definitions scalar-definitions)
         operation-uses (set (concat (mapcat #(concat (:inputs %) (:scalars %)) operations)
                                     (mapcat #(when (= :scalar (:kind %))
@@ -737,7 +741,12 @@
 
 (defn- selected-scalars
   [descriptions operation-equations outputs]
-  (let [by-symbol (into {} (keep #(when (= :scalar (:kind %)) [(:sym %) %])) descriptions)
+  (let [physical-outputs (physical-output-symbols descriptions)
+        by-symbol (into {}
+                        (keep #(when (and (= :scalar (:kind %))
+                                          (not (generated-scaffolding? % physical-outputs)))
+                                 [(:sym %) %]))
+                        descriptions)
         roots (set (concat outputs
                            (mapcat (fn [equation]
                                      (into (dialect/operation-inputs equation)

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -269,7 +269,9 @@
    Typed equations own parallel/scalar computation, but a caller-owned physical destination may
    retain an ordinary allocation expression. That expression can depend on pure scalar bindings
    introduced by inlining (for example `size = m*n`). Preserve that dependency closure instead of
-   leaving an alpha-renamed callee parameter free in the reconstructed JVM/C host form."
+   leaving an alpha-renamed callee parameter free in the reconstructed JVM/C host form. `pairs`
+   contains only bindings without a realized typed equation, so dependency traversal stops at the
+   new semantic boundary instead of resurrecting a fused-away producer."
   [pairs roots]
   (let [definitions (into {} (map (fn [[symbol expression]] [symbol expression])) pairs)
         definition-symbols (set (keys definitions))]
@@ -298,7 +300,9 @@
               (:equations (dialect/facts program)))
         host-bindings
         (required-host-bindings
-         original-pairs
+         (keep-indexed (fn [id pair]
+                         (when (empty? (get by-placement id)) pair))
+                       original-pairs)
          (set/union physical-destinations
                     (into #{} (mapcat util/free-syms) body)))
         pairs

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -4,7 +4,8 @@
    Supported programs are represented and fused in the typed dialect whether or not a fusion
    fires. The resulting functional equations are mechanically projected into the surrounding host
    control expression and retained as first-class algorithms in a ParallelProgram."
-  (:require [raster.compiler.core.dtype :as dtype]
+  (:require [clojure.set :as set]
+            [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
@@ -262,6 +263,25 @@
          :site [:binding result]
          :source source}))))
 
+(defn- required-host-bindings
+  "Return the transitive source bindings needed by host materialization.
+
+   Typed equations own parallel/scalar computation, but a caller-owned physical destination may
+   retain an ordinary allocation expression. That expression can depend on pure scalar bindings
+   introduced by inlining (for example `size = m*n`). Preserve that dependency closure instead of
+   leaving an alpha-renamed callee parameter free in the reconstructed JVM/C host form."
+  [pairs roots]
+  (let [definitions (into {} (map (fn [[symbol expression]] [symbol expression])) pairs)
+        definition-symbols (set (keys definitions))]
+    (loop [required (set/intersection definition-symbols (set roots))]
+      (let [dependencies
+            (->> required
+                 (mapcat #(util/free-syms (get definitions %)))
+                 set
+                 (set/intersection definition-symbols))
+            required' (set/union required dependencies)]
+        (if (= required required') required (recur required'))))))
+
 (defn- realize-source
   [form program]
   (let [[let-head bindings & body] form
@@ -276,6 +296,11 @@
                          (map :destination
                               (get-in equation-facts [:attributes :result-storage])))))
               (:equations (dialect/facts program)))
+        host-bindings
+        (required-host-bindings
+         original-pairs
+         (set/union physical-destinations
+                    (into #{} (mapcat util/free-syms) body)))
         pairs
         (vec
          (mapcat
@@ -287,7 +312,7 @@
                ;; allocation. Preserve a defining source binding when one exists; dropping it
                ;; leaves CPU-C/JVM materialization with an unbound destination and also loses a
                ;; resident scratch allocation before GPU extraction.
-               (when (and (contains? physical-destinations symbol)
+               (when (and (contains? host-bindings symbol)
                           (empty? (get by-placement id)))
                  [original-pair])
                (mapcat :pairs (get by-placement id)))))

--- a/src/raster/compiler/report.clj
+++ b/src/raster/compiler/report.clj
@@ -20,8 +20,16 @@
   [value]
   (cond
     (nil? value) []
-    (map? value) [value]
-    (sequential? value) value
+    (and (coll? value) (empty? value)) []
+    (map? value)
+    (if (some #(contains? value %) [:reason :message :leaf :value])
+      [value]
+      (mapcat (fn [[reason count]]
+                (if (and (nat-int? count) (pos? count))
+                  (repeat count {:reason reason})
+                  [{:reason reason :value count}]))
+              value))
+    (sequential? value) (remove #(and (coll? %) (empty? %)) value)
     :else [{:value value}]))
 
 (defn- normalize-decline

--- a/src/raster/dl/array_ops.clj
+++ b/src/raster/dl/array_ops.clj
@@ -331,55 +331,51 @@
 
 ;; ================================================================
 ;; pack-heads / unpack-heads: multi-head attention layout combinators.
-;; Both are parametric (All [T]) and expressed as a resident strided copy:
-;; a `par/map-void!` over the n-heads*seq-len output BLOCKS (one work-item per
-;; [head, seq] block), each copying `head-dim` contiguous elements from the
-;; permuted source offset. Index math is clojure.core integer arithmetic
-;; (quot/rem/*/+ — the flat block coordinate → source/dest offsets), so it
-;; lowers in-kernel; the inner contiguous copy vectorizes on CPU and becomes a
-;; resident :map-void OpenCL kernel on GPU (same shape as par/gather /
-;; kv-append! / the decode kernels). No index table, no atomics — a pure
-;; permutation. pack-heads and unpack-heads are exact duals (the AD templates
-;; below reference each other by name, so the resident rewrite leaves them
-;; untouched).
+;; Both are parametric (All [T]) and expressed as output-element-parallel
+;; permutations. The launch spans seq-len*n-heads*head-dim, so every work item
+;; owns exactly one dense output coordinate and the typed SOAC legality proof is
+;; simply `out[idx]`. Index math is ordinary clojure.core integer arithmetic;
+;; there is no index table, allocation policy, or attention-specific compiler
+;; rule. pack-heads and unpack-heads are exact duals (the AD templates below
+;; reference each other by name, so the resident rewrite leaves them untouched).
 ;; ================================================================
 
 (deftm pack-heads
   "Reshape [seq-len, n-heads*head-dim] (row-major) → [n-heads, seq-len, head-dim]
   so each head slab is contiguous: out[h*seq*hd + s*hd + d] = x[s*(nh*hd) + h*hd + d].
-  Resident strided copy: work-item e = h*seq-len + s copies a head-dim slab."
+  Resident strided copy: work-item idx = (h*seq-len+s)*head-dim+d owns out[idx]."
   (All [T] [x :- (Array T) seq-len :- Long n-heads :- Long head-dim :- Long] :- (Array T)
-       (let [out (alloc-like x (* seq-len n-heads head-dim))]
-         (par/map-void! e (clojure.core/* n-heads seq-len)
-                        (let [h (quot e seq-len)
-                              s (rem e seq-len)
-                              dst (clojure.core/* e head-dim)
-                              src (clojure.core/+ (clojure.core/* s (clojure.core/* n-heads head-dim))
-                                                  (clojure.core/* h head-dim))]
-                          (loop [d 0]
-                            (if (< d head-dim)
-                              (do (aset out (clojure.core/+ dst d) (aget x (clojure.core/+ src d)))
-                                  (recur (inc d)))
-                              nil))))
-         out)))
+       (let [out (alloc-like x (* seq-len n-heads head-dim))
+             result (par/map! out idx
+                              (clojure.core/* (clojure.core/* n-heads seq-len) head-dim)
+                              nil
+                              (let [^long d (rem idx head-dim)
+                                    ^long e (quot idx head-dim)
+                                    ^long h (quot e seq-len)
+                                    ^long s (rem e seq-len)
+                                    ^long src (clojure.core/+ (clojure.core/* s (clojure.core/* n-heads head-dim))
+                                                              (clojure.core/+ (clojure.core/* h head-dim) d))]
+                                (aget x src)))]
+         result)))
 
 (deftm unpack-heads
   "Dual of pack-heads: [n-heads, seq-len, head-dim] → [seq-len, n-heads*head-dim]:
   out[s*(nh*hd) + h*hd + d] = x[h*seq*hd + s*hd + d].
-  Resident strided copy: work-item e = s*n-heads + h copies a head-dim slab."
+  Resident strided copy: work-item idx = (s*n-heads+h)*head-dim+d owns out[idx]."
   (All [T] [x :- (Array T) seq-len :- Long n-heads :- Long head-dim :- Long] :- (Array T)
-       (let [out (alloc-like x (* seq-len n-heads head-dim))]
-         (par/map-void! e (clojure.core/* seq-len n-heads)
-                        (let [s (quot e n-heads)
-                              h (rem e n-heads)
-                              dst (clojure.core/* e head-dim)
-                              src (clojure.core/* (clojure.core/+ (clojure.core/* h seq-len) s) head-dim)]
-                          (loop [d 0]
-                            (if (< d head-dim)
-                              (do (aset out (clojure.core/+ dst d) (aget x (clojure.core/+ src d)))
-                                  (recur (inc d)))
-                              nil))))
-         out)))
+       (let [out (alloc-like x (* seq-len n-heads head-dim))
+             result (par/map! out idx
+                              (clojure.core/* (clojure.core/* seq-len n-heads) head-dim)
+                              nil
+                              (let [^long d (rem idx head-dim)
+                                    ^long e (quot idx head-dim)
+                                    ^long s (quot e n-heads)
+                                    ^long h (rem e n-heads)
+                                    ^long src (clojure.core/+ (clojure.core/* (clojure.core/+ (clojure.core/* h seq-len) s)
+                                                                              head-dim)
+                                                              d)]
+                                (aget x src)))]
+         result)))
 
 (deftm blit-slab!
   "Copy `len` contiguous elements from `src[0..len)` into `dst[dst-off .. dst-off+len)`.

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -3,10 +3,12 @@
  "Exact fast-lane compiler signatures for representative ML and scientific workloads. Improvements update this debt downward; unexpected route, fallback, or emitter drift fails CI. Large numerical/performance comparisons live in the cold benchmark lane."
  :workloads
  {:dense-relu-jvm
+  ;; One unsupported JVM par primitive is now expanded through the canonical
+  ;; correctness path and counted instead of leaking through the backend.
   {:route {:backend :simd :source-dialect :typed-soac :typed-validated true :declines {}}
    :fusion {:vertical 1 :horizontal 0 :iterations 2 :placements 0}
    :lowering {:segops 2 :kernel-graphs 0 :typed-reused 2 :typed-scalar-equations 4
-              :backend-reused 2 :backend-relowered 2 :fallback 2}
+              :backend-reused 2 :backend-relowered 2 :fallback 3}
    :emission {:kernel-count 0 :targets [] :strategies [] :fallback-reasons [] :declines {}}}
 
   :symbolic-dense-contraction-gpu

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -3,12 +3,10 @@
  "Exact fast-lane compiler signatures for representative ML and scientific workloads. Improvements update this debt downward; unexpected route, fallback, or emitter drift fails CI. Large numerical/performance comparisons live in the cold benchmark lane."
  :workloads
  {:dense-relu-jvm
-  ;; One unsupported JVM par primitive is now expanded through the canonical
-  ;; correctness path and counted instead of leaking through the backend.
   {:route {:backend :simd :source-dialect :typed-soac :typed-validated true :declines {}}
    :fusion {:vertical 1 :horizontal 0 :iterations 2 :placements 0}
    :lowering {:segops 2 :kernel-graphs 0 :typed-reused 2 :typed-scalar-equations 4
-              :backend-reused 2 :backend-relowered 2 :fallback 3}
+              :backend-reused 2 :backend-relowered 2 :fallback 2}
    :emission {:kernel-count 0 :targets [] :strategies [] :fallback-reasons [] :declines {}}}
 
   :symbolic-dense-contraction-gpu

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -10,9 +10,11 @@
    :emission {:kernel-count 0 :targets [] :strategies [] :fallback-reasons [] :declines {}}}
 
   :symbolic-dense-contraction-gpu
-  {:route {:backend :opencl :source-dialect :compatibility :typed-validated false :declines {}}
+  {:route {:backend :opencl :source-dialect :typed-soac :typed-validated true
+           :declines {[:backend-applied-stats :typed-contraction-dispatch-declines
+                       :typed-contraction-dispatch-dynamic-scalar] 1}}
    :fusion {:vertical 0 :horizontal 0 :iterations 1 :placements 0}
-   :lowering {:segops 1 :kernel-graphs 0 :typed-reused 0 :typed-scalar-equations 0
+   :lowering {:segops 1 :kernel-graphs 0 :typed-reused 1 :typed-scalar-equations 0
               :backend-reused 1 :backend-relowered 0 :fallback 0}
    :emission {:kernel-count 1 :targets [:opencl-c] :strategies [:portable-segred]
               :fallback-reasons [:symbolic-dims]
@@ -30,11 +32,11 @@
 
   :gqa-causal-mha-gpu
   {:route {:backend :opencl :source-dialect :compatibility :typed-validated false
-           :declines {[:segop-lowered-stats :segops-declined :no-lowering-rule] 6}}
-   :fusion {:vertical 0 :horizontal 1 :iterations 2 :placements 0}
-   :lowering {:segops 2 :kernel-graphs 0 :typed-reused 0 :typed-scalar-equations 0
-              :backend-reused 0 :backend-relowered 0 :fallback 0}
-   :emission {:kernel-count 8 :targets [:opencl-c] :strategies []
+           :declines {[:segop-lowered-stats :segops-declined :no-lowering-rule] 2}}
+   :fusion {:vertical 0 :horizontal 2 :iterations 2 :placements 0}
+   :lowering {:segops 5 :kernel-graphs 0 :typed-reused 0 :typed-scalar-equations 0
+              :backend-reused 3 :backend-relowered 0 :fallback 0}
+   :emission {:kernel-count 7 :targets [:opencl-c] :strategies []
               :fallback-reasons [] :declines {}}}
 
   :heat-rhs-1d-jvm

--- a/test/raster/compiler/contraction_marker_abi_test.clj
+++ b/test/raster/compiler/contraction_marker_abi_test.clj
@@ -8,6 +8,9 @@
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-executable :as kexec]
+            [raster.compiler.ir.kernel-graph :as kgraph]
+            [raster.compiler.ir.kernel-graph-call :as kgcall]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.passes.parallel.contract-route :as route]
             [raster.compiler.passes.parallel.par-fusion :as fusion]
@@ -213,26 +216,31 @@
         (is (= :float (:expected scalar-data)))
         (is (= :int (:actual scalar-data)))))))
 
-(deftest compile-gpu-program-extracts-a-real-contraction-as-an-ordered-resident-step
+(deftest compile-gpu-program-extracts-a-real-contraction-as-an-ordered-resident-executable
   (let [descriptor (pipeline/compile-gpu-program #'resident-contract-descriptor-probe
                                                   :ze:0 :dtype :float)
         step (first (:steps descriptor))
+        executable (:artifact step)
         args [(float-array 64) (float-array 64)]
         call-arguments (mapv (fn [{:keys [kind type value-fn]}]
                                (if (= :scalar kind)
                                  {:type type :value (value-fn args)}
                                  (Object.)))
                              (:argument-specs step))
-        call (kcall/make (:artifact step) call-arguments)]
-    (is (= :contract (:convention step)))
+        {:keys [buffers scalar-values]} (kexec/graph-bindings executable call-arguments)
+        call (kgcall/make executable buffers scalar-values)
+        kernel-call (get-in call [:nodes 0 :call])]
+    (is (= :executable (:convention step)))
+    (is (kgraph/kernel-graph? executable)
+        "typed contraction candidates retain their common graph boundary")
     (is (= '[A B C] (mapv (comp :name :slot) (:argument-specs step))))
     (is (= [:input :input :output] (mapv :kind (:argument-specs step))))
     (is (= 'C (:result-sym descriptor)) "the invoke result aliases its ABI :result buffer")
     (is (= {'A :input 'B :input} (:array-roles descriptor)))
     (is (= :float (:dtype (first (:allocs descriptor))))
         "scratch allocation dtype comes from the contraction output ABI")
-    (is (= 64 (kart/attribute (:artifact step) :out-elems)))
-    (is (= 2 (count (get-in call [:geometry :workgroup-size]))))
-    (is (= 2 (count (get-in call [:geometry :group-count]))))
-    (is (every? pos? (get-in call [:geometry :workgroup-size])))
-    (is (every? pos? (get-in call [:geometry :group-count])))))
+    (is (= 64 (kart/attribute (first (kexec/artifacts executable)) :out-elems)))
+    (is (= 2 (count (get-in kernel-call [:geometry :workgroup-size]))))
+    (is (= 2 (count (get-in kernel-call [:geometry :group-count]))))
+    (is (every? pos? (get-in kernel-call [:geometry :workgroup-size])))
+    (is (every? pos? (get-in kernel-call [:geometry :group-count])))))

--- a/test/raster/compiler/head_layout_typed_test.clj
+++ b/test/raster/compiler/head_layout_typed_test.clj
@@ -1,0 +1,25 @@
+(ns raster.compiler.head-layout-typed-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.pipeline :as pipeline]
+            [raster.compiler.report :as report]
+            [raster.dl.array-ops :as ops]))
+
+(deftest head-layout-permutations-use-the-direct-typed-route
+  (doseq [operation [#'ops/pack-heads #'ops/unpack-heads]]
+    (let [compiled (pipeline/show-pipeline operation :target-device :ze:0 :dtype :float)
+          compiler-report (report/from-pipeline compiled)]
+      (is (= {:backend :opencl :source-dialect :typed-soac
+              :typed-validated true :declines []}
+             (:route compiler-report))
+          (str (:name (meta operation)) " route"))
+      (is (= {:segops 1 :kernel-graphs 0 :typed-reused 1 :typed-scalar-equations 1
+              :backend-reused 1 :backend-relowered 0 :fallback 0}
+             (:lowering compiler-report))
+          (str (:name (meta operation)) " lowering"))
+      (is (= 1 (count (:kernels compiled))))
+      (is (= #{['out :float] ['x :float]}
+             (->> (:abi (first (:kernels compiled)))
+                  (remove #(= :scalar (:kind %)))
+                  (map (juxt :name :dtype))
+                  set))
+          "the typed schedule retains one input and one physical destination"))))

--- a/test/raster/compiler/passes/parallel/typed_segmented_reduction_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_segmented_reduction_test.clj
@@ -1,6 +1,7 @@
 (ns raster.compiler.passes.parallel.typed-segmented-reduction-test
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.dialects :as dialects]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.segop :as segop]
@@ -114,6 +115,8 @@
                  envelope {:target-device :ze:0 :dtype :float})
         scheduled-equation (first (:equations (:form lowered)))
         operation (first (:operations scheduled-equation))]
+    (is (dialects/valid-typed-soac-program? envelope)
+        "the pipeline boundary admits the TypedSOAC segmented-reduce operation")
     (is (= :segop (:dialect (:form lowered))))
     (is (= 1 (get-in lowered [:stats :typed-soac-reused])))
     (is (= 1 (get-in lowered [:stats :segops-lowered])))

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -60,6 +60,24 @@
                                   {:scalar-types {'nrows :long 'width :long}})
                    [:stats :front-end])))))
 
+(deftest devirtualized-output-allocation-is-generated-scaffolding
+  (let [allocation (with-meta
+                     '(.invk raster.arrays/alloc-like_m_array_long-impl x n)
+                     {:raster.op/original 'raster.arrays/alloc-like})
+        source (list 'let*
+                     (vector 'out allocation
+                             'result '(raster.par/map! out i n float
+                                                       (clojure.core/aget x i)))
+                     'result)
+        direct (frontend/form->program
+                source {:dtype :float :array-types {'x :float 'out :float}
+                        :scalar-types {'n :long}})]
+    (is (= ['map] (mapv dialect/operation-kind (dialect/equations direct))))
+    (is (= :analyzed-source
+           (get-in (route/attempt source :float {'x :float 'out :float}
+                                  {:scalar-types {'n :long}})
+                   [:stats :front-end])))))
+
 (deftest guarded-dense-write-is-an-explicit-inout-map
   (let [program
         (frontend/form->program

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -62,21 +62,25 @@
 
 (deftest devirtualized-output-allocation-is-generated-scaffolding
   (let [allocation (with-meta
-                     '(.invk raster.arrays/alloc-like_m_array_long-impl x n)
+                     '(.invk raster.arrays/alloc-like_m_array_long-impl x size)
                      {:raster.op/original 'raster.arrays/alloc-like})
         source (list 'let*
-                     (vector 'out allocation
+                     (vector 'size '(clojure.core/* m n)
+                             'out allocation
                              'result '(raster.par/map! out i n float
                                                        (clojure.core/aget x i)))
                      'result)
         direct (frontend/form->program
                 source {:dtype :float :array-types {'x :float 'out :float}
-                        :scalar-types {'n :long}})]
+                        :scalar-types {'m :long 'n :long}})
+        routed (route/attempt source :float {'x :float 'out :float}
+                              {:scalar-types {'m :long 'n :long}})]
     (is (= ['map] (mapv dialect/operation-kind (dialect/equations direct))))
     (is (= :analyzed-source
-           (get-in (route/attempt source :float {'x :float 'out :float}
-                                  {:scalar-types {'n :long}})
-                   [:stats :front-end])))))
+           (get-in routed [:stats :front-end])))
+    (is (= ['size '(clojure.core/* m n)]
+           (vec (take 2 (second (get-in routed [:program :source])))))
+        "host allocation retains the transitive scalar binding that computes its extent")))
 
 (deftest guarded-dense-write-is-an-explicit-inout-map
   (let [program

--- a/test/raster/compiler/report_test.clj
+++ b/test/raster/compiler/report_test.clj
@@ -11,6 +11,7 @@
           :segop-lowered-stats {:segops-lowered 2 :kernel-graphs-lowered 1
                                 :typed-soac-reused 3 :typed-scalar-equations 4}
           :backend-applied-stats {:segop-reused 2 :segop-relowered 1 :fallback 0
+                                  :typed-contraction-dispatch-declines [{}]
                                   :segop-declined [{:reason :missing-rule}]}
           :kernels [{:target :opencl-c
                      :attributes {:strategy :portable
@@ -41,3 +42,17 @@
                                  :backend-applied-stats {:fallback 0}
                                  :kernels [{:target :opencl-c}]})]
     (is (= :compatibility (get-in r [:route :source-dialect])))))
+
+(deftest counted-decline-summaries-retain-their-reasons
+  (let [r (report/from-pipeline
+           {:backend :opencl
+            :backend-applied-stats
+            {:typed-contraction-dispatch-declines {:dynamic-scalar 2}}
+            :kernels []})]
+    (is (= [{:stage :backend-applied-stats
+             :kind :typed-contraction-dispatch-declines
+             :reason :dynamic-scalar}
+            {:stage :backend-applied-stats
+             :kind :typed-contraction-dispatch-declines
+             :reason :dynamic-scalar}]
+           (get-in r [:route :declines])))))


### PR DESCRIPTION
Moves pack-heads and unpack-heads from effectful block-copy loops to ordinary one-output-per-work-item TypedSOAC maps. The direct frontend now recognizes generated output allocation through the shared semantic operation descriptor, and the pipeline validator admits the existing typed segmented-reduce operation used by symbolic contraction. Compiler reporting also normalizes counted decline summaries without inventing declines from empty diagnostics.

The compatibility ledger records symbolic contraction on the validated typed route and reduces GQA compatibility declines from six to two while reducing emitted kernels from eight to seven.

Focused cold gates:
- compatibility ledger: 1 test, 7 assertions
- compiler/frontend/report/head layout: 23 tests, 136 assertions
- array ops and batched attention: 37 tests, 252 assertions