### PR TITLE
Unify additive scatters in TypedSOAC

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -409,6 +409,15 @@ row gather as ordinary graph dataflow, while chunked paged prefill and cache per
 bulk host/device staging with block scatter/gather. Neither path introduces a decoder, attention,
 page-manager, or quantization primitive into the compiler.
 
+Repeated-destination updates are not smuggled through the unique-write contract. Flat
+`scatter!` and additive `reduce-by-key` now canonicalize to the same proof-carrying TypedSOAC
+scatter: its conflict value records the operator, identity, dtype and checked commutative-monoid
+certificate, while each scalar-region write denotes a contribution. The scalar JVM schedule
+executes exact ordered read/modify/write updates; the portable OpenCL schedule selects typed atomic
+addition and retains an `:inout` ABI. Thus histogram/scatter algebra is independent from the key,
+value and destination layouts. Strided contributions, non-additive atomics, privatized/tiled
+histograms and deterministic floating-point accumulation remain schedule and numerical-policy work.
+
 Artifact linking and value rebinding are not runtime conveniences. They are
 compiler primitives required for competitive model execution.
 
@@ -973,9 +982,11 @@ The immediate continuation after the verified double-buffered weighted-reduction
    route, including resident block transfers. The public flat `par/gather` spelling now canonicalizes
    to that ordinary typed map: JVM scheduling recognizes an exact stable indirect read and selects
    hardware `vgather`, while C-family targets emit the same SegMap. Kernel-local C names are fresh
-   with respect to the typed ABI, so an index buffer cannot shadow the launch coordinate. Strided
-   gather, reducing/atomic scatter variants, the remaining parallel forms, calibrated whole-graph
-   placement costs, and deletion of the remaining graph/backend fallbacks remain.
+   with respect to the typed ABI, so an index buffer cannot shadow the launch coordinate. Flat
+   additive reducing scatters also carry a checked conflict algebra through this boundary and select
+   exact JVM or atomic OpenCL schedules. Strided gather/scatter, additional atomic monoids,
+   privatized histogram schedules, the remaining parallel forms, calibrated whole-graph placement
+   costs, and deletion of the remaining graph/backend fallbacks remain.
 6. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a
    read-only distributed track without interrupting the kernel and typed-middle-end verticals.
 

--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -83,11 +83,39 @@
    :float-min       "fmin"
    :float-suffix?   true})
 
+(def opencl-atomic-add-float-helper
+  "OpenCL 1.x CAS-loop used when the verified array dtype selects float atomic addition."
+  "float atomic_add_float(volatile __global float *addr, float val) {
+    int old = *(volatile __global int*)addr;
+    int assumed;
+    do {
+        assumed = old;
+        old = atomic_cmpxchg((volatile __global int*)addr, assumed,
+                              as_int(as_float(assumed) + val));
+    } while (old != assumed);
+    return as_float(old);
+}\n")
+
 ;; ================================================================
 ;; Dynamic state
 ;; ================================================================
 
 (def ^:dynamic *scalar-type* "double")
+
+(def ^:dynamic *array-dtypes*
+  "Verified array element dtypes supplied by the scheduled ABI. Expression emission consults this
+  only where the target spelling depends on storage type (notably atomics); metadata remains a
+  compatibility fallback for callers that have not bound an ABI map."
+  {})
+
+(defn- array-dtype
+  [array]
+  (or (get *array-dtypes* array)
+      (when (symbol? array)
+        (get *array-dtypes* (symbol (name array))))
+      (when (symbol? array)
+        (dtype/dtype-for-scalar-tag
+         (or (:raster.type/tag (meta array)) (:tag (meta array)))))))
 
 (def ^:dynamic *loop-result-var*
   "When a loop is emitted as a statement-expression value (reduction), the C
@@ -1224,8 +1252,8 @@
            arr-str (c-symbol arr)
            idx-str (emit-expr idx-e idx-sym array-syms opencl-idx)
            val-str (emit-expr val-e idx-sym array-syms opencl-idx)
-           tag (when (symbol? arr) (or (:raster.type/tag (meta arr)) (:tag (meta arr))))
-           is-float? (contains? #{'floats 'float} tag)
+           array-dtype (array-dtype arr)
+           is-float? (= :float array-dtype)
            atomic-fn (if is-float?
                        (let [f (:atomic-add-float *emit-config*)]
                          (if (= f :cas-helper) "atomic_add_float" f))
@@ -1865,6 +1893,14 @@
                  c-helper-src)))
        distinct
        (str/join "\n")))
