### PR TITLE
Typed effect maps with store loops; BLAS GEMMs as typed contractions

### DIFF
--- a/src/raster/compiler/backend/gpu/c_emit.clj
+++ b/src/raster/compiler/backend/gpu/c_emit.clj
@@ -372,7 +372,7 @@
 
 (def element-tag->c
   "Map primitive element-tag to C type string."
-  {'double "double" 'float "float" 'long "long" 'int "int" 'byte "int8_t"})
+  {'double "double" 'float "float" 'long "long" 'int "int" 'byte "int8_t" 'short "int16_t"})
 
 ;; ================================================================
 ;; Symbol mangling
@@ -994,7 +994,7 @@
 
      ;; Primitive cast
      (and (seq? expr)
-          (contains? #{'double 'float 'long 'int} (first expr))
+          (contains? #{'double 'float 'long 'int 'byte 'short} (first expr))
           (= 2 (count expr)))
      ;; Vectorizing: a cast the walker inserted around a now-vector expr. An element-type
      ;; cast MATCHING the element type (e.g. `(double x)` where x is a double vload) is a
@@ -1005,7 +1005,9 @@
        (if (= (name (first expr)) *scalar-type*)
          (emit-expr (second expr) idx-sym array-syms opencl-idx)
          (throw (ex-info "vector precision cast" {:raster.compiler.backend.gpu.c-emit/bail true})))
-       (emit-cast (remap-type (name (first expr)))
+       (emit-cast (let [tag (name (first expr))]
+                    ;; Narrow integer casts name JVM scalar tags; C spells them by width.
+                    (get {"byte" "int8_t" "short" "int16_t"} tag (remap-type tag)))
                   (emit-expr (second expr) idx-sym array-syms opencl-idx)))
 
      ;; TypedSOAC scalar Fold. It remains a semantic term through scheduling;
@@ -1708,7 +1710,7 @@
                                     'clojure.core/alength
                                     'if 'when 'cond 'case 'case* 'loop 'loop* 'recur
                                     'fn 'fn* 'quote 'new 'throw 'try
-                                    'double 'float 'long 'int
+                                    'double 'float 'long 'int 'byte 'short
                                     'Math/sin 'Math/cos 'Math/exp 'Math/log
                                     'Math/sqrt 'Math/abs 'Math/pow 'Math/max
                                     'Math/min 'Math/fma 'Math/atan2
@@ -1990,9 +1992,10 @@
 
 (def ^:private quot-ops #{'quot 'clojure.core/quot})
 (def ^:private rem-ops  #{'rem 'clojure.core/rem 'mod 'clojure.core/mod})
-(def ^:private prim-cast-ops #{'double 'float 'long 'int
+(def ^:private prim-cast-ops #{'double 'float 'long 'int 'byte 'short
                                'clojure.core/double 'clojure.core/float
-                               'clojure.core/long 'clojure.core/int})
+                               'clojure.core/long 'clojure.core/int
+                               'clojure.core/byte 'clojure.core/short})
 (def ^:private idx-cast-ops #{'long 'int 'clojure.core/long 'clojure.core/int})
 
 (defn- sym-occurs?

--- a/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
+++ b/src/raster/compiler/backend/gpu/kernel_body_opencl.clj
@@ -867,13 +867,20 @@
                            :source-type source-type :result-type result-type
                            :rounding rounding :overflow overflow}))))
 
