### PR TITLE
Functionalize typed sequential loops

### DIFF
--- a/src/raster/compiler/ir/structured_loop_call.clj
+++ b/src/raster/compiler/ir/structured_loop_call.clj
@@ -69,10 +69,17 @@
                                 "symbolic trip-count binding differs from its retained dtype"
                                 {:value trip-count :expected expected :actual (:type value)})))
                      (:value value)))]
-    (when-not (and (integer? resolved) (not (neg? resolved)))
-      (fail! :structured-loop-trip-count "loop trip count must resolve non-negative"
+    (when-not (integer? resolved)
+      (fail! :structured-loop-trip-count "loop trip count must resolve to an integer"
              {:resolved resolved}))
-    (long resolved)))
+    (let [semantics (get-in (control/facts algorithm)
+                            [:attributes :trip-count-semantics])]
+      (cond
+        (not (neg? resolved)) (long resolved)
+        (= :clamp-nonnegative semantics) 0
+        :else
+        (fail! :structured-loop-trip-count "loop trip count must resolve non-negative"
+               {:resolved resolved :semantics semantics})))))
 
 (defn- scalar-binding
   [slots id expected-dtype value]

--- a/src/raster/compiler/passes/parallel/structured_control_frontend.clj
+++ b/src/raster/compiler/passes/parallel/structured_control_frontend.clj
@@ -1,0 +1,341 @@
+(ns raster.compiler.passes.parallel.structured-control-frontend
+  "Functionalize one counted sequential host loop around a TypedSOAC body.
+
+   This pass knows neither RK4 nor any numerical method. It recognizes a generic `dotimes`
+   fixpoint, alpha-flattens its lexical body, replaces complete destination-writing parallel
+   operations with logical SSA values, and accepts the state transition only when AbstractValue
+   analysis proves a complete compatible array copy back into the carried state.
+
+   The result is a TypedStructuredControl expression whose body enters the same TypedSOAC fusion
+   and scheduling vertical as a loop-free program. Prefix/suffix source is retained only so a later
+   mixed-program envelope can splice the typed fixpoint into the enclosing host computation."
+  (:require [clojure.set :as set]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.util :as util]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.par :as par]
+            [raster.compiler.ir.soac-dialect :as soac]
+            [raster.compiler.ir.structured-control :as control]
+            [raster.compiler.passes.parallel.typed-soac-frontend :as typed-frontend]
+            [raster.compiler.passes.parallel.typed-soac-fusion :as typed-fusion]
+            [raster.compiler.passes.scalar.host-abstract-value :as host-av]))
+
+(def ^:private dotimes-heads '#{dotimes clojure.core/dotimes})
+
+(defn- dotimes-form?
+  [expression]
+  (and (seq? expression)
+       (contains? dotimes-heads (first expression))
+       (vector? (second expression))
+       (= 2 (count (second expression)))))
+
+(defn- fail!
+  [reason message data]
+  (throw (ex-info message (assoc data :reason reason
+                                 :pass :structured-control-frontend))))
+
+(defn- destination-write
+  [expression]
+  (cond
+    (par/par-stencil-form? expression)
+    (:out (par/extract-par-stencil-info expression))
+
+    (par/par-map-form? expression)
+    (let [{:keys [out offset]} (par/extract-par-map-info expression)]
+      (when-not offset out))
+
+    :else nil))
+
+(defn- source-symbols
+  [expression]
+  (cond
+    (symbol? expression) #{expression}
+    (and (seq? expression) (= 'quote (first expression))) #{}
+    (coll? expression) (reduce into #{} (map source-symbols expression))
+    :else #{}))
+
+(defn- fresh-allocation-bindings
+  [pairs]
+  (into #{}
+        (keep (fn [[binder initializer]]
+                (when (and (seq? initializer)
+                           (descriptor/alloc-op?
+                            (descriptor/semantic-op initializer)))
+                  binder)))
+        pairs))
+
+(defn- arraycopy-destination
+  [expression]
+  (when (and (seq? expression)
+             (contains? #{'System/arraycopy 'java.lang.System/arraycopy}
+                        (descriptor/semantic-op expression))
+             (= 5 (count (descriptor/call-args expression))))
+    (nth (descriptor/call-args expression) 2)))
+
+(defn- allocate-id
+  [state prefix source-meta]
+  (loop [ordinal (:ordinal state)]
+    (let [id (with-meta (symbol (str prefix ordinal)) source-meta)]
+      (if (contains? (:reserved state) id)
+        (recur (inc ordinal))
+        [(-> state
+             (assoc :ordinal (inc ordinal))
+             (update :reserved conj id))
+         id]))))
+
+(declare lower-value)
+
+(defn- emit-value
+  [state expression lexical source-meta]
+  (let [lexical-expression (util/subst-syms lexical expression)
+        destination (destination-write lexical-expression)
+        copy-destination (arraycopy-destination lexical-expression)]
+    (when (and destination
+               (contains? (par/collect-aget-arrays lexical-expression) destination))
+      (fail! :structured-loop-hidden-carry
+             "a destination-writing scratch operation may not read its prior physical value"
+             {:destination destination :expression lexical-expression}))
+    (when (and destination (contains? (:written state) destination))
+      (fail! :structured-loop-repeated-destination
+             "one physical destination may be written only once in a functionalized iteration"
+             {:destination destination :expression lexical-expression}))
+    (when (and copy-destination (contains? (:written state) copy-destination))
+      (fail! :structured-loop-mutated-carry
+             "the copied loop carry may not also be a destination-written body buffer"
+             {:destination copy-destination :expression lexical-expression}))
+    (let [rewritten (util/subst-syms (:aliases state) lexical-expression)
+          [state id] (allocate-id state "rstr_loop_value_" source-meta)
+          state (-> state
+                    (update :pairs conj [id rewritten])
+                    (cond-> destination
+                      (update :writes conj {:binding id :destination destination
+                                            :expression rewritten})
+                      destination (update :written conj destination)
+                      destination (assoc-in [:aliases destination] id)))]
+      [state id])))
+
+(defn- lower-sequence
+  [state expressions lexical]
+  (reduce (fn [[state _] expression]
+            (lower-value state expression lexical))
+          [state nil]
+          expressions))
+
+(defn- lower-binding-form
+  [state expression lexical]
+  (let [[_ bindings & body] expression]
+    (when-not (even? (count bindings))
+      (fail! :structured-loop-bindings
+             "nested loop-body binding form requires an even binding vector"
+             {:expression expression}))
+    (let [[state lexical]
+          (reduce (fn [[state lexical] [binder initializer]]
+                    (when-not (symbol? binder)
+                      (fail! :structured-loop-binder
+                             "functionalized loop bindings must be symbols"
+                             {:binder binder :expression expression}))
+                    (let [[state value] (lower-value state initializer lexical)]
+                      [state (assoc lexical binder value)]))
+                  [state lexical]
+                  (partition 2 bindings))]
+      (lower-sequence state body lexical))))
+
+(defn- lower-value
+  [state expression lexical]
+  (cond
+    (and (seq? expression) (contains? #{'let 'let*} (first expression)))
+    (lower-binding-form state expression lexical)
+
+    (and (seq? expression) (= 'do (first expression)))
+    (lower-sequence state (rest expression) lexical)
+
+    :else
+    (emit-value state expression lexical (meta expression))))
+
+(defn- flatten-loop-body
+  [body reserved]
+  (let [[state result]
+        (lower-sequence {:pairs [] :writes [] :written #{} :aliases {}
+                         :ordinal 0 :reserved reserved}
+                        body {})]
+    (assoc state :result result)))
+
+(defn- values->array-types
+  [values]
+  (into {} (keep (fn [[id value]]
+                   (when (seq (:shape value)) [id (:dtype value)]))) values))
+
+(defn- values->scalar-types
+  [values]
+  (into {} (keep (fn [[id value]]
+                   (when (= [] (:shape value)) [id (:dtype value)]))) values))
+
+(defn- one-loop-binding
+  [pairs]
+  (let [matches (keep-indexed (fn [ordinal [binder initializer]]
+                                (when (dotimes-form? initializer)
+                                  {:ordinal ordinal :binder binder :form initializer}))
+                              pairs)]
+    (when (= 1 (count matches)) (first matches))))
+
+(defn- add-iteration-value
+  [program iteration]
+  (let [facts (soac/facts program)
+        iteration-value (av/tensor {:dtype :long :shape []})]
+    (soac/make (update facts :values #(assoc % iteration iteration-value))
+               (soac/equations program)
+               (soac/outputs program))))
+
+(defn- boundary-id
+  [state prefix]
+  (allocate-id state prefix nil))
+
+(defn- order-body-boundary
+  [program declared]
+  (let [facts (soac/facts program)
+        actual (set (:inputs facts))]
+    (soac/make (assoc facts :inputs (filterv actual declared))
+               (soac/equations program)
+               (soac/outputs program))))
+
+(defn form->structured-loop
+  "Return a certified structured-loop decomposition for one flat outer binding form, or nil.
+
+   A candidate must contain exactly one binding whose initializer is `dotimes`. The loop body may
+   contain nested `let`/`let*`/`do`, pure TypedSOAC operations, and complete destination-writing
+   stencil/map operations. Its last operation must be a proved full array copy into the carried
+   state. Unsupported source shapes decline; contradictions after accepting a destination write
+   fail loudly.
+
+   `options` is the same retained type/AbstractValue environment accepted by the TypedSOAC and
+   host AbstractValue frontends."
+  [source {:keys [dtype values array-types scalar-types abstract-machine]
+           :or {dtype :double values {} array-types {} scalar-types {}} :as options}]
+  (when (and (seq? source) (contains? #{'let 'let*} (first source)))
+    (let [[_ bindings & outer-body] source
+          pairs (when (and (vector? bindings) (even? (count bindings)))
+                  (vec (map vec (partition 2 bindings))))]
+      (when-let [{:keys [ordinal binder form]} (and pairs (one-loop-binding pairs))]
+        (let [[_ [iteration raw-trip-count] & loop-body] form
+              trip-count (if (integer? raw-trip-count)
+                           (max 0 raw-trip-count)
+                           raw-trip-count)
+              prefix-pairs (subvec pairs 0 ordinal)
+              suffix-pairs (subvec pairs (inc ordinal))
+              prefix-source (list 'let*
+                                  (vec (mapcat identity prefix-pairs))
+                                  (if (seq prefix-pairs) (ffirst (rseq prefix-pairs)) nil))
+              reserved (source-symbols source)
+              flattened (flatten-loop-body loop-body reserved)
+              flattened-pairs (:pairs flattened)
+              [copy-binding copy-expression] (peek flattened-pairs)
+              body-pairs (when (seq flattened-pairs) (pop flattened-pairs))
+              flattened-source (when (seq flattened-pairs)
+                                 (list 'let* (vec (mapcat identity flattened-pairs))
+                                       copy-binding))
+              outer-analysis (host-av/analyze prefix-source options)
+              body-analysis
+              (when flattened-source
+                (host-av/analyze
+                 flattened-source
+                 {:dtype dtype
+                  :values (:values outer-analysis)
+                  :array-types array-types
+                  :scalar-types (assoc scalar-types iteration :long)}))
+              copy-certificate (when body-analysis
+                                 (host-av/full-array-copy body-analysis copy-expression))
+              write-certificates
+              (mapv #(host-av/full-array-write body-analysis (:binding %) (:expression %))
+                    (:writes flattened))
+              written-destinations (set (map :destination (:writes flattened)))
+              fresh-allocations (fresh-allocation-bindings prefix-pairs)
+              suffix-uses (reduce into #{}
+                                  (map util/free-syms
+                                       (concat (map second suffix-pairs) outer-body)))]
+          (when (and (soac/extent? trip-count)
+                     copy-certificate
+                     (every? some? write-certificates))
+            (when-not (every? fresh-allocations written-destinations)
+              (fail! :structured-loop-scratch-ownership
+                     "functionalized destination writes require fresh prefix allocations"
+                     {:destinations written-destinations
+                      :fresh-allocations fresh-allocations}))
+            (when-let [escaping (seq (set/intersection written-destinations suffix-uses))]
+              (fail! :structured-loop-scratch-escape
+                     "functionalized scratch destinations may not escape the sequential loop"
+                     {:destinations (set escaping)}))
+            (let [carry-initial (:destination copy-certificate)
+                  carry-result (:source copy-certificate)
+                  typed-source (list 'let* (vec (mapcat identity body-pairs)) carry-result)
+                  typed-values (:values body-analysis)
+                  typed-program
+                  (typed-frontend/form->program
+                   typed-source
+                   {:dtype dtype
+                    :values (assoc typed-values iteration
+                                   (av/tensor {:dtype :long :shape []}))
+                    :array-types (merge (values->array-types typed-values) array-types)
+                    :scalar-types (merge (values->scalar-types typed-values) scalar-types
+                                         {iteration :long})})]
+              (when typed-program
+                (let [typed-program (add-iteration-value typed-program iteration)
+                      [fused fusion-stats]
+                      (typed-fusion/fusion-fixpoint typed-program abstract-machine)
+                      body-inputs (:inputs (soac/facts fused))
+                      invariant-outers (filterv #(not (contains? #{carry-initial iteration} %))
+                                                body-inputs)
+                      boundary-values (:values outer-analysis)]
+                  (when (and (contains? boundary-values carry-initial)
+                             (every? #(contains? boundary-values %) invariant-outers)
+                             (or (integer? trip-count)
+                                 (contains? boundary-values trip-count)))
+                    (let [[state iteration-parameter] (boundary-id flattened
+                                                                   "rstr_loop_iteration_")
+                          [state carry-parameter] (boundary-id state "rstr_loop_carry_")
+                          [state carry-output] (boundary-id state "rstr_loop_output_")
+                          [state invariant-bindings]
+                          (reduce (fn [[state bindings] outer]
+                                    (let [[state parameter]
+                                          (boundary-id state "rstr_loop_invariant_")]
+                                      [state (conj bindings {:outer outer
+                                                             :parameter parameter})]))
+                                  [state []] invariant-outers)
+                          renames (merge {iteration iteration-parameter
+                                          carry-initial carry-parameter}
+                                         (into {} (map (juxt :outer :parameter)
+                                                       invariant-bindings)))
+                          body (-> (soac/remap-values fused renames)
+                                   (order-body-boundary
+                                    (vec (concat [iteration-parameter]
+                                                 (map :parameter invariant-bindings)
+                                                 [carry-parameter]))))
+                          outer-values (assoc boundary-values
+                                              carry-output
+                                              (get-in outer-analysis
+                                                      [:values carry-initial]))
+                          loop-facts
+                          {:id (symbol (str (name binder) "-typed-fixpoint"))
+                           :effects (:effects (soac/facts body))
+                           :provenance {:source-dialect :closed-clojure
+                                        :front-end :structured-control-frontend
+                                        :source-binding binder}
+                           :attributes {:association :sequential
+                                        :trip-count-semantics :clamp-nonnegative}}
+                          loop
+                          (control/make
+                           loop-facts [iteration-parameter trip-count]
+                           invariant-bindings
+                           [{:initial carry-initial :parameter carry-parameter
+                             :result (get renames carry-result carry-result)
+                             :output carry-output}]
+                           body outer-values)]
+                      {:loop loop
+                       :loop-binding binder
+                       :prefix-bindings prefix-pairs
+                       :suffix-bindings suffix-pairs
+                       :outer-body (vec outer-body)
+                       :flattened-body-source flattened-source
+                       :typed-body-source typed-source
+                       :copy-certificate copy-certificate
+                       :write-certificates write-certificates
+                       :fusion-stats fusion-stats})))))))))))

--- a/src/raster/compiler/passes/scalar/host_abstract_value.clj
+++ b/src/raster/compiler/passes/scalar/host_abstract_value.clj
@@ -44,6 +44,14 @@
                  (= 1 (count arguments)))
         (first arguments)))))
 
+(defn- fresh-allocation-value
+  [source-value shape]
+  (av/tensor
+   {:dtype (:dtype source-value)
+    :shape shape
+    :logical-layout (:logical-layout source-value)
+    :representation (:representation source-value)}))
+
 (defn- array-allocation
   [expression]
   (when (and (seq? expression)
@@ -117,7 +125,17 @@
         alength-array (when alength-expression
                         (first (descriptor/call-args alength-expression)))
         clone-source (source-shaped-allocation expression)
-        allocation (array-allocation expression)]
+        allocation (array-allocation expression)
+        destination-write
+        (cond
+          (par/par-stencil-form? expression)
+          (select-keys (par/extract-par-stencil-info expression)
+                       [:out :bound :cast :elem-type])
+
+          (par/par-map-form? expression)
+          (let [{:keys [out bound cast elem-type offset]}
+                (par/extract-par-map-info expression)]
+            (when-not offset {:out out :bound bound :cast cast :elem-type elem-type})))]
     (cond
       alength-expression
       (let [state (assoc-in state [:values symbol]
@@ -128,8 +146,9 @@
       clone-source
       (if-let [source-value (get values clone-source)]
         (assoc-in state [:values symbol]
-                  (assoc source-value :shape (canonical-shape (:equalities state)
-                                                              (:shape source-value))))
+                  (fresh-allocation-value
+                   source-value
+                   (canonical-shape (:equalities state) (:shape source-value))))
         state)
 
       allocation
@@ -146,6 +165,20 @@
         (when (and elem-type cast-dtype (not= elem-type cast-dtype))
           (throw (ex-info "parallel map element type disagrees with its explicit cast"
                           {:reason :host-abstract-value-pmap-dtype
+                           :element-type elem-type :cast-dtype cast-dtype
+                           :expression expression})))
+        (assoc-in state [:values symbol]
+                  (tensor (or elem-type cast-dtype default-dtype)
+                          [(or (shape-extent state bound) bound)])))
+
+      destination-write
+      (let [{:keys [bound cast elem-type]} destination-write
+            cast-dtype (some-> cast descriptor/cast-result-tag
+                               dtype/dtype-for-scalar-tag)
+            elem-type (some-> elem-type dtype/canon)]
+        (when (and elem-type cast-dtype (not= elem-type cast-dtype))
+          (throw (ex-info "parallel write element type disagrees with its explicit cast"
+                          {:reason :host-abstract-value-write-dtype
                            :element-type elem-type :cast-dtype cast-dtype
                            :expression expression})))
         (assoc-in state [:values symbol]
@@ -222,3 +255,34 @@
                  (= source-shape destination-shape [copied-extent]))
         {:source source :destination destination :extent copied-extent
          :dtype (:dtype source-value)}))))
+
+(defn full-array-write
+  "Return a certified descriptor for one complete rank-one destination-writing SOAC.
+
+   This is a storage proof, not an operation-name inference rule: the parallel dialect extractor
+   supplies the destination and iteration extent, while retained AbstractValues prove that the
+   operation covers the destination's complete logical storage contract. Offset maps deliberately
+   remain outside this proof."
+  [analysis result expression]
+  (let [{:keys [out bound kind]}
+        (cond
+          (par/par-stencil-form? expression)
+          (assoc (select-keys (par/extract-par-stencil-info expression) [:out :bound])
+                 :kind :stencil)
+
+          (par/par-map-form? expression)
+          (let [{:keys [out bound offset]} (par/extract-par-map-info expression)]
+            (when-not offset {:out out :bound bound :kind :map}))
+
+          :else nil)
+        destination-value (get-in analysis [:values out])
+        result-value (get-in analysis [:values result])
+        destination-shape (value-shape analysis destination-value)
+        result-shape (value-shape analysis result-value)
+        write-extent (shape-extent analysis bound)]
+    (when (and (symbol? out) (symbol? result)
+               (= :tensor (:kind destination-value) (:kind result-value))
+               (av/storage-contract-compatible? destination-value result-value)
+               (= 1 (count destination-shape) (count result-shape))
+               (= destination-shape result-shape [write-extent]))
+      {:destination out :extent write-extent :dtype (:dtype destination-value) :kind kind})))

--- a/test/raster/compiler/passes/parallel/structured_control_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_frontend_test.clj
@@ -1,0 +1,125 @@
+(ns raster.compiler.passes.parallel.structured-control-frontend-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.walk :as walk]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.soac-dialect :as soac]
+            [raster.compiler.ir.structured-control :as control]
+            [raster.compiler.passes.parallel.structured-control-frontend :as frontend]
+            [raster.compiler.passes.parallel.structured-control-lower :as lower]))
+
+(def ^:private initial
+  (av/tensor {:dtype :double :shape ['extent] :representation {:kind :plain}}))
+
+(defn- loop-source
+  [copy-length]
+  (list
+   'let*
+   ['n '(int (clojure.core/alength u0))
+    'u '(clojure.core/aclone u0)
+    'scratch '(raster.numeric/similar_m_doubles u0)
+    'time-loop
+    (list 'dotimes '[step steps]
+          '(raster.par/stencil! scratch [u] 1 :dirichlet double i n
+                                (+ (clojure.core/aget u i) alpha))
+          (list 'let* ['next '(raster.par/pmap j n double
+                                               (+ (clojure.core/aget u j)
+                                                  (clojure.core/aget scratch j)
+                                                  (* 0.0 step)))]
+                (list 'java.lang.System/arraycopy 'next 0 'u 0 copy-length)))
+    'after '(raster.par/pmap k n double (clojure.core/aget u k))]
+   'after))
+
+(def ^:private options
+  {:dtype :double
+   :values {'u0 initial
+            'steps (av/tensor {:dtype :long :shape []})
+            'alpha (av/tensor {:dtype :double :shape []})}
+   :scalar-types {'steps :long 'alpha :double}})
+
+(defn- update-bindings
+  [source f]
+  (apply list (first source) (f (second source)) (drop 2 source)))
+
+(deftest destination-writing-loop-becomes-a-typed-functional-fixpoint
+  (let [{:keys [loop prefix-bindings suffix-bindings copy-certificate
+                write-certificates fusion-stats typed-body-source]}
+        (frontend/form->structured-loop (loop-source 'n) options)
+        body (control/body loop)
+        scheduled (lower/schedule loop {:target-device :cpu:0 :dtype :double})
+        graph (:graph scheduled)
+        body-inputs (:inputs (soac/facts body))]
+    (is (= loop (control/validate! loop)))
+    (is (soac/program-form? body))
+    (is (= 3 (count prefix-bindings)))
+    (is (= 1 (count suffix-bindings)))
+    (is (= {:source 'rstr_loop_value_1 :destination 'u :extent 'n :dtype :double}
+           copy-certificate))
+    (is (= [{:destination 'scratch :extent 'n :dtype :double :kind :stencil}]
+           write-certificates))
+    (is (map? fusion-stats))
+    (testing "destination mutation is represented as logical SSA dataflow"
+      (is (not-any? #{'scratch} body-inputs))
+      (is (some #{'rstr_loop_value_0}
+                (tree-seq coll? seq typed-body-source))))
+    (testing "the ordinary SOAC scheduler owns the iteration graph"
+      (is (lower/scheduled-loop? scheduled))
+      (is (not-any? #{'scratch} (map :id (:inputs graph)))))))
+
+(deftest unsupported-or-ambiguous-state-transitions-decline-or-fail-exactly
+  (testing "a partial copy is not silently interpreted as a loop carry"
+    (is (nil? (frontend/form->structured-loop (loop-source '(dec n)) options))))
+  (testing "two writes to one physical destination violate one-iteration SSA"
+    (let [source (loop-source 'n)
+          bindings (second source)
+          dotimes (nth bindings 7)
+          dotimes (apply list (concat (take 3 dotimes)
+                                      [(nth dotimes 2)]
+                                      (drop 3 dotimes)))
+          source (apply list 'let* (assoc bindings 7 dotimes) (drop 2 source))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"one physical destination may be written only once"
+           (frontend/form->structured-loop source options))))))
+
+(deftest loop-boundary-does-not-admit-suffix-or-escaping-scratch-values
+  (testing "a later binding is not falsely available as a loop invariant"
+    (let [source (loop-source 'n)
+          bindings (second source)
+          dotimes (nth bindings 7)
+          dotimes (walk/postwalk-replace {'alpha 'late-value} dotimes)
+          bindings (assoc bindings 7 dotimes)
+          bindings (vec (concat (subvec bindings 0 8)
+                                ['late-value 1.0]
+                                (subvec bindings 8)))
+          source (apply list 'let* bindings (drop 2 source))]
+      (is (nil? (frontend/form->structured-loop source options)))))
+  (testing "a functionalized physical scratch buffer may not escape after the loop"
+    (let [source (loop-source 'n)
+          source (update-bindings
+                  source #(assoc % 9 '(raster.par/pmap k n double
+                                                       (clojure.core/aget scratch k))))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"may not escape"
+           (frontend/form->structured-loop source options)))))
+  (testing "an alias of caller storage is not accepted as private scratch"
+    (let [source (loop-source 'n)
+          source (update-bindings source #(assoc % 5 'u0))]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"require fresh prefix allocations"
+           (frontend/form->structured-loop source options))))))
+
+(deftest generated-boundaries-are-alpha-safe-and-retain-dotimes-semantics
+  (testing "all source binders are reserved from generated SSA names"
+    (let [source (walk/postwalk-replace {'next 'rstr_loop_value_0} (loop-source 'n))
+          {:keys [typed-body-source]} (frontend/form->structured-loop source options)]
+      (is (= 'rstr_loop_value_1 (first (second typed-body-source))))))
+  (testing "a negative literal dotimes count has zero-trip semantics"
+    (let [source (loop-source 'n)
+          source (update-bindings
+                  source #(update % 7 (fn [dotimes]
+                                        (apply list (first dotimes)
+                                               [(first (second dotimes)) -4]
+                                               (drop 2 dotimes)))))
+          loop (:loop (frontend/form->structured-loop source options))]
+      (is (= 0 (second (control/loop-index loop))))
+      (is (= :clamp-nonnegative
+             (get-in (control/facts loop) [:attributes :trip-count-semantics]))))))

--- a/test/raster/compiler/passes/parallel/structured_control_lower_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_lower_test.clj
@@ -145,3 +145,27 @@
               {})]
     (is (= 0 (:trip-count call)))
     (is (= {'u-final :initial-buffer} (:outputs call)))))
+
+(deftest dotimes-derived-loop-clamps-a-negative-runtime-bound-to-zero
+  (let [program (loop-program)
+        program (control/make
+                 (assoc-in (control/facts program)
+                           [:attributes :trip-count-semantics]
+                           :clamp-nonnegative)
+                 (control/loop-index program)
+                 (control/invariants program)
+                 (control/carried program)
+                 (control/body program)
+                 (control/outer-values program))
+        scheduled (lower/schedule program {:target-device :cpu:0 :dtype :float})
+        emitted (opencl/generate-kernel-graph
+                 (:graph scheduled) :scalar-types {'alpha-in :float 'iteration :long})
+        call (loop-call/make
+              scheduled emitted
+              {'u0 :initial-buffer 'u-final :unused-output-buffer}
+              {'steps {:type :long :value -3}
+               'n {:type :int :value 64}
+               'alpha {:type :float :value 0.25}}
+              {})]
+    (is (zero? (:trip-count call)))
+    (is (= {'u-final :initial-buffer} (:outputs call)))))

--- a/test/raster/compiler/passes/scalar/host_abstract_value_test.clj
+++ b/test/raster/compiler/passes/scalar/host_abstract_value_test.clj
@@ -70,6 +70,37 @@
     (is (= ['n] (get-in analysis [:values 'y :shape])))
     (is (nil? (get-in analysis [:values 'unknown])))))
 
+(deftest complete-parallel-writes-retain-their-destination-contract
+  (let [source
+        '(let* [n (int (clojure.core/alength u))
+                written (raster.par/stencil! scratch [u] 1 :dirichlet double i n
+                                             (clojure.core/aget u i))]
+               written)
+        input (av/tensor {:dtype :double :shape ['extent] :representation {:kind :plain}})
+        analysis (host-av/analyze source {:values {'u input 'scratch input}})
+        expression (nth (second source) 3)]
+    (is (= ['n] (get-in analysis [:values 'written :shape])))
+    (is (= {:destination 'scratch :extent 'n :dtype :double :kind :stencil}
+           (host-av/full-array-write analysis 'written expression)))
+    (testing "a partial destination iteration space has no complete-write proof"
+      (is (nil? (host-av/full-array-write
+                 analysis 'written (apply list (assoc (vec expression) 7 '(dec n)))))))))
+
+(deftest source-shaped-allocation-has-fresh-ownership
+  (let [external (av/tensor {:dtype :double :shape ['n] :ownership :external
+                             :effects #{:memory/read}
+                             :attributes {:source :caller}})
+        analysis (host-av/analyze
+                  '(let* [copy (clojure.core/aclone input)] copy)
+                  {:values {'input external}})
+        copy (get-in analysis [:values 'copy])]
+    (is (nil? (:ownership copy))
+        "the relational pass clears caller ownership; allocation assigns physical ownership later")
+    (is (= #{} (:effects copy)))
+    (is (= {} (:attributes copy)))
+    (is (= (select-keys external [:dtype :shape :logical-layout :representation])
+           (select-keys copy [:dtype :shape :logical-layout :representation])))))
+
 (deftest malformed-input-contracts-fail-loud
   (testing "authoritative values must be AbstractValues"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"expected an AbstractValue"


### PR DESCRIPTION
## Outcome
- alpha-flatten generic counted loop bodies and convert full destination-writing stencil/map operations into logical SSA
- prove full state transitions and fresh, non-escaping scratch storage with retained AbstractValues
- build a TypedStructuredControl fixpoint whose body follows the ordinary TypedSOAC fusion and SegOp/KernelGraph schedule vertical
- preserve Clojure dotimes zero-trip semantics for negative dynamic bounds
- clear inherited ownership/effects from clone/similar AbstractValues

This is intentionally a standalone certified frontend slice. Mixed prefix/loop/suffix envelope wiring and removal of the legacy RK4 compound route follow separately.

## Verification
- focused compiler tests: 52 tests, 386 assertions
- includes alpha-collision, suffix-scope, scratch escape/ownership, partial copy, duplicate write, zero/negative trip, scheduling, and exact graph-certificate coverage
- independently reviewed for AbstractValue, alpha-renaming, and hidden-carry soundness; identified P0/P1 issues were addressed before opening

Stacked on #249.