### PR TITLE
Report TypedSOAC source coverage gaps

### DIFF
--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -753,42 +753,74 @@
                   (:outputs %) #{})
                descriptions)))
 
+(defn- supported-description?
+  [physical-outputs description]
+  (case (:kind description)
+    :scalar (or (provably-pure-scalar? (:expr description))
+                (generated-scaffolding? description physical-outputs))
+    :map (or (:pure? description)
+             (and (seq (:result-storage description))
+                  (every? (comp symbol? :destination) (:result-storage description))))
+    :scatter (and (seq (:result-storage description))
+                  (or (= :unique (:conflict description))
+                      (dialect/reducing-scatter-conflict? (:conflict description)))
+                  (every? (comp symbol? :destination) (:result-storage description)))
+    :stencil (and (= 1 (count (:result-storage description)))
+                  (symbol? (get-in description [:result-storage 0 :destination])))
+    :reduce true
+    :segmented-reduce (and (seq (:segment-axes description))
+                           (symbol? (get-in description [:result-storage 0 :destination])))
+    :product-reduce (and (seq (:segment-axes description))
+                         (seq (:result-components description))
+                         (every? (comp symbol? :destination) (:result-storage description)))
+    :segmented-fold-map
+    (and (seq (:segment-axes description)) (seq (:folds description))
+         (every? (comp symbol? :destination) (:result-storage description)))
+    :scan (and (= 1 (count (:result-storage description)))
+               (= (:primary-out description)
+                  (get-in description [:result-storage 0 :destination])))
+    false))
+
 (defn- supported-descriptions?
   [descriptions]
   (let [physical-outputs (physical-output-symbols descriptions)]
-    (every? (fn [description]
-              (case (:kind description)
-                :scalar (or (provably-pure-scalar? (:expr description))
-                            (generated-scaffolding? description physical-outputs))
-                :map (or (:pure? description)
-                         (and (seq (:result-storage description))
-                              (every? (comp symbol? :destination)
-                                      (:result-storage description))))
-                :scatter (and (seq (:result-storage description))
-                              (or (= :unique (:conflict description))
-                                  (dialect/reducing-scatter-conflict?
-                                   (:conflict description)))
-                              (every? (comp symbol? :destination)
-                                      (:result-storage description)))
-                :stencil (and (= 1 (count (:result-storage description)))
-                              (symbol? (get-in description
-                                               [:result-storage 0 :destination])))
-                :reduce true
-                :segmented-reduce (and (seq (:segment-axes description))
-                                       (symbol? (get-in description [:result-storage 0 :destination])))
-                :product-reduce (and (seq (:segment-axes description))
-                                     (seq (:result-components description))
-                                     (every? (comp symbol? :destination)
-                                             (:result-storage description)))
-                :segmented-fold-map
-                (and (seq (:segment-axes description)) (seq (:folds description))
-                     (every? (comp symbol? :destination)
-                             (:result-storage description)))
-                :scan (and (= 1 (count (:result-storage description)))
-                           (= (:primary-out description)
-                              (get-in description [:result-storage 0 :destination])))
-                false))
-            descriptions)))
+    (every? #(supported-description? physical-outputs %) descriptions)))
+
+(defn coverage-decline
+  "Describe the exact source bindings that prevent admission to the closed TypedSOAC subset.
+
+   This is diagnostic evidence only: it uses the same descriptions and admission predicate as
+   form->program, so reporting cannot become a second legality implementation."
+  [source {:keys [dtype values shape-equalities]
+           :or {dtype :double values {} shape-equalities {}}}]
+  (when (and (seq? source) (contains? #{'let 'let*} (first source)))
+    (let [[_ bindings] source
+          pairs (vec (partition 2 bindings))
+          descriptions (normalize-extents (source-descriptions pairs dtype)
+                                          shape-equalities values)
+          physical-outputs (physical-output-symbols descriptions)
+          declined (remove #(supported-description? physical-outputs %) descriptions)
+          parallel? (some #(not= :scalar (:kind %)) descriptions)]
+      (when (and parallel? (seq declined))
+        {:reason :typed-soac-source-coverage
+         :bindings
+         (mapv (fn [{:keys [id sym kind expr]}]
+                 {:id id
+                  :binding sym
+                  :kind kind
+                  :operation (when (seq? expr) (descriptor/semantic-op expr))
+                  :reason (case kind
+                            :unsupported :unsupported-parallel-operation
+                            :scalar :uncertified-host-scalar
+                            :map :unverified-map-effects
+                            :scatter :unverified-scatter-conflict
+                            :stencil :unverified-stencil-storage
+                            :segmented-reduce :unverified-segmented-reduction
+                            :product-reduce :unverified-product-reduction
+                            :segmented-fold-map :unverified-segmented-fold-map
+                            :scan :unverified-scan-storage
+                            :unverified-operation-contract)})
+               declined)}))))
 
 (defn- element-symbols [n] (mapv #(symbol (str "%element" %)) (range n)))
 (defn- capture-symbols [n] (mapv #(symbol (str "%capture" %)) (range n)))

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -474,26 +474,30 @@
    (when (and (seq? form) (contains? #{'let 'let*} (first form)))
      (let [form (frontend/normalize-source form)]
        (try
-         (when-let [typed-input (frontend/form->program
-                                 form {:dtype dtype :array-types array-types
-                                       :scalar-types scalar-types :values values})]
-           (let [[typed-result typed-stats] (fusion/fusion-fixpoint typed-input abstract-machine)
-                 [typed-result resident-stats]
-                 (if resident-reductions?
-                   (resident/realize typed-result)
-                   [typed-result {:resident-reductions 0 :inlined-scalars 0}])]
-             (if (not-any? #(contains? #{:map :scatter :stencil :reduce
-                                         :segmented-reduce :product-reduce
-                                         :segmented-fold-map :scan}
-                                       (:kind (fusion/equation-info %)))
-                           (dialect/equations typed-result))
-               {:declined {:reason :no-certified-parallel-equation
-                           :stats (merge typed-stats resident-stats)}}
-               (let [{:keys [source realized]} (realize-source form typed-result)]
-                 {:program (envelope typed-result source realized)
-                  :stats (merge typed-stats resident-stats
-                                {:route :typed-soac :typed-validated true
-                                 :front-end :analyzed-source})}))))
+         (let [frontend-options {:dtype dtype :array-types array-types
+                                 :scalar-types scalar-types :values values}
+               typed-input (frontend/form->program form frontend-options)]
+           (if-not typed-input
+             (when-let [decline (frontend/coverage-decline form frontend-options)]
+               {:declined decline})
+             (let [[typed-result typed-stats]
+                   (fusion/fusion-fixpoint typed-input abstract-machine)
+                   [typed-result resident-stats]
+                   (if resident-reductions?
+                     (resident/realize typed-result)
+                     [typed-result {:resident-reductions 0 :inlined-scalars 0}])]
+               (if (not-any? #(contains? #{:map :scatter :stencil :reduce
+                                           :segmented-reduce :product-reduce
+                                           :segmented-fold-map :scan}
+                                         (:kind (fusion/equation-info %)))
+                             (dialect/equations typed-result))
+                 {:declined {:reason :no-certified-parallel-equation
+                             :stats (merge typed-stats resident-stats)}}
+                 (let [{:keys [source realized]} (realize-source form typed-result)]
+                   {:program (envelope typed-result source realized)
+                    :stats (merge typed-stats resident-stats
+                                  {:route :typed-soac :typed-validated true
+                                   :front-end :analyzed-source})})))))
          (catch clojure.lang.ExceptionInfo exception
            (when (contains? #{:raster/fatal :raster/bug} (:reason (ex-data exception)))
              (throw exception))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -365,12 +365,20 @@
     (is (= '[y z] (-> hardware-guided :program :equations first :results)))
     (is (= '[y z] (get-in hardware-guided [:program :outputs])))))
 
-(deftest effectful-host-binding-keeps-the-compatibility-route
+(deftest effectful-host-binding-reports-why-it-keeps-the-compatibility-route
   (let [source '(let* [y (raster.par/pmap i n float (* (clojure.core/aget x i) 2.0))
                        side (println y)
                        z (raster.par/pmap j n float (+ (clojure.core/aget y j) 1.0))]
-                      z)]
-    (is (nil? (route/attempt source :float)))))
+                      z)
+        result (route/attempt source :float)]
+    (is (nil? (:program result)))
+    (is (= :typed-soac-source-coverage (get-in result [:declined :reason])))
+    (is (= [{:id 1
+             :binding 'side
+             :kind :scalar
+             :operation 'println
+             :reason :uncertified-host-scalar}]
+           (get-in result [:declined :bindings])))))
 
 (deftest scalar-equations-require-retained-source-type-facts
   (let [source '(let* [n (clojure.core/alength x)


### PR DESCRIPTION
Makes the all-or-nothing TypedSOAC front-end fallback observable. The diagnostic is derived from the same source descriptions and admission predicate as form-to-program, and reports the exact binding, operation family, and missing contract without changing routing.\n\nThis provides the coverage ledger needed to migrate mixed host/parallel programs and eventually delete soac-graph/par-fusion safely.\n\nFocused validation: complete TypedSOAC route suite, 38 tests and 320 assertions.