### PR TITLE
Schedule typed ordered effect maps

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -162,6 +162,16 @@ bridge is introduced only when reuse requires it, so fusion does not duplicate s
 resident `deftm` signatures provide their declared per-buffer dtypes before fusion, so a
 mixed FP32/int8-input, FP32/int32-output map does not inherit a global default dtype.
 
+Mixed kernels whose lane performs both unique writes and certified reductions use a distinct
+typed `effect-map`, rather than disguising ordered mutation as a tuple-valued functional map. Its
+ordered destinations, predicates, local SSA and per-destination conflict certificates schedule
+directly to one `SegMap`; unique effects lower to `ScalarStore`, reductions lower to `AtomicRMW`,
+and guarded effects retain structured `IfRegion` control in the common `KernelBody`. The same body
+and ordered ABI emit as portable OpenCL, CUDA, and HIP. Fusion treats this operation as a
+conservative boundary until an effect-aware rule proves that moving or combining it preserves the
+declared memory order. Source selection remains gated on proving indirect-write uniqueness rather
+than inferring it from a workload or variable name.
+
 Adam and AdamW use this effect-map contract directly: gradient is a read-only operand, parameter
 and moment buffers are typed inout storage, and the bias-corrected moment snapshots form one local
 SSA spine evaluated before all three writes. Each optimizer lowers as one certified resident

--- a/design/soac-fusion.md
+++ b/design/soac-fusion.md
@@ -27,6 +27,10 @@ contractions represented as segmented reductions, and scalar equations needed to
 shape/value dependencies. It also defines a conservative ordered effect-map boundary for kernels
 that mix unique writes and certified atomic reductions. Each destination and conflict proof is
 explicit; effect maps remain non-fusible until an effect-aware rule proves a transformation.
+The GPU schedule projects their ordered local SSA and guarded effects directly into one `SegMap`:
+unique effects become `ScalarStore`, checked reduction effects become `AtomicRMW`, and predicates
+become structured `IfRegion` nodes. OpenCL, CUDA, and HIP therefore consume the same verified
+`KernelBody`; the operation is not reconstructed as source-level mutation in an emitter.
 
 Fusion iterates three general transformations to a fixpoint:
 
@@ -82,9 +86,10 @@ models can refine a choice, while the typed program and numerical oracle constra
 
 ## Remaining work
 
-1. Replace remaining compatibility operation coverage (active-ID narrowing, collect/atomics, and
-   specialized block movement) with direct typed equations and schedules. RNG fill is now an
-   ordinary typed map with wrapping SplitMix64 scalar SSA.
+1. Select the ordered effect-map from closed typed source for remaining mixed unique-write/atomic
+   workloads, requiring explicit uniqueness and reduction proofs. Replace active-ID narrowing and
+   specialized block-movement compatibility coverage with direct typed equations and schedules.
+   RNG fill is now an ordinary typed map with wrapping SplitMix64 scalar SSA.
 2. Finish explicit typed scalar SSA for every region; do not recover scalar types in emitters or
    beta-reduce away type contracts.
 3. Finish explicit integer arithmetic semantics. Unchecked source add/subtract/multiply now retain

--- a/src/raster/compiler/passes/parallel/segmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segmap_body.clj
@@ -5,6 +5,7 @@
    KernelBody ForLoop; scalar loads, computation, branches, and horizontally fused stores use the
    shared typed scalar-expression lowering boundary."
   (:require [clojure.set :as set]
+            [raster.compiler.backend.intrinsics :as intrinsics]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.layout :as layout]
             [raster.compiler.core.op-descriptor :as descriptor]
@@ -58,15 +59,19 @@
    source-shaped lambda remains only for compatibility-created SegMaps; its binder metadata is
    projected once here and is never used to infer an arithmetic function or result type."
   [segmap]
