### PR TITLE
Share scheduled equation graph derivation

### DIFF
--- a/src/raster/compiler/ir/structured_control_schedule.clj
+++ b/src/raster/compiler/ir/structured_control_schedule.clj
@@ -1,12 +1,11 @@
 (ns raster.compiler.ir.structured-control-schedule
   "Checked schedule value for a typed sequential fixpoint."
-  (:require [clojure.set :as set]
-            [raster.compiler.ir.kernel-graph :as graph]
-            [raster.compiler.ir.kernel-launch :as launch]
+  (:require [raster.compiler.ir.kernel-graph :as graph]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as soac]
-            [raster.compiler.ir.structured-control :as control]))
+            [raster.compiler.ir.structured-control :as control]
+            [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]))
 
 (defrecord ScheduledStructuredLoop [algorithm body graph strategy effects provenance attributes])
 
@@ -20,91 +19,14 @@
   [reason message data]
   (throw (ex-info message (assoc data :reason reason :ir :structured-control-schedule))))
 
-(defn- value-elements
-  [value]
-  (let [shape (:shape value)]
-    (cond
-      (empty? shape) 1
-      (= 1 (count shape)) (first shape)
-      :else (apply launch/product shape))))
-
-(defn- physical-body-outputs
-  [algorithm]
-  (let [facts (soac/facts algorithm)
-        producer (into {}
-                       (mapcat (fn [equation]
-                                 (map vector (nth equation 2)
-                                      (soac/physical-results facts equation))))
-                       (soac/equations algorithm))]
-    (mapv (fn [result]
-            (or (get producer result)
-                (fail! :structured-loop-result-storage
-                       "structured loop body result has no physical storage identity"
-                       {:result result})))
-          (soac/outputs algorithm))))
-
-(defn- external-inputs
-  [operations]
-  (:inputs
-   (reduce (fn [{:keys [initialized] :as state} operation]
-             (let [reads (segop/operation-inputs operation)
-                   writes (segop/operation-outputs operation)]
-               (-> state
-                   (update :inputs set/union (set/difference reads initialized))
-                   (update :initialized set/union writes))))
-           {:inputs #{} :initialized #{}}
-           operations)))
-
-(defn- storage-spec
-  [values id]
-  (let [value (get values id)]
-    (when-not value
-      (fail! :structured-loop-storage-value
-             "scheduled structured loop storage lacks an AbstractValue"
-             {:value id}))
-    {:dtype (:dtype value)
-     :elements (value-elements value)
-     :memory-space (or (:memory-space value) :device)}))
-
 (defn iteration-graph
   "Derive the one-iteration KernelGraph solely from a loop algorithm and scheduled SegOp body."
   [algorithm scheduled]
-  (let [algorithm (control/validate! algorithm)
-        scheduled (parallel-program/validate!
-                   scheduled segop/segop-node?
-                   (fn [equation typed-algorithm]
-                     (and (= typed-algorithm (soac/validate! typed-algorithm))
-                          (= (:operands equation) (:inputs (soac/facts typed-algorithm)))
-                          (= (:results equation) (soac/outputs typed-algorithm)))))
-        operations (vec (mapcat :operations (:equations scheduled)))
-        _ (when (empty? operations)
-            (fail! :structured-loop-empty-schedule
-                   "structured loop body requires at least one scheduled parallel operation" {}))
-        _ (when (some #(get-in % [:attributes :host-only]) (:equations scheduled))
-            (fail! :structured-loop-host-scalar
-                   "host scalar equations inside structured control require explicit lowering" {}))
-        inputs (external-inputs operations)
-        outputs (set (physical-body-outputs (control/body algorithm)))
-        operation-values (reduce set/union #{}
-                                 (map #(set/union (segop/operation-inputs %)
-                                                  (segop/operation-outputs %))
-                                      operations))
-        temporary-ids (set/difference operation-values inputs outputs)
-        values (:values scheduled)
-        buffer-specs (into {}
-                           (map (fn [id] [id (storage-spec values id)]))
-                           (set/union inputs outputs temporary-ids))]
-    (graph/from-segops
-     operations
-     {:inputs inputs
-      :outputs outputs
-      :temporaries (select-keys buffer-specs temporary-ids)
-      :buffer-specs buffer-specs
-      :dtype (:dtype (first (vals buffer-specs)))
-      :effects {:semantic (:effects (control/facts algorithm))}
-      :provenance {:source-dialect :typed-structured-control
-                   :algorithm-dialect :typed-soac
-                   :schedule-dialect :segop}
+  (let [algorithm (control/validate! algorithm)]
+    (equation-graph/make
+     (control/body algorithm) scheduled
+     {:effects {:semantic (:effects (control/facts algorithm))}
+      :provenance {:source-dialect :typed-structured-control}
       :attributes {:control :sequential-fixpoint
                    :execution :host-repetition}})))
 

--- a/src/raster/compiler/passes/parallel/scheduled_equation_graph.clj
+++ b/src/raster/compiler/passes/parallel/scheduled_equation_graph.clj
@@ -1,0 +1,124 @@
+(ns raster.compiler.passes.parallel.scheduled-equation-graph
+  "Derive one target-neutral KernelGraph from a scheduled TypedSOAC program.
+
+   This is the shared graph boundary for an ordinary equation and for one iteration of structured
+   control. It consumes only the retained functional algorithm, ordered SegOps, and AbstractValue
+   contracts; source spelling and operation-family names play no role."
+  (:require [clojure.set :as set]
+            [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.parallel-program :as program]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.ir.soac-dialect :as soac]))
+
+(defn- fail!
+  [reason message data]
+  (throw (ex-info message (assoc data :reason reason :pass :scheduled-equation-graph))))
+
+(defn- value-elements
+  [value]
+  (let [shape (:shape value)]
+    (cond
+      (empty? shape) 1
+      (= 1 (count shape)) (first shape)
+      :else (apply launch/product shape))))
+
+(defn- physical-outputs
+  [algorithm]
+  (let [facts (soac/facts algorithm)
+        producers (into {}
+                        (mapcat (fn [equation]
+                                  (map vector (nth equation 2)
+                                       (soac/physical-results facts equation))))
+                        (soac/equations algorithm))]
+    (mapv (fn [result]
+            (or (get producers result)
+                (fail! :scheduled-equation-result-storage
+                       "a scheduled result has no physical storage identity"
+                       {:result result})))
+          (soac/outputs algorithm))))
+
+(defn- external-inputs
+  [operations]
+  (:inputs
+   (reduce (fn [{:keys [initialized] :as state} operation]
+             (let [reads (segop/operation-inputs operation)
+                   writes (segop/operation-outputs operation)]
+               (-> state
+                   (update :inputs set/union (set/difference reads initialized))
+                   (update :initialized set/union writes))))
+           {:inputs #{} :initialized #{}}
+           operations)))
+
+(defn- storage-spec
+  [values id]
+  (let [value (get values id)]
+    (when-not value
+      (fail! :scheduled-equation-storage-value
+             "scheduled storage lacks an AbstractValue"
+             {:value id}))
+    {:dtype (:dtype value)
+     :elements (value-elements value)
+     :memory-space (or (:memory-space value) :device)}))
+
+(defn- algorithm-boundary?
+  [equation algorithm]
+  (and (= algorithm (soac/validate! algorithm))
+       (= (:operands equation) (:inputs (soac/facts algorithm)))
+       (= (:results equation) (soac/outputs algorithm))))
+
+(defn make
+  "Build a verified graph from `algorithm` and its fully scheduled SegOp ParallelProgram.
+
+   Optional facts describe the enclosing control/equation context without changing dataflow."
+  ([algorithm scheduled] (make algorithm scheduled {}))
+  ([algorithm scheduled {:keys [effects provenance attributes]
+                         :or {provenance {} attributes {}}}]
+   (let [algorithm (soac/validate! algorithm)
+         scheduled (program/validate! scheduled segop/segop-node? algorithm-boundary?)
+         _ (when-not (= :segop (:dialect scheduled))
+             (fail! :scheduled-equation-dialect
+                    "KernelGraph derivation requires a fully scheduled :segop program"
+                    {:dialect (:dialect scheduled)}))
+         retained-equations (vec (mapcat (comp soac/equations :algorithm)
+                                         (:equations scheduled)))
+         _ (when-not (and (= (soac/equations algorithm) retained-equations)
+                          (= (:inputs (soac/facts algorithm)) (:inputs scheduled))
+                          (= (soac/outputs algorithm) (:outputs scheduled)))
+             (fail! :scheduled-equation-algorithm
+                    "scheduled equations or program boundary differ from the retained algorithm"
+                    {:algorithm-inputs (:inputs (soac/facts algorithm))
+                     :scheduled-inputs (:inputs scheduled)
+                     :algorithm-outputs (soac/outputs algorithm)
+                     :scheduled-outputs (:outputs scheduled)}))
+         operations (vec (mapcat :operations (:equations scheduled)))
+         _ (when (empty? operations)
+             (fail! :scheduled-equation-empty
+                    "a KernelGraph requires at least one scheduled operation" {}))
+         _ (when (some #(get-in % [:attributes :host-only]) (:equations scheduled))
+             (fail! :scheduled-equation-host-scalar
+                    "host scalar equations require an explicit host schedule" {}))
+         inputs (external-inputs operations)
+         outputs (set (physical-outputs algorithm))
+         operation-values (reduce set/union #{}
+                                  (map #(set/union (segop/operation-inputs %)
+                                                   (segop/operation-outputs %))
+                                       operations))
+         temporary-ids (set/difference operation-values inputs outputs)
+         values (:values scheduled)
+         buffer-specs (into {}
+                            (map (fn [id] [id (storage-spec values id)]))
+                            (set/union inputs outputs temporary-ids))]
+     (graph/from-segops
+      operations
+      {:inputs inputs
+       :outputs outputs
+       :temporaries (select-keys buffer-specs temporary-ids)
+       :buffer-specs buffer-specs
+       :dtype (:dtype (first (vals buffer-specs)))
+       :effects (or effects {:semantic (:effects (soac/facts algorithm))})
+       :provenance (merge {:source-dialect :typed-soac
+                           :algorithm-dialect :typed-soac
+                           :schedule-dialect :segop}
+                          provenance)
+       :attributes attributes}))))

--- a/test/raster/compiler/passes/parallel/structured_control_route_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_route_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.dialects :as dialects]
+            [raster.compiler.ir.kernel-graph :as graph]
             [raster.compiler.ir.parallel-program :as program]
             [raster.compiler.ir.soac-dialect :as soac]
             [raster.compiler.ir.structured-control :as control]
@@ -9,6 +10,9 @@
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.structured-control-frontend :as frontend]
             [raster.compiler.passes.parallel.structured-control-route :as route]
+            [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
+            [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
             [raster.compiler.pipeline :as pipeline]))
 
 (defn- loop-decomposition
@@ -201,3 +205,23 @@
         scheduled (pipeline/schedule-parallel-form (mixed-source) options)]
     (is (not= :scheduled-parallel (:dialect (:form scheduled))))
     (is (not= :typed-structured-control (get-in scheduled [:stats :source-dialect])))))
