### PR TITLE
Pin releases to their build commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,7 @@ jobs:
 
               echo "Creating release for version ${VERSION}"
               gh release create "v${VERSION}" \
+                --target "${CIRCLE_SHA1}" \
                 --title "Release ${VERSION}" \
                 --notes "Raster ${VERSION}" \
                 "$JAR_FILE" || echo "Release may already exist"


### PR DESCRIPTION
Concurrent mainline pipelines could create a versioned JAR from one commit and then let GitHub tag a newer default-branch head because the release job has no checkout and omitted an explicit target. This produced v0.2.497 and v0.2.498 on the same commit when #280 and #281 overlapped.\n\nPin gh release create to CircleCI's CIRCLE_SHA1 so each tag identifies the exact commit whose tested artifact was deployed. Historical tags are left untouched.\n\nValidation: YAML-only one-line change; full CI is the integration gate.