### PR TITLE
Require total integer arithmetic semantics

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -238,15 +238,17 @@ sources. Uniform memory facts require an explicit body-level stable-read contrac
 KernelBody-to-ABI seam projects it to a no-write-alias precondition, artifacts reject equal compiler
 bindings, direct calls check resident ranges, and graph/link binding retains its stronger
 overlapping-write rejection. Floating narrowing distinguishes IEEE overflow from integral
-wrap/saturate/trap policies. Unchecked integral add/subtract/multiply retain an explicit wrapping
-policy in scalar SSA, and the shared C-family lowering performs those operations in the
-same-width unsigned representation rather than relying on undefined signed overflow. Scalar SSA
-also distinguishes a compiler-certified `:no-overflow` operation from a semantic `:trap`; C-family
+wrap/saturate/trap policies. Ordinary typed source integral add/subtract/multiply retain their
+checked semantics as `:trap`, while unchecked variants retain an explicit `:wrap` policy. The shared
+C-family lowering performs wrapping operations in the same-width unsigned representation rather
+than relying on undefined signed overflow. Scalar SSA also distinguishes a compiler-certified
+`:no-overflow` operation from a semantic `:trap`; C-family
 targets emit the former as signed arithmetic. CUDA and HIP lower the latter through checked
 same-width unsigned predicates followed by PTX/LLVM target traps; OpenCL targets explicitly decline
 it because OpenCL C has no standard trap primitive. Schedule-local scan extent subtraction
 is the first proved operation. Source-derived address algebra is not blanket-certified: it still
-awaits AxisMap/range proofs. Whole-kernel
+awaits AxisMap/range proofs, and schedule-produced integral expressions must be migrated before the
+verifier can reject every remaining omitted policy. Whole-kernel
 workgroup allocations now have static typed shapes, named
 layouts, explicit 1–16-byte alignment, and one deterministic packed-memory plan; launch shared-byte
 accounting must match that plan exactly. Full-participation acquire/release workgroup barriers are

--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -247,8 +247,9 @@ targets emit the former as signed arithmetic. CUDA and HIP lower the latter thro
 same-width unsigned predicates followed by PTX/LLVM target traps; OpenCL targets explicitly decline
 it because OpenCL C has no standard trap primitive. Schedule-local scan extent subtraction
 is the first proved operation. Source-derived address algebra is not blanket-certified: it still
-awaits AxisMap/range proofs, and schedule-produced integral expressions must be migrated before the
-verifier can reject every remaining omitted policy. Whole-kernel
+awaits AxisMap/range proofs. Scheduled attention and stencil bodies retain their own validated
+capacity/range proofs, and the KernelBody verifier rejects every omitted integral arithmetic
+policy. Whole-kernel
 workgroup allocations now have static typed shapes, named
 layouts, explicit 1–16-byte alignment, and one deterministic packed-memory plan; launch shared-byte
 accounting must match that plan exactly. Full-participation acquire/release workgroup barriers are

--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -242,9 +242,11 @@ wrap/saturate/trap policies. Unchecked integral add/subtract/multiply retain an 
 policy in scalar SSA, and the shared C-family lowering performs those operations in the
 same-width unsigned representation rather than relying on undefined signed overflow. Scalar SSA
 also distinguishes a compiler-certified `:no-overflow` operation from a semantic `:trap`; C-family
-targets emit the former as signed arithmetic and explicitly reject the latter until checked target
-helpers land. Schedule-local scan extent subtraction is the first proved operation. Source-derived
-address algebra is not blanket-certified: it still awaits AxisMap/range proofs. Whole-kernel
+targets emit the former as signed arithmetic. CUDA and HIP lower the latter through checked
+same-width unsigned predicates followed by PTX/LLVM target traps; OpenCL targets explicitly decline
+it because OpenCL C has no standard trap primitive. Schedule-local scan extent subtraction
+is the first proved operation. Source-derived address algebra is not blanket-certified: it still
+awaits AxisMap/range proofs. Whole-kernel
 workgroup allocations now have static typed shapes, named
 layouts, explicit 1–16-byte alignment, and one deterministic packed-memory plan; launch shared-byte
 accounting must match that plan exactly. Full-participation acquire/release workgroup barriers are

