### PR TITLE
KV continuation transfer plan over paged geometry; transfer capabilities as a stated contract

### DIFF
--- a/src/raster/compiler/ir/distributed_plan.clj
+++ b/src/raster/compiler/ir/distributed_plan.clj
@@ -885,9 +885,13 @@
          (fn [state step]
            (let [dependency-ready (reduce max 0 (map #(get-in state [:finish-by-step %])
                                                      (:dependencies step)))
+                 ;; a transfer an endpoint physically serializes with compute (a stated
+                 ;; capability, carried as `:serialized-on`) occupies that compute lane too
                  resources (case (:kind step)
                              :compute [[:compute (:device step)]]
-                             :transfer (mapv (fn [link-id] [:link link-id]) (:route step)))
+                             :transfer (into (mapv (fn [link-id] [:link link-id]) (:route step))
+                                             (map (fn [device] [:compute device]))
+                                             (get-in step [:attributes :serialized-on])))
                  resource-ready (reduce max 0 (map #(get-in state [:resource-free %] 0)
                                                    resources))
                  start (max dependency-ready resource-ready)
@@ -910,13 +914,17 @@
                    (assoc-in [:resource-free [:compute (:device step)]] finish))
 
                :transfer
-               (reduce (fn [state link-id]
-                         (-> state
-                             (assoc-in [:resource-free [:link link-id]] finish)
-                             (update-in [:link-transfer-bytes link-id]
-                                        (fnil + 0) (:bytes step))
-                             (update-in [:link-busy-ns link-id] (fnil + 0) duration)))
-                       state (:route step)))))
+               (as-> state state
+                 (reduce (fn [state link-id]
+                           (-> state
+                               (assoc-in [:resource-free [:link link-id]] finish)
+                               (update-in [:link-transfer-bytes link-id]
+                                          (fnil + 0) (:bytes step))
+                               (update-in [:link-busy-ns link-id] (fnil + 0) duration)))
+                         state (:route step))
+                 (reduce (fn [state device]
+                           (assoc-in state [:resource-free [:compute device]] finish))
+                         state (get-in step [:attributes :serialized-on]))))))
          initial (:steps plan))
         makespan (reduce max 0 (vals (:finish-by-step state)))
         transferred-bytes (reduce + 0 (map :bytes (filter #(= :transfer (:kind %))

--- a/src/raster/compiler/ir/kv_transfer.clj
+++ b/src/raster/compiler/ir/kv_transfer.clj
@@ -24,6 +24,20 @@
            [layers page-size physical-pages key-elements-per-token value-elements-per-token
             storage-dtype])
 
+(defn- exact
+  "Checked long arithmetic: every derived extent must fit a non-negative long, or the geometry
+   is refused as a whole rather than overflowing later in a range or a byte count."
+  [operation & operands]
+  (try
+    (reduce (fn [acc operand]
+              (case operation
+                :* (Math/multiplyExact (long acc) (long operand))
+                :+ (Math/addExact (long acc) (long operand))))
+            operands)
+    (catch ArithmeticException _
+      (fail! "paged geometry extent exceeds signed 64-bit capacity"
+             :kv-transfer-geometry-overflow {:operation operation :operands (vec operands)}))))
+
 (defn paged-geometry?
   [value]
   (instance? PagedGeometry value))
@@ -40,15 +54,23 @@
    page pool); byte counts follow from it, never from the arithmetic dtype."
   [{:keys [layers page-size physical-pages key-elements-per-token value-elements-per-token
            storage-dtype]}]
-  (let [storage-dtype (dtype/canon storage-dtype)]
+  (let [storage-dtype (dtype/canon storage-dtype)
+        layers (positive-integer! :layers layers)
+        page-size (positive-integer! :page-size page-size)
+        physical-pages (positive-integer! :physical-pages physical-pages)
+        key-per-token (positive-integer! :key-elements-per-token key-elements-per-token)
+        value-per-token (positive-integer! :value-elements-per-token value-elements-per-token)]
     (when-not (dtype/known? storage-dtype)
       (fail! "paged geometry requires a known storage dtype"
              :kv-transfer-storage-dtype {:storage-dtype storage-dtype}))
-    (->PagedGeometry (positive-integer! :layers layers)
-                     (positive-integer! :page-size page-size)
-                     (positive-integer! :physical-pages physical-pages)
-                     (positive-integer! :key-elements-per-token key-elements-per-token)
-                     (positive-integer! :value-elements-per-token value-elements-per-token)
+    ;; the largest quantity any derived value can reach: every layer buffer's extent, the whole
+    ;; pool's continuation, and its byte count; smaller page sets are bounded by these
+    (let [page-elements (exact :+ (exact :* page-size key-per-token)
+                               (exact :* page-size value-per-token))
+          pool-elements (exact :* physical-pages page-elements)
+          all-elements (exact :* layers pool-elements)]
+      (exact :* all-elements (dtype/bytes-of storage-dtype)))
+    (->PagedGeometry layers page-size physical-pages key-per-token value-per-token
                      storage-dtype)))
 
 (defn validate-geometry!
@@ -135,18 +157,28 @@
                                 :ownership :replica}))
           devices)))
 
