### PR TITLE
Compose structured loops with typed suffixes

### DIFF
--- a/src/raster/compiler/passes/parallel/structured_control_route.clj
+++ b/src/raster/compiler/passes/parallel/structured_control_route.clj
@@ -5,79 +5,258 @@
    This route gives structured control the same ordered equation/value spine used by loop-free
    algorithms. Scheduling replaces the equation's typed control operation with one checked
    ScheduledStructuredLoop; it does not reconstruct or recognize a source-shaped compound loop."
-  (:require [raster.compiler.ir.parallel-program :as program]
+  (:require [clojure.set :as set]
+            [raster.compiler.core.util :as util]
+            [raster.compiler.ir.parallel-program :as program]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.ir.soac-dialect :as soac]
             [raster.compiler.ir.structured-control :as control]
             [raster.compiler.ir.structured-control-schedule :as schedule]
-            [raster.compiler.passes.parallel.structured-control-lower :as lower]))
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
+            [raster.compiler.passes.parallel.structured-control-lower :as lower]
+            [raster.compiler.passes.parallel.typed-soac-frontend :as typed-frontend]
+            [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]
+            [raster.compiler.passes.parallel.typed-soac-route :as typed-route]))
 
 (defn- ordered-distinct
   [values]
   (vec (distinct values)))
 
