### PR TITLE
Scope durable content through runtime events

### DIFF
--- a/design/durable-numerical-state.md
+++ b/design/durable-numerical-state.md
@@ -94,6 +94,15 @@ The common runtime capability should consequently be scoped, not a naked segment
 File-backed Konserve and LMDB can implement that capability with different lifetime rules. Remote
 stores implement promotion to a local provider, not a fictitious remote mmap.
 
+`raster.runtime.numerical-content` now defines this seam as capability-described storage tiers,
+provider-owned promotion/localization events, and an `AutoCloseable` `LocalContentLease`. A retained
+Raster range-transfer event may take ownership of one or more leases after successful submission;
+completion or session shutdown releases them exactly once. Failed validation leaves ownership with
+the caller. This supports today's staging implementations and a future borrowed direct-DMA path
+without changing the manifest or weakening mmap/LMDB lifetime rules. A nonblocking completion poll
+does not release the lease: cancellation stops admission of new work, then `release-event!` waits at
+the current transfer boundary and consumes the event and lease together.
+
 In-place mmap editing is for ephemeral working copies. Mutating an object already published under a
 content address violates snapshot immutability. Same-sized Boring edits may dirty only touched
 pages, which is valuable while constructing the next chunk; the result must then be sealed under a

--- a/src/raster/compiler/ir/execution_plan.clj
+++ b/src/raster/compiler/ir/execution_plan.clj
@@ -8,7 +8,7 @@
             [raster.compiler.ir.kernel-call :as kcall]
             [raster.compiler.ir.kernel-graph-call :as kgcall]))
 
-(def queue-classes #{:compute :transfer :collective :host})
+(def queue-classes #{:compute :transfer :collective :storage :host})
 (def queue-orderings #{:in-order :out-of-order})
 
 (defrecord LogicalQueue [id class ordinal ordering])
@@ -37,6 +37,12 @@
   "The default target-neutral in-order host/device transfer queue."
   []
   (->LogicalQueue :transfer-0 :transfer 0 :in-order))
+
+(defn storage-queue
+  "The default target-neutral in-order durable-content queue. Storage promotion/localization may
+   overlap compute, transfers and collectives, but remains an explicit schedulable resource."
+  []
+  (->LogicalQueue :storage-0 :storage 0 :in-order))
 
 (defn validate!
   "Validate and return an ExecutionPlan.

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -40,7 +40,8 @@
             [raster.compiler.pipeline :as pl]
             [raster.core :as rcore]
             [raster.gpu.measurement :as measurement]
-            [raster.gpu.resident-value :as resident-value]))
+            [raster.gpu.resident-value :as resident-value])
+  (:import [java.lang AutoCloseable]))
 
 ;; ================================================================
 ;; Backend dispatch
