### PR TITLE
Certify emitted structured loops

### DIFF
--- a/src/raster/compiler/ir/emitted_structured_loop.clj
+++ b/src/raster/compiler/ir/emitted_structured_loop.clj
@@ -1,0 +1,62 @@
+(ns raster.compiler.ir.emitted-structured-loop
+  "Checked target emission of one ScheduledStructuredLoop.
+
+   The value pairs the exact semantic/scheduled loop with an emitted KernelGraph. It is the
+   operation carried by an equation-first target program before runtime buffers and scalar values
+   are bound into a StructuredLoopCall."
+  (:require [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.structured-control-schedule :as schedule]))
+
+(defrecord EmittedStructuredLoop [schedule graph provenance attributes])
+
+(defn emitted-loop?
+  [value]
+  (and value
+       (= "raster.compiler.ir.emitted_structured_loop.EmittedStructuredLoop"
+          (.getName (class value)))))
+
+(defn- fail!
+  [reason message data]
+  (throw (ex-info message (assoc data :reason reason :ir :emitted-structured-loop))))
+
+(defn validate!
+  [emitted-loop]
+  (when-not (emitted-loop? emitted-loop)
+    (fail! :emitted-structured-loop-type
+           "expected an EmittedStructuredLoop"
+           {:actual (type emitted-loop)}))
+  (let [{scheduled :schedule emitted :graph provenance :provenance attributes :attributes}
+        emitted-loop
+        scheduled (schedule/validate! scheduled)
+        emitted (graph/validate! emitted)]
+    (when-not (every? (comp artifact/kernel-artifact? :operation) (:nodes emitted))
+      (fail! :emitted-structured-loop-artifact
+             "emitted structured-loop graph requires only KernelArtifact nodes" {}))
+    (when-not (graph/dataflow-equivalent? (:graph scheduled) emitted)
+      (fail! :emitted-structured-loop-dataflow
+             "target emission changed the scheduled loop dataflow"
+             {:scheduled (graph/dataflow-contract (:graph scheduled))
+              :emitted (graph/dataflow-contract emitted)}))
+    (when-not (every? true?
+                      (map (fn [scheduled-node emitted-node]
+                             (= (:operation scheduled-node)
+                                (get-in emitted-node
+                                        [:operation :provenance :scheduled-operation])))
+                           (:nodes (:graph scheduled)) (:nodes emitted)))
+      (fail! :emitted-structured-loop-operation
+             "target emission changed a scheduled loop operation certificate" {}))
+    (doseq [[field value] [[:provenance provenance] [:attributes attributes]]]
+      (when-not (map? value)
+        (fail! :emitted-structured-loop-description
+               "emitted structured-loop descriptions must be maps"
+               {:field field :value value})))
+    emitted-loop))
+
+(defn make
+  ([scheduled emitted]
+   (make scheduled emitted {}))
+  ([scheduled emitted {:keys [provenance attributes]
+                       :or {provenance {} attributes {}}}]
+   (validate!
+    (->EmittedStructuredLoop scheduled emitted provenance attributes))))

--- a/src/raster/compiler/ir/structured_loop_call.clj
+++ b/src/raster/compiler/ir/structured_loop_call.clj
@@ -4,8 +4,8 @@
    The call owns no driver handles. It maps outer values to the emitted graph boundary and plans
    double-buffered carry rotation. A runtime may bind/replay each returned iteration through its
    ordinary KernelGraph machinery."
-  (:require [raster.compiler.ir.kernel-artifact :as artifact]
-            [raster.compiler.core.dtype :as dtype]
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.emitted-structured-loop :as emitted-loop]
             [raster.compiler.ir.kernel-graph :as graph]
             [raster.compiler.ir.structured-control :as control]
             [raster.compiler.ir.structured-control-schedule :as schedule]
@@ -114,21 +114,8 @@
          buffers :buffers scalars :scalars scratch :scratch outputs :outputs attributes :attributes}
         call
         scheduled (schedule/validate! scheduled)
-        emitted (graph/validate! emitted)]
-    (when-not (every? (comp artifact/kernel-artifact? :operation) (:nodes emitted))
-      (fail! :structured-loop-emitted-graph
-             "structured loop call requires a fully emitted KernelGraph" {}))
-    (when-not (and (graph/dataflow-equivalent? (:graph scheduled) emitted)
-                   (every? true?
-                           (map (fn [scheduled-node emitted-node]
-                                  (= (:operation scheduled-node)
-                                     (get-in emitted-node
-                                             [:operation :provenance
-                                              :scheduled-operation])))
-                                (:nodes (:graph scheduled)) (:nodes emitted))))
-      (fail! :structured-loop-emitted-graph
-             "emitted graph dataflow or operation certificates differ from the scheduled iteration"
-             {}))
+        emitted (graph/validate! emitted)
+        _ (emitted-loop/make scheduled emitted)]
     (when-not (and (integer? trip-count) (not (neg? trip-count)))
       (fail! :structured-loop-trip-count "resolved trip count must be non-negative"
              {:trip-count trip-count}))

--- a/test/raster/compiler/passes/parallel/structured_control_lower_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_lower_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.segop-opencl :as opencl]
             [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.emitted-structured-loop :as emitted-loop]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.soac-dialect :as soac]
@@ -86,6 +87,7 @@
     (is (= '[u-next] (mapv :id (:outputs graph))))
     (let [emitted (opencl/generate-kernel-graph
                    graph :scalar-types {'alpha-in :float 'iteration :long})]
+      (is (emitted-loop/emitted-loop? (emitted-loop/make scheduled emitted)))
       (is (every? artifact/kernel-artifact? (map :operation (:nodes emitted))))
       (is (= '[u-in u-next alpha-in iteration n-in] (:arguments emitted)))
       (is (= :opencl-c (get-in emitted [:provenance :target-dialect])))
@@ -119,16 +121,16 @@
                                     :scheduled-operation :grid :block-size]
                                    128)]
             (is (thrown-with-msg?
-                 clojure.lang.ExceptionInfo #"operation certificates differ"
+                 clojure.lang.ExceptionInfo #"operation certificate"
                  (loop-call/validate! (assoc call :graph tampered))))))
         (testing "target emission cannot change buffers or graph effects"
           (is (thrown-with-msg?
-               clojure.lang.ExceptionInfo #"dataflow or operation certificates differ"
+               clojure.lang.ExceptionInfo #"scheduled loop dataflow"
                (loop-call/validate!
                 (assoc call :graph
                        (assoc-in emitted [:inputs 0 :elements] 'different-extent)))))
           (is (thrown-with-msg?
-               clojure.lang.ExceptionInfo #"dataflow or operation certificates differ"
+               clojure.lang.ExceptionInfo #"scheduled loop dataflow"
                (loop-call/validate!
                 (assoc call :graph (assoc emitted :effects {:semantic #{:io}}))))))))))
 


### PR DESCRIPTION
## Summary
- introduce a checked EmittedStructuredLoop value pairing one exact schedule with its emitted KernelGraph
- prove target emission preserves graph dataflow and every scheduled operation certificate
- require KernelArtifact nodes and explicit provenance/attributes
- reuse the same validator from StructuredLoopCall before runtime binding

## Validation
- focused structured-control lowering and host-repetition runtime suite: 7 tests, 43 assertions
- cljfmt check on all touched files