### PR TITLE
Route flat gathers through TypedSOAC

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -575,10 +575,13 @@ resident rewrite and typed-route opt-out are deleted. The analyzed front end now
 TypedSOAC subset directly. Certified inclusive and exclusive scans also cross the same typed
 algorithm and scheduled-program boundary, retaining explicit destination, result-layout, and
 graph-owned temporary-storage contracts. Migration is complete when hardware-costed multi-consumer
-fusion, the remaining parallel forms, and covered backend compatibility re-lowerings are deleted. Nested reductions
-inside a retained map are typed and correctly classified, but the JVM SIMD leaf still lowers those inner
-regions through its established scalar fallback; this is an explicit scheduling boundary rather
-than a loss of semantic facts.
+fusion, the remaining parallel forms, and covered backend compatibility re-lowerings are deleted.
+Nested scalar folds inside a retained map are now explicit typed scalar-region terms. Monoid-shaped
+folds carry an `AssociativeScan` certificate and an implementation-defined association contract, so
+the JVM may select its multi-accumulator SIMD reduction. General recurrences carry an ordered
+association contract and lower to an exact scalar loop. Portable C-family emission consumes the same
+term as a sequential fold; future subgroup/workgroup schedules must be selected from its certificate
+rather than rediscovering a reduction from source spelling.
 
 ### 3.3 Schedule and transform IR
 
@@ -967,9 +970,12 @@ The immediate continuation after the verified double-buffered weighted-reduction
    the same device-stripped Abstract Machine into this decision, and a missing machine retains the
    typed materialization boundary rather than speculating about duplicated work.
    Stable indexed gathers and explicitly unique guarded scatters also use this typed scheduled-map
-   route, including resident block transfers. Nested-region JVM scheduling, reducing/atomic
-   scatter variants, the remaining parallel forms, calibrated whole-graph placement costs, and
-   deletion of the remaining graph/backend fallbacks remain.
+   route, including resident block transfers. The public flat `par/gather` spelling now canonicalizes
+   to that ordinary typed map: JVM scheduling recognizes an exact stable indirect read and selects
+   hardware `vgather`, while C-family targets emit the same SegMap. Kernel-local C names are fresh
+   with respect to the typed ABI, so an index buffer cannot shadow the launch coordinate. Strided
+   gather, reducing/atomic scatter variants, the remaining parallel forms, calibrated whole-graph
+   placement costs, and deletion of the remaining graph/backend fallbacks remain.
 6. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a
    read-only distributed track without interrupting the kernel and typed-middle-end verticals.
 

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -43,6 +43,13 @@
 (defn- seg-idx [segop] (:name (segop/seg-space-reduced-dim (:space segop))))
 (defn- seg-bound [segop] (:bound (segop/seg-space-reduced-dim (:space segop))))
 
