### PR TITLE
Preserve TypedSOAC islands across host barriers

### DIFF
--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -752,11 +752,16 @@
                   (:outputs %) #{})
                descriptions)))
 
+(defn- contains-parallel-form?
+  [expression]
+  (boolean (some par/par-form? (tree-seq coll? seq expression))))
+
 (defn- supported-description?
   [physical-outputs description]
   (case (:kind description)
-    :scalar (or (provably-pure-scalar? (:expr description))
-                (generated-scaffolding? description physical-outputs))
+    :scalar (and (not (contains-parallel-form? (:expr description)))
+                 (or (provably-pure-scalar? (:expr description))
+                     (generated-scaffolding? description physical-outputs)))
     :map (or (:pure? description)
              (and (seq (:result-storage description))
                   (every? (comp symbol? :destination) (:result-storage description))))
@@ -783,7 +788,12 @@
 (defn- supported-descriptions?
   [descriptions]
   (let [physical-outputs (physical-output-symbols descriptions)]
-    (every? #(supported-description? physical-outputs %) descriptions)))
+    ;; Ordinary host scalar bindings are opaque control/dataflow boundaries around TypedSOAC
+    ;; islands. Unsupported parallel operations still decline: executing those through a second
+    ;; lowering route inside one program would duplicate semantics.
+    (every? #(or (= :scalar (:kind %))
+                 (supported-description? physical-outputs %))
+            descriptions)))
 
 (defn coverage-decline
   "Describe the exact source bindings that prevent admission to the closed TypedSOAC subset.
@@ -1153,16 +1163,22 @@
                         :segmented-fold-map (if (:effect-only? %) [] (:results %))
                         (:outputs %))
                      operations))
+        typed-scalars (filter #(and (= :scalar (:kind %))
+                                    (supported-description? physical-outputs %))
+                              descriptions)
+        host-scalars (filter #(and (= :scalar (:kind %))
+                                   (not (supported-description? physical-outputs %)))
+                             descriptions)
         scalar-definitions
         (set (keep #(when (and (= :scalar (:kind %))
+                               (supported-description? physical-outputs %)
                                (not (generated-scaffolding? % physical-outputs)))
                       (:sym %))
                    descriptions))
         all-definitions (set/union operation-definitions scalar-definitions)
         operation-uses (set (concat (mapcat #(concat (:inputs %) (:scalars %)) operations)
-                                    (mapcat #(when (= :scalar (:kind %))
-                                               (util/free-syms (:expr %)))
-                                            descriptions)))
+                                    (mapcat #(util/free-syms (:expr %)) typed-scalars)))
+        host-uses (set (mapcat #(util/free-syms (:expr %)) host-scalars))
         body-uses (set (mapcat util/free-syms body))
         ;; Destination-writing source forms return the destination buffer, while TypedSOAC names
         ;; the fresh logical result produced by that write. Preserve the public return by
@@ -1186,6 +1202,7 @@
         (into #{} (keep destination-results) body-uses)]
     (vec (sort-by pr-str
                   (set/union (set/difference terminal-operation-definitions operation-uses)
+                             (set/intersection operation-definitions host-uses)
                              (set/intersection all-definitions body-uses)
                              returned-destination-results)))))
 
@@ -1194,6 +1211,7 @@
   (let [physical-outputs (physical-output-symbols descriptions)
         by-symbol (into {}
                         (keep #(when (and (= :scalar (:kind %))
+                                          (supported-description? physical-outputs %)
                                           (not (generated-scaffolding? % physical-outputs)))
                                  [(:sym %) %]))
                         descriptions)
@@ -1317,9 +1335,10 @@
      (assoc values id contract))))
 
 (defn form->program
-  "Construct and validate TypedSOAC directly from a closed let form.
+  "Construct and validate TypedSOAC islands directly from a let form.
 
-   Returns nil when any binding is outside the certified source subset. Type/effect/value
+   Opaque scalar host bindings are retained as ordered barriers around the functional equations.
+   Returns nil when a parallel binding is outside the certified source subset. Type/effect/value
    contradictions throw ExceptionInfo because falling through after accepting them would hide a
    compiler correctness defect."
   [source {:keys [dtype array-types scalar-types values shape-equalities]
@@ -1331,11 +1350,16 @@
                                           shape-equalities values)]
       (when (and (even? (count bindings))
                  (seq descriptions)
+                 (some #(contains? #{:map :scatter :stencil :reduce :segmented-reduce
+                                      :product-reduce :segmented-fold-map :scan}
+                                    (:kind %))
+                       descriptions)
                  (supported-descriptions? descriptions))
         (let [operation-descriptions
               (filterv #(contains? #{:map :scatter :stencil :reduce :segmented-reduce
                                      :product-reduce :segmented-fold-map :scan} (:kind %))
                        descriptions)
