### PR TITLE
Preserve lexical context in ordered loop lowering

### DIFF
--- a/src/raster/compiler/passes/parallel/patterns.clj
+++ b/src/raster/compiler/passes/parallel/patterns.clj
@@ -676,6 +676,25 @@
 
       :else nil)))
 
+(defn- scoped-recur-value
+  "Retain the lexical bindings surrounding one recur argument.
+
+   Pattern recognition still receives the raw argument in `:update-expr`. Structured ordered-loop
+   lowering consumes this scoped form, so a target IR never sees references to let-bound values
+   after the recur node itself has been removed. Multi-expression/effectful regions remain outside
+   this conservative projection."
+  [then-branch update-expr]
+  (cond
+    (and (seq? then-branch) (= 'recur (first then-branch)))
+    update-expr
+
+    (and (form/binding-form? then-branch)
+         (= 1 (count (drop 2 then-branch))))
+    (with-meta (list (first then-branch) (second then-branch) update-expr)
+      (meta then-branch))
+
+    :else nil))
+
 (defn match-reduce-loop
   "Generic matcher for reduction loops.
 	Returns a structural descriptor of the loop/update shape or nil."
@@ -713,7 +732,8 @@
                :else-expr else-branch
                :recur-form recur-form
                :idx-update-expr idx-update-expr
-               :update-expr update-expr})))))))
+               :update-expr update-expr
+               :scoped-update-expr (scoped-recur-value then-branch update-expr)})))))))
 
 (defn match-binary-reduce-loop
   "Generic matcher for simple binary reduction loops.

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -31,7 +31,9 @@
   "Recognize the canonical one-index/one-carry loop without authorizing reassociation."
   [expression]
   (or
-   (some-> (patterns/match-reduce-loop expression) (assoc :inclusive? false))
+   (when-let [matched (patterns/match-reduce-loop expression)]
+     (assoc matched :inclusive? false
+            :update-expr (or (:scoped-update-expr matched) (:update-expr matched))))
    (when-let [{:keys [kind index-sym acc-sym acc-init body-form bound]}
               (patterns/normalize-loop expression)]
      (when (and (= :reduce-loop kind)

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -25,6 +25,7 @@
             [raster.dl.attention :as dl-attention]
             [raster.numeric]
             [raster.par]
+            [raster.quant.kernels-k :as qk]
             [raster.runtime.hardware :as hardware]))
 
 (deftm public-c-family-dot
@@ -212,6 +213,8 @@
                  #'public-c-family-scan {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'public-c-family-stencil {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
+                 #'qk/qmatmul-q4k-dp4a-rows! {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'dl-attention/gqa-causal-mha {:target device-id :dtype :float}))))))
 

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -35,10 +35,8 @@
    :emission {:structured-loops-emitted 0
               :typed-equations-emitted 1
               :host-scalar-equations 0
-              :emission-routes {:verified-segmap-opencl 1}
-              :kernel-body-declines
-              {[:segmap-kernel-body-declined :unbound-scalar
-                :verified-segmap-opencl] 1}}}
+              :emission-routes {:kernel-body 1}
+              :kernel-body-declines {}}}
 
   :gqa-causal-mha-gpu
   {:route {:semantic-dialect :typed-parallel

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -253,6 +253,41 @@
     (is (= [2.0 3.0 4.0 5.0] (mapv double a)))
     (is (= [4.0 9.0 16.0 25.0] (mapv double b)))))
 
+(deftest ordered-map-loop-retains-its-lexical-update-region
+  (let [source '(let* [result
+                       (raster.par/map! out i n float
+                                        (loop* [j 0 acc (float 0.0)]
+                                          (if (< (long j) (long width))
+                                            (let* [value
+                                                   (clojure.core/aget
+                                                    x (+ (* (long i) (long width))
+                                                         (long j)))]
+                                              (recur (inc (long j))
+                                                     (+ (float acc) (float value))))
+                                            acc)))]
+                      result)
+        typed (:program
+               (route/attempt source :float {'x :float 'out :float}
+                              {:scalar-types {'n :long 'width :long}}))
+        scheduled (:form
+                   (segop-lower/segop-lower-pass
+                    typed {:dtype :float :target-device :ocl:0
+                           :array-types {'x :float 'out :float}
+                           :scalar-types {'n :long 'width :long}}))
+        operation (first (:operations (first (:equations scheduled))))
+        artifact (segop-opencl/generate-scheduled-segmap-kernel
+                  operation :array-types {'x :float 'out :float}
+                  :scalar-types {'n :long 'width :long})
+        loop-operation
+        (some #(when (= "ForLoop" (some-> % class .getSimpleName)) %)
+              (get-in artifact [:attributes :kernel-body :operations]))]
+    (is (= :kernel-body (get-in artifact [:attributes :emission-route])))
+    (is (nil? (get-in artifact [:attributes :kernel-body-decline])))
+    (is loop-operation)
+    (is (some #(= "ScalarLoad" (some-> % class .getSimpleName))
+              (:operations loop-operation))
+        "the scoped let-bound value remains a load inside the ordered loop body")))
+
 (deftest typed-inout-preserves-sequential-jvm-semantics
   (let [source '(let* [step (raster.par/map! target i n float
                                              (* (clojure.core/aget target i) 2.0))]


### PR DESCRIPTION
## Outcome

Canonical ordered scalar loops retain the lexical let-region surrounding each recur update when lowering TypedSOAC scalar regions to KernelBody. Q4_K row projection therefore binds its decoded activation scale once and emits through the shared typed KernelBody route.

## Changes

- retain a scoped recur-update expression alongside the raw algebraic update
- consume the scoped update in ordered KernelBody loop lowering
- keep the raw projection for algebraic matchers
- move Q4_K from the verified SegMap compatibility route to KernelBody
- add the generated Q4 projection to CUDA and HIP compiler fixtures

## Validation

- focused TypedSOAC, compatibility-ledger, loop, and quantization suites are green
- real Intel GPU Q4 and Q8-to-Q4 chain tests are green
- generated CUDA Q4 source compiles to PTX containing dp4a.s32.s32
- generated HIP Q4 source compiles to a gfx1100 code object
- full suite and vendor compile gates run in CircleCI