### PR TITLE
Emit typed contractions through KernelBody

### DIFF
--- a/src/raster/compiler/backend/gpu/parallel_program_c_family.clj
+++ b/src/raster/compiler/backend/gpu/parallel_program_c_family.clj
@@ -7,6 +7,7 @@
    KernelBody source dialect boundary."
   (:require [raster.compiler.backend.gpu.kernel-body-c-dialect :as c-dialect]
             [raster.compiler.backend.gpu.segop-opencl :as segop-emission]
+            [raster.compiler.ir.contraction-facts :as contraction-facts]
             [raster.compiler.ir.emitted-parallel-equation :as emitted-equation]
             [raster.compiler.ir.emitted-parallel-program :as emitted-program]
             [raster.compiler.ir.emitted-structured-loop :as emitted-loop]
@@ -18,7 +19,8 @@
             [raster.compiler.ir.structured-control :as control]
             [raster.compiler.ir.structured-control-schedule :as schedule]
             [raster.compiler.passes.parallel.scheduled-equation-graph :as equation-graph]
-            [raster.compiler.passes.parallel.structured-control-route :as structured-route]))
+            [raster.compiler.passes.parallel.structured-control-route :as structured-route]
+            [raster.compiler.passes.parallel.typed-soac-projection :as typed-projection]))
 
 (defn- fail!
   [reason message data]
@@ -64,7 +66,29 @@
      scheduled-graph
      :scalar-types (merge (:scalar-types opts) types)
      :array-types (:array-types opts)
-     :target-dialect (get opts :target-dialect :opencl-intel))))
+     :target-dialect (get opts :target-dialect :opencl-intel)
+     :target-device (:target-device opts)
+     :contraction-facts (:contraction-facts opts))))
+
+(defn- contraction-facts-by-operation
+  "Project typed contraction facts once at the algorithm/schedule boundary.
+
+   The target emitter receives verified facts keyed by the immutable SegRed identity; it never
+   reparses retained Clojure source or guesses that an arbitrary segmented reduction is GEMM."
+  [algorithm operations]
+  (let [equations (into {} (map (juxt second identity)) (soac/equations algorithm))]
+    (into {}
+          (keep (fn [operation]
+                  (when (= :contraction (:phase operation))
+                    (let [equation (or (get equations (:id operation))
+                                       (fail! :c-family-contraction-equation
+                                              "scheduled contraction lacks its typed equation"
+                                              {:operation (:id operation)}))]
+                      [(:id operation)
+                       (contraction-facts/from-components
+                        (typed-projection/segmented-reduce-contract-components
+                         algorithm equation))]))))
+          operations)))
 
 (defn- target-program-dialect
   [target-dialect]
@@ -115,7 +139,12 @@
                                graph-contract
                                (assoc :provenance (:provenance graph-contract)
                                       :attributes (:attributes graph-contract))))
-            emitted (emit-graph scheduled-graph (:values body) (:operations equation) opts)]
+            operations (:operations equation)
+            contraction-facts (contraction-facts-by-operation algorithm operations)
+            emitted (emit-graph scheduled-graph (:values body) operations
+                                (cond-> opts
+                                  (seq contraction-facts)
+                                  (assoc :contraction-facts contraction-facts)))]
         (assoc equation :operations
                [(emitted-equation/make algorithm body emitted {:provenance provenance})]))
 

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -27,6 +27,7 @@
             [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.passes.parallel.register-tiled-body :as register-tiled-body]
+            [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]
             [raster.compiler.passes.parallel.segred-body :as segred-body]
             [raster.compiler.passes.parallel.segfoldmap-body :as segfoldmap-body]
             [raster.compiler.passes.parallel.segmap-body :as segmap-body]
@@ -770,6 +771,11 @@
   [segred out-sym & {:keys [dtype kernel-name-prefix scalar-types array-types target-dialect]
                      :or {dtype :double kernel-name-prefix "par_reduce" scalar-types {}
                           array-types {} target-dialect :opencl-intel}}]