+              physical-outputs (physical-output-symbols descriptions)
               operation-equations (mapv #(case (:kind %) :map (map-equation %)
                                                :scatter (scatter-equation %)
                                                :stencil (stencil-equation %)
@@ -1433,9 +1457,17 @@
                                                     (:host-binding description)}))]))
                          equation-descriptions))
               total-effects (reduce set/union #{} (map :effects (vals equation-facts)))
+              host-binding-ids
+              (->> descriptions
+                   (keep #(when (and (= :scalar (:kind %))
+                                     (not (supported-description?
+                                           physical-outputs %)))
+                            (:id %)))
+                   vec)
               facts (dialect/default-program-facts
                      {:values values :inputs inputs :equations equation-facts
                       :effects total-effects
                       :provenance {:front-end :analyzed-source}
-                      :attributes {:source-dialect :closed-clojure}})]
+                      :attributes {:source-dialect :closed-clojure
+                                   :host-binding-ids host-binding-ids}})]
           (dialect/make facts equations outputs))))))

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -312,6 +312,32 @@
                      (empty? (:aliases equation-facts)))))
             (subvec equations (inc left-index) right-index))))
 
+(defn- equation-source-binding-ids
+  [facts equation-id]
+  (let [equation-facts (get-in facts [:equations equation-id])
+        constituents (vals (get-in equation-facts [:attributes :fusion/constituents]))]
+    (into #{}
+          (keep #(get-in % [:provenance :source-binding-id]))
+          (conj (vec constituents) equation-facts))))
+
+(defn- host-barrier-free?
+  "Whether two equations belong to the same certified source island.
+
+   Opaque host bindings remain in ParallelProgram control, not in the functional SOAC dialect.
+   Their source positions are nevertheless compiler facts and prohibit motion, recomputation or
+   fusion across them."
+  [program left right]
+  (let [facts (dialect/facts program)
+        barriers (set (get-in facts [:attributes :host-binding-ids]))]
+    (if (empty? barriers)
+      true
+      (let [positions (set/union (equation-source-binding-ids facts (:id left))
+                                 (equation-source-binding-ids facts (:id right)))]
+        (and (seq positions)
+             (let [lower (apply min positions)
+                   upper (apply max positions)]
+               (not-any? #(< lower % upper) barriers)))))))
+
 (declare remove-equation-fact)
 
 (defn- horizontal-boundary
@@ -535,6 +561,7 @@
                     (value-scalar-dtype program (first (:results consumer))))
            :when (fusible-equation? program (:id producer))
            :when (fusible-equation? program (:id consumer))
+           :when (host-barrier-free? program producer consumer)
            :when transform]
        {:producer-index producer-index :consumer-index consumer-index
         :producer producer :consumer consumer :transform transform}))))
@@ -706,6 +733,7 @@
            :when (empty? (set/intersection
                           #{consumed-destination consumer-destination}
                           (set (map :value (:operands transform)))))
+           :when (host-barrier-free? program producer consumer)
            :when transform]
        {:producer-index producer-index :consumer-index consumer-index
         :producer producer :consumer consumer :transform transform}))))
