### PR TITLE
Refuse offset maps in compatibility SOAC lowering

### DIFF
--- a/src/raster/compiler/ir/soac.clj
+++ b/src/raster/compiler/ir/soac.clj
@@ -212,6 +212,13 @@
     ;; Imperative par/map! (with output buffer)
     (par/par-map-form? expr)
     (let [info (par/extract-par-map-info expr)
+          _ (when (:offset info)
+              (throw (ex-info "offset map requires an explicit indexed-store operation"
+                              {:reason :offset-map-requires-indexed-store
+                               :operation 'raster.par/map!
+                               :offset (:offset info)
+                               :target-dialect :typed-soac-scatter
+                               :fallback :scalar-expansion})))
           {:keys [inputs outputs scalars]}
           (extract-io (:body info) (:idx info) [(:out info)])
           elem-type (or (:elem-type info)

--- a/test/raster/compiler/backend/jvm/par_simd_test.clj
+++ b/test/raster/compiler/backend/jvm/par_simd_test.clj
@@ -233,6 +233,18 @@
                      (tree-seq seq? seq form)))
           "No par forms should remain"))))
 
+(deftest offset-map-falls-back-with-correct-destination-indices
+  (testing "a compatibility refusal retains out[base+i] semantics on the JVM"
+    (let [source '(let* [out (double-array [99.0 99.0 99.0 99.0 99.0 99.0])
+                         x (double-array [10.0 11.0 12.0])
+                         base 2
+                         n 3]
+                        (raster.par/map! out i n :offset base double (aget x i)))
+          {:keys [form stats]} (par-simd/simd-pass source :min-elements 0)
+          result (eval form)]
+      (is (= 1 (:fallback stats)))
+      (is (= [99.0 99.0 10.0 11.0 12.0 99.0] (vec result))))))
+
 ;; ================================================================
 ;; From walked deftm body
 ;; ================================================================

--- a/test/raster/compiler/ir/soac_test.clj
+++ b/test/raster/compiler/ir/soac_test.clj
@@ -24,6 +24,18 @@
       ;; n is the bound expression, not in scalars (scalars = free syms of lambda minus inputs/idx)
       (is (not (contains? (:scalars node) 'n))))))
 
+(deftest offset-map-cannot-lose-its-destination-base
+  (testing "the compatibility SoacMap has no indexed-store field, so accepting an offset map would
+            silently turn out[base+i] into out[i]"
+    (try
+      (soac/par-form->soac
+       'out '(raster.par/map! out i n :offset base float (aget x i)) 0)
+      (is false "an offset map must not enter the compatibility SOAC dialect")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :offset-map-requires-indexed-store (:reason (ex-data e))))
+        (is (= 'base (:offset (ex-data e))))
+        (is (= :typed-soac-scatter (:target-dialect (ex-data e))))))))
+
 (deftest par-reduce->soac-test
   (testing "Convert raster.par/reduce to SoacReduce"
     (let [expr '(raster.par/reduce acc 0.0 j n (+ acc (aget a j)))

--- a/test/raster/compiler/segop_boundary_test.clj
+++ b/test/raster/compiler/segop_boundary_test.clj
@@ -84,6 +84,29 @@
         (is (some? (:reason d)) "the missing rule")
         (is (some? (:fallback d)) "and what happens instead — a stated outcome, not an absence")))))
 
+(deftest offset-map-is-refused-before-segop-lowering
+  (let [source '(raster.par/map! out i n :offset base float (aget x i))
+        r (slp/segop-lower-pass
+           (list 'let* ['result source] 'result)
+           {:target-device :ze:0
+            :dtype :float
+            :array-types {'out :float 'x :float}
+            :scalar-types {'n :long 'base :long}})
+        d (first (get-in r [:stats :segops-declined]))]
+    (testing "the middle end records exactly why it cannot represent the write"
+      (is (zero? (get-in r [:stats :segops-lowered])))
+      (is (= :soac (:stage d)))
+      (is (= :offset-map-requires-indexed-store (:reason d))))
+    (testing "the GPU boundary fails loudly instead of emitting an out[i] kernel"
+      (try
+        ((requiring-resolve 'raster.compiler.backend.gpu.opencl-pass/opencl-pass)
+         source :dtype :float :device-id :ze:0 :min-elements 0)
+        (is false "an offset map must remain illegal until typed scatter lowering exists")
+        (catch clojure.lang.ExceptionInfo e
+          (is (= :illegal-op-remains (:reason (ex-data e))))
+          (is (= :offset-map-requires-indexed-store (:missing-rule (ex-data e))))
+          (is (= :none (:fallback (ex-data e)))))))))
+
 (deftest a-fatal-reason-still-escapes
   (testing "a violated invariant is not a missing lowering rule. Recording one as a conversion
             decline would let the pipeline continue on the legacy path with the bug intact — the


### PR DESCRIPTION
Summary:

- reject offset par/map! before compatibility SoacMap can discard its destination base
- preserve correct JVM behavior through scalar expansion
- make the GPU boundary fail with a structured missing-rule diagnostic instead of emitting a prefix write

This is a correctness gate for a confirmed silent miscompile. A future typed unique-scatter operation can replace the refusal without adding an offset field to the compatibility dialect.

Verification: targeted compiler tests pass: 42 tests, 136 assertions, zero failures or errors. Changed files pass formatting and whitespace checks.