### PR TITLE
Bound structured loop graph replay

### DIFF
--- a/src/raster/compiler/core/dtype.clj
+++ b/src/raster/compiler/core/dtype.clj
@@ -37,13 +37,16 @@
             :bytes 2 :jvm-array-class-name "[S" :aliases #{:float16 :f16}}
    :int    {:native {:c "int" :opencl "int" :glsl "int"}
             :scalar-tag 'int :array-tag 'ints :vt :i32 :needs-pragma nil :fp? false
-            :bytes 4 :jvm-array-class-name "[I" :aliases #{:int32 :i32}}
+            :bytes 4 :jvm-array-class-name "[I" :aliases #{:int32 :i32}
+            :limits {:min Integer/MIN_VALUE :max Integer/MAX_VALUE}}
    :long   {:native {:c "long long" :opencl "long" :glsl "int"}
             :scalar-tag 'long :array-tag 'longs :vt :i64 :needs-pragma nil :fp? false
-            :bytes 8 :jvm-array-class-name "[J" :aliases #{:int64 :i64}}
+            :bytes 8 :jvm-array-class-name "[J" :aliases #{:int64 :i64}
+            :limits {:min Long/MIN_VALUE :max Long/MAX_VALUE}}
    :byte   {:native {:c "int8_t" :opencl "char" :glsl "int"}
             :scalar-tag 'byte :array-tag 'bytes :vt :i32 :needs-pragma nil :fp? false
-            :bytes 1 :jvm-array-class-name "[B" :aliases #{:int8 :i8}}})
+            :bytes 1 :jvm-array-class-name "[B" :aliases #{:int8 :i8}
+            :limits {:min Byte/MIN_VALUE :max Byte/MAX_VALUE}}})
 
 (def ^:private alias->canonical
   (into {} (for [[k v] dtype-info, a (cons k (:aliases v))] [a k])))

--- a/src/raster/compiler/core/op_descriptor.clj
+++ b/src/raster/compiler/core/op_descriptor.clj
@@ -925,7 +925,7 @@
    single source emitters use to seed accumulators (segop-simd, GPU segred).
    Derived from the :algebra facet's abstract identity; min/max (whose abstract
    identity is nil — no identity over unbounded domains) become the dtype's
-   ∓Infinity, which IS their identity over IEEE floats. Emits a LITERAL or a
+   ∓Infinity over IEEE floats or exact extrema over bounded integers. Emits a LITERAL or a
    symbol suitable for splicing into generated code. Throws for ops without a
    registered monoid — an unregistered reduction must fail loud, not seed 0."
   [op-sym dtype]
@@ -935,16 +935,23 @@
       (throw (ex-info (str "no :algebra facet for reduction op " op-sym
                            " — register it (op-descriptor) before reducing with it")
                       {:op op-sym :dtype dtype})))
