### PR TITLE
Reuse scheduled SegRed in typed contraction routing

### DIFF
--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -483,7 +483,7 @@
                   (when bound-sr
                     (try
                       (croute/route-static-typed-contraction-dispatch
-                       typed-algorithm (:id bound-sr) (:schedule bound-sr)
+                       typed-algorithm bound-sr
                        :dtype dtype :tile (:tile schedule) :desc target-desc)
                       (catch clojure.lang.ExceptionInfo exception
                         (let [reason (:reason (ex-data exception))]
@@ -528,7 +528,7 @@
                 (let [r (ensure-contraction-marker-expressible!
                          (if bound-sr
                            (croute/route-typed-contraction
-                            typed-algorithm (:id bound-sr) (:schedule bound-sr)
+                            typed-algorithm bound-sr
                             :dtype dtype :tile (:tile schedule) :desc target-desc)
                            (croute/route-contraction
                             ;; A compatibility equation routes from its verified facts. Without a

--- a/src/raster/compiler/ir/contraction_facts.clj
+++ b/src/raster/compiler/ir/contraction_facts.clj
@@ -133,17 +133,15 @@
 (defn from-components
   "Construct the sole verified contraction-facts value from explicit semantic components.
 
-   `form` is optional provenance/compatibility spelling. When absent it is generated mechanically;
-   no fact is inferred by parsing that spelling. Throws on malformed axes or an unverifiable
-   physical layout declaration."
+   `form` is optional provenance owned only by the source compatibility entry. Typed semantic
+   callers do not manufacture one: a target leaf that still consumes surface syntax must project
+   it explicitly at that leaf boundary. Throws on malformed axes or an unverifiable physical
+   layout declaration."
   [{:keys [out free-axes contract-axes body opts dtype form metadata]
     :or {opts {} dtype :double}}]
-  (let [form (or form (surface-form {:out out :free-axes free-axes
-                                     :contract-axes contract-axes :body body
-                                     :opts opts :metadata metadata}))
-        _ (when-not (symbol? out)
+  (let [_ (when-not (symbol? out)
             (throw (ex-info "contract output must be a symbol" {:reason :malformed-output
-                                                                 :out out})))
+                                                                :out out})))
         _ (when-not (vector? free-axes)
             (throw (ex-info "contract free-axes must be a vector" {:reason :malformed-free-axes})))
         _ (when-not (vector? contract-axes)
@@ -166,26 +164,26 @@
                     (into {} (map-indexed (fn [n [_ e]] [(keyword (str "contract" n)) e])) contract-axes))
         normalized (canonical-reduction-facts out contract-axes body opts dtype)]
     (merge
-     {facts-tag true
-      :form form
-      :out out
-      :free-axes (mapv vec free-axes)
-      :contract-axes (mapv vec contract-axes)
-      :n-free (count free-axes)
-      :n-contract (count contract-axes)
-      :body body
-      :operands terms
+     (cond-> {facts-tag true
+              :out out
+              :free-axes (mapv vec free-axes)
+              :contract-axes (mapv vec contract-axes)
+              :n-free (count free-axes)
+              :n-contract (count contract-axes)
+              :body body
+              :operands terms
       ;; Compatibility projections. New semantic and schedule passes consume :reduction; leaf
       ;; gates still read these until the contraction KernelBody vertical is complete.
-      :combine (get opts :combine '+)
-      :init (get opts :init 0.0)
-      :dtype dtype
-      :out-dtype (get opts :out-dtype)
-      :stages (:stages opts)
-      :epilogue (:epilogue opts)
-      :roles roles
-      :dims dims
-      :opts opts}
+              :combine (get opts :combine '+)
+              :init (get opts :init 0.0)
+              :dtype dtype
+              :out-dtype (get opts :out-dtype)
+              :stages (:stages opts)
+              :epilogue (:epilogue opts)
+              :roles roles
+              :dims dims
+              :opts opts}
+       form (assoc :form form))
      normalized)))
 
 (defn contraction-facts

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -29,6 +29,7 @@
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-launch :as klaunch]
             [raster.compiler.ir.reduction :as reduction]
+            [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as soac-dialect]
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]
             [raster.compiler.passes.parallel.typed-soac-projection :as typed-projection]))
@@ -289,10 +290,10 @@
    consume the same scheduled body vocabulary.  Quantization remains an operand/decode concern,
    not a buffer-ownership or graph-composition concern."
   [contract-form & {:keys [dtype prefer-peak? desc tile epilogue stages operands facts operation-id
-                           candidate-families]
+                           candidate-families scheduled-operation]
                     :or {dtype :half prefer-peak? false}}]
   (let [contract-facts (or facts (cf/contraction-facts contract-form :dtype dtype))
-        contract-form (or contract-form (:form contract-facts))
+        contract-form (or contract-form (:form contract-facts) (cf/surface-form contract-facts))
         _ (when-not (and (cf/facts? contract-facts) contract-form)
             (throw (ex-info "contraction routing requires verified facts and a target spelling"
                             {:reason :contraction-route-input
@@ -394,7 +395,8 @@
       ;; Its launch protocol differs (two phases + a host-side final combine), so the descriptor
       ;; says so with :invoke :reduction rather than pretending it is a 2-D kernel launch.
         (zero? n-free)
-        (let [sr (cl/contract-form->segred contract-form :dtype dtype :facts contract-facts)
+        (let [sr (or scheduled-operation
+                     (cl/contract-form->segred contract-form :dtype dtype :facts contract-facts))
               k (sco/generate-segred-kernel sr out-sym :dtype dtype)
               attrs (:attributes k)
               red-bound (second (first contract-axes))]
@@ -442,7 +444,8 @@
                              :families candidate-families
                              :declines (when (and (= 2 n-free) (= 1 n-contract))
                                          (::declines (tensorize-plan)))})))
-          (let [sr (cl/contract-form->segred contract-form :dtype dtype :facts contract-facts)
+          (let [sr (or scheduled-operation
+                       (cl/contract-form->segred contract-form :dtype dtype :facts contract-facts))
                 portable (contraction-schedule/plan-portable-body contract-facts sr desc)
                 emitted (when (:ok portable)
                           (sco/generate-contraction-kernel-body (:body portable)))
@@ -495,45 +498,92 @@
                        :allowed contraction-families})))
     families))
 
-(defn route-typed-contraction
-  "Route one scheduled scalar TypedSOAC contraction without exposing a source-form or facts adapter
-   to the backend.
+(defn- scheduled-typed-contraction-context
+  "Validate that one scheduled SegRed is the physical schedule for its TypedSOAC equation.
 
-   The validated equation is the semantic input. `schedule` certifies that SegOp scheduling chose
-   the contraction candidate family; this target route then selects and verifies the concrete
-   matrix, register-tiled or portable leaf against the device descriptor. The temporary verified
-   contraction facts remain private to this migration adapter until those leaves accept the typed
-   reduction and operand maps directly."
-  [program operation-id schedule & options]
+   This is the typed semantic/schedule seam. The immutable equation id joins the two dialects;
+   dtype, iteration space, physical operands and result storage are checked here so target routing
+   cannot accept a SegRed borrowed from another equation."
+  [program operation]
   (let [program (soac-dialect/validate! program)
-        schedule (reduction/validate-schedule! schedule)
-        _ (when-not (= :hardware-contraction-candidates (:strategy schedule))
-            (throw (ex-info "typed contraction requires a contraction candidate schedule"
-                            {:reason :typed-contraction-schedule
-                             :operation operation-id :schedule schedule})))
-        families (validated-typed-contraction-families schedule operation-id)
+        _ (when-not (instance? raster.compiler.ir.segop.SegRed operation)
+            (throw (ex-info "typed contraction route requires a scheduled SegRed"
+                            {:reason :typed-contraction-operation :operation operation})))
+        operation-id (:id operation)
         equation (or (some #(when (= operation-id (second %)) %)
                            (soac-dialect/equations program))
                      (throw (ex-info "typed contraction program lacks its scheduled equation"
                                      {:reason :typed-contraction-equation
                                       :operation operation-id})))
         components (typed-projection/segmented-reduce-contract-components program equation)
+        facts (cf/from-components components)
         equation-dtype (:dtype components)
+        expected-space (conj (:free-axes facts) (:flat-contract-axis facts))
+        actual-space (mapv (juxt :name :bound) (get-in operation [:space :dims]))
+        transform-inputs (set (map :sym (get-in facts [:epilogue :operands])))
+        expected-inputs (into transform-inputs (map :sym) (:operands facts))
+        expected-outputs #{(:out facts)}
+        schedule (reduction/validate-schedule! (:schedule operation))]
+    (when-not (= :contraction (:phase operation))
+      (throw (ex-info "typed contraction SegRed has the wrong phase"
+                      {:reason :typed-contraction-phase
+                       :operation operation-id :phase (:phase operation)})))
+    (when-not (= equation-dtype (:dtype operation))
+      (throw (ex-info "typed contraction SegRed dtype disagrees with its equation"
+                      {:reason :typed-contraction-operation-dtype
+                       :operation operation-id :equation-dtype equation-dtype
+                       :operation-dtype (:dtype operation)})))
+    (when-not (= expected-space actual-space)
+      (throw (ex-info "typed contraction SegRed iteration space disagrees with its equation"
+                      {:reason :typed-contraction-space
+                       :operation operation-id :expected expected-space :actual actual-space})))
+    (when-not (and (= expected-inputs (segop/operation-inputs operation))
+                   (= expected-outputs (segop/operation-outputs operation)))
+      (throw (ex-info "typed contraction SegRed storage boundary disagrees with its equation"
+                      {:reason :typed-contraction-storage
+                       :operation operation-id
+                       :expected-inputs expected-inputs
+                       :actual-inputs (segop/operation-inputs operation)
+                       :expected-outputs expected-outputs
+                       :actual-outputs (segop/operation-outputs operation)})))
+    {:program program
+     :operation operation
+     :operation-id operation-id
+     :equation equation
+     :components components
+     :facts facts
+     :dtype equation-dtype
+     :schedule schedule}))
+
+(defn route-typed-contraction
+  "Route one scheduled scalar TypedSOAC contraction from its algorithm and exact SegRed.
+
+   The equation is the semantic input and the supplied SegRed is the already-applied schedule.
+   Target routing selects and verifies the concrete matrix, register-tiled or portable leaf without
+   re-lowering a generated host form into a second SegRed."
+  [program operation & options]
+  (let [{:keys [program operation-id facts dtype schedule]}
+        (scheduled-typed-contraction-context program operation)
+        _ (when-not (= :hardware-contraction-candidates (:strategy schedule))
+            (throw (ex-info "typed contraction requires a contraction candidate schedule"
+                            {:reason :typed-contraction-schedule
+                             :operation operation-id :schedule schedule})))
+        families (validated-typed-contraction-families schedule operation-id)
         options (apply hash-map options)
         _ (when (and (contains? options :dtype)
-                     (not= equation-dtype (:dtype options)))
+                     (not= dtype (:dtype options)))
             (throw (ex-info "typed contraction route dtype disagrees with its equation"
                             {:reason :typed-contraction-dtype
                              :operation operation-id
-                             :equation-dtype equation-dtype
+                             :equation-dtype dtype
                              :route-dtype (:dtype options)})))
-        facts (cf/from-components components)
         routed (try
                  (apply route-contraction nil
                         (mapcat identity
                                 (assoc options
-                                       :dtype equation-dtype
+                                       :dtype dtype
                                        :facts facts
+                                       :scheduled-operation operation
                                        :candidate-families families
                                        :operation-id operation-id)))
                  (catch clojure.lang.ExceptionInfo exception
@@ -579,15 +629,16 @@
    reported as failures. Different physical ABIs are permitted here because offline compile-time
    selection measures each candidate independently; a runtime KernelDispatch requires a later
    common-interface normalization."
-  [program operation-id schedule & options]
-  (let [schedule (reduction/validate-schedule! schedule)
+  [program operation & options]
+  (let [operation-id (:id operation)
+        schedule (reduction/validate-schedule! (:schedule operation))
         families (validated-typed-contraction-families schedule operation-id)
         results
         (mapv
          (fn [family]
            (let [pinned (assoc-in schedule [:tuning-space :families] [family])]
              (try
-               (-> (apply route-typed-contraction program operation-id pinned options)
+               (-> (apply route-typed-contraction program (assoc operation :schedule pinned) options)
                    (assoc :family family)
                    (assoc :candidate-schedule pinned)
                    (update :declines #(candidate-declines family %)))
@@ -610,9 +661,9 @@
 
 (defn route-typed-contraction-candidates!
   "Emit typed contraction candidates or fail when no enabled family has a legal target leaf."
-  [program operation-id schedule & options]
+  [program operation & options]
   (let [result (apply route-typed-contraction-candidates
-                      program operation-id schedule options)]
+                      program operation options)]
     (if (seq (:candidates result))
       result
       (throw (ex-info "no executable typed contraction candidates"
@@ -786,10 +837,12 @@
    portable kernels can therefore compete through the existing KernelDispatch tuning machinery.
    Runtime-dependent private dimensions are refused until they have a common public ABI rather
    than silently baking one sample."
-  [program operation-id schedule & options]
-  (let [{:keys [candidates] :as routed}
+  [program operation & options]
+  (let [operation-id (:id operation)
+        schedule (reduction/validate-schedule! (:schedule operation))
+        {:keys [candidates] :as routed}
         (apply route-typed-contraction-candidates!
-               program operation-id schedule options)
+               program operation options)
         candidates (mapv #(static-private-scalars! % operation-id) candidates)
         {:keys [abi arguments]} (common-logical-interface candidates operation-id)
         default-strategy (:strategy (first candidates))

--- a/src/raster/compiler/passes/parallel/contraction_body.clj
+++ b/src/raster/compiler/passes/parallel/contraction_body.clj
@@ -8,6 +8,7 @@
   (:require [clojure.set :as set]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.layout :as layout]
+            [raster.compiler.core.util :as util]
             [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.contraction-facts :as facts]
             [raster.compiler.ir.kernel-body :as body]
@@ -60,8 +61,20 @@
         result-region (scalar-region-lower/make-region result-transform)
         transform-operands (vec (:operands result-transform))
         transform-scalars (vec (:scalars result-transform))
-        arrays (vec (sort-by name (:inputs segred)))
-        scalars (vec (sort-by name (:scalars segred)))
+        core-operand-ids (set (map :sym (:operands contract-facts)))
+        axes (concat (:free-axes contract-facts) (:contract-axes contract-facts))
+        axis-indices (set (map first axes))
+        core-symbols (reduce set/union #{}
+                             (map util/free-syms
+                                  (conj (mapv second axes) (:body contract-facts))))
+        core-scalar-ids (set/difference core-symbols core-operand-ids axis-indices
+                                        #{(:out contract-facts)})
+        ;; The scheduled TypedSOAC operation exposes its complete physical boundary, including
+        ;; result-transform captures. Core contraction loads and epilogue loads have different
+        ;; layout/dtype rules, so partition those roles from the verified facts instead of
+        ;; rebuilding a narrower SegRed from a generated host form.
+        arrays (vec (sort-by name (set/intersection (:inputs segred) core-operand-ids)))
+        scalars (vec (sort-by name (set/intersection (:scalars segred) core-scalar-ids)))
         transform-only-operands
         (filterv #(not (contains? (set arrays) (:sym %))) transform-operands)
         transform-only-scalars

--- a/test/raster/compiler/ir/contraction_facts_test.clj
+++ b/test/raster/compiler/ir/contraction_facts_test.clj
@@ -56,10 +56,11 @@
                                     :roles :dims :opts :dtype])))
     (is (= (select-keys (cf/scalar-reduction-view parsed) [:neutral :combine :dtype])
            (select-keys (cf/scalar-reduction-view components) [:neutral :combine :dtype])))
-    (is (= (:form components)
-           (cf/surface-form {:out 'out :free-axes '[[i 4] [j 6]]
-                             :contract-axes '[[blk 4] [t 32]] :body body
-                             :opts (array-map :init 0 :combine 'clojure.core/+)})))))
+    (is (nil? (:form components))
+        "typed semantic facts do not carry a generated compatibility program")
+    (is (= (form :init 0 :combine 'clojure.core/+)
+           (cf/surface-form components))
+        "a remaining compatibility leaf projects syntax explicitly at its own boundary")))
 
 (deftest a-stage-list-cannot-supply-the-axes-it-is-checked-against
   (testing "the form's contract axes are independent of its :stages — the two are separate slots,
@@ -128,7 +129,7 @@
       (is (= :layout (:reason (cf/check-layout nt (:dpas cf/leaf-layouts))))))
     (testing "the two rows differ ONLY in the col operand's axis order"
       (is (= [:free0 :contract0] (get-in cf/leaf-layouts [:dpas :row])
-                                 (get-in cf/leaf-layouts [:dp4a :row])))
+             (get-in cf/leaf-layouts [:dp4a :row])))
       (is (= [:contract0 :free1] (get-in cf/leaf-layouts [:dpas :col])))
       (is (= [:free1 :contract0] (get-in cf/leaf-layouts [:dp4a :col]))))))
 
@@ -149,7 +150,7 @@
     (let [three (cf/contraction-facts
                  (list 'raster.par/contract 'C [['i 4] ['j 6]] [['l 8]]
                        (list 'raster.numeric/* (list 'aget 'A 'l) (list 'aget 'B 'l)
-                                               (list 'aget 'D 'l))))]
+                             (list 'aget 'D 'l))))]
       (is (= :operand-count (:reason (cf/check-layout three (:dpas cf/leaf-layouts)))))))
   (testing "check-layout refuses a hand-built map — it requires real facts"
     (is (thrown? clojure.lang.ExceptionInfo

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -14,6 +14,7 @@
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.pipeline :as pipeline]
+            [raster.compiler.passes.parallel.contract-lower :as contract-lower]
             [raster.compiler.passes.parallel.contract-route :as contract-route]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.typed-soac-frontend :as frontend]
@@ -25,7 +26,7 @@
 (defn- scalar-stores
   [artifact]
   (filterv #(= "raster.compiler.ir.kernel_body.ScalarStore"
-                (.getName (class %)))
+               (.getName (class %)))
            (get-in artifact [:attributes :kernel-body :operations])))
 
 (def ^:private map-map
@@ -51,7 +52,7 @@
                                                        (clojure.core/aget x i)))))
           mapped (raster.par/pmap j n float (* (clojure.core/aget shared j) 2.0))
           reduced (raster.par/reduce acc 0.0 k n
-                                      (+ acc (clojure.core/aget shared k)))]
+                                     (+ acc (clojure.core/aget shared k)))]
          [mapped reduced]))
 
 (deftest production-route-retains-hardware-costed-placement-witnesses
@@ -259,14 +260,14 @@
   (let [source '(let* [result
                        (raster.par/map! out i n float
                                         (loop* [j 0 acc (float 0.0)]
-                                          (if (< (long j) (long width))
-                                            (let* [value
-                                                   (clojure.core/aget
-                                                    x (+ (* (long i) (long width))
-                                                         (long j)))]
-                                              (recur (inc (long j))
-                                                     (+ (float acc) (float value))))
-                                            acc)))]
+                                               (if (< (long j) (long width))
+                                                 (let* [value
+                                                        (clojure.core/aget
+                                                         x (+ (* (long i) (long width))
+                                                              (long j)))]
+                                                       (recur (inc (long j))
+                                                              (+ (float acc) (float value))))
+                                                 acc)))]
                       result)
         typed (:program
                (route/attempt source :float {'x :float 'out :float}
@@ -390,10 +391,10 @@
 
 (deftest opaque-host-binding-also-blocks-horizontal-code-motion
   (let [source '(let* [left (raster.par/pmap i n float
-                                              (+ (clojure.core/aget a i) 1.0))
+                                             (+ (clojure.core/aget a i) 1.0))
                        side (println :between-kernels)
                        right (raster.par/pmap j n float
-                                               (* (clojure.core/aget b j) 2.0))]
+                                              (* (clojure.core/aget b j) 2.0))]
                       [left right])
         {:keys [program stats]}
         (route/attempt source :float {'a :float 'b :float})]
@@ -407,11 +408,11 @@
 
 (deftest nested-compatibility-parallel-work-is-an-opaque-host-barrier
   (let [source '(let* [mapped (raster.par/pmap i n double
-                                                (* (clojure.core/aget x i) 2.0))
+                                               (* (clojure.core/aget x i) 2.0))
                        mean (let* [total (raster.par/reduce
                                           acc 0.0 j n
                                           (+ acc (clojure.core/aget mapped j)))]
-                                   (/ total (double n)))]
+                                  (/ total (double n)))]
                       mean)
         {:keys [program stats]} (route/attempt source :double {'x :double})]
     (is (= :typed-soac (:dialect program)))
@@ -434,9 +435,9 @@
 (deftest route-distinguishes-source-coverage-from-compiler-contradictions
   (testing "an uncertified recurrence is an explicit source coverage decline"
     (let [source '(let* [result (raster.par/scan target h 0.0 i n float
-                                                  (Math/tanh
-                                                   (+ h (clojure.core/aget x i))))]
-                         result)]
+                                                 (Math/tanh
+                                                  (+ h (clojure.core/aget x i))))]
+                        result)]
       (is (= :scan-not-associative
              (get-in (route/attempt source :float {'x :float 'target :float})
                      [:declined :reason])))))
@@ -449,8 +450,8 @@
              (get-in (route/attempt '(let* [x 1] x) :float) [:declined :reason])))))
   (testing "a contradiction after TypedSOAC construction is never compatibility fallback"
     (let [source '(let* [result (raster.par/pmap i n float
-                                                  (clojure.core/aget x i))]
-                         result)
+                                                 (clojure.core/aget x i))]
+                        result)
           typed (frontend/form->program source {:dtype :float :array-types {'x :float}})]
       (with-redefs [frontend/form->program (fn [& _] typed)
                     fusion/fusion-fixpoint
@@ -587,7 +588,7 @@
 
 (deftest typed-map-scan-fuses-before-the-shared-scan-schedule
   (let [source '(let* [mapped (raster.par/pmap i n float
-                                                (* (clojure.core/aget x i) 2.0))
+                                               (* (clojure.core/aget x i) 2.0))
                        result (raster.par/scan out acc 0.0 j n float
                                                (+ acc (clojure.core/aget mapped j)))]
                       result)
@@ -741,9 +742,9 @@
 
 (deftest typed-horizontal-fusion-combines-distinct-materialized-write-boundaries
   (let [source '(let* [u (raster.par/map! u-out i n float
-                                           (* (clojure.core/aget a i) 2.0))
+                                          (* (clojure.core/aget a i) 2.0))
                        v (raster.par/map! v-out j n float
-                                           (+ (clojure.core/aget b j) 1.0))]
+                                          (+ (clojure.core/aget b j) 1.0))]
                       [u v])
         {:keys [program stats]}
         (route/attempt source :float
@@ -840,9 +841,9 @@
 (deftest typed-contraction-schedule-view-retains-body-scalars
   (let [source
         '(let* [step (raster.par/contract C [[i m] [j n]] [[l k]]
-                       (* alpha
-                          (clojure.core/aget A (+ (* i k) l))
-                          (clojure.core/aget B (+ (* l n) j))))]
+                                          (* alpha
+                                             (clojure.core/aget A (+ (* i k) l))
+                                             (clojure.core/aget B (+ (* l n) j))))]
                step)
         {:keys [form]}
         (pipeline/schedule-parallel-form
@@ -857,8 +858,8 @@
 (deftest gpu-emission-consumes-the-scheduled-typed-contraction
   (let [source
         '(let* [step (raster.par/contract C [[i m] [j n]] [[l k]]
-                       (* (clojure.core/aget A (+ (* i k) l))
-                          (clojure.core/aget B (+ (* l n) j))))]
+                                          (* (clojure.core/aget A (+ (* i k) l))
+                                             (clojure.core/aget B (+ (* l n) j))))]
                step)
         {:keys [form stats]}
         (pipeline/schedule-parallel-form
@@ -870,23 +871,32 @@
         directly-routed
         (with-redefs [contraction-facts/contraction-facts
                       (fn [& _]
-                        (throw (ex-info "typed routing reparsed source" {})))]
+                        (throw (ex-info "typed routing reparsed source" {})))
+                      contract-lower/contract-form->segred
+                      (fn [& _]
+                        (throw (ex-info "typed routing rebuilt its scheduled SegRed" {})))]
           (contract-route/route-typed-contraction
-           algorithm (:id operation) (:schedule operation)
+           algorithm operation
            :dtype :float :desc {}))
         candidate-routes
         (with-redefs [contraction-facts/contraction-facts
                       (fn [& _]
-                        (throw (ex-info "candidate routing reparsed source" {})))]
+                        (throw (ex-info "candidate routing reparsed source" {})))
+                      contract-lower/contract-form->segred
+                      (fn [& _]
+                        (throw (ex-info "candidate routing rebuilt its scheduled SegRed" {})))]
           (contract-route/route-typed-contraction-candidates!
-           algorithm (:id operation) (:schedule operation)
+           algorithm operation
            :dtype :float :desc {}))
         emitted
         (with-redefs [contraction-facts/contraction-facts
                       (fn [& _]
-                        (throw (ex-info "typed emission reparsed source" {})))]
+                        (throw (ex-info "typed emission reparsed source" {})))
+                      contract-lower/contract-form->segred
+                      (fn [& _]
+                        (throw (ex-info "typed emission rebuilt its scheduled SegRed" {})))]
           (opencl-pass/opencl-pass form :device-id :ocl:0
-                                     :dtype :float :min-elements 0))]
+                                   :dtype :float :min-elements 0))]
     (is (= :typed-soac (:source-dialect stats)))
     (is (instance? raster.compiler.ir.segop.SegRed operation))
     (is (= :contraction (:phase operation)))
@@ -899,7 +909,7 @@
                   (:declines candidate-routes)))
     (try
       (contract-route/route-static-typed-contraction-dispatch
-       algorithm (:id operation) (:schedule operation)
+       algorithm operation
        :dtype :float :desc {})
       (is false "a static dispatch must not bake runtime-dependent contraction dimensions")
       (catch clojure.lang.ExceptionInfo exception
@@ -907,29 +917,35 @@
                (:reason (ex-data exception))))))
     (try
       (contract-route/route-typed-contraction
-       algorithm (:id operation) (:schedule operation) :dtype :double :desc {})
+       algorithm operation :dtype :double :desc {})
       (is false "a route dtype that disagrees with the typed equation must fail")
       (catch clojure.lang.ExceptionInfo exception
         (is (= :typed-contraction-dtype (:reason (ex-data exception))))))
     (try
       (contract-route/route-typed-contraction
-       algorithm (:id operation) (assoc (:schedule operation) :strategy :workgroup-tree)
+       algorithm (assoc operation :phase :segmented) :dtype :float :desc {})
+      (is false "a SegRed from another scheduled phase must fail the typed seam")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :typed-contraction-phase (:reason (ex-data exception))))))
+    (try
+      (contract-route/route-typed-contraction
+       algorithm (assoc operation :schedule (assoc (:schedule operation) :strategy :workgroup-tree))
        :dtype :float :desc {})
       (is false "a non-contraction reduction schedule must fail")
       (catch clojure.lang.ExceptionInfo exception
         (is (= :typed-contraction-schedule (:reason (ex-data exception))))))
     (try
       (contract-route/route-typed-contraction
-       algorithm (:id operation)
-       (assoc-in (:schedule operation) [:tuning-space :families] [:matrix])
+       algorithm (assoc operation :schedule
+                        (assoc-in (:schedule operation) [:tuning-space :families] [:matrix]))
        :dtype :float :desc {})
       (is false "a pinned family that cannot lower the equation must fail")
       (catch clojure.lang.ExceptionInfo exception
         (is (= :no-legal-contraction-family (:reason (ex-data exception))))))
     (try
       (contract-route/route-typed-contraction-candidates!
-       algorithm (:id operation)
-       (assoc-in (:schedule operation) [:tuning-space :families] [:matrix])
+       algorithm (assoc operation :schedule
+                        (assoc-in (:schedule operation) [:tuning-space :families] [:matrix]))
        :dtype :float :desc {})
       (is false "candidate enumeration must fail when every enabled family declines")
       (catch clojure.lang.ExceptionInfo exception
@@ -951,8 +967,8 @@
 (deftest typed-contraction-schedule-families-control-leaf-selection
   (let [source
         '(let* [step (raster.par/contract C [[i 128] [j 128]] [[l 128]]
-                       (* (clojure.core/aget A (+ (* i 128) l))
-                          (clojure.core/aget B (+ (* l 128) j))))]
+                                          (* (clojure.core/aget A (+ (* i 128) l))
+                                             (clojure.core/aget B (+ (* l 128) j))))]
                step)
         {:keys [form]}
         (pipeline/schedule-parallel-form
@@ -966,16 +982,16 @@
         select-family
         (fn [family]
           (contract-route/route-typed-contraction
-           algorithm (:id operation)
-           (assoc-in (:schedule operation) [:tuning-space :families] [family])
+           algorithm (assoc operation :schedule
+                            (assoc-in (:schedule operation) [:tuning-space :families] [family]))
            :dtype :half :desc descriptor))
         candidates
         (contract-route/route-typed-contraction-candidates!
-         algorithm (:id operation) (:schedule operation)
+         algorithm operation
          :dtype :half :desc descriptor)
         dispatch
         (contract-route/route-static-typed-contraction-dispatch
-         algorithm (:id operation) (:schedule operation)
+         algorithm operation
          :dtype :half :desc descriptor)
         alternatives (:alternatives dispatch)
         emitted (with-redefs [hardware/descriptor-for (constantly descriptor)]
@@ -1042,8 +1058,8 @@
     (with-redefs [contract-route/route-contraction (fn [& _] {:strategy :full-reduce})]
       (try
         (contract-route/route-typed-contraction
-         algorithm (:id operation)
-         (assoc-in (:schedule operation) [:tuning-space :families] [:matrix])
+         algorithm (assoc operation :schedule
+                          (assoc-in (:schedule operation) [:tuning-space :families] [:matrix]))
          :dtype :half :desc descriptor)
         (is false "a routed leaf outside the pinned schedule family must be rejected")
         (catch clojure.lang.ExceptionInfo exception
@@ -1053,8 +1069,8 @@
     (doseq [families [[] [:unknown]]]
       (try
         (contract-route/route-typed-contraction
-         algorithm (:id operation)
-         (assoc-in (:schedule operation) [:tuning-space :families] families)
+         algorithm (assoc operation :schedule
+                          (assoc-in (:schedule operation) [:tuning-space :families] families))
          :dtype :half :desc descriptor)
         (is false "an empty or unknown candidate family must fail")
         (catch clojure.lang.ExceptionInfo exception
@@ -1071,8 +1087,8 @@
         contract (apply list
                         (concat
                          '(raster.par/contract C [[i 128] [j 128]] [[l 128]]
-                           (* (clojure.core/aget A (+ (* i 128) l))
-                              (clojure.core/aget B (+ (* l 128) j))))
+                                               (* (clojure.core/aget A (+ (* i 128) l))
+                                                  (clojure.core/aget B (+ (* l 128) j))))
                          [:epilogue transform]))
         source (list 'let* ['step contract] 'step)
         {:keys [form stats]}
@@ -1086,8 +1102,9 @@
                     :grf-bytes-per-lane 256 :subgroup-size 16
                     :max-workgroup-size 1024 :shared-local-memory 131072}
         routed (contract-route/route-typed-contraction
-                algorithm (:id operation)
-                (assoc-in (:schedule operation) [:tuning-space :families] [:matrix])
+                algorithm (assoc operation :schedule
+                                 (assoc-in (:schedule operation)
+                                           [:tuning-space :families] [:matrix]))
                 :dtype :half :desc descriptor)
         emitted (with-redefs [hardware/descriptor-for (constantly descriptor)]
                   (opencl-pass/opencl-pass form :device-id :ocl:0


### PR DESCRIPTION
Summary:

- route typed contractions from the validated TypedSOAC algorithm and its exact scheduled SegRed
- validate equation identity, phase, dtype, iteration space, storage boundary, and schedule at the dialect seam
- stop typed ContractionFacts from carrying a generated compatibility form
- partition core contraction operands from epilogue captures without rebuilding the scheduled reduction
- migrate direct routing, candidate enumeration, static dispatch, and OpenCL emission to the unified entry

The production tests redefine contract-form-to-segred to throw, proving that typed routing no longer constructs a second physical schedule.

Verification:

- focused contraction regression set: 128 tests, 900 assertions, zero failures or errors
- typed route suite after final seam assertion: 43 tests, 345 assertions, zero failures or errors
- changed files pass formatting and whitespace checks