+
+(deftest ordinary-suffix-equations-use-the-same-kernel-graph-builder
+  (let [initial (av/tensor {:dtype :double :shape ['extent]
+                            :representation {:kind :plain}})
+        options {:dtype :double
+                 :target-device :ocl:0
+                 :values {'u0 initial 'steps (av/tensor {:dtype :long :shape []})}
+                 :scalar-types {'steps :long}}
+        typed (:program (route/attempt (mixed-source) options))
+        algorithm (get-in typed [:equations 1 :algorithm])
+        scheduled (:form (segop-lower/segop-lower-pass
+                          (typed-route/program-envelope algorithm) options))
+        kernel-graph (equation-graph/make
+                      algorithm scheduled
+                      {:provenance {:source-dialect :mixed-suffix}})]
+    (is (= kernel-graph (graph/validate! kernel-graph)))
+    (is (= (vec (mapcat :operations (:equations scheduled)))
+           (mapv :operation (:nodes kernel-graph))))
+    (is (= :mixed-suffix (get-in kernel-graph [:provenance :source-dialect])))
+    (is (nil? (:source scheduled)))))


### PR DESCRIPTION
## Summary
- extract one source-independent TypedSOAC + SegOp → KernelGraph derivation pass
- make structured loop iteration graphs use that same checked builder
- verify exact retained equations, boundaries, AbstractValue storage, host-scalar exclusion, and SegOp dialect
- demonstrate an ordinary post-loop suffix equation uses the identical graph path

## Validation
- focused structured-control IR/lowering/routing and ParallelProgram suite: 23 tests, 123 assertions
- cljfmt check on all touched files