--- a/design/soac-fusion.md
+++ b/design/soac-fusion.md
@@ -103,9 +103,10 @@ models can refine a choice, while the typed program and numerical oracle constra
 3. Finish explicit integer arithmetic semantics. Unchecked source add/subtract/multiply now retain
    `:wrap` in scalar `KernelBody` SSA and C-family targets execute them through the corresponding
    unsigned representation. KernelBody now distinguishes `:trap` from compiler-certified
-   `:no-overflow`; C-family targets fail loudly for the former until checked helpers land, and only
-   locally proved schedule arithmetic uses the latter. Add range proofs for source-derived address
-   algebra before admitting ordinary integral operations for indexing, routing, and quantization.
+   `:no-overflow`; CUDA/HIP use checked target-trap helpers for the former, OpenCL targets decline
+   it because the language has no standard trap primitive, and only locally proved schedule
+   arithmetic uses the latter. Add range proofs for source-derived address algebra before admitting
+   ordinary integral operations for indexing, routing, and quantization.
 4. Generalize `AxisMap` and layout facts for multidimensional views, strided gather/scatter, and
    block movement without turning layouts into semantic tensor operators.
 5. Add independent numerical/property tests across aliases, mutation, fan-out, empty extents,

--- a/design/soac-fusion.md
+++ b/design/soac-fusion.md
@@ -106,8 +106,9 @@ models can refine a choice, while the typed program and numerical oracle constra
    KernelBody distinguishes `:trap` from compiler-certified
    `:no-overflow`; CUDA/HIP use checked target-trap helpers for the former, OpenCL targets decline
    it because the language has no standard trap primitive, and only locally proved schedule
-   arithmetic uses the latter. Add range proofs for source-derived address algebra, migrate the
-   remaining schedule constructors, then make an omitted integral overflow policy invalid IR.
+   arithmetic uses the latter, and omitted integral overflow semantics are invalid KernelBody IR.
+   Continue moving source-derived address algebra into explicit AxisMap/range proofs rather than
+   certifying it from emitter syntax.
 4. Generalize `AxisMap` and layout facts for multidimensional views, strided gather/scatter, and
    block movement without turning layouts into semantic tensor operators.
 5. Add independent numerical/property tests across aliases, mutation, fan-out, empty extents,

--- a/design/soac-fusion.md
+++ b/design/soac-fusion.md
@@ -100,13 +100,14 @@ models can refine a choice, while the typed program and numerical oracle constra
    beta-reduce away type contracts. Direct compound map extents now retain their typed host-scalar
    prefix through GPU and JVM entry points; a singleton SegOp projection explicitly refuses such a
    mini-program rather than falling back to legacy source lowering.
-3. Finish explicit integer arithmetic semantics. Unchecked source add/subtract/multiply now retain
-   `:wrap` in scalar `KernelBody` SSA and C-family targets execute them through the corresponding
-   unsigned representation. KernelBody now distinguishes `:trap` from compiler-certified
+3. Finish explicit integer arithmetic semantics. Ordinary typed source add/subtract/multiply now
+   retain `:trap`, while unchecked variants retain `:wrap` in scalar `KernelBody` SSA; C-family
+   targets execute wrapping operations through the corresponding unsigned representation.
+   KernelBody distinguishes `:trap` from compiler-certified
    `:no-overflow`; CUDA/HIP use checked target-trap helpers for the former, OpenCL targets decline
    it because the language has no standard trap primitive, and only locally proved schedule
