### PR TITLE
Emit mixed programs equation first

### DIFF
--- a/src/raster/compiler/backend/gpu/parallel_program_opencl.clj
+++ b/src/raster/compiler/backend/gpu/parallel_program_opencl.clj
@@ -1,0 +1,168 @@
+(ns raster.compiler.backend.gpu.parallel-program-opencl
+  "Equation-first OpenCL emission for a scheduled mixed ParallelProgram.
+
+   This pass never inspects retained source or equation sites. Structured loops emit their exact
+   one-iteration graph; ordinary TypedSOAC equations derive and emit the same checked graph. Host
+   scalar equations remain explicit host-only steps for the whole-program executor."
+  (:require [raster.compiler.backend.gpu.segop-opencl :as opencl]
+            [raster.compiler.ir.emitted-parallel-equation :as emitted-equation]
+            [raster.compiler.ir.emitted-structured-loop :as emitted-loop]
+            [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.parallel-program :as program]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.ir.soac-dialect :as soac]
+            [raster.compiler.ir.structured-control :as control]
+            [raster.compiler.ir.structured-control-schedule :as schedule]
+            [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
+            [raster.compiler.passes.parallel.structured-control-route :as structured-route]))
+
+(defn- fail!
+  [reason message data]
+  (throw (ex-info message (assoc data :reason reason :pass :parallel-program-opencl))))
+
+(defn- scalar-types
+  [values operations]
+  (into {}
+        (map (fn [id]
+               (let [value (get values id)]
+                 (when-not value
+                   (fail! :opencl-parallel-scalar-value
+                          "scheduled scalar lacks an AbstractValue"
+                          {:value id}))
+                 [id (:dtype value)])))
+        (distinct (mapcat segop/operation-scalars operations))))
+
+(defn- scheduled-body
+  [parallel-program equation]
+  (let [algorithm (:algorithm equation)]
+    (program/make
+     {:dialect :segop
+      :source nil
+      :values (:values parallel-program)
+      :inputs (:operands equation)
+      :equations [equation]
+      :outputs (:results equation)
+      :effects (:effects equation)
+      :diagnostics []
+      :provenance {:source-dialect :typed-soac
+                   :pass :parallel-program-opencl}
+      :attributes {:host-control :explicit-typed-algorithm}
+      :operation? segop/segop-node?
+      :algorithm? (fn [candidate retained]
+                    (and (= retained (soac/validate! retained))
+                         (= (:operands candidate) (:inputs (soac/facts retained)))
+                         (= (:results candidate) (soac/outputs retained))))})))
+
+(defn- emit-graph
+  [scheduled-graph values operations opts]
+  (let [types (scalar-types values operations)]
+    (opencl/generate-kernel-graph
+     scheduled-graph
+     :scalar-types (merge (:scalar-types opts) types))))
+
+(defn- emit-equation
+  [parallel-program equation opts]
+  (let [algorithm (:algorithm equation)]
+    (cond
+      (control/loop-program? algorithm)
+      (let [scheduled (schedule/validate! (first (:operations equation)))
+            body (:body scheduled)
+            operations (vec (mapcat :operations (:equations body)))
+            emitted (emit-graph (:graph scheduled) (:values body) operations opts)]
+        (assoc equation :operations
+               [(emitted-loop/make
+                 scheduled emitted
+                 {:provenance {:target-dialect :opencl-c
+                               :pass :parallel-program-opencl}})]))
+
+      (and (soac/program-form? algorithm)
+           (true? (get-in equation [:attributes :host-only])))
+      equation
+
+      (soac/program-form? algorithm)
+      (let [body (scheduled-body parallel-program equation)
+            scheduled-graph (equation-graph/make algorithm body)
+            emitted (emit-graph scheduled-graph (:values body) (:operations equation) opts)]
+        (assoc equation :operations
+               [(emitted-equation/make
+                 algorithm body emitted
+                 {:provenance {:target-dialect :opencl-c
+                               :pass :parallel-program-opencl}})]))
+
+      :else
+      (fail! :opencl-parallel-algorithm
+             "scheduled equation has no supported retained algorithm"
+             {:equation (:id equation) :algorithm algorithm}))))
+
+(defn- emitted-operation?
+  [operation]
+  (or (emitted-loop/emitted-loop? operation)
+      (emitted-equation/emitted-equation? operation)))
+
+(defn- emitted-boundary?
+  [equation algorithm]
+  (cond
+    (control/loop-program? algorithm)
+    (and (= 1 (count (:operations equation)))
+         (let [operation (first (:operations equation))]
+           (and (emitted-loop/emitted-loop? operation)
+                (= algorithm (:algorithm (:schedule (emitted-loop/validate! operation)))))))
+
+    (soac/program-form? algorithm)
+    (if (true? (get-in equation [:attributes :host-only]))
+      (empty? (:operations equation))
+      (and (= 1 (count (:operations equation)))
+           (let [operation (first (:operations equation))]
+             (and (emitted-equation/emitted-equation? operation)
+                  (= algorithm (:algorithm (emitted-equation/validate! operation)))))))
+
+    :else false))
+
+(defn validate-program!
+  [parallel-program]
+  (when-not (= :opencl-parallel (:dialect parallel-program))
+    (fail! :opencl-parallel-dialect
+           "equation-first OpenCL emission requires :opencl-parallel"
+           {:dialect (:dialect parallel-program)}))
+  (program/validate! parallel-program emitted-operation? emitted-boundary?))
+
+(defn emit-program
+  "Emit every numerical equation directly and return its checked target program plus artifacts."
+  ([parallel-program] (emit-program parallel-program {}))
+  ([parallel-program opts]
+   (let [parallel-program (structured-route/validate-scheduled-program! parallel-program)
+         equations (mapv #(emit-equation parallel-program % opts)
+                         (:equations parallel-program))
+         emitted-program
+         (validate-program!
+          (program/make
+           {:dialect :opencl-parallel
+            :source (:source parallel-program)
+            :values (:values parallel-program)
+            :inputs (:inputs parallel-program)
+            :equations equations
+            :outputs (:outputs parallel-program)
+            :effects (:effects parallel-program)
+            :diagnostics (:diagnostics parallel-program)
+            :provenance (assoc (:provenance parallel-program)
+                               :target-dialect :opencl-parallel)
+            :attributes (:attributes parallel-program)
+            :operation? emitted-operation?
+            :algorithm? emitted-boundary?}))
+         graphs (keep (fn [equation]
+                        (when-let [operation (first (:operations equation))]
+                          (cond
+                            (emitted-loop/emitted-loop? operation) (:graph operation)
+                            (emitted-equation/emitted-equation? operation) (:graph operation))))
+                      equations)
+         kernels (vec (mapcat #(map :operation (:nodes (graph/validate! %)))
+                              graphs))]
+     {:program emitted-program
+      :kernels kernels
+      :stats {:structured-loops-emitted
+              (count (filter (comp emitted-loop/emitted-loop? first :operations) equations))
+              :typed-equations-emitted
+              (count (filter (comp emitted-equation/emitted-equation? first :operations)
+                             equations))
+              :host-scalar-equations
+              (count (filter #(get-in % [:attributes :host-only]) equations))}})))

--- a/src/raster/compiler/ir/emitted_parallel_equation.clj
+++ b/src/raster/compiler/ir/emitted_parallel_equation.clj
@@ -1,0 +1,68 @@
+(ns raster.compiler.ir.emitted-parallel-equation
+  "Checked target emission of one scheduled TypedSOAC equation."
+  (:require [raster.compiler.ir.kernel-artifact :as artifact]
+            [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.parallel-program :as program]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.ir.soac-dialect :as soac]
+            [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]))
+
+(defrecord EmittedParallelEquation [algorithm body graph provenance attributes])
+
+(defn emitted-equation?
+  [value]
+  (and value
+       (= "raster.compiler.ir.emitted_parallel_equation.EmittedParallelEquation"
+          (.getName (class value)))))
+
+(defn- fail!
+  [reason message data]
+  (throw (ex-info message (assoc data :reason reason :ir :emitted-parallel-equation))))
+
+(defn- algorithm-boundary?
+  [equation algorithm]
+  (and (= algorithm (soac/validate! algorithm))
+       (= (:operands equation) (:inputs (soac/facts algorithm)))
+       (= (:results equation) (soac/outputs algorithm))))
+
+(defn validate!
+  [emitted-equation]
+  (when-not (emitted-equation? emitted-equation)
+    (fail! :emitted-parallel-equation-type
+           "expected an EmittedParallelEquation"
+           {:actual (type emitted-equation)}))
+  (let [{:keys [algorithm body graph provenance attributes]} emitted-equation
+        algorithm (soac/validate! algorithm)
+        body (program/validate! body segop/segop-node? algorithm-boundary?)
+        expected (equation-graph/make algorithm body)
+        emitted (graph/validate! graph)]
+    (when-not (every? (comp artifact/kernel-artifact? :operation) (:nodes emitted))
+      (fail! :emitted-parallel-equation-artifact
+             "emitted equation graph requires only KernelArtifact nodes" {}))
+    (when-not (graph/dataflow-equivalent? expected emitted)
+      (fail! :emitted-parallel-equation-dataflow
+             "target emission changed scheduled equation dataflow"
+             {:scheduled (graph/dataflow-contract expected)
+              :emitted (graph/dataflow-contract emitted)}))
+    (when-not (every? true?
+                      (map (fn [scheduled-node emitted-node]
+                             (= (:operation scheduled-node)
+                                (get-in emitted-node
+                                        [:operation :provenance :scheduled-operation])))
+                           (:nodes expected) (:nodes emitted)))
+      (fail! :emitted-parallel-equation-operation
+             "target emission changed a scheduled equation operation certificate" {}))
+    (doseq [[field value] [[:provenance provenance] [:attributes attributes]]]
+      (when-not (map? value)
+        (fail! :emitted-parallel-equation-description
+               "emitted equation descriptions must be maps"
+               {:field field :value value})))
+    emitted-equation))
+
+(defn make
+  ([algorithm body emitted]
+   (make algorithm body emitted {}))
+  ([algorithm body emitted {:keys [provenance attributes]
+                            :or {provenance {} attributes {}}}]
+   (validate!
+    (->EmittedParallelEquation algorithm body emitted provenance attributes))))

--- a/test/raster/compiler/passes/parallel/structured_control_route_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_route_test.clj
@@ -1,7 +1,11 @@
 (ns raster.compiler.passes.parallel.structured-control-route-test
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.parallel-program-opencl :as program-opencl]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.dialects :as dialects]
+            [raster.compiler.ir.emitted-parallel-equation :as emitted-equation]
+            [raster.compiler.ir.emitted-structured-loop :as emitted-loop]
+            [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-graph :as graph]
             [raster.compiler.ir.parallel-program :as program]
             [raster.compiler.ir.soac-dialect :as soac]
@@ -225,3 +229,31 @@
            (mapv :operation (:nodes kernel-graph))))
     (is (= :mixed-suffix (get-in kernel-graph [:provenance :source-dialect])))
     (is (nil? (:source scheduled)))))
+
+(deftest equation-first-opencl-emits-loop-and-suffix-without-reading-source
+  (let [initial (av/tensor {:dtype :double :shape ['extent]
+                            :representation {:kind :plain}})
+        options {:dtype :double
+                 :target-device :ocl:0
+                 :values {'u0 initial 'steps (av/tensor {:dtype :long :shape []})}
+                 :scalar-types {'steps :long}}
+        scheduled (:form (pipeline/schedule-parallel-form (mixed-source) options))
+        opaque-source (assoc scheduled :source ::must-not-be-inspected)
+        {:keys [program kernels stats]} (program-opencl/emit-program opaque-source options)
+        [loop-equation suffix-equation] (:equations program)]
+    (is (= :opencl-parallel (:dialect program)))
+    (is (= ::must-not-be-inspected (:source program)))
+    (is (emitted-loop/emitted-loop? (first (:operations loop-equation))))
+    (is (emitted-equation/emitted-equation? (first (:operations suffix-equation))))
+    (is (every? artifact/kernel-artifact? kernels))
+    (is (= {:structured-loops-emitted 1
+            :typed-equations-emitted 1
+            :host-scalar-equations 0}
+           stats))
+    (is (= program (program-opencl/validate-program! program)))
+    (testing "emitted algorithm kinds cannot be exchanged between equations"
+      (let [suffix-operation (get-in suffix-equation [:operations 0])]
+        (is (= :parallel-program-algorithm
+               (reason-of #(program-opencl/validate-program!
+                            (assoc-in program [:equations 0 :operations]
+                                      [suffix-operation])))))))))


### PR DESCRIPTION
## Summary
- add a checked emitted value for ordinary scheduled TypedSOAC equations
- emit scheduled mixed ParallelPrograms directly from retained algorithms and SegOps
- emit structured loop iteration graphs and ordinary suffix graphs through the same OpenCL graph boundary
- retain explicit host-only scalar equations for the upcoming whole-program executor
- return target artifacts and explicit emission counts without inspecting source or equation sites

## Validation
- focused structured-control, TypedSOAC, and host-repetition suite: 55 tests, 397 assertions
- opaque-source regression proves emission is equation-driven
- malformed emitted algorithm/operation pairing fails loud
- cljfmt check on all touched files