-  (if-let [{:keys [locals result] :as region} (:scalar-region segmap)]
+  (if-let [{:keys [locals result effects] :as region} (:scalar-region segmap)]
     (do
       (when-not (and (vector? locals)
                      (every? #(and (symbol? (:id %)) (:dtype %) (contains? % :init)) locals)
-                     (contains? region :result))
+                     (not= (contains? region :result) (contains? region :effects))
+                     (or (not (contains? region :effects))
+                         (and (vector? effects) (seq effects))))
         (decline! :typed-local-region
                   "scheduled typed map carries a malformed scalar region"
                   {:operation (:id segmap) :scalar-region region}))
-      {:locals locals :result result})
+      (cond-> {:locals locals}
+        (contains? region :result) (assoc :result result)
+        (contains? region :effects) (assoc :effects effects)))
     (let [expression (:lambda segmap)]
       (if (and (seq? expression)
                (contains? #{'let 'let* 'clojure.core/let} (first expression)))
@@ -122,17 +127,25 @@
                                [primary-output]))
                   (vec (sort-by name (:outputs segmap))))
         output-set (set outputs)
-        inout (set/intersection (set inputs) output-set)
+        write-conflicts (or (:write-conflicts segmap) {})
+        reduction-destinations
+        (into #{} (keep (fn [[destination conflict]]
+                          (when (= :reduce (:kind conflict)) destination)))
+              write-conflicts)
+        inout (set/union (set/intersection (set inputs) output-set)
+                         reduction-destinations)
         read-only-inputs (vec (remove inout inputs))
         scalars (vec (sort-by name (:scalars segmap)))
+        {:keys [locals result effects]} (scalar-region segmap)
+        ordered-effects? (seq effects)
         explicit-certified-write?
         (and (nil? primary-output)
              (contains? #{:unique :reduce} (:write-conflict segmap)))
-        {:keys [locals result]} (scalar-region segmap)
         same-element-inout?
         (same-element-inout? inout index (conj (mapv :init locals) result))
         _ (when (and (seq inout)
-                     (not (or explicit-certified-write? same-element-inout?)))
+                     (not (or explicit-certified-write? ordered-effects?
+                              same-element-inout?)))
             (decline! :inout-storage
                       "portable dense map writable results may only read their lane-owned element"
                       {:operation (:id segmap) :inputs inputs :outputs outputs}))
@@ -179,7 +192,9 @@
               :environment (assoc environment (:result lowered) (:type lowered))}))
          {:substitutions {} :operations [] :environment base-environment}
          locals)
-        forms (scalar-forms (util/subst-syms (:substitutions local-state) result))
+        forms (if ordered-effects?
+                []
+                (scalar-forms (util/subst-syms (:substitutions local-state) result)))
         explicit-forms (if primary-output (pop forms) forms)
         primary-form (when primary-output (peek forms))
         _ (when (and primary-output (empty? forms))
@@ -215,12 +230,53 @@
                          (body/->ScalarStore array [coordinate-expression]
                                              (:result lowered) :map-active))]))))
         explicit-operations (vec (mapcat lower-store explicit-forms))
