### PR TITLE
Plan host-repeated structured loop calls

### DIFF
--- a/src/raster/compiler/ir/structured_control_schedule.clj
+++ b/src/raster/compiler/ir/structured_control_schedule.clj
@@ -1,0 +1,66 @@
+(ns raster.compiler.ir.structured-control-schedule
+  "Checked schedule value for a typed sequential fixpoint."
+  (:require [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.parallel-program :as parallel-program]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.ir.soac-dialect :as soac]
+            [raster.compiler.ir.structured-control :as control]))
+
+(defrecord ScheduledStructuredLoop [algorithm body graph strategy effects provenance attributes])
+
+(defn scheduled-loop?
+  [value]
+  (and value
+       (= "raster.compiler.ir.structured_control_schedule.ScheduledStructuredLoop"
+          (.getName (class value)))))
+
+(defn- fail!
+  [reason message data]
+  (throw (ex-info message (assoc data :reason reason :ir :structured-control-schedule))))
+
+(defn validate!
+  [scheduled-loop]
+  (when-not (scheduled-loop? scheduled-loop)
+    (fail! :structured-loop-schedule-type "expected a ScheduledStructuredLoop"
+           {:actual (type scheduled-loop)}))
+  (let [{:keys [algorithm body graph strategy effects provenance attributes]} scheduled-loop
+        algorithm (control/validate! algorithm)
+        body (parallel-program/validate!
+              body segop/segop-node?
+              (fn [equation typed-algorithm]
+                (and (= typed-algorithm (soac/validate! typed-algorithm))
+                     (= (:operands equation) (:inputs (soac/facts typed-algorithm)))
+                     (= (:results equation) (soac/outputs typed-algorithm)))))
+        graph (graph/validate! graph)
+        typed-body (control/body algorithm)
+        retained-equations (vec (mapcat (comp soac/equations :algorithm) (:equations body)))]
+    (when-not (= :segop (:dialect body))
+      (fail! :structured-loop-body-dialect "structured loop body must be fully scheduled SegOp"
+             {:dialect (:dialect body)}))
+    (when-not (and (= (soac/equations typed-body) retained-equations)
+                   (= (:inputs (soac/facts typed-body)) (:inputs body))
+                   (= (soac/outputs typed-body) (:outputs body)))
+      (fail! :structured-loop-algorithm
+             "structured loop body boundary or equations changed during scheduling"
+             {:algorithm-inputs (:inputs (soac/facts typed-body))
+              :scheduled-inputs (:inputs body)
+              :algorithm-outputs (soac/outputs typed-body)
+              :scheduled-outputs (:outputs body)}))
+    (when-not (= {:kind :host-repetition :association :sequential} strategy)
+      (fail! :structured-loop-strategy "first structured loop schedule must be host repetition"
+             {:strategy strategy}))
+    (when-not (= effects (:effects (control/facts algorithm)))
+      (fail! :structured-loop-effects "scheduled loop effects differ from its algorithm"
+             {:scheduled effects :algorithm (:effects (control/facts algorithm))}))
+    (doseq [[field value] [[:provenance provenance] [:attributes attributes]]]
+      (when-not (map? value)
+        (fail! :structured-loop-description "scheduled loop descriptions must be maps"
+               {:field field :value value})))
+    (when-not (= (vec (mapcat :operations (:equations body)))
+                 (mapv :operation (:nodes graph)))
+      (fail! :structured-loop-graph "KernelGraph operations differ from the scheduled body" {}))
+    scheduled-loop))
+
+(defn make
+  [fields]
+  (validate! (map->ScheduledStructuredLoop fields)))

