### PR TITLE
Fuse typed result transforms into matrix graphs

### DIFF
--- a/src/raster/compiler/backend/gpu/gemm.clj
+++ b/src/raster/compiler/backend/gpu/gemm.clj
@@ -9,6 +9,7 @@
             [raster.compiler.backend.gpu.kernel-body-opencl :as kernel-body-opencl]
             [raster.compiler.backend.gpu.layout-transform :as layout-emitter]
             [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.ir.axis-map :as axis-map]
             [raster.compiler.ir.kernel-abi :as kabi]
             [raster.compiler.ir.kernel-artifact :as kart]
             [raster.compiler.ir.kernel-dispatch :as kdispatch]
@@ -39,15 +40,36 @@
   [id operation uses dependencies]
   (kgraph/->ScheduledKernel id operation (vec uses) (vec dependencies)))
 
+(defn- epilogue-interface
+  [epilogue]
+  (vec
+   (concat
+    (for [{:keys [sym dtype] :or {dtype :float}} (:operands epilogue)]
+      [(kabi/slot sym :input dtype :c-name (name sym) :role :epilogue)
+       sym])
+    (for [{:keys [sym dtype] :or {dtype :float}} (:scalars epilogue)]
+      [(kabi/slot sym :scalar dtype :c-name (name sym) :role :epilogue)
+       sym]))))
+
+(defn- epilogue-buffer-specs
+  [epilogue]
+  (mapv (fn [{:keys [sym dtype map] :or {dtype :float}}]
+          (let [shape (axis-map/shape map)
+                elements (if (seq shape) (apply klaunch/product shape) 1)]
+            {:id sym :dtype dtype :elements elements}))
+        (:operands epilogue)))
+
 (defn- outer-interface
-  [{:keys [a b c m n k]}]
-  {:abi [(kabi/slot a :input :float :c-name "A" :role :lhs)
-         (kabi/slot b :input :float :c-name "B" :role :rhs)
-         (kabi/slot c :output :float :c-name "C" :role :result)
-         (kabi/slot m :scalar :int :c-name "M" :role :extent)
-         (kabi/slot n :scalar :int :c-name "N" :role :extent)
-         (kabi/slot k :scalar :int :c-name "K" :role :extent)]
-   :arguments [a b c m n k]})
+  [{:keys [a b c m n k epilogue]}]
+  (let [base [[(kabi/slot a :input :float :c-name "A" :role :lhs) a]
+              [(kabi/slot b :input :float :c-name "B" :role :rhs) b]
+              [(kabi/slot c :output :float :c-name "C" :role :result) c]
+              [(kabi/slot m :scalar :int :c-name "M" :role :extent) m]
+              [(kabi/slot n :scalar :int :c-name "N" :role :extent) n]
+              [(kabi/slot k :scalar :int :c-name "K" :role :extent) k]]
+        interface (into base (epilogue-interface epilogue))]
+    {:abi (mapv first interface)
+     :arguments (mapv second interface)}))
 
 (defn- batched-outer-interface
   [{:keys [a b c batch m n k]}]
@@ -69,8 +91,10 @@
    :c-elements (klaunch/product m n)})
 
 (defn- effects
-  [{:keys [a b c]}]
-  {:kind :tensor-contraction :reads [a b] :writes [c]})
+  [{:keys [a b c epilogue]}]
+  {:kind :tensor-contraction
+   :reads (into [a b] (map :sym) (:operands epilogue))
+   :writes [c]})
 
 (defn- artifact
   [kernel-name source abi arguments launch phase attributes]
@@ -305,18 +329,17 @@
                    :batching batching}
       :parameter-names {batch "batch"}})))
 
