### PR TITLE
Schedule direct GPU programs as one typed unit

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1132,6 +1132,9 @@ The immediate continuation after the verified double-buffered weighted-reduction
    scatter workloads. Direct strided gather and scatter now consume the complete typed
    mini-program: normalization's hoisted product extent remains an ordered host-scalar equation,
    and the backend consumes the following scheduled SegMap without reconstructing either fact.
+   A raw binding program handed directly to the GPU backend likewise enters this whole-program
+   adapter once, preserving cross-equation typed facts instead of independently scheduling each
+   child operation.
    Monolithic C/SIMD now preserves the `ParallelProgram` envelope through host-only length and
    memory-reuse passes. Direct map/reduction sites consume their already scheduled SegMap/SegRed;
    C ABI length legalization is a target expression transform, and the former C-only legacy-SOAC

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -8,6 +8,7 @@
    This is the GPU counterpart of simd-pass — both consume the same
    par form vocabulary but produce different target code."
   (:require [clojure.set :as set]
+            [raster.compiler.ir.form :as form]
             [raster.compiler.ir.par :as par]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.kernel-abi :as kabi]
@@ -301,13 +302,19 @@
                       (:stride (par/extract-par-gather-info form)))
                  (and (par/par-scatter-form? form)
                       (:stride (par/extract-par-scatter-info form)))))
-        direct-program
-        (when direct-strided-indexed?
-          (:program
-           (segop-lower-pass/schedule-single-program
-            (gensym "direct_indexed_result_") form
-            {:target-device device-id :dtype dtype
-             :scalar-types scalar-types :array-types array-types})))
+        direct-schedule
+        (cond
+          (and (nil? supplied-program) (form/binding-form? form))
+          (segop-lower-pass/schedule-source-program
+           form {:target-device device-id :dtype dtype
+                 :scalar-types scalar-types :array-types array-types})
+
+          direct-strided-indexed?
+          (segop-lower-pass/schedule-single-program
+           (gensym "direct_indexed_result_") form
+           {:target-device device-id :dtype dtype
+            :scalar-types scalar-types :array-types array-types}))
+        direct-program (:program direct-schedule)
         parallel-program (or supplied-program direct-program)
         source-form (if parallel-program (parallel-program/source-form parallel-program) form)
         ;; Typed values supply dtypes; scheduled SegOps supply ABI roles. Logical rank cannot choose
@@ -333,9 +340,11 @@
         top-array-types (merge (or (:array-types program-types) {})
                                (or (:array-types (meta source-form)) {})
                                (or (:array-types (meta form)) {}) array-types)
-        stats (atom {:ze-maps 0 :ze-reduces 0 :ze-compounds 0 :ze-contracts 0
-                     :ze-structured-reductions 0 :kernel-graphs 0
-                     :fallback 0})
+        stats (atom (cond-> {:ze-maps 0 :ze-reduces 0 :ze-compounds 0 :ze-contracts 0
+                             :ze-structured-reductions 0 :kernel-graphs 0
+                             :fallback 0}
+                      direct-schedule
+                      (assoc :direct-scheduling (:stats direct-schedule))))
         kernels (atom [])
         dispatches (atom [])
         target-desc (delay

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -540,3 +540,23 @@
      :algorithm (:algorithm equation)
      :diagnostics (:diagnostics scheduled)
      :stats (merge (:stats typed-result) stats)}))
+
+(defn schedule-source-program
+  "Schedule a complete direct-backend binding form through the shared typed boundary.
+
+   This non-cyclic middle-end entry is for backends that receive source without the ordinary
+   pipeline having run. Supported equations retain TypedSOAC algorithms and cross-equation scalar
+   dependencies; a structured source decline remains an explicit compatibility ParallelProgram."
+  [source opts]
+  (let [typed-result
+        (typed-route/attempt
+         source (or (:dtype opts) :double) (:array-types opts)
+         {:resident-reductions? (true? (:resident-reductions? opts))
+          :scalar-types (:scalar-types opts)
+          :values (:values opts)
+          :abstract-machine (:abstract-machine opts)})
+        {scheduled :form stats :stats}
+        (segop-lower-pass (or (:program typed-result) source) opts)]
+    {:program scheduled
+     :declined (:declined typed-result)
+     :stats (merge (:stats typed-result) stats)}))

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -739,48 +739,54 @@
    This normalization inserts an ordinary typed scalar binding immediately before its operation,
    so the same expression remains visible to JVM materialization and runtime specialization."
   [source]
