### PR TITLE
Lower casts and transposes from affine KernelBodies

### DIFF
--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -7,6 +7,7 @@
    the graph; callers never bind them and runtimes never reconstruct the algorithm from `:gemm`."
   (:require [clojure.string :as str]
             [raster.compiler.backend.gpu.kernel-body-opencl :as kernel-body-opencl]
+            [raster.compiler.backend.gpu.layout-transform :as layout-emitter]
             [raster.compiler.backend.gpu.opencl-codegen :as codegen]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
@@ -100,33 +101,42 @@
 
 (defn- convert-artifact
   [kernel-name in out elements vector-width phase]
-  (artifact
-   kernel-name (codegen/emit-f32-to-f16-kernel kernel-name vector-width)
-   [(kabi/slot in :input :float :c-name "in")
-    (kabi/slot out :output :half :c-name "out")
-    (kabi/slot :elements :scalar :int :c-name "n")]
-   [in out elements]
-   (klaunch/spec
-    {:workgroup-size [256]
-     :group-count [(klaunch/ceil-div
-                    (klaunch/ceil-div (klaunch/runtime-value elements) vector-width)
-                    256)]})
-   phase {:vector-width vector-width :from :float :to :half
-          :cacheable-transform? true}))
+  (let [{:keys [source kernel-body]}
+        (layout-emitter/emit-cast-kernel
+         {:kernel-name kernel-name :input in :output out
+          :source-dtype :float :destination-dtype :half :vector-width vector-width
+          :rounding :nearest-even :overflow :ieee})]
+    (artifact
+     kernel-name source
+     [(kabi/slot in :input :float :c-name "in")
+      (kabi/slot out :output :half :c-name "out")
+      (kabi/slot :layout-elements :scalar :int :c-name "n")]
+     [in out elements]
+     (klaunch/spec
+      {:workgroup-size [256]
+       :group-count [(klaunch/ceil-div
+                      (klaunch/ceil-div (klaunch/runtime-value elements) vector-width)
+                      256)]})
+     phase {:vector-width vector-width :from :float :to :half
+            :rounding :nearest-even :overflow :ieee
+            :kernel-body kernel-body :cacheable-transform? true})))
 
 (defn- transpose-artifact
   [kernel-name in out rows cols phase]
-  (let [elements (klaunch/product rows cols)]
+  (let [{:keys [source kernel-body]}
+        (layout-emitter/emit-transpose-kernel
+         {:kernel-name kernel-name :input in :output out :element-dtype :half})]
     (artifact
-     kernel-name (codegen/emit-transpose-kernel kernel-name :dtype :half)
+     kernel-name source
      [(kabi/slot in :input :half :c-name "in")
       (kabi/slot out :output :half :c-name "out")
-      (kabi/slot :rows :scalar :int :c-name "rows")
-      (kabi/slot :cols :scalar :int :c-name "cols")]
+      (kabi/slot :layout-rows :scalar :int :c-name "rows")
+      (kabi/slot :layout-cols :scalar :int :c-name "cols")]
      [in out rows cols]
      (klaunch/spec {:workgroup-size [256]
-                    :group-count [(klaunch/ceil-div elements 256)]})
-     phase {:layout :transpose :dtype :half :cacheable-transform? true})))
+                    :group-count [(klaunch/ceil-div (klaunch/product rows cols) 256)]})
+     phase {:layout :transpose :dtype :half
+            :kernel-body kernel-body :cacheable-transform? true})))
 
 (defn emit-scheduled-matrix-kernel
   "Build and directly lower one canonical f16 matrix contraction.

--- a/src/raster/compiler/backend/gpu/layout_transform.clj
+++ b/src/raster/compiler/backend/gpu/layout_transform.clj
@@ -1,0 +1,34 @@
+(ns raster.compiler.backend.gpu.layout-transform
+  "Lower target-neutral affine layout-transform schedules to C-family kernel artifacts."
+  (:require [raster.compiler.backend.gpu.kernel-body-opencl :as emitter]
+            [raster.compiler.passes.parallel.layout-transform-schedule :as schedule]))
+
+(defn emit-cast-kernel
+  [{:keys [kernel-name input output source-dtype destination-dtype vector-width rounding overflow
+           target-dialect]
+    :or {vector-width 1 target-dialect :opencl-intel}}]
+  (let [kernel-body (schedule/cast-body
+                     {:id [:layout-transform kernel-name]
+                      :input input :output output
+                      :source-dtype source-dtype :destination-dtype destination-dtype
+                      :vector-width vector-width
+                      :rounding rounding :overflow overflow})]
+    {:source (emitter/emit-scalar-kernel
+              kernel-name kernel-body
+              {:target-dialect target-dialect
+               :parameter-names {input "in" output "out" :layout-elements "n"}})
+     :kernel-body kernel-body}))
+
+(defn emit-transpose-kernel
+  [{:keys [kernel-name input output element-dtype target-dialect]
+    :or {target-dialect :opencl-intel}}]
+  (let [kernel-body (schedule/transpose-body
+                     {:id [:layout-transform kernel-name]
+                      :input input :output output
+                      :element-dtype element-dtype})]
+    {:source (emitter/emit-scalar-kernel
+              kernel-name kernel-body
+              {:target-dialect target-dialect
+               :parameter-names {input "in" output "out"
+                                 :layout-rows "rows" :layout-cols "cols"}})
+     :kernel-body kernel-body}))

--- a/src/raster/compiler/backend/gpu/opencl_codegen.clj
+++ b/src/raster/compiler/backend/gpu/opencl_codegen.clj
@@ -17,7 +17,6 @@
     (kernel-launch-config 100000 :device-id :ze:0)"
   (:require [clojure.string :as str]
             [raster.compiler.core.dtype :as dtype]
-            [raster.compiler.core.layout :as layout]
             [raster.compiler.backend.gpu.c-emit :as ce]))
 
 ;; ================================================================
