### PR TITLE
Bind external TypedSOAC result storage

### DIFF
--- a/src/raster/compiler/ir/invocation_materialization.clj
+++ b/src/raster/compiler/ir/invocation_materialization.clj
@@ -2,9 +2,10 @@
   "Pure specialization of a typed InvocationPlan against ordered public arguments.
 
    The result contains typed scalars and logical buffer initializers for the exact internal
-   ParallelProgram input order. It allocates no driver objects and does not evaluate Clojure
-   source: scalar regions are delegated as closed TypedSOAC regions to an injected compiler or
-   interpreter. A later lowering realizes MaterializedBuffers as LinkValues/BufferViews."
+   ParallelProgram inputs plus explicitly bound caller-owned result storage. It allocates no driver
+   objects and does not evaluate Clojure source: scalar regions are delegated as closed TypedSOAC
+   regions to an injected compiler or interpreter. A later lowering realizes MaterializedBuffers
+   as LinkValues/BufferViews."
   (:require [clojure.set :as set]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.abstract-value :as av]
@@ -208,12 +209,19 @@
       (fail! :invocation-materialization-values
              "materialization must retain every public parameter and invocation SSA result"
              {:expected invocation-ids :actual (set (keys values))}))
-    (when-not (= (set (:program-inputs plan))
-                 (set (concat (keys program-buffers) (keys program-scalars))))
-      (fail! :invocation-materialization-inputs
-             "materialized bindings must partition the exact ParallelProgram inputs"
-             {:expected (:program-inputs plan)
-              :buffers (keys program-buffers) :scalars (keys program-scalars)}))
+    (let [storage-values (set (map :program-value (:storage-bindings plan)))
+          materialized-values (set/union (set (:program-inputs plan)) storage-values)]
+      (when-not (= materialized-values
+                   (set (concat (keys program-buffers) (keys program-scalars))))
+        (fail! :invocation-materialization-inputs
+               "materialized bindings must partition logical inputs and external result storage"
+               {:expected materialized-values
+                :buffers (keys program-buffers) :scalars (keys program-scalars)}))
+      (when-let [scalar-storage (seq (set/intersection storage-values
+                                                       (set (keys program-scalars))))]
+        (fail! :invocation-materialization-storage-kind
+               "external result storage cannot materialize as scalar values"
+               {:values (set scalar-storage)})))
     (when (seq (set/intersection (set (keys program-buffers))
                                  (set (keys program-scalars))))
       (fail! :invocation-materialization-input-kind
@@ -227,7 +235,8 @@
                  {:program-value id :expected expected :actual (:shape buffer)}))))
     (doseq [[id scalar] program-scalars]
       (checked-scalar id (get-in plan [:values id]) scalar))
