### PR TITLE
Report KernelBody compatibility debt

### DIFF
--- a/src/raster/compiler/backend/gpu/parallel_program_c_family.clj
+++ b/src/raster/compiler/backend/gpu/parallel_program_c_family.clj
@@ -10,6 +10,7 @@
             [raster.compiler.ir.emitted-parallel-equation :as emitted-equation]
             [raster.compiler.ir.emitted-parallel-program :as emitted-program]
             [raster.compiler.ir.emitted-structured-loop :as emitted-loop]
+            [raster.compiler.ir.kernel-artifact :as kernel-artifact]
             [raster.compiler.ir.kernel-graph :as graph]
             [raster.compiler.ir.parallel-program :as program]
             [raster.compiler.ir.segop :as segop]
@@ -71,6 +72,15 @@
     :opencl-c :opencl-parallel
     :cuda-c :cuda-parallel
     :hip-cpp :hip-parallel))
+
+(defn- kernel-attribute
+  [kernel key]
+  (or (get kernel key) (get-in kernel [:attributes key])))
+
+(defn- kernel-body-decline-key
+  [kernel]
+  (when-let [decline (kernel-attribute kernel :kernel-body-decline)]
+    [(:reason decline) (:missing-rule decline) (:fallback decline)]))
 
 (defn- emit-equation
   [parallel-program equation opts]
@@ -164,4 +174,7 @@
               (count (filter (comp emitted-equation/emitted-equation? first :operations)
                              equations))
               :host-scalar-equations
-              (count (filter #(get-in % [:attributes :host-only]) equations))}})))
+              (count (filter #(get-in % [:attributes :host-only]) equations))
+              :emission-routes (frequencies (map kernel-artifact/emission-route kernels))
+              :kernel-body-declines
+              (frequencies (keep kernel-body-decline-key kernels))}})))

--- a/src/raster/compiler/ir/kernel_artifact.clj
+++ b/src/raster/compiler/ir/kernel_artifact.clj
@@ -96,3 +96,16 @@
   "Read one emitter attribute without flattening it into the runtime registry namespace."
   [artifact k]
   (get (:attributes (validate! artifact)) k))
+
+(defn emission-route
+  "Return the stable route used to produce an artifact.
+
+   New emitters set `:emission-route` explicitly. Existing verified artifacts retain their
+   provenance dialect as an observable compatibility class until they are migrated; only an
+   artifact with neither fact is reported as unclassified. This accessor intentionally accepts
+   artifact-shaped maps so pure compiler-report tests need not construct target source."
+  [artifact]
+  (or (get artifact :emission-route)
+      (get-in artifact [:attributes :emission-route])
+      (get-in artifact [:provenance :dialect])
+      :unclassified))

--- a/src/raster/compiler/report.clj
+++ b/src/raster/compiler/report.clj
@@ -4,7 +4,8 @@
    This namespace does not compile, inspect source forms, or infer operations. It turns the
    authoritative records produced by the pipeline and its emitters into a small, stable report
    suitable for compatibility ledgers and tooling."
-  (:require [clojure.string :as str]))
+  (:require [clojure.string :as str]
+            [raster.compiler.ir.kernel-artifact :as kernel-artifact]))
 
 (def schema-version 1)
 
@@ -77,8 +78,13 @@
   [kernels]
   (->> kernels
        (mapcat (fn [kernel]
-                 (map #(normalize-decline :emission :candidate %)
-                      (decline-values (kernel-attribute kernel :declines)))))
+                 (concat
+                  (map #(normalize-decline :emission :candidate %)
+                       (decline-values (kernel-attribute kernel :declines)))
+                  (map #(normalize-decline
+                         :emission :kernel-body-coverage
+                         (cond-> % (:missing-rule %) (assoc :leaf (:missing-rule %))))
+                       (decline-values (kernel-attribute kernel :kernel-body-decline))))))
        vec))
 
 (defn- source-dialect
@@ -122,13 +128,16 @@
                 :backend-reused (counter backend-stats :segop-reused)
                 :backend-relowered (counter backend-stats :segop-relowered)
                 :fallback (counter backend-stats :fallback)}