+(defn- serialized-devices
+  "Endpoints whose stated transfer capabilities serialize transfers with compute. Such a leg
+   also occupies the device's compute lane in the simulation, so the plan never claims an
+   overlap the hardware contract rules out."
+  [capabilities devices]
+  (vec (filter #(true? (get-in capabilities [% :physically-serialized?])) devices)))
+
 (defn transfer
   "The transfer steps of one continuation: one `DistributedPlan` transfer leg per layer, in
    layer order, each depending on `dependencies` (page reservation on the target, the decode
-   event that produced the pages) and on nothing else; legs of one continuation serialize on
-   their route's links, so a per-layer compute loop on the target may consume layer `l` while
-   layer `l+1` is in flight. Returns `{:value :steps :ranges :bytes}`; `:value` is the
-   continuation's page-set identity the plan must declare with `value-of`."
-  [{:keys [id source target route geometry pages dependencies attributes]
-    :or {dependencies [] attributes {}}}]
+   event that produced the pages) and on nothing else. Legs serialize on their route's links;
+   whether a per-layer compute loop on the target overlaps a leg in flight is decided by the
+   endpoints' stated transfer capabilities (`capabilities`: device → validated capability map):
+   a physically serialized endpoint's compute lane is reserved for the leg as well.
+   Returns `{:value :steps :ranges :bytes}`; `:value` is the continuation's page-set identity
+   the plan must declare with `value-of`."
+  [{:keys [id source target route geometry pages dependencies attributes capabilities]
+    :or {dependencies [] attributes {} capabilities {}}}]
   (let [geometry (validate-geometry! geometry)
         pages (pages! geometry pages)
         per-layer (layer-bytes geometry pages)
+        serialized (serialized-devices capabilities [source target])
         value id]
     (when (nil? id)
       (fail! "kv transfer requires an identity" :kv-transfer-id {}))
@@ -157,12 +189,42 @@
                     (distributed/transfer-step
                      {:id (leg-id id layer) :source source :target target :route route
                       :value value :bytes per-layer :dependencies (vec dependencies)
-                      :attributes (assoc attributes :kv-transfer id :layer layer
-                                         :pages pages)}))
+                      :attributes (cond-> (assoc attributes :kv-transfer id :layer layer
+                                                 :pages pages)
+                                    (seq serialized) (assoc :serialized-on serialized))}))
                   (range (:layers geometry)))}))
 
