### PR TITLE
Lower strided gathers through typed maps

### DIFF
--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -287,10 +287,10 @@
         (reducing-scatter-description id symbol out vals keys n op default-dtype)))
 
     ;; A flat gather is semantically an ordinary dense map with one pointwise index input and one
-    ;; stable, indirectly-read data input.  Keep it in that small functional vocabulary; the JVM
+    ;; stable, indirectly-read data input. Keep it in that small functional vocabulary; the JVM
     ;; scheduler may later select hardware vgather from the typed scalar region, while GPU targets
-    ;; consume the same SegMap.  The strided spelling needs a two-dimensional iteration space (or
-    ;; an explicitly hoisted product extent), so it remains outside this first exact migration.
+    ;; consume the same SegMap. normalize-source has already expressed a strided gather as the
+    ;; corresponding flattened map with one hoisted product extent.
     (par/par-gather-form? expression)
     (let [{:keys [out src index n stride]} (par/extract-par-gather-info expression)]
       (when-not stride
@@ -616,6 +616,34 @@
     (when position
       (with-meta (apply list (assoc (vec expression) position extent)) (meta expression)))))
 
+(defn- canonicalize-strided-gather
+  "Express a strided gather in the existing one-dimensional functional map algebra.
+
+   The flattened coordinate is split into row/component indices inside the scalar region. The
+   ordinary compound-extent normalization below then gives n*stride one stable scalar SSA value.
+   This keeps storage layout in index expressions instead of introducing an attention- or
+   gather-specific semantic operation."
+  [ordinal expression]
+  (if-let [{:keys [out src index n stride]}
+           (when (par/par-gather-form? expression)
+             (par/extract-par-gather-info expression))]
+    (if stride
+      (let [flat-index (clojure.core/symbol (str "rstr_gather_flat_" ordinal))
+            row-index (list 'clojure.core/quot flat-index stride)
+            component (list 'clojure.core/rem flat-index stride)
+            source-index (list 'clojure.core/+
+                               (list 'clojure.core/*
+                                     (list 'clojure.core/aget index row-index)
+                                     stride)
+                               component)]
+        (with-meta
+          (list 'raster.par/map! out flat-index
+                (list 'clojure.core/* n stride) nil
+                (list 'clojure.core/aget src source-index))
+          (meta expression)))
+      expression)
+    expression))
+
 (defn normalize-source
   "Give pure compound parallel extents stable scalar SSA identities before dialect construction.
 
@@ -629,7 +657,8 @@
           {:keys [normalized]}
           (reduce
            (fn [{:keys [compound-extents] :as state} [ordinal [symbol expression]]]
-             (let [extent (parallel-extent expression)
+             (let [expression (canonicalize-strided-gather ordinal expression)
+                   extent (parallel-extent expression)
                    canonical-extent (some-> extent descriptor/unwrap-int-cast)]
                (cond
                  (nil? extent)

--- a/test/raster/compiler/passes/parallel/typed_gather_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_gather_test.clj
@@ -1,6 +1,7 @@
 (ns raster.compiler.passes.parallel.typed-gather-test
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
+            [clojure.walk :as walk]
             [raster.compiler.backend.gpu.opencl-pass :as opencl-pass]
             [raster.compiler.backend.jvm.par-simd :as par-simd]
             [raster.compiler.ir.segop :as segop]
@@ -12,11 +13,15 @@
   '(let* [step (raster.par/gather out src idx n)]
          step))
 
+(def ^:private strided-source
+  '(let* [step (raster.par/gather out src idx n stride)]
+         step))
+
 (def ^:private array-types
   {'out :float 'src :float 'idx :int})
 
 (def ^:private scalar-types
-  {'n :long})
+  {'n :long 'stride :long})
 
 (defn- scheduled-program []
   (let [{:keys [program]} (route/attempt source :float array-types
@@ -67,3 +72,56 @@
       (is (= [:int :float :float :int] (mapv :dtype (:abi kernel))))
       (is (str/includes? kernel-source "src[idx[idx_0]]"))
       (is (not (str/includes? kernel-source "src[idx[idx]]"))))))
+
+(deftest strided-gather-is-a-flattened-typed-map
+  (let [{:keys [program stats]} (route/attempt strided-source :float array-types
+                                               {:scalar-types scalar-types})
+        scalar-equation (first (:equations program))
+        map-equation (second (:equations program))
+        algorithm (:algorithm map-equation)
+        operation (-> algorithm dialect/equations first dialect/operation-parts)
+        body (-> operation :lambda dialect/lambda-parts :body-results first)]
+    (is (= :typed-soac (:dialect program)))
+    (is (= :analyzed-source (:front-end stats)))
+    (is (= 'scalar (-> scalar-equation :algorithm dialect/equations first
+                       dialect/operation-parts :kind)))
+    (is (= 'map (:kind operation)))
+    (is (= (first (:results scalar-equation))
+           (get-in operation [:attributes :extent])))
+    (is (some #{'clojure.core/quot} (flatten body)))
+    (is (some #{'clojure.core/rem} (flatten body)))
+    (is (not-any? #{'raster.par/gather}
+                  (tree-seq coll? seq (:source program))))))
+
+(deftest strided-gather-reuses-one-schedule-across-jvm-and-gpu
+  (let [{:keys [program]} (route/attempt strided-source :float array-types
+                                         {:scalar-types scalar-types})
+        scheduled (:form (segop-lower/segop-lower-pass
+                          program {:dtype :float :target-device :ocl:0
+                                   :array-types array-types :scalar-types scalar-types}))
+        jvm (par-simd/simd-pass scheduled :min-elements 1)
+        gpu (opencl-pass/opencl-pass scheduled :device-id :ocl:0
+                                     :dtype :float :min-elements 0
+                                     :array-types array-types
+                                     :scalar-types scalar-types)
+        kernel-source (:source (first (:kernels gpu)))
+        evaluable-jvm-form (walk/postwalk
+                            #(if (symbol? %) (with-meta % nil) %)
+                            (:form jvm))
+        jvm-values (eval
+                    (list 'let* ['out (list 'float-array 4)
+                                 'src (list 'float-array [10.0 11.0 20.0 21.0 30.0 31.0])
+                                 'idx (list 'int-array [2 0])
+                                 'n 2
+                                 'stride 2]
+                          (list 'vec evaluable-jvm-form)))]
+    (testing "JVM consumes the typed map and honestly scalarizes the unsupported vector schedule"
+      (is (= 1 (get-in jvm [:stats :segop-reused])))
+      (is (nil? (get-in jvm [:stats :segop-relowered])))
+      (is (= 1 (get-in jvm [:stats :fallback])))
+      (is (= [30.0 31.0 10.0 11.0] jvm-values)))
+    (testing "GPU emits the same flattened scalar region"
+      (is (= 1 (get-in gpu [:stats :segop-reused])))
+      (is (zero? (get-in gpu [:stats :fallback])))
+      (is (str/includes? kernel-source " / stride"))
+      (is (str/includes? kernel-source " % stride")))))

--- a/test/raster/compiler/pipeline_test.clj
+++ b/test/raster/compiler/pipeline_test.clj
@@ -88,12 +88,12 @@
       (is (not (contains? specs :par-fuse))))))
 
 (deftest uncertified-parallel-source-never-reenters-legacy-fusion
-  (let [source '(let* [step (raster.par/gather out src idx n stride)] step)
+  (let [source '(let* [step (raster.par/butterfly! re im i half wr wi base)] step)
         options {:dtype :float
-                 :array-types {'out :float 'src :float 'idx :int}
-                 :scalar-types {'n :long 'stride :long}}
+                 :array-types {'re :float 'im :float 'wr :float 'wi :float}
+                 :scalar-types {'half :long 'base :long}}
         result (#'pipeline/pass-soac-fuse source options)
-        bare '(raster.par/gather out src idx n stride)
+        bare '(raster.par/butterfly! re im i half wr wi base)
         bare-result (#'pipeline/pass-soac-fuse bare options)]
     (testing "a binding-form coverage gap remains byte-for-byte unfused"
       (is (= source (:form result)))


### PR DESCRIPTION
Canonicalize strided gather into the existing one-dimensional TypedSOAC map algebra: flatten row/component coordinates, hoist n times stride as typed scalar SSA, and retain indirect source/index reads as stable captures. No gather-specific semantic node is introduced. JVM consumes the schedule and honestly scalarizes; GPU emits the same region. Verification: 27 tests and 176 assertions, including an exact numerical row-gather oracle.