-    (let [float? (contains? #{:half :float} dtype)]
+    (let [dtype (dtype/canon dtype)
+          floating? (not (dtype/integral? dtype))
+          float-width? (contains? #{:half :float} dtype)
+          limits (:limits (dtype/info dtype))]
       (case base
-        (min Math/min) (if float? 'Float/POSITIVE_INFINITY 'Double/POSITIVE_INFINITY)
-        (max Math/max) (if float? 'Float/NEGATIVE_INFINITY 'Double/NEGATIVE_INFINITY)
+        (min Math/min) (if floating?
+                         (if float-width? 'Float/POSITIVE_INFINITY 'Double/POSITIVE_INFINITY)
+                         (:max limits))
+        (max Math/max) (if floating?
+                         (if float-width? 'Float/NEGATIVE_INFINITY 'Double/NEGATIVE_INFINITY)
+                         (:min limits))
         ;; numeric monoids: type the abstract identity for the dtype
         (let [id (:identity a)]
           (cond
             (nil? id) (throw (ex-info (str "op " op-sym " has no identity") {:op op-sym}))
             (contains? #{:int :long :byte} dtype) id
-            float?    (list 'float (double id))
+            float-width? (list 'float (double id))
             :else     (double id)))))))
 
 ;; --- Analytic cost (:cost facet; hardware-guided fusion profitability) ---

--- a/src/raster/compiler/ir/scan.clj
+++ b/src/raster/compiler/ir/scan.clj
@@ -6,6 +6,7 @@
    only when the body is an associative combine of the prior accumulator and an accumulator-free
    element expression. This boundary proves that property before SegScan scheduling."
   (:require [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.dtype :as dtype]
             [raster.compiler.passes.scalar.effects :as effects]
             [raster.compiler.core.util :as util]))
 
@@ -14,15 +15,19 @@
 (defn associative-scan? [x]
   (and x (= "raster.compiler.ir.scan.AssociativeScan" (.getName (class x)))))
 
+(def ^:private cast-dtypes
+  {'float :float, 'clojure.core/float :float
+   'double :double, 'clojure.core/double :double
+   'int :int, 'clojure.core/int :int
+   'long :long, 'clojure.core/long :long})
+
 (defn- acc-ref?
-  [expr acc]
+  [expr acc reduction-dtype]
   (or (= expr acc)
       (and (seq? expr)
            (= 2 (count expr))
-           (contains? #{'float 'double 'int 'long
-                        'clojure.core/float 'clojure.core/double
-                        'clojure.core/int 'clojure.core/long}
-                      (first expr))
+           (= (dtype/canon reduction-dtype)
+              (some-> (get cast-dtypes (first expr)) dtype/canon))
            (= acc (second expr)))))
 
 (defn- contains-symbol?
@@ -33,23 +38,24 @@
     :else false))
 
 (defn- literal-value
-  [expr]
+  [expr _reduction-dtype]
   (if (and (seq? expr)
            (= 2 (count expr))
-           (contains? #{'float 'double 'int 'long
-                        'clojure.core/float 'clojure.core/double
-                        'clojure.core/int 'clojure.core/long}
-                      (first expr))
+           ;; Casts around literal identities are representation spelling, not accumulator
+           ;; evidence. Compare the literal exactly in the reduction domain below; unlike
+           ;; acc-ref?, accepting `(double 0.0)` for an explicitly float scan cannot change which
+           ;; value is carried or hide a cross-dtype accumulator.
+           (contains? cast-dtypes (first expr))
            (number? (second expr)))
     (second expr)
     expr))
 
 (defn- identity-equivalent?
-  [left right]
-  (let [left (literal-value left)
-        right (literal-value right)]
+  [left right reduction-dtype]
+  (let [left (literal-value left reduction-dtype)
+        right (literal-value right reduction-dtype)]
     (if (and (number? left) (number? right))
-      (== (double left) (double right))
+      (== left right)
       (= left right))))
 
 (defn- pure-element?
@@ -77,7 +83,7 @@
                      (throw exception))))
         combine (descriptor/semantic-op lambda)
         args (vec (descriptor/call-args lambda))