-(defn- algorithm-boundary?
+(defn- loop-boundary?
   [equation algorithm]
   (and (control/loop-program? algorithm)
        (= algorithm (control/validate! algorithm))
        (= (:operands equation) (ordered-distinct (control/outer-operands algorithm)))
        (= (:results equation) (control/outer-results algorithm))))
 
+(defn- soac-boundary?
+  [equation algorithm]
+  (and (soac/program-form? algorithm)
+       (= algorithm (soac/validate! algorithm))
+       (= (:operands equation) (:inputs (soac/facts algorithm)))
+       (= (:results equation) (soac/outputs algorithm))))
+
+(defn- typed-algorithm-boundary?
+  [equation algorithm]
+  (cond
+    (control/loop-program? algorithm)
+    (and (loop-boundary? equation algorithm)
+         (= [algorithm] (:operations equation)))
+
+    (soac/program-form? algorithm)
+    (and (soac-boundary? equation algorithm)
+         (= (soac/equations algorithm) (:operations equation)))
+
+    :else false))
+
+(defn- scheduled-algorithm-boundary?
+  [equation algorithm]
+  (cond
+    (control/loop-program? algorithm)
+    (and (loop-boundary? equation algorithm)
+         (= 1 (count (:operations equation)))
+         (let [scheduled (first (:operations equation))]
+           (and (schedule/scheduled-loop? scheduled)
+                (= algorithm (:algorithm (schedule/validate! scheduled))))))
+
+    (soac/program-form? algorithm)
+    (and (soac-boundary? equation algorithm)
+         (or (and (true? (get-in equation [:attributes :host-only]))
+                  (empty? (:operations equation)))
+             (and (seq (:operations equation))
+                  (every? segop/segop-node? (:operations equation)))))
+
+    :else false))
+
+(defn- typed-operation?
+  [operation]
+  (or (control/loop-program? operation) (boolean (fusion/equation-info operation))))
+
+(defn- scheduled-operation?
+  [operation]
+  (or (schedule/scheduled-loop? operation) (segop/segop-node? operation)))
+
+(defn- merge-values
+  [left right]
+  (reduce-kv
+   (fn [values id value]
+     (if-let [prior (get values id)]
+       (if (= prior value)
+         values
+         (throw (ex-info "mixed typed algorithms disagree on one AbstractValue"
+                         {:reason :structured-control-value-conflict
+                          :id id :first prior :second value})))
+       (assoc values id value)))
+   left right))
+
+(defn- fail!
+  [reason message data]
+  (throw (ex-info message (assoc data :reason reason :pass :structured-control-route))))
+
+(defn- program-boundary
+  [equations outputs]
+  (let [{:keys [inputs available]}
+        (reduce
+         (fn [{:keys [inputs available definitions] :as state} equation]
+           (let [new-inputs (remove available (:operands equation))
+                 input-set (set new-inputs)
+                 duplicate-results (set/intersection definitions (set (:results equation)))
+                 clobbered-inputs (set/intersection (into (set inputs) new-inputs)
+                                                    (set (:results equation)))]
+             (when (seq duplicate-results)
+               (fail! :structured-control-result-redefinition
+                      "mixed algorithms may define each logical value only once"
+                      {:equation (:id equation) :values duplicate-results}))
+             (when (seq clobbered-inputs)
+               (fail! :structured-control-use-before-definition
+                      "a value used before its definition cannot later be defined"
+                      {:equation (:id equation) :values clobbered-inputs}))
+             (-> state
+                 (update :inputs into (remove (set inputs) new-inputs))
+                 (update :available into input-set)
+                 (update :available into (:results equation))
+                 (update :definitions into (:results equation)))))
+         {:inputs [] :available #{} :definitions #{}}
+         equations)
+        unavailable-outputs (remove available outputs)]
+    (when (seq unavailable-outputs)
+      (fail! :structured-control-unavailable-output
+             "mixed program outputs must be inputs or produced values"
+             {:outputs (vec outputs) :unavailable (vec unavailable-outputs)}))
+    {:inputs inputs :outputs (vec outputs)}))
+
+(defn- value-types
+  [values shape?]
+  (into {} (keep (fn [[id value]]
+                   (when (shape? (:shape value)) [id (:dtype value)]))) values))
+
+(defn- suffix-program
+  [{:keys [loop suffix-bindings outer-body]} {:keys [dtype abstract-machine] :as options}]
+  (when (or (seq suffix-bindings) (seq outer-body))
+    (let [substitutions (into {} (map (juxt :initial :output) (control/carried loop)))
+          source (util/subst-syms
+                  substitutions
+                  (list* 'let* (vec (mapcat identity suffix-bindings)) outer-body))
+          values (control/outer-values loop)
+          typed (typed-frontend/form->program
+                 source (assoc options
+                               :dtype (or dtype :double)
+                               :values values
+                               :array-types (merge (:array-types options)
+                                                   (value-types values seq))
+                               :scalar-types (merge (:scalar-types options)
+                                                    (value-types values empty?))))]
+      (when-not typed
+        (fail! :structured-control-unsupported-suffix
+               "post-loop computation is outside the certified TypedSOAC subset"
+               {:suffix-bindings suffix-bindings :outer-body outer-body}))
+      (first (fusion/fusion-fixpoint typed abstract-machine)))))
+
+(defn- loop-equation
+  [loop loop-binding]
+  (let [facts (control/facts loop)]
+    (program/->ProgramEquation
+     [:structured-loop (:id facts)] [:binding loop-binding] nil
+     (ordered-distinct (control/outer-operands loop))
+     (control/outer-results loop) loop [loop]
+     (:effects facts)
+     (assoc (:provenance facts) :pass :structured-control-route)
+     (assoc (:attributes facts) :algorithm-dialect :typed-structured-control))))
+
 (defn program-envelope
-  "Wrap one certified frontend decomposition in the shared typed program envelope."
-  [{:keys [loop source loop-binding] :as decomposition}]
-  (when-not (and (map? decomposition) loop)
-    (throw (ex-info "structured-control routing requires a certified frontend decomposition"
-                    {:reason :structured-control-decomposition
-                     :decomposition decomposition})))
-  (let [loop (control/validate! loop)
-        facts (control/facts loop)
-        operands (ordered-distinct (control/outer-operands loop))
-        results (control/outer-results loop)
-        equation
-        (program/->ProgramEquation
-         (:id facts) [:binding loop-binding] nil operands results loop [loop]
-         (:effects facts)
-         (assoc (:provenance facts) :pass :structured-control-route)
-         (assoc (:attributes facts) :algorithm-dialect :typed-structured-control))]
-    (program/make
-     {:dialect :typed-parallel
-      :source source
-      :values (control/outer-values loop)
-      :inputs operands
-      :equations [equation]
-      :outputs results
-      :effects (:effects facts)
-      :provenance {:source-dialect :typed-structured-control
-                   :pass :structured-control-route}
-      :attributes {:host-control :typed-structured-control}
-      :operation? control/loop-program?
-      :algorithm? algorithm-boundary?})))
+  "Wrap one certified frontend decomposition in the shared typed program envelope.
+
+   When a suffix is itself in the TypedSOAC subset, its uses of the physical carried array are
+   alpha-remapped to the loop's fresh logical output and appended as ordinary typed equations."
+  ([decomposition] (program-envelope decomposition {}))
+  ([{:keys [loop source loop-binding] :as decomposition} options]
+   (when-not (and (map? decomposition) loop)
+     (throw (ex-info "structured-control routing requires a certified frontend decomposition"
+                     {:reason :structured-control-decomposition
+                      :decomposition decomposition})))
+   (let [loop (control/validate! loop)
+         loop-equation (loop-equation loop loop-binding)
+         suffix (suffix-program decomposition options)
+         suffix-envelope (when suffix (typed-route/program-envelope suffix))
+         suffix-equations (mapv #(update % :id (fn [id] [:suffix id]))
+                                (:equations suffix-envelope))
+         equations (into [loop-equation] suffix-equations)
+         values (merge-values (control/outer-values loop) (:values suffix-envelope))
+         program-outputs (or (:outputs suffix-envelope) (control/outer-results loop))
+         {:keys [inputs outputs]} (program-boundary equations program-outputs)
+         effects (reduce set/union #{} (map :effects equations))]
+     (program/make
+      {:dialect :typed-parallel
+       :source source
+       :values values
+       :inputs inputs
+       :equations equations
+       :outputs outputs
+       :effects effects
+       :provenance {:source-dialect :typed-structured-control
+                    :pass :structured-control-route}
+       :attributes {:host-control :typed-structured-control
+                    :mixed-algorithms (boolean suffix)}
+       :operation? typed-operation?
+       :algorithm? typed-algorithm-boundary?}))))
 
 (defn schedule-program
   "Schedule every typed-control equation through the ordinary loop-body SOAC vertical."
   [parallel-program opts]
   (let [parallel-program
-        (program/validate! parallel-program control/loop-program? algorithm-boundary?)
-        equations
-        (mapv (fn [equation]
-                (let [scheduled (lower/schedule (:algorithm equation) opts)]
-                  (-> equation
-                      (assoc :operations [scheduled])
-                      (update :provenance assoc :target-dialect :structured-control-schedule)
-                      (update :attributes assoc
-                              :schedule-dialect :segop
-                              :graph-dialect :kernel-graph))))
-              (:equations parallel-program))]
+        (program/validate! parallel-program typed-operation? typed-algorithm-boundary?)
+        {:keys [equations values]}
+        (reduce
+         (fn [{:keys [equations values]} equation]
+           (let [algorithm (:algorithm equation)]
+             (if (control/loop-program? algorithm)
+               (let [scheduled (lower/schedule algorithm opts)]
+                 {:equations
+                  (conj equations
+                        (-> equation
+                            (assoc :operations [scheduled])
+                            (update :provenance assoc
+                                    :target-dialect :structured-control-schedule)
+                            (update :attributes assoc
+                                    :schedule-dialect :segop
+                                    :graph-dialect :kernel-graph)))
+                  :values values})
+               (let [algorithm-values (:values (soac/facts algorithm))
+                     schedule-options
+                     (assoc opts
+                            :array-types (merge (:array-types opts)
+                                                (value-types algorithm-values seq))
+                            :scalar-types (merge (:scalar-types opts)
+                                                 (value-types algorithm-values empty?)))
+                     scheduled (:form (segop-lower/segop-lower-pass
+                                       (typed-route/program-envelope algorithm)
+                                       schedule-options))
+                     _ (when-not (= 1 (count (:equations scheduled)))
+                         (fail! :structured-control-suffix-schedule
+                                "one mixed suffix equation must lower to one scheduled equation"
+                                {:equation (:id equation)
+                                 :scheduled-equations (mapv :id (:equations scheduled))}))
+                     scheduled-equation (first (:equations scheduled))]
+                 {:equations
+                  (conj equations
+                        (-> equation
+                            (assoc :operations (:operations scheduled-equation))
+                            (update :provenance merge (:provenance scheduled-equation))
+                            (update :attributes merge (:attributes scheduled-equation))))
+                  :values (merge-values values (:values scheduled))}))))
+         {:equations [] :values (:values parallel-program)}
+         (:equations parallel-program))]
     (program/make
-     {:dialect :structured-control-schedule
+     {:dialect :scheduled-parallel
       :source (:source parallel-program)
-      :values (:values parallel-program)
+      :values values
       :inputs (:inputs parallel-program)
       :equations equations
       :outputs (:outputs parallel-program)
       :effects (:effects parallel-program)
       :diagnostics (:diagnostics parallel-program)
       :provenance (assoc (:provenance parallel-program)
-                         :target-dialect :structured-control-schedule)
+                         :target-dialect :scheduled-parallel)
       :attributes (:attributes parallel-program)
-      :operation? schedule/scheduled-loop?
-      :algorithm? algorithm-boundary?})))
+      :operation? scheduled-operation?
+      :algorithm? scheduled-algorithm-boundary?})))