-   arithmetic uses the latter. Add range proofs for source-derived address algebra before admitting
-   ordinary integral operations for indexing, routing, and quantization.
+   arithmetic uses the latter. Add range proofs for source-derived address algebra, migrate the
+   remaining schedule constructors, then make an omitted integral overflow policy invalid IR.
 4. Generalize `AxisMap` and layout facts for multidimensional views, strided gather/scatter, and
    block movement without turning layouts into semantic tensor operators.
 5. Add independent numerical/property tests across aliases, mutation, fan-out, empty extents,

--- a/src/raster/compiler/backend/gpu/kernel_body_c_dialect.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_c_dialect.clj
@@ -162,6 +162,65 @@
     source
     (str/replace source #"(?m)^inline " "__device__ __forceinline__ ")))
 
+(defn trapping-arithmetic-name
+  "Name a checked signed-integer operation only when the target can terminate the invocation.
+
+  OpenCL C has no standard trap operation.  A portable OpenCL dialect must therefore decline this
+  contract instead of quietly depending on one vendor compiler's builtin or turning the operation
+  into undefined signed arithmetic."
+  [dialect operation type]
+  (when (opencl? dialect)
+    (throw (ex-info "OpenCL C has no portable trapping-arithmetic primitive"
+                    {:reason :kernel-body-c-trap-unsupported
+                     :dialect (:id dialect) :operation operation :type (dtype/canon type)})))
+  (str "rstr_trap_"
+       ({:+ "add" :- "sub" :* "mul"} operation)
+       "_"
+       ({:byte "i8" :int "i32" :long "i64"} (dtype/canon type))))
+
+(defn trapping-arithmetic-helper-source
+  "Emit one checked signed operation without first evaluating an overflowing signed expression.
+
+  The predicates use same-width unsigned arithmetic.  Only after the predicate proves the result
+  representable does the helper evaluate the ordinary signed operation.  CUDA terminates with the
+  PTX trap instruction; HIP's Clang frontend lowers `__builtin_trap` to LLVM's target trap."
+  [dialect operation type]
+  (let [type (dtype/canon type)
+        signed-type (type-name dialect type)
+        unsigned-type (unsigned-type-name dialect type)
+        helper-name (trapping-arithmetic-name dialect operation type)
+        sign-bit (str "((" unsigned-type ")1 << " (dec (* 8 (dtype/bytes-of type))) ")")
+        trap-source (case (:id dialect)
+                      :cuda "asm volatile(\"trap;\");"
+                      :hip "__builtin_trap();")
+        arithmetic ({:+ "+" :- "-" :* "*"} operation)]
+    (when-not arithmetic
+      (throw (ex-info "trapping arithmetic helper has no operation"
+                      {:reason :kernel-body-c-trap-operation
+                       :dialect (:id dialect) :operation operation :type type})))
+    (str
+     "inline " signed-type " " helper-name "(" signed-type " a, " signed-type " b) {\n"
+     "  " unsigned-type " ua = (" unsigned-type ")a;\n"
+     "  " unsigned-type " ub = (" unsigned-type ")b;\n"
+     "  " unsigned-type " sign = " sign-bit ";\n"
+     (case operation
+       :+ (str "  " unsigned-type " ur = ua + ub;\n"
+               "  if (((~(ua ^ ub) & (ua ^ ur)) & sign) != 0) {\n")
+       :- (str "  " unsigned-type " ur = ua - ub;\n"
+               "  if ((((ua ^ ub) & (ua ^ ur)) & sign) != 0) {\n")
+       :* (str "  " unsigned-type " ma = (a < 0) ? ((" unsigned-type ")0 - ua) : ua;\n"
+               "  " unsigned-type " mb = (b < 0) ? ((" unsigned-type ")0 - ub) : ub;\n"
+               "  " unsigned-type " limit = ((a < 0) != (b < 0)) ? sign : (sign - 1);\n"
+               "  if ((mb != 0) && (ma > (limit / mb))) {\n"))
+     "    " trap-source "\n"
+     ;; Keep the overflowing signed expression unreachable in the source language too.  CUDA's
+     ;; inline PTX is not declared noreturn to the C++ frontend, so falling through here would
+     ;; reintroduce the very signed UB this helper exists to prevent.
+     "    return (" signed-type ")0;\n"
+     "  }\n"
+     "  return a " arithmetic " b;\n"
+     "}\n")))
+
 (defn workgroup-arena-declaration
   "Spell one statically sized, explicitly aligned workgroup-memory arena."
   [dialect name bytes alignment]

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -721,6 +721,23 @@
                (scalar-body-operations (:operations operation)))))
    operations))
 
