### PR TITLE
Schedule typed JVM programs before SIMD emission

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1134,7 +1134,9 @@ The immediate continuation after the verified double-buffered weighted-reduction
    and the backend consumes the following scheduled SegMap without reconstructing either fact.
    A raw binding program handed directly to the GPU backend likewise enters this whole-program
    adapter once, preserving cross-equation typed facts instead of independently scheduling each
-   child operation.
+   child operation. The JVM SIMD direct entry does the same when its caller supplies an
+   authoritative dtype; untyped compatibility calls remain counted rather than guessing types in
+   the backend.
    Monolithic C/SIMD now preserves the `ParallelProgram` envelope through host-only length and
    memory-reuse passes. Direct map/reduction sites consume their already scheduled SegMap/SegRed;
    C ABI length legalization is a target expression transform, and the former C-only legacy-SOAC

--- a/src/raster/compiler/backend/jvm/par_simd.clj
+++ b/src/raster/compiler/backend/jvm/par_simd.clj
@@ -5,8 +5,9 @@
   Compiles raster.par/reduce → SIMD horizontal reduction with 4 accumulators.
 
   Scheduled programs consume their checked SegOps and treat the retained dtype as authoritative.
-  Direct source callers use an explicit counted compatibility lowering; fusion belongs exclusively
-  to the typed functional middle end.
+  Typed direct source programs enter that same whole-program boundary when given a dtype; untyped
+  source callers retain an explicit counted compatibility lowering. Fusion belongs exclusively to
+  the typed functional middle end.
 
   Supports:
     - Arithmetic: +, -, *, /
@@ -374,7 +375,9 @@
 
   Options:
     :simd? — enable/disable SIMD (default true)
-    :min-elements — minimum elements for SIMD (default 8)"
+    :min-elements — minimum elements for SIMD (default 8)
+    :dtype — authoritative element dtype; enables whole-program direct scheduling
+    :array-types/:scalar-types/:values — optional retained compiler facts for that scheduling"
   [form & {:keys [simd? min-elements dtype scalar-types array-types values abstract-machine]
            :or {simd? true min-elements nil}}]
   (if-not simd?

--- a/src/raster/compiler/backend/jvm/par_simd.clj
+++ b/src/raster/compiler/backend/jvm/par_simd.clj
@@ -21,6 +21,7 @@
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.backend.jvm.segop-simd :as segop-simd]
             [raster.compiler.backend.jvm.bytecode :as bc]
+            [raster.compiler.ir.form :as form]
             [raster.compiler.ir.par :as par]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.segop :as segop]
@@ -374,17 +375,28 @@
   Options:
     :simd? — enable/disable SIMD (default true)
     :min-elements — minimum elements for SIMD (default 8)"
-  [form & {:keys [simd? min-elements] :or {simd? true min-elements nil}}]
+  [form & {:keys [simd? min-elements dtype scalar-types array-types values abstract-machine]
+           :or {simd? true min-elements nil}}]
   (if-not simd?
     (let [p (when (parallel-program/parallel-program? form)
               (parallel-program/validate! form segop/segop-node?))
           source (if p (parallel-program/source-form p) form)]
       {:form (par/expand-par-forms source) :stats {:simd? false}})
-    (let [parallel-program (when (parallel-program/parallel-program? form)
+    (let [supplied-program (when (parallel-program/parallel-program? form)
                              (parallel-program/validate! form segop/segop-node?))
+          direct-schedule
+          (when (and (nil? supplied-program) dtype (form/binding-form? form))
+            (segop-lower-pass/schedule-source-program
+             form {:target-device :cpu:0 :dtype dtype
+                   :scalar-types scalar-types :array-types array-types
+                   :values values :abstract-machine abstract-machine}))
+          parallel-program (or supplied-program (:program direct-schedule))
           source-form (if parallel-program (parallel-program/source-form parallel-program) form)
           min-elements (or min-elements (effective-min-elements))
-          stats (atom {:simd-maps 0 :simd-reduces 0 :fallback 0 :fused 0 :skipped-small 0})
+          stats (atom (cond-> {:simd-maps 0 :simd-reduces 0 :fallback 0
+                               :fused 0 :skipped-small 0}
+                        direct-schedule
+                        (assoc :direct-scheduling (:stats direct-schedule))))
             ;; Scheduled SegOps own their checked dtype. Only the raw compatibility door derives a
             ;; dtype from source syntax, because it has no typed equation to consume.
           take-bound (fn [pred]

--- a/test/raster/compiler/backend/jvm/par_simd_test.clj
+++ b/test/raster/compiler/backend/jvm/par_simd_test.clj
@@ -240,12 +240,14 @@
                          base 2
                          n 3]
                         (raster.par/map! out i n :offset base double (aget x i)))
-          {:keys [form stats]} (par-simd/simd-pass source :min-elements 0)
+          {:keys [form stats]} (par-simd/simd-pass source :min-elements 0 :dtype :double)
           result (eval form)]
       (is (= 1 (:fallback stats))
           "the typed unique-scatter has no JVM vector-store schedule yet")
       (is (= 1 (:segop-relowered stats))
-          "the direct API records its one middle-end compatibility scheduling request")
+          "the production typed route explicitly declines the missing JVM indexed-store schedule")
+      (is (= :offset-map-requires-indexed-store
+             (get-in stats [:direct-scheduling :segops-declined 0 :reason])))
       (is (= [99.0 99.0 10.0 11.0 12.0 99.0] (vec result))))))
 
 ;; ================================================================

