### PR TITLE
Remove the scalar reduction OpenCL fallback

### DIFF
--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -755,19 +755,11 @@
           (throw exception))))))
 
 (defn generate-segred-kernel
-  "Generate OpenCL C reduction kernels from a SegRed record.
+  "Emit a scheduled full reduction exclusively through target-neutral KernelBody.
 
-   For two-phase reduction (default for large arrays):
-   Phase 1: block-local shared-memory tree reduction
-   Phase 2: single-block reduction of partial results
-
-   Returns {:kernel-name str :source str :abi [ordered typed slots]
-            :arguments [ordered compiler values] :array-params [syms]
-            :scalar-params [syms] :dtype kw :n-phases int}.
-
-   `out-sym` is nil for the host-scalar staging protocol: the ordered :arguments vector then
-   carries nil at the single :result slot, which the runtime replaces with its partial-results
-   buffer.  Resident reduce-into supplies the real output buffer symbol at that same ABI position."
+   The artifact carries the complete ordered ABI, symbolic launch, workgroup scratch and two-phase
+   reduction protocol. Unsupported scalar regions fail with their structured KernelBody decline;
+   no target may recover semantics by reparsing a source-shaped lambda."
   [segred out-sym & {:keys [dtype kernel-name-prefix scalar-types array-types target-dialect]
                      :or {dtype :double kernel-name-prefix "par_reduce" scalar-types {}
                           array-types {} target-dialect :opencl-intel}}]
@@ -776,214 +768,27 @@
             "segmented reductions require a verified contraction schedule"
             {:reason :segmented-reduction-requires-contraction-schedule
              :operation (:id segred) :fallback :none})))