-      ;; Saturating FP->integer conversion and wrapping integral conversion have direct spellings.
-      (or (and source-fp? (not result-fp?) (= :saturate overflow))
-          (and (not source-fp?) (not result-fp?) (= :wrap overflow)))
+      ;; Wrapping integral conversion: OpenCL spells it `convert_T`; on CUDA and HIP the plain C
+      ;; cast between two's-complement integer types is the same modular truncation.
+      (and (not source-fp?) (not result-fp?) (= :wrap overflow))
       (if (c-dialect/opencl? *scalar-dialect*)
         (str "convert_" (target-type result-type) (cast-suffix rounding overflow)
              "(" argument-source ")")
-        (throw (ex-info "CUDA/HIP cannot preserve this saturating or wrapping cast policy"
+        (str "(" (target-type result-type) ")(" argument-source ")"))
+
+      ;; Saturating FP->integer conversion has a direct OpenCL spelling only.
+      (and source-fp? (not result-fp?) (= :saturate overflow))
+      (if (c-dialect/opencl? *scalar-dialect*)
+        (str "convert_" (target-type result-type) (cast-suffix rounding overflow)
+             "(" argument-source ")")
+        (throw (ex-info "CUDA/HIP cannot preserve this saturating cast policy"
                         {:reason :kernel-body-c-cast-policy
                          :dialect (:id *scalar-dialect*)
                          :source-type source-type :result-type result-type

--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -7,7 +7,8 @@
 
    This is the GPU counterpart of simd-pass — both consume the same
    par form vocabulary but produce different target code."
-  (:require [clojure.set :as set]
+  (:require [raster.compiler.core.util :as util]
+            [clojure.set :as set]
             [clojure.walk :as walk]
             [raster.compiler.ir.form :as form]
             [raster.compiler.ir.par :as par]
@@ -612,9 +613,12 @@
                   typed-dispatch
                   (when bound-sr
                     (try
+                      ;; The scheduled SegRed carries its equation's dtype; a double contraction
+                      ;; inside a float program routes at its own precision, not the program's.
                       (croute/route-static-typed-contraction-dispatch
                        typed-algorithm bound-sr
-                       :dtype dtype :tile (:tile schedule) :desc target-desc)
+                       :dtype (:dtype bound-sr) :tile (:tile schedule) :desc target-desc
+                       :precision (:precision schedule))
                       (catch clojure.lang.ExceptionInfo exception
                         (let [reason (:reason (ex-data exception))]
                           (if (contains? #{:typed-contraction-dispatch-dynamic-scalar
@@ -659,7 +663,8 @@
                          (if bound-sr
                            (croute/route-typed-contraction
                             typed-algorithm bound-sr
-                            :dtype dtype :tile (:tile schedule) :desc target-desc)
+                            :dtype (:dtype bound-sr) :tile (:tile schedule) :desc target-desc
+                            :precision (:precision schedule))
                            (croute/route-contraction
                             ;; A compatibility equation routes from its verified facts. Without a
                             ;; scheduled operation, the direct backend door still consumes the form.
@@ -935,7 +940,13 @@
                 rebuilt))
 
             :else form))]
-    {:form (transform source-form)
+    ;; Every declared value id is a local of the compiled form, even one spelled like a
+    ;; `clojure.core` name (a parameter called `seq`): free-symbol analysis inside the emitters
+    ;; must read it as a kernel scalar, never as the core function.
+    {:form (binding [util/*shadowing-locals*
+                     (set (concat (keys top-scalar-types) (keys top-array-types)
+                                  (keys (:values parallel-program))))]
+             (transform source-form))
      :stats @stats
      :kernels @kernels
      :dispatches @dispatches}))

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -66,6 +66,14 @@
   [segmap & {:keys [dtype kernel-name-prefix scalar-types array-types]
              :or {dtype :float kernel-name-prefix "segmap_effect"
                   scalar-types {} array-types {}}}]
+  ;; This generator consumes only a source-shaped lambda. A typed scalar region carries no
+  ;; source spelling, and emitting its absence as an empty body would be a silent miscompile.
+  (when (nil? (:lambda segmap))
+    (throw (ex-info "explicit-store SegMap emission requires a source-shaped lambda"
+                    {:reason :explicit-segmap-requires-source-lambda
+                     :operation (:id segmap)
+                     :scalar-region (some-> (:scalar-region segmap) keys vec)
+                     :fallback :none})))
   (let [idx (seg-idx segmap)
         bound (seg-bound segmap)
         body (ce/normalize-array-prims (:lambda segmap))

--- a/src/raster/compiler/backend/jvm/segop_simd.clj
+++ b/src/raster/compiler/backend/jvm/segop_simd.clj
@@ -978,7 +978,19 @@
           strip-binder-tags
           (fn [form]
             (clojure.walk/postwalk
-             (fn [x] (if (and (symbol? x) (:tag (meta x))) (vary-meta x dissoc :tag) x))
+             (fn [x]
+               (if (and (seq? x) (contains? #{'let* 'loop*} (first x)) (vector? (second x)))
+                 (with-meta
+                   (list* (first x)
+                          (vec (map-indexed (fn [ordinal item]
+                                              (if (and (even? ordinal) (symbol? item)
+                                                       (:tag (meta item)))
+                                                (vary-meta item dissoc :tag)
+                                                item))
+                                            (second x)))
+                          (nnext x))
+                   (meta x))
+                 x))
              form))
           materialize-locals
           (fn [locals body]
@@ -1011,9 +1023,13 @@
                   destination-dtype (or dtype (when reduction? (:dtype conflict)))
                   scalar-tag (when destination-dtype
                                (dtype/scalar-tag-for-dtype destination-dtype))
+                  ;; The destination is an array: its tag is the primitive-array tag, so the
+                  ;; bytecode compiler emits a typed array store instead of a boxed aastore.
+                  array-tag (when destination-dtype
+                              (dtype/array-tag-for-dtype destination-dtype))
                   destination (if destination-dtype
                                 (with-meta destination
-                                  {:tag scalar-tag :raster.type/tag scalar-tag})
+                                  {:tag array-tag :raster.type/tag array-tag})
                                 destination)
                   value (if scalar-tag (list scalar-tag value) value)
                   store (if reduction?

--- a/src/raster/compiler/backend/jvm/segop_simd.clj
+++ b/src/raster/compiler/backend/jvm/segop_simd.clj
@@ -972,8 +972,41 @@
           n-sym (gensym "effect_n__")
           j-sym (gensym "effect_i__")
           {:keys [locals effects]} (:scalar-region segmap)
+          ;; Typed locals are materialized as explicit casts; source binder tags inside their
+          ;; initializers (a walker `^double v` over a primitive init) would make the JVM compiler
+          ;; refuse the form, so the tags are dropped here and the casts carry the types.
+          strip-binder-tags
+          (fn [form]
+            (clojure.walk/postwalk
+             (fn [x] (if (and (symbol? x) (:tag (meta x))) (vary-meta x dissoc :tag) x))
+             form))
+          materialize-locals
+          (fn [locals body]
+            (if (seq locals)
+              (list 'let*
+                    (vec (mapcat (fn [{:keys [id dtype init]}]
+                                   (let [tag (dtype/scalar-tag-for-dtype dtype)]
+                                     [(with-meta id {:raster.type/tag tag})
+                                      (list tag (strip-binder-tags init))]))
+                                 locals))
+                    body)
+              body))
           effect-statement
-          (fn [{:keys [destination dtype conflict destination-index predicate value]}]
+          (fn effect-statement
+            [{:keys [destination dtype conflict destination-index predicate value] :as effect}]
+            (if-let [{loop-index :index loop-locals :locals loop-effects :effects
+                      :keys [lower extent]} (:loop effect)]
+              (let [loop-n (gensym "effect_loop_n__")]
+                (list 'let* [loop-n (list 'int extent)]
+                      (list 'loop* [loop-index (list 'int lower)]
+                            (list 'if (ix< loop-index loop-n)
+                                  (list 'do
+                                        (materialize-locals
+                                         loop-locals
+                                         (list* 'do (mapv effect-statement loop-effects)))
+                                        (list 'recur
+                                              (list 'clojure.core/unchecked-inc-int loop-index)))
+                                  nil))))
             (let [reduction? (soac-dialect/reducing-scatter-conflict? conflict)
                   destination-dtype (or dtype (when reduction? (:dtype conflict)))
                   scalar-tag (when destination-dtype
@@ -988,20 +1021,10 @@
                           (list 'clojure.core/aset destination destination-index value))]
               (if (contains? #{true 1} predicate)
                 store
-                (list 'if predicate store))))
+                (list 'if predicate store)))))
           typed-region-body
           (when (seq effects)
-            (let [statements (mapv effect-statement effects)
-                  body (list* 'do statements)]
-              (if (seq locals)
-                (list 'let*
-                      (vec (mapcat (fn [{:keys [id dtype init]}]
-                                     (let [tag (dtype/scalar-tag-for-dtype dtype)]
-                                       [(with-meta id {:raster.type/tag tag})
-                                        (list tag init)]))
-                                   locals))
-                      body)
-                body)))
+            (materialize-locals locals (list* 'do (mapv effect-statement effects))))
           body (clojure.walk/postwalk
                 (fn [form] (if (= form index) j-sym form))
                 (bc/desugar-invk (or typed-region-body (:lambda segmap))))]

--- a/src/raster/compiler/ir/parallel_program.clj
+++ b/src/raster/compiler/ir/parallel_program.clj
@@ -235,9 +235,15 @@
   [program sym source]
   (:operations (equation-for-binding program sym source)))
 
+(defn- scheduled-algorithm
+  "The algorithm a target should schedule against: the physically remapped one when scheduling
+   recorded it (logical results replaced by the destinations they alias), else the semantic one."
+  [equation]
+  (or (:physical-algorithm equation) (:algorithm equation)))
+
 (defn algorithm-for-binding
   [program sym source]
-  (:algorithm (equation-for-binding program sym source)))
+  (scheduled-algorithm (equation-for-binding program sym source)))
 
 (defn result-id-for-binding
   "The explicit value ID produced by a binding equation, when it has one result."
@@ -250,7 +256,7 @@
 
 (defn algorithm-for-source
   [program source]
-  (:algorithm (equation-for-source program source)))
+  (scheduled-algorithm (equation-for-source program source)))
 
 (defn kernel-graph-for-binding
   [program sym source]

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -188,6 +188,15 @@
   [value]
   (or (contains? #{:unique :ordered} value) (reducing-scatter-conflict? value)))
 
+(defn effect-loop-attributes?
+  "The binder of a counted store loop inside an effect region: its index symbol and the integer
+   lower bound. The extent is a scalar operand of the form, so the grammar checks it."
+  [value]
+  (and (map? value)
+       (= #{:index :lower} (set (keys value)))
+       (symbol? (:index value))
+       (integer? (:lower value))))
+
 (defn effect-map-attributes?
   [value]
   (and (map-attributes? value)
@@ -456,6 +465,7 @@
              [xa scatter-attributes?]
              [ema effect-map-attributes?]
              [ec effect-conflict?]
+             [ela effect-loop-attributes?]
              [sta stencil-attributes?]
              [ra reduce-attributes?]
              [sra segmented-reduce-attributes?]
@@ -479,7 +489,8 @@
 
   (Effect [e :enforce]
           (effect ?sym:destination ?ec:conflict
-                  ?s:destination-index ?s:predicate ?s:value))
+                  ?s:destination-index ?s:predicate ?s:value)
+          (effect-loop ?ela ?s:extent ?el))
 
   (Local [d :enforce]
          (let-value ?sym:binding ?dt ?s:init))
@@ -605,17 +616,55 @@
     (let [[_ destination-index predicate written-value] value]
       {:destination-index destination-index :predicate predicate :value written-value})))
 
-(defn effect-form?
-  "Whether a typed ordered-effect region item has canonical syntax."
+(defn effect-loop-form?
+  "Whether an effect-region item is a counted store loop `(effect-loop attrs extent lambda)`."
   [value]
-  (and (seq? value) (= 'effect (first value)) (= 6 (count value))))
+  (and (seq? value) (= 'effect-loop (first value)) (= 4 (count value))))
+
+(defn effect-form?
+  "Whether a typed ordered-effect region item has canonical syntax: one store effect or one
+   counted loop of them."
+  [value]
+  (or (and (seq? value) (= 'effect (first value)) (= 6 (count value)))
+      (effect-loop-form? value)))
+
+(declare lambda-parts)
 
 (defn effect-parts
+  "Project one effect-region item. Store effects yield their destination, conflict contract,
+   index, predicate and value; loops yield `:loop true` with `:index`, `:lower`, `:extent` and
+   the `:lambda` whose single parameter is the loop index."
   [value]
-  (when (effect-form? value)
+  (cond
+    (effect-loop-form? value)
+    (let [[_ attributes extent lambda] value]
+      {:loop true :index (:index attributes) :lower (:lower attributes)
+       :extent extent :lambda lambda})
+
+    (effect-form? value)
     (let [[_ destination conflict destination-index predicate written-value] value]
       {:destination destination :conflict conflict
        :destination-index destination-index :predicate predicate :value written-value})))
+
+(defn effect-part-leaves
+  "The store effects of projected effect parts, descending into store loops."
+  [parts]
+  (vec (mapcat (fn [part]
+                 (if (:loop part)
+                   (effect-part-leaves
+                    (map effect-parts (:body-results (lambda-parts (:lambda part)))))
+                   [part]))
+               parts)))
+
+(defn effect-leaves
+  "The store effects of lowered effect maps (`{:loop {:effects […]}}` entries), descending into
+   store loops."
+  [effects]
+  (vec (mapcat (fn [effect]
+                 (if-let [loop (:loop effect)]
+                   (effect-leaves (:effects loop))
+                   [effect]))
+               effects)))
 
 (defn local-value
   "Construct one explicitly typed scalar-region SSA definition."
@@ -955,9 +1004,12 @@
               expression (cond
                            (= 'scatter kind) (vals (write-parts body))
                            (= 'effect-map kind)
-                           (let [{:keys [destination destination-index predicate value]}
+                           (let [{:keys [loop extent destination destination-index predicate
+                                         value]}
                                  (effect-parts body)]
-                             [destination destination-index predicate value])
+                             (if loop
+                               [extent]
+                               [destination destination-index predicate value]))
                            :else [body])
               :let [unbound (util/free-syms expression final-bound)]
               :when (seq unbound)]
@@ -988,8 +1040,34 @@
             destination-parameters (vec (take-last destination-count parameters))
             destination-set (set destination-parameters)
             effects (mapv effect-parts body-results)
-            by-destination (group-by :destination effects)
-            iteration-order (:iteration-order attributes)]
+            leaves (effect-part-leaves effects)
+            by-destination (group-by :destination leaves)
+            iteration-order (:iteration-order attributes)
+            region-bound (into (set parameters) (cons (:index attributes) (map :id locals)))]
+        (doseq [part effects :when (:loop part)]
+          (let [{loop-parameters :parameters loop-locals :locals :keys [body-results]}
+                (lambda-parts (:lambda part))
+                loop-bound (into region-bound (cons (:index part) (map :id loop-locals)))
+                inner (map effect-parts body-results)
+                extent-unbound (util/free-syms (:extent part) region-bound)
+                unbound (into #{}
+                              (mapcat #(util/free-syms % loop-bound))
+                              (concat (map :init loop-locals)
+                                      (mapcat (fn [{:keys [loop destination-index predicate value]}]
+                                                (when-not loop
+                                                  [destination-index predicate value]))
+                                              inner)))]
+            (when-not (and (= [(:index part)] loop-parameters)
+                           (every? some? inner)
+                           (not (some :loop inner))
+                           (seq inner)
+                           (empty? extent-unbound)
+                           (empty? unbound))
+              (fail! :typed-soac-effect-loop
+                     "effect loops are closed single-level counted regions over their loop index"
+                     {:equation equation-id :loop (:index part) :parameters loop-parameters
+                      :extent-unbound extent-unbound :unbound unbound
+                      :body body-results}))))
         (when-not (= result-count destination-count (count (:dtypes attributes)))
           (fail! :typed-soac-effect-results
                  "effect-map results, physical destinations, and dtypes must align"
@@ -1000,7 +1078,7 @@
                  "effect-map regions contain only canonical ordered effects"
                  {:equation equation-id :effects body-results}))
         (when (and (= :independent iteration-order)
-                   (some #(= :ordered (:conflict %)) effects))
+                   (some #(= :ordered (:conflict %)) leaves))
           (fail! :typed-soac-effect-iteration-order
                  "conflicting effects require sequential logical iteration"
                  {:equation equation-id :iteration-order iteration-order

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -1047,17 +1047,26 @@
         (doseq [part effects :when (:loop part)]
           (let [{loop-parameters :parameters loop-locals :locals :keys [body-results]}
                 (lambda-parts (:lambda part))
-                loop-bound (into region-bound (cons (:index part) (map :id loop-locals)))
+                loop-ids (mapv :id loop-locals)
+                ;; loop locals are ordered SSA: each initializer sees the index and the
+                ;; locals before it, never a later one
+                {:keys [bound local-unbound]}
+                (reduce (fn [{:keys [bound local-unbound]} {:keys [id init]}]
+                          {:bound (conj bound id)
+                           :local-unbound (into local-unbound (util/free-syms init bound))})
+                        {:bound (conj region-bound (:index part)) :local-unbound #{}}
+                        loop-locals)
                 inner (map effect-parts body-results)
                 extent-unbound (util/free-syms (:extent part) region-bound)
-                unbound (into #{}
-                              (mapcat #(util/free-syms % loop-bound))
-                              (concat (map :init loop-locals)
-                                      (mapcat (fn [{:keys [loop destination-index predicate value]}]
-                                                (when-not loop
-                                                  [destination-index predicate value]))
-                                              inner)))]
+                unbound (into local-unbound
+                              (mapcat #(util/free-syms % bound))
+                              (mapcat (fn [{:keys [loop destination-index predicate value]}]
+                                        (when-not loop
+                                          [destination-index predicate value]))
+                                      inner))]
             (when-not (and (= [(:index part)] loop-parameters)
+                           (= (count loop-ids) (count (distinct loop-ids)))
+                           (not (contains? region-bound (:index part)))
                            (every? some? inner)
                            (not (some :loop inner))
                            (seq inner)

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -16,7 +16,8 @@
    (int8 widening). Keys: :kernel-name :source :array-params (binding order) :dtype :out-dtype
    :out-elems :wg/:grid (uniform 1-3D geometry) :scalar-args [{:type :value}…] :dims, plus optional
    :fallback-reason, :scheme (quant decode) and :pre-steps (inserted layout rearranges)."
-  (:require [raster.compiler.core.op-descriptor :as od]
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.op-descriptor :as od]
             [clojure.string :as str]
             [raster.compiler.passes.parallel.contract-lower :as cl]
             [raster.compiler.backend.gpu.segop-opencl :as sco]
@@ -516,10 +517,14 @@
    `:f32-scalar` promises exact f32 arithmetic, so the `:matrix` family (f16 XMX / int8
    instruction inputs) is excluded; the default `:f16-xmx` policy admits every family. An
    unknown policy or a policy that leaves no family is a loud error, never a silent default."
-  [families precision operation-id]
+  [families precision dtype operation-id]
   (case precision
     (nil :f16-xmx) families
-    :f32-scalar (let [kept (vec (remove #{:matrix} families))]
+    ;; The matrix family covers f16 XMX products and exact int8 dp4a products; only the
+    ;; floating-point contractions lose exactness there, so integer contractions keep it.
+    :f32-scalar (let [kept (if (dtype/fp-dtype? (dtype/canon dtype))
+                             (vec (remove #{:matrix} families))
+                             families)]
                   (when (empty? kept)
                     (throw (ex-info "the :f32-scalar precision policy leaves no contraction family"
                                     {:reason :typed-contraction-precision
@@ -616,7 +621,7 @@
         options (apply hash-map options)
         families (families-for-precision
                   (validated-typed-contraction-families schedule operation-id)
-                  (:precision options) operation-id)
+                  (:precision options) dtype operation-id)
         _ (when (and (contains? options :dtype)
                      (not= dtype (:dtype options)))
             (throw (ex-info "typed contraction route dtype disagrees with its equation"
@@ -681,7 +686,7 @@
         schedule (reduction/validate-schedule! (:schedule operation))
         families (families-for-precision
                   (validated-typed-contraction-families schedule operation-id)
-                  (:precision (apply hash-map options)) operation-id)
+                  (:precision (apply hash-map options)) (:dtype operation) operation-id)
         results
         (mapv
          (fn [family]

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -510,6 +510,26 @@
           ;; specific :symbolic-dims / :non-plus-combine is the actual answer.
               (seq declines) (assoc :fallback-reason (:reason (last declines)))))))))))
 
+(defn- families-for-precision
+  "Restrict candidate families to the compile's precision policy.
+
+   `:f32-scalar` promises exact f32 arithmetic, so the `:matrix` family (f16 XMX / int8
+   instruction inputs) is excluded; the default `:f16-xmx` policy admits every family. An
+   unknown policy or a policy that leaves no family is a loud error, never a silent default."
+  [families precision operation-id]
+  (case precision
+    (nil :f16-xmx) families
+    :f32-scalar (let [kept (vec (remove #{:matrix} families))]
+                  (when (empty? kept)
+                    (throw (ex-info "the :f32-scalar precision policy leaves no contraction family"
+                                    {:reason :typed-contraction-precision
+                                     :operation operation-id :precision precision
+                                     :families families})))
+                  kept)
+    (throw (ex-info "unknown contraction precision policy"
+                    {:reason :typed-contraction-precision
+                     :operation operation-id :precision precision}))))
+
 (defn- validated-typed-contraction-families
   [schedule operation-id]
   (let [families (get-in schedule [:tuning-space :families])]
@@ -593,8 +613,10 @@
             (throw (ex-info "typed contraction requires a contraction candidate schedule"
                             {:reason :typed-contraction-schedule
                              :operation operation-id :schedule schedule})))
-        families (validated-typed-contraction-families schedule operation-id)
         options (apply hash-map options)
+        families (families-for-precision
+                  (validated-typed-contraction-families schedule operation-id)
+                  (:precision options) operation-id)
         _ (when (and (contains? options :dtype)
                      (not= dtype (:dtype options)))
             (throw (ex-info "typed contraction route dtype disagrees with its equation"
@@ -657,7 +679,9 @@
   [program operation & options]
   (let [operation-id (:id operation)
         schedule (reduction/validate-schedule! (:schedule operation))
-        families (validated-typed-contraction-families schedule operation-id)
+        families (families-for-precision
+                  (validated-typed-contraction-families schedule operation-id)
+                  (:precision (apply hash-map options)) operation-id)
         results
         (mapv
          (fn [family]

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -279,6 +279,17 @@
                               "scalar loop is outside the canonical ordered carry form"
                               {:expression expression}))
 
+                  ;; `inc`/`dec` are the closed-core index steppers: `(+ x 1)` / `(- x 1)` with the
+                  ;; same operand dtype and overflow policy. Normalize before intrinsic lookup so
+                  ;; the KernelBody vocabulary stays binary.
+                  (and (seq? expression) (= 2 (count expression))
+                       (contains? '#{inc clojure.core/inc} (first expression)))
+                  (lower (list 'clojure.core/+ (second expression) 1) expected env)
+
+                  (and (seq? expression) (= 2 (count expression))
+                       (contains? '#{dec clojure.core/dec} (first expression)))
+                  (lower (list 'clojure.core/- (second expression) 1) expected env)
+
                   (seq? expression)
                   (let [semantic-operation (descriptor/semantic-op expression)
                         operator (intrinsics/canonical semantic-operation)

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -224,15 +224,23 @@
                     (do
                       (when (or (patterns/contains-sym? bound-expr index-sym)
                                 (patterns/contains-sym? bound-expr acc-sym)
-                                (not= else-expr acc-sym))
+                                (patterns/contains-sym? else-expr index-sym))
                         (decline! :ordered-loop-shape
-                                  "ordered scalar loop requires an invariant upper bound and returns its carry"
+                                  "ordered scalar loop requires an invariant upper bound and an exit over its carry"
                                   {:expression expression :bound bound-expr
                                    :index index-sym :accumulator acc-sym :exit else-expr}))
                       (let [loop-index (fresh "loop-index")
                             carry (fresh "loop-carry")
                             result (fresh "loop-result")
-                            initial (lower acc-init expected env)
+                            ;; `(loop [i 0 s init] (if (< i n) (recur (inc i) step) exit))` is the
+                            ;; ordered fold followed by `exit` over the final carry. The carry keeps
+                            ;; the step's own dtype so the exit's cast (e.g. `(double s)`) is an
+                            ;; explicit conversion rather than a silent widening of the fold.
+                            exit? (not= else-expr acc-sym)
+                            carry-type (if exit?
+                                         (canon-type (source-type update-expr expected env))
+                                         expected)
+                            initial (lower acc-init carry-type env)
                             loop-type (:type initial)
                             update (util/subst-syms {index-sym loop-index acc-sym carry}
                                                     update-expr)
@@ -257,9 +265,16 @@
                                   (conj (vec (:operations lowered))
                                         (body/->Yield [(:result lowered)]))
                                   [(body/value result loop-type)]
-                                  {:association :ordered})]
-                        {:operations (conj (vec (:operations initial)) loop)
-                         :result result :type loop-type}))
+                                  {:association :ordered})
+                            exit (when exit?
+                                   (lower (util/subst-syms {acc-sym result} else-expr)
+                                          expected (assoc env result loop-type)))]
+                        (if exit
+                          {:operations (into (conj (vec (:operations initial)) loop)
+                                             (:operations exit))
+                           :result (:result exit) :type (:type exit)}
+                          {:operations (conj (vec (:operations initial)) loop)
+                           :result result :type loop-type})))
                     (decline! :ordered-loop-shape
                               "scalar loop is outside the canonical ordered carry form"
                               {:expression expression}))

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -108,8 +108,10 @@
                           (and fp-source? fp-target?) [:nearest-even :ieee]
                           (and (not fp-source?) (not fp-target?) widening?) [:exact :exact]
                           ;; Integral narrowing (`(int j)` on a long counter) keeps the two's
-                          ;; complement bits, which agrees with the checked JVM cast on every
-                          ;; in-range value; the policy is stated so no target can guess it.
+                          ;; complement bits. The JVM source cast is range-checked and throws
+                          ;; on overflow; kernels state `:wrap` because no portable target traps
+                          ;; inside a conversion, so an out-of-range narrowing is loud on the
+                          ;; JVM and modular on the device. In-range values agree everywhere.
                           (and (not fp-source?) (not fp-target?)) [:exact :wrap]
                           (and (not fp-source?) fp-target? (= :double target)
                                (<= (dtype/bytes-of source) 4)) [:exact :exact]

--- a/src/raster/compiler/passes/parallel/scalar_expression_body.clj
+++ b/src/raster/compiler/passes/parallel/scalar_expression_body.clj
@@ -107,6 +107,10 @@
                           (and fp-source? fp-target? widening?) [:exact :exact]
                           (and fp-source? fp-target?) [:nearest-even :ieee]
                           (and (not fp-source?) (not fp-target?) widening?) [:exact :exact]
+                          ;; Integral narrowing (`(int j)` on a long counter) keeps the two's
+                          ;; complement bits, which agrees with the checked JVM cast on every
+                          ;; in-range value; the policy is stated so no target can guess it.
+                          (and (not fp-source?) (not fp-target?)) [:exact :wrap]
                           (and (not fp-source?) fp-target? (= :double target)
                                (<= (dtype/bytes-of source) 4)) [:exact :exact]
                           (and (not fp-source?) fp-target?)

--- a/src/raster/compiler/passes/parallel/segmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segmap_body.clj
@@ -214,7 +214,17 @@
                       {:operation (:id segmap) :output primary-output}))
         environment (:environment local-state)
         lower-store
-        (fn [form]
+        (fn lower-store [form]
+          (if (and (seq? form) (= 'if (first form)) (= 3 (count form)))
+            ;; A guarded explicit store `(if predicate (aset …))` is the store under an
+            ;; IfRegion; the bounds guard of a block scatter is exactly this shape.
+            (let [[_ predicate store] form
+                  lowered-predicate ((:lower lowerer) predicate :predicate environment)
+                  store-operations (vec (lower-store store))]
+              (vec (concat (:operations lowered-predicate)
+                           [(body/->IfRegion (:result lowered-predicate)
+                                             (conj store-operations (body/->Yield []))
+                                             [(body/->Yield [])] [])])))
           (let [atomic-add? (and (seq? form)
                                  (= 'raster.par/atomic-add!
                                     (descriptor/semantic-op form)))]
@@ -241,7 +251,7 @@
                          (body/->AtomicRMW array [coordinate-expression]
                                            (:result lowered) :+ :map-active)
                          (body/->ScalarStore array [coordinate-expression]
-                                             (:result lowered) :map-active))]))))
+                                             (:result lowered) :map-active))])))))
         explicit-operations (vec (mapcat lower-store explicit-forms))
         substitute-effect
         (fn substitute-effect [substitutions effect]

--- a/src/raster/compiler/passes/parallel/segmap_body.clj
+++ b/src/raster/compiler/passes/parallel/segmap_body.clj
@@ -185,7 +185,8 @@
                   :lower-index lower-index :predicate :map-active
                   :id-prefix "map" :decline! decline!})
         base-environment (assoc scalar-types index :long)
-        local-state
+        lower-locals
+        (fn [locals base-environment]
         (reduce
          (fn [{:keys [substitutions operations environment]}
               {:keys [id init] local-dtype :dtype}]
@@ -201,7 +202,8 @@
               :operations (into operations (:operations lowered))
               :environment (assoc environment (:result lowered) (:type lowered))}))
          {:substitutions {} :operations [] :environment base-environment}
-         locals)
+         locals))
+        local-state (lower-locals locals base-environment)
         forms (if ordered-effects?
                 []
                 (scalar-forms (util/subst-syms (:substitutions local-state) result)))
@@ -241,8 +243,41 @@
                          (body/->ScalarStore array [coordinate-expression]
                                              (:result lowered) :map-active))]))))
         explicit-operations (vec (mapcat lower-store explicit-forms))
+        substitute-effect
+        (fn substitute-effect [substitutions effect]
+          (let [substitute #(util/subst-syms substitutions %)]
+            (if-let [loop (:loop effect)]
+              (assoc effect :loop
+                     (-> loop
+                         (update :extent substitute)
+                         (update :locals (fn [locals] (mapv #(update % :init substitute) locals)))
+                         (update :effects (fn [effects]
+                                            (mapv #(substitute-effect substitutions %) effects)))))
+              (reduce (fn [effect field] (update effect field substitute))
+                      effect [:destination :destination-index :predicate :value]))))
         lower-effect
-        (fn [{:keys [destination conflict destination-index predicate value] :as effect}]
+        (fn lower-effect
+          [environment {:keys [destination conflict destination-index predicate value] :as effect}]
+          (if-let [{loop-index :index loop-locals :locals loop-effects :effects
+                    :keys [lower extent]} (:loop effect)]
+            ;; A counted store loop lowers to an ordered ForLoop nested in the work item: its
+            ;; locals are SSA values scoped to one iteration and its stores keep their own
+            ;; per-destination contracts.
+            (let [loop-state (lower-locals loop-locals (assoc environment loop-index :long))
+                  inner (vec (mapcat #(lower-effect (:environment loop-state)
+                                                    (substitute-effect
+                                                     (:substitutions loop-state) %))
+                                     loop-effects))]
+              [(body/->ForLoop
+                (body/value loop-index :long)
+                (lower-index lower (set (keys environment)) environment)
+                (lower-index extent (set (keys environment)) environment)
+                1
+                []
+                (vec (concat (:operations loop-state) inner [(body/->Yield [])]))
+                []
+                {:association :ordered :source-order true})])
+          (do
           (when-not (contains? output-set destination)
             (decline! :effect-destination
                       "ordered effect targets an undeclared result"
@@ -273,16 +308,11 @@
                 (vec (concat (:operations lowered-predicate)
                              [(body/->IfRegion (:result lowered-predicate)
                                                (conj effect-operations (body/->Yield []))
-                                               [(body/->Yield [])] [])]))))))
+                                               [(body/->Yield [])] [])]))))))))
         effect-operations
-        (vec (mapcat lower-effect
-                     (map #(reduce (fn [effect field]
-                                     (update effect field
-                                             (fn [expression]
-                                               (util/subst-syms
-                                                (:substitutions local-state) expression))))
-                                   % [:destination :destination-index :predicate :value])
-                          effects)))
+        (vec (mapcat #(lower-effect environment
+                                    (substitute-effect (:substitutions local-state) %))
+                     effects))
         primary-lowered (when primary-output
                           ((:lower lowerer) primary-form
                                             (get array-types primary-output) environment))

--- a/src/raster/compiler/passes/parallel/segop_lower_pass.clj
+++ b/src/raster/compiler/passes/parallel/segop_lower_pass.clj
@@ -8,7 +8,8 @@
    This decouples hardware-aware execution planning from backend codegen:
    - Lowering decides phase decomposition, launch params, accumulator count
    - Backend translates SegOp to target code (SIMD, OpenCL, scalar)"
-  (:require [raster.compiler.ir.par :as par]
+  (:require [raster.compiler.core.util :as util]
+            [raster.compiler.ir.par :as par]
             [raster.compiler.ir.soac :as soac]
             [raster.compiler.ir.soac-dialect :as soac-dialect]
             [raster.compiler.ir.abstract-value :as av]
@@ -282,6 +283,10 @@
      :dtype — element type (:double or :float)"
   [form opts]
   (if (and (program/parallel-program? form) (= :typed-soac (:dialect form)))
+    ;; Every declared value of a TypedSOAC program is a local of the compiled form, even one
+    ;; spelled like a `clojure.core` name (a parameter called `seq`): free-symbol analysis in
+    ;; the lowerings must read it as a scalar operand, never as the core function.
+    (binding [util/*shadowing-locals* (set (keys (:values form)))]
     (let [device-id (or (:target-device opts) :cpu:0)
           dtype (or (:dtype opts) :double)
           ;; The TypedSOAC program remains purely functional, while `:result-storage` gives every
@@ -323,7 +328,11 @@
                     operations (:operations lowered)
                     scheduled-equation
                     (-> equation
-                        (assoc :operations operations)
+                        (assoc :operations operations
+                               ;; The algorithm in physical value names: a logical result that
+                               ;; aliases an earlier destination is spelled as that destination
+                               ;; here, exactly as the scheduled SegOps name it.
+                               :physical-algorithm scheduling-algorithm)
                         (update :provenance assoc :target-dialect :segop)
                         (update :attributes assoc :device device-id)
                         (cond-> (:kernel-graph lowered)
@@ -432,7 +441,7 @@
        :stats {:segops-lowered parallel-equation-count
                :kernel-graphs-lowered kernel-graph-count
                :typed-soac-reused parallel-equation-count
-               :typed-scalar-equations scalar-equation-count}})
+               :typed-scalar-equations scalar-equation-count}}))
     (if-not (form/binding-form? form)
       {:form (build-program form [] [] (:target-device opts) (:dtype opts))
        :stats {:segops-lowered 0 :kernel-graphs-lowered 0}}

--- a/src/raster/compiler/passes/parallel/soac_lower.clj
+++ b/src/raster/compiler/passes/parallel/soac_lower.clj
@@ -339,25 +339,36 @@
           locals (mapv #(update % :init
                                 (fn [init] (util/subst-syms substitutions init)))
                        locals)
-          effects
-          (mapv (fn [effect]
-                  (let [{:keys [destination conflict destination-index predicate value]}
-                        (soac-dialect/effect-parts effect)]
-                    {:destination (util/subst-syms substitutions destination)
-                     :dtype (get destination-dtypes
-                                 (util/subst-syms substitutions destination))
-                     :conflict conflict
-                     :destination-index (util/subst-syms substitutions destination-index)
-                     :predicate (util/subst-syms substitutions predicate)
-                     :value (util/subst-syms substitutions value)}))
-                body-results)
+          lower-effect
+          (fn lower-effect [effect]
+            (let [{:keys [loop destination conflict destination-index predicate value]
+                   :as parts}
+                  (soac-dialect/effect-parts effect)]
+              (if loop
+                (let [{:keys [locals body-results]} (soac-dialect/lambda-parts (:lambda parts))]
+                  {:loop {:index (:index parts)
+                          :lower (:lower parts)
+                          :extent (util/subst-syms substitutions (:extent parts))
+                          :locals (mapv #(update % :init
+                                                 (fn [init] (util/subst-syms substitutions init)))
+                                        locals)
+                          :effects (mapv lower-effect body-results)}})
+                {:destination (util/subst-syms substitutions destination)
+                 :dtype (get destination-dtypes
+                             (util/subst-syms substitutions destination))
+                 :conflict conflict
+                 :destination-index (util/subst-syms substitutions destination-index)
+                 :predicate (util/subst-syms substitutions predicate)
+                 :value (util/subst-syms substitutions value)})))
+          effects (mapv lower-effect body-results)
+          effect-leaves (soac-dialect/effect-leaves effects)
           stable (set (get-in attributes [:attributes :stable-array-captures]))
           scalar-captures (set (remove stable captures))
           write-conflicts
           (into {} (map (fn [destination]
                           [destination (:conflict
                                         (first (filter #(= destination (:destination %))
-                                                       effects)))])
+                                                       effect-leaves)))])
                         physical-results))
           result-dtype (or (:dtype (get values (first results))) dtype :double)
           iteration-order (:iteration-order attributes)

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -1020,8 +1020,14 @@
 
     (and (seq? expression) (= 'raster.par/contract (first expression)))
     (let [facts (contraction-facts/contraction-facts
-                 expression :dtype (or (:raster.type/elem-type (meta expression))
-                                       default-dtype :double))
+                 expression
+                 ;; A contraction's element dtype is the declared dtype of the array it writes.
+                 ;; The form's elem-type stamp is the compile's dtype policy, which a hard-typed
+                 ;; double kernel compiled under a float policy does not follow; the program-wide
+                 ;; dtype is only the last resort when nothing declares it.
+                 :dtype (or (some-> (get array-types (second expression)) dtype/canon)
+                            (:raster.type/elem-type (meta expression))
+                            default-dtype :double))
           {:keys [free-axes contract-axes out opts]} facts
           epilogue (:epilogue facts)
           result-transform (typed-result-transform epilogue)

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -190,13 +190,19 @@
                                 locals)))
         (update :stores (fn [stores] (mapv #(substitute-store substitutions %) stores))))))
 
+(defn- region-order
+  "The source order of a region's effects as `[:store i]` / `[:loop j]` entries into its
+   `:stores` and `:loops` vectors. Regions without loops are their stores in order."
+  [{:keys [stores order]}]
+  (or order (mapv (fn [ordinal] [:store ordinal]) (range (count stores)))))
+
 (defn- rebase-region-locals
   "Move a recursively recognized region behind `offset` lexical SSA values.
 
    Every nested scope initially numbers its locals from zero.  Rebasing before composing scopes
    gives the combined region one deterministic, collision-free SSA namespace. Counted store
    loops keep their own body locals; only their references to the enclosing locals are renamed."
-  [{:keys [locals stores loops]} offset]
+  [{:keys [locals stores loops] :as region} offset]
   (let [renames (into {}
                       (map-indexed
                        (fn [ordinal {:keys [id]}]
@@ -208,7 +214,8 @@
                          (update :init #(util/subst-syms renames %))))
                    locals)
      :stores (mapv #(substitute-store renames %) stores)
-     :loops (mapv #(substitute-loop renames %) (or loops []))}))
+     :loops (mapv #(substitute-loop renames %) (or loops []))
+     :order (region-order region)}))
 
 (defn- strip-trailing-recur
   "Remove a counted loop's `(recur (inc i))` from the tail of its body, returning the remaining
@@ -279,19 +286,25 @@
                (not (contains? (util/free-syms (:extent counted)) (:index counted))))
       (when-let [region (store-region (:body counted) index)]
         (when (and (seq (:stores region)) (empty? (:loops region)))
-          (let [renames (into {} (map (fn [{:keys [id]}]
-                                        [id (symbol (str "rstr_loop_" (name id)))])
-                                      (:locals region)))]
+          ;; The loop index and the body locals get their own names: a source loop index may
+          ;; shadow a captured scalar of the enclosing region, and the region's SSA namespace
+          ;; must not confuse the two.
+          (let [loop-index (symbol (str "rstr_loop_index_" (name (:index counted))))
+                renames (into {(:index counted) loop-index}
+                              (map (fn [{:keys [id]}]
+                                     [id (symbol (str "rstr_loop_" (name id)))])
+                                   (:locals region)))]
             {:locals []
              :stores []
-             :loops [{:index (:index counted)
+             :loops [{:index loop-index
                       :lower (:lower counted)
                       :extent (:extent counted)
                       :locals (mapv (fn [{:keys [id] :as local}]
                                       (-> local (assoc :id (get renames id))
                                           (update :init #(util/subst-syms renames %))))
                                     (:locals region))
-                      :stores (mapv #(substitute-store renames %) (:stores region))}]}))))))
+                      :stores (mapv #(substitute-store renames %) (:stores region))}]
+             :order [[:loop 0]]}))))))
 
 (defn- store-region
   "Recognize an ordered, pure local-SSA spine ending exclusively in certified effects.
@@ -330,7 +343,8 @@
                                (:locals nested))
                  :stores (mapv #(substitute-store substitutions %)
                                (:stores nested))
-                 :loops (mapv #(substitute-loop substitutions %) (:loops nested))}))))))
+                 :loops (mapv #(substitute-loop substitutions %) (:loops nested))
+                 :order (region-order nested)}))))))
 
     (and (seq? body) (= 'do (first body)))
     (let [expressions (vec (rest body))]
@@ -339,8 +353,20 @@
         (let [groups (mapv #(store-region % index) expressions)]
           (when (and (seq groups) (every? some? groups)
                      (every? (comp empty? :locals) groups))
-            {:locals [] :stores (vec (mapcat :stores groups))
-             :loops (vec (mapcat :loops groups))}))))
+            (reduce (fn [{:keys [stores loops order]} group]
+                      (let [store-offset (count stores)
+                            loop-offset (count loops)]
+                        {:locals []
+                         :stores (into stores (:stores group))
+                         :loops (into loops (:loops group))
+                         :order (into order
+                                      (map (fn [[kind ordinal]]
+                                             [kind (+ ordinal (if (= :store kind)
+                                                                store-offset
+                                                                loop-offset))]))
+                                      (region-order group))}))
+                    {:locals [] :stores [] :loops [] :order []}
+                    groups)))))
 
     (and (seq? body)
          (contains? #{'if 'clojure.core/if} (first body))
@@ -497,7 +523,7 @@
    Typed locals are evaluated before the effect sequence and may deliberately snapshot destination
    state. Direct reads in coordinates, predicates, or values would instead make cross-work-item
    ordering observable and require a stronger schedule than an effect map."
-  [locals stores]
+  [locals stores & [loop-expressions]]
   (let [destinations (set (map :out stores))]
     (and (seq stores)
          (every? (fn [{:keys [index predicate value]}]
@@ -505,6 +531,10 @@
                             destinations
                             (par/collect-aget-arrays (list 'do index predicate value)))))
                  stores)
+         ;; Loop-body locals are re-evaluated inside the loop, interleaved with its stores;
+         ;; unlike the region's pre-effect locals they are not snapshots.
+         (empty? (set/intersection destinations
+                                   (par/collect-aget-arrays (list* 'do loop-expressions))))
          ;; Locals are an ordered pre-effect SSA spine, so their reads are snapshots rather than
          ;; sibling effect dependencies. Keep the argument explicit for this legality boundary.
          (vector? locals))))
@@ -513,16 +543,33 @@
   "Element dtypes of the arrays a source `let` binds, read from the walker's array tags on the
    binders (`floats`, `doubles`, …). A use-site symbol carries no metadata, so an internal
    allocation such as an attention output would otherwise have no declared dtype and every map
-   writing it would decline. Declared `array-types` take precedence."
-  [pairs array-types]
-  (merge
-   (into {}
-         (keep (fn [[binder _]]
-                 (when (symbol? binder)
-                   (when-let [element (some-> (types/sym-type-tag binder) dtype/dtype-for-array-tag)]
-                     [binder element]))))
-         pairs)
-   (or array-types {})))
+   writing it would decline. Declared `array-types` take precedence.
+
+   Float-family tags follow the kernel dtype exactly as `derive-param-types` maps the
+   parameters: a kernel compiled at `:float` reads and writes float buffers throughout, so a
+   double-declared allocation inside it is a float buffer of that kernel, not a second precision."
+  [pairs array-types dtype]
+  (let [kernel-dtype (some-> dtype dtype/canon)
+        policy (fn [element]
+                 (if (and kernel-dtype (dtype/fp-dtype? kernel-dtype)
+                          (contains? #{:float :double} element))
+                   kernel-dtype
+                   element))]
+    (merge
+     (into {}
+           (keep (fn [[binder init]]
+                   (when (symbol? binder)
+                     (when-let [element (some-> (types/sym-type-tag binder)
+                                                dtype/dtype-for-array-tag dtype/canon)]
+                       ;; Only a bare allocation follows the policy. A parallel form's result
+                       ;; binder carries the form's own explicit element dtype (`pmap … double`),
+                       ;; which its equation declares; retyping it here would contradict that.
+                       [binder (if (and (seq? init)
+                                        (descriptor/alloc-op? (descriptor/semantic-op init)))
+                                 (policy element)
+                                 element)]))))
+           pairs)
+     (or array-types {}))))
 
 (defn- destination-dtype
   [array-types destination]
@@ -570,12 +617,16 @@
   [expression loop-index map-index extent]
   (let [expression (strip-index-casts expression)
         extent (strip-index-casts extent)
+        ;; Rows are disjoint only when every item's row has the same width: an extent that
+        ;; varies with the map index (`(- n r)`) makes consecutive rows overlap.
+        invariant-extent? (not (contains? (util/free-syms extent) map-index))
         row-offset? (fn [form]
                       (and (seq? form) (= 3 (count form))
                            (contains? '#{* clojure.core/*} (first form))
                            (= #{map-index extent} (set (rest form)))
                            (not= map-index extent)))]
-    (and (seq? expression) (= 3 (count expression))
+    (and invariant-extent?
+         (seq? expression) (= 3 (count expression))
          (contains? '#{+ clojure.core/+} (first expression))
          (let [[_ left right] expression]
            (or (and (= left loop-index) (row-offset? right))
@@ -591,9 +642,10 @@
                effects)))
 
 (defn- write-region-description
-  [id symbol index extent {:keys [locals stores loops]} elem-type
+  [id symbol index extent {:keys [locals stores loops] :as region} elem-type
    & {:keys [host-return array-types] :or {host-return :effect array-types {}}}]
-  (let [loops (or loops [])]
+  (let [loops (or loops [])
+        order (region-order region)]
     (when (and (or (seq stores) (seq loops))
                (or (= :effect host-return) (and (empty? loops) (= 1 (count stores))))
                ;; A destination written both directly and inside a store loop would lose the work
@@ -679,7 +731,9 @@
             all-locals (vec (concat locals (mapcat :locals loops)))
             iteration-order (when ordered?
                               (if (or (some #(= :ordered (:effect-conflict %)) all-stores)
-                                      (not (ordered-effects-safe? all-locals all-stores)))
+                                      (not (ordered-effects-safe?
+                                            locals all-stores
+                                            (map :init (mapcat :locals loops)))))
                                 :sequential
                                 :independent))
             destinations (if ordered?
@@ -701,22 +755,27 @@
             store-effect (fn [store]
                            (select-keys store [:out :index :predicate :value :cast
                                                :effect-conflict]))
-            loop-effects (map-indexed
-                          (fn [ordinal {loop-index :index loop-locals :locals
-                                        :keys [lower extent]}]
-                            {:loop {:index loop-index :lower lower :extent extent
-                                    :locals loop-locals
-                                    :effects (mapv store-effect
-                                                   (filter #(= ordinal (:loop %)) all-stores))}})
-                          loops)]
+            loop-effects (mapv (fn [ordinal {loop-index :index loop-locals :locals
+                                             :keys [lower extent]}]
+                                 {:loop {:index loop-index :lower lower :extent extent
+                                         :locals loop-locals
+                                         :effects (mapv store-effect
+                                                        (filter #(= ordinal (:loop %))
+                                                                all-stores))}})
+                               (range) loops)
+            ;; Effects keep the region's source order across direct stores and loops.
+            ordered-effects (mapv (fn [[kind ordinal]]
+                                    (if (= :store kind)
+                                      (store-effect (nth stores ordinal))
+                                      (nth loop-effects ordinal)))
+                                  order)]
         (when (or pointwise? scatter? (and ordered? (every? some? result-dtypes)))
           (merge {:kind (cond pointwise? :map scatter? :scatter :else :effect-map)
                   :id id :sym symbol :index index :extent extent
                   :results results :locals locals :bodies values :casts (mapv :cast all-stores)
                   :write-indices write-indices :predicates predicates
                   :conflict (when scatter? uniform-conflict)
-                  :effects (when ordered?
-                             (vec (concat (map store-effect stores) loop-effects)))
+                  :effects (when ordered? ordered-effects)
                   :iteration-order iteration-order
                   :result-dtypes (when ordered? result-dtypes)
                   :effect-only? (= :effect host-return)
@@ -1264,6 +1323,47 @@
     (into (set (filter symbol? (take-nth 2 bindings)))
           (mapcat keys type-maps))))
 
+(declare alength-array)
+
+(defn- length-expression?
+  "A syntactic array-length operand: a value id, an integer, or integer arithmetic over them.
+   A collection-valued constructor argument (`(float-array [1 2 3])`) is not a length."
+  [expression]
+  (or (symbol? expression)
+      (integer? expression)
+      (and (seq? expression)
+           (contains? '#{* + - quot clojure.core/* clojure.core/+ clojure.core/- clojure.core/quot
+                         long int clojure.core/long clojure.core/int}
+                      (first expression))
+           (every? length-expression? (rest expression)))))
+
+(defn- allocation-length
+  "The length expression an allocation binding declares, or nil.
+
+   `(float-array n)` and `(zeros-like a n)` allocate `n` elements; `(zeros-like a)` allocates
+   `(alength a)`. Recording this lets `(alength y)` over a local allocation resolve to the same
+   extent id as every other use of `n`, instead of each `alength` minting a fresh compound
+   extent that then contradicts the buffer's shape elsewhere in the program."
+  [expression]
+  (when (and (seq? expression) (descriptor/alloc-op? (descriptor/semantic-op expression)))
+    (let [operation (descriptor/semantic-op expression)
+          arguments (vec (descriptor/call-args expression))
+          constructor? (or (contains? descriptor/alloc-sym->array-tag operation)
+                           (contains? descriptor/alloc-sym->array-tag
+                                      (some-> operation name clojure.core/symbol)))]
+      (cond
+        (and constructor? (= 1 (count arguments)) (length-expression? (first arguments)))
+        (first arguments)
+
+        (and (not constructor?) (= 2 (count arguments)) (symbol? (first arguments))
+             (length-expression? (second arguments)))
+        (second arguments)
+
+        (and (not constructor?) (= 1 (count arguments)) (symbol? (first arguments)))
+        (list 'clojure.core/alength (first arguments))
+
+        :else nil))))
+
 (defn- normalize-source*
   [source]
   ;; Direct backend entry may see source before the ordinary pipeline's SSA cleanup. Clojure
@@ -1277,12 +1377,57 @@
             pairs (vec (partition 2 bindings))
             {:keys [normalized]}
             (reduce
-             (fn [{:keys [compound-extents] :as state} [ordinal [symbol expression]]]
+             (fn [{:keys [compound-extents allocation-lengths scalar-aliases pure-scalar-ids]
+                   :as state}
+                  [ordinal [symbol expression]]]
                (let [expression (->> expression
                                      (canonicalize-strided-indexed-operation ordinal)
                                      (canonicalize-blas-gemm ordinal))
+                     ;; Host scalar identities: a binding that renames a scalar, or recomputes
+                     ;; a pure scalar expression an earlier binding already computed, denotes
+                     ;; that earlier value. Extents are compared in these canonical names so
+                     ;; `(* seq dff)` and `(* n1 n2)` with `n1 = seq`, `n2 = dff` are one size.
+                     canonical-scalar (fn [form]
+                                        (util/subst-syms scalar-aliases (strip-index-casts form)))
+                     scalar-form (when-not (or (parallel-extent expression)
+                                               (allocation-length expression)
+                                               (par/par-form? expression))
+                                   (canonical-scalar expression))
+                     state (cond
+                             (and (symbol? scalar-form) (not= scalar-form symbol))
+                             (assoc-in state [:scalar-aliases symbol] scalar-form)
+
+                             (and (seq? scalar-form) (provably-pure-scalar? scalar-form))
+                             (if-let [earlier (get pure-scalar-ids scalar-form)]
+                               (assoc-in state [:scalar-aliases symbol] earlier)
+                               (assoc-in state [:pure-scalar-ids scalar-form] symbol))
+
+                             :else state)
+                     scalar-aliases (:scalar-aliases state)
                      extent (parallel-extent expression)
-                     canonical-extent (some-> extent descriptor/unwrap-int-cast)]
+                     ;; `(alength y)` over a local allocation is the allocation's declared
+                     ;; length; follow renamed allocations to their length as well.
+                     resolve-length (fn resolve-length [extent seen]
+                                      (let [array (alength-array extent)]
+                                        (if (and array (contains? allocation-lengths array)
+                                                 (not (contains? seen array)))
+                                          (resolve-length (get allocation-lengths array)
+                                                          (conj seen array))
+                                          extent)))
+                     canonical-extent (some-> extent
+                                              (resolve-length #{})
+                                              (->> (util/subst-syms scalar-aliases))
+                                              descriptor/unwrap-int-cast)
+                     state (if-let [length (allocation-length expression)]
+                             (assoc-in state [:allocation-lengths symbol]
+                                       (->> (resolve-length length #{})
+                                            (util/subst-syms scalar-aliases)
+                                            descriptor/unwrap-int-cast))
+                             (if (and (symbol? expression)
+                                      (contains? allocation-lengths expression))
+                               (assoc-in state [:allocation-lengths symbol]
+                                         (get allocation-lengths expression))
+                               state))]
                  (cond
                    (nil? extent)
                    (update state :normalized conj [symbol expression])
@@ -1312,7 +1457,8 @@
 
                    :else
                    (update state :normalized conj [symbol expression]))))
-             {:normalized [] :compound-extents {}}
+             {:normalized [] :compound-extents {} :allocation-lengths {}
+              :scalar-aliases {} :pure-scalar-ids {}}
              (map-indexed vector pairs))]
         (with-meta (list* head (vec (mapcat identity normalized)) body) (meta source)))
       source)))
@@ -1523,7 +1669,7 @@
   (when (and (seq? source) (contains? #{'let 'let*} (first source)))
     (let [[_ bindings] source
           pairs (vec (partition 2 bindings))
-          array-types (binder-array-types pairs array-types)
+          array-types (binder-array-types pairs array-types dtype)
           descriptions (normalize-extents (source-descriptions pairs dtype array-types)
                                           shape-equalities values)
           physical-outputs (physical-output-symbols descriptions)
@@ -1595,11 +1741,32 @@
        form))
    expression))
 
+(defn- declare-result-conversion
+  "Wrap a map body in the explicit cast to its result element dtype when the body's retained
+   dtype differs.
+
+   Both dtypes are facts: the result buffer's element dtype and the walker's stamp on the body.
+   A double body written to a float buffer (a double-typed schedule compiled under the float
+   policy) is a stated narrowing, not a silent one; KernelBody would otherwise refuse the store."
+  [expression elem-type]
+  (let [tag (when (instance? clojure.lang.IObj expression)
+              (or (:raster.type/tag (meta expression)) (:tag (meta expression))))
+        source (some-> tag dtype/dtype-for-scalar-tag dtype/canon)
+        target (some-> elem-type dtype/canon)]
+    (if (and source target (not= source target)
+             (dtype/fp-dtype? source) (dtype/fp-dtype? target))
+      (list (dtype/scalar-tag-for-dtype target) expression)
+      expression)))
+
 (defn- map-equation
   [description]
   (let [{:keys [id index extent locals casts bodies inputs results elem-type]} description
         fold-dtype (or elem-type (:result-dtype description) :double)
-        expressions (mapv (fn [cast body] (if cast (list cast body) body)) casts bodies)
+        expressions (mapv (fn [cast body]
+                            (if cast
+                              (list cast body)
+                              (declare-result-conversion body fold-dtype)))
+                          casts bodies)
         all-expressions (into (mapv :init locals) expressions)
         [pointwise stable] ((juxt filter remove) #(pointwise-input? all-expressions % index) inputs)
         arrays (vec (sort-by pr-str pointwise))
@@ -2134,7 +2301,7 @@
   (when (and (seq? source) (contains? #{'let 'let*} (first source)))
     (let [[_ bindings & body] source
           pairs (vec (partition 2 bindings))
-          array-types (binder-array-types pairs array-types)
+          array-types (binder-array-types pairs array-types dtype)
           descriptions (normalize-extents (source-descriptions pairs dtype array-types)
                                           shape-equalities values)]
       (when (and (even? (count bindings))

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -193,8 +193,24 @@
 (defn- region-order
   "The source order of a region's effects as `[:store i]` / `[:loop j]` entries into its
    `:stores` and `:loops` vectors. Regions without loops are their stores in order."
-  [{:keys [stores order]}]
+  [{:keys [stores loops order]}]
+  (when (and (nil? order) (seq loops))
+    (throw (ex-info "a region with store loops must carry its source order"
+                    {:reason :raster/bug :loops (count loops) :stores (count stores)})))
   (or order (mapv (fn [ordinal] [:store ordinal]) (range (count stores)))))
+
+(defn- rename-loop-index
+  "Give a counted store loop the index name `fresh`, renaming its body locals' inits and its
+   stores. Sibling loops that reuse one source index name (`i`) would otherwise share a
+   KernelBody SSA value."
+  [{:keys [index] :as loop} fresh]
+  (let [renames {index fresh}]
+    (-> loop
+        (assoc :index fresh)
+        (update :locals (fn [locals]
+                          (mapv #(update % :init (fn [init] (util/subst-syms renames init)))
+                                locals)))
+        (update :stores (fn [stores] (mapv #(substitute-store renames %) stores))))))
 
 (defn- rebase-region-locals
   "Move a recursively recognized region behind `offset` lexical SSA values.
@@ -265,7 +281,8 @@
 
                   (and (symbol? head) (form/loop-head? head)
                        (vector? bindings) (= 2 (count bindings))
-                       (symbol? (first bindings)) (integer? (second bindings))
+                       (symbol? (first bindings))
+                       (integer? (second bindings)) (<= 0 (second bindings))
                        (= 1 (count body)))
                   (let [[loop-index lower] bindings
                         conditional (first body)]
@@ -561,13 +578,20 @@
                    (when (symbol? binder)
                      (when-let [element (some-> (types/sym-type-tag binder)
                                                 dtype/dtype-for-array-tag dtype/canon)]
-                       ;; Only a bare allocation follows the policy. A parallel form's result
-                       ;; binder carries the form's own explicit element dtype (`pmap … double`),
-                       ;; which its equation declares; retyping it here would contradict that.
-                       [binder (if (and (seq? init)
-                                        (descriptor/alloc-op? (descriptor/semantic-op init)))
-                                 (policy element)
-                                 element)]))))
+                       ;; Only an allocation that does not name its element type (`alloc-like`,
+                       ;; `zeros-like`, `similar`) follows the policy. `float-array` states its
+                       ;; element type, and a parallel form's result binder carries the form's
+                       ;; own explicit dtype (`pmap … double`); retyping either would contradict
+                       ;; a declared fact.
+                       [binder (let [operation (when (seq? init) (descriptor/semantic-op init))
+                                     named-element?
+                                     (or (contains? descriptor/alloc-sym->array-tag operation)
+                                         (contains? descriptor/alloc-sym->array-tag
+                                                    (some-> operation name clojure.core/symbol)))]
+                                 (if (and operation (descriptor/alloc-op? operation)
+                                          (not named-element?))
+                                   (policy element)
+                                   element))]))))
            pairs)
      (or array-types {}))))
 
@@ -644,8 +668,11 @@
 (defn- write-region-description
   [id symbol index extent {:keys [locals stores loops] :as region} elem-type
    & {:keys [host-return array-types] :or {host-return :effect array-types {}}}]
-  (let [loops (or loops [])
-        order (region-order region)]
+  (let [order (region-order region)
+        loops (vec (map-indexed (fn [ordinal loop]
+                                  (rename-loop-index
+                                   loop (clojure.core/symbol (str "rstr_loop_index_" ordinal))))
+                                (or loops [])))]
     (when (and (or (seq stores) (seq loops))
                (or (= :effect host-return) (and (empty? loops) (= 1 (count stores))))
                ;; A destination written both directly and inside a store loop would lose the work
@@ -733,7 +760,8 @@
                               (if (or (some #(= :ordered (:effect-conflict %)) all-stores)
                                       (not (ordered-effects-safe?
                                             locals all-stores
-                                            (map :init (mapcat :locals loops)))))
+                                            (concat (map :extent loops)
+                                                    (map :init (mapcat :locals loops))))))
                                 :sequential
                                 :independent))
             destinations (if ordered?
@@ -1329,7 +1357,8 @@
   "A syntactic array-length operand: a value id, an integer, or integer arithmetic over them.
    A collection-valued constructor argument (`(float-array [1 2 3])`) is not a length."
   [expression]
-  (or (symbol? expression)
+  (or (and (symbol? expression)
+           (nil? (some-> (types/sym-type-tag expression) dtype/dtype-for-array-tag)))
       (integer? expression)
       (and (seq? expression)
            (contains? '#{* + - quot clojure.core/* clojure.core/+ clojure.core/- clojure.core/quot
@@ -1389,15 +1418,30 @@
                      ;; `(* seq dff)` and `(* n1 n2)` with `n1 = seq`, `n2 = dff` are one size.
                      canonical-scalar (fn [form]
                                         (util/subst-syms scalar-aliases (strip-index-casts form)))
+                     ;; `(long x)` of a floating scalar is a conversion, not a renaming.
+                     floating-cast? (and (seq? expression) (= 2 (count expression))
+                                         (contains? '#{long int clojure.core/long clojure.core/int}
+                                                    (first expression))
+                                         (symbol? (second expression))
+                                         (some-> (types/sym-type-tag (second expression))
+                                                 dtype/dtype-for-scalar-tag dtype/fp-dtype?))
                      scalar-form (when-not (or (parallel-extent expression)
                                                (allocation-length expression)
-                                               (par/par-form? expression))
+                                               (par/par-form? expression)
+                                               floating-cast?)
                                    (canonical-scalar expression))
+                     ;; A recomputed scalar denotes an earlier one only when nothing between
+                     ;; them can have changed its value: it reads no array (a kernel in between
+                     ;; may write one), or it is an array length, which no kernel changes.
+                     stable-scalar? (and (seq? scalar-form)
+                                         (provably-pure-scalar? scalar-form)
+                                         (or (empty? (par/collect-aget-arrays scalar-form))
+                                             (some? (alength-array scalar-form))))
                      state (cond
                              (and (symbol? scalar-form) (not= scalar-form symbol))
                              (assoc-in state [:scalar-aliases symbol] scalar-form)
 
-                             (and (seq? scalar-form) (provably-pure-scalar? scalar-form))
+                             stable-scalar?
                              (if-let [earlier (get pure-scalar-ids scalar-form)]
                                (assoc-in state [:scalar-aliases symbol] earlier)
                                (assoc-in state [:pure-scalar-ids scalar-form] symbol))

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -548,10 +548,13 @@
                             destinations
                             (par/collect-aget-arrays (list 'do index predicate value)))))
                  stores)
-         ;; Loop-body locals are re-evaluated inside the loop, interleaved with its stores;
-         ;; unlike the region's pre-effect locals they are not snapshots.
+         ;; A region local is a snapshot only within its own work item: another item's store
+         ;; may already be visible when it is taken, so a local that reads a destination makes
+         ;; the cross-item order observable. Loop-body locals and extents are re-evaluated
+         ;; inside the loop and are checked for the same reason.
          (empty? (set/intersection destinations
-                                   (par/collect-aget-arrays (list* 'do loop-expressions))))
+                                   (par/collect-aget-arrays
+                                    (list* 'do (concat (map :init locals) loop-expressions)))))
          ;; Locals are an ordered pre-effect SSA spine, so their reads are snapshots rather than
          ;; sibling effect dependencies. Keep the argument explicit for this legality boundary.
          (vector? locals))))
@@ -1353,12 +1356,22 @@
 
 (declare alength-array)
 
+(def ^:dynamic ^:private *declared-kinds*
+  "Declared value kinds visible to `normalize-source`: `{:arrays #{sym} :scalars #{sym}}`."
+  {:arrays #{} :scalars #{}})
+
 (defn- length-expression?
-  "A syntactic array-length operand: a value id, an integer, or integer arithmetic over them.
-   A collection-valued constructor argument (`(float-array [1 2 3])`) is not a length."
+  "A syntactic array-length operand: a scalar value id, an integer, or integer arithmetic over
+   them. A bare symbol counts only when it is positively a scalar (declared, or carrying an
+   integral scalar tag): `(float-array x)` with an array `x` is a copy constructor, and a symbol
+   of unknown kind is not a length either."
   [expression]
   (or (and (symbol? expression)
-           (nil? (some-> (types/sym-type-tag expression) dtype/dtype-for-array-tag)))
+           (not (contains? (:arrays *declared-kinds*) expression))
+           (or (contains? (:scalars *declared-kinds*) expression)
+               (contains? #{:long :int}
+                          (some-> (types/sym-type-tag expression) dtype/dtype-for-scalar-tag
+                                  dtype/canon))))
       (integer? expression)
       (and (seq? expression)
            (contains? '#{* + - quot clojure.core/* clojure.core/+ clojure.core/- clojure.core/quot
@@ -1439,7 +1452,15 @@
                                              (some? (alength-array scalar-form))))
                      state (cond
                              (and (symbol? scalar-form) (not= scalar-form symbol))
-                             (assoc-in state [:scalar-aliases symbol] scalar-form)
+                             (do
+                               ;; the alias inherits its target's declared kind
+                               (when (contains? (:scalars *declared-kinds*) scalar-form)
+                                 (set! *declared-kinds*
+                                       (update *declared-kinds* :scalars conj symbol)))
+                               (when (contains? (:arrays *declared-kinds*) scalar-form)
+                                 (set! *declared-kinds*
+                                       (update *declared-kinds* :arrays conj symbol)))
+                               (assoc-in state [:scalar-aliases symbol] scalar-form))
 
                              stable-scalar?
                              (if-let [earlier (get pure-scalar-ids scalar-form)]
@@ -1691,9 +1712,23 @@
    TypedSOAC operations name extents; executable host expressions never leak into schedule fields.
    This normalization inserts an ordinary typed scalar binding immediately before its operation,
    so the same expression remains visible to JVM materialization and runtime specialization."
-  [source]
-  (binding [util/*shadowing-locals* (source-shadowing-locals source)]
-    (normalize-source* source)))
+  ([source] (normalize-source source {}))
+  ([source {:keys [array-types scalar-types]}]
+   ;; The let's own binders declare kinds too: a `^long n` binder is a scalar, a `^floats y`
+   ;; binder an array, exactly as the walker stamps them.
+   (let [binders (when (and (seq? source) (contains? #{'let 'let*} (first source)))
+                   (filter symbol? (take-nth 2 (second source))))
+         tagged (fn [kind?]
+                  (set (filter #(kind? (types/sym-type-tag %)) binders)))]
+     (binding [util/*shadowing-locals* (source-shadowing-locals source)
+               *declared-kinds*
+               {:arrays (into (set (keys array-types))
+                              (tagged #(some? (dtype/dtype-for-array-tag %))))
+                :scalars (into (set (keys scalar-types))
+                               (tagged #(contains? #{:long :int}
+                                                   (some-> % dtype/dtype-for-scalar-tag
+                                                           dtype/canon))))}]
+       (normalize-source* source)))))
 
 (declare coverage-decline*)
 

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -178,12 +178,25 @@
             (update store field #(util/subst-syms substitutions %)))
           store [:index :predicate :value]))
 
+(defn- substitute-loop
+  "Apply `substitutions` inside a counted store loop: its extent, its body locals' inits and its
+   stores. The loop index itself is bound by the loop and is never substituted."
+  [substitutions {:keys [index] :as loop}]
+  (let [substitutions (dissoc substitutions index)]
+    (-> loop
+        (update :extent #(util/subst-syms substitutions %))
+        (update :locals (fn [locals]
+                          (mapv #(update % :init (fn [init] (util/subst-syms substitutions init)))
+                                locals)))
+        (update :stores (fn [stores] (mapv #(substitute-store substitutions %) stores))))))
+
 (defn- rebase-region-locals
   "Move a recursively recognized region behind `offset` lexical SSA values.
 
    Every nested scope initially numbers its locals from zero.  Rebasing before composing scopes
-   gives the combined region one deterministic, collision-free SSA namespace."
-  [{:keys [locals stores]} offset]
+   gives the combined region one deterministic, collision-free SSA namespace. Counted store
+   loops keep their own body locals; only their references to the enclosing locals are renamed."
+  [{:keys [locals stores loops]} offset]
   (let [renames (into {}
                       (map-indexed
                        (fn [ordinal {:keys [id]}]
@@ -194,7 +207,91 @@
                          (assoc :id (get renames id))
                          (update :init #(util/subst-syms renames %))))
                    locals)
-     :stores (mapv #(substitute-store renames %) stores)}))
+     :stores (mapv #(substitute-store renames %) stores)
+     :loops (mapv #(substitute-loop renames %) (or loops []))}))
+
+(defn- strip-trailing-recur
+  "Remove a counted loop's `(recur (inc i))` from the tail of its body, returning the remaining
+   statements form, or nil when the tail is not that exact step."
+  [form index]
+  (let [step? (fn [x]
+                (and (seq? x) (= 'recur (first x)) (= 2 (count x))
+                     (let [update (strip-index-cast (second x))]
+                       (or (and (seq? update) (= 2 (count update))
+                                (contains? '#{inc clojure.core/inc} (first update))
+                                (= index (strip-index-cast (second update))))
+                           (and (seq? update) (= 3 (count update))
+                                (contains? '#{+ clojure.core/+} (first update))
+                                (= index (strip-index-cast (second update)))
+                                (= 1 (strip-index-cast (nth update 2))))))))]
+    (cond
+      (step? form) '(do)
+      (and (seq? form) (= 'do (first form)) (step? (last form)))
+      (list* 'do (butlast (rest form)))
+      ;; (let* [...] stmt… (recur …)) — the closed-core spelling puts the statements directly
+      ;; in the let body; normalize them into one `do` before the recursive recognition.
+      (and (seq? form) (symbol? (first form)) (form/let-head? (first form)) (<= 3 (count form)))
+      (let [[head bindings & statements] form
+            inner (if (= 1 (count statements))
+                    (first statements)
+                    (list* 'do statements))]
+        (when-let [stripped (strip-trailing-recur inner index)]
+          (list head bindings stripped)))
+      :else nil)))
+
+(declare store-region)
+
+(defn- counted-store-loop
+  "Recognize a counted loop of stores inside an effect-map body.
+
+   Accepted shapes are the unexpanded `(dotimes [i n] …)` and its closed-core form
+   `(loop* [i 0] (if (< i n) (do … (recur (inc i)))))`. The body is recognized by `store-region`
+   with the map index as its context; nested store loops decline. The loop's body locals live in
+   their own SSA namespace so they cannot collide with the enclosing region's locals."
+  [form index]
+  (let [[head bindings & body] (when (seq? form) form)
+        counted (cond
+                  (and (contains? '#{dotimes clojure.core/dotimes} head)
+                       (vector? bindings) (= 2 (count bindings)) (symbol? (first bindings)))
+                  {:index (first bindings) :lower 0 :extent (strip-index-cast (second bindings))
+                   :body (list* 'do body)}
+
+                  (and (symbol? head) (form/loop-head? head)
+                       (vector? bindings) (= 2 (count bindings))
+                       (symbol? (first bindings)) (integer? (second bindings))
+                       (= 1 (count body)))
+                  (let [[loop-index lower] bindings
+                        conditional (first body)]
+                    (when (and (seq? conditional)
+                               (contains? '#{if clojure.core/if} (first conditional))
+                               (<= 3 (count conditional) 4)
+                               (nil? (nth conditional 3 nil)))
+                      (let [[_ test then] conditional]
+                        (when (and (seq? test) (= 3 (count test))
+                                   (contains? '#{< clojure.core/<} (first test))
+                                   (= loop-index (strip-index-cast (second test))))
+                          (when-let [statements (strip-trailing-recur then loop-index)]
+                            {:index loop-index :lower lower
+                             :extent (strip-index-cast (nth test 2))
+                             :body statements}))))))]
+    (when (and counted
+               (not= (:index counted) index)
+               (not (contains? (util/free-syms (:extent counted)) (:index counted))))
+      (when-let [region (store-region (:body counted) index)]
+        (when (and (seq (:stores region)) (empty? (:loops region)))
+          (let [renames (into {} (map (fn [{:keys [id]}]
+                                        [id (symbol (str "rstr_loop_" (name id)))])
+                                      (:locals region)))]
+            {:locals []
+             :stores []
+             :loops [{:index (:index counted)
+                      :lower (:lower counted)
+                      :extent (:extent counted)
+                      :locals (mapv (fn [{:keys [id] :as local}]
+                                      (-> local (assoc :id (get renames id))
+                                          (update :init #(util/subst-syms renames %))))
+                                    (:locals region))
+                      :stores (mapv #(substitute-store renames %) (:stores region))}]}))))))
 
 (defn- store-region
   "Recognize an ordered, pure local-SSA spine ending exclusively in certified effects.
@@ -232,7 +329,8 @@
                                                (util/subst-syms substitutions init))))
                                (:locals nested))
                  :stores (mapv #(substitute-store substitutions %)
-                               (:stores nested))}))))))
+                               (:stores nested))
+                 :loops (mapv #(substitute-loop substitutions %) (:loops nested))}))))))
 
     (and (seq? body) (= 'do (first body)))
     (let [expressions (vec (rest body))]
@@ -241,7 +339,8 @@
         (let [groups (mapv #(store-region % index) expressions)]
           (when (and (seq groups) (every? some? groups)
                      (every? (comp empty? :locals) groups))
-            {:locals [] :stores (vec (mapcat :stores groups))}))))
+            {:locals [] :stores (vec (mapcat :stores groups))
+             :loops (vec (mapcat :loops groups))}))))
 
     (and (seq? body)
          (contains? #{'if 'clojure.core/if} (first body))
@@ -267,6 +366,10 @@
                                value (:value (first stores))]
                            (if (seq bindings) (list 'let* bindings value) value)))]
       (cond
+        ;; Store loops under a branch would need predicated loop regions; decline for now.
+        (or (seq (:loops then-region)) (seq (:loops else-region)))
+        nil
+
         ;; Both branches store once to the same destination and at least one branch owns
         ;; locals: one predicated store of a value-if over the two scoped branch values.
         (and then-region else-region aligned?
@@ -315,6 +418,11 @@
     (and (seq? body) (= 'case* (first body)))
     (when-let [conditional (integer-case-chain body)]
       (store-region conditional index))
+
+    (and (seq? body) (symbol? (first body))
+         (or (form/loop-head? (first body))
+             (contains? '#{dotimes clojure.core/dotimes} (first body))))
+    (counted-store-loop body index)
 
     (descriptor/aset-call? body)
     (let [arguments (vec (descriptor/call-args body))]
@@ -401,6 +509,21 @@
          ;; sibling effect dependencies. Keep the argument explicit for this legality boundary.
          (vector? locals))))
 
+(defn- binder-array-types
+  "Element dtypes of the arrays a source `let` binds, read from the walker's array tags on the
+   binders (`floats`, `doubles`, …). A use-site symbol carries no metadata, so an internal
+   allocation such as an attention output would otherwise have no declared dtype and every map
+   writing it would decline. Declared `array-types` take precedence."
+  [pairs array-types]
+  (merge
+   (into {}
+         (keep (fn [[binder _]]
+                 (when (symbol? binder)
+                   (when-let [element (some-> (types/sym-type-tag binder) dtype/dtype-for-array-tag)]
+                     [binder element]))))
+         pairs)
+   (or array-types {})))
+
 (defn- destination-dtype
   [array-types destination]
   (or (get array-types destination)
@@ -426,113 +549,192 @@
       :scalars (mapv #(-> % (assoc :value (:sym %)) (dissoc :sym)) (:scalars epilogue))
       :result-dtype (or (:dtype epilogue) :float)})))
 
+(defn- strip-index-casts
+  [expression]
+  (util/postwalk-preserving-meta strip-index-cast expression))
+
+(defn- inline-region-locals
+  "Substitute region-local SSA ids by their initializers until the expression is closed."
+  [expression locals]
+  (let [substitutions (into {} (map (juxt :id :init)) locals)]
+    (loop [expression expression remaining (inc (count locals))]
+      (let [inlined (util/subst-syms substitutions expression)]
+        (if (or (= inlined expression) (zero? remaining))
+          inlined
+          (recur inlined (dec remaining)))))))
+
+(defn- row-major-loop-index?
+  "Whether a store index inside a counted loop is `r*K + i` (either operand order) with `K` the
+   loop extent, `r` the map index and `i` the loop index: the row-major layout in which the
+   map items own disjoint rows, so the writes are injective across work items."
+  [expression loop-index map-index extent]
+  (let [expression (strip-index-casts expression)
+        extent (strip-index-casts extent)
+        row-offset? (fn [form]
+                      (and (seq? form) (= 3 (count form))
+                           (contains? '#{* clojure.core/*} (first form))
+                           (= #{map-index extent} (set (rest form)))
+                           (not= map-index extent)))]
+    (and (seq? expression) (= 3 (count expression))
+         (contains? '#{+ clojure.core/+} (first expression))
+         (let [[_ left right] expression]
+           (or (and (= left loop-index) (row-offset? right))
+               (and (= right loop-index) (row-offset? left)))))))
+
+(defn- effect-leaves
+  "The store effects of a description, descending into store loops."
+  [effects]
+  (vec (mapcat (fn [effect]
+                 (if-let [loop (:loop effect)]
+                   (effect-leaves (:effects loop))
+                   [effect]))
+               effects)))
+
 (defn- write-region-description
-  [id symbol index extent {:keys [locals stores]} elem-type
+  [id symbol index extent {:keys [locals stores loops]} elem-type
    & {:keys [host-return array-types] :or {host-return :effect array-types {}}}]
-  (when (and (seq stores) (or (= :effect host-return) (= 1 (count stores))))
-    (let [stores (mapv #(merge {:index index :predicate 1} %) stores)
-          dense-pointwise? (every? #(and (= index (:index %)) (nil? (:reduction-op %))) stores)
-          pointwise? (and dense-pointwise? (independent-stores? locals stores))
-          stores (if pointwise?
-                   (mapv (fn [{:keys [out predicate value] :as store}]
-                           (assoc store :value
-                                  (if (contains? #{true 1} predicate)
-                                    value
-                                    ;; A guarded dense write preserves its caller-owned
-                                    ;; destination. Making that read explicit yields an ordinary
-                                    ;; inout map instead of a hidden conditional effect.
-                                    (list 'if predicate value
-                                          (list 'clojure.core/aget out index)))))
-                         stores)
-                   stores)
-          stores (mapv (fn [{:keys [out reduction-op conflict] :as store}]
-                         (let [destination-type (some-> (destination-dtype array-types out)
-                                                       dtype/canon)
-                               contract (cond
-                                          (= :unique conflict) :unique
-                                          reduction-op
-                                          (when destination-type
-                                            (dialect/reducing-scatter-conflict
-                                             reduction-op destination-type))
-                                          (= index (:index store)) :unique
-                                          :else :ordered)]
-                           (assoc store :effect-conflict contract
-                                        :destination-dtype destination-type)))
-                       stores)
-          ;; One physical destination has one cross-item contract. If any ordinary store may
-          ;; collide, its otherwise-unique siblings must join the same sequential contract. A
-          ;; reduction mixed with an ordered overwrite remains unsupported: those are distinct
-          ;; operations and must not be blurred into one conflict certificate.
-          stores (reduce (fn [current [_ grouped]]
-                           (let [contracts (set (map :effect-conflict grouped))]
-                             (if (and (contains? contracts :ordered)
-                                      (set/subset? contracts #{:unique :ordered}))
-                               (mapv (fn [store]
-                                       (if (= (:out (first grouped)) (:out store))
-                                         (assoc store :effect-conflict :ordered)
-                                         store))
-                                     current)
-                               current)))
-                         stores (group-by :out stores))
-          effect-contracts (mapv :effect-conflict stores)
-          uniform-conflict (when (= 1 (count (set effect-contracts)))
-                             (first effect-contracts))
-          scatter? (and (not pointwise?)
-                        (independent-stores? locals stores)
-                        (or (= :unique uniform-conflict)
-                            (dialect/reducing-scatter-conflict? uniform-conflict)))
-          ordered? (and (not dense-pointwise?) (not scatter?) (= :effect host-return)
-                        (every? some? effect-contracts)
-                        (every? (fn [[_ grouped]]
-                                  (= 1 (count (set (map :effect-conflict grouped)))))
-                                (group-by :out stores)))
-          iteration-order (when ordered?
-                            (if (or (some #(= :ordered (:effect-conflict %)) stores)
-                                    (not (ordered-effects-safe? locals stores)))
-                              :sequential
-                              :independent))
-          destinations (if ordered?
-                         (vec (distinct (map :out stores)))
-                         (mapv :out stores))
-          values (mapv :value stores)
-          write-indices (mapv :index stores)
-          predicates (mapv :predicate stores)
-          analysis-values (concat (map :init locals) write-indices predicates values)
-          io (update (extract-io (list* 'do analysis-values) index destinations)
-                     :scalars set/difference (set (map :id locals)))
-          results (if (= :buffer host-return)
-                    [symbol]
-                    (mapv #(effect-result-id id %) (range (count destinations))))
-          result-dtypes (mapv #(some-> (destination-dtype array-types %) dtype/canon)
-                              destinations)]
-      (when (or pointwise? scatter? (and ordered? (every? some? result-dtypes)))
-        (merge {:kind (cond pointwise? :map scatter? :scatter :else :effect-map)
-                :id id :sym symbol :index index :extent extent
-                :results results :locals locals :bodies values :casts (mapv :cast stores)
-                :write-indices write-indices :predicates predicates
-                :conflict (when scatter? uniform-conflict)
-                :effects (when ordered?
-                           (mapv #(select-keys % [:out :index :predicate :value :cast
-                                                  :effect-conflict])
-                                 stores))
-                :iteration-order iteration-order
-                :result-dtypes (when ordered? result-dtypes)
-                :effect-only? (= :effect host-return)
-                :host-binding symbol :elem-type elem-type
-                :result-storage
-                (mapv (fn [destination]
-                        {:destination destination
-                         :access (if (or scatter?
-                                         (and ordered?
-                                              (some #(and (= destination (:out %))
-                                                          (dialect/reducing-scatter-conflict?
-                                                           (:effect-conflict %)))
-                                                    stores))
-                                         (contains? (:inputs io) destination))
-                                   :read-write :write)
-                         :host-return host-return})
-                      destinations)}
-               io)))))
+  (let [loops (or loops [])]
+    (when (and (or (seq stores) (seq loops))
+               (or (= :effect host-return) (and (empty? loops) (= 1 (count stores))))
+               ;; A destination written both directly and inside a store loop would lose the work
+               ;; item's source order between the two kinds of write; such regions stay unsupported.
+               (empty? (set/intersection (set (map :out stores))
+                                         (set (mapcat #(map :out (:stores %)) loops)))))
+      (let [stores (mapv #(merge {:index index :predicate 1} %) stores)
+            loop-stores
+            (vec (mapcat (fn [ordinal {loop-index :index loop-extent :extent
+                                       loop-locals :locals loop-store-list :stores}]
+                           (map (fn [store]
+                                  (let [store (merge {:index index :predicate 1} store)]
+                                    (assoc store
+                                           :loop ordinal
+                                           :loop-injective?
+                                           (row-major-loop-index?
+                                            (inline-region-locals (:index store)
+                                                                  (concat locals loop-locals))
+                                            loop-index index loop-extent))))
+                                loop-store-list))
+                         (range) loops))
+            dense-pointwise? (and (empty? loops)
+                                  (every? #(and (= index (:index %)) (nil? (:reduction-op %)))
+                                          stores))
+            pointwise? (and dense-pointwise? (independent-stores? locals stores))
+            stores (if pointwise?
+                     (mapv (fn [{:keys [out predicate value] :as store}]
+                             (assoc store :value
+                                    (if (contains? #{true 1} predicate)
+                                      value
+                                      ;; A guarded dense write preserves its caller-owned
+                                      ;; destination. Making that read explicit yields an ordinary
+                                      ;; inout map instead of a hidden conditional effect.
+                                      (list 'if predicate value
+                                            (list 'clojure.core/aget out index)))))
+                           stores)
+                     stores)
+            all-stores (mapv (fn [{:keys [out reduction-op conflict] :as store}]
+                               (let [destination-type (some-> (destination-dtype array-types out)
+                                                             dtype/canon)
+                                     contract (cond
+                                                (= :unique conflict) :unique
+                                                reduction-op
+                                                (when destination-type
+                                                  (dialect/reducing-scatter-conflict
+                                                   reduction-op destination-type))
+                                                (:loop-injective? store) :unique
+                                                (and (nil? (:loop store)) (= index (:index store)))
+                                                :unique
+                                                :else :ordered)]
+                                 (assoc store :effect-conflict contract
+                                              :destination-dtype destination-type)))
+                             (into stores loop-stores))
+            ;; One physical destination has one cross-item contract. If any ordinary store may
+            ;; collide, its otherwise-unique siblings must join the same sequential contract. A
+            ;; reduction mixed with an ordered overwrite remains unsupported: those are distinct
+            ;; operations and must not be blurred into one conflict certificate.
+            all-stores (reduce (fn [current [_ grouped]]
+                                 (let [contracts (set (map :effect-conflict grouped))]
+                                   (if (and (contains? contracts :ordered)
+                                            (set/subset? contracts #{:unique :ordered}))
+                                     (mapv (fn [store]
+                                             (if (= (:out (first grouped)) (:out store))
+                                               (assoc store :effect-conflict :ordered)
+                                               store))
+                                           current)
+                                     current)))
+                               all-stores (group-by :out all-stores))
+            stores (vec (remove :loop all-stores))
+            effect-contracts (mapv :effect-conflict all-stores)
+            uniform-conflict (when (= 1 (count (set effect-contracts)))
+                               (first effect-contracts))
+            scatter? (and (not pointwise?)
+                          (empty? loops)
+                          (independent-stores? locals stores)
+                          (or (= :unique uniform-conflict)
+                              (dialect/reducing-scatter-conflict? uniform-conflict)))
+            ordered? (and (not dense-pointwise?) (not scatter?) (= :effect host-return)
+                          (every? some? effect-contracts)
+                          (every? (fn [[_ grouped]]
+                                    (= 1 (count (set (map :effect-conflict grouped)))))
+                                  (group-by :out all-stores)))
+            all-locals (vec (concat locals (mapcat :locals loops)))
+            iteration-order (when ordered?
+                              (if (or (some #(= :ordered (:effect-conflict %)) all-stores)
+                                      (not (ordered-effects-safe? all-locals all-stores)))
+                                :sequential
+                                :independent))
+            destinations (if ordered?
+                           (vec (distinct (map :out all-stores)))
+                           (mapv :out stores))
+            values (mapv :value all-stores)
+            write-indices (mapv :index all-stores)
+            predicates (mapv :predicate all-stores)
+            analysis-values (concat (map :init all-locals) (map :extent loops)
+                                    write-indices predicates values)
+            io (update (extract-io (list* 'do analysis-values) index destinations)
+                       :scalars set/difference (set (map :id all-locals))
+                       (set (map :index loops)))
+            results (if (= :buffer host-return)
+                      [symbol]
+                      (mapv #(effect-result-id id %) (range (count destinations))))
+            result-dtypes (mapv #(some-> (destination-dtype array-types %) dtype/canon)
+                                destinations)
+            store-effect (fn [store]
+                           (select-keys store [:out :index :predicate :value :cast
+                                               :effect-conflict]))
+            loop-effects (map-indexed
+                          (fn [ordinal {loop-index :index loop-locals :locals
+                                        :keys [lower extent]}]
+                            {:loop {:index loop-index :lower lower :extent extent
+                                    :locals loop-locals
+                                    :effects (mapv store-effect
+                                                   (filter #(= ordinal (:loop %)) all-stores))}})
+                          loops)]
+        (when (or pointwise? scatter? (and ordered? (every? some? result-dtypes)))
+          (merge {:kind (cond pointwise? :map scatter? :scatter :else :effect-map)
+                  :id id :sym symbol :index index :extent extent
+                  :results results :locals locals :bodies values :casts (mapv :cast all-stores)
+                  :write-indices write-indices :predicates predicates
+                  :conflict (when scatter? uniform-conflict)
+                  :effects (when ordered?
+                             (vec (concat (map store-effect stores) loop-effects)))
+                  :iteration-order iteration-order
+                  :result-dtypes (when ordered? result-dtypes)
+                  :effect-only? (= :effect host-return)
+                  :host-binding symbol :elem-type elem-type
+                  :result-storage
+                  (mapv (fn [destination]
+                          {:destination destination
+                           :access (if (or scatter?
+                                           (and ordered?
+                                                (some #(and (= destination (:out %))
+                                                            (dialect/reducing-scatter-conflict?
+                                                             (:effect-conflict %)))
+                                                      all-stores))
+                                           (contains? (:inputs io) destination))
+                                     :read-write :write)
+                           :host-return host-return})
+                        destinations)}
+                 io))))))
 
 (defn- reducing-scatter-description
   [id symbol out values indices extent operator default-dtype]
@@ -1172,7 +1374,7 @@
                      (every? (fn [{:keys [effect-conflict]}]
                                (or (contains? #{:unique :ordered} effect-conflict)
                                    (dialect/reducing-scatter-conflict? effect-conflict)))
-                             (:effects description)))
+                             (effect-leaves (:effects description))))
     :stencil (and (= 1 (count (:result-storage description)))
                   (symbol? (get-in description [:result-storage 0 :destination])))
     :reduce true
@@ -1209,6 +1411,7 @@
   (when (and (seq? source) (contains? #{'let 'let*} (first source)))
     (let [[_ bindings] source
           pairs (vec (partition 2 bindings))
+          array-types (binder-array-types pairs array-types)
           descriptions (normalize-extents (source-descriptions pairs dtype array-types)
                                           shape-equalities values)
           physical-outputs (physical-output-symbols descriptions)
@@ -1347,13 +1550,20 @@
                 (dialect/lambda-form (vec (concat parameters capture-parameters))
                                      local-forms writes)))))
 
+(defn- effect-expressions
+  "Every expression an effect evaluates, descending into store loops."
+  [effect]
+  (if-let [{:keys [extent locals effects]} (:loop effect)]
+    (concat [extent] (map :init locals) (mapcat effect-expressions effects))
+    [(:index effect) (:predicate effect) (:value effect)]))
+
 (defn- effect-map-equation
   [{:keys [id index extent iteration-order locals inputs scalars results result-storage effects
            result-dtypes]}]
   (let [destinations (mapv :destination result-storage)
         destination-set (set destinations)
         all-expressions (vec (concat (map :init locals)
-                                     (mapcat (juxt :index :predicate :value) effects)))
+                                     (mapcat effect-expressions effects)))
         semantic-inputs (set/difference (set inputs) destination-set)
         [pointwise stable]
         ((juxt filter remove) #(pointwise-input? all-expressions % index) semantic-inputs)
@@ -1373,12 +1583,21 @@
         local-forms (mapv (fn [{:keys [id dtype init]}]
                             (dialect/local-value id dtype (transform init)))
                           locals)
-        effect-forms
-        (mapv (fn [{:keys [out index predicate value cast effect-conflict]}]
-                (list 'effect (get destination-substitutions out)
-                      effect-conflict (transform index) (transform predicate)
-                      (transform (if cast (list cast value) value))))
-              effects)]
+        effect-form
+        (fn effect-form [{:keys [out index predicate value cast effect-conflict] :as effect}]
+          (if-let [{loop-index :index loop-locals :locals loop-effects :effects
+                    :keys [lower extent]} (:loop effect)]
+            (list 'effect-loop {:index loop-index :lower lower} (transform extent)
+                  (list 'lambda [loop-index]
+                        (dialect/effect-lambda-region
+                         (mapv (fn [{:keys [id dtype init]}]
+                                 (dialect/local-value id dtype (transform init)))
+                               loop-locals)
+                         (mapv effect-form loop-effects))))
+            (list 'effect (get destination-substitutions out)
+                  effect-conflict (transform index) (transform predicate)
+                  (transform (if cast (list cast value) value)))))
+        effect-forms (mapv effect-form effects)]
     (list '= id results
           (list 'effect-map
                 {:index index :extent extent :dtypes result-dtypes
@@ -1795,6 +2014,7 @@
   (when (and (seq? source) (contains? #{'let 'let*} (first source)))
     (let [[_ bindings & body] source
           pairs (vec (partition 2 bindings))
+          array-types (binder-array-types pairs array-types)
           descriptions (normalize-extents (source-descriptions pairs dtype array-types)
                                           shape-equalities values)]
       (when (and (even? (count bindings))

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -1035,6 +1035,13 @@
                  ;; conversions are not scalar fold syntax. Keep them on the certified
                  ;; contraction route until TypedSOAC represents those facts explicitly.
                  (empty? (apply dissoc opts [:init :combine :algebra :epilogue]))
+                 ;; The contraction's element dtype is the dtype of its operands. A double
+                 ;; product over arrays declared float (a hard-typed double function compiled
+                 ;; under a float policy) has no single typed kernel; it stays a host call.
+                 (every? (fn [{:keys [sym]}]
+                           (let [declared (some-> (get array-types sym) dtype/canon)]
+                             (or (nil? declared) (= declared (dtype/canon (:dtype facts))))))
+                         (:operands facts))
                  (or (nil? epilogue) (dialect/result-transform? result-transform))
                  (reduction/scalar? (:reduction facts)))
         (let [product (:reduction facts)
@@ -1179,12 +1186,79 @@
           (cond-> (meta expression) scatter (assoc ::host-return :buffer))))
       expression)))
 
-(defn normalize-source
-  "Give pure compound parallel extents stable scalar SSA identities before dialect construction.
+(defn- canonicalize-blas-gemm
+  "Express a devirtualized BLAS GEMM call as the explicit contraction it computes.
 
-   TypedSOAC operations name extents; executable host expressions never leak into schedule fields.
-   This normalization inserts an ordinary typed scalar binding immediately before its operation,
-   so the same expression remains visible to JVM materialization and runtime specialization."
+   `(dgemm! A B C m k n alpha beta)` is `C[m,n] = alpha·A·B + beta·C` over row-major operands;
+   the `-tn!`/`-nt!` variants store `A` as `[k,m]` / `B` as `[n,k]`. With `beta = 0` the call
+   is the pure contraction `(raster.par/contract C [[i m] [j n]] [[l k]] (* A[i,l] B[l,j]))`
+   scaled by `alpha`, and the typed route can schedule it like any contraction instead of
+   leaving the whole block on the host because one binding is an opaque BLAS effect. A non-zero
+   `beta` reads the destination inside its own epilogue and stays a host call for now."
+  [ordinal expression]
+  (let [variant (when (and (seq? expression) (= '.invk (first expression)))
+                  (get descriptor/blas-gemm-ops (:raster.op/original (meta expression))))
+        arguments (when variant (vec (drop 2 expression)))
+        [A B C m k n alpha beta] arguments
+        beta-literal (when variant (descriptor/gemm-scalar-literal beta))
+        alpha-literal (when variant (descriptor/gemm-scalar-literal alpha))]
+    (if (and variant (= 8 (count arguments))
+             (symbol? A) (symbol? B) (symbol? C)
+             (= 0.0 beta-literal))
+      (let [i (clojure.core/symbol (str "rstr_gemm_i_" ordinal))
+            j (clojure.core/symbol (str "rstr_gemm_j_" ordinal))
+            l (clojure.core/symbol (str "rstr_gemm_l_" ordinal))
+            [m k n] (map descriptor/unwrap-int-cast [m k n])
+            a-index (case variant
+                      (:nn :nt) (list 'clojure.core/+ (list 'clojure.core/* i k) l)
+                      :tn (list 'clojure.core/+ (list 'clojure.core/* l m) i))
+            b-index (case variant
+                      (:nn :tn) (list 'clojure.core/+ (list 'clojure.core/* l n) j)
+                      :nt (list 'clojure.core/+ (list 'clojure.core/* j k) l))
+            elem-type (some-> (or (:raster.type/tag (meta expression)) (:tag (meta expression)))
+                              dtype/dtype-for-array-tag dtype/canon)
+            ;; The walker stamps every arithmetic form with its result dtype; the emitted loads
+            ;; and product carry the same stamp so scalar lowering reads the type instead of
+            ;; guessing it.
+            scalar-tag (some-> elem-type dtype/scalar-tag-for-dtype)
+            typed (fn [form]
+                    (if scalar-tag
+                      (with-meta form {:raster.type/tag scalar-tag :tag scalar-tag})
+                      form))
+            product (typed (list 'clojure.core/*
+                                 (typed (list 'clojure.core/aget A a-index))
+                                 (typed (list 'clojure.core/aget B b-index))))
+            ;; `alpha` arrives as `(oftype witness value)` from the source spelling; the scalar
+            ;; factor is its value, not the type witness array.
+            alpha-value (cond
+                          ;; A literal factor (`-1`, `(float 2.0)`) is the element-typed number
+                          ;; it denotes, not an integer literal that would mistype the product.
+                          (some? alpha-literal) alpha-literal
+                          (and (seq? alpha)
+                               (= 'raster.numeric/oftype (descriptor/semantic-op alpha))
+                               (= 2 (count (descriptor/call-args alpha))))
+                          (second (descriptor/call-args alpha))
+                          :else alpha)
+            body (if (= 1.0 alpha-literal)
+                   product
+                   (typed (list 'clojure.core/* alpha-value product)))]
+        (with-meta (list 'raster.par/contract C [[i m] [j n]] [[l k]] body)
+          (cond-> {:raster.op/original (:raster.op/original (meta expression))}
+            elem-type (assoc :raster.type/elem-type elem-type))))
+      expression)))
+
+(defn- source-shadowing-locals
+  "The symbols that are locals of the analyzed source even when they collide with a
+   `clojure.core` name: the let's own binders and the declared parameters. `util/free-syms`
+   would otherwise read a parameter named `seq` or `count` as the core function and drop it
+   from every capture set, leaving a kernel that references an unbound scalar."
+  [source & type-maps]
+  (let [[_ bindings] (when (and (seq? source) (contains? #{'let 'let*} (first source)))
+                       source)]
+    (into (set (filter symbol? (take-nth 2 bindings)))
+          (mapcat keys type-maps))))
+
+(defn- normalize-source*
   [source]
   ;; Direct backend entry may see source before the ordinary pipeline's SSA cleanup. Clojure
   ;; permits sequential rebinding (most commonly repeated `_` effect binders), while TypedSOAC
@@ -1198,7 +1272,9 @@
             {:keys [normalized]}
             (reduce
              (fn [{:keys [compound-extents] :as state} [ordinal [symbol expression]]]
-               (let [expression (canonicalize-strided-indexed-operation ordinal expression)
+               (let [expression (->> expression
+                                     (canonicalize-strided-indexed-operation ordinal)
+                                     (canonicalize-blas-gemm ordinal))
                      extent (parallel-extent expression)
                      canonical-extent (some-> extent descriptor/unwrap-int-cast)]
                  (cond
@@ -1342,12 +1418,24 @@
                   (descriptor/alloc-op? (descriptor/semantic-op expression)))))))
 
 (defn- physical-output-symbols
+  "Every buffer some operation writes, closed under host renamings: a binding that merely
+   renames a buffer (`out y`) shares its physical identity, so a write through the alias is a
+   write to the allocation it names and that allocation is generated scaffolding as well."
   [descriptions]
-  (reduce set/union #{}
-          (map #(if (contains? #{:map :scatter :effect-map :stencil :reduce :segmented-reduce
-                                 :product-reduce :segmented-fold-map :scan} (:kind %))
-                  (:outputs %) #{})
-               descriptions)))
+  (let [written (reduce set/union #{}
+                        (map #(if (contains? #{:map :scatter :effect-map :stencil :reduce
+                                               :segmented-reduce :product-reduce
+                                               :segmented-fold-map :scan} (:kind %))
+                                (:outputs %) #{})
+                             descriptions))
+        renamings (keep #(when (and (= :scalar (:kind %)) (symbol? (:expr %)))
+                           [(:sym %) (:expr %)])
+                        descriptions)]
+    (loop [outputs written]
+      (let [closed (into outputs (keep (fn [[alias source]]
+                                         (when (contains? outputs alias) source))
+                                       renamings))]
+        (if (= closed outputs) outputs (recur closed))))))
 
 (defn- contains-parallel-form?
   [expression]
@@ -1401,11 +1489,29 @@
                  (supported-description? physical-outputs %))
             descriptions)))
 
+(defn normalize-source
+  "Give pure compound parallel extents stable scalar SSA identities before dialect construction.
+
+   TypedSOAC operations name extents; executable host expressions never leak into schedule fields.
+   This normalization inserts an ordinary typed scalar binding immediately before its operation,
+   so the same expression remains visible to JVM materialization and runtime specialization."
+  [source]
+  (binding [util/*shadowing-locals* (source-shadowing-locals source)]
+    (normalize-source* source)))
+
+(declare coverage-decline*)
+
 (defn coverage-decline
   "Describe the exact source bindings that prevent admission to the closed TypedSOAC subset.
 
    This is diagnostic evidence only: it uses the same descriptions and admission predicate as
    form->program, so reporting cannot become a second legality implementation."
+  [source {:keys [array-types scalar-types values] :as options}]
+  (binding [util/*shadowing-locals* (source-shadowing-locals source array-types scalar-types
+                                                             values)]
+    (coverage-decline* source options)))
+
+(defn- coverage-decline*
   [source {:keys [dtype array-types values shape-equalities]
            :or {dtype :double array-types {} values {} shape-equalities {}}}]
   (when (and (seq? source) (contains? #{'let 'let*} (first source)))
@@ -2002,6 +2108,8 @@
                 {:id id :first prior :second contract})))
      (assoc values id contract))))
 
+(declare form->program*)
+
 (defn form->program
   "Construct and validate TypedSOAC islands directly from a let form.
 
@@ -2009,6 +2117,12 @@
    Returns nil when a parallel binding is outside the certified source subset. Type/effect/value
    contradictions throw ExceptionInfo because falling through after accepting them would hide a
    compiler correctness defect."
+  [source {:keys [array-types scalar-types values] :as options}]
+  (binding [util/*shadowing-locals* (source-shadowing-locals source array-types scalar-types
+                                                             values)]
+    (form->program* source options)))
+
+(defn- form->program*
   [source {:keys [dtype array-types scalar-types values shape-equalities]
            :or {dtype :double array-types {} scalar-types {} values {} shape-equalities {}}}]
   (when (and (seq? source) (contains? #{'let 'let*} (first source)))

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -265,8 +265,17 @@
            :locals locals
            :body-results (mapv #(util/subst-syms substitutions %) (:body-results info)))))
 
+(def ^:private single-lambda-kinds
+  "Operation kinds whose form is exactly `(kind attributes arrays captures lambda)`. Fold-maps,
+   product reductions and effect maps carry further parts (folds, a combine lambda,
+   destinations) that this emitter would silently drop."
+  #{:scalar :map :scatter :stencil :reduce :segmented-reduce :scan})
+
 (defn- emit-equation
   [{:keys [kind id results attributes arrays captures parameters locals body-results]}]
+  (when-not (contains? single-lambda-kinds kind)
+    (throw (ex-info "fusion cannot re-emit an operation kind with parts beyond one lambda"
+                    {:reason :raster/bug :kind kind :equation id})))
   (list '= id (vec results)
         (list (symbol (name kind)) attributes (vec arrays) (vec captures)
               (dialect/lambda-form (vec parameters) (dialect/emit-locals locals)
@@ -799,11 +808,10 @@
       (rebuild-boundary program facts equations))))
 
 (defn- producer-placement-witness
-  [program infos uses producer produced abstract-machine]
-  (let [consumer-ids (->> infos
-                          (filter #(some #{produced} (equation-references
-                                                      (emit-equation %))))
-                          (mapv :id))
+  [program _infos uses producer produced abstract-machine]
+  (let [consumer-ids (->> (dialect/equations program)
+                          (filter #(some #{produced} (equation-references %)))
+                          (mapv second))
         witness (placement/placement-decision
                  {:abstract-machine abstract-machine
                   :dtype (value-scalar-dtype program produced)

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -295,8 +295,8 @@
                           result-dtype (get dtype-by-destination destination)
                           destination (with-meta destination
                                         {:raster.type/tag
-                                         (dtype/scalar-tag-for-dtype result-dtype)
-                                         :tag (dtype/scalar-tag-for-dtype result-dtype)})
+                                         (dtype/array-tag-for-dtype result-dtype)
+                                         :tag (dtype/array-tag-for-dtype result-dtype)})
                           typed-value (list cast value)
                           store (if (dialect/reducing-scatter-conflict? conflict)
                                   (list 'raster.par/atomic-add!

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -85,6 +85,16 @@
                        locals)
          :bodies (mapv project-body body-results)}))))
 
+(defn- storage-only-dtype?
+  "A dtype with device storage but no JVM scalar: its values move bit-exactly between arrays
+   (`short[]` carries `:half`) and a host statement stores them without a scalar cast."
+  [dtype]
+  (= :half (some-> dtype dtype/canon)))
+
+(defn- typed-store-value
+  [cast value]
+  (if cast (list cast value) value))
+
 (defn- materialize-region
   [locals body]
   (if (seq locals)
@@ -144,7 +154,10 @@
         (let [result (first results)
               result-dtypes (mapv #(:dtype (get values %)) results)
               casts (mapv #(nth (get dtype->allocation %) 2 nil) result-dtypes)
-              _ (when (some nil? casts)
+              ;; A storage-only dtype (`:half` in `short[]`) has no JVM scalar cast; its map
+              ;; results are stored bit-exactly, so only dtypes with a scalar need one.
+              _ (when (some (fn [[cast dtype]] (and (nil? cast) (not (storage-only-dtype? dtype))))
+                            (map vector casts result-dtypes))
                   (throw (ex-info "TypedSOAC materialization has no scalar cast for map output"
                                   {:reason :typed-soac-materialization-dtype
                                    :results results :dtypes result-dtypes})))
@@ -164,7 +177,7 @@
               secondary-stores
               (mapv (fn [secondary secondary-cast body]
                       (list 'clojure.core/aset secondary (:index attributes)
-                            (list secondary-cast body)))
+                            (typed-store-value secondary-cast body)))
                     (rest physical-results) (rest casts) (rest bodies))
               body (materialize-region
                     region-locals
@@ -182,7 +195,7 @@
                                        (map (fn [destination result-cast result-body]
                                               (list 'clojure.core/aset destination
                                                     (:index attributes)
-                                                    (list result-cast result-body)))
+                                                    (typed-store-value result-cast result-body)))
                                             physical-results casts bodies))))
 
                          (= #{:buffer} host-returns)
@@ -221,7 +234,8 @@
             host-returns (mapv :host-return storage)
             _ (when-not (and (= (count results) (count writes) (count physical-results))
                              (every? some? writes)
-                             (every? some? casts)
+                             (every? (fn [[cast dtype]] (or cast (storage-only-dtype? dtype)))
+                                     (map vector casts result-dtypes))
                              (every? #{:effect :buffer} host-returns))
                 (throw (ex-info "the production scatter route requires typed effect writes"
                                 {:reason :typed-soac-production-subset
@@ -232,9 +246,9 @@
                        {:keys [destination-index predicate value]}]
                     (let [destination (with-meta destination
                                         {:raster.type/tag
-                                         (dtype/scalar-tag-for-dtype result-dtype)
-                                         :tag (dtype/scalar-tag-for-dtype result-dtype)})
-                          typed-value (list cast value)
+                                         (dtype/array-tag-for-dtype result-dtype)
+                                         :tag (dtype/array-tag-for-dtype result-dtype)})
+                          typed-value (typed-store-value cast value)
                           store (if reducing?
                                   (list 'raster.par/atomic-add!
                                         destination destination-index typed-value)
@@ -270,7 +284,9 @@
             effects (mapv dialect/effect-parts bodies)
             _ (when-not (and (= (count results) (count physical-results)
                                 (count result-dtypes) (count casts))
-                             (every? some? effects) (every? some? casts)
+                             (every? some? effects)
+                             (every? (fn [[cast dtype]] (or cast (storage-only-dtype? dtype)))
+                                     (map vector casts result-dtypes))
                              (= #{:effect} (set (map :host-return storage))))
                 (throw (ex-info "the production effect-map route requires typed effect storage"
                                 {:reason :typed-soac-production-subset
@@ -297,7 +313,7 @@
                                         {:raster.type/tag
                                          (dtype/array-tag-for-dtype result-dtype)
                                          :tag (dtype/array-tag-for-dtype result-dtype)})
-                          typed-value (list cast value)
+                          typed-value (typed-store-value cast value)
                           store (if (dialect/reducing-scatter-conflict? conflict)
                                   (list 'raster.par/atomic-add!
                                         destination destination-index typed-value)
@@ -558,7 +574,8 @@
   ([form dtype array-types {:keys [resident-reductions? scalar-types values abstract-machine]
                             :or {resident-reductions? false}}]
    (when (and (seq? form) (contains? #{'let 'let*} (first form)))
-     (let [form (frontend/normalize-source form)]
+     (let [form (frontend/normalize-source form {:array-types array-types
+                                                 :scalar-types scalar-types})]
        (try
          (let [frontend-options {:dtype dtype :array-types array-types
                                  :scalar-types scalar-types :values values}

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -59,14 +59,26 @@
               (projection/scalar-folds->source
                (util/subst-syms substitutions expression)))
             project-body
-            (fn [body]
+            (fn project-body [body]
               (if (= 'effect-map kind)
-                (let [{:keys [destination conflict destination-index predicate value]}
+                (let [{:keys [loop destination conflict destination-index predicate value]
+                       :as parts}
                       (dialect/effect-parts body)]
-                  (list 'effect (get substitutions destination destination) conflict
-                        (project-expression destination-index)
-                        (project-expression predicate)
-                        (project-expression value)))
+                  (if loop
+                    (let [{:keys [locals body-results]} (dialect/lambda-parts (:lambda parts))]
+                      (list 'effect-loop {:index (:index parts) :lower (:lower parts)}
+                            (project-expression (:extent parts))
+                            (list 'lambda [(:index parts)]
+                                  (dialect/effect-lambda-region
+                                   (mapv (fn [{:keys [id dtype init]}]
+                                           (dialect/local-value id dtype
+                                                                (project-expression init)))
+                                         locals)
+                                   (mapv project-body body-results)))))
+                    (list 'effect (get substitutions destination destination) conflict
+                          (project-expression destination-index)
+                          (project-expression predicate)
+                          (project-expression value))))
                 (project-expression body)))]
         {:locals (mapv #(update % :init (fn [init]
                                           (project-expression init)))
@@ -264,8 +276,21 @@
                                 {:reason :typed-soac-production-subset
                                  :equation equation-id :results results
                                  :storage storage :effects effects :dtypes result-dtypes})))
-            statements
-            (mapv (fn [{:keys [destination conflict destination-index predicate value]}]
+            statement
+            (fn statement [{:keys [loop destination conflict destination-index predicate value]
+                            :as parts}]
+                  (if loop
+                    (let [{:keys [locals body-results]} (dialect/lambda-parts (:lambda parts))
+                          loop-index (:index parts)]
+                      (list 'loop* [loop-index (:lower parts)]
+                            (list 'if (list 'clojure.core/< loop-index (:extent parts))
+                                  (list 'do
+                                        (materialize-region
+                                         locals
+                                         (list* 'do (mapv (comp statement dialect/effect-parts)
+                                                          body-results)))
+                                        (list 'recur (list 'clojure.core/inc loop-index)))
+                                  nil)))
                     (let [cast (get cast-by-destination destination)
                           result-dtype (get dtype-by-destination destination)
                           destination (with-meta destination
@@ -278,8 +303,8 @@
                                         destination destination-index typed-value)
                                   (list 'clojure.core/aset destination destination-index
                                         typed-value))]
-                      (if (contains? #{true 1} predicate) store (list 'if predicate store))))
-                  effects)
+                      (if (contains? #{true 1} predicate) store (list 'if predicate store)))))
+            statements (mapv statement effects)
             effect-source
             (with-meta
               (list 'raster.par/map-void! (:index attributes) (:extent attributes)

--- a/src/raster/linalg/blas.clj
+++ b/src/raster/linalg/blas.clj
@@ -214,50 +214,71 @@
 ;; Lazy — MethodHandle created on first deref
 (def ^:private dgemm-mh (delay (make-handle "cblas_dgemm" dgemm-fd)))
 
+(defn- scale-output-double!
+  "BLAS semantics for a GEMM whose contraction extent is zero: `C := beta·C` over the `m·n`
+   output elements (zero fill for `beta = 0`). The library call itself is skipped for `k = 0`
+   because MKL rejects a zero leading dimension, but the output contract must not change."
+  [^doubles C ^long n ^double beta]
+  (if (zero? beta)
+    (java.util.Arrays/fill C 0 (int n) 0.0)
+    (dotimes [i n] (aset C i (* beta (aget C i))))))
+
+(defn- scale-output-float!
+  [^floats C ^long n ^double beta]
+  (if (zero? beta)
+    (java.util.Arrays/fill C 0 (int n) (float 0.0))
+    (dotimes [i n] (aset C i (float (* beta (aget C i)))))))
+
 (deftm ^:no-inline dgemm!
   [A :- (Array double) B :- (Array double) C :- (Array double)
    m :- Long k :- Long n :- Long alpha :- Double beta :- Double]
   :- (Array double)
   ;; Skip degenerate (empty) gemm — see the f32 dgemm-nt! note (MKL lda=0 guard).
-  (when (and (pos? m) (pos? n) (pos? k))
-    (.invokeWithArguments ^java.lang.invoke.MethodHandle @dgemm-mh
+  (if (and (pos? m) (pos? n) (zero? k))
+    (scale-output-double! C (* m n) beta)
+    (when (and (pos? m) (pos? n) (pos? k))
+      (.invokeWithArguments ^java.lang.invoke.MethodHandle @dgemm-mh
                           [CBLAS_ROW_MAJOR CBLAS_NO_TRANS CBLAS_NO_TRANS
                            (int m) (int n) (int k)
                            alpha
                            (MemorySegment/ofArray A) (int k)
                            (MemorySegment/ofArray B) (int n)
                            beta
-                           (MemorySegment/ofArray C) (int n)]))
+                           (MemorySegment/ofArray C) (int n)])))
   C)
 
 (deftm ^:no-inline dgemm-tn!
   [A :- (Array double) B :- (Array double) C :- (Array double)
    m :- Long k :- Long n :- Long alpha :- Double beta :- Double]
   :- (Array double)
-  (when (and (pos? m) (pos? n) (pos? k))
-    (.invokeWithArguments ^java.lang.invoke.MethodHandle @dgemm-mh
+  (if (and (pos? m) (pos? n) (zero? k))
+    (scale-output-double! C (* m n) beta)
+    (when (and (pos? m) (pos? n) (pos? k))
+      (.invokeWithArguments ^java.lang.invoke.MethodHandle @dgemm-mh
                           [CBLAS_ROW_MAJOR CBLAS_TRANS CBLAS_NO_TRANS
                            (int m) (int n) (int k)
                            alpha
                            (MemorySegment/ofArray A) (int m)   ;; lda = m (A is [k,m])
                            (MemorySegment/ofArray B) (int n)
                            beta
-                           (MemorySegment/ofArray C) (int n)]))
+                           (MemorySegment/ofArray C) (int n)])))
   C)
 
 (deftm ^:no-inline dgemm-nt!
   [A :- (Array double) B :- (Array double) C :- (Array double)
    m :- Long k :- Long n :- Long alpha :- Double beta :- Double]
   :- (Array double)
-  (when (and (pos? m) (pos? n) (pos? k))
-    (.invokeWithArguments ^java.lang.invoke.MethodHandle @dgemm-mh
+  (if (and (pos? m) (pos? n) (zero? k))
+    (scale-output-double! C (* m n) beta)
+    (when (and (pos? m) (pos? n) (pos? k))
+      (.invokeWithArguments ^java.lang.invoke.MethodHandle @dgemm-mh
                           [CBLAS_ROW_MAJOR CBLAS_NO_TRANS CBLAS_TRANS
                            (int m) (int n) (int k)
                            alpha
                            (MemorySegment/ofArray A) (int k)
                            (MemorySegment/ofArray B) (int k)   ;; ldb = k (B is [n,k])
                            beta
-                           (MemorySegment/ofArray C) (int n)]))
+                           (MemorySegment/ofArray C) (int n)])))
   C)
 
 ;; ================================================================
@@ -288,30 +309,34 @@
   [A :- (Array float) B :- (Array float) C :- (Array float)
    m :- Long k :- Long n :- Long alpha :- Float beta :- Float]
   :- (Array float)
-  (when (and (pos? m) (pos? n) (pos? k))
-    (.invokeWithArguments ^java.lang.invoke.MethodHandle @sgemm-mh
+  (if (and (pos? m) (pos? n) (zero? k))
+    (scale-output-float! C (* m n) beta)
+    (when (and (pos? m) (pos? n) (pos? k))
+      (.invokeWithArguments ^java.lang.invoke.MethodHandle @sgemm-mh
                           [CBLAS_ROW_MAJOR CBLAS_NO_TRANS CBLAS_NO_TRANS
                            (int m) (int n) (int k)
                            alpha
                            (MemorySegment/ofArray A) (int k)
                            (MemorySegment/ofArray B) (int n)
                            beta
-                           (MemorySegment/ofArray C) (int n)]))
+                           (MemorySegment/ofArray C) (int n)])))
   C)
 
 (deftm ^:no-inline dgemm-tn!
   [A :- (Array float) B :- (Array float) C :- (Array float)
    m :- Long k :- Long n :- Long alpha :- Float beta :- Float]
   :- (Array float)
-  (when (and (pos? m) (pos? n) (pos? k))
-    (.invokeWithArguments ^java.lang.invoke.MethodHandle @sgemm-mh
+  (if (and (pos? m) (pos? n) (zero? k))
+    (scale-output-float! C (* m n) beta)
+    (when (and (pos? m) (pos? n) (pos? k))
+      (.invokeWithArguments ^java.lang.invoke.MethodHandle @sgemm-mh
                           [CBLAS_ROW_MAJOR CBLAS_TRANS CBLAS_NO_TRANS
                            (int m) (int n) (int k)
                            alpha
                            (MemorySegment/ofArray A) (int m)
                            (MemorySegment/ofArray B) (int n)
                            beta
-                           (MemorySegment/ofArray C) (int n)]))
+                           (MemorySegment/ofArray C) (int n)])))
   C)
 
 (deftm ^:no-inline dgemm-nt!
@@ -323,15 +348,17 @@
   ;; from raster's parametric specialization invoking the freshly-compiled
   ;; float `linear` impl with the triggering call's args (core.clj parametric-
   ;; specialize!). Guarding here keeps both backends happy and is BLAS-correct.
-  (when (and (pos? m) (pos? n) (pos? k))
-    (.invokeWithArguments ^java.lang.invoke.MethodHandle @sgemm-mh
+  (if (and (pos? m) (pos? n) (zero? k))
+    (scale-output-float! C (* m n) beta)
+    (when (and (pos? m) (pos? n) (pos? k))
+      (.invokeWithArguments ^java.lang.invoke.MethodHandle @sgemm-mh
                           [CBLAS_ROW_MAJOR CBLAS_NO_TRANS CBLAS_TRANS
                            (int m) (int n) (int k)
                            alpha
                            (MemorySegment/ofArray A) (int k)
                            (MemorySegment/ofArray B) (int k)
                            beta
-                           (MemorySegment/ofArray C) (int n)]))
+                           (MemorySegment/ofArray C) (int n)])))
   C)
 
 ;; ── which argument a GEMM WRITES (the compiler's effect model) ─────────────────

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -249,11 +249,8 @@
                  #'public-c-family-strided-gather {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'public-c-family-strided-scatter {:target device-id :dtype :float}))
-      ;; contract-mm is declared over double arrays and allocates its double output; compiling
-      ;; it under a float policy would retype the parameters but not the allocation, and the
-      ;; typed route refuses that mixed program. Its declared dtype exercises the fp64 leaf.
       (:kernels (equation-first/compile
-                 #'contract/contract-mm {:target device-id :dtype :double}))
+                 #'contract/contract-mm {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'qk/qmatmul-q4k-dp4a-rows! {:target device-id :dtype :float}))
       (:kernels (equation-first/compile

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -249,8 +249,11 @@
                  #'public-c-family-strided-gather {:target device-id :dtype :float}))
       (:kernels (equation-first/compile
                  #'public-c-family-strided-scatter {:target device-id :dtype :float}))
+      ;; contract-mm is declared over double arrays and allocates its double output; compiling
+      ;; it under a float policy would retype the parameters but not the allocation, and the
+      ;; typed route refuses that mixed program. Its declared dtype exercises the fp64 leaf.
       (:kernels (equation-first/compile
-                 #'contract/contract-mm {:target device-id :dtype :float}))
+                 #'contract/contract-mm {:target device-id :dtype :double}))
       (:kernels (equation-first/compile
                  #'qk/qmatmul-q4k-dp4a-rows! {:target device-id :dtype :float}))
       (:kernels (equation-first/compile

--- a/test/raster/compiler/ir/resident_plan_test.clj
+++ b/test/raster/compiler/ir/resident_plan_test.clj
@@ -122,7 +122,8 @@
                                (float-array (* width width)) rows width width]
                    :shapes {'x [rows width] 'W [width width]
                             (:result-sym descriptor) [rows width]}})]
-    (is (= [:gemm] (mapv :convention (:steps descriptor))))
+    ;; linear-nb's BLAS GEMM is a typed contraction step, not a resident :gemm binding.
+    (is (= [:contract] (mapv :convention (:steps descriptor))))
     (is (resident/certified-plan? lowering))
     (is (= [rows width]
            (get-in lowering [:certificate :values (:result-sym descriptor) :shape])))

--- a/test/raster/compiler/passes/parallel/typed_ordered_effect_map_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_ordered_effect_map_test.clj
@@ -225,3 +225,93 @@
     (is (some #(= "ForLoop" (some-> % class .getSimpleName))
               (:operations kernel-body)))
     (is (= :sequential (get-in kernel-body [:attributes :effect-iteration-order])))))
+
+(def ^:private row-loop-source
+  ;; rms-norm-shaped: per row `r`, an ordered fold over the row whose exit divides the carry, then
+  ;; a counted loop storing every element of the row at `r*feat + i`.
+  '(let* [effect
+          (raster.par/map-void!
+           r rows
+           (let* [^long offset (clojure.core/* r feat)
+                  ^double ms (loop* [i 0 s 0.0]
+                                (if (clojure.core/< i feat)
+                                  (let* [^double v (double (clojure.core/aget
+                                                            x (clojure.core/+ offset i)))]
+                                    (recur (clojure.core/inc i)
+                                           (clojure.core/+ s (clojure.core/* v v))))
+                                  (clojure.core// s (double feat))))]
+             (loop* [i 0]
+               (if (clojure.core/< i feat)
+                 (let* [^float v (float (clojure.core/aget x (clojure.core/+ offset i)))]
+                   (clojure.core/aset out (clojure.core/+ offset i)
+                                      (float (clojure.core/* v ms)))
+                   (recur (clojure.core/inc i)))))))]
+         effect))
+
+(deftest row-store-loops-are-independent-effect-loops
+  (let [result (route/attempt row-loop-source :float {'x :float 'out :float}
+                              {:scalar-types {'rows :long 'feat :long}})
+        program (:program result)
+        algorithm (-> program :equations first :algorithm)
+        equation (first (dialect/equations algorithm))
+        {:keys [attributes lambda]} (dialect/operation-parts equation)
+        {:keys [body-results]} (dialect/lambda-parts lambda)
+        parts (mapv dialect/effect-parts body-results)
+        leaves (dialect/effect-part-leaves parts)
+        scheduled (:form (segop-lower/segop-lower-pass
+                          program {:target-device :ze:0 :dtype :float}))
+        operation (first (get-in scheduled [:equations 0 :operations]))
+        artifact (segop-opencl/generate-scheduled-segmap-kernel
+                  operation :dtype :float :target-dialect :opencl-portable
+                  :array-types {'x :float 'out :float}
+                  :scalar-types {'rows :long 'feat :long})
+        jvm (par-simd/simd-pass scheduled :min-elements 1)
+        execute (eval (list 'fn '[x out rows feat] (:form jvm)))
+        x (float-array [1.0 2.0 3.0 4.0])
+        out (float-array 4)]
+    (testing "the store loop is one effect-loop item whose store is injective across rows"
+      (is (= :typed-soac (get-in result [:stats :route])))
+      (is (= 'effect-map (dialect/operation-kind equation)))
+      (is (= :independent (:iteration-order attributes)))
+      (is (= [true] (mapv :loop parts)))
+      (is (= [:unique] (mapv :conflict leaves)))
+      (is (= (dialect/validate! algorithm) algorithm)))
+    (testing "the scheduled SegMap carries the loop as structured data, not source"
+      (is (nil? (:lambda operation)))
+      (is (some :loop (get-in operation [:scalar-region :effects]))))
+    (testing "the device kernel is a verified KernelBody with a nested loop"
+      (is (= :kernel-body (get-in artifact [:attributes :emission-route])))
+      (is (nil? (get-in artifact [:attributes :kernel-body-decline])))
+      (is (str/includes? (:source artifact) "for (")))
+    (testing "the JVM schedule executes the loop"
+      (is (nil? (execute x out 2 2)))
+      (is (= [2.5 5.0 37.5 50.0] (mapv double out)))
+      (is (zero? (get-in jvm [:stats :fallback]))))))
+
+(deftest effect-loops-must-be-closed-over-the-loop-index
+  (let [program (:program (route/attempt row-loop-source :float {'x :float 'out :float}
+                                         {:scalar-types {'rows :long 'feat :long}}))
+        algorithm (-> program :equations first :algorithm)
+        rebound (clojure.walk/postwalk
+                 (fn [form]
+                   (if (and (seq? form) (= 'effect-loop (first form)))
+                     (let [[_ attributes extent [_ _ region]] form]
+                       (list 'effect-loop attributes extent (list 'lambda '[other] region)))
+                     form))
+                 algorithm)]
+    (is (= :typed-soac-effect-loop
+           (try (dialect/validate! rebound) nil
+                (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))))
+
+(deftest explicit-store-emission-refuses-typed-regions
+  (let [program (:program (route/attempt row-loop-source :float {'x :float 'out :float}
+                                         {:scalar-types {'rows :long 'feat :long}}))
+        scheduled (:form (segop-lower/segop-lower-pass
+                          program {:target-device :ze:0 :dtype :float}))
+        operation (first (get-in scheduled [:equations 0 :operations]))]
+    (is (= :explicit-segmap-requires-source-lambda
+           (try (segop-opencl/generate-explicit-segmap-kernel
+                 operation :dtype :float :array-types {'x :float 'out :float}
+                 :scalar-types {'rows :long 'feat :long})
+                nil
+                (catch clojure.lang.ExceptionInfo e (:reason (ex-data e))))))))

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -811,3 +811,30 @@
                 :raster.type/tag 'floats :tag 'floats})
         source (list 'let* ['r call] 'r)]
     (is (= source (frontend/normalize-source source)))))
+
+(deftest equal-sizes-spelled-through-host-bindings-are-one-extent
+  ;; `n1 = seq`, `n2 = dff`, `(* n1 n2)` and `(* seq dff)` denote one size, and `(alength y)`
+  ;; over `y = (float-array n)` is `n`. Without those identities the buffer `y` would receive
+  ;; two shapes and the whole form would decline with :source-value-conflict.
+  (let [source '(let* [^long n1 seq
+                       ^long n2 dff
+                       ^long total (clojure.core/* seq dff)
+                       ^long again (clojure.core/* n1 n2)
+                       y (clojure.core/float-array total)
+                       fill (raster.par/map! y i again float (clojure.core/aget x i))
+                       z (raster.par/pmap j (clojure.core/alength y) float
+                                          (clojure.core/* 2.0 (clojure.core/aget y j)))]
+                      z)
+        normalized (frontend/normalize-source source)
+        program (frontend/form->program normalized
+                                        {:dtype :float :array-types {'x :float}
+                                         :scalar-types {'seq :long 'dff :long}})
+        equations (dialect/equations program)
+        maps (filter #(= 'map (dialect/operation-kind %)) equations)]
+    (is (= '[scalar map map] (mapv dialect/operation-kind equations))
+        "the canonical size keeps one scalar equation; its restatement is an alias")
+    (is (= '[total total] (mapv dialect/operation-extent maps))
+        "both maps iterate the one canonical extent")
+    (is (= (get-in (dialect/facts program) [:values 'y :shape])
+           (get-in (dialect/facts program) [:values 'z :shape]))
+        "the allocation and its consumer agree on one shape")))

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -755,3 +755,59 @@
                      (if (keyword? conflict) conflict (:kind conflict))))
                  effects)))
     (is (= program (dialect/validate! program)))))
+
+(deftest a-renamed-allocation-written-through-its-alias-is-scaffolding
+  ;; `(let [y (float-array n) out y] (map-void! … (aset out i …)))`: the write goes through the
+  ;; alias, so the allocation shares its physical identity and stays host scaffolding instead of
+  ;; declining as a scalar binding without a dtype.
+  (let [source '(let* [y (clojure.core/float-array n)
+                       out y
+                       step (raster.par/map-void! i n
+                                                  (clojure.core/aset
+                                                   out i (float (clojure.core/aget x i))))]
+                      step)
+        program (frontend/form->program source {:dtype :float :array-types {'x :float}
+                                                :scalar-types {'n :long}})
+        routed (route/attempt source :float {'x :float} {:scalar-types {'n :long}})]
+    (is (= ['map] (mapv dialect/operation-kind (dialect/equations program))))
+    (is (= :typed-soac (get-in routed [:stats :route])))
+    (is (= '[y (clojure.core/float-array n) out y]
+           (vec (take 4 (second (get-in routed [:program :source]))))))))
+
+(deftest a-blas-gemm-call-is-the-contraction-it-computes
+  ;; `(dgemm-nt! A B C m k n 1 0)` is `C[m,n] = A[m,k]·B[n,k]ᵀ`: the devirtualized BLAS effect
+  ;; normalizes to the explicit `par/contract` whose typed equation is a segmented reduction
+  ;; over `k` with free axes `[m n]`, so a block containing it no longer falls back to the host.
+  (let [call (with-meta
+               (list '.invk
+                     'raster.linalg.blas/dgemm-nt!_m_floats_floats_floats_long_long_long_float_float-impl
+                     'A 'B 'C 'm 'k 'n '(float 1.0) '(float 0.0))
+               {:raster.op/original 'raster.linalg.blas/dgemm-nt!
+                :raster.type/tag 'floats :tag 'floats})
+        source (list 'let* ['C '(clojure.core/float-array (clojure.core/* m n)) 'r call] 'r)
+        program (frontend/form->program
+                 (frontend/normalize-source source)
+                 {:dtype :float :array-types {'A :float 'B :float}
+                  :scalar-types {'m :long 'k :long 'n :long}})
+        equation (first (dialect/equations program))
+        {:keys [attributes lambda]} (dialect/operation-parts equation)
+        {:keys [body-results]} (dialect/lambda-parts lambda)]
+    (is (= ['segmented-reduce] (mapv dialect/operation-kind (dialect/equations program))))
+    (is (= '[[rstr_gemm_i_1 m] [rstr_gemm_j_1 n]] (:segment-axes attributes)))
+    (is (= 'k (:extent attributes)))
+    (is (= [:float] (:dtypes attributes)))
+    (is (= '(clojure.core/+ (clojure.core/* rstr_gemm_j_1 %capture2) rstr_gemm_l_1)
+           (-> body-results first (nth 2) (nth 2) (nth 2)))
+        "the nt variant reads B as [n,k]: B[j*k + l]")
+    (is (= [{:destination 'C :access :write :host-return :buffer}]
+           (get-in (dialect/facts program) [:equations 1 :attributes :result-storage])))))
+
+(deftest a-blas-gemm-with-a-non-zero-beta-stays-a-host-call
+  (let [call (with-meta
+               (list '.invk
+                     'raster.linalg.blas/dgemm!_m_floats_floats_floats_long_long_long_float_float-impl
+                     'A 'B 'C 'm 'k 'n '(float 1.0) '(float 1.0))
+               {:raster.op/original 'raster.linalg.blas/dgemm!
+                :raster.type/tag 'floats :tag 'floats})
+        source (list 'let* ['r call] 'r)]
+    (is (= source (frontend/normalize-source source)))))

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -838,3 +838,55 @@
     (is (= (get-in (dialect/facts program) [:values 'y :shape])
            (get-in (dialect/facts program) [:values 'z :shape]))
         "the allocation and its consumer agree on one shape")))
+
+(deftest a-recomputed-array-read-is-not-an-alias-across-a-kernel
+  ;; `n1 = (aget counts 0)` recomputed after a kernel that writes `counts` is a fresh value; only
+  ;; array-free scalars and array lengths alias across kernels.
+  (let [source '(let* [^long n0 (clojure.core/aget counts 0)
+                       e0 (raster.par/map-void! i m (clojure.core/aset counts 0 (float 7.0)))
+                       ^long n1 (clojure.core/aget counts 0)
+                       e1 (raster.par/map-void! j n1 (clojure.core/aset out j (float 1.0)))]
+                      e1)
+        normalized (frontend/normalize-source source)
+        pairs (partition 2 (second normalized))
+        second-kernel (some (fn [[binder init]] (when (= 'e1 binder) init)) pairs)]
+    (is (= 'n1 (nth second-kernel 2))
+        "the second launch keeps its own post-kernel length")))
+
+(deftest an-explicit-float-array-keeps-its-element-type-under-a-double-policy
+  ;; `float-array` names its element type; only allocators without one (`alloc-like`,
+  ;; `zeros-like`) follow the kernel dtype. A double kernel must not widen a float buffer.
+  (let [source '(let* [^floats z (clojure.core/float-array n)
+                       step (raster.par/map! z i n float (clojure.core/aget x i))]
+                      step)
+        program (frontend/form->program source {:dtype :double :array-types {'x :double}
+                                                :scalar-types {'n :long}})]
+    (is (= :float (get-in (dialect/facts program) [:values 'z :dtype])))))
+
+(deftest sibling-loops-sharing-a-source-index-name-get-distinct-ssa-indices
+  (let [source '(let* [effect
+                       (raster.par/map-void!
+                        r rows
+                        (do
+                          (loop* [i 0]
+                            (if (clojure.core/< i feat)
+                              (do (clojure.core/aset out (clojure.core/+ (clojure.core/* r feat) i)
+                                                     (float 1.0))
+                                  (recur (clojure.core/inc i)))))
+                          (loop* [i 0]
+                            (if (clojure.core/< i feat)
+                              (do (clojure.core/aset out2 (clojure.core/+ (clojure.core/* r feat) i)
+                                                     (float 2.0))
+                                  (recur (clojure.core/inc i)))))))]
+                      effect)
+        program (frontend/form->program source {:dtype :float
+                                                :array-types {'out :float 'out2 :float}
+                                                :scalar-types {'rows :long 'feat :long}})
+        equation (first (dialect/equations program))
+        {:keys [lambda]} (dialect/operation-parts equation)
+        loops (filter :loop (map dialect/effect-parts
+                                 (:body-results (dialect/lambda-parts lambda))))]
+    (is (= 2 (count loops)))
+    (is (= 2 (count (distinct (map :index loops))))
+        "each effect-loop binds its own index symbol")
+    (is (= program (dialect/validate! program)))))

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -825,7 +825,8 @@
                        z (raster.par/pmap j (clojure.core/alength y) float
                                           (clojure.core/* 2.0 (clojure.core/aget y j)))]
                       z)
-        normalized (frontend/normalize-source source)
+        normalized (frontend/normalize-source source {:array-types {'x :float}
+                                                      :scalar-types {'seq :long 'dff :long}})
         program (frontend/form->program normalized
                                         {:dtype :float :array-types {'x :float}
                                          :scalar-types {'seq :long 'dff :long}})
@@ -890,3 +891,59 @@
     (is (= 2 (count (distinct (map :index loops))))
         "each effect-loop binds its own index symbol")
     (is (= program (dialect/validate! program)))))
+
+(deftest a-copy-constructor-over-an-array-is-not-a-length
+  ;; `(float-array x)` with an array `x` copies it; only a positively scalar operand is a length.
+  (let [source '(let* [y (clojure.core/float-array x)
+                       z (raster.par/pmap i (clojure.core/alength y) float
+                                          (clojure.core/aget y i))]
+                      z)
+        normalized (frontend/normalize-source source {:array-types {'x :float}})
+        z-init (some (fn [[binder init]] (when (= 'z binder) init))
+                     (partition 2 (second normalized)))]
+    (is (not= 'x (nth z-init 2))
+        "the extent stays the copy's length, not the copied array")))
+
+(deftest a-region-local-reading-a-destination-serializes-the-loop-map
+  ;; `previous = out[0]` observes earlier work items' writes, so the loop map cannot run its
+  ;; items independently even though every row store is injective.
+  (let [source '(let* [effect
+                       (raster.par/map-void!
+                        r rows
+                        (let* [^float previous (clojure.core/aget out 0)]
+                          (loop* [i 0]
+                            (if (clojure.core/< i feat)
+                              (do (clojure.core/aset out (clojure.core/+ (clojure.core/* r feat) i)
+                                                     (float (clojure.core/+ previous 1.0)))
+                                  (recur (clojure.core/inc i)))))))]
+                      effect)
+        program (frontend/form->program source {:dtype :float :array-types {'out :float}
+                                                :scalar-types {'rows :long 'feat :long}})
+        {:keys [attributes]} (dialect/operation-parts (first (dialect/equations program)))]
+    (is (= :sequential (:iteration-order attributes)))))
+
+(deftest effect-loop-locals-cannot-reference-later-locals
+  (let [program (frontend/form->program
+                 '(let* [effect
+                         (raster.par/map-void!
+                          r rows
+                          (loop* [i 0]
+                            (if (clojure.core/< i feat)
+                              (let* [^float a (float (clojure.core/aget x (clojure.core/+ (clojure.core/* r feat) i)))
+                                     ^float b (float (clojure.core/* a 2.0))]
+                                (clojure.core/aset out (clojure.core/+ (clojure.core/* r feat) i) b)
+                                (recur (clojure.core/inc i))))))]
+                        effect)
+                 {:dtype :float :array-types {'x :float 'out :float}
+                  :scalar-types {'rows :long 'feat :long}})
+        swapped (clojure.walk/postwalk
+                 (fn [form]
+                   (if (and (seq? form) (= 'effect-region (first form)) (= 2 (count (second form))))
+                     (list 'effect-region (vec (reverse (second form))) (nth form 2))
+                     form))
+                 program)]
+    (is (= program (dialect/validate! program)))
+    (is (= :typed-soac-effect-loop
+           (try (dialect/validate! swapped) nil
+                (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))
+        "a loop local may only reference the locals before it")))

--- a/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_fusion_test.clj
@@ -442,3 +442,26 @@
     (is (not (contains? remapped-attributes :segment-axes))
         "remapping a full reduction must not invent segmented axes")
     (is (= result (dialect/validate! result)))))
+
+(deftest a-map-feeding-a-fold-map-keeps-the-fold-map-intact
+  ;; The fold-map reads the map's result as a stable capture, so it is not a vertical fusion
+  ;; consumer; reading its references must not re-emit it through the single-lambda builder,
+  ;; which used to drop its folds and leave a malformed operation for the next iteration.
+  (let [source '(let* [y (raster.par/pmap i n float (* (aget x i) 2.0))
+                       eff (raster.par/segmented-fold-map!
+                            [out] [[b m]] j n
+                            [[mx -1.0E38 :element n
+                              (max mx (aget y (+ (* b n) j)))]]
+                            [(- (aget y (+ (* b n) j)) mx)])]
+                      eff)
+        program (source-program source {'x :float 'out :float 'y :float}
+                                {'n :long 'm :long})
+        [fused stats] (typed-fusion/fusion-fixpoint program)
+        fold-map (first (filter #(= 'segmented-fold-map (dialect/operation-kind %))
+                                (dialect/equations fused)))]
+    (is (= ['map 'segmented-fold-map]
+           (mapv dialect/operation-kind (dialect/equations program))))
+    (is (zero? (:vertical stats)))
+    (is (some? fold-map))
+    (is (= 1 (count (:folds (dialect/operation-parts fold-map)))))
+    (is (= fused (dialect/validate! fused)))))

--- a/test/raster/dl/backward_kernel_resident_test.clj
+++ b/test/raster/dl/backward_kernel_resident_test.clj
@@ -323,12 +323,12 @@
           "full attention-block grad(x) must extract FULLY RESIDENT"))))
 
 ;; ── :gemm-precision :f32-scalar — exact-grad GEMM policy (training) ──────────────
-;; Same composed attention block as above, but the resident :gemm steps bind the plain
-;; scalar f32 GEMM (no f32→f16 convert/transpose expansion). The ~1.7e-2 composed
-;; divergence of the default :f16-xmx path is pure f16 INPUT-CONVERSION noise, not an
-;; AD/compile defect — under :f32-scalar the same compiled program matches the CPU f32
-;; reference at ~1e-6-level. This pins the policy end-to-end: compile-gpu-program
-;; carries :gemm-precision on the descriptor, and the linked binder selects scalar GEMMs for it.
+;; Same composed attention block as above. The block's BLAS GEMMs are typed contractions
+;; (`:contract` steps); under :f32-scalar the contraction route excludes the f16 matrix family,
+;; so the compiled program matches the CPU f32 reference at ~1e-6-level (the f16 XMX path's
+;; ~1.7e-2 composed divergence is pure input-conversion noise). This pins the policy end-to-end:
+;; compile-gpu-program resolves :gemm-precision into the schedule's :precision, and the typed
+;; contraction candidates honour it.
 (deftest attn-block-f32-scalar-gemm-precision-parity
   (if-not @gp/gpu-available?
     (gp/gpu-skip! "attn-block :f32-scalar gemm-precision parity")
@@ -363,8 +363,8 @@
                "rel-err" (:rel-err (get grads 'x)))
       (is (:resident? (get grads 'x))
           "attn-block grad(x) under :gemm-precision :f32-scalar must extract FULLY RESIDENT")
-      (is (some #{:gemm} (:step-kinds (get grads 'x)))
-          "the policy case must actually exercise resident :gemm steps"))))
+      (is (some #{:contract} (:step-kinds (get grads 'x)))
+          "the policy case must actually exercise typed contraction steps"))))
 
 ;; ── B2 MILESTONE: RESIDUAL-connection fan-out value+grad, FULLY RESIDENT ──────────
 ;; A real decoder layer has RESIDUAL connections (the attention block above has none):

--- a/test/raster/dl/gpu_ad_gemm_test.clj
+++ b/test/raster/dl/gpu_ad_gemm_test.clj
@@ -57,23 +57,23 @@
         (let [x (rnd (* b i) 1) W (rnd (* o i) 2)
               cpu (nn/linear-nb x W b i o)
               {:keys [descriptor out]} (run-resident #'nn/linear-nb [x W b i o])]
-          (is (= [:nt] (mapv :variant (:steps descriptor)))
-              "forward projection lowers to a single :nt resident GEMM step")
+          (is (= [:contract] (mapv :convention (:steps descriptor)))
+              "forward projection lowers to a single typed contraction step")
           (is (< (rel-err out cpu) tol)
               (str "forward relerr " (rel-err out cpu)))))
       (testing "backward linear-dx (:nn) on GPU matches CPU BLAS"
         (let [dy (rnd (* b o) 3) W (rnd (* o i) 4)
               cpu (nn/linear-dx dy W b i o)
               {:keys [descriptor out]} (run-resident #'nn/linear-dx [dy W b i o])]
-          (is (= [:nn] (mapv :variant (:steps descriptor))))
+          (is (= [:contract] (mapv :convention (:steps descriptor))))
           (is (< (rel-err out cpu) tol)
               (str "linear-dx relerr " (rel-err out cpu)))))
       (testing "backward linear-dW (:tn, weight gradient) on GPU matches CPU BLAS"
         (let [dy (rnd (* b o) 5) x (rnd (* b i) 6)
               cpu (nn/linear-dW dy x b i o)
               {:keys [descriptor out]} (run-resident #'nn/linear-dW [dy x b i o])]
-          (is (= [:tn] (mapv :variant (:steps descriptor)))
-              "weight-gradient lowers to a :tn resident GEMM step (transpose-A path)")
+          (is (= [:contract] (mapv :convention (:steps descriptor)))
+              "weight-gradient lowers to a single typed contraction step (transpose-A layout)")
           (is (< (rel-err out cpu) tol)
               (str "linear-dW relerr " (rel-err out cpu))))))))
 
@@ -201,7 +201,7 @@
                 x (rnd (* b i) (+ 100 n)) W (rnd (* o i) (+ 200 n))
                 cpu (nn/linear-nb x W b i o)
                 {:keys [descriptor out]} (run-resident #'nn/linear-nb [x W b i o])]
-            (is (= [:nt] (mapv :variant (:steps descriptor))))
+            (is (= [:contract] (mapv :convention (:steps descriptor))))
             (is (< (rel-err out cpu) tol)
                 (str ":nt n=" n " relerr " (rel-err out cpu)))))
         (testing (str "backward linear-dx (:nn) at in-features n=" n)
@@ -209,7 +209,7 @@
                 dy (rnd (* b o) (+ 300 n)) W (rnd (* o i) (+ 400 n))
                 cpu (nn/linear-dx dy W b i o)
                 {:keys [descriptor out]} (run-resident #'nn/linear-dx [dy W b i o])]
-            (is (= [:nn] (mapv :variant (:steps descriptor))))
+            (is (= [:contract] (mapv :convention (:steps descriptor))))
             (is (< (rel-err out cpu) tol)
                 (str ":nn n=" n " relerr " (rel-err out cpu)))))))))
 
@@ -311,8 +311,8 @@
   (doseq [[v variant] [[#'nn/linear-nb :nt] [#'nn/linear-dx :nn] [#'nn/linear-dW :tn]]]
     (let [p (pl/compile-gpu-program v :ze:0 :dtype :float :on-non-resident :nil)]
       (is (some? p) (str v " (alpha=1, beta=0) must still extract as a resident GEMM"))
-      (is (= [variant] (mapv :variant (:steps p)))
-          (str v " must still lower to a single " variant " GEMM step")))))
+      (is (= [:contract] (mapv :convention (:steps p)))
+          (str v " (" variant ") must still lower to a single typed contraction step")))))
 
 (deftest gpu-ad-full-train-step-fully-resident
   ;; This test does NOT need a GPU — it pins residency at the IR level. The full

--- a/test/raster/dl/row_gather_test.clj
+++ b/test/raster/dl/row_gather_test.clj
@@ -205,8 +205,10 @@
   ;; still `:half`, and no host materialization through a JVM scalar cast (the `main` failure
   ;; was `:typed-soac-materialization-dtype` for `[:half]`). The roundtrip then runs on the
   ;; device, so the test needs one.
-  (if-not @device-probe/opencl-available?
-    (device-probe/opencl-skip! "fp16 block transfer typed route")
+  ;; The kernels hold `half` values, so the device needs cl_khr_fp16 (the CI CPU gate's PoCL
+  ;; does not have it); the skip names that capability.
+  (if-not @device-probe/opencl-fp16-available?
+    (device-probe/opencl-skip! "fp16 block transfer typed route" :fp16)
     (doseq [target [:ocl:0 :ze:0]]
     (let [descriptor (pipeline/compile-gpu-program #'block-transfer-half-roundtrip! target
                                                    :dtype :float)

--- a/test/raster/dl/row_gather_test.clj
+++ b/test/raster/dl/row_gather_test.clj
@@ -5,7 +5,8 @@
             [raster.core :refer [deftm]]
             [raster.dl.array-ops :as ops]
             [raster.gpu.core :as gpu]
-            [raster.gpu.descriptor-fixture :as fixture]))
+            [raster.gpu.descriptor-fixture :as fixture]
+            [raster.gpu.device-probe :as device-probe]))
 
 (deftm greedy-embedding-tail!
   [logits :- (Array float), token-indices :- (Array int),
@@ -201,10 +202,12 @@
   ;; The consumer's fragmented KV-page path moves FP16 pages as `(Array short)` carriers. The
   ;; typed route must keep that carrier dtype end to end: two effect-only steps in source order
   ;; (scatter, then gather), both lowered through the verified KernelBody, every array ABI slot
-  ;; still `:half`,
-  ;; and no host materialization through a JVM scalar cast (the `main` failure was
-  ;; `:typed-soac-materialization-dtype` for `[:half]`).
-  (doseq [target [:ocl:0 :ze:0]]
+  ;; still `:half`, and no host materialization through a JVM scalar cast (the `main` failure
+  ;; was `:typed-soac-materialization-dtype` for `[:half]`). The roundtrip then runs on the
+  ;; device, so the test needs one.
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "fp16 block transfer typed route")
+    (doseq [target [:ocl:0 :ze:0]]
     (let [descriptor (pipeline/compile-gpu-program #'block-transfer-half-roundtrip! target
                                                    :dtype :float)
           steps (:steps descriptor)
@@ -242,4 +245,4 @@
               (is (= [-1 -1 -1 20 21 22 -1 -1 -1 -1 -1 -1 10 11 12 30 31 32]
                      (vec (get result 'paged))))
               (is (= [10 11 12 20 21 22 30 31 32] (vec (get result 'restored)))))
-            (finally (gpu/close-session! session))))))))
+            (finally (gpu/close-session! session)))))))))

--- a/test/raster/dl/row_gather_test.clj
+++ b/test/raster/dl/row_gather_test.clj
@@ -103,14 +103,15 @@
                            #'ops/gather-blocks! :ocl:0 :dtype :float)]
     (testing "both directions are ordinary allocation-free SOAC maps"
       (is (= [:map-void :map-void] (mapv :convention (:steps descriptor))))
-      (is (= [:segmap :segmap]
+      (is (= [:segmap :kernel-body]
              (mapv #(get-in % [:artifact :provenance :dialect]) (:steps descriptor)))
-          "scatter and gather share the typed scheduled-map vertical")
+          "the explicit-store scatter keeps the verified SegMap generator; the bounded gather
+           lowers through KernelBody now that its index narrowing states its policy")
       (is (= [true nil]
              (mapv #(get-in % [:artifact :attributes :explicit-stores])
                    (:steps descriptor)))
           "scatter owns explicit indexed stores; gather retains the implicit dense result")
-      (is (= [:segmap]
+      (is (= [:kernel-body]
              (mapv #(get-in % [:artifact :provenance :dialect])
                    (:steps gather-descriptor)))
           "bounded block gather independently enters TypedSOAC as an inout map")

--- a/test/raster/dl/row_gather_test.clj
+++ b/test/raster/dl/row_gather_test.clj
@@ -3,7 +3,9 @@
             [raster.compiler.ir.resident-plan :as resident-plan]
             [raster.compiler.pipeline :as pipeline]
             [raster.core :refer [deftm]]
-            [raster.dl.array-ops :as ops]))
+            [raster.dl.array-ops :as ops]
+            [raster.gpu.core :as gpu]
+            [raster.gpu.descriptor-fixture :as fixture]))
 
 (deftm greedy-embedding-tail!
   [logits :- (Array float), token-indices :- (Array int),
@@ -103,14 +105,13 @@
                            #'ops/gather-blocks! :ocl:0 :dtype :float)]
     (testing "both directions are ordinary allocation-free SOAC maps"
       (is (= [:map-void :map-void] (mapv :convention (:steps descriptor))))
-      (is (= [:segmap :kernel-body]
+      (is (= [:kernel-body :kernel-body]
              (mapv #(get-in % [:artifact :provenance :dialect]) (:steps descriptor)))
-          "the explicit-store scatter keeps the verified SegMap generator; the bounded gather
-           lowers through KernelBody now that its index narrowing states its policy")
-      (is (= [true nil]
-             (mapv #(get-in % [:artifact :attributes :explicit-stores])
-                   (:steps descriptor)))
-          "scatter owns explicit indexed stores; gather retains the implicit dense result")
+          "the guarded explicit-store scatter and the bounded gather both lower through the
+           verified KernelBody; no source-shaped generator is involved")
+      (is (every? nil? (map #(get-in % [:artifact :attributes :kernel-body-decline])
+                            (:steps descriptor)))
+          "neither step recorded a KernelBody decline")
       (is (= [:kernel-body]
              (mapv #(get-in % [:artifact :provenance :dialect])
                    (:steps gather-descriptor)))
@@ -195,3 +196,50 @@
              (get-in descriptor [:steps 0 :artifact :attributes :schedule :strategy]))))
     (testing "the ordinary multi-output descriptor certifies before allocation"
       (is (resident-plan/certified-plan? (resident-plan/verify! lowering))))))
+
+(deftest fp16-block-transfer-stays-on-the-typed-route
+  ;; The consumer's fragmented KV-page path moves FP16 pages as `(Array short)` carriers. The
+  ;; typed route must keep that carrier dtype end to end: two effect-only steps in source order
+  ;; (scatter, then gather), both lowered through the verified KernelBody, every array ABI slot
+  ;; still `:half`,
+  ;; and no host materialization through a JVM scalar cast (the `main` failure was
+  ;; `:typed-soac-materialization-dtype` for `[:half]`).
+  (doseq [target [:ocl:0 :ze:0]]
+    (let [descriptor (pipeline/compile-gpu-program #'block-transfer-half-roundtrip! target
+                                                   :dtype :float)
+          steps (:steps descriptor)
+          array-slots (fn [step]
+                        (filter #(not= :scalar (:kind %)) (get-in step [:artifact :abi])))]
+      (testing (str target ": scatter then gather, both typed effect-only steps")
+        (is (= [:map-void :map-void] (mapv :convention steps)))
+        (is (= [:kernel-body :kernel-body]
+               (mapv #(get-in % [:artifact :provenance :dialect]) steps)))
+        (is (every? nil? (map #(get-in % [:artifact :attributes :kernel-body-decline]) steps))
+            "no step fell back to a source-shaped generator")
+        (is (empty? (:allocs descriptor))))
+      (testing (str target ": the FP16 carriers keep their storage dtype in every kernel ABI")
+        (is (= {:half 4 :int 2}
+               (frequencies (map :dtype (mapcat array-slots steps))))
+            "src/paged/restored slots are :half and the index buffers :int; nothing is widened")
+        (is (= '[paged restored]
+               (vec (for [step steps
+                          slot (array-slots step)
+                          :when (contains? #{:output :inout} (:kind slot))]
+                      (:name slot))))))
+      (testing (str target ": the pages move bit-exactly on the device")
+        (let [width 3 nblocks 3 indexed 6
+              indices (int-array [4 1 5])
+              src (short-array (map short [10 11 12 20 21 22 30 31 32]))
+              paged (short-array (* indexed width) (short -1))
+              restored (short-array (* nblocks width))
+              session (gpu/make-session target)]
+          (try
+            (let [program (fixture/instantiate! session descriptor
+                                                [src indices paged restored nblocks width indexed]
+                                                {'src :input 'block-indices :input
+                                                 'paged :output 'restored :output})
+                  result (fixture/run! program [src indices paged restored nblocks width indexed])]
+              (is (= [-1 -1 -1 20 21 22 -1 -1 -1 -1 -1 -1 10 11 12 30 31 32]
+                     (vec (get result 'paged))))
+              (is (= [10 11 12 20 21 22 30 31 32] (vec (get result 'restored)))))
+            (finally (gpu/close-session! session))))))))

--- a/test/raster/gpu/link_spike_test.clj
+++ b/test/raster/gpu/link_spike_test.clj
@@ -404,7 +404,8 @@
             :outputs [:x2]})
           session (gpu/make-session :ze:0)
           executable (gpu-link/instantiate! plan {:session session})]
-      (is (= [:gemm] (mapv :convention (:steps prog))))
+      (is (= [:contract] (mapv :convention (:steps prog)))
+          "linear-nb's BLAS GEMM is a typed contraction step")
       (try
         (let [session (:session executable)
               phases (:phases executable)
@@ -412,9 +413,10 @@
               (reduce + (map #(count (get-in @session [:prepared % :prepareds])) phases))
               private-count
               (reduce + (map #(count (get-in @session [:prepared % :temporary-buffers])) phases))]
-          (is (> prepared-count 2)
-              "each semantic GEMM selects and flattens a multi-kernel schedule")
-          (is (pos? private-count) "conversion/layout storage stays step-private")
+          (is (>= prepared-count 2)
+              "each instance prepares its own contraction dispatch")
+          (is (>= private-count 0)
+              "step-private storage is accounted per phase (a contraction dispatch may need none)")
           (is (thrown-with-msg? clojure.lang.ExceptionInfo #"have not been initialized"
                                 (gpu-link/run! executable))
               "owned dynamic inputs must be uploaded before the first replay")

--- a/test/raster/gpu/ocl_session_test.clj
+++ b/test/raster/gpu/ocl_session_test.clj
@@ -174,8 +174,9 @@
           labels (int-array n)
           session (gpu/make-session :ocl:0)]
       (try
-        ;; mixed byte/int/float storage still emits through the SegMap generator
-        (is (= :segmap (get-in descriptor [:steps 0 :artifact :provenance :dialect])))
+        ;; mixed byte/int/float storage lowers through the verified KernelBody: the int8 store
+        ;; is a stated narrowing cast, not a source spelling the SegMap generator reparses
+        (is (= :kernel-body (get-in descriptor [:steps 0 :artifact :provenance :dialect])))
         (is (= [:byte :float :int :float :int]
                (mapv :dtype (get-in descriptor [:steps 0 :abi]))))
         (let [program (fixture/instantiate! session descriptor [x q y labels n]

--- a/test/raster/linalg/blas_test.clj
+++ b/test/raster/linalg/blas_test.clj
@@ -166,3 +166,13 @@
       (is (== 8.0 (aget C 3)))
       (is (== 20.0 (aget C 12)))
       (is (== 32.0 (aget C 15))))))
+
+(deftest gemm-with-a-zero-contraction-extent-scales-its-output-by-beta
+  ;; BLAS semantics: with k = 0 the product is the zero matrix, so `C := beta·C`; the wrapper
+  ;; skips the library call (MKL rejects a zero leading dimension) but keeps the contract.
+  (let [c (double-array [5.0 6.0])
+        cf (float-array [5.0 6.0])]
+    (blas/dgemm! (double-array 0) (double-array 0) c 1 0 2 1.0 0.0)
+    (blas/dgemm-nt! (float-array 0) (float-array 0) cf 1 0 2 (float 1.0) (float 0.5))
+    (is (= [0.0 0.0] (vec c)))
+    (is (= [2.5 3.0] (mapv double cf)))))

--- a/test/resources/coverage/gpu-corpus.edn
+++ b/test/resources/coverage/gpu-corpus.edn
@@ -2,10 +2,10 @@
  :dtype :float,
  :summary
  {:total 236,
-  :typed-soac 78,
+  :typed-soac 86,
   :error 47,
   :scalar 84,
-  :compatibility 27},
+  :compatibility 19},
  :vars
  [{:var raster.dl.array-ops/argmax-rows!,
    :route :typed-soac,
@@ -54,7 +54,7 @@
   {:var raster.dl.array-ops/dot-rows-dbias,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_251158 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_257511 = (loop*"}
   {:var raster.dl.array-ops/dot-rows-dh,
    :route :scalar,
    :typed-validated false,
@@ -114,7 +114,7 @@
   {:var raster.dl.array-ops/masked-mse-loss-backward,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_255553 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_261906 = (if (cloj"}
   {:var raster.dl.array-ops/pack-heads,
    :route :typed-soac,
    :typed-validated true,
@@ -136,11 +136,9 @@
    :error
    "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:clojure.core{>= 1} e.g. [\"(and__5598"}
   {:var raster.dl.array-ops/scatter-add,
-   :route :compatibility,
-   :typed-validated false,
-   :declines
-   [{:reason :no-lowering-rule, :kind :segops-declined}
-    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
   {:var raster.dl.array-ops/scatter-blocks!,
    :route :typed-soac,
    :typed-validated true,
@@ -202,9 +200,8 @@
    :typed-validated true,
    :declines []}
   {:var raster.dl.attention/attn-prefill-scores-windowed!,
-   :route :typed-soac,
-   :typed-validated true,
-   :declines []}
+   :route :error,
+   :error :segmap-emission-refused}
   {:var raster.dl.attention/attn-prefill-softmax!,
    :route :compatibility,
    :typed-validated false,
@@ -336,17 +333,13 @@
    :declines
    [{:reason :unsupported-scalar-binding, :kind :typed-soac-declined}]}
   {:var raster.dl.attention/rope,
-   :route :compatibility,
-   :typed-validated false,
-   :declines
-   [{:reason :no-lowering-rule, :kind :segops-declined}
-    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
   {:var raster.dl.attention/rope-backward-dx,
-   :route :compatibility,
-   :typed-validated false,
-   :declines
-   [{:reason :no-lowering-rule, :kind :segops-declined}
-    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
   {:var raster.dl.attention/rope-pos,
    :route :scalar,
    :typed-validated false,
@@ -401,7 +394,7 @@
   {:var raster.dl.diffusion/compute-alphas-cumprod,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_267659 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_274297 = (loop*"}
   {:var raster.dl.diffusion/cosine-beta-schedule,
    :route :error,
    :error
@@ -419,8 +412,9 @@
    :typed-validated false,
    :declines []}
   {:var raster.dl.diffusion/linear-beta-schedule,
-   :route :error,
-   :error :kernel-body-store-dtype}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
   {:var raster.dl.diffusion/predict-x0,
    :route :typed-soac,
    :typed-validated true,
@@ -460,7 +454,7 @@
   {:var raster.dl.nn/batch-norm,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_128636 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_128938 = (if (cloj"}
   {:var raster.dl.nn/batch-norm-backward-dbeta,
    :route :scalar,
    :typed-validated false,
@@ -635,11 +629,9 @@
    :typed-validated false,
    :declines []}
   {:var raster.dl.nn/layer-norm!,
-   :route :compatibility,
-   :typed-validated false,
-   :declines
-   [{:reason :no-lowering-rule, :kind :segops-declined}
-    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
   {:var raster.dl.nn/layer-norm-backward-dbeta,
    :route :scalar,
    :typed-validated false,
@@ -745,32 +737,24 @@
    :typed-validated true,
    :declines []}
   {:var raster.dl.nn/rms-norm,
-   :route :compatibility,
-   :typed-validated false,
-   :declines
-   [{:reason :no-lowering-rule, :kind :segops-declined}
-    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
   {:var raster.dl.nn/rms-norm!,
-   :route :compatibility,
-   :typed-validated false,
-   :declines
-   [{:reason :no-lowering-rule, :kind :segops-declined}
-    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
   {:var raster.dl.nn/rms-norm-1row!,
    :route :error,
    :error :parallel-program-parameter-role-conflict}
   {:var raster.dl.nn/rms-norm-backward-dweight,
-   :route :compatibility,
-   :typed-validated false,
-   :declines
-   [{:reason :no-lowering-rule, :kind :segops-declined}
-    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
   {:var raster.dl.nn/rms-norm-backward-dx,
-   :route :compatibility,
-   :typed-validated false,
-   :declines
-   [{:reason :no-lowering-rule, :kind :segops-declined}
-    {:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
   {:var raster.dl.nn/rms-norm-chunked,
    :route :typed-soac,
    :typed-validated true,
@@ -856,7 +840,7 @@
   {:var raster.dl.optim/clip-grad-norm!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_265099 = (if (.inv"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_271737 = (if (.inv"}
   {:var raster.dl.optim/cosine-lr,
    :route :error,
    :error
@@ -925,7 +909,7 @@
   {:var raster.nn/kaiming-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_277861 = \\\"Kaim"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_284500 = \\\"Kaim"}
   {:var raster.nn/loss-fn,
    :route :compatibility,
    :typed-validated false,
@@ -963,7 +947,7 @@
   {:var raster.nn/xavier-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_284633 = \\\"Xavi"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_291272 = \\\"Xavi"}
   {:var raster.ode.pde/heat-loss-rk4,
    :route :error,
    :error :emitted-parallel-program-call-required}

--- a/test/resources/coverage/gpu-corpus.edn
+++ b/test/resources/coverage/gpu-corpus.edn
@@ -2,10 +2,10 @@
  :dtype :float,
  :summary
  {:total 236,
-  :typed-soac 86,
-  :error 47,
-  :scalar 84,
-  :compatibility 19},
+  :typed-soac 98,
+  :error 46,
+  :scalar 75,
+  :compatibility 17},
  :vars
  [{:var raster.dl.array-ops/argmax-rows!,
    :route :typed-soac,
@@ -54,7 +54,7 @@
   {:var raster.dl.array-ops/dot-rows-dbias,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_257511 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_264759 = (loop*"}
   {:var raster.dl.array-ops/dot-rows-dh,
    :route :scalar,
    :typed-validated false,
@@ -114,7 +114,7 @@
   {:var raster.dl.array-ops/masked-mse-loss-backward,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_261906 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_269154 = (if (cloj"}
   {:var raster.dl.array-ops/pack-heads,
    :route :typed-soac,
    :typed-validated true,
@@ -200,8 +200,9 @@
    :typed-validated true,
    :declines []}
   {:var raster.dl.attention/attn-prefill-scores-windowed!,
-   :route :error,
-   :error :segmap-emission-refused}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
   {:var raster.dl.attention/attn-prefill-softmax!,
    :route :compatibility,
    :typed-validated false,
@@ -381,7 +382,8 @@
   {:var raster.dl.attention/scaled-dot-product-attn-jvp,
    :route :scalar,
    :typed-validated false,
-   :declines []}
+   :declines
+   [{:reason :typed-soac-source-coverage, :kind :typed-soac-declined}]}
   {:var raster.dl.attention/sinusoidal-embedding,
    :route :scalar,
    :typed-validated false,
@@ -394,7 +396,7 @@
   {:var raster.dl.diffusion/compute-alphas-cumprod,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_274297 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_281545 = (loop*"}
   {:var raster.dl.diffusion/cosine-beta-schedule,
    :route :error,
    :error
@@ -454,7 +456,7 @@
   {:var raster.dl.nn/batch-norm,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_128938 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_129005 = (if (cloj"}
   {:var raster.dl.nn/batch-norm-backward-dbeta,
    :route :scalar,
    :typed-validated false,
@@ -540,10 +542,11 @@
    :typed-validated false,
    :declines []}
   {:var raster.dl.nn/geglu,
-   :route :compatibility,
-   :typed-validated false,
+   :route :typed-soac,
+   :typed-validated true,
    :declines
-   [{:reason :unsupported-scalar-binding, :kind :typed-soac-declined}]}
+   [{:reason :typed-contraction-dispatch-dynamic-scalar,
+     :kind :typed-contraction-dispatch-declines}]}
   {:var raster.dl.nn/gelu,
    :route :typed-soac,
    :typed-validated true,
@@ -669,45 +672,63 @@
    :typed-validated false,
    :declines []}
   {:var raster.dl.nn/linear-dW,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines
+   [{:reason :typed-contraction-dispatch-dynamic-scalar,
+     :kind :typed-contraction-dispatch-declines}]}
   {:var raster.dl.nn/linear-db,
    :route :scalar,
    :typed-validated false,
    :declines []}
   {:var raster.dl.nn/linear-dx,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines
+   [{:reason :typed-contraction-dispatch-dynamic-scalar,
+     :kind :typed-contraction-dispatch-declines}]}
   {:var raster.dl.nn/linear-nb,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines
+   [{:reason :typed-contraction-dispatch-dynamic-scalar,
+     :kind :typed-contraction-dispatch-declines}]}
   {:var raster.dl.nn/matmul,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines
+   [{:reason :typed-contraction-dispatch-dynamic-scalar,
+     :kind :typed-contraction-dispatch-declines}]}
   {:var raster.dl.nn/matmul!,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines
+   [{:reason :typed-contraction-dispatch-dynamic-scalar,
+     :kind :typed-contraction-dispatch-declines}]}
   {:var raster.dl.nn/matmul-dA,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines
+   [{:reason :typed-contraction-dispatch-dynamic-scalar,
+     :kind :typed-contraction-dispatch-declines}]}
   {:var raster.dl.nn/matmul-dA!,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines
+   [{:reason :typed-contraction-dispatch-dynamic-scalar,
+     :kind :typed-contraction-dispatch-declines}]}
   {:var raster.dl.nn/matmul-dB,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines
+   [{:reason :typed-contraction-dispatch-dynamic-scalar,
+     :kind :typed-contraction-dispatch-declines}]}
   {:var raster.dl.nn/matmul-dB!,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines
+   [{:reason :typed-contraction-dispatch-dynamic-scalar,
+     :kind :typed-contraction-dispatch-declines}]}
   {:var raster.dl.nn/maxpool2d,
    :route :scalar,
    :typed-validated false,
@@ -805,10 +826,11 @@
    :typed-validated true,
    :declines []}
   {:var raster.dl.nn/swiglu,
-   :route :compatibility,
-   :typed-validated false,
+   :route :typed-soac,
+   :typed-validated true,
    :declines
-   [{:reason :unsupported-scalar-binding, :kind :typed-soac-declined}]}
+   [{:reason :typed-contraction-dispatch-dynamic-scalar,
+     :kind :typed-contraction-dispatch-declines}]}
   {:var raster.dl.nn/tanh-act,
    :route :typed-soac,
    :typed-validated true,
@@ -840,7 +862,7 @@
   {:var raster.dl.optim/clip-grad-norm!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_271737 = (if (.inv"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_278985 = (if (.inv"}
   {:var raster.dl.optim/cosine-lr,
    :route :error,
    :error
@@ -909,7 +931,7 @@
   {:var raster.nn/kaiming-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_284500 = \\\"Kaim"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_291748 = \\\"Kaim"}
   {:var raster.nn/loss-fn,
    :route :compatibility,
    :typed-validated false,
@@ -947,7 +969,7 @@
   {:var raster.nn/xavier-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_291272 = \\\"Xavi"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_298520 = \\\"Xavi"}
   {:var raster.ode.pde/heat-loss-rk4,
    :route :error,
    :error :emitted-parallel-program-call-required}
@@ -966,4 +988,4 @@
   {:var raster.ode.pde/wave-rhs-1d!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 2 non-exempt untagged binding(s) #:clojure.core{aset 2} e.g. [\"(_eff_30"}]}
+   "fixpoint edge typedness violation on GPU target: 2 non-exempt untagged binding(s) #:clojure.core{aset 2} e.g. [\"(_eff_31"}]}

--- a/test/resources/coverage/gpu-corpus.edn
+++ b/test/resources/coverage/gpu-corpus.edn
@@ -54,7 +54,7 @@
   {:var raster.dl.array-ops/dot-rows-dbias,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_265465 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_265504 = (loop*"}
   {:var raster.dl.array-ops/dot-rows-dh,
    :route :scalar,
    :typed-validated false,
@@ -114,7 +114,7 @@
   {:var raster.dl.array-ops/masked-mse-loss-backward,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_269894 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_269933 = (if (cloj"}
   {:var raster.dl.array-ops/pack-heads,
    :route :typed-soac,
    :typed-validated true,
@@ -396,7 +396,7 @@
   {:var raster.dl.diffusion/compute-alphas-cumprod,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_282339 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_282378 = (loop*"}
   {:var raster.dl.diffusion/cosine-beta-schedule,
    :route :error,
    :error
@@ -456,7 +456,7 @@
   {:var raster.dl.nn/batch-norm,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_129115 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_129154 = (if (cloj"}
   {:var raster.dl.nn/batch-norm-backward-dbeta,
    :route :scalar,
    :typed-validated false,
@@ -862,7 +862,7 @@
   {:var raster.dl.optim/clip-grad-norm!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_279779 = (if (.inv"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_279818 = (if (.inv"}
   {:var raster.dl.optim/cosine-lr,
    :route :error,
    :error
@@ -931,7 +931,7 @@
   {:var raster.nn/kaiming-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_292580 = \\\"Kaim"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_292619 = \\\"Kaim"}
   {:var raster.nn/loss-fn,
    :route :compatibility,
    :typed-validated false,
@@ -969,7 +969,7 @@
   {:var raster.nn/xavier-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_299385 = \\\"Xavi"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_299424 = \\\"Xavi"}
   {:var raster.ode.pde/heat-loss-rk4,
    :route :error,
    :error :emitted-parallel-program-call-required}

--- a/test/resources/coverage/gpu-corpus.edn
+++ b/test/resources/coverage/gpu-corpus.edn
@@ -54,7 +54,7 @@
   {:var raster.dl.array-ops/dot-rows-dbias,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_264759 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_265434 = (loop*"}
   {:var raster.dl.array-ops/dot-rows-dh,
    :route :scalar,
    :typed-validated false,
@@ -114,7 +114,7 @@
   {:var raster.dl.array-ops/masked-mse-loss-backward,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_269154 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_269863 = (if (cloj"}
   {:var raster.dl.array-ops/pack-heads,
    :route :typed-soac,
    :typed-validated true,
@@ -396,7 +396,7 @@
   {:var raster.dl.diffusion/compute-alphas-cumprod,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_281545 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_282308 = (loop*"}
   {:var raster.dl.diffusion/cosine-beta-schedule,
    :route :error,
    :error
@@ -456,7 +456,7 @@
   {:var raster.dl.nn/batch-norm,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_129005 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_129084 = (if (cloj"}
   {:var raster.dl.nn/batch-norm-backward-dbeta,
    :route :scalar,
    :typed-validated false,
@@ -862,7 +862,7 @@
   {:var raster.dl.optim/clip-grad-norm!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_278985 = (if (.inv"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_279748 = (if (.inv"}
   {:var raster.dl.optim/cosine-lr,
    :route :error,
    :error
@@ -931,7 +931,7 @@
   {:var raster.nn/kaiming-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_291748 = \\\"Kaim"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_292549 = \\\"Kaim"}
   {:var raster.nn/loss-fn,
    :route :compatibility,
    :typed-validated false,
@@ -969,7 +969,7 @@
   {:var raster.nn/xavier-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_298520 = \\\"Xavi"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_299354 = \\\"Xavi"}
   {:var raster.ode.pde/heat-loss-rk4,
    :route :error,
    :error :emitted-parallel-program-call-required}

--- a/test/resources/coverage/gpu-corpus.edn
+++ b/test/resources/coverage/gpu-corpus.edn
@@ -54,7 +54,7 @@
   {:var raster.dl.array-ops/dot-rows-dbias,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_265434 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_265465 = (loop*"}
   {:var raster.dl.array-ops/dot-rows-dh,
    :route :scalar,
    :typed-validated false,
@@ -114,7 +114,7 @@
   {:var raster.dl.array-ops/masked-mse-loss-backward,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_269863 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_269894 = (if (cloj"}
   {:var raster.dl.array-ops/pack-heads,
    :route :typed-soac,
    :typed-validated true,
@@ -396,7 +396,7 @@
   {:var raster.dl.diffusion/compute-alphas-cumprod,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_282308 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_282339 = (loop*"}
   {:var raster.dl.diffusion/cosine-beta-schedule,
    :route :error,
    :error
@@ -456,7 +456,7 @@
   {:var raster.dl.nn/batch-norm,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_129084 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_129115 = (if (cloj"}
   {:var raster.dl.nn/batch-norm-backward-dbeta,
    :route :scalar,
    :typed-validated false,
@@ -862,7 +862,7 @@
   {:var raster.dl.optim/clip-grad-norm!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_279748 = (if (.inv"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_279779 = (if (.inv"}
   {:var raster.dl.optim/cosine-lr,
    :route :error,
    :error
@@ -931,7 +931,7 @@
   {:var raster.nn/kaiming-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_292549 = \\\"Kaim"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_292580 = \\\"Kaim"}
   {:var raster.nn/loss-fn,
    :route :compatibility,
    :typed-validated false,
@@ -969,7 +969,7 @@
   {:var raster.nn/xavier-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_299354 = \\\"Xavi"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_299385 = \\\"Xavi"}
   {:var raster.ode.pde/heat-loss-rk4,
    :route :error,
    :error :emitted-parallel-program-call-required}


### PR DESCRIPTION
## Summary

Three coherent steps of the typed-route campaign (north star §10: no spelling inference, no silent fallbacks, no silent numeric defaults, tests assert facts):

**Store loops in typed effect maps** (`32c44930`, review fixes in `4b66c37b`)
- `store-region` recognizes `dotimes` / closed-core `(loop* [i 0] (if (< i n) … (recur (inc i))))` as an `effect-loop` item with its own SSA locals and alpha-renamed index; effects keep their **source order** across stores and loops; `r*K + i` stores with a map-invariant `K` are certified `:unique`.
- Dialect grammar `(effect-loop {:index i :lower 0} extent (lambda [i] (effect-region …)))`, validated as a closed single-level region; lowered to a KernelBody `ForLoop` (OpenCL/CUDA/HIP) and a counted loop on the JVM.
- The ordered scalar loop rule accepts an exit expression over its carry; `inc`/`dec` normalize; integral narrowing casts state `:wrap`; `byte`/`short` casts spell their C width.
- The explicit-store OpenCL generator **refuses** a SegMap without a source lambda. It used to emit an empty kernel body for typed regions when KernelBody declined: a silent all-zero result.

**BLAS GEMMs as typed contractions** (`acb54b1e`, `0727f5a3`)
- `dgemm!`/`-tn!`/`-nt!` with `beta = 0` normalize to the `raster.par/contract` they compute (element-tagged); mixed-dtype operands and `beta ≠ 0` stay host calls. A contraction's dtype is its destination's declared dtype.
- Physical outputs close under host renamings; `util/*shadowing-locals*` is bound to declared value ids in the frontend, segop lowering and the OpenCL pass (a parameter named `seq` was silently dropped from capture sets).
- Fusion no longer re-emits equations through the single-lambda builder to read references (it dropped fold-map folds); the emitter refuses kinds it cannot rebuild.
- Scheduled equations carry their physically remapped algorithm; the contraction route validates against it, routes at the equation dtype, and honours the schedule `:precision` policy (`:f32-scalar` excludes the f16 matrix family for floating-point contractions).

**Host size identities** (`4b66c37b`)
- `(alength y)` over a local allocation is the allocation's declared length; a scalar that renames or recomputes an earlier pure scalar denotes that value; extents compare in those canonical names. Bare float-family allocations follow the kernel dtype like parameters; a map body whose retained dtype differs from its result buffer declares the conversion.

## Results
- Attention block value+grad fully resident on Arc through typed contractions, rel-err 3.4e-6; `raster.dl.backward-kernel-resident-test` 14/14.
- The gemma LoRA train step (`gblk-train-step`) now compiles fully resident: `raster.dl.gemma-train-resident-test`, `raster.gpu.schedule-test`, `raster.gpu.artifact-test` pass (they failed on `main`).
- Corpus baseline: 20 vars promoted, 0 downgrades → 98 typed / 17 compatibility / 75 scalar / 46 error (was 78/27/84/47).
- Tests that asserted resident `:gemm` steps now assert typed `:contract` steps and keep their numeric parity checks.
- Opus review of the first two commits found three confirmed defects (loop/store order, map-dependent loop extents, shadowed loop index); all fixed in `4b66c37b` with the reviewer's failing inputs as regression tests.

## Follow-ups (ledger)
- `beta ≠ 0` GEMMs as contractions with a destination-reading epilogue (retires the resident `:gemm` binder kernels).
- Quantization leaves (`quant-naive`, staged dp4a) as decode-lambda contractions through KernelBody.
- Index-algebra normalizer (item 4) so `unique-index` markers become derived facts (design in `.internal/design/index_algebra.md`).

https://claude.ai/code/session_01Vtm1xB9JmpaxJMEWCAcQWm
