### PR TITLE
Preserve typed scalar prefixes in direct maps

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1164,6 +1164,10 @@ The immediate continuation after the verified double-buffered weighted-reduction
    scatter workloads. Direct strided gather and scatter now consume the complete typed
    mini-program: normalization's hoisted product extent remains an ordered host-scalar equation,
    and the backend consumes the following scheduled SegMap without reconstructing either fact.
+   Direct maps with compound extents use the same complete mini-program route on GPU and JVM. The
+   remaining singleton adapter accepts only a closed equation and fails with
+   `:direct-operation-requires-program` if a caller would discard a host-scalar prefix; it never
+   silently re-enters legacy SOAC to erase that dependency.
    A raw binding program handed directly to the GPU backend likewise enters this whole-program
    adapter once, preserving cross-equation typed facts instead of independently scheduling each
    child operation. The JVM SIMD direct entry does the same when its caller supplies an

--- a/design/soac-fusion.md
+++ b/design/soac-fusion.md
@@ -97,7 +97,9 @@ models can refine a choice, while the typed program and numerical oracle constra
    and specialized block-movement compatibility coverage with direct typed equations and schedules.
    RNG fill is now an ordinary typed map with wrapping SplitMix64 scalar SSA.
 2. Finish explicit typed scalar SSA for every region; do not recover scalar types in emitters or
-   beta-reduce away type contracts.
+   beta-reduce away type contracts. Direct compound map extents now retain their typed host-scalar
+   prefix through GPU and JVM entry points; a singleton SegOp projection explicitly refuses such a
+   mini-program rather than falling back to legacy source lowering.
 3. Finish explicit integer arithmetic semantics. Unchecked source add/subtract/multiply now retain
    `:wrap` in scalar `KernelBody` SSA and C-family targets execute them through the corresponding
    unsigned representation; add `trap` and proved-no-overflow contracts before admitting ordinary

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -18,6 +18,7 @@
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.segop :as segop]
+            [raster.compiler.ir.soac-dialect :as soac-dialect]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower-pass]
             [raster.compiler.backend.gpu.segop-opencl :as segop-cl]
@@ -302,7 +303,12 @@
                  (and (par/par-gather-form? form)
                       (:stride (par/extract-par-gather-info form)))
                  (and (par/par-scatter-form? form)
-                      (:stride (par/extract-par-scatter-info form)))))
+                      (:stride (par/extract-par-scatter-info form)))
+                 ;; A compound source extent normalizes to a preceding typed scalar equation. It
+                 ;; cannot be projected as a closed SegMap without losing that SSA definition.
+                 (and (par/par-map-form? form)
+                      (not (soac-dialect/extent?
+                            (:bound (par/extract-par-map-info form)))))))
         direct-schedule
         (cond
           (and (nil? supplied-program) (form/binding-form? form))

--- a/src/raster/compiler/backend/jvm/par_simd.clj
+++ b/src/raster/compiler/backend/jvm/par_simd.clj
@@ -26,6 +26,7 @@
             [raster.compiler.ir.par :as par]
             [raster.compiler.ir.parallel-program :as parallel-program]
             [raster.compiler.ir.segop :as segop]
+            [raster.compiler.ir.soac-dialect :as soac-dialect]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower-pass]
             [raster.runtime.hardware :as hw]
             [clojure.set :as set]))
@@ -388,11 +389,21 @@
     (let [supplied-program (when (parallel-program/parallel-program? form)
                              (parallel-program/validate! form segop/segop-node?))
           direct-schedule
-          (when (and (nil? supplied-program) dtype (form/binding-form? form))
-            (segop-lower-pass/schedule-source-program
-             form {:target-device :cpu:0 :dtype dtype
-                   :scalar-types scalar-types :array-types array-types
-                   :values values :abstract-machine abstract-machine}))
+          (when (and (nil? supplied-program) dtype)
+            (cond
+              (form/binding-form? form)
+              (segop-lower-pass/schedule-source-program
+               form {:target-device :cpu:0 :dtype dtype
+                     :scalar-types scalar-types :array-types array-types
+                     :values values :abstract-machine abstract-machine})
+
+              (and (par/par-map-form? form)
+                   (not (soac-dialect/extent?
+                         (:bound (par/extract-par-map-info form)))))
+              (segop-lower-pass/schedule-single-program
+               (gensym "direct_parallel_result_") form
+               {:target-device :cpu:0 :dtype dtype
+                :scalar-types scalar-types :array-types array-types})))
           parallel-program (or supplied-program (:program direct-schedule))
           source-form (if parallel-program (parallel-program/source-form parallel-program) form)
           min-elements (or min-elements (effective-min-elements))

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -477,12 +477,7 @@
                          :kernel-graphs-lowered @graphs-lowered}
                   (seq @declined) (assoc :segops-declined @declined))}))))
 
