### PR TITLE
Route structured control through the public scheduler

### DIFF
--- a/src/raster/compiler/ir/dialects.clj
+++ b/src/raster/compiler/ir/dialects.clj
@@ -22,6 +22,7 @@
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as soac-dialect]
+            [raster.compiler.passes.parallel.structured-control-route :as structured-route]
             [raster.compiler.core.util :as util]
             [clojure.set :as set]))
 
@@ -510,6 +511,25 @@
     (catch clojure.lang.ExceptionInfo e
       {:fail :segop-program :details (ex-data e) :message (.getMessage e)})))
 
+(defn valid-scheduled-program?
+  [value]
+  (or (valid-segop-program? value)
+      (structured-route/valid-scheduled-program? value)))
+
+(defn validate-scheduled-program
+  [value]
+  (cond
+    (valid-segop-program? value) :ok
+    (structured-route/valid-scheduled-program? value) :ok
+    :else {:fail :scheduled-parallel-program
+           :segop (validate-segop-program value)
+           :structured-control
+           (try
+             (structured-route/validate-scheduled-program! value)
+             :ok
+             (catch clojure.lang.ExceptionInfo exception
+               {:details (ex-data exception) :message (.getMessage exception)}))}))
+
 (defn valid-typed-soac-program?
   [value]
   (try
@@ -532,11 +552,14 @@
 
 (defn valid-source-or-typed-soac?
   [value]
-  (or (valid-let*-ordered? value) (valid-typed-soac-program? value)))
+  (or (valid-let*-ordered? value)
+      (valid-typed-soac-program? value)
+      (structured-route/valid-typed-program? value)))
 
 (defn validate-source-or-typed-soac
   [value]
-  (if (valid-typed-soac-program? value)
+  (if (or (valid-typed-soac-program? value)
+          (structured-route/valid-typed-program? value))
     :ok
     (validate-let*-ordered value)))
 
@@ -564,7 +587,7 @@
    :par-fused        [valid-let*-ordered? validate-let*-ordered]
    :soac-fused       [valid-source-or-typed-soac? validate-source-or-typed-soac]
    :materialized     [valid-source-or-typed-soac? validate-source-or-typed-soac]
-   :segop-lowered    [valid-segop-program? validate-segop-program]
+   :segop-lowered    [valid-scheduled-program? validate-scheduled-program]
    :compound-detected [valid-source-or-typed-soac? validate-source-or-typed-soac]
    :gpu-planned      [valid-let*-ordered? validate-let*-ordered]
    :dtype-remapped   [valid-let*-ordered? validate-let*-ordered]

--- a/src/raster/compiler/passes/parallel/structured_control_route.clj
+++ b/src/raster/compiler/passes/parallel/structured_control_route.clj
@@ -13,6 +13,7 @@
             [raster.compiler.ir.structured-control :as control]
             [raster.compiler.ir.structured-control-schedule :as schedule]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
+            [raster.compiler.passes.parallel.structured-control-frontend :as frontend]
             [raster.compiler.passes.parallel.structured-control-lower :as lower]
             [raster.compiler.passes.parallel.typed-soac-frontend :as typed-frontend]
             [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]
@@ -75,6 +76,38 @@
 (defn- scheduled-operation?
   [operation]
   (or (schedule/scheduled-loop? operation) (segop/segop-node? operation)))
+
+(declare fail!)
+
+(defn validate-typed-program!
+  "Validate the exact mixed typed algorithm union admitted by this route."
+  [parallel-program]
+  (when-not (= :typed-parallel (:dialect parallel-program))
+    (fail! :structured-control-program-dialect
+           "typed structured-control routing requires :typed-parallel"
+           {:dialect (:dialect parallel-program)}))
+  (program/validate! parallel-program typed-operation? typed-algorithm-boundary?))
+
+(defn valid-typed-program?
+  [parallel-program]
+  (try
+    (boolean (validate-typed-program! parallel-program))
+    (catch clojure.lang.ExceptionInfo _ false)))
+
+(defn validate-scheduled-program!
+  "Validate the exact scheduled loop/SegOp union admitted by this route."
+  [parallel-program]
+  (when-not (= :scheduled-parallel (:dialect parallel-program))
+    (fail! :structured-control-program-dialect
+           "scheduled structured-control routing requires :scheduled-parallel"
+           {:dialect (:dialect parallel-program)}))
+  (program/validate! parallel-program scheduled-operation? scheduled-algorithm-boundary?))
+
+(defn valid-scheduled-program?
+  [parallel-program]
+  (try
+    (boolean (validate-scheduled-program! parallel-program))
+    (catch clojure.lang.ExceptionInfo _ false)))
 
 (defn- merge-values
   [left right]
@@ -173,11 +206,34 @@
        :operation? typed-operation?
        :algorithm? typed-algorithm-boundary?}))))
 
