### PR TITLE
Route real RK4 through typed structured control

### DIFF
--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -1193,9 +1193,8 @@
                     (emit-node node) (:operation node))))]
     (finalize-emitted-graph emitted :opencl-c)))
 
-(defn- generate-elementwise-kernel-graph
-  [graph {:keys [scalar-types array-types]
-          :or {scalar-types {} array-types {}}}]
+(defn- graph-array-types
+  [graph array-types]
   (let [declared-array-types
         (into {}
               (map (juxt :id :dtype))
@@ -1207,8 +1206,13 @@
                   :when (and supplied (not= supplied declared))]
             (throw (ex-info "kernel graph buffer dtype differs from target emission facts"
                             {:reason :kernel-graph-buffer-dtype
-                             :buffer id :declared declared :supplied supplied})))
-        array-types (merge array-types declared-array-types)
+                             :buffer id :declared declared :supplied supplied})))]
+    (merge array-types declared-array-types)))
+
+(defn- generate-elementwise-kernel-graph
+  [graph {:keys [scalar-types array-types]
+          :or {scalar-types {} array-types {}}}]
+  (let [array-types (graph-array-types graph array-types)
         emitted
         (kgraph/map-operations
          graph
@@ -1239,6 +1243,27 @@
             operation)))]
     (finalize-emitted-graph emitted :opencl-c)))
 
+(defn- generate-reduction-kernel-graph
+  [graph {:keys [scalar-types array-types]
+          :or {scalar-types {} array-types {}}}]
+  (let [array-types (graph-array-types graph array-types)
+        emitted
+        (kgraph/map-operations
+         graph
+         (fn [{:keys [id operation]}]
+           (let [outputs (vec (:outputs operation))]
+             (when-not (= 1 (count outputs))
+               (throw (ex-info "scalar SegRed graph node requires exactly one scheduled output"
+                               {:reason :kernel-graph-reduction-output
+                                :target :opencl-c :node id :outputs outputs})))
+             (kart/certify-scheduled-operation
+              (generate-segred-kernel
+               operation (first outputs)
+               :dtype (:dtype operation)
+               :scalar-types scalar-types :array-types array-types)
+              operation))))]
+    (finalize-emitted-graph emitted :opencl-c)))
+
 (defn generate-kernel-graph
   "Target-lower one scheduled KernelGraph through the backend's single graph-emission boundary.
 
@@ -1256,6 +1281,11 @@
                         (instance? raster.compiler.ir.segop.SegStencil (:operation %)))
                    (:nodes graph)))
       (generate-elementwise-kernel-graph graph opts)
