### PR TITLE
North star simulation track: objective and irregular primitives, periodic/accumulating halos, GPU regression fixes

### DIFF
--- a/design/compiler-north-star.md
+++ b/design/compiler-north-star.md
@@ -1,6 +1,9 @@
 # Raster compiler north star
 
-Status: architectural direction, reconciled with the implementation on 2026-09-01.
+Status: architectural direction, reconciled with the implementation on 2026-09-01. Objective,
+fidelity/time schedule axes, irregular primitives, composition, and the inference track were added
+on 2026-09-03 after the simulator survey (twenty rubric surveys of production simulators,
+training and inference systems; internal working note).
 
 Raster should become a compiler in which a typed Clojure program, its parallel
 algorithm, its schedule, its device placement, and its executable artifact are
@@ -25,6 +28,50 @@ Futhark, Triton, JAX, or MLIR. Raster keeps its typed multiple-dispatch frontend
 functional Clojure programming model, explicit AD rules, portable hardware
 model, and vendor-JIT backends. The reference systems supply specific missing
 ideas at specific layers.
+
+## 0. Objective: what the compiler is for
+
+Raster is the foundation for compiler-driven algebraic simulation and for inference through
+simulators. The quantity to optimize is not kernel time. It is **grounding quality per unit of
+compute**: posterior or decision quality obtained from a simulation-backed model for a given
+budget of time, memory, energy and communication. Simulation-based inference that treats the
+simulator as a black box is the worst case the system must always support. The intended case is
+that inference uses the simulator's internals, through the same certified transformations the
+compiler already owns: automatic differentiation, local linearization, coarse-grained or
+marginalized variants, multi-level estimators, and emulators trained on internal state.
+
+This changes what a unit of value is. An AI agent can write a bespoke SPH or shallow-water code
+in days. What it cannot cheaply reproduce is a verified program transformation with a certificate,
+a shared cost and measurement history across workloads, and composition of plans with a database
+and provenance. Production simulators confirm the alternative: hand-instantiated kernel families,
+several hand-written transports of one halo, two hand schedules of one physics, whole-loop taping
+without checkpoint schedules. The unit of value in Raster is therefore **a verified transformation
+of a program that keeps its semantic identity**, not a kernel. The acceptance test for the whole
+project is the agent baseline in §9: if a bespoke reimplementation plus its certification is
+cheaper than expressing the workload in Raster, the direction is wrong.
+
+Three consequences are structural:
+
+1. **The cost vector gains approximation error and information value.** Beyond latency,
+   throughput, peak memory, bytes, tuning budget, energy and floating-point error, a plan carries
+   the approximation error introduced by every fidelity, coarse-graining, marginalization or
+   surrogate decision, under an explicit error model, and where a decision or inference task is
+   known, the expected information gain or decision utility that the compute buys.
+2. **Fidelity is a schedule axis.** Level of refinement, coarse-graining map, marginalized
+   sub-model, multi-level estimator, surrogate substitution and precision are schedule decisions
+   with legality rules (conservation, symmetry, positivity, coupling contracts) and an error
+   model, exactly as tile size is a schedule decision with a resource rule. Coarse-grained models
+   are proposals with an error bound, never silent substitutes.
+3. **Every transformation carries an error model.** The minimal contract is not that every solver
+   is a probabilistic-numerics solver; it is that every solver and every transformation exposes
+   an error model the certificate can check and the cost vector can consume: an a-posteriori
+   estimate, a multi-level difference, a perturbation ensemble, or a posterior variance.
+
+Probabilistic numerics is the lens that unifies these. Discretization error is epistemic
+uncertainty; a multi-fidelity hierarchy is a model over fidelities; coarse-graining is
+marginalization with an error bound; a solver is an inference procedure whose posterior variance is
+the numerical-error entry of the cost vector; optimal grounding per compute is experimental design
+under a budget. The lens is a framing for the contracts above, not a requirement on users.
 
 ## 1. What is already strong
 
@@ -717,7 +764,16 @@ IR. It is more than a bag of kernel kwargs. It can express:
 - staging space, copies, pipeline depth, and barriers;
 - reduction decomposition and split-K;
 - buffer donation, residency, and graph capture;
-- device/mesh placement and resharding policy.
+- device/mesh placement and resharding policy;
+- time integration scheme, operator splitting, subcycling ratios, task ordering and
+  iteration budgets of data-dependent loops;
+- fidelity level, coarse-graining map, marginalized sub-models, multi-level estimator
+  selection, surrogate substitution, and checkpoint/recompute schedule across time steps.
+
+Time and fidelity are scheduled axes (§3.8). Their legality rules are conservation, symmetry,
+coupling and error-model contracts rather than resource limits, but they enter the same
+legality → feasibility → analytic rank → measured rank sequence, and a failed legality check never
+changes the semantic program.
 
 Halide supplies the algorithm/schedule separation and structural search model.
 MLIR's Transform dialect supplies a useful safety model: typed handles,
@@ -886,10 +942,85 @@ Device-to-device binding is the normal path. Host transfer is an explicit graph
 edge with a reason and byte count. The compiler's memory plan owns temporary
 liveness, reuse, alignment, and peak-memory accounting.
 
+A running cluster is driven from a REPL. Changing a fidelity level, a decomposition, a coupling
+period or a tile must be a plan hot-swap on live artifacts, not a whole-program rebuild, so
+compilation must be incremental at the granularity of plan nodes, with unchanged kernels and
+artifacts reused by identity. A forkable execution context, as in Spindel, is the mechanism for
+trying a plan change on a branch and committing or discarding it with its measurements.
+
 JAX pytrees are the model for separating user structure from flat leaves, but
 Raster trees should retain stable keyed paths and type/shape information. JAX
 donation and sharding contracts are also useful references; Raster's existing
 ownership checks should remain fail-loud.
+
+### 3.8 Time, composition and rate scheduling
+
+Algorithm/schedule separation applies to the time axis. The semantic layer states a dynamical
+system: right-hand sides, conservation laws, symmetries, constraints, coupling ports, and the
+observables that ground it. The schedule layer states how it is integrated: explicit, IMEX or
+implicit tableau; operator splitting; leapfrog or multistep history; subcycled nesting with
+per-level time ratios; task ordering and retry; iteration budgets and reduced exit conditions of
+data-dependent loops; checkpoint and recompute placement for adjoints. Production codes show
+these as three schedules of one semantics: a per-block task list with dependency masks, a
+recursive nesting scheduler with per-level Δt, and a tableau-driven stepper with an implicit
+column sub-solve. Raster does not fix an integrator. It fixes that the integrator is schedule data
+with legality rules and an error model.
+
+Composition of models with different rates and different grids is a scheduling problem, not a
+scene graph. The pattern is shared by coupled Earth-system components, whole-cell models that
+partition one state among ODE, stochastic and linear-programming sub-models each step, and
+molecular dynamics with a mesh solver on its own decomposition. The plan therefore needs:
+
+- a rate scheduler over systems with declared read/write sets and periods, in the sense of an
+  entity-component schedule, expressed as SOACs over entity-set shards with explicit effects;
+- a coupler node: several meshes with owner maps, remapping weights as a content-addressed sparse
+  contraction with a pinned reduction order, conservative fractions, accumulation between coupling
+  intervals, and coupling periods;
+- a partitioned-shared-state primitive: request, allocate, run, merge, with an exact-sum
+  conservation contract for contended quantities;
+- data-dependent loops with a reduced exit condition and deterministic ordered reductions, so
+  iterative solvers lower and their iteration counts are priced.
+
+Open dynamical systems composed along ports are the specification of what composition must
+preserve. Raster uses that algebra to state legality and certificates; it does not require users
+to write categorical syntax, and it does not adopt a scene hierarchy or an entity DSL.
+
+### 3.9 Irregular values and communication
+
+The simulator survey found that dense stencils and contractions are two of ten computational
+patterns in production simulation; the others are unstructured-neighbour stencils, particles and
+populations, event-driven sparse updates, spectral transposes, multi-rate composition, coupled
+grids, adaptive refinement and differentiable rollouts. Five primitives cover them without
+prescribing any simulator:
+
+1. **A star-forest communication node.** Root and leaf index sets, a combiner monoid with a
+   deterministic-order attribute, split issue and wait phases, and periodicity as a per-pair
+   coordinate shift. It subsumes N-D halos with per-axis periodicity and widths, corner policy
+   and staggered centering; accumulating reverse halos (direct stiffness summation, deposition,
+   force return); redistribution and pencil transposes; all-to-all-v; population migration; and
+   delayed delivery, which is a halo along the time axis.
+2. **Irregular values.** Ragged arrays and CSR with offsets as first-class values; connectivity
+   tables with source dimension, local dimension, maximum arity and skip value; shards as
+   entity-id sets with an ownership function or table. The SOACs over them are gather-contract
+   (a gather fused into a weighted reduction), scatter-reduce with a declared conflict algebra,
+   segmented irregular reduce over runtime segment sets, and compaction. A pass that tiles a
+   sparse neighbour structure into small dense contractions with masks, as cluster-pair
+   molecular-dynamics kernels do, is the highest-value single lowering.
+3. **Access facts on edges.** Each dependency carries subset, volume and write-conflict facts
+   that propagate through scopes, so halo widths are derived from operator access, fusion
+   legality is subset intersection, transfer bytes are exact, and in-place reuse is proved rather
+   than inferred from spelling.
+4. **A schedule for time** (§3.8), whose simulator prices live memory under a recompute policy,
+   pipeline bubbles, subcycle ratios and iteration counts, and ingests measured per-task costs.
+5. **Contracts as certificates.** Adjoint prolongation/restriction pairs or flux registers for
+   refinement, ordered-reduction attributes that survive lowering, invariance of results under
+   re-layout, index rotation and restart, tolerance-envelope oracles from perturbation ensembles,
+   non-field state in the durable manifest, and stateless counter-based random number generation
+   so checkpoints carry no generator state.
+
+Population and particle values are irregular values with a pure `position → region → owner`
+function, so migration is derived, plus a spatial index as a plan node with static-shape overflow.
+Region trees are IR values.
 
 ## 4. Quantized computation
 