+(defn attempt
+  "Attempt the complete structured-control semantic route.
+
+   Absence means the source is outside the generic counted-loop shape. An unsupported post-loop
+   continuation is an explicit coverage decline and leaves the caller free to preserve the
+   original source; contradictions after certification still escape."
+  [source options]
+  (when-let [decomposition (frontend/form->structured-loop source options)]
+    (try
+      (let [parallel-program (program-envelope decomposition options)
+            equations (:equations parallel-program)]
+        {:program parallel-program
+         :stats {:route :typed-structured-control
+                 :typed-validated true
+                 :structured-loop-equations
+                 (count (filter #(control/loop-program? (:algorithm %)) equations))
+                 :typed-soac-equations
+                 (count (filter #(soac/program-form? (:algorithm %)) equations))}})
+      (catch clojure.lang.ExceptionInfo exception
+        (if (= :structured-control-unsupported-suffix (:reason (ex-data exception)))
+          {:declined (select-keys (ex-data exception) [:reason :suffix-bindings :outer-body])}
+          (throw exception))))))
+
 (defn schedule-program
   "Schedule every typed-control equation through the ordinary loop-body SOAC vertical."
   [parallel-program opts]
   (let [parallel-program
-        (program/validate! parallel-program typed-operation? typed-algorithm-boundary?)
+        (validate-typed-program! parallel-program)
         {:keys [equations values]}
         (reduce
          (fn [{:keys [equations values]} equation]
@@ -219,17 +275,18 @@
                   :values (merge-values values (:values scheduled))}))))
          {:equations [] :values (:values parallel-program)}
          (:equations parallel-program))]
-    (program/make
-     {:dialect :scheduled-parallel
-      :source (:source parallel-program)
-      :values values
-      :inputs (:inputs parallel-program)
-      :equations equations
-      :outputs (:outputs parallel-program)
-      :effects (:effects parallel-program)
-      :diagnostics (:diagnostics parallel-program)
-      :provenance (assoc (:provenance parallel-program)
-                         :target-dialect :scheduled-parallel)
-      :attributes (:attributes parallel-program)
-      :operation? scheduled-operation?
-      :algorithm? scheduled-algorithm-boundary?})))
+    (validate-scheduled-program!
+     (program/make
+      {:dialect :scheduled-parallel
+       :source (:source parallel-program)
+       :values values
+       :inputs (:inputs parallel-program)
+       :equations equations
+       :outputs (:outputs parallel-program)
+       :effects (:effects parallel-program)
+       :diagnostics (:diagnostics parallel-program)
+       :provenance (assoc (:provenance parallel-program)
+                          :target-dialect :scheduled-parallel)
+       :attributes (:attributes parallel-program)
+       :operation? scheduled-operation?
+       :algorithm? scheduled-algorithm-boundary?}))))

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -42,6 +42,7 @@
             [raster.compiler.passes.parallel.par-fusion :as par-fusion]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.soac-graph :as soac-graph]
