### PR TITLE
Remove surface syntax from typed contraction routing

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -367,8 +367,9 @@ alpha-remapping, and general equations lower mechanically to canonical `SegRed` 
 constructing the former `SoacContract` record. Ordinary scalar `raster.par/contract` source now
 enters this equation directly; the operation is intentionally not a matmul node, so scientific
 contractions, batched reductions and attention-derived reductions share the same semantic
-vocabulary. Until the tensorization route consumes TypedSOAC itself, one shared mechanical
-component projection supplies host materialization and target routing. Ordinary typed contractions
+vocabulary. Target selection consumes the validated equation/facts together with its already
+scheduled `SegRed`; matrix, register-tiled and portable families do not reconstruct a source form
+or a second reduction operation. Ordinary typed contractions
 lower to a canonical `SegRed` whose `ReductionSchedule` records the hardware candidate families,
 workgroup search space and numerical constraints; the validated TypedSOAC equation remains attached
 to its `ProgramEquation`. Candidate families are executable constraints rather than diagnostics:
@@ -377,8 +378,9 @@ loudly when no enabled family can implement the equation. GPU routing derives it
 contraction facts from that equation behind a typed routing API and never reparses the walked source
 form; the OpenCL pipeline
 therefore knows only the typed program, stable operation ID and certified candidate schedule, not
-the projection used by compatibility leaves. Only host materialization and compatibility leaves
-request a generated surface spelling. A segmented reduction may now carry one typed scalar
+the projection used by compatibility leaves. Host materialization and the still-form-backed
+staged/quantized compatibility leaves request an explicit surface spelling locally; it is not a
+common routing invariant. A segmented reduction may now carry one typed scalar
 result-transform: its accumulator, expression, result dtype, tensor operands with axis maps/dtypes,
 and uniform scalar captures with dtypes are all verified at the equation boundary. Contraction
 epilogues expressed by that closed contract therefore stay on TypedSOAC and lower through the same

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -238,6 +238,19 @@
 
 (declare route-2free-1contract route-quant)
 