@@ -387,72 +386,6 @@
 ;; ================================================================
 ;; Transpose kernel
 ;; ================================================================
-
-(defn emit-f32-to-f16-kernel
-  "Generate the vectorized f32→f16 conversion used by mixed-precision GEMM schedules.
-
-   `vector-width` is the compiler-selected number of elements per work-item and must be 1, 2, or
-   4. The scalar tail preserves correctness for arbitrary extents and for extents below the vector
-   width. Keeping this emitter in compiler codegen lets conversion participate in KernelGraph
-   scheduling instead of being synthesized privately by a runtime registry."
-  [kernel-name vector-width]
-  (let [w (long vector-width)]
-    (when-not (contains? #{1 2 4} w)
-      (throw (ex-info "f32-to-f16 vector width must be 1, 2, or 4"
-                      {:vector-width vector-width})))
-    (if (= 1 w)
-      (str "__kernel void " kernel-name
-           "(__global const float* restrict in, __global half* restrict out, int n) {\n"
-           "  for (int i = get_global_id(0); i < n; i += get_global_size(0)) "
-           "out[i] = (half)in[i];\n}\n")
-      (let [shift (case w 2 1 4 2)]
-        (str "__kernel void " kernel-name
-             "(__global const float* restrict in, __global half* restrict out, int n) {\n"
-             "  int nv = n >> " shift ";\n"
-             "  for (int i = get_global_id(0); i < nv; i += get_global_size(0))\n"
-             "    vstore_half" w "(vload" w "(i, in), i, out);\n"
-             "  for (int i = (nv << " shift ") + get_global_id(0); i < n; "
-             "i += get_global_size(0))\n"
-             "    out[i] = (half)in[i];\n}\n")))))
-
-(defn- render-c-index
-  "Render a layout->offset index S-expression to C infix (matches the hand-written kernel strings:
-   `(+ (* i cols) j)` → \"i * cols + j\"). Index arithmetic only (+ and *, symbols/ints)."
-  [e]
-  (cond
-    (symbol? e) (name e)
-    (number? e) (str e)
-    (seq? e)    (let [[op a b] e]
-                  (str (render-c-index a) " " (case op + "+" * "*" (str op)) " " (render-c-index b)))
-    :else       (str e)))
-
-(defn emit-transpose-kernel
-  "Generate an OpenCL 2D matrix transpose kernel. LAYOUT-DRIVEN: the read/write indices are computed
-   from the layout facet (`layout/layout->offset`), not hand-written — a transpose is exactly a
-   `convert_layout` between a row-major input [rows,cols] and its transposed output [cols,rows]. The
-   emitted string is byte-identical to the former hand-written `out[j*rows+i] = in[i*cols+j]`; this
-   is the first place a layout DRIVES codegen (the Stage-1 transpose-as-convert seam, proven here).
-
-  dtype: :double | :float | :half (default :float). Returns OpenCL C source string."
-  [kernel-name & {:keys [dtype] :or {dtype :float}}]
-  (let [ctype  (if (= dtype :half) "half" (get opencl-type-map dtype "float"))
-        in-l   (layout/row-major '[rows cols] dtype)          ;; input row-major
-        out-l  (layout/row-major '[cols rows] dtype)          ;; output row-major, transposed extents
-        in-idx  (render-c-index (layout/layout->offset in-l  '[i j]))   ;; "i * cols + j"
-        out-idx (render-c-index (layout/layout->offset out-l '[j i]))]  ;; "j * rows + i"
-    (str (extension-pragmas dtype)
-         "__kernel void " kernel-name
-         "(__global const " ctype "* restrict in,"
-         " __global " ctype "* restrict out,"
-         " int rows, int cols) {\n"
-         "    int gid = get_global_id(0);\n"
-         "    int total = rows * cols;\n"
-         "    for (int idx = gid; idx < total; idx += get_global_size(0)) {\n"
-         "        int i = idx / cols;\n"
-         "        int j = idx % cols;\n"
-         "        out[" out-idx "] = in[" in-idx "];\n"
-         "    }\n"
-         "}\n")))
 
 ;; ================================================================
 ;; Scalar (non-XMX) GEMM kernel — small-N fallback

--- a/src/raster/compiler/passes/parallel/gpu_plan.clj
+++ b/src/raster/compiler/passes/parallel/gpu_plan.clj
@@ -18,12 +18,12 @@
   (:require
    [clojure.set :as set]
    [raster.compiler.backend.gpu.gemm :as gpu-gemm]
+   [raster.compiler.backend.gpu.layout-transform :as layout-emitter]
    [raster.compiler.core.op-descriptor :as op]
    [raster.compiler.core.hardware :as hardware]
    [raster.compiler.passes.parallel.device :as device]
    [raster.compiler.passes.parallel.patterns :as patterns]
-   [raster.compiler.passes.parallel.gemm-recognize :as gemm-recognize]
-   [raster.compiler.backend.gpu.opencl-codegen :as codegen]))
+   [raster.compiler.passes.parallel.gemm-recognize :as gemm-recognize]))
 
 ;; ================================================================
 ;; Pattern matching helpers
@@ -160,10 +160,14 @@
 (defn- gen-transpose-kernel
   "Generate a transpose kernel. Returns {:kernel-name :source :dtype}."
   [dtype kernel-counter]
-  (let [kname (str "transpose_" (swap! kernel-counter inc))]
+  (let [kname (str "transpose_" (swap! kernel-counter inc))
+        dtype (or dtype :float)
+        emitted (layout-emitter/emit-transpose-kernel
+                 {:kernel-name kname :input 'in :output 'out :element-dtype dtype})]
     {:kernel-name kname
-     :source (codegen/emit-transpose-kernel kname :dtype (or dtype :float))
-     :dtype (or dtype :float)
+     :source (:source emitted)
+     :kernel-body (:kernel-body emitted)
+     :dtype dtype
      :type :transpose}))
 
 ;; ================================================================

--- a/src/raster/compiler/passes/parallel/layout_transform_schedule.clj
+++ b/src/raster/compiler/passes/parallel/layout_transform_schedule.clj
@@ -1,0 +1,149 @@
+(ns raster.compiler.passes.parallel.layout-transform-schedule
+  "Target-neutral schedules for affine, elementwise layout transformations.
+
+   These bodies are deliberately independent of GEMM. A mixed-precision contraction may use
+   them to materialize a representation, while fusion and buffer planning may later eliminate
+   the materialization or reuse it. Target emitters only spell the already scheduled body."
+  (:require [raster.compiler.core.dtype :as dtype]
+            [raster.compiler.core.layout :as layout]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-launch :as launch]))
+
+(def ^:private workgroup-size 256)
+
+(defn- global-index
+  [id]
+  [(body/->IndexBinding :layout-group :group 0)
+   (body/->IndexBinding :layout-lane :local 0)
+   (body/->IndexCompute
+    id
+    (body/index-cast
+     (body/expression :add
+                      (body/expression :mul :layout-group workgroup-size)
+                      :layout-lane)
+     :long :exact))])
+
+(defn cast-body
+  "Schedule a dense one-dimensional representation conversion.
+
+   `vector-width` is expressed as statically unrolled lane-owned elements, not a target vector
+   builtin. This preserves the same coalesced access geometry on OpenCL, CUDA and HIP while
+   leaving physical vector formation to target lowering. Narrowing behavior is an explicit part
+   of the body and can therefore participate in dispatch equivalence and certification."
+  [{:keys [id input output extent-id source-dtype destination-dtype vector-width rounding overflow]
+    :or {extent-id :layout-elements vector-width 1}}]
+  (let [source-dtype (dtype/canon source-dtype)
+        destination-dtype (dtype/canon destination-dtype)]
+    (when-not (and rounding overflow)
+      (throw (ex-info "layout conversion requires explicit rounding and overflow policies"
+                      {:reason :layout-transform-numerical-policy
+                       :rounding rounding :overflow overflow})))
+    (when-not (contains? #{1 2 4} vector-width)
+      (throw (ex-info "layout conversion vector width must be 1, 2, or 4"
+                      {:reason :layout-transform-vector-width
+                       :vector-width vector-width})))
+    (let [work-item :layout-work-item
+          base :layout-base
+          extent extent-id
+          operations
+          (vec
+           (mapcat
+            (fn [offset]
+              (let [coordinate (body/expression :add base
+                                                (body/index-cast offset :long :exact))
+                    active (keyword (str "layout-active-" offset))
+                    loaded (keyword (str "layout-loaded-" offset))
+                    converted (keyword (str "layout-converted-" offset))]
+                [(body/->ScalarLoad
+                  (body/value loaded source-dtype) input [coordinate] active
+                  (body/literal 0 source-dtype) :streaming)
+                 (body/->ScalarCompute
+                  (body/value converted destination-dtype)
+                  (body/cast-expression loaded destination-dtype rounding overflow))
+                 (body/->ScalarStore output [coordinate] converted active)]))
+            (range vector-width)))
+          masks
+          (mapv (fn [offset]
+                  (body/->Mask
+                   (keyword (str "layout-active-" offset))
+                   [(body/predicate :lt (body/expression
+                                         :add base (body/index-cast offset :long :exact))
+                                    (body/index-cast extent :long :exact))]))
+                (range vector-width))]
+      (body/make
+       {:id id
+        :parameters [(body/->KernelParameter
+                      input :input source-dtype [extent] :global
+                      (layout/row-major [extent] source-dtype) :source)
+                     (body/->KernelParameter
+                      output :output destination-dtype [extent] :global
+                      (layout/row-major [extent] destination-dtype) :destination)
+                     (body/->KernelParameter extent :scalar :int [] nil nil :extent)]
+        :stable-reads [(body/stable-read input)]
+        :indices (conj (global-index work-item)
+                       (body/->IndexCompute
+                        base (body/expression
+                              :mul work-item
+                              (body/index-cast vector-width :long :exact))))
+        :masks masks
+        :operations operations
+        :schedule {:strategy :affine-elementwise-cast
+                   :elements-per-work-item vector-width
+                   :rounding rounding :overflow overflow}
+        :launch (launch/spec
+                 {:workgroup-size [workgroup-size]
+                  :group-count [(launch/ceil-div
+                                 (launch/ceil-div (launch/runtime-value extent) vector-width)
+                                 workgroup-size)]})
+        :provenance {:dialect :kernel-body :source-dialect :layout-transform}
+        :attributes {:kind :layout-transform :operation :cast
+                     :source-dtype source-dtype :destination-dtype destination-dtype}}))))
+
+(defn transpose-body
+  "Schedule a dense row-major [rows, cols] -> [cols, rows] transpose."
+  [{:keys [id input output row-extent-id column-extent-id element-dtype]
+    :or {row-extent-id :layout-rows column-extent-id :layout-cols}}]
+  (let [element-dtype (dtype/canon element-dtype)
+        linear :layout-linear
+        row :layout-row
+        column :layout-column
+        rows-id row-extent-id
+        cols-id column-extent-id
+        elements (body/expression :mul
+                                  (body/index-cast rows-id :long :exact)
+                                  (body/index-cast cols-id :long :exact))]
+    (body/make
+     {:id id
+      :parameters [(body/->KernelParameter
+                    input :input element-dtype [rows-id cols-id] :global
+                    (layout/row-major [rows-id cols-id] element-dtype) :source)
+                   (body/->KernelParameter
+                    output :output element-dtype [cols-id rows-id] :global
+                    (layout/row-major [cols-id rows-id] element-dtype) :destination)
+                   (body/->KernelParameter rows-id :scalar :int [] nil nil :extent)
+                   (body/->KernelParameter cols-id :scalar :int [] nil nil :extent)]
+      :stable-reads [(body/stable-read input)]
+      :indices (into (global-index linear)
+                     [(body/->IndexCompute
+                       row (body/expression :floor-div linear
+                                            (body/index-cast cols-id :long :exact)))
+                      (body/->IndexCompute
+                       column (body/expression :mod linear
+                                               (body/index-cast cols-id :long :exact)))])
+      :masks [(body/->Mask :layout-active [(body/predicate :lt linear elements)])]
+      :operations [(body/->ScalarLoad
+                    (body/value :layout-value element-dtype)
+                    input [row column] :layout-active
+                    (body/literal 0 element-dtype) :streaming)
+                   (body/->ScalarStore
+                    output [column row] :layout-value :layout-active)]
+      :schedule {:strategy :affine-layout-transform :permutation [1 0]}
+      :launch (launch/spec
+               {:workgroup-size [workgroup-size]
+                :group-count [(launch/ceil-div
+                               (launch/product (launch/runtime-value rows-id)
+                                               (launch/runtime-value cols-id))
+                               workgroup-size)]})
+      :provenance {:dialect :kernel-body :source-dialect :layout-transform}
+      :attributes {:kind :layout-transform :operation :transpose
+                   :permutation [1 0] :element-dtype element-dtype}})))

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -2556,10 +2556,13 @@
 
 (defn- convert-source
   "Compatibility substrate for raw benchmark callers. Production graph schedules consume the
-   same compiler-owned conversion emitter directly."
+   same target-neutral layout-transform schedule directly."
   [w]
-  ((requiring-resolve 'raster.compiler.backend.gpu.opencl-codegen/emit-f32-to-f16-kernel)
-   "f32_to_f16" w))
+  (:source
+   ((requiring-resolve 'raster.compiler.backend.gpu.layout-transform/emit-cast-kernel)
+    {:kernel-name "f32_to_f16" :input 'in :output 'out
+     :source-dtype :float :destination-dtype :half :vector-width w
+     :rounding :nearest-even :overflow :ieee})))
 
 (defn- ensure-convert-kernel!
   "Lazily compile + cache the f32→f16 convert kernel for vector width `w`. {:module :kernel}."
@@ -2580,8 +2583,7 @@
   out: f16 (:half) DeviceBuffer, n elements. Returns a bound {:kernel :gc-seg} map. Fresh
   kernel handle per binding.
 
-  `w` = elements per work-item (the vector width the CALLER scheduled from the hardware
-  descriptor); default 1 = the scalar kernel."
+  `w` = statically unrolled elements per work-item, selected by the schedule; default 1."
   ([in out n] (bind-registered-convert! in out n 1))
   ([in out n w]
    (let [{:keys [module]} (ensure-convert-kernel! w)
@@ -2589,9 +2591,8 @@
          n (long n) w (long w)
          args [(:segment in) (:segment out) {:type :int :value (int n)}]
          bnd (bind-kernel! kh 256 args)
-         ;; one work-item per w elements. Floor at one group so an n < w program still
-         ;; launches the work-items its tail loop needs.
-         gc (max 1 (long (Math/ceil (/ (double (quot n w)) 256.0))))]
+         ;; One work-item owns w masked elements. Floor at one group so n < w still launches.
+         gc (max 1 (long (Math/ceil (/ (double n) (* (double w) 256.0)))))]
      (.set ^MemorySegment (:gc-seg bnd) I32 0 (int gc))
      bnd)))
 
@@ -2604,9 +2605,10 @@
   (ensure-init!)
   (or (get @transpose-cache dtype)
       (let [kname (str "transpose_" (name dtype))
-            src (do (require 'raster.compiler.backend.gpu.opencl-codegen)
-                    ((resolve 'raster.compiler.backend.gpu.opencl-codegen/emit-transpose-kernel)
-                     kname :dtype dtype))
+            src (:source
+                 ((requiring-resolve
+                   'raster.compiler.backend.gpu.layout-transform/emit-transpose-kernel)
+                  {:kernel-name kname :input 'in :output 'out :element-dtype dtype}))
             spv (do (require 'raster.compiler.support.spirv-cache)
                     ((resolve 'raster.compiler.support.spirv-cache/compile-opencl-to-spirv)
                      src :device (:device-id-hex @state)))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -5,6 +5,7 @@
             [raster.compiler.backend.gpu.attention :as attention-emit]
             [raster.compiler.backend.gpu.kernel-body-fixtures :as body-fixtures]
             [raster.compiler.backend.gpu.kernel-body-opencl :as body-emit]
+            [raster.compiler.backend.gpu.layout-transform :as layout-transform]
             [raster.compiler.backend.gpu.segop-opencl :as segop-emit]
             [raster.compiler.backend.gpu.target :as gpu-target]
             [raster.compiler.equation-first :as equation-first]
@@ -311,6 +312,18 @@
                             (segmented-fold-map-artifact dialect))
            (write-source! directory suffix "register-tiled-contraction"
                           (register-tiled-contraction-source dialect))
+           (write-source! directory suffix "layout-cast"
+                          (:source
+                           (layout-transform/emit-cast-kernel
+                            {:kernel-name "layout_cast" :input 'in :output 'out
+                             :source-dtype :float :destination-dtype :half
+                             :vector-width 4 :rounding :nearest-even :overflow :ieee
+                             :target-dialect dialect})))
+           (write-source! directory suffix "layout-transpose"
+                          (:source
+                           (layout-transform/emit-transpose-kernel
+                            {:kernel-name "layout_transpose" :input 'in :output 'out
+                             :element-dtype :half :target-dialect dialect})))
            (write-source! directory suffix "workgroup-memory"
                           (body-emit/emit-scalar-kernel
                            "workgroup_memory" (body-fixtures/workgroup-memory-body 32)

--- a/test/raster/compiler/passes/parallel/layout_transform_schedule_test.clj
+++ b/test/raster/compiler/passes/parallel/layout_transform_schedule_test.clj
@@ -1,0 +1,44 @@
+(ns raster.compiler.passes.parallel.layout-transform-schedule-test
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.kernel-body-opencl :as emitter]
+            [raster.compiler.ir.kernel-body :as body]
+            [raster.compiler.ir.kernel-launch :as launch]
+            [raster.compiler.passes.parallel.layout-transform-schedule :as schedule]))
+
+(deftest cast-is-a-typed-unrolled-affine-kernel-body
+  (let [kernel (schedule/cast-body
+                {:id :cast :input 'x :output 'y :extent-id 'n
+                 :source-dtype :float :destination-dtype :half :vector-width 4
+                 :rounding :nearest-even :overflow :ieee})]
+    (is (body/kernel-body? kernel))
+    (is (= [:float :half :int] (mapv :dtype (:parameters kernel))))
+    (is (= 4 (count (:masks kernel))))
+    (is (= 12 (count (:operations kernel))))
+    (is (= [2] (:group-count
+                (launch/realize (:launch kernel) {'n 1025})))
+        "the masked tail owns a work-item even when the extent is not divisible by four")
+    (is (= {:strategy :affine-elementwise-cast
+            :elements-per-work-item 4 :rounding :nearest-even :overflow :ieee}
+           (:schedule kernel)))
+    (doseq [dialect [:opencl-portable :cuda :hip]]
+      (testing (name dialect)
+        (let [source (emitter/emit-scalar-kernel "cast_rows" kernel
+                                                 {:target-dialect dialect})]
+          (is (str/includes? source "cast_rows"))
+          (is (str/includes? source "layout_converted_3")))))))
+
+(deftest transpose-is-an-affine-permutation-not-target-source
+  (let [kernel (schedule/transpose-body
+                {:id :transpose :input 'x :output 'y
+                 :row-extent-id 'm :column-extent-id 'n
+                 :element-dtype :half})
+        source (emitter/emit-scalar-kernel "transpose_rows" kernel)]
+    (is (body/kernel-body? kernel))
+    (is (= [1 0] (get-in kernel [:schedule :permutation])))
+    (is (= [:layout-row :layout-column]
+           (get-in kernel [:operations 0 :coordinates])))
+    (is (= [:layout-column :layout-row]
+           (get-in kernel [:operations 1 :coordinates])))
+    (is (str/includes? source "rstr_layout_column"))
+    (is (str/includes? source "rstr_layout_row"))))

--- a/test/raster/dl/gsdm_test.clj
+++ b/test/raster/dl/gsdm_test.clj
@@ -416,14 +416,16 @@
                    (emit "bad" :c-dtype :float :beta 1.0 :epilogue (fn [a _ _] a)))
           "epilogue + beta≠0 (both write the store) is rejected"))))
 
-(deftest transpose-kernel-layout-driven-byte-identical
-  (testing "the transpose kernel is now LAYOUT-DRIVEN (indices from layout/layout->offset) yet emits
-            the byte-identical row-major index line — the first place a layout drives codegen"
-    (require 'raster.compiler.backend.gpu.opencl-codegen)
-    (let [emit (resolve 'raster.compiler.backend.gpu.opencl-codegen/emit-transpose-kernel)]
+(deftest transpose-kernel-is-lowered-from-the-layout-transform-body
+  (testing "the transpose is a typed affine permutation before target source emission"
+    (require 'raster.compiler.backend.gpu.layout-transform)
+    (let [emit (resolve 'raster.compiler.backend.gpu.layout-transform/emit-transpose-kernel)]
       (doseq [dt [:float :double :half]]
-        (is (.contains ^String (emit "t" :dtype dt) "out[j * rows + i] = in[i * cols + j];")
-            (str "layout-driven transpose index must be byte-identical for " dt))))))
+        (let [{:keys [source kernel-body]}
+              (emit {:kernel-name "t" :input 'in :output 'out :element-dtype dt})]
+          (is (= [1 0] (get-in kernel-body [:schedule :permutation])))
+          (is (.contains ^String source "rstr_layout_column")
+              (str "layout-driven transpose must lower for " dt)))))))
 
 (deftest gemm-tiled-kernel-test
   (testing "tile-parametric GEMM kernel generates valid OpenCL"

--- a/test/raster/gpu/gemm_splitk_test.clj
+++ b/test/raster/gpu/gemm_splitk_test.clj
@@ -77,15 +77,13 @@
             (destroy! g))
           (doseq [b [af bf a16 b16 c-plain c-split parts]] (free! b)))))))
 
-(deftest vectorized-convert-is-bit-exact
-  ;; The f32→f16 operand cast is VECTORIZED (w elements per work-item, w from the hardware
-  ;; descriptor). `vstore_halfN` rounds to nearest-even — the same rounding as the `(half)`
-  ;; cast it replaced — so the result must be BIT-IDENTICAL to the scalar reference, not
-  ;; merely close. The interesting cases are the ones a vectorized kernel gets wrong:
-  ;; an n that is not a multiple of w (the tail loop) and an n below w (no vector iteration
-  ;; at all, and a group count that must not round down to zero).
+(deftest unrolled-layout-convert-is-bit-exact
+  ;; The f32→f16 operand cast schedules w statically unrolled, lane-owned elements per work-item.
+  ;; Its explicit nearest-even IEEE conversion must be BIT-IDENTICAL to the scalar reference, not
+  ;; merely close. The interesting cases are a non-multiple tail and an extent below w, where the
+  ;; launch still needs one workgroup and every inactive unrolled element must remain masked.
   (if-not @gp/gpu-available?
-    (gp/gpu-skip! "vectorized convert")
+    (gp/gpu-skip! "unrolled layout convert")
     (let [ze (do (require 'raster.gpu.ze-runtime) (find-ns 'raster.gpu.ze-runtime))
           make-buffer (ns-resolve ze 'make-buffer)
           upload!     (ns-resolve ze 'array->buffer!)


### PR DESCRIPTION
Stacked after PR 339. Replaces the handwritten OpenCL float-to-half and transpose emitters with one target-neutral affine layout-transform schedule and C-family lowering. Mixed GEMM graphs, the older GPU-plan seam, and raw Level Zero benchmark entry points now consume the same implementation. Numerical cast policy and tail masks are explicit. Focused unit tests pass; Arc tail execution is bit-exact; generated kernels compile locally with nvcc for SM80 and hipcc for gfx1100. CUDA/HIP fixtures are included in CI.