+
+      (and (seq (:nodes graph))
+           (every? #(instance? raster.compiler.ir.segop.SegRed (:operation %))
+                   (:nodes graph)))
+      (generate-reduction-kernel-graph graph opts)
 
       :else
       (throw (ex-info "OpenCL backend has no target lowering for scheduled KernelGraph"

--- a/src/raster/compiler/core/op_descriptor.clj
+++ b/src/raster/compiler/core/op_descriptor.clj
@@ -82,7 +82,9 @@
                         (and (symbol? expr) (contains? param-idx expr))
                         (nth args (get param-idx expr))
                         (seq? expr)
-                        (apply list (first expr) (map #(resolve-to-args % args) (rest expr)))
+                        (with-meta
+                          (apply list (first expr) (map #(resolve-to-args % args) (rest expr)))
+                          (meta expr))
                         :else expr))
                     alloc-ctor (first body)]
                 {:allocates? true
@@ -139,7 +141,9 @@
                             (and (symbol? expr) (get binding-map expr))
                             (resolve-to-args (get binding-map expr) args)
                             (seq? expr)
-                            (apply list (first expr) (map #(resolve-to-args % args) (rest expr)))
+                            (with-meta
+                              (apply list (first expr) (map #(resolve-to-args % args) (rest expr)))
+                              (meta expr))
                             :else expr))]
                     ;; Build into-variant: body with alloc binding → buf param
                     (let [alloc-sym (:sym match)

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -24,7 +24,8 @@
             [raster.compiler.ir.soac-dialect :as soac-dialect]
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.segop :as segop]
-            [raster.compiler.passes.parallel.execution-plan :as execution-plan]))
+            [raster.compiler.passes.parallel.execution-plan :as execution-plan]
+            [raster.compiler.passes.parallel.segred-body :as segred-body]))
 
 (declare lower-reduce)
 (declare lower-map)
@@ -786,9 +787,27 @@
               phase-2-space (segop/make-seg-space phase-2-idx (:num-blocks grid-1))
               grid-2 (single-block-grid grid-1)
               level-2 (segop/->SegLevel :block :none)
+              {:keys [operator identity accumulator]} (segred-body/scalar-plan phase-1)
+              combine-op ({:+ 'clojure.core/+
+                           :* 'clojure.core/*
+                           :min 'clojure.core/min
+                           :max 'clojure.core/max} operator)
+              component (first (:components reduction))
+              phase-2-reduction
+              (reduction/scalar
+               {:accumulator accumulator
+                :neutral identity
+                :dtype (:dtype component)
+                :result (:sym soac)
+                :index phase-2-idx
+                :step-result (list combine-op accumulator
+                                   (list 'clojure.core/aget partials-sym phase-2-idx))
+                :algebra (:algebra reduction)
+                :attributes (assoc (:attributes reduction)
+                                   :physical-phase :cross-block)})
               phase-2 (segop/->SegRed (+ (:id soac) 1000)
                                       phase-2-space level-2
-                                      reduction nil
+                                      phase-2-reduction nil
                                       #{partials-sym} #{(:sym soac)}
                                       #{} grid-2 :cross-block nil
                                       dtype)]

--- a/src/raster/compiler/passes/parallel/structured_control_frontend.clj
+++ b/src/raster/compiler/passes/parallel/structured_control_frontend.clj
@@ -56,13 +56,14 @@
 
 (defn- fresh-allocation-bindings
   [pairs]
-  (into #{}
-        (keep (fn [[binder initializer]]
-                (when (and (seq? initializer)
-                           (descriptor/alloc-op?
-                            (descriptor/semantic-op initializer)))
-                  binder)))
-        pairs))
+  (reduce (fn [fresh [binder initializer]]
+            (if (or (and (seq? initializer)
+                         (descriptor/alloc-op?
+                          (descriptor/semantic-op initializer)))
+                    (and (symbol? initializer) (contains? fresh initializer)))
+              (conj fresh binder)
+              fresh))
+          #{} pairs))
 
 (defn- arraycopy-destination
   [expression]
@@ -160,6 +161,30 @@
                         body {})]
     (assoc state :result result)))
 
+(defn- terminal-copy
+  "Find the final state transition modulo an ordinary return of the copied destination.
+
+   Expanded mutating helpers conventionally spell their value semantics as
+   `(do (System/arraycopy next ... carry ...) carry)`. The trailing `carry` is not another state
+   transition, so the functional body excludes both it and the certified copy. Any other trailing
+   expression remains unsupported."
+  [pairs]
+  (when (seq pairs)
+    (let [[copy-binding copy-expression] (peek pairs)
+          copy-destination (arraycopy-destination copy-expression)]
+      (if copy-destination
+        {:binding copy-binding :expression copy-expression :body-pairs (pop pairs)}
+        (when (< 1 (count pairs))
+          (let [[returned-binding returned-expression] (peek pairs)
+                before-return (pop pairs)
+                [copy-binding copy-expression] (peek before-return)
+                copy-destination (arraycopy-destination copy-expression)]
+            (when (and (symbol? returned-expression)
+                       (= returned-expression copy-destination))
+              {:binding copy-binding :expression copy-expression
+               :returned-binding returned-binding
+               :body-pairs (pop before-return)})))))))
+
 (defn- values->array-types
   [values]
   (into {} (keep (fn [[id value]]
@@ -228,8 +253,10 @@
               reserved (source-symbols source)
               flattened (flatten-loop-body loop-body reserved)
               flattened-pairs (:pairs flattened)
-              [copy-binding copy-expression] (peek flattened-pairs)
-              body-pairs (when (seq flattened-pairs) (pop flattened-pairs))
+              terminal (terminal-copy flattened-pairs)
+              copy-binding (:binding terminal)
+              copy-expression (:expression terminal)
+              body-pairs (:body-pairs terminal)
               flattened-source (when (seq flattened-pairs)
                                  (list 'let* (vec (mapcat identity flattened-pairs))
                                        copy-binding))
@@ -270,13 +297,14 @@
                   typed-values (:values body-analysis)
                   typed-program
                   (typed-frontend/form->program
-                   typed-source
+                   (typed-frontend/normalize-source typed-source)
                    {:dtype dtype
                     :values (assoc typed-values iteration
                                    (av/tensor {:dtype :long :shape []}))
                     :array-types (merge (values->array-types typed-values) array-types)
                     :scalar-types (merge (values->scalar-types typed-values) scalar-types
-                                         {iteration :long})})]
+                                         {iteration :long})
+                    :shape-equalities (:equalities body-analysis)})]
               (when typed-program
                 (let [typed-program (add-iteration-value typed-program iteration)
                       [fused fusion-stats]
@@ -309,10 +337,18 @@
                                     (vec (concat [iteration-parameter]
                                                  (map :parameter invariant-bindings)
                                                  [carry-parameter]))))
-                          outer-values (assoc boundary-values
-                                              carry-output
-                                              (get-in outer-analysis
-                                                      [:values carry-initial]))
+                          outer-operands
+                          (vec (concat (when (soac/value-id? trip-count) [trip-count])
+                                       (map :outer invariant-bindings)
+                                       [carry-initial]))
+                          ;; A loop retains exactly its semantic boundary, not every value visible
+                          ;; in the enclosing lexical scope. Suffix-only values are certified by
+                          ;; the suffix TypedSOAC program and must not create false value conflicts
+                          ;; when that program refines a conservative shape.
+                          outer-values
+                          (assoc (select-keys boundary-values outer-operands)
+                                 carry-output
+                                 (get-in outer-analysis [:values carry-initial]))
                           loop-facts
                           {:id (symbol (str (name binder) "-typed-fixpoint"))
                            :effects (:effects (soac/facts body))

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -665,8 +665,30 @@
                 {:kind :scalar :id id :sym symbol :expr expression})))
         (range) pairs))
 
