### PR TITLE
Prefer KernelBody for scheduled scalar graphs

### DIFF
--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -870,6 +870,26 @@
            (= [:exact :exact] [rounding overflow]))
       (str "(" (target-type result-type) ")(" argument-source ")")
 
+      ;; Integral-to-floating precision loss is explicit. OpenCL conversion builtins preserve the
+      ;; requested rounding; CUDA/HIP expose the corresponding signed integer RN intrinsics.
+      (and (not source-fp?) result-fp? (= :nearest-even rounding)
+           (= (if (= :half result-type) :ieee :exact) overflow))
+      (if (c-dialect/opencl? *scalar-dialect*)
+        (str "convert_" (target-type result-type) (cast-suffix rounding overflow)
+             "(" argument-source ")")
+        (case [source-type result-type]
+          [:byte :float] (str "(float)(" argument-source ")")
+          [:byte :double] (str "(double)(" argument-source ")")
+          [:int :float] (str "__int2float_rn(" argument-source ")")
+          [:int :double] (str "(double)(" argument-source ")")
+          [:long :float] (str "__ll2float_rn(" argument-source ")")
+          [:long :double] (str "__ll2double_rn(" argument-source ")")
+          (throw (ex-info "CUDA/HIP cannot preserve this integral-to-floating policy"
+                          {:reason :kernel-body-c-cast-policy
+                           :dialect (:id *scalar-dialect*)
+                           :source-type source-type :result-type result-type
+                           :rounding rounding :overflow overflow}))))
+
       :else
       (throw (ex-info "C-family target cannot preserve this KernelBody cast policy"
                       {:reason :kernel-body-c-cast-policy

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -758,7 +758,7 @@
                              :reason :segred-result-transform-lowering
                              :fallback :none)
                       exception)))
