### PR TITLE
Prefer TypedSOAC for direct backend scheduling

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -65,8 +65,9 @@ SSA-like result IDs, `AbstractValue` contracts, effects, diagnostics, and proven
 GPU and JVM backends consume the recorded operations; the source expression is retained only to
 reconstruct scalar host control around them. The `:segop-lowered` validator performs a full
 operation/type legality check, and source equality invalidates an equation after a backend-local
-rewrite. Direct calls to a backend may still use the explicit, counted compatibility re-lowering
-path.
+rewrite. Direct calls to a backend may still request explicit, counted compatibility scheduling,
+but that request now crosses the shared SegOp middle-end boundary; JVM and OpenCL emitters no
+longer construct legacy SOAC nodes themselves.
 
 The typed map/reduction vertical is now production-routed for supported programs whether or not a
 fusion fires. Unsupported source remains deliberately unfused for compatibility lowering; it can

--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1128,7 +1128,12 @@ The immediate continuation after the verified double-buffered weighted-reduction
    Monolithic C/SIMD now preserves the `ParallelProgram` envelope through host-only length and
    memory-reuse passes. Direct map/reduction sites consume their already scheduled SegMap/SegRed;
    C ABI length legalization is a target expression transform, and the former C-only legacy-SOAC
-   reconstruction is deleted. Additional atomic monoids, privatized histogram schedules, nested
+   reconstruction is deleted. Direct JVM and GPU compatibility entry points use one middle-end
+   singleton adapter that attempts analyzed-source→TypedSOAC first and falls back only for an exact
+   structured source-admission decline. Scheduled SegMap storage selects the runtime marker from
+   the emitted ABI: dense single-result maps remain value-producing, while unique scatters and
+   fused multi-result maps use the general effect marker without reconstructing destination facts
+   from source. Additional atomic monoids, privatized histogram schedules, nested
    structured C/SIMD sites, the remaining parallel forms, calibrated whole-graph placement costs,
    and deletion of the remaining graph/backend fallbacks remain.
 6. Add a differential PTX target dialect/module boundary. Start topology and sharding values as a

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -129,7 +129,7 @@
    available; otherwise re-lowered here with the REAL `device-id` (it was `:ze:0` hardcoded) and
    counted as `:segop-relowered`. SegMap is a full conversion: a missing rule is an illegal
    operation, never permission to select a second emitter."
