### PR TITLE
Lower Adam optimizers through TypedSOAC

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -126,12 +126,22 @@ guarded indexed store remain visible to scheduling and ABI construction. Shared 
 explicit ordered local-SSA spine inside the tuple map's scalar region; each definition has a dtype
 retained from walker/TypedClojure facts, and local binders never become fake program inputs.
 Validation proves definition order and lexical closure, and the front end expands locals only for
-dependency analysis so a local cannot hide sibling write/read ordering. JVM and GPU lowering both
+I/O discovery. A direct sibling-destination read still preserves imperative store ordering and
+declines the functional tuple map, while a typed local may snapshot any destination before the
+store sequence and safely feed several results. JVM and GPU lowering both
 materialize the same typed spine once around all tuple results. Vertical and horizontal fusion
 alpha-rename and compose these regions while preserving definition order; a typed producer-result
 bridge is introduced only when reuse requires it, so fusion does not duplicate scalar work. Flat
 resident `deftm` signatures provide their declared per-buffer dtypes before fusion, so a
 mixed FP32/int8-input, FP32/int32-output map does not inherit a global default dtype.
+
+Adam and AdamW use this effect-map contract directly: gradient is a read-only operand, parameter
+and moment buffers are typed inout storage, and the bias-corrected moment snapshots form one local
+SSA spine evaluated before all three writes. Each optimizer lowers as one certified resident
+kernel with zero compiler allocation or compatibility fallback. The C-family vector fast path
+currently declines multi-store lexical regions rather than inlining a snapshot past a state write;
+vector KernelBody lowering of local SSA is the remaining schedule improvement, not a second
+optimizer-specific semantic path.
 
 Boundary-aware scientific stencils now enter that same direct vertical as a distinct functional
 `stencil` equation. The equation keeps whole neighborhood tensors as stable captures, proves every

--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -2110,8 +2110,19 @@
       (when (some #(and (seq? %) (= 'fold (first %)))
                   (tree-seq coll? seq body))
         (vec-bail!))
