### PR TITLE
Lower typed integer case maps through KernelBody

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -130,9 +130,11 @@ Pointwise maps that read and write their caller-owned destination stay on this s
 typed equation records read/write destination access, and GPU lowering emits that storage exactly
 once as a `KernelABI` `:inout` pointer with semantic role `:result`. Physical access and functional
 identity are therefore orthogonal: resident and staged binders derive transfers from ABI kind,
-while composition identifies the returned value by role. OpenCL and Level Zero staged maps also
-use target-specific invocation markers selected by the emitter, rather than leaking a Level Zero
-runtime call into an OpenCL program.
+while composition identifies the returned value by role. The portable schedule admits an inout
+map only when every destination read uses the same logical element index as its write; shifted or
+indirect reads still require a stencil, scatter, or ordered schedule. OpenCL and Level Zero staged
+maps also use target-specific invocation markers selected by the emitter, rather than leaking a
+Level Zero runtime call into an OpenCL program.
 
 Effect-only pointwise maps now use the same orthogonal contract for several outputs. `map2!` and
 independent multi-store `map-void!` bodies become one tuple-valued TypedSOAC `map`: fresh logical
@@ -144,9 +146,12 @@ map-void bodies retain the compatibility generator. The front end refuses duplic
 uncontracted scatter indices, sibling write/read ordering, and atomics. A destination wrapped in
 `par/unique-index` carries an explicit caller proof of conflict freedom into a TypedSOAC `scatter`;
 the marker is consumed before scalar lowering, while the checked read/write storage contract and
-guarded indexed store remain visible to scheduling and ABI construction. Shared scalar work now remains one
-explicit ordered local-SSA spine inside the tuple map's scalar region; each definition has a dtype
-retained from walker/TypedClojure facts, and local binders never become fake program inputs.
+guarded indexed store remain visible to scheduling and ABI construction. Shared scalar work now
+remains one explicit ordered local-SSA spine inside the tuple map's scalar region; nested lexical
+scopes are alpha-renamed into that spine, each definition has a dtype retained from
+walker/TypedClojure facts, and local binders never become fake program inputs. Closed-core integer
+`case*` dispatch is projected into exact typed conditional expressions before scheduling; hash
+dispatch maps and switch metadata never reach KernelBody or a target emitter.
 Validation proves definition order and lexical closure, and the front end expands locals only for
 I/O discovery. A direct sibling-destination read still preserves imperative store ordering and
 declines the functional tuple map, while a typed local may snapshot any destination before the

--- a/design/soac-fusion.md
+++ b/design/soac-fusion.md
@@ -37,6 +37,12 @@ ordered multi-results, physical result-storage contracts, effects, aliases, and 
 provenance. Contraction result transforms are represented as typed store regions rather than as a
 hard-coded attention or linear-algebra fusion pass.
 
+Nested source scopes are alpha-renamed into the same ordered local-SSA region. Finite closed-core
+integer `case*` forms become exact conditional scalar expressions at the TypedSOAC boundary, so
+Clojure dispatch tables and keyword metadata are never part of scheduled or emitted kernel IR.
+Guarded dense updates remain ordinary maps only when all reads of an inout result use the lane's
+same logical index; nonlocal reads require a different certified schedule.
+
 ## Legality boundary
 
 A transformation is legal only when the TypedSOAC value/effect facts prove it. In particular:

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -131,6 +131,14 @@
                   {:operations [] :result expression
                    :type (canon-type (:type expression))}
 
+                  (and (= :predicate expected) (number? expression))
+                  (if (contains? #{0 1} expression)
+                    {:operations [] :result (body/literal (= 1 expression) :predicate)
+                     :type :predicate}
+                    (decline! :predicate-literal
+                              "numeric predicates must use the canonical zero/one encoding"
+                              {:expression expression}))
+
                   (number? expression)
                   {:operations [] :result (body/literal expression expected) :type expected}
 

--- a/src/raster/compiler/passes/parallel/segmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segmap_body.clj
@@ -85,6 +85,18 @@
            :result (first body)})
         {:locals [] :result expression}))))
 