-        dtype (or dtype :double)
+        dtype (dtype/canon (or dtype :double))
         supported-dtypes (if (= :scan operation)
                            #{:int :long :float :double}
                            #{:byte :int :long :half :float :double})]
@@ -92,8 +98,8 @@
                        :combine combine :body lambda :reduction-op reduction-op})))
     (let [[left right] args
           element (cond
-                    (and (acc-ref? left acc) (not (contains-symbol? right acc))) right
-                    (and (acc-ref? right acc) (not (contains-symbol? left acc))) left
+                    (and (acc-ref? left acc dtype) (not (contains-symbol? right acc))) right
+                    (and (acc-ref? right acc dtype) (not (contains-symbol? left acc))) left
                     :else nil)]
       (when-not element
         (throw (ex-info "parallel reduction must combine one accumulator with an accumulator-free element"
@@ -104,7 +110,7 @@
                         {:reason (reason operation "element-impure-or-unknown")
                          :element element :body lambda :reduction-op reduction-op})))
       (let [identity (descriptor/typed-reduce-identity combine dtype)]
-        (when-not (identity-equivalent? init identity)
+        (when-not (identity-equivalent? init identity dtype)
           (throw (ex-info "parallel reduction with a non-identity init requires a distinct schedule"
                           {:reason (reason operation "nonidentity-init")
                            :combine combine :init init :identity identity :dtype dtype})))
@@ -131,11 +137,11 @@
        ;; Accumulators and element operands are lexical binders that may be alpha-renamed or
        ;; projected from captures between independently certified regions. The certificate is the
        ;; typed monoid contract; each concrete region has already been certified on its own.
+       (= (:dtype declared) (:dtype derived))
        (= (some-> (:combine declared) name symbol)
           (some-> (:combine derived) name symbol))
-       (identity-equivalent? (:init declared) (:init derived))
-       (identity-equivalent? (:identity declared) (:identity derived))
-       (= (:dtype declared) (:dtype derived))))
+       (identity-equivalent? (:init declared) (:init derived) (:dtype declared))
+       (identity-equivalent? (:identity declared) (:identity derived) (:dtype declared))))
 
 (defn certify
   "Certify `scan-op` as a parallel associative scan or throw a structured conversion decline.

--- a/src/raster/compiler/passes/parallel/scheduled_equation_graph.clj
+++ b/src/raster/compiler/passes/parallel/scheduled_equation_graph.clj
@@ -17,7 +17,16 @@
 
 (defn- value-elements
   [value]
-  (let [shape (:shape value)]
+  (let [dimension-value (fn [dimension]
+                          ;; AbstractValue uses `(value id)` to distinguish a compound stable
+                          ;; value ID from shape syntax. KernelGraph owns explicit integer
+                          ;; expressions, so remove only that marker at this physical boundary.
+                          (if (and (seq? dimension)
+                                   (= 'value (first dimension))
+                                   (= 2 (count dimension)))
+                            (second dimension)
+                            dimension))
+        shape (mapv dimension-value (:shape value))]
     (cond
       (empty? shape) 1
       (= 1 (count shape)) (first shape)

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -17,6 +17,7 @@
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.soac-dialect-adapter :as soac-adapter]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
+            [raster.compiler.passes.parallel.segred-body :as segred-body]
             [raster.compiler.ir.form :as form]
             [clojure.set :as set]))
 
@@ -334,16 +335,21 @@
                 (fn [values operation]
                   (if (and (instance? raster.compiler.ir.segop.SegRed operation)
                            (= :block-local (:phase operation)))
-                    (reduce (fn [values id]
-                              (if (contains? values id)
-                                values
-                                (assoc values id
-                                       (av/tensor
-                                        {:dtype (:dtype operation)
-                                         :shape [(:num-blocks (:grid operation))]
-                                         :representation {:kind :plain}
-                                         :memory-space :device}))))
-                            values (:outputs operation))
+                    (let [grid (:grid operation)
+                          reduced-bound (-> operation :space segop/seg-space-reduced-dim :bound)
+                          partial-extent
+                          (segred-body/launch-group-count
+                           (:num-blocks grid) reduced-bound (:block-size grid))]
+                      (reduce (fn [values id]
+                                (if (contains? values id)
+                                  values
+                                  (assoc values id
+                                         (av/tensor
+                                          {:dtype (:dtype operation)
+                                           :shape (soac-dialect/extent-shape partial-extent)
+                                           :representation {:kind :plain}
+                                           :memory-space :device}))))
+                              values (:outputs operation)))
                     values))
                 values (:operations equation))))
            (:values form) equations)

--- a/src/raster/gpu/parallel_program.clj
+++ b/src/raster/gpu/parallel_program.clj
@@ -1,40 +1,79 @@
 (ns raster.gpu.parallel-program
   "Stage-once execution of a checked emitted parallel program call.
 
-   Every numerical graph is bound before the first launch. Structured control is initially
-   realized as one pre-bound graph per host iteration; all buffers remain resident and suffix
-   equations consume the exact carry bindings selected by the call IR."
+   Every numerical graph is bound before the first launch. Structured control reuses prepared
+   graphs for equal carry-buffer variants; all buffers remain resident and suffix equations
+   consume the exact carry bindings selected by the call IR."
   (:refer-clojure :exclude [run!])
   (:require [raster.compiler.ir.emitted-parallel-program-call :as program-call]
             [raster.compiler.ir.structured-loop-call :as loop-call]))
 
