### PR TITLE
Compile equation-first programs to CUDA and HIP source

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -76,6 +76,13 @@ that SegRed. The GPU schedules eligible scalar regions as one verified workgroup
 with typed scalar SSA, stable reads, workgroup allocation, masks, barriers and an ordered result ABI;
 the same body emits as OpenCL, CUDA and HIP and is compiled by the hardware-free vendor CI gates.
 Unsupported scalar regions decline explicitly to the established verified SegRed OpenCL emitter.
+The public `equation-first/compile` boundary now selects that C-family emitter directly from a
+synthetic or physical OpenCL, CUDA, or HIP target descriptor. Its first hardware-free public
+vertical covers portable SegRed and SegFoldMap KernelBodies, preserves `:fallback :none`, validates
+that every artifact target agrees with the emitted program dialect, and sends the resulting CUDA
+and HIP reduction phases through nvcc/hipcc in CI. Graph families that have not yet acquired a
+portable KernelBody (currently SegMap, SegStencil, and SegScan) fail at this boundary instead of
+embedding OpenCL source in a CUDA/HIP program.
 
 The map/scalar/full-reduction/certified-scan front end now constructs TypedSOAC directly from closed analyzed
 source and retained walker type metadata. It establishes stable equation/value identity, types,
@@ -1073,8 +1080,10 @@ The immediate continuation after the verified double-buffered weighted-reduction
    Stable indexed gathers and explicitly unique guarded scatters also use this typed scheduled-map
    route, including resident block transfers. The public flat `par/gather` spelling now canonicalizes
    to that ordinary typed map: JVM scheduling recognizes an exact stable indirect read and selects
-   hardware `vgather`, while C-family targets emit the same SegMap. Kernel-local C names are fresh
-   with respect to the typed ABI, so an index buffer cannot shadow the launch coordinate. Flat
+   hardware `vgather`, while OpenCL emits the same scheduled SegMap. Portable scalar/control
+   KernelBody lowering for SegMap is the remaining step before the public CUDA/HIP C-family entry
+   accepts this graph family. Kernel-local C names are fresh with respect to the typed ABI, so an
+   index buffer cannot shadow the launch coordinate. Flat
    additive reducing scatters also carry a checked conflict algebra through this boundary and select
    exact JVM or atomic OpenCL schedules. Strided gather/scatter, additional atomic monoids,
    privatized histogram schedules, the remaining parallel forms, calibrated whole-graph placement

