### PR TITLE
Lower scalar GEMM fallbacks as typed contractions

### DIFF
--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -8,7 +8,6 @@
   (:require [clojure.string :as str]
             [raster.compiler.backend.gpu.kernel-body-opencl :as kernel-body-opencl]
             [raster.compiler.backend.gpu.layout-transform :as layout-emitter]
-            [raster.compiler.backend.gpu.opencl-codegen :as codegen]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
@@ -71,25 +70,68 @@
     :provenance {:semantic-op :contraction :lowering :gemm-graph :phase phase}
     :attributes (merge {:strategy phase} attributes)}))
 
+(defn- scalar-contraction-form
+  [variant]
+  (case variant
+    :nn '(raster.par/contract C [[i m] [j n]] [[l k]]
+                               (* (aget A (+ (* i k) l))
+                                  (aget B (+ (* l n) j))))
+    :nt '(raster.par/contract C [[i m] [j n]] [[l k]]
+                               (* (aget A (+ (* i k) l))
+                                  (aget B (+ (* j k) l))))
+    :tn '(raster.par/contract C [[i m] [j n]] [[l k]]
+                               (* (aget A (+ (* l m) i))
+                                  (aget B (+ (* l n) j))))))
+
+(defn emit-portable-scalar-matrix-kernel
+  "Lower a dynamic f32 NN/NT/TN matrix product through the portable contraction schedule."
+  ([kernel-name variant]
+   (emit-portable-scalar-matrix-kernel kernel-name variant :opencl-intel))
+  ([kernel-name variant target-dialect]
+   (let [form (scalar-contraction-form variant)
+         facts (contraction-facts/contraction-facts form :dtype :float)
+         operation (contract-lower/contract-form->segred form :dtype :float :facts facts)
+         planned (contraction-schedule/plan-portable-body
+                  facts operation {}
+                  {:array-types {'A :float 'B :float 'C :float}
+                   :scalar-types {'m :int 'n :int 'k :int}})
+         _ (when-not (:ok planned)
+             (throw (ex-info "matrix product did not admit the portable contraction schedule"
+                             {:reason :raster/bug :variant variant :plan planned})))
+         kernel-body (:body planned)]
+     {:source
+      (kernel-body-opencl/emit-scalar-kernel
+       kernel-name kernel-body
+       {:target-dialect target-dialect
+        :parameter-names {'A "A" 'B "B" 'C "C" 'k "k" 'm "m" 'n "n"
+                          '_nseg "_nseg"}})
+      :kernel-body kernel-body
+      :workgroup-size 256})))
+
 (defn- scalar-graph
   [{:keys [id a b c m n k variant] :as spec}]
   (let [{:keys [abi arguments]} (outer-interface spec)
         {:keys [a-elements b-elements c-elements]} (extents spec)
         prefix (identifier (str id "_scalar"))
         kernel-name (str prefix "_gemm")
+        emitted (emit-portable-scalar-matrix-kernel kernel-name variant)
         gemm (artifact
               kernel-name
-              (codegen/emit-gemm-scalar-kernel kernel-name :variant variant)
-              [(kabi/slot a :input :float :c-name "A")
-               (kabi/slot b :input :float :c-name "B")
-               (kabi/slot c :output :float :c-name "C")
-               (kabi/slot m :scalar :int :c-name "m")
-               (kabi/slot n :scalar :int :c-name "n")
-               (kabi/slot k :scalar :int :c-name "k")]
-              [a b c m n k]
+              (:source emitted)
+              [(kabi/slot 'A :input :float :c-name "A" :role :operand
+                          :aliasing :no-write-alias)
+               (kabi/slot 'B :input :float :c-name "B" :role :operand
+                          :aliasing :no-write-alias)
+               (kabi/slot 'C :output :float :c-name "C" :role :result)
+               (kabi/slot 'k :scalar :int :c-name "k" :role :extent)
+               (kabi/slot 'm :scalar :int :c-name "m" :role :extent)
+               (kabi/slot 'n :scalar :int :c-name "n" :role :extent)
+               (kabi/slot '_nseg :scalar :int :c-name "_nseg" :role :bound)]
+              [a b c k m n c-elements]
               (klaunch/spec {:workgroup-size [256]
                              :group-count [(klaunch/ceil-div c-elements 256)]})
-              :scalar-gemm {:variant variant})]
+              :scalar-gemm {:variant variant :kernel-body (:kernel-body emitted)
+                            :semantic-op :contraction})]
     (kgraph/make
      {:inputs [(graph-buffer a :float a-elements :input)
                (graph-buffer b :float b-elements :input)]

--- a/src/raster/compiler/backend/gpu/opencl_codegen.clj
+++ b/src/raster/compiler/backend/gpu/opencl_codegen.clj
@@ -388,41 +388,6 @@
 ;; ================================================================
 
 ;; ================================================================
-;; Scalar (non-XMX) GEMM kernel — small-N fallback
-;; ================================================================
-
-(defn emit-gemm-scalar-kernel
-  "Generate a plain scalar (non-XMX) f32 GEMM kernel for output-column dims too
-  small for the XMX 2D-block path: Intel 2D-block IO requires a >=16-byte pitch,
-  which at fp16 means N>=8 — N in {2,4,6} reads a garbage B tile. This kernel
-  reads the f32 resident buffers DIRECTLY (no f16 convert/transpose expansion),
-  one work-item per C element, grid-stride over m*n, scalar k-loop.
-
-    :nn  C[m,n] = A[m,k] * B[k,n]
-    :nt  C[m,n] = A[m,k] * B[n,k]^T   (B stored row-major [n,k])
-    :tn  C[m,n] = A[k,m]^T * B[k,n]   (A stored row-major [k,m])
-
-  kernel-name: string name. variant: :nn | :nt | :tn (default :nn).
-  Returns OpenCL C source string."
-  [kernel-name & {:keys [variant] :or {variant :nn}}]
-  (let [a-idx (case variant :tn "A[p * m + i]" "A[i * k + p]")
-        b-idx (case variant :nt "B[j * k + p]" "B[p * n + j]")]
-    (str "__kernel void " kernel-name
-         "(__global const float* restrict A,"
-         " __global const float* restrict B,"
-         " __global float* restrict C,"
-         " int m, int n, int k) {\n"
-         "    int total = m * n;\n"
-         "    for (int idx = get_global_id(0); idx < total; idx += get_global_size(0)) {\n"
-         "        int i = idx / n;\n"
-         "        int j = idx % n;\n"
-         "        float acc = 0.0f;\n"
-         "        for (int p = 0; p < k; ++p) acc += " a-idx " * " b-idx ";\n"
-         "        C[idx] = acc;\n"
-         "    }\n"
-         "}\n")))
-
-;; ================================================================
 ;; Axpy kernel (in-place weight update)
 ;; ================================================================
 

--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -2523,16 +2523,18 @@
   (ensure-init!)
   (or (get @gemm-scalar-cache variant)
       (let [kname (str "gemm_scalar_" (name variant))
-            cl-src (do (require 'raster.compiler.backend.gpu.opencl-codegen)
-                       ((resolve 'raster.compiler.backend.gpu.opencl-codegen/emit-gemm-scalar-kernel)
-                        kname :variant variant))
+            emitted ((requiring-resolve
+                      'raster.compiler.backend.gpu.gemm/emit-portable-scalar-matrix-kernel)
+                     kname variant)
+            cl-src (:source emitted)
             device-hex (:device-id-hex @state)
             spv (do (require 'raster.compiler.support.spirv-cache)
                     ((resolve 'raster.compiler.support.spirv-cache/compile-opencl-to-spirv)
                      cl-src :device device-hex))
             module (load-module! spv)
             kernel (create-kernel module kname)
-            entry {:module module :kernel kernel :kernel-name kname}]
+            entry {:module module :kernel kernel :kernel-name kname
+                   :kernel-body (:kernel-body emitted)}]
         (swap! gemm-scalar-cache assoc variant entry)
         entry)))
 
@@ -2550,7 +2552,8 @@
         m (long m) n (long n) k (long k)
         total (* m n)
         args [(:segment a) (:segment b) (:segment c)
-              {:type :int :value (int m)} {:type :int :value (int n)} {:type :int :value (int k)}]
+              {:type :int :value (int k)} {:type :int :value (int m)}
+              {:type :int :value (int n)} {:type :int :value (int total)}]
         bnd (bind-kernel! kh 256 args)]
     (.set ^MemorySegment (:gc-seg bnd) I32 0 (int (Math/ceil (/ (double total) 256.0))))
     bnd))

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -44,6 +44,19 @@
     (testing "a low-output-occupancy, deep-K shape selects a graph-private split"
       (is (= :xmx-split-k (executable/strategy (select [13 640 262144])))))))
 
+(deftest scalar-layout-fallbacks-are-portable-typed-contractions
+  (doseq [variant [:nn :nt :tn]]
+    (let [graph (dispatch/alternative (emitted variant) :f32-scalar)
+          operation (get-in graph [:nodes 0 :operation])
+          kernel-body (artifact/attribute operation :kernel-body)
+          runtime-arguments (arguments 3 2 4)
+          {:keys [buffers scalar-values]} (executable/graph-bindings graph runtime-arguments)
+          call (graph-call/make graph buffers scalar-values)]
+      (is (body/kernel-body? kernel-body) (name variant))
+      (is (= :contraction (artifact/attribute operation :semantic-op)))
+      (is (= [256] (get-in kernel-body [:launch :workgroup-size])))
+      (is (graph-call/kernel-graph-call? call)))))
+
 (deftest split-k-storage-and-launch-use-the-selector-expression
   (let [scheduled (emitted :nn)
         runtime-arguments (arguments 13 640 262144)

--- a/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
+++ b/test/raster/compiler/backend/gpu/kernel_body_compile_fixtures.clj
@@ -329,6 +329,10 @@
                           (:source
                            (gemm-emit/emit-split-k-combine-kernel
                             "split_k_combine" dialect)))
+           (write-source! directory suffix "portable-matrix-nt"
+                          (:source
+                           (gemm-emit/emit-portable-scalar-matrix-kernel
+                            "portable_matrix_nt" :nt dialect)))
            (write-source! directory suffix "workgroup-memory"
                           (body-emit/emit-scalar-kernel
                            "workgroup_memory" (body-fixtures/workgroup-memory-body 32)


### PR DESCRIPTION
Stacked after PR 341. Removes the handwritten scalar NN/NT/TN GEMM OpenCL template. Each fallback is now the same dynamic two-free-axis, one-reduction-axis typed contraction used elsewhere, scheduled through the portable KernelBody path. The graph route and raw Level Zero seam share that implementation. Unit and graph-call tests pass; the small-N Arc execution suite passes; and the NT fixture compiles locally to SM80 PTX and a gfx1100 code object.