@@ -973,7 +1104,10 @@ the source of truth.
 ## 6. Distributed and resource-aware programming model
 
 Distribution belongs in the abstract value and scheduled graph, not in a
-separate orchestration wrapper. The program model needs:
+separate orchestration wrapper. Shards are entity-id sets with an ownership function or table,
+of which rectangular one-axis partitions are the simplest case; shard boundaries are plan state
+that a re-plan may move on measured cost, as dynamic load balancing and regridding require.
+Halos carry a combiner and are instances of the star-forest node of §3.9. The program model needs:
 
 - a device mesh and topology descriptor;
 - sharding annotations on logical dimensions;
@@ -982,14 +1116,23 @@ separate orchestration wrapper. The program model needs:
   point-to-point operations;
 - compute/communication dependency events;
 - memory capacity and bandwidth constraints per device/link;
-- heterogeneous placement and legal dtype/layout capabilities.
+- heterogeneous placement and legal dtype/layout capabilities;
+- mesh-axis to tensor-axis bindings so several shardings coexist on one value;
+- pipeline stage and microbatch coordinates on steps;
+- a recompute and offload policy with live-range memory accounting;
+- redistribution and all-to-all-v as first-class steps.
 
 Compilation minimizes a cost vector rather than a single kernel time:
 
 ```text
 latency, throughput, peak memory, transferred bytes,
-compile/tune budget, energy when measurable, and numerical error
+compile/tune budget, energy when measurable, floating-point error,
+approximation error under an explicit error model, and information value
 ```
+
+The analytic simulator is a seed. It must price live memory under the recompute policy, pipeline
+bubbles, subcycle ratios and iteration counts, and it must ingest measured per-task costs keyed
+by plan node and device signature so that re-planning on measurement is an ordinary transform.
 
 The compiler hierarchy extends upward without making the single-device `LinkPlan` a cluster object:
 
@@ -1075,7 +1218,17 @@ institutional archive. Datahike publishes the semantic state only after required
 receipts; direct fabrics still move hot halos, gradients and activations. See
 [`durable-numerical-state.md`](durable-numerical-state.md).
 
-## 7. Reflection, structural self-modification, and learning
+## 7. Reflection, inference through simulator internals, and learning
+
+This section is a track, not an appendix. Inference is the driver of §0, and inference that uses
+simulator internals is exactly reflection: the program is data, so automatic differentiation,
+linearization, coarse-graining, marginalization, multi-level estimators and emulators of internal
+state are certified transformations that an inference procedure may request. The track's
+demonstrator is fixed: one simulation-backed inference task solved by black-box sequential Monte
+Carlo or approximate Bayesian computation on the simulator, and again by procedures that use its
+internals through Raster transformations, with calibration checked by simulation-based
+calibration and the cost vector reported for both. Learned proposals, including amortized
+proposals from pretrained models, compete in shadow mode under the same calibration gate.
 
 Raster can make reflection unusually powerful because Clojure data is a natural
 representation for programs and schedules. The safe version has four rules:
@@ -1203,6 +1356,7 @@ The integrated roadmap has six cooperating tracks rather than one backend-only s
 | Measurement and selection | One tuner over coupled graph/kernel axes with numerical and resource gates | Hardware-aware schedule selection and selective autotuning |
 | Precise target lowering | Format-neutral target modules, differential PTX, later AMD-specific lowering | Exact async/matrix/cache control where portable source is insufficient |
 | Distributed/workload planning | Typed mesh/topology/sharding values, then certified `DistributedPlan` | End-to-end node, cluster and data-center optimization |
+| Simulation and inference vertical | One end-to-end workload with a fidelity transform, restart/branch and a parameter inference, early and on toy kernels | The objective of §0 becomes measurable before the backend is complete |
 
 The table below is the durable architectural dependency ledger, not a claim that every increment is
 unstarted. ABI, artifact composition and much of the kernel-IR foundation have landed; their stated
@@ -1218,6 +1372,26 @@ completion gates remain useful for finding legacy paths that have not joined the
 | 6. Closed tuning loop | Connect real device timing to schedule candidates and graph choices; make cache/provenance complete; wire or explicitly classify every schedule axis. | A cold compile tunes once, a warm compile reproduces the winner, numerical validation precedes timing, and the artifact explains why it won. |
 | 7. Workload-driven coverage | Add stream/hist/gather/scatter, masking/block views, atomics, layouts/staging, and quant formats as demanded by model/scientific kernels. | Coverage is measured through production lowering on a published workload corpus, with differential and device compile/run gates. |
 | 8. Distributed IR | Add mesh/sharding abstract values, collective nodes, communication cost, and placement scheduling. | A transformer training step runs data-parallel on multiple devices without hidden host copies and reports compute, communication, and memory costs. |
+
+The tracks interleave. The simulation and inference vertical does not wait for increments 7 and 8;
+it lands on toy kernels as soon as increment 1 is closed, so that fidelity axes, error models and
+calibration gates are exercised while the backend matures. Its ladder, each rung one
+production-lowered kernel, one certified plan and one oracle, with the reference kernel named in the
+survey:
+
+| Rung | Demonstrator | Primitives | Oracle |
+|---|---|---|---|
+| D1 | 2-D shallow water, 2-D decomposition, periodic and wall halos, coarse-graining transform, restart and branch, one parameter inference | star forest, access facts, contracts | mass, lake-at-rest, convergence, bitwise invariance under re-layout/rotate/restart, calibration |
+| D2 | Icosahedral divergence or spectral-element gradient with direct stiffness summation | irregular values, combiner halo | reference values, rank-invariant ordered sums |
+| D3 | Smoothed-particle pair density or Lennard-Jones over cell lists with ghost exchange | populations, star forest | brute-force oracle with per-field tolerance table |
+| D4 | Spiking-network spike delivery with delays: ragged send table, ring-buffer scatter, all-to-all-v | irregular values, time halo | exact-integration neuron reference |
+| D5 | Pencil transpose and FFT inside a distributed pressure solve with a reduced exit | redistribution, data-dependent loop | reference solver |
+| D6 | One transformer layer under tensor and data parallelism with sharded optimizer state, certified collective sequence, simulated with recompute memory and a pipeline bubble | time schedule, access facts | collective trace and measured two-device run |
+| D7 | Whole-cell-style partition/merge of ODE, stochastic and linear-programming sub-models under a versioned outer loop | rate scheduler, coupler, contracts | exact-sum conservation, queryable plan lineage |
+| D8 | Key/value continuation state: prefix index over the content chain and a cross-node transfer plan | star forest | hit rate and transfer bytes against serving systems |
+
+D2 to D4 are the test of the claim that one substrate covers simulation, because they are the
+three patterns that are not dense. D6 is the honest ceiling for training on measurable hardware.
 
 The first two increments are correctness infrastructure and should precede
 additional backend breadth. Increment 5 is the first major model-execution
@@ -1239,7 +1413,16 @@ Every tier compares semantics first and performance second:
 5. one transformer layer forward, VJP, optimizer update, and mixed precision;
 6. `pretrained-rstr` prefill and decode with KV residency and logits parity;
 7. `finetune-rstr` batched SFT/LoRA/QLoRA with a wholly resident train step;
-8. full model execution and training, then multi-device versions.
+8. full model execution and training, then multi-device versions;
+9. transformation legality: a fidelity switch, coarse-graining or marginalization preserves the
+   declared conservation and coupling contracts and stays inside its error model;
+10. calibration: simulation-based calibration of inference across fidelities, with the cost
+    vector reported per fidelity;
+11. invariance: identical results under re-layout, index rotation, restart and reproducible mode,
+    as a test matrix rather than a single case;
+12. the agent baseline: time an agent writing and certifying a bespoke version of the same
+    workload; if that is cheaper than the Raster expression including its certificate, record it
+    as a failure of direction, not of the agent.
 
 For each tier record numerical error, kernel count, allocations, peak memory,
 host/device and device/device bytes, compile time, tuning time, steady-state
@@ -1262,6 +1445,14 @@ transfer boundaries, and numerical modes.
 - Do not add distributed side protocols that are invisible to the value and
   effect model.
 - Do not let self-modifying or learned components bypass the trusted verifier.
+- Do not adopt a scene graph, entity hierarchy or integrator DSL; integrators, rates and couplings
+  are schedule data over the semantic dynamical system.
+- Do not require users to write categorical syntax; the algebra of open systems is the
+  specification the certificate checks.
+- Do not add a fidelity, coarse-graining, marginalization or surrogate transform without its
+  error model, legality rule, calibration oracle and cost-vector entry.
+- Do not require every solver to be a probabilistic-numerics solver; require every solver to
+  expose an error model.
 
 ## 11. Reference mapping and study snapshot
 
@@ -1276,6 +1467,15 @@ transfer boundaries, and numerical modes.
 | Mojo/MAX | one language spanning host and device, parametric low-level GPU libraries, explicit layouts/pipelines, heterogeneous cross-compilation | coupling Raster's semantics to a closed compiler stack or requiring imperative kernels as the main abstraction |
 | TVM Relax/Disco | graph-level tensor distribution, SPMD worker sessions, explicit collective runtime boundary | making a controller/runtime protocol the distributed semantic IR |
 | Legion/DaCe | correctness-independent mapping, topology-aware task/data placement, explicit data movement and transformations | adopting a second user programming model before Raster's value and schedule IRs are complete |
