### PR TITLE
Retain typed public invocation plans

### DIFF
--- a/src/raster/compiler/core/op_descriptor.clj
+++ b/src/raster/compiler/core/op_descriptor.clj
@@ -381,26 +381,46 @@
     (merge base
            (into {} (map (fn [[k v]] [(symbol "clojure.core" (name k)) v]) base)))))
 
-(def ^:private known-allocator-base-names
-  "Base names (before _m_ mangling) of deftm functions that are pure allocators.
-   Includes aclone — the hoister fills via arraycopy instead of zero-fill."
-  #{"zeros-like" "alloc-like" "similar" "aclone"})
+(def ^:private known-allocator-initializations
+  "Base names (before _m_ mangling) of deftm functions that are pure allocators."
+  {"zeros-like" :zero, "alloc-like" :unspecified, "similar" :unspecified, "aclone" :copy})
+
+(defn- allocator-base-name
+  [sym]
+  (when (symbol? sym)
+    (let [n (name sym)]
+      (if-let [idx (clojure.string/index-of n "_m_")]
+        (subs n 0 idx)
+        n))))
+
+(defn allocation-initialization
+  "Return the semantic initialization contract of an allocation operation.
+
+   `:copy` means the first source-shaped argument must be copied, `:zero` means the language
+   guarantees zero initialization, and `:unspecified` means callers may leave the fresh storage
+   uninitialized. nil means the operation is not a recognized allocator. This classification lives
+   beside `alloc-op?` so invocation planning and host hoisting cannot drift."
+  [sym]
+  (let [base (allocator-base-name sym)]
+    (or
+     (get known-allocator-initializations base)
+     (cond
+      (or (contains? alloc-ops sym)
+          (contains? alloc-sym->array-tag sym)
+          (contains? alloc-sym->array-tag (some-> base symbol))) :zero
+      :else nil))))
 
 (defn alloc-op?
   "True if sym is an array allocation operation.
    Recognizes standard constructors (double-array etc.) and deftm allocators
    (zeros-like, aclone) including their mangled variants."
   [sym]
-  (and (symbol? sym)
-       (let [n (name sym)]
-         (or (contains? alloc-ops sym)
-             (contains? alloc-sym->array-tag sym)
-             (contains? alloc-sym->array-tag (symbol n))
-             ;; Check base name for known deftm allocators
-             (let [base (if-let [idx (clojure.string/index-of n "_m_")]
-                          (subs n 0 idx)
-                          n)]
-               (contains? known-allocator-base-names base))))))
+  (boolean (allocation-initialization sym)))
+
+(defn copy-allocation-op?
+  "Whether `sym` allocates fresh storage initialized by copying a source value."
+  [sym]
+  (= :copy (allocation-initialization sym)))
 
 ;; --- Primitive casts ---
 