+(defn- loop-staging-plan
+  [step execution-id step-index]
+  (when (and (get-in step [:scalars :iteration]) (> (:trip-count step) 1))
+    (throw (ex-info
+            "stage-once execution cannot freeze a changing loop induction scalar"
+            {:reason :parallel-program-dynamic-loop-binding
+             :step-index step-index :trip-count (:trip-count step)
+             :fallback :bounded-iteration-execution})))
+  ;; StructuredLoopCall has either an in-place carry or one initial buffer plus a two-buffer
+  ;; parity rotation. Consequently iteration zero and the two parities after it are the complete
+  ;; binding state space. Inspecting more iterations would only allocate O(trip-count) host data
+  ;; before the first launch—the exact failure bounded replay exists to avoid.
+  (reduce
+   (fn [{:keys [bindings entries] :as state} iteration]
+     (let [{:keys [buffers scalar-values]} (loop-call/iteration-binding step iteration)
+           binding [buffers scalar-values]]
+       (if (contains? bindings binding)
+         state
+         (let [variant (count bindings)
+               key [:parallel-program execution-id step-index :variant variant]]
+           (when (>= variant 3)
+             (throw (ex-info
+                     "structured loop produced more than the bounded carry rotation variants"
+                     {:reason :parallel-program-unbounded-loop-binding
+                      :step-index step-index :iteration iteration
+                      :variants (inc variant)})))
+           {:bindings (assoc bindings binding key)
+            :entries (conj entries
+                           {:key key :graph (:graph step)
+                            :buffers buffers :scalar-values scalar-values})}))))
+   {:bindings {} :entries []}
+   (range (min 3 (:trip-count step)))))
+
+(defn- preparation-plan
+  [call execution-id]
+  (reduce
+   (fn [{:keys [entries step-keys] :as plan} [step-index step]]
+     (cond
+       (program-call/evaluated-host-equation? step)
+       plan
+
+       (program-call/emitted-equation-call? step)
+       (let [key [:parallel-program execution-id step-index]]
+         {:entries (conj entries
+                         {:key key :graph (:graph step)
+                          :buffers (:buffers step)
+                          :scalar-values (:scalar-values step)})
+          :step-keys (assoc step-keys step-index key)})
+
+       (loop-call/structured-loop-call? step)
+       (let [{:keys [bindings] loop-entries :entries}
+             (loop-staging-plan step execution-id step-index)]
+         {:entries (into entries loop-entries)
+          :step-keys (assoc step-keys step-index bindings)})))
+   {:entries [] :step-keys {}}
+   (map-indexed vector (:steps call))))
+
 (defn staging-plan
-  "Return ordered graph bindings for a prepared program call without contacting a driver."
+  "Return the bounded set of distinct graph bindings to prepare without contacting a driver.
+
+   The initial preserved carry may add one prologue variant to the two parity variants. Both the
+   returned host data and the eventual driver bindings are therefore constant rather than
+   proportional to trip count; replay order is streamed separately by `run-with!`."
   [call execution-id]
   (let [call (program-call/validate! call)]
-    (vec
-     (mapcat
-      (fn [step-index step]
-        (cond
-          (program-call/evaluated-host-equation? step)
-          []
-
-          (program-call/emitted-equation-call? step)
-          [{:key [:parallel-program execution-id step-index]
-            :graph (:graph step)
-            :buffers (:buffers step)
-            :scalar-values (:scalar-values step)}]
-
-          (loop-call/structured-loop-call? step)
-          (mapv (fn [iteration]
-                  (let [{:keys [buffers scalar-values]}
-                        (loop-call/iteration-binding step iteration)]
-                    {:key [:parallel-program execution-id step-index iteration]
-                     :graph (:graph step)
-                     :buffers buffers
-                     :scalar-values scalar-values}))
-                (range (:trip-count step)))))
-      (range) (:steps call)))))
+    (:entries (preparation-plan call execution-id))))
 
 (defn run-with!
   "Bind the complete call, then execute it through an injected graph executor.
@@ -48,17 +87,37 @@
         (throw (ex-info "parallel program executor requires callable operations"
                         {:reason :parallel-program-executor
                          :operation operation :executor executor}))))
