### PR TITLE
Accumulating GEMMs as typed contractions; region copies as store loops

### DIFF
--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -1152,7 +1152,7 @@
         epilogue-operands
         (vec (map :id (filter #(and (= :input (:kind %))
                                     (= :epilogue (:role %))) parameters)))
-        output-parameter (first (filter #(= :output (:kind %)) parameters))
+        output-parameter (first (filter #(contains? #{:output :inout} (:kind %)) parameters))
         output (:id output-parameter)
         scalar-parameters (vec (filter #(and (= :scalar (:kind %))
                                              (not= :epilogue (:role %))) parameters))

--- a/src/raster/compiler/ir/dialects.clj
+++ b/src/raster/compiler/ir/dialects.clj
@@ -579,6 +579,7 @@
   Used by run-passes to validate IR at pass boundaries."
   {:walked           [valid-walked?       validate-walked]
    :lowered          [valid-walked?      validate-walked]
+   :region-copied    [valid-walked?      validate-walked]
    :structured-reductions [valid-walked? validate-walked]
    :ad-transformed   [valid-ad-transformed? validate-ad-transformed]
    :flattened        [valid-flattened?    validate-flattened]

--- a/src/raster/compiler/ir/index_algebra.clj
+++ b/src/raster/compiler/ir/index_algebra.clj
@@ -250,9 +250,14 @@
 ;; ---------------------------------------------------------------------------------------------
 ;; Affine forms over digits
 
+(defn- monomial-form
+  [{:keys [const factors]}]
+  (apply list 'clojure.core/* const factors))
+
 (defn- affine
   "Affine normal form `{:terms {sym monomial-coefficient} :const n}` of an index expression over
-   the given digit symbols, or nil when it is not affine in them."
+   the given digit symbols, or nil when it is not affine in them. A product of one affine
+   factor by invariant monomials distributes: `(i·a + h)·b = i·(a·b) + h·b`."
   [expression digit-set]
   (let [expression (strip-cast expression)]
     (cond
@@ -283,7 +288,27 @@
           ;; a product without any digit is a symbolic offset
           (and (empty? digit-operands) (monomial expression))
           {:terms {} :const 0 :symbolic [expression]}
-          :else nil))
+          ;; one non-monomial factor (a sum, or a nested product carrying digits) times
+          ;; invariant monomials: distribute the scale over its terms and offsets
+          :else
+          (let [invariant? (fn [operand]
+                             (and (monomial operand)
+                                  (not (contains? digit-set (strip-cast operand)))))
+                [inner :as affine-operands] (remove invariant? operands)
+                scale (map monomial (filter invariant? operands))]
+            (when (and (= 1 (count affine-operands)) (seq scale))
+              (when-let [inner (affine inner digit-set)]
+                (let [m (apply product scale)]
+                  {:terms (into {} (map (fn [[digit coefficient]]
+                                          [digit (product coefficient m)]))
+                                (:terms inner))
+                   :const 0
+                   :symbolic (vec (concat (map (fn [symbolic]
+                                                 (list 'clojure.core/* symbolic (monomial-form m)))
+                                               (:symbolic inner))
+                                          (when-not (zero? (:const inner))
+                                            [(list 'clojure.core/* (:const inner)
+                                                   (monomial-form m))])))}))))))
       :else nil)))
 
 (defn index-form

--- a/src/raster/compiler/ir/invariants.clj
+++ b/src/raster/compiler/ir/invariants.clj
@@ -331,7 +331,7 @@
   I-T3 (dtype closure) THROWS — it guards against the f64-in-f32 silent
   miscompile class. It runs on the STAMPED dialects only (post-rewalk,
   pre-backend); it is skipped at:
-    :lowered and :structured-reductions — the :lower pass splices AD templates whose stamps
+    :lowered, :region-copied and :structured-reductions — the :lower pass splices AD templates whose stamps
       (:raster.type/tag, :raster.op/original) are only (re)established by the
       :fixpoint rewalk; structured-reduction recognition also runs before that rewalk and preserves
       all unmatched forms unchanged. Pre-rewalk IR is half-stamped by design (probed: an
@@ -344,7 +344,7 @@
   their corpora are clean."
   [dialect-key form pass-key {:keys [params dtype param-env]}]
   (when (and (= dtype :float)
-             (not (contains? #{:lowered :structured-reductions
+             (not (contains? #{:lowered :region-copied :structured-reductions
                                :backend-applied :alength-resolved
                                :mem-merged}
                              dialect-key)))

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -297,6 +297,8 @@
          (dtype/known? (:result-dtype value))
          (= (:result-dtype value) (dtype/canon (:result-dtype value))))))
 
+(declare lambda-parts)
+
 (defn result-transform-boundary-expression
   "The result-transform body with every declared operand read collapsed to its operand
    parameter.
@@ -1816,10 +1818,13 @@
                                                    (update storage :destination rename))
                                                  %))))]))
               (:equations source-facts))
-        facts' (assoc source-facts
-                      :values values
-                      :inputs (mapv rename (:inputs source-facts))
-                      :equations equation-facts)]
+        facts' (cond-> (assoc source-facts
+                              :values values
+                              :inputs (mapv rename (:inputs source-facts))
+                              :equations equation-facts)
+                 (seq (get-in source-facts [:attributes :host-read-values]))
+                 (update-in [:attributes :host-read-values]
+                            #(vec (distinct (map rename %)))))]
     (make facts' equation-forms (mapv rename (outputs program)))))
 
 (defn default-equation-facts

--- a/src/raster/compiler/ir/soac_dialect.clj
+++ b/src/raster/compiler/ir/soac_dialect.clj
@@ -297,13 +297,32 @@
          (dtype/known? (:result-dtype value))
          (= (:result-dtype value) (dtype/canon (:result-dtype value))))))
 
