### PR TITLE
Lower typed maps through portable KernelBody

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -81,8 +81,11 @@ synthetic or physical OpenCL, CUDA, or HIP target descriptor. Its first hardware
 vertical covers portable SegRed and SegFoldMap KernelBodies, preserves `:fallback :none`, validates
 that every artifact target agrees with the emitted program dialect, and sends the resulting CUDA
 and HIP reduction phases through nvcc/hipcc in CI. Graph families that have not yet acquired a
-portable KernelBody (currently SegMap, SegStencil, and SegScan) fail at this boundary instead of
-embedding OpenCL source in a CUDA/HIP program.
+portable KernelBody fail at this boundary instead of embedding OpenCL source in a CUDA/HIP
+program. Typed one-dimensional SegMap now shares one scalar-expression lowering with SegFoldMap:
+stable loads, retained dtypes, scalar SSA, branches, and horizontally fused stores emit from the
+same KernelBody to all three C-family targets. Loop-carried map regions, SegStencil, and SegScan
+remain explicit coverage gaps.
 
 The map/scalar/full-reduction/certified-scan front end now constructs TypedSOAC directly from closed analyzed
 source and retained walker type metadata. It establishes stable equation/value identity, types,
@@ -1080,10 +1083,10 @@ The immediate continuation after the verified double-buffered weighted-reduction
    Stable indexed gathers and explicitly unique guarded scatters also use this typed scheduled-map
    route, including resident block transfers. The public flat `par/gather` spelling now canonicalizes
    to that ordinary typed map: JVM scheduling recognizes an exact stable indirect read and selects
-   hardware `vgather`, while OpenCL emits the same scheduled SegMap. Portable scalar/control
-   KernelBody lowering for SegMap is the remaining step before the public CUDA/HIP C-family entry
-   accepts this graph family. Kernel-local C names are fresh with respect to the typed ABI, so an
-   index buffer cannot shadow the launch coordinate. Flat
+   hardware `vgather`, while the portable scalar/control KernelBody emits the admitted scheduled
+   SegMap subset across OpenCL, CUDA and HIP. Loop-carried scalar regions remain a checked decline
+   until their TypedSOAC loop values lower to KernelBody `ForLoop`. Kernel-local C names are fresh
+   with respect to the typed ABI, so an index buffer cannot shadow the launch coordinate. Flat
    additive reducing scatters also carry a checked conflict algebra through this boundary and select
    exact JVM or atomic OpenCL schedules. Strided gather/scatter, additional atomic monoids,
    privatized histogram schedules, the remaining parallel forms, calibrated whole-graph placement

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -29,6 +29,7 @@
             [raster.compiler.passes.parallel.register-tiled-body :as register-tiled-body]
             [raster.compiler.passes.parallel.segred-body :as segred-body]
             [raster.compiler.passes.parallel.segfoldmap-body :as segfoldmap-body]
+            [raster.compiler.passes.parallel.segmap-body :as segmap-body]
             [clojure.walk :as walk]
             [clojure.set]
             [raster.compiler.ir.segop :as segop]
@@ -453,6 +454,52 @@
                    :array-params (vec (concat (:inputs segfoldmap) (:outputs segfoldmap)))
                    :scalar-params (vec (:scalars segfoldmap))
                    :dtype (first (:dtypes segfoldmap))