+(defn- canonical-extent
+  [equalities values extent]
+  (loop [extent extent seen #{}]
+    (let [wrapped? (and (seq? extent) (= 'value (first extent)) (= 2 (count extent)))
+          inner (if wrapped? (second extent) extent)
+          normalized (descriptor/unwrap-int-cast inner)
+          array (alength-array normalized)
+          proved-shape (when array (:shape (get values array)))
+          proved-extent (when (= 1 (count proved-shape)) (first proved-shape))
+          next (or proved-extent
+                   (get equalities normalized)
+                   (get equalities inner)
+                   (when-not (= inner normalized) normalized)
+                   extent)]
+      (cond
+        (or (= next extent) (contains? seen next)) extent
+        ;; `(value compound-id)` is an unambiguous dimension reference. Once relational facts
+        ;; prove that compound value equal to a proper dimension, the wrapper has served its
+        ;; purpose and must not survive as a distinct shape.
+        (and wrapped? (= next inner)) extent
+        :else (recur next (conj seen extent))))))
+
 (defn- normalize-extents
-  [descriptions]
+  [descriptions shape-equalities values]
   (:descriptions
    (reduce
     (fn [{:keys [extents scalar-representatives] :as state} description]
@@ -674,11 +696,13 @@
         :scalar
         (let [expression (:expr description)
               array (alength-array expression)
+              proved-extent (canonical-extent shape-equalities values expression)
               representative (cond
                                (and array (contains? extents array)) (get extents array)
                                (symbol? expression)
                                (get scalar-representatives expression expression)
                                (integer? expression) expression
+                               (not= proved-extent expression) proved-extent
                                :else (:sym description))]
           (-> state
               (update :descriptions conj
@@ -689,9 +713,11 @@
         (:map :scatter :stencil :reduce :scan)
         (let [extent (descriptor/unwrap-int-cast (:extent description))
               array (alength-array extent)
+              proved-extent (canonical-extent shape-equalities values extent)
               extent' (cond
                         (and array (contains? extents array)) (get extents array)
                         (symbol? extent) (get scalar-representatives extent extent)
+                        (not= proved-extent extent) proved-extent
                         :else extent)
               description' (assoc description :extent extent')]
           (cond-> (update state :descriptions conj description')
@@ -1194,20 +1220,25 @@
                    results result-dtypes)))))
 
 (defn- merge-value
-  [values id contract]
-  (if-let [prior (get values id)]
-    (let [unknown-shape? (fn [value]
-                           (= [(list 'unknown-dimension id)] (:shape value)))
-          same-nonshape-contract? (= (dissoc prior :shape) (dissoc contract :shape))]
-      (cond
-        (= prior contract) values
-        (and same-nonshape-contract? (unknown-shape? prior)) (assoc values id contract)
-        (and same-nonshape-contract? (unknown-shape? contract)) values
-        :else
-        (fail! :source-value-conflict
-               "source bindings imply incompatible AbstractValues for one logical value"
-               {:id id :first prior :second contract})))
-    (assoc values id contract)))
+  ([values id contract] (merge-value values id contract {}))
+  ([values id contract shape-equalities]
+   (if-let [prior (get values id)]
+     (let [unknown-shape? (fn [value]
+                            (= [(list 'unknown-dimension id)] (:shape value)))
+           same-nonshape-contract? (= (dissoc prior :shape) (dissoc contract :shape))
+           equivalent-shape?
+           (= (mapv #(canonical-extent shape-equalities values %) (:shape prior))
+              (mapv #(canonical-extent shape-equalities values %) (:shape contract)))]
+       (cond
+         (= prior contract) values
+         (and same-nonshape-contract? equivalent-shape?) (assoc values id contract)
+         (and same-nonshape-contract? (unknown-shape? prior)) (assoc values id contract)
+         (and same-nonshape-contract? (unknown-shape? contract)) values
+         :else
+         (fail! :source-value-conflict
+                "source bindings imply incompatible AbstractValues for one logical value"
+                {:id id :first prior :second contract})))
+     (assoc values id contract))))
 
 (defn form->program
   "Construct and validate TypedSOAC directly from a closed let form.
@@ -1215,12 +1246,13 @@
    Returns nil when any binding is outside the certified source subset. Type/effect/value
    contradictions throw ExceptionInfo because falling through after accepting them would hide a
    compiler correctness defect."
-  [source {:keys [dtype array-types scalar-types values]
-           :or {dtype :double array-types {} scalar-types {} values {}}}]
+  [source {:keys [dtype array-types scalar-types values shape-equalities]
+           :or {dtype :double array-types {} scalar-types {} values {} shape-equalities {}}}]
   (when (and (seq? source) (contains? #{'let 'let*} (first source)))
     (let [[_ bindings & body] source
           pairs (vec (partition 2 bindings))
-          descriptions (normalize-extents (source-descriptions pairs dtype))]
+          descriptions (normalize-extents (source-descriptions pairs dtype)
+                                          shape-equalities values)]
       (when (and (even? (count bindings))
                  (seq descriptions)
                  (supported-descriptions? descriptions))
@@ -1299,12 +1331,13 @@
                                    (:result-storage description))))
                     equation-descriptions)
               inferred-values (reduce (fn [contracts equation]
-                                        (reduce-kv merge-value contracts
+                                        (reduce-kv #(merge-value %1 %2 %3 shape-equalities) contracts
                                                    (equation-values equation dtype array-types'
                                                                     scalar-types
                                                                     contracts)))
                                       destination-values equations)
-              values (reduce-kv merge-value inferred-values values)
+              values (reduce-kv #(merge-value %1 %2 %3 shape-equalities)
+                                inferred-values values)
               equation-facts
               (into {}
                     (map (fn [description]

--- a/src/raster/compiler/passes/scalar/host_abstract_value.clj
+++ b/src/raster/compiler/passes/scalar/host_abstract_value.clj
@@ -7,6 +7,7 @@
    analysis proves a complete same-dtype state copy."
   (:require [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.types :as types]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.form :as form]
             [raster.compiler.ir.par :as par]))
@@ -106,9 +107,19 @@
       state)
     state))
 
+(defn- retain-extent-equality
+  [state expression extent]
+  (let [normalized (descriptor/unwrap-int-cast expression)]
+    (cond-> state
+      (not= normalized extent) (assoc-in [:equalities normalized] extent)
+      (not= expression normalized) (assoc-in [:equalities expression] extent))))
+
 (defn- infer-value
   [state symbol expression default-dtype]
   (let [values (:values state)
+        retained-scalar-dtype
+        (or (some-> symbol types/sym-type-tag dtype/dtype-for-scalar-tag)
+            (some-> expression types/sym-type-tag dtype/dtype-for-scalar-tag))
         cast-dtype (scalar-cast-dtype expression)
         inner (when (and cast-dtype (= 1 (count (descriptor/call-args expression))))
                 (first (descriptor/call-args expression)))
@@ -152,38 +163,43 @@
         state)
 
       allocation
-      (assoc-in state [:values symbol]
-                (tensor (:dtype allocation)
-                        [(or (shape-extent state (:extent allocation))
-                             (:extent allocation))]))
+      (let [extent (or (shape-extent state (:extent allocation))
+                       (:extent allocation))]
+        (-> state
+            (retain-extent-equality (:extent allocation) extent)
+            (assoc-in [:values symbol] (tensor (:dtype allocation) [extent]))))
 
       (par/par-map-pure-form? expression)
       (let [{:keys [bound cast elem-type]} (par/extract-par-map-pure-info expression)
             cast-dtype (some-> cast descriptor/cast-result-tag
                                dtype/dtype-for-scalar-tag)
-            elem-type (some-> elem-type dtype/canon)]
+            elem-type (some-> elem-type dtype/canon)
+            extent (or (shape-extent state bound) bound)]
         (when (and elem-type cast-dtype (not= elem-type cast-dtype))
           (throw (ex-info "parallel map element type disagrees with its explicit cast"
                           {:reason :host-abstract-value-pmap-dtype
                            :element-type elem-type :cast-dtype cast-dtype
                            :expression expression})))
-        (assoc-in state [:values symbol]
-                  (tensor (or elem-type cast-dtype default-dtype)
-                          [(or (shape-extent state bound) bound)])))
+        (-> state
+            (retain-extent-equality bound extent)
+            (assoc-in [:values symbol]
+                      (tensor (or elem-type cast-dtype default-dtype) [extent]))))
 
       destination-write
       (let [{:keys [bound cast elem-type]} destination-write
             cast-dtype (some-> cast descriptor/cast-result-tag
                                dtype/dtype-for-scalar-tag)
-            elem-type (some-> elem-type dtype/canon)]
+            elem-type (some-> elem-type dtype/canon)
+            extent (or (shape-extent state bound) bound)]
         (when (and elem-type cast-dtype (not= elem-type cast-dtype))
           (throw (ex-info "parallel write element type disagrees with its explicit cast"
                           {:reason :host-abstract-value-write-dtype
                            :element-type elem-type :cast-dtype cast-dtype
                            :expression expression})))
-        (assoc-in state [:values symbol]
-                  (tensor (or elem-type cast-dtype default-dtype)
-                          [(or (shape-extent state bound) bound)])))
+        (-> state
+            (retain-extent-equality bound extent)
+            (assoc-in [:values symbol]
+                      (tensor (or elem-type cast-dtype default-dtype) [extent]))))
 
       (symbol? expression)
       (if-let [value (get values expression)]
@@ -192,6 +208,12 @@
 
       cast-dtype
       (assoc-in state [:values symbol] (tensor cast-dtype []))
+
+      retained-scalar-dtype
+      ;; The walker/TypedClojure result type is authoritative. We deliberately do not inspect the
+      ;; operator here: this pass propagates retained contracts and relational shapes; it is not a
+      ;; second scalar type-inference engine.
+      (assoc-in state [:values symbol] (tensor retained-scalar-dtype []))
 
       :else state)))
 

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -48,6 +48,7 @@
             [raster.compiler.backend.gpu.par-opencl :as par-opencl]
             [raster.compiler.backend.gpu.c-emit :as c-emit]
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
+            [raster.compiler.backend.gpu.parallel-program-opencl :as parallel-program-opencl]
             [raster.compiler.backend.gpu.gemm :as gpu-gemm]
             [raster.compiler.passes.parallel.compound-detect :as compound-detect]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
@@ -976,17 +977,32 @@
       ;; Attach the declared scalar/array types (from opts) onto the form so opencl-pass's
       ;; generators read declared types instead of guessing. The materialized form preserves
       ;; the original param symbols, so a name-keyed type map still applies.
-        (let [form (cond-> form
-                     (or (:scalar-types opts) (:array-types opts))
-                     (vary-meta assoc :scalar-types (:scalar-types opts) :array-types (:array-types opts)))
-              result (opencl-pass/opencl-pass form
-                                              :device-id target-device
-                                              :dtype (:dtype opts)
-                                              :schedule (:schedule opts))]
-          (register-gpu-kernels! (:kernels result) target-device)
-          (register-gpu-dispatches! (:dispatches result) target-device)
-          {:form (:form result) :stats (:stats result)
-           :kernels (:kernels result) :dispatches (:dispatches result) :backend :opencl})
+        (if (and (parallel-program/parallel-program? form)
+                 (= :scheduled-parallel (:dialect form)))
+          (let [{:keys [program kernels stats]}
+                (parallel-program-opencl/emit-program form opts)]
+            ;; Emission is complete and source-independent here. The ordinary compile-aot entry
+            ;; cannot guess physical buffers, scalar values, or loop scratch for the checked
+            ;; whole-program call; doing so would reintroduce the source/ABI binder this vertical
+            ;; removed. The resident-call integration is the next explicit compiler boundary.
+            (throw (ex-info
+                    "emitted parallel program requires an explicit checked runtime call"
+                    {:reason :emitted-parallel-program-call-required
+                     :target-dialect :opencl-parallel
+                     :program program :kernel-count (count kernels)
+                     :emission-stats stats :fallback :none})))
+          (let [form (cond-> form
+                       (or (:scalar-types opts) (:array-types opts))
+                       (vary-meta assoc :scalar-types (:scalar-types opts)
+                                  :array-types (:array-types opts)))
+                result (opencl-pass/opencl-pass form
+                                                :device-id target-device
+                                                :dtype (:dtype opts)
+                                                :schedule (:schedule opts))]
+            (register-gpu-kernels! (:kernels result) target-device)
+            (register-gpu-dispatches! (:dispatches result) target-device)
+            {:form (:form result) :stats (:stats result)
+             :kernels (:kernels result) :dispatches (:dispatches result) :backend :opencl}))
 
         :simd
         (let [clean-form (strip-compound-markers form)

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -14,10 +14,31 @@
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.soac-lower :as lower]
             [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
             [raster.compiler.backend.gpu.segop-opencl :as sg]))
+
+(deftest two-phase-reduction-graph-emits-its-explicit-scheduled-dataflow
+  (let [source '(let* [result (raster.par/reduce acc 0.0 i n
+                                                  (+ acc (clojure.core/aget a i)))]
+                      result)
+        options {:dtype :double :array-types {'a :double}
+                 :scalar-types {'n :long}}
+        typed (:program (typed-route/attempt source :double {'a :double} options))
+        algorithm (get-in typed [:equations 0 :algorithm])
+        scheduled (:form (segop-lower/segop-lower-pass typed options))
+        graph (equation-graph/make algorithm scheduled)
+        emitted (sg/generate-kernel-graph
+                 graph :array-types {'a :double} :scalar-types {'n :long})
+        [phase-one phase-two] (mapv :operation (:nodes emitted))
+        partials (first (:inputs (second (mapv :operation (:nodes graph)))))]
+    (is (= 2 (count (:nodes emitted))))
+    (is (every? kart/kernel-artifact? [phase-one phase-two]))
+    (is (str/includes? (:source phase-two) (str (name partials) "[")))
+    (is (not (re-find #"\ba\[" (:source phase-two)))
+        "the cross-block target kernel must not resurrect the original reduction body")))
 
 (deftest typed-stencil-emits-a-guarded-typed-artifact
   (let [source '(let* [result
@@ -147,7 +168,7 @@
     ;; Before the fix, op-args extraction took a0=acc a1=x and DROPPED y — emitting a
     ;; kernel that reduced with just x. A segmented reduce combine is binary (op acc elem).
     (is (thrown-with-msg?
-         Exception #"only a binary \(op acc elem\) combine"
+         Exception #"binary associative scalar combine"
          (segred-source '(+ acc (clojure.core/aget a j) (clojure.core/aget b j))))))
   (testing "the ordinary binary combine still lowers unchanged"
     (let [source (segred-source '(+ acc (clojure.core/aget a j)))]
@@ -159,7 +180,7 @@
     ;; The single-aset-void store-drop shape on the reduce side: (last bdy) silently dropped
     ;; the earlier body forms.
     (is (thrown-with-msg?
-         Exception #"multi-statement body"
+         Exception #"single-expression let region"
          (segred-source '(let* [t (clojure.core/aget a j)] (+ acc t) (+ acc t)))))))
 
 (deftest segred-devirtualized-aget-lowers-to-subscript

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -54,5 +54,5 @@
               :fallback-reasons [] :declines {}}}
 
   :heat-loss-rk4-gpu
-  {:declined {:reason :unscheduled-stencil
-              :target-dialect :opencl}}}}
+  {:declined {:reason :emitted-parallel-program-call-required
+              :target-dialect :opencl-parallel}}}}

--- a/test/raster/compiler/ir/segop_test.clj
+++ b/test/raster/compiler/ir/segop_test.clj
@@ -91,8 +91,17 @@
       (is (= :block-local (:phase (first segops))))
       (is (pos? (:shared-mem-bytes (:grid (first segops)))))
       ;; Phase 2: cross-block
-      (is (instance? raster.compiler.ir.segop.SegRed (second segops)))
-      (is (= :cross-block (:phase (second segops)))))))
+      (let [phase-two (second segops)
+            partials (first (:inputs phase-two))
+            index (get-in phase-two [:space :dims 0 :name])
+            {:keys [acc lambda]} (segop/scalar-reduce-op phase-two)]
+        (is (instance? raster.compiler.ir.segop.SegRed phase-two))
+        (is (= :cross-block (:phase phase-two)))
+        (is (= (list 'clojure.core/+ acc
+                     (list 'clojure.core/aget partials index))
+               lambda)
+            "the scheduled second phase reduces its partial buffer, not the original element body")
+        (is (not (contains? (:inputs phase-two) 'a)))))))
 
 (deftest lower-reduce-single-phase-test
   (testing "Small constant reduce lowers to a single SegRed"

--- a/test/raster/compiler/passes/parallel/structured_control_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_frontend_test.clj
@@ -65,6 +65,36 @@
       (is (lower/scheduled-loop? scheduled))
       (is (not-any? #{'scratch} (map :id (:inputs graph)))))))
 
+(deftest expanded-copy-helper-may-return-its-mutated-carry
+  (let [source (loop-source 'n)
+        bindings (second source)
+        dotimes (nth bindings 7)
+        copy-expression (last dotimes)
+        returning-copy (apply list (concat (butlast dotimes)
+                                           [(list 'do copy-expression 'u)]))
+        source (apply list 'let* (assoc bindings 7 returning-copy) (drop 2 source))
+        {:keys [loop copy-certificate typed-body-source]}
+        (frontend/form->structured-loop source options)]
+    (is (= loop (control/validate! loop)))
+    (is (= {:source 'rstr_loop_value_1 :destination 'u :extent 'n :dtype :double}
+           copy-certificate))
+    (is (not-any? #{'java.lang.System/arraycopy}
+                  (tree-seq coll? seq typed-body-source))
+        "the physical state transition is not retained as numerical body work")))
+
+(deftest fresh-prefix-allocation-may-flow-through-a-lexical-alias
+  (let [source (loop-source 'n)
+        source (update-bindings
+                source #(vec (concat (subvec % 0 4)
+                                     ['scratch-storage (nth % 5)
+                                      'scratch 'scratch-storage]
+                                     (subvec % 6))))
+        {:keys [loop write-certificates]}
+        (frontend/form->structured-loop source options)]
+    (is (= loop (control/validate! loop)))
+    (is (= [{:destination 'scratch :extent 'n :dtype :double :kind :stencil}]
+           write-certificates))))
+
 (deftest unsupported-or-ambiguous-state-transitions-decline-or-fail-exactly
   (testing "a partial copy is not silently interpreted as a loop carry"
     (is (nil? (frontend/form->structured-loop (loop-source '(dec n)) options))))

--- a/test/raster/compiler/passes/parallel/structured_control_route_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_route_test.clj
@@ -19,7 +19,8 @@
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
             [raster.compiler.pipeline :as pipeline]
-            [raster.gpu.parallel-program :as program-runtime]))
+            [raster.gpu.parallel-program :as program-runtime]
+            [raster.ode.pde :as pde]))
 
 (defn- loop-decomposition
   []
@@ -259,6 +260,32 @@
                (reason-of #(program-opencl/validate-program!
                             (assoc-in program [:equations 0 :operations]
                                       [suffix-operation])))))))))
+
+(deftest real-rk4-pde-reaches-the-equation-first-opencl-vertical
+  (let [options {:dtype :double :target-device :ze:debug
+                 :source-ns (the-ns 'raster.ode.pde)
+                 :array-types {'u0 :double 'target :double}
+                 :scalar-types {'alpha :double 'inv-dx2 :double
+                                'dt :double 'nsteps :long}}
+        walked (pipeline/get-walked-body #'pde/heat-loss-rk4 :double)
+        source (if (= 1 (count walked)) (first walked) (list* 'do walked))
+        semantic (pipeline/run-passes
+                  source pipeline/gpu-resident-pre-soa-passes options)
+        scheduled (route/schedule-program semantic options)
+        emitted (program-opencl/emit-program scheduled options)
+        loop-operation (get-in scheduled [:equations 0 :operations 0])]
+    (is (= :typed-parallel (:dialect semantic)))
+    (is (= :scheduled-parallel (:dialect scheduled)))
+    (is (= 4 (count (:equations scheduled)))
+        "one generic fixpoint and three suffix equations represent the RK4 loss")
+    (is (= 8 (count (get-in loop-operation [:graph :nodes])))
+        "the loop body is the ordinary stencil/map schedule, not an RK4 primitive")
+    (is (= :opencl-parallel (get-in emitted [:program :dialect])))
+    (is (= 10 (count (:kernels emitted))))
+    (is (= {:structured-loops-emitted 1
+            :typed-equations-emitted 1
+            :host-scalar-equations 2}
+           (:stats emitted)))))
 
 (defn- prepared-mixed-call
   [trip-count]

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -1,5 +1,6 @@
 (ns raster.compiler.passes.parallel.typed-soac-frontend-test
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.soac :as legacy]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.ir.segop :as segop]
@@ -59,6 +60,21 @@
            (get-in (route/attempt source :float {'x :float 'target :float}
                                   {:scalar-types {'nrows :long 'width :long}})
                    [:stats :front-end])))))
+
+(deftest retained-array-shapes-prove-compound-parallel-extents
+  (let [program
+        (frontend/form->program
+         '(let* [total (raster.par/reduce acc 0.0 i
+                                           (clojure.core/alength x)
+                                           (+ acc (clojure.core/aget x i)))]
+                total)
+         {:dtype :double
+          :values {'x (av/tensor {:dtype :double :shape ['n]})}
+          :array-types {'x :double}
+          :scalar-types {'n :long}})
+        equation (first (dialect/equations program))]
+    (is (= 'n (dialect/operation-extent equation)))
+    (is (= ['n] (get-in (dialect/facts program) [:values 'x :shape])))))
 
 (deftest devirtualized-output-allocation-is-generated-scaffolding
   (let [allocation (with-meta

--- a/test/raster/compiler/passes/scalar/host_abstract_value_test.clj
+++ b/test/raster/compiler/passes/scalar/host_abstract_value_test.clj
@@ -28,6 +28,8 @@
     (is (= ['n] (get-in analysis [:values 'u :shape])))
     (is (= ['n] (get-in analysis [:values 'scratch :shape])))
     (is (= ['n] (get-in analysis [:values 'next :shape])))
+    (is (= 'n (get-in analysis [:equalities '(clojure.core/alength u)]))
+        "the syntax extent used by TypedSOAC retains its relational shape proof")
     (is (= {:source 'next :destination 'u :extent 'n :dtype :double}
            (host-av/full-array-copy analysis copy-expression)))))
 
@@ -69,6 +71,18 @@
     (is (= :float (get-in analysis [:values 'y :dtype])))
     (is (= ['n] (get-in analysis [:values 'y :shape])))
     (is (nil? (get-in analysis [:values 'unknown])))))
+
+(deftest retained-scalar-metadata-is-propagated-without-operator-inference
+  (let [binding (with-meta 'derived {:raster.type/tag 'double})
+        expression (with-meta '(unknown.library/scalar-op input) {:tag 'double})
+        analysis (host-av/analyze
+                  (list 'let* [binding expression
+                               'untyped '(unknown.library/scalar-op input)]
+                        binding)
+                  {})]
+    (is (= {:kind :tensor :dtype :double :shape []}
+           (select-keys (get-in analysis [:values binding]) [:kind :dtype :shape])))
+    (is (nil? (get-in analysis [:values 'untyped])))))
 
 (deftest complete-parallel-writes-retain-their-destination-contract
   (let [source


### PR DESCRIPTION
## Outcome

Routes the real `heat-loss-rk4` workload through the generic typed structured-control vertical and equation-first OpenCL emission. No RK4/PDE primitive or operator type registry is introduced.

## Compiler changes

- Preserve devirtualized allocation metadata and fresh allocation aliases.
- Recognize expanded `arraycopy` helpers that return their destination.
- Propagate retained TypedClojure scalar contracts and relational shape equalities into Typed SOAC.
- Keep structured-loop boundaries minimal so suffix-only values are refined by their own equations.
- Make two-phase scalar reductions explicit `input -> partials -> result` dataflow.
- Emit scheduled SegRed KernelGraphs equation-first.
- Report the remaining public `compile-aot` seam as `:emitted-parallel-program-call-required` instead of falling into the legacy stencil backend.

## Verification

- Focused suite: 82 tests, 392 assertions.
- Cold real-workload regression: `heat-loss-rk4` becomes one generic fixpoint plus three suffix equations and emits ten checked OpenCL kernels without GPU hardware.
- CUDA/HIP compile gates remain inherited from the stack.