### PR TITLE
Lower RNG fill as an ordinary typed map

### DIFF
--- a/design/soac-fusion.md
+++ b/design/soac-fusion.md
@@ -74,8 +74,9 @@ models can refine a choice, while the typed program and numerical oracle constra
 
 ## Remaining work
 
-1. Replace remaining compatibility operation coverage (RNG, collect/atomics, and specialized block
-   movement) with direct typed equations and schedules.
+1. Replace remaining compatibility operation coverage (active-ID narrowing, collect/atomics, and
+   specialized block movement) with direct typed equations and schedules. RNG fill is now an
+   ordinary typed map with wrapping SplitMix64 scalar SSA.
 2. Finish explicit typed scalar SSA for every region; do not recover scalar types in emitters or
    beta-reduce away type contracts.
 3. Finish explicit integer arithmetic semantics. Unchecked source add/subtract/multiply now retain

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -277,7 +277,7 @@
 
    Uses full SegOp conversion for par/map! and par/reduce.
    Certified effect-only map-void forms consume their scheduled TypedSOAC SegMap; unsupported
-   bodies and the remaining stencil, scatter, rng, active-id and key-reduction forms retain
+   bodies and the remaining stencil, scatter, active-id and key-reduction forms retain
    explicit compatibility generators.
 
    Returns {:form new-form :stats {:ze-maps N :ze-reduces N :fallback N}
@@ -296,9 +296,10 @@
   ;; would otherwise misfire the "offset"→int heuristic). Form-meta types are the base.
   (let [supplied-program (when (parallel-program/parallel-program? form)
                            (parallel-program/validate! form segop/segop-node?))
-        direct-strided-indexed?
+        direct-mini-program?
         (and (nil? supplied-program)
-             (or (and (par/par-gather-form? form)
+             (or (par/par-rng-fill-form? form)
+                 (and (par/par-gather-form? form)
                       (:stride (par/extract-par-gather-info form)))
                  (and (par/par-scatter-form? form)
                       (:stride (par/extract-par-scatter-info form)))))
@@ -309,7 +310,7 @@
            form {:target-device device-id :dtype dtype
                  :scalar-types scalar-types :array-types array-types})
 
-          direct-strided-indexed?
+          direct-mini-program?
           (segop-lower-pass/schedule-single-program
            (gensym "direct_indexed_result_") form
            {:target-device device-id :dtype dtype
@@ -674,14 +675,21 @@
                              :source form :target-dialect :kernel-graph
                              :fallback :none}))
 
-            ;; par/rng-fill!
+            ;; par/rng-fill! is a source convenience for an ordinary typed map. This branch only
+            ;; projects the scheduled artifact back into the direct backend's compatibility call.
             (par/par-rng-fill-form? form)
-            (let [{:keys [seeds n base-seed]} (par/extract-par-rng-fill-info form)
-                  k (register-kernel!
-                     (legacy/generate-par-rng-fill-kernel)
-                     :ze-maps)]
-              (list 'raster.gpu.ze-runtime/invoke-registered-rng-fill-kernel
-                    (:kernel-name k) seeds n base-seed))
+            (if-let [scheduled (take-bound-segop
+                                stats :segmap
+                                #(and (instance? raster.compiler.ir.segop.SegMap %)
+                                      (= :typed-soac (:algorithm-dialect %))))]
+              (let [kernel (segop-cl/generate-scheduled-segmap-kernel
+                            scheduled :dtype (:dtype scheduled)
+                            :scalar-types top-scalar-types :array-types top-array-types)
+                    k (register-kernel! kernel :ze-maps)]
+                (emit-map-invocation k device-id))
+              (throw (ex-info "GPU RNG fill source has no verified TypedSOAC map schedule"
+                              {:reason :unscheduled-rng-fill
+                               :target-dialect :kernel-body :form form :fallback :none})))
 
             ;; par/active-ids!
             (par/par-active-ids-form? form)

--- a/src/raster/compiler/backend/gpu/par_opencl.clj
+++ b/src/raster/compiler/backend/gpu/par_opencl.clj
@@ -555,38 +555,6 @@
                      {:name 'base-seed :type :long}]
      :active-ids? true}))
 
