### PR TITLE
Lower certified scans through portable KernelBody

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -87,7 +87,10 @@ stable loads, retained dtypes, scalar SSA, branches, and horizontally fused stor
 same KernelBody to all three C-family targets. Canonical loop/recur scalar carries become ordered
 KernelBody `ForLoop` regions rather than being reassociated as reductions. This is sufficient for
 the public seven-stage GQA composition to emit entirely as CUDA/HIP and pass both vendor compilers;
-SegStencil and SegScan remain explicit coverage gaps.
+SegStencil remains the explicit portable C-family coverage gap. Certified scans now lower their
+single- or three-phase schedule to target-neutral KernelBody scalar SSA, workgroup storage,
+barriers, ordered block carries, and inclusive/exclusive result placement. The same bodies compile
+with OpenCL, nvcc, and hipcc; the former handwritten OpenCL scan source path has been deleted.
 
 The map/scalar/full-reduction/certified-scan front end now constructs TypedSOAC directly from closed analyzed
 source and retained walker type metadata. It establishes stable equation/value identity, types,
@@ -99,7 +102,10 @@ certificate; its caller-owned destination and output layout are facts, not part 
 algebra. Both modes lower directly to the same one- or three-node SegScan `KernelGraph` without
 constructing a legacy `SoacScan`. Exclusive mode retains logical traversal extent `n`, records its
 result as `n+1` through checked symbolic integer-expression IR, and specializes scheduled stores to
-materialize the identity at zero and prefixes at `idx+1`. The GPU backend now target-lowers that
+materialize the identity at zero and prefixes at `idx+1`. Scan uses the same checked
+logical-result/physical-`result-storage` relation as every other destination-writing TypedSOAC;
+the destination is neither a functional capture nor a scan-specific backend convention. The GPU
+backend now target-lowers that
 scheduled value through one fail-loud graph-emission boundary, wraps it in the same
 `KernelDispatch` value used by other selectable
 schedules, and resident descriptor extraction retains it as one executable step. LinkPlan and the

--- a/src/raster/compiler/backend/gpu/parallel_program_c_family.clj
+++ b/src/raster/compiler/backend/gpu/parallel_program_c_family.clj
@@ -95,7 +95,16 @@
 
       (soac/program-form? algorithm)
       (let [body (scheduled-body parallel-program equation)
-            scheduled-graph (equation-graph/make algorithm body)
+            ;; Multi-phase schedules retain family-independent decisions (algebra, phase
+            ;; decomposition, tuning choice) on their certified graph. Rebuilding the physical
+            ;; dataflow remains generic, but those schedule facts must survive to target lowering.
+            graph-contract (get-in equation [:attributes :kernel-graph])
+            scheduled-graph (equation-graph/make
+                             algorithm body
+                             (cond-> {}
+                               graph-contract
+                               (assoc :provenance (:provenance graph-contract)
+                                      :attributes (:attributes graph-contract))))
             emitted (emit-graph scheduled-graph (:values body) (:operations equation) opts)]
         (assoc equation :operations
                [(emitted-equation/make algorithm body emitted {:provenance provenance})]))

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -30,6 +30,7 @@
             [raster.compiler.passes.parallel.segred-body :as segred-body]
             [raster.compiler.passes.parallel.segfoldmap-body :as segfoldmap-body]
             [raster.compiler.passes.parallel.segmap-body :as segmap-body]
+            [raster.compiler.passes.parallel.segscan-body :as segscan-body]
             [clojure.walk :as walk]
             [clojure.set]
             [raster.compiler.ir.segop :as segop]
@@ -1034,235 +1035,6 @@
         (assoc-in [:provenance :target-dialect] target-dialect)
         (assoc-in [:attributes :emitted?] true)
         kgraph/validate!)))