+| PETSc star forest, DaCe memlets | one communication primitive under halos, gather-scatter and collectives; subset/volume facts on edges with propagation | a solver-library object model |
+| Oceananigans, Devito, GROMACS | halo width and pairlist lifetime derived from operator access and an error tolerance; decomposition priced by an analytic communication model | hand-packed tags, per-layout kernel families |
+| AMReX, Trixi.jl | flux registers or adjoint prolong/restrict as the conservation contract of refinement | a fixed refinement data structure |
+| ICON, MOM6, E3SM | order-insensitive sums, invariance test matrices, perturbation-ensemble tolerance oracles, two schedules of one physics | Fortran-era global state |
+| Athena++, SWIFT | per-block task lists with dependencies and retry, measured task costs driving re-decomposition, stateless random numbers | bulk-synchronous stepping |
+| NEST, FLAME GPU 2, whole-cell models | ragged delivery with delays, populations with birth/death and spatial messaging, partition/merge of contended state across sub-models | a fixed neuron, agent or cell model |
+| Alpa, DeepSpeed | plans and pipeline schedules as replayable data with a cost model and memory constraint | mutable process-group globals |
+| vLLM, Mooncake | prefix-hash identity for continuation state, topology-aware transfer | scheduler state that cannot be replayed |
+| Probabilistic numerics, AlgebraicDynamics | error as uncertainty, solvers as inference, open systems composed along ports as the composition specification | a mandatory probabilistic solver or a categorical user syntax |
 
 Local source revisions studied for this direction:
 
@@ -1295,3 +1495,31 @@ The durable decision is not any one revision's class hierarchy. It is the
 separation of semantic program, transform/schedule, verified kernel, target
 lowering, and composable artifact—with stable identities and measurements
 connecting them.
+
+## 12. Iteration procedure
+
+The document is the specification; the survey corpus and its reference kernels are the
+regression reference; the demonstrator ladder in §8 is the schedule. Each rung goes through one
+cycle:
+
+1. **Design note** (internal working note, not this document): the rung, the reference kernel by
+   file and line in the surveyed system, the primitives of §3.8–§3.9 it touches, the oracle,
+   the error model, and the agent baseline to be timed.
+2. **REPL spike** on toy sizes, single device, using the existing typed route; no new pass until
+   the spike shows which primitive is actually missing.
+3. **Land the primitive** with its certificate, a production-path test through the ordinary
+   compile entry, `explain-pipeline` visibility, and no metadata-only transport.
+4. **Run the gates**: the rung's oracle, the invariance matrix of §9, the calibration check where
+   inference is involved, and the agent baseline.
+5. **Record** measurements and the certified plan with provenance, so re-planning on measurement
+   and comparison across rungs are queries rather than notebooks.
+6. **Write back** to this document: every architectural claim carries one of the labels
+   *designed*, *landed* or *measured*, and a claim may not be promoted without the gate that
+   promotes it.
+7. **Drift audit** before the next rung: an independent rubric-style reading of the landed code
+   against §10, in the manner of the alignment notes, so that landed-but-unwired pieces are
+   caught while they are small.
+
+One rung is one pull request per coherent phase, with checkpoint commits on the branch. A rung
+that fails its agent baseline twice is a direction finding, not an implementation finding, and
+returns to §0.

--- a/src/raster/compiler/core/macroexpand.clj
+++ b/src/raster/compiler/core/macroexpand.clj
@@ -17,6 +17,7 @@
                  (list? form)   (outer (apply list (map inner form)))
                  (seq? form)    (outer (doall (map inner form)))
                  (vector? form) (outer (mapv inner form))
+                 (record? form) (outer (reduce-kv (fn [r k v] (assoc r k (inner v))) form form))
                  (map? form)    (outer (into (empty form)
                                              (map (fn [[k v]] [(inner k) (inner v)]) form)))
                  (set? form)    (outer (into (empty form) (map inner form)))
@@ -111,6 +112,7 @@
 
     (seq? form)   (with-meta (apply list (map resugar-interop form)) (meta form))
     (vector? form) (with-meta (mapv resugar-interop form) (meta form))
+    (record? form) (reduce-kv (fn [r k v] (assoc r k (resugar-interop v))) form form)
     (map? form)   (with-meta (into (empty form)
                                    (map (fn [[k v]] [(resugar-interop k) (resugar-interop v)]) form))
                     (meta form))