--- a/src/raster/compiler/backend/gpu/parallel_program_c_family.clj
+++ b/src/raster/compiler/backend/gpu/parallel_program_c_family.clj
@@ -1,0 +1,158 @@
+(ns raster.compiler.backend.gpu.parallel-program-c-family
+  "Equation-first C-family emission for a scheduled mixed ParallelProgram.
+
+   This pass never inspects retained source or equation sites. Structured loops emit their exact
+   one-iteration graph; ordinary TypedSOAC equations derive and emit the same checked graph. Host
+   scalar equations remain explicit host-only steps. OpenCL, CUDA, and HIP differ only at the
+   KernelBody source dialect boundary."
+  (:require [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
+            [raster.compiler.backend.gpu.segop-opencl :as segop-emission]
+            [raster.compiler.ir.emitted-parallel-equation :as emitted-equation]
+            [raster.compiler.ir.emitted-parallel-program :as emitted-program]
+            [raster.compiler.ir.emitted-structured-loop :as emitted-loop]
+            [raster.compiler.ir.kernel-graph :as graph]
+            [raster.compiler.ir.parallel-program :as program]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.ir.soac-dialect :as soac]
+            [raster.compiler.ir.structured-control :as control]
+            [raster.compiler.ir.structured-control-schedule :as schedule]
+            [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
+            [raster.compiler.passes.parallel.structured-control-route :as structured-route]))
+
+(defn- fail!
+  [reason message data]
+  (throw (ex-info message (assoc data :reason reason :pass :parallel-program-c-family))))
+
+(defn- scalar-types
+  [values operations]
+  (into {}
+        (map (fn [id]
+               (let [value (get values id)]
+                 (when-not value
+                   (fail! :c-family-parallel-scalar-value
+                          "scheduled scalar lacks an AbstractValue"
+                          {:value id}))
+                 [id (:dtype value)])))
+        (distinct (mapcat segop/operation-scalars operations))))
+
+(defn- scheduled-body
+  [parallel-program equation]
+  (let [algorithm (:algorithm equation)]
+    (program/make
+     {:dialect :segop
+      :source nil
+      :values (:values parallel-program)
+      :inputs (:operands equation)
+      :equations [equation]
+      :outputs (:results equation)
+      :effects (:effects equation)
+      :diagnostics []
+      :provenance {:source-dialect :typed-soac
+                   :pass :parallel-program-c-family}
+      :attributes {:host-control :explicit-typed-algorithm}
+      :operation? segop/segop-node?
+      :algorithm? (fn [candidate retained]
+                    (and (= retained (soac/validate! retained))
+                         (= (:operands candidate) (:inputs (soac/facts retained)))
+                         (= (:results candidate) (soac/outputs retained))))})))
+
+(defn- emit-graph
+  [scheduled-graph values operations opts]
+  (let [types (scalar-types values operations)]
+    (segop-emission/generate-kernel-graph
+     scheduled-graph
+     :scalar-types (merge (:scalar-types opts) types)
+     :array-types (:array-types opts)
+     :target-dialect (get opts :target-dialect :opencl-intel))))
+
+(defn- target-program-dialect
+  [target-dialect]
+  (case (c-dialect/target (c-dialect/resolve! target-dialect))
+    :opencl-c :opencl-parallel
+    :cuda-c :cuda-parallel
+    :hip-cpp :hip-parallel))
+
+(defn- emit-equation
+  [parallel-program equation opts]
+  (let [algorithm (:algorithm equation)
+        target-dialect (get opts :target-dialect :opencl-intel)
+        target-module (c-dialect/target (c-dialect/resolve! target-dialect))
+        provenance {:target-dialect target-dialect
+                    :target-module target-module
+                    :pass :parallel-program-c-family}]
+    (cond
+      (control/loop-program? algorithm)
+      (let [scheduled (schedule/validate! (first (:operations equation)))
+            body (:body scheduled)
+            operations (vec (mapcat :operations (:equations body)))
+            emitted (emit-graph (:graph scheduled) (:values body) operations opts)]
+        (assoc equation :operations
+               [(emitted-loop/make scheduled emitted {:provenance provenance})]))
+
+      (and (soac/program-form? algorithm)
+           (true? (get-in equation [:attributes :host-only])))
+      equation
+
+      (soac/program-form? algorithm)
+      (let [body (scheduled-body parallel-program equation)
+            scheduled-graph (equation-graph/make algorithm body)
+            emitted (emit-graph scheduled-graph (:values body) (:operations equation) opts)]
+        (assoc equation :operations
+               [(emitted-equation/make algorithm body emitted {:provenance provenance})]))
+
+      :else
+      (fail! :c-family-parallel-algorithm
+             "scheduled equation has no supported retained algorithm"
+             {:equation (:id equation) :algorithm algorithm}))))
+
+(defn validate-program!
+  [parallel-program]
+  (emitted-program/validate! parallel-program))
+
+(defn emit-program
+  "Emit every numerical equation directly to `:target-dialect`.
+
+   Supported dialects are `:opencl-intel`, `:opencl-portable`, `:cuda`, and `:hip`."
+  ([parallel-program]
+   (emit-program parallel-program {}))
+  ([parallel-program opts]
+   (let [parallel-program (structured-route/validate-scheduled-program! parallel-program)
+         target-dialect (get opts :target-dialect :opencl-intel)
+         target-module (c-dialect/target (c-dialect/resolve! target-dialect))
+         program-dialect (target-program-dialect target-dialect)
+         equations (mapv #(emit-equation parallel-program % opts)
+                         (:equations parallel-program))
+         emitted-program
+         (validate-program!
+          (program/make
+           {:dialect program-dialect
+            :source (:source parallel-program)
+            :values (:values parallel-program)
+            :inputs (:inputs parallel-program)
+            :equations equations
+            :outputs (:outputs parallel-program)
+            :effects (:effects parallel-program)
+            :diagnostics (:diagnostics parallel-program)
+            :provenance (assoc (:provenance parallel-program)
+                               :target-dialect target-dialect
+                               :target-module target-module)
+            :attributes (:attributes parallel-program)
+            :operation? emitted-program/emitted-operation?
+            :algorithm? emitted-program/emitted-boundary?}))
+         graphs (keep (fn [equation]
+                        (when-let [operation (first (:operations equation))]
+                          (cond
+                            (emitted-loop/emitted-loop? operation) (:graph operation)
+                            (emitted-equation/emitted-equation? operation) (:graph operation))))
+                      equations)
+         kernels (vec (mapcat #(map :operation (:nodes (graph/validate! %)))
+                              graphs))]
+     {:program emitted-program
+      :kernels kernels
+      :stats {:structured-loops-emitted
+              (count (filter (comp emitted-loop/emitted-loop? first :operations) equations))
+              :typed-equations-emitted
+              (count (filter (comp emitted-equation/emitted-equation? first :operations)
+                             equations))
+              :host-scalar-equations
+              (count (filter #(get-in % [:attributes :host-only]) equations))}})))

--- a/src/raster/compiler/backend/gpu/parallel_program_opencl.clj
+++ b/src/raster/compiler/backend/gpu/parallel_program_opencl.clj
@@ -1,141 +1,25 @@
 (ns raster.compiler.backend.gpu.parallel-program-opencl
-  "Equation-first OpenCL emission for a scheduled mixed ParallelProgram.
+  "Compatibility entry for equation-first OpenCL emission.
 
-   This pass never inspects retained source or equation sites. Structured loops emit their exact
-   one-iteration graph; ordinary TypedSOAC equations derive and emit the same checked graph. Host
-   scalar equations remain explicit host-only steps for the whole-program executor."
-  (:require [raster.compiler.backend.gpu.segop-opencl :as opencl]
-            [raster.compiler.ir.emitted-parallel-equation :as emitted-equation]
-            [raster.compiler.ir.emitted-parallel-program :as emitted-program]
-            [raster.compiler.ir.emitted-structured-loop :as emitted-loop]
-            [raster.compiler.ir.kernel-graph :as graph]
-            [raster.compiler.ir.parallel-program :as program]
-            [raster.compiler.ir.segop :as segop]
-            [raster.compiler.ir.soac-dialect :as soac]
-            [raster.compiler.ir.structured-control :as control]
-            [raster.compiler.ir.structured-control-schedule :as schedule]
-            [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
-            [raster.compiler.passes.parallel.structured-control-route :as structured-route]))
-
-(defn- fail!
-  [reason message data]
-  (throw (ex-info message (assoc data :reason reason :pass :parallel-program-opencl))))
-
-(defn- scalar-types
-  [values operations]
-  (into {}
-        (map (fn [id]
-               (let [value (get values id)]
-                 (when-not value
-                   (fail! :opencl-parallel-scalar-value
-                          "scheduled scalar lacks an AbstractValue"
-                          {:value id}))
-                 [id (:dtype value)])))
-        (distinct (mapcat segop/operation-scalars operations))))
-
-(defn- scheduled-body
-  [parallel-program equation]
-  (let [algorithm (:algorithm equation)]
-    (program/make
-     {:dialect :segop
-      :source nil
-      :values (:values parallel-program)
-      :inputs (:operands equation)
-      :equations [equation]
-      :outputs (:results equation)
-      :effects (:effects equation)
-      :diagnostics []
-      :provenance {:source-dialect :typed-soac
-                   :pass :parallel-program-opencl}
-      :attributes {:host-control :explicit-typed-algorithm}
-      :operation? segop/segop-node?
-      :algorithm? (fn [candidate retained]
-                    (and (= retained (soac/validate! retained))
-                         (= (:operands candidate) (:inputs (soac/facts retained)))
-                         (= (:results candidate) (soac/outputs retained))))})))
-
-(defn- emit-graph
-  [scheduled-graph values operations opts]
-  (let [types (scalar-types values operations)]
-    (opencl/generate-kernel-graph
-     scheduled-graph
-     :scalar-types (merge (:scalar-types opts) types))))
-
-(defn- emit-equation
-  [parallel-program equation opts]
-  (let [algorithm (:algorithm equation)]
-    (cond
-      (control/loop-program? algorithm)
-      (let [scheduled (schedule/validate! (first (:operations equation)))
-            body (:body scheduled)
-            operations (vec (mapcat :operations (:equations body)))
-            emitted (emit-graph (:graph scheduled) (:values body) operations opts)]
-        (assoc equation :operations
-               [(emitted-loop/make
-                 scheduled emitted
-                 {:provenance {:target-dialect :opencl-c
-                               :pass :parallel-program-opencl}})]))
-
-      (and (soac/program-form? algorithm)
-           (true? (get-in equation [:attributes :host-only])))
-      equation
-
-      (soac/program-form? algorithm)
-      (let [body (scheduled-body parallel-program equation)
-            scheduled-graph (equation-graph/make algorithm body)
-            emitted (emit-graph scheduled-graph (:values body) (:operations equation) opts)]
-        (assoc equation :operations
-               [(emitted-equation/make
-                 algorithm body emitted
-                 {:provenance {:target-dialect :opencl-c
-                               :pass :parallel-program-opencl}})]))
-
-      :else
-      (fail! :opencl-parallel-algorithm
-             "scheduled equation has no supported retained algorithm"
-             {:equation (:id equation) :algorithm algorithm}))))
+   The target-parametric implementation lives in `parallel-program-c-family`. New public compiler
+   paths should use that namespace directly."
+  (:require [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
+            [raster.compiler.backend.gpu.parallel-program-c-family :as c-family]))
 
 (defn validate-program!
   [parallel-program]
-  (emitted-program/validate! parallel-program))
+  (c-family/validate-program! parallel-program))
 
 (defn emit-program
-  "Emit every numerical equation directly and return its checked target program plus artifacts."
-  ([parallel-program] (emit-program parallel-program {}))
-  ([parallel-program opts]
-   (let [parallel-program (structured-route/validate-scheduled-program! parallel-program)
-         equations (mapv #(emit-equation parallel-program % opts)
-                         (:equations parallel-program))
-         emitted-program
-         (validate-program!
-          (program/make
-           {:dialect :opencl-parallel
-            :source (:source parallel-program)
-            :values (:values parallel-program)
-            :inputs (:inputs parallel-program)
-            :equations equations
-            :outputs (:outputs parallel-program)
-            :effects (:effects parallel-program)
-            :diagnostics (:diagnostics parallel-program)
-            :provenance (assoc (:provenance parallel-program)
-                               :target-dialect :opencl-parallel)
-            :attributes (:attributes parallel-program)
-            :operation? emitted-program/emitted-operation?
-            :algorithm? emitted-program/emitted-boundary?}))
-         graphs (keep (fn [equation]
-                        (when-let [operation (first (:operations equation))]
-                          (cond
-                            (emitted-loop/emitted-loop? operation) (:graph operation)
-                            (emitted-equation/emitted-equation? operation) (:graph operation))))
-                      equations)
-         kernels (vec (mapcat #(map :operation (:nodes (graph/validate! %)))
-                              graphs))]
-     {:program emitted-program
-      :kernels kernels
-      :stats {:structured-loops-emitted
-              (count (filter (comp emitted-loop/emitted-loop? first :operations) equations))
-              :typed-equations-emitted
-              (count (filter (comp emitted-equation/emitted-equation? first :operations)
-                             equations))
-              :host-scalar-equations
-              (count (filter #(get-in % [:attributes :host-only]) equations))}})))
+  "Emit an equation-first program to an OpenCL KernelBody source dialect."
+  ([parallel-program]
+   (emit-program parallel-program {}))
+  ([parallel-program options]
+   (let [target-dialect (get options :target-dialect :opencl-intel)]
+     (when-not (c-dialect/opencl? (c-dialect/resolve! target-dialect))
+       (throw (ex-info "OpenCL compatibility entry requires an OpenCL target dialect"
+                       {:reason :parallel-program-opencl-target
+                        :target-dialect target-dialect
+                        :fallback :none})))
+     (c-family/emit-program parallel-program
+                            (assoc options :target-dialect target-dialect)))))

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -754,6 +754,15 @@
             {:decline (ex-data exception)}))]
     (or
      (:artifact kernel-body-attempt)
+     (when-not (kernel-body-c-dialect/opencl?
+                (kernel-body-c-dialect/resolve! target-dialect))
+       (throw (ex-info
+               "scheduled reduction is outside the portable KernelBody C-family subset"
+               {:reason :kernel-graph-target-lowering-missing
+                :target-dialect target-dialect
+                :operation (:id segred)
+                :kernel-body-decline (:decline kernel-body-attempt)
+                :fallback :none})))
      (let [idx (seg-idx segred)
            bound (seg-bound segred)
            {:keys [acc init lambda]} (segop/scalar-reduce-op segred)
@@ -1258,8 +1267,8 @@
     (finalize-emitted-graph emitted :opencl-c scalar-types)))
 
 (defn- generate-reduction-kernel-graph
-  [graph {:keys [scalar-types array-types]
-          :or {scalar-types {} array-types {}}}]
+  [graph {:keys [scalar-types array-types target-dialect]
+          :or {scalar-types {} array-types {} target-dialect :opencl-intel}}]
   (let [array-types (graph-array-types graph array-types)
         emitted
         (kgraph/map-operations
@@ -1274,24 +1283,46 @@
               (generate-segred-kernel
                operation (first outputs)
                :dtype (:dtype operation)
-               :scalar-types scalar-types :array-types array-types)
+               :scalar-types scalar-types :array-types array-types
+               :target-dialect target-dialect)
               operation))))]
-    (finalize-emitted-graph emitted :opencl-c scalar-types)))
+    (finalize-emitted-graph
+     emitted
+     (kernel-body-c-dialect/target (kernel-body-c-dialect/resolve! target-dialect))
+     scalar-types)))
 
 (defn- generate-fold-map-kernel-graph
-  [graph {:keys [scalar-types array-types]
-          :or {scalar-types {} array-types {}}}]
-  (let [array-types (graph-array-types graph array-types)
+  [graph {:keys [scalar-types array-types target-dialect]
+          :or {scalar-types {} array-types {} target-dialect :opencl-intel}}]
+  (let [target (kernel-body-c-dialect/resolve! target-dialect)
+        array-types (graph-array-types graph array-types)
         emitted
         (kgraph/map-operations
          graph
          (fn [{:keys [operation]}]
-           (kart/certify-scheduled-operation
-            (generate-segfoldmap-kernel
-             operation :scalar-types scalar-types :array-types array-types
-             :kernel-name-prefix "graph_segmented_fold_map")
-            operation)))]
-    (finalize-emitted-graph emitted :opencl-c scalar-types)))
+           (try
+             (kart/certify-scheduled-operation
+              (generate-segfoldmap-kernel
+               operation :scalar-types scalar-types :array-types array-types
+               :target-dialect target-dialect
+               :kernel-name-prefix "graph_segmented_fold_map")
+              operation)
+             (catch clojure.lang.ExceptionInfo exception
+               (if (and (not (kernel-body-c-dialect/opencl? target))
+                        (segfoldmap-body/declined? exception))
+                 (throw (ex-info
+                         "scheduled fold-map is outside the portable KernelBody C-family subset"
+                         {:reason :kernel-graph-target-lowering-missing
+                          :target-dialect target-dialect
+                          :operation (:id operation)
+                          :kernel-body-decline (ex-data exception)
+                          :fallback :none}
+                         exception))
+                 (throw exception))))))]
+    (finalize-emitted-graph
+     emitted
+     (kernel-body-c-dialect/target target)
+     scalar-types)))
 
 (defn generate-kernel-graph
   "Target-lower one scheduled KernelGraph through the backend's single graph-emission boundary.
@@ -1300,16 +1331,27 @@
    by scheduling. Unsupported graph families fail loudly; callers never fall back to reconstructing
    an operation from source spelling or node names."
   [graph & {:as opts}]
-  (let [graph (kgraph/validate! graph)]
+  (let [graph (kgraph/validate! graph)
+        target-dialect (get opts :target-dialect :opencl-intel)
+        opencl? (kernel-body-c-dialect/opencl?
+                 (kernel-body-c-dialect/resolve! target-dialect))]
     (cond
       (scan/associative-scan? (get-in graph [:attributes :scan-algebra]))
-      (apply generate-scan-kernel-graph graph (mapcat identity opts))
+      (if opencl?
+        (apply generate-scan-kernel-graph graph (mapcat identity opts))
+        (throw (ex-info "scan graph has no portable KernelBody C-family lowering"
+                        {:reason :kernel-graph-target-lowering-missing
+                         :target-dialect target-dialect :fallback :none})))
 
       (and (seq (:nodes graph))
            (every? #(or (instance? raster.compiler.ir.segop.SegMap (:operation %))
                         (instance? raster.compiler.ir.segop.SegStencil (:operation %)))
                    (:nodes graph)))
-      (generate-elementwise-kernel-graph graph opts)
+      (if opencl?
+        (generate-elementwise-kernel-graph graph opts)
+        (throw (ex-info "elementwise graph has no portable KernelBody C-family lowering"
+                        {:reason :kernel-graph-target-lowering-missing
+                         :target-dialect target-dialect :fallback :none})))
 
       (and (seq (:nodes graph))
            (every? #(instance? raster.compiler.ir.segop.SegRed (:operation %))
@@ -1322,9 +1364,10 @@
       (generate-fold-map-kernel-graph graph opts)
 
       :else
-      (throw (ex-info "OpenCL backend has no target lowering for scheduled KernelGraph"
+      (throw (ex-info "C-family backend has no target lowering for scheduled KernelGraph"
                       {:reason :kernel-graph-target-lowering-missing
-                       :target :opencl-c
+                       :target-dialect target-dialect
+                       :fallback :none
                        :provenance (:provenance graph)
                        :attributes (:attributes graph)})))))
 

--- a/src/raster/compiler/equation_first.clj
+++ b/src/raster/compiler/equation_first.clj
@@ -10,9 +10,11 @@
    resident descriptor extractor or reconstruct ABI/storage facts from emitted source."
   (:refer-clojure :exclude [compile])
   (:require [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
-            [raster.compiler.backend.gpu.parallel-program-opencl :as program-opencl]
+            [raster.compiler.backend.gpu.parallel-program-c-family :as program-c-family]
+            [raster.compiler.backend.gpu.target :as gpu-target]
             [raster.compiler.backend.jvm.typed-scalar :as scalar]
             [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.hardware :as hardware]
             [raster.compiler.ir.invocation-link :as invocation-link]
             [raster.compiler.ir.invocation-materialization :as materialization]
             [raster.compiler.ir.invocation-plan :as invocation]
@@ -74,12 +76,32 @@
             :scalar-types (:scalar-types parameter-types)}
            (when param-env {:param-env param-env}))))
 
+(defn- target-source-dialect
+  "Select source spelling from the same hardware descriptor used by scheduling.
+
+   A missing optional descriptor still has a conservative family default: Level Zero is the
+   explicit Intel path, while generic OpenCL uses portable subgroup spelling."
+  [target backend]
+  (or (try
+        (some-> target hardware/descriptor-for gpu-target/kernel-body-c-dialect)
+        (catch Throwable _ nil))
+      (case (device/device-type target)
+        :ze :opencl-intel
+        :ocl :opencl-portable
+        :cuda :cuda
+        :hip :hip
+        (case backend
+          :cuda :cuda
+          :hip :hip
+          nil))))
+
 (defn compile
   "Compile one deftm Var into an immutable equation-first target program.
 
-   Options currently require `:target` in the Level Zero/OpenCL family. CUDA/HIP source emitters
-   will plug in at this same scheduled-program boundary; unsupported target families fail rather
-   than borrowing the compatibility backend. `:dtype` defaults from the deftm's retained tags."
+   `:target` may select Level Zero/OpenCL, CUDA, or HIP. CUDA/HIP compilation is hardware-free:
+   it produces verified target source artifacts but does not require an installed runtime or a
+   physical device. Unsupported target families and uncovered KernelBody graph families fail
+   rather than borrowing the compatibility backend. `:dtype` defaults from retained deftm tags."
   ([f-var] (compile f-var {}))
   ([f-var {:keys [target dtype] :or {target :ze:0} :as options}]
    (when-not (var? f-var)
@@ -103,9 +125,11 @@
                      :dialect (:dialect semantic) :fallback :none}))
          scheduled (structured-route/schedule-program semantic compiler-options)
          backend (device/select-runtime-backend target true nil)
+         target-dialect (target-source-dialect target backend)
          emission
-         (case backend
-           :opencl (program-opencl/emit-program scheduled compiler-options)
+         (if target-dialect
+           (program-c-family/emit-program
+            scheduled (assoc compiler-options :target-dialect target-dialect))
            (fail! :equation-first-target-emitter
                   "equation-first scheduled program has no public source emitter for this target"
                   {:target target :backend backend :fallback :none}))

--- a/src/raster/compiler/ir/emitted_parallel_program.clj
+++ b/src/raster/compiler/ir/emitted_parallel_program.clj
@@ -6,9 +6,15 @@
    equations with an empty emitted operation sequence."
   (:require [raster.compiler.ir.emitted-parallel-equation :as emitted-equation]
             [raster.compiler.ir.emitted-structured-loop :as emitted-loop]
+            [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.parallel-program :as program]
             [raster.compiler.ir.soac-dialect :as soac]
             [raster.compiler.ir.structured-control :as control]))
+
+(def ^:private dialect-targets
+  {:opencl-parallel :opencl-c
+   :cuda-parallel :cuda-c
+   :hip-parallel :hip-cpp})
 
 (defn emitted-operation?
   [operation]
@@ -38,9 +44,27 @@
 (defn validate!
   "Validate a fully emitted equation-first program without depending on a target backend."
   [parallel-program]
-  (when-not (= :opencl-parallel (:dialect parallel-program))
-    (throw (ex-info "emitted parallel program requires :opencl-parallel"
+  (when-not (contains? dialect-targets (:dialect parallel-program))
+    (throw (ex-info "emitted parallel program requires a supported C-family dialect"
                     {:reason :emitted-parallel-program-dialect
                      :dialect (:dialect parallel-program)
+                     :supported (set (keys dialect-targets))
                      :ir :emitted-parallel-program})))
-  (program/validate! parallel-program emitted-operation? emitted-boundary?))
+  (let [parallel-program
+        (program/validate! parallel-program emitted-operation? emitted-boundary?)
+        expected-target (get dialect-targets (:dialect parallel-program))
+        artifacts
+        (vec
+         (for [equation (:equations parallel-program)
+               operation (:operations equation)
+               node (:nodes (:graph operation))]
+           (artifact/validate! (:operation node))))
+        mismatches (filterv #(not= expected-target (:target %)) artifacts)]
+    (when (seq mismatches)
+      (throw (ex-info "emitted program dialect disagrees with a contained kernel target"
+                      {:reason :emitted-parallel-program-target
+                       :dialect (:dialect parallel-program)
+                       :expected-target expected-target
+                       :artifact-targets (mapv :target artifacts)
+                       :ir :emitted-parallel-program})))
+    parallel-program))

--- a/src/raster/compiler/passes/parallel/device.clj
+++ b/src/raster/compiler/passes/parallel/device.clj
@@ -1,24 +1,25 @@
 (ns raster.compiler.passes.parallel.device
   "Device helpers for compiler backend selection and allocation policy.
 
-  Device ids are concrete keywords such as :cpu:0, :cuda:0, :ze:0, and :ocl:0.
+  Device ids are concrete keywords such as :cpu:0, :cuda:0, :hip:0, :ze:0, and :ocl:0.
   The compiler uses these concrete ids directly rather than a second layer of
   :cpu/:cuda pseudo-devices."
   (:require [clojure.string :as str]))
 
 (defn device-type
-  "Extract device type (:cpu, :cuda, :ze, or :ocl) from a device-id keyword.
-  E.g. :cpu:0 -> :cpu, :cuda:1 -> :cuda, :ze:0 -> :ze, :ocl:0 -> :ocl"
+  "Extract device type from a concrete device-id keyword."
   [device-id]
   (when device-id
     (let [s (name device-id)]
       (cond
         (= s "cpu")                :cpu
         (= s "cuda")               :cuda
+        (= s "hip")                :hip
         (= s "ze")                 :ze
         (= s "ocl")                :ocl
         (str/starts-with? s "cpu")  :cpu
         (str/starts-with? s "cuda") :cuda
+        (str/starts-with? s "hip")  :hip
         (str/starts-with? s "ze")   :ze
         (str/starts-with? s "ocl")  :ocl
         :else (keyword (first (str/split s #":")))))))
@@ -26,7 +27,7 @@
 (defn gpu-target?
   "True when device-id selects a GPU backend family."
   [device-id]
-  (contains? #{:cuda :ze :ocl} (device-type device-id)))
+  (contains? #{:cuda :hip :ze :ocl} (device-type device-id)))
 
 (defn level-zero-target?
   "True when device-id selects a Level Zero target family."
@@ -66,14 +67,15 @@
 
 (defn select-backend
   "Select backend for a par form based on device and size hint.
-  Returns :cuda, :opencl, :simd, or :scalar.
+  Returns :cuda, :hip, :opencl, :simd, or :scalar.
 
-  device-id: keyword like :cpu:0, :cuda:0, :ze:0, or :ocl:0
+  device-id: keyword like :cpu:0, :cuda:0, :hip:0, :ze:0, or :ocl:0
   size-hint: known or estimated element count (may be nil)"
   [device-id size-hint]
   (let [dt (device-type (or device-id :cpu:0))]
     (cond
       (= :cuda dt)                         :cuda
+      (= :hip dt)                          :hip
       (= :ze dt)                           :opencl
       (= :ocl dt)                          :opencl
       (and size-hint (>= size-hint 8))     :simd

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -1,11 +1,13 @@
 (ns raster.compiler.backend.gpu.kernel-body-compile-fixtures
   "Generate production scheduled KernelBody sources for hardware-free CUDA/HIP CI gates."
   (:require [clojure.java.io :as io]
+            [raster.arrays]
             [raster.compiler.backend.gpu.attention :as attention-emit]
             [raster.compiler.backend.gpu.kernel-body-fixtures :as body-fixtures]
             [raster.compiler.backend.gpu.kernel-body-opencl :as body-emit]
             [raster.compiler.backend.gpu.segop-opencl :as segop-emit]
             [raster.compiler.backend.gpu.target :as gpu-target]
+            [raster.compiler.equation-first :as equation-first]
             [raster.compiler.ir.attention :as attention]
             [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
@@ -18,7 +20,21 @@
             [raster.compiler.passes.parallel.segmented-weighted-reduction-schedule :as schedule]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
-            [raster.compiler.passes.parallel.soac-lower :as soac-lower]))
+            [raster.compiler.passes.parallel.soac-lower :as soac-lower]
+            [raster.core :refer [deftm]]
+            [raster.numeric]
+            [raster.par]
+            [raster.runtime.hardware :as hardware]))
+
+(deftm public-c-family-dot
+  "Public equation-first workload compiled by nvcc/hipcc without a physical device."
+  (All [T] [left :- (Array T) right :- (Array T) n :- Long] :- Double
+       (raster.par/reduce
+        accumulator 0.0 index n
+        (raster.numeric/+
+         accumulator
+         (raster.numeric/* (raster.arrays/aget left index)
+                           (raster.arrays/aget right index))))))
 
 (defn- reduction-artifact
   [dialect]
@@ -142,6 +158,26 @@
          :descriptor {:device-type :gpu :backend :hip :vendor "AMD"
                       :subgroup-size 32 :max-workgroup-size 1024}}})
 
+(defn- equation-first-artifacts
+  [target descriptor]
+  (let [device-id (keyword (str (name target) ":equation-first-compile-gate"))
+        capabilities (cond-> {:subgroup-sizes [(:subgroup-size descriptor)]
+                              :warp-size (:subgroup-size descriptor)
+                              :max-workgroup-size (:max-workgroup-size descriptor)
+                              :shared-local-memory 65536
+                              :total-eus 64}
+                       (:compute-capability descriptor)
+                       (assoc :compute-capability (:compute-capability descriptor))
+
+                       (= :hip target)
+                       (assoc :gfx-arch :gfx1100))]
+    (hardware/register-target-device!
+     device-id {:type target
+                :name (str "Synthetic " (name target) " public compile gate")
+                :capabilities capabilities})
+    (:kernels (equation-first/compile
+               #'public-c-family-dot {:target device-id :dtype :float}))))
+
 (defn- write-artifact!
   [directory suffix label artifact]
   (let [file (io/file directory (str label suffix))]
@@ -183,7 +219,8 @@
                    plan pipelined-schedule dialect descriptor)
         swizzled-pipelined (attention-emit/emit-fp16-pipelined
                             plan swizzled-pipelined-schedule dialect descriptor)
-        tiled (attention-emit/emit-fp16-tiled-history plan tiled-schedule dialect)]
+        tiled (attention-emit/emit-fp16-tiled-history plan tiled-schedule dialect)
+        public-artifacts (equation-first-artifacts target descriptor)]
     (into [(write-artifact! directory suffix "cooperative" cooperative)
            (write-artifact! directory suffix "pipelined-attention" pipelined)
            (write-artifact! directory suffix "swizzled-pipelined-attention"
@@ -215,9 +252,15 @@
                            "pipelined_staging"
                            (body-fixtures/pipelined-staging-body 32 :preferred)
                            {:target-dialect dialect :target-features descriptor}))]
-          (map-indexed (fn [index artifact]
-                         (write-artifact! directory suffix (str "tiled-" index) artifact))
-                       (executable/artifacts tiled)))))
+          (concat
+           (map-indexed
+            (fn [index artifact]
+              (write-artifact! directory suffix (str "equation-first-" index) artifact))
+            public-artifacts)
+           (map-indexed
+            (fn [index artifact]
+              (write-artifact! directory suffix (str "tiled-" index) artifact))
+            (executable/artifacts tiled))))))
 
 (defn -main
   [& [root]]

--- a/test/raster/compiler/equation_first_c_family_test.clj
+++ b/test/raster/compiler/equation_first_c_family_test.clj
@@ -1,0 +1,123 @@
+(ns raster.compiler.equation-first-c-family-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [raster.arrays]
+            [raster.compiler.equation-first :as equation-first]
+            [raster.compiler.ir.emitted-parallel-program :as emitted-program]
+            [raster.core :refer [deftm]]
+            [raster.numeric]
+            [raster.par]
+            [raster.runtime.hardware :as hardware]))
+
+(def ^:private cuda-target :cuda:equation-first-source-test)
+(def ^:private hip-target :hip:equation-first-source-test)
+
+(use-fixtures
+  :once
+  (fn [f]
+    (hardware/register-target-device!
+     cuda-target
+     {:type :cuda
+      :name "Synthetic NVIDIA equation-first source target"
+      :capabilities {:compute-capability [8 0]
+                     :warp-size 32
+                     :subgroup-sizes [32]
+                     :max-workgroup-size 1024
+                     :shared-local-memory 65536
+                     :total-eus 108}})
+    (hardware/register-target-device!
+     hip-target
+     {:type :hip
+      :name "Synthetic AMD equation-first source target"
+      :capabilities {:gfx-arch :gfx1100
+                     :warp-size 32
+                     :subgroup-sizes [32 64]
+                     :max-workgroup-size 1024
+                     :shared-local-memory 65536
+                     :total-eus 60}})
+    (f)))
+
+(deftm c-family-dot
+  "A public TypedSOAC reduction compiled without a CUDA/HIP runtime or physical GPU."
+  (All [T] [left :- (Array T) right :- (Array T) n :- Long] :- Double
+       (raster.par/reduce
+        accumulator 0.0 index n
+        (raster.numeric/+
+         accumulator
+         (raster.numeric/* (raster.arrays/aget left index)
+                           (raster.arrays/aget right index))))))
+
+(deftm uncovered-elementwise
+  [input :- (Array float) n :- Long] :- (Array float)
+  (let [output (float-array n)]
+    (raster.par/map! output index n float
+                     (raster.numeric/* (float 2.0)
+                                       (raster.arrays/aget input index)))))
+
+(deftm c-family-segment-sum!
+  [output :- (Array float) segment-count :- Long width :- Long] :- Void
+  (let [effect
+        (raster.par/segmented-fold-map!
+         [output] [[segment segment-count]] index width
+         [[sum 0.0 :float width sum]]
+         [(float sum)])]
+    effect))
+
+(defn- reason-of
+  [thunk]
+  (try
+    (thunk)
+    nil
+    (catch clojure.lang.ExceptionInfo exception
+      (ex-data exception))))
+
+(deftest public-equation-first-compilation-emits-cuda-and-hip-source
+  (doseq [[target program-dialect module-target]
+          [[cuda-target :cuda-parallel :cuda-c]
+           [hip-target :hip-parallel :hip-cpp]]]
+    (testing (name target)
+      (let [compilation (equation-first/compile
+                         #'c-family-dot {:target target :dtype :float})
+            linked (equation-first/lower
+                    compilation [(float-array 8) (float-array 8) 8])
+            kernels (:kernels compilation)]
+        (is (= program-dialect (get-in compilation [:emitted :dialect])))
+        (is (= :none (get-in compilation [:stats :fallback])))
+        (is (= 2 (count kernels)) "the scheduled reduction owns both emitted phases")
+        (is (every? #(= module-target (:target %)) kernels))
+        (is (every? #(get-in % [:attributes :kernel-body]) kernels))
+        (is (every? #(str/includes? (:source %) "__global__ void") kernels))
+        (is (not-any? #(re-find #"__kernel|get_global_id|get_local_id" (:source %)) kernels))
+        (is (= 0 (get-in linked [:attributes :driver-allocations])))
+        (is (= 1 (count (:outputs linked))))
+        (is (= (:emitted compilation)
+               (emitted-program/validate! (:emitted compilation))))))))
+
+(deftest public-c-family-route-never-borrows-opencl-source
+  (doseq [target [cuda-target hip-target]]
+    (let [failure (reason-of #(equation-first/compile
+                               #'uncovered-elementwise {:target target :dtype :float}))]
+      (is (= :kernel-graph-target-lowering-missing (:reason failure)))
+      (is (= :none (:fallback failure))))))
+
+(deftest public-segmented-fold-map-uses-the-same-c-family-boundary
+  (doseq [[target module-target]
+          [[cuda-target :cuda-c]
+           [hip-target :hip-cpp]]]
+    (let [compilation (equation-first/compile
+                       #'c-family-segment-sum! {:target target :dtype :float})
+          linked (equation-first/lower
+                  compilation [(float-array 8) 2 4])]
+      (is (= [module-target] (mapv :target (:kernels compilation))))
+      (is (= :none (get-in compilation [:stats :fallback])))
+      (is (= 0 (get-in linked [:attributes :driver-allocations]))))))
+
+(deftest emitted-program-rejects-a-mixed-target-module
+  (let [compilation (equation-first/compile
+                     #'c-family-dot {:target cuda-target :dtype :float})
+        mixed (assoc-in (:emitted compilation)
+                        [:equations 0 :operations 0 :graph :nodes 0 :operation :target]
+                        :hip-cpp)
+        failure (reason-of #(emitted-program/validate! mixed))]
+    (is (= :emitted-parallel-program-target (:reason failure)))
+    (is (= :cuda-c (:expected-target failure)))))

--- a/test/raster/compiler/passes/parallel/device_test.clj
+++ b/test/raster/compiler/passes/parallel/device_test.clj
@@ -11,12 +11,14 @@
   (testing "device ids normalize to backend families"
     (is (= :cpu (device/device-type :cpu:0)))
     (is (= :cuda (device/device-type :cuda:1)))
+    (is (= :hip (device/device-type :hip:2)))
     (is (= :ze (device/device-type :ze:0)))
     (is (= :ocl (device/device-type :ocl:3))))
 
   (testing "bare family keywords still parse when encountered"
     (is (= :cpu (device/device-type :cpu)))
-    (is (= :cuda (device/device-type :cuda)))))
+    (is (= :cuda (device/device-type :cuda)))
+    (is (= :hip (device/device-type :hip)))))
 
 ;; ================================================================
 ;; allocation helpers
@@ -34,6 +36,7 @@
 (deftest select-backend-test
   (testing "explicit device targets win"
     (is (= :cuda (device/select-backend :cuda:0 nil)))
+    (is (= :hip (device/select-backend :hip:0 nil)))
     (is (= :opencl (device/select-backend :ze:0 nil)))
     (is (= :opencl (device/select-backend :ocl:0 nil))))
 
@@ -46,6 +49,7 @@
   (testing "GPU target and dtype helpers centralize target policy"
     (is (true? (device/gpu-target? :ze:0)))
     (is (true? (device/gpu-target? :cuda:0)))
+    (is (true? (device/gpu-target? :hip:0)))
     (is (false? (device/gpu-target? :cpu:0)))
     (is (true? (device/level-zero-target? :ze:0)))
     (is (nil? (device/preferred-dtype :cpu:0)))
@@ -54,6 +58,7 @@
   (testing "runtime backend selection handles device and simd policy"
     (is (= :opencl (device/select-runtime-backend :ze:0 true nil)))
     (is (= :cuda (device/select-runtime-backend :cuda:0 true nil)))
+    (is (= :hip (device/select-runtime-backend :hip:0 true nil)))
     (is (= :simd (device/select-runtime-backend nil true nil)))
     (is (= :scalar (device/select-runtime-backend nil false nil)))))
 


### PR DESCRIPTION
Extends the public allocation-free equation-first compiler across OpenCL, CUDA, and HIP source targets. The scheduled ParallelProgram now reaches one target-parametric C-family emission boundary, and emitted programs validate that every kernel artifact agrees with the selected target dialect. Unsupported graph families fail with fallback none instead of borrowing OpenCL source. Adds hardware-free public SegRed and SegFoldMap coverage plus actual public CUDA/HIP fixtures for the nvcc and hipcc CI gates. SegMap, SegStencil, and SegScan remain explicit follow-up gaps.