-(defn schedule-single-operation
-  "Run one direct-backend compatibility source form through the shared SegOp boundary.
-
-   Production compilation arrives with a ParallelProgram and never calls this adapter. It exists
-   only for public backend APIs that are invoked directly in tests or tools, keeping all source
-   interpretation in the middle end rather than duplicating `par-form->soac` inside emitters."
+(defn- schedule-direct-program
   [result-id source opts]
   (let [;; Imperative map callers commonly pass the destination as their nominal result ID. Give
         ;; the host result its own value identity so the typed frontend can represent the declared
@@ -493,24 +488,12 @@
                       (gensym "direct_parallel_result_")
                       result-id)
         host-source (list 'let* [host-result source] host-result)
-        typed-candidate
-        (try
-          (typed-frontend/form->program
-           (typed-frontend/normalize-source host-source)
-           {:dtype (or (:dtype opts) :double)
-            :array-types (:array-types opts)
-            :scalar-types (:scalar-types opts)})
-          (catch clojure.lang.ExceptionInfo exception
-            (when-not (typed-frontend/source-decline? exception)
-              (throw exception))
-            nil))
-        ;; The compatibility return value exposes one operation, not a mini-program. Source
-        ;; normalization may introduce host scalar equations (notably a hoisted compound extent);
-        ;; using only the parallel equation would leave those SSA values unbound in the caller.
-        ;; Keep such sites on compatibility lowering until this API returns the complete envelope.
-        typed (when (= 1 (count (soac-dialect/equations typed-candidate))) typed-candidate)
+        typed-result
+        (typed-route/attempt
+         host-source (or (:dtype opts) :double) (:array-types opts)
+         {:scalar-types (:scalar-types opts)})
         {scheduled :form stats :stats}
-        (segop-lower-pass (if typed (typed-route/program-envelope typed) host-source) opts)
+        (segop-lower-pass (or (:program typed-result) host-source) opts)
         ;; Compound extents may introduce a preceding host-scalar equation. Select the one
         ;; scheduled parallel equation rather than assuming it is first in program order.
         equation (some #(when (seq (:operations %)) %) (:equations scheduled))]
@@ -519,30 +502,34 @@
      :operations (:operations equation)
      :algorithm (:algorithm equation)
      :diagnostics (:diagnostics scheduled)
-     :stats stats}))
+     :declined (:declined typed-result)
+     :stats (merge (:stats typed-result) stats)}))
+
+(defn schedule-single-operation
+  "Schedule one closed direct-backend operation through the shared typed boundary.
+
+   This projection is only valid when the operation has no preceding host equations. Callers whose
+   source normalization introduces scalar SSA (for example a compound extent) must consume
+   `schedule-single-program`; silently discarding that prefix would create an unbound kernel ABI."
+  [result-id source opts]
+  (let [scheduled (schedule-direct-program result-id source opts)
+        host-equations (filterv #(true? (get-in % [:attributes :host-only]))
+                                (get-in scheduled [:program :equations]))]
+    (when (seq host-equations)
+      (throw (ex-info "direct operation requires its complete scheduled program"
+                      {:reason :direct-operation-requires-program
+                       :source source
+                       :host-equations (mapv :id host-equations)})))
+    scheduled))
 
 (defn schedule-single-program
   "Run one direct-backend source form through the complete typed program boundary.
 
-   Unlike `schedule-single-operation`, this entry preserves host scalar equations introduced by
-   normalization and reconstructs their host bindings around the scheduled parallel equation.
-   Backends use it when a direct source spelling expands to a genuine mini-program rather than
-   pretending that the parallel operation is closed in isolation."
+   This entry preserves host scalar equations introduced by normalization and reconstructs their
+   host bindings around the scheduled parallel equation. Backends use it whenever a direct source
+   spelling may expand to a genuine mini-program."
   [result-id source opts]
-  (let [host-source (list 'let* [result-id source] result-id)
-        typed-result
-        (typed-route/attempt
-         host-source (or (:dtype opts) :double) (:array-types opts)
-         {:scalar-types (:scalar-types opts)})
-        {scheduled :form stats :stats}
-        (segop-lower-pass (or (:program typed-result) host-source) opts)
-        equation (some #(when (seq (:operations %)) %) (:equations scheduled))]
-    {:program scheduled
-     :equation equation
-     :operations (:operations equation)
-     :algorithm (:algorithm equation)
-     :diagnostics (:diagnostics scheduled)
-     :stats (merge (:stats typed-result) stats)}))
+  (schedule-direct-program result-id source opts))
 
 (defn schedule-source-program
   "Schedule a complete direct-backend binding form through the shared typed boundary.

--- a/test/raster/compiler/segop_boundary_test.clj
+++ b/test/raster/compiler/segop_boundary_test.clj
@@ -107,20 +107,16 @@
       (is (not (re-find #"inout_result\[idx\] =" kernel-source))
           "a unique scatter must not acquire a second implicit dense store"))))
 
-(deftest direct-single-operation-does-not-drop-hoisted-scalar-equations
+(deftest direct-single-operation-refuses-to-drop-hoisted-scalar-equations
   (let [source '(raster.par/map! out i (* n stride) float (aget x i))
-        scheduled (slp/schedule-single-operation
-                   'out source
-                   {:dtype :float
-                    :array-types {'out :float 'x :float}
-                    :scalar-types {'n :long 'stride :long}})
-        operation (first (:operations scheduled))]
-    (is (nil? (:algorithm scheduled))
-        "the one-operation compatibility API cannot return a typed mini-program with host equations")
-    (is (= '(* n stride) (-> operation :space :dims first :bound)))
-    (is (not-any? #(and (symbol? %) (.startsWith (name %) "rstr_extent_"))
-                  (flatten operation))
-        "a hoisted SSA extent must never escape without its defining equation")))
+        opts {:dtype :float
+              :array-types {'out :float 'x :float}
+              :scalar-types {'n :long 'stride :long}}]
+    (try
+      (slp/schedule-single-operation 'out source opts)
+      (is false "a singleton projection must not discard its typed host prefix")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :direct-operation-requires-program (:reason (ex-data exception))))))))
 
 (deftest direct-mini-program-preserves-hoisted-scalar-equations
   (let [source '(raster.par/gather out x indices n stride)
@@ -141,6 +137,28 @@
            (-> operation :space :dims first :bound)))
     (is (some? (:source program))
         "the direct backend receives executable host control, not a source-free algorithm")))