-(defn generate-par-rng-fill-kernel
-  "Generate an OpenCL kernel for raster.par/rng-fill! (splitmix64 per-element).
-  Each work-item computes: seeds[i] = splitmix64(base_seed + i * golden_ratio_64).
-  Fully parallel — no inter-thread communication needed.
-
-  Returns {:kernel-name str :source str :array-params ['seeds]
-           :scalar-params [{:name 'n :type :int} {:name 'base-seed :type :long}]
-           :rng-fill? true}."
-  [& {:keys [kernel-name device-id]
-      :or {kernel-name (str "par_rng_fill_" (gensym ""))}}]
-  (let [src (str "#pragma OPENCL EXTENSION cl_khr_int64_base_atomics : enable\n"
-                 "__kernel void " kernel-name
-                 "(__global long* seeds, int _n_bound, long base_seed) {\n"
-                 "  int i = get_global_id(0);\n"
-                 "  if (i >= _n_bound) return;\n"
-                 "  ulong state = (ulong)base_seed + (ulong)(long)i * (ulong)0x9e3779b97f4a7c15L;\n"
-                 "  state ^= state >> 30;\n"
-                 "  state *= (ulong)0xbf58476d1ce4e5b9L;\n"
-                 "  state ^= state >> 27;\n"
-                 "  state *= (ulong)0x94d049bb133111ebL;\n"
-                 "  state ^= state >> 31;\n"
-                 "  seeds[i] = (long)state;\n"
-                 "}\n")
-        spv-bytes (when device-id
-                    (compile-kernel-to-spirv src :device-id device-id))]
-    {:kernel-name kernel-name
-     :source src
-     :spv-bytes spv-bytes
-     :array-params ['seeds]
-     :scalar-params [{:name 'n :type :int} {:name 'base-seed :type :long}]
-     :rng-fill? true}))
-
 ;; ================================================================
 ;; Scatter kernel generator
 ;; ================================================================

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -354,6 +354,48 @@
 (defn- operation-description
   [id symbol expression default-dtype]
   (cond
+    ;; SplitMix64 is pointwise scalar algebra, not a semantic parallel primitive. Preserve the
+    ;; public convenience operation's fixed-width ABI here, then expose an ordinary typed map to
+    ;; fusion and scheduling. Wrapping arithmetic remains explicit in the scalar source and is
+    ;; retained by scalar-expression-body when a schedule becomes KernelBody SSA.
+    (par/par-rng-fill-form? expression)
+    (let [{:keys [seeds n base-seed]} (par/extract-par-rng-fill-info expression)
+          typed-symbol (fn [value tag]
+                         (if (symbol? value)
+                           (with-meta value (merge (meta value)
+                                                  {:tag tag :raster.type/tag tag}))
+                           value))
+          extent (typed-symbol (descriptor/unwrap-int-cast n) 'int)
+          base (typed-symbol (descriptor/unwrap-int-cast base-seed) 'long)
+          index (with-meta (clojure.core/symbol (str "rstr_rng_index_" id))
+                  {:tag 'long :raster.type/tag 'long})
+          local (fn [name]
+                  (with-meta (clojure.core/symbol (str "rstr_rng_" name "_" id))
+                    {:tag 'long :raster.type/tag 'long}))
+          state (local "state")
+          s1 (local "s1")
+          s2 (local "s2")
+          s3 (local "s3")
+          s4 (local "s4")
+          s5 (local "s5")
+          locals [{:id state :dtype :long
+                   :init (list 'unchecked-add base
+                               (list 'unchecked-multiply (list 'long index) par/SM-GAMMA))}
+                  {:id s1 :dtype :long
+                   :init (list 'bit-xor state
+                               (list 'unsigned-bit-shift-right state 30))}
+                  {:id s2 :dtype :long :init (list 'unchecked-multiply s1 par/SM-MIX1)}
+                  {:id s3 :dtype :long
+                   :init (list 'bit-xor s2 (list 'unsigned-bit-shift-right s2 27))}
+                  {:id s4 :dtype :long :init (list 'unchecked-multiply s3 par/SM-MIX2)}
+                  {:id s5 :dtype :long
+                   :init (list 'bit-xor s4 (list 'unsigned-bit-shift-right s4 31))}]]
+      {:kind :map :id id :sym symbol :results [symbol]
+       :index index :extent extent :locals locals :casts [nil] :bodies [s5]
+       :inputs #{} :outputs #{seeds} :scalars (set (filter symbol? [base]))
+       :result-storage [{:destination seeds :access :write :host-return :buffer}]
+       :host-binding symbol :elem-type :long :source-operation :raster.par/rng-fill!})
+
     (par/par-scatter-form? expression)
     (let [{:keys [out src index n stride]} (par/extract-par-scatter-info expression)]
       (when-not stride
@@ -670,6 +712,7 @@
 (defn- parallel-extent
   [expression]
   (cond
+    (par/par-rng-fill-form? expression) (:n (par/extract-par-rng-fill-info expression))
     (par/par-map-pure-form? expression) (nth expression 2)
     (par/par-map-form? expression) (nth expression 3)
     (par/par-map2-form? expression) (nth expression 4)
@@ -684,6 +727,7 @@
 (defn- replace-parallel-extent
   [expression extent]
   (let [position (cond
+                   (par/par-rng-fill-form? expression) 2
                    (par/par-map-pure-form? expression) 2
                    (par/par-map-form? expression) 3
                    (par/par-map2-form? expression) 4

--- a/src/raster/gpu/core.clj
+++ b/src/raster/gpu/core.clj
@@ -823,7 +823,7 @@
         (release-kernel-graph! sess handle)))))
 
 (defn invoke-rng-fill!
-  "Invoke a compiled parallel RNG fill kernel from the session.
+  "Invoke the compiled typed-map RNG fill artifact from the session.
 
    sess: session atom
    phase-key: keyword identifying the RNG fill kernel
@@ -834,8 +834,9 @@
   (let [{:keys [kernels buffers]} @sess
         kernel-info (first (get kernels phase-key))
         device-id (:device-id @sess)
-        invoke! (rt-resolve device-id "invoke-registered-rng-fill-kernel")]
-    (invoke! (:kernel-name kernel-info) (get buffers buf-key) n base-seed)))
+        invoke! (rt-resolve device-id "invoke-registered-kernel")]
+    (invoke! (:kernel-name kernel-info) [] (get buffers buf-key)
+             [{:type :long :value (long base-seed)}] n)))
 
 (defn invoke-active-ids!
   "Invoke a compiled parallel active-id generation kernel from the session.

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -1250,34 +1250,6 @@
                            a))]
           full-arr)))))
 
-(defn invoke-registered-rng-fill-kernel
-  "Invoke a compiled rng-fill kernel. Same interface as ze_runtime."
-  [^String kernel-name seeds-buf n ^long base-seed]
-  (ensure-init!)
-  (let [{:keys [kernel-handle workgroup-size]
-         :or {workgroup-size 256}} (ensure-kernel-loaded! kernel-name)
-        {:keys [queue]} @state
-        n (long n)
-        wg (long workgroup-size)
-        global-size (* wg (long (Math/ceil (/ (double n) wg))))]
-    ;; Set args: ids-buf, n_active (reused as n), base_seed, n_agents (reused as n)
-    (set-kernel-arg-buffer! kernel-handle 0 (:cl-mem seeds-buf))
-    (set-kernel-arg-scalar! kernel-handle 1 {:type :int :value (int n)})
-    (set-kernel-arg-scalar! kernel-handle 2 {:type :long :value base-seed})
-
-    (let [arena (Arena/ofConfined)]
-      (try
-        (let [global-seg (.allocate arena I64)
-              local-seg (.allocate arena I64)]
-          (.set global-seg I64 0 (long global-size))
-          (.set local-seg I64 0 (long wg))
-          (cl-call! "clEnqueueNDRangeKernel" @h-clEnqueueNDRangeKernel
-                    [queue kernel-handle (int 1) MemorySegment/NULL
-                     global-seg local-seg (int 0) MemorySegment/NULL MemorySegment/NULL])
-          (cl-call! "clFinish" @h-clFinish [queue]))
-        (finally (.close arena))))
-    (buffer->array seeds-buf)))
-
 (defn invoke-registered-active-ids-kernel
   "Invoke a compiled active-ids kernel. Same interface as ze_runtime."
   [^String kernel-name ids-buf n-active n-agents base-seed]

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -3284,34 +3284,6 @@
     output-array))
 
 ;; ================================================================
-;; RNG fill kernel invocation (splitmix64 parallel seed generation)
-;; ================================================================
-
-(defn invoke-registered-rng-fill-kernel
-  "Invoke a compiled rng-fill kernel to fill a seeds buffer on-device.
-  Generates n splitmix64 seeds from base-seed + i*golden_ratio in parallel.
-
-  kernel-name: registered rng-fill kernel
-  seeds-buf:   DeviceBuffer (long, n elements) or JVM long-array
-  n:           number of seeds to generate
-  base-seed:   scalar long seed from which per-element seeds are derived"
-  [^String kernel-name seeds-buf n ^long base-seed]
-  (let [{:keys [kernel-handle workgroup-size]} (ensure-kernel-loaded! kernel-name)
-        n (long n)
-        wg (long (or workgroup-size 256))
-        groups (long (Math/ceil (/ (double n) (double wg))))
-        seeds-seg (if (device-buffer? seeds-buf)
-                    (:segment ^DeviceBuffer seeds-buf)
-                    (let [ab (* n 8)
-                          seg (ensure-seg kernel-name :seeds-buf ab)
-                          src (MemorySegment/ofArray seeds-buf)]
-                      (MemorySegment/copy src 0 seg 0 ab)
-                      seg))]
-    (launch! kernel-handle groups wg
-             [seeds-seg {:type :int :value (int n)} {:type :long :value base-seed}])
-    seeds-buf))
-
-;; ================================================================
 ;; Active-ids kernel invocation (splitmix64 random index generation)
 ;; ================================================================
 

--- a/test/raster/abm/firms/gpu_test.clj
+++ b/test/raster/abm/firms/gpu_test.clj
@@ -242,6 +242,21 @@
       (par/active-ids! ids2 n-active n-agents 77777)
       (is (= (seq ids1) (seq ids2)) "Same seed must be deterministic"))))
 