+(defn- compatibility-form!
+  "Require an explicit source/leaf spelling at a compatibility-only boundary.
+
+   Ordinary typed contraction families consume verified facts plus their scheduled SegRed and
+   must never pass through this gate. A leaf that still operates on surface syntax may project a
+   form explicitly before calling here; the common router does not manufacture one implicitly."
+  [contract-form leaf]
+  (or contract-form
+      (throw (ex-info "contraction compatibility leaf requires a surface form"
+                      {:reason :contraction-compatibility-form-required
+                       :leaf leaf
+                       :fallback :none}))))
+
 (def ^:private splice-capable-strategies
   "Strategies whose scheduled body or emitter has a typed store region and can honour an :epilogue.
    A WHITELIST on purpose: refuse by ABSENCE of support, never by a blacklist of shapes — a
@@ -280,9 +293,10 @@
 (defn route-contraction
   "Route a contraction form through verified facts, an applied hardware schedule and a target leaf.
 
-   `contract-form` may be nil when verified `:facts` are supplied. In that case any temporary
-   source-shaped spelling needed by a compatibility leaf is generated from those facts; routing
-   and legality never inspect the walked source form.
+   `contract-form` may be nil when verified `:facts` and a scheduled operation are supplied.
+   Ordinary typed matrix, register-tiled, portable and full-reduction routes need no source
+   spelling. Staged, SegMap and source fallbacks require one explicitly; the int8 compatibility
+   leaf performs its temporary projection locally until it consumes the typed scalar vocabulary.
 
    Canonical f16 products first become a target-neutral KernelBody and are then lowered by the
    OpenCL DPAS backend.  Unsupported shapes retain the portable register-tiled route.  Byte/int8
@@ -293,9 +307,9 @@
                            candidate-families scheduled-operation]
                     :or {dtype :half prefer-peak? false}}]
   (let [contract-facts (or facts (cf/contraction-facts contract-form :dtype dtype))
-        contract-form (or contract-form (:form contract-facts) (cf/surface-form contract-facts))
-        _ (when-not (and (cf/facts? contract-facts) contract-form)
-            (throw (ex-info "contraction routing requires verified facts and a target spelling"
+        contract-form (or contract-form (:form contract-facts))
+        _ (when-not (cf/facts? contract-facts)
+            (throw (ex-info "contraction routing requires verified facts"
                             {:reason :contraction-route-input
                              :facts contract-facts :form contract-form})))
         out-sym (:out contract-facts)
@@ -326,7 +340,7 @@
                             {:reason :contraction-candidate-families
                              :families candidate-families
                              :allowed contraction-families})))
-        tensorize-plan (memoize #(route-2free-1contract contract-form out-sym dtype desc tile
+        tensorize-plan (memoize #(route-2free-1contract out-sym dtype desc tile
                                                         epilogue contract-facts operation-id
                                                         candidate-families))]
     ;; Every descriptor is validated against the kernel it describes before it leaves this fn. The
@@ -342,7 +356,8 @@
       ;; contraction algebra at all. The flat leaves below cannot represent it — they have one
       ;; accumulator. 1 stage is the flat case and is left to them.
         (and (seq stages) (> (count stages) 1))
-        (let [;; The staged emitter hardwires `+=` at every level, and a lift's linearity argument
+        (let [contract-form (compatibility-form! contract-form :staged-segred)
+              ;; The staged emitter hardwires `+=` at every level, and a lift's linearity argument
             ;; assumes `+`. A form carrying :combine max routed here and was SILENTLY SUMMED —
             ;; contraction-facts surfaces :combine and nothing read it. Refuse rather than ignore.
               _ (let [cmb (:combine (cf/scalar-reduction-view contract-facts))]
@@ -386,7 +401,12 @@
 
       ;; int8 → the quant leaves (dp4a for :nt, quant naive-widening for :nn)
         (#{:byte :int8} dtype)
-        (route-quant contract-form out-sym n-free n-contract nseg prefer-peak?)
+        (route-quant
+         ;; Quant leaves still rewrite surface layout for the optional transpose pre-step. Keep
+         ;; that temporary projection local to the leaf instead of making syntax a common router
+         ;; invariant; ordinary typed contraction families never observe it.
+         (compatibility-form! (or contract-form (cf/surface-form contract-facts)) :quant)
+         out-sym n-free n-contract nseg prefer-peak?)
 
       ;; 0 FREE axes → a full reduction to a scalar. This is the last cell of contract's
       ;; algebra: (n free, 0 contract) = map, (n, n) = contraction, (0, n) = REDUCTION. The
@@ -396,7 +416,9 @@
       ;; says so with :invoke :reduction rather than pretending it is a 2-D kernel launch.
         (zero? n-free)
         (let [sr (or scheduled-operation
-                     (cl/contract-form->segred contract-form :dtype dtype :facts contract-facts))
+                     (cl/contract-form->segred
+                      (compatibility-form! contract-form :full-reduce)
+                      :dtype dtype :facts contract-facts))
               k (sco/generate-segred-kernel sr out-sym :dtype dtype)
               attrs (:attributes k)
               red-bound (second (first contract-axes))]
@@ -415,7 +437,8 @@
            :scalar-args [] :dims [1]})
 
         (zero? n-contract)
-        (let [sm (cl/contract-form->segmap contract-form :dtype dtype)
+        (let [sm (cl/contract-form->segmap
+                  (compatibility-form! contract-form :segmap) :dtype dtype)
               {:keys [kernel-name source array-params scalar-params abi]}
               (sco/generate-segmap-nd-kernel sm out-sym :dtype dtype)]
           {:strategy :segmap
@@ -445,7 +468,9 @@
                              :declines (when (and (= 2 n-free) (= 1 n-contract))
                                          (::declines (tensorize-plan)))})))
           (let [sr (or scheduled-operation
-                       (cl/contract-form->segred contract-form :dtype dtype :facts contract-facts))
+                       (cl/contract-form->segred
+                        (compatibility-form! contract-form :portable-segred)
+                        :dtype dtype :facts contract-facts))
                 portable (contraction-schedule/plan-portable-body contract-facts sr desc)
                 emitted (when (:ok portable)
                           (sco/generate-contraction-kernel-body (:body portable)))
@@ -934,7 +959,7 @@
    shape could express neither: a decline is usually LEGITIMATE (symbolic dims, a non-`+` combine and
    a non-product body are all perfectly good contractions that merely are not tiled-leaf shaped), and
    it is always worth REPORTING."
-  [contract-form out-sym dtype desc tile epilogue contract-facts operation-id candidate-families]
+  [out-sym dtype desc tile epilogue contract-facts operation-id candidate-families]
   (let [acc (volatile! [])
         note! (fn [d] (vswap! acc conj d) nil)
         matrix? (contains? candidate-families :matrix)

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -906,6 +906,9 @@
         (with-redefs [contraction-facts/contraction-facts
                       (fn [& _]
                         (throw (ex-info "typed routing reparsed source" {})))
+                      contraction-facts/surface-form
+                      (fn [& _]
+                        (throw (ex-info "typed routing manufactured source" {})))
                       contract-lower/contract-form->segred
                       (fn [& _]
                         (throw (ex-info "typed routing rebuilt its scheduled SegRed" {})))]
@@ -916,6 +919,9 @@
         (with-redefs [contraction-facts/contraction-facts
                       (fn [& _]
                         (throw (ex-info "candidate routing reparsed source" {})))
+                      contraction-facts/surface-form
+                      (fn [& _]
+                        (throw (ex-info "candidate routing manufactured source" {})))
                       contract-lower/contract-form->segred
                       (fn [& _]
                         (throw (ex-info "candidate routing rebuilt its scheduled SegRed" {})))]
@@ -926,6 +932,9 @@
         (with-redefs [contraction-facts/contraction-facts
                       (fn [& _]
                         (throw (ex-info "typed emission reparsed source" {})))
+                      contraction-facts/surface-form
+                      (fn [& _]
+                        (throw (ex-info "typed emission manufactured source" {})))
                       contract-lower/contract-form->segred
                       (fn [& _]
                         (throw (ex-info "typed emission rebuilt its scheduled SegRed" {})))]
@@ -998,6 +1007,20 @@
     (is (empty? (:dispatches emitted)))
     (is (= 1 (count (:kernels emitted))))))
 
+(deftest compatibility-contraction-without-source-or-schedule-fails-loud
+  (let [source '(raster.par/contract C [[i 8]] [[l 8]]
+                                       (* (clojure.core/aget A (+ (* i 8) l))
+                                          (clojure.core/aget B l)))
+        facts (dissoc (contraction-facts/contraction-facts source :dtype :float) :form)]
+    (try
+      (contract-route/route-contraction nil :dtype :float :facts facts)
+      (is false "a compatibility fallback must not reconstruct syntax implicitly")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :contraction-compatibility-form-required
+               (:reason (ex-data exception))))
+        (is (= :portable-segred (:leaf (ex-data exception))))
+        (is (= :none (:fallback (ex-data exception))))))))
+
 (deftest typed-contraction-schedule-families-control-leaf-selection
   (let [source
         '(let* [step (raster.par/contract C [[i 128] [j 128]] [[l 128]]
@@ -1013,32 +1036,43 @@
         descriptor {:matrix {:family :dpas :m 8 :n 16 :k 16 :subgroup 16}
                     :grf-bytes-per-lane 256 :subgroup-size 16
                     :max-workgroup-size 1024 :shared-local-memory 131072}
+        without-surface
+        (fn [thunk]
+          (with-redefs [contraction-facts/surface-form
+                        (fn [& _]
+                          (throw (ex-info "ordinary typed family manufactured source" {})))]
+            (thunk)))
         select-family
         (fn [family]
-          (contract-route/route-typed-contraction
-           algorithm (assoc operation :schedule
-                            (assoc-in (:schedule operation) [:tuning-space :families] [family]))
-           :dtype :half :desc descriptor))
+          (without-surface
+           #(contract-route/route-typed-contraction
+             algorithm (assoc operation :schedule
+                              (assoc-in (:schedule operation) [:tuning-space :families] [family]))
+             :dtype :half :desc descriptor)))
         candidates
-        (contract-route/route-typed-contraction-candidates!
-         algorithm operation
-         :dtype :half :desc descriptor)
+        (without-surface
+         #(contract-route/route-typed-contraction-candidates!
+           algorithm operation
+           :dtype :half :desc descriptor))
         dispatch
-        (contract-route/route-static-typed-contraction-dispatch
-         algorithm operation
-         :dtype :half :desc descriptor)
+        (without-surface
+         #(contract-route/route-static-typed-contraction-dispatch
+           algorithm operation
+           :dtype :half :desc descriptor))
         alternatives (:alternatives dispatch)
-        emitted (with-redefs [hardware/descriptor-for (constantly descriptor)]
-                  (opencl-pass/opencl-pass form :device-id :ocl:0
-                                           :dtype :half :min-elements 0))
+        emitted (without-surface
+                 #(with-redefs [hardware/descriptor-for (constantly descriptor)]
+                    (opencl-pass/opencl-pass form :device-id :ocl:0
+                                             :dtype :half :min-elements 0)))
         emitted-dispatch (first (:dispatches emitted))
         measured-selector {:kind :fixed-strategy :strategy :portable-segred}
         measured-emitted
-        (with-redefs [hardware/descriptor-for (constantly descriptor)]
-          (opencl-pass/opencl-pass
-           form :device-id :ocl:0 :dtype :half :min-elements 0
-           :schedule {:typed-contraction
-                      {:measured-selectors {(:id emitted-dispatch) measured-selector}}}))
+        (without-surface
+         #(with-redefs [hardware/descriptor-for (constantly descriptor)]
+            (opencl-pass/opencl-pass
+             form :device-id :ocl:0 :dtype :half :min-elements 0
+             :schedule {:typed-contraction
+                        {:measured-selectors {(:id emitted-dispatch) measured-selector}}})))
         measured-dispatch (first (:dispatches measured-emitted))]
     (is (= :dpas (:strategy (select-family :matrix))))
     (is (= :regtiled (:strategy (select-family :register-tiled))))


### PR DESCRIPTION
## Summary
- route ordinary typed contractions from validated equation facts plus the scheduled SegRed without manufacturing a par/contract form
- keep surface projection explicit and local to the still-form-backed int8 compatibility leaf
- make unscheduled compatibility fallbacks fail loudly when their required source spelling is absent
- cover matrix, register-tiled, portable, candidate-dispatch, and production OpenCL routes against accidental source reconstruction

## Validation
- `raster.compiler.passes.parallel.typed-soac-route-test`: 45 tests, 360 assertions
- DP4A, quantized, staged, and ABI compatibility group: 33 tests passed; one local device-fixture launch errored in Level Zero mock/driver setup before assertions