### PR TITLE
Lower certified stencils through portable KernelBody

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -87,10 +87,11 @@ stable loads, retained dtypes, scalar SSA, branches, and horizontally fused stor
 same KernelBody to all three C-family targets. Canonical loop/recur scalar carries become ordered
 KernelBody `ForLoop` regions rather than being reassociated as reductions. This is sufficient for
 the public seven-stage GQA composition to emit entirely as CUDA/HIP and pass both vendor compilers;
-SegStencil remains the explicit portable C-family coverage gap. Certified scans now lower their
+certified stencils and scans now lower their
 single- or three-phase schedule to target-neutral KernelBody scalar SSA, workgroup storage,
 barriers, ordered block carries, and inclusive/exclusive result placement. The same bodies compile
-with OpenCL, nvcc, and hipcc; the former handwritten OpenCL scan source path has been deleted.
+with OpenCL, nvcc, and hipcc; the former handwritten OpenCL scan and stencil source paths have
+been deleted.
 
 The map/scalar/full-reduction/certified-scan front end now constructs TypedSOAC directly from closed analyzed
 source and retained walker type metadata. It establishes stable equation/value identity, types,

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -665,7 +665,7 @@
                                 stats :segstencil
                                 #(and (instance? raster.compiler.ir.segop.SegStencil %)
                                       (= :typed-soac (:algorithm-dialect %))))]
-              (let [kernel (segop-cl/generate-segstencil-kernel
+              (let [kernel (segop-cl/generate-segstencil-kernel-body
                             scheduled :scalar-types top-scalar-types
                             :array-types top-array-types)
                     k (register-kernel! kernel :ze-maps)]

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -1,9 +1,9 @@
 (ns raster.compiler.backend.gpu.segop-opencl
-  "OpenCL kernel generation from SegOp IR.
+  "C-family kernel generation from scheduled SegOp IR.
 
-   Translates SegMap and SegRed records into OpenCL C source strings.
-   Uses the pre-computed inputs/outputs/scalars from SegOp lowering
-   instead of re-analyzing par forms.
+   Portable schedules lower through typed KernelBody and emit OpenCL, CUDA, or HIP source. The
+   remaining specialized OpenCL leaves use the same pre-computed inputs/outputs/scalars from
+   SegOp lowering instead of re-analyzing par forms.
 
    This is the GPU counterpart to segop_simd.clj — both consume the
    same SegOp IR but produce different target code."
@@ -31,6 +31,7 @@
             [raster.compiler.passes.parallel.segfoldmap-body :as segfoldmap-body]
             [raster.compiler.passes.parallel.segmap-body :as segmap-body]
             [raster.compiler.passes.parallel.segscan-body :as segscan-body]
+            [raster.compiler.passes.parallel.segstencil-body :as segstencil-body]
             [clojure.walk :as walk]
             [clojure.set]
             [raster.compiler.ir.segop :as segop]
@@ -322,95 +323,6 @@
        :out-param out-param
        :dtype out-dtype}})))
 