-  (if (and (seq? source) (contains? #{'let 'let*} (first source)))
-    (let [[head bindings & body] source
-          pairs (vec (partition 2 bindings))
-          {:keys [normalized]}
-          (reduce
-           (fn [{:keys [compound-extents] :as state} [ordinal [symbol expression]]]
-             (let [expression (canonicalize-strided-indexed-operation ordinal expression)
-                   extent (parallel-extent expression)
-                   canonical-extent (some-> extent descriptor/unwrap-int-cast)]
-               (cond
-                 (nil? extent)
-                 (update state :normalized conj [symbol expression])
+  ;; Direct backend entry may see source before the ordinary pipeline's SSA cleanup. Clojure
+  ;; permits sequential rebinding (most commonly repeated `_` effect binders), while TypedSOAC
+  ;; deliberately requires one logical definition per value. Use the shared scope-aware
+  ;; alpha-renamer so later references keep their lexical meaning; inventing identities only in
+  ;; operation-description would disconnect host materialization from the semantic equation.
+  (let [source (util/uniquify-rebindings source)]
+    (if (and (seq? source) (contains? #{'let 'let*} (first source)))
+      (let [[head bindings & body] source
+            pairs (vec (partition 2 bindings))
+            {:keys [normalized]}
+            (reduce
+             (fn [{:keys [compound-extents] :as state} [ordinal [symbol expression]]]
+               (let [expression (canonicalize-strided-indexed-operation ordinal expression)
+                     extent (parallel-extent expression)
+                     canonical-extent (some-> extent descriptor/unwrap-int-cast)]
+                 (cond
+                   (nil? extent)
+                   (update state :normalized conj [symbol expression])
 
-                 ;; Integral casts are representation noise, not new semantic dimensions.
-                 ;; Keeping their underlying value identity also prevents one array from
-                 ;; acquiring incompatible [n] and [(long n)] shapes across operations.
-                 (dialect/extent? canonical-extent)
-                 (update state :normalized conj
-                         [symbol (replace-parallel-extent expression canonical-extent)])
-
-                 (provably-pure-scalar? canonical-extent)
-                 (if-let [extent-id (get compound-extents canonical-extent)]
-                   ;; Equal pure extent expressions are one SSA value. Besides avoiding
-                   ;; redundant scalar work, this exposes equal launch geometry to the
-                   ;; general horizontal-fusion rule (for example two same-shaped views).
+                   ;; Integral casts are representation noise, not new semantic dimensions.
+                   ;; Keeping their underlying value identity also prevents one array from
+                   ;; acquiring incompatible [n] and [(long n)] shapes across operations.
+                   (dialect/extent? canonical-extent)
                    (update state :normalized conj
-                           [symbol (replace-parallel-extent expression extent-id)])
-                   (let [extent-id (with-meta
-                                     (clojure.core/symbol (str "rstr_extent_" ordinal))
-                                     {:tag 'long :raster.type/tag 'long})]
-                     (-> state
-                         (assoc-in [:compound-extents canonical-extent] extent-id)
-                         (update :normalized into
-                                 [[extent-id canonical-extent]
-                                  [symbol (replace-parallel-extent expression extent-id)]]))))
+                           [symbol (replace-parallel-extent expression canonical-extent)])
 
-                 :else
-                 (update state :normalized conj [symbol expression]))))
-           {:normalized [] :compound-extents {}}
-           (map-indexed vector pairs))]
-      (with-meta (list* head (vec (mapcat identity normalized)) body) (meta source)))
-    source))
+                   (provably-pure-scalar? canonical-extent)
+                   (if-let [extent-id (get compound-extents canonical-extent)]
+                     ;; Equal pure extent expressions are one SSA value. Besides avoiding
+                     ;; redundant scalar work, this exposes equal launch geometry to the
+                     ;; general horizontal-fusion rule (for example two same-shaped views).
+                     (update state :normalized conj
+                             [symbol (replace-parallel-extent expression extent-id)])
+                     (let [extent-id (with-meta
+                                       (clojure.core/symbol (str "rstr_extent_" ordinal))
+                                       {:tag 'long :raster.type/tag 'long})]
+                       (-> state
+                           (assoc-in [:compound-extents canonical-extent] extent-id)
+                           (update :normalized into
+                                   [[extent-id canonical-extent]
+                                    [symbol (replace-parallel-extent expression extent-id)]]))))
+
+                   :else
+                   (update state :normalized conj [symbol expression]))))
+             {:normalized [] :compound-extents {}}
+             (map-indexed vector pairs))]
+        (with-meta (list* head (vec (mapcat identity normalized)) body) (meta source)))
+      source)))
 
 (defn- alength-array
   [expression]

--- a/test/raster/compiler/contract_soac_node_test.clj
+++ b/test/raster/compiler/contract_soac_node_test.clj
@@ -10,7 +10,6 @@
    downstream reads the facts; nothing re-derives them. `Dot` — one constructor and a unit test —
    is the dead representation this replaces."
   (:require [clojure.test :refer [deftest is testing]]
-            [clojure.string :as str]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.reduction :as reduction]
             [raster.compiler.ir.soac :as soac]
@@ -50,18 +49,18 @@
     (is (= :ze:0 (:device-id (first so))))))
 
 (deftest opencl-pass-consumes-the-segcontract
-  (let [run (fn [f] (op/opencl-pass f :device-id :ze:0 :dtype :double :min-elements 0))
-        norm #(str/replace (str %) #"_\d{3,}" "_N")]
+  (let [run (fn [f] (op/opencl-pass f :device-id :ze:0 :dtype :double :min-elements 0))]
     (testing "consumed after segop-lower — reused, not re-lowered — routing unchanged"
       (let [r (run (:form (slp/segop-lower-pass bound {:target-device :ze:0 :dtype :double})))]
         (is (= 1 (:segop-reused (:stats r))))
         (is (nil? (:segop-relowered (:stats r))))
         (is (= :regtiled (kart/attribute (first (:kernels r)) :strategy)))))
-    (testing "without segop-lower (door C): re-lowered and COUNTED"
-      (is (= 1 (:segop-relowered (:stats (run bound))))))
-    (testing "it is a refactor: identical kernel source both ways"
-      (is (= (norm (:source (first (:kernels (run (:form (slp/segop-lower-pass bound {:target-device :ze:0 :dtype :double})))))))
-             (norm (:source (first (:kernels (run bound))))))))))
+    (testing "without a prior pass, door C schedules the whole typed program once"
+      (let [r (run bound)]
+        (is (= 1 (:segop-reused (:stats r))))
+        (is (nil? (:segop-relowered (:stats r))))
+        (is (= :typed-soac (get-in r [:stats :direct-scheduling :route])))
+        (is (= :regtiled (kart/attribute (first (:kernels r)) :strategy)))))))
 
 (deftest the-cpu-path-still-compiles-and-is-numerically-right
   (testing "the production deftm through compile-aot on the JVM, against a scalar oracle"

--- a/test/raster/compiler/contraction_marker_abi_test.clj
+++ b/test/raster/compiler/contraction_marker_abi_test.clj
@@ -13,7 +13,6 @@
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-graph-call :as kgcall]
             [raster.compiler.ir.kernel-launch :as klaunch]
-            [raster.compiler.passes.parallel.contract-route :as route]
             [raster.core :refer [deftm]]
             [raster.gpu.ocl-runtime :as ocl]
             [raster.gpu.ze-runtime :as ze]))
