### PR TITLE
Map OpenCL transfers to an independent queue

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -815,8 +815,10 @@ after submission, while download destinations become visible only after the
 host wait. Level Zero's current shared allocations complete their Panama copy
 inline and report host-monotonic timing explicitly rather than pretending that
 a device copy event exists. Logical compute and transfer queues initially map
-to one physical in-order OpenCL queue, preserving ordering until execution-plan
-lowering can express and realize cross-queue dependencies safely. Immediate-wait
+to distinct physical in-order OpenCL queues for explicit range submissions.
+Callers await a transfer event before the same buffer changes queue roles;
+unrelated immutable transfers may overlap compute. Automatic cross-queue wait
+edges for a mixed execution plan remain future lowering work. Immediate-wait
 measurements are the calibration path; `host-wall-ns` otherwise includes any
 intentional host work between submission and wait.
 

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -377,6 +377,18 @@
            :events {}           ;; {event-id → session-owned asynchronous completion}
            :closed?   false})))
 
+(defn transfer-capabilities
+  "Return backend transfer execution capabilities for `sess`.
+
+  `:independent-physical-queue?` reports whether transfer submission uses a
+  physical queue distinct from compute. It is a scheduling capability, not a
+  promise that a particular device overlaps copy and kernels under load."
+  [sess]
+  (let [device-id (:device-id @sess)]
+    (assoc ((rt-resolve device-id "transfer-capabilities"))
+           :backend (backend-type device-id)
+           :device-id device-id)))
+
 (declare release-event!)
 
 (defn close-session!
@@ -1126,10 +1138,11 @@
 (defn submit-upload-ranges!
   "Validate and submit a batch of host-to-resident ranges without waiting.
 
-   Returns a session-owned `GPUEvent` on the logical transfer queue. OpenCL owns an immutable
-   native staging copy until the event is awaited/released, so callers may reuse their source after
-   submission. Level Zero shared allocations may complete inline; that distinction is reported by
-   `event-measurement`, not exposed as a different API."
+   Returns a session-owned `GPUEvent` on the logical transfer queue. OpenCL submits through an
+   independent physical in-order transfer queue and owns an immutable native staging copy until
+   the event is awaited/released, so callers may reuse their source after submission. Level Zero
+   shared allocations may complete inline; inspect `transfer-capabilities` and
+   `event-measurement` rather than assuming physical overlap."
   [sess entries]
   (submit-transfer-ranges! sess entries :upload))
 

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -247,7 +247,8 @@
          :platform nil       ;; MemorySegment (cl_platform_id)
          :device nil         ;; MemorySegment (cl_device_id)
          :context nil        ;; MemorySegment (cl_context)
-         :queue nil          ;; MemorySegment (cl_command_queue)
+         :queue nil          ;; compute cl_command_queue
+         :transfer-queue nil ;; independent transfer cl_command_queue
          :arena nil          ;; Arena for long-lived allocations
          :device-name nil
          :device-info nil
@@ -361,7 +362,8 @@
   "Initialize OpenCL runtime. Idempotent.
   Finds the first platform with a device of the requested type (default GPU;
   RASTER_OCL_DEVICE_TYPE=cpu|all selects CPU/any device — POCL, Intel CPU
-  runtime, vendor-portability testing), creates context and in-order queue."
+  runtime, vendor-portability testing), creates a context plus independent
+  in-order compute and transfer queues."
   []
   (when-not (:initialized? @state)
     (let [arena (Arena/ofShared)
@@ -413,16 +415,39 @@
                                                         (.allocateFrom arena PTR device)
                                                         MemorySegment/NULL MemorySegment/NULL err-seg]))
           _ (when (not= CL_SUCCESS (read-int err-seg))
+              (.close arena)
               (throw (ex-info "clCreateContext failed" {:error (read-int err-seg)})))
 
