### PR TITLE
Schedule mixed matrix graphs from typed contractions

### DIFF
--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -8,6 +8,7 @@
   (:require [clojure.string :as str]
             [raster.compiler.backend.gpu.kernel-body-opencl :as kernel-body-opencl]
             [raster.compiler.backend.gpu.layout-transform :as layout-emitter]
+            [raster.compiler.core.hardware :as hardware]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
@@ -50,8 +51,10 @@
 
 (defn- extents
   [{:keys [m n k variant]}]
-  {:a-elements (if (= :tn variant) (klaunch/product k m) (klaunch/product m k))
-   :b-elements (if (= :nt variant) (klaunch/product n k) (klaunch/product k n))
+  {:a-elements (if (contains? #{:tn :tt} variant)
+                 (klaunch/product k m) (klaunch/product m k))
+   :b-elements (if (contains? #{:nt :tt} variant)
+                 (klaunch/product n k) (klaunch/product k n))
    :c-elements (klaunch/product m n)})
 
 (defn- effects
@@ -81,10 +84,13 @@
                                   (aget B (+ (* j k) l))))
     :tn '(raster.par/contract C [[i m] [j n]] [[l k]]
                                (* (aget A (+ (* l m) i))
-                                  (aget B (+ (* l n) j))))))
+                                  (aget B (+ (* l n) j))))
+    :tt '(raster.par/contract C [[i m] [j n]] [[l k]]
+                               (* (aget A (+ (* l m) i))
+                                  (aget B (+ (* j k) l))))))
 
 (defn emit-portable-scalar-matrix-kernel
-  "Lower a dynamic f32 NN/NT/TN matrix product through the portable contraction schedule."
+  "Lower a dynamic f32 NN/NT/TN/TT matrix product through the portable contraction schedule."
   ([kernel-name variant]
    (emit-portable-scalar-matrix-kernel kernel-name variant :opencl-intel))
   ([kernel-name variant target-dialect]
@@ -354,8 +360,8 @@
         at16 [:gemm id strategy :at16]
         bt16 [:gemm id strategy :bt16]
         partials [:gemm id strategy :partials]
-        final-a (if (= :tn variant) at16 a16)
-        final-b (if (= :nt variant) bt16 b16)
+        final-a (if (contains? #{:tn :tt} variant) at16 a16)
+        final-b (if (contains? #{:nt :tt} variant) bt16 b16)
         kc (when split-k?
              (klaunch/align-up (klaunch/ceil-div k requested-splits) (:block-k tile)))
         splits (when split-k? (klaunch/ceil-div k kc))
@@ -369,10 +375,10 @@
                                     :convert-a)
         convert-b (convert-artifact (str prefix "_convert_b") b b16 b-elements vector-width
                                     :convert-b)
-        transpose-a (when (= :tn variant)
+        transpose-a (when (contains? #{:tn :tt} variant)
                       (transpose-artifact (str prefix "_transpose_a") a16 at16 k m
                                           :transpose-a))
-        transpose-b (when (= :nt variant)
+        transpose-b (when (contains? #{:nt :tt} variant)
                       (transpose-artifact (str prefix "_transpose_b") b16 bt16 n k
                                           :transpose-b))
         contract-output (if split-k? partials c)
@@ -436,6 +442,27 @@
                       (klaunch/floor-div k min-split-chunk)
                       max-splits))))
 
+(defn mixed-dpas-schedule
+  "Return the target-derived schedule facts for the current mixed f16×f16→f32 DPAS graph.
+
+   A nil result is an honest target decline.  CUDA MMA and HIP MFMA will be separate target
+   lowering rows over the same typed contraction; an arbitrary `:matrix` capability must never be
+   emitted with Intel DPAS source."
+  [desc requested-tile]
+  (let [{:keys [family m n k subgroup]} (:matrix desc)
+        backend (:backend desc)]
+    (when (and (contains? #{:ze :opencl} backend)
+               (= :dpas family) (= [8 16 16] [m n k])
+               (contains? #{8 16} subgroup)
+               (contains? (hardware/supported-subgroup-sizes desc) (long subgroup)))
+      (let [tile (or requested-tile (hardware/gemm-tile-for desc))
+            workgroup-size (* (quot (:block-m tile) (:sg-m tile))
+                              (quot (:block-n tile) (:sg-n tile))
+                              subgroup)]
+        {:tile tile
+         :fill-workgroups (hardware/fill-workgroups desc workgroup-size)
+         :matrix (:matrix desc)}))))
+
 (defn emit-executable
   "Emit the resident GEMM schedule as one graph or a checked runtime dispatch.
 
@@ -445,8 +472,8 @@
   [{:keys [id a b c m n k variant precision tile fill-workgroups vector-width]
     :or {vector-width 4}
     :as spec}]
-  (when-not (contains? #{:nn :nt :tn} variant)
-    (throw (ex-info "GEMM executable requires :nn, :nt, or :tn variant"
+  (when-not (contains? #{:nn :nt :tn :tt} variant)
+    (throw (ex-info "GEMM executable requires :nn, :nt, :tn, or :tt variant"
                     {:id id :variant variant})))
   (doseq [[field value] [[:id id] [:a a] [:b b] [:c c] [:m m] [:n n] [:k k]
                          [:precision precision] [:tile tile] [:fill-workgroups fill-workgroups]]]
@@ -469,6 +496,10 @@
           {:kind :runtime-expression-cases
            :cases [{:expression n :op :< :value 8 :strategy :f32-scalar}
                    {:expression k :op :< :value 8 :strategy :f32-scalar}
+                   {:expression (kbody/expression :mod n 8)
+                    :op :> :value 0 :strategy :f32-scalar}
+                   {:expression (kbody/expression :mod k (get-in tile [:matrix :k]))
+                    :op :> :value 0 :strategy :f32-scalar}
                    {:expression split-expression :op :>= :value 2 :strategy :xmx-split-k}]
            :default :xmx-direct}
           :provenance {:semantic-op :contraction :variant variant :lowering :gemm-schedule}

--- a/src/raster/compiler/ir/contraction_facts.clj
+++ b/src/raster/compiler/ir/contraction_facts.clj
@@ -293,6 +293,18 @@
    :quant-naive {:row [:free0 :contract0] :col [:contract0 :free1]}
    :dp4a        {:row [:free0 :contract0] :col [:free1 :contract0]}})
 
+(def dense-matrix-layouts
+  "The four dense two-free/one-contracted matrix storage orientations.
+
+   These are semantic AxisMap requirements, not BLAS call-name patterns.  A contraction may bind
+   either multiplication operand to `:row` or `:col`; `check-layout` proves the assignment against
+   the actual typed operand indices.  Target schedules use the resulting `:variant` only to choose
+   layout adapters before their canonical matrix instruction."
+  {:nn {:row [:free0 :contract0] :col [:contract0 :free1]}
+   :nt {:row [:free0 :contract0] :col [:free1 :contract0]}
+   :tn {:row [:contract0 :free0] :col [:contract0 :free1]}
+   :tt {:row [:contract0 :free0] :col [:free1 :contract0]}})
+
 (defn- role-map
   "The axis-map a role-spec denotes, e.g. [:free0 :contract0] → of-axes [[i M] [l L]] (index i·L+l)."
   [facts axis-roles]
@@ -326,6 +338,51 @@
           {:ok false :reason :layout
            :required (into {} (map (fn [r] [r (am/index-expr (role-map facts (get required r)))])) roles)
            :actual (mapv (juxt :sym :idx) ops)})))))
+
+(defn dense-matrix-view
+  "Recognize the dense matrix view of an ordinary verified product reduction.
+
+   This does not introduce a GEMM semantic node.  It proves that a two-free/one-contracted additive
+   reduction is exactly a product of two dense operands in one of the four AxisMap orientations,
+   and returns the schedule-facing row/column bindings and M/N/K extents.  Anything else returns a
+   structured decline so sparse gathers, extra factors, non-additive monoids, and result transforms
+   remain on their general contraction schedules."
+  [facts]
+  (when-not (facts? facts)
+    (throw (ex-info "dense matrix classification requires verified contraction facts"
+                    {:reason :raster/bug :facts facts})))
+  (let [{:keys [free-axes contract-axes operands epilogue]} facts
+        {:keys [combine neutral element]} (scalar-reduction-view facts)]
+    (cond
+      (not= [2 1] [(count free-axes) (count contract-axes)])
+      {:ok false :reason :not-2-free}
+
+      (not (contains? '#{+ clojure.core/+ raster.numeric/+} combine))
+      {:ok false :reason :non-plus-combine :combine combine}
+
+      (not (and (number? neutral) (zero? neutral)))
+      {:ok false :reason :non-zero-matrix-init :init neutral}
+
+      (nil? (body-product-of element (map :sym operands)))
+      {:ok false :reason :body-has-unmodeled-terms}
+
+      (seq epilogue)
+      {:ok false :reason :matrix-graph-result-transform-not-lowered}
+
+      :else
+      (if-let [[variant verdict]
+               (some (fn [variant]
+                       (let [verdict (check-layout facts (get dense-matrix-layouts variant))]
+                         (when (:ok verdict) [variant verdict])))
+                     [:nn :nt :tn :tt])]
+        {:ok true
+         :variant variant
+         :bindings (:bindings verdict)
+         :dimensions [(second (first free-axes))
+                      (second (second free-axes))
+                      (second (first contract-axes))]}
+        {:ok false :reason :non-dense-matrix-layout
+         :actual (mapv (juxt :sym :idx) operands)}))))
 
 (defn layout-maps
   "For a PASSING `check-layout` verdict, the axis-map of each operand — derived from the layout the

--- a/src/raster/compiler/ir/kernel_launch.clj
+++ b/src/raster/compiler/ir/kernel_launch.clj
@@ -107,6 +107,8 @@
 (defn- minimum? [x]
   (record-kind? "raster.compiler.ir.kernel_launch.Minimum" x))
 
+(declare index-expr? index-cast?)
+
 (defn expression?
   "True for explicit symbolic integer-expression nodes and literal integers. Opaque compiler
    values such as symbols are leaves and are therefore also accepted. Sequential Clojure forms
@@ -122,6 +124,8 @@
     (align-up? x) (and (expression? (:value x))
                        (integer? (:alignment x)) (pos? (:alignment x)))
     (minimum? x) (and (seq (:values x)) (every? expression? (:values x)))
+    (index-expr? x) (and (seq (:arguments x)) (every? expression? (:arguments x)))
+    (index-cast? x) (expression? (:argument x))
     (sequential? x) false
     :else (some? x)))
 
@@ -139,6 +143,9 @@
     (product? expression) (reduce into #{} (map expression-references (:factors expression)))
     (align-up? expression) (expression-references (:value expression))
     (minimum? expression) (reduce into #{} (map expression-references (:values expression)))
+    (index-expr? expression)
+    (reduce into #{} (map expression-references (:arguments expression)))
+    (index-cast? expression) (expression-references (:argument expression))
     :else #{expression}))
 
 (defn- dimension-vector!

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -20,6 +20,7 @@
             [raster.compiler.core.op-descriptor :as od]
             [raster.compiler.core.util :as util]
             [clojure.string :as str]
+            [raster.compiler.backend.gpu.gemm :as gpu-gemm]
             [raster.compiler.passes.parallel.contract-lower :as cl]
             [raster.compiler.backend.gpu.segop-opencl :as sco]
             [raster.compiler.backend.gpu.c-emit :as ce]
@@ -908,9 +909,10 @@
                    :candidate-schedule candidate-schedule}})))
 
 (defn- candidate-dispatch-id
-  [operation-id candidates]
+  [operation-id candidates schedule-identity]
   (let [identity
         [operation-id
+         schedule-identity
          (mapv (fn [{:keys [family strategy artifact]}]
                  (let [kernel-name (:kernel-name artifact)]
                    {:family family
@@ -946,6 +948,87 @@
                       :interface interface}
      :layout {:external-interface interface}}))
 
+(defn- reinterface-graph
+  [graph abi arguments effects operation-id]
+  (kgraph/validate!
+   (-> graph
+       (assoc :abi abi :arguments arguments :effects effects)
+       (update :provenance merge {:operation-id operation-id
+                                  :source-dialect :typed-soac})
+       (update :attributes merge {:candidate-family :matrix
+                                  :semantic-op :contraction}))))
+
+(defn- mixed-dpas-alternatives
+  "Derive graph-valued mixed-precision DPAS schedules from ordinary typed contraction facts.
+
+   The typed equation remains the algorithm.  This bridge contributes only schedule alternatives:
+   explicit f32→f16 layout adapters, a canonical matrix KernelBody, and an optional typed split-K
+   reduction.  It declines as data when the algebra, layout, precision policy, enabled families,
+   or target capability does not justify that transformation."
+  [program operation options abi arguments effects]
+  (let [{:keys [facts dtype operation-id]}
+        (scheduled-typed-contraction-context program operation)
+        precision (or (:precision options) :mixed-f16-f32)
+        matrix-enabled? (contains? (set (get-in operation [:schedule :tuning-space :families]))
+                                   :matrix)
+        matrix-view (when (and matrix-enabled? (= :float (dtype/canon dtype)))
+                      (cf/dense-matrix-view facts))
+        target-schedule (when (and (= :mixed-f16-f32 precision) (:ok matrix-view))
+                          (gpu-gemm/mixed-dpas-schedule (:desc options) (:tile options)))]
+    (cond
+      (not matrix-enabled?)
+      {:alternatives [] :decline {:reason :schedule-family-disabled :family :matrix}}
+
+      (not= :mixed-f16-f32 precision)
+      {:alternatives [] :decline {:reason :precision-policy :precision precision}}
+
+      (not= :float (dtype/canon dtype))
+      {:alternatives [] :decline {:reason :mixed-dpas-source-dtype :dtype dtype}}
+
+      (not (:ok matrix-view))
+      {:alternatives [] :decline (dissoc matrix-view :ok)}
+
+      (nil? target-schedule)
+      {:alternatives []
+       :decline {:reason :mixed-dpas-target-capability
+                 :backend (get-in options [:desc :backend])
+                 :matrix (get-in options [:desc :matrix])}}
+
+      :else
+      (let [[m n k] (:dimensions matrix-view)
+            {:keys [row col]} (:bindings matrix-view)
+            emitted (gpu-gemm/emit-executable
+                     {:id [:typed-contraction operation-id]
+                      :a row :b col :c (:out facts)
+                      :m m :n n :k k
+                      :variant (:variant matrix-view)
+                      :precision :mixed-f16-f32
+                      :tile (:tile target-schedule)
+                      :fill-workgroups (:fill-workgroups target-schedule)})
+            alternatives (->> (:alternatives emitted)
+                              (remove #(= :f32-scalar (get-in % [:attributes :strategy])))
+                              (mapv #(reinterface-graph % abi arguments effects operation-id)))
+            selector (:selector emitted)]
+        {:alternatives alternatives
+         :selector selector
+         :schedule {:family :matrix
+                    :precision :mixed-f16-f32
+                    :variant (:variant matrix-view)
+                    :bindings (:bindings matrix-view)
+                    :dimensions (:dimensions matrix-view)
+                    :tile (:tile target-schedule)
+                    :matrix (:matrix target-schedule)}}))))
+
+(defn- replace-selector-strategy
+  [selector old-strategy new-strategy]
+  (-> selector
+      (update :cases
+              (fn [cases]
+                (mapv #(cond-> % (= old-strategy (:strategy %))
+                               (assoc :strategy new-strategy))
+                      cases)))
+      (update :default #(if (= old-strategy %) new-strategy %))))
+
 (defn route-typed-contraction-dispatch
   "Normalize legal typed contraction leaves behind one logical ABI-compatible dispatch.
 
@@ -962,25 +1045,40 @@
         {:keys [abi arguments public-scalars]}
         (common-logical-interface candidates operation operation-id)
         candidates (mapv #(bindable-private-scalars! % operation-id public-scalars) candidates)
-        default-strategy (:strategy (first candidates))
-        dispatch-id (candidate-dispatch-id operation-id candidates)
+        fallback-strategy (:strategy (first candidates))
+        common-effects (:effects (:artifact (first candidates)))
+        mixed (mixed-dpas-alternatives program operation options abi arguments common-effects)
+        default-strategy (if (seq (:alternatives mixed)) :xmx-direct fallback-strategy)
+        schedule-identity (select-keys mixed [:schedule :decline])
+        dispatch-id (candidate-dispatch-id operation-id candidates schedule-identity)
         candidates (mapv #(deterministic-candidate-entry-point % dispatch-id) candidates)
-        alternatives (mapv #(candidate-graph % operation-id abi arguments) candidates)]
+        alternatives (into (mapv #(candidate-graph % operation-id abi arguments) candidates)
+                           (:alternatives mixed))
+        selector (if (seq (:alternatives mixed))
+                   (replace-selector-strategy (:selector mixed)
+                                              :f32-scalar fallback-strategy)
+                   {:kind :fixed-strategy :strategy default-strategy})]
     (kdispatch/make
      {:id dispatch-id
       :alternatives alternatives
       :default-strategy default-strategy
-      :selector {:kind :fixed-strategy :strategy default-strategy}
+      :selector selector
       :provenance {:operation-id operation-id
                    :semantic-op :contraction
                    :source-dialect :typed-soac}
       :attributes {:operation-family :typed-contraction
                    :candidate-schedules
-                   (into {} (map (juxt :strategy :candidate-schedule)) candidates)
+                   (cond-> (into {} (map (juxt :strategy :candidate-schedule)) candidates)
+                     (:schedule mixed)
+                     (assoc :xmx-direct (:schedule mixed)
+                            :xmx-split-k (assoc (:schedule mixed) :split-k? true)))
                    :declines (:declines routed)
+                   :matrix-graph-decline (:decline mixed)
                    :tuning (typed-contraction-tuning-contract schedule dispatch-id abi
                                                                (:precision options))
-                   :selection :analytic-fixed}})))
+                   :selection (if (seq (:alternatives mixed))
+                                :analytic-runtime
+                                :analytic-fixed)}})))
 
 (def ^:private decline-reasons
   "The reasons a tensorize leaf may legitimately REFUSE a shape — a WHITELIST.

--- a/test/raster/compiler/backend/gpu/gemm_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_test.clj
@@ -38,14 +38,16 @@
            (mapv executable/strategy (:alternatives scheduled))))
     (testing "the matrix-instruction pitch gate is part of the selector, not a runtime binder"
       (is (= :f32-scalar (executable/strategy (select [32 4 4096]))))
-      (is (= :f32-scalar (executable/strategy (select [32 128 4])))))
+      (is (= :f32-scalar (executable/strategy (select [32 128 4]))))
+      (is (= :f32-scalar (executable/strategy (select [32 126 4096]))))
+      (is (= :f32-scalar (executable/strategy (select [32 128 4094])))))
     (testing "a machine-filling shape stays direct"
       (is (= :xmx-direct (executable/strategy (select [512 512 512])))))
     (testing "a low-output-occupancy, deep-K shape selects a graph-private split"
       (is (= :xmx-split-k (executable/strategy (select [13 640 262144])))))))
 
 (deftest scalar-layout-fallbacks-are-portable-typed-contractions
-  (doseq [variant [:nn :nt :tn]]
+  (doseq [variant [:nn :nt :tn :tt]]
     (let [graph (dispatch/alternative (emitted variant) :f32-scalar)
           operation (get-in graph [:nodes 0 :operation])
           kernel-body (artifact/attribute operation :kernel-body)
@@ -186,7 +188,7 @@
 
 (deftest layout-variants-are-graph-topology-not-runtime-conventions
   (doseq [[variant expected-node-count transpose-phase]
-          [[:nn 3 nil] [:nt 4 :transpose-b] [:tn 4 :transpose-a]]]
+          [[:nn 3 nil] [:nt 4 :transpose-b] [:tn 4 :transpose-a] [:tt 5 :transpose-a]]]
     (let [graph (dispatch/alternative (emitted variant) :xmx-direct)
           phases (mapv #(get-in % [:operation :attributes :strategy]) (:nodes graph))]
       (is (= expected-node-count (count (:nodes graph))) (name variant))
@@ -195,7 +197,7 @@
 
 (deftest every-layout-schedule-realizes-to-kernel-calls
   (let [runtime-arguments (arguments 13 640 262144)]
-    (doseq [variant [:nn :nt :tn]
+    (doseq [variant [:nn :nt :tn :tt]
             strategy [:xmx-direct :xmx-split-k]]
       (let [graph (dispatch/alternative (emitted variant) strategy)
             {:keys [buffers scalar-values]} (executable/graph-bindings graph runtime-arguments)

--- a/test/raster/compiler/ir/contraction_facts_test.clj
+++ b/test/raster/compiler/ir/contraction_facts_test.clj
@@ -117,6 +117,34 @@
 (def ^:private nn-idx '(clojure.core/+ (clojure.core/* l 6) j))   ; B[l,j]
 (def ^:private nt-idx '(clojure.core/+ (clojure.core/* j 8) l))   ; B[j,l] — K-contiguous
 
+(defn- dense-matrix-form
+  [variant]
+  (let [row-idx (if (contains? #{:tn :tt} variant)
+                  '(clojure.core/+ (clojure.core/* l 4) i)
+                  '(clojure.core/+ (clojure.core/* i 8) l))
+        col-idx (if (contains? #{:nt :tt} variant) nt-idx nn-idx)]
+    (list 'raster.par/contract 'C [['i 4] ['j 6]] [['l 8]]
+          (list 'raster.numeric/* (list 'aget 'A row-idx) (list 'aget 'B col-idx)))))
+
+(deftest dense-matrix-view-is-proved-from-axis-algebra
+  (doseq [variant [:nn :nt :tn :tt]]
+    (testing (name variant)
+      (let [view (cf/dense-matrix-view
+                  (cf/contraction-facts (dense-matrix-form variant) :dtype :float))]
+        (is (:ok view))
+        (is (= variant (:variant view)))
+        (is (= '{:row A :col B} (:bindings view)))
+        (is (= [4 6 8] (:dimensions view))))))
+  (testing "an extra factor is a general contraction, not a matrix schedule"
+    (let [base (dense-matrix-form :nn)
+          rejected (cf/dense-matrix-view
+                    (cf/contraction-facts
+                     (apply list
+                            (assoc (vec base) 4
+                                   (list 'raster.numeric/* (nth base 4) 2.0)))
+                     :dtype :float))]
+      (is (= :body-has-unmodeled-terms (:reason rejected))))))
+
 (deftest orientation-is-a-data-row
   (let [nn (cf/contraction-facts (mm-form nn-idx))
         nt (cf/contraction-facts (mm-form nt-idx))]
@@ -157,10 +185,8 @@
                  (cf/check-layout {:operands [] :roles {}} (:dpas cf/leaf-layouts))))))
 
 ;; ── anti-drift: the data table and the predicate it will replace must AGREE ──────────
-;; `check-layout` is not yet consumed by the gates. That is deliberate — four of the six
-;; orientation call sites live in the quant and dp4a generators, which the next increment deletes
-;; outright, and wiring only the fifth (dpas) would create a dual path. But an unconsumed
-;; capability is how this subsystem drifted in the first place, so the equivalence is PINNED here:
+;; The table is consumed by typed dense-matrix classification and the existing leaf gates.  Keep
+;; their equivalence pinned here while the remaining staged quant compatibility leaves migrate:
 ;; if the table and the live predicate ever disagree on a case, this fails.
 (deftest table-agrees-with-the-live-orientation-gate
   (let [cases [[:nn nn-idx :dpas true] [:nn nn-idx :dp4a false]

--- a/test/raster/compiler/ir/kernel_launch_test.clj
+++ b/test/raster/compiler/ir/kernel_launch_test.clj
@@ -58,6 +58,10 @@
     (is (= #{'m 'n 'k} (launch/expression-references requested-splits)))
     (is (= 26 (launch/resolve-expression {'m 13 'n 640 'k 262144}
                                          requested-splits))))
+  (let [remainder (body/expression :mod 'k 16)]
+    (is (launch/expression? remainder))
+    (is (= #{'k} (launch/expression-references remainder)))
+    (is (= 14 (launch/resolve-expression {'k 510} remainder))))
   (is (= [3 2]
          (:group-count
           (launch/realize

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1077,6 +1077,56 @@
         (is (= :portable-segred (:leaf (ex-data exception))))
         (is (= :none (:fallback (ex-data exception))))))))
 
+(deftest dynamic-f32-contraction-owns-its-dpas-graph-alternatives
+  (let [source
+        '(let* [step (raster.par/contract C [[i m] [j n]] [[l k]]
+                                          (* (clojure.core/aget A (+ (* i k) l))
+                                             (clojure.core/aget B (+ (* l n) j))))]
+               step)
+        {:keys [form]}
+        (pipeline/schedule-parallel-form
+         source {:target-device :ze:0 :dtype :float
+                 :array-types {'A :float 'B :float 'C :float}
+                 :scalar-types {'m :int 'n :int 'k :int}})
+        operation (-> form :equations first :operations first)
+        algorithm (-> form :equations first :algorithm)
+        descriptor {:backend :ze
+                    :matrix {:family :dpas :m 8 :n 16 :k 16 :subgroup 16}
+                    :execution {:subgroup-sizes #{16 32} :max-workgroup-size 1024}
+                    :subgroup-size 16 :max-workgroup-size 1024
+                    :grf-bytes-per-lane 256 :machine-lanes 8192
+                    :shared-local-memory 131072}
+        dispatch (contract-route/route-typed-contraction-dispatch
+                  algorithm operation :dtype :float :desc descriptor
+                  :precision :mixed-f16-f32)
+        strategies (mapv kdispatch/alternative-strategy (:alternatives dispatch))
+        select (fn [m n k]
+                 (kdispatch/alternative-strategy
+                  (kdispatch/select-alternative dispatch
+                                                [:a :b :c m n k])))]
+    (is (= [:portable-segred :xmx-direct :xmx-split-k] strategies))
+    (is (apply = (map :abi (:alternatives dispatch))))
+    (is (apply = (map :arguments (:alternatives dispatch))))
+    (is (= '[A B C m n k] (:arguments (first (:alternatives dispatch)))))
+    (is (= :xmx-direct (select 512 512 512)))
+    (is (= :portable-segred (select 512 510 512))
+        "a misaligned half row pitch cannot enter the DPAS graph")
+    (is (= :portable-segred (select 512 512 510))
+        "a partial matrix K fragment cannot enter the DPAS graph")
+    (is (= :mixed-f16-f32
+           (get-in dispatch [:attributes :candidate-schedules :xmx-direct :precision])))
+    (is (nil? (get-in dispatch [:attributes :matrix-graph-decline])))
+    (testing "a non-DPAS target keeps the same semantic contraction on portable schedules"
+      (let [portable (contract-route/route-typed-contraction-dispatch
+                      algorithm operation :dtype :float
+                      :desc (assoc descriptor :backend :cuda
+                                   :matrix {:family :mma :m 16 :n 16 :k 16 :subgroup 32})
+                      :precision :mixed-f16-f32)]
+        (is (= [:portable-segred]
+               (mapv kdispatch/alternative-strategy (:alternatives portable))))
+        (is (= :mixed-dpas-target-capability
+               (get-in portable [:attributes :matrix-graph-decline :reason])))))))
+
 (deftest typed-contraction-schedule-families-control-leaf-selection
   (let [source
         '(let* [step (raster.par/contract C [[i 128] [j 128]] [[l 128]]


### PR DESCRIPTION
Typed segmented product reductions now derive a dense matrix view from verified AxisMaps and admit DPAS direct/split-K graphs as schedule alternatives behind the same semantic ABI. Dynamic selection includes explicit pitch and fragment-alignment gates, all NN/NT/TN/TT layouts are graph transforms, and non-DPAS targets retain the portable typed route. This is the bridge required before deleting the legacy resident :gemm binder; it does not introduce a GEMM semantic operator.