### PR TITLE
Distinguish TypedSOAC coverage from compiler failures

### DIFF
--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -21,6 +21,35 @@
    :long ['clojure.core/long-array 'longs 'long]
    :byte ['clojure.core/byte-array 'bytes 'byte]})
 
+(def ^:private source-decline-reasons
+  "Structured exceptions that mean analyzed source is outside the closed TypedSOAC subset.
+
+   Keep this list exact. Before a validated TypedSOAC program exists, incomplete shapes, scalar
+   capture facts, or dialect coverage are honest admission declines. After construction, only the
+   explicit production-subset reason may decline; fusion bugs and unexpected materialization
+   failures must escape."
+  #{:unsupported-scalar-binding
+    :source-value-conflict
+    :scan-dtype-unsupported
+    :scan-not-associative
+    :scan-not-elementwise
+    :scan-element-impure-or-unknown
+    :scan-nonidentity-init
+    :reduction-dtype-unsupported
+    :reduction-not-associative
+    :reduction-not-elementwise
+    :reduction-element-impure-or-unknown
+    :reduction-nonidentity-init
+    :typed-soac-production-subset
+    :typed-soac-stable-read-alias
+    :typed-soac-syntax
+    :typed-soac-unbound-scalar
+    :typed-soac-unknown-value})
+
+(defn- source-decline?
+  [exception]
+  (contains? source-decline-reasons (:reason (ex-data exception))))
+
 (defn- equation-subprogram
   [program equation]
   (let [equation-id (second equation)
@@ -499,8 +528,8 @@
                                   {:route :typed-soac :typed-validated true
                                    :front-end :analyzed-source})})))))
          (catch clojure.lang.ExceptionInfo exception
-           (when (contains? #{:raster/fatal :raster/bug} (:reason (ex-data exception)))
-             (throw exception))
-           {:declined {:reason (or (:reason (ex-data exception)) :typed-soac-route-declined)
-                       :message (.getMessage exception)
-                       :details (ex-data exception)}}))))))
+           (if (source-decline? exception)
+             {:declined {:reason (:reason (ex-data exception))
+                         :message (.getMessage exception)
+                         :details (ex-data exception)}}
+             (throw exception))))))))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -16,6 +16,8 @@
             [raster.compiler.pipeline :as pipeline]
             [raster.compiler.passes.parallel.contract-route :as contract-route]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
+            [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
+            [raster.compiler.passes.parallel.typed-soac-fusion :as fusion]
             [raster.compiler.passes.parallel.typed-soac-route :as route]
             [raster.gpu.dispatch-tuning :as dispatch-tuning]
             [raster.gpu.program-tuning :as program-tuning]))
@@ -388,6 +390,35 @@
     (is (= :unsupported-scalar-binding
            (get-in (route/attempt source :float {'x :float}) [:declined :reason]))
         "the compatibility adapter must not reconstruct a missing TypedClojure result type")))
+
+(deftest route-distinguishes-source-coverage-from-compiler-contradictions
+  (testing "an uncertified recurrence is an explicit source coverage decline"
+    (let [source '(let* [result (raster.par/scan target h 0.0 i n float
+                                                  (Math/tanh
+                                                   (+ h (clojure.core/aget x i))))]
+                         result)]
+      (is (= :scan-not-associative
+             (get-in (route/attempt source :float {'x :float 'target :float})
+                     [:declined :reason])))))
+  (testing "a pre-certificate shape contradiction is an honest admission decline"
+    (with-redefs [frontend/form->program
+                  (fn [& _]
+                    (throw (ex-info "simulated value contradiction"
+                                    {:reason :source-value-conflict})))]
+      (is (= :source-value-conflict
+             (get-in (route/attempt '(let* [x 1] x) :float) [:declined :reason])))))
+  (testing "a contradiction after TypedSOAC construction is never compatibility fallback"
+    (let [source '(let* [result (raster.par/pmap i n float
+                                                  (clojure.core/aget x i))]
+                         result)
+          typed (frontend/form->program source {:dtype :float :array-types {'x :float}})]
+      (with-redefs [frontend/form->program (fn [& _] typed)
+                    fusion/fusion-fixpoint
+                    (fn [& _]
+                      (throw (ex-info "simulated fusion contradiction"
+                                      {:reason :typed-soac-fusion-contradiction})))]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"simulated fusion contradiction"
+                              (route/attempt source :float {'x :float})))))))
 
 (deftest semantic-alength-bounds-normalize-to-the-producing-extent
   (let [source '(let* [^long n (clojure.core/alength x)


### PR DESCRIPTION
## Summary
- whitelist the exact source-analysis exceptions that mean the program is outside TypedSOAC coverage
- preserve explicit declines for unsupported scalar bindings and uncertified scan/reduction recurrences
- rethrow value/effect contradictions, dialect validation failures, fusion failures, and materialization failures

This keeps compatibility routing from hiding compiler correctness defects.

## Verification
- TypedSOAC route suite: 39 tests, 322 assertions
- full validation delegated to CircleCI