+(defn- scalar-expressions
+  [value]
+  (when (record-kind? "ScalarExpr" value)
+    (cons value (mapcat scalar-expressions (:arguments value)))))
+
+(defn- trapping-arithmetic-requirements
+  [operations]
+  (->> operations
+       (filter #(record-kind? "ScalarCompute" %))
+       (mapcat #(scalar-expressions (:expression %)))
+       (keep (fn [expression]
+               (when (= :trap (get-in expression [:options :overflow]))
+                 [(intrinsics/canonical (:op expression))
+                  (dtype/canon (:result-type expression))])))
+       distinct
+       (sort-by pr-str)))
+
 (defn- scalar-defined-ids
   [operations]
   (mapcat
@@ -914,13 +931,11 @@
         (str "(" (target-type operand-type) ")((" unsigned-type ")(" (first arguments)
              ") " (:op lowering) " (" unsigned-type ")(" (second arguments) "))"))
 
-      ;; The target-neutral dialect can retain trapping source semantics before every C-family
-      ;; target has a checked-arithmetic helper. Never weaken a requested trap to C signed UB.
+      ;; A checked helper first proves representability in unsigned arithmetic.  It only evaluates
+      ;; the signed operation on the safe branch, so the check itself cannot introduce C signed UB.
       (= :trap overflow-policy)
-      (throw (ex-info "C-family target has no trapping integer arithmetic lowering"
-                      {:reason :kernel-body-c-intrinsic-overflow
-                       :dialect (:id *scalar-dialect*) :operation op
-                       :operand-type operand-type :overflow overflow-policy}))
+      (str (c-dialect/trapping-arithmetic-name *scalar-dialect* op operand-type)
+           "(" (str/join ", " arguments) ")")
 
       ;; The shared C descriptor uses the floating spelling. OpenCL integer min/max are distinct
       ;; overloads, so target spelling must retain the verified operand dtype.
@@ -1694,7 +1709,12 @@
         helper-source
         (c-dialect/helper-source
          *scalar-dialect*
-         (str (when (and (c-dialect/opencl? *scalar-dialect*)
+         (str (apply str
+                     (map (fn [[operation type]]
+                            (c-dialect/trapping-arithmetic-helper-source
+                             *scalar-dialect* operation type))
+                          (trapping-arithmetic-requirements operations)))
+              (when (and (c-dialect/opencl? *scalar-dialect*)
                          (str/includes? operation-source "atomic_add_float("))
                 ce/opencl-atomic-add-float-helper)
               (ce/intrinsic-helper-sources operation-source

--- a/src/raster/compiler/ir/kernel_body.clj
+++ b/src/raster/compiler/ir/kernel_body.clj
@@ -1071,10 +1071,10 @@
         (when-not (= arity (count infos))
           (throw (ex-info "scalar intrinsic arity mismatch"
                           {:operation canonical-op :expected arity :actual (count infos)})))
-        (when (and arithmetic-overflow? (seq options)
+        (when (and arithmetic-overflow?
                    (not (and (= #{:overflow} (set (keys options)))
                              (contains? arithmetic-overflow-policies overflow-policy))))
-          (throw (ex-info "integral arithmetic has an unsupported explicit overflow contract"
+          (throw (ex-info "integral arithmetic requires exactly one overflow contract"
                           {:reason :kernel-body-intrinsic-overflow
                            :operation canonical-op :operand-type operand-type
                            :options options})))

--- a/src/raster/compiler/passes/parallel/contraction_body.clj
+++ b/src/raster/compiler/passes/parallel/contraction_body.clj
@@ -57,6 +57,10 @@
                       "portable contraction body requires at least one free axis"
                       {:segred-id (:id segred)}))
         dtype (dtype/canon (:dtype segred))
+        _ (when (dtype/integral? dtype)
+            (decline! :integral-overflow-algebra
+                      "portable integer contraction requires explicit product and accumulation overflow contracts"
+                      {:dtype dtype :segred-id (:id segred)}))
         result-transform (:epilogue contract-facts)
         result-region (scalar-region-lower/make-region result-transform)
         transform-operands (vec (:operands result-transform))

--- a/src/raster/compiler/passes/parallel/register_tiled_body.clj
+++ b/src/raster/compiler/passes/parallel/register_tiled_body.clj
@@ -147,6 +147,10 @@
             (decline! :storage-dtype
                       "register-tiled schedule requires a known storage dtype"
                       {:dtype dtype}))
+        _ (when (dtype/integral? dtype)
+            (decline! :integral-overflow-contract
+                      "register-tiled integer contraction requires an explicit accumulation overflow algebra"
+                      {:dtype dtype :operation-id operation-id}))
         tile (select-tile tile descriptor dtype)
         {:keys [combine neutral]} (facts/scalar-reduction-view contract-facts)
         {:keys [block-m block-n block-k thread-m thread-n]} tile

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -299,7 +299,12 @@
                                               operand-type expression)
                                             arguments)
                               result-type (if comparison? :predicate operand-type)
-                              overflow (intrinsics/source-overflow-policy semantic-operation)
+                              integral-arithmetic?
+                              (and (contains? #{:byte :int :long} operand-type)
+                                   (contains? #{:+ :- :*} operator))
+                              overflow (when integral-arithmetic?
+                                         (or (intrinsics/source-overflow-policy semantic-operation)
+                                             :trap))
                               options (cond-> {} overflow (assoc :overflow overflow))
                               _ (when-not (every? #(= operand-type (:type %)) lowered)
                                   (decline! :operand-dtype

--- a/src/raster/compiler/passes/parallel/scalar_region_lower.clj
+++ b/src/raster/compiler/passes/parallel/scalar_region_lower.clj
@@ -166,7 +166,8 @@
                   (cast (lower-expression (second expression)) target))
 
                 (seq? expression)
-                (let [operator (intrinsics/canonical (descriptor/semantic-op expression))
+                (let [semantic-operation (descriptor/semantic-op expression)
+                      operator (intrinsics/canonical semantic-operation)
                       intrinsic (intrinsics/descriptor operator)
                       arguments (vec (descriptor/call-args expression))]
                   (when-not (and intrinsic
@@ -178,10 +179,16 @@
                               {:expression expression :operator operator
                                :result-dtype result-dtype}))
                   (let [inputs (mapv (comp :value lower-expression) arguments)
+                        overflow (when (and (contains? #{:byte :int :long} result-dtype)
+                                            (contains? #{:+ :- :*} operator))
+                                   (or (intrinsics/source-overflow-policy semantic-operation)
+                                       :trap))
                         result (fresh "result-transform-value")]
                     (emit! (body/->ScalarCompute
                             (body/value result result-dtype)
-                            (body/scalar-expression operator result-dtype inputs))
+                            (body/scalar-expression
+                             operator result-dtype inputs
+                             (cond-> {} overflow (assoc :overflow overflow))))
                            result result-dtype)))
 
                 :else

--- a/src/raster/compiler/passes/parallel/segmented_weighted_reduction_body.clj
+++ b/src/raster/compiler/passes/parallel/segmented_weighted_reduction_body.clj
@@ -16,7 +16,15 @@
   (body/literal value type))
 
 (defn- expr [op type & arguments]
-  (body/scalar-expression op type arguments))
+  ;; This pass owns a verified schedule: integral address/cursor arithmetic is derived from
+  ;; int-width route metadata, statically bounded capacities, or loop bounds over those values.
+  ;; Retain that proof explicitly instead of making the C-family emitter infer it from syntax.
+  (body/scalar-expression
+   op type arguments
+   (if (and (contains? #{:byte :int :long} type)
+            (contains? #{:+ :- :*} op))
+     {:overflow :no-overflow}
+     {})))
 
 (defn- select-expr [condition if-true if-false type]
   (body/scalar-expression :select type [condition if-true if-false]))

--- a/src/raster/compiler/passes/parallel/segscan_body.clj
+++ b/src/raster/compiler/passes/parallel/segscan_body.clj
@@ -117,6 +117,11 @@
                                                    :parameter)
                           scalar-ids)
                      [(body/->KernelParameter '_n_bound :scalar :int [] nil nil :bound)]))]
+    (when (dtype/integral? result-type)
+      (decline! :integral-overflow-algebra
+                "portable integer scan requires an explicit combine overflow contract"
+                {:phase phase :mode scan-mode :algebra scan-algebra
+                 :result-type result-type}))
     (when-not (and (contains? #{:single :intra-block :block-scan :carry-in} phase)
                    (contains? #{:inclusive :exclusive} scan-mode)
                    (scan/associative-scan? scan-algebra)

--- a/src/raster/compiler/passes/parallel/segstencil_body.clj
+++ b/src/raster/compiler/passes/parallel/segstencil_body.clj
@@ -141,7 +141,8 @@
          (body/value right-limit :long)
          (body/scalar-expression
           :- :long [(body/cast-expression '_n_bound :long :exact :exact)
-                    (body/literal radius :long)]))
+                    (body/literal radius :long)]
+          {:overflow :no-overflow}))
         (body/->ScalarCompute
          (body/value left-interior :predicate)
          (body/scalar-expression :le :predicate

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -315,6 +315,10 @@
                           (body-emit/emit-scalar-kernel
                            "workgroup_memory" (body-fixtures/workgroup-memory-body 32)
                            {:target-dialect dialect}))
+           (write-source! directory suffix "trapping-arithmetic"
+                          (body-emit/emit-scalar-kernel
+                           "trapping_arithmetic" (body-fixtures/trapping-arithmetic-body)
+                           {:target-dialect dialect}))
            (write-source! directory suffix "swizzled-workgroup-memory"
                           (body-emit/emit-scalar-kernel
                            "swizzled_workgroup_memory"

--- a/test/raster/compiler/backend/gpu/kernel_body_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_fixtures.clj
@@ -34,6 +34,44 @@
     :provenance {:dialect :compile-gate}
     :attributes {:kind :workgroup-memory}}))
 
+(defn trapping-arithmetic-body
+  "Every checked signed arithmetic helper in one hardware-free target-compiler fixture."
+  []
+  (let [types [[:byte "i8"] [:int "i32"] [:long "i64"]]
+        operations [[:+ "add"] [:- "sub"] [:* "mul"]]
+        symbol-of (fn [& parts] (symbol (apply str parts)))]
+    (body/make
+     {:id :c-family-trapping-arithmetic-gate
+      :parameters
+      (vec
+       (mapcat
+        (fn [[type suffix]]
+          [(body/->KernelParameter (symbol-of "a_" suffix) :scalar type [] nil nil :left)
+           (body/->KernelParameter (symbol-of "b_" suffix) :scalar type [] nil nil :right)
+           (body/->KernelParameter
+            (symbol-of "out_" suffix) :output type [(count operations)] :global
+            (layout/row-major [(count operations)] type) :result)])
+        types))
+      :operations
+      (vec
+       (mapcat
+        (fn [[type suffix]]
+          (mapcat
+           (fn [index [operation operation-name]]
+             (let [result (symbol-of operation-name "_" suffix)]
+               [(body/->ScalarCompute
+                 (body/value result type)
+                 (body/scalar-expression
+                  operation type [(symbol-of "a_" suffix) (symbol-of "b_" suffix)]
+                  {:overflow :trap}))
+                (body/->ScalarStore (symbol-of "out_" suffix) [index] result nil)]))
+           (range) operations))
+        types))
+      :schedule {}
+      :launch (launch/spec {:workgroup-size [1] :group-count [1]})
+      :provenance {:dialect :compile-gate}
+      :attributes {:kind :trapping-arithmetic}})))
+
 (defn swizzled-workgroup-memory-body
   "A 2-D XOR-layout fixture. Each lane accesses one logical column element; source compilation
    proves that OpenCL/CUDA/HIP share the verified address transform without choosing a schedule."

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -313,6 +313,21 @@
         (is (not (str/includes? source "rstr_a + rstr_b"))
             "signed target arithmetic must not weaken modulo-2^N semantics")))))
 
+(deftest checked-source-arithmetic-retains-trapping-semantics
+  (let [decline! (fn [rule message data]
+                   (throw (ex-info message (assoc data :rule rule))))
+        lowerer (scalar-expression/make-lowerer
+                 {:array-types {} :scalar-types {'a :long 'b :long} :arrays #{}
+                  :index-scope #{} :lower-index (fn [value _] value)
+                  :decline! decline!})
+        checked ((:lower lowerer) '(+ a b) :long {'a :long 'b :long})
+        unchecked ((:lower lowerer) '(unchecked-add a b) :long {'a :long 'b :long})]
+    (is (= {:overflow :trap}
+           (get-in checked [:operations 0 :expression :options])))
+    (is (= {:overflow :wrap}
+           (get-in unchecked [:operations 0 :expression :options])))
+    (is (= :long (:type checked)))))
+
 (deftest explicit-signed-overflow-contracts-reach-the-target-boundary
   (doseq [target [:opencl-portable :cuda :hip]]
     (testing (name target)

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -135,20 +135,23 @@
     :provenance {:dialect :test}
     :attributes {:kind :scalar}}))
 
-(defn- integer-arithmetic-kernel-body [overflow]
-  (body/make
-   {:id [:integer-arithmetic-test overflow]
-    :parameters [(body/->KernelParameter 'a :scalar :long [] nil nil :left)
-                 (body/->KernelParameter 'b :scalar :long [] nil nil :right)
-                 (body/->KernelParameter 'out :output :long [1] :global
-                                         (layout/row-major [1] :long) :result)]
-    :operations [(body/->ScalarCompute
-                  (body/value 'sum :long)
-                  (body/scalar-expression :+ :long ['a 'b] {:overflow overflow}))
-                 (body/->ScalarStore 'out [0] 'sum nil)]
-    :launch (launch/spec {:workgroup-size [1] :group-count [1]})
-    :provenance {:dialect :test}
-    :attributes {:kind :scalar}}))
+(defn- integer-arithmetic-kernel-body
+  ([overflow]
+   (integer-arithmetic-kernel-body overflow :+ :long))
+  ([overflow operation type]
+   (body/make
+    {:id [:integer-arithmetic-test overflow operation type]
+     :parameters [(body/->KernelParameter 'a :scalar type [] nil nil :left)
+                  (body/->KernelParameter 'b :scalar type [] nil nil :right)
+                  (body/->KernelParameter 'out :output type [1] :global
+                                          (layout/row-major [1] type) :result)]
+     :operations [(body/->ScalarCompute
+                   (body/value 'result type)
+                   (body/scalar-expression operation type ['a 'b] {:overflow overflow}))
+                  (body/->ScalarStore 'out [0] 'result nil)]
+     :launch (launch/spec {:workgroup-size [1] :group-count [1]})
+     :provenance {:dialect :test}
+     :attributes {:kind :scalar}})))
 
 (defn- wrapping-arithmetic-kernel-body []
   (integer-arithmetic-kernel-body :wrap))
@@ -318,14 +321,43 @@
                     (integer-arithmetic-kernel-body :no-overflow)
                     {:target-dialect target})]
         (is (str/includes? source "rstr_a + rstr_b")
-            "a proved in-range operation may use the target's signed instruction"))
+            "a proved in-range operation may use the target's signed instruction"))))
+  (testing "OpenCL C declines a contract for which the language has no standard trap primitive"
+    (doseq [target [:opencl-portable :opencl-intel]]
       (try
         (opencl/emit-scalar-kernel
          "trapping_arithmetic" (integer-arithmetic-kernel-body :trap)
          {:target-dialect target})
         (is false "trapping arithmetic must not silently become signed target overflow")
         (catch clojure.lang.ExceptionInfo exception
-          (is (= :kernel-body-c-intrinsic-overflow (:reason (ex-data exception)))))))))
+          (is (= :kernel-body-c-trap-unsupported (:reason (ex-data exception)))
+              (name target))))))
+  (doseq [[target compiler trap-spelling]
+          [[:cuda "nvcc" "asm volatile(\"trap;\")"]
+           [:hip "hipcc" "__builtin_trap()"]]]
+    (testing (str (name target) " checked helpers")
+      (doseq [[operation operation-name guard]
+              [[:+ "add" "~(ua ^ ub) & (ua ^ ur)"]
+               [:- "sub" "(ua ^ ub) & (ua ^ ur)"]
+               [:* "mul" "ma > (limit / mb)"]]
+              type [:byte :int :long]]
+        (let [source (opencl/emit-scalar-kernel
+                      "trapping_arithmetic"
+                      (integer-arithmetic-kernel-body :trap operation type)
+                      {:target-dialect target})
+              helper-name (str "rstr_trap_" operation-name "_"
+                               ({:byte "i8" :int "i32" :long "i64"} type))]
+          (is (str/includes? source (str helper-name "(rstr_a, rstr_b)")))
+          (is (str/includes? source guard))
+          (is (str/includes? source trap-spelling))
+          (is (= 2 (count (re-seq (re-pattern (str helper-name "\\(")) source)))
+              "one checked definition accompanies one typed call")))
+      (when (command-available? compiler)
+        (let [source (opencl/emit-scalar-kernel
+                      "trapping_arithmetic" (fixtures/trapping-arithmetic-body)
+                      {:target-dialect target})
+              {:keys [exit err]} (compile-c-family-source target source)]
+          (is (zero? exit) err))))))
 
 (deftest registry-intrinsic-helpers-follow-the-c-family-target
   (doseq [[target qualifier physical-op compiler]

--- a/test/raster/compiler/ir/kernel_body_test.clj
+++ b/test/raster/compiler/ir/kernel_body_test.clj
@@ -296,6 +296,14 @@
              :* :long [(body/literal Long/MAX_VALUE :long)
                        (body/literal 2 :long)]
              {:overflow :wrap}))]))))
+  (testing "integral arithmetic cannot omit its overflow semantics"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo #"requires exactly one overflow contract"
+         (scalar-body
+          [(body/->ScalarCompute
+            (body/value 'ambiguous :long)
+            (body/scalar-expression
+             :+ :long [(body/literal 1 :long) (body/literal 2 :long)]))]))))
   (testing "trapping and compiler-proved arithmetic are distinct legal contracts"
     (doseq [policy [:trap :no-overflow]]
       (is (body/kernel-body?


### PR DESCRIPTION
Summary:
- Reject every integral KernelBody add/subtract/multiply that omits its overflow contract.
- Preserve checked overflow policy in scalar result regions.
- Certify widened stencil and validated routed-attention schedule arithmetic explicitly.
- Decline generic integer scan and contraction schedules until their algebra carries an overflow policy.

Focused verification:
- Active C-family, attention, indexed-attention, TypedSOAC, and KernelBody routes: 122 tests, 1083 assertions.
- Contraction, register-tiled, scan IR, and SegOp emitter suites: 40 tests, 230 assertions.

Stacked on #327.