### PR TITLE
Lower offset maps as typed unique scatters

### DIFF
--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -324,21 +324,30 @@
           elem-type (dtype/canon (or elem-type
                                      (dtype/dtype-for-scalar-tag cast)
                                      default-dtype))
-          io (extract-io body idx [out])]
-      ;; Offset maps are not pointwise in the result coordinate and require an indexed/scatter
-      ;; operation in the typed dialect. A binder with the same spelling as the caller-owned
-      ;; destination also needs distinct value/view identity before it can be SSA. A pointwise read
-      ;; of the destination is an explicit read/write operand; scheduling must retain it as one
-      ;; physical inout value rather than manufacturing separate aliased input/output pointers.
-      (when-not (or offset (= symbol out))
-        (merge {:kind :map :id id :sym symbol :results [symbol]
-                :index idx :extent bound :locals [] :casts [cast] :bodies [body]
-                :result-storage [{:destination out
-                                  :access (if (contains? (:inputs io) out) :read-write :write)
-                                  :host-return :buffer}]
-                :host-binding symbol
-                :elem-type elem-type}
-               io)))
+          write-index (when offset (list 'clojure.core/+ offset idx))
+          io (extract-io (if offset (list 'do write-index body) body) idx [out])]
+      ;; A binder with the same spelling as the caller-owned destination needs distinct value/view
+      ;; identity before it can be SSA. Every other offset map is an injective partial write:
+      ;; destination[base+i] is a typed unique scatter, not a map carrying an emitter-only offset.
+      ;; The destination is read/write because elements outside the slice remain observable.
+      (when-not (= symbol out)
+        (if offset
+          (merge {:kind :scatter :id id :sym symbol :results [symbol]
+                  :index idx :extent bound :locals [] :casts [cast] :bodies [body]
+                  :write-indices [write-index] :predicates [1] :conflict :unique
+                  :result-storage [{:destination out :access :read-write
+                                    :host-return :buffer}]
+                  :host-binding symbol :elem-type elem-type
+                  :source-operation :raster.par/map-offset}
+                 io)
+          (merge {:kind :map :id id :sym symbol :results [symbol]
+                  :index idx :extent bound :locals [] :casts [cast] :bodies [body]
+                  :result-storage [{:destination out
+                                    :access (if (contains? (:inputs io) out) :read-write :write)
+                                    :host-return :buffer}]
+                  :host-binding symbol
+                  :elem-type elem-type}
+                 io))))
 
     (par/par-stencil-form? expression)
     (let [{:keys [out in-arrays radius boundary cast idx bound body elem-type]}
@@ -1351,8 +1360,8 @@
       (when (and (even? (count bindings))
                  (seq descriptions)
                  (some #(contains? #{:map :scatter :stencil :reduce :segmented-reduce
-                                      :product-reduce :segmented-fold-map :scan}
-                                    (:kind %))
+                                     :product-reduce :segmented-fold-map :scan}
+                                   (:kind %))
                        descriptions)
                  (supported-descriptions? descriptions))
         (let [operation-descriptions

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -161,6 +161,26 @@
                                   {:scalar-types {'n :long}})
                    [:stats :front-end])))))
 
+(deftest offset-map-is-an-injective-typed-scatter
+  (let [source '(let* [result
+                       (raster.par/map! out i n :offset base float
+                                        (clojure.core/aget src i))]
+                      result)
+        program (frontend/form->program
+                 source {:dtype :float
+                         :array-types {'src :float 'out :float}
+                         :scalar-types {'n :long 'base :long}})
+        equation (first (dialect/equations program))
+        operation (dialect/operation-parts equation)
+        write (dialect/write-parts
+               (first (:body-results (dialect/lambda-parts (:lambda operation)))))]
+    (is (= 'scatter (:kind operation)))
+    (is (= :unique (get-in operation [:attributes :conflict])))
+    (is (= '(clojure.core/+ %capture0 i) (:destination-index write)))
+    (is (= '[src base out] (dialect/operation-inputs equation)))
+    (is (= [{:destination 'out :access :read-write :host-return :buffer}]
+           (dialect/result-storage program (second equation))))))
+
 (deftest typed-map-reduce-and-scatter-lower-without-compatibility-records
   (let [map-program
         (frontend/form->program

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -167,6 +167,37 @@
                    (tree-seq coll? seq (:form emitted))))
         "an OpenCL program must not leak a Level Zero staging call")))
 
+(deftest offset-map-routes-as-typed-unique-scatter
+  (let [source '(let* [result
+                       (raster.par/map! out i n :offset base float
+                                        (clojure.core/aget x i))]
+                      result)
+        {:keys [form stats]}
+        (pipeline/schedule-parallel-form
+         source {:target-device :ocl:0 :dtype :float
+                 :array-types {'x :float 'out :float}
+                 :scalar-types {'n :long 'base :long}})
+        equation (first (:equations form))
+        operation (first (:operations equation))
+        emitted (opencl-pass/opencl-pass form :device-id :ocl:0
+                                         :dtype :float :min-elements 0)
+        artifact (first (:kernels emitted))
+        jvm (par-simd/simd-pass form :min-elements 1)
+        execute (eval (list 'fn '[out x n base] (:form jvm)))
+        out (float-array [99.0 99.0 99.0 99.0 99.0 99.0])
+        result (execute out (float-array [10.0 11.0 12.0]) 3 2)]
+    (is (= :typed-soac (:source-dialect stats)))
+    (is (instance? raster.compiler.ir.segop.SegMap operation))
+    (is (= :unique (:write-conflict operation)))
+    (is (= :read-write (get-in equation [:attributes :result-storage 0 :access])))
+    (is (re-find #"out_\[\(base \+ idx\)\]" (:source artifact))
+        "the scheduled GPU store retains destination[base+i]")
+    (is (some #{'base} (:arguments artifact)))
+    (is (= 1 (get-in emitted [:stats :segop-reused])))
+    (is (nil? (get-in emitted [:stats :segop-relowered])))
+    (is (identical? out result))
+    (is (= [99.0 99.0 10.0 11.0 12.0 99.0] (mapv double result)))))
+
 (deftest tuple-map-deduplicates-a-read-write-physical-result
   (let [source '(raster.par/map-void!
                  i n


### PR DESCRIPTION
Summary:

- classify destination base plus iteration index as a proof-carrying unique scatter in TypedSOAC
- keep the partial destination as one read-write physical value
- preserve base as a typed scalar ABI argument
- lower the same scheduled scatter to OpenCL and the JVM without using the compatibility SOAC parser

This is the positive replacement for PR #303's correctness refusal: the old record path still rejects an unrepresentable offset, while the production typed path now emits destination[base+i] correctly.

Verification:

- frontend, typed route, and compiler boundary suites: 78 tests, 546 assertions, zero failures or errors
- numerical JVM sentinel preserves the untouched prefix and suffix
- emitted OpenCL source contains the base-indexed store and reuses the scheduled SegMap
- changed files pass formatting and whitespace checks