### PR TITLE
Fuse typed maps into certified scans

### DIFF
--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -3,7 +3,7 @@
 
    The pattern library recognizes the compact equation grammar. Raster code performs the legality
    checks and fact-table updates explicitly; failed candidates leave the immutable program intact.
-   This first slice covers map→map, map→reduce and horizontal map fusion."
+   This first slice covers map→map, map→reduce, map→scan and horizontal map fusion."
   (:require [clojure.set :as set]
             [pattern.nanopass.dialect :refer [from-dialect]]
             [pattern.r3.core :refer [rule success]]
@@ -262,6 +262,40 @@
          ;; Alias-aware fusion can be added once legality is proved. Until then, equation results
          ;; are treated as fresh SSA values and any explicit alias contract declines fusion.
          (empty? (:aliases facts)))))
+
+(defn- scan-write-boundary
+  "Return the one proven destination of a vertically fusible scan, or nil.
+
+   A scan is functional in its logical result but effectful at its resident buffer boundary.
+   Map→scan fusion keeps that boundary in place; accepting only this exact contract prevents a
+   generic effect exception from weakening fusion legality."
+  [program info]
+  (when (= :scan (:kind info))
+    (let [equation-facts (get-in (dialect/facts program) [:equations (:id info)])
+          storage (vec (get-in equation-facts [:attributes :result-storage]))
+          destination (:destination (first storage))
+          result (first (:results info))]
+      (when (and (= 1 (count (:results info)) (count (:body-results info)) (count storage))
+                 (= #{:memory/write} (:effects equation-facts))
+                 (symbol? destination)
+                 (= [{:destination destination :access :write :host-return :buffer}] storage)
+                 (= {result destination} (:aliases equation-facts))
+                 (= result (get-in equation-facts [:attributes :host-binding])))
+        {:destination destination :storage storage}))))
+
+(defn- vertical-consumer-boundary
+  "Prove the boundary retained at a vertically fused consumer.
+
+   Pure consumers have no physical boundary. Scans retain their exact, single destination write.
+   No other effectful or aliasing consumer is admitted here."
+  [program producer consumer]
+  (or (when (fusible-equation? program (:id consumer)) {:kind :pure})
+      (when-let [boundary (scan-write-boundary program consumer)]
+        (let [destination (:destination boundary)
+              reads (set (concat (:arrays producer) (:captures producer)
+                                 (:arrays consumer) (:captures consumer)))]
+          (when-not (contains? reads destination)
+            (assoc boundary :kind :scan-write))))))
 
 (defn- reorder-barrier-free?
   "Whether moving or recomputing work between two equation positions preserves memory order.
@@ -751,13 +785,13 @@
            :when (= :map (:kind producer))
            :when (= 1 (count (:results producer)))
            :when (= 1 (count (:body-results producer)))
-           :when (contains? #{:map :reduce} (:kind consumer))
+           :when (contains? #{:map :reduce :scan} (:kind consumer))
            ;; Local SSA is currently a map-region facility. A local-bearing producer/consumer can
-           ;; therefore compose vertically into another map; the established local-free
-           ;; map->reduce rule remains available until reduction regions admit typed locals.
+           ;; therefore compose vertically into another map; reduction and scan consumers remain
+           ;; local-free until their regions admit typed locals.
            :when (or (= :map (:kind consumer))
                      (and (empty? (:locals producer)) (empty? (:locals consumer))))
-           :when (or (= :reduce (:kind consumer))
+           :when (or (contains? #{:reduce :scan} (:kind consumer))
                      (and (empty? (:locals producer)) (empty? (:locals consumer)))
                      (some? (value-scalar-dtype program produced)))
            :when (= (:extent (:attributes producer)) (:extent (:attributes consumer)))
@@ -765,7 +799,7 @@
            :when (some #{produced} (:arrays consumer))
            :when (reorder-barrier-free? program producer-index consumer-index)
            :when (fusible-equation? program (:id producer))
-           :when (fusible-equation? program (:id consumer))
+           :when (vertical-consumer-boundary program producer consumer)
            :let [placement-witness (producer-placement-witness
                                     program infos uses producer produced abstract-machine)]]
        {:producer-index producer-index :consumer-index consumer-index
@@ -843,10 +877,12 @@
                          :locals (:locals canonical)
                          :body-results (:body-results canonical))
           updated
-          (if (= :reduce (:kind updated))
+          (if (contains? #{:reduce :scan} (:kind updated))
             (let [{:keys [accumulators identities dtypes]} (:attributes updated)
                   algebra (mapv (fn [accumulator identity component-dtype result]
-                                  (scan/certify-reassociation
+                                  ((if (= :scan (:kind updated))
+                                     scan/certify
+                                     scan/certify-reassociation)
                                    {:acc accumulator :init identity :lambda result}
                                    component-dtype))
                                 accumulators identities dtypes (:body-results updated))]

--- a/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
@@ -60,6 +60,55 @@
     (is (= 'reduce (first (nth (first (dialect/equations typed-result)) 3))))
     (is (not-any? #{'y} (flatten (dialect/equations typed-result))))))
 
+(deftest map-scan-fusion-preserves-the-certified-resident-boundary
+  (doseq [[source mode result-shape]
+          [['(let* [mapped (raster.par/pmap i n float
+                                             (* (clojure.core/aget x i) 2.0))
+                    result (raster.par/scan out acc 0.0 j n float
+                                            (+ acc (clojure.core/aget mapped j)))]
+                   result)
+            :inclusive '[n]]
+           ['(let* [mapped (raster.par/pmap i n float
+                                             (* (clojure.core/aget x i) 2.0))
+                    result (raster.par/scan-exclusive out acc 0.0 j n float
+                                                      (+ acc (clojure.core/aget mapped j)))]
+                   result)
+            :exclusive '[(clojure.core/inc n)]]]]
+    (let [program (frontend/form->program source
+                                          {:dtype :float
+                                           :array-types {'x :float 'out :float}})
+          mapped-id (first (nth (first (dialect/equations program)) 2))
+          [result stats] (typed-fusion/fusion-fixpoint program)
+          equation (first (dialect/equations result))
+          operation (dialect/operation-parts equation)
+          result-id (first (nth equation 2))
+          equation-facts (get-in (dialect/facts result) [:equations (second equation)])]
+      (is (= {:vertical 1 :horizontal 0 :iterations 2} stats))
+      (is (= 1 (count (dialect/equations result))))
+      (is (= 'scan (:kind operation)))
+      (is (= mode (get-in operation [:attributes :mode])))
+      (is (= '[x] (:arrays operation)))
+      (is (= result-shape (get-in (dialect/facts result) [:values result-id :shape])))
+      (is (= #{:memory/write} (:effects equation-facts)))
+      (is (= {result-id 'out} (:aliases equation-facts)))
+      (is (= [{:destination 'out :access :write :host-return :buffer}]
+             (get-in equation-facts [:attributes :result-storage])))
+      (is (not-any? #{mapped-id} (flatten (dialect/equations result))))
+      (is (= result (dialect/validate! result))))))
+
+(deftest map-scan-fusion-declines-an-aliased-destination-read
+  (let [source '(let* [mapped (raster.par/pmap i n float
+                                                (* (clojure.core/aget x i) 2.0))
+                       result (raster.par/scan x acc 0.0 j n float
+                                               (+ acc (clojure.core/aget mapped j)))]
+                      result)
+        program (frontend/form->program source {:dtype :float :array-types {'x :float}})
+        [result stats] (typed-fusion/fusion-fixpoint program)]
+    (is (= program result))
+    (is (= {:vertical 0 :horizontal 0 :iterations 1} stats))
+    (is (= 2 (count (dialect/equations result)))
+        "materializing the map preserves its complete read before the scan mutates x")))
+
 (deftest horizontal-map-fusion-matches-current-graph
   (let [{:keys [legacy-result typed-result typed-stats]}
         (differential-fusion horizontal-map-pairs '[u v])

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -514,6 +514,25 @@
     (is (= 1 (count (:temporaries graph))))
     (parallel-program/validate! scheduled segop/segop-node?)))
 
+(deftest typed-map-scan-fuses-before-the-shared-scan-schedule
+  (let [source '(let* [mapped (raster.par/pmap i n float
+                                                (* (clojure.core/aget x i) 2.0))
+                       result (raster.par/scan out acc 0.0 j n float
+                                               (+ acc (clojure.core/aget mapped j)))]
+                      result)
+        {:keys [program stats]} (route/attempt source :float {'x :float 'out :float})
+        lowered (segop-lower/segop-lower-pass
+                 program {:dtype :float :target-device :ocl:0
+                          :array-types {'x :float 'out :float}})
+        equation (first (:equations (:form lowered)))]
+    (is (= 1 (:vertical stats)))
+    (is (= 1 (count (:equations program))))
+    (is (not-any? #{'mapped} (flatten (:source program))))
+    (is (= 1 (get-in lowered [:stats :kernel-graphs-lowered])))
+    (is (= [:intra-block :block-scan nil]
+           (mapv :phase (:operations equation))))
+    (parallel-program/validate! (:form lowered) segop/segop-node?)))
+
 (deftest typed-inclusive-scan-target-lowers-to-one-executable-dispatch
   (let [typed (:program (route/attempt inclusive-scan :float
                                        {'x :float 'out :float}))


### PR DESCRIPTION
## Summary
- fuse pure TypedSOAC maps into inclusive and exclusive scan regions
- re-certify the transformed scan algebra before rebuilding the program
- preserve the scan's exact resident destination/effect boundary and reject destination-read aliasing
- verify the fused public route reaches the shared scheduled scan graph

## Validation
- 23 fusion tests, 119 assertions
- focused public route/scheduling test
- git diff --check