+        lower-effect
+        (fn [{:keys [destination conflict destination-index predicate value] :as effect}]
+          (when-not (contains? output-set destination)
+            (decline! :effect-destination
+                      "ordered effect targets an undeclared result"
+                      {:operation (:id segmap) :effect effect}))
+          (let [coordinate-value (when (contains-indexed-load? destination-index)
+                                   ((:lower lowerer) destination-index :long environment))
+                coordinate-expression (if coordinate-value
+                                        (:result coordinate-value)
+                                        (lower-index destination-index))
+                lowered-value ((:lower lowerer) value (get array-types destination) environment)
+                operator (when (= :reduce (:kind conflict))
+                           (intrinsics/canonical (:operator conflict)))
+                _ (when (and (= :reduce (:kind conflict)) (nil? operator))
+                    (decline! :effect-reduction-operator
+                              "ordered reduction effect has no canonical scalar operator"
+                              {:operation (:id segmap) :effect effect}))
+                store (if (= :reduce (:kind conflict))
+                        (body/->AtomicRMW destination [coordinate-expression]
+                                          (:result lowered-value) operator :map-active)
+                        (body/->ScalarStore destination [coordinate-expression]
+                                            (:result lowered-value) :map-active))
+                effect-operations (vec (concat (:operations coordinate-value)
+                                               (:operations lowered-value) [store]))]
+            (if (contains? #{true 1} predicate)
+              effect-operations
+              (let [lowered-predicate ((:lower lowerer) predicate :predicate environment)]
+                (vec (concat (:operations lowered-predicate)
+                             [(body/->IfRegion (:result lowered-predicate)
+                                               (conj effect-operations (body/->Yield []))
+                                               [(body/->Yield [])] [])]))))))
+        effect-operations
+        (vec (mapcat lower-effect
+                     (map #(reduce (fn [effect field]
+                                     (update effect field
+                                             (fn [expression]
+                                               (util/subst-syms
+                                                (:substitutions local-state) expression))))
+                                   % [:destination :destination-index :predicate :value])
+                          effects)))
         primary-lowered (when primary-output
                           ((:lower lowerer) primary-form
                                             (get array-types primary-output) environment))
         scalar-operations
         (vec (concat (:operations local-state)
-                     explicit-operations
+                     (if ordered-effects? effect-operations explicit-operations)
                      (:operations primary-lowered)
                      (when primary-output
                        [(body/->ScalarStore primary-output [index]

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -301,6 +301,9 @@
                                                 scheduling-algorithm device-id :dtype dtype)}
                               scatter {:operations (soac-lower/lower-typed-scatter
                                                     scheduling-algorithm device-id :dtype dtype)}
+                              effect-map
+                              {:operations (soac-lower/lower-typed-effect-map
+                                            scheduling-algorithm device-id :dtype dtype)}
                               stencil {:operations (soac-lower/lower-typed-stencil
                                                     scheduling-algorithm device-id :dtype dtype)}
                               reduce {:operations (soac-lower/lower-typed-reduce

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -297,6 +297,78 @@
                     :conflict-contract conflict)
             (lower-map-description description device-id :dtype result-dtype)))))
 
+(defn lower-typed-effect-map
+  "Lower one validated ordered effect-map to the common portable SegMap schedule boundary.
+
+   Effects remain structured data in `:scalar-region`; no source `map-void!` form is rebuilt.
+   Physical destinations come from the checked result-storage contract and every destination keeps
+   its unique/reduction conflict proof for KernelBody lowering."
+  [program device-id & {:keys [dtype] :or {dtype :double}}]
+  (let [program (soac-dialect/validate! program)
+        equation (first (soac-dialect/equations program))]
+    (when-not (and (= 1 (count (soac-dialect/equations program)))
+                   (= 'effect-map (soac-dialect/operation-kind equation)))
+      (throw (ex-info "typed effect-map lowering requires one effect-map equation"
+                      {:reason :typed-soac-effect-map-subset :program program})))
+    (let [[_ equation-id results _operation] equation
+          {:keys [attributes arrays captures destinations lambda]}
+          (soac-dialect/operation-parts equation)
+          {:keys [locals body-results]} (soac-dialect/lambda-parts lambda)
+          {:keys [elements capture-parameters destination-parameters]}
+          (soac-dialect/parameter-layout equation)
+          facts (soac-dialect/facts program)
+          values (:values facts)
+          physical-results (soac-dialect/physical-results facts equation)
+          _ (when-not (= destinations physical-results)
+              (throw (ex-info "typed effect-map destination storage changed after validation"
+                              {:reason :raster/bug :equation equation-id
+                               :destinations destinations :physical physical-results})))
+          substitutions
+          (into (zipmap capture-parameters captures)
+                (concat
+                 (map (fn [parameter array]
+                        [parameter (list 'clojure.core/aget array (:index attributes))])
+                      elements arrays)
+                 (map vector destination-parameters physical-results)))
+          locals (mapv #(update % :init
+                                (fn [init] (util/subst-syms substitutions init)))
+                       locals)
+          effects
+          (mapv (fn [effect]
+                  (let [{:keys [destination conflict destination-index predicate value]}
+                        (soac-dialect/effect-parts effect)]
+                    {:destination (util/subst-syms substitutions destination)
+                     :conflict conflict
+                     :destination-index (util/subst-syms substitutions destination-index)
+                     :predicate (util/subst-syms substitutions predicate)
+                     :value (util/subst-syms substitutions value)}))
+                body-results)
+          stable (set (get-in attributes [:attributes :stable-array-captures]))
+          scalar-captures (set (remove stable captures))
+          write-conflicts
+          (into {} (map (fn [destination]
+                          [destination (:conflict
+                                        (first (filter #(= destination (:destination %))
+                                                       effects)))])
+                        physical-results))
+          result-dtype (or (:dtype (get values (first results))) dtype :double)
+          description {:id equation-id
+                       :bound (:extent attributes)
+                       :idx (:index attributes)
+                       :lambda nil
+                       :scalar-region {:locals locals :effects effects}
+                       :inputs (into (set arrays) stable)
+                       :outputs (set physical-results)
+                       :scalars scalar-captures
+                       :elem-type result-dtype
+                       :out-sym nil
+                       :cast-fn nil}]
+      (mapv #(assoc % :algorithm-dialect :typed-soac
+                    :algorithm-equation equation-id
+                    :write-conflict :ordered-effects
+                    :write-conflicts write-conflicts)
+            (lower-map-description description device-id :dtype result-dtype)))))
+
 (defn typed-reduce-program?
   "Whether a validated one-equation TypedSOAC program is the scalar reduction vertical currently
    accepted by SegRed lowering."

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -104,6 +104,22 @@
                                 :local-definitions local-definitions
                                 :body-results body-results}))))
 
