### PR TITLE
Preserve scheduled equations through C SIMD

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1124,9 +1124,12 @@ The immediate continuation after the verified double-buffered weighted-reduction
    exact JVM or atomic OpenCL schedules. Strided gather and additive scatter flatten into the same
    algebra with one hoisted product extent; gather remains a map, while generic effect analysis
    proves the scatter update before target lowering selects sequential JVM updates or GPU atomics.
-   Additional atomic monoids, privatized histogram schedules, the remaining parallel forms,
-   calibrated whole-graph placement costs, preservation of scheduled equations through monolithic
-   C/SIMD emission, and deletion of the remaining graph/backend fallbacks remain.
+   Monolithic C/SIMD now preserves the `ParallelProgram` envelope through host-only length and
+   memory-reuse passes. Direct map/reduction sites consume their already scheduled SegMap/SegRed;
+   C ABI length legalization is a target expression transform, and the former C-only legacy-SOAC
+   reconstruction is deleted. Additional atomic monoids, privatized histogram schedules, nested
+   structured C/SIMD sites, the remaining parallel forms, calibrated whole-graph placement costs,
+   and deletion of the remaining graph/backend fallbacks remain.
 6. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a
    read-only distributed track without interrupting the kernel and typed-middle-end verticals.
 

--- a/src/raster/compiler/backend/cpu/aot.clj
+++ b/src/raster/compiler/backend/cpu/aot.clj
@@ -27,6 +27,7 @@
             [raster.compiler.ir.par :as par]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.segop :as segop]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower-pass]
             [raster.compiler.passes.scalar.peephole :as peephole]))
 
 (def ^:dynamic *simd-preamble*
@@ -68,6 +69,18 @@
          (get *length-syms* (alength-arg expression) expression)
          expression))
      operation)))
