### PR TITLE
Stage emitted parallel programs once

### DIFF
--- a/src/raster/compiler/backend/gpu/parallel_program_opencl.clj
+++ b/src/raster/compiler/backend/gpu/parallel_program_opencl.clj
@@ -6,6 +6,7 @@
    scalar equations remain explicit host-only steps for the whole-program executor."
   (:require [raster.compiler.backend.gpu.segop-opencl :as opencl]
             [raster.compiler.ir.emitted-parallel-equation :as emitted-equation]
+            [raster.compiler.ir.emitted-parallel-program :as emitted-program]
             [raster.compiler.ir.emitted-structured-loop :as emitted-loop]
             [raster.compiler.ir.kernel-graph :as graph]
             [raster.compiler.ir.parallel-program :as program]
@@ -94,37 +95,9 @@
              "scheduled equation has no supported retained algorithm"
              {:equation (:id equation) :algorithm algorithm}))))
 
-(defn- emitted-operation?
-  [operation]
-  (or (emitted-loop/emitted-loop? operation)
-      (emitted-equation/emitted-equation? operation)))
-
-(defn- emitted-boundary?
-  [equation algorithm]
-  (cond
-    (control/loop-program? algorithm)
-    (and (= 1 (count (:operations equation)))
-         (let [operation (first (:operations equation))]
-           (and (emitted-loop/emitted-loop? operation)
-                (= algorithm (:algorithm (:schedule (emitted-loop/validate! operation)))))))
-
-    (soac/program-form? algorithm)
-    (if (true? (get-in equation [:attributes :host-only]))
-      (empty? (:operations equation))
-      (and (= 1 (count (:operations equation)))
-           (let [operation (first (:operations equation))]
-             (and (emitted-equation/emitted-equation? operation)
-                  (= algorithm (:algorithm (emitted-equation/validate! operation)))))))
-
-    :else false))
-
 (defn validate-program!
   [parallel-program]
-  (when-not (= :opencl-parallel (:dialect parallel-program))
-    (fail! :opencl-parallel-dialect
-           "equation-first OpenCL emission requires :opencl-parallel"
-           {:dialect (:dialect parallel-program)}))
-  (program/validate! parallel-program emitted-operation? emitted-boundary?))
+  (emitted-program/validate! parallel-program))
 
 (defn emit-program
   "Emit every numerical equation directly and return its checked target program plus artifacts."
@@ -147,8 +120,8 @@
             :provenance (assoc (:provenance parallel-program)
                                :target-dialect :opencl-parallel)
             :attributes (:attributes parallel-program)
-            :operation? emitted-operation?
-            :algorithm? emitted-boundary?}))
+            :operation? emitted-program/emitted-operation?
+            :algorithm? emitted-program/emitted-boundary?}))
          graphs (keep (fn [equation]
                         (when-let [operation (first (:operations equation))]
                           (cond

--- a/src/raster/compiler/ir/emitted_parallel_program.clj
+++ b/src/raster/compiler/ir/emitted_parallel_program.clj
@@ -1,0 +1,46 @@
+(ns raster.compiler.ir.emitted-parallel-program
+  "Validation for an equation-first emitted ParallelProgram.
+
+   The target backend may replace scheduled operations, but the retained typed algorithms and
+   ordered program dataflow remain authoritative. Host-only scalar equations are the only
+   equations with an empty emitted operation sequence."
+  (:require [raster.compiler.ir.emitted-parallel-equation :as emitted-equation]
+            [raster.compiler.ir.emitted-structured-loop :as emitted-loop]
+            [raster.compiler.ir.parallel-program :as program]
+            [raster.compiler.ir.soac-dialect :as soac]
+            [raster.compiler.ir.structured-control :as control]))
+
+(defn emitted-operation?
+  [operation]
+  (or (emitted-loop/emitted-loop? operation)
+      (emitted-equation/emitted-equation? operation)))
+
+(defn emitted-boundary?
+  [equation algorithm]
+  (cond
+    (control/loop-program? algorithm)
+    (and (= 1 (count (:operations equation)))
+         (let [operation (first (:operations equation))]
+           (and (emitted-loop/emitted-loop? operation)
+                (= algorithm (:algorithm (:schedule (emitted-loop/validate! operation)))))))
+
+    (soac/program-form? algorithm)
+    (if (true? (get-in equation [:attributes :host-only]))
+      (and (empty? (:operations equation))
+           (every? #(= 'scalar (soac/operation-kind %)) (soac/equations algorithm)))
+      (and (= 1 (count (:operations equation)))
+           (let [operation (first (:operations equation))]
+             (and (emitted-equation/emitted-equation? operation)
+                  (= algorithm (:algorithm (emitted-equation/validate! operation)))))))
+
+    :else false))
+
+(defn validate!
+  "Validate a fully emitted equation-first program without depending on a target backend."
+  [parallel-program]
+  (when-not (= :opencl-parallel (:dialect parallel-program))
+    (throw (ex-info "emitted parallel program requires :opencl-parallel"
+                    {:reason :emitted-parallel-program-dialect
+                     :dialect (:dialect parallel-program)
+                     :ir :emitted-parallel-program})))
+  (program/validate! parallel-program emitted-operation? emitted-boundary?))

--- a/src/raster/compiler/ir/emitted_parallel_program_call.clj
+++ b/src/raster/compiler/ir/emitted_parallel_program_call.clj
@@ -1,0 +1,364 @@
+(ns raster.compiler.ir.emitted-parallel-program-call
+  "Pure runtime binding for one equation-first emitted parallel program.
+
+   Construction evaluates only effect-free host scalar equations that are independent of device
+   results. Every numerical equation is then bound from its emitted ABI and retained physical
+   result contracts. The resulting call owns no driver handles and never reads retained source."
+  (:require [clojure.set :as set]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.emitted-parallel-equation :as emitted-equation]
+            [raster.compiler.ir.emitted-parallel-program :as emitted-program]
+            [raster.compiler.ir.emitted-structured-loop :as emitted-loop]
+            [raster.compiler.ir.kernel-executable :as executable]
+            [raster.compiler.ir.parallel-program :as program]
+            [raster.compiler.ir.soac-dialect :as soac]
+            [raster.compiler.ir.structured-control :as control]
+            [raster.compiler.ir.structured-loop-call :as loop-call]))
+
+(defrecord EvaluatedHostEquation [equation operands results])
+(defrecord EmittedEquationCall [equation graph buffers scalar-values outputs])
+(defrecord EmittedParallelProgramCall
+           [program steps buffers scalar-values loop-scratch outputs attributes])
+
+(defn- record-kind?
+  [record-class value]
+  (and value (= record-class (.getName (class value)))))
+
+(defn evaluated-host-equation?
+  [value]
+  (record-kind?
+   "raster.compiler.ir.emitted_parallel_program_call.EvaluatedHostEquation" value))
+
+(defn emitted-equation-call?
+  [value]
+  (record-kind?
+   "raster.compiler.ir.emitted_parallel_program_call.EmittedEquationCall" value))
+
+(defn emitted-program-call?
+  [value]
+  (record-kind?
+   "raster.compiler.ir.emitted_parallel_program_call.EmittedParallelProgramCall" value))
+
+(defn- fail!
+  [reason message data]
+  (throw (ex-info message (assoc data :reason reason :ir :emitted-parallel-program-call))))
+
+(defn- typed-scalar?
+  [value]
+  (and (map? value) (keyword? (:type value)) (contains? value :value)))
+
+(defn- checked-scalar
+  [values id value]
+  (let [expected (:dtype (get values id))]
+    (when-not (typed-scalar? value)
+      (fail! :emitted-program-scalar
+             "parallel program scalars require explicit runtime dtypes"
+             {:value id :scalar value}))
+    (when-not (= (dtype/canon expected) (dtype/canon (:type value)))
+      (fail! :emitted-program-scalar-type
+             "runtime scalar dtype differs from its retained AbstractValue"
+             {:value id :expected expected :actual (:type value)}))
+    value))
+
+(defn- require-buffer
+  [buffers id role]
+  (let [value (get buffers id ::missing)]
+    (when (or (= ::missing value) (nil? value))
+      (fail! :emitted-program-buffer
+             "parallel program buffer binding is missing"
+             {:value id :role role}))
+    value))
+
+(defn- physical-results
+  [algorithm]
+  (let [facts (soac/facts algorithm)]
+    (into {}
+          (mapcat (fn [equation]
+                    (map vector (nth equation 2) (soac/physical-results facts equation))))
+          (soac/equations algorithm))))
+
+(defn- validate-host-step!
+  [values step]
+  (when-not (evaluated-host-equation? step)
+    (fail! :emitted-program-host-step "expected an EvaluatedHostEquation" {:step step}))
+  (let [{:keys [equation operands results]} step]
+    (when-not (and (program/equation? equation)
+                   (true? (get-in equation [:attributes :host-only]))
+                   (empty? (:operations equation)))
+      (fail! :emitted-program-host-equation
+             "evaluated host step does not retain a host-only equation"
+             {:equation equation}))
+    (when-not (= (set (:operands equation)) (set (keys operands)))
+      (fail! :emitted-program-host-operands
+             "evaluated host operands differ from the retained equation"
+             {:equation (:id equation) :expected (:operands equation)
+              :actual (keys operands)}))
+    (when-not (= (set (:results equation)) (set (keys results)))
+      (fail! :emitted-program-host-results
+             "evaluated host results differ from the retained equation"
+             {:equation (:id equation) :expected (:results equation)
+              :actual (keys results)}))
+    (doseq [[id value] results]
+      (checked-scalar values id value))
+    step))
+
+(defn validate-equation-call!
+  [call]
+  (when-not (emitted-equation-call? call)
+    (fail! :emitted-program-equation-call "expected an EmittedEquationCall" {:call call}))
+  (let [{equation :equation call-graph :graph buffers :buffers
+         scalar-values :scalar-values outputs :outputs} call
+        operation (first (:operations equation))
+        emitted (emitted-equation/validate! operation)
+        graph (:graph emitted)
+        runtime-arguments
+        (mapv (fn [slot argument]
+                (if (= :scalar (:kind slot))
+                  (get scalar-values argument ::missing)
+                  (get buffers argument ::missing)))
+              (:abi graph) (:arguments graph))]
+    (when (some #{::missing} runtime-arguments)
+      (fail! :emitted-program-equation-interface
+             "emitted equation call does not bind its complete graph ABI"
+             {:equation (:id equation)}))
+    (let [bindings (executable/graph-bindings graph runtime-arguments)]
+      (when-not (= {:buffers buffers :scalar-values scalar-values} bindings)
+        (fail! :emitted-program-equation-bindings
+               "emitted equation call bindings differ from its ordered ABI"
+               {:equation (:id equation)})))
+    (when-not (= (set (:results equation)) (set (keys outputs)))
+      (fail! :emitted-program-equation-outputs
+             "emitted equation outputs differ from its logical results"
+             {:equation (:id equation) :expected (:results equation)
+              :actual (keys outputs)}))
+    (when-not (= graph call-graph)
+      (fail! :emitted-program-equation-graph
+             "emitted equation call graph differs from its certified operation"
+             {:equation (:id equation)}))
+    call))
+
+(defn- prepare-equation-call
+  [equation values buffers scalars]
+  (let [emitted (emitted-equation/validate! (first (:operations equation)))
+        graph (:graph emitted)
+        result-storage (physical-results (:algorithm emitted))
+        buffers
+        (reduce
+         (fn [bindings result]
+           (let [physical (get result-storage result)
+                 physical-binding (get bindings physical ::missing)
+                 logical-binding (get bindings result ::missing)
+                 selected (cond
+                            (not= ::missing physical-binding) physical-binding
+                            (not= ::missing logical-binding) logical-binding
+                            :else (fail! :emitted-program-result-buffer
+                                         "numerical result requires preallocated resident storage"
+                                         {:equation (:id equation) :result result
+                                          :physical-result physical}))]
+             (when (and (not= ::missing physical-binding)
+                        (not= ::missing logical-binding)
+                        (not= physical-binding logical-binding))
+               (fail! :emitted-program-result-alias
+                      "logical and physical result bindings disagree"
+                      {:equation (:id equation) :result result :physical-result physical}))
+             (assoc bindings physical selected result selected)))
+         buffers (:results equation))
+        runtime-arguments
+        (mapv (fn [slot argument]
+                (if (= :scalar (:kind slot))
+                  (let [value (checked-scalar values argument (get scalars argument))]
+                    (when-not (= (dtype/canon (:kernel-dtype slot))
+                                 (dtype/canon (:type value)))
+                      (fail! :emitted-program-scalar-abi
+                             "runtime scalar dtype differs from the emitted graph ABI"
+                             {:equation (:id equation) :value argument
+                              :expected (:kernel-dtype slot) :actual (:type value)}))
+                    value)
+                  (require-buffer buffers argument :equation-interface)))
+              (:abi graph) (:arguments graph))
+        bindings (executable/graph-bindings graph runtime-arguments)
+        outputs (select-keys buffers (:results equation))]
+    {:call (validate-equation-call!
+            (->EmittedEquationCall equation graph (:buffers bindings)
+                                   (:scalar-values bindings) outputs))
+     :buffers buffers}))
+
+(defn- evaluate-host-equations
+  [parallel-program buffers scalars evaluate-host]
+  (let [values (:values parallel-program)]
+    (reduce
+     (fn [{:keys [scalars device-results host-steps] :as state} equation]
+       (if-not (true? (get-in equation [:attributes :host-only]))
+         (update state :device-results into (:results equation))
+         (do
+           (when (seq (:effects equation))
+             (fail! :emitted-program-host-effects
+                    "host scalar equations must be effect-free before they can be hoisted"
+                    {:equation (:id equation) :effects (:effects equation)}))
+           (let [device-dependencies (set/intersection device-results
+                                                       (set (:operands equation)))]
+             (when (seq device-dependencies)
+               (fail! :emitted-program-host-device-dependency
+                      "a host scalar equation cannot be staged before a device result"
+                      {:equation (:id equation) :values device-dependencies})))
+           (when-not (ifn? evaluate-host)
+             (fail! :emitted-program-host-evaluator
+                    "an emitted program with host scalar equations requires an evaluator"
+                    {:equation (:id equation)}))
+           (let [operand-bindings
+                 (into {}
+                       (map (fn [id]
+                              [id (cond
+                                    (contains? scalars id) (checked-scalar values id (get scalars id))
+                                    (contains? buffers id) (get buffers id)
+                                    :else (fail! :emitted-program-host-operand
+                                                 "host scalar operand has no runtime binding"
+                                                 {:equation (:id equation) :value id}))]))
+                       (:operands equation))
+                 results (evaluate-host equation
+                                        {:operands operand-bindings
+                                         :values values})]
+             (when-not (map? results)
+               (fail! :emitted-program-host-evaluation
+                      "host scalar evaluator must return a result map"
+                      {:equation (:id equation) :results results}))
+             (let [step (validate-host-step!
+                         values (->EvaluatedHostEquation equation operand-bindings results))]
+               (-> state
+                   (assoc :scalars
+                          (reduce-kv (fn [environment id value]
+                                       (when-let [supplied (get environment id)]
+                                         (when-not (= supplied value)
+                                           (fail! :emitted-program-host-result-conflict
+                                                  "supplied and evaluated host scalars disagree"
+                                                  {:equation (:id equation) :value id})))
+                                       (assoc environment id value))
+                                     scalars results))
+                   (assoc-in [:host-steps (:id equation)] step)))))))
+     {:scalars scalars :device-results #{} :host-steps {}}
+     (:equations parallel-program))))
+
+(defn validate!
+  [call]
+  (when-not (emitted-program-call? call)
+    (fail! :emitted-program-call-type "expected an EmittedParallelProgramCall"
+           {:actual (type call)}))
+  (let [{:keys [program steps buffers scalar-values loop-scratch outputs attributes]} call
+        parallel-program (emitted-program/validate! program)]
+    (doseq [[field value] [[:buffers buffers] [:scalar-values scalar-values]
+                           [:loop-scratch loop-scratch] [:outputs outputs]
+                           [:attributes attributes]]]
+      (when-not (map? value)
+        (fail! :emitted-program-call-field "emitted program call fields must be maps"
+               {:field field :value value})))
+    (when-not (= (count steps) (count (:equations parallel-program)))
+      (fail! :emitted-program-call-steps
+             "emitted program call must retain one step per equation"
+             {:expected (count (:equations parallel-program)) :actual (count steps)}))
+    (doseq [[equation step] (map vector (:equations parallel-program) steps)]
+      (cond
+        (evaluated-host-equation? step)
+        (do (validate-host-step! (:values parallel-program) step)
+            (when-not (= equation (:equation step))
+              (fail! :emitted-program-call-step-equation
+                     "evaluated host step changed equation identity" {:equation (:id equation)})))
+
+        (emitted-equation-call? step)
+        (do (validate-equation-call! step)
+            (when-not (= equation (:equation step))
+              (fail! :emitted-program-call-step-equation
+                     "emitted graph step changed equation identity" {:equation (:id equation)})))
+
+        (loop-call/structured-loop-call? step)
+        (let [step (loop-call/validate! step)
+              emitted (emitted-loop/validate! (first (:operations equation)))]
+          (when-not (and (= (:schedule emitted) (:schedule step))
+                         (= (:graph emitted) (:graph step)))
+            (fail! :emitted-program-call-loop
+                   "structured loop call differs from its emitted equation"
+                   {:equation (:id equation)})))
+
+        :else
+        (fail! :emitted-program-call-step "emitted program call has an unknown step"
+               {:equation (:id equation) :step step})))
+    (when-not (= (set (:outputs parallel-program)) (set (keys outputs)))
+      (fail! :emitted-program-call-outputs
+             "emitted program call outputs differ from the program boundary"
+             {:expected (:outputs parallel-program) :actual (keys outputs)}))
+    call))
+
+(defn make
+  "Prepare a source-independent, target-neutral call of an emitted parallel program.
+
+   `buffers` may include preallocated intermediate and output storage in addition to inputs.
+   `scalar-values` contains typed runtime scalars. `loop-scratch` maps loop output IDs to alternate
+   carry buffers. `evaluate-host` is called only for effect-free scalar equations that do not
+   depend on device results."
+  [parallel-program buffers scalar-values loop-scratch evaluate-host]
+  (let [parallel-program (emitted-program/validate! parallel-program)
+        values (:values parallel-program)
+        overlapping-runtime-values (set/intersection (set (keys buffers))
+                                                     (set (keys scalar-values)))
+        _ (when (seq overlapping-runtime-values)
+            (fail! :emitted-program-runtime-kind
+                   "one runtime value cannot be both a buffer and a scalar"
+                   {:values overlapping-runtime-values}))
+        _ (doseq [[id value] scalar-values]
+            (when-not (contains? values id)
+              (fail! :emitted-program-runtime-value
+                     "runtime scalar names an undeclared program value" {:value id}))
+            (checked-scalar values id value))
+        _ (doseq [[id value] buffers]
+            (when-not (contains? values id)
+              (fail! :emitted-program-runtime-value
+                     "runtime buffer names an undeclared program value" {:value id}))
+            (when (nil? value)
+              (fail! :emitted-program-buffer "runtime buffer cannot be nil" {:value id})))
+        loop-outputs
+        (into #{}
+              (comp (filter #(emitted-loop/emitted-loop? (first (:operations %))))
+                    (mapcat #(map :output (control/carried (:algorithm %)))))
+              (:equations parallel-program))
+        _ (doseq [[id value] loop-scratch]
+            (when-not (contains? loop-outputs id)
+              (fail! :emitted-program-loop-scratch
+                     "loop scratch must name a structured loop output" {:value id}))
+            (when (nil? value)
+              (fail! :emitted-program-loop-scratch
+                     "loop scratch binding cannot be nil" {:value id})))
+        {:keys [scalars host-steps]}
+        (evaluate-host-equations parallel-program buffers scalar-values evaluate-host)
+        planned
+        (reduce
+         (fn [{:keys [buffers steps]} equation]
+           (cond
+             (true? (get-in equation [:attributes :host-only]))
+             {:buffers buffers :steps (conj steps (get host-steps (:id equation)))}
+
+             (emitted-loop/emitted-loop? (first (:operations equation)))
+             (let [emitted (emitted-loop/validate! (first (:operations equation)))
+                   call (loop-call/make (:schedule emitted) (:graph emitted)
+                                        buffers scalars loop-scratch)]
+               {:buffers (merge buffers (:outputs call))
+                :steps (conj steps call)})
+
+             :else
+             (let [{:keys [call buffers]}
+                   (prepare-equation-call equation values buffers scalars)]
+               {:buffers buffers :steps (conj steps call)})))
+         {:buffers buffers :steps []}
+         (:equations parallel-program))
+        final-buffers (:buffers planned)
+        outputs
+        (into {}
+              (map (fn [id]
+                     [id (cond
+                           (contains? scalars id) (get scalars id)
+                           (contains? final-buffers id) (get final-buffers id)
+                           :else (fail! :emitted-program-output-binding
+                                        "program output has no runtime binding" {:value id}))]))
+              (:outputs parallel-program))]
+    (validate!
+     (->EmittedParallelProgramCall
+      parallel-program (:steps planned) final-buffers scalars loop-scratch outputs
+      {:execution :stage-once-host-repetition :source-inspected false}))))

--- a/src/raster/gpu/parallel_program.clj
+++ b/src/raster/gpu/parallel_program.clj
@@ -1,0 +1,74 @@
+(ns raster.gpu.parallel-program
+  "Stage-once execution of a checked emitted parallel program call.
+
+   Every numerical graph is bound before the first launch. Structured control is initially
+   realized as one pre-bound graph per host iteration; all buffers remain resident and suffix
+   equations consume the exact carry bindings selected by the call IR."
+  (:refer-clojure :exclude [run!])
+  (:require [raster.compiler.ir.emitted-parallel-program-call :as program-call]
+            [raster.compiler.ir.structured-loop-call :as loop-call]))
+
+(defn staging-plan
+  "Return ordered graph bindings for a prepared program call without contacting a driver."
+  [call execution-id]
+  (let [call (program-call/validate! call)]
+    (vec
+     (mapcat
+      (fn [step-index step]
+        (cond
+          (program-call/evaluated-host-equation? step)
+          []
+
+          (program-call/emitted-equation-call? step)
+          [{:key [:parallel-program execution-id step-index]
+            :graph (:graph step)
+            :buffers (:buffers step)
+            :scalar-values (:scalar-values step)}]
+
+          (loop-call/structured-loop-call? step)
+          (mapv (fn [iteration]
+                  (let [{:keys [buffers scalar-values]}
+                        (loop-call/iteration-binding step iteration)]
+                    {:key [:parallel-program execution-id step-index iteration]
+                     :graph (:graph step)
+                     :buffers buffers
+                     :scalar-values scalar-values}))
+                (range (:trip-count step)))))
+      (range) (:steps call)))))
+
+(defn run-with!
+  "Bind the complete call, then execute it through an injected graph executor.
+
+   `executor` contains `:bind!`, `:run!`, and `:release!`. A staging failure releases all prior
+   handles without launching; an execution failure releases the entire staged program."
+  [call {:keys [bind! run! release!] :as executor}]
+  (let [call (program-call/validate! call)]
+    (doseq [[operation function] [[:bind! bind!] [:run! run!] [:release! release!]]]
+      (when-not (ifn? function)
+        (throw (ex-info "parallel program executor requires callable operations"
+                        {:reason :parallel-program-executor
+                         :operation operation :executor executor}))))
+    (let [staged (volatile! [])]
+      (try
+        (doseq [{:keys [key graph buffers scalar-values]}
+                (staging-plan call (random-uuid))]
+          (vswap! staged conj (bind! key graph buffers scalar-values)))
+        (doseq [handle @staged]
+          (run! handle))
+        (:outputs call)
+        (finally
+          (doseq [handle (rseq @staged)]
+            (release! handle)))))))
+
+(defn run!
+  "Run a prepared emitted parallel program in one GPU session."
+  [session call]
+  (let [bind-graph! (requiring-resolve 'raster.gpu.core/bind-kernel-graph!)
+        run-graph! (requiring-resolve 'raster.gpu.core/run-kernel-graph!)
+        release-graph! (requiring-resolve 'raster.gpu.core/release-kernel-graph!)]
+    (run-with!
+     call
+     {:bind! (fn [key graph buffers scalars]
+               (bind-graph! session key graph buffers scalars))
+      :run! (fn [handle] (run-graph! session handle))
+      :release! (fn [handle] (release-graph! session handle))})))

--- a/test/raster/compiler/passes/parallel/structured_control_route_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_route_test.clj
@@ -4,6 +4,7 @@
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.dialects :as dialects]
             [raster.compiler.ir.emitted-parallel-equation :as emitted-equation]
+            [raster.compiler.ir.emitted-parallel-program-call :as program-call]
             [raster.compiler.ir.emitted-structured-loop :as emitted-loop]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-graph :as graph]
@@ -17,7 +18,8 @@
             [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
-            [raster.compiler.pipeline :as pipeline]))
+            [raster.compiler.pipeline :as pipeline]
+            [raster.gpu.parallel-program :as program-runtime]))
 
 (defn- loop-decomposition
   []
@@ -257,3 +259,136 @@
                (reason-of #(program-opencl/validate-program!
                             (assoc-in program [:equations 0 :operations]
                                       [suffix-operation])))))))))
+
+(defn- prepared-mixed-call
+  [trip-count]
+  (let [initial (av/tensor {:dtype :double :shape ['extent]
+                            :representation {:kind :plain}})
+        options {:dtype :double
+                 :target-device :ocl:0
+                 :values {'u0 initial 'steps (av/tensor {:dtype :long :shape []})}
+                 :scalar-types {'steps :long}}
+        scheduled (:form (pipeline/schedule-parallel-form (mixed-source) options))
+        emitted (:program (program-opencl/emit-program
+                           (assoc scheduled :source ::must-not-be-inspected) options))
+        loop-equation (first (:equations emitted))
+        carried (first (control/carried (:algorithm loop-equation)))
+        initial (:initial carried)
+        loop-output (:output carried)
+        result (first (:outputs emitted))
+        scalar (fn [id value]
+                 {:type (get-in emitted [:values id :dtype]) :value value})]
+    {:call
+     (program-call/make
+      emitted
+      {initial :initial loop-output :loop-output result :suffix-output}
+      {'steps (scalar 'steps trip-count)
+       'n (scalar 'n 64)}
+      (if (> trip-count 1) {loop-output :carry-scratch} {})
+      nil)
+     :loop-output loop-output
+     :result result}))
+
+(deftest emitted-program-stages-once-before-running-resident-equations
+  (let [{:keys [call loop-output result]} (prepared-mixed-call 3)
+        events (atom [])
+        outputs
+        (program-runtime/run-with!
+         call
+         {:bind! (fn [key _graph buffers scalars]
+                   (let [handle {:key key :buffers buffers :scalars scalars}]
+                     (swap! events conj [:bind handle])
+                     handle))
+          :run! (fn [handle] (swap! events conj [:run handle]))
+          :release! (fn [handle] (swap! events conj [:release handle]))})
+        bindings (mapv (comp :buffers second) (filter #(= :bind (first %)) @events))]
+    (is (= {result :suffix-output} outputs))
+    (is (= 4 (count bindings)))
+    (is (= [:bind :bind :bind :bind :run :run :run :run
+            :release :release :release :release]
+           (mapv first @events))
+        "all target graphs are staged before the first launch")
+    (is (= :loop-output (get (last bindings) loop-output)))
+    (is (= :suffix-output (get (last bindings) result)))
+    (is (= :stage-once-host-repetition (get-in call [:attributes :execution])))
+    (is (false? (get-in call [:attributes :source-inspected])))))
+
+(deftest zero-trip-program-feeds-the-initial-carry-to-its-suffix
+  (let [{:keys [call loop-output result]} (prepared-mixed-call 0)
+        plan (program-runtime/staging-plan call :execution)]
+    (is (= 1 (count plan)))
+    (is (= :initial (get-in plan [0 :buffers loop-output])))
+    (is (= :suffix-output (get-in plan [0 :buffers result])))))
+
+(deftest whole-program-staging-is-transactional
+  (let [call (:call (prepared-mixed-call 3))
+        events (atom [])
+        attempts (atom 0)]
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"staging failed"
+         (program-runtime/run-with!
+          call
+          {:bind! (fn [key & _]
+                    (if (= 3 (swap! attempts inc))
+                      (throw (ex-info "staging failed" {}))
+                      (let [handle [:handle key]]
+                        (swap! events conj [:bind handle])
+                        handle)))
+           :run! (fn [handle] (swap! events conj [:run handle]))
+           :release! (fn [handle] (swap! events conj [:release handle]))})))
+    (is (= [:bind :bind :release :release] (mapv first @events)))
+    (is (empty? (filter #(= :run (first %)) @events)))
+    (is (= (reverse (map second (take 2 @events)))
+           (map second (drop 2 @events))))))
+
+(deftest effect-free-host-scalars-are-evaluated-before-device-staging
+  (let [initial (av/tensor {:dtype :double :shape ['extent]
+                            :representation {:kind :plain}})
+        options {:dtype :double
+                 :target-device :ocl:0
+                 :values {'u0 initial 'steps (av/tensor {:dtype :long :shape []})}
+                 :scalar-types {'steps :long}}
+        scheduled (:form (pipeline/schedule-parallel-form (mixed-source) options))
+        base (:program (program-opencl/emit-program
+                        (assoc scheduled :source ::must-not-be-inspected) options))
+        loop-equation (first (:equations base))
+        answer-value (av/tensor {:dtype :long :shape []})
+        host-algorithm
+        (soac/make
+         (soac/default-program-facts
+          {:values {'steps (get-in base [:values 'steps]) 'answer answer-value}
+           :inputs '[steps]
+           :equations {'host-scalar (soac/default-equation-facts)}})
+         [(list '= 'host-scalar '[answer]
+                (list 'scalar {:dtypes [:long]} '[steps]
+                      (soac/lambda-form '[value] '[(unchecked-inc value)])))]
+         '[answer])
+        host-equation
+        (program/->ProgramEquation
+         [:host-scalar] [:test :host-scalar] nil '[steps] '[answer]
+         host-algorithm [] #{} {:source :test} {:host-only true})
+        emitted (-> base
+                    (assoc :values (assoc (:values base) 'answer answer-value))
+                    (assoc :equations [loop-equation host-equation])
+                    (assoc :outputs '[answer]))
+        carried (first (control/carried (:algorithm loop-equation)))
+        initial-id (:initial carried)
+        loop-output (:output carried)
+        result 'answer
+        scalar (fn [id value]
+                 {:type (get-in emitted [:values id :dtype]) :value value})
+        evaluations (atom [])
+        call
+        (program-call/make
+         emitted
+         {initial-id :initial loop-output :loop-output}
+         {'steps (scalar 'steps 2) 'n (scalar 'n 64)}
+         {loop-output :carry-scratch}
+         (fn [equation {:keys [operands]}]
+           (swap! evaluations conj [(:id equation) operands])
+           {result (scalar result (inc (get-in operands ['steps :value])))}))]
+    (is (true? (get-in host-equation [:attributes :host-only])))
+    (is (= 1 (count @evaluations)))
+    (is (= 3 (get-in call [:outputs result :value])))
+    (is (= 2 (count (program-runtime/staging-plan call :execution))))
+    (is (false? (get-in call [:attributes :source-inspected])))))


### PR DESCRIPTION
## Summary
- validate emitted equation-first programs independently of the OpenCL backend
- bind loop iterations and ordinary equation graphs from retained ABI and physical-result facts
- evaluate only effect-free host scalar equations independent of device results
- stage every graph before the first resident launch and release transactionally

## Verification
- `clojure -M:test -n raster.compiler.ir.parallel-program-test -n raster.compiler.passes.parallel.structured-control-lower-test -n raster.compiler.passes.parallel.structured-control-route-test -n raster.compiler.backend.gpu.segop-opencl-test -n raster.gpu.structured-loop-test`
- 43 tests, 215 assertions