--- a/src/raster/compiler/ir/invocation_plan.clj
+++ b/src/raster/compiler/ir/invocation_plan.clj
@@ -1,0 +1,362 @@
+(ns raster.compiler.ir.invocation-plan
+  "Typed semantic boundary from public function arguments to an internal ParallelProgram.
+
+   ParallelProgram inputs are compiler SSA values: they may include shape projections, narrowed
+   scalars, cloned state, and fresh scratch. InvocationPlan retains how ordered public parameters
+   produce those values without asking a runtime to inspect the original function body or infer
+   storage roles from names. Physical allocation, views, ownership, and transfers remain the job of
+   ResidentPlan/LinkPlan lowering."
+  (:require [clojure.set :as set]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.util :as util]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.soac-dialect :as soac]
+            [raster.compiler.passes.scalar.effects :as effects]))
+
+(defrecord InvocationParameter [id symbol value])
+(defrecord ShapeProjection [id symbol operands source axis value])
+(defrecord ScalarCompute [id symbol operands region value])
+(defrecord BufferAllocation [id symbol operands initialization value])
+(defrecord BufferClone [id symbol operands source value])
+(defrecord ValueAlias [id symbol operands source value])
+(defrecord InvocationPlan
+           [id parameters steps bindings program-inputs program-outputs values attributes])
+
+(defn- record-kind?
+  [class-name value]
+  (and value (= class-name (.getName (class value)))))
+
+(defn invocation-parameter? [x]
+  (record-kind? "raster.compiler.ir.invocation_plan.InvocationParameter" x))
+(defn shape-projection? [x]
+  (record-kind? "raster.compiler.ir.invocation_plan.ShapeProjection" x))
+(defn scalar-compute? [x]
+  (record-kind? "raster.compiler.ir.invocation_plan.ScalarCompute" x))
+(defn buffer-allocation? [x]
+  (record-kind? "raster.compiler.ir.invocation_plan.BufferAllocation" x))
+(defn buffer-clone? [x]
+  (record-kind? "raster.compiler.ir.invocation_plan.BufferClone" x))
+(defn value-alias? [x]
+  (record-kind? "raster.compiler.ir.invocation_plan.ValueAlias" x))
+(defn invocation-plan? [x]
+  (record-kind? "raster.compiler.ir.invocation_plan.InvocationPlan" x))
+
+(defn invocation-step?
+  [x]
+  (or (shape-projection? x) (scalar-compute? x)
+      (buffer-allocation? x) (buffer-clone? x) (value-alias? x)))
+
+(defn- fail!
+  [reason message data]
+  (throw (ex-info message (assoc data :reason reason :ir :invocation-plan))))
+
+(defn- distinct-vector?
+  [values]
+  (and (vector? values) (= (count values) (count (distinct values)))))
+
+(defn- scalar-value?
+  [value]
+  (and (= :tensor (:kind value)) (empty? (:shape value))))
+
+(defn- buffer-value?
+  [value]
+  (and (= :tensor (:kind value)) (seq (:shape value))))
+
+(defn- operand-map
+  [step]
+  (let [operands (:operands step)]
+    (when-not (and (vector? operands)
+                   (every? #(and (map? %) (symbol? (:symbol %))
+                                 (contains? % :value)) operands)
+                   (= (count operands) (count (distinct (map :symbol operands)))))
+      (fail! :invocation-step-operands
+             "invocation step operands must be ordered unique symbol/value references"
+             {:step (:id step) :operands operands}))
+    (into {} (map (juxt :symbol :value)) operands)))
+
+(defn- compatible-value?
+  [left right]
+  (and left right
+       (= (:kind left) (:kind right))
+       (= (:dtype left) (:dtype right))
+       (av/storage-contract-compatible? left right)))
+
+(defn- validate-step!
+  [step values available]
+  (when-not (invocation-step? step)
+    (fail! :invocation-step-type "invocation plan contains an unknown step"
+           {:step step :actual (type step)}))
+  (let [{:keys [id symbol value]} step
+        operands (operand-map step)
+        operand-values (set (vals operands))]
+    (when (or (nil? id) (not (symbol? symbol)))
+      (fail! :invocation-step-identity
+             "invocation step requires a stable identity and lexical result symbol"
+             {:step id :symbol symbol}))
+    (when (contains? available id)
+      (fail! :invocation-step-redefinition "invocation step result must be fresh SSA"
+             {:step id}))
+    (when-let [missing (seq (set/difference operand-values available))]
+      (fail! :invocation-step-use-before-definition
+             "invocation step operand is not a public parameter or earlier result"
+             {:step id :values (set missing)}))
+    (when-not (= value (get values id))
+      (fail! :invocation-step-value
+             "invocation step value differs from the plan value table"
+             {:step id :declared value :table (get values id)}))
+    (av/validate! value)
+    (cond
+      (shape-projection? step)
+      (let [source-value (get values (:source step))]
+        (when-not (and (= 1 (count operands))
+                       (= (:source step) (first operand-values))
+                       (buffer-value? source-value)
+                       (integer? (:axis step))
+                       (<= 0 (:axis step) (dec (count (:shape source-value))))
+                       (scalar-value? value)
+                       (contains? #{:int :long} (:dtype value)))
+          (fail! :invocation-shape-projection
+                 "shape projection requires one shaped source and an integer scalar result"
+                 {:step id :source (:source step) :axis (:axis step) :value value})))
+
+      (scalar-compute? step)
+      (let [{:keys [parameters locals body-results]} (soac/lambda-parts (:region step))
+            parameter-set (set parameters)
+            free-symbols (when (= 1 (count body-results))
+                           (util/free-syms (first body-results)))]
+        (when-not (scalar-value? value)
+          (fail! :invocation-scalar-value "scalar computation must produce a rank-zero value"
+                 {:step id :value value}))
+        (when-not (every? (fn [operand]
+                            (scalar-value? (get values (:value operand))))
+                          (:operands step))
+          (fail! :invocation-scalar-operands
+                 "invocation scalar computation operands must all be rank zero"
+                 {:step id :operands (:operands step)}))
+        (when-not (and (= parameters (mapv :symbol (:operands step)))
+                       (empty? locals)
+                       (= 1 (count body-results)))
+          (fail! :invocation-scalar-region
+                 "invocation scalar region must close one result over its ordered operands"
+                 {:step id :region (:region step) :operands (:operands step)}))
+        (when-let [unbound (seq (set/difference free-symbols parameter-set))]
+          (fail! :invocation-scalar-free-symbol
+                 "invocation scalar region references a value outside its closed operands"
+                 {:step id :region (:region step) :free-symbols (set unbound)
+                  :parameters parameter-set}))
+        (when-not (= :pure (effects/analyze-effect (first body-results)))
+          (fail! :invocation-scalar-effect
+                 "invocation scalar computation must be proven pure"
+                 {:step id :region (:region step)})))
+
+      (buffer-allocation? step)
+      (when-not (and (buffer-value? value)
+                     (contains? #{:zero :unspecified} (:initialization step)))
+        (fail! :invocation-buffer-allocation
+               "buffer allocation must retain a recognized fresh-allocation contract"
+               {:step id :initialization (:initialization step) :value value}))
+
+      (buffer-clone? step)
+      (let [source-value (get values (:source step))]
+        (when-not (and (buffer-value? value)
+                       (= 1 (count operands))
+                       (= (:source step) (first operand-values))
+                       (compatible-value? source-value value))
+          (fail! :invocation-buffer-clone
+                 "buffer clone requires one storage-compatible source"
+                 {:step id :source (:source step) :value value})))
+
+      (value-alias? step)
+      (let [source-value (get values (:source step))]
+        (when-not (and (= 1 (count operands))
+                       (= (:source step) (first operand-values))
+                       (compatible-value? source-value value))
+          (fail! :invocation-value-alias
+                 "value alias requires one storage-compatible earlier value"
+                 {:step id :source (:source step) :value value}))))
+    (conj available id)))
+
+(defn validate!
+  [plan]
+  (when-not (invocation-plan? plan)
+    (fail! :invocation-plan-type "expected an InvocationPlan" {:actual (type plan)}))
+  (let [{:keys [id parameters steps bindings program-inputs program-outputs values attributes]} plan]
+    (when (nil? id)
+      (fail! :invocation-plan-id "invocation plan requires a stable identity" {}))
+    (when-not (and (vector? parameters) (every? invocation-parameter? parameters)
+                   (distinct-vector? (mapv :id parameters))
+                   (distinct-vector? (mapv :symbol parameters)))
+      (fail! :invocation-parameters
+             "public invocation parameters must have unique ordered IDs and symbols"
+             {:parameters parameters}))
+    (when-not (and (vector? steps) (vector? bindings)
+                   (distinct-vector? program-inputs) (distinct-vector? program-outputs)
+                   (map? values) (map? attributes))
+      (fail! :invocation-plan-fields "invocation plan fields have invalid container types"
+             {:steps steps :bindings bindings :inputs program-inputs
+              :outputs program-outputs :values values :attributes attributes}))
+    (doseq [{:keys [id value] :as parameter} parameters]
+      (when-not (= value (get values id))
+        (fail! :invocation-parameter-value
+               "public parameter differs from the invocation value table"
+               {:parameter parameter :table (get values id)}))
+      (av/validate! value))
+    (let [available (reduce (fn [available step]
+                              (validate-step! step values available))
+                            (set (map :id parameters)) steps)
+          expected-bindings (mapv :program-value bindings)
+          invocation-values (mapv :invocation-value bindings)]
+      (when-not (= program-inputs expected-bindings)
+        (fail! :invocation-program-input-order
+               "invocation bindings must exactly follow the internal program input order"
+               {:inputs program-inputs :bindings expected-bindings}))
+      (when-let [missing (seq (set/difference (set invocation-values) available))]
+        (fail! :invocation-program-input-value
+               "internal program input is not produced by the invocation prefix"
+               {:values (set missing)}))
+      (doseq [{program-value :program-value invocation-value :invocation-value} bindings]
+        (when-not (compatible-value? (get values program-value) (get values invocation-value))
+          (fail! :invocation-program-input-contract
+                 "public materialization differs from the internal program value contract"
+                 {:program-value program-value :invocation-value invocation-value
+                  :program-contract (get values program-value)
+                  :invocation-contract (get values invocation-value)})))
+      (doseq [output program-outputs]
+        (when-not (contains? values output)
+          (fail! :invocation-program-output
+                 "invocation output has no retained AbstractValue" {:output output}))))
+    plan))
+
+(defn- parameter-id [plan-id ordinal symbol]
+  [:invocation plan-id :parameter ordinal symbol])
+
+(defn- binding-id [plan-id ordinal symbol]
+  [:invocation plan-id :binding ordinal symbol])
+
+(defn- referenced-operands
+  [expression environment]
+  (let [symbols (sort-by str (util/free-syms expression))]
+    (mapv (fn [symbol]
+            (if-let [value (get environment symbol)]
+              {:symbol symbol :value value}
+              (fail! :invocation-prefix-free-value
+                     "invocation prefix references a value outside its public lexical boundary"
+                     {:symbol symbol :expression expression
+                      :available (set (keys environment))})))
+          symbols)))
+
+(defn- unwrap-casts
+  [expression]
+  (loop [expression expression]
+    (if (and (seq? expression)
+             (descriptor/cast-op? (descriptor/semantic-op expression))
+             (= 1 (count (descriptor/call-args expression))))
+      (recur (first (descriptor/call-args expression)))
+      expression)))
+
+(defn- shape-source
+  [expression]
+  (let [expression (unwrap-casts expression)]
+    (when (and (seq? expression)
+               (descriptor/alength-op? (descriptor/semantic-op expression))
+               (= 1 (count (descriptor/call-args expression)))
+               (symbol? (first (descriptor/call-args expression))))
+      (first (descriptor/call-args expression)))))
+
+(defn- prefix-step
+  [plan-id ordinal symbol expression value environment]
+  (let [id (binding-id plan-id ordinal symbol)
+        operands (referenced-operands expression environment)
+        operation (descriptor/semantic-op expression)
+        initialization (descriptor/allocation-initialization operation)]
+    (cond
+      (shape-source expression)
+      (let [source-symbol (shape-source expression)]
+        (->ShapeProjection id symbol operands (get environment source-symbol) 0 value))
+
+      (= :copy initialization)
+      (let [source-symbol (some-> expression descriptor/call-args first unwrap-casts)]
+        (when-not (symbol? source-symbol)
+          (fail! :invocation-clone-source
+                 "copy allocation requires one lexical source value"
+                 {:symbol symbol :expression expression}))
+        (->BufferClone id symbol operands (get environment source-symbol) value))
+
+      initialization
+      (->BufferAllocation id symbol operands initialization value)
+
+      (symbol? expression)
+      (->ValueAlias id symbol operands (get environment expression) value)
+
+      (scalar-value? value)
+      (->ScalarCompute id symbol operands
+                       (soac/lambda-form (mapv :symbol operands) [expression]) value)
+
+      :else
+      (fail! :invocation-prefix-unsupported
+             "typed invocation planning does not support this host materialization"
+             {:symbol symbol :expression expression :value value}))))
+
+(defn from-prefix
+  "Build a typed invocation plan from a certified flat host prefix.
+
+   `parameters` is the public function order. `parameter-values` describes those values before any
+   lexical shadowing; `binding-values` describes prefix results. `program-values`, inputs, and
+   outputs are the already validated internal ParallelProgram boundary. Stable SSA IDs keep a
+   narrowed binding such as `nsteps = (int nsteps)` distinct from its public long parameter."
+  [{:keys [id parameters parameter-values bindings binding-values program-values
+           program-inputs program-outputs attributes]
+    :or {attributes {}}}]
+  (let [parameters (vec parameters)
+        public
+        (mapv (fn [ordinal symbol]
+                (let [value (get parameter-values symbol)]
+                  (when-not value
+                    (fail! :invocation-parameter-contract
+                           "public parameter has no retained AbstractValue"
+                           {:parameter symbol :parameters parameters}))
+                  (->InvocationParameter (parameter-id id ordinal symbol) symbol value)))
+              (range) parameters)
+        initial-values (into {} (map (juxt :id :value)) public)
+        initial-environment (into {} (map (juxt :symbol :id)) public)
+        {:keys [steps values environment]}
+        (reduce (fn [{:keys [steps values environment]} [ordinal [symbol expression]]]
+                  (let [value (get binding-values symbol)]
+                    (when-not value
+                      (fail! :invocation-prefix-value
+                             "invocation prefix binding has no retained AbstractValue"
+                             {:symbol symbol :expression expression}))
+                    (let [step (prefix-step id ordinal symbol expression value environment)]
+                      {:steps (conj steps step)
+                       :values (assoc values (:id step) value)
+                       :environment (assoc environment symbol (:id step))})))
+                {:steps [] :values initial-values :environment initial-environment}
+                (map-indexed vector bindings))
+        input-bindings
+        (mapv (fn [program-value]
+                (if-let [invocation-value (get environment program-value)]
+                  {:program-value program-value :invocation-value invocation-value}
+                  (fail! :invocation-program-input
+                         "internal program input has no public or materialized producer"
+                         {:program-value program-value
+                          :available (set (keys environment))})))
+              program-inputs)
+        values (merge program-values values)]
+    (validate!
+     (->InvocationPlan id public steps input-bindings (vec program-inputs)
+                       (vec program-outputs) values attributes))))
+
+(defn validate-against!
+  "Validate that `plan` still matches a program's explicit value/input/output boundary."
+  [plan parallel-program]
+  (let [plan (validate! plan)]
+    (when-not (and (= (:program-inputs plan) (:inputs parallel-program))
+                   (= (:program-outputs plan) (:outputs parallel-program))
+                   (every? (fn [id] (= (get (:values plan) id)
+                                       (get (:values parallel-program) id)))
+                           (concat (:inputs parallel-program) (:outputs parallel-program))))
+      (fail! :invocation-program-mismatch
+             "invocation plan no longer matches its internal ParallelProgram boundary"
+             {:plan-inputs (:program-inputs plan) :program-inputs (:inputs parallel-program)
+              :plan-outputs (:program-outputs plan) :program-outputs (:outputs parallel-program)}))
+    plan))

--- a/src/raster/compiler/passes/parallel/structured_control_frontend.clj
+++ b/src/raster/compiler/passes/parallel/structured_control_frontend.clj
@@ -260,6 +260,7 @@
               flattened-source (when (seq flattened-pairs)
                                  (list 'let* (vec (mapcat identity flattened-pairs))
                                        copy-binding))
+              parameter-analysis (host-av/analyze '(let* [] nil) options)
               outer-analysis (host-av/analyze prefix-source options)
               body-analysis
               (when flattened-source
@@ -369,6 +370,8 @@
                        :source source
                        :loop-binding binder
                        :prefix-bindings prefix-pairs
+                       :parameter-values (:values parameter-analysis)
+                       :outer-values (:values outer-analysis)
                        :suffix-bindings suffix-pairs
                        :outer-body (vec outer-body)
                        :flattened-body-source flattened-source

--- a/src/raster/compiler/passes/parallel/structured_control_route.clj
+++ b/src/raster/compiler/passes/parallel/structured_control_route.clj
@@ -7,6 +7,7 @@
    ScheduledStructuredLoop; it does not reconstruct or recognize a source-shaped compound loop."
   (:require [clojure.set :as set]
             [raster.compiler.core.util :as util]
+            [raster.compiler.ir.invocation-plan :as invocation]
             [raster.compiler.ir.parallel-program :as program]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as soac]
@@ -175,7 +176,8 @@
    When a suffix is itself in the TypedSOAC subset, its uses of the physical carried array are
    alpha-remapped to the loop's fresh logical output and appended as ordinary typed equations."
   ([decomposition] (program-envelope decomposition {}))
-  ([{:keys [loop source loop-binding] :as decomposition} options]
+  ([{:keys [loop source loop-binding prefix-bindings parameter-values outer-values]
+     :as decomposition} options]
    (when-not (and (map? decomposition) loop)
      (throw (ex-info "structured-control routing requires a certified frontend decomposition"
                      {:reason :structured-control-decomposition
@@ -190,21 +192,40 @@
          values (merge-values (control/outer-values loop) (:values suffix-envelope))
          program-outputs (or (:outputs suffix-envelope) (control/outer-results loop))
          {:keys [inputs outputs]} (program-boundary equations program-outputs)
-         effects (reduce set/union #{} (map :effects equations))]
-     (program/make
-      {:dialect :typed-parallel
-       :source source
-       :values values
-       :inputs inputs
-       :equations equations
-       :outputs outputs
-       :effects effects
-       :provenance {:source-dialect :typed-structured-control
-                    :pass :structured-control-route}
-       :attributes {:host-control :typed-structured-control
-                    :mixed-algorithms (boolean suffix)}
-       :operation? typed-operation?
-       :algorithm? typed-algorithm-boundary?}))))
+         effects (reduce set/union #{} (map :effects equations))
+         parallel-program
+         (program/make
+          {:dialect :typed-parallel
+           :source source
+           :values values
+           :inputs inputs
+           :equations equations
+           :outputs outputs
+           :effects effects
+           :provenance {:source-dialect :typed-structured-control
+                        :pass :structured-control-route}
+           :attributes {:host-control :typed-structured-control
+                        :mixed-algorithms (boolean suffix)}
+           :operation? typed-operation?
+           :algorithm? typed-algorithm-boundary?})
+         public-parameters (or (:public-parameters options) (:active-params options))]
+     (if (seq public-parameters)
+       (let [plan (invocation/from-prefix
+                   {:id [:program-invocation (:id (control/facts loop))]
+                    :parameters public-parameters
+                    :parameter-values parameter-values
+                    :bindings prefix-bindings
+                    :binding-values outer-values
+                    :program-values values
+                    :program-inputs inputs
+                    :program-outputs outputs
+                    :attributes {:source-dialect :closed-clojure
+                                 :target-dialect :typed-invocation}})]
+         (-> parallel-program
+             (assoc-in [:attributes :invocation-plan]
+                       (invocation/validate-against! plan parallel-program))
+             validate-typed-program!))
+       parallel-program))))
 
 (defn attempt
   "Attempt the complete structured-control semantic route.

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -783,6 +783,7 @@
                 :values (:values opts)
                 :array-types (:array-types opts)
                 :scalar-types (:scalar-types opts)
+                :public-parameters (or (:public-parameters opts) (:active-params opts))
                 :abstract-machine abstract-machine}
         structured (when (device/gpu-target? (:target-device opts))
                      (structured-route/attempt source common))]

--- a/test/raster/compiler/core/op_descriptor_test.clj
+++ b/test/raster/compiler/core/op_descriptor_test.clj
@@ -2,6 +2,14 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.core.op-descriptor :as descriptor]))
 
+(deftest allocation-initialization-contracts
+  (is (= :zero (descriptor/allocation-initialization 'double-array)))
+  (is (= :zero (descriptor/allocation-initialization 'raster.arrays/zeros-like_m_double)))
+  (is (= :unspecified (descriptor/allocation-initialization 'similar_m_double)))
+  (is (= :copy (descriptor/allocation-initialization 'clojure.core/aclone)))
+  (is (descriptor/copy-allocation-op? 'aclone_m_double))
+  (is (nil? (descriptor/allocation-initialization 'example/not-an-allocation))))
+
 (deftest descriptor-facets-merge-directly-test
   (testing "buffer, device, and shape registrations converge on one descriptor"
     (descriptor/register-buffer-semantics! 'test.descriptor/op

--- a/test/raster/compiler/ir/invocation_plan_test.clj
+++ b/test/raster/compiler/ir/invocation_plan_test.clj
@@ -1,0 +1,90 @@
+(ns raster.compiler.ir.invocation-plan-test
+  (:require [clojure.test :refer [deftest is]]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.invocation-plan :as invocation]))
+
+(defn- scalar [dtype]
+  (av/tensor {:dtype dtype :shape []}))
+
+(defn- array-value [dtype extent]
+  (av/tensor {:dtype dtype :shape [extent] :representation {:kind :plain}}))
+
+(defn- reason-of [thunk]
+  (try (thunk) nil
+       (catch clojure.lang.ExceptionInfo exception
+         (:reason (ex-data exception)))))
+
+(deftest public-shadowing-is-explicit-ssa
+  (let [public-array (array-value :double '(extent u0))
+        internal-array (array-value :double 'n)
+        values {'u0 public-array 'nsteps (scalar :long)}
+        binding-values {'n (scalar :int)
+                        'u internal-array
+                        'scratch internal-array
+                        'nsteps (scalar :int)}
+        program-values {'n (scalar :int) 'u internal-array 'scratch internal-array
+                        'nsteps (scalar :int) 'result internal-array}
+        plan (invocation/from-prefix
+              {:id :test
+               :parameters '[u0 nsteps]
+               :parameter-values values
+               :bindings '[[n (int (alength u0))]
+                           [u (aclone u0)]
+                           [scratch (double-array n)]
+                           [nsteps (int nsteps)]]
+               :binding-values binding-values
+               :program-values program-values
+               :program-inputs '[nsteps n u scratch]
+               :program-outputs '[result]})
+        public-nsteps (:id (second (:parameters plan)))
+        narrowed (last (:steps plan))]
+    (is (invocation/invocation-plan? plan))
+    (is (invocation/shape-projection? (first (:steps plan))))
+    (is (invocation/buffer-clone? (second (:steps plan))))
+    (is (invocation/buffer-allocation? (nth (:steps plan) 2)))
+    (is (invocation/scalar-compute? narrowed))
+    (is (= '(lambda [nsteps] (region [] [(int nsteps)])) (:region narrowed)))
+    (is (not (contains? narrowed :expression)))
+    (is (not= public-nsteps (:id narrowed)))
+    (is (= public-nsteps (-> narrowed :operands first :value)))
+    (is (= (:id narrowed) (get-in plan [:bindings 0 :invocation-value])))))
+
+(deftest impure-prefix-scalar-is-rejected
+  (is (= :invocation-scalar-effect
+         (reason-of
+          #(invocation/from-prefix
+            {:id :impure
+             :parameters '[x]
+             :parameter-values {'x (scalar :double)}
+             :bindings '[[y (example.effects/mystery-effect! x)]]
+             :binding-values {'y (scalar :double)}
+             :program-values {'y (scalar :double)}
+             :program-inputs '[y]
+             :program-outputs '[y]})))))
+
+(deftest scalar-compute-is-a-closed-rank-zero-region
+  (is (= :invocation-scalar-operands
+         (reason-of
+          #(invocation/from-prefix
+            {:id :buffer-scalar
+             :parameters '[x]
+             :parameter-values {'x (array-value :double 4)}
+             :bindings '[[y (int x)]]
+             :binding-values {'y (scalar :int)}
+             :program-values {'y (scalar :int)}
+             :program-inputs '[y]
+             :program-outputs '[y]}))))
+  (let [plan (invocation/from-prefix
+              {:id :closed-scalar
+               :parameters '[x]
+               :parameter-values {'x (scalar :long)}
+               :bindings '[[y (int x)]]
+               :binding-values {'y (scalar :int)}
+               :program-values {'y (scalar :int)}
+               :program-inputs '[y]
+               :program-outputs '[y]})
+        open-step (assoc (first (:steps plan))
+                         :region '(lambda [x] (region [] [(+ x rogue)])))
+        open-plan (assoc plan :steps [open-step])]
+    (is (= :invocation-scalar-free-symbol
+           (reason-of #(invocation/validate! open-plan))))))

--- a/test/raster/compiler/passes/parallel/structured_control_route_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_route_test.clj
@@ -9,6 +9,7 @@
             [raster.compiler.ir.emitted-structured-loop :as emitted-loop]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.invocation-plan :as invocation]
             [raster.compiler.ir.parallel-program :as program]
             [raster.compiler.ir.soac-dialect :as soac]
             [raster.compiler.ir.structured-control :as control]
@@ -271,6 +272,7 @@
 (deftest real-rk4-pde-reaches-the-equation-first-opencl-vertical
   (let [options {:dtype :double :target-device :ze:debug
                  :source-ns (the-ns 'raster.ode.pde)
+                 :public-parameters '[u0 target alpha inv-dx2 dt nsteps]
                  :array-types {'u0 :double 'target :double}
                  :scalar-types {'alpha :double 'inv-dx2 :double
                                 'dt :double 'nsteps :long}}
@@ -281,6 +283,7 @@
         scheduled (route/schedule-program semantic options)
         emitted (program-opencl/emit-program scheduled options)
         emitted-program (:program emitted)
+        invocation-plan (get-in semantic [:attributes :invocation-plan])
         loop-operation (get-in scheduled [:equations 0 :operations 0])
         loop-equation (first (:equations emitted-program))
         trip-count-id (second (control/loop-index (:algorithm loop-equation)))
@@ -318,6 +321,30 @@
                                :value (/ 1.0 divisor)}]))
                    (:results equation)))))]
     (is (= :typed-parallel (:dialect semantic)))
+    (is (invocation/invocation-plan? invocation-plan))
+    (is (= '[u0 target alpha inv-dx2 dt nsteps]
+           (mapv :symbol (:parameters invocation-plan))))
+    (is (= (:inputs semantic) (mapv :program-value (:bindings invocation-plan))))
+    (is (= 1 (count (filter invocation/shape-projection? (:steps invocation-plan)))))
+    (is (= 1 (count (filter invocation/buffer-clone? (:steps invocation-plan)))))
+    (is (= 4 (count (filter invocation/buffer-allocation? (:steps invocation-plan)))))
+    (is (= 4 (count (filter invocation/value-alias? (:steps invocation-plan)))))
+    (is (= 3 (count (filter invocation/scalar-compute? (:steps invocation-plan)))))
+    (is (every? #(not (contains? % :expression)) (:steps invocation-plan)))
+    (let [public-nsteps (:id (first (filter #(= 'nsteps (:symbol %))
+                                           (:parameters invocation-plan))))
+          narrowed (first (filter #(some (fn [operand]
+                                           (= public-nsteps (:value operand)))
+                                         (:operands %))
+                                  (:steps invocation-plan)))
+          bound-nsteps (some (fn [{:keys [invocation-value]}]
+                               (when (= (:id narrowed) invocation-value)
+                                 invocation-value))
+                             (:bindings invocation-plan))]
+      (is (invocation/scalar-compute? narrowed))
+      (is (not= public-nsteps (:id narrowed)))
+      (is (= public-nsteps (-> narrowed :operands first :value)))
+      (is (= (:id narrowed) bound-nsteps)))
     (is (= :scheduled-parallel (:dialect scheduled)))
     (is (= 3 (count (:equations scheduled)))
         "the generic fixpoint, host inv-n, and reduction with a final scalar epilogue represent the RK4 loss")


### PR DESCRIPTION
## Summary
- introduce a validated InvocationPlan from ordered public arguments to internal ParallelProgram SSA values
- retain shape projections, scalar computations, clones, fresh allocations, and physical aliases explicitly
- attach and cross-check the plan on the real structured RK4 compiler route
- centralize allocation initialization contracts in the operation descriptor

## Verification
- focused nREPL suite: 28 tests, 142 assertions
- real heat-loss RK4 reaches the typed equation-first OpenCL vertical with a validated invocation plan
- full suite delegated to CircleCI