### PR TITLE
Reject eliminated scientific time loops

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,8 @@ Use `:reload` (not `:reload-all`) when requiring `raster.core` to avoid ClassCas
 
 ```bash
 clojure -M:test                           # run all tests
-clojure -M:test -e :exec-fn -- -n raster.core-test  # single namespace
+clojure -M:test -n raster.core-test       # single namespace
+clojure -X:test :nses '[raster.core-test]' # single namespace (exec API)
 ```
 
 ### Benchmarks

--- a/src/raster/compiler/core/op_descriptor.clj
+++ b/src/raster/compiler/core/op_descriptor.clj
@@ -3,7 +3,8 @@
 
   Descriptors merge multiple compiler facets under one lookup point, e.g.:
     :buffer {:allocates? ... :in-place-arg ... :alloc-form ... :rewrite-fn ...}
-    :effects {:pure? ... :mutating? ... :primitive-mutation? ...}
+    :effects {:pure? ... :mutating? ... :primitive-mutation? ...
+              :mutation-target-arg ...}
     :device {:rule ...}
     :shape  {:dim-rule ...}
 
@@ -238,6 +239,17 @@
    buf-arg-idx is the 0-based index of the buffer argument."
   [op-sym mode buf-arg-idx]
   (register-op-descriptor! op-sym {:buffer-write {:mode mode :buf-arg-idx buf-arg-idx}}))
+
+;; JVM arraycopy is a primitive partial write, not a full-buffer overwrite.  Keep its mutation
+;; target in the effects facet instead of misusing :buffer-write (whose :overwrite mode permits
+;; whole-buffer reuse).  Both spellings occur across walked and normalized compiler forms.
+(doseq [op-sym '[System/arraycopy java.lang.System/arraycopy]]
+  (register-op-descriptor!
+   op-sym
+   {:effects {:pure? false
+              :mutating? true
+              :primitive-mutation? true
+              :mutation-target-arg 2}}))
 
 (defn get-buffer-write-mode
   "Return the buffer-write descriptor for op-sym, or nil."
@@ -717,14 +729,14 @@
    bodies rewritten here flow to emitters that read `:raster.type/tag` and `:raster.op/original`."
   [expr replace-fn]
   (letfn [(go [f]
-            (cond
-              (and (seq? f) (= 'quote (first f))) f
-              (seq? f) (or (when (aget-call? f) (replace-fn f))
-                           (with-meta (apply list (map go f)) (meta f)))
-              (vector? f) (with-meta (mapv go f) (meta f))
-              (map? f) (with-meta (into (empty f) (map (fn [[k v]] [(go k) (go v)])) f) (meta f))
-              (set? f) (with-meta (into (empty f) (map go) f) (meta f))
-              :else f))]
+              (cond
+                (and (seq? f) (= 'quote (first f))) f
+                (seq? f) (or (when (aget-call? f) (replace-fn f))
+                             (with-meta (apply list (map go f)) (meta f)))
+                (vector? f) (with-meta (mapv go f) (meta f))
+                (map? f) (with-meta (into (empty f) (map (fn [[k v]] [(go k) (go v)])) f) (meta f))
+                (set? f) (with-meta (into (empty f) (map go) f) (meta f))
+                :else f))]
     (go expr)))
 
 (defn rewrite-aget-indices

--- a/src/raster/compiler/passes/scalar/dce.clj
+++ b/src/raster/compiler/passes/scalar/dce.clj
@@ -31,6 +31,7 @@
 (defn- declared-output-arg
   "The 0-based index of the ONE argument a mutating op writes, when the op EXPLICITLY
    declares it in the op-descriptor registry:
+     - :effects :mutation-target-arg      (primitive partial writes, e.g. arraycopy)
      - :buffer-write :buf-arg-idx        (e.g. dense-into!, qlinear-i8!)
      - :buffer {:allocates? false, :in-place-arg i}  (the *-into! shape: writes into,
        and returns, a caller-provided buffer)
@@ -44,7 +45,8 @@
   [op-sym]
   (letfn [(idx-of [s]
             (when-let [d (descriptor/get-op-descriptor s)]
-              (or (get-in d [:buffer-write :buf-arg-idx])
+              (or (get-in d [:effects :mutation-target-arg])
+                  (get-in d [:buffer-write :buf-arg-idx])
                   (let [b (:buffer d)]
                     (when (and b (false? (:allocates? b))) (:in-place-arg b))))))]
     (when (symbol? op-sym)

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -46,4 +46,8 @@
    :lowering {:segops 1 :kernel-graphs 0 :typed-reused 1 :typed-scalar-equations 1
               :backend-reused 1 :backend-relowered 0 :fallback 0}
    :emission {:kernel-count 0 :targets [] :strategies []
-              :fallback-reasons [] :declines {}}}}}
+              :fallback-reasons [] :declines {}}}
+
+  :heat-loss-rk4-gpu
+  {:declined {:reason :unscheduled-stencil
+              :target-dialect :opencl}}}}

--- a/test/raster/compiler/compatibility_ledger_test.clj
+++ b/test/raster/compiler/compatibility_ledger_test.clj
@@ -60,6 +60,13 @@
     :heat-rhs-1d-jvm
     (pipeline/compile-report #'pde/heat-rhs-1d! :dtype :double)
 
+    :heat-loss-rk4-gpu
+    (try
+      (pipeline/compile-report #'pde/heat-loss-rk4
+                               :target-device target :dtype :double)
+      (catch clojure.lang.ExceptionInfo exception
+        {:declined (select-keys (ex-data exception) [:reason :target-dialect])}))
+
     (throw (ex-info "compatibility ledger has no workload compiler"
                     {:workload id}))))
 