+                   :aliasing :no-write-alias}})))
+
+(defn generate-segmap-kernel-body
+  "Schedule and emit one typed SegMap through the shared scalar KernelBody dialect."
+  [segmap & {:keys [kernel-name-prefix target-dialect workgroup-size scalar-types array-types]
+             :or {kernel-name-prefix "segmap"
+                  target-dialect :opencl-intel workgroup-size 256
+                  scalar-types {} array-types {}}}]
+  (let [{:keys [kernel-body bound inputs outputs scalars]}
+        (segmap-body/lower segmap
+                           {:workgroup-size workgroup-size
+                            :scalar-types scalar-types :array-types array-types})
+        parameters (:parameters kernel-body)
+        kernel-name (str kernel-name-prefix "_" (gensym ""))
+        parameter-names (into {}
+                              (map (fn [parameter]
+                                     [(:id parameter) (ce/c-symbol (:id parameter))]))
+                              parameters)
+        source (kernel-body-opencl/emit-scalar-kernel
+                kernel-name kernel-body
+                {:target-dialect target-dialect :parameter-names parameter-names})
+        abi (body-abi/project-contracts
+             (mapv (fn [{:keys [id kind dtype role]}]
+                     (kabi/slot id kind dtype :c-name (get parameter-names id)
+                                :role (if (= id '_n_bound) :bound role)))
+                   parameters)
+             kernel-body)
+        arguments (mapv (fn [parameter]
+                          (if (= '_n_bound (:id parameter)) bound (:id parameter)))
+                        parameters)]
+    (kart/make
+     {:kernel-name kernel-name
+      :source source
+      :abi abi
+      :arguments arguments
+      :launch (:launch kernel-body)
+      :temporaries []
+      :effects {:kind :elementwise-map :write-conflict :unique}
+      :target (kernel-body-c-dialect/target
+               (kernel-body-c-dialect/resolve! target-dialect))
+      :provenance {:dialect :kernel-body :source-dialect :segmap
+                   :segop-id (:id segmap)}
+      :attributes {:kernel-body kernel-body
+                   :array-params (vec (concat inputs outputs))
+                   :scalar-params scalars
+                   :dtype (:dtype segmap)
                    :aliasing :no-write-alias}})))
 
 ;; ================================================================
@@ -1233,9 +1280,11 @@
     (merge array-types declared-array-types)))
 
 (defn- generate-elementwise-kernel-graph
-  [graph {:keys [scalar-types array-types]
-          :or {scalar-types {} array-types {}}}]
-  (let [array-types (graph-array-types graph array-types)
+  [graph {:keys [scalar-types array-types target-dialect]
+          :or {scalar-types {} array-types {} target-dialect :opencl-intel}}]
+  (let [target (kernel-body-c-dialect/resolve! target-dialect)
+        opencl? (kernel-body-c-dialect/opencl? target)
+        array-types (graph-array-types graph array-types)
         emitted
         (kgraph/map-operations
          graph
@@ -1243,28 +1292,42 @@
            (kart/certify-scheduled-operation
             (cond
               (instance? raster.compiler.ir.segop.SegMap operation)
-              (if (:out-sym operation)
-                (generate-segmap-kernel
-                 operation (:out-sym operation)
-                 :dtype (:dtype operation)
-                 :scalar-types scalar-types :array-types array-types
-                 :kernel-name-prefix "graph_segmap")
-                (generate-explicit-segmap-kernel
+              (try
+                (generate-segmap-kernel-body
                  operation :dtype (:dtype operation)
                  :scalar-types scalar-types :array-types array-types
-                 :kernel-name-prefix "graph_segmap_effect"))
+                 :target-dialect target-dialect
+                 :kernel-name-prefix "graph_segmap")
+                (catch clojure.lang.ExceptionInfo exception
+                  (if (and opencl? (segmap-body/declined? exception))
+                    (if (:out-sym operation)
+                      (generate-segmap-kernel
+                       operation (:out-sym operation)
+                       :dtype (:dtype operation)
+                       :scalar-types scalar-types :array-types array-types
+                       :kernel-name-prefix "graph_segmap")
+                      (generate-explicit-segmap-kernel
+                       operation :dtype (:dtype operation)
+                       :scalar-types scalar-types :array-types array-types
+                       :kernel-name-prefix "graph_segmap_effect"))
+                    (throw exception))))
 
               (instance? raster.compiler.ir.segop.SegStencil operation)
-              (generate-segstencil-kernel
-               operation :scalar-types scalar-types :array-types array-types
-               :kernel-name-prefix "graph_segstencil")
+              (if opencl?
+                (generate-segstencil-kernel
+                 operation :scalar-types scalar-types :array-types array-types
+                 :kernel-name-prefix "graph_segstencil")
+                (throw (ex-info "stencil has no portable KernelBody C-family lowering"
+                                {:reason :kernel-graph-target-lowering-missing
+                                 :target-dialect target-dialect :operation (:id operation)
+                                 :fallback :none})))
 
               :else
               (throw (ex-info "OpenCL elementwise graph has an unsupported scheduled node"
                               {:reason :kernel-graph-node-target-lowering-missing
                                :target :opencl-c :node id :operation operation})))
             operation)))]
-    (finalize-emitted-graph emitted :opencl-c scalar-types)))
+    (finalize-emitted-graph emitted (kernel-body-c-dialect/target target) scalar-types)))
 
 (defn- generate-reduction-kernel-graph
   [graph {:keys [scalar-types array-types target-dialect]
@@ -1347,11 +1410,17 @@
            (every? #(or (instance? raster.compiler.ir.segop.SegMap (:operation %))
                         (instance? raster.compiler.ir.segop.SegStencil (:operation %)))
                    (:nodes graph)))
-      (if opencl?
+      (try
         (generate-elementwise-kernel-graph graph opts)
-        (throw (ex-info "elementwise graph has no portable KernelBody C-family lowering"
-                        {:reason :kernel-graph-target-lowering-missing
-                         :target-dialect target-dialect :fallback :none})))
+        (catch clojure.lang.ExceptionInfo exception
+          (if (and (not opencl?) (segmap-body/declined? exception))
+            (throw (ex-info "scheduled map is outside the portable KernelBody C-family subset"
+                            {:reason :kernel-graph-target-lowering-missing
+                             :target-dialect target-dialect
+                             :kernel-body-decline (ex-data exception)
+                             :fallback :none}
+                            exception))
+            (throw exception))))
 
       (and (seq (:nodes graph))
            (every? #(instance? raster.compiler.ir.segop.SegRed (:operation %))

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -1,0 +1,179 @@
+(ns raster.compiler.passes.parallel.scalar-expression-body
+  "Lower a typed scalar S-expression region to target-neutral KernelBody SSA.
+
+   This is shared by ordinary maps and ordered fold-maps. The caller supplies authoritative
+   storage/scalar dtypes, index lowering, participation, and its own structured decline function;
+   this pass performs no source-level type or function inference."
+  (:require [raster.compiler.backend.intrinsics :as intrinsics]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.util :as util]
+            [raster.compiler.ir.kernel-body :as body]))
+
+(def ^:private cast-heads
+  {'byte :byte, 'clojure.core/byte :byte
+   'int :int, 'clojure.core/int :int
+   'long :long, 'clojure.core/long :long
+   'float :float, 'clojure.core/float :float
+   'double :double, 'clojure.core/double :double})
+
+(defn inline-lets
+  "Inline a top-level scalar let region while preserving its already-typed expression tree."
+  [expression]
+  (if (and (seq? expression) (contains? #{'let 'let* 'clojure.core/let} (first expression)))
+    (let [[_ bindings result] expression]
+      (reduce (fn [result [id init]] (util/subst-syms {id init} result))
+              result (reverse (partition 2 bindings))))
+    expression))
+
+(defn make-lowerer
+  "Build a scalar-expression lowerer.
+
+   Returns `{:lower f}` where `f` accepts expression, expected dtype, and a map of typed local
+   values. `decline!` is called as `(decline! rule message data)` so each owning schedule retains
+   an honest, local coverage contract."
+  [{:keys [array-types scalar-types arrays index-scope lower-index predicate id-prefix decline!]
+    :or {id-prefix "scalar"}}]
+  (let [canon-type #(if (= :predicate %) :predicate (dtype/canon %))
+        counter (atom 0)
+        fresh (fn [prefix] (symbol (str id-prefix "-" prefix "-" (swap! counter inc))))
+        source-type
+        (fn source-type [expression expected env]
+          (let [expression (inline-lets expression)]
+            (or
+             (some-> (or (:raster.type/tag (meta expression)) (:tag (meta expression)))
+                     dtype/dtype-for-scalar-tag)
+             (cond
+               (symbol? expression) (or (get env expression) (get scalar-types expression) expected)
+               (number? expression) expected
+               (descriptor/aget-call? expression)
+               (or (get array-types (descriptor/aget-array-sym expression)) expected)
+               (and (seq? expression) (contains? cast-heads (first expression)))
+               (get cast-heads (first expression))
+               (and (seq? expression)
+                    (= :cmp (:kind (intrinsics/descriptor
+                                    (intrinsics/canonical
+                                     (descriptor/semantic-op expression))))))
+               :predicate
+               :else expected))))]
+    (when-not (and (fn? lower-index) (fn? decline!))
+      (throw (ex-info "scalar KernelBody lowering requires index and decline callbacks"
+                      {:reason :raster/bug :lower-index lower-index :decline decline!})))
+    (letfn [(lower [expression expected env]
+              (let [expression (inline-lets expression)
+                    expected (canon-type expected)]
+                (cond
+                  (number? expression)
+                  {:operations [] :result (body/literal expression expected) :type expected}
+
+                  (boolean? expression)
+                  {:operations [] :result (body/literal expression :predicate) :type :predicate}
+
+                  (symbol? expression)
+                  (if-let [actual (or (get env expression) (get scalar-types expression))]
+                    {:operations [] :result expression :type (canon-type actual)}
+                    (decline! :unbound-scalar
+                              "scalar expression references an undeclared value"
+                              {:expression expression :environment (set (keys env))}))
+
+                  (descriptor/aget-call? expression)
+                  (let [array (descriptor/aget-array-sym expression)
+                        arguments (vec (descriptor/call-args expression))
+                        coordinate (last arguments)
+                        array-type (some-> (get array-types array) dtype/canon)]
+                    (when-not (and (= 2 (count arguments)) (contains? arrays array) array-type)
+                      (decline! :indexed-load
+                                "scalar loads require a declared typed stable tensor"
+                                {:expression expression :array array :array-types array-types}))
+                    (let [id (fresh "load")]
+                      {:operations [(body/->ScalarLoad
+                                     (body/value id array-type) array
+                                     [(lower-index coordinate)] predicate
+                                     (when predicate (body/literal 0 array-type)) :cached)]
+                       :result id :type array-type}))
+
+                  (and (seq? expression) (contains? cast-heads (first expression))
+                       (= 2 (count expression)))
+                  (let [target (dtype/canon (get cast-heads (first expression)))
+                        source-expected (dtype/canon (source-type (second expression) target env))
+                        lowered (lower (second expression) source-expected env)]
+                    (if (= target (:type lowered))
+                      lowered
+                      (let [source (dtype/canon (:type lowered))
+                            fp-source? (dtype/fp-dtype? source)
+                            fp-target? (dtype/fp-dtype? target)
+                            widening? (<= (dtype/bytes-of source) (dtype/bytes-of target))
+                            [rounding overflow]
+                            (cond
+                              (and fp-source? fp-target? widening?) [:exact :exact]
+                              (and fp-source? fp-target?) [:nearest-even :ieee]
+                              (and (not fp-source?) (not fp-target?) widening?) [:exact :exact]
+                              :else
+                              (decline! :cast-policy
+                                        "scalar cast has no portable exact policy"
+                                        {:expression expression :source source :target target}))
+                            id (fresh "cast")]
+                        {:operations (conj (:operations lowered)
+                                           (body/->ScalarCompute
+                                            (body/value id target)
+                                            (body/cast-expression (:result lowered) target
+                                                                  rounding overflow)))
+                         :result id :type target})))
+
+                  (and (seq? expression) (= 'if (first expression)) (= 4 (count expression)))
+                  (let [[_ condition then-expression else-expression] expression
+                        condition (lower condition :predicate env)
+                        then-value (lower then-expression expected env)
+                        else-value (lower else-expression expected env)
+                        result-type (:type then-value)
+                        _ (when-not (= result-type (:type else-value) expected)
+                            (decline! :branch-dtype
+                                      "scalar branches must have one explicit result dtype"
+                                      {:expression expression :then (:type then-value)
+                                       :else (:type else-value) :expected expected}))
+                        result (fresh "if")]
+                    {:operations
+                     (conj (vec (:operations condition))
+                           (body/->IfRegion
+                            (:result condition)
+                            (conj (vec (:operations then-value))
+                                  (body/->Yield [(:result then-value)]))
+                            (conj (vec (:operations else-value))
+                                  (body/->Yield [(:result else-value)]))
+                            [(body/value result result-type)]))
+                     :result result :type result-type})
+
+                  (seq? expression)
+                  (let [operator (intrinsics/canonical (descriptor/semantic-op expression))
+                        intrinsic (intrinsics/descriptor operator)
+                        arguments (vec (descriptor/call-args expression))]
+                    (when-not (and intrinsic (= (:arity intrinsic) (count arguments)))
+                      (decline! :scalar-expression
+                                "scalar expression has no canonical intrinsic"
+                                {:expression expression :operator operator}))
+                    (let [comparison? (= :cmp (:kind intrinsic))
+                          operand-type (if comparison?
+                                         (dtype/canon
+                                          (or (source-type (first arguments) :int env) :int))
+                                         expected)
+                          lowered (mapv #(lower % operand-type env) arguments)
+                          result-type (if comparison? :predicate operand-type)
+                          _ (when-not (every? #(= operand-type (:type %)) lowered)
+                              (decline! :operand-dtype
+                                        "scalar intrinsic operands require one dtype"
+                                        {:expression expression :operand-type operand-type
+                                         :actual (mapv :type lowered)}))
+                          result (fresh "value")]
+                      {:operations
+                       (conj (vec (mapcat :operations lowered))
+                             (body/->ScalarCompute
+                              (body/value result result-type)
+                              (body/scalar-expression operator result-type
+                                                      (mapv :result lowered))))
+                       :result result :type result-type}))
+
+                  :else
+                  (decline! :scalar-expression
+                            "scalar expression has an unsupported value"
+                            {:expression expression :type (type expression)}))))]
+      {:lower lower})))

--- a/src/raster/compiler/passes/parallel/segfoldmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segfoldmap_body.clj
@@ -5,22 +5,14 @@
    declared order; completed fold values feed later folds and the final dense map. This is the
    baseline schedule, not an attention or normalization implementation."
   (:require [clojure.set :as set]
-            [raster.compiler.backend.intrinsics :as intrinsics]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.layout :as layout]
-            [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.segop :as segop]
-            [raster.compiler.passes.parallel.contraction-body :as contraction-body]))
-
-(def ^:private cast-heads
-  {'byte :byte, 'clojure.core/byte :byte
-   'int :int, 'clojure.core/int :int
-   'long :long, 'clojure.core/long :long
-   'float :float, 'clojure.core/float :float
-   'double :double, 'clojure.core/double :double})
+            [raster.compiler.passes.parallel.contraction-body :as contraction-body]
+            [raster.compiler.passes.parallel.scalar-expression-body :as scalar-expression]))
 
 (defn- decline!
   [rule message data]
@@ -54,138 +46,6 @@
       (body/index-cast expression :long :exact))
     :else expression))
 
-(defn- inline-let
-  [expression]
-  (if (and (seq? expression) (contains? #{'let 'let* 'clojure.core/let} (first expression)))
-    (let [[_ bindings result] expression]
-      (reduce (fn [result [id init]] (util/subst-syms {id init} result))
-              result (reverse (partition 2 bindings))))
-    expression))
-
-(defn- scalar-lowerer
-  [{:keys [array-types scalar-types arrays index-scope lower-index active-mask]}]
-  (let [counter (atom 0)
-        fresh (fn [prefix] (symbol (str "foldmap-" prefix "-" (swap! counter inc))))
-        source-type
-        (fn source-type [expression expected env]
-          (let [expression (inline-let expression)]
-            (cond
-              (symbol? expression) (or (get env expression) (get scalar-types expression) expected)
-              (number? expression) expected
-              (descriptor/aget-call? expression)
-              (or (get array-types (descriptor/aget-array-sym expression)) expected)
-              (and (seq? expression) (contains? cast-heads (first expression)))
-              (get cast-heads (first expression))
-              (and (seq? expression)
-                   (= :cmp (:kind (intrinsics/descriptor
-                                   (intrinsics/canonical
-                                    (descriptor/semantic-op expression))))))
-              :predicate
-              :else expected)))]
-    (letfn [(lower [expression expected env]
-              (let [expression (inline-let expression)]
-                (cond
-                  (number? expression)
-                  {:operations [] :result (body/literal expression expected) :type expected}
-
-                  (boolean? expression)
-                  {:operations [] :result (body/literal expression :predicate) :type :predicate}
-
-                  (symbol? expression)
-                  (if-let [actual (or (get env expression) (get scalar-types expression))]
-                    {:operations [] :result expression :type actual}
-                    (decline! :unbound-scalar
-                              "fold-map scalar expression references an undeclared value"
-                              {:expression expression :environment (set (keys env))}))
-
-                  (descriptor/aget-call? expression)
-                  (let [array (descriptor/aget-array-sym expression)
-                        arguments (vec (descriptor/call-args expression))
-                        coordinate (last arguments)
-                        array-type (some-> (get array-types array) dtype/canon)]
-                    (when-not (and (= 2 (count arguments)) (contains? arrays array) array-type)
-                      (decline! :indexed-load
-                                "fold-map loads require a declared typed stable tensor"
-                                {:expression expression :array array :array-types array-types}))
-                    (let [id (fresh "load")]
-                      {:operations [(body/->ScalarLoad
-                                     (body/value id array-type) array
-                                     [(lower-index coordinate)] active-mask
-                                     (body/literal 0 array-type) :cached)]
-                       :result id :type array-type}))
-
-                  (and (seq? expression) (contains? cast-heads (first expression))
-                       (= 2 (count expression)))
-                  (let [target (dtype/canon (get cast-heads (first expression)))
-                        lowered (lower (second expression) target env)]
-                    (if (= target (:type lowered))
-                      lowered
-                      (let [id (fresh "cast")]
-                        {:operations (conj (:operations lowered)
-                                           (body/->ScalarCompute
-                                            (body/value id target)
-                                            (body/cast-expression (:result lowered) target
-                                                                  :exact :exact)))
-                         :result id :type target})))
-
-                  (and (seq? expression) (= 'if (first expression)) (= 4 (count expression)))
-                  (let [[_ condition then-expression else-expression] expression
-                        condition (lower condition :predicate env)
-                        then-value (lower then-expression expected env)
-                        else-value (lower else-expression expected env)
-                        result-type (:type then-value)
-                        _ (when-not (= result-type (:type else-value) expected)
-                            (decline! :branch-dtype
-                                      "fold-map branches must have one explicit scalar dtype"
-                                      {:expression expression :then (:type then-value)
-                                       :else (:type else-value) :expected expected}))
-                        result (fresh "if")]
-                    {:operations
-                     (conj (vec (:operations condition))
-                           (body/->IfRegion
-                            (:result condition)
-                            (conj (vec (:operations then-value))
-                                  (body/->Yield [(:result then-value)]))
-                            (conj (vec (:operations else-value))
-                                  (body/->Yield [(:result else-value)]))
-                            [(body/value result result-type)]))
-                     :result result :type result-type})
-
-                  (seq? expression)
-                  (let [operator (intrinsics/canonical (descriptor/semantic-op expression))
-                        intrinsic (intrinsics/descriptor operator)
-                        arguments (vec (descriptor/call-args expression))]
-                    (when-not (and intrinsic (= (:arity intrinsic) (count arguments)))
-                      (decline! :scalar-expression
-                                "fold-map scalar expression has no canonical intrinsic"
-                                {:expression expression :operator operator}))
-                    (let [comparison? (= :cmp (:kind intrinsic))
-                          operand-type (if comparison?
-                                         (dtype/canon
-                                          (or (source-type (first arguments) :int env) :int))
-                                         (dtype/canon expected))
-                          lowered (mapv #(lower % operand-type env) arguments)
-                          result-type (if comparison? :predicate operand-type)
-                          _ (when-not (every? #(= operand-type (:type %)) lowered)
-                              (decline! :operand-dtype
-                                        "fold-map intrinsic operands require one scalar dtype"
-                                        {:expression expression :operand-type operand-type
-                                         :actual (mapv :type lowered)}))
-                          result (fresh "value")]
-                      {:operations
-                       (conj (vec (mapcat :operations lowered))
-                             (body/->ScalarCompute
-                              (body/value result result-type)
-                              (body/scalar-expression operator result-type
-                                                      (mapv :result lowered))))
-                       :result result :type result-type}))
-
-                  :else
-                  (decline! :scalar-expression
-                            "fold-map scalar expression has an unsupported value"
-                            {:expression expression :type (type expression)}))))]
-      {:lower lower})))
-
 (defn lower
   "Apply the portable one-work-item-per-segment schedule to a SegFoldMap."
   [segfold {:keys [workgroup-size array-types scalar-types]
@@ -210,8 +70,8 @@
         array-types (into {}
                           (map (fn [id]
                                  [id (dtype/canon (or (get array-types id)
-                                                     (get array-types (symbol (name id)))
-                                                     default-dtype))]))
+                                                      (get array-types (symbol (name id)))
+                                                      default-dtype))]))
                           (concat inputs outputs))
         declared-scalar-types scalar-types
         scalar-types (into {}
@@ -270,9 +130,11 @@
         base-env (merge (zipmap (map :name segment-dims) (repeat :long))
                         {(:index segfold) :long}
                         scalar-types)
-        scalar-lower (scalar-lowerer {:array-types array-types :scalar-types scalar-types
-                                      :arrays (set inputs) :index-scope index-scope
-                                      :lower-index lower-index :active-mask active-mask})
+        scalar-lower (scalar-expression/make-lowerer
+                      {:array-types array-types :scalar-types scalar-types
+                       :arrays (set inputs) :index-scope index-scope
+                       :lower-index lower-index :predicate active-mask
+                       :id-prefix "foldmap" :decline! decline!})
         fold-state
         (reduce
          (fn [{:keys [operations env]} [ordinal fold]]
@@ -288,12 +150,12 @@
                  expression (util/subst-syms {source-index loop-index accumulator carry}
                                              (:step fold))
                  lowered ((:lower scalar-lower) expression fold-dtype
-                          (assoc env loop-index :long carry fold-dtype))
+                                                (assoc env loop-index :long carry fold-dtype))
                  loop (body/->ForLoop
                        (body/value loop-index :long)
                        (body/index-cast 0 :long :exact) (lower-index (:extent fold)) 1
                        [(body/->LoopArg (body/value carry fold-dtype)
-                                       (body/literal (:identity fold) fold-dtype))]
+                                        (body/literal (:identity fold) fold-dtype))]
                        (vec (concat (:operations lowered)
                                     [(body/->Yield [(:result lowered)])]))
                        [(body/value accumulator fold-dtype)]
@@ -309,7 +171,7 @@
          (fn [ordinal output output-dtype expression]
            (let [expression (util/subst-syms {(:index segfold) map-index} expression)
                  lowered ((:lower scalar-lower) expression output-dtype
-                          (assoc (:env fold-state) map-index :long))]
+                                                (assoc (:env fold-state) map-index :long))]
              (concat (:operations lowered)
                      [(body/->ScalarStore output [output-coordinate]
                                           (:result lowered) active-mask)])))

--- a/src/raster/compiler/passes/parallel/segmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segmap_body.clj
@@ -1,0 +1,167 @@
+(ns raster.compiler.passes.parallel.segmap-body
+  "Portable scalar/control schedule for a one-dimensional typed SegMap.
+
+   One work item owns each logical element. Grid-stride virtualization remains explicit as a
+   KernelBody ForLoop; scalar loads, computation, branches, and horizontally fused stores use the
+   shared typed scalar-expression lowering boundary."
+  (:require [clojure.set :as set]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.layout :as layout]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.passes.parallel.contraction-body :as contraction-body]
+            [raster.compiler.passes.parallel.scalar-expression-body :as scalar-expression]))
+
+(defn- decline!
+  [rule message data]
+  (throw (ex-info message (assoc data :reason :segmap-kernel-body-declined
+                                 :missing-rule rule))))
+
+(defn declined?
+  [exception]
+  (= :segmap-kernel-body-declined (:reason (ex-data exception))))
+
+(defn- widen-index-expression
+  [expression value-types]
+  (cond
+    (integer? expression) (body/index-cast expression :long :exact)
+    (symbol? expression)
+    (if (= :long (dtype/canon (get value-types expression :int)))
+      expression
+      (body/index-cast expression :long :exact))
+    (instance? raster.compiler.ir.kernel_body.IndexExpr expression)
+    (apply body/expression (:op expression)
+           (map #(widen-index-expression % value-types) (:arguments expression)))
+    (instance? raster.compiler.ir.kernel_body.IndexCast expression)
+    (if (= :long (dtype/canon (:dtype expression)))
+      expression
+      (body/index-cast expression :long :exact))
+    :else expression))
+
+(defn- scalar-forms
+  [expression]
+  (let [expression (scalar-expression/inline-lets expression)]
+    (if (and (seq? expression) (= 'do (first expression)))
+      (vec (rest expression))
+      [expression])))
+
+(defn lower
+  "Apply a portable grid-stride scalar schedule to a typed one-dimensional SegMap."
+  [segmap {:keys [workgroup-size array-types scalar-types]
+           :or {workgroup-size 256 array-types {} scalar-types {}}}]
+  (when-not (instance? raster.compiler.ir.segop.SegMap segmap)
+    (throw (ex-info "map KernelBody lowering requires SegMap"
+                    {:reason :raster/bug :operation segmap})))
+  (let [space (:space segmap)
+        dimensions (:dims space)
+        _ (when-not (= 1 (count dimensions))
+            (decline! :iteration-rank
+                      "the first portable map schedule requires one flattened iteration axis"
+                      {:operation (:id segmap) :dimensions dimensions}))
+        _ (when-not (and (integer? workgroup-size) (pos? workgroup-size))
+            (decline! :workgroup-size "map workgroup size must be positive"
+                      {:workgroup-size workgroup-size}))
+        index (:name (first dimensions))
+        bound (:bound (first dimensions))
+        inputs (vec (sort-by name (:inputs segmap)))
+        outputs (vec (sort-by name (:outputs segmap)))
+        scalars (vec (sort-by name (:scalars segmap)))
+        _ (when (seq (set/intersection (set inputs) (set outputs)))
+            (decline! :inout-storage
+                      "portable map stable reads must not alias writable results"
+                      {:operation (:id segmap) :inputs inputs :outputs outputs}))
+        default-dtype (dtype/canon (or (:dtype segmap) :float))
+        array-dtype (fn [id]
+                      (dtype/canon (or (get array-types id)
+                                       (get array-types (symbol (name id)))
+                                       default-dtype)))
+        scalar-dtype (fn [id]
+                       (dtype/canon (or (get scalar-types id)
+                                        (get scalar-types (symbol (name id)))
+                                        :int)))
+        array-types (into {} (map (juxt identity array-dtype)) (concat inputs outputs))
+        scalar-types (into {} (map (juxt identity scalar-dtype)) scalars)
+        index-scope (conj (set scalars) index)
+        index-types (assoc scalar-types index :long)
+        lower-index #(widen-index-expression
+                      (contraction-body/lower-index % index-scope) index-types)
+        lowerer (scalar-expression/make-lowerer
+                 {:array-types array-types :scalar-types scalar-types
+                  :arrays (set inputs) :index-scope index-scope
+                  :lower-index lower-index :predicate :map-active
+                  :id-prefix "map" :decline! decline!})
+        forms (scalar-forms (:lambda segmap))
+        primary-output (:out-sym segmap)
+        explicit-forms (if primary-output (pop forms) forms)
+        primary-form (when primary-output (peek forms))
+        _ (when (and primary-output (empty? forms))
+            (decline! :missing-result "map result has no scalar expression"
+                      {:operation (:id segmap) :output primary-output}))
+        environment (assoc scalar-types index :long)
+        lower-store
+        (fn [form]
+          (when-not (descriptor/aset-call? form)
+            (decline! :explicit-store
+                      "map side-effect region contains a non-store statement"
+                      {:operation (:id segmap) :statement form}))
+          (let [[array coordinate expression] (take-last 3 (descriptor/call-args form))
+                array (descriptor/aset-array-sym form)
+                _ (when-not (contains? (set outputs) array)
+                    (decline! :explicit-store-target
+                              "map store targets an undeclared result"
+                              {:operation (:id segmap) :statement form :target array}))
+                lowered ((:lower lowerer) expression (get array-types array) environment)]
+            (concat (:operations lowered)
+                    [(body/->ScalarStore array [(lower-index coordinate)]
+                                         (:result lowered) :map-active)])))
+        explicit-operations (vec (mapcat lower-store explicit-forms))
+        primary-lowered (when primary-output
+                          ((:lower lowerer) primary-form
+                                            (get array-types primary-output) environment))
+        scalar-operations
+        (vec (concat explicit-operations
+                     (:operations primary-lowered)
+                     (when primary-output
+                       [(body/->ScalarStore primary-output [index]
+                                            (:result primary-lowered) :map-active)])))
+        group-index 'map-group
+        local-index 'map-lane
+        parameters
+        (vec (concat
+              (map #(body/->KernelParameter
+                     % :input (get array-types %) ['_n_bound] :global
+                     (layout/row-major ['_n_bound] (get array-types %)) :operand)
+                   inputs)
+              (map #(body/->KernelParameter
+                     % :output (get array-types %) ['_n_bound] :global
+                     (layout/row-major ['_n_bound] (get array-types %)) :result)
+                   outputs)
+              (map #(body/->KernelParameter % :scalar (get scalar-types %) [] nil nil :parameter)
+                   scalars)
+              [(body/->KernelParameter '_n_bound :scalar :long [] nil nil :bound)]))]
+    {:kernel-body
+     (body/make
+      {:id [:segmap (:id segmap) :portable-one-item]
+       :parameters parameters
+       :stable-reads (mapv body/stable-read inputs)
+       :indices [(body/->IndexBinding group-index :group 0)
+                 (body/->IndexBinding local-index :local 0)
+                 (body/->IndexCompute
+                  index
+                  (body/index-cast
+                   (body/expression :add
+                                    (body/expression :mul group-index workgroup-size)
+                                    local-index)
+                   :long :exact))]
+       :masks [(body/->Mask :map-active [(body/predicate :lt index '_n_bound)])]
+       :operations scalar-operations
+       :schedule {:strategy :one-work-item-per-element :association :independent
+                  :workgroup-size workgroup-size}
+       :launch (launch/spec {:workgroup-size [workgroup-size]
+                             :group-count [(launch/ceil-div bound workgroup-size)]})
+       :provenance {:dialect :kernel-body :source-dialect :segmap
+                    :segop-id (:id segmap)}
+       :attributes {:kind :portable-segmap :extent bound :no-write-alias true}})
+     :bound bound :inputs inputs :outputs outputs :scalars scalars}))

--- a/src/raster/compiler/passes/parallel/segmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segmap_body.clj
@@ -140,7 +140,7 @@
                    outputs)
               (map #(body/->KernelParameter % :scalar (get scalar-types %) [] nil nil :parameter)
                    scalars)
-              [(body/->KernelParameter '_n_bound :scalar :long [] nil nil :bound)]))]
+              [(body/->KernelParameter '_n_bound :scalar :int [] nil nil :bound)]))]
     {:kernel-body
      (body/make
       {:id [:segmap (:id segmap) :portable-one-item]
@@ -155,7 +155,9 @@
                                     (body/expression :mul group-index workgroup-size)
                                     local-index)
                    :long :exact))]
-       :masks [(body/->Mask :map-active [(body/predicate :lt index '_n_bound)])]
+       :masks [(body/->Mask
+                :map-active
+                [(body/predicate :lt index (body/index-cast '_n_bound :long :exact))])]
        :operations scalar-operations
        :schedule {:strategy :one-work-item-per-element :association :independent
                   :workgroup-size workgroup-size}

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -36,6 +36,14 @@
          (raster.numeric/* (raster.arrays/aget left index)
                            (raster.arrays/aget right index))))))
 
+(deftm public-c-family-map
+  "Public equation-first scalar map compiled by nvcc/hipcc without a physical device."
+  [input :- (Array float) n :- Long] :- (Array float)
+  (let [output (float-array n)]
+    (raster.par/map! output index n float
+                     (raster.numeric/* (float 2.0)
+                                       (raster.arrays/aget input index)))))
+
 (defn- reduction-artifact
   [dialect]
   (let [form (with-meta
@@ -175,8 +183,12 @@
      device-id {:type target
                 :name (str "Synthetic " (name target) " public compile gate")
                 :capabilities capabilities})
-    (:kernels (equation-first/compile
-               #'public-c-family-dot {:target device-id :dtype :float}))))
+    (vec
+     (concat
+      (:kernels (equation-first/compile
+                 #'public-c-family-dot {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
+                 #'public-c-family-map {:target device-id :dtype :float}))))))
 
 (defn- write-artifact!
   [directory suffix label artifact]

--- a/test/raster/compiler/equation_first_c_family_test.clj
+++ b/test/raster/compiler/equation_first_c_family_test.clj
@@ -47,12 +47,30 @@
          (raster.numeric/* (raster.arrays/aget left index)
                            (raster.arrays/aget right index))))))
 
-(deftm uncovered-elementwise
+(deftm c-family-elementwise
   [input :- (Array float) n :- Long] :- (Array float)
   (let [output (float-array n)]
     (raster.par/map! output index n float
                      (raster.numeric/* (float 2.0)
                                        (raster.arrays/aget input index)))))
+
+(deftm c-family-effect-map!
+  [input :- (Array float) left :- (Array float) right :- (Array long) n :- Long] :- Void
+  (raster.par/map-void!
+   index n
+   (do (raster.arrays/aset left index
+                           (float (raster.numeric/* (float 2.0)
+                                                    (raster.arrays/aget input index))))
+       (raster.arrays/aset right index (long index)))))
+
+(deftm uncovered-stencil
+  [input :- (Array float) n :- Long] :- (Array float)
+  (let [output (float-array n)]
+    (raster.par/stencil!
+     output [input] 1 :dirichlet float index n
+     (raster.numeric/+
+      (raster.arrays/aget input (dec index))
+      (raster.arrays/aget input (inc index))))))
 
 (deftm c-family-segment-sum!
   [output :- (Array float) segment-count :- Long width :- Long] :- Void
@@ -93,11 +111,41 @@
         (is (= (:emitted compilation)
                (emitted-program/validate! (:emitted compilation))))))))
 
-(deftest public-c-family-route-never-borrows-opencl-source
+(deftest public-elementwise-map-uses-portable-kernel-body
+  (doseq [[target module-target]
+          [[cuda-target :cuda-c]
+           [hip-target :hip-cpp]]]
+    (let [compilation (equation-first/compile
+                       #'c-family-elementwise {:target target :dtype :float})
+          kernel (first (:kernels compilation))]
+      (is (= [module-target] (mapv :target (:kernels compilation))))
+      (is (= :portable-segmap
+             (get-in kernel [:attributes :kernel-body :attributes :kind])))
+      (is (= :none (get-in compilation [:stats :fallback]))))))
+
+(deftest public-effect-map-preserves-typed-multi-output-storage
+  (doseq [[target module-target]
+          [[cuda-target :cuda-c]
+           [hip-target :hip-cpp]]]
+    (let [compilation (equation-first/compile
+                       #'c-family-effect-map! {:target target :dtype :float})
+          linked (equation-first/lower
+                  compilation [(float-array 8) (float-array 8) (long-array 8) 8])
+          kernel (first (:kernels compilation))]
+      (is (= module-target (:target kernel)))
+      (is (= #{'left 'right}
+             (into #{}
+                   (comp (filter #(= :output (:kind %))) (map :id))
+                   (get-in kernel [:attributes :kernel-body :parameters]))))
+      (is (empty? (:outputs linked)) "Void host semantics remain effect-only")
+      (is (= :none (get-in compilation [:stats :fallback]))))))
+
+(deftest uncovered-c-family-route-never-borrows-opencl-source
   (doseq [target [cuda-target hip-target]]
     (let [failure (reason-of #(equation-first/compile
-                               #'uncovered-elementwise {:target target :dtype :float}))]
-      (is (= :kernel-graph-target-lowering-missing (:reason failure)))
+                               #'uncovered-stencil {:target target :dtype :float}))]
+      (is (contains? #{:equation-first-coverage :kernel-graph-target-lowering-missing}
+                     (:reason failure)))
       (is (= :none (:fallback failure))))))
 
 (deftest public-segmented-fold-map-uses-the-same-c-family-boundary


### PR DESCRIPTION
Adds a shared typed scalar-expression lowering boundary for SegMap and SegFoldMap, then lowers one-dimensional maps to target-neutral KernelBody with stable reads, explicit scalar SSA, branches, retained cast policy, participation masks, and horizontally fused stores. Public equation-first maps now emit as OpenCL, CUDA, or HIP without source reconstruction; unsupported loop-carried regions still decline with fallback none. The hardware-free fixture sends a real public map through both nvcc and hipcc. Focused coverage: 72 tests and 549 assertions, plus local nvcc sm_80 PTX and hipcc gfx1100 HSACO compilation.