-      (let [core (inline-pure-lets body)
+      (let [;; A multi-store lexical region can snapshot arrays that its later
+            ;; stores mutate (Adam/AdamW are the canonical case).  The current
+            ;; vector emitter inlines locals and emits vstores in sequence; that
+            ;; would turn the snapshot back into a post-store load.  Keep these
+            ;; regions on the scalar grid-stride path until vector KernelBody
+            ;; lowering represents their SSA locals explicitly.
+            lexical-region? (boolean
+                             (some #(and (seq? %)
+                                         (contains? #{'let 'let*} (first %)))
+                                   (tree-seq coll? seq body)))
+            core (inline-pure-lets body)
             stores (or (collect-stores core) (vec-bail!))]
+        (when (and lexical-region? (> (count stores) 1)) (vec-bail!))
         (when (idx-leaks? core idx-sym) (vec-bail!))
         ;; no control flow in a vectorizable straight-line body
         (walk/postwalk

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -178,22 +178,21 @@
 
     :else nil))
 
-(defn- expanded-local-expression
-  [locals expression]
-  (reduce (fn [body {:keys [id init]}]
-            (util/subst-syms {id init} body))
-          expression (reverse locals)))
-
 (defn- independent-stores?
-  [locals stores]
+  [_locals stores]
   (let [destinations (mapv :out stores)
         destination-set (set destinations)]
     (and (= (count destinations) (count destination-set))
          (every? (fn [{:keys [out index predicate value]}]
+                   ;; Region locals are lexical SSA snapshots evaluated before the
+                   ;; store sequence.  A local may therefore read any destination
+                   ;; without introducing an ordering dependency between tuple
+                   ;; results.  Only a DIRECT sibling-destination read in a store
+                   ;; expression observes an earlier write and must decline the
+                   ;; functional effect-map representation.
                    (empty? (disj (set/intersection destination-set
                                                    (par/collect-aget-arrays
-                                                    (expanded-local-expression
-                                                     locals (list 'do index predicate value))))
+                                                    (list 'do index predicate value)))
                                  out)))
                  stores))))
 

--- a/src/raster/dl/optim.clj
+++ b/src/raster/dl/optim.clj
@@ -22,7 +22,8 @@
             [raster.arrays :refer [aget aset alength aclone]]
             [raster.numeric :refer [+ - * / < > <= >= == zero? pos? neg? max min abs mod rem]]
             [raster.math :as m]
-            [raster.numeric :as n]))
+            [raster.numeric :as n]
+            [raster.par]))
 
 ;; ================================================================
 ;; SGD
@@ -52,17 +53,18 @@
                             eps :- T t :- Long] :- (Array T)
                        (let [bc1 (- 1.0 (n/pow beta1 t))
                              bc2 (- 1.0 (n/pow beta2 t))]
-                         (dotimes [i n]
-                           (let [g (aget grad i)
-                                 m-new (+ (* beta1 (aget m i)) (* (- 1.0 beta1) g))
-                                 v-new (+ (* beta2 (aget v i)) (* (- 1.0 beta2) (* g g)))
-                                 m-hat (/ m-new bc1)
-                                 v-hat (/ v-new bc2)]
-                             (aset m i m-new)
-                             (aset v i v-new)
-                             (aset param i
-                                   (- (aget param i)
-                                      (* lr (/ m-hat (+ (n/sqrt v-hat) eps)))))))
+                         (raster.par/map-void!
+                          i n
+                          (let [g (aget grad i)
+                                m-new (+ (* beta1 (aget m i)) (* (- 1.0 beta1) g))
+                                v-new (+ (* beta2 (aget v i)) (* (- 1.0 beta2) (* g g)))
+                                m-hat (/ m-new bc1)
+                                v-hat (/ v-new bc2)]
+                            (aset m i m-new)
+                            (aset v i v-new)
+                            (aset param i
+                                  (- (aget param i)
+                                     (* lr (/ m-hat (+ (n/sqrt v-hat) eps)))))))
                          param)))
 
 ;; ================================================================
@@ -76,18 +78,19 @@
                         :- (Array T)
                         (let [bc1 (- 1.0 (n/pow beta1 t))
                               bc2 (- 1.0 (n/pow beta2 t))]
-                          (dotimes [i n]
-                            (let [g (aget grad i)
-                                  m-new (+ (* beta1 (aget m i)) (* (- 1.0 beta1) g))
-                                  v-new (+ (* beta2 (aget v i)) (* (- 1.0 beta2) (* g g)))
-                                  m-hat (/ m-new bc1)
-                                  v-hat (/ v-new bc2)
-            ;; weight decay applied to param directly
-                                  p-decayed (* (aget param i) (- 1.0 (* lr weight-decay)))]
-                              (aset m i m-new)
-                              (aset v i v-new)
-                              (aset param i
-                                    (- p-decayed (* lr (/ m-hat (+ (n/sqrt v-hat) eps)))))))
+                          (raster.par/map-void!
+                           i n
+                           (let [g (aget grad i)
+                                 m-new (+ (* beta1 (aget m i)) (* (- 1.0 beta1) g))
+                                 v-new (+ (* beta2 (aget v i)) (* (- 1.0 beta2) (* g g)))
+                                 m-hat (/ m-new bc1)
+                                 v-hat (/ v-new bc2)
+             ;; weight decay applied to param directly
+                                 p-decayed (* (aget param i) (- 1.0 (* lr weight-decay)))]
+                             (aset m i m-new)
+                             (aset v i v-new)
+                             (aset param i
+                                   (- p-decayed (* lr (/ m-hat (+ (n/sqrt v-hat) eps)))))))
                           param)))
 
 ;; ================================================================

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -116,6 +116,25 @@
       (is (= '[state x y] (kart/attribute k :array-params)))
       (is (= '[state x y limit scale n] (:arguments k))))))
 
+(deftest multi-store-lexical-snapshots-do-not-vectorize-past-their-writes
+  (let [form '(raster.par/map-void!
+               i n
+               (let* [^float next-state (+ (clojure.core/aget state i)
+                                           (clojure.core/aget grad i))]
+                     (clojure.core/aset state i (float next-state))
+                     (clojure.core/aset param i
+                                        (float (- (clojure.core/aget param i)
+                                                  next-state)))))
+        source (:source
+                (par-opencl/generate-par-map-void-kernel
+                 form :dtype :float
+                 :array-types {'state :float 'grad :float 'param :float}))]
+    (is (str/includes? source "float next_state ="))
+    (is (not (str/includes? source "vstore4"))
+        "inlining a pre-store snapshot into sequential vector stores changes semantics")
+    (is (< (str/index-of source "float next_state =")
+           (str/index-of source "state[idx] =")))))
+
 (deftest generate-gather-kernel-is-a-side-effect-artifact
   (let [k (par-opencl/generate-par-gather-kernel
            '(raster.par/gather out src index n stride) :dtype :float)]

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -487,6 +487,34 @@
                   (keys (:values (dialect/facts program))))
         "region-local SSA values are lexical, not fake program inputs")))
 
+(deftest typed-local-snapshots-may-feed-several-updated-destinations
+  (let [source
+        '(let* [effect
+                (raster.par/map-void!
+                 i n
+                 (let* [^float m-new (+ (clojure.core/aget m i)
+                                        (clojure.core/aget grad i))
+                        ^float v-new (+ (clojure.core/aget v i)
+                                        (* (clojure.core/aget grad i)
+                                           (clojure.core/aget grad i)))]
+                       (clojure.core/aset m i (float m-new))
+                       (clojure.core/aset v i (float v-new))
+                       (clojure.core/aset param i
+                                          (float (- (clojure.core/aget param i)
+                                                    (/ m-new (+ v-new 1.0)))))))]
+               effect)
+        program (frontend/form->program
+                 source {:dtype :float
+                         :array-types {'grad :float 'm :float 'v :float 'param :float}})
+        equation (first (dialect/equations program))
+        {:keys [locals body-results]}
+        (dialect/lambda-parts (:lambda (dialect/operation-parts equation)))]
+    (is (= 2 (count locals)))
+    (is (= 3 (count body-results)))
+    (is (= ['m 'v 'param] (dialect/physical-results program equation)))
+    (is (= [:read-write :read-write :read-write]
+           (mapv :access (dialect/result-storage program 0))))))
+
 (deftest ordered-void-bodies-decline-the-functional-tuple-map
   (doseq [[label body]
           [["one destination written twice"
@@ -495,10 +523,6 @@
            ["a later store observes an earlier sibling write"
             '(do (clojure.core/aset a i (float (clojure.core/aget x i)))
                  (clojure.core/aset b i (float (clojure.core/aget a i))))]
-           ["a typed local cannot hide a sibling destination dependency"
-            '(let* [^float observed (clojure.core/aget a i)]
-                   (clojure.core/aset a i (float (clojure.core/aget x i)))
-                   (clojure.core/aset b i (float observed)))]
            ["an untyped shared local cannot enter a typed region"
             '(let* [v (+ (clojure.core/aget x i) 1.0)]
                    (clojure.core/aset a i (float v))

--- a/test/raster/dl/optim_resident_test.clj
+++ b/test/raster/dl/optim_resident_test.clj
@@ -1,0 +1,44 @@
+(ns raster.dl.optim-resident-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [raster.compiler.pipeline :as pipeline]
+            [raster.dl.optim :as optim]))
+
+(deftest adaptive-optimizers-use-one-certified-resident-effect-map
+  (doseq [[label optimizer expected-scalars]
+          [["Adam" #'optim/adam-step!
+            '#{bc1 bc2 beta1 beta2 eps lr}]
+           ["AdamW" #'optim/adamw-step!
+            '#{bc1 bc2 beta1 beta2 eps lr weight-decay}]]]
+    (testing label
+      (let [program (pipeline/compile-gpu-program
+                     optimizer :ze:0 :dtype :float
+                     :on-non-resident :nil :compiler-report? true)
+            report (:compiler-report program)
+            step (first (:steps program))
+            artifact (:artifact step)
+            abi (:abi step)
+            scalar-names (->> abi
+                              (filter #(= :parameter (:role %)))
+                              (map :name)
+                              set)]
+        (is (some? program))
+        (is (= 1 (count (:steps program))))
+        (is (= :typed-soac (get-in report [:route :source-dialect])))
+        (is (true? (get-in report [:route :typed-validated])))
+        (is (= 1 (get-in report [:lowering :typed-reused])))
+        (is (zero? (get-in report [:lowering :fallback])))
+        (is (true? (get-in report [:residency :resident?])))
+        (is (= :map-void (:convention step)))
+        (is (= :elementwise-map (get-in artifact [:effects :kind])))
+        (is (= expected-scalars scalar-names))
+        (is (= #{'param 'm 'v}
+               (->> abi
+                    (filter #(= :inout (:kind %)))
+                    (map :name)
+                    set)))
+        (is (= ['grad] (->> abi
+                            (filter #(= :input (:kind %)))
+                            (mapv :name))))
+        (is (not (str/includes? (:source artifact) "vstore4"))
+            "lexical moment snapshots must not be inlined past their state writes")))))


### PR DESCRIPTION
## Summary

- express Adam and AdamW updates as typed multi-output effect maps
- permit lexical SSA snapshots of sibling destinations while still rejecting direct store-order dependencies
- prevent the C vector fast path from moving lexical snapshots past state writes
- pin one-kernel resident TypedSOAC routing and optimizer ABI contracts

## Correctness

This fixes a latent vectorization bug: inlining Adam moment locals into sequential vector stores could make the parameter update observe already-updated moments. Multi-store lexical regions now conservatively retain the scalar grid-stride schedule until KernelBody vector lowering can preserve local SSA explicitly.

## Validation

- warm focused namespaces: 50 tests / 277 assertions
- cold focused namespaces: 50 tests / 277 assertions
- complete linear + VJP + AdamW probe: four resident steps, three compiler allocations, zero fallback

The full suite and CUDA/HIP compile gates are delegated to CI.