--- a/src/raster/compiler/ir/structured_loop_call.clj
+++ b/src/raster/compiler/ir/structured_loop_call.clj
@@ -1,0 +1,235 @@
+(ns raster.compiler.ir.structured-loop-call
+  "Pure host-repetition binding for an emitted structured-loop iteration graph.
+
+   The call owns no driver handles. It maps outer values to the emitted graph boundary and plans
+   double-buffered carry rotation. A runtime may bind/replay each returned iteration through its
+   ordinary KernelGraph machinery."
+  (:require [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.structured-control :as control]
+            [raster.compiler.ir.structured-control-schedule :as schedule]
+            [raster.compiler.ir.soac-dialect :as soac]))
+
+(defrecord StructuredLoopCall
+           [schedule graph trip-count buffers scalars scratch outputs attributes])
+
+(defn structured-loop-call?
+  [value]
+  (and value
+       (= "raster.compiler.ir.structured_loop_call.StructuredLoopCall"
+          (.getName (class value)))))
+
+(defn- fail!
+  [reason message data]
+  (throw (ex-info message (assoc data :reason reason :ir :structured-loop-call))))
+
+(defn- typed-scalar?
+  [value]
+  (and (map? value) (keyword? (:type value)) (contains? value :value)))
+
+(defn- external-buffer-ids
+  [emitted]
+  (set (map :id (concat (:inputs emitted) (:outputs emitted)))))
+
+(defn- scalar-slots
+  [emitted]
+  (into {}
+        (keep (fn [[slot argument]]
+                (when (= :scalar (:kind slot)) [argument slot])))
+        (map vector (:abi emitted) (:arguments emitted))))
+
+(defn- physical-results
+  [algorithm]
+  (let [body (control/body algorithm)
+        facts (soac/facts body)]
+    (into {}
+          (mapcat (fn [equation]
+                    (map vector (nth equation 2) (soac/physical-results facts equation))))
+          (soac/equations body))))
+
+(defn- resolve-trip-count
+  [algorithm scalars]
+  (let [trip-count (second (control/loop-index algorithm))
+        resolved (if (integer? trip-count)
+                   trip-count
+                   (let [value (get scalars trip-count)]
+                     (when-not (typed-scalar? value)
+                       (fail! :structured-loop-trip-count
+                              "symbolic loop trip count requires a typed scalar"
+                              {:value trip-count :scalar value}))
+                     (:value value)))]
+    (when-not (and (integer? resolved) (not (neg? resolved)))
+      (fail! :structured-loop-trip-count "loop trip count must resolve non-negative"
+             {:resolved resolved}))
+    (long resolved)))
+
+(defn- scalar-binding
+  [slots id value]
+  (let [slot (get slots id)]
+    (when-not slot
+      (fail! :structured-loop-scalar-interface
+             "structured loop scalar is absent from the emitted graph interface" {:value id}))
+    (when-not (typed-scalar? value)
+      (fail! :structured-loop-scalar "structured loop requires an explicitly typed scalar"
+             {:value id :scalar value}))
+    (when-not (= (:kernel-dtype slot) (:type value))
+      (fail! :structured-loop-scalar-type
+             "structured loop scalar type differs from the emitted graph ABI"
+             {:value id :expected (:kernel-dtype slot) :actual (:type value)}))
+    value))
+
+(defn- require-buffer!
+  [buffers id role]
+  (let [value (get buffers id ::missing)]
+    (when (or (= ::missing value) (nil? value))
+      (fail! :structured-loop-buffer "structured loop buffer binding is missing"
+             {:value id :role role}))
+    value))
+
+(defn validate!
+  [call]
+  (when-not (structured-loop-call? call)
+    (fail! :structured-loop-call-type "expected a StructuredLoopCall" {:actual (type call)}))
+  (let [{scheduled :schedule emitted :graph trip-count :trip-count
+         buffers :buffers scalars :scalars scratch :scratch outputs :outputs attributes :attributes}
+        call
+        scheduled (schedule/validate! scheduled)
+        emitted (graph/validate! emitted)]
+    (when-not (every? (comp artifact/kernel-artifact? :operation) (:nodes emitted))
+      (fail! :structured-loop-emitted-graph
+             "structured loop call requires a fully emitted KernelGraph" {}))
+    (when-not (and (= (mapv :id (:nodes (:graph scheduled))) (mapv :id (:nodes emitted)))
+                   (every? true?
+                           (map (fn [scheduled-node emitted-node]
+                                  (= (get-in emitted-node [:operation :provenance :segop-id])
+                                     (get-in scheduled-node [:operation :id])))
+                                (:nodes (:graph scheduled)) (:nodes emitted))))
+      (fail! :structured-loop-emitted-graph
+             "emitted graph identities or semantic provenance differ from the scheduled iteration"
+             {}))
+    (when-not (and (integer? trip-count) (not (neg? trip-count)))
+      (fail! :structured-loop-trip-count "resolved trip count must be non-negative"
+             {:trip-count trip-count}))
+    (doseq [[field value] [[:buffers buffers] [:scalars scalars] [:scratch scratch]
+                           [:outputs outputs] [:attributes attributes]]]
+      (when-not (map? value)
+        (fail! :structured-loop-call-field "structured loop call fields must be maps"
+               {:field field :value value})))
+    call))
+
+(defn make
+  "Bind outer logical values for target-neutral host repetition.
+
+   `buffers` maps outer invariant/initial/output IDs to resident keys or views. `scalars` maps
+   outer scalar IDs to typed values. `scratch` maps each carry output ID to its alternate buffer;
+   it is required for an out-of-place carry only when the resolved trip count exceeds one."
+  [scheduled emitted buffers scalars scratch]
+  (let [scheduled (schedule/validate! scheduled)
+        algorithm (:algorithm scheduled)
+        emitted (graph/validate! emitted)
+        graph-buffers (external-buffer-ids emitted)
+        slots (scalar-slots emitted)
+        trip-count (resolve-trip-count algorithm scalars)
+        iteration (first (control/loop-index algorithm))
+        invariant-buffer-bindings
+        (into {}
+              (keep (fn [{:keys [outer parameter]}]
+                      (when (contains? graph-buffers parameter)
+                        [parameter (require-buffer! buffers outer :invariant)])))
+              (control/invariants algorithm))
+        invariant-scalar-bindings
+        (into {}
+              (keep (fn [{:keys [outer parameter]}]
+                      (when (contains? slots parameter)
+                        [parameter (scalar-binding slots parameter (get scalars outer))])))
+              (control/invariants algorithm))
+        result-storage (physical-results algorithm)
+        carry-plans
+        (mapv (fn [{:keys [initial parameter result output]}]
+                (let [physical-result (get result-storage result)
+                      initial-buffer (require-buffer! buffers initial :carry-initial)
+                      output-buffer (require-buffer! buffers output :carry-output)
+                      in-place? (= parameter physical-result)
+                      alternate (get scratch output)]
+                  (when-not (and (contains? graph-buffers parameter)
+                                 (contains? graph-buffers physical-result))
+                    (fail! :structured-loop-carry-interface
+                           "loop carry is absent from the emitted graph buffer interface"
+                           {:parameter parameter :result physical-result}))
+                  (if in-place?
+                    (when-not (= initial-buffer output-buffer)
+                      (fail! :structured-loop-in-place-carry
+                             "an in-place carry requires one shared initial/output binding"
+                             {:initial initial :output output}))
+                    (do
+                      (when (= initial-buffer output-buffer)
+                        (fail! :structured-loop-carry-alias
+                               "an out-of-place carry requires distinct initial/output buffers"
+                               {:initial initial :output output}))
+                      (when (and (> trip-count 1) (nil? alternate))
+                        (fail! :structured-loop-carry-scratch
+                               "multi-step out-of-place carry requires an alternate buffer"
+                               {:output output :trip-count trip-count}))
+                      (when (and alternate
+                                 (or (= alternate initial-buffer) (= alternate output-buffer)))
+                        (fail! :structured-loop-carry-scratch-alias
+                               "carry scratch must differ from initial and output buffers"
+                               {:output output}))))
+                  {:initial-id initial :output-id output
+                   :parameter parameter :result physical-result
+                   :initial initial-buffer :output output-buffer
+                   :alternate alternate :in-place? in-place?}))
+              (control/carried algorithm))
+        iteration-slot (get slots iteration)
+        _ (doseq [scalar-id (keys slots)]
+            (when-not (or (= scalar-id iteration)
+                          (contains? invariant-scalar-bindings scalar-id))
+              (fail! :structured-loop-scalar-interface
+                     "emitted iteration graph scalar is not a loop invariant or induction value"
+                     {:value scalar-id})))
+        output-bindings (into {}
+                              (map (fn [{:keys [initial-id output-id initial output]}]
+                                     [output-id (if (zero? trip-count) initial output)]))
+                              carry-plans)
+        call (->StructuredLoopCall
+              scheduled emitted trip-count
+              {:invariants invariant-buffer-bindings :carries carry-plans}
+              {:invariants invariant-scalar-bindings
+               :iteration (when iteration-slot
+                            {:id iteration :type (:kernel-dtype iteration-slot)})}
+              scratch output-bindings {:execution :host-repetition})]
+    (validate! call)))
+
+(defn iteration-binding
+  "Return the ordinary KernelGraph buffer/scalar bindings for iteration `index`."
+  [call index]
+  (let [call (validate! call)
+        trip-count (:trip-count call)]
+    (when-not (and (integer? index) (<= 0 index) (< index trip-count))
+      (fail! :structured-loop-iteration "iteration index is outside the loop trip count"
+             {:index index :trip-count trip-count}))
+    (let [last-index (dec trip-count)
+          carry-bindings
+          (into {}
+                (mapcat
+                 (fn [{:keys [parameter result initial output alternate in-place?]}]
+                   (if in-place?
+                     [[parameter initial]]
+                     (let [first-destination (if (odd? trip-count) output alternate)
+                           destination (if (even? index)
+                                         first-destination
+                                         (if (= first-destination output) alternate output))
+                           source (if (zero? index)
+                                    initial
+                                    (if (= destination output) alternate output))]
+                       [[parameter source] [result destination]])))
+                 (get-in call [:buffers :carries])))
+          iteration-scalar (get-in call [:scalars :iteration])]
+      {:index index
+       :last? (= index last-index)
+       :buffers (merge (get-in call [:buffers :invariants]) carry-bindings)
+       :scalar-values
+       (cond-> (get-in call [:scalars :invariants])
+         iteration-scalar
+         (assoc (:id iteration-scalar)
+                {:type (:type iteration-scalar) :value index}))})))

