### PR TITLE
Allow unused structured loop binders

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -605,7 +605,9 @@ rather than rediscovering a reduction from source spelling.
 Sequential control around a parallel algorithm is represented separately as the Pattern-declared
 `TypedStructuredControl` dialect. Its canonical loop is a typed fixpoint around one closed
 `TypedSOAC` body: it binds an integer induction value, ordered invariants, and ordered loop-carried
-scalars or tensors, and gives each final result a distinct outer SSA value. The body boundary,
+scalars or tensors, and gives each final result a distinct outer SSA value. The minimal body input
+boundary is an ordered subset of those declared binders, so an unused induction value or invariant
+does not require fake scalar work. The body boundary,
 effects, and `AbstractValue` contracts are checked modulo the explicit outer-to-inner alpha-renaming;
 zero iterations therefore retain the initial value contract without emitter inference. Values
 defined and consumed only inside the body are ordinary SSA scratch, not entries in another memory

--- a/src/raster/compiler/ir/structured_control.clj
+++ b/src/raster/compiler/ir/structured_control.clj
@@ -17,9 +17,9 @@
        typed-soac-body)
 
    `trip-count` is either a non-negative integer or an outer scalar value ID.  At zero trips each
-   output denotes its corresponding initial value.  The body input boundary is exactly the
-   iteration parameter followed by invariant parameters and carried parameters; its ordered
-   outputs are exactly the carried results."
+   output denotes its corresponding initial value. The body may use any ordered subset of the
+   iteration parameter, invariant parameters, and carried parameters; its ordered outputs are
+   exactly the carried results."
   (:require [clojure.walk :as walk]
             [pattern.nanopass.dialect :as dialect :refer [def-dialect]]
             [raster.compiler.ir.abstract-value :as av]
@@ -90,10 +90,16 @@
   (mapv :output (carried program)))
 
 (defn body-inputs
+  "All declared loop-body binders in canonical scope order."
   [program]
   (vec (concat [(first (loop-index program))]
                (map :parameter (invariants program))
                (map :parameter (carried program)))))
+
+(defn used-body-inputs
+  "The minimal ordered input boundary used by the closed TypedSOAC body."
+  [program]
+  (vec (:inputs (soac/facts (body program)))))
 
 (defn body-results
   [program]
@@ -176,10 +182,14 @@
        (fail! :typed-loop-outer-bindings
               "loop operands and results must be distinct in the enclosing scope"
               {:ids outer-ids}))
-     (when-not (= expected-inputs (:inputs body-facts))
-       (fail! :typed-loop-body-inputs
-              "loop body inputs must exactly follow iteration, invariants, and carried values"
-              {:expected expected-inputs :actual (:inputs body-facts)}))
+     (let [actual-inputs (:inputs body-facts)
+           actual-set (set actual-inputs)
+           expected-used (filterv actual-set expected-inputs)]
+       (when-not (= expected-used actual-inputs)
+         (fail! :typed-loop-body-inputs
+                "loop body inputs must be an ordered subset of declared structured-loop binders"
+                {:declared expected-inputs :expected-used expected-used
+                 :actual actual-inputs})))
      (when-not (= expected-results (soac/outputs body-program))
        (fail! :typed-loop-body-results
               "loop body outputs must exactly match the ordered carried results"

--- a/test/raster/compiler/ir/structured_control_test.clj
+++ b/test/raster/compiler/ir/structured_control_test.clj
@@ -47,6 +47,7 @@
     (is (= '[steps n alpha u0] (control/outer-operands program)))
     (is (= '[u-final] (control/outer-results program)))
     (is (= '[iteration n-in alpha-in u-in] (control/body-inputs program)))
+    (is (= '[iteration n-in alpha-in u-in] (control/used-body-inputs program)))
     (is (= '[u-next] (control/body-results program)))
     (testing "zero trips retain the same typed initial/output contract"
       (let [zero-trip (assoc (vec program) 2 '[iteration 0])
@@ -67,6 +68,21 @@
           (is false "reordered body inputs must fail")
           (catch clojure.lang.ExceptionInfo exception
             (is (= :typed-loop-body-inputs (:reason (ex-data exception))))))))
+
+    (testing "declared binders may be unused by a minimal TypedSOAC boundary"
+      (let [body (control/body program)
+            equation (first (soac/equations body))
+            operation (nth equation 3)
+            operation (assoc (vec operation) 3 '[alpha-in])
+            operation (apply list operation)
+            lambda (soac/lambda-form '[u-value alpha-value] '[(+ u-value alpha-value)])
+            operation (apply list (assoc (vec operation) 4 lambda))
+            equation (apply list (assoc (vec equation) 3 operation))
+            facts (assoc (soac/facts body) :inputs '[n-in alpha-in u-in])
+            unused-iteration-body (soac/make facts [equation] (soac/outputs body))
+            unused-iteration (apply list (assoc (vec program) 5 unused-iteration-body))]
+        (is (= '[n-in alpha-in u-in] (control/used-body-inputs unused-iteration)))
+        (is (= unused-iteration (control/validate! unused-iteration outer-values)))))
 
     (testing "loop-carried values retain one AbstractValue contract"
       (let [bad-values (assoc outer-values 'u-final

--- a/test/raster/gpu/structured_loop_test.clj
+++ b/test/raster/gpu/structured_loop_test.clj
@@ -17,15 +17,13 @@
         equation
         (list '= 'advance '[u-next]
               (list 'map {:index 'i :extent 'n-in}
-                    '[u-in] '[alpha-in iteration]
-                    (soac/lambda-form
-                     '[u-value alpha-value iteration-value]
-                     '[(+ u-value alpha-value (* 0.0 iteration-value))])))
+                    '[u-in] '[alpha-in]
+                    (soac/lambda-form '[u-value alpha-value] '[(+ u-value alpha-value)])))
         body (soac/make
               (soac/default-program-facts
                {:values {'iteration extent 'n-in extent 'alpha-in scalar
                          'u-in inner-tensor 'u-next inner-tensor}
-                :inputs '[iteration n-in alpha-in u-in]
+                :inputs '[n-in alpha-in u-in]
                 :equations {'advance (soac/default-equation-facts)}})
               [equation] '[u-next])
         algorithm
@@ -40,7 +38,7 @@
          {'steps extent 'n extent 'alpha scalar 'u0 tensor 'u-final tensor})
         scheduled (lower/schedule algorithm {:target-device :cpu:0 :dtype :float})
         emitted (opencl/generate-kernel-graph
-                 (:graph scheduled) :scalar-types {'alpha-in :float 'iteration :long})]
+                 (:graph scheduled) :scalar-types {'alpha-in :float})]
     (loop-call/make
      scheduled emitted
      {'u0 :initial 'u-final :output}


### PR DESCRIPTION
Allows the minimal TypedSOAC body input boundary to be an ordered subset of declared induction, invariant, and carry binders. This matches closed SSA semantics and real scientific loops whose induction value is unused, without fake scalar arithmetic. Declared binders remain typed and carry/result contracts remain exact.