+(deftest rng-fill-session-api-uses-the-generic-map-abi
+  (let [call (atom nil)
+        session (atom {:device-id :ze:0
+                       :kernels {:fill-rng-seeds [{:kernel-name "typed_rng_map"}]}
+                       :buffers {:rng-seeds :resident-seeds}})
+        resolver (fn [_device operation]
+                   (is (= "invoke-registered-kernel" operation))
+                   (fn [& arguments] (reset! call arguments)))]
+    (with-redefs-fn
+      {(ns-resolve 'raster.gpu.core 'rt-resolve) resolver}
+      #(gpu/invoke-rng-fill! session :fill-rng-seeds :rng-seeds 17 42))
+    (is (= ["typed_rng_map" [] :resident-seeds
+            [{:type :long :value 42}] 17]
+           @call))))
+
 (deftest test-active-ids-codegen
   (testing "generate-par-active-ids-kernel emits correct long types"
     (let [k (par-opencl/generate-par-active-ids-kernel)]

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -55,6 +55,58 @@
                                      (+ acc (clojure.core/aget shared k)))]
          [mapped reduced]))
 
+(deftest rng-fill-is-an-ordinary-typed-map
+  (let [source '(let* [result (raster.par/rng-fill! seeds n base-seed)] result)
+        {:keys [program stats]}
+        (route/attempt source :long {'seeds :long}
+                       {:scalar-types {'n :int 'base-seed :long}})
+        algorithm (get-in program [:equations 0 :algorithm])
+        equation (first (dialect/equations algorithm))
+        operation (dialect/operation-parts equation)
+        locals (:locals (dialect/lambda-parts (:lambda operation)))
+        scheduled (:form (segop-lower/segop-lower-pass
+                          program {:dtype :long :target-device :ze:0}))
+        segmap (first (get-in scheduled [:equations 0 :operations]))
+        emitted (segop-opencl/generate-scheduled-segmap-kernel
+                 segmap :dtype :long
+                 :array-types {'seeds :long}
+                 :scalar-types {'n :int 'base-seed :long})]
+    (is (= :typed-soac (:route stats)))
+    (is (= 'map (:kind operation))
+        "RNG is scalar algebra in the existing functional map vocabulary")
+    (is (= 6 (count locals)))
+    (is (= [:long :long :long :long :long :long] (mapv :dtype locals)))
+    (is (= #{:wrap}
+           (into #{}
+                 (keep #(when (= "ScalarCompute" (some-> % class .getSimpleName))
+                          (get-in % [:expression :options :overflow])))
+                 (get-in emitted [:attributes :kernel-body :operations])))
+        "unchecked SplitMix arithmetic remains explicit after scheduling")
+    (is (re-find #"\(ulong\).* \* \(ulong\)" (:source emitted)))
+    (is (not (re-find #"par_rng_fill" (:source emitted)))))
+  (testing "the direct backend API enters the same complete typed mini-program"
+    (let [{:keys [kernels form]}
+          (opencl-pass/opencl-pass
+           '(raster.par/rng-fill! seeds n base-seed)
+           :dtype :long :min-elements 1
+           :array-types {'seeds :long}
+           :scalar-types {'n :int 'base-seed :long})]
+      (is (= 1 (count kernels)))
+      (is (re-find #"\(ulong\).* \* \(ulong\)" (:source (first kernels))))
+      (is (some #{'raster.gpu.ze-runtime/invoke-registered-kernel} (flatten form)))
+      (is (not-any? #{'raster.gpu.ze-runtime/invoke-registered-rng-fill-kernel}
+                    (flatten form)))))
+  (testing "the primitive signature casts emitted by macro expansion are canonicalized"
+    (let [{:keys [program]}
+          (route/attempt
+           '(let* [result (raster.par/rng-fill! seeds (int n) (long base-seed))]
+                  result)
+           :long {'seeds :long})
+          algorithm (get-in program [:equations 0 :algorithm])
+          operation (dialect/operation-parts (first (dialect/equations algorithm)))]
+      (is (= ['base-seed] (:captures operation)))
+      (is (= 'n (get-in operation [:attributes :extent]))))))
+
 (deftest production-route-retains-hardware-costed-placement-witnesses
   (let [poor (route/attempt expensive-fanout :float {'x :float}
                             {:abstract-machine {:ridge {:float 2.0}}})


### PR DESCRIPTION
## Summary
- project rng-fill! to the existing typed map algebra with six explicit long SSA locals
- preserve SplitMix64 wrapping arithmetic through KernelBody and shared C-family emission
- remove the handwritten OpenCL RNG generator and OpenCL/Level Zero-specific launch wrappers
- route the session API through the generic emitter-authored map ABI

## Validation
- typed SOAC route: 46 tests, 373 assertions
- focused generic session ABI test: 1 test, 2 assertions

The active-ID primitive remains separate until its long-to-int narrowing is backed by an explicit range proof.