### PR TITLE
Remove legacy SOAC graph scaffolding

### DIFF
--- a/src/raster/compiler/ir/soac.clj
+++ b/src/raster/compiler/ir/soac.clj
@@ -1,22 +1,19 @@
 (ns raster.compiler.ir.soac
-  "SOAC (Second-Order Array Combinators) IR for fusion.
+  "Compatibility SOAC descriptions for direct backend doors.
 
-  Lifts flat let* bindings containing raster.par/* forms into typed
-  SOAC nodes that a dependency graph can reason about. Provides
-  round-trip conversion: par S-expr ↔ SOAC record ↔ par S-expr.
+  Parses individual raster.par/* forms into records consumed by compatibility SegOp lowering.
+  Functional programs and fusion live exclusively in `ir.soac-dialect` (TypedSOAC).
 
   SOAC types mirror Futhark's combinator classification:
     SoacMap     — element-wise parallel map
     SoacReduce  — parallel fold with associative operator
-    SoacScan    — parallel prefix scan (inclusive)
-    ScalarBinding — non-parallel scalar/allocation binding"
+    SoacScan    — parallel prefix scan (inclusive)"
   (:require [raster.compiler.ir.par :as par]
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.form :as form]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
-            [clojure.set :as set]
-            [clojure.walk :as walk]))
+            [clojure.set :as set]))
 
 ;; ================================================================
 ;; SOAC records
@@ -57,11 +54,6 @@
             outputs     ;; #{sym} — output array symbols
             scalars])   ;; #{sym} — free scalars
 
-(defrecord ScalarBinding
-           [id          ;; int
-            sym         ;; symbol
-            expr])      ;; the RHS expression
-
 ;; ================================================================
 (defrecord SoacContract
            [id           ;; int
@@ -87,7 +79,6 @@
 (defn soac-map? [node] (record-kind? "raster.compiler.ir.soac.SoacMap" node))
 (defn soac-reduce? [node] (record-kind? "raster.compiler.ir.soac.SoacReduce" node))
 (defn soac-scan? [node] (record-kind? "raster.compiler.ir.soac.SoacScan" node))
-(defn scalar-binding? [node] (record-kind? "raster.compiler.ir.soac.ScalarBinding" node))
 (defn contract? [node] (record-kind? "raster.compiler.ir.soac.SoacContract" node))
 
 ;; ================================================================
@@ -106,11 +97,8 @@
   scalars: free syms minus inputs, outputs, idx, acc, and operators
 
   INVARIANT: an array symbol written inside the lambda is an array OUTPUT of
-  the SOAC — never a scalar. The structural out slot alone is not enough: a
-  horizontally-fused multi-output map carries its secondary outputs only as
-  side-effect asets in the lambda body (soac->par-form flattens the fused node
-  to a single-out par/map!), so the write-side collection is what keeps them
-  classified as array params when the par form is re-parsed."
+  the compatibility operation—never a scalar. The structural out slot alone
+  is not enough for map bodies that carry secondary side-effect stores."
   [lambda idx-sym out-syms & {:keys [acc-sym]}]
   (let [inputs (collect-aget-arrays lambda)
         written (par/collect-aset-arrays lambda)
@@ -148,17 +136,14 @@
    Unwraps a `do` with one statement and any let* scaffolding the walker emits
    around the write (e.g. `(let* [g (aget gate i)] (aset tmp i …g…))`), inlining
    those bindings into VAL so the returned :value is one flat expression — the
-   same shape a pure map's lambda has, which is what lets the SAME vertical-fusion
-   path inline it downstream. Recognizes bare `aset` and walker-devirtualized
+   same shape as a pure map's lambda. Recognizes bare `aset` and walker-devirtualized
    `(.invk aset-impl …)` via the op-descriptor matchers.
 
    The let* body must be a SINGLE form. A multi-statement let* body
    `(let* [v …] (aset a i v) (aset b i …))` is NOT a single write: modelling it as
-   a SoacMap over `b` DROPPED the store to `a` outright (soac->par-form rebuilds the
-   body from the lambda alone), and the store vanished from the emitted kernel —
-   a silent miscompile, not a missed fusion. Anything with more than one statement
-   returns nil ⇒ ScalarBinding ⇒ the legacy void path, which emits the body as
-   written."
+   a SoacMap over `b` would drop the store to `a` in compatibility lowering. Anything
+   with more than one statement returns nil so the complete source stays on the
+   specialized void path."
   [body idx-sym]
   (let [stmt (if (and (seq? body) (= 'do (first body)) (= 2 (count body)))
                (second body) body)]
@@ -170,8 +155,8 @@
                    ;; PURITY GATE. This inlining duplicates each binding into the lambda, so an
                    ;; effectful init would have its effect duplicated or reordered. The old
                    ;; `postwalk-replace` copy had no gate and rested on an unstated `walker bindings
-                   ;; are SSA` precondition. Refusing here is free: nil ⇒ ScalarBinding ⇒ the legacy
-                   ;; void path, which emits the body as written.
+                   ;; are SSA` precondition. Refusing here preserves the complete source for the
+                   ;; specialized void path.
                    (not-any? util/effectful? (take-nth 2 (rest binds))))
           (when-let [inner (single-aset-void (first lbody) idx-sym)]
             ;; capture-avoiding: an init that rebinds an earlier name internally, or a name that
@@ -303,13 +288,9 @@
 
     ;; Imperative par/map-void! with a SINGLE 1:1 in-place write — model as a
     ;; non-pure (in-place) SoacMap whose OUTPUT is the written array and whose
-    ;; LAMBDA is the written value. This makes it indistinguishable from a pure
-    ;; map for the SOAC fuser: a downstream map reading (aget OUT i) fuses by
-    ;; substituting this value (the existing vertical-fusion path), eliminating
-    ;; the intermediate buffer. :void? round-trips it back to map-void! in
-    ;; soac->par-form, so codegen stays on the (correct) legacy void generator
-    ;; whether or not it fused. Multi-aset / offset-scatter / reduction void
-    ;; bodies return nil here → ScalarBinding → unchanged legacy path.
+    ;; LAMBDA is the written value. This is the narrow compatibility shape that
+    ;; generic SegMap lowering can preserve. Multi-aset, offset-scatter, and reduction
+    ;; bodies return nil and stay on their specialized source-level paths.
     (par/par-map-void-form? expr)
     (let [info (par/extract-par-map-void-info expr)
           idx (:idx info)]
@@ -325,205 +306,15 @@
     :else nil))
 
 ;; ================================================================
-;; SOAC → par S-expression conversion
-;; ================================================================
-
-(defn- stamp-elem-type
-  "Attach :raster.type/elem-type metadata from a SOAC's :elem-type to a form."
-  [form soac]
-  (if-let [et (:elem-type soac)]
-    (vary-meta form assoc :raster.type/elem-type et)
-    form))
-
-(defn soac->par-form
-  "Convert a SOAC record back to a raster.par/* S-expression."
-  [soac]
-  (stamp-elem-type
-   (condp instance? soac
-     ;; a contraction reconstructs to its ORIGINAL surface form — the facts keep it for exactly
-     ;; this dialect boundary (the CPU path round-trips SOAC nodes back to par forms after
-     ;; fusion; before contract was a node it was never round-tripped, so no arm existed)
-     SoacContract
-     (:form (:facts soac))
-
-     SoacMap
-     (cond
-       ;; In-place single-aset void map: reconstruct the imperative write so codegen
-       ;; stays on the legacy void generator (handles normalize + per-array dtype +
-       ;; written-arrays). The lambda is the produced value; re-wrap it in the aset.
-       (:void? soac)
-       (let [out (or (:primary-out soac) (first (:outputs soac)))
-             v (if (:cast-fn soac) (list (:cast-fn soac) (:lambda soac)) (:lambda soac))]
-         (list 'raster.par/map-void! (:idx soac) (:bound soac)
-               (list 'raster.arrays/aset out (:idx soac) v)))
-
-       (:pure? soac)
-       (list 'raster.par/pmap (:idx soac) (:bound soac) (:cast-fn soac) (:lambda soac))
-
-       :else
-       (list 'raster.par/map! (or (:primary-out soac) (first (:outputs soac)))
-             (:idx soac) (:bound soac) (:cast-fn soac) (:lambda soac)))
-
-     SoacReduce
-     (if (= :raster.par/product-reduce! (get-in soac [:reduction :attributes :source]))
-       (list 'raster.par/product-reduce!
-             (reduction/results (:reduction soac))
-             (mapv (fn [component]
-                     [(:accumulator component) (:neutral component) (:dtype component)])
-                   (:components (:reduction soac)))
-             (:segment-axes soac)
-             (:index (:reduction soac)) (:bound soac)
-             (:bindings (reduction/element-region (:reduction soac)))
-             (:results (reduction/element-region (:reduction soac)))
-             (:parameters (reduction/combine-region (:reduction soac)))
-             (:bindings (reduction/combine-region (:reduction soac)))
-             (:results (reduction/combine-region (:reduction soac)))
-             (:algebra (:reduction soac)))
-       (let [{:keys [acc init lambda]} (reduction/scalar-op (:reduction soac))]
-         (list 'raster.par/reduce acc init
-               (:index (:reduction soac)) (:bound soac) lambda)))
-
-     SoacScan
-     (list 'raster.par/scan (:out soac) (:acc soac) (:init soac)
-           (:idx soac) (:bound soac) (:cast-fn soac) (:lambda soac))
-
-     ;; Not a SOAC
-     (throw (ex-info "Cannot convert non-SOAC to par form" {:node soac})))
-   soac))
-
-;; ================================================================
-;; Bulk conversion: let* bindings ↔ SOAC/Scalar nodes
-;; ================================================================
-
-(defn let-bindings->nodes
-  "Convert a sequence of [sym expr] binding pairs to SOAC/Scalar nodes.
-  Each pair gets a sequential id for ordering.
-
-  This compatibility adapter must not turn a legal sequential `par/reduce` fallback into an
-  invalid parallel tree. If the canonical reduction constructor declines reassociation (for
-  example a finite max sentinel rather than the true typed identity), retain the complete source
-  expression as a ScalarBinding. Direct typed routing remains strict and reports its structured
-  decline separately."
-  [pairs]
-  (vec
-   (map-indexed
-    (fn [id [sym expr]]
-      (let [converted
-            (try
-              (par-form->soac sym expr id)
-              (catch clojure.lang.ExceptionInfo exception
-                (if (and (par/par-reduce-form? expr)
-                         (some-> exception ex-data :reason name
-                                 (.startsWith "reduction-")))
-                  nil
-                  (throw exception))))]
-        (or converted (->ScalarBinding id sym expr))))
-    pairs)))
-
-(declare node-all-free-syms node-produced-syms)
-
-(defn- node-full-free-syms
-  "Get ALL free symbols of a node by computing free-syms on its full expression.
-  More robust than node-all-free-syms after fusion modifies lambda bodies."
-  [node]
-  (if (instance? ScalarBinding node)
-    (util/free-syms (:expr node))
-    ;; For SOACs: free-syms of the full par expression + output buffers
-    ;; (outputs must be allocated before the SOAC runs)
-    (let [par-form (soac->par-form node)]
-      (set/union (util/free-syms par-form)
-                 (or (:outputs node) #{})))))
-
-(defn- topological-sort-nodes
-  "Sort nodes respecting data dependencies: a node appears after all nodes
-  that produce symbols it references. Falls back to :id order for nodes
-  with no dependency relationship (preserves original evaluation order)."
-  [nodes-seq]
-  (let [;; Build producer map: each sym → producing node.
-        ;; Use only :sym (the LHS binding) per node, preserving the FIRST
-        ;; producer (lowest :id) when multiple nodes produce the same sym.
-        ;; This ensures allocation ScalarBindings win over SOACs that
-        ;; also claim the output buffer.
-        producer-of (reduce (fn [m node]
-                              (let [sym (:sym node)]
-                                (if (contains? m sym)
-                                  m  ;; keep earliest producer
-                                  (assoc m sym node))))
-                            {} (sort-by :id nodes-seq))
-        ;; Build dependency graph using full expression free-syms.
-        ;; This is robust against fusion modifying lambda bodies (e.g.
-        ;; horizontal fusion adding aset calls for secondary outputs).
-        node-deps (into {}
-                        (map (fn [node]
-                               (let [free (node-full-free-syms node)
-                                     dep-nodes (set (keep producer-of free))]
-                                 [node (disj dep-nodes node)])))
-                        nodes-seq)
-        ;; Kahn's algorithm with :id tiebreaking for stability
-        ;; Start with nodes that have no internal dependencies
-        ready (into (sorted-set-by (fn [a b] (compare (:id a) (:id b))))
-                    (filter #(empty? (get node-deps %)) nodes-seq))
-        remaining-deps (atom node-deps)]
-    (loop [ready ready, result []]
-      (if (empty? ready)
-        (let [leftover (remove (set result) nodes-seq)]
-          (if (empty? leftover)
-            result
-            ;; Cycle or unresolved — append remaining by :id (shouldn't happen)
-            (into result (sort-by :id leftover))))
-        (let [node (first ready)
-              ready' (disj ready node)
-              result' (conj result node)
-              ;; Remove node from all dependency sets; add newly-ready nodes
-              produced (node-produced-syms node)
-              newly-ready
-              (reduce (fn [acc other]
-                        (let [deps (get @remaining-deps other #{})]
-                          (when (contains? deps node)
-                            (swap! remaining-deps update other disj node))
-                          (let [new-deps (disj deps node)]
-                            (if (and (seq deps) (empty? new-deps)
-                                     (not (contains? (set result') other)))
-                              (conj acc other)
-                              acc))))
-                      #{}
-                      nodes-seq)]
-          (recur (into ready' newly-ready) result'))))))
-
-(defn nodes->let-bindings
-  "Convert SOAC/Scalar nodes back to [sym expr] binding pairs.
-  Uses topological sort to respect data dependencies — a binding appears
-  after all bindings it references. Falls back to :id order for nodes
-  with no dependency relationship."
-  [nodes]
-  (let [nodes-seq (vals (if (map? nodes) nodes
-                            (into {} (map (fn [n] [(:id n) n]) nodes))))
-        sorted (topological-sort-nodes nodes-seq)]
-    (mapv (fn [node]
-            (if (instance? ScalarBinding node)
-              [(:sym node) (:expr node)]
-              [(:sym node) (soac->par-form node)]))
-          sorted)))
-
-;; ================================================================
 ;; Predicates and accessors
 ;; ================================================================
-
-(defn soac?
-  "Check if a node is a generic compatibility SOAC (map/reduce/scan) — NOT a ScalarBinding, and NOT a
-   SoacContract (a contraction has its own lowering; generic map/reduce lowering must skip it)."
-  [node]
-  (and (not (scalar-binding? node))
-       ;; a contraction has its own lowering (SegContract) and must NOT enter the generic
-       ;; map/reduce/scan lowering or lambda fusion, whose consumers assume idx/lambda/1-D bound
-       (not (contract? node))))
 
 (defn soac-inputs
   "Get the set of input array symbols for a SOAC node."
   [node]
   (if (contract? node)
     (set (map :sym (:operands (:facts node))))
-    (when (soac? node) (:inputs node))))
+    (:inputs node)))
 
 (defn soac-outputs
   "Get the set of output symbols for a SOAC node."
@@ -536,16 +327,10 @@
       (soac-scan? node)    (:outputs node)
       :else nil)))
 
-(defn soac-bound
-  "Get the iteration bound expression for a SOAC node."
-  [node]
-  (when (soac? node) (:bound node)))
-
 (defn soac-idx
   "Get the index variable for a SOAC node."
   [node]
-  (when (soac? node)
-    (if (soac-reduce? node) (:index (:reduction node)) (:idx node))))
+  (if (soac-reduce? node) (:index (:reduction node)) (:idx node)))
 
 (defn node-all-free-syms
   "Get all free symbols referenced by a node (inputs + outputs + scalars + bound + init).
@@ -553,49 +338,10 @@
   output buffers that must be defined before the SOAC runs. Pure par/map SOACs
   don't have external output buffers — their output IS their binding symbol."
   [node]
-  (if (instance? ScalarBinding node)
-    (util/free-syms (:expr node))
-    (set/union (or (:inputs node) #{})
-               (if (:pure? node) #{} (set (filter symbol? (or (:outputs node) #{}))))
-               (or (:scalars node) #{})
-               (util/free-syms (:bound node))
-               (if (soac-reduce? node)
-                 (reduce set/union #{} (map util/free-syms (reduction/neutrals (:reduction node))))
-                 (if (:init node) (util/free-syms (:init node)) #{})))))
-
-(defn- expr-written-arrays
-  "Arrays written via aset (bare or devirtualized) anywhere in `expr`. Used so a
-   ScalarBinding wrapping a side-effecting void form (a multi-aset par/map-void!
-   like rms-norm/attention/quant-act that doesn't reduce to a single-aset SoacMap)
-   still declares the buffers it produces — otherwise consumers of those buffers
-   get no dependency edge and the scheduler / horizontal-fuser can incorrectly
-   reorder or parallelize across the write (silent miscompile in composed layers).
-
-   KNOWN GAP (silently-ignored-information family, deferred): this sees ONLY aset
-   writes. An op whose output buffer is declared via the op-descriptor :buffer-write
-   registry but that writes with NO literal aset in this expr (a BLAS/GEMM .invk that
-   writes C in place, a runtime scatter) contributes NO producer edge here, so the
-   SOAC topological sort could reorder a consumer ahead of it. The registry DCE now
-   consults IS the right source of truth, but wiring it in here is a non-trivial change
-   (this runs pre-lowering where those ops are still symbolic deftm calls, not the
-   devirtualized .invk the registry keys on). Fixing it belongs with the descriptor
-   VALIDATOR (S4). Until then a genuinely reorderable buffer-write-only op reaching the
-   SOAC scheduler is the outstanding risk — documented, not yet guarded."
-  [expr]
-  (let [w (volatile! #{})]
-    (walk/postwalk
-     (fn [f]
-       (when (descriptor/aset-call? f)
-         (when-let [a (descriptor/aset-array-sym f)] (vswap! w conj a)))
-       f)
-     expr)
-    @w))
-
-(defn node-produced-syms
-  "Get the set of symbols produced (defined) by a node. For a ScalarBinding this
-   is its binding sym PLUS any arrays its expression writes in place (so in-place
-   void writes participate in dependency analysis)."
-  [node]
-  (if (instance? ScalarBinding node)
-    (conj (expr-written-arrays (:expr node)) (:sym node))
-    (set/union #{(:sym node)} (or (soac-outputs node) #{}))))
+  (set/union (or (:inputs node) #{})
+             (if (:pure? node) #{} (set (filter symbol? (or (:outputs node) #{}))))
+             (or (:scalars node) #{})
+             (util/free-syms (:bound node))
+             (if (soac-reduce? node)
+               (reduce set/union #{} (map util/free-syms (reduction/neutrals (:reduction node))))
+               (if (:init node) (util/free-syms (:init node)) #{}))))

--- a/test/raster/compiler/contract_soac_node_test.clj
+++ b/test/raster/compiler/contract_soac_node_test.clj
@@ -7,14 +7,8 @@
    gate (north-star §8) names 'one contraction' travelling the same recorded path as map/reduce.
 
    The node carries `contraction-facts` as its SOLE payload (§10: no second registry). Everything
-   downstream reads the facts; nothing re-derives them. `Dot` — one constructor, a unit test; excluded
-   from lowering, fusion and reconstruction — is the dead representation this replaces.
-
-   Two properties a GPU-only check cannot see, both pinned here: the node must stay OUT of the
-   generic map/reduce lowering and lambda fusion (`soac?`), whose consumers assume idx/lambda/1-D
-   bound; and it must reconstruct to its exact surface form at the dialect boundary, because the
-   CPU path round-trips SOAC nodes back to par forms after fusion — the first draft broke
-   `compile-aot` of every contraction with 'Cannot convert non-SOAC to par form'."
+   downstream reads the facts; nothing re-derives them. `Dot` — one constructor and a unit test —
+   is the dead representation this replaces."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
             [raster.compiler.ir.kernel-artifact :as kart]
@@ -40,16 +34,9 @@
       (is (= '[[l 128]] (:contract-axes (:facts n))))
       (is (= '[A B] (mapv :sym (:operands (:facts n)))))
       (is (reduction/product-reduction? (:reduction (:facts n)))))
-    (testing "graph projections derive from the facts"
+    (testing "compatibility projections derive from the facts"
       (is (= '#{A B} (soac/soac-inputs n)))
-      (is (= '#{C} (soac/soac-outputs n))))
-    (testing "it is NOT a generic SOAC — generic lowering and lambda fusion must skip it"
-      (is (not (soac/soac? n))))))
-
-(deftest the-node-reconstructs-to-its-exact-surface-form
-  (testing "the CPU path round-trips nodes back to par forms after fusion; this arm did not exist
-            and broke compile-aot of every contraction"
-    (is (= cform (soac/soac->par-form (soac/par-form->soac 'c cform 1 :dtype :double))))))
+      (is (= '#{C} (soac/soac-outputs n))))))
 
 (deftest segop-lower-records-a-segcontract-instead-of-declining
   (let [r (slp/segop-lower-pass bound {:target-device :ze:0 :dtype :double})

--- a/test/raster/compiler/core/inline_pure_lets_test.clj
+++ b/test/raster/compiler/core/inline_pure_lets_test.clj
@@ -44,7 +44,7 @@
            (util/inline-pure-lets
             '(let* [a (raster.arrays/aget A i)
                     b (clojure.core/* a 2)]
-               (clojure.core/+ b 1))))))
+                   (clojure.core/+ b 1))))))
   (testing "binding-env exposes the same env for the caller that has already destructured"
     (is (= '{a (raster.arrays/aget A i) b (clojure.core/* (raster.arrays/aget A i) 2)}
            (util/binding-env '[a (raster.arrays/aget A i) b (clojure.core/* a 2)])))))
@@ -55,7 +55,7 @@
     (is (= '(clojure.core/+ 99 1)
            (util/inline-pure-lets
             '(let* [x (raster.arrays/aget A i)]
-               (let* [x 99] (clojure.core/+ x 1)))))))
+                   (let* [x 99] (clojure.core/+ x 1)))))))
   (testing "a name in an ARRAY position is likewise a binder-independent occurrence: substituting
             an array symbol must not be confused with substituting an index"
     (is (= '(raster.arrays/aget A (clojure.core/* 2 4))
@@ -64,7 +64,7 @@
   (testing "a par binder shadowing an inlined name alpha-renames rather than capturing"
     (let [r (util/inline-pure-lets
              '(let* [s (clojure.core/* n 2)]
-                (raster.par/map! O n (fn* [n] (clojure.core/+ n s)))))]
+                    (raster.par/map! O n (fn* [n] (clojure.core/+ n s)))))]
       (is (not= 'n (first (nth (nth r 3) 1)))
           "the fn* binder was renamed, so `s`'s reference to the OUTER n still resolves"))))
 
@@ -158,14 +158,14 @@
                       (catch clojure.lang.ExceptionInfo e
                         (:raster.compiler.backend.gpu.c-emit/bail (ex-data e)))))
           "vec-bail! is the refusal channel the enclosing try already catches")))
-  (testing "the SOAC lowerer returns nil (⇒ ScalarBinding ⇒ legacy void path) for an effectful
+  (testing "the SOAC lowerer returns nil (⇒ specialized void path) for an effectful
             let-wrapped write, instead of duplicating the effect into a SoacMap lambda"
     (let [sav (var-get (requiring-resolve 'raster.compiler.ir.soac/single-aset-void))]
       (is (nil? (sav '(let* [t (raster.arrays/aset SIDE 0 1.0)]
-                        (raster.arrays/aset OUT i t))
+                            (raster.arrays/aset OUT i t))
                      'i)))
       (is (some? (sav '(let* [g (raster.arrays/aget GATE i)]
-                         (raster.arrays/aset OUT i g))
+                             (raster.arrays/aset OUT i g))
                       'i))
           "…and the pure case is still recognized, so fusion is unchanged"))))
 

--- a/test/raster/compiler/fusion_test.clj
+++ b/test/raster/compiler/fusion_test.clj
@@ -369,11 +369,11 @@
 ;; by recursing into the LAST body form. A body with several statements —
 ;;   (let* [v (aget x i)] (aset a i v) (aset b i (* v v)))
 ;; — therefore modelled as a SoacMap whose output is `b` and whose lambda is `(* v v)`;
-;; soac->par-form then REBUILT the body from the lambda alone and the store to `a`
+;; the old graph reconstruction then REBUILT the body from the lambda alone and the store to `a`
 ;; disappeared from the emitted kernel. `a` was not even in the kernel's array list, so
 ;; nothing failed loudly: the buffer just stayed at its initial contents (this is how the
 ;; SFT head's `lse` buffer silently stayed zero). Multi-statement bodies must fall through
-;; to a ScalarBinding, i.e. the legacy void path that emits the body as written.
+;; to the compatibility void path that emits the source body as written.
 
 (deftest multi-store-map-void-is-not-a-single-write-soac
   (testing "two asets in one map-void! body ⇒ NOT modelled as a single-write SoacMap"
@@ -384,17 +384,6 @@
                        (clojure.core/aset b i (float (raster.numeric/* v v)))))]
       (is (nil? (soac/par-form->soac 'out form 0))
           "modelling it as a SoacMap over `b` silently drops the store to `a`")))
-
-  (testing "the multi-store form round-trips through the SOAC graph UNCHANGED"
-    (let [form '(raster.par/map-void!
-                 i (long n)
-                 (let* [v (clojure.core/aget x i)]
-                       (clojure.core/aset a i (float v))
-                       (clojure.core/aset b i (float (raster.numeric/* v v)))))
-          nodes (soac/let-bindings->nodes [['_eff form]])
-          [[_ round-tripped]] (soac/nodes->let-bindings nodes)]
-      (is (= form round-tripped)
-          "the legacy void path must emit the body exactly as written")))
 
   (testing "a SINGLE let*-wrapped write still models as a SoacMap (the fusible shape)"
     (let [form '(raster.par/map-void!

--- a/test/raster/compiler/ir/soac_test.clj
+++ b/test/raster/compiler/ir/soac_test.clj
@@ -63,46 +63,9 @@
     (is (nil? (soac/par-form->soac 'x '(+ 1 2) 0)))))
 
 ;; ================================================================
-;; soac->par-form round-trip
-;; ================================================================
-
-(deftest round-trip-map-test
-  (testing "SoacMap round-trip: par→soac→par"
-    (let [original '(raster.par/map! out i n double (* (aget a i) 2.0))
-          node (soac/par-form->soac 'out original 0)
-          reconstructed (soac/soac->par-form node)]
-      (is (= (first original) (first reconstructed)))
-      (is (= (second original) (second reconstructed)))
-      (is (= (nth original 2) (nth reconstructed 2)))
-      (is (= (nth original 3) (nth reconstructed 3)))
-      (is (= (nth original 4) (nth reconstructed 4)))
-      (is (= (nth original 5) (nth reconstructed 5))))))
-
-(deftest round-trip-reduce-test
-  (testing "SoacReduce round-trip: par→soac→par"
-    (let [original '(raster.par/reduce acc 0.0 j n (+ acc (aget a j)))
-          node (soac/par-form->soac 'result original 0)
-          reconstructed (soac/soac->par-form node)]
-      (is (= 'raster.par/reduce (first reconstructed)))
-      (is (= 'acc (second reconstructed)))
-      (is (= 0.0 (nth reconstructed 2)))
-      (is (= 'j (nth reconstructed 3)))
-      (is (= 'n (nth reconstructed 4))))))
-
-(deftest round-trip-scan-test
-  (testing "SoacScan round-trip: par→soac→par"
-    (let [original '(raster.par/scan out acc 0.0 i n double (+ acc (aget a i)))
-          node (soac/par-form->soac 'out original 0)
-          reconstructed (soac/soac->par-form node)]
-      (is (= 'raster.par/scan (first reconstructed)))
-      (is (= 'out (second reconstructed))))))
-
-;; ================================================================
-;; Written arrays are OUTPUTS, never scalars (the horizontal-fusion
-;; multi-output invariant): soac->par-form flattens a fused multi-output
-;; map to a single-out par/map! whose SECONDARY outputs survive only as
-;; side-effect asets in the lambda — re-parsing that form must classify
-;; them as array outputs or the GPU backend declares them as scalar
+;; Written arrays are OUTPUTS, never scalars. Re-parsing a compatibility
+;; map with side-effect stores must classify secondary destinations as
+;; array outputs or the GPU backend declares them as scalar
 ;; kernel params (`float hfuse_out__N`) and extraction emits an
 ;; unresolvable host reference.
 ;; ================================================================
@@ -131,63 +94,8 @@
       (is (contains? (:outputs node) 'hout2))
       (is (not (contains? (:scalars node) 'hout2))))))
 
-;; ================================================================
-;; let-bindings->nodes / nodes->let-bindings
-;; ================================================================
-
-(deftest let-bindings->nodes-test
-  (testing "Correctly classifies SOAC vs scalar bindings"
-    (let [pairs [['out '(raster.par/map! out i n double (* (aget a i) 2.0))]
-                 ['x '42]
-                 ['result '(raster.par/reduce acc 0.0 j n (+ acc (aget out j)))]]
-          nodes (soac/let-bindings->nodes pairs)]
-      (is (= 3 (count nodes)))
-      (is (instance? raster.compiler.ir.soac.SoacMap (nth nodes 0)))
-      (is (instance? raster.compiler.ir.soac.ScalarBinding (nth nodes 1)))
-      (is (instance? raster.compiler.ir.soac.SoacReduce (nth nodes 2))))))
-
-(deftest nonidentity-reduction-remains-a-sequential-compatibility-binding
-  (let [expression '(raster.par/reduce best finite-sentinel i n
-                      (raster.numeric/max best (raster.arrays/aget values i)))
-        node (first (soac/let-bindings->nodes [['result expression]]))]
-    (is (instance? raster.compiler.ir.soac.ScalarBinding node))
-    (is (= expression (:expr node)))
-    (is (= [['result expression]] (soac/nodes->let-bindings [node])))))
-
-(deftest nodes->let-bindings-roundtrip-test
-  (testing "Round-trip through nodes preserves binding order"
-    (let [pairs [['out '(raster.par/map! out i n double (* (aget a i) 2.0))]
-                 ['x '42]
-                 ['result '(raster.par/reduce acc 0.0 j n (+ acc (aget out j)))]]
-          nodes (soac/let-bindings->nodes pairs)
-          reconstructed (soac/nodes->let-bindings nodes)]
-      (is (= 3 (count reconstructed)))
-      ;; Scalar binding preserved exactly
-      (is (= ['x '42] (nth reconstructed 1)))
-      ;; SOAC types preserved
-      (is (= 'raster.par/map! (first (second (nth reconstructed 0)))))
-      (is (= 'raster.par/reduce (first (second (nth reconstructed 2))))))))
-
-;; ================================================================
-;; Predicates and accessors
-;; ================================================================
-
-(deftest soac?-test
-  (testing "soac? returns true for SOACs, false for ScalarBinding"
-    (let [map-node (soac/par-form->soac 'out
-                                        '(raster.par/map! out i n double (aget a i)) 0)
-          scalar (soac/->ScalarBinding 1 'x '42)]
-      (is (true? (soac/soac? map-node)))
-      (is (false? (soac/soac? scalar))))))
-
 (deftest soac-inputs-test
   (testing "soac-inputs extracts array symbols"
     (let [node (soac/par-form->soac 'out
                                     '(raster.par/map! out i n double (+ (aget a i) (aget b i))) 0)]
       (is (= #{'a 'b} (soac/soac-inputs node))))))
-
-(deftest soac-bound-test
-  (testing "soac-bound extracts iteration bound"
-    (let [node (soac/par-form->soac 'out
-                                    '(raster.par/map! out i len double (aget a i)) 0)]
-      (is (= 'len (soac/soac-bound node))))))


### PR DESCRIPTION
## Outcome

Shrinks `ir.soac` to its actual remaining role: parsing individual parallel forms for explicit compatibility lowering. Functional programs, fusion, dependency ordering, and typed values now live only in TypedSOAC/ParallelProgram.

## What changed

- delete `ScalarBinding`, whole-let graph construction, topological reconstruction, and reverse SOAC-to-source projection
- remove dead generic `soac?`, graph liveness/write helpers, and obsolete round-trip tests
- simplify the compatibility accessors used by `segop-lower-pass`
- retain and test individual map/reduce/scan/contract parsing and compatibility SegOp lowering
- rewrite stale comments that still claimed record-level fusion/reconstruction

## Verification

- 61 affected tests / 242 assertions
- targeted formatting and `git diff --check`
- no remaining `ScalarBinding`, graph conversion, reverse projection, or generic record-fusion references

## Stack

Depends on #301 (and transitively #300).