### PR TITLE
Preserve indexed expressions in product reductions

### DIFF
--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -621,12 +621,12 @@
                      (emit-result element result (:dtype component) {}) ";"))
               components (:results element) elem-names)
         combine-lines
-        (fn [left-names right-names destination-names]
+        (fn [left-exprs right-exprs destination-names]
           (let [substitutions
                 (into {}
-                      (mapcat (fn [[[left right] left-name right-name]]
-                                [[left (symbol left-name)] [right (symbol right-name)]])
-                              (map vector (:parameters combine) left-names right-names)))]
+                      (mapcat (fn [[[left right] left-expr right-expr]]
+                                [[left left-expr] [right right-expr]])
+                              (map vector (:parameters combine) left-exprs right-exprs)))]
             (mapv (fn [component result destination]
                     (str (component-ctype component) " " destination " = "
                          (emit-result combine result (:dtype component) substitutions) ";"))
@@ -643,15 +643,19 @@
                               (str (component-ctype component) " " acc-name " = "
                                    (product-neutral-c (:neutral component) (:dtype component)) ";"))
                             components acc-names)
-        first-combine (combine-lines acc-names elem-names next-names)
+        first-combine (combine-lines (mapv symbol acc-names)
+                                     (mapv symbol elem-names)
+                                     next-names)
         assign-next (mapv #(str % " = " %2 ";") acc-names next-names)
         shared-decls (mapv (fn [component shared]
                              (str "__local " (component-ctype component) " " shared
                                   "[" block-size "];"))
                            components shared-names)
         shared-store (mapv #(str % "[lid] = " %2 ";") shared-names acc-names)
-        tree-left (mapv #(str % "[lid]") shared-names)
-        tree-right (mapv #(str % "[lid + stride]") shared-names)
+        tree-left (mapv #(list 'clojure.core/aget (symbol %) 'lid) shared-names)
+        tree-right (mapv #(list 'clojure.core/aget (symbol %)
+                                (list 'clojure.core/+ 'lid 'stride))
+                         shared-names)
         tree-next (mapv #(str "tree_next_" %) (range (count components)))
         tree-combine (combine-lines tree-left tree-right tree-next)
         tree-store (mapv #(str % "[lid] = " %2 ";") shared-names tree-next)

--- a/test/raster/dl/indexed_reduction_test.clj
+++ b/test/raster/dl/indexed_reduction_test.clj
@@ -86,6 +86,9 @@
     (testing "OpenCL C preserves mixed local products and portable NaN comparison"
       (is (str/includes? (first sources) "__local float shared_0"))
       (is (str/includes? (first sources) "__local int shared_1"))
+      (is (every? #(str/includes? % "shared_0[lid]") sources))
+      (is (every? #(str/includes? % "shared_0[(lid + stride)]") sources))
+      (is (every? #(not (str/includes? % "_u005b_")) sources))
       (is (str/includes? (first sources) "for (int col = lid"))
       (is (str/includes? (first sources) "barrier(CLK_LOCAL_MEM_FENCE)"))
       (is (every? #(not (str/includes? % "boolean(")) sources))


### PR DESCRIPTION
Product-reduction tree operands were represented as symbols containing C subscript syntax. The C-family emitter correctly sanitized their brackets, producing undeclared identifiers and causing OpenCL and Level Zero compilation to fail for row-wise argmax (including Gemma decoder tails).\n\nThis keeps the operands as structured aget expressions through combine-region substitution and adds regression assertions for the emitted local-memory accesses.\n\nValidation:\n- clojure -J-Xmx3200m -M:test -n raster.compiler.ir.reduction-test -n raster.dl.indexed-reduction-test (7 tests, 63 assertions)\n- pretrained-rstr Gemma 3 270M paged decode/fork anchor completes on Level Zero with this Raster worktree