### PR TITLE
Derive batched matrix schedules from typed contractions

### DIFF
--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -49,6 +49,17 @@
          (kabi/slot k :scalar :int :c-name "K" :role :extent)]
    :arguments [a b c m n k]})
 
+(defn- batched-outer-interface
+  [{:keys [a b c batch m n k]}]
+  {:abi [(kabi/slot a :input :float :c-name "A" :role :lhs)
+         (kabi/slot b :input :float :c-name "B" :role :rhs)
+         (kabi/slot c :output :float :c-name "C" :role :result)
+         (kabi/slot batch :scalar :int :c-name "batch" :role :extent)
+         (kabi/slot m :scalar :int :c-name "M" :role :extent)
+         (kabi/slot n :scalar :int :c-name "N" :role :extent)
+         (kabi/slot k :scalar :int :c-name "K" :role :extent)]
+   :arguments [a b c batch m n k]})
+
 (defn- extents
   [{:keys [m n k variant]}]
   {:a-elements (if (contains? #{:tn :tt} variant)
@@ -251,29 +262,47 @@
       :parameter-names {kc "KC" splits "splits"}})))
 
 (defn emit-scheduled-batched-matrix-kernel
-  "Lower independent dense matrix slabs as grid-Z-selected contiguous buffer views."
-  [{:keys [kernel-name id a b c m n k batch tile provenance]}]
+  "Lower independent dense matrix slabs as grid-Z-selected contiguous buffer views.
+
+   `batching` states whether each operand carries the leading batch axis.  A false entry denotes a
+   stable broadcast operand (most commonly shared model weights), so its view has zero batch
+   offset instead of materializing a repeated tensor."
+  [{:keys [kernel-name id a b c m n k batch tile provenance batching]
+    :or {batching {:row true :col true}}}]
   (let [z 'slab
         a-view 'batch-lhs-view
         b-view 'batch-rhs-view
-        c-view 'batch-result-view]
+        c-view 'batch-result-view
+        row-batched? (get batching :row true)
+        col-batched? (get batching :col true)
+        a-shape (if row-batched? [batch m k] [m k])
+        b-shape (if col-batched? [batch k n] [k n])
+        buffer-views
+        (cond-> [{:id c-view :buffer c
+                  :element-offset (kbody/expression :mul z m n) :shape [m n]}]
+          row-batched?
+          (conj {:id a-view :buffer a
+                 :element-offset (kbody/expression :mul z m k) :shape [m k]})
+          col-batched?
+          (conj {:id b-view :buffer b
+                 :element-offset (kbody/expression :mul z k n) :shape [k n]}))
+        operation-buffers
+        (cond-> {c c-view}
+          row-batched? (assoc a a-view)
+          col-batched? (assoc b b-view))]
     (emit-scheduled-matrix-kernel
      {:kernel-name kernel-name :id id :a a :b b :c c :m m :n n :k k
       :tile tile :result-dtype :float :provenance provenance
       :additional-parameters [(kbody/->KernelParameter batch :scalar :int [] nil nil :schedule)]
       :additional-indices [(kbody/->IndexBinding z :group 2)]
-      :buffer-shapes {a [batch m k] b [batch k n] c [batch m n]}
-      :buffer-views [{:id a-view :buffer a
-                      :element-offset (kbody/expression :mul z m k) :shape [m k]}
-                     {:id b-view :buffer b
-                      :element-offset (kbody/expression :mul z k n) :shape [k n]}
-                     {:id c-view :buffer c
-                      :element-offset (kbody/expression :mul z m n) :shape [m n]}]
-      :operation-buffers {a a-view b b-view c c-view}
+      :buffer-shapes {a a-shape b b-shape c [batch m n]}
+      :buffer-views buffer-views
+      :operation-buffers operation-buffers
       :launch-group-count [(klaunch/ceil-div (klaunch/runtime-value n) (:block-n tile))
                            (klaunch/ceil-div (klaunch/runtime-value m) (:block-m tile))
                            (klaunch/runtime-value batch)]
-      :attributes {:grid-z {:index z :extent batch :purpose :independent-slices}}
+      :attributes {:grid-z {:index z :extent batch :purpose :independent-slices}
+                   :batching batching}
       :parameter-names {batch "batch"}})))
 
 (defn- gemm-artifact
@@ -420,6 +449,115 @@
       :provenance {:semantic-op :contraction :variant variant :lowering :xmx-gemm}
       :attributes {:strategy strategy :variant variant :precision :mixed-f16-f32
                    :tile tile :requested-splits requested-splits}})))
