### PR TITLE
Schedule consumers from physical result storage

### DIFF
--- a/src/raster/compiler/ir/emitted_parallel_program_call.clj
+++ b/src/raster/compiler/ir/emitted_parallel_program_call.clj
@@ -316,15 +316,13 @@
    are not call-boundary storage and are excluded."
   [call]
   (let [call (validate! call)
-        buffer-result? (fn [id] (seq (get-in call [:program :values id :shape])))
         output-bindings (fn [outputs]
-                          (keep (fn [[id value]] (when (buffer-result? id) [id value])) outputs))
+                          (remove (comp typed-scalar? second) outputs))
         step-bindings
         (fn [step]
           (cond
             (evaluated-host-equation? step)
-            (concat (keep (fn [[id value]] (when (buffer-result? id) [id value]))
-                          (:operands step))
+            (concat (remove (comp typed-scalar? second) (:operands step))
                     (output-bindings (:outputs step)))
 
             (emitted-equation-call? step)
@@ -382,14 +380,13 @@
                      (fail! :emitted-program-buffer-remap-untracked
                             "nested emitted call references storage outside the program binding"
                             {:buffer %}))
-            buffer-result? (fn [id] (seq (get-in call [:program :values id :shape])))
             remap-host-step
             (fn [step]
               (update step :operands
                       (fn [operands]
                         (into (empty operands)
                               (map (fn [[id value]]
-                                     [id (if (buffer-result? id) (remap value) value)]))
+                                     [id (if (typed-scalar? value) value (remap value))]))
                               operands))))
             remap-step
             (fn [step]
@@ -409,7 +406,7 @@
                         (fn [outputs]
                           (into (empty outputs)
                                 (map (fn [[id value]]
-                                       [id (if (buffer-result? id) (remap value) value)]))
+                                       [id (if (typed-scalar? value) value (remap value))]))
                                 outputs))))]
         (validate! remapped)))))
 

--- a/src/raster/compiler/ir/link_plan.clj
+++ b/src/raster/compiler/ir/link_plan.clj
@@ -845,7 +845,7 @@
       (program-value-node! nodes values id compiler-value value-id))))
 
 (defn- program-graph-fact
-  [nodes values instance-id step-id phase graph buffers]
+  [nodes values instance-id step-id phase graph buffers scalar-values]
   (let [graph (kgraph/validate! graph)
         external
         (vals
@@ -855,18 +855,26 @@
     {:instance instance-id :step step-id :phase phase
      :facts
      (mapv
-      (fn [{:keys [id dtype role]}]
+      (fn [{:keys [id dtype role elements]}]
         (let [value-id (get buffers id ::missing)]
           (when (= ::missing value-id)
             (throw (ex-info "emitted graph buffer has no linked program binding"
                             {:reason :program-link-graph-buffer :instance instance-id
                              :step step-id :buffer id})))
-          (let [node (program-value-node! nodes values instance-id id value-id)]
+          (let [node (program-value-node! nodes values instance-id id value-id)
+                expected-elements (when (some? elements)
+                                    (kgcall/resolve-integer scalar-values elements))
+                capacity (shape-elements (get-in node [:view :shape]))]
             (when-not (= (dtype/canon dtype) (dtype/canon (get-in node [:view :dtype])))
               (throw (ex-info "emitted graph buffer dtype differs from its linked node"
                               {:reason :program-link-graph-dtype :instance instance-id
                                :step step-id :buffer id :value value-id
                                :expected dtype :actual (get-in node [:view :dtype])})))
+            (when (and expected-elements (> (long expected-elements) (long capacity)))
+              (throw (ex-info "emitted graph extent exceeds its linked node view"
+                              {:reason :program-link-graph-range :instance instance-id
+                               :step step-id :buffer id :value value-id
+                               :expected expected-elements :capacity capacity})))
             {:symbol id :node (:id node)
              :access (case role
                        :input :read
@@ -886,13 +894,14 @@
           (program-call/emitted-equation-call? step)
           [(program-graph-fact nodes values id step-index
                                (get-in step [:equation :id])
-                               (:graph step) (:buffers step))]
+                               (:graph step) (:buffers step) (:scalar-values step))]
           (loop-call/structured-loop-call? step)
           (mapv (fn [iteration]
-                  (let [{:keys [buffers]} (loop-call/iteration-binding step iteration)]
+                  (let [{:keys [buffers scalar-values]}
+                        (loop-call/iteration-binding step iteration)]
                     (program-graph-fact nodes values id [step-index iteration]
                                         :structured-loop-iteration
-                                        (:graph step) buffers)))
+                                        (:graph step) buffers scalar-values)))
                 (range (min 3 (:trip-count step))))))
       (map-indexed vector (:steps call))))))
 

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -256,6 +256,17 @@
                          (= (:operands equation) (:inputs (soac-dialect/facts algorithm)))
                          (= (:results equation) (soac-dialect/outputs algorithm))))})))
 
