### PR TITLE
Link emitted programs through stable buffer identities

### DIFF
--- a/src/raster/compiler/ir/emitted_parallel_program_call.clj
+++ b/src/raster/compiler/ir/emitted_parallel_program_call.clj
@@ -287,6 +287,88 @@
              {:expected (:outputs parallel-program) :actual (keys outputs)}))
     call))
 
+(defn- remap-buffer-map
+  [remap buffers]
+  (into (empty buffers) (map (fn [[id buffer]] [id (remap buffer)])) buffers))
+
+(defn- remap-loop-call
+  [call remap]
+  (let [remap-optional #(when (some? %) (remap %))]
+    (loop-call/validate!
+     (-> call
+         (update-in [:buffers :invariants] #(remap-buffer-map remap %))
+         (update-in [:buffers :carries]
+                    (fn [carries]
+                      (mapv #(-> %
+                                 (update :initial remap)
+                                 (update :output remap)
+                                 (update :alternate remap-optional))
+                            carries)))
+         (update :scratch #(remap-buffer-map remap %))
+         (update :outputs #(remap-buffer-map remap %))))))
+
+(defn map-buffers
+  "Map every external/resident buffer token in an emitted program call exactly once.
+
+   `f` is a pure storage-identity projection, typically MaterializedBuffer → LinkValue ID. The
+   mapping must be total, non-nil, and injective over distinct source storage: this operation may
+   rename existing aliases but cannot silently introduce a new alias. Graph-owned temporaries are
+   intentionally absent from EmittedParallelProgramCall and remain private to KernelGraph."
+  [call f]
+  (let [call (validate! call)]
+    (when-not (ifn? f)
+      (fail! :emitted-program-buffer-mapper
+             "emitted program buffer remapping requires a callable projection"
+             {:mapper f}))
+    (let [source-buffers (vec (distinct (concat (vals (:buffers call))
+                                                (vals (:loop-scratch call)))))
+          target-buffers (mapv f source-buffers)]
+      (when-let [source (some (fn [[source target]] (when (nil? target) source))
+                              (map vector source-buffers target-buffers))]
+        (fail! :emitted-program-buffer-remap-missing
+               "emitted program buffer projection returned nil"
+               {:source source}))
+      (when-not (= (count target-buffers) (count (distinct target-buffers)))
+        (fail! :emitted-program-buffer-remap-collision
+               "emitted program buffer projection collapsed distinct storage identities"
+               {:sources source-buffers :targets target-buffers}))
+      (let [mapping (zipmap source-buffers target-buffers)
+            remap #(if (contains? mapping %)
+                     (get mapping %)
+                     (fail! :emitted-program-buffer-remap-untracked
+                            "nested emitted call references storage outside the program binding"
+                            {:buffer %}))
+            buffer-result? (fn [id] (seq (get-in call [:program :values id :shape])))
+            remap-host-step
+            (fn [step]
+              (update step :operands
+                      (fn [operands]
+                        (into (empty operands)
+                              (map (fn [[id value]]
+                                     [id (if (buffer-result? id) (remap value) value)]))
+                              operands))))
+            remap-step
+            (fn [step]
+              (cond
+                (evaluated-host-equation? step) (remap-host-step step)
+                (emitted-equation-call? step)
+                (-> step
+                    (update :buffers #(remap-buffer-map remap %))
+                    (update :outputs #(remap-buffer-map remap %)))
+                (loop-call/structured-loop-call? step) (remap-loop-call step remap)))
+            remapped
+            (-> call
+                (update :steps #(mapv remap-step %))
+                (update :buffers #(remap-buffer-map remap %))
+                (update :loop-scratch #(remap-buffer-map remap %))
+                (update :outputs
+                        (fn [outputs]
+                          (into (empty outputs)
+                                (map (fn [[id value]]
+                                       [id (if (buffer-result? id) (remap value) value)]))
+                                outputs))))]
+        (validate! remapped)))))
+
 (defn make
   "Prepare a source-independent, target-neutral call of an emitted parallel program.
 

--- a/src/raster/compiler/ir/emitted_parallel_program_call.clj
+++ b/src/raster/compiler/ir/emitted_parallel_program_call.clj
@@ -307,6 +307,51 @@
          (update :scratch #(remap-buffer-map remap %))
          (update :outputs #(remap-buffer-map remap %))))))
 
+(defn buffer-bindings
+  "Return every compiler-value/storage pair referenced by an emitted call boundary.
+
+   A zero-trip structured loop can retain a dead carry-output token that is intentionally absent
+   from the call's effective top-level `:buffers`. It is still part of the nested call structure
+   and must therefore participate in total storage-identity projections. Graph-owned temporaries
+   are not call-boundary storage and are excluded."
+  [call]
+  (let [call (validate! call)
+        buffer-result? (fn [id] (seq (get-in call [:program :values id :shape])))
+        output-bindings (fn [outputs]
+                          (keep (fn [[id value]] (when (buffer-result? id) [id value])) outputs))
+        step-bindings
+        (fn [step]
+          (cond
+            (evaluated-host-equation? step)
+            (concat (keep (fn [[id value]] (when (buffer-result? id) [id value]))
+                          (:operands step))
+                    (output-bindings (:outputs step)))
+
+            (emitted-equation-call? step)
+            (concat (:buffers step) (output-bindings (:outputs step)))
+
+            (loop-call/structured-loop-call? step)
+            (let [invariants (get-in step [:buffers :invariants])
+                  carries (get-in step [:buffers :carries])]
+              (concat invariants
+                      (mapcat (fn [{:keys [initial-id output-id initial output alternate]}]
+                                (cond-> [[initial-id initial] [output-id output]]
+                                  (some? alternate) (conj [output-id alternate])))
+                              carries)
+                      (:scratch step)
+                      (:outputs step)))
+
+            :else []))]
+    (vec (distinct (concat (:buffers call)
+                           (:loop-scratch call)
+                           (output-bindings (:outputs call))
+                           (mapcat step-bindings (:steps call)))))))
+
+(defn buffer-identities
+  "Return every distinct external/resident storage token referenced by an emitted call."
+  [call]
+  (vec (distinct (map second (buffer-bindings call)))))
+
 (defn map-buffers
   "Map every external/resident buffer token in an emitted program call exactly once.
 
@@ -320,8 +365,7 @@
       (fail! :emitted-program-buffer-mapper
              "emitted program buffer remapping requires a callable projection"
              {:mapper f}))
-    (let [source-buffers (vec (distinct (concat (vals (:buffers call))
-                                                (vals (:loop-scratch call)))))
+    (let [source-buffers (buffer-identities call)
           target-buffers (mapv f source-buffers)]
       (when-let [source (some (fn [[source target]] (when (nil? target) source))
                               (map vector source-buffers target-buffers))]

--- a/src/raster/compiler/ir/link_plan.clj
+++ b/src/raster/compiler/ir/link_plan.clj
@@ -1,5 +1,5 @@
 (ns raster.compiler.ir.link-plan
-  "Pure, backend-neutral composition of compiled resident program descriptors.
+  "Pure, backend-neutral composition of compiled resident descriptors and emitted programs.
 
    A LinkPlan names storage with stable LinkNodes and binds each descriptor's compiler symbols to
    those node identities. Validation closes shapes, dtypes, aliases, scalar environments and
@@ -9,10 +9,13 @@
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.buffer-view :as bview]
+            [raster.compiler.ir.emitted-parallel-program-call :as program-call]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-executable :as kexec]
-            [raster.compiler.ir.kernel-graph-call :as kgcall]))
+            [raster.compiler.ir.kernel-graph :as kgraph]
+            [raster.compiler.ir.kernel-graph-call :as kgcall]
+            [raster.compiler.ir.structured-loop-call :as loop-call]))
 
 (def node-roles #{:input :constant :state :output :internal :scratch})
 (def binder-roles #{:input :constant :state :output :scratch})
@@ -20,6 +23,7 @@
 (defrecord LinkNode [id view role source])
 (defrecord LinkValue [id abstract physical-layout leaves])
 (defrecord LinkInstance [id descriptor bindings scalars schedule roles arguments])
+(defrecord ProgramLinkInstance [id call roles attributes])
 (defrecord LinkPlan [id target nodes values instances outputs aliases attributes])
 
 (defn link-node? [x]
@@ -27,6 +31,12 @@
 
 (defn link-instance? [x]
   (and x (= "raster.compiler.ir.link_plan.LinkInstance" (.getName (class x)))))
+
+(defn program-link-instance? [x]
+  (and x (= "raster.compiler.ir.link_plan.ProgramLinkInstance" (.getName (class x)))))
+
+(defn plan-instance? [x]
+  (or (link-instance? x) (program-link-instance? x)))
 
 (defn link-plan? [x]
   (and x (= "raster.compiler.ir.link_plan.LinkPlan" (.getName (class x)))))
@@ -292,6 +302,40 @@
    array parameters; runtime pointer binding still comes exclusively from `:bindings`."
   [{:keys [id descriptor bindings scalars schedule roles arguments] :or {scalars {} roles {}}}]
   (validate-instance! (->LinkInstance id descriptor bindings scalars schedule roles arguments)))
+
+(defn validate-program-instance!
+  [instance]
+  (when-not (program-link-instance? instance)
+    (throw (ex-info "expected a ProgramLinkInstance"
+                    {:reason :program-link-instance-type
+                     :instance instance :actual (type instance)})))
+  (let [{:keys [id call roles attributes]} instance
+        call (program-call/validate! call)
+        buffer-values (set (keys (:buffers call)))]
+    (when (nil? id)
+      (throw (ex-info "a program link instance requires a stable identity"
+                      {:reason :program-link-instance-id})))
+    (when-not (and (map? roles) (every? binder-roles (vals roles)))
+      (throw (ex-info "program link roles must map compiler values to resident roles"
+                      {:reason :program-link-instance-roles :instance id
+                       :roles roles :allowed binder-roles})))
+    (when-not (set/subset? (set (keys roles)) buffer-values)
+      (throw (ex-info "program link roles name values outside its resident buffer boundary"
+                      {:reason :program-link-instance-role-values :instance id
+                       :extra (set/difference (set (keys roles)) buffer-values)})))
+    (when-not (map? attributes)
+      (throw (ex-info "program link instance attributes must be a map"
+                      {:reason :program-link-instance-attributes
+                       :instance id :attributes attributes}))))
+  instance)
+
+(defn program-instance
+  "Construct an equation-first emitted program instance whose call buffers are LinkValue IDs.
+
+   KernelGraph temporaries remain graph-private. `:roles` may refine residency policy for public
+   program buffer values but never supplies or reconstructs a binding."
+  [{:keys [id call roles attributes] :or {roles {} attributes {}}}]
+  (validate-program-instance! (->ProgramLinkInstance id call roles attributes)))
 
 (defn instance-arguments
   "Return the descriptor's ordered specialization arguments. Explicit arguments retain array
@@ -628,7 +672,14 @@
     (when-not (and (vector? instances) (seq instances))
       (throw (ex-info "a link plan requires an ordered non-empty instance vector"
                       {:reason :link-instances :instances instances})))
-    (doseq [link-instance instances] (validate-instance! link-instance))
+    (doseq [link-instance instances]
+      (cond
+        (link-instance? link-instance) (validate-instance! link-instance)
+        (program-link-instance? link-instance) (validate-program-instance! link-instance)
+        :else
+        (throw (ex-info "link plan contains an unknown instance variant"
+                        {:reason :link-instance-type :instance link-instance
+                         :actual (type link-instance)}))))
     (when-not (= (count instances) (count (distinct (map :id instances))))
       (throw (ex-info "link instance identities must be unique"
                       {:reason :link-instance-ids :ids (mapv :id instances)})))
@@ -755,14 +806,111 @@
               (instance-step-facts nodes values instance step-index step))
             (map-indexed vector (:steps descriptor))))))
 
+(defn- program-value-node!
+  [nodes values instance-id compiler-value value-id]
+  (let [link-value (get values value-id)]
+    (when-not link-value
+      (throw (ex-info "emitted program buffer names an absent logical LinkValue"
+                      {:reason :program-link-absent-value :instance instance-id
+                       :compiler-value compiler-value :value value-id})))
+    (when-not (= 1 (count (:leaves link-value)))
+      (throw (ex-info "one emitted program graph buffer requires one physical LinkValue leaf"
+                      {:reason :program-link-leaf-count :instance instance-id
+                       :compiler-value compiler-value :value value-id
+                       :leaves (:leaves link-value)})))
+    (get nodes (get-in link-value [:leaves 0 :node]))))
+
+(defn- validate-program-buffer-contracts!
+  [nodes values {:keys [id call roles]}]
+  (let [program-values (get-in call [:program :values])]
+    (doseq [[compiler-value value-id] (:buffers call)]
+      (let [expected (get program-values compiler-value)
+            link-value (get values value-id)
+            node (program-value-node! nodes values id compiler-value value-id)]
+        (when-not (and expected
+                       (= (count (:shape expected)) (count (get-in node [:view :shape])))
+                       (av/storage-contract-compatible? expected (:abstract link-value)))
+          (throw (ex-info "emitted program buffer differs from its logical LinkValue contract"
+                          {:reason :program-link-value-contract :instance id
+                           :compiler-value compiler-value :value value-id
+                           :expected expected :actual (:abstract link-value)
+                           :physical-shape (get-in node [:view :shape])})))
+        (when (and (= :constant (get roles compiler-value))
+                   (not= :constant (:role node)))
+          (throw (ex-info "a constant program binding requires a constant LinkValue"
+                          {:reason :program-link-role-mismatch :instance id
+                           :compiler-value compiler-value :value value-id
+                           :value-role (:role node)})))))
+    (doseq [[compiler-value value-id] (:loop-scratch call)]
+      (program-value-node! nodes values id compiler-value value-id))))
+
+(defn- program-graph-fact
+  [nodes values instance-id step-id phase graph buffers]
+  (let [graph (kgraph/validate! graph)
+        external
+        (vals
+         (reduce (fn [by-id buffer]
+                   (assoc by-id (:id buffer) buffer))
+                 {} (concat (:inputs graph) (:outputs graph))))]
+    {:instance instance-id :step step-id :phase phase
+     :facts
+     (mapv
+      (fn [{:keys [id dtype role]}]
+        (let [value-id (get buffers id ::missing)]
+          (when (= ::missing value-id)
+            (throw (ex-info "emitted graph buffer has no linked program binding"
+                            {:reason :program-link-graph-buffer :instance instance-id
+                             :step step-id :buffer id})))
+          (let [node (program-value-node! nodes values instance-id id value-id)]
+            (when-not (= (dtype/canon dtype) (dtype/canon (get-in node [:view :dtype])))
+              (throw (ex-info "emitted graph buffer dtype differs from its linked node"
+                              {:reason :program-link-graph-dtype :instance instance-id
+                               :step step-id :buffer id :value value-id
+                               :expected dtype :actual (get-in node [:view :dtype])})))
+            {:symbol id :node (:id node)
+             :access (case role
+                       :input :read
+                       :output :write
+                       :inout :read-write)})))
+      external)}))
+
+(defn- validate-program-instance-bindings!
+  [nodes values instance]
+  (let [{:keys [id call]} (validate-program-instance! instance)]
+    (validate-program-buffer-contracts! nodes values instance)
+    (vec
+     (mapcat
+      (fn [[step-index step]]
+        (cond
+          (program-call/evaluated-host-equation? step) []
+          (program-call/emitted-equation-call? step)
+          [(program-graph-fact nodes values id step-index
+                               (get-in step [:equation :id])
+                               (:graph step) (:buffers step))]
+          (loop-call/structured-loop-call? step)
+          (mapv (fn [iteration]
+                  (let [{:keys [buffers]} (loop-call/iteration-binding step iteration)]
+                    (program-graph-fact nodes values id [step-index iteration]
+                                        :structured-loop-iteration
+                                        (:graph step) buffers)))
+                (range (min 3 (:trip-count step))))))
+      (map-indexed vector (:steps call))))))
+
 (defn- validate-effects! [{:keys [target nodes values instances outputs aliases] :as plan}]
   (when (and (not (let [target-name (name target)]
                     (or (= "ze" target-name) (.startsWith target-name "ze:"))))
              (some #(= :scatter (:convention %))
-                   (mapcat (comp :steps :descriptor) instances)))
+                   (mapcat (fn [instance]
+                             (when (link-instance? instance)
+                               (get-in instance [:descriptor :steps])))
+                           instances)))
     (throw (ex-info "linked scatter execution is not available on this target backend"
                     {:reason :link-target-convention :target target :convention :scatter})))
-  (let [step-facts (mapcat #(validate-instance-bindings! nodes values %) instances)
+  (let [step-facts
+        (mapcat #(if (link-instance? %)
+                   (validate-instance-bindings! nodes values %)
+                   (validate-program-instance-bindings! nodes values %))
+                instances)
         initialized (volatile! (into #{}
                                      (keep (fn [[id {:keys [role source]}]]
                                              ;; Ownership answers who releases storage, not whether
@@ -833,15 +981,35 @@
   [plan instance]
   (when-not (link-plan? plan)
     (throw (ex-info "instance-roles requires a LinkPlan" {:actual (type plan)})))
-  (validate-instance! instance)
   (let [nodes (:nodes plan)
         values (:values plan)]
-    (merge
-     (into {}
-           (map (fn [[sym value-id]]
-                  (let [node-id (get-in values [value-id :leaves 0 :node])]
-                    [sym (case (get-in nodes [node-id :role])
+    (cond
+      (link-instance? instance)
+      (let [instance (validate-instance! instance)]
+        (merge
+         (into {}
+               (map (fn [[sym value-id]]
+                      (let [node-id (get-in values [value-id :leaves 0 :node])]
+                        [sym (case (get-in nodes [node-id :role])
+                               :internal :scratch
+                               (get-in nodes [node-id :role]))]))
+                    (:bindings instance)))
+         (:roles instance)))
+
+      (program-link-instance? instance)
+      (let [{:keys [call roles]} (validate-program-instance! instance)]
+        (merge
+         (into {}
+               (map (fn [[compiler-value value-id]]
+                      (let [node-id (get-in values [value-id :leaves 0 :node])]
+                        [compiler-value
+                         (case (get-in nodes [node-id :role])
                            :internal :scratch
                            (get-in nodes [node-id :role]))]))
-                (:bindings instance)))
-     (:roles instance))))
+                    (:buffers call)))
+         roles))
+
+      :else
+      (throw (ex-info "instance-roles requires a recognized LinkPlan instance"
+                      {:reason :link-instance-type :instance instance
+                       :actual (type instance)})))))

--- a/test/raster/compiler/passes/parallel/structured_control_route_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_route_test.clj
@@ -9,6 +9,7 @@
             [raster.compiler.ir.emitted-structured-loop :as emitted-loop]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.link-plan :as link]
             [raster.compiler.ir.invocation-materialization :as materialization]
             [raster.compiler.ir.invocation-plan :as invocation]
             [raster.compiler.ir.parallel-program :as program]
@@ -488,6 +489,38 @@
             (ex-data
              (try (program-call/map-buffers call (constantly :same-storage))
                   (catch clojure.lang.ExceptionInfo exception exception))))))))
+
+(deftest emitted-program-call-is-a-native-link-plan-instance
+  (let [{:keys [call]} (prepared-mixed-call 0)
+        sources (program-call/buffer-identities call)
+        mapping (zipmap sources (mapv #(vector :program-value %)
+                                      (range (count sources))))
+        remapped (program-call/map-buffers call mapping)
+        source-contracts
+        (reduce (fn [contracts [compiler-value source]]
+                  (assoc contracts source (get-in call [:program :values compiler-value])))
+                {} (program-call/buffer-bindings call))
+        nodes
+        (mapv (fn [[source value-id]]
+                (let [abstract (get source-contracts source)]
+                  (link/node {:id value-id :dtype (:dtype abstract) :shape [64]
+                              :device :ocl:0 :role :state})))
+              mapping)
+        values
+        (mapv (fn [[source value-id]]
+                (link/value {:id value-id :abstract (get source-contracts source)
+                             :leaves [{:name :value :node value-id}]}))
+              mapping)
+        instance (link/program-instance {:id :rk4-call :call remapped})
+        output-id (-> remapped :outputs vals first)
+        plan (link/make {:id :linked-rk4 :target :ocl:0
+                         :nodes nodes :values values
+                         :instances [instance] :outputs [output-id]})]
+    (is (link/program-link-instance? instance))
+    (is (link/link-plan? plan))
+    (is (= #{:state} (set (vals (link/instance-roles plan instance)))))
+    (is (every? #(= 1 (count (:leaves %))) (vals (:values plan))))
+    (is (false? (get-in remapped [:attributes :source-inspected])))))
 
 (deftest structured-loop-staging-is-bounded-by-carry-rotation-not-trip-count
   (let [{:keys [call]} (prepared-mixed-call 9)

--- a/test/raster/compiler/passes/parallel/structured_control_route_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_route_test.clj
@@ -15,6 +15,7 @@
             [raster.compiler.ir.soac-dialect :as soac]
             [raster.compiler.ir.structured-control :as control]
             [raster.compiler.ir.structured-control-schedule :as schedule]
+            [raster.compiler.ir.structured-loop-call :as loop-call]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.structured-control-frontend :as frontend]
             [raster.compiler.passes.parallel.structured-control-route :as route]
@@ -370,7 +371,7 @@
       (is (identical? (get-in materialized [:values (:id alias)])
                       (get-in materialized [:values (:source alias)]))))
     (let [public-nsteps (:id (first (filter #(= 'nsteps (:symbol %))
-                                           (:parameters invocation-plan))))
+                                            (:parameters invocation-plan))))
           narrowed (first (filter #(some (fn [operand]
                                            (= public-nsteps (:value operand)))
                                          (:operands %))
@@ -461,6 +462,32 @@
     (is (= :suffix-output (get (last bindings) result)))
     (is (= :stage-once-host-repetition (get-in call [:attributes :execution])))
     (is (false? (get-in call [:attributes :source-inspected])))))
+
+(deftest emitted-program-buffer-remapping-is-total-and-alias-stable
+  (let [{:keys [call]} (prepared-mixed-call 3)
+        sources (vec (distinct (concat (vals (:buffers call))
+                                       (vals (:loop-scratch call)))))
+        mapping (zipmap sources (mapv #(vector :link-value %) (range (count sources))))
+        remapped (program-call/map-buffers call mapping)
+        loop-step (first (:steps remapped))]
+    (is (= (set (vals mapping))
+           (set (concat (vals (:buffers remapped))
+                        (vals (:loop-scratch remapped))))))
+    (is (= (:scalar-values call) (:scalar-values remapped)))
+    (is (= (:program call) (:program remapped)))
+    (doseq [iteration (range 3)]
+      (is (every? (set (vals mapping))
+                  (vals (:buffers (loop-call/iteration-binding loop-step iteration))))))
+    (is (= :emitted-program-buffer-remap-missing
+           (:reason
+            (ex-data
+             (try (program-call/map-buffers call {})
+                  (catch clojure.lang.ExceptionInfo exception exception))))))
+    (is (= :emitted-program-buffer-remap-collision
+           (:reason
+            (ex-data
+             (try (program-call/map-buffers call (constantly :same-storage))
+                  (catch clojure.lang.ExceptionInfo exception exception))))))))
 
 (deftest structured-loop-staging-is-bounded-by-carry-rotation-not-trip-count
   (let [{:keys [call]} (prepared-mixed-call 9)


### PR DESCRIPTION
Adds a validated, source-independent buffer identity projection for EmittedParallelProgramCall. The projection inventories every call-boundary token, including zero-trip loop carry outputs, and rewrites equation calls, structured-loop carry rotations, scratch, outputs, and host buffer operands consistently. It rejects nil mappings and newly introduced alias collisions while leaving KernelGraph-owned temporaries private.

Introduces ProgramLinkInstance so equation-first emitted calls are admitted directly into the pure, backend-neutral LinkPlan certificate. Validation checks logical storage contracts, single physical leaves, graph dtypes, roles, ordered effects, and bounded loop carry rotations without reconstructing a legacy resident descriptor. Runtime allocation and execution remain deliberately separate.

Focused validation: LinkPlan and structured-control suites, 26 tests / 138 assertions.