@@ -1082,35 +1083,45 @@
   (and x (= "raster.gpu.core.GPUEvent" (.getName (class x)))))
 
 (defn- submit-transfer-ranges!
-  [sess entries direction]
-  (locking sess
-    (let [{:keys [device-id session-id closed?]} @sess]
-      (when closed?
-        (throw (ex-info "cannot submit a transfer to a closed GPU session"
-                        {:direction direction})))
-      ;; Validation and host-side upload staging both complete before the event becomes visible.
-      ;; The backend owns any native staging until await/release consumes its completion token.
-      (let [plans (plan-transfer-ranges sess entries direction)
-            values (mapv (fn [[buffer _ host]]
-                           (if (= :upload direction) buffer host))
-                         plans)
-            submitted-ns (System/nanoTime)
-            backend-event ((rt-resolve device-id "submit-range-batch!")
-                           (mapv (fn [[buffer plan _]] [buffer plan]) plans)
-                           direction)
-            submit-return-ns (System/nanoTime)
-            event-id (random-uuid)
-            event (->GPUEvent session-id event-id (execution/transfer-queue))]
-        (swap! sess assoc-in [:events event-id]
-               {:event event
-                :kind :transfer
-                :direction direction
-                :status :pending
-                :backend-event backend-event
-                :submitted-ns submitted-ns
-                :submit-return-ns submit-return-ns
-                :value values})
-        event))))
+  ([sess entries direction]
+   (submit-transfer-ranges! sess entries direction []))
+  ([sess entries direction retained-resources]
+   (when-not (and (vector? retained-resources)
+                  (every? #(instance? AutoCloseable %) retained-resources))
+     (throw (ex-info "retained transfer resources must be a vector of AutoCloseable values"
+                     {:direction direction :resources retained-resources})))
+   (locking sess
+     (let [{:keys [device-id session-id closed?]} @sess]
+       (when closed?
+         (throw (ex-info "cannot submit a transfer to a closed GPU session"
+                         {:direction direction})))
+       ;; Validation and host-side upload staging both complete before the event becomes visible.
+       ;; The backend owns any native staging until await/release consumes its completion token.
+       ;; Retained resources cover a stronger future path in which the backend borrows a mapped
+       ;; source/destination directly: successful submission transfers their close responsibility
+       ;; to this event, and completion releases them exactly once.
+       (let [plans (plan-transfer-ranges sess entries direction)
+             values (mapv (fn [[buffer _ host]]
+                            (if (= :upload direction) buffer host))
+                          plans)
+             submitted-ns (System/nanoTime)
+             backend-event ((rt-resolve device-id "submit-range-batch!")
+                            (mapv (fn [[buffer plan _]] [buffer plan]) plans)
+                            direction)
+             submit-return-ns (System/nanoTime)
+             event-id (random-uuid)
+             event (->GPUEvent session-id event-id (execution/transfer-queue))]
+         (swap! sess assoc-in [:events event-id]
+                {:event event
+                 :kind :transfer
+                 :direction direction
+                 :status :pending
+                 :backend-event backend-event
+                 :submitted-ns submitted-ns
+                 :submit-return-ns submit-return-ns
+                 :retained-resources retained-resources
+                 :value values})
+         event)))))
 
 (defn submit-upload-ranges!
   "Validate and submit a batch of host-to-resident ranges without waiting.
@@ -1122,6 +1133,16 @@
   [sess entries]
   (submit-transfer-ranges! sess entries :upload))
 
+(defn submit-upload-ranges-retained!
+  "Submit host-to-resident ranges and transfer ownership of scoped host resources to the event.
+
+   `retained-resources` must be a vector of AutoCloseable leases. On successful submission they
+   remain live until await-event! or release-event! establishes completion; session close also
+   drains the event. If submission throws, ownership remains with the caller. This is the safe seam
+   for mmap/LMDB payloads and future direct DMA that does not make an owned staging copy."
+  [sess entries retained-resources]
+  (submit-transfer-ranges! sess entries :upload retained-resources))
+
 (defn submit-download-ranges!
   "Validate and submit a batch of resident-to-host ranges without waiting.
 
@@ -1130,6 +1151,12 @@
    with `event-measurement` after awaiting it."
   [sess entries]
   (submit-transfer-ranges! sess entries :download))
+
+(defn submit-download-ranges-retained!
+  "Download into scoped host resources retained through device completion. See
+   submit-upload-ranges-retained! for ownership semantics."
+  [sess entries retained-resources]
+  (submit-transfer-ranges! sess entries :download retained-resources))
 
 (defn- external-graph-buffer-ids
   [graph]
@@ -1271,10 +1298,22 @@
       (throw (ex-info "GPU event is no longer owned by this session"
                       {:event event :events (keys (:events @sess))}))))
 
+(defn- close-retained-resources
+  [resources]
+  (reduce (fn [errors resource]
+            (try
+              (.close ^AutoCloseable resource)
+              errors
+              (catch Exception error
+                (conj errors error))))
+          []
+          (reverse resources)))
+
 (defn- await-event-under-lock!
   [sess event]
   (let [{:keys [device-id closed?]} @sess
-        {:keys [status backend-event kind submitted-ns submit-return-ns] :as entry}
+        {:keys [status backend-event kind submitted-ns submit-return-ns retained-resources]
+         :as entry}
         (resolve-event-entry sess event)]
     (when closed?
       (throw (ex-info "cannot use an event from a closed GPU session" {:event event})))
@@ -1289,9 +1328,19 @@
                                  {:host-wall-ns (- completed-ns submitted-ns)
                                   :submit-host-ns (- submit-return-ns submitted-ns)}))]
         ((rt-resolve device-id "release-event!") backend-event)