-            {:decline (ex-data exception)}))]
+            {:decline (assoc (ex-data exception) :fallback :verified-segred-opencl)}))]
     (or
      (:artifact kernel-body-attempt)
      (when-not (kernel-body-c-dialect/opencl?
@@ -1110,7 +1110,6 @@
   [graph {:keys [scalar-types array-types target-dialect]
           :or {scalar-types {} array-types {} target-dialect :opencl-intel}}]
   (let [target (kernel-body-c-dialect/resolve! target-dialect)
-        opencl? (kernel-body-c-dialect/opencl? target)
         array-types (graph-array-types graph array-types)
         emitted
         (kgraph/map-operations
@@ -1119,25 +1118,11 @@
            (kart/certify-scheduled-operation
             (cond
               (instance? raster.compiler.ir.segop.SegMap operation)
-              (try
-                (generate-segmap-kernel-body
-                 operation :dtype (:dtype operation)
-                 :scalar-types scalar-types :array-types array-types
-                 :target-dialect target-dialect
-                 :kernel-name-prefix "graph_segmap")
-                (catch clojure.lang.ExceptionInfo exception
-                  (if (and opencl? (segmap-body/declined? exception))
-                    (if (:out-sym operation)
-                      (generate-segmap-kernel
-                       operation (:out-sym operation)
-                       :dtype (:dtype operation)
-                       :scalar-types scalar-types :array-types array-types
-                       :kernel-name-prefix "graph_segmap")
-                      (generate-explicit-segmap-kernel
-                       operation :dtype (:dtype operation)
-                       :scalar-types scalar-types :array-types array-types
-                       :kernel-name-prefix "graph_segmap_effect"))
-                    (throw exception))))
+              (generate-segmap-kernel-body
+               operation :dtype (:dtype operation)
+               :scalar-types scalar-types :array-types array-types
+               :target-dialect target-dialect
+               :kernel-name-prefix "graph_segmap")
 
               (instance? raster.compiler.ir.segop.SegStencil operation)
               (generate-segstencil-kernel-body
@@ -1166,7 +1151,7 @@
                                {:reason :kernel-graph-reduction-output
                                 :target :opencl-c :node id :outputs outputs})))
              (kart/certify-scheduled-operation
-              (generate-segred-kernel
+              (generate-segred-kernel-body
                operation (first outputs)
                :dtype (:dtype operation)
                :scalar-types scalar-types :array-types array-types
@@ -1218,9 +1203,7 @@
    an operation from source spelling or node names."
   [graph & {:as opts}]
   (let [graph (kgraph/validate! graph)
-        target-dialect (get opts :target-dialect :opencl-intel)
-        opencl? (kernel-body-c-dialect/opencl?
-                 (kernel-body-c-dialect/resolve! target-dialect))]
+        target-dialect (get opts :target-dialect :opencl-intel)]
     (cond
       (scan/associative-scan? (get-in graph [:attributes :scan-algebra]))
       (apply generate-scan-kernel-graph graph (mapcat identity opts))
@@ -1232,7 +1215,7 @@
       (try
         (generate-elementwise-kernel-graph graph opts)
         (catch clojure.lang.ExceptionInfo exception
-          (if (and (not opencl?) (segmap-body/declined? exception))
+          (if (segmap-body/declined? exception)
             (throw (ex-info "scheduled map is outside the portable KernelBody C-family subset"
                             {:reason :kernel-graph-target-lowering-missing
                              :target-dialect target-dialect
@@ -1244,7 +1227,17 @@
       (and (seq (:nodes graph))
            (every? #(instance? raster.compiler.ir.segop.SegRed (:operation %))
                    (:nodes graph)))
-      (generate-reduction-kernel-graph graph opts)
+      (try
+        (generate-reduction-kernel-graph graph opts)
+        (catch clojure.lang.ExceptionInfo exception
+          (if (segred-body/declined? exception)
+            (throw (ex-info "scheduled reduction is outside the portable KernelBody C-family subset"
+                            {:reason :kernel-graph-target-lowering-missing
+                             :target-dialect target-dialect
+                             :kernel-body-decline (ex-data exception)
+                             :fallback :none}
+                            exception))
+            (throw exception))))
 
       (and (seq (:nodes graph))
            (every? #(instance? raster.compiler.ir.segop.SegFoldMap (:operation %))

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -1110,6 +1110,7 @@
   [graph {:keys [scalar-types array-types target-dialect]
           :or {scalar-types {} array-types {} target-dialect :opencl-intel}}]
   (let [target (kernel-body-c-dialect/resolve! target-dialect)
+        opencl? (kernel-body-c-dialect/opencl? target)
         array-types (graph-array-types graph array-types)
         emitted
         (kgraph/map-operations
@@ -1118,11 +1119,29 @@
            (kart/certify-scheduled-operation
             (cond
               (instance? raster.compiler.ir.segop.SegMap operation)
-              (generate-segmap-kernel-body
-               operation :dtype (:dtype operation)
-               :scalar-types scalar-types :array-types array-types
-               :target-dialect target-dialect
-               :kernel-name-prefix "graph_segmap")
+              (try
+                (generate-segmap-kernel-body
+                 operation :dtype (:dtype operation)
+                 :scalar-types scalar-types :array-types array-types
+                 :target-dialect target-dialect
+                 :kernel-name-prefix "graph_segmap")
+                (catch clojure.lang.ExceptionInfo exception
+                  (if (and opencl? (segmap-body/declined? exception))
+                    (-> (if (:out-sym operation)
+                          (generate-segmap-kernel
+                           operation (:out-sym operation)
+                           :dtype (:dtype operation)
+                           :scalar-types scalar-types :array-types array-types
+                           :kernel-name-prefix "graph_segmap")
+                          (generate-explicit-segmap-kernel
+                           operation :dtype (:dtype operation)
+                           :scalar-types scalar-types :array-types array-types
+                           :kernel-name-prefix "graph_segmap_effect"))
+                        (assoc-in [:attributes :emission-route] :verified-segmap-opencl)
+                        (assoc-in [:attributes :kernel-body-decline]
+                                  (assoc (ex-data exception)
+                                         :fallback :verified-segmap-opencl)))
+                    (throw exception))))
 
               (instance? raster.compiler.ir.segop.SegStencil operation)
               (generate-segstencil-kernel-body
@@ -1151,7 +1170,7 @@
                                {:reason :kernel-graph-reduction-output
                                 :target :opencl-c :node id :outputs outputs})))
              (kart/certify-scheduled-operation
-              (generate-segred-kernel-body
+              (generate-segred-kernel
                operation (first outputs)
                :dtype (:dtype operation)
                :scalar-types scalar-types :array-types array-types
@@ -1203,7 +1222,9 @@
    an operation from source spelling or node names."
   [graph & {:as opts}]
   (let [graph (kgraph/validate! graph)
-        target-dialect (get opts :target-dialect :opencl-intel)]
+        target-dialect (get opts :target-dialect :opencl-intel)
+        opencl? (kernel-body-c-dialect/opencl?
+                 (kernel-body-c-dialect/resolve! target-dialect))]
     (cond
       (scan/associative-scan? (get-in graph [:attributes :scan-algebra]))
       (apply generate-scan-kernel-graph graph (mapcat identity opts))
@@ -1215,7 +1236,7 @@
       (try
         (generate-elementwise-kernel-graph graph opts)
         (catch clojure.lang.ExceptionInfo exception
-          (if (segmap-body/declined? exception)
+          (if (and (not opencl?) (segmap-body/declined? exception))
             (throw (ex-info "scheduled map is outside the portable KernelBody C-family subset"
                             {:reason :kernel-graph-target-lowering-missing
                              :target-dialect target-dialect
@@ -1227,17 +1248,7 @@
       (and (seq (:nodes graph))
            (every? #(instance? raster.compiler.ir.segop.SegRed (:operation %))
                    (:nodes graph)))
-      (try
-        (generate-reduction-kernel-graph graph opts)
-        (catch clojure.lang.ExceptionInfo exception
-          (if (segred-body/declined? exception)
-            (throw (ex-info "scheduled reduction is outside the portable KernelBody C-family subset"
-                            {:reason :kernel-graph-target-lowering-missing
-                             :target-dialect target-dialect
-                             :kernel-body-decline (ex-data exception)
-                             :fallback :none}
-                            exception))
-            (throw exception))))
+      (generate-reduction-kernel-graph graph opts)
 
       (and (seq (:nodes graph))
            (every? #(instance? raster.compiler.ir.segop.SegFoldMap (:operation %))

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -965,6 +965,7 @@
       (let [source-type (:type (first infos))
             source-integral? (contains? #{:byte :int :long} source-type)
             result-integral? (contains? #{:byte :int :long} result-type)
+            result-floating? (dtype/fp-dtype? result-type)
             both-floating? (and (dtype/fp-dtype? source-type) (dtype/fp-dtype? result-type))
             narrowing? (and both-floating?
                             (> (dtype/bytes-of source-type) (dtype/bytes-of result-type)))
@@ -982,18 +983,34 @@
         (when (or (= :predicate result-type) (= :predicate (:type (first infos))))
           (throw (ex-info "numeric casts cannot create or consume predicates"
                           {:expression expression})))
-        ;; Rounding has no meaning when the source is already integral. Wrapping is a
-        ;; representation operation only between integral types. FP same-width/widening casts are
-        ;; exact; FP narrowing states an IEEE overflow and directional rounding contract.
-        (when-not (and (or (not source-integral?) (= :exact rounding))
-                       (or (not= :wrap overflow)
-                           (and source-integral? result-integral?))
-                       (if both-floating?
-                         (if narrowing?
-                           (and (= :ieee overflow)
-                                (contains? #{:nearest-even :toward-zero :up :down} rounding))
-                           (and (= :exact rounding) (= :exact overflow)))
-                         (not= :ieee overflow)))
+        ;; Integral-to-integral conversion has no rounding. Integral-to-floating conversion can
+        ;; lose precision and therefore states nearest-even explicitly; float/double cover the
+        ;; complete integral range, while half retains IEEE overflow. FP same-width/widening casts
+        ;; are exact; FP narrowing states IEEE overflow and a directional rounding contract.
+        (when-not
+         (cond
+           (and source-integral? result-integral?)
+           (and (= :exact rounding) (not= :ieee overflow))
+
+           (and source-integral? result-floating?)
+           (or (and (= :double result-type)
+                    (<= (dtype/bytes-of source-type) 4)
+                    (= [:exact :exact] [rounding overflow]))
+               (and (= :nearest-even rounding)
+                    (= (if (= :half result-type) :ieee :exact) overflow)))
+
+           both-floating?
+           (if narrowing?
+             (and (= :ieee overflow)
+                  (contains? #{:nearest-even :toward-zero :up :down} rounding))
+             (and (= :exact rounding) (= :exact overflow)))
+
+           ;; Floating-to-integral casts may state their directional rounding and their chosen
+           ;; finite-range policy, but never borrow representation wrapping or IEEE FP overflow.
+           result-integral?
+           (and (not= :wrap overflow) (not= :ieee overflow))
+
+           :else false)
           (throw (ex-info "scalar cast policies disagree with its source and result dtypes"
                           {:reason :kernel-body-cast-policy
                            :source-type source-type :result-type result-type

--- a/src/raster/compiler/passes/parallel/contraction_body.clj
+++ b/src/raster/compiler/passes/parallel/contraction_body.clj
@@ -8,27 +8,14 @@
   (:require [clojure.set :as set]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.layout :as layout]
-            [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.contraction-facts :as facts]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.segop :as segop]
+            [raster.compiler.passes.parallel.index-expression :as index-expression]
             [raster.compiler.passes.parallel.scalar-region-lower :as scalar-region-lower]
             [raster.compiler.passes.parallel.segred-body :as segred-body]))
-
-(def ^:private index-operators
-  {'+ :add, 'clojure.core/+ :add, 'raster.numeric/+ :add
-   '- :sub, 'clojure.core/- :sub, 'raster.numeric/- :sub
-   '* :mul, 'clojure.core/* :mul, 'raster.numeric/* :mul
-   'quot :floor-div, 'clojure.core/quot :floor-div
-   'rem :mod, 'clojure.core/rem :mod
-   'mod :mod, 'clojure.core/mod :mod
-   'min :min, 'clojure.core/min :min
-   'max :max, 'clojure.core/max :max})
-
-(def ^:private index-casts
-  '#{int long clojure.core/int clojure.core/long})
 
 (defn- decline!
   [rule message data]
@@ -45,49 +32,7 @@
 (defn lower-index
   "Translate verified source index arithmetic into KernelBody index expressions."
   [expression scope]
-  (let [expression (descriptor/unwrap-int-cast expression)]
-    (cond
-      (integer? expression) expression
-
-      (symbol? expression)
-      (if (contains? scope expression)
-        expression
-        (decline! :unbound-index-symbol
-                  "portable contraction index references an undeclared symbol"
-                  {:expression expression :scope scope}))
-
-      (and (seq? expression) (contains? index-casts (first expression))
-           (= 2 (count expression)))
-      (lower-index (second expression) scope)
-
-      (and (seq? expression)
-           (descriptor/increment-op? (descriptor/semantic-op expression))
-           (= 1 (count (descriptor/call-args expression))))
-      (body/expression :add
-                       (lower-index (first (descriptor/call-args expression)) scope)
-                       1)
-
-      (and (seq? expression)
-           (descriptor/decrement-op? (descriptor/semantic-op expression))
-           (= 1 (count (descriptor/call-args expression))))
-      (body/expression :sub
-                       (lower-index (first (descriptor/call-args expression)) scope)
-                       1)
-
-      (seq? expression)
-      (let [operator (get index-operators (descriptor/semantic-op expression))
-            arguments (vec (descriptor/call-args expression))]
-        (when-not (and operator (seq arguments)
-                       (or (not= :sub operator) (= 2 (count arguments))))
-          (decline! :index-expression
-                    "portable contraction requires explicit integer affine/decomposition arithmetic"
-                    {:expression expression :operator (descriptor/semantic-op expression)}))
-        (apply body/expression operator (map #(lower-index % scope) arguments)))
-
-      :else
-      (decline! :index-expression
-                "portable contraction index has an unsupported value"
-                {:expression expression :type (type expression)}))))
+  (index-expression/lower expression scope decline!))
 
 (defn- product-expression
   [values]

--- a/src/raster/compiler/passes/parallel/index_expression.clj
+++ b/src/raster/compiler/passes/parallel/index_expression.clj
@@ -1,0 +1,71 @@
+(ns raster.compiler.passes.parallel.index-expression
+  "Lower already-verified integer index expressions to target-neutral KernelBody arithmetic.
+
+   Schedules provide their own decline function so this small shared vocabulary does not decide
+   whether a missing rule is a map, reduction, scan, or contraction coverage failure."
+  (:require [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.ir.kernel-body :as body]))
+
+(def ^:private operators
+  {'+ :add, 'clojure.core/+ :add, 'raster.numeric/+ :add
+   '- :sub, 'clojure.core/- :sub, 'raster.numeric/- :sub
+   '* :mul, 'clojure.core/* :mul, 'raster.numeric/* :mul
+   'quot :floor-div, 'clojure.core/quot :floor-div
+   'rem :mod, 'clojure.core/rem :mod
+   'mod :mod, 'clojure.core/mod :mod
+   'min :min, 'clojure.core/min :min
+   'max :max, 'clojure.core/max :max})
+
+(def ^:private casts
+  '#{int long clojure.core/int clojure.core/long})
+
+(defn lower
+  "Translate a typed source index expression whose symbols are members of `scope`.
+
+   `decline!` is called as `(decline! rule message data)`.  This is normalization of explicit
+   index arithmetic only; it does not infer types, layouts, or affine facts."
+  [expression scope decline!]
+  (let [expression (descriptor/unwrap-int-cast expression)]
+    (cond
+      (integer? expression) expression
+
+      (symbol? expression)
+      (if (contains? scope expression)
+        expression
+        (decline! :unbound-index-symbol
+                  "portable index expression references an undeclared symbol"
+                  {:expression expression :scope scope}))
+
+      (and (seq? expression) (contains? casts (first expression))
+           (= 2 (count expression)))
+      (lower (second expression) scope decline!)
+
+      (and (seq? expression)
+           (descriptor/increment-op? (descriptor/semantic-op expression))
+           (= 1 (count (descriptor/call-args expression))))
+      (body/expression :add
+                       (lower (first (descriptor/call-args expression)) scope decline!)
+                       1)
+
+      (and (seq? expression)
+           (descriptor/decrement-op? (descriptor/semantic-op expression))
+           (= 1 (count (descriptor/call-args expression))))
+      (body/expression :sub
+                       (lower (first (descriptor/call-args expression)) scope decline!)
+                       1)
+
+      (seq? expression)
+      (let [operator (get operators (descriptor/semantic-op expression))
+            arguments (vec (descriptor/call-args expression))]
+        (when-not (and operator (seq arguments)
+                       (or (not= :sub operator) (= 2 (count arguments))))
+          (decline! :index-expression
+                    "portable index expression requires explicit integer arithmetic"
+                    {:expression expression :operator (descriptor/semantic-op expression)}))
+        (apply body/expression operator
+               (map #(lower % scope decline!) arguments)))
+
+      :else
+      (decline! :index-expression
+                "portable index expression has an unsupported value"
+                {:expression expression :type (type expression)}))))

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -103,9 +103,11 @@
                           (and (not fp-source?) (not fp-target?) widening?) [:exact :exact]
                           (and (not fp-source?) fp-target? (= :double target)
                                (<= (dtype/bytes-of source) 4)) [:exact :exact]
+                          (and (not fp-source?) fp-target?)
+                          [:nearest-even (if (= :half target) :ieee :exact)]
                           :else
                           (decline! :cast-policy
-                                    "scalar cast has no portable exact policy"
+                                    "scalar cast has no portable rounding and overflow policy"
                                     {:expression expression :source source :target target}))
                         id (fresh "cast")]
                     {:operations (conj (:operations lowered)
@@ -262,7 +264,10 @@
                                              (dtype/canon
                                               (or (source-type (first arguments) :int env) :int))
                                              expected)
-                              lowered (mapv #(lower % operand-type env) arguments)
+                              lowered (mapv #(cast-lowered
+                                              (lower % operand-type env)
+                                              operand-type expression)
+                                            arguments)
                               result-type (if comparison? :predicate operand-type)
                               _ (when-not (every? #(= operand-type (:type %)) lowered)
                                   (decline! :operand-dtype

--- a/src/raster/compiler/passes/parallel/segfoldmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segfoldmap_body.clj
@@ -11,7 +11,7 @@
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.segop :as segop]
-            [raster.compiler.passes.parallel.contraction-body :as contraction-body]
+            [raster.compiler.passes.parallel.index-expression :as index-expression]
             [raster.compiler.passes.parallel.scalar-expression-body :as scalar-expression]))
 
 (defn- decline!
@@ -94,8 +94,8 @@
                       ([expression] (lower-index expression #{}))
                       ([expression extra-scope]
                        (widen-index-expression
-                        (contraction-body/lower-index
-                         expression (set/union index-scope extra-scope))
+                        (index-expression/lower
+                         expression (set/union index-scope extra-scope) decline!)
                         index-value-types)))
         segment-count (lower-index segment-count-source)
         map-extent (lower-index (:bound mapped-dim))

--- a/src/raster/compiler/passes/parallel/segmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segmap_body.clj
@@ -11,7 +11,7 @@
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.segop :as segop]
-            [raster.compiler.passes.parallel.contraction-body :as contraction-body]
+            [raster.compiler.passes.parallel.index-expression :as index-expression]
             [raster.compiler.passes.parallel.scalar-expression-body :as scalar-expression]))
 
 (defn- decline!
@@ -89,8 +89,8 @@
                       ([expression] (lower-index expression #{}))
                       ([expression extra-scope]
                        (widen-index-expression
-                        (contraction-body/lower-index
-                         expression (set/union index-scope extra-scope))
+                        (index-expression/lower
+                         expression (set/union index-scope extra-scope) decline!)
                         index-types)))
         lowerer (scalar-expression/make-lowerer
                  {:array-types array-types :scalar-types scalar-types

--- a/src/raster/compiler/passes/parallel/segred_body.clj
+++ b/src/raster/compiler/passes/parallel/segred_body.clj
@@ -16,6 +16,7 @@
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.segop :as segop]
+            [raster.compiler.passes.parallel.index-expression :as index-expression]
             [raster.compiler.passes.parallel.scalar-region-lower :as scalar-region-lower]))
 
 (def ^:private cast-heads
@@ -30,7 +31,7 @@
   (throw (ex-info message (assoc data
                                  :reason :segred-kernel-body-declined
                                  :missing-rule rule
-                                 :fallback :verified-segred-opencl))))
+                                 :fallback :none))))
 
 (defn declined?
   [exception]
@@ -135,7 +136,7 @@
   "Lower a scalar reduction element into typed SSA. `coordinate-lower` may translate a verified
    source-level flat array index into KernelBody index arithmetic; without it, this retains the
    pointwise full-reduction contract. A predicate requires an explicit typed load fallback."
-  [expression {:keys [index coordinate dtype arrays scalars coordinate-lower
+  [expression {:keys [index coordinate dtype arrays scalars scalar-types coordinate-lower
                       load-predicate load-other]}]
   (let [operations (atom [])
         counter (atom 0)
@@ -151,7 +152,13 @@
 
                   (symbol? expression)
                   (if (contains? scalars expression)
-                    expression
+                    (if (= (dtype/canon dtype)
+                           (dtype/canon (get scalar-types expression dtype)))
+                      expression
+                      (decline! :scalar-dtype
+                                "KernelBody reduction value scalar must match the accumulator dtype"
+                                {:expression expression :dtype dtype
+                                 :scalar-dtype (get scalar-types expression)}))
                     (decline! :unbound-scalar
                               "KernelBody element expression references an undeclared scalar"
                               {:expression expression :scalars scalars}))
@@ -216,8 +223,8 @@
 (defn lower
   "Lower an eligible scalar SegRed to one verified portable workgroup-tree KernelBody.
 
-   `array-types` and `scalar-types` are authoritative ABI facts. This vertical initially accepts
-   the uniform-dtype storage contract already implemented by the scalar SegRed runtime."
+   `array-types` and `scalar-types` are authoritative ABI facts. Tensor element storage and the
+   accumulator remain uniform; integral scalar parameters may participate in index expressions."
   [segred out-sym & {:keys [dtype array-types scalar-types]
                      :or {dtype :double array-types {} scalar-types {}}}]
   (let [dtype (or (:dtype segred) dtype)
@@ -238,9 +245,9 @@
                          (zero? (bit-and workgroup-size (dec workgroup-size)))
                          (launch/dimension-expression? bound-dimension)
                          (every? #(= (dtype/canon dtype) (dtype/canon (array-dtype %))) arrays)
-                         (every? #(= (dtype/canon dtype) (dtype/canon (scalar-dtype %))) scalars))
+                         (every? #(dtype/known? (dtype/canon (scalar-dtype %))) scalars))
             (decline! :uniform-scalar-storage
-                      "KernelBody scalar reduction requires a static power-of-two workgroup and uniform scalar storage"
+                      "KernelBody scalar reduction requires a static power-of-two workgroup and uniform tensor storage"
                       {:segred-id (:id segred) :dtype dtype :bound bound
                        :workgroup-size workgroup-size :arrays arrays :scalars scalars}))
         {:keys [operator identity element]} (scalar-plan segred)
@@ -254,8 +261,17 @@
         next-lane-accumulator 'next-lane-accumulator
         lane-result 'lane-result
         {:keys [operations result]}
-        (lower-element-operations element {:index index :coordinate element-index :dtype dtype
-                                           :arrays (set arrays) :scalars (set scalars)})
+        (lower-element-operations
+         element
+         {:index index :coordinate element-index :dtype dtype
+          :arrays (set arrays) :scalars (set scalars)
+          :scalar-types (into {} (map (fn [id] [id (scalar-dtype id)])) scalars)
+          :coordinate-lower
+          (fn [source-coordinate]
+            (index-expression/lower
+             (util/subst-syms {index element-index} source-coordinate)
+             (conj (set scalars) element-index)
+             decline!))})
         output (or out-sym 'output)
         group-count (launch-group-count (get-in segred [:grid :num-blocks])
                                         bound workgroup-size)

--- a/src/raster/compiler/passes/parallel/segscan_body.clj
+++ b/src/raster/compiler/passes/parallel/segscan_body.clj
@@ -14,7 +14,7 @@
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.segop :as segop]
-            [raster.compiler.passes.parallel.contraction-body :as contraction-body]
+            [raster.compiler.passes.parallel.index-expression :as index-expression]
             [raster.compiler.passes.parallel.scalar-expression-body :as scalar-expression]))
 
 (defn- decline!
@@ -146,7 +146,7 @@
         (fn lower-index
           ([form] (lower-index form #{}))
           ([form extra-scope]
-           (contraction-body/lower-index form (set/union index-scope extra-scope))))
+           (index-expression/lower form (set/union index-scope extra-scope) decline!)))
         lowerer (scalar-expression/make-lowerer
                  {:array-types array-types :scalar-types scalar-types
                   :arrays (set pointer-ids) :index-scope index-scope

--- a/src/raster/compiler/passes/parallel/segstencil_body.clj
+++ b/src/raster/compiler/passes/parallel/segstencil_body.clj
@@ -6,7 +6,7 @@
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.segop :as segop]
-            [raster.compiler.passes.parallel.contraction-body :as contraction-body]
+            [raster.compiler.passes.parallel.index-expression :as index-expression]
             [raster.compiler.passes.parallel.scalar-expression-body :as scalar-expression]))
 
 (defn- decline!
@@ -89,8 +89,8 @@
                       ([expression] (lower-index expression #{}))
                       ([expression extra-scope]
                        (widen-index-expression
-                        (contraction-body/lower-index
-                         expression (set/union index-scope extra-scope))
+                        (index-expression/lower
+                         expression (set/union index-scope extra-scope) decline!)
                         index-types)))
         lowerer (scalar-expression/make-lowerer
                  {:array-types array-types :scalar-types scalar-types

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -19,6 +19,7 @@
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
+            [raster.compiler.passes.parallel.segred-body :as segred-body]
             [raster.compiler.passes.parallel.soac-lower :as lower]
             [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
             [raster.compiler.backend.gpu.segop-opencl :as sg]))
@@ -46,6 +47,31 @@
         "the cross-block target kernel must not resurrect the original reduction body")
     (is (= 2 (second (get temporary-specs partials)))
         "dynamic two-phase scratch resolves through KernelLaunch IR at call time")))
+
+(deftest scheduled-reduction-graph-never-selects-the-compatibility-emitter
+  (let [source '(let* [result (raster.par/reduce acc 0.0 i n
+                                                 (+ acc (clojure.core/aget a i)))]
+                      result)
+        options {:dtype :double :array-types {'a :double}}
+        typed (:program (typed-route/attempt source :double {'a :double} options))
+        algorithm (get-in typed [:equations 0 :algorithm])
+        scheduled (:form (segop-lower/segop-lower-pass typed options))
+        graph (equation-graph/make algorithm scheduled)
+        exception
+        (try
+          (with-redefs [segred-body/lower
+                        (fn [& _]
+                          (throw (ex-info "simulated portable coverage gap"
+                                          {:reason :segred-kernel-body-declined
+                                           :missing-rule :simulated
+                                           :fallback :none})))]
+            (sg/generate-kernel-graph graph :array-types {'a :double}))
+          nil
+          (catch clojure.lang.ExceptionInfo exception exception))]
+    (is (= :kernel-graph-target-lowering-missing (:reason (ex-data exception))))
+    (is (= :simulated (get-in (ex-data exception)
+                              [:kernel-body-decline :missing-rule])))
+    (is (= :none (:fallback (ex-data exception))))))
 
 (deftest typed-stencil-emits-a-guarded-typed-artifact
   (let [source '(let* [result
@@ -304,20 +330,17 @@
       (is (= '[a output _n_bound] (mapv :name (:abi k))))
       (is (= '[a nil n] (:arguments k))))))
 
-(deftest segred-kernel-body-decline-is-retained-in-the-fallback-artifact
+(deftest mixed-index-scalars-stay-on-the-portable-reduction-route
   (let [form '(raster.par/reduce acc 0.0 i n
                                  (+ acc (clojure.core/aget a (+ i offset))))
         node (soac/par-form->soac 'result form 22 :dtype :float)
         operation (first (lower/lower-reduce node nil :dtype :float))
         artifact (sg/generate-segred-kernel
                   operation nil :dtype :float :scalar-types {'offset :int})]
-    (is (= :verified-segred-opencl (get-in artifact [:attributes :emission-route])))
-    (is (= :segred-kernel-body-declined
-           (get-in artifact [:attributes :kernel-body-decline :reason])))
-    (is (= :uniform-scalar-storage
-           (get-in artifact [:attributes :kernel-body-decline :missing-rule])))
-    (is (= :verified-segred-opencl
-           (get-in artifact [:attributes :kernel-body-decline :fallback])))))
+    (is (= :kernel-body (get-in artifact [:attributes :emission-route])))
+    (is (= :int (some #(when (= 'offset (:name %)) (:dtype %)) (:abi artifact))))
+    (is (re-find #"element_index.* \+ offset" (:source artifact)))
+    (is (nil? (get-in artifact [:attributes :kernel-body-decline])))))
 
 ;; ================================================================
 ;; Horizontally-fused multi-output SegMap: the SECONDARY output (written

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -48,7 +48,7 @@
     (is (= 2 (second (get temporary-specs partials)))
         "dynamic two-phase scratch resolves through KernelLaunch IR at call time")))
 
-(deftest scheduled-reduction-graph-never-selects-the-compatibility-emitter
+(deftest scheduled-reduction-graph-does-not-export-an-opencl-fallback-to-cuda
   (let [source '(let* [result (raster.par/reduce acc 0.0 i n
                                                  (+ acc (clojure.core/aget a i)))]
                       result)
@@ -65,7 +65,8 @@
                                           {:reason :segred-kernel-body-declined
                                            :missing-rule :simulated
                                            :fallback :none})))]
-            (sg/generate-kernel-graph graph :array-types {'a :double}))
+            (sg/generate-kernel-graph graph :array-types {'a :double}
+                                      :target-dialect :cuda))
           nil
           (catch clojure.lang.ExceptionInfo exception exception))]
     (is (= :kernel-graph-target-lowering-missing (:reason (ex-data exception))))

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -294,6 +294,13 @@
           [(body/->ScalarCompute
             (body/value 'bad :long)
             (body/cast-expression (body/literal 1 :int) :long :up :exact))]))))
+  (testing "integral-to-floating conversion states its precision loss"
+    (is (body/kernel-body?
+         (scalar-body
+          [(body/->ScalarCompute
+            (body/value 'converted :float)
+            (body/cast-expression (body/literal 1 :long)
+                                  :float :nearest-even :exact))]))))
   (testing "floating conversions cannot silently request integer wrapping"
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo #"policies disagree"


### PR DESCRIPTION
## Outcome

Scheduled TypedSOAC map and reduction graphs now prefer portable KernelBody. OpenCL-only coverage gaps remain executable, but the artifact records both the verified compatibility route and the structured KernelBody decline. CUDA and HIP fail explicitly instead of inheriting OpenCL source.

## Coverage closed

- centralize verified integer index normalization for maps, stencils, scans, fold-maps, contractions, and reductions
- support typed integral scalar offsets in reduction load coordinates
- make integral-to-floating precision loss explicit in KernelBody and lower it for OpenCL/CUDA/HIP C-family targets
- preserve exact int32-to-double conversion separately
- distinguish portable KernelBody emission from verified transitional OpenCL emission in artifact metadata

## Remaining explicit coverage gaps

- segmented/free-axis reductions need a corresponding KernelBody schedule
- nested fold scalar regions need structured lowering before their compatibility route can be removed

## Validation

- 79 focused tests, 562 assertions, all green
- CircleCI owns the full suite plus hardware-free nvcc/hipcc compile gates

The repository-wide cljfmt check is already baseline-red across unrelated files; no bulk formatting is included here.