### PR TITLE
Preserve checked source integer arithmetic

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -238,15 +238,17 @@ sources. Uniform memory facts require an explicit body-level stable-read contrac
 KernelBody-to-ABI seam projects it to a no-write-alias precondition, artifacts reject equal compiler
 bindings, direct calls check resident ranges, and graph/link binding retains its stronger
 overlapping-write rejection. Floating narrowing distinguishes IEEE overflow from integral
-wrap/saturate/trap policies. Unchecked integral add/subtract/multiply retain an explicit wrapping
-policy in scalar SSA, and the shared C-family lowering performs those operations in the
-same-width unsigned representation rather than relying on undefined signed overflow. Scalar SSA
-also distinguishes a compiler-certified `:no-overflow` operation from a semantic `:trap`; C-family
-targets emit the former as signed arithmetic. CUDA and HIP lower the latter through checked
-same-width unsigned predicates followed by PTX/LLVM target traps; OpenCL targets explicitly decline
-it because OpenCL C has no standard trap primitive. Schedule-local scan extent subtraction
+wrap/saturate/trap policies. Ordinary typed source integral add/subtract/multiply retain their
+checked semantics as `:trap`, while unchecked variants retain an explicit `:wrap` policy. The shared
+C-family lowering performs wrapping operations in the same-width unsigned representation rather
+than relying on undefined signed overflow. Scalar SSA also distinguishes a compiler-certified
+`:no-overflow` operation from a semantic `:trap`; C-family
+targets emit the former as signed arithmetic. CUDA, HIP, and Intel oneAPI OpenCL lower the latter
+through checked same-width unsigned predicates followed by a target trap. Portable OpenCL
+explicitly declines it because OpenCL C has no standard trap primitive. Schedule-local scan extent subtraction
 is the first proved operation. Source-derived address algebra is not blanket-certified: it still
-awaits AxisMap/range proofs. Whole-kernel
+awaits AxisMap/range proofs, and schedule-produced integral expressions must be migrated before the
+verifier can reject every remaining omitted policy. Whole-kernel
 workgroup allocations now have static typed shapes, named
 layouts, explicit 1–16-byte alignment, and one deterministic packed-memory plan; launch shared-byte
 accounting must match that plan exactly. Full-participation acquire/release workgroup barriers are

--- a/design/soac-fusion.md
+++ b/design/soac-fusion.md
@@ -100,13 +100,14 @@ models can refine a choice, while the typed program and numerical oracle constra
    beta-reduce away type contracts. Direct compound map extents now retain their typed host-scalar
    prefix through GPU and JVM entry points; a singleton SegOp projection explicitly refuses such a
    mini-program rather than falling back to legacy source lowering.
-3. Finish explicit integer arithmetic semantics. Unchecked source add/subtract/multiply now retain
-   `:wrap` in scalar `KernelBody` SSA and C-family targets execute them through the corresponding
-   unsigned representation. KernelBody now distinguishes `:trap` from compiler-certified
-   `:no-overflow`; CUDA/HIP use checked target-trap helpers for the former, OpenCL targets decline
-   it because the language has no standard trap primitive, and only locally proved schedule
-   arithmetic uses the latter. Add range proofs for source-derived address algebra before admitting
-   ordinary integral operations for indexing, routing, and quantization.
+3. Finish explicit integer arithmetic semantics. Ordinary typed source add/subtract/multiply now
+   retain `:trap`, while unchecked variants retain `:wrap` in scalar `KernelBody` SSA; C-family
+   targets execute wrapping operations through the corresponding unsigned representation.
+   KernelBody distinguishes `:trap` from compiler-certified
+   `:no-overflow`; CUDA, HIP, and Intel oneAPI OpenCL use checked target-trap helpers for the former,
+   portable OpenCL declines it because the language has no standard trap primitive, and only locally proved schedule
+   arithmetic uses the latter. Add range proofs for source-derived address algebra, migrate the
+   remaining schedule constructors, then make an omitted integral overflow policy invalid IR.
 4. Generalize `AxisMap` and layout facts for multidimensional views, strided gather/scatter, and
    block movement without turning layouts into semantic tensor operators.
 5. Add independent numerical/property tests across aliases, mutation, fan-out, empty extents,

