### PR TITLE
Select certified ordered effects from typed source

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -170,9 +170,19 @@ and guarded effects retain structured `IfRegion` control in the common `KernelBo
 and ordered ABI emit as portable OpenCL, CUDA, and HIP. Fusion treats this operation as a
 conservative boundary until an effect-aware rule proves that moving or combining it preserves the
 declared memory order. Source selection remains gated on proving indirect-write uniqueness rather
-than inferring it from a workload or variable name.
+than inferring it from a workload or variable name. Closed typed source can now form this boundary
+for mixed unique and reducing effects, with per-destination dtypes and conflict certificates; JVM
+execution and OpenCL/CUDA/HIP emission consume the same scheduled region. Typed locals are
+pre-effect snapshots, while a direct read after a sibling write still declines.
 
-Adam and AdamW use this effect-map contract directly: gradient is a read-only operand, parameter
+This proof boundary exposed a pre-existing firms-ABM race rather than hiding it: active IDs are
+sampled with replacement, so two decision lanes may write the same agent state and cannot carry a
+`unique-index` certificate. The semantics-preserving production route is a resident ordered queue
+loop (or, later, grouping by agent followed by one ordered lane per group). A single-thread/device
+ordered-iteration schedule is therefore explicit remaining coverage; parallel `effect-map` is not
+permission to assert workload-specific uniqueness.
+
+Adam and AdamW use the functional tuple-map storage contract directly: gradient is a read-only operand, parameter
 and moment buffers are typed inout storage, and the bias-corrected moment snapshots form one local
 SSA spine evaluated before all three writes. Each optimizer lowers as one certified resident
 kernel with zero compiler allocation or compatibility fallback. The C-family vector fast path

--- a/design/soac-fusion.md
+++ b/design/soac-fusion.md
@@ -31,6 +31,11 @@ The GPU schedule projects their ordered local SSA and guarded effects directly i
 unique effects become `ScalarStore`, checked reduction effects become `AtomicRMW`, and predicates
 become structured `IfRegion` nodes. OpenCL, CUDA, and HIP therefore consume the same verified
 `KernelBody`; the operation is not reconstructed as source-level mutation in an emitter.
+Closed typed `map-void!` bodies select this operation only when every indirect write carries an
+explicit uniqueness marker or a checked reduction algebra. Conflict and dtype are retained per
+physical destination, so mixed FP32/int32 effects do not inherit a global kernel dtype. Typed
+locals form a pre-effect snapshot spine and guarded branches retain ordered predicates. The JVM
+consumes the same scheduled region as an exact sequential loop; unproved cross-lane writes decline.
 
 Fusion iterates three general transformations to a fixpoint:
 
@@ -86,10 +91,12 @@ models can refine a choice, while the typed program and numerical oracle constra
 
 ## Remaining work
 
-1. Select the ordered effect-map from closed typed source for remaining mixed unique-write/atomic
-   workloads, requiring explicit uniqueness and reduction proofs. Replace active-ID narrowing and
-   specialized block-movement compatibility coverage with direct typed equations and schedules.
-   RNG fill is now an ordinary typed map with wrapping SplitMix64 scalar SSA.
+1. Add a resident ordered-iteration schedule for effect programs whose indices are not independent.
+   In particular, the firms ABM samples active IDs with replacement, so its decision phase cannot
+   claim unique agent writes; it must process the queue in order or group by agent before parallel
+   scheduling. Replace active-ID narrowing and specialized block-movement compatibility coverage
+   with direct typed equations and schedules. RNG fill is now an ordinary typed map with wrapping
+   SplitMix64 scalar SSA.
 2. Finish explicit typed scalar SSA for every region; do not recover scalar types in emitters or
    beta-reduce away type contracts.
 3. Finish explicit integer arithmetic semantics. Unchecked source add/subtract/multiply now retain

--- a/src/raster/compiler/backend/jvm/segop_simd.clj
+++ b/src/raster/compiler/backend/jvm/segop_simd.clj
@@ -14,7 +14,8 @@
    - Parse par forms (SegOp already has inputs/outputs/scalars/lambda)
    - Decide phase decomposition (SegOp already decided)
    - Collect arrays/scalars (SegOp already has them)"
-  (:require [raster.compiler.core.op-descriptor :as descriptor]
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.backend.jvm.bytecode :as bc]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.reduction :as reduction]
@@ -970,9 +971,36 @@
           bound (seg-bound segmap)
           n-sym (gensym "effect_n__")
           j-sym (gensym "effect_i__")
+          {:keys [locals effects]} (:scalar-region segmap)
+          effect-statement
+          (fn [{:keys [destination conflict destination-index predicate value]}]
+            (let [reduction? (soac-dialect/reducing-scatter-conflict? conflict)
+                  destination (if reduction?
+                                (let [tag (dtype/scalar-tag-for-dtype (:dtype conflict))]
+                                  (with-meta destination {:tag tag :raster.type/tag tag}))
+                                destination)
+                  store (if reduction?
+                          (list 'raster.par/atomic-add! destination destination-index value)
+                          (list 'clojure.core/aset destination destination-index value))]
+              (if (contains? #{true 1} predicate)
+                store
+                (list 'if predicate store))))
+          typed-region-body
+          (when (seq effects)
+            (let [statements (mapv effect-statement effects)
+                  body (list* 'do statements)]
+              (if (seq locals)
+                (list 'let*
+                      (vec (mapcat (fn [{:keys [id dtype init]}]
+                                     (let [tag (dtype/scalar-tag-for-dtype dtype)]
+                                       [(with-meta id {:raster.type/tag tag})
+                                        (list tag init)]))
+                                   locals))
+                      body)
+                body)))
           body (clojure.walk/postwalk
                 (fn [form] (if (= form index) j-sym form))
-                (bc/desugar-invk (:lambda segmap)))]
+                (bc/desugar-invk (or typed-region-body (:lambda segmap))))]
       (list 'let* [n-sym (list 'int bound)]
             (list 'loop* [j-sym '(int 0)]
                   (list 'if (ix< j-sym n-sym)

--- a/src/raster/compiler/ir/dialects.clj
+++ b/src/raster/compiler/ir/dialects.clj
@@ -552,7 +552,7 @@
                                   (= 4 (count operation)))
                          (nth operation 3))]
               (and (seq? body)
-                   (contains? #{'scalar 'map 'scatter 'stencil 'reduce
+                   (contains? #{'scalar 'map 'scatter 'effect-map 'stencil 'reduce
                                 'segmented-reduce 'product-reduce 'segmented-fold-map 'scan}
                               (first body)))))
           (fn [_ algorithm]

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -319,6 +319,11 @@
           facts (soac-dialect/facts program)
           values (:values facts)
           physical-results (soac-dialect/physical-results facts equation)
+          result-storage (soac-dialect/result-storage facts equation-id)
+          read-write-destinations
+          (into #{} (keep (fn [{:keys [destination access]}]
+                            (when (= :read-write access) destination)))
+                result-storage)
           _ (when-not (= destinations physical-results)
               (throw (ex-info "typed effect-map destination storage changed after validation"
                               {:reason :raster/bug :equation equation-id
@@ -357,7 +362,7 @@
                        :idx (:index attributes)
                        :lambda nil
                        :scalar-region {:locals locals :effects effects}
-                       :inputs (into (set arrays) stable)
+                       :inputs (into (into (set arrays) stable) read-write-destinations)
                        :outputs (set physical-results)
                        :scalars scalar-captures
                        :elem-type result-dtype

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -992,12 +992,30 @@
 
 (defn- source-descriptions
   [pairs default-dtype array-types]
-  (mapv (fn [id [symbol expression]]
-          (or (operation-description id symbol expression default-dtype array-types)
-              (if (par/par-form? expression)
-                {:kind :unsupported :id id :sym symbol :expr expression}
-                {:kind :scalar :id id :sym symbol :expr expression})))
-        (range) pairs))
+  ;; Earlier local allocations are authoritative array-type facts for later effects. Thread those
+  ;; facts in source order instead of falling back to the program-wide arithmetic dtype: a local
+  ;; float-array reduced by a strided scatter remains FP32 even in a mixed-precision program.
+  (:descriptions
+   (reduce
+    (fn [{:keys [array-types] :as state} [id [symbol expression]]]
+      (let [description
+            (or (operation-description id symbol expression default-dtype array-types)
+                (if (par/par-form? expression)
+                  {:kind :unsupported :id id :sym symbol :expr expression}
+                  {:kind :scalar :id id :sym symbol :expr expression}))
+            allocation-dtype
+            (when (and (= :scalar (:kind description))
+                       (seq? expression)
+                       (descriptor/alloc-op? (descriptor/semantic-op expression)))
+              (let [operation (descriptor/semantic-op expression)
+                    array-tag (or (get descriptor/alloc-sym->array-tag operation)
+                                  (get descriptor/alloc-sym->array-tag
+                                       (some-> operation name symbol)))]
+                (some-> array-tag dtype/dtype-for-array-tag dtype/canon)))]
+        (cond-> (update state :descriptions conj description)
+          allocation-dtype (assoc-in [:array-types symbol] allocation-dtype))))
+    {:descriptions [] :array-types array-types}
+    (map-indexed vector pairs))))
 
 (defn- canonical-extent
   [equalities values extent]

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -73,6 +73,9 @@
 (def ^:private unique-index-ops
   '#{raster.par/unique-index unique-index})
 
+(def ^:private atomic-add-ops
+  '#{raster.par/atomic-add! atomic-add!})
+
 (defn- unique-index-expression
   "Return the inner destination expression when `expression` carries Raster's explicit
    uniqueness contract. The marker may be a direct source call or a walker-devirtualized call;
@@ -82,6 +85,12 @@
              (contains? unique-index-ops (descriptor/semantic-op expression))
              (= 1 (count (descriptor/call-args expression))))
     (first (descriptor/call-args expression))))
+
+(defn- atomic-add-call?
+  [expression]
+  (and (seq? expression)
+       (contains? atomic-add-ops (descriptor/semantic-op expression))
+       (= 3 (count (descriptor/call-args expression)))))
 
 (defn- same-symbol?
   [left right]
@@ -187,13 +196,14 @@
                    locals)
      :stores (mapv #(substitute-store renames %) stores)}))
 
-(defn- pointwise-region
-  "Recognize an ordered, pure local-SSA spine ending exclusively in indexed stores.
+(defn- store-region
+  "Recognize an ordered, pure local-SSA spine ending exclusively in certified effects.
 
    Local types come only from retained walker/TypedClojure facts. Nested lexical scopes are
    alpha-renamed into one ordered SSA spine; missing local types decline because guessing them in
-   this source recognizer or a C emitter would make the region only nominally typed. Store
-   legality is checked separately after local dependencies are expanded for analysis."
+   this source recognizer or a C emitter would make the region only nominally typed. Direct stores
+   and atomic additions become data here; cross-work-item legality is checked separately after
+   local dependencies are expanded for analysis."
   [body index]
   (cond
     (and (seq? body) (form/let-head? (first body)))
@@ -201,7 +211,7 @@
       (when (and (even? (count bindings))
                  (seq nested-body)
                  (not-any? util/effectful? (take-nth 2 (rest bindings))))
-        (when-let [nested-region (pointwise-region (list* 'do nested-body) index)]
+        (when-let [nested-region (store-region (list* 'do nested-body) index)]
           (let [pairs (vec (partition 2 bindings))
                 typed (mapv (fn [[binding init]]
                               [binding init (retained-local-dtype binding init)])
@@ -227,8 +237,8 @@
     (and (seq? body) (= 'do (first body)))
     (let [expressions (vec (rest body))]
       (if (= 1 (count expressions))
-        (pointwise-region (first expressions) index)
-        (let [groups (mapv #(pointwise-region % index) expressions)]
+        (store-region (first expressions) index)
+        (let [groups (mapv #(store-region % index) expressions)]
           (when (and (seq groups) (every? some? groups)
                      (every? (comp empty? :locals) groups))
             {:locals [] :stores (vec (mapcat :stores groups))}))))
@@ -237,34 +247,45 @@
          (contains? #{'if 'clojure.core/if} (first body))
          (<= 3 (count body) 4))
     (let [[_ predicate then-expression else-expression] body
-          then-region (pointwise-region then-expression index)
-          else-region (when else-expression (pointwise-region else-expression index))]
+          then-region (store-region then-expression index)
+          else-region (when else-expression (store-region else-expression index))
+          aligned? (and else-region
+                        (= (mapv (juxt :out :index) (:stores then-region))
+                           (mapv (juxt :out :index) (:stores else-region))))]
       (when (and then-region
                  (empty? (:locals then-region))
                  (or (nil? else-expression)
-                     (and else-region (empty? (:locals else-region))))
-                 (or (nil? else-region)
-                     (= (mapv (juxt :out :index) (:stores then-region))
-                        (mapv (juxt :out :index) (:stores else-region)))))
+                     (and else-region (empty? (:locals else-region)))))
         {:locals []
          :stores
-         (mapv (fn [ordinal then-store]
-                 (let [else-store (when else-region (nth (:stores else-region) ordinal))]
-                   (if else-store
+         (if aligned?
+           (mapv (fn [ordinal then-store]
+                   (let [else-store (nth (:stores else-region) ordinal)]
                      (assoc then-store
                             :value (list 'if predicate (:value then-store) (:value else-store))
                             :predicate (list 'if predicate
                                              (:predicate then-store)
-                                             (:predicate else-store)))
-                     (update then-store :predicate
-                             #(if (contains? #{true 1} %)
-                                predicate
-                                (list 'if predicate % 0))))))
-               (range) (:stores then-region))}))
+                                             (:predicate else-store)))))
+                 (range) (:stores then-region))
+           (vec
+            (concat
+             (map (fn [store]
+                    (update store :predicate
+                            #(if (contains? #{true 1} %)
+                               predicate
+                               (list 'if predicate % 0))))
+                  (:stores then-region))
+             (map (fn [store]
+                    (update store :predicate
+                            #(let [else-predicate (list 'if predicate 0 1)]
+                               (if (contains? #{true 1} %)
+                                 else-predicate
+                                 (list 'if else-predicate % 0)))))
+                  (:stores else-region)))))}))
 
     (and (seq? body) (= 'case* (first body)))
     (when-let [conditional (integer-case-chain body)]
-      (pointwise-region conditional index))
+      (store-region conditional index))
 
     (descriptor/aset-call? body)
     (let [arguments (vec (descriptor/call-args body))]
@@ -282,7 +303,8 @@
                               (descriptor/aset-array-sym body) raw-index value))
               cast? (and (seq? value)
                          (contains? #{'float 'double 'int 'long
-                                      'clojure.core/float 'clojure.core/double}
+                                      'clojure.core/float 'clojure.core/double
+                                      'clojure.core/int 'clojure.core/long}
                                     (first value))
                          (= 2 (count value)))]
           {:locals []
@@ -295,6 +317,22 @@
                               contribution
                               (if cast? (second value) value))
                      :cast (when (and cast? (not contribution)) (first value))}]})))
+
+    (atomic-add-call? body)
+    (let [[destination raw-index raw-value] (descriptor/call-args body)
+          cast? (and (seq? raw-value)
+                     (contains? #{'float 'double 'int 'long
+                                  'clojure.core/float 'clojure.core/double
+                                  'clojure.core/int 'clojure.core/long}
+                                (first raw-value))
+                     (= 2 (count raw-value)))]
+      {:locals []
+       :stores [{:out destination
+                 :index (strip-index-cast raw-index)
+                 :reduction-op '+
+                 :predicate 1
+                 :value (if cast? (second raw-value) raw-value)
+                 :cast (when cast? (first raw-value))}]})
 
     :else nil))
 
@@ -316,6 +354,31 @@
                                  out)))
                  stores))))
 
+(defn- ordered-effects-safe?
+  "An ordered effect may not observe a sibling destination directly after stores begin.
+
+   Typed locals are evaluated before the effect sequence and may deliberately snapshot destination
+   state. Direct reads in coordinates, predicates, or values would instead make cross-work-item
+   ordering observable and require a stronger schedule than an effect map."
+  [locals stores]
+  (let [destinations (set (map :out stores))]
+    (and (seq stores)
+         (every? (fn [{:keys [index predicate value]}]
+                   (empty? (set/intersection
+                            destinations
+                            (par/collect-aget-arrays (list 'do index predicate value)))))
+                 stores)
+         ;; Locals are an ordered pre-effect SSA spine, so their reads are snapshots rather than
+         ;; sibling effect dependencies. Keep the argument explicit for this legality boundary.
+         (vector? locals))))
+
+(defn- destination-dtype
+  [array-types destination]
+  (or (get array-types destination)
+      (when (symbol? destination)
+        (or (get array-types (symbol (name destination)))
+            (dtype/dtype-for-scalar-tag (types/sym-type-tag destination))))))
+
 (defn- effect-result-id
   [equation-id ordinal]
   [:effect-map equation-id ordinal])
@@ -334,13 +397,13 @@
       :scalars (mapv #(-> % (assoc :value (:sym %)) (dissoc :sym)) (:scalars epilogue))
       :result-dtype (or (:dtype epilogue) :float)})))
 
-(defn- effect-map-description
+(defn- write-region-description
   [id symbol index extent {:keys [locals stores]} elem-type
-   & {:keys [host-return] :or {host-return :effect}}]
-  (when (and (seq stores) (independent-stores? locals stores)
-             (or (= :effect host-return) (= 1 (count stores))))
+   & {:keys [host-return array-types] :or {host-return :effect array-types {}}}]
+  (when (and (seq stores) (or (= :effect host-return) (= 1 (count stores))))
     (let [stores (mapv #(merge {:index index :predicate 1} %) stores)
-          pointwise? (every? #(and (= index (:index %)) (nil? (:reduction-op %))) stores)
+          dense-pointwise? (every? #(and (= index (:index %)) (nil? (:reduction-op %))) stores)
+          pointwise? (and dense-pointwise? (independent-stores? locals stores))
           stores (if pointwise?
                    (mapv (fn [{:keys [out predicate value] :as store}]
                            (assoc store :value
@@ -353,13 +416,35 @@
                                           (list 'clojure.core/aget out index)))))
                          stores)
                    stores)
-          reduction-ops (set (keep :reduction-op stores))
-          conflict (cond
-                     (every? #(= :unique (:conflict %)) stores) :unique
-                     (and (= 1 (count reduction-ops))
-                          (every? :reduction-op stores))
-                     (dialect/reducing-scatter-conflict (first reduction-ops) elem-type))
-          destinations (mapv :out stores)
+          stores (mapv (fn [{:keys [out reduction-op conflict] :as store}]
+                         (let [destination-type (some-> (destination-dtype array-types out)
+                                                       dtype/canon)
+                               contract (cond
+                                          (= :unique conflict) :unique
+                                          reduction-op
+                                          (when destination-type
+                                            (dialect/reducing-scatter-conflict
+                                             reduction-op destination-type))
+                                          (= index (:index store)) :unique)]
+                           (assoc store :effect-conflict contract
+                                        :destination-dtype destination-type)))
+                       stores)
+          effect-contracts (mapv :effect-conflict stores)
+          uniform-conflict (when (= 1 (count (set effect-contracts)))
+                             (first effect-contracts))
+          scatter? (and (not pointwise?)
+                        (independent-stores? locals stores)
+                        (or (= :unique uniform-conflict)
+                            (dialect/reducing-scatter-conflict? uniform-conflict)))
+          ordered? (and (not dense-pointwise?) (not scatter?) (= :effect host-return)
+                        (every? some? effect-contracts)
+                        (ordered-effects-safe? locals stores)
+                        (every? (fn [[_ grouped]]
+                                  (= 1 (count (set (map :effect-conflict grouped)))))
+                                (group-by :out stores)))
+          destinations (if ordered?
+                         (vec (distinct (map :out stores)))
+                         (mapv :out stores))
           values (mapv :value stores)
           write-indices (mapv :index stores)
           predicates (mapv :predicate stores)
@@ -368,20 +453,31 @@
                      :scalars set/difference (set (map :id locals)))
           results (if (= :buffer host-return)
                     [symbol]
-                    (mapv #(effect-result-id id %) (range (count stores))))]
-      (when (or pointwise? (= :unique conflict)
-                (dialect/reducing-scatter-conflict? conflict))
-        (merge {:kind (if pointwise? :map :scatter)
+                    (mapv #(effect-result-id id %) (range (count destinations))))
+          result-dtypes (mapv #(some-> (destination-dtype array-types %) dtype/canon)
+                              destinations)]
+      (when (or pointwise? scatter? (and ordered? (every? some? result-dtypes)))
+        (merge {:kind (cond pointwise? :map scatter? :scatter :else :effect-map)
                 :id id :sym symbol :index index :extent extent
                 :results results :locals locals :bodies values :casts (mapv :cast stores)
                 :write-indices write-indices :predicates predicates
-                :conflict (when-not pointwise? conflict)
+                :conflict (when scatter? uniform-conflict)
+                :effects (when ordered?
+                           (mapv #(select-keys % [:out :index :predicate :value :cast
+                                                  :effect-conflict])
+                                 stores))
+                :result-dtypes (when ordered? result-dtypes)
                 :effect-only? (= :effect host-return)
                 :host-binding symbol :elem-type elem-type
                 :result-storage
                 (mapv (fn [destination]
                         {:destination destination
-                         :access (if (or (not pointwise?)
+                         :access (if (or scatter?
+                                         (and ordered?
+                                              (some #(and (= destination (:out %))
+                                                          (dialect/reducing-scatter-conflict?
+                                                           (:effect-conflict %)))
+                                                    stores))
                                          (contains? (:inputs io) destination))
                                    :read-write :write)
                          :host-return host-return})
@@ -406,7 +502,7 @@
            io)))
 
 (defn- operation-description
-  [id symbol expression default-dtype]
+  [id symbol expression default-dtype array-types]
   (cond
     ;; SplitMix64 is pointwise scalar algebra, not a semantic parallel primitive. Preserve the
     ;; public convenience operation's fixed-width ABI here, then expose an ordinary typed map to
@@ -548,11 +644,11 @@
     (par/par-map2-form? expression)
     (let [{:keys [out1 out2 idx bound cast body1 body2 elem-type]}
           (par/extract-par-map2-info expression)]
-      (effect-map-description id symbol idx bound
+      (write-region-description id symbol idx bound
                               {:locals []
                                :stores [{:out out1 :value body1 :cast cast}
                                         {:out out2 :value body2 :cast cast}]}
-                              elem-type))
+                              elem-type :array-types array-types))
 
     (par/par-product-reduce-form? expression)
     (let [{:keys [outputs components segment-axes idx bound element-bindings element-results
@@ -749,10 +845,11 @@
     (par/par-map-void-form? expression)
     (let [{:keys [idx bound body elem-type]}
           (par/extract-par-map-void-info expression)]
-      (when-let [region (pointwise-region body idx)]
-        (effect-map-description id symbol idx bound region
+      (when-let [region (store-region body idx)]
+        (write-region-description id symbol idx bound region
                                 (dtype/canon (or elem-type default-dtype))
-                                :host-return (or (::host-return (meta expression)) :effect))))
+                                :host-return (or (::host-return (meta expression)) :effect)
+                                :array-types array-types)))
 
     :else nil))
 
@@ -894,9 +991,9 @@
     (first (descriptor/call-args expression))))
 
 (defn- source-descriptions
-  [pairs default-dtype]
+  [pairs default-dtype array-types]
   (mapv (fn [id [symbol expression]]
-          (or (operation-description id symbol expression default-dtype)
+          (or (operation-description id symbol expression default-dtype array-types)
               (if (par/par-form? expression)
                 {:kind :unsupported :id id :sym symbol :expr expression}
                 {:kind :scalar :id id :sym symbol :expr expression})))
@@ -947,7 +1044,7 @@
                                                  expression representative)))
               (assoc-in [:scalar-representatives (:sym description)] representative)))
 
-        (:map :scatter :stencil :reduce :scan)
+        (:map :scatter :effect-map :stencil :reduce :scan)
         (let [extent (descriptor/unwrap-int-cast (:extent description))
               array (alength-array extent)
               proved-extent (canonical-extent shape-equalities values extent)
@@ -958,7 +1055,7 @@
                         :else extent)
               description' (assoc description :extent extent')]
           (cond-> (update state :descriptions conj description')
-            (contains? #{:map :scatter :stencil :scan} (:kind description'))
+            (contains? #{:map :scatter :effect-map :stencil :scan} (:kind description'))
             (assoc-in [:extents (:sym description')] extent')))
 
         (update state :descriptions conj description)))
@@ -977,7 +1074,7 @@
 (defn- physical-output-symbols
   [descriptions]
   (reduce set/union #{}
-          (map #(if (contains? #{:map :scatter :stencil :reduce :segmented-reduce
+          (map #(if (contains? #{:map :scatter :effect-map :stencil :reduce :segmented-reduce
                                  :product-reduce :segmented-fold-map :scan} (:kind %))
                   (:outputs %) #{})
                descriptions)))
@@ -999,6 +1096,15 @@
                   (or (= :unique (:conflict description))
                       (dialect/reducing-scatter-conflict? (:conflict description)))
                   (every? (comp symbol? :destination) (:result-storage description)))
+    :effect-map (and (seq (:effects description))
+                     (seq (:result-storage description))
+                     (= (count (:result-storage description))
+                        (count (:result-dtypes description)))
+                     (every? (comp symbol? :destination) (:result-storage description))
+                     (every? (fn [{:keys [effect-conflict]}]
+                               (or (= :unique effect-conflict)
+                                   (dialect/reducing-scatter-conflict? effect-conflict)))
+                             (:effects description)))
     :stencil (and (= 1 (count (:result-storage description)))
                   (symbol? (get-in description [:result-storage 0 :destination])))
     :reduce true
@@ -1030,12 +1136,12 @@
 
    This is diagnostic evidence only: it uses the same descriptions and admission predicate as
    form->program, so reporting cannot become a second legality implementation."
-  [source {:keys [dtype values shape-equalities]
-           :or {dtype :double values {} shape-equalities {}}}]
+  [source {:keys [dtype array-types values shape-equalities]
+           :or {dtype :double array-types {} values {} shape-equalities {}}}]
   (when (and (seq? source) (contains? #{'let 'let*} (first source)))
     (let [[_ bindings] source
           pairs (vec (partition 2 bindings))
-          descriptions (normalize-extents (source-descriptions pairs dtype)
+          descriptions (normalize-extents (source-descriptions pairs dtype array-types)
                                           shape-equalities values)
           physical-outputs (physical-output-symbols descriptions)
           declined (remove #(supported-description? physical-outputs %) descriptions)
@@ -1053,6 +1159,7 @@
                             :scalar :uncertified-host-scalar
                             :map :unverified-map-effects
                             :scatter :unverified-scatter-conflict
+                            :effect-map :unverified-ordered-effects
                             :stencil :unverified-stencil-storage
                             :segmented-reduce :unverified-segmented-reduction
                             :product-reduce :unverified-product-reduction
@@ -1171,6 +1278,46 @@
                 arrays captures
                 (dialect/lambda-form (vec (concat parameters capture-parameters))
                                      local-forms writes)))))
+
+(defn- effect-map-equation
+  [{:keys [id index extent locals inputs scalars results result-storage effects result-dtypes]}]
+  (let [destinations (mapv :destination result-storage)
+        destination-set (set destinations)
+        all-expressions (vec (concat (map :init locals)
+                                     (mapcat (juxt :index :predicate :value) effects)))
+        semantic-inputs (set/difference (set inputs) destination-set)
+        [pointwise stable]
+        ((juxt filter remove) #(pointwise-input? all-expressions % index) semantic-inputs)
+        arrays (vec (sort-by pr-str pointwise))
+        captures (vec (sort-by pr-str (distinct (concat stable scalars))))
+        element-parameters (element-symbols (count arrays))
+        capture-parameters (capture-symbols (count captures))
+        destination-parameters (mapv #(symbol (str "%destination" %))
+                                     (range (count destinations)))
+        destination-substitutions (zipmap destinations destination-parameters)
+        substitutions (into (zipmap captures capture-parameters)
+                            destination-substitutions)
+        transform (fn [expression]
+                    (util/subst-syms
+                     substitutions
+                     (first (elementize [expression] arrays element-parameters index))))
+        local-forms (mapv (fn [{:keys [id dtype init]}]
+                            (dialect/local-value id dtype (transform init)))
+                          locals)
+        effect-forms
+        (mapv (fn [{:keys [out index predicate value cast effect-conflict]}]
+                (list 'effect (get destination-substitutions out)
+                      effect-conflict (transform index) (transform predicate)
+                      (transform (if cast (list cast value) value))))
+              effects)]
+    (list '= id results
+          (list 'effect-map
+                {:index index :extent extent :dtypes result-dtypes
+                 :attributes {:stable-array-captures (vec (sort-by pr-str stable))}}
+                arrays captures destinations
+                (dialect/effect-lambda-form
+                 (vec (concat element-parameters capture-parameters destination-parameters))
+                 local-forms effect-forms)))))
 
 (defn- stencil-equation
   [{:keys [id index extent radius boundary inputs scalars results result-dtype casts bodies]}]
@@ -1373,11 +1520,11 @@
 (defn- terminal-results
   [descriptions body]
   (let [physical-outputs (physical-output-symbols descriptions)
-        operations (filter #(contains? #{:map :scatter :stencil :reduce :segmented-reduce
+        operations (filter #(contains? #{:map :scatter :effect-map :stencil :reduce :segmented-reduce
                                          :product-reduce :segmented-fold-map :scan} (:kind %))
                            descriptions)
         operation-definitions (set (mapcat #(case (:kind %)
-                                              (:map :scatter :stencil) (:results %)
+                                              (:map :scatter :effect-map :stencil) (:results %)
                                               :scan [(:sym %)]
                                               :segmented-reduce (:results %)
                                               :product-reduce (:results %)
@@ -1386,7 +1533,8 @@
                                            operations))
         terminal-operation-definitions
         (set (mapcat #(case (:kind %)
-                        (:map :scatter :stencil) (if (:effect-only? %) [] (:results %))
+                        (:map :scatter :effect-map :stencil)
+                        (if (:effect-only? %) [] (:results %))
                         :scan [(:sym %)]
                         :segmented-reduce (if (:effect-only? %) [] (:results %))
                         :product-reduce (if (:effect-only? %) [] (:results %))
@@ -1499,6 +1647,7 @@
                                              (:result-components attributes))
                         segmented-fold-map (:dtypes attributes)
                         scan (:dtypes attributes)
+                        effect-map (:dtypes attributes)
                         (map scatter) (map #(value-dtype % default-dtype array-types) results))]
     (merge
      (into {} (map (fn [id] [id (dimension-value id)])) dimension-ids)
@@ -1539,7 +1688,7 @@
                                          segmented-fold-map
                                          (dialect/segmented-fold-map-result-shape attributes)
                                          scan (dialect/scan-result-shape attributes)
-                                         scatter [(list 'unknown-dimension id)]
+                                         (scatter effect-map) [(list 'unknown-dimension id)]
                                          (dialect/extent-shape extent)))])
                    results result-dtypes)))))
 
@@ -1576,22 +1725,23 @@
   (when (and (seq? source) (contains? #{'let 'let*} (first source)))
     (let [[_ bindings & body] source
           pairs (vec (partition 2 bindings))
-          descriptions (normalize-extents (source-descriptions pairs dtype)
+          descriptions (normalize-extents (source-descriptions pairs dtype array-types)
                                           shape-equalities values)]
       (when (and (even? (count bindings))
                  (seq descriptions)
-                 (some #(contains? #{:map :scatter :stencil :reduce :segmented-reduce
+                 (some #(contains? #{:map :scatter :effect-map :stencil :reduce :segmented-reduce
                                      :product-reduce :segmented-fold-map :scan}
                                    (:kind %))
                        descriptions)
                  (supported-descriptions? descriptions))
         (let [operation-descriptions
-              (filterv #(contains? #{:map :scatter :stencil :reduce :segmented-reduce
+              (filterv #(contains? #{:map :scatter :effect-map :stencil :reduce :segmented-reduce
                                      :product-reduce :segmented-fold-map :scan} (:kind %))
                        descriptions)
               physical-outputs (physical-output-symbols descriptions)
               operation-equations (mapv #(case (:kind %) :map (map-equation %)
                                                :scatter (scatter-equation %)
+                                               :effect-map (effect-map-equation %)
                                                :stencil (stencil-equation %)
                                                :reduce (reduce-equation %)
                                                :segmented-reduce (segmented-reduce-equation %)
@@ -1613,13 +1763,14 @@
                                   (update :equation-descriptions conj description)
                                   (assoc-in [:scalar-dtypes (:sym description)] result-dtype)))
                             state)
-                          (:map :scatter :stencil :reduce :segmented-reduce
+                          (:map :scatter :effect-map :stencil :reduce :segmented-reduce
                                 :product-reduce :segmented-fold-map :scan)
                           (-> state
                               (update :equations conj
                                       (case (:kind description)
                                         :map (map-equation description)
                                         :scatter (scatter-equation description)
+                                        :effect-map (effect-map-equation description)
                                         :stencil (stencil-equation description)
                                         :reduce (reduce-equation description)
                                         :segmented-reduce (segmented-reduce-equation description)

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -40,25 +40,38 @@
 
 (defn- scalar-region
   [equation]
-  (let [{:keys [kind attributes arrays captures lambda element-lambda]}
+  (let [{:keys [kind attributes arrays captures destinations lambda element-lambda]}
         (dialect/operation-parts equation)]
     (if (= 'segmented-fold-map kind)
       {:locals [] :bodies []}
       (let [{:keys [locals body-results]}
             (dialect/lambda-parts (or lambda element-lambda))
-            {:keys [elements capture-parameters]} (dialect/parameter-layout equation)
+            {:keys [elements capture-parameters destination-parameters]}
+            (dialect/parameter-layout equation)
             substitutions
-            (into (zipmap capture-parameters captures)
+            (into (into (zipmap capture-parameters captures)
+                        (zipmap destination-parameters destinations))
                   (map (fn [parameter array]
                          [parameter (list 'clojure.core/aget array (:index attributes))])
-                       elements arrays))]
+                       elements arrays))
+            project-expression
+            (fn [expression]
+              (projection/scalar-folds->source
+               (util/subst-syms substitutions expression)))
+            project-body
+            (fn [body]
+              (if (= 'effect-map kind)
+                (let [{:keys [destination conflict destination-index predicate value]}
+                      (dialect/effect-parts body)]
+                  (list 'effect (get substitutions destination destination) conflict
+                        (project-expression destination-index)
+                        (project-expression predicate)
+                        (project-expression value)))
+                (project-expression body)))]
         {:locals (mapv #(update % :init (fn [init]
-                                          (projection/scalar-folds->source
-                                           (util/subst-syms substitutions init))))
+                                          (project-expression init)))
                        locals)
-         :bodies (mapv #(projection/scalar-folds->source
-                         (util/subst-syms substitutions %))
-                       body-results)}))))
+         :bodies (mapv project-body body-results)}))))
 
 (defn- materialize-region
   [locals body]
@@ -231,6 +244,51 @@
                    [host-binding (first physical-results)]]
                   [[host-binding effect-source]])
          :site [:binding (if buffer-return? effect-binding host-binding)]
+         :source effect-source})
+
+      effect-map
+      (let [storage (dialect/result-storage (dialect/facts program) equation-id)
+            physical-results (dialect/physical-results (dialect/facts program) equation)
+            host-binding (or (get-in placement-facts [:attributes :host-binding])
+                             (first results))
+            result-dtypes (mapv #(:dtype (get values %)) results)
+            casts (mapv #(nth (get dtype->allocation %) 2 nil) result-dtypes)
+            dtype-by-destination (zipmap physical-results result-dtypes)
+            cast-by-destination (zipmap physical-results casts)
+            effects (mapv dialect/effect-parts bodies)
+            _ (when-not (and (= (count results) (count physical-results)
+                                (count result-dtypes) (count casts))
+                             (every? some? effects) (every? some? casts)
+                             (= #{:effect} (set (map :host-return storage))))
+                (throw (ex-info "the production effect-map route requires typed effect storage"
+                                {:reason :typed-soac-production-subset
+                                 :equation equation-id :results results
+                                 :storage storage :effects effects :dtypes result-dtypes})))
+            statements
+            (mapv (fn [{:keys [destination conflict destination-index predicate value]}]
+                    (let [cast (get cast-by-destination destination)
+                          result-dtype (get dtype-by-destination destination)
+                          destination (with-meta destination
+                                        {:raster.type/tag
+                                         (dtype/scalar-tag-for-dtype result-dtype)
+                                         :tag (dtype/scalar-tag-for-dtype result-dtype)})
+                          typed-value (list cast value)
+                          store (if (dialect/reducing-scatter-conflict? conflict)
+                                  (list 'raster.par/atomic-add!
+                                        destination destination-index typed-value)
+                                  (list 'clojure.core/aset destination destination-index
+                                        typed-value))]
+                      (if (contains? #{true 1} predicate) store (list 'if predicate store))))
+                  effects)
+            effect-source
+            (with-meta
+              (list 'raster.par/map-void! (:index attributes) (:extent attributes)
+                    (materialize-region region-locals (list* 'do statements)))
+              {:raster.type/elem-type (first result-dtypes)})]
+        {:equation-id equation-id
+         :placement placement
+         :pairs [[host-binding effect-source]]
+         :site [:binding host-binding]
          :source effect-source})
 
       stencil
@@ -489,7 +547,7 @@
                    (if resident-reductions?
                      (resident/realize typed-result)
                      [typed-result {:resident-reductions 0 :inlined-scalars 0}])]
-               (if (not-any? #(contains? #{:map :scatter :stencil :reduce
+               (if (not-any? #(contains? #{:map :scatter :effect-map :stencil :reduce
                                            :segmented-reduce :product-reduce
                                            :segmented-fold-map :scan}
                                          (:kind (fusion/equation-info %)))

--- a/test/raster/compiler/passes/parallel/typed_ordered_effect_map_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_ordered_effect_map_test.clj
@@ -2,11 +2,13 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.segop-opencl :as segop-opencl]
+            [raster.compiler.backend.jvm.par-simd :as par-simd]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
-            [raster.compiler.passes.parallel.typed-soac-route :as route]))
+            [raster.compiler.passes.parallel.typed-soac-route :as route]
+            [raster.par]))
 
 (def ^:private extent (av/tensor {:dtype :long :shape []}))
 (def ^:private vector-value (av/tensor {:dtype :float :shape '[n]}))
@@ -55,6 +57,20 @@
   [operation]
   (assoc-in operation [:space :flat-idx] 'thread-index))
 
+(def ^:private mixed-effect-source
+  '(let* [effect
+          (raster.par/map-void!
+           i n
+           (let* [^float previous
+                  (clojure.core/aget out (clojure.core/aget slots i))]
+             (do
+               (if (> (clojure.core/aget x i) 0.0)
+                 (clojure.core/aset
+                  out (raster.par/unique-index (clojure.core/aget slots i))
+                  (float (+ previous (clojure.core/aget x i)))))
+               (raster.par/atomic-add! total 0 (float (clojure.core/aget x i))))))]
+         effect))
+
 (deftest ordered-effects-lower-to-portable-kernelbody-control-and-atomics
   (let [program (effect-program)
         operation (first (soac-lower/lower-typed-effect-map
@@ -96,3 +112,35 @@
           (is (some #(= "ScalarStore" (some-> % class .getSimpleName)) operations))
           (is (some #(= "AtomicRMW" (some-> % class .getSimpleName)) operations))
           (is (str/includes? (:source artifact) atomic)))))))
+
+(deftest analyzed-source-selects-the-same-ordered-effect-schedule
+  (let [result (route/attempt mixed-effect-source :float
+                              {'x :float 'slots :int 'out :float 'total :float})
+        parallel-program (:program result)
+        typed-operation (-> parallel-program :equations first :algorithm
+                            dialect/equations first dialect/operation-kind)
+        scheduled (:form (segop-lower/segop-lower-pass
+                          parallel-program {:target-device :ze:0 :dtype :float}))
+        operation (first (get-in scheduled [:equations 0 :operations]))
+        artifact (segop-opencl/generate-scheduled-segmap-kernel
+                  operation :dtype :float :target-dialect :opencl-portable
+                  :array-types {'x :float 'slots :int 'out :float 'total :float}
+                  :scalar-types {'n :long})
+        jvm (par-simd/simd-pass scheduled :min-elements 1)
+        execute (eval (list 'fn '[x slots out total n] (:form jvm)))
+        x (float-array [-1.0 2.0 3.0])
+        out (float-array [10.0 20.0 30.0])
+        total (float-array 1)]
+    (is (= :typed-soac (get-in result [:stats :route])))
+    (is (= 'effect-map typed-operation))
+    (is (= :ordered-effects (:write-conflict operation)))
+    (is (= ['slots 'x 'out 'total]
+           (mapv :name (filterv #(not= :scalar (:kind %)) (:abi artifact)))))
+    (is (= [:input :input :inout :inout]
+           (mapv :kind (filterv #(not= :scalar (:kind %)) (:abi artifact)))))
+    (is (str/includes? (:source artifact) "atomic_add_float"))
+    (is (nil? (execute x (int-array [2 0 1]) out total 3)))
+    (is (= [12.0 23.0 30.0] (mapv double out)))
+    (is (= [4.0] (mapv double total)))
+    (is (= 1 (get-in jvm [:stats :segop-reused])))
+    (is (zero? (get-in jvm [:stats :fallback])))))

--- a/test/raster/compiler/passes/parallel/typed_reducing_scatter_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_reducing_scatter_test.clj
@@ -6,7 +6,8 @@
             [raster.compiler.backend.jvm.par-simd :as par-simd]
             [raster.compiler.ir.scan :as scan]
             [raster.compiler.ir.soac-dialect :as dialect]
-            [raster.compiler.pipeline :as pipeline]))
+            [raster.compiler.pipeline :as pipeline]
+            [raster.compiler.passes.parallel.typed-soac-route :as route]))
 
 (def ^:private float-types
   {'out :float 'vals :float 'keys :int})
@@ -103,6 +104,20 @@
       (is (str/includes? kernel-source "atomic_add_float"))
       (is (str/includes? kernel-source " / stride"))
       (is (str/includes? kernel-source " % stride")))))
+
+(deftest local-allocation-retains-its-own-scatter-dtype
+  (let [source '(let* [out (clojure.core/float-array
+                            (clojure.core/* (long n) (long stride)))
+                       step (raster.par/scatter! out vals keys n stride)]
+                      step)
+        result (route/attempt source :double {'vals :float 'keys :int}
+                              {:scalar-types {'n :long 'stride :long}})
+        equation (-> result :program :equations second :algorithm dialect/equations first)
+        conflict (-> equation dialect/operation-parts :attributes :conflict)]
+    (is (= :typed-soac (get-in result [:stats :route])))
+    (is (= :reduce (:kind conflict)))
+    (is (= :float (:dtype conflict))
+        "the float-array declaration, not the default arithmetic dtype, owns storage type")))
 
 (deftest additive-effect-recognition-refuses-an-extra-destination-read
   (let [unsafe

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -703,3 +703,53 @@
                  (list 'let* ['effect (list 'raster.par/map-void! 'i 'n body)] 'effect)
                  {:dtype :float
                   :array-types {'x :float 'a :float 'b :float 'indices :int}}))))))
+
+(deftest mixed-unique-and-reduction-effects-enter-one-typed-effect-map
+  (let [source
+        '(let* [effect
+                (raster.par/map-void!
+                 i n
+                 (do
+                   (if (> (clojure.core/aget x i) 0.0)
+                     (clojure.core/aset
+                      out
+                      (raster.par/unique-index (clojure.core/aget slots i))
+                      (float (clojure.core/aget x i))))
+                   (raster.par/atomic-add! total 0 (float (clojure.core/aget x i)))
+                   (raster.par/atomic-add! count 0 (int 1))))]
+               effect)
+        program (frontend/form->program
+                 source {:dtype :float
+                         :array-types {'x :float 'slots :int 'out :float
+                                       'total :float 'count :int}})
+        equation (first (dialect/equations program))
+        {:keys [attributes destinations lambda]} (dialect/operation-parts equation)
+        {:keys [body-results]} (dialect/lambda-parts lambda)
+        effect-parts (mapv dialect/effect-parts body-results)]
+    (is (= 'effect-map (dialect/operation-kind equation)))
+    (is (= ['out 'total 'count] destinations))
+    (is (= [:float :float :int] (:dtypes attributes)))
+    (is (= [:unique :reduce :reduce]
+           (mapv #(if (= :unique (:conflict %))
+                    :unique (get-in % [:conflict :kind]))
+                 effect-parts)))
+    (is (= [:float :int]
+           (mapv #(get-in % [:conflict :dtype]) (rest effect-parts))))
+    (is (= [:write :read-write :read-write]
+           (mapv :access (dialect/result-storage program 0))))
+    (is (= [] (dialect/outputs program)))
+    (is (= program (dialect/validate! program)))))
+
+(deftest mixed-effects-still-require-an-explicit-indirect-write-proof
+  (let [source
+        '(let* [effect
+                (raster.par/map-void!
+                 i n
+                 (do
+                   (clojure.core/aset out (clojure.core/aget slots i)
+                                      (float (clojure.core/aget x i)))
+                   (raster.par/atomic-add! total 0 (float 1.0))))]
+               effect)]
+    (is (nil? (frontend/form->program
+               source {:dtype :float
+                       :array-types {'x :float 'slots :int 'out :float 'total :float}})))))


### PR DESCRIPTION
## Summary

- recognize proof-carrying mixed unique/reduction regions from closed typed `map-void!` source
- retain conflict and dtype per destination and preserve guarded ordered effects through TypedSOAC
- execute the same scheduled region exactly on the JVM and emit it through common GPU KernelBody
- keep unproved indirect writes outside the parallel effect-map contract

## Validation

- `clojure -M:test -n raster.compiler.passes.parallel.typed-ordered-effect-map-test`
- `clojure -M:test -n raster.compiler.passes.parallel.typed-soac-frontend-test`
- `clojure -M:test -n raster.compiler.passes.parallel.typed-soac-route-test`
- `clojure -M:test -n raster.compiler.passes.parallel.typed-reducing-scatter-test`

Stacked on #321. The firms ABM decision phase intentionally remains outside this parallel route: its active IDs are sampled with replacement, so agent writes are not unique. A resident ordered-iteration schedule is the semantics-preserving follow-up.
