### PR TITLE
Certify structured loop emission dataflow

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -623,6 +623,13 @@ schedule selected only when its participation, memory, and synchronization proof
 vertical consumes scientific time loops, the source-shaped compound detector and handwritten local
 emitter are deleted rather than retained as a compatibility route.
 
+The one-iteration graph is re-derived during validation from the retained TypedSOAC algorithm and
+scheduled SegOps; buffers, storage contracts, uses, hazards, and dependencies cannot be supplied as
+independent claims. Target emission may replace only each scheduled operation. Every resulting
+`KernelArtifact` retains the complete immutable operation it implements, while graph validation
+requires the pre/post-emission dataflow contracts to be identical. A copied operation ID is not an
+emission certificate.
+
 Functionalizing a mutating host loop is deliberately proof-gated. A relational host
 `AbstractValue` refinement records shape equalities exposed by typed length queries, clones,
 same-shaped allocation, and pure maps. A primitive copy becomes a loop-carried state transition

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -1193,7 +1193,11 @@
               :provenance {:dialect :segscan :segop-id (:id operation) :graph-node id}
               :attributes {:phase phase :dtype dtype :scan-mode scan-mode
                            :scan-workgroup scan-workgroup}})))
-        emitted (kgraph/map-operations graph emit-node)]
+        emitted (kgraph/map-operations
+                 graph
+                 (fn [node]
+                   (kart/certify-scheduled-operation
+                    (emit-node node) (:operation node))))]
     (finalize-emitted-graph emitted :opencl-c)))
 
 (defn- generate-elementwise-kernel-graph
@@ -1216,28 +1220,30 @@
         (kgraph/map-operations
          graph
          (fn [{:keys [id operation]}]
-           (cond
-             (instance? raster.compiler.ir.segop.SegMap operation)
-             (if (:out-sym operation)
-               (generate-segmap-kernel
-                operation (:out-sym operation)
-                :dtype (:dtype operation)
-                :scalar-types scalar-types :array-types array-types
-                :kernel-name-prefix "graph_segmap")
-               (generate-explicit-segmap-kernel
-                operation :dtype (:dtype operation)
-                :scalar-types scalar-types :array-types array-types
-                :kernel-name-prefix "graph_segmap_effect"))
+           (kart/certify-scheduled-operation
+            (cond
+              (instance? raster.compiler.ir.segop.SegMap operation)
+              (if (:out-sym operation)
+                (generate-segmap-kernel
+                 operation (:out-sym operation)
+                 :dtype (:dtype operation)
+                 :scalar-types scalar-types :array-types array-types
+                 :kernel-name-prefix "graph_segmap")
+                (generate-explicit-segmap-kernel
+                 operation :dtype (:dtype operation)
+                 :scalar-types scalar-types :array-types array-types
+                 :kernel-name-prefix "graph_segmap_effect"))
 
-             (instance? raster.compiler.ir.segop.SegStencil operation)
-             (generate-segstencil-kernel
-              operation :scalar-types scalar-types :array-types array-types
-              :kernel-name-prefix "graph_segstencil")
+              (instance? raster.compiler.ir.segop.SegStencil operation)
+              (generate-segstencil-kernel
+               operation :scalar-types scalar-types :array-types array-types
+               :kernel-name-prefix "graph_segstencil")
 
-             :else
-             (throw (ex-info "OpenCL elementwise graph has an unsupported scheduled node"
-                             {:reason :kernel-graph-node-target-lowering-missing
-                              :target :opencl-c :node id :operation operation})))))]
+              :else
+              (throw (ex-info "OpenCL elementwise graph has an unsupported scheduled node"
+                              {:reason :kernel-graph-node-target-lowering-missing
+                               :target :opencl-c :node id :operation operation})))
+            operation)))]
     (finalize-emitted-graph emitted :opencl-c)))
 
 (defn generate-kernel-graph

--- a/src/raster/compiler/ir/kernel_artifact.clj
+++ b/src/raster/compiler/ir/kernel_artifact.clj
@@ -77,6 +77,16 @@
   (validate! (->KernelArtifact kernel-name target source abi arguments launch
                                temporaries effects provenance attributes)))
 
