### PR TITLE
Typed-route coverage ratchet over the deftm corpus; refuse undeclared kernel scalar dtypes

### DIFF
--- a/scripts/update-coverage-baseline.sh
+++ b/scripts/update-coverage-baseline.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Regenerate the typed-route coverage baseline on a CPU OpenCL device (the same class of device
+# the CI gate uses), so route facts in the baseline match what CI measures.
+set -euo pipefail
+export RASTER_OCL_DEVICE_TYPE="${RASTER_OCL_DEVICE_TYPE:-cpu}"
+exec clojure -M:dev -m raster.compiler.coverage update

--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -333,12 +333,14 @@
                    (throw (ex-info "kernel scalar has an unknown declared dtype"
                                    {:reason :kernel-scalar-dtype :symbol sym
                                     :declared explicit})))
-      ;; Stamped tag is authoritative — it OUTRANKS the name regex so a float named
-      ;; `len`/`count` isn't truncated to int and an int renamed away from an int-ish
-      ;; name still declares int.
       metadata-dtype metadata-dtype
-      (re-find #"(?i)n[-_]|size|count|len|idx|offset" sname) :int
-      :else (dtype/canon default-dtype))))
+      ;; No declared fact and no stamped tag: refuse rather than guess from the name or the
+      ;; kernel dtype. The pipeline forwards every deftm param and every tagged binder, so
+      ;; reaching this branch means a scalar lost its type upstream.
+      :else (throw (ex-info "kernel scalar parameter has no declared or retained dtype"
+                            {:reason :kernel-scalar-dtype-unknown :symbol sym
+                             :kernel-dtype (some-> default-dtype dtype/canon)
+                             :declared (vec (keys scalar-types))})))))
 
 (defn fn-style-reduction-op?
   "True if a reduction op emits as a C function call `f(a,b)` (fmax/fmin) rather

--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -327,7 +327,15 @@
         metadata-dtype (cond
                          (keyword? mtag) (when (dtype/known? mtag) (dtype/canon mtag))
                          (symbol? mtag) (dtype/dtype-for-scalar-tag
-                                         (descriptor/cast-result-tag mtag)))]
+                                         (descriptor/cast-result-tag mtag)))
+        ;; A floating hoisted local specializes to the kernel dtype exactly as a declared
+        ;; floating param does (derive-param-types), so the host encoding and the kernel
+        ;; declaration cannot disagree on width.
+        kernel-dtype (some-> default-dtype dtype/canon)
+        metadata-dtype (if (and metadata-dtype kernel-dtype
+                                (dtype/fp-dtype? metadata-dtype) (dtype/fp-dtype? kernel-dtype))
+                         kernel-dtype
+                         metadata-dtype)]
     (cond
       explicit (or declared
                    (throw (ex-info "kernel scalar has an unknown declared dtype"

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -34,11 +34,15 @@
   [expression types]
   (cond
     (integer? expression) :int
-    (value-id? expression) (get types expression :int)
+    (value-id? expression)
+    (or (get types expression)
+        (throw (ex-info "index expression references a value with no declared dtype"
+                        {:reason :index-value-dtype-unknown :value expression})))
     (record-kind? "IndexCast" expression) (dtype/canon (:dtype expression))
     (record-kind? "IndexExpr" expression)
-    (or (some-> (:arguments expression) first (index-expression-dtype types)) :int)
-    :else :int))
+    (index-expression-dtype (first (:arguments expression)) types)
+    :else (throw (ex-info "index expression has an unsupported operand"
+                          {:reason :index-expression-operand :expression expression}))))
 
 (defn- emit-infix [operator arguments env]
   (str "(" (str/join (str " " operator " ")

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -11,6 +11,7 @@
             [raster.compiler.ir.form :as form]
             [raster.compiler.ir.par :as par]
             [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.types :as types]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-call :as kcall]
@@ -47,6 +48,50 @@
 ;; Single source of declared GPU param types (shared by BOTH compile entries:
 ;; raster.gpu.core/compile-deftm-internal! and the pipeline's pass-backend).
 ;; ================================================================
+
+(defn- counted-loop-index-dtype
+  "The integral dtype of a `loop*` binder initialised by an integer literal or an explicit
+   integral cast: the expanded `dotimes` counter. The fact is the init's own type, not a guess
+   from the binder's name; a floating or untyped init yields nil."
+  [form init]
+  (cond
+    ;; an unexpanded dotimes counter is a long by the macro's own contract
+    (contains? '#{dotimes clojure.core/dotimes} (first form)) :long
+    (form/loop-head? (first form))
+    (cond
+      (integer? init) :long
+      (and (seq? init) (= 2 (count init)))
+      (case (first init)
+        (long clojure.core/long) :long
+        (int clojure.core/int) :int
+        nil)
+      :else nil)
+    :else nil))
+
+(defn binder-scalar-types
+  "Walker-stamped scalar dtypes of every `let`/`loop` binder in `form`, projected the way
+   `derive-param-types` projects declared params: integral tags keep their width, floating
+   tags take the kernel dtype. A hoisted host scalar that a kernel captures therefore has the
+   same declared dtype on the host and in the kernel ABI; no emitter guesses it from its name."
+  [form kernel-dtype]
+  (let [kernel-dtype (dtype/canon (or kernel-dtype :float))
+        found (atom {})]
+    (clojure.walk/prewalk
+     (fn [x]
+       (when (and (seq? x)
+                  (symbol? (first x))
+                  (or (form/let-head? (first x)) (form/loop-head? (first x))
+                      (contains? '#{dotimes clojure.core/dotimes} (first x)))
+                  (vector? (second x)))
+         (doseq [[binder init] (partition 2 (second x))]
+           (when (symbol? binder)
+             (when-let [declared (or (some-> (types/sym-type-tag binder) dtype/dtype-for-scalar-tag)
+                                     (counted-loop-index-dtype x init))]
+               (swap! found assoc binder
+                      (if (dtype/fp-dtype? declared) kernel-dtype declared))))))
+       x)
+     form)
+    @found))
 
 (defn derive-param-types
   "Declared scalar + array element types for the GPU emitter, read from a deftm's params + tags
@@ -349,7 +394,8 @@
                :array-types (parallel-program/declared-value-types parallel-program arrays)}
               {:scalar-types (parallel-program/known-value-types parallel-program scalars)
                :array-types (parallel-program/known-value-types parallel-program arrays)})))
-        top-scalar-types (merge (or (:scalar-types program-types) {})
+        top-scalar-types (merge (binder-scalar-types source-form dtype)
+                                (or (:scalar-types program-types) {})
                                 (or (:scalar-types (meta source-form)) {})
                                 (or (:scalar-types (meta form)) {}) scalar-types)
         top-array-types (merge (or (:array-types program-types) {})

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -8,6 +8,7 @@
    This is the GPU counterpart of simd-pass — both consume the same
    par form vocabulary but produce different target code."
   (:require [clojure.set :as set]
+            [clojure.walk :as walk]
             [raster.compiler.ir.form :as form]
             [raster.compiler.ir.par :as par]
             [raster.compiler.core.dtype :as dtype]
@@ -49,34 +50,61 @@
 ;; raster.gpu.core/compile-deftm-internal! and the pipeline's pass-backend).
 ;; ================================================================
 
-(defn- counted-loop-index-dtype
-  "The integral dtype of a `loop*` binder initialised by an integer literal or an explicit
-   integral cast: the expanded `dotimes` counter. The fact is the init's own type, not a guess
-   from the binder's name; a floating or untyped init yields nil."
-  [form init]
+(def ^:private integral-arithmetic-heads
+  "clojure.core integer index/dimension arithmetic: the fixpoint census exempts such bindings from
+   type tags because their result is a long whenever every operand is a long."
+  '#{clojure.core/* clojure.core/+ clojure.core/- clojure.core/quot clojure.core/rem
+     clojure.core/mod clojure.core/inc clojure.core/dec clojure.core/max clojure.core/min})
+
+(defn- strip-scalar-cast [x]
+  (if (and (seq? x) (= 2 (count x))
+           (contains? '#{long clojure.core/long int clojure.core/int} (first x)))
+    (recur (second x))
+    x))
+
+(defn- integral-expression?
+  "An expression whose value is provably an integral scalar from declared facts: an integer
+   literal, an explicit integral cast, a symbol declared integral in `env`, or integer arithmetic
+   over such operands."
+  [expression env]
   (cond
-    ;; an unexpanded dotimes counter is a long by the macro's own contract
+    (integer? expression) true
+    (symbol? expression) (contains? #{:int :long} (get env expression))
+    (and (seq? expression) (= 2 (count expression))
+         (contains? '#{long clojure.core/long int clojure.core/int} (first expression)))
+    true
+    (and (seq? expression) (contains? integral-arithmetic-heads (first expression)))
+    (every? #(integral-expression? % env) (rest expression))
+    :else false))
+
+(defn- counted-loop-index-dtype
+  "The integral dtype of a loop counter: a `dotimes` binder, or the `loop*` binder that the
+   loop's own exit test compares against a bound. The fact is the loop's structure, not the
+   binder's name; accumulators and other carries are left to their tags."
+  [form binder init]
+  (cond
     (contains? '#{dotimes clojure.core/dotimes} (first form)) :long
-    (form/loop-head? (first form))
-    (cond
-      (integer? init) :long
-      (and (seq? init) (= 2 (count init)))
-      (case (first init)
-        (long clojure.core/long) :long
-        (int clojure.core/int) :int
-        nil)
-      :else nil)
+    (and (form/loop-head? (first form)) (integer? init))
+    (let [body (nth form 2 nil)
+          test (when (and (seq? body) (contains? '#{if clojure.core/if} (first body)))
+                 (second body))]
+      (when (and (seq? test)
+                 (contains? '#{< <= clojure.core/< clojure.core/<=} (first test))
+                 (= binder (strip-scalar-cast (second test))))
+        :long))
     :else nil))
 
 (defn binder-scalar-types
-  "Walker-stamped scalar dtypes of every `let`/`loop` binder in `form`, projected the way
-   `derive-param-types` projects declared params: integral tags keep their width, floating
-   tags take the kernel dtype. A hoisted host scalar that a kernel captures therefore has the
-   same declared dtype on the host and in the kernel ABI; no emitter guesses it from its name."
-  [form kernel-dtype]
+  "Walker-stamped scalar dtypes of every `let`/`loop`/`dotimes` binder in `form`, projected the
+   way `derive-param-types` projects declared params: integral tags keep their width, floating
+   tags take the kernel dtype. Untagged integer-arithmetic locals (which the fixpoint census
+   exempts from tags) are typed from their operands' declared dtypes. A hoisted host scalar that
+   a kernel captures therefore has the same declared dtype on the host and in the kernel ABI; no
+   emitter guesses it from its name."
+  [form kernel-dtype declared]
   (let [kernel-dtype (dtype/canon (or kernel-dtype :float))
-        found (atom {})]
-    (clojure.walk/prewalk
+        found (atom (or declared {}))]
+    (walk/prewalk
      (fn [x]
        (when (and (seq? x)
                   (symbol? (first x))
@@ -85,13 +113,14 @@
                   (vector? (second x)))
          (doseq [[binder init] (partition 2 (second x))]
            (when (symbol? binder)
-             (when-let [declared (or (some-> (types/sym-type-tag binder) dtype/dtype-for-scalar-tag)
-                                     (counted-loop-index-dtype x init))]
+             (when-let [inferred (or (some-> (types/sym-type-tag binder) dtype/dtype-for-scalar-tag)
+                                     (counted-loop-index-dtype x binder init)
+                                     (when (integral-expression? init @found) :long))]
                (swap! found assoc binder
-                      (if (dtype/fp-dtype? declared) kernel-dtype declared))))))
+                      (if (dtype/fp-dtype? inferred) kernel-dtype inferred))))))
        x)
      form)
-    @found))
+    (apply dissoc @found (keys (or declared {})))))
 
 (defn derive-param-types
   "Declared scalar + array element types for the GPU emitter, read from a deftm's params + tags
@@ -394,7 +423,11 @@
                :array-types (parallel-program/declared-value-types parallel-program arrays)}
               {:scalar-types (parallel-program/known-value-types parallel-program scalars)
                :array-types (parallel-program/known-value-types parallel-program arrays)})))
-        top-scalar-types (merge (binder-scalar-types source-form dtype)
+        top-scalar-types (merge (binder-scalar-types
+                                 source-form dtype
+                                 (merge (or (:scalar-types program-types) {})
+                                        (or (:scalar-types (meta source-form)) {})
+                                        (or (:scalar-types (meta form)) {}) scalar-types))
                                 (or (:scalar-types program-types) {})
                                 (or (:scalar-types (meta source-form)) {})
                                 (or (:scalar-types (meta form)) {}) scalar-types)

--- a/src/raster/compiler/backend/gpu/par_opencl.clj
+++ b/src/raster/compiler/backend/gpu/par_opencl.clj
@@ -283,8 +283,9 @@
                      (or dtype
                          (throw (ex-info "exclusive scan generator requires a scan dtype"
                                          {:reason :scan-dtype-unknown :form form}))))
-        ctype (get {:int "int" :long "long" :float "float" :double "double"}
-                   scan-dtype "int")
+        ctype (or (get {:int "int" :long "long" :float "float" :double "double"} scan-dtype)
+                  (throw (ex-info "exclusive scan generator has no C type for its dtype"
+                                  {:reason :scan-dtype-unknown :dtype scan-dtype :form form})))
         ;; Extract combining op and element expression (same pattern as reduce)
         [let-bindings inner-body]
         (if (and (seq? body) (contains? #{'let* 'let} (first body)))

--- a/src/raster/compiler/backend/gpu/par_opencl.clj
+++ b/src/raster/compiler/backend/gpu/par_opencl.clj
@@ -280,7 +280,9 @@
                      long :long
                      float :float
                      double :double
-                     (or dtype :int))
+                     (or dtype
+                         (throw (ex-info "exclusive scan generator requires a scan dtype"
+                                         {:reason :scan-dtype-unknown :form form}))))
         ctype (get {:int "int" :long "long" :float "float" :double "double"}
                    scan-dtype "int")
         ;; Extract combining op and element expression (same pattern as reduce)

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -694,7 +694,9 @@
         scalar-dtype (fn [id]
                        (or (get scalar-types id)
                            (get scalar-types (symbol (name id)))
-                           dtype))
+                           (throw (ex-info "kernel scalar parameter has no declared dtype"
+                                           {:reason :kernel-scalar-dtype-unknown :symbol id
+                                            :declared (vec (keys scalar-types))}))))
         result-name (or out-sym 'output)
         abi (kabi/validate!
              (vec (concat
@@ -746,17 +748,27 @@
        (catch clojure.lang.ExceptionInfo exception
          (if (and (kernel-body-c-dialect/opencl? target)
                   (segmap-body/declined? exception))
-           (-> (if (:out-sym operation)
-                 (generate-segmap-kernel
-                  operation (:out-sym operation)
-                  :dtype dtype :scalar-types scalar-types :array-types array-types
-                  :kernel-name-prefix kernel-name-prefix)
-                 (generate-explicit-segmap-kernel
-                  operation :dtype dtype :scalar-types scalar-types :array-types array-types
-                  :kernel-name-prefix (str kernel-name-prefix "_effect")))
-               (assoc-in [:attributes :emission-route] :verified-segmap-opencl)
-               (assoc-in [:attributes :kernel-body-decline]
-                         (assoc (ex-data exception) :fallback :verified-segmap-opencl)))
+           (try
+             (-> (if (:out-sym operation)
+                   (generate-segmap-kernel
+                    operation (:out-sym operation)
+                    :dtype dtype :scalar-types scalar-types :array-types array-types
+                    :kernel-name-prefix kernel-name-prefix)
+                   (generate-explicit-segmap-kernel
+                    operation :dtype dtype :scalar-types scalar-types :array-types array-types
+                    :kernel-name-prefix (str kernel-name-prefix "_effect")))
+                 (assoc-in [:attributes :emission-route] :verified-segmap-opencl)
+                 (assoc-in [:attributes :kernel-body-decline]
+                           (assoc (ex-data exception) :fallback :verified-segmap-opencl)))
+             (catch clojure.lang.ExceptionInfo retry
+               ;; The verified OpenCL generator refused as well: report both refusals as one
+               ;; structured error instead of letting the second one hide the first.
+               (throw (ex-info "scheduled map has no OpenCL emission: KernelBody declined and the verified generator refused"
+                               {:reason :segmap-emission-refused
+                                :operation (:id operation)
+                                :kernel-body-decline (ex-data exception)
+                                :generator-refusal (ex-data retry)}
+                               retry))))
            (throw exception))))
      operation)))
 
@@ -894,7 +906,9 @@
         scalar-dtype (fn [id]
                        (or (get scalar-types id)
                            (get scalar-types (symbol (name id)))
-                           (:dtype algebra)))
+                           (throw (ex-info "kernel scalar parameter has no declared dtype"
+                                           {:reason :kernel-scalar-dtype-unknown :symbol id
+                                            :declared (vec (keys scalar-types))}))))
         emitted
         (kgraph/map-operations
          graph

--- a/src/raster/compiler/coverage.clj
+++ b/src/raster/compiler/coverage.clj
@@ -79,11 +79,16 @@
                       (frequencies (map :route rows)))
       :vars (vec (sort-by (comp str :var) rows))})))
 
+(def route-rank
+  "Routes ordered from best to worst; a move down this order is a regression."
+  {:typed-soac 0 :compatibility 1 :scalar 2 :error 3})
+
 (defn ratchet-violations
   "Ways in which `report` regressed against `baseline`.
 
-   A var on the typed route may not leave it; a var that compiled may not error. New and removed
-   vars are not violations, so the corpus can grow and shrink without editing the baseline."
+   A var may not move to a worse route (typed → compatibility → scalar → error) and a validated
+   typed program may not lose its validation. New and removed vars are not violations, so the
+   corpus can grow and shrink without editing the baseline."
   [baseline report]
   (let [before (into {} (map (juxt :var identity)) (:vars baseline))]
     (vec
@@ -91,15 +96,14 @@
            :let [old (get before (:var row))]
            :when old
            violation (cond-> []
-                       (and (= :typed-soac (:route old))
-                            (not= :typed-soac (:route row)))
-                       (conj {:var (:var row) :violation :left-typed-route
+                       (> (get route-rank (:route row) 3) (get route-rank (:route old) 3))
+                       (conj {:var (:var row) :violation :route-downgraded
                               :before (:route old) :after (:route row)
                               :declines (:declines row) :error (:error row)})
 
-                       (and (not= :error (:route old)) (= :error (:route row)))
-                       (conj {:var (:var row) :violation :started-failing
-                              :before (:route old) :error (:error row)}))]
+                       (and (:typed-validated old) (not (:typed-validated row)))
+                       (conj {:var (:var row) :violation :lost-typed-validation
+                              :route (:route row)}))]
        violation))))
 
 (defn read-baseline [path]

--- a/src/raster/compiler/coverage.clj
+++ b/src/raster/compiler/coverage.clj
@@ -1,0 +1,132 @@
+(ns raster.compiler.coverage
+  "Typed-route coverage of the compiler over a corpus of `deftm` functions.
+
+   The compiler's coverage claim is measured, not asserted: every source `deftm` in the corpus
+   namespaces is compiled through the diagnostic pipeline for a GPU target and the normalized
+   report records which route it took (`:typed-soac`, `:compatibility`, `:scalar`), every
+   route decline with its reason and operation, and any hard error. A committed baseline turns
+   this into a ratchet (`ratchet-violations`): a function that took the typed route may not fall
+   back, and a function that compiled may not start failing.
+
+   This namespace only enumerates vars and calls `raster.compiler.pipeline/compile-report`; it
+   never inspects source forms or infers operations."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.pprint :as pp]
+            [raster.compiler.pipeline :as pipeline]))
+
+(def default-namespaces
+  "Corpus namespaces: the deep-learning substrate, the ODE/PDE surface and the NN primitives."
+  '[raster.dl.nn raster.dl.attention raster.dl.loss raster.dl.array-ops raster.dl.optim
+    raster.dl.tensor raster.dl.einsum raster.dl.diffusion raster.dl.train raster.nn
+    raster.ode.pde])
+
+(def default-baseline-path "test/resources/coverage/gpu-corpus.edn")
+
+(defn corpus-vars
+  "Source `deftm` vars (generic functions, not their generated specializations) in `namespaces`."
+  [namespaces]
+  (vec
+   (for [ns-sym namespaces
+         :let [_ (require ns-sym)]
+         v (sort-by (comp str :name meta) (vals (ns-publics ns-sym)))
+         :when (:raster.core/generic-function (meta v))]
+     v)))
+
+(defn- var-symbol [v]
+  (symbol (str (ns-name (:ns (meta v)))) (str (:name (meta v)))))
+
+(defn- decline-facts [declines]
+  (->> declines
+       (mapcat (fn [decline]
+                 (if (seq (:bindings decline))
+                   (map (fn [binding]
+                          {:reason (:reason binding)
+                           :operation (:operation binding)
+                           :kind (:kind binding)})
+                        (:bindings decline))
+                   [(select-keys decline [:reason :operation :kind])])))
+       (remove empty?)
+       distinct
+       vec))
+
+(defn- error-reason [throwable]
+  (or (:reason (ex-data throwable))
+      (some-> (.getMessage throwable) (subs 0 (min 120 (count (.getMessage throwable)))))))
+
+(defn report-var
+  "Compile one source deftm for `target-device` at `dtype` and reduce its report to route facts."
+  [v {:keys [target-device dtype] :or {dtype :float}}]
+  (let [row {:var (var-symbol v)}]
+    (try
+      (let [report (pipeline/compile-report v :target-device target-device :dtype dtype)]
+        (assoc row
+               :route (get-in report [:route :source-dialect])
+               :typed-validated (boolean (get-in report [:route :typed-validated]))
+               :declines (decline-facts (get-in report [:route :declines]))
+               :emission-declines (count (get-in report [:emission :declines]))))
+      (catch Throwable t
+        (assoc row :route :error :error (error-reason t))))))
+
+(defn corpus-report
+  "Route facts for every corpus var, with a summary by route."
+  ([opts] (corpus-report default-namespaces opts))
+  ([namespaces opts]
+   (let [rows (mapv #(report-var % opts) (corpus-vars namespaces))]
+     {:target-device (:target-device opts)
+      :dtype (:dtype opts :float)
+      :summary (merge {:total (count rows)}
+                      (frequencies (map :route rows)))
+      :vars (vec (sort-by (comp str :var) rows))})))
+
+(defn ratchet-violations
+  "Ways in which `report` regressed against `baseline`.
+
+   A var on the typed route may not leave it; a var that compiled may not error. New and removed
+   vars are not violations, so the corpus can grow and shrink without editing the baseline."
+  [baseline report]
+  (let [before (into {} (map (juxt :var identity)) (:vars baseline))]
+    (vec
+     (for [row (:vars report)
+           :let [old (get before (:var row))]
+           :when old
+           violation (cond-> []
+                       (and (= :typed-soac (:route old))
+                            (not= :typed-soac (:route row)))
+                       (conj {:var (:var row) :violation :left-typed-route
+                              :before (:route old) :after (:route row)
+                              :declines (:declines row) :error (:error row)})
+
+                       (and (not= :error (:route old)) (= :error (:route row)))
+                       (conj {:var (:var row) :violation :started-failing
+                              :before (:route old) :error (:error row)}))]
+       violation))))
+
+(defn read-baseline [path]
+  (with-open [reader (java.io.PushbackReader. (io/reader path))]
+    (edn/read reader)))
+
+(defn write-baseline!
+  "Write `report` as the committed baseline. Emission facts are excluded: they depend on the
+   device's tuned leaves, while route and error facts are device-independent."
+  [path report]
+  (io/make-parents path)
+  (with-open [writer (io/writer path)]
+    (binding [*print-length* nil *print-level* nil]
+      (pp/pprint (update report :vars
+                         (fn [rows] (mapv #(dissoc % :emission-declines) rows)))
+                 writer)))
+  path)
+
+(defn -main
+  "`update` rewrites the baseline for the OpenCL device the runtime selects; otherwise prints the
+   summary and the ratchet violations against the committed baseline."
+  [& [command]]
+  (let [report (corpus-report {:target-device :ocl:0 :dtype :float})]
+    (println "coverage summary:" (pr-str (:summary report)))
+    (if (= "update" command)
+      (println "baseline written:" (write-baseline! default-baseline-path report))
+      (let [violations (ratchet-violations (read-baseline default-baseline-path) report)]
+        (doseq [v violations] (println "  violation:" (pr-str v)))
+        (when (seq violations) (System/exit 1))))
+    (shutdown-agents)))

--- a/src/raster/compiler/passes/parallel/segmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segmap_body.clj
@@ -157,9 +157,15 @@
                                        (get array-types (symbol (name id)))
                                        default-dtype)))
         scalar-dtype (fn [id]
-                       (dtype/canon (or (get scalar-types id)
-                                        (get scalar-types (symbol (name id)))
-                                        :int)))
+                       (if-let [declared (or (get scalar-types id)
+                                             (get scalar-types (symbol (name id))))]
+                         (dtype/canon declared)
+                         ;; A guessed integer here silently zeroed a captured floating scalar
+                         ;; once; the owner (params, program values or walker tags) must say.
+                         (decline! :scalar-dtype
+                                   "portable map scalar parameter has no declared dtype"
+                                   {:operation (:id segmap) :scalar id
+                                    :declared (vec (keys scalar-types))})))
         array-types (into {} (map (juxt identity array-dtype)) (concat inputs outputs))
         scalar-types (into {} (map (juxt identity scalar-dtype)) scalars)
         index-scope (conj (set scalars) index)

--- a/test/raster/compiler/backend/gpu/c_emit_test.clj
+++ b/test/raster/compiler/backend/gpu/c_emit_test.clj
@@ -10,8 +10,18 @@
                 (with-meta 'renamed {:raster.type/tag 'long}) {} :float)))
   (is (= :byte (c-emit/scalar-parameter-dtype
                 (with-meta 'packed {:raster.type/tag 'byte}) {} :float)))
