### PR TITLE
Route structured loops through ParallelProgram

### DIFF
--- a/src/raster/compiler/passes/parallel/structured_control_frontend.clj
+++ b/src/raster/compiler/passes/parallel/structured_control_frontend.clj
@@ -330,6 +330,7 @@
                              :output carry-output}]
                            body outer-values)]
                       {:loop loop
+                       :source source
                        :loop-binding binder
                        :prefix-bindings prefix-pairs
                        :suffix-bindings suffix-pairs

--- a/src/raster/compiler/passes/parallel/structured_control_route.clj
+++ b/src/raster/compiler/passes/parallel/structured_control_route.clj
@@ -1,0 +1,83 @@
+(ns raster.compiler.passes.parallel.structured-control-route
+  "Place a typed sequential fixpoint in Raster's common ParallelProgram envelope.
+
+   TypedSOAC and TypedStructuredControl are two algorithm variants, not two program containers.
+   This route gives structured control the same ordered equation/value spine used by loop-free
+   algorithms. Scheduling replaces the equation's typed control operation with one checked
+   ScheduledStructuredLoop; it does not reconstruct or recognize a source-shaped compound loop."
+  (:require [raster.compiler.ir.parallel-program :as program]
+            [raster.compiler.ir.structured-control :as control]
+            [raster.compiler.ir.structured-control-schedule :as schedule]
+            [raster.compiler.passes.parallel.structured-control-lower :as lower]))
+
+(defn- ordered-distinct
+  [values]
+  (vec (distinct values)))
+
+(defn- algorithm-boundary?
+  [equation algorithm]
+  (and (control/loop-program? algorithm)
+       (= algorithm (control/validate! algorithm))
+       (= (:operands equation) (ordered-distinct (control/outer-operands algorithm)))
+       (= (:results equation) (control/outer-results algorithm))))
+
+(defn program-envelope
+  "Wrap one certified frontend decomposition in the shared typed program envelope."
+  [{:keys [loop source loop-binding] :as decomposition}]
+  (when-not (and (map? decomposition) loop)
+    (throw (ex-info "structured-control routing requires a certified frontend decomposition"
+                    {:reason :structured-control-decomposition
+                     :decomposition decomposition})))
+  (let [loop (control/validate! loop)
+        facts (control/facts loop)
+        operands (ordered-distinct (control/outer-operands loop))
+        results (control/outer-results loop)
+        equation
+        (program/->ProgramEquation
+         (:id facts) [:binding loop-binding] nil operands results loop [loop]
+         (:effects facts)
+         (assoc (:provenance facts) :pass :structured-control-route)
+         (assoc (:attributes facts) :algorithm-dialect :typed-structured-control))]
+    (program/make
+     {:dialect :typed-parallel
+      :source source
+      :values (control/outer-values loop)
+      :inputs operands
+      :equations [equation]
+      :outputs results
+      :effects (:effects facts)
+      :provenance {:source-dialect :typed-structured-control
+                   :pass :structured-control-route}
+      :attributes {:host-control :typed-structured-control}
+      :operation? control/loop-program?
+      :algorithm? algorithm-boundary?})))
+
+(defn schedule-program
+  "Schedule every typed-control equation through the ordinary loop-body SOAC vertical."
+  [parallel-program opts]
+  (let [parallel-program
+        (program/validate! parallel-program control/loop-program? algorithm-boundary?)
+        equations
+        (mapv (fn [equation]
+                (let [scheduled (lower/schedule (:algorithm equation) opts)]
+                  (-> equation
+                      (assoc :operations [scheduled])
+                      (update :provenance assoc :target-dialect :structured-control-schedule)
+                      (update :attributes assoc
+                              :schedule-dialect :segop
+                              :graph-dialect :kernel-graph))))
+              (:equations parallel-program))]
+    (program/make
+     {:dialect :structured-control-schedule
+      :source (:source parallel-program)
+      :values (:values parallel-program)
+      :inputs (:inputs parallel-program)
+      :equations equations
+      :outputs (:outputs parallel-program)
+      :effects (:effects parallel-program)
+      :diagnostics (:diagnostics parallel-program)
+      :provenance (assoc (:provenance parallel-program)
+                         :target-dialect :structured-control-schedule)
+      :attributes (:attributes parallel-program)
+      :operation? schedule/scheduled-loop?
+      :algorithm? algorithm-boundary?})))

--- a/test/raster/compiler/passes/parallel/structured_control_route_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_route_test.clj
@@ -1,0 +1,65 @@
+(ns raster.compiler.passes.parallel.structured-control-route-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.parallel-program :as program]
+            [raster.compiler.ir.soac-dialect :as soac]
+            [raster.compiler.ir.structured-control :as control]
+            [raster.compiler.ir.structured-control-schedule :as schedule]
+            [raster.compiler.passes.parallel.structured-control-route :as route]))
+
+(defn- loop-decomposition
+  []
+  (let [extent (av/tensor {:dtype :int :shape []})
+        index (av/tensor {:dtype :long :shape []})
+        tensor (av/tensor {:dtype :float :shape '[n]})
+        inner (av/tensor {:dtype :float :shape '[n-in]})
+        equation (list '= 'advance '[u-next]
+                       (list 'map {:index 'i :extent 'n-in}
+                             '[u-in] '[]
+                             (soac/lambda-form '[value] '[(+ value 1.0)])))
+        body (soac/make
+              (soac/default-program-facts
+               {:values {'iteration index 'n-in extent 'u-in inner 'u-next inner}
+                :inputs '[n-in u-in]
+                :equations {'advance (soac/default-equation-facts)}})
+              [equation] '[u-next])
+        loop (control/make
+              {:id 'time-loop :effects #{} :provenance {:source :test}
+               :attributes {:association :sequential}}
+              '[iteration steps]
+              [{:outer 'n :parameter 'n-in}]
+              [{:initial 'u :parameter 'u-in :result 'u-next :output 'u-final}]
+              body
+              {'steps index 'n extent 'u tensor 'u-final tensor})]
+    {:loop loop :loop-binding 'time-loop :source '(let* [] nil)}))
+
+(deftest structured-control-uses-the-common-program-equation-spine
+  (let [typed (route/program-envelope (loop-decomposition))
+        scheduled (route/schedule-program typed {:target-device :cpu:0 :dtype :float})
+        typed-equation (first (:equations typed))
+        scheduled-equation (first (:equations scheduled))]
+    (is (program/parallel-program? typed))
+    (is (= :typed-parallel (:dialect typed)))
+    (is (= '[steps n u] (:inputs typed)))
+    (is (= '[u-final] (:outputs typed)))
+    (is (= (:algorithm typed-equation) (:algorithm scheduled-equation)))
+    (is (= :structured-control-schedule (:dialect scheduled)))
+    (is (schedule/scheduled-loop? (first (:operations scheduled-equation))))
+    (testing "the scheduled equation retains the certified one-iteration graph"
+      (is (= :kernel-graph
+             (get-in scheduled-equation [:attributes :graph-dialect])))
+      (is (= '[u-in]
+             (mapv :id (get-in scheduled-equation [:operations 0 :graph :inputs])))))))
+
+(deftest repeated-outer-operands-do-not-break-program-ssa
+  (let [{:keys [loop] :as decomposition} (loop-decomposition)
+        loop (control/make
+              (control/facts loop)
+              (assoc (control/loop-index loop) 1 'n)
+              (control/invariants loop)
+              (control/carried loop)
+              (control/body loop)
+              (control/outer-values loop))
+        typed (route/program-envelope (assoc decomposition :loop loop))]
+    (is (= '[n u] (:inputs typed)))
+    (is (= '[n u] (:operands (first (:equations typed)))))))


### PR DESCRIPTION
## Outcome
- represent TypedStructuredControl as an algorithm variant in Raster's existing ordered ParallelProgram equation/value spine
- schedule the equation through the shared TypedSOAC body vertical into a checked ScheduledStructuredLoop with a certified KernelGraph
- preserve the typed algorithm across scheduling; no source reconstruction or compound-loop recognition
- deduplicate repeated outer operands at the program SSA boundary without weakening the loop's own binding contract

## Verification
- 10 focused tests, 63 assertions across frontend, loop scheduling, and common program routing
- includes exact program operands/results, retained algorithm identity, scheduled graph boundary, and repeated-operand coverage

Stacked on #250.