+(defn- kernel-epilogue-interface
+  [kernel-body]
+  (mapv
+   (fn [{:keys [id kind dtype]}]
+     [(kabi/slot id kind dtype :c-name (name id) :role :epilogue)
+      id])
+   (filterv #(= :epilogue (:role %)) (:parameters kernel-body))))
+
 (defn- gemm-artifact
-  [{:keys [id m n k tile]} kernel-name a b c split-k? kc splits phase]
+  [{:keys [id m n k tile epilogue]} kernel-name a b c split-k? kc splits phase]
   (let [{:keys [block-m block-n]} tile
-        abi (cond-> [(kabi/slot a :input :half :c-name "A")
-                     (kabi/slot b :input :half :c-name "B")
-                     (kabi/slot c :output :float :c-name "C")
-                     (kabi/slot m :scalar :int :c-name "M")
-                     (kabi/slot n :scalar :int :c-name "N")
-                     (kabi/slot k :scalar :int :c-name "K")]
-              split-k? (conj (kabi/slot :k-chunk :scalar :int :c-name "KC")
-                             (kabi/slot :splits :scalar :int :c-name "splits")))
-        arguments (cond-> [a b c m n k] split-k? (conj kc splits))
         group-count (cond-> [(klaunch/ceil-div n block-n)
                              (klaunch/ceil-div m block-m)]
                       split-k? (conj (klaunch/runtime-value splits)))
@@ -324,11 +347,24 @@
                    :id [:gemm id phase]
                    :a a :b b :c c :m m :n n :k k
                    :tile tile :result-dtype :float
+                   :epilogue (when-not split-k? epilogue)
                    :provenance {:operation-id id :phase phase}}
         scheduled (if split-k?
                     (emit-scheduled-split-k-kernel
                      (assoc emit-args :kc :k-chunk :splits :splits))
-                    (emit-scheduled-matrix-kernel emit-args))]
+                    (emit-scheduled-matrix-kernel emit-args))
+        base-interface
+        (cond-> [[(kabi/slot a :input :half :c-name "A") a]
+                 [(kabi/slot b :input :half :c-name "B") b]
+                 [(kabi/slot c :output :float :c-name "C") c]
+                 [(kabi/slot m :scalar :int :c-name "M") m]
+                 [(kabi/slot n :scalar :int :c-name "N") n]
+                 [(kabi/slot k :scalar :int :c-name "K") k]]
+          split-k? (conj [(kabi/slot :k-chunk :scalar :int :c-name "KC") kc]
+                         [(kabi/slot :splits :scalar :int :c-name "splits") splits]))
+        interface (into base-interface (kernel-epilogue-interface (:kernel-body scheduled)))
+        abi (mapv first interface)
+        arguments (mapv second interface)]
     (artifact
      kernel-name (:source scheduled)
      abi arguments
@@ -379,9 +415,11 @@
                        :semantic-op :contraction})))
 
 (defn- xmx-graph
-  [{:keys [id a b c m n k variant tile vector-width requested-splits split-k?] :as spec}]
+  [{:keys [id a b c m n k variant tile vector-width requested-splits split-k? epilogue]
+    :as spec}]
   (let [{:keys [abi arguments]} (outer-interface spec)
         {:keys [a-elements b-elements c-elements]} (extents spec)
+        epilogue-buffers (epilogue-buffer-specs epilogue)
         strategy (if split-k? :xmx-split-k :xmx-direct)
         prefix (identifier (str id "_" (name strategy)))
         a16 [:gemm id strategy :a16]
@@ -426,8 +464,10 @@
                             [(value-use b16 :read) (value-use bt16 :write)] [convert-b-id]))
                 true
                 (conj (node contract-id contract
-                            [(value-use final-a :read) (value-use final-b :read)
-                             (value-use contract-output :write)]
+                            (into [(value-use final-a :read) (value-use final-b :read)
+                                   (value-use contract-output :write)]
+                                  (map #(value-use (:id %) :read))
+                                  epilogue-buffers)
                             [(if transpose-a transpose-a-id convert-a-id)
                              (if transpose-b transpose-b-id convert-b-id)]))
                 combine
@@ -439,8 +479,10 @@
                       transpose-b (conj (graph-buffer bt16 :half b-elements :temporary))
                       split-k? (conj (graph-buffer partials :float partial-elements :temporary)))]
     (kgraph/make
-     {:inputs [(graph-buffer a :float a-elements :input)
-               (graph-buffer b :float b-elements :input)]
+     {:inputs (into [(graph-buffer a :float a-elements :input)
+                    (graph-buffer b :float b-elements :input)]
+                   (map #(graph-buffer (:id %) (:dtype %) (:elements %) :input))
+                   epilogue-buffers)
       :outputs [(graph-buffer c :float c-elements :output)]
       :temporaries temporaries
       :nodes nodes
@@ -601,13 +643,54 @@
          :fill-workgroups (hardware/fill-workgroups desc workgroup-size)
          :matrix (:matrix desc)}))))
 
