### PR TITLE
Lower ordered segmented folds through TypedSOAC

### DIFF
--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -352,15 +352,25 @@
 
 (defn c-symbol
   "Convert a Clojure symbol name to a valid C identifier.
-  Appends _ suffix for C/GLSL/OpenCL reserved word collisions."
+  Appends _ suffix for C/GLSL/OpenCL reserved word collisions. Non-ASCII and
+  otherwise unsupported characters are escaped by Unicode code point so alpha-
+  renamed Clojure binders remain portable across OpenCL, CUDA, and HIP without
+  collapsing distinct source identities."
   [sym]
-  (let [s (-> (name sym)
-              (str/replace "-" "_")
-              (str/replace "*" "_star_")
-              (str/replace "/" "_slash_")
-              (str/replace "?" "_p")
-              (str/replace "!" "_b")
-              (str/replace "'" "_prime"))]   ; Clojure allows ' in symbols (a', x'); C does not
+  (let [source (-> (name sym)
+                   (str/replace "-" "_")
+                   (str/replace "*" "_star_")
+                   (str/replace "/" "_slash_")
+                   (str/replace "?" "_p")
+                   (str/replace "!" "_b")
+                   (str/replace "'" "_prime")) ; Clojure allows ' in symbols; C does not.
+        ascii? (fn [ch]
+                 (or (= ch \_)
+                     (<= (int \a) (int ch) (int \z))
+                     (<= (int \A) (int ch) (int \Z))
+                     (<= (int \0) (int ch) (int \9))))
+        s (apply str (map #(if (ascii? %) (str %) (format "_u%04x_" (int %))) source))
+        s (if (and (seq s) (Character/isDigit ^char (first s))) (str "_" s) s)]
     (if (contains? c-reserved-words s)
       (str s "_")
       s)))

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -28,7 +28,17 @@
       (str/replace #"[^A-Za-z0-9_]" "_")
       (str/replace #"^[^A-Za-z_]" "_$0")))
 
-(declare emit-index-expression)
+(declare emit-index-expression target-type)
+
+(defn- index-expression-dtype
+  [expression types]
+  (cond
+    (integer? expression) :int
+    (value-id? expression) (get types expression :int)
+    (record-kind? "IndexCast" expression) (dtype/canon (:dtype expression))
+    (record-kind? "IndexExpr" expression)
+    (or (some-> (:arguments expression) first (index-expression-dtype types)) :int)
+    :else :int))
 
 (defn- emit-infix [operator arguments env]
   (str "(" (str/join (str " " operator " ")
@@ -39,6 +49,10 @@
   (cond
     (number? expression) (str expression)
     (value-id? expression) (or (get env expression) (target-name expression))
+    (record-kind? "IndexCast" expression)
+    (str "("
+         (target-type (:dtype expression))
+         ")(" (emit-index-expression (:argument expression) env) ")")
     (record-kind? "IndexExpr" expression)
     (let [arguments (:arguments expression)]
       (case (:op expression)
@@ -183,6 +197,8 @@
   (cond
     (value-id? expression) #{expression}
     (number? expression) #{}
+    (record-kind? "IndexCast" expression)
+    (expression-references (:argument expression))
     (record-kind? "IndexExpr" expression)
     (reduce into #{} (map expression-references (:arguments expression)))
     :else #{}))
@@ -1553,7 +1569,11 @@
         names (reduce (fn [env index]
                         (assoc env (:id index) (scalar-local-name (:id index))))
                       (merge parameter-names allocation-names) indices)
-        types (reduce (fn [env index] (assoc env (:id index) :int))
+        types (reduce (fn [env index]
+                        (assoc env (:id index)
+                               (if (record-kind? "IndexBinding" index)
+                                 :int
+                                 (index-expression-dtype (:expression index) env))))
                       (into {}
                             (map (fn [parameter]
                                    [(:id parameter) (dtype/canon (:dtype parameter))])
@@ -1610,7 +1630,7 @@
                             (get-in kernel-body [:schedule :subgroup-size]))
                            ";"))
                      (indent-lines
-                      1 (str "int " name " = "
+                      1 (str (target-type (get types (:id index))) " " name " = "
                              (emit-index-expression (:expression index) names) ";"))))))
         [operation-source _] (emit-scalar-operations (:operations kernel-body) context 1)
         storage-declarations (concat parameters (:allocations kernel-body))

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -585,6 +585,24 @@
                   k (register-kernel! kernel :ze-reduces)]
               (emit-map-void-invocation k device-id))
 
+            ;; Ordered segmented fold-map. The source spelling is only a host fallback; GPU
+            ;; emission must consume the bound TypedSOAC SegFoldMap and its verified KernelBody.
+            (par/par-segmented-fold-map-form? form)
+            (if-let [scheduled (take-bound-segop
+                                stats :segfoldmap
+                                #(and (instance? raster.compiler.ir.segop.SegFoldMap %)
+                                      (= :typed-soac (:algorithm-dialect %))))]
+              (let [kernel (segop-cl/generate-segfoldmap-kernel
+                            scheduled
+                            :workgroup-size (or (get-in scheduled [:grid :block-size]) 256)
+                            :scalar-types top-scalar-types
+                            :array-types top-array-types)
+                    k (register-kernel! kernel :ze-maps)]
+                (emit-map-void-invocation k device-id))
+              (throw (ex-info "GPU fold-map source has no verified TypedSOAC schedule"
+                              {:reason :unscheduled-segmented-fold-map
+                               :target-dialect :opencl :form form})))
+
             ;; === Specialized forms — delegate to legacy generators ===
 
             ;; par/map-void!

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -28,6 +28,7 @@
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.passes.parallel.register-tiled-body :as register-tiled-body]
             [raster.compiler.passes.parallel.segred-body :as segred-body]
+            [raster.compiler.passes.parallel.segfoldmap-body :as segfoldmap-body]
             [clojure.walk :as walk]
             [clojure.set]
             [raster.compiler.ir.segop :as segop]
@@ -395,6 +396,52 @@
       :provenance {:dialect :segstencil :segop-id (:id segstencil)}
       :attributes {:array-params inputs :scalar-params scalars :out-param out
                    :dtype dtype :aliasing :no-write-alias}})))
+
+(defn generate-segfoldmap-kernel
+  "Schedule and emit one ordered SegFoldMap through the shared scalar KernelBody dialect."
+  [segfoldmap & {:keys [kernel-name-prefix target-dialect workgroup-size scalar-types array-types]
+                 :or {kernel-name-prefix "segmented_fold_map"
+                      target-dialect :opencl-intel workgroup-size 256
+                      scalar-types {} array-types {}}}]
+  (let [{:keys [kernel-body segment-count]}
+        (segfoldmap-body/lower segfoldmap
+                              {:workgroup-size workgroup-size
+                               :scalar-types scalar-types :array-types array-types})
+        parameters (:parameters kernel-body)
+        kernel-name (str kernel-name-prefix "_" (gensym ""))
+        parameter-names (into {}
+                              (map (fn [parameter]
+                                     [(:id parameter) (ce/c-symbol (:id parameter))]))
+                              parameters)
+        source (kernel-body-opencl/emit-scalar-kernel
+                kernel-name kernel-body
+                {:target-dialect target-dialect :parameter-names parameter-names})
+        abi (body-abi/project-contracts
+             (mapv (fn [{:keys [id kind dtype role]}]
+                     (kabi/slot id kind dtype :c-name (get parameter-names id)
+                                :role (if (= id '_nseg) :bound role)))
+                   parameters)
+             kernel-body)
+        arguments (mapv (fn [parameter]
+                          (if (= '_nseg (:id parameter)) segment-count (:id parameter)))
+                        parameters)]
+    (kart/make
+     {:kernel-name kernel-name
+      :source source
+      :abi abi
+      :arguments arguments
+      :launch (:launch kernel-body)
+      :temporaries []
+      :effects {:kind :segmented-fold-map :association :ordered}
+      :target (kernel-body-c-dialect/target
+               (kernel-body-c-dialect/resolve! target-dialect))
+      :provenance {:dialect :kernel-body :source-dialect :segfoldmap
+                   :segop-id (:id segfoldmap)}
+      :attributes {:kernel-body kernel-body
+                   :array-params (vec (concat (:inputs segfoldmap) (:outputs segfoldmap)))
+                   :scalar-params (vec (:scalars segfoldmap))
+                   :dtype (first (:dtypes segfoldmap))
+                   :aliasing :no-write-alias}})))
 
 ;; ================================================================
 ;; SegRed → OpenCL kernel (two-phase reduction)

--- a/src/raster/compiler/core/op_descriptor.clj
+++ b/src/raster/compiler/core/op_descriptor.clj
@@ -573,12 +573,22 @@
 
 (def increment-ops
   "All symbol variants recognized as increment."
-  #{'inc 'unchecked-inc 'clojure.core/inc 'clojure.core/unchecked-inc})
+  #{'inc 'unchecked-inc 'unchecked-inc-int
+    'clojure.core/inc 'clojure.core/unchecked-inc 'clojure.core/unchecked-inc-int})
 
 (defn increment-op?
   "True if sym is an increment operation."
   [sym]
   (contains? increment-ops sym))
+
+(def decrement-ops
+  "All symbol variants recognized as decrement."
+  #{'dec 'unchecked-dec 'unchecked-dec-int
+    'clojure.core/dec 'clojure.core/unchecked-dec 'clojure.core/unchecked-dec-int})
+
+(defn decrement-op?
+  [sym]
+  (contains? decrement-ops sym))
 
 (defn semantic-op
   "The semantic operator of a call form. For a walker-devirtualized

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -208,6 +208,14 @@
                resolved (if (and (symbol? head) (namespace head))
                           (resolve-aliased-symbol head (:source-ns ctx))
                           head)]
+           (= 'raster.par/segmented-fold-map! resolved)))
+    :par-segmented-fold-map
+
+    (and (seq? form)
+         (let [head (first form)
+               resolved (if (and (symbol? head) (namespace head))
+                          (resolve-aliased-symbol head (:source-ns ctx))
+                          head)]
            (= 'raster.par/scan resolved)))
     :par-scan
 
@@ -1011,6 +1019,43 @@
           (vec walked-combine-bindings)
           (mapv #(walk % combine-result-env) combine-results)
           algebra)))
+
+(defmethod walk-form :par-segmented-fold-map
+  [form ctx]
+  (let [[_ outputs segment-axes idx-sym map-extent folds map-results] form
+        dtype-tag {:float 'float :double 'double :int 'int :long 'long :byte 'byte}
+        index-env (reduce (fn [env [segment _]] (ctx-assoc-type env segment 'long))
+                          (ctx-assoc-type ctx idx-sym 'long)
+                          segment-axes)
+        [fold-env walked-folds]
+        (reduce (fn [[env result] [acc identity component-dtype extent step]]
+                  (let [walked-identity (walk identity env)
+                        tag (or (get dtype-tag component-dtype)
+                                (when (= :element component-dtype)
+                                  (get dtype-tag (:element-dtype ctx)))
+                                (inf/hint-tag acc)
+                                (inf/infer-arg-tag walked-identity (:type-env env)))
+                        fold-ctx (cond-> env tag (ctx-assoc-type acc tag))
+                        walked-step (walk step fold-ctx)]
+                    [(cond-> env tag (ctx-assoc-type acc tag))
+                     (conj result [acc walked-identity component-dtype
+                                   (walk extent env) walked-step])]))
+                [index-env []] folds)
+        hinted-outputs
+        (mapv (fn [out]
+                (if-let [tag (and (symbol? out) (ctx-get-tag ctx out))]
+                  (stamp-type-meta out tag)
+                  out))
+              outputs)
+        result (list 'raster.par/segmented-fold-map!
+                     hinted-outputs
+                     (mapv (fn [[segment bound]] [segment (walk bound ctx)]) segment-axes)
+                     idx-sym (walk map-extent ctx) (vec walked-folds)
+                     (mapv #(walk % fold-env) map-results))
+        element-dtype (:element-dtype ctx)]
+    (if element-dtype
+      (with-meta result {:raster.type/elem-type element-dtype})
+      result)))
 
 (defmethod walk-form :par-scan [form ctx]
   (let [[_ out-sym acc-sym init-expr i-sym bound-expr cast-fn body-expr] form

--- a/src/raster/compiler/ir/dialects.clj
+++ b/src/raster/compiler/ir/dialects.clj
@@ -522,7 +522,7 @@
                          (nth operation 3))]
               (and (seq? body)
                    (contains? #{'scalar 'map 'scatter 'stencil 'reduce
-                                'segmented-reduce 'product-reduce 'scan}
+                                'segmented-reduce 'product-reduce 'segmented-fold-map 'scan}
                               (first body)))))
           (fn [_ algorithm]
             (= algorithm (soac-dialect/validate! algorithm))))

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -19,6 +19,7 @@
 (defrecord IndexBinding [id source axis])
 (defrecord IndexCompute [id expression])
 (defrecord IndexExpr [op arguments])
+(defrecord IndexCast [argument dtype overflow])
 (defrecord Predicate [op arguments])
 (defrecord Mask [id predicates])
 (defrecord Fragment [id dtype shape layout])
@@ -99,6 +100,11 @@
     (throw (ex-info "kernel index expression has an unsupported operation"
                     {:operation op :arguments arguments})))
   (->IndexExpr op (vec arguments)))
+
+(defn index-cast
+  "Construct an explicit integral representation conversion for index arithmetic."
+  [argument target-dtype overflow]
+  (->IndexCast argument target-dtype overflow))
 
 (defn predicate
   "Construct an explicit target-neutral bounds predicate."
@@ -212,6 +218,10 @@
 (defn- expression? [value]
   (cond
     (or (integer? value) (value-id? value)) true
+    (record-kind? "raster.compiler.ir.kernel_body.IndexCast" value)
+    (and (contains? #{:int :long} (dtype/canon (:dtype value)))
+         (contains? cast-overflow-policies (:overflow value))
+         (expression? (:argument value)))
     (record-kind? "raster.compiler.ir.kernel_body.IndexExpr" value)
     (and (contains? index-ops (:op value))
          (seq (:arguments value))
@@ -222,6 +232,8 @@
   (cond
     (value-id? value) #{value}
     (integer? value) #{}
+    (record-kind? "raster.compiler.ir.kernel_body.IndexCast" value)
+    (expression-references (:argument value))
     (record-kind? "raster.compiler.ir.kernel_body.IndexExpr" value)
     (reduce into #{} (map expression-references (:arguments value)))
     :else #{}))
@@ -1041,17 +1053,48 @@
 
 (defn- expression-info!
   [expression values]
-  (let [infos (mapv #(typed-info! values % "index expression")
-                    (expression-references expression))
-        types (set (map :type infos))]
-    (when-not (every? #{:int :long} types)
-      (throw (ex-info "index expression references a non-integral SSA value"
-                      {:reason :kernel-body-index-dtype :expression expression :types types})))
-    (when (> (count types) 1)
-      (throw (ex-info "index expression mixes integral widths without an explicit conversion"
-                      {:reason :kernel-body-index-dtype :expression expression :types types})))
-    {:type (or (first types) :int)
-     :uniformity (join-uniformity infos)}))
+  (cond
+    (integer? expression)
+    {:type :int :uniformity all-uniform}
+
+    (value-id? expression)
+    (typed-info! values expression "index expression")
+
+    (record-kind? "raster.compiler.ir.kernel_body.IndexCast" expression)
+    (let [source (expression-info! (:argument expression) values)
+          target (dtype/canon (:dtype expression))]
+      (when-not (contains? #{:int :long} target)
+        (throw (ex-info "index conversion target must be integral"
+                        {:reason :kernel-body-index-cast-dtype
+                         :expression expression :target target})))
+      (when-not (contains? cast-overflow-policies (:overflow expression))
+        (throw (ex-info "index conversion requires an explicit overflow policy"
+                        {:reason :kernel-body-index-cast-overflow
+                         :expression expression :overflow (:overflow expression)})))
+      (when-not (and (= :exact (:overflow expression))
+                     (or (= (:type source) target)
+                         (and (= :int (:type source)) (= :long target))))
+        (throw (ex-info "the portable index IR currently permits only exact widening conversions"
+                        {:reason :kernel-body-index-cast-semantics
+                         :expression expression :source (:type source) :target target
+                         :overflow (:overflow expression)})))
+      {:type target :uniformity (:uniformity source)})
+
+    (record-kind? "raster.compiler.ir.kernel_body.IndexExpr" expression)
+    (let [infos (mapv #(expression-info! % values) (:arguments expression))
+          types (set (map :type infos))]
+      (when-not (every? #{:int :long} types)
+        (throw (ex-info "index expression references a non-integral SSA value"
+                        {:reason :kernel-body-index-dtype :expression expression :types types})))
+      (when (> (count types) 1)
+        (throw (ex-info "index expression mixes integral widths without an explicit conversion"
+                        {:reason :kernel-body-index-dtype :expression expression :types types})))
+      {:type (or (first types) :int)
+       :uniformity (join-uniformity infos)})
+
+    :else
+    (throw (ex-info "unsupported kernel index expression"
+                    {:reason :kernel-body-index-expression :expression expression}))))
 
 (defn- expression-uniformity
   [expression values]
@@ -1954,7 +1997,11 @@
                          :subgroup subgroup-uniform
                          :lane lane-varying)
                        (expression-uniformity (:expression idx) values))]
-                 (assoc values (:id idx) {:type :int :uniformity uniformity})))
+                 (assoc values (:id idx)
+                        {:type (if (record-kind? "raster.compiler.ir.kernel_body.IndexBinding" idx)
+                                 :int
+                                 (:type (expression-info! (:expression idx) values)))
+                         :uniformity uniformity})))
              (into {}
                    (map (fn [parameter]
                           [(:id parameter)

--- a/src/raster/compiler/ir/par.clj
+++ b/src/raster/compiler/ir/par.clj
@@ -351,6 +351,9 @@
     (and (seq? form) (= 'raster.par/product-reduce! (first form)))
     (expand-par-forms (macroexpand-1 form))
 
+    (and (seq? form) (= 'raster.par/segmented-fold-map! (first form)))
+    (expand-par-forms (macroexpand-1 form))
+
     ;; contract = an annotated redomap; the CPU/correctness fallback is its macro expansion
     ;; (a sequential dotimes over the free space of a per-tuple reduce over the contract axis).
     ;; Delegating to macroexpand-1 keeps ONE source of truth (the raster.par/contract macro).
@@ -410,6 +413,7 @@
                     'raster.par/contract 'par/contract
                     'raster.par/reduce 'par/reduce
                     'raster.par/product-reduce! 'par/product-reduce!
+                    'raster.par/segmented-fold-map! 'par/segmented-fold-map!
                     'raster.par/reduce-into 'par/reduce-into
                     'raster.par/scan 'par/scan
                     'raster.par/scan-exclusive 'par/scan-exclusive
@@ -463,6 +467,12 @@
   [form]
   (and (seq? form)
        (contains? #{'raster.par/product-reduce! 'par/product-reduce!} (first form))))
+
+(defn par-segmented-fold-map-form?
+  "Check if a form is an ordered segmented fold followed by a dense map."
+  [form]
+  (and (seq? form)
+       (contains? #{'raster.par/segmented-fold-map! 'par/segmented-fold-map!} (first form))))
 
 (defn par-stencil-form?
   "Check if a form is a raster.par/stencil! parallel stencil."
@@ -645,6 +655,39 @@
                    element-bindings' (vec element-results') combine-parameters'
                    combine-bindings' (vec combine-results') algebra')))})
 
+        ;; segmented-fold-map!: segment/map indices and fold accumulators are lexical binders.
+        ;; A completed accumulator is visible to every later fold and to the final map.
+        (par-segmented-fold-map-form? form)
+        (let [[_ outputs segment-axes idx map-extent folds map-results] form
+              segment-indices (mapv first segment-axes)
+              accumulators (mapv first folds)
+              scoped (vec (concat segment-indices [idx] accumulators))
+              inner (vec (concat (mapcat (fn [fold] [(nth fold 3) (nth fold 4)]) folds)
+                                 map-results))
+              outer (vec (concat outputs (map second segment-axes) [map-extent]
+                                 (mapcat (fn [[_ identity dtype _ _]] [identity dtype])
+                                         folds)))]
+          {:scoped-syms scoped :inner-exprs inner :outer-exprs outer
+           :rebuild
+           (fn [scoped' inner' outer']
+             (let [nsegments (count segment-indices)
+                   nfolds (count folds)
+                   [segment-indices' scoped-rest] (split-at nsegments scoped')
+                   idx' (first scoped-rest)
+                   accumulators' (vec (rest scoped-rest))
+                   [fold-inner map-results'] (split-at (* 2 nfolds) inner')
+                   fold-inner (partition 2 fold-inner)
+                   [outputs' outer-rest] (split-at (count outputs) outer')
+                   [segment-bounds' outer-rest] (split-at nsegments outer-rest)
+                   map-extent' (first outer-rest)
+                   fold-fields (partition 2 (rest outer-rest))
+                   folds' (mapv (fn [acc [identity dtype] [extent step]]
+                                  [acc identity dtype extent step])
+                                accumulators' fold-fields fold-inner)]
+               (pl form head (vec outputs')
+                   (mapv vector segment-indices' segment-bounds')
+                   idx' map-extent' folds' (vec map-results'))))})
+
         ;; scan / scan-exclusive: (head out acc init idx bound cast body)
         (or (= n "scan") (= n "scan-exclusive"))
         (let [[_ out acc init idx bound cast body] form]
@@ -717,6 +760,19 @@
        :combine-bindings (vec combine-bindings)
        :combine-results (vec combine-results)
        :algebra algebra})))
+
+(defn extract-par-segmented-fold-map-info
+  "Extract the ordered structural fields of `raster.par/segmented-fold-map!`."
+  [form]
+  (when (par-segmented-fold-map-form? form)
+    (let [[_ outputs segment-axes idx map-extent folds map-results] form]
+      {:outputs (vec outputs)
+       :segment-axes (vec segment-axes)
+       :idx idx
+       :map-extent map-extent
+       :folds (vec folds)
+       :map-results (vec map-results)
+       :elem-type (:raster.type/elem-type (meta form))})))
 
 (defn extract-par-map2-info
   "Extract structured info from a par/map2! form.

--- a/src/raster/compiler/ir/segop.clj
+++ b/src/raster/compiler/ir/segop.clj
@@ -69,6 +69,20 @@
             cast-fn      ;; scalar result cast
             aliasing])   ;; :no-write-alias — neighborhood inputs must not alias destination
 
+(defrecord SegFoldMap
+           [id           ;; equation identity
+            space        ;; parallel segment space; one work item owns one segment
+            index        ;; ordered fold/final-map index symbol
+            extent       ;; complete final-map width
+            folds        ;; ordered [{:accumulator :identity :dtype :extent :step} ...]
+            map-results  ;; pure final values aligned with outputs
+            inputs       ;; stable whole-tensor reads
+            outputs      ;; ordered caller-owned dense destinations, aligned with map results
+            scalars      ;; extent/index scalar parameters
+            grid         ;; portable one-work-item-per-segment launch plan
+            dtypes       ;; final output dtypes
+            aliasing])   ;; :no-write-alias — stable reads are distinct from destinations
+
 (defrecord SegRed
            [id          ;; int
             space       ;; SegSpace
@@ -122,6 +136,7 @@
   (and x
        (contains? #{"raster.compiler.ir.segop.SegMap"
                     "raster.compiler.ir.segop.SegStencil"
+                    "raster.compiler.ir.segop.SegFoldMap"
                     "raster.compiler.ir.segop.SegRed"
                     "raster.compiler.ir.segop.SegScan"}
                   (.getName (class x)))))
@@ -146,7 +161,7 @@
   [operation]
   (if (instance? SegContract operation)
     #{(get-in operation [:facts :out])}
-    (or (:outputs operation) #{})))
+    (set (or (:outputs operation) #{}))))
 
 (defn operation-scalars
   "Scalar shape operands of a scheduled operation.

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -117,6 +117,12 @@
   [attributes]
   (mapv (comp first extent-shape second) (:segment-axes attributes)))
 
+(defn segmented-fold-map-result-shape
+  "Canonical dense output shape of an ordered segmented fold-map."
+  [attributes]
+  (conj (segmented-reduce-result-shape attributes)
+        (first (extent-shape (:extent attributes)))))
+
 (defn map-attributes?
   [value]
   (and (map? value)
@@ -299,6 +305,35 @@
          (map? (:algebra value))
          (true? (get-in value [:algebra :associative?])))))
 
+(defn fold-attributes?
+  "Attributes of one sequential, loop-carried fold inside a segmented fold-map."
+  [value]
+  (and (map? value)
+       (symbol? (:accumulator value))
+       (scalar-literal? (:identity value))
+       (keyword? (:dtype value))
+       (dtype/known? (:dtype value))
+       (= (:dtype value) (dtype/canon (:dtype value)))
+       (or (extent? (:extent value)) (seq? (:extent value)))
+       (= :ordered (:association value))))
+
+(defn segmented-fold-map-attributes?
+  "Attributes for independent segments containing dependent ordered folds and a final dense map."
+  [value]
+  (let [axes (:segment-axes value)
+        indices (mapv first axes)]
+    (and (map-attributes? value)
+         (vector? axes) (seq axes)
+         (every? #(and (vector? %) (= 2 (count %))
+                       (symbol? (first %)) (extent? (second %)))
+                 axes)
+         (= (count indices) (count (distinct indices)))
+         (not (contains? (set indices) (:index value)))
+         (= :ordered (:association value))
+         (vector? (:dtypes value)) (seq (:dtypes value))
+         (every? #(and (keyword? %) (dtype/known? %) (= % (dtype/canon %)))
+                 (:dtypes value)))))
+
 (defn scan-attributes?
   "Attributes for a certified scan dialect operation. The explicit mode is load-bearing because
    inclusive and exclusive scans have different observable result layouts."
@@ -350,6 +385,8 @@
              [ra reduce-attributes?]
              [sra segmented-reduce-attributes?]
              [pra product-reduce-attributes?]
+             [fa fold-attributes?]
+             [sfma segmented-fold-map-attributes?]
              [ca scan-attributes?]
              [dt keyword?]
              [facts program-facts?])
@@ -373,6 +410,9 @@
   (Lambda [l :enforce]
           (lambda [(?:* ?sym:parameter)] ?r))
 
+  (Fold [f :enforce]
+        (fold ?fa ?l))
+
   (Operation [o :enforce]
              (scalar ?sa [(?:* ?id:capture)] ?l)
              (map ?ma [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
@@ -382,6 +422,8 @@
              (segmented-reduce ?sra [(?:* ?id:array)] [(?:* ?id:capture)] ?l)
              (product-reduce ?pra [(?:* ?id:array)] [(?:* ?id:capture)]
                              ?l:element ?l:combine)
+             (segmented-fold-map ?sfma [(?:* ?id:array)] [(?:* ?id:capture)]
+                                 [(?:+ f)] ?l)
              (scan ?ca [(?:* ?id:array)] [(?:* ?id:capture)] ?l))
 
   (Equation [q :enforce]
@@ -425,8 +467,11 @@
    the parallel segment space followed by the innermost reduction extent."
   [equation]
   (let [{:keys [kind attributes]} (operation-parts equation)]
-    (if (contains? #{'segmented-reduce 'product-reduce} kind)
-      (conj (mapv second (:segment-axes attributes)) (:extent attributes))
+    (if (contains? #{'segmented-reduce 'product-reduce 'segmented-fold-map} kind)
+      (into (conj (mapv second (:segment-axes attributes)) (:extent attributes))
+            (when (= 'segmented-fold-map kind)
+              (map #(get-in % [:attributes :extent])
+                   (:folds (operation-parts equation)))))
       (if-let [extent (:extent attributes)] [extent] []))))
 
 (defn operation-parts
@@ -443,6 +488,14 @@
       (let [[_ attributes arrays captures element-lambda combine-lambda] operation]
         {:kind kind :attributes attributes :arrays arrays :captures captures
          :element-lambda element-lambda :combine-lambda combine-lambda})
+
+      (= 'segmented-fold-map kind)
+      (let [[_ attributes arrays captures folds map-lambda] operation]
+        {:kind kind :attributes attributes :arrays arrays :captures captures
+         :folds (mapv (fn [[_ fold-attributes fold-lambda]]
+                        {:attributes fold-attributes :lambda fold-lambda})
+                      folds)
+         :map-lambda map-lambda})
 
       :else
       (let [[_ attributes arrays captures lambda] operation]
@@ -608,10 +661,13 @@
 (defn- validate-equation!
   [equation]
   (let [[_ equation-id results operation] equation
-        {:keys [kind attributes arrays captures lambda element-lambda combine-lambda]}
+        {:keys [kind attributes arrays captures lambda element-lambda combine-lambda
+                folds map-lambda]}
         (operation-parts equation)
         product? (= 'product-reduce kind)
-        {:keys [parameters locals body-results]} (lambda-parts (or lambda element-lambda))
+        fold-map? (= 'segmented-fold-map kind)
+        {:keys [parameters locals body-results]}
+        (lambda-parts (or lambda element-lambda map-lambda))
         component-count (when product? (count (:component-ids attributes)))
         result-count (count results)]
     (when-not (distinct-vector? results)
@@ -644,7 +700,7 @@
                "scalar-region parameters and local SSA definitions must be distinct"
                {:equation equation-id :parameters parameters :locals local-ids}))
       (when (and (contains? #{'map 'scatter 'stencil 'reduce 'segmented-reduce
-                              'product-reduce 'scan} kind)
+                              'product-reduce 'segmented-fold-map 'scan} kind)
                  (some #{(:index attributes)} local-ids))
         (fail! :typed-soac-region-binders
                "a scalar-region local cannot shadow its operation index"
@@ -659,7 +715,8 @@
         (fail! :typed-soac-local-dtype
                "scalar-region locals require a supported JVM scalar dtype"
                {:equation equation-id :local local :dtype dtype})))
-    (when (and (seq locals) (not (contains? #{'map 'scatter 'product-reduce} kind)))
+    (when (and (seq locals)
+               (not (contains? #{'map 'scatter 'product-reduce 'segmented-fold-map} kind)))
       (fail! :typed-soac-region-operation
              "typed local SSA is not admitted in this operation's scalar region"
              {:equation equation-id :operation kind :locals locals}))
@@ -667,9 +724,11 @@
       (fail! :typed-soac-result-arity "SOAC result and lambda arity differ"
              {:equation equation-id :results result-count :components component-count
               :body-results (count body-results)}))
-    (let [expected-parameter-count (+ (if (contains? #{'reduce 'segmented-reduce 'scan} kind)
+    (let [expected-parameter-count (+ (cond
+                                        (contains? #{'reduce 'segmented-reduce 'scan} kind)
                                         (count (:accumulators attributes))
-                                        0)
+                                        fold-map? (count folds)
+                                        :else 0)
                                       (count arrays)
                                       (count captures))]
       (when-not (= expected-parameter-count (count parameters))
@@ -682,9 +741,10 @@
                 :captures captures})))
     (let [initial-bound (cond-> (set parameters)
                           (contains? #{'map 'scatter 'stencil 'reduce 'segmented-reduce
-                                      'product-reduce 'scan} kind)
+                                      'product-reduce 'segmented-fold-map 'scan} kind)
                           (conj (:index attributes))
-                          (contains? #{'segmented-reduce 'product-reduce} kind)
+                          (contains? #{'segmented-reduce 'product-reduce
+                                      'segmented-fold-map} kind)
                           (into (map first (:segment-axes attributes))))
           final-bound
           (reduce (fn [bound {:keys [id init] :as local}]
@@ -843,6 +903,88 @@
                    "product-reduce combine must be a closed scalar binary operator"
                    {:equation equation-id :expression expression :unbound unbound}))))
 
+      segmented-fold-map
+      (let [fold-attributes (mapv :attributes folds)
+            accumulators (mapv :accumulator fold-attributes)
+            segment-indices (set (map first (:segment-axes attributes)))
+            capture-count (count captures)
+            map-parameters parameters
+            capture-parameters (vec (take-last capture-count map-parameters))
+            iteration-index (:index attributes)]
+        (when-not (= (count results) (count (:dtypes attributes)))
+          (fail! :typed-soac-segmented-fold-map-results
+                 "segmented-fold-map result arity must equal its declared result dtype arity"
+                 {:equation equation-id :results results :dtypes (:dtypes attributes)}))
+        (when (seq arrays)
+          (fail! :typed-soac-segmented-fold-map-array-role
+                 "the initial ordered schedule uses whole-tensor stable captures, not pointwise arrays"
+                 {:equation equation-id :arrays arrays}))
+        (when-not (= (count accumulators) (count (distinct accumulators)))
+          (fail! :typed-soac-segmented-fold-map-accumulators
+                 "ordered fold accumulators must be distinct"
+                 {:equation equation-id :accumulators accumulators}))
+        (when-not (= accumulators
+                     (subvec map-parameters 0 (count accumulators)))
+          (fail! :typed-soac-segmented-fold-map-map-parameters
+                 "the final map must receive completed folds, pointwise elements, and captures in order"
+                 {:equation equation-id :parameters map-parameters
+                  :accumulators accumulators :arrays arrays :captures captures}))
+        (doseq [[ordinal {:keys [attributes lambda]}] (map-indexed vector folds)]
+          (let [{fold-parameters :parameters fold-locals :locals
+                 fold-results :body-results} (lambda-parts lambda)
+                prior (subvec accumulators 0 ordinal)
+                expected (vec (concat [(:accumulator attributes)] prior capture-parameters))
+                bound (set/union (set fold-parameters) segment-indices
+                                 #{iteration-index})
+                final-bound
+                (reduce (fn [bound {:keys [id init] :as local}]
+                          (when-not (and (keyword? (:dtype local))
+                                         (dtype/known? (:dtype local))
+                                         (= (:dtype local) (dtype/canon (:dtype local)))
+                                         (:scalar-tag (dtype/info (:dtype local))))
+                            (fail! :typed-soac-local-dtype
+                                   "ordered fold locals require canonical scalar dtypes"
+                                   {:equation equation-id :fold ordinal :local local}))
+                          (let [unbound (util/free-syms init bound)]
+                            (when (or (contains? bound id) (seq unbound))
+                              (fail! :typed-soac-segmented-fold-map-fold-local
+                                     "ordered fold locals may reference only its lexical boundary and earlier locals"
+                                     {:equation equation-id :fold ordinal :local local
+                                      :unbound unbound}))
+                            (conj bound id)))
+                        bound fold-locals)]
+            (let [unbound-extent
+                  (set/difference (util/free-syms (:extent attributes))
+                                  (set/union segment-indices (set captures)))]
+              (when (seq unbound-extent)
+                (fail! :typed-soac-segmented-fold-map-fold-extent
+                       "ordered fold extents may reference only segment axes and explicit captures"
+                       {:equation equation-id :fold ordinal :extent (:extent attributes)
+                        :unbound unbound-extent})))
+            (when-not (= fold-parameters expected)
+              (fail! :typed-soac-segmented-fold-map-fold-parameters
+                     "each ordered fold must receive its accumulator, prior fold results, and captures"
+                     {:equation equation-id :fold ordinal :parameters fold-parameters
+                      :expected expected}))
+            (when-not (= 1 (count fold-results))
+              (fail! :typed-soac-segmented-fold-map-fold-result
+                     "each ordered fold must yield exactly one next accumulator"
+                     {:equation equation-id :fold ordinal :results fold-results}))
+            (when (some write-form? fold-results)
+              (fail! :typed-soac-segmented-fold-map-fold-write
+                     "ordered folds are pure scalar regions"
+                     {:equation equation-id :fold ordinal :results fold-results}))
+            (let [unbound (binding [util/*shadowing-locals* (set accumulators)]
+                            (util/free-syms (first fold-results) final-bound))]
+              (when (seq unbound)
+                (fail! :typed-soac-segmented-fold-map-fold-closure
+                       "ordered fold steps may not reference future folds or implicit state"
+                       {:equation equation-id :fold ordinal :unbound unbound})))))
+        (when (some write-form? body-results)
+          (fail! :typed-soac-segmented-fold-map-map-write
+                 "the final fold-map region must yield pure scalar results"
+                 {:equation equation-id :results body-results})))
+
       scan
       (let [accumulators (:accumulators attributes)]
         (when-not (= accumulators (vec (take (count accumulators) parameters)))
@@ -974,6 +1116,19 @@
                      {:equation equation-id :id id :value value
                       :component-dtype dtype :segment-axes (:segment-axes attributes)})))))
 
+      segmented-fold-map
+      (let [result-shape (segmented-fold-map-result-shape attributes)]
+        (doseq [[id result-dtype] (map vector results (:dtypes attributes))]
+          (let [value (get values id)]
+            (when (and value
+                       (not (and (= :tensor (:kind value))
+                                 (= result-shape (:shape value))
+                                 (= result-dtype (:dtype value)))))
+              (fail! :typed-soac-segmented-fold-map-result-type
+                     "segmented-fold-map results must cover the complete segment/map space"
+                     {:equation equation-id :id id :value value
+                      :shape result-shape :dtype result-dtype})))))
+
       scan
       (doseq [[id dtype] (map vector results (:dtypes attributes))]
         (let [value (get values id)]
@@ -995,7 +1150,7 @@
         storage (result-storage program-facts equation-id)]
     (when storage
       (when-not (contains? #{'map 'scatter 'stencil 'segmented-reduce
-                             'product-reduce} kind)
+                             'product-reduce 'segmented-fold-map} kind)
         (fail! :typed-soac-result-storage-operation
                "physical result storage is valid only for writing tensor operations"
                {:equation equation-id :operation kind :storage storage}))
@@ -1011,13 +1166,13 @@
                {:equation equation-id :results results :storage storage}))
       (let [destinations (mapv :destination storage)
             aliases (get-in program-facts [:equations equation-id :aliases])]
-        (when (and (= 'stencil kind)
+        (when (and (contains? #{'stencil 'segmented-fold-map} kind)
                    (seq (set/intersection
                          (set destinations)
                          (set (get-in (operation-parts equation)
                                      [:attributes :attributes :stable-array-captures])))))
-          (fail! :typed-soac-stencil-alias
-                 "stencil output storage must not alias a stable neighborhood input"
+          (fail! :typed-soac-stable-read-alias
+                 "a stable tensor input must not alias this operation's output storage"
                  {:equation equation-id
                   :destinations destinations
                   :stable-array-captures
@@ -1176,14 +1331,16 @@
                           {} (:values source-facts))
         equation-forms
         (mapv (fn [[equals equation-id results :as equation]]
-                (let [{:keys [kind attributes arrays captures lambda element-lambda combine-lambda]}
+                (let [{:keys [kind attributes arrays captures lambda element-lambda combine-lambda
+                              folds map-lambda]}
                       (operation-parts equation)
                       attributes (cond-> attributes
                                    (seq (get-in attributes
                                                 [:attributes :stable-array-captures]))
                                    (update-in [:attributes :stable-array-captures]
                                               #(mapv rename %)))
-                      attributes (if (contains? #{'segmented-reduce 'product-reduce} kind)
+                      attributes (if (contains? #{'segmented-reduce 'product-reduce
+                                                  'segmented-fold-map} kind)
                                    (-> attributes
                                        (update :segment-axes
                                                #(mapv (fn [[index extent]]
@@ -1209,6 +1366,17 @@
                                   product-reduce
                                   (list kind attributes (mapv rename arrays)
                                         (mapv rename captures) element-lambda combine-lambda)
+
+                                  segmented-fold-map
+                                  (list kind attributes (mapv rename arrays)
+                                        (mapv rename captures)
+                                        (mapv (fn [{:keys [attributes lambda]}]
+                                                (list 'fold
+                                                      (update attributes :extent
+                                                              #(util/subst-syms value-map %))
+                                                      lambda))
+                                              folds)
+                                        map-lambda)
 
                                   (list kind attributes (mapv rename arrays)
                                         (mapv rename captures) lambda))]

--- a/src/raster/compiler/passes/parallel/contraction_body.clj
+++ b/src/raster/compiler/passes/parallel/contraction_body.clj
@@ -60,6 +60,20 @@
            (= 2 (count expression)))
       (lower-index (second expression) scope)
 
+      (and (seq? expression)
+           (descriptor/increment-op? (descriptor/semantic-op expression))
+           (= 1 (count (descriptor/call-args expression))))
+      (body/expression :add
+                       (lower-index (first (descriptor/call-args expression)) scope)
+                       1)
+
+      (and (seq? expression)
+           (descriptor/decrement-op? (descriptor/semantic-op expression))
+           (= 1 (count (descriptor/call-args expression))))
+      (body/expression :sub
+                       (lower-index (first (descriptor/call-args expression)) scope)
+                       1)
+
       (seq? expression)
       (let [operator (get index-operators (descriptor/semantic-op expression))
             arguments (vec (descriptor/call-args expression))]

--- a/src/raster/compiler/passes/parallel/segfoldmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segfoldmap_body.clj
@@ -1,0 +1,353 @@
+(ns raster.compiler.passes.parallel.segfoldmap-body
+  "Portable KernelBody schedule for ordered segmented fold-map operations.
+
+   One work item owns one independent segment. Each fold is a sequential, loop-carried region in
+   declared order; completed fold values feed later folds and the final dense map. This is the
+   baseline schedule, not an attention or normalization implementation."
+  (:require [clojure.set :as set]
+            [raster.compiler.backend.intrinsics :as intrinsics]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.layout :as layout]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.util :as util]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.passes.parallel.contraction-body :as contraction-body]))
+
+(def ^:private cast-heads
+  {'byte :byte, 'clojure.core/byte :byte
+   'int :int, 'clojure.core/int :int
+   'long :long, 'clojure.core/long :long
+   'float :float, 'clojure.core/float :float
+   'double :double, 'clojure.core/double :double})
+
+(defn- decline!
+  [rule message data]
+  (throw (ex-info message (assoc data :reason :segfoldmap-kernel-body-declined
+                                 :missing-rule rule))))
+
+(defn declined? [exception]
+  (= :segfoldmap-kernel-body-declined (:reason (ex-data exception))))
+
+(defn- product-expression [values]
+  (case (count values)
+    0 1
+    1 (first values)
+    (apply body/expression :mul values)))
+
+(defn- widen-index-expression
+  "Make portable address arithmetic uniformly 64-bit without changing scalar ABI types."
+  [expression value-types]
+  (cond
+    (integer? expression) (body/index-cast expression :long :exact)
+    (symbol? expression)
+    (if (= :long (dtype/canon (get value-types expression :int)))
+      expression
+      (body/index-cast expression :long :exact))
+    (instance? raster.compiler.ir.kernel_body.IndexExpr expression)
+    (apply body/expression (:op expression)
+           (map #(widen-index-expression % value-types) (:arguments expression)))
+    (instance? raster.compiler.ir.kernel_body.IndexCast expression)
+    (if (= :long (dtype/canon (:dtype expression)))
+      expression
+      (body/index-cast expression :long :exact))
+    :else expression))
+
+(defn- inline-let
+  [expression]
+  (if (and (seq? expression) (contains? #{'let 'let* 'clojure.core/let} (first expression)))
+    (let [[_ bindings result] expression]
+      (reduce (fn [result [id init]] (util/subst-syms {id init} result))
+              result (reverse (partition 2 bindings))))
+    expression))
+
+(defn- scalar-lowerer
+  [{:keys [array-types scalar-types arrays index-scope lower-index active-mask]}]
+  (let [counter (atom 0)
+        fresh (fn [prefix] (symbol (str "foldmap-" prefix "-" (swap! counter inc))))
+        source-type
+        (fn source-type [expression expected env]
+          (let [expression (inline-let expression)]
+            (cond
+              (symbol? expression) (or (get env expression) (get scalar-types expression) expected)
+              (number? expression) expected
+              (descriptor/aget-call? expression)
+              (or (get array-types (descriptor/aget-array-sym expression)) expected)
+              (and (seq? expression) (contains? cast-heads (first expression)))
+              (get cast-heads (first expression))
+              (and (seq? expression)
+                   (= :cmp (:kind (intrinsics/descriptor
+                                   (intrinsics/canonical
+                                    (descriptor/semantic-op expression))))))
+              :predicate
+              :else expected)))]
+    (letfn [(lower [expression expected env]
+              (let [expression (inline-let expression)]
+                (cond
+                  (number? expression)
+                  {:operations [] :result (body/literal expression expected) :type expected}
+
+                  (boolean? expression)
+                  {:operations [] :result (body/literal expression :predicate) :type :predicate}
+
+                  (symbol? expression)
+                  (if-let [actual (or (get env expression) (get scalar-types expression))]
+                    {:operations [] :result expression :type actual}
+                    (decline! :unbound-scalar
+                              "fold-map scalar expression references an undeclared value"
+                              {:expression expression :environment (set (keys env))}))
+
+                  (descriptor/aget-call? expression)
+                  (let [array (descriptor/aget-array-sym expression)
+                        arguments (vec (descriptor/call-args expression))
+                        coordinate (last arguments)
+                        array-type (some-> (get array-types array) dtype/canon)]
+                    (when-not (and (= 2 (count arguments)) (contains? arrays array) array-type)
+                      (decline! :indexed-load
+                                "fold-map loads require a declared typed stable tensor"
+                                {:expression expression :array array :array-types array-types}))
+                    (let [id (fresh "load")]
+                      {:operations [(body/->ScalarLoad
+                                     (body/value id array-type) array
+                                     [(lower-index coordinate)] active-mask
+                                     (body/literal 0 array-type) :cached)]
+                       :result id :type array-type}))
+
+                  (and (seq? expression) (contains? cast-heads (first expression))
+                       (= 2 (count expression)))
+                  (let [target (dtype/canon (get cast-heads (first expression)))
+                        lowered (lower (second expression) target env)]
+                    (if (= target (:type lowered))
+                      lowered
+                      (let [id (fresh "cast")]
+                        {:operations (conj (:operations lowered)
+                                           (body/->ScalarCompute
+                                            (body/value id target)
+                                            (body/cast-expression (:result lowered) target
+                                                                  :exact :exact)))
+                         :result id :type target})))
+
+                  (and (seq? expression) (= 'if (first expression)) (= 4 (count expression)))
+                  (let [[_ condition then-expression else-expression] expression
+                        condition (lower condition :predicate env)
+                        then-value (lower then-expression expected env)
+                        else-value (lower else-expression expected env)
+                        result-type (:type then-value)
+                        _ (when-not (= result-type (:type else-value) expected)
+                            (decline! :branch-dtype
+                                      "fold-map branches must have one explicit scalar dtype"
+                                      {:expression expression :then (:type then-value)
+                                       :else (:type else-value) :expected expected}))
+                        result (fresh "if")]
+                    {:operations
+                     (conj (vec (:operations condition))
+                           (body/->IfRegion
+                            (:result condition)
+                            (conj (vec (:operations then-value))
+                                  (body/->Yield [(:result then-value)]))
+                            (conj (vec (:operations else-value))
+                                  (body/->Yield [(:result else-value)]))
+                            [(body/value result result-type)]))
+                     :result result :type result-type})
+
+                  (seq? expression)
+                  (let [operator (intrinsics/canonical (descriptor/semantic-op expression))
+                        intrinsic (intrinsics/descriptor operator)
+                        arguments (vec (descriptor/call-args expression))]
+                    (when-not (and intrinsic (= (:arity intrinsic) (count arguments)))
+                      (decline! :scalar-expression
+                                "fold-map scalar expression has no canonical intrinsic"
+                                {:expression expression :operator operator}))
+                    (let [comparison? (= :cmp (:kind intrinsic))
+                          operand-type (if comparison?
+                                         (dtype/canon
+                                          (or (source-type (first arguments) :int env) :int))
+                                         (dtype/canon expected))
+                          lowered (mapv #(lower % operand-type env) arguments)
+                          result-type (if comparison? :predicate operand-type)
+                          _ (when-not (every? #(= operand-type (:type %)) lowered)
+                              (decline! :operand-dtype
+                                        "fold-map intrinsic operands require one scalar dtype"
+                                        {:expression expression :operand-type operand-type
+                                         :actual (mapv :type lowered)}))
+                          result (fresh "value")]
+                      {:operations
+                       (conj (vec (mapcat :operations lowered))
+                             (body/->ScalarCompute
+                              (body/value result result-type)
+                              (body/scalar-expression operator result-type
+                                                      (mapv :result lowered))))
+                       :result result :type result-type}))
+
+                  :else
+                  (decline! :scalar-expression
+                            "fold-map scalar expression has an unsupported value"
+                            {:expression expression :type (type expression)}))))]
+      {:lower lower})))
+
+(defn lower
+  "Apply the portable one-work-item-per-segment schedule to a SegFoldMap."
+  [segfold {:keys [workgroup-size array-types scalar-types]
+            :or {workgroup-size 256 array-types {} scalar-types {}}}]
+  (when-not (instance? raster.compiler.ir.segop.SegFoldMap segfold)
+    (throw (ex-info "fold-map KernelBody lowering requires SegFoldMap"
+                    {:reason :raster/bug :operation segfold})))
+  (let [space (:space segfold)
+        segment-dims (segop/seg-space-segment-dims space)
+        mapped-dim (segop/seg-space-reduced-dim space)
+        _ (when (empty? segment-dims)
+            (decline! :no-segments "fold-map requires at least one segment axis"
+                      {:operation (:id segfold)}))
+        _ (when-not (and (integer? workgroup-size) (pos? workgroup-size))
+            (decline! :workgroup-size "fold-map workgroup size must be positive"
+                      {:workgroup-size workgroup-size}))
+        inputs (vec (sort-by name (:inputs segfold)))
+        outputs (vec (:outputs segfold))
+        scalars (vec (sort-by name (:scalars segfold)))
+        output-dtypes (mapv dtype/canon (:dtypes segfold))
+        default-dtype (or (first output-dtypes) :float)
+        array-types (into {}
+                          (map (fn [id]
+                                 [id (dtype/canon (or (get array-types id)
+                                                     (get array-types (symbol (name id)))
+                                                     default-dtype))]))
+                          (concat inputs outputs))
+        declared-scalar-types scalar-types
+        scalar-types (into {}
+                           (map (fn [id]
+                                  [id (dtype/canon
+                                       (or (get declared-scalar-types id)
+                                           (get declared-scalar-types (symbol (name id)))
+                                           :int))]))
+                           scalars)
+        axis-symbols (set (concat (map :name segment-dims) [(:name mapped-dim)]))
+        scheduled-indices (conj (set (map #(symbol (str "foldmap-index-" %))
+                                          (range (count (:folds segfold)))))
+                                'foldmap-map-index)
+        index-scope (into (set/union axis-symbols scheduled-indices) scalars)
+        index-value-types (merge (zipmap axis-symbols (repeat :long))
+                                 (zipmap scheduled-indices (repeat :long))
+                                 scalar-types)
+        segment-count-source (segop/seg-space-num-segments-expr space)
+        lower-index #(widen-index-expression
+                      (contraction-body/lower-index % index-scope)
+                      index-value-types)
+        segment-count (lower-index segment-count-source)
+        map-extent (lower-index (:bound mapped-dim))
+        total-elements (body/expression :mul segment-count map-extent)
+        segment-index 'foldmap-segment
+        group-index 'foldmap-group
+        local-index 'foldmap-lane
+        active-mask :foldmap-active
+        decomposition
+        (mapv
+         (fn [position {:keys [name bound]}]
+           (let [following (subvec (vec segment-dims) (inc position))
+                 divisor (product-expression (mapv #(lower-index (:bound %)) following))
+                 quotient (if (= 1 divisor) segment-index
+                              (body/expression :floor-div segment-index divisor))]
+             (body/->IndexCompute name
+                                  (body/expression :mod quotient (lower-index bound)))))
+         (range) segment-dims)
+        base-coordinate (body/expression :mul segment-index map-extent)
+        parameters
+        (vec (concat
+              (map (fn [input]
+                     (let [input-dtype (get array-types input)]
+                       (body/->KernelParameter input :input input-dtype [total-elements] :global
+                                               (layout/row-major [total-elements] input-dtype)
+                                               :operand)))
+                   inputs)
+              (map (fn [output output-dtype]
+                     (body/->KernelParameter output :output output-dtype [total-elements] :global
+                                             (layout/row-major [total-elements] output-dtype)
+                                             :result))
+                   outputs output-dtypes)
+              (map #(body/->KernelParameter % :scalar (get scalar-types %) [] nil nil :parameter)
+                   scalars)
+              [(body/->KernelParameter '_nseg :scalar :long [] nil nil :bound)]))
+        base-env (merge (zipmap (map :name segment-dims) (repeat :long))
+                        {(:index segfold) :long}
+                        scalar-types)
+        scalar-lower (scalar-lowerer {:array-types array-types :scalar-types scalar-types
+                                      :arrays (set inputs) :index-scope index-scope
+                                      :lower-index lower-index :active-mask active-mask})
+        fold-state
+        (reduce
+         (fn [{:keys [operations env]} [ordinal fold]]
+           (when (seq (:locals fold))
+             (decline! :fold-locals
+                       "the first portable fold-map schedule requires canonical expression-only folds"
+                       {:fold ordinal :locals (:locals fold)}))
+           (let [source-index (:index segfold)
+                 loop-index (symbol (str "foldmap-index-" ordinal))
+                 carry (symbol (str "foldmap-carry-" ordinal))
+                 accumulator (:accumulator fold)
+                 fold-dtype (dtype/canon (:dtype fold))
+                 expression (util/subst-syms {source-index loop-index accumulator carry}
+                                             (:step fold))
+                 lowered ((:lower scalar-lower) expression fold-dtype
+                          (assoc env loop-index :long carry fold-dtype))
+                 loop (body/->ForLoop
+                       (body/value loop-index :long)
+                       (body/index-cast 0 :long :exact) (lower-index (:extent fold)) 1
+                       [(body/->LoopArg (body/value carry fold-dtype)
+                                       (body/literal (:identity fold) fold-dtype))]
+                       (vec (concat (:operations lowered)
+                                    [(body/->Yield [(:result lowered)])]))
+                       [(body/value accumulator fold-dtype)]
+                       {:association :ordered})]
+             {:operations (conj operations loop)
+              :env (assoc env accumulator fold-dtype)}))
+         {:operations [] :env base-env}
+         (map-indexed vector (:folds segfold)))
+        map-index 'foldmap-map-index
+        output-coordinate (body/expression :add base-coordinate map-index)
+        map-operations
+        (mapcat
+         (fn [ordinal output output-dtype expression]
+           (let [expression (util/subst-syms {(:index segfold) map-index} expression)
+                 lowered ((:lower scalar-lower) expression output-dtype
+                          (assoc (:env fold-state) map-index :long))]
+             (concat (:operations lowered)
+                     [(body/->ScalarStore output [output-coordinate]
+                                          (:result lowered) active-mask)])))
+         (range) outputs output-dtypes (:map-results segfold))
+        final-loop
+        (body/->ForLoop (body/value map-index :long)
+                        (body/index-cast 0 :long :exact) map-extent 1 []
+                        (vec (concat map-operations [(body/->Yield [])])) []
+                        {:association :ordered :role :final-map})]
+    {:kernel-body
+     (body/make
+      {:id [:segmented-fold-map (:id segfold) :portable-ordered]
+       :parameters parameters
+       :stable-reads (mapv body/stable-read inputs)
+       :indices (vec (concat
+                      [(body/->IndexBinding group-index :group 0)
+                       (body/->IndexBinding local-index :local 0)
+                       (body/->IndexCompute
+                        segment-index
+                        (body/index-cast
+                         (body/expression :add
+                                          (body/expression :mul group-index workgroup-size)
+                                          local-index)
+                         :long :exact))]
+                      decomposition))
+       :masks [(body/->Mask active-mask
+                            [(body/predicate :lt segment-index '_nseg)])]
+       :operations (conj (vec (:operations fold-state)) final-loop)
+       :schedule {:strategy :one-work-item-per-segment
+                  :association :ordered :workgroup-size workgroup-size
+                  :fold-count (count (:folds segfold))}
+       :launch (launch/spec {:workgroup-size [workgroup-size]
+                             :group-count [(launch/ceil-div segment-count workgroup-size)]})
+       :provenance {:dialect :kernel-body :source-dialect :segfoldmap
+                    :segop-id (:id segfold)}
+       :attributes {:kind :portable-segmented-fold-map
+                    :segment-count segment-count :map-extent map-extent
+                    :no-write-alias true}})
+     :arrays inputs :outputs outputs :scalars scalars
+     :segment-count segment-count :map-extent map-extent
+     :workgroup-size workgroup-size}))

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -294,6 +294,9 @@
                              product-reduce
                              {:operations (soac-lower/lower-typed-product-reduce
                                            algorithm device-id :dtype dtype)}
+                             segmented-fold-map
+                             {:operations (soac-lower/lower-typed-segmented-fold-map
+                                           algorithm device-id :dtype dtype)}
                              scan (soac-lower/lower-typed-scan
                                    algorithm device-id :dtype dtype
                                    :array-types (:array-types opts)))

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -157,6 +157,61 @@
               :algorithm-dialect :typed-soac
               :algorithm-equation equation-id)])))
 
+(defn lower-typed-segmented-fold-map
+  "Lower one ordered segmented fold-map to a single semantic SegFoldMap.
+
+   The operation remains target-neutral: segments are parallel, folds are explicitly ordered,
+   and the final map covers the complete per-segment extent. A later schedule makes loop/control
+   structure and launch geometry concrete in KernelBody."
+  [program device-id & {:keys [dtype] :or {dtype :double}}]
+  (let [program (soac-dialect/validate! program)
+        equation (first (soac-dialect/equations program))
+        [_ equation-id results] equation
+        {:keys [kind attributes arrays captures folds map-lambda]}
+        (soac-dialect/operation-parts equation)
+        facts (soac-dialect/facts program)
+        physical-results (soac-dialect/physical-results facts equation)
+        stable (set (get-in attributes [:attributes :stable-array-captures]))
+        accumulators (mapv #(get-in % [:attributes :accumulator]) folds)
+        map-region (soac-dialect/lambda-parts map-lambda)
+        capture-parameters (vec (drop (count accumulators) (:parameters map-region)))
+        substitutions (zipmap capture-parameters captures)
+        lowered-folds
+        (mapv (fn [{:keys [attributes lambda]}]
+                (let [{:keys [locals body-results]} (soac-dialect/lambda-parts lambda)]
+                  (assoc attributes
+                         :locals (mapv #(update % :init
+                                                (fn [init]
+                                                  (util/subst-syms substitutions init)))
+                                       locals)
+                         :step (util/subst-syms substitutions (first body-results)))))
+              folds)
+        map-results (mapv #(util/subst-syms substitutions %)
+                          (:body-results map-region))
+        result-dtypes (:dtypes attributes)]
+    (when-not (and (= 1 (count (soac-dialect/equations program)))
+                   (= 'segmented-fold-map kind) (empty? arrays)
+                   (= (count results) (count physical-results) (count map-results)
+                      (count result-dtypes)))
+      (throw (ex-info "typed fold-map lowering requires one closed ordered equation"
+                      {:reason :typed-soac-segmented-fold-map-subset
+                       :equation equation-id :kind kind :results results
+                       :physical-results physical-results})))
+    (let [dims (conj (mapv (fn [[index bound]] {:name index :bound bound})
+                           (:segment-axes attributes))
+                     {:name (:index attributes) :bound (:extent attributes)})
+          space (segop/make-seg-space-nd dims)
+          segment-count (segop/seg-space-num-segments-expr space)
+          result-dtype (or (first result-dtypes) dtype)
+          grid (phase-grid :map device-id segment-count result-dtype)]
+      [(assoc (segop/->SegFoldMap
+               equation-id space (:index attributes) (:extent attributes)
+               lowered-folds map-results stable (vec physical-results)
+               (set/difference (set captures) stable) grid result-dtypes
+               :no-write-alias)
+              :algorithm-dialect :typed-soac
+              :algorithm-equation equation-id)])))
+
 (defn lower-typed-scatter
   "Lower one unique-destination TypedSOAC scatter to an explicit-store SegMap.
 

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -374,9 +374,56 @@
          :element-locals element-locals :combine-locals combine-locals
          :effect-only? true :host-binding symbol :result-storage storage}))
 
+    (par/par-segmented-fold-map-form? expression)
+    (let [{:keys [outputs segment-axes idx map-extent folds map-results elem-type]}
+          (par/extract-par-segmented-fold-map-info expression)
+          fold-dtype (fn [declared]
+                       (dtype/canon (if (= :element declared)
+                                      (or elem-type default-dtype :double)
+                                      declared)))
+          normalized-folds
+          (mapv (fn [[accumulator identity declared-dtype extent step]]
+                  {:accumulator accumulator :identity identity
+                   :dtype (fold-dtype declared-dtype) :extent extent :step step})
+                folds)
+          all-expressions (vec (concat (map :step normalized-folds) map-results))
+          inputs (reduce set/union #{} (map par/collect-aget-arrays all-expressions))
+          binders (set (concat (map first segment-axes) [idx]
+                               (map :accumulator normalized-folds)))
+          output-set (set outputs)
+          scalar-uses
+          (reduce set/union #{}
+                  (map util/free-syms
+                       (concat (map second segment-axes) [map-extent]
+                               (map :extent normalized-folds)
+                               (map :identity normalized-folds)
+                               all-expressions)))
+          scalars (set/difference scalar-uses inputs output-set binders
+                                  descriptor/aget-ops descriptor/aset-ops
+                                  #{'do 'let 'let* 'if 'double 'float 'int 'long})
+          results (mapv #(effect-result-id id %) (range (count outputs)))
+          result-dtype (dtype/canon (or elem-type default-dtype :double))]
+      (when (and (seq outputs) (= (count outputs) (count map-results))
+                 (every? symbol? outputs) (seq segment-axes) (seq normalized-folds)
+                 (every? #(and (dtype/known? (:dtype %))
+                               (= (:dtype %) (dtype/canon (:dtype %))))
+                         normalized-folds))
+        {:kind :segmented-fold-map :id id :sym symbol
+         :segment-axes segment-axes :index idx :extent map-extent
+         :folds normalized-folds :map-results map-results
+         :results results :result-dtypes (vec (repeat (count outputs) result-dtype))
+         :inputs inputs :outputs output-set :scalars scalars
+         :effect-only? true :host-binding symbol
+         :result-storage (mapv (fn [output]
+                                 {:destination output :access :write :host-return :effect})
+                               outputs)}))
+
     (par/par-reduce-form? expression)
     (let [{:keys [acc init idx bound body elem-type]} (par/extract-par-reduce-info expression)
-          io (extract-io body idx [symbol] :accumulator acc)]
+          io (extract-io body idx [symbol] :accumulator acc)
+          identity-scalars
+          (set/difference (util/free-syms init) (:inputs io)
+                          (set [symbol acc idx]) descriptor/aget-ops descriptor/aset-ops)]
       (merge {:kind :reduce :id id :sym symbol :index idx :extent bound
               :product (reduction/scalar
                         ;; The walker stamps contextual FP narrowing on the par form.  Without
@@ -385,7 +432,7 @@
                         {:accumulator acc :neutral init :dtype (or elem-type :double)
                          :result symbol :index idx :step-result body
                          :attributes {:source :raster.par/reduce}})}
-             io))
+             (update io :scalars set/union identity-scalars)))
 
     (and (seq? expression) (= 'raster.par/contract (first expression)))
     (let [facts (contraction-facts/contraction-facts
@@ -444,11 +491,16 @@
       ;; value/view identity before it can be SSA. Keep that uncommon compatibility form outside
       ;; the typed route instead of pretending the destination is both an input and a definition.
       (when-not (= symbol out)
-        (let [algebra (scan/certify {:acc acc :init init :lambda body :out out} scan-dtype)]
+        (let [algebra (scan/certify {:acc acc :init init :lambda body :out out} scan-dtype)
+              io (extract-io body idx [out] :accumulator acc)
+              identity-scalars
+              (set/difference (util/free-syms init) (:inputs io)
+                              (set [symbol out acc idx])
+                              descriptor/aget-ops descriptor/aset-ops)]
           (merge {:kind :scan :id id :sym symbol :index idx :extent bound :mode mode
                   :primary-out out :accumulator acc :identity init :dtype scan-dtype
                   :algebra algebra :body body}
-                 (extract-io body idx [out] :accumulator acc)))))
+                 (update io :scalars set/union identity-scalars)))))
 
     (par/par-map-void-form? expression)
     (let [{:keys [idx bound body elem-type]}
@@ -475,6 +527,7 @@
     (or (par/par-scan-form? expression) (par/par-scan-exclusive-form? expression))
     (nth expression 5)
     (par/par-stencil-form? expression) (nth expression 7)
+    (par/par-segmented-fold-map-form? expression) (nth expression 4)
     (par/par-map-void-form? expression) (nth expression 2)
     :else nil))
 
@@ -488,6 +541,7 @@
                    (or (par/par-scan-form? expression)
                        (par/par-scan-exclusive-form? expression)) 5
                    (par/par-stencil-form? expression) 7
+                   (par/par-segmented-fold-map-form? expression) 4
                    (par/par-map-void-form? expression) 2)]
     (when position
       (with-meta (apply list (assoc (vec expression) position extent)) (meta expression)))))
@@ -502,31 +556,42 @@
   (if (and (seq? source) (contains? #{'let 'let*} (first source)))
     (let [[head bindings & body] source
           pairs (vec (partition 2 bindings))
-          normalized
-          (mapcat
-           (fn [ordinal [symbol expression]]
+          {:keys [normalized]}
+          (reduce
+           (fn [{:keys [compound-extents] :as state} [ordinal [symbol expression]]]
              (let [extent (parallel-extent expression)
                    canonical-extent (some-> extent descriptor/unwrap-int-cast)]
                (cond
                  (nil? extent)
-                 [[symbol expression]]
+                 (update state :normalized conj [symbol expression])
 
                  ;; Integral casts are representation noise, not new semantic dimensions.
                  ;; Keeping their underlying value identity also prevents one array from
                  ;; acquiring incompatible [n] and [(long n)] shapes across operations.
                  (dialect/extent? canonical-extent)
-                 [[symbol (replace-parallel-extent expression canonical-extent)]]
+                 (update state :normalized conj
+                         [symbol (replace-parallel-extent expression canonical-extent)])
 
                  (provably-pure-scalar? canonical-extent)
-                 (let [extent-id (with-meta
-                                   (clojure.core/symbol (str "rstr_extent_" ordinal))
-                                   {:tag 'long :raster.type/tag 'long})]
-                   [[extent-id canonical-extent]
-                    [symbol (replace-parallel-extent expression extent-id)]])
+                 (if-let [extent-id (get compound-extents canonical-extent)]
+                   ;; Equal pure extent expressions are one SSA value. Besides avoiding
+                   ;; redundant scalar work, this exposes equal launch geometry to the
+                   ;; general horizontal-fusion rule (for example two same-shaped views).
+                   (update state :normalized conj
+                           [symbol (replace-parallel-extent expression extent-id)])
+                   (let [extent-id (with-meta
+                                     (clojure.core/symbol (str "rstr_extent_" ordinal))
+                                     {:tag 'long :raster.type/tag 'long})]
+                     (-> state
+                         (assoc-in [:compound-extents canonical-extent] extent-id)
+                         (update :normalized into
+                                 [[extent-id canonical-extent]
+                                  [symbol (replace-parallel-extent expression extent-id)]]))))
 
                  :else
-                 [[symbol expression]])))
-           (range) pairs)]
+                 (update state :normalized conj [symbol expression]))))
+           {:normalized [] :compound-extents {}}
+           (map-indexed vector pairs))]
       (with-meta (list* head (vec (mapcat identity normalized)) body) (meta source)))
     source))
 
@@ -596,7 +661,7 @@
   [descriptions]
   (reduce set/union #{}
           (map #(if (contains? #{:map :scatter :stencil :reduce :segmented-reduce
-                                 :product-reduce :scan} (:kind %))
+                                 :product-reduce :segmented-fold-map :scan} (:kind %))
                   (:outputs %) #{})
                descriptions)))
 
@@ -625,6 +690,10 @@
                                      (seq (:result-components description))
                                      (every? (comp symbol? :destination)
                                              (:result-storage description)))
+                :segmented-fold-map
+                (and (seq (:segment-axes description)) (seq (:folds description))
+                     (every? (comp symbol? :destination)
+                             (:result-storage description)))
                 :scan (symbol? (:primary-out description))
                 false))
             descriptions)))
@@ -809,6 +878,43 @@
                  (dialect/emit-locals combine-locals)
                  (:results combine-region))))))
 
+(defn- segmented-fold-map-equation
+  [{:keys [id segment-axes index extent folds map-results inputs scalars results
+           result-dtypes]}]
+  (let [accumulator-set (set (map :accumulator folds))
+        stable (vec (sort-by pr-str inputs))
+        ;; Accumulator names are lexical across the complete ordered fold chain,
+        ;; never implicit external captures. Removing every accumulator here makes
+        ;; a reference to a later fold remain unbound and lets dialect validation
+        ;; reject it instead of silently changing its meaning into a scalar input.
+        captures (vec (sort-by pr-str
+                               (remove accumulator-set
+                                       (distinct (concat stable scalars)))))
+        capture-parameters (capture-symbols (count captures))
+        substitutions (zipmap captures capture-parameters)
+        accumulators (mapv :accumulator folds)
+        fold-forms
+        (mapv (fn [ordinal {:keys [accumulator identity dtype extent step]}]
+                (list 'fold
+                      {:accumulator accumulator :identity identity :dtype dtype
+                       :extent extent :association :ordered}
+                      (dialect/lambda-form
+                       (vec (concat [accumulator] (subvec accumulators 0 ordinal)
+                                    capture-parameters))
+                       [(util/subst-syms substitutions step)])))
+              (range) folds)
+        map-lambda
+        (dialect/lambda-form
+         (vec (concat accumulators capture-parameters))
+         (mapv #(util/subst-syms substitutions %) map-results))]
+    (list '= id results
+          (list 'segmented-fold-map
+                {:segment-axes segment-axes :index index :extent extent
+                 :association :ordered :dtypes result-dtypes
+                 :attributes {:stable-array-captures stable
+                              :source-operation :raster.par/segmented-fold-map!}}
+                [] captures fold-forms map-lambda))))
+
 (defn- scan-equation
   [{:keys [id sym index extent mode inputs scalars primary-out accumulator identity dtype body]}]
   (let [[pointwise stable] ((juxt filter remove) #(pointwise-input? [body] % index) inputs)
@@ -863,12 +969,14 @@
   [descriptions body]
   (let [physical-outputs (physical-output-symbols descriptions)
         operations (filter #(contains? #{:map :scatter :stencil :reduce :segmented-reduce
-                                         :product-reduce :scan} (:kind %)) descriptions)
+                                         :product-reduce :segmented-fold-map :scan} (:kind %))
+                           descriptions)
         operation-definitions (set (mapcat #(case (:kind %)
                                               (:map :scatter :stencil) (:results %)
                                               :scan [(:sym %)]
                                               :segmented-reduce (:results %)
                                               :product-reduce (:results %)
+                                              :segmented-fold-map (:results %)
                                               (:outputs %))
                                            operations))
         terminal-operation-definitions
@@ -877,6 +985,7 @@
                         :scan [(:sym %)]
                         :segmented-reduce (if (:effect-only? %) [] (:results %))
                         :product-reduce (if (:effect-only? %) [] (:results %))
+                        :segmented-fold-map (if (:effect-only? %) [] (:results %))
                         (:outputs %))
                      operations))
         scalar-definitions
@@ -932,6 +1041,20 @@
         {:keys [kind attributes arrays captures]} (dialect/operation-parts equation)
         extent (:extent attributes)
         dimension-ids (set (filter dialect/value-id? (dialect/operation-extents equation)))
+        dimension-value
+        (fn [id]
+          ;; A shape dimension is integral, but its representation is an ABI fact:
+          ;; GPU launch/scalar parameters are commonly :int while JVM-derived extents
+          ;; may be :long.  Preserve the already-known or declared scalar contract and
+          ;; use :long only when no upstream type information exists.
+          (or (get known-values id)
+              (when-let [declared (declared-type scalar-types id)]
+                (tensor-value declared []))
+              (when-let [declared (and (symbol? id)
+                                       (dtype/dtype-for-scalar-tag
+                                        (types/sym-type-tag id)))]
+                (tensor-value declared []))
+              (tensor-value :long [])))
         stable (set (get-in attributes [:attributes :stable-array-captures]))
         result-dtypes (case kind
                         scalar (:dtypes attributes)
@@ -940,10 +1063,11 @@
                         segmented-reduce (:dtypes attributes)
                         product-reduce (mapv #((:dtypes attributes) %)
                                              (:result-components attributes))
+                        segmented-fold-map (:dtypes attributes)
                         scan (:dtypes attributes)
                         (map scatter) (map #(value-dtype % default-dtype array-types) results))]
     (merge
-     (into {} (map (fn [id] [id (tensor-value :long [])])) dimension-ids)
+     (into {} (map (fn [id] [id (dimension-value id)])) dimension-ids)
      (into {} (map (fn [id] [id (tensor-value (value-dtype id default-dtype array-types)
                                               (dialect/extent-shape extent))]) arrays))
      (if (= 'scalar kind)
@@ -958,7 +1082,7 @@
                           [id value]))) captures)
        (into {} (map (fn [id]
                        [id (or (when (contains? dimension-ids id)
-                                 (tensor-value :long []))
+                                 (dimension-value id))
                                (get known-values id)
                                (if (or (contains? stable id)
                                        (contains? array-types id)
@@ -978,6 +1102,8 @@
                                          (dialect/segmented-reduce-result-shape attributes)
                                          product-reduce
                                          (dialect/segmented-reduce-result-shape attributes)
+                                         segmented-fold-map
+                                         (dialect/segmented-fold-map-result-shape attributes)
                                          scan (dialect/scan-result-shape attributes)
                                          scatter [(list 'unknown-dimension id)]
                                          (dialect/extent-shape extent)))])
@@ -1016,13 +1142,15 @@
                  (supported-descriptions? descriptions))
         (let [operation-descriptions
               (filterv #(contains? #{:map :scatter :stencil :reduce :segmented-reduce
-                                     :product-reduce :scan} (:kind %)) descriptions)
+                                     :product-reduce :segmented-fold-map :scan} (:kind %))
+                       descriptions)
               operation-equations (mapv #(case (:kind %) :map (map-equation %)
                                                :scatter (scatter-equation %)
                                                :stencil (stencil-equation %)
                                                :reduce (reduce-equation %)
                                                :segmented-reduce (segmented-reduce-equation %)
                                                :product-reduce (product-reduce-equation %)
+                                               :segmented-fold-map (segmented-fold-map-equation %)
                                                :scan (scan-equation %))
                                         operation-descriptions)
               outputs (terminal-results descriptions body)
@@ -1040,7 +1168,7 @@
                                   (assoc-in [:scalar-dtypes (:sym description)] result-dtype)))
                             state)
                           (:map :scatter :stencil :reduce :segmented-reduce
-                           :product-reduce :scan)
+                           :product-reduce :segmented-fold-map :scan)
                           (-> state
                               (update :equations conj
                                       (case (:kind description)
@@ -1050,6 +1178,8 @@
                                         :reduce (reduce-equation description)
                                         :segmented-reduce (segmented-reduce-equation description)
                                         :product-reduce (product-reduce-equation description)
+                                        :segmented-fold-map
+                                        (segmented-fold-map-equation description)
                                         :scan (scan-equation description)))
                               (update :equation-descriptions conj description))))
                       {:equations [] :equation-descriptions [] :scalar-dtypes {}}

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -74,6 +74,20 @@
                                 :element-lambda element-lambda
                                 :combine-lambda combine-lambda}))))
 
+(def ^:private segmented-fold-map-equation-rule
+  (from-dialect dialect/TypedSOAC
+                (rule '(= ?equation-id [??results]
+                          (segmented-fold-map ?attributes [??arrays] [??captures]
+                                              [??folds] ?map-lambda))
+                      (success {:kind :segmented-fold-map
+                                :id equation-id
+                                :results results
+                                :attributes attributes
+                                :arrays arrays
+                                :captures captures
+                                :folds folds
+                                :map-lambda map-lambda}))))
+
 (def ^:private scatter-equation-rule
   (from-dialect dialect/TypedSOAC
                 (rule '(= ?equation-id [??results]
@@ -146,10 +160,11 @@
                     (reduce-equation-rule equation)
                     (segmented-reduce-equation-rule equation)
                     (product-reduce-equation-rule equation)
+                    (segmented-fold-map-equation-rule equation)
                     (scan-equation-rule equation)])]
-    (let [{:keys [lambda element-lambda]} (dialect/operation-parts equation)]
+    (let [{:keys [lambda element-lambda map-lambda]} (dialect/operation-parts equation)]
       (merge (dissoc matched :local-definitions)
-             (dialect/lambda-parts (or lambda element-lambda))))))
+             (dialect/lambda-parts (or lambda element-lambda map-lambda))))))
 
 (defn- equation-references
   [equation]
@@ -246,6 +261,72 @@
          ;; Alias-aware fusion can be added once legality is proved. Until then, equation results
          ;; are treated as fresh SSA values and any explicit alias contract declines fusion.
          (empty? (:aliases facts)))))
+
+(declare remove-equation-fact)
+
+(defn- horizontal-boundary
+  "Return the proven write boundary of a horizontally fusible map, or nil.
+
+   Pure SSA maps have an empty boundary. Materialized maps are also safe when
+   every result has one distinct, dense unique-write destination. This is the
+   alias-aware case produced by buffer fusion; it must remain explicit because
+   combining two such maps combines their effects rather than erasing them."
+  [program info]
+  (let [equation-facts (get-in (dialect/facts program) [:equations (:id info)])
+        effects (:effects equation-facts)
+        aliases (:aliases equation-facts)
+        storage (vec (get-in equation-facts [:attributes :result-storage]))
+        destinations (mapv :destination storage)
+        expected-aliases (zipmap (:results info) destinations)]
+    (cond
+      (and (empty? effects) (empty? aliases) (empty? storage))
+      {:storage [] :destinations #{} :host-bindings {}}
+
+      (and (= #{:memory/write} effects)
+           (= (count (:results info)) (count (:body-results info)) (count storage))
+           (every? #(and (= :write (:access %))
+                         (contains? #{:buffer :effect} (:host-return %))
+                         (symbol? (:destination %)))
+                   storage)
+           (= (count destinations) (count (distinct destinations)))
+           (= expected-aliases aliases))
+      (let [saved (get-in equation-facts [:attributes :host-bindings])
+            singular (get-in equation-facts [:attributes :host-binding])
+            buffer-results (map first
+                                (filter (fn [[_ result-storage]]
+                                          (= :buffer (:host-return result-storage)))
+                                        (map vector (:results info) storage)))]
+        {:storage storage
+         :destinations (set destinations)
+         :host-bindings
+         (or saved
+             (when (seq buffer-results)
+               (into {}
+                     (map-indexed (fn [index result]
+                                    [result (if (zero? index) singular result)]))
+                     buffer-results))
+             {})})
+
+      :else nil)))
+
+(defn- merge-horizontal-facts
+  [facts left right left-boundary right-boundary]
+  (let [facts (remove-equation-fact facts (:id right) (:id left) :horizontal-map)
+        left-facts (get-in facts [:equations (:id left)])
+        storage (vec (concat (:storage left-boundary) (:storage right-boundary)))
+        host-bindings (merge (:host-bindings left-boundary)
+                             (:host-bindings right-boundary))
+        aliases (merge (zipmap (:results left) (map :destination (:storage left-boundary)))
+                       (zipmap (:results right) (map :destination (:storage right-boundary))))
+        effects (if (seq storage) #{:memory/write} #{})]
+    (-> facts
+        (assoc-in [:equations (:id left) :effects] effects)
+        (assoc-in [:equations (:id left) :aliases] aliases)
+        (assoc-in [:equations (:id left) :attributes]
+                  (cond-> (:attributes left-facts)
+                    (seq storage) (assoc :result-storage storage
+                                         :host-bindings host-bindings)
+                    (empty? storage) (dissoc :result-storage :host-binding :host-bindings))))))
 
 (defn- value-scalar-dtype
   "Return the canonical scalar dtype carried by one logical tensor value, or nil.
@@ -677,28 +758,37 @@
            right-index (range (inc left-index) (count infos))
            :let [left (nth infos left-index)
                  right (nth infos right-index)
+                 left-boundary (horizontal-boundary program left)
+                 right-boundary (horizontal-boundary program right)
                  left-results (set (:results left))
                  right-results (set (:results right))
                  left-uses (set (concat (:arrays left) (:captures left)))
                  right-uses (set (concat (:arrays right) (:captures right)
                                          [(:extent (:attributes right))]))]
            :when (= :map (:kind left) (:kind right))
+           :when left-boundary
+           :when right-boundary
            :when (= (:extent (:attributes left)) (:extent (:attributes right)))
            :when (empty? (set/intersection left-results right-uses))
            :when (empty? (set/intersection right-results left-uses))
+           :when (empty? (set/intersection (:destinations left-boundary)
+                                           (:destinations right-boundary)))
+           :when (empty? (set/intersection (:destinations left-boundary) right-uses))
+           :when (empty? (set/intersection (:destinations right-boundary) left-uses))
            ;; Moving the right equation to the left's position must not move it before an
            ;; intervening producer. Program inputs have no producer index and are always ready.
            :when (every? (fn [value]
                            (let [index (get producer-index value)]
                              (or (nil? index) (< index left-index))))
                          right-uses)
-           :when (fusible-equation? program (:id left))
-           :when (fusible-equation? program (:id right))]
-       {:left-index left-index :right-index right-index :left left :right right}))))
+           ]
+       {:left-index left-index :right-index right-index :left left :right right
+        :left-boundary left-boundary :right-boundary right-boundary}))))
 
 (defn- fuse-horizontal-once
   [program]
-  (when-let [{:keys [left-index right-index left right]} (horizontal-candidate program)]
+  (when-let [{:keys [left-index right-index left right left-boundary right-boundary]}
+             (horizontal-candidate program)]
     (let [left (freshen-parameters left "left")
           right (freshen-parameters right "right")
           left-parameters (parameter-parts left)
@@ -738,8 +828,8 @@
                         (->> (keep-indexed (fn [index equation]
                                              (when-not (= index right-index) equation)))
                              vec))
-          facts (remove-equation-fact (dialect/facts program) (:id right) (:id left)
-                                      :horizontal-map)]
+          facts (merge-horizontal-facts (dialect/facts program) left right
+                                        left-boundary right-boundary)]
       (rebuild-boundary program facts equations))))
 
 (defn- placement-key

--- a/src/raster/compiler/passes/parallel/typed_soac_projection.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_projection.clj
@@ -163,6 +163,39 @@
     (with-meta form {:raster.type/elem-type
                      ((:dtypes attributes) (first result-components))})))
 
+(defn segmented-fold-map-form
+  "Spell one validated ordered fold-map in Raster's interpreted host vocabulary."
+  [program equation]
+  (let [program (dialect/validate! program)
+        [_ equation-id results] equation
+        {:keys [kind attributes captures folds map-lambda]}
+        (dialect/operation-parts equation)
+        physical-results (dialect/physical-results program equation)
+        map-region (dialect/lambda-parts map-lambda)
+        accumulators (mapv #(get-in % [:attributes :accumulator]) folds)
+        capture-parameters (vec (drop (count accumulators) (:parameters map-region)))
+        substitutions (zipmap capture-parameters captures)
+        _ (when-not (and (= 'segmented-fold-map kind)
+                         (= (count results) (count physical-results)
+                            (count (:body-results map-region))))
+            (throw (ex-info "fold-map projection requires aligned logical and physical results"
+                            {:reason :typed-soac-segmented-fold-map-projection
+                             :equation equation-id :kind kind :results results
+                             :physical-results physical-results})))
+        source-folds
+        (mapv (fn [{:keys [attributes lambda]}]
+                (let [{:keys [body-results]} (dialect/lambda-parts lambda)]
+                  [(:accumulator attributes) (:identity attributes) (:dtype attributes)
+                   (:extent attributes)
+                   (util/subst-syms substitutions (first body-results))]))
+              folds)
+        form (list 'raster.par/segmented-fold-map!
+                   physical-results (:segment-axes attributes)
+                   (:index attributes) (:extent attributes) source-folds
+                   (mapv #(util/subst-syms substitutions %)
+                         (:body-results map-region)))]
+    (with-meta form {:raster.type/elem-type (first (:dtypes attributes))})))
+
 (defn stencil-form
   "Spell one validated stencil equation in Raster's interpreted host vocabulary."
   [program equation]

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -40,18 +40,21 @@
 
 (defn- scalar-region
   [equation]
-  (let [{:keys [attributes arrays captures lambda element-lambda]}
-        (dialect/operation-parts equation)
-        {:keys [locals body-results]} (dialect/lambda-parts (or lambda element-lambda))
-        {:keys [elements capture-parameters]} (dialect/parameter-layout equation)
-        substitutions
-        (into (zipmap capture-parameters captures)
-              (map (fn [parameter array]
-                     [parameter (list 'clojure.core/aget array (:index attributes))])
-                   elements arrays))]
-    {:locals (mapv #(update % :init (fn [init] (util/subst-syms substitutions init)))
-                   locals)
-     :bodies (mapv #(util/subst-syms substitutions %) body-results)}))
+  (let [{:keys [kind attributes arrays captures lambda element-lambda]}
+        (dialect/operation-parts equation)]
+    (if (= 'segmented-fold-map kind)
+      {:locals [] :bodies []}
+      (let [{:keys [locals body-results]}
+            (dialect/lambda-parts (or lambda element-lambda))
+            {:keys [elements capture-parameters]} (dialect/parameter-layout equation)
+            substitutions
+            (into (zipmap capture-parameters captures)
+                  (map (fn [parameter array]
+                         [parameter (list 'clojure.core/aget array (:index attributes))])
+                       elements arrays))]
+        {:locals (mapv #(update % :init (fn [init] (util/subst-syms substitutions init)))
+                       locals)
+         :bodies (mapv #(util/subst-syms substitutions %) body-results)}))))
 
 (defn- materialize-region
   [locals body]
@@ -120,11 +123,12 @@
               storage (dialect/result-storage (dialect/facts program) equation-id)
               physical-results (dialect/physical-results (dialect/facts program) equation)
               host-binding (or (get-in placement-facts [:attributes :host-binding]) result)
+              host-bindings (or (get-in placement-facts [:attributes :host-bindings])
+                                {result host-binding})
               host-returns (set (map :host-return storage))
               _ (when (and storage
                            (not (or (= #{:effect} host-returns)
-                                    (and (= 1 (count storage))
-                                         (= #{:buffer} host-returns)))))
+                                    (= #{:buffer} host-returns))))
                   (throw (ex-info "stored map results require one coherent host return contract"
                                   {:reason :typed-soac-production-subset
                                    :equation equation-id :storage storage})))
@@ -164,7 +168,12 @@
           {:equation-id equation-id
            :placement placement
            :pairs (if storage
-                    [[host-binding source]]
+                    (into [[host-binding source]]
+                          (keep (fn [[logical destination]]
+                                  (let [binding (get host-bindings logical)]
+                                    (when (and binding (not= binding host-binding))
+                                      [binding destination])))
+                                (map vector results physical-results)))
                     (conj (mapv #(allocation-pair values % (:extent attributes)) results)
                           [effect source]))
            :site [:binding (if storage host-binding effect)]
@@ -258,6 +267,16 @@
          :site [:binding host-binding]
          :source source})
 
+      segmented-fold-map
+      (let [host-binding (or (get-in placement-facts [:attributes :host-binding])
+                             (first results))
+            source (projection/segmented-fold-map-form program equation)]
+        {:equation-id equation-id
+         :placement placement
+         :pairs [[host-binding source]]
+         :site [:binding host-binding]
+         :source source})
+
       scan
       (let [result (first results)
             mode (:mode attributes)
@@ -311,6 +330,11 @@
         original-pairs (vec (partition 2 bindings))
         realized (mapv #(realize-equation program %) (dialect/equations program))
         by-placement (group-by :placement realized)
+        realized-host-symbols
+        (into #{} (mapcat (fn [equation]
+                            (keep (fn [[symbol _]] (when (symbol? symbol) symbol))
+                                  (:pairs equation))))
+              realized)
         physical-destinations
         (into #{}
               (mapcat (fn [[_ equation-facts]]
@@ -321,8 +345,12 @@
               (:equations (dialect/facts program)))
         host-bindings
         (required-host-bindings
-         (keep-indexed (fn [id pair]
-                         (when (empty? (get by-placement id)) pair))
+         (keep-indexed (fn [_ [symbol :as pair]]
+                         ;; A fused equation may be placed at a later constituent while
+                         ;; defining a host symbol whose original source pair occurred earlier.
+                         ;; That symbol is globally realized; retaining its old pair would execute
+                         ;; the producer twice and bypass the fused schedule.
+                         (when-not (contains? realized-host-symbols symbol) pair))
                        original-pairs)
          (set/union physical-destinations
                     (into #{} (mapcat util/free-syms) body)))
@@ -338,6 +366,7 @@
                ;; leaves CPU-C/JVM materialization with an unbound destination and also loses a
                ;; resident scratch allocation before GPU extraction.
                (when (and (contains? host-bindings symbol)
+                          (not (contains? realized-host-symbols symbol))
                           (empty? (get by-placement id)))
                  [original-pair])
                (mapcat :pairs (get by-placement id)))))
@@ -404,7 +433,8 @@
                  (resident/realize typed-result)
                  [typed-result {:resident-reductions 0 :inlined-scalars 0}])]
            (if (not-any? #(contains? #{:map :scatter :stencil :reduce
-                                       :segmented-reduce :product-reduce :scan}
+                                       :segmented-reduce :product-reduce
+                                       :segmented-fold-map :scan}
                                      (:kind (fusion/equation-info %)))
                          (dialect/equations typed-result))
              {:declined {:reason :no-certified-parallel-equation

--- a/src/raster/compiler/passes/scalar/effects.clj
+++ b/src/raster/compiler/passes/scalar/effects.clj
@@ -8,6 +8,7 @@
    The raster context pre-registers raster.numeric and raster.math vars
    as :pure so beichte doesn't need to analyze their source each time."
   (:require [beichte.core :as b]
+            [clojure.walk :as walk]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.form :as form]))
@@ -125,6 +126,23 @@
   [v]
   (b/analyze-var v @raster-context))
 
+(defn- semantic-calls
+  "Restore walker-devirtualized calls to the source-level operation recorded in
+   their metadata before handing the expression to Beichte.  `.invk` is Raster
+   dispatch IR, not a Clojure call Beichte can resolve; the carried
+   :raster.op/original identity is the authoritative semantic seam.  Unknown
+   `.invk` forms deliberately remain unchanged and therefore classify
+   conservatively."
+  [expr]
+  (walk/postwalk
+   (fn [node]
+     (if (and (seq? node) (= '.invk (first node)))
+       (if-let [operation (descriptor/semantic-op node)]
+         (with-meta (apply list operation (descriptor/call-args node)) (meta node))
+         node)
+       node))
+   expr))
+
 (defn descriptor
   "Return the effect descriptor for a compiler IR expression.
 
@@ -137,8 +155,9 @@
   (if (not (seq? expr))
     {:effect :pure :flags #{}}
     (try
-      (let [locals (collect-locals expr)
-            result (b/analyze-full expr @raster-context locals)]
+      (let [semantic-expr (semantic-calls expr)
+            locals (collect-locals semantic-expr)
+            result (b/analyze-full semantic-expr @raster-context locals)]
         (if (map? result)
           (update result :flags #(or % #{}))
           {:effect (or result :io) :flags #{}}))

--- a/src/raster/compiler/passes/scalar/effects.clj
+++ b/src/raster/compiler/passes/scalar/effects.clj
@@ -176,8 +176,15 @@
          (empty? flags))))
 
 (defn cse-safe-expr?
-  "True if an expression is safe to common-subexpression eliminate."
+  "True if an expression is safe to common-subexpression eliminate.
+
+   External purity is necessary but not sufficient: an allocator is removable
+   when its result is dead, yet two live allocations have distinct mutable
+   identities and must never be coalesced.  Keep that distinction here rather
+   than teaching individual compiler markers or consumers to protect their
+   operands."
   [expr]
   (and (seq? expr)
        (symbol? (first expr))
+       (not (descriptor/alloc-op? (form/effective-op expr)))
        (removable-expr? expr)))

--- a/src/raster/compiler/passes/scalar/inline.clj
+++ b/src/raster/compiler/passes/scalar/inline.clj
@@ -1717,6 +1717,31 @@
                   (mapv #(resolve-dispatch-walk % combine-result-env) combine-results)
                   algebra)]
       (if-let [m (meta expr)] (with-meta r m) r))
+    ;; segmented-fold-map!: each ordered accumulator is visible to later folds and the final map.
+    (and (symbol? (first expr))
+         (contains? #{'raster.par/segmented-fold-map! 'par/segmented-fold-map!} (first expr)))
+    (let [[head outputs segment-axes idx map-extent folds map-results] expr
+          index-env (into (assoc env idx 'long)
+                          (map (fn [[segment _]] [segment 'long]) segment-axes))
+          [fold-env folds']
+          (reduce (fn [[current result] [acc init dtype extent step]]
+                    (let [init' (resolve-dispatch-walk init current)
+                          tag (or (case dtype
+                                    :float 'float :double 'double :int 'int :long 'long nil)
+                                  (inf/infer-arg-tag init' current))
+                          step-env (cond-> current tag (assoc acc tag))]
+                      [(cond-> current tag (assoc acc tag))
+                       (conj result [acc init' dtype
+                                     (resolve-dispatch-walk extent current)
+                                     (resolve-dispatch-walk step step-env)])]))
+                  [index-env []] folds)
+          r (list head outputs
+                  (mapv (fn [[segment bound]]
+                          [segment (resolve-dispatch-walk bound env)])
+                        segment-axes)
+                  idx (resolve-dispatch-walk map-extent env) (vec folds')
+                  (mapv #(resolve-dispatch-walk % fold-env) map-results))]
+      (if-let [m (meta expr)] (with-meta r m) r))
     ;; Qualified symbol call: try dispatch resolution then recurse into args
     (and (symbol? (first expr)) (namespace (first expr)))
     (let [;; First recurse into args so nested calls get resolved

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -611,7 +611,8 @@
   [head]
   (or (contains? '#{raster.par/map-void! par/map-void!
                     raster.par/map2! par/map2!
-                    raster.par/product-reduce! par/product-reduce! dotimes} head)
+                    raster.par/product-reduce! par/product-reduce!
+                    raster.par/segmented-fold-map! par/segmented-fold-map! dotimes} head)
       (contains? census-exempt-int-arith-heads head)
       (= :vector head)))
 

--- a/src/raster/dl/attention.clj
+++ b/src/raster/dl/attention.clj
@@ -1111,28 +1111,31 @@
                                                 acc))]
                                     (/ dot (n/oftype dot (n/sqrt (double head-dim)))))
                                   0.0)))]
-         ;; kernel 2: per query row — mx/Z over the ≤i scores, write normalized weights
-         (raster.par/map-void! bi (clojure.core/* batch seq-len)
-                               (let [b (quot bi seq-len)
-                                     i (rem bi seq-len)
-                                     roff (clojure.core/+ (clojure.core/* b ss) (clojure.core/* i seq-len))
-                                     mx (loop [j 0 mm -1.0e38]
-                                          (if (<= j i)
-                                            (recur (inc j) (n/max mm (aget scores (clojure.core/+ roff j))))
-                                            mm))
-                                     sum (loop [j 0 s 0.0]
-                                           (if (<= j i)
-                                             (recur (inc j) (+ s (m/exp (- (aget scores (clojure.core/+ roff j)) mx))))
-                                             s))
-                                     inv (/ 1.0 sum)]
-                                 (loop [j 0]
-                                   (if (< j seq-len)
-                                     (do (if (<= j i)
-                                           (aset W (clojure.core/+ roff j)
-                                                 (* (m/exp (- (aget scores (clojure.core/+ roff j)) mx)) inv))
-                                           (aset W (clojure.core/+ roff j) 0.0))
-                                         (recur (inc j)))
-                                     nil))))
+         ;; kernel 2: a generic ordered segmented fold-map. Rows are independent parallel
+         ;; segments; max and denominator are dependent ordered folds; the final dense map writes
+         ;; both the visible softmax and explicit causal zeroes. Attention is not a compiler op.
+         (raster.par/segmented-fold-map!
+          [W] [[b batch] [i seq-len]] j seq-len
+          [[mx -1.0e38 :element (clojure.core/inc i)
+            (n/max mx
+                   (aget scores
+                         (clojure.core/+ (clojure.core/* b ss)
+                                         (clojure.core/* i seq-len) j)))]
+           [sum 0.0 :element (clojure.core/inc i)
+            (+ sum
+               (m/exp
+                (- (aget scores
+                         (clojure.core/+ (clojure.core/* b ss)
+                                         (clojure.core/* i seq-len) j))
+                   mx)))]]
+          [(if (<= j i)
+             (/ (m/exp
+                 (- (aget scores
+                          (clojure.core/+ (clojure.core/* b ss)
+                                          (clojure.core/* i seq-len) j))
+                    mx))
+                sum)
+             0.0)])
          W)))
 
 (deftm batched-causal-attn-dw

--- a/src/raster/par.clj
+++ b/src/raster/par.clj
@@ -15,7 +15,8 @@
   Common array operations are provided as deftm wrappers that use
   broadcast/reduce! internally and participate in typed dispatch."
   (:refer-clojure :exclude [aget aset alength aclone reduce map pmap])
-  (:require [raster.core :refer [deftm broadcast reduce!]] ;; broadcast/reduce! are typed-macro stubs; scan defined locally
+  (:require [clojure.walk :as walk]
+            [raster.core :refer [deftm broadcast reduce!]] ;; broadcast/reduce! are typed-macro stubs; scan defined locally
             [raster.arrays :refer [aget aset alength aclone]]
             [raster.numeric :as n]
             [raster.compiler.ir.par :as ir.par]))
@@ -200,6 +201,72 @@
         segmented (clojure.core/reduce (fn [body [segment bound]]
                                          `(dotimes [~segment (int ~bound)] ~body))
                                        fold (reverse segment-axes))]
+    `(do ~segmented nil)))
+
+(defmacro segmented-fold-map!
+  "Ordered folds followed by a dense map, independently for every segment.
+
+  Form:
+    (segmented-fold-map! outputs
+      [[segment-index segment-bound] ...]
+      index map-extent
+      [[accumulator identity dtype fold-extent step] ...]
+      [map-result ...])
+
+  Fold `n` may reference the completed results of folds `0..n-1`. `:element` denotes the
+  surrounding tensor element dtype; the typed frontend resolves it before scheduling.  The
+  interpreted fallback preserves the declared fold order exactly. Accelerator schedules may
+  parallelize segments, but must not reassociate an ordered fold.
+
+  The result buffers are dense row-major tensors with shape
+  `[segment-bound ... map-extent]`. This is a general row-statistics primitive: softmax,
+  normalization and ragged scientific reductions are applications, not compiler operations."
+  [outputs segment-axes idx-sym map-extent folds map-results]
+  (assert (and (vector? outputs) (seq outputs) (every? symbol? outputs))
+          "segmented-fold-map!: outputs must be a non-empty symbol vector")
+  (assert (and (vector? segment-axes) (seq segment-axes)
+               (every? #(and (vector? %) (= 2 (count %)) (symbol? (first %)))
+                       segment-axes))
+          "segmented-fold-map!: segment axes must be [[index bound] ...]")
+  (assert (symbol? idx-sym) "segmented-fold-map!: map index must be a symbol")
+  (assert (and (vector? folds) (seq folds)
+               (every? #(and (vector? %) (= 5 (count %)) (symbol? (first %))) folds))
+          "segmented-fold-map!: folds must be [[acc identity dtype extent step] ...]")
+  (assert (= (count outputs) (count map-results))
+          "segmented-fold-map!: outputs and map results must have equal arity")
+  (let [flat-index
+        (clojure.core/reduce
+         (fn [flat [index bound]] `(+ (* ~flat (long ~bound)) ~index))
+         0 (conj (vec segment-axes) [idx-sym map-extent]))
+        cast-result
+        (fn [dtype value]
+          (if-let [cast (get {:float `float :double `double :int `int :long `long
+                              :byte `byte}
+                             dtype)]
+            `(~cast ~value)
+            value))
+        stores (mapv (fn [output result]
+                       `(clojure.core/aset ~output ~flat-index ~result))
+                     outputs map-results)
+        mapped `(dotimes [~idx-sym (int ~map-extent)] ~@stores)
+        folded
+        (clojure.core/reduce
+         (fn [body [acc identity dtype fold-extent step]]
+           (let [fold-index (gensym "fold_index__")
+                 folded-value (gensym "fold_value__")]
+             `(let [~folded-value
+                    (loop [~fold-index (long 0) ~acc ~identity]
+                      (if (< ~fold-index (long ~fold-extent))
+                        (recur (unchecked-inc ~fold-index)
+                               ~(cast-result dtype
+                                             (walk/postwalk-replace {idx-sym fold-index} step)))
+                        ~acc))]
+                (let [~acc ~folded-value] ~body))))
+         mapped (reverse folds))
+        segmented (clojure.core/reduce
+                   (fn [body [segment bound]]
+                     `(dotimes [~segment (int ~bound)] ~body))
+                   folded (reverse segment-axes))]
     `(do ~segmented nil)))
 
 (defmacro contract

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -16,6 +16,8 @@
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]
             [raster.compiler.passes.parallel.register-tiled-body :as register-tiled-body]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-schedule :as schedule]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
+            [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]))
 
 (defn- reduction-artifact
@@ -74,6 +76,48 @@
         kernel-body (:kernel-body (register-tiled-body/lower facts {}))]
     (body-emit/emit-scalar-kernel
      "register_tiled_contraction" kernel-body {:target-dialect dialect})))
+
+(defn- segmented-fold-map-artifact
+  [dialect]
+  (let [source
+        '(let* [effect
+                (raster.par/segmented-fold-map!
+                 [out] [[segment nsegments]] index width
+                 [[maximum -1.0E38 :float width
+                   (clojure.core/max
+                    maximum
+                    (clojure.core/aget values
+                                       (clojure.core/+ (clojure.core/* segment width) index)))]
+                  [denominator 0.0 :float width
+                   (clojure.core/+
+                    denominator
+                    (Math/exp
+                     (clojure.core/-
+                      (clojure.core/aget
+                       values (clojure.core/+ (clojure.core/* segment width) index))
+                      maximum)))]]
+                 [(clojure.core//
+                   (Math/exp
+                    (clojure.core/-
+                     (clojure.core/aget
+                      values (clojure.core/+ (clojure.core/* segment width) index))
+                     maximum))
+                   denominator)])]
+               effect)
+        program (:program
+                 (typed-route/attempt
+                  source :float {'values :float 'out :float}
+                  {:scalar-types {'nsegments :int 'width :int}}))
+        scheduled (:form
+                   (segop-lower/segop-lower-pass
+                    program {:dtype :float :target-device :ocl:0
+                             :array-types {'values :float 'out :float}
+                             :scalar-types {'nsegments :int 'width :int}}))
+        operation (first (:operations (first (:equations scheduled))))]
+    (segop-emit/generate-segfoldmap-kernel
+     operation :target-dialect dialect :kernel-name-prefix "segmented_fold_map"
+     :array-types {'values :float 'out :float}
+     :scalar-types {'nsegments :int 'width :int})))
 
 (defn- problem []
   (attention/make
@@ -148,6 +192,8 @@
                             (reduction-artifact dialect))
            (write-artifact! directory suffix "portable-contraction"
                             (contraction-artifact dialect descriptor))
+           (write-artifact! directory suffix "segmented-fold-map"
+                            (segmented-fold-map-artifact dialect))
            (write-source! directory suffix "register-tiled-contraction"
                           (register-tiled-contraction-source dialect))
            (write-source! directory suffix "workgroup-memory"

--- a/test/raster/compiler/backend/gpu/opencl_codegen_test.clj
+++ b/test/raster/compiler/backend/gpu/opencl_codegen_test.clj
@@ -14,7 +14,9 @@
   (testing "Question mark to _p"
     (is (= "nil_p" (ce/c-symbol 'nil?))))
   (testing "Combined"
-    (is (= "has_value_p" (ce/c-symbol 'has-value?)))))
+    (is (= "has_value_p" (ce/c-symbol 'has-value?))))
+  (testing "Unicode alpha-renamed binders are portable C identifiers"
+    (is (= "y__u03b1__42" (ce/c-symbol 'y_α_42)))))
 
 (deftest shared-emit-expr-test
   (testing "Number literals"

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -31,11 +31,11 @@
               :fallback-reasons [] :declines {}}}
 
   :gqa-causal-mha-gpu
-  {:route {:backend :opencl :source-dialect :compatibility :typed-validated false
-           :declines {[:segop-lowered-stats :segops-declined :no-lowering-rule] 1}}
-   :fusion {:vertical 0 :horizontal 2 :iterations 2 :placements 0}
-   :lowering {:segops 6 :kernel-graphs 0 :typed-reused 0 :typed-scalar-equations 0
-              :backend-reused 4 :backend-relowered 0 :fallback 0}
+  {:route {:backend :opencl :source-dialect :typed-soac :typed-validated true
+           :declines {}}
+   :fusion {:vertical 0 :horizontal 2 :iterations 3 :placements 0}
+   :lowering {:segops 7 :kernel-graphs 0 :typed-reused 7 :typed-scalar-equations 12
+              :backend-reused 7 :backend-relowered 0 :fallback 0}
    :emission {:kernel-count 7 :targets [:opencl-c] :strategies []
               :fallback-reasons [] :declines {}}}
 

--- a/test/raster/compiler/passes/parallel/typed_segmented_fold_map_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_segmented_fold_map_test.clj
@@ -1,0 +1,155 @@
+(ns raster.compiler.passes.parallel.typed-segmented-fold-map-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.segop-opencl :as segop-opencl]
+            [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.passes.parallel.segfoldmap-body :as fold-body]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
+            [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
+            [raster.compiler.passes.parallel.typed-soac-route :as route]
+            [raster.par :as par]))
+
+(def ^:private source
+  '(let* [effect
+          (raster.par/segmented-fold-map!
+           [out] [[segment nsegments]] index width
+           [[maximum -1.0E38 :float width
+             (clojure.core/max
+              maximum
+              (clojure.core/aget values
+                                 (clojure.core/+ (clojure.core/* segment width) index)))]
+            [denominator 0.0 :float width
+             (clojure.core/+
+              denominator
+              (Math/exp
+               (clojure.core/-
+                (clojure.core/aget values
+                                   (clojure.core/+ (clojure.core/* segment width) index))
+                maximum)))]]
+           [(clojure.core//
+             (Math/exp
+              (clojure.core/-
+               (clojure.core/aget values
+                                  (clojure.core/+ (clojure.core/* segment width) index))
+               maximum))
+             denominator)])]
+         effect))
+
+(defn- scheduled-operation []
+  (let [program (:program
+                 (route/attempt source :float {'values :float 'out :float}
+                                {:scalar-types {'nsegments :int 'width :int}}))
+        scheduled (:form
+                   (segop-lower/segop-lower-pass
+                    program {:dtype :float :target-device :ocl:0
+                             :array-types {'values :float 'out :float}
+                             :scalar-types {'nsegments :int 'width :int}}))]
+    (first (:operations (first (:equations scheduled))))))
+
+(deftest interpreted-segmented-fold-map-preserves-dependent-fold-order
+  (let [values (float-array [1.0 3.0, 2.0 2.0])
+        out (float-array 4)]
+    (par/segmented-fold-map!
+     [out] [[segment 2]] index 2
+     [[maximum -1.0E38 :float 2
+       (max maximum (aget values (+ (* segment 2) index)))]
+      [denominator 0.0 :float 2
+       (+ denominator (Math/exp (- (aget values (+ (* segment 2) index)) maximum)))]]
+     [(/ (Math/exp (- (aget values (+ (* segment 2) index)) maximum)) denominator)])
+    (is (< (Math/abs (- (aget out 0) 0.11920292)) 1.0e-6))
+    (is (< (Math/abs (- (aget out 1) 0.8807971)) 1.0e-6))
+    (is (< (Math/abs (- (aget out 2) 0.5)) 1.0e-6))
+    (is (< (Math/abs (- (aget out 3) 0.5)) 1.0e-6))))
+
+(deftest dependent-folds-are-first-class-typed-soac
+  (let [program (frontend/form->program
+                 source {:dtype :float :array-types {'values :float 'out :float}
+                         :scalar-types {'nsegments :int 'width :int}})
+        equation (first (dialect/equations program))
+        operation (dialect/operation-parts equation)]
+    (is (= 'segmented-fold-map (:kind operation)))
+    (is (= 2 (count (:folds operation))))
+    (is (= '[nsegments values width] (:inputs (dialect/facts program))))
+    (is (= '[out] (dialect/physical-results program equation)))
+    (is (= :int (:dtype (get-in (dialect/facts program) [:values 'width])))
+        "launch dimensions retain their declared ABI representation")))
+
+(deftest portable-schedule-is-three-explicit-ordered-loops
+  (let [operation (scheduled-operation)
+        {:keys [kernel-body]} (fold-body/lower
+                               operation {:workgroup-size 64
+                                          :array-types {'values :float 'out :float}
+                                          :scalar-types {'nsegments :int 'width :int}})
+        loops (filterv #(instance? raster.compiler.ir.kernel_body.ForLoop %)
+                       (:operations kernel-body))]
+    (is (= 3 (count loops)) "maximum, denominator, then the final dense map")
+    (is (= [:ordered :ordered :ordered]
+           (mapv #(get-in % [:attributes :association]) loops)))
+    (is (str/includes? (pr-str (second loops)) "maximum")
+        "the second fold consumes the completed first fold")
+    (is (empty? (:iter-args (last loops))))
+    (is (= :final-map (get-in (last loops) [:attributes :role])))
+    (is (= ['values] (mapv :buffer (:stable-reads kernel-body))))))
+
+(deftest one-certified-schedule-emits-for-all-c-family-targets
+  (let [operation (scheduled-operation)]
+    (doseq [[target expected]
+            [[:opencl-portable :opencl-c]
+             [:cuda :cuda-c]
+             [:hip :hip-cpp]]]
+      (testing (name target)
+        (let [kernel (segop-opencl/generate-segfoldmap-kernel
+                      operation :target-dialect target
+                      :array-types {'values :float 'out :float}
+                      :scalar-types {'nsegments :int 'width :int})]
+          (is (artifact/kernel-artifact? kernel))
+          (is (= expected (:target kernel)))
+          (is (= :no-write-alias (get-in kernel [:abi 0 :aliasing])))
+          (is (every? #(<= (int %) 127) (:source kernel))))))))
+
+(deftest scalar-captures-retain-their-typed-abi
+  (let [scaled-source
+        '(let* [effect
+                (raster.par/segmented-fold-map!
+                 [out] [[segment nsegments]] index width
+                 [[sum 0.0 :float width
+                   (clojure.core/+ sum
+                                   (clojure.core/aget values
+                                                      (clojure.core/+ (clojure.core/* segment width)
+                                                                      index)))]]
+                 [(clojure.core/* scale sum)])]
+               effect)
+        program (:program
+                 (route/attempt scaled-source :float {'values :float 'out :float}
+                                {:scalar-types {'nsegments :int 'width :int 'scale :float}}))
+        operation (-> (segop-lower/segop-lower-pass
+                       program {:dtype :float :target-device :ocl:0
+                                :array-types {'values :float 'out :float}
+                                :scalar-types {'nsegments :int 'width :int 'scale :float}})
+                      :form :equations first :operations first)
+        kernel (segop-opencl/generate-segfoldmap-kernel
+                operation :target-dialect :opencl-portable
+                :array-types {'values :float 'out :float}
+                :scalar-types {'nsegments :int 'width :int 'scale :float})
+        scale-parameter (some #(when (= 'scale (:name %)) %) (:abi kernel))]
+    (is (= :float (:dtype scale-parameter)))
+    (is (str/includes? (:source kernel) "float scale"))))
+
+(deftest a-fold-cannot-reference-a-future-accumulator
+  (let [bad
+        '(let* [effect
+                (raster.par/segmented-fold-map!
+                 [out] [[segment nsegments]] index width
+                 [[first 0.0 :float width (clojure.core/+ first future)]
+                  [future 0.0 :float width (clojure.core/+ future 1.0)]]
+                 [first])]
+               effect)]
+    (try
+      (frontend/form->program
+       bad {:dtype :float :array-types {'out :float}
+            :scalar-types {'nsegments :int 'width :int}})
+      (is false "future fold dependencies must fail validation")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :typed-soac-segmented-fold-map-fold-closure
+               (:reason (ex-data exception))))))))

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -362,7 +362,7 @@
                     :scalar-types {'n :long}})
           (is false "an aliased output invalidates stable neighborhood reads")
           (catch clojure.lang.ExceptionInfo exception
-            (is (= :typed-soac-stencil-alias (:reason (ex-data exception))))))))))
+            (is (= :typed-soac-stable-read-alias (:reason (ex-data exception))))))))))
 
 (deftest explicit-contraction-result-transform-stays-in-typed-soac
   (let [transform {:acc 'acc

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -575,6 +575,40 @@
            (mapv :kind (:abi kernel))))
     (is (re-find #"__global float\* restrict [uv]" (:source kernel)))))
 
+(deftest typed-horizontal-fusion-combines-distinct-materialized-write-boundaries
+  (let [source '(let* [u (raster.par/map! u-out i n float
+                                           (* (clojure.core/aget a i) 2.0))
+                       v (raster.par/map! v-out j n float
+                                           (+ (clojure.core/aget b j) 1.0))]
+                      [u v])
+        {:keys [program stats]}
+        (route/attempt source :float
+                       {'a :float 'b :float 'u-out :float 'v-out :float}
+                       {:scalar-types {'n :int}})
+        projected (:source program)
+        scheduled (:form
+                   (segop-lower/segop-lower-pass
+                    program {:dtype :float :target-device :ocl:0
+                             :array-types {'a :float 'b :float
+                                           'u-out :float 'v-out :float}
+                             :scalar-types {'n :int}}))
+        emitted (opencl-pass/opencl-pass scheduled :device-id :ocl:0
+                                         :dtype :float :min-elements 1)
+        parallel-forms (filter #(and (seq? %)
+                                     (contains? #{'raster.par/map! 'raster.par/map-void!}
+                                                (first %)))
+                               (tree-seq coll? seq projected))]
+    (is (= 1 (:horizontal stats)))
+    (is (= 1 (count parallel-forms))
+        "host projection must not resurrect either original producer")
+    (is (= 1 (count (:equations program))))
+    (is (= 1 (count (:kernels emitted))))
+    (is (= 1 (get-in emitted [:stats :segop-reused])))
+    (is (nil? (get-in emitted [:stats :segop-relowered])))
+    (is (= #{'u-out 'v-out}
+           (set (map :destination
+                     (get-in program [:equations 0 :attributes :result-storage])))))))
+
 (deftest effect-only-tuple-map-lowers-to-one-explicit-multi-output-segmap
   (let [source
         '(let* [effect

--- a/test/raster/compiler/passes/scalar/cse_test.clj
+++ b/test/raster/compiler/passes/scalar/cse_test.clj
@@ -23,6 +23,18 @@
           {:keys [stats]} (cse/cse-let form)]
       (is (= 0 (:cse-aliases stats))))))
 
+(deftest fresh-allocations-are-removable-but-not-commonable
+  (testing "devirtualized pure allocators retain distinct mutable identities"
+    (let [allocation
+          (with-meta
+            '(.invk raster.arrays/zeros-like_m_floats_long-impl exemplar n)
+            {:raster.op/original 'raster.arrays/zeros-like
+             :raster.type/tag 'floats :tag 'floats})
+          form (list 'let* ['q allocation 'k allocation] '[q k])
+          {:keys [form stats]} (cse/cse-let form)]
+      (is (= 0 (:cse-aliases stats)))
+      (is (= allocation (second (second (partition 2 (second form)))))))))
+
 (deftest no-cse-for-different-exprs-test
   (testing "different expressions stay independent"
     (let [{:keys [stats]} (cse/cse-let '(let* [a (Math/sin x) b (Math/cos x)] (+ a b)))]

--- a/test/raster/compiler/passes/scalar/effects_test.clj
+++ b/test/raster/compiler/passes/scalar/effects_test.clj
@@ -1,0 +1,15 @@
+(ns raster.compiler.passes.scalar.effects-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.passes.scalar.effects :as effects]))
+
+(deftest beichte-analyzes-the-semantic-operation-behind-invk
+  (let [pure-call
+        (with-meta
+          '(.invk raster.numeric/_star__m_long_long-impl rows width)
+          {:raster.op/original 'raster.numeric/*
+           :raster.type/tag 'long :tag 'long})
+        unknown-call '(.invk user/unknown-impl rows width)]
+    (is (= {:effect :pure :flags #{}} (effects/descriptor pure-call)))
+    (is (effects/removable-expr? pure-call))
+    (is (not (effects/removable-expr? unknown-call))
+        "an invk without certified semantic metadata remains conservative")))

--- a/test/raster/compiler/passes/scalar/effects_test.clj
+++ b/test/raster/compiler/passes/scalar/effects_test.clj
@@ -13,3 +13,14 @@
     (is (effects/removable-expr? pure-call))
     (is (not (effects/removable-expr? unknown-call))
         "an invk without certified semantic metadata remains conservative")))
+
+(deftest allocation-purity-does-not-imply-commonable-identity
+  (let [allocation
+        (with-meta
+          '(.invk raster.arrays/zeros-like_m_floats_long-impl exemplar n)
+          {:raster.op/original 'raster.arrays/zeros-like
+           :raster.type/tag 'floats :tag 'floats})]
+    (is (effects/removable-expr? allocation)
+        "an unused local allocation may be eliminated")
+    (is (not (effects/cse-safe-expr? allocation))
+        "two live allocations may not share mutable identity")))


### PR DESCRIPTION
This lands the next direct TypedSOAC vertical: a generic ordered segmented fold-map primitive and portable KernelBody schedule. Attention softmax is now a library composition over that primitive instead of a compiler-known loop nest.\n\nIt also closes the correctness gaps exposed by the production GQA graph: alias-aware horizontal fusion and host projection, metadata-certified effect recovery, symbolic reduction/scan identity dependencies, authoritative scalar ABI widths with explicit exact index widening, complete inc/dec lowering, and portable injective C identifiers.\n\nThe compatibility ledger now reports the GQA workload as direct typed lowering: 7 TypedSOAC kernels, zero backend relowering, zero fallback. CUDA and HIP compile fixtures include the production fold-map artifact.\n\nFocused local validation:\n- 12 tests / 55 assertions across fold-map, effects, and semantic invariants\n- compatibility ledger green\n- typed route focused tests green before the final index-width fix; the ledger exercises that path afterward\n- generated segmented-fold-map source compiled successfully with nvcc sm_80 and hipcc gfx1100\n\nThe full suite and complete CUDA/HIP fixture matrices are intentionally delegated to CircleCI.