--- a/src/raster/compiler/backend/gpu/kernel_body_c_dialect.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_c_dialect.clj
@@ -165,11 +165,11 @@
 (defn trapping-arithmetic-name
   "Name a checked signed-integer operation only when the target can terminate the invocation.
 
-  OpenCL C has no standard trap operation.  A portable OpenCL dialect must therefore decline this
-  contract instead of quietly depending on one vendor compiler's builtin or turning the operation
-  into undefined signed arithmetic."
+  OpenCL C has no standard trap operation.  The portable dialect therefore declines this contract
+  instead of quietly depending on a vendor builtin. Intel's oneAPI OpenCL compiler accepts
+  `__builtin_trap`; that target-specific dialect can preserve the same contract as HIP."
   [dialect operation type]
-  (when (opencl? dialect)
+  (when (= :opencl-portable (:id dialect))
     (throw (ex-info "OpenCL C has no portable trapping-arithmetic primitive"
                     {:reason :kernel-body-c-trap-unsupported
                      :dialect (:id dialect) :operation operation :type (dtype/canon type)})))
@@ -182,8 +182,9 @@
   "Emit one checked signed operation without first evaluating an overflowing signed expression.
 
   The predicates use same-width unsigned arithmetic.  Only after the predicate proves the result
-  representable does the helper evaluate the ordinary signed operation.  CUDA terminates with the
-  PTX trap instruction; HIP's Clang frontend lowers `__builtin_trap` to LLVM's target trap."
+  representable does the helper evaluate the ordinary signed operation. CUDA terminates with the
+  PTX trap instruction; HIP and Intel oneAPI OpenCL lower `__builtin_trap` through their Clang/LLVM
+  frontends."
   [dialect operation type]
   (let [type (dtype/canon type)
         signed-type (type-name dialect type)
@@ -192,7 +193,7 @@
         sign-bit (str "((" unsigned-type ")1 << " (dec (* 8 (dtype/bytes-of type))) ")")
         trap-source (case (:id dialect)
                       :cuda "asm volatile(\"trap;\");"
-                      :hip "__builtin_trap();")
+                      (:hip :opencl-intel) "__builtin_trap();")
         arithmetic ({:+ "+" :- "-" :* "*"} operation)]
     (when-not arithmetic
       (throw (ex-info "trapping arithmetic helper has no operation"

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -299,7 +299,12 @@
                                               operand-type expression)
                                             arguments)
                               result-type (if comparison? :predicate operand-type)
-                              overflow (intrinsics/source-overflow-policy semantic-operation)
+                              integral-arithmetic?
+                              (and (contains? #{:byte :int :long} operand-type)
+                                   (contains? #{:+ :- :*} operator))
+                              overflow (when integral-arithmetic?
+                                         (or (intrinsics/source-overflow-policy semantic-operation)
+                                             :trap))
                               options (cond-> {} overflow (assoc :overflow overflow))
                               _ (when-not (every? #(= operand-type (:type %)) lowered)
                                   (decline! :operand-dtype

--- a/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_opencl_test.clj
@@ -232,11 +232,13 @@
 
 (defn- compile-c-family-source
   [target source]
-  (let [suffix (case target :cuda ".cu" :hip ".hip")
+  (let [suffix (case target :opencl-intel ".cl" :cuda ".cu" :hip ".hip")
         source-file (java.io.File/createTempFile "raster-kernel-body-" suffix)
         output-file (str (.getAbsolutePath source-file) ".ptx")]
     (spit source-file source)
     (case target
+      :opencl-intel (shell/sh "clang" "-x" "cl" "-cl-std=CL2.0"
+                              "-fsyntax-only" (.getAbsolutePath source-file))
       :cuda (shell/sh "nvcc" "-ptx" "-arch=sm_80" "-o" output-file
                       (.getAbsolutePath source-file))
       :hip (shell/sh "hipcc" "--offload-arch=gfx1100" "--genco"
@@ -313,6 +315,21 @@
         (is (not (str/includes? source "rstr_a + rstr_b"))
             "signed target arithmetic must not weaken modulo-2^N semantics")))))
 
+(deftest checked-source-arithmetic-retains-trapping-semantics
+  (let [decline! (fn [rule message data]
+                   (throw (ex-info message (assoc data :rule rule))))
+        lowerer (scalar-expression/make-lowerer
+                 {:array-types {} :scalar-types {'a :long 'b :long} :arrays #{}
+                  :index-scope #{} :lower-index (fn [value _] value)
+                  :decline! decline!})
+        checked ((:lower lowerer) '(+ a b) :long {'a :long 'b :long})
+        unchecked ((:lower lowerer) '(unchecked-add a b) :long {'a :long 'b :long})]
+    (is (= {:overflow :trap}
+           (get-in checked [:operations 0 :expression :options])))
+    (is (= {:overflow :wrap}
+           (get-in unchecked [:operations 0 :expression :options])))
+    (is (= :long (:type checked)))))
+
 (deftest explicit-signed-overflow-contracts-reach-the-target-boundary
   (doseq [target [:opencl-portable :cuda :hip]]
     (testing (name target)
@@ -322,18 +339,17 @@
                     {:target-dialect target})]
         (is (str/includes? source "rstr_a + rstr_b")
             "a proved in-range operation may use the target's signed instruction"))))
-  (testing "OpenCL C declines a contract for which the language has no standard trap primitive"
-    (doseq [target [:opencl-portable :opencl-intel]]
-      (try
-        (opencl/emit-scalar-kernel
-         "trapping_arithmetic" (integer-arithmetic-kernel-body :trap)
-         {:target-dialect target})
-        (is false "trapping arithmetic must not silently become signed target overflow")
-        (catch clojure.lang.ExceptionInfo exception
-          (is (= :kernel-body-c-trap-unsupported (:reason (ex-data exception)))
-              (name target))))))
+  (testing "portable OpenCL declines a contract for which the language has no standard trap"
+    (try
+      (opencl/emit-scalar-kernel
+       "trapping_arithmetic" (integer-arithmetic-kernel-body :trap)
+       {:target-dialect :opencl-portable})
+      (is false "trapping arithmetic must not silently become signed target overflow")
+      (catch clojure.lang.ExceptionInfo exception
+        (is (= :kernel-body-c-trap-unsupported (:reason (ex-data exception)))))))
   (doseq [[target compiler trap-spelling]
-          [[:cuda "nvcc" "asm volatile(\"trap;\")"]
+          [[:opencl-intel "clang" "__builtin_trap()"]
+           [:cuda "nvcc" "asm volatile(\"trap;\")"]
            [:hip "hipcc" "__builtin_trap()"]]]
     (testing (str (name target) " checked helpers")
       (doseq [[operation operation-name guard]


### PR DESCRIPTION
Summary:
- Attach the semantic trap policy to ordinary typed source integer add/subtract/multiply.
- Keep unchecked source arithmetic explicitly wrapping.
- Preserve checked arithmetic on Intel oneAPI OpenCL, CUDA, and HIP with target trap helpers; portable OpenCL declines.
- Leave compiler-certified no-overflow schedule contracts distinct from source semantics.

Verification:
- KernelBody target suite: 13 tests, 227 assertions.
- Quant, RoPE, and typed scatter focused suite: 21 tests, 72 assertions after the target change.
- All nine helper/type combinations compiled through the installed Intel oneAPI OpenCL 3.0 runtime.
- CUDA/HIP compiler gates remain part of CI.