### PR TITLE
Represent integer overflow contracts in KernelBody

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -240,7 +240,11 @@ bindings, direct calls check resident ranges, and graph/link binding retains its
 overlapping-write rejection. Floating narrowing distinguishes IEEE overflow from integral
 wrap/saturate/trap policies. Unchecked integral add/subtract/multiply retain an explicit wrapping
 policy in scalar SSA, and the shared C-family lowering performs those operations in the
-same-width unsigned representation rather than relying on undefined signed overflow. Whole-kernel
+same-width unsigned representation rather than relying on undefined signed overflow. Scalar SSA
+also distinguishes a compiler-certified `:no-overflow` operation from a semantic `:trap`; C-family
+targets emit the former as signed arithmetic and explicitly reject the latter until checked target
+helpers land. Schedule-local scan extent subtraction is the first proved operation. Source-derived
+address algebra is not blanket-certified: it still awaits AxisMap/range proofs. Whole-kernel
 workgroup allocations now have static typed shapes, named
 layouts, explicit 1–16-byte alignment, and one deterministic packed-memory plan; launch shared-byte
 accounting must match that plan exactly. Full-participation acquire/release workgroup barriers are

--- a/design/soac-fusion.md
+++ b/design/soac-fusion.md
@@ -102,8 +102,10 @@ models can refine a choice, while the typed program and numerical oracle constra
    mini-program rather than falling back to legacy source lowering.
 3. Finish explicit integer arithmetic semantics. Unchecked source add/subtract/multiply now retain
    `:wrap` in scalar `KernelBody` SSA and C-family targets execute them through the corresponding