+
+(deftest direct-backends-consume-the-complete-typed-mini-program
+  (let [source '(raster.par/map! out i (* n stride) float (aget x i))
+        opts [:dtype :float :min-elements 0
+              :array-types {'out :float 'x :float}
+              :scalar-types {'n :long 'stride :long}]
+        [gpu jvm]
+        (with-redefs [soac/par-form->soac
+                      (fn [& _]
+                        (throw (AssertionError. "legacy SOAC was constructed")))]
+          [(apply (requiring-resolve 'raster.compiler.backend.gpu.opencl-pass/opencl-pass)
+                  source :device-id :ze:0 opts)
+           (apply (requiring-resolve 'raster.compiler.backend.jvm.par-simd/simd-pass)
+                  source opts)])]
+    (doseq [{:keys [form stats]} [gpu jvm]]
+      (is (= :typed-soac (get-in stats [:direct-scheduling :route])))
+      (is (= 1 (get-in stats [:direct-scheduling :typed-scalar-equations])))
+      (is (some #(and (symbol? %) (.startsWith (name %) "rstr_extent_"))
+                (take-nth 2 (second form)))
+          "the hoisted extent remains an executable binding in the backend form"))
+    (is (zero? (get-in gpu [:stats :fallback])))
+    (is (zero? (get-in jvm [:stats :fallback])))))
 
 (deftest a-fatal-reason-still-escapes
   (testing "a violated invariant is not a missing lowering rule. Recording one as a conversion


### PR DESCRIPTION
## Summary
- share one typed mini-program scheduler between direct singleton and complete-program adapters
- route compound map extents through complete typed host-scalar prefixes on GPU and JVM
- make the closed-operation projection reject host-prefix loss explicitly instead of re-entering legacy SOAC

## Correctness
- simple direct marker shapes and dynamic reduction behavior remain unchanged
- compound direct maps emit executable extent bindings with zero backend fallback
- admitted GPU/JVM paths are tested with legacy SOAC construction disabled

## Tests
- focused direct GPU/JVM backend suite
- 71 tests, 277 assertions, 0 failures/errors

Stacked on #323.