-(defn generate-segstencil-kernel
-  "Generate a guarded OpenCL kernel directly from a scheduled SegStencil.
-
-   The boundary branch dominates every neighborhood load, so a radius-one stencil never issues
-   an out-of-range read.  Ordered ABI slots project the scheduled no-write-alias precondition
-   instead of relying on C `restrict` as an unchecked promise."
-  [segstencil & {:keys [kernel-name-prefix scalar-types array-types]
-                 :or {kernel-name-prefix "par_stencil" scalar-types {} array-types {}}}]
-  (let [idx (seg-idx segstencil)
-        bound (seg-bound segstencil)
-        dtype (:dtype segstencil)
-        out (:out-sym segstencil)
-        inputs (vec (sort-by name (:inputs segstencil)))
-        scalars (vec (sort-by name (:scalars segstencil)))
-        body (ce/normalize-array-prims (:lambda segstencil))
-        radius (:radius segstencil)
-        boundary (:boundary segstencil)
-        _ (when-not (and (= :dirichlet boundary)
-                         (= 1 radius)
-                         (= :no-write-alias (:aliasing segstencil)))
-            (throw (ex-info "scheduled stencil has no certified OpenCL lowering"
-                            {:reason :segstencil-opencl-subset
-                             :radius radius :boundary boundary
-                             :aliasing (:aliasing segstencil)})))
-        kernel-name (str kernel-name-prefix "_" (gensym ""))
-        default-ctype (dt/ctype :opencl dtype)
-        input-dtype (fn [id]
-                      (or (get array-types id)
-                          (get array-types (symbol (name id)))
-                          dtype))
-        input-ctype #(dt/ctype :opencl (input-dtype %))
-        scalar-dtype #(ce/scalar-parameter-dtype % scalar-types dtype)
-        scalar-ctype #(dt/ctype :opencl (scalar-dtype %))
-        scalar-var-types (into {} (map (juxt identity scalar-ctype)) scalars)
-        input-params (str/join ", "
-                               (map #(str "__global const " (input-ctype %)
-                                          "* restrict " (ce/c-symbol %))
-                                    inputs))
-        output-param (str "__global " default-ctype "* restrict out")
-        scalar-params (str/join ", "
-                                (map #(str (scalar-ctype %) " " (ce/c-symbol %)) scalars))
-        all-params (str/join ", "
-                             (remove empty? [input-params output-param scalar-params
-                                             "int _n_bound"]))
-        int-scalars (set (keep #(when (contains? #{:int :long} (scalar-dtype %)) %) scalars))
-        adapted-body (ce/adapt-casts-for-dtype body dtype)
-        body-str (binding [ce/*emit-config* ce/opencl-config
-                           ce/*scalar-type* default-ctype
-                           ce/*scalar-var-types* scalar-var-types
-                           ce/*idx-sym* idx
-                           ce/*int-vars* (into ce/*int-vars* int-scalars)]
-                   (ce/emit-expr adapted-body idx (set inputs)))
-        workgroup-size (or (get-in segstencil [:grid :block-size]) 256)
-        abi (kabi/validate!
-             (vec (concat
-                   (map #(kabi/slot % :input (input-dtype %)
-                                    :c-name (ce/c-symbol %) :role :operand
-                                    :aliasing :no-write-alias)
-                        inputs)
-                   [(kabi/slot out :output dtype :c-name "out" :role :result)]
-                   (map #(kabi/slot % :scalar (scalar-dtype %)
-                                    :c-name (ce/c-symbol %) :role :parameter)
-                        scalars)
-                   [(kabi/slot '_n_bound :scalar :int :role :bound)])))
-        source (str (apply codegen/extension-pragmas dtype (map input-dtype inputs))
-                    (ce/helper-sources body-str)
-                    "__kernel void " kernel-name "(" all-params ") {\n"
-                    "    for (int idx = get_global_id(0); idx < _n_bound; "
-                    "idx += get_global_size(0)) {\n"
-                    "        if (idx < " radius " || idx >= _n_bound - " radius ") {\n"
-                    "            out[idx] = (" default-ctype ")0;\n"
-                    "        } else {\n"
-                    "            out[idx] = (" default-ctype ")(" body-str ");\n"
-                    "        }\n"
-                    "    }\n"
-                    "}\n")]
-    (kart/make
-     {:kernel-name kernel-name
-      :source source
-      :abi abi
-      :arguments (vec (concat inputs [out] scalars [bound]))
-      :launch (klaunch/spec {:workgroup-size [workgroup-size]
-                             :group-count [(klaunch/ceil-div bound workgroup-size)]})
-      :temporaries []
-      :effects {:kind :stencil :boundary boundary :radius radius}
-      :provenance {:dialect :segstencil :segop-id (:id segstencil)}
-      :attributes {:array-params inputs :scalar-params scalars :out-param out
-                   :dtype dtype :aliasing :no-write-alias}})))
-
 (defn generate-segfoldmap-kernel
   "Schedule and emit one ordered SegFoldMap through the shared scalar KernelBody dialect."
   [segfoldmap & {:keys [kernel-name-prefix target-dialect workgroup-size scalar-types array-types]
@@ -501,6 +413,49 @@
                    :array-params (vec (concat inputs outputs))
                    :scalar-params scalars
                    :dtype (:dtype segmap)
+                   :aliasing :no-write-alias}})))
+
+(defn generate-segstencil-kernel-body
+  "Schedule and emit one certified SegStencil through portable KernelBody."
+  [stencil & {:keys [kernel-name-prefix target-dialect workgroup-size scalar-types array-types]
+              :or {kernel-name-prefix "segstencil"
+                   target-dialect :opencl-intel
+                   scalar-types {} array-types {}}}]
+  (let [workgroup-size (or workgroup-size (get-in stencil [:grid :block-size]) 256)
+        {:keys [kernel-body bound inputs outputs scalars]}
+        (segstencil-body/lower
+         stencil {:workgroup-size workgroup-size
+                  :scalar-types scalar-types :array-types array-types})
+        parameters (:parameters kernel-body)
+        kernel-name (str kernel-name-prefix "_" (gensym ""))
+        parameter-names (into {}
+                              (map (fn [parameter]
+                                     [(:id parameter) (ce/c-symbol (:id parameter))]))
+                              parameters)
+        source (kernel-body-opencl/emit-scalar-kernel
+                kernel-name kernel-body
+                {:target-dialect target-dialect :parameter-names parameter-names})
+        abi (body-abi/project-contracts
+             (mapv (fn [{:keys [id kind dtype role]}]
+                     (kabi/slot id kind dtype :c-name (get parameter-names id)
+                                :role (if (= id '_n_bound) :bound role)))
+                   parameters)
+             kernel-body)
+        arguments (mapv (fn [parameter]
+                          (if (= '_n_bound (:id parameter)) bound (:id parameter)))
+                        parameters)]
+    (kart/make
+     {:kernel-name kernel-name :source source :abi abi :arguments arguments
+      :launch (:launch kernel-body) :temporaries []
+      :effects {:kind :stencil :boundary (:boundary stencil) :radius (:radius stencil)}
+      :target (kernel-body-c-dialect/target
+               (kernel-body-c-dialect/resolve! target-dialect))
+      :provenance {:dialect :kernel-body :source-dialect :segstencil
+                   :segop-id (:id stencil)}
+      :attributes {:kernel-body kernel-body
+                   :array-params (vec (concat inputs outputs))
+                   :scalar-params scalars :dtype (:dtype stencil)
+                   :boundary (:boundary stencil) :radius (:radius stencil)
                    :aliasing :no-write-alias}})))
 
 ;; ================================================================
@@ -1181,14 +1136,10 @@
                     (throw exception))))
 
               (instance? raster.compiler.ir.segop.SegStencil operation)
-              (if opencl?
-                (generate-segstencil-kernel
-                 operation :scalar-types scalar-types :array-types array-types
-                 :kernel-name-prefix "graph_segstencil")
-                (throw (ex-info "stencil has no portable KernelBody C-family lowering"
-                                {:reason :kernel-graph-target-lowering-missing
-                                 :target-dialect target-dialect :operation (:id operation)
-                                 :fallback :none})))
+              (generate-segstencil-kernel-body
+               operation :scalar-types scalar-types :array-types array-types
+               :target-dialect target-dialect
+               :kernel-name-prefix "graph_segstencil")
 
               :else
               (throw (ex-info "OpenCL elementwise graph has an unsupported scheduled node"

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -667,13 +667,28 @@
 (defn- stencil-index-offset
   "Return the constant offset of one admitted affine stencil index, or nil.
 
-   The initial typed stencil contract deliberately admits only `i`, `i + c`, `c + i`, and
-   `i - c`. This keeps the radius proof semantic and target-independent; emitters never guess
+   The initial typed stencil contract deliberately admits only `i`, `inc i`, `dec i`, `i + c`,
+   `c + i`, and `i - c`. `inc`/`dec` are the analyzed canonical forms of the same unit-affine
+   indices. This keeps the radius proof semantic and target-independent; emitters never guess
    whether an arbitrary index expression remains inside the guarded neighborhood."
   [index expression]
   (let [expression (unwrap-stencil-index-cast expression)]
     (cond
     (= index expression) 0
+
+    (and (seq? expression) (= 2 (count expression))
+         (contains? '#{inc clojure.core/inc unchecked-inc-int
+                       clojure.core/unchecked-inc-int}
+                    (first expression))
+         (= index (unwrap-stencil-index-cast (second expression))))
+    1
+
+    (and (seq? expression) (= 2 (count expression))
+         (contains? '#{dec clojure.core/dec unchecked-dec-int
+                       clojure.core/unchecked-dec-int}
+                    (first expression))
+         (= index (unwrap-stencil-index-cast (second expression))))
+    -1
 
     (and (seq? expression) (= 3 (count expression))
          (contains? '#{+ clojure.core/+} (first expression)))

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -237,30 +237,46 @@
                   (let [operator (intrinsics/canonical (descriptor/semantic-op expression))
                         intrinsic (intrinsics/descriptor operator)
                         arguments (vec (descriptor/call-args expression))]
-                    (when-not (and intrinsic (= (:arity intrinsic) (count arguments)))
+                    (when-not intrinsic
                       (decline! :scalar-expression
                                 "scalar expression has no canonical intrinsic"
                                 {:expression expression :operator operator}))
-                    (let [comparison? (= :cmp (:kind intrinsic))
-                          operand-type (if comparison?
-                                         (dtype/canon
-                                          (or (source-type (first arguments) :int env) :int))
-                                         expected)
-                          lowered (mapv #(lower % operand-type env) arguments)
-                          result-type (if comparison? :predicate operand-type)
-                          _ (when-not (every? #(= operand-type (:type %)) lowered)
-                              (decline! :operand-dtype
-                                        "scalar intrinsic operands require one dtype"
-                                        {:expression expression :operand-type operand-type
-                                         :actual (mapv :type lowered)}))
-                          result (fresh "value")]
-                      {:operations
-                       (conj (vec (mapcat :operations lowered))
-                             (body/->ScalarCompute
-                              (body/value result result-type)
-                              (body/scalar-expression operator result-type
-                                                      (mapv :result lowered))))
-                       :result result :type result-type}))
+                    (if (and (= 2 (:arity intrinsic)) (> (count arguments) 2)
+                             (contains? #{:+ :* :- :div :min :max} operator))
+                      ;; Preserve source evaluation order while spelling variadic scalar folds in
+                      ;; the binary KernelBody vocabulary. This is normalization, not algebraic
+                      ;; reassociation: `(- a b c)` becomes `(- (- a b) c)`.
+                      (lower (reduce (fn [left right]
+                                       (list (descriptor/semantic-op expression) left right))
+                                     arguments)
+                             expected env)
+                      (do
+                        (when-not (= (:arity intrinsic) (count arguments))
+                          (decline! :scalar-expression
+                                    "scalar expression has the wrong intrinsic arity"
+                                    {:expression expression :operator operator
+                                     :expected (:arity intrinsic)
+                                     :actual (count arguments)}))
+                        (let [comparison? (= :cmp (:kind intrinsic))
+                              operand-type (if comparison?
+                                             (dtype/canon
+                                              (or (source-type (first arguments) :int env) :int))
+                                             expected)
+                              lowered (mapv #(lower % operand-type env) arguments)
+                              result-type (if comparison? :predicate operand-type)
+                              _ (when-not (every? #(= operand-type (:type %)) lowered)
+                                  (decline! :operand-dtype
+                                            "scalar intrinsic operands require one dtype"
+                                            {:expression expression :operand-type operand-type
+                                             :actual (mapv :type lowered)}))
+                              result (fresh "value")]
+                          {:operations
+                           (conj (vec (mapcat :operations lowered))
+                                 (body/->ScalarCompute
+                                  (body/value result result-type)
+                                  (body/scalar-expression operator result-type
+                                                          (mapv :result lowered))))
+                           :result result :type result-type}))))
 
                   :else
                   (decline! :scalar-expression

--- a/src/raster/compiler/passes/parallel/segstencil_body.clj
+++ b/src/raster/compiler/passes/parallel/segstencil_body.clj
@@ -1,0 +1,171 @@
+(ns raster.compiler.passes.parallel.segstencil-body
+  "Portable KernelBody schedule for certified one-dimensional boundary stencils."
+  (:require [clojure.set :as set]
+            [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.layout :as layout]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.ir.segop :as segop]
+            [raster.compiler.passes.parallel.contraction-body :as contraction-body]
+            [raster.compiler.passes.parallel.scalar-expression-body :as scalar-expression]))
+
+(defn- decline!
+  [rule message data]
+  (throw (ex-info message (assoc data :reason :segstencil-kernel-body-declined
+                                 :missing-rule rule :fallback :none))))
+
+(defn declined?
+  [exception]
+  (= :segstencil-kernel-body-declined (:reason (ex-data exception))))
+
+(defn- widen-index-expression
+  [expression value-types]
+  (cond
+    (integer? expression) (body/index-cast expression :long :exact)
+    (symbol? expression)
+    (if (= :long (dtype/canon (get value-types expression :int)))
+      expression
+      (body/index-cast expression :long :exact))
+    (instance? raster.compiler.ir.kernel_body.IndexExpr expression)
+    (apply body/expression (:op expression)
+           (map #(widen-index-expression % value-types) (:arguments expression)))
+    (instance? raster.compiler.ir.kernel_body.IndexCast expression)
+    (if (= :long (dtype/canon (:dtype expression)))
+      expression
+      (body/index-cast expression :long :exact))
+    :else expression))
+
+(defn lower
+  "Select a one-item-per-element portable schedule for a proved Dirichlet stencil.
+
+   The interior branch dominates all neighborhood loads. Boundary lanes yield the typed zero
+   value and perform one final store, so no target emitter reconstructs boundary semantics."
+  [stencil {:keys [workgroup-size array-types scalar-types]
+            :or {workgroup-size 256 array-types {} scalar-types {}}}]
+  (when-not (instance? raster.compiler.ir.segop.SegStencil stencil)
+    (throw (ex-info "stencil KernelBody lowering requires SegStencil"
+                    {:reason :raster/bug :operation stencil})))
+  (let [dimensions (get-in stencil [:space :dims])
+        _ (when-not (= 1 (count dimensions))
+            (decline! :iteration-rank
+                      "portable stencil requires one flattened iteration axis"
+                      {:operation (:id stencil) :dimensions dimensions}))
+        _ (when-not (and (= :dirichlet (:boundary stencil))
+                         (= 1 (:radius stencil))
+                         (= :no-write-alias (:aliasing stencil)))
+            (decline! :boundary-contract
+                      "portable stencil requires the certified radius-one Dirichlet contract"
+                      {:operation (:id stencil) :radius (:radius stencil)
+                       :boundary (:boundary stencil) :aliasing (:aliasing stencil)}))
+        _ (when-not (and (integer? workgroup-size) (pos? workgroup-size))
+            (decline! :workgroup-size "stencil workgroup size must be positive"
+                      {:workgroup-size workgroup-size}))
+        index (:name (first dimensions))
+        bound (:bound (first dimensions))
+        radius (:radius stencil)
+        inputs (vec (sort-by name (:inputs stencil)))
+        outputs (vec (sort-by name (:outputs stencil)))
+        output (:out-sym stencil)
+        scalars (vec (sort-by name (:scalars stencil)))
+        _ (when-not (and (= 1 (count outputs)) (= output (first outputs))
+                         (empty? (set/intersection (set inputs) (set outputs))))
+            (decline! :storage-contract
+                      "portable stencil requires one distinct physical result"
+                      {:operation (:id stencil) :inputs inputs :outputs outputs :output output}))
+        result-type (dtype/canon (:dtype stencil))
+        array-dtype (fn [id]
+                      (dtype/canon (or (get array-types id)
+                                       (get array-types (symbol (name id)))
+                                       result-type)))
+        scalar-dtype (fn [id]
+                       (dtype/canon (or (get scalar-types id)
+                                        (get scalar-types (symbol (name id)))
+                                        :int)))
+        array-types (into {} (map (juxt identity array-dtype)) (concat inputs outputs))
+        scalar-types (into {} (map (juxt identity scalar-dtype)) scalars)
+        index-scope (conj (set scalars) index)
+        index-types (assoc scalar-types index :long)
+        lower-index (fn lower-index
+                      ([expression] (lower-index expression #{}))
+                      ([expression extra-scope]
+                       (widen-index-expression
+                        (contraction-body/lower-index
+                         expression (set/union index-scope extra-scope))
+                        index-types)))
+        lowerer (scalar-expression/make-lowerer
+                 {:array-types array-types :scalar-types scalar-types
+                  :arrays (set inputs) :index-scope index-scope
+                  :lower-index lower-index :predicate nil
+                  :id-prefix "stencil" :decline! decline!})
+        lowered ((:lower lowerer) (:lambda stencil) result-type
+                                    (assoc scalar-types index :long))
+        group-index 'stencil-group
+        local-index 'stencil-lane
+        right-limit 'stencil-right-limit
+        left-interior 'stencil-left-interior
+        right-interior 'stencil-right-interior
+        right-result 'stencil-right-result
+        result 'stencil-result
+        parameters
+        (vec
+         (concat
+          (map #(body/->KernelParameter
+                 % :input (get array-types %) ['_n_bound] :global
+                 (layout/row-major ['_n_bound] (get array-types %)) :operand)
+               inputs)
+          [(body/->KernelParameter
+            output :output result-type ['_n_bound] :global
+            (layout/row-major ['_n_bound] result-type) :result)]
+          (map #(body/->KernelParameter % :scalar (get scalar-types %) [] nil nil :parameter)
+               scalars)
+          [(body/->KernelParameter '_n_bound :scalar :int [] nil nil :bound)]))]
+    {:kernel-body
+     (body/make
+      {:id [:segstencil (:id stencil) :portable-one-item]
+       :parameters parameters
+       :stable-reads (mapv body/stable-read inputs)
+       :indices [(body/->IndexBinding group-index :group 0)
+                 (body/->IndexBinding local-index :local 0)
+                 (body/->IndexCompute
+                  index
+                  (body/index-cast
+                   (body/expression :add
+                                    (body/expression :mul group-index workgroup-size)
+                                    local-index)
+                   :long :exact))]
+       :masks [(body/->Mask
+                :stencil-active
+                [(body/predicate :lt index (body/index-cast '_n_bound :long :exact))])]
+       :operations
+       [(body/->ScalarCompute
+         (body/value right-limit :long)
+         (body/scalar-expression
+          :- :long [(body/cast-expression '_n_bound :long :exact :exact)
+                    (body/literal radius :long)]))
+        (body/->ScalarCompute
+         (body/value left-interior :predicate)
+         (body/scalar-expression :le :predicate
+                                 [(body/literal radius :long) index]))
+        (body/->ScalarCompute
+         (body/value right-interior :predicate)
+         (body/scalar-expression :lt :predicate [index right-limit]))
+        (body/->IfRegion
+         left-interior
+         [(body/->IfRegion
+           right-interior
+           (conj (vec (:operations lowered)) (body/->Yield [(:result lowered)]))
+           [(body/->Yield [(body/literal 0 result-type)])]
+           [(body/value right-result result-type)])
+          (body/->Yield [right-result])]
+         [(body/->Yield [(body/literal 0 result-type)])]
+         [(body/value result result-type)])
+        (body/->ScalarStore output [index] result :stencil-active)]
+       :schedule {:strategy :one-work-item-per-element :association :independent
+                  :workgroup-size workgroup-size :boundary :dirichlet :radius radius}
+       :launch (launch/spec {:workgroup-size [workgroup-size]
+                             :group-count [(launch/ceil-div bound workgroup-size)]})
+       :provenance {:dialect :kernel-body :source-dialect :segstencil
+                    :segop-id (:id stencil)}
+       :attributes {:kind :portable-segstencil :extent bound
+                    :boundary :dirichlet :radius radius :no-write-alias true}})
+     :bound bound :inputs inputs :outputs outputs :scalars scalars}))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -53,6 +53,16 @@
                      (raster.numeric/+ accumulator
                                        (raster.arrays/aget input index)))))
 
+(deftm public-c-family-stencil
+  "Public equation-first radius-one stencil compiled by nvcc/hipcc without a physical device."
+  [input :- (Array float) n :- Long] :- (Array float)
+  (let [output (float-array n)]
+    (raster.par/stencil!
+     output [input] 1 :dirichlet float index n
+     (raster.numeric/+
+      (raster.arrays/aget input (dec index))
+      (raster.arrays/aget input (inc index))))))
+
 (defn- reduction-artifact
   [dialect]
   (let [form (with-meta
@@ -200,6 +210,8 @@
                  #'public-c-family-map {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'public-c-family-scan {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
+                 #'public-c-family-stencil {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'dl-attention/gqa-causal-mha {:target device-id :dtype :float}))))))
 

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -61,21 +61,26 @@
                    {:scalar-types {'n :long 'alpha :double 'inv-dx2 :double}})
                   :program :equations first :algorithm)
         scheduled (first (lower/lower-typed-stencil typed :cpu:0 :dtype :double))
-        artifact (sg/generate-segstencil-kernel
+        artifact (sg/generate-segstencil-kernel-body
                   scheduled
                   :array-types {'du :double 'u :double}
                   :scalar-types {'n :long 'alpha :double 'inv-dx2 :double})
-        source (:source artifact)
-        guard-position (str/index-of source "if (idx < 1 || idx >= _n_bound - 1)")
-        first-load-position (str/index-of source "u[")]
+        kernel-body (get-in artifact [:attributes :kernel-body])
+        if-region (some #(when (= "IfRegion" (some-> % class .getSimpleName)) %)
+                        (:operations kernel-body))
+        interior-region (some #(when (= "IfRegion" (some-> % class .getSimpleName)) %)
+                              (:then-operations if-region))
+        loads (filterv #(= "ScalarLoad" (some-> % class .getSimpleName))
+                       (:then-operations interior-region))]
     (is (kart/kernel-artifact? artifact))
     (is (= '[u du alpha inv-dx2 _n_bound] (mapv :name (:abi artifact))))
     (is (= [:input :output :scalar :scalar :scalar] (mapv :kind (:abi artifact))))
     (is (= [:double :double :double :double :int] (mapv :dtype (:abi artifact))))
     (is (= :no-write-alias (get-in artifact [:abi 0 :aliasing])))
     (is (= {:kind :stencil :boundary :dirichlet :radius 1} (:effects artifact)))
-    (is (and guard-position first-load-position (< guard-position first-load-position))
-        "the boundary test must dominate every neighborhood read")))
+    (is (= :portable-segstencil (get-in kernel-body [:attributes :kind])))
+    (is (= 3 (count loads))
+        "the interior control region must dominate every neighborhood read")))
 
 (defn- segred-source [body-expr]
   (let [form (list 'raster.par/reduce 'acc 0.0 'j 'n body-expr)

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -64,6 +64,17 @@
    :emission {:kernel-count 0 :targets [] :strategies []
               :fallback-reasons [] :declines {}}}
 
+  :heat-rhs-1d-gpu
+  {:route {:semantic-dialect :typed-parallel
+           :scheduled-dialect :scheduled-parallel
+           :emitted-dialect :opencl-parallel
+           :fallback :none}
+   :lowering {:nodes 2 :values 2 :instances 1 :program-instances 1
+              :outputs 1 :driver-allocations 0}
+   :emission {:structured-loops-emitted 0
+              :typed-equations-emitted 1
+              :host-scalar-equations 0}}
+
   :heat-loss-rk4-gpu
   {:route {:semantic-dialect :typed-parallel
            :scheduled-dialect :scheduled-parallel

--- a/test/raster/compiler/compatibility_ledger_test.clj
+++ b/test/raster/compiler/compatibility_ledger_test.clj
@@ -113,6 +113,13 @@
     :heat-rhs-1d-jvm
     (pipeline/compile-report #'pde/heat-rhs-1d! :dtype :double)
 
+    :heat-rhs-1d-gpu
+    (let [compilation (equation-first/compile
+                       #'pde/heat-rhs-1d! {:target target :dtype :double})
+          plan (equation-first/lower
+                compilation [(double-array 8) (double-array 8) 0.1 1.0])]
+      (equation-first-signature compilation plan))
+
     :heat-loss-rk4-gpu
     (let [compilation (equation-first/compile
                        #'pde/heat-loss-rk4 {:target target :dtype :double})
@@ -132,6 +139,7 @@
              :gqa-causal-mha-gpu
              :prefix-sum-gpu
              :heat-rhs-1d-jvm
+             :heat-rhs-1d-gpu
              :heat-loss-rk4-gpu}
            (set (keys workloads))))
     (doseq [[id expected] workloads]
@@ -142,6 +150,7 @@
                                   :q4k-dp4a-rows-gpu
                                   :gqa-causal-mha-gpu
                                   :prefix-sum-gpu
+                                  :heat-rhs-1d-gpu
                                   :heat-loss-rk4-gpu} id) report
                      :else (signature report))]
         (is (= expected actual)

--- a/test/raster/compiler/equation_first_c_family_test.clj
+++ b/test/raster/compiler/equation_first_c_family_test.clj
@@ -72,7 +72,7 @@
                                                     (raster.arrays/aget input index))))
        (raster.arrays/aset right index (long index)))))
 
-(deftm uncovered-stencil
+(deftm c-family-stencil
   [input :- (Array float) n :- Long] :- (Array float)
   (let [output (float-array n)]
     (raster.par/stencil!
@@ -208,13 +208,18 @@
       (is (= 1 (count (:outputs linked))))
       (is (= :none (get-in compilation [:stats :fallback]))))))
 
-(deftest uncovered-c-family-route-never-borrows-opencl-source
-  (doseq [target [cuda-target hip-target]]
-    (let [failure (reason-of #(equation-first/compile
-                               #'uncovered-stencil {:target target :dtype :float}))]
-      (is (contains? #{:equation-first-coverage :kernel-graph-target-lowering-missing}
-                     (:reason failure)))
-      (is (= :none (:fallback failure))))))
+(deftest public-stencil-uses-portable-kernel-body
+  (doseq [[target module-target]
+          [[cuda-target :cuda-c]
+           [hip-target :hip-cpp]]]
+    (let [compilation (equation-first/compile
+                       #'c-family-stencil {:target target :dtype :float})
+          kernel (first (:kernels compilation))]
+      (is (= [module-target] (mapv :target (:kernels compilation))))
+      (is (= :portable-segstencil
+             (get-in kernel [:attributes :kernel-body :attributes :kind])))
+      (is (not (re-find #"__kernel|get_global_id|get_local_id" (:source kernel))))
+      (is (= :none (get-in compilation [:stats :fallback]))))))
 
 (deftest public-segmented-fold-map-uses-the-same-c-family-boundary
   (doseq [[target module-target]

--- a/test/raster/compiler/ir/soac_dialect_test.clj
+++ b/test/raster/compiler/ir/soac_dialect_test.clj
@@ -290,6 +290,17 @@
             (is false "an unproved neighborhood index must not reach scheduling")
             (catch clojure.lang.ExceptionInfo exception
               (is (= :typed-soac-stencil-index (:reason (ex-data exception)))))))))
+    (testing "analyzed inc/dec forms retain the unit-affine radius proof"
+      (doseq [unit-index '[(clojure.core/inc (long i))
+                           (clojure.core/dec (long i))]]
+        (let [unit-lambda (dialect/lambda-form
+                           '[a input]
+                           [(list '+ 'a (list 'clojure.core/aget 'input unit-index))])
+              unit-equation (list '= 'stencil-0 '[result]
+                                  (list 'stencil attributes arrays captures unit-lambda))]
+          (is (pattern-dialect/valid?
+               dialect/TypedSOAC
+               (dialect/make facts [unit-equation] '[result]))))))
     (testing "devirtualized array loads are covered by the same radius proof"
       (let [read (with-meta
                    '(.invk raster.arrays/aget_m_doubles_long-impl input (+ i 2))

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -85,6 +85,13 @@
   (raster.par/scan-exclusive out acc 0.0 i n float
                              (clojure.core/+ acc (ra/aget x i))))
 
+(deftm ocl-session-stencil
+  [x :- (Array float) out :- (Array float) n :- Long] :- (Array float)
+  (raster.par/stencil!
+   out [x] 1 :dirichlet float i n
+   (clojure.core/+ (ra/aget x (clojure.core/dec i))
+                   (ra/aget x (clojure.core/inc i)))))
+
 (deftest ocl-map-void-mixed-storage-abi-roundtrip
   (if-not @device-probe/opencl-available?
     (device-probe/opencl-skip! "mixed-storage map-void")
@@ -235,6 +242,27 @@
       (is (= (float n) (aget out (dec n))))
       (is (every? (fn [i] (= (float (inc i)) (aget out i)))
                   [0 1 255 256 511 512 1024])))))
+
+(deftest ocl-resident-typed-stencil-runs-through-portable-kernel-body
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "resident typed stencil KernelBody")
+    (let [n 513
+          descriptor (pl/compile-gpu-program #'ocl-session-stencil :ocl:0 :dtype :float)
+          x (float-array (map float (range n)))
+          out (float-array n)
+          session (gpu/make-session :ocl:0)]
+      (try
+        (is (= :portable-segstencil
+               (get-in descriptor [:steps 0 :artifact :attributes
+                                   :kernel-body :attributes :kind])))
+        (let [program (fixture/instantiate! session descriptor [x out n]
+                                            {'x :input 'out :output})
+              ^floats result (get (fixture/run! program [x out n]) 'out)]
+          (is (= 0.0 (double (aget result 0))))
+          (is (= 0.0 (double (aget result (dec n)))))
+          (is (every? (fn [i] (= (double (* 2 i)) (double (aget result i))))
+                      [1 2 255 256 511])))
+        (finally (gpu/close-session! session))))))
 
 (deftest ocl-resident-and-staged-exclusive-scan-use-the-same-typed-graph
   (if-not @device-probe/opencl-available?


### PR DESCRIPTION
Completes the public certified stencil vertical across OpenCL, CUDA, and HIP.

- lowers radius-one Dirichlet SegStencil through target-neutral KernelBody scalar SSA and guarded control regions
- deletes the handwritten OpenCL stencil source path
- recognizes analyzed inc/dec as unit-affine stencil indices at the TypedSOAC proof boundary
- preserves variadic scalar evaluation order through binary KernelBody folds
- adds public equation-first CUDA/HIP compile fixtures and a scientific heat-equation compatibility ledger entry
- adds real OpenCL numerical coverage for interior and boundary lanes

Focused verification:
- equation-first C-family: 8 tests / 86 assertions
- TypedSOAC dialect: 13 tests / 63 assertions
- compatibility ledger: 1 test / 11 assertions
- segop emission: 16 tests / 85 assertions
- Intel Arc OpenCL numerical stencil: 1 test / 4 assertions
- nvcc 12.4 sm_80 and hipcc 5.7 gfx1100 compile the emitted public stencil source

The full suite and all generated CUDA/HIP fixtures are delegated to CircleCI.