-  [stats form dtype device-id]
+  [stats form dtype device-id scalar-types array-types]
   (or (take-bound-segop stats :segmap #(instance? raster.compiler.ir.segop.SegMap %))
       (do (swap! stats update :segop-relowered (fnil inc 0))
           (or (segop-attempt stats :segmap form dtype :none
@@ -138,7 +138,9 @@
                                     (segop-lower-pass/schedule-single-operation
                                      (:out par-info) form
                                      {:target-device (or device-id :ze:0)
-                                      :dtype (or dtype :double)})]
+                                      :dtype (or dtype :double)
+                                      :scalar-types scalar-types
+                                      :array-types array-types})]
                                 (first (:operations scheduled))))
               (let [decline (last (:segop-declined @stats))]
                 (throw (ex-info "par/map! remains illegal after full SegOp conversion"
@@ -153,7 +155,7 @@
 (defn- par->segred
   "The SegRed for a par/reduce form. Reduction is a FULL conversion: absence is an illegal
    operation at the SegOp boundary, never permission to select a second emitter."
-  [stats form dtype device-id]
+  [stats form dtype device-id scalar-types array-types]
   (or (take-bound-segop stats :segred #(instance? raster.compiler.ir.segop.SegRed %))
       (do (swap! stats update :segop-relowered (fnil inc 0))
           (or (segop-attempt stats :segred form dtype :none
@@ -161,7 +163,9 @@
                                     scheduled
                                     (segop-lower-pass/schedule-single-operation
                                      sym form {:target-device (or device-id :ze:0)
-                                               :dtype (or dtype :double)})]
+                                               :dtype (or dtype :double)
+                                               :scalar-types scalar-types
+                                               :array-types array-types})]
                                 (first (:operations scheduled))))
               (let [decline (last (:segop-declined @stats))]
                 (throw (ex-info "par/reduce remains illegal after full SegOp conversion"
@@ -427,17 +431,27 @@
 
             ;; === par/map! — SegOp path ===
             (par/par-map-form? form)
-            (let [{:keys [bound out]} (par/extract-par-map-info form)]
+            (let [{:keys [bound]} (par/extract-par-map-info form)]
               (if (and (number? bound) (< bound min-elements))
                 (do (swap! stats update :fallback inc)
                     (par/expand-par-map! form))
-                (let [segmap (par->segmap stats form dtype device-id)
-                      kernel (segop-cl/generate-segmap-kernel
-                              segmap out
+                (let [segmap (par->segmap stats form dtype device-id
+                                          top-scalar-types top-array-types)
+                      ;; Physical storage and effects come exclusively from the scheduled SegMap.
+                      ;; A dense map has one logical result; an offset map is an explicit-store
+                      ;; unique scatter and therefore uses the effect-only ABI/marker.
+                      kernel (segop-cl/generate-scheduled-segmap-kernel
+                              segmap
                               :dtype dtype :scalar-types top-scalar-types
                               :array-types (merge top-array-types (:array-types (meta form))))
-                      k (register-kernel! kernel :ze-maps)]
-                  (emit-map-invocation k device-id))))
+                      k (register-kernel! kernel :ze-maps)
+                      result-count (count (filter #(= :result (:role %)) (:abi k)))]
+                  ;; The compatibility map marker models exactly one returned buffer. A fused
+                  ;; multi-output map and an effect-only scatter are both already fully described
+                  ;; by the artifact ABI, so use the general resident-effect marker for them.
+                  (if (= 1 result-count)
+                    (emit-map-invocation k device-id)
+                    (emit-map-void-invocation k device-id)))))
 
             ;; === par/contract — tensor contraction, routed through the DPAS legality gate ===
             ;; The routing brain (contract-route) chooses the hardware-optimal kernel: DPAS/XMX
@@ -555,7 +569,8 @@
             ;; instead of round-tripping a host scalar. Emitted by the reduce-fusion pass.
             (par/par-reduce-into-form? form)
             (let [{:keys [out-buf reduce-form]} (par/extract-par-reduce-into-info form)
-                  segred (par->segred stats reduce-form dtype device-id)
+                  segred (par->segred stats reduce-form dtype device-id
+                                      top-scalar-types top-array-types)
                   kernel (segop-cl/generate-segred-kernel
                           segred out-buf :dtype dtype :scalar-types top-scalar-types
                           :array-types top-array-types)
@@ -568,7 +583,8 @@
               (if (and (number? bound) (< bound min-elements))
                 (do (swap! stats update :fallback inc)
                     (par/expand-par-reduce form))
-                (let [segred (par->segred stats form dtype device-id)
+                (let [segred (par->segred stats form dtype device-id
+                                          top-scalar-types top-array-types)
                       kernel (segop-cl/generate-segred-kernel
                               segred nil :dtype dtype :scalar-types top-scalar-types
                               :array-types top-array-types)
@@ -578,7 +594,8 @@
             ;; Typed segmented product reduction. The portable schedule is one deterministic
             ;; workgroup tree per segment; mixed result components remain separate ABI buffers.
             (par/par-product-reduce-form? form)
-            (let [segred (par->segred stats form dtype device-id)
+            (let [segred (par->segred stats form dtype device-id
+                                      top-scalar-types top-array-types)
                   kernel (segop-cl/generate-product-reduction-kernel
                           segred :scalar-types top-scalar-types :array-types top-array-types)
                   k (register-kernel! kernel :ze-reduces)]

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -9,7 +9,6 @@
    par form vocabulary but produce different target code."
   (:require [clojure.set :as set]
             [raster.compiler.ir.par :as par]
-            [raster.compiler.ir.soac]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
@@ -19,7 +18,7 @@
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.core.op-descriptor :as descriptor]
-            [raster.compiler.passes.parallel.soac-lower]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower-pass]
             [raster.compiler.backend.gpu.segop-opencl :as segop-cl]
             [raster.compiler.passes.parallel.contract-route :as croute]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-fuse :as swr-fuse]
@@ -68,8 +67,6 @@
                                    (when-let [dt (dtype/dtype-for-array-tag t)]
                                      [p (if (#{:float :double} dt) dtype dt)]))
                                  (map vector params tags)))}))
-
-(def ^:private segop-id-counter (atom 0))
 
 (def ^:private fatal-reasons
   "A violated invariant is not \"the SegOp path does not cover this form\". Letting one fall through
@@ -137,10 +134,12 @@
       (do (swap! stats update :segop-relowered (fnil inc 0))
           (or (segop-attempt stats :segmap form dtype :none
                              #(let [par-info (par/extract-par-map-info form)
-                                    soac (raster.compiler.ir.soac/par-form->soac
-                                          (:out par-info) form (swap! segop-id-counter inc))]
-                                (first (raster.compiler.passes.parallel.soac-lower/lower-soac
-                                        soac (or device-id :ze:0) :dtype (or dtype :double)))))
+                                    scheduled
+                                    (segop-lower-pass/schedule-single-operation
+                                     (:out par-info) form
+                                     {:target-device (or device-id :ze:0)
+                                      :dtype (or dtype :double)})]
+                                (first (:operations scheduled))))
               (let [decline (last (:segop-declined @stats))]
                 (throw (ex-info "par/map! remains illegal after full SegOp conversion"
                                 {:reason :illegal-op-remains
@@ -159,11 +158,11 @@
       (do (swap! stats update :segop-relowered (fnil inc 0))
           (or (segop-attempt stats :segred form dtype :none
                              #(let [sym (gensym "red_")
-                                    soac (raster.compiler.ir.soac/par-form->soac
-                                          sym form (swap! segop-id-counter inc)
-                                          :dtype (or dtype :double))]
-                                (first (raster.compiler.passes.parallel.soac-lower/lower-soac
-                                        soac (or device-id :ze:0) :dtype (or dtype :double)))))
+                                    scheduled
+                                    (segop-lower-pass/schedule-single-operation
+                                     sym form {:target-device (or device-id :ze:0)
+                                               :dtype (or dtype :double)})]
+                                (first (:operations scheduled))))
               (let [decline (last (:segop-declined @stats))]
                 (throw (ex-info "par/reduce remains illegal after full SegOp conversion"
                                 {:reason :illegal-op-remains

--- a/src/raster/compiler/backend/jvm/par_simd.clj
+++ b/src/raster/compiler/backend/jvm/par_simd.clj
@@ -21,11 +21,10 @@
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.backend.jvm.segop-simd :as segop-simd]
             [raster.compiler.backend.jvm.bytecode :as bc]
-            [raster.compiler.ir.soac]
-            [raster.compiler.passes.parallel.soac-lower]
             [raster.compiler.ir.par :as par]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.segop :as segop]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower-pass]
             [raster.runtime.hardware :as hw]
             [clojure.set :as set]))
 
@@ -361,8 +360,6 @@
     (max 8 (* 2 (int (hw/simd-lanes :cpu:0 :double))))
     (catch Exception _ 8)))
 
-(def ^:private segop-id-counter (atom 0))
-
 (def ^:dynamic *bound-segops*
   "SegOps owned by the ParallelProgram equation currently being transformed, or nil for direct
    S-expression callers. Consumption is dtype-guarded."
@@ -401,7 +398,11 @@
                                     dtype (or (:elem-type par-info)
                                               (cast->elem-type (:cast par-info))
                                               (out-sym->elem-type (:out par-info))
-                                              :double)]
+                                              :double)
+                                    scheduled
+                                    (segop-lower-pass/schedule-single-operation
+                                     (:out par-info) form
+                                     {:target-device :cpu:0 :dtype dtype})]
                                 (when (System/getProperty "raster.debug.simd-dtype")
                                   (binding [*out* *err*]
                                     (println "[par-simd] compatibility dtype=" dtype
@@ -411,11 +412,7 @@
                                              " out-tag=" (or (:raster.type/tag (meta (:out par-info)))
                                                              (:tag (meta (:out par-info)))))))
                                 (swap! stats update :segop-relowered (fnil inc 0))
-                                (let [soac (raster.compiler.ir.soac/par-form->soac
-                                            (:out par-info) form (swap! segop-id-counter inc))
-                                      segops (raster.compiler.passes.parallel.soac-lower/lower-soac
-                                              soac :cpu:0 :dtype dtype)]
-                                  (first segops)))
+                                (first (:operations scheduled)))
                               ;; A structured unsupported-form refusal may fall back to scalar code.
                               ;; Raw implementation exceptions must escape, as on the GPU boundary.
                               (catch clojure.lang.ExceptionInfo _ nil))))
@@ -424,13 +421,12 @@
                             (try
                               (let [par-info (par/extract-par-reduce-info form)
                                     dtype (or (:elem-type par-info) :double)
-                                    sym (gensym "red_")]
+                                    sym (gensym "red_")
+                                    scheduled
+                                    (segop-lower-pass/schedule-single-operation
+                                     sym form {:target-device :cpu:0 :dtype dtype})]
                                 (swap! stats update :segop-relowered (fnil inc 0))
-                                (let [soac (raster.compiler.ir.soac/par-form->soac
-                                            sym form (swap! segop-id-counter inc) :dtype dtype)
-                                      segops (raster.compiler.passes.parallel.soac-lower/lower-soac
-                                              soac :cpu:0 :dtype dtype)]
-                                  (first segops)))
+                                (first (:operations scheduled)))
                               (catch clojure.lang.ExceptionInfo _ nil))))
           transform
           (fn transform [form]

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -18,6 +18,7 @@
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
             [raster.compiler.passes.parallel.segred-body :as segred-body]
             [raster.compiler.passes.parallel.typed-soac-frontend :as typed-frontend]
+            [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
             [raster.compiler.ir.form :as form]
             [clojure.set :as set]))
 
@@ -480,9 +481,30 @@
    only for public backend APIs that are invoked directly in tests or tools, keeping all source
    interpretation in the middle end rather than duplicating `par-form->soac` inside emitters."
   [result-id source opts]
-  (let [host-source (list 'let* [result-id source] result-id)
-        {scheduled :form stats :stats} (segop-lower-pass host-source opts)
-        equation (program/equation-for-binding scheduled result-id source)]
+  (let [;; Imperative map callers commonly pass the destination as their nominal result ID. Give
+        ;; the host result its own value identity so the typed frontend can represent the declared
+        ;; result-to-storage alias without conflating it with the caller-owned buffer.
+        physical-map-output (when (par/par-map-form? source)
+                              (:out (par/extract-par-map-info source)))
+        host-result (if (= result-id physical-map-output)
+                      (gensym "direct_parallel_result_")
+                      result-id)
+        host-source (list 'let* [host-result source] host-result)
+        typed (try
+                (typed-frontend/form->program
+                 (typed-frontend/normalize-source host-source)
+                 {:dtype (or (:dtype opts) :double)
+                  :array-types (:array-types opts)
+                  :scalar-types (:scalar-types opts)})
+                (catch clojure.lang.ExceptionInfo exception
+                  (when-not (typed-frontend/source-decline? exception)
+                    (throw exception))
+                  nil))
+        {scheduled :form stats :stats}
+        (segop-lower-pass (if typed (typed-route/program-envelope typed) host-source) opts)
+        ;; Compound extents may introduce a preceding host-scalar equation. Select the one
+        ;; scheduled parallel equation rather than assuming it is first in program order.
+        equation (some #(when (seq (:operations %)) %) (:equations scheduled))]
     {:program scheduled
      :equation equation
      :operations (:operations equation)

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -490,16 +490,22 @@
                       (gensym "direct_parallel_result_")
                       result-id)
         host-source (list 'let* [host-result source] host-result)
-        typed (try
-                (typed-frontend/form->program
-                 (typed-frontend/normalize-source host-source)
-                 {:dtype (or (:dtype opts) :double)
-                  :array-types (:array-types opts)
-                  :scalar-types (:scalar-types opts)})
-                (catch clojure.lang.ExceptionInfo exception
-                  (when-not (typed-frontend/source-decline? exception)
-                    (throw exception))
-                  nil))
+        typed-candidate
+        (try
+          (typed-frontend/form->program
+           (typed-frontend/normalize-source host-source)
+           {:dtype (or (:dtype opts) :double)
+            :array-types (:array-types opts)
+            :scalar-types (:scalar-types opts)})
+          (catch clojure.lang.ExceptionInfo exception
+            (when-not (typed-frontend/source-decline? exception)
+              (throw exception))
+            nil))
+        ;; The compatibility return value exposes one operation, not a mini-program. Source
+        ;; normalization may introduce host scalar equations (notably a hoisted compound extent);
+        ;; using only the parallel equation would leave those SSA values unbound in the caller.
+        ;; Keep such sites on compatibility lowering until this API returns the complete envelope.
+        typed (when (= 1 (count (soac-dialect/equations typed-candidate))) typed-candidate)
         {scheduled :form stats :stats}
         (segop-lower-pass (if typed (typed-route/program-envelope typed) host-source) opts)
         ;; Compound extents may introduce a preceding host-scalar equation. Select the one

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -25,6 +25,30 @@
   [reason message data]
   (throw (ex-info message (assoc data :reason reason :front-end :analyzed-source))))
 
+(def source-decline-reasons
+  "Structured analysis failures that mean source lies outside the closed TypedSOAC subset."
+  #{:unsupported-scalar-binding
+    :source-value-conflict
+    :scan-dtype-unsupported
+    :scan-not-associative
+    :scan-not-elementwise
+    :scan-element-impure-or-unknown
+    :scan-nonidentity-init
+    :reduction-dtype-unsupported
+    :reduction-not-associative
+    :reduction-not-elementwise
+    :reduction-element-impure-or-unknown
+    :reduction-nonidentity-init
+    :typed-soac-production-subset
+    :typed-soac-stable-read-alias
+    :typed-soac-syntax
+    :typed-soac-unbound-scalar
+    :typed-soac-unknown-value})
+
+(defn source-decline?
+  [exception]
+  (contains? source-decline-reasons (:reason (ex-data exception))))
+
 (defn- extract-io
   [body index outputs & {:keys [accumulator]}]
   (let [inputs (par/collect-aget-arrays body)

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -21,35 +21,6 @@
    :long ['clojure.core/long-array 'longs 'long]
    :byte ['clojure.core/byte-array 'bytes 'byte]})
 
-(def ^:private source-decline-reasons
-  "Structured exceptions that mean analyzed source is outside the closed TypedSOAC subset.
-
-   Keep this list exact. Before a validated TypedSOAC program exists, incomplete shapes, scalar
-   capture facts, or dialect coverage are honest admission declines. After construction, only the
-   explicit production-subset reason may decline; fusion bugs and unexpected materialization
-   failures must escape."
-  #{:unsupported-scalar-binding
-    :source-value-conflict
-    :scan-dtype-unsupported
-    :scan-not-associative
-    :scan-not-elementwise
-    :scan-element-impure-or-unknown
-    :scan-nonidentity-init
-    :reduction-dtype-unsupported
-    :reduction-not-associative
-    :reduction-not-elementwise
-    :reduction-element-impure-or-unknown
-    :reduction-nonidentity-init
-    :typed-soac-production-subset
-    :typed-soac-stable-read-alias
-    :typed-soac-syntax
-    :typed-soac-unbound-scalar
-    :typed-soac-unknown-value})
-
-(defn- source-decline?
-  [exception]
-  (contains? source-decline-reasons (:reason (ex-data exception))))
-
 (defn- equation-subprogram
   [program equation]
   (let [equation-id (second equation)
@@ -531,7 +502,7 @@
                                   {:route :typed-soac :typed-validated true
                                    :front-end :analyzed-source})})))))
          (catch clojure.lang.ExceptionInfo exception
-           (if (source-decline? exception)
+           (if (frontend/source-decline? exception)
              {:declined {:reason (:reason (ex-data exception))
                          :message (.getMessage exception)
                          :details (ex-data exception)}}

--- a/test/raster/compiler/backend/gpu/gpu_correctness_test.clj
+++ b/test/raster/compiler/backend/gpu/gpu_correctness_test.clj
@@ -133,7 +133,7 @@
                '(raster.par/map! out i n double (clojure.core/+ (aget a i) (aget b i))))]
       (is (str/includes? src "a["))
       (is (str/includes? src "b["))
-      (is (str/includes? src "out["))))
+      (is (str/includes? src "out_["))))
   (testing "aset in void kernel → assignment"
     (let [src (map-void-kernel-src
                '(raster.par/map-void! i n
@@ -210,7 +210,7 @@
                                                  (clojure.core/* b (Math/pow (aget x i) beta)))))]
       (is (str/includes? src "pow("))
       (is (str/includes? src "x["))
-      (is (str/includes? src "out["))))
+      (is (str/includes? src "out_["))))
   (testing "Boolean predicate in if → C comparison"
     (let [src (map-void-kernel-src
                '(raster.par/map-void! i n
@@ -279,8 +279,10 @@
      (let [n 1024
            scale 0.75
            input (float-array (map #(float (/ (inc %) 1024.0)) (range n)))
-           form '(raster.par/reduce acc 0.0 i n
-                                    (+ acc (* scale (aget input i))))
+           form (with-meta
+                  '(raster.par/reduce acc 0.0 i n
+                                      (+ acc (* scale (aget input i))))
+                  {:raster.type/elem-type :float})
            compiled (opencl-pass/opencl-pass
                      form :device-id :ze:0 :dtype :float
                      :scalar-types {'scale :float 'n :int})

--- a/test/raster/compiler/backend/gpu/par_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/par_opencl_test.clj
@@ -51,30 +51,31 @@
       (is (string? (:source kernel)))
       ;; OpenCL-specific syntax
       (is (str/includes? (:source kernel) "__kernel void"))
-      (is (str/includes? (:source kernel) "get_global_id(0)"))
-      (is (str/includes? (:source kernel) "get_global_size(0)"))
+      (is (str/includes? (:source kernel) "get_group_id(0)"))
+      (is (str/includes? (:source kernel) "get_local_id(0)"))
       (is (str/includes? (:source kernel) "__global const double* restrict"))
-      (is (str/includes? (:source kernel) "__global double* restrict out"))
+      (is (str/includes? (:source kernel) "__global double* out"))
       ;; Must NOT have CUDA syntax
       (is (not (str/includes? (:source kernel) "blockIdx")))
       (is (not (str/includes? (:source kernel) "__global__")))
       (is (not (str/includes? (:source kernel) "extern \"C\"")))
       ;; Check parameter lists
-      (is (= 2 (count (kart/attribute kernel :array-params))))
+      (is (= 3 (count (kart/attribute kernel :array-params))))
       (is (= '[a b out _n_bound] (mapv :name (:abi kernel))))
       (is (= [:input :input :output :scalar] (mapv :kind (:abi kernel))))
       (is (= '[a b out n] (:arguments kernel)))
       (is (= :double (kart/attribute kernel :dtype)))
-      (is (= :segmap (get-in kernel [:provenance :dialect])))
+      (is (= :kernel-body (get-in kernel [:provenance :dialect])))
+      (is (= :kernel-body (kart/attribute kernel :emission-route)))
       (is (= [256] (get-in kernel [:launch :workgroup-size]))))))
 
 (deftest generate-segmap-kernel-scalar-test
   (testing "Map with scalar parameter"
     (let [form '(raster.par/map! out i n double (* alpha (aget a i)))
-          kernel (emitted-map form)]
+          kernel (emitted-map form :scalar-types {'alpha :double 'n :int})]
       (is (kart/kernel-artifact? kernel))
       (is (str/includes? (:source kernel) "alpha"))
-      (is (= 1 (count (kart/attribute kernel :array-params))))
+      (is (= 2 (count (kart/attribute kernel :array-params))))
       (is (= '[a out alpha _n_bound] (mapv :name (:abi kernel))))
       (is (= [:double :double :double :int] (mapv :dtype (:abi kernel)))))))
 
@@ -222,7 +223,9 @@
 (deftest opencl-pass-reduce-test
   (testing "par/reduce gets replaced with the ordered registered reduction marker"
     (let [product (with-meta '(* scale (aget a i)) {:raster.type/tag 'float})
-          form (list 'raster.par/reduce 'acc 0.0 'i 'n (list '+ 'acc product))
+          form (with-meta
+                 (list 'raster.par/reduce 'acc 0.0 'i 'n (list '+ 'acc product))
+                 {:raster.type/elem-type :float})
           result (opencl-pass/opencl-pass form :device-id :ze:0 :dtype :float
                                           :scalar-types {'scale :float 'n :int})]
       (is (= 1 (:ze-reduces (:stats result))))
@@ -234,8 +237,10 @@
              (mapv :name (:abi (first (:kernels result))))))))
   (testing "reduce-into supplies its resident result at the same ordered ABI slot"
     (let [product (with-meta '(* scale (aget a i)) {:raster.type/tag 'float})
-          form (list 'raster.par/reduce-into 'obuf 'acc 0.0 'i 'n
-                     (list '+ 'acc product))
+          form (with-meta
+                 (list 'raster.par/reduce-into 'obuf 'acc 0.0 'i 'n
+                       (list '+ 'acc product))
+                 {:raster.type/elem-type :float})
           result (opencl-pass/opencl-pass form :device-id :ze:0 :dtype :float
                                           :scalar-types {'scale :float 'n :int})]
       (is (= 'raster.gpu.ze-runtime/invoke-registered-reduction-kernel

--- a/test/raster/compiler/backend/jvm/par_simd_test.clj
+++ b/test/raster/compiler/backend/jvm/par_simd_test.clj
@@ -233,8 +233,8 @@
                      (tree-seq seq? seq form)))
           "No par forms should remain"))))
 
-(deftest offset-map-falls-back-with-correct-destination-indices
-  (testing "a compatibility refusal retains out[base+i] semantics on the JVM"
+(deftest direct-offset-map-uses-the-shared-typed-schedule
+  (testing "a direct backend call retains out[base+i] semantics through shared scheduling"
     (let [source '(let* [out (double-array [99.0 99.0 99.0 99.0 99.0 99.0])
                          x (double-array [10.0 11.0 12.0])
                          base 2
@@ -242,7 +242,10 @@
                         (raster.par/map! out i n :offset base double (aget x i)))
           {:keys [form stats]} (par-simd/simd-pass source :min-elements 0)
           result (eval form)]
-      (is (= 1 (:fallback stats)))
+      (is (= 1 (:fallback stats))
+          "the typed unique-scatter has no JVM vector-store schedule yet")
+      (is (= 1 (:segop-relowered stats))
+          "the direct API records its one middle-end compatibility scheduling request")
       (is (= [99.0 99.0 10.0 11.0 12.0 99.0] (vec result))))))
 
 ;; ================================================================

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -769,7 +769,9 @@
     (is (nil? (get-in jvm [:stats :segop-relowered])))
     (is (= [:input :input :output :output :scalar]
            (mapv :kind (:abi kernel))))
-    (is (re-find #"__global float\* restrict [uv]" (:source kernel)))))
+    (is (= :kernel-body (get-in kernel [:attributes :emission-route])))
+    (is (re-find #"__global float\* [uv]" (:source kernel))
+        "the scheduled multi-result body, not the single-result compatibility emitter, owns storage")))
 
 (deftest typed-horizontal-fusion-combines-distinct-materialized-write-boundaries
   (let [source '(let* [u (raster.par/map! u-out i n float

--- a/test/raster/compiler/segop_boundary_test.clj
+++ b/test/raster/compiler/segop_boundary_test.clj
@@ -84,28 +84,26 @@
         (is (some? (:reason d)) "the missing rule")
         (is (some? (:fallback d)) "and what happens instead — a stated outcome, not an absence")))))
 
-(deftest offset-map-is-refused-before-segop-lowering
+(deftest direct-offset-map-enters-the-typed-boundary-before-compatibility
   (let [source '(raster.par/map! out i n :offset base float (aget x i))
-        r (slp/segop-lower-pass
-           (list 'let* ['result source] 'result)
-           {:target-device :ze:0
-            :dtype :float
-            :array-types {'out :float 'x :float}
-            :scalar-types {'n :long 'base :long}})
-        d (first (get-in r [:stats :segops-declined]))]
-    (testing "the middle end records exactly why it cannot represent the write"
-      (is (zero? (get-in r [:stats :segops-lowered])))
-      (is (= :soac (:stage d)))
-      (is (= :offset-map-requires-indexed-store (:reason d))))
-    (testing "the GPU boundary fails loudly instead of emitting an out[i] kernel"
-      (try
-        ((requiring-resolve 'raster.compiler.backend.gpu.opencl-pass/opencl-pass)
-         source :dtype :float :device-id :ze:0 :min-elements 0)
-        (is false "an offset map must remain illegal until typed scatter lowering exists")
-        (catch clojure.lang.ExceptionInfo e
-          (is (= :illegal-op-remains (:reason (ex-data e))))
-          (is (= :offset-map-requires-indexed-store (:missing-rule (ex-data e))))
-          (is (= :none (:fallback (ex-data e)))))))))
+        opts {:target-device :ze:0
+              :dtype :float
+              :array-types {'out :float 'x :float}
+              :scalar-types {'n :long 'base :long}}
+        scheduled (with-redefs [soac/par-form->soac
+                                (fn [& _]
+                                  (throw (AssertionError. "legacy SOAC was constructed")))]
+                    (slp/schedule-single-operation 'out source opts))
+        operation (first (:operations scheduled))
+        emitted ((requiring-resolve 'raster.compiler.backend.gpu.opencl-pass/opencl-pass)
+                 source :dtype :float :device-id :ze:0 :min-elements 0)]
+    (is (some? (:algorithm scheduled)))
+    (is (= :typed-soac (get-in operation [:algorithm-dialect])))
+    (is (= :unique (:write-conflict operation)))
+    (let [kernel-source (:source (first (:kernels emitted)))]
+      (is (re-find #"\[\(base \+ idx\)\]" kernel-source))
+      (is (not (re-find #"inout_result\[idx\] =" kernel-source))
+          "a unique scatter must not acquire a second implicit dense store"))))
 
 (deftest a-fatal-reason-still-escapes
   (testing "a violated invariant is not a missing lowering rule. Recording one as a conversion
@@ -164,30 +162,23 @@
                                          (fn [] (throw (NullPointerException.
                                                         "implementation bug")))))))))))
 
-(deftest map-is-a-full-conversion-with-no-legacy-emitter
-  (testing "a missing SegMap rule leaves an illegal op and cannot silently change code generators"
+(deftest direct-map-is-a-full-typed-conversion-with-no-legacy-emitter
+  (testing "the direct adapter does not need compatibility SOAC lowering for an admitted map"
     (with-redefs [soac-lower/lower-soac (fn [& _] nil)]
-      (try
-        ((requiring-resolve 'raster.compiler.backend.gpu.opencl-pass/opencl-pass)
-         '(raster.par/map! out i n float (clojure.core/aget a i))
-         :dtype :float :min-elements 0)
-        (is false "an unlowered map must fail full conversion")
-        (catch clojure.lang.ExceptionInfo e
-          (is (= :illegal-op-remains (:reason (ex-data e))))
-          (is (= :segop (:target-dialect (ex-data e))))
-          (is (= :none (:fallback (ex-data e))))
-          (is (= :none (get-in (ex-data e) [:decline :fallback]))))))))
+      (let [compiled ((requiring-resolve
+                       'raster.compiler.backend.gpu.opencl-pass/opencl-pass)
+                      '(raster.par/map! out i n float (clojure.core/aget a i))
+                      :dtype :float :min-elements 0)]
+        (is (= 1 (get-in compiled [:stats :ze-maps])))
+        (is (= 1 (get-in compiled [:stats :segop-relowered])))))))
 
-(deftest reduction-is-a-full-conversion-with-no-legacy-emitter
-  (testing "a missing SegRed rule leaves an illegal op and cannot silently change code generators"
+(deftest direct-reduction-is-a-full-typed-conversion-with-no-legacy-emitter
+  (testing "the direct adapter does not need compatibility SOAC lowering for an admitted reduction"
     (with-redefs [soac-lower/lower-soac (fn [& _] nil)]
-      (try
-        ((requiring-resolve 'raster.compiler.backend.gpu.opencl-pass/opencl-pass)
-         '(raster.par/reduce acc 0.0 i n (+ acc (clojure.core/aget a i)))
-         :dtype :float :min-elements 0)
-        (is false "an unlowered reduction must fail full conversion")
-        (catch clojure.lang.ExceptionInfo e
-          (is (= :illegal-op-remains (:reason (ex-data e))))
-          (is (= :segop (:target-dialect (ex-data e))))
-          (is (= :none (:fallback (ex-data e))))
-          (is (= :none (get-in (ex-data e) [:decline :fallback]))))))))
+      (let [compiled ((requiring-resolve
+                       'raster.compiler.backend.gpu.opencl-pass/opencl-pass)
+                      '(raster.par/reduce acc 0.0 i n
+                                          (+ acc (clojure.core/aget a i)))
+                      :dtype :float :min-elements 0)]
+        (is (= 1 (get-in compiled [:stats :ze-reduces])))
+        (is (= 1 (get-in compiled [:stats :segop-relowered])))))))

--- a/test/raster/compiler/segop_boundary_test.clj
+++ b/test/raster/compiler/segop_boundary_test.clj
@@ -105,6 +105,21 @@
       (is (not (re-find #"inout_result\[idx\] =" kernel-source))
           "a unique scatter must not acquire a second implicit dense store"))))
 
+(deftest direct-single-operation-does-not-drop-hoisted-scalar-equations
+  (let [source '(raster.par/map! out i (* n stride) float (aget x i))
+        scheduled (slp/schedule-single-operation
+                   'out source
+                   {:dtype :float
+                    :array-types {'out :float 'x :float}
+                    :scalar-types {'n :long 'stride :long}})
+        operation (first (:operations scheduled))]
+    (is (nil? (:algorithm scheduled))
+        "the one-operation compatibility API cannot return a typed mini-program with host equations")
+    (is (= '(* n stride) (-> operation :space :dims first :bound)))
+    (is (not-any? #(and (symbol? %) (.startsWith (name %) "rstr_extent_"))
+                  (flatten operation))
+        "a hoisted SSA extent must never escape without its defining equation")))
+
 (deftest a-fatal-reason-still-escapes
   (testing "a violated invariant is not a missing lowering rule. Recording one as a conversion
             decline would let the pipeline continue on the legacy path with the bug intact — the

--- a/test/raster/compiler/segop_consumption_test.clj
+++ b/test/raster/compiler/segop_consumption_test.clj
@@ -12,6 +12,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
             [raster.compiler.passes.parallel.segop-lower-pass :as slp]
+            [raster.compiler.passes.parallel.typed-soac-frontend :as typed-frontend]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.backend.gpu.opencl-pass :as op]
             [raster.compiler.backend.jvm.par-simd :as par-simd]
@@ -58,7 +59,8 @@
             lower-soac — observable because compute-launch-params asks the descriptor for THAT id"
     (let [calls (atom [])
           orig raster.compiler.passes.parallel.soac-lower/lower-soac]
-      (with-redefs [raster.compiler.passes.parallel.soac-lower/lower-soac
+      (with-redefs [typed-frontend/form->program (fn [& _] nil)
+                    raster.compiler.passes.parallel.soac-lower/lower-soac
                     (fn [soac device-id & opts] (swap! calls conj device-id) (apply orig soac :ze:0 opts))]
         (op/opencl-pass map-form :device-id :ze:1 :dtype :double :min-elements 0))
       (is (= [:ze:1] @calls) (str "lower-soac was called with " @calls ", not the pass's device-id")))))
@@ -117,7 +119,8 @@
 
 (deftest jvm-simd-does-not-turn-an-implementation-bug-into-scalar-fallback
   (testing "an unstructured re-lowering exception is a compiler bug, not an unsupported SIMD form"
-    (with-redefs [soac/par-form->soac
+    (with-redefs [typed-frontend/form->program (fn [& _] nil)
+                  soac/par-form->soac
                   (fn [& _] (throw (NullPointerException. "simulated SIMD lowering bug")))]
       (is (thrown-with-msg? NullPointerException #"simulated SIMD lowering bug"
                             (run-simd map-form))))))


### PR DESCRIPTION
## Summary
- centralize direct JVM SIMD and OpenCL map/reduce scheduling in one middle-end adapter
- attempt analyzed-source to TypedSOAC first and fall back only on exact structured admission declines
- emit dense, unique-scatter, and fused multi-output maps from the scheduled SegMap ABI without recovering storage from source
- thread declared scalar and array types through direct OpenCL scheduling and remove backend-local legacy SOAC construction

## Validation
- 108 typed fusion/JVM/OpenCL boundary tests, 636 assertions
- 33 OpenCL compatibility tests, 156 assertions
- direct offset scatter regression proves no implicit dense store
- full suite and hardware-free CUDA/HIP compilation delegated to CircleCI