### PR TITLE
Certify scalar types in reduction lowering

### DIFF
--- a/src/raster/compiler/core/inference.clj
+++ b/src/raster/compiler/core/inference.clj
@@ -427,18 +427,8 @@
 ;; Literal type inference
 ;; ================================================================
 
-(def ^:private literal-type-tags
-  ;; Use instance? checks instead of float? (which is true for both Float and Double)
-  [[integer?                       'long]
-   [#(instance? Float %)           'float]
-   [#(instance? Double %)          'double]
-   [string?                        'String]
-   [boolean?                       'boolean]
-   [keyword?                       'clojure.lang.Keyword]
-   [char?                          'char]])
-
 (defn literal-tag [form]
-  (some (fn [[pred tag]] (when (pred form) tag)) literal-type-tags))
+  (types/literal-tag form))
 
 (defn floating-literal-tag
   "Type tag for a literal `form`, narrowing a bare floating (Double) literal to

--- a/src/raster/compiler/core/types.clj
+++ b/src/raster/compiler/core/types.clj
@@ -27,6 +27,23 @@
    'short   Short
    'char    Character})
 
+(defn literal-tag
+  "Primitive source-language tag for a literal value, or nil.
+
+   This is the shared non-contextual fact. Monomorphizing consumers may deliberately narrow a
+   floating literal later, but checked casts and typed scalar IR must start from the source value's
+   own JVM type."
+  [value]
+  (cond
+    (integer? value) 'long
+    (instance? Float value) 'float
+    (instance? Double value) 'double
+    (string? value) 'String
+    (boolean? value) 'boolean
+    (keyword? value) 'clojure.lang.Keyword
+    (char? value) 'char
+    :else nil))
+
 (def primitive-array-info
   "Primitive array type tag -> array class."
   {'doubles (Class/forName "[D")

--- a/src/raster/compiler/core/util.clj
+++ b/src/raster/compiler/core/util.clj
@@ -366,6 +366,25 @@
       (with-meta (apply list children) m)
       (apply list children))))
 
+(defn postwalk-preserving-meta
+  "Bottom-up tree rewrite that preserves metadata on every rebuilt collection.
+
+   Quoted data is opaque. A replacement returned by `f` keeps its own metadata; metadata from the
+   replaced node is not incorrectly transferred onto a semantically different value."
+  [f expression]
+  (letfn [(go [form]
+            (f
+             (cond
+               (and (seq? form) (= 'quote (first form))) form
+               (seq? form) (remake-from form (map go form))
+               (vector? form) (with-meta (mapv go form) (meta form))
+               (map? form) (with-meta
+                             (into (empty form) (map (fn [[k v]] [(go k) (go v)])) form)
+                             (meta form))
+               (set? form) (with-meta (into (empty form) (map go) form) (meta form))
+               :else form)))]
+    (go expression)))
+
 (defn call-head
   "Extract the head symbol from a call expression.
    Handles both direct calls (f x y) and .invk calls (.invk obj x y)."

--- a/src/raster/compiler/core/walker.clj
+++ b/src/raster/compiler/core/walker.clj
@@ -518,6 +518,17 @@
                   rt (or (signature-result-tag head arg-tags)  ; signature first
                          (descriptor/result-tag head arg-tags))]
               (if rt (vary-meta result assoc :raster.type/tag rt) result))
+            ;; Bare scalar arithmetic has already been typed by the central rewritten-form
+            ;; inference used for overload resolution. Retain that result on the analyzed form so
+            ;; TypedSOAC/KernelBody consumers do not reconstruct promotion from operand widths.
+            ;; This adds no operator/type table: descriptor/scalar-op? and infer-rewritten-tag are
+            ;; the existing authoritative classification and typing seam.
+            (and (symbol? head)
+                 (descriptor/scalar-op? head)
+                 (not (descriptor/cast-op? head)))
+            (if-let [rt (inf/infer-rewritten-tag result nil type-env)]
+              (vary-meta result assoc :raster.type/tag rt)
+              result)
             ;; Primitive cast — (double x), (float x), etc.
             (contains? types/primitive-info head)
             (vary-meta result assoc :raster.type/tag head)

--- a/src/raster/compiler/passes/parallel/contraction_body.clj
+++ b/src/raster/compiler/passes/parallel/contraction_body.clj
@@ -127,6 +127,11 @@
         {:keys [operations result]}
         (segred-body/lower-element-operations
          element {:index reduced-index :coordinate reduced-index :dtype dtype
+                  ;; The verified contraction region declares the product result dtype even when
+                  ;; a synthetic surface fixture carries no walker metadata on its outer call.
+                  ;; This fact applies only to the region result; nested scalar calls remain typed
+                  ;; by their own retained source facts.
+                  :declared-result-dtype dtype
                   :arrays (set arrays) :scalars (set scalars)
                   :coordinate-lower element-coordinate-lower
                   :load-predicate active-mask

--- a/src/raster/compiler/passes/parallel/fusion_support.clj
+++ b/src/raster/compiler/passes/parallel/fusion_support.clj
@@ -1,7 +1,7 @@
 (ns raster.compiler.passes.parallel.fusion-support
   "Shared rewrite helpers for parallel fusion passes."
-  (:require [clojure.walk :as walk]
-            [raster.compiler.core.op-descriptor :as descriptor]))
+  (:require [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.util :as util]))
 
 (defn substitute-aget
   "Replace reads of `(aget target-sym idx)` inside `body` with `replacement`.
@@ -14,31 +14,24 @@
 	handles). A consumer that reads a DIFFERENT element — `(aget tmp (+ j 1))`, a
 	transpose, a gather — would be wrongly replaced with the producer's element at the
 	consumer's index. Vertical fusion only fires on same-index elementwise producer→
-	consumer pairs, so no reachable caller violates this today; a real guard must abort
+  consumer pairs, so no reachable caller violates this today; a real guard must abort
 	the whole fusion (declining to substitute would leave a dangling ref to an eliminated
 	buffer), which belongs with the descriptor VALIDATOR (S4). Documented, not yet asserted."
   [body target-sym source-idx target-idx replacement]
-  (walk/postwalk
-   (fn [form]
-     ;; Match both bare (aget target idx) and devirtualized (.invk aget-impl target idx);
-     ;; aget-array-sym unwraps casts + strips ns so it compares against target-sym by name.
-     (if (and (descriptor/aget-call? form)
-              (let [s (descriptor/aget-array-sym form)]
-                (and (symbol? s) (= (name target-sym) (name s)))))
-       (walk/postwalk
-        (fn [inner]
-          (if (= inner source-idx) target-idx inner))
-        replacement)
-       form))
-   body))
+  (let [replacement (util/subst-syms {source-idx target-idx} replacement)]
+    (descriptor/rewrite-aget-reads
+     body
+     (fn [form]
+       ;; Match both bare (aget target idx) and devirtualized (.invk aget-impl target idx);
+       ;; aget-array-sym unwraps casts + strips ns so it compares against target-sym by name.
+       (let [s (descriptor/aget-array-sym form)]
+         (when (and (symbol? s) (= (name target-sym) (name s)))
+           replacement))))))
 
 (defn rewrite-index-sym
   "Rewrite occurrences of `from-idx` to `to-idx` throughout `body`."
   [body from-idx to-idx]
-  (walk/postwalk
-   (fn [form]
-     (if (= form from-idx) to-idx form))
-   body))
+  (util/subst-syms {from-idx to-idx} body))
 
 (defn emit-side-effect-aset
   "Build an `aset` side effect for a secondary horizontally fused output.

--- a/src/raster/compiler/passes/parallel/segred_body.clj
+++ b/src/raster/compiler/passes/parallel/segred_body.clj
@@ -6,11 +6,12 @@
    padding, workgroup scratch, a barrier-separated binary tree, and one partial result per
    workgroup. Scalar expressions become typed SSA operations; target emitters never recover either
    the algorithm or schedule from Clojure source spelling. Unsupported scalar regions decline
-   structurally to the established emitter."
+   explicitly; scheduled graphs have no source-shaped target fallback."
   (:require [raster.compiler.backend.intrinsics :as intrinsics]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.types :as types]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]
@@ -18,13 +19,6 @@
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.parallel.index-expression :as index-expression]
             [raster.compiler.passes.parallel.scalar-region-lower :as scalar-region-lower]))
-
-(def ^:private cast-heads
-  {'byte :byte, 'clojure.core/byte :byte
-   'int :int, 'clojure.core/int :int
-   'long :long, 'clojure.core/long :long
-   'float :float, 'clojure.core/float :float
-   'double :double, 'clojure.core/double :double})
 
 (defn- decline!
   [rule message data]
@@ -37,10 +31,31 @@
   [exception]
   (= :segred-kernel-body-declined (:reason (ex-data exception))))
 
+(defn- retained-expression-dtype
+  "Read the walker/TypedClojure result fact carried by a scalar expression.
+
+   This is intentionally not an inference rule: if a retained tag is present but outside the
+   portable scalar vocabulary, the scheduled reduction declines."
+  [expression]
+  (when (instance? clojure.lang.IObj expression)
+    (when-let [tag (types/sym-type-tag expression)]
+      (or (when (and (keyword? tag) (dtype/known? tag)) (dtype/canon tag))
+          (dtype/dtype-for-scalar-tag tag)
+          (decline! :scalar-result-dtype
+                    "KernelBody reduction cannot project the retained scalar result type"
+                    {:expression expression :retained-tag tag})))))
+
+(defn- source-value-dtype
+  [expression]
+  (or (retained-expression-dtype expression)
+      (when (number? expression)
+        (some-> expression types/literal-tag dtype/dtype-for-scalar-tag))))
+
 (defn- inline-scalar-bindings
   [expression]
   (if (and (seq? expression) (contains? #{'let 'let*} (first expression)))
     (let [[_ bindings & body] expression
+          pairs (vec (partition 2 bindings))
           initializers (vec (take-nth 2 (rest bindings)))]
       (when-not (= 1 (count body))
         (decline! :multi-expression-let
@@ -50,6 +65,14 @@
         (decline! :effectful-scalar-binding
                   "KernelBody scalar reduction cannot inline effectful scalar bindings"
                   {:expression expression}))
+      (doseq [[binding init] pairs
+              :let [binding-dtype (some-> binding types/sym-type-tag
+                                          dtype/dtype-for-scalar-tag)]
+              :when (and binding-dtype (not= binding-dtype (source-value-dtype init)))]
+        (decline! :typed-scalar-binding-conversion
+                  "KernelBody reduction cannot erase a typed scalar binding conversion"
+                  {:binding binding :binding-dtype binding-dtype :initializer init
+                   :initializer-dtype (source-value-dtype init)}))
       (recur (util/subst-syms (util/binding-env bindings) (first body))))
     expression))
 
@@ -57,7 +80,7 @@
   [value]
   (if (and (seq? value)
            (= 2 (count value))
-           (contains? cast-heads (first value))
+           (descriptor/cast-op? (first value))
            (number? (second value)))
     (second value)
     (case value
@@ -150,34 +173,32 @@
         [:nearest-even (if (= :half target) :ieee :exact)])
 
       (and (dtype/fp-dtype? source) (dtype/integral? target))
-      [:toward-zero :saturate]
+      (decline! :checked-scalar-cast
+                "KernelBody reduction cannot preserve a checked floating-to-integral cast"
+                {:source-dtype source :target-dtype target})
 
       (and (dtype/integral? source) (dtype/integral? target))
-      [:exact :wrap]
+      (if (< (dtype/bytes-of source) (dtype/bytes-of target))
+        [:exact :exact]
+        (decline! :checked-scalar-cast
+                  "KernelBody reduction cannot preserve a checked narrowing integral cast"
+                  {:source-dtype source :target-dtype target}))
 
       :else
       (decline! :scalar-cast
                 "KernelBody reduction has no explicit numerical cast policy"
                 {:source-dtype source :target-dtype target}))))
 
-(defn- promoted-dtype
-  [types]
-  (let [types (mapv dtype/canon types)
-        floating (filterv dtype/fp-dtype? types)
-        candidates (if (seq floating) floating types)]
-    (when-not (and (seq candidates) (every? dtype/known? candidates))
-      (decline! :scalar-promotion
-                "KernelBody reduction cannot promote unknown scalar dtypes"
-                {:types types}))
-    (apply max-key dtype/bytes-of candidates)))
-
 (defn lower-element-operations
   "Lower a scalar reduction element into typed SSA. coordinate-lower may translate a verified
    source-level flat array index into KernelBody index arithmetic; without it, this retains the
-   pointwise full-reduction contract. Mixed scalar arithmetic is widened explicitly and the final
-   element is narrowed to the accumulator dtype before it enters the certified monoid."
+   pointwise full-reduction contract. Mixed scalar arithmetic requires the walker/TypedClojure
+   result dtype retained on that expression. The lowered element must already match the certified
+   accumulator dtype; this pass never invents a final narrowing conversion. A typed region owner
+   may provide `declared-result-dtype` for the outer expression only; nested calls still require
+   their own retained facts."
   [expression {:keys [index coordinate dtype arrays scalars scalar-types coordinate-lower
-                      load-predicate load-other]}]
+                      load-predicate load-other declared-result-dtype]}]
   (let [dtype (dtype/canon dtype)
         operations (atom [])
         counter (atom 0)
@@ -197,11 +218,16 @@
                             (body/cast-expression value target rounding overflow))
                            result target)))))
 