-   unsigned representation; add `trap` and proved-no-overflow contracts before admitting ordinary
-   integral scalar algebra for indexing, RNG, and quantization.
+   unsigned representation. KernelBody now distinguishes `:trap` from compiler-certified
+   `:no-overflow`; C-family targets fail loudly for the former until checked helpers land, and only
+   locally proved schedule arithmetic uses the latter. Add range proofs for source-derived address
+   algebra before admitting ordinary integral operations for indexing, routing, and quantization.
 4. Generalize `AxisMap` and layout facts for multidimensional views, strided gather/scatter, and
    block movement without turning layouts into semantic tensor operators.
 5. Add independent numerical/property tests across aliases, mutation, fan-out, empty extents,

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -904,15 +904,23 @@
         arguments (mapv #(emit-scalar-value % context) (:arguments expression))
         operand-type (scalar-value-type (first (:arguments expression)) (:types context))
         integral? (contains? #{:byte :int :long} operand-type)
-        wrapping? (= {:overflow :wrap} (:options expression))]
+        overflow-policy (get-in expression [:options :overflow])]
     (cond
       ;; C-family signed overflow is undefined. Preserve the verified modulo-2^N contract by
       ;; doing the arithmetic in the same-width unsigned representation and converting the bits
       ;; back to the expression's declared signed storage type.
-      wrapping?
+      (= :wrap overflow-policy)
       (let [unsigned-type (c-dialect/unsigned-type-name *scalar-dialect* operand-type)]
         (str "(" (target-type operand-type) ")((" unsigned-type ")(" (first arguments)
              ") " (:op lowering) " (" unsigned-type ")(" (second arguments) "))"))
+
+      ;; The target-neutral dialect can retain trapping source semantics before every C-family
+      ;; target has a checked-arithmetic helper. Never weaken a requested trap to C signed UB.
+      (= :trap overflow-policy)
+      (throw (ex-info "C-family target has no trapping integer arithmetic lowering"
+                      {:reason :kernel-body-c-intrinsic-overflow
+                       :dialect (:id *scalar-dialect*) :operation op
+                       :operand-type operand-type :overflow overflow-policy}))
 
       ;; The shared C descriptor uses the floating spelling. OpenCL integer min/max are distinct
       ;; overloads, so target spelling must retain the verified operand dtype.

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -77,6 +77,7 @@
 (def ^:private special-scalar-ops #{:cast :select :isnan})
 (def ^:private cast-rounding-policies #{:toward-zero :nearest-even :up :down :exact})
 (def ^:private cast-overflow-policies #{:wrap :saturate :trap :exact :ieee})
+(def ^:private arithmetic-overflow-policies #{:wrap :trap :no-overflow})
 (def ^:private collective-kinds #{:reduce :broadcast})
 (def ^:private workgroup-memory-spaces #{:workgroup})
 (def ^:private barrier-semantics #{:acquire-release})
@@ -1063,17 +1064,22 @@
       (let [arity (:arity intrinsic)
             kind (:kind intrinsic)
             operand-type (same-types! "scalar intrinsic" infos)
-            wrapping? (= {:overflow :wrap} options)]
+            integral? (contains? #{:byte :int :long} operand-type)
+            overflow-op? (contains? #{:+ :- :*} canonical-op)
+            arithmetic-overflow? (and integral? overflow-op?)
+            overflow-policy (:overflow options)]
         (when-not (= arity (count infos))
           (throw (ex-info "scalar intrinsic arity mismatch"
                           {:operation canonical-op :expected arity :actual (count infos)})))
-        (when (and (seq options) (not wrapping?))
-          (throw (ex-info "scalar intrinsic does not accept unspecified lowering options"
-                          {:operation canonical-op :options options})))
-        (when (and wrapping?
-                   (not (and (contains? #{:+ :- :*} canonical-op)
-                             (contains? #{:byte :int :long} operand-type))))
-          (throw (ex-info "wrapping overflow is only defined for integral add, subtract, and multiply"
+        (when (and arithmetic-overflow? (seq options)
+                   (not (and (= #{:overflow} (set (keys options)))
+                             (contains? arithmetic-overflow-policies overflow-policy))))
+          (throw (ex-info "integral arithmetic has an unsupported explicit overflow contract"
+                          {:reason :kernel-body-intrinsic-overflow
+                           :operation canonical-op :operand-type operand-type
+                           :options options})))
+        (when (and (seq options) (not arithmetic-overflow?))
+          (throw (ex-info "overflow contracts are only defined for integral add, subtract, and multiply"
                           {:reason :kernel-body-intrinsic-overflow
                            :operation canonical-op :operand-type operand-type
                            :options options})))

--- a/src/raster/compiler/passes/parallel/segscan_body.clj
+++ b/src/raster/compiler/passes/parallel/segscan_body.clj
@@ -289,7 +289,8 @@
             (body/scalar-expression :min :int
                                     [(body/literal workgroup-size :int)
                                      (body/scalar-expression :- :int
-                                                             ['_n_bound 'scan-base])]))
+                                                             ['_n_bound 'scan-base]
+                                                             {:overflow :no-overflow})]))
            (body/->ScalarLoad
             (body/value 'scan-chunk-last result-type) scratch
             [(body/expression :sub 'scan-chunk-remaining 1)]

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -135,20 +135,23 @@
     :provenance {:dialect :test}
     :attributes {:kind :scalar}}))
 
-(defn- wrapping-arithmetic-kernel-body []
+(defn- integer-arithmetic-kernel-body [overflow]
   (body/make
-   {:id :wrapping-arithmetic-test
+   {:id [:integer-arithmetic-test overflow]
     :parameters [(body/->KernelParameter 'a :scalar :long [] nil nil :left)
                  (body/->KernelParameter 'b :scalar :long [] nil nil :right)
                  (body/->KernelParameter 'out :output :long [1] :global
                                          (layout/row-major [1] :long) :result)]
     :operations [(body/->ScalarCompute
                   (body/value 'sum :long)
-                  (body/scalar-expression :+ :long ['a 'b] {:overflow :wrap}))
+                  (body/scalar-expression :+ :long ['a 'b] {:overflow overflow}))
                  (body/->ScalarStore 'out [0] 'sum nil)]
     :launch (launch/spec {:workgroup-size [1] :group-count [1]})
     :provenance {:dialect :test}
     :attributes {:kind :scalar}}))
+
+(defn- wrapping-arithmetic-kernel-body []
+  (integer-arithmetic-kernel-body :wrap))
 
 (deftest scalar-kernel-body-lowers-without-recovering-a-schedule
   (let [source (opencl/emit-scalar-kernel
@@ -306,6 +309,23 @@
                            (str "(" unsigned-type ")(rstr_a) + (" unsigned-type ")(rstr_b)")))
         (is (not (str/includes? source "rstr_a + rstr_b"))
             "signed target arithmetic must not weaken modulo-2^N semantics")))))
+
+(deftest explicit-signed-overflow-contracts-reach-the-target-boundary
+  (doseq [target [:opencl-portable :cuda :hip]]
+    (testing (name target)
+      (let [source (opencl/emit-scalar-kernel
+                    "proved_arithmetic"
+                    (integer-arithmetic-kernel-body :no-overflow)
+                    {:target-dialect target})]
+        (is (str/includes? source "rstr_a + rstr_b")
+            "a proved in-range operation may use the target's signed instruction"))
+      (try
+        (opencl/emit-scalar-kernel
+         "trapping_arithmetic" (integer-arithmetic-kernel-body :trap)
+         {:target-dialect target})
+        (is false "trapping arithmetic must not silently become signed target overflow")
+        (catch clojure.lang.ExceptionInfo exception
+          (is (= :kernel-body-c-intrinsic-overflow (:reason (ex-data exception)))))))))
 
 (deftest registry-intrinsic-helpers-follow-the-c-family-target
   (doseq [[target qualifier physical-op compiler]

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -296,9 +296,18 @@
              :* :long [(body/literal Long/MAX_VALUE :long)
                        (body/literal 2 :long)]
              {:overflow :wrap}))]))))
+  (testing "trapping and compiler-proved arithmetic are distinct legal contracts"
+    (doseq [policy [:trap :no-overflow]]
+      (is (body/kernel-body?
+           (scalar-body
+            [(body/->ScalarCompute
+              (body/value (symbol (name policy)) :long)
+              (body/scalar-expression
+               :- :long [(body/literal 4 :long) (body/literal 2 :long)]
+               {:overflow policy}))])))))
   (testing "wrapping overflow is not a floating-point policy"
     (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo #"wrapping overflow is only defined"
+         clojure.lang.ExceptionInfo #"overflow contracts are only defined"
          (scalar-body
           [(load-x)
            (body/->ScalarCompute
@@ -308,7 +317,7 @@
                                     {:overflow :wrap}))]))))
   (testing "wrapping overflow cannot annotate unrelated integral intrinsics"
     (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo #"wrapping overflow is only defined"
+         clojure.lang.ExceptionInfo #"overflow contracts are only defined"
          (scalar-body
           [(body/->ScalarCompute
             (body/value 'bad :int)
@@ -848,7 +857,8 @@
                   (into [(body/->ScalarCompute
                           (body/value 'source-base :int)
                           (body/scalar-expression
-                           :+ :int ['group (body/literal 0 :int)]))]
+                           :+ :int ['group (body/literal 0 :int)]
+                           {:overflow :no-overflow}))]
                         (assoc (async-stage-operations) 0
                                (async-stage-copy ['source-base])))
                   options))))


### PR DESCRIPTION
## Summary
- distinguish wrap, semantic trap, and compiler-certified no-overflow on integral KernelBody arithmetic
- retain unsigned C-family lowering for wrapping arithmetic and reject trapping arithmetic until checked target helpers land
- mark the locally proved scan-tail subtraction as no-overflow without blanket-certifying source-derived address algebra

## Correctness
- unsupported contracts fail KernelBody verification
- no-overflow emits signed target arithmetic only where the schedule supplies the certificate
- trap fails at the C-family target boundary instead of degrading to undefined signed overflow

## Tests
- KernelBody verifier and OpenCL/CUDA/HIP scalar emission
- public GQA, stencil, scan and typed route regressions
- 91 tests, 702 assertions, 0 failures/errors

Stacked on #324.