-    (doseq [{:keys [program-value invocation-value]} (:bindings plan)]
+    (doseq [{:keys [program-value invocation-value]}
+            (concat (:bindings plan) (:storage-bindings plan))]
       (when-not (= (get values invocation-value)
                    (or (get program-buffers program-value)
                        (get program-scalars program-value)))
@@ -332,7 +341,7 @@
           (into {}
                 (map (fn [{:keys [program-value invocation-value]}]
                        [program-value (get values invocation-value)]))
-                (:bindings plan))
+                (concat (:bindings plan) (:storage-bindings plan)))
           program-buffers (into {} (filter (comp materialized-buffer? val)) input-values)
           program-scalars (into {} (filter (comp typed-scalar? val)) input-values)]
       (validate!

--- a/src/raster/compiler/ir/invocation_plan.clj
+++ b/src/raster/compiler/ir/invocation_plan.clj
@@ -2,10 +2,11 @@
   "Typed semantic boundary from public function arguments to an internal ParallelProgram.
 
    ParallelProgram inputs are compiler SSA values: they may include shape projections, narrowed
-   scalars, cloned state, and fresh scratch. InvocationPlan retains how ordered public parameters
-   produce those values without asking a runtime to inspect the original function body or infer
-   storage roles from names. Physical allocation, views, ownership, and transfers remain the job of
-   ResidentPlan/LinkPlan lowering."
+   scalars, cloned state, and fresh scratch. `storage-bindings` separately retain caller-owned
+   write-only destinations, which are physical result storage rather than numerical operands.
+   InvocationPlan records how ordered public parameters produce both boundaries without asking a
+   runtime to inspect the original function body or infer storage roles from names. Physical
+   allocation, views, ownership, and transfers remain the job of LinkPlan lowering."
   (:require [clojure.set :as set]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
@@ -20,7 +21,8 @@
 (defrecord BufferClone [id symbol operands source value])
 (defrecord ValueAlias [id symbol operands source value])
 (defrecord InvocationPlan
-           [id parameters steps bindings program-inputs program-outputs values attributes])
+           [id parameters steps bindings storage-bindings
+            program-inputs program-outputs values attributes])
 
 (defn- record-kind?
   [class-name value]
@@ -184,7 +186,8 @@
   [plan]
   (when-not (invocation-plan? plan)
     (fail! :invocation-plan-type "expected an InvocationPlan" {:actual (type plan)}))
-  (let [{:keys [id parameters steps bindings program-inputs program-outputs values attributes]} plan]
+  (let [{:keys [id parameters steps bindings storage-bindings
+                program-inputs program-outputs values attributes]} plan]
     (when (nil? id)
       (fail! :invocation-plan-id "invocation plan requires a stable identity" {}))
     (when-not (and (vector? parameters) (every? invocation-parameter? parameters)
@@ -193,7 +196,7 @@
       (fail! :invocation-parameters
              "public invocation parameters must have unique ordered IDs and symbols"
              {:parameters parameters}))
-    (when-not (and (vector? steps) (vector? bindings)
+    (when-not (and (vector? steps) (vector? bindings) (vector? storage-bindings)
                    (distinct-vector? program-inputs) (distinct-vector? program-outputs)
                    (map? values) (map? attributes))
       (fail! :invocation-plan-fields "invocation plan fields have invalid container types"
@@ -209,22 +212,34 @@
                               (validate-step! step values available))
                             (set (map :id parameters)) steps)
           expected-bindings (mapv :program-value bindings)
-          invocation-values (mapv :invocation-value bindings)]
+          storage-values (mapv :program-value storage-bindings)
+          invocation-values (mapv :invocation-value (concat bindings storage-bindings))]
       (when-not (= program-inputs expected-bindings)
         (fail! :invocation-program-input-order
                "invocation bindings must exactly follow the internal program input order"
                {:inputs program-inputs :bindings expected-bindings}))
+      (when-not (and (distinct-vector? storage-values)
+                     (empty? (set/intersection (set program-inputs) (set storage-values))))
+        (fail! :invocation-storage-bindings
+               "write-only storage bindings must be distinct from logical program inputs"
+               {:inputs program-inputs :storage storage-values}))
       (when-let [missing (seq (set/difference (set invocation-values) available))]
         (fail! :invocation-program-input-value
                "internal program input is not produced by the invocation prefix"
                {:values (set missing)}))
-      (doseq [{program-value :program-value invocation-value :invocation-value} bindings]
+      (doseq [{program-value :program-value invocation-value :invocation-value}
+              (concat bindings storage-bindings)]
         (when-not (compatible-value? (get values program-value) (get values invocation-value))
           (fail! :invocation-program-input-contract
                  "public materialization differs from the internal program value contract"
                  {:program-value program-value :invocation-value invocation-value
                   :program-contract (get values program-value)
                   :invocation-contract (get values invocation-value)})))
+      (doseq [{:keys [program-value]} storage-bindings]
+        (when-not (buffer-value? (get values program-value))
+          (fail! :invocation-storage-value
+                 "write-only storage binding must name a tensor buffer"
+                 {:program-value program-value :value (get values program-value)})))
       (doseq [output program-outputs]
         (when-not (contains? values output)
           (fail! :invocation-program-output
@@ -319,12 +334,12 @@
   "Build a typed invocation plan from a certified flat host prefix.
 
    `parameters` is the public function order. `parameter-values` describes those values before any
-   lexical shadowing; `binding-values` describes prefix results. `program-values`, inputs, and
-   outputs are the already validated internal ParallelProgram boundary. Stable SSA IDs keep a
+   lexical shadowing; `binding-values` describes prefix results. `program-values`, logical inputs,
+   write-only external storage, and outputs are the validated internal program boundary. Stable SSA IDs keep a
    narrowed binding such as `nsteps = (int nsteps)` distinct from its public long parameter."
   [{:keys [id parameters parameter-values bindings binding-values program-values
-           program-inputs program-outputs attributes]
-    :or {attributes {}}}]
+           program-inputs program-storage program-outputs attributes]
+    :or {program-storage [] attributes {}}}]
   (let [parameters (vec parameters)
         public
         (mapv (fn [ordinal symbol]
@@ -350,18 +365,19 @@
                        :environment (assoc environment symbol (:id step))})))
                 {:steps [] :values initial-values :environment initial-environment}
                 (map-indexed vector bindings))
-        input-bindings
-        (mapv (fn [program-value]
-                (if-let [invocation-value (get environment program-value)]
-                  {:program-value program-value :invocation-value invocation-value}
-                  (fail! :invocation-program-input
-                         "internal program input has no public or materialized producer"
-                         {:program-value program-value
-                          :available (set (keys environment))})))
-              program-inputs)
+        binding-for
+        (fn [kind program-value]
+          (if-let [invocation-value (get environment program-value)]
+            {:program-value program-value :invocation-value invocation-value}
+            (fail! kind
+                   "internal program value has no public or materialized producer"
+                   {:program-value program-value
+                    :available (set (keys environment))})))
+        input-bindings (mapv #(binding-for :invocation-program-input %) program-inputs)
+        storage-bindings (mapv #(binding-for :invocation-program-storage %) program-storage)
         values (merge program-values values)]
     (validate!
-     (->InvocationPlan id public steps input-bindings (vec program-inputs)
+     (->InvocationPlan id public steps input-bindings storage-bindings (vec program-inputs)
                        (vec program-outputs) values attributes))))
 
 (defn validate-against!
@@ -372,7 +388,9 @@
                    (= (:program-outputs plan) (:outputs parallel-program))
                    (every? (fn [id] (= (get (:values plan) id)
                                        (get (:values parallel-program) id)))
-                           (concat (:inputs parallel-program) (:outputs parallel-program))))
+                           (concat (:inputs parallel-program)
+                                   (:outputs parallel-program)
+                                   (map :program-value (:storage-bindings plan)))))
       (fail! :invocation-program-mismatch
              "invocation plan no longer matches its internal ParallelProgram boundary"
              {:plan-inputs (:program-inputs plan) :program-inputs (:inputs parallel-program)

--- a/src/raster/compiler/passes/parallel/structured_control_route.clj
+++ b/src/raster/compiler/passes/parallel/structured_control_route.clj
@@ -412,6 +412,15 @@
                    program-values binding-values)
         parallel-program (assoc parallel-program :values program-values)
         promoted (assoc parallel-program :dialect :typed-parallel)
+        public-set (set public-parameters)
+        external-result-storage
+        (->> (:equations parallel-program)
+             (mapcat #(get-in % [:attributes :result-storage]))
+             (map :destination)
+             (filter public-set)
+             (remove (set (:inputs parallel-program)))
+             distinct
+             vec)
         plan (invocation/from-prefix
               {:id [:program-invocation (mapv :id (:equations parallel-program))]
                :parameters public-parameters
@@ -420,6 +429,7 @@
                :binding-values binding-values
                :program-values program-values
                :program-inputs (:inputs parallel-program)
+               :program-storage external-result-storage
                :program-outputs (:outputs parallel-program)
                :attributes {:source-dialect :closed-clojure
                             :algorithm-dialect :typed-soac

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -1127,9 +1127,15 @@
         destination-results
         (into {}
               (mapcat (fn [description]
-                        (map (fn [result {:keys [destination]}]
-                               [destination result])
-                             (:results description) (:result-storage description))))
+                        (keep (fn [[result {:keys [destination host-return]}]]
+                                ;; Effect-only operations expose their destinations through the
+                                ;; reconstructed host form, not as numerical TypedSOAC results.
+                                ;; Only value-returning storage contracts may rewrite a terminal
+                                ;; physical destination to its logical SSA result.
+                                (when (= :buffer host-return)
+                                  [destination result]))
+                              (map vector (:results description)
+                                   (:result-storage description)))))
               descriptions)
         returned-destination-results
         (into #{} (keep destination-results) body-uses)]

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -242,19 +242,19 @@
           results (mapv #(effect-result-id id %) (range (count stores)))]
       (when (or pointwise? (= :unique conflict))
         (merge {:kind (if pointwise? :map :scatter)
-              :id id :sym symbol :index index :extent extent
-              :results results :locals locals :bodies values :casts (mapv :cast stores)
-              :write-indices write-indices :predicates predicates
-              :conflict (when-not pointwise? conflict)
-              :effect-only? true :host-binding symbol :elem-type elem-type
-              :result-storage
-              (mapv (fn [destination]
-                      {:destination destination
-                       :access (if (or (not pointwise?)
-                                       (contains? (:inputs io) destination))
-                                 :read-write :write)
-                       :host-return :effect})
-                    destinations)}
+                :id id :sym symbol :index index :extent extent
+                :results results :locals locals :bodies values :casts (mapv :cast stores)
+                :write-indices write-indices :predicates predicates
+                :conflict (when-not pointwise? conflict)
+                :effect-only? true :host-binding symbol :elem-type elem-type
+                :result-storage
+                (mapv (fn [destination]
+                        {:destination destination
+                         :access (if (or (not pointwise?)
+                                         (contains? (:inputs io) destination))
+                                   :read-write :write)
+                         :host-return :effect})
+                      destinations)}
                io)))))
 
 (defn- reducing-scatter-description
@@ -1118,10 +1118,25 @@
                                     (mapcat #(when (= :scalar (:kind %))
                                                (util/free-syms (:expr %)))
                                             descriptions)))
-        body-uses (set (mapcat util/free-syms body))]
+        body-uses (set (mapcat util/free-syms body))
+        ;; Destination-writing source forms return the destination buffer, while TypedSOAC names
+        ;; the fresh logical result produced by that write. Preserve the public return by
+        ;; projecting a returned physical destination to its corresponding logical SSA result.
+        ;; This is the same result-storage relation later consumed by scheduling and linking; no
+        ;; operation-specific knowledge is introduced here.
+        destination-results
+        (into {}
+              (mapcat (fn [description]
+                        (map (fn [result {:keys [destination]}]
+                               [destination result])
+                             (:results description) (:result-storage description))))
+              descriptions)
+        returned-destination-results
+        (into #{} (keep destination-results) body-uses)]
     (vec (sort-by pr-str
                   (set/union (set/difference terminal-operation-definitions operation-uses)
-                             (set/intersection all-definitions body-uses))))))
+                             (set/intersection all-definitions body-uses)
+                             returned-destination-results)))))
 
 (defn- selected-scalars
   [descriptions operation-equations outputs]
@@ -1294,7 +1309,7 @@
                                   (assoc-in [:scalar-dtypes (:sym description)] result-dtype)))
                             state)
                           (:map :scatter :stencil :reduce :segmented-reduce
-                           :product-reduce :segmented-fold-map :scan)
+                                :product-reduce :segmented-fold-map :scan)
                           (-> state
                               (update :equations conj
                                       (case (:kind description)

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -528,7 +528,11 @@
            :scalars (set/union scalars epilogue-scalar-ids)
            :result-transform result-transform
            :effect-only? true :host-binding symbol
-           :result-storage [{:destination out :access :write :host-return :effect}]})))
+           ;; Contract is effectful at the source spelling because it writes `out`, but its
+           ;; TypedSOAC equation denotes the mathematical output tensor. A terminal reference to
+           ;; that physical destination therefore returns the logical value; generic map-void
+           ;; destinations remain `:effect` storage and retain host nil semantics.
+           :result-storage [{:destination out :access :write :host-return :buffer}]})))
 
     (or (par/par-scan-form? expression)
         (par/par-scan-exclusive-form? expression))

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -11,27 +11,26 @@
    :emission {:kernel-count 0 :targets [] :strategies [] :fallback-reasons [] :declines {}}}
 
   :symbolic-dense-contraction-gpu
