### PR TITLE
Prove store uniqueness with an index algebra; unique-index becomes a checked claim

### DIFF
--- a/src/raster/compiler/coverage.clj
+++ b/src/raster/compiler/coverage.clj
@@ -13,7 +13,9 @@
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.pprint :as pp]
-            [raster.compiler.pipeline :as pipeline]))
+            [raster.compiler.ir.soac-dialect :as dialect]
+            [raster.compiler.pipeline :as pipeline]
+            [raster.compiler.report :as report]))
 
 (def default-namespaces
   "Corpus namespaces: the deep-learning substrate, the ODE/PDE surface and the NN primitives."
@@ -54,17 +56,35 @@
   (or (:reason (ex-data throwable))
       (some-> (.getMessage throwable) (subs 0 (min 120 (count (.getMessage throwable)))))))
 
+(defn- effect-order-facts
+  "How the typed program's effect maps iterate: `{:independent n :sequential m}`. A store the
+   index algebra proves injective keeps its map `:independent`; an unproven one serializes the
+   whole launch, so a move from `:independent` to `:sequential` is a performance regression the
+   ratchet must see even though the route is unchanged."
+  [pipeline]
+  (let [program (:soac-fused pipeline)]
+    (when (and (map? program) (= :typed-soac (:dialect program)))
+      (frequencies
+       (for [equation (:equations program)
+             typed-equation (dialect/equations (:algorithm equation))
+             :let [{:keys [kind attributes]} (dialect/operation-parts typed-equation)]
+             :when (= 'effect-map kind)]
+         (:iteration-order attributes))))))
+
 (defn report-var
   "Compile one source deftm for `target-device` at `dtype` and reduce its report to route facts."
   [v {:keys [target-device dtype] :or {dtype :float}}]
   (let [row {:var (var-symbol v)}]
     (try
-      (let [report (pipeline/compile-report v :target-device target-device :dtype dtype)]
-        (assoc row
-               :route (get-in report [:route :source-dialect])
-               :typed-validated (boolean (get-in report [:route :typed-validated]))
-               :declines (decline-facts (get-in report [:route :declines]))
-               :emission-declines (count (get-in report [:emission :declines]))))
+      (let [pipeline (pipeline/show-pipeline v :target-device target-device :dtype dtype)
+            report (report/from-pipeline pipeline)
+            orders (effect-order-facts pipeline)]
+        (cond-> (assoc row
+                       :route (get-in report [:route :source-dialect])
+                       :typed-validated (boolean (get-in report [:route :typed-validated]))
+                       :declines (decline-facts (get-in report [:route :declines]))
+                       :emission-declines (count (get-in report [:emission :declines])))
+          (seq orders) (assoc :effect-orders orders)))
       (catch Throwable t
         (assoc row :route :error :error (error-reason t))))))
 
@@ -103,7 +123,13 @@
 
                        (and (:typed-validated old) (not (:typed-validated row)))
                        (conj {:var (:var row) :violation :lost-typed-validation
-                              :route (:route row)}))]
+                              :route (:route row)})
+
+                       ;; an effect map that iterated independently may not start serializing
+                       (> (get-in row [:effect-orders :sequential] 0)
+                          (get-in old [:effect-orders :sequential] 0))
+                       (conj {:var (:var row) :violation :effect-map-serialized
+                              :before (:effect-orders old) :after (:effect-orders row)}))]
        violation))))
 
 (defn read-baseline [path]

--- a/src/raster/compiler/coverage.clj
+++ b/src/raster/compiler/coverage.clj
@@ -126,8 +126,11 @@
                               :route (:route row)})
 
                        ;; an effect map that iterated independently may not start serializing
-                       (> (get-in row [:effect-orders :sequential] 0)
-                          (get-in old [:effect-orders :sequential] 0))
+                       ;; or disappear from the typed program
+                       (or (> (get-in row [:effect-orders :sequential] 0)
+                              (get-in old [:effect-orders :sequential] 0))
+                           (< (get-in row [:effect-orders :independent] 0)
+                              (get-in old [:effect-orders :independent] 0)))
                        (conj {:var (:var row) :violation :effect-map-serialized
                               :before (:effect-orders old) :after (:effect-orders row)}))]
        violation))))

--- a/src/raster/compiler/ir/index_algebra.clj
+++ b/src/raster/compiler/ir/index_algebra.clj
@@ -14,7 +14,6 @@
 
    See .internal/design/index_algebra.md for the derivation."
   (:require [clojure.set :as set]
-            [clojure.set]
             [clojure.walk]))
 
 ;; ---------------------------------------------------------------------------------------------
@@ -211,7 +210,7 @@
            (quot-form? init)
            (if-let [[divisor bound] (let [d (resolve state (nth init 2))
                                           b (resolve state (second init))]
-                                      (when (and d b) [d b]))]
+                                      (when (and d b (pos? (:const d))) [d b]))]
              (-> state
                  (assoc-in [:substitutions id] id)
                  (assoc-in [:quot-expressions (clojure.walk/postwalk strip-cast init)] id)
@@ -230,15 +229,22 @@
      locals)))
 
 (defn- complete-digits
-  "Resolve the map index's own radix (its extent) once every scalar local is known."
-  [{:keys [digits] :as state} index]
+  "Resolve the map index's own radix (its extent) once every scalar local is known, under the
+   same guard as any radix: no digit and no unresolved local among its factors."
+  [{:keys [digits substitutions quot-expressions] unresolved :locals :as state} index]
   (let [extent (or (get-in digits [index :radix])
-                   (let [{:keys [substitutions quot-expressions]} state
-                         raw (get-in state [:quantities index :raw])]
-                     (monomial (->> (strip-cast raw)
-                                    (clojure.walk/postwalk-replace substitutions)
-                                    (clojure.walk/postwalk strip-cast)
-                                    (clojure.walk/postwalk-replace quot-expressions)))))]
+                   (let [raw (get-in state [:quantities index :raw])
+                         m (monomial (->> (strip-cast raw)
+                                          (clojure.walk/postwalk-replace substitutions)
+                                          (clojure.walk/postwalk strip-cast)
+                                          (clojure.walk/postwalk-replace quot-expressions)))
+                         factors (set (:factors m))]
+                     (when (and m
+                                (empty? (set/intersection factors (set (keys digits))))
+                                (empty? (set/intersection
+                                         factors (set (remove (set (keys substitutions))
+                                                              unresolved)))))
+                       m)))]
     (assoc-in state [:digits index :radix] extent)))
 
 ;; ---------------------------------------------------------------------------------------------
@@ -286,12 +292,31 @@
    `loop-indices` is a map of loop index symbol → extent for counted loops inside the region;
    they are digits too, with their extent as radix."
   [expression index extent locals loop-indices]