+
+(defn helper-sources
+  "Target helper definitions required by an already-emitted C-family body."
+  [body-str]
+  (str (when (and (= :cas-helper (:atomic-add-float *emit-config*))
+                  (str/includes? body-str "atomic_add_float("))
+         opencl-atomic-add-float-helper)
+       (intrinsic-helper-sources body-str)))
 
 (defn generate-c-helper
   "Generate a static C helper function from a GPU-inlinable deftm."

--- a/src/raster/compiler/backend/gpu/par_opencl.clj
+++ b/src/raster/compiler/backend/gpu/par_opencl.clj
@@ -29,19 +29,6 @@
 ;; OpenCL-specific helpers (expression emission delegated to c-emit)
 ;; ================================================================
 
-(def ^:private atomic-add-float-helper
-  "OpenCL CAS-loop for float atomic-add (no native float atomic_add in OpenCL 1.x)."
-  "float atomic_add_float(volatile __global float *addr, float val) {
-    int old = *(volatile __global int*)addr;
-    int assumed;
-    do {
-        assumed = old;
-        old = atomic_cmpxchg((volatile __global int*)addr, assumed,
-                              as_int(as_float(assumed) + val));
-    } while (old != assumed);
-    return as_float(old);
-}\n")
-
 (def ^:private rstr-dp4a-helper
   "Portable int8 4-way dot-accumulate helper SOURCE — canonical home is the
    intrinsics registry (:dp4a :c-helper-src); this def just reads it."
@@ -233,7 +220,7 @@
         source (str (codegen/extension-pragmas dtype (when needs-fp64? :double))
                     "#pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : enable\n"
                     helper-sources
-                    (when needs-float-atomic? atomic-add-float-helper)
+                    (when needs-float-atomic? ce/opencl-atomic-add-float-helper)
                     ;; registry-owned intrinsic definitions (rstr_dp4a …), defined iff called
                     (ce/intrinsic-helper-sources body-str)
                     "__kernel void " kernel-name
@@ -628,7 +615,7 @@
         needs-float-atomic? (contains? #{:float :double} dtype)
         source (str (codegen/extension-pragmas dtype)
                     "#pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : enable\n"
-                    (when needs-float-atomic? atomic-add-float-helper)
+                    (when needs-float-atomic? ce/opencl-atomic-add-float-helper)
                     "__kernel void " kernel-name
                     "(__global " ctype "* " out-c
                     ", __global const " ctype "* restrict " src-c
@@ -745,7 +732,7 @@
         ;; Only + is supported for atomic reduce-by-key (most common case)
         source (str (codegen/extension-pragmas dtype)
                     "#pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : enable\n"
-                    (when needs-float-atomic? atomic-add-float-helper)
+                    (when needs-float-atomic? ce/opencl-atomic-add-float-helper)
                     "__kernel void " kernel-name
                     "(__global " ctype "* " out-c
                     ", __global const int* restrict " keys-c

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -111,6 +111,7 @@
         adapted-body (ce/adapt-casts-for-dtype body default-dtype)
         body-source (binding [ce/*emit-config* ce/opencl-config
                               ce/*scalar-type* default-ctype
+                              ce/*array-dtypes* array-types
                               ce/*idx-sym* idx
                               ce/*int-vars* (into ce/*int-vars* int-scalars)]
                       (ce/emit-stmt adapted-body idx array-symbols local-index))
@@ -129,7 +130,10 @@
                    [(kabi/slot '_n_bound :scalar :int :role :bound)])))
         source (str (apply codegen/extension-pragmas
                            default-dtype (map pointer-dtype pointers))
-                    (ce/intrinsic-helper-sources body-source)
+                    (when (and (= :reduce (:write-conflict segmap))
+                               (= :float default-dtype))
+                      "#pragma OPENCL EXTENSION cl_khr_global_int32_base_atomics : enable\n")
+                    (ce/helper-sources body-source)
                     "__kernel void " kernel-name "(" parameter-list ") {\n"
                     "    for (int " local-index " = get_global_id(0); " local-index
                     " < _n_bound; " local-index " += get_global_size(0)) {\n"
@@ -144,13 +148,16 @@
       :launch (klaunch/spec {:workgroup-size [256]
                              :group-count [(klaunch/ceil-div bound 256)]})
       :temporaries []
-      :effects {:kind :side-effect-map :write-conflict :unique}
+      :effects {:kind (if (= :reduce (:write-conflict segmap))
+                        :reducing-scatter :side-effect-map)
+                :write-conflict (or (:write-conflict segmap) :unique)}
       :provenance {:dialect :segmap :segop-id (:id segmap)}
       :attributes {:array-params pointers
                    :scalar-params scalars
                    :written-arrays (vec (sort-by name outputs))
                    :array-types array-types
                    :dtype default-dtype
+                   :conflict-contract (:conflict-contract segmap)
                    :explicit-stores true}})))
 
 (defn generate-segmap-kernel
@@ -286,7 +293,7 @@
                    [(kabi/slot '_n_bound :scalar :int :role :bound)])))
         source (str (apply codegen/extension-pragmas out-dtype (map arr-dtype arr-params))
                     ;; registry intrinsics this body calls (e.g. rstr_dp4a) must be DEFINED
-                    (ce/intrinsic-helper-sources scalar-body-str)
+                    (ce/helper-sources scalar-body-str)
                     "__kernel void " kernel-name
                     "(" all-params ") {\n"
                     "    "
@@ -384,7 +391,7 @@
                         scalars)
                    [(kabi/slot '_n_bound :scalar :int :role :bound)])))
         source (str (apply codegen/extension-pragmas dtype (map input-dtype inputs))
-                    (ce/intrinsic-helper-sources body-str)
+                    (ce/helper-sources body-str)
                     "__kernel void " kernel-name "(" all-params ") {\n"
                     "    for (int idx = get_global_id(0); idx < _n_bound; "
                     "idx += get_global_size(0)) {\n"
@@ -2087,7 +2094,7 @@
              (codegen/extension-pragmas out-dtype dtype)
                  ;; registry-driven, not `(intrinsics/descriptor 'dp4a)`: define every intrinsic
                  ;; helper this body actually calls — the same scan every other emitter uses
-             (ce/intrinsic-helper-sources nest)
+             (ce/helper-sources nest)
              "__kernel void " kernel-name "(" params ") {\n"
              "    int seg = get_global_id(0);\n"
              "    if (seg >= _nseg) return;\n"

--- a/src/raster/compiler/backend/jvm/par_simd.clj
+++ b/src/raster/compiler/backend/jvm/par_simd.clj
@@ -573,6 +573,21 @@
                   (do (swap! stats update :fallback inc)
                       (par/expand-par-gather! form))))
 
+              ;; Explicit-store maps consume their scheduled scalar region even when there is no
+              ;; legal SIMD schedule. This keeps reducing-scatter algebra attached to the same
+              ;; SegMap while executing an exact sequential read/modify/write loop on the JVM.
+              (par/par-map-void-form? form)
+              (let [dtype (or (:raster.type/elem-type (meta form)) :double)
+                    scheduled (take-bound
+                               #(and (instance? raster.compiler.ir.segop.SegMap %)
+                                     (nil? (:out-sym %)))
+                               dtype)]
+                (if-let [scalar-form (some-> scheduled segop-simd/compile-effect-segmap)]
+                  (do (swap! stats update :scalar-effect-maps (fnil inc 0))
+                      scalar-form)
+                  (do (swap! stats update :fallback inc)
+                      (par/expand-par-map-void! form))))
+
               ;; Correctness boundary for a parallel primitive without a JVM SIMD schedule.
               ;; In particular, a typed segmented contraction projects back to par/contract for
               ;; host execution. Generic sequence recursion would leave its free/contract axis

--- a/src/raster/compiler/backend/jvm/segop_simd.clj
+++ b/src/raster/compiler/backend/jvm/segop_simd.clj
@@ -958,6 +958,29 @@
                               (when (= cast 'float) :float)
                               :double)))))
 
+(defn compile-effect-segmap
+  "Lower a scheduled explicit-store SegMap to its exact ordered JVM loop.
+
+  Unique stores and reducing scatters share this scalar host schedule. GPU targets may distribute
+  the former and use certified atomics for the latter; the JVM fallback macro is deliberately not
+  run concurrently because its read/modify/write implementation is sequential."
+  [segmap]
+  (when (nil? (:out-sym segmap))
+    (let [index (seg-idx segmap)
+          bound (seg-bound segmap)
+          n-sym (gensym "effect_n__")
+          j-sym (gensym "effect_i__")
+          body (clojure.walk/postwalk
+                (fn [form] (if (= form index) j-sym form))
+                (bc/desugar-invk (:lambda segmap)))]
+      (list 'let* [n-sym (list 'int bound)]
+            (list 'loop* [j-sym '(int 0)]
+                  (list 'if (ix< j-sym n-sym)
+                        (list 'do body
+                              (list 'recur
+                                    (list 'clojure.core/unchecked-inc-int j-sym)))
+                        nil))))))
+
 ;; ================================================================
 ;; SegRed → SIMD (multi-accumulator)
 ;; ================================================================

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -20,7 +20,9 @@
                (region [(let-value local :dtype init-expr) ...]
                        [result-expr ...]))))
         (= equation-id [result ...]
-           (scatter {:index i :extent n :conflict :unique} [array ...] [capture ...]
+           (scatter {:index i :extent n
+                     :conflict :unique-or-proof-carrying-reduction}
+             [array ...] [capture ...]
              (lambda [element ... capture-parameter ...]
                (region [(let-value local :dtype init-expr) ...]
                        [(write destination-index predicate value) ...]))))
@@ -130,10 +132,39 @@
        (extent? (:extent value))
        (or (nil? (:attributes value)) (map? (:attributes value)))))
 
+(def ^:private scatter-accumulator '%scatter-accumulator)
+(def ^:private scatter-contribution '%scatter-contribution)
+
+(defn reducing-scatter-conflict
+  "Build the canonical proof-carrying conflict contract for a reducing scatter.
+
+  The current atomic schedules accept commutative scalar monoids.  Keeping the certificate in the
+  functional IR distinguishes an update contribution from a unique destination store and prevents
+  an emitter from inventing reassociation legality from a function name."
+  [operator dtype]
+  (let [dtype (dtype/canon dtype)
+        identity (descriptor/typed-reduce-identity operator dtype)
+        algebra (scan-ir/certify
+                 {:acc scatter-accumulator :init identity
+                  :lambda (list operator scatter-accumulator scatter-contribution)}
+                 dtype)]
+    {:kind :reduce :operator (:combine algebra) :identity identity
+     :dtype dtype :algebra algebra}))
+
+(defn reducing-scatter-conflict?
+  [value]
+  (and (map? value)
+       (= :reduce (:kind value))
+       (contains? #{:int :float} (:dtype value))
+       (try
+         (= value (reducing-scatter-conflict (:operator value) (:dtype value)))
+         (catch clojure.lang.ExceptionInfo _ false))))
+
 (defn scatter-attributes?
   [value]
   (and (map-attributes? value)
-       (= :unique (:conflict value))))
+       (or (= :unique (:conflict value))
+           (reducing-scatter-conflict? (:conflict value)))))
 
 (defn stencil-attributes?
   "Attributes for a boundary-aware neighborhood map.

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -211,11 +211,12 @@
               :algorithm-equation equation-id)])))
 
 (defn lower-typed-scatter
-  "Lower one unique-destination TypedSOAC scatter to an explicit-store SegMap.
+  "Lower one proof-carrying TypedSOAC scatter to an explicit-store SegMap.
 
    The SegMap has no implicit primary result store (`out-sym` is nil); its typed scalar region
-   contains every conditional indexed write. Physical destinations remain both inputs and outputs
-   because an indexed update preserves unselected elements."
+   contains every conditional indexed write or certified atomic contribution. Physical
+   destinations remain both inputs and outputs because an indexed update preserves unselected
+   elements."
   [program device-id & {:keys [dtype] :or {dtype :double}}]
   (let [program (soac-dialect/validate! program)
         equation (first (soac-dialect/equations program))]
@@ -250,22 +251,37 @@
                               {:reason :typed-soac-scatter-subset :equation equation-id
                                :results results :writes writes
                                :physical-results physical-results})))
+          conflict (:conflict attributes)
+          reducing? (soac-dialect/reducing-scatter-conflict? conflict)
+          result-dtype (or (:dtype (get-in facts [:values (first results)])) dtype :double)
           statements
           (mapv (fn [destination {:keys [destination-index predicate value]}]
-                  (let [store (list 'clojure.core/aset destination destination-index value)]
+                  (let [destination (if reducing?
+                                      (with-meta destination
+                                        {:raster.type/tag
+                                         (dtype/scalar-tag-for-dtype result-dtype)
+                                         :tag (dtype/scalar-tag-for-dtype result-dtype)})
+                                      destination)
+                        store (if reducing?
+                                (list 'raster.par/atomic-add!
+                                      destination destination-index value)
+                                (list 'clojure.core/aset destination destination-index value))]
                     (if (contains? #{true 1} predicate) store (list 'if predicate store))))
                 physical-results writes)
           body (materialize-region-locals locals (list* 'do statements))
           stable (set (get-in attributes [:attributes :stable-array-captures]))
           scalar-captures (set (remove stable captures))
-          result-dtype (or (:dtype (get-in facts [:values (first results)])) dtype :double)
           node (assoc (soac/->SoacMap equation-id nil (:index attributes)
                                       (:extent attributes) nil body
                                       (into (set arrays) stable)
                                       (set physical-results) scalar-captures)
-                      :elem-type result-dtype :pure? false)]
+                      :elem-type result-dtype :pure? false
+                      :write-conflict (if reducing? :reduce :unique)
+                      :conflict-contract conflict)]
       (mapv #(assoc % :algorithm-dialect :typed-soac
-                    :algorithm-equation equation-id)
+                    :algorithm-equation equation-id
+                    :write-conflict (if reducing? :reduce :unique)
+                    :conflict-contract conflict)
             (lower-map node device-id :dtype result-dtype)))))
 
 (defn typed-reduce-program?

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -258,9 +258,36 @@
                     destinations)}
                io)))))
 
+(defn- reducing-scatter-description
+  [id symbol out values indices extent operator default-dtype]
+  (let [index (clojure.core/symbol (str "scatter_i__" id))
+        contribution (list 'clojure.core/aget values index)
+        destination-index (list 'clojure.core/aget indices index)
+        elem-type (dtype/canon default-dtype)
+        io (extract-io (list 'do contribution destination-index) index [out])]
+    (merge {:kind :scatter :id id :sym symbol :index index :extent extent
+            :results [symbol] :locals [] :casts [nil] :bodies [contribution]
+            :write-indices [destination-index] :predicates [1]
+            :conflict (dialect/reducing-scatter-conflict operator elem-type)
+            :effect-only? false :host-binding symbol :elem-type elem-type
+            :result-storage [{:destination out :access :read-write
+                              :host-return :buffer}]
+            :source-operation :reducing-scatter}
+           io)))
+
 (defn- operation-description
   [id symbol expression default-dtype]
   (cond
+    (par/par-scatter-form? expression)
+    (let [{:keys [out src index n stride]} (par/extract-par-scatter-info expression)]
+      (when-not stride
+        (reducing-scatter-description id symbol out src index n '+ default-dtype)))
+
+    (par/par-reduce-by-key-form? expression)
+    (let [{:keys [out keys vals n op]} (par/extract-par-reduce-by-key-info expression)]
+      (when (contains? #{'+ 'clojure.core/+} op)
+        (reducing-scatter-description id symbol out vals keys n op default-dtype)))
+
     ;; A flat gather is semantically an ordinary dense map with one pointwise index input and one
     ;; stable, indirectly-read data input.  Keep it in that small functional vocabulary; the JVM
     ;; scheduler may later select hardware vgather from the typed scalar region, while GPU targets
@@ -705,7 +732,9 @@
                               (every? (comp symbol? :destination)
                                       (:result-storage description))))
                 :scatter (and (seq (:result-storage description))
-                              (= :unique (:conflict description))
+                              (or (= :unique (:conflict description))
+                                  (dialect/reducing-scatter-conflict?
+                                   (:conflict description)))
                               (every? (comp symbol? :destination)
                                       (:result-storage description)))
                 :stencil (and (= 1 (count (:result-storage description)))

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -191,29 +191,47 @@
             result-dtypes (mapv #(:dtype (get values %)) results)
             casts (mapv #(nth (get dtype->allocation %) 2 nil) result-dtypes)
             writes (mapv dialect/write-parts bodies)
+            conflict (:conflict attributes)
+            reducing? (dialect/reducing-scatter-conflict? conflict)
+            host-returns (mapv :host-return storage)
             _ (when-not (and (= (count results) (count writes) (count physical-results))
                              (every? some? writes)
                              (every? some? casts)
-                             (= #{:effect} (set (map :host-return storage))))
+                             (every? #{:effect :buffer} host-returns))
                 (throw (ex-info "the production scatter route requires typed effect writes"
                                 {:reason :typed-soac-production-subset
                                  :equation equation-id :results results
                                  :storage storage :writes writes :dtypes result-dtypes})))
             statements
-            (mapv (fn [destination cast {:keys [destination-index predicate value]}]
-                    (let [store (list 'clojure.core/aset destination destination-index
-                                      (list cast value))]
+            (mapv (fn [destination result-dtype cast
+                       {:keys [destination-index predicate value]}]
+                    (let [destination (with-meta destination
+                                        {:raster.type/tag
+                                         (dtype/scalar-tag-for-dtype result-dtype)
+                                         :tag (dtype/scalar-tag-for-dtype result-dtype)})
+                          typed-value (list cast value)
+                          store (if reducing?
+                                  (list 'raster.par/atomic-add!
+                                        destination destination-index typed-value)
+                                  (list 'clojure.core/aset destination destination-index
+                                        typed-value))]
                       (if (contains? #{true 1} predicate) store (list 'if predicate store))))
-                  physical-results casts writes)
-            source (with-meta
-                     (list 'raster.par/map-void! (:index attributes) (:extent attributes)
-                           (materialize-region region-locals (list* 'do statements)))
-                     {:raster.type/elem-type (first result-dtypes)})]
+                  physical-results result-dtypes casts writes)
+            effect-source (with-meta
+                            (list 'raster.par/map-void! (:index attributes)
+                                  (:extent attributes)
+                                  (materialize-region region-locals (list* 'do statements)))
+                            {:raster.type/elem-type (first result-dtypes)})
+            effect-binding (clojure.core/symbol (str "scatter_effect__" equation-id))
+            buffer-return? (= [:buffer] host-returns)]
         {:equation-id equation-id
          :placement placement
-         :pairs [[host-binding source]]
-         :site [:binding host-binding]
-         :source source})
+         :pairs (if buffer-return?
+                  [[effect-binding effect-source]
+                   [host-binding (first physical-results)]]
+                  [[host-binding effect-source]])
+         :site [:binding (if buffer-return? effect-binding host-binding)]
+         :source effect-source})
 
       stencil
       (let [host-binding (or (get-in placement-facts [:attributes :host-binding])

--- a/test/raster/compiler/passes/parallel/typed_reducing_scatter_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_reducing_scatter_test.clj
@@ -1,0 +1,97 @@
+(ns raster.compiler.passes.parallel.typed-reducing-scatter-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.c-emit :as c-emit]
+            [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
+            [raster.compiler.backend.jvm.par-simd :as par-simd]
+            [raster.compiler.ir.scan :as scan]
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.pipeline :as pipeline]))
+
+(def ^:private float-types
+  {'out :float 'vals :float 'keys :int})
+
+(def ^:private scalar-types
+  {'n :long})
+
+(defn- schedule [source dtype array-types target]
+  (pipeline/schedule-parallel-form
+   source {:target-device target :dtype dtype
+           :array-types array-types :scalar-types scalar-types}))
+
+(deftest scatter-add-carries-a-checked-conflict-algebra
+  (let [source '(let* [step (raster.par/scatter! out vals keys n)] step)
+        {:keys [form stats]} (schedule source :float float-types :cpu:0)
+        algorithm (get-in form [:equations 0 :algorithm])
+        equation (first (dialect/equations algorithm))
+        operation (dialect/operation-parts equation)
+        conflict (get-in operation [:attributes :conflict])]
+    (is (= :typed-soac (:source-dialect stats)))
+    (is (= 'scatter (:kind operation)))
+    (is (= :reduce (:kind conflict)))
+    (is (= '+ (:operator conflict)))
+    (is (= :float (:dtype conflict)))
+    (is (scan/associative-scan? (:algebra conflict)))
+    (is (= conflict (dialect/reducing-scatter-conflict '+ :float)))
+    (is (= [{:destination 'out :access :read-write :host-return :buffer}]
+           (get-in (dialect/facts algorithm)
+                   [:equations 0 :attributes :result-storage])))
+    (is (false? (dialect/reducing-scatter-conflict?
+                 (assoc conflict :identity 1.0))))))
+
+(deftest reducing-scatter-shares-one-schedule-boundary-across-jvm-and-opencl
+  (let [source '(let* [step (raster.par/scatter! out vals keys n)] step)
+        {scheduled :form} (schedule source :float float-types :ocl:0)
+        operation (-> scheduled :equations first :operations first)
+        jvm (par-simd/simd-pass scheduled :min-elements 1)
+        execute (eval (list 'fn '[out vals keys n] (:form jvm)))
+        out (float-array [10.0 20.0 30.0])
+        gpu (opencl-pass/opencl-pass
+             scheduled :device-id :ocl:0 :dtype :float :min-elements 0
+             :array-types float-types :scalar-types scalar-types)
+        kernel (first (:kernels gpu))]
+    (testing "the JVM consumes the SegMap as an exact sequential update schedule"
+      (is (= :reduce (:write-conflict operation)))
+      (is (= 1 (get-in jvm [:stats :segop-reused])))
+      (is (= 1 (get-in jvm [:stats :scalar-effect-maps])))
+      (is (zero? (get-in jvm [:stats :fallback])))
+      (is (identical? out (execute out (float-array [1 2 3 4])
+                                   (int-array [2 0 2 0]) 4)))
+      (is (= [16.0 20.0 34.0] (mapv double out))))
+    (testing "OpenCL selects typed atomic addition without a legacy scatter generator"
+      (is (= 1 (get-in gpu [:stats :segop-reused])))
+      (is (zero? (get-in gpu [:stats :fallback])))
+      (is (= :reducing-scatter (get-in kernel [:effects :kind])))
+      (is (= :reduce (get-in kernel [:effects :write-conflict])))
+      (is (= :inout (:kind (second (:abi kernel)))))
+      (is (str/includes? (:source kernel) "float atomic_add_float"))
+      (is (str/includes? (:source kernel) "atomic_add_float(out_ + keys[idx], vals[idx])")))))
+
+(deftest verified-array-dtype-selects-the-target-atomic-spelling
+  (let [operation '(raster.par/atomic-add! out i contribution)
+        emit (fn [config]
+               (binding [c-emit/*emit-config* config
+                         c-emit/*array-dtypes* {'out :float}
+                         c-emit/*scalar-type* "float"]
+                 (c-emit/emit-stmt operation 'i #{'out} "idx")))]
+    (is (= "atomic_add_float(out_ + idx, contribution);"
+           (emit c-emit/opencl-config)))
+    (is (= "atomicAdd(out_ + idx, contribution);"
+           (emit c-emit/hip-config)))))
+
+(deftest reduce-by-key-is-the-same-typed-additive-conflict-operation
+  (let [source '(let* [step (raster.par/reduce-by-key out keys vals n +)] step)
+        {scheduled :form stats :stats} (schedule source :int
+                                                 {'out :int 'keys :int 'vals :int}
+                                                 :ocl:0)
+        operation (-> scheduled :equations first :operations first)
+        gpu (opencl-pass/opencl-pass
+             scheduled :device-id :ocl:0 :dtype :int :min-elements 0
+             :array-types {'out :int 'keys :int 'vals :int}
+             :scalar-types scalar-types)
+        source (:source (first (:kernels gpu)))]
+    (is (= :typed-soac (:source-dialect stats)))
+    (is (= :reduce (:write-conflict operation)))
+    (is (= :int (get-in operation [:conflict-contract :dtype])))
+    (is (str/includes? source "atomic_add(out_ + keys[idx], vals[idx])"))
+    (is (not (str/includes? source "atomic_add_float")))))


### PR DESCRIPTION
## Summary

- canonicalize flat `scatter!` and additive `reduce-by-key` into one TypedSOAC scatter operation
- distinguish unique stores from repeated-destination contributions with a checked commutative-monoid conflict certificate
- consume the same scheduled SegMap as an exact ordered JVM loop or typed OpenCL atomic update
- derive atomic spelling from verified ABI dtypes and share the OpenCL float CAS helper
- retain buffer-return, in-place ownership, and `:inout` ABI semantics

## Validation

- new focused suite: 4 tests, 29 assertions, all green
- affected compiler suite: 149 tests, 790 assertions, all green
- `git diff --check`
- full suite and hardware-free CUDA/HIP gates delegated to CircleCI

This intentionally starts with flat `+` over int/float. Strided updates, other atomic monoids, privatized histograms, and deterministic floating-point policies remain explicit schedule work.