### PR TITLE
Model typed structured control around SOAC

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -602,6 +602,22 @@ association contract and lower to an exact scalar loop. Portable C-family emissi
 term as a sequential fold; future subgroup/workgroup schedules must be selected from its certificate
 rather than rediscovering a reduction from source spelling.
 
+Sequential control around a parallel algorithm is represented separately as the Pattern-declared
+`TypedStructuredControl` dialect. Its canonical loop is a typed fixpoint around one closed
+`TypedSOAC` body: it binds an integer induction value, ordered invariants, and ordered loop-carried
+scalars or tensors, and gives each final result a distinct outer SSA value. The body boundary,
+effects, and `AbstractValue` contracts are checked modulo the explicit outer-to-inner alpha-renaming;
+zero iterations therefore retain the initial value contract without emitter inference. Values
+defined and consumed only inside the body are ordinary SSA scratch, not entries in another memory
+registry. The association contract is explicitly sequential.
+
+This does not add a time-loop SOAC or a PDE-specific primitive. SOAC fusion continues to reason
+algebraically about the parallel body. The first lowering must preserve the fixpoint as explicit
+host repetition of a target-neutral scheduled `KernelGraph`; a persistent workgroup loop is a later
+schedule selected only when its participation, memory, and synchronization proofs hold. Once this
+vertical consumes scientific time loops, the source-shaped compound detector and handwritten local
+emitter are deleted rather than retained as a compatibility route.
+
 ### 3.3 Schedule and transform IR
 
 A schedule is an immutable transformation program over the functional parallel