+
+(defn- batched-gemm-artifact
+  [{:keys [id a b c batch m n k tile batching]}]
+  (let [{:keys [block-m block-n]} tile
+        kernel-name (str (identifier (str id "_xmx_batched")) "_contract")
+        scheduled (emit-scheduled-batched-matrix-kernel
+                   {:kernel-name kernel-name
+                    :id [:gemm id :xmx-batched]
+                    :a a :b b :c c :m m :n n :k k :batch batch :batching batching
+                    :tile tile
+                    :provenance {:operation-id id :phase :matrix-contract}})]
+    (artifact
+     kernel-name (:source scheduled)
+     [(kabi/slot a :input :half :c-name "A")
+      (kabi/slot b :input :half :c-name "B")
+      (kabi/slot c :output :float :c-name "C")
+      (kabi/slot m :scalar :int :c-name "M")
+      (kabi/slot n :scalar :int :c-name "N")
+      (kabi/slot k :scalar :int :c-name "K")
+      (kabi/slot batch :scalar :int :c-name "batch")]
+     [a b c m n k batch]
+     (klaunch/spec
+      {:workgroup-size (:workgroup-size scheduled)
+       :group-count [(klaunch/ceil-div n block-n)
+                     (klaunch/ceil-div m block-m)
+                     (klaunch/runtime-value batch)]})
+     :matrix-contract
+     {:tile tile
+      :batched? true
+      :batching batching
+      :accumulator-dtype :float
+      :kernel-body (:kernel-body scheduled)})))
+
+(defn emit-batched-matrix-alternative
+  "Emit one compiler-owned matrix schedule for a leading batch of dense NN contractions.
+
+   The input and result tensors remain ordinary contiguous f32 values.  Flat layout adapters
+   convert both operands once, then a grid-Z-selected matrix KernelBody interprets them as
+   [batch,M,K], [batch,K,N], and [batch,M,N] views.  The return value deliberately is not a
+   standalone dispatch: the originating typed contraction supplies its general fallback and this
+   schedule contributes the alignment selector that chooses between them."
+  [{:keys [id a b c batch m n k variant tile vector-width batching]
+    :or {vector-width 4 batching {:row true :col true}}
+    :as spec}]
+  (when-not (= :nn variant)
+    (throw (ex-info "batched matrix schedule currently requires canonical NN storage"
+                    {:reason :batched-matrix-layout-not-lowered
+                     :id id :variant variant})))
+  (doseq [[field value] [[:id id] [:a a] [:b b] [:c c] [:batch batch]
+                         [:m m] [:n n] [:k k] [:tile tile]]]
+    (when (nil? value)
+      (throw (ex-info "batched matrix schedule is missing a required field"
+                      {:reason :raster/bug :field field :spec spec}))))
+  (let [{:keys [abi arguments]} (batched-outer-interface spec)
+        a-elements (if (get batching :row true)
+                     (klaunch/product batch m k)
+                     (klaunch/product m k))
+        b-elements (if (get batching :col true)
+                     (klaunch/product batch k n)
+                     (klaunch/product k n))
+        c-elements (klaunch/product batch m n)
+        prefix (identifier (str id "_xmx_batched"))
+        a16 [:gemm id :xmx-batched :a16]
+        b16 [:gemm id :xmx-batched :b16]
+        convert-a-id [:gemm id :xmx-batched :convert-a]
+        convert-b-id [:gemm id :xmx-batched :convert-b]
+        contract-id [:gemm id :xmx-batched :contract]
+        convert-a (convert-artifact (str prefix "_convert_a") a a16 a-elements vector-width
+                                    :convert-a)
+        convert-b (convert-artifact (str prefix "_convert_b") b b16 b-elements vector-width
+                                    :convert-b)
+        contract (batched-gemm-artifact
+                  (assoc spec :a a16 :b b16 :c c :batching batching))
+        graph
+        (kgraph/make
+         {:inputs [(graph-buffer a :float a-elements :input)
+                   (graph-buffer b :float b-elements :input)]
+          :outputs [(graph-buffer c :float c-elements :output)]
+          :temporaries [(graph-buffer a16 :half a-elements :temporary)
+                        (graph-buffer b16 :half b-elements :temporary)]
+          :nodes [(node convert-a-id convert-a
+                        [(value-use a :read) (value-use a16 :write)] [])
+                  (node convert-b-id convert-b
+                        [(value-use b :read) (value-use b16 :write)] [])
+                  (node contract-id contract
+                        [(value-use a16 :read) (value-use b16 :read)
+                         (value-use c :write)]
+                        [convert-a-id convert-b-id])]
+          :abi abi :arguments arguments
+          :effects (effects spec)
+          :provenance {:semantic-op :contraction
+                       :variant :nn
+                       :lowering :batched-xmx-gemm}
+          :attributes {:strategy :xmx-batched
+                       :variant :nn
+                       :batched? true
+                       :batching batching
+                       :precision :mixed-f16-f32
+                       :tile tile}})]
+    {:graph graph
+     :selector
+     {:kind :runtime-expression-cases
+      :cases [{:expression n :op :< :value 8 :strategy :f32-scalar}
+              {:expression k :op :< :value 8 :strategy :f32-scalar}
+              {:expression (kbody/expression :mod n 8)
+               :op :> :value 0 :strategy :f32-scalar}
+              {:expression (kbody/expression :mod k (get-in tile [:matrix :k]))
+               :op :> :value 0 :strategy :f32-scalar}]
+      :default :xmx-batched}}))
 
 (defn requested-splits
   "Build the generic occupancy expression used by both selection and split-K storage/launches."

--- a/src/raster/compiler/ir/contraction_facts.clj
+++ b/src/raster/compiler/ir/contraction_facts.clj
@@ -305,6 +305,20 @@
    :tn {:row [:contract0 :free0] :col [:contract0 :free1]}
    :tt {:row [:contract0 :free0] :col [:free1 :contract0]}})
 