+  (when (seq (segop/seg-space-segment-dims (:space segred)))
+    (throw (ex-info
+            "segmented reductions require a verified contraction schedule"
+            {:reason :segmented-reduction-requires-contraction-schedule
+             :operation (:id segred) :fallback :none})))
   (let [_certified-plan
         ;; Both emitters reassociate the fold. Prove the concrete scheduled scalar region before
         ;; either route is selected; a KernelBody coverage decline must never become permission
@@ -1169,9 +1175,12 @@
             operation)))]
     (finalize-emitted-graph emitted (kernel-body-c-dialect/target target) scalar-types)))
 
+(declare generate-contraction-kernel-artifact)
+
 (defn- generate-reduction-kernel-graph
-  [graph {:keys [scalar-types array-types target-dialect]
-          :or {scalar-types {} array-types {} target-dialect :opencl-intel}}]
+  [graph {:keys [scalar-types array-types target-dialect target-device contraction-facts]
+          :or {scalar-types {} array-types {} target-dialect :opencl-intel
+               contraction-facts {}}}]
   (let [array-types (graph-array-types graph array-types)
         emitted
         (kgraph/map-operations
@@ -1183,11 +1192,30 @@
                                {:reason :kernel-graph-reduction-output
                                 :target :opencl-c :node id :outputs outputs})))
              (kart/certify-scheduled-operation
-              (generate-segred-kernel
-               operation (first outputs)
-               :dtype (:dtype operation)
-               :scalar-types scalar-types :array-types array-types
-               :target-dialect target-dialect)
+              (if (seq (segop/seg-space-segment-dims (:space operation)))
+                (let [facts (or (get contraction-facts (:id operation))
+                                (throw (ex-info
+                                        "segmented reduction lacks verified contraction facts"
+                                        {:reason :kernel-graph-segmented-reduction-facts
+                                         :operation (:id operation) :fallback :none})))
+                      descriptor (hw/descriptor-for target-device)
+                      planned (contraction-schedule/plan-portable-body
+                               facts operation descriptor
+                               {:array-types array-types :scalar-types scalar-types})]
+                  (when-not (:ok planned)
+                    (throw (ex-info
+                            "segmented reduction has no portable KernelBody schedule"
+                            {:reason :kernel-graph-segmented-reduction-body
+                             :operation (:id operation) :schedule-decline planned
+                             :fallback :none})))
+                  (generate-contraction-kernel-artifact
+                   (:body planned) :target-dialect target-dialect
+                   :kernel-name-prefix "graph_contraction"))
+                (generate-segred-kernel
+                 operation (first outputs)
+                 :dtype (:dtype operation)
+                 :scalar-types scalar-types :array-types array-types
+                 :target-dialect target-dialect))
               operation))))]
     (finalize-emitted-graph
      emitted
@@ -1328,6 +1356,40 @@
      :output output
      :kernel-body kernel-body
      :launch (:launch kernel-body)}))