+(defn emit-matrix-alternatives
+  "Emit direct and, when algebraically valid, split-K matrix graph schedules.
+
+   This is the schedule contribution used by a typed contraction dispatch; it does not invent a
+   scalar fallback or a new semantic operation.  A result transform is fused into the direct
+   matrix store.  Split-K is withheld until the final combine can own that transform exactly—
+   applying it independently to partial sums would be a silent algebraic error."
+  [{:keys [id a b c m n k variant tile fill-workgroups vector-width epilogue]
+    :or {vector-width 4}
+    :as spec}]
+  (when-not (contains? #{:nn :nt :tn :tt} variant)
+    (throw (ex-info "matrix alternatives require :nn, :nt, :tn, or :tt variant"
+                    {:id id :variant variant})))
+  (doseq [[field value] [[:id id] [:a a] [:b b] [:c c] [:m m] [:n n] [:k k]
+                         [:tile tile] [:fill-workgroups fill-workgroups]]]
+    (when (nil? value)
+      (throw (ex-info "matrix alternatives are missing a required field"
+                      {:field field :spec spec}))))
+  (let [spec (assoc spec :vector-width vector-width)
+        split-expression (requested-splits spec)
+        xmx-spec (assoc spec :requested-splits split-expression)
+        direct (xmx-graph (assoc xmx-spec :split-k? false))
+        split? (not (seq epilogue))
+        split (when split? (xmx-graph (assoc xmx-spec :split-k? true)))
+        alignment-cases
+        [{:expression n :op :< :value 8 :strategy :f32-scalar}
+         {:expression k :op :< :value 8 :strategy :f32-scalar}
+         {:expression (kbody/expression :mod n 8)
+          :op :> :value 0 :strategy :f32-scalar}
+         {:expression (kbody/expression :mod k (get-in tile [:matrix :k]))
+          :op :> :value 0 :strategy :f32-scalar}]
+        selector {:kind :runtime-expression-cases
+                  :cases (cond-> alignment-cases
+                           split? (conj {:expression split-expression :op :>= :value 2
+                                         :strategy :xmx-split-k}))
+                  :default :xmx-direct}]
+    {:alternatives (cond-> [direct] split (conj split))
+     :selector selector
+     :result-transform-split-decline
+     (when-not split? {:reason :split-k-result-transform-not-lowered})}))
+
 (defn emit-executable
   "Emit the resident GEMM schedule as one graph or a checked runtime dispatch.
 
    Required keys: :id, :a/:b/:c, :m/:n/:k compiler values, :variant, :precision, :tile,
    :fill-workgroups. The mixed-precision dispatch handles the XMX pitch gate and low-occupancy
    split-K choice entirely through generic expression cases."
-  [{:keys [id a b c m n k variant precision tile fill-workgroups vector-width]
+  [{:keys [id a b c m n k variant precision tile fill-workgroups vector-width epilogue]
     :or {vector-width 4}
     :as spec}]
   (when-not (contains? #{:nn :nt :tn :tt} variant)
@@ -622,24 +705,16 @@
     (case precision
       :f32-scalar scalar
       :mixed-f16-f32
-      (let [split-expression (requested-splits spec)
-            xmx-spec (assoc spec :requested-splits split-expression)
-            direct (xmx-graph (assoc xmx-spec :split-k? false))
-            split (xmx-graph (assoc xmx-spec :split-k? true))]
+      (let [_ (when (seq epilogue)
+                (throw (ex-info
+                        "standalone GEMM executable cannot manufacture its scalar fallback for a result transform"
+                        {:reason :result-transform-requires-typed-contraction :id id})))
+            {:keys [alternatives selector]} (emit-matrix-alternatives spec)]
         (kdispatch/make
          {:id (str id)
-          :alternatives [scalar direct split]
+          :alternatives (into [scalar] alternatives)
           :default-strategy :xmx-direct
-          :selector
-          {:kind :runtime-expression-cases
-           :cases [{:expression n :op :< :value 8 :strategy :f32-scalar}
-                   {:expression k :op :< :value 8 :strategy :f32-scalar}
-                   {:expression (kbody/expression :mod n 8)
-                    :op :> :value 0 :strategy :f32-scalar}
-                   {:expression (kbody/expression :mod k (get-in tile [:matrix :k]))
-                    :op :> :value 0 :strategy :f32-scalar}
-                   {:expression split-expression :op :>= :value 2 :strategy :xmx-split-k}]
-           :default :xmx-direct}
+          :selector selector
           :provenance {:semantic-op :contraction :variant variant :lowering :gemm-schedule}
           :attributes {:tile tile :precision precision :hardware-aware? true}}))
       (throw (ex-info "unsupported GEMM precision" {:id id :precision precision})))))

--- a/src/raster/compiler/ir/contraction_facts.clj
+++ b/src/raster/compiler/ir/contraction_facts.clj
@@ -385,9 +385,6 @@
       (nil? (body-product-of element (map :sym operands)))
       {:ok false :reason :body-has-unmodeled-terms}
 
-      (seq epilogue)
-      {:ok false :reason :matrix-graph-result-transform-not-lowered}
-
       :else
       (if-let [[layout-kind verdict]
                (some (fn [layout-kind]
@@ -398,6 +395,7 @@
          {:ok true
           :variant (if batched? :nn layout-kind)
           :batched? batched?
+          :epilogue epilogue
           :bindings (:bindings verdict)
           :dimensions (if batched?
                         [(second (second free-axes))

--- a/src/raster/compiler/passes/parallel/contract_route.clj
+++ b/src/raster/compiler/passes/parallel/contract_route.clj
@@ -988,6 +988,10 @@
       (not (:ok matrix-view))
       {:alternatives [] :decline (dissoc matrix-view :ok)}
 
+      (and (:batched? matrix-view) (seq (:epilogue matrix-view)))
+      {:alternatives []
+       :decline {:reason :batched-matrix-result-transform-not-lowered}}
+
       (nil? target-schedule)
       {:alternatives []
        :decline {:reason :mixed-dpas-target-capability
@@ -1001,6 +1005,7 @@
                        :a row :b col :c (:out facts)
                        :m m :n n :k k
                        :variant (:variant matrix-view)
+                       :epilogue (:epilogue matrix-view)
                        :precision :mixed-f16-f32
                        :tile (:tile target-schedule)
                        :fill-workgroups (:fill-workgroups target-schedule)}
@@ -1009,12 +1014,10 @@
                        (assoc emit-spec
                               :batch (:batch matrix-view)
                               :batching (:batching matrix-view)))
-                      (gpu-gemm/emit-executable emit-spec))
+                      (gpu-gemm/emit-matrix-alternatives emit-spec))
             raw-alternatives (if (:batched? matrix-view)
                                [(:graph emitted)]
-                               (remove #(= :f32-scalar
-                                           (get-in % [:attributes :strategy]))
-                                       (:alternatives emitted)))
+                               (:alternatives emitted))
             alternatives (mapv #(reinterface-graph % abi arguments effects operation-id)
                                raw-alternatives)
             selector (:selector emitted)]
@@ -1026,6 +1029,8 @@
                     :batched? (:batched? matrix-view)
                     :batch (:batch matrix-view)
                     :batching (:batching matrix-view)
+                    :result-transform? (boolean (seq (:epilogue matrix-view)))
+                    :split-k-decline (:result-transform-split-decline emitted)
                     :bindings (:bindings matrix-view)
                     :dimensions (:dimensions matrix-view)
                     :tile (:tile target-schedule)

--- a/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_contraction_matrix_device_test.clj
@@ -54,6 +54,35 @@
      :desc (hardware/descriptor-for device-id)
      :precision :mixed-f16-f32)))
 
+(defn- typed-epilogue-dispatch
+  [device-id]
+  (let [transform {:acc 'acc
+                   :expr '(raster.numeric/*
+                           (raster.numeric/+ acc (clojure.core/aget bias j)) scale)
+                   :operands [{:sym 'bias :dtype :float
+                               :map {:groups [[['j 'n]]]}}]
+                   :scalars [{:sym 'scale :dtype :float}]
+                   :dtype :float}
+        contract (apply list
+                        (concat
+                         '(raster.par/contract C [[i m] [j n]] [[l k]]
+                                               (* (clojure.core/aget A (+ (* i k) l))
+                                                  (clojure.core/aget B (+ (* l n) j))))
+                         [:epilogue transform]))
+        {:keys [form]}
+        (pipeline/schedule-parallel-form
+         (list 'let* ['step contract] 'step)
+         {:target-device device-id
+          :dtype :float
+          :array-types {'A :float 'B :float 'C :float 'bias :float}
+          :scalar-types {'m :int 'n :int 'k :int 'scale :float}})
+        equation (first (:equations form))]
+    (contract-route/route-typed-contraction-dispatch
+     (:algorithm equation) (first (:operations equation))
+     :dtype :float
+     :desc (hardware/descriptor-for device-id)
+     :precision :mixed-f16-f32)))
+
 (defn- input-array
   [n seed]
   (let [result (float-array n)
@@ -182,5 +211,45 @@
             (is (< (relative-l1 (gpu/download session :c)
                                 (batched-reference a b batch m n k))
                    1.0e-3))
+            (finally
+              (gpu/release-kernel-graph! session handle))))))))
+
+(deftest typed-result-transform-executes-inside-the-matrix-store
+  (if-not @gpu-probe/gpu-available?
+    (gpu-probe/gpu-skip! "typed matrix result transform")
+    (let [device-id :ze:0
+          m 8
+          n 16
+          k 16
+          scale 0.5
+          a (input-array (* m k) 47)
+          b (input-array (* k n) 53)
+          bias (input-array n 59)
+          base (reference a b m n k)
+          expected (float-array (* m n))
+          _ (dotimes [index (* m n)]
+              (aset expected index
+                    (float (* scale
+                              (+ (double (aget base index))
+                                 (double (aget bias (mod index n))))))))
+          scheduled (typed-epilogue-dispatch device-id)
+          runtime-arguments
+          [:a :b :c :bias
+           {:type :float :value scale}
+           {:type :int :value m}
+           {:type :int :value n}
+           {:type :int :value k}]
+          selected (dispatch/select-alternative scheduled runtime-arguments)]
+      (is (= :xmx-direct (executable/strategy selected)))
+      (gpu/with-gpu-session [session device-id]
+        (gpu/alloc! session {:a [:float (* m k) a]
+                             :b [:float (* k n) b]
+                             :bias [:float n bias]
+                             :c [:float (* m n) nil]})
+        (let [handle (gpu/bind-kernel-executable!
+                      session :typed-result-transform selected runtime-arguments)]
+          (try
+            (gpu/run-kernel-graph! session handle)
+            (is (< (relative-l1 (gpu/download session :c) expected) 1.0e-3))
             (finally
               (gpu/release-kernel-graph! session handle))))))))

--- a/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
+++ b/test/raster/compiler/passes/parallel/typed_soac_route_test.clj
@@ -1366,6 +1366,60 @@
            (last (-> call :nodes first :call :arguments))))
     (is (nil? (get-in emitted [:stats :segop-relowered])))))
 