+            [raster.compiler.passes.parallel.structured-control-route :as structured-route]
             [raster.compiler.passes.parallel.typed-soac-route :as typed-soac-route]
             [raster.compiler.backend.gpu.entry :as gpu-entry]
             [raster.compiler.backend.gpu.par-opencl :as par-opencl]
@@ -770,6 +771,32 @@
       (core-hw/abstract-machine (core-hw/descriptor-for target-device))
       (catch Throwable _ nil))))
 
+(defn- semantic-program-attempt
+  "Try the finite semantic-program variants in specificity order.
+
+   Structured control is currently GPU-only until the equation-first JVM schedule lands. A
+   coverage decline preserves the original source and remains visible beside any later TypedSOAC
+   decline; certified contradictions are never converted into fallback."
+  [source opts abstract-machine]
+  (let [common {:dtype (:dtype opts)
+                :values (:values opts)
+                :array-types (:array-types opts)
+                :scalar-types (:scalar-types opts)
+                :abstract-machine abstract-machine}
+        structured (when (device/gpu-target? (:target-device opts))
+                     (structured-route/attempt source common))]
+    (if (:program structured)
+      structured
+      (let [typed (typed-soac-route/attempt
+                   source (:dtype opts) (:array-types opts)
+                   {:resident-reductions? (true? (:resident-reductions? opts))
+                    :scalar-types (:scalar-types opts)
+                    :values (:values opts)
+                    :abstract-machine abstract-machine})]
+        (cond-> (or typed {})
+          (:declined structured)
+          (assoc :structured-control-declined (:declined structured)))))))
+
 (defn- pass-soac-fuse
   "SOAC graph-based fusion: vertical (map→map, map→reduce, map→scan),
   horizontal (independent same-bound maps), iterated to fixpoint.
@@ -778,13 +805,9 @@
   [form opts]
   (if (form/binding-form? form)
     (let [am (abstract-machine-for-target (:target-device opts))
-          typed (typed-soac-route/attempt
-                 form (:dtype opts) (:array-types opts)
-                 {:resident-reductions? (true? (:resident-reductions? opts))
-                  :scalar-types (:scalar-types opts)
-                  :abstract-machine am})]
-      (if (:program typed)
-        {:form (:program typed) :stats (:stats typed)}
+          semantic (semantic-program-attempt form opts am)]
+      (if (:program semantic)
+        {:form (:program semantic) :stats (:stats semantic)}
         (let [[let-sym bindings-vec & body-exprs] form
               pairs (vec (partition 2 bindings-vec))
               nodes (soac/let-bindings->nodes pairs)
@@ -801,23 +824,26 @@
               new-bindings (vec (mapcat identity new-pairs))]
           {:form (list* let-sym new-bindings body-exprs)
            :stats (cond-> stats
-                    (:declined typed) (assoc :typed-soac-declined (:declined typed)))})))
+                    (:declined semantic)
+                    (assoc :typed-soac-declined (:declined semantic))
+                    (:structured-control-declined semantic)
+                    (assoc :typed-structured-control-declined
+                           (:structured-control-declined semantic)))})))
     ;; A bare top-level parallel expression has no binding site for the direct SSA front end.
     ;; Normalize it only HERE, after fixpoint/type analysis, and retain the wrapper only when the
     ;; typed route accepts it. Unsupported forms must reach compatibility lowering unchanged.
     (let [source (top-level-binding-form form)
           am (abstract-machine-for-target (:target-device opts))
-          typed (typed-soac-route/attempt
-                 source (:dtype opts) (:array-types opts)
-                 {:resident-reductions? (true? (:resident-reductions? opts))
-                  :scalar-types (:scalar-types opts)
-                  :abstract-machine am})]
-      (if (:program typed)
-        {:form (:program typed) :stats (:stats typed)}
+          semantic (semantic-program-attempt source opts am)]
+      (if (:program semantic)
+        {:form (:program semantic) :stats (:stats semantic)}
         (let [fallback (par-fusion/par-fusion-pass form)]
           (cond-> fallback
-            (:declined typed)
-            (assoc-in [:stats :typed-soac-declined] (:declined typed))))))))
+            (:declined semantic)
+            (assoc-in [:stats :typed-soac-declined] (:declined semantic))
+            (:structured-control-declined semantic)
+            (assoc-in [:stats :typed-structured-control-declined]
+                      (:structured-control-declined semantic))))))))
 
 (defn- register-gpu-kernels!
   "Register generated GPU kernels eagerly so they're available at eval time.
@@ -895,7 +921,17 @@
   "Lower par forms to typed equations in a first-class SegOp ParallelProgram.
   (=> :compound-detected :segop-lowered)"
   [form opts]
-  (segop-lower/segop-lower-pass form opts))
+  (if (and (parallel-program/parallel-program? form)
+           (= :typed-parallel (:dialect form)))
+    (let [scheduled (structured-route/schedule-program form opts)
+          equations (:equations scheduled)]
+      {:form scheduled
+       :stats {:structured-loops-scheduled
+               (count (filter #(get-in % [:attributes :graph-dialect]) equations))
+               :typed-soac-reused
+               (count (filter #(= :typed-soac
+                                  (get-in % [:attributes :algorithm-dialect])) equations))}})
+    (segop-lower/segop-lower-pass form opts)))
 
 (defn- pass-compound-detect
   "Compound kernel detection: finds dotimes loops with ≥2 par forms
@@ -1080,18 +1116,23 @@
    validated TypedSOAC algorithm and are scheduled exactly once before backend emission."
   [source {:keys [dtype array-types scalar-types target-device] :as opts}]
   (let [source (top-level-binding-form source)
-        typed (typed-soac-route/attempt source dtype array-types
-                                        {:scalar-types scalar-types
-                                         :abstract-machine
-                                         (abstract-machine-for-target target-device)})
+        typed (semantic-program-attempt source opts
+                                        (abstract-machine-for-target target-device))
         semantic (or (:program typed) source)
-        scheduled (segop-lower/segop-lower-pass
-                   semantic (assoc opts :dtype dtype :target-device target-device))]
+        scheduled (pass-segop-lower semantic
+                                    (assoc opts :dtype dtype :target-device target-device))]
     (update scheduled :stats merge
             (cond-> {:parallel-scheduling :shared}
-              (:program typed) (assoc :source-dialect :typed-soac
-                                      :typed-soac (:stats typed))
-              (:declined typed) (assoc :typed-soac-declined (:declined typed))))))
+              (:program typed)
+              (assoc :source-dialect (get-in typed [:stats :route])
+                     :semantic-program (:stats typed))
+              (= :typed-soac (get-in typed [:stats :route]))
+              (assoc :typed-soac (:stats typed))
+              (:declined typed)
+              (assoc :typed-soac-declined (:declined typed))
+              (:structured-control-declined typed)
+              (assoc :typed-structured-control-declined
+                     (:structured-control-declined typed))))))
 
 ;; ================================================================
 ;; Mode configurations (declarative pass vectors)