-          ;; One physical in-order queue initially realizes the backend-neutral compute and
-          ;; transfer queue classes. Profiling is enabled so transfer GPUEvents have device
-          ;; timestamps without introducing unsynchronized cross-queue execution.
+          ;; Compute and transfer are distinct physical in-order queues. Callers establish
+          ;; cross-queue dependencies by awaiting an event before the same buffer changes roles;
+          ;; unrelated immutable transfer and compute work may proceed independently.
           queue (.invokeWithArguments ^MethodHandle @h-clCreateCommandQueue
                                       (into-array Object
                                                   [ctx device CL_QUEUE_PROFILING_ENABLE err-seg]))
           _ (when (not= CL_SUCCESS (read-int err-seg))
-              (throw (ex-info "clCreateCommandQueue failed" {:error (read-int err-seg)})))]
+              (try
+                (.invokeWithArguments ^MethodHandle @h-clReleaseContext
+                                      (into-array Object [ctx]))
+                (catch Exception _))
+              (.close arena)
+              (throw (ex-info "clCreateCommandQueue(compute) failed"
+                              {:error (read-int err-seg)})))
+          transfer-queue
+          (.invokeWithArguments ^MethodHandle @h-clCreateCommandQueue
+                                (into-array Object
+                                            [ctx device CL_QUEUE_PROFILING_ENABLE err-seg]))
+          _ (when (not= CL_SUCCESS (read-int err-seg))
+              (try
+                (.invokeWithArguments ^MethodHandle @h-clReleaseCommandQueue
+                                      (into-array Object [queue]))
+                (catch Exception _))
+              (try
+                (.invokeWithArguments ^MethodHandle @h-clReleaseContext
+                                      (into-array Object [ctx]))
+                (catch Exception _))
+              (.close arena)
+              (throw (ex-info "clCreateCommandQueue(transfer) failed"
+                              {:error (read-int err-seg)})))]
 
       (swap! state assoc
              :initialized? true
@@ -430,6 +455,7 @@
              :device device
              :context ctx
              :queue queue
+             :transfer-queue transfer-queue
              :arena arena
              :device-name dev-name
              :device-info device-info
@@ -1503,7 +1529,7 @@
     (cl-call! "clReleaseEvent" @h-clReleaseEvent [event])))
 
 (defn submit-range-batch!
-  "Submit a validated range batch on the profiling-enabled OpenCL queue without waiting.
+  "Submit a validated range batch on the independent OpenCL transfer queue without waiting.
 
    Every command owns a private native staging slice until the returned completion token is
    awaited and released. Upload sources are copied into immutable staging before return; download
@@ -1517,7 +1543,7 @@
        :completion {:timing-source :host-monotonic
                     :elapsed-ns 0 :bytes total-bytes :commands 0
                     :direction direction :asynchronous? false}}
-      (let [queue (:queue @state)
+      (let [queue (:transfer-queue @state)
             arena (Arena/ofShared)
             event-outs (.allocate arena (* 8 (count active)))
             status-out (.allocate arena I32)
@@ -1685,9 +1711,19 @@
         (release-event! event)))))
 
 (defn synchronize-async!
-  "Block until all enqueued work completes."
+  "Block until all compute and transfer work completes."
   []
-  (cl-call! "clFinish" @h-clFinish [(:queue @state)]))
+  (let [{:keys [queue transfer-queue]} @state]
+    (cl-call! "clFinish" @h-clFinish [queue])
+    (cl-call! "clFinish" @h-clFinish [transfer-queue])))
+
+(defn transfer-capabilities
+  "Return the OpenCL runtime's physical transfer execution contract."
+  []
+  {:submission :device-event
+   :host-staging :runtime-owned-native
+   :independent-physical-queue? true
+   :queue-ordering :in-order})
 
 (defn reset-graph-events!
   "Discard the most recent OpenCL profiling sample and release its native events."
@@ -1768,8 +1804,13 @@
 (defn shutdown!
   "Shutdown OpenCL runtime, releasing all handles."
   []
-  (let [{:keys [queue context arena initialized?]} @state]
+  (let [{:keys [queue transfer-queue context arena initialized?]} @state]
     (when initialized?
+      (when transfer-queue
+        (let [ret (int (.invokeWithArguments ^MethodHandle @h-clReleaseCommandQueue
+                                             (into-array Object [transfer-queue])))]
+          (when-not (zero? ret)
+            (println (str "[ocl-runtime] WARNING: clReleaseCommandQueue(transfer) failed with error " ret)))))
       (when queue
         (let [ret (int (.invokeWithArguments ^MethodHandle @h-clReleaseCommandQueue
                                              (into-array Object [queue])))]
@@ -1784,7 +1825,8 @@
         (.close ^Arena arena))
       (clojure.core/reset! state
                            {:initialized? false :platform nil :device nil :context nil
-                            :queue nil :arena nil :device-name nil :device-info nil
+                            :queue nil :transfer-queue nil
+                            :arena nil :device-name nil :device-info nil
                             :unified-memory? false
                             :buffer-offset-alignment nil
                             :programs {} :kernels {}}))))
@@ -1797,7 +1839,8 @@
       (.close ^Arena arena)))
   (clojure.core/reset! state
                        {:initialized? false :platform nil :device nil :context nil
-                        :queue nil :arena nil :device-name nil :device-info nil
+                        :queue nil :transfer-queue nil
+                        :arena nil :device-name nil :device-info nil
                         :unified-memory? false
                         :buffer-offset-alignment nil
                         :programs {} :kernels {}})

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -935,6 +935,14 @@
                     :direction direction
                     :asynchronous? false}})))
 