-        (let [completed (cond-> (assoc entry :status :complete :backend-event nil)
-                          measurement (assoc :measurement measurement))]
+        (let [release-errors (close-retained-resources retained-resources)
+              completed (cond-> (assoc entry
+                                       :status :complete
+                                       :backend-event nil
+                                       :retained-resources [])
+                          measurement (assoc :measurement measurement)
+                          (seq release-errors) (assoc :retention-release-errors release-errors))]
+          ;; Record completion before surfacing a lease-close failure: the native event has already
+          ;; been consumed and must never be released a second time.
           (swap! sess assoc-in [:events (:id event)] completed)
+          (when (seq release-errors)
+            (throw (ex-info "transfer completed but retained resource release failed"
+                            {:event event :errors release-errors} (first release-errors))))
           completed)))))
 
 (defn event-complete?

--- a/src/raster/runtime/numerical_content.clj
+++ b/src/raster/runtime/numerical_content.clj
@@ -1,0 +1,345 @@
+(ns raster.runtime.numerical-content
+  "Runtime realization of immutable numerical-state chunks.
+
+   The compiler manifest names content, not storage products. A ContentProvider describes its
+   tiers and capabilities, submits asynchronous promotion/localization operations, and opens a
+   local realization as a scoped MemorySegment lease. Implementations may wrap Konserve file/S3
+   tiering, LMDB transactions, Ceph, EOS, GPFS, Lustre, or an institutional archive.
+
+   This namespace owns no store implementation. In particular, remote object storage is localized
+   before `open-local-content!`; a remote object is never represented as a fictitious mmap."
+  (:require [raster.compiler.ir.execution-plan :as execution]
+            [raster.compiler.ir.numerical-state :as numerical-state])
+  (:import [java.lang AutoCloseable]
+           [java.lang.foreign MemorySegment]))
+
+(defrecord StorageTier [id kind locality durability capabilities attributes])
+(defrecord ContentProviderDescriptor [id tiers capabilities attributes])
+(defrecord ContentPlacement [provider-id tier-id content attributes])
+(defrecord StorageEvent [provider-id id operation queue])
+
+(defrecord LocalContentLease
+           [content placement segment byte-offset byte-length release-fn closed-state]
+  AutoCloseable
+  (close [_]
+    (when (compare-and-set! closed-state false true)
+      (release-fn))
+    nil))
+
+(defprotocol ContentProvider
+  "Backend contract for immutable numerical content.
+
+   Provider events are opaque, provider-owned completions. Promotion establishes the requested
+   durable tier; localization establishes a local realization that can subsequently be opened as a
+   scoped lease. Event methods deliberately mirror Raster GPU events without sharing native handles
+   or pretending storage and device queues are the same resource."
+  (-provider-descriptor [provider])
+  (-submit-promotion! [provider content target-tier opts])
+  (-submit-localization! [provider content opts])
+  (-open-local-content! [provider content opts])
+  (-storage-event-complete? [provider event])
+  (-await-storage-event! [provider event])
+  (-storage-event-measurement [provider event])
+  (-release-storage-event! [provider event]))
+
+(defn storage-tier? [value] (instance? StorageTier value))
+(defn provider-descriptor? [value] (instance? ContentProviderDescriptor value))
+(defn content-placement? [value] (instance? ContentPlacement value))
+(defn storage-event? [value] (instance? StorageEvent value))
+(defn local-content-lease? [value] (instance? LocalContentLease value))
+
+(defn- fail!
+  [message reason data]
+  (throw (ex-info message (assoc data :reason reason))))
+
+(defn- keyword-set?
+  [value]
+  (and (set? value) (every? keyword? value)))
+
+(defn storage-tier
+  [{:keys [id kind locality durability capabilities attributes]
+    :or {capabilities #{} attributes {}}}]
+  (when (nil? id)
+    (fail! "storage tier requires an identity" :numerical-content-tier-id {}))
+  (doseq [[field value] [[:kind kind] [:locality locality] [:durability durability]]]
+    (when-not (keyword? value)
+      (fail! "storage tier facets must be explicit keywords"
+             :numerical-content-tier-facet {:tier id :field field :value value})))
+  (when-not (keyword-set? capabilities)
+    (fail! "storage tier capabilities must be a set of keywords"
+           :numerical-content-tier-capabilities
+           {:tier id :capabilities capabilities}))
+  (when-not (map? attributes)
+    (fail! "storage tier attributes must be a map"
+           :numerical-content-tier-attributes {:tier id :attributes attributes}))
+  (->StorageTier id kind locality durability capabilities attributes))
+
+(defn provider-description
+  [{:keys [id tiers capabilities attributes]
+    :or {capabilities #{} attributes {}}}]
+  (when (nil? id)
+    (fail! "content provider requires an identity" :numerical-content-provider-id {}))
+  (when-not (and (vector? tiers) (seq tiers) (every? storage-tier? tiers))
+    (fail! "content provider requires a non-empty ordered vector of StorageTiers"
+           :numerical-content-provider-tiers {:provider id :tiers tiers}))
+  (let [tier-ids (mapv :id tiers)]
+    (when-not (= (count tier-ids) (count (distinct tier-ids)))
+      (fail! "content provider tier identities must be unique"
+             :numerical-content-provider-tier-identities
+             {:provider id :tiers tier-ids})))
+  (when-not (keyword-set? capabilities)
+    (fail! "content provider capabilities must be a set of keywords"
+           :numerical-content-provider-capabilities
+           {:provider id :capabilities capabilities}))
+  (when-not (map? attributes)
+    (fail! "content provider attributes must be a map"
+           :numerical-content-provider-attributes
+           {:provider id :attributes attributes}))
+  (->ContentProviderDescriptor id tiers capabilities attributes))
+
+(defn content-placement
+  [{:keys [provider-id tier-id content attributes]
+    :or {attributes {}}}]
+  (when (nil? provider-id)
+    (fail! "content placement requires a provider identity"
+           :numerical-content-placement-provider {}))
+  (when (nil? tier-id)
+    (fail! "content placement requires a tier identity"
+           :numerical-content-placement-tier {:provider provider-id}))
+  (when-not (numerical-state/content-address? content)
+    (fail! "content placement requires an immutable ContentAddress"
+           :numerical-content-placement-content {:content content}))
+  (when-not (map? attributes)
+    (fail! "content placement attributes must be a map"
+           :numerical-content-placement-attributes {:attributes attributes}))
+  (->ContentPlacement provider-id tier-id content attributes))
+
+(defn storage-event
+  [{:keys [provider-id id operation queue]
+    :or {queue (execution/storage-queue)}}]
+  (when (nil? provider-id)
+    (fail! "storage event requires a provider identity"
+           :numerical-content-event-provider {}))
+  (when (nil? id)
+    (fail! "storage event requires an identity"
+           :numerical-content-event-id {:provider provider-id}))
+  (when-not (keyword? operation)
+    (fail! "storage event operation must be a keyword"
+           :numerical-content-event-operation {:operation operation}))
+  (when-not (and (execution/logical-queue? queue) (= :storage (:class queue)))
+    (fail! "storage event queue must be a logical storage queue"
+           :numerical-content-event-queue {:queue queue}))
+  (->StorageEvent provider-id id operation queue))
+
+(defn local-content-lease
+  "Create an AutoCloseable lease over a local content realization.
+
+   `release-fn` closes the mapped-file arena, LMDB read transaction, cache pin, or equivalent
+   provider resource exactly once. `lease-segment` returns the declared slice and fails after close."
+  [{:keys [content placement segment byte-offset byte-length release-fn]
+    :or {byte-offset 0}}]
+  (when-not (numerical-state/content-address? content)
+    (fail! "local content lease requires an immutable ContentAddress"
+           :numerical-content-lease-content {:content content}))
+  (when-not (content-placement? placement)
+    (fail! "local content lease requires a ContentPlacement"
+           :numerical-content-lease-placement {:placement placement}))
+  (when-not (= content (:content placement))
+    (fail! "local content lease and placement name different content"
+           :numerical-content-lease-content-mismatch
+           {:content content :placement-content (:content placement)}))
+  (when-not (instance? MemorySegment segment)
+    (fail! "local content lease requires a MemorySegment"
+           :numerical-content-lease-segment {:actual (type segment)}))
+  (when-not (and (integer? byte-offset) (not (neg? byte-offset)))
+    (fail! "local content lease byte offset must be a non-negative integer"
+           :numerical-content-lease-offset {:byte-offset byte-offset}))
+  (when-not (and (integer? byte-length) (not (neg? byte-length)))
+    (fail! "local content lease byte length must be a non-negative integer"
+           :numerical-content-lease-length {:byte-length byte-length}))
+  (when (> (+ byte-offset byte-length) (.byteSize ^MemorySegment segment))
+    (fail! "local content lease range exceeds its MemorySegment"
+           :numerical-content-lease-bounds
+           {:byte-offset byte-offset :byte-length byte-length
+            :segment-bytes (.byteSize ^MemorySegment segment)}))
+  (when-not (ifn? release-fn)
+    (fail! "local content lease requires a release function"
+           :numerical-content-lease-release {:release-fn release-fn}))
+  (->LocalContentLease content placement segment byte-offset byte-length release-fn (atom false)))
+
+(defn lease-closed?
+  [lease]
+  (when-not (local-content-lease? lease)
+    (fail! "expected a LocalContentLease"
+           :numerical-content-lease-type {:actual (type lease)}))
+  @(:closed-state lease))
+
+(defn lease-segment
+  "Return the live, range-limited MemorySegment owned by a LocalContentLease."
+  [lease]
+  (when-not (local-content-lease? lease)
+    (fail! "expected a LocalContentLease"
+           :numerical-content-lease-type {:actual (type lease)}))
+  (when (lease-closed? lease)
+    (fail! "local content lease is closed"
+           :numerical-content-lease-closed {:content (:content lease)}))
+  (.asSlice ^MemorySegment (:segment lease) (long (:byte-offset lease))
+            (long (:byte-length lease))))
+
+(defn provider-descriptor
+  [provider]
+  (when-not (satisfies? ContentProvider provider)
+    (fail! "value does not implement ContentProvider"
+           :numerical-content-provider-type {:actual (type provider)}))
+  (let [description (-provider-descriptor provider)]
+    (when-not (provider-descriptor? description)
+      (fail! "ContentProvider returned a non-descriptor"
+             :numerical-content-provider-descriptor-type
+             {:actual (type description)}))
+    ;; Reconstruction revalidates mutated records and their tiers.
+    (doseq [tier (:tiers description)]
+      (storage-tier tier))
+    (provider-description description)))
+
+(defn- require-capability!
+  [description capability]
+  (when-not (contains? (:capabilities description) capability)
+    (fail! "content provider lacks a required capability"
+           :numerical-content-provider-capability
+           {:provider (:id description) :required capability
+            :available (:capabilities description)})))
+
+(defn- tier-by-id
+  [description tier-id]
+  (or (some #(when (= tier-id (:id %)) %) (:tiers description))
+      (fail! "content provider does not declare the requested tier"
+             :numerical-content-provider-tier
+             {:provider (:id description) :tier tier-id
+              :available (mapv :id (:tiers description))})))
+
+(defn- validate-provider-event!
+  [description operation event]
+  (when-not (storage-event? event)
+    (fail! "ContentProvider returned a non-StorageEvent"
+           :numerical-content-event-type {:actual (type event)}))
+  (when-not (= (:id description) (:provider-id event))
+    (fail! "storage event belongs to a different content provider"
+           :numerical-content-event-provider-mismatch
+           {:expected (:id description) :actual (:provider-id event)}))
+  (when-not (= operation (:operation event))
+    (fail! "storage event operation differs from its submission"
+           :numerical-content-event-operation-mismatch
+           {:expected operation :actual (:operation event)}))
+  event)
+
+(defn submit-promotion!
+  "Submit promotion of immutable content to a declared durable tier."
+  ([provider content target-tier] (submit-promotion! provider content target-tier {}))
+  ([provider content target-tier opts]
+   (let [description (provider-descriptor provider)]
+     (when-not (numerical-state/content-address? content)
+       (fail! "content promotion requires an immutable ContentAddress"
+              :numerical-content-promotion-content {:content content}))
+     (when-not (map? opts)
+       (fail! "content promotion options must be a map"
+              :numerical-content-promotion-options {:opts opts}))
+     (require-capability! description :promote)
+     (let [tier (tier-by-id description target-tier)]
+       (when-not (contains? (:capabilities tier) :durable-receipt)
+         (fail! "promotion target does not promise a durable receipt"
+                :numerical-content-promotion-durability
+                {:provider (:id description) :tier target-tier
+                 :capabilities (:capabilities tier)})))
+     (validate-provider-event!
+      description :promote (-submit-promotion! provider content target-tier opts)))))
+
+(defn submit-localization!
+  "Submit localization of immutable content into a provider tier that can later be opened."
+  ([provider content] (submit-localization! provider content {}))
+  ([provider content opts]
+   (let [description (provider-descriptor provider)]
+     (when-not (numerical-state/content-address? content)
+       (fail! "content localization requires an immutable ContentAddress"
+              :numerical-content-localization-content {:content content}))
+     (when-not (map? opts)
+       (fail! "content localization options must be a map"
+              :numerical-content-localization-options {:opts opts}))
+     (require-capability! description :localize)
+     (when-let [tier-id (:tier opts)]
+       (tier-by-id description tier-id))
+     (validate-provider-event!
+      description :localize (-submit-localization! provider content opts)))))
+
+(defn- checked-event
+  [provider event]
+  (let [description (provider-descriptor provider)]
+    (when-not (storage-event? event)
+      (fail! "storage event operation requires a StorageEvent"
+             :numerical-content-event-type {:actual (type event)}))
+    (when-not (= (:id description) (:provider-id event))
+      (fail! "storage event belongs to a different content provider"
+             :numerical-content-event-provider-mismatch
+             {:expected (:id description) :actual (:provider-id event)}))
+    event))
+
+(defn storage-event-complete?
+  [provider event]
+  (-storage-event-complete? provider (checked-event provider event)))
+
+(defn await-storage-event!
+  [provider event]
+  (-await-storage-event! provider (checked-event provider event)))
+
+(defn storage-event-measurement
+  [provider event]
+  (-storage-event-measurement provider (checked-event provider event)))
+
+(defn release-storage-event!
+  [provider event]
+  (-release-storage-event! provider (checked-event provider event))
+  nil)
+
+(defn open-local-content!
+  "Open already-localized content as a scoped MemorySegment lease."
+  ([provider content] (open-local-content! provider content {}))
+  ([provider content opts]
+   (let [description (provider-descriptor provider)]
+     (when-not (numerical-state/content-address? content)
+       (fail! "opening local content requires an immutable ContentAddress"
+              :numerical-content-open-content {:content content}))
+     (when-not (map? opts)
+       (fail! "local content options must be a map"
+              :numerical-content-open-options {:opts opts}))
+     (require-capability! description :scoped-segment)
+     (let [lease (-open-local-content! provider content opts)]
+       (when-not (local-content-lease? lease)
+         (fail! "ContentProvider returned a non-LocalContentLease"
+                :numerical-content-lease-type {:actual (type lease)}))
+       (when-not (= content (:content lease))
+         (.close ^AutoCloseable lease)
+         (fail! "ContentProvider opened a lease for different content"
+                :numerical-content-open-mismatch
+                {:expected content :actual (:content lease)}))
+       (let [placement (:placement lease)]
+         (when-not (= (:id description) (:provider-id placement))
+           (.close ^AutoCloseable lease)
+           (fail! "local content placement belongs to a different provider"
+                  :numerical-content-placement-provider-mismatch
+                  {:expected (:id description) :actual (:provider-id placement)}))
+         (tier-by-id description (:tier-id placement)))
+       ;; Access once so a malformed or already-closed lease fails before ownership is returned.
+       (lease-segment lease)
+       lease))))
+
+(defn with-local-content
+  "Open localized content, call `f` with its lease, and release the provider resource exactly once."
+  ([provider content f] (with-local-content provider content {} f))
+  ([provider content opts f]
+   (when-not (ifn? f)
+     (fail! "with-local-content requires a callback"
+            :numerical-content-callback {:callback f}))
+   (let [lease (open-local-content! provider content opts)]
+     (try
+       (f lease)
+       (finally
+         (.close ^AutoCloseable lease))))))

--- a/test/raster/compiler/ir/execution_plan_test.clj
+++ b/test/raster/compiler/ir/execution_plan_test.clj
@@ -80,3 +80,11 @@
     (is (= :transfer (:class queue)))
     (is (= :in-order (:ordering queue)))
     (is (not= queue (execution/compute-queue)))))
+
+(deftest durable-storage-has-a-distinct-logical-resource-queue
+  (let [queue (execution/storage-queue)]
+    (is (execution/logical-queue? queue))
+    (is (= :storage (:class queue)))
+    (is (= :in-order (:ordering queue)))
+    (is (not= queue (execution/transfer-queue)))
+    (is (not= queue (execution/compute-queue)))))

--- a/test/raster/runtime/numerical_content_test.clj
+++ b/test/raster/runtime/numerical_content_test.clj
@@ -1,0 +1,226 @@
+(ns raster.runtime.numerical-content-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.buffer-view :as buffer-view]
+            [raster.compiler.ir.numerical-state :as numerical-state]
+            [raster.gpu.core :as gpu]
+            [raster.runtime.numerical-content :as content])
+  (:import [java.lang AutoCloseable]
+           [java.lang.foreign MemorySegment ValueLayout]))
+
+(defn- address
+  [n]
+  (numerical-state/content-address :sha-256 (format "%064x" n)))
+
+(defn- fake-provider
+  [provider-id]
+  (let [events (atom {})
+        releases (atom 0)
+        local-tier (content/storage-tier
+                    {:id :local
+                     :kind :file
+                     :locality :node
+                     :durability :cached
+                     :capabilities #{:scoped-segment}})
+        durable-tier (content/storage-tier
+                      {:id :durable
+                       :kind :object-store
+                       :locality :site
+                       :durability :durable
+                       :capabilities #{:durable-receipt :range-read :multipart-write}})
+        description (content/provider-description
+                     {:id provider-id
+                      :tiers [local-tier durable-tier]
+                      :capabilities #{:promote :localize :scoped-segment}
+                      :attributes {:implementation :fake}})
+        submit (fn [operation value]
+                 (let [event (content/storage-event
+                              {:provider-id provider-id
+                               :id (random-uuid)
+                               :operation operation})]
+                   (swap! events assoc (:id event)
+                          {:status :pending
+                           :value value
+                           :measurement {:timing-source :fake
+                                         :bytes 16
+                                         :elapsed-ns 20}})
+                   event))
+        provider
+        (reify content/ContentProvider
+          (-provider-descriptor [_] description)
+          (-submit-promotion! [_ chunk target-tier _opts]
+            (submit :promote
+                    (content/content-placement
+                     {:provider-id provider-id :tier-id target-tier :content chunk})))
+          (-submit-localization! [_ chunk opts]
+            (submit :localize
+                    (content/content-placement
+                     {:provider-id provider-id :tier-id (or (:tier opts) :local)
+                      :content chunk})))
+          (-open-local-content! [_ chunk _opts]
+            (let [bytes (byte-array (map byte (range 16)))
+                  placement (content/content-placement
+                             {:provider-id provider-id :tier-id :local :content chunk})]
+              (content/local-content-lease
+               {:content chunk
+                :placement placement
+                :segment (MemorySegment/ofArray bytes)
+                :byte-offset 4
+                :byte-length 8
+                :release-fn #(swap! releases inc)})))
+          (-storage-event-complete? [_ event]
+            (= :complete (get-in @events [(:id event) :status])))
+          (-await-storage-event! [_ event]
+            (swap! events assoc-in [(:id event) :status] :complete)
+            (get-in @events [(:id event) :value]))
+          (-storage-event-measurement [_ event]
+            (when (= :complete (get-in @events [(:id event) :status]))
+              (get-in @events [(:id event) :measurement])))
+          (-release-storage-event! [_ event]
+            (swap! events dissoc (:id event))))]
+    {:provider provider :events events :releases releases :description description}))
+
+(deftest provider-capabilities-govern-promotion-and-localization
+  (let [{:keys [provider events description]} (fake-provider :tiered-store)
+        chunk (address 1)
+        promotion (content/submit-promotion! provider chunk :durable)
+        localization (content/submit-localization! provider chunk {:tier :local})]
+    (is (= description (content/provider-descriptor provider)))
+    (is (= :storage (get-in promotion [:queue :class])))
+    (is (= :promote (:operation promotion)))
+    (is (= :localize (:operation localization)))
+    (is (false? (content/storage-event-complete? provider promotion)))
+    (is (= :durable (:tier-id (content/await-storage-event! provider promotion))))
+    (is (content/storage-event-complete? provider promotion))
+    (is (= {:timing-source :fake :bytes 16 :elapsed-ns 20}
+           (content/storage-event-measurement provider promotion)))
+    (is (= :local (:tier-id (content/await-storage-event! provider localization))))
+    (content/release-storage-event! provider promotion)
+    (content/release-storage-event! provider localization)
+    (is (empty? @events))))
+
+(deftest events-and-target-tiers-cannot-cross-provider-boundaries
+  (let [{left :provider} (fake-provider :left)
+        {right :provider} (fake-provider :right)
+        event (content/submit-localization! left (address 2))]
+    (is (= :numerical-content-event-provider-mismatch
+           (:reason
+            (try
+              (content/await-storage-event! right event)
+              nil
+              (catch clojure.lang.ExceptionInfo error
+                (ex-data error))))))
+    (is (= :numerical-content-provider-tier
+           (:reason
+            (try
+              (content/submit-promotion! left (address 2) :unknown)
+              nil
+              (catch clojure.lang.ExceptionInfo error
+                (ex-data error))))))
+    (content/release-storage-event! left event)))
+
+(deftest local-content-is-scoped-and-range-limited
+  (let [{:keys [provider releases]} (fake-provider :local-provider)
+        chunk (address 3)
+        observed
+        (content/with-local-content
+          provider chunk
+          (fn [lease]
+            (let [segment (content/lease-segment lease)]
+              (is (= 8 (.byteSize ^MemorySegment segment)))
+              (is (= 4 (.get ^MemorySegment segment ValueLayout/JAVA_BYTE 0)))
+              lease)))]
+    (is (content/lease-closed? observed))
+    (is (= 1 @releases))
+    (.close ^AutoCloseable observed)
+    (is (= 1 @releases) "lease release is idempotent")
+    (is (= :numerical-content-lease-closed
+           (:reason
+            (try
+              (content/lease-segment observed)
+              nil
+              (catch clojure.lang.ExceptionInfo error
+                (ex-data error))))))))
+
+(defn- fake-transfer-session
+  []
+  (let [buffer {:dtype :byte :n-elements 8 :byte-size 8}
+        allocation (buffer-view/allocation
+                    {:id :resident-allocation
+                     :byte-size 8
+                     :memory-space :device
+                     :device :ze:0
+                     :coherence :host-coherent
+                     :ownership :owned})]
+    (atom {:device-id :ze:0
+           :session-id :retained-transfer-session
+           :buffers {:buffer buffer}
+           :allocations {:buffer allocation}
+           :kernel-graphs {}
+           :events {}
+           :closed? false})))
+
+(deftest polling-and-cancellation-release-local-content-only-at-the-transfer-boundary
+  (let [{:keys [provider releases]} (fake-provider :transfer-provider)
+        lease (content/open-local-content! provider (address 4))
+        session (fake-transfer-session)
+        backend-token ::backend-transfer
+        backend-complete? (atom false)
+        resolver
+        (fn [_ name]
+          (case name
+            "plan-range" (fn [_ host spec direction]
+                           {:host-segment host :spec spec :direction direction :n-bytes 8})
+            "submit-range-batch!" (fn [_ direction]
+                                    (is (= :upload direction))
+                                    backend-token)
+            "await-event!" (fn [token]
+                             (is (= backend-token token))
+                             {:timing-source :device-event
+                              :elapsed-ns 10 :bytes 8 :commands 1
+                              :direction :upload :asynchronous? true})
+            "release-event!" (fn [token] (is (= backend-token token)))
+            "event-complete?" (fn [token]
+                                (is (= backend-token token))
+                                @backend-complete?)
+            (throw (ex-info "unexpected mocked runtime function" {:name name}))))]
+    (with-redefs-fn
+      {(ns-resolve 'raster.gpu.core 'rt-resolve) resolver}
+      (fn []
+        (let [event (gpu/submit-upload-ranges-retained!
+                     session
+                     [[:buffer (content/lease-segment lease) {:elements 8}]]
+                     [lease])]
+          (is (false? (content/lease-closed? lease)))
+          (is (= 0 @releases))
+          (is (false? (gpu/event-complete? session event)))
+          ;; A cancellation request may stop scheduling new work, but it cannot close the mapped
+          ;; arena. Even a positive device poll is only an observation: release-event! establishes
+          ;; the host-visible transfer boundary and consumes both event and lease ownership.
+          (reset! backend-complete? true)
+          (is (gpu/event-complete? session event))
+          (is (false? (content/lease-closed? lease)))
+          (gpu/release-event! session event)
+          (is (content/lease-closed? lease))
+          (is (= 1 @releases))
+          (is (empty? (:events @session))))))))
+
+(deftest failed-transfer-submission-does-not-take-lease-ownership
+  (let [{:keys [provider releases]} (fake-provider :failing-provider)
+        lease (content/open-local-content! provider (address 5))
+        session (fake-transfer-session)]
+    (with-redefs-fn
+      {(ns-resolve 'raster.gpu.core 'rt-resolve)
+       (fn [_ name]
+         (case name
+           "plan-range" (fn [& _] (throw (ex-info "invalid range" {})))
+           (throw (ex-info "unexpected mocked runtime function" {:name name}))))}
+      (fn []
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"invalid range"
+                              (gpu/submit-upload-ranges-retained!
+                               session
+                               [[:buffer (content/lease-segment lease) {:elements 8}]]
+                               [lease])))
+        (is (false? (content/lease-closed? lease)))
+        (is (= 0 @releases))))
+    (.close ^AutoCloseable lease)
+    (is (= 1 @releases))))


### PR DESCRIPTION
Adds the storage-neutral runtime realization seam required by durable numerical manifests and pretrained restore workers.

- capability-described storage tiers and providers
- asynchronous promotion and localization events on a shared logical storage queue
- scoped AutoCloseable MemorySegment leases for local file mmap or LMDB transactions
- retained upload and download APIs that transfer lease ownership to a GPU event only after successful submission
- polling observes completion without releasing the source; await, release, or session shutdown consumes the transfer boundary and closes resources exactly once
- documentation covering cancellation and backend adapter responsibilities

Verification:
- numerical-content plus execution-plan: 10 tests, 57 assertions
- range-transfer suite including Intel Arc execution: 14 tests, 63 assertions