### PR TITLE
Separate mixed precision policy from XMX scheduling

### DIFF
--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -374,7 +374,7 @@
         scalar (scalar-graph spec)]
     (case precision
       :f32-scalar scalar
-      :f16-xmx
+      :mixed-f16-f32
       (let [split-expression (requested-splits spec)
             xmx-spec (assoc spec :requested-splits split-expression)
             direct (xmx-graph (assoc xmx-spec :split-k? false))

--- a/src/raster/compiler/backend/gpu/paged_kv_append.clj
+++ b/src/raster/compiler/backend/gpu/paged_kv_append.clj
@@ -63,8 +63,8 @@
      [(kabi/slot key-rows :input :float :c-name "key_rows" :role :key-rows)
       (kabi/slot value-rows :input :float :c-name "value_rows" :role :value-rows)
       (kabi/slot slot-mapping :input :int :c-name "slot_mapping" :role :slot-mapping)
-      (kabi/slot key-pages :output :half :c-name "key_pages" :role :key-pages)
-      (kabi/slot value-pages :output :half :c-name "value_pages" :role :value-pages)])))
+      (kabi/slot key-pages :inout :half :c-name "key_pages" :role :key-pages)
+      (kabi/slot value-pages :inout :half :c-name "value_pages" :role :value-pages)])))
 
 (defn emit-fp32-to-fp16-reference
   "Emit the portable assignment kernel as a verified KernelArtifact."

--- a/src/raster/compiler/backend/gpu/segop_opencl.clj
+++ b/src/raster/compiler/backend/gpu/segop_opencl.clj
@@ -841,7 +841,11 @@
                               {:reason :kernel-graph-scalar-dtype
                                :argument argument :slots (mapv first pairs)}))))
         pointer-abi (mapv (fn [{:keys [id dtype role]}]
-                            (kabi/slot id (if (= :input role) :input :output) dtype
+                            (kabi/slot id (case role
+                                            :input :input
+                                            :output :output
+                                            :inout :inout)
+                                       dtype
                                        :role (case role
                                                :input :operand
                                                :output :result

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -519,11 +519,11 @@
   "Restrict candidate families to the compile's precision policy.
 
    `:f32-scalar` promises exact f32 arithmetic, so the `:matrix` family (f16 XMX / int8
-   instruction inputs) is excluded; the default `:f16-xmx` policy admits every family. An
+   instruction inputs) is excluded; the default `:mixed-f16-f32` policy admits every family. An
    unknown policy or a policy that leaves no family is a loud error, never a silent default."
   [families precision dtype operation-id]
   (case precision
-    (nil :f16-xmx) families
+    (nil :mixed-f16-f32) families
     ;; The matrix family covers f16 XMX products and exact int8 dp4a products; only the
     ;; floating-point contractions lose exactness there, so integer contractions keep it.
     :f32-scalar (let [kept (if (dtype/fp-dtype? (dtype/canon dtype))
@@ -935,13 +935,14 @@
                 (update :source str/replace old-name new-name))))))
 
 (defn- typed-contraction-tuning-contract
-  [schedule dispatch-id abi]
+  [schedule dispatch-id abi precision]
   (let [interface (mapv #(select-keys % [:kind :dtype :kernel-dtype :role
                                          :aliasing :alignment])
                         abi)]
     {:schedule-path [:typed-contraction :measured-selectors]
      :schedule-key dispatch-id
-     :numerical-mode {:reduction (:numerical-mode schedule)
+     :numerical-mode {:precision (or precision :mixed-f16-f32)
+                      :reduction (:numerical-mode schedule)
                       :interface interface}
      :layout {:external-interface interface}}))
 
@@ -952,11 +953,12 @@
    remain graph-private checked expressions over those scalars. Matrix, register-tiled and portable
    kernels can therefore compete without baking a runtime shape or exposing schedule temporaries."
   [program operation & options]
-  (let [operation-id (:id operation)
+  (let [options (apply hash-map options)
+        operation-id (:id operation)
         schedule (reduction/validate-schedule! (:schedule operation))
         {:keys [candidates] :as routed}
         (apply route-typed-contraction-candidates!
-               program operation options)
+               program operation (mapcat identity options))
         {:keys [abi arguments public-scalars]}
         (common-logical-interface candidates operation operation-id)
         candidates (mapv #(bindable-private-scalars! % operation-id public-scalars) candidates)
@@ -976,7 +978,8 @@
                    :candidate-schedules
                    (into {} (map (juxt :strategy :candidate-schedule)) candidates)
                    :declines (:declines routed)
-                   :tuning (typed-contraction-tuning-contract schedule dispatch-id abi)
+                   :tuning (typed-contraction-tuning-contract schedule dispatch-id abi
+                                                               (:precision options))
                    :selection :analytic-fixed}})))
 
 (def ^:private decline-reasons

--- a/src/raster/compiler/pipeline.clj
+++ b/src/raster/compiler/pipeline.clj
@@ -1800,7 +1800,7 @@
    schedule's [:schedule :precision] (the source of truth the linked step binder reads). A caller
    overrides the policy on the plain-data descriptor with (assoc-in descriptor [:schedule :precision] …)
    — NOT (assoc descriptor :gemm-precision …), which the resolved schedule now shadows:
-     :f16-xmx (default) — convert A/B f32→f16, XMX gemm, f32 C accumulate/output. The
+     :mixed-f16-f32 (default) — permit f16 operands with f32 accumulation/output. The
                           mixed-precision (AMP) policy: f16 INPUTS, f32 math. Costs ~1e-3
                           relative gradient noise (f16 mantissa, cosine similarity to the
                           f32 grads still 1.000) and buys ~3x on the GEMM kernels.
@@ -1819,10 +1819,10 @@
    KernelDispatch expression cases. LinkPlan instantiation selects and binds that compiler value; it does
    not recognize GEMM shapes or reconstruct conversion/split kernels."
   [f-var device-id & {:keys [dtype on-non-resident gemm-precision schedule compiler-report?]
-                      :or {on-non-resident :throw gemm-precision :f16-xmx}}]
-  (when-not (contains? #{:f16-xmx :f32-scalar} gemm-precision)
+                      :or {on-non-resident :throw gemm-precision :mixed-f16-f32}}]
+  (when-not (contains? #{:mixed-f16-f32 :f32-scalar} gemm-precision)
     (throw (ex-info (str "compile-gpu-program: unknown :gemm-precision " (pr-str gemm-precision)
-                         " (expected :f16-xmx or :f32-scalar)")
+                         " (expected :mixed-f16-f32 or :f32-scalar)")
                     {:gemm-precision gemm-precision})))
   ;; S6 schedule: derive the descriptor-default schedule, deep-merge the user :schedule override
   ;; (:gemm-precision is deprecated sugar → the precision policy), and run the register-budget
@@ -2050,8 +2050,8 @@
                              :m m-argument :n n-argument :k k-argument
                              :variant (:variant step)
                              ;; Emit the complete legal schedule family. The resolved precision
-                             ;; selects :f32-scalar at bind; :f16-xmx uses the checked cases.
-                             :precision :f16-xmx
+                             ;; selects :f32-scalar at bind; mixed precision uses the checked cases.
+                             :precision :mixed-f16-f32
                              :tile tile
                              :fill-workgroups
                              (core-hw/fill-workgroups hardware-descriptor workgroup-size)

--- a/src/raster/gpu/compiled.clj
+++ b/src/raster/gpu/compiled.clj
@@ -143,7 +143,7 @@
             :outputs [sym …]         additional written params to project as outputs
             :taps    [sym …]         internal nodes to additionally expose (§5.1)
             :roles   {sym → role}    explicit role override (last word)
-            :gemm-precision :f16-xmx|:f32-scalar
+            :gemm-precision :mixed-f16-f32|:f32-scalar
             :on-non-resident :nil|:throw
             :schedule <map>}         reserved S6 schedule (threaded into the cache key)"
   [fn-var args {:keys [target dtype donate constants outputs taps roles

--- a/src/raster/gpu/schedule.clj
+++ b/src/raster/gpu/schedule.clj
@@ -29,7 +29,7 @@
 (def ^:private default-precision
   "The one POLICY axis. Training default: mixed-precision f16 GEMM inputs, f32 accumulate —
    the measured-robust 2.33× backward speedup at grads cosine 1.000."
-  :f16-xmx)
+  :mixed-f16-f32)
 
 (defn- machine-params
   "The cost/legality numbers the schedule carries in :meta for inspection + the gate."
@@ -43,7 +43,8 @@
    descriptor values. PR-1 wires the precision axis; :grf/:stage are the dead-knob homes,
    default OFF (:grf128 / :stage :none) so the emitter never sees a dead default on.
 
-   opts: {:precision :f16-xmx|:f32-scalar}  — policy override of the training default."
+   opts: {:precision :mixed-f16-f32|:f32-scalar} — numerical policy override. Matrix-instruction
+   families such as XMX, MMA and MFMA are target schedules, not precision names."
   ([desc] (derive-default nil desc {}))
   ([steps desc] (derive-default steps desc {}))
   ([steps desc {:keys [precision]}]
@@ -89,7 +90,7 @@
     (some? b) b
     :else a))
 
-(def ^:private valid-precisions #{:f16-xmx :f32-scalar})
+(def ^:private valid-precisions #{:mixed-f16-f32 :f32-scalar})
 (def ^:private valid-stage-spaces #{:none :slm :l3 :register})
 (def ^:private valid-grf-modes #{:grf128 :grf256})
 (def ^:private valid-segmented-reduction-strategies
@@ -158,12 +159,12 @@
 
 (defn- acc-bytes-per-lane
   "Accumulator footprint per lane by precision. Prefers the ACTUAL emitted :tile (T2/T3 —
-   tile-acc-bytes-per-lane); falls back to the Arc-default constant when no tile is pinned. f16-xmx
+   tile-acc-bytes-per-lane); falls back to the Arc-default constant when no tile is pinned. Mixed
    uses the full XMX accumulator tile; :f32-scalar a quarter of it (no wide MMA accumulator)."
   [schedule]
   (let [full (or (tile-acc-bytes-per-lane schedule) xmx-f16-acc-bytes-per-lane)]
     (case (:precision schedule)
-      :f16-xmx    full
+      :mixed-f16-f32 full
       :f32-scalar (quot full 4)
       full)))
 
@@ -185,13 +186,13 @@
    Requires `acc + register-staged ≤ GRF-budget` per lane. Fail-loud (raster-native); a
    `minimize()` fallback is deferred until an autotuner generates candidates.
 
-   Anchors (grf128, 256 B/lane): the default f16-xmx GEMM with :stage :none is 256 ≤ 256 → OK;
+   Anchors (grf128, 256 B/lane): the default mixed-f16-f32 GEMM with :stage :none is 256 ≤ 256 → OK;
    register double-buffering both operands is 256 + 4×64 = 512 > 256 → REJECTED at compile time
    (precisely the measurement-time spill, turned into a loud rejection)."
   [schedule desc]
   ;; validate the resolved schedule BEFORE pricing it — an unmodeled precision / stage-space / grf
   ;; mode (e.g. a :bf16 typo, or `:regsiter`) must FAIL LOUD here, not slip past into a silent XMX
-  ;; bind (the #{:f16-xmx :f32-scalar} kwarg check upstream only sees the sugar, not a :schedule).
+  ;; bind (the #{:mixed-f16-f32 :f32-scalar} kwarg check upstream only sees the sugar, not a :schedule).
   (let [prec  (:precision schedule)
         space (get-in schedule [:stage :space] :none)
         grf   (get-in schedule [:grf :mode] :grf128)

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -22,7 +22,7 @@
   (gemm/emit-executable
    {:id (str "gemm-test-" (name variant))
     :a 'a :b 'b :c 'c :m :m :n :n :k :k
-    :variant variant :precision :f16-xmx
+    :variant variant :precision :mixed-f16-f32
     :tile (hardware/derive-gemm-tile {})
     :fill-workgroups 32}))
 

--- a/test/raster/compiler/backend/gpu/segop_opencl_test.clj
+++ b/test/raster/compiler/backend/gpu/segop_opencl_test.clj
@@ -25,6 +25,19 @@
             [raster.compiler.passes.parallel.typed-soac-route :as typed-route]
             [raster.compiler.backend.gpu.segop-opencl :as sg]))
 
+(deftest emitted-graph-interface-preserves-in-place-buffer-direction
+  (let [operation (segop/->SegMap
+                   901 (segop/make-seg-space 'i 'n) (segop/->SegLevel :thread :virtual)
+                   '(inc (clojure.core/aget output i)) nil #{'output} #{'output} #{}
+                   (segop/->KernelGrid 1 32 0) :float 'output nil)
+        scheduled (kgraph/from-segops [operation]
+                                      {:inputs #{'output} :outputs #{'output} :dtype :float})
+        emitted (sg/generate-kernel-graph
+                 scheduled :array-types {'output :float} :scalar-types {'n :int})]
+    (is (= ['output 'n] (:arguments emitted)))
+    (is (= [:inout :scalar] (mapv :kind (:abi emitted))))
+    (is (= :inout (get-in emitted [:inputs 0 :role])))))
+
 (deftest two-phase-reduction-graph-emits-its-explicit-scheduled-dataflow
   (let [source '(let* [result (raster.par/reduce acc 0.0 i n
                                                  (+ acc (clojure.core/aget a i)))]

--- a/test/raster/compiler/passes/parallel/paged_kv_append_route_test.clj
+++ b/test/raster/compiler/passes/parallel/paged_kv_append_route_test.clj
@@ -52,6 +52,9 @@
     (is (not (str/includes? source "atomic")))
     (is (= ['key-rows 'value-rows 'slots 'key-pages 'value-pages]
            (:arguments artifact)))
+    (is (= [:input :input :input :inout :inout]
+           (mapv :kind (:abi artifact)))
+        "the append mutates existing page pools rather than producing fresh whole pools")
     (is (= :paged-kv-append (get-in graph [:provenance :semantic-op])))
     (is (= #{'key-pages 'value-pages}
            (set (map :id (:outputs graph)))))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1148,6 +1148,8 @@
            (get-in dispatch [:attributes :tuning :schedule-path])))
     (is (= (:id dispatch) (get-in dispatch [:attributes :tuning :schedule-key])))
     (is (map? (get-in dispatch [:attributes :tuning :numerical-mode])))
+    (is (= :mixed-f16-f32
+           (get-in dispatch [:attributes :tuning :numerical-mode :precision])))
     (is (map? (get-in dispatch [:attributes :tuning :layout])))
     (is (= {:path [:typed-contraction :measured-selectors]
             :key (:id dispatch)}

--- a/test/raster/dl/gemma_train_resident_test.clj
+++ b/test/raster/dl/gemma_train_resident_test.clj
@@ -298,7 +298,7 @@
 
 ;; ═════════════════════════════════════════════════════════════════════════════════
 ;; MIXED-PRECISION BACKWARD (S2a): the SAME resident train step (value+grad + SGD) under
-;; :gemm-precision :f16-xmx — f16 GEMM inputs, f32 accumulate/output — must train the
+;; :gemm-precision :mixed-f16-f32 — f16 GEMM inputs, f32 accumulate/output — must train the
 ;; adapters along the SAME loss trajectory as the exact :f32-scalar policy.
 ;;
 ;; This is the gate for running the VJP/backward program in mixed precision (the forward
@@ -372,11 +372,11 @@
           ;; through [:schedule :precision] (NOT the deprecated top-level :gemm-precision, which the
           ;; schedule now shadows — assoc'ing it would be a silent no-op and both trajectories would
           ;; run f32).
-          p16 (assoc-in p32 [:schedule :precision] :f16-xmx)]
+          p16 (assoc-in p32 [:schedule :precision] :mixed-f16-f32)]
       (is (some? p32) "train-step must extract fully resident")
       (when p32
         (let [dims (gemm-dims p32 args)]
-          (testing "every backward GEMM clears the XMX pitch gate (so :f16-xmx really fires)"
+          (testing "every backward GEMM clears the XMX pitch gate (so mixed precision really fires)"
             (println "  [mixed-precision bwd]" (count dims) "gemm steps, variants:"
                      (frequencies (map :variant dims)))
             (is (every? (fn [{:keys [n k]}] (and (>= n 8) (>= k 8))) dims)
@@ -387,13 +387,13 @@
             (println "  [mixed-precision bwd] f32-scalar loss:"
                      (mapv #(format "%.6f" %) (take 3 l32)) "…"
                      (mapv #(format "%.6f" %) (take-last 2 l32)))
-            (println "  [mixed-precision bwd] f16-xmx    loss:"
+            (println "  [mixed-precision bwd] mixed-f16-f32 loss:"
                      (mapv #(format "%.6f" %) (take 3 l16)) "…"
                      (mapv #(format "%.6f" %) (take-last 2 l16)))
-            (testing "the f16-xmx backward still trains (loss decreases on-device)"
+            (testing "the mixed-f16-f32 backward still trains (loss decreases on-device)"
               (is (< (peek l16) (* 0.7 (first l16)))
                   (str "final " (peek l16) " vs initial " (first l16))))
-            (testing "the f16-xmx trajectory tracks the exact f32 trajectory step for step"
+            (testing "the mixed-f16-f32 trajectory tracks the exact f32 trajectory step for step"
               ;; f16 GEMM inputs perturb each gradient by ~1e-3 relative; over 25 SGD steps
               ;; that stays a ~1e-3-level trajectory divergence (it does NOT compound into a
               ;; different optimization path at this lr).

--- a/test/raster/dl/gpu_grad_parity.clj
+++ b/test/raster/dl/gpu_grad_parity.clj
@@ -138,7 +138,7 @@
 
 (defn- run-resident
   "Bind + replay f-var's resident descriptor on ze:0 for `args`; returns the result array.
-   gemm-precision is compile-gpu-program's :gemm-precision (:f16-xmx | :f32-scalar)."
+   gemm-precision is compile-gpu-program's :gemm-precision (:mixed-f16-f32 | :f32-scalar)."
   [f-var args dtype gemm-precision]
   (let [p (pl/compile-gpu-program f-var :ze:0 :dtype dtype :gemm-precision gemm-precision)
         s (gpu/make-session :ze:0)]
@@ -187,14 +187,14 @@
      :dtype       :float (default) | :double   — resident compile dtype
      :rtol        max relative error (default 1e-3 for f32)
      :grad-args   coll of arg :name symbols to check (default: all Array-typed args)
-     :gemm-precision  :f16-xmx (default) | :f32-scalar — compile-gpu-program's resident
+     :gemm-precision  :mixed-f16-f32 (default) | :f32-scalar — compile-gpu-program's resident
                   :gemm binding policy (:f32-scalar = exact-grad scalar f32 GEMM)
 
    Runs on ze:0. Fails loudly (via clojure.test/is) if any checked gradient's wrapper
    does not extract fully resident, or if the GPU grad diverges beyond rtol.
    Returns {:grads {argname {:resident? :step-kinds :rel-err}}}."
   [loss-var arg-specs & {:keys [dtype rtol grad-args gemm-precision]
-                         :or {dtype :float rtol 1.0e-3 gemm-precision :f16-xmx}}]
+                         :or {dtype :float rtol 1.0e-3 gemm-precision :mixed-f16-f32}}]
   (let [names (mapv :name arg-specs)
         types (mapv :type arg-specs)
         vals  (mapv :val arg-specs)

--- a/test/raster/gpu/gemm_link_topology_test.clj
+++ b/test/raster/gpu/gemm_link_topology_test.clj
@@ -15,8 +15,8 @@
   []
   (let [tile (hardware/derive-gemm-tile {})]
     {:dtype :float
-     :gemm-precision :f16-xmx
-     :schedule {:precision :f16-xmx}
+     :gemm-precision :mixed-f16-f32
+     :schedule {:precision :mixed-f16-f32}
      :all-params '[a b c m n k]
      :array-params '[a b c]
      :array-roles {'a :input 'b :input 'c :output}
@@ -28,7 +28,7 @@
        (gemm/emit-executable
         {:id "mock-linked-gemm" :a 'a :b 'b :c 'c
          :m :gemm-m :n :gemm-n :k :gemm-k :variant :nt
-         :precision :f16-xmx :tile tile :fill-workgroups 32})
+         :precision :mixed-f16-f32 :tile tile :fill-workgroups 32})
        :argument-specs [{:kind :input :sym 'a}
                         {:kind :input :sym 'b}
                         {:kind :output :sym 'c}

--- a/test/raster/gpu/link_spike_test.clj
+++ b/test/raster/gpu/link_spike_test.clj
@@ -376,7 +376,7 @@
           W0 (fa (* width width) 12)
           W1 (fa (* width width) 13)
           prog (pl/compile-gpu-program #'nn/linear-nb :ze:0 :dtype :float
-                                       :gemm-precision :f16-xmx :on-non-resident :nil)
+                                       :gemm-precision :mixed-f16-f32 :on-non-resident :nil)
           _ (is (some? prog) "spike-gemm must extract as one resident contraction")
           result-sym (:result-sym prog)
           scalar-values {'batch rows 'in-f width 'out-f width}

--- a/test/raster/gpu/schedule_test.clj
+++ b/test/raster/gpu/schedule_test.clj
@@ -50,8 +50,8 @@
       (is (= (sched/resolve derived {:gemm-precision :f32-scalar})
              (sched/resolve derived {:precision :f32-scalar}))
           "sugar and explicit override produce byte-identical schedules"))
-    (testing "the default policy is f16-xmx (training AMP)"
-      (is (= :f16-xmx (:precision derived))))
+    (testing "the default policy is target-neutral mixed f16/f32"
+      (is (= :mixed-f16-f32 (:precision derived))))
     (testing "dynamic segmented reductions default to runtime shape selection"
       (is (= {:strategy :auto :score-reuse-subgroup-multiple 16
               :measured-selectors {}}
@@ -71,13 +71,13 @@
 ;; ════════════════════════════════════════════════════════════════════════════════
 
 (deftest t2-feasibility-gate
-  (testing "the DEFAULT f16-xmx GEMM (stage :none) is feasible at grf128 — 256 ≤ 256"
+  (testing "the default mixed-f16-f32 GEMM (stage :none) is feasible at grf128 — 256 ≤ 256"
     (is (true? (sched/feasible? (sched/derive-default nil arc-desc) arc-desc))))
   (testing "f32-scalar (quarter-file accumulator) is comfortably feasible"
     (is (true? (sched/feasible? (sched/resolve (sched/derive-default nil arc-desc)
                                                {:precision :f32-scalar})
                                 arc-desc))))
-  (testing "register double-buffering BOTH operands on f16-xmx at grf128 is REJECTED before emit"
+  (testing "register double-buffering both operands under mixed-f16-f32 is rejected before emit"
     (let [infeasible (sched/resolve (sched/derive-default nil arc-desc)
                                     {:stage {:space :register :copies {:a 2 :b 2}}})
           ex (try (sched/feasible? infeasible arc-desc) nil
@@ -93,7 +93,7 @@
   (testing "grf256 DOUBLES the budget and GENUINELY unblocks register staging (acc is fixed, not budget-coupled)"
     ;; the accumulator is a fixed 256 B/lane tile property; grf256 lifts the budget to 512, so
     ;; register double-buffering both operands (256 acc + 256 staged = 512) now FITS — the knob is
-    ;; not pointless (the earlier budget-coupled model made grf256 useless for f16-xmx).
+    ;; not pointless (the earlier budget-coupled model made grf256 useless for mixed f16/f32).
     (let [g128 (sched/resolve (sched/derive-default nil arc-desc)
                               {:stage {:space :register :copies {:a 2 :b 2}}})
           g256 (sched/resolve (sched/derive-default nil arc-desc)
@@ -184,7 +184,7 @@
   (testing "conflicting :gemm-precision sugar and :precision throw, not silently prefer the deprecated key"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"conflicting"
                           (sched/resolve (sched/derive-default nil arc-desc)
-                                         {:gemm-precision :f16-xmx :precision :f32-scalar})))))
+                                         {:gemm-precision :mixed-f16-f32 :precision :f32-scalar})))))
 
 ;; ════════════════════════════════════════════════════════════════════════════════
 ;; T3 — derive-default: no dead knobs on by default (no device)
@@ -192,8 +192,8 @@
 
 (deftest t3-derived-default
   (let [d (sched/derive-default nil arc-desc)]
-    (testing "precision default is f16-xmx"
-      (is (= :f16-xmx (:precision d))))
+    (testing "precision default is mixed-f16-f32"
+      (is (= :mixed-f16-f32 (:precision d))))
     (testing "the dead inner-loop knobs are OFF by default"
       (is (= :grf128 (get-in d [:grf :mode])))
       (is (= :none (get-in d [:stage :space]))))


### PR DESCRIPTION
Retargeted successor to PR 338 after its stacked base was squash-merged. Names the public numerical policy mixed-f16-f32 rather than exposing Intel XMX as a precision; keeps XMX as a target schedule family; includes precision in the typed contraction tuning identity; and removes the obsolete f16-xmx policy name without a compatibility path. Focused compiler and schedule tests passed locally; CI is authoritative for the full suite.