--- a/src/raster/compiler/report.clj
+++ b/src/raster/compiler/report.clj
@@ -116,6 +116,7 @@
               :placements (counter soac-stats :placements)}
      :lowering {:segops (counter segop-stats :segops-lowered)
                 :kernel-graphs (counter segop-stats :kernel-graphs-lowered)
+                :structured-loops (counter segop-stats :structured-loops-scheduled)
                 :typed-reused (counter segop-stats :typed-soac-reused)
                 :typed-scalar-equations (counter segop-stats :typed-scalar-equations)
                 :backend-reused (counter backend-stats :segop-reused)

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -5,7 +5,8 @@
  {:dense-relu-jvm
   {:route {:backend :simd :source-dialect :typed-soac :typed-validated true :declines {}}
    :fusion {:vertical 1 :horizontal 0 :iterations 2 :placements 0}
-   :lowering {:segops 2 :kernel-graphs 0 :typed-reused 2 :typed-scalar-equations 4
+   :lowering {:segops 2 :kernel-graphs 0 :structured-loops 0
+              :typed-reused 2 :typed-scalar-equations 4
               :backend-reused 2 :backend-relowered 0 :fallback 0}
    :emission {:kernel-count 0 :targets [] :strategies [] :fallback-reasons [] :declines {}}}
 
@@ -14,7 +15,8 @@
            :declines {[:backend-applied-stats :typed-contraction-dispatch-declines
                        :typed-contraction-dispatch-dynamic-scalar] 1}}
    :fusion {:vertical 0 :horizontal 0 :iterations 1 :placements 0}
-   :lowering {:segops 1 :kernel-graphs 0 :typed-reused 1 :typed-scalar-equations 0
+   :lowering {:segops 1 :kernel-graphs 0 :structured-loops 0
+              :typed-reused 1 :typed-scalar-equations 0
               :backend-reused 1 :backend-relowered 0 :fallback 0}
    :emission {:kernel-count 1 :targets [:opencl-c] :strategies [:portable-segred]
               :fallback-reasons [:symbolic-dims]
@@ -25,7 +27,8 @@
   {:route {:backend :opencl :source-dialect :typed-soac :typed-validated true
            :declines {}}
    :fusion {:vertical 0 :horizontal 0 :iterations 1 :placements 0}
-   :lowering {:segops 1 :kernel-graphs 0 :typed-reused 1 :typed-scalar-equations 1
+   :lowering {:segops 1 :kernel-graphs 0 :structured-loops 0
+              :typed-reused 1 :typed-scalar-equations 1
               :backend-reused 1 :backend-relowered 0 :fallback 0}
    :emission {:kernel-count 1 :targets [:opencl-c] :strategies []
               :fallback-reasons [] :declines {}}}
@@ -34,7 +37,8 @@
   {:route {:backend :opencl :source-dialect :typed-soac :typed-validated true
            :declines {}}
    :fusion {:vertical 0 :horizontal 2 :iterations 3 :placements 0}
-   :lowering {:segops 7 :kernel-graphs 0 :typed-reused 7 :typed-scalar-equations 12
+   :lowering {:segops 7 :kernel-graphs 0 :structured-loops 0
+              :typed-reused 7 :typed-scalar-equations 12
               :backend-reused 7 :backend-relowered 0 :fallback 0}
    :emission {:kernel-count 7 :targets [:opencl-c] :strategies []
               :fallback-reasons [] :declines {}}}
@@ -43,7 +47,8 @@
   {:route {:backend :simd :source-dialect :typed-soac :typed-validated true
            :declines {}}
    :fusion {:vertical 0 :horizontal 0 :iterations 1 :placements 0}
-   :lowering {:segops 1 :kernel-graphs 0 :typed-reused 1 :typed-scalar-equations 1
+   :lowering {:segops 1 :kernel-graphs 0 :structured-loops 0
+              :typed-reused 1 :typed-scalar-equations 1
               :backend-reused 1 :backend-relowered 0 :fallback 0}
    :emission {:kernel-count 0 :targets [] :strategies []
               :fallback-reasons [] :declines {}}}

--- a/test/raster/compiler/head_layout_typed_test.clj
+++ b/test/raster/compiler/head_layout_typed_test.clj
@@ -12,7 +12,8 @@
               :typed-validated true :declines []}
              (:route compiler-report))
           (str (:name (meta operation)) " route"))
-      (is (= {:segops 1 :kernel-graphs 0 :typed-reused 1 :typed-scalar-equations 1
+      (is (= {:segops 1 :kernel-graphs 0 :structured-loops 0
+              :typed-reused 1 :typed-scalar-equations 1
               :backend-reused 1 :backend-relowered 0 :fallback 0}
              (:lowering compiler-report))
           (str (:name (meta operation)) " lowering"))

--- a/test/raster/compiler/passes/parallel/structured_control_route_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_route_test.clj
@@ -1,13 +1,15 @@
 (ns raster.compiler.passes.parallel.structured-control-route-test
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.dialects :as dialects]
             [raster.compiler.ir.parallel-program :as program]
             [raster.compiler.ir.soac-dialect :as soac]
             [raster.compiler.ir.structured-control :as control]
             [raster.compiler.ir.structured-control-schedule :as schedule]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.structured-control-frontend :as frontend]
-            [raster.compiler.passes.parallel.structured-control-route :as route]))
+            [raster.compiler.passes.parallel.structured-control-route :as route]
+            [raster.compiler.pipeline :as pipeline]))
 
 (defn- loop-decomposition
   []
@@ -158,3 +160,44 @@
     (is (= :parallel-program-algorithm
            (reason-of #(route/schedule-program malformed
                                                {:target-device :cpu:0 :dtype :double}))))))