--- a/src/raster/compiler/passes/parallel/structured_control_lower.clj
+++ b/src/raster/compiler/passes/parallel/structured_control_lower.clj
@@ -7,20 +7,14 @@
   (:require [clojure.set :as set]
             [raster.compiler.ir.kernel-graph :as graph]
             [raster.compiler.ir.kernel-launch :as launch]
-            [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as soac]
             [raster.compiler.ir.structured-control :as control]
+            [raster.compiler.ir.structured-control-schedule :as control-schedule]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.typed-soac-route :as typed-route]))
 
-(defrecord ScheduledStructuredLoop [algorithm body graph strategy effects provenance attributes])
-
-(defn scheduled-loop?
-  [value]
-  (and value
-       (= "raster.compiler.passes.parallel.structured_control_lower.ScheduledStructuredLoop"
-          (.getName (class value)))))
+(def scheduled-loop? control-schedule/scheduled-loop?)
 
 (defn- fail!
   [reason message data]
@@ -109,43 +103,7 @@
       :attributes {:control :sequential-fixpoint
                    :execution :host-repetition}})))
 
-(defn validate!
-  [scheduled-loop]
-  (when-not (scheduled-loop? scheduled-loop)
-    (fail! :structured-loop-schedule-type "expected a ScheduledStructuredLoop"
-           {:actual (type scheduled-loop)}))
-  (let [{:keys [algorithm body graph strategy effects provenance attributes]} scheduled-loop
-        algorithm (control/validate! algorithm)
-        body (parallel-program/validate! body segop/segop-node?)
-        graph (graph/validate! graph)
-        typed-body (control/body algorithm)
-        retained-equations (vec (mapcat (comp soac/equations :algorithm) (:equations body)))]
-    (when-not (= :segop (:dialect body))
-      (fail! :structured-loop-body-dialect "structured loop body must be fully scheduled SegOp"
-             {:dialect (:dialect body)}))
-    (when-not (and (= (soac/equations typed-body) retained-equations)
-                   (= (:inputs (soac/facts typed-body)) (:inputs body))
-                   (= (soac/outputs typed-body) (:outputs body)))
-      (fail! :structured-loop-algorithm
-             "structured loop body boundary or equations changed during scheduling"
-             {:algorithm-inputs (:inputs (soac/facts typed-body))
-              :scheduled-inputs (:inputs body)
-              :algorithm-outputs (soac/outputs typed-body)
-              :scheduled-outputs (:outputs body)}))
-    (when-not (= {:kind :host-repetition :association :sequential} strategy)
-      (fail! :structured-loop-strategy "first structured loop schedule must be host repetition"
-             {:strategy strategy}))
-    (when-not (= effects (:effects (control/facts algorithm)))
-      (fail! :structured-loop-effects "scheduled loop effects differ from its algorithm"
-             {:scheduled effects :algorithm (:effects (control/facts algorithm))}))
-    (doseq [[field value] [[:provenance provenance] [:attributes attributes]]]
-      (when-not (map? value)
-        (fail! :structured-loop-description "scheduled loop descriptions must be maps"
-               {:field field :value value})))
-    (when-not (= (vec (mapcat :operations (:equations body)))
-                 (mapv :operation (:nodes graph)))
-      (fail! :structured-loop-graph "KernelGraph operations differ from the scheduled body" {}))
-    scheduled-loop))
+(def validate! control-schedule/validate!)
 
 (defn schedule
   "Schedule a typed structured loop without changing its sequential association.
@@ -158,10 +116,14 @@
         envelope (typed-route/program-envelope (control/body algorithm))
         scheduled (:form (segop-lower/segop-lower-pass envelope opts))
         graph (body-graph (control/body algorithm) scheduled)]