-     :emission {:kernel-count (count kernels)
-                :targets (->> kernels (map :target) (remove nil?) distinct vec)
-                :strategies (->> kernels (map kernel-strategy) (remove nil?) distinct vec)
-                :fallback-reasons (->> kernels
-                                       (map #(kernel-attribute % :fallback-reason))
-                                       (remove nil?) distinct vec)
-                :declines (emitted-declines kernels)}
+     :emission (cond->
+                {:kernel-count (count kernels)
+                 :targets (->> kernels (map :target) (remove nil?) distinct vec)
+                 :strategies (->> kernels (map kernel-strategy) (remove nil?) distinct vec)
+                 :fallback-reasons (->> kernels
+                                        (map #(kernel-attribute % :fallback-reason))
+                                        (remove nil?) distinct vec)
+                 :declines (emitted-declines kernels)}
+                 (seq kernels)
+                 (assoc :routes (frequencies (map kernel-artifact/emission-route kernels))))
      :residency {:assessed? false
                  :resident? nil
                  :device-scratch-count nil

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -19,7 +19,11 @@
               :outputs 1 :driver-allocations 0}
    :emission {:structured-loops-emitted 0
               :typed-equations-emitted 1
-              :host-scalar-equations 0}}
+              :host-scalar-equations 0
+              :emission-routes {:verified-segred-opencl 1}
+              :kernel-body-declines
+              {[:segred-kernel-body-declined :unbound-index-symbol
+                :verified-segred-opencl] 1}}}
 
   :q4k-dp4a-rows-gpu
   {:route {:semantic-dialect :typed-parallel
@@ -30,7 +34,11 @@
               :outputs 0 :driver-allocations 0}
    :emission {:structured-loops-emitted 0
               :typed-equations-emitted 1
-              :host-scalar-equations 0}}
+              :host-scalar-equations 0
+              :emission-routes {:verified-segmap-opencl 1}
+              :kernel-body-declines
+              {[:segmap-kernel-body-declined :unbound-scalar
+                :verified-segmap-opencl] 1}}}
 
   :gqa-causal-mha-gpu
   {:route {:semantic-dialect :typed-parallel
@@ -41,7 +49,9 @@
               :outputs 1 :driver-allocations 0}
    :emission {:structured-loops-emitted 0
               :typed-equations-emitted 7
-              :host-scalar-equations 0}}
+              :host-scalar-equations 0
+              :emission-routes {:kernel-body 7}
+              :kernel-body-declines {}}}
 
   :prefix-sum-gpu
   {:route {:semantic-dialect :typed-parallel
@@ -52,7 +62,9 @@
               :outputs 1 :driver-allocations 0}
    :emission {:structured-loops-emitted 0
               :typed-equations-emitted 1
-              :host-scalar-equations 0}}
+              :host-scalar-equations 0
+              :emission-routes {:kernel-body 3}
+              :kernel-body-declines {}}}
 
   :heat-rhs-1d-jvm
   {:route {:backend :simd :source-dialect :typed-soac :typed-validated true
@@ -73,7 +85,9 @@
               :outputs 1 :driver-allocations 0}
    :emission {:structured-loops-emitted 0
               :typed-equations-emitted 1
-              :host-scalar-equations 0}}
+              :host-scalar-equations 0
+              :emission-routes {:kernel-body 1}
+              :kernel-body-declines {}}}
 
   :heat-loss-rk4-gpu
   {:route {:semantic-dialect :typed-parallel
@@ -84,4 +98,6 @@
               :outputs 1 :driver-allocations 0}
    :emission {:structured-loops-emitted 1
               :typed-equations-emitted 1
-              :host-scalar-equations 1}}}}
+              :host-scalar-equations 1
+              :emission-routes {:kernel-body 10}
+              :kernel-body-declines {}}}}}