-  {:route {:backend :opencl :source-dialect :typed-soac :typed-validated true
-           :declines {[:backend-applied-stats :typed-contraction-dispatch-declines
-                       :typed-contraction-dispatch-dynamic-scalar] 1}}
-   :fusion {:vertical 0 :horizontal 0 :iterations 1 :placements 0}
-   :lowering {:segops 1 :kernel-graphs 0 :structured-loops 0
-              :typed-reused 1 :typed-scalar-equations 0
-              :backend-reused 1 :backend-relowered 0 :fallback 0}
-   :emission {:kernel-count 1 :targets [:opencl-c] :strategies [:portable-segred]
-              :fallback-reasons [:symbolic-dims]
-              :declines {[:dpas :matrix-capability-unavailable] 1
-                         [:regtiled :symbolic-dims] 1}}}
+  {:route {:semantic-dialect :typed-parallel
+           :scheduled-dialect :scheduled-parallel
+           :emitted-dialect :opencl-parallel
+           :fallback :none}
+   :lowering {:nodes 3 :values 3 :instances 1 :program-instances 1
+              :outputs 1 :driver-allocations 0}
+   :emission {:structured-loops-emitted 0
+              :typed-equations-emitted 1
+              :host-scalar-equations 0}}
 
   :q4k-dp4a-rows-gpu