@@ -798,6 +826,7 @@
            :when (pos? (get uses produced 0))
            :when (some #{produced} (:arrays consumer))
            :when (reorder-barrier-free? program producer-index consumer-index)
+           :when (host-barrier-free? program producer consumer)
            :when (fusible-equation? program (:id producer))
            :when (vertical-consumer-boundary program producer consumer)
            :let [placement-witness (producer-placement-witness
@@ -936,6 +965,7 @@
            :when (empty? (set/intersection (:destinations left-boundary) right-uses))
            :when (empty? (set/intersection (:destinations right-boundary) left-uses))
            :when (reorder-barrier-free? program left-index right-index)
+           :when (host-barrier-free? program left right)
            ;; Moving the right equation to the left's position must not move it before an
            ;; intervening producer. Program inputs have no producer index and are always ready.
            :when (every? (fn [value]

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -1,5 +1,5 @@
 (ns raster.compiler.passes.parallel.typed-soac-route
-  "Production route for the closed TypedSOAC map/scalar/reduction subset.
+  "Production route for certified TypedSOAC islands inside host-controlled programs.
 
    Supported programs are represented and fused in the typed dialect whether or not a fusion
    fires. The resulting functional equations are mechanically projected into the surrounding host
@@ -383,6 +383,8 @@
   [form program]
   (let [[let-head bindings & body] form
         original-pairs (vec (partition 2 bindings))
+        host-binding-ids (set (get-in (dialect/facts program)
+                                      [:attributes :host-binding-ids]))
         realized (mapv #(realize-equation program %) (dialect/equations program))
         by-placement (group-by :placement realized)
         realized-host-symbols
@@ -420,7 +422,8 @@
                ;; allocation. Preserve a defining source binding when one exists; dropping it
                ;; leaves CPU-C/JVM materialization with an unbound destination and also loses a
                ;; resident scratch allocation before GPU extraction.
-               (when (and (contains? host-bindings symbol)
+               (when (and (or (contains? host-bindings symbol)
+                              (contains? host-binding-ids id))
                           (not (contains? realized-host-symbols symbol))
                           (empty? (get by-placement id)))
                  [original-pair])
@@ -493,7 +496,7 @@
 
 (defn attempt
   "Return a typed production ParallelProgram result, an explicit `:declined` result, or nil when
-   the form is outside this closed subset."
+   no parallel binding is in this closed subset."
   ([form dtype]
    (attempt form dtype {}))
   ([form dtype array-types]

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -367,20 +367,60 @@
     (is (= '[y z] (-> hardware-guided :program :equations first :results)))
     (is (= '[y z] (get-in hardware-guided [:program :outputs])))))
 
-(deftest effectful-host-binding-reports-why-it-keeps-the-compatibility-route
+(deftest effectful-host-binding-delimits-certified-typed-islands
   (let [source '(let* [y (raster.par/pmap i n float (* (clojure.core/aget x i) 2.0))
                        side (println y)
                        z (raster.par/pmap j n float (+ (clojure.core/aget y j) 1.0))]
                       z)
-        result (route/attempt source :float)]
-    (is (nil? (:program result)))
-    (is (= :typed-soac-source-coverage (get-in result [:declined :reason])))
-    (is (= [{:id 1
-             :binding 'side
-             :kind :scalar
-             :operation 'println
-             :reason :uncertified-host-scalar}]
-           (get-in result [:declined :bindings])))))
+        {:keys [program stats]} (route/attempt source :float {'x :float})
+        source-pairs (partition 2 (second (:source program)))
+        lowered (segop-lower/segop-lower-pass program {:dtype :float})]
+    (is (= :typed-soac (:dialect program)))
+    (is (= '[y z] (:outputs program))
+        "y crosses the typed/host boundary and therefore remains materialized")
+    (is (nil? (get-in program [:values 'side]))
+        "opaque host values do not pretend to be functional TypedSOAC values")
+    (is (= [1] (get-in program [:attributes :host-binding-ids])))
+    (is (= 2 (count (:equations program))))
+    (is (= 2 (get-in lowered [:stats :typed-soac-reused]))
+        "both sides of the host barrier stay on the shared typed schedule vertical")
+    (is (zero? (:vertical stats))
+        "the dependent maps cannot fuse across an opaque host effect")
+    (is (= '(println y) (some #(when (= 'side (first %)) (second %)) source-pairs)))))
+
+(deftest opaque-host-binding-also-blocks-horizontal-code-motion
+  (let [source '(let* [left (raster.par/pmap i n float
+                                              (+ (clojure.core/aget a i) 1.0))
+                       side (println :between-kernels)
+                       right (raster.par/pmap j n float
+                                               (* (clojure.core/aget b j) 2.0))]
+                      [left right])
+        {:keys [program stats]}
+        (route/attempt source :float {'a :float 'b :float})]
+    (is (= 2 (count (:equations program))))
+    (is (zero? (:horizontal stats)))
+    (is (= [1] (get-in program [:attributes :host-binding-ids])))
+    (is (some #{'println} (flatten (:source program))))))
+
+(deftest scalar-only-host-control-does-not-construct-an-empty-typed-program
+  (is (nil? (route/attempt '(let* [x 1 y (println x)] y) :float))))
+
+(deftest nested-compatibility-parallel-work-is-an-opaque-host-barrier
+  (let [source '(let* [mapped (raster.par/pmap i n double
+                                                (* (clojure.core/aget x i) 2.0))
+                       mean (let* [total (raster.par/reduce
+                                          acc 0.0 j n
+                                          (+ acc (clojure.core/aget mapped j)))]
+                                   (/ total (double n)))]
+                      mean)
+        {:keys [program stats]} (route/attempt source :double {'x :double})]
+    (is (= :typed-soac (:dialect program)))
+    (is (= 1 (count (:equations program))))
+    (is (= '[mapped] (:outputs program))
+        "the typed result consumed by compatibility host work stays materialized")
+    (is (= [1] (get-in program [:attributes :host-binding-ids])))
+    (is (some #{'raster.par/reduce} (flatten (:source program))))
+    (is (:typed-validated stats))))
 
 (deftest scalar-equations-require-retained-source-type-facts
   (let [source '(let* [n (clojure.core/alength x)


### PR DESCRIPTION
## Summary
- admit certified parallel equations even when ordinary host-controlled scalar bindings surround them
- keep opaque host values out of TypedSOAC while retaining their source bindings in order
- record host binding positions as compiler facts and prohibit every fusion family from crossing them
- retain typed values that cross into host control as observable materializations
- keep both islands on the shared typed scheduling vertical

## Validation
- TypedSOAC route suite: 42 tests, 338 assertions
- fusion suite: 23 tests, 119 assertions
- focused two-island SegOp lowering check
- git diff --check