### PR TITLE
Schedule conflicting effects in source order

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -169,18 +169,20 @@ directly to one `SegMap`; unique effects lower to `ScalarStore`, reductions lowe
 and guarded effects retain structured `IfRegion` control in the common `KernelBody`. The same body
 and ordered ABI emit as portable OpenCL, CUDA, and HIP. Fusion treats this operation as a
 conservative boundary until an effect-aware rule proves that moving or combining it preserves the
-declared memory order. Source selection remains gated on proving indirect-write uniqueness rather
-than inferring it from a workload or variable name. Closed typed source can now form this boundary
-for mixed unique and reducing effects, with per-destination dtypes and conflict certificates; JVM
-execution and OpenCL/CUDA/HIP emission consume the same scheduled region. Typed locals are
-pre-effect snapshots, while a direct read after a sibling write still declines.
+declared memory order. Source selection never infers indirect-write uniqueness from a workload or
+variable name. Closed typed source forms parallel effect maps only from explicit uniqueness or
+reduction certificates; unproved ordinary conflicts instead carry `:ordered` and
+`:iteration-order :sequential`. That schedule keeps the semantic extent and ABI unchanged, launches
+one work item, and emits an explicit source-order `KernelBody.ForLoop` on OpenCL/CUDA/HIP. JVM
+execution consumes the same ordered region. Typed locals are pre-effect snapshots, while direct
+reads after sibling writes are legal only in the sequential schedule.
 
 This proof boundary exposed a pre-existing firms-ABM race rather than hiding it: active IDs are
 sampled with replacement, so two decision lanes may write the same agent state and cannot carry a
 `unique-index` certificate. The semantics-preserving production route is a resident ordered queue
-loop (or, later, grouping by agent followed by one ordered lane per group). A single-thread/device
-ordered-iteration schedule is therefore explicit remaining coverage; parallel `effect-map` is not
-permission to assert workload-specific uniqueness.
+loop (or, later, grouping by agent followed by one ordered lane per group). The target-neutral
+ordered-iteration schedule now represents that route; parallel `effect-map` remains unavailable
+without a real conflict-freedom certificate.
 
 Adam and AdamW use the functional tuple-map storage contract directly: gradient is a read-only operand, parameter
 and moment buffers are typed inout storage, and the bias-corrected moment snapshots form one local

--- a/design/soac-fusion.md
+++ b/design/soac-fusion.md
@@ -31,11 +31,12 @@ The GPU schedule projects their ordered local SSA and guarded effects directly i
 unique effects become `ScalarStore`, checked reduction effects become `AtomicRMW`, and predicates
 become structured `IfRegion` nodes. OpenCL, CUDA, and HIP therefore consume the same verified
 `KernelBody`; the operation is not reconstructed as source-level mutation in an emitter.
-Closed typed `map-void!` bodies select this operation only when every indirect write carries an
-explicit uniqueness marker or a checked reduction algebra. Conflict and dtype are retained per
-physical destination, so mixed FP32/int32 effects do not inherit a global kernel dtype. Typed
+Closed typed `map-void!` bodies retain every supported indirect write in this operation. Explicit
+uniqueness and checked reduction certificates permit independent iteration; an unproved ordinary
+write is marked `:ordered` and forces one source-order device loop. Conflict and dtype are retained
+per physical destination, so mixed FP32/int32 effects do not inherit a global kernel dtype. Typed
 locals form a pre-effect snapshot spine and guarded branches retain ordered predicates. The JVM
-consumes the same scheduled region as an exact sequential loop; unproved cross-lane writes decline.
+consumes the same region as an exact sequential loop.
 
 Fusion iterates three general transformations to a fixpoint:
 
@@ -91,12 +92,10 @@ models can refine a choice, while the typed program and numerical oracle constra
 
 ## Remaining work
 
-1. Add a resident ordered-iteration schedule for effect programs whose indices are not independent.
-   In particular, the firms ABM samples active IDs with replacement, so its decision phase cannot
-   claim unique agent writes; it must process the queue in order or group by agent before parallel
-   scheduling. Replace active-ID narrowing and specialized block-movement compatibility coverage
-   with direct typed equations and schedules. RNG fill is now an ordinary typed map with wrapping
-   SplitMix64 scalar SSA.
+1. Route the firms ABM sampled decision queue through the new resident ordered-iteration schedule,
+   then evaluate grouping by agent as a legal parallel optimization. Replace active-ID narrowing
+   and specialized block-movement compatibility coverage with direct typed equations and schedules.
+   RNG fill is now an ordinary typed map with wrapping SplitMix64 scalar SSA.
 2. Finish explicit typed scalar SSA for every region; do not recover scalar types in emitters or
    beta-reduce away type contracts.
 3. Finish explicit integer arithmetic semantics. Unchecked source add/subtract/multiply now retain

