### PR TITLE
Route product reductions through TypedSOAC

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -303,16 +303,21 @@ kernel remains available for already padded layouts. Padding is layout, not quan
 memory ownership.
 
 Decoder selection is likewise an ordinary indexed row reduction, not an attention or quantization
-primitive. Scalar reduction is now the one-component case of a canonical typed `ProductReduction`;
-multi-result reductions carry ordered, independently typed components plus distinct element and
-closed binary-combine regions. The first portable `ReductionSchedule` maps a segmented product to
+primitive. TypedSOAC represents it as `product-reduce`: ordered independently typed components,
+identities and algebra accompany distinct element and closed binary-combine regions. A component
+may participate in the algebra without becoming a materialized SSA result; an explicit ordinal map
+connects only retained components to caller-owned result storage. This projects mechanically to the
+canonical `ProductReduction` used by scheduling rather than recovering either region from source.
+The first portable `ReductionSchedule` maps a segmented product to
 strided lane folds, a fixed workgroup-local tree and segment stores. Its workgroup is constrained by
 the target thread limit and the sum of every component's local-memory width, while numerical mode
 and tuning candidates remain inspectable data. `argmax-rows!` therefore emits one mixed-type
 `(value,index)` workgroup tree per row with no compiler-visible global scratch. The semantic ABI
 contains only values, output indices, row count and width; ties select the lowest index, and the first
-NaN outranks numeric values so corruption is visible and deterministic. Subgroup/shuffle and
-multi-workgroup alternatives remain schedule candidates, not new semantic primitives.
+NaN outranks numeric values so corruption is visible and deterministic. Its public compile report
+now proves direct analyzed-source-to-TypedSOAC routing, typed schedule reuse and zero compatibility
+fallback. Subgroup/shuffle and multi-workgroup alternatives remain schedule candidates, not new
+semantic primitives.
 
 TypedSOAC now also names the general `segmented-reduce` algebra directly: ordered parallel segment
 axes, one innermost reduction axis, typed accumulator products, dense element operands and stable

--- a/src/raster/compiler/core/inference.clj
+++ b/src/raster/compiler/core/inference.clj
@@ -1842,13 +1842,31 @@
                          nil)))))
     (catch Throwable _ nil)))
 
+(defn- late-env-tag
+  "Return `sym`'s dispatch tag from either compiler type-environment shape.
+
+   The walker carries the canonical rich entry
+   `{sym {:tag tag :element element-tag ...}}`; later scalar passes retain the
+   historical compact `{sym tag}` projection.  `infer-arg-tag` is shared by both
+   layers, so environment access belongs here instead of at individual operation
+   cases."
+  [env sym]
+  (let [entry (get env sym)]
+    (if (map? entry) (:tag entry) entry)))
+
+(defn- late-env-element-tag
+  "Return the explicitly retained element tag from a rich type environment."
+  [env sym]
+  (let [entry (get env sym)]
+    (when (map? entry) (:element entry))))
+
 (defn infer-arg-tag
   "Infer the type tag of an expression in the late pipeline.
    Priority: env lookup → :tag metadata → resolved-var tag → structural analysis.
    Metadata-based inference is the primary mechanism."
   [expr env]
   (cond
-    (symbol? expr) (or (get env expr)
+    (symbol? expr) (or (late-env-tag env expr)
                        (:raster.type/tag (meta expr))
                        (:tag (meta expr))
                        (when (namespace expr) (var-ref-tag expr)))
@@ -1873,7 +1891,8 @@
             ;; non-mutating default of arg 1 would be wrong for scan).
             (contains? #{'raster.par/scan 'par/scan} head)
             (let [out-sym (second expr)]
-              (when (symbol? out-sym) (or (get env out-sym) (:tag (meta out-sym)))))
+              (when (symbol? out-sym)
+                (or (late-env-tag env out-sym) (:tag (meta out-sym)))))
             ;; Allocations: handle both direct (double-array size)
             ;; and devirtualized (.invk zeros-like_m_...-impl ref size) forms.
             ;; Stays inline rather than a :result-type facet entry: the rule is a
@@ -1896,10 +1915,11 @@
             ;; via env/:tag only — routing through the facet would narrow it.
             (descriptor/aget-op? head)
             (when (symbol? (second expr))
-              (let [arr-tag (or (get env (second expr)) (:tag (meta (second expr))))]
-                (get {'doubles 'double 'floats 'float 'longs 'long 'ints 'int
-                      'bytes 'byte 'shorts 'short 'chars 'char 'booleans 'boolean}
-                     arr-tag)))
+              (let [arr-sym (second expr)
+                    arr-tag (or (late-env-tag env arr-sym) (:tag (meta arr-sym)))]
+                (or (late-env-element-tag env arr-sym)
+                    (:raster.type/element (meta arr-sym))
+                    (get types/primitive-array-element-types arr-tag))))
             ;; :result-type facet — ops whose result tag derives from their arg
             ;; tags via a registry rule (op-descriptor): oftype → the ELEMENT
             ;; type of its ref (first arg) — `(n/oftype Q x)` is a float at

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -977,7 +977,7 @@
                   (let [walked (walk init env)
                         tag (or (inf/hint-tag sym) (inf/infer-arg-tag walked (:type-env env)))
                         env' (if tag (ctx-assoc-type env sym tag) env)]
-                    [env' (conj bindings sym walked)]))
+                    [env' (conj bindings (if tag (stamp-type-meta sym tag) sym) walked)]))
                 [index-env []]
                 (partition 2 element-bindings))
         combine-env
@@ -991,7 +991,7 @@
                   (let [walked (walk init env)
                         tag (or (inf/hint-tag sym) (inf/infer-arg-tag walked (:type-env env)))
                         env' (if tag (ctx-assoc-type env sym tag) env)]
-                    [env' (conj bindings sym walked)]))
+                    [env' (conj bindings (if tag (stamp-type-meta sym tag) sym) walked)]))
                 [combine-env []]
                 (partition 2 combine-bindings))
         hinted-outputs

--- a/src/raster/compiler/ir/dialects.clj
+++ b/src/raster/compiler/ir/dialects.clj
@@ -521,7 +521,8 @@
                                   (= 4 (count operation)))
                          (nth operation 3))]
               (and (seq? body)
-                   (contains? #{'scalar 'map 'scatter 'reduce 'segmented-reduce 'scan}
+                   (contains? #{'scalar 'map 'scatter 'reduce 'segmented-reduce
+                                'product-reduce 'scan}
                               (first body)))))
           (fn [_ algorithm]
             (= algorithm (soac-dialect/validate! algorithm))))

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -244,6 +244,42 @@
              (and (= 1 (count (:accumulators value)))
                   (result-transform? (:result-transform value)))))))
 