-  (is (= :int (c-emit/scalar-parameter-dtype 'row-count {} :float)))
-  (is (= :double (c-emit/scalar-parameter-dtype 'scale {} :double)))
+  ;; A floating tag specializes to the kernel dtype, as a declared floating param does, so host
+  ;; encoding and kernel declaration agree on width.
+  (is (= :float (c-emit/scalar-parameter-dtype
+                 (with-meta 'scale {:raster.type/tag 'double}) {} :float)))
+  ;; No declaration and no tag: refused with a structured reason, never guessed from the name
+  ;; or from the kernel dtype.
+  (is (= :kernel-scalar-dtype-unknown
+         (try (c-emit/scalar-parameter-dtype 'row-count {} :float)
+              (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
+  (is (= :kernel-scalar-dtype-unknown
+         (try (c-emit/scalar-parameter-dtype 'scale {} :double)
+              (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))
   (is (= "long"
          (binding [c-emit/*scalar-var-types* {'iteration "long"}
                    c-emit/*int-vars* #{'iteration}]

--- a/test/raster/compiler/backend/gpu/gpu_correctness_test.clj
+++ b/test/raster/compiler/backend/gpu/gpu_correctness_test.clj
@@ -51,8 +51,12 @@
      (println "  [SKIP] No Level Zero GPU")))
 
 ;; Helper: generate kernel and extract source
-(defn- map-kernel-src [form]
-  (:source (first (:kernels (opencl-pass/opencl-pass form :min-elements 0)))))
+(defn- map-kernel-src
+  "Emit one map kernel from a bare par form. An isolated emitter test has no deftm to declare
+   its captured scalars, so it states their dtypes explicitly; the emitters refuse to guess."
+  [form & {:keys [scalar-types]}]
+  (:source (first (:kernels (opencl-pass/opencl-pass form :min-elements 0
+                                                     :scalar-types scalar-types)))))
 
 (defn- map-void-kernel-src [form]
   (:source (par-opencl/generate-par-map-void-kernel form)))
@@ -207,7 +211,8 @@
     (let [src (map-kernel-src
                '(raster.par/map! out i n double
                                  (clojure.core/+ (clojure.core/* a (aget x i))
-                                                 (clojure.core/* b (Math/pow (aget x i) beta)))))]
+                                                 (clojure.core/* b (Math/pow (aget x i) beta))))
+               :scalar-types '{a :double b :double beta :double})]
       (is (str/includes? src "pow("))
       (is (str/includes? src "x["))
       (is (str/includes? src "out_["))))

--- a/test/raster/compiler/backend/gpu/hip_compile_gate_test.clj
+++ b/test/raster/compiler/backend/gpu/hip_compile_gate_test.clj
@@ -51,17 +51,22 @@
   "[label form opts] — arith, scalar broadcast, device math, float, fma, the abs/max/min double
    overrides (hip-config), and an integer body."
   [["add-double"   '(raster.par/map! out i n double (+ (aget a i) (aget b i)))          {}]
-   ["scalar-mul"   '(raster.par/map! out i n double (* alpha (aget a i)))               {}]
+   ;; captured scalars are declared: an isolated emitter test has no deftm to type them and
+   ;; the emitters refuse to guess
+   ["scalar-mul"   '(raster.par/map! out i n double (* alpha (aget a i)))
+    {:scalar-types {'alpha :double}}]
    ["device-math"  '(raster.par/map! out i n double (Math/sin (aget a i)))              {}]
    ["abs-double"   '(raster.par/map! out i n double (Math/abs (aget a i)))              {}]
-   ["clamp-double" '(raster.par/map! out i n double (Math/max (aget a i) (Math/min (aget b i) c))) {}]
+   ["clamp-double" '(raster.par/map! out i n double (Math/max (aget a i) (Math/min (aget b i) c)))
+    {:scalar-types {'c :double}}]
    ["long-scalar"  '(raster.par/map! out i n double (+ (aget a i) (* 0.0 iteration)))
     {:scalar-types {'iteration :long}}]
    ["add-float"    '(raster.par/map! out i n float  (+ (aget a i) (aget b i)))          {:dtype :float}]
    ["fma-float"    '(raster.par/map! out i n float  (+ (* (aget a i) (aget b i)) (aget c i))) {:dtype :float}]])
 
 (def ^:private void-kernels
-  [["axpy-void"   '(raster.par/map-void! i n (raster.arrays/aset y i (+ (aget y i) (* alpha (aget x i))))) {:dtype :float}]
+  [["axpy-void"   '(raster.par/map-void! i n (raster.arrays/aset y i (+ (aget y i) (* alpha (aget x i)))))
+    {:dtype :float :scalar-types {'alpha :float}}]
    ;; a let-BOUND integer index: without *int-vars* seeding `base` infers the float scalar-type and
    ;; becomes a non-integer array subscript → compile error. Guards the emit-stmt/*int-vars* path.
    ["let-index-void" '(raster.par/map-void! i n (let [base (* i 2)]

--- a/test/raster/compiler/coverage_corpus_test.clj
+++ b/test/raster/compiler/coverage_corpus_test.clj
@@ -1,0 +1,26 @@
+(ns raster.compiler.coverage-corpus-test
+  "Typed-route coverage ratchet over the deftm corpus.
+
+   Runs wherever an OpenCL device is present (the CI CPU OpenCL gate, or a local GPU). The
+   committed baseline lists every corpus var's route and declines; this test fails when a var
+   leaves the typed route or starts failing, and prints the new declines so the regression is
+   named at the PR that introduced it. Refresh the baseline with
+   `scripts/update-coverage-baseline.sh` after an intended change."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.coverage :as coverage]
+            [raster.gpu.device-probe :as device-probe]))
+
+(deftest corpus-does-not-leave-the-typed-route
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "typed-route coverage corpus")
+    (let [baseline (coverage/read-baseline coverage/default-baseline-path)
+          report (coverage/corpus-report {:target-device :ocl:0 :dtype :float})
+          violations (coverage/ratchet-violations baseline report)]
+      (println "  [coverage] summary:" (pr-str (:summary report)))
+      (testing "every var that took the typed route still does, and no var started failing"
+        (is (empty? violations)
+            (with-out-str
+              (doseq [v violations]
+                (println "  coverage regression:" (pr-str v))))))
+      (testing "the corpus compiled for a real device"
+        (is (pos? (:total (:summary report))))))))

--- a/test/raster/compiler/segop_boundary_test.clj
+++ b/test/raster/compiler/segop_boundary_test.clj
@@ -96,7 +96,8 @@
                     (slp/schedule-single-operation 'out source opts))
         operation (first (:operations scheduled))
         emitted ((requiring-resolve 'raster.compiler.backend.gpu.opencl-pass/opencl-pass)
-                 source :dtype :float :device-id :ze:0 :min-elements 0)]
+                 source :dtype :float :device-id :ze:0 :min-elements 0
+                 :scalar-types (:scalar-types opts) :array-types (:array-types opts))]
     (is (some? (:algorithm scheduled)))
     (is (= :typed-soac (get-in operation [:algorithm-dialect])))
     (is (= :unique (:write-conflict operation)))

--- a/test/resources/coverage/gpu-corpus.edn
+++ b/test/resources/coverage/gpu-corpus.edn
@@ -1,0 +1,985 @@
+{:target-device :ocl:0,
+ :dtype :float,
+ :summary
+ {:total 236,
+  :typed-soac 78,
+  :error 47,
+  :scalar 84,
+  :compatibility 27},
+ :vars
+ [{:var raster.dl.array-ops/argmax-rows!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.array-ops/array-add,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.array-ops/array-add-backward,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.array-ops/array-copy,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:java.lang.System{arraycopy 1} e.g. ["}
+  {:var raster.dl.array-ops/blit-slab!,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/broadcast-add,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/broadcast-add-dh,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:java.lang.System{arraycopy 1} e.g. ["}
+  {:var raster.dl.array-ops/broadcast-add-dt,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/broadcast-kv-heads,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.array-ops/dot-rows,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/dot-rows-dW,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/dot-rows-dbias,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_251158 = (loop*"}
+  {:var raster.dl.array-ops/dot-rows-dh,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/flat-embed-d-space-emb,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/flat-embed-d-state-emb,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/flat-embed-d-values,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/flat-embed-dWe,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/flat-embed-dbe,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/flat-embed-op,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/gather,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.array-ops/gather-blocks!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.array-ops/gather-rows!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.array-ops/indexed-dot,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/indexed-dot-dA,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/indexed-dot-dB,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/masked-mse-loss,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/masked-mse-loss-backward,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_255553 = (if (cloj"}
+  {:var raster.dl.array-ops/pack-heads,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.array-ops/reduce-axis,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/reduce-axis-backward,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/scale-clamp-exp,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.array-ops/scale-clamp-exp-backward,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:clojure.core{>= 1} e.g. [\"(and__5598"}
+  {:var raster.dl.array-ops/scatter-add,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :no-lowering-rule, :kind :segops-declined}
+    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+  {:var raster.dl.array-ops/scatter-blocks!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.array-ops/scatter-mul-add,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/scatter-mul-add-d-coeffs,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/scatter-mul-add-d-src,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/scatter-strided-2d,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/segment-div,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/segment-div-dZ,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/segment-div-dwV,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/segment-div-jvp-dZ,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/slice-strided-2d,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.array-ops/sum-kv-heads,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.array-ops/unpack-heads,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.attention/attn-prefill-out!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.attention/attn-prefill-scores!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.attention/attn-prefill-scores-bidir!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.attention/attn-prefill-scores-windowed!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.attention/attn-prefill-softmax!,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :no-lowering-rule, :kind :segops-declined}
+    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+  {:var raster.dl.attention/batched-causal-attn-dsum,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.attention/batched-causal-attn-dw,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.attention/batched-causal-attn-weights,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.attention/batched-causal-sdpa,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.attention/batched-causal-sdpa-dk,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.attention/batched-causal-sdpa-dq,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.attention/batched-causal-sdpa-dv,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.attention/causal-attn-with-cache!,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.attention/causal-multi-head-attention,
+   :route :error,
+   :error :illegal-op-remains}
+  {:var raster.dl.attention/causal-multi-head-attention-cached!,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.attention/causal-scaled-dot-product-attn,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:raster.linalg.blas{dgemm!_m_floats_f"}
+  {:var raster.dl.attention/causal-scaled-dot-product-attn-dk,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :no-lowering-rule, :kind :segops-declined}
+    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+  {:var raster.dl.attention/causal-scaled-dot-product-attn-dq,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :no-lowering-rule, :kind :segops-declined}
+    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+  {:var raster.dl.attention/causal-scaled-dot-product-attn-dv,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :no-lowering-rule, :kind :segops-declined}
+    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+  {:var raster.dl.attention/causal-scaled-dot-product-attn-jvp,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.attention/causal-single-head-attention,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:raster.linalg.blas{dgemm!_m_floats_f"}
+  {:var raster.dl.attention/fast-exp,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.attention/gqa-causal-attention,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.attention/gqa-causal-mha,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.attention/gqa-causal-mha-jvp,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.attention/gqa-decode-attention,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.attention/gqa-decode-attention-buf!,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :no-lowering-rule, :kind :segops-declined}
+    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+  {:var raster.dl.attention/gqa-decode-attention-gpu!,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_ = (loop* [j 0] (if"}
+  {:var raster.dl.attention/gqa-decode-attention-heads!,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_ = (loop* [j j0] (i"}
+  {:var raster.dl.attention/gqa-decode-attention-weights!,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.attention/graph-attention,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 4 non-exempt untagged binding(s) #:raster.linalg.blas{dgemm!_m_doubles_"}
+  {:var raster.dl.attention/kv-append!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.attention/kv-append-buf!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.attention/multi-head-attention,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :unsupported-scalar-binding, :kind :typed-soac-declined}]}
+  {:var raster.dl.attention/rope,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :no-lowering-rule, :kind :segops-declined}
+    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+  {:var raster.dl.attention/rope-backward-dx,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :no-lowering-rule, :kind :segops-declined}
+    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+  {:var raster.dl.attention/rope-pos,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.attention/rope-pos-partial!,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.attention/rope-pos-rows-buf!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.attention/rope-prefill!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.attention/scaled-dot-product-attn,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:raster.linalg.blas{dgemm!_m_floats_f"}
+  {:var raster.dl.attention/scaled-dot-product-attn-dk,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :no-lowering-rule, :kind :segops-declined}
+    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+  {:var raster.dl.attention/scaled-dot-product-attn-dq,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :no-lowering-rule, :kind :segops-declined}
+    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+  {:var raster.dl.attention/scaled-dot-product-attn-dv,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :no-lowering-rule, :kind :segops-declined}
+    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+  {:var raster.dl.attention/scaled-dot-product-attn-jvp,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.attention/sinusoidal-embedding,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.attention/softmax-rows!,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :unsupported-scalar-binding, :kind :typed-soac-declined}]}
+  {:var raster.dl.diffusion/compute-alphas-cumprod,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_267659 = (loop*"}
+  {:var raster.dl.diffusion/cosine-beta-schedule,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 0 non-exempt untagged binding(s) {}; 6 undevirtualized dispatch call(s)"}
+  {:var raster.dl.diffusion/ddpm-sample-step,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.diffusion/forward-noise,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.diffusion/forward-noise-backward,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.diffusion/linear-beta-schedule,
+   :route :error,
+   :error :kernel-body-store-dtype}
+  {:var raster.dl.diffusion/predict-x0,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.loss/cross-entropy-loss,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.loss/cross-entropy-loss-backward,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.loss/huber-loss,
+   :route :error,
+   :error :illegal-op-remains}
+  {:var raster.dl.loss/huber-loss-backward,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.loss/l1-loss,
+   :route :error,
+   :error :illegal-op-remains}
+  {:var raster.dl.loss/l1-loss-backward,
+   :route :error,
+   :error :kernel-body-opencl-intrinsic}
+  {:var raster.dl.loss/mse-grad,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.loss/mse-loss,
+   :route :error,
+   :error :illegal-op-remains}
+  {:var raster.dl.nn/add-bias-rows!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/batch-norm,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_128636 = (if (cloj"}
+  {:var raster.dl.nn/batch-norm-backward-dbeta,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/batch-norm-backward-dgamma,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/batch-norm-backward-dx,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/batch-norm-jvp-dx,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/col2im-1d,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:clojure.core{>= 1} e.g. [\"(and__5598"}
+  {:var raster.dl.nn/col2im-2d,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) #:clojure.core{>= 2, < 1} e.g. [\"(and_"}
+  {:var raster.dl.nn/col2im-2d!,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 7 non-exempt untagged binding(s) {if 1, clojure.core/== 3, clojure.core"}
+  {:var raster.dl.nn/conv1d,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 2 non-exempt untagged binding(s) {raster.linalg.blas/dgemm!_m_floats_fl"}
+  {:var raster.dl.nn/conv1d-backward-dW,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:clojure.core{>= 1} e.g. [\"(and__5598"}
+  {:var raster.dl.nn/conv1d-backward-db,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/conv1d-backward-dx,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:clojure.core{>= 1} e.g. [\"(and__5598"}
+  {:var raster.dl.nn/conv1d-cl,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:clojure.core{>= 1} e.g. [\"(and__5598"}
+  {:var raster.dl.nn/conv2d,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 4 non-exempt untagged binding(s) {raster.linalg.blas/dgemm!_m_floats_fl"}
+  {:var raster.dl.nn/conv2d-backward-dW-into!,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/conv2d-backward-db-into!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/conv2d-backward-dcols-into!,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/conv2d-rearrange-dy!,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/dropout,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/dropout-backward,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/embedding,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/embedding-backward,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/geglu,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :unsupported-scalar-binding, :kind :typed-soac-declined}]}
+  {:var raster.dl.nn/gelu,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/gelu!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/gelu-backward,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/gelu-erf!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/gelu-mul!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/gelu-second-deriv,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/generate-dropout-mask,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/group-norm,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/group-norm-backward-dbeta,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/group-norm-backward-dgamma,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/group-norm-backward-dx,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/group-norm-jvp-dx,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/hadamard,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/hadamard-backward,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/he-init,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 0 non-exempt untagged binding(s) {}; 1 undevirtualized dispatch call(s)"}
+  {:var raster.dl.nn/im2col-1d,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:clojure.core{>= 1} e.g. [\"(and__5598"}
+  {:var raster.dl.nn/im2col-1d-cl,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:clojure.core{>= 1} e.g. [\"(and__5598"}
+  {:var raster.dl.nn/im2col-2d,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) #:clojure.core{>= 2, < 1} e.g. [\"(and_"}
+  {:var raster.dl.nn/im2col-2d!,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 7 non-exempt untagged binding(s) {if 1, clojure.core/== 3, clojure.core"}
+  {:var raster.dl.nn/l2-normalize!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/layer-norm,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/layer-norm!,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :no-lowering-rule, :kind :segops-declined}
+    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+  {:var raster.dl.nn/layer-norm-backward-dbeta,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/layer-norm-backward-dgamma,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/layer-norm-backward-dx,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(sums = (loop* [i 0 s"}
+  {:var raster.dl.nn/layer-norm-jvp-dx,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/leaky-relu,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/leaky-relu!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/leaky-relu-backward,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/linear,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/linear!,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/linear-dW,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/linear-db,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/linear-dx,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/linear-nb,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/matmul,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/matmul!,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/matmul-dA,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/matmul-dA!,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/matmul-dB,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/matmul-dB!,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/maxpool2d,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/maxpool2d!,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/maxpool2d-bwd!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/mean-pool,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/residual-add,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/residual-add!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/residual-add-backward,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/rms-norm,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :no-lowering-rule, :kind :segops-declined}
+    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+  {:var raster.dl.nn/rms-norm!,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :no-lowering-rule, :kind :segops-declined}
+    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+  {:var raster.dl.nn/rms-norm-1row!,
+   :route :error,
+   :error :parallel-program-parameter-role-conflict}
+  {:var raster.dl.nn/rms-norm-backward-dweight,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :no-lowering-rule, :kind :segops-declined}
+    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+  {:var raster.dl.nn/rms-norm-backward-dx,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :no-lowering-rule, :kind :segops-declined}
+    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+  {:var raster.dl.nn/rms-norm-chunked,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/rms-norm-chunked-backward-dx,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/rms-norm-jvp-dx,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/sigmoid,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/sigmoid-backward,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/silu,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/silu-backward,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/silu-mul!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/silu-second-deriv,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/skip-layer-norm,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/softmax-1d,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :typed-soac-unknown-value, :kind :typed-soac-declined}]}
+  {:var raster.dl.nn/softmax-1d-backward,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/swiglu,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :unsupported-scalar-binding, :kind :typed-soac-declined}]}
+  {:var raster.dl.nn/tanh-act,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/tanh-act-backward,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.nn/transpose-2d,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/transpose-2d!,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.nn/xavier-init,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 0 non-exempt untagged binding(s) {}; 1 undevirtualized dispatch call(s)"}
+  {:var raster.dl.optim/adam-step!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.optim/adamw-step!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.optim/clip-grad-norm!,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_265099 = (if (.inv"}
+  {:var raster.dl.optim/cosine-lr,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 0 non-exempt untagged binding(s) {}; 2 undevirtualized dispatch call(s)"}
+  {:var raster.dl.optim/ema-update!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.optim/linear-warmup-lr,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.optim/sgd-step!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.dl.optim/step-lr,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.dl.optim/warmup-cosine-lr,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.nn/cross-entropy,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.nn/cross-entropy-backward-dp,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.nn/dense,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.nn/dense-backward-dW,
+   :route :compatibility,
+   :typed-validated false,
+   :declines []}
+  {:var raster.nn/dense-backward-dW-into!,
+   :route :compatibility,
+   :typed-validated false,
+   :declines []}
+  {:var raster.nn/dense-backward-db,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:clojure.core{aclone 1} e.g. [\"(body_"}
+  {:var raster.nn/dense-backward-db-into!,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:java.lang.System{arraycopy 1} e.g. ["}
+  {:var raster.nn/dense-backward-dx,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :typed-soac-unknown-value, :kind :typed-soac-declined}]}
+  {:var raster.nn/dense-backward-dx-into!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.nn/dense-into!,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:java.lang.System{arraycopy 1} e.g. ["}
+  {:var raster.nn/kaiming-init!,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_277861 = \\\"Kaim"}
+  {:var raster.nn/loss-fn,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :unsupported-scalar-binding, :kind :typed-soac-declined}]}
+  {:var raster.nn/predict-fn,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.nn/relu,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.nn/relu-backward,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.nn/softmax,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :unsupported-scalar-binding, :kind :typed-soac-declined}]}
+  {:var raster.nn/softmax-backward,
+   :route :error,
+   :error :parallel-program-parameter-role-conflict}
+  {:var raster.nn/softmax-cross-entropy,
+   :route :compatibility,
+   :typed-validated false,
+   :declines
+   [{:reason :unsupported-scalar-binding, :kind :typed-soac-declined}]}
+  {:var raster.nn/softmax-cross-entropy-backward,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.nn/xavier-init!,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_284633 = \\\"Xavi"}
+  {:var raster.ode.pde/heat-loss-rk4,
+   :route :error,
+   :error :emitted-parallel-program-call-required}
+  {:var raster.ode.pde/heat-rhs-1d!,
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
+  {:var raster.ode.pde/heat-rhs-2d!,
+   :route :scalar,
+   :typed-validated false,
+   :declines []}
+  {:var raster.ode.pde/solve-fixed-step,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 0 non-exempt untagged binding(s) {}; 1 undevirtualized dispatch call(s)"}
+  {:var raster.ode.pde/wave-rhs-1d!,
+   :route :error,
+   :error
+   "fixpoint edge typedness violation on GPU target: 2 non-exempt untagged binding(s) #:clojure.core{aset 2} e.g. [\"(_eff_30"}]}


### PR DESCRIPTION
## Coverage ratchet (item 5 of the compiler-quality plan)
`raster.compiler.coverage` compiles every source deftm in the DL substrate, NN primitives and PDE surface through the diagnostic pipeline for an OpenCL device and records route, declines by reason and errors. Baseline on PoCL: 236 functions, 78 typed, 84 scalar-only, 27 compatibility, 47 erroring (38 of those are the fixpoint typedness census on functions never written for GPU). The test runs in the CI CPU OpenCL gate; a function may not leave the typed route or start failing. `scripts/update-coverage-baseline.sh` refreshes it.

## No silent scalar dtype defaults (item 2)
SegMap body int default, C emitter name regex + kernel-dtype fallback, index emitter int default, exclusive-scan dtype default: all become declines/errors naming the value. The OpenCL pass forwards walker-stamped dtypes of every let/loop/dotimes binder so typed scalars still reach the backends. The ratchet caught the two functions that depended on the name guess (a dotimes counter) and the binder rule restored them; the ratchet reports zero violations and the GPU/CPU suites are green locally.

https://claude.ai/code/session_01Vtm1xB9JmpaxJMEWCAcQWm