--- a/src/raster/compiler/core/util.clj
+++ b/src/raster/compiler/core/util.clj
@@ -187,6 +187,9 @@
          (remake-from expr (map #(subst-syms smap % leaf-fn) expr)))
 
        (vector? expr) (mapv #(subst-syms smap % leaf-fn) expr)
+       ;; IR records (KernelBody IndexExpr, SegOps, ...) are maps whose type must survive:
+       ;; substitute inside their fields, never `empty` them.
+       (record? expr) (reduce-kv (fn [r k v] (assoc r k (subst-syms smap v leaf-fn))) expr expr)
        (map? expr) (into (empty expr) (map (fn [[k v]] [(subst-syms smap k leaf-fn) (subst-syms smap v leaf-fn)]) expr))
        (set? expr) (into (empty expr) (map #(subst-syms smap % leaf-fn) expr))
        :else expr))))
@@ -245,6 +248,7 @@
                 (mapv #(alpha-convert env %) outer))
        (remake-from form (map #(alpha-convert env %) form)))
      (vector? form) (mapv #(alpha-convert env %) form)
+     (record? form) (reduce-kv (fn [r k v] (assoc r k (alpha-convert env v))) form form)
      (map? form) (into (empty form) (map (fn [[k v]] [(alpha-convert env k) (alpha-convert env v)]) form))
      (set? form) (into (empty form) (map #(alpha-convert env %) form))
      :else form)))
@@ -289,6 +293,7 @@
                (mapv #(uniquify* env bound %) outer))
       (remake-from form (map #(uniquify* env bound %) form)))
     (vector? form) (mapv #(uniquify* env bound %) form)
+    (record? form) (reduce-kv (fn [r k v] (assoc r k (uniquify* env bound v))) form form)
     (map? form) (into (empty form) (map (fn [[k v]] [(uniquify* env bound k) (uniquify* env bound v)]) form))
     (set? form) (into (empty form) (map #(uniquify* env bound %) form))
     :else form))
@@ -378,6 +383,7 @@
                (and (seq? form) (= 'quote (first form))) form
                (seq? form) (remake-from form (map go form))
                (vector? form) (with-meta (mapv go form) (meta form))
+               (record? form) (reduce-kv (fn [r k v] (assoc r k (go v))) form form)
                (map? form) (with-meta
                              (into (empty form) (map (fn [[k v]] [(go k) (go v)])) form)
                              (meta form))

--- a/src/raster/compiler/ir/amr_plan.clj
+++ b/src/raster/compiler/ir/amr_plan.clj
@@ -11,7 +11,8 @@
   (:require [raster.compiler.core.dtype :as dtype]
             [raster.compiler.ir.abstract-value :as abstract-value]
             [raster.compiler.ir.distributed-plan :as distributed]
-            [raster.compiler.ir.numerical-state :as state]))
+            [raster.compiler.ir.numerical-state :as state]
+            [raster.compiler.ir.validate :refer [fail! exact-keys! unique-by!]]))
 
 (def schema-version 1)
 (def operation-kinds #{:prolongation :restriction})
@@ -51,25 +52,6 @@
 (defn certified-plan?
   [value]
   (record-type? "raster.compiler.ir.amr_plan.CertifiedAMRWorkload" value))
-
-(defn- fail!
-  [message reason data]
-  (throw (ex-info message (assoc data :reason reason))))
-
-(defn- exact-keys!
-  [label reason candidate allowed]
-  (let [unexpected (vec (remove allowed (keys candidate)))]
-    (when (seq unexpected)
-      (fail! (str label " contains fields outside its versioned schema")
-             reason {:unexpected unexpected :allowed allowed})))
-  candidate)
-
-(defn- unique-by!
-  [label reason key-fn values]
-  (let [ids (mapv key-fn values)]
-    (when-not (= (count ids) (count (distinct ids)))
-      (fail! (str label " must have unique identities") reason {:ids ids})))
-  values)
 
 (defn- rectangle!
   [label reason {:keys [offsets shape] :as region} rank]

--- a/src/raster/compiler/ir/distributed_plan.clj
+++ b/src/raster/compiler/ir/distributed_plan.clj
@@ -20,7 +20,8 @@
 (def shard-ownerships #{:owned :replica})
 (def step-kinds #{:compute :transfer})
 (def collective-kinds #{:all-reduce :all-gather :reduce-scatter :broadcast})
-(def halo-boundaries #{:nonperiodic})
+(def halo-boundaries #{:nonperiodic :periodic})
+(def halo-destination-modes #{:copy :combine})
 
 (defrecord DeviceMesh [axes devices])
 (defrecord DeviceResource [id memory-capacity-bytes descriptor attributes])
@@ -32,7 +33,7 @@
 (defrecord CollectiveOperation [id kind group value reduction root attributes])
 (defrecord CollectiveSchedule [algorithm rounds numerical-mode attributes])
 (defrecord ScheduledCollective [operation schedule dependencies steps completions])
-(defrecord HaloExchange [id value axis width boundary attributes])
+(defrecord HaloExchange [id value axis width boundary combine attributes])
 (defrecord ScheduledHalo [exchange routes dependencies steps completions])
 (defrecord DistributedStep
            [id kind device source target route value bytes duration-ns dependencies
@@ -298,7 +299,13 @@
     (->ScheduledCollective operation schedule dependencies steps completions)))
 
 (defn halo-exchange
-  [{:keys [id value axis width boundary attributes]
+  "Declare a semantic neighbor exchange along one partitioned axis.
+
+   `boundary` is `:nonperiodic` (only adjacent shards exchange) or `:periodic` (the last and first
+   shards also exchange across the wrap edge). `combine` is nil for a copy into the target's ghost
+   region, or a certified associative reduction when the source face accumulates into the target's
+   owned face, as direct stiffness summation, deposition and force return require."
+  [{:keys [id value axis width boundary combine attributes]
     :or {boundary :nonperiodic attributes {}}}]
   (when-not (and id value (integer? axis) (not (neg? axis))
                  (pos-int? width) (contains? halo-boundaries boundary) (map? attributes))
@@ -306,9 +313,13 @@
            :distributed-halo-exchange
            {:id id :value value :axis axis :width width
             :boundary boundary :attributes attributes}))
-  (->HaloExchange id value axis width boundary attributes))
+  (when (and combine (not (scan/associative-scan? combine)))
+    (fail! "accumulating halo exchange requires a certified associative reduction"
+           :distributed-halo-combine {:id id :combine combine}))
+  (->HaloExchange id value axis width boundary combine attributes))
 
-(defn- halo-region
+(defn- halo-face
+  "Global rectangle of a shard's owned face of `width` cells on `side` of `axis`."
   [candidate axis width side]
   (let [offsets (:offsets candidate)
         shape (:shape candidate)
@@ -318,15 +329,56 @@
     {:offsets (assoc offsets axis start)
      :shape (assoc shape axis width)}))
 
-(defn schedule-halo
-  "Derive a nonperiodic neighbor exchange from certified axis-partitioned shards.
+(defn- halo-destination
+  "Where a received face lands on the target.
 
-   `routes` maps `[source-device target-device]` to an ordered directed-link path. All neighbor
-   transfers share one round after `dependencies`; exact source rectangles and byte counts are
-   retained on each transfer step."
+   Copy mode writes the ghost strip beyond the target's owned extent, expressed in the target's
+   local frame so a lower ghost has a negative offset. Combine mode accumulates into the target's
+   owned face, expressed in the global frame."
+  [target axis width side mode]
+  (case mode
+    :copy (let [rank (count (:shape target))
+                offsets (vec (repeat rank 0))
+                start (case side :lower (- width) :upper (nth (:shape target) axis))]
+            {:frame :target-local
+             :offsets (assoc offsets axis start)
+             :shape (assoc (:shape target) axis width)})
+    :combine (assoc (halo-face target axis width side) :frame :global)))
+
+(defn- pack-halo-rounds
+  "Greedily assign legs to the earliest round in which none of their directed links is claimed.
+
+   Legs of one round overlap; a later round waits for the previous round's completions. The
+   packing is deterministic in leg order, so a re-derived schedule reproduces the same rounds."
+  [legs]
+  (reduce
+   (fn [rounds leg]
+     (let [links (set (get-in leg [:leg :route]))
+           index (or (some (fn [[i round]]
+                             (when (empty? (set/intersection links (:links round))) i))
+                           (map-indexed vector rounds))
+                     (count rounds))
+           round (get rounds index {:links #{} :legs []})]
+       (assoc rounds index
+              (-> round
+                  (update :links set/union links)
+                  (update :legs conj leg)))))
+   []
+   legs))
+
+(defn schedule-halo
+  "Derive a neighbor exchange from certified axis-partitioned shards.
+
+   `routes` maps `[source-device target-device]` to an ordered directed-link path. Adjacent shard
+   pairs exchange their faces in both directions; a periodic boundary adds the wrap edge between
+   the last and first shards. Legs are packed into rounds so that no round claims one directed
+   link twice; a later round depends on the completions of the previous one. Exact source
+   rectangles, destination regions, byte counts and the round index are retained on each transfer
+   step."
   [exchange abstract shards routes dependencies]
   (let [exchange (if (halo-exchange? exchange) exchange (halo-exchange exchange))
-        {:keys [id value axis width]} exchange
+        {:keys [id value axis width boundary combine]} exchange
+        mode (if combine :combine :copy)
         sharding (:sharding abstract)
         global-shape (:shape abstract)
         candidates (if (and (vector? global-shape) (< axis (count global-shape)))
@@ -338,6 +390,10 @@
       (fail! "halo exchange requires a matching axis-partitioned AbstractValue"
              :distributed-halo-sharding
              {:halo id :axis axis :sharding sharding :shards candidates}))
+    (when (and combine (not= (:dtype combine) (:dtype abstract)))
+      (fail! "halo combine dtype differs from its AbstractValue"
+             :distributed-halo-combine-dtype
+             {:halo id :combine (:dtype combine) :value (:dtype abstract)}))
     (when-not (map? routes)
       (fail! "halo schedule routes must be keyed by device pairs"
              :distributed-halo-routes {:halo id :routes routes}))
@@ -351,10 +407,14 @@
                                               (fn [i extent] (when (not= i axis) extent))
                                               global-shape)))
           bytes (* face-elements (dtype/bytes-of (:dtype abstract)))
+          adjacent (map-indexed (fn [i pair] [i false pair]) (partition 2 1 candidates))
+          edges (cond-> (vec adjacent)
+                  (= :periodic boundary)
+                  (conj [(dec (count candidates)) true [(peek candidates) (first candidates)]]))
           legs
           (vec
            (mapcat
-            (fn [edge-index [left right]]
+            (fn [[edge-index wrap? [left right]]]
               (mapv
                (fn [[direction source target side destination-side]]
                  (let [route (get routes [(:device source) (:device target)])]
@@ -362,32 +422,43 @@
                      (fail! "halo schedule lacks a route for an adjacent shard pair"
                             :distributed-halo-route
                             {:halo id :source (:device source) :target (:device target)}))
-                   {:edge edge-index :direction direction :source source :target target
+                   {:edge edge-index :direction direction :wrap wrap?
                     :leg (communication-leg
                           {:source (:device source) :target (:device target)
                            :route (vec route) :bytes bytes
                            :attributes {:source-shard (:id source)
                                         :target-shard (:id target)
-                                        :source-region (halo-region source axis width side)
-                                        :destination-side destination-side}})}))
+                                        :source-region (halo-face source axis width side)
+                                        :destination-side destination-side
+                                        :destination-mode mode
+                                        :destination-region
+                                        (halo-destination target axis width
+                                                          destination-side mode)}})}))
                [[:forward left right :upper :lower]
                 [:backward right left :lower :upper]]))
-            (range) (partition 2 1 candidates)))
-          link-ids (mapcat (comp :route :leg) legs)]
-      (when-not (= (count link-ids) (count (distinct link-ids)))
-        (fail! "parallel halo legs cannot claim the same directed link"
-               :distributed-halo-link-conflict {:halo id :links (vec link-ids)}))
-      (let [steps
-            (mapv (fn [{:keys [edge direction leg]}]
-                    (transfer-step
-                     {:id [id :edge edge direction]
-                      :source (:source leg) :target (:target leg) :route (:route leg)
-                      :value value :bytes (:bytes leg) :dependencies (vec dependencies)
-                      :attributes (merge (:attributes leg)
-                                         {:halo id :axis axis :width width
-                                          :edge edge :direction direction})}))
-                  legs)]
-        (->ScheduledHalo exchange routes (vec dependencies) steps (mapv :id steps))))))
+            edges))
+          rounds (pack-halo-rounds legs)
+          {:keys [steps completions]}
+          (reduce
+           (fn [{:keys [steps completions]} [round-index round]]
+             (let [waits (if (zero? round-index) (vec dependencies) completions)
+                   round-steps
+                   (mapv (fn [{:keys [edge direction wrap leg]}]
+                           (transfer-step
+                            {:id [id :edge edge direction]
+                             :source (:source leg) :target (:target leg) :route (:route leg)
+                             :value value :bytes (:bytes leg) :dependencies waits
+                             :attributes (merge (:attributes leg)
+                                                {:halo id :axis axis :width width
+                                                 :boundary boundary
+                                                 :edge edge :direction direction
+                                                 :wrap wrap :round round-index})}))
+                         (:legs round))]
+               {:steps (into steps round-steps)
+                :completions (mapv :id round-steps)}))
+           {:steps [] :completions []}
+           (map-indexed vector rounds))]
+      (->ScheduledHalo exchange routes (vec dependencies) steps completions))))
 
 (defn- concrete-shape!
   [value-id value]
@@ -922,6 +993,9 @@
      (mapv (fn [{:keys [exchange steps completions]}]
              {:id (:id exchange) :value (:value exchange) :axis (:axis exchange)
               :width (:width exchange) :boundary (:boundary exchange)
+              :combine (some-> (:combine exchange)
+                               (select-keys [:combine :identity :dtype]))
+              :rounds (inc (reduce max 0 (map #(get-in % [:attributes :round]) steps)))
               :steps (mapv :id steps) :completions completions
               :bytes (reduce + 0 (map :bytes steps))})
            (:halos plan))

--- a/src/raster/compiler/ir/distributed_plan.clj
+++ b/src/raster/compiler/ir/distributed_plan.clj
@@ -14,7 +14,9 @@
             [raster.compiler.ir.abstract-value :as abstract-value]
             [raster.compiler.ir.execution-plan :as execution-plan]
             [raster.compiler.ir.link-plan :as link-plan]
-            [raster.compiler.ir.scan :as scan]))
+            [raster.compiler.ir.scan :as scan]
+            [raster.compiler.ir.validate :refer [fail! finite-number? non-negative-number?
+                                                  positive-number? unique-by!]]))
 
 (def shard-kinds #{:replicated :partitioned})
 (def shard-ownerships #{:owned :replica})
@@ -62,29 +64,6 @@
 (defn distributed-plan? [value] (instance? DistributedPlan value))
 (defn certificate? [value] (instance? DistributedPlanCertificate value))
 (defn certified-plan? [value] (instance? CertifiedDistributedPlan value))
-
-(defn- fail!
-  [message reason data]
-  (throw (ex-info message (assoc data :reason reason))))
-
-(defn- finite-number?
-  [value]
-  (and (number? value) (Double/isFinite (double value))))
-
-(defn- non-negative-number?
-  [value]
-  (and (finite-number? value) (not (neg? value))))
-
-(defn- positive-number?
-  [value]
-  (and (finite-number? value) (pos? value)))
-
-(defn- unique-by!
-  [label reason key-fn values]
-  (let [ids (mapv key-fn values)]
-    (when-not (= (count ids) (count (distinct ids)))
-      (fail! (str label " must have unique identities") reason {:ids ids})))
-  values)
 
 (defn mesh
   "Construct a rectangular row-major device mesh.

--- a/src/raster/compiler/ir/kernel_launch.clj
+++ b/src/raster/compiler/ir/kernel_launch.clj
@@ -246,6 +246,15 @@
                       {:workgroup-size workgroup-size :launch launch-spec})))
     (mapv long workgroup-size)))
 
+(defn- index-expr?
+  "A KernelBody IndexExpr, recognized by class name so the launch algebra stays a leaf."
+  [x]
+  (record-kind? "raster.compiler.ir.kernel_body.IndexExpr" x))
+
+(defn- index-cast?
+  [x]
+  (record-kind? "raster.compiler.ir.kernel_body.IndexCast" x))
+
 (defn- resolve-integer!
   [resolve-value expression value]
   (let [resolved (resolve-value value)]
@@ -300,6 +309,37 @@
                   (long alignment)))
                (minimum? expression)
                (reduce min (map resolve* (:values expression)))
+               ;; KernelBody index algebra may reach a launch dimension when a scheduled body
+               ;; projects its own extent expressions into the launch spec. Evaluate it here with
+               ;; the same exact-overflow discipline rather than asking the runtime binder to
+               ;; interpret a compiler record it does not own.
+               (index-expr? expression)
+               (let [arguments (mapv resolve* (:arguments expression))]
+                 (case (:op expression)
+                   :add (reduce #(Math/addExact (long %1) (long %2)) arguments)
+                   :sub (reduce #(Math/subtractExact (long %1) (long %2)) arguments)
+                   :mul (reduce #(Math/multiplyExact (long %1) (long %2)) arguments)
+                   :floor-div (let [[value divisor] arguments]
+                                (when-not (pos? divisor)
+                                  (throw (ex-info "index floor-div resolved divisor must be positive"
+                                                  {:expression expression :divisor divisor})))
+                                (quot value divisor))
+                   :ceil-div (let [[value divisor] arguments]
+                               (when-not (pos? divisor)
+                                 (throw (ex-info "index ceil-div resolved divisor must be positive"
+                                                 {:expression expression :divisor divisor})))
+                               (+ (quot value divisor) (if (zero? (rem value divisor)) 0 1)))
+                   :mod (let [[value divisor] arguments]
+                          (when-not (pos? divisor)
+                            (throw (ex-info "index mod resolved divisor must be positive"
+                                            {:expression expression :divisor divisor})))
+                          (mod value divisor))
+                   :min (reduce min arguments)
+                   :max (reduce max arguments)
+                   (throw (ex-info "launch dimension uses an unsupported index operation"
+                                   {:expression expression :op (:op expression)}))))
+               (index-cast? expression)
+               (resolve* (:argument expression))
                :else (resolve-integer! resolve-value expression expression))))]
     (resolve* dimension)))
 

--- a/src/raster/compiler/ir/numerical_state.clj
+++ b/src/raster/compiler/ir/numerical_state.clj
@@ -12,9 +12,9 @@
    reconstruction.  Sparse and AMR states are represented as multiple explicitly coordinated
    fields; future schemas may add partial/delta field coverage without weakening this contract."
   (:refer-clojure :exclude [chunk])
-  (:require [clojure.string :as string]
-            [raster.compiler.core.dtype :as dtype]
-            [raster.compiler.ir.abstract-value :as abstract-value]))
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.abstract-value :as abstract-value]
+            [raster.compiler.ir.validate :refer [fail! exact-keys! non-blank-string? unique-by!]]))
 
 (def schema-version 1)
 
