### PR TITLE
Unify loop-free TypedSOAC execution

### DIFF
--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -940,7 +940,7 @@
    Node artifacts remain free to order their own physical parameters. The graph boundary groups
    equal symbolic scalars, proves their emitted dtypes agree, and exposes every external buffer
    exactly once."
-  [emitted target-dialect]
+  [emitted target-dialect scalar-types]
   (let [external-buffers (vec (distinct (concat (:inputs emitted) (:outputs emitted))))
         scalar-pairs (->> (:nodes emitted)
                           (mapcat (fn [node]
@@ -965,10 +965,12 @@
         scalar-arguments (vec (sort-by name (keys scalar-groups)))
         scalar-abi (mapv (fn [argument]
                            (let [slots (mapv first (get scalar-groups argument))
-                                 dtype (:kernel-dtype (first slots))
+                                 kernel-dtype (:kernel-dtype (first slots))
+                                 logical-dtype (or (get scalar-types argument) kernel-dtype)
                                  role (if (some #(= :bound (:role %)) slots)
                                         :bound :parameter)]
-                             (kabi/slot argument :scalar dtype :role role)))
+                             (kabi/slot argument :scalar logical-dtype
+                                        :kernel-dtype kernel-dtype :role role)))
                          scalar-arguments)]
     (-> emitted
         (assoc :abi (vec (concat pointer-abi scalar-abi))
@@ -1203,7 +1205,7 @@
                  (fn [node]
                    (kart/certify-scheduled-operation
                     (emit-node node) (:operation node))))]
-    (finalize-emitted-graph emitted :opencl-c)))
+    (finalize-emitted-graph emitted :opencl-c scalar-types)))
 
 (defn- graph-array-types
   [graph array-types]
@@ -1253,7 +1255,7 @@
                               {:reason :kernel-graph-node-target-lowering-missing
                                :target :opencl-c :node id :operation operation})))
             operation)))]
-    (finalize-emitted-graph emitted :opencl-c)))
+    (finalize-emitted-graph emitted :opencl-c scalar-types)))
 
 (defn- generate-reduction-kernel-graph
   [graph {:keys [scalar-types array-types]
@@ -1274,7 +1276,7 @@
                :dtype (:dtype operation)
                :scalar-types scalar-types :array-types array-types)
               operation))))]
-    (finalize-emitted-graph emitted :opencl-c)))
+    (finalize-emitted-graph emitted :opencl-c scalar-types)))
 
 (defn generate-kernel-graph
   "Target-lower one scheduled KernelGraph through the backend's single graph-emission boundary.

--- a/src/raster/compiler/backend/jvm/typed_scalar.clj
+++ b/src/raster/compiler/backend/jvm/typed_scalar.clj
@@ -19,6 +19,19 @@
   [value]
   (and (map? value) (keyword? (:type value)) (contains? value :value)))
 
