### PR TITLE
Expose causal score computation as a typed map

### DIFF
--- a/src/raster/dl/attention.clj
+++ b/src/raster/dl/attention.clj
@@ -1091,25 +1091,26 @@
        (let [slab (* seq-len head-dim)
              ss (* seq-len seq-len)
              S (alloc-like Q (* batch ss))
-             W (alloc-like Q (* batch ss))]
-         ;; kernel 1: raw scaled causal scores S[b,i,j] (0 above the diagonal)
-         (raster.par/map-void! t (clojure.core/* batch ss)
-                               (let [b (quot t ss)
-                                     r (rem t ss)
-                                     i (quot r seq-len)
-                                     j (rem r seq-len)
-                                     boff (clojure.core/* b slab)]
-                                 (if (<= j i)
-                                   (let [qrow (clojure.core/+ boff (clojure.core/* i head-dim))
-                                         krow (clojure.core/+ boff (clojure.core/* j head-dim))
-                                         dot (loop [d 0 acc 0.0]
-                                               (if (< d head-dim)
-                                                 (recur (inc d)
-                                                        (+ acc (* (aget Q (clojure.core/+ qrow d))
-                                                                  (aget K (clojure.core/+ krow d)))))
-                                                 acc))]
-                                     (aset S t (/ dot (n/oftype dot (n/sqrt (double head-dim))))))
-                                   (aset S t 0.0))))
+             W (alloc-like Q (* batch ss))
+             ;; kernel 1: raw scaled causal scores S[b,i,j] (0 above the diagonal)
+             scores
+             (raster.par/map! S t (clojure.core/* batch ss) nil
+                              (let [b (quot t ss)
+                                    r (rem t ss)
+                                    i (quot r seq-len)
+                                    j (rem r seq-len)
+                                    boff (clojure.core/* b slab)]
+                                (if (<= j i)
+                                  (let [qrow (clojure.core/+ boff (clojure.core/* i head-dim))
+                                        krow (clojure.core/+ boff (clojure.core/* j head-dim))
+                                        dot (loop [d 0 acc 0.0]
+                                              (if (< d head-dim)
+                                                (recur (inc d)
+                                                       (+ acc (* (aget Q (clojure.core/+ qrow d))
+                                                                 (aget K (clojure.core/+ krow d)))))
+                                                acc))]
+                                    (/ dot (n/oftype dot (n/sqrt (double head-dim)))))
+                                  0.0)))]
          ;; kernel 2: per query row — mx/Z over the ≤i scores, write normalized weights
          (raster.par/map-void! bi (clojure.core/* batch seq-len)
                                (let [b (quot bi seq-len)
@@ -1117,18 +1118,18 @@
                                      roff (clojure.core/+ (clojure.core/* b ss) (clojure.core/* i seq-len))
                                      mx (loop [j 0 mm -1.0e38]
                                           (if (<= j i)
-                                            (recur (inc j) (n/max mm (aget S (clojure.core/+ roff j))))
+                                            (recur (inc j) (n/max mm (aget scores (clojure.core/+ roff j))))
                                             mm))
                                      sum (loop [j 0 s 0.0]
                                            (if (<= j i)
-                                             (recur (inc j) (+ s (m/exp (- (aget S (clojure.core/+ roff j)) mx))))
+                                             (recur (inc j) (+ s (m/exp (- (aget scores (clojure.core/+ roff j)) mx))))
                                              s))
                                      inv (/ 1.0 sum)]
                                  (loop [j 0]
                                    (if (< j seq-len)
                                      (do (if (<= j i)
                                            (aset W (clojure.core/+ roff j)
-                                                 (* (m/exp (- (aget S (clojure.core/+ roff j)) mx)) inv))
+                                                 (* (m/exp (- (aget scores (clojure.core/+ roff j)) mx)) inv))
                                            (aset W (clojure.core/+ roff j) 0.0))
                                          (recur (inc j)))
                                      nil))))

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -32,10 +32,10 @@
 
   :gqa-causal-mha-gpu
   {:route {:backend :opencl :source-dialect :compatibility :typed-validated false
-           :declines {[:segop-lowered-stats :segops-declined :no-lowering-rule] 2}}
+           :declines {[:segop-lowered-stats :segops-declined :no-lowering-rule] 1}}
    :fusion {:vertical 0 :horizontal 2 :iterations 2 :placements 0}
-   :lowering {:segops 5 :kernel-graphs 0 :typed-reused 0 :typed-scalar-equations 0
-              :backend-reused 3 :backend-relowered 0 :fallback 0}
+   :lowering {:segops 6 :kernel-graphs 0 :typed-reused 0 :typed-scalar-equations 0
+              :backend-reused 4 :backend-relowered 0 :fallback 0}
    :emission {:kernel-count 7 :targets [:opencl-c] :strategies []
               :fallback-reasons [] :declines {}}}
 


### PR DESCRIPTION
## Outcome

Moves the reusable causal Q/K score computation in grouped-query attention onto the direct TypedSOAC map path. The attention boundary remains semantic, while its ordinary pointwise score construction can now participate in the shared typed compiler vertical.

## Compiler effect

- reduces the GQA compatibility decline count from 2 to 1
- adds one direct segmented operation and one reused backend algorithm
- does not add kernels or fallback paths
- keeps routed paged storage and attention scheduling unchanged

## Validation

Focused TypedSOAC route, frontend, segmented-reduction, compatibility-ledger, and public attention/compiler tests passed locally. Full suite and hardware-free CUDA/HIP compile gates are delegated to CircleCI.