--- a/src/raster/compiler/ir/structured_control.clj
+++ b/src/raster/compiler/ir/structured_control.clj
@@ -1,0 +1,233 @@
+(ns raster.compiler.ir.structured-control
+  "Typed functional control around parallel algorithms.
+
+   A sequential loop is not itself a SOAC.  It is a small fixpoint expression whose body is a
+   closed TypedSOAC program.  Explicit outer-to-inner bindings keep lexical names out of compiler
+   reasoning and make loop-carried state, invariants, zero-trip semantics, effects, and value
+   compatibility independently certifiable before a schedule chooses host repetition or a
+   persistent device kernel.
+
+   Canonical form:
+
+     (loop-program facts
+       [iteration-parameter trip-count]
+       [{:outer invariant :parameter body-parameter} ...]
+       [{:initial initial-value :parameter body-parameter
+         :result body-result :output final-value} ...]
+       typed-soac-body)
+
+   `trip-count` is either a non-negative integer or an outer scalar value ID.  At zero trips each
+   output denotes its corresponding initial value.  The body input boundary is exactly the
+   iteration parameter followed by invariant parameters and carried parameters; its ordered
+   outputs are exactly the carried results."
+  (:require [clojure.walk :as walk]
+            [pattern.nanopass.dialect :as dialect :refer [def-dialect]]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.soac-dialect :as soac]))
+
+(defn loop-facts?
+  [value]
+  (and (map? value)
+       (soac/equation-id? (:id value))
+       (set? (:effects value))
+       (map? (:provenance value))
+       (map? (:attributes value))
+       (= :sequential (get-in value [:attributes :association]))))
+
+(defn loop-index?
+  [value]
+  (and (vector? value)
+       (= 2 (count value))
+       (soac/value-id? (first value))
+       (soac/extent? (second value))))
+
+(defn loop-invariant?
+  [value]
+  (and (map? value)
+       (= #{:outer :parameter} (set (keys value)))
+       (soac/value-id? (:outer value))
+       (soac/value-id? (:parameter value))))
+
+(defn loop-carry?
+  [value]
+  (and (map? value)
+       (= #{:initial :parameter :result :output} (set (keys value)))
+       (every? soac/value-id?
+               ((juxt :initial :parameter :result :output) value))))
+
+(def-dialect TypedStructuredControl
+  (terminals [lf loop-facts?]
+             [li loop-index?]
+             [iv loop-invariant?]
+             [lc loop-carry?]
+             [sp soac/program-form?])
+
+  (Program [p :enforce]
+           (loop-program ?lf ?li [(?:* ?iv)] [(?:+ ?lc)] ?sp))
+
+  (entry Program))
+
+(defn loop-program?
+  [value]
+  (and (seq? value) (= 'loop-program (first value)) (= 6 (count value))))
+
+(defn facts [program] (second program))
+(defn loop-index [program] (nth program 2))
+(defn invariants [program] (vec (nth program 3)))
+(defn carried [program] (vec (nth program 4)))
+(defn body [program] (nth program 5))
+
+(defn outer-operands
+  "Ordered values read by one loop expression.  A symbolic trip count is an operand."
+  [program]
+  (let [[_ trip-count] (loop-index program)]
+    (vec (concat (when (soac/value-id? trip-count) [trip-count])
+                 (map :outer (invariants program))
+                 (map :initial (carried program))))))
+
+(defn outer-results
+  [program]
+  (mapv :output (carried program)))
+
+(defn body-inputs
+  [program]
+  (vec (concat [(first (loop-index program))]
+               (map :parameter (invariants program))
+               (map :parameter (carried program)))))
+
+(defn body-results
+  [program]
+  (mapv :result (carried program)))
+
+(defn- fail!
+  [reason message data]
+  (throw (ex-info message (assoc data :reason reason :dialect :typed-structured-control))))
+
+(defn- distinct-vector?
+  [value]
+  (and (vector? value) (= (count value) (count (distinct value)))))
+
+(defn- integer-scalar?
+  [value]
+  (and (av/abstract-value? value)
+       (= [] (:shape value))
+       (contains? #{:int :long} (:dtype value))))
+
+(defn- require-value!
+  [values id role]
+  (let [value (get values id ::missing)]
+    (when (= ::missing value)
+      (fail! :typed-loop-unknown-value "structured loop references an unknown value"
+             {:id id :role role}))
+    (av/validate! value)
+    value))
+
+(def ^:private remapped-value-facets
+  [:shape :logical-layout :representation :placement :sharding :attributes])
+
+(defn- remap-value
+  "Rename scoped value IDs embedded in an AbstractValue without changing its record identity."
+  [value renames]
+  (reduce (fn [value facet]
+            (update value facet #(walk/postwalk-replace renames %)))
+          value remapped-value-facets))
+
+(defn- require-compatible!
+  [left-id left right-id right right->left role]
+  (let [right (remap-value right right->left)]
+    (when-not (= left right)
+      (fail! :typed-loop-value-mismatch
+             "structured loop boundary values require alpha-stable AbstractValue contracts"
+             {:role role :left-id left-id :left left :right-id right-id :right right}))))
+
+(defn validate!
+  "Validate a typed structured loop and return it unchanged.
+
+   With `outer-values`, also certify the symbolic trip count and every outer/inner invariant and
+   carry boundary.  This second arity is what an enclosing ParallelProgram must use."
+  ([program] (validate! program nil))
+  ([program outer-values]
+   (when-not (loop-program? program)
+     (fail! :typed-loop-program "expected a loop-program form" {:program program}))
+   (when-not (dialect/valid? TypedStructuredControl program)
+     (fail! :typed-loop-syntax "program does not conform to the structured-control dialect"
+            {:details (dialect/validate TypedStructuredControl program)}))
+   (let [loop-facts (facts program)
+         [iteration trip-count] (loop-index program)
+         invariant-bindings (invariants program)
+         carry-bindings (carried program)
+         body-program (soac/validate! (body program))
+         body-facts (soac/facts body-program)
+         inner-values (:values body-facts)
+         expected-inputs (body-inputs program)
+         expected-results (body-results program)
+         inner-ids (vec (concat expected-inputs expected-results))
+         outer-ids (vec (concat (outer-operands program) (outer-results program)))
+         inner->outer
+         (into {}
+               (concat (map (juxt :parameter :outer) invariant-bindings)
+                       (map (juxt :parameter :initial) carry-bindings)
+                       (map (juxt :result :output) carry-bindings)))]
+     (when-not (distinct-vector? inner-ids)
+       (fail! :typed-loop-inner-bindings
+              "iteration, invariant, carry, and result IDs must be distinct inside the body"
+              {:ids inner-ids}))
+     (when-not (distinct-vector? outer-ids)
+       (fail! :typed-loop-outer-bindings
+              "loop operands and results must be distinct in the enclosing scope"
+              {:ids outer-ids}))
+     (when-not (= expected-inputs (:inputs body-facts))
+       (fail! :typed-loop-body-inputs
+              "loop body inputs must exactly follow iteration, invariants, and carried values"
+              {:expected expected-inputs :actual (:inputs body-facts)}))
+     (when-not (= expected-results (soac/outputs body-program))
+       (fail! :typed-loop-body-results
+              "loop body outputs must exactly match the ordered carried results"
+              {:expected expected-results :actual (soac/outputs body-program)}))
+     (when-not (= (:effects loop-facts) (:effects body-facts))
+       (fail! :typed-loop-effects "loop effects must equal its body effects"
+              {:declared (:effects loop-facts) :body (:effects body-facts)}))
+     (let [iteration-value (require-value! inner-values iteration :iteration)]
+       (when-not (integer-scalar? iteration-value)
+         (fail! :typed-loop-index-type "loop iteration parameter must be an integer scalar"
+                {:id iteration :value iteration-value})))
+     (doseq [{:keys [parameter]} invariant-bindings]
+       (require-value! inner-values parameter :invariant-parameter))
+     (doseq [{:keys [parameter result]} carry-bindings]
+       (let [parameter-value (require-value! inner-values parameter :carry-parameter)
+             result-value (require-value! inner-values result :carry-result)]
+         (require-compatible! parameter parameter-value result result-value {} :body-carry)))
+     (when outer-values
+       (when-not (map? outer-values)
+         (fail! :typed-loop-outer-values "outer values must be an ID-to-AbstractValue map"
+                {:values outer-values}))
+       (when (soac/value-id? trip-count)
+         (let [trip-value (require-value! outer-values trip-count :trip-count)]
+           (when-not (integer-scalar? trip-value)
+             (fail! :typed-loop-trip-count-type "symbolic trip count must be an integer scalar"
+                    {:id trip-count :value trip-value}))))
+       (doseq [{:keys [outer parameter]} invariant-bindings]
+         (require-compatible!
+          outer (require-value! outer-values outer :invariant)
+          parameter (require-value! inner-values parameter :invariant-parameter)
+          inner->outer :invariant))
+       (doseq [{:keys [initial parameter result output]} carry-bindings]
+         (let [initial-value (require-value! outer-values initial :carry-initial)
+               parameter-value (require-value! inner-values parameter :carry-parameter)
+               result-value (require-value! inner-values result :carry-result)
+               output-value (require-value! outer-values output :carry-output)]
+           (require-compatible! initial initial-value parameter parameter-value
+                                inner->outer :carry-input)
+           (require-compatible! output output-value result result-value
+                                inner->outer :carry-output))))
+     program)))
+
+(defn make
+  "Construct and validate a typed structured loop."
+  ([loop-facts index invariant-bindings carry-bindings body-program]
+   (make loop-facts index invariant-bindings carry-bindings body-program nil))
+  ([loop-facts index invariant-bindings carry-bindings body-program outer-values]
+   (validate!
+    (list 'loop-program loop-facts (vec index) (vec invariant-bindings)
+          (vec carry-bindings) body-program)
+    outer-values)))

--- a/test/raster/compiler/ir/structured_control_test.clj
+++ b/test/raster/compiler/ir/structured_control_test.clj
@@ -1,0 +1,106 @@
+(ns raster.compiler.ir.structured-control-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [pattern.nanopass.dialect :as pattern-dialect]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.soac-dialect :as soac]
+            [raster.compiler.ir.structured-control :as control]))
+
+(def ^:private tensor (av/tensor {:dtype :float :shape '[n]}))
+(def ^:private inner-tensor (av/tensor {:dtype :float :shape '[n-in]}))
+(def ^:private extent (av/tensor {:dtype :long :shape []}))
+(def ^:private scalar (av/tensor {:dtype :float :shape []}))
+
+(defn- fixture
+  []
+  (let [body-equation
+        (list '= 'advance '[u-next]
+              (list 'map {:index 'i :extent 'n-in}
+                    '[u-in] '[alpha-in iteration]
+                    (soac/lambda-form
+                     '[u-value alpha-value iteration-value]
+                     '[(if (>= iteration-value 0)
+                         (+ u-value alpha-value)
+                         u-value)])))
+        body-facts
+        (soac/default-program-facts
+         {:values {'iteration extent 'n-in extent 'alpha-in scalar
+                   'u-in inner-tensor 'u-next inner-tensor}
+          :inputs '[iteration n-in alpha-in u-in]
+          :equations {'advance (soac/default-equation-facts)}})
+        body-program (soac/make body-facts [body-equation] '[u-next])
+        outer-values {'steps extent 'n extent 'alpha scalar 'u0 tensor 'u-final tensor}
+        loop-facts {:id 'time-loop :effects #{}
+                    :provenance {:source :rk4-like}
+                    :attributes {:association :sequential}}
+        index '[iteration steps]
+        invariants [{:outer 'n :parameter 'n-in}
+                    {:outer 'alpha :parameter 'alpha-in}]
+        carried [{:initial 'u0 :parameter 'u-in
+                  :result 'u-next :output 'u-final}]
+        program (control/make loop-facts index invariants carried body-program outer-values)]
+    {:program program :body body-program :outer-values outer-values}))
+
+(deftest structured-loop-is-a-pattern-declared-functional-fixpoint
+  (let [{:keys [program outer-values]} (fixture)]
+    (is (pattern-dialect/valid? control/TypedStructuredControl program))
+    (is (= program (control/validate! program outer-values)))
+    (is (= '[steps n alpha u0] (control/outer-operands program)))
+    (is (= '[u-final] (control/outer-results program)))
+    (is (= '[iteration n-in alpha-in u-in] (control/body-inputs program)))
+    (is (= '[u-next] (control/body-results program)))
+    (testing "zero trips retain the same typed initial/output contract"
+      (let [zero-trip (assoc (vec program) 2 '[iteration 0])
+            zero-trip (apply list zero-trip)]
+        (is (= zero-trip (control/validate! zero-trip outer-values)))))))
+
+(deftest structured-loop-boundaries-are-certified
+  (let [{:keys [program outer-values]} (fixture)]
+    (testing "body inputs are ordered, not inferred from a set"
+      (let [bad-body (soac/make
+                      (assoc (soac/facts (control/body program))
+                             :inputs '[iteration alpha-in n-in u-in])
+                      (soac/equations (control/body program))
+                      (soac/outputs (control/body program)))
+            bad (apply list (assoc (vec program) 5 bad-body))]
+        (try
+          (control/validate! bad outer-values)
+          (is false "reordered body inputs must fail")
+          (catch clojure.lang.ExceptionInfo exception
+            (is (= :typed-loop-body-inputs (:reason (ex-data exception))))))))
+
+    (testing "loop-carried values retain one AbstractValue contract"
+      (let [bad-values (assoc outer-values 'u-final
+                              (av/tensor {:dtype :double :shape '[n]}))]
+        (try
+          (control/validate! program bad-values)
+          (is false "a changed carry dtype must fail")
+          (catch clojure.lang.ExceptionInfo exception
+            (is (= :typed-loop-value-mismatch (:reason (ex-data exception))))))))
+
+    (testing "a symbolic trip count is an integer scalar"
+      (let [bad-values (assoc outer-values 'steps scalar)]
+        (try
+          (control/validate! program bad-values)
+          (is false "floating trip counts must fail")
+          (catch clojure.lang.ExceptionInfo exception
+            (is (= :typed-loop-trip-count-type (:reason (ex-data exception))))))))
+
+    (testing "effects cannot be hidden by the control wrapper"
+      (let [bad (apply list (assoc (vec program) 1
+                                   (assoc (control/facts program) :effects #{:io})))]
+        (try
+          (control/validate! bad outer-values)
+          (is false "loop effects must equal body effects")
+          (catch clojure.lang.ExceptionInfo exception
+            (is (= :typed-loop-effects (:reason (ex-data exception))))))))
+
+    (testing "association is explicitly sequential"
+      (let [bad (apply list (assoc (vec program) 1
+                                   (assoc-in (control/facts program)
+                                             [:attributes :association]
+                                             :parallel)))]
+        (try
+          (control/validate! bad outer-values)
+          (is false "structured time loops cannot silently reassociate")
+          (catch clojure.lang.ExceptionInfo exception
+            (is (= :typed-loop-syntax (:reason (ex-data exception))))))))))


### PR DESCRIPTION
Adds a Pattern-declared TypedStructuredControl fixpoint around a closed TypedSOAC body. It certifies ordered invariants and loop-carried values, effects, zero-trip value contracts, explicit sequential association, and alpha-stable AbstractValue boundaries. The north-star now records host-repeated KernelGraph execution as the baseline lowering and persistent workgroup execution as a later proven schedule. Focused verification: clojure -M:test -n raster.compiler.ir.structured-control-test.