+(defn buffer-operand
+  "Describe one shaped host/runtime buffer to a host-only typed scalar equation."
+  [shape]
+  (let [shape (vec shape)]
+    (when-not (every? #(and (integer? %) (not (neg? %))) shape)
+      (fail! :typed-scalar-buffer-shape "typed scalar buffer shape must be concrete"
+             {:shape shape}))
+    {::buffer true :shape shape}))
+
+(defn- buffer-operand?
+  [value]
+  (and (map? value) (true? (::buffer value)) (vector? (:shape value))))
+
 (defn- namespace-object
   [source-ns]
   (cond
@@ -72,29 +85,45 @@
     (when-not operation
       (fail! :typed-scalar-operation "typed scalar call has no retained semantic operation"
              {:expression expression}))
-    (case operation
-      if (let [[predicate consequent alternate] arguments]
-           (evaluate-expression source-ns environment
-                                (if (evaluate-expression source-ns environment predicate)
-                                  consequent alternate)))
-      and (loop [[argument & remaining] arguments, result true]
-            (if argument
-              (let [value (evaluate-expression source-ns environment argument)]
-                (if value (recur remaining value) value))
-              result))
-      or (loop [[argument & remaining] arguments]
-           (when argument
-             (let [value (evaluate-expression source-ns environment argument)]
-               (if value value (recur remaining)))))
-      (let [values (mapv #(evaluate-expression source-ns environment %) arguments)]
-        (if-let [callable (resolve-callable source-ns operation)]
-          (apply callable values)
-          (if-let [owner (resolve-class source-ns operation)]
-            (clojure.lang.Reflector/invokeStaticMethod
-             (.getName ^Class owner) (name operation) (to-array values))
-            (fail! :typed-scalar-operation
-                   "typed scalar semantic operation cannot be resolved by the JVM backend"
-                   {:operation operation :expression expression :source-ns (ns-name source-ns)})))))))
+    (cond
+      (descriptor/alength-op? operation)
+      (let [[argument & extra] arguments
+            value (evaluate-expression source-ns environment argument)]
+        (when (or (nil? argument) (seq extra))
+          (fail! :typed-scalar-alength "typed scalar alength requires one buffer operand"
+                 {:expression expression}))
+        (cond
+          (buffer-operand? value) (first (:shape value))
+          (and value (.isArray (class value))) (alength value)
+          :else (fail! :typed-scalar-alength
+                       "typed scalar alength operand has no host shape contract"
+                       {:expression expression :operand value})))
+
+      :else
+      (case operation
+        if (let [[predicate consequent alternate] arguments]
+             (evaluate-expression source-ns environment
+                                  (if (evaluate-expression source-ns environment predicate)
+                                    consequent alternate)))
+        and (loop [[argument & remaining] arguments, result true]
+              (if argument
+                (let [value (evaluate-expression source-ns environment argument)]
+                  (if value (recur remaining value) value))
+                result))
+        or (loop [[argument & remaining] arguments]
+             (when argument
+               (let [value (evaluate-expression source-ns environment argument)]
+                 (if value value (recur remaining)))))
+        (let [values (mapv #(evaluate-expression source-ns environment %) arguments)]
+          (if-let [callable (resolve-callable source-ns operation)]
+            (apply callable values)
+            (if-let [owner (resolve-class source-ns operation)]
+              (clojure.lang.Reflector/invokeStaticMethod
+               (.getName ^Class owner) (name operation) (to-array values))
+              (fail! :typed-scalar-operation
+                     "typed scalar semantic operation cannot be resolved by the JVM backend"
+                     {:operation operation :expression expression
+                      :source-ns (ns-name source-ns)}))))))))
 
 (defn evaluate-expression
   "Interpret one proven-pure scalar expression in `environment`.
@@ -132,14 +161,16 @@
     (when-not (= (count parameters) (count operands))
       (fail! :typed-scalar-arity "typed scalar operand count differs from its lambda"
              {:parameters parameters :operand-count (count operands)}))
-    (when-not (every? typed-scalar? operands)
-      (fail! :typed-scalar-operand "typed scalar region requires typed scalar operands"
+    (when-not (every? #(or (typed-scalar? %) (buffer-operand? %)) operands)
+      (fail! :typed-scalar-operand "typed scalar region requires typed scalar or buffer operands"
              {:operands operands}))
     (when-not (= (count body-results) (count result-dtypes))
       (fail! :typed-scalar-results "typed scalar result dtypes differ from its result arity"
              {:results (count body-results) :dtypes result-dtypes}))
     (let [initial (into {} (map (fn [parameter operand]
-                                  [parameter (:value operand)])
+                                  [parameter (if (typed-scalar? operand)
+                                               (:value operand)
+                                               operand)])
                                 parameters operands))
           environment
           (reduce (fn [environment {:keys [id dtype init]}]
@@ -168,8 +199,14 @@
 
 (defn evaluate-host-equation
   "EmittedParallelProgramCall evaluator for one host-only TypedSOAC equation."
-  [source-ns equation {:keys [operands values]}]
+  [source-ns equation {:keys [operands values buffer-shapes]}]
   (let [algorithm (soac/validate! (:algorithm equation))
+        operands (reduce-kv (fn [operands id value]
+                              (assoc operands id
+                                     (if-let [shape (get buffer-shapes id)]
+                                       (buffer-operand shape)
+                                       value)))
+                            {} operands)
         environment
         (reduce
          (fn [environment algorithm-equation]

--- a/src/raster/compiler/equation_first.clj
+++ b/src/raster/compiler/equation_first.clj
@@ -89,8 +89,13 @@
                                             (dissoc options :target))
          walked (pipeline/get-walked-body f-var (:dtype compiler-options))
          source (if (= 1 (count walked)) (first walked) (list* 'do walked))
-         semantic (pipeline/run-passes source pipeline/gpu-resident-pre-soa-passes
-                                       compiler-options)
+         semantic-candidate (pipeline/run-passes
+                             source pipeline/gpu-resident-pre-soa-passes compiler-options)
+         semantic (case (:dialect semantic-candidate)
+                    :typed-parallel semantic-candidate
+                    :typed-soac (structured-route/promote-soac-program
+                                 semantic-candidate compiler-options)
+                    semantic-candidate)
          _ (when-not (= :typed-parallel (:dialect semantic))
              (fail! :equation-first-coverage
                     "deftm is outside the direct TypedSOAC/structured-control vertical"
@@ -139,10 +144,15 @@
         materialized
         (materialization/materialize
          invocation-plan (vec arguments)
-         (partial scalar/evaluate-invocation-step source-ns))]
+         (partial scalar/evaluate-invocation-step source-ns))
+        buffer-shapes (into {} (map (fn [[id buffer]] [id (:shape buffer)]))
+                            (:program-buffers materialized))
+        evaluate-host (fn [equation context]
+                        (scalar/evaluate-host-equation
+                         source-ns equation (assoc context :buffer-shapes buffer-shapes)))]
     (invocation-link/lower
      materialized (:emitted compilation) (:target compilation)
-     (partial scalar/evaluate-host-equation source-ns))))
+     evaluate-host)))
 
 (defn compile-link-plan
   "Convenience composition of `compile` and `lower`; still performs no runtime allocation."

--- a/src/raster/compiler/ir/abstract_value.clj
+++ b/src/raster/compiler/ir/abstract_value.clj
@@ -99,3 +99,29 @@
   "Whether two validated AbstractValues have the same logical raw-storage contract."
   [left right]
   (= (storage-contract left) (storage-contract right)))
+
+(defn- unknown-dimension?
+  [dimension]
+  (and (seq? dimension) (= 'unknown-dimension (first dimension)) (= 2 (count dimension))))
+
+(defn merge-refinement
+  "Join two facts for the same SSA value when they differ only by unknown shape dimensions.
+
+   A concrete/static/symbolic dimension refines `(unknown-dimension id)`; two distinct known
+   dimensions remain a contradiction. All non-shape AbstractValue facets must agree exactly, so
+   this is a checked information refinement rather than dtype/layout/ownership inference. Returns
+   nil when neither value refines the other."
+  [left right]
+  (let [left (validate! left)
+        right (validate! right)]
+    (when (and (= (assoc left :shape []) (assoc right :shape []))
+               (= (count (:shape left)) (count (:shape right))))
+      (let [shape (mapv (fn [left-dimension right-dimension]
+                          (cond
+                            (= left-dimension right-dimension) left-dimension
+                            (unknown-dimension? left-dimension) right-dimension
+                            (unknown-dimension? right-dimension) left-dimension
+                            :else ::conflict))
+                        (:shape left) (:shape right))]
+        (when-not (some #{::conflict} shape)
+          (assoc left :shape shape))))))

--- a/src/raster/compiler/ir/emitted_parallel_program_call.clj
+++ b/src/raster/compiler/ir/emitted_parallel_program_call.clj
@@ -167,15 +167,16 @@
         (mapv (fn [slot argument]
                 (if (= :scalar (:kind slot))
                   (let [value (checked-scalar values argument (get scalars argument))]
-                    (when-not (= (dtype/canon (:kernel-dtype slot))
+                    (when-not (= (dtype/canon (:dtype slot))
                                  (dtype/canon (:type value)))
                       (fail! :emitted-program-scalar-abi
-                             "runtime scalar dtype differs from the emitted graph ABI"
+                             "runtime scalar dtype differs from the logical graph ABI"
                              {:equation (:id equation) :value argument
-                              :expected (:kernel-dtype slot) :actual (:type value)}))
+                              :expected (:dtype slot) :actual (:type value)}))
                     value)
                   (require-buffer buffers argument :equation-interface)))
               (:abi graph) (:arguments graph))
+        runtime-arguments (executable/typed-runtime-arguments graph runtime-arguments)
         bindings (executable/graph-bindings graph runtime-arguments)
         outputs (select-keys buffers (:results equation))]
     {:call (validate-equation-call!

--- a/src/raster/compiler/ir/kernel_executable.clj
+++ b/src/raster/compiler/ir/kernel_executable.clj
@@ -5,7 +5,8 @@
    properties that dispatch selection and offline tuning may compare: target, ordered external
    ABI, compiler arguments, logical effects, strategy, and concrete entry-point artifacts. Graph
    temporaries, dependencies, and derived scalars remain graph-owned schedule details."
-  (:require [raster.compiler.ir.kernel-abi :as kabi]
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-graph :as kgraph]))
 
@@ -76,7 +77,9 @@
 (defn- cast-runtime-scalar
   [dtype value]
   (case dtype
-    :int (int value)
+    :int (if (integer? value)
+           (Math/toIntExact (long value))
+           (int value))
     :long (long value)
     :float (float value)
     :double (double value)
@@ -97,11 +100,13 @@
             (if (= :scalar (:kind slot))
               (if (and (map? value) (contains? value :type) (contains? value :value))
                 (do
-                  (when-not (= (:kernel-dtype slot) (:type value))
-                    (throw (ex-info "kernel executable scalar argument has the wrong ABI dtype"
-                                    {:slot slot :expected (:kernel-dtype slot)
+                  (when-not (= (dtype/canon (:dtype slot))
+                               (dtype/canon (:type value)))
+                    (throw (ex-info "kernel executable scalar argument has the wrong logical ABI dtype"
+                                    {:slot slot :expected (:dtype slot)
                                      :actual (:type value) :value value})))
-                  (update value :value #(cast-runtime-scalar (:kernel-dtype slot) %)))
+                  {:type (:kernel-dtype slot)
+                   :value (cast-runtime-scalar (:kernel-dtype slot) (:value value))})
                 {:type (:kernel-dtype slot)
                  :value (cast-runtime-scalar (:kernel-dtype slot) value)})
               value))

--- a/src/raster/compiler/ir/link_plan.clj
+++ b/src/raster/compiler/ir/link_plan.clj
@@ -845,8 +845,22 @@
       (program-value-node! nodes values id compiler-value value-id))))
 
 (defn- program-graph-fact
-  [nodes values instance-id step-id phase graph buffers scalar-values]
+  [nodes values instance-id step-id phase graph buffers program-scalars scalar-values]
   (let [graph (kgraph/validate! graph)
+        extent-values
+        (into {}
+              (keep (fn [[compiler-value value-id]]
+                      (let [node (program-value-node!
+                                  nodes values instance-id compiler-value value-id)
+                            shape (get-in node [:view :shape])]
+                        (when (seq shape)
+                          [(list 'extent compiler-value) (first shape)]))))
+              buffers)
+        ;; A graph ABI contains only scalars consumed by that kernel. Buffer shapes may also name
+        ;; an earlier, program-wide shape value which the kernel does not otherwise consume. Keep
+        ;; those certified facts available for range validation; kernel-local narrowed values win
+        ;; when the same logical scalar is present in both maps.
+        scalar-values (merge extent-values program-scalars scalar-values)
         external
         (vals
          (reduce (fn [by-id buffer]
@@ -894,14 +908,16 @@
           (program-call/emitted-equation-call? step)
           [(program-graph-fact nodes values id step-index
                                (get-in step [:equation :id])
-                               (:graph step) (:buffers step) (:scalar-values step))]
+                               (:graph step) (:buffers step)
+                               (:scalar-values call) (:scalar-values step))]
           (loop-call/structured-loop-call? step)
           (mapv (fn [iteration]
                   (let [{:keys [buffers scalar-values]}
                         (loop-call/iteration-binding step iteration)]
                     (program-graph-fact nodes values id [step-index iteration]
                                         :structured-loop-iteration
-                                        (:graph step) buffers scalar-values)))
+                                        (:graph step) buffers
+                                        (:scalar-values call) scalar-values)))
                 (range (min 3 (:trip-count step))))))
       (map-indexed vector (:steps call))))))
 

--- a/src/raster/compiler/ir/segop.clj
+++ b/src/raster/compiler/ir/segop.clj
@@ -178,7 +178,14 @@
       (set/difference
        (reduce set/union #{} (map util/free-syms expressions))
        arrays axis-indices))
-    (or (:scalars operation) #{})))
+    (let [space (:space operation)
+          axes (into #{(:flat-idx space)} (map :name) (:dims space))
+          arrays (set/union (operation-inputs operation) (operation-outputs operation))
+          extent-expressions (cond-> (mapv :bound (:dims space))
+                               (:extent operation) (conj (:extent operation)))
+          extent-scalars (reduce set/union #{} (map util/free-syms extent-expressions))]
+      (set/union (or (:scalars operation) #{})
+                 (set/difference extent-scalars arrays axes)))))
 
 (defn segop-grid
   "Get the KernelGrid from a SegOp."

--- a/src/raster/compiler/passes/parallel/structured_control_route.clj
+++ b/src/raster/compiler/passes/parallel/structured_control_route.clj
@@ -6,7 +6,10 @@
    algorithms. Scheduling replaces the equation's typed control operation with one checked
    ScheduledStructuredLoop; it does not reconstruct or recognize a source-shaped compound loop."
   (:require [clojure.set :as set]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
+            [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.invocation-plan :as invocation]
             [raster.compiler.ir.parallel-program :as program]
             [raster.compiler.ir.segop :as segop]
@@ -18,7 +21,8 @@
             [raster.compiler.passes.parallel.structured-control-lower :as lower]
             [raster.compiler.passes.parallel.typed-soac-frontend :as typed-frontend]
             [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]
-            [raster.compiler.passes.parallel.typed-soac-route :as typed-route]))
+            [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
+            [raster.compiler.passes.scalar.effects :as effects]))
 
 (defn- ordered-distinct
   [values]
@@ -110,13 +114,251 @@
     (boolean (validate-scheduled-program! parallel-program))
     (catch clojure.lang.ExceptionInfo _ false)))
 
+(defn- declared-parameter-value
+  [program-values array-types scalar-types parameter]
+  (let [retained (get program-values parameter)]
+    (cond
+      (contains? array-types parameter)
+      ;; The analyzed algorithm may retain `(unknown-dimension p)` because shape is deliberately
+      ;; absent until invocation. The public flat-array boundary has a stronger fact: its one
+      ;; dimension is the extent of that exact argument.
+      (av/tensor {:dtype (get array-types parameter)
+                  :shape [(list 'extent parameter)]
+                  :representation (or (:representation retained) {:kind :plain})
+                  :memory-space (:memory-space retained)
+                  :placement (:placement retained)
+                  :sharding (:sharding retained)
+                  :ownership (:ownership retained)
+                  :effects (or (:effects retained) #{})
+                  :attributes (or (:attributes retained) {})})
+
+      (contains? scalar-types parameter)
+      (or retained (av/tensor {:dtype (get scalar-types parameter) :shape []}))
+
+      retained retained
+
+      :else
+      (fail! :structured-control-public-value
+             "public parameter has no retained or declared AbstractValue"
+             {:parameter parameter :available (set (keys program-values))}))))
+
+(defn- shape-projection-source
+  [expression]
+  (loop [expression expression]
+    (if (and (seq? expression)
+             (descriptor/cast-op? (descriptor/semantic-op expression))
+             (= 1 (count (descriptor/call-args expression))))
+      (recur (first (descriptor/call-args expression)))
+      (when (and (seq? expression)
+                 (descriptor/alength-op? (descriptor/semantic-op expression))
+                 (= 1 (count (descriptor/call-args expression)))
+                 (symbol? (first (descriptor/call-args expression))))
+        (first (descriptor/call-args expression))))))
+
+(defn- scalar-value?
+  [value]
+  (and (= :tensor (:kind value)) (empty? (:shape value))))
+
+(defn- dimension-expression
+  [dimension]
+  (if (and (seq? dimension) (= 'value (first dimension)) (= 2 (count dimension)))
+    (second dimension)
+    dimension))
+
+(defn- host-computable-dimension?
+  [program-values dimension]
+  (let [dimension (dimension-expression dimension)
+        references (util/free-syms dimension)]
+    (or (integer? dimension)
+        (and (symbol? dimension) (scalar-value? (get program-values dimension)))
+        (and (seq? dimension)
+             (= :pure (effects/analyze-effect dimension))
+             (every? #(scalar-value? (get program-values %)) references)))))
+
+(defn- certified-shape-dimension
+  [program-values source]
+  (let [shape (:shape (get program-values source))
+        dimension (when (= 1 (count shape)) (first shape))]
+    (when (and dimension (host-computable-dimension? program-values dimension))
+      (dimension-expression dimension))))
+
+(defn- canonicalize-shape-projection
+  [program-values public-inputs symbol expression]
+  (let [source (shape-projection-source expression)
+        dimension (when (and source (not (contains? public-inputs source)))
+                    (certified-shape-dimension program-values source))]
+    (if-not dimension
+      expression
+      (let [result-dtype (:dtype (get program-values symbol))
+            dimension-dtype (when (symbol? dimension)
+                              (:dtype (get program-values dimension)))]
+        (if (or (nil? dimension-dtype) (= result-dtype dimension-dtype))
+          dimension
+          (list (dtype/scalar-tag-for-dtype result-dtype) dimension))))))
+
+(defn- host-shape-equation?
+  [program-values program-inputs program-outputs equation]
+  (let [algorithm (:algorithm equation)]
+    (when (and (soac/program-form? algorithm)
+               (empty? (:effects equation))
+               (= 1 (count (:results equation)))
+               (not-any? (set (:results equation)) program-outputs)
+               (= 1 (count (soac/equations algorithm))))
+      (let [algorithm-equation (first (soac/equations algorithm))
+            {:keys [kind captures lambda]} (soac/operation-parts algorithm-equation)
+            {:keys [parameters locals body-results]} (soac/lambda-parts lambda)
+            expression (when (and (= 'scalar kind) (empty? locals)
+                                  (= 1 (count body-results)))
+                         (util/subst-syms (zipmap parameters captures)
+                                          (first body-results)))
+            source (shape-projection-source expression)]
+        (and source
+             (or (contains? program-inputs source)
+                 (certified-shape-dimension program-values source)))))))
+
+(defn- hoist-host-shape-equations
+  [parallel-program]
+  (let [program-values (:values parallel-program)
+        program-inputs (set (:inputs parallel-program))
+        program-outputs (:outputs parallel-program)
+        [hoisted retained] ((juxt filter remove)
+                            #(host-shape-equation? program-values program-inputs program-outputs %)
+                            (:equations parallel-program))
+        hoisted (vec hoisted)
+        retained (vec retained)]
+    (if (empty? hoisted)
+      parallel-program
+      (let [required (set (program/infer-inputs retained))
+            hoisted-results (vec (mapcat :results hoisted))
+            inputs (vec (distinct (concat (:inputs parallel-program)
+                                          (filter required hoisted-results))))]
+        (-> parallel-program
+            (assoc :equations retained
+                   :inputs inputs
+                   :effects (reduce set/union #{} (map :effects retained)))
+            (update :attributes assoc
+                    :invocation-shape-equations (count hoisted)))))))
+
+(defn- required-prefix-symbols
+  [pairs roots]
+  (let [definitions (into {} (map (fn [[symbol expression]] [symbol expression])) pairs)
+        available (set (keys definitions))]
+    (loop [required (set/intersection available (set roots))]
+      (let [dependencies (->> required
+                              (mapcat #(util/free-syms (get definitions %)))
+                              set
+                              (set/intersection available))
+            required' (set/union required dependencies)]
+        (if (= required required') required (recur required'))))))
+
+(defn- invocation-prefix
+  [parallel-program public-parameters]
+  (let [source (:source parallel-program)]
+    (when-not (and (seq? source) (contains? #{'let 'let*} (first source)))
+      (fail! :structured-control-invocation-source
+             "an analyzed TypedSOAC program requires a flat retained host source boundary"
+             {:source source}))
+    (let [program-values (:values parallel-program)
+          public-inputs (set public-parameters)
+          source-pairs (mapv (fn [[symbol expression]]
+                               [symbol (canonicalize-shape-projection
+                                        program-values public-inputs symbol expression)])
+                             (partition 2 (second source)))
+          equation-sites (into #{} (keep (fn [equation]
+                                           (when (= :binding (first (:site equation)))
+                                             (second (:site equation)))))
+                               (:equations parallel-program))
+          candidates (filterv (fn [[symbol _]]
+                                (not (contains? equation-sites symbol)))
+                              source-pairs)
+          roots (set/difference (set (:inputs parallel-program))
+                                (set public-parameters))
+          required (required-prefix-symbols candidates roots)
+          bindings (filterv (comp required first) candidates)
+          produced (set (map first bindings))
+          missing (set/difference roots produced)]
+      (when (seq missing)
+        (fail! :structured-control-invocation-prefix
+               "internal TypedSOAC inputs are not public parameters or host-prefix values"
+               {:inputs missing :public-parameters (set public-parameters)
+                :available produced}))
+      bindings)))
+
+(defn- normalize-public-contracts
+  [parallel-program parameter-values]
+  (let [normalize-values (fn [values]
+                           (reduce-kv (fn [values id value]
+                                        (if (and (contains? values id)
+                                                 (some (fn [dimension]
+                                                         (and (seq? dimension)
+                                                              (= 'unknown-dimension
+                                                                 (first dimension))))
+                                                       (:shape (get values id))))
+                                          (assoc values id value)
+                                          values))
+                                      values parameter-values))]
+    (update parallel-program :values normalize-values)))
+
+(defn promote-soac-program
+  "Promote one analyzed, loop-free TypedSOAC ParallelProgram into the common typed program union.
+
+   The numerical equations are unchanged. This pass adds only the public invocation contract:
+   direct parameters map by identity, while the transitive non-equation host prefix becomes typed
+   ShapeProjection/ScalarCompute/allocation steps. Structured loops and loop-free algorithms can
+   therefore share scheduling, emission, ProgramCall, LinkPlan, and runtime lowering."
+  [parallel-program {:keys [public-parameters active-params array-types scalar-types]}]
+  (when-not (= :typed-soac (:dialect parallel-program))
+    (fail! :structured-control-soac-promotion
+           "loop-free promotion requires an analyzed :typed-soac ParallelProgram"
+           {:dialect (:dialect parallel-program)}))
+  (let [parallel-program (hoist-host-shape-equations parallel-program)
+        public-parameters (vec (or public-parameters active-params))
+        _ (when-not (seq public-parameters)
+            (fail! :structured-control-public-parameters
+                   "loop-free equation-first promotion requires ordered public parameters" {}))
+        retained-values (:values parallel-program)
+        parameter-values (into {} (map (fn [parameter]
+                                         [parameter
+                                          (declared-parameter-value
+                                           retained-values array-types scalar-types parameter)]))
+                               public-parameters)
+        parallel-program (normalize-public-contracts parallel-program parameter-values)
+        program-values (:values parallel-program)
+        prefix (invocation-prefix parallel-program public-parameters)
+        binding-values (into {} (map (fn [[symbol expression]]
+                                       (let [value (get program-values symbol)]
+                                         (when-not value
+                                           (fail! :structured-control-prefix-value
+                                                  "host-prefix binding has no retained AbstractValue"
+                                                  {:symbol symbol :expression expression}))
+                                         [symbol value]))
+                                     prefix))
+        promoted (assoc parallel-program :dialect :typed-parallel)
+        plan (invocation/from-prefix
+              {:id [:program-invocation (mapv :id (:equations parallel-program))]
+               :parameters public-parameters
+               :parameter-values parameter-values
+               :bindings prefix
+               :binding-values binding-values
+               :program-values program-values
+               :program-inputs (:inputs parallel-program)
+               :program-outputs (:outputs parallel-program)
+               :attributes {:source-dialect :closed-clojure
+                            :algorithm-dialect :typed-soac
+                            :target-dialect :typed-invocation}})]
+    (-> promoted
+        (update :attributes assoc
+                :host-control :typed-invocation
+                :invocation-plan (invocation/validate-against! plan promoted))
+        validate-typed-program!)))
+
 (defn- merge-values
   [left right]
   (reduce-kv
    (fn [values id value]
      (if-let [prior (get values id)]
-       (if (= prior value)
-         values
+       (if-let [refined (av/merge-refinement prior value)]
+         (assoc values id refined)
          (throw (ex-info "mixed typed algorithms disagree on one AbstractValue"
                          {:reason :structured-control-value-conflict
                           :id id :first prior :second value})))

--- a/src/raster/gpu/link.clj
+++ b/src/raster/gpu/link.clj
@@ -185,14 +185,23 @@
               (parallel-program/prepare-with!
                (:call instance)
                {:bind! (fn [key graph buffers scalars]
-                         (gpu/bind-kernel-graph!
-                          session [::program-graph execution-id key] graph
-                          (into {}
-                                (map (fn [[compiler-value value-id]]
-                                       [compiler-value
-                                        (resident-link-value plan node-views value-id)]))
-                                buffers)
-                          scalars {:profile? profile?}))
+                         (let [resident-buffers
+                               (into {}
+                                     (map (fn [[compiler-value value-id]]
+                                            [compiler-value
+                                             (resident-link-value plan node-views value-id)]))
+                                     buffers)
+                               extent-scalars
+                               (into {}
+                                     (keep (fn [[compiler-value resident]]
+                                             (when-let [extent (first (get-in resident [:view :shape]))]
+                                               [(list 'extent compiler-value)
+                                                {:type :long :value extent}])))
+                                     resident-buffers)]
+                           (gpu/bind-kernel-graph!
+                            session [::program-graph execution-id key] graph
+                            resident-buffers (merge extent-scalars scalars)
+                            {:profile? profile?})))
                 :run! #(gpu/run-kernel-graph! session %)
                 :release! #(gpu/release-kernel-graph! session %)}))
              (do

--- a/src/raster/gpu/parallel_program.clj
+++ b/src/raster/gpu/parallel_program.clj
@@ -54,27 +54,37 @@
 
 (defn- preparation-plan
   [call execution-id]
-  (reduce
-   (fn [{:keys [entries step-keys] :as plan} [step-index step]]
-     (cond
-       (program-call/evaluated-host-equation? step)
-       plan
+  (let [program-scalars (:scalar-values call)
+        plan
+        (reduce
+         (fn [{:keys [entries step-keys] :as plan} [step-index step]]
+           (cond
+             (program-call/evaluated-host-equation? step)
+             plan
 
-       (program-call/emitted-equation-call? step)
-       (let [key [:parallel-program execution-id step-index]]
-         {:entries (conj entries
-                         {:key key :graph (:graph step)
-                          :buffers (:buffers step)
-                          :scalar-values (:scalar-values step)})
-          :step-keys (assoc step-keys step-index key)})
+             (program-call/emitted-equation-call? step)
+             (let [key [:parallel-program execution-id step-index]]
+               {:entries (conj entries
+                               {:key key :graph (:graph step)
+                                :buffers (:buffers step)
+                                :scalar-values (:scalar-values step)})
+                :step-keys (assoc step-keys step-index key)})
 
-       (loop-call/structured-loop-call? step)
-       (let [{:keys [bindings] loop-entries :entries}
-             (loop-staging-plan step execution-id step-index)]
-         {:entries (into entries loop-entries)
-          :step-keys (assoc step-keys step-index bindings)})))
-   {:entries [] :step-keys {}}
-   (map-indexed vector (:steps call))))
+             (loop-call/structured-loop-call? step)
+             (let [{:keys [bindings] loop-entries :entries}
+                   (loop-staging-plan step execution-id step-index)]
+               {:entries (into entries loop-entries)
+                :step-keys (assoc step-keys step-index bindings)})))
+         {:entries [] :step-keys {}}
+         (map-indexed vector (:steps call)))]
+    ;; Kernel-local maps deliberately contain only ABI scalars. Program-wide shape values still
+    ;; participate in graph buffer extents, including intermediate tensors consumed by a later
+    ;; equation, so retain them while staging. A local target-width cast remains authoritative.
+    (update plan :entries
+            (fn [entries]
+              (mapv #(update % :scalar-values
+                             (fn [local] (merge program-scalars local)))
+                    entries)))))
 
 (defn staging-plan
   "Return the bounded set of distinct graph bindings to prepare without contacting a driver.

--- a/test/raster/compiler/ir/kernel_dispatch_test.clj
+++ b/test/raster/compiler/ir/kernel_dispatch_test.clj
@@ -47,6 +47,19 @@
                :at-least :subgroup-score-reuse
                :otherwise :reference}}))
 
+(deftest logical-scalars-narrow-only-at-the-target-abi
+  (let [narrowed (assoc-in reference [:abi 2 :kernel-dtype] :int)]
+    (is (= {:type :int :value 64}
+           (last (kexec/typed-runtime-arguments
+                  narrowed [:x :out {:type :long :value 64}]))))
+    (is (thrown? ArithmeticException
+                 (kexec/typed-runtime-arguments
+                  narrowed [:x :out {:type :long :value (inc (long Integer/MAX_VALUE))}])))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"wrong logical ABI dtype"
+         (kexec/typed-runtime-arguments
+          narrowed [:x :out {:type :int :value 64}])))))
+
 (defn- staged-graph
   []
   (let [temporary 'dispatch-temporary
@@ -240,7 +253,7 @@
        (fn [_ function-name]
          (case function-name
            "kernel-dispatch-registry-entry" #(when (= % "staged-graph-dispatch")
-                                                graph-dispatch)
+                                               graph-dispatch)
            "device-buffer?" (constantly false)
            (throw (ex-info "unexpected runtime resolution" {:function function-name}))))
        #'gpu/with-gpu-session*

--- a/test/raster/compiler/passes/parallel/structured_control_route_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_route_test.clj
@@ -29,6 +29,7 @@
             [raster.gpu.core :as gpu]
             [raster.gpu.link :as gpu-link]
             [raster.gpu.parallel-program :as program-runtime]
+            [raster.nn :as nn]
             [raster.ode.pde :as pde]))
 
 (defn- evaluate-test-scalar-expression [expression operands]
@@ -456,6 +457,32 @@
           remapped (program-call/map-buffers call mapping)]
       (is (every? (set (vals mapping)) (vals (:outputs remapped)))
           "the rank-zero GPU reduction result remains resident storage during remapping"))))
+
+(deftest loop-free-mlp-shares-the-public-equation-first-vertical
+  (let [arguments [(double-array [1.0 0.0 0.0 1.0])
+                   (double-array [0.0 0.0])
+                   (double-array [0.5 0.5])
+                   (double-array [0.25])
+                   (double-array [1.0 -1.0])]
+        compilation (equation-first/compile #'nn/predict-fn {:target :ze:0})
+        semantic (:semantic compilation)
+        invocation-plan (get-in semantic [:attributes :invocation-plan])
+        linked-plan (equation-first/lower compilation arguments)
+        call (get-in linked-plan [:instances 0 :call])
+        staging (program-runtime/staging-plan call :loop-free-mlp)
+        first-layer-rows (first (get-in semantic [:values 'b1 :shape]))
+        host-equation (first (filter #(true? (get-in % [:attributes :host-only]))
+                                     (get-in compilation [:scheduled :equations])))]
+    (is (= :typed-parallel (:dialect semantic)))
+    (is (= :none (get-in compilation [:stats :fallback])))
+    (is (= 3 (get-in semantic [:attributes :invocation-shape-equations])))
+    (is (= 3 (count (filter invocation/shape-projection? (:steps invocation-plan)))))
+    (is (= [first-layer-rows] (:operands host-equation))
+        "the second layer consumes the certified intermediate extent, not a device alength")
+    (is (= 2 (count staging)))
+    (is (every? #(contains? (:scalar-values %) first-layer-rows) staging)
+        "program shape facts remain available when a later kernel has no ABI use for them")
+    (is (= 0 (get-in linked-plan [:attributes :driver-allocations])))))
 
 (defn- prepared-mixed-call
   ([trip-count]


### PR DESCRIPTION
Promote ordinary loop-free TypedSOAC programs into the same typed-parallel equation-first vertical used by structured control. Retain public invocation shape facts, safely separate logical and target scalar dtypes, and carry program-wide shape scalars through LinkPlan validation and runtime staging. Adds a hardware-free two-layer MLP regression, checked narrowing coverage, and was manually verified on Intel Arc with CPU and GPU both producing [0.75].