### PR TITLE
Lower split-K combine as a typed contraction

### DIFF
--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -15,6 +15,8 @@
             [raster.compiler.ir.kernel-graph :as kgraph]
             [raster.compiler.ir.kernel-body :as kbody]
             [raster.compiler.ir.kernel-launch :as klaunch]
+            [raster.compiler.ir.contraction-facts :as contraction-facts]
+            [raster.compiler.passes.parallel.contract-lower :as contract-lower]
             [raster.compiler.passes.parallel.contraction-schedule :as contraction-schedule]))
 
 (def ^:private default-min-split-chunk 1024)
@@ -258,18 +260,46 @@
      phase (cond-> {:tile tile :split-k? split-k? :accumulator-dtype :float}
              scheduled (assoc :kernel-body (:kernel-body scheduled))))))
 
+(defn emit-split-k-combine-kernel
+  "Lower C[i] = sum_s partials[s, i] through the generic portable contraction schedule."
+  ([kernel-name] (emit-split-k-combine-kernel kernel-name :opencl-intel))
+  ([kernel-name target-dialect]
+   (let [form '(raster.par/contract C [[i mn]] [[s splits]]
+                                     (clojure.core/aget
+                                      partials (clojure.core/+ (clojure.core/* s mn) i)))
+        facts (contraction-facts/contraction-facts form :dtype :float)
+        operation (contract-lower/contract-form->segred form :dtype :float :facts facts)
+        planned (contraction-schedule/plan-portable-body
+                 facts operation {}
+                 {:array-types {'partials :float 'C :float}
+                  :scalar-types {'mn :int 'splits :int}})
+        _ (when-not (:ok planned)
+            (throw (ex-info "split-K combination did not admit the portable contraction schedule"
+                            {:reason :raster/bug :plan planned})))
+        kernel-body (:body planned)
+        source (kernel-body-opencl/emit-scalar-kernel
+                kernel-name kernel-body
+                {:target-dialect target-dialect
+                 :parameter-names {'partials "partials" 'C "C"
+                                   'mn "mn" 'splits "splits" '_nseg "_nseg"}})]
+     {:source source :kernel-body kernel-body :workgroup-size 256})))
+
 (defn- combine-artifact
   [kernel-name partials c mn splits]
-  (artifact
-   kernel-name (codegen/emit-gemm-splitk-reduce-kernel kernel-name)
-   [(kabi/slot partials :input :float :c-name "partials")
-    (kabi/slot c :output :float :c-name "C")
-    (kabi/slot :mn :scalar :int :c-name "mn")
-    (kabi/slot :splits :scalar :int :c-name "splits")]
-   [partials c mn splits]
-   (klaunch/spec {:workgroup-size [256]
-                  :group-count [(klaunch/ceil-div (klaunch/runtime-value mn) 256)]})
-   :split-k-combine {:accumulator-dtype :float}))
+  (let [{:keys [source kernel-body]} (emit-split-k-combine-kernel kernel-name)]
+    (artifact
+     kernel-name source
+     [(kabi/slot 'partials :input :float :c-name "partials" :role :operand
+                 :aliasing :no-write-alias)
+      (kabi/slot 'C :output :float :c-name "C" :role :result)
+      (kabi/slot 'mn :scalar :int :c-name "mn" :role :extent)
+      (kabi/slot 'splits :scalar :int :c-name "splits" :role :extent)
+      (kabi/slot '_nseg :scalar :int :c-name "_nseg" :role :bound)]
+     [partials c mn splits mn]
+     (klaunch/spec {:workgroup-size [256]
+                    :group-count [(klaunch/ceil-div (klaunch/runtime-value mn) 256)]})
+     :split-k-combine {:accumulator-dtype :float :kernel-body kernel-body
+                       :semantic-op :contraction})))
 
 (defn- xmx-graph
   [{:keys [id a b c m n k variant tile vector-width requested-splits split-k?] :as spec}]

--- a/src/raster/compiler/backend/gpu/opencl_codegen.clj
+++ b/src/raster/compiler/backend/gpu/opencl_codegen.clj
@@ -698,23 +698,6 @@
                      "      }\n    }\n")))
        "}\n"))))
 
-(defn emit-gemm-splitk-reduce-kernel
-  "Second stage of a split-k GEMM: C[i] = Σ_s partials[s·MN + i], i < MN = M·N.
-  One work-item per OUTPUT element (grid-stride), each summing `splits` f32
-  partials — MN work items, so the combine itself has full occupancy whenever the
-  GEMM's output is non-tiny. f32 throughout (the partials are f32 accumulators)."
-  [kernel-name]
-  (str "__kernel void " kernel-name "(\n"
-       "    __global const float* restrict partials,\n"
-       "    __global float* restrict C,\n"
-       "    int mn, int splits) {\n"
-       "    for (int i = get_global_id(0); i < mn; i += get_global_size(0)) {\n"
-       "        float acc = 0.0f;\n"
-       "        for (int s = 0; s < splits; ++s) acc += partials[(long)s * (long)mn + i];\n"
-       "        C[i] = acc;\n"
-       "    }\n"
-       "}\n"))
-
 (defn gemm-launch-config
   "Compute 2D launch config for GEMM kernel.
   Returns {:workgroup-size [256 1] :group-count [gc-n gc-m]}

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -2404,16 +2404,18 @@
   (ensure-init!)
   (when (nil? @splitk-reduce-cache)
     (let [kname "gemm_splitk_reduce"
-          src (do (require 'raster.compiler.backend.gpu.opencl-codegen)
-                  ((resolve 'raster.compiler.backend.gpu.opencl-codegen/emit-gemm-splitk-reduce-kernel)
-                   kname))
+          emitted ((requiring-resolve
+                    'raster.compiler.backend.gpu.gemm/emit-split-k-combine-kernel)
+                   kname)
+          src (:source emitted)
           spv (do (require 'raster.compiler.support.spirv-cache)
                   ((resolve 'raster.compiler.support.spirv-cache/compile-opencl-to-spirv)
                    src :device (:device-id-hex @state)))
           module (load-module! spv)
           kernel (create-kernel module kname)]
       (clojure.core/reset! splitk-reduce-cache
-                           {:module module :kernel kernel :kernel-name kname})))
+                           {:module module :kernel kernel :kernel-name kname
+                            :kernel-body (:kernel-body emitted)})))
   @splitk-reduce-cache)
 
 (defn bind-registered-gemm-splitk!
@@ -2446,7 +2448,8 @@
         kh (create-kernel-fresh module kernel-name)
         mn (long mn) splits (long splits)
         args [(:segment partials) (:segment c)
-              {:type :int :value (int mn)} {:type :int :value (int splits)}]
+              {:type :int :value (int mn)} {:type :int :value (int splits)}
+              {:type :int :value (int mn)}]
         bnd (bind-kernel! kh 256 args)]
     (.set ^MemorySegment (:gc-seg bnd) I32 0 (int (Math/ceil (/ (double mn) 256.0))))
     bnd))

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -53,7 +53,12 @@
         partial-spec (some (fn [[id spec]] (when (= :partials (last id)) spec))
                            temporary-specs)
         contract (matrix-contract graph)
+        combine (some #(when (= :split-k-combine
+                                (get-in % [:operation :attributes :strategy]))
+                         (:operation %))
+                      (:nodes graph))
         kernel-body (artifact/attribute contract :kernel-body)
+        combine-body (artifact/attribute combine :kernel-body)
         outer-loop (first (filter #(instance? raster.compiler.ir.kernel_body.Loop %)
                                   (get-in kernel-body [:operations 0 :operations])))]
     (is (= :xmx-split-k (executable/strategy graph)))
@@ -65,6 +70,9 @@
                             #(graph-call/resolve-integer scalar-values %)))))
     (is (= 4 (count (:nodes graph))))
     (is (body/kernel-body? kernel-body))
+    (is (body/kernel-body? combine-body)
+        "split-K combination is the portable typed contraction schedule")
+    (is (= :contraction (artifact/attribute combine :semantic-op)))
     (is (= 1 (count (:views kernel-body))))
     (is (= [:splits :m :n] (:shape (first (filter #(= :result (:role %))
                                                   (:parameters kernel-body))))))

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -3,6 +3,7 @@
   (:require [clojure.java.io :as io]
             [raster.arrays]
             [raster.compiler.backend.gpu.attention :as attention-emit]
+            [raster.compiler.backend.gpu.gemm :as gemm-emit]
             [raster.compiler.backend.gpu.kernel-body-fixtures :as body-fixtures]
             [raster.compiler.backend.gpu.kernel-body-opencl :as body-emit]
             [raster.compiler.backend.gpu.layout-transform :as layout-transform]
@@ -324,6 +325,10 @@
                            (layout-transform/emit-transpose-kernel
                             {:kernel-name "layout_transpose" :input 'in :output 'out
                              :element-dtype :half :target-dialect dialect})))
+           (write-source! directory suffix "split-k-combine"
+                          (:source
+                           (gemm-emit/emit-split-k-combine-kernel
+                            "split_k_combine" dialect)))
            (write-source! directory suffix "workgroup-memory"
                           (body-emit/emit-scalar-kernel
                            "workgroup_memory" (body-fixtures/workgroup-memory-body 32)


### PR DESCRIPTION
Stacked after PR 340. Removes the handwritten split-K partial-combine OpenCL emitter. The combine is now an ordinary dynamically shaped additive contraction, scheduled through the portable KernelBody reduction path and lowered by the shared C-family emitter. The graph and raw Level Zero benchmark seam consume the same body. Unit tests pass, Arc split-K matches direct XMX execution, and the generated combine kernel compiles locally to SM80 PTX and gfx1100 code objects; both are now CI fixtures.