+
+(defn generate-contraction-kernel-artifact
+  "Emit one portable contraction KernelBody as a complete executable compiler value."
+  [kernel-body & {:keys [kernel-name-prefix target-dialect]
+                  :or {kernel-name-prefix "contract" target-dialect :opencl-intel}}]
+  (let [kernel-body (kbody/validate! kernel-body)
+        emitted (generate-contraction-kernel-body
+                 kernel-body :kernel-name-prefix kernel-name-prefix
+                 :target-dialect target-dialect)
+        launch-segment-count (get-in kernel-body [:attributes :launch-segment-count])
+        arguments (mapv (fn [parameter]
+                          (if (= '_nseg (:id parameter)) launch-segment-count (:id parameter)))
+                        (:parameters kernel-body))]
+    (kart/make
+     {:kernel-name (:kernel-name emitted)
+      :target (:target emitted)
+      :source (:source emitted)
+      :abi (:abi emitted)
+      :arguments arguments
+      :launch (:launch emitted)
+      :effects {:kind :pure-contraction}
+      :provenance {:dialect :kernel-body
+                   :source-dialect :segcontract
+                   :segop-id (get-in kernel-body [:provenance :segop-id])}
+      :attributes {:array-params (:array-params emitted)
+                   :scalar-params (:scalar-params emitted)
+                   :epilogue-operands (:epilogue-operands emitted)
+                   :epilogue-scalars (:epilogue-scalars emitted)
+                   :written-arrays #{(:output emitted)}
+                   :kernel-body kernel-body
+                   :strategy (get-in kernel-body [:schedule :strategy])
+                   :out-elems launch-segment-count
+                   :emission-route :kernel-body
+                   :target-dialect target-dialect}})))
 
 (defn generate-segmented-reduce-kernel
   "NAIVE segmented reduction (a contraction) → OpenCL. One work-item per SEGMENT (free-axis

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -88,9 +88,11 @@
     :source source
     :abi abi
     :arguments arguments
-    :launch (klaunch/spec
-             {:workgroup-size (mapv launch-dimension wg)
-              :group-count (mapv launch-dimension grid)})
+    :launch (if (= :portable-segred strategy)
+              (get-in descriptor [:kernel-body :launch])
+              (klaunch/spec
+               {:workgroup-size (mapv launch-dimension wg)
+                :group-count (mapv launch-dimension grid)}))
     :temporaries []
     :effects {:kind :tensor-contraction}
     :provenance {:dialect :segcontract :strategy strategy}

--- a/src/raster/compiler/passes/parallel/contraction_body.clj
+++ b/src/raster/compiler/passes/parallel/contraction_body.clj
@@ -95,6 +95,7 @@
         index-scope (into axis-symbols scalars)
         segment-count-source (segop/seg-space-num-segments-expr space)
         segment-count (lower-index segment-count-source index-scope)
+        launch-segment-count (index-expression/to-launch-expression segment-count decline!)
         reduced-bound (lower-index (:bound reduced-dim) index-scope)
         segment-index 'segment-index
         group-index 'segment-group
@@ -117,12 +118,17 @@
             (decline! :literal-identity
                       "portable contraction requires a typed numeric reduction identity"
                       {:identity identity :segred-id (:id segred)}))
-        coordinate-lower #(lower-index (axis-map/index-expr %) index-scope)
+        ;; Operand indices in the certified contraction body are already the authoritative
+        ;; physical coordinate expressions.  `operand-maps` prove those expressions and provide
+        ;; storage extents; they are not a wrapper around the expression handed back by
+        ;; `lower-element-operations`.
+        element-coordinate-lower #(lower-index % index-scope)
+        epilogue-coordinate-lower #(lower-index (axis-map/index-expr %) index-scope)
         {:keys [operations result]}
         (segred-body/lower-element-operations
          element {:index reduced-index :coordinate reduced-index :dtype dtype
                   :arrays (set arrays) :scalars (set scalars)
-                  :coordinate-lower coordinate-lower
+                  :coordinate-lower element-coordinate-lower
                   :load-predicate active-mask
                   :load-other (body/literal identity dtype)})
         accumulator 'segment-accumulator
@@ -168,7 +174,7 @@
               :accumulator-dtype dtype
               :store-dtype dtype
               :parameters parameter-map
-              :coordinate-lower coordinate-lower
+              :coordinate-lower epilogue-coordinate-lower
               :predicate active-mask}))
           stored-result (or (:result lowered-transform) reduction-result)]
       {:kernel-body
@@ -211,12 +217,13 @@
                     :reduction-operator operator}
          :launch (launch/spec
                   {:workgroup-size [workgroup-size]
-                   :group-count [(launch/ceil-div segment-count workgroup-size)]})
+                   :group-count [(launch/ceil-div launch-segment-count workgroup-size)]})
          :provenance {:dialect :kernel-body :source-dialect :segcontract
                       :segop-id (:id segred)}
          :attributes {:kind :portable-contraction
                       :identity identity :operator operator
                       :segment-count segment-count
+                      :launch-segment-count launch-segment-count
                       :reduced-bound reduced-bound
                       :axis-symbols (vec (concat (map :name segment-dims)
                                                  [reduced-index]))
@@ -225,4 +232,5 @@
        :scalars scalars
        :output output
        :segment-count segment-count
+       :launch-segment-count launch-segment-count
        :workgroup-size workgroup-size})))