-  (let [_certified-plan
-        ;; Both emitters reassociate the fold. Prove the concrete scheduled scalar region before
-        ;; either route is selected; a KernelBody coverage decline must never become permission
-        ;; for the compatibility emitter to invent an algebra.
-        (segred-body/scalar-plan segred)
-        kernel-body-attempt
-        (try
-          {:artifact
-           (generate-segred-kernel-body
-            segred out-sym :dtype dtype :kernel-name-prefix kernel-name-prefix
-            :scalar-types scalar-types :array-types array-types :target-dialect target-dialect)}
-          (catch clojure.lang.ExceptionInfo exception
-            (when-not (segred-body/declined? exception) (throw exception))
-            (when (get-in segred [:reduction :attributes :result-region])
-              (throw (ex-info
-                      "completed-reduction transforms require verified KernelBody lowering"
-                      (assoc (ex-data exception)
-                             :reason :segred-result-transform-lowering
-                             :fallback :none)
-                      exception)))
-            {:decline (assoc (ex-data exception) :fallback :verified-segred-opencl)}))]
-    (or
-     (:artifact kernel-body-attempt)
-     (when-not (kernel-body-c-dialect/opencl?
-                (kernel-body-c-dialect/resolve! target-dialect))
-       (throw (ex-info
-               "scheduled reduction is outside the portable KernelBody C-family subset"
-               {:reason :kernel-graph-target-lowering-missing
-                :target-dialect target-dialect
-                :operation (:id segred)
-                :kernel-body-decline (:decline kernel-body-attempt)
-                :fallback :none})))
-     (let [idx (seg-idx segred)
-           bound (seg-bound segred)
-           {:keys [acc init lambda]} (segop/scalar-reduce-op segred)
-        ;; #55 fix: normalize devirtualized array prims ((.invk aget-impl arr i)
-        ;; → canonical aget head) BEFORE any rewrapping, exactly as SegMap does.
-        ;; Without it, a parametric-array kernel (qlinear-k) emitted broken
-        ;; gpufn_aget helper calls while a typed-array kernel (decoder-gpu)
-        ;; emitted x[i] — same op, ns-sensitive lowering.
-           lambda (ce/normalize-array-prims lambda)
-           dtype (or (:dtype segred) dtype)
-           kernel-name (str kernel-name-prefix "_" (gensym ""))
-           ctype (dt/ctype :opencl dtype)
-           arr-params (vec (sort-by name (:inputs segred)))
-           scl-params (vec (sort-by name (:scalars segred)))
-           scalar-dtype #(ce/scalar-parameter-dtype % scalar-types dtype)
-           scl-type #(dt/ctype :opencl (scalar-dtype %))
-           scalar-var-types (into {} (map (juxt identity scl-type)) scl-params)
-           int-scalar-syms (set (filter #(dt/integral? (scalar-dtype %)) scl-params))
-        ;; Detect reduction op from lambda — unwrap let to find op, keep let for elem
-           [let-bindings inner-body]
-           (if (and (seq? lambda) (contains? #{'let* 'let} (first lambda)))
-             (let [[_ binds & bdy] lambda]
-            ;; A reduce combine's let body must be ONE expression `(op acc elem)`. Taking
-            ;; `(last bdy)` of a multi-statement body would SILENTLY DROP the earlier forms
-            ;; — the same shape as the single-aset-void store-drop. If earlier statements
-            ;; exist they carry computation/effects the combine depends on; reject loudly.
-               (when (> (count bdy) 1)
-                 (throw (ex-info (str "SegRed: reduce combine lambda has a multi-statement body ("
-                                      (count bdy) " forms) — only a single combine expression is"
-                                      " modeled; earlier forms would be dropped")
-                                 {:lambda lambda :body (vec bdy)})))
-               [(vec (partition 2 binds)) (last bdy)])
-             [nil lambda])
-        ;; .invk-aware: the walker devirtualizes (raster.numeric/+ acc x) into
-        ;; (.invk _plus_impl acc x) with :raster.op/original metadata. semantic-op recovers the
-        ;; original op and call-args the real operands — never parse the mangled impl name (which
-        ;; would mis-detect the op and capture the impl symbol as the element). Same fix #37 made
-        ;; for SegMap; here it keeps SegRed combine-op detection sound for both bare and .invk forms.
-           op-sym (when (seq? inner-body) (descriptor/semantic-op inner-body))
-           normalized-op (get {'clojure.core/+ '+, 'clojure.core/* '*,
-                               'raster.numeric/+ '+, 'raster.numeric/* '*,
-                               'clojure.core/max 'max, 'raster.numeric/max 'max, 'Math/max 'max,
-                               'clojure.core/min 'min, 'raster.numeric/min 'min, 'Math/min 'min}
-                              op-sym op-sym)
-        ;; Unknown combine ops must FAIL LOUD — the old default silently combined with "+"
-        ;; (a max reduce summed the per-lane maxima). Only associative ops are legal here.
-           c-op (condp = normalized-op '+ "+" '* "*" 'max "fmax" 'min "fmin"
-                       (throw (ex-info (str "SegRed: unsupported reduce combine op " op-sym
-                                            " — GPU reduction needs an associative op (+ * max min)")
-                                       {:op op-sym :lambda lambda})))
-           c-identity-val ({"+" "0.0" "*" "1.0" "fmax" "-INFINITY" "fmin" "INFINITY"} c-op "0.0")
-           identity-val ({"+" 0.0 "*" 1.0 "fmax" Double/NEGATIVE_INFINITY "fmin" Double/POSITIVE_INFINITY} c-op 0.0)
-        ;; fmax/fmin are functions, not infix operators
-           c-combine (fn [a b] (if (#{"fmax" "fmin"} c-op)
-                                 (str c-op "(" a ", " b ")")
-                                 (str "(" a " " c-op " " b ")")))
-        ;; Extract the element expression (the non-acc operand) from the SEMANTIC args.
-           op-args (vec (when (seq? inner-body) (descriptor/call-args inner-body)))
-        ;; A segmented reduce combine is BINARY: (op acc elem). A variadic combine like
-        ;; (+ acc x y) has 3 operands — extracting only ONE non-acc operand would SILENTLY
-        ;; emit a kernel that sums just `x`, dropping `y` (the store-drop family). A legit
-        ;; fused map→reduce nests the map body as a single elem operand, so >2 is unmodeled.
-           _ (when (> (count op-args) 2)
-               (throw (ex-info (str "SegRed: reduce combine op has " (count op-args)
-                                    " operands — only a binary (op acc elem) combine is modeled;"
-                                    " extra operands would be dropped")
-                               {:op op-sym :op-args op-args :lambda lambda})))
-        ;; Typed float pipelines cast the accumulator to `(float acc)` while double pipelines
-        ;; use `(double acc)`. Treat both as the accumulator position; recognizing only double
-        ;; made an otherwise-valid float SegRed return nil and fall through to a legacy kernel
-        ;; whose body referenced captured scalars absent from its signature.
-           acc-at? (fn [a] (or (= a acc)
-                               (and (seq? a)
-                                    (contains? #{'float 'double 'clojure.core/float
-                                                 'clojure.core/double}
-                                               (first a))
-                                    (= acc (second a)))))
-           [_acc-pos elem-expr-raw]
-           (when (>= (count op-args) 2)
-             (let [a0 (nth op-args 0) a1 (nth op-args 1)]
-               (cond
-                 (acc-at? a0) [:left a1]
-                 (acc-at? a1) [:right a0]
-                 :else [nil nil])))
-        ;; Re-wrap in let if there were bindings (preserves local variable scope)
-        ;; preserve the raw expr's metadata across the rewrap — dropping it
-        ;; severed :raster.op/original on .invk forms (part of #55)
-           elem-expr (if (and elem-expr-raw (seq let-bindings))
-                       (with-meta (list 'let* (vec (mapcat identity let-bindings)) elem-expr-raw)
-                         (meta elem-expr-raw))
-                       elem-expr-raw)
-           adapted-elem (when elem-expr (ce/adapt-casts-for-dtype elem-expr dtype))
-           idx-c-name (ce/c-symbol idx)
-           elem-str (when adapted-elem
-                      (binding [ce/*emit-config* ce/opencl-config
-                                ce/*scalar-type* ctype
-                                ce/*scalar-var-types* scalar-var-types
-                                ce/*int-vars* (into ce/*int-vars* int-scalar-syms)]
-                        (ce/emit-expr adapted-elem idx (set (map #(symbol (name %)) arr-params)) idx-c-name)))
-        ;; Build kernel source
-           workgroup-size 256
-           arr-param-str (str/join ", "
-                                   (map (fn [s] (str "__global const " ctype "* restrict "
-                                                     (ce/c-symbol s)))
-                                        arr-params))
-           scl-param-str (str/join ", "
-                                   (map (fn [s] (str (scl-type s) " " (ce/c-symbol s))) scl-params))
-        ;; The emitted name is pinned by the ordered ABI.
-           all-params (str/join ", "
-                                (remove empty?
-                                        [arr-param-str
-                                         (str "__global " ctype "* restrict output")
-                                         scl-param-str
-                                         "int _n_bound"]))
-           result-name (or out-sym 'output)
-           abi (kabi/validate!
-                (vec (concat
-                      (map #(kabi/slot % :input dtype :c-name (ce/c-symbol %) :role :operand)
-                           arr-params)
-                      [(kabi/slot result-name :output dtype :c-name "output" :role :result)]
-                      (map #(kabi/slot % :scalar (scalar-dtype %)
-                                       :c-name (ce/c-symbol %) :role :parameter)
-                           scl-params)
-                      [(kabi/slot '_n_bound :scalar :int :role :bound)])))
-        ;; Static shared memory is part of the artifact launch contract (no dynamic-local ABI slot).
-           _ (when-not elem-str
-               (throw (ex-info "SegRed emission produced no element expression"
-                               {:reason :illegal-op-remains
-                                :missing-rule :segred-element-expression
-                                :target-dialect :kernel-artifact
-                                :segred-id (:id segred)
-                                :lambda lambda
-                                :fallback :none})))
-           source (str (codegen/extension-pragmas dtype)
-                       "#if defined(cl_khr_subgroups)\n#pragma OPENCL EXTENSION cl_khr_subgroups : enable\n#elif defined(cl_intel_subgroups)\n#pragma OPENCL EXTENSION cl_intel_subgroups : enable\n#endif\n"
-                       "__kernel void " kernel-name
-                       "(" all-params ") {\n"
-                       "    __local " ctype " sdata[" workgroup-size "];\n"
-                       "    int tid = get_local_id(0);\n"
-                       "    " ctype " val = " c-identity-val ";\n"
-                       "    int stride = get_global_size(0);\n"
-                       "    int " (ce/c-symbol idx) " = get_global_id(0);\n"
-                       "    for (; " (ce/c-symbol idx) " < _n_bound; " (ce/c-symbol idx) " += stride) {\n"
-                       "        val = " (c-combine "val" elem-str) ";\n"
-                       "    }\n"
-                       "    sdata[tid] = val;\n"
-                       "    barrier(CLK_LOCAL_MEM_FENCE);\n"
-                       "    for (int s = get_local_size(0) / 2; s > 0; s >>= 1) {\n"
-                       "        if (tid < s) {\n"
-                       "            sdata[tid] = " (c-combine "sdata[tid]" "sdata[tid + s]") ";\n"
-                       "        }\n"
-                       "        barrier(CLK_LOCAL_MEM_FENCE);\n"
-                       "    }\n"
-                       "    if (tid == 0) output[get_group_id(0)] = sdata[0];\n"
-                       "}\n")]
-       (kart/make
-        {:kernel-name kernel-name
-         :source source
-         :abi abi
-         :arguments (vec (concat arr-params [out-sym] scl-params [(seg-bound segred)]))
-         :launch (klaunch/spec
-                  {:workgroup-size [workgroup-size]
-                   :group-count [(klaunch/ceil-div (seg-bound segred) workgroup-size)]
-                   :shared-memory-bytes (* workgroup-size (dt/bytes-of dtype))})
-         :temporaries []
-         :effects {:kind :pure-reduction}
-         :provenance {:dialect :segred :segop-id (:id segred)}
-         :attributes {:array-params arr-params
-                      :scalar-params scl-params
-                      :dtype dtype
-                      :n-phases 2
-                      :identity-val identity-val
-                      :c-op c-op
-                      :emission-route :verified-segred-opencl
-                      :kernel-body-decline (:decline kernel-body-attempt)}})))))
-
+  (try
+    (generate-segred-kernel-body
+     segred out-sym :dtype dtype :kernel-name-prefix kernel-name-prefix
+     :scalar-types scalar-types :array-types array-types :target-dialect target-dialect)
+    (catch clojure.lang.ExceptionInfo exception
+      (when-not (segred-body/declined? exception) (throw exception))
+      (let [decline (assoc (ex-data exception) :fallback :none)]
+        (if (get-in segred [:reduction :attributes :result-region])
+          (throw (ex-info
+                  "completed-reduction transforms require verified KernelBody lowering"
+                  (assoc decline :reason :segred-result-transform-lowering
+                         :kernel-body-decline (ex-data exception))
+                  exception))
+          (throw (ex-info
+                  "scheduled reduction is outside the portable KernelBody C-family subset"
+                  {:reason :kernel-graph-target-lowering-missing
+                   :target-dialect target-dialect
+                   :operation (:id segred)
+                   :kernel-body-decline decline
+                   :fallback :none}
+                  exception)))))))
 ;; ================================================================
 ;; KernelGraph scan → OpenCL KernelArtifacts
 ;; ================================================================

--- a/src/raster/compiler/passes/parallel/segred_body.clj
+++ b/src/raster/compiler/passes/parallel/segred_body.clj
@@ -132,33 +132,81 @@
     (second expression)
     expression))
 
+(defn- cast-policy
+  [source target]
+  (let [source (dtype/canon source)
+        target (dtype/canon target)]
+    (cond
+      (= source target) nil
+
+      (and (dtype/fp-dtype? source) (dtype/fp-dtype? target))
+      (if (< (dtype/bytes-of source) (dtype/bytes-of target))
+        [:exact :exact]
+        [:nearest-even :ieee])
+
+      (and (dtype/integral? source) (dtype/fp-dtype? target))
+      (if (and (= :double target) (<= (dtype/bytes-of source) 4))
+        [:exact :exact]
+        [:nearest-even (if (= :half target) :ieee :exact)])
+
+      (and (dtype/fp-dtype? source) (dtype/integral? target))
+      [:toward-zero :saturate]
+
+      (and (dtype/integral? source) (dtype/integral? target))
+      [:exact :wrap]
+
+      :else
+      (decline! :scalar-cast
+                "KernelBody reduction has no explicit numerical cast policy"
+                {:source-dtype source :target-dtype target}))))
+
+(defn- promoted-dtype
+  [types]
+  (let [types (mapv dtype/canon types)
+        floating (filterv dtype/fp-dtype? types)
+        candidates (if (seq floating) floating types)]
+    (when-not (and (seq candidates) (every? dtype/known? candidates))
+      (decline! :scalar-promotion
+                "KernelBody reduction cannot promote unknown scalar dtypes"
+                {:types types}))
+    (apply max-key dtype/bytes-of candidates)))
+
 (defn lower-element-operations
-  "Lower a scalar reduction element into typed SSA. `coordinate-lower` may translate a verified
+  "Lower a scalar reduction element into typed SSA. coordinate-lower may translate a verified
    source-level flat array index into KernelBody index arithmetic; without it, this retains the
-   pointwise full-reduction contract. A predicate requires an explicit typed load fallback."
+   pointwise full-reduction contract. Mixed scalar arithmetic is widened explicitly and the final
+   element is narrowed to the accumulator dtype before it enters the certified monoid."
   [expression {:keys [index coordinate dtype arrays scalars scalar-types coordinate-lower
                       load-predicate load-other]}]
-  (let [operations (atom [])
+  (let [dtype (dtype/canon dtype)
+        operations (atom [])
         counter (atom 0)
         fresh (fn [prefix] (symbol (str prefix "-" (swap! counter inc))))
-        emit! (fn [operation result]
+        emit! (fn [operation value value-dtype]
                 (swap! operations conj operation)
-                result)]
-    (letfn [(lower [expression]
+                {:value value :dtype (dtype/canon value-dtype)})]
+    (letfn [(cast! [{:keys [value dtype] :as typed} target]
+              (let [source (dtype/canon dtype)
+                    target (dtype/canon target)]
+                (if (= source target)
+                  typed
+                  (let [[rounding overflow] (cast-policy source target)
+                        result (fresh "element-cast")]
+                    (emit! (body/->ScalarCompute
+                            (body/value result target)
+                            (body/cast-expression value target rounding overflow))
+                           result target)))))
+
+            (lower [expression]
               (let [expression (inline-scalar-bindings expression)]
                 (cond
                   (number? expression)
-                  (body/literal expression dtype)
+                  {:value (body/literal expression dtype) :dtype dtype}
 
                   (symbol? expression)
                   (if (contains? scalars expression)
-                    (if (= (dtype/canon dtype)
-                           (dtype/canon (get scalar-types expression dtype)))
-                      expression
-                      (decline! :scalar-dtype
-                                "KernelBody reduction value scalar must match the accumulator dtype"
-                                {:expression expression :dtype dtype
-                                 :scalar-dtype (get scalar-types expression)}))
+                    {:value expression
+                     :dtype (dtype/canon (get scalar-types expression dtype))}
                     (decline! :unbound-scalar
                               "KernelBody element expression references an undeclared scalar"
                               {:expression expression :scalars scalars}))
@@ -184,42 +232,39 @@
                               (when load-predicate
                                 (or load-other (body/literal 0 dtype)))
                               :cached)
-                             result)))
+                             result dtype)))
 
                   (and (seq? expression) (contains? cast-heads (first expression))
                        (= 2 (count expression)))
-                  (let [target (get cast-heads (first expression))]
-                    (when-not (= (dtype/canon target) (dtype/canon dtype))
-                      (decline! :scalar-cast
-                                "initial KernelBody reduction requires element casts to its dtype"
-                                {:expression expression :source-dtype dtype :target-dtype target}))
-                    (lower (second expression)))
+                  (cast! (lower (second expression)) (get cast-heads (first expression)))
 
                   (seq? expression)
                   (let [operator (intrinsics/canonical (descriptor/semantic-op expression))
-                        descriptor (intrinsics/descriptor operator)
-                        arguments (vec (descriptor/call-args expression))]
-                    (when-not (and descriptor
-                                   (= (:arity descriptor) (count arguments))
-                                   (intrinsics/accepts-scalar-dtype? operator dtype)
-                                   (not= :cmp (:kind descriptor)))
+                        intrinsic (intrinsics/descriptor operator)
+                        arguments (vec (descriptor/call-args expression))
+                        typed-inputs (mapv lower arguments)
+                        result-dtype (promoted-dtype (mapv :dtype typed-inputs))]
+                    (when-not (and intrinsic
+                                   (= (:arity intrinsic) (count arguments))
+                                   (intrinsics/accepts-scalar-dtype? operator result-dtype)
+                                   (not= :cmp (:kind intrinsic)))
                       (decline! :scalar-expression
                                 "KernelBody element expression contains an unsupported scalar operation"
-                                {:expression expression :operator operator :dtype dtype}))
-                    (let [inputs (mapv lower arguments)
+                                {:expression expression :operator operator
+                                 :result-dtype result-dtype}))
+                    (let [inputs (mapv (comp :value #(cast! % result-dtype)) typed-inputs)
                           result (fresh "element-value")]
                       (emit! (body/->ScalarCompute
-                              (body/value result dtype)
-                              (body/scalar-expression operator dtype inputs))
-                             result)))
+                              (body/value result result-dtype)
+                              (body/scalar-expression operator result-dtype inputs))
+                             result result-dtype)))
 
                   :else
                   (decline! :scalar-expression
                             "KernelBody element expression has an unsupported value"
                             {:expression expression :type (type expression)}))))]
-      (let [result (lower expression)]
-        {:operations @operations :result result}))))
-
+      (let [result (cast! (lower expression) dtype)]
+        {:operations @operations :result (:value result)}))))
 (defn lower
   "Lower an eligible scalar SegRed to one verified portable workgroup-tree KernelBody.
 
@@ -230,7 +275,10 @@
   (let [dtype (or (:dtype segred) dtype)
         index (:name (segop/seg-space-reduced-dim (:space segred)))
         bound (:bound (segop/seg-space-reduced-dim (:space segred)))
-        workgroup-size (get-in segred [:grid :block-size])
+        ;; Direct compatibility-front-door reductions can arrive before target scheduling. Keep
+        ;; the portable baseline explicit here; scheduled TypedSOAC operations retain their
+        ;; descriptor-derived block size and capped group count.
+        workgroup-size (or (get-in segred [:grid :block-size]) 256)
         arrays (vec (sort-by name (:inputs segred)))
         scalars (vec (sort-by name (:scalars segred)))
         scalar-dtype (fn [id] (or (get scalar-types id)
@@ -273,8 +321,9 @@
              (conj (set scalars) element-index)
              decline!))})
         output (or out-sym 'output)
-        group-count (launch-group-count (get-in segred [:grid :num-blocks])
-                                        bound workgroup-size)
+        group-count (if-let [grid-expression (get-in segred [:grid :num-blocks])]
+                      (launch-group-count grid-expression bound workgroup-size)
+                      (launch/ceil-div bound-dimension workgroup-size))
         scratch 'workgroup-reduction-scratch
         barrier (fn [] (body/->WorkgroupBarrier
                         :workgroup #{:workgroup} :acquire-release (body/full-participation)))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -69,12 +69,13 @@
   [dialect]
   (let [form (with-meta
                '(raster.par/reduce acc 0.0 i n
-                                   (+ acc (* scale (clojure.core/aget values i))))
+                                   (+ acc (* (double scale)
+                                             (clojure.core/aget values i))))
                {:raster.type/elem-type :float})
         node (soac/par-form->soac 'result form 901 :dtype :float)
         operation (first (soac-lower/lower-reduce node nil :dtype :float))]
     (segop-emit/generate-segred-kernel-body
-     operation nil :dtype :float :scalar-types {'scale :float}
+     operation nil :dtype :float :scalar-types {'scale :double}
      :target-dialect dialect :kernel-name-prefix "workgroup_reduce")))
 
 (defn- contraction-artifact

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -49,7 +49,7 @@
     (is (= 2 (second (get temporary-specs partials)))
         "dynamic two-phase scratch resolves through KernelLaunch IR at call time")))
 
-(deftest scheduled-reduction-graph-does-not-export-an-opencl-fallback-to-cuda
+(deftest scheduled-reduction-graph-has-no-source-shaped-target-fallback
   (let [source '(let* [result (raster.par/reduce acc 0.0 i n
                                                  (+ acc (clojure.core/aget a i)))]
                       result)
@@ -58,22 +58,24 @@
         algorithm (get-in typed [:equations 0 :algorithm])
         scheduled (:form (segop-lower/segop-lower-pass typed options))
         graph (equation-graph/make algorithm scheduled)
-        exception
-        (try
-          (with-redefs [segred-body/lower
-                        (fn [& _]
-                          (throw (ex-info "simulated portable coverage gap"
-                                          {:reason :segred-kernel-body-declined
-                                           :missing-rule :simulated
-                                           :fallback :none})))]
-            (sg/generate-kernel-graph graph :array-types {'a :double}
-                                      :target-dialect :cuda))
-          nil
-          (catch clojure.lang.ExceptionInfo exception exception))]
-    (is (= :kernel-graph-target-lowering-missing (:reason (ex-data exception))))
-    (is (= :simulated (get-in (ex-data exception)
-                              [:kernel-body-decline :missing-rule])))
-    (is (= :none (:fallback (ex-data exception))))))
+        decline (fn [& _]
+                  (throw (ex-info "simulated portable coverage gap"
+                                  {:reason :segred-kernel-body-declined
+                                   :missing-rule :simulated
+                                   :fallback :none})))]
+    (doseq [target-dialect [:opencl-intel :cuda]]
+      (testing (name target-dialect)
+        (let [exception
+              (try
+                (with-redefs [segred-body/lower decline]
+                  (sg/generate-kernel-graph graph :array-types {'a :double}
+                                            :target-dialect target-dialect))
+                nil
+                (catch clojure.lang.ExceptionInfo exception exception))]
+          (is (= :kernel-graph-target-lowering-missing (:reason (ex-data exception))))
+          (is (= :simulated (get-in (ex-data exception)
+                                    [:kernel-body-decline :missing-rule])))
+          (is (= :none (:fallback (ex-data exception)))))))))
 
 (deftest typed-stencil-emits-a-guarded-typed-artifact
   (let [source '(let* [result
@@ -343,6 +345,30 @@
     (is (= :int (some #(when (= 'offset (:name %)) (:dtype %)) (:abi artifact))))
     (is (re-find #"element_index.* \+ offset" (:source artifact)))
     (is (nil? (get-in artifact [:attributes :kernel-body-decline])))))
+
+(deftest mixed-floating-reduction-arithmetic-is-explicit-typed-ssa
+  (let [form (with-meta
+               '(raster.par/reduce acc 0.0 i n
+                                   (+ acc (* (double scale) (clojure.core/aget a i))))
+               {:raster.type/elem-type :float})
+        node (soac/par-form->soac 'result form 88 :dtype :float)
+        operation (first (lower/lower-reduce node :ze:0 :dtype :float))
+        artifact (sg/generate-segred-kernel
+                  operation nil :dtype :float
+                  :scalar-types {'scale :double 'n :long})
+        loop-body (:operations (first (:operations
+                                       (get-in artifact [:attributes :kernel-body]))))
+        casts (keep (fn [operation]
+                      (let [expression (:expression operation)]
+                        (when (= :cast (:op expression))
+                          [(:result-type expression) (:options expression)])))
+                    loop-body)]
+    (is (= [[:double {:rounding :exact :overflow :exact}]
+            [:float {:rounding :nearest-even :overflow :ieee}]]
+           casts))
+    (is (= :double (some #(when (= 'scale (:name %)) (:kernel-dtype %))
+                         (:abi artifact))))
+    (is (= :kernel-body (get-in artifact [:attributes :emission-route])))))
 
 ;; ================================================================
 ;; Horizontally-fused multi-output SegMap: the SECONDARY output (written

--- a/test/raster/compiler/kernel_call_pipeline_test.clj
+++ b/test/raster/compiler/kernel_call_pipeline_test.clj
@@ -120,7 +120,9 @@
   (let [descriptor (pipeline/compile-gpu-program #'resident-kernel-call-reduce
                                                  :ze:0 :dtype :float)
         step (first (filter #(= :reduce (:convention %)) (:steps descriptor)))
-        runtime-params [(float-array 513) (float-array 513) 0.75 513]
+        workgroup-size (first (get-in step [:artifact :launch :workgroup-size]))
+        n (inc (* 2 workgroup-size))
+        runtime-params [(float-array n) (float-array n) 0.75 n]
         ordered-values
         (mapv (fn [{:keys [kind sym type value-fn]}]
                 (if (= :scalar kind)


### PR DESCRIPTION
Deletes the source-reparsing OpenCL implementation of full scalar reductions. Every C-family target now consumes the same scheduled KernelBody or reports the same structured coverage failure.\n\nCloses the two uncovered typed cases discovered during deletion: mixed floating arithmetic now has explicit widening and narrowing SSA casts with numerical policies, and direct unscheduled full reductions receive an explicit portable 256-lane baseline. The mixed float-storage/double-scalar body is compiled by the CUDA and HIP fixture gates.\n\nFocused validation: 101 tests / 677 assertions, including real Intel GPU integration; nvcc sm_80 PTX and hipcc gfx1100 code object compilation both pass locally. Net removal: 117 lines.