### PR TITLE
Schedule structured SOAC loop bodies

### DIFF
--- a/src/raster/compiler/passes/parallel/structured_control_lower.clj
+++ b/src/raster/compiler/passes/parallel/structured_control_lower.clj
@@ -1,0 +1,167 @@
+(ns raster.compiler.passes.parallel.structured-control-lower
+  "Certified scheduling of typed sequential control.
+
+   The loop remains a sequential fixpoint while its closed TypedSOAC body takes the ordinary
+   TypedSOAC -> ParallelProgram -> SegOp -> KernelGraph vertical.  This pass deliberately does not
+   emit a persistent kernel or reconstruct a source-shaped compound program."
+  (:require [clojure.set :as set]
+            [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.parallel-program :as parallel-program]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.ir.soac-dialect :as soac]
+            [raster.compiler.ir.structured-control :as control]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
+            [raster.compiler.passes.parallel.typed-soac-route :as typed-route]))
+
+(defrecord ScheduledStructuredLoop [algorithm body graph strategy effects provenance attributes])
+
+(defn scheduled-loop?
+  [value]
+  (and value
+       (= "raster.compiler.passes.parallel.structured_control_lower.ScheduledStructuredLoop"
+          (.getName (class value)))))
+
+(defn- fail!
+  [reason message data]
+  (throw (ex-info message (assoc data :reason reason :pass :structured-control-lower))))
+
+(defn- value-elements
+  [value]
+  (let [shape (:shape value)]
+    (cond
+      (empty? shape) 1
+      (= 1 (count shape)) (first shape)
+      :else (apply launch/product shape))))
+
+(defn- physical-body-outputs
+  [algorithm]
+  (let [facts (soac/facts algorithm)
+        producer (into {}
+                       (mapcat (fn [equation]
+                                 (map vector (nth equation 2)
+                                      (soac/physical-results facts equation))))
+                       (soac/equations algorithm))]
+    (mapv (fn [result]
+            (or (get producer result)
+                (fail! :structured-loop-result-storage
+                       "structured loop body result has no physical storage identity"
+                       {:result result})))
+          (soac/outputs algorithm))))
+
+(defn- external-inputs
+  "Find physical values read before any body operation initializes them."
+  [operations]
+  (:inputs
+   (reduce (fn [{:keys [initialized] :as state} operation]
+             (let [reads (segop/operation-inputs operation)
+                   writes (segop/operation-outputs operation)]
+               (-> state
+                   (update :inputs set/union (set/difference reads initialized))
+                   (update :initialized set/union writes))))
+           {:inputs #{} :initialized #{}}
+           operations)))
+
+(defn- storage-spec
+  [values id]
+  (let [value (get values id)]
+    (when-not value
+      (fail! :structured-loop-storage-value
+             "scheduled structured loop storage lacks an AbstractValue"
+             {:value id}))
+    {:dtype (:dtype value)
+     :elements (value-elements value)
+     :memory-space (or (:memory-space value) :device)}))
+
+(defn- body-graph
+  [algorithm scheduled]
+  (let [operations (vec (mapcat :operations (:equations scheduled)))
+        _ (when (empty? operations)
+            (fail! :structured-loop-empty-schedule
+                   "structured loop body requires at least one scheduled parallel operation" {}))
+        _ (when (some #(get-in % [:attributes :host-only]) (:equations scheduled))
+            (fail! :structured-loop-host-scalar
+                   "host scalar equations inside structured control require explicit loop scalar lowering"
+                   {}))
+        inputs (external-inputs operations)
+        outputs (set (physical-body-outputs algorithm))
+        operation-values (reduce set/union #{}
+                                 (map #(set/union (segop/operation-inputs %)
+                                                  (segop/operation-outputs %))
+                                      operations))
+        temporary-ids (set/difference operation-values inputs outputs)
+        values (:values scheduled)
+        buffer-specs (into {}
+                           (map (fn [id] [id (storage-spec values id)]))
+                           (set/union inputs outputs temporary-ids))
+        temporaries (select-keys buffer-specs temporary-ids)]
+    (graph/from-segops
+     operations
+     {:inputs inputs
+      :outputs outputs
+      :temporaries temporaries
+      :buffer-specs buffer-specs
+      :dtype (:dtype (first (vals buffer-specs)))
+      :effects {:semantic (:effects (soac/facts algorithm))}
+      :provenance {:source-dialect :typed-structured-control
+                   :algorithm-dialect :typed-soac
+                   :schedule-dialect :segop}
+      :attributes {:control :sequential-fixpoint
+                   :execution :host-repetition}})))
+
+(defn validate!
+  [scheduled-loop]
+  (when-not (scheduled-loop? scheduled-loop)
+    (fail! :structured-loop-schedule-type "expected a ScheduledStructuredLoop"
+           {:actual (type scheduled-loop)}))
+  (let [{:keys [algorithm body graph strategy effects provenance attributes]} scheduled-loop
+        algorithm (control/validate! algorithm)
+        body (parallel-program/validate! body segop/segop-node?)
+        graph (graph/validate! graph)
+        typed-body (control/body algorithm)
+        retained-equations (vec (mapcat (comp soac/equations :algorithm) (:equations body)))]
+    (when-not (= :segop (:dialect body))
+      (fail! :structured-loop-body-dialect "structured loop body must be fully scheduled SegOp"
+             {:dialect (:dialect body)}))
+    (when-not (and (= (soac/equations typed-body) retained-equations)
+                   (= (:inputs (soac/facts typed-body)) (:inputs body))
+                   (= (soac/outputs typed-body) (:outputs body)))
+      (fail! :structured-loop-algorithm
+             "structured loop body boundary or equations changed during scheduling"
+             {:algorithm-inputs (:inputs (soac/facts typed-body))
+              :scheduled-inputs (:inputs body)
+              :algorithm-outputs (soac/outputs typed-body)
+              :scheduled-outputs (:outputs body)}))
+    (when-not (= {:kind :host-repetition :association :sequential} strategy)
+      (fail! :structured-loop-strategy "first structured loop schedule must be host repetition"
+             {:strategy strategy}))
+    (when-not (= effects (:effects (control/facts algorithm)))
+      (fail! :structured-loop-effects "scheduled loop effects differ from its algorithm"
+             {:scheduled effects :algorithm (:effects (control/facts algorithm))}))
+    (doseq [[field value] [[:provenance provenance] [:attributes attributes]]]
+      (when-not (map? value)
+        (fail! :structured-loop-description "scheduled loop descriptions must be maps"
+               {:field field :value value})))
+    (when-not (= (vec (mapcat :operations (:equations body)))
+                 (mapv :operation (:nodes graph)))
+      (fail! :structured-loop-graph "KernelGraph operations differ from the scheduled body" {}))
+    scheduled-loop))
+
+(defn schedule
+  "Schedule a typed structured loop without changing its sequential association.
+
+   The returned KernelGraph describes one iteration. A runtime host-repetition binder can replay
+   it with the loop's ordered invariant/carry bindings; persistent device execution is a distinct
+   future schedule, not an emitter fallback."
+  [algorithm opts]
+  (let [algorithm (control/validate! algorithm)
+        envelope (typed-route/program-envelope (control/body algorithm))
+        scheduled (:form (segop-lower/segop-lower-pass envelope opts))
+        graph (body-graph (control/body algorithm) scheduled)]
+    (validate!
+     (->ScheduledStructuredLoop
+      algorithm scheduled graph
+      {:kind :host-repetition :association :sequential}
+      (:effects (control/facts algorithm))
+      {:source-dialect :typed-structured-control :pass :structured-control-lower}
+      {:body-dialect :typed-soac :schedule-dialect :segop :graph-dialect :kernel-graph}))))

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -434,6 +434,30 @@
                          (= (:operands equation) (:inputs (dialect/facts algorithm)))
                          (= (:results equation) (dialect/outputs algorithm))))})))
 