@@ -42,22 +42,6 @@
 (defn manifest? [value] (instance? NumericalStateManifest value))
 (defn certificate? [value] (instance? NumericalStateCertificate value))
 (defn certified-state? [value] (instance? CertifiedNumericalState value))
-
-(defn- fail!
-  [message reason data]
-  (throw (ex-info message (assoc data :reason reason))))
-
-(defn- exact-keys!
-  [label reason candidate allowed]
-  (let [unexpected (vec (remove allowed (keys candidate)))]
-    (when (seq unexpected)
-      (fail! (str label " contains fields outside its versioned schema")
-             reason {:unexpected unexpected :allowed allowed})))
-  candidate)
-
-(defn- non-blank-string?
-  [value]
-  (and (string? value) (not (string/blank? value))))
 
 (defn content-address
   "Construct a storage-independent identity for immutable bytes.
@@ -154,13 +138,6 @@
          parents [] logical-coordinate {} fields [] attributes {}}}]
   (->NumericalStateManifest id schema-version parents logical-coordinate fields numerical-contract
                             provenance attributes))
-
-(defn- unique-by!
-  [label reason key-fn values]
-  (let [ids (mapv key-fn values)]
-    (when-not (= (count ids) (count (distinct ids)))
-      (fail! (str label " must have unique identities") reason {:ids ids})))
-  values)
 
 (defn- concrete-shape!
   [field-id value]

--- a/src/raster/compiler/ir/validate.clj
+++ b/src/raster/compiler/ir/validate.clj
@@ -1,0 +1,46 @@
+(ns raster.compiler.ir.validate
+  "Shared structural validation helpers for certified plan IRs.
+
+   Distributed plans, adaptive-mesh plans and durable numerical-state manifests all fail loudly
+   with one `ex-info` shape: a message, a keyword `:reason`, and structured data. This leaf holds
+   that shape and the small predicates the three namespaces previously each redefined, so a
+   certificate consumer sees one error contract and a fix to a predicate lands once."
+  (:require [clojure.string :as string]))
+
+(defn fail!
+  "Throw the plan-IR error contract: `message`, keyword `reason` merged into `data` as `:reason`."
+  [message reason data]
+  (throw (ex-info message (assoc data :reason reason))))
+
+(defn finite-number?
+  [value]
+  (and (number? value) (Double/isFinite (double value))))
+
+(defn non-negative-number?
+  [value]
+  (and (finite-number? value) (not (neg? value))))
+
+(defn positive-number?
+  [value]
+  (and (finite-number? value) (pos? value)))
+
+(defn non-blank-string?
+  [value]
+  (and (string? value) (not (string/blank? value))))
+
+(defn unique-by!
+  "Fail with `reason` unless `key-fn` is injective over `values`; returns `values`."
+  [label reason key-fn values]
+  (let [ids (mapv key-fn values)]
+    (when-not (= (count ids) (count (distinct ids)))
+      (fail! (str label " must have unique identities") reason {:ids ids})))
+  values)
+
+(defn exact-keys!
+  "Fail with `reason` when `candidate` carries a key outside `allowed`; returns `candidate`."
+  [label reason candidate allowed]
+  (let [unexpected (vec (remove allowed (keys candidate)))]
+    (when (seq unexpected)
+      (fail! (str label " contains fields outside its versioned schema")
+             reason {:unexpected unexpected :allowed allowed})))
+  candidate)

--- a/src/raster/compiler/passes/parallel/scalar_region_lower.clj
+++ b/src/raster/compiler/passes/parallel/scalar_region_lower.clj
@@ -9,6 +9,7 @@
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.axis-map :as axis-map]
+            [raster.compiler.ir.form :as form]
             [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.soac-dialect :as dialect]))
 
@@ -129,13 +130,36 @@
                           result operand-dtype)
                    result-dtype))))
 
-            (lower-expression [expression]
+            (lower-let [expression env]
+              ;; A let region is an ordered sequence of typed SSA bindings: each init lowers in
+              ;; the environment of the binders before it, and the single body lowers in the
+              ;; environment of all of them. Binders shadow region parameters lexically.
+              (let [[_ bindings & body] expression]
+                (when-not (and (vector? bindings) (even? (count bindings))
+                               (every? simple-symbol? (take-nth 2 bindings))
+                               (= 1 (count body)))
+                  (decline! :result-transform-let
+                            "result-transform let requires simple symbol binders and one body"
+                            {:expression expression}))
+                (let [env (reduce (fn [env [binder init]]
+                                    (assoc env binder (lower-expression init env)))
+                                  env
+                                  (partition 2 bindings))]
+                  (lower-expression (first body) env))))
+
+            (lower-expression [expression env]
               (cond
                 (number? expression)
                 {:value (body/literal expression result-dtype) :dtype result-dtype}
 
+                (contains? env expression)
+                (cast (get env expression) result-dtype)
+
                 (= accumulator-id expression)
                 (cast {:value accumulator :dtype accumulator-dtype} result-dtype)
+
+                (and (seq? expression) (form/let-head? (first expression)))
+                (lower-let expression env)
 
                 (contains? (set scalar-ids) expression)
                 (let [parameter (get parameters expression)]
@@ -163,7 +187,7 @@
                               "portable result transform requires casts to its declared result dtype"
                               {:expression expression :target target
                                :result-dtype result-dtype}))
-                  (cast (lower-expression (second expression)) target))
+                  (cast (lower-expression (second expression) env) target))
 
                 (seq? expression)
                 (let [operator (intrinsics/canonical (descriptor/semantic-op expression))
@@ -177,7 +201,7 @@
                               "result-transform expression has no typed portable scalar lowering"
                               {:expression expression :operator operator
                                :result-dtype result-dtype}))
