### PR TITLE
Preserve typed map locals in KernelBody

### DIFF
--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -616,17 +616,11 @@
                                  #(and (instance? raster.compiler.ir.segop.SegMap %)
                                        (= :typed-soac (:algorithm-dialect %))))
                       kernel (if scheduled
-                               (if (:out-sym scheduled)
-                                 (segop-cl/generate-segmap-kernel
-                                  scheduled (:out-sym scheduled)
-                                  :dtype (:dtype scheduled)
-                                  :scalar-types top-scalar-types
-                                  :array-types top-array-types)
-                                 (segop-cl/generate-explicit-segmap-kernel
-                                  scheduled
-                                  :dtype (:dtype scheduled)
-                                  :scalar-types top-scalar-types
-                                  :array-types top-array-types))
+                               (segop-cl/generate-scheduled-segmap-kernel
+                                scheduled
+                                :dtype (:dtype scheduled)
+                                :scalar-types top-scalar-types
+                                :array-types top-array-types)
                                (legacy/generate-par-map-void-kernel
                                 form :dtype dtype :device-id device-id
                                 :array-types top-array-types

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -410,6 +410,7 @@
       :provenance {:dialect :kernel-body :source-dialect :segmap
                    :segop-id (:id segmap)}
       :attributes {:kernel-body kernel-body
+                   :emission-route :kernel-body
                    :array-params (vec (concat inputs outputs))
                    :scalar-params scalars
                    :dtype (:dtype segmap)
@@ -720,6 +721,37 @@
                    :kernel-body kernel-body
                    :emission-route :kernel-body
                    :target-dialect target-dialect}})))