+(defn transfer-capabilities
+  "Return the Level Zero runtime's physical transfer execution contract."
+  []
+  {:submission :inline-host-copy
+   :host-staging :caller-owned
+   :independent-physical-queue? false
+   :queue-ordering :inline})
+
 (defn upload-range!
   "Copy `elements` elements from `src` (JVM array or MemorySegment, starting at element
    `src-element`) into `buf` starting at element `dst-element`. Elements, not bytes: the byte

--- a/test/raster/gpu/range_transfer_test.clj
+++ b/test/raster/gpu/range_transfer_test.clj
@@ -67,6 +67,22 @@
           (is (= @submitted @awaited @released))
           (is (empty? (:events @session))))))))
 
+(deftest transfer-capabilities-preserve-backend-and-device-identity
+  (let [session (atom {:device-id :ocl:3})]
+    (with-redefs-fn
+      {(ns-resolve 'raster.gpu.core 'rt-resolve)
+       (fn [device-id function-name]
+         (is (= :ocl:3 device-id))
+         (is (= "transfer-capabilities" function-name))
+         (fn [] {:submission :device-event
+                 :independent-physical-queue? true}))}
+      (fn []
+        (is (= {:submission :device-event
+                :independent-physical-queue? true
+                :backend :ocl
+                :device-id :ocl:3}
+               (g/transfer-capabilities session)))))))
+
 ;; gemma-270m's real KV shape: 2048 positions x (1 kv-head x 256 head-dim)
 (def ^:private maxpos 2048)
 (def ^:private kvrow 256)
@@ -256,7 +272,7 @@
                   (str k " carries ITS OWN layer's prefix, not a neighbour's")))))))))
 
 (defn- asynchronous-mixed-storage-roundtrip!
-  [device-id expected-timing-source]
+  [device-id expected-timing-source expected-independent-queue?]
   (let [n 257
         float-source (float-array (map #(float (+ 1 %)) (range n)))
         half-source (short-array (map #(Float/floatToFloat16 (float (+ 1 %))) (range n)))
@@ -266,6 +282,9 @@
         half-destination (short-array n)
         session (g/make-session device-id)]
     (try
+      (is (= expected-independent-queue?
+             (:independent-physical-queue?
+              (g/transfer-capabilities session))))
       (g/alloc! session {:float-buffer [:float n nil]
                          :half-buffer [:half n nil]})
       (let [event (g/submit-upload-ranges!
@@ -302,12 +321,12 @@
 (deftest level-zero-asynchronous-batch-has-honest-host-timing
   (if-not @gp/gpu-available?
     (gp/gpu-skip! "asynchronous mixed-storage range batch on Level Zero")
-    (asynchronous-mixed-storage-roundtrip! :ze:0 :host-monotonic)))
+    (asynchronous-mixed-storage-roundtrip! :ze:0 :host-monotonic false)))
 
 (deftest opencl-asynchronous-batch-has-device-event-timing
   (if-not @device-probe/opencl-available?
     (device-probe/opencl-skip! "asynchronous mixed-storage range batch on OpenCL")
-    (asynchronous-mixed-storage-roundtrip! :ocl:0 :device-event)))
+    (asynchronous-mixed-storage-roundtrip! :ocl:0 :device-event true)))
 
 (deftest a-bad-entry-anywhere-leaves-the-whole-cache-untouched
   (if-not @gp/gpu-available?


### PR DESCRIPTION
## Summary

- submit explicit OpenCL range transfers on a physical command queue distinct from compute
- expose backend transfer capabilities through the public session API
- keep Level Zero's current inline host-copy contract explicit
- document the cross-queue synchronization boundary

The capability reports scheduling structure, not guaranteed hardware overlap. Callers must await a transfer before the same buffer changes queue roles; unrelated immutable transfer and compute work may overlap.

## Validation

- `raster.gpu.range-transfer-test`: 15 tests, 68 assertions, 0 failures/errors
  - includes real Intel Arc/OpenCL mixed float/half upload and download with device-event timing
- `raster.gpu.ocl-session-test/ocl-resident-session-roundtrip`: passes on Intel Arc
- manual OpenCL shutdown/reinitialization lifecycle: passes
- `git diff --check`: clean

The focused checks ran through nREPL. I left the full suite to CI because the local host is under memory pressure.