-
-(defn- scan-c-combine
-  [combine dtype]
-  (let [op (symbol (name combine))
-        floating? (contains? #{:float :double} dtype)
-        token (case op
-                + "+"
-                * "*"
-                bit-and "&"
-                bit-or "|"
-                bit-xor "^"
-                min (if floating? "fmin" "min")
-                max (if floating? "fmax" "max")
-                (throw (ex-info "certified scan combine has no OpenCL lowering"
-                                {:reason :scan-combine-not-emittable
-                                 :combine combine :dtype dtype})))]
-    (fn [left right]
-      (if (contains? #{"fmin" "fmax" "min" "max"} token)
-        (str token "(" left ", " right ")")
-        (str "(" left " " token " " right ")")))))
-
-(defn- scan-c-identity
-  [identity dtype]
-  (cond
-    (contains? #{'Double/POSITIVE_INFINITY 'Float/POSITIVE_INFINITY} identity) "INFINITY"
-    (contains? #{'Double/NEGATIVE_INFINITY 'Float/NEGATIVE_INFINITY} identity) "-INFINITY"
-    (number? identity) (if (= :float dtype) (str (float identity) "f") (str identity))
-    (and (seq? identity) (= 2 (count identity)) (number? (second identity)))
-    (scan-c-identity (second identity) dtype)
-    :else (throw (ex-info "certified scan identity has no OpenCL literal"
-                          {:reason :scan-identity-not-emittable
-                           :identity identity :dtype dtype}))))
-
-(defn generate-scan-kernel-graph
-  "Target-lower a certified scheduled scan graph into a graph of verified KernelArtifacts.
-
-   The graph remains the owner of buffers and dependencies. Each node artifact owns exactly one
-   OpenCL entry point, ordered ABI, arguments, and launch. No runtime marker convention is involved
-   in this conversion. The block-totals kernel deliberately scans arbitrarily many totals in
-   workgroup-sized chunks, so symbolic input sizes do not require an unrolled recursive graph."
-  [graph & {:keys [kernel-name-prefix scalar-types]
-            :or {kernel-name-prefix "segscan" scalar-types {}}}]
-  (let [graph (kgraph/validate! graph)
-        algebra (get-in graph [:attributes :scan-algebra])
-        _ (when-not (scan/associative-scan? algebra)
-            (throw (ex-info "scan KernelGraph lacks certified associative algebra"
-                            {:reason :uncertified-scan-graph :algebra algebra})))
-        scan-mode (or (get-in graph [:attributes :scan-mode]) :inclusive)
-        _ (when-not (contains? #{:inclusive :exclusive} scan-mode)
-            (throw (ex-info "scan KernelGraph has an unsupported result mode"
-                            {:reason :scan-mode-not-emittable :mode scan-mode})))
-        _ (when-not (= 1 (count (:outputs graph)))
-            (throw (ex-info "scan artifact lowering requires exactly one graph output"
-                            {:reason :scan-multi-output-unimplemented
-                             :outputs (mapv :id (:outputs graph))})))
-        dtype (:dtype algebra)
-        ctype (dt/ctype :opencl dtype)
-        combine-c (scan-c-combine (:combine algebra) dtype)
-        identity-c (scan-c-identity (:identity algebra) dtype)
-        buffers (into {} (map (juxt :id identity))
-                      (concat (:inputs graph) (:outputs graph) (:temporaries graph)))
-        temporary-ids (set (map :id (:temporaries graph)))
-        output-ids (set (map :id (:outputs graph)))
-        first-scan (some #(when (segop/segop? (:operation %))
-                            (when (:scan-op (:operation %)) (:operation %)))
-                         (:nodes graph))
-        scan-workgroup (or (get-in first-scan [:grid :block-size]) 256)
-        scalar-dtype (fn [sym]
-                       (or (get scalar-types sym)
-                           (get scalar-types (symbol (name sym)))
-                           dtype))
-        emit-node
-        (fn [{:keys [id operation uses]}]
-          (let [phase (or (:phase operation) :carry-in)
-                bound (seg-bound operation)
-                workgroup (or (get-in operation [:grid :block-size]) scan-workgroup)
-                pointer-ids (mapv :buffer uses)
-                scalar-ids (vec (sort-by name (:scalars operation)))
-                pointer-slots
-                (mapv (fn [{:keys [buffer access]}]
-                        (let [spec (get buffers buffer)
-                              output? (contains? #{:write :read-write} access)]
-                          (kabi/slot buffer (case access
-                                              :read :input
-                                              :write :output
-                                              :read-write :inout)
-                                     (:dtype spec)
-                                     :c-name (ce/c-symbol buffer)
-                                     :role (cond
-                                             (contains? temporary-ids buffer) :temporary
-                                             (and output? (contains? output-ids buffer)) :result
-                                             :else :operand))))
-                      uses)
-                scalar-slots (mapv #(kabi/slot % :scalar (scalar-dtype %)
-                                               :c-name (ce/c-symbol %) :role :parameter)
-                                   scalar-ids)
-                bound-slot (kabi/slot '_n_bound :scalar :int :role :bound)
-                abi (kabi/validate! (vec (concat pointer-slots scalar-slots [bound-slot])))
-                pointer-param
-                (fn [slot]
-                  (str "__global " (when (= :input (:kind slot)) "const ")
-                       (dt/ctype :opencl (:kernel-dtype slot)) "* restrict " (:c-name slot)))
-                scalar-param
-                (fn [slot]
-                  (str (dt/ctype :opencl (:kernel-dtype slot)) " " (:c-name slot)))
-                params (str/join ", "
-                                 (concat (map pointer-param pointer-slots)
-                                         (map scalar-param scalar-slots)
-                                         ["int _n_bound"]))
-                kernel-name (str kernel-name-prefix "_" (str/replace (name phase) "-" "_")
-                                 "_" (gensym ""))
-                totals-id (first (filter temporary-ids pointer-ids))
-                out-id (first (filter output-ids pointer-ids))
-                totals-c (some-> totals-id ce/c-symbol)
-                out-c (some-> out-id ce/c-symbol)
-                idx (or (some-> operation :space segop/seg-space-reduced-dim :name) 'idx)
-                input-ids (vec (:inputs operation))
-                int-scalars (set (keep #(when (= :int (scalar-dtype %)) %) scalar-ids))
-                element (:element algebra)
-                element-c
-                (when (contains? #{:single :intra-block} phase)
-                  (binding [ce/*emit-config* ce/opencl-config
-                            ce/*scalar-type* ctype
-                            ce/*idx-sym* idx
-                            ce/*int-vars* (into ce/*int-vars* int-scalars)]
-                    (ce/emit-expr (ce/adapt-casts-for-dtype
-                                   (ce/normalize-array-prims element) dtype)
-                                  idx (set (map #(symbol (name %)) input-ids)) "idx")))
-                result-index (if (= :exclusive scan-mode) "idx + 1" "idx")
-                source-body
-                (case phase
-                  (:single :intra-block)
-                  (str "    __local " ctype " sdata[" workgroup "];\n"
-                       "    int tid = get_local_id(0);\n"
-                       "    int block = get_group_id(0);\n"
-                       "    int base = block * " workgroup ";\n"
-                       "    int idx = base + tid;\n"
-                       "    " ctype " value = " identity-c ";\n"
-                       "    if (idx < _n_bound) value = (" ctype ")(" element-c ");\n"
-                       "    sdata[tid] = value;\n"
-                       "    barrier(CLK_LOCAL_MEM_FENCE);\n"
-                       "    for (int offset = 1; offset < " workgroup "; offset <<= 1) {\n"
-                       "        " ctype " self = sdata[tid];\n"
-                       "        " ctype " left = " identity-c ";\n"
-                       "        if (tid >= offset) left = sdata[tid - offset];\n"
-                       "        barrier(CLK_LOCAL_MEM_FENCE);\n"
-                       "        if (tid >= offset) sdata[tid] = " (combine-c "left" "self") ";\n"
-                       "        barrier(CLK_LOCAL_MEM_FENCE);\n"
-                       "    }\n"
-                       (when (= :exclusive scan-mode)
-                         (str "    if (block == 0 && tid == 0) " out-c "[0] = " identity-c ";\n"))
-                       "    if (idx < _n_bound) " out-c "[" result-index "] = sdata[tid];\n"
-                       (when totals-c
-                         (str "    if (tid == 0 && base < _n_bound) {\n"
-                              "        int valid = min(" workgroup ", _n_bound - base);\n"
-                              "        " totals-c "[block] = sdata[valid - 1];\n"
-                              "    }\n")))
-
-                  :block-scan
-                  (str "    __local " ctype " sdata[" workgroup "];\n"
-                       "    __local " ctype " carry;\n"
-                       "    int tid = get_local_id(0);\n"
-                       "    if (tid == 0) carry = " identity-c ";\n"
-                       "    barrier(CLK_LOCAL_MEM_FENCE);\n"
-                       "    for (int base = 0; base < _n_bound; base += " workgroup ") {\n"
-                       "        int idx = base + tid;\n"
-                       "        sdata[tid] = (idx < _n_bound) ? " totals-c "[idx] : " identity-c ";\n"
-                       "        barrier(CLK_LOCAL_MEM_FENCE);\n"
-                       "        for (int offset = 1; offset < " workgroup "; offset <<= 1) {\n"
-                       "            " ctype " self = sdata[tid];\n"
-                       "            " ctype " left = " identity-c ";\n"
-                       "            if (tid >= offset) left = sdata[tid - offset];\n"
-                       "            barrier(CLK_LOCAL_MEM_FENCE);\n"
-                       "            if (tid >= offset) sdata[tid] = " (combine-c "left" "self") ";\n"
-                       "            barrier(CLK_LOCAL_MEM_FENCE);\n"
-                       "        }\n"
-                       "        " ctype " prefix = carry;\n"
-                       "        barrier(CLK_LOCAL_MEM_FENCE);\n"
-                       "        if (idx < _n_bound) " totals-c "[idx] = "
-                       (combine-c "prefix" "sdata[tid]") ";\n"
-                       "        barrier(CLK_LOCAL_MEM_FENCE);\n"
-                       "        if (tid == 0) {\n"
-                       "            int valid = min(" workgroup ", _n_bound - base);\n"
-                       "            carry = " (combine-c "prefix" "sdata[valid - 1]") ";\n"
-                       "        }\n"
-                       "        barrier(CLK_LOCAL_MEM_FENCE);\n"
-                       "    }\n")
-
-                  :carry-in
-                  (str "    int stride = get_global_size(0);\n"
-                       "    for (int idx = get_global_id(0); idx < _n_bound; idx += stride) {\n"
-                       "        int block = idx / " scan-workgroup ";\n"
-                       "        if (block > 0) " out-c "[" result-index "] = "
-                       (combine-c (str totals-c "[block - 1]")
-                                  (str out-c "[" result-index "]")) ";\n"
-                       "    }\n")
-
-                  (throw (ex-info "scheduled scan node has no target lowering"
-                                  {:reason :scan-phase-not-emittable :phase phase :node id})))
-                source (str (apply codegen/extension-pragmas
-                                   dtype (map :dtype (keep buffers pointer-ids)))
-                            "__kernel void " kernel-name "(" params ") {\n"
-                            source-body
-                            "}\n")
-                group-count (case phase
-                              (:single :block-scan) [1]
-                              :intra-block [(klaunch/ceil-div bound workgroup)]
-                              :carry-in [(klaunch/ceil-div bound workgroup)])
-                shared-bytes (if (= :carry-in phase) 0 (* workgroup (dt/bytes-of dtype)))]
-            (kart/make
-             {:kernel-name kernel-name
-              :source source
-              :abi abi
-              :arguments (vec (concat pointer-ids scalar-ids [bound]))
-              :launch (klaunch/spec {:workgroup-size [workgroup]
-                                     :group-count group-count
-                                     :shared-memory-bytes shared-bytes})
-              :temporaries []
-              :effects {:kind :scan-stage :phase phase}
-              :provenance {:dialect :segscan :segop-id (:id operation) :graph-node id}
-              :attributes {:phase phase :dtype dtype :scan-mode scan-mode
-                           :scan-workgroup scan-workgroup}})))
-        emitted (kgraph/map-operations
-                 graph
-                 (fn [node]
-                   (kart/certify-scheduled-operation
-                    (emit-node node) (:operation node))))]
-    (finalize-emitted-graph emitted :opencl-c scalar-types)))
-
 (defn- graph-array-types
   [graph array-types]
   (let [declared-array-types
@@ -1278,6 +1050,102 @@
                             {:reason :kernel-graph-buffer-dtype
                              :buffer id :declared declared :supplied supplied})))]
     (merge array-types declared-array-types)))
+
+(defn generate-scan-kernel-graph
+  "Lower a certified scheduled scan graph through portable KernelBody data.
+
+   Every node retains the graph's exact ordered ABI and dependency structure.  OpenCL, CUDA and
+   HIP consume the same scheduled bodies; this boundary contains no source-template fallback."
+  [graph & {:keys [kernel-name-prefix scalar-types array-types target-dialect]
+            :or {kernel-name-prefix "segscan" scalar-types {} array-types {}
+                 target-dialect :opencl-intel}}]
+  (let [graph (kgraph/validate! graph)
+        algebra (get-in graph [:attributes :scan-algebra])
+        scan-mode (or (get-in graph [:attributes :scan-mode]) :inclusive)
+        _ (when-not (scan/associative-scan? algebra)
+            (throw (ex-info "scan KernelGraph lacks certified associative algebra"
+                            {:reason :uncertified-scan-graph :algebra algebra})))
+        _ (when-not (contains? #{:inclusive :exclusive} scan-mode)
+            (throw (ex-info "scan KernelGraph has an unsupported result mode"
+                            {:reason :scan-mode-not-emittable :mode scan-mode})))
+        _ (when-not (= 1 (count (:outputs graph)))
+            (throw (ex-info "scan artifact lowering requires exactly one graph output"
+                            {:reason :scan-multi-output-unimplemented
+                             :outputs (mapv :id (:outputs graph))})))
+        target (kernel-body-c-dialect/resolve! target-dialect)
+        target-module (kernel-body-c-dialect/target target)
+        array-types (graph-array-types graph array-types)
+        buffers (into {} (map (juxt :id identity))
+                      (concat (:inputs graph) (:outputs graph) (:temporaries graph)))
+        temporary-ids (set (map :id (:temporaries graph)))
+        output-ids (set (map :id (:outputs graph)))
+        first-scan (some #(when (instance? raster.compiler.ir.segop.SegScan (:operation %))
+                            (:operation %))
+                         (:nodes graph))
+        scan-workgroup (or (get-in first-scan [:grid :block-size]) 256)
+        scalar-dtype (fn [id]
+                       (or (get scalar-types id)
+                           (get scalar-types (symbol (name id)))
+                           (:dtype algebra)))
+        emitted
+        (kgraph/map-operations
+         graph
+         (fn [{:keys [id operation uses]}]
+           (let [{:keys [kernel-body phase bound pointer-ids scalar-ids]}
+                 (segscan-body/lower
+                  operation
+                  {:uses uses :buffers buffers
+                   :temporary-ids temporary-ids :output-ids output-ids
+                   :scan-algebra algebra :scan-mode scan-mode
+                   :scan-workgroup scan-workgroup
+                   :scalar-types scalar-types :array-types array-types})
+                 parameters (:parameters kernel-body)
+                 kernel-name (str kernel-name-prefix "_" (str/replace (name phase) "-" "_")
+                                  "_" (gensym ""))
+                 parameter-names (into {}
+                                       (map (fn [parameter]
+                                              [(:id parameter) (ce/c-symbol (:id parameter))]))
+                                       parameters)
+                 source (kernel-body-opencl/emit-scalar-kernel
+                         kernel-name kernel-body
+                         {:target-dialect target-dialect
+                          :parameter-names parameter-names})
+                 pointer-slots
+                 (mapv
+                  (fn [{:keys [buffer access]}]
+                    (let [spec (get buffers buffer)
+                          output? (contains? #{:write :read-write} access)]
+                      (kabi/slot
+                       buffer
+                       (case access :read :input :write :output :read-write :inout)
+                       (:dtype spec) :c-name (get parameter-names buffer)
+                       :role (cond
+                               (contains? temporary-ids buffer) :temporary
+                               (and output? (contains? output-ids buffer)) :result
+                               :else :operand))))
+                  uses)
+                 scalar-slots
+                 (mapv #(kabi/slot % :scalar (scalar-dtype %)
+                                   :c-name (get parameter-names %) :role :parameter)
+                       scalar-ids)
+                 bound-slot (kabi/slot '_n_bound :scalar :int
+                                       :c-name (get parameter-names '_n_bound) :role :bound)
+                 abi (body-abi/project-contracts
+                      (vec (concat pointer-slots scalar-slots [bound-slot])) kernel-body)
+                 artifact
+                 (kart/make
+                  {:kernel-name kernel-name :target target-module :source source :abi abi
+                   :arguments (vec (concat pointer-ids scalar-ids [bound]))
+                   :launch (:launch kernel-body) :temporaries []
+                   :effects {:kind :scan-stage :phase phase}
+                   :provenance {:dialect :kernel-body :source-dialect :segscan
+                                :segop-id (:id operation) :graph-node id}
+                   :attributes {:phase phase :dtype (:dtype algebra) :scan-mode scan-mode
+                                :scan-workgroup scan-workgroup :kernel-body kernel-body
+                                :emission-route :kernel-body
+                                :target-dialect target-dialect}})]
+             (kart/certify-scheduled-operation artifact operation))))]
+    (finalize-emitted-graph emitted target-module scalar-types)))
 
 (defn- generate-elementwise-kernel-graph
   [graph {:keys [scalar-types array-types target-dialect]
@@ -1400,11 +1268,7 @@
                  (kernel-body-c-dialect/resolve! target-dialect))]
     (cond
       (scan/associative-scan? (get-in graph [:attributes :scan-algebra]))
-      (if opencl?
-        (apply generate-scan-kernel-graph graph (mapcat identity opts))
-        (throw (ex-info "scan graph has no portable KernelBody C-family lowering"
-                        {:reason :kernel-graph-target-lowering-missing
-                         :target-dialect target-dialect :fallback :none})))
+      (apply generate-scan-kernel-graph graph (mapcat identity opts))
 
       (and (seq (:nodes graph))
            (every? #(or (instance? raster.compiler.ir.segop.SegMap (:operation %))

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -339,6 +339,7 @@
   (when-not (and (vector? shape) (seq shape)
                  (every? #(or (value-id? %)
                               (and (integer? %) (pos? %))
+                              (launch/dimension-expression? %)
                               (and (record-kind?
                                     "raster.compiler.ir.kernel_body.IndexExpr" %)
                                    (expression? %)))

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -60,7 +60,8 @@
    operands with explicit scalar lambda parameters, so stable value IDs never leak into lexical
    expression binding. Lambda regions have one typed, ordered local-SSA spine. A local initializer
    may reference parameters, the map index, and earlier locals; results may reference all locals.
-   This represents shared scalar work once without smuggling type inference into an emitter."
+   This represents shared scalar work once without smuggling type inference into an emitter.
+   Scan results use the same result-storage relation when materialized into caller-owned buffers."
   (:require [clojure.set :as set]
             [pattern.nanopass.dialect :as dialect
              :refer [def-dialect]]
@@ -1286,7 +1287,7 @@
         {:keys [kind]} (operation-parts equation)
         storage (result-storage program-facts equation-id)]
     (when storage
-      (when-not (contains? #{'map 'scatter 'stencil 'segmented-reduce
+      (when-not (contains? #{'map 'scatter 'stencil 'segmented-reduce 'scan
                              'product-reduce 'segmented-fold-map} kind)
         (fail! :typed-soac-result-storage-operation
                "physical result storage is valid only for writing tensor operations"
@@ -1303,7 +1304,7 @@
                {:equation equation-id :results results :storage storage}))
       (let [destinations (mapv :destination storage)
             aliases (get-in program-facts [:equations equation-id :aliases])]
-        (when (and (contains? #{'stencil 'segmented-fold-map} kind)
+        (when (and (contains? #{'stencil 'segmented-fold-map 'scan} kind)
                    (seq (set/intersection
                          (set destinations)
                          (set (get-in (operation-parts equation)

--- a/src/raster/compiler/passes/parallel/segscan_body.clj
+++ b/src/raster/compiler/passes/parallel/segscan_body.clj
@@ -1,0 +1,404 @@
+(ns raster.compiler.passes.parallel.segscan-body
+  "Portable KernelBody schedules for certified one-dimensional SegScan graphs.
+
+   The functional scan algebra is already certified before this pass.  This pass makes the
+   selected Hillis-Steele schedule explicit: workgroup storage, full-participation barriers,
+   block totals, the ordered block-total carry, and inclusive/exclusive result placement.  It
+   emits no target syntax and performs no scalar type inference."
+  (:require [clojure.set :as set]
+            [raster.compiler.backend.intrinsics :as intrinsics]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.layout :as layout]
+            [raster.compiler.core.util :as util]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.scan :as scan]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.passes.parallel.contraction-body :as contraction-body]
+            [raster.compiler.passes.parallel.scalar-expression-body :as scalar-expression]))
+
+(defn- decline!
+  [rule message data]
+  (throw (ex-info message (assoc data :reason :segscan-kernel-body-declined
+                                 :missing-rule rule :fallback :none))))
+
+(defn declined?
+  [exception]
+  (= :segscan-kernel-body-declined (:reason (ex-data exception))))
+
+(defn- barrier []
+  (body/->WorkgroupBarrier
+   :workgroup #{:workgroup} :acquire-release (body/full-participation)))
+
+(defn- identity-value
+  [value result-type]
+  (let [value (if (and (seq? value) (= 2 (count value)) (number? (second value)))
+                (second value)
+                value)
+        value (if (symbol? value)
+                (case (str value)
+                  "Double/POSITIVE_INFINITY" Double/POSITIVE_INFINITY
+                  "Double/NEGATIVE_INFINITY" Double/NEGATIVE_INFINITY
+                  "Float/POSITIVE_INFINITY" Float/POSITIVE_INFINITY
+                  "Float/NEGATIVE_INFINITY" Float/NEGATIVE_INFINITY
+                  "Integer/MAX_VALUE" Integer/MAX_VALUE
+                  "Integer/MIN_VALUE" Integer/MIN_VALUE
+                  "Long/MAX_VALUE" Long/MAX_VALUE
+                  "Long/MIN_VALUE" Long/MIN_VALUE
+                  value)
+                value)]
+    (when-not (number? value)
+      (decline! :literal-identity
+                "portable scan requires a scalar numerical identity"
+                {:identity value :dtype result-type}))
+    (body/literal value result-type)))
+
+(defn- offset-mask [offset]
+  (keyword (str "scan-offset-" offset)))
+
+(defn- scan-stages
+  [scratch result-type operator identity workgroup-size]
+  (mapcat
+   (fn [offset]
+     (let [self (symbol (str "scan-self-" offset))
+           left (symbol (str "scan-left-" offset))
+           combined (symbol (str "scan-combined-" offset))]
+       [(body/->ScalarLoad (body/value self result-type) scratch ['scan-lane]
+                           nil nil :cached)
+        (body/->ScalarLoad
+         (body/value left result-type) scratch
+         [(body/expression :sub 'scan-lane offset)]
+         (offset-mask offset) identity :cached)
+        (barrier)
+        (body/->ScalarCompute
+         (body/value combined result-type)
+         (body/scalar-expression operator result-type [left self]))
+        (body/->ScalarStore scratch ['scan-lane] combined (offset-mask offset))
+        (barrier)]))
+   (take-while #(< % workgroup-size) (iterate #(* 2 %) 1))))
+
+(defn- parameter
+  [buffer access spec role]
+  (let [buffer-type (dtype/canon (:dtype spec))
+        elements (:elements spec)]
+    (when-not (and buffer-type elements)
+      (decline! :buffer-contract
+                "scan graph buffer requires an explicit dtype and element extent"
+                {:buffer buffer :spec spec}))
+    (body/->KernelParameter
+     buffer (if (= :read access) :input :output) buffer-type [elements] :global
+     (layout/row-major [elements] buffer-type) role)))
+
+(defn- common-context
+  [operation {:keys [uses buffers temporary-ids output-ids scalar-types scan-algebra
+                     scan-mode scan-workgroup]}]
+  (let [phase (or (:phase operation) :carry-in)
+        result-type (dtype/canon (:dtype scan-algebra))
+        workgroup-size (or (get-in operation [:grid :block-size]) scan-workgroup)
+        bound (:bound (segop/seg-space-reduced-dim (:space operation)))
+        pointer-ids (mapv :buffer uses)
+        scalar-ids (vec (sort-by name (:scalars operation)))
+        scalar-type (fn [id]
+                      (dtype/canon (or (get scalar-types id)
+                                       (get scalar-types (symbol (name id)))
+                                       result-type)))
+        roles (fn [id access]
+                (cond
+                  (contains? temporary-ids id) :temporary
+                  (contains? output-ids id) (if (= :read-write access) :inout :result)
+                  :else :operand))
+        parameters (vec
+                    (concat
+                     (map (fn [{:keys [buffer access]}]
+                            (parameter buffer access (get buffers buffer)
+                                       (roles buffer access)))
+                          uses)
+                     (map #(body/->KernelParameter % :scalar (scalar-type %) [] nil nil
+                                                   :parameter)
+                          scalar-ids)
+                     [(body/->KernelParameter '_n_bound :scalar :int [] nil nil :bound)]))]
+    (when-not (and (contains? #{:single :intra-block :block-scan :carry-in} phase)
+                   (contains? #{:inclusive :exclusive} scan-mode)
+                   (scan/associative-scan? scan-algebra)
+                   (= result-type (dtype/canon (:dtype operation)))
+                   (integer? workgroup-size) (pos? workgroup-size)
+                   (zero? (bit-and workgroup-size (dec workgroup-size))))
+      (decline! :schedule-contract
+                "portable scan requires a certified scalar scan and a power-of-two workgroup"
+                {:phase phase :mode scan-mode :algebra scan-algebra
+                 :operation-dtype (:dtype operation) :workgroup-size workgroup-size}))
+    {:phase phase :result-type result-type :workgroup-size workgroup-size :bound bound
+     :pointer-ids pointer-ids :scalar-ids scalar-ids :scalar-type scalar-type
+     :parameters parameters
+     :stable-reads (mapv (comp body/stable-read :buffer)
+                         (filter #(= :read (:access %)) uses))}))
+
+(defn- element-operations
+  [operation context]
+  (let [{:keys [result-type pointer-ids scalar-ids scalar-type scan-algebra]} context
+        source-index (:name (segop/seg-space-reduced-dim (:space operation)))
+        expression (util/subst-syms {source-index 'scan-index} (:element scan-algebra))
+        array-types (into {} (map (fn [id] [id (get-in context [:buffers id :dtype])]))
+                          pointer-ids)
+        scalar-types (into {} (map (juxt identity scalar-type)) scalar-ids)
+        index-scope (conj (set scalar-ids) 'scan-index)
+        lower-index
+        (fn lower-index
+          ([form] (lower-index form #{}))
+          ([form extra-scope]
+           (contraction-body/lower-index form (set/union index-scope extra-scope))))
+        lowerer (scalar-expression/make-lowerer
+                 {:array-types array-types :scalar-types scalar-types
+                  :arrays (set pointer-ids) :index-scope index-scope
+                  :lower-index lower-index :predicate nil
+                  :id-prefix "scan-element" :decline! decline!})
+        lowered ((:lower lowerer) expression result-type
+                                    (assoc scalar-types 'scan-index :int))]
+    [(body/->ScalarCompute
+      (body/value 'scan-element-active :predicate)
+      (body/scalar-expression :lt :predicate ['scan-index '_n_bound]))
+     (body/->IfRegion
+      'scan-element-active
+      (conj (vec (:operations lowered)) (body/->Yield [(:result lowered)]))
+      [(body/->Yield [(identity-value (:identity scan-algebra) result-type)])]
+      [(body/value 'scan-element result-type)])]))
+
+(defn- scan-node-body
+  [operation context]
+  (let [{:keys [phase result-type workgroup-size bound parameters stable-reads scan-algebra
+                scan-mode temporary-ids output-ids]} context
+        operator (intrinsics/canonical (:combine scan-algebra))
+        identity (identity-value (:identity scan-algebra) result-type)
+        scratch 'scan-workgroup-values
+        output (first (filter output-ids (map :buffer (:uses context))))
+        totals (first (filter temporary-ids (map :buffer (:uses context))))
+        result-index (if (= :exclusive scan-mode)
+                       (body/expression :add 'scan-index 1)
+                       'scan-index)
+        offsets (take-while #(< % workgroup-size) (iterate #(* 2 %) 1))
+        masks (vec
+               (concat
+                [(body/->Mask :scan-active [(body/predicate :lt 'scan-index '_n_bound)])
+                 (body/->Mask :scan-lane-zero [(body/predicate :eq 'scan-lane 0)])
+                 (body/->Mask :scan-first-lane
+                              [(body/predicate :eq 'scan-group 0)
+                               (body/predicate :eq 'scan-lane 0)])]
+                (map #(body/->Mask (offset-mask %)
+                                   [(body/predicate :lte % 'scan-lane)])
+                     offsets)))
+        indices (vec
+                 (concat
+                  [(body/->IndexBinding 'scan-group :group 0)
+                   (body/->IndexBinding 'scan-lane :local 0)
+                   (body/->IndexCompute
+                    'scan-index
+                    (body/expression :add
+                                     (body/expression :mul 'scan-group workgroup-size)
+                                     'scan-lane))]
+                  (when totals
+                    [(body/->IndexCompute
+                      'scan-block-base (body/expression :mul 'scan-group workgroup-size))
+                     (body/->IndexCompute
+                      'scan-valid-count
+                      (body/expression :min workgroup-size
+                                       (body/expression :sub '_n_bound
+                                                        'scan-block-base)))])))
+        initial (element-operations operation context)
+        stages (scan-stages scratch result-type operator identity workgroup-size)
+        tail (vec
+              (concat
+               [(body/->ScalarLoad (body/value 'scan-result result-type) scratch ['scan-lane]
+                                   nil nil :cached)
+                (body/->ScalarStore output [result-index] 'scan-result :scan-active)]
+               (when totals
+                 [(body/->ScalarLoad
+                   (body/value 'scan-block-total result-type) scratch
+                   [(body/expression :sub 'scan-valid-count 1)]
+                   :scan-lane-zero identity :cached)
+                  (body/->ScalarStore totals ['scan-group] 'scan-block-total :scan-lane-zero)])
+               (when (= :exclusive scan-mode)
+                 [(body/->ScalarStore output [0]
+                                      identity
+                                      :scan-first-lane)])))
+        group-count (if (= :single phase) 1 (get-in operation [:grid :num-blocks]))]
+    (body/make
+     {:id [:segscan (:id operation) phase :portable-workgroup]
+      :parameters parameters :stable-reads stable-reads
+      :allocations [(body/->WorkgroupAllocation
+                     scratch result-type [workgroup-size]
+                     (layout/row-major [workgroup-size] result-type)
+                     (dtype/bytes-of result-type))]
+      :indices indices :masks masks
+      :operations (vec (concat initial
+                               [(body/->ScalarStore scratch ['scan-lane]
+                                                    'scan-element nil)
+                                (barrier)]
+                               stages tail))
+      :schedule {:strategy :workgroup-hillis-steele :association :certified
+                 :phase phase :workgroup-size workgroup-size :operator operator}
+      :launch (launch/spec
+               {:workgroup-size [workgroup-size]
+                :group-count [group-count]
+                :shared-memory-bytes (* workgroup-size (dtype/bytes-of result-type))})
+      :provenance {:dialect :kernel-body :source-dialect :segscan
+                   :segop-id (:id operation)}
+      :attributes {:kind :portable-segscan :phase phase :scan-mode scan-mode
+                   :operator operator :identity (:identity scan-algebra)}})))
+
+(defn- block-scan-body
+  [operation context]
+  (let [{:keys [result-type workgroup-size bound parameters scan-algebra temporary-ids]} context
+        totals (first (filter temporary-ids (map :buffer (:uses context))))
+        operator (intrinsics/canonical (:combine scan-algebra))
+        identity (identity-value (:identity scan-algebra) result-type)
+        scratch 'scan-workgroup-values
+        carry 'scan-workgroup-carry
+        offsets (take-while #(< % workgroup-size) (iterate #(* 2 %) 1))
+        masks (vec
+               (concat
+                [(body/->Mask :scan-lane-zero [(body/predicate :eq 'scan-lane 0)])
+                 (body/->Mask :scan-loop-active
+                              [(body/predicate
+                                :lt (body/expression :add 'scan-base 'scan-lane)
+                                '_n_bound)])]
+                (map #(body/->Mask (offset-mask %)
+                                   [(body/predicate :lte % 'scan-lane)])
+                     offsets)))
+        loop-body
+        (vec
+         (concat
+          [(body/->ScalarLoad (body/value 'scan-chunk-value result-type) totals
+                              [(body/expression :add 'scan-base 'scan-lane)]
+                              :scan-loop-active identity :cached)
+           (body/->ScalarStore scratch ['scan-lane] 'scan-chunk-value nil)
+           (barrier)]
+          (scan-stages scratch result-type operator identity workgroup-size)
+          [(body/->ScalarLoad (body/value 'scan-prefix result-type) carry [0]
+                              nil nil :cached)
+           (body/->ScalarLoad (body/value 'scan-chunk-prefix result-type) scratch
+                              ['scan-lane] nil nil :cached)
+           (body/->ScalarCompute
+            (body/value 'scan-total-prefix result-type)
+            (body/scalar-expression operator result-type
+                                    ['scan-prefix 'scan-chunk-prefix]))
+           (body/->ScalarStore totals [(body/expression :add 'scan-base 'scan-lane)]
+                                'scan-total-prefix :scan-loop-active)
+           (barrier)
+           (body/->ScalarCompute
+            (body/value 'scan-chunk-remaining :int)
+            (body/scalar-expression :min :int
+                                    [(body/literal workgroup-size :int)
+                                     (body/scalar-expression :- :int
+                                                             ['_n_bound 'scan-base])]))
+           (body/->ScalarLoad
+            (body/value 'scan-chunk-last result-type) scratch
+            [(body/expression :sub 'scan-chunk-remaining 1)]
+            :scan-lane-zero identity :cached)
+           (body/->ScalarCompute
+            (body/value 'scan-next-carry result-type)
+            (body/scalar-expression operator result-type
+                                    ['scan-prefix 'scan-chunk-last]))
+           (body/->ScalarStore carry [0] 'scan-next-carry :scan-lane-zero)
+           (barrier)
+           (body/->Yield [])]))]
+    (when-not totals
+      (decline! :block-total-buffer
+                "block scan requires its graph-owned totals buffer"
+                {:operation (:id operation) :uses (:uses context)}))
+    (body/make
+     {:id [:segscan (:id operation) :block-scan :portable-workgroup]
+      :parameters parameters
+      :allocations [(body/->WorkgroupAllocation
+                     scratch result-type [workgroup-size]
+                     (layout/row-major [workgroup-size] result-type)
+                     (dtype/bytes-of result-type))
+                    (body/->WorkgroupAllocation
+                     carry result-type [1] (layout/row-major [1] result-type)
+                     (dtype/bytes-of result-type))]
+      :indices [(body/->IndexBinding 'scan-lane :local 0)]
+      :masks masks
+      :operations [(body/->ScalarStore carry [0] identity :scan-lane-zero)
+                   (barrier)
+                   (body/->ForLoop
+                    (body/value 'scan-base :int) 0 '_n_bound workgroup-size []
+                    loop-body [] {:association :ordered
+                                  :uniform-iter-args #{}})]
+      :schedule {:strategy :ordered-workgroup-chunks :association :certified
+                 :phase :block-scan :workgroup-size workgroup-size :operator operator}
+      :launch (launch/spec
+               {:workgroup-size [workgroup-size] :group-count [1]
+                :shared-memory-bytes (* (inc workgroup-size)
+                                        (dtype/bytes-of result-type))})
+      :provenance {:dialect :kernel-body :source-dialect :segscan
+                   :segop-id (:id operation)}
+      :attributes {:kind :portable-segscan :phase :block-scan
+                   :scan-mode (:scan-mode context)
+                   :operator operator :identity (:identity scan-algebra)}})))
+
+(defn- carry-body
+  [operation context]
+  (let [{:keys [result-type workgroup-size scan-workgroup bound parameters stable-reads
+                scan-algebra scan-mode temporary-ids output-ids]} context
+        totals (first (filter temporary-ids (map :buffer (:uses context))))
+        output (first (filter output-ids (map :buffer (:uses context))))
+        operator (intrinsics/canonical (:combine scan-algebra))
+        identity (identity-value (:identity scan-algebra) result-type)
+        result-index (if (= :exclusive scan-mode)
+                       (body/expression :add 'scan-index 1)
+                       'scan-index)]
+    (when-not (and totals output)
+      (decline! :carry-buffers
+                "scan carry propagation requires totals and result buffers"
+                {:operation (:id operation) :uses (:uses context)}))
+    (body/make
+     {:id [:segscan (:id operation) :carry-in :portable-map]
+      :parameters parameters :stable-reads stable-reads
+      :indices [(body/->IndexBinding 'scan-group :group 0)
+                (body/->IndexBinding 'scan-lane :local 0)
+                (body/->IndexCompute
+                 'scan-index
+                 (body/expression :add
+                                  (body/expression :mul 'scan-group workgroup-size)
+                                  'scan-lane))
+                (body/->IndexCompute
+                 'scan-block (body/expression :floor-div 'scan-index scan-workgroup))]
+      :masks [(body/->Mask :scan-active [(body/predicate :lt 'scan-index '_n_bound)])
+              (body/->Mask :scan-has-carry
+                           [(body/predicate :lt 'scan-index '_n_bound)
+                            (body/predicate :lte 1 'scan-block)])]
+      :operations [(body/->ScalarLoad (body/value 'scan-current result-type) output
+                                      [result-index] :scan-active identity :cached)
+                   (body/->ScalarLoad
+                    (body/value 'scan-carry result-type) totals
+                    [(body/expression :sub 'scan-block 1)]
+                    :scan-has-carry identity :cached)
+                   (body/->ScalarCompute
+                    (body/value 'scan-with-carry result-type)
+                    (body/scalar-expression operator result-type
+                                            ['scan-carry 'scan-current]))
+                   (body/->ScalarStore output [result-index]
+                                        'scan-with-carry :scan-active)]
+      :schedule {:strategy :one-work-item-per-element :association :independent
+                 :phase :carry-in :workgroup-size workgroup-size
+                 :scan-block-size scan-workgroup :operator operator}
+      :launch (launch/spec
+               {:workgroup-size [workgroup-size]
+                :group-count [(launch/ceil-div bound workgroup-size)]})
+      :provenance {:dialect :kernel-body :source-dialect :segscan
+                   :segop-id (:id operation)}
+      :attributes {:kind :portable-segscan :phase :carry-in :scan-mode scan-mode
+                   :operator operator :identity (:identity scan-algebra)}})))
+
+(defn lower
+  "Lower one scheduled node of a certified scan graph to a portable KernelBody."
+  [operation options]
+  (let [context (merge (common-context operation options)
+                       (select-keys options [:uses :buffers :temporary-ids :output-ids
+                                             :scan-algebra :scan-mode :scan-workgroup]))
+        kernel-body (case (:phase context)
+                      (:single :intra-block) (scan-node-body operation context)
+                      :block-scan (block-scan-body operation context)
+                      :carry-in (carry-body operation context))]
+    {:kernel-body kernel-body
+     :phase (:phase context) :bound (:bound context)
+     :pointer-ids (:pointer-ids context) :scalar-ids (:scalar-ids context)}))

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -545,13 +545,14 @@
         {:keys [accumulators elements capture-parameters]}
         (soac-dialect/parameter-layout equation)
         facts (soac-dialect/facts program)
-        destination (get-in facts [:equations equation-id :attributes :destination])
+        storage (soac-dialect/result-storage facts equation-id)
+        destination (:destination (first storage))
         _ (when-not (and (= 1 (count results)) (= 1 (count accumulators))
-                         (= 1 (count body-results)) destination)
+                         (= 1 (count body-results)) (= 1 (count storage)) destination)
             (throw (ex-info "typed scan requires one result, accumulator and destination"
                             {:reason :typed-soac-scan-subset :equation equation-id
                              :results results :accumulators accumulators
-                             :destination destination})))
+                             :result-storage storage})))
         index (:index attributes)
         substitutions
         (into (zipmap capture-parameters captures)

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -555,9 +555,13 @@
               (set/difference (util/free-syms init) (:inputs io)
                               (set [symbol out acc idx])
                               descriptor/aget-ops descriptor/aset-ops)]
-          (merge {:kind :scan :id id :sym symbol :index idx :extent bound :mode mode
+          (merge {:kind :scan :id id :sym symbol :results [symbol]
+                  :index idx :extent bound :mode mode
                   :primary-out out :accumulator acc :identity init :dtype scan-dtype
-                  :algebra algebra :body body}
+                  :algebra algebra :body body
+                  :result-storage [{:destination out :access :write
+                                    :host-return :buffer}]
+                  :host-binding symbol}
                  (update io :scalars set/union identity-scalars)))))
 
     (par/par-map-void-form? expression)
@@ -780,7 +784,9 @@
                 (and (seq (:segment-axes description)) (seq (:folds description))
                      (every? (comp symbol? :destination)
                              (:result-storage description)))
-                :scan (symbol? (:primary-out description))
+                :scan (and (= 1 (count (:result-storage description)))
+                           (= (:primary-out description)
+                              (get-in description [:result-storage 0 :destination])))
                 false))
             descriptions)))
 
@@ -1043,7 +1049,9 @@
   [{:keys [id sym index extent mode inputs scalars primary-out accumulator identity dtype body]}]
   (let [[pointwise stable] ((juxt filter remove) #(pointwise-input? [body] % index) inputs)
         arrays (vec (sort-by pr-str pointwise))
-        stable (conj (set stable) primary-out)
+        ;; The caller-owned destination is physical result storage, not a value read by the
+        ;; functional scan. Keeping it out of captures prevents a false read/alias contract.
+        stable (set stable)
         captures (vec (sort-by pr-str (distinct (concat stable scalars))))
         elements (element-symbols (count arrays))
         capture-parameters (capture-symbols (count captures))
@@ -1376,17 +1384,11 @@
               equation-facts
               (into {}
                     (map (fn [description]
-                           (let [destination (when (= :scan (:kind description))
-                                               (:primary-out description))
-                                 storage (:result-storage description)]
+                           (let [storage (:result-storage description)]
                              [(:id description)
                               (cond-> (dialect/default-equation-facts
                                        {:front-end :analyzed-source
                                         :source-binding-id (:id description)})
-                                destination
-                                (assoc :effects #{:memory/write}
-                                       :aliases {(:sym description) destination}
-                                       :attributes {:destination destination})
                                 storage
                                 (assoc :effects #{:memory/write}
                                        :aliases (into {}

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -302,12 +302,16 @@
       scan
       (let [result (first results)
             mode (:mode attributes)
-            destination (get-in placement-facts [:attributes :destination])
+            ;; Scans share the same logical-result/physical-storage contract as maps and
+            ;; segmented reductions. Materialization must not recover a second, scan-only
+            ;; destination convention from equation attributes.
+            storage (get-in placement-facts [:attributes :result-storage])
+            destination (:destination (first storage))
             _ (when-not (and (= 1 (count results)) destination)
                 (throw (ex-info "typed scan requires one caller-owned destination"
                                 {:reason :typed-soac-production-subset
                                  :equation equation-id :results results
-                                 :destination destination})))
+                                 :result-storage storage})))
             source (with-meta
                      (list (case mode
                              :inclusive 'raster.par/scan

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -1252,11 +1252,16 @@
 (defn- runtime-buffer-for-view
   [device-id buffer view]
   (let [raw-dtype (dtype/canon (:dtype buffer))
-        view-dtype (dtype/canon (:dtype view))]
+        view-dtype (dtype/canon (:dtype view))
+        whole-buffer? (and (zero? (:byte-offset view))
+                           (= (:byte-length view) (:byte-size buffer)))]
     (when-not (= raw-dtype view-dtype)
       (throw (ex-info "kernel ABI cannot reinterpret a resident buffer dtype"
                       {:buffer-dtype raw-dtype :view-dtype view-dtype :view (:id view)})))
-    (if (zero? (:byte-offset view))
+    ;; A zero-origin prefix is still a range, not the whole allocation. Preserve its exact
+    ;; physical extent so KernelABI no-write-alias validation can prove it disjoint from a later
+    ;; sibling view of the same allocation.
+    (if whole-buffer?
       {:buffer buffer :owned-view? false}
       (case (backend-type device-id)
         :ze {:buffer ((rt-resolve device-id "slice-buffer") buffer (:byte-offset view)

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -45,6 +45,14 @@
                      (raster.numeric/* (float 2.0)
                                        (raster.arrays/aget input index)))))
 
+(deftm public-c-family-scan
+  "Public equation-first scan compiled by nvcc/hipcc without a physical device."
+  [input :- (Array float) n :- Long] :- (Array float)
+  (let [output (float-array n)]
+    (raster.par/scan output accumulator (float 0.0) index n float
+                     (raster.numeric/+ accumulator
+                                       (raster.arrays/aget input index)))))
+
 (defn- reduction-artifact
   [dialect]
   (let [form (with-meta
@@ -190,6 +198,8 @@
                  #'public-c-family-dot {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'public-c-family-map {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
+                 #'public-c-family-scan {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'dl-attention/gqa-causal-mha {:target device-id :dtype :float}))))))
 

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -12,9 +12,11 @@
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
+            [raster.compiler.ir.kernel-body :as kernel-body]
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-graph-call :as graph-call]
             [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.soac-lower :as lower]
@@ -90,6 +92,21 @@
      (sg/generate-scan-kernel-graph graph
                                     :scalar-types (:scalar-types opts)))))
 
+(defn- kernel-body-operations
+  [artifact]
+  (letfn [(walk [operations]
+            (mapcat
+             (fn [operation]
+               (cons operation
+                     (concat (walk (or (:operations operation) []))
+                             (walk (or (:then-operations operation) []))
+                             (walk (or (:else-operations operation) [])))))
+             operations))]
+    (walk (get-in artifact [:attributes :kernel-body :operations]))))
+
+(defn- operation-kind [operation]
+  (some-> operation class .getSimpleName))
+
 (deftest segscan-graph-emits-one-verified-artifact-per-scheduled-node
   (let [emitted (emitted-scan-graph
                  '(raster.par/scan out acc 0.0 i n double
@@ -101,16 +118,31 @@
     (is (every? kart/kernel-artifact? [intra block carry]))
     (is (= [:intra-block :block-scan :carry-in]
            (mapv #(get-in % [:attributes :phase]) [intra block carry])))
+    (is (every? #(= :portable-segscan
+                    (get-in % [:attributes :kernel-body :attributes :kind]))
+                [intra block carry]))
     (testing "stage 1 owns both the result and graph temporary in one exact ABI"
       (is (= [:temporary :result :operand :parameter :bound]
              (mapv :role (:abi intra))))
       (is (= '[scale n] (take-last 2 (:arguments intra))))
-      (is (re-find #"value = \(double\).*scale.*values\[idx\]" (:source intra))))
+      (let [operations (kernel-body-operations intra)]
+        (is (some #(and (= "ScalarLoad" (operation-kind %))
+                        (= 'values (:buffer %)))
+                  operations))
+        (is (some #(and (= "ScalarCompute" (operation-kind %))
+                        (= :* (get-in % [:expression :op])))
+                  operations))))
     (testing "block totals are scanned in one chunked workgroup for unbounded symbolic sizes"
       (is (= [1] (get-in block [:launch :group-count])))
-      (is (re-find #"for \(int base = 0; base < _n_bound; base \+= 256\)" (:source block))))
+      (let [loop (some #(when (= "ForLoop" (operation-kind %)) %) (kernel-body-operations block))]
+        (is (= [0 '_n_bound 256 :ordered]
+               [(:lower loop) (:upper loop) (:step loop)
+                (get-in loop [:attributes :association])]))))
     (testing "carry consumes the scanned total of the preceding block"
-      (is (re-find #"block_totals_.*\[block - 1\].*out_\[idx\]" (:source carry))))
+      (let [loads (filter #(= "ScalarLoad" (operation-kind %))
+                          (kernel-body-operations carry))]
+        (is (= #{(first (map :id (:temporaries emitted))) 'out}
+               (set (map :buffer loads))))))
     (testing "entry-point names are valid C identifiers"
       (is (every? #(re-matches #"[A-Za-z_][A-Za-z0-9_]*" (:kernel-name %))
                   [intra block carry])))
@@ -159,9 +191,35 @@
 (deftest segscan-carry-emits-the-certified-combine
   (let [emitted (emitted-scan-graph
                  '(raster.par/scan out acc 1.0 i n double (* acc (aget values i))))
-        carry (get-in emitted [:nodes 2 :operation])]
-    (is (re-find #"block_totals_.*\[block - 1\] \* out_\[idx\]" (:source carry))
+        carry (get-in emitted [:nodes 2 :operation])
+        combines (for [operation (kernel-body-operations carry)
+                       :when (= "ScalarCompute" (operation-kind operation))]
+                   (get-in operation [:expression :op]))]
+    (is (= [:*] (vec combines))
         "carry propagation must use the certified monoid, not a hard-coded addition")))
+
+(deftest segscan-carry-separates-its-launch-width-from-the-scanned-block-width
+  (let [node (soac/par-form->soac
+              'scan-result
+              '(raster.par/scan out acc 0.0 i n float (+ acc (aget values i)))
+              73)
+        operations (lower/lower-scan node nil :dtype :float)
+        scan-width (get-in operations [0 :grid :block-size])
+        carry-width (quot scan-width 2)
+        operations (assoc-in operations [2 :grid]
+                             (segop/->KernelGrid
+                              (klaunch/ceil-div 'n carry-width)
+                              carry-width 0))
+        graph (lower/scan-kernel-graph
+               node operations {:array-types {'values :float 'out :float}})
+        carry (get-in (sg/generate-scan-kernel-graph graph) [:nodes 2 :operation])
+        scan-block (some #(when (= 'scan-block (:id %)) %)
+                         (get-in carry [:attributes :kernel-body :indices]))]
+    (is (= [carry-width] (get-in carry [:launch :workgroup-size])))
+    (is (= scan-width
+           (get-in carry [:attributes :kernel-body :schedule :scan-block-size])))
+    (is (= (kernel-body/expression :floor-div 'scan-index scan-width)
+           (:expression scan-block)))))
 
 ;; ================================================================
 ;; Silently-ignored-information family: a SegRed combine that the

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -43,6 +43,17 @@
               :typed-equations-emitted 7
               :host-scalar-equations 0}}
 
+  :prefix-sum-gpu
+  {:route {:semantic-dialect :typed-parallel
+           :scheduled-dialect :scheduled-parallel
+           :emitted-dialect :opencl-parallel
+           :fallback :none}
+   :lowering {:nodes 2 :values 2 :instances 1 :program-instances 1
+              :outputs 1 :driver-allocations 0}
+   :emission {:structured-loops-emitted 0
+              :typed-equations-emitted 1
+              :host-scalar-equations 0}}
+
   :heat-rhs-1d-jvm
   {:route {:backend :simd :source-dialect :typed-soac :typed-validated true
            :declines {}}

--- a/test/raster/compiler/compatibility_ledger_test.clj
+++ b/test/raster/compiler/compatibility_ledger_test.clj
@@ -1,6 +1,7 @@
 (ns raster.compiler.compatibility-ledger-test
   (:require [clojure.edn :as edn]
             [clojure.test :refer [deftest is use-fixtures]]
+            [raster.arrays]
             [raster.compiler.equation-first :as equation-first]
             [raster.compiler.ir.link-plan :as link-plan]
             [raster.compiler.pipeline :as pipeline]
@@ -9,10 +10,20 @@
             [raster.nn :as nn]
             [raster.ode.pde :as pde]
             [raster.quant.kernels-k :as qk]
+            [raster.core :refer [deftm]]
+            [raster.numeric]
+            [raster.par]
             [raster.runtime.hardware :as hardware]))
 
 (def ^:private ledger-path "test/raster/compiler/compatibility_ledger.edn")
 (def ^:private target :ze:compatibility-ledger)
+
+(deftm prefix-sum-gpu
+  [input :- (Array float) n :- Long] :- (Array float)
+  (let [output (float-array n)]
+    (raster.par/scan output accumulator (float 0.0) index n float
+                     (raster.numeric/+ accumulator
+                                       (raster.arrays/aget input index)))))
 
 (use-fixtures
   :once
@@ -92,6 +103,13 @@
                  1 2 2 1 2])]
       (equation-first-signature compilation plan))
 
+    :prefix-sum-gpu
+    (let [compilation (equation-first/compile
+                       #'prefix-sum-gpu {:target target :dtype :float})
+          plan (equation-first/lower
+                compilation [(float-array [1 2 3 4]) 4])]
+      (equation-first-signature compilation plan))
+
     :heat-rhs-1d-jvm
     (pipeline/compile-report #'pde/heat-rhs-1d! :dtype :double)
 
@@ -112,6 +130,7 @@
              :symbolic-dense-contraction-gpu
              :q4k-dp4a-rows-gpu
              :gqa-causal-mha-gpu
+             :prefix-sum-gpu
              :heat-rhs-1d-jvm
              :heat-loss-rk4-gpu}
            (set (keys workloads))))
@@ -122,6 +141,7 @@
                      (contains? #{:symbolic-dense-contraction-gpu
                                   :q4k-dp4a-rows-gpu
                                   :gqa-causal-mha-gpu
+                                  :prefix-sum-gpu
                                   :heat-loss-rk4-gpu} id) report
                      :else (signature report))]
         (is (= expected actual)

--- a/test/raster/compiler/equation_first_c_family_test.clj
+++ b/test/raster/compiler/equation_first_c_family_test.clj
@@ -55,6 +55,14 @@
                      (raster.numeric/* (float 2.0)
                                        (raster.arrays/aget input index)))))
 
+(deftm c-family-scan
+  "A public certified scan lowered as a three-stage portable KernelGraph."
+  [input :- (Array float) n :- Long] :- (Array float)
+  (let [output (float-array n)]
+    (raster.par/scan output accumulator (float 0.0) index n float
+                     (raster.numeric/+ accumulator
+                                       (raster.arrays/aget input index)))))
+
 (deftm c-family-effect-map!
   [input :- (Array float) left :- (Array float) right :- (Array long) n :- Long] :- Void
   (raster.par/map-void!
@@ -131,6 +139,27 @@
       (is (= [module-target] (mapv :target (:kernels compilation))))
       (is (= :portable-segmap
              (get-in kernel [:attributes :kernel-body :attributes :kind])))
+      (is (= :none (get-in compilation [:stats :fallback]))))))
+
+(deftest public-scan-uses-one-portable-kernel-body-graph
+  (doseq [[target program-dialect module-target]
+          [[cuda-target :cuda-parallel :cuda-c]
+           [hip-target :hip-parallel :hip-cpp]]]
+    (let [compilation (equation-first/compile
+                       #'c-family-scan {:target target :dtype :float})
+          linked (equation-first/lower
+                  compilation [(float-array [1 2 3 4]) 4])
+          kernels (:kernels compilation)]
+      (is (= program-dialect (get-in compilation [:emitted :dialect])))
+      (is (= [:intra-block :block-scan :carry-in]
+             (mapv #(get-in % [:attributes :phase]) kernels)))
+      (is (every? #(= module-target (:target %)) kernels))
+      (is (every? #(= :portable-segscan
+                      (get-in % [:attributes :kernel-body :attributes :kind]))
+                  kernels))
+      (is (not-any? #(re-find #"__kernel|get_global_id|get_local_id" (:source %)) kernels))
+      (is (= 0 (get-in linked [:attributes :driver-allocations])))
+      (is (= 1 (count (:outputs linked))))
       (is (= :none (get-in compilation [:stats :fallback]))))))
 
 (deftest public-effect-map-preserves-typed-multi-output-storage

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -51,6 +51,15 @@
     (is (= :in-bounds (:mask guard)))
     (is (= matrix (:instruction (nth (:operations loop-op) 2))))))
 
+(deftest kernel-buffer-shapes-retain-symbolic-launch-arithmetic
+  (let [extent (launch/ceil-div 'n 256)
+        kernel (-> (minimal-body)
+                   (assoc-in [:parameters 0 :shape] [extent])
+                   (assoc-in [:parameters 0 :layout]
+                             (layout/row-major [extent] :half)))]
+    (is (= kernel (body/validate! kernel)))
+    (is (= extent (get-in kernel [:parameters 0 :shape 0])))))
+
 (deftest the-verifier-refuses-implicit-or-incompatible-kernel-semantics
   (testing "opaque list arithmetic cannot hide in coordinates"
     (let [kernel (minimal-body)

--- a/test/raster/compiler/ir/kernel_dispatch_test.clj
+++ b/test/raster/compiler/ir/kernel_dispatch_test.clj
@@ -440,8 +440,9 @@
        #'raster.gpu.core/rt-resolve-soft soft-resolver}
       (fn []
         (gpu/bind-step! session step {} {'x x-view 'out out-view})
-        (is (= 1 (count @slices)) "the non-zero OpenCL range is one owned cl_mem sub-buffer")
-        (is (= 1 (count (get-in @session [:prepared :view-step :owned-view-buffers]))))
+        (is (= 2 (count @slices))
+            "both partial OpenCL ranges are owned cl_mem sub-buffers, including a zero-origin prefix")
+        (is (= 2 (count (get-in @session [:prepared :view-step :owned-view-buffers]))))
         (gpu/release-prepared! session :view-step)
         (is (= 1 (count @destroyed)))
         (is (= @slices @freed) "view handles follow the bound step lifetime")

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -158,6 +158,11 @@
       (is (= 'scan (dialect/operation-kind equation)))
       (is (= :inclusive (get-in (dialect/operation-parts equation) [:attributes :mode])))
       (is (= '{result target} (get-in (dialect/facts program) [:equations 0 :aliases])))
+      (is (= ['target] (dialect/physical-results program equation)))
+      (is (= [{:destination 'target :access :write :host-return :buffer}]
+             (dialect/result-storage program 0)))
+      (is (empty? (get-in (dialect/operation-parts equation)
+                          [:attributes :attributes :stable-array-captures])))
       (is (= #{:memory/write} (:effects (dialect/facts program))))))
 
   (testing "exclusive scan is the same certified operation with a distinct result mode"

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -3,6 +3,7 @@
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
             [raster.compiler.backend.jvm.par-simd :as par-simd]
             [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.ir.kernel-body :as kernel-body]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
             [raster.compiler.ir.kernel-graph :as kernel-graph]
             [raster.compiler.ir.kernel-graph-call :as kernel-graph-call]
@@ -17,6 +18,12 @@
             [raster.compiler.passes.parallel.typed-soac-route :as route]
             [raster.gpu.dispatch-tuning :as dispatch-tuning]
             [raster.gpu.program-tuning :as program-tuning]))
+
+(defn- scalar-stores
+  [artifact]
+  (filterv #(= "raster.compiler.ir.kernel_body.ScalarStore"
+                (.getName (class %)))
+           (get-in artifact [:attributes :kernel-body :operations])))
 
 (def ^:private map-map
   '(let* [y (raster.par/pmap i n float
@@ -495,7 +502,8 @@
         equation (first (:equations scheduled))
         graph (get-in equation [:attributes :kernel-graph])
         emitted (opencl-pass/opencl-pass scheduled :device-id :ocl:0 :dtype :float)
-        [intra _ carry] (:kernels emitted)]
+        [intra _ carry] (:kernels emitted)
+        result-index [(kernel-body/expression :add 'scan-index 1)]]
     (is (= :typed-soac (:route stats)))
     (is (= :exclusive
            (get-in (dialect/operation-parts
@@ -504,9 +512,13 @@
     (is (= :exclusive (get-in graph [:attributes :scan-mode])))
     (is (= (kernel-launch/sum 'n 1) (:elements (first (:outputs graph)))))
     (is (= 3 (count (:nodes graph))))
-    (is (re-find #"\[0\] = 0.0f" (:source intra)))
-    (is (re-find #"\[idx \+ 1\] = sdata\[tid\]" (:source intra)))
-    (is (re-find #"\[idx \+ 1\]" (:source carry)))
+    (is (some #(and (= 'out (:buffer %)) (= result-index (:coordinates %)))
+              (scalar-stores intra)))
+    (is (some #(and (= 'out (:buffer %)) (= [0] (:coordinates %))
+                    (= :scan-first-lane (:predicate %)))
+              (scalar-stores intra)))
+    (is (some #(and (= 'out (:buffer %)) (= result-index (:coordinates %)))
+              (scalar-stores carry)))
     (is (= 1 (get-in emitted [:stats :kernel-graphs])))
     (is (nil? (get-in emitted [:stats :segop-relowered])))))
 
@@ -551,7 +563,9 @@
     (is (= 1 (count (:nodes graph))))
     (is (= (kernel-launch/sum 0 1) (:elements (first (:outputs graph)))))
     (is (= [1] (get-in artifact [:launch :group-count])))
-    (is (re-find #"\[0\] = 0.0f" (:source artifact)))
+    (is (some #(and (= 'out (:buffer %)) (= [0] (:coordinates %))
+                    (= :scan-first-lane (:predicate %)))
+              (scalar-stores artifact)))
     (is (identical? out (execute out)))
     (is (= 0.0 (double (aget out 0))))))
 

--- a/test/raster/gpu/kernel_graph_runner_test.clj
+++ b/test/raster/gpu/kernel_graph_runner_test.clj
@@ -59,8 +59,8 @@
 
 (deftest session-runner-owns-only-graph-temporaries-and-bound-driver-objects
   (let [graph (emitted-graph)
-        values-buffer {:dtype :float :n-elements 1025 :byte-size 4100}
-        output-buffer {:dtype :float :n-elements 1025 :byte-size 4100}
+        values-buffer {:id :values-buffer :dtype :float :n-elements 1025 :byte-size 4100}
+        output-buffer {:id :output-buffer :dtype :float :n-elements 1025 :byte-size 4100}
         allocation (fn [id]
                      (bview/allocation {:id id :byte-size 4100 :memory-space :shared
                                         :device :ze:0 :coherence :host-coherent
@@ -274,14 +274,16 @@
         (let [handle (gpu/bind-kernel-graph!
                       sess :view-scan graph {'values input 'out output}
                       {'n {:type :int :value n}})
-              sub-buffer (first @slices)
+              [input-sub-buffer output-sub-buffer] @slices
               temporary (first (vals (get-in @sess [:kernel-graphs :view-scan
                                                     :temporary-buffers])))]
-          (is (= 1 (count @slices)) "only the nonzero view needs a cl_mem sub-buffer")
-          (is (identical? sub-buffer (get-in @sess [:kernel-graphs :view-scan
-                                                    :outputs 'out])))
+          (is (= [[0 n-bytes] [output-offset n-bytes]]
+                 (mapv (juxt :byte-offset :byte-size) @slices))
+              "both proper subranges retain their exact physical extent")
+          (is (identical? output-sub-buffer
+                          (get-in @sess [:kernel-graphs :view-scan :outputs 'out])))
           (gpu/release-kernel-graph! sess handle)
-          (is (= #{sub-buffer temporary} (set @freed)))
+          (is (= #{input-sub-buffer output-sub-buffer temporary} (set @freed)))
           (is (not-any? #(identical? root-buffer %) @freed)
               "the session-owned root allocation survives graph release"))
         (reset! slices [])
@@ -291,9 +293,9 @@
                               (gpu/bind-kernel-graph!
                                sess :failed-view-scan graph {'values input 'out output}
                                {'n {:type :int :value n}})))
-        (is (= 1 (count @slices)))
-        (is (= 2 (count @freed))
-            "failed binding releases both its created sub-buffer and temporary")
-        (is (some :sub-buffer @freed))
+        (is (= 2 (count @slices)))
+        (is (= 3 (count @freed))
+            "failed binding releases both created sub-buffers and its temporary")
+        (is (= 2 (count (filter :sub-buffer @freed))))
         (is (some :temporary @freed))
         (is (empty? (:kernel-graphs @sess)))))))


### PR DESCRIPTION
## Summary\n- lower certified inclusive/exclusive SegScan schedules to target-neutral KernelBody scalar SSA, workgroup memory, barriers, and ordered carry phases\n- unify scan logical results with the common TypedSOAC result-storage contract and preserve schedule annotations through equation-first emission\n- delete the handwritten OpenCL scan source path and add public OpenCL/CUDA/HIP scan coverage plus nvcc/hipcc fixtures\n- preserve exact resident prefix-view ranges so KernelABI no-write-alias checks accept disjoint sibling views\n- add prefix scan to the compatibility ledger and update the compiler north star\n\n## Focused verification\n- typed SOAC frontend: 20 tests / 129 assertions\n- equation-first C-family: 8 / 82\n- SegOp emission: 16 / 84\n- TypedSOAC route: 37 / 311\n- structured control route: 24 / 152\n- KernelBody IR: 22 / 105\n- compatibility ledger: 1 / 10\n- kernel graph runner: 4 / 42\n- Intel Arc Level Zero/OpenCL graph execution: 4 / 16\n- generated public scan CUDA sources compile with nvcc 12.4 (sm_80)\n- generated public scan HIP sources compile with hipcc 5.7 (gfx1100)\n\nThe full suite and complete CUDA/HIP fixture sets are intentionally delegated to CircleCI.