### PR TITLE
Lower GQA through public TypedSOAC

### DIFF
--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -1278,6 +1278,21 @@
               operation))))]
     (finalize-emitted-graph emitted :opencl-c scalar-types)))
 
+(defn- generate-fold-map-kernel-graph
+  [graph {:keys [scalar-types array-types]
+          :or {scalar-types {} array-types {}}}]
+  (let [array-types (graph-array-types graph array-types)
+        emitted
+        (kgraph/map-operations
+         graph
+         (fn [{:keys [operation]}]
+           (kart/certify-scheduled-operation
+            (generate-segfoldmap-kernel
+             operation :scalar-types scalar-types :array-types array-types
+             :kernel-name-prefix "graph_segmented_fold_map")
+            operation)))]
+    (finalize-emitted-graph emitted :opencl-c scalar-types)))
+
 (defn generate-kernel-graph
   "Target-lower one scheduled KernelGraph through the backend's single graph-emission boundary.
 
@@ -1300,6 +1315,11 @@
            (every? #(instance? raster.compiler.ir.segop.SegRed (:operation %))
                    (:nodes graph)))
       (generate-reduction-kernel-graph graph opts)
+
+      (and (seq (:nodes graph))
+           (every? #(instance? raster.compiler.ir.segop.SegFoldMap (:operation %))
+                   (:nodes graph)))
+      (generate-fold-map-kernel-graph graph opts)
 
       :else
       (throw (ex-info "OpenCL backend has no target lowering for scheduled KernelGraph"

--- a/src/raster/compiler/ir/invocation_link.clj
+++ b/src/raster/compiler/ir/invocation_link.clj
@@ -25,16 +25,29 @@
   (and (map? value) (keyword? (:type value)) (contains? value :value)))
 
 (defn- scalar-number
-  [scalars id]
-  (let [scalar (get scalars id)]
+  [scalars value-id storage-id]
+  (let [scalar (get scalars value-id)]
     (when-not (and (typed-scalar? scalar) (integer? (:value scalar)))
       (fail! :invocation-link-shape-scalar
              "program storage shape requires an integral typed scalar"
-             {:value id :scalar scalar :available (set (keys scalars))}))
+             {:storage-value storage-id :shape-value value-id
+              :scalar scalar :available (set (keys scalars))}))
     (long (:value scalar))))
 
