### PR TITLE
Expose semantic contraction extents in typed dispatch ABI

### DIFF
--- a/src/raster/compiler/backend/gpu/opencl_pass.clj
+++ b/src/raster/compiler/backend/gpu/opencl_pass.clj
@@ -615,14 +615,13 @@
                     (try
                       ;; The scheduled SegRed carries its equation's dtype; a double contraction
                       ;; inside a float program routes at its own precision, not the program's.
-                      (croute/route-static-typed-contraction-dispatch
+                      (croute/route-typed-contraction-dispatch
                        typed-algorithm bound-sr
                        :dtype (:dtype bound-sr) :tile (:tile schedule) :desc target-desc
                        :precision (:precision schedule))
                       (catch clojure.lang.ExceptionInfo exception
                         (let [reason (:reason (ex-data exception))]
-                          (if (contains? #{:typed-contraction-dispatch-dynamic-scalar
-                                           :typed-contraction-dispatch-invoke-protocol}
+                          (if (contains? #{:typed-contraction-dispatch-invoke-protocol}
                                          reason)
                             (do
                               (swap! stats update-in [:typed-contraction-dispatch-declines reason]

--- a/src/raster/compiler/ir/kernel_graph.clj
+++ b/src/raster/compiler/ir/kernel_graph.clj
@@ -102,7 +102,10 @@
                           {:scalar-arguments scalar-arguments})))
         (doseq [[slot id] pointer-pairs]
           (let [{:keys [dtype role]} (get external-by-id id)
-                expected-kind (if (= :input role) :input :output)]
+                expected-kind (case role
+                                :input :input
+                                :output :output
+                                :inout :inout)]
             (when-not (= dtype (:dtype slot))
               (throw (ex-info "kernel graph ABI storage dtype differs from its buffer"
                               {:buffer id :buffer-dtype dtype :slot slot})))

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -18,6 +18,7 @@
    :fallback-reason, :scheme (quant decode) and :pre-steps (inserted layout rearranges)."
   (:require [raster.compiler.core.dtype :as dtype]
             [raster.compiler.core.op-descriptor :as od]
+            [raster.compiler.core.util :as util]
             [clojure.string :as str]
             [raster.compiler.passes.parallel.contract-lower :as cl]
             [raster.compiler.backend.gpu.segop-opencl :as sco]
@@ -327,7 +328,7 @@
         free-bounds (map second free-axes)
         nseg (if (every? number? free-bounds)
                (reduce * 1 free-bounds)
-               (reduce (fn [a b] (list 'clojure.core/* a b)) free-bounds))
+               (apply klaunch/product free-bounds))
         ;; memoized so the cond's test arm doesn't regenerate the kernel
         ;; A TypedSOAC result transform projects to an epilogue in the form's trailing opts;
         ;; an explicit :epilogue kwarg overrides it at this temporary leaf boundary.
@@ -741,8 +742,62 @@
        (filter (comp public-interface-slot? first))
        vec))
 
+(defn- ordered-distinct
+  [values]
+  (reduce (fn [result value]
+            (if (some #(= value %) result) result (conj result value)))
+          [] values))
+
+(defn- semantic-scalar-interface
+  "Construct the scalar part of a typed contraction's public ABI from semantic inputs.
+
+   Axis-bound inputs precede other scalar captures and follow axis order. A target leaf may bake
+   one of these values or expose it under a different parameter name; neither changes the logical
+   call. Conversely, leaf-derived values such as a flattened segment count are deliberately absent
+   and remain graph-private expressions over this interface."
+  [candidates operation operation-id existing-arguments]
+  (let [axis-bounds (mapv :bound (get-in operation [:space :dims]))
+        extent-scalars (ordered-distinct
+                        (mapcat #(sort-by str (util/free-syms %)) axis-bounds))
+        semantic-scalars (segop/operation-scalars operation)
+        parameter-scalars (sort-by str (remove (set extent-scalars) semantic-scalars))
+        ordered-scalars (filterv semantic-scalars (into extent-scalars parameter-scalars))]
+    (into []
+          (comp
+           (remove (set existing-arguments))
+           (map
+            (fn [argument]
+              (let [slots (into []
+                                (comp
+                                 (mapcat (fn [candidate]
+                                           (map vector (get-in candidate [:artifact :abi])
+                                                (get-in candidate [:artifact :arguments]))))
+                                 (filter (fn [[slot value]]
+                                           (and (= :scalar (:kind slot))
+                                                (= argument value))))
+                                 (map first))
+                                candidates)
+                    views (mapv #(select-keys % [:kind :dtype :kernel-dtype]) slots)]
+                (when (empty? slots)
+                  (throw (ex-info
+                          "typed contraction semantic scalar is absent from every candidate ABI"
+                          {:reason :typed-contraction-candidate-missing-semantic-scalar
+                           :operation operation-id :argument argument})))
+                (when-not (apply = views)
+                  (throw (ex-info
+                          "typed contraction candidates disagree on a semantic scalar ABI"
+                          {:reason :typed-contraction-candidate-scalar-semantics
+                           :operation operation-id :argument argument :slots slots})))
+                [(-> (first slots)
+                     (assoc :name argument :c-name (name argument)
+                            :role (if (some #{argument} extent-scalars)
+                                    :extent :parameter))
+                     (dissoc :binding :field :aliasing :alignment))
+                 argument]))))
+          ordered-scalars)))
+
 (defn- common-logical-interface
-  [candidates operation-id]
+  [candidates operation operation-id]
   (let [interfaces (mapv (comp artifact-logical-interface :artifact) candidates)
         arguments (mapv second (first interfaces))]
     (doseq [[candidate interface] (map vector candidates interfaces)]
@@ -773,12 +828,16 @@
                  (nil? aliasing) (dissoc :aliasing)
                  alignment (assoc :alignment alignment)
                  (nil? alignment) (dissoc :alignment))))
-           (range (count arguments)) arguments)]
+           (range (count arguments)) arguments)
+          scalar-interface (semantic-scalar-interface candidates operation operation-id arguments)
+          abi (into abi (map first) scalar-interface)
+          arguments (into arguments (map second) scalar-interface)]
       (kabi/validate! abi)
-      {:abi abi :arguments arguments})))
+      {:abi abi :arguments arguments
+       :public-scalars (into #{} (map second) scalar-interface)})))
 
-(defn- static-private-scalars!
-  [candidate operation-id]
+(defn- bindable-private-scalars!
+  [candidate operation-id public-scalars]
   (when (:invoke candidate)
     (throw (ex-info "typed contraction candidate uses a non-graph leaf invocation protocol"
                     {:reason :typed-contraction-dispatch-invoke-protocol
@@ -791,12 +850,12 @@
           :when (and (= :scalar (:kind slot))
                      (not (public-interface-slot? slot)))]
     (when-not (and (contains? #{:int :long} (:kernel-dtype slot))
-                   (or (integer? compiler-value)
-                       (and (klaunch/expression? compiler-value)
-                            (empty? (klaunch/expression-references compiler-value)))))
+                   (klaunch/expression? compiler-value)
+                   (every? public-scalars
+                           (klaunch/expression-references compiler-value)))
       (throw (ex-info
-              "static typed contraction dispatch has a runtime-dependent private scalar"
-              {:reason :typed-contraction-dispatch-dynamic-scalar
+              "typed contraction candidate has a private scalar outside its semantic ABI"
+              {:reason :typed-contraction-dispatch-unbound-private-scalar
                :operation operation-id
                :family (:family candidate)
                :slot slot
@@ -886,22 +945,21 @@
                       :interface interface}
      :layout {:external-interface interface}}))
 
-(defn route-static-typed-contraction-dispatch
-  "Normalize legal static typed contraction leaves behind one logical ABI-compatible dispatch.
+(defn route-typed-contraction-dispatch
+  "Normalize legal typed contraction leaves behind one logical ABI-compatible dispatch.
 
-   Leaf-only dimensions remain graph-private derived scalars, while typed result-transform scalar
-   captures join operand/result pointers in the shared public ABI. Matrix, register-tiled and
-   portable kernels can therefore compete through the existing KernelDispatch tuning machinery.
-   Runtime-dependent private dimensions are refused until they have a common public ABI rather
-   than silently baking one sample."
+   Semantic scalar inputs join operand/result pointers in the ordered public ABI. Leaf-only values
+   remain graph-private checked expressions over those scalars. Matrix, register-tiled and portable
+   kernels can therefore compete without baking a runtime shape or exposing schedule temporaries."
   [program operation & options]
   (let [operation-id (:id operation)
         schedule (reduction/validate-schedule! (:schedule operation))
         {:keys [candidates] :as routed}
         (apply route-typed-contraction-candidates!
                program operation options)
-        candidates (mapv #(static-private-scalars! % operation-id) candidates)
-        {:keys [abi arguments]} (common-logical-interface candidates operation-id)
+        {:keys [abi arguments public-scalars]}
+        (common-logical-interface candidates operation operation-id)
+        candidates (mapv #(bindable-private-scalars! % operation-id public-scalars) candidates)
         default-strategy (:strategy (first candidates))
         dispatch-id (candidate-dispatch-id operation-id candidates)
         candidates (mapv #(deterministic-candidate-entry-point % dispatch-id) candidates)

--- a/test/raster/compiler/ir/kernel_graph_test.clj
+++ b/test/raster/compiler/ir/kernel_graph_test.clj
@@ -1,5 +1,6 @@
 (ns raster.compiler.ir.kernel-graph-test
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-graph :as graph]
             [raster.compiler.ir.segop :as segop]
             [raster.compiler.ir.soac :as soac]
@@ -81,6 +82,20 @@
     (is (= :inout (get-in scheduled [:inputs 0 :role])))
     (is (identical? (first (:inputs scheduled)) (first (:outputs scheduled))))
     (is (= :read-write (get-in scheduled [:nodes 0 :uses 0 :access])))))
+
+(deftest in-place-graph-interface-retains-the-read-write-abi-direction
+  (let [operation (segop/->SegMap
+                   9 (segop/make-seg-space 'i 'n) (segop/->SegLevel :thread :virtual)
+                   '(inc (aget state i)) nil #{'state} #{'state} #{}
+                   (segop/->KernelGrid 1 32 0) :float 'state nil)
+        scheduled (graph/from-segops [operation]
+                                     {:inputs #{'state} :outputs #{'state} :dtype :float})
+        interfaced (assoc scheduled
+                          :abi [(kabi/slot 'state :inout :float)
+                                (kabi/slot 'n :scalar :long)]
+                          :arguments '[state n])]
+    (is (identical? interfaced (graph/validate! interfaced)))
+    (is (= :inout (get-in interfaced [:abi 0 :kind])))))
 
 (deftest ordered-output-vectors-retain-write-access
   (let [operation (segop/->SegFoldMap

--- a/test/raster/compiler/ir/resident_plan_test.clj
+++ b/test/raster/compiler/ir/resident_plan_test.clj
@@ -122,8 +122,9 @@
                                (float-array (* width width)) rows width width]
                    :shapes {'x [rows width] 'W [width width]
                             (:result-sym descriptor) [rows width]}})]
-    ;; linear-nb's BLAS GEMM is a typed contraction step, not a resident :gemm binding.
-    (is (= [:contract] (mapv :convention (:steps descriptor))))
+    ;; linear-nb's BLAS GEMM is a typed contraction dispatch, not a resident :gemm binding.
+    ;; The executable container keeps its semantic extents public for runtime schedule choice.
+    (is (= [:executable] (mapv :convention (:steps descriptor))))
     (is (resident/certified-plan? lowering))
     (is (= [rows width]
            (get-in lowering [:certificate :values (:result-sym descriptor) :shape])))

--- a/test/raster/compiler/passes/parallel/gemm_epilogue_device_test.clj
+++ b/test/raster/compiler/passes/parallel/gemm_epilogue_device_test.clj
@@ -1,11 +1,13 @@
 (ns raster.compiler.passes.parallel.gemm-epilogue-device-test
   "An accumulating BLAS GEMM (`beta ≠ 0`) is a typed contraction whose result transform reads
    the destination element it overwrites. The deftm below keeps its BLAS spelling; the typed
-   route turns it into one resident `:contract` step whose destination is a single `:inout`
+   route turns it into one typed executable dispatch whose destination is a single `:inout`
    ABI slot, and the same source runs bit-comparably on the JVM (host expansion of the same
    result transform), on OpenCL and on Level Zero."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.pipeline :as pipeline]
+            [raster.compiler.ir.kernel-dispatch :as kdispatch]
+            [raster.compiler.ir.kernel-executable :as kexec]
             [raster.core :refer [deftm]]
             [raster.dl.gpu-grad-parity :as gpu-probe]
             [raster.gpu.core :as gpu]
@@ -28,6 +30,14 @@
 (defn- b-matrix [] (float-array (map #(float (* 0.5 %)) (range (* k n)))))
 (defn- c-initial [] (float-array (map #(float (* 100 %)) (range (* m n)))))
 
+(defn- default-executable
+  [step]
+  (kdispatch/default-alternative (:dispatch step)))
+
+(defn- default-artifact
+  [step]
+  (first (kexec/artifacts (default-executable step))))
+
 (defn- reference
   "C0 + A·B in float, the value every backend must reproduce."
   []
@@ -45,18 +55,20 @@
     (accumulate-gemm! (a-matrix) (b-matrix) C m k n)
     (is (= (reference) (vec C)))))
 
-(deftest the-resident-program-is-one-contract-step-with-a-read-write-destination
+(deftest the-resident-program-is-one-typed-executable-with-a-read-write-destination
   (doseq [target [:ocl:0 :ze:0]]
     (let [descriptor (pipeline/compile-gpu-program #'accumulate-gemm! target :dtype :float)
-          step (first (:steps descriptor))]
+          step (first (:steps descriptor))
+          executable (default-executable step)
+          artifact (default-artifact step)]
       (testing (str target)
-        (is (= [:contract] (mapv :convention (:steps descriptor))))
+        (is (= [:executable] (mapv :convention (:steps descriptor))))
         (is (= '[[A :input] [B :input] [C :inout]]
-               (vec (for [slot (get-in step [:artifact :abi])
+               (vec (for [slot (kexec/abi executable)
                           :when (not= :scalar (:kind slot))]
                       [(:name slot) (:kind slot)]))))
         (is (empty? (:allocs descriptor)))
-        (is (re-find #"__global float\* C" (get-in step [:artifact :source]))
+        (is (re-find #"__global float\* C" (:source artifact))
             "the destination pointer is writable: no const qualifier")))))
 
 (defn- run-on-device
@@ -105,13 +117,14 @@
                      (reduce + (for [l (range in-f)]
                                  (* (aget x (+ (* i in-f) l)) (aget W (+ (* j in-f) l)))))))))))
 
-(deftest the-linear-layer-is-a-resident-map-and-contract
+(deftest the-linear-layer-is-a-resident-map-and-typed-executable
   (doseq [target [:ocl:0 :ze:0]]
     (let [descriptor (pipeline/compile-gpu-program #'nn/linear! target :dtype :float)]
       (testing (str target)
-        (is (= [:map :contract] (mapv :convention (:steps descriptor))))
+        (is (= [:map :executable] (mapv :convention (:steps descriptor))))
         (is (= '[[W :input] [x :input] [y :inout]]
-               (vec (for [slot (get-in (second (:steps descriptor)) [:artifact :abi])
+               (vec (for [slot (kexec/abi
+                                (default-executable (second (:steps descriptor))))
                           :when (not= :scalar (:kind slot))]
                       [(:name slot) (:kind slot)]))))))))
 

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1003,14 +1003,17 @@
            (set (map :candidate-family (:declines candidate-routes)))))
     (is (not-any? #(= :schedule-family-disabled (:reason %))
                   (:declines candidate-routes)))
-    (try
-      (contract-route/route-static-typed-contraction-dispatch
-       algorithm operation
-       :dtype :float :desc {})
-      (is false "a static dispatch must not bake runtime-dependent contraction dimensions")
-      (catch clojure.lang.ExceptionInfo exception
-        (is (= :typed-contraction-dispatch-dynamic-scalar
-               (:reason (ex-data exception))))))
+    (let [dispatch (contract-route/route-typed-contraction-dispatch
+                    algorithm operation :dtype :float :desc {})
+          alternative (first (:alternatives dispatch))]
+      (is (= '[A B C m n k] (:arguments alternative)))
+      (is (= [:extent :extent :extent]
+             (mapv :role (drop 3 (:abi alternative)))))
+      (is (kernel-graph-call/kernel-graph-call?
+           (kernel-graph-call/make alternative {'A :a 'B :b 'C :c}
+                                   {'m {:type :int :value 7}
+                                    'n {:type :int :value 5}
+                                    'k {:type :int :value 3}}))))
     (try
       (contract-route/route-typed-contraction
        algorithm operation :dtype :double :desc {})
@@ -1055,9 +1058,9 @@
     (is (= 1 (get-in emitted [:stats :ze-contracts])))
     (is (= 1 (get-in emitted [:stats :segop-reused])))
     (is (nil? (get-in emitted [:stats :segop-relowered])))
-    (is (= 1 (get-in emitted [:stats :typed-contraction-dispatch-declines
-                              :typed-contraction-dispatch-dynamic-scalar])))
-    (is (empty? (:dispatches emitted)))
+    (is (zero? (get-in emitted [:stats :typed-contraction-dispatch-declines
+                                :typed-contraction-dispatch-dynamic-scalar] 0)))
+    (is (= 1 (count (:dispatches emitted))))
     (is (= 1 (count (:kernels emitted))))))
 
 (deftest compatibility-contraction-without-source-or-schedule-fails-loud
@@ -1109,7 +1112,7 @@
            :dtype :half :desc descriptor))
         dispatch
         (without-surface
-         #(contract-route/route-static-typed-contraction-dispatch
+         #(contract-route/route-typed-contraction-dispatch
            algorithm operation
            :dtype :half :desc descriptor))
         alternatives (:alternatives dispatch)

--- a/test/raster/dl/gpu_ad_gemm_test.clj
+++ b/test/raster/dl/gpu_ad_gemm_test.clj
@@ -57,7 +57,7 @@
         (let [x (rnd (* b i) 1) W (rnd (* o i) 2)
               cpu (nn/linear-nb x W b i o)
               {:keys [descriptor out]} (run-resident #'nn/linear-nb [x W b i o])]
-          (is (= [:contract] (mapv :convention (:steps descriptor)))
+          (is (= [:executable] (mapv :convention (:steps descriptor)))
               "forward projection lowers to a single typed contraction step")
           (is (< (rel-err out cpu) tol)
               (str "forward relerr " (rel-err out cpu)))))
@@ -65,14 +65,14 @@
         (let [dy (rnd (* b o) 3) W (rnd (* o i) 4)
               cpu (nn/linear-dx dy W b i o)
               {:keys [descriptor out]} (run-resident #'nn/linear-dx [dy W b i o])]
-          (is (= [:contract] (mapv :convention (:steps descriptor))))
+          (is (= [:executable] (mapv :convention (:steps descriptor))))
           (is (< (rel-err out cpu) tol)
               (str "linear-dx relerr " (rel-err out cpu)))))
       (testing "backward linear-dW (:tn, weight gradient) on GPU matches CPU BLAS"
         (let [dy (rnd (* b o) 5) x (rnd (* b i) 6)
               cpu (nn/linear-dW dy x b i o)
               {:keys [descriptor out]} (run-resident #'nn/linear-dW [dy x b i o])]
-          (is (= [:contract] (mapv :convention (:steps descriptor)))
+          (is (= [:executable] (mapv :convention (:steps descriptor)))
               "weight-gradient lowers to a single typed contraction step (transpose-A layout)")
           (is (< (rel-err out cpu) tol)
               (str "linear-dW relerr " (rel-err out cpu))))))))
@@ -201,7 +201,7 @@
                 x (rnd (* b i) (+ 100 n)) W (rnd (* o i) (+ 200 n))
                 cpu (nn/linear-nb x W b i o)
                 {:keys [descriptor out]} (run-resident #'nn/linear-nb [x W b i o])]
-            (is (= [:contract] (mapv :convention (:steps descriptor))))
+            (is (= [:executable] (mapv :convention (:steps descriptor))))
             (is (< (rel-err out cpu) tol)
                 (str ":nt n=" n " relerr " (rel-err out cpu)))))
         (testing (str "backward linear-dx (:nn) at in-features n=" n)
@@ -209,7 +209,7 @@
                 dy (rnd (* b o) (+ 300 n)) W (rnd (* o i) (+ 400 n))
                 cpu (nn/linear-dx dy W b i o)
                 {:keys [descriptor out]} (run-resident #'nn/linear-dx [dy W b i o])]
-            (is (= [:contract] (mapv :convention (:steps descriptor))))
+            (is (= [:executable] (mapv :convention (:steps descriptor))))
             (is (< (rel-err out cpu) tol)
                 (str ":nn n=" n " relerr " (rel-err out cpu)))))))))
 
@@ -311,7 +311,7 @@
   (doseq [[v variant] [[#'nn/linear-nb :nt] [#'nn/linear-dx :nn] [#'nn/linear-dW :tn]]]
     (let [p (pl/compile-gpu-program v :ze:0 :dtype :float :on-non-resident :nil)]
       (is (some? p) (str v " (alpha=1, beta=0) must still extract as a resident GEMM"))
-      (is (= [:contract] (mapv :convention (:steps p)))
+      (is (= [:executable] (mapv :convention (:steps p)))
           (str v " (" variant ") must still lower to a single typed contraction step")))))
 
 (deftest gpu-ad-full-train-step-fully-resident

--- a/test/raster/gpu/link_spike_test.clj
+++ b/test/raster/gpu/link_spike_test.clj
@@ -404,7 +404,7 @@
             :outputs [:x2]})
           session (gpu/make-session :ze:0)
           executable (gpu-link/instantiate! plan {:session session})]
-      (is (= [:contract] (mapv :convention (:steps prog)))
+      (is (= [:executable] (mapv :convention (:steps prog)))
           "linear-nb's BLAS GEMM is a typed contraction step")
       (try
         (let [session (:session executable)


### PR DESCRIPTION
## What\n- put runtime contraction scalar inputs in the ordered typed dispatch ABI\n- keep leaf-derived segment counts as checked graph-private expressions\n- route symbolic contractions through the ordinary typed KernelDispatch path\n- remove the misleading static-only route name and dynamic-shape decline\n\n## Why\nThis is the ABI prerequisite for expressing mixed-precision conversion, matrix execution, and split-K as schedule-owned typed graphs without retaining the resident :gemm binder. Semantic M/N/K belong to the caller; target-specific derived values do not.\n\n## Validation\n- typed SOAC route: 48 tests, 382 assertions\n- adjacent compiler/emission/call suites: 64 tests, 309 assertions\n- full suite delegated to CI