### PR TITLE
Guard typed fusion across physical effects

### DIFF
--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -263,6 +263,21 @@
          ;; are treated as fresh SSA values and any explicit alias contract declines fusion.
          (empty? (:aliases facts)))))
 
+(defn- reorder-barrier-free?
+  "Whether moving or recomputing work between two equation positions preserves memory order.
+
+   TypedSOAC values are SSA, but physical destination writes are not yet memory SSA. Until read and
+   write footprints participate in dependence analysis, any intervening effect or alias contract
+   is a hard fusion barrier."
+  [program left-index right-index]
+  (let [equations (dialect/equations program)
+        facts (dialect/facts program)]
+    (every? (fn [equation]
+              (let [equation-facts (get-in facts [:equations (second equation)])]
+                (and (empty? (:effects equation-facts))
+                     (empty? (:aliases equation-facts)))))
+            (subvec equations (inc left-index) right-index))))
+
 (declare remove-equation-fact)
 
 (defn- horizontal-boundary
@@ -748,6 +763,7 @@
            :when (= (:extent (:attributes producer)) (:extent (:attributes consumer)))
            :when (pos? (get uses produced 0))
            :when (some #{produced} (:arrays consumer))
+           :when (reorder-barrier-free? program producer-index consumer-index)
            :when (fusible-equation? program (:id producer))
            :when (fusible-equation? program (:id consumer))
            :let [placement-witness (producer-placement-witness
@@ -883,6 +899,7 @@
                                            (:destinations right-boundary)))
            :when (empty? (set/intersection (:destinations left-boundary) right-uses))
            :when (empty? (set/intersection (:destinations right-boundary) left-uses))
+           :when (reorder-barrier-free? program left-index right-index)
            ;; Moving the right equation to the left's position must not move it before an
            ;; intervening producer. Program inputs have no producer index and are always ready.
            :when (every? (fn [value]

--- a/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
@@ -135,6 +135,37 @@
     (is (= program result))
     (is (= {:vertical 0 :horizontal 0 :iterations 1} stats))))
 
+(deftest vertical-fusion-does-not-recompute-a-read-after-an-intervening-write
+  (let [source '(let* [producer (raster.par/pmap i n float
+                                                  (clojure.core/aget x i))
+                       middle (raster.par/map! x j n float
+                                               (+ (clojure.core/aget x j) 1.0))
+                       consumer (raster.par/pmap k n float
+                                                  (* (clojure.core/aget producer k) 2.0))]
+                      consumer)
+        program (frontend/form->program source {:dtype :float :array-types {'x :float}})
+        [result stats] (typed-fusion/fusion-fixpoint program)]
+    (is (= 3 (count (dialect/equations result))))
+    (is (= {:vertical 0 :horizontal 0 :iterations 1} stats))
+    (is (some #{'producer} (flatten (dialect/equations result)))
+        "the consumer must read the value captured before x is mutated")))
+
+(deftest horizontal-fusion-does-not-move-a-read-before-an-intervening-write
+  (let [source '(let* [left (raster.par/pmap i n float
+                                              (+ (clojure.core/aget a i) 1.0))
+                       middle (raster.par/map! x j n float
+                                               (+ (clojure.core/aget x j) 1.0))
+                       right (raster.par/pmap k n float
+                                               (* (clojure.core/aget x k) 2.0))]
+                      [left right])
+        program (frontend/form->program
+                 source {:dtype :float :array-types {'a :float 'x :float}})
+        [result stats] (typed-fusion/fusion-fixpoint program)]
+    (is (= 3 (count (dialect/equations result))))
+    (is (= {:vertical 0 :horizontal 0 :iterations 1} stats))
+    (is (= '[left middle right] (dialect/outputs result))
+        "the effect result remains observable and ordered between the two reads")))
+
 (deftest aliased-equations-decline-unproved-fusion
   (let [legacy-graph (graph/build-fusion-graph (legacy/let-bindings->nodes map-map-pairs))
         program (adapter/legacy-nodes->program (:nodes legacy-graph)


### PR DESCRIPTION
## Summary
- treat intervening physical effects or alias contracts as hard TypedSOAC fusion barriers
- prevent vertical fusion from recomputing pre-mutation reads after an in-place write
- prevent horizontal fusion from moving post-mutation reads before an in-place write

## Verification
- focused mutation regressions: 2 tests, 6 assertions
- TypedSOAC fusion suite: 21 tests, 94 assertions
- full validation delegated to CircleCI