--- a/src/raster/compiler/backend/jvm/segop_simd.clj
+++ b/src/raster/compiler/backend/jvm/segop_simd.clj
@@ -973,12 +973,16 @@
           j-sym (gensym "effect_i__")
           {:keys [locals effects]} (:scalar-region segmap)
           effect-statement
-          (fn [{:keys [destination conflict destination-index predicate value]}]
+          (fn [{:keys [destination dtype conflict destination-index predicate value]}]
             (let [reduction? (soac-dialect/reducing-scatter-conflict? conflict)
-                  destination (if reduction?
-                                (let [tag (dtype/scalar-tag-for-dtype (:dtype conflict))]
-                                  (with-meta destination {:tag tag :raster.type/tag tag}))
+                  destination-dtype (or dtype (when reduction? (:dtype conflict)))
+                  scalar-tag (when destination-dtype
+                               (dtype/scalar-tag-for-dtype destination-dtype))
+                  destination (if destination-dtype
+                                (with-meta destination
+                                  {:tag scalar-tag :raster.type/tag scalar-tag})
                                 destination)
+                  value (if scalar-tag (list scalar-tag value) value)
                   store (if reduction?
                           (list 'raster.par/atomic-add! destination destination-index value)
                           (list 'clojure.core/aset destination destination-index value))]

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -27,7 +27,8 @@
                (region [(let-value local :dtype init-expr) ...]
                        [(write destination-index predicate value) ...]))))
         (= equation-id [result ...]
-           (effect-map {:index i :extent n :dtypes [:float ...]}
+           (effect-map {:index i :extent n :dtypes [:float ...]
+                        :iteration-order :independent-or-sequential}
              [array ...] [capture ...] [destination ...]
              (lambda [element ... capture-parameter ... destination-parameter ...]
                (effect-region [(let-value local :dtype init-expr) ...]
@@ -182,14 +183,15 @@
   "A race-freedom contract for one ordered effect destination.
 
    `:unique` certifies injective writes across logical work items. Reduction effects reuse the
-   same checked commutative-monoid certificate as typed scatter; the effect order is retained only
-   within a work item and does not invent a cross-item order."
+   same checked commutative-monoid certificate as typed scatter. `:ordered` permits conflicts only
+   when the enclosing effect map requires source-order iteration."
   [value]
-  (or (= :unique value) (reducing-scatter-conflict? value)))
+  (or (contains? #{:unique :ordered} value) (reducing-scatter-conflict? value)))
 
 (defn effect-map-attributes?
   [value]
   (and (map-attributes? value)
+       (contains? #{:independent :sequential} (:iteration-order value))
        (vector? (:dtypes value))
        (seq (:dtypes value))
        (every? #(and (keyword? %) (dtype/known? %)
@@ -986,7 +988,8 @@
             destination-parameters (vec (take-last destination-count parameters))
             destination-set (set destination-parameters)
             effects (mapv effect-parts body-results)
-            by-destination (group-by :destination effects)]
+            by-destination (group-by :destination effects)
+            iteration-order (:iteration-order attributes)]
         (when-not (= result-count destination-count (count (:dtypes attributes)))
           (fail! :typed-soac-effect-results
                  "effect-map results, physical destinations, and dtypes must align"
@@ -996,6 +999,12 @@
           (fail! :typed-soac-effect-form
                  "effect-map regions contain only canonical ordered effects"
                  {:equation equation-id :effects body-results}))
+        (when (and (= :independent iteration-order)
+                   (some #(= :ordered (:conflict %)) effects))
+          (fail! :typed-soac-effect-iteration-order
+                 "conflicting effects require sequential logical iteration"
+                 {:equation equation-id :iteration-order iteration-order
+                  :effects body-results}))
         (when-not (= destination-set (set (keys by-destination)))
           (fail! :typed-soac-effect-destinations
                  "every declared effect destination must be referenced through its lambda parameter"

--- a/src/raster/compiler/passes/parallel/segmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segmap_body.clj
@@ -59,7 +59,7 @@
    source-shaped lambda remains only for compatibility-created SegMaps; its binder metadata is
    projected once here and is never used to infer an arithmetic function or result type."
   [segmap]
-  (if-let [{:keys [locals result effects] :as region} (:scalar-region segmap)]
+  (if-let [{:keys [locals result effects iteration-order] :as region} (:scalar-region segmap)]
     (do
       (when-not (and (vector? locals)
                      (every? #(and (symbol? (:id %)) (:dtype %) (contains? % :init)) locals)
@@ -71,7 +71,8 @@
                   {:operation (:id segmap) :scalar-region region}))
       (cond-> {:locals locals}
         (contains? region :result) (assoc :result result)
-        (contains? region :effects) (assoc :effects effects)))
+        (contains? region :effects) (assoc :effects effects)
+        (contains? region :iteration-order) (assoc :iteration-order iteration-order)))
     (let [expression (:lambda segmap)]
       (if (and (seq? expression)
                (contains? #{'let 'let* 'clojure.core/let} (first expression)))
@@ -136,8 +137,9 @@
                          reduction-destinations)
         read-only-inputs (vec (remove inout inputs))
         scalars (vec (sort-by name (:scalars segmap)))
-        {:keys [locals result effects]} (scalar-region segmap)
+        {:keys [locals result effects iteration-order]} (scalar-region segmap)
         ordered-effects? (seq effects)
+        sequential-effects? (and ordered-effects? (= :sequential iteration-order))
         explicit-certified-write?
         (and (nil? primary-output)
              (contains? #{:unique :reduce} (:write-conflict segmap)))
@@ -165,10 +167,12 @@
         lower-index (fn lower-index
                       ([expression] (lower-index expression #{}))
                       ([expression extra-scope]
+                       (lower-index expression extra-scope {}))
+                      ([expression extra-scope extra-types]
                        (widen-index-expression
                         (index-expression/lower
                          expression (set/union index-scope extra-scope) decline!)
-                        index-types)))
+                        (merge index-types extra-types))))
         lowerer (scalar-expression/make-lowerer
                  {:array-types array-types :scalar-types scalar-types
                   :arrays (set inputs) :index-scope index-scope
@@ -220,7 +224,8 @@
                                      ((:lower lowerer) coordinate :long environment))
                   coordinate-expression (if coordinate-value
                                           (:result coordinate-value)
-                                          (lower-index coordinate))
+                                          (lower-index coordinate (set (keys environment))
+                                                       environment))
                   lowered ((:lower lowerer) expression (get array-types array) environment)]
               (concat (:operations coordinate-value)
                       (:operations lowered)
@@ -240,7 +245,8 @@
                                    ((:lower lowerer) destination-index :long environment))
                 coordinate-expression (if coordinate-value
                                         (:result coordinate-value)
-                                        (lower-index destination-index))
+                                        (lower-index destination-index
+                                                     (set (keys environment)) environment))
                 lowered-value ((:lower lowerer) value (get array-types destination) environment)
                 operator (when (= :reduce (:kind conflict))
                            (intrinsics/canonical (:operator conflict)))
@@ -283,6 +289,19 @@
                                             (:result primary-lowered) :map-active)])))
         group-index 'map-group
         local-index 'map-lane
+        launch-index (if sequential-effects? 'effect-launch index)
+        scheduled-operations
+        (if sequential-effects?
+          [(body/->ForLoop
+            (body/value index :long)
+            (body/index-cast 0 :long :exact)
+            (body/index-cast '_n_bound :long :exact)
+            1
+            []
+            (conj scalar-operations (body/->Yield []))
+            []
+            {:association :ordered :source-order true})]
+          scalar-operations)
         parameters
         (vec (concat
               (map #(body/->KernelParameter
@@ -305,7 +324,7 @@
        :indices [(body/->IndexBinding group-index :group 0)
                  (body/->IndexBinding local-index :local 0)
                  (body/->IndexCompute
-                  index
+                  launch-index
                   (body/index-cast
                    (body/expression :add
                                     (body/expression :mul group-index workgroup-size)
@@ -313,13 +332,21 @@
                    :long :exact))]
        :masks [(body/->Mask
                 :map-active
-                [(body/predicate :lt index (body/index-cast '_n_bound :long :exact))])]
-       :operations scalar-operations
-       :schedule {:strategy :one-work-item-per-element :association :independent
+                [(if sequential-effects?
+                   (body/predicate :eq launch-index 0)
+                   (body/predicate :lt index (body/index-cast '_n_bound :long :exact)))])]
+       :operations scheduled-operations
+       :schedule {:strategy (if sequential-effects?
+                              :one-work-item-ordered-loop
+                              :one-work-item-per-element)
+                  :association (if sequential-effects? :ordered :independent)
                   :workgroup-size workgroup-size}
-       :launch (launch/spec {:workgroup-size [workgroup-size]
-                             :group-count [(launch/ceil-div bound workgroup-size)]})
+       :launch (if sequential-effects?
+                 (launch/spec {:workgroup-size [1] :group-count [1]})
+                 (launch/spec {:workgroup-size [workgroup-size]
+                               :group-count [(launch/ceil-div bound workgroup-size)]}))
        :provenance {:dialect :kernel-body :source-dialect :segmap
                     :segop-id (:id segmap)}
-       :attributes {:kind :portable-segmap :extent bound :no-write-alias true}})
+       :attributes {:kind :portable-segmap :extent bound :no-write-alias true
+                    :effect-iteration-order iteration-order}})
      :bound bound :inputs read-only-inputs :outputs outputs :scalars scalars}))

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -324,6 +324,7 @@
           (into #{} (keep (fn [{:keys [destination access]}]
                             (when (= :read-write access) destination)))
                 result-storage)
+          destination-dtypes (zipmap physical-results (:dtypes attributes))
           _ (when-not (= destinations physical-results)
               (throw (ex-info "typed effect-map destination storage changed after validation"
                               {:reason :raster/bug :equation equation-id
@@ -343,6 +344,8 @@
                   (let [{:keys [destination conflict destination-index predicate value]}
                         (soac-dialect/effect-parts effect)]
                     {:destination (util/subst-syms substitutions destination)
+                     :dtype (get destination-dtypes
+                                 (util/subst-syms substitutions destination))
                      :conflict conflict
                      :destination-index (util/subst-syms substitutions destination-index)
                      :predicate (util/subst-syms substitutions predicate)
@@ -357,11 +360,13 @@
                                                        effects)))])
                         physical-results))
           result-dtype (or (:dtype (get values (first results))) dtype :double)
+          iteration-order (:iteration-order attributes)
           description {:id equation-id
                        :bound (:extent attributes)
                        :idx (:index attributes)
                        :lambda nil
-                       :scalar-region {:locals locals :effects effects}
+                       :scalar-region {:locals locals :effects effects
+                                       :iteration-order iteration-order}
                        :inputs (into (into (set arrays) stable) read-write-destinations)
                        :outputs (set physical-results)
                        :scalars scalar-captures
@@ -371,6 +376,7 @@
       (mapv #(assoc % :algorithm-dialect :typed-soac
                     :algorithm-equation equation-id
                     :write-conflict :ordered-effects
+                    :effect-iteration-order iteration-order
                     :write-conflicts write-conflicts)
             (lower-map-description description device-id :dtype result-dtype)))))
 

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -425,10 +425,26 @@
                                           (when destination-type
                                             (dialect/reducing-scatter-conflict
                                              reduction-op destination-type))
-                                          (= index (:index store)) :unique)]
+                                          (= index (:index store)) :unique
+                                          :else :ordered)]
                            (assoc store :effect-conflict contract
                                         :destination-dtype destination-type)))
                        stores)
+          ;; One physical destination has one cross-item contract. If any ordinary store may
+          ;; collide, its otherwise-unique siblings must join the same sequential contract. A
+          ;; reduction mixed with an ordered overwrite remains unsupported: those are distinct
+          ;; operations and must not be blurred into one conflict certificate.
+          stores (reduce (fn [current [_ grouped]]
+                           (let [contracts (set (map :effect-conflict grouped))]
+                             (if (and (contains? contracts :ordered)
+                                      (set/subset? contracts #{:unique :ordered}))
+                               (mapv (fn [store]
+                                       (if (= (:out (first grouped)) (:out store))
+                                         (assoc store :effect-conflict :ordered)
+                                         store))
+                                     current)
+                               current)))
+                         stores (group-by :out stores))
           effect-contracts (mapv :effect-conflict stores)
           uniform-conflict (when (= 1 (count (set effect-contracts)))
                              (first effect-contracts))
@@ -438,10 +454,14 @@
                             (dialect/reducing-scatter-conflict? uniform-conflict)))
           ordered? (and (not dense-pointwise?) (not scatter?) (= :effect host-return)
                         (every? some? effect-contracts)
-                        (ordered-effects-safe? locals stores)
                         (every? (fn [[_ grouped]]
                                   (= 1 (count (set (map :effect-conflict grouped)))))
                                 (group-by :out stores)))
+          iteration-order (when ordered?
+                            (if (or (some #(= :ordered (:effect-conflict %)) stores)
+                                    (not (ordered-effects-safe? locals stores)))
+                              :sequential
+                              :independent))
           destinations (if ordered?
                          (vec (distinct (map :out stores)))
                          (mapv :out stores))
@@ -466,6 +486,7 @@
                            (mapv #(select-keys % [:out :index :predicate :value :cast
                                                   :effect-conflict])
                                  stores))
+                :iteration-order iteration-order
                 :result-dtypes (when ordered? result-dtypes)
                 :effect-only? (= :effect host-return)
                 :host-binding symbol :elem-type elem-type
@@ -1120,7 +1141,7 @@
                         (count (:result-dtypes description)))
                      (every? (comp symbol? :destination) (:result-storage description))
                      (every? (fn [{:keys [effect-conflict]}]
-                               (or (= :unique effect-conflict)
+                               (or (contains? #{:unique :ordered} effect-conflict)
                                    (dialect/reducing-scatter-conflict? effect-conflict)))
                              (:effects description)))
     :stencil (and (= 1 (count (:result-storage description)))
@@ -1298,7 +1319,8 @@
                                      local-forms writes)))))
 
 (defn- effect-map-equation
-  [{:keys [id index extent locals inputs scalars results result-storage effects result-dtypes]}]
+  [{:keys [id index extent iteration-order locals inputs scalars results result-storage effects
+           result-dtypes]}]
   (let [destinations (mapv :destination result-storage)
         destination-set (set destinations)
         all-expressions (vec (concat (map :init locals)
@@ -1331,6 +1353,7 @@
     (list '= id results
           (list 'effect-map
                 {:index index :extent extent :dtypes result-dtypes
+                 :iteration-order iteration-order
                  :attributes {:stable-array-captures (vec (sort-by pr-str stable))}}
                 arrays captures destinations
                 (dialect/effect-lambda-form

--- a/test/raster/compiler/ir/soac_dialect_test.clj
+++ b/test/raster/compiler/ir/soac_dialect_test.clj
@@ -105,6 +105,7 @@
         (list '= 'effect-0 [left-result total-result]
               (list 'effect-map
                     {:index 'i :extent 'n :dtypes [:float :float]
+                     :iteration-order :independent
                      :attributes {:stable-array-captures '[indices]}}
                     '[x] '[indices] '[out total]
                     (dialect/effect-lambda-form
@@ -137,6 +138,29 @@
     (is (= [[:storage :out] [:storage :total]]
            (:destinations (dialect/operation-parts remapped-equation))))
     (is (= program (dialect/validate! program)))
+    (testing "ordered conflicts require a sequential iteration contract"
+      (let [[_ attrs arrays captures destinations lambda] (nth equation 3)
+            {:keys [parameters locals body-results]} (dialect/lambda-parts lambda)
+            ordered-effects (assoc body-results 0
+                                   (list 'effect 'out-destination :ordered
+                                         '(clojure.core/aget index-buffer i) true 'element))
+            ordered-lambda (dialect/effect-lambda-form
+                            parameters (dialect/emit-locals locals) ordered-effects)
+            independent-equation
+            (list '= 'effect-0 [left-result total-result]
+                  (list 'effect-map attrs arrays captures destinations ordered-lambda))
+            sequential-equation
+            (list '= 'effect-0 [left-result total-result]
+                  (list 'effect-map (assoc attrs :iteration-order :sequential)
+                        arrays captures destinations ordered-lambda))]
+        (try
+          (dialect/make facts [independent-equation] [])
+          (is false "an independent schedule must not accept a conflicting store")
+          (catch clojure.lang.ExceptionInfo exception
+            (is (= :typed-soac-effect-iteration-order (:reason (ex-data exception))))))
+        (is (= 'effect-map
+               (dialect/operation-kind (first (dialect/equations
+                                               (dialect/make facts [sequential-equation] []))))))))
     (testing "operation destinations cannot drift from physical result storage"
       (let [[_ attrs arrays captures _destinations lambda] (nth equation 3)
             bad-equation

--- a/test/raster/compiler/passes/parallel/typed_ordered_effect_map_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_ordered_effect_map_test.clj
@@ -3,11 +3,13 @@
             [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.segop-opencl :as segop-opencl]
             [raster.compiler.backend.jvm.par-simd :as par-simd]
+            [raster.compiler.pipeline :as pipeline]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.soac-lower :as soac-lower]
             [raster.compiler.passes.parallel.typed-soac-route :as route]
+            [raster.abm.firms.phases :as firms-phases]
             [raster.par]))
 
 (def ^:private extent (av/tensor {:dtype :long :shape []}))
@@ -22,7 +24,8 @@
         equation
         (list '= 0 [out-result total-result]
               (list 'effect-map
-                    {:index 'i :extent 'n :dtypes [:float :float]}
+                    {:index 'i :extent 'n :dtypes [:float :float]
+                     :iteration-order :independent}
                     '[x] [] '[out total]
                     (dialect/effect-lambda-form
                      '[element out-destination total-destination]
@@ -49,7 +52,8 @@
   [operations]
   (mapcat (fn [operation]
             (cons operation
-                  (concat (nested-operations (or (:then-operations operation) []))
+                  (concat (nested-operations (or (:operations operation) []))
+                          (nested-operations (or (:then-operations operation) []))
                           (nested-operations (or (:else-operations operation) [])))))
           operations))
 
@@ -86,12 +90,14 @@
     (is (= #{'out 'total} (:outputs operation)))
     (is (= {:locals [{:id 'shifted :dtype :float :init '(+ (clojure.core/aget x i) 1.0)}]
             :effects
-            [{:destination 'out :conflict :unique :destination-index 'i
+            [{:destination 'out :dtype :float :conflict :unique :destination-index 'i
               :predicate '(> (clojure.core/aget x i) 0.0) :value 'shifted}
              {:destination 'total
+              :dtype :float
               :conflict (dialect/reducing-scatter-conflict '+ :float)
               :destination-index 0 :predicate true
-              :value '(clojure.core/aget x i)}]}
+              :value '(clojure.core/aget x i)}]
+            :iteration-order :independent}
            (:scalar-region operation)))
     (doseq [[target atomic]
             [[:opencl-portable "atomic_add_float"]
@@ -144,3 +150,78 @@
     (is (= [4.0] (mapv double total)))
     (is (= 1 (get-in jvm [:stats :segop-reused])))
     (is (zero? (get-in jvm [:stats :fallback])))))
+
+(deftest potentially-conflicting-effects-use-one-ordered-device-loop
+  (let [source
+        '(let* [effect
+                (raster.par/map-void!
+                 i n
+                 (do
+                   (clojure.core/aset out (clojure.core/aget slots i)
+                                      (float (clojure.core/aget x i)))
+                   (raster.par/atomic-add! total 0 (float 1.0))))]
+               effect)
+        result (route/attempt source :float
+                              {'x :float 'slots :int 'out :float 'total :float})
+        program (:program result)
+        equation (-> program :equations first :algorithm dialect/equations first)
+        scheduled (:form (segop-lower/segop-lower-pass
+                          program {:target-device :ze:0 :dtype :float}))
+        operation (first (get-in scheduled [:equations 0 :operations]))
+        artifacts
+        (into {}
+              (map (fn [target]
+                     [target
+                      (segop-opencl/generate-scheduled-segmap-kernel
+                       operation :dtype :float :target-dialect target
+                       :array-types {'x :float 'slots :int 'out :float 'total :float}
+                       :scalar-types {'n :long})]))
+              [:opencl-portable :cuda :hip])
+        artifact (get artifacts :opencl-portable)
+        kernel-body (get-in artifact [:attributes :kernel-body])
+        operations (nested-operations (:operations kernel-body))
+        jvm (par-simd/simd-pass scheduled :min-elements 1)
+        execute (eval (list 'fn '[x slots out total n] (:form jvm)))
+        out (float-array [10.0 20.0])
+        total (float-array 1)]
+    (is (= :typed-soac (get-in result [:stats :route])))
+    (is (= :sequential (get-in (dialect/operation-parts equation)
+                                [:attributes :iteration-order])))
+    (is (= [:ordered :reduce]
+           (mapv (fn [effect]
+                   (let [conflict (:conflict (dialect/effect-parts effect))]
+                     (if (keyword? conflict) conflict (:kind conflict))))
+                 (:body-results
+                  (dialect/lambda-parts (:lambda (dialect/operation-parts equation)))))))
+    (is (= :sequential (:effect-iteration-order operation)))
+    (is (= [1] (get-in kernel-body [:launch :workgroup-size])))
+    (is (= [1] (get-in kernel-body [:launch :group-count])))
+    (is (= :one-work-item-ordered-loop (get-in kernel-body [:schedule :strategy])))
+    (is (some #(= "ForLoop" (some-> % class .getSimpleName)) operations))
+    (doseq [[target emitted] artifacts]
+      (testing (name target)
+        (is (= :kernel-body (get-in emitted [:attributes :emission-route])))
+        (is (= :one-work-item-ordered-loop
+               (get-in emitted [:attributes :kernel-body :schedule :strategy])))
+        (is (str/includes? (:source emitted) "for ("))))
+    (is (nil? (execute (float-array [1.0 2.0 3.0]) (int-array [1 1 1]) out total 3)))
+    (is (= [10.0 3.0] (mapv double out)) "the last source-order overwrite wins")
+    (is (= [3.0] (mapv double total)))
+    (is (= 1 (get-in jvm [:stats :segop-reused])))
+    (is (zero? (get-in jvm [:stats :fallback])))))
+
+(deftest firms-decision-queue-uses-the-certified-ordered-kernel
+  (let [descriptor (pipeline/compile-gpu-program
+                    #'firms-phases/execute-stay-switch-par!
+                    :ze:0 :dtype :float :on-non-resident :nil)
+        step (first (:steps descriptor))
+        kernel-body (get-in step [:artifact :attributes :kernel-body])]
+    (is (some? descriptor))
+    (is (= :kernel-body (get-in step [:artifact :attributes :emission-route])))
+    (is (= :one-work-item-ordered-loop (get-in kernel-body [:schedule :strategy])))
+    (is (= :ordered (get-in kernel-body [:schedule :association])))
+    (is (= [1] (get-in kernel-body [:launch :workgroup-size])))
+    (is (= [1] (get-in kernel-body [:launch :group-count])))
+    (is (some #(= "ForLoop" (some-> % class .getSimpleName))
+              (:operations kernel-body)))
+    (is (= :sequential (get-in kernel-body [:attributes :effect-iteration-order])))))

--- a/test/raster/compiler/passes/parallel/typed_reducing_scatter_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_reducing_scatter_test.clj
@@ -119,7 +119,7 @@
     (is (= :float (:dtype conflict))
         "the float-array declaration, not the default arithmetic dtype, owns storage type")))
 
-(deftest additive-effect-recognition-refuses-an-extra-destination-read
+(deftest additive-effect-with-an-extra-destination-read-preserves-source-order
   (let [unsafe
         '(let* [effect
                 (raster.par/map-void!
@@ -132,12 +132,20 @@
                effect)
         routed (pipeline/schedule-parallel-form
                 unsafe {:target-device :cpu:0 :dtype :float
-                        :array-types float-types :scalar-types scalar-types})]
-    (is (not= :typed-soac (get-in routed [:stats :source-dialect])))
-    (is (= :typed-soac-source-coverage
-           (get-in routed [:stats :typed-soac-declined :reason])))
-    (is (= :unsupported-parallel-operation
-           (get-in routed [:stats :typed-soac-declined :bindings 0 :reason])))))
+                        :array-types float-types :scalar-types scalar-types})
+        scheduled (:form routed)
+        equation (first (:equations scheduled))
+        attributes (-> equation :algorithm dialect/equations first
+                       dialect/operation-parts :attributes)
+        operation (first (:operations equation))
+        jvm (par-simd/simd-pass scheduled :min-elements 1)
+        execute (eval (list 'fn '[out keys n] (:form jvm)))
+        out (float-array [10.0 20.0 30.0])]
+    (is (= :typed-soac (get-in routed [:stats :source-dialect])))
+    (is (= :sequential (:iteration-order attributes)))
+    (is (= :sequential (:effect-iteration-order operation)))
+    (is (nil? (execute out (int-array [1 1]) 2)))
+    (is (= [10.0 60.0 30.0] (mapv double out)))))
 
 (deftest verified-array-dtype-selects-the-target-atomic-spelling
   (let [operation '(raster.par/atomic-add! out i contribution)

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -678,15 +678,9 @@
     (is (= [:read-write :read-write :read-write]
            (mapv :access (dialect/result-storage program 0))))))
 
-(deftest ordered-void-bodies-decline-the-functional-tuple-map
+(deftest untyped-ordered-void-bodies-decline-the-typed-effect-map
   (doseq [[label body]
-          [["one destination written twice"
-            '(do (clojure.core/aset a i (float 1.0))
-                 (clojure.core/aset a i (float 2.0)))]
-           ["a later store observes an earlier sibling write"
-            '(do (clojure.core/aset a i (float (clojure.core/aget x i)))
-                 (clojure.core/aset b i (float (clojure.core/aget a i))))]
-           ["an untyped shared local cannot enter a typed region"
+          [["an untyped shared local cannot enter a typed region"
             '(let* [v (+ (clojure.core/aget x i) 1.0)]
                    (clojure.core/aset a i (float v))
                    (clojure.core/aset b i (float (* v v))))]
@@ -694,10 +688,7 @@
             '(let* [u (+ (clojure.core/aget x i) 1.0)
                     v (* u 2.0)]
                    (clojure.core/aset a i (float v))
-                   (clojure.core/aset b i (float u)))]
-           ["an indexed write without an explicit conflict contract"
-            '(clojure.core/aset a (clojure.core/aget indices i)
-                                (float (clojure.core/aget x i)))]]]
+                   (clojure.core/aset b i (float u)))]]]
     (testing label
       (is (nil? (frontend/form->program
                  (list 'let* ['effect (list 'raster.par/map-void! 'i 'n body)] 'effect)
@@ -740,7 +731,7 @@
     (is (= [] (dialect/outputs program)))
     (is (= program (dialect/validate! program)))))
 
-(deftest mixed-effects-still-require-an-explicit-indirect-write-proof
+(deftest unproved-indirect-write-is-explicitly-sequential
   (let [source
         '(let* [effect
                 (raster.par/map-void!
@@ -749,7 +740,18 @@
                    (clojure.core/aset out (clojure.core/aget slots i)
                                       (float (clojure.core/aget x i)))
                    (raster.par/atomic-add! total 0 (float 1.0))))]
-               effect)]
-    (is (nil? (frontend/form->program
-               source {:dtype :float
-                       :array-types {'x :float 'slots :int 'out :float 'total :float}})))))
+               effect)
+        program (frontend/form->program
+                 source {:dtype :float
+                         :array-types {'x :float 'slots :int 'out :float 'total :float}})
+        equation (first (dialect/equations program))
+        {:keys [attributes lambda]} (dialect/operation-parts equation)
+        effects (:body-results (dialect/lambda-parts lambda))]
+    (is (= 'effect-map (dialect/operation-kind equation)))
+    (is (= :sequential (:iteration-order attributes)))
+    (is (= [:ordered :reduce]
+           (mapv (fn [effect]
+                   (let [conflict (:conflict (dialect/effect-parts effect))]
+                     (if (keyword? conflict) conflict (:kind conflict))))
+                 effects)))
+    (is (= program (dialect/validate! program)))))

--- a/test/raster/quant/kernels_k_gpu_test.clj
+++ b/test/raster/quant/kernels_k_gpu_test.clj
@@ -92,10 +92,11 @@
   (let [kernels (:kernels (pipeline/show-pipeline #'attn/rope-pos-rows-buf!
                                                   :target-device :ze:0 :dtype :float))]
     (is (= 1 (count kernels)))
-    (is (= '[[out :float] [positions :int] [x :float]
-             [head-dim :int] [heads :int] [theta :float] [_n_bound :int]]
-           (mapv (juxt :name :dtype) (:abi (first kernels))))
-        "row count shapes the launch but is specialized out of the physical ABI"))
+    (is (= '[[positions :input :int] [x :input :float] [out :output :float]
+             [head-dim :scalar :int] [heads :scalar :int] [theta :scalar :float]
+             [_n_bound :scalar :int]]
+           (mapv (juxt :name :kind :dtype) (:abi (first kernels))))
+        "KernelBody orders inputs, outputs, then scalars; row count is specialized out"))
   (when (gpu-available?)
     (testing "buffered RoPE lowers one independent position per row"
       (let [nrows 3 heads 8 hd 64 theta 10000.0 positions (int-array [0 5 29])


### PR DESCRIPTION
## Summary

- distinguish independently schedulable effect maps from source-ordered effect programs
- retain unproved indirect stores as explicit `:ordered` effects and lower them to a one-work-item `KernelBody.ForLoop`
- preserve the semantic extent and ABI while emitting the same ordered body for OpenCL, CUDA, HIP, and the JVM
- route the firms ABM decision queue through the typed KernelBody vertical without falsely claiming unique sampled agent IDs
- retain per-destination storage dtypes through scheduled effects and exact JVM stores

## Correctness boundary

`active-ids!` samples with replacement, so duplicate agent IDs are legal. The compiler now represents that fact rather than annotating the workload as unique. Independent effect maps reject `:ordered` conflicts; the sequential schedule is the only legal schedule until a later grouping-by-agent transformation proves parallel ownership.

## Verification

- `clojure -M:test -n raster.compiler.ir.soac-dialect-test -n raster.compiler.passes.parallel.typed-soac-frontend-test -n raster.compiler.passes.parallel.typed-soac-route-test -n raster.compiler.passes.parallel.typed-ordered-effect-map-test`
  - 92 tests, 664 assertions, green
- `clojure -M:test -n raster.compiler.passes.parallel.typed-reducing-scatter-test -n raster.compiler.passes.parallel.typed-ordered-effect-map-test`
  - 11 tests, 113 assertions after the typed JVM store correction
- production compile regression verifies `execute-stay-switch-par!` emits one ordered KernelBody loop

Stacked on #322.
