### PR TITLE
Expose the equation-first TypedSOAC compiler

### DIFF
--- a/src/raster/compiler/backend/jvm/typed_scalar.clj
+++ b/src/raster/compiler/backend/jvm/typed_scalar.clj
@@ -1,0 +1,193 @@
+(ns raster.compiler.backend.jvm.typed-scalar
+  "Reference execution for closed, typed scalar regions.
+
+   This is a JVM backend for TypedSOAC scalar SSA, not another type or function inference layer.
+   Regions have already retained operand/result dtypes and passed the compiler's purity checker.
+   The interpreter resolves their semantic operations through the defining namespace (or a Java
+   static class) and coerces every local/result at its declared dtype boundary. It never evals a
+   source form and keeps no private operation registry."
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.ir.soac-dialect :as soac]
+            [raster.compiler.passes.scalar.effects :as effects]))
+
+(defn- fail!
+  [reason message data]
+  (throw (ex-info message (assoc data :reason reason :backend :typed-scalar-jvm))))
+
+(defn- typed-scalar?
+  [value]
+  (and (map? value) (keyword? (:type value)) (contains? value :value)))
+
+(defn- namespace-object
+  [source-ns]
+  (cond
+    (instance? clojure.lang.Namespace source-ns) source-ns
+    (symbol? source-ns)
+    (or (find-ns source-ns)
+        (fail! :typed-scalar-namespace "typed scalar source namespace is not loaded"
+               {:source-ns source-ns}))
+    :else
+    (fail! :typed-scalar-namespace "typed scalar execution requires a namespace or namespace symbol"
+           {:source-ns source-ns})))
+
+(defn- coerce-value
+  [declared value]
+  (case (dtype/canon declared)
+    :byte (byte value)
+    :int (int value)
+    :long (long value)
+    :float (float value)
+    :double (double value)
+    :half (fail! :typed-scalar-half
+                 "the JVM reference backend has no scalar FP16 value representation"
+                 {:dtype declared :value value})))
+
+(defn- resolve-class
+  [source-ns operation]
+  (when-let [owner (namespace operation)]
+    (let [owner-symbol (symbol owner)
+          resolved (or (ns-resolve source-ns owner-symbol)
+                       (try (Class/forName owner false (.getContextClassLoader
+                                                        (Thread/currentThread)))
+                            (catch ClassNotFoundException _ nil))
+                       (try (Class/forName (str "java.lang." owner) false
+                                           (.getContextClassLoader (Thread/currentThread)))
+                            (catch ClassNotFoundException _ nil)))]
+      (when (class? resolved) resolved))))
+
+(defn- resolve-callable
+  [source-ns operation]
+  (or (when (namespace operation)
+        (try (requiring-resolve operation) (catch Throwable _ nil)))
+      (ns-resolve source-ns operation)
+      (ns-resolve 'clojure.core operation)))
+
+(declare evaluate-expression)
+
+(defn- invoke-operation
+  [source-ns expression environment]
+  (let [operation (descriptor/semantic-op expression)
+        arguments (descriptor/call-args expression)]
+    (when-not operation
+      (fail! :typed-scalar-operation "typed scalar call has no retained semantic operation"
+             {:expression expression}))
+    (case operation
+      if (let [[predicate consequent alternate] arguments]
+           (evaluate-expression source-ns environment
+                                (if (evaluate-expression source-ns environment predicate)
+                                  consequent alternate)))
+      and (loop [[argument & remaining] arguments, result true]
+            (if argument
+              (let [value (evaluate-expression source-ns environment argument)]
+                (if value (recur remaining value) value))
+              result))
+      or (loop [[argument & remaining] arguments]
+           (when argument
+             (let [value (evaluate-expression source-ns environment argument)]
+               (if value value (recur remaining)))))
+      (let [values (mapv #(evaluate-expression source-ns environment %) arguments)]
+        (if-let [callable (resolve-callable source-ns operation)]
+          (apply callable values)
+          (if-let [owner (resolve-class source-ns operation)]
+            (clojure.lang.Reflector/invokeStaticMethod
+             (.getName ^Class owner) (name operation) (to-array values))
+            (fail! :typed-scalar-operation
+                   "typed scalar semantic operation cannot be resolved by the JVM backend"
+                   {:operation operation :expression expression :source-ns (ns-name source-ns)})))))))
+
+(defn evaluate-expression
+  "Interpret one proven-pure scalar expression in `environment`.
+
+   Symbols name typed region operands/locals. Calls are dispatched by their retained semantic
+   identity; unknown or effectful expressions fail loudly."
+  [source-ns environment expression]
+  (let [source-ns (namespace-object source-ns)]
+    (cond
+      (or (number? expression) (boolean? expression) (nil? expression)) expression
+      (symbol? expression)
+      (if (contains? environment expression)
+        (get environment expression)
+        (fail! :typed-scalar-unbound "typed scalar expression references an unbound SSA value"
+               {:symbol expression :available (set (keys environment))}))
+      (seq? expression)
+      (do
+        (when-not (= :pure (effects/analyze-effect expression))
+          (fail! :typed-scalar-effect "JVM scalar backend only executes proven-pure expressions"
+                 {:expression expression :effect (effects/analyze-effect expression)}))
+        (invoke-operation source-ns expression environment))
+      :else
+      (fail! :typed-scalar-expression "JVM scalar backend cannot execute this typed scalar value"
+             {:expression expression :type (type expression)}))))
+
+(defn evaluate-region
+  "Execute a canonical TypedSOAC lambda for ordered typed scalar operands.
+
+   `result-dtypes` must align with the region's declared result expressions. The return value is
+   an ordered vector of `{:type dtype :value value}` maps suitable for compiler/runtime ABIs."
+  [source-ns lambda operands result-dtypes]
+  (let [{:keys [parameters locals body-results]} (soac/lambda-parts lambda)
+        operands (vec operands)
+        result-dtypes (vec result-dtypes)]
+    (when-not (= (count parameters) (count operands))
+      (fail! :typed-scalar-arity "typed scalar operand count differs from its lambda"
+             {:parameters parameters :operand-count (count operands)}))
+    (when-not (every? typed-scalar? operands)
+      (fail! :typed-scalar-operand "typed scalar region requires typed scalar operands"
+             {:operands operands}))
+    (when-not (= (count body-results) (count result-dtypes))
+      (fail! :typed-scalar-results "typed scalar result dtypes differ from its result arity"
+             {:results (count body-results) :dtypes result-dtypes}))
+    (let [initial (into {} (map (fn [parameter operand]
+                                  [parameter (:value operand)])
+                                parameters operands))
+          environment
+          (reduce (fn [environment {:keys [id dtype init]}]
+                    (assoc environment id
+                           (coerce-value dtype
+                                         (evaluate-expression source-ns environment init))))
+                  initial locals)]
+      (mapv (fn [expression result-dtype]
+              {:type (dtype/canon result-dtype)
+               :value (coerce-value result-dtype
+                                    (evaluate-expression source-ns environment expression))})
+            body-results result-dtypes))))
+
+(defn evaluate-invocation-step
+  "InvocationMaterialization evaluator for one closed ScalarCompute step."
+  [source-ns step operand-values]
+  (let [{:keys [parameters]} (soac/lambda-parts (:region step))
+        operands (mapv (fn [parameter]
+                         (or (get operand-values parameter)
+                             (fail! :typed-scalar-invocation-operand
+                                    "invocation scalar operand is missing"
+                                    {:parameter parameter :available (set (keys operand-values))})))
+                       parameters)]
+    (first (evaluate-region source-ns (:region step) operands
+                            [(get-in step [:value :dtype])]))))
+
+(defn evaluate-host-equation
+  "EmittedParallelProgramCall evaluator for one host-only TypedSOAC equation."
+  [source-ns equation {:keys [operands values]}]
+  (let [algorithm (soac/validate! (:algorithm equation))
+        environment
+        (reduce
+         (fn [environment algorithm-equation]
+           (let [{:keys [kind captures lambda]} (soac/operation-parts algorithm-equation)
+                 results (vec (nth algorithm-equation 2))]
+             (when-not (= 'scalar kind)
+               (fail! :typed-scalar-host-operation
+                      "host-only equation contains a non-scalar TypedSOAC operation"
+                      {:equation (:id equation) :kind kind}))
+             (let [arguments (mapv (fn [capture]
+                                     (or (get environment capture)
+                                         (fail! :typed-scalar-host-operand
+                                                "host scalar capture is unavailable"
+                                                {:capture capture
+                                                 :available (set (keys environment))})))
+                                   captures)
+                   produced (evaluate-region source-ns lambda arguments
+                                             (mapv #(get-in values [% :dtype]) results))]
+               (into environment (map vector results produced)))))
+         operands (soac/equations algorithm))]
+    (select-keys environment (:results equation))))

--- a/src/raster/compiler/equation_first.clj
+++ b/src/raster/compiler/equation_first.clj
@@ -1,0 +1,150 @@
+(ns raster.compiler.equation-first
+  "Public, allocation-free compilation of a deftm through Raster's equation-first TypedSOAC path.
+
+   `compile` retains the semantic program, selected schedule, emitted target program, and kernel
+   artifacts as ordinary immutable compiler values. `lower` specializes the public invocation
+   contract against ordered arguments and returns the sole physical composition boundary: a
+   validated LinkPlan. Runtime allocation begins only in raster.gpu.link/instantiate!.
+
+   This is the migration boundary for direct TypedSOAC programs. It does not consult the legacy
+   resident descriptor extractor or reconstruct ABI/storage facts from emitted source."
+  (:refer-clojure :exclude [compile])
+  (:require [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
+            [raster.compiler.backend.gpu.parallel-program-opencl :as program-opencl]
+            [raster.compiler.backend.jvm.typed-scalar :as scalar]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.invocation-link :as invocation-link]
+            [raster.compiler.ir.invocation-materialization :as materialization]
+            [raster.compiler.ir.invocation-plan :as invocation]
+            [raster.compiler.passes.parallel.device :as device]
+            [raster.compiler.passes.parallel.structured-control-route :as structured-route]
+            [raster.compiler.pipeline :as pipeline]))
+
+(defrecord EquationFirstCompilation
+           [id function target dtype source-ns options semantic scheduled emitted kernels stats])
+
+(defn equation-first-compilation?
+  [value]
+  (instance? EquationFirstCompilation value))
+
+(defn- fail!
+  [reason message data]
+  (throw (ex-info message (assoc data :reason reason :compiler :equation-first))))
+
+(defn- source-namespace-symbol
+  [f-var]
+  (let [metadata (meta f-var)]
+    (or (:raster.core/deftm-source-ns metadata)
+        (some-> (:ns metadata) ns-name)
+        (fail! :equation-first-source-namespace
+               "equation-first compilation requires the deftm defining namespace"
+               {:function f-var}))))
+
+(defn- function-symbol
+  [f-var]
+  (let [{:keys [ns name]} (meta f-var)]
+    (if (and ns name)
+      (symbol (str (ns-name ns)) (str name))
+      (fail! :equation-first-function "equation-first compilation requires a deftm Var"
+             {:function f-var}))))
+
+(defn- compiler-options
+  [f-var target requested-dtype options]
+  (let [metadata (meta f-var)
+        parameters (pipeline/clean-params (pipeline/get-params f-var requested-dtype))
+        declared-tags (:raster.core/deftm-tags metadata)
+        effective-dtype (or requested-dtype (dtype/infer-dtype-from-tags declared-tags) :double)
+        source-ns-symbol (source-namespace-symbol f-var)
+        source-ns (or (find-ns source-ns-symbol)
+                      (fail! :equation-first-source-namespace
+                             "deftm defining namespace is not loaded"
+                             {:function f-var :source-ns source-ns-symbol}))
+        param-env (pipeline/build-param-env f-var effective-dtype)
+        ;; Parametric deftm wrappers do not themselves retain dispatch tags; get-params and
+        ;; build-param-env resolve the same dtype specialization used by get-walked-body.
+        tags (mapv param-env parameters)
+        parameter-types (opencl-pass/derive-param-types parameters tags effective-dtype)]
+    (merge options
+           {:dtype effective-dtype
+            :target-device target
+            :active-params parameters
+            :public-parameters parameters
+            :source-ns source-ns
+            :array-types (:array-types parameter-types)
+            :scalar-types (:scalar-types parameter-types)}
+           (when param-env {:param-env param-env}))))
+
+(defn compile
+  "Compile one deftm Var into an immutable equation-first target program.
+
+   Options currently require `:target` in the Level Zero/OpenCL family. CUDA/HIP source emitters
+   will plug in at this same scheduled-program boundary; unsupported target families fail rather
+   than borrowing the compatibility backend. `:dtype` defaults from the deftm's retained tags."
+  ([f-var] (compile f-var {}))
+  ([f-var {:keys [target dtype] :or {target :ze:0} :as options}]
+   (when-not (var? f-var)
+     (fail! :equation-first-function "equation-first compilation requires a deftm Var"
+            {:function f-var :actual (type f-var)}))
+   (let [compiler-options (compiler-options f-var target dtype
+                                            (dissoc options :target))
+         walked (pipeline/get-walked-body f-var (:dtype compiler-options))
+         source (if (= 1 (count walked)) (first walked) (list* 'do walked))
+         semantic (pipeline/run-passes source pipeline/gpu-resident-pre-soa-passes
+                                       compiler-options)
+         _ (when-not (= :typed-parallel (:dialect semantic))
+             (fail! :equation-first-coverage
+                    "deftm is outside the direct TypedSOAC/structured-control vertical"
+                    {:function (function-symbol f-var)
+                     :dialect (:dialect semantic) :fallback :none}))
+         scheduled (structured-route/schedule-program semantic compiler-options)
+         backend (device/select-runtime-backend target true nil)
+         emission
+         (case backend
+           :opencl (program-opencl/emit-program scheduled compiler-options)
+           (fail! :equation-first-target-emitter
+                  "equation-first scheduled program has no public source emitter for this target"
+                  {:target target :backend backend :fallback :none}))
+         invocation-plan (some-> semantic :attributes :invocation-plan invocation/validate!)
+         _ (when-not invocation-plan
+             (fail! :equation-first-invocation
+                    "equation-first semantic program has no retained public invocation plan"
+                    {:function (function-symbol f-var)}))
+         source-ns-symbol (source-namespace-symbol f-var)
+         id [::compilation (function-symbol f-var) target (:dtype compiler-options)]]
+     (->EquationFirstCompilation
+      id (function-symbol f-var) target (:dtype compiler-options) source-ns-symbol
+      (-> compiler-options
+          (assoc :source-ns source-ns-symbol)
+          (dissoc :values))
+      semantic scheduled (:program emission) (:kernels emission)
+      {:semantic {:dialect (:dialect semantic)
+                  :equations (count (:equations semantic))}
+       :schedule {:dialect (:dialect scheduled)
+                  :equations (count (:equations scheduled))}
+       :emission (:stats emission)
+       :fallback :none}))))
+
+(defn lower
+  "Specialize a compiled equation-first program against ordered public arguments.
+
+   Returns a validated, allocation-free LinkPlan. Public buffers retain their stable host source
+   identity until instantiation; scalar prefix and host-only equations execute through the same
+   typed JVM reference backend."
+  [compilation arguments]
+  (when-not (equation-first-compilation? compilation)
+    (fail! :equation-first-compilation "lower requires an EquationFirstCompilation"
+           {:actual (type compilation)}))
+  (let [source-ns (:source-ns compilation)
+        invocation-plan (get-in compilation [:semantic :attributes :invocation-plan])
+        materialized
+        (materialization/materialize
+         invocation-plan (vec arguments)
+         (partial scalar/evaluate-invocation-step source-ns))]
+    (invocation-link/lower
+     materialized (:emitted compilation) (:target compilation)
+     (partial scalar/evaluate-host-equation source-ns))))
+
+(defn compile-link-plan
+  "Convenience composition of `compile` and `lower`; still performs no runtime allocation."
+  [f-var arguments options]
+  (lower (compile f-var options) arguments))

--- a/test/raster/compiler/backend/jvm/typed_scalar_test.clj
+++ b/test/raster/compiler/backend/jvm/typed_scalar_test.clj
@@ -1,0 +1,46 @@
+(ns raster.compiler.backend.jvm.typed-scalar-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.jvm.typed-scalar :as scalar]
+            [raster.compiler.ir.soac-dialect :as soac]))
+
+(defn- reason-of [thunk]
+  (try (thunk) nil (catch clojure.lang.ExceptionInfo exception
+                     (:reason (ex-data exception)))))
+
+(deftest typed-region-executes-retained-ssa-and-dtypes
+  (let [lambda
+        (soac/lambda-form
+         '[x n]
+         [(soac/local-value 'scaled :double '(clojure.core/* x 2.0))
+          (soac/local-value 'counted :double '(double n))]
+         '[(clojure.core/+ scaled counted)])]
+    (is (= [{:type :double :value 5.0}]
+           (scalar/evaluate-region
+            'raster.compiler.backend.jvm.typed-scalar-test lambda
+            [{:type :double :value 1.5} {:type :long :value 2}]
+            [:double])))))
+
+(deftest typed-region-resolves-java-static-semantics-without-a-function-table
+  (is (= [{:type :double :value 3.0}]
+         (scalar/evaluate-region
+          'raster.compiler.backend.jvm.typed-scalar-test
+          (soac/lambda-form '[x] '[(Math/sqrt x)])
+          [{:type :double :value 9.0}]
+          [:double]))))
+
+(deftest typed-region-fails-on-unbound-effectful-or-unrepresentable-values
+  (testing "SSA closure is checked at execution as well as IR validation"
+    (is (= :typed-scalar-unbound
+           (reason-of #(scalar/evaluate-region
+                        'raster.compiler.backend.jvm.typed-scalar-test
+                        (soac/lambda-form '[] '[missing]) [] [:double])))))
+  (testing "the reference backend never executes an unproven side effect"
+    (is (= :typed-scalar-effect
+           (reason-of #(scalar/evaluate-region
+                        'raster.compiler.backend.jvm.typed-scalar-test
+                        (soac/lambda-form '[] '[(println "no")]) [] [:double])))))
+  (testing "FP16 requires an explicit representable host scalar contract"
+    (is (= :typed-scalar-half
+           (reason-of #(scalar/evaluate-region
+                        'raster.compiler.backend.jvm.typed-scalar-test
+                        (soac/lambda-form '[] '[1.0]) [] [:half]))))))

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -54,5 +54,12 @@
               :fallback-reasons [] :declines {}}}
 
   :heat-loss-rk4-gpu
-  {:declined {:reason :emitted-parallel-program-call-required
-              :target-dialect :opencl-parallel}}}}
+  {:route {:semantic-dialect :typed-parallel
+           :scheduled-dialect :scheduled-parallel
+           :emitted-dialect :opencl-parallel
+           :fallback :none}
+   :lowering {:nodes 5 :values 5 :instances 1 :program-instances 1
+              :outputs 1 :driver-allocations 0}
+   :emission {:structured-loops-emitted 1
+              :typed-equations-emitted 1
+              :host-scalar-equations 1}}}}

--- a/test/raster/compiler/compatibility_ledger_test.clj
+++ b/test/raster/compiler/compatibility_ledger_test.clj
@@ -1,6 +1,8 @@
 (ns raster.compiler.compatibility-ledger-test
   (:require [clojure.edn :as edn]
             [clojure.test :refer [deftest is use-fixtures]]
+            [raster.compiler.equation-first :as equation-first]
+            [raster.compiler.ir.link-plan :as link-plan]
             [raster.compiler.pipeline :as pipeline]
             [raster.dl.attention :as attention]
             [raster.linalg.contract :as contract]
@@ -40,6 +42,21 @@
    :emission (-> (:emission report)
                  (update :declines #(frequencies-by (juxt :leaf :reason) %)))})
 
+(defn- equation-first-signature
+  [compilation plan]
+  {:route {:semantic-dialect (get-in compilation [:semantic :dialect])
+           :scheduled-dialect (get-in compilation [:scheduled :dialect])
+           :emitted-dialect (get-in compilation [:emitted :dialect])
+           :fallback (get-in compilation [:stats :fallback])}
+   :lowering {:nodes (count (:nodes plan))
+              :values (count (:values plan))
+              :instances (count (:instances plan))
+              :program-instances (count (filter link-plan/program-link-instance?
+                                                (:instances plan)))
+              :outputs (count (:outputs plan))
+              :driver-allocations (get-in plan [:attributes :driver-allocations])}
+   :emission (get-in compilation [:stats :emission])})
+
 (defn- compile-workload
   [id]
   (case id
@@ -61,11 +78,11 @@
     (pipeline/compile-report #'pde/heat-rhs-1d! :dtype :double)
 
     :heat-loss-rk4-gpu
-    (try
-      (pipeline/compile-report #'pde/heat-loss-rk4
-                               :target-device target :dtype :double)
-      (catch clojure.lang.ExceptionInfo exception
-        {:declined (select-keys (ex-data exception) [:reason :target-dialect])}))
+    (let [compilation (equation-first/compile
+                       #'pde/heat-loss-rk4 {:target target :dtype :double})
+          plan (equation-first/lower
+                compilation [(double-array 8) (double-array 8) 0.1 1.0 0.01 3])]
+      (equation-first-signature compilation plan))
 
     (throw (ex-info "compatibility ledger has no workload compiler"
                     {:workload id}))))
@@ -82,7 +99,10 @@
            (set (keys workloads))))
     (doseq [[id expected] workloads]
       (let [report (compile-workload id)
-            actual (if (:declined report) report (signature report))]
+            actual (cond
+                     (:declined report) report
+                     (= :heat-loss-rk4-gpu id) report
+                     :else (signature report))]
         (is (= expected actual)
             (str "compiler compatibility changed for " id
                  "; improve the ledger downward or explain the new debt"))

--- a/test/raster/compiler/gpu_integration_test.clj
+++ b/test/raster/compiler/gpu_integration_test.clj
@@ -6,11 +6,14 @@
 
   Verifies:
     1. Functional correctness against analytical heat equation solution
-    2. GPU compilation fails loudly while structured loops containing SOACs remain debt
-
-  The hardware-free exact debt signature is also recorded in compatibility_ledger.edn."
+    2. The real RK4/PDE workload crosses the public equation-first TypedSOAC compiler
+    3. The resulting allocation-free LinkPlan executes numerically on an available GPU."
   (:require [clojure.test :refer [deftest is testing]]
-            [raster.dl.gpu-grad-parity :as gp]))
+            [raster.compiler.equation-first :as equation-first]
+            [raster.compiler.ir.link-plan :as link-plan]
+            [raster.dl.gpu-grad-parity :as gp]
+            [raster.gpu.link :as gpu-link]
+            [raster.ode.pde :as pde]))
 
 ;; ================================================================
 ;; GPU availability check
@@ -92,15 +95,35 @@
                 (format "%s: CPU=%.10f analytical=%.10f tol=%.6f"
                         label (double cpu-loss) analytical tol))))))))
 
-(deftest gpu-rk4-structured-loop-declines-honestly-test
-  (testing "GPU compilation rejects the unsupported structured SOAC loop"
-    (when-gpu "gpu-rk4-structured-loop-decline"
-              (require '[raster.compiler.pipeline :as pipeline])
-              (require 'raster.ode.pde)
-              (try
-                ((resolve 'raster.compiler.pipeline/compile-aot)
-                 (resolve 'raster.ode.pde/heat-loss-rk4)
-                 {:target-device :ze:0})
-                (is false "RK4 must not compile by deleting its loop or using the legacy compound emitter")
-                (catch clojure.lang.ExceptionInfo exception
-                  (is (= :unscheduled-stencil (:reason (ex-data exception)))))))))
+(deftest gpu-rk4-uses-the-public-equation-first-vertical-test
+  (let [n 64
+        nsteps 3
+        [u0 target alpha inv-dx2 dt] (setup-heat-problem n)
+        arguments [u0 target alpha inv-dx2 dt nsteps]
+        compilation (equation-first/compile
+                     #'pde/heat-loss-rk4 {:target :ze:0 :dtype :double})
+        plan (equation-first/lower compilation arguments)]
+    (testing "compilation and lowering are inspectable and allocate no driver resources"
+      (is (equation-first/equation-first-compilation? compilation))
+      (is (= :typed-parallel (get-in compilation [:semantic :dialect])))
+      (is (= :scheduled-parallel (get-in compilation [:scheduled :dialect])))
+      (is (= :opencl-parallel (get-in compilation [:emitted :dialect])))
+      (is (= :none (get-in compilation [:stats :fallback])))
+      (is (link-plan/link-plan? plan))
+      (is (= 0 (get-in plan [:attributes :driver-allocations])))
+      (is (= 1 (count (:outputs plan)))))
+    (testing "the public LinkPlan executes the same numerical program on an available GPU"
+      (when-gpu "gpu-rk4-equation-first-execution"
+                (let [expected (pde/heat-loss-rk4 (aclone u0) (aclone target)
+                                                  alpha inv-dx2 dt nsteps)
+                      executable (gpu-link/instantiate! plan)]
+                  (try
+                    (gpu-link/run! executable)
+                    (let [actual (double (aget ^doubles
+                                          (gpu-link/download executable
+                                                             (first (:outputs plan)))
+                                               0))]
+                      (is (< (Math/abs (- (double expected) actual)) 1.0e-10)
+                          (format "CPU=%.15g GPU=%.15g" (double expected) actual)))
+                    (finally
+                      (gpu-link/close! executable))))))))

--- a/test/raster/compiler/passes/parallel/structured_control_route_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_route_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.walk :as walk]
             [raster.compiler.backend.gpu.parallel-program-opencl :as program-opencl]
+            [raster.compiler.equation-first :as equation-first]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.dialects :as dialects]
             [raster.compiler.ir.emitted-parallel-equation :as emitted-equation]
@@ -301,24 +302,20 @@
                                       [suffix-operation])))))))))
 
 (deftest real-rk4-pde-reaches-the-equation-first-opencl-vertical
-  (let [options {:dtype :double :target-device :ze:debug
-                 :source-ns (the-ns 'raster.ode.pde)
-                 :public-parameters '[u0 target alpha inv-dx2 dt nsteps]
-                 :array-types {'u0 :double 'target :double}
-                 :scalar-types {'alpha :double 'inv-dx2 :double
-                                'dt :double 'nsteps :long}}
-        walked (pipeline/get-walked-body #'pde/heat-loss-rk4 :double)
-        source (if (= 1 (count walked)) (first walked) (list* 'do walked))
-        semantic (pipeline/run-passes
-                  source pipeline/gpu-resident-pre-soa-passes options)
-        scheduled (route/schedule-program semantic options)
-        emitted (program-opencl/emit-program scheduled options)
-        emitted-program (:program emitted)
+  (let [arguments [(double-array 8) (double-array 8) 0.1 1.0 0.01 3]
+        compilation (equation-first/compile
+                     #'pde/heat-loss-rk4 {:dtype :double :target :ze:debug})
+        semantic (:semantic compilation)
+        scheduled (:scheduled compilation)
+        emitted {:program (:emitted compilation)
+                 :kernels (:kernels compilation)
+                 :stats (get-in compilation [:stats :emission])}
+        emitted-program (:emitted compilation)
         invocation-plan (get-in semantic [:attributes :invocation-plan])
         materialized
         (materialization/materialize
          invocation-plan
-         [(double-array 8) (double-array 8) 0.1 1.0 0.01 3]
+         arguments
          evaluate-test-scalar)
         loop-operation (get-in scheduled [:equations 0 :operations 0])
         loop-equation (first (:equations emitted-program))
@@ -356,7 +353,9 @@
                   (:results equation))))
         call (program-call/make emitted-program buffers scalar-values
                                 {loop-output :rk4-carry-scratch} host-evaluator)
-        linked-plan (invocation-link/lower materialized emitted-program :ze:debug host-evaluator)]
+        linked-plan (equation-first/lower compilation arguments)]
+    (is (equation-first/equation-first-compilation? compilation))
+    (is (= :none (get-in compilation [:stats :fallback])))
     (is (= :typed-parallel (:dialect semantic)))
     (is (invocation/invocation-plan? invocation-plan))
     (is (= '[u0 target alpha inv-dx2 dt nsteps]


### PR DESCRIPTION
## Summary
- add a public, allocation-free compile/lower boundary over the direct TypedSOAC structured-control pipeline
- execute retained pure scalar SSA through one dtype-driven JVM reference backend, without source eval or a private operation registry
- replace the obsolete RK4/PDE decline ratchet with public LinkPlan lowering and real GPU numerical execution

## Verification
- 28 tests, 159 assertions across typed scalar, structured-control, and GPU integration namespaces
- 0 failures, 0 errors
- real Intel Arc RK4 execution matches the CPU result within 1e-10
- cljfmt and git diff checks pass

Stacked on #270 because runtime execution of ProgramLinkInstance lands there.