-                  (let [inputs (mapv (comp :value lower-expression) arguments)
+                  (let [inputs (mapv #(:value (lower-expression % env)) arguments)
                         result (fresh "result-transform-value")]
                     (emit! (body/->ScalarCompute
                             (body/value result result-dtype)
@@ -188,7 +212,7 @@
                 (decline! :result-transform-expression
                           "result-transform expression references an unbound or unsupported value"
                           {:expression expression})))]
-      (let [typed-result (lower-expression (:expression region))
+      (let [typed-result (lower-expression (:expression region) {})
             stored-result (cast typed-result store-dtype)]
         {:operations @operations
          :result (:value stored-result)

--- a/test/raster/compiler/backend/gpu/contract_pipeline_device_test.clj
+++ b/test/raster/compiler/backend/gpu/contract_pipeline_device_test.clj
@@ -4,7 +4,8 @@
    registers + launches the chosen kernel on device → result matches CPU. End-to-end proof
    that the SOAC contraction path compiles automatically (not just as a standalone emitter).
    Gated on a real GPU."
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.string]
+            [clojure.test :refer [deftest is testing]]
             [raster.arrays :as ra]
             [raster.compiler.backend.gpu.opencl-pass :as ocl]
             [raster.compiler.ir.kernel-call :as kcall]
@@ -51,7 +52,12 @@
       (try
         (let [program (fixture/instantiate! session descriptor [A B])
               result (get (fixture/run! program [A B]) 'C)]
-          (is (= [:contract] (mapv :convention (:steps descriptor))))
+          ;; The typed contraction route emits one scheduled-executable step whose dispatch is
+          ;; the typed contraction dispatch; no convention-specific contraction marker remains.
+          (is (= [:executable] (mapv :convention (:steps descriptor))))
+          (is (every? #(clojure.string/starts-with? (str (:dispatch-id %))
+                                                    "raster_typed_contraction_dispatch")
+                      (:steps descriptor)))
           (is (= (vec (mapcat #(repeat 8 (float %))
                               (map (fn [row] (reduce + (range (* row 8) (* (inc row) 8))))
                                    (range 8))))

--- a/test/raster/compiler/backend/gpu/dpas_contract_device_test.clj
+++ b/test/raster/compiler/backend/gpu/dpas_contract_device_test.clj
@@ -179,9 +179,12 @@
       (testing "the fused KernelBody gains the operand ABI and a typed scalar region"
         (is (str/includes? (:source fused-k) "restrict bias"))
         (is (not (str/includes? (:source fused-k) "silu_f")))
-        (is (re-find #"float x = \(\(acc00\.s0\) \+ .*bias\[[^]]*col"
-                     (:source fused-k))
-            "the axis-map's j must bind to the store slot's col"))
+        ;; The typed scalar region lowers the `let` to SSA; the emitted text binds the bias
+        ;; operand's j axis to the store slot's col and evaluates the activation in place.
+        (is (re-find #"\(acc00\.s0\) \+ bias\[[^]]*col" (:source fused-k))
+            "the axis-map's j must bind to the store slot's col")
+        (is (re-find #"exp\(" (:source fused-k))
+            "the activation reaches the store slot as a scalar intrinsic"))
       (testing "fused result == unfused GEMM followed by a separate bias+silu pass"
         ;; the two-pass reference: read C back, then apply the epilogue on the host
         (let [ref (vec (map-indexed (fn [idx v] (silu (+ (double v) (aget biasd (mod idx N)))))

--- a/test/raster/compiler/core/util_test.clj
+++ b/test/raster/compiler/core/util_test.clj
@@ -1,6 +1,7 @@
 (ns raster.compiler.core.util-test
   "Tests for free variable analysis — correctness of scoping across all binding forms."
   (:require [clojure.test :refer [deftest testing is]]
+            [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.core.util :as util]))
 
 ;; ================================================================
@@ -292,3 +293,15 @@
     ;; documents WHY the mechanism was replaced, and would fail if postwalk-replace ever became safe
     (let [smap (into {} (map (fn [s] [s (gensym (str (name s) "__"))])) '[a b a c])]
       (is (= 3 (count smap)) "the duplicate `a` yields ONE entry — the collapse, in one line"))))
+
+(deftest subst-syms-rebuilds-ir-records-instead-of-emptying-them
+  (testing "a KernelBody index record keeps its type and gets its fields substituted"
+    (let [expression (body/expression :mul 'batch (body/index-cast 'seq-len :long :exact))
+          substituted (util/subst-syms '{batch arg_batch seq-len arg_seq} expression)]
+      (is (instance? raster.compiler.ir.kernel_body.IndexExpr substituted))
+      (is (= 'arg_batch (first (:arguments substituted))))
+      (is (= 'arg_seq (:argument (second (:arguments substituted)))))))
+  (testing "records nested inside forms are reached"
+    (let [form (list 'let* ['n (body/expression :add 'a 1)] 'n)
+          substituted (util/subst-syms '{a b} form)]
+      (is (= 'b (first (:arguments (second (second substituted)))))))))

--- a/test/raster/compiler/explain_pipeline_truth_test.clj
+++ b/test/raster/compiler/explain_pipeline_truth_test.clj
@@ -46,11 +46,22 @@
 (deftest a-declined-conversion-is-visible-even-though-the-form-did-not-change
   (if-not @gp/gpu-available?
     (gp/gpu-skip! "explain-pipeline: declines")
-    (let [s (explain #'raster.linalg.contract/contract-mm :target-device :ze:0)]
+    (let [s (explain #'raster.linalg.contract/contract-mm :target-device :ze:0)
+          stage-section (fn [label]
+                          (second (re-find (re-pattern (str "--- Stage \\d+: " label
+                                                            " ---([\\s\\S]*?)(?=--- Stage|--- Kernels|\\z)"))
+                                           s)))
+          segop-lower (stage-section "segop-lower")
+          backend (stage-section "backend")]
       (testing "segop-lower records the contraction as a first-class SegContract equation; this
                 stage used to print a decline, and its stats must remain visible"
-        (is (re-find #":segops-lowered 1" s))
-        (is (not (re-find #"DECLINED a conversion" s)) "nothing declines any more"))
+        (is (re-find #":segops-lowered 1" (str segop-lower)))
+        (is (not (re-find #"DECLINED a conversion" (str segop-lower)))
+            "segop-lower no longer declines"))
+      (testing "the backend stage that declines the typed contraction dispatch (symbolic dims) says
+                so in its own stats, so the decline is visible where it happens"
+        (is (re-find #":typed-contraction-dispatch-declines" (str backend)))
+        (is (re-find #"DECLINED a conversion" (str backend))))
       (testing "the kernel section names the leaf, the headline reason, and every leaf that refused"
         (is (re-find #"--- Kernels ---" s))
         (is (re-find #"strategy=:portable-segred" s))

--- a/test/raster/compiler/ir/distributed_plan_test.clj
+++ b/test/raster/compiler/ir/distributed_plan_test.clj
@@ -243,7 +243,7 @@
     (is (= 1151 (:makespan-ns simulation)))
     (is (= 32 (:transferred-bytes simulation)))
     (is (= {:id :batch-halo :value :batch :axis 0 :width 1
-            :boundary :nonperiodic
+            :boundary :nonperiodic :combine nil :rounds 1
             :steps [[:batch-halo :edge 0 :forward]
                     [:batch-halo :edge 0 :backward]]
             :completions [[:batch-halo :edge 0 :forward]
@@ -257,3 +257,173 @@
                 (catch clojure.lang.ExceptionInfo exception exception))]
     (is (= :distributed-halo-route (:reason (ex-data error))))
     (is (= :gpu-1 (:source (ex-data error))))))
+
+(deftest halo-steps-retain-destination-regions-in-both-frames
+  (let [halo (two-device-halo
+              {[:gpu-0 :gpu-1] [:gpu-0->gpu-1]
+               [:gpu-1 :gpu-0] [:gpu-1->gpu-0]})
+        [forward backward] (:steps halo)]
+    ;; gpu-1 receives gpu-0's upper face into its lower ghost strip, one row before its origin.
+    (is (= {:frame :target-local :offsets [-1 0] :shape [1 4]}
+           (get-in forward [:attributes :destination-region])))
+    (is (= :copy (get-in forward [:attributes :destination-mode])))
+    (is (= {:frame :target-local :offsets [4 0] :shape [1 4]}
+           (get-in backward [:attributes :destination-region])))
+    (is (= [0 0] (mapv #(get-in % [:attributes :round]) (:steps halo))))
+    (is (false? (get-in forward [:attributes :wrap])))))
+
+(defn- three-device-topology
+  []
+  (distributed/topology
+   [(distributed/device {:id :gpu-0 :memory-capacity-bytes 16000000000})
+    (distributed/device {:id :gpu-1 :memory-capacity-bytes 16000000000})
+    (distributed/device {:id :gpu-2 :memory-capacity-bytes 16000000000})]
+   (for [[source target] [[:gpu-0 :gpu-1] [:gpu-1 :gpu-0] [:gpu-1 :gpu-2] [:gpu-2 :gpu-1]
+                          [:gpu-2 :gpu-0] [:gpu-0 :gpu-2]]]
+     (distributed/link {:id (keyword (str (name source) "->" (name target)))
+                        :source source :target target
+                        :kind :pcie :bandwidth-bytes-s 25.0e9 :latency-ns 1000}))))
+
+(defn- ring-routes
+  []
+  (into {} (for [[source target] [[:gpu-0 :gpu-1] [:gpu-1 :gpu-0] [:gpu-1 :gpu-2] [:gpu-2 :gpu-1]
+                                  [:gpu-2 :gpu-0] [:gpu-0 :gpu-2]]]
+             [[source target] [(keyword (str (name source) "->" (name target)))]])))
+
+(defn- three-shard-field
+  []
+  {:value (abstract-value/tensor
+           {:dtype :float :shape [12 4]
+            :sharding {:kind :partitioned :axis 0 :devices [:gpu-0 :gpu-1 :gpu-2]}
+            :ownership :owned})
+   :shards [(distributed/shard {:id :field-0 :value :field :device :gpu-0
+                                :offsets [0 0] :shape [4 4]})
+            (distributed/shard {:id :field-1 :value :field :device :gpu-1
+                                :offsets [4 0] :shape [4 4]})
+            (distributed/shard {:id :field-2 :value :field :device :gpu-2
+                                :offsets [8 0] :shape [4 4]})]})
+
+(deftest periodic-halo-adds-the-wrap-edge-in-one-round-on-a-ring
+  (let [{:keys [value shards]} (three-shard-field)
+        halo (distributed/schedule-halo
+              (distributed/halo-exchange
+               {:id :field-halo :value :field :axis 0 :width 1 :boundary :periodic})
+              value shards (ring-routes) [])
+        steps (:steps halo)
+        wrap-forward (first (filter #(= [:field-halo :edge 2 :forward] (:id %)) steps))
+        wrap-backward (first (filter #(= [:field-halo :edge 2 :backward] (:id %)) steps))]
+    (is (= 6 (count steps)))
+    (is (every? zero? (map #(get-in % [:attributes :round]) steps)))
+    (is (= (mapv :id steps) (:completions halo)))
+    ;; The wrap edge sends the last shard's upper face to the first shard's lower ghost.
+    (is (= :gpu-2 (:source wrap-forward)))
+    (is (= :gpu-0 (:target wrap-forward)))
+    (is (true? (get-in wrap-forward [:attributes :wrap])))
+    (is (= {:offsets [11 0] :shape [1 4]}
+           (get-in wrap-forward [:attributes :source-region])))
+    (is (= {:frame :target-local :offsets [-1 0] :shape [1 4]}
+           (get-in wrap-forward [:attributes :destination-region])))
+    (is (= {:offsets [0 0] :shape [1 4]}
+           (get-in wrap-backward [:attributes :source-region])))
+    (let [plan (distributed/plan
+                {:id :periodic-ring
+                 :mesh (distributed/mesh [{:name :space :size 3}] [:gpu-0 :gpu-1 :gpu-2])
+                 :topology (three-device-topology)
+                 :values {:field value} :shards {:field shards}
+                 :halos [halo] :steps steps :outputs (:completions halo)})
+          certificate (:certificate (distributed/certify plan))
+          simulation (distributed/simulate plan)]
+      (is (distributed/certified-plan? (distributed/verify! (distributed/certify plan))))
+      (is (= :periodic (get-in certificate [:halos 0 :boundary])))
+      (is (= 1 (get-in certificate [:halos 0 :rounds])))
+      (is (nil? (get-in certificate [:halos 0 :combine])))
+      (is (= 96 (:transferred-bytes simulation)))
+      ;; Six distinct directed links, all legs overlap: one latency + 16 B serialization.
+      (is (= 1001 (:makespan-ns simulation))))))
+
+(deftest periodic-halo-on-two-shards-packs-the-wrap-edge-into-a-second-round
+  (let [halo (distributed/schedule-halo
+              (distributed/halo-exchange
+               {:id :batch-halo :value :batch :axis 0 :width 1 :boundary :periodic})
+              (:batch (training-values)) (:batch (training-shards))
+              {[:gpu-0 :gpu-1] [:gpu-0->gpu-1]
+               [:gpu-1 :gpu-0] [:gpu-1->gpu-0]}
+              [:stencil-0 :stencil-1])
+        steps (:steps halo)
+        rounds (mapv #(get-in % [:attributes :round]) steps)
+        second-round (filter #(= 1 (get-in % [:attributes :round])) steps)]
+    (is (= [0 0 1 1] rounds))
+    (is (= [[:batch-halo :edge 0 :forward] [:batch-halo :edge 0 :backward]]
+           (:dependencies (first second-round))))
+    (is (= [[:batch-halo :edge 1 :forward] [:batch-halo :edge 1 :backward]]
+           (:completions halo)))
+    (let [compute [(distributed/compute-step
+                    {:id :stencil-0 :device :gpu-0 :duration-ns 100})
+                   (distributed/compute-step
+                    {:id :stencil-1 :device :gpu-1 :duration-ns 150})]
+          plan (distributed/plan
+                {:id :periodic-pair
+                 :mesh (distributed/mesh [{:name :space :size 2}] [:gpu-0 :gpu-1])
+                 :topology (two-device-topology)
+                 :values (training-values) :shards (training-shards)
+                 :halos [halo]
+                 :steps (into compute steps)
+                 :outputs (:completions halo)})
+          simulation (distributed/simulate plan)]
+      (is (= 2 (get-in (:certificate (distributed/certify plan)) [:halos 0 :rounds])))
+      ;; Round 0 finishes at 150 + 1001; round 1 serializes behind it on the same links.
+      (is (= 2152 (:makespan-ns simulation)))
+      (is (= 64 (:transferred-bytes simulation))))))
+
+(deftest accumulating-halo-lands-on-the-owned-face-and-records-its-monoid
+  (let [combine (scan/certify {:acc 'acc :init 0.0 :lambda '(+ acc element)} :float)
+        halo (distributed/schedule-halo
+              (distributed/halo-exchange
+               {:id :dss :value :batch :axis 0 :width 1 :combine combine})
+              (:batch (training-values)) (:batch (training-shards))
+              {[:gpu-0 :gpu-1] [:gpu-0->gpu-1]
+               [:gpu-1 :gpu-0] [:gpu-1->gpu-0]}
+              [])
+        [forward backward] (:steps halo)
+        plan (distributed/plan
+              {:id :dss-probe
+               :mesh (distributed/mesh [{:name :space :size 2}] [:gpu-0 :gpu-1])
+               :topology (two-device-topology)
+               :values (training-values) :shards (training-shards)
+               :halos [halo] :steps (:steps halo) :outputs (:completions halo)})
+        certificate (:certificate (distributed/certify plan))]
+    (is (= :combine (get-in forward [:attributes :destination-mode])))
+    ;; gpu-0's upper face accumulates into gpu-1's lower owned row, in global coordinates.
+    (is (= {:frame :global :offsets [4 0] :shape [1 4]}
+           (get-in forward [:attributes :destination-region])))
+    (is (= {:frame :global :offsets [3 0] :shape [1 4]}
+           (get-in backward [:attributes :destination-region])))
+    (is (= {:combine (:combine combine) :identity (:identity combine) :dtype :float}
+           (get-in certificate [:halos 0 :combine])))
+    (is (distributed/certified-plan? (distributed/verify! (distributed/certify plan))))))
+
+(deftest accumulating-halos-require-a-certified-monoid-of-the-value-dtype
+  (let [uncertified (try
+                      (distributed/halo-exchange
+                       {:id :dss :value :batch :axis 0 :width 1 :combine '(+ acc element)})
+                      (catch clojure.lang.ExceptionInfo exception exception))
+        wrong-dtype (try
+                      (distributed/schedule-halo
+                       (distributed/halo-exchange
+                        {:id :dss :value :batch :axis 0 :width 1
+                         :combine (scan/certify {:acc 'acc :init 0.0 :lambda '(+ acc element)}
+                                                :double)})
+                       (:batch (training-values)) (:batch (training-shards))
+                       {[:gpu-0 :gpu-1] [:gpu-0->gpu-1]
+                        [:gpu-1 :gpu-0] [:gpu-1->gpu-0]}
+                       [])
+                      (catch clojure.lang.ExceptionInfo exception exception))]
+    (is (= :distributed-halo-combine (:reason (ex-data uncertified))))
+    (is (= :distributed-halo-combine-dtype (:reason (ex-data wrong-dtype))))))
+
+(deftest halo-boundary-policy-is-validated
+  (let [error (try
+                (distributed/halo-exchange
+                 {:id :bad :value :batch :axis 0 :width 1 :boundary :reflective})
+                (catch clojure.lang.ExceptionInfo exception exception))]
+    (is (= :distributed-halo-exchange (:reason (ex-data error))))))

--- a/test/raster/compiler/ir/kernel_launch_test.clj
+++ b/test/raster/compiler/ir/kernel_launch_test.clj
@@ -1,5 +1,6 @@
 (ns raster.compiler.ir.kernel-launch-test
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-body :as body]
             [raster.compiler.ir.kernel-launch :as launch]))
 
 (deftest launch-contracts-are-uniformly-one-to-three-dimensional
@@ -74,3 +75,17 @@
                         (launch/geometry {:workgroup-size [8]
                                           :group-count [1]
                                           :shared-memory-bytes -1}))))
+
+(deftest kernel-body-index-algebra-resolves-as-a-launch-dimension
+  (testing "a scheduled body's extent expression evaluates with the binder's symbol values"
+    (let [expression (body/expression :mul 'batch (body/index-cast 'seq-len :long :exact))
+          resolve (fn [value] (get {'batch 4 'seq-len 6} value))]
+      (is (= 24 (launch/resolve-expression resolve expression)))
+      (is (= 3 (launch/resolve-expression
+                resolve (body/expression :ceil-div 'seq-len 2))))
+      (is (= 2 (launch/resolve-expression
+                resolve (body/expression :floor-div 'seq-len 3))))))
+  (testing "an unsupported divisor is refused rather than guessed"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (launch/resolve-expression (constantly 0)
+                                            (body/expression :ceil-div 'n 'zero))))))

--- a/test/raster/compiler/passes/parallel/contract_route_device_test.clj
+++ b/test/raster/compiler/passes/parallel/contract_route_device_test.clj
@@ -46,7 +46,10 @@
         buf->doubles (ns-resolve ze 'buffer->double-array)
         _ (register! kernel-name {:source source :dtype dtype})
         {:keys [kernel-handle]} (ensure-loaded! kernel-name)
-        [gx gy] grid
+        ;; A routed descriptor's launch rank follows its schedule: the portable segmented
+        ;; reduction is a 1-D launch, the tiled leaves are 2-D. Pad the missing axis with 1.
+        [gx gy] (into (vec grid) (repeat (- 2 (count grid)) 1))
+        wg (into (vec wg) (repeat (- 2 (count wg)) 1))
         args (into (mapv #(:segment (get bufs %)) array-params)
                    (into [(:segment out)] scalar-args))]
     (launch-2d! kernel-handle wg [gx gy] args)

--- a/test/raster/compiler/passes/parallel/contraction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_body_test.clj
@@ -103,6 +103,49 @@
           (is (str/includes? (:source emitted) "bias["))
           (is (str/includes? (:source emitted) "scale")))))))
 
+(defn- let-epilogue-plan [expr]
+  (let [epilogue {:acc 'acc
+                  :expr expr
+                  :operands [{:sym 'bias :dtype :float
+                              :map (axis-map/of-axes [['j 8]])}]
+                  :dtype :float}
+        form '(raster.par/contract C [[i 4] [j 8]] [[l 16]]
+                                    (raster.numeric/*
+                                     (clojure.core/aget A (clojure.core/+ (clojure.core/* i 16) l))
+                                     (clojure.core/aget B (clojure.core/+ (clojure.core/* l 8) j))))
+        form (concat form [:epilogue epilogue])
+        verified (facts/contraction-facts form :dtype :half)
+        segred (lower/contract-form->segred form :dtype :half :facts verified)]
+    (schedule/plan-portable-body verified segred nil)))
+
+(deftest a-let-bound-result-transform-lowers-to-shared-typed-ssa
+  (testing "a let binding is one SSA value reused by every later reference"
+    (let [plan (let-epilogue-plan
+                '(let [x (raster.numeric/+ acc (clojure.core/aget bias j))]
+                   (raster.numeric// x (raster.numeric/+ 1.0
+                                                         (raster.math/exp
+                                                          (raster.numeric/* -1.0 x))))))
+          kernel (:body plan)
+          operations (:operations kernel)
+          epilogue-operations (subvec operations 1 (dec (count operations)))
+          operators (keep #(get-in % [:expression :op]) epilogue-operations)]
+      (is (:ok plan))
+      ;; widen acc, load bias, x = acc + bias, -1*x, exp, 1+exp, x/(1+exp), narrow to half
+      (is (= 8 (count epilogue-operations)))
+      (is (= [:cast :+ :* :exp :+ :div :cast] (vec operators))
+          "the addition bound to x is emitted once and reused, not once per use")
+      (doseq [dialect [:opencl-portable :cuda :hip]]
+        (let [emitted (emit/generate-contraction-kernel-body kernel :target-dialect dialect)]
+          (is (str/includes? (:source emitted) "exp("))
+          (is (= '[bias] (:epilogue-operands emitted)))))))
+  (testing "a let binder shadows the accumulator lexically"
+    (let [plan (let-epilogue-plan '(let [acc (raster.numeric/* acc 2.0)] acc))
+          operations (:operations (:body plan))
+          epilogue-operations (subvec operations 1 (dec (count operations)))]
+      (is (:ok plan))
+      ;; widen acc, multiply, narrow to half
+      (is (= 3 (count epilogue-operations))))))
+
 (deftest a-result-transform-can-reuse-one-contraction-operand-without-a-second-abi-slot
   (let [epilogue {:acc 'acc
                   :expr '(raster.numeric/+ acc (clojure.core/aget A

--- a/test/raster/dl/gpu_ad_gemm_test.clj
+++ b/test/raster/dl/gpu_ad_gemm_test.clj
@@ -89,13 +89,17 @@
         (let [sl 6 nh 4 hd 8 x (rnd (* sl nh hd) 21)
               cpu (ops/pack-heads x sl nh hd)
               {:keys [descriptor out]} (run-resident #'ops/pack-heads [x sl nh hd])]
-          (is (= [:map-void] (mapv :convention (:steps descriptor))))
+          ;; one resident kernel; the typed route emits a value-producing :map for a dense
+          ;; single-result copy rather than the nil-returning effect convention
+          (is (= 1 (count (:steps descriptor))))
+          (is (contains? #{:map :map-void} (:convention (first (:steps descriptor)))))
           (is (< (rel-err out cpu) tol) (str "pack-heads relerr " (rel-err out cpu)))))
       (testing "unpack-heads lowers to a resident :map-void kernel and matches CPU"
         (let [sl 6 nh 4 hd 8 x (rnd (* sl nh hd) 22)
               cpu (ops/unpack-heads x sl nh hd)
               {:keys [descriptor out]} (run-resident #'ops/unpack-heads [x sl nh hd])]
-          (is (= [:map-void] (mapv :convention (:steps descriptor))))
+          (is (= 1 (count (:steps descriptor))))
+          (is (contains? #{:map :map-void} (:convention (first (:steps descriptor)))))
           (is (< (rel-err out cpu) tol) (str "unpack-heads relerr " (rel-err out cpu)))))
       (testing "broadcast-kv-heads (MQA fan-out) lowers resident and matches CPU"
         (let [nkv 2 grp 4 slab 48 src (rnd (* nkv slab) 23)

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -145,8 +145,9 @@
       (try
         (is (= [:map-void] (mapv :convention (:steps descriptor)))
             "host control retains the nil-returning effect convention")
-        (is (= :segmap (get-in descriptor [:steps 0 :artifact :provenance :dialect]))
-            "kernel generation consumes the scheduled TypedSOAC SegMap")
+        (is (= :kernel-body (get-in descriptor [:steps 0 :artifact :provenance :dialect]))
+            "kernel generation consumes the scheduled TypedSOAC SegMap through KernelBody")
+        (is (= :segmap (get-in descriptor [:steps 0 :artifact :provenance :source-dialect])))
         (is (= [:input :input :output :output :scalar]
                (mapv :kind (get-in descriptor [:steps 0 :abi]))))
         (let [program (fixture/instantiate! session descriptor [x y a b n]
@@ -173,6 +174,7 @@
           labels (int-array n)
           session (gpu/make-session :ocl:0)]
       (try
+        ;; mixed byte/int/float storage still emits through the SegMap generator
         (is (= :segmap (get-in descriptor [:steps 0 :artifact :provenance :dialect])))
         (is (= [:byte :float :int :float :int]
                (mapv :dtype (get-in descriptor [:steps 0 :abi]))))
@@ -198,9 +200,9 @@
           b (float-array n)
           session (gpu/make-session :ocl:0)]
       (try
-        (is (= :segmap (get-in descriptor [:steps 0 :artifact :provenance :dialect])))
-        (is (= 1 (count (re-seq #"x\[idx\]" source)))
-            "the live kernel computes its shared tuple producer once")
+        (is (= :kernel-body (get-in descriptor [:steps 0 :artifact :provenance :dialect])))
+        (is (= 1 (count (re-seq #"x\[" source)))
+            "the live kernel loads the shared tuple producer's input once")
         (let [program (fixture/instantiate! session descriptor [x a b n]
                                             {'x :input 'a :output 'b :output})
               result (fixture/run! program [x a b n])
@@ -390,7 +392,7 @@
       (try
         (let [program (fixture/instantiate! s descriptor [A B])
               result (get (fixture/run! program [A B]) 'C)]
-          (is (= [:contract] (mapv :convention (:steps descriptor))))
+          (is (= [:executable] (mapv :convention (:steps descriptor))))
           (is (= (vec (mapcat #(repeat 8 (float %))
                               (map (fn [row] (reduce + (range (* row 8) (* (inc row) 8))))
                                    (range 8))))


### PR DESCRIPTION
## North star: simulation track kick-off, halo exchange increment, GPU regression fixes

One PR for one coherent phase (per the PR-batching preference): the amended north star, the
first distributed-plan increment of the D1 ladder, and the correctness fixes the local GPU
baseline surfaced. Twenty simulator/training/inference surveys and the design notes behind
this live in the gitignored `.internal/` and are summarized in the north star itself.

### Design (`design/compiler-north-star.md`)
- §0 Objective: grounding quality per compute; the unit of value is a verified transformation;
  cost vector gains approximation error under an error model and information value; every
  transformation carries an error model; probabilistic numerics as the framing lens.
- Time and fidelity are schedule axes (§3.3); §3.8 time/composition/rate scheduling; §3.9 the
  five irregular primitives from the survey (star-forest communication, irregular values,
  access facts on edges, a schedule for time, contracts as certificates).
- §6 entity-set shards, combiner halos, pipeline coordinates, recompute policy; §7 becomes the
  inference-through-internals track; §8 gains the D1–D8 demonstrator ladder; §9 tiers 9–12
  including the agent baseline; §10/§11 non-goals and surveyed references; §12 iteration procedure.

### Distributed plan (`ir/distributed_plan.clj`)
- `HaloExchange` gains `:periodic` boundaries (wrap edge) and a certified `:combine` monoid
  (accumulate into the owned face, as DSS/deposition/force return need). Legs are packed into
  rounds so no round claims one directed link twice; steps retain source face, destination
  region (target-local ghost frame or global owned face), mode, wrap flag and round; the
  certificate records the monoid and round count. Tests cover ring, two-shard second-round
  packing, combine, dtype and policy refusals.
- `ir/validate.clj`: the three plan IRs share one error contract instead of three copies.

### Compiler fixes (found by the full local suite on the Arc; CI has no GPU)
- `scalar_region_lower`: `let`/`let*` in typed result transforms lower as shared SSA with
  lexical shadowing (fused bias+SiLU epilogues reach the DPAS leaf again). CPU test added.
- `core/util`, `core/macroexpand`: substitution/alpha/uniquify/macroexpansion walkers rebuild IR
  records field-wise instead of calling `empty` on them (crashed on `IndexExpr`).
- `ir/kernel_launch`: `resolve-expression` evaluates KernelBody `IndexExpr`/`IndexCast`.
- Stale GPU test expectations refreshed to the typed route's actual facts (value-producing
  `:map`, KernelBody provenance, `:executable` contraction steps, scoped decline banner,
  1-D launch helper).

### Still open on main (documented in `.internal/debt_audit_2026_09_03.md`, GPU only)
- Zero gradients on the resident path: an AD host scalar (`mse_scale`) is captured untyped and
  the kernel ABI declares it `int` (root cause isolated; fix belongs in the typed frontend's
  capture typing).
- Attention `segmented-fold-map!` has no TypedSOAC schedule since the legacy fallback removal;
  every GQA/Gemma GPU program errors.
- Reduction element/accumulator dtype mismatch declines at the KernelBody boundary; a KernelBody
  index record still reaches a runtime scalar argument in the attention forward.

https://claude.ai/code/session_01Vtm1xB9JmpaxJMEWCAcQWm