+(deftest dynamic-result-transform-fuses-into-the-mixed-matrix-graph
+  (let [transform {:acc 'acc
+                   :expr '(raster.numeric/*
+                           (raster.numeric/+ acc (clojure.core/aget bias j)) scale)
+                   :operands [{:sym 'bias :dtype :float
+                               :map {:groups [[['j 'n]]]}}]
+                   :scalars [{:sym 'scale :dtype :float}]
+                   :dtype :float}
+        contract (apply list
+                        (concat
+                         '(raster.par/contract C [[i m] [j n]] [[l k]]
+                                               (* (clojure.core/aget A (+ (* i k) l))
+                                                  (clojure.core/aget B (+ (* l n) j))))
+                         [:epilogue transform]))
+        source (list 'let* ['step contract] 'step)
+        {:keys [form]}
+        (pipeline/schedule-parallel-form
+         source {:target-device :ze:0 :dtype :float
+                 :array-types {'A :float 'B :float 'C :float 'bias :float}
+                 :scalar-types {'m :int 'n :int 'k :int 'scale :float}})
+        operation (-> form :equations first :operations first)
+        algorithm (-> form :equations first :algorithm)
+        descriptor {:backend :ze
+                    :matrix {:family :dpas :m 8 :n 16 :k 16 :subgroup 16}
+                    :execution {:subgroup-sizes #{16 32} :max-workgroup-size 1024}
+                    :subgroup-size 16 :max-workgroup-size 1024
+                    :grf-bytes-per-lane 256 :machine-lanes 8192
+                    :shared-local-memory 131072}
+        scheduled (contract-route/route-typed-contraction-dispatch
+                   algorithm operation :dtype :float :desc descriptor
+                   :precision :mixed-f16-f32)
+        matrix-graph (kdispatch/alternative scheduled :xmx-direct)
+        contract-artifact (-> matrix-graph :nodes last :operation)
+        body (get-in contract-artifact [:attributes :kernel-body])]
+    (is (= [:portable-segred :xmx-direct]
+           (mapv kdispatch/alternative-strategy (:alternatives scheduled)))
+        "split-K waits until its final combine can own the result transform")
+    (is (= '[A B C bias scale m n k] (:arguments matrix-graph)))
+    (is (some #(= 'bias (:id %)) (:inputs matrix-graph)))
+    (is (some #(= 'bias (:buffer %)) (:uses (last (:nodes matrix-graph))))
+        "the fused operand is an explicit graph input and matrix-node read")
+    (is (= :split-k-result-transform-not-lowered
+           (get-in scheduled [:attributes :candidate-schedules
+                              :xmx-direct :split-k-decline :reason])))
+    (is (= '[bias scale]
+           (mapv :id (filter #(= :epilogue (:role %)) (:parameters body)))))
+    (is (re-find #"bias\[.*col" (:source contract-artifact)))
+    (is (re-find #"\* scale" (:source contract-artifact)))
+    (is (= :xmx-direct
+           (-> (kdispatch/select-alternative
+                scheduled [:a :b :c :bias 0.5 13 128 8192])
+               kdispatch/alternative-strategy))
+        "low occupancy stays direct rather than transforming split partials")))
+
 (deftest resident-reduction-realization-stays-on-the-typed-spine
   (let [source
         '(let* [total (raster.par/reduce acc 0.0 i n


### PR DESCRIPTION
Carries the typed contraction ScalarRegion through the mixed matrix graph ABI and into the direct matrix KernelBody store. Epilogue operands/scalars become ordinary typed graph inputs; no emitter-side function registry is introduced. Split-K is withheld with an explicit decline until its final combine can own the transform, avoiding an invalid transform of partial sums.\n\nFocused checks: typed route 51 tests/413 assertions and real Arc device execution 3 tests/8 assertions, all green.