### PR TITLE
Retain wrapping scalar arithmetic in KernelBody

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -211,7 +211,10 @@ sources. Uniform memory facts require an explicit body-level stable-read contrac
 KernelBody-to-ABI seam projects it to a no-write-alias precondition, artifacts reject equal compiler
 bindings, direct calls check resident ranges, and graph/link binding retains its stronger
 overlapping-write rejection. Floating narrowing distinguishes IEEE overflow from integral
-wrap/saturate/trap policies. Whole-kernel workgroup allocations now have static typed shapes, named
+wrap/saturate/trap policies. Unchecked integral add/subtract/multiply retain an explicit wrapping
+policy in scalar SSA, and the shared C-family lowering performs those operations in the
+same-width unsigned representation rather than relying on undefined signed overflow. Whole-kernel
+workgroup allocations now have static typed shapes, named
 layouts, explicit 1–16-byte alignment, and one deterministic packed-memory plan; launch shared-byte
 accounting must match that plan exactly. Full-participation acquire/release workgroup barriers are
 rejected outside workgroup-uniform control flow and lower from the same operation to OpenCL,

--- a/design/soac-fusion.md
+++ b/design/soac-fusion.md
@@ -78,7 +78,9 @@ models can refine a choice, while the typed program and numerical oracle constra
    movement) with direct typed equations and schedules.
 2. Finish explicit typed scalar SSA for every region; do not recover scalar types in emitters or
    beta-reduce away type contracts.
