### PR TITLE
Lower ordered scalar loops through KernelBody

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -84,8 +84,10 @@ and HIP reduction phases through nvcc/hipcc in CI. Graph families that have not 
 portable KernelBody fail at this boundary instead of embedding OpenCL source in a CUDA/HIP
 program. Typed one-dimensional SegMap now shares one scalar-expression lowering with SegFoldMap:
 stable loads, retained dtypes, scalar SSA, branches, and horizontally fused stores emit from the
-same KernelBody to all three C-family targets. Loop-carried map regions, SegStencil, and SegScan
-remain explicit coverage gaps.
+same KernelBody to all three C-family targets. Canonical loop/recur scalar carries become ordered
+KernelBody `ForLoop` regions rather than being reassociated as reductions. This is sufficient for
+the public seven-stage GQA composition to emit entirely as CUDA/HIP and pass both vendor compilers;
+SegStencil and SegScan remain explicit coverage gaps.
 
 The map/scalar/full-reduction/certified-scan front end now constructs TypedSOAC directly from closed analyzed
 source and retained walker type metadata. It establishes stable equation/value identity, types,
@@ -1084,9 +1086,10 @@ The immediate continuation after the verified double-buffered weighted-reduction
    route, including resident block transfers. The public flat `par/gather` spelling now canonicalizes
    to that ordinary typed map: JVM scheduling recognizes an exact stable indirect read and selects
    hardware `vgather`, while the portable scalar/control KernelBody emits the admitted scheduled
-   SegMap subset across OpenCL, CUDA and HIP. Loop-carried scalar regions remain a checked decline
-   until their TypedSOAC loop values lower to KernelBody `ForLoop`. Kernel-local C names are fresh
-   with respect to the typed ABI, so an index buffer cannot shadow the launch coordinate. Flat
+   SegMap subset across OpenCL, CUDA and HIP. Canonical one-index/one-carry scalar loops preserve
+   their ordered semantics as KernelBody `ForLoop`; non-canonical control remains a checked decline.
+   Kernel-local C names are fresh with respect to the typed ABI, so an index buffer cannot shadow
+   the launch coordinate. Flat
    additive reducing scatters also carry a checked conflict algebra through this boundary and select
    exact JVM or atomic OpenCL schedules. Strided gather/scatter, additional atomic monoids,
    privatized histogram schedules, the remaining parallel forms, calibrated whole-graph placement

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -864,6 +864,12 @@
            (<= (dtype/bytes-of source-type) (dtype/bytes-of result-type)))
       (str "(" (target-type result-type) ")(" argument-source ")")
 
+      ;; Every signed 32-bit integer is exactly representable as IEEE f64.
+      (and (not source-fp?) result-fp? (= :double result-type)
+           (<= (dtype/bytes-of source-type) 4)
+           (= [:exact :exact] [rounding overflow]))
+      (str "(" (target-type result-type) ")(" argument-source ")")
+
       :else
       (throw (ex-info "C-family target cannot preserve this KernelBody cast policy"
                       {:reason :kernel-body-c-cast-policy
@@ -1655,7 +1661,7 @@
                    (map #(c-dialect/parameter-declaration
                           *scalar-dialect*
                           (cond-> % (contains? stable-reads (:id %))
-                            (assoc :restrict? true))
+                                  (assoc :restrict? true))
                           (get parameter-names (:id %)))
                         parameters))
          ") {\n"

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -8,7 +8,8 @@
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
-            [raster.compiler.ir.kernel-body :as body]))
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.passes.parallel.patterns :as patterns]))
 
 (def ^:private cast-heads
   {'byte :byte, 'clojure.core/byte :byte
@@ -25,6 +26,34 @@
       (reduce (fn [result [id init]] (util/subst-syms {id init} result))
               result (reverse (partition 2 bindings))))
     expression))