@@ -70,11 +77,13 @@
              :symbolic-dense-contraction-gpu
              :q4k-dp4a-rows-gpu
              :gqa-causal-mha-gpu
-             :heat-rhs-1d-jvm}
+             :heat-rhs-1d-jvm
+             :heat-loss-rk4-gpu}
            (set (keys workloads))))
     (doseq [[id expected] workloads]
-      (let [report (compile-workload id)]
-        (is (= expected (signature report))
+      (let [report (compile-workload id)
+            actual (if (:declined report) report (signature report))]
+        (is (= expected actual)
             (str "compiler compatibility changed for " id
                  "; improve the ledger downward or explain the new debt"))
         (when (= :heat-rhs-1d-jvm id)

--- a/test/raster/compiler/gpu_integration_test.clj
+++ b/test/raster/compiler/gpu_integration_test.clj
@@ -1,16 +1,15 @@
 (ns raster.compiler.gpu-integration-test
-  "GPU integration tests for compound kernel compilation.
+  "Numerical and GPU-compiler ratchets for the heat-equation workload.
 
   These tests require a Level Zero GPU device. They skip gracefully
   when no GPU is available (CI, CPU-only machines).
 
   Verifies:
     1. Functional correctness against analytical heat equation solution
-    2. CPU vs GPU numerical consistency
-    3. Both :local (n=64) and :global/per-phase (n=4096) strategies
-  Note: GPU kernels currently compute in float32 even for double inputs.
-  Tolerance must account for float32 accumulated error (~1e-5 for typical workloads)."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+    2. GPU compilation fails loudly while structured loops containing SOACs remain debt
+
+  The hardware-free exact debt signature is also recorded in compatibility_ledger.edn."
+  (:require [clojure.test :refer [deftest is testing]]
             [raster.dl.gpu-grad-parity :as gp]))
 
 ;; ================================================================
@@ -93,59 +92,15 @@
                 (format "%s: CPU=%.10f analytical=%.10f tol=%.6f"
                         label (double cpu-loss) analytical tol))))))))
 