+(def ^:private effect-map-equation-rule
+  (from-dialect dialect/TypedSOAC
+                (rule '(= ?equation-id [??results]
+                          (effect-map ?attributes [??arrays] [??captures] [??destinations]
+                            (lambda [??parameters]
+                              (effect-region [??local-definitions] [??body-results]))))
+                      (success {:kind :effect-map
+                                :id equation-id
+                                :results results
+                                :attributes attributes
+                                :arrays arrays
+                                :captures captures
+                                :destinations destinations
+                                :local-definitions local-definitions
+                                :body-results body-results}))))
+
 (def ^:private stencil-equation-rule
   (from-dialect dialect/TypedSOAC
                 (rule '(= ?equation-id [??results]
@@ -157,6 +173,7 @@
                    [(scalar-equation-rule equation)
                     (map-equation-rule equation)
                     (scatter-equation-rule equation)
+                    (effect-map-equation-rule equation)
                     (stencil-equation-rule equation)
                     (reduce-equation-rule equation)
                     (segmented-reduce-equation-rule equation)

--- a/test/raster/compiler/passes/parallel/typed_ordered_effect_map_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_ordered_effect_map_test.clj
@@ -1,0 +1,98 @@
+(ns raster.compiler.passes.parallel.typed-ordered-effect-map-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.segop-opencl :as segop-opencl]
+            [raster.compiler.ir.abstract-value :as av]
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
+            [raster.compiler.passes.parallel.soac-lower :as soac-lower]
+            [raster.compiler.passes.parallel.typed-soac-route :as route]))
+
+(def ^:private extent (av/tensor {:dtype :long :shape []}))
+(def ^:private vector-value (av/tensor {:dtype :float :shape '[n]}))
+(def ^:private scalar-slot (av/tensor {:dtype :float :shape '[1]}))
+
+(defn- effect-program
+  []
+  (let [out-result [:effect 0 0]
+        total-result [:effect 0 1]
+        reduction (dialect/reducing-scatter-conflict '+ :float)
+        equation
+        (list '= 0 [out-result total-result]
+              (list 'effect-map
+                    {:index 'i :extent 'n :dtypes [:float :float]}
+                    '[x] [] '[out total]
+                    (dialect/effect-lambda-form
+                     '[element out-destination total-destination]
+                     [(dialect/local-value 'shifted :float '(+ element 1.0))]
+                     [(list 'effect 'out-destination :unique 'i '(> element 0.0) 'shifted)
+                      (list 'effect 'total-destination reduction 0 true 'element)])))
+        storage [{:destination 'out :access :write :host-return :effect}
+                 {:destination 'total :access :read-write :host-return :effect}]
+        equation-facts
+        (assoc (dialect/default-equation-facts)
+               :effects #{:memory/write}
+               :aliases {out-result 'out total-result 'total}
+               :attributes {:result-storage storage})]
+    (dialect/make
+     (dialect/default-program-facts
+      {:values {'n extent 'x vector-value 'out vector-value 'total scalar-slot
+                out-result vector-value total-result scalar-slot}
+       :inputs '[n x]
+       :equations {0 equation-facts}
+       :effects #{:memory/write}})
+     [equation] [])))
+
+(defn- nested-operations
+  [operations]
+  (mapcat (fn [operation]
+            (cons operation
+                  (concat (nested-operations (or (:then-operations operation) []))
+                          (nested-operations (or (:else-operations operation) [])))))
+          operations))
+
+(defn- normalize-fresh-thread-index
+  [operation]
+  (assoc-in operation [:space :flat-idx] 'thread-index))
+
+(deftest ordered-effects-lower-to-portable-kernelbody-control-and-atomics
+  (let [program (effect-program)
+        operation (first (soac-lower/lower-typed-effect-map
+                          program :ze:0 :dtype :float))
+        scheduled (:form (segop-lower/segop-lower-pass
+                          (route/program-envelope program)
+                          {:target-device :ze:0 :dtype :float}))
+        scheduled-operation (first (get-in scheduled [:equations 0 :operations]))]
+    (is (= :ordered-effects (:write-conflict operation)))
+    (is (= (normalize-fresh-thread-index operation)
+           (normalize-fresh-thread-index scheduled-operation))
+        "whole-program scheduling dispatches the same semantic effect-map lowering")
+    (is (= #{'out 'total} (:outputs operation)))
+    (is (= {:locals [{:id 'shifted :dtype :float :init '(+ (clojure.core/aget x i) 1.0)}]
+            :effects
+            [{:destination 'out :conflict :unique :destination-index 'i
+              :predicate '(> (clojure.core/aget x i) 0.0) :value 'shifted}
+             {:destination 'total
+              :conflict (dialect/reducing-scatter-conflict '+ :float)
+              :destination-index 0 :predicate true
+              :value '(clojure.core/aget x i)}]}
+           (:scalar-region operation)))
+    (doseq [[target atomic]
+            [[:opencl-portable "atomic_add_float"]
+             [:cuda "atomicAdd"]
+             [:hip "atomicAdd"]]]
+      (testing (name target)
+        (let [artifact (segop-opencl/generate-scheduled-segmap-kernel
+                        operation :dtype :float :target-dialect target
+                        :array-types {'x :float 'out :float 'total :float}
+                        :scalar-types {'n :long})
+              kernel-body (get-in artifact [:attributes :kernel-body])
+              operations (nested-operations (:operations kernel-body))
+              pointer-slots (filterv #(not= :scalar (:kind %)) (:abi artifact))]
+          (is (= :kernel-body (get-in artifact [:attributes :emission-route])))
+          (is (= ['x 'out 'total] (mapv :name pointer-slots)))
+          (is (= [:input :output :inout] (mapv :kind pointer-slots)))
+          (is (some #(= "IfRegion" (some-> % class .getSimpleName)) operations))
+          (is (some #(= "ScalarStore" (some-> % class .getSimpleName)) operations))
+          (is (some #(= "AtomicRMW" (some-> % class .getSimpleName)) operations))
+          (is (str/includes? (:source artifact) atomic)))))))


### PR DESCRIPTION
## Summary

- lower validated TypedSOAC effect maps to the common SegMap schedule boundary
- retain ordered guarded unique stores and certified reductions as structured KernelBody effects
- emit the same checked body and ordered ABI for portable OpenCL, CUDA, and HIP

## Validation

- `clojure -M:test -n raster.compiler.passes.parallel.typed-ordered-effect-map-test`
- `clojure -M:test -n raster.compiler.ir.soac-dialect-test`

Stacked on #320; source selection is deliberately deferred until indirect-write uniqueness is proved.