-3. Add explicit integer arithmetic semantics (`wrap`, `trap`, or proved no-overflow) before using
+3. Finish explicit integer arithmetic semantics. Unchecked source add/subtract/multiply now retain
+   `:wrap` in scalar `KernelBody` SSA and C-family targets execute them through the corresponding
+   unsigned representation; add `trap` and proved-no-overflow contracts before admitting ordinary
    integral scalar algebra for indexing, RNG, and quantization.
 4. Generalize `AxisMap` and layout facts for multidimensional views, strided gather/scatter, and
    block movement without turning layouts into semantic tensor operators.

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -903,8 +903,17 @@
         lowering (intrinsics/op->c-lowering op false)
         arguments (mapv #(emit-scalar-value % context) (:arguments expression))
         operand-type (scalar-value-type (first (:arguments expression)) (:types context))
-        integral? (contains? #{:byte :int :long} operand-type)]
+        integral? (contains? #{:byte :int :long} operand-type)
+        wrapping? (= {:overflow :wrap} (:options expression))]
     (cond
+      ;; C-family signed overflow is undefined. Preserve the verified modulo-2^N contract by
+      ;; doing the arithmetic in the same-width unsigned representation and converting the bits
+      ;; back to the expression's declared signed storage type.
+      wrapping?
+      (let [unsigned-type (c-dialect/unsigned-type-name *scalar-dialect* operand-type)]
+        (str "(" (target-type operand-type) ")((" unsigned-type ")(" (first arguments)
+             ") " (:op lowering) " (" unsigned-type ")(" (second arguments) "))"))
+
       ;; The shared C descriptor uses the floating spelling. OpenCL integer min/max are distinct
       ;; overloads, so target spelling must retain the verified operand dtype.
       (and integral? (contains? #{:min :max} op))

--- a/src/raster/compiler/backend/intrinsics.clj
+++ b/src/raster/compiler/backend/intrinsics.clj
@@ -172,7 +172,10 @@
 ;; local-name → canonical key (covers raster.numeric/Math/clojure.core syms and
 ;; bare names; arithmetic + comparison spellings both routed here).
 (def ^:private name->key
-  {"+" :+ "-" :- "*" :* "/" :div
+  {"+" :+ "unchecked-add" :+ "unchecked-add-int" :+
+   "-" :- "unchecked-subtract" :- "unchecked-subtract-int" :-
+   "*" :* "unchecked-multiply" :* "unchecked-multiply-int" :*
+   "/" :div
    "<" :lt ">" :gt "<=" :le ">=" :ge "==" :eq "=" :eq "not=" :ne "!=" :ne
    "rem" :rem "unchecked-remainder-int" :rem "mod" :mod "quot" :quot
    "bit-and" :bit-and "bit-or" :bit-or "bit-xor" :bit-xor
@@ -205,6 +208,24 @@
     :else nil))
 
 (defn descriptor [op] (get table (canonical op)))
+
+;; These source operations carry a semantic promise that is not part of canonical operator
+;; identity: JVM-width integral arithmetic wraps modulo 2^N.  Keep the distinction here, beside
+;; canonicalization, so scalar frontends retain it in typed IR and target emitters never recover
+;; it from a function name.
+(def ^:private wrapping-arithmetic-names
+  #{"unchecked-add" "unchecked-add-int"
+    "unchecked-subtract" "unchecked-subtract-int"
+    "unchecked-multiply" "unchecked-multiply-int"})
+
+(defn source-overflow-policy
+  "Return the explicit overflow contract carried by source operation `op`, if any.
+
+  This describes source semantics only. Callers still provide and verify the authoritative
+  operand/result dtype before attaching the policy to typed IR."
+  [op]
+  (when (and (symbol? op) (contains? wrapping-arithmetic-names (name op)))
+    :wrap))
 
 ;; Semantic scalar domains are centralized beside canonical operator identity.  Backend facets say
 ;; how an operation is spelled; they do not by themselves prove that (for example) sqrt accepts an

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -1062,13 +1062,21 @@
       intrinsic
       (let [arity (:arity intrinsic)
             kind (:kind intrinsic)
-            operand-type (same-types! "scalar intrinsic" infos)]
+            operand-type (same-types! "scalar intrinsic" infos)
+            wrapping? (= {:overflow :wrap} options)]
         (when-not (= arity (count infos))
           (throw (ex-info "scalar intrinsic arity mismatch"
                           {:operation canonical-op :expected arity :actual (count infos)})))
-        (when (seq options)
+        (when (and (seq options) (not wrapping?))
           (throw (ex-info "scalar intrinsic does not accept unspecified lowering options"
                           {:operation canonical-op :options options})))
+        (when (and wrapping?
+                   (not (and (contains? #{:+ :- :*} canonical-op)
+                             (contains? #{:byte :int :long} operand-type))))
+          (throw (ex-info "wrapping overflow is only defined for integral add, subtract, and multiply"
+                          {:reason :kernel-body-intrinsic-overflow
+                           :operation canonical-op :operand-type operand-type
+                           :options options})))
         (when (= :predicate operand-type)
           (throw (ex-info "numeric intrinsics cannot consume predicate values"
                           {:operation canonical-op})))

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -257,7 +257,8 @@
                               {:expression expression}))
 
                   (seq? expression)
-                  (let [operator (intrinsics/canonical (descriptor/semantic-op expression))
+                  (let [semantic-operation (descriptor/semantic-op expression)
+                        operator (intrinsics/canonical semantic-operation)
                         intrinsic (intrinsics/descriptor operator)
                         arguments (vec (descriptor/call-args expression))]
                     (when-not intrinsic
@@ -290,6 +291,8 @@
                                               operand-type expression)
                                             arguments)
                               result-type (if comparison? :predicate operand-type)
+                              overflow (intrinsics/source-overflow-policy semantic-operation)
+                              options (cond-> {} overflow (assoc :overflow overflow))
                               _ (when-not (every? #(= operand-type (:type %)) lowered)
                                   (decline! :operand-dtype
                                             "scalar intrinsic operands require one dtype"
@@ -299,9 +302,10 @@
                           {:operations
                            (conj (vec (mapcat :operations lowered))
                                  (body/->ScalarCompute
-                                  (body/value result result-type)
+                                 (body/value result result-type)
                                   (body/scalar-expression operator result-type
-                                                          (mapv :result lowered))))
+                                                          (mapv :result lowered)
+                                                          options)))
                            :result result :type result-type}))))
 
                   :else

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -6,7 +6,8 @@
             [raster.compiler.backend.gpu.kernel-body-opencl :as opencl]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.ir.kernel-body :as body]
-            [raster.compiler.ir.kernel-launch :as launch]))
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.passes.parallel.scalar-expression-body :as scalar-expression]))
 
 (defn- scalar-kernel-body []
   (let [group 'query-row
@@ -131,6 +132,21 @@
     :indices [(body/->IndexBinding 'lane :local 0)]
     :operations [(body/->AtomicRMW 'out ['lane] 'contribution :+ nil)]
     :launch (launch/spec {:workgroup-size [16] :group-count [1]})
+    :provenance {:dialect :test}
+    :attributes {:kind :scalar}}))
+
+(defn- wrapping-arithmetic-kernel-body []
+  (body/make
+   {:id :wrapping-arithmetic-test
+    :parameters [(body/->KernelParameter 'a :scalar :long [] nil nil :left)
+                 (body/->KernelParameter 'b :scalar :long [] nil nil :right)
+                 (body/->KernelParameter 'out :output :long [1] :global
+                                         (layout/row-major [1] :long) :result)]
+    :operations [(body/->ScalarCompute
+                  (body/value 'sum :long)
+                  (body/scalar-expression :+ :long ['a 'b] {:overflow :wrap}))
+                 (body/->ScalarStore 'out [0] 'sum nil)]
+    :launch (launch/spec {:workgroup-size [1] :group-count [1]})
     :provenance {:dialect :test}
     :attributes {:kind :scalar}}))
 
@@ -265,6 +281,31 @@
             {:keys [exit err]} (shell/sh "clang" "-x" "cl" "-cl-std=CL2.0"
                                          "-fsyntax-only" "-" :in source)]
         (is (zero? exit) err)))))
+
+(deftest unchecked-source-arithmetic-retains-wrapping-semantics
+  (let [decline! (fn [rule message data]
+                   (throw (ex-info message (assoc data :rule rule))))
+        lowerer (scalar-expression/make-lowerer
+                 {:array-types {} :scalar-types {'a :long 'b :long} :arrays #{}
+                  :index-scope #{} :lower-index (fn [value _] value)
+                  :decline! decline!})
+        lowered ((:lower lowerer) '(unchecked-add a b) :long
+                 {'a :long 'b :long})]
+    (is (= {:overflow :wrap}
+           (get-in lowered [:operations 0 :expression :options])))
+    (is (= :+ (get-in lowered [:operations 0 :expression :op]))))
+  (doseq [[target unsigned-type]
+          [[:opencl-portable "ulong"]
+           [:cuda "unsigned long long"]
+           [:hip "unsigned long long"]]]
+    (testing (name target)
+      (let [source (opencl/emit-scalar-kernel
+                    "wrapping_arithmetic" (wrapping-arithmetic-kernel-body)
+                    {:target-dialect target})]
+        (is (str/includes? source
+                           (str "(" unsigned-type ")(rstr_a) + (" unsigned-type ")(rstr_b)")))
+        (is (not (str/includes? source "rstr_a + rstr_b"))
+            "signed target arithmetic must not weaken modulo-2^N semantics")))))
 
 (deftest registry-intrinsic-helpers-follow-the-c-family-target
   (doseq [[target qualifier physical-op compiler]

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -287,6 +287,34 @@
            (body/->ScalarCompute
             (body/value 'converted :int)
             (body/cast-expression 'x-value :int :toward-zero :saturate))]))))
+  (testing "integral arithmetic may carry an explicit wrapping contract"
+    (is (body/kernel-body?
+         (scalar-body
+          [(body/->ScalarCompute
+            (body/value 'wrapped :long)
+            (body/scalar-expression
+             :* :long [(body/literal Long/MAX_VALUE :long)
+                       (body/literal 2 :long)]
+             {:overflow :wrap}))]))))
+  (testing "wrapping overflow is not a floating-point policy"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"wrapping overflow is only defined"
+         (scalar-body
+          [(load-x)
+           (body/->ScalarCompute
+            (body/value 'bad :float)
+            (body/scalar-expression :+ :float
+                                    ['x-value (body/literal 1.0 :float)]
+                                    {:overflow :wrap}))]))))
+  (testing "wrapping overflow cannot annotate unrelated integral intrinsics"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"wrapping overflow is only defined"
+         (scalar-body
+          [(body/->ScalarCompute
+            (body/value 'bad :int)
+            (body/scalar-expression :bit-xor :int
+                                    [(body/literal 1 :int) (body/literal 2 :int)]
+                                    {:overflow :wrap}))]))))
   (testing "integral sources do not accept a fictitious rounding direction"
     (is (thrown-with-msg?
          clojure.lang.ExceptionInfo #"policies disagree"


### PR DESCRIPTION
## Summary
- retain unchecked add/subtract/multiply overflow semantics as typed ScalarExpr options
- verify wrapping only for integral add/subtract/multiply
- lower modulo-2^N arithmetic through same-width unsigned C-family representations
- cover source retention and shared OpenCL/CUDA/HIP spelling

## Validation
- 34 tests, 222 assertions (KernelBody IR and C-family scalar emitter)

This is the semantic prerequisite for replacing the handwritten SplitMix64 RNG and active-ID kernels with ordinary typed map equations.