+(defn- same-element-inout?
+  "Prove that every read of a writable result is owned by the same logical work item.
+
+   A same-index read followed by a same-index write is ordinary private lane state, not a
+   cross-lane alias hazard.  Shifted/indirect reads remain outside the portable SegMap schedule;
+   they require a stencil, scatter, or an explicitly ordered schedule."
+  [inout index expressions]
+  (every? (fn [{:keys [sym idx]}]
+            (or (not (contains? inout sym))
+                (= index (descriptor/unwrap-int-cast idx))))
+          (mapcat descriptor/aget-reads expressions)))
+
 (defn lower
   "Apply a portable grid-stride scalar schedule to a typed one-dimensional SegMap."
   [segmap {:keys [workgroup-size array-types scalar-types]
@@ -116,9 +128,13 @@
         explicit-certified-write?
         (and (nil? primary-output)
              (contains? #{:unique :reduce} (:write-conflict segmap)))
-        _ (when (and (seq inout) (not explicit-certified-write?))
+        {:keys [locals result]} (scalar-region segmap)
+        same-element-inout?
+        (same-element-inout? inout index (conj (mapv :init locals) result))
+        _ (when (and (seq inout)
+                     (not (or explicit-certified-write? same-element-inout?)))
             (decline! :inout-storage
-                      "portable dense map stable reads must not alias writable results"
+                      "portable dense map writable results may only read their lane-owned element"
                       {:operation (:id segmap) :inputs inputs :outputs outputs}))
         default-dtype (dtype/canon (or (:dtype segmap) :float))
         array-dtype (fn [id]
@@ -145,7 +161,6 @@
                   :arrays (set inputs) :index-scope index-scope
                   :lower-index lower-index :predicate :map-active
                   :id-prefix "map" :decline! decline!})
-        {:keys [locals result]} (scalar-region segmap)
         base-environment (assoc scalar-types index :long)
         local-state
         (reduce

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -136,13 +136,64 @@
                  (every? :dtype locals))
         locals))))
 
+(defn- integer-case-chain
+  "Project one closed-core integer `case*` into the conditional scalar vocabulary.
+
+   Clojure has already bound the tested expression before producing `case*`, so accepting only a
+   symbolic test preserves its evaluate-once semantics.  The clause map's dispatch hashes are an
+   implementation detail; exact integer test values are retained in its `[test-value result]`
+   entries.  Other case representations decline instead of leaking hash/keyword interpretation
+   into a target emitter."
+  [expression]
+  (when (and (seq? expression) (= 'case* (first expression)))
+    (let [[_ test _shift _mask default clauses _switch-type test-type] expression
+          ordered-clauses (when (and (map? clauses) (every? integer? (keys clauses)))
+                            (->> clauses
+                                 (sort-by key)
+                                 (mapv val)))]
+      (when (and (symbol? test)
+                 (= :int test-type)
+                 (map? clauses)
+                 (every? integer? (keys clauses))
+                 (every? #(and (vector? %) (= 2 (count %))
+                                (integer? (first %)))
+                         ordered-clauses))
+        (reduce (fn [otherwise [test-value result]]
+                  (list 'if (list 'clojure.core/== test test-value)
+                        result otherwise))
+                default (reverse ordered-clauses))))))
+
+(defn- substitute-store
+  [substitutions store]
+  (reduce (fn [store field]
+            (update store field #(util/subst-syms substitutions %)))
+          store [:index :predicate :value]))
+
+(defn- rebase-region-locals
+  "Move a recursively recognized region behind `offset` lexical SSA values.
+
+   Every nested scope initially numbers its locals from zero.  Rebasing before composing scopes
+   gives the combined region one deterministic, collision-free SSA namespace."
+  [{:keys [locals stores]} offset]
+  (let [renames (into {}
+                      (map-indexed
+                       (fn [ordinal {:keys [id]}]
+                         [id (symbol (str "rstr_local_" (+ offset ordinal)))])
+                       locals))]
+    {:locals (mapv (fn [{:keys [id] :as local}]
+                     (-> local
+                         (assoc :id (get renames id))
+                         (update :init #(util/subst-syms renames %))))
+                   locals)
+     :stores (mapv #(substitute-store renames %) stores)}))
+
 (defn- pointwise-region
   "Recognize an ordered, pure local-SSA spine ending exclusively in indexed stores.
 
-   Local types come only from retained walker/TypedClojure facts. Nested local scopes and missing
-   local types decline; guessing them in this source recognizer or a C emitter would make the
-   region only nominally typed. Store legality is checked separately after local dependencies are
-   expanded for analysis."
+   Local types come only from retained walker/TypedClojure facts. Nested lexical scopes are
+   alpha-renamed into one ordered SSA spine; missing local types decline because guessing them in
+   this source recognizer or a C emitter would make the region only nominally typed. Store
+   legality is checked separately after local dependencies are expanded for analysis."
   [body index]
   (cond
     (and (seq? body) (form/let-head? (first body)))
@@ -150,38 +201,37 @@
       (when (and (even? (count bindings))
                  (seq nested-body)
                  (not-any? util/effectful? (take-nth 2 (rest bindings))))
-        (when-let [{nested-locals :locals stores :stores}
-                   (pointwise-region (list* 'do nested-body) index)]
-          ;; Flattening nested lexical scopes needs alpha-renaming across each scope. Keep this
-          ;; first production slice to the ANF shape the walker emits: one local spine around the
-          ;; store sequence.
-          (when (empty? nested-locals)
-            (let [pairs (vec (partition 2 bindings))
-                  typed (mapv (fn [[binding init]]
-                                [binding init (retained-local-dtype binding init)])
-                              pairs)]
-              (when (every? (comp some? #(nth % 2)) typed)
-                (let [{:keys [locals substitutions]}
-                      (reduce (fn [{:keys [locals substitutions]} [binding init local-dtype]]
-                                (let [id (symbol (str "rstr_local_" (count locals)))]
-                                  {:locals (conj locals
-                                                 {:id id :dtype local-dtype
-                                                  :init (util/subst-syms substitutions init)})
-                                   :substitutions (assoc substitutions binding id)}))
-                              {:locals [] :substitutions {}} typed)]
-                  {:locals locals
-                   :stores (mapv (fn [store]
-                                   (reduce (fn [store field]
-                                             (update store field
-                                                     #(util/subst-syms substitutions %)))
-                                           store [:index :predicate :value]))
-                                 stores)})))))))
+        (when-let [nested-region (pointwise-region (list* 'do nested-body) index)]
+          (let [pairs (vec (partition 2 bindings))
+                typed (mapv (fn [[binding init]]
+                              [binding init (retained-local-dtype binding init)])
+                            pairs)]
+            (when (every? (comp some? #(nth % 2)) typed)
+              (let [{:keys [locals substitutions]}
+                    (reduce (fn [{:keys [locals substitutions]} [binding init local-dtype]]
+                              (let [id (symbol (str "rstr_local_" (count locals)))]
+                                {:locals (conj locals
+                                               {:id id :dtype local-dtype
+                                                :init (util/subst-syms substitutions init)})
+                                 :substitutions (assoc substitutions binding id)}))
+                            {:locals [] :substitutions {}} typed)
+                    nested (rebase-region-locals nested-region (count locals))]
+                {:locals (into locals
+                               (map #(update % :init
+                                             (fn [init]
+                                               (util/subst-syms substitutions init))))
+                               (:locals nested))
+                 :stores (mapv #(substitute-store substitutions %)
+                               (:stores nested))}))))))
 
     (and (seq? body) (= 'do (first body)))
-    (let [groups (mapv #(pointwise-region % index) (rest body))]
-      (when (and (seq groups) (every? some? groups)
-                 (every? (comp empty? :locals) groups))
-        {:locals [] :stores (vec (mapcat :stores groups))}))
+    (let [expressions (vec (rest body))]
+      (if (= 1 (count expressions))
+        (pointwise-region (first expressions) index)
+        (let [groups (mapv #(pointwise-region % index) expressions)]
+          (when (and (seq groups) (every? some? groups)
+                     (every? (comp empty? :locals) groups))
+            {:locals [] :stores (vec (mapcat :stores groups))}))))
 
     (and (seq? body)
          (contains? #{'if 'clojure.core/if} (first body))
@@ -211,6 +261,10 @@
                                 predicate
                                 (list 'if predicate % 0))))))
                (range) (:stores then-region))}))
+
+    (and (seq? body) (= 'case* (first body)))
+    (when-let [conditional (integer-case-chain body)]
+      (pointwise-region conditional index))
 
     (descriptor/aset-call? body)
     (let [arguments (vec (descriptor/call-args body))]

--- a/test/raster/compiler/equation_first_c_family_test.clj
+++ b/test/raster/compiler/equation_first_c_family_test.clj
@@ -72,6 +72,24 @@
                                                     (raster.arrays/aget input index))))
        (raster.arrays/aset right index (long index)))))
 
+(deftm c-family-case-map!
+  [choices :- (Array int) output :- (Array float) n :- Long] :- Void
+  (raster.par/map-void!
+   index n
+   (case (raster.arrays/aget choices index)
+     0 (raster.arrays/aset output index (float 10.0))
+     1 (raster.arrays/aset output index (float 20.0))
+     nil)))
+
+(deftm c-family-shifted-inout!
+  [output :- (Array float) n :- Long] :- Void
+  (raster.par/map-void!
+   index n
+   (raster.arrays/aset
+    output index
+    (raster.arrays/aget output
+                        (if (< (inc index) n) (inc index) (long 0))))))
+
 (deftm c-family-stencil
   [input :- (Array float) n :- Long] :- (Array float)
   (let [output (float-array n)]
@@ -178,6 +196,30 @@
                    (get-in kernel [:attributes :kernel-body :parameters]))))
       (is (empty? (:outputs linked)) "Void host semantics remain effect-only")
       (is (= :none (get-in compilation [:stats :fallback]))))))
+
+(deftest public-integer-case-map-lowers-through-portable-kernel-control
+  (doseq [[target module-target]
+          [[cuda-target :cuda-c]
+           [hip-target :hip-cpp]]]
+    (let [compilation (equation-first/compile
+                       #'c-family-case-map! {:target target :dtype :float})
+          kernel (first (:kernels compilation))
+          operations (nested-operations
+                      (get-in kernel [:attributes :kernel-body :operations]))]
+      (is (= module-target (:target kernel)))
+      (is (= :portable-segmap
+             (get-in kernel [:attributes :kernel-body :attributes :kind])))
+      (is (some #(= "IfRegion" (some-> % class .getSimpleName)) operations))
+      (is (not (str/includes? (:source kernel) "case*")))
+      (is (= :none (get-in compilation [:stats :fallback]))))))
+
+(deftest portable-inout-map-refuses-a-cross-lane-read
+  (let [reason (reason-of #(equation-first/compile
+                            #'c-family-shifted-inout!
+                            {:target cuda-target :dtype :float}))]
+    (is (= :kernel-graph-target-lowering-missing (:reason reason)))
+    (is (= :inout-storage
+           (get-in reason [:kernel-body-decline :missing-rule])))))
 
 (deftest public-gqa-composition-emits-only-portable-c-family-kernels
   (doseq [[target program-dialect module-target]

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -597,6 +597,59 @@
                   (keys (:values (dialect/facts program))))
         "region-local SSA values are lexical, not fake program inputs")))
 
+(deftest nested-typed-scopes-share-one-alpha-stable-region
+  (let [expression
+        '(raster.par/map-void!
+          i n
+          (let* [^float shifted (+ (clojure.core/aget x i) 1.0)]
+                (let* [^float squared (* shifted shifted)]
+                      (clojure.core/aset out i (float squared)))))
+        program (frontend/form->program
+                 (list 'let* ['effect expression] 'effect)
+                 {:dtype :float :array-types {'x :float 'out :float}})
+        equation (first (dialect/equations program))
+        {:keys [locals body-results]}
+        (dialect/lambda-parts (:lambda (dialect/operation-parts equation)))]
+    (is (= [{:id 'rstr_local_0 :dtype :float
+             :init '(+ %element0 1.0)}
+            {:id 'rstr_local_1 :dtype :float
+             :init '(* rstr_local_0 rstr_local_0)}]
+           locals))
+    (is (= '[(float rstr_local_1)] body-results))))
+
+(deftest closed-core-integer-case-becomes-a-typed-conditional-map
+  (let [expression
+        '(raster.par/map-void!
+          i n
+          (let* [^int choice (clojure.core/aget choices i)]
+                (case* choice 0 0 nil
+                       {0 [0 (clojure.core/aset out i (float 10.0))]
+                        1 [1 (clojure.core/aset out i (float 20.0))]}
+                       :compact :int)))
+        program (frontend/form->program
+                 (list 'let* ['effect expression] 'effect)
+                 {:dtype :float :array-types {'choices :int 'out :float}})
+        equation (first (dialect/equations program))
+        {:keys [body-results]}
+        (dialect/lambda-parts (:lambda (dialect/operation-parts equation)))
+        result (first body-results)]
+    (is (= 'map (dialect/operation-kind equation)))
+    (is (= 'out (first (dialect/physical-results program equation))))
+    (is (not-any? #{'case* :compact :int} (flatten result)))
+    (is (some #{'clojure.core/==} (flatten result)))
+    (is (some #{10.0 20.0} (flatten result)))))
+
+(deftest noninteger-case-representation-declines-the-typed-route
+  (let [expression
+        '(raster.par/map-void!
+          i n
+          (case* choice 0 0 nil
+                 {0 [:stay (clojure.core/aset out i (float 10.0))]}
+                 :compact :hash-equiv))]
+    (is (nil? (frontend/form->program
+               (list 'let* ['effect expression] 'effect)
+               {:dtype :float :array-types {'out :float}})))))
+
 (deftest typed-local-snapshots-may-feed-several-updated-destinations
   (let [source
         '(let* [effect

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -211,8 +211,9 @@
     (is (= [:inout] (mapv :kind pointer-slots)))
     (is (= [:result] (mapv :role pointer-slots)))
     (is (= '[target n] (:arguments artifact)))
-    (is (re-find #"inout_result\[idx\]" (:source artifact))
-        "the scalar-region read is projected through the sole result parameter")
+    (is (re-find #"rstr_map_load_\d+ = .*target\[" (:source artifact))
+        "the scalar-region read is projected through the sole typed result parameter")
+    (is (re-find #"target\[.*\] = rstr_map_value_\d+" (:source artifact)))
     (is (some #{'raster.gpu.ocl-runtime/invoke-registered-kernel}
               (tree-seq coll? seq (:form emitted))))
     (is (not (some #{'raster.gpu.ze-runtime/invoke-registered-kernel}
@@ -269,13 +270,13 @@
     (is (= :typed-soac (:source-dialect stats)))
     (is (= [:write :read-write]
            (mapv :access (get-in equation [:attributes :result-storage]))))
-    (is (= ['b 'x 'a] (mapv :name pointer-slots)))
-    (is (= [:inout :input :output] (mapv :kind pointer-slots)))
+    (is (= ['x 'b 'a] (mapv :name pointer-slots)))
+    (is (= [:input :inout :output] (mapv :kind pointer-slots)))
     (is (= 1 (count (filter #(= 'b (:name %)) pointer-slots)))
         "a read/write destination is one physical ABI value, not aliased input and output slots")
     (is (= #{'a 'b} (:outputs (first (:operations equation)))))
-    (is (re-find #"b\[idx\] = \(float\)" (:source artifact)))
-    (is (re-find #"out\[idx\]" (:source artifact)))))
+    (is (re-find #"b\[.*\] = rstr_map_value_\d+" (:source artifact)))
+    (is (re-find #"a\[.*\] = rstr_map_load_\d+" (:source artifact)))))
 
 (deftest typed-tuple-map-preserves-effect-semantics-on-the-jvm
   (let [source '(let* [effect


### PR DESCRIPTION
## Summary
- alpha-rename nested typed lexical scopes into one TypedSOAC scalar SSA region
- project closed-core integer case dispatch into exact typed conditionals
- admit only proven same-element inout maps in the portable SegMap schedule
- canonicalize SOAC 0/1 predicates to KernelBody booleans

## Verification
- typed SOAC frontend: 26 tests, 149 assertions
- equation-first C-family: 10 tests, 98 assertions (including CUDA/HIP case emission and shifted-inout refusal)
- broad and vendor compiler suites delegated to CircleCI