+
+(defn generate-scheduled-segmap-kernel
+  "Emit one scheduled SegMap through the single KernelBody-first C-family boundary.
+
+   Portable targets never consume source-shaped OpenCL fallback code. OpenCL retains the verified
+   compatibility emitter for scalar regions and memory effects that KernelBody cannot represent
+   yet, with the structured decline attached to the artifact so the remaining debt is observable."
+  [operation & {:keys [dtype kernel-name-prefix scalar-types array-types target-dialect]
+                :or {kernel-name-prefix "segmap" scalar-types {} array-types {}
+                     target-dialect :opencl-intel}}]
+  (let [dtype (or (:dtype operation) dtype :double)
+        target (kernel-body-c-dialect/resolve! target-dialect)]
+    (try
+      (generate-segmap-kernel-body
+       operation :dtype dtype :scalar-types scalar-types :array-types array-types
+       :target-dialect target-dialect :kernel-name-prefix kernel-name-prefix)
+      (catch clojure.lang.ExceptionInfo exception
+        (if (and (kernel-body-c-dialect/opencl? target)
+                 (segmap-body/declined? exception))
+          (-> (if (:out-sym operation)
+                (generate-segmap-kernel
+                 operation (:out-sym operation)
+                 :dtype dtype :scalar-types scalar-types :array-types array-types
+                 :kernel-name-prefix kernel-name-prefix)
+                (generate-explicit-segmap-kernel
+                 operation :dtype dtype :scalar-types scalar-types :array-types array-types
+                 :kernel-name-prefix (str kernel-name-prefix "_effect")))
+              (assoc-in [:attributes :emission-route] :verified-segmap-opencl)
+              (assoc-in [:attributes :kernel-body-decline]
+                        (assoc (ex-data exception) :fallback :verified-segmap-opencl)))
+          (throw exception))))))
 
 (defn generate-segred-kernel
   "Generate OpenCL C reduction kernels from a SegRed record.
@@ -1110,7 +1142,6 @@
   [graph {:keys [scalar-types array-types target-dialect]
           :or {scalar-types {} array-types {} target-dialect :opencl-intel}}]
   (let [target (kernel-body-c-dialect/resolve! target-dialect)
-        opencl? (kernel-body-c-dialect/opencl? target)
         array-types (graph-array-types graph array-types)
         emitted
         (kgraph/map-operations
@@ -1119,29 +1150,11 @@
            (kart/certify-scheduled-operation
             (cond
               (instance? raster.compiler.ir.segop.SegMap operation)
-              (try
-                (generate-segmap-kernel-body
-                 operation :dtype (:dtype operation)
-                 :scalar-types scalar-types :array-types array-types
-                 :target-dialect target-dialect
-                 :kernel-name-prefix "graph_segmap")
-                (catch clojure.lang.ExceptionInfo exception
-                  (if (and opencl? (segmap-body/declined? exception))
-                    (-> (if (:out-sym operation)
-                          (generate-segmap-kernel
-                           operation (:out-sym operation)
-                           :dtype (:dtype operation)
-                           :scalar-types scalar-types :array-types array-types
-                           :kernel-name-prefix "graph_segmap")
-                          (generate-explicit-segmap-kernel
-                           operation :dtype (:dtype operation)
-                           :scalar-types scalar-types :array-types array-types
-                           :kernel-name-prefix "graph_segmap_effect"))
-                        (assoc-in [:attributes :emission-route] :verified-segmap-opencl)
-                        (assoc-in [:attributes :kernel-body-decline]
-                                  (assoc (ex-data exception)
-                                         :fallback :verified-segmap-opencl)))
-                    (throw exception))))
+              (generate-scheduled-segmap-kernel
+               operation :dtype (:dtype operation)
+               :scalar-types scalar-types :array-types array-types
+               :target-dialect target-dialect
+               :kernel-name-prefix "graph_segmap")
 
               (instance? raster.compiler.ir.segop.SegStencil operation)
               (generate-segstencil-kernel-body

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -121,6 +121,10 @@
               (let [expression (inline-lets expression)
                     expected (canon-type expected)]
                 (cond
+                  (instance? raster.compiler.ir.kernel_body.Literal expression)
+                  {:operations [] :result expression
+                   :type (canon-type (:type expression))}
+
                   (number? expression)
                   {:operations [] :result (body/literal expression expected) :type expected}
 

--- a/src/raster/compiler/passes/parallel/segmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segmap_body.clj
@@ -8,6 +8,7 @@
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.util :as util]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.segop :as segop]
@@ -42,10 +43,25 @@
 
 (defn- scalar-forms
   [expression]
-  (let [expression (scalar-expression/inline-lets expression)]
-    (if (and (seq? expression) (= 'do (first expression)))
-      (vec (rest expression))
-      [expression])))
+  (if (and (seq? expression) (= 'do (first expression)))
+    (vec (rest expression))
+    [expression]))
+
+(defn- scalar-region
+  "Separate the typed top-level local bindings from a SegMap result region.
+
+   TypedSOAC materialization annotates every local ID with its scalar dtype. Keeping these
+   bindings explicit lets KernelBody preserve sharing across several result stores."
+  [expression]
+  (if (and (seq? expression)
+           (contains? #{'let 'let* 'clojure.core/let} (first expression)))
+    (let [[_ bindings & body] expression]
+      (when-not (= 1 (count body))
+        (decline! :local-region-shape
+                  "map scalar local region requires one result expression"
+                  {:expression expression :body-count (count body)}))
+      {:bindings (vec (partition 2 bindings)) :result (first body)})
+    {:bindings [] :result expression}))
 
 (defn lower
   "Apply a portable grid-stride scalar schedule to a typed one-dimensional SegMap."
@@ -66,7 +82,11 @@
         index (:name (first dimensions))
         bound (:bound (first dimensions))
         inputs (vec (sort-by name (:inputs segmap)))
-        outputs (vec (sort-by name (:outputs segmap)))
+        primary-output (:out-sym segmap)
+        outputs (if primary-output
+                  (vec (concat (sort-by name (disj (:outputs segmap) primary-output))
+                               [primary-output]))
+                  (vec (sort-by name (:outputs segmap))))
         scalars (vec (sort-by name (:scalars segmap)))
         _ (when (seq (set/intersection (set inputs) (set outputs)))
             (decline! :inout-storage
@@ -97,14 +117,31 @@
                   :arrays (set inputs) :index-scope index-scope
                   :lower-index lower-index :predicate :map-active
                   :id-prefix "map" :decline! decline!})
-        forms (scalar-forms (:lambda segmap))
-        primary-output (:out-sym segmap)
+        {:keys [bindings result]} (scalar-region (:lambda segmap))
+        base-environment (assoc scalar-types index :long)
+        local-state
+        (reduce
+         (fn [{:keys [substitutions operations environment]} [id init]]
+           (let [tag (or (:raster.type/tag (meta id)) (:tag (meta id)))
+                 local-type (some-> tag dtype/dtype-for-scalar-tag dtype/canon)
+                 _ (when-not local-type
+                     (decline! :local-dtype
+                               "map scalar local is missing its TypedSOAC dtype"
+                               {:operation (:id segmap) :local id :metadata (meta id)}))
+                 init (util/subst-syms substitutions init)
+                 lowered ((:lower lowerer) init local-type environment)]
+             {:substitutions (assoc substitutions id (:result lowered))
+              :operations (into operations (:operations lowered))
+              :environment (assoc environment (:result lowered) (:type lowered))}))
+         {:substitutions {} :operations [] :environment base-environment}
+         bindings)
+        forms (scalar-forms (util/subst-syms (:substitutions local-state) result))
         explicit-forms (if primary-output (pop forms) forms)
         primary-form (when primary-output (peek forms))
         _ (when (and primary-output (empty? forms))
             (decline! :missing-result "map result has no scalar expression"
                       {:operation (:id segmap) :output primary-output}))
-        environment (assoc scalar-types index :long)
+        environment (:environment local-state)
         lower-store
         (fn [form]
           (when-not (descriptor/aset-call? form)
@@ -126,7 +163,8 @@
                           ((:lower lowerer) primary-form
                                             (get array-types primary-output) environment))
         scalar-operations
-        (vec (concat explicit-operations
+        (vec (concat (:operations local-state)
+                     explicit-operations
                      (:operations primary-lowered)
                      (when primary-output
                        [(body/->ScalarStore primary-output [index]

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -19,6 +19,7 @@
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
+            [raster.compiler.passes.parallel.segmap-body :as segmap-body]
             [raster.compiler.passes.parallel.segred-body :as segred-body]
             [raster.compiler.passes.parallel.soac-lower :as lower]
             [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
@@ -387,3 +388,24 @@
     (is (= [:float :float :int :int] (mapv :dtype (:abi k))))
     (is (re-find #"int offset" (:source k)))
     (is (= '[a out offset n] (:arguments k)))))
+
+(deftest scheduled-segmap-uses-one-observable-compatibility-boundary
+  (let [form '(raster.par/map! out i n float
+                               (clojure.core/aget a i))
+        operation (-> (soac/par-form->soac 'out form 2)
+                      (lower/lower-map nil :dtype :float)
+                      first)
+        artifact
+        (with-redefs [segmap-body/lower
+                      (fn [& _]
+                        (throw (ex-info "simulated portable coverage gap"
+                                        {:reason :segmap-kernel-body-declined
+                                         :missing-rule :simulated
+                                         :fallback :none})))]
+          (sg/generate-scheduled-segmap-kernel operation :dtype :float))]
+    (is (= :verified-segmap-opencl
+           (get-in artifact [:attributes :emission-route])))
+    (is (= :simulated
+           (get-in artifact [:attributes :kernel-body-decline :missing-rule])))
+    (is (= :verified-segmap-opencl
+           (get-in artifact [:attributes :kernel-body-decline :fallback])))))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1,6 +1,7 @@
 (ns raster.compiler.passes.parallel.typed-soac-route-test
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
+            [raster.compiler.backend.gpu.segop-opencl :as segop-opencl]
             [raster.compiler.backend.jvm.par-simd :as par-simd]
             [raster.compiler.core.hardware :as hardware]
             [raster.compiler.ir.kernel-body :as kernel-body]
@@ -226,14 +227,25 @@
         emitted (opencl-pass/opencl-pass scheduled :device-id :ocl:0
                                          :dtype :float :min-elements 0)
         kernel-source (:source (first (:kernels emitted)))
+        portable (segop-opencl/generate-segmap-kernel-body
+                  (first (:operations (first (:equations scheduled))))
+                  :array-types {'x :float 'a :float 'b :float})
+        portable-source (:source portable)
         jvm (par-simd/simd-pass scheduled :min-elements 1)
         execute (eval (list 'fn '[x a b n] (:form jvm)))
         x (float-array [1.0 2.0 3.0 4.0])
         a (float-array 4)
         b (float-array 4)]
-    (is (= 1 (count (re-seq #"x\[idx\]" kernel-source)))
+    (is (= 1 (count (re-seq #"x\[" kernel-source)))
         "the shared producer is emitted once, not projected into both results")
-    (is (re-find #"float rstr_local_0" kernel-source))
+    (is (= :kernel-body (get-in (first (:kernels emitted))
+                                [:attributes :emission-route])))
+    (is (= 1 (count (re-seq #"x\[" portable-source)))
+        "KernelBody retains the same typed local instead of duplicating its load")
+    (is (= 1 (count (filter #(and (= "ScalarCompute" (some-> % class .getSimpleName))
+                                  (= :* (get-in % [:expression :op])))
+                            (get-in portable [:attributes :kernel-body :operations]))))
+        "the shared square is one scalar SSA definition")
     (is (nil? (execute x a b 4)))
     (is (= [2.0 3.0 4.0 5.0] (mapv double a)))
     (is (= [4.0 9.0 16.0 25.0] (mapv double b)))))


### PR DESCRIPTION
## Outcome

Typed one-dimensional maps now retain top-level TypedSOAC local bindings as ordered KernelBody scalar SSA. Horizontally fused outputs share their producer loads and arithmetic instead of re-inlining the same expression into each store.

## Compiler cleanup

- preserve dtype metadata on scalar locals and reject missing type facts
- preserve the primary result as the final ordered tuple component
- accept already-lowered KernelBody literals during local substitution
- centralize scheduled SegMap target lowering in one KernelBody-first boundary
- route both graph emission and the direct OpenCL pass through that boundary
- retain reducing/in-place and otherwise unsupported OpenCL maps as explicitly marked verified compatibility artifacts

## Validation

- 107 focused tests, 683 assertions, all green
- full suite and C-family compile gates run in CircleCI

This is stacked on #284 and should be rebased to main after that PR lands.