+
+(defn- match-ordered-loop
+  "Recognize the canonical one-index/one-carry loop without authorizing reassociation."
+  [expression]
+  (or
+   (some-> (patterns/match-reduce-loop expression) (assoc :inclusive? false))
+   (when-let [{:keys [kind index-sym acc-sym acc-init body-form bound]}
+              (patterns/normalize-loop expression)]
+     (when (and (= :reduce-loop kind)
+                (= :le (descriptor/comparison-kind
+                        (descriptor/semantic-op (second body-form)))))
+       (let [[_ _test then-branch else-expr] body-form
+             recur-form (patterns/find-recur-form then-branch)
+             recur-args (vec (rest recur-form))
+             index-update? #(= 1 (descriptor/affine-step % index-sym))
+             [update-expr index-update]
+             (cond
+               (and (= 2 (count recur-args)) (index-update? (second recur-args)))
+               [(first recur-args) (second recur-args)]
+
+               (and (= 2 (count recur-args)) (index-update? (first recur-args)))
+               [(second recur-args) (first recur-args)]
+
+               :else [nil nil])]
+         (when (and update-expr index-update)
+           {:acc-sym acc-sym :acc-init acc-init :index-sym index-sym
+            :bound-expr bound :else-expr else-expr :update-expr update-expr
+            :inclusive? true}))))))
 
 (defn make-lowerer
   "Build a scalar-expression lowerer.
@@ -59,7 +88,34 @@
     (when-not (and (fn? lower-index) (fn? decline!))
       (throw (ex-info "scalar KernelBody lowering requires index and decline callbacks"
                       {:reason :raster/bug :lower-index lower-index :decline decline!})))
-    (letfn [(lower [expression expected env]
+    (letfn [(cast-lowered [lowered target expression]
+              (let [target (dtype/canon target)]
+                (if (= target (:type lowered))
+                  lowered
+                  (let [source (dtype/canon (:type lowered))
+                        fp-source? (dtype/fp-dtype? source)
+                        fp-target? (dtype/fp-dtype? target)
+                        widening? (<= (dtype/bytes-of source) (dtype/bytes-of target))
+                        [rounding overflow]
+                        (cond
+                          (and fp-source? fp-target? widening?) [:exact :exact]
+                          (and fp-source? fp-target?) [:nearest-even :ieee]
+                          (and (not fp-source?) (not fp-target?) widening?) [:exact :exact]
+                          (and (not fp-source?) fp-target? (= :double target)
+                               (<= (dtype/bytes-of source) 4)) [:exact :exact]
+                          :else
+                          (decline! :cast-policy
+                                    "scalar cast has no portable exact policy"
+                                    {:expression expression :source source :target target}))
+                        id (fresh "cast")]
+                    {:operations (conj (:operations lowered)
+                                       (body/->ScalarCompute
+                                        (body/value id target)
+                                        (body/cast-expression (:result lowered) target
+                                                              rounding overflow)))
+                     :result id :type target}))))
+
+            (lower [expression expected env]
               (let [expression (inline-lets expression)
                     expected (canon-type expected)]
                 (cond
@@ -88,7 +144,7 @@
                     (let [id (fresh "load")]
                       {:operations [(body/->ScalarLoad
                                      (body/value id array-type) array
-                                     [(lower-index coordinate)] predicate
+                                     [(lower-index coordinate (set (keys env)))] predicate
                                      (when predicate (body/literal 0 array-type)) :cached)]
                        :result id :type array-type}))
 
@@ -97,28 +153,15 @@
                   (let [target (dtype/canon (get cast-heads (first expression)))
                         source-expected (dtype/canon (source-type (second expression) target env))
                         lowered (lower (second expression) source-expected env)]
-                    (if (= target (:type lowered))
-                      lowered
-                      (let [source (dtype/canon (:type lowered))
-                            fp-source? (dtype/fp-dtype? source)
-                            fp-target? (dtype/fp-dtype? target)
-                            widening? (<= (dtype/bytes-of source) (dtype/bytes-of target))
-                            [rounding overflow]
-                            (cond
-                              (and fp-source? fp-target? widening?) [:exact :exact]
-                              (and fp-source? fp-target?) [:nearest-even :ieee]
-                              (and (not fp-source?) (not fp-target?) widening?) [:exact :exact]
-                              :else
-                              (decline! :cast-policy
-                                        "scalar cast has no portable exact policy"
-                                        {:expression expression :source source :target target}))
-                            id (fresh "cast")]
-                        {:operations (conj (:operations lowered)
-                                           (body/->ScalarCompute
-                                            (body/value id target)
-                                            (body/cast-expression (:result lowered) target
-                                                                  rounding overflow)))
-                         :result id :type target})))
+                    (cast-lowered lowered target expression))
+
+                  (and (seq? expression)
+                       (= 'raster.numeric/oftype (descriptor/semantic-op expression))
+                       (= 2 (count (descriptor/call-args expression))))
+                  (let [value-expression (second (descriptor/call-args expression))
+                        source-expected (canon-type (source-type value-expression expected env))
+                        lowered (lower value-expression source-expected env)]
+                    (cast-lowered lowered expected expression))
 
                   (and (seq? expression) (= 'if (first expression)) (= 4 (count expression)))
                   (let [[_ condition then-expression else-expression] expression
@@ -142,6 +185,53 @@
                                   (body/->Yield [(:result else-value)]))
                             [(body/value result result-type)]))
                      :result result :type result-type})
+
+                  (and (seq? expression) (contains? #{'loop 'loop*} (first expression)))
+                  (if-let [{:keys [acc-sym acc-init index-sym bound-expr else-expr update-expr
+                                   inclusive?]}
+                           (match-ordered-loop expression)]
+                    (do
+                      (when (or (patterns/contains-sym? bound-expr index-sym)
+                                (patterns/contains-sym? bound-expr acc-sym)
+                                (not= else-expr acc-sym))
+                        (decline! :ordered-loop-shape
+                                  "ordered scalar loop requires an invariant upper bound and returns its carry"
+                                  {:expression expression :bound bound-expr
+                                   :index index-sym :accumulator acc-sym :exit else-expr}))
+                      (let [loop-index (fresh "loop-index")
+                            carry (fresh "loop-carry")
+                            result (fresh "loop-result")
+                            initial (lower acc-init expected env)
+                            loop-type (:type initial)
+                            update (util/subst-syms {index-sym loop-index acc-sym carry}
+                                                    update-expr)
+                            lowered (lower update loop-type
+                                           (assoc env loop-index :long carry loop-type))
+                            _ (when-not (= loop-type (:type lowered))
+                                (decline! :ordered-loop-dtype
+                                          "ordered scalar loop carry dtype must remain invariant"
+                                          {:expression expression :initial loop-type
+                                           :update (:type lowered)}))
+                            upper (lower-index bound-expr (set (keys env)))
+                            upper (if inclusive?
+                                    (body/expression :add upper
+                                                     (body/index-cast 1 :long :exact))
+                                    upper)
+                            loop (body/->ForLoop
+                                  (body/value loop-index :long)
+                                  (body/index-cast 0 :long :exact)
+                                  upper 1
+                                  [(body/->LoopArg (body/value carry loop-type)
+                                                   (:result initial))]
+                                  (conj (vec (:operations lowered))
+                                        (body/->Yield [(:result lowered)]))
+                                  [(body/value result loop-type)]
+                                  {:association :ordered})]
+                        {:operations (conj (vec (:operations initial)) loop)
+                         :result result :type loop-type}))
+                    (decline! :ordered-loop-shape
+                              "scalar loop is outside the canonical ordered carry form"
+                              {:expression expression}))
 
                   (seq? expression)
                   (let [operator (intrinsics/canonical (descriptor/semantic-op expression))

--- a/src/raster/compiler/passes/parallel/segfoldmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segfoldmap_body.clj
@@ -90,9 +90,13 @@
                                  (zipmap scheduled-indices (repeat :long))
                                  scalar-types)
         segment-count-source (segop/seg-space-num-segments-expr space)
-        lower-index #(widen-index-expression
-                      (contraction-body/lower-index % index-scope)
-                      index-value-types)
+        lower-index (fn lower-index
+                      ([expression] (lower-index expression #{}))
+                      ([expression extra-scope]
+                       (widen-index-expression
+                        (contraction-body/lower-index
+                         expression (set/union index-scope extra-scope))
+                        index-value-types)))
         segment-count (lower-index segment-count-source)
         map-extent (lower-index (:bound mapped-dim))
         total-elements (body/expression :mul segment-count map-extent)

--- a/src/raster/compiler/passes/parallel/segmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segmap_body.clj
@@ -85,8 +85,13 @@
         scalar-types (into {} (map (juxt identity scalar-dtype)) scalars)
         index-scope (conj (set scalars) index)
         index-types (assoc scalar-types index :long)
-        lower-index #(widen-index-expression
-                      (contraction-body/lower-index % index-scope) index-types)
+        lower-index (fn lower-index
+                      ([expression] (lower-index expression #{}))
+                      ([expression extra-scope]
+                       (widen-index-expression
+                        (contraction-body/lower-index
+                         expression (set/union index-scope extra-scope))
+                        index-types)))
         lowerer (scalar-expression/make-lowerer
                  {:array-types array-types :scalar-types scalar-types
                   :arrays (set inputs) :index-scope index-scope

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -22,6 +22,7 @@
             [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
             [raster.core :refer [deftm]]
+            [raster.dl.attention :as dl-attention]
             [raster.numeric]
             [raster.par]
             [raster.runtime.hardware :as hardware]))
@@ -188,7 +189,9 @@
       (:kernels (equation-first/compile
                  #'public-c-family-dot {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
-                 #'public-c-family-map {:target device-id :dtype :float}))))))
+                 #'public-c-family-map {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
+                 #'dl-attention/gqa-causal-mha {:target device-id :dtype :float}))))))
 
 (defn- write-artifact!
   [directory suffix label artifact]

--- a/test/raster/compiler/equation_first_c_family_test.clj
+++ b/test/raster/compiler/equation_first_c_family_test.clj
@@ -5,6 +5,7 @@
             [raster.compiler.equation-first :as equation-first]
             [raster.compiler.ir.emitted-parallel-program :as emitted-program]
             [raster.core :refer [deftm]]
+            [raster.dl.attention :as attention]
             [raster.numeric]
             [raster.par]
             [raster.runtime.hardware :as hardware]))
@@ -89,6 +90,15 @@
     (catch clojure.lang.ExceptionInfo exception
       (ex-data exception))))
 
+(defn- nested-operations
+  [operations]
+  (mapcat (fn [operation]
+            (cons operation
+                  (concat (nested-operations (or (:operations operation) []))
+                          (nested-operations (or (:then-operations operation) []))
+                          (nested-operations (or (:else-operations operation) [])))))
+          operations))
+
 (deftest public-equation-first-compilation-emits-cuda-and-hip-source
   (doseq [[target program-dialect module-target]
           [[cuda-target :cuda-parallel :cuda-c]
@@ -138,6 +148,35 @@
                    (comp (filter #(= :output (:kind %))) (map :id))
                    (get-in kernel [:attributes :kernel-body :parameters]))))
       (is (empty? (:outputs linked)) "Void host semantics remain effect-only")
+      (is (= :none (get-in compilation [:stats :fallback]))))))
+
+(deftest public-gqa-composition-emits-only-portable-c-family-kernels
+  (doseq [[target program-dialect module-target]
+          [[cuda-target :cuda-parallel :cuda-c]
+           [hip-target :hip-parallel :hip-cpp]]]
+    (let [compilation (equation-first/compile
+                       #'attention/gqa-causal-mha {:target target :dtype :float})
+          linked (equation-first/lower
+                  compilation
+                  [(float-array [1 0 0 1 1 1 1 -1])
+                   (float-array [1 0 0 1])
+                   (float-array [1 2 3 4])
+                   1 2 2 1 2])
+          kernels (:kernels compilation)
+          loops (for [kernel kernels
+                      operation (nested-operations
+                                 (get-in kernel [:attributes :kernel-body :operations]))
+                      :when (= "ForLoop" (some-> operation class .getSimpleName))]
+                  operation)]
+      (is (= program-dialect (get-in compilation [:emitted :dialect])))
+      (is (= 7 (count kernels)))
+      (is (every? #(= module-target (:target %)) kernels))
+      (is (every? #(get-in % [:attributes :kernel-body]) kernels))
+      (is (not-any? #(re-find #"__kernel|get_global_id|get_local_id" (:source %)) kernels))
+      (is (seq loops))
+      (is (every? #(= :ordered (get-in % [:attributes :association])) loops))
+      (is (= 0 (get-in linked [:attributes :driver-allocations])))
+      (is (= 1 (count (:outputs linked))))
       (is (= :none (get-in compilation [:stats :fallback]))))))
 
 (deftest uncovered-c-family-route-never-borrows-opencl-source


### PR DESCRIPTION
Lowers canonical one-index/one-carry loop-recur scalar regions into ordered KernelBody ForLoop operations without authorizing reassociation. Adds retained oftype conversion and the exact int-to-f64 cast policy needed by parametric scalar code. This closes the public seven-kernel GQA source vertical across CUDA and HIP with fallback none; CI fixtures send every emitted GQA stage through nvcc and hipcc. Public lower still produces an allocation-free LinkPlan. Focused coverage: 67 tests and 545 assertions; local vendor compilation passed for all seven GQA kernels on sm_80 and gfx1100.