### PR TITLE
Fuse completed reductions with scalar epilogues

### DIFF
--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -739,6 +739,13 @@
             :scalar-types scalar-types :array-types array-types :target-dialect target-dialect)}
           (catch clojure.lang.ExceptionInfo exception
             (when-not (segred-body/declined? exception) (throw exception))
+            (when (get-in segred [:reduction :attributes :result-region])
+              (throw (ex-info
+                      "completed-reduction transforms require verified KernelBody lowering"
+                      (assoc (ex-data exception)
+                             :reason :segred-result-transform-lowering
+                             :fallback :none)
+                      exception)))
             {:decline (ex-data exception)}))]
     (or
      (:artifact kernel-body-attempt)

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -731,7 +731,12 @@
   [segred out-sym & {:keys [dtype kernel-name-prefix scalar-types array-types target-dialect]
                      :or {dtype :double kernel-name-prefix "par_reduce" scalar-types {}
                           array-types {} target-dialect :opencl-intel}}]
-  (let [kernel-body-attempt
+  (let [_certified-plan
+        ;; Both emitters reassociate the fold. Prove the concrete scheduled scalar region before
+        ;; either route is selected; a KernelBody coverage decline must never become permission
+        ;; for the compatibility emitter to invent an algebra.
+        (segred-body/scalar-plan segred)
+        kernel-body-attempt
         (try
           {:artifact
            (generate-segred-kernel-body

--- a/src/raster/compiler/backend/jvm/segop_simd.clj
+++ b/src/raster/compiler/backend/jvm/segop_simd.clj
@@ -817,24 +817,24 @@
   (let [{:keys [attributes lambda]} (soac-dialect/scalar-fold-parts fold)
         {:keys [parameters locals body-results]} (soac-dialect/lambda-parts lambda)
         [accumulator index] parameters
-        operator (reduction/scalar
-                  {:accumulator accumulator :neutral (:identity attributes)
-                   :dtype (:dtype attributes) :result nil :index index
-                   :step-result (first body-results)
-                   :algebra (or (:algebra attributes) {})
-                   :attributes {:source :typed-soac-scalar-fold}})
-        scheduled (segop/->SegRed
-                   [:scalar-fold (:id segmap) index]
-                   (segop/make-seg-space index (:extent attributes))
-                   (segop/->SegLevel :thread :virtual)
-                   operator nil (:inputs segmap) #{} (:scalars segmap)
-                   nil :single nil (:dtype attributes))
         cast (case (:dtype attributes)
                :float 'float :double 'double :int 'int :long 'long)
         n-sym (gensym "fold_n__")]
     (when (empty? locals)
       (if (= :implementation-defined (:association attributes))
-        (compile-segred scheduled)
+        (let [operator (reduction/scalar
+                        {:accumulator accumulator :neutral (:identity attributes)
+                         :dtype (:dtype attributes) :result nil :index index
+                         :step-result (first body-results)
+                         :algebra (or (:algebra attributes) {})
+                         :attributes {:source :typed-soac-scalar-fold}})
+              scheduled (segop/->SegRed
+                         [:scalar-fold (:id segmap) index]
+                         (segop/make-seg-space index (:extent attributes))
+                         (segop/->SegLevel :thread :virtual)
+                         operator nil (:inputs segmap) #{} (:scalars segmap)
+                         nil :single nil (:dtype attributes))]
+          (compile-segred scheduled))
         (list 'let* [n-sym (list 'int (:extent attributes))]
               (list 'loop* [index '(int 0)
                             accumulator (list cast (:identity attributes))]

--- a/src/raster/compiler/core/op_descriptor.clj
+++ b/src/raster/compiler/core/op_descriptor.clj
@@ -935,7 +935,7 @@
       (throw (ex-info (str "no :algebra facet for reduction op " op-sym
                            " — register it (op-descriptor) before reducing with it")
                       {:op op-sym :dtype dtype})))
-    (let [float? (= dtype :float)]
+    (let [float? (contains? #{:half :float} dtype)]
       (case base
         (min Math/min) (if float? 'Float/POSITIVE_INFINITY 'Double/POSITIVE_INFINITY)
         (max Math/max) (if float? 'Float/NEGATIVE_INFINITY 'Double/NEGATIVE_INFINITY)

--- a/src/raster/compiler/ir/kernel_launch.clj
+++ b/src/raster/compiler/ir/kernel_launch.clj
@@ -155,7 +155,12 @@
                       {:field field :axis axis :value value :dimensions dimensions}))))
   dimensions)
 
-(defn- launch-expression?
+(defn dimension-expression?
+  "Whether `x` is legal as one symbolic launch dimension.
+
+   Unlike `expression?`, this excludes arbitrary opaque leaves: callers must wrap runtime compiler
+   values with `runtime-value` so scheduled extents cannot smuggle source S-expressions into an
+   emitted ABI."
   [x]
   (or (and (integer? x) (pos? x))
       (runtime-value? x)
@@ -173,9 +178,11 @@
     (throw (ex-info "launch contract must be a LaunchSpec" {:launch spec :actual (type spec)})))
   (let [{:keys [workgroup-size group-count shared-memory-bytes]} spec]
     (dimension-vector! "launch specification" :workgroup-size workgroup-size
-                       launch-expression? "a positive integer or explicit runtime expression")
+                       dimension-expression?
+                       "a positive integer or explicit runtime expression")
     (dimension-vector! "launch specification" :group-count group-count
-                       launch-expression? "a positive integer or explicit runtime expression")
+                       dimension-expression?
+                       "a positive integer or explicit runtime expression")
     (when-not (= (count workgroup-size) (count group-count))
       (throw (ex-info "launch workgroup and group-count dimensionality must match"
                       {:workgroup-size workgroup-size :group-count group-count})))

--- a/src/raster/compiler/ir/reduction.clj
+++ b/src/raster/compiler/ir/reduction.clj
@@ -4,7 +4,8 @@
    A scalar reduction is the one-component case.  Product reductions keep accumulator components,
    neutral values and step results in one ordered record so lowering cannot silently lose a value
    or guess its dtype.  The operator is semantic: segmentation and target schedules live in SOAC
-   and SegOp layers, while physical scratch is introduced only during scheduling/materialization.")
+   and SegOp layers, while physical scratch is introduced only during scheduling/materialization."
+  (:require [raster.compiler.ir.scan :as scan]))
 
 (defrecord ReductionComponent
            [id accumulator neutral dtype result attributes])
@@ -191,18 +192,28 @@
     step algebra attributes)))
 
 (defn scalar
-  "Construct the canonical one-component representation of `raster.par/reduce`."
+  "Construct the canonical, proof-carrying representation of `raster.par/reduce`.
+
+   Every scalar ProductReduction has parallel semantics, so its recurrence is certified here—the
+   single constructor boundary—rather than rediscovered by individual schedules or emitters."
   [{:keys [accumulator neutral dtype result index step-result algebra attributes]
     :or {algebra {} attributes {}}}]
-  (make {:components [{:id :value
-                       :accumulator accumulator
-                       :neutral neutral
-                       :dtype dtype
-                       :result result}]
-         :index index
-         :step (->ReductionRegion [] [step-result] {})
-         :algebra algebra
-         :attributes attributes}))
+  (let [derived (scan/certify-reassociation
+                 {:acc accumulator :init neutral :lambda step-result} dtype)
+        algebra (if (empty? algebra) derived algebra)]
+    (when-not (scan/compatible-certificate? algebra derived)
+      (throw (ex-info "scalar reduction algebra disagrees with its recurrence"
+                      {:reason :scalar-reduction-certificate-mismatch
+                       :declared algebra :derived derived})))
+    (make {:components [{:id :value
+                         :accumulator accumulator
+                         :neutral neutral
+                         :dtype dtype
+                         :result result}]
+           :index index
+           :step (->ReductionRegion [] [step-result] {})
+           :algebra algebra
+           :attributes attributes})))
 
 (defn scalar?
   [reduction]

--- a/src/raster/compiler/ir/scan.clj
+++ b/src/raster/compiler/ir/scan.clj
@@ -1,12 +1,13 @@
 (ns raster.compiler.ir.scan
-  "Certified algebra for parallel prefix scans.
+  "Certified scalar algebra for parallel scans and reductions.
 
    Raster's surface `par/scan` is also a general left-to-right recurrence primitive. Such a
    recurrence is not automatically a parallel scan: Blelloch/Hillis-Steele scheduling is sound
    only when the body is an associative combine of the prior accumulator and an accumulator-free
    element expression. This boundary proves that property before SegScan scheduling."
   (:require [raster.ad.purity :as purity]
-            [raster.compiler.core.op-descriptor :as descriptor]))
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.util :as util]))
 
 (defrecord AssociativeScan [acc init combine element identity dtype])
 
@@ -61,6 +62,82 @@
     (coll? expr) (every? pure-element? expr)
     :else true))
 
+(defn- reason
+  [operation suffix]
+  (keyword (str (name operation) "-" suffix)))
+
+(defn- certify*
+  [reduction-op dtype operation]
+  (let [{:keys [acc init lambda]} reduction-op
+        lambda (try
+                 (util/inline-pure-lets lambda)
+                 (catch clojure.lang.ExceptionInfo exception
+                   (if (= :impure-binding (:reason (ex-data exception)))
+                     (throw (ex-info "parallel reduction element contains an impure binding"
+                                     {:reason (reason operation "element-impure-or-unknown")
+                                      :body lambda :reduction-op reduction-op}
+                                     exception))
+                     (throw exception))))
+        combine (descriptor/semantic-op lambda)
+        args (vec (descriptor/call-args lambda))
+        dtype (or dtype :double)
+        supported-dtypes (if (= :scan operation)
+                           #{:int :long :float :double}
+                           #{:byte :int :long :half :float :double})]
+    (when-not (contains? supported-dtypes dtype)
+      (throw (ex-info "parallel reduction dtype is not supported by the current kernel dialect"
+                      {:reason (reason operation "dtype-unsupported")
+                       :dtype dtype :reduction-op reduction-op})))
+    (when-not (and combine (= 2 (count args))
+                   (descriptor/commutative-monoid-op? combine))
+      (throw (ex-info "parallel recurrence is not a certified associative reduction"
+                      {:reason (reason operation "not-associative")
+                       :combine combine :body lambda :reduction-op reduction-op})))
+    (let [[left right] args
+          element (cond
+                    (and (acc-ref? left acc) (not (contains-symbol? right acc))) right
+                    (and (acc-ref? right acc) (not (contains-symbol? left acc))) left
+                    :else nil)]
+      (when-not element
+        (throw (ex-info "parallel reduction must combine one accumulator with an accumulator-free element"
+                        {:reason (reason operation "not-elementwise")
+                         :acc acc :body lambda :reduction-op reduction-op})))
+      (when-not (pure-element? element)
+        (throw (ex-info "parallel reduction element expression is impure or has unknown effects"
+                        {:reason (reason operation "element-impure-or-unknown")
+                         :element element :body lambda :reduction-op reduction-op})))
+      (let [identity (descriptor/typed-reduce-identity combine dtype)]
+        (when-not (identity-equivalent? init identity)
+          (throw (ex-info "parallel reduction with a non-identity init requires a distinct schedule"
+                          {:reason (reason operation "nonidentity-init")
+                           :combine combine :init init :identity identity :dtype dtype})))
+        (->AssociativeScan acc init combine element identity dtype)))))
+
+(defn certify-reassociation
+  "Certify a scalar recurrence for parallel reassociation.
+
+   This is the shared proof boundary for reductions, scans, reducing scatters and nested folds.
+   Pure `let` regions are beta-reduced by the compiler's one capture-safe implementation before
+   the registered monoid and exact typed identity are checked."
+  [reduction-op dtype]
+  (certify* reduction-op dtype :reduction))
+
+(defn compatible-certificate?
+  "Whether two independently derived certificates prove the same typed monoid contract.
+
+   Element expressions may differ across a mechanical parameter-to-load projection, so the
+   comparison deliberately covers only the reassociation facts; callers must independently
+   certify each concrete scalar region before using this predicate."
+  [declared derived]
+  (and (associative-scan? declared)
+       (associative-scan? derived)
+       (= (:acc declared) (:acc derived))
+       (= (some-> (:combine declared) name symbol)
+          (some-> (:combine derived) name symbol))
+       (identity-equivalent? (:init declared) (:init derived))
+       (identity-equivalent? (:identity declared) (:identity derived))
+       (= (:dtype declared) (:dtype derived))))
+
 (defn certify
   "Certify `scan-op` as a parallel associative scan or throw a structured conversion decline.
 
@@ -70,33 +147,4 @@
    The initial value must be the registered identity: injecting a non-identity once globally needs
    a distinct schedule and must not be duplicated independently in every block."
   [scan-op dtype]
-  (let [{:keys [acc init lambda]} scan-op
-        combine (descriptor/semantic-op lambda)
-        args (vec (descriptor/call-args lambda))
-        dtype (or dtype :double)]
-    (when-not (contains? #{:int :long :float :double} dtype)
-      (throw (ex-info "parallel scan dtype is not supported by the current kernel dialect"
-                      {:reason :scan-dtype-unsupported :dtype dtype :scan-op scan-op})))
-    (when-not (and combine (= 2 (count args))
-                   (descriptor/commutative-monoid-op? combine))
-      (throw (ex-info "par/scan is a general recurrence, not a certified associative scan"
-                      {:reason :scan-not-associative
-                       :combine combine :body lambda :scan-op scan-op})))
-    (let [[left right] args
-          element (cond
-                    (and (acc-ref? left acc) (not (contains-symbol? right acc))) right
-                    (and (acc-ref? right acc) (not (contains-symbol? left acc))) left
-                    :else nil)]
-      (when-not element
-        (throw (ex-info "parallel scan body must combine one accumulator with an accumulator-free element"
-                        {:reason :scan-not-elementwise :acc acc :body lambda :scan-op scan-op})))
-      (when-not (pure-element? element)
-        (throw (ex-info "parallel scan element expression is impure or has unknown effects"
-                        {:reason :scan-element-impure-or-unknown
-                         :element element :body lambda :scan-op scan-op})))
-      (let [identity (descriptor/typed-reduce-identity combine dtype)]
-        (when-not (identity-equivalent? init identity)
-          (throw (ex-info "parallel scan with a non-identity init requires a distinct global-prefix schedule"
-                          {:reason :scan-nonidentity-init
-                           :combine combine :init init :identity identity :dtype dtype})))
-        (->AssociativeScan acc init combine element identity dtype)))))
+  (certify* scan-op dtype :scan))

--- a/src/raster/compiler/ir/scan.clj
+++ b/src/raster/compiler/ir/scan.clj
@@ -5,8 +5,8 @@
    recurrence is not automatically a parallel scan: Blelloch/Hillis-Steele scheduling is sound
    only when the body is an associative combine of the prior accumulator and an accumulator-free
    element expression. This boundary proves that property before SegScan scheduling."
-  (:require [raster.ad.purity :as purity]
-            [raster.compiler.core.op-descriptor :as descriptor]
+  (:require [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.passes.scalar.effects :as effects]
             [raster.compiler.core.util :as util]))
 
 (defrecord AssociativeScan [acc init combine element identity dtype])
@@ -54,13 +54,10 @@
 
 (defn- pure-element?
   [expr]
-  (cond
-    (seq? expr) (let [op (descriptor/semantic-op expr)]
-                  (and op
-                       (= :pure (purity/pure-op? op))
-                       (every? pure-element? (descriptor/call-args expr))))
-    (coll? expr) (every? pure-element? expr)
-    :else true))
+  ;; Effect analysis is deliberately centralized in the Beichte-backed scalar-effects
+  ;; boundary.  A second syntactic operator allow-list here would disagree with the
+  ;; canonical registry for valid Raster operations (for example raster.numeric/*).
+  (= :pure (effects/analyze-effect expr)))
 
 (defn- reason
   [operation suffix]

--- a/src/raster/compiler/ir/scan.clj
+++ b/src/raster/compiler/ir/scan.clj
@@ -128,7 +128,9 @@
   [declared derived]
   (and (associative-scan? declared)
        (associative-scan? derived)
-       (= (:acc declared) (:acc derived))
+       ;; Accumulators and element operands are lexical binders that may be alpha-renamed or
+       ;; projected from captures between independently certified regions. The certificate is the
+       ;; typed monoid contract; each concrete region has already been certified on its own.
        (= (some-> (:combine declared) name symbol)
           (some-> (:combine derived) name symbol))
        (identity-equivalent? (:init declared) (:init derived))

--- a/src/raster/compiler/ir/soac.clj
+++ b/src/raster/compiler/ir/soac.clj
@@ -398,13 +398,27 @@
 
 (defn let-bindings->nodes
   "Convert a sequence of [sym expr] binding pairs to SOAC/Scalar nodes.
-  Each pair gets a sequential id for ordering."
+  Each pair gets a sequential id for ordering.
+
+  This compatibility adapter must not turn a legal sequential `par/reduce` fallback into an
+  invalid parallel tree. If the canonical reduction constructor declines reassociation (for
+  example a finite max sentinel rather than the true typed identity), retain the complete source
+  expression as a ScalarBinding. Direct typed routing remains strict and reports its structured
+  decline separately."
   [pairs]
   (vec
    (map-indexed
     (fn [id [sym expr]]
-      (or (par-form->soac sym expr id)
-          (->ScalarBinding id sym expr)))
+      (let [converted
+            (try
+              (par-form->soac sym expr id)
+              (catch clojure.lang.ExceptionInfo exception
+                (if (and (par/par-reduce-form? expr)
+                         (some-> exception ex-data :reason name
+                                 (.startsWith "reduction-")))
+                  nil
+                  (throw exception))))]
+        (or converted (->ScalarBinding id sym expr))))
     pairs)))
 
 (declare node-all-free-syms node-produced-syms)

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -184,6 +184,8 @@
               (dtype/known? component-dtype)
               (= component-dtype (dtype/canon component-dtype))))))
 
+(declare lambda-form result-transform?)
+
 (defn reduce-attributes?
   [value]
   (and (map-attributes? value)
@@ -199,9 +201,10 @@
           (count (:dtypes value))
           (count (:algebra value)))
        (every? keyword? (:dtypes value))
-       (every? map? (:algebra value))))
-
-(declare lambda-form)
+       (every? map? (:algebra value))
+       (or (nil? (:result-transform value))
+           (and (= 1 (count (:accumulators value)))
+                (result-transform? (:result-transform value))))))
 
 (defn result-transform?
   "A typed scalar transform applied once to a completed reduction result.
@@ -889,7 +892,8 @@
                  {:equation equation-id :results body-results})))
 
       reduce
-      (let [accumulators (:accumulators attributes)]
+      (let [accumulators (:accumulators attributes)
+            transform (:result-transform attributes)]
         (when-not (= accumulators (vec (take (count accumulators) parameters)))
           (fail! :typed-soac-reduce-accumulators
                  "reduce accumulator parameters must lead the lambda in declared order"
@@ -897,7 +901,29 @@
         (when-not (= result-count (count accumulators))
           (fail! :typed-soac-reduce-results
                  "reduce result arity must equal accumulator arity"
-                 {:equation equation-id :results results :accumulators accumulators})))
+                 {:equation equation-id :results results :accumulators accumulators}))
+        (when transform
+          (let [operand-ids (set (map :value (:operands transform)))
+                scalar-ids (set (map :value (:scalars transform)))
+                transform-ids (set/union operand-ids scalar-ids)
+                {:keys [parameters body-results]} (lambda-parts (:lambda transform))
+                unbound (util/free-syms (first body-results) (set parameters))]
+            (when-not (set/subset? transform-ids (set captures))
+              (fail! :typed-soac-result-transform-captures
+                     "reduce result transforms require explicit capture values"
+                     {:equation equation-id :transform-captures transform-ids
+                      :captures captures}))
+            ;; A full reduction has no remaining result axes with which to address a tensor.
+            ;; Tensor epilogues belong to segmented reductions; this scalar boundary accepts only
+            ;; uniform captures until an explicit scalar-load schedule exists.
+            (when (seq operand-ids)
+              (fail! :typed-soac-reduce-result-transform-operands
+                     "full-reduction result transforms cannot address tensor operands"
+                     {:equation equation-id :operands operand-ids}))
+            (when (seq unbound)
+              (fail! :typed-soac-result-transform-expression
+                     "result-transform expressions may reference only their typed region boundary"
+                     {:equation equation-id :unbound unbound :transform transform})))))
 
       segmented-reduce
       (let [accumulators (:accumulators attributes)
@@ -1434,20 +1460,20 @@
                                               #(mapv rename %)))
                       attributes (if (contains? #{'segmented-reduce 'product-reduce
                                                   'segmented-fold-map} kind)
-                                   (-> attributes
-                                       (update :segment-axes
-                                               #(mapv (fn [[index extent]]
-                                                        [index (if (value-id? extent)
-                                                                 (rename extent) extent)]) %))
-                                       (cond-> (:result-transform attributes)
-                                         (update-in [:result-transform :operands]
-                                                    #(mapv (fn [operand]
-                                                             (update operand :value rename)) %))
-                                         (:result-transform attributes)
-                                         (update-in [:result-transform :scalars]
-                                                    #(mapv (fn [scalar]
-                                                             (update scalar :value rename)) %))))
+                                   (update attributes :segment-axes
+                                           #(mapv (fn [[index extent]]
+                                                    [index (if (value-id? extent)
+                                                             (rename extent) extent)]) %))
                                    attributes)
+                      attributes (cond-> attributes
+                                   (:result-transform attributes)
+                                   (update-in [:result-transform :operands]
+                                              #(mapv (fn [operand]
+                                                       (update operand :value rename)) %))
+                                   (:result-transform attributes)
+                                   (update-in [:result-transform :scalars]
+                                              #(mapv (fn [scalar]
+                                                       (update scalar :value rename)) %)))
                       attributes (if (= 'scalar kind)
                                    attributes
                                    (update attributes :extent

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -902,6 +902,15 @@
           (fail! :typed-soac-reduce-results
                  "reduce result arity must equal accumulator arity"
                  {:equation equation-id :results results :accumulators accumulators}))
+        (doseq [[accumulator identity dtype certificate result]
+                (map vector accumulators (:identities attributes) (:dtypes attributes)
+                     (:algebra attributes) body-results)]
+          (let [derived (scan-ir/certify-reassociation
+                         {:acc accumulator :init identity :lambda result} dtype)]
+            (when-not (scan-ir/compatible-certificate? certificate derived)
+              (fail! :typed-soac-reduction-certificate
+                     "reduction algebra certificate disagrees with its scalar region"
+                     {:equation equation-id :declared certificate :derived derived}))))
         (when transform
           (let [operand-ids (set (map :value (:operands transform)))
                 scalar-ids (set (map :value (:scalars transform)))
@@ -936,6 +945,15 @@
           (fail! :typed-soac-segmented-reduce-results
                  "segmented-reduce result arity must equal accumulator arity"
                  {:equation equation-id :results results :accumulators accumulators}))
+        (doseq [[accumulator identity dtype certificate result]
+                (map vector accumulators (:identities attributes) (:dtypes attributes)
+                     (:algebra attributes) body-results)]
+          (let [derived (scan-ir/certify-reassociation
+                         {:acc accumulator :init identity :lambda result} dtype)]
+            (when-not (scan-ir/compatible-certificate? certificate derived)
+              (fail! :typed-soac-reduction-certificate
+                     "segmented-reduction algebra certificate disagrees with its scalar region"
+                     {:equation equation-id :declared certificate :derived derived}))))
         (when transform
           (let [operand-ids (set (map :value (:operands transform)))
                 scalar-ids (set (map :value (:scalars transform)))

--- a/src/raster/compiler/passes/parallel/scalar_region_lower.clj
+++ b/src/raster/compiler/passes/parallel/scalar_region_lower.clj
@@ -7,8 +7,32 @@
   (:require [raster.compiler.backend.intrinsics :as intrinsics]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.util :as util]
             [raster.compiler.ir.axis-map :as axis-map]
-            [raster.compiler.ir.kernel-body :as body]))
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.soac-dialect :as dialect]))
+
+(defn from-typed-result-transform
+  "Project a validated TypedSOAC result transform to the shared scheduled ScalarRegion.
+
+   This is a mechanical alpha-boundary projection: dtypes, captures and the expression already
+   belong to TypedSOAC. No source operator or type inference occurs here."
+  [transform]
+  (when transform
+    (let [{:keys [parameters body-results]} (dialect/lambda-parts (:lambda transform))
+          accumulator (first parameters)
+          substitutions
+          (into {}
+                (concat (map (juxt :parameter :value) (:operands transform))
+                        (map (juxt :parameter :value) (:scalars transform))))]
+      (body/->ScalarRegion
+       (vec (concat [accumulator]
+                    (map :value (:operands transform))
+                    (map :value (:scalars transform))))
+       (util/subst-syms substitutions (first body-results))
+       (mapv #(-> % (assoc :sym (:value %)) (dissoc :value :parameter))
+             (:operands transform))
+       (:result-dtype transform)))))
 
 (defn make-region
   "Convert the target-neutral result-transform descriptor into KernelBody region data."

--- a/src/raster/compiler/passes/parallel/segred_body.clj
+++ b/src/raster/compiler/passes/parallel/segred_body.clj
@@ -14,7 +14,8 @@
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
-            [raster.compiler.ir.segop :as segop]))
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.passes.parallel.scalar-region-lower :as scalar-region-lower]))
 
 (def ^:private associative-operators #{:+ :* :min :max})
 (def ^:private cast-heads
@@ -92,7 +93,7 @@
     Float/NEGATIVE_INFINITY Float/NEGATIVE_INFINITY
     value))
 
-(defn- launch-group-count
+(defn launch-group-count
   "Translate SegRed's historical capped-grid expression into inspectable launch IR.
 
    `compute-launch-params` predates KernelLaunch and represents the reduction grid as
@@ -228,10 +229,13 @@
                                   (get scalar-types (symbol (name id))) dtype))
         array-dtype (fn [id] (or (get array-types id)
                                  (get array-types (symbol (name id))) dtype))
+        bound-dimension (if (or (symbol? bound) (keyword? bound) (vector? bound))
+                          (launch/runtime-value bound)
+                          bound)
         _ (when-not (and (contains? #{:float :double} (dtype/canon dtype))
                          (integer? workgroup-size) (pos? workgroup-size)
                          (zero? (bit-and workgroup-size (dec workgroup-size)))
-                         (or (and (integer? bound) (pos? bound)) (symbol? bound))
+                         (launch/dimension-expression? bound-dimension)
                          (every? #(= (dtype/canon dtype) (dtype/canon (array-dtype %))) arrays)
                          (every? #(= (dtype/canon dtype) (dtype/canon (scalar-dtype %))) scalars))
             (decline! :uniform-scalar-storage
@@ -280,13 +284,31 @@
         parameters
         (vec (concat
               (map #(body/->KernelParameter
-                     % :input dtype [bound] :global (layout/row-major [bound] dtype) :operand)
+                     % :input dtype ['_n_bound] :global
+                     (layout/row-major ['_n_bound] dtype) :operand)
                    arrays)
               [(body/->KernelParameter output :output dtype ['partial-count] :global
                                        (layout/row-major ['partial-count] dtype) :result)]
               (map #(body/->KernelParameter % :scalar (scalar-dtype %) [] nil nil :parameter)
                    scalars)
               [(body/->KernelParameter '_n_bound :scalar :int [] nil nil :bound)]))
+        result-region (get-in segred [:reduction :attributes :result-region])
+        _ (when (and result-region (seq (:operands result-region)))
+            (decline! :full-reduction-result-operands
+                      "full-reduction result transforms cannot address tensor operands"
+                      {:segred-id (:id segred) :operands (:operands result-region)}))
+        transformed
+        (when result-region
+          (scalar-region-lower/lower
+           result-region
+           {:accumulator final-value :accumulator-dtype dtype :store-dtype dtype
+            :parameters (into {} (map (fn [parameter] [(:id parameter) parameter])) parameters)
+            :coordinate-lower (fn [_]
+                                (decline! :full-reduction-result-operands
+                                          "full-reduction result transform has no tensor axes"
+                                          {:segred-id (:id segred)}))
+            :id-prefix "completed-reduction"}))
+        stored-value (or (:result transformed) final-value)
         kernel-body
         (body/make
          {:id [:segred (:id segred) :workgroup-tree]
@@ -336,8 +358,9 @@
                              (barrier)]
                             tree-stages
                             [(body/->ScalarLoad (body/value final-value dtype) scratch [0]
-                                                :lane-zero (body/literal identity dtype) :cached)
-                             (body/->ScalarStore output ['group-index] final-value :lane-zero)]))
+                                                :lane-zero (body/literal identity dtype) :cached)]
+                            (:operations transformed)
+                            [(body/->ScalarStore output ['group-index] stored-value :lane-zero)]))
           :schedule {:strategy :workgroup-tree
                      :workgroup-size workgroup-size
                      :reduction-operator operator}

--- a/src/raster/compiler/passes/parallel/segred_body.clj
+++ b/src/raster/compiler/passes/parallel/segred_body.clj
@@ -52,6 +52,20 @@
       (recur (util/subst-syms (util/binding-env bindings) (first body))))
     expression))
 
+(defn- literal-value
+  [value]
+  (if (and (seq? value)
+           (= 2 (count value))
+           (contains? cast-heads (first value))
+           (number? (second value)))
+    (second value)
+    (case value
+      Double/POSITIVE_INFINITY Double/POSITIVE_INFINITY
+      Double/NEGATIVE_INFINITY Double/NEGATIVE_INFINITY
+      Float/POSITIVE_INFINITY Float/POSITIVE_INFINITY
+      Float/NEGATIVE_INFINITY Float/NEGATIVE_INFINITY
+      value)))
+
 (defn scalar-plan
   "Project one scalar SegRed into an explicit combine operator, identity and element expression."
   [segred]
@@ -77,22 +91,8 @@
                 {:segred-id (:id segred) :declared declared :derived derived}))
     ;; Retain the concrete neutral spelling after proving it equivalent to the typed registry
     ;; identity. KernelBody consumers need a literal, while the certificate remains the proof.
-    {:operator operator :identity init :element (:element derived)
+    {:operator operator :identity (literal-value init) :element (:element derived)
      :accumulator acc}))
-
-(defn- literal-value
-  [value]
-  (if (and (seq? value)
-           (= 2 (count value))
-           (contains? cast-heads (first value))
-           (number? (second value)))
-    (second value)
-    (case value
-      Double/POSITIVE_INFINITY Double/POSITIVE_INFINITY
-      Double/NEGATIVE_INFINITY Double/NEGATIVE_INFINITY
-      Float/POSITIVE_INFINITY Float/POSITIVE_INFINITY
-      Float/NEGATIVE_INFINITY Float/NEGATIVE_INFINITY
-      value)))
 
 (defn launch-group-count
   "Translate SegRed's historical capped-grid expression into inspectable launch IR.

--- a/src/raster/compiler/passes/parallel/segred_body.clj
+++ b/src/raster/compiler/passes/parallel/segred_body.clj
@@ -75,7 +75,9 @@
       (decline! :certified-monoid
                 "scheduled reduction algebra disagrees with its concrete scalar region"
                 {:segred-id (:id segred) :declared declared :derived derived}))
-    {:operator operator :identity (:identity derived) :element (:element derived)
+    ;; Retain the concrete neutral spelling after proving it equivalent to the typed registry
+    ;; identity. KernelBody consumers need a literal, while the certificate remains the proof.
+    {:operator operator :identity init :element (:element derived)
      :accumulator acc}))
 
 (defn- literal-value

--- a/src/raster/compiler/passes/parallel/segred_body.clj
+++ b/src/raster/compiler/passes/parallel/segred_body.clj
@@ -14,10 +14,10 @@
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.scalar-region-lower :as scalar-region-lower]))
 
-(def ^:private associative-operators #{:+ :* :min :max})
 (def ^:private cast-heads
   {'byte :byte, 'clojure.core/byte :byte
    'int :int, 'clojure.core/int :int
@@ -52,46 +52,45 @@
       (recur (util/subst-syms (util/binding-env bindings) (first body))))
     expression))
 
-(defn- accumulator-use?
-  [accumulator expression]
-  (or (= accumulator expression)
-      (and (seq? expression)
-           (contains? (set (keys cast-heads)) (first expression))
-           (= 2 (count expression))
-           (= accumulator (second expression)))))
-
 (defn scalar-plan
   "Project one scalar SegRed into an explicit combine operator, identity and element expression."
   [segred]
   (let [{:keys [acc init lambda]} (segop/scalar-reduce-op segred)
         expression (inline-scalar-bindings lambda)
-        operator (when (seq? expression)
-                   (intrinsics/canonical (descriptor/semantic-op expression)))
-        arguments (vec (when (seq? expression) (descriptor/call-args expression)))]
-    (when-not (and acc (some? init) (contains? associative-operators operator)
-                   (= 2 (count arguments)))
-      (decline! :scalar-combine
-                "KernelBody reduction requires a binary associative scalar combine"
-                {:segred-id (:id segred) :accumulator acc :identity init
-                 :operator operator :arguments arguments :lambda lambda}))
-    (let [[left right] arguments
-          left-accumulator? (accumulator-use? acc left)
-          right-accumulator? (accumulator-use? acc right)
-          element (if left-accumulator? right left)]
-      (when (= left-accumulator? right-accumulator?)
-        (decline! :accumulator-position
-                  "KernelBody reduction combine does not contain its accumulator exactly once"
-                  {:segred-id (:id segred) :accumulator acc :arguments arguments}))
-      {:operator operator :identity init :element element :accumulator acc})))
+        component (first (get-in segred [:reduction :components]))
+        dtype (:dtype component)
+        declared-algebra (get-in segred [:reduction :algebra])
+        declared (if (scan/associative-scan? declared-algebra)
+                   declared-algebra
+                   (first (:components declared-algebra)))
+        derived (try
+                  (scan/certify-reassociation
+                   {:acc acc :init init :lambda expression} dtype)
+                  (catch clojure.lang.ExceptionInfo exception
+                    (decline! :certified-monoid
+                              "KernelBody reduction requires a certified typed monoid"
+                              {:segred-id (:id segred) :certificate-error (ex-data exception)})))
+        operator (intrinsics/canonical (:combine derived))]
+    (when-not (scan/compatible-certificate? declared derived)
+      (decline! :certified-monoid
+                "scheduled reduction algebra disagrees with its concrete scalar region"
+                {:segred-id (:id segred) :declared declared :derived derived}))
+    {:operator operator :identity (:identity derived) :element (:element derived)
+     :accumulator acc}))
 
 (defn- literal-value
   [value]
-  (case value
-    Double/POSITIVE_INFINITY Double/POSITIVE_INFINITY
-    Double/NEGATIVE_INFINITY Double/NEGATIVE_INFINITY
-    Float/POSITIVE_INFINITY Float/POSITIVE_INFINITY
-    Float/NEGATIVE_INFINITY Float/NEGATIVE_INFINITY
-    value))
+  (if (and (seq? value)
+           (= 2 (count value))
+           (contains? cast-heads (first value))
+           (number? (second value)))
+    (second value)
+    (case value
+      Double/POSITIVE_INFINITY Double/POSITIVE_INFINITY
+      Double/NEGATIVE_INFINITY Double/NEGATIVE_INFINITY
+      Float/POSITIVE_INFINITY Float/POSITIVE_INFINITY
+      Float/NEGATIVE_INFINITY Float/NEGATIVE_INFINITY
+      value)))
 
 (defn launch-group-count
   "Translate SegRed's historical capped-grid expression into inspectable launch IR.

--- a/src/raster/compiler/passes/parallel/soac_dialect_adapter.clj
+++ b/src/raster/compiler/passes/parallel/soac_dialect_adapter.clj
@@ -12,6 +12,7 @@
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.reduction :as reduction]
+            [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.soac :as legacy]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.passes.parallel.fusion-support :as fusion-support]))
@@ -152,13 +153,18 @@
           capture-parameters (capture-symbols (count captures))
           body-results (->> (elementize expressions arrays element-parameters (:index product))
                             (mapv #(util/subst-syms (zipmap captures capture-parameters) %)))
+          algebra (scan/certify-reassociation
+                   {:acc (:accumulator component)
+                    :init (:neutral component)
+                    :lambda (first body-results)}
+                   (:dtype component))
           attributes {:index (:index product)
                       :extent (:bound node)
                       :attributes {:stable-array-captures (vec (sort-by pr-str stable))}
                       :accumulators [(:accumulator component)]
                       :identities [(:neutral component)]
                       :dtypes [(:dtype component)]
-                      :algebra [(:algebra product)]}]
+                      :algebra [algebra]}]
       (list '= (:id node) (vec (filter some? (reduction/results product)))
             (list 'reduce attributes arrays captures
                   (dialect/lambda-form

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -25,6 +25,7 @@
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.execution-plan :as execution-plan]
+            [raster.compiler.passes.parallel.scalar-region-lower :as scalar-region-lower]
             [raster.compiler.passes.parallel.segred-body :as segred-body]))
 
 (declare lower-reduce)
@@ -331,6 +332,8 @@
           stable-array-captures (set (get-in attributes
                                              [:attributes :stable-array-captures]))
           scalar-captures (set (remove stable-array-captures captures))
+          result-region
+          (scalar-region-lower/from-typed-result-transform (:result-transform attributes))
           operator (reduction/scalar
                     {:accumulator accumulator
                      :neutral (first (:identities attributes))
@@ -339,7 +342,8 @@
                      :index index
                      :step-result step-result
                      :algebra (or (first (:algebra attributes)) {})
-                     :attributes {:source :typed-soac :equation equation-id}})
+                     :attributes (cond-> {:source :typed-soac :equation equation-id}
+                                   result-region (assoc :result-region result-region))})
           node (cond-> (soac/->SoacReduce equation-id result operator []
                                           (:extent attributes)
                                           (into (set arrays) stable-array-captures)
@@ -776,15 +780,26 @@
         :two-phase
         (let [level-1 (segop/->SegLevel :block :virtual)
               partials-sym (gensym "partials_")
+              phase-1-reduction (update reduction :attributes dissoc :result-region)
+              result-region (get-in reduction [:attributes :result-region])
+              fold-symbols (reduce set/union #{}
+                                   (map util/free-syms
+                                        (cond-> (vec (get-in reduction [:step :results]))
+                                          map-lambda (conj map-lambda))))
+              fold-scalars (if result-region
+                             (set/intersection (set (:scalars soac)) fold-symbols)
+                             (:scalars soac))
               phase-1 (segop/->SegRed (:id soac) space level-1
-                                      reduction map-lambda
+                                      phase-1-reduction map-lambda
                                       (:inputs soac)
                                       #{partials-sym}
-                                      (:scalars soac)
+                                      fold-scalars
                                       grid-1 :block-local nil
                                       dtype)
               phase-2-idx (gensym "j_")
-              phase-2-space (segop/make-seg-space phase-2-idx (:num-blocks grid-1))
+              phase-2-bound (segred-body/launch-group-count
+                             (:num-blocks grid-1) bound (:block-size grid-1))
+              phase-2-space (segop/make-seg-space phase-2-idx phase-2-bound)
               grid-2 (single-block-grid grid-1)
               level-2 (segop/->SegLevel :block :none)
               {:keys [operator identity accumulator]} (segred-body/scalar-plan phase-1)
@@ -793,6 +808,7 @@
                            :min 'clojure.core/min
                            :max 'clojure.core/max} operator)
               component (first (:components reduction))
+              result-scalars (set (drop 1 (:parameters result-region)))
               phase-2-reduction
               (reduction/scalar
                {:accumulator accumulator
@@ -805,11 +821,11 @@
                 :algebra (:algebra reduction)
                 :attributes (assoc (:attributes reduction)
                                    :physical-phase :cross-block)})
-              phase-2 (segop/->SegRed (+ (:id soac) 1000)
+              phase-2 (segop/->SegRed [:reduction-phase (:id soac) :cross-block]
                                       phase-2-space level-2
                                       phase-2-reduction nil
                                       #{partials-sym} #{(:sym soac)}
-                                      #{} grid-2 :cross-block nil
+                                      result-scalars grid-2 :cross-block nil
                                       dtype)]
           [phase-1 phase-2])))))
 

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -917,14 +917,19 @@
         elements (element-symbols (count arrays))
         capture-parameters (capture-symbols (count captures))
         results (->> (elementize expressions arrays elements index)
-                     (mapv #(util/subst-syms (zipmap captures capture-parameters) %)))]
+                     (mapv #(util/subst-syms (zipmap captures capture-parameters) %)))
+        algebra (scan/certify-reassociation
+                 {:acc (:accumulator component)
+                  :init (:neutral component)
+                  :lambda (first results)}
+                 (:dtype component))]
     (list '= id (vec (filter some? (reduction/results product)))
           (list 'reduce {:index index :extent extent
                          :attributes {:stable-array-captures (vec (sort-by pr-str stable))}
                          :accumulators [(:accumulator component)]
                          :identities [(:neutral component)]
                          :dtypes [(:dtype component)]
-                         :algebra [(:algebra product)]}
+                         :algebra [algebra]}
                 arrays captures
                 (dialect/lambda-form
                  (vec (concat [(:accumulator component)] elements capture-parameters))
@@ -938,7 +943,12 @@
         captures (vec (sort-by pr-str (distinct (concat stable scalars))))
         capture-parameters (capture-symbols (count captures))
         step-results (mapv #(util/subst-syms (zipmap captures capture-parameters) %)
-                           (:results (reduction/fold-region product)))]
+                           (:results (reduction/fold-region product)))
+        algebra (scan/certify-reassociation
+                 {:acc (:accumulator component)
+                  :init (:neutral component)
+                  :lambda (first step-results)}
+                 (:dtype component))]
     (list '= id results
           (list 'segmented-reduce
                 {:segment-axes segment-axes
@@ -948,7 +958,7 @@
                  :accumulators [(:accumulator component)]
                  :identities [(:neutral component)]
                  :dtypes [(:dtype component)]
-                 :algebra [(:algebra product)]
+                 :algebra [algebra]
                  :result-transform result-transform}
                 [] captures
                 (dialect/lambda-form

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -11,6 +11,7 @@
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.axis-map :as axis-map]
+            [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.passes.parallel.fusion-placement :as placement]))
 
@@ -825,6 +826,16 @@
                                                   (:capture-parameters canonical)))
                          :locals (:locals canonical)
                          :body-results (:body-results canonical))
+          updated
+          (if (= :reduce (:kind updated))
+            (let [{:keys [accumulators identities dtypes]} (:attributes updated)
+                  algebra (mapv (fn [accumulator identity component-dtype result]
+                                  (scan/certify-reassociation
+                                   {:acc accumulator :init identity :lambda result}
+                                   component-dtype))
+                                accumulators identities dtypes (:body-results updated))]
+              (assoc-in updated [:attributes :algebra] algebra))
+            updated)
           retain-producer? (> use-count 1)
           fused-kind (keyword (str "map-" (name (:kind consumer))))
           equations (assoc (dialect/equations program) consumer-index (emit-equation updated))

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -395,10 +395,9 @@
 
 (defn- transfer-result-boundary
   "Keep `producer-id`'s fused provenance, but make the consumer's observable store its boundary."
-  [facts producer-id consumer-id]
+  [facts producer-id consumer-id fused-kind]
   (let [consumer (get-in facts [:equations consumer-id])
-        facts (remove-equation-fact facts consumer-id producer-id
-                                    :segmented-reduce-result-map)
+        facts (remove-equation-fact facts consumer-id producer-id fused-kind)
         producer (get-in facts [:equations producer-id])
         boundary-attributes (select-keys (:attributes consumer)
                                          [:result-storage :host-binding])
@@ -427,6 +426,103 @@
                   (assoc :inputs inputs)
                   (update :values select-keys live-values))]
     (dialect/make facts equations (dialect/outputs program))))
+
+(defn- reduce-result-scalar-transform
+  "Translate a pure scalar consumer into a transform applied once to a completed reduction.
+
+   The reduction result becomes the transform accumulator. Every other consumer capture remains
+   an explicitly typed uniform scalar. A full reduction has no result axes, so this rule never
+   invents tensor indexing."
+  [program producer consumer]
+  (let [produced (first (:results producer))
+        accumulator (first (get-in producer [:attributes :accumulators]))
+        {:keys [capture-parameters]} (parameter-parts consumer)
+        bindings (mapv vector (:captures consumer) capture-parameters)
+        consumed (filterv #(= produced (first %)) bindings)
+        scalar-bindings (filterv #(not= produced (first %)) bindings)
+        substitutions
+        (into {}
+              (map (fn [[value parameter]]
+                     [parameter (if (= value produced) accumulator value)]))
+              bindings)
+        expression (util/subst-syms substitutions (first (:body-results consumer)))
+        scalars (mapv (fn [[value _]]
+                        {:value value :dtype (value-scalar-dtype program value)})
+                      scalar-bindings)
+        result-dtype (value-scalar-dtype program (first (:results consumer)))]
+    (when (and (= 1 (count consumed))
+               (every? :dtype scalars)
+               result-dtype)
+      (dialect/make-result-transform
+       {:accumulator accumulator
+        :expression expression
+        :operands []
+        :scalars scalars
+        :result-dtype result-dtype}))))
+
+(defn- reduce-result-scalar-candidate
+  [program]
+  (let [equations (dialect/equations program)
+        infos (mapv equation-info equations)
+        uses (value-use-counts program)]
+    (first
+     (for [producer-index (range (dec (count infos)))
+           :let [consumer-index (inc producer-index)
+                 producer (nth infos producer-index)
+                 consumer (nth infos consumer-index)
+                 produced (first (:results producer))
+                 transform (reduce-result-scalar-transform program producer consumer)]
+           :when (= :reduce (:kind producer))
+           :when (= :scalar (:kind consumer))
+           :when (= 1 (count (:results producer)) (count (:body-results producer))
+                    (count (:results consumer)) (count (:body-results consumer)))
+           :when (= 1 (count (get-in producer [:attributes :accumulators])))
+           :when (nil? (get-in producer [:attributes :result-transform]))
+           :when (empty? (:locals consumer))
+           :when (= 1 (get uses produced 0))
+           :when (not (contains? (set (dialect/outputs program)) produced))
+           :when (= (first (get-in producer [:attributes :dtypes]))
+                    (value-scalar-dtype program (first (:results consumer))))
+           :when (fusible-equation? program (:id producer))
+           :when (fusible-equation? program (:id consumer))
+           :when transform]
+       {:producer-index producer-index :consumer-index consumer-index
+        :producer producer :consumer consumer :transform transform}))))
+
+(defn- fuse-reduce-result-scalar-once
+  [program]
+  (when-let [{:keys [producer-index consumer-index producer consumer transform]}
+             (reduce-result-scalar-candidate program)]
+    (let [producer-parameters (parameter-parts producer)
+          transform-values (mapv :value (:scalars transform))
+          fresh-transform-parameters
+          (mapv #(symbol (str "%fused-result-scalar" %)) (range (count transform-values)))
+          canonical (canonical-operands
+                     (:arrays producer) (:elements producer-parameters)
+                     (vec (concat (:captures producer) transform-values))
+                     (vec (concat (:capture-parameters producer-parameters)
+                                  fresh-transform-parameters))
+                     (:locals producer) (:body-results producer))
+          updated (assoc producer
+                         :results (:results consumer)
+                         :attributes (assoc (:attributes producer) :result-transform transform)
+                         :arrays (:arrays canonical)
+                         :captures (:captures canonical)
+                         :parameters (vec (concat (:accumulators producer-parameters)
+                                                  (:elements canonical)
+                                                  (:capture-parameters canonical)))
+                         :locals (:locals canonical)
+                         :body-results (:body-results canonical))
+          equations (-> (dialect/equations program)
+                        (assoc producer-index (emit-equation updated))
+                        (->> (keep-indexed (fn [index equation]
+                                             (when-not (= index consumer-index) equation)))
+                             vec))
+          facts (-> (transfer-result-boundary (dialect/facts program)
+                                              (:id producer) (:id consumer)
+                                              :reduce-result-scalar)
+                    (update-in [:values (first (:results consumer))] assoc :shape []))]
+      (rebuild-boundary program facts equations))))
 
 (defn- single-write-boundary?
   [facts equation-id result destination]
@@ -599,7 +695,8 @@
                                              (when-not (= index consumer-index) equation)))
                              vec))
           facts (-> (transfer-result-boundary (dialect/facts program)
-                                              (:id producer) (:id consumer))
+                                              (:id producer) (:id consumer)
+                                              :segmented-reduce-result-map)
                     (update-in [:values (first (:results consumer))]
                                assoc
                                :shape (dialect/segmented-reduce-result-shape
@@ -877,18 +974,20 @@
          (recur (fuse-vertical-candidate program candidate)
                 (inc vertical) horizontal (inc iterations)
                 (remember-placement placements (:placement candidate)))
-         (if-let [fused (fuse-segmented-reduce-result-map-once program)]
+         (if-let [fused (fuse-reduce-result-scalar-once program)]
            (recur fused (inc vertical) horizontal (inc iterations) placements)
-           (if-let [fused (fuse-horizontal-once program)]
-             (recur fused vertical (inc horizontal) (inc iterations) placements)
-             (let [placements
-                   (reduce remember-placement placements
-                           (map :placement
-                                (filter (comp not :fuse? :placement) candidates)))
-                   [program ordered-placements] (attach-placement-facts program placements)
-                   stats {:vertical vertical
-                          :horizontal horizontal
-                          :iterations (inc iterations)}]
-               [program (cond-> stats
-                          (seq ordered-placements)
-                          (assoc :placements ordered-placements))]))))))))
+           (if-let [fused (fuse-segmented-reduce-result-map-once program)]
+             (recur fused (inc vertical) horizontal (inc iterations) placements)
+             (if-let [fused (fuse-horizontal-once program)]
+               (recur fused vertical (inc horizontal) (inc iterations) placements)
+               (let [placements
+                     (reduce remember-placement placements
+                             (map :placement
+                                  (filter (comp not :fuse? :placement) candidates)))
+                     [program ordered-placements] (attach-placement-facts program placements)
+                     stats {:vertical vertical
+                            :horizontal horizontal
+                            :iterations (inc iterations)}]
+                 [program (cond-> stats
+                            (seq ordered-placements)
+                            (assoc :placements ordered-placements))])))))))))

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -168,7 +168,7 @@
     ;; Before the fix, op-args extraction took a0=acc a1=x and DROPPED y — emitting a
     ;; kernel that reduced with just x. A segmented reduce combine is binary (op acc elem).
     (is (thrown-with-msg?
-         Exception #"binary associative scalar combine"
+         Exception #"certified associative reduction"
          (segred-source '(+ acc (clojure.core/aget a j) (clojure.core/aget b j))))))
   (testing "the ordinary binary combine still lowers unchanged"
     (let [source (segred-source '(+ acc (clojure.core/aget a j)))]
@@ -180,7 +180,7 @@
     ;; The single-aset-void store-drop shape on the reduce side: (last bdy) silently dropped
     ;; the earlier body forms.
     (is (thrown-with-msg?
-         Exception #"single-expression let region"
+         Exception #"certified associative reduction"
          (segred-source '(let* [t (clojure.core/aget a j)] (+ acc t) (+ acc t)))))))
 
 (deftest segred-devirtualized-aget-lowers-to-subscript

--- a/test/raster/compiler/csimd_test.clj
+++ b/test/raster/compiler/csimd_test.clj
@@ -8,7 +8,11 @@
             [raster.compiler.backend.cpu.csimd :as cs]
             [raster.compiler.backend.cpu.codegen :as cpu]
             [raster.compiler.backend.gpu.c-emit :as ce]
+            [raster.compiler.core.util :as util]
             [raster.compiler.ir.reduction :as reduction]))
+
+(defn- numeric-invk [impl & arguments]
+  (util/make-invk impl arguments))
 
 (defn- clang-avx2? []
   (try
@@ -20,19 +24,23 @@
   {:space {:dims [{:name 'i :bound 'n}]} :dtype dt
    :reduction (reduction/scalar
                {:accumulator 'acc :neutral 0.0 :dtype dt :result 'out :index 'i
-                :step-result '(.invk raster.numeric/_plus__m_double_double-impl acc
-                                     (.invk raster.numeric/_star__m_double_double-impl
-                                            (clojure.core/aget x (long i))
-                                            (clojure.core/aget x (long i))))})})
+                :step-result
+                (numeric-invk
+                 'raster.numeric/_plus__m_double_double-impl 'acc
+                 (numeric-invk 'raster.numeric/_star__m_double_double-impl
+                               '(clojure.core/aget x (long i))
+                               '(clojure.core/aget x (long i))))})})
 
 (defn- dot-segred [dt]
   {:space {:dims [{:name 'i :bound 'n}]} :dtype dt
    :reduction (reduction/scalar
                {:accumulator 'acc :neutral 0.0 :dtype dt :result 'out :index 'i
-                :step-result '(.invk raster.numeric/_plus__m_double_double-impl acc
-                                     (.invk raster.numeric/_star__m_double_double-impl
-                                            (clojure.core/aget a (long i))
-                                            (clojure.core/aget b (long i))))})})
+                :step-result
+                (numeric-invk
+                 'raster.numeric/_plus__m_double_double-impl 'acc
+                 (numeric-invk 'raster.numeric/_star__m_double_double-impl
+                               '(clojure.core/aget a (long i))
+                               '(clojure.core/aget b (long i))))})})
 
 (defn- run1 [native arrs n]
   (let [out (first arrs)]

--- a/test/raster/compiler/fail_loud_contraction_test.clj
+++ b/test/raster/compiler/fail_loud_contraction_test.clj
@@ -14,7 +14,7 @@
                 (list 'raster.numeric/* (list 'aget 'a 't) (list 'aget 'b 't))
                 :stages [{:axis 'blk :extent 2 :dtype :float :init 0.0 :lift 'inner}
                          {:axis 't :extent extent :dtype :int :init 0}])
-          (when combine [:combine combine])))
+          (when combine [:combine combine :init 'Double/NEGATIVE_INFINITY])))
 
 (deftest staged-refuses-a-combine-it-would-silently-turn-into-a-sum
   (testing "every accumulator level uses `+=` and a lift's linearity argument assumes addition, so
@@ -106,7 +106,7 @@
     (let [r (cr/route-contraction
              (list 'raster.par/contract 'O [] [['l 8]]
                    (list 'raster.numeric/* (list 'aget 'a 'l) (list 'aget 'b 'l))
-                   :combine 'max :init -1.0e30)
+                   :combine 'max :init 'Double/NEGATIVE_INFINITY)
              :dtype :double)]
       (is (= :full-reduce (:strategy r)))
       (is (= "fmax" (:c-op r)))

--- a/test/raster/compiler/ir/contraction_facts_test.clj
+++ b/test/raster/compiler/ir/contraction_facts_test.clj
@@ -42,12 +42,12 @@
                (second (rest (first (:results (reduction/fold-region operator)))))))))))
 
 (deftest source-and-semantic-components-enter-the-same-facts-constructor
-  (let [source (form :init 1 :combine 'clojure.core/+)
+  (let [source (form :init 0 :combine 'clojure.core/+)
         parsed (cf/contraction-facts source :dtype :byte)
         components (cf/from-components
                     {:out 'out :free-axes '[[i 4] [j 6]]
                      :contract-axes '[[blk 4] [t 32]] :body body
-                     :opts (array-map :init 1 :combine 'clojure.core/+)
+                     :opts (array-map :init 0 :combine 'clojure.core/+)
                      :dtype :byte})]
     (is (cf/facts? components))
     (is (= (select-keys parsed [:out :free-axes :contract-axes :body :operands
@@ -59,7 +59,7 @@
     (is (= (:form components)
            (cf/surface-form {:out 'out :free-axes '[[i 4] [j 6]]
                              :contract-axes '[[blk 4] [t 32]] :body body
-                             :opts (array-map :init 1 :combine 'clojure.core/+)})))))
+                             :opts (array-map :init 0 :combine 'clojure.core/+)})))))
 
 (deftest a-stage-list-cannot-supply-the-axes-it-is-checked-against
   (testing "the form's contract axes are independent of its :stages — the two are separate slots,

--- a/test/raster/compiler/ir/reduction_test.clj
+++ b/test/raster/compiler/ir/reduction_test.clj
@@ -5,6 +5,7 @@
             [raster.compiler.core.hardware :as hardware]
             [raster.compiler.ir.par :as par-ir]
             [raster.compiler.ir.reduction :as reduction]
+            [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
@@ -41,9 +42,20 @@
                    :index 'i :step-result '(+ acc (aget values i))})]
     (is (reduction/product-reduction? operator))
     (is (reduction/scalar? operator))
+    (is (scan/associative-scan? (:algebra operator)))
     (is (= [:double] (reduction/dtypes operator)))
     (is (= {:acc 'acc :init 0.0 :lambda '(+ acc (aget values i))}
            (reduction/scalar-op operator)))))
+
+(deftest scalar-parallel-reduction-requires-the-registered-typed-identity
+  (try
+    (reduction/scalar
+     {:accumulator 'acc :neutral 5.0 :dtype :double :result 'sum
+      :index 'i :step-result '(+ acc (aget values i))})
+    (is false "a non-identity init must not be duplicated across lanes and blocks")
+    (catch clojure.lang.ExceptionInfo exception
+      (is (= :reduction-nonidentity-init (:reason (ex-data exception))))
+      (is (= 0.0 (:identity (ex-data exception)))))))
 
 (deftest typed-product-validation-test
   (let [node (soac/par-form->soac '_ argmax-product-form 7 :dtype :float)

--- a/test/raster/compiler/ir/scan_test.clj
+++ b/test/raster/compiler/ir/scan_test.clj
@@ -28,6 +28,16 @@
                (- (aget x i) (aget target i)))
            (:element facts)))))
 
+(deftest reassociation-certification-uses-the-central-effect-analysis
+  (let [facts (scan/certify-reassociation
+               {:acc 'acc :init 0.0
+                :lambda '(raster.numeric/+
+                          acc
+                          (raster.numeric/* (aget a i) (aget b i)))}
+               :half)]
+    (is (scan/associative-scan? facts))
+    (is (= 'raster.numeric/* (first (:element facts))))))
+
 (deftest general-recurrences-are-not-relabelled-parallel-scans
   (testing "an RNN recurrence is sequential unless it is explicitly lifted to an associative algebra"
     (try

--- a/test/raster/compiler/ir/scan_test.clj
+++ b/test/raster/compiler/ir/scan_test.clj
@@ -16,6 +16,18 @@
                         :lambda '(raster.numeric/+ (float acc) (aget values i))}
                        :float)))))
 
+(deftest reassociation-certification-uses-the-shared-pure-let-rewrite
+  (let [facts (scan/certify-reassociation
+               {:acc 'acc :init 0.0
+                :lambda '(let* [difference (- (aget x i) (aget target i))]
+                           (+ acc (* difference difference)))}
+               :double)]
+    (is (scan/associative-scan? facts))
+    (is (= '+ (:combine facts)))
+    (is (= '(* (- (aget x i) (aget target i))
+               (- (aget x i) (aget target i)))
+           (:element facts)))))
+
 (deftest general-recurrences-are-not-relabelled-parallel-scans
   (testing "an RNN recurrence is sequential unless it is explicitly lifted to an associative algebra"
     (try

--- a/test/raster/compiler/ir/segop_test.clj
+++ b/test/raster/compiler/ir/segop_test.clj
@@ -1,5 +1,6 @@
 (ns raster.compiler.ir.segop-test
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.soac-lower :as lower]))
@@ -97,11 +98,22 @@
             {:keys [acc lambda]} (segop/scalar-reduce-op phase-two)]
         (is (instance? raster.compiler.ir.segop.SegRed phase-two))
         (is (= :cross-block (:phase phase-two)))
+        (is (= [:reduction-phase 0 :cross-block] (:id phase-two)))
+        (is (launch/dimension-expression? (get-in phase-two [:space :dims 0 :bound])))
         (is (= (list 'clojure.core/+ acc
                      (list 'clojure.core/aget partials index))
                lambda)
             "the scheduled second phase reduces its partial buffer, not the original element body")
         (is (not (contains? (:inputs phase-two) 'a)))))))
+
+(deftest lower-reduce-phase-id-is-structured-for-any-equation-id
+  (let [reduction (assoc (soac/par-form->soac
+                          'result
+                          '(raster.par/reduce acc 0.0 j n (+ acc (aget a j))) 0)
+                         :id 'symbolic-reduction)
+        phase-two (second (lower/lower-reduce reduction nil))]
+    (is (= [:reduction-phase 'symbolic-reduction :cross-block] (:id phase-two)))
+    (is (launch/dimension-expression? (get-in phase-two [:space :dims 0 :bound])))))
 
 (deftest lower-reduce-single-phase-test
   (testing "Small constant reduce lowers to a single SegRed"

--- a/test/raster/compiler/ir/soac_test.clj
+++ b/test/raster/compiler/ir/soac_test.clj
@@ -146,6 +146,14 @@
       (is (instance? raster.compiler.ir.soac.ScalarBinding (nth nodes 1)))
       (is (instance? raster.compiler.ir.soac.SoacReduce (nth nodes 2))))))
 
+(deftest nonidentity-reduction-remains-a-sequential-compatibility-binding
+  (let [expression '(raster.par/reduce best finite-sentinel i n
+                      (raster.numeric/max best (raster.arrays/aget values i)))
+        node (first (soac/let-bindings->nodes [['result expression]]))]
+    (is (instance? raster.compiler.ir.soac.ScalarBinding node))
+    (is (= expression (:expr node)))
+    (is (= [['result expression]] (soac/nodes->let-bindings [node])))))
+
 (deftest nodes->let-bindings-roundtrip-test
   (testing "Round-trip through nodes preserves binding order"
     (let [pairs [['out '(raster.par/map! out i n double (* (aget a i) 2.0))]

--- a/test/raster/compiler/passes/parallel/contract_lower_test.clj
+++ b/test/raster/compiler/passes/parallel/contract_lower_test.clj
@@ -45,12 +45,12 @@
       (is (= '#{y} (:outputs sr))))))
 
 (deftest contract-form-custom-init-combine
-  (testing "opts :init/:combine flow into reduce-op (e.g. max-plus semiring)"
+  (testing "the exact typed identity and combine flow into the certified max-plus reduction"
     (let [form '(raster.par/contract C [[i m] [j n]] [[l k]]
                                      (+ (aget A (+ (* i k) l)) (aget B (+ (* l n) j)))
-                                     :init -1.0e30 :combine max)
+                                     :init Double/NEGATIVE_INFINITY :combine max)
           sr (cl/contract-form->segred form)]
-      (is (= -1.0e30 (:init (segop/scalar-reduce-op sr))))
+      (is (= 'Double/NEGATIVE_INFINITY (:init (segop/scalar-reduce-op sr))))
       (is (= 'max (first (:lambda (segop/scalar-reduce-op sr))))))))
 
 (deftest contract-form-three-free-axes

--- a/test/raster/compiler/passes/parallel/contraction_schedule_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_schedule_test.clj
@@ -57,10 +57,11 @@
       (is (= :partial-matrix-k-fragment (:reason planned)))
       (is (= 16 (:matrix-k planned)))))
   (testing "a non-zero reduction initializer cannot be dropped by a zero-initialized matrix body"
-    (is (= :non-zero-matrix-init
-           (:reason (schedule/plan-matrix-body
-                     (facts/contraction-facts (matrix-form 128 128 128 1.0) :dtype :half)
-                     nil nil)))))
+    (try
+      (facts/contraction-facts (matrix-form 128 128 128 1.0) :dtype :half)
+      (is false "non-identity parallel reductions must be rejected before scheduling")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :reduction-nonidentity-init (:reason (ex-data exception)))))))
   (testing "matrix N and subgroup width must agree with an implemented DPAS spelling"
     (let [desc {:matrix {:family :dpas :m 8 :n 16 :k 16 :subgroup 8}}
           planned (schedule/plan-matrix-body

--- a/test/raster/compiler/passes/parallel/structured_control_route_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_route_test.clj
@@ -273,19 +273,67 @@
                   source pipeline/gpu-resident-pre-soa-passes options)
         scheduled (route/schedule-program semantic options)
         emitted (program-opencl/emit-program scheduled options)
-        loop-operation (get-in scheduled [:equations 0 :operations 0])]
+        emitted-program (:program emitted)
+        loop-operation (get-in scheduled [:equations 0 :operations 0])
+        loop-equation (first (:equations emitted-program))
+        trip-count-id (second (control/loop-index (:algorithm loop-equation)))
+        loop-output (-> loop-equation :algorithm control/carried first :output)
+        device-results
+        (set (mapcat :results
+                     (remove #(true? (get-in % [:attributes :host-only]))
+                             (:equations emitted-program))))
+        buffer-ids
+        (into device-results
+              (filter #(seq (:shape (get (:values emitted-program) %)))
+                      (:inputs emitted-program)))
+        buffers (zipmap buffer-ids (map #(keyword (str "rk4-buffer-" (hash %))) buffer-ids))
+        scalar-values
+        (into {}
+              (keep (fn [id]
+                      (when-not (contains? buffer-ids id)
+                        (let [dtype (get-in emitted-program [:values id :dtype])]
+                          [id {:type dtype
+                               :value (case dtype
+                                        :int (if (= id trip-count-id) 2 64)
+                                        :long 2
+                                        :float (float 0.25)
+                                        :double 0.25)}]))))
+              (:inputs emitted-program))
+        call
+        (program-call/make
+         emitted-program buffers scalar-values {loop-output :rk4-carry-scratch}
+         (fn [equation {:keys [operands]}]
+           (let [operand-id (first (:operands equation))
+                 divisor (double (get-in operands [operand-id :value]))]
+             (into {}
+                   (map (fn [id]
+                          [id {:type (get-in emitted-program [:values id :dtype])
+                               :value (/ 1.0 divisor)}]))
+                   (:results equation)))))]
     (is (= :typed-parallel (:dialect semantic)))
     (is (= :scheduled-parallel (:dialect scheduled)))
-    (is (= 4 (count (:equations scheduled)))
-        "one generic fixpoint and three suffix equations represent the RK4 loss")
+    (is (= 3 (count (:equations scheduled)))
+        "the generic fixpoint, host inv-n, and reduction with a final scalar epilogue represent the RK4 loss")
     (is (= 8 (count (get-in loop-operation [:graph :nodes])))
         "the loop body is the ordinary stencil/map schedule, not an RK4 primitive")
     (is (= :opencl-parallel (get-in emitted [:program :dialect])))
     (is (= 10 (count (:kernels emitted))))
     (is (= {:structured-loops-emitted 1
             :typed-equations-emitted 1
-            :host-scalar-equations 2}
-           (:stats emitted)))))
+            :host-scalar-equations 1}
+           (:stats emitted)))
+    (let [[partial final] (take-last 2 (:kernels emitted))
+          inv-n? #(and (symbol? %) (.startsWith (name %) "inv-n_"))]
+      (is (= [:kernel-body :kernel-body]
+             (mapv #(get-in % [:attributes :emission-route]) [partial final])))
+      (is (not-any? inv-n? (:arguments partial))
+          "the pre-combine phase must not apply or even bind the completed-result transform")
+      (is (some inv-n? (:arguments final))
+          "only the final reduction phase consumes the scalar epilogue input"))
+    (is (= ["StructuredLoopCall" "EvaluatedHostEquation" "EmittedEquationCall"]
+           (mapv #(-> % class .getSimpleName) (:steps call)))
+        "the real emitted workload must cross the checked runtime-call boundary")
+    (is (= (set (:outputs emitted-program)) (set (keys (:outputs call)))))))
 
 (defn- prepared-mixed-call
   [trip-count]

--- a/test/raster/compiler/passes/parallel/typed_segmented_reduction_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_segmented_reduction_test.clj
@@ -4,6 +4,7 @@
             [raster.compiler.ir.dialects :as dialects]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.reduction :as reduction]
+            [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac :as legacy]
             [raster.compiler.ir.soac-dialect :as dialect]
@@ -15,20 +16,21 @@
   (av/tensor {:dtype dtype :shape shape :representation {:kind :plain}}))
 
 (defn- program []
-  (let [equation
-        '(= contract-equation [C]
-            (segmented-reduce
-             {:segment-axes [[i m] [j n]]
-              :index l :extent k
-              :accumulators [acc] :identities [0.0]
-              :dtypes [:float] :algebra [{}]
-              :attributes {:stable-array-captures [A B]}}
-             [] [A B n k]
-             (lambda [acc lhs rhs width inner]
-               (region []
-                       [(+ acc
-                           (* (aget lhs (+ (* i inner) l))
-                              (aget rhs (+ (* l width) j))))]))))
+  (let [body '(+ acc
+                 (* (aget lhs (+ (* i inner) l))
+                    (aget rhs (+ (* l width) j))))
+        algebra (scan/certify-reassociation
+                 {:acc 'acc :init 0.0 :lambda body} :float)
+        equation
+        (list '= 'contract-equation ['C]
+              (list 'segmented-reduce
+                    {:segment-axes '[[i m] [j n]]
+                     :index 'l :extent 'k
+                     :accumulators ['acc] :identities [0.0]
+                     :dtypes [:float] :algebra [algebra]
+                     :attributes {:stable-array-captures ['A 'B]}}
+                    [] ['A 'B 'n 'k]
+                    (dialect/lambda-form ['acc 'lhs 'rhs 'width 'inner] [body])))
         facts
         (assoc (dialect/default-program-facts
                 {:front-end :typed-segmented-reduction-test})

--- a/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
@@ -352,3 +352,39 @@
     (is (= program result))
     (is (= {:vertical 0 :horizontal 0 :iterations 1} stats))
     (is (= 2 (count (dialect/equations result))))))
+
+(deftest completed-reduction-fuses-a-pure-scalar-consumer
+  (let [program
+        (frontend/form->program
+         '(let* [total (raster.par/reduce acc 0.0 i n
+                                           (+ acc (clojure.core/aget x i)))
+                 ^double scaled (* ^double total ^double scale)]
+            scaled)
+         {:dtype :double
+          :array-types {'x :double}
+          :scalar-types {'scale :double}})
+        fold-before (-> program dialect/equations first typed-fusion/equation-info :body-results)
+        [result stats] (typed-fusion/fusion-fixpoint program)
+        equation (first (dialect/equations result))
+        operation (dialect/operation-parts equation)
+        transform (get-in operation [:attributes :result-transform])
+        transform-region (dialect/lambda-parts (:lambda transform))
+        remapped (dialect/remap-values result {'scale 'gain})
+        remapped-attributes (:attributes (dialect/operation-parts
+                                          (first (dialect/equations remapped))))]
+    (is (= {:vertical 1 :horizontal 0 :iterations 2} stats))
+    (is (= 1 (count (dialect/equations result))))
+    (is (= 'reduce (:kind operation)))
+    (is (= '[scaled] (nth equation 2)))
+    (is (= '[scaled] (dialect/outputs result)))
+    (is (= '#{n scale x} (set (:inputs (dialect/facts result)))))
+    (is (= fold-before (:body-results (dialect/lambda-parts (:lambda operation))))
+        "the scalar epilogue must never enter the element or partial-reduction fold")
+    (is (= [] (:operands transform)))
+    (is (= '[scale] (mapv :value (:scalars transform))))
+    (is (not-any? #{'total} (flatten (:body-results transform-region))))
+    (is (= '[gain] (mapv :value (get-in remapped-attributes
+                                        [:result-transform :scalars]))))
+    (is (not (contains? remapped-attributes :segment-axes))
+        "remapping a full reduction must not invent segmented axes")
+    (is (= result (dialect/validate! result)))))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1037,9 +1037,12 @@
                                  source :float {'a :float 'out :float}
                                  {:resident-reductions? true})]
     (is (= :typed-soac (:dialect program)))
+    (is (= 1 (:vertical stats)))
     (is (zero? (:resident-reductions stats)))
-    (is (= :plain (get-in program [:values 'total :representation :kind])))
-    (is (= [:binding 'scaled] (get-in program [:equations 1 :site])))
+    (is (nil? (get-in program [:values 'total]))
+        "the unobservable pre-epilogue scalar is no longer materialized")
+    (is (= :plain (get-in program [:values 'scaled :representation :kind])))
+    (is (= [:binding 'scaled] (get-in program [:equations 0 :site])))
     (is (some #{'raster.par/reduce} (flatten (:source program))))
     (is (not-any? #{'raster.par/reduce-into} (flatten (:source program))))))
 

--- a/test/raster/compiler/router_declines_test.clj
+++ b/test/raster/compiler/router_declines_test.clj
@@ -29,7 +29,7 @@
                             (list 'clojure.core/+ (list 'clojure.core/* 'i k) 'l))
                       (list 'clojure.core/aget 'B
                             (list 'clojure.core/+ (list 'clojure.core/* 'l n) 'j))))
-          (when combine [:combine combine])))
+          (when combine [:combine combine :init 'Float/NEGATIVE_INFINITY])))
 
 (defn- route [form dtype] (cr/route-contraction form :dtype dtype))
 


### PR DESCRIPTION
Adds a generic TypedSOAC reduce-to-scalar fusion rule and carries its typed result transform through SegRed and KernelBody. Two-phase reductions apply the transform only in the final combine kernel; unsupported lowering fails closed. The real RK4 workload now has one fewer host scalar boundary. Reassociation is certified through Raster's central Beichte-backed effect analysis, including half-precision contraction fixtures. Focused regression set: 117 tests, 670 assertions.