### PR TITLE
Enforce ParallelProgram ordered SSA

### DIFF
--- a/src/raster/compiler/ir/parallel_program.clj
+++ b/src/raster/compiler/ir/parallel_program.clj
@@ -5,7 +5,8 @@
    current compiler still needs `source` to reconstruct scalar host control around emitted kernel
    calls, but scheduled operations live in equations, never in Clojure symbol metadata.  As more
    scalar control becomes explicit, `source` can shrink without changing value or operation IDs."
-  (:require [raster.compiler.ir.abstract-value :as av]))
+  (:require [clojure.set :as set]
+            [raster.compiler.ir.abstract-value :as av]))
 
 (defrecord ProgramEquation
            [id site source operands results algorithm operations effects provenance attributes])
@@ -28,6 +29,47 @@
 (defn- distinct-vector?
   [value]
   (and (vector? value) (= (count value) (count (distinct value)))))
+
+(defn infer-inputs
+  "Infer external inputs in first-use order from an ordered equation sequence.
+
+   This is a constructor helper, not a substitute for validation. A value used before a later
+   definition is inferred as external and `validate!` subsequently rejects that definition as an
+   input clobber."
+  [equations]
+  (:inputs
+   (reduce (fn [{:keys [inputs available] :as state} equation]
+             (let [external (remove available (:operands equation))]
+               (-> state
+                   (update :inputs into (remove (set inputs) external))
+                   (update :available into external)
+                   (update :available into (:results equation)))))
+           {:inputs [] :available #{}}
+           equations)))
+
+(defn- validate-dataflow!
+  [{:keys [inputs equations outputs] :as program}]
+  (let [available
+        (reduce
+         (fn [available equation]
+           (let [missing (set/difference (set (:operands equation)) available)
+                 redefined (set/intersection (set (:results equation)) available)]
+             (when (seq missing)
+               (throw (ex-info "equation operands must be program inputs or earlier results"
+                               {:reason :parallel-program-use-before-definition
+                                :equation (:id equation) :values missing})))
+             (when (seq redefined)
+               (throw (ex-info "equation results must be fresh logical values"
+                               {:reason :parallel-program-result-redefinition
+                                :equation (:id equation) :values redefined})))
+             (into available (:results equation))))
+         (set inputs) equations)
+        unavailable (set/difference (set outputs) available)]
+    (when (seq unavailable)
+      (throw (ex-info "program outputs must be inputs or equation results"
+                      {:reason :parallel-program-unavailable-output
+                       :values unavailable})))
+    program))
 
 (defn validate!
   "Validate a ParallelProgram and return it unchanged.
@@ -114,6 +156,7 @@
        (when-not (map? (:attributes equation))
          (throw (ex-info "equation attributes must be a map"
                          {:reason :parallel-program-attributes :equation (:id equation)}))))
+     (validate-dataflow! program)
      (when-not (set? effects)
        (throw (ex-info "parallel program effects must be an explicit set"
                        {:reason :parallel-program-effects :effects effects})))

--- a/src/raster/compiler/passes/parallel/structured_control_route.clj
+++ b/src/raster/compiler/passes/parallel/structured_control_route.clj
@@ -95,35 +95,8 @@
 
 (defn- program-boundary
   [equations outputs]
-  (let [{:keys [inputs available]}
-        (reduce
-         (fn [{:keys [inputs available definitions] :as state} equation]
-           (let [new-inputs (remove available (:operands equation))
-                 input-set (set new-inputs)
-                 duplicate-results (set/intersection definitions (set (:results equation)))
-                 clobbered-inputs (set/intersection (into (set inputs) new-inputs)
-                                                    (set (:results equation)))]
-             (when (seq duplicate-results)
-               (fail! :structured-control-result-redefinition
-                      "mixed algorithms may define each logical value only once"
-                      {:equation (:id equation) :values duplicate-results}))
-             (when (seq clobbered-inputs)
-               (fail! :structured-control-use-before-definition
-                      "a value used before its definition cannot later be defined"
-                      {:equation (:id equation) :values clobbered-inputs}))
-             (-> state
-                 (update :inputs into (remove (set inputs) new-inputs))
-                 (update :available into input-set)
-                 (update :available into (:results equation))
-                 (update :definitions into (:results equation)))))
-         {:inputs [] :available #{} :definitions #{}}
-         equations)
-        unavailable-outputs (remove available outputs)]
-    (when (seq unavailable-outputs)
-      (fail! :structured-control-unavailable-output
-             "mixed program outputs must be inputs or produced values"
-             {:outputs (vec outputs) :unavailable (vec unavailable-outputs)}))
-    {:inputs inputs :outputs (vec outputs)}))
+  {:inputs (program/infer-inputs equations)
+   :outputs (vec outputs)})
 
 (defn- value-types
   [values shape?]

--- a/test/raster/compiler/ir/parallel_program_test.clj
+++ b/test/raster/compiler/ir/parallel_program_test.clj
@@ -13,6 +13,30 @@
                                        {:target-device :cpu:0 :dtype :double
                                         :array-types {'values :double}})))
 
+(defn- dataflow-equation
+  [id operands results]
+  (program/->ProgramEquation id [:test id] nil (vec operands) (vec results) nil [:test]
+                             #{} {} {}))
+
+(defn- dataflow-program
+  [inputs equations outputs]
+  (let [ids (set (concat inputs outputs (mapcat :operands equations) (mapcat :results equations)))
+        value (av/tensor {:dtype :int :shape []})]
+    (program/make {:dialect :test
+                   :values (zipmap ids (repeat value))
+                   :inputs inputs
+                   :equations equations
+                   :outputs outputs
+                   :operation? #{:test}})))
+
+(defn- reason-of
+  [thunk]
+  (try
+    (thunk)
+    nil
+    (catch clojure.lang.ExceptionInfo exception
+      (:reason (ex-data exception)))))
+
 (deftest segops-are-first-class-typed-equations
   (let [p (lowered-program)
         equation (first (:equations p))]
@@ -89,3 +113,41 @@
     (is (nil? (:algorithm equation)))
     (is (seq (:operations equation)))
     (is (= [:binding 'total] (:site equation)))))
+
+(deftest parallel-program-enforces-ordered-logical-ssa
+  (testing "external inputs and earlier results are the only available operands"
+    (is (= :parallel-program-use-before-definition
+           (reason-of #(dataflow-program
+                        '[input]
+                        [(dataflow-equation 'first '[later] '[middle])
+                         (dataflow-equation 'second '[input] '[later])]
+                        '[middle])))))
+  (testing "results cannot clobber a program input or an earlier result"
+    (is (= :parallel-program-result-redefinition
+           (reason-of #(dataflow-program
+                        '[input]
+                        [(dataflow-equation 'clobber '[input] '[input])]
+                        '[input]))))
+    (is (= :parallel-program-result-redefinition
+           (reason-of #(dataflow-program
+                        '[input]
+                        [(dataflow-equation 'first '[input] '[result])
+                         (dataflow-equation 'second '[result] '[result])]
+                        '[result])))))
+  (testing "outputs must be available at the end of the program"
+    (is (= :parallel-program-unavailable-output
+           (reason-of #(dataflow-program
+                        '[input]
+                        [(dataflow-equation 'equation '[input] '[result])]
+                        '[missing])))))
+  (testing "pass-through outputs and unused inputs/results remain legal"
+    (is (program/parallel-program?
+         (dataflow-program
+          '[input unused]
+          [(dataflow-equation 'equation '[input] '[unused-result])]
+          '[input])))))
+
+(deftest external-input-inference-preserves-first-use-order
+  (let [equations [(dataflow-equation 'first '[z a] '[x])
+                   (dataflow-equation 'second '[x b a] '[y])]]
+    (is (= '[z a b] (program/infer-inputs equations)))))

--- a/test/raster/compiler/passes/parallel/structured_control_route_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_route_test.clj
@@ -142,7 +142,7 @@
                                      (* 2.0 (clojure.core/aget u k)))]
                 'u)
         decomposition (frontend/form->structured-loop source options)]
-    (is (= :structured-control-use-before-definition
+    (is (= :parallel-program-result-redefinition
            (reason-of #(route/program-envelope decomposition options))))))
 
 (deftest algorithm-kind-and-operation-kind-must-remain-paired


### PR DESCRIPTION
## Summary
- enforce use-before-definition, fresh logical results, and available program outputs in the shared ParallelProgram validator
- add first-use-ordered external input inference for program constructors
- remove duplicate structured-control dataflow checks and rely on the common IR invariant
- cover forward uses, input/result clobbering, unavailable outputs, pass-through values, and input ordering

## Validation
- focused ParallelProgram, structured route, TypedSOAC route, SegOp boundary, and SegOp consumption suite: 71 tests, 454 assertions
- cljfmt check on all touched files