-(deftest gpu-local-strategy-test
-  (testing "GPU compound kernel (:local, n=64) matches CPU and analytical"
-    (when-gpu "gpu-local-strategy"
-     (require '[raster.compiler.pipeline :as pipeline])
-     (require 'raster.ode.pde)
-     (let [compile-aot (resolve 'raster.compiler.pipeline/compile-aot)
-           heat-loss-rk4 (resolve 'raster.ode.pde/heat-loss-rk4)
-           heat-var (resolve 'raster.ode.pde/heat-loss-rk4)
-           n 64
-           nsteps 100
-           [u0 target alpha inv-dx2 dt] (setup-heat-problem n)
-           cpu-loss (heat-loss-rk4 (aclone u0) target alpha inv-dx2 dt (long nsteps))
-           analytical (analytical-heat-loss n alpha dt nsteps)
-            ;; Compile GPU forward fn
-           fwd (compile-aot heat-var {:target-device :ze:0})
-           gpu-loss (fwd (aclone u0) target alpha inv-dx2 dt (long nsteps))]
-        ;; GPU computes in float32 → expect ~1e-1 tolerance for :local strategy
-        ;; TODO: :local compound kernel has a correctness bug for multi-step RK4.
-        ;; The result is wrong even for float32 (0.123 vs 0.081).
-        ;; Investigate barrier synchronization and buffer aliasing in par_opencl.clj.
-       (is (< (Math/abs (- (double gpu-loss) (double cpu-loss))) 0.05)
-           (format "GPU vs CPU: gpu=%.15f cpu=%.15f"
-                   (double gpu-loss) (double cpu-loss)))
-        ;; Both should be close to analytical (O(dx²) spatial error)
-       (let [dx (/ 1.0 63.0)
-             tol (* 10.0 dx dx)]
-         (is (< (Math/abs (- (double cpu-loss) analytical)) tol)
-             (format "CPU vs analytical: cpu=%.10f ana=%.10f"
-                     (double cpu-loss) analytical)))))))
-
-(deftest gpu-global-strategy-test
-  (testing "GPU per-phase kernels (n=4096) match CPU and analytical"
-    (when-gpu "gpu-global-strategy"
-     (require '[raster.compiler.pipeline :as pipeline])
-     (require 'raster.ode.pde)
-     (let [compile-aot (resolve 'raster.compiler.pipeline/compile-aot)
-           heat-loss-rk4 (resolve 'raster.ode.pde/heat-loss-rk4)
-           heat-var (resolve 'raster.ode.pde/heat-loss-rk4)
-           n 4096
-           nsteps 10
-           [u0 target alpha inv-dx2 dt] (setup-heat-problem n)
-           cpu-loss (heat-loss-rk4 (aclone u0) target alpha inv-dx2 dt (long nsteps))
-           analytical (analytical-heat-loss n alpha dt nsteps)
-            ;; Compile GPU forward fn
-           fwd (compile-aot heat-var {:target-device :ze:0})
-           gpu-loss (fwd (aclone u0) target alpha inv-dx2 dt (long nsteps))]
-        ;; GPU computes in float32 → accumulated error ~1e-5 for n=4096, 10 steps
-       (is (< (Math/abs (- (double gpu-loss) (double cpu-loss))) 1e-4)
-           (format "GPU vs CPU: gpu=%.15f cpu=%.15f"
-                   (double gpu-loss) (double cpu-loss)))
-        ;; Both close to analytical (tighter tolerance for fine grid)
-       (let [dx (/ 1.0 (double (dec n)))
-             tol (* 10.0 dx dx)]
-         (is (< (Math/abs (- (double cpu-loss) analytical)) tol)
-             (format "CPU vs analytical: cpu=%.10f ana=%.10f"
-                     (double cpu-loss) analytical)))))))
+(deftest gpu-rk4-structured-loop-declines-honestly-test
+  (testing "GPU compilation rejects the unsupported structured SOAC loop"
+    (when-gpu "gpu-rk4-structured-loop-decline"
+              (require '[raster.compiler.pipeline :as pipeline])
+              (require 'raster.ode.pde)
+              (try
+                ((resolve 'raster.compiler.pipeline/compile-aot)
+                 (resolve 'raster.ode.pde/heat-loss-rk4)
+                 {:target-device :ze:0})
+                (is false "RK4 must not compile by deleting its loop or using the legacy compound emitter")
+                (catch clojure.lang.ExceptionInfo exception
+                  (is (= :unscheduled-stencil (:reason (ex-data exception)))))))))

--- a/test/raster/compiler/passes/scalar/dce_test.clj
+++ b/test/raster/compiler/passes/scalar/dce_test.clj
@@ -67,6 +67,25 @@
       (is (= 0 (:bindings-removed stats))
           "effectful binding should be preserved"))))
 
+(deftest arraycopy-loop-mutation-preservation-test
+  (let [emt @#'dce/extract-mutation-targets]
+    (testing "System.arraycopy identifies only its destination as mutated"
+      (is (= '#{dst}
+             (emt '(java.lang.System/arraycopy src 0 dst 0 n)))))
+
+    (testing "an unused loop result survives when arraycopy updates a live destination"
+      (let [effect-sym (with-meta '_effect {:raster.effect/effectful true})
+            form (list 'let*
+                       ['u '(clojure.core/aclone input)
+                        effect-sym '(dotimes [step nsteps]
+                                      (java.lang.System/arraycopy tmp 0 u 0 n))
+                        'result '(clojure.core/aget u 0)]
+                       'result)
+            {:keys [form stats]} (dce/eliminate-dead-bindings form)
+            kept (set (take-nth 2 (second form)))]
+        (is (zero? (:bindings-removed stats)))
+        (is (contains? kept effect-sym))))))
+
 ;; ================================================================
 ;; Nested let* with partially dead bindings
 ;; ================================================================


### PR DESCRIPTION
## Outcome

Raster no longer compiles the RK4 heat workload by silently deleting its time-stepping loop. System.arraycopy now declares its destination through the central mutation descriptor, so DCE preserves loop-carried state updates. The next unsupported boundary fails loudly as unscheduled-stencil until typed structured loops land.

## Coverage

- adds an exact DCE mutation/liveness regression
- replaces the roughly 52 percent wrong-answer tolerance with an honest device decline assertion
- records heat-loss-rk4 in the hardware-free compatibility-debt ledger
- fixes the documented single-namespace test command, which previously launched the full suite

## Verification

Focused affected namespaces: 12 tests, 44 assertions, zero failures or errors. The real Intel Arc path was exercised for the fail-loud assertion.