+(defn- invocation-shape-scalars
+  [materialized]
+  (let [plan (:plan materialized)
+        values (:values materialized)]
+    (reduce (fn [environment {:keys [id symbol]}]
+              (let [value (get values id)]
+                (if (typed-scalar? value)
+                  (assoc environment symbol value)
+                  environment)))
+            {}
+            (concat (:parameters plan) (:steps plan)))))
+
 (defn- concrete-shape
-  [abstract scalars buffers storage]
+  [id abstract scalars buffers storage]
   (mapv
    (fn [dimension]
      (let [dimension (if (and (seq? dimension) (= 'value (first dimension))
@@ -45,7 +58,7 @@
            (cond
              (integer? dimension) (long dimension)
              (or (symbol? dimension) (vector? dimension) (keyword? dimension))
-             (scalar-number scalars dimension)
+             (scalar-number scalars dimension id)
              (and (seq? dimension) (= 'extent (first dimension)) (= 2 (count dimension)))
              (let [source-id (get buffers (second dimension))
                    source (get storage source-id)]
@@ -57,7 +70,7 @@
              :else
              (fail! :invocation-link-shape-expression
                     "program storage shape is not a canonical integer/value/extent expression"
-                    {:dimension dimension :shape (:shape abstract)}))]
+                    {:value-id id :dimension dimension :shape (:shape abstract)}))]
        (when (neg? resolved)
          (fail! :invocation-link-shape-negative
                 "program storage dimensions must be non-negative"
@@ -97,14 +110,39 @@
   (if-let [token (get-in state [:buffers compiler-value])]
     [state token]
     (let [token (storage-id invocation-id kind compiler-value)
-          shape (concrete-shape abstract scalars (:buffers state) (:storage state))]
+          shape (concrete-shape compiler-value abstract scalars
+                                (:buffers state) (:storage state))]
       [(-> state
            (assoc-in [:buffers compiler-value] token)
            (add-storage token compiler-value abstract shape nil :unspecified))
        token])))
 
+(defn- graph-buffer-access
+  [graph id]
+  (let [roles (into #{}
+                    (keep (fn [buffer] (when (= id (:id buffer)) (:role buffer))))
+                    (concat (:inputs graph) (:outputs graph)))]
+    (cond
+      (contains? roles :inout) :read-write
+      (and (contains? roles :input) (contains? roles :output)) :read-write
+      (contains? roles :input) :read
+      (contains? roles :output) :write
+      :else nil)))
+
+(defn- write-before-read-inputs
+  [parallel-program compiler-values]
+  (into #{}
+        (keep (fn [id]
+                (let [first-access
+                      (some (fn [equation]
+                              (when-let [operation (first (:operations equation))]
+                                (graph-buffer-access (:graph operation) id)))
+                            (:equations parallel-program))]
+                  (when (= :write first-access) id))))
+        compiler-values))
+
 (defn- add-materialized-inputs
-  [state materialized program-values]
+  [state materialized program-values overwrite-inputs]
   (reduce-kv
    (fn [state compiler-value buffer]
      (let [token (:id buffer)
@@ -113,14 +151,18 @@
          (fail! :invocation-link-program-input
                 "materialized buffer names a value absent from the emitted program"
                 {:compiler-value compiler-value}))
-       (when (= :zero (:initialization buffer))
+       (when (and (= :zero (:initialization buffer))
+                  (not (contains? overwrite-inputs compiler-value)))
          (fail! :invocation-link-zero-initializer
                 "zero-initialized program storage requires an explicit initializer schedule"
                 {:compiler-value compiler-value :storage token :shape (:shape buffer)}))
-       (-> state
-           (assoc-in [:buffers compiler-value] token)
-           (add-storage token compiler-value expected (:shape buffer)
-                        (:source buffer) (:initialization buffer)))))
+       (let [initialization (if (contains? overwrite-inputs compiler-value)
+                              :unspecified
+                              (:initialization buffer))]
+         (-> state
+             (assoc-in [:buffers compiler-value] token)
+             (add-storage token compiler-value expected (:shape buffer)
+                          (:source buffer) initialization)))))
    state (:program-buffers materialized)))
 
 (defn- lower-loop-storage
@@ -148,7 +190,8 @@
          (if in-place?
            state
            (let [scratch-token (storage-id invocation-id :loop-alternate output)
-                 shape (concrete-shape output-abstract scalars (:buffers state) (:storage state))]
+                 shape (concrete-shape output output-abstract scalars
+                                       (:buffers state) (:storage state))]
              (-> state
                  (assoc-in [:loop-scratch output] scratch-token)
                  (add-storage scratch-token output output-abstract shape nil :unspecified))))))
@@ -194,12 +237,20 @@
                    {:invocation-inputs (:program-inputs invocation-plan)
                     :program-inputs (:inputs parallel-program)}))
         scalars (:program-scalars materialized)
+        shape-scalars (merge (invocation-shape-scalars materialized) scalars)
+        overwrite-inputs (write-before-read-inputs parallel-program
+                                                   (keys (:program-buffers materialized)))
         initial (add-materialized-inputs {:buffers {} :loop-scratch {} :storage {}}
-                                         materialized (:values parallel-program))
+                                         materialized (:values parallel-program)
+                                         overwrite-inputs)
         realized (reduce #(lower-equation-storage %1 invocation-id %2
-                                                  (:values parallel-program) scalars)
+                                                  (:values parallel-program) shape-scalars)
                          initial (:equations parallel-program))
-        call (program-call/make parallel-program (:buffers realized) scalars
+        call-scalars (select-keys shape-scalars (keys (:values parallel-program)))
+        ;; Shape-only invocation scalars are part of the physical program contract even when no
+        ;; kernel ABI consumes them. Retain them in the call so logical N-D values can be proved
+        ;; element-equivalent to flattened result storage at the LinkPlan boundary.
+        call (program-call/make parallel-program (:buffers realized) call-scalars
                                 (:loop-scratch realized) evaluate-host)
         resident-outputs (into [] (remove (comp typed-scalar? val)) (:outputs call))
         output-tokens (set (map val resident-outputs))

--- a/src/raster/compiler/ir/invocation_plan.clj
+++ b/src/raster/compiler/ir/invocation_plan.clj
@@ -150,11 +150,15 @@
                  {:step id :region (:region step)})))
 
       (buffer-allocation? step)