+(defn- fresh-c-local
+  "Choose a deterministic kernel-local C identifier that cannot shadow an ABI parameter."
+  [base symbols]
+  (let [occupied (set (map ce/c-symbol symbols))]
+    (first (remove occupied
+                   (cons base (map #(str base "_" %) (range)))))))
+
 ;; ================================================================
 ;; SegMap → OpenCL kernel
 ;; ================================================================
@@ -98,6 +105,7 @@
                                 (map #(str (scalar-ctype %) " " (ce/c-symbol %)) scalars))
         parameter-list (str/join ", "
                                  (remove empty? [pointer-params scalar-params "int _n_bound"]))
+        local-index (fresh-c-local "idx" (concat pointers scalars ['_n_bound]))
         array-symbols (set (map #(clojure.core/symbol (name %)) pointers))
         int-scalars (into #{idx} (filter #(= "int" (scalar-ctype %)) scalars))
         adapted-body (ce/adapt-casts-for-dtype body default-dtype)
@@ -105,7 +113,7 @@
                               ce/*scalar-type* default-ctype
                               ce/*idx-sym* idx
                               ce/*int-vars* (into ce/*int-vars* int-scalars)]
-                      (ce/emit-stmt adapted-body idx array-symbols "idx"))
+                      (ce/emit-stmt adapted-body idx array-symbols local-index))
         kernel-name (str kernel-name-prefix "_" (gensym ""))
         abi (kabi/validate!
              (vec (concat
@@ -123,8 +131,8 @@
                            default-dtype (map pointer-dtype pointers))
                     (ce/intrinsic-helper-sources body-source)
                     "__kernel void " kernel-name "(" parameter-list ") {\n"
-                    "    for (int idx = get_global_id(0); idx < _n_bound; "
-                    "idx += get_global_size(0)) {\n"
+                    "    for (int " local-index " = get_global_id(0); " local-index
+                    " < _n_bound; " local-index " += get_global_size(0)) {\n"
                     "        " body-source "\n"
                     "    }\n}\n")]
     (kabi/validate-source-signature! kernel-name source abi)
@@ -223,6 +231,8 @@
         all-params (str/join ", "
                              (remove empty?
                                      [arr-param-str out-param scl-param-str "int _n_bound"]))
+        local-index (fresh-c-local "idx"
+                                   (concat arr-params [out-sym] scl-params ['_n_bound]))
         ;; Emit body as C expression
         adapted-body (ce/adapt-casts-for-dtype body out-dtype)
         arr-sym-set (cond-> (set (map #(symbol (name %)) arr-params))
@@ -231,9 +241,9 @@
                            ce/*scalar-type* out-ctype
                            ce/*idx-sym* idx
                            ce/*int-vars* (into ce/*int-vars* int-scalar-syms)]
-                   (ce/emit-expr adapted-body idx arr-sym-set))
+                   (ce/emit-expr adapted-body idx arr-sym-set local-index))
         cast-str (if cast-fn (str "(" (name cast-fn) ")(" body-str ")") body-str)
-        scalar-body-str (str result-c-name "[idx] = " cast-str ";")
+        scalar-body-str (str result-c-name "[" local-index "] = " cast-str ";")
         ;; Affine-index vectorization (shared c_emit): a SegMap store is `out[idx] = f(..)`,
         ;; expressed here as the synthetic aset the vectorizer analyzes. The store target
         ;; is the literal `out` param (not c-symbol-mangled), so pass :store-name. nil ⇒
@@ -245,7 +255,7 @@
                       (ce/emit-vectorized-elementwise-loop
                        (list 'aset result-symbol idx
                              (if cast-fn (list cast-fn adapted-body) adapted-body))
-                       idx (conj arr-sym-set result-symbol) "idx" scalar-body-str
+                       idx (conj arr-sym-set result-symbol) local-index scalar-body-str
                        {:n-bound "_n_bound" :store-name result-c-name}))
         ;; pragmas cover the output dtype AND every input array's dtype
         scalar-dtype (fn [s]
@@ -281,7 +291,8 @@
                     "(" all-params ") {\n"
                     "    "
                     (or loop-region
-                        (str "for (int idx = get_global_id(0); idx < _n_bound; idx += get_global_size(0)) {\n"
+                        (str "for (int " local-index " = get_global_id(0); " local-index
+                             " < _n_bound; " local-index " += get_global_size(0)) {\n"
                              "        " scalar-body-str "\n"
                              "    }"))
                     "\n}\n")

--- a/src/raster/compiler/backend/jvm/segop_simd.clj
+++ b/src/raster/compiler/backend/jvm/segop_simd.clj
@@ -874,13 +874,19 @@
                                 (list 'recur (list 'clojure.core/unchecked-inc-int j-sym)))
                           out-sym)))))))
 
+(declare compile-indexed-gather-segmap)
+
 (defn compile-segmap
   "Compile a scheduled SegMap. Pointwise maps vectorize across their mapped dimension; maps with
-  explicit scalar Fold terms keep the outer map scalar and SIMD-schedule each inner fold."
+  explicit scalar Fold terms keep the outer map scalar and SIMD-schedule each inner fold. Stable
+  indirect reads select hardware vgather from this scheduled scalar region rather than from a raw
+  raster.par source form."
   [segmap out-sym cast & {:keys [store-offset]}]
   (if (seq (scalar-folds (:lambda segmap)))
     (compile-fold-map-scalar-loop segmap out-sym cast store-offset)
-    (compile-vector-segmap segmap out-sym cast :store-offset store-offset)))
+    (or (when-not store-offset
+          (compile-indexed-gather-segmap segmap out-sym cast))
+        (compile-vector-segmap segmap out-sym cast :store-offset store-offset))))
 
 ;; ================================================================
 ;; par/gather → SIMD hardware vgather
@@ -920,6 +926,37 @@
                                                       (list 'clojure.core/aget index j-sym)))
                                           (list 'recur (list 'inc j-sym)))
                                     out))))))))
+
+(defn- exact-indexed-gather
+  "Return [source index-map] for the canonical typed scalar region
+  `source[index-map[i]]`.  Casts around the result are already represented by SegMap's result
+  dtype/store cast and are deliberately not guessed here."
+  [expression index]
+  (when (and (seq? expression)
+             (descriptor/aget-call? expression))
+    (let [[source source-index] (descriptor/call-args expression)]
+      (when (and (symbol? source)
+                 (seq? source-index)
+                 (descriptor/aget-call? source-index)
+                 (= 2 (count (descriptor/call-args source-index))))
+        (let [[index-map map-index] (descriptor/call-args source-index)]
+          (when (and (symbol? index-map)
+                     (= index (descriptor/unwrap-int-cast map-index)))
+            [source index-map]))))))
+
+(defn compile-indexed-gather-segmap
+  "Select the JVM hardware-vgather schedule from a typed SegMap's exact scalar region.
+
+  This is a schedule recognizer over verified compiler IR, not a second source-language route.
+  Repeated source indices are legal because every destination coordinate is written exactly once."
+  [segmap out-sym cast]
+  (let [body (-> (:lambda segmap) clean-dead-bindings bc/desugar-invk)
+        index (seg-idx segmap)]
+    (when-let [[source index-map] (exact-indexed-gather body index)]
+      (compile-par-gather out-sym source index-map (seg-bound segmap)
+                          (or (:dtype segmap)
+                              (when (= cast 'float) :float)
+                              :double)))))
 
 ;; ================================================================
 ;; SegRed → SIMD (multi-accumulator)

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -261,6 +261,27 @@
 (defn- operation-description
   [id symbol expression default-dtype]
   (cond
+    ;; A flat gather is semantically an ordinary dense map with one pointwise index input and one
+    ;; stable, indirectly-read data input.  Keep it in that small functional vocabulary; the JVM
+    ;; scheduler may later select hardware vgather from the typed scalar region, while GPU targets
+    ;; consume the same SegMap.  The strided spelling needs a two-dimensional iteration space (or
+    ;; an explicitly hoisted product extent), so it remains outside this first exact migration.
+    (par/par-gather-form? expression)
+    (let [{:keys [out src index n stride]} (par/extract-par-gather-info expression)]
+      (when-not stride
+        (let [idx (clojure.core/symbol (str "gather_i__" id))
+              body (list 'clojure.core/aget src
+                         (list 'clojure.core/aget index idx))
+              elem-type (dtype/canon default-dtype)
+              io (extract-io body idx [out])]
+          (merge {:kind :map :id id :sym symbol :results [symbol]
+                  :index idx :extent n :locals [] :casts [nil] :bodies [body]
+                  :result-storage [{:destination out :access :write
+                                    :host-return :buffer}]
+                  :host-binding symbol :elem-type elem-type
+                  :source-operation :raster.par/gather}
+                 io))))
+
     (par/par-map-pure-form? expression)
     (let [{:keys [idx bound cast body elem-type]} (par/extract-par-map-pure-info expression)
           elem-type (dtype/canon (or elem-type

--- a/test/raster/compiler/passes/parallel/typed_gather_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_gather_test.clj
@@ -1,0 +1,69 @@
+(ns raster.compiler.passes.parallel.typed-gather-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
+            [raster.compiler.backend.jvm.par-simd :as par-simd]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
+            [raster.compiler.passes.parallel.typed-soac-route :as route]))
+
+(def ^:private source
+  '(let* [step (raster.par/gather out src idx n)]
+         step))
+
+(def ^:private array-types
+  {'out :float 'src :float 'idx :int})
+
+(def ^:private scalar-types
+  {'n :long})
+
+(defn- scheduled-program []
+  (let [{:keys [program]} (route/attempt source :float array-types
+                                         {:scalar-types scalar-types})]
+    (:form (segop-lower/segop-lower-pass
+            program {:dtype :float :target-device :ocl:0
+                     :array-types array-types :scalar-types scalar-types}))))
+
+(deftest flat-gather-is-an-ordinary-typed-map
+  (let [{:keys [program stats]} (route/attempt source :float array-types
+                                               {:scalar-types scalar-types})
+        equation (first (dialect/equations (get-in program [:equations 0 :algorithm])))
+        operation (dialect/operation-parts equation)
+        {:keys [parameters body-results]} (dialect/lambda-parts (:lambda operation))]
+    (is (= :typed-soac (:dialect program)))
+    (is (= :analyzed-source (:front-end stats)))
+    (is (= 'map (:kind operation)))
+    (is (= '[idx] (:arrays operation))
+        "the index map is pointwise")
+    (is (= '[src] (:captures operation))
+        "the indirectly read source remains a stable tensor capture")
+    (is (= '(clojure.core/aget %capture0 %element0) (first body-results)))
+    (is (= 2 (count parameters)))
+    (is (= [{:destination 'out :access :write :host-return :buffer}]
+           (get-in program [:equations 0 :attributes :result-storage])))
+    (is (not-any? #{'raster.par/gather}
+                  (tree-seq coll? seq (:source program))))))
+
+(deftest typed-gather-has-target-specific-schedules-without-semantic-reparsing
+  (let [scheduled (scheduled-program)
+        operation (-> scheduled :equations first :operations first)
+        jvm (par-simd/simd-pass scheduled :min-elements 1)
+        gpu (opencl-pass/opencl-pass scheduled :device-id :ocl:0
+                                     :dtype :float :min-elements 0
+                                     :array-types array-types
+                                     :scalar-types scalar-types)
+        kernel (first (:kernels gpu))
+        kernel-source (:source kernel)]
+    (is (instance? raster.compiler.ir.segop.SegMap operation))
+    (is (= :typed-soac (:algorithm-dialect operation)))
+    (testing "JVM recognizes hardware vgather from the scheduled scalar region"
+      (is (= 1 (get-in jvm [:stats :segop-reused])))
+      (is (nil? (get-in jvm [:stats :segop-relowered])))
+      (is (str/includes? (pr-str (:form jvm)) "FloatVector/fromArray")))
+    (testing "portable GPU emission consumes the same SegMap and keeps C names hygienic"
+      (is (= 1 (get-in gpu [:stats :segop-reused])))
+      (is (zero? (get-in gpu [:stats :fallback])))
+      (is (= [:int :float :float :int] (mapv :dtype (:abi kernel))))
+      (is (str/includes? kernel-source "src[idx[idx_0]]"))
+      (is (not (str/includes? kernel-source "src[idx[idx]]"))))))


### PR DESCRIPTION
## Summary

- canonicalize flat `raster.par/gather` as an ordinary typed map with a stable indirect read
- select JVM hardware vgather from the scheduled SegMap instead of raw source spelling
- emit the same SegMap through portable C-family lowering and make kernel-local indices hygienic against ABI names
- update the compiler north-star and add direct frontend/JVM/OpenCL regression coverage

## Validation

- focused nREPL suite: 57 tests, 412 assertions, all green
- `git diff --check`
- full Clojure and hardware-free CUDA/HIP gates delegated to CircleCI

Strided gather remains an explicit compatibility case because it needs a 2-D schedule or a typed hoisted product extent. Reducing scatter remains a distinct algebraic operation.