+(defn product-reduce-attributes?
+  "Attributes for an associative segmented product reduction.
+
+   `:result-components` aligns the equation's materialized result vector with component ordinals;
+   omitted ordinals participate in the algebra but require no output storage. The element and
+   combine regions remain explicit operation children rather than opaque attribute payloads."
+  [value]
+  (let [axes (:segment-axes value)
+        component-ids (:component-ids value)
+        component-count (count component-ids)
+        result-components (:result-components value)
+        indices (mapv first axes)]
+    (and (map-attributes? value)
+         (vector? axes) (seq axes)
+         (every? #(and (vector? %) (= 2 (count %))
+                       (symbol? (first %)) (extent? (second %)))
+                 axes)
+         (= (count indices) (count (distinct indices)))
+         (not (contains? (set indices) (:index value)))
+         (vector? component-ids) (pos? component-count)
+         (= component-count (count (distinct component-ids)))
+         (vector? (:accumulators value))
+         (= component-count (count (:accumulators value)))
+         (every? symbol? (:accumulators value))
+         (= component-count (count (distinct (:accumulators value))))
+         (vector? (:identities value))
+         (vector? (:dtypes value))
+         (= component-count (count (:identities value)) (count (:dtypes value)))
+         (every? #(and (keyword? %) (dtype/known? %) (= % (dtype/canon %)))
+                 (:dtypes value))
+         (vector? result-components) (seq result-components)
+         (= (count result-components) (count (distinct result-components)))
+         (every? #(and (integer? %) (<= 0 %) (< % component-count)) result-components)
+         (map? (:algebra value))
+         (true? (get-in value [:algebra :associative?])))))
+
 (defn scan-attributes?
   "Attributes for a certified scan dialect operation. The explicit mode is load-bearing because
    inclusive and exclusive scans have different observable result layouts."
@@ -293,6 +329,7 @@
              [xa scatter-attributes?]
              [ra reduce-attributes?]
              [sra segmented-reduce-attributes?]
+             [pra product-reduce-attributes?]
              [ca scan-attributes?]
              [dt keyword?]
              [facts program-facts?])