+(defn program-envelope
+  "Wrap an already constructed TypedSOAC program in the same ParallelProgram boundary used by
+   the analyzed-source production route.
+
+   This source-free entry is for compiler-generated algorithms such as structured-control bodies.
+   Each equation keeps its closed TypedSOAC subprogram and stable value/equation facts; no host
+   expression is reconstructed merely to enter scheduling."
+  [typed-program]
+  (let [typed-program (dialect/validate! typed-program)
+        realized (into {}
+                       (map (fn [equation]
+                              (let [equation-id (second equation)]
+                                [equation-id {:site [:algorithm equation-id] :source nil}])))
+                       (dialect/equations typed-program))]
+    (-> (envelope typed-program nil realized)
+        (assoc :attributes (assoc (:attributes (dialect/facts typed-program))
+                                  :host-control :explicit-typed-algorithm))
+        (parallel-program/validate!
+         equation-operation?
+         (fn [equation algorithm]
+           (and (= algorithm (dialect/validate! algorithm))
+                (= (:operands equation) (:inputs (dialect/facts algorithm)))
+                (= (:results equation) (dialect/outputs algorithm))))))))
+
 (defn attempt
   "Return a typed production ParallelProgram result, an explicit `:declined` result, or nil when
    the form is outside this closed subset."
@@ -446,29 +470,29 @@
    (when (and (seq? form) (contains? #{'let 'let*} (first form)))
      (let [form (frontend/normalize-source form)]
        (try
-        (when-let [typed-input (frontend/form->program
-                                form {:dtype dtype :array-types array-types
-                                      :scalar-types scalar-types :values values})]
-         (let [[typed-result typed-stats] (fusion/fusion-fixpoint typed-input abstract-machine)
-               [typed-result resident-stats]
-               (if resident-reductions?
-                 (resident/realize typed-result)
-                 [typed-result {:resident-reductions 0 :inlined-scalars 0}])]
-           (if (not-any? #(contains? #{:map :scatter :stencil :reduce
-                                       :segmented-reduce :product-reduce
-                                       :segmented-fold-map :scan}
-                                     (:kind (fusion/equation-info %)))
-                         (dialect/equations typed-result))
-             {:declined {:reason :no-certified-parallel-equation
-                         :stats (merge typed-stats resident-stats)}}
-             (let [{:keys [source realized]} (realize-source form typed-result)]
-               {:program (envelope typed-result source realized)
-                :stats (merge typed-stats resident-stats
-                              {:route :typed-soac :typed-validated true
-                               :front-end :analyzed-source})}))))
-        (catch clojure.lang.ExceptionInfo exception
-          (when (contains? #{:raster/fatal :raster/bug} (:reason (ex-data exception)))
-            (throw exception))
-          {:declined {:reason (or (:reason (ex-data exception)) :typed-soac-route-declined)
-                      :message (.getMessage exception)
-                      :details (ex-data exception)}}))))))
+         (when-let [typed-input (frontend/form->program
+                                 form {:dtype dtype :array-types array-types
+                                       :scalar-types scalar-types :values values})]
+           (let [[typed-result typed-stats] (fusion/fusion-fixpoint typed-input abstract-machine)
+                 [typed-result resident-stats]
+                 (if resident-reductions?
+                   (resident/realize typed-result)
+                   [typed-result {:resident-reductions 0 :inlined-scalars 0}])]
+             (if (not-any? #(contains? #{:map :scatter :stencil :reduce
+                                         :segmented-reduce :product-reduce
+                                         :segmented-fold-map :scan}
+                                       (:kind (fusion/equation-info %)))
+                           (dialect/equations typed-result))
+               {:declined {:reason :no-certified-parallel-equation
+                           :stats (merge typed-stats resident-stats)}}
+               (let [{:keys [source realized]} (realize-source form typed-result)]
+                 {:program (envelope typed-result source realized)
+                  :stats (merge typed-stats resident-stats
+                                {:route :typed-soac :typed-validated true
+                                 :front-end :analyzed-source})}))))
+         (catch clojure.lang.ExceptionInfo exception
+           (when (contains? #{:raster/fatal :raster/bug} (:reason (ex-data exception)))
+             (throw exception))
+           {:declined {:reason (or (:reason (ex-data exception)) :typed-soac-route-declined)
+                       :message (.getMessage exception)
+                       :details (ex-data exception)}}))))))