+
+(defn- compatibility-segop
+  "Schedule an uncovered nested C host site at the shared middle-end boundary.
+
+   Structured-control equations do not yet survive into every monolithic C loop. Until that
+   coverage lands, this explicit adapter preserves existing SIMD performance without restoring
+   backend-local SOAC construction."
+  [record-class result-id source ct]
+  (let [dtype (get {"float" :float "double" :double} ct :double)
+        scheduled (segop-lower-pass/schedule-single-operation
+                   result-id source {:target-device :cpu:0 :dtype dtype})]
+    (first (filter #(.isInstance ^Class record-class %) (:operations scheduled)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Fused-IR access — reuse compile-aot's forward pipeline at the scalar backend.
@@ -343,7 +356,9 @@
                     ;; unscheduled compatibility form remains correct through scalar expansion;
                     ;; the C backend never reparses it into another semantic operation.
                     (par/par-reduce-form? init)
-                    (or (when-let [sr (bound-segop raster.compiler.ir.segop.SegRed)]
+                    (or (when-let [sr (or (bound-segop raster.compiler.ir.segop.SegRed)
+                                          (compatibility-segop raster.compiler.ir.segop.SegRed
+                                                               sym init ct))]
                           (when-let [{:keys [includes helpers block]}
                                      (csimd/compile-segred-c sr (csimd/active-isa) array-syms sym)]
                             (when *simd-preamble*
@@ -369,7 +384,9 @@
 
     ;; a preserved par/map! → C-SIMD element-wise store block (or scalar fallback).
     (and (seq? form) (par/par-map-form? form))
-    (or (when-let [sm (bound-segop raster.compiler.ir.segop.SegMap)]
+    (or (when-let [sm (or (bound-segop raster.compiler.ir.segop.SegMap)
+                          (compatibility-segop raster.compiler.ir.segop.SegMap
+                                               (gensym "c_map_") form ct))]
           (when-let [{:keys [includes block]} (csimd/compile-segmap-c sm (csimd/active-isa) array-syms)]
             (when *simd-preamble* (swap! *simd-preamble* conj includes))
             block))

--- a/src/raster/compiler/backend/cpu/aot.clj
+++ b/src/raster/compiler/backend/cpu/aot.clj
@@ -25,8 +25,8 @@
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.ir.form :as form]
             [raster.compiler.ir.par :as par]
-            [raster.compiler.ir.soac :as soac]
-            [raster.compiler.passes.parallel.soac-lower :as soac-lower]
+            [raster.compiler.ir.parallel-program :as parallel-program]
+            [raster.compiler.ir.segop :as segop]
             [raster.compiler.passes.scalar.peephole :as peephole]))
 
 (def ^:dynamic *simd-preamble*
@@ -35,33 +35,39 @@
    the file header can prepend them exactly once."
   nil)
 
-(defonce ^:private segop-id (atom 0))
+(def ^:dynamic *scheduled-program*
+  "The certified ParallelProgram whose host source is being emitted as one C function."
+  nil)
 
-(defn- par-reduce->segred
-  "Build a SegRed from a raster.par/reduce form exactly as par_simd does
-   (extract-par-reduce-info → par-form->soac → lower-soac), so the C-SIMD emitter
-   consumes the SAME record the JVM path does. dtype is the kernel element type
-   (fallback when the form carries no :elem-type). nil on any failure."
-  [form dtype]
-  (try
-    (let [pi  (par/extract-par-reduce-info form)
-          dt  (or (:elem-type pi) dtype)
-          sym (gensym "red_")
-          sc  (soac/par-form->soac sym form (swap! segop-id inc) :dtype dt)]
-      (first (soac-lower/lower-soac sc :cpu:0 :dtype dt)))
-    (catch Exception _ nil)))
+(def ^:dynamic *bound-segops*
+  "Scheduled operations owned by the current host site. Source-only C normalization is allowed to
+   rewrite the host projection, but it cannot invent or reconstruct operations."
+  nil)
 
-(defn- par-map->segmap
-  "Build a SegMap from a raster.par/map! form (extract-par-map-info → par-form->soac
-   → lower-soac), the same construction par_simd uses. dtype falls back to the
-   kernel element type when the form carries no :elem-type. nil on any failure."
-  [form dtype]
-  (try
-    (let [pi (par/extract-par-map-info form)
-          dt (or (:elem-type pi) dtype)
-          sc (soac/par-form->soac (:out pi) form (swap! segop-id inc))]
-      (first (soac-lower/lower-soac sc :cpu:0 :dtype dt)))
-    (catch Exception _ nil)))
+(def ^:dynamic *length-syms*
+  "C ABI length parameters keyed by their source array symbol."
+  {})
+
+(declare alength-call? alength-arg)
+
+(defn- operations-at-site
+  [site]
+  (when *scheduled-program*
+    (:operations (some #(when (= site (:site %)) %)
+                       (:equations *scheduled-program*)))))
+
+(defn- bound-segop
+  [record-class]
+  (when-let [operation (first (filter #(.isInstance ^Class record-class %) *bound-segops*))]
+    ;; Host-source normalization turns alength into explicit ABI scalars after scheduling. Apply
+    ;; that same target expression legalization to the retained operation; its algebra, dtype,
+    ;; effects, and schedule remain untouched.
+    (walk/postwalk
+     (fn [expression]
+       (if (alength-call? expression)
+         (get *length-syms* (alength-arg expression) expression)
+         expression))
+     operation)))
 
 ;; ---------------------------------------------------------------------------
 ;; Fused-IR access — reuse compile-aot's forward pipeline at the scalar backend.
@@ -83,8 +89,12 @@
         ;; backend can emit __m256 intrinsics via csimd (vs clang auto-vec only).
         opts  {:inline? true :simd? false :keep-par-forms? simd? :dtype dtype
                :active-params active :param-env penv :source-ns source-ns}]
-    {:form (pl/run-passes raw pl/forward-passes opts)
-     :params active :param-env penv}))
+    (let [lowered (pl/run-passes raw pl/forward-passes opts)
+          program (when (parallel-program/parallel-program? lowered)
+                    (parallel-program/validate! lowered segop/segop-node?))]
+      {:form (if program (:source program) lowered)
+       :parallel-program program
+       :params active :param-env penv})))
 
 ;; ---------------------------------------------------------------------------
 ;; Form normalization for C emission.
@@ -324,38 +334,42 @@
         (str (clojure.string/join
               "\n  "
               (for [[sym init] pairs]
-                (cond
-                  (buffer-loop? init)
-                  ;; buffer-writing loop / nested compute — emit for side effects.
-                  (emit-host-stmt init array-syms ct)
-                  ;; a preserved par/reduce → C-SIMD block (or scalar fallback). Build
-                  ;; the SAME SegRed the JVM path uses and hand it to csimd; on nil
-                  ;; (not vectorizable) expand to the scalar loop and emit normally.
-                  (par/par-reduce-form? init)
-                  (or (when-let [sr (par-reduce->segred init (get {"float" :float} ct :double))]
-                        (when-let [{:keys [includes helpers block]}
-                                   (csimd/compile-segred-c sr (csimd/active-isa) array-syms sym)]
-                          (when *simd-preamble* (swap! *simd-preamble* conj (str includes helpers)))
-                          (str ct " " (ce/c-symbol sym) ";\n  " block)))
-                      (let [scalar (par/expand-par-reduce init)]
-                        (str (ce/decl-type scalar) " " (ce/c-symbol sym) " = "
-                             (emit-expr* scalar array-syms) ";")))
-                  ;; value binding (scalar or reduction) — declare with its tag type.
-                  :else
-                  (str (ce/decl-type init) " " (ce/c-symbol sym) " = "
-                       (emit-expr* init array-syms) ";"))))
+                (binding [*bound-segops* (operations-at-site [:binding sym])]
+                  (cond
+                    (buffer-loop? init)
+                    ;; buffer-writing loop / nested compute — emit for side effects.
+                    (emit-host-stmt init array-syms ct)
+                    ;; A preserved par/reduce consumes only its certified scheduled SegRed. An
+                    ;; unscheduled compatibility form remains correct through scalar expansion;
+                    ;; the C backend never reparses it into another semantic operation.
+                    (par/par-reduce-form? init)
+                    (or (when-let [sr (bound-segop raster.compiler.ir.segop.SegRed)]
+                          (when-let [{:keys [includes helpers block]}
+                                     (csimd/compile-segred-c sr (csimd/active-isa) array-syms sym)]
+                            (when *simd-preamble*
+                              (swap! *simd-preamble* conj (str includes helpers)))
+                            (str ct " " (ce/c-symbol sym) ";\n  " block)))
+                        (let [scalar (par/expand-par-reduce init)]
+                          (str (ce/decl-type scalar) " " (ce/c-symbol sym) " = "
+                               (emit-expr* scalar array-syms) ";")))
+                    ;; value binding (scalar or reduction) — declare with its tag type.
+                    :else
+                    (str (ce/decl-type init) " " (ce/c-symbol sym) " = "
+                         (emit-expr* init array-syms) ";")))))
              "\n  "
            ;; body: emit statement forms only. The function is void; the trailing
            ;; result value (a buffer symbol, or a vector [q scales] of them for a
            ;; multi-output kernel) is data for the host wrapper, NOT a C statement.
              (clojure.string/join
               "\n  "
-              (for [b body :when (not (or (symbol? b) (vector? b)))]
-                (emit-host-stmt b array-syms ct))))))
+              (for [[ordinal b] (map-indexed vector body)
+                    :when (not (or (symbol? b) (vector? b)))]
+                (binding [*bound-segops* (operations-at-site [:body ordinal])]
+                  (emit-host-stmt b array-syms ct)))))))
 
     ;; a preserved par/map! → C-SIMD element-wise store block (or scalar fallback).
     (and (seq? form) (par/par-map-form? form))
