### PR TITLE
Certify durable numerical state manifests

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -941,6 +941,14 @@ GPU-initiated transports such as NVSHMEM are interchangeable execution backends,
 semantic memory model. Datahike may retain durable topology, plan, measurement and decision history;
 it does not replace hot-path allocation or communication.
 
+Durable numerical state follows the same separation. A certified storage-neutral
+`NumericalStateManifest` binds logical `AbstractValue` fields to immutable content-addressed chunks,
+lineage, numerical compatibility and provenance. Store placement remains a runtime decision: a
+local mmap/Konserve or LMDB frontend may be backed by S3, Ceph, a parallel filesystem or an
+institutional archive. Datahike publishes the semantic state only after required durability
+receipts; direct fabrics still move hot halos, gradients and activations. See
+[`durable-numerical-state.md`](durable-numerical-state.md).
+
 ## 7. Reflection, structural self-modification, and learning
 
 Raster can make reflection unusually powerful because Clojure data is a natural

--- a/design/durable-numerical-state.md
+++ b/design/durable-numerical-state.md
@@ -1,0 +1,196 @@
+# Durable numerical state
+
+Status: initial compiler contract and runtime direction, 2026-08-31.
+
+Raster needs durable state for model parameters and optimizer state, KV continuations, PDE fields,
+multilevel meshes, sampled agents, compiler measurements, and reproducible branches of a running
+workflow. This is not a reason to make the numerical hot path transact through a database. It is a
+reason to separate three planes and connect them with explicit lifecycle events.
+
+```text
+Datahike semantic/control plane
+  state identity, parents, logical time, ownership, leases, decisions, provenance
+                     |
+                     | publish only after durable receipts
+                     v
+immutable numerical content plane
+  local Boring/Konserve files or LMDB frontend <-> S3-compatible authoritative tier
+                     |
+                     | scoped local segment / asynchronous promotion
+                     v
+Raster resident compute plane
+  BufferViews, block gather/scatter, device queues/events, direct peer communication
+```
+
+Hot node-to-node communication belongs to MPI, UCX, NCCL/RCCL, oneCCL, RDMA or another direct
+transport selected from a certified `DistributedPlan`. Datahike records topology, intent, durable
+state lineage, measurements and completed decisions. It must not relay halo cells, gradients or
+activations.
+
+## Identities and publication
+
+Three identities must remain distinct:
+
+- A **state identity** names a semantic checkpoint or branch, such as simulation time 1200 s or
+  optimizer step 40. It has zero or more parents.
+- A **content address** names immutable chunk content. Different states may reuse it.
+- A **placement** says where a realization is available: local file, LMDB key, S3 object, host
+  memory, GPU allocation, or a replica on another worker.
+
+`NumericalStateManifest` is the storage-neutral compiler/runtime boundary. Version 1 contains
+complete, regular, rectangular chunks for dense `AbstractValue` tensors. It certifies dtype-derived
+logical byte counts, clipped edge cells, canonical grid order, content addresses, explicit byte
+order, numerical compatibility, producer provenance and lineage. It does not contain paths,
+buckets, object keys, mmap segments, buffers, queues, devices or store handles.
+
+Publication is immutable and ordered:
+
+1. gather changed resident blocks into bounded staging or writable local mapped files;
+2. seal each chunk, compute and verify its content address;
+3. write it to the local frontend and start durable backend promotion;
+4. await the backend durability receipts required by policy;
+5. publish one complete manifest/state transaction to Datahike;
+6. release staging allocations and eventually garbage-collect unrooted content.
+
+S3 has no transaction spanning many objects. Immutable chunks followed by one manifest commit give
+readers an atomic semantic publication point. An S3 ETag is not a content identity, particularly
+for multipart objects; Raster must retain its own digest.
+
+## Konserve, mmap, LMDB and S3
+
+The practical first composition is a Konserve tiered store with a local file frontend and an
+S3-compatible authoritative backend. `konserve.mmap` can expose an uncompressed, unencrypted Boring
+value in the local file store. A missing remote object must first be promoted to that frontend;
+object storage itself cannot be memory-mapped.
+
+This supports a useful restore path:
+
+```text
+S3 object -> local immutable file -> scoped MemorySegment -> Raster async upload/scatter -> GPU
+```
+
+The final arrow can avoid an intermediate JVM primitive array. The S3 arrow is not currently
+zero-copy: the inspected `konserve-s3` implementation materializes reads with `readAllBytes` and
+writes with `ByteArrayOutputStream`/`RequestBody.fromBytes`. Before using it for multi-GiB fields,
+the storage layer needs byte-preserving streaming promotion, ranged/file downloads, multipart/file
+uploads, bounded verification, and cancellation/backpressure. Tier promotion should not require
+decoding and re-encoding a large numerical value.
+
+`konserve-lmdb` is a useful alternative local frontend for many small or medium immutable chunks,
+ordered scans, MVCC metadata and fast lookup. Its zero-copy segment is valid only inside the LMDB
+read transaction that owns it. Long read transactions pin pages and delay reclamation; one writer
+is serialized; map size and version garbage collection require operations policy; and the database
+must not live on a network filesystem. A file mmap is usually the safer staging source for a long
+asynchronous GPU transfer because its lifetime can be pinned without pinning an LMDB transaction.
+
+The common runtime capability should consequently be scoped, not a naked segment:
+
+```clojure
+(with-local-content content-address
+  (fn [{:keys [segment offset byte-length release]}]
+    ... submit transfer ... retain until event ...))
+```
+
+File-backed Konserve and LMDB can implement that capability with different lifetime rules. Remote
+stores implement promotion to a local provider, not a fictitious remote mmap.
+
+In-place mmap editing is for ephemeral working copies. Mutating an object already published under a
+content address violates snapshot immutability. Same-sized Boring edits may dirty only touched
+pages, which is valuable while constructing the next chunk; the result must then be sealed under a
+new address. Size-changing edits can move the tail and are unsuitable for large field hot paths.
+
+## Deployment profiles
+
+The contract is realistic for both institutional HPC and frontier-model clusters only if S3 is one
+placement capability, not the semantic storage model:
+
+- CERN publicly documents EOS as its disk namespace/buffer in front of CTA tape, accessed through
+  XRootD or HTTP. A deployment there should implement an EOS/file promotion adapter and preserve
+  CTA's existing lifecycle rather than require an S3 gateway.
+- Jülich's JUST publicly documents tiered IBM Spectrum Scale/GPFS storage mounted by its compute
+  systems, plus an S3 object service on JUDAC. The same manifest could therefore be realized through
+  GPFS for the active campaign and S3 or tape-oriented policy for durable retention.
+- LANL's public MarFS material describes a near-POSIX namespace over scalable object/file data
+  stores, deployed alongside Lustre scratch and HPSS archive. That is structurally close to the
+  content/placement separation here, including the need for parallel bulk movers.
+- Cloud AI guidance pairs durable S3 with FSx for Lustre, local NVMe and a high-performance fabric.
+  Checkpoints are written asynchronously and distributed hierarchically rather than independently
+  downloaded by every accelerator worker. Public Anthropic material also confirms that frontier
+  workloads span Trainium, TPUs and NVIDIA GPUs, so neither the device nor storage runtime can be
+  assumed from the programming model.
+
+Ceph is an attractive on-premises realization because one RADOS cluster can expose S3-compatible
+RGW, CephFS and block devices. It also introduces a substantial operational system, correlated
+failure/rebalancing domains and an S3 compatibility subset. Raster/Konserve should be able to use
+it, but should not require it. Similar adapters can target MinIO, EOS/XRootD, Spectrum Scale,
+Lustre, MarFS, DAOS or plain local files.
+
+The runtime capability set should be tested rather than inferred from a product name: immutable
+put, conditional publication, range read, multipart/streaming write, localize, scoped mmap, durable
+receipt, checksum verification, listing/GC, and observed bandwidth/latency. A parallel filesystem
+may implement `localize` as an already-mounted path; an object store stages into a node/rack cache;
+an archive may return a delayed recall operation. This keeps the compiler and manifest stable while
+the workload planner selects a suitable path for the current allocation.
+
+## Relationship to scientific formats
+
+Raster should provide adapters rather than claim that an EDN/object store replaces the scientific
+data ecosystem.
+
+| Format/system | Strong fit | Missing or awkward for Raster's goal |
+|---|---|---|
+| Boring + Konserve | Rich Clojure metadata, immutable values, local mmap navigation, tiering, natural Datahike references | No standard N-D coordinate/chunk schema; current S3 backend lacks bulk streaming/range paths |
+| Raw slabs + small manifest | Minimal overhead, direct mmap and GPU transfer, simple checksums | Raster owns schema evolution, endian/layout rules, partial tiles and interoperability |
+| Zarr v3 | Cloud-native chunked N-D arrays, sharding, broad Python/scientific tooling | Many-object overhead; weak cross-array snapshot/branch transaction and provenance semantics |
+| HDF5 / NetCDF | Mature self-describing arrays, shared-filesystem and MPI-IO ecosystem | Monolithic files and concurrent/object-store mutation are awkward; not content-addressed lineage |
+| ADIOS2 BP5/SST | HPC checkpoints, streaming and in-situ workflows, strong MPI integration | External native runtime; not a durable queryable semantic state graph |
+| TileDB | Dense/sparse arrays, object storage, fragments and time travel | Heavyweight competing array/catalog/runtime model |
+| TensorStore | Asynchronous N-D slicing and index transforms over cloud formats | Native C++ integration; not a provenance or workflow state store |
+| Arrow | Excellent columnar interchange and analytics | Not an N-D checkpoint, halo or multilevel field format |
+| safetensors | Immutable mmap-friendly tensor offsets and model weight interchange | Little chunk hierarchy, coordinates, sparse/AMR structure or branching |
+
+Zarr import/export is the best early interoperability target for chunked simulation fields.
+ADIOS2 is the strongest reference or adapter for MPI/in-situ checkpoint bandwidth. safetensors is a
+useful model-weight boundary. Internally, Raster still benefits from content-addressed chunks and a
+Datahike lineage graph because none of those formats supplies the whole programming model.
+
+## Correctness and operational hazards
+
+- Compression and encryption prevent direct mmap interpretation. Keep the hot local tier raw;
+  allow compressed cold chunks only when the restore plan includes decode resources and cost.
+- Chunk size trades per-object/API overhead against read amplification, retry cost and staging
+  memory. It is a schedule/cost parameter, not a universal constant.
+- Dtype, endian, layout, coordinate system, partial-edge shape, codec and checksum domain must be
+  explicit. Shape and dtype alone do not establish restore compatibility.
+- Async transfers must retain the mapped file or transaction until the event completes, unless the
+  GPU backend has made an owned staging copy.
+- Immutable versioning requires roots, leases and garbage collection. A state transaction may be
+  removed only after no retained branch, running plan, replica or publication attempt can reach it.
+- Exact restart also needs RNG state, input/dataset cursor, solver/controller state and numerical
+  mode. Reconstructing tensor bytes alone is not reproducibility.
+- Direct communication and durable checkpoint traffic contend for PCIe/NIC/storage bandwidth. The
+  outer workload planner must schedule both, even though only the former is a collective/halo step.
+
+## Workload-driven landing order
+
+1. Ratchet the existing RK4/PDE numerical oracle and remove its broad compound-kernel tolerance.
+2. Land and use the certified storage-neutral `NumericalStateManifest`.
+3. Define scoped local-content and asynchronous promotion receipts; implement local immutable file
+   mmap first, then LMDB callbacks and S3 promotion.
+4. Replace whole-object heap S3 operations with streaming/range/multipart paths and byte-preserving
+   tier synchronization.
+5. Bind manifest chunks to existing `ResidentBufferView`, async transfer and block gather/scatter
+   contracts. KV cache state becomes one use case, not a separate memory ABI.
+6. Generalize TypedSOAC stencil/index-space semantics to N-D neighborhoods and derive periodic,
+   multidimensional halo regions in `DistributedPlan`.
+7. Demonstrate a conservative 2-D shallow-water workload: mass/lake-at-rest/convergence oracles,
+   chunk checkpoint, exact restore, branch to a changed parameter or boundary, and simulated
+   multi-device halo overlap. Run local mmap in the hot loop; make MinIO/S3 an optional slow gate.
+8. Add AMR hierarchy values plus typed restriction, prolongation and reflux contracts; checkpoint
+   only changed tiles. Validate the same state machinery with a transformer training checkpoint
+   containing parameters, optimizer, RNG and data cursor.
+
+The laptop/CI loop remains hardware-independent: semantic certification, restore compatibility,
+storage fault injection, the distributed simulator and small numerical oracles run locally.
+Cloud GPUs, a real MPI fabric and object storage provide periodic performance acceptance, not a
+required compiler-development loop.