+(defn certify-scheduled-operation
+  "Bind a target artifact to the complete immutable scheduled operation it implements."
+  [artifact scheduled-operation]
+  (when (nil? scheduled-operation)
+    (throw (ex-info "an emitted artifact requires its scheduled operation certificate"
+                    {:reason :kernel-artifact-scheduled-operation})))
+  (validate! (assoc-in (validate! artifact)
+                       [:provenance :scheduled-operation]
+                       scheduled-operation)))
+
 (defn launch-value
   "Read one value from the artifact's launch contract."
   [artifact k]

--- a/src/raster/compiler/ir/kernel_graph.clj
+++ b/src/raster/compiler/ir/kernel_graph.clj
@@ -246,6 +246,25 @@
     (validate! (update graph :nodes
                        #(mapv (fn [node] (assoc node :operation (f node))) %)))))
 
+(defn dataflow-contract
+  "Project the target-independent buffers, accesses, and ordering of a KernelGraph.
+
+   Operations and the emitted external ABI are deliberately excluded: target lowering replaces
+   the former and constructs the latter. Buffer contracts, node identities, uses, dependencies,
+   and semantic graph effects may not change during that replacement."
+  [graph]
+  (let [graph (validate! graph)]
+    {:inputs (:inputs graph)
+     :outputs (:outputs graph)
+     :temporaries (:temporaries graph)
+     :nodes (mapv #(select-keys % [:id :uses :dependencies]) (:nodes graph))
+     :effects (:effects graph)}))
+
+(defn dataflow-equivalent?
+  "Whether two valid graphs have exactly the same target-independent dataflow contract."
+  [left right]
+  (= (dataflow-contract left) (dataflow-contract right)))
+
 (defn- ordered [xs]
   (vec (sort-by pr-str xs)))
 

--- a/src/raster/compiler/ir/structured_control_schedule.clj
+++ b/src/raster/compiler/ir/structured_control_schedule.clj
@@ -1,6 +1,8 @@
 (ns raster.compiler.ir.structured-control-schedule
   "Checked schedule value for a typed sequential fixpoint."
-  (:require [raster.compiler.ir.kernel-graph :as graph]
+  (:require [clojure.set :as set]
+            [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as soac]
@@ -18,6 +20,94 @@
   [reason message data]
   (throw (ex-info message (assoc data :reason reason :ir :structured-control-schedule))))
 
+(defn- value-elements
+  [value]
+  (let [shape (:shape value)]
+    (cond
+      (empty? shape) 1
+      (= 1 (count shape)) (first shape)
+      :else (apply launch/product shape))))
+
+(defn- physical-body-outputs
+  [algorithm]
+  (let [facts (soac/facts algorithm)
+        producer (into {}
+                       (mapcat (fn [equation]
+                                 (map vector (nth equation 2)
+                                      (soac/physical-results facts equation))))
+                       (soac/equations algorithm))]
+    (mapv (fn [result]
+            (or (get producer result)
+                (fail! :structured-loop-result-storage
+                       "structured loop body result has no physical storage identity"
+                       {:result result})))
+          (soac/outputs algorithm))))
+
+(defn- external-inputs
+  [operations]
+  (:inputs
+   (reduce (fn [{:keys [initialized] :as state} operation]
+             (let [reads (segop/operation-inputs operation)
+                   writes (segop/operation-outputs operation)]
+               (-> state
+                   (update :inputs set/union (set/difference reads initialized))
+                   (update :initialized set/union writes))))
+           {:inputs #{} :initialized #{}}
+           operations)))
+
+(defn- storage-spec
+  [values id]
+  (let [value (get values id)]
+    (when-not value
+      (fail! :structured-loop-storage-value
+             "scheduled structured loop storage lacks an AbstractValue"
+             {:value id}))
+    {:dtype (:dtype value)
+     :elements (value-elements value)
+     :memory-space (or (:memory-space value) :device)}))
+
+(defn iteration-graph
+  "Derive the one-iteration KernelGraph solely from a loop algorithm and scheduled SegOp body."
+  [algorithm scheduled]
+  (let [algorithm (control/validate! algorithm)
+        scheduled (parallel-program/validate!
+                   scheduled segop/segop-node?
+                   (fn [equation typed-algorithm]
+                     (and (= typed-algorithm (soac/validate! typed-algorithm))
+                          (= (:operands equation) (:inputs (soac/facts typed-algorithm)))
+                          (= (:results equation) (soac/outputs typed-algorithm)))))
+        operations (vec (mapcat :operations (:equations scheduled)))
+        _ (when (empty? operations)
+            (fail! :structured-loop-empty-schedule
+                   "structured loop body requires at least one scheduled parallel operation" {}))
+        _ (when (some #(get-in % [:attributes :host-only]) (:equations scheduled))
+            (fail! :structured-loop-host-scalar
+                   "host scalar equations inside structured control require explicit lowering" {}))
+        inputs (external-inputs operations)
+        outputs (set (physical-body-outputs (control/body algorithm)))
+        operation-values (reduce set/union #{}
+                                 (map #(set/union (segop/operation-inputs %)
+                                                  (segop/operation-outputs %))
+                                      operations))
+        temporary-ids (set/difference operation-values inputs outputs)
+        values (:values scheduled)
+        buffer-specs (into {}
+                           (map (fn [id] [id (storage-spec values id)]))
+                           (set/union inputs outputs temporary-ids))]
+    (graph/from-segops
+     operations
+     {:inputs inputs
+      :outputs outputs
+      :temporaries (select-keys buffer-specs temporary-ids)
+      :buffer-specs buffer-specs
+      :dtype (:dtype (first (vals buffer-specs)))
+      :effects {:semantic (:effects (control/facts algorithm))}
+      :provenance {:source-dialect :typed-structured-control
+                   :algorithm-dialect :typed-soac
+                   :schedule-dialect :segop}
+      :attributes {:control :sequential-fixpoint
+                   :execution :host-repetition}})))
+
 (defn validate!
   [scheduled-loop]
   (when-not (scheduled-loop? scheduled-loop)
@@ -32,6 +122,7 @@
                      (= (:operands equation) (:inputs (soac/facts typed-algorithm)))
                      (= (:results equation) (soac/outputs typed-algorithm)))))
         graph (graph/validate! graph)
+        expected-graph (iteration-graph algorithm body)
         typed-body (control/body algorithm)
         retained-equations (vec (mapcat (comp soac/equations :algorithm) (:equations body)))]
     (when-not (= :segop (:dialect body))
@@ -59,6 +150,11 @@
     (when-not (= (vec (mapcat :operations (:equations body)))
                  (mapv :operation (:nodes graph)))
       (fail! :structured-loop-graph "KernelGraph operations differ from the scheduled body" {}))
+    (when-not (= expected-graph graph)
+      (fail! :structured-loop-graph
+             "KernelGraph boundary, storage, uses, or dependencies differ from scheduled dataflow"
+             {:expected (graph/dataflow-contract expected-graph)
+              :actual (graph/dataflow-contract graph)}))
     scheduled-loop))
 
 (defn make

--- a/src/raster/compiler/ir/structured_loop_call.clj
+++ b/src/raster/compiler/ir/structured_loop_call.clj
@@ -98,14 +98,16 @@
     (when-not (every? (comp artifact/kernel-artifact? :operation) (:nodes emitted))
       (fail! :structured-loop-emitted-graph
              "structured loop call requires a fully emitted KernelGraph" {}))
-    (when-not (and (= (mapv :id (:nodes (:graph scheduled))) (mapv :id (:nodes emitted)))
+    (when-not (and (graph/dataflow-equivalent? (:graph scheduled) emitted)
                    (every? true?
                            (map (fn [scheduled-node emitted-node]
-                                  (= (get-in emitted-node [:operation :provenance :segop-id])
-                                     (get-in scheduled-node [:operation :id])))
+                                  (= (:operation scheduled-node)
+                                     (get-in emitted-node
+                                             [:operation :provenance
+                                              :scheduled-operation])))
                                 (:nodes (:graph scheduled)) (:nodes emitted))))
       (fail! :structured-loop-emitted-graph
-             "emitted graph identities or semantic provenance differ from the scheduled iteration"
+             "emitted graph dataflow or operation certificates differ from the scheduled iteration"
              {}))
     (when-not (and (integer? trip-count) (not (neg? trip-count)))
       (fail! :structured-loop-trip-count "resolved trip count must be non-negative"

--- a/src/raster/compiler/passes/parallel/structured_control_lower.clj
+++ b/src/raster/compiler/passes/parallel/structured_control_lower.clj
@@ -4,104 +4,12 @@
    The loop remains a sequential fixpoint while its closed TypedSOAC body takes the ordinary
    TypedSOAC -> ParallelProgram -> SegOp -> KernelGraph vertical.  This pass deliberately does not
    emit a persistent kernel or reconstruct a source-shaped compound program."
-  (:require [clojure.set :as set]
-            [raster.compiler.ir.kernel-graph :as graph]
-            [raster.compiler.ir.kernel-launch :as launch]
-            [raster.compiler.ir.segop :as segop]
-            [raster.compiler.ir.soac-dialect :as soac]
-            [raster.compiler.ir.structured-control :as control]
+  (:require [raster.compiler.ir.structured-control :as control]
             [raster.compiler.ir.structured-control-schedule :as control-schedule]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.typed-soac-route :as typed-route]))
 
 (def scheduled-loop? control-schedule/scheduled-loop?)
-
-(defn- fail!
-  [reason message data]
-  (throw (ex-info message (assoc data :reason reason :pass :structured-control-lower))))
-
-(defn- value-elements
-  [value]
-  (let [shape (:shape value)]
-    (cond
-      (empty? shape) 1
-      (= 1 (count shape)) (first shape)
-      :else (apply launch/product shape))))
-
-(defn- physical-body-outputs
-  [algorithm]
-  (let [facts (soac/facts algorithm)
-        producer (into {}
-                       (mapcat (fn [equation]
-                                 (map vector (nth equation 2)
-                                      (soac/physical-results facts equation))))
-                       (soac/equations algorithm))]
-    (mapv (fn [result]
-            (or (get producer result)
-                (fail! :structured-loop-result-storage
-                       "structured loop body result has no physical storage identity"
-                       {:result result})))
-          (soac/outputs algorithm))))
-
-(defn- external-inputs
-  "Find physical values read before any body operation initializes them."
-  [operations]
-  (:inputs
-   (reduce (fn [{:keys [initialized] :as state} operation]
-             (let [reads (segop/operation-inputs operation)
-                   writes (segop/operation-outputs operation)]
-               (-> state
-                   (update :inputs set/union (set/difference reads initialized))
-                   (update :initialized set/union writes))))
-           {:inputs #{} :initialized #{}}
-           operations)))
-
-(defn- storage-spec
-  [values id]
-  (let [value (get values id)]
-    (when-not value
-      (fail! :structured-loop-storage-value
-             "scheduled structured loop storage lacks an AbstractValue"
-             {:value id}))
-    {:dtype (:dtype value)
-     :elements (value-elements value)
-     :memory-space (or (:memory-space value) :device)}))
-
-(defn- body-graph
-  [algorithm scheduled]
-  (let [operations (vec (mapcat :operations (:equations scheduled)))
-        _ (when (empty? operations)
-            (fail! :structured-loop-empty-schedule
-                   "structured loop body requires at least one scheduled parallel operation" {}))
-        _ (when (some #(get-in % [:attributes :host-only]) (:equations scheduled))
-            (fail! :structured-loop-host-scalar
-                   "host scalar equations inside structured control require explicit loop scalar lowering"
-                   {}))
-        inputs (external-inputs operations)
-        outputs (set (physical-body-outputs algorithm))
-        operation-values (reduce set/union #{}
-                                 (map #(set/union (segop/operation-inputs %)
-                                                  (segop/operation-outputs %))
-                                      operations))
-        temporary-ids (set/difference operation-values inputs outputs)
-        values (:values scheduled)
-        buffer-specs (into {}
-                           (map (fn [id] [id (storage-spec values id)]))
-                           (set/union inputs outputs temporary-ids))
-        temporaries (select-keys buffer-specs temporary-ids)]
-    (graph/from-segops
-     operations
-     {:inputs inputs
-      :outputs outputs
-      :temporaries temporaries
-      :buffer-specs buffer-specs
-      :dtype (:dtype (first (vals buffer-specs)))
-      :effects {:semantic (:effects (soac/facts algorithm))}
-      :provenance {:source-dialect :typed-structured-control
-                   :algorithm-dialect :typed-soac
-                   :schedule-dialect :segop}
-      :attributes {:control :sequential-fixpoint
-                   :execution :host-repetition}})))
 
 (def validate! control-schedule/validate!)
 
@@ -115,7 +23,7 @@
   (let [algorithm (control/validate! algorithm)
         envelope (typed-route/program-envelope (control/body algorithm))
         scheduled (:form (segop-lower/segop-lower-pass envelope opts))
-        graph (body-graph (control/body algorithm) scheduled)]
+        graph (control-schedule/iteration-graph algorithm scheduled)]
     (control-schedule/make
      {:algorithm algorithm
       :body scheduled

--- a/test/raster/compiler/ir/kernel_graph_test.clj
+++ b/test/raster/compiler/ir/kernel_graph_test.clj
@@ -82,6 +82,20 @@
     (is (identical? (first (:inputs scheduled)) (first (:outputs scheduled))))
     (is (= :read-write (get-in scheduled [:nodes 0 :uses 0 :access])))))
 
+(deftest target-emission-cannot-change-the-scheduled-dataflow-contract
+  (let [operation (segop/->SegMap
+                   9 (segop/make-seg-space 'i 'n) (segop/->SegLevel :thread :virtual)
+                   '(inc (aget values i)) #{'values} #{'out} #{}
+                   (segop/->KernelGrid 1 32 0) :float 'out nil)
+        scheduled (graph/from-segops [operation]
+                                     {:inputs #{'values} :outputs #{'out} :dtype :float})
+        emitted-shape (graph/map-operations scheduled (constantly :artifact))]
+    (is (graph/dataflow-equivalent? scheduled emitted-shape))
+    (is (not (graph/dataflow-equivalent?
+              scheduled (assoc emitted-shape :effects {:semantic #{:io}}))))
+    (is (not (graph/dataflow-equivalent?
+              scheduled (assoc-in emitted-shape [:inputs 0 :elements] 'different-extent))))))
+
 (deftest scan-graph-preserves-per-buffer-storage-dtypes
   (let [node (soac/par-form->soac
               'scan-result

--- a/test/raster/compiler/passes/parallel/structured_control_lower_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_lower_test.clj
@@ -1,5 +1,5 @@
 (ns raster.compiler.passes.parallel.structured-control-lower-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.segop-opencl :as opencl]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.kernel-artifact :as artifact]
@@ -67,7 +67,12 @@
     (is (= {:kind :host-repetition :association :sequential}
            (:strategy scheduled)))
     (is (= :typed-soac (get-in scheduled [:attributes :body-dialect])))
-    (is (= scheduled (lower/validate! scheduled)))))
+    (is (= scheduled (lower/validate! scheduled)))
+    (testing "the scheduled graph is re-derived from exact SegOp dataflow"
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"storage, uses, or dependencies differ"
+           (lower/validate!
+            (assoc-in scheduled [:graph :inputs 0 :elements] 'different-extent)))))))
 
 (deftest structured-loop-body-dataflow-becomes-one-verified-iteration-graph
   (let [scheduled (lower/schedule (loop-program true) {:target-device :cpu:0 :dtype :float})
@@ -83,6 +88,9 @@
       (is (every? artifact/kernel-artifact? (map :operation (:nodes emitted))))
       (is (= '[u-in u-next alpha-in iteration n-in] (:arguments emitted)))
       (is (= :opencl-c (get-in emitted [:provenance :target-dialect])))
+      (is (= (mapv :operation (:nodes graph))
+             (mapv #(get-in % [:operation :provenance :scheduled-operation])
+                   (:nodes emitted))))
       (is (every? #(re-find #"__kernel void graph_segmap" (:source %))
                   (map :operation (:nodes emitted))))
       (let [call (loop-call/make
@@ -101,7 +109,25 @@
                (:buffers (loop-call/iteration-binding call 2))))
         (is (= {:type :int :value 2}
                (get-in (loop-call/iteration-binding call 2)
-                       [:scalar-values 'iteration])))))))
+                       [:scalar-values 'iteration])))
+        (testing "a copied SegOp ID cannot hide a changed operation certificate"
+          (let [tampered (assoc-in emitted
+                                   [:nodes 0 :operation :provenance
+                                    :scheduled-operation :grid :block-size]
+                                   128)]
+            (is (thrown-with-msg?
+                 clojure.lang.ExceptionInfo #"operation certificates differ"
+                 (loop-call/validate! (assoc call :graph tampered))))))
+        (testing "target emission cannot change buffers or graph effects"
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo #"dataflow or operation certificates differ"
+               (loop-call/validate!
+                (assoc call :graph
+                       (assoc-in emitted [:inputs 0 :elements] 'different-extent)))))
+          (is (thrown-with-msg?
+               clojure.lang.ExceptionInfo #"dataflow or operation certificates differ"
+               (loop-call/validate!
+                (assoc call :graph (assoc emitted :effects {:semantic #{:io}}))))))))))
 
 (deftest zero-trip-loop-returns-the-initial-logical-value-without-scratch
   (let [scheduled (lower/schedule (loop-program) {:target-device :cpu:0 :dtype :float})


### PR DESCRIPTION
## Summary
- re-derive every scheduled loop iteration graph from its TypedSOAC algorithm and scheduled SegOps during validation
- preserve and compare exact buffer, storage, use, hazard, dependency, and effect contracts across target emission
- bind each KernelArtifact to the complete immutable scheduled operation it implements
- reject tampered graphs and copied-ID operation substitutions before runtime binding

## Tests
- clojure -M:test -n raster.compiler.ir.kernel-graph-test -n raster.compiler.passes.parallel.structured-control-lower-test -n raster.gpu.structured-loop-test
- 13 tests, 67 assertions

Stacked on #247 and #246.