+(def dense-batched-matrix-layouts
+  "Canonical dense batch×matrix storage layouts.
+
+   The leading free axis selects an independent slab; the other two free axes and the contracted
+   axis retain the ordinary M/N/K meaning.  This first schedule row is deliberately NN-only.
+   Transposed batched operands require a compiler-owned batched layout transform before they can
+   enter the same matrix body; they must not be accepted by assuming a stride convention."
+  {:both       {:row [:free0 :free1 :contract0]
+                :col [:free0 :contract0 :free2]}
+   :shared-col {:row [:free0 :free1 :contract0]
+                :col [:contract0 :free2]}
+   :shared-row {:row [:free1 :contract0]
+                :col [:free0 :contract0 :free2]}})
+
 (defn- role-map
   "The axis-map a role-spec denotes, e.g. [:free0 :contract0] → of-axes [[i M] [l L]] (index i·L+l)."
   [facts axis-roles]
@@ -344,17 +358,22 @@
 
    This does not introduce a GEMM semantic node.  It proves that a two-free/one-contracted additive
    reduction is exactly a product of two dense operands in one of the four AxisMap orientations,
-   and returns the schedule-facing row/column bindings and M/N/K extents.  Anything else returns a
-   structured decline so sparse gathers, extra factors, non-additive monoids, and result transforms
-   remain on their general contraction schedules."
+   or that a three-free reduction is a leading batch of canonical NN products.  It returns only
+   schedule-facing row/column bindings and B/M/N/K extents.  Anything else returns a structured
+   decline so sparse gathers, extra factors, non-additive monoids, and result transforms remain on
+   their general contraction schedules."
   [facts]
   (when-not (facts? facts)
     (throw (ex-info "dense matrix classification requires verified contraction facts"
                     {:reason :raster/bug :facts facts})))
   (let [{:keys [free-axes contract-axes operands epilogue]} facts
-        {:keys [combine neutral element]} (scalar-reduction-view facts)]
+        {:keys [combine neutral element]} (scalar-reduction-view facts)
+        batched? (= 3 (count free-axes))
+        layouts (if batched? dense-batched-matrix-layouts dense-matrix-layouts)
+        layout-order (if batched? [:both :shared-col :shared-row] [:nn :nt :tn :tt])]
     (cond
-      (not= [2 1] [(count free-axes) (count contract-axes)])
+      (not (and (contains? #{2 3} (count free-axes))
+                (= 1 (count contract-axes))))
       {:ok false :reason :not-2-free}
 
       (not (contains? '#{+ clojure.core/+ raster.numeric/+} combine))
@@ -370,17 +389,26 @@
       {:ok false :reason :matrix-graph-result-transform-not-lowered}
 
       :else
-      (if-let [[variant verdict]
-               (some (fn [variant]
-                       (let [verdict (check-layout facts (get dense-matrix-layouts variant))]
-                         (when (:ok verdict) [variant verdict])))
-                     [:nn :nt :tn :tt])]
-        {:ok true
-         :variant variant
-         :bindings (:bindings verdict)
-         :dimensions [(second (first free-axes))
-                      (second (second free-axes))
-                      (second (first contract-axes))]}
+      (if-let [[layout-kind verdict]
+               (some (fn [layout-kind]
+                       (let [verdict (check-layout facts (get layouts layout-kind))]
+                         (when (:ok verdict) [layout-kind verdict])))
+                     layout-order)]
+        (cond->
+         {:ok true
+          :variant (if batched? :nn layout-kind)
+          :batched? batched?
+          :bindings (:bindings verdict)
+          :dimensions (if batched?
+                        [(second (second free-axes))
+                         (second (nth free-axes 2))
+                         (second (first contract-axes))]
+                        [(second (first free-axes))
+                         (second (second free-axes))
+                         (second (first contract-axes))])}
+          batched? (assoc :batch (second (first free-axes))
+                          :batching {:row (contains? #{:both :shared-col} layout-kind)
+                                     :col (contains? #{:both :shared-row} layout-kind)}))
         {:ok false :reason :non-dense-matrix-layout
          :actual (mapv (juxt :sym :idx) operands)}))))
 

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -997,23 +997,35 @@
       :else
       (let [[m n k] (:dimensions matrix-view)
             {:keys [row col]} (:bindings matrix-view)
-            emitted (gpu-gemm/emit-executable
-                     {:id [:typed-contraction operation-id]
-                      :a row :b col :c (:out facts)
-                      :m m :n n :k k
-                      :variant (:variant matrix-view)
-                      :precision :mixed-f16-f32
-                      :tile (:tile target-schedule)
-                      :fill-workgroups (:fill-workgroups target-schedule)})
-            alternatives (->> (:alternatives emitted)
-                              (remove #(= :f32-scalar (get-in % [:attributes :strategy])))
-                              (mapv #(reinterface-graph % abi arguments effects operation-id)))
+            emit-spec {:id [:typed-contraction operation-id]
+                       :a row :b col :c (:out facts)
+                       :m m :n n :k k
+                       :variant (:variant matrix-view)
+                       :precision :mixed-f16-f32
+                       :tile (:tile target-schedule)
+                       :fill-workgroups (:fill-workgroups target-schedule)}
+            emitted (if (:batched? matrix-view)
+                      (gpu-gemm/emit-batched-matrix-alternative
+                       (assoc emit-spec
+                              :batch (:batch matrix-view)
+                              :batching (:batching matrix-view)))
+                      (gpu-gemm/emit-executable emit-spec))
+            raw-alternatives (if (:batched? matrix-view)
+                               [(:graph emitted)]
+                               (remove #(= :f32-scalar
+                                           (get-in % [:attributes :strategy]))
+                                       (:alternatives emitted)))
+            alternatives (mapv #(reinterface-graph % abi arguments effects operation-id)
+                               raw-alternatives)
             selector (:selector emitted)]
         {:alternatives alternatives
          :selector selector
          :schedule {:family :matrix
                     :precision :mixed-f16-f32
                     :variant (:variant matrix-view)
+                    :batched? (:batched? matrix-view)
+                    :batch (:batch matrix-view)
+                    :batching (:batching matrix-view)
                     :bindings (:bindings matrix-view)
                     :dimensions (:dimensions matrix-view)
                     :tile (:tile target-schedule)
@@ -1048,7 +1060,8 @@
         fallback-strategy (:strategy (first candidates))
         common-effects (:effects (:artifact (first candidates)))
         mixed (mixed-dpas-alternatives program operation options abi arguments common-effects)
-        default-strategy (if (seq (:alternatives mixed)) :xmx-direct fallback-strategy)
+        matrix-default (some-> mixed :alternatives first kdispatch/alternative-strategy)
+        default-strategy (or matrix-default fallback-strategy)
         schedule-identity (select-keys mixed [:schedule :decline])
         dispatch-id (candidate-dispatch-id operation-id candidates schedule-identity)
         candidates (mapv #(deterministic-candidate-entry-point % dispatch-id) candidates)
@@ -1070,8 +1083,11 @@
                    :candidate-schedules
                    (cond-> (into {} (map (juxt :strategy :candidate-schedule)) candidates)
                      (:schedule mixed)
-                     (assoc :xmx-direct (:schedule mixed)
-                            :xmx-split-k (assoc (:schedule mixed) :split-k? true)))
+                     (merge
+                      (if (:batched? (:schedule mixed))
+                        {:xmx-batched (:schedule mixed)}
+                        {:xmx-direct (:schedule mixed)
+                         :xmx-split-k (assoc (:schedule mixed) :split-k? true)})))
                    :declines (:declines routed)
                    :matrix-graph-decline (:decline mixed)
                    :tuning (typed-contraction-tuning-contract schedule dispatch-id abi

--- a/test/raster/compiler/ir/contraction_facts_test.clj
+++ b/test/raster/compiler/ir/contraction_facts_test.clj
@@ -145,6 +145,35 @@
                      :dtype :float))]
       (is (= :body-has-unmodeled-terms (:reason rejected))))))
 
+(deftest batched-dense-matrix-views-are-proved-with-explicit-broadcasting
+  (let [form
+        (fn [col-index]
+          (list 'raster.par/contract 'C [['b 3] ['i 4] ['j 6]] [['l 8]]
+                (list 'raster.numeric/*
+                      (list 'aget 'A
+                            '(clojure.core/+ (clojure.core/*
+                                              (clojure.core/+ (clojure.core/* b 4) i) 8) l))
+                      (list 'aget 'B col-index))))
+        batched-col
+        '(clojure.core/+ (clojure.core/*
+                          (clojure.core/+ (clojure.core/* b 8) l) 6) j)
+        shared-col '(clojure.core/+ (clojure.core/* l 6) j)]
+    (testing "both operands may carry the leading batch axis"
+      (let [view (cf/dense-matrix-view
+                  (cf/contraction-facts (form batched-col) :dtype :float))]
+        (is (:ok view))
+        (is (:batched? view))
+        (is (= 3 (:batch view)))
+        (is (= [4 6 8] (:dimensions view)))
+        (is (= {:row true :col true} (:batching view)))
+        (is (= '{:row A :col B} (:bindings view)))))
+    (testing "a batch-local activation may contract with stable shared weights"
+      (let [view (cf/dense-matrix-view
+                  (cf/contraction-facts (form shared-col) :dtype :float))]
+        (is (:ok view))
+        (is (= {:row true :col false} (:batching view)))
+        (is (= '{:row A :col B} (:bindings view)))))))
+
 (deftest orientation-is-a-data-row
   (let [nn (cf/contraction-facts (mm-form nn-idx))
         nt (cf/contraction-facts (mm-form nt-idx))]

--- a/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
@@ -17,6 +17,13 @@
                                          (clojure.core/aget B (+ (* l n) j))))]
      step))
 
+(def ^:private batched-source
+  '(let* [step (raster.par/contract
+                C [[b batch] [i m] [j n]] [[l k]]
+                (* (clojure.core/aget A (+ (* (+ (* b m) i) k) l))
+                   (clojure.core/aget B (+ (* l n) j))))]
+     step))
+
 (defn- typed-dispatch
   [device-id]
   (let [{:keys [form]}
@@ -25,6 +32,21 @@
                  :dtype :float
                  :array-types {'A :float 'B :float 'C :float}
                  :scalar-types {'m :int 'n :int 'k :int}})
+        equation (first (:equations form))]
+    (contract-route/route-typed-contraction-dispatch
+     (:algorithm equation) (first (:operations equation))
+     :dtype :float
+     :desc (hardware/descriptor-for device-id)
+     :precision :mixed-f16-f32)))
+
+(defn- typed-batched-dispatch
+  [device-id]
+  (let [{:keys [form]}
+        (pipeline/schedule-parallel-form
+         batched-source {:target-device device-id
+                         :dtype :float
+                         :array-types {'A :float 'B :float 'C :float}
+                         :scalar-types {'batch :int 'm :int 'n :int 'k :int}})
         equation (first (:equations form))]
     (contract-route/route-typed-contraction-dispatch
      (:algorithm equation) (first (:operations equation))
@@ -58,6 +80,24 @@
                           (+ sum (* (f16 (aget a (+ (* i k) l)))
                                     (f16 (aget b (+ (* l n) j))))))
                    sum))))))
+    result))
+
+(defn- batched-reference
+  [^floats a ^floats b batch m n k]
+  (let [result (float-array (* batch m n))]
+    (dotimes [batch-index batch]
+      (dotimes [i m]
+        (dotimes [j n]
+          (aset result (+ (* (+ (* batch-index m) i) n) j)
+                (float
+                 (loop [l 0
+                        sum 0.0]
+                   (if (< l k)
+                     (recur (inc l)
+                            (+ sum
+                               (* (f16 (aget a (+ (* (+ (* batch-index m) i) k) l)))
+                                  (f16 (aget b (+ (* l n) j))))))
+                     sum)))))))
     result))
 
 (defn- relative-l1
@@ -111,3 +151,36 @@
               (run-contraction :ze:0 scheduled 13 16 8192)]
           (is (= :xmx-split-k strategy))
           (is (< (relative-l1 actual expected) 1.0e-3)))))))
+
+(deftest batched-typed-contraction-executes-with-shared-weights
+  (if-not @gpu-probe/gpu-available?
+    (gpu-probe/gpu-skip! "batched typed contraction matrix KernelExecutable")
+    (let [device-id :ze:0
+          batch 2
+          m 8
+          n 16
+          k 16
+          a (input-array (* batch m k) 41)
+          b (input-array (* k n) 43)
+          scheduled (typed-batched-dispatch device-id)
+          runtime-arguments
+          [:a :b :c
+           {:type :int :value batch}
+           {:type :int :value m}
+           {:type :int :value n}
+           {:type :int :value k}]
+          selected (dispatch/select-alternative scheduled runtime-arguments)]
+      (is (= :xmx-batched (executable/strategy selected)))
+      (gpu/with-gpu-session [session device-id]
+        (gpu/alloc! session {:a [:float (* batch m k) a]
+                             :b [:float (* k n) b]
+                             :c [:float (* batch m n) nil]})
+        (let [handle (gpu/bind-kernel-executable!
+                      session :typed-batched-contraction selected runtime-arguments)]
+          (try
+            (gpu/run-kernel-graph! session handle)
+            (is (< (relative-l1 (gpu/download session :c)
+                                (batched-reference a b batch m n k))
+                   1.0e-3))
+            (finally
+              (gpu/release-kernel-graph! session handle))))))))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1127,6 +1127,56 @@
         (is (= :mixed-dpas-target-capability
                (get-in portable [:attributes :matrix-graph-decline :reason])))))))
 
+(deftest batched-f32-contraction-derives-one-grid-z-matrix-schedule
+  (let [source
+        '(let* [step (raster.par/contract
+                      C [[b batch] [i m] [j n]] [[l k]]
+                      (* (clojure.core/aget
+                          A (+ (* (+ (* b m) i) k) l))
+                         (clojure.core/aget B (+ (* l n) j))))]
+           step)
+        {:keys [form]}
+        (pipeline/schedule-parallel-form
+         source {:target-device :ze:0 :dtype :float
+                 :array-types {'A :float 'B :float 'C :float}
+                 :scalar-types {'batch :int 'm :int 'n :int 'k :int}})
+        operation (-> form :equations first :operations first)
+        algorithm (-> form :equations first :algorithm)
+        descriptor {:backend :ze
+                    :matrix {:family :dpas :m 8 :n 16 :k 16 :subgroup 16}
+                    :execution {:subgroup-sizes #{16 32} :max-workgroup-size 1024}
+                    :subgroup-size 16 :max-workgroup-size 1024
+                    :grf-bytes-per-lane 256 :machine-lanes 8192
+                    :shared-local-memory 131072}
+        scheduled (contract-route/route-typed-contraction-dispatch
+                   algorithm operation :dtype :float :desc descriptor
+                   :precision :mixed-f16-f32)
+        matrix-graph (kdispatch/alternative scheduled :xmx-batched)
+        matrix-node (last (:nodes matrix-graph))
+        matrix-body (get-in matrix-node [:operation :attributes :kernel-body])
+        buffer-views (into {} (map (juxt :id identity)) (:views matrix-body))
+        select (fn [batch m n k]
+                 (-> (kdispatch/select-alternative
+                      scheduled [:a :b :c batch m n k])
+                     kdispatch/alternative-strategy))]
+    (is (= [:portable-segred :xmx-batched]
+           (mapv kdispatch/alternative-strategy (:alternatives scheduled))))
+    (is (= '[A B C batch m n k] (:arguments matrix-graph)))
+    (is (= :xmx-batched (select 4 64 128 64)))
+    (is (= :portable-segred (select 4 64 126 64)))
+    (is (= :portable-segred (select 4 64 128 62)))
+    (is (= {:row true :col false}
+           (get-in matrix-graph [:attributes :batching])))
+    (is (nil? (get buffer-views 'batch-rhs-view))
+        "shared weights remain the original stable buffer, not a fabricated batched view")
+    (is (= '[k n]
+           (:shape (first (filter #(= :rhs (:role %)) (:parameters matrix-body)))))
+        "the matrix ABI records the shared weight shape without a leading batch extent")
+    (is (= 3 (count (get-in matrix-node [:operation :launch :group-count]))))
+    (is (= 'batch
+           (get-in matrix-node [:operation :launch :group-count 2 :value]))
+        "the third launch dimension is the semantic batch extent")))
+
 (deftest typed-contraction-schedule-families-control-leaf-selection
   (let [source
         '(let* [step (raster.par/contract C [[i 128] [j 128]] [[l 128]]


### PR DESCRIPTION
Generalizes the optimized matrix schedule without adding a GEMM semantic primitive. ContractionFacts proves leading-batch dense products from AxisMaps, including shared-row/shared-column broadcasts. The schedule emits f32 layout adapters plus one grid-Z matrix KernelBody; stable shared weights remain unbatched buffers and batch-local activations/results become checked views. Misaligned shapes retain the ordinary portable typed-contraction fallback.\n\nFocused result: 73 tests, 565 assertions, including real Arc execution of direct, split-K, and batched shared-weight KernelExecutable graphs; zero failures.