--- a/src/raster/compiler/passes/parallel/index_expression.clj
+++ b/src/raster/compiler/passes/parallel/index_expression.clj
@@ -4,7 +4,8 @@
    Schedules provide their own decline function so this small shared vocabulary does not decide
    whether a missing rule is a map, reduction, scan, or contraction coverage failure."
   (:require [raster.compiler.core.op-descriptor :as descriptor]
-            [raster.compiler.ir.kernel-body :as body]))
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-launch :as launch]))
 
 (def ^:private operators
   {'+ :add, 'clojure.core/+ :add, 'raster.numeric/+ :add
@@ -69,3 +70,34 @@
       (decline! :index-expression
                 "portable index expression has an unsupported value"
                 {:expression expression :type (type expression)}))))
+
+(defn to-launch-expression
+  "Project non-negative KernelBody index arithmetic into resolvable host launch IR.
+
+   KernelBody and KernelLaunch deliberately use distinct expression records because one executes
+   in a kernel and the other is resolved by the runtime binder. This conversion admits only the
+   monotone extent vocabulary shared by both; subtraction and modulo remain kernel-local."
+  [expression decline!]
+  (cond
+    (integer? expression) expression
+    (or (symbol? expression) (keyword? expression)) (launch/runtime-value expression)
+
+    (instance? raster.compiler.ir.kernel_body.IndexCast expression)
+    (to-launch-expression (:argument expression) decline!)
+
+    (instance? raster.compiler.ir.kernel_body.IndexExpr expression)
+    (let [arguments (mapv #(to-launch-expression % decline!) (:arguments expression))]
+      (case (:op expression)
+        :add (apply launch/sum arguments)
+        :mul (apply launch/product arguments)
+        :floor-div (apply launch/floor-div arguments)
+        :ceil-div (apply launch/ceil-div arguments)
+        :min (apply launch/minimum arguments)
+        (decline! :launch-index-expression
+                  "kernel index operation is not a non-negative launch extent"
+                  {:expression expression :operation (:op expression)})))
+
+    :else
+    (decline! :launch-index-expression
+              "kernel index value cannot be projected into launch IR"
+              {:expression expression :type (type expression)})))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -23,6 +23,7 @@
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
             [raster.core :refer [deftm]]
             [raster.dl.attention :as dl-attention]
+            [raster.linalg.contract :as contract]
             [raster.numeric]
             [raster.par]
             [raster.quant.kernels-k :as qk]
@@ -213,6 +214,8 @@
                  #'public-c-family-scan {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'public-c-family-stencil {:target device-id :dtype :float}))
+      (:kernels (equation-first/compile
+                 #'contract/contract-mm {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'qk/qmatmul-q4k-dp4a-rows! {:target device-id :dtype :float}))
       (:kernels (equation-first/compile

--- a/test/raster/compiler/compatibility_ledger.edn
+++ b/test/raster/compiler/compatibility_ledger.edn
@@ -20,10 +20,8 @@
    :emission {:structured-loops-emitted 0
               :typed-equations-emitted 1
               :host-scalar-equations 0
-              :emission-routes {:verified-segred-opencl 1}
-              :kernel-body-declines
-              {[:segred-kernel-body-declined :unbound-index-symbol
-                :verified-segred-opencl] 1}}}
+              :emission-routes {:kernel-body 1}
+              :kernel-body-declines {}}}
 
   :q4k-dp4a-rows-gpu
   {:route {:semantic-dialect :typed-parallel

--- a/test/raster/compiler/gpu_integration_test.clj
+++ b/test/raster/compiler/gpu_integration_test.clj
@@ -10,9 +10,11 @@
     3. The resulting allocation-free LinkPlan executes numerically on an available GPU."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.equation-first :as equation-first]
+            [raster.compiler.ir.kernel-body :as kernel-body]
             [raster.compiler.ir.link-plan :as link-plan]
             [raster.dl.gpu-grad-parity :as gp]
             [raster.gpu.link :as gpu-link]
+            [raster.linalg.contract :as contract]
             [raster.ode.pde :as pde]))
 
 ;; ================================================================
@@ -125,5 +127,32 @@
                                                0))]
                       (is (< (Math/abs (- (double expected) actual)) 1.0e-10)
                           (format "CPU=%.15g GPU=%.15g" (double expected) actual)))