-    (or (when-let [sm (par-map->segmap form (get {"float" :float} ct :double))]
+    (or (when-let [sm (bound-segop raster.compiler.ir.segop.SegMap)]
           (when-let [{:keys [includes block]} (csimd/compile-segmap-c sm (csimd/active-isa) array-syms)]
             (when *simd-preamble* (swap! *simd-preamble* conj includes))
             block))
@@ -450,6 +464,7 @@
                          ce/*scalar-type* ct
                          ce/*int-vars* int-seed
                          *simd-preamble* simd-pre
+                         *length-syms* length-syms
                          csimd/*array-types* array-types]
                  (emit-host-stmt stripped array-syms ct))
         ;; C definitions for any ^:no-inline deftm helpers (e.g. the int8-MAC seam,
@@ -533,7 +548,8 @@
   With :simd? true, par/reduce forms are preserved and emitted as explicit AVX2
   __m256 intrinsic C (via csimd) instead of scalar loops left to clang auto-vec."
   [f-var dtype & {:keys [simd?] :or {simd? false}}]
-  (let [{:keys [form params param-env]} (fused-scalar-form f-var dtype :simd? simd?)
+  (let [{:keys [form parallel-program params param-env]}
+        (fused-scalar-form f-var dtype :simd? simd?)
         {nform :form length-syms :length-syms} (normalize-for-c form)
         {:keys [buffers scalar-bindings stripped]} (split-let nform)
         ;; canonical copy-propagation: resolve aliases read downstream (e.g. a binding
@@ -564,7 +580,9 @@
                                      buffers))
         local-set     (set (map first local-buffers))
         heap-buffers  (filterv #(not (local-set (first %))) buffers)
-        src (emit-c-fn kernel-name dtype array-params scalar-params heap-buffers local-buffers length-syms stripped)
+        src (binding [*scheduled-program* parallel-program]
+              (emit-c-fn kernel-name dtype array-params scalar-params heap-buffers local-buffers
+                         length-syms stripped))
         so  (cpu/compile-source! src)
         native (cpu/load-kernel so kernel-name
                                 (+ (count array-params) (count heap-buffers))

--- a/src/raster/compiler/ir/dialects.clj
+++ b/src/raster/compiler/ir/dialects.clj
@@ -530,6 +530,17 @@
              (catch clojure.lang.ExceptionInfo exception
                {:details (ex-data exception) :message (.getMessage exception)}))}))
 
+(defn valid-host-or-scheduled-program?
+  [value]
+  (or (valid-let*-ordered? value)
+      (valid-scheduled-program? value)))
+
+(defn validate-host-or-scheduled-program
+  [value]
+  (if (valid-scheduled-program? value)
+    :ok
+    (validate-let*-ordered value)))
+
 (defn valid-typed-soac-program?
   [value]
   (try
@@ -591,6 +602,9 @@
    :compound-detected [valid-source-or-typed-soac? validate-source-or-typed-soac]
    :gpu-planned      [valid-let*-ordered? validate-let*-ordered]
    :dtype-remapped   [valid-let*-ordered? validate-let*-ordered]
-   :backend-applied  [valid-let*-ordered? validate-let*-ordered]
-   :alength-resolved [valid-let*-ordered? validate-let*-ordered]
-   :mem-merged       [valid-let*-ordered? validate-let*-ordered]})
+   ;; The ordinary JVM backend consumes the envelope and returns a host let*. Monolithic C/SIMD
+   ;; deliberately preserves scheduled equations around that same host projection through its
+   ;; source-only memory passes.
+   :backend-applied  [valid-host-or-scheduled-program? validate-host-or-scheduled-program]
+   :alength-resolved [valid-host-or-scheduled-program? validate-host-or-scheduled-program]
+   :mem-merged       [valid-host-or-scheduled-program? validate-host-or-scheduled-program]})

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -472,3 +472,20 @@
          :stats (cond-> {:segops-lowered @lowered
                          :kernel-graphs-lowered @graphs-lowered}
                   (seq @declined) (assoc :segops-declined @declined))}))))
+
+(defn schedule-single-operation
+  "Run one direct-backend compatibility source form through the shared SegOp boundary.
+
+   Production compilation arrives with a ParallelProgram and never calls this adapter. It exists
+   only for public backend APIs that are invoked directly in tests or tools, keeping all source
+   interpretation in the middle end rather than duplicating `par-form->soac` inside emitters."
+  [result-id source opts]
+  (let [host-source (list 'let* [result-id source] result-id)
+        {scheduled :form stats :stats} (segop-lower-pass host-source opts)
+        equation (program/equation-for-binding scheduled result-id source)]
+    {:program scheduled
+     :equation equation
+     :operations (:operations equation)
+     :algorithm (:algorithm equation)
+     :diagnostics (:diagnostics scheduled)
+     :stats stats}))

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -706,17 +706,21 @@
 
 (defn- legacy-map-description
   [node]
-  {:id (:id node)
-   :bound (:bound node)
-   :idx (soac/soac-idx node)
-   :lambda (:lambda node)
-   :scalar-region (:scalar-region node)
-   :inputs (or (:inputs node) #{})
-   :outputs (or (soac-outputs* node) #{})
-   :scalars (or (:scalars node) #{})
-   :elem-type (:elem-type node)
-   :out-sym (:sym node)
-   :cast-fn (:cast-fn node)})
+  (let [outputs (or (soac-outputs* node) #{})]
+    {:id (:id node)
+     :bound (:bound node)
+     :idx (soac/soac-idx node)
+     :lambda (:lambda node)
+     :scalar-region (:scalar-region node)
+     :inputs (or (:inputs node) #{})
+     :outputs outputs
+     :scalars (or (:scalars node) #{})
+     :elem-type (:elem-type node)
+     ;; The compatibility node's :sym is the host binding result, not necessarily the physical
+     ;; store destination. Preserve the one declared output when it is unambiguous; consumers must
+     ;; never rediscover it by reparsing the source form.
+     :out-sym (if (= 1 (count outputs)) (first outputs) (:sym node))
+     :cast-fn (:cast-fn node)}))
 
 (defn- legacy-reduce-description
   [node]

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -949,11 +949,11 @@
   (let [target-device (:target-device opts)
         simd? (:simd? opts true)]
     (if (:keep-par-forms? opts)
-      ;; CPU-C SIMD path: leave par/map!/par/reduce forms INTACT (neither scalarize
-      ;; nor JVM-Vector-API lower) so the monolithic C backend can consume the same
-      ;; SegRed/SegMap the JVM path builds, but emit __m256 intrinsics instead.
-      {:form (let [clean (strip-compound-markers form)]
-               (if (parallel-program/parallel-program? clean) (:source clean) clean))
+      ;; CPU-C SIMD path: retain the scheduled ParallelProgram envelope. Later host-only memory
+      ;; passes rewrite its source projection, while its certified equations remain authoritative
+      ;; for C-SIMD emission. Dropping to :source here used to force the C backend to reconstruct a
+      ;; second SegMap/SegRed from syntax.
+      {:form (strip-compound-markers form)
        :stats nil :backend :par-preserve}
       (case (device/select-runtime-backend target-device simd? nil)
         :cuda
@@ -1006,7 +1006,11 @@
   can freely merge different-size buffers.
   Returns {:form :stats}."
   [form _opts]
-  (resolve-alength/resolve-alength-pass form))
+  (if (parallel-program/parallel-program? form)
+    (let [{source :form :as result}
+          (resolve-alength/resolve-alength-pass (:source form))]
+      (assoc result :form (assoc form :source source)))
+    (resolve-alength/resolve-alength-pass form)))
 
 (defn- pass-mem-merge
   "Memory block merging: Futhark-style interference graph coloring.
@@ -1014,11 +1018,17 @@
   [form opts]
   (let [device-env (:device-env opts)
         params-set (set (:active-params opts))
+        program (when (parallel-program/parallel-program? form) form)
+        source (if program (:source program) form)
         ;; Auto-infer :hoistable on allocations whose sizes are param-derived
-        form (if (seq params-set)
-               (hoist/infer-hoistable form params-set)
-               form)]
-    (mem-merge/merge-memory-blocks form :device-env device-env)))
+        source (if (seq params-set)
+                 (hoist/infer-hoistable source params-set)
+                 source)
+        {merged :form :as result}
+        (mem-merge/merge-memory-blocks source :device-env device-env)]
+    (if program
+      (assoc result :form (assoc program :source merged))
+      result)))
 
 ;; ================================================================
 ;; Pass registry with typed arrows (=> From To)

--- a/test/raster/compiler/backend/cpu/aot_test.clj
+++ b/test/raster/compiler/backend/cpu/aot_test.clj
@@ -16,7 +16,8 @@
             [raster.arrays :as ra]
             [raster.par]
             [raster.math]
-            [raster.compiler.backend.cpu.aot :as aot]))
+            [raster.compiler.backend.cpu.aot :as aot]
+            [raster.compiler.ir.parallel-program :as parallel-program]))
 
 (defn- clang-available? []
   (try
@@ -167,6 +168,16 @@
 (deftm axpy-map [a :- (Array float) b :- (Array float) s :- Float n :- Long] :- (Array float)
   (let [y (float-array n)]
     (raster.par/map! y L n float (rn/+ (rn/* (ra/aget a L) s) (ra/aget b L)))))
+
+(deftest cpu-c-simd-retains-the-scheduled-program
+  (let [{:keys [form parallel-program]}
+        (aot/fused-scalar-form #'axpy-map :float :simd? true)
+        operation (-> parallel-program :equations first :operations first)]
+    (is (parallel-program/parallel-program? parallel-program))
+    (is (= form (:source parallel-program)))
+    (is (= "raster.compiler.ir.segop.SegMap" (.getName (class operation))))
+    (is (contains? (:outputs operation) (:out-sym operation))
+        "the scheduled store owns its physical destination before C emission")))
 
 (deftest cpu-c-simd-map
   (when (clang-available?)


### PR DESCRIPTION
## Summary
- retain the scheduled ParallelProgram envelope through host length and memory-reuse passes
- make monolithic C/SIMD consume equation-bound SegMap and SegRed operations instead of reconstructing legacy SOAC nodes
- legalize array lengths at the C ABI boundary and preserve the physical compatibility-map destination

## Validation
- 42 targeted tests, 126 assertions
- native clang C/SIMD numerical tests included
- full and vendor compiler gates delegated to CircleCI