--- a/test/raster/compiler/passes/parallel/structured_control_lower_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_lower_test.clj
@@ -1,0 +1,77 @@
+(ns raster.compiler.passes.parallel.structured-control-lower-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.parallel-program :as parallel-program]
+            [raster.compiler.ir.soac-dialect :as soac]
+            [raster.compiler.ir.structured-control :as control]
+            [raster.compiler.passes.parallel.structured-control-lower :as lower]))
+
+(defn- loop-program
+  ([] (loop-program false))
+  ([chained?]
+   (let [extent (av/tensor {:dtype :long :shape []})
+         scalar (av/tensor {:dtype :float :shape []})
+         tensor (av/tensor {:dtype :float :shape '[n]})
+         inner-tensor (av/tensor {:dtype :float :shape '[n-in]})
+         first-result (if chained? 'u-temporary 'u-next)
+         equation
+         (list '= 'advance '[u-next]
+               (list 'map {:index 'i :extent 'n-in}
+                     '[u-in] '[alpha-in iteration]
+                     (soac/lambda-form
+                      '[u-value alpha-value iteration-value]
+                      '[(+ u-value alpha-value (* 0.0 iteration-value))])))
+         first-equation (assoc (vec equation) 1 'advance-first 2 [first-result])
+         first-equation (apply list first-equation)
+         second-equation
+         (list '= 'advance-second '[u-next]
+               (list 'map {:index 'i :extent 'n-in}
+                     '[u-temporary] '[]
+                     (soac/lambda-form '[temporary-value] '[(* 2.0 temporary-value)])))
+         equations (if chained? [first-equation second-equation] [equation])
+         equation-facts (into {}
+                              (map (fn [equation]
+                                     [(second equation) (soac/default-equation-facts)]))
+                              equations)
+         body (soac/make
+               (soac/default-program-facts
+                {:values {'iteration extent 'n-in extent 'alpha-in scalar
+                          'u-in inner-tensor 'u-temporary inner-tensor
+                          'u-next inner-tensor}
+                 :inputs '[iteration n-in alpha-in u-in]
+                 :equations equation-facts})
+               equations '[u-next])]
+     (control/make
+      {:id 'time-loop :effects #{} :provenance {:source :test}
+       :attributes {:association :sequential}}
+      '[iteration steps]
+      [{:outer 'n :parameter 'n-in}
+       {:outer 'alpha :parameter 'alpha-in}]
+      [{:initial 'u0 :parameter 'u-in :result 'u-next :output 'u-final}]
+      body
+      {'steps extent 'n extent 'alpha scalar 'u0 tensor 'u-final tensor}))))
+
+(deftest structured-control-takes-the-shared-soac-schedule-vertical
+  (let [scheduled (lower/schedule (loop-program) {:target-device :cpu:0 :dtype :float})
+        body (:body scheduled)
+        graph (:graph scheduled)]
+    (is (lower/scheduled-loop? scheduled))
+    (is (= :segop (:dialect body)))
+    (is (parallel-program/parallel-program? body))
+    (is (= 1 (count (:nodes graph))))
+    (is (= '[u-in] (mapv :id (:inputs graph))))
+    (is (= '[u-next] (mapv :id (:outputs graph))))
+    (is (= {:kind :host-repetition :association :sequential}
+           (:strategy scheduled)))
+    (is (= :typed-soac (get-in scheduled [:attributes :body-dialect])))
+    (is (= scheduled (lower/validate! scheduled)))))
+
+(deftest structured-loop-body-dataflow-becomes-one-verified-iteration-graph
+  (let [scheduled (lower/schedule (loop-program true) {:target-device :cpu:0 :dtype :float})
+        graph (:graph scheduled)
+        [first-node second-node] (:nodes graph)]
+    (is (= 2 (count (:nodes graph))))
+    (is (= '[u-temporary] (mapv :id (:temporaries graph))))
+    (is (= [(:id first-node)] (:dependencies second-node)))
+    (is (= '[u-in] (mapv :id (:inputs graph))))
+    (is (= '[u-next] (mapv :id (:outputs graph))))))


### PR DESCRIPTION
Adds a source-free production envelope for closed TypedSOAC algorithms, then schedules a TypedStructuredControl body through the shared ParallelProgram and SegOp vertical into one verified per-iteration KernelGraph. Multi-operation bodies derive graph temporaries and hazard dependencies from physical scheduled dataflow. Host repetition remains explicit and sequential; persistent execution is not selected. Focused verification: clojure -M:test -n raster.compiler.passes.parallel.structured-control-lower-test.