+(defn result-transform-boundary-expression
+  "The result-transform body with every declared operand read collapsed to its operand
+   parameter.
+
+   An operand read `(aget operand index)` denotes the element the operand's axis map names at
+   the current segment coordinates; the spelled `index` is that map's row-major spelling for
+   host expansion and may mention the segment extents. Every kernel lowering loads through the
+   map, so the boundary an expression must respect is judged on this collapsed form."
+  [transform]
+  (let [operand-parameters (set (map :parameter (:operands transform)))
+        {:keys [body-results]} (lambda-parts (:lambda transform))]
+    (descriptor/rewrite-aget-reads
+     (first body-results)
+     (fn [read]
+       (let [operand (descriptor/aget-array-sym read)]
+         (when (contains? operand-parameters operand) operand))))))
+
 (defn make-result-transform
   "Close a post-reduction scalar expression over an alpha-stable typed boundary.
 
    Operand and scalar `:value` fields are program SSA IDs.  The returned lambda refers only to
-   fresh lexical parameters, its accumulator, and the segmented-reduction axes.  Frontends and
-   fusion rules use this one constructor so target projections never have to rediscover captures
-   from an expression."
+   fresh lexical parameters, its accumulator, and the segmented-reduction axes; an operand read
+   `(aget operand index)` is addressed by the operand's axis map, its spelled index being the
+   map's row-major spelling (see `result-transform-boundary-expression`).  Frontends and fusion
+   rules use this one constructor so target projections never have to rediscover captures from
+   an expression."
   [{:keys [accumulator expression operands scalars result-dtype]}]
   (let [operands (mapv (fn [ordinal {:keys [value dtype map]}]
                          {:value value
@@ -1154,8 +1173,9 @@
           (let [operand-ids (set (map :value (:operands transform)))
                 scalar-ids (set (map :value (:scalars transform)))
                 transform-ids (set/union operand-ids scalar-ids)
-                {:keys [parameters body-results]} (lambda-parts (:lambda transform))
-                unbound (util/free-syms (first body-results) (set parameters))]
+                {:keys [parameters]} (lambda-parts (:lambda transform))
+                unbound (util/free-syms (result-transform-boundary-expression transform)
+                                        (set parameters))]
             (when-not (set/subset? transform-ids (set captures))
               (fail! :typed-soac-result-transform-captures
                      "reduce result transforms require explicit capture values"
@@ -1199,9 +1219,9 @@
                 transform-ids (set/union operand-ids scalar-ids)
                 stable (set (get-in attributes [:attributes :stable-array-captures]))
                 segment-indices (set (map first (:segment-axes attributes)))
-                {:keys [parameters body-results]} (lambda-parts (:lambda transform))
+                {:keys [parameters]} (lambda-parts (:lambda transform))
                 bound (set/union (set parameters) segment-indices)
-                unbound (util/free-syms (first body-results) bound)
+                unbound (util/free-syms (result-transform-boundary-expression transform) bound)
                 map-axes (set (mapcat (comp axis-map/axes :map) (:operands transform)))]
             (when-not (set/subset? transform-ids (set captures))
               (fail! :typed-soac-result-transform-captures

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -288,7 +288,10 @@
   (when (and (seq epilogue) (not (contains? splice-capable-strategies (:strategy d))))
     (throw (ex-info (str "contraction: strategy " (:strategy d) " has no store splice, so its "
                          ":epilogue would be silently dropped")
-                    {:reason :epilogue-unsupported-by-this-leaf :strategy (:strategy d)})))
+                    ;; The leaves that declined before this fallback was chosen are the reason
+                    ;; a splice-capable leaf was unavailable; keep them with the refusal.
+                    {:reason :epilogue-unsupported-by-this-leaf :strategy (:strategy d)
+                     :declines (vec (:declines d))})))
   d)
 
 (defn route-contraction

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -224,7 +224,7 @@
               arguments
               (mapv (fn [{:keys [name kind role] :as slot}]
                       (case kind
-                        (:input :output) name
+                        (:input :output :inout) name
                         :scalar
                         (if (= :epilogue role)
                           name
@@ -991,15 +991,23 @@
   [out-sym dtype desc tile epilogue contract-facts operation-id candidate-families]
   (let [acc (volatile! [])
         note! (fn [d] (vswap! acc conj d) nil)
+        ;; The matrix leaf stores whole tiles through fragment registers; a result transform
+        ;; that reads the destination element would need a fragment-level load of the tile it
+        ;; overwrites, which that store path does not express yet.
+        destination-read? (boolean (some #(= out-sym (:sym %)) (:operands epilogue)))
         matrix? (contains? candidate-families :matrix)
         register-tiled? (contains? candidate-families :register-tiled)]
     (try
-      (let [scheduled (when matrix?
+      (let [scheduled (when (and matrix? (not destination-read?))
                         (contraction-schedule/plan-matrix-body
                          contract-facts desc tile {:operation-id operation-id}))
             dpas (cond
                    (not matrix?)
                    {:tensorized false :reason :schedule-family-disabled :family :matrix}
+
+                   destination-read?
+                   {:tensorized false :reason :epilogue-reads-destination
+                    :family :matrix :destination out-sym}
 
                    (:ok scheduled)
                    (sco/generate-dpas-kernel-body (:body scheduled) out-sym)

--- a/src/raster/compiler/passes/parallel/contraction_body.clj
+++ b/src/raster/compiler/passes/parallel/contraction_body.clj
@@ -75,8 +75,14 @@
         ;; rebuilding a narrower SegRed from a generated host form.
         arrays (vec (sort-by name (set/intersection (:inputs segred) core-operand-ids)))
         scalars (vec (sort-by name (set/intersection (:scalars segred) core-scalar-ids)))
+        output (:out contract-facts)
+        ;; A result transform that reads the destination (`C := acc + beta·C`) reads the element
+        ;; this work item stores: the destination is one read-write parameter, never a second
+        ;; read-only view of the same storage.
+        destination-read? (boolean (some #(= output (:sym %)) transform-operands))
         transform-only-operands
-        (filterv #(not (contains? (set arrays) (:sym %))) transform-operands)
+        (filterv #(not (or (contains? (set arrays) (:sym %)) (= output (:sym %))))
+                 transform-operands)
         transform-only-scalars
         (filterv #(not (contains? (set scalars) (:sym %))) transform-scalars)
         scalar-dtype (fn [id] (or (get scalar-types id)
@@ -152,7 +158,6 @@
         accumulator 'segment-accumulator
         next-accumulator 'next-segment-accumulator
         reduction-result 'segment-result
-        output (:out contract-facts)
         physical-extent
         (fn [array]
           (lower-index (axis-map/n-elements (get operand-maps array)) index-scope))
@@ -176,7 +181,8 @@
                         array :input dtype [extent] :global
                         (layout/row-major [extent] dtype) :operand)))
                    arrays)
-              [(body/->KernelParameter output :output dtype [segment-count] :global
+              [(body/->KernelParameter output (if destination-read? :inout :output) dtype
+                                       [segment-count] :global
                                        (layout/row-major [segment-count] dtype) :result)]
               (map #(body/->KernelParameter % :scalar (scalar-dtype %) [] nil nil :parameter)
                    scalars)
@@ -200,7 +206,8 @@
         {:id [:contraction (:id segred) :portable-sequential]
          :parameters parameters
          :stable-reads (mapv body/stable-read
-                             (distinct (concat arrays (map :sym transform-operands))))
+                             (distinct (remove #{output}
+                                               (concat arrays (map :sym transform-operands)))))
          :indices (vec (concat
                         [(body/->IndexBinding group-index :group 0)
                          (body/->IndexBinding local-index :local 0)

--- a/src/raster/compiler/passes/parallel/patterns.clj
+++ b/src/raster/compiler/passes/parallel/patterns.clj
@@ -125,35 +125,30 @@
   [sym]
   (or (descriptor/multiplication-op? sym) (contains? unchecked-multiply-ops sym)))
 
+(defn- linear-index-parts
+  "`[outer-sym extent inner-sym]` of an index spelled `(+ (* outer extent) inner)`, in the
+   semantic view of the call (a walked `.invk` multiply is a multiply), else nil."
+  [idx-expr]
+  (when (and (seq? idx-expr) (index-add-op? (descriptor/semantic-op idx-expr)))
+    (let [[mul-expr inner :as arguments] (vec (descriptor/call-args idx-expr))]
+      (when (and (= 2 (count arguments))
+                 (seq? mul-expr)
+                 (index-multiply-op? (descriptor/semantic-op mul-expr)))
+        (let [[outer extent :as factors] (vec (descriptor/call-args mul-expr))]
+          (when (= 2 (count factors))
+            [outer extent inner]))))))
+
 (defn row-major-linear-index?
   "Check whether idx-expr is the row-major linearization (+ (* i cols) j).
-	Accepts qualified and unchecked arithmetic variants."
+	Accepts qualified, unchecked and walker-devirtualized arithmetic variants."
   [idx-expr i-sym j-sym cols-expr]
-  (and (seq? idx-expr)
-       (index-add-op? (first idx-expr))
-       (= 3 (count idx-expr))
-       (let [mul-expr (second idx-expr)]
-         (and (seq? mul-expr)
-              (index-multiply-op? (first mul-expr))
-              (= 3 (count mul-expr))
-              (= i-sym (second mul-expr))
-              (= cols-expr (nth mul-expr 2))))
-       (= j-sym (nth idx-expr 2))))
+  (= [i-sym cols-expr j-sym] (linear-index-parts idx-expr)))
 
 (defn column-major-linear-index?
   "Check whether idx-expr is the column-major linearization (+ (* j rows) i).
-				Accepts qualified and unchecked arithmetic variants."
+	Accepts qualified, unchecked and walker-devirtualized arithmetic variants."
   [idx-expr i-sym j-sym rows-expr]
-  (and (seq? idx-expr)
-       (index-add-op? (first idx-expr))
-       (= 3 (count idx-expr))
-       (let [mul-expr (second idx-expr)]
-         (and (seq? mul-expr)
-              (index-multiply-op? (first mul-expr))
-              (= 3 (count mul-expr))
-              (= j-sym (second mul-expr))
-              (= rows-expr (nth mul-expr 2))))
-       (= i-sym (nth idx-expr 2))))
+  (= [j-sym rows-expr i-sym] (linear-index-parts idx-expr)))
 
 (defn match-dotimes-map-loop
   "Match a dotimes loop that writes one element with aset.

--- a/src/raster/compiler/passes/parallel/register_tiled_body.clj
+++ b/src/raster/compiler/passes/parallel/register_tiled_body.clj
@@ -181,10 +181,14 @@
         row-layout (layout/row-major row-shape dtype)
         col-layout (layout/row-major col-shape dtype)
         out-layout (layout/row-major out-shape dtype)
+        ;; A result transform that reads the destination reads the element this thread stores;
+        ;; the destination is then one read-write parameter.
+        destination-read? (boolean (some #(= out (:sym %)) (:operands epilogue)))
         base-parameters
         [(body/->KernelParameter row :input dtype row-shape :global row-layout :lhs)
          (body/->KernelParameter col :input dtype col-shape :global col-layout :rhs)
-         (body/->KernelParameter out :output dtype out-shape :global out-layout :result)]
+         (body/->KernelParameter out (if destination-read? :inout :output) dtype out-shape
+                                 :global out-layout :result)]
         parameters (into (vec base-parameters) (transform-parameters epilogue base-parameters))
         parameter-map (into {} (map (juxt :id identity)) parameters)
         row-allocation 'register-tile-a
@@ -372,7 +376,8 @@
       {:id [:contraction (or operation-id out) :register-tiled]
        :parameters parameters
        :stable-reads (mapv body/stable-read
-                           (distinct (concat [row col] (map :sym (:operands epilogue)))))
+                           (distinct (remove #{out}
+                                             (concat [row col] (map :sym (:operands epilogue))))))
        :allocations allocations
        :indices indices
        :masks masks

--- a/src/raster/compiler/passes/parallel/scalar_region_lower.clj
+++ b/src/raster/compiler/passes/parallel/scalar_region_lower.clj
@@ -112,8 +112,14 @@
               (let [{:keys [map] :as operand} (get operand-by-id id)
                     operand-dtype (dtype/canon (get operand :dtype :float))
                     parameter (get parameters id)]
-                (when-not (and operand parameter (= :input (:kind parameter))
-                               (contains? #{:operand :lhs :rhs :epilogue} (:role parameter))
+                ;; An operand is a read-only input, or the kernel's own read-write result when
+                ;; the transform reads the element it overwrites.
+                (when-not (and operand parameter
+                               (or (and (= :input (:kind parameter))
+                                        (contains? #{:operand :lhs :rhs :epilogue}
+                                                   (:role parameter)))
+                                   (and (= :inout (:kind parameter))
+                                        (= :result (:role parameter))))
                                (= operand-dtype (dtype/canon (:dtype parameter))))
                   (decline! :result-transform-operand
                             "result-transform operand lacks its typed KernelBody parameter"

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -984,8 +984,13 @@
     (par/par-map-form? expression)
     (let [{:keys [out idx bound cast body elem-type offset]}
           (par/extract-par-map-info expression)
+          ;; The map's element dtype is a fact before it is a policy: the form's own element
+          ;; type, its store cast, then the destination's declared dtype (a lifted copy into a
+          ;; `double-array` under a float policy stores doubles). The program dtype is the last
+          ;; resort when nothing declares it.
           elem-type (dtype/canon (or elem-type
                                      (dtype/dtype-for-scalar-tag cast)
+                                     (when (symbol? out) (get array-types out))
                                      default-dtype))
           write-index (when offset (list 'clojure.core/+ offset idx))
           io (extract-io (if offset (list 'do write-index body) body) idx [out])]

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -644,13 +644,40 @@
         expanded
         (recur expanded (dec remaining))))))
 
+(defn- invariant-read-atoms
+  "Replace every array read in `form` that is uniform across the map with an atom symbol: a
+   read of an array the region does not write, at an index free of the map index, the loop
+   indices and the region locals (`(aget posbuf 0)`, a position established before the map).
+   Such a read is a scalar the algebra can treat as an invariant factor. `atoms` memoizes one
+   symbol per distinct read so equal reads stay equal."
+  [form destinations varying atoms]
+  (descriptor/rewrite-aget-reads
+   form
+   (fn [read]
+     (let [array (descriptor/aget-array-sym read)
+           index (descriptor/aget-index read)]
+       (when (and (symbol? array)
+                  (not (contains? destinations array))
+                  (empty? (set/intersection varying (util/free-syms index))))
+         (let [key (list 'clojure.core/aget array index)]
+           (or (get @atoms key)
+               (let [atom-symbol (clojure.core/symbol (str "rstr_read_" (count @atoms)))]
+                 (swap! atoms assoc key atom-symbol)
+                 atom-symbol))))))))
+
 (defn- store-index-form
   "The mixed-radix index form of a store's destination index over the map index (extent
    `extent`), the region locals and, for a loop store, its loop's locals and index. Host
-   scalar definitions are expanded first so extents and strides show their factors."
-  [store index extent locals loops]
+   scalar definitions are expanded first so extents and strides show their factors, and
+   uniform array reads become invariant atoms (`destinations` are the region's written arrays)."
+  [store index extent locals loops destinations]
   (let [loop (when (:loop store) (nth loops (:loop store)))
-        expand expand-scalar-definitions]
+        varying (into #{index}
+                      (concat (map :id locals) (map :id (:locals loop))
+                              (map :index loops)))
+        atoms (atom {})
+        expand (fn [form]
+                 (invariant-read-atoms (expand-scalar-definitions form) destinations varying atoms))]
     (index-algebra/index-form (expand (:index store)) index (expand extent)
                               (mapv #(update % :init expand) (concat locals (:locals loop)))
                               (if loop {(:index loop) (expand (:extent loop))} {}))))
@@ -660,7 +687,8 @@
    index form is injective, and stores sharing a destination share one form and write at
    provably disjoint offsets. Returns the set of store ordinals."
   [stores index extent locals loops]
-  (let [forms (mapv #(store-index-form % index extent locals loops) stores)
+  (let [destinations (set (map :out stores))
+        forms (mapv #(store-index-form % index extent locals loops destinations) stores)
         by-destination (group-by (fn [ordinal] (:out (nth stores ordinal)))
                                  (range (count stores)))]
     (into #{}
@@ -669,8 +697,11 @@
                       (when (and (every? some? group-forms)
                                  (every? index-algebra/injective? group-forms)
                                  (apply = (map :terms group-forms))
+                                 ;; stores at one address (the arms of a conditional) are the
+                                 ;; same element of one work item; distinct offsets must be
+                                 ;; disjoint across work items
                                  (index-algebra/disjoint-offsets?
-                                  (first group-forms) (map :offset group-forms)))
+                                  (first group-forms) (distinct (map :offset group-forms))))
                         ordinals))))
           by-destination)))
 

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -9,6 +9,7 @@
   (:require [clojure.set :as set]
             [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.core.types :as types]
             [raster.compiler.core.util :as util]
             [raster.compiler.ir.abstract-value :as av]
@@ -1214,8 +1215,11 @@
            ;; Contract is effectful at the source spelling because it writes `out`, but its
            ;; TypedSOAC equation denotes the mathematical output tensor. A terminal reference to
            ;; that physical destination therefore returns the logical value; generic map-void
-           ;; destinations remain `:effect` storage and retain host nil semantics.
-           :result-storage [{:destination out :access :write :host-return :buffer}]})))
+           ;; destinations remain `:effect` storage and retain host nil semantics. A result
+           ;; transform that reads the destination (an accumulating GEMM) makes it read-write.
+           :result-storage [{:destination out
+                             :access (if (contains? epilogue-arrays out) :read-write :write)
+                             :host-return :buffer}]})))
 
     (or (par/par-scan-form? expression)
         (par/par-scan-exclusive-form? expression))
@@ -1340,17 +1344,38 @@
    is the pure contraction `(raster.par/contract C [[i m] [j n]] [[l k]] (* A[i,l] B[l,j]))`
    scaled by `alpha`, and the typed route can schedule it like any contraction instead of
    leaving the whole block on the host because one binding is an opaque BLAS effect. A non-zero
-   `beta` reads the destination inside its own epilogue and stays a host call for now."
+   `beta` (a literal or a scalar value) is the same contraction with a result transform that
+   reads the destination element it overwrites: `C[i,j] := acc + beta·C[i,j]`. The destination
+   is then read-write storage of one kernel, which the KernelBody builders express as a single
+   `:inout` parameter. A `beta` that is neither a literal nor a scalar value id, or a call whose
+   element type is unknown, stays a host call."
   [ordinal expression]
   (let [variant (when (and (seq? expression) (= '.invk (first expression)))
                   (get descriptor/blas-gemm-ops (:raster.op/original (meta expression))))
         arguments (when variant (vec (drop 2 expression)))
         [A B C m k n alpha beta] arguments
         beta-literal (when variant (descriptor/gemm-scalar-literal beta))
-        alpha-literal (when variant (descriptor/gemm-scalar-literal alpha))]
+        alpha-literal (when variant (descriptor/gemm-scalar-literal alpha))
+        ;; `alpha`/`beta` arrive as `(oftype witness value)` from the source spelling; the scalar
+        ;; factor is its value, not the type witness array.
+        scalar-value (fn [argument literal]
+                       (cond
+                         ;; A literal factor (`-1`, `(float 2.0)`) is the element-typed number
+                         ;; it denotes, not an integer literal that would mistype the product.
+                         (some? literal) literal
+                         (and (seq? argument)
+                              (= 'raster.numeric/oftype (descriptor/semantic-op argument))
+                              (= 2 (count (descriptor/call-args argument))))
+                         (second (descriptor/call-args argument))
+                         :else argument))
+        beta-value (when variant (scalar-value beta beta-literal))
+        accumulate? (not= 0.0 beta-literal)
+        elem-type (some-> (or (:raster.type/tag (meta expression)) (:tag (meta expression)))
+                          dtype/dtype-for-array-tag dtype/canon)]
     (if (and variant (= 8 (count arguments))
              (symbol? A) (symbol? B) (symbol? C)
-             (= 0.0 beta-literal))
+             (or (not accumulate?)
+                 (and elem-type (or (number? beta-value) (symbol? beta-value)))))
       (let [i (clojure.core/symbol (str "rstr_gemm_i_" ordinal))
             j (clojure.core/symbol (str "rstr_gemm_j_" ordinal))
             l (clojure.core/symbol (str "rstr_gemm_l_" ordinal))
@@ -1361,8 +1386,6 @@
             b-index (case variant
                       (:nn :tn) (list 'clojure.core/+ (list 'clojure.core/* l n) j)
                       :nt (list 'clojure.core/+ (list 'clojure.core/* j k) l))
-            elem-type (some-> (or (:raster.type/tag (meta expression)) (:tag (meta expression)))
-                              dtype/dtype-for-array-tag dtype/canon)
             ;; The walker stamps every arithmetic form with its result dtype; the emitted loads
             ;; and product carry the same stamp so scalar lowering reads the type instead of
             ;; guessing it.
@@ -1374,21 +1397,29 @@
             product (typed (list 'clojure.core/*
                                  (typed (list 'clojure.core/aget A a-index))
                                  (typed (list 'clojure.core/aget B b-index))))
-            ;; `alpha` arrives as `(oftype witness value)` from the source spelling; the scalar
-            ;; factor is its value, not the type witness array.
-            alpha-value (cond
-                          ;; A literal factor (`-1`, `(float 2.0)`) is the element-typed number
-                          ;; it denotes, not an integer literal that would mistype the product.
-                          (some? alpha-literal) alpha-literal
-                          (and (seq? alpha)
-                               (= 'raster.numeric/oftype (descriptor/semantic-op alpha))
-                               (= 2 (count (descriptor/call-args alpha))))
-                          (second (descriptor/call-args alpha))
-                          :else alpha)
+            alpha-value (scalar-value alpha alpha-literal)
             body (if (= 1.0 alpha-literal)
                    product
-                   (typed (list 'clojure.core/* alpha-value product)))]
-        (with-meta (list 'raster.par/contract C [[i m] [j n]] [[l k]] body)
+                   (typed (list 'clojure.core/* alpha-value product)))
+            ;; `beta·C[i,j]` is read at the store coordinates of the element being produced;
+            ;; the operand map declares that coordinate, the index inside the read is its
+            ;; row-major spelling for the host expansion.
+            epilogue
+            (when accumulate?
+              (let [acc (clojure.core/symbol (str "rstr_gemm_acc_" ordinal))
+                    destination (typed (list 'clojure.core/aget C
+                                             (list 'clojure.core/+ (list 'clojure.core/* i n) j)))
+                    scaled (if (= 1.0 beta-literal)
+                             destination
+                             (typed (list 'clojure.core/* beta-value destination)))]
+                {:acc acc
+                 :expr (typed (list 'clojure.core/+ acc scaled))
+                 :operands [{:sym C :map (axis-map/of-axes [[i m] [j n]]) :dtype elem-type}]
+                 :scalars (if (symbol? beta-value) [{:sym beta-value :dtype elem-type}] [])
+                 :dtype elem-type}))]
+        (with-meta (cond-> (list 'raster.par/contract C [[i m] [j n]] [[l k]] body)
+                     epilogue (concat [:epilogue epilogue])
+                     true (->> (apply list)))
           (cond-> {:raster.op/original (:raster.op/original (meta expression))}
             elem-type (assoc :raster.type/elem-type elem-type))))
       expression)))

--- a/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_frontend.clj
@@ -1175,7 +1175,21 @@
                             (:raster.type/elem-type (meta expression))
                             default-dtype :double))
           {:keys [free-axes contract-axes out opts]} facts
-          epilogue (:epilogue facts)
+          contraction-dtype (dtype/canon (:dtype facts))
+          ;; A result transform that reads the destination reads the storage the contraction
+          ;; writes: that operand and the transform result have the contraction's dtype (a
+          ;; double-spelled GEMM compiled under the float policy accumulates into a float
+          ;; buffer), whatever tag the source call carried.
+          epilogue (let [epilogue (:epilogue facts)]
+                     (if (some #(= out (:sym %)) (:operands epilogue))
+                       (-> epilogue
+                           (assoc :dtype contraction-dtype)
+                           (update :operands
+                                   (fn [operands]
+                                     (mapv #(cond-> % (= out (:sym %))
+                                              (assoc :dtype contraction-dtype))
+                                           operands))))
+                       epilogue))
           result-transform (typed-result-transform epilogue)
           epilogue-arrays (set (map :value (:operands result-transform)))
           epilogue-scalar-ids (set (map :value (:scalars result-transform)))]
@@ -2592,17 +2606,25 @@
                                                     (:host-binding description)}))]))
                          equation-descriptions))
               total-effects (reduce set/union #{} (map :effects (vals equation-facts)))
-              host-binding-ids
-              (->> descriptions
-                   (keep #(when (and (= :scalar (:kind %))
-                                     (not (supported-description?
-                                           physical-outputs %)))
-                            (:id %)))
+              host-descriptions
+              (filterv #(and (= :scalar (:kind %))
+                             (not (supported-description? physical-outputs %)))
+                       descriptions)
+              host-binding-ids (mapv :id host-descriptions)
+              ;; Program values a host-controlled binding reads are uses of those values: a
+              ;; producer read by the host must stay materialized, whatever fusion does with
+              ;; its typed consumers.
+              host-read-values
+              (->> host-descriptions
+                   (mapcat #(util/free-syms (:expr %)))
+                   (filter #(contains? values %))
+                   distinct
                    vec)
               facts (dialect/default-program-facts
                      {:values values :inputs inputs :equations equation-facts
                       :effects total-effects
                       :provenance {:front-end :analyzed-source}
                       :attributes {:source-dialect :closed-clojure
-                                   :host-binding-ids host-binding-ids}})]
+                                   :host-binding-ids host-binding-ids
+                                   :host-read-values host-read-values}})]
           (dialect/make facts equations outputs))))))

--- a/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_fusion.clj
@@ -445,11 +445,15 @@
       candidate)))
 
 (defn- value-use-counts
+  "Uses of every program value: typed equation references, program outputs, and the reads of
+   host-controlled bindings (a producer the host reads is live however its typed consumers
+   fuse)."
   [program]
   (frequencies
    (concat
     (mapcat equation-references (dialect/equations program))
-    (dialect/outputs program))))
+    (dialect/outputs program)
+    (get-in (dialect/facts program) [:attributes :host-read-values]))))
 
 (defn- merge-provenance
   [left right fused-kind]

--- a/src/raster/compiler/passes/parallel/typed_soac_route.clj
+++ b/src/raster/compiler/passes/parallel/typed_soac_route.clj
@@ -470,6 +470,15 @@
                          (map :destination
                               (get-in equation-facts [:attributes :result-storage])))))
               (:equations (dialect/facts program)))
+        ;; Bindings the typed program leaves under host control (an opaque effect loop, a
+        ;; host call) are retained as written, so everything they read is a root of the host
+        ;; dependency closure too: a size scalar only that loop reads must stay bound.
+        host-controlled-reads
+        (into #{}
+              (comp (keep-indexed (fn [id [_ expression]]
+                                    (when (contains? host-binding-ids id) expression)))
+                    (mapcat util/free-syms))
+              original-pairs)
         host-bindings
         (required-host-bindings
          (keep-indexed (fn [_ [symbol :as pair]]
@@ -480,6 +489,7 @@
                          (when-not (contains? realized-host-symbols symbol) pair))
                        original-pairs)
          (set/union physical-destinations
+                    host-controlled-reads
                     (into #{} (mapcat util/free-syms) body)))
         pairs
         (vec

--- a/src/raster/compiler/passes/region_copy.clj
+++ b/src/raster/compiler/passes/region_copy.clj
@@ -1,0 +1,131 @@
+(ns raster.compiler.passes.region-copy
+  "Array region copies spelled as the store loops they are.
+
+   `(acopy! src src-off dst dst-off len)` and the `System/arraycopy` it inlines to are opaque
+   effects to every later pass: the loop lifter sees no store, the typed frontend sees an
+   untagged binding, and a bias prefill spelled as one copy per row keeps a whole linear layer
+   on the host. The copy of `len` elements is, element for element,
+
+     (dotimes [t len] (aset dst (+ dst-off t) (aget src (+ src-off t))))
+
+   whenever the source and the destination are distinct storage. That is what this pass emits,
+   in statement positions only: a `do` statement, a `dotimes` body, or an effect binding whose
+   value nothing reads. A copy whose value is used keeps its call (it returns the destination),
+   and a copy within one array keeps its call too (`System/arraycopy` is a memmove, an
+   elementwise forward loop is not).
+
+   The emitted read carries the copied element type as its scalar tag when a fact states one:
+   the call's own result tag, the tag of the binder that introduced either array, or the
+   deftm parameter tag. Downstream typing then reads a fact rather than inferring one."
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.op-descriptor :as descriptor]
+            [raster.compiler.core.util :as util]
+            [raster.compiler.ir.form :as form]))
+
+(def ^:private copy-ops
+  "Region copy spellings: the deftm and the JVM primitive it inlines to. Arguments are
+   `src src-off dst dst-off len` in every spelling."
+  '#{raster.arrays/acopy! System/arraycopy java.lang.System/arraycopy})
+
+(defn- array-tag
+  "The array type tag a fact states for `array`: the tag on its binder or deftm parameter."
+  [environment array]
+  (let [tag (get environment array)]
+    (when (symbol? tag) tag)))
+
+(defn- copy-call
+  "`{:src :src-off :dst :dst-off :len :returns-destination? :tag}` for a region copy call over
+   two distinct array symbols, else nil. `environment` maps array symbols to their tags."
+  [expression environment]
+  (when (and (seq? expression) (contains? copy-ops (descriptor/semantic-op expression)))
+    (let [[src src-off dst dst-off len :as arguments] (vec (descriptor/call-args expression))]
+      (when (and (= 5 (count arguments)) (symbol? src) (symbol? dst) (not= src dst))
+        {:src src :src-off src-off :dst dst :dst-off dst-off :len len
+         :returns-destination? (= 'raster.arrays/acopy! (descriptor/semantic-op expression))
+         :tag (or (:raster.type/tag (meta expression))
+                  (array-tag environment dst)
+                  (array-tag environment src))}))))
+
+(defn- offset-index
+  "`offset + index`; a zero offset (the walker spells a literal `0` as `(int 0)`) is the bare
+   index, which is what the loop lifter's element-wise matchers recognize."
+  [offset index]
+  (let [offset (descriptor/unwrap-int-cast offset)]
+    (if (and (number? offset) (zero? offset))
+      index
+      (list 'clojure.core/+ offset index))))
+
+(defn- store-loop
+  "The counted store loop equal to a copy call."
+  [{:keys [src src-off dst dst-off len tag]} index]
+  (let [scalar-tag (some-> tag dtype/dtype-for-array-tag dtype/canon dtype/scalar-tag-for-dtype)
+        read (cond-> (list 'clojure.core/aget src (offset-index src-off index))
+               scalar-tag (with-meta {:raster.type/tag scalar-tag :tag scalar-tag}))]
+    (list 'dotimes [index len]
+          (list 'clojure.core/aset dst (offset-index dst-off index) read))))
+
+(defn- binder-tag
+  [symbol]
+  (or (:raster.type/tag (meta symbol)) (:tag (meta symbol))))
+
+(defn expand-region-copies
+  "Rewrite every region copy in statement position of `form` into its store loop.
+   `param-env` maps deftm parameters to their array tags. Returns `{:form :stats}` with
+   `:region-copies-expanded`."
+  [form & {:keys [param-env]}]
+  (let [counter (atom 0)
+        expanded (atom 0)
+        fresh (fn [] (symbol (str "rstr_copy_" (swap! counter inc))))
+        expand! (fn [call]
+                  (swap! expanded inc)
+                  (store-loop call (fresh)))]
+    (letfn [(statement [expression environment]
+              ;; a value nobody reads: a copy here is exactly its loop
+              (if-let [call (copy-call expression environment)]
+                (expand! call)
+                (walk expression environment)))
+            (walk [expression environment]
+              (cond
+                (not (seq? expression)) expression
+
+                (= 'do (first expression))
+                (let [statements (butlast (rest expression))
+                      value (last expression)]
+                  (with-meta (apply list 'do (concat (map #(statement % environment) statements)
+                                                     [(walk value environment)]))
+                    (meta expression)))
+
+                (= 'dotimes (first expression))
+                (let [[_ bindings & body] expression]
+                  (with-meta (apply list 'dotimes bindings (map #(statement % environment) body))
+                    (meta expression)))
+
+                (form/binding-form? expression)
+                (let [[head bindings & body] expression
+                      pairs (vec (partition 2 bindings))
+                      inits (mapv second pairs)
+                      ;; everything evaluated after binding k
+                      later (fn [k] (list* 'do (concat (drop (inc k) inits) body)))
+                      [environment pairs]
+                      (reduce (fn [[environment pairs] [k [symbol init]]]
+                                (let [call (copy-call init environment)
+                                      init (if (and call
+                                                    (or (not (:returns-destination? call))
+                                                        (not (contains? (util/free-syms (later k))
+                                                                        symbol))))
+                                             (expand! call)
+                                             (walk init environment))
+                                      environment (cond-> environment
+                                                    (binder-tag symbol)
+                                                    (assoc symbol (binder-tag symbol)))]
+                                  [environment (conj pairs [symbol init])]))
+                              [environment []]
+                              (map-indexed vector pairs))]
+                  (with-meta (apply list head (vec (mapcat identity pairs))
+                                    (map #(walk % environment) body))
+                    (meta expression)))
+
+                :else
+                (with-meta (apply list (map #(walk % environment) expression)) (meta expression))))]
+      (let [form (walk form (or param-env {}))]
+        {:form form :stats {:region-copies-expanded @expanded}}))))

--- a/src/raster/compiler/passes/region_copy.clj
+++ b/src/raster/compiler/passes/region_copy.clj
@@ -9,14 +9,22 @@
      (dotimes [t len] (aset dst (+ dst-off t) (aget src (+ src-off t))))
 
    whenever the source and the destination are distinct storage. That is what this pass emits,
-   in statement positions only: a `do` statement, a `dotimes` body, or an effect binding whose
-   value nothing reads. A copy whose value is used keeps its call (it returns the destination),
-   and a copy within one array keeps its call too (`System/arraycopy` is a memmove, an
-   elementwise forward loop is not).
+   in statement positions only: a `do` statement, a `dotimes` body, a discarded `if`/`when`
+   arm, or an effect binding whose value nothing reads. A copy whose value is used keeps its
+   call (it returns the destination), and a copy within one array keeps its call too
+   (`System/arraycopy` is a memmove, an elementwise forward loop is not).
+
+   Distinct array symbols denote distinct storage here, as they do for every typed kernel
+   (each array parameter is emitted `restrict`); a locally allocated array is distinct by
+   construction. Region validity is kernel semantics: an out-of-range region is undefined in
+   a kernel, and on the JVM the loop throws at the first out-of-range element rather than
+   before the first store.
 
    The emitted read carries the copied element type as its scalar tag when a fact states one:
-   the call's own result tag, the tag of the binder that introduced either array, or the
-   deftm parameter tag. Downstream typing then reads a fact rather than inferring one."
+   the call's own result tag, the tag of the binder or deftm parameter that introduced the
+   source, else that of the destination. Two known tags that disagree are not one copy (the
+   JVM rejects such a call), so the call is retained. Downstream typing then reads a fact
+   rather than inferring one."
   (:require [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.op-descriptor :as descriptor]
             [raster.compiler.core.util :as util]
@@ -38,13 +46,14 @@
    two distinct array symbols, else nil. `environment` maps array symbols to their tags."
   [expression environment]
   (when (and (seq? expression) (contains? copy-ops (descriptor/semantic-op expression)))
-    (let [[src src-off dst dst-off len :as arguments] (vec (descriptor/call-args expression))]
-      (when (and (= 5 (count arguments)) (symbol? src) (symbol? dst) (not= src dst))
+    (let [[src src-off dst dst-off len :as arguments] (vec (descriptor/call-args expression))
+          src-tag (array-tag environment src)
+          dst-tag (array-tag environment dst)]
+      (when (and (= 5 (count arguments)) (symbol? src) (symbol? dst) (not= src dst)
+                 (or (nil? src-tag) (nil? dst-tag) (= src-tag dst-tag)))
         {:src src :src-off src-off :dst dst :dst-off dst-off :len len
          :returns-destination? (= 'raster.arrays/acopy! (descriptor/semantic-op expression))
-         :tag (or (:raster.type/tag (meta expression))
-                  (array-tag environment dst)
-                  (array-tag environment src))}))))
+         :tag (or (:raster.type/tag (meta expression)) src-tag dst-tag)}))))
 
 (defn- offset-index
   "`offset + index`; a zero offset (the walker spells a literal `0` as `(int 0)`) is the bare
@@ -80,9 +89,22 @@
                   (swap! expanded inc)
                   (store-loop call (fresh)))]
     (letfn [(statement [expression environment]
-              ;; a value nobody reads: a copy here is exactly its loop
-              (if-let [call (copy-call expression environment)]
-                (expand! call)
+              ;; a value nobody reads: a copy here is exactly its loop, and the discarded
+              ;; positions inside a conditional or a block are statements too
+              (cond
+                (copy-call expression environment)
+                (expand! (copy-call expression environment))
+
+                (and (seq? expression) (contains? '#{if when} (first expression)))
+                (with-meta (apply list (first expression) (walk (second expression) environment)
+                                  (map #(statement % environment) (nnext expression)))
+                  (meta expression))
+
+                (and (seq? expression) (= 'do (first expression)))
+                (with-meta (apply list 'do (map #(statement % environment) (rest expression)))
+                  (meta expression))
+
+                :else
                 (walk expression environment)))
             (walk [expression environment]
               (cond
@@ -109,11 +131,13 @@
                       [environment pairs]
                       (reduce (fn [[environment pairs] [k [symbol init]]]
                                 (let [call (copy-call init environment)
-                                      init (if (and call
-                                                    (or (not (:returns-destination? call))
-                                                        (not (contains? (util/free-syms (later k))
-                                                                        symbol))))
-                                             (expand! call)
+                                      ;; a binder nothing reads (an effect binding) discards its
+                                      ;; value: its init is a statement, conditionals included;
+                                      ;; a copy that returns nothing is a statement anywhere
+                                      unused? (not (contains? (util/free-syms (later k)) symbol))
+                                      init (if (or unused?
+                                                   (and call (not (:returns-destination? call))))
+                                             (statement init environment)
                                              (walk init environment))
                                       environment (cond-> environment
                                                     (binder-tag symbol)

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -1553,16 +1553,18 @@
   '#{dotimes loop* loop doseq while})
 
 (defn- host-control-flow?
-  "Does `expr` run a loop or write an array on the host? Such a binding is an effect the
-   resident program cannot carry as a size-let closure: evaluating it at bind time would run
-   the loop once over host arrays, and dropping it would lose the effect. Only a pure scalar
-   expression is a host size-let."
+  "Does `expr` run a loop, write an array, or call a mutating operation on the host? Such a
+   binding is an effect the resident program cannot carry as a size-let closure: evaluating it
+   at bind time would run it once over host arrays, and dropping it would lose the effect.
+   Only a pure scalar expression is a host size-let."
   [expr]
   (boolean
    (some (fn [form]
            (and (seq? form)
-                (or (contains? host-loop-heads (first form))
-                    (op/aset-op? (op/semantic-op form)))))
+                (let [operation (op/semantic-op form)]
+                  (or (contains? host-loop-heads (first form))
+                      (op/aset-op? operation)
+                      (and (symbol? operation) (op/mutating-op? operation))))))
          (tree-seq seq? seq expr))))
 
 (defn- contains-gpu-invoke?

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -6,7 +6,7 @@
   runner validates arrow compatibility at composition time.
 
   Single unified pipeline (GPU/SIMD):
-    [:lower :structured-reduction-fuse :fixpoint :dce :buffer-fuse :resolve-alength :soac-fuse :compound-detect :backend :mem-merge]
+    [:lower :region-copy :structured-reduction-fuse :fixpoint :dce :buffer-fuse :resolve-alength :soac-fuse :compound-detect :backend :mem-merge]
 
   AD is handled by inlining value+grad calls during the fixpoint pass.
   Training, gradients, and higher-order derivatives all go through the
@@ -51,6 +51,7 @@
             [raster.compiler.passes.parallel.compound-detect :as compound-detect]
             [raster.compiler.passes.parallel.segop-lower-pass :as segop-lower]
             [raster.compiler.passes.parallel.loop-lift :as loop-lift]
+            [raster.compiler.passes.region-copy :as region-copy]
             [raster.compiler.passes.parallel.write-read-fuse :as write-read-fuse]
             [raster.compiler.passes.parallel.materialize :as materialize]
             [raster.compiler.passes.parallel.segmented-weighted-reduction-fuse :as swr-fuse]
@@ -328,6 +329,13 @@
    Entry point that initializes the env from param-env."
   [form param-env]
   (tag-expr-types form (or param-env {})))
+
+(defn- pass-region-copy
+  "Spell array region copies (`acopy!`, `System/arraycopy`) in statement position as the
+  counted store loops they are, so the loop lifter, the typed frontend and the resident
+  extractor see stores instead of an opaque effect. (=> :lowered :region-copied)"
+  [form opts]
+  (region-copy/expand-region-copies form :param-env (:param-env opts)))
 
 (defn- pass-lower
   "Lower compound deftm ops into primitive ops for AD.
@@ -1043,8 +1051,10 @@
   flat let* form). The :from tag is set to the most common input."
   {;; Core pipeline passes (used in forward-passes)
    :lower            {:from :walked            :to :lowered           :fn pass-lower}
+   :region-copy      {:from :lowered           :to :region-copied     :fn pass-region-copy
+                      :label "Region copies as store loops"}
    :structured-reduction-fuse
-   {:from :lowered :to :structured-reductions :fn pass-structured-reduction-fuse}
+   {:from :region-copied :to :structured-reductions :fn pass-structured-reduction-fuse}
    :fixpoint         {:from :structured-reductions :to :fixpointed    :fn pass-fixpoint}
    :dce              {:from :*                 :to :dce-cleaned       :fn pass-dce}
    :buffer-fuse      {:from :dce-cleaned       :to :buffer-fused      :fn pass-buffer-fuse}
@@ -1152,19 +1162,20 @@
 ;; ================================================================
 
 (def forward-passes
-  "Forward: lower → fixpoint → DCE → buffer-fuse → late-cleanup → loop-lift → write-read-fuse → soac-fuse → compound-detect → segop-lower → backend → resolve-alength → mem-merge.
+  "Forward: lower → region-copy → fixpoint → DCE → buffer-fuse → late-cleanup → loop-lift → write-read-fuse → soac-fuse → compound-detect → segop-lower → backend → resolve-alength → mem-merge.
+   region-copy spells acopy!/System.arraycopy statements as counted store loops.
    fixpoint loops expand+normalize+rewalk until stable, handling composable AD inlining.
    loop-lift recovers par structure from dotimes/loop forms (e.g. SGD inlined to dotimes).
    write-read-fuse eliminates intermediate buffers by fusing 2D producers into 1D consumers (dW+SGD).
    segop-lower converts par forms to a typed SegOp ParallelProgram for unified backend consumption."
-  [:lower :structured-reduction-fuse :fixpoint :dce :buffer-fuse :late-cleanup :loop-lift :write-read-fuse :soac-fuse :materialize :compound-detect :segop-lower :backend :resolve-alength :mem-merge])
+  [:lower :region-copy :structured-reduction-fuse :fixpoint :dce :buffer-fuse :late-cleanup :loop-lift :write-read-fuse :soac-fuse :materialize :compound-detect :segop-lower :backend :resolve-alength :mem-merge])
 
 (def gpu-resident-pre-soa-passes
   "forward-passes up to (and including) :materialize. The resident GPU path splits here so
    soa-lower can explode value-type (Params container) params into per-field arrays at the
    :materialized boundary — BEFORE the :backend pass emits kernels (the JVM bytecode backend
    keeps Valhalla value-classes native, so soa-lower is per-backend, not a shared pass)."
-  [:lower :structured-reduction-fuse :fixpoint :dce :buffer-fuse :late-cleanup :loop-lift :write-read-fuse :soac-fuse :materialize])
+  [:lower :region-copy :structured-reduction-fuse :fixpoint :dce :buffer-fuse :late-cleanup :loop-lift :write-read-fuse :soac-fuse :materialize])
 
 (def gpu-resident-post-soa-passes
   "forward-passes from :compound-detect onward — resumed (from :materialized) after soa-lower."
@@ -1538,6 +1549,22 @@
          :out-buf (nth args 2) :returns sym})
       :else nil)))
 
+(def ^:private host-loop-heads
+  '#{dotimes loop* loop doseq while})
+
+(defn- host-control-flow?
+  "Does `expr` run a loop or write an array on the host? Such a binding is an effect the
+   resident program cannot carry as a size-let closure: evaluating it at bind time would run
+   the loop once over host arrays, and dropping it would lose the effect. Only a pure scalar
+   expression is a host size-let."
+  [expr]
+  (boolean
+   (some (fn [form]
+           (and (seq? form)
+                (or (contains? host-loop-heads (first form))
+                    (op/aset-op? (op/semantic-op form)))))
+         (tree-seq seq? seq expr))))
+
 (defn- contains-gpu-invoke?
   "Deep check: does form contain a gpu-invoke head anywhere? (A scalar binding whose value is
    itself computed from a kernel result is NOT a straight-line scalar let.)"
@@ -1670,6 +1697,10 @@
           ;; alength) is fine — only intermediate buffers are tracked.
              (seq (set/intersection (mem/sexp-free-vars expr) @device-buffers))
              (reject! :scalar-let-reads-device-buffer sym expr)
+          ;; A host loop or array write is an effect, not a size-let: it can neither be
+          ;; evaluated at bind time nor dropped. The program is not straight-line.
+             (host-control-flow? expr)
+             (reject! :host-control-flow sym expr)
           ;; A pure scalar binding (no nested kernel) feeds sizes/counts — keep it.
              (not (contains-gpu-invoke? expr))
              (vswap! scalar-lets into [sym expr])

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -3627,6 +3627,18 @@
                     (vreset! output-seg [seg half? esize])
                     seg)
 
+                  ;; Read-write storage: the kernel reads the destination it overwrites (an
+                  ;; accumulating contraction), so a host array is staged in and read back.
+                  :inout
+                  (let [half? (boolean (#{:half :float16} dtype))
+                        esize (long (get dtype-byte-sizes dtype 8))
+                        seg (if (device-buffer? value)
+                              (:segment ^DeviceBuffer value)
+                              (stage-operand! kernel-name :c-out value out-elems half? esize))]
+                    (vreset! output value)
+                    (vreset! output-seg [seg half? esize])
+                    seg)
+
                   :scalar
                   value
 

--- a/src/raster/par.clj
+++ b/src/raster/par.clj
@@ -284,7 +284,11 @@
     contract-axes— [[idx-sym bound] ...] the reduced axes: 0 (outer product / pure map),
                    1, or n (n≥2 are flattened into one innermost reduced dim)
     body         — the summand expression; may reference every free and contract idx
-    opts         — :init (accumulator init, default 0.0), :combine (default +)
+    opts         — :init (accumulator init, default 0.0), :combine (default +),
+                   :epilogue (a result transform applied to every completed segment result:
+                   {:acc sym :expr form :operands [{:sym array :map axis-map :dtype dt}]
+                    :scalars [{:sym s :dtype dt}]}; `expr` reads each operand at the element
+                   its axis map names, so it may read the destination itself)
 
   Semantics: for each free index tuple f, out[flat(f)] = combine-fold over the
   contracted axis of body. The COMPILER recognizes the `raster.par/contract` form
@@ -296,7 +300,8 @@
   Example (C[m,n] = A[m,k]·B[k,n], row-major):
     (raster.par/contract C [[i m] [j n]] [[l k]]
       (* (aget A (+ (* i k) l)) (aget B (+ (* l n) j))))"
-  [out free-axes contract-axes body & {:keys [init combine stages] :or {init 0.0 combine '+}}]
+  [out free-axes contract-axes body & {:keys [init combine stages epilogue]
+                                       :or {init 0.0 combine '+}}]
   (assert (vector? free-axes) "par/contract: free-axes must be a vector of [idx bound]")
   (assert (vector? contract-axes)
           "par/contract: contract-axes must be a vector (0 → outer product/map; n≥1 → contraction, n≥2 flattened)")
@@ -313,6 +318,21 @@
         body (if (seq stages)
                ((requiring-resolve 'raster.compiler.ir.contract-stages/flat-equivalent) stages body)
                body)
+        ;; The result transform is the same region the typed kernels store through; an operand
+        ;; read is the element at the coordinates its axis map names, in the free indices that
+        ;; are in scope at the store.
+        apply-epilogue
+        (fn [value]
+          (if epilogue
+            (let [{:keys [acc expr operands]} epilogue
+                  index-expr (requiring-resolve 'raster.compiler.ir.axis-map/index-expr)
+                  rewrite (requiring-resolve
+                           'raster.compiler.core.op-descriptor/rewrite-aget-indices)
+                  indices (into {} (clojure.core/map (fn [operand]
+                                                       [(:sym operand) (index-expr (:map operand))]))
+                                operands)]
+              `(let [~acc ~value] ~(rewrite expr indices)))
+            value))
         free-syms   (mapv first free-axes)
         int-bounds  (mapv (fn [[_ b]] `(int ~b)) free-axes)
         f-sym   (gensym "f__")
@@ -341,7 +361,7 @@
       `(let [~out-sym ~out ~F-sym ~F-expr]
          (dotimes [~f-sym ~F-sym]
            (let [~@decomp]
-             (clojure.core/aset ~out-sym ~f-sym ~body)))
+             (clojure.core/aset ~out-sym ~f-sym ~(apply-epilogue body))))
          ~out-sym)
       ;; n≥1 contract axes → contraction: reduce `body` over the (flattened) contracted axis.
       ;; flatten-contract-axes collapses n≥2 axes into one flat index k-sym and substitutes
@@ -353,10 +373,11 @@
            (dotimes [~f-sym ~F-sym]
              (let [~@decomp]
                (clojure.core/aset ~out-sym ~f-sym
-                                  (loop [~k-sym 0 ~acc-sym ~init]
-                                    (if (clojure.core/< ~k-sym (int ~k-bound))
-                                      (recur (clojure.core/inc ~k-sym) (~combine ~acc-sym ~sbody))
-                                      ~acc-sym)))))
+                                  ~(apply-epilogue
+                                    `(loop [~k-sym 0 ~acc-sym ~init]
+                                       (if (clojure.core/< ~k-sym (int ~k-bound))
+                                         (recur (clojure.core/inc ~k-sym) (~combine ~acc-sym ~sbody))
+                                         ~acc-sym))))))
            ~out-sym)))))
 
 (defmacro scan

--- a/test/raster/compiler/ir/index_algebra_test.clj
+++ b/test/raster/compiler/ir/index_algebra_test.clj
@@ -91,3 +91,26 @@
     (is (nil? (ia/index-form '(+ (+ (* t (* 2 (* h H))) (* h (* 2 h))) j) 'idx '(* T H)
                              '[{:id t :init (quot idx H)} {:id h :init (rem idx H)}]
                              '{j (* 2 h)})))))
+
+(deftest a-product-of-a-sum-by-an-invariant-distributes
+  ;; attention prefill: sc[(i·n-q + hq)·nrows + j] over idx with digits i, hq, j
+  (let [extent '(clojure.core/* nrows (clojure.core/* n-q nrows))
+        locals '[{:id per-i :init (clojure.core/* n-q nrows)}
+                 {:id i :init (clojure.core/quot idx per-i)}
+                 {:id rest0 :init (clojure.core/rem idx per-i)}
+                 {:id hq :init (clojure.core/quot rest0 nrows)}
+                 {:id j :init (clojure.core/rem rest0 nrows)}
+                 {:id row :init (clojure.core/+ (clojure.core/* i n-q) hq)}]
+        form (ia/index-form '(clojure.core/+ (clojure.core/* row nrows) j) 'idx extent locals {})]
+    (is (some? form))
+    (is (ia/injective? form))
+    (is (= '{i {:const 1 :factors [n-q nrows]} hq {:const 1 :factors [nrows]} j {:const 1 :factors []}}
+           (into {} (map (fn [[digit {:keys [coefficient]}]] [digit coefficient])) (:terms form)))))
+  (testing "a scaled constant becomes a symbolic offset"
+    (let [form (ia/index-form '(clojure.core/* (clojure.core/+ i 1) n) 'i 'm [] {})]
+      (is (= {:const 1 :factors '[n]} (:offset form)))))
+  (testing "a product of two digit-carrying factors is not affine"
+    (is (nil? (ia/index-form '(clojure.core/* (clojure.core/+ i 1) (clojure.core/+ j 1)) 'idx
+                             '(clojure.core/* m n)
+                             '[{:id i :init (clojure.core/quot idx n)} {:id j :init (clojure.core/rem idx n)}]
+                             {})))))

--- a/test/raster/compiler/passes/parallel/contraction_body_test.clj
+++ b/test/raster/compiler/passes/parallel/contraction_body_test.clj
@@ -232,3 +232,41 @@
     (is (= :operand-layout (:fallback-reason routed)))
     (is (= :portable-kernel-body (-> routed :declines last :leaf)))
     (is (nil? (:kernel-body routed)))))
+
+(defn- destination-reading-form
+  [dtype]
+  (concat
+   '(raster.par/contract C [[i 4] [j 8]] [[l 16]]
+                         (raster.numeric/*
+                          (clojure.core/aget A (clojure.core/+ (clojure.core/* i 16) l))
+                          (clojure.core/aget B (clojure.core/+ (clojure.core/* l 8) j))))
+   [:epilogue {:acc 'acc
+               :expr '(raster.numeric/+ acc (raster.numeric/* beta (clojure.core/aget C (clojure.core/+ (clojure.core/* i 8) j))))
+               :operands [{:sym 'C :dtype dtype :map (axis-map/of-axes [['i 4] ['j 8]])}]
+               :scalars [{:sym 'beta :dtype dtype}]
+               :dtype dtype}]))
+
+(deftest a-result-transform-reading-the-destination-makes-it-one-read-write-parameter
+  ;; `C := acc + beta·C` (an accumulating GEMM) reads the element this work item stores. The
+  ;; destination is a single `:inout` parameter: no second read-only view of the same storage,
+  ;; no stable-read claim on a buffer the kernel writes, and no `const` on its pointer.
+  (let [routed (route/route-contraction (destination-reading-form :float) :dtype :float :desc {}
+                                        :candidate-families #{:portable})]
+    (is (= :portable-segred (:strategy routed)))
+    (is (= '[[A :input] [B :input] [C :inout] [beta :scalar] [_nseg :scalar]]
+           (mapv (juxt :name :kind) (:abi routed))))
+    (is (= '[A B] (:array-params routed)))
+    (is (empty? (:epilogue-operands routed)))
+    (is (= '[beta] (:epilogue-scalars routed)))
+    (is (= '[A B] (mapv :buffer (get-in routed [:kernel-body :stable-reads]))))
+    (is (re-find #"__global float\* C" (:source routed)))
+    (is (not (re-find #"const float\* C" (:source routed))))))
+
+(deftest the-matrix-leaf-declines-a-destination-reading-transform-by-name
+  ;; The tile store writes whole fragments; reading the destination element inside that store
+  ;; is not expressed yet, so the FP16 product routes to the register-tiled body and says why.
+  (let [routed (route/route-contraction (destination-reading-form :half) :dtype :half)]
+    (is (= :regtiled (:strategy routed)))
+    (is (= [[:dpas :epilogue-reads-destination]]
+           (mapv (juxt :leaf :reason) (:declines routed))))
+    (is (= :inout (:kind (first (filter #(= 'C (:name %)) (:abi routed))))))))

--- a/test/raster/compiler/passes/parallel/gemm_epilogue_device_test.clj
+++ b/test/raster/compiler/passes/parallel/gemm_epilogue_device_test.clj
@@ -1,0 +1,81 @@
+(ns raster.compiler.passes.parallel.gemm-epilogue-device-test
+  "An accumulating BLAS GEMM (`beta ≠ 0`) is a typed contraction whose result transform reads
+   the destination element it overwrites. The deftm below keeps its BLAS spelling; the typed
+   route turns it into one resident `:contract` step whose destination is a single `:inout`
+   ABI slot, and the same source runs bit-comparably on the JVM (host expansion of the same
+   result transform), on OpenCL and on Level Zero."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.pipeline :as pipeline]
+            [raster.core :refer [deftm]]
+            [raster.dl.gpu-grad-parity :as gpu-probe]
+            [raster.gpu.core :as gpu]
+            [raster.gpu.descriptor-fixture :as fixture]
+            [raster.gpu.device-probe :as device-probe]
+            [raster.linalg.blas :as blas]
+            [raster.numeric :as n]))
+
+(deftm accumulate-gemm! [A :- (Array float), B :- (Array float), C :- (Array float),
+                         m :- Long, k :- Long, n :- Long] :- (Array float)
+  (let [_ (blas/dgemm! A B C m k n (n/oftype A 1.0) (n/oftype A 1.0))]
+    C))
+
+(def ^:private m 3)
+(def ^:private k 4)
+(def ^:private n 5)
+
+(defn- a-matrix [] (float-array (map float (range (* m k)))))
+(defn- b-matrix [] (float-array (map #(float (* 0.5 %)) (range (* k n)))))
+(defn- c-initial [] (float-array (map #(float (* 100 %)) (range (* m n)))))
+
+(defn- reference
+  "C0 + A·B in float, the value every backend must reproduce."
+  []
+  (let [A (a-matrix) B (b-matrix) C0 (c-initial) C (aclone C0)]
+    (dotimes [i m]
+      (dotimes [j n]
+        (aset C (+ (* i n) j)
+              (float (+ (aget C0 (+ (* i n) j))
+                        (reduce + (for [l (range k)]
+                                    (* (aget A (+ (* i k) l)) (aget B (+ (* l n) j))))))))))
+    (vec C)))
+
+(deftest the-jvm-accumulates-into-the-destination
+  (let [C (c-initial)]
+    (accumulate-gemm! (a-matrix) (b-matrix) C m k n)
+    (is (= (reference) (vec C)))))
+
+(deftest the-resident-program-is-one-contract-step-with-a-read-write-destination
+  (doseq [target [:ocl:0 :ze:0]]
+    (let [descriptor (pipeline/compile-gpu-program #'accumulate-gemm! target :dtype :float)
+          step (first (:steps descriptor))]
+      (testing (str target)
+        (is (= [:contract] (mapv :convention (:steps descriptor))))
+        (is (= '[[A :input] [B :input] [C :inout]]
+               (vec (for [slot (get-in step [:artifact :abi])
+                          :when (not= :scalar (:kind slot))]
+                      [(:name slot) (:kind slot)]))))
+        (is (empty? (:allocs descriptor)))
+        (is (re-find #"__global float\* C" (get-in step [:artifact :source]))
+            "the destination pointer is writable: no const qualifier")))))
+
+(defn- run-on-device
+  [target]
+  (let [descriptor (pipeline/compile-gpu-program #'accumulate-gemm! target :dtype :float)
+        session (gpu/make-session target)
+        C (c-initial)
+        arguments [(a-matrix) (b-matrix) C m k n]]
+    (try
+      (let [program (fixture/instantiate! session descriptor arguments
+                                          {'A :input 'B :input 'C :output})]
+        (vec (get (fixture/run! program arguments) 'C)))
+      (finally (gpu/close-session! session)))))
+
+(deftest opencl-accumulates-into-the-destination
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "accumulating GEMM on OpenCL")
+    (is (= (reference) (run-on-device :ocl:0)))))
+
+(deftest level-zero-accumulates-into-the-destination
+  (if-not @gpu-probe/gpu-available?
+    (gpu-probe/gpu-skip! "accumulating GEMM on Level Zero")
+    (is (= (reference) (run-on-device :ze:0)))))

--- a/test/raster/compiler/passes/parallel/gemm_epilogue_device_test.clj
+++ b/test/raster/compiler/passes/parallel/gemm_epilogue_device_test.clj
@@ -12,6 +12,7 @@
             [raster.gpu.descriptor-fixture :as fixture]
             [raster.gpu.device-probe :as device-probe]
             [raster.linalg.blas :as blas]
+            [raster.dl.nn :as nn]
             [raster.numeric :as n]))
 
 (deftm accumulate-gemm! [A :- (Array float), B :- (Array float), C :- (Array float),
@@ -79,3 +80,59 @@
   (if-not @gpu-probe/gpu-available?
     (gpu-probe/gpu-skip! "accumulating GEMM on Level Zero")
     (is (= (reference) (run-on-device :ze:0)))))
+
+;; `linear!` prefills its output with the bias, one row copy at a time, then accumulates
+;; `x·Wᵀ` into it with `beta = 1`. Both halves are now typed: the row copies are a store loop
+;; the lifter turns into one map, and the GEMM is a contraction whose result transform reads
+;; the destination.
+(def ^:private batch 3)
+(def ^:private in-f 4)
+(def ^:private out-f 5)
+
+(defn- linear-arguments
+  []
+  [(float-array (map #(float (* 0.25 %)) (range (* batch in-f))))
+   (float-array (map #(float (- (* 0.5 %) 3.0)) (range (* out-f in-f))))
+   (float-array (map #(float (* 10 %)) (range out-f)))
+   (float-array (* batch out-f))
+   batch in-f out-f])
+
+(defn- linear-reference
+  []
+  (let [[x W b] (linear-arguments)]
+    (vec (for [i (range batch) j (range out-f)]
+           (float (+ (aget b j)
+                     (reduce + (for [l (range in-f)]
+                                 (* (aget x (+ (* i in-f) l)) (aget W (+ (* j in-f) l)))))))))))
+
+(deftest the-linear-layer-is-a-resident-map-and-contract
+  (doseq [target [:ocl:0 :ze:0]]
+    (let [descriptor (pipeline/compile-gpu-program #'nn/linear! target :dtype :float)]
+      (testing (str target)
+        (is (= [:map :contract] (mapv :convention (:steps descriptor))))
+        (is (= '[[W :input] [x :input] [y :inout]]
+               (vec (for [slot (get-in (second (:steps descriptor)) [:artifact :abi])
+                          :when (not= :scalar (:kind slot))]
+                      [(:name slot) (:kind slot)]))))))))
+
+(defn- run-linear-on-device
+  [target]
+  (let [descriptor (pipeline/compile-gpu-program #'nn/linear! target :dtype :float)
+        session (gpu/make-session target)
+        arguments (linear-arguments)]
+    (try
+      (let [program (fixture/instantiate! session descriptor arguments
+                                          {'x :input 'W :input 'b :input 'y :output})]
+        (vec (get (fixture/run! program arguments) 'y)))
+      (finally (gpu/close-session! session)))))
+
+(deftest the-linear-layer-matches-on-every-backend
+  (let [[x W b y & dims] (linear-arguments)]
+    (apply nn/linear! x W b y dims)
+    (is (= (linear-reference) (vec y)) "JVM"))
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "linear! on OpenCL")
+    (is (= (linear-reference) (run-linear-on-device :ocl:0)) "OpenCL"))
+  (if-not @gpu-probe/gpu-available?
+    (gpu-probe/gpu-skip! "linear! on Level Zero")
+    (is (= (linear-reference) (run-linear-on-device :ze:0)) "Level Zero")))

--- a/test/raster/compiler/passes/parallel/register_tiled_body_test.clj
+++ b/test/raster/compiler/passes/parallel/register_tiled_body_test.clj
@@ -96,3 +96,25 @@
         (contraction)
         {:descriptor {:execution {:max-workgroup-size 8}
                       :shared-local-memory 128}}))))
+
+(deftest a-destination-reading-result-transform-stores-through-one-read-write-parameter
+  (let [epilogue {:acc 'acc
+                  :expr '(raster.numeric/+ acc (raster.numeric/* beta (clojure.core/aget C (clojure.core/+ (clojure.core/* i 8) j))))
+                  :operands [{:sym 'C :dtype :float
+                              :map (axis-map/of-axes [['i 8] ['j 8]])}]
+                  :scalars [{:sym 'beta :dtype :float}]
+                  :dtype :float}
+        emitted (segop-emit/generate-register-tiled-kernel-body
+                 (contraction epilogue) 'C :tile small-tile)
+        kernel-body (:kernel-body emitted)]
+    (is (body/kernel-body? kernel-body))
+    (is (= '[[A :input] [B :input] [C :inout] [beta :scalar]]
+           (mapv (juxt :name :kind) (:abi emitted))))
+    (is (empty? (:epilogue-operands emitted)))
+    (is (= '[A B] (mapv :buffer (:stable-reads kernel-body)))
+        "the destination is written, so it carries no stable-read contract")
+    (is (re-find #"__global float\* out" (:source emitted))
+        "the destination pointer is writable: no const qualifier")
+    (is (re-find #"\? out\[" (:source emitted))
+        "the destination element is loaded under the same store mask")
+    (is (str/includes? (:source emitted) "(beta * "))))

--- a/test/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse_test.clj
+++ b/test/raster/compiler/passes/parallel/segmented_weighted_reduction_fuse_test.clj
@@ -117,8 +117,8 @@
 
 (deftest compiler-pass-is-gpu-only
   (let [opts {:inline? false :simd? false :dtype :float}
-        cpu (pipeline/run-passes (chain) [:lower :structured-reduction-fuse] opts)
-        gpu (pipeline/run-passes (chain) [:lower :structured-reduction-fuse]
+        cpu (pipeline/run-passes (chain) [:lower :region-copy :structured-reduction-fuse] opts)
+        gpu (pipeline/run-passes (chain) [:lower :region-copy :structured-reduction-fuse]
                                  (assoc opts :target-device :ze:0))
         marker-count #(count (filter fuse/marker? (tree-seq coll? seq %)))]
     (is (zero? (marker-count cpu)))

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -1047,3 +1047,60 @@
     (is (= [:float] (:dtypes attributes)))
     (is (= :float (:result-dtype transform)))
     (is (= [:float] (mapv :dtype (:operands transform))))))
+
+(defn- effect-map-order
+  "`:independent`/`:sequential` for an effect map; a proven unique offset write becomes a
+   certified scatter, reported as `:unique`."
+  [source types]
+  (let [program (frontend/form->program (frontend/normalize-source source types) types)
+        equation (last (dialect/equations program))
+        {:keys [attributes]} (dialect/operation-parts equation)]
+    (if (= 'scatter (dialect/operation-kind equation))
+      (:conflict attributes)
+      (:iteration-order attributes))))
+
+(deftest a-uniform-array-read-is-an-invariant-offset
+  ;; kv-append: cache[posbuf[0]·kvrow + i] over i < kvrow; posbuf[0] is read, never written,
+  ;; at an index free of the map, so it is an invariant factor and the map is independent
+  (let [types {:dtype :float :array-types {'src :float 'cache :float 'posbuf :long}
+               :scalar-types {'kvrow :long}}
+        map-over (fn [index]
+                   (list 'let* ['effect (list 'raster.par/map-void! 'i 'kvrow
+                                              (list 'clojure.core/aset 'cache index
+                                                    '(clojure.core/aget src i)))]
+                         'effect))]
+    (is (= :unique
+           (effect-map-order
+            (map-over '(clojure.core/+ (clojure.core/* (clojure.core/aget posbuf 0) kvrow) i))
+            types))
+        "proven unique: a certified scatter, no ordering claim")
+    (testing "a read that varies with the map index is data the algebra cannot see"
+      (is (= :sequential
+             (effect-map-order
+              (map-over '(clojure.core/+ (clojure.core/* (clojure.core/aget posbuf i) kvrow) i))
+              types))))
+    (testing "a read of the destination itself is not invariant"
+      (is (= :sequential
+             (effect-map-order
+              (map-over '(clojure.core/+ (clojure.core/* (clojure.core/aget cache 0) kvrow) i))
+              types))))))
+
+(deftest stores-at-one-address-in-exclusive-arms-are-one-write
+  ;; attention prefill: both arms write sc[(i·n-q + hq)·nrows + j]; one work item, one element
+  (let [source '(let* [effect (raster.par/map-void!
+                               idx (clojure.core/* nrows (clojure.core/* n-q nrows))
+                               (let* [^long per-i (clojure.core/* n-q nrows)
+                                      ^long i (clojure.core/quot idx per-i)
+                                      ^long rest0 (clojure.core/rem idx per-i)
+                                      ^long hq (clojure.core/quot rest0 nrows)
+                                      ^long j (clojure.core/rem rest0 nrows)
+                                      ^long row (clojure.core/+ (clojure.core/* i n-q) hq)]
+                                 (if (clojure.core/< i j)
+                                   (clojure.core/aset sc (clojure.core/+ (clojure.core/* row nrows) j)
+                                                      (float -1.0e30))
+                                   (clojure.core/aset sc (clojure.core/+ (clojure.core/* row nrows) j)
+                                                      (clojure.core/aget q j)))))]
+                  effect)]
+    (is (= :unique
+           (effect-map-order source {:dtype :float :array-types {'sc :float 'q :float}
+                                     :scalar-types {'nrows :long 'n-q :long}})))))

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -1027,3 +1027,23 @@
                                      effect)
                               :float {'out :float} {:scalar-types {'n :long 'stride :long}})]
     (is (= :unique-index-not-provable (get-in routed [:declined :reason])))))
+
+(deftest a-destination-reading-transform-follows-the-contraction-dtype
+  ;; A double-spelled GEMM (`doubles` call tag) compiled under the float policy writes a float
+  ;; buffer; the destination it reads back is that same float buffer, so the transform's
+  ;; operand and result dtypes are the contraction's, not the call tag's.
+  (let [call (with-meta
+               (list '.invk
+                     'raster.linalg.blas/dgemm!_m_doubles_doubles_doubles_long_long_long_double_double-impl
+                     'A 'B 'C 'm 'k 'n 1.0 1.0)
+               {:raster.op/original 'raster.linalg.blas/dgemm!
+                :raster.type/tag 'doubles :tag 'doubles})
+        types {:dtype :float :array-types {'A :float 'B :float 'C :float}
+               :scalar-types {'m :long 'k :long 'n :long}}
+        program (frontend/form->program
+                 (frontend/normalize-source (list 'let* ['r call] 'r) types) types)
+        {:keys [attributes]} (dialect/operation-parts (first (dialect/equations program)))
+        transform (:result-transform attributes)]
+    (is (= [:float] (:dtypes attributes)))
+    (is (= :float (:result-dtype transform)))
+    (is (= [:float] (mapv :dtype (:operands transform))))))

--- a/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_frontend_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.abstract-value :as av]
             [raster.compiler.ir.soac :as legacy-soac]
+            [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.soac-dialect :as dialect]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.reduction :as reduction]
@@ -802,15 +803,46 @@
     (is (= [{:destination 'C :access :write :host-return :buffer}]
            (get-in (dialect/facts program) [:equations 1 :attributes :result-storage])))))
 
-(deftest a-blas-gemm-with-a-non-zero-beta-stays-a-host-call
-  (let [call (with-meta
-               (list '.invk
-                     'raster.linalg.blas/dgemm!_m_floats_floats_floats_long_long_long_float_float-impl
-                     'A 'B 'C 'm 'k 'n '(float 1.0) '(float 1.0))
-               {:raster.op/original 'raster.linalg.blas/dgemm!
-                :raster.type/tag 'floats :tag 'floats})
-        source (list 'let* ['r call] 'r)]
-    (is (= source (frontend/normalize-source source)))))
+(defn- accumulating-gemm-call
+  [beta]
+  (with-meta
+    (list '.invk
+          'raster.linalg.blas/dgemm!_m_floats_floats_floats_long_long_long_float_float-impl
+          'A 'B 'C 'm 'k 'n '(float 1.0) beta)
+    {:raster.op/original 'raster.linalg.blas/dgemm!
+     :raster.type/tag 'floats :tag 'floats}))
+
+(deftest a-blas-gemm-with-a-non-zero-beta-reads-its-destination-in-the-result-transform
+  ;; `(dgemm! A B C m k n 1 beta)` is `C[i,j] := Σ_l A[i,l]·B[l,j] + beta·C[i,j]`: the same
+  ;; contraction, with a result transform that reads the destination element it overwrites.
+  ;; The destination is then read-write storage of one kernel rather than a host BLAS effect.
+  (let [types {:dtype :float :array-types {'A :float 'B :float 'C :float}
+               :scalar-types {'m :long 'k :long 'n :long 'beta :float}}
+        program-for (fn [beta]
+                      (let [source (list 'let* ['r (accumulating-gemm-call beta)] 'r)]
+                        (frontend/form->program (frontend/normalize-source source types) types)))
+        program (program-for '(float 1.0))
+        equation (first (dialect/equations program))
+        {:keys [attributes]} (dialect/operation-parts equation)
+        transform (:result-transform attributes)]
+    (is (= ['segmented-reduce] (mapv dialect/operation-kind (dialect/equations program))))
+    (is (= '[[rstr_gemm_i_0 m] [rstr_gemm_j_0 n]] (:segment-axes attributes)))
+    (is (= [{:value 'C :parameter '%result-operand0 :dtype :float
+             :map (axis-map/of-axes '[[rstr_gemm_i_0 m] [rstr_gemm_j_0 n]])}]
+           (:operands transform))
+        "the destination is the one transform operand, read at the store coordinates")
+    (is (= [] (:scalars transform)) "beta = 1 is folded")
+    (is (= [{:destination 'C :access :read-write :host-return :buffer}]
+           (get-in (dialect/facts program)
+                   [:equations (second equation) :attributes :result-storage])))
+    (testing "a scalar beta is a transform scalar"
+      (let [program (program-for 'beta)
+            {:keys [attributes]} (dialect/operation-parts (first (dialect/equations program)))]
+        (is (= [{:value 'beta :parameter '%result-scalar0 :dtype :float}]
+               (:scalars (:result-transform attributes))))))
+    (testing "a beta that is neither a literal nor a scalar value stays a host call"
+      (let [source (list 'let* ['r (accumulating-gemm-call '(clojure.core/aget S 0))] 'r)]
+        (is (= source (frontend/normalize-source source types)))))))
 
 (deftest equal-sizes-spelled-through-host-bindings-are-one-extent
   ;; `n1 = seq`, `n2 = dff`, `(* n1 n2)` and `(* seq dff)` denote one size, and `(alength y)`

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1356,3 +1356,23 @@
     (is (= :typed-soac (get-in scheduled [:equations 0 :attributes :algorithm-dialect])))
     (is (= 1 (get-in simd [:stats :segop-reused])))
     (is (nil? (get-in simd [:stats :segop-relowered])))))
+
+(deftest host-controlled-bindings-keep-the-scalars-they-read
+  ;; `cols` is read only by the host reduction loop the typed program leaves under host
+  ;; control. The realized source must still bind it: the host closure is a root of the
+  ;; dependency closure, not only the body and the physical destinations.
+  (let [routed (route/attempt
+                '(let* [^long rows (clojure.core/alength b)
+                        ^long cols (clojure.core/alength x)
+                        fill (raster.par/map! out i rows nil (clojure.core/aget b i))
+                        _eff (dotimes [i rows]
+                               (dotimes [j cols]
+                                 (clojure.core/aset out i (clojure.core/+ (clojure.core/aget out i)
+                                                                           (clojure.core/aget x j)))))]
+                       out)
+                :float {'b :float 'x :float 'out :float} {})
+        source (:source (:program routed))
+        binders (take-nth 2 (second source))]
+    (is (nil? (:declined routed)))
+    (is (some #{'cols} binders) (pr-str source))
+    (is (some #{'_eff} binders) "the host loop itself is retained as written")))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1376,3 +1376,22 @@
     (is (nil? (:declined routed)))
     (is (some #{'cols} binders) (pr-str source))
     (is (some #{'_eff} binders) "the host loop itself is retained as written")))
+
+(deftest a-producer-the-host-reads-is-not-fused-away
+  ;; `y` has one typed consumer (`z`) and one host reader (the loop). Counting only typed uses
+  ;; would inline `y` into `z` and then resurrect its source binding for the host: the producer
+  ;; would run twice. Host reads are uses, so `y` stays its own equation.
+  (let [routed (route/attempt
+                '(let* [y (raster.par/pmap i n float (clojure.core/* 2.0 (clojure.core/aget x i)))
+                        z (raster.par/pmap j n float (clojure.core/+ 1.0 (clojure.core/aget y j)))
+                        _eff (dotimes [k n]
+                               (clojure.core/aset acc 0 (clojure.core/+ (clojure.core/aget acc 0)
+                                                                         (clojure.core/aget y k))))]
+                       z)
+                :float {'x :float 'acc :float} {:scalar-types {'n :long}})
+        program (:program routed)
+        source (:source program)
+        binders (vec (take-nth 2 (second source)))]
+    (is (nil? (:declined routed)))
+    (is (= 2 (count (:equations program))) "y and z remain separate equations")
+    (is (= 1 (count (filter #{'y} binders))) "y is materialized exactly once")))

--- a/test/raster/compiler/passes/region_copy_test.clj
+++ b/test/raster/compiler/passes/region_copy_test.clj
@@ -77,3 +77,28 @@
         {:keys [form stats]} (region-copy/expand-region-copies form)]
     (is (= {:region-copies-expanded 0} stats))
     (is (= '(java.lang.System/arraycopy buf 0 buf 1 n) (second (second form))))))
+
+(deftest a-copy-in-a-discarded-conditional-arm-is-a-statement
+  (let [form '(let* [effect_1 (if flag
+                                (java.lang.System/arraycopy src (int 0) out (int 0) n)
+                                nil)]
+                out)
+        {:keys [form stats]} (region-copy/expand-region-copies form)
+        [_ [_ conditional] _] form]
+    (is (= {:region-copies-expanded 1} stats))
+    (is (= 'dotimes (first (nth conditional 2))))))
+
+(deftest disagreeing-element-tags-keep-the-call
+  ;; float[] → double[] is not one copy (the JVM rejects the call); nothing to spell
+  (let [call '(java.lang.System/arraycopy src (int 0) out (int 0) n)
+        form (list 'let* ['effect_1 call] 'out)
+        {:keys [form stats]} (region-copy/expand-region-copies
+                              form :param-env '{src floats out doubles})]
+    (is (= {:region-copies-expanded 0} stats))
+    (is (= call (second (second form))))))
+
+(deftest the-read-is-typed-from-the-source-first
+  (let [form '(let* [effect_1 (java.lang.System/arraycopy src (int 0) out (int 0) n)] out)
+        {:keys [form]} (region-copy/expand-region-copies form :param-env '{src floats})
+        [_ [_ loop] _] form]
+    (is (= 'float (:raster.type/tag (meta (nth (nth loop 2) 3)))))))

--- a/test/raster/compiler/passes/region_copy_test.clj
+++ b/test/raster/compiler/passes/region_copy_test.clj
@@ -1,0 +1,79 @@
+(ns raster.compiler.passes.region-copy-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.passes.region-copy :as region-copy]))
+
+(defn- acopy-call
+  [& arguments]
+  (with-meta (apply list '.invk 'raster.arrays/acopy!_m_floats_long_floats_long_long-impl arguments)
+    {:raster.op/original 'raster.arrays/acopy! :raster.type/tag 'floats :tag 'floats}))
+
+(deftest a-copy-per-row-is-a-nested-store-loop
+  ;; linear's bias prefill: one acopy! per batch row, in the body of a dotimes
+  (let [form (list 'let* ['_ (list 'dotimes '[i batch]
+                                   (acopy-call 'b 0 'y '(clojure.core/* i out-f) 'out-f))]
+                   'y)
+        {:keys [form stats]} (region-copy/expand-region-copies form)
+        [_ [_ loop] _] form
+        [_ _ inner] loop
+        [_ [index len] store] inner
+        [_ dst dst-index read] store]
+    (is (= {:region-copies-expanded 1} stats))
+    (is (= 'dotimes (first inner)))
+    (is (= 'out-f len))
+    (is (= 'y dst))
+    (is (= (list 'clojure.core/+ '(clojure.core/* i out-f) index) dst-index)
+        "the destination index is the copy offset plus the element ordinal")
+    (is (= (list 'clojure.core/aget 'b index) read) "a zero source offset is the bare ordinal")
+    (is (= 'float (:raster.type/tag (meta read)))
+        "the read carries the copied element type the call states")))
+
+(deftest an-effect-binding-copy-becomes-its-loop
+  ;; the inlined JVM primitive returns nothing, so its binding value is never read; the walker
+  ;; spells literal offsets as `(int k)`, and a zero offset is the bare ordinal
+  (let [form '(let* [out (clojure.core/float-array n)
+                     effect_1 (java.lang.System/arraycopy src (int 2) out (int 3) n)
+                     effect_2 (java.lang.System/arraycopy src (int 0) out (int 0) n)]
+                out)
+        {:keys [form stats]} (region-copy/expand-region-copies form)
+        [_ [_ _ _ loop _ zero-loop] _] form]
+    (is (= {:region-copies-expanded 2} stats))
+    (is (= 'dotimes (first loop)))
+    (is (= '(clojure.core/aset out (clojure.core/+ 3 rstr_copy_1)
+                               (clojure.core/aget src (clojure.core/+ 2 rstr_copy_1)))
+           (nth loop 2)))
+    (is (= '(clojure.core/aset out rstr_copy_2 (clojure.core/aget src rstr_copy_2))
+           (nth zero-loop 2)))))
+
+(deftest the-read-is-typed-by-a-binder-or-parameter-tag
+  (testing "the destination binder's tag"
+    (let [out (with-meta 'out {:raster.type/tag 'doubles})
+          form (list 'let* [out '(clojure.core/double-array n)
+                            'effect_1 '(java.lang.System/arraycopy src (int 0) out (int 0) n)]
+                     'out)
+          {:keys [form]} (region-copy/expand-region-copies form)
+          [_ [_ _ _ loop] _] form]
+      (is (= 'double (:raster.type/tag (meta (nth (nth loop 2) 3)))))))
+  (testing "a deftm parameter's tag"
+    (let [form '(let* [effect_1 (java.lang.System/arraycopy src (int 0) out (int 0) n)] out)
+          {:keys [form]} (region-copy/expand-region-copies form :param-env '{src floats out floats})
+          [_ [_ loop] _] form]
+      (is (= 'float (:raster.type/tag (meta (nth (nth loop 2) 3)))))))
+  (testing "no fact: the read stays untagged for downstream typing to decide"
+    (let [form '(let* [effect_1 (java.lang.System/arraycopy src (int 0) out (int 0) n)] out)
+          {:keys [form]} (region-copy/expand-region-copies form)
+          [_ [_ loop] _] form]
+      (is (nil? (meta (nth (nth loop 2) 3)))))))
+
+(deftest a-copy-whose-value-is-read-keeps-its-call
+  (let [call (acopy-call 'src 0 'dst 0 'n)
+        form (list 'let* ['copied call] '(clojure.core/aget copied 0))
+        {:keys [form stats]} (region-copy/expand-region-copies form)]
+    (is (= {:region-copies-expanded 0} stats))
+    (is (= call (second (second form))))))
+
+(deftest a-copy-within-one-array-keeps-its-call
+  ;; System/arraycopy moves overlapping regions correctly; an elementwise loop would not
+  (let [form '(let* [effect_1 (java.lang.System/arraycopy buf 0 buf 1 n)] buf)
+        {:keys [form stats]} (region-copy/expand-region-copies form)]
+    (is (= {:region-copies-expanded 0} stats))
+    (is (= '(java.lang.System/arraycopy buf 0 buf 1 n) (second (second form))))))

--- a/test/raster/compiler/pipeline_extractor_test.clj
+++ b/test/raster/compiler/pipeline_extractor_test.clj
@@ -127,3 +127,10 @@
                                (clojure.core/aset out i (clojure.core/+ (clojure.core/aget out i)
                                                                          (clojure.core/aget x j)))))]
                      out)))))
+
+(deftest a-mutating-host-call-is-not-a-size-let
+  ;; a copy the region-copy pass retains (same array: memmove) is still an effect
+  (is (= :host-control-flow
+         (why '(let* [fill (raster.gpu.ze-runtime/invoke-registered-kernel "k" [b] out [] n)
+                      _eff (java.lang.System/arraycopy out (int 0) out (int 1) n)]
+                     out)))))

--- a/test/raster/compiler/pipeline_extractor_test.clj
+++ b/test/raster/compiler/pipeline_extractor_test.clj
@@ -113,3 +113,17 @@
                info)]
         (is (nil? (nr-key r)))
         (is (= 'obuf (:result r)))))))
+
+(deftest a-host-loop-after-a-kernel-step-is-not-straight-line
+  ;; A `dotimes` binding is untagged and reads no intermediate buffer, so it used to pass as a
+  ;; size-let closure: the loop's effect (here a reduction into `out`) silently vanished from
+  ;; the resident program. It is host control flow and is rejected by name.
+  (is (= :host-control-flow
+         (why '(let* [rows (clojure.core/alength b)
+                      cols (clojure.core/alength x)
+                      fill (raster.gpu.ze-runtime/invoke-registered-kernel "k" [b] out [] rows)
+                      _eff (dotimes [i rows]
+                             (dotimes [j cols]
+                               (clojure.core/aset out i (clojure.core/+ (clojure.core/aget out i)
+                                                                         (clojure.core/aget x j)))))]
+                     out)))))

--- a/test/raster/par_contract_test.clj
+++ b/test/raster/par_contract_test.clj
@@ -115,3 +115,21 @@
             f (eval (list 'fn '[A B C] (expand cform)))]
         (f A B C)
         (is (= (vec C) (mapv double [9 12 15 19 26 33 29 40 51 39 54 69])))))))
+
+(deftest contract-result-transform-reads-the-destination
+  (testing ":epilogue is the typed kernels' result transform: C := acc + beta·C on the host too"
+    (let [m 3 k 4 n 2
+          A (double-array (map double (range (* m k))))
+          B (double-array (map #(* 0.5 (double %)) (range (* k n))))
+          C (double-array (map #(* 10.0 (double %)) (range (* m n))))
+          expected (let [product (ref-matmul-nn A B m k n)]
+                     (mapv (fn [p c] (+ p (* 0.5 c))) (vec product) (vec C)))]
+      ;; the operand map is macro-time data: the axis-map of the destination over the free axes
+      (par/contract C [[i m] [j n]] [[l k]]
+                    (* (aget A (+ (* i k) l)) (aget B (+ (* l n) j)))
+                    :epilogue {:acc acc
+                               :expr (+ acc (* 0.5 (aget C (+ (* i n) j))))
+                               :operands [{:sym C :map {:groups [[[i m]] [[j n]]]} :dtype :double}]
+                               :scalars []
+                               :dtype :double})
+      (is (= expected (vec C))))))

--- a/test/resources/coverage/gpu-corpus.edn
+++ b/test/resources/coverage/gpu-corpus.edn
@@ -52,7 +52,7 @@
   {:var raster.dl.array-ops/dot-rows-dbias,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_273054 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_273037 = (loop*"}
   {:var raster.dl.array-ops/dot-rows-dh,
    :route :scalar,
    :typed-validated false,
@@ -112,7 +112,7 @@
   {:var raster.dl.array-ops/masked-mse-loss-backward,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_277645 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_277628 = (if (cloj"}
   {:var raster.dl.array-ops/pack-heads,
    :route :typed-soac,
    :typed-validated true,
@@ -192,18 +192,15 @@
   {:var raster.dl.attention/attn-prefill-scores!,
    :route :typed-soac,
    :typed-validated true,
-   :declines [],
-   :effect-orders {:sequential 1}}
+   :declines []}
   {:var raster.dl.attention/attn-prefill-scores-bidir!,
    :route :typed-soac,
    :typed-validated true,
-   :declines [],
-   :effect-orders {:sequential 1}}
+   :declines []}
   {:var raster.dl.attention/attn-prefill-scores-windowed!,
    :route :typed-soac,
    :typed-validated true,
-   :declines [],
-   :effect-orders {:sequential 1}}
+   :declines []}
   {:var raster.dl.attention/attn-prefill-softmax!,
    :route :compatibility,
    :typed-validated false,
@@ -333,8 +330,7 @@
   {:var raster.dl.attention/kv-append-buf!,
    :route :typed-soac,
    :typed-validated true,
-   :declines [],
-   :effect-orders {:sequential 1}}
+   :declines []}
   {:var raster.dl.attention/multi-head-attention,
    :route :compatibility,
    :typed-validated false,
@@ -407,7 +403,7 @@
   {:var raster.dl.diffusion/compute-alphas-cumprod,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_290436 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_290419 = (loop*"}
   {:var raster.dl.diffusion/cosine-beta-schedule,
    :route :error,
    :error
@@ -467,7 +463,7 @@
   {:var raster.dl.nn/batch-norm,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_129622 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_129649 = (if (cloj"}
   {:var raster.dl.nn/batch-norm-backward-dbeta,
    :route :scalar,
    :typed-validated false,
@@ -882,7 +878,7 @@
   {:var raster.dl.optim/clip-grad-norm!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_287828 = (if (.inv"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_287811 = (if (.inv"}
   {:var raster.dl.optim/cosine-lr,
    :route :error,
    :error
@@ -951,7 +947,7 @@
   {:var raster.nn/kaiming-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_301234 = \\\"Kaim"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_301217 = \\\"Kaim"}
   {:var raster.nn/loss-fn,
    :route :compatibility,
    :typed-validated false,
@@ -989,7 +985,7 @@
   {:var raster.nn/xavier-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_308099 = \\\"Xavi"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_308082 = \\\"Xavi"}
   {:var raster.ode.pde/heat-loss-rk4,
    :route :error,
    :error :emitted-parallel-program-call-required}

--- a/test/resources/coverage/gpu-corpus.edn
+++ b/test/resources/coverage/gpu-corpus.edn
@@ -2,9 +2,9 @@
  :dtype :float,
  :summary
  {:total 236,
-  :typed-soac 98,
-  :error 46,
-  :scalar 75,
+  :typed-soac 102,
+  :error 44,
+  :scalar 73,
   :compatibility 17},
  :vars
  [{:var raster.dl.array-ops/argmax-rows!,
@@ -21,8 +21,7 @@
    :declines []}
   {:var raster.dl.array-ops/array-copy,
    :route :error,
-   :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:java.lang.System{arraycopy 1} e.g. ["}
+   :error :kernel-body-store-dtype}
   {:var raster.dl.array-ops/blit-slab!,
    :route :scalar,
    :typed-validated false,
@@ -33,8 +32,7 @@
    :declines []}
   {:var raster.dl.array-ops/broadcast-add-dh,
    :route :error,
-   :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:java.lang.System{arraycopy 1} e.g. ["}
+   :error :kernel-body-store-dtype}
   {:var raster.dl.array-ops/broadcast-add-dt,
    :route :scalar,
    :typed-validated false,
@@ -54,7 +52,7 @@
   {:var raster.dl.array-ops/dot-rows-dbias,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_265847 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_272671 = (loop*"}
   {:var raster.dl.array-ops/dot-rows-dh,
    :route :scalar,
    :typed-validated false,
@@ -114,7 +112,7 @@
   {:var raster.dl.array-ops/masked-mse-loss-backward,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_270280 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_277262 = (if (cloj"}
   {:var raster.dl.array-ops/pack-heads,
    :route :typed-soac,
    :typed-validated true,
@@ -246,11 +244,12 @@
    :declines []}
   {:var raster.dl.attention/causal-multi-head-attention,
    :route :error,
-   :error :illegal-op-remains}
+   :error :typed-contraction-no-candidates}
   {:var raster.dl.attention/causal-multi-head-attention-cached!,
    :route :scalar,
    :typed-validated false,
-   :declines []}
+   :declines
+   [{:reason :unsupported-scalar-binding, :kind :typed-soac-declined}]}
   {:var raster.dl.attention/causal-scaled-dot-product-attn,
    :route :error,
    :error
@@ -276,7 +275,8 @@
   {:var raster.dl.attention/causal-scaled-dot-product-attn-jvp,
    :route :scalar,
    :typed-validated false,
-   :declines []}
+   :declines
+   [{:reason :unsupported-scalar-binding, :kind :typed-soac-declined}]}
   {:var raster.dl.attention/causal-single-head-attention,
    :route :error,
    :error
@@ -404,7 +404,7 @@
   {:var raster.dl.diffusion/compute-alphas-cumprod,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_282746 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_290053 = (loop*"}
   {:var raster.dl.diffusion/cosine-beta-schedule,
    :route :error,
    :error
@@ -464,7 +464,7 @@
   {:var raster.dl.nn/batch-norm,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_129454 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_129591 = (if (cloj"}
   {:var raster.dl.nn/batch-norm-backward-dbeta,
    :route :scalar,
    :typed-validated false,
@@ -673,13 +673,17 @@
    :typed-validated true,
    :declines []}
   {:var raster.dl.nn/linear,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines
+   [{:reason :typed-contraction-dispatch-dynamic-scalar,
+     :kind :typed-contraction-dispatch-declines}]}
   {:var raster.dl.nn/linear!,
-   :route :scalar,
-   :typed-validated false,
-   :declines []}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines
+   [{:reason :typed-contraction-dispatch-dynamic-scalar,
+     :kind :typed-contraction-dispatch-declines}]}
   {:var raster.dl.nn/linear-dW,
    :route :typed-soac,
    :typed-validated true,
@@ -875,7 +879,7 @@
   {:var raster.dl.optim/clip-grad-norm!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_280186 = (if (.inv"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_287445 = (if (.inv"}
   {:var raster.dl.optim/cosine-lr,
    :route :error,
    :error
@@ -925,9 +929,9 @@
    :error
    "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:clojure.core{aclone 1} e.g. [\"(body_"}
   {:var raster.nn/dense-backward-db-into!,
-   :route :error,
-   :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:java.lang.System{arraycopy 1} e.g. ["}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
   {:var raster.nn/dense-backward-dx,
    :route :compatibility,
    :typed-validated false,
@@ -938,13 +942,13 @@
    :typed-validated true,
    :declines []}
   {:var raster.nn/dense-into!,
-   :route :error,
-   :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) #:java.lang.System{arraycopy 1} e.g. ["}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines []}
   {:var raster.nn/kaiming-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_292987 = \\\"Kaim"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_300851 = \\\"Kaim"}
   {:var raster.nn/loss-fn,
    :route :compatibility,
    :typed-validated false,
@@ -982,7 +986,7 @@
   {:var raster.nn/xavier-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_299792 = \\\"Xavi"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_307716 = \\\"Xavi"}
   {:var raster.ode.pde/heat-loss-rk4,
    :route :error,
    :error :emitted-parallel-program-call-required}
@@ -1001,4 +1005,4 @@
   {:var raster.ode.pde/wave-rhs-1d!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 2 non-exempt untagged binding(s) #:clojure.core{aset 2} e.g. [\"(_eff_31"}]}
+   "fixpoint edge typedness violation on GPU target: 2 non-exempt untagged binding(s) #:clojure.core{aset 2} e.g. [\"(_eff_32"}]}

--- a/test/resources/coverage/gpu-corpus.edn
+++ b/test/resources/coverage/gpu-corpus.edn
@@ -2,8 +2,8 @@
  :dtype :float,
  :summary
  {:total 236,
-  :typed-soac 102,
-  :error 44,
+  :typed-soac 103,
+  :error 43,
   :scalar 73,
   :compatibility 17},
  :vars
@@ -52,7 +52,7 @@
   {:var raster.dl.array-ops/dot-rows-dbias,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_272671 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_273054 = (loop*"}
   {:var raster.dl.array-ops/dot-rows-dh,
    :route :scalar,
    :typed-validated false,
@@ -112,7 +112,7 @@
   {:var raster.dl.array-ops/masked-mse-loss-backward,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_277262 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_277645 = (if (cloj"}
   {:var raster.dl.array-ops/pack-heads,
    :route :typed-soac,
    :typed-validated true,
@@ -243,8 +243,11 @@
    :typed-validated false,
    :declines []}
   {:var raster.dl.attention/causal-multi-head-attention,
-   :route :error,
-   :error :typed-contraction-no-candidates}
+   :route :typed-soac,
+   :typed-validated true,
+   :declines
+   [{:reason :typed-contraction-dispatch-dynamic-scalar,
+     :kind :typed-contraction-dispatch-declines}]}
   {:var raster.dl.attention/causal-multi-head-attention-cached!,
    :route :scalar,
    :typed-validated false,
@@ -404,7 +407,7 @@
   {:var raster.dl.diffusion/compute-alphas-cumprod,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_290053 = (loop*"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {loop* 1} e.g. [\"(_eff_290436 = (loop*"}
   {:var raster.dl.diffusion/cosine-beta-schedule,
    :route :error,
    :error
@@ -464,7 +467,7 @@
   {:var raster.dl.nn/batch-norm,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_129591 = (if (cloj"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_129622 = (if (cloj"}
   {:var raster.dl.nn/batch-norm-backward-dbeta,
    :route :scalar,
    :typed-validated false,
@@ -879,7 +882,7 @@
   {:var raster.dl.optim/clip-grad-norm!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_287445 = (if (.inv"}
+   "fixpoint edge typedness violation on GPU target: 1 non-exempt untagged binding(s) {if 1} e.g. [\"(_eff_287828 = (if (.inv"}
   {:var raster.dl.optim/cosine-lr,
    :route :error,
    :error
@@ -948,7 +951,7 @@
   {:var raster.nn/kaiming-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_300851 = \\\"Kaim"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_301234 = \\\"Kaim"}
   {:var raster.nn/loss-fn,
    :route :compatibility,
    :typed-validated false,
@@ -986,7 +989,7 @@
   {:var raster.nn/xavier-init!,
    :route :error,
    :error
-   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_307716 = \\\"Xavi"}
+   "fixpoint edge typedness violation on GPU target: 3 non-exempt untagged binding(s) {:atom 3} e.g. [\"(_eff_308099 = \\\"Xavi"}
   {:var raster.ode.pde/heat-loss-rk4,
    :route :error,
    :error :emitted-parallel-program-call-required}


### PR DESCRIPTION
## Accumulating GEMMs as typed contractions; region copies as store loops

Third phase of the typed-route campaign (after #333 store loops / BLAS-as-contraction and #334 index algebra).

### `beta ≠ 0` BLAS GEMMs
`(dgemm! A B C m k n alpha beta)` with a non-zero `beta` (literal or scalar value) normalizes to the same `raster.par/contract` as the pure product, with a result transform `C[i,j] := acc + beta·C[i,j]` that reads the destination element it overwrites.
- The destination is read-write storage of one kernel: the portable and register-tiled KernelBody builders express it as a single `:inout` parameter (no second read-only view, no stable-read claim); the OpenCL emitter spells it without `const`; the contraction ABI, dispatch graph and Level Zero staging accept the slot.
- The matrix (DPAS) leaf declines by name (`:epilogue-reads-destination`) until its tile store can read the destination fragment; FP16 products route to the register-tiled body.
- The host `raster.par/contract` macro applies `:epilogue` now. It silently ignored it before, so the JVM projection of any epilogue-carrying contract computed the plain product.
- TypedSOAC boundary rule: a result-transform operand read is addressed by its axis map; the spelled index is that map's row-major spelling and may mention the segment extents (`result-transform-boundary-expression`). The old rule also blocked fusion with symbolic extents.

### `:region-copy` pass
`acopy!` and the `System/arraycopy` it inlines to were opaque effects: the loop lifter saw no store, the typed frontend an untagged binding, and a bias prefill spelled as one row copy per batch row kept a whole linear layer on the host. The new pass (after `:lower`, visible in `explain-pipeline`) spells a copy in statement position as `(dotimes [t len] (aset dst (+ dst-off t) (aget src (+ src-off t))))`, typed from the call tag, the binder tag or the deftm parameter tag. Copies whose value is read and copies within one array (memmove) keep their call. The loop lifter's row/column-major matchers now read the semantic op of a walked `.invk` multiply.

Result: `raster.dl.nn/linear` and `linear!` are resident `[:map :contract]` programs with the GEMM destination as one `:inout` slot; `dense-backward-db-into!` is a `[:map]`.

### Two holes closed on the way
- `typed-soac-route/realize-source` dropped a scalar binding read only by a host-controlled binding (`cols` in `dense-into!`, read by the host reduction loop). Host-controlled reads are roots of the dependency closure now.
- The resident extractor accepted an untagged `dotimes` effect binding as a size-let closure, so the host reduction of `dense-into!` vanished from the resident program. Host loops and array writes are rejected by name (`:host-control-flow`).

### The four remaining sequential effect maps
The index algebra distributes a product over a sum (`(i·n-q + hq)·nrows + j`), and the frontend turns a uniform array read (`(aget posbuf 0)`: an array the region does not write, at an index free of the map and loop indices and the locals) into an invariant atom. `kv-append-buf!` and the three `attn-prefill-scores*!` maps are proven unique and become certified scatters; the corpus has no sequential effect map left (ratchet: `:effect-orders` sequential 4 → 0).

### Review (Codex, one pass)
Six defects fixed with tests: `lambda-parts` forward declaration on a clean load; copy reads typed from the source array, disagreeing tags keep the call; discarded conditional arms and block positions are statements; the extractor rejects mutating host calls too; host-controlled reads count as uses in fusion (`:host-read-values`, renamed by `remap-values`) so a producer the host reads is never fused into its consumer and resurrected. Accepted as codebase convention: distinct array symbols denote distinct storage (every kernel parameter is `restrict`). Open risk recorded in the ledger: a resident program whose `:inout` destination is host state is refreshed only at instantiate.

### Tests
Frontend (beta literal / scalar / unsupported), portable and register-tiled KernelBody (`:inout`, stable reads, `const`), DPAS decline by name, host macro parity, region-copy unit tests (statement positions, offsets, tags), loop-lift matcher, extractor rejection, typed-route closure, and a device test running the accumulating GEMM and `linear!` on the JVM, OpenCL and Level Zero against one reference. Coverage baseline regenerated.

Ledger: `.internal/debt_audit_2026_09_03.md` addendum 2026-09-04e.

https://claude.ai/code/session_01Vtm1xB9JmpaxJMEWCAcQWm