-(defn certified-bytes
-  "Bytes a certified plan moves for continuation `id`, recomputed from its legs."
-  [certified id]
-  (reduce + 0 (map :bytes (filter #(= id (get-in % [:attributes :kv-transfer]))
-                                  (get-in certified [:plan :steps])))))
+(defn certificate
+  "The KV witness of continuation `id`: canonical geometry, pages, ranges and the per-layer
+   byte count, all derived here. `verify!` recomputes it and checks the plan's legs against it."
+  [id geometry pages]
+  (let [geometry (validate-geometry! geometry)
+        pages (pages! geometry pages)]
+    {:kv-transfer id
+     :geometry (into {} geometry)
+     :pages pages
+     :ranges (ranges geometry pages)
+     :layer-bytes (layer-bytes geometry pages)
+     :bytes (total-bytes geometry pages)}))
+
+(defn verify!
+  "Check a certified `DistributedPlan` against a KV certificate: the certificate is recomputed
+   from its own geometry and pages, and the plan holds exactly one leg per layer for the
+   continuation, in layer order, each moving that layer's derived bytes. Returns the bytes."
+  [certified {:keys [kv-transfer pages] witness-geometry :geometry :as witness}]
+  (let [expected (certificate kv-transfer (geometry witness-geometry) pages)
+        legs (filterv #(= kv-transfer (get-in % [:attributes :kv-transfer]))
+                      (get-in certified [:plan :steps]))]
+    (when-not (= expected witness)
+      (fail! "kv transfer certificate does not match its geometry and pages"
+             :kv-transfer-certificate {:expected expected :actual witness}))
+    (when-not (and (= (:layers (:geometry expected)) (count legs))
+                   (= (range (count legs)) (map #(get-in % [:attributes :layer]) legs))
+                   (every? #(= (:layer-bytes expected) (:bytes %)) legs)
+                   (every? #(= (:pages expected) (get-in % [:attributes :pages])) legs))
+      (fail! "certified plan legs disagree with the kv transfer certificate"
+             :kv-transfer-legs
+             {:expected {:layers (:layers (:geometry expected))
+                         :layer-bytes (:layer-bytes expected) :pages (:pages expected)}
+              :legs (mapv #(select-keys % [:id :bytes :attributes]) legs)}))
+    (:bytes expected)))

--- a/src/raster/compiler/ir/kv_transfer.clj
+++ b/src/raster/compiler/ir/kv_transfer.clj
@@ -1,0 +1,168 @@
+(ns raster.compiler.ir.kv-transfer
+  "A continuation's key/value pages as a certified cross-device transfer plan.
+
+   Rung D8 of the north star. The plan owns no transport: it derives, from checked paged
+   geometry, the byte-exact set of resident ranges that move and the `DistributedPlan` transfer
+   steps that carry them — one leg per layer, so a transfer interleaves with a per-layer decode
+   loop on the target. Bytes are derived from geometry and never stated by the caller; the
+   distributed certificate recomputes them.
+
+   Geometry (position-major caches, one K and one V buffer per layer, as
+   `raster.compiler.ir.paged-kv-append` lays them out): a page holds `page-size` token
+   positions; token position `t` of a layer buffer occupies elements
+   `[t·elements-per-token, (t+1)·elements-per-token)`. A page `p` is therefore the contiguous
+   element range `[p·page-size·elements-per-token, (p+1)·page-size·elements-per-token)` of each
+   layer buffer, and a continuation's pages need not be contiguous: the range list is the
+   fragmented transfer the runtime executes with `upload-ranges!`/`download-ranges!`/
+   `copy-range!`, or a peer route executes over a socket, byte for byte."
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.ir.abstract-value :as abstract-value]
+            [raster.compiler.ir.distributed-plan :as distributed]
+            [raster.compiler.ir.validate :refer [fail!]]))
+
+(defrecord PagedGeometry
+           [layers page-size physical-pages key-elements-per-token value-elements-per-token
+            storage-dtype])
+
+(defn paged-geometry?
+  [value]
+  (instance? PagedGeometry value))
+
+(defn- positive-integer!
+  [field value]
+  (when-not (and (integer? value) (pos? value))
+    (fail! "paged geometry extents must be positive integers"
+           :kv-transfer-geometry {:field field :value value}))
+  (long value))
+
+(defn geometry
+  "Checked paged geometry. `storage-dtype` is the cache's storage dtype (`:half` for an FP16
+   page pool); byte counts follow from it, never from the arithmetic dtype."
+  [{:keys [layers page-size physical-pages key-elements-per-token value-elements-per-token
+           storage-dtype]}]
+  (let [storage-dtype (dtype/canon storage-dtype)]
+    (when-not (dtype/known? storage-dtype)
+      (fail! "paged geometry requires a known storage dtype"
+             :kv-transfer-storage-dtype {:storage-dtype storage-dtype}))
+    (->PagedGeometry (positive-integer! :layers layers)
+                     (positive-integer! :page-size page-size)
+                     (positive-integer! :physical-pages physical-pages)
+                     (positive-integer! :key-elements-per-token key-elements-per-token)
+                     (positive-integer! :value-elements-per-token value-elements-per-token)
+                     storage-dtype)))
+
+(defn validate-geometry!
+  [value]
+  (when-not (paged-geometry? value)
+    (fail! "expected a PagedGeometry value" :kv-transfer-geometry-type {:actual (type value)}))
+  (geometry value))
+
+(defn- pages!
+  "Pages of one continuation: a vector of distinct physical page indices in transfer order."
+  [{:keys [physical-pages]} pages]
+  (when-not (and (vector? pages) (seq pages)
+                 (every? #(and (integer? %) (<= 0 % (dec physical-pages))) pages)
+                 (= (count pages) (count (distinct pages))))
+    (fail! "continuation pages must be distinct physical page indices inside the page pool"
+           :kv-transfer-pages {:pages pages :physical-pages physical-pages}))
+  (mapv long pages))
+
+(defn page-elements
+  "Elements one page occupies in a layer buffer with `elements-per-token` elements per token."
+  [{:keys [page-size]} elements-per-token]
+  (* (long page-size) (long elements-per-token)))
+
+(defn layer-bytes
+  "Bytes one layer's K and V pages of a continuation occupy."
+  [{:keys [key-elements-per-token value-elements-per-token storage-dtype] :as geometry} pages]
+  (let [pages (pages! geometry pages)
+        element-bytes (long (dtype/bytes-of storage-dtype))]
+    (* (count pages)
+       (+ (page-elements geometry key-elements-per-token)
+          (page-elements geometry value-elements-per-token))
+       element-bytes)))
+
+(defn total-bytes
+  [{:keys [layers] :as geometry} pages]
+  (* (long layers) (layer-bytes geometry pages)))
+
+(defn ranges
+  "The fragmented element ranges of a continuation, one entry per (layer, buffer, page):
+   `{:layer l :buffer :key|:value :page p :element e :elements n}` in transfer order (layer-major,
+   K before V, pages in the continuation's order). `:element` is the page's first element in
+   the layer buffer, the same on the source and the target when both pools share the geometry;
+   a target with a different page assignment rewrites `:page`/`:element` per entry."
+  [{:keys [layers key-elements-per-token value-elements-per-token] :as geometry} pages]
+  (let [geometry (validate-geometry! geometry)
+        pages (pages! geometry pages)]
+    (vec (for [layer (range layers)
+               [buffer per-token] [[:key key-elements-per-token] [:value value-elements-per-token]]
+               page pages
+               :let [n (page-elements geometry per-token)]]
+           {:layer layer :buffer buffer :page page :element (* page n) :elements n}))))
+
+(defn- leg-id
+  [id layer]
+  (keyword (str (name id) "-layer-" layer)))
+
+(defn- continuation-elements
+  [{:keys [layers key-elements-per-token value-elements-per-token] :as geometry} pages]
+  (* (long layers) (count pages)
+     (+ (page-elements geometry key-elements-per-token)
+        (page-elements geometry value-elements-per-token))))
+
+(defn value-of
+  "The AbstractValue a `DistributedPlan` declares for the moving pages: the storage dtype and
+   the flat element shape of one continuation across every layer, replicated over `devices`
+   (the source that owns it and every target that receives it)."
+  [{:keys [storage-dtype] :as geometry} pages devices]
+  (let [geometry (validate-geometry! geometry)
+        pages (pages! geometry pages)]
+    (abstract-value/tensor {:dtype storage-dtype :shape [(continuation-elements geometry pages)]
+                            :representation {:kind :plain} :memory-space :device
+                            :sharding {:kind :replicated :devices (vec devices)}
+                            :ownership :owned})))
+
+(defn shards
+  "The plan's physical placements of continuation `id`: one full replica per device."
+  [id geometry pages devices]
+  (let [geometry (validate-geometry! geometry)
+        pages (pages! geometry pages)
+        elements (continuation-elements geometry pages)]
+    (mapv (fn [device]
+            (distributed/shard {:id (keyword (str (name id) "-on-" (name device)))
+                                :value id :device device :offsets [0] :shape [elements]
+                                :ownership :replica}))
+          devices)))
+
+(defn transfer
+  "The transfer steps of one continuation: one `DistributedPlan` transfer leg per layer, in
+   layer order, each depending on `dependencies` (page reservation on the target, the decode
+   event that produced the pages) and on nothing else; legs of one continuation serialize on
+   their route's links, so a per-layer compute loop on the target may consume layer `l` while
+   layer `l+1` is in flight. Returns `{:value :steps :ranges :bytes}`; `:value` is the
+   continuation's page-set identity the plan must declare with `value-of`."
+  [{:keys [id source target route geometry pages dependencies attributes]
+    :or {dependencies [] attributes {}}}]
+  (let [geometry (validate-geometry! geometry)
+        pages (pages! geometry pages)
+        per-layer (layer-bytes geometry pages)
+        value id]
+    (when (nil? id)
+      (fail! "kv transfer requires an identity" :kv-transfer-id {}))
+    {:value value
+     :bytes (* (long (:layers geometry)) per-layer)
+     :ranges (ranges geometry pages)
+     :steps (mapv (fn [layer]
+                    (distributed/transfer-step
+                     {:id (leg-id id layer) :source source :target target :route route
+                      :value value :bytes per-layer :dependencies (vec dependencies)
+                      :attributes (assoc attributes :kv-transfer id :layer layer
+                                         :pages pages)}))
+                  (range (:layers geometry)))}))
+
+(defn certified-bytes
+  "Bytes a certified plan moves for continuation `id`, recomputed from its legs."
+  [certified id]
+  (reduce + 0 (map :bytes (filter #(= id (get-in % [:attributes :kv-transfer]))
+                                  (get-in certified [:plan :steps])))))

--- a/src/raster/compiler/ir/transfer_capabilities.clj
+++ b/src/raster/compiler/ir/transfer_capabilities.clj
@@ -1,0 +1,84 @@
+(ns raster.compiler.ir.transfer-capabilities
+  "The physical transfer contract a backend states per device: queryable facts a serving
+   scheduler can plan against without inferring overlap from the shape of an API.
+
+   Every fact is declared, none is defaulted: a backend that cannot state one of them does not
+   satisfy the contract. `physically-serialized?` is stated separately from the queue fact so a
+   backend with a logical transfer queue that maps onto its compute queue says so."
+  (:require [raster.compiler.ir.validate :refer [fail!]]))
+
+(def submissions
+  "How a transfer is submitted: as device work completing through an event, or as a host copy
+   that has completed when the call returns."
+  #{:device-event :inline-host-copy})
+
+(def host-stagings
+  "Who owns the host-side staging copy of a transfer while it is in flight."
+  #{:runtime-owned-native :caller-owned :none})
+
+(def queue-orderings #{:in-order :out-of-order :inline})
+
+(def host-memory-requirements
+  "What host memory a transfer source or destination must be."
+  #{:any :pinned :shared})
+
+(def event-semantics
+  "What awaiting a transfer's completion token establishes."
+  #{:device-completion :already-complete})
+
+(def peer-mechanisms #{:direct-copy :staged-through-host})
+
+(def facts
+  [:submission :host-staging :independent-physical-queue? :queue-ordering
+   :async-h2d? :async-d2h? :peer-transfer? :peer-mechanisms
+   :event-semantics :host-lease-until-await? :host-memory :physically-serialized?])
+
+(defn validate!
+  "Validate a backend's transfer capability map; returns it unchanged."
+  [capabilities]
+  (when-not (map? capabilities)
+    (fail! "transfer capabilities must be a map" :transfer-capabilities-type
+           {:actual (type capabilities)}))
+  (let [missing (remove #(contains? capabilities %) facts)]
+    (when (seq missing)
+      (fail! "transfer capabilities must state every fact"
+             :transfer-capabilities-missing {:missing (vec missing)})))
+  (let [{:keys [submission host-staging independent-physical-queue? queue-ordering async-h2d?
+                async-d2h? peer-transfer? host-lease-until-await? host-memory
+                physically-serialized?]
+         mechanisms :peer-mechanisms
+         semantics :event-semantics} capabilities
+        check (fn [fact ok? value]
+                (when-not ok?
+                  (fail! (str "transfer capability " fact " has an unsupported value")
+                         :transfer-capabilities-value {:fact fact :value value})))]
+    (check :submission (contains? submissions submission) submission)
+    (check :host-staging (contains? host-stagings host-staging) host-staging)
+    (check :independent-physical-queue? (boolean? independent-physical-queue?)
+           independent-physical-queue?)
+    (check :queue-ordering (contains? queue-orderings queue-ordering) queue-ordering)
+    (check :async-h2d? (boolean? async-h2d?) async-h2d?)
+    (check :async-d2h? (boolean? async-d2h?) async-d2h?)
+    (check :peer-transfer? (boolean? peer-transfer?) peer-transfer?)
+    (check :peer-mechanisms (and (vector? mechanisms) (every? peer-mechanisms mechanisms))
+           mechanisms)
+    (check :event-semantics (contains? event-semantics semantics) semantics)
+    (check :host-lease-until-await? (boolean? host-lease-until-await?) host-lease-until-await?)
+    (check :host-memory (contains? host-memory-requirements host-memory) host-memory)
+    (check :physically-serialized? (boolean? physically-serialized?) physically-serialized?)
+    ;; consistency: a backend without an independent physical queue is serialized; a peer
+    ;; route needs at least one mechanism; an inline host copy has no asynchrony to report
+    (when (and (not independent-physical-queue?) (not physically-serialized?))
+      (fail! "a transfer queue that is not physically independent is physically serialized"
+             :transfer-capabilities-consistency
+             {:independent-physical-queue? independent-physical-queue?
+              :physically-serialized? physically-serialized?}))
+    (when (not= peer-transfer? (boolean (seq mechanisms)))
+      (fail! "peer transfer support and its mechanisms must agree"
+             :transfer-capabilities-consistency
+             {:peer-transfer? peer-transfer? :peer-mechanisms mechanisms}))
+    (when (and (= :inline-host-copy submission) (or async-h2d? async-d2h?))
+      (fail! "an inline host copy is complete on return; it is not asynchronous"
+             :transfer-capabilities-consistency
+             {:submission submission :async-h2d? async-h2d? :async-d2h? async-d2h?})))
+  capabilities)

--- a/src/raster/compiler/ir/transfer_capabilities.clj
+++ b/src/raster/compiler/ir/transfer_capabilities.clj
@@ -66,13 +66,30 @@
     (check :host-lease-until-await? (boolean? host-lease-until-await?) host-lease-until-await?)
     (check :host-memory (contains? host-memory-requirements host-memory) host-memory)
     (check :physically-serialized? (boolean? physically-serialized?) physically-serialized?)
-    ;; consistency: a backend without an independent physical queue is serialized; a peer
-    ;; route needs at least one mechanism; an inline host copy has no asynchrony to report
-    (when (and (not independent-physical-queue?) (not physically-serialized?))
-      (fail! "a transfer queue that is not physically independent is physically serialized"
+    ;; consistency: an inline copy, or an in-order queue shared with compute, serializes
+    ;; transfers with compute (an out-of-order shared queue may still overlap them); a peer
+    ;; route needs at least one mechanism; an inline host copy has no asynchrony, no device
+    ;; event and no queue order to report, and a device-event submission has all three
+    (when (and (or (= :inline queue-ordering)
+                   (and (not independent-physical-queue?) (= :in-order queue-ordering)))
+               (not physically-serialized?))
+      (fail! "an inline copy or an in-order queue shared with compute is physically serialized"
              :transfer-capabilities-consistency
              {:independent-physical-queue? independent-physical-queue?
+              :queue-ordering queue-ordering
               :physically-serialized? physically-serialized?}))
+    (when (and (= :inline-host-copy submission)
+               (not (and (= :inline queue-ordering) (= :already-complete semantics))))
+      (fail! "an inline host copy has inline ordering and is complete when it returns"
+             :transfer-capabilities-consistency
+             {:submission submission :queue-ordering queue-ordering
+              :event-semantics semantics}))
+    (when (and (= :device-event submission)
+               (not (and (not= :inline queue-ordering) (= :device-completion semantics))))
+      (fail! "a device-event submission is queued device work completing through its event"
+             :transfer-capabilities-consistency
+             {:submission submission :queue-ordering queue-ordering
+              :event-semantics semantics}))
     (when (not= peer-transfer? (boolean (seq mechanisms)))
       (fail! "peer transfer support and its mechanisms must agree"
              :transfer-capabilities-consistency

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -1710,15 +1710,16 @@
    :independent-physical-queue? true
    :queue-ordering :in-order
    ;; H2D/D2H are submitted as device work and complete through an event; no peer route is
-   ;; implemented (a device-to-device move stages through the host); the host source of an
-   ;; upload is copied into runtime-owned native staging before the event is visible, so the
-   ;; caller's array is free on return and any host memory works.
+   ;; implemented (a device-to-device move stages through the host). An upload's host source
+   ;; is copied into runtime-owned native staging before the event is visible, but a download's
+   ;; host destination is written only when the event is awaited: the caller keeps the host
+   ;; memory alive until then. Any host memory works.
    :async-h2d? true
    :async-d2h? true
    :peer-transfer? false
    :peer-mechanisms []
    :event-semantics :device-completion
-   :host-lease-until-await? false
+   :host-lease-until-await? true
    :host-memory :any
    :physically-serialized? false})
 

--- a/src/raster/gpu/ocl_runtime.clj
+++ b/src/raster/gpu/ocl_runtime.clj
@@ -1708,7 +1708,19 @@
   {:submission :device-event
    :host-staging :runtime-owned-native
    :independent-physical-queue? true
-   :queue-ordering :in-order})
+   :queue-ordering :in-order
+   ;; H2D/D2H are submitted as device work and complete through an event; no peer route is
+   ;; implemented (a device-to-device move stages through the host); the host source of an
+   ;; upload is copied into runtime-owned native staging before the event is visible, so the
+   ;; caller's array is free on return and any host memory works.
+   :async-h2d? true
+   :async-d2h? true
+   :peer-transfer? false
+   :peer-mechanisms []
+   :event-semantics :device-completion
+   :host-lease-until-await? false
+   :host-memory :any
+   :physically-serialized? false})
 
 (defn reset-graph-events!
   "Discard the most recent OpenCL profiling sample and release its native events."

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -939,18 +939,19 @@
   "Return the Level Zero runtime's physical transfer execution contract."
   []
   {:submission :inline-host-copy
-   :host-staging :caller-owned
+   ;; Transfers are inline host copies into shared device allocations: complete on return, so
+   ;; there is no in-flight staging copy, no asynchrony, no peer route, no event to await and no
+   ;; physical queue of their own; the host argument may be any JVM array or segment.
+   :host-staging :none
    :independent-physical-queue? false
    :queue-ordering :inline
-   ;; Transfers are inline host copies into shared allocations: complete on return, no
-   ;; asynchrony, no peer route, no event to await, no physical queue of their own.
    :async-h2d? false
    :async-d2h? false
    :peer-transfer? false
    :peer-mechanisms []
    :event-semantics :already-complete
    :host-lease-until-await? false
-   :host-memory :shared
+   :host-memory :any
    :physically-serialized? true})
 
 (defn upload-range!

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -941,7 +941,17 @@
   {:submission :inline-host-copy
    :host-staging :caller-owned
    :independent-physical-queue? false
-   :queue-ordering :inline})
+   :queue-ordering :inline
+   ;; Transfers are inline host copies into shared allocations: complete on return, no
+   ;; asynchrony, no peer route, no event to await, no physical queue of their own.
+   :async-h2d? false
+   :async-d2h? false
+   :peer-transfer? false
+   :peer-mechanisms []
+   :event-semantics :already-complete
+   :host-lease-until-await? false
+   :host-memory :shared
+   :physically-serialized? true})
 
 (defn upload-range!
   "Copy `elements` elements from `src` (JVM array or MemorySegment, starting at element

--- a/test/raster/compiler/ir/kv_transfer_device_test.clj
+++ b/test/raster/compiler/ir/kv_transfer_device_test.clj
@@ -1,0 +1,60 @@
+(ns raster.compiler.ir.kv-transfer-device-test
+  "The range list a KV transfer plan derives is executable byte for byte by the resident range
+   API: a continuation's pages move from one page pool to another with `copy-range!`, and
+   nothing else in the target pool changes."
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kv-transfer :as kv]
+            [raster.gpu.core :as gpu]
+            [raster.gpu.device-probe :as device-probe]))
+
+(def ^:private geometry
+  (kv/geometry {:layers 2 :page-size 4 :physical-pages 6
+                :key-elements-per-token 8 :value-elements-per-token 8
+                :storage-dtype :float}))
+
+(defn- pool-buffers
+  "One K and one V buffer per layer, each `physical-pages × page-size × elements-per-token`."
+  [prefix]
+  (into {}
+        (for [layer (range (:layers geometry))
+              [buffer per-token] [[:key (:key-elements-per-token geometry)]
+                                  [:value (:value-elements-per-token geometry)]]]
+          [(keyword (str prefix "-" layer "-" (name buffer)))
+           [:float (* (:physical-pages geometry) (kv/page-elements geometry per-token)) nil]])))
+
+(defn- buffer-key [prefix {:keys [layer buffer]}]
+  (keyword (str prefix "-" layer "-" (name buffer))))
+
+(deftest a-continuation-moves-between-page-pools-by-its-range-list
+  (if-not @device-probe/opencl-available?
+    (device-probe/opencl-skip! "KV transfer ranges on OpenCL")
+    (let [session (gpu/make-session :ocl:0)
+          pages [4 1]
+          ranges (kv/ranges geometry pages)
+          n (* (:physical-pages geometry) (kv/page-elements geometry 8))]
+      (try
+        (gpu/alloc! session (merge (pool-buffers "source") (pool-buffers "target")))
+        (let [sources (into {} (for [[k _] (pool-buffers "source")]
+                                 [k (float-array (map #(float (+ % (* 1000 (hash k)))) (range n)))]))
+              targets (into {} (for [[k _] (pool-buffers "target")]
+                                 [k (float-array n (float -1.0))]))]
+          (doseq [[k array] (merge sources targets)]
+            (gpu/upload-range! session k array {:elements n}))
+          (doseq [{:keys [element elements] :as range} ranges]
+            (gpu/copy-range! session (buffer-key "source" range) (buffer-key "target" range)
+                             {:src-element element :dst-element element :elements elements}))
+          (testing "every page of the continuation arrived and nothing else was written"
+            (doseq [[k _] (pool-buffers "target")]
+              (let [layer (Long/parseLong (second (re-find #"target-(\d+)-" (name k))))
+                    buffer (keyword (last (clojure.string/split (name k) #"-")))
+                    source (get sources (keyword (str "source-" layer "-" (name buffer))))
+                    moved (float-array n)
+                    _ (gpu/download-range! session k moved {:elements n})
+                    page-of (fn [e] (quot e (kv/page-elements geometry 8)))]
+                (dotimes [e n]
+                  (is (= (if (some #{(page-of e)} pages) (aget source e) (float -1.0))
+                         (aget moved e)))))))
+          (testing "the certified byte count equals the bytes the range list moved"
+            (is (= (kv/total-bytes geometry pages)
+                   (* 4 (reduce + (map :elements ranges)))))))
+        (finally (gpu/close-session! session))))))

--- a/test/raster/compiler/ir/kv_transfer_test.clj
+++ b/test/raster/compiler/ir/kv_transfer_test.clj
@@ -1,0 +1,79 @@
+(ns raster.compiler.ir.kv-transfer-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.distributed-plan :as distributed]
+            [raster.compiler.ir.kv-transfer :as kv]))
+
+;; gemma-270m's KV shape: one kv-head of 256, FP16 page pool, 16 tokens per page
+(def ^:private geometry
+  (kv/geometry {:layers 3 :page-size 16 :physical-pages 64
+                :key-elements-per-token 256 :value-elements-per-token 256
+                :storage-dtype :half}))
+
+(deftest bytes-follow-the-geometry
+  (testing "one page of one buffer is page-size × elements-per-token elements"
+    (is (= 4096 (kv/page-elements geometry 256))))
+  (testing "a layer's K and V pages, in FP16"
+    ;; 3 pages × (4096 + 4096) elements × 2 bytes
+    (is (= (* 3 8192 2) (kv/layer-bytes geometry [5 2 9]))))
+  (testing "all layers"
+    (is (= (* 3 3 8192 2) (kv/total-bytes geometry [5 2 9])))))
+
+(deftest ranges-are-the-fragmented-transfer-in-layer-order
+  (let [ranges (kv/ranges geometry [5 2])]
+    (is (= 12 (count ranges)) "3 layers × 2 buffers × 2 pages")
+    (is (= [{:layer 0 :buffer :key :page 5 :element (* 5 4096) :elements 4096}
+            {:layer 0 :buffer :key :page 2 :element (* 2 4096) :elements 4096}
+            {:layer 0 :buffer :value :page 5 :element (* 5 4096) :elements 4096}
+            {:layer 0 :buffer :value :page 2 :element (* 2 4096) :elements 4096}]
+           (take 4 ranges))
+        "layer-major, K before V, pages in the continuation's order")
+    (is (= (kv/total-bytes geometry [5 2])
+           (* 2 (reduce + (map :elements ranges))))
+        "the range list moves exactly the certified bytes")))
+
+(deftest pages-must-be-distinct-and-inside-the-pool
+  (doseq [pages [[] [64] [3 3] [-1]]]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"distinct physical page indices"
+                          (kv/ranges geometry pages)))))
+
+(defn- two-device-plan
+  [continuation]
+  (distributed/plan
+   {:id :restore
+    :mesh (distributed/mesh [{:name :data :size 2}] [:gpu-0 :gpu-1])
+    :topology (distributed/topology
+               [(distributed/device {:id :gpu-0 :memory-capacity-bytes (* 8 1024 1024 1024)})
+                (distributed/device {:id :gpu-1 :memory-capacity-bytes (* 8 1024 1024 1024)})]
+               [(distributed/link {:id :gpu-0->gpu-1 :source :gpu-0 :target :gpu-1
+                                   :bandwidth-bytes-s 1.0e9 :latency-ns 10000})])
+    :values {(:value continuation) (kv/value-of geometry [5 2 9] [:gpu-0 :gpu-1])}
+    :shards {(:value continuation) (kv/shards (:value continuation) geometry [5 2 9]
+                                              [:gpu-0 :gpu-1])}
+    :steps (into [(distributed/compute-step {:id :reserve-pages :device :gpu-1 :duration-ns 100})]
+                 (:steps continuation))
+    :outputs (mapv :id (:steps continuation))}))
+
+(deftest a-continuation-transfers-one-leg-per-layer
+  (let [continuation (kv/transfer {:id :continuation-7 :source :gpu-0 :target :gpu-1
+                                   :route [:gpu-0->gpu-1] :geometry geometry :pages [5 2 9]
+                                   :dependencies [:reserve-pages]})
+        certified (distributed/certify (two-device-plan continuation))
+        simulation (distributed/simulate (:plan certified))]
+    (is (= [:continuation-7-layer-0 :continuation-7-layer-1 :continuation-7-layer-2]
+           (mapv :id (:steps continuation))))
+    (is (= (kv/total-bytes geometry [5 2 9]) (:bytes continuation)))
+    (is (= (:bytes continuation) (kv/certified-bytes certified :continuation-7))
+        "the certificate recomputes the bytes from the legs")
+    (is (= (:bytes continuation) (get-in simulation [:link-transfer-bytes :gpu-0->gpu-1])))
+    (testing "legs serialize on the link and each waits only for the reservation"
+      (let [timeline (:timeline simulation)
+            starts (mapv #(get-in timeline [% :start-ns]) (mapv :id (:steps continuation)))]
+        (is (apply < starts))
+        (is (= 100 (first starts)) "the first leg starts when the reservation completes")))
+    (is (distributed/verify! certified))))
+
+(deftest a-transfer-plan-still-checks-its-route
+  (let [continuation (kv/transfer {:id :c :source :gpu-0 :target :gpu-1
+                                   :route [:gpu-1->gpu-0] :geometry geometry :pages [1]})]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"route"
+                          (two-device-plan continuation)))))

--- a/test/raster/compiler/ir/kv_transfer_test.clj
+++ b/test/raster/compiler/ir/kv_transfer_test.clj
@@ -1,7 +1,9 @@
 (ns raster.compiler.ir.kv-transfer-test
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.ir.distributed-plan :as distributed]
-            [raster.compiler.ir.kv-transfer :as kv]))
+            [raster.compiler.ir.kv-transfer :as kv]
+            [raster.gpu.ocl-runtime :as ocl]
+            [raster.gpu.ze-runtime :as ze]))
 
 ;; gemma-270m's KV shape: one kv-head of 256, FP16 page pool, 16 tokens per page
 (def ^:private geometry
@@ -36,6 +38,12 @@
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"distinct physical page indices"
                           (kv/ranges geometry pages)))))
 
+(deftest a-geometry-whose-extents-overflow-is-refused-whole
+  (is (thrown-with-msg? clojure.lang.ExceptionInfo #"64-bit capacity"
+                        (kv/geometry {:layers 1 :page-size Long/MAX_VALUE :physical-pages 1
+                                      :key-elements-per-token 2 :value-elements-per-token 1
+                                      :storage-dtype :half}))))
+
 (defn- two-device-plan
   [continuation]
   (distributed/plan
@@ -62,8 +70,14 @@
     (is (= [:continuation-7-layer-0 :continuation-7-layer-1 :continuation-7-layer-2]
            (mapv :id (:steps continuation))))
     (is (= (kv/total-bytes geometry [5 2 9]) (:bytes continuation)))
-    (is (= (:bytes continuation) (kv/certified-bytes certified :continuation-7))
-        "the certificate recomputes the bytes from the legs")
+    (testing "the KV certificate binds geometry, pages and ranges to the plan's legs"
+      (let [witness (kv/certificate :continuation-7 geometry [5 2 9])]
+        (is (= (:bytes continuation) (kv/verify! certified witness)))
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"legs disagree"
+                              (kv/verify! (update-in certified [:plan :steps 1] assoc :bytes 1)
+                                          witness)))
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"does not match its geometry"
+                              (kv/verify! certified (assoc witness :bytes 1))))))
     (is (= (:bytes continuation) (get-in simulation [:link-transfer-bytes :gpu-0->gpu-1])))
     (testing "legs serialize on the link and each waits only for the reservation"
       (let [timeline (:timeline simulation)
@@ -77,3 +91,31 @@
                                    :route [:gpu-1->gpu-0] :geometry geometry :pages [1]})]
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"route"
                           (two-device-plan continuation)))))
+
+(deftest overlap-follows-the-endpoints-stated-capabilities
+  ;; a target that serializes transfers with compute (Level Zero today) cannot decode layer 0
+  ;; while layer 1 is in flight; an OpenCL target can
+  (let [plan-with (fn [capabilities]
+                    (let [continuation (kv/transfer {:id :c :source :gpu-0 :target :gpu-1
+                                                     :route [:gpu-0->gpu-1] :geometry geometry
+                                                     :pages [5 2 9] :dependencies [:reserve-pages]
+                                                     :capabilities {:gpu-1 capabilities}})
+                          plan (two-device-plan continuation)
+                          decode (distributed/compute-step
+                                  {:id :decode-layer-0 :device :gpu-1 :duration-ns 50000
+                                   :dependencies [:c-layer-0]})]
+                      (distributed/simulate
+                       (distributed/plan (assoc plan
+                                                :steps (conj (:steps plan) decode)
+                                                :outputs [:decode-layer-0 :c-layer-2])))))
+        overlaps? (fn [simulation]
+                    (let [timeline (:timeline simulation)
+                          decode (get timeline :decode-layer-0)
+                          leg (get timeline :c-layer-1)]
+                      (< (:start-ns decode) (:finish-ns leg))))]
+    (is (overlaps? (plan-with (ocl/transfer-capabilities))))
+    (is (not (overlaps? (plan-with (ze/transfer-capabilities)))))
+    (is (= [:gpu-1] (get-in (kv/transfer {:id :c :source :gpu-0 :target :gpu-1
+                                          :route [:gpu-0->gpu-1] :geometry geometry :pages [1]
+                                          :capabilities {:gpu-1 (ze/transfer-capabilities)}})
+                            [:steps 0 :attributes :serialized-on])))))

--- a/test/raster/compiler/ir/transfer_capabilities_test.clj
+++ b/test/raster/compiler/ir/transfer_capabilities_test.clj
@@ -1,0 +1,32 @@
+(ns raster.compiler.ir.transfer-capabilities-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.transfer-capabilities :as capabilities]))
+
+(deftest every-backend-states-the-whole-contract
+  ;; pure fact tables: no device is needed to read them
+  (require 'raster.gpu.ocl-runtime 'raster.gpu.ze-runtime)
+  (let [opencl ((resolve 'raster.gpu.ocl-runtime/transfer-capabilities))
+        level-zero ((resolve 'raster.gpu.ze-runtime/transfer-capabilities))]
+    (is (= opencl (capabilities/validate! opencl)))
+    (is (= level-zero (capabilities/validate! level-zero)))
+    (testing "the facts a scheduler plans against are honest, not inferred from the API"
+      (is (true? (:independent-physical-queue? opencl)))
+      (is (false? (:physically-serialized? opencl)))
+      (is (= :device-completion (:event-semantics opencl)))
+      (is (true? (:physically-serialized? level-zero)))
+      (is (= :already-complete (:event-semantics level-zero)))
+      (is (false? (:peer-transfer? level-zero)) "no peer route exists yet, and it says so"))))
+
+(deftest a-missing-or-contradictory-fact-is-refused
+  (let [complete (capabilities/validate! ((resolve 'raster.gpu.ocl-runtime/transfer-capabilities)))]
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"state every fact"
+                          (capabilities/validate! (dissoc complete :async-d2h?))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"physically serialized"
+                          (capabilities/validate!
+                           (assoc complete :independent-physical-queue? false
+                                  :physically-serialized? false))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"mechanisms must agree"
+                          (capabilities/validate! (assoc complete :peer-transfer? true))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not asynchronous"
+                          (capabilities/validate!
+                           (assoc complete :submission :inline-host-copy))))))

--- a/test/raster/compiler/ir/transfer_capabilities_test.clj
+++ b/test/raster/compiler/ir/transfer_capabilities_test.clj
@@ -1,24 +1,29 @@
 (ns raster.compiler.ir.transfer-capabilities-test
   (:require [clojure.test :refer [deftest is testing]]
-            [raster.compiler.ir.transfer-capabilities :as capabilities]))
+            [raster.compiler.ir.transfer-capabilities :as capabilities]
+            ;; pure fact tables: no device is needed to read them
+            [raster.gpu.ocl-runtime :as ocl]
+            [raster.gpu.ze-runtime :as ze]))
 
 (deftest every-backend-states-the-whole-contract
-  ;; pure fact tables: no device is needed to read them
-  (require 'raster.gpu.ocl-runtime 'raster.gpu.ze-runtime)
-  (let [opencl ((resolve 'raster.gpu.ocl-runtime/transfer-capabilities))
-        level-zero ((resolve 'raster.gpu.ze-runtime/transfer-capabilities))]
+  (let [opencl (ocl/transfer-capabilities)
+        level-zero (ze/transfer-capabilities)]
     (is (= opencl (capabilities/validate! opencl)))
     (is (= level-zero (capabilities/validate! level-zero)))
     (testing "the facts a scheduler plans against are honest, not inferred from the API"
       (is (true? (:independent-physical-queue? opencl)))
       (is (false? (:physically-serialized? opencl)))
       (is (= :device-completion (:event-semantics opencl)))
+      (is (true? (:host-lease-until-await? opencl))
+          "a download's host destination is written at await time")
       (is (true? (:physically-serialized? level-zero)))
       (is (= :already-complete (:event-semantics level-zero)))
+      (is (= :none (:host-staging level-zero)) "an inline copy has no in-flight staging copy")
+      (is (= :any (:host-memory level-zero)) "the host argument is any array or segment")
       (is (false? (:peer-transfer? level-zero)) "no peer route exists yet, and it says so"))))
 
 (deftest a-missing-or-contradictory-fact-is-refused
-  (let [complete (capabilities/validate! ((resolve 'raster.gpu.ocl-runtime/transfer-capabilities)))]
+  (let [complete (capabilities/validate! (ocl/transfer-capabilities))]
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"state every fact"
                           (capabilities/validate! (dissoc complete :async-d2h?))))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"physically serialized"
@@ -29,4 +34,21 @@
                           (capabilities/validate! (assoc complete :peer-transfer? true))))
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"not asynchronous"
                           (capabilities/validate!
-                           (assoc complete :submission :inline-host-copy))))))
+                           (assoc complete :submission :inline-host-copy
+                                  :queue-ordering :inline :event-semantics :already-complete
+                                  :physically-serialized? true))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"inline ordering"
+                          (capabilities/validate!
+                           (assoc (ze/transfer-capabilities) :event-semantics :device-completion))))
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"queued device work"
+                          (capabilities/validate!
+                           (assoc complete :queue-ordering :inline
+                                  :physically-serialized? true))))))
+
+(deftest an-out-of-order-shared-queue-may-overlap
+  ;; one out-of-order device queue for compute and transfers is legal and not serialized
+  (is (capabilities/validate!
+       {:submission :device-event :host-staging :none :independent-physical-queue? false
+        :queue-ordering :out-of-order :async-h2d? true :async-d2h? true
+        :peer-transfer? false :peer-mechanisms [] :event-semantics :device-completion
+        :host-lease-until-await? true :host-memory :pinned :physically-serialized? false})))


### PR DESCRIPTION
## KV continuation transfer plan; transfer capabilities as a stated contract

Rung D8 of the north star, the Raster side of the pretrained-rstr distributed-LLM handoff (items 1 and 3). Design: `.internal/design/D8_distributed_continuation_cache.md`.

### `raster.compiler.ir.kv-transfer`
From checked paged geometry (layers, page size, page pool, K/V elements per token, storage dtype) it derives:
- the byte-exact fragmented range list of a continuation's pages (`{:layer :buffer :page :element :elements}`, layer-major, K before V), which the resident range API executes as is (`copy-range!`/`upload-ranges!`/`download-ranges!`) and a peer route executes over a socket;
- the `DistributedPlan` transfer legs, one per layer, each depending only on the caller's dependencies (page reservation, decode event), so a per-layer decode loop on the target overlaps layers in flight;
- the continuation's `AbstractValue` (replicated over source and targets) and its replica shards.

Bytes are derived from geometry, never stated; `certify`/`verify!` recompute them from the legs, and the plan's route and shard legality apply unchanged.

### `raster.compiler.ir.transfer-capabilities`
The physical transfer contract a backend must state per device: submission, staging ownership, independent physical queue, ordering, async H2D/D2H, peer routes and mechanisms, event semantics, host lease, host memory requirement, physical serialization, with consistency rules (no independent queue ⇒ serialized; peer support ⇔ mechanisms; inline copies are not asynchronous). OpenCL and Level Zero state every fact honestly (Level Zero: inline host copies into shared allocations, serialized, no peer route).

### Review (Codex, one pass, eight findings fixed)
The certificate now binds geometry, pages and ranges to the legs (`kv/certificate` + `kv/verify!`; a tampered leg or witness is refused by name); geometry extents are checked arithmetic; OpenCL states `:host-lease-until-await? true` (a download's host destination is written at await) and Level Zero `:host-staging :none` / `:host-memory :any`; the contract rules distinguish an out-of-order shared queue (may overlap) from inline or in-order shared queues (serialized) and tie submission to ordering and event semantics; a leg to or from a physically serialized endpoint reserves that device's compute lane in the simulation, so the plan claims per-layer overlap only where the stated capabilities allow it.

### Tests
Geometry bytes, range order and totals, page validation, a certified two-device plan with per-layer legs (simulation, certificate recomputation, route legality), the capability contract for both runtimes plus refusals, and an OpenCL device test moving a continuation between two page pools by the derived range list.

https://claude.ai/code/session_01Vtm1xB9JmpaxJMEWCAcQWm