-            (lower [expression]
+            (lower [expression declared-dtype]
               (let [expression (inline-scalar-bindings expression)]
                 (cond
                   (number? expression)
-                  {:value (body/literal expression dtype) :dtype dtype}
+                  (if-let [literal-dtype (some-> expression types/literal-tag
+                                                 dtype/dtype-for-scalar-tag)]
+                    {:value (body/literal expression literal-dtype) :dtype literal-dtype}
+                    (decline! :scalar-literal-dtype
+                              "KernelBody reduction requires a primitive numeric literal"
+                              {:expression expression :class (class expression)}))
 
                   (symbol? expression)
                   (if (contains? scalars expression)
@@ -234,16 +260,38 @@
                               :cached)
                              result dtype)))
 
-                  (and (seq? expression) (contains? cast-heads (first expression))
+                  (and (seq? expression) (descriptor/cast-op? (first expression))
                        (= 2 (count expression)))
-                  (cast! (lower (second expression)) (get cast-heads (first expression)))
+                  (let [target (dtype/dtype-for-scalar-tag
+                                (descriptor/cast-result-tag (first expression)))]
+                    ;; Clojure's integral casts are checked. KernelBody can describe a trapping
+                    ;; conversion, but the current C-family emitters intentionally reject it.
+                    ;; Refuse the source construct here instead of silently changing it to the
+                    ;; backend's wrap or saturate conversion.
+                    (when (dtype/integral? target)
+                      (decline! :checked-scalar-cast
+                                "portable reduction lowering cannot yet emit checked integral casts"
+                                {:expression expression :target-dtype target}))
+                    (cast! (lower (second expression) nil) target))
 
                   (seq? expression)
                   (let [operator (intrinsics/canonical (descriptor/semantic-op expression))
                         intrinsic (intrinsics/descriptor operator)
                         arguments (vec (descriptor/call-args expression))
-                        typed-inputs (mapv lower arguments)
-                        result-dtype (promoted-dtype (mapv :dtype typed-inputs))]
+                        retained-dtype (or (retained-expression-dtype expression)
+                                           (some-> declared-dtype dtype/canon))
+                        _ (when-not retained-dtype
+                            (decline! :scalar-result-dtype
+                                      "scalar arithmetic requires its retained walker/TypedClojure result dtype"
+                                      {:expression expression :operator operator}))
+                        typed-inputs (mapv #(lower % nil) arguments)
+                        input-dtypes (mapv :dtype typed-inputs)
+                        result-dtype retained-dtype]
+                    (when (dtype/integral? result-dtype)
+                      (decline! :integral-scalar-arithmetic
+                                "portable reduction value arithmetic requires explicit overflow semantics"
+                                {:expression expression :operator operator
+                                 :result-dtype result-dtype}))
                     (when-not (and intrinsic
                                    (= (:arity intrinsic) (count arguments))
                                    (intrinsics/accepts-scalar-dtype? operator result-dtype)
@@ -263,7 +311,12 @@
                   (decline! :scalar-expression
                             "KernelBody element expression has an unsupported value"
                             {:expression expression :type (type expression)}))))]
-      (let [result (cast! (lower expression) dtype)]
+      (let [result (lower expression declared-result-dtype)]
+        (when-not (= dtype (:dtype result))
+          (decline! :element-result-dtype
+                    "KernelBody reduction element must match its certified accumulator dtype"
+                    {:expression expression :element-dtype (:dtype result)
+                     :accumulator-dtype dtype}))
         {:operations @operations :result (:value result)}))))
 (defn lower
   "Lower an eligible scalar SegRed to one verified portable workgroup-tree KernelBody.
@@ -312,6 +365,10 @@
         (lower-element-operations
          element
          {:index index :coordinate element-index :dtype dtype
+          ;; SegRed's certified scalar region declares the dtype of its outer element value. This
+          ;; authorizes only that result; nested calls still need retained walker/TypedClojure
+          ;; facts in lower-element-operations.
+          :declared-result-dtype dtype
           :arrays (set arrays) :scalars (set scalars)
           :scalar-types (into {} (map (fn [id] [id (scalar-dtype id)])) scalars)
           :coordinate-lower

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -7,7 +7,6 @@
    Once an operation is accepted, all value, effect and provenance facts are made explicit before
    fusion or scheduling sees it."
   (:require [clojure.set :as set]
-            [clojure.walk :as walk]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.types :as types]
@@ -843,7 +842,7 @@
 
 (defn- canonicalize-scalar-folds
   [expression default-dtype]
-  (walk/postwalk
+  (util/postwalk-preserving-meta
    (fn [form]
      (if (par/par-reduce-form? form)
        (let [{:keys [acc init idx bound body elem-type]}
@@ -854,12 +853,14 @@
                          (scan/certify {:acc acc :init init :lambda body} fold-dtype)
                          (catch clojure.lang.ExceptionInfo _ nil)))]
          (if (and (symbol? acc) (symbol? idx) (dialect/scalar-literal? init))
-           (list 'fold
-                 (cond-> {:accumulator acc :index idx :identity init :dtype fold-dtype
-                          :extent bound
-                          :association (if algebra :implementation-defined :ordered)}
-                   algebra (assoc :algebra algebra))
-                 (dialect/lambda-form [acc idx] [body]))
+           (util/remake
+            form
+            'fold
+            (cond-> {:accumulator acc :index idx :identity init :dtype fold-dtype
+                     :extent bound
+                     :association (if algebra :implementation-defined :ordered)}
+              algebra (assoc :algebra algebra))
+            (dialect/lambda-form [acc idx] [body]))
            form))
        form))
    expression))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -67,10 +67,12 @@
 
 (defn- reduction-artifact
   [dialect]
-  (let [form (with-meta
-               '(raster.par/reduce acc 0.0 i n
-                                   (+ acc (* (double scale)
-                                             (clojure.core/aget values i))))
+  (let [product (with-meta
+                  '(* (double scale) (clojure.core/aget values i))
+                  {:raster.type/tag 'double})
+        form (with-meta
+               (list 'raster.par/reduce 'acc 0.0 'i 'n
+                     (list '+ 'acc (list 'float product)))
                {:raster.type/elem-type :float})
         node (soac/par-form->soac 'result form 901 :dtype :float)
         operation (first (soac-lower/lower-reduce node nil :dtype :float))]

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -221,7 +221,8 @@
 
 (deftest opencl-pass-reduce-test
   (testing "par/reduce gets replaced with the ordered registered reduction marker"
-    (let [form '(raster.par/reduce acc 0.0 i n (+ acc (* scale (aget a i))))
+    (let [product (with-meta '(* scale (aget a i)) {:raster.type/tag 'float})
+          form (list 'raster.par/reduce 'acc 0.0 'i 'n (list '+ 'acc product))
           result (opencl-pass/opencl-pass form :device-id :ze:0 :dtype :float
                                           :scalar-types {'scale :float 'n :int})]
       (is (= 1 (:ze-reduces (:stats result))))
@@ -232,7 +233,9 @@
       (is (= '[a output scale _n_bound]
              (mapv :name (:abi (first (:kernels result))))))))
   (testing "reduce-into supplies its resident result at the same ordered ABI slot"
-    (let [form '(raster.par/reduce-into obuf acc 0.0 i n (+ acc (* scale (aget a i))))
+    (let [product (with-meta '(* scale (aget a i)) {:raster.type/tag 'float})
+          form (list 'raster.par/reduce-into 'obuf 'acc 0.0 'i 'n
+                     (list '+ 'acc product))
           result (opencl-pass/opencl-pass form :device-id :ze:0 :dtype :float
                                           :scalar-types {'scale :float 'n :int})]
       (is (= 'raster.gpu.ze-runtime/invoke-registered-reduction-kernel
@@ -242,7 +245,8 @@
              (mapv :name (:abi (first (:kernels result)))))))))
 
 (deftest opencl-pass-full-contraction-reduction-uses-ordered-marker
-  (let [form '(raster.par/contract O [] [[i 8]] (* (aget A i) (aget B i)))
+  (let [product (with-meta '(* (aget A i) (aget B i)) {:raster.type/tag 'float})
+        form (list 'raster.par/contract 'O [] '[[i 8]] product)
         result (opencl-pass/opencl-pass form :device-id :ze:0 :dtype :float)
         kernel (first (:kernels result))]
     (is (= 'raster.gpu.ze-runtime/invoke-registered-reduction-kernel

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -302,8 +302,10 @@
       (is (re-find #"a\[" src)))))
 
 (deftest segred-emits-complete-ordered-typed-abi
-  (let [form (with-meta '(raster.par/reduce acc 0.0 i n
-                                            (+ (float acc) (* scale (clojure.core/aget a i))))
+  (let [product (with-meta '(* scale (clojure.core/aget a i))
+                  {:raster.type/tag 'float})
+        form (with-meta (list 'raster.par/reduce 'acc 0.0 'i 'n
+                              (list '+ (list 'float 'acc) product))
                {:raster.type/elem-type :float})
         s (soac/par-form->soac 'result form 0)
         segred (first (lower/lower-reduce s nil))
@@ -347,9 +349,12 @@
     (is (nil? (get-in artifact [:attributes :kernel-body-decline])))))
 
 (deftest mixed-floating-reduction-arithmetic-is-explicit-typed-ssa
-  (let [form (with-meta
-               '(raster.par/reduce acc 0.0 i n
-                                   (+ acc (* (double scale) (clojure.core/aget a i))))
+  (let [product (with-meta
+                  '(* (double scale) (clojure.core/aget a i))
+                  {:raster.type/tag 'double})
+        form (with-meta
+               (list 'raster.par/reduce 'acc 0.0 'i 'n
+                     (list '+ 'acc (list 'float product)))
                {:raster.type/elem-type :float})
         node (soac/par-form->soac 'result form 88 :dtype :float)
         operation (first (lower/lower-reduce node :ze:0 :dtype :float))
@@ -369,6 +374,45 @@
     (is (= :double (some #(when (= 'scale (:name %)) (:kernel-dtype %))
                          (:abi artifact))))
     (is (= :kernel-body (get-in artifact [:attributes :emission-route])))))
+
+(deftest reduction-scalar-typing-declines-uncertified-language-semantics
+  (let [options {:index 'i :coordinate 'element-index :dtype :float
+                 :arrays #{'a} :scalars #{'scale 'counter}
+                 :scalar-types {'scale :double 'counter :long}}
+        decline (fn [expression]
+                  (try
+                    (segred-body/lower-element-operations expression options)
+                    nil
+                    (catch clojure.lang.ExceptionInfo exception
+                      (ex-data exception))))]
+    (testing "mixed arithmetic needs its retained walker/TypedClojure result fact"
+      (is (= :scalar-result-dtype
+             (:missing-rule
+              (decline '(* scale (clojure.core/aget a i)))))))
+    (testing "even uniform Float operands do not identify clojure.core versus typed arithmetic"
+      (is (= :scalar-result-dtype
+             (:missing-rule
+              (decline '(* (clojure.core/aget a i)
+                           (clojure.core/aget a i)))))))
+    (testing "checked integral casts are not reinterpreted as wrap or saturation"
+      (is (= :checked-scalar-cast (:missing-rule (decline '(int scale)))))
+      (is (= :checked-scalar-cast (:missing-rule (decline '(byte 128))))))
+    (testing "integral value arithmetic waits for an explicit overflow contract"
+      (is (= :integral-scalar-arithmetic
+             (:missing-rule
+              (decline (with-meta '(+ counter 1) {:raster.type/tag 'long}))))))
+    (testing "literal and expression results cannot be silently narrowed to the accumulator"
+      (is (= {:missing-rule :element-result-dtype :element-dtype :double}
+             (select-keys (decline 0.1) [:missing-rule :element-dtype])))
+      (is (= :element-result-dtype
+             (:missing-rule
+              (decline (with-meta '(* scale (clojure.core/aget a i))
+                         {:raster.type/tag 'double}))))))
+    (testing "beta reduction cannot erase a typed local conversion"
+      (let [local (with-meta 'local {:raster.type/tag 'float})]
+        (is (= :typed-scalar-binding-conversion
+               (:missing-rule
+                (decline (list 'let* [local 0.1] (list 'double local))))))))))
 
 ;; ================================================================
 ;; Horizontally-fused multi-output SegMap: the SECONDARY output (written

--- a/test/raster/compiler/core/walker_test.clj
+++ b/test/raster/compiler/core/walker_test.clj
@@ -96,6 +96,15 @@
             [_ init] (first bindings)]
         (is (= 'raster.numeric/+ (:raster.op/original (meta init))))))))
 
+(deftest bare-scalar-arithmetic-retains-the-central-inferred-result-type
+  (let [mixed (wb '(clojure.core/* (double scale) (clojure.core/aget x i))
+                  {'scale 'double 'x 'floats 'i 'long})
+        uniform (wb '(clojure.core/+ left right) {'left 'float 'right 'float})]
+    (is (= 'double (:raster.type/tag (meta mixed))))
+    (is (= 'float (:raster.type/tag (meta uniform))))
+    (is (nil? (:raster.op/original (meta mixed)))
+        "retaining an inferred type does not pretend that a bare core call was devirtualized")))
+
 (deftest walk-nested-let-test
   (testing "nested let bindings are walked"
     (let [walked (wb '(let [a (raster.numeric/+ x y)

--- a/test/raster/compiler/kernel_call_pipeline_test.clj
+++ b/test/raster/compiler/kernel_call_pipeline_test.clj
@@ -19,7 +19,7 @@
 (deftm resident-kernel-call-reduce
   [x :- (Array float) out :- (Array float) scale :- Double n :- Long] :- Void
   (let [sum (raster.par/reduce acc 0.0 i n
-                               (+ acc (* scale (ra/aget x i))))]
+                               (+ acc (float (* scale (ra/aget x i)))))]
     (raster.par/map-void! j n
                           (ra/aset out j (* (ra/aget x j) sum)))))
 

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -40,6 +40,23 @@
     (is (= :analyzed-source
            (get-in (route/attempt source :float {'x :float}) [:stats :front-end])))))
 
+(deftest scalar-result-types-survive-elementization-and-vertical-fusion
+  (let [product (with-meta
+                  '(* (clojure.core/aget x i) 2.0)
+                  {:raster.type/tag 'float})
+        source (list 'let*
+                     (vector 'mapped (list 'raster.par/pmap 'i 'n 'float product)
+                             'total '(raster.par/reduce acc 0.0 j n
+                                                       (+ acc (clojure.core/aget mapped j))))
+                     'total)
+        routed (route/attempt source :float {'x :float})
+        products (filter #(and (seq? %) (= '* (first %)))
+                         (tree-seq coll? seq (get-in routed [:program :equations])))]
+    (is (= 1 (get-in routed [:stats :vertical])))
+    (is (seq products))
+    (is (every? #(= 'float (:raster.type/tag (meta %))) products)
+        "source type proofs remain attached after aget substitution and index rewriting")))
+
 (deftest compound-parallel-extents-become-typed-scalar-ssa
   (let [source '(let* [step (raster.par/map! target i
                                              (clojure.core/* nrows width)

--- a/test/raster/quant/kernels_k_test.clj
+++ b/test/raster/quant/kernels_k_test.clj
@@ -223,7 +223,7 @@
               [padded-in :int] [width :int] [_n_bound :int]]]
            (mapv #(mapv (juxt :name :dtype) (:abi %)) padded-kernels))
         "the adapter changes layout indexing without changing the two-phase Q8_K representation")
-    (is (every? #(re-find #"col < .*width" (:source %)) padded-kernels)
+    (is (every? #(re-find #"col\).*<.*width" (:source %)) padded-kernels)
         "both phases guard dense-row reads and synthesize the padding region")
     (is (= 1 (count projection-kernels)))
     (is (= {:backend :opencl


### PR DESCRIPTION
## Summary
- retain the existing central scalar result inference on analyzed call forms instead of reconstructing promotion in KernelBody lowering
- preserve type metadata through elementization, index rewrites, and scalar-fold canonicalization
- remove operand-width promotion and implicit final narrowing from scalar/product reductions
- type literals from source JVM semantics and decline checked integral casts or integral arithmetic without portable overflow contracts
- let verified contraction regions declare only their outer scalar result dtype; nested calls still require retained facts
- reuse the central cast/literal/type vocabulary instead of private reduction registries

## Correctness cases
- mixed FP arithmetic needs an authoritative result type
- Double elements cannot silently enter Float accumulators without an explicit source cast
- checked FP/integral and narrowing casts do not become saturation or wrap
- typed local beta reduction cannot erase a conversion
- fusion rewrites retain scalar type evidence

## Verification
- 162 focused tests, 933 assertions via the long-lived nREPL
- includes real resident deftm compilation, TypedSOAC routing, contraction scheduling, OpenCL artifact emission, walker/type-flow, and metadata-preserving fusion tests
- full suite and CUDA/HIP fixture gates delegated to CircleCI