-  {:route {:backend :opencl :source-dialect :typed-soac :typed-validated true
-           :declines {}}
-   :fusion {:vertical 0 :horizontal 0 :iterations 1 :placements 0}
-   :lowering {:segops 1 :kernel-graphs 0 :structured-loops 0
-              :typed-reused 1 :typed-scalar-equations 1
-              :backend-reused 1 :backend-relowered 0 :fallback 0}
-   :emission {:kernel-count 1 :targets [:opencl-c] :strategies []
-              :fallback-reasons [] :declines {}}}
+  {:route {:semantic-dialect :typed-parallel
+           :scheduled-dialect :scheduled-parallel
+           :emitted-dialect :opencl-parallel
+           :fallback :none}
+   :lowering {:nodes 9 :values 9 :instances 1 :program-instances 1
+              :outputs 0 :driver-allocations 0}
+   :emission {:structured-loops-emitted 0
+              :typed-equations-emitted 1
+              :host-scalar-equations 0}}
 
   :gqa-causal-mha-gpu
   {:route {:semantic-dialect :typed-parallel

--- a/test/raster/compiler/compatibility_ledger_test.clj
+++ b/test/raster/compiler/compatibility_ledger_test.clj
@@ -64,11 +64,22 @@
     (pipeline/compile-report #'nn/predict-fn)
 
     :symbolic-dense-contraction-gpu
-    (pipeline/compile-report #'contract/contract-mm :target-device target :dtype :float)
+    (let [compilation (equation-first/compile
+                       #'contract/contract-mm {:target target :dtype :float})
+          plan (equation-first/lower
+                compilation [(float-array 6) (float-array 6) 2 3 2])]
+      (equation-first-signature compilation plan))
 
     :q4k-dp4a-rows-gpu
-    (pipeline/compile-report #'qk/qmatmul-q4k-dp4a-rows!
-                             :target-device target :dtype :float)
+    (let [compilation (equation-first/compile
+                       #'qk/qmatmul-q4k-dp4a-rows! {:target target :dtype :float})
+          plan (equation-first/lower
+                compilation
+                [(int-array 64) (float-array 1) (int-array 8)
+                 (int-array 64) (float-array 2) (float-array 2)
+                 (byte-array 16) (byte-array 16) (float-array 2)
+                 256 2 1])]
+      (equation-first-signature compilation plan))
 
     :gqa-causal-mha-gpu
     (let [compilation (equation-first/compile
@@ -108,7 +119,10 @@
       (let [report (compile-workload id)
             actual (cond
                      (:declined report) report
-                     (contains? #{:gqa-causal-mha-gpu :heat-loss-rk4-gpu} id) report
+                     (contains? #{:symbolic-dense-contraction-gpu
+                                  :q4k-dp4a-rows-gpu
+                                  :gqa-causal-mha-gpu
+                                  :heat-loss-rk4-gpu} id) report
                      :else (signature report))]
         (is (= expected actual)
             (str "compiler compatibility changed for " id

--- a/test/raster/compiler/ir/invocation_materialization_test.clj
+++ b/test/raster/compiler/ir/invocation_materialization_test.clj
@@ -70,6 +70,26 @@
                             (materialization/materialize plan [(float-array 3) 0.25 7]
                                                          evaluate-scalar))))))
 
+(deftest caller-owned-write-only-storage-is-materialized-outside-logical-inputs
+  (let [value (array-value :float 4)
+        plan (invocation/from-prefix
+              {:id :write-only-storage
+               :parameters '[x y]
+               :parameter-values {'x value 'y value}
+               :bindings [] :binding-values {}
+               :program-values {'x value 'y value}
+               :program-inputs '[x]
+               :program-storage '[y]
+               :program-outputs []})
+        x (float-array 4)
+        y (float-array 4)
+        materialized (materialization/materialize plan [x y] evaluate-scalar)]
+    (is (= '[x] (mapv :program-value (:bindings plan))))
+    (is (= '[y] (mapv :program-value (:storage-bindings plan))))
+    (is (= #{'x 'y} (set (keys (:program-buffers materialized)))))
+    (is (identical? y (get-in materialized [:program-buffers 'y :source])))
+    (is (empty? (:program-scalars materialized)))))
+
 (deftest concrete-public-and-program-shapes-are-checked
   (testing "a static public shape cannot silently accept a different array length"
     (let [value (array-value :double 3)

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -42,9 +42,9 @@
 
 (deftest compound-parallel-extents-become-typed-scalar-ssa
   (let [source '(let* [step (raster.par/map! target i
-                                              (clojure.core/* nrows width)
-                                              float (clojure.core/aget x i))]
-                        step)
+                                             (clojure.core/* nrows width)
+                                             float (clojure.core/aget x i))]
+                      step)
         normalized (frontend/normalize-source source)
         program (frontend/form->program
                  normalized
@@ -65,8 +65,8 @@
   (let [program
         (frontend/form->program
          '(let* [total (raster.par/reduce acc 0.0 i
-                                           (clojure.core/alength x)
-                                           (+ acc (clojure.core/aget x i)))]
+                                          (clojure.core/alength x)
+                                          (+ acc (clojure.core/aget x i)))]
                 total)
          {:dtype :double
           :values {'x (av/tensor {:dtype :double :shape ['n]})}
@@ -102,9 +102,9 @@
   (let [program
         (frontend/form->program
          '(let* [step (raster.par/map-void! i n
-                                             (if (< i limit)
-                                               (clojure.core/aset
-                                                out i (clojure.core/aget src i))))]
+                                            (if (< i limit)
+                                              (clojure.core/aset
+                                               out i (clojure.core/aget src i))))]
                 step)
          {:dtype :float
           :array-types {'src :float 'out :float}
@@ -219,8 +219,8 @@
 (deftest contraction-enters-as-a-general-typed-segmented-reduction
   (let [source
         '(let* [step (raster.par/contract C [[i m] [j n]] [[l k]]
-                       (* (clojure.core/aget A (+ (* i k) l))
-                          (clojure.core/aget B (+ (* l n) j))))]
+                                          (* (clojure.core/aget A (+ (* i k) l))
+                                             (clojure.core/aget B (+ (* l n) j))))]
                step)
         options {:dtype :float
                  :array-types {'A :float 'B :float 'C :float}
@@ -367,10 +367,10 @@
     (is (= :typed-soac (:algorithm-dialect stencil)))
     (testing "the verifier rejects in-place neighborhood updates before scheduling"
       (let [aliased (list 'let* ['result
-                                  '(raster.par/stencil!
-                                    u [u] 1 :dirichlet double i n
-                                    (+ (clojure.core/aget u (clojure.core/- i 1))
-                                       (clojure.core/aget u (clojure.core/+ i 1))))]
+                                 '(raster.par/stencil!
+                                   u [u] 1 :dirichlet double i n
+                                   (+ (clojure.core/aget u (clojure.core/- i 1))
+                                      (clojure.core/aget u (clojure.core/+ i 1))))]
                           'result)]
         (try
           (frontend/form->program
@@ -391,8 +391,8 @@
                             (apply list
                                    (concat
                                     '(raster.par/contract C [[i 128] [j 128]] [[l 128]]
-                                      (* (clojure.core/aget A (+ (* i 128) l))
-                                         (clojure.core/aget B (+ (* l 128) j))))
+                                                          (* (clojure.core/aget A (+ (* i 128) l))
+                                                             (clojure.core/aget B (+ (* l 128) j))))
                                     [:epilogue transform]))]
                      'step)
         program (frontend/form->program
@@ -427,8 +427,8 @@
         contract (apply list
                         (concat
                          '(raster.par/contract C [[i 8] [j 8]] [[l 8]]
-                           (* (clojure.core/aget A (+ (* i 8) l))
-                              (clojure.core/aget B (+ (* l 8) j))))
+                                               (* (clojure.core/aget A (+ (* i 8) l))
+                                                  (clojure.core/aget B (+ (* l 8) j))))
                          [:epilogue transform]))]
     (try
       (frontend/form->program
@@ -477,6 +477,18 @@
         (is (= #{:memory/write} (:effects facts)))
         (is (= [] (dialect/outputs program))
             "the host nil result is not mislabeled as a tensor result")))))
+
+(deftest returned-write-destination-projects-to-its-logical-result
+  (let [program
+        (frontend/form->program
+         '(let* [effect (raster.par/map! out i n float
+                                         (+ (clojure.core/aget x i) 1.0))]
+                out)
+         {:dtype :float :array-types {'x :float 'out :float}})
+        equation (first (dialect/equations program))]
+    (is (= ['out] (dialect/physical-results program equation)))
+    (is (= (vec (nth equation 2)) (dialect/outputs program))
+        "a returned destination denotes the fresh logical result, not an undeclared buffer")))
 
 (deftest typed-shared-locals-become-one-region-ssa-spine
   (let [expression

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -241,7 +241,7 @@
     (is (= 'segmented-reduce (:kind operation)))
     (is (= '[[i m] [j n]] (get-in operation [:attributes :segment-axes])))
     (is (= '[m n k] (dialect/operation-extents equation)))
-    (is (= [{:destination 'C :access :write :host-return :effect}]
+    (is (= [{:destination 'C :access :write :host-return :buffer}]
            (get-in (dialect/facts program) [:equations 0 :attributes :result-storage])))
     (is (= '[m n] (:shape (get-in (dialect/facts program)
                                   [:values (first (nth equation 2))]))))


### PR DESCRIPTION
Migrates dense contraction and the Q4_K row projection to the public equation-first TypedSOAC compile/lower boundary.

The generic InvocationPlan now distinguishes logical SSA inputs from caller-owned write-only storage bindings. This lets a mutating numerical primitive bind its public destination without pretending that destination is a numerical operand, while internal allocated results remain compiler-owned. Returned destination writes project back to their logical SSA results.

Compatibility ledger improvements:
- dense contraction: one public output, 3 LinkNodes/LinkValues, zero driver allocations, no fallback
- Q4_K row projection: caller-owned y storage, 9 LinkNodes/LinkValues, zero driver allocations, no fallback

Focused evidence: 52 tests, 322 assertions, zero failures/errors. Full compiler/vendor coverage is delegated to CircleCI.