+                    (finally
+                      (gpu-link/close! executable))))))))
+
+(deftest symbolic-dense-contraction-uses-one-correct-kernel-body-test
+  (let [left (float-array [1 2 3 4 5 6])
+        right (float-array [7 8 9 10 11 12])
+        compilation (equation-first/compile
+                     #'contract/contract-mm {:target :ze:0 :dtype :float})
+        plan (equation-first/lower compilation [left right 2 3 2])
+        artifact (first (:kernels compilation))
+        body (get-in artifact [:attributes :kernel-body])]
+    (testing "the typed equation owns the segment schedule and target-neutral body"
+      (is (= {:kernel-body 1}
+             (get-in compilation [:stats :emission :emission-routes])))
+      (is (empty? (get-in compilation [:stats :emission :kernel-body-declines])))
+      (is (= 1 (count (:kernels compilation))))
+      (is (kernel-body/kernel-body? body))
+      (is (= :sequential-segments (get-in body [:schedule :strategy])))
+      (is (= '[A B C k m n _nseg] (mapv :id (:parameters body))))
+      (is (= 0 (get-in plan [:attributes :driver-allocations]))))
+    (testing "all free-axis segments execute with their own verified operand coordinates"
+      (when-gpu "gpu-symbolic-dense-contraction-execution"
+                (let [executable (gpu-link/instantiate! plan)]
+                  (try
+                    (gpu-link/run! executable)
+                    (is (= [58.0 64.0 139.0 154.0]
+                           (vec (gpu-link/download executable (first (:outputs plan))))))
                     (finally
                       (gpu-link/close! executable))))))))

--- a/test/raster/compiler/passes/parallel/contraction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_body_test.clj
@@ -6,6 +6,7 @@
             [raster.compiler.ir.contraction-facts :as facts]
             [raster.compiler.ir.kernel-artifact :as artifact]
             [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-launch :as launch]
             [raster.compiler.passes.parallel.contract-lower :as lower]
             [raster.compiler.passes.parallel.contract-route :as route]
             [raster.compiler.passes.parallel.contraction-schedule :as schedule]))
@@ -47,6 +48,9 @@
     (is (body/kernel-body? kernel))
     (is (= :sequential-segments (get-in kernel [:schedule :strategy])))
     (is (= [256] (get-in kernel [:launch :workgroup-size])))
+    (is (= [1]
+           (mapv #(launch/resolve-expression {'m 7} %)
+                 (get-in kernel [:launch :group-count]))))
     (is (= '[A x y k m _nseg] (mapv :id (:parameters kernel))))
     (is (= [:input :input :output :scalar :scalar :scalar]
            (mapv :kind (:parameters kernel))))
@@ -153,6 +157,17 @@
                   (throw (ex-info "legacy source template was called" {})))]
     (is (= :portable-segred
            (:strategy (route/route-contraction matvec :dtype :float :desc {}))))))
+
+(deftest full-reduction-emitter-refuses-a-segmented-space
+  (let [verified (facts/contraction-facts matvec :dtype :float)
+        segmented (lower/contract-form->segred matvec :dtype :float :facts verified)
+        failure (try
+                  (emit/generate-segred-kernel segmented 'y :dtype :float)
+                  nil
+                  (catch clojure.lang.ExceptionInfo exception
+                    (ex-data exception)))]
+    (is (= :segmented-reduction-requires-contraction-schedule (:reason failure)))
+    (is (= :none (:fallback failure)))))
 
 (deftest flattened-symbolic-reduction-extents-remain-in-the-typed-abi
   (let [form '(raster.par/contract y [[i m]] [[l1 k1] [l2 k2]]


### PR DESCRIPTION
Routes equation-first segmented contractions from retained TypedSOAC facts through the target-neutral portable KernelBody schedule instead of the full-reduction compatibility emitter. Keeps kernel and host launch expressions distinct, preserves portable KernelBody launch geometry, and makes the full-reduction emitter reject segmented spaces. Adds a real Intel GPU matrix-product oracle, compatibility-ledger ratchet, and hardware-free CUDA PTX plus HIP code-object fixtures.\n\nFocused validation: 13 tests / 107 assertions for contraction, GPU integration, and ledger; 48 tests / 396 assertions for typed contraction routing; real GPU result [58 64 139 154]; nvcc sm_80 PTX and hipcc gfx1100 code object both compile.