-      (when-not (and (buffer-value? value)
-                     (contains? #{:zero :unspecified} (:initialization step)))
-        (fail! :invocation-buffer-allocation
-               "buffer allocation must retain a recognized fresh-allocation contract"
-               {:step id :initialization (:initialization step) :value value}))
+      (let [shape-symbols (into #{} (mapcat util/free-syms) (:shape value))]
+        (when-not (and (buffer-value? value)
+                       (contains? #{:zero :unspecified} (:initialization step))
+                       (= shape-symbols (set (map :symbol (:operands step)))))
+          (fail! :invocation-buffer-allocation
+                 "buffer allocation operands must exactly close its typed shape contract"
+                 {:step id :initialization (:initialization step) :value value
+                  :shape-symbols shape-symbols
+                  :operands (mapv :symbol (:operands step))})))
 
       (buffer-clone? step)
       (let [source-value (get values (:source step))]
@@ -263,19 +267,30 @@
                (symbol? (first (descriptor/call-args expression))))
       (first (descriptor/call-args expression)))))
 
+(defn- allocation-operands
+  [value environment]
+  (->> (:shape value)
+       (mapcat #(referenced-operands % environment))
+       (reduce (fn [operands operand]
+                 (if (some #(= (:symbol %) (:symbol operand)) operands)
+                   operands
+                   (conj operands operand)))
+               [])))
+
 (defn- prefix-step
   [plan-id ordinal symbol expression value environment]
   (let [id (binding-id plan-id ordinal symbol)
-        operands (referenced-operands expression environment)
         operation (descriptor/semantic-op expression)
         initialization (descriptor/allocation-initialization operation)]
     (cond
       (shape-source expression)
-      (let [source-symbol (shape-source expression)]
+      (let [operands (referenced-operands expression environment)
+            source-symbol (shape-source expression)]
         (->ShapeProjection id symbol operands (get environment source-symbol) 0 value))
 
       (= :copy initialization)
-      (let [source-symbol (some-> expression descriptor/call-args first unwrap-casts)]
+      (let [operands (referenced-operands expression environment)
+            source-symbol (some-> expression descriptor/call-args first unwrap-casts)]
         (when-not (symbol? source-symbol)
           (fail! :invocation-clone-source
                  "copy allocation requires one lexical source value"
@@ -283,14 +298,17 @@
         (->BufferClone id symbol operands (get environment source-symbol) value))
 
       initialization
-      (->BufferAllocation id symbol operands initialization value)
+      (->BufferAllocation id symbol (allocation-operands value environment)
+                          initialization value)
 
       (symbol? expression)
-      (->ValueAlias id symbol operands (get environment expression) value)
+      (->ValueAlias id symbol (referenced-operands expression environment)
+                    (get environment expression) value)
 
       (scalar-value? value)
-      (->ScalarCompute id symbol operands
-                       (soac/lambda-form (mapv :symbol operands) [expression]) value)
+      (let [operands (referenced-operands expression environment)]
+        (->ScalarCompute id symbol operands
+                         (soac/lambda-form (mapv :symbol operands) [expression]) value))
 
       :else
       (fail! :invocation-prefix-unsupported

--- a/src/raster/compiler/ir/kernel_graph.clj
+++ b/src/raster/compiler/ir/kernel_graph.clj
@@ -294,8 +294,8 @@
         output-ids (set outputs)
         external-ids (set/union input-ids output-ids)
         operation-ids (reduce set/union #{}
-                              (map #(set/union (or (segop/segop-inputs %) #{})
-                                               (or (segop/segop-outputs %) #{}))
+                              (map #(set/union (set (or (segop/segop-inputs %) #{}))
+                                               (set (or (segop/segop-outputs %) #{})))
                                    segops))
         temporary-ids (set (keys temporaries))
         expected-temporaries (set/difference operation-ids external-ids)]
@@ -327,8 +327,8 @@
                              (ordered temporary-ids))
           nodes (loop [ops segops index 0 previous [] result []]
                   (if-let [op (first ops)]
-                    (let [ins (or (segop/segop-inputs op) #{})
-                          outs (or (segop/segop-outputs op) #{})
+                    (let [ins (set (or (segop/segop-inputs op) #{}))
+                          outs (set (or (segop/segop-outputs op) #{}))
                           uses (mapv #(operation-use ins outs %)
                                      (ordered (set/union ins outs)))
                           ;; A scheduled-node identity is not a SegOp identity. The position makes

--- a/src/raster/compiler/ir/link_plan.clj
+++ b/src/raster/compiler/ir/link_plan.clj
@@ -820,21 +820,60 @@
                        :leaves (:leaves link-value)})))
     (get nodes (get-in link-value [:leaves 0 :node]))))
 
+(defn- program-logical-elements
+  [nodes values call compiler-value abstract]
+  (let [scalar-values (:scalar-values call)
+        buffers (:buffers call)
+        resolve-dimension
+        (fn [dimension]
+          (cond
+            (and (seq? dimension) (= 'value (first dimension)) (= 2 (count dimension)))
+            (kgcall/resolve-integer scalar-values (second dimension))
+
+            (and (seq? dimension) (= 'extent (first dimension)) (= 2 (count dimension)))
+            (let [source-value (get buffers (second dimension) ::missing)]
+              (when (= ::missing source-value)
+                (throw (ex-info "logical program shape projects an unbound buffer extent"
+                                {:reason :program-link-shape-extent
+                                 :compiler-value compiler-value
+                                 :dimension dimension})))
+              (first (get-in (program-value-node! nodes values (:id call)
+                                                  (second dimension) source-value)
+                             [:view :shape])))
+
+            :else (kgcall/resolve-integer scalar-values dimension)))]
+    (try
+      (reduce (fn [elements dimension]
+                (Math/multiplyExact (long elements) (long (resolve-dimension dimension))))
+              1 (:shape abstract))
+      (catch Exception exception
+        (throw (ex-info "logical program buffer shape did not resolve at the LinkPlan boundary"
+                        {:reason :program-link-logical-shape
+                         :compiler-value compiler-value
+                         :shape (:shape abstract)}
+                        exception))))))
+
 (defn- validate-program-buffer-contracts!
   [nodes values {:keys [id call roles]}]
   (let [program-values (get-in call [:program :values])]
     (doseq [[compiler-value value-id] (:buffers call)]
       (let [expected (get program-values compiler-value)
             link-value (get values value-id)
-            node (program-value-node! nodes values id compiler-value value-id)]
+            node (program-value-node! nodes values id compiler-value value-id)
+            logical-elements (when expected
+                               (program-logical-elements nodes values call
+                                                         compiler-value expected))
+            physical-elements (shape-elements (get-in node [:view :shape]))]
         (when-not (and expected
-                       (= (count (:shape expected)) (count (get-in node [:view :shape])))
-                       (av/storage-contract-compatible? expected (:abstract link-value)))
+                       (av/storage-contract-compatible? expected (:abstract link-value))
+                       (= logical-elements physical-elements))
           (throw (ex-info "emitted program buffer differs from its logical LinkValue contract"
                           {:reason :program-link-value-contract :instance id
                            :compiler-value compiler-value :value value-id
                            :expected expected :actual (:abstract link-value)
-                           :physical-shape (get-in node [:view :shape])})))
+                           :logical-elements logical-elements
+                           :physical-shape (get-in node [:view :shape])
+                           :physical-elements physical-elements})))
         (when (and (= :constant (get roles compiler-value))
                    (not= :constant (:role node)))
           (throw (ex-info "a constant program binding requires a constant LinkValue"

--- a/src/raster/compiler/passes/parallel/structured_control_route.clj
+++ b/src/raster/compiler/passes/parallel/structured_control_route.clj
@@ -22,7 +22,8 @@
             [raster.compiler.passes.parallel.typed-soac-frontend :as typed-frontend]
             [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]
             [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
-            [raster.compiler.passes.scalar.effects :as effects]))
+            [raster.compiler.passes.scalar.effects :as effects]
+            [raster.compiler.passes.scalar.host-abstract-value :as host-av]))
 
 (defn- ordered-distinct
   [values]
@@ -196,13 +197,12 @@
           dimension
           (list (dtype/scalar-tag-for-dtype result-dtype) dimension))))))
 
-(defn- host-shape-equation?
-  [program-values program-inputs program-outputs equation]
+(defn- scalar-equation-expression
+  [equation]
   (let [algorithm (:algorithm equation)]
     (when (and (soac/program-form? algorithm)
                (empty? (:effects equation))
                (= 1 (count (:results equation)))
-               (not-any? (set (:results equation)) program-outputs)
                (= 1 (count (soac/equations algorithm))))
       (let [algorithm-equation (first (soac/equations algorithm))
             {:keys [kind captures lambda]} (soac/operation-parts algorithm-equation)
@@ -210,34 +210,44 @@
             expression (when (and (= 'scalar kind) (empty? locals)
                                   (= 1 (count body-results)))
                          (util/subst-syms (zipmap parameters captures)
-                                          (first body-results)))
-            source (shape-projection-source expression)]
-        (and source
-             (or (contains? program-inputs source)
-                 (certified-shape-dimension program-values source)))))))
+                                          (first body-results)))]
+        expression))))
 
-(defn- hoist-host-shape-equations
+(defn- host-invocation-equation?
+  [available program-outputs equation]
+  (let [expression (scalar-equation-expression equation)]
+    (and expression
+         (not-any? (set (:results equation)) program-outputs)
+         (set/subset? (set (:operands equation)) available)
+         (or (shape-projection-source expression)
+             (= :pure (effects/analyze-effect expression))))))
+
+(defn- hoist-host-invocation-equations
   [parallel-program]
-  (let [program-values (:values parallel-program)
-        program-inputs (set (:inputs parallel-program))
-        program-outputs (:outputs parallel-program)
-        [hoisted retained] ((juxt filter remove)
-                            #(host-shape-equation? program-values program-inputs program-outputs %)
-                            (:equations parallel-program))
-        hoisted (vec hoisted)
-        retained (vec retained)]
+  (let [program-outputs (:outputs parallel-program)
+        {:keys [hoisted retained]}
+        (reduce (fn [{:keys [available] :as state} equation]
+                  (if (host-invocation-equation? available program-outputs equation)
+                    (-> state
+                        (update :hoisted conj equation)
+                        (update :available into (:results equation)))
+                    (update state :retained conj equation)))
+                {:available (set (:inputs parallel-program))
+                 :hoisted [] :retained []}
+                (:equations parallel-program))]
     (if (empty? hoisted)
       parallel-program
-      (let [required (set (program/infer-inputs retained))
-            hoisted-results (vec (mapcat :results hoisted))
-            inputs (vec (distinct (concat (:inputs parallel-program)
-                                          (filter required hoisted-results))))]
+      (let [inputs (program/infer-inputs retained)
+            shape-equations (count (filter (comp shape-projection-source
+                                                 scalar-equation-expression)
+                                           hoisted))]
         (-> parallel-program
             (assoc :equations retained
                    :inputs inputs
                    :effects (reduce set/union #{} (map :effects retained)))
             (update :attributes assoc
-                    :invocation-shape-equations (count hoisted)))))))
+                    :invocation-scalar-equations (count hoisted)
+                    :invocation-shape-equations shape-equations))))))
 
 (defn- required-prefix-symbols
   [pairs roots]
@@ -252,17 +262,18 @@
         (if (= required required') required (recur required'))))))
 
 (defn- invocation-prefix
-  [parallel-program public-parameters]
+  [parallel-program public-parameters prefix-values]
   (let [source (:source parallel-program)]
     (when-not (and (seq? source) (contains? #{'let 'let*} (first source)))
       (fail! :structured-control-invocation-source
              "an analyzed TypedSOAC program requires a flat retained host source boundary"
              {:source source}))
     (let [program-values (:values parallel-program)
+          prefix-values (merge prefix-values program-values)
           public-inputs (set public-parameters)
           source-pairs (mapv (fn [[symbol expression]]
                                [symbol (canonicalize-shape-projection
-                                        program-values public-inputs symbol expression)])
+                                        prefix-values public-inputs symbol expression)])
                              (partition 2 (second source)))
           equation-sites (into #{} (keep (fn [equation]
                                            (when (= :binding (first (:site equation)))
@@ -271,7 +282,12 @@
           candidates (filterv (fn [[symbol _]]
                                 (not (contains? equation-sites symbol)))
                               source-pairs)
-          roots (set/difference (set (:inputs parallel-program))
+          shape-roots
+          (into #{}
+                (comp (mapcat (comp #(mapcat util/free-syms %) :shape val))
+                      (filter #(scalar-value? (get prefix-values %))))
+                program-values)
+          roots (set/difference (set/union (set (:inputs parallel-program)) shape-roots)
                                 (set public-parameters))
           required (required-prefix-symbols candidates roots)
           bindings (filterv (comp required first) candidates)
@@ -306,12 +322,13 @@
    direct parameters map by identity, while the transitive non-equation host prefix becomes typed
    ShapeProjection/ScalarCompute/allocation steps. Structured loops and loop-free algorithms can
    therefore share scheduling, emission, ProgramCall, LinkPlan, and runtime lowering."
-  [parallel-program {:keys [public-parameters active-params array-types scalar-types]}]
+  [parallel-program {:keys [public-parameters active-params array-types scalar-types]
+                     :as options}]
   (when-not (= :typed-soac (:dialect parallel-program))
     (fail! :structured-control-soac-promotion
            "loop-free promotion requires an analyzed :typed-soac ParallelProgram"
            {:dialect (:dialect parallel-program)}))
-  (let [parallel-program (hoist-host-shape-equations parallel-program)
+  (let [parallel-program (hoist-host-invocation-equations parallel-program)
         public-parameters (vec (or public-parameters active-params))
         _ (when-not (seq public-parameters)
             (fail! :structured-control-public-parameters
@@ -324,15 +341,76 @@
                                public-parameters)
         parallel-program (normalize-public-contracts parallel-program parameter-values)
         program-values (:values parallel-program)
-        prefix (invocation-prefix parallel-program public-parameters)
-        binding-values (into {} (map (fn [[symbol expression]]
-                                       (let [value (get program-values symbol)]
-                                         (when-not value
-                                           (fail! :structured-control-prefix-value
-                                                  "host-prefix binding has no retained AbstractValue"
-                                                  {:symbol symbol :expression expression}))
-                                         [symbol value]))
-                                     prefix))
+        host-values
+        (:values
+         (host-av/analyze
+          (:source parallel-program)
+          (assoc options :values program-values
+                 :array-types array-types :scalar-types scalar-types)))
+        ;; Host relational analysis is authoritative only where it genuinely refines the typed
+        ;; program (not where it merely chooses a different symbolic spelling). This supplies flat
+        ;; physical allocation extents while preserving logical N-D result shapes.
+        program-values
+        (reduce-kv (fn [values symbol host-value]
+                     (if-let [program-value (get values symbol)]
+                       (if-let [refined (av/merge-refinement program-value host-value)]
+                         (assoc values symbol refined)
+                         values)
+                       values))
+                   program-values host-values)
+        ;; Symbols that occur only as logical/physical dimensions are still typed values at the
+        ;; public invocation boundary. Declare their retained host facts in the program value
+        ;; table so emitted calls can certify N-D logical shapes against flattened storage without
+        ;; inventing an untyped shape environment in the linker.
+        shape-symbols (into #{} (mapcat (comp #(mapcat util/free-syms %) :shape val))
+                            program-values)
+        shape-values (into {} (filter (fn [[symbol value]]
+                                        (and (contains? shape-symbols symbol)
+                                             (scalar-value? value))))
+                           host-values)
+        program-values (merge shape-values program-values)
+        parallel-program (assoc parallel-program :values program-values)
+        prefix (invocation-prefix parallel-program public-parameters host-values)
+        binding-values
+        (into {}
+              (map (fn [[symbol expression]]
+                     (let [program-value (get program-values symbol)
+                           host-value (get host-values symbol)
+                           value (cond
+                                   ;; An exact lexical alias keeps one runtime storage identity.
+                                   ;; Its program-side symbolic shape remains authoritative and
+                                   ;; materialization later proves both symbolic extents resolve to
+                                   ;; the same concrete view before binding.
+                                   (and program-value host-value (symbol? expression))
+                                   program-value
+
+                                   (and program-value host-value)
+                                   (or (av/merge-refinement program-value host-value)
+                                       (when (av/storage-contract-compatible?
+                                              program-value host-value)
+                                         host-value)
+                                       (fail! :structured-control-prefix-value-conflict
+                                              "host and typed program facts disagree on a prefix value"
+                                              {:symbol symbol :expression expression
+                                               :program-value program-value
+                                               :host-value host-value}))
+                                   program-value program-value
+                                   host-value host-value)]
+                       (when-not value
+                         (fail! :structured-control-prefix-value
+                                "host-prefix binding has no retained AbstractValue"
+                                {:symbol symbol :expression expression}))
+                       [symbol value])))
+              prefix)
+        program-values
+        (reduce-kv (fn [values symbol value]
+                     (if-let [prior (get values symbol)]
+                       (if-let [refined (av/merge-refinement prior value)]
+                         (assoc values symbol refined)
+                         values)
+                       values))
+                   program-values binding-values)
+        parallel-program (assoc parallel-program :values program-values)
         promoted (assoc parallel-program :dialect :typed-parallel)
         plan (invocation/from-prefix
               {:id [:program-invocation (mapv :id (:equations parallel-program))]

--- a/src/raster/compiler/passes/scalar/host_abstract_value.clj
+++ b/src/raster/compiler/passes/scalar/host_abstract_value.clj
@@ -59,13 +59,24 @@
              (descriptor/alloc-op? (descriptor/semantic-op expression)))
     (let [semantic-operation (descriptor/semantic-op expression)
           operation (operation-name expression)
-          length (first (descriptor/call-args expression))
+          arguments (descriptor/call-args expression)
           array-tag (or (get descriptor/alloc-sym->array-tag semantic-operation)
                         (get descriptor/alloc-sym->array-tag
                              (some-> operation symbol)))
-          allocation-dtype (dtype/dtype-for-array-tag array-tag)]
-      (when (and allocation-dtype length)
-        {:dtype allocation-dtype :extent length}))))
+          allocation-dtype (dtype/dtype-for-array-tag array-tag)
+          initialization (descriptor/allocation-initialization semantic-operation)]
+      (cond
+        (and allocation-dtype (= 1 (count arguments)))
+        {:dtype allocation-dtype :extent (first arguments)}
+
+        ;; Parametric allocators use the first argument only as a dtype exemplar. Their retained
+        ;; AbstractValue and final length are sufficient for host planning; no value dependency on
+        ;; the exemplar exists for :zero/:unspecified initialization.
+        (and (contains? #{:zero :unspecified} initialization)
+             (<= 2 (count arguments)))
+        {:source (first arguments) :extent (last arguments)}
+
+        :else nil))))
 
 (defn- canonical-extent
   [equalities extent]
@@ -117,6 +128,9 @@
 (defn- infer-value
   [state symbol expression default-dtype]
   (let [values (:values state)
+        retained-array-dtype
+        (or (some-> symbol types/sym-type-tag dtype/dtype-for-array-tag)
+            (some-> expression types/sym-type-tag dtype/dtype-for-array-tag))
         retained-scalar-dtype
         (or (some-> symbol types/sym-type-tag dtype/dtype-for-scalar-tag)
             (some-> expression types/sym-type-tag dtype/dtype-for-scalar-tag))
@@ -151,6 +165,7 @@
       alength-expression
       (let [state (assoc-in state [:values symbol]
                             (tensor (or cast-dtype
+                                        (get-in values [symbol :dtype])
                                         (dtype/dtype-for-scalar-tag 'int)) []))]
         (refine-array-extent state alength-array symbol))
 
@@ -164,10 +179,15 @@
 
       allocation
       (let [extent (or (shape-extent state (:extent allocation))
-                       (:extent allocation))]
-        (-> state
-            (retain-extent-equality (:extent allocation) extent)
-            (assoc-in [:values symbol] (tensor (:dtype allocation) [extent]))))
+                       (:extent allocation))
+            allocation-dtype (or (:dtype allocation)
+                                 (get-in values [(:source allocation) :dtype])
+                                 retained-array-dtype)]
+        (if allocation-dtype
+          (-> state
+              (retain-extent-equality (:extent allocation) extent)
+              (assoc-in [:values symbol] (tensor allocation-dtype [extent])))
+          state))
 
       (par/par-map-pure-form? expression)
       (let [{:keys [bound cast elem-type]} (par/extract-par-map-pure-info expression)
@@ -203,7 +223,10 @@
 
       (symbol? expression)
       (if-let [value (get values expression)]
-        (assoc-in state [:values symbol] value)
+        (cond-> (assoc-in state [:values symbol] value)
+          (and (= [] (:shape value))
+               (contains? #{:int :long} (dtype/canon (:dtype value))))
+          (assoc-in [:equalities expression] symbol))
         state)
 
       cast-dtype
@@ -241,12 +264,20 @@
         values (into {} (map (fn [[id value]] [id (normalize-value value)])) values)
         [_ bindings] source
         pairs (partition 2 bindings)]
-    (reduce (fn [state [symbol expression]]
-              (infer-value state symbol expression dtype))
-            {:values (merge seed-arrays seed-scalars values)
-             :equalities {}
-             :diagnostics []}
-            pairs)))
+    (let [analysis
+          (reduce (fn [state [symbol expression]]
+                    (infer-value state symbol expression dtype))
+                  {:values (merge seed-arrays seed-scalars values)
+                   :equalities {}
+                   :diagnostics []}
+                  pairs)]
+      (update analysis :values
+              (fn [values]
+                (into {}
+                      (map (fn [[id value]]
+                             [id (update value :shape
+                                         #(canonical-shape (:equalities analysis) %))]))
+                      values))))))
 
 (defn- zero-index?
   [expression]

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -34,14 +34,15 @@
               :fallback-reasons [] :declines {}}}
 
   :gqa-causal-mha-gpu
-  {:route {:backend :opencl :source-dialect :typed-soac :typed-validated true
-           :declines {}}
-   :fusion {:vertical 0 :horizontal 2 :iterations 3 :placements 0}
-   :lowering {:segops 7 :kernel-graphs 0 :structured-loops 0
-              :typed-reused 7 :typed-scalar-equations 12
-              :backend-reused 7 :backend-relowered 0 :fallback 0}
-   :emission {:kernel-count 7 :targets [:opencl-c] :strategies []
-              :fallback-reasons [] :declines {}}}
+  {:route {:semantic-dialect :typed-parallel
+           :scheduled-dialect :scheduled-parallel
+           :emitted-dialect :opencl-parallel
+           :fallback :none}
+   :lowering {:nodes 12 :values 12 :instances 1 :program-instances 1
+              :outputs 1 :driver-allocations 0}
+   :emission {:structured-loops-emitted 0
+              :typed-equations-emitted 7
+              :host-scalar-equations 0}}
 
   :heat-rhs-1d-jvm
   {:route {:backend :simd :source-dialect :typed-soac :typed-validated true

--- a/test/raster/compiler/compatibility_ledger_test.clj
+++ b/test/raster/compiler/compatibility_ledger_test.clj
@@ -71,8 +71,15 @@
                              :target-device target :dtype :float)
 
     :gqa-causal-mha-gpu
-    (pipeline/compile-report #'attention/gqa-causal-mha
-                             :target-device target :dtype :float)
+    (let [compilation (equation-first/compile
+                       #'attention/gqa-causal-mha {:target target :dtype :float})
+          plan (equation-first/lower
+                compilation
+                [(float-array [1 0 0 1 1 1 1 -1])
+                 (float-array [1 0 0 1])
+                 (float-array [1 2 3 4])
+                 1 2 2 1 2])]
+      (equation-first-signature compilation plan))
 
     :heat-rhs-1d-jvm
     (pipeline/compile-report #'pde/heat-rhs-1d! :dtype :double)
@@ -101,7 +108,7 @@
       (let [report (compile-workload id)
             actual (cond
                      (:declined report) report
-                     (= :heat-loss-rk4-gpu id) report
+                     (contains? #{:gqa-causal-mha-gpu :heat-loss-rk4-gpu} id) report
                      :else (signature report))]
         (is (= expected actual)
             (str "compiler compatibility changed for " id

--- a/test/raster/compiler/ir/kernel_graph_test.clj
+++ b/test/raster/compiler/ir/kernel_graph_test.clj
@@ -82,6 +82,17 @@
     (is (identical? (first (:inputs scheduled)) (first (:outputs scheduled))))
     (is (= :read-write (get-in scheduled [:nodes 0 :uses 0 :access])))))
 
+(deftest ordered-output-vectors-retain-write-access
+  (let [operation (segop/->SegFoldMap
+                   10 (segop/make-seg-space 'segment 'nsegments)
+                   'index 'width [] [0.0] #{'values} ['out] #{}
+                   (segop/->KernelGrid 1 32 0) [:float] :no-write-alias)
+        scheduled (graph/from-segops [operation]
+                                     {:inputs #{'values} :outputs #{'out} :dtype :float})]
+    (is (= :write (->> scheduled :nodes first :uses
+                       (filter #(= 'out (:buffer %))) first :access))
+        "ordered tuple outputs are value collections, not associative-set indices")))
+
 (deftest target-emission-cannot-change-the-scheduled-dataflow-contract
   (let [operation (segop/->SegMap
                    9 (segop/make-seg-space 'i 'n) (segop/->SegLevel :thread :virtual)

--- a/test/raster/compiler/passes/parallel/structured_control_route_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_route_test.clj
@@ -470,15 +470,15 @@
         linked-plan (equation-first/lower compilation arguments)
         call (get-in linked-plan [:instances 0 :call])
         staging (program-runtime/staging-plan call :loop-free-mlp)
-        first-layer-rows (first (get-in semantic [:values 'b1 :shape]))
-        host-equation (first (filter #(true? (get-in % [:attributes :host-only]))
-                                     (get-in compilation [:scheduled :equations])))]
+        first-layer-rows (first (get-in semantic [:values 'b1 :shape]))]
     (is (= :typed-parallel (:dialect semantic)))
     (is (= :none (get-in compilation [:stats :fallback])))
     (is (= 3 (get-in semantic [:attributes :invocation-shape-equations])))
+    (is (= 4 (get-in semantic [:attributes :invocation-scalar-equations])))
     (is (= 3 (count (filter invocation/shape-projection? (:steps invocation-plan)))))
-    (is (= [first-layer-rows] (:operands host-equation))
-        "the second layer consumes the certified intermediate extent, not a device alength")
+    (is (= 2 (count (get-in compilation [:scheduled :equations])))
+        "pure host scalar/shape equations belong to the typed invocation plan")
+    (is (= 0 (get-in compilation [:stats :emission :host-scalar-equations])))
     (is (= 2 (count staging)))
     (is (every? #(contains? (:scalar-values %) first-layer-rows) staging)
         "program shape facts remain available when a later kernel has no ABI use for them")
@@ -596,7 +596,7 @@
     (is (= #{:state} (set (vals (link/instance-roles plan instance)))))
     (is (every? #(= 1 (count (:leaves %))) (vals (:values plan))))
     (is (false? (get-in remapped [:attributes :source-inspected])))
-    (is (= :program-link-graph-range
+    (is (= :program-link-value-contract
            (reason-of
             #(link/make
               {:id :undersized-rk4 :target :ocl:0

--- a/test/raster/compiler/passes/scalar/host_abstract_value_test.clj
+++ b/test/raster/compiler/passes/scalar/host_abstract_value_test.clj
@@ -115,6 +115,19 @@
     (is (= (select-keys external [:dtype :shape :logical-layout :representation])
            (select-keys copy [:dtype :shape :logical-layout :representation])))))
 
+(deftest parametric-allocation-uses-its-exemplar-dtype-and-explicit-extent
+  (let [input (av/tensor {:dtype :float :shape ['m] :representation {:kind :plain}})
+        allocation (with-meta
+                     '(.invk raster.arrays/zeros-like_m_floats_long-impl input n)
+                     {:raster.op/original 'raster.arrays/zeros-like})
+        analysis
+        (host-av/analyze
+         (list 'let* ['canonical-n 'n 'out allocation] 'out)
+         {:values {'input input}
+          :scalar-types {'n :long}})]
+    (is (= {:dtype :float :shape ['canonical-n]}
+           (select-keys (get-in analysis [:values 'out]) [:dtype :shape])))))
+
 (deftest malformed-input-contracts-fail-loud
   (testing "authoritative values must be AbstractValues"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"expected an AbstractValue"


### PR DESCRIPTION
Routes the real gqa-causal-mha workload through Raster’s public equation-first TypedSOAC vertical with no legacy fallback and no driver allocations.

Compiler changes:
- Hoist pure invocation scalar/shape equations into the typed invocation contract.
- Retain shape-only typed values needed to prove logical N-D tensors against flat physical storage.
- Model parametric allocation extents without false data dependencies.
- Preserve ordered SegFoldMap write roles and emit its verified KernelBody as a KernelGraph.
- Skip zero materialization only when the first graph access is a complete write.
- Validate logical/physical element equivalence at the LinkPlan boundary.

Evidence: public GQA has 7 typed/emitted equations, 12 LinkNodes/LinkValues, one ProgramLinkInstance, one output, zero driver allocations, and fallback none. Focused suite: 42 tests, 219 assertions, zero failures/errors. The compatibility ledger now compiles and lowers GQA through raster.compiler.equation-first. The full matrix is delegated to CircleCI.