-  (let [{:keys [digits leaves parents substitutions quot-facts] unresolved :locals}
+  (let [{:keys [digits leaves parents substitutions quot-facts quot-expressions]
+         unresolved :locals :as state}
         (complete-digits (digits index extent locals) index)
+        ;; a loop extent is a radix: an extent monomial over resolved, digit-free factors
+        invariant-extent (fn [form]
+                           (let [m (monomial (->> (strip-cast form)
+                                                  (clojure.walk/postwalk-replace substitutions)
+                                                  (clojure.walk/postwalk strip-cast)
+                                                  (clojure.walk/postwalk-replace quot-expressions)))
+                                 factors (set (:factors m))]
+                             (when (and m (pos? (:const m))
+                                        (empty? (set/intersection factors (set (keys digits))))
+                                        (empty? (set/intersection
+                                                 factors
+                                                 (set (remove (set (keys substitutions))
+                                                              unresolved)))))
+                               m)))
         loop-digits (reduce-kv (fn [acc loop-index loop-extent]
-                                 (if-let [radix (monomial loop-extent)]
-                                   (assoc acc loop-index {:radix radix :order (count acc)})
-                                   acc))
+                                 (when acc
+                                   (if-let [radix (invariant-extent loop-extent)]
+                                     (assoc acc loop-index {:radix radix :order (count acc)})
+                                     ;; a triangular or data-dependent loop extent is not a
+                                     ;; radix; the loop index cannot be a digit, so the form is
+                                     ;; undecidable rather than the index an invariant offset
+                                     (reduced nil))))
                                {} loop-indices)
         digits (merge digits loop-digits)
         leaves (into leaves (keys loop-digits))
@@ -302,7 +327,7 @@
         resolved (set/union digit-set (set (keys substitutions)))
         unresolved-locals (set/intersection (set (remove resolved unresolved))
                                             (set (filter symbol? (tree-seq coll? seq expression))))
-        form (when (empty? unresolved-locals) (affine expression digit-set))
+        form (when (and loop-digits (empty? unresolved-locals)) (affine expression digit-set))
         ;; the constant offset: an integer, or the sum of the symbolic operands when that sum
         ;; is one monomial (`d + d = 2d`); a mixed or non-monomial sum is undecidable
         offset (when form
@@ -319,7 +344,12 @@
     (when (and form offset (seq term-set)
                ;; a quantity used whole may not appear beside a digit derived from it
                (not-any? (fn [digit] (some term-set (ancestors digit))) term-set)
-               (every? #(some? (get-in digits [% :radix])) term-set))
+               (every? #(some? (get-in digits [% :radix])) term-set)
+               ;; coefficients and the offset are constant across the digits
+               (every? (fn [[_ coefficient]]
+                         (empty? (set/intersection (set (:factors coefficient)) digit-set)))
+                       (:terms form))
+               (empty? (set/intersection (set (:factors offset)) digit-set)))
       {:terms (into {} (map (fn [[digit coefficient]]
                               [digit {:coefficient coefficient
                                       :radix (get-in digits [digit :radix])}]))
@@ -331,17 +361,6 @@
 
 ;; ---------------------------------------------------------------------------------------------
 ;; Proofs
-
-(defn- span
-  "The monomial bound on Σ c_j (r_j − 1) + 1 over `terms`: Σ c_j·r_j is a sound over-approximation."
-  [terms]
-  (reduce (fn [acc {:keys [coefficient radix]}]
-            (let [term (product coefficient radix)]
-              (when (and acc term)
-                ;; monomials do not add; a sound bound is the dominant term times the count
-                (if (dominates? acc term) acc (if (dominates? term acc) term nil)))))
-          {:const 0 :factors []}
-          terms))
 
 (defn complete?
   "Every leaf digit of the map index is covered by a term: itself, or an ancestor used whole.
@@ -363,7 +382,7 @@
       (some (fn [{:keys [factor* le]}]
               (and (some #(some #{factor*} (:factors %)) lower-radices)
                    (some #{factor} (:factors le))))
-            (map #(clojure.set/rename-keys % {:factor :factor*}) quot-facts))))
+            (map #(set/rename-keys % {:factor :factor*}) quot-facts))))
 
 (defn injective?
   "Sufficient condition that the index form maps distinct digit tuples to distinct addresses:

--- a/src/raster/compiler/ir/index_algebra.clj
+++ b/src/raster/compiler/ir/index_algebra.clj
@@ -151,15 +151,20 @@
                  :quot-expressions {}
                  :quot-facts []
                  :order 1}
-        ;; a radix or divisor is an extent: it may not mention the index or a digit. A
+        ;; a radix or divisor is an extent: it may not mention the index, a digit, or a region
+        ;; local the algebra did not resolve (`y = (- 8 i)` varies with the item). A
         ;; `(quot e c)` inside it is the scalar local that computed it, when one exists.
-        resolve (fn [{:keys [substitutions quot-expressions digits]} form]
+        resolve (fn [{:keys [substitutions quot-expressions digits] unresolved :locals} form]
                   (let [m (monomial (->> (strip-cast form)
                                          (clojure.walk/postwalk-replace substitutions)
                                          (clojure.walk/postwalk strip-cast)
-                                         (clojure.walk/postwalk-replace quot-expressions)))]
-                    (when (and m (empty? (set/intersection (set (:factors m))
-                                                           (set (keys digits)))))
+                                         (clojure.walk/postwalk-replace quot-expressions)))
+                        factors (set (:factors m))]
+                    (when (and m
+                               (empty? (set/intersection factors (set (keys digits))))
+                               (empty? (set/intersection factors
+                                                         (set (remove (set (keys substitutions))
+                                                                      unresolved)))))
                       m)))
         ;; the map extent may mention a quot the locals define later; resolve it on demand
         quantity-extent (fn [state quantity]

--- a/src/raster/compiler/ir/index_algebra.clj
+++ b/src/raster/compiler/ir/index_algebra.clj
@@ -14,6 +14,7 @@
 
    See .internal/design/index_algebra.md for the derivation."
   (:require [clojure.set :as set]
+            [clojure.set]
             [clojure.walk]))
 
 ;; ---------------------------------------------------------------------------------------------
@@ -56,6 +57,12 @@
                :factors (vec (sort (concat (:factors acc) (:factors m))))}))
           {:const 1 :factors []}
           monomials))
+
+(defn add
+  "The sum of two monomials when it is again a monomial (equal factor multisets), else nil."
+  [a b]
+  (when (and a b (= (:factors a) (:factors b)))
+    {:const (+ (:const a) (:const b)) :factors (:factors a)}))
 
 (defn- dominates-directly?
   [a b]
@@ -109,19 +116,37 @@
   (and (seq? expression) (= 3 (count expression))
        (contains? '#{rem clojure.core/rem mod clojure.core/mod} (first expression))))
 
+(defn- quotient
+  "The exact monomial quotient `a / b`, or nil when `b` does not divide `a` syntactically."
+  [a b]
+  (when (and a b (pos? (:const b)) (zero? (mod (:const a) (:const b))))
+    (let [remaining (reduce (fn [factors f]
+                              (let [position (.indexOf ^java.util.List factors f)]
+                                (if (and factors (<= 0 position))
+                                  (vec (concat (subvec factors 0 position)
+                                               (subvec factors (inc position))))
+                                  (reduced nil))))
+                            (:factors a) (:factors b))]
+      (when remaining
+        {:const (quot (:const a) (:const b)) :factors remaining}))))
+
 (defn digits
   "Recover the mixed-radix digits of `index` (extent `extent`) from ordered region locals.
 
-   Returns `{:digits {sym {:radix monomial :order n}} :quot-facts [{:factor sym :times m :le e}]}`.
-   A `rem`-digit `(rem x m)` of an already known quantity `x` has radix `m`; a `quot`-digit
-   `(quot x m)` has radix `extent(x)/m`, recorded as an opaque factor with the fact
-   `m·factor ≤ extent(x)`. Locals that are neither are ignored (they may be arithmetic over
-   digits, which `index-form` handles)."
+   A quantity `x` of extent `E` is decomposed only by a matched pair `(quot x d)` / `(rem x d)`
+   with the same divisor `d` dividing `E` exactly: the remainder digit has radix `d`, the
+   quotient digit radix `E/d`, and `x` stops being a leaf only then (a lone `quot` or `rem` is a
+   lossy projection, so `x` stays a leaf and a store using only the projection is incomplete).
+   A scalar `(quot e c)` local becomes an opaque factor with the fact `c·factor ≤ e`. Locals
+   that are products or sums are substituted into later expressions; any other local stays an
+   unresolved symbol that `index-form` refuses."
   [index extent locals]
   (let [initial {:quantities {index {:extent nil :raw extent}}
                  :digits {index {:radix nil :order 0}}
                  :leaves #{index}
                  :parents {}
+                 :pending {}
+                 :locals #{}
                  :substitutions {}
                  :quot-expressions {}
                  :quot-facts []
@@ -142,37 +167,39 @@
                               (when-let [raw (get-in state [:quantities quantity :raw])]
                                 (resolve state raw))))]
     (reduce
-     (fn [{:keys [quantities substitutions] :as state} {:keys [id init]}]
+     (fn [{:keys [quantities] :as state} {:keys [id init]}]
        (let [init (strip-cast init)
-             source (when (seq? init) (strip-cast (second init)))]
+             source (when (seq? init) (strip-cast (second init)))
+             state (update state :locals conj id)
+             ;; a quot/rem digit of a known quantity: registered once its divisor divides the
+             ;; quantity's extent exactly; the source leaves the leaf set only when both digits
+             ;; of the same divisor exist
+             decompose
+             (fn [kind]
+               (let [divisor (resolve state (nth init 2))
+                     source-extent (quantity-extent state source)
+                     radix (when (and divisor source-extent)
+                             (case kind
+                               :rem divisor
+                               :quot (quotient source-extent divisor)))]
+                 (if (and radix (pos? (:const radix)))
+                   (let [state (-> state
+                                   (assoc-in [:digits id] {:radix radix :order (:order state)})
+                                   (assoc-in [:quantities id] {:extent radix})
+                                   (assoc-in [:parents id] source)
+                                   (assoc-in [:pending source divisor kind] id)
+                                   (update :order inc))
+                         pair (get-in state [:pending source divisor])]
+                     (if (and (:quot pair) (:rem pair))
+                       (update state :leaves #(-> % (disj source) (conj (:quot pair) (:rem pair))))
+                       state))
+                   state)))]
          (cond
-           ;; a digit: the remainder of a known quantity
            (and (rem-form? init) (contains? quantities source))
-           (if-let [radix (resolve state (nth init 2))]
-             (-> state
-                 (assoc-in [:digits id] {:radix radix :order (:order state)})
-                 (assoc-in [:quantities id] {:extent radix})
-                 (assoc-in [:parents id] source)
-                 (update :leaves #(-> % (disj source) (conj id)))
-                 (update :order inc))
-             state)
+           (decompose :rem)
 
-           ;; a digit: the quotient of a known quantity, with radix extent/divisor as an
-           ;; opaque factor bounded by `divisor·factor ≤ extent`
            (and (quot-form? init) (contains? quantities source))
-           (let [divisor (resolve state (nth init 2))
-                 source-extent (quantity-extent state source)]
-             (if (and divisor source-extent)
-               (let [factor (symbol (str "rstr_quot_" (name id)))
-                     radix {:const 1 :factors [factor]}]
-                 (-> state
-                     (assoc-in [:digits id] {:radix radix :order (:order state)})
-                     (assoc-in [:quantities id] {:extent radix})
-                     (assoc-in [:parents id] source)
-                     (update :leaves #(-> % (disj source) (conj id)))
-                     (update :quot-facts conj {:factor factor :times divisor :le source-extent})
-                     (update :order inc)))
-               state))
+           (decompose :quot)
 
            ;; a scalar quotient of an extent (`hdim2 = (quot head-dim 2)`): an opaque factor
            ;; with its bound, usable in later radices and coefficients
@@ -191,7 +218,7 @@
            (and (seq? init)
                 (contains? '#{* + clojure.core/* clojure.core/+} (first init)))
            (assoc-in state [:substitutions id]
-                     (clojure.walk/postwalk-replace substitutions init))
+                     (clojure.walk/postwalk-replace (:substitutions state) init))
 
            :else state)))
      initial
@@ -227,9 +254,11 @@
       (reduce (fn [sum operand]
                 (when-let [a (affine operand digit-set)]
                   (when sum
-                    {:terms (merge-with (fn [x y] (product x y)) (:terms sum) (:terms a))
-                     :const (+ (:const sum) (:const a))
-                     :symbolic (vec (concat (:symbolic sum) (:symbolic a)))})))
+                    (let [terms (merge-with add (:terms sum) (:terms a))]
+                      (when (every? some? (vals terms))
+                        {:terms terms
+                         :const (+ (:const sum) (:const a))
+                         :symbolic (vec (concat (:symbolic sum) (:symbolic a)))})))))
               {:terms {} :const 0 :symbolic []}
               (rest expression))
       (and (seq? expression) (contains? '#{* clojure.core/*} (first expression)))
@@ -252,7 +281,7 @@
    `loop-indices` is a map of loop index symbol → extent for counted loops inside the region;
    they are digits too, with their extent as radix."
   [expression index extent locals loop-indices]
-  (let [{:keys [digits leaves parents substitutions quot-facts]}
+  (let [{:keys [digits leaves parents substitutions quot-facts] unresolved :locals}
         (complete-digits (digits index extent locals) index)
         loop-digits (reduce-kv (fn [acc loop-index loop-extent]
                                  (if-let [radix (monomial loop-extent)]
@@ -263,14 +292,20 @@
         leaves (into leaves (keys loop-digits))
         digit-set (set (keys digits))
         expression (clojure.walk/postwalk-replace substitutions (strip-cast expression))
-        form (affine expression digit-set)
-        ;; the constant offset: an integer, or one symbolic extent monomial (not both)
+        ;; every local the index references must have become a digit or been substituted:
+        ;; an unresolved local (a subtraction, a load, a cast of a float) is not invariant
+        resolved (set/union digit-set (set (keys substitutions)))
+        unresolved-locals (set/intersection (set (remove resolved unresolved))
+                                            (set (filter symbol? (tree-seq coll? seq expression))))
+        form (when (empty? unresolved-locals) (affine expression digit-set))
+        ;; the constant offset: an integer, or the sum of the symbolic operands when that sum
+        ;; is one monomial (`d + d = 2d`); a mixed or non-monomial sum is undecidable
         offset (when form
-                 (let [symbolic (distinct (:symbolic form))]
+                 (let [symbolic (map monomial (:symbolic form))]
                    (cond
                      (empty? symbolic) {:const (:const form) :factors []}
-                     (and (= 1 (count symbolic)) (zero? (:const form)))
-                     (monomial (first symbolic))
+                     (and (every? some? symbolic) (zero? (:const form)))
+                     (reduce add symbolic)
                      :else nil)))
         ancestors (fn ancestors [digit]
                     (when-let [parent (get parents digit)]
@@ -313,10 +348,23 @@
                        (when-let [parent (get parents digit)] (covered? parent))))]
     (every? covered? leaves)))
 
+(defn- supported-factor?
+  "A symbolic factor of a coefficient is admissible only when some lower digit's radix vouches
+   for it: it is a factor of that radix, or a quot fact bounds such a factor by it. Then a zero
+   value of the factor empties the lower digit and no item stores at all, so `a·f ≥ a` may be
+   used; an arbitrary captured scalar (`stride`) could be zero and collapse every item."
+  [factor lower-radices quot-facts]
+  (or (some #(some #{factor} (:factors %)) lower-radices)
+      (some (fn [{:keys [factor* le]}]
+              (and (some #(some #{factor*} (:factors %)) lower-radices)
+                   (some #{factor} (:factors le))))
+            (map #(clojure.set/rename-keys % {:factor :factor*}) quot-facts))))
+
 (defn injective?
   "Sufficient condition that the index form maps distinct digit tuples to distinct addresses:
    with terms ordered by coefficient dominance, every coefficient dominates the product of the
-   radices of all lower terms (the row-major carry condition), and the form is complete."
+   radices of all lower terms (the row-major carry condition), every coefficient's symbolic
+   factors are vouched for by a lower radix, and the form is complete."
   [{:keys [terms quot-facts] :as form}]
   (boolean
    (and form
@@ -340,10 +388,14 @@
            ;; induction `c_k ≥ Σ_{j>k} c_j (r_j − 1) + 1`, so distinct digit tuples never meet.
            (every? (fn [k]
                      (let [{:keys [coefficient]} (nth ordered k)
-                           required (if-let [next-term (nth ordered (inc k) nil)]
+                           lower (subvec ordered (inc k))
+                           required (if-let [next-term (first lower)]
                                       (product (:coefficient next-term) (:radix next-term))
                                       {:const 1 :factors []})]
-                       (dominates? coefficient required quot-facts)))
+                       (and (pos? (:const coefficient))
+                            (every? #(supported-factor? % (map :radix lower) quot-facts)
+                                    (:factors coefficient))
+                            (dominates? coefficient required quot-facts))))
                    (range (count ordered))))))))
 
 (defn- offset-multiple

--- a/src/raster/compiler/ir/index_algebra.clj
+++ b/src/raster/compiler/ir/index_algebra.clj
@@ -1,0 +1,384 @@
+(ns raster.compiler.ir.index-algebra
+  "Mixed-radix index forms and the injectivity facts a store contract needs.
+
+   A map index `idx` over `[0, N)` is decomposed into digits by a `quot`/`rem` chain and
+   re-assembled into a store index by an affine form over those digits. `index-form` recovers
+   that structure from region locals; `injective?` proves the form maps distinct work items to
+   distinct addresses, and `disjoint-offsets?` proves several stores of one region never
+   collide. Every proof is a sufficient condition over symbolic extents: it either succeeds or
+   declines, it never guesses.
+
+   Extents are compared as monomials: an integer constant times a multiset of non-negative
+   symbolic factors. `(quot e 2)` becomes an opaque factor that remembers `2·factor ≤ e`, which
+   is exactly the fact a half-dimension layout needs.
+
+   See .internal/design/index_algebra.md for the derivation."
+  (:require [clojure.set :as set]
+            [clojure.walk]))
+
+;; ---------------------------------------------------------------------------------------------
+;; Monomials over symbolic extents
+
+(defn- strip-cast
+  [expression]
+  (if (and (seq? expression) (= 2 (count expression))
+           (contains? '#{long int clojure.core/long clojure.core/int} (first expression)))
+    (recur (second expression))
+    expression))
+
+(defn monomial
+  "Normalize an extent expression to `{:const n :factors [sym …]}` (factors sorted, repeated
+   for powers), or nil when the expression is not a product of non-negative factors."
+  [expression]
+  (let [expression (strip-cast expression)]
+    (cond
+      (integer? expression) (when (<= 0 expression) {:const (long expression) :factors []})
+      (symbol? expression) {:const 1 :factors [expression]}
+      (and (seq? expression) (contains? '#{* clojure.core/*} (first expression)))
+      (reduce (fn [product operand]
+                (when-let [m (monomial operand)]
+                  (when product
+                    {:const (* (:const product) (:const m))
+                     :factors (vec (sort (concat (:factors product) (:factors m))))})))
+              {:const 1 :factors []}
+              (rest expression))
+      :else nil)))
+
+(defn- multiset
+  [factors]
+  (frequencies factors))
+
+(defn product
+  [& monomials]
+  (reduce (fn [acc m]
+            (when (and acc m)
+              {:const (* (:const acc) (:const m))
+               :factors (vec (sort (concat (:factors acc) (:factors m))))}))
+          {:const 1 :factors []}
+          monomials))
+
+(defn- dominates-directly?
+  [a b]
+  (and a b
+       (>= (:const a) (:const b))
+       (every? (fn [[factor n]] (>= (get (multiset (:factors a)) factor 0) n))
+               (multiset (:factors b)))))
+
+(defn- scale
+  [m n]
+  (update m :const * n))
+
+(defn- replace-factor
+  [m factor replacement]
+  (let [factors (:factors m)
+        position (.indexOf ^java.util.List factors factor)]
+    (when (<= 0 position)
+      {:const (* (:const m) (:const replacement))
+       :factors (vec (sort (concat (subvec factors 0 position)
+                                   (subvec factors (inc position))
+                                   (:factors replacement))))})))
+
+(defn dominates?
+  "Whether monomial `a` is at least monomial `b` for every non-negative assignment of the
+   factors: `a`'s factors contain `b`'s as a multiset and its constant is at least `b`'s.
+
+   `facts` are `{:factor f :times m :le e}` bounds (`m·f ≤ e`, from `(quot e m)`): when `b`
+   mentions such an `f`, `a ≥ b` follows from `m·a ≥ b[f := e]`. Sufficient, not complete."
+  ([a b] (dominates? a b []))
+  ([a b facts]
+   (boolean
+    (and a b
+         (or (dominates-directly? a b)
+             (some (fn [{:keys [factor times le]}]
+                     (when (some #{factor} (:factors b))
+                       (dominates? (product a times)
+                                   (replace-factor b factor le)
+                                   (remove #(= factor (:factor %)) facts))))
+                   facts))))))
+
+;; ---------------------------------------------------------------------------------------------
+;; Digits
+
+(defn- quot-form?
+  [expression]
+  (and (seq? expression) (= 3 (count expression))
+       (contains? '#{quot clojure.core/quot} (first expression))))
+
+(defn- rem-form?
+  [expression]
+  (and (seq? expression) (= 3 (count expression))
+       (contains? '#{rem clojure.core/rem mod clojure.core/mod} (first expression))))
+
+(defn digits
+  "Recover the mixed-radix digits of `index` (extent `extent`) from ordered region locals.
+
+   Returns `{:digits {sym {:radix monomial :order n}} :quot-facts [{:factor sym :times m :le e}]}`.
+   A `rem`-digit `(rem x m)` of an already known quantity `x` has radix `m`; a `quot`-digit
+   `(quot x m)` has radix `extent(x)/m`, recorded as an opaque factor with the fact
+   `m·factor ≤ extent(x)`. Locals that are neither are ignored (they may be arithmetic over
+   digits, which `index-form` handles)."
+  [index extent locals]
+  (let [initial {:quantities {index {:extent nil :raw extent}}
+                 :digits {index {:radix nil :order 0}}
+                 :leaves #{index}
+                 :parents {}
+                 :substitutions {}
+                 :quot-expressions {}
+                 :quot-facts []
+                 :order 1}
+        ;; a radix or divisor is an extent: it may not mention the index or a digit. A
+        ;; `(quot e c)` inside it is the scalar local that computed it, when one exists.
+        resolve (fn [{:keys [substitutions quot-expressions digits]} form]
+                  (let [m (monomial (->> (strip-cast form)
+                                         (clojure.walk/postwalk-replace substitutions)
+                                         (clojure.walk/postwalk strip-cast)
+                                         (clojure.walk/postwalk-replace quot-expressions)))]
+                    (when (and m (empty? (set/intersection (set (:factors m))
+                                                           (set (keys digits)))))
+                      m)))
+        ;; the map extent may mention a quot the locals define later; resolve it on demand
+        quantity-extent (fn [state quantity]
+                          (or (get-in state [:quantities quantity :extent])
+                              (when-let [raw (get-in state [:quantities quantity :raw])]
+                                (resolve state raw))))]
+    (reduce
+     (fn [{:keys [quantities substitutions] :as state} {:keys [id init]}]
+       (let [init (strip-cast init)
+             source (when (seq? init) (strip-cast (second init)))]
+         (cond
+           ;; a digit: the remainder of a known quantity
+           (and (rem-form? init) (contains? quantities source))
+           (if-let [radix (resolve state (nth init 2))]
+             (-> state
+                 (assoc-in [:digits id] {:radix radix :order (:order state)})
+                 (assoc-in [:quantities id] {:extent radix})
+                 (assoc-in [:parents id] source)
+                 (update :leaves #(-> % (disj source) (conj id)))
+                 (update :order inc))
+             state)
+
+           ;; a digit: the quotient of a known quantity, with radix extent/divisor as an
+           ;; opaque factor bounded by `divisor·factor ≤ extent`
+           (and (quot-form? init) (contains? quantities source))
+           (let [divisor (resolve state (nth init 2))
+                 source-extent (quantity-extent state source)]
+             (if (and divisor source-extent)
+               (let [factor (symbol (str "rstr_quot_" (name id)))
+                     radix {:const 1 :factors [factor]}]
+                 (-> state
+                     (assoc-in [:digits id] {:radix radix :order (:order state)})
+                     (assoc-in [:quantities id] {:extent radix})
+                     (assoc-in [:parents id] source)
+                     (update :leaves #(-> % (disj source) (conj id)))
+                     (update :quot-facts conj {:factor factor :times divisor :le source-extent})
+                     (update :order inc)))
+               state))
+
+           ;; a scalar quotient of an extent (`hdim2 = (quot head-dim 2)`): an opaque factor
+           ;; with its bound, usable in later radices and coefficients
+           (quot-form? init)
+           (if-let [[divisor bound] (let [d (resolve state (nth init 2))
+                                          b (resolve state (second init))]
+                                      (when (and d b) [d b]))]
+             (-> state
+                 (assoc-in [:substitutions id] id)
+                 (assoc-in [:quot-expressions (clojure.walk/postwalk strip-cast init)] id)
+                 (update :quot-facts conj {:factor id :times divisor :le bound}))
+             state)
+
+           ;; an affine or product local (`per-row = heads*hdim2`, `base = t*width + h`):
+           ;; substitute it into later expressions
+           (and (seq? init)
+                (contains? '#{* + clojure.core/* clojure.core/+} (first init)))
+           (assoc-in state [:substitutions id]
+                     (clojure.walk/postwalk-replace substitutions init))
+
+           :else state)))
+     initial
+     locals)))
+
+(defn- complete-digits
+  "Resolve the map index's own radix (its extent) once every scalar local is known."
+  [{:keys [digits] :as state} index]
+  (let [extent (or (get-in digits [index :radix])
+                   (let [{:keys [substitutions quot-expressions]} state
+                         raw (get-in state [:quantities index :raw])]
+                     (monomial (->> (strip-cast raw)
+                                    (clojure.walk/postwalk-replace substitutions)
+                                    (clojure.walk/postwalk strip-cast)
+                                    (clojure.walk/postwalk-replace quot-expressions)))))]
+    (assoc-in state [:digits index :radix] extent)))
+
+;; ---------------------------------------------------------------------------------------------
+;; Affine forms over digits
+
+(defn- affine
+  "Affine normal form `{:terms {sym monomial-coefficient} :const n}` of an index expression over
+   the given digit symbols, or nil when it is not affine in them."
+  [expression digit-set]
+  (let [expression (strip-cast expression)]
+    (cond
+      (integer? expression) {:terms {} :const (long expression)}
+      (symbol? expression) (if (contains? digit-set expression)
+                             {:terms {expression {:const 1 :factors []}} :const 0}
+                             ;; a free symbolic scalar is a symbolic constant offset
+                             {:terms {} :const 0 :symbolic [expression]})
+      (and (seq? expression) (contains? '#{+ clojure.core/+} (first expression)))
+      (reduce (fn [sum operand]
+                (when-let [a (affine operand digit-set)]
+                  (when sum
+                    {:terms (merge-with (fn [x y] (product x y)) (:terms sum) (:terms a))
+                     :const (+ (:const sum) (:const a))
+                     :symbolic (vec (concat (:symbolic sum) (:symbolic a)))})))
+              {:terms {} :const 0 :symbolic []}
+              (rest expression))
+      (and (seq? expression) (contains? '#{* clojure.core/*} (first expression)))
+      (let [operands (rest expression)
+            digit-operands (filter #(contains? digit-set (strip-cast %)) operands)
+            others (remove #(contains? digit-set (strip-cast %)) operands)]
+        (cond
+          (and (= 1 (count digit-operands)) (every? monomial others))
+          {:terms {(strip-cast (first digit-operands)) (apply product (map monomial others))}
+           :const 0 :symbolic []}
+          ;; a product without any digit is a symbolic offset
+          (and (empty? digit-operands) (monomial expression))
+          {:terms {} :const 0 :symbolic [expression]}
+          :else nil))
+      :else nil)))
+
+(defn index-form
+  "The affine form of `expression` over the digits of `index`, with each term's radix, or nil.
+
+   `loop-indices` is a map of loop index symbol → extent for counted loops inside the region;
+   they are digits too, with their extent as radix."
+  [expression index extent locals loop-indices]
+  (let [{:keys [digits leaves parents substitutions quot-facts]}
+        (complete-digits (digits index extent locals) index)
+        loop-digits (reduce-kv (fn [acc loop-index loop-extent]
+                                 (if-let [radix (monomial loop-extent)]
+                                   (assoc acc loop-index {:radix radix :order (count acc)})
+                                   acc))
+                               {} loop-indices)
+        digits (merge digits loop-digits)
+        leaves (into leaves (keys loop-digits))
+        digit-set (set (keys digits))
+        expression (clojure.walk/postwalk-replace substitutions (strip-cast expression))
+        form (affine expression digit-set)
+        ;; the constant offset: an integer, or one symbolic extent monomial (not both)
+        offset (when form
+                 (let [symbolic (distinct (:symbolic form))]
+                   (cond
+                     (empty? symbolic) {:const (:const form) :factors []}
+                     (and (= 1 (count symbolic)) (zero? (:const form)))
+                     (monomial (first symbolic))
+                     :else nil)))
+        ancestors (fn ancestors [digit]
+                    (when-let [parent (get parents digit)]
+                      (cons parent (ancestors parent))))
+        term-set (set (keys (:terms form)))]
+    (when (and form offset (seq term-set)
+               ;; a quantity used whole may not appear beside a digit derived from it
+               (not-any? (fn [digit] (some term-set (ancestors digit))) term-set)
+               (every? #(some? (get-in digits [% :radix])) term-set))
+      {:terms (into {} (map (fn [[digit coefficient]]
+                              [digit {:coefficient coefficient
+                                      :radix (get-in digits [digit :radix])}]))
+                    (:terms form))
+       :offset offset
+       :leaves leaves
+       :parents parents
+       :quot-facts quot-facts})))
+
+;; ---------------------------------------------------------------------------------------------
+;; Proofs
+
+(defn- span
+  "The monomial bound on Σ c_j (r_j − 1) + 1 over `terms`: Σ c_j·r_j is a sound over-approximation."
+  [terms]
+  (reduce (fn [acc {:keys [coefficient radix]}]
+            (let [term (product coefficient radix)]
+              (when (and acc term)
+                ;; monomials do not add; a sound bound is the dominant term times the count
+                (if (dominates? acc term) acc (if (dominates? term acc) term nil)))))
+          {:const 0 :factors []}
+          terms))
+
+(defn complete?
+  "Every leaf digit of the map index is covered by a term: itself, or an ancestor used whole.
+   A dropped digit means two work items collide."
+  [{:keys [terms leaves parents]}]
+  (let [term-set (set (keys terms))
+        covered? (fn covered? [digit]
+                   (or (contains? term-set digit)
+                       (when-let [parent (get parents digit)] (covered? parent))))]
+    (every? covered? leaves)))
+
+(defn injective?
+  "Sufficient condition that the index form maps distinct digit tuples to distinct addresses:
+   with terms ordered by coefficient dominance, every coefficient dominates the product of the
+   radices of all lower terms (the row-major carry condition), and the form is complete."
+  [{:keys [terms quot-facts] :as form}]
+  (boolean
+   (and form
+        (complete? form)
+        (let [entries (vec (vals terms))
+              ;; sort by dominance: insertion sort with the fact-aware comparison
+              ordered (reduce (fn [sorted entry]
+                                (let [position (count (take-while
+                                                       #(dominates? (:coefficient %)
+                                                                    (:coefficient entry)
+                                                                    quot-facts)
+                                                       sorted))]
+                                  (vec (concat (subvec sorted 0 position) [entry]
+                                               (subvec sorted position)))))
+                              [] entries)]
+          (and
+           (every? (fn [[a b]] (dominates? (:coefficient a) (:coefficient b) quot-facts))
+                   (partition 2 1 ordered))
+           ;; Nested row-major carry: each coefficient covers the whole span of the next
+           ;; level, `c_k ≥ c_{k+1}·r_{k+1}`, and the innermost stride is at least one. By
+           ;; induction `c_k ≥ Σ_{j>k} c_j (r_j − 1) + 1`, so distinct digit tuples never meet.
+           (every? (fn [k]
+                     (let [{:keys [coefficient]} (nth ordered k)
+                           required (if-let [next-term (nth ordered (inc k) nil)]
+                                      (product (:coefficient next-term) (:radix next-term))
+                                      {:const 1 :factors []})]
+                       (dominates? coefficient required quot-facts)))
+                   (range (count ordered))))))))
+
+(defn- offset-multiple
+  "The integer `q` with `offset = q·stride` for monomials, or nil."
+  [offset stride]
+  (when (and offset stride
+             (= (:factors offset) (:factors stride))
+             (pos? (:const stride))
+             (zero? (mod (:const offset) (:const stride))))
+    (quot (:const offset) (:const stride))))
+
+(defn disjoint-offsets?
+  "Sufficient condition that stores sharing one index form and differing only by constant
+   offsets never collide within one work item or across items.
+
+   Offsets are extent expressions (`0`, `hdim2`, `(* 2 hdim2)`). They must be multiples
+   `q·d` of one stride monomial `d` with `0 ≤ q < m`; the store ordinal then becomes one more
+   digit of radix `m` and coefficient `d`, and the row-major carry condition decides. For RoPE
+   (`+ i` and `+ i + hdim2` under `h·head-dim`) the fact `2·hdim2 ≤ head-dim` closes it."
+  [{:keys [terms quot-facts] :as form} offsets]
+  (let [monomials (mapv #(if (map? %) % (monomial %)) offsets)]
+    (boolean
+     (and form
+          (every? some? monomials)
+          (or (<= (count (distinct monomials)) 1)
+              (let [zero {:const 0 :factors []}
+                    nonzero (remove #(= zero %) (distinct monomials))
+                    ;; the smallest non-zero offset is the candidate stride
+                    stride (reduce (fn [a b] (if (dominates? a b quot-facts) b a)) nonzero)
+                    multiples (mapv #(if (= zero %) 0 (offset-multiple % stride)) (distinct monomials))]
+                (and (every? some? multiples)
+                     (= (count multiples) (count (distinct multiples)))
+                     (let [radix {:const (inc (long (apply max multiples))) :factors []}
+                           ordinal (symbol "rstr_store_ordinal")]
+                       (injective?
+                        (-> form
+                            (assoc-in [:terms ordinal] {:coefficient stride :radix radix})
+                            (update :leaves conj ordinal)))))))))))

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -1604,7 +1604,9 @@
                        (seq? expression)
                        (contains? '#{* + clojure.core/* clojure.core/+ quot clojure.core/quot}
                                   (descriptor/semantic-op expression))
-                       (provably-pure-scalar? expression))
+                       (provably-pure-scalar? expression)
+                       ;; a definition that reads an array is not an invariant extent
+                       (empty? (par/collect-aget-arrays expression)))
               expression)
             allocation-dtype
             (when (and (= :scalar (:kind description))

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -628,14 +628,30 @@
   [expression]
   (util/postwalk-preserving-meta strip-index-cast expression))
 
+(def ^:dynamic ^:private *scalar-definitions*
+  "Host scalar bindings preceding the operation being described, as `{id expression}` for the
+   pure product/sum definitions (the normalizer's `rstr_extent_n` ids among them). The index
+   algebra needs an extent's product structure, which its SSA id hides."
+  {})
+
+(defn- expand-scalar-definitions
+  [expression]
+  (loop [expression expression remaining (inc (count *scalar-definitions*))]
+    (let [expanded (util/subst-syms *scalar-definitions* expression)]
+      (if (or (= expanded expression) (zero? remaining))
+        expanded
+        (recur expanded (dec remaining))))))
+
 (defn- store-index-form
   "The mixed-radix index form of a store's destination index over the map index (extent
-   `extent`), the region locals and, for a loop store, its loop's locals and index."
+   `extent`), the region locals and, for a loop store, its loop's locals and index. Host
+   scalar definitions are expanded first so extents and strides show their factors."
   [store index extent locals loops]
-  (let [loop (when (:loop store) (nth loops (:loop store)))]
-    (index-algebra/index-form (:index store) index extent
-                              (vec (concat locals (:locals loop)))
-                              (if loop {(:index loop) (:extent loop)} {}))))
+  (let [loop (when (:loop store) (nth loops (:loop store)))
+        expand expand-scalar-definitions]
+    (index-algebra/index-form (expand (:index store)) index (expand extent)
+                              (mapv #(update % :init expand) (concat locals (:locals loop)))
+                              (if loop {(:index loop) (expand (:extent loop))} {}))))
 
 (defn- proven-unique-stores
   "The stores whose destination writes are provably injective across work items: each store's
@@ -713,12 +729,28 @@
                                          index extent locals loops)
             proven? (let [indices (vec (remove :reduction-op candidate-stores))]
                       (fn [store] (contains? proven (.indexOf ^java.util.List indices store))))
+            ;; A marker is honoured only for an index outside the algebra's reach: the index
+            ;; expression or a local it depends on (transitively) reads an array. Unrelated
+            ;; locals may not authorize a claim, so only the index's dependency slice counts.
             data-dependent? (fn [{:keys [index] :as store}]
-                              (seq (par/collect-aget-arrays
-                                    (list 'do index
-                                          (map :init (concat locals
-                                                             (:locals (when (:loop store)
-                                                                        (nth loops (:loop store))))))))))
+                              (let [scope (concat locals
+                                                  (:locals (when (:loop store)
+                                                             (nth loops (:loop store)))))
+                                    inits (into {} (map (juxt :id :init)) scope)
+                                    slice (loop [pending (set (filter symbol?
+                                                                      (tree-seq coll? seq index)))
+                                                 seen #{}
+                                                 expressions [index]]
+                                            (let [next (set/difference pending seen)]
+                                              (if (empty? next)
+                                                expressions
+                                                (let [found (keep inits next)]
+                                                  (recur (set (filter symbol?
+                                                                      (mapcat #(tree-seq coll? seq %)
+                                                                              found)))
+                                                         (set/union seen next)
+                                                         (into expressions found))))))]
+                                (seq (par/collect-aget-arrays (list* 'do slice)))))
             all-stores (mapv (fn [{:keys [out reduction-op conflict] :as store}]
                                (let [destination-type (some-> (destination-dtype array-types out)
                                                              dtype/canon)
@@ -1559,12 +1591,21 @@
   ;; float-array reduced by a strided scatter remains FP32 even in a mixed-precision program.
   (:descriptions
    (reduce
-    (fn [{:keys [array-types] :as state} [id [symbol expression]]]
+    (fn [{:keys [array-types scalar-definitions] :as state} [id [symbol expression]]]
       (let [description
-            (or (operation-description id symbol expression default-dtype array-types)
+            (or (binding [*scalar-definitions* scalar-definitions]
+                  (operation-description id symbol expression default-dtype array-types))
                 (if (par/par-form? expression)
                   {:kind :unsupported :id id :sym symbol :expr expression}
                   {:kind :scalar :id id :sym symbol :expr expression}))
+            ;; a pure product/sum of scalars is a definition later index algebra may expand
+            scalar-definition
+            (when (and (= :scalar (:kind description)) (symbol? symbol)
+                       (seq? expression)
+                       (contains? '#{* + clojure.core/* clojure.core/+ quot clojure.core/quot}
+                                  (descriptor/semantic-op expression))
+                       (provably-pure-scalar? expression))
+              expression)
             allocation-dtype
             (when (and (= :scalar (:kind description))
                        (seq? expression)
@@ -1575,8 +1616,9 @@
                                        (some-> operation name symbol)))]
                 (some-> array-tag dtype/dtype-for-array-tag dtype/canon)))]
         (cond-> (update state :descriptions conj description)
-          allocation-dtype (assoc-in [:array-types symbol] allocation-dtype))))
-    {:descriptions [] :array-types array-types}
+          allocation-dtype (assoc-in [:array-types symbol] allocation-dtype)
+          scalar-definition (assoc-in [:scalar-definitions symbol] scalar-definition))))
+    {:descriptions [] :array-types array-types :scalar-definitions {}}
     (map-indexed vector pairs))))
 
 (defn- canonical-extent

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -13,6 +13,7 @@
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.contraction-facts :as contraction-facts]
+            [raster.compiler.ir.index-algebra :as index-algebra]
             [raster.compiler.ir.form :as form]
             [raster.compiler.ir.par :as par]
             [raster.compiler.ir.reduction :as reduction]
@@ -627,37 +628,33 @@
   [expression]
   (util/postwalk-preserving-meta strip-index-cast expression))
 
-(defn- inline-region-locals
-  "Substitute region-local SSA ids by their initializers until the expression is closed."
-  [expression locals]
-  (let [substitutions (into {} (map (juxt :id :init)) locals)]
-    (loop [expression expression remaining (inc (count locals))]
-      (let [inlined (util/subst-syms substitutions expression)]
-        (if (or (= inlined expression) (zero? remaining))
-          inlined
-          (recur inlined (dec remaining)))))))
+(defn- store-index-form
+  "The mixed-radix index form of a store's destination index over the map index (extent
+   `extent`), the region locals and, for a loop store, its loop's locals and index."
+  [store index extent locals loops]
+  (let [loop (when (:loop store) (nth loops (:loop store)))]
+    (index-algebra/index-form (:index store) index extent
+                              (vec (concat locals (:locals loop)))
+                              (if loop {(:index loop) (:extent loop)} {}))))
 
-(defn- row-major-loop-index?
-  "Whether a store index inside a counted loop is `r*K + i` (either operand order) with `K` the
-   loop extent, `r` the map index and `i` the loop index: the row-major layout in which the
-   map items own disjoint rows, so the writes are injective across work items."
-  [expression loop-index map-index extent]
-  (let [expression (strip-index-casts expression)
-        extent (strip-index-casts extent)
-        ;; Rows are disjoint only when every item's row has the same width: an extent that
-        ;; varies with the map index (`(- n r)`) makes consecutive rows overlap.
-        invariant-extent? (not (contains? (util/free-syms extent) map-index))
-        row-offset? (fn [form]
-                      (and (seq? form) (= 3 (count form))
-                           (contains? '#{* clojure.core/*} (first form))
-                           (= #{map-index extent} (set (rest form)))
-                           (not= map-index extent)))]
-    (and invariant-extent?
-         (seq? expression) (= 3 (count expression))
-         (contains? '#{+ clojure.core/+} (first expression))
-         (let [[_ left right] expression]
-           (or (and (= left loop-index) (row-offset? right))
-               (and (= right loop-index) (row-offset? left)))))))
+(defn- proven-unique-stores
+  "The stores whose destination writes are provably injective across work items: each store's
+   index form is injective, and stores sharing a destination share one form and write at
+   provably disjoint offsets. Returns the set of store ordinals."
+  [stores index extent locals loops]
+  (let [forms (mapv #(store-index-form % index extent locals loops) stores)
+        by-destination (group-by (fn [ordinal] (:out (nth stores ordinal)))
+                                 (range (count stores)))]
+    (into #{}
+          (mapcat (fn [[_ ordinals]]
+                    (let [group-forms (map #(nth forms %) ordinals)]
+                      (when (and (every? some? group-forms)
+                                 (every? index-algebra/injective? group-forms)
+                                 (apply = (map :terms group-forms))
+                                 (index-algebra/disjoint-offsets?
+                                  (first group-forms) (map :offset group-forms)))
+                        ordinals))))
+          by-destination)))
 
 (defn- effect-leaves
   "The store effects of a description, descending into store loops."
@@ -684,17 +681,10 @@
                                          (set (mapcat #(map :out (:stores %)) loops)))))
       (let [stores (mapv #(merge {:index index :predicate 1} %) stores)
             loop-stores
-            (vec (mapcat (fn [ordinal {loop-index :index loop-extent :extent
-                                       loop-locals :locals loop-store-list :stores}]
+            (vec (mapcat (fn [ordinal {loop-store-list :stores}]
                            (map (fn [store]
-                                  (let [store (merge {:index index :predicate 1} store)]
-                                    (assoc store
-                                           :loop ordinal
-                                           :loop-injective?
-                                           (row-major-loop-index?
-                                            (inline-region-locals (:index store)
-                                                                  (concat locals loop-locals))
-                                            loop-index index loop-extent))))
+                                  (assoc (merge {:index index :predicate 1} store)
+                                         :loop ordinal))
                                 loop-store-list))
                          (range) loops))
             dense-pointwise? (and (empty? loops)
@@ -713,22 +703,49 @@
                                             (list 'clojure.core/aget out index)))))
                            stores)
                      stores)
+            candidate-stores (into stores loop-stores)
+            ;; Uniqueness is a fact the index algebra proves. A source `unique-index` marker is
+            ;; an author's claim: it is redundant when the proof succeeds, it is the only
+            ;; certificate when the index depends on data the algebra cannot see (an indirect
+            ;; index through another array, established at runtime by validate-block-indices!),
+            ;; and it is an error when the index is in the algebra's reach and the proof fails.
+            proven (proven-unique-stores (vec (remove :reduction-op candidate-stores))
+                                         index extent locals loops)
+            proven? (let [indices (vec (remove :reduction-op candidate-stores))]
+                      (fn [store] (contains? proven (.indexOf ^java.util.List indices store))))
+            data-dependent? (fn [{:keys [index] :as store}]
+                              (seq (par/collect-aget-arrays
+                                    (list 'do index
+                                          (map :init (concat locals
+                                                             (:locals (when (:loop store)
+                                                                        (nth loops (:loop store))))))))))
             all-stores (mapv (fn [{:keys [out reduction-op conflict] :as store}]
                                (let [destination-type (some-> (destination-dtype array-types out)
                                                              dtype/canon)
+                                     uniqueness (cond
+                                                  reduction-op nil
+                                                  (proven? store) :proven
+                                                  (and (= :unique conflict) (data-dependent? store))
+                                                  :claimed
+                                                  (= :unique conflict)
+                                                  (fail! :unique-index-not-provable
+                                                         "a unique-index claim on an index the algebra can decide must be provable"
+                                                         {:binding id :destination out
+                                                          :index (:index store)})
+                                                  :else nil)
                                      contract (cond
-                                                (= :unique conflict) :unique
                                                 reduction-op
                                                 (when destination-type
                                                   (dialect/reducing-scatter-conflict
                                                    reduction-op destination-type))
-                                                (:loop-injective? store) :unique
+                                                uniqueness :unique
                                                 (and (nil? (:loop store)) (= index (:index store)))
                                                 :unique
                                                 :else :ordered)]
                                  (assoc store :effect-conflict contract
-                                              :destination-dtype destination-type)))
-                             (into stores loop-stores))
+                                              :destination-dtype destination-type
+                                              :uniqueness uniqueness)))
+                             candidate-stores)
             ;; One physical destination has one cross-item contract. If any ordinary store may
             ;; collide, its otherwise-unique siblings must join the same sequential contract. A
             ;; reduction mixed with an ordered overwrite remains unsupported: those are distinct

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -44,7 +44,8 @@
     :typed-soac-stable-read-alias
     :typed-soac-syntax
     :typed-soac-unbound-scalar
-    :typed-soac-unknown-value})
+    :typed-soac-unknown-value
+    :unique-index-not-provable})
 
 (defn source-decline?
   [exception]
@@ -761,7 +762,7 @@
                                                   :claimed
                                                   (= :unique conflict)
                                                   (fail! :unique-index-not-provable
-                                                         "a unique-index claim on an index the algebra can decide must be provable"
+                                                         "a unique-index claim on an index the algebra can decide must be provable; the proof is a sufficient condition, so the form declines to the compatibility route"
                                                          {:binding id :destination out
                                                           :index (:index store)})
                                                   :else nil)

--- a/src/raster/dl/attention.clj
+++ b/src/raster/dl/attention.clj
@@ -97,8 +97,8 @@
                                                c (m/cos ang) s (m/sin ang)
                                                x0 (aget x (clojure.core/+ base i))
                                                x1 (aget x (clojure.core/+ (clojure.core/+ base i) hdim2))]
-                                           (aset out (raster.par/unique-index (clojure.core/+ base i)) (- (* x0 c) (* x1 s)))
-                                           (aset out (raster.par/unique-index (clojure.core/+ (clojure.core/+ base i) hdim2)) (+ (* x1 c) (* x0 s)))))
+                                           (aset out (clojure.core/+ base i) (- (* x0 c) (* x1 s)))
+                                           (aset out (clojure.core/+ (clojure.core/+ base i) hdim2) (+ (* x1 c) (* x0 s)))))
                    out)))
 
 ;; RoPE backward: RoPE applies the orthogonal rotation R(ang) to each (x0,x1)
@@ -132,8 +132,8 @@
                                                            c (m/cos ang) s (m/sin ang)
                                                            d0 (aget dy (clojure.core/+ base i))
                                                            d1 (aget dy (clojure.core/+ (clojure.core/+ base i) hdim2))]
-                                                       (aset dx (raster.par/unique-index (clojure.core/+ base i)) (+ (* d0 c) (* d1 s)))
-                                                       (aset dx (raster.par/unique-index (clojure.core/+ (clojure.core/+ base i) hdim2)) (- (* d1 c) (* d0 s)))))
+                                                       (aset dx (clojure.core/+ base i) (+ (* d0 c) (* d1 s)))
+                                                       (aset dx (clojure.core/+ (clojure.core/+ base i) hdim2) (- (* d1 c) (* d0 s)))))
                                dx)))
 
 (tmpl/merge-into-template! 'raster.dl.attention/rope
@@ -210,7 +210,7 @@
                                      c (m/cos ang) s (m/sin ang)
                                      x0 (aget x (+ base i))
                                      x1 (aget x (+ (+ base i) half))]
-                                 (aset out (raster.par/unique-index (+ base i)) (- (* x0 c) (* x1 s)))
+                                 (aset out (+ base i) (- (* x0 c) (* x1 s)))
                                  (aset out (+ (+ base i) half) (+ (* x1 c) (* x0 s))))))))
                        out)))
 
@@ -474,8 +474,8 @@
                                    c (m/cos ang) s (m/sin ang)
                                    x0 (aget x (clojure.core/+ base i))
                                    x1 (aget x (clojure.core/+ (clojure.core/+ base i) hdim2))]
-                               (aset out (raster.par/unique-index (clojure.core/+ base i)) (- (* x0 c) (* x1 s)))
-                               (aset out (raster.par/unique-index (clojure.core/+ (clojure.core/+ base i) hdim2)) (+ (* x1 c) (* x0 s)))))))
+                               (aset out (clojure.core/+ base i) (- (* x0 c) (* x1 s)))
+                               (aset out (clojure.core/+ (clojure.core/+ base i) hdim2) (+ (* x1 c) (* x0 s)))))))
 
 (deftm kv-append-buf! (All [T] [src :- (Array T) cache :- (Array T) kvrow :- Long posbuf :- (Array long)] :- Void
                            (raster.par/map-void! i kvrow
@@ -2180,8 +2180,8 @@
                                                       c (m/cos ang) s (m/sin ang)
                                                       x0 (aget x (clojure.core/+ base i))
                                                       x1 (aget x (clojure.core/+ (clojure.core/+ base i) hdim2))]
-                                                  (aset out (raster.par/unique-index (clojure.core/+ base i)) (- (* x0 c) (* x1 s)))
-                                                  (aset out (raster.par/unique-index (clojure.core/+ (clojure.core/+ base i) hdim2)) (+ (* x1 c) (* x0 s)))))))
+                                                  (aset out (clojure.core/+ base i) (- (* x0 c) (* x1 s)))
+                                                  (aset out (clojure.core/+ (clojure.core/+ base i) hdim2) (+ (* x1 c) (* x0 s)))))))
 
 ;; Causal batched attention, 3 phases. q:[T,nq*hd] k,v:[T,nkv*hd] row-major;
 ;; sc:[T*nq, T] scores/probs scratch; out:[T, nq*hd].

--- a/test/raster/compiler/ir/index_algebra_test.clj
+++ b/test/raster/compiler/ir/index_algebra_test.clj
@@ -82,3 +82,12 @@
   ;; not become an extent factor. Items (1,0) and (0,3) both address 3 in `i·q + j`.
   (is (nil? (ia/index-form '(+ (* i q) j) 'i 8
                            '[{:id y :init (- 8 i)} {:id q :init (quot y 2)}] '{j q}))))
+
+(deftest loop-extents-must-be-invariant-radices
+  (testing "a triangular loop index is not a digit, so the form is undecidable"
+    (is (nil? (ia/index-form '(+ (* r 4) j) 'r 'rows [] '{j (+ r 1)})))
+    (is (nil? (ia/index-form '(+ (* r 4) j) 'r 'rows [] '{j (quot n 2)}))))
+  (testing "a coefficient may not mention a digit"
+    (is (nil? (ia/index-form '(+ (+ (* t (* 2 (* h H))) (* h (* 2 h))) j) 'idx '(* T H)
+                             '[{:id t :init (quot idx H)} {:id h :init (rem idx H)}]
+                             '{j (* 2 h)})))))

--- a/test/raster/compiler/ir/index_algebra_test.clj
+++ b/test/raster/compiler/ir/index_algebra_test.clj
@@ -76,3 +76,9 @@
       "a captured stride may be zero and collapse every item")
   (is (ia/injective? (ia/index-form '(+ (* r feat) j) 'r 'rows [] '{j feat}))
       "feat is the inner digit's radix: a zero feat empties the loop"))
+
+(deftest an-extent-may-not-depend-on-an-unresolved-local
+  ;; `q = (quot (- 8 i) 2)` varies with the item: it is neither a digit nor invariant, so it may
+  ;; not become an extent factor. Items (1,0) and (0,3) both address 3 in `i·q + j`.
+  (is (nil? (ia/index-form '(+ (* i q) j) 'i 8
+                           '[{:id y :init (- 8 i)} {:id q :init (quot y 2)}] '{j q}))))

--- a/test/raster/compiler/ir/index_algebra_test.clj
+++ b/test/raster/compiler/ir/index_algebra_test.clj
@@ -1,0 +1,46 @@
+(ns raster.compiler.ir.index-algebra-test
+  "Injectivity facts over mixed-radix index forms: what the frontend may certify as `:unique`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.index-algebra :as ia]))
+
+(def ^:private rope-locals
+  '[{:id hdim2 :init (quot head-dim 2)}
+    {:id per-row :init (* heads hdim2)}
+    {:id t :init (quot idx per-row)}
+    {:id r0 :init (rem idx per-row)}
+    {:id h :init (quot r0 hdim2)}
+    {:id i :init (rem r0 hdim2)}])
+
+(deftest monomials-compare-as-products-of-non-negative-factors
+  (is (= {:const 6 :factors '[a b]} (ia/monomial '(* 2 (* a (* 3 b))))))
+  (is (nil? (ia/monomial '(+ a 1))))
+  (is (ia/dominates? (ia/monomial '(* a b)) (ia/monomial 'a)))
+  (is (not (ia/dominates? (ia/monomial 'a) (ia/monomial '(* a b)))))
+  (testing "a quot fact closes the half-dimension comparison"
+    (is (ia/dominates? (ia/monomial 'head-dim) (ia/monomial 'hdim2)
+                       [{:factor 'hdim2 :times {:const 2 :factors []}
+                         :le {:const 1 :factors ['head-dim]}}]))))
+
+(deftest row-major-forms-are-injective-and-dropped-digits-are-not
+  (let [row (ia/index-form '(+ (* r feat) j) 'r 'rows [] '{j feat})
+        overlap (ia/index-form '(+ (* r 3) j) 'r 'rows [] '{j 4})
+        rope (ia/index-form '(+ (+ (* t (* heads head-dim)) (* h head-dim)) i)
+                            'idx 'n rope-locals {})
+        dropped (ia/index-form '(+ (* t (* heads head-dim)) i) 'idx 'n rope-locals {})
+        whole (ia/index-form '(+ idx i) 'idx 'n rope-locals {})]
+    (is (ia/injective? row))
+    (is (not (ia/injective? overlap)) "row stride 3 under a 4-wide inner digit overlaps")
+    (is (ia/injective? rope) "the RoPE layout is row-major over (t h i)")
+    (is (not (ia/injective? dropped)) "dropping the head digit makes heads collide")
+    (is (nil? whole) "a decomposed index may not also appear whole")))
+
+(deftest constant-offsets-are-one-more-digit
+  (let [rope (ia/index-form '(+ (+ (* t (* heads head-dim)) (* h head-dim)) i)
+                            'idx 'n rope-locals {})
+        row (ia/index-form '(+ (* r feat) j) 'r 'rows [] '{j feat})]
+    (is (ia/disjoint-offsets? rope '[0 hdim2])
+        "the two RoPE halves fit under head-dim because 2·hdim2 ≤ head-dim")
+    (is (not (ia/disjoint-offsets? rope '[0 head-dim]))
+        "an offset of a whole head lands on the next head's row")
+    (is (not (ia/disjoint-offsets? row [0 2]))
+        "two literal offsets inside a symbolic-width row overlap")))

--- a/test/raster/compiler/ir/index_algebra_test.clj
+++ b/test/raster/compiler/ir/index_algebra_test.clj
@@ -4,6 +4,7 @@
             [raster.compiler.ir.index-algebra :as ia]))
 
 (def ^:private rope-locals
+  ;; the map extent `batch·seq-len·heads·hdim2` is an exact multiple of every divisor below
   '[{:id hdim2 :init (quot head-dim 2)}
     {:id per-row :init (* heads hdim2)}
     {:id t :init (quot idx per-row)}
@@ -25,9 +26,9 @@
   (let [row (ia/index-form '(+ (* r feat) j) 'r 'rows [] '{j feat})
         overlap (ia/index-form '(+ (* r 3) j) 'r 'rows [] '{j 4})
         rope (ia/index-form '(+ (+ (* t (* heads head-dim)) (* h head-dim)) i)
-                            'idx 'n rope-locals {})
-        dropped (ia/index-form '(+ (* t (* heads head-dim)) i) 'idx 'n rope-locals {})
-        whole (ia/index-form '(+ idx i) 'idx 'n rope-locals {})]
+                            'idx '(* (* batch seq-len) (* heads hdim2)) rope-locals {})
+        dropped (ia/index-form '(+ (* t (* heads head-dim)) i) 'idx '(* (* batch seq-len) (* heads hdim2)) rope-locals {})
+        whole (ia/index-form '(+ idx i) 'idx '(* (* batch seq-len) (* heads hdim2)) rope-locals {})]
     (is (ia/injective? row))
     (is (not (ia/injective? overlap)) "row stride 3 under a 4-wide inner digit overlaps")
     (is (ia/injective? rope) "the RoPE layout is row-major over (t h i)")
@@ -36,7 +37,7 @@
 
 (deftest constant-offsets-are-one-more-digit
   (let [rope (ia/index-form '(+ (+ (* t (* heads head-dim)) (* h head-dim)) i)
-                            'idx 'n rope-locals {})
+                            'idx '(* (* batch seq-len) (* heads hdim2)) rope-locals {})
         row (ia/index-form '(+ (* r feat) j) 'r 'rows [] '{j feat})]
     (is (ia/disjoint-offsets? rope '[0 hdim2])
         "the two RoPE halves fit under head-dim because 2·hdim2 ≤ head-dim")
@@ -44,3 +45,34 @@
         "an offset of a whole head lands on the next head's row")
     (is (not (ia/disjoint-offsets? row [0 2]))
         "two literal offsets inside a symbolic-width row overlap")))
+
+(deftest lossy-projections-and-unresolved-locals-are-not-injective
+  (testing "a lone quot or rem is a projection, not a decomposition"
+    (is (not (ia/injective? (ia/index-form 'q 'idx 4 '[{:id q :init (quot idx 2)}] {}))))
+    (is (not (ia/injective? (ia/index-form 'r 'idx 4 '[{:id r :init (rem idx 2)}] {})))))
+  (testing "a matched pair whose divisor divides the extent decomposes"
+    (is (ia/injective? (ia/index-form '(+ (* q 2) r) 'idx '(* 2 m)
+                                      '[{:id q :init (quot idx 2)} {:id r :init (rem idx 2)}] {}))))
+  (testing "a divisor that does not divide the extent is undecidable"
+    (is (nil? (ia/index-form '(+ (* q 3) r) 'idx 'n
+                             '[{:id q :init (quot idx 3)} {:id r :init (rem idx 3)}] {}))))
+  (testing "a local the algebra cannot normalize makes the form undecidable"
+    (is (nil? (ia/index-form '(+ i k) 'i 'n '[{:id k :init (- 0 i)}] {})))
+    (is (nil? (ia/index-form '(+ i k) 'i 'n '[{:id k :init (long (aget slots i))}] {})))))
+
+(deftest affine-sums-add-coefficients-and-keep-offset-multiplicity
+  (let [doubled (ia/index-form '(+ (* i 4) (* i 4) j (* j 7)) 'i 2 [] '{j 2})]
+    (is (= 8 (get-in doubled [:terms 'i :coefficient :const])))
+    (is (= 8 (get-in doubled [:terms 'j :coefficient :const])))
+    (is (not (ia/injective? doubled)) "8i + 8j collides at (1,0) and (0,1)"))
+  (let [a (ia/index-form '(* i (* 2 d)) 'i 4 [] {})
+        b (ia/index-form '(+ (* i (* 2 d)) d d) 'i 4 [] {})]
+    (is (= {:const 2 :factors ['d]} (:offset b)) "d + d is 2d, not d")
+    (is (not (ia/disjoint-offsets? a [(:offset a) (:offset b)]))
+        "an offset of a whole stride lands on the next item")))
+
+(deftest coefficients-need-a-lower-radix-to-vouch-for-their-factors
+  (is (not (ia/injective? (ia/index-form '(* i stride) 'i 'n [] {})))
+      "a captured stride may be zero and collapse every item")
+  (is (ia/injective? (ia/index-form '(+ (* r feat) j) 'r 'rows [] '{j feat}))
+      "feat is the inner digit's radix: a zero feat empties the loop"))

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -970,3 +970,28 @@
                    {:dtype :float :array-types {'slots :int 'out :float} :scalar-types {'n :long}})
           {:keys [attributes]} (dialect/operation-parts (first (dialect/equations program)))]
       (is (= :unique (:conflict attributes))))))
+
+(deftest a-triangular-store-loop-is-not-certified-unique
+  ;; `4r + i` for `i < r + 1` collides ((4,4) and (5,0) both write 20); the loop extent is not an
+  ;; invariant radix, so the map stays :sequential.
+  (let [program (frontend/form->program
+                 '(let* [effect (raster.par/map-void!
+                                 r rows
+                                 (loop* [i 0]
+                                   (if (clojure.core/< i (clojure.core/+ r 1))
+                                     (do (clojure.core/aset out (clojure.core/+ (clojure.core/* r 4) i)
+                                                            (float 1.0))
+                                         (recur (clojure.core/inc i))))))]
+                        effect)
+                 {:dtype :float :array-types {'out :float} :scalar-types {'rows :long}})
+        {:keys [attributes]} (dialect/operation-parts (first (dialect/equations program)))]
+    (is (= :sequential (:iteration-order attributes)))))
+
+(deftest an-unprovable-claim-declines-instead-of-failing-the-compile
+  (let [routed (route/attempt '(let* [effect (raster.par/map-void!
+                                              i n
+                                              (clojure.core/aset out (raster.par/unique-index (clojure.core/* i stride))
+                                                                 (float 1.0)))]
+                                     effect)
+                              :float {'out :float} {:scalar-types {'n :long 'stride :long}})]
+    (is (= :unique-index-not-provable (get-in routed [:declined :reason])))))

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -947,3 +947,26 @@
            (try (dialect/validate! swapped) nil
                 (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))
         "a loop local may only reference the locals before it")))
+
+(deftest a-unique-index-claim-is-checked-against-its-own-dependency-slice
+  (testing "an unrelated array read does not authorize a claim on a decidable colliding index"
+    (is (= :unique-index-not-provable
+           (try (frontend/form->program
+                 '(let* [effect (raster.par/map-void!
+                                 i n
+                                 (let* [^long k (long (clojure.core/aget slots i))]
+                                   (clojure.core/aset out (raster.par/unique-index 0) (float k))))]
+                        effect)
+                 {:dtype :float :array-types {'slots :int 'out :float} :scalar-types {'n :long}})
+                nil
+                (catch clojure.lang.ExceptionInfo e (:reason (ex-data e)))))))
+  (testing "a claim on an index that reads an array is honoured"
+    (let [program (frontend/form->program
+                   '(let* [effect (raster.par/map-void!
+                                   i n
+                                   (let* [^long k (long (clojure.core/aget slots i))]
+                                     (clojure.core/aset out (raster.par/unique-index k) (float 1.0))))]
+                          effect)
+                   {:dtype :float :array-types {'slots :int 'out :float} :scalar-types {'n :long}})
+          {:keys [attributes]} (dialect/operation-parts (first (dialect/equations program)))]
+      (is (= :unique (:conflict attributes))))))

--- a/test/resources/coverage/gpu-corpus.edn
+++ b/test/resources/coverage/gpu-corpus.edn
@@ -54,7 +54,7 @@
   {:var raster.dl.array-ops/dot-rows-dbias,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_265718 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_265847 = (loop*"}
   {:var raster.dl.array-ops/dot-rows-dh,
    :route :scalar,
    :typed-validated false,
@@ -114,7 +114,7 @@
   {:var raster.dl.array-ops/masked-mse-loss-backward,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_270147 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_270280 = (if (cloj"}
   {:var raster.dl.array-ops/pack-heads,
    :route :typed-soac,
    :typed-validated true,
@@ -404,7 +404,7 @@
   {:var raster.dl.diffusion/compute-alphas-cumprod,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_282592 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_282746 = (loop*"}
   {:var raster.dl.diffusion/cosine-beta-schedule,
    :route :error,
    :error
@@ -464,7 +464,7 @@
   {:var raster.dl.nn/batch-norm,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_129408 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_129454 = (if (cloj"}
   {:var raster.dl.nn/batch-norm-backward-dbeta,
    :route :scalar,
    :typed-validated false,
@@ -875,7 +875,7 @@
   {:var raster.dl.optim/clip-grad-norm!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_280032 = (if (.inv"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_280186 = (if (.inv"}
   {:var raster.dl.optim/cosine-lr,
    :route :error,
    :error
@@ -944,7 +944,7 @@
   {:var raster.nn/kaiming-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_292833 = \\\"Kaim"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_292987 = \\\"Kaim"}
   {:var raster.nn/loss-fn,
    :route :compatibility,
    :typed-validated false,
@@ -982,7 +982,7 @@
   {:var raster.nn/xavier-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_299638 = \\\"Xavi"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_299792 = \\\"Xavi"}
   {:var raster.ode.pde/heat-loss-rk4,
    :route :error,
    :error :emitted-parallel-program-call-required}

--- a/test/resources/coverage/gpu-corpus.edn
+++ b/test/resources/coverage/gpu-corpus.edn
@@ -54,7 +54,7 @@
   {:var raster.dl.array-ops/dot-rows-dbias,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_265504 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_265718 = (loop*"}
   {:var raster.dl.array-ops/dot-rows-dh,
    :route :scalar,
    :typed-validated false,
@@ -114,7 +114,7 @@
   {:var raster.dl.array-ops/masked-mse-loss-backward,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_269933 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_270147 = (if (cloj"}
   {:var raster.dl.array-ops/pack-heads,
    :route :typed-soac,
    :typed-validated true,
@@ -194,15 +194,18 @@
   {:var raster.dl.attention/attn-prefill-scores!,
    :route :typed-soac,
    :typed-validated true,
-   :declines []}
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.attention/attn-prefill-scores-bidir!,
    :route :typed-soac,
    :typed-validated true,
-   :declines []}
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.attention/attn-prefill-scores-windowed!,
    :route :typed-soac,
    :typed-validated true,
-   :declines []}
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.attention/attn-prefill-softmax!,
    :route :compatibility,
    :typed-validated false,
@@ -327,7 +330,8 @@
   {:var raster.dl.attention/kv-append-buf!,
    :route :typed-soac,
    :typed-validated true,
-   :declines []}
+   :declines [],
+   :effect-orders {:sequential 1}}
   {:var raster.dl.attention/multi-head-attention,
    :route :compatibility,
    :typed-validated false,
@@ -336,11 +340,13 @@
   {:var raster.dl.attention/rope,
    :route :typed-soac,
    :typed-validated true,
-   :declines []}
+   :declines [],
+   :effect-orders {:independent 1}}
   {:var raster.dl.attention/rope-backward-dx,
    :route :typed-soac,
    :typed-validated true,
-   :declines []}
+   :declines [],
+   :effect-orders {:independent 1}}
   {:var raster.dl.attention/rope-pos,
    :route :scalar,
    :typed-validated false,
@@ -352,11 +358,13 @@
   {:var raster.dl.attention/rope-pos-rows-buf!,
    :route :typed-soac,
    :typed-validated true,
-   :declines []}
+   :declines [],
+   :effect-orders {:independent 1}}
   {:var raster.dl.attention/rope-prefill!,
    :route :typed-soac,
    :typed-validated true,
-   :declines []}
+   :declines [],
+   :effect-orders {:independent 1}}
   {:var raster.dl.attention/scaled-dot-product-attn,
    :route :error,
    :error
@@ -396,7 +404,7 @@
   {:var raster.dl.diffusion/compute-alphas-cumprod,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_282378 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_282592 = (loop*"}
   {:var raster.dl.diffusion/cosine-beta-schedule,
    :route :error,
    :error
@@ -456,7 +464,7 @@
   {:var raster.dl.nn/batch-norm,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_129154 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_129408 = (if (cloj"}
   {:var raster.dl.nn/batch-norm-backward-dbeta,
    :route :scalar,
    :typed-validated false,
@@ -634,7 +642,8 @@
   {:var raster.dl.nn/layer-norm!,
    :route :typed-soac,
    :typed-validated true,
-   :declines []}
+   :declines [],
+   :effect-orders {:independent 1}}
   {:var raster.dl.nn/layer-norm-backward-dbeta,
    :route :scalar,
    :typed-validated false,
@@ -760,22 +769,26 @@
   {:var raster.dl.nn/rms-norm,
    :route :typed-soac,
    :typed-validated true,
-   :declines []}
+   :declines [],
+   :effect-orders {:independent 1}}
   {:var raster.dl.nn/rms-norm!,
    :route :typed-soac,
    :typed-validated true,
-   :declines []}
+   :declines [],
+   :effect-orders {:independent 1}}
   {:var raster.dl.nn/rms-norm-1row!,
    :route :error,
    :error :parallel-program-parameter-role-conflict}
   {:var raster.dl.nn/rms-norm-backward-dweight,
    :route :typed-soac,
    :typed-validated true,
-   :declines []}
+   :declines [],
+   :effect-orders {:independent 1}}
   {:var raster.dl.nn/rms-norm-backward-dx,
    :route :typed-soac,
    :typed-validated true,
-   :declines []}
+   :declines [],
+   :effect-orders {:independent 1}}
   {:var raster.dl.nn/rms-norm-chunked,
    :route :typed-soac,
    :typed-validated true,
@@ -862,7 +875,7 @@
   {:var raster.dl.optim/clip-grad-norm!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_279818 = (if (.inv"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_280032 = (if (.inv"}
   {:var raster.dl.optim/cosine-lr,
    :route :error,
    :error
@@ -931,7 +944,7 @@
   {:var raster.nn/kaiming-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_292619 = \\\"Kaim"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_292833 = \\\"Kaim"}
   {:var raster.nn/loss-fn,
    :route :compatibility,
    :typed-validated false,
@@ -969,7 +982,7 @@
   {:var raster.nn/xavier-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_299424 = \\\"Xavi"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_299638 = \\\"Xavi"}
   {:var raster.ode.pde/heat-loss-rk4,
    :route :error,
    :error :emitted-parallel-program-call-required}


### PR DESCRIPTION
## Summary

Item 4 of the systematic-gaps agenda. A store's uniqueness across work items is now a fact the compiler proves, not a claim the author makes.

- `raster.compiler.ir.index-algebra` (new, pure): monomials over symbolic extents with `quot` bounds as facts (`2·hdim2 ≤ head-dim`), digit recovery from matched `quot`/`rem` pairs whose divisor divides the quantity's extent exactly, loop indices as digits when their extent is an invariant radix, affine forms over digits (coefficients add; offsets keep multiplicity; coefficients may not mention digits), the nested row-major carry criterion `c_k ≥ c_{k+1}·r_{k+1}` with completeness over leaf digits and every coefficient factor vouched for by a lower radix, and store offsets as one more digit.
- The frontend replaces the row-major loop rule with this proof for direct and loop stores. `raster.par/unique-index` is redundant when the proof succeeds, remains the certificate for a data-dependent index (judged on the index's own dependency slice; block scatters validated at runtime), and is a structured decline `:unique-index-not-provable` (compatibility route) when the index is decidable and the proof fails. The nine RoPE-family markers are removed from `raster.dl.attention`. Host scalar definitions (the normalizer's compound extents, no array reads) are expanded for the algebra so an extent's SSA id does not hide its factors.
- The coverage ratchet records `:effect-orders` per typed program and refuses a var whose effect maps start serializing or stop being independent.

## Reviews
Three review passes (Codex ×2, Opus ×1) found eight soundness holes across the iterations: lone `quot`/`rem` as a decomposition, unresolved locals as invariant offsets, affine sums multiplying coefficients and offsets losing multiplicity, symbolic factors assumed ≥ 1, the marker's dependency slice, an unresolved local as a `quot`-bound extent factor, a triangular loop index read as an invariant offset, and a coefficient mentioning a digit. Every one is closed with the reviewer's failing input as a regression test. The remaining known limitation is that factors are assumed non-negative (captured `Long` parameters are extents by construction; a negative extent is a caller error).

## Results
- RoPE, GQA, rms-norm, attention-block and FP16 block-transfer parity on Arc unchanged with the markers gone (RoPE rel-err 0.0).
- Corpus routes unchanged (98 typed); 9 independent and 4 sequential effect maps (attention prefill scores ×3 and KV append remain to be proven); no unprovable claims.

## Follow-ups
- Prove the four remaining sequential effect maps (a uniform data-dependent offset `posbuf[0]·kvrow + i`, and the prefill scores' merged predicated store).
- `beta ≠ 0` GEMM epilogues; D8 for the pretrained-rstr handoff.

https://claude.ai/code/session_01Vtm1xB9JmpaxJMEWCAcQWm