-    (validate!
-     (->ScheduledStructuredLoop
-      algorithm scheduled graph
-      {:kind :host-repetition :association :sequential}
-      (:effects (control/facts algorithm))
-      {:source-dialect :typed-structured-control :pass :structured-control-lower}
-      {:body-dialect :typed-soac :schedule-dialect :segop :graph-dialect :kernel-graph}))))
+    (control-schedule/make
+     {:algorithm algorithm
+      :body scheduled
+      :graph graph
+      :strategy {:kind :host-repetition :association :sequential}
+      :effects (:effects (control/facts algorithm))
+      :provenance {:source-dialect :typed-structured-control
+                   :pass :structured-control-lower}
+      :attributes {:body-dialect :typed-soac
+                   :schedule-dialect :segop
+                   :graph-dialect :kernel-graph}})))

--- a/test/raster/compiler/passes/parallel/structured_control_lower_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_lower_test.clj
@@ -6,6 +6,7 @@
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.soac-dialect :as soac]
             [raster.compiler.ir.structured-control :as control]
+            [raster.compiler.ir.structured-loop-call :as loop-call]
             [raster.compiler.passes.parallel.structured-control-lower :as lower]))
 
 (defn- loop-program
@@ -83,4 +84,35 @@
       (is (= '[u-in u-next alpha-in iteration n-in] (:arguments emitted)))
       (is (= :opencl-c (get-in emitted [:provenance :target-dialect])))
       (is (every? #(re-find #"__kernel void graph_segmap" (:source %))
-                  (map :operation (:nodes emitted)))))))
+                  (map :operation (:nodes emitted))))
+      (let [call (loop-call/make
+                  scheduled emitted
+                  {'u0 :initial-buffer 'u-final :output-buffer}
+                  {'steps {:type :long :value 3}
+                   'n {:type :int :value 64}
+                   'alpha {:type :float :value 0.25}}
+                  {'u-final :scratch-buffer})]
+        (is (= {'u-final :output-buffer} (:outputs call)))
+        (is (= {'u-in :initial-buffer 'u-next :output-buffer}
+               (:buffers (loop-call/iteration-binding call 0))))
+        (is (= {'u-in :output-buffer 'u-next :scratch-buffer}
+               (:buffers (loop-call/iteration-binding call 1))))
+        (is (= {'u-in :scratch-buffer 'u-next :output-buffer}
+               (:buffers (loop-call/iteration-binding call 2))))
+        (is (= {:type :int :value 2}
+               (get-in (loop-call/iteration-binding call 2)
+                       [:scalar-values 'iteration])))))))
+
+(deftest zero-trip-loop-returns-the-initial-logical-value-without-scratch
+  (let [scheduled (lower/schedule (loop-program) {:target-device :cpu:0 :dtype :float})
+        emitted (opencl/generate-kernel-graph
+                 (:graph scheduled) :scalar-types {'alpha-in :float 'iteration :long})
+        call (loop-call/make
+              scheduled emitted
+              {'u0 :initial-buffer 'u-final :unused-output-buffer}
+              {'steps {:type :long :value 0}
+               'n {:type :int :value 64}
+               'alpha {:type :float :value 0.25}}
+              {})]
+    (is (= 0 (:trip-count call)))
+    (is (= {'u-final :initial-buffer} (:outputs call)))))


### PR DESCRIPTION
Promotes ScheduledStructuredLoop into compiler IR and adds a pure StructuredLoopCall plan. The plan resolves typed symbolic trip counts, maps outer scalar and buffer invariants to an emitted KernelGraph ABI, derives the induction representation from that ABI, certifies emitted-node provenance, and rotates out-of-place carries through parity-correct output/scratch bindings. Zero trips return the initial logical value without launching or requiring scratch.