--- a/src/raster/compiler/ir/numerical_state.clj
+++ b/src/raster/compiler/ir/numerical_state.clj
@@ -1,0 +1,351 @@
+(ns raster.compiler.ir.numerical-state
+  "Certified logical snapshots of durable numerical state.
+
+   A NumericalStateManifest connects backend-neutral AbstractValues to immutable rectangular
+   chunks.  It records lineage, logical coordinates, numerical compatibility and producer
+   provenance, but deliberately contains no store handles, paths, buckets, mmap segments, device
+   buffers, queues or events.  A runtime may therefore realize the same content addresses through
+   a local file/Konserve mmap tier, LMDB, S3, or another object store without changing compiler IR.
+
+   Version 1 describes complete dense fields on a regular chunk grid.  Reusing a parent's content
+   address gives incremental checkpoints without making a manifest depend on its parent for
+   reconstruction.  Sparse and AMR states are represented as multiple explicitly coordinated
+   fields; future schemas may add partial/delta field coverage without weakening this contract."
+  (:refer-clojure :exclude [chunk])
+  (:require [clojure.string :as string]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.abstract-value :as abstract-value]))
+
+(def schema-version 1)
+
+(def determinism-contracts
+  #{:bitwise :reproducible-order :toleranced :nondeterministic})
+
+(def byte-orders #{:little-endian :big-endian})
+
+(defrecord ContentAddress [algorithm digest])
+(defrecord StateChunk
+           [id offsets shape logical-byte-length stored-byte-length content storage attributes])
+(defrecord StateField
+           [id value chunk-shape coordinate-space chunks attributes])
+(defrecord NumericalStateManifest
+           [id schema-version parents logical-coordinate fields numerical-contract provenance
+            attributes])
+(defrecord NumericalStateCertificate
+           [state-id schema-version parents logical-coordinate fields numerical-contract provenance
+            attributes logical-byte-length stored-byte-length content-addresses])
+(defrecord CertifiedNumericalState [manifest certificate])
+
+(defn content-address? [value] (instance? ContentAddress value))
+(defn state-chunk? [value] (instance? StateChunk value))
+(defn state-field? [value] (instance? StateField value))
+(defn manifest? [value] (instance? NumericalStateManifest value))
+(defn certificate? [value] (instance? NumericalStateCertificate value))
+(defn certified-state? [value] (instance? CertifiedNumericalState value))
+
+(defn- fail!
+  [message reason data]
+  (throw (ex-info message (assoc data :reason reason))))
+
+(defn- exact-keys!
+  [label reason candidate allowed]
+  (let [unexpected (vec (remove allowed (keys candidate)))]
+    (when (seq unexpected)
+      (fail! (str label " contains fields outside its versioned schema")
+             reason {:unexpected unexpected :allowed allowed})))
+  candidate)
+
+(defn- non-blank-string?
+  [value]
+  (and (string? value) (not (string/blank? value))))
+
+(defn content-address
+  "Construct a storage-independent identity for immutable bytes.
+
+   `algorithm` identifies the digest algorithm (normally `:sha-256`); `digest` is its canonical
+   printable representation.  An object key, bucket, local path or LMDB key is a runtime placement
+   of this identity and must not be embedded here."
+  [algorithm digest]
+  (when-not (keyword? algorithm)
+    (fail! "content-address algorithm must be a keyword"
+           :numerical-state-content-algorithm {:algorithm algorithm}))
+  (when-not (non-blank-string? digest)
+    (fail! "content-address digest must be a non-blank string"
+           :numerical-state-content-digest {:digest digest}))
+  (->ContentAddress algorithm digest))
+
+(defn- validate-content-address!
+  [candidate]
+  (when-not (content-address? candidate)
+    (fail! "state chunk requires an immutable ContentAddress"
+           :numerical-state-chunk-content {:content candidate}))
+  (exact-keys! "content address" :numerical-state-content-fields candidate
+               #{:algorithm :digest})
+  (content-address (:algorithm candidate) (:digest candidate))
+  candidate)
+
+(defn chunk
+  [{:keys [id offsets shape logical-byte-length stored-byte-length content storage attributes]
+    :or {attributes {}}}]
+  (when (nil? id)
+    (fail! "state chunk requires an identity" :numerical-state-chunk-id {}))
+  (when-not (and (vector? offsets) (every? #(and (integer? %) (not (neg? %))) offsets))
+    (fail! "state chunk offsets must be a vector of non-negative integers"
+           :numerical-state-chunk-offsets {:chunk id :offsets offsets}))
+  (when-not (and (vector? shape) (seq shape) (every? pos-int? shape))
+    (fail! "state chunk shape must be a non-empty vector of positive integers"
+           :numerical-state-chunk-shape {:chunk id :shape shape}))
+  (when-not (= (count offsets) (count shape))
+    (fail! "state chunk offsets and shape must have equal rank"
+           :numerical-state-chunk-rank {:chunk id :offsets offsets :shape shape}))
+  (when-not (and (integer? logical-byte-length) (not (neg? logical-byte-length)))
+    (fail! "state chunk logical byte length must be a non-negative integer"
+           :numerical-state-chunk-logical-bytes
+           {:chunk id :logical-byte-length logical-byte-length}))
+  (when-not (pos-int? stored-byte-length)
+    (fail! "state chunk stored byte length must be a positive integer"
+           :numerical-state-chunk-stored-bytes
+           {:chunk id :stored-byte-length stored-byte-length}))
+  (validate-content-address! content)
+  (when-not (and (map? storage) (keyword? (:format storage)))
+    (fail! "state chunk storage requires a map with a keyword :format"
+           :numerical-state-chunk-storage {:chunk id :storage storage}))
+  (when-not (contains? byte-orders (:byte-order storage))
+    (fail! "state chunk storage requires a durable, explicit byte order"
+           :numerical-state-chunk-byte-order
+           {:chunk id :byte-order (:byte-order storage) :allowed byte-orders}))
+  (when-not (map? attributes)
+    (fail! "state chunk attributes must be a map"
+           :numerical-state-chunk-attributes {:chunk id :attributes attributes}))
+  (->StateChunk id offsets shape logical-byte-length stored-byte-length content storage attributes))
+
+(defn field
+  [{:keys [id value chunk-shape coordinate-space chunks attributes]
+    :or {coordinate-space {} chunks [] attributes {}}}]
+  (when (nil? id)
+    (fail! "state field requires an identity" :numerical-state-field-id {}))
+  (abstract-value/validate! value)
+  (when-not (= :tensor (:kind value))
+    (fail! "version 1 numerical state fields must contain tensor AbstractValues"
+           :numerical-state-field-kind {:field id :kind (:kind value)}))
+  (when-not (and (vector? chunk-shape) (seq chunk-shape) (every? pos-int? chunk-shape))
+    (fail! "state field chunk shape must be a non-empty vector of positive integers"
+           :numerical-state-field-chunk-shape {:field id :chunk-shape chunk-shape}))
+  (when-not (= (count (:shape value)) (count chunk-shape))
+    (fail! "state field value and chunk grid must have equal rank"
+           :numerical-state-field-rank
+           {:field id :shape (:shape value) :chunk-shape chunk-shape}))
+  (when-not (map? coordinate-space)
+    (fail! "state field coordinate space must be a map"
+           :numerical-state-field-coordinate-space
+           {:field id :coordinate-space coordinate-space}))
+  (when-not (and (vector? chunks) (every? state-chunk? chunks))
+    (fail! "state field chunks must be a vector of StateChunks"
+           :numerical-state-field-chunks {:field id :chunks chunks}))
+  (when-not (map? attributes)
+    (fail! "state field attributes must be a map"
+           :numerical-state-field-attributes {:field id :attributes attributes}))
+  (->StateField id value chunk-shape coordinate-space chunks attributes))
+
+(defn manifest
+  [{:keys [id schema-version parents logical-coordinate fields numerical-contract provenance
+           attributes]
+    :or {schema-version raster.compiler.ir.numerical-state/schema-version
+         parents [] logical-coordinate {} fields [] attributes {}}}]
+  (->NumericalStateManifest id schema-version parents logical-coordinate fields numerical-contract
+                            provenance attributes))
+
+(defn- unique-by!
+  [label reason key-fn values]
+  (let [ids (mapv key-fn values)]
+    (when-not (= (count ids) (count (distinct ids)))
+      (fail! (str label " must have unique identities") reason {:ids ids})))
+  values)
+
+(defn- concrete-shape!
+  [field-id value]
+  (let [shape (:shape value)]
+    (when-not (and (seq shape) (every? pos-int? shape))
+      (fail! "durable numerical fields require a positive concrete logical shape"
+             :numerical-state-field-shape {:field field-id :shape shape}))
+    shape))
+
+(defn- grid-offsets
+  [shape chunk-shape]
+  (reduce (fn [prefixes [extent step]]
+            (vec (for [prefix prefixes
+                       offset (range 0 extent step)]
+                   (conj prefix offset))))
+          [[]]
+          (map vector shape chunk-shape)))
+
+(defn- expected-chunk-shape
+  [shape chunk-shape offsets]
+  (mapv (fn [extent chunk-extent offset]
+          (min chunk-extent (- extent offset)))
+        shape chunk-shape offsets))
+
+(defn- validate-chunks!
+  [field-id value chunk-shape chunks]
+  (let [shape (concrete-shape! field-id value)
+        element-bytes (dtype/bytes-of (:dtype value))
+        expected-offsets (grid-offsets shape chunk-shape)
+        actual-offsets (mapv :offsets chunks)]
+    (unique-by! "state chunks" :numerical-state-chunk-identities :id chunks)
+    (doseq [candidate chunks]
+      ;; Reconstructing invokes chunk-local checks even after record mutation through assoc.
+      (exact-keys! "state chunk" :numerical-state-chunk-fields candidate
+                   #{:id :offsets :shape :logical-byte-length :stored-byte-length
+                     :content :storage :attributes})
+      (chunk candidate))
+    (when-not (= actual-offsets (vec (sort actual-offsets)))
+      (fail! "state chunks must use canonical row-major offset order"
+             :numerical-state-chunk-order {:field field-id :offsets actual-offsets}))
+    (when-not (= expected-offsets actual-offsets)
+      (fail! "state chunks must exactly cover the regular logical chunk grid"
+             :numerical-state-chunk-coverage
+             {:field field-id :expected-offsets expected-offsets
+              :actual-offsets actual-offsets}))
+    (doseq [candidate chunks]
+      (let [expected-shape (expected-chunk-shape shape chunk-shape (:offsets candidate))
+            expected-bytes (* element-bytes (reduce * 1 expected-shape))]
+        (when-not (= expected-shape (:shape candidate))
+          (fail! "state chunk shape does not match its clipped logical grid cell"
+                 :numerical-state-chunk-grid-shape
+                 {:field field-id :chunk (:id candidate) :offsets (:offsets candidate)
+                  :expected expected-shape :actual (:shape candidate)}))
+        (when-not (= expected-bytes (:logical-byte-length candidate))
+          (fail! "state chunk logical byte length disagrees with its dtype and shape"
+                 :numerical-state-chunk-logical-bytes
+                 {:field field-id :chunk (:id candidate) :dtype (:dtype value)
+                  :shape expected-shape :expected expected-bytes
+                  :actual (:logical-byte-length candidate)}))))
+    chunks))
+
+(defn- validate-field!
+  [candidate]
+  (when-not (state-field? candidate)
+    (fail! "numerical state fields must be StateFields"
+           :numerical-state-field-type {:field candidate :actual (type candidate)}))
+  (exact-keys! "state field" :numerical-state-field-fields candidate
+               #{:id :value :chunk-shape :coordinate-space :chunks :attributes})
+  ;; Reconstructing invokes all field-local structural checks even if a record was mutated with
+  ;; assoc after construction.
+  (field candidate)
+  (let [value (abstract-value/validate! (:value candidate))]
+    (when-not (dtype/known? (:dtype value))
+      (fail! "durable numerical state requires a compiler-known element dtype"
+             :numerical-state-field-dtype
+             {:field (:id candidate) :dtype (:dtype value)}))
+    (validate-chunks! (:id candidate) value (:chunk-shape candidate) (:chunks candidate)))
+  candidate)
+
+(defn- validate-numerical-contract!
+  [contract]
+  (when-not (map? contract)
+    (fail! "numerical state requires an explicit numerical contract"
+           :numerical-state-numerical-contract {:contract contract}))
+  (when-not (keyword? (:mode contract))
+    (fail! "numerical contract requires a keyword :mode"
+           :numerical-state-numerical-mode {:contract contract}))
+  (when-not (contains? determinism-contracts (:determinism contract))
+    (fail! "numerical contract has an unsupported :determinism policy"
+           :numerical-state-determinism
+           {:determinism (:determinism contract) :allowed determinism-contracts}))
+  (when-not (non-blank-string? (:compatibility-id contract))
+    (fail! "numerical contract requires a non-blank :compatibility-id"
+           :numerical-state-compatibility-id {:contract contract}))
+  contract)
+
+(defn- validate-provenance!
+  [provenance]
+  (when-not (map? provenance)
+    (fail! "numerical state provenance must be a map"
+           :numerical-state-provenance {:provenance provenance}))
+  (when-not (non-blank-string? (:program-fingerprint provenance))
+    (fail! "numerical state provenance requires a non-blank :program-fingerprint"
+           :numerical-state-program-fingerprint {:provenance provenance}))
+  provenance)
+
+(defn validate!
+  "Validate a complete, backend-neutral numerical snapshot manifest.
+
+   Validation proves regular dense chunk coverage and exact logical byte counts.  Stored byte
+   counts remain representation-dependent and are retained for placement/cost planning."
+  [candidate]
+  (when-not (manifest? candidate)
+    (fail! "expected a NumericalStateManifest"
+           :numerical-state-manifest-type {:actual (type candidate)}))
+  (exact-keys! "numerical state manifest" :numerical-state-manifest-fields candidate
+               #{:id :schema-version :parents :logical-coordinate :fields
+                 :numerical-contract :provenance :attributes})
+  (let [{:keys [id schema-version parents logical-coordinate fields numerical-contract provenance
+                attributes]}
+        candidate]
+    (when (nil? id)
+      (fail! "numerical state manifest requires an identity" :numerical-state-id {}))
+    (when-not (= raster.compiler.ir.numerical-state/schema-version schema-version)
+      (fail! "unsupported numerical state schema version"
+             :numerical-state-schema-version
+             {:expected raster.compiler.ir.numerical-state/schema-version :actual schema-version}))
+    (when-not (and (vector? parents) (not-any? nil? parents))
+      (fail! "numerical state parents must be a vector of non-nil identities"
+             :numerical-state-parents {:parents parents}))
+    (unique-by! "numerical state parents" :numerical-state-parent-identities identity parents)
+    (when (some #{id} parents)
+      (fail! "a numerical state cannot name itself as a parent"
+             :numerical-state-parent-cycle {:state id :parents parents}))
+    (when-not (map? logical-coordinate)
+      (fail! "numerical state logical coordinate must be a map"
+             :numerical-state-logical-coordinate {:logical-coordinate logical-coordinate}))
+    (when-not (and (vector? fields) (seq fields))
+      (fail! "numerical state requires a non-empty ordered field vector"
+             :numerical-state-fields {:fields fields}))
+    (unique-by! "numerical state fields" :numerical-state-field-identities :id fields)
+    (doseq [candidate-field fields]
+      (validate-field! candidate-field))
+    (validate-numerical-contract! numerical-contract)
+    (validate-provenance! provenance)
+    (when-not (map? attributes)
+      (fail! "numerical state attributes must be a map"
+             :numerical-state-attributes {:attributes attributes})))
+  candidate)
+
+(defn- derive-certificate
+  [manifest]
+  (let [chunks (mapcat :chunks (:fields manifest))]
+    (->NumericalStateCertificate
+     (:id manifest)
+     (:schema-version manifest)
+     (:parents manifest)
+     (:logical-coordinate manifest)
+     (:fields manifest)
+     (:numerical-contract manifest)
+     (:provenance manifest)
+     (:attributes manifest)
+     (reduce + 0 (map :logical-byte-length chunks))
+     (reduce + 0 (map :stored-byte-length chunks))
+     (mapv :content chunks))))
+
+(defn certify
+  "Validate a manifest and attach a reproducible coverage, lineage and byte-cost witness."
+  [manifest]
+  (let [manifest (validate! manifest)]
+    (->CertifiedNumericalState manifest (derive-certificate manifest))))
+
+(defn verify!
+  "Revalidate a CertifiedNumericalState and independently derive its certificate."
+  [certified]
+  (when-not (certified-state? certified)
+    (fail! "expected a CertifiedNumericalState"
+           :numerical-state-certified-type {:actual (type certified)}))
+  (let [manifest (validate! (:manifest certified))
+        certificate (:certificate certified)
+        expected (derive-certificate manifest)]
+    (when-not (certificate? certificate)
+      (fail! "numerical state certificate has the wrong type"
+             :numerical-state-certificate-type {:actual (type certificate)}))
+    (when-not (= expected certificate)
+      (fail! "numerical state certificate does not match its manifest"
+             :numerical-state-certificate {:expected expected :actual certificate}))
+    certified))

--- a/test/raster/compiler/ir/numerical_state_test.clj
+++ b/test/raster/compiler/ir/numerical_state_test.clj
@@ -1,0 +1,175 @@
+(ns raster.compiler.ir.numerical-state-test
+  (:refer-clojure :exclude [chunk])
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.abstract-value :as abstract-value]
+            [raster.compiler.ir.numerical-state :as state]))
+
+(defn- content
+  [n]
+  (state/content-address :sha-256 (format "%064x" n)))
+
+(defn- chunk
+  [id offsets shape logical-bytes stored-bytes digest]
+  (state/chunk
+   {:id id
+    :offsets offsets
+    :shape shape
+    :logical-byte-length logical-bytes
+    :stored-byte-length stored-bytes
+    :content (content digest)
+    :storage {:format :boring-rfc8746 :byte-order :little-endian}
+    :attributes {}}))
+
+(defn- temperature-field
+  []
+  (state/field
+   {:id :temperature
+    :value (abstract-value/tensor
+            {:dtype :float
+             :shape [5 4]
+             :logical-layout {:order :row-major}
+             :representation {:kind :plain}
+             :ownership :owned})
+    :chunk-shape [3 3]
+    :coordinate-space
+    {:level 0
+     :axes [{:name :y :origin 0.0 :spacing 0.25}
+            {:name :x :origin 0.0 :spacing 0.5}]}
+    :chunks [(chunk :t-0-0 [0 0] [3 3] 36 48 1)
+             (chunk :t-0-3 [0 3] [3 1] 12 24 2)
+             (chunk :t-3-0 [3 0] [2 3] 24 36 3)
+             (chunk :t-3-3 [3 3] [2 1] 8 20 4)]}))
+
+(defn- checkpoint
+  ([] (checkpoint [(temperature-field)]))
+  ([fields]
+   (state/manifest
+    {:id :weather/step-40
+     :parents [:weather/step-32]
+     :logical-coordinate {:step 40 :time-seconds 10.0 :stage :accepted}
+     :fields fields
+     :numerical-contract
+     {:mode :ieee-mixed-precision
+      :determinism :reproducible-order
+      :compatibility-id "shallow-water-v3:f32-storage:f32-accumulate"}
+     :provenance
+     {:program-fingerprint "sha256:compiler-and-solver-fingerprint"
+      :parameters {:cfl 0.45}}
+     :attributes {:scenario :coastal-probe}})))
+
+(defn- thrown-data
+  [f]
+  (try
+    (f)
+    nil
+    (catch clojure.lang.ExceptionInfo exception
+      (ex-data exception))))
+
+(deftest complete-dense-state-is-certified-with-lineage-and-costs
+  (let [certified (state/certify (checkpoint))
+        certificate (:certificate certified)]
+    (is (state/certified-state? (state/verify! certified)))
+    (is (= :weather/step-40 (:state-id certificate)))
+    (is (= [:weather/step-32] (:parents certificate)))
+    (is (= {:step 40 :time-seconds 10.0 :stage :accepted}
+           (:logical-coordinate certificate)))
+    (is (= 80 (:logical-byte-length certificate)))
+    (is (= 128 (:stored-byte-length certificate)))
+    (is (= (mapv (comp :digest :content) (:chunks (temperature-field)))
+           (mapv :digest (:content-addresses certificate))))
+    (is (= :reproducible-order (get-in certificate [:numerical-contract :determinism])))
+    (is (= "sha256:compiler-and-solver-fingerprint"
+           (get-in certificate [:provenance :program-fingerprint])))))
+
+(deftest storage-placement-is-not-part-of-the-compiler-manifest
+  (let [candidate (first (:chunks (temperature-field)))]
+    (is (= #{:id :offsets :shape :logical-byte-length :stored-byte-length
+             :content :storage :attributes}
+           (set (keys candidate))))
+    (is (not-any? #(contains? candidate %)
+                  [:path :bucket :object-key :store :mmap :segment :buffer :device :queue]))
+    (is (= :numerical-state-chunk-fields
+           (:reason
+            (thrown-data
+             #(state/certify
+               (checkpoint
+                [(assoc-in (temperature-field) [:chunks 0 :object-key]
+                           "s3://bucket/chunk")]))))))))
+
+(deftest regular-grid-coverage-shape-and-byte-count-are-load-bearing
+  (let [field (temperature-field)]
+    (testing "a missing cell is a coverage gap"
+      (is (= :numerical-state-chunk-coverage
+             (:reason
+              (thrown-data
+               #(state/certify
+                 (checkpoint [(assoc field :chunks (pop (:chunks field)))])))))))
+    (testing "edge cells must be clipped to the global shape"
+      (is (= :numerical-state-chunk-grid-shape
+             (:reason
+              (thrown-data
+               #(state/certify
+                 (checkpoint
+                  [(assoc-in field [:chunks 3 :shape] [3 1])])))))))
+    (testing "logical byte counts are derived from dtype and shape"
+      (is (= :numerical-state-chunk-logical-bytes
+             (:reason
+              (thrown-data
+               #(state/certify
+                 (checkpoint
+                  [(assoc-in field [:chunks 0 :logical-byte-length] 35)])))))))
+    (testing "native byte order is not a durable cross-machine contract"
+      (is (= :numerical-state-chunk-byte-order
+             (:reason
+              (thrown-data
+               #(state/certify
+                 (checkpoint
+                  [(assoc-in field [:chunks 0 :storage :byte-order] :native)])))))))
+    (testing "canonical grid order makes publication and certification deterministic"
+      (is (= :numerical-state-chunk-order
+             (:reason
+              (thrown-data
+               #(state/certify
+                 (checkpoint
+                  [(assoc field :chunks (vec (reverse (:chunks field))))])))))))))
+
+(deftest certificates-detect-manifest-drift
+  (let [certified (state/certify (checkpoint))
+        changed-coordinate (assoc-in certified [:manifest :logical-coordinate :step] 41)
+        changed-content (assoc-in certified
+                                  [:manifest :fields 0 :chunks 0 :content]
+                                  (content 99))]
+    (is (= :numerical-state-certificate
+           (:reason (thrown-data #(state/verify! changed-coordinate)))))
+    (is (= :numerical-state-certificate
+           (:reason (thrown-data #(state/verify! changed-content)))))))
+
+(deftest numerical-compatibility-and-provenance-are-explicit
+  (testing "restore compatibility is not inferred from dtype and shape"
+    (is (= :numerical-state-compatibility-id
+           (:reason
+            (thrown-data
+             #(state/certify
+               (assoc (checkpoint)
+                      :numerical-contract
+                      {:mode :ieee-mixed-precision
+                       :determinism :reproducible-order})))))))
+  (testing "the producing program is identified independently from state and chunk identities"
+    (is (= :numerical-state-program-fingerprint
+           (:reason
+            (thrown-data
+             #(state/certify
+               (assoc (checkpoint) :provenance {:parameters {:cfl 0.45}}))))))))
+
+(deftest manifests-may-reuse-immutable-chunks-across-branches
+  (let [parent-field (temperature-field)
+        reused (get-in parent-field [:chunks 0 :content])
+        child-field (assoc-in parent-field [:chunks 1 :content] (content 20))
+        certified (state/certify
+                   (state/manifest
+                    (assoc (into {} (checkpoint [child-field]))
+                           :id :weather/branch-b
+                           :parents [:weather/step-40]
+                           :logical-coordinate {:step 48 :branch :higher-viscosity})))]
+    (is (= reused (get-in certified [:certificate :fields 0 :chunks 0 :content])))
+    (is (= (content 20) (get-in certified [:certificate :fields 0 :chunks 1 :content])))))


### PR DESCRIPTION
Adds a storage-neutral NumericalStateManifest over AbstractValue fields and immutable rectangular chunks. Certification validates complete regular-grid coverage, clipped edge shapes, dtype-derived logical byte counts, durable byte order, lineage, numerical compatibility, provenance, and content identities without embedding store or device handles.

Documents the three-plane Datahike / immutable-content / resident-compute architecture, Konserve mmap plus S3 or LMDB lifetime constraints, scientific format tradeoffs, facility deployment profiles, and the workload-driven PDE/AMR landing order.

Focused verification:
- numerical-state: 6 tests, 23 assertions
- abstract-value: 2 tests, 9 assertions
- distributed-plan: 11 tests, 35 assertions