--- a/test/raster/compiler/passes/parallel/structured_control_route_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_route_test.clj
@@ -5,6 +5,8 @@
             [raster.compiler.ir.soac-dialect :as soac]
             [raster.compiler.ir.structured-control :as control]
             [raster.compiler.ir.structured-control-schedule :as schedule]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.passes.parallel.structured-control-frontend :as frontend]
             [raster.compiler.passes.parallel.structured-control-route :as route]))
 
 (defn- loop-decomposition
@@ -43,7 +45,7 @@
     (is (= '[steps n u] (:inputs typed)))
     (is (= '[u-final] (:outputs typed)))
     (is (= (:algorithm typed-equation) (:algorithm scheduled-equation)))
-    (is (= :structured-control-schedule (:dialect scheduled)))
+    (is (= :scheduled-parallel (:dialect scheduled)))
     (is (schedule/scheduled-loop? (first (:operations scheduled-equation))))
     (testing "the scheduled equation retains the certified one-iteration graph"
       (is (= :kernel-graph
@@ -63,3 +65,96 @@
         typed (route/program-envelope (assoc decomposition :loop loop))]
     (is (= '[n u] (:inputs typed)))
     (is (= '[n u] (:operands (first (:equations typed)))))))
+
+(defn- mixed-source
+  []
+  '(let* [n (int (clojure.core/alength u0))
+          u (clojure.core/aclone u0)
+          scratch (clojure.core/double-array n)
+          time-loop
+          (dotimes [step steps]
+            (raster.par/map! scratch i n double
+                             (+ (clojure.core/aget u i) 1.0))
+            (let* [next (raster.par/pmap j n double
+                                         (+ (clojure.core/aget u j)
+                                            (clojure.core/aget scratch j)
+                                            (* 0.0 step)))]
+                  (java.lang.System/arraycopy next 0 u 0 n)))
+          after (raster.par/pmap k n double
+                                 (* 2.0 (clojure.core/aget u k)))]
+         after))
+
+(defn- source-with-suffix
+  [suffix-bindings result]
+  (let [[_ bindings] (mixed-source)]
+    (list 'let* (vec (concat (take 8 bindings) suffix-bindings)) result)))
+
+(defn- reason-of
+  [thunk]
+  (try
+    (thunk)
+    nil
+    (catch clojure.lang.ExceptionInfo exception
+      (:reason (ex-data exception)))))
+
+(deftest loop-output-feeds-an-ordinary-typed-suffix
+  (let [initial (av/tensor {:dtype :double :shape ['extent]
+                            :representation {:kind :plain}})
+        options {:dtype :double
+                 :values {'u0 initial 'steps (av/tensor {:dtype :long :shape []})}
+                 :scalar-types {'steps :long}}
+        decomposition (frontend/form->structured-loop (mixed-source) options)
+        typed (route/program-envelope decomposition options)
+        scheduled (route/schedule-program typed {:target-device :cpu:0 :dtype :double})
+        [loop-equation suffix-equation] (:equations typed)
+        [scheduled-loop scheduled-suffix] (:equations scheduled)
+        loop-output (first (:results loop-equation))]
+    (is (= 2 (count (:equations typed))))
+    (is (= [loop-output 'n] (:operands suffix-equation)))
+    (is (= '[after] (:outputs typed)))
+    (is (= '[steps n u] (:inputs typed)))
+    (is (= true (get-in typed [:attributes :mixed-algorithms])))
+    (is (schedule/scheduled-loop? (first (:operations scheduled-loop))))
+    (is (segop/segop-node? (first (:operations scheduled-suffix))))
+    (is (not-any? #{'u} (:operands suffix-equation)))))
+
+(deftest mixed-routing-never-drops-an-unsupported-suffix
+  (let [initial (av/tensor {:dtype :double :shape ['extent]
+                            :representation {:kind :plain}})
+        options {:dtype :double
+                 :values {'u0 initial 'steps (av/tensor {:dtype :long :shape []})}
+                 :scalar-types {'steps :long}}
+        source (source-with-suffix
+                '[unsupported (java.lang.System/gc)]
+                'unsupported)
+        decomposition (frontend/form->structured-loop source options)]
+    (is (= :structured-control-unsupported-suffix
+           (reason-of #(route/program-envelope decomposition options))))))
+
+(deftest suffix-shadowing-is-rejected-instead-of-breaking-program-ssa
+  (let [initial (av/tensor {:dtype :double :shape ['extent]
+                            :representation {:kind :plain}})
+        options {:dtype :double
+                 :values {'u0 initial 'steps (av/tensor {:dtype :long :shape []})}
+                 :scalar-types {'steps :long}}
+        source (source-with-suffix
+                '[u (raster.par/pmap k n double
+                                     (* 2.0 (clojure.core/aget u k)))]
+                'u)
+        decomposition (frontend/form->structured-loop source options)]
+    (is (= :structured-control-use-before-definition
+           (reason-of #(route/program-envelope decomposition options))))))
+
+(deftest algorithm-kind-and-operation-kind-must-remain-paired
+  (let [initial (av/tensor {:dtype :double :shape ['extent]
+                            :representation {:kind :plain}})
+        options {:dtype :double
+                 :values {'u0 initial 'steps (av/tensor {:dtype :long :shape []})}
+                 :scalar-types {'steps :long}}
+        decomposition (frontend/form->structured-loop (mixed-source) options)
+        typed (route/program-envelope decomposition options)
+        suffix-operation (get-in typed [:equations 1 :operations 0])
+        malformed (assoc-in typed [:equations 0 :operations] [suffix-operation])]
+    (is (= :parallel-program-algorithm
+           (reason-of #(route/schedule-program malformed
+                                               {:target-device :cpu:0 :dtype :double}))))))


### PR DESCRIPTION
## Summary
- compose typed sequential fixpoints and ordinary TypedSOAC suffix equations in one ParallelProgram
- schedule each algorithm variant through the existing structured-control or SegOp vertical
- fail closed on unsupported suffixes, preserve all carry substitutions, and certify ordered SSA boundaries
- retain authoritative AbstractValue types while scheduling suffix operations

## Validation
- focused structured-control frontend/lowering/route suite: 14 tests, 74 assertions
- cljfmt check on both touched files