@@ -322,6 +359,8 @@
              (scatter ?xa [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
              (reduce ?ra [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
              (segmented-reduce ?sra [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
+             (product-reduce ?pra [(?:* ?id:array)] [(?:* ?id:capture)]
+                             ?l:element ?l:combine)
              (scan ?ca [(?:* ?id:array)] [(?:* ?id:capture)] ?l))
 
   (Equation [q :enforce]
@@ -365,7 +404,7 @@
    the parallel segment space followed by the innermost reduction extent."
   [equation]
   (let [{:keys [kind attributes]} (operation-parts equation)]
-    (if (= 'segmented-reduce kind)
+    (if (contains? #{'segmented-reduce 'product-reduce} kind)
       (conj (mapv second (:segment-axes attributes)) (:extent attributes))
       (if-let [extent (:extent attributes)] [extent] []))))
 
@@ -374,9 +413,17 @@
   [equation]
   (let [operation (nth equation 3)
         kind (first operation)]
-    (if (= 'scalar kind)
+    (cond
+      (= 'scalar kind)
       (let [[_ attributes captures lambda] operation]
         {:kind kind :attributes attributes :arrays [] :captures captures :lambda lambda})
+
+      (= 'product-reduce kind)
+      (let [[_ attributes arrays captures element-lambda combine-lambda] operation]
+        {:kind kind :attributes attributes :arrays arrays :captures captures
+         :element-lambda element-lambda :combine-lambda combine-lambda})
+
+      :else
       (let [[_ attributes arrays captures lambda] operation]
         {:kind kind :attributes attributes :arrays arrays :captures captures :lambda lambda}))))
 
@@ -451,8 +498,8 @@
 (defn parameter-layout
   "Split a SOAC lambda's ordered parameters into semantic roles."
   [equation]
-  (let [{:keys [kind attributes arrays captures lambda]} (operation-parts equation)
-        parameters (:parameters (lambda-parts lambda))
+  (let [{:keys [kind attributes arrays captures lambda element-lambda]} (operation-parts equation)
+        parameters (:parameters (lambda-parts (or lambda element-lambda)))
         accumulator-count (if (contains? #{'reduce 'segmented-reduce 'scan} kind)
                             (count (:accumulators attributes)) 0)
         array-count (count arrays)
@@ -473,8 +520,11 @@
 (defn- validate-equation!
   [equation]
   (let [[_ equation-id results operation] equation
-        {:keys [kind attributes arrays captures lambda]} (operation-parts equation)
-        {:keys [parameters locals body-results]} (lambda-parts lambda)
+        {:keys [kind attributes arrays captures lambda element-lambda combine-lambda]}
+        (operation-parts equation)
+        product? (= 'product-reduce kind)
+        {:keys [parameters locals body-results]} (lambda-parts (or lambda element-lambda))
+        component-count (when product? (count (:component-ids attributes)))
         result-count (count results)]
     (when-not (distinct-vector? results)
       (fail! :typed-soac-equation-results "SOAC equation results must be distinct"
@@ -505,7 +555,8 @@
         (fail! :typed-soac-region-binders
                "scalar-region parameters and local SSA definitions must be distinct"
                {:equation equation-id :parameters parameters :locals local-ids}))
-      (when (and (contains? #{'map 'scatter 'reduce 'segmented-reduce 'scan} kind)
+      (when (and (contains? #{'map 'scatter 'reduce 'segmented-reduce
+                              'product-reduce 'scan} kind)
                  (some #{(:index attributes)} local-ids))
         (fail! :typed-soac-region-binders
                "a scalar-region local cannot shadow its operation index"
@@ -520,13 +571,14 @@
         (fail! :typed-soac-local-dtype
                "scalar-region locals require a supported JVM scalar dtype"
                {:equation equation-id :local local :dtype dtype})))
-    (when (and (seq locals) (not (contains? #{'map 'scatter} kind)))
+    (when (and (seq locals) (not (contains? #{'map 'scatter 'product-reduce} kind)))
       (fail! :typed-soac-region-operation
-             "typed local SSA is currently admitted only in map/scatter scalar regions"
+             "typed local SSA is not admitted in this operation's scalar region"
              {:equation equation-id :operation kind :locals locals}))
-    (when-not (= result-count (count body-results))
+    (when-not (= (if product? component-count result-count) (count body-results))
       (fail! :typed-soac-result-arity "SOAC result and lambda arity differ"
-             {:equation equation-id :results result-count :body-results (count body-results)}))
+             {:equation equation-id :results result-count :components component-count
+              :body-results (count body-results)}))
     (let [expected-parameter-count (+ (if (contains? #{'reduce 'segmented-reduce 'scan} kind)
                                         (count (:accumulators attributes))
                                         0)
@@ -541,9 +593,10 @@
                 :arrays arrays
                 :captures captures})))
     (let [initial-bound (cond-> (set parameters)
-                          (contains? #{'map 'scatter 'reduce 'segmented-reduce 'scan} kind)
+                          (contains? #{'map 'scatter 'reduce 'segmented-reduce
+                                      'product-reduce 'scan} kind)
                           (conj (:index attributes))
-                          (= 'segmented-reduce kind)
+                          (contains? #{'segmented-reduce 'product-reduce} kind)
                           (into (map first (:segment-axes attributes))))
           final-bound
           (reduce (fn [bound {:keys [id init] :as local}]
@@ -632,6 +685,58 @@
               (fail! :typed-soac-result-transform-expression
                      "result-transform expressions may reference only their typed region boundary"
                      {:equation equation-id :unbound unbound :transform transform})))))
+
+      product-reduce
+      (let [result-components (:result-components attributes)
+            {combine-parameters :parameters
+             combine-locals :locals
+             combine-results :body-results}
+            (lambda-parts combine-lambda)]
+        (when (some write-form? body-results)
+          (fail! :typed-soac-product-reduce-element-write
+                 "product-reduce element results must be pure scalar values"
+                 {:equation equation-id :results body-results}))
+        (when-not (= result-count (count result-components))
+          (fail! :typed-soac-product-reduce-results
+                 "product-reduce results must align with materialized component ordinals"
+                 {:equation equation-id :results results
+                  :result-components result-components}))
+        (when-not (and (= (* 2 component-count) (count combine-parameters))
+                       (every? symbol? combine-parameters)
+                       (= (count combine-parameters) (count (distinct combine-parameters))))
+          (fail! :typed-soac-product-reduce-combine-parameters
+                 "product-reduce combine requires one distinct ordered left/right pair per component"
+                 {:equation equation-id :components component-count
+                  :parameters combine-parameters}))
+        (let [combine-bound
+              (loop [bound (set combine-parameters)
+                     [local & remaining] combine-locals]
+                (if-not local
+                  bound
+                  (let [{:keys [id dtype init]} local
+                        unbound (util/free-syms init bound)]
+                    (when-not (and (symbol? id) (keyword? dtype) (dtype/known? dtype)
+                                   (= dtype (dtype/canon dtype))
+                                   (:scalar-tag (dtype/info dtype)))
+                      (fail! :typed-soac-local-dtype
+                             "product-reduce combine locals require canonical scalar dtypes"
+                             {:equation equation-id :local local}))
+                    (when (or (contains? bound id) (seq unbound))
+                      (fail! :typed-soac-product-reduce-combine-local
+                             "combine locals may reference only component pairs and earlier locals"
+                             {:equation equation-id :local local :unbound unbound}))
+                    (recur (conj bound id) remaining))))]
+          (when-not (= component-count (count combine-results))
+            (fail! :typed-soac-product-reduce-combine-results
+                   "product-reduce combine result arity must equal component arity"
+                   {:equation equation-id :components component-count
+                    :results combine-results}))
+          (doseq [expression combine-results
+                  :let [unbound (util/free-syms expression combine-bound)]
+                  :when (seq unbound)]
+            (fail! :typed-soac-product-reduce-combine-closure
+                   "product-reduce combine must be a closed scalar binary operator"
+                   {:equation equation-id :expression expression :unbound unbound}))))
 
       scan
       (let [accumulators (:accumulators attributes)]
@@ -729,6 +834,20 @@
                      {:equation equation-id :id id :value value
                       :segment-axes (:segment-axes attributes) :dtype dtype})))))
 
+      product-reduce
+      (let [result-shape (segmented-reduce-result-shape attributes)
+            result-dtypes (mapv #((:dtypes attributes) %)
+                                (:result-components attributes))]
+        (doseq [[id dtype] (map vector results result-dtypes)]
+          (let [value (get values id)]
+            (when (and value
+                       (not (and (= :tensor (:kind value)) (= result-shape (:shape value))
+                                 (= dtype (:dtype value)))))
+              (fail! :typed-soac-product-reduce-result-type
+                     "product-reduce results must match their component dtype and segment space"
+                     {:equation equation-id :id id :value value
+                      :component-dtype dtype :segment-axes (:segment-axes attributes)})))))
+
       scan
       (doseq [[id dtype] (map vector results (:dtypes attributes))]
         (let [value (get values id)]
@@ -749,9 +868,9 @@
         {:keys [kind]} (operation-parts equation)
         storage (result-storage program-facts equation-id)]
     (when storage
-      (when-not (contains? #{'map 'scatter 'segmented-reduce} kind)
+      (when-not (contains? #{'map 'scatter 'segmented-reduce 'product-reduce} kind)
         (fail! :typed-soac-result-storage-operation
-               "physical result storage is valid only for map/scatter/segmented-reduce equations"
+               "physical result storage is valid only for writing tensor operations"
                {:equation equation-id :operation kind :storage storage}))
       (when-not (and (vector? storage)
                      (= (count results) (count storage))
@@ -918,13 +1037,14 @@
                           {} (:values source-facts))
         equation-forms
         (mapv (fn [[equals equation-id results :as equation]]
-                (let [{:keys [kind attributes arrays captures lambda]} (operation-parts equation)
+                (let [{:keys [kind attributes arrays captures lambda element-lambda combine-lambda]}
+                      (operation-parts equation)
                       attributes (cond-> attributes
                                    (seq (get-in attributes
                                                 [:attributes :stable-array-captures]))
                                    (update-in [:attributes :stable-array-captures]
                                               #(mapv rename %)))
-                      attributes (if (= 'segmented-reduce kind)
+                      attributes (if (contains? #{'segmented-reduce 'product-reduce} kind)
                                    (-> attributes
                                        (update :segment-axes
                                                #(mapv (fn [[index extent]]
@@ -939,11 +1059,20 @@
                                                     #(mapv (fn [scalar]
                                                              (update scalar :value rename)) %))))
                                    attributes)
-                      operation (if (= 'scalar kind)
+                      attributes (if (= 'scalar kind)
+                                   attributes
+                                   (update attributes :extent
+                                           #(if (value-id? %) (rename %) %)))
+                      operation (case kind
+                                  scalar
                                   (list kind attributes (mapv rename captures) lambda)
-                                  (list kind (update attributes :extent
-                                                     #(if (value-id? %) (rename %) %))
-                                        (mapv rename arrays) (mapv rename captures) lambda))]
+
+                                  product-reduce
+                                  (list kind attributes (mapv rename arrays)
+                                        (mapv rename captures) element-lambda combine-lambda)
+
+                                  (list kind attributes (mapv rename arrays)
+                                        (mapv rename captures) lambda))]
                   (list equals equation-id (mapv rename results) operation)))
               (equations program))
         rename-aliases

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -289,6 +289,9 @@
                              segmented-reduce
                              {:operations (soac-lower/lower-typed-segmented-reduce
                                            algorithm device-id :dtype dtype)}
+                             product-reduce
+                             {:operations (soac-lower/lower-typed-product-reduce
+                                           algorithm device-id :dtype dtype)}
                              scan (soac-lower/lower-typed-scan
                                    algorithm device-id :dtype dtype
                                    :array-types (:array-types opts)))

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -349,6 +349,75 @@
                        (if contraction? :contraction :segmented)
                        contraction-schedule output-dtype)])))
 
+(defn typed-product-reduce-program?
+  "Whether a validated one-equation TypedSOAC program is a product reduction."
+  [program]
+  (and (soac-dialect/program-form? program)
+       (= 1 (count (soac-dialect/equations program)))
+       (= 'product-reduce
+          (soac-dialect/operation-kind (first (soac-dialect/equations program))))))
+
+(defn lower-typed-product-reduce
+  "Mechanically project a typed two-region product reduction into the existing SegRed schedule."
+  [program device-id & {:keys [dtype] :or {dtype :double}}]
+  (let [program (soac-dialect/validate! program)]
+    (when-not (typed-product-reduce-program? program)
+      (throw (ex-info "typed product reduction lowering requires one product-reduce equation"
+                      {:reason :typed-soac-product-reduce-subset :program program})))
+    (let [equation (first (soac-dialect/equations program))
+          [_ equation-id results] equation
+          {:keys [attributes arrays captures element-lambda combine-lambda]}
+          (soac-dialect/operation-parts equation)
+          element (soac-dialect/lambda-parts element-lambda)
+          combine (soac-dialect/lambda-parts combine-lambda)
+          coordinate (flat-segment-coordinate (:segment-axes attributes)
+                                              (:index attributes) (:extent attributes))
+          array-count (count arrays)
+          element-parameters (:parameters element)
+          array-parameters (subvec element-parameters 0 array-count)
+          capture-parameters (subvec element-parameters array-count)
+          substitutions
+          (into (zipmap capture-parameters captures)
+                (map (fn [parameter array]
+                       [parameter (list 'clojure.core/aget array coordinate)])
+                     array-parameters arrays))
+          element-bindings
+          (vec (mapcat (fn [{:keys [id init]}]
+                         [id (util/subst-syms substitutions init)])
+                       (:locals element)))
+          element-results (mapv #(util/subst-syms substitutions %)
+                                (:body-results element))
+          combine-bindings
+          (vec (mapcat (fn [{:keys [id init]}] [id init]) (:locals combine)))
+          facts (soac-dialect/facts program)
+          physical-results (soac-dialect/physical-results facts equation)
+          result-by-component (zipmap (:result-components attributes) physical-results)
+          components
+          (mapv (fn [ordinal component-id accumulator neutral component-dtype]
+                  {:id component-id :accumulator accumulator :neutral neutral
+                   :dtype component-dtype :result (get result-by-component ordinal)})
+                (range) (:component-ids attributes) (:accumulators attributes)
+                (:identities attributes) (:dtypes attributes))
+          operator
+          (reduction/make
+           {:components components :index (:index attributes)
+            :element-bindings element-bindings :element-results element-results
+            :combine-parameters (mapv vec (partition 2 (:parameters combine)))
+            :combine-bindings combine-bindings :combine-results (:body-results combine)
+            :algebra (:algebra attributes)
+            :attributes {:source :typed-soac :equation equation-id :segmented true}})
+          stable (set (get-in attributes [:attributes :stable-array-captures]))
+          inputs (into (set arrays) stable)
+          scalars (set/difference (set captures) stable)
+          output-dtype (or (first (:dtypes attributes)) dtype :double)
+          node (cond-> (soac/->SoacReduce equation-id (first results) operator
+                                           (:segment-axes attributes) (:extent attributes)
+                                           inputs (vec (keep :result components)) scalars)
+                 output-dtype (assoc :elem-type output-dtype))]
+      (mapv #(assoc % :algorithm-dialect :typed-soac
+                    :algorithm-equation equation-id)
+            (lower-reduce node device-id :dtype output-dtype)))))
+
 (defn typed-scan-program?
   "Whether a validated one-equation TypedSOAC program is a certified scan."
   [program]

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -66,6 +66,20 @@
     (or (dtype/dtype-for-scalar-tag (types/sym-type-tag binding))
         (dtype/dtype-for-scalar-tag init-tag))))
 
+(defn- typed-region-locals
+  "Translate a flat source binding vector into explicit typed lexical SSA.
+
+   This is deliberately metadata-only: a missing walker/TypedClojure fact declines the direct
+   route instead of introducing another local type inference registry."
+  [bindings]
+  (when (and (vector? bindings) (even? (count bindings)))
+    (let [locals (mapv (fn [[binding init]]
+                         {:id binding :dtype (retained-local-dtype binding init) :init init})
+                       (partition 2 bindings))]
+      (when (and (= (count locals) (count (distinct (map :id locals))))
+                 (every? :dtype locals))
+        locals))))
+
 (defn- pointwise-region
   "Recognize an ordered, pure local-SSA spine ending exclusively in indexed stores.
 
@@ -281,6 +295,62 @@
                                :stores [{:out out1 :value body1 :cast cast}
                                         {:out out2 :value body2 :cast cast}]}
                               elem-type))
+
+    (par/par-product-reduce-form? expression)
+    (let [{:keys [outputs components segment-axes idx bound element-bindings element-results
+                  combine-parameters combine-bindings combine-results algebra]}
+          (par/extract-par-product-reduce-info expression)
+          materialized (vec (keep-indexed (fn [ordinal output]
+                                            (when (symbol? output) [ordinal output]))
+                                          outputs))
+          element-locals (typed-region-locals element-bindings)
+          combine-locals (typed-region-locals combine-bindings)
+          element-form (list 'let* element-bindings (vec element-results))
+          combine-form (list 'let* combine-bindings (vec combine-results))
+          component-records
+          (mapv (fn [ordinal [accumulator neutral component-dtype] output]
+                  {:id (keyword (str "component-" ordinal))
+                   :accumulator accumulator :neutral neutral
+                   :dtype (dtype/canon component-dtype) :result output})
+                (range) components outputs)
+          product (when (and (seq materialized)
+                             (true? (:associative? algebra))
+                             (some? element-locals) (some? combine-locals))
+                    (reduction/make
+                     {:components component-records :index idx
+                      :element-bindings element-bindings :element-results element-results
+                      :combine-parameters combine-parameters
+                      :combine-bindings combine-bindings :combine-results combine-results
+                      :algebra algebra
+                      :attributes {:source :raster.par/product-reduce!}}))
+          inputs (par/collect-aget-arrays element-form)
+          binders (set (concat (map first segment-axes) [idx]
+                               (map first components)
+                               (take-nth 2 element-bindings)
+                               (mapcat identity combine-parameters)
+                               (take-nth 2 combine-bindings)))
+          output-set (set (map second materialized))
+          scalar-uses (set/union
+                       (util/free-syms element-form)
+                       (util/free-syms combine-form)
+                       (reduce set/union #{}
+                               (map (comp util/free-syms second) components))
+                       (reduce set/union #{} (map (comp util/free-syms second) segment-axes))
+                       (util/free-syms bound))
+          scalars (set/difference scalar-uses inputs output-set binders
+                                  descriptor/aget-ops descriptor/aset-ops
+                                  #{'do 'let 'let* 'if 'double 'float 'int 'long})
+          results (mapv #(effect-result-id id (first %)) materialized)
+          storage (mapv (fn [[_ output]]
+                          {:destination output :access :write :host-return :effect})
+                        materialized)]
+      (when product
+        {:kind :product-reduce :id id :sym symbol
+         :segment-axes segment-axes :reduce-index idx :reduce-extent bound
+         :results results :result-components (mapv first materialized)
+         :product product :inputs inputs :outputs output-set :scalars scalars
+         :element-locals element-locals :combine-locals combine-locals
+         :effect-only? true :host-binding symbol :result-storage storage}))
 
     (par/par-reduce-form? expression)
     (let [{:keys [acc init idx bound body elem-type]} (par/extract-par-reduce-info expression)
@@ -501,7 +571,8 @@
 (defn- physical-output-symbols
   [descriptions]
   (reduce set/union #{}
-          (map #(if (contains? #{:map :scatter :reduce :segmented-reduce :scan} (:kind %))
+          (map #(if (contains? #{:map :scatter :reduce :segmented-reduce
+                                 :product-reduce :scan} (:kind %))
                   (:outputs %) #{})
                descriptions)))
 
@@ -523,6 +594,10 @@
                 :reduce true
                 :segmented-reduce (and (seq (:segment-axes description))
                                        (symbol? (get-in description [:result-storage 0 :destination])))
+                :product-reduce (and (seq (:segment-axes description))
+                                     (seq (:result-components description))
+                                     (every? (comp symbol? :destination)
+                                             (:result-storage description)))
                 :scan (symbol? (:primary-out description))
                 false))
             descriptions)))
@@ -657,6 +732,39 @@
                  (vec (concat [(:accumulator component)] capture-parameters))
                  step-results)))))
 
+(defn- product-reduce-equation
+  [{:keys [id segment-axes reduce-index reduce-extent inputs scalars product results
+           result-components element-locals combine-locals]}]
+  (let [captures (vec (sort-by pr-str (distinct (concat inputs scalars))))
+        capture-parameters (capture-symbols (count captures))
+        substitutions (zipmap captures capture-parameters)
+        element-region (reduction/element-region product)
+        combine-region (reduction/combine-region product)
+        element-locals
+        (mapv #(update % :init (fn [init] (util/subst-syms substitutions init)))
+              element-locals)
+        element-results (mapv #(util/subst-syms substitutions %)
+                              (:results element-region))]
+    (list '= id results
+          (list 'product-reduce
+                {:segment-axes segment-axes :index reduce-index :extent reduce-extent
+                 :component-ids (mapv :id (:components product))
+                 :accumulators (reduction/accumulators product)
+                 :identities (reduction/neutrals product)
+                 :dtypes (reduction/dtypes product)
+                 :result-components result-components
+                 :algebra (:algebra product)
+                 :attributes {:stable-array-captures (vec (sort-by pr-str inputs))
+                              :source-operation :raster.par/product-reduce!}}
+                [] captures
+                (dialect/lambda-form capture-parameters
+                                     (dialect/emit-locals element-locals)
+                                     element-results)
+                (dialect/lambda-form
+                 (vec (mapcat identity (:parameters combine-region)))
+                 (dialect/emit-locals combine-locals)
+                 (:results combine-region))))))
+
 (defn- scan-equation
   [{:keys [id sym index extent mode inputs scalars primary-out accumulator identity dtype body]}]
   (let [[pointwise stable] ((juxt filter remove) #(pointwise-input? [body] % index) inputs)
@@ -710,11 +818,13 @@
 (defn- terminal-results
   [descriptions body]
   (let [physical-outputs (physical-output-symbols descriptions)
-        operations (filter #(contains? #{:map :scatter :reduce :segmented-reduce :scan} (:kind %)) descriptions)
+        operations (filter #(contains? #{:map :scatter :reduce :segmented-reduce
+                                         :product-reduce :scan} (:kind %)) descriptions)
         operation-definitions (set (mapcat #(case (:kind %)
                                               (:map :scatter) (:results %)
                                               :scan [(:sym %)]
                                               :segmented-reduce (:results %)
+                                              :product-reduce (:results %)
                                               (:outputs %))
                                            operations))
         terminal-operation-definitions
@@ -722,6 +832,7 @@
                         (:map :scatter) (if (:effect-only? %) [] (:results %))
                         :scan [(:sym %)]
                         :segmented-reduce (if (:effect-only? %) [] (:results %))
+                        :product-reduce (if (:effect-only? %) [] (:results %))
                         (:outputs %))
                      operations))
         scalar-definitions
@@ -782,6 +893,8 @@
                         scalar (:dtypes attributes)
                         reduce (:dtypes attributes)
                         segmented-reduce (:dtypes attributes)
+                        product-reduce (mapv #((:dtypes attributes) %)
+                                             (:result-components attributes))
                         scan (:dtypes attributes)
                         (map scatter) (map #(value-dtype % default-dtype array-types) results))]
     (merge
@@ -817,6 +930,8 @@
                                        (case kind
                                          (scalar reduce) []
                                          segmented-reduce
+                                         (dialect/segmented-reduce-result-shape attributes)
+                                         product-reduce
                                          (dialect/segmented-reduce-result-shape attributes)
                                          scan (dialect/scan-result-shape attributes)
                                          scatter [(list 'unknown-dimension id)]
@@ -855,11 +970,13 @@
                  (seq descriptions)
                  (supported-descriptions? descriptions))
         (let [operation-descriptions
-              (filterv #(contains? #{:map :scatter :reduce :segmented-reduce :scan} (:kind %)) descriptions)
+              (filterv #(contains? #{:map :scatter :reduce :segmented-reduce
+                                     :product-reduce :scan} (:kind %)) descriptions)
               operation-equations (mapv #(case (:kind %) :map (map-equation %)
                                                :scatter (scatter-equation %)
                                                :reduce (reduce-equation %)
                                                :segmented-reduce (segmented-reduce-equation %)
+                                               :product-reduce (product-reduce-equation %)
                                                :scan (scan-equation %))
                                         operation-descriptions)
               outputs (terminal-results descriptions body)
@@ -876,7 +993,7 @@
                                   (update :equation-descriptions conj description)
                                   (assoc-in [:scalar-dtypes (:sym description)] result-dtype)))
                             state)
-                          (:map :scatter :reduce :segmented-reduce :scan)
+                          (:map :scatter :reduce :segmented-reduce :product-reduce :scan)
                           (-> state
                               (update :equations conj
                                       (case (:kind description)
@@ -884,6 +1001,7 @@
                                         :scatter (scatter-equation description)
                                         :reduce (reduce-equation description)
                                         :segmented-reduce (segmented-reduce-equation description)
+                                        :product-reduce (product-reduce-equation description)
                                         :scan (scan-equation description)))
                               (update :equation-descriptions conj description))))
                       {:equations [] :equation-descriptions [] :scalar-dtypes {}}

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -60,6 +60,20 @@
                                 :local-definitions local-definitions
                                 :body-results body-results}))))
 
+(def ^:private product-reduce-equation-rule
+  (from-dialect dialect/TypedSOAC
+                (rule '(= ?equation-id [??results]
+                          (product-reduce ?attributes [??arrays] [??captures]
+                                          ?element-lambda ?combine-lambda))
+                      (success {:kind :product-reduce
+                                :id equation-id
+                                :results results
+                                :attributes attributes
+                                :arrays arrays
+                                :captures captures
+                                :element-lambda element-lambda
+                                :combine-lambda combine-lambda}))))
+
 (def ^:private scatter-equation-rule
   (from-dialect dialect/TypedSOAC
                 (rule '(= ?equation-id [??results]
@@ -115,10 +129,11 @@
                     (scatter-equation-rule equation)
                     (reduce-equation-rule equation)
                     (segmented-reduce-equation-rule equation)
+                    (product-reduce-equation-rule equation)
                     (scan-equation-rule equation)])]
-    (let [lambda (:lambda (dialect/operation-parts equation))]
+    (let [{:keys [lambda element-lambda]} (dialect/operation-parts equation)]
       (merge (dissoc matched :local-definitions)
-             (dialect/lambda-parts lambda)))))
+             (dialect/lambda-parts (or lambda element-lambda))))))
 
 (defn- equation-references
   [equation]

--- a/src/raster/compiler/passes/parallel/typed_soac_projection.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_projection.clj
@@ -118,3 +118,47 @@
   [program equation]
   (contraction-facts/surface-form
    (segmented-reduce-contract-components program equation)))
+
+(defn- source-bindings
+  [locals substitutions]
+  (vec
+   (mapcat (fn [{:keys [id dtype init]}]
+             (let [tag (dtype/scalar-tag-for-dtype dtype)]
+               [(with-meta id {:raster.type/tag tag})
+                (list tag (util/subst-syms substitutions init))]))
+           locals)))
+
+(defn product-reduce-form
+  "Spell one validated product-reduce equation in Raster's interpreted host vocabulary."
+  [program equation]
+  (let [program (dialect/validate! program)
+        [_ equation-id results] equation
+        {:keys [kind attributes captures element-lambda combine-lambda]}
+        (dialect/operation-parts equation)
+        physical-results (dialect/physical-results program equation)
+        component-count (count (:component-ids attributes))
+        result-components (:result-components attributes)
+        outputs (reduce (fn [outputs [component result]] (assoc outputs component result))
+                        (vec (repeat component-count nil))
+                        (map vector result-components physical-results))
+        element (dialect/lambda-parts element-lambda)
+        element-substitutions (zipmap (:parameters element) captures)
+        combine (dialect/lambda-parts combine-lambda)
+        _ (when-not (= 'product-reduce kind)
+            (throw (ex-info "product projection requires a product-reduce equation"
+                            {:reason :typed-soac-product-projection
+                             :equation equation-id :kind kind :results results})))
+        form
+        (list 'raster.par/product-reduce!
+              outputs
+              (mapv vector (:accumulators attributes)
+                    (:identities attributes) (:dtypes attributes))
+              (:segment-axes attributes) (:index attributes) (:extent attributes)
+              (source-bindings (:locals element) element-substitutions)
+              (mapv #(util/subst-syms element-substitutions %) (:body-results element))
+              (mapv vec (partition 2 (:parameters combine)))
+              (source-bindings (:locals combine) {})
+              (:body-results combine)
+              (:algebra attributes))]
+    (with-meta form {:raster.type/elem-type
+                     ((:dtypes attributes) (first result-components))})))

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -40,8 +40,9 @@
 
 (defn- scalar-region
   [equation]
-  (let [{:keys [attributes arrays captures lambda]} (dialect/operation-parts equation)
-        {:keys [locals body-results]} (dialect/lambda-parts lambda)
+  (let [{:keys [attributes arrays captures lambda element-lambda]}
+        (dialect/operation-parts equation)
+        {:keys [locals body-results]} (dialect/lambda-parts (or lambda element-lambda))
         {:keys [elements capture-parameters]} (dialect/parameter-layout equation)
         substitutions
         (into (zipmap capture-parameters captures)
@@ -237,6 +238,16 @@
          :site [:binding host-binding]
          :source source})
 
+      product-reduce
+      (let [host-binding (or (get-in placement-facts [:attributes :host-binding])
+                             (first results))
+            source (projection/product-reduce-form program equation)]
+        {:equation-id equation-id
+         :placement placement
+         :pairs [[host-binding source]]
+         :site [:binding host-binding]
+         :source source})
+
       scan
       (let [result (first results)
             mode (:mode attributes)
@@ -382,7 +393,8 @@
                (if resident-reductions?
                  (resident/realize typed-result)
                  [typed-result {:resident-reductions 0 :inlined-scalars 0}])]
-           (if (not-any? #(contains? #{:map :scatter :reduce :segmented-reduce :scan}
+           (if (not-any? #(contains? #{:map :scatter :reduce :segmented-reduce
+                                       :product-reduce :scan}
                                      (:kind (fusion/equation-info %)))
                          (dialect/equations typed-result))
              {:declined {:reason :no-certified-parallel-equation

--- a/test/raster/compiler/core/inference_test.clj
+++ b/test/raster/compiler/core/inference_test.clj
@@ -131,6 +131,21 @@
     (is (= 'java.util.Random (inf/infer-arg-tag '(java.util.Random.) {})))
     (is (= 'Foo (inf/infer-arg-tag '(Foo. 1 2) {})))))
 
+(deftest infer-arg-tag-accepts-rich-walker-environments-test
+  (testing "symbols and primitive array reads retain walker-owned type facts"
+    (let [env {'values {:tag 'floats}
+               'objects {:tag 'objects :element 'double}
+               'row {:tag 'long}}]
+      (is (= 'long (inf/infer-arg-tag 'row env)))
+      (is (= 'float
+             (inf/infer-arg-tag '(clojure.core/aget values row) env)))
+      (is (= 'double
+             (inf/infer-arg-tag '(clojure.core/aget objects row) env)))))
+  (testing "the compact late-pass environment remains supported"
+    (is (= 'float
+           (inf/infer-arg-tag '(clojure.core/aget values row)
+                              {'values 'floats 'row 'long})))))
+
 ;; ================================================================
 ;; trace-inference
 ;; ================================================================

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -239,6 +239,79 @@
     (is (= :typed-soac (get-in (-> scheduled :form :equations first)
                                [:attributes :algorithm-dialect])))))
 
+(deftest product-reduction-keeps-discarded-components-out-of-ssa-results
+  (let [expression
+        '(raster.par/product-reduce!
+          [nil indices]
+          [[best-value -1.0e38 :float] [best-index 2147483647 :int]]
+          [[row nrows]] col width
+          []
+          [(clojure.core/aget values (clojure.core/+ (clojure.core/* row width) col))
+           (int col)]
+          [[left-value right-value] [left-index right-index]]
+          []
+          [(if (> right-value left-value) right-value left-value)
+           (if (> right-value left-value) right-index left-index)]
+          {:associative? true :commutative? true})
+        source (list 'let* ['effect expression] 'effect)
+        options {:dtype :float
+                 :array-types {'values :float 'indices :int}
+                 :scalar-types {'nrows :long 'width :long}}
+        program (frontend/form->program source options)
+        equation (first (dialect/equations program))
+        operation (dialect/operation-parts equation)
+        routed (route/attempt source :float (:array-types options)
+                              {:scalar-types (:scalar-types options)})
+        scheduled
+        ((requiring-resolve
+          'raster.compiler.passes.parallel.segop-lower-pass/segop-lower-pass)
+         (:program routed) {:target-device :ocl:0 :dtype :float})
+        product (-> scheduled :form :equations first :operations first)
+        remapped (dialect/remap-values program {'values [:binding 'values]})
+        remapped-operation (dialect/operation-parts
+                            (first (dialect/equations remapped)))]
+    (is (= 'product-reduce (:kind operation)))
+    (is (= [1] (get-in operation [:attributes :result-components])))
+    (is (= [:float :int] (get-in operation [:attributes :dtypes])))
+    (is (= 1 (count (nth equation 2)))
+        "the winning value remains an algebra component but is not a fake SSA output")
+    (is (= ['indices] (dialect/physical-results program equation)))
+    (is (= program (dialect/validate! program)))
+    (is (= :analyzed-source (get-in routed [:stats :front-end])))
+    (is (instance? raster.compiler.ir.segop.SegRed product))
+    (is (= :product (:phase product)))
+    (is (= [:float :int] (reduction/dtypes (:reduction product))))
+    (is (= #{'indices} (:outputs product)))
+    (is (= :typed-soac (:algorithm-dialect product)))
+    (is (some #{[:binding 'values]} (:captures remapped-operation)))
+    (is (= (:element-lambda operation) (:element-lambda remapped-operation)))
+    (is (= (:combine-lambda operation) (:combine-lambda remapped-operation)))
+    (is (= remapped (dialect/validate! remapped)))))
+
+(deftest product-reduction-combine-is-a-closed-scalar-region
+  (let [expression
+        '(raster.par/product-reduce!
+          [nil indices]
+          [[best-value -1.0e38 :float] [best-index 2147483647 :int]]
+          [[row nrows]] col width
+          []
+          [(clojure.core/aget values (clojure.core/+ (clojure.core/* row width) col))
+           (int col)]
+          [[left-value right-value] [left-index right-index]]
+          []
+          [row (if (> right-value left-value) right-index left-index)]
+          {:associative? true :commutative? true})]
+    (try
+      (frontend/form->program
+       (list 'let* ['effect expression] 'effect)
+       {:dtype :float
+        :array-types {'values :float 'indices :int}
+        :scalar-types {'nrows :long 'width :long}})
+      (is false "a segment-axis capture must not enter the binary combine algebra")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :typed-soac-product-reduce-combine-closure
+               (:reason (ex-data exception))))))))
+
 (deftest explicit-contraction-result-transform-stays-in-typed-soac
   (let [transform {:acc 'acc
                    :expr '(raster.numeric/+ acc (clojure.core/aget bias j))

--- a/test/raster/dl/indexed_reduction_test.clj
+++ b/test/raster/dl/indexed_reduction_test.clj
@@ -41,6 +41,8 @@
                                  [target (pipeline/compile-gpu-program
                                           #'ops/argmax-rows! target :dtype :float)]))
                           [:ocl:0 :ze:0])
+        report (pipeline/compile-report
+                #'ops/argmax-rows! :target-device :ocl:0 :dtype :float)
         descriptor (get descriptors :ocl:0)
         allocs (:allocs descriptor)
         steps (:steps descriptor)
@@ -60,6 +62,14 @@
       (is (= :segmented-workgroup-tree
              (get-in steps [0 :artifact :attributes :schedule :strategy]))))
     (testing "the typed product reduction is one resident scheduled step"
+      (is (= {:backend :opencl
+              :source-dialect :typed-soac
+              :typed-validated true
+              :declines []}
+             (:route report)))
+      (is (= 1 (get-in report [:lowering :typed-reused])))
+      (is (zero? (get-in report [:lowering :backend-relowered])))
+      (is (zero? (get-in report [:lowering :fallback])))
       (is (= [:map-void] (mapv :convention steps)))
       (is (= 1 (count steps)))
       (is (= ['values 'indices]


### PR DESCRIPTION
## Outcome

Adds a first-class typed product-reduction operation with separate element and associative combine regions, then routes the public deterministic row-wise argmax kernel through it.

The operation represents mixed-dtype reduction products (for example float value plus int index) without exposing discarded algebra components as fake SSA outputs or allocating storage for them.

## Compiler effect

- explicit typed component identities, dtypes, algebra, and materialized result ordinals
- closed scalar combine region with typed lexical SSA
- mechanical TypedSOAC projection into the existing mixed-dtype workgroup-tree scheduler
- public argmax-rows! now reports source-dialect typed-soac, one typed reuse, zero backend re-lowering, and zero fallback
- shared inference now reads both rich walker and compact late-pass type environments; no new function or type registry

## Validation

Locally: 91 focused tests and 607 assertions across inference, TypedSOAC dialect, frontend, route, reductions, compatibility ledger, and the public resident argmax kernel. Full suite and emitter compile gates are delegated to CircleCI.

Stacked on #225; rebase target becomes main after that lands.