+
+(deftest public-scheduler-selects-the-structured-semantic-program
+  (let [initial (av/tensor {:dtype :double :shape ['extent]
+                            :representation {:kind :plain}})
+        options {:dtype :double
+                 :target-device :ocl:0
+                 :values {'u0 initial 'steps (av/tensor {:dtype :long :shape []})}
+                 :scalar-types {'steps :long}}
+        attempted (route/attempt (mixed-source) options)
+        scheduled (pipeline/schedule-parallel-form (mixed-source) options)]
+    (is (= :typed-structured-control (get-in attempted [:stats :route])))
+    (is (dialects/valid-source-or-typed-soac? (:program attempted)))
+    (is (= :scheduled-parallel (:dialect (:form scheduled))))
+    (is (dialects/valid-scheduled-program? (:form scheduled)))
+    (is (= :typed-structured-control (get-in scheduled [:stats :source-dialect])))
+    (is (= 1 (get-in scheduled [:stats :structured-loops-scheduled])))
+    (is (= 2 (count (:equations (:form scheduled)))))))
+
+(deftest structured-attempt-exposes-a-coverage-decline
+  (let [initial (av/tensor {:dtype :double :shape ['extent]
+                            :representation {:kind :plain}})
+        options {:dtype :double
+                 :target-device :ocl:0
+                 :values {'u0 initial 'steps (av/tensor {:dtype :long :shape []})}
+                 :scalar-types {'steps :long}}
+        source (source-with-suffix '[unsupported (java.lang.System/gc)] 'unsupported)
+        attempted (route/attempt source options)]
+    (is (nil? (:program attempted)))
+    (is (= :structured-control-unsupported-suffix
+           (get-in attempted [:declined :reason])))))
+
+(deftest cpu-public-scheduling-does-not-enter-the-gpu-structured-route
+  (let [initial (av/tensor {:dtype :double :shape ['extent]
+                            :representation {:kind :plain}})
+        options {:dtype :double
+                 :target-device :cpu:0
+                 :values {'u0 initial 'steps (av/tensor {:dtype :long :shape []})}
+                 :scalar-types {'steps :long}}
+        scheduled (pipeline/schedule-parallel-form (mixed-source) options)]
+    (is (not= :scheduled-parallel (:dialect (:form scheduled))))
+    (is (not= :typed-structured-control (get-in scheduled [:stats :source-dialect])))))

--- a/test/raster/compiler/passes/parallel/typed_scalar_fold_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_scalar_fold_test.clj
@@ -103,7 +103,7 @@
               (double-array [0.5 0.5])
               (double-array [0.25])
               (double-array [1.0 -1.0])]]
-    (is (= {:segops 2 :kernel-graphs 0 :typed-reused 2
+    (is (= {:segops 2 :kernel-graphs 0 :structured-loops 0 :typed-reused 2
             :typed-scalar-equations 4 :backend-reused 2
             :backend-relowered 0 :fallback 0}
            (:lowering report)))

--- a/test/raster/compiler/report_test.clj
+++ b/test/raster/compiler/report_test.clj
@@ -9,6 +9,7 @@
           :soac-fused-stats {:route :typed-soac :typed-validated true
                              :vertical 2 :horizontal 1 :iterations 3}
           :segop-lowered-stats {:segops-lowered 2 :kernel-graphs-lowered 1
+                                :structured-loops-scheduled 1
                                 :typed-soac-reused 3 :typed-scalar-equations 4}
           :backend-applied-stats {:segop-reused 2 :segop-relowered 1 :fallback 0
                                   :typed-contraction-dispatch-declines [{}]
@@ -24,7 +25,8 @@
            (:route normalized)))
     (is (= {:vertical 2 :horizontal 1 :iterations 3 :placements 0}
            (:fusion normalized)))
-    (is (= {:segops 2 :kernel-graphs 1 :typed-reused 3 :typed-scalar-equations 4
+    (is (= {:segops 2 :kernel-graphs 1 :structured-loops 1
+            :typed-reused 3 :typed-scalar-equations 4
             :backend-reused 2 :backend-relowered 1 :fallback 0}
            (:lowering normalized)))
     (is (= {:kernel-count 1 :targets [:opencl-c] :strategies [:portable]

--- a/test/raster/quant/kernels_k_test.clj
+++ b/test/raster/quant/kernels_k_test.clj
@@ -232,7 +232,8 @@
             :declines []}
            (:route projection-report))
         "Q4_K uses the validated typed route rather than compatibility lowering")
-    (is (= {:segops 1 :kernel-graphs 0 :typed-reused 1 :typed-scalar-equations 1
+    (is (= {:segops 1 :kernel-graphs 0 :structured-loops 0
+            :typed-reused 1 :typed-scalar-equations 1
             :backend-reused 1 :backend-relowered 0 :fallback 0}
            (:lowering projection-report))
         "the scheduled SegMap is preserved through OpenCL emission")
@@ -256,10 +257,12 @@
                         :typed-validated true :declines []}]
     (is (= expected-route (:route q6-report)))
     (is (= expected-route (:route i8-report)))
-    (is (= {:segops 1 :kernel-graphs 0 :typed-reused 1 :typed-scalar-equations 0
+    (is (= {:segops 1 :kernel-graphs 0 :structured-loops 0
+            :typed-reused 1 :typed-scalar-equations 0
             :backend-reused 1 :backend-relowered 0 :fallback 0}
            (:lowering q6-report)))
-    (is (= {:segops 1 :kernel-graphs 0 :typed-reused 1 :typed-scalar-equations 1
+    (is (= {:segops 1 :kernel-graphs 0 :structured-loops 0
+            :typed-reused 1 :typed-scalar-equations 1
             :backend-reused 1 :backend-relowered 0 :fallback 0}
            (:lowering i8-report)))
     (is (= '[[[bsums :int] [ds :float] [sc :byte] [wp :int] [xp :int]


### PR DESCRIPTION
## Summary
- select the generic structured-control semantic route before ordinary TypedSOAC on GPU targets
- schedule typed loop and suffix equations through the public scheduling entry and ordinary pipeline pass
- validate typed/scheduled mixed ParallelPrograms at pipeline dialect boundaries
- expose unsupported suffixes as counted coverage declines and leave CPU routing unchanged
- report structured-loop scheduling explicitly

## Validation
- focused route, pipeline, TypedSOAC, ParallelProgram, and report suite: 81 tests, 482 assertions
- cljfmt check on all touched files

## Scope
This lands semantic entry and scheduling only. Equation-first target emission and the stage-once whole-program executor follow in separate stacked PRs before ordinary compile-aot claims structured-loop execution.