@@ -71,13 +70,17 @@
   (let [contract (bias-epilogue-contract)
         compiled (compile-form contract)
         kernel (first (:kernels compiled))
+        dispatch (first (:dispatches compiled))
         marker (-> compiled :form second second)]
     (is (= :dpas (kart/attribute kernel :strategy)))
     (is (= '[A B out M N K bias] (mapv :name (:abi kernel))))
     (is (= [:input :input :output :scalar :scalar :scalar :input]
            (mapv :kind (:abi kernel))))
-    (testing "values appear in exactly the same order as ABI slots"
-      (is (= '[A B out 128 256 64 bias] (nth marker 2))))))
+    (testing "the selected artifact preserves its complete ABI while dispatch binds dynamic inputs"
+      (is (= '[A B out 128 256 64 bias] (:arguments kernel)))
+      (is (= 'raster.compiler.pipeline/invoke-scheduled-executable! (first marker)))
+      (is (= (:arguments (kdispatch/default-alternative dispatch)) (nth marker 3)))
+      (is (= '[A B out bias] (nth marker 3))))))
 
 (deftest codegen-only-routing-facts-remain-legal-and-observable
   (let [dp4a '(raster.par/contract C [[i 4] [j 4]] [[l 8]]
@@ -91,8 +94,8 @@
       (is (= :int8x4 (kart/attribute kernel :packed)))
       (is (= [:byte :byte] (mapv :dtype (take 2 (:abi kernel)))))
       (is (= [:int :int] (mapv :kernel-dtype (take 2 (:abi kernel))))))
-    (testing "the ordinary two-input descriptor still emits the production marker"
-      (is (= 'raster.gpu.ze-runtime/invoke-registered-contraction!
+    (testing "the ordinary descriptor emits the production scheduled-executable boundary"
+      (is (= 'raster.compiler.pipeline/invoke-scheduled-executable!
              (-> compiled :form second second first))))))
 
 (deftest epilogue-scalars-occupy-their-real-signature-position
@@ -102,9 +105,13 @@
                                      :scalars [{:sym 'alpha :dtype :float}]}])
         compiled (compile-form contract)
         kernel (first (:kernels compiled))
+        dispatch (first (:dispatches compiled))
         marker (-> compiled :form second second)]
     (is (= '[A B C M N K alpha] (mapv :name (:abi kernel))))
-    (is (= '[A B C 128 256 64 alpha] (nth marker 2)))))
+    (is (= '[A B C 128 256 64 alpha] (:arguments kernel)))
+    (is (= 'raster.compiler.pipeline/invoke-scheduled-executable! (first marker)))
+    (is (= (:arguments (kdispatch/default-alternative dispatch)) (nth marker 3)))
+    (is (= '[A B C alpha] (nth marker 3)))))
 
 (deftest non-argument-pre-steps-remain-fail-loud
   (let [base {:strategy :probe
@@ -113,14 +120,13 @@
               :array-params '[A]
               :dtype :double :out-dtype :double :out-elems 1
               :wg [1 1] :grid [1 1] :scalar-args []}
-        contract (mm 1 1 1)]
-    (let [value [{:op :transpose}]
-          data (with-redefs [route/route-contraction
-                             (fn [& _] (assoc base :pre-steps value))]
-                 (thrown-data #(compile-form contract)))]
-      (is (= :raster/fatal (:reason data)))
-      (is (= [:pre-steps] (:unsupported-fields data)))
-      (is (= {:pre-steps value} (:unsupported-values data))))))
+        value [{:op :transpose}]
+        data (thrown-data
+              #((var op/ensure-contraction-marker-expressible!)
+                (assoc base :pre-steps value)))]
+    (is (= :raster/fatal (:reason data)))
+    (is (= [:pre-steps] (:unsupported-fields data)))
+    (is (= {:pre-steps value} (:unsupported-values data)))))
 
 (deftest runtime-rejects-an-abi-value-count-mismatch-before-touching-the-driver
   (let [kernel-name (str "abi_count_probe_" (gensym))

--- a/test/raster/compiler/segop_consumption_test.clj
+++ b/test/raster/compiler/segop_consumption_test.clj
@@ -6,9 +6,9 @@
    `opencl-pass` used to re-lower each form from scratch with `:ze:0` hardcoded. The equation is now
    consumed directly, with no binder metadata and no second lowering.
 
-   Now the stored SegOp is consumed; re-lowering is the fallback, with the real device-id, and
-   both paths are COUNTED (`:segop-reused` / `:segop-relowered`) so a form that bypasses the
-   pass's output shows up in the stats instead of silently taking a second path."
+   Now the stored SegOp is consumed. A raw binding form first enters the same whole-program typed
+   scheduler, while only bare compatibility expressions request singleton scheduling. Both paths
+   remain counted so bypasses are visible rather than silent."
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.string :as str]
             [raster.compiler.passes.parallel.segop-lower-pass :as slp]
@@ -38,21 +38,42 @@
         (is (= 1 (:segop-reused st)) "…from the SegOp segop-lower attached")
         (is (nil? (:segop-relowered st)) "…and NOT re-lowered")))))
 
-(deftest an-unlowered-form-is-relowered-and-says-so
-  (testing "door C hands opencl-pass a walked body with no segop-lower pass run; the fallback
-            must still work — and must be VISIBLE, not a silent second path"
+(deftest an-unlowered-binding-form-is-scheduled-once-and-consumed
+  (testing "door C may hand opencl-pass a walked body with no prior middle-end pass; the backend
+            schedules the complete program once and then consumes its equations"
     (doseq [[label form] [["par/map!" map-form] ["par/reduce" reduce-form]]]
       (testing label
         (let [st (:stats (run form))]
-          (is (= 1 (:segop-relowered st)))
-          (is (nil? (:segop-reused st))))))))
+          (is (= 1 (:segop-reused st)))
+          (is (nil? (:segop-relowered st)))
+          (is (= :typed-soac (get-in st [:direct-scheduling :route]))))))))
 
 (deftest consuming-is-a-refactor-the-kernel-is-identical
-  (testing "same kernel source whether the SegOp was consumed or re-lowered — this is the
-            assertion that makes the switch safe"
+  (testing "same kernel source whether scheduling happened before or at backend entry"
     (doseq [form [map-form reduce-form]]
       (is (= (norm (:source (first (:kernels (run (lowered form))))))
              (norm (:source (first (:kernels (run form))))))))))
+
+(deftest direct-binding-scheduling-preserves-cross-equation-fusion
+  (let [form '(let* [tmp (raster.par/pmap i n double
+                                           (double
+                                            ^double
+                                            (* (clojure.core/aget X i)
+                                               (clojure.core/aget X i))))
+                      total (raster.par/reduce acc 0.0 j n
+                                               (+ acc (clojure.core/aget tmp j)))]
+                     total)
+        compiled (op/opencl-pass
+                  form :device-id :ze:0 :dtype :double :min-elements 0
+                  :array-types {'X :double} :scalar-types {'n :long})
+        kernel (first (:kernels compiled))]
+    (is (= 1 (count (:kernels compiled))))
+    (is (= 1 (get-in compiled [:stats :ze-reduces])))
+    (is (= 1 (get-in compiled [:stats :segop-reused])))
+    (is (nil? (get-in compiled [:stats :segop-relowered])))
+    (is (= :typed-soac (get-in compiled [:stats :direct-scheduling :route])))
+    (is (not (str/includes? (:source kernel) "TMP"))
+        "the direct backend must not rematerialize a fused semantic intermediate")))
 
 (deftest the-fallback-uses-the-real-device-id
   (testing "re-lowering used `:ze:0` hardcoded. A registered non-:ze:0 target must reach


### PR DESCRIPTION
Makes the raw binding-form GPU entry invoke one shared source -> TypedSOAC -> SegOp adapter before emission. Supported programs preserve cross-equation scalar facts and fusion decisions; structured source declines remain explicit compatibility ParallelPrograms.\n\nThis removes independent per-child scheduling for direct GPU program callers. A map->reduce regression proves the raw entry emits one fused reduction kernel without materializing the semantic intermediate.\n\nValidation: focused GPU correctness, SegOp boundary/consumption, and direct-entry suites are green.