-    (let [staged (volatile! [])]
+    (let [staged (volatile! {})
+          binding-order (volatile! [])
+          plan (preparation-plan call (random-uuid))]
       (try
-        (doseq [{:keys [key graph buffers scalar-values]}
-                (staging-plan call (random-uuid))]
-          (vswap! staged conj (bind! key graph buffers scalar-values)))
-        (doseq [handle @staged]
-          (run! handle))
+        (doseq [{:keys [key graph buffers scalar-values]} (:entries plan)]
+          (let [handle (bind! key graph buffers scalar-values)]
+            (vswap! staged assoc key handle)
+            (vswap! binding-order conj key)))
+        (doseq [[step-index step] (map-indexed vector (:steps call))]
+          (cond
+            (program-call/evaluated-host-equation? step)
+            nil
+
+            (program-call/emitted-equation-call? step)
+            (run! (get @staged (get-in plan [:step-keys step-index])))
+
+            (loop-call/structured-loop-call? step)
+            (doseq [iteration (range (:trip-count step))]
+              (let [{:keys [buffers scalar-values]}
+                    (loop-call/iteration-binding step iteration)
+                    key (get-in plan [:step-keys step-index [buffers scalar-values]])]
+                (when-not key
+                  (throw (ex-info
+                          "structured loop escaped its certified bounded carry rotation"
+                          {:reason :parallel-program-unbounded-loop-binding
+                           :step-index step-index :iteration iteration})))
+                (run! (get @staged key))))))
         (:outputs call)
         (finally
-          (doseq [handle (rseq @staged)]
-            (release! handle)))))))
+          (doseq [key (rseq @binding-order)]
+            (release! (get @staged key))))))))
 
 (defn run!
   "Run a prepared emitted parallel program in one GPU session."

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -13,6 +13,7 @@
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-graph :as kgraph]
+            [raster.compiler.ir.kernel-graph-call :as graph-call]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
@@ -22,7 +23,7 @@
 
 (deftest two-phase-reduction-graph-emits-its-explicit-scheduled-dataflow
   (let [source '(let* [result (raster.par/reduce acc 0.0 i n
-                                                  (+ acc (clojure.core/aget a i)))]
+                                                 (+ acc (clojure.core/aget a i)))]
                       result)
         options {:dtype :double :array-types {'a :double}
                  :scalar-types {'n :long}}
@@ -33,22 +34,26 @@
         emitted (sg/generate-kernel-graph
                  graph :array-types {'a :double} :scalar-types {'n :long})
         [phase-one phase-two] (mapv :operation (:nodes emitted))
-        partials (first (:inputs (second (mapv :operation (:nodes graph)))))]
+        partials (first (:inputs (second (mapv :operation (:nodes graph)))))
+        temporary-specs (graph-call/temporary-specs
+                         emitted {'n {:type :long :value 1025}})]
     (is (= 2 (count (:nodes emitted))))
     (is (every? kart/kernel-artifact? [phase-one phase-two]))
     (is (str/includes? (:source phase-two) (str (name partials) "[")))
     (is (not (re-find #"\ba\[" (:source phase-two)))
-        "the cross-block target kernel must not resurrect the original reduction body")))
+        "the cross-block target kernel must not resurrect the original reduction body")
+    (is (= 2 (second (get temporary-specs partials)))
+        "dynamic two-phase scratch resolves through KernelLaunch IR at call time")))
 
 (deftest typed-stencil-emits-a-guarded-typed-artifact
   (let [source '(let* [result
-                        (raster.par/stencil!
-                         du [u] 1 :dirichlet double i n
-                         (* alpha inv-dx2
-                            (+ (clojure.core/aget u (clojure.core/- i 1))
-                               (* -2.0 (clojure.core/aget u i))
-                               (clojure.core/aget u (clojure.core/+ i 1)))))]
-                       result)
+                       (raster.par/stencil!
+                        du [u] 1 :dirichlet double i n
+                        (* alpha inv-dx2
+                           (+ (clojure.core/aget u (clojure.core/- i 1))
+                              (* -2.0 (clojure.core/aget u i))
+                              (clojure.core/aget u (clojure.core/+ i 1)))))]
+                      result)
         typed (-> (typed-route/attempt
                    source :double {'du :double 'u :double}
                    {:scalar-types {'n :long 'alpha :double 'inv-dx2 :double}})

--- a/test/raster/compiler/fail_loud_contraction_test.clj
+++ b/test/raster/compiler/fail_loud_contraction_test.clj
@@ -14,7 +14,7 @@
                 (list 'raster.numeric/* (list 'aget 'a 't) (list 'aget 'b 't))
                 :stages [{:axis 'blk :extent 2 :dtype :float :init 0.0 :lift 'inner}
                          {:axis 't :extent extent :dtype :int :init 0}])
-          (when combine [:combine combine :init 'Double/NEGATIVE_INFINITY])))
+          (when combine [:combine combine :init Byte/MIN_VALUE])))
 
 (deftest staged-refuses-a-combine-it-would-silently-turn-into-a-sum
   (testing "every accumulator level uses `+=` and a lift's linearity argument assumes addition, so

--- a/test/raster/compiler/ir/scan_test.clj
+++ b/test/raster/compiler/ir/scan_test.clj
@@ -1,5 +1,6 @@
 (ns raster.compiler.ir.scan-test
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.ir.scan :as scan]))
 
 (deftest associative-scan-certification
@@ -14,13 +15,43 @@
     (is (scan/associative-scan?
          (scan/certify {:acc 'acc :init 0.0
                         :lambda '(raster.numeric/+ (float acc) (aget values i))}
+                       :float))))
+  (testing "only a cast to the reduction dtype denotes the accumulator"
+    (doseq [body '[(+ (int acc) (aget values i))
+                   (+ (float acc) (aget values i))]]
+      (try
+        (scan/certify {:acc 'acc :init 0.0 :lambda body} :double)
+        (is false (str "cross-dtype accumulator cast must decline: " body))
+        (catch clojure.lang.ExceptionInfo exception
+          (is (= :scan-not-elementwise (:reason (ex-data exception))))))))
+  (testing "a frontend numeric-literal cast does not change the exact identity"
+    (is (scan/associative-scan?
+         (scan/certify {:acc 'acc :init '(double 0.0)
+                        :lambda '(+ acc (aget values i))}
                        :float)))))
+
+(deftest integral-min-max-use-the-exact-bounded-domain-identities
+  (is (= Integer/MAX_VALUE (descriptor/typed-reduce-identity 'min :int)))
+  (is (= Integer/MIN_VALUE (descriptor/typed-reduce-identity 'max :int)))
+  (is (= Long/MAX_VALUE (descriptor/typed-reduce-identity 'min :long)))
+  (is (= Long/MIN_VALUE (descriptor/typed-reduce-identity 'max :long)))
+  (is (scan/associative-scan?
+       (scan/certify {:acc 'acc :init Integer/MIN_VALUE
+                      :lambda '(max acc (aget values i))}
+                     :int)))
+  (try
+    (scan/certify {:acc 'acc :init 'Double/NEGATIVE_INFINITY
+                   :lambda '(max acc (aget values i))}
+                  :int)
+    (is false "an IEEE infinity is not an integer-domain identity")
+    (catch clojure.lang.ExceptionInfo exception
+      (is (= :scan-nonidentity-init (:reason (ex-data exception)))))))
 
 (deftest reassociation-certification-uses-the-shared-pure-let-rewrite
   (let [facts (scan/certify-reassociation
                {:acc 'acc :init 0.0
                 :lambda '(let* [difference (- (aget x i) (aget target i))]
-                           (+ acc (* difference difference)))}
+                               (+ acc (* difference difference)))}
                :double)]
     (is (scan/associative-scan? facts))
     (is (= '+ (:combine facts)))

--- a/test/raster/compiler/passes/parallel/structured_control_route_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_route_test.clj
@@ -1,5 +1,6 @@
 (ns raster.compiler.passes.parallel.structured-control-route-test
   (:require [clojure.test :refer [deftest is testing]]
+            [clojure.walk :as walk]
             [raster.compiler.backend.gpu.parallel-program-opencl :as program-opencl]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.dialects :as dialects]
@@ -96,6 +97,12 @@
           after (raster.par/pmap k n double
                                  (* 2.0 (clojure.core/aget u k)))]
          after))
+
+(defn- mixed-source-without-induction
+  []
+  (walk/postwalk
+   #(if (= '(* 0.0 step) %) 0.0 %)
+   (mixed-source)))
 
 (defn- source-with-suffix
   [suffix-bindings result]
@@ -336,33 +343,35 @@
     (is (= (set (:outputs emitted-program)) (set (keys (:outputs call)))))))
 
 (defn- prepared-mixed-call
-  [trip-count]
-  (let [initial (av/tensor {:dtype :double :shape ['extent]
-                            :representation {:kind :plain}})
-        options {:dtype :double
-                 :target-device :ocl:0
-                 :values {'u0 initial 'steps (av/tensor {:dtype :long :shape []})}
-                 :scalar-types {'steps :long}}
-        scheduled (:form (pipeline/schedule-parallel-form (mixed-source) options))
-        emitted (:program (program-opencl/emit-program
-                           (assoc scheduled :source ::must-not-be-inspected) options))
-        loop-equation (first (:equations emitted))
-        carried (first (control/carried (:algorithm loop-equation)))
-        initial (:initial carried)
-        loop-output (:output carried)
-        result (first (:outputs emitted))
-        scalar (fn [id value]
-                 {:type (get-in emitted [:values id :dtype]) :value value})]
-    {:call
-     (program-call/make
-      emitted
-      {initial :initial loop-output :loop-output result :suffix-output}
-      {'steps (scalar 'steps trip-count)
-       'n (scalar 'n 64)}
-      (if (> trip-count 1) {loop-output :carry-scratch} {})
-      nil)
-     :loop-output loop-output
-     :result result}))
+  ([trip-count]
+   (prepared-mixed-call trip-count (mixed-source-without-induction)))
+  ([trip-count source]
+   (let [initial (av/tensor {:dtype :double :shape ['extent]
+                             :representation {:kind :plain}})
+         options {:dtype :double
+                  :target-device :ocl:0
+                  :values {'u0 initial 'steps (av/tensor {:dtype :long :shape []})}
+                  :scalar-types {'steps :long}}
+         scheduled (:form (pipeline/schedule-parallel-form source options))
+         emitted (:program (program-opencl/emit-program
+                            (assoc scheduled :source ::must-not-be-inspected) options))
+         loop-equation (first (:equations emitted))
+         carried (first (control/carried (:algorithm loop-equation)))
+         initial (:initial carried)
+         loop-output (:output carried)
+         result (first (:outputs emitted))
+         scalar (fn [id value]
+                  {:type (get-in emitted [:values id :dtype]) :value value})]
+     {:call
+      (program-call/make
+       emitted
+       {initial :initial loop-output :loop-output result :suffix-output}
+       {'steps (scalar 'steps trip-count)
+        'n (scalar 'n 64)}
+       (if (> trip-count 1) {loop-output :carry-scratch} {})
+       nil)
+      :loop-output loop-output
+      :result result})))
 
 (deftest emitted-program-stages-once-before-running-resident-equations
   (let [{:keys [call loop-output result]} (prepared-mixed-call 3)
@@ -387,6 +396,59 @@
     (is (= :suffix-output (get (last bindings) result)))
     (is (= :stage-once-host-repetition (get-in call [:attributes :execution])))
     (is (false? (get-in call [:attributes :source-inspected])))))
+
+(deftest structured-loop-staging-is-bounded-by-carry-rotation-not-trip-count
+  (let [{:keys [call]} (prepared-mixed-call 9)
+        events (atom [])]
+    (program-runtime/run-with!
+     call
+     {:bind! (fn [key _graph buffers _scalars]
+               (let [handle {:key key :buffers buffers}]
+                 (swap! events conj [:bind handle])
+                 handle))
+      :run! #(swap! events conj [:run %])
+      :release! #(swap! events conj [:release %])})
+    (let [bindings (filter #(= :bind (first %)) @events)
+          runs (filter #(= :run (first %)) @events)
+          releases (filter #(= :release (first %)) @events)]
+      (is (= 4 (count bindings))
+          "one preserved-input prologue, two carry parities, and one suffix are prepared")
+      (is (= 10 (count runs)) "nine loop launches replay three handles before the suffix")
+      (is (= 4 (count releases)))
+      (is (= 4 (count (distinct (map (comp :key second) bindings))))))))
+
+(deftest structured-loop-preparation-stays-constant-for-huge-trip-counts
+  (let [call (:call (prepared-mixed-call 1000000000))]
+    (is (= 4 (count (program-runtime/staging-plan call :execution)))
+        "one billion iterations still prepare three carry variants and one suffix")
+    (let [events (atom [])
+          launches (atom 0)]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo #"stop streamed replay"
+           (program-runtime/run-with!
+            call
+            {:bind! (fn [key & _]
+                      (swap! events conj [:bind key])
+                      key)
+             :run! (fn [handle]
+                     (swap! events conj [:run handle])
+                     (when (= 4 (swap! launches inc))
+                       (throw (ex-info "stop streamed replay" {}))))
+             :release! (fn [handle]
+                         (swap! events conj [:release handle]))})))
+      (is (= 4 (count (filter #(= :bind (first %)) @events))))
+      (is (= 4 (count (filter #(= :run (first %)) @events))))
+      (is (= 4 (count (filter #(= :release (first %)) @events)))))))
+
+(deftest stage-once-declines-a-changing-induction-scalar
+  (let [call (:call (prepared-mixed-call 3 (mixed-source)))]
+    (try
+      (program-runtime/staging-plan call :execution)
+      (is false "an iteration-varying ABI value cannot be frozen into a prepared graph")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :parallel-program-dynamic-loop-binding
+               (:reason (ex-data exception))))
+        (is (= :bounded-iteration-execution (:fallback (ex-data exception))))))))
 
 (deftest zero-trip-program-feeds-the-initial-carry-to-its-suffix
   (let [{:keys [call loop-output result]} (prepared-mixed-call 0)
@@ -423,7 +485,8 @@
                  :target-device :ocl:0
                  :values {'u0 initial 'steps (av/tensor {:dtype :long :shape []})}
                  :scalar-types {'steps :long}}
-        scheduled (:form (pipeline/schedule-parallel-form (mixed-source) options))
+        scheduled (:form (pipeline/schedule-parallel-form
+                          (mixed-source-without-induction) options))
         base (:program (program-opencl/emit-program
                         (assoc scheduled :source ::must-not-be-inspected) options))
         loop-equation (first (:equations base))


### PR DESCRIPTION
## Summary
- reuse prepared graph handles across equal structured-loop carry rotations
- bound induction-free loop preparation to one preserved-input variant plus two parity variants
- decline stage-once execution when a changing induction scalar is part of the kernel ABI
- keep transactional staging and reverse-order release for unique bindings

## Verification
- focused structured-control route suite: 18 tests, 82 assertions
- full suite delegated to CircleCI