--- a/test/raster/compiler/passes/parallel/structured_control_route_test.clj
+++ b/test/raster/compiler/passes/parallel/structured_control_route_test.clj
@@ -292,7 +292,9 @@
     (is (every? artifact/kernel-artifact? kernels))
     (is (= {:structured-loops-emitted 1
             :typed-equations-emitted 1
-            :host-scalar-equations 0}
+            :host-scalar-equations 0
+            :emission-routes {:kernel-body 3}
+            :kernel-body-declines {}}
            stats))
     (is (= program (program-opencl/validate-program! program)))
     (testing "emitted algorithm kinds cannot be exchanged between equations"
@@ -398,7 +400,9 @@
     (is (= 10 (count (:kernels emitted))))
     (is (= {:structured-loops-emitted 1
             :typed-equations-emitted 1
-            :host-scalar-equations 1}
+            :host-scalar-equations 1
+            :emission-routes {:kernel-body 10}
+            :kernel-body-declines {}}
            (:stats emitted)))
     (let [[partial final] (take-last 2 (:kernels emitted))
           inv-n? #(and (symbol? %) (.startsWith (name %) "inv-n_"))]

--- a/test/raster/compiler/report_test.clj
+++ b/test/raster/compiler/report_test.clj
@@ -16,8 +16,13 @@
                                   :segop-declined [{:reason :missing-rule}]}
           :kernels [{:target :opencl-c
                      :attributes {:strategy :portable
+                                  :emission-route :verified-segmap-opencl
                                   :fallback-reason :symbolic-dims
-                                  :declines [{:leaf :tensorized :reason :symbolic-dims}]}}]})]
+                                  :declines [{:leaf :tensorized :reason :symbolic-dims}]
+                                  :kernel-body-decline
+                                  {:reason :segmap-kernel-body-declined
+                                   :missing-rule :scalar-fold
+                                   :fallback :verified-segmap-opencl}}}]})]
     (is (= {:backend :opencl :source-dialect :typed-soac :typed-validated true
             :declines [{:stage :backend-applied-stats
                         :kind :segop-declined
@@ -30,9 +35,12 @@
             :backend-reused 2 :backend-relowered 1 :fallback 0}
            (:lowering normalized)))
     (is (= {:kernel-count 1 :targets [:opencl-c] :strategies [:portable]
+            :routes {:verified-segmap-opencl 1}
             :fallback-reasons [:symbolic-dims]
             :declines [{:stage :emission :kind :candidate
-                        :leaf :tensorized :reason :symbolic-dims}]}
+                        :leaf :tensorized :reason :symbolic-dims}
+                       {:stage :emission :kind :kernel-body-coverage
+                        :leaf :scalar-fold :reason :segmap-kernel-body-declined}]}
            (:emission normalized)))
     (is (= {:assessed? false :resident? nil :device-scratch-count nil
             :host-array-allocs-in-compute nil :internal-host-roundtrips nil}


### PR DESCRIPTION
## Outcome

Compiler reports and the representative compatibility ledger now expose the exact target emission route and any structured KernelBody coverage decline for every emitted artifact.

## Why

This turns remaining compatibility emitters into measurable compiler debt instead of a hidden implementation detail. The same stable route and decline data can later feed deterministic schedule search or learned candidate proposal without granting either permission to bypass legality.

## Changes

- add one canonical artifact emission-route accessor
- report per-route frequencies for emitted programs
- include structured KernelBody declines in normalized compiler reports
- pin the current representative workload routes and decline reasons in the fast compatibility ledger

## Validation

- 66 focused report, compatibility-ledger, structured-control, and TypedSOAC tests
- 488 assertions, all green
- full suite runs in CircleCI