+(defn- equation-physical-results
+  [algorithm]
+  (let [facts (soac-dialect/facts algorithm)
+        producers
+        (into {}
+              (mapcat (fn [equation]
+                        (map vector (nth equation 2)
+                             (soac-dialect/physical-results facts equation))))
+              (soac-dialect/equations algorithm))]
+    (mapv producers (soac-dialect/outputs algorithm))))
+
 (defn segop-lower-pass
   "Pipeline pass: convert par forms in let* bindings to SegOp records.
 
@@ -273,44 +284,56 @@
   (if (and (program/parallel-program? form) (= :typed-soac (:dialect form)))
     (let [device-id (or (:target-device opts) :cpu:0)
           dtype (or (:dtype opts) :double)
+          ;; The TypedSOAC program remains purely functional, while `:result-storage` gives every
+          ;; equation result its physical identity. Scheduling later equations must consume that
+          ;; identity—not reintroduce the logical result as a second external graph buffer.
           equations
-          (mapv
-           (fn [equation]
-             (let [algorithm (:algorithm equation)
-                   kind (soac-dialect/operation-kind
-                         (first (soac-dialect/equations algorithm)))
-                   lowered (case kind
-                             scalar {:operations []}
-                             map {:operations (soac-lower/lower-typed-map
-                                               algorithm device-id :dtype dtype)}
-                             scatter {:operations (soac-lower/lower-typed-scatter
-                                                   algorithm device-id :dtype dtype)}
-                             stencil {:operations (soac-lower/lower-typed-stencil
-                                                   algorithm device-id :dtype dtype)}
-                             reduce {:operations (soac-lower/lower-typed-reduce
-                                                  algorithm device-id :dtype dtype)}
-                             segmented-reduce
-                             {:operations (soac-lower/lower-typed-segmented-reduce
-                                           algorithm device-id :dtype dtype)}
-                             product-reduce
-                             {:operations (soac-lower/lower-typed-product-reduce
-                                           algorithm device-id :dtype dtype)}
-                             segmented-fold-map
-                             {:operations (soac-lower/lower-typed-segmented-fold-map
-                                           algorithm device-id :dtype dtype)}
-                             scan (soac-lower/lower-typed-scan
-                                   algorithm device-id :dtype dtype
-                                   :array-types (:array-types opts)))
-                   operations (:operations lowered)]
-               (-> equation
-                   (assoc :operations operations)
-                   (update :provenance assoc :target-dialect :segop)
-                   (update :attributes assoc :device device-id)
-                   (cond-> (:kernel-graph lowered)
-                     (update :attributes assoc :kernel-graph (:kernel-graph lowered)))
-                   (cond-> (= 'scalar kind)
-                     (update :attributes assoc :host-only true)))))
-           (:equations form))
+          (:equations
+           (reduce
+            (fn [{:keys [physical] :as state} equation]
+              (let [algorithm (:algorithm equation)
+                    scheduling-algorithm (soac-dialect/remap-values algorithm physical)
+                    kind (soac-dialect/operation-kind
+                          (first (soac-dialect/equations scheduling-algorithm)))
+                    lowered (case kind
+                              scalar {:operations []}
+                              map {:operations (soac-lower/lower-typed-map
+                                                scheduling-algorithm device-id :dtype dtype)}
+                              scatter {:operations (soac-lower/lower-typed-scatter
+                                                    scheduling-algorithm device-id :dtype dtype)}
+                              stencil {:operations (soac-lower/lower-typed-stencil
+                                                    scheduling-algorithm device-id :dtype dtype)}
+                              reduce {:operations (soac-lower/lower-typed-reduce
+                                                   scheduling-algorithm device-id :dtype dtype)}
+                              segmented-reduce
+                              {:operations (soac-lower/lower-typed-segmented-reduce
+                                            scheduling-algorithm device-id :dtype dtype)}
+                              product-reduce
+                              {:operations (soac-lower/lower-typed-product-reduce
+                                            scheduling-algorithm device-id :dtype dtype)}
+                              segmented-fold-map
+                              {:operations (soac-lower/lower-typed-segmented-fold-map
+                                            scheduling-algorithm device-id :dtype dtype)}
+                              scan (soac-lower/lower-typed-scan
+                                    scheduling-algorithm device-id :dtype dtype
+                                    :array-types (:array-types opts)))
+                    operations (:operations lowered)
+                    scheduled-equation
+                    (-> equation
+                        (assoc :operations operations)
+                        (update :provenance assoc :target-dialect :segop)
+                        (update :attributes assoc :device device-id)
+                        (cond-> (:kernel-graph lowered)
+                          (update :attributes assoc :kernel-graph (:kernel-graph lowered)))
+                        (cond-> (= 'scalar kind)
+                          (update :attributes assoc :host-only true)))
+                    result-storage (zipmap (:results equation)
+                                           (equation-physical-results algorithm))]
+                (-> state
+                    (update :equations conj scheduled-equation)
+                    (update :physical merge result-storage))))
+            {:physical {} :equations []}
+            (:equations form)))
           ;; A multi-phase schedule introduces physical SSA values that do not exist in the
           ;; functional algorithm. They still require explicit contracts; an emitter must never
           ;; infer their dtype or extent from a generated name.

--- a/test/raster/compiler/passes/parallel/structured_control_route_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_route_test.clj
@@ -407,7 +407,13 @@
     (is (= ["StructuredLoopCall" "EvaluatedHostEquation" "EmittedEquationCall"]
            (mapv #(-> % class .getSimpleName) (:steps call)))
         "the real emitted workload must cross the checked runtime-call boundary")
-    (is (= (set (:outputs emitted-program)) (set (keys (:outputs call)))))))
+    (is (= (set (:outputs emitted-program)) (set (keys (:outputs call)))))
+    (let [sources (program-call/buffer-identities call)
+          mapping (zipmap sources (mapv #(vector :rk4-storage %)
+                                        (range (count sources))))
+          remapped (program-call/map-buffers call mapping)]
+      (is (every? (set (vals mapping)) (vals (:outputs remapped)))
+          "the rank-zero GPU reduction result remains resident storage during remapping"))))
 
 (defn- prepared-mixed-call
   ([trip-count]
@@ -491,7 +497,7 @@
                   (catch clojure.lang.ExceptionInfo exception exception))))))))
 
 (deftest emitted-program-call-is-a-native-link-plan-instance
-  (let [{:keys [call]} (prepared-mixed-call 0)
+  (let [{:keys [call]} (prepared-mixed-call 3)
         sources (program-call/buffer-identities call)
         mapping (zipmap sources (mapv #(vector :program-value %)
                                       (range (count sources))))
@@ -520,7 +526,25 @@
     (is (link/link-plan? plan))
     (is (= #{:state} (set (vals (link/instance-roles plan instance)))))
     (is (every? #(= 1 (count (:leaves %))) (vals (:values plan))))
-    (is (false? (get-in remapped [:attributes :source-inspected])))))
+    (is (false? (get-in remapped [:attributes :source-inspected])))
+    (is (= :program-link-graph-range
+           (reason-of
+            #(link/make
+              {:id :undersized-rk4 :target :ocl:0
+               :nodes (mapv (fn [node]
+                              (link/node {:id (:id node) :dtype (get-in node [:view :dtype])
+                                          :shape [1] :device :ocl:0 :role :state}))
+                            nodes)
+               :values values :instances [instance] :outputs [output-id]}))))))
+
+(deftest scheduled-loop-consumers-read-physical-result-storage
+  (let [graph (-> (prepared-mixed-call 1) :call :steps first :graph)
+        [producer consumer] (:nodes graph)]
+    (is (= '[rstr_loop_carry_4] (mapv :id (:inputs graph))))
+    (is (= '[scratch] (mapv :id (:temporaries graph))))
+    (is (some #(and (= 'scratch (:buffer %)) (= :read (:access %))) (:uses consumer)))
+    (is (= [(:id producer)] (:dependencies consumer)))
+    (is (not-any? #(= 'rstr_loop_value_0 (:buffer %)) (:uses consumer)))))
 
 (deftest structured-loop-staging-is-bounded-by-carry-rotation-not-trip-count
   (let [{:keys [call]} (prepared-mixed-call 9)


### PR DESCRIPTION
Carries TypedSOAC's certified logical-result to physical-storage mapping across scheduled equations. Downstream SegOps now consume the producer's physical destination, so KernelGraph derives the real dependency and does not expose a phantom logical result as an external input. The functional TypedSOAC algorithm remains unchanged.

Strengthens the equation-first LinkPlan test from a zero-trip call to a real three-iteration loop with carry rotation.

Focused validation: 114 tests / 704 assertions across LinkPlan, structured control, ParallelProgram, TypedSOAC scheduling families, and SegOp boundary/consumption; all green.