--- a/test/raster/compiler/segop_consumption_test.clj
+++ b/test/raster/compiler/segop_consumption_test.clj
@@ -27,7 +27,7 @@
 (defn- run [form] (op/opencl-pass form :device-id :ze:0 :dtype :double :min-elements 0))
 (defn- lowered-cpu [form dtype]
   (:form (slp/segop-lower-pass form {:target-device :cpu:0 :dtype dtype})))
-(defn- run-simd [form] (par-simd/simd-pass form :min-elements 0))
+(defn- run-simd [form] (par-simd/simd-pass form :min-elements 0 :dtype :double))
 (defn- norm [src] (str/replace (str src) #"_\d{3,}" "_N"))
 
 (deftest a-lowered-binding-is-consumed-not-relowered
@@ -66,14 +66,21 @@
         compiled (op/opencl-pass
                   form :device-id :ze:0 :dtype :double :min-elements 0
                   :array-types {'X :double} :scalar-types {'n :long})
-        kernel (first (:kernels compiled))]
+        kernel (first (:kernels compiled))
+        simd (par-simd/simd-pass
+              form :dtype :double :min-elements 0
+              :array-types {'X :double} :scalar-types {'n :long})]
     (is (= 1 (count (:kernels compiled))))
     (is (= 1 (get-in compiled [:stats :ze-reduces])))
     (is (= 1 (get-in compiled [:stats :segop-reused])))
     (is (nil? (get-in compiled [:stats :segop-relowered])))
     (is (= :typed-soac (get-in compiled [:stats :direct-scheduling :route])))
     (is (not (str/includes? (:source kernel) "TMP"))
-        "the direct backend must not rematerialize a fused semantic intermediate")))
+        "the direct backend must not rematerialize a fused semantic intermediate")
+    (is (= 1 (get-in simd [:stats :simd-reduces])))
+    (is (= 1 (get-in simd [:stats :segop-reused])))
+    (is (nil? (get-in simd [:stats :segop-relowered])))
+    (is (= :typed-soac (get-in simd [:stats :direct-scheduling :route])))))
 
 (deftest the-fallback-uses-the-real-device-id
   (testing "re-lowering used `:ze:0` hardcoded. A registered non-:ze:0 target must reach


### PR DESCRIPTION
Extends the whole-program direct-entry boundary to JVM SIMD when the caller supplies an authoritative dtype and optional value/type facts. Supported binding programs preserve TypedSOAC fusion and consume scheduled SegOps once; untyped callers remain on an explicit counted compatibility path rather than triggering backend-local type guesses.\n\nThe shared map->reduce regression now proves both GPU and JVM direct entries retain fusion without rematerializing the intermediate.\n\nValidation: JVM SIMD plus SegOp consumption suites: 35 tests, 106 assertions.