### PR TITLE
Preserve typed map locals in KernelBody

### DIFF
--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -1900,14 +1900,17 @@
    the staged-contraction emitter prepended the helper — hardcoded as `(intrinsics/descriptor
    'dp4a)`. Every other kernel that used the intrinsic compiled to `use of undeclared identifier
    'rstr_dp4a'`. One registry scan replaces the per-emitter, per-intrinsic special case."
-  [body-str]
-  (->> intrinsics/table
-       (keep (fn [[_ {:keys [c c-helper-src]}]]
-               (when (and c-helper-src (:fn c)
+  ([body-str]
+   (intrinsic-helper-sources body-str nil))
+  ([body-str target-dialect]
+   (->> intrinsics/table
+       (keep (fn [[_ {:keys [c c-helper-src target-helper-src]}]]
+               (let [helper-src (or (get target-helper-src target-dialect) c-helper-src)]
+                 (when (and helper-src (:fn c)
                           (re-find (re-pattern (str "\\b" (java.util.regex.Pattern/quote (:fn c)) "\\(")) body-str))
-                 c-helper-src)))
+                   helper-src))))
        distinct
-       (str/join "\n")))
+       (str/join "\n"))))
 
 (defn helper-sources
   "Target helper definitions required by an already-emitted C-family body."

--- a/src/raster/compiler/backend/gpu/kernel_body_c_dialect.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_c_dialect.clj
@@ -138,6 +138,13 @@
   [dialect]
   (if (opencl? dialect) "__kernel void " "extern \"C\" __global__ void "))
 
+(defn helper-source
+  "Add only the target-language qualifier to registry-owned scalar helper definitions."
+  [dialect source]
+  (if (or (empty? source) (opencl? dialect))
+    source
+    (str/replace source #"(?m)^inline " "__device__ __forceinline__ ")))
+
 (defn workgroup-arena-declaration
   "Spell one statically sized, explicitly aligned workgroup-memory arena."
   [dialect name bytes alignment]

--- a/src/raster/compiler/backend/gpu/kernel_body_c_dialect.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_c_dialect.clj
@@ -129,7 +129,7 @@
          (when (or uses-half? uses-double? uses-subgroups?) "\n"))
     (str "#include <stdint.h>\n#include <math.h>\n"
          (case (:id dialect)
-           :cuda "#include <cuda_fp16.h>\n"
+           :cuda "#include <cuda_fp16.h>\n#include <cuda_runtime.h>\n"
            :hip (str "#include <hip/hip_runtime.h>\n"
                      "#include <hip/hip_fp16.h>\n"))
          "\n")))

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -1660,7 +1660,9 @@
                              (emit-index-expression (:expression index) names) ";"))))))
         [operation-source _] (emit-scalar-operations (:operations kernel-body) context 1)
         helper-source (c-dialect/helper-source
-                       *scalar-dialect* (ce/intrinsic-helper-sources operation-source))
+                       *scalar-dialect*
+                       (ce/intrinsic-helper-sources operation-source
+                                                    (:id *scalar-dialect*)))
         storage-declarations (concat parameters (:allocations kernel-body))
         stable-reads (set (map :buffer (:stable-reads kernel-body)))
         uses-half? (some #(= :half (dtype/canon (:dtype %))) storage-declarations)

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -1659,6 +1659,8 @@
                       1 (str (target-type (get types (:id index))) " " name " = "
                              (emit-index-expression (:expression index) names) ";"))))))
         [operation-source _] (emit-scalar-operations (:operations kernel-body) context 1)
+        helper-source (c-dialect/helper-source
+                       *scalar-dialect* (ce/intrinsic-helper-sources operation-source))
         storage-declarations (concat parameters (:allocations kernel-body))
         stable-reads (set (map :buffer (:stable-reads kernel-body)))
         uses-half? (some #(= :half (dtype/canon (:dtype %))) storage-declarations)
@@ -1675,6 +1677,8 @@
     (str (c-dialect/preamble *scalar-dialect*
                              {:uses-half? uses-half? :uses-double? uses-double?
                               :uses-subgroups? uses-subgroups?})
+         helper-source
+         (when (seq helper-source) "\n")
          attribute
          (c-dialect/entry-prefix *scalar-dialect*) (target-name kernel-name) "(\n    "
          (str/join ",\n    "

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -616,17 +616,11 @@
                                  #(and (instance? raster.compiler.ir.segop.SegMap %)
                                        (= :typed-soac (:algorithm-dialect %))))
                       kernel (if scheduled
-                               (if (:out-sym scheduled)
-                                 (segop-cl/generate-segmap-kernel
-                                  scheduled (:out-sym scheduled)
-                                  :dtype (:dtype scheduled)
-                                  :scalar-types top-scalar-types
-                                  :array-types top-array-types)
-                                 (segop-cl/generate-explicit-segmap-kernel
-                                  scheduled
-                                  :dtype (:dtype scheduled)
-                                  :scalar-types top-scalar-types
-                                  :array-types top-array-types))
+                               (segop-cl/generate-scheduled-segmap-kernel
+                                scheduled
+                                :dtype (:dtype scheduled)
+                                :scalar-types top-scalar-types
+                                :array-types top-array-types)
                                (legacy/generate-par-map-void-kernel
                                 form :dtype dtype :device-id device-id
                                 :array-types top-array-types

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -410,6 +410,7 @@
       :provenance {:dialect :kernel-body :source-dialect :segmap
                    :segop-id (:id segmap)}
       :attributes {:kernel-body kernel-body
+                   :emission-route :kernel-body
                    :array-params (vec (concat inputs outputs))
                    :scalar-params scalars
                    :dtype (:dtype segmap)
@@ -720,6 +721,37 @@
                    :kernel-body kernel-body
                    :emission-route :kernel-body
                    :target-dialect target-dialect}})))
+
+(defn generate-scheduled-segmap-kernel
+  "Emit one scheduled SegMap through the single KernelBody-first C-family boundary.
+
+   Portable targets never consume source-shaped OpenCL fallback code. OpenCL retains the verified
+   compatibility emitter for scalar regions and memory effects that KernelBody cannot represent
+   yet, with the structured decline attached to the artifact so the remaining debt is observable."
+  [operation & {:keys [dtype kernel-name-prefix scalar-types array-types target-dialect]
+                :or {kernel-name-prefix "segmap" scalar-types {} array-types {}
+                     target-dialect :opencl-intel}}]
+  (let [dtype (or (:dtype operation) dtype :double)
+        target (kernel-body-c-dialect/resolve! target-dialect)]
+    (try
+      (generate-segmap-kernel-body
+       operation :dtype dtype :scalar-types scalar-types :array-types array-types
+       :target-dialect target-dialect :kernel-name-prefix kernel-name-prefix)
+      (catch clojure.lang.ExceptionInfo exception
+        (if (and (kernel-body-c-dialect/opencl? target)
+                 (segmap-body/declined? exception))
+          (-> (if (:out-sym operation)
+                (generate-segmap-kernel
+                 operation (:out-sym operation)
+                 :dtype dtype :scalar-types scalar-types :array-types array-types
+                 :kernel-name-prefix kernel-name-prefix)
+                (generate-explicit-segmap-kernel
+                 operation :dtype dtype :scalar-types scalar-types :array-types array-types
+                 :kernel-name-prefix (str kernel-name-prefix "_effect")))
+              (assoc-in [:attributes :emission-route] :verified-segmap-opencl)
+              (assoc-in [:attributes :kernel-body-decline]
+                        (assoc (ex-data exception) :fallback :verified-segmap-opencl)))
+          (throw exception))))))
 
 (defn generate-segred-kernel
   "Generate OpenCL C reduction kernels from a SegRed record.
@@ -1110,7 +1142,6 @@
   [graph {:keys [scalar-types array-types target-dialect]
           :or {scalar-types {} array-types {} target-dialect :opencl-intel}}]
   (let [target (kernel-body-c-dialect/resolve! target-dialect)
-        opencl? (kernel-body-c-dialect/opencl? target)
         array-types (graph-array-types graph array-types)
         emitted
         (kgraph/map-operations
@@ -1119,29 +1150,11 @@
            (kart/certify-scheduled-operation
             (cond
               (instance? raster.compiler.ir.segop.SegMap operation)
-              (try
-                (generate-segmap-kernel-body
-                 operation :dtype (:dtype operation)
-                 :scalar-types scalar-types :array-types array-types
-                 :target-dialect target-dialect
-                 :kernel-name-prefix "graph_segmap")
-                (catch clojure.lang.ExceptionInfo exception
-                  (if (and opencl? (segmap-body/declined? exception))
-                    (-> (if (:out-sym operation)
-                          (generate-segmap-kernel
-                           operation (:out-sym operation)
-                           :dtype (:dtype operation)
-                           :scalar-types scalar-types :array-types array-types
-                           :kernel-name-prefix "graph_segmap")
-                          (generate-explicit-segmap-kernel
-                           operation :dtype (:dtype operation)
-                           :scalar-types scalar-types :array-types array-types
-                           :kernel-name-prefix "graph_segmap_effect"))
-                        (assoc-in [:attributes :emission-route] :verified-segmap-opencl)
-                        (assoc-in [:attributes :kernel-body-decline]
-                                  (assoc (ex-data exception)
-                                         :fallback :verified-segmap-opencl)))
-                    (throw exception))))
+              (generate-scheduled-segmap-kernel
+               operation :dtype (:dtype operation)
+               :scalar-types scalar-types :array-types array-types
+               :target-dialect target-dialect
+               :kernel-name-prefix "graph_segmap")
 
               (instance? raster.compiler.ir.segop.SegStencil operation)
               (generate-segstencil-kernel-body

--- a/src/raster/compiler/backend/intrinsics.clj
+++ b/src/raster/compiler/backend/intrinsics.clj
@@ -116,6 +116,13 @@
    ;; The VECTOR schedules (AVX2 maddubs, wasm i32x4.dot) are :wi8-dot above.
    :dp4a {:arity 3 :kind :dp4a
           :c {:fn "rstr_dp4a"}
+          :target-helper-src
+          {:cuda (str "__device__ __forceinline__ int rstr_dp4a(int a, int b, int acc) {\n"
+                      "    return __dp4a(a, b, acc);\n"
+                      "}\n")
+           :hip (str "__device__ __forceinline__ int rstr_dp4a(int a, int b, int acc) {\n"
+                     "    return __ockl_sdot4(a, b, acc, false);\n"
+                     "}\n")}
           :c-helper-src (str "inline int rstr_dp4a(int a, int b, int acc) {\n"
                              "    unsigned int ua = (unsigned int)a;\n"
                              "    unsigned int ub = (unsigned int)b;\n"

--- a/src/raster/compiler/backend/intrinsics.clj
+++ b/src/raster/compiler/backend/intrinsics.clj
@@ -108,8 +108,8 @@
    ;; little-endian in each i32 — the scalar int8-MAC primitive (semantic op
    ;; raster.par/dp4a, JVM reference impl in raster.par). ONE canonical entry;
    ;; every backend spelling lives HERE as data:
-   ;;   :c    — portable helper name; :c-helper-src is its OpenCL/C source
-   ;;           (as_char4 idiom, pattern-matched to hardware dp4a by IGC/NV/AMD)
+   ;;   :c    — portable helper name; :c-helper-src is valid OpenCL C, CUDA C++, HIP C++,
+   ;;           and ordinary C. Physical instruction selection remains a target-lowering concern.
    ;;   :cuda/:hip (Phase B) — __dp4a / __builtin_amdgcn_sdot4 go HERE, not in
    ;;           an emitter table
    ;;   :wasm — :scalar-lanes (shift/mask lane extraction; emitter-local emit fn)
@@ -117,10 +117,17 @@
    :dp4a {:arity 3 :kind :dp4a
           :c {:fn "rstr_dp4a"}
           :c-helper-src (str "inline int rstr_dp4a(int a, int b, int acc) {\n"
-                             "    char4 va = as_char4(a);\n"
-                             "    char4 vb = as_char4(b);\n"
-                             "    return acc + (int)va.x*(int)vb.x + (int)va.y*(int)vb.y\n"
-                             "               + (int)va.z*(int)vb.z + (int)va.w*(int)vb.w;\n"
+                             "    unsigned int ua = (unsigned int)a;\n"
+                             "    unsigned int ub = (unsigned int)b;\n"
+                             "    int a0 = (int)(ua & 255u); a0 = a0 < 128 ? a0 : a0 - 256;\n"
+                             "    int a1 = (int)((ua >> 8) & 255u); a1 = a1 < 128 ? a1 : a1 - 256;\n"
+                             "    int a2 = (int)((ua >> 16) & 255u); a2 = a2 < 128 ? a2 : a2 - 256;\n"
+                             "    int a3 = (int)((ua >> 24) & 255u); a3 = a3 < 128 ? a3 : a3 - 256;\n"
+                             "    int b0 = (int)(ub & 255u); b0 = b0 < 128 ? b0 : b0 - 256;\n"
+                             "    int b1 = (int)((ub >> 8) & 255u); b1 = b1 < 128 ? b1 : b1 - 256;\n"
+                             "    int b2 = (int)((ub >> 16) & 255u); b2 = b2 < 128 ? b2 : b2 - 256;\n"
+                             "    int b3 = (int)((ub >> 24) & 255u); b3 = b3 < 128 ? b3 : b3 - 256;\n"
+                             "    return acc + a0*b0 + a1*b1 + a2*b2 + a3*b3;\n"
                              "}\n")
           :wasm :scalar-lanes}
    ;; broader elementary set — all wasm via composition/polynomial (see

--- a/src/raster/compiler/ir/segop.clj
+++ b/src/raster/compiler/ir/segop.clj
@@ -44,7 +44,9 @@
            [id          ;; int — from original SOAC id
             space       ;; SegSpace
             level       ;; SegLevel
-            lambda      ;; expr — kernel body S-expression
+            lambda      ;; expr — transitional source projection for compatibility emission
+            scalar-region ;; nil | {:locals [{:id :dtype :init} ...] :result expr}
+                          ;; Authoritative typed scalar SSA for direct TypedSOAC scheduling.
             inputs      ;; #{sym} — array symbols read
             outputs     ;; #{sym} — array symbols written
             scalars     ;; #{sym} — scalar parameters

--- a/src/raster/compiler/passes/parallel/contract_lower.clj
+++ b/src/raster/compiler/passes/parallel/contract_lower.clj
@@ -96,6 +96,7 @@
     (segop/->SegMap id space
                     (segop/->SegLevel :thread :virtual)
                     body                ; map lambda = the element expression
+                    nil
                     inputs
                     #{out}
                     (set/difference bound-syms arrays #{out})

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -121,6 +121,10 @@
               (let [expression (inline-lets expression)
                     expected (canon-type expected)]
                 (cond
+                  (instance? raster.compiler.ir.kernel_body.Literal expression)
+                  {:operations [] :result expression
+                   :type (canon-type (:type expression))}
+
                   (number? expression)
                   {:operations [] :result (body/literal expression expected) :type expected}
 

--- a/src/raster/compiler/passes/parallel/segmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segmap_body.clj
@@ -8,6 +8,7 @@
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.util :as util]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.ir.segop :as segop]
@@ -42,10 +43,43 @@
 
 (defn- scalar-forms
   [expression]
-  (let [expression (scalar-expression/inline-lets expression)]
-    (if (and (seq? expression) (= 'do (first expression)))
-      (vec (rest expression))
-      [expression])))
+  (if (and (seq? expression) (= 'do (first expression)))
+    (vec (rest expression))
+    [expression]))
+
+(defn- scalar-region
+  "Read typed local SSA directly from a scheduled SegMap.
+
+   Direct TypedSOAC lowering carries the authoritative local dtype beside each definition. The
+   source-shaped lambda remains only for compatibility-created SegMaps; its binder metadata is
+   projected once here and is never used to infer an arithmetic function or result type."
+  [segmap]
+  (if-let [{:keys [locals result] :as region} (:scalar-region segmap)]
+    (do
+      (when-not (and (vector? locals)
+                     (every? #(and (symbol? (:id %)) (:dtype %) (contains? % :init)) locals)
+                     (contains? region :result))
+        (decline! :typed-local-region
+                  "scheduled typed map carries a malformed scalar region"
+                  {:operation (:id segmap) :scalar-region region}))
+      {:locals locals :result result})
+    (let [expression (:lambda segmap)]
+      (if (and (seq? expression)
+               (contains? #{'let 'let* 'clojure.core/let} (first expression)))
+        (let [[_ bindings & body] expression]
+          (when-not (= 1 (count body))
+            (decline! :local-region-shape
+                      "map scalar local region requires one result expression"
+                      {:expression expression :body-count (count body)}))
+          {:locals
+           (mapv (fn [[id init]]
+                   {:id id
+                    :dtype (some-> (or (:raster.type/tag (meta id)) (:tag (meta id)))
+                                   dtype/dtype-for-scalar-tag dtype/canon)
+                    :init init})
+                 (partition 2 bindings))
+           :result (first body)})
+        {:locals [] :result expression}))))
 
 (defn lower
   "Apply a portable grid-stride scalar schedule to a typed one-dimensional SegMap."
@@ -66,7 +100,11 @@
         index (:name (first dimensions))
         bound (:bound (first dimensions))
         inputs (vec (sort-by name (:inputs segmap)))
-        outputs (vec (sort-by name (:outputs segmap)))
+        primary-output (:out-sym segmap)
+        outputs (if primary-output
+                  (vec (concat (sort-by name (disj (:outputs segmap) primary-output))
+                               [primary-output]))
+                  (vec (sort-by name (:outputs segmap))))
         scalars (vec (sort-by name (:scalars segmap)))
         _ (when (seq (set/intersection (set inputs) (set outputs)))
             (decline! :inout-storage
@@ -97,14 +135,32 @@
                   :arrays (set inputs) :index-scope index-scope
                   :lower-index lower-index :predicate :map-active
                   :id-prefix "map" :decline! decline!})
-        forms (scalar-forms (:lambda segmap))
-        primary-output (:out-sym segmap)
+        {:keys [locals result]} (scalar-region segmap)
+        base-environment (assoc scalar-types index :long)
+        local-state
+        (reduce
+         (fn [{:keys [substitutions operations environment]}
+              {:keys [id init] local-dtype :dtype}]
+           (let [local-type (some-> local-dtype dtype/canon)
+                 _ (when-not local-type
+                     (decline! :local-dtype
+                               "map scalar local is missing its scheduled dtype"
+                               {:operation (:id segmap) :local id
+                                :scalar-region (:scalar-region segmap)}))
+                 init (util/subst-syms substitutions init)
+                 lowered ((:lower lowerer) init local-type environment)]
+             {:substitutions (assoc substitutions id (:result lowered))
+              :operations (into operations (:operations lowered))
+              :environment (assoc environment (:result lowered) (:type lowered))}))
+         {:substitutions {} :operations [] :environment base-environment}
+         locals)
+        forms (scalar-forms (util/subst-syms (:substitutions local-state) result))
         explicit-forms (if primary-output (pop forms) forms)
         primary-form (when primary-output (peek forms))
         _ (when (and primary-output (empty? forms))
             (decline! :missing-result "map result has no scalar expression"
                       {:operation (:id segmap) :output primary-output}))
-        environment (assoc scalar-types index :long)
+        environment (:environment local-state)
         lower-store
         (fn [form]
           (when-not (descriptor/aset-call? form)
@@ -126,7 +182,8 @@
                           ((:lower lowerer) primary-form
                                             (get array-types primary-output) environment))
         scalar-operations
-        (vec (concat explicit-operations
+        (vec (concat (:operations local-state)
+                     explicit-operations
                      (:operations primary-lowered)
                      (when primary-output
                        [(body/->ScalarStore primary-output [index]

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -99,11 +99,10 @@
                     (list 'clojure.core/aset secondary-result index
                           (list cast secondary-body))))
                 (rest results) (rest physical-results) (rest bodies))
-          body (materialize-region-locals
-                locals
-                (if (seq secondary-stores)
-                  (list* 'do (concat secondary-stores [(first bodies)]))
-                  (first bodies)))
+          scalar-result (if (seq secondary-stores)
+                          (list* 'do (concat secondary-stores [(first bodies)]))
+                          (first bodies))
+          body (materialize-region-locals locals scalar-result)
           stable-array-captures (set (get-in attributes
                                              [:attributes :stable-array-captures]))
           scalar-captures (set (remove stable-array-captures captures))
@@ -115,7 +114,8 @@
                                       (into (set arrays) stable-array-captures)
                                       (set physical-results)
                                       scalar-captures)
-                      :sym physical-result :elem-type result-dtype :pure? (nil? storage))]
+                      :sym physical-result :elem-type result-dtype :pure? (nil? storage)
+                      :scalar-region {:locals locals :result scalar-result})]
       (mapv #(assoc % :algorithm-dialect :typed-soac
                     :algorithm-equation equation-id)
             (lower-map node device-id :dtype result-dtype)))))
@@ -270,7 +270,8 @@
                                 (list 'clojure.core/aset destination destination-index value))]
                     (if (contains? #{true 1} predicate) store (list 'if predicate store))))
                 physical-results writes)
-          body (materialize-region-locals locals (list* 'do statements))
+          scalar-result (list* 'do statements)
+          body (materialize-region-locals locals scalar-result)
           stable (set (get-in attributes [:attributes :stable-array-captures]))
           scalar-captures (set (remove stable captures))
           node (assoc (soac/->SoacMap equation-id nil (:index attributes)
@@ -278,6 +279,7 @@
                                       (into (set arrays) stable)
                                       (set physical-results) scalar-captures)
                       :elem-type result-dtype :pure? false
+                      :scalar-region {:locals locals :result scalar-result}
                       :write-conflict (if reducing? :reduce :unique)
                       :conflict-contract conflict)]
       (mapv #(assoc % :algorithm-dialect :typed-soac
@@ -708,6 +710,7 @@
         cast-fn (:cast-fn soac)]
     [(segop/->SegMap (:id soac) space level
                      (:lambda soac)
+                     (:scalar-region soac)
                      (:inputs soac) (soac-outputs* soac)
                      (:scalars soac) grid
                      dtype out-sym cast-fn)]))
@@ -916,6 +919,7 @@
             stage-3 (segop/->SegMap (+ (:id description) 3000)
                                     carry-space level-3
                                     carry-lambda
+                                    nil
                                     #{out-sym totals-sym}
                                     #{out-sym}
                                     #{} grid-3

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -146,6 +146,8 @@
         result (par-opencl scheduled
                            :device-id device-id
                            :dtype dtype
+                           :array-types array-types
+                           :scalar-types scalar-types
                            :min-elements min-elements)]
     (doseq [k (:kernels result)]
       (register! (:kernel-name k) k))

--- a/src/raster/par.clj
+++ b/src/raster/par.clj
@@ -559,8 +559,7 @@
 
 (deftm ^:no-inline dp4a
   "4-way int8 dot-accumulate. `a` and `b` each pack four signed int8 lanes into an int32,
-  little-endian (lane 0 = low byte), exactly as `as_char4` reinterprets memory on a
-  little-endian device. Returns `acc + Σ_i lane_i(a)·lane_i(b)`.
+  little-endian (lane 0 = low byte). Returns `acc + Σ_i lane_i(a)·lane_i(b)`.
 
   This is the JVM/reference impl of the `rstr_dp4a` primitive: in a deftm/par body the
   GPU and CPU-C backends lower a `(par/dp4a a b acc)` call to `rstr_dp4a(a, b, acc)` (a
@@ -568,7 +567,9 @@
   Intel/CUDA `__dp4a`, AMD `sdot4`). The masked extraction below is sign-correct
   regardless of how the int sign-extends into the JVM long.
 
-  A `deftm`, not a `defn`, so the walker STAMPS its Long result type. As a plain defn it had no
+  A `deftm`, not a `defn`, so the walker stamps its Integer result type. The target primitive and
+  packed operands are int32; the JVM reference explicitly wraps to the same representation instead
+  of exposing an accidental 64-bit result. As a plain defn it had no
   declared return type, every let-bound `(par/dp4a …)` intermediate reached the GPU fixpoint
   edge untagged, and the typedness census (correctly) refused the program — `bind-decode!` on
   gemma-3-270m failed with `14 non-exempt untagged binding(s) {raster.par/dp4a 14}` from the
@@ -577,16 +578,17 @@
   intrinsics registry (`:dp4a` → `rstr_dp4a`), which the `:raster.op/original` stamp preserves,
   so emission is unchanged. Do not exempt dp4a from the census instead: the census exists to
   catch exactly the narrowing class an untyped integer accumulate can hide."
-  [a :- Long, b :- Long, acc :- Long] :- Long
+  [a :- Long, b :- Long, acc :- Long] :- Integer
   (let [a (long (unchecked-int a)) b (long (unchecked-int b))
         sx (fn ^long [^long x ^long sh]
              (let [v (bit-and (unsigned-bit-shift-right x sh) 0xFF)]
                (if (>= v 128) (- v 256) v)))]
-    (+ (long acc)
-       (* (sx a 0) (sx b 0))
-       (* (sx a 8) (sx b 8))
-       (* (sx a 16) (sx b 16))
-       (* (sx a 24) (sx b 24)))))
+    (unchecked-int
+     (+ (long acc)
+        (* (sx a 0) (sx b 0))
+        (* (sx a 8) (sx b 8))
+        (* (sx a 16) (sx b 16))
+        (* (sx a 24) (sx b 24))))))
 
 (defmacro rng-fill!
   "Fill a long array with splitmix64 pseudo-random seeds.

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -235,14 +235,16 @@
               (is (zero? exit) err))))))))
 
 (deftest registry-intrinsic-helpers-follow-the-c-family-target
-  (doseq [[target qualifier compiler]
-          [[:opencl-portable "inline int rstr_dp4a" nil]
-           [:cuda "__device__ __forceinline__ int rstr_dp4a" "nvcc"]
-           [:hip "__device__ __forceinline__ int rstr_dp4a" "hipcc"]]]
+  (doseq [[target qualifier physical-op compiler]
+          [[:opencl-portable "inline int rstr_dp4a" "a0*b0" nil]
+           [:cuda "__device__ __forceinline__ int rstr_dp4a" "__dp4a(a, b, acc)" "nvcc"]
+           [:hip "__device__ __forceinline__ int rstr_dp4a"
+            "__ockl_sdot4(a, b, acc, false)" "hipcc"]]]
     (testing (name target)
       (let [source (opencl/emit-scalar-kernel
                     "dp4a_helper" (dp4a-kernel-body) {:target-dialect target})]
         (is (str/includes? source qualifier))
+        (is (str/includes? source physical-op))
         (is (= 2 (count (re-seq #"rstr_dp4a\(" source)))
             "one registry-owned definition accompanies one typed call")
         (when (and compiler (command-available? compiler))

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -105,6 +105,22 @@
   ([] (pipelined-staging-kernel-body :preferred))
   ([overlap] (fixtures/pipelined-staging-body 32 overlap)))
 
+(defn- dp4a-kernel-body []
+  (body/make
+   {:id :dp4a-helper-test
+    :parameters [(body/->KernelParameter 'a :scalar :int [] nil nil :a)
+                 (body/->KernelParameter 'b :scalar :int [] nil nil :b)
+                 (body/->KernelParameter 'out :output :int [1] :global
+                                         (layout/row-major [1] :int) :result)]
+    :operations [(body/->ScalarCompute
+                  (body/value 'dot :int)
+                  (body/scalar-expression :dp4a :int
+                                          ['a 'b (body/literal 0 :int)]))
+                 (body/->ScalarStore 'out [0] 'dot nil)]
+    :launch (launch/spec {:workgroup-size [1] :group-count [1]})
+    :provenance {:dialect :test}
+    :attributes {:kind :scalar}}))
+
 (deftest scalar-kernel-body-lowers-without-recovering-a-schedule
   (let [source (opencl/emit-scalar-kernel
                 "scheduled_scalar"
@@ -217,6 +233,21 @@
             (is true (str compiler " unavailable; source structure remains covered"))
             (let [{:keys [exit err]} (compile-c-family-source target source)]
               (is (zero? exit) err))))))))
+
+(deftest registry-intrinsic-helpers-follow-the-c-family-target
+  (doseq [[target qualifier compiler]
+          [[:opencl-portable "inline int rstr_dp4a" nil]
+           [:cuda "__device__ __forceinline__ int rstr_dp4a" "nvcc"]
+           [:hip "__device__ __forceinline__ int rstr_dp4a" "hipcc"]]]
+    (testing (name target)
+      (let [source (opencl/emit-scalar-kernel
+                    "dp4a_helper" (dp4a-kernel-body) {:target-dialect target})]
+        (is (str/includes? source qualifier))
+        (is (= 2 (count (re-seq #"rstr_dp4a\(" source)))
+            "one registry-owned definition accompanies one typed call")
+        (when (and compiler (command-available? compiler))
+          (let [{:keys [exit err]} (compile-c-family-source target source)]
+            (is (zero? exit) err)))))))
 
 (deftest portable-opencl-keeps-the-scheduled-subgroup-width
   (let [source (opencl/emit-scalar-kernel

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -19,6 +19,7 @@
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
+            [raster.compiler.passes.parallel.segmap-body :as segmap-body]
             [raster.compiler.passes.parallel.segred-body :as segred-body]
             [raster.compiler.passes.parallel.soac-lower :as lower]
             [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
@@ -387,3 +388,24 @@
     (is (= [:float :float :int :int] (mapv :dtype (:abi k))))
     (is (re-find #"int offset" (:source k)))
     (is (= '[a out offset n] (:arguments k)))))
+
+(deftest scheduled-segmap-uses-one-observable-compatibility-boundary
+  (let [form '(raster.par/map! out i n float
+                               (clojure.core/aget a i))
+        operation (-> (soac/par-form->soac 'out form 2)
+                      (lower/lower-map nil :dtype :float)
+                      first)
+        artifact
+        (with-redefs [segmap-body/lower
+                      (fn [& _]
+                        (throw (ex-info "simulated portable coverage gap"
+                                        {:reason :segmap-kernel-body-declined
+                                         :missing-rule :simulated
+                                         :fallback :none})))]
+          (sg/generate-scheduled-segmap-kernel operation :dtype :float))]
+    (is (= :verified-segmap-opencl
+           (get-in artifact [:attributes :emission-route])))
+    (is (= :simulated
+           (get-in artifact [:attributes :kernel-body-decline :missing-rule])))
+    (is (= :verified-segmap-opencl
+           (get-in artifact [:attributes :kernel-body-decline :fallback])))))

--- a/test/raster/compiler/intrinsic_opacity_test.clj
+++ b/test/raster/compiler/intrinsic_opacity_test.clj
@@ -38,11 +38,11 @@
     (is (dispatch/no-inline? #'par/dp4a))))
 
 (deftest an-intrinsic-intermediate-is-tagged
-  (testing "every walked dp4a call carries its Long result type — this is what the census needs"
+  (testing "every walked dp4a call carries its int32 result type — this is what the census needs"
     (let [wb ((requiring-resolve 'raster.core/ensure-walked-body!) #'dp4a-chain!)
           calls (filter #(= 'raster.par/dp4a (:raster.op/original (meta %))) (tree-seq coll? seq wb))]
       (is (= 2 (count calls)))
-      (is (every? #(= 'long (:raster.type/tag (meta %))) calls)
+      (is (every? #(= 'int (:raster.type/tag (meta %))) calls)
           (str "tags: " (mapv #(:raster.type/tag (meta %)) calls))))))
 
 (deftest an-intrinsic-lowers-through-the-registry-not-its-body

--- a/test/raster/compiler/ir/kernel_graph_test.clj
+++ b/test/raster/compiler/ir/kernel_graph_test.clj
@@ -74,7 +74,7 @@
 (deftest in-place-dataflow-retains-one-buffer-identity
   (let [operation (segop/->SegMap
                    9 (segop/make-seg-space 'i 'n) (segop/->SegLevel :thread :virtual)
-                   '(inc (aget state i)) #{'state} #{'state} #{}
+                   '(inc (aget state i)) nil #{'state} #{'state} #{}
                    (segop/->KernelGrid 1 32 0) :float 'state nil)
         scheduled (graph/from-segops [operation]
                                      {:inputs #{'state} :outputs #{'state} :dtype :float})]
@@ -96,7 +96,7 @@
 (deftest target-emission-cannot-change-the-scheduled-dataflow-contract
   (let [operation (segop/->SegMap
                    9 (segop/make-seg-space 'i 'n) (segop/->SegLevel :thread :virtual)
-                   '(inc (aget values i)) #{'values} #{'out} #{}
+                   '(inc (aget values i)) nil #{'values} #{'out} #{}
                    (segop/->KernelGrid 1 32 0) :float 'out nil)
         scheduled (graph/from-segops [operation]
                                      {:inputs #{'values} :outputs #{'out} :dtype :float})

--- a/test/raster/compiler/ir/segop_test.clj
+++ b/test/raster/compiler/ir/segop_test.clj
@@ -37,7 +37,7 @@
           level (segop/->SegLevel :thread :none)
           grid (segop/->KernelGrid 1 256 0)
           seg-map (segop/->SegMap 0 space level '(* (aget a i) 2.0)
-                                  #{'a} #{'out} #{} grid
+                                  nil #{'a} #{'out} #{} grid
                                   :double 'out nil)]
       (is (segop/segop? seg-map))
       (is (segop/segop-node? (segop/->SegContract 1 {} :double :ze:0)))

--- a/test/raster/compiler/kernel_call_pipeline_test.clj
+++ b/test/raster/compiler/kernel_call_pipeline_test.clj
@@ -152,7 +152,8 @@
     (is (= :map-void (:convention step)))
     (is (:logical-bindings? step))
     (is (kart/kernel-artifact? (:artifact step)))
-    (is (= :segmap (get-in step [:artifact :provenance :dialect])))
+    (is (= :kernel-body (get-in step [:artifact :provenance :dialect])))
+    (is (= :kernel-body (get-in step [:artifact :attributes :emission-route])))
     (is (= '[x out scale]
            (subvec (kcall/logical-arguments (:artifact step)) 0 3)))
     (is (= [3] (get-in call [:geometry :group-count])))))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1,6 +1,7 @@
 (ns raster.compiler.passes.parallel.typed-soac-route-test
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
+            [raster.compiler.backend.gpu.segop-opencl :as segop-opencl]
             [raster.compiler.backend.jvm.par-simd :as par-simd]
             [raster.compiler.core.hardware :as hardware]
             [raster.compiler.ir.kernel-body :as kernel-body]
@@ -226,14 +227,28 @@
         emitted (opencl-pass/opencl-pass scheduled :device-id :ocl:0
                                          :dtype :float :min-elements 0)
         kernel-source (:source (first (:kernels emitted)))
+        operation (first (:operations (first (:equations scheduled))))
+        portable (segop-opencl/generate-segmap-kernel-body
+                  operation
+                  :array-types {'x :float 'a :float 'b :float})
+        portable-source (:source portable)
         jvm (par-simd/simd-pass scheduled :min-elements 1)
         execute (eval (list 'fn '[x a b n] (:form jvm)))
         x (float-array [1.0 2.0 3.0 4.0])
         a (float-array 4)
         b (float-array 4)]
-    (is (= 1 (count (re-seq #"x\[idx\]" kernel-source)))
+    (is (= 1 (count (re-seq #"x\[" kernel-source)))
         "the shared producer is emitted once, not projected into both results")
-    (is (re-find #"float rstr_local_0" kernel-source))
+    (is (= :kernel-body (get-in (first (:kernels emitted))
+                                [:attributes :emission-route])))
+    (is (= [:float :float] (mapv :dtype (get-in operation [:scalar-region :locals])))
+        "SegMap scheduling retains TypedSOAC local dtypes as data, not symbol metadata")
+    (is (= 1 (count (re-seq #"x\[" portable-source)))
+        "KernelBody retains the same typed local instead of duplicating its load")
+    (is (= 1 (count (filter #(and (= "ScalarCompute" (some-> % class .getSimpleName))
+                                  (= :* (get-in % [:expression :op])))
+                            (get-in portable [:attributes :kernel-body :operations]))))
+        "the shared square is one scalar SSA definition")
     (is (nil? (execute x a b 4)))
     (is (= [2.0 3.0 4.0 5.0] (mapv double a)))
     (is (= [4.0 9.0 16.0 25.0] (mapv double b)))))

--- a/test/raster/dl/row_gather_test.clj
+++ b/test/raster/dl/row_gather_test.clj
@@ -150,7 +150,8 @@
       (is (empty? (:allocs descriptor))))
     (testing "every output element lowers through one target-neutral map"
       (is (= [:map-void] (mapv :convention (:steps descriptor))))
-      (is (= :segmap (get-in step [:artifact :provenance :dialect])))
+      (is (= :kernel-body (get-in step [:artifact :provenance :dialect])))
+      (is (= :kernel-body (get-in step [:artifact :attributes :emission-route])))
       (is (= '[indices src out width _n_bound] (mapv :name (:abi step))))
       (is (= [:int :float :float :int :int] (mapv :dtype (:abi step))))
       (is (= 'rstr_extent_0 (last (get-in step [:artifact :arguments])))


### PR DESCRIPTION
## Outcome

Typed one-dimensional maps now carry their TypedSOAC scalar region into SegMap as explicit typed data and lower local definitions to ordered KernelBody SSA. Horizontally fused outputs share producer loads and arithmetic instead of re-inlining the same expression into each store.

## Compiler cleanup

- retain each scalar local ID, dtype, initializer, and result expression across TypedSOAC to SegMap
- stop relying on symbol metadata for production local typing
- centralize scheduled SegMap target lowering in one KernelBody-first boundary
- preserve authoritative scalar and array types through direct GPU session compilation
- type the canonical dp4a result as int32 and emit its registry-owned helper automatically
- select CUDA and HIP physical dp4a helpers from the shared intrinsic registry
- retain unsupported OpenCL maps only as explicitly marked verified compatibility artifacts

## Validation

- focused compiler, ABI, cross-target, quantization, and real Intel GPU suites are green
- nvcc and hipcc compile the typed dp4a KernelBody without a physical device
- generated CUDA Q4 PTX contains dp4a.s32.s32
- full suite and vendor compile gates run in CircleCI

Supersedes automatically closed stacked PR #285 after #284 was squash-merged.