### PR TITLE
Retire direct matrix runtime binders

### DIFF
--- a/src/raster/gpu/ze_runtime.clj
+++ b/src/raster/gpu/ze_runtime.clj
@@ -1336,18 +1336,11 @@
 ;; GPU GEMM (non-square XMX)
 ;; ================================================================
 
-(defn- emit-scheduled-gemm
-  "Ask the compiler for the shared scheduled matrix body and its direct OpenCL lowering."
-  [kernel-name c-dtype tile epilogue]
-  ((requiring-resolve 'raster.compiler.backend.gpu.gemm/emit-scheduled-matrix-kernel)
-   {:kernel-name kernel-name
-    :id [:resident-gemm kernel-name]
-    :a 'A :b 'B :c 'C :m 'M :n 'N :k 'K
-    :tile tile :result-dtype c-dtype :epilogue epilogue
-    :provenance {:dialect :resident-runtime}}))
-
 (defn- emit-scheduled-split-k-gemm
-  "Ask the compiler for a grid-Z sliced K reduction over resident buffers."
+  "Legacy explicit-split-factor benchmark seam.
+
+   Ordinary direct/split selection is compiler-owned. This remains only until split count becomes
+   a finite typed-contraction schedule space rather than a runtime-specific benchmark parameter."
   [kernel-name tile]
   ((requiring-resolve 'raster.compiler.backend.gpu.gemm/emit-scheduled-split-k-kernel)
    {:kernel-name kernel-name
@@ -1356,44 +1349,7 @@
     :tile tile
     :provenance {:dialect :resident-runtime}}))
 
-(defn- emit-scheduled-batched-gemm
-  "Ask the compiler for grid-Z-selected independent resident matrix views."
-  [kernel-name tile]
-  ((requiring-resolve 'raster.compiler.backend.gpu.gemm/emit-scheduled-batched-matrix-kernel)
-   {:kernel-name kernel-name
-    :id [:resident-gemm kernel-name]
-    :a 'A :b 'B :c 'C :m 'M :n 'N :k 'K :batch 'batch
-    :tile tile
-    :provenance {:dialect :resident-runtime}}))
-
 (declare gemm-tile)
-
-(def ^:private gemm-cache
-  "Cache for compiled GEMM kernels, keyed by C-output dtype (:half | :float).
-   Each entry is {:module :kernel :kernel-name}. (A/B are always fp16 in.)"
-  (atom {}))
-
-(defn- ensure-gemm-kernel!
-  "Lazily compile + cache the XMX gemm_nonsquare kernel for a given C-output dtype
-   (:half or :float — A/B always fp16, fp32 accumulate). Returns {:module :kernel :kernel-name}."
-  [c-dtype]
-  (ensure-init!)
-  (or (get @gemm-cache c-dtype)
-      (let [kname (str "gemm_nonsquare_" (name c-dtype))
-            tile (gemm-tile)
-            emitted (emit-scheduled-gemm kname c-dtype tile nil)
-            cl-src (:source emitted)
-            device-hex (:device-id-hex @state)
-            spv (do (require 'raster.compiler.support.spirv-cache)
-                    ((resolve 'raster.compiler.support.spirv-cache/compile-opencl-to-spirv)
-                     cl-src :device device-hex))
-            module (load-module! spv)
-            kernel (create-kernel module kname)
-            entry {:module module :kernel kernel :kernel-name kname
-                   :tile tile :kernel-body (:kernel-body emitted)
-                   :workgroup (:workgroup-size emitted)}]
-        (swap! gemm-cache assoc c-dtype entry)
-        entry)))
 
 (defn- gemm-tile
   "The GEMM tile for this device, from the ONE source (compiler.core.hardware/gemm-tile-for).
@@ -2164,187 +2120,6 @@
   [kernel-name]
   (get @kernel-registry kernel-name))
 
-(defn bind-registered-gemm!
-  "Bind the XMX GEMM kernel (C = A×B) over RESIDENT fp16 DeviceBuffers for legacy benchmark
-  recording. A:[m×k] B:[k×n] C:[m×n], all fp16 (:half) resident buffers, row-major. Returns a bound
-  {:kernel :gc-seg …} map (128×128 XMX tiles → gc = ceil(n/128) × ceil(m/128)). A fresh kernel
-  handle per binding (LZ kernel args are mutable handle state → shared handles clobber)."
-  ([a b c m n k] (bind-registered-gemm! a b c m n k :half))
-  ([a b c m n k c-dtype]
-   ;; Fail loud on an output-buffer dtype mismatch: a :half kernel writing 2-byte halfs into a
-   ;; :float (4-byte) buffer reads back as silent zeros/garbage — the exact silent-miscompile the
-   ;; compiler is built to prevent. The kernel's output dtype IS c-dtype; the buffer must agree.
-   (when-let [bd (:dtype c)]
-     (when (not= bd c-dtype)
-       (throw (ex-info (str "bind-registered-gemm!: output buffer dtype " bd " ≠ kernel output dtype " c-dtype
-                            " — a mismatched write reads back as garbage. Allocate C as " c-dtype
-                            " or pass the matching c-dtype.")
-                       {:buffer-dtype bd :kernel-c-dtype c-dtype}))))
-   (let [{:keys [module kernel-name tile workgroup]} (ensure-gemm-kernel! c-dtype)
-         kh (create-kernel-fresh module kernel-name)
-         m (long m) n (long n) k (long k)
-         args [(:segment a) (:segment b) (:segment c)
-               {:type :int :value (int m)} {:type :int :value (int n)} {:type :int :value (int k)}]
-         bnd (bind-kernel! kh workgroup args)
-         gc ^MemorySegment (:gc-seg bnd)]
-     (.set gc I32 0 (int (Math/ceil (/ (double n) (double (:block-n tile))))))   ;; X = gc-n
-     (.set gc I32 4 (int (Math/ceil (/ (double m) (double (:block-m tile))))))   ;; Y = gc-m
-     (.set gc I32 8 (int 1))
-     bnd)))
-
-;; ── TILE-PARAMETRIC GEMM (autotune-facing) ─────────────────────────────────────
-;; The default bind-registered-gemm! above schedules the device-derived default tile. This path
-;; takes an EXPLICIT tile map (from schedule/derive-gemm-tile or an autotune candidate) through the
-;; same KernelBody scheduler and derives launch geometry from that body. At the default tile it
-;; produces identical source and launch geometry.
-
-(def ^:private gemm-tiled-cache
-  "Compiled tile-parametric GEMM kernels, keyed by [c-dtype tile-map]. Distinct tiles are distinct
-   kernels (distinct __kernel names)."
-  (atom {}))
-
-(defn- tile-signature [tile]
-  (let [{:keys [block-m block-n sg-m sg-n block-k num-stages]} tile]
-    (str block-m "x" block-n "_" sg-m "x" sg-n "_k" block-k "_s" (or num-stages 3))))
-
-(defn- ensure-gemm-kernel-tiled!
-  "Compile + cache the GEMM kernel for [c-dtype × tile]. Returns {:module :kernel-name :tile}."
-  [c-dtype tile]
-  (ensure-init!)
-  (or (get @gemm-tiled-cache [c-dtype tile])
-      (let [kname (str "gemm_tiled_" (name c-dtype) "_" (tile-signature tile))
-            emitted (emit-scheduled-gemm kname c-dtype tile nil)
-            cl-src (:source emitted)
-            spv (do (require 'raster.compiler.support.spirv-cache)
-                    ((resolve 'raster.compiler.support.spirv-cache/compile-opencl-to-spirv)
-                     cl-src :device (:device-id-hex @state)))
-            module (load-module! spv)
-            entry {:module module :kernel-name kname :tile tile
-                   :kernel-body (:kernel-body emitted)
-                   :workgroup (:workgroup-size emitted)}]
-        (swap! gemm-tiled-cache assoc [c-dtype tile] entry)
-        entry)))
-
-(defn bind-registered-gemm-tiled!
-  "Bind the GEMM kernel for an EXPLICIT tile over resident fp16 buffers, DERIVING the launch
-   geometry from the tile. `tile` is a derive-gemm-tile map {:block-m :block-n :sg-m :sg-n :block-k
-   :matrix}. Fail-loud on an output-dtype mismatch, like bind-registered-gemm!."
-  [a b c m n k c-dtype tile]
-  (when-let [bd (:dtype c)]
-    (when (not= bd c-dtype)
-      (throw (ex-info (str "bind-registered-gemm-tiled!: output buffer dtype " bd " ≠ kernel dtype " c-dtype)
-                      {:buffer-dtype bd :kernel-c-dtype c-dtype}))))
-  (let [{:keys [module kernel-name workgroup]} (ensure-gemm-kernel-tiled! c-dtype tile)
-        {:keys [block-m block-n]} tile
-        kh   (create-kernel-fresh module kernel-name)
-        args [(:segment a) (:segment b) (:segment c)
-              {:type :int :value (int m)} {:type :int :value (int n)} {:type :int :value (int k)}]
-        bnd  (bind-kernel! kh workgroup args)
-        gc ^MemorySegment (:gc-seg bnd)]
-    (.set gc I32 0 (int (Math/ceil (/ (double n) (double block-n)))))   ;; X = gc-n
-    (.set gc I32 4 (int (Math/ceil (/ (double m) (double block-m)))))   ;; Y = gc-m
-    (.set gc I32 8 (int 1))
-    bnd))
-
-;; ── FUSED-EPILOGUE GEMM (C = ScalarRegion(A·B, row, col)) ──────────────────────
-;; One typed KernelBody for GEMM + a same-position elementwise consumer (bias/act/residual), the
-;; training-M win (~15-18% at M≥512, measured). Runtime bindings remain separate from the scalar
-;; program so cache identity and ABI order come from compiler data rather than source strings.
-(def ^:private gemm-epilogue-cache (atom {}))
-
-(defn- resident-epilogue-program
-  [epilogue]
-  (let [allowed #{:acc :expr :operands :scalars :dtype :bindings}
-        unsupported (seq (remove allowed (keys epilogue)))]
-    (when unsupported
-      (throw (ex-info "resident GEMM epilogue contains unsupported fields"
-                      {:unsupported (vec unsupported) :allowed allowed})))
-    (when-not (map? (:bindings epilogue))
-      (throw (ex-info "resident GEMM epilogue requires explicit runtime bindings"
-                      {:epilogue epilogue})))
-    (dissoc epilogue :bindings)))
-
-(defn- ensure-gemm-epilogue-kernel!
-  "Compile and cache a typed ScalarRegion GEMM by its structural program, output dtype and tile."
-  [c-dtype tile epilogue]
-  (ensure-init!)
-  (let [program (resident-epilogue-program epilogue)
-        cache-key [c-dtype tile program]]
-    (or (get @gemm-epilogue-cache cache-key)
-        (let [program-id (Integer/toUnsignedString (hash program) 16)
-              kname (str "gemm_epi_" program-id "_" (name c-dtype) "_" (tile-signature tile))
-              emitted (emit-scheduled-gemm kname c-dtype tile program)
-              cl-src (:source emitted)
-              spv (do (require 'raster.compiler.support.spirv-cache)
-                      ((resolve 'raster.compiler.support.spirv-cache/compile-opencl-to-spirv)
-                       cl-src :device (:device-id-hex @state)))
-              module (load-module! spv)
-              entry {:module module :kernel-name kname :tile tile :program program
-                     :kernel-body (:kernel-body emitted)
-                     :workgroup (:workgroup-size emitted)}]
-          (swap! gemm-epilogue-cache assoc cache-key entry)
-          entry))))
-
-(defn- resident-epilogue-argument
-  [parameter value]
-  (case (:kind parameter)
-    :input
-    (do
-      (when-not (instance? DeviceBuffer value)
-        (throw (ex-info "resident epilogue buffer binding is not a DeviceBuffer"
-                        {:parameter parameter :actual (type value)})))
-      (when-not (= (dt/canon (:dtype parameter)) (dt/canon (:dtype value)))
-        (throw (ex-info "resident epilogue buffer dtype differs from its KernelBody ABI"
-                        {:parameter parameter :actual (:dtype value)})))
-      (:segment value))
-
-    :scalar
-    {:type (case (dt/canon (:dtype parameter))
-             :int8 :byte
-             :byte :byte
-             :half :half
-             :float :float
-             :double :double
-             :int :int
-             :long :long
-             (throw (ex-info "resident epilogue scalar dtype is unsupported"
-                             {:parameter parameter})))
-     :value value}
-
-    (throw (ex-info "resident epilogue ABI slot must be input or scalar"
-                    {:parameter parameter}))))
-
-(defn bind-registered-gemm-epilogue!
-  "Bind C = ScalarRegion(A·B) using the same typed epilogue descriptor as the compiler.
-
-   `epilogue` contains :acc, :expr, ordered :operands/:scalars, and a :bindings map from each
-   operand/scalar identity to its resident buffer or scalar value. KernelBody owns the physical
-   ABI and launch geometry; target source callbacks and declaration strings are not accepted."
-  [a b c m n k c-dtype tile epilogue]
-  (when-let [bd (:dtype c)]
-    (when (not= bd c-dtype)
-      (throw (ex-info (str "bind-registered-gemm-epilogue!: output buffer dtype " bd " ≠ kernel dtype " c-dtype) {}))))
-  (let [{:keys [module kernel-name kernel-body workgroup]}
-        (ensure-gemm-epilogue-kernel! c-dtype tile epilogue)
-        {:keys [block-m block-n]} tile
-        parameters (filterv #(= :epilogue (:role %)) (:parameters kernel-body))
-        expected (mapv :id parameters)
-        bindings (:bindings epilogue)
-        provided (set (keys bindings))
-        _ (when-not (= (set expected) provided)
-            (throw (ex-info "resident epilogue bindings differ from the KernelBody ABI"
-                            {:expected expected :provided (vec (keys bindings))})))
-        kh   (create-kernel-fresh module kernel-name)
-        args (vec (concat [(:segment a) (:segment b) (:segment c)
-                           {:type :int :value (int m)} {:type :int :value (int n)} {:type :int :value (int k)}]
-                          (map #(resident-epilogue-argument % (get bindings (:id %))) parameters)))
-        bnd  (bind-kernel! kh workgroup args)
-        gc ^MemorySegment (:gc-seg bnd)]
-    (.set gc I32 0 (int (Math/ceil (/ (double n) (double block-n)))))
-    (.set gc I32 4 (int (Math/ceil (/ (double m) (double block-m)))))
-    (.set gc I32 8 (int 1))
-    bnd))
-
 ;; ── SPLIT-K GEMM (the low-occupancy-shape schedule) ────────────────────────────
 ;; A GEMM whose (M,N) tiling yields fewer workgroups than fill the machine —
 ;; ceil(N/128)·ceil(M/128) — cannot be rescued by a better inner loop: the machine
@@ -2432,61 +2207,6 @@
               {:type :int :value (int mn)}]
         bnd (bind-kernel! kh 256 args)]
     (.set ^MemorySegment (:gc-seg bnd) I32 0 (int (Math/ceil (/ (double mn) 256.0))))
-    bnd))
-
-;; ── BATCHED XMX GEMM (bmm) ───────────────────────────────────────────────────
-;; A per-slab GEMM whose (M,N) tiling launches too few workgroups to fill the
-;; machine is occupancy-bound (see split-k). When the deficit is instead resolved
-;; by MANY independent slabs (attention over heads: dV[b]=W[b]ᵀ·dO[b], 64 slabs of
-;; m=k=64,n=256), a single batched kernel over a 3D grid (z = slab) launches
-;; slabs × per-slab-tiles workgroups — feeding the DPAS array across all slabs where
-;; one slab starves it. A/B/C are contiguous [batch,M,K]/[batch,K,N]/[batch,M,N]
-;; f16/f16/f32 buffers; each workgroup offsets its base by its slab. This is the
-;; batched-nn primitive; the -tn/-nt layouts are handled by staging A/B (convert +
-;; batched transpose) exactly as the single GEMM's resident path does.
-
-(def ^:private gemm-batched-cache (atom nil))
-
-(defn- ensure-gemm-batched-kernel!
-  "Lazily compile + cache the BATCHED XMX gemm (f16 A/B in, f32 C out, grid-z=slab).
-   Returns {:module :kernel :kernel-name}."
-  []
-  (ensure-init!)
-  (when (nil? @gemm-batched-cache)
-    (let [kname "gemm_nonsquare_batched"
-          tile (gemm-tile)
-          emitted (emit-scheduled-batched-gemm kname tile)
-          cl-src (:source emitted)
-          spv (do (require 'raster.compiler.support.spirv-cache)
-                  ((resolve 'raster.compiler.support.spirv-cache/compile-opencl-to-spirv)
-                   cl-src :device (:device-id-hex @state)))
-          module (load-module! spv)
-          kernel (create-kernel module kname)]
-      (clojure.core/reset! gemm-batched-cache
-                           {:module module :kernel kernel :kernel-name kname :tile tile
-                            :kernel-body (:kernel-body emitted)
-                            :workgroup (:workgroup-size emitted)})))
-  @gemm-batched-cache)
-
-(defn bind-registered-gemm-batched!
-  "Bind the BATCHED XMX GEMM: C[b] = A[b]·B[b] (nn) for b in 0..batch-1, over a 3D
-  grid — X = ceil(n/128), Y = ceil(m/128), Z = batch — so the launched workgroup
-  count is `batch`× the plain GEMM's. A[batch,m,k] & B[batch,k,n] f16, C[batch,m,n]
-  f32, all contiguous. Fresh kernel handle per bind (LZ kernel args are mutable
-  handle state)."
-  [a b c m n k batch]
-  (let [{:keys [module kernel-name tile workgroup]} (ensure-gemm-batched-kernel!)
-        {:keys [block-m block-n]} tile
-        kh (create-kernel-fresh module kernel-name)
-        m (long m) n (long n) k (long k) batch (long batch)
-        args [(:segment a) (:segment b) (:segment c)
-              {:type :int :value (int m)} {:type :int :value (int n)}
-              {:type :int :value (int k)} {:type :int :value (int batch)}]
-        bnd (bind-kernel! kh workgroup args)
-        gc ^MemorySegment (:gc-seg bnd)]
-    (.set gc I32 0 (int (Math/ceil (/ (double n) (double block-n))))) ;; X = gc-n
-    (.set gc I32 4 (int (Math/ceil (/ (double m) (double block-m))))) ;; Y = gc-m
-    (.set gc I32 8 (int batch))                              ;; Z = slabs
     bnd))
 
 (def ^:private convert-cache (atom {}))

--- a/test/raster/compiler/backend/gpu/gemm_tiled_test.clj
+++ b/test/raster/compiler/backend/gpu/gemm_tiled_test.clj
@@ -1,116 +1,95 @@
 (ns raster.compiler.backend.gpu.gemm-tiled-test
-  "Correctness of tile-parametric scheduled XMX GEMM lowering. Two guards:
+  "Device guards for compiler-derived matrix schedules.
 
-     (1) ABSOLUTE correctness — the resident GEMM (default Arc tile, launched through the production
-         bind-registered-gemm! path) matches an independent CPU f32-accumulate reference over
-         f16-rounded inputs. This catches a miscompiled tile that produces zeros/garbage (the exact
-         failure mode a silent GPU miscompile would show).
-
-     (2) CROSS-TILE bit-invariance — a non-default tile (block 64×64, block-k 64) produces output
-         BIT-IDENTICAL to the default tile. Every output element's K-reduction is the same DPAS
-         sequence regardless of how the tile assigns elements to subgroups/workgroups, so a correct
-         generator is bit-invariant across tile geometry. This is the guard the T2/T3 autotune work
-         (which VARIES the tile) rests on — a tile bug that changes results at all trips it.
-
-   The old string generator remains an independent cross-tile oracle in this test. Device-free
-   body/source checks live in raster.compiler.backend.gpu.gemm-test."
+   The tests start from ordinary TypedSOAC contractions, isolate a scheduled matrix artifact only
+   when measuring target-kernel properties, and use the common KernelExecutable binder.  The
+   Level Zero runtime neither recognizes GEMM nor reconstructs its ABI or launch geometry."
   (:require [clojure.test :refer [deftest is testing]]
-            [raster.compiler.ir.axis-map :as axis-map]
-            [raster.dl.gpu-grad-parity :as gp]))
+            [raster.compiler.backend.gpu.typed-matrix-device-support :as support]
+            [raster.compiler.core.hardware :as hardware]
+            [raster.dl.gpu-grad-parity :as gpu-probe]
+            [raster.gpu.core :as gpu]))
 
-(defn- cpu-gemm-ref
-  "C[m×n] = A[m×k]·B[k×n], f16-rounded inputs, f64 accumulate → float (the independent oracle)."
-  [^floats A ^floats B m n k]
-  (let [h  (fn [x] (Float/float16ToFloat (Float/floatToFloat16 (float x))))
-        C  (float-array (* m n))]
-    (dotimes [i m]
-      (dotimes [j n]
-        (let [acc (loop [p 0 s 0.0]
-                    (if (< p k)
-                      (recur (inc p) (+ s (* (double (h (aget A (+ (* i k) p))))
-                                             (double (h (aget B (+ (* p n) j)))))))
-                      s))]
-          (aset C (+ (* i n) j) (float acc)))))
-    C))
+(defn- rms
+  [actual expected]
+  (Math/sqrt
+   (/ (reduce + (map (fn [x y]
+                       (let [difference (- (double x) (double y))]
+                         (* difference difference)))
+                     actual expected))
+      (double (count actual)))))
 
-(defn- rms [a b] (Math/sqrt (/ (reduce + (map (fn [x y] (let [d (- (double x) (double y))] (* d d))) a b))
-                               (double (count a)))))
+(defn- run-tile
+  [session tile ^floats a ^floats b m n k key]
+  (let [scheduled (support/dense-dispatch :ze:0 :tile tile)
+        artifact (support/matrix-artifact scheduled :xmx-direct)]
+    (gpu/alloc! session {[:a key] [:half (* m k) (support/half-array a)]
+                         [:b key] [:half (* k n) (support/half-array b)]
+                         [:c key] [:float (* m n) nil]})
+    (let [handle (gpu/bind-kernel-executable!
+                  session [:matrix key] artifact
+                  [[:a key] [:b key] [:c key]
+                   {:type :int :value m}
+                   {:type :int :value n}
+                   {:type :int :value k}])]
+      (try
+        (gpu/run-kernel-graph! session handle)
+        (gpu/download session [:c key])
+        (finally
+          (gpu/release-kernel-graph! session handle))))))
 
 (deftest tiled-gemm-matches-cpu-and-is-tile-invariant
-  (if-not @gp/gpu-available?
-    (gp/gpu-skip! "tile-parametric GEMM: CPU-reference correctness + cross-tile bit-invariance")
-    (let [ze   (do (require 'raster.gpu.ze-runtime) (find-ns 'raster.gpu.ze-runtime))
-          sv   (requiring-resolve 'raster.compiler.support.spirv-cache/compile-opencl-to-spirv)
-          emit (requiring-resolve 'raster.compiler.backend.gpu.opencl-codegen/emit-gemm-tiled)
-          r    (fn [s] (ns-resolve ze s))
-          _    (@(r 'ensure-init!))                 ;; MUST init before reading device-hex (else :device nil → generic compile, no DPAS)
-          I32  @(r 'I32)
-          dev  (:device-id-hex @@(r 'state))
-          f16  @(r 'buffer-of-floats-as-half)  MB @(r 'make-buffer)
-          LM   @(r 'load-module!)  CK @(r 'create-kernel-fresh)  BK2 @(r 'bind-kernel!)
-          RG   @(r 'record-graph!) RP @(r 'replay-graph!) DG @(r 'destroy-graph!)
-          BA   @(r 'buffer->array) FB @(r 'free-buffer!)  breg @(r 'bind-registered-gemm!)
-          seti (fn [seg off v] (.set ^java.lang.foreign.MemorySegment seg I32 (int off) (int v)))
-          ;; launch an arbitrary tiled kernel source at (m,n,k) with an explicit (block-m,block-n) grid
-          run  (fn [src kname a16 b16 m n block-m block-n k]
-                 (let [mod (LM (sv src :device dev)) kh (CK mod kname) c (MB (* m n) :float)
-                       bnd (BK2 kh [256 1] [(:segment a16) (:segment b16) (:segment c)
-                                            {:type :int :value (int m)} {:type :int :value (int n)} {:type :int :value (int k)}])
-                       gc (:gc-seg bnd)]
-                   (seti gc 0 (Math/ceil (/ (double n) (double block-n))))
-                   (seti gc 4 (Math/ceil (/ (double m) (double block-m))))
-                   (seti gc 8 1)
-                   (let [g (RG [{:bound bnd :kernel-name kname}])] (RP g) (let [o (BA c)] (DG g) (FB c) o))))
-          rng  (java.util.Random. 7)  m 64 n 128 k 256
-          mk   (fn [s] (let [a (float-array s)] (dotimes [i s] (aset a i (float (* 0.1 (.nextGaussian rng))))) a))
-          A    (mk (* m k))  B (mk (* k n))
-          a16  (f16 A)  b16 (f16 B)]
-      (try
-        (testing "(1) resident GEMM (production path) matches the CPU f32 reference"
-          (let [c (MB (* m n) :float)
-                ;; :float output arity (7-arg) — the 6-arg default is :half and would write
-                ;; 2-byte halfs into this 4-byte float buffer (→ garbage read back as float).
-                g (RG [{:bound (breg a16 b16 c m n k :float) :kernel-name "gemm_nonsquare_float"}])
-                _ (RP g)  gpu (BA c)  ref (cpu-gemm-ref A B m n k)
-                err (rms gpu ref)]
-            (DG g) (FB c)
-            (is (< err 1.0e-2) (str "resident GEMM vs CPU reference RMS=" err " (miscompile → zeros/garbage would blow this up)"))
-            (is (pos? (count (filter #(> (Math/abs (double %)) 0.05) gpu))) "output is non-trivial (not all zeros)")))
-        (testing "(2) a non-default tile is bit-identical to the default tile"
-          (let [dflt (run (emit "g_def" :c-dtype :float) "g_def" a16 b16 m n 128 128 k)
-                t64  (run (emit "g64" :c-dtype :float :block-m 64 :block-n 64) "g64" a16 b16 m n 64 64 k)
-                tk64 (run (emit "gk64" :c-dtype :float :block-k 64) "gk64" a16 b16 m n 128 128 k)]
-            (is (= (seq dflt) (seq t64))  "block 64×64 tile ≡ default (bit-identical)")
-            (is (= (seq dflt) (seq tk64)) "block-k 64 tile ≡ default (bit-identical)")))
-        (finally (FB a16) (FB b16))))))
+  (if-not @gpu-probe/gpu-available?
+    (gpu-probe/gpu-skip! "typed matrix schedule: CPU correctness + cross-tile invariance")
+    (let [descriptor (hardware/descriptor-for :ze:0)
+          default-tile (hardware/gemm-tile-for descriptor)
+          tile-64 (assoc default-tile :block-m 64 :block-n 64)
+          tile-k64 (assoc default-tile :block-k 64)
+          m 64 n 128 k 256
+          a (support/input-array (* m k) 7)
+          b (support/input-array (* k n) 11)
+          expected (support/reference a b m n k)]
+      (gpu/with-gpu-session [session :ze:0]
+        (let [default-result (run-tile session default-tile a b m n k :default)
+              tile-64-result (run-tile session tile-64 a b m n k :tile-64)
+              tile-k64-result (run-tile session tile-k64 a b m n k :tile-k64)]
+          (testing "the compiler-derived default matrix artifact matches an independent CPU oracle"
+            (is (< (rms default-result expected) 1.0e-2))
+            (is (some #(> (Math/abs (double %)) 0.05) default-result)))
+          (testing "schedule tile changes preserve the contraction result bit-for-bit"
+            (is (= (seq default-result) (seq tile-64-result)))
+            (is (= (seq default-result) (seq tile-k64-result)))))))))
 
-(deftest fused-epilogue-gemm-binder
-  (if-not @gp/gpu-available?
-    (gp/gpu-skip! "fused-epilogue GEMM (bind-registered-gemm-epilogue!): C = A·B + bias")
-    (let [ze   (do (require 'raster.gpu.ze-runtime) (find-ns 'raster.gpu.ze-runtime))
-          hw   (do (require 'raster.compiler.core.hardware) (find-ns 'raster.compiler.core.hardware))
-          r    (fn [s] @(ns-resolve ze s))
-          _    ((r 'ensure-init!))
-          f16  (r 'buffer-of-floats-as-half) MB (r 'make-buffer) RG (r 'record-graph!)
-          RP (r 'replay-graph!) DG (r 'destroy-graph!) BA (r 'buffer->array) FB (r 'free-buffer!)
-          bind (r 'bind-registered-gemm-epilogue!)
-          tile ((ns-resolve hw 'derive-gemm-tile) ((ns-resolve hw 'descriptor-for) :ze:0))
-          m 64 n 128 k 256 rng (java.util.Random. 3)
-          mk (fn [s] (let [a (float-array s)] (dotimes [i s] (aset a i (float (* 0.1 (.nextGaussian rng))))) a))
-          A (mk (* m k)) B (mk (* k n)) bias (mk n)
-          a16 (f16 A) b16 (f16 B) biasbuf (f16 bias) c (MB (* m n) :float)
-          epi {:acc 'acc
-               :expr '(raster.numeric/* (raster.numeric/+ acc (aget bias j)) scale)
-               :operands [{:sym 'bias :map (axis-map/of-axes [['j n]]) :dtype :half}]
-               :scalars [{:sym 'scale :dtype :float}]
-               :bindings {'bias biasbuf 'scale 0.5}}]
-      (try
-        (RP (RG [{:bound (bind a16 b16 c m n k :float tile epi) :kernel-name "gemm_epi_bias_float"}]))
-        (let [gpu (BA c) h (fn [x] (Float/float16ToFloat (Float/floatToFloat16 (float x)))) ref (float-array (* m n))]
-          (dotimes [i m] (dotimes [j n]
-                           (let [s (loop [p 0 acc 0.0] (if (< p k) (recur (inc p) (+ acc (* (double (h (aget A (+ (* i k) p)))) (double (h (aget B (+ (* p n) j))))))) acc))]
-                             (aset ref (+ (* i n) j)
-                                   (float (* 0.5 (+ s (double (h (aget bias j))))))))))
-          (let [maxrel (reduce max 0.0 (map (fn [a b] (/ (Math/abs (- (double a) (double b))) (+ 0.05 (Math/abs (double b))))) gpu ref))]
-            (is (< maxrel 1.0e-3) (str "fused C=A·B+bias must match CPU ref within f16 tol (max-rel " maxrel ")"))))
-        (finally (FB a16) (FB b16) (FB biasbuf) (FB c))))))
+(deftest typed-result-transform-is-part-of-the-matrix-artifact
+  (if-not @gpu-probe/gpu-available?
+    (gpu-probe/gpu-skip! "typed matrix result transform")
+    (let [m 64 n 128 k 256 scale 0.5
+          a (support/input-array (* m k) 3)
+          b (support/input-array (* k n) 5)
+          bias (support/input-array n 13)
+          base (support/reference a b m n k)
+          expected (float-array (* m n))
+          scheduled (support/epilogue-dispatch :ze:0)
+          artifact (support/matrix-artifact scheduled :xmx-direct)]
+      (dotimes [index (* m n)]
+        (aset expected index
+              (float (* scale (+ (double (aget base index))
+                                 (double (aget bias (mod index n))))))))
+      (gpu/with-gpu-session [session :ze:0]
+        (gpu/alloc! session {:a [:half (* m k) (support/half-array a)]
+                             :b [:half (* k n) (support/half-array b)]
+                             :bias [:float n bias]
+                             :c [:float (* m n) nil]})
+        (let [handle (gpu/bind-kernel-executable!
+                      session :typed-matrix-result-transform artifact
+                      [:a :b :c
+                       {:type :int :value m}
+                       {:type :int :value n}
+                       {:type :int :value k}
+                       :bias
+                       {:type :float :value scale}])]
+          (try
+            (gpu/run-kernel-graph! session handle)
+            (is (< (support/relative-l1 (gpu/download session :c) expected) 1.0e-3))
+            (finally
+              (gpu/release-kernel-graph! session handle))))))))

--- a/test/raster/compiler/backend/gpu/typed_matrix_device_support.clj
+++ b/test/raster/compiler/backend/gpu/typed_matrix_device_support.clj
@@ -1,0 +1,146 @@
+(ns raster.compiler.backend.gpu.typed-matrix-device-support
+  "Test support for exercising matrix schedules from ordinary TypedSOAC contractions.
+
+   Performance tests may isolate the target matrix artifact after the compiler has proved and
+   scheduled the contraction.  They still bind it through the backend-neutral KernelExecutable
+   API; no backend runtime is allowed to reconstruct a GEMM ABI, launch, or kernel cache."
+  (:require [raster.compiler.core.hardware :as hardware]
+            [raster.compiler.ir.kernel-dispatch :as dispatch]
+            [raster.compiler.ir.kernel-executable :as executable]
+            [raster.compiler.passes.parallel.contract-route :as contract-route]
+            [raster.compiler.pipeline :as pipeline]))
+
+(def dense-source
+  '(let* [step (raster.par/contract C [[i m] [j n]] [[l k]]
+                                    (* (clojure.core/aget A (+ (* i k) l))
+                                       (clojure.core/aget B (+ (* l n) j))))]
+         step))
+
+(def batched-source
+  '(let* [step (raster.par/contract
+                C [[b batch] [i m] [j n]] [[l k]]
+                (* (clojure.core/aget A (+ (* (+ (* b m) i) k) l))
+                   (clojure.core/aget B (+ (* (+ (* b k) l) n) j))))]
+         step))
+
+(def shared-column-batched-source
+  '(let* [step (raster.par/contract
+                C [[b batch] [i m] [j n]] [[l k]]
+                (* (clojure.core/aget A (+ (* (+ (* b m) i) k) l))
+                   (clojure.core/aget B (+ (* l n) j))))]
+         step))
+
+(defn route
+  "Compile `source` through TypedSOAC and return its target-aware contraction dispatch."
+  [device-id source array-types scalar-types & {:keys [tile precision]
+                                                :or {precision :mixed-f16-f32}}]
+  (let [{:keys [form]}
+        (pipeline/schedule-parallel-form
+         source {:target-device device-id
+                 :dtype :float
+                 :array-types array-types
+                 :scalar-types scalar-types})
+        equation (first (:equations form))]
+    (apply contract-route/route-typed-contraction-dispatch
+           (:algorithm equation) (first (:operations equation))
+           (cond-> [:dtype :float
+                    :desc (hardware/descriptor-for device-id)
+                    :precision precision]
+             tile (conj :tile tile)))))
+
+(defn dense-dispatch
+  [device-id & {:keys [tile]}]
+  (route device-id dense-source
+         {'A :float 'B :float 'C :float}
+         {'m :int 'n :int 'k :int}
+         :tile tile))
+
+(defn batched-dispatch
+  [device-id & {:keys [shared-column?]
+                :or {shared-column? false}}]
+  (route device-id
+         (if shared-column? shared-column-batched-source batched-source)
+         {'A :float 'B :float 'C :float}
+         {'batch :int 'm :int 'n :int 'k :int}))
+
+(defn epilogue-dispatch
+  "Compile C=(A·B+bias)*scale as a contraction with a typed result ScalarRegion."
+  [device-id & {:keys [tile]}]
+  (let [transform {:acc 'acc
+                   :expr '(raster.numeric/*
+                           (raster.numeric/+ acc (clojure.core/aget bias j)) scale)
+                   :operands [{:sym 'bias :dtype :float
+                               :map {:groups [[['j 'n]]]}}]
+                   :scalars [{:sym 'scale :dtype :float}]
+                   :dtype :float}
+        contract (apply list
+                        (concat
+                         '(raster.par/contract C [[i m] [j n]] [[l k]]
+                                               (* (clojure.core/aget A (+ (* i k) l))
+                                                  (clojure.core/aget B (+ (* l n) j))))
+                         [:epilogue transform]))]
+    (route device-id (list 'let* ['step contract] 'step)
+           {'A :float 'B :float 'C :float 'bias :float}
+           {'m :int 'n :int 'k :int 'scale :float}
+           :tile tile)))
+
+(defn matrix-artifact
+  "Return the one matrix-instruction artifact contributed by `strategy`.
+
+   Conversion and transpose artifacts have no :tile.  A split graph also has a portable final
+   combine, so selecting by the certified matrix tile is stable across all graph topologies."
+  [scheduled strategy]
+  (let [artifacts (->> (dispatch/alternative scheduled strategy)
+                       executable/artifacts
+                       (filter #(get-in % [:attributes :tile]))
+                       vec)]
+    (when-not (= 1 (count artifacts))
+      (throw (ex-info "matrix schedule must contain exactly one tiled matrix artifact"
+                      {:strategy strategy
+                       :artifacts (mapv #(select-keys % [:kernel-name :attributes]) artifacts)})))
+    (first artifacts)))
+
+(defn input-array
+  [n seed]
+  (let [result (float-array n)
+        random (java.util.Random. (long seed))]
+    (dotimes [index n]
+      (aset result index (float (* 0.05 (.nextGaussian random)))))
+    result))
+
+(defn half-array
+  ^shorts [^floats values]
+  (let [result (short-array (alength values))]
+    (dotimes [index (alength values)]
+      (aset result index (Float/floatToFloat16 (aget values index))))
+    result))
+
+(defn f16
+  ^double [value]
+  (double (Float/float16ToFloat (Float/floatToFloat16 (float value)))))
+
+(defn reference
+  [^floats a ^floats b m n k]
+  (let [result (float-array (* m n))]
+    (dotimes [i m]
+      (dotimes [j n]
+        (aset result (+ (* i n) j)
+              (float
+               (loop [l 0 sum 0.0]
+                 (if (< l k)
+                   (recur (inc l)
+                          (+ sum (* (f16 (aget a (+ (* i k) l)))
+                                    (f16 (aget b (+ (* l n) j))))))
+                   sum))))))
+    result))
+
+(defn relative-l1
+  [^floats actual ^floats expected]
+  (loop [index 0 difference 0.0 scale 0.0]
+    (if (< index (alength actual))
+      (recur (inc index)
+             (+ difference
+                (Math/abs (- (double (aget actual index))
+                             (double (aget expected index)))))
+             (+ scale (Math/abs (double (aget expected index)))))
+      (/ difference (max scale 1.0e-30)))))

--- a/test/raster/dl/dv_batched_gemm_spike.clj
+++ b/test/raster/dl/dv_batched_gemm_spike.clj
@@ -11,16 +11,18 @@
    tiles = 128 workgroups, which FILL the ~32-workgroup iGPU where one slab (2 wg)
    starves it.
 
-   Kernel: raster.gpu.ze-runtime/bind-registered-gemm-batched!, lowered from three explicit
-   grid-Z-selected KernelBody buffer views. This is the batched NN primitive C[b]=A[b]·B[b]; the -tn layout
-   (Wᵀ) is staged host-side here (transpose each W slab → A) to isolate the GEMM lever
-   the GATE measures.
+   The target artifact is derived from an ordinary batched TypedSOAC contraction and contains
+   three explicit grid-Z-selected KernelBody buffer views. This is the batched NN schedule
+   C[b]=A[b]·B[b]; the -tn layout (Wᵀ) is staged host-side here (transpose each W slab → A)
+   to isolate the matrix-instruction lever the GATE measures.
 
    GATE (real shape 64 slabs, m=k=64, n=256): device-event GFLOPS ≥ ~900 (½ of the
    oneDNN 1829-GFLOPS ceiling, ~10× the 79-GFLOPS scalar path) → the lever is real."
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.typed-matrix-device-support :as support]
             [raster.dl.nn :as nn]
-            [raster.dl.attention :as attn]))
+            [raster.dl.attention :as attn]
+            [raster.gpu.core :as gpu]))
 
 (def ^:private gpu-available?
   (delay (try (require 'raster.gpu.ze-runtime)
@@ -33,11 +35,6 @@
 (defn- da ^doubles [n seed]
   (let [r (java.util.Random. (long seed)) a (double-array n)]
     (dotimes [i n] (aset a i (.nextGaussian r))) a))
-
-(defn- median [xs]
-  (let [v (vec (sort xs)) n (count v)]
-    (if (odd? n) (nth v (quot n 2))
-        (/ (+ (nth v (dec (quot n 2))) (nth v (quot n 2))) 2.0))))
 
 ;; ── Host transpose-A staging: A[b] = W[b]ᵀ, flattened [batch, seq, seq] ───────────
 (defn- transpose-slabs ^floats [^floats W batch seq-len]
@@ -74,19 +71,7 @@
 (deftest dv-batched-gemm-gpu-gate
   (if-not @gpu-available?
     (println "  [SKIP] dv batched-gemm gate: no Level Zero GPU")
-    (let [ze (do (require 'raster.gpu.ze-runtime) (find-ns 'raster.gpu.ze-runtime))
-          make-buffer (ns-resolve ze 'make-buffer)
-          buf-f16-of  (ns-resolve ze 'buffer-of-floats-as-half)
-          upload!     (ns-resolve ze 'array->buffer!)
-          download    (ns-resolve ze 'buffer->array)
-          free!       (ns-resolve ze 'free-buffer!)
-          record!     (ns-resolve ze 'record-graph!)
-          replay!     (ns-resolve ze 'replay-graph!)
-          reset-ev!   (ns-resolve ze 'reset-graph-events!)
-          read-ts!    (ns-resolve ze 'read-graph-timestamps!)
-          destroy!    (ns-resolve ze 'destroy-graph!)
-          batched!    (ns-resolve ze 'bind-registered-gemm-batched!)
-          ;; real gemma attention shape: 64 slabs (B·n-heads), seq=64, hd=256
+    (let [;; real gemma attention shape: 64 slabs (B·n-heads), seq=64, hd=256
           batch 64 sl 64 hd 256
           m sl k sl n hd
           nQ (* batch sl hd)
@@ -95,26 +80,32 @@
           W ^floats (attn/batched-causal-attn-weights Q K batch sl hd)
           A (transpose-slabs W batch sl)           ;; [batch, m=seq, k=seq]  (= Wᵀ per slab)
           B dO                                     ;; [batch, k=seq, n=hd]
-          a16 (buf-f16-of A)
-          b16 (buf-f16-of B)
-          c   (make-buffer nQ :float)]
-      (try
-        (let [g (record! [{:bound (batched! a16 b16 c m n k batch)
-                           :kernel-name "gemm_nonsquare_batched"}]
-                         {:profile? true})]
+          scheduled (support/batched-dispatch :ze:0)
+          artifact (support/matrix-artifact scheduled :xmx-batched)]
+      (gpu/with-gpu-session [session :ze:0]
+        (gpu/alloc! session {:a [:half (* batch m k) (support/half-array A)]
+                             :b [:half (* batch k n) (support/half-array B)]
+                             :c [:float nQ nil]})
+        (let [handle (gpu/bind-kernel-executable!
+                      session :typed-batched-matrix artifact
+                      [:a :b :c
+                       {:type :int :value m}
+                       {:type :int :value n}
+                       {:type :int :value k}
+                       {:type :int :value batch}]
+                      {:profile? true})]
           (try
-            ;; warmup
-            (dotimes [_ 3] (replay! g) (reset-ev! g))
-            ;; timed replays (interleaved medians)
-            (let [samples (vec (for [_ (range 13)]
-                                 (do (replay! g)
-                                     (let [ts (read-ts! g)]
-                                       (-> ts :kernels first :ms)))))
-                  med-ms (median samples)
+            (gpu/run-kernel-graph! session handle)
+            (let [measurement (gpu/measure-bound-kernel-graph!
+                               session handle
+                               :warmup-iterations 3 :budget-ms 1000
+                               :min-samples 13 :max-samples 13)
+                  samples (mapv #(/ % 1.0e6) (:samples-ns measurement))
+                  med-ms (/ (:median-ns measurement) 1.0e6)
                   flops (* 2.0 batch m k n)
                   gflops (/ flops (* med-ms 1.0e6))
                   ceil 1829.0 scalar-gflops 79.0
-                  out ^floats (download c)
+                  out ^floats (gpu/download session :c)
                   numr (reduce max 0.0 (map #(Math/abs (- (double %1) (double %2))) out scalar))
                   denr (reduce max 1e-9 (map #(Math/abs (double %)) scalar))
                   relerr (/ numr denr)]
@@ -129,5 +120,5 @@
                                relerr (if (>= gflops 900.0) "PASS" "FAIL")))
               (is (< relerr 5.0e-3)
                   (str "batched-GEMM dV vs scalar rel-err " relerr " (f16 floor ~1e-3)")))
-            (finally (destroy! g))))
-        (finally (doseq [b [a16 b16 c]] (free! b)))))))
+            (finally
+              (gpu/release-kernel-graph! session handle))))))))

--- a/test/raster/gpu/gemm_autotune_test.clj
+++ b/test/raster/gpu/gemm_autotune_test.clj
@@ -11,8 +11,10 @@
    not a 'maximize splits' heuristic — finds a measured beneficial interior point.  The exact
    factor is deliberately hardware-, driver-, and load-dependent."
   (:require [clojure.test :refer [deftest is testing]]
+            [raster.compiler.backend.gpu.typed-matrix-device-support :as support]
+            [raster.compiler.core.hardware :as hw]
             [raster.dl.gpu-grad-parity :as gp]
-            [raster.compiler.core.hardware :as hw]))
+            [raster.gpu.core :as gpu]))
 
 ;; ── the real cost-fn: device-event time of the resident split-k XMX GEMM ─────────
 (defn- bench-splitk-ms
@@ -71,42 +73,54 @@
 
 ;; ── T3: the TILE axis — every finite emitted candidate is correct and device-priced ──
 (defn- run-tiled-gemm
-  "Run bind-registered-gemm-tiled! for `tile` at (m,n,k) over fixed A/B, returning [C median-ms]."
-  [ze a16 b16 m n k tile]
-  (let [g!   (ns-resolve ze 'make-buffer)   free (ns-resolve ze 'free-buffer!)
-        rec  (ns-resolve ze 'record-graph!) rep (ns-resolve ze 'replay-graph!)
-        rst  (ns-resolve ze 'reset-graph-events!) rts (ns-resolve ze 'read-graph-timestamps!)
-        dst  (ns-resolve ze 'destroy-graph!) ba (ns-resolve ze 'buffer->array)
-        btg  (ns-resolve ze 'bind-registered-gemm-tiled!)
-        c    (g! (* m n) :float)]
+  "Measure one tile selected from an ordinary typed contraction.
+
+   The compiler-emitted matrix artifact is isolated so this remains a target-kernel tile ruler;
+   binding, launch geometry, profiling, and ownership still go through the generic runtime API."
+  [session m n k tile key]
+  (let [scheduled (support/dense-dispatch :ze:0 :tile tile)
+        artifact (support/matrix-artifact scheduled :xmx-direct)
+        c-key [:tile-output key]
+        _ (gpu/alloc! session {c-key [:float (* m n) nil]})
+        handle (gpu/bind-kernel-executable!
+                session [:tile-candidate key] artifact
+                [:tile-a :tile-b c-key
+                 {:type :int :value m}
+                 {:type :int :value n}
+                 {:type :int :value k}]
+                {:profile? true})]
     (try
-      (let [g (rec [{:bound (btg a16 b16 c m n k :float tile) :kernel-name "t"}] {:profile? true})]
-        (try
-          (dotimes [_ 2] (rep g) (rst g))
-          (let [ms (vec (for [_ (range 7)] (do (rep g) (reduce + (map :ms (:kernels (rts g)))))))]
-            [(vec (ba c)) (nth (sort ms) 3)])
-          (finally (dst g))))
-      (finally (free c)))))
+      (gpu/run-kernel-graph! session handle)
+      (let [measurement (gpu/measure-bound-kernel-graph!
+                         session handle
+                         :warmup-iterations 2 :budget-ms 1000
+                         :min-samples 7 :max-samples 7)]
+        [(vec (gpu/download session c-key)) (/ (:median-ns measurement) 1.0e6)])
+      (finally
+        (gpu/release-kernel-graph! session handle)))))
 
 (deftest autotune-tile-axis-all-candidates-correct
   (if-not @gp/gpu-available?
     (gp/gpu-skip! "GEMM autotune: tile axis (all candidates correct + measured search)")
-    (let [ze   (do (require 'raster.gpu.ze-runtime) (find-ns 'raster.gpu.ze-runtime))
-          f16  (ns-resolve ze 'buffer-of-floats-as-half)  free (ns-resolve ze 'free-buffer!)
-          desc (hw/descriptor-for :ze:0)
+    (let [desc (hw/descriptor-for :ze:0)
           cands (hw/gemm-tile-candidates desc)
           default-tile (hw/derive-gemm-tile desc)
           m 256 n 256 k 512
           rng (java.util.Random. 4)
           mk  (fn [s] (let [a (float-array s)] (dotimes [i s] (aset a i (float (* 0.05 (.nextGaussian rng))))) a))
-          a16 (f16 (mk (* m k)))  b16 (f16 (mk (* k n)))]
-      (try
+          a (mk (* m k))
+          b (mk (* k n))]
+      (gpu/with-gpu-session [session :ze:0]
+        (gpu/alloc! session {:tile-a [:half (* m k) (support/half-array a)]
+                             :tile-b [:half (* k n) (support/half-array b)]})
         (testing "the curated candidate list is non-trivial and includes the derived default"
           (is (> (count cands) 1) "more than one tile to search")
           (is (some #(= % default-tile) cands) "the derived default is in the search space"))
-        (let [ref (first (run-tiled-gemm ze a16 b16 m n k default-tile))
-              results (mapv (fn [t] (let [[c ms] (run-tiled-gemm ze a16 b16 m n k t)]
-                                      {:tile t :bit-identical? (= ref c) :ms ms})) cands)]
+        (let [ref (first (run-tiled-gemm session m n k default-tile :reference))
+              results (mapv (fn [index t]
+                              (let [[c ms] (run-tiled-gemm session m n k t index)]
+                                {:tile t :bit-identical? (= ref c) :ms ms}))
+                            (range) cands)]
           (testing "SAFETY: every candidate tile produces output bit-identical to the default"
             (doseq [{:keys [tile bit-identical?]} results]
               (is bit-identical? (str "tile " (select-keys tile [:block-m :block-n :block-k]) " must match default"))))
@@ -117,5 +131,5 @@
                                ms (if (= tile winner) "  <- winner" ""))))
             (testing "measured search returns a feasible candidate (Arc: hand-tuned default is ~optimal)"
               (is (some #(= % winner) cands) "winner is one of the candidates")
-              (is (= ref (first (run-tiled-gemm ze a16 b16 m n k winner))) "winner output is correct"))))
-        (finally (free a16) (free b16))))))
+              (is (= ref (first (run-tiled-gemm session m n k winner :winner)))
+                  "winner output is correct"))))))))

--- a/test/raster/gpu/gemm_splitk_test.clj
+++ b/test/raster/gpu/gemm_splitk_test.clj
@@ -16,9 +16,11 @@
        and splits the low-occupancy ones."
   (:require [clojure.test :refer [deftest is testing]]
             [raster.compiler.backend.gpu.gemm :as gemm]
+            [raster.compiler.backend.gpu.typed-matrix-device-support :as support]
             [raster.compiler.core.hardware :as hardware]
             [raster.compiler.ir.kernel-launch :as launch]
-            [raster.dl.gpu-grad-parity :as gp]))
+            [raster.dl.gpu-grad-parity :as gp]
+            [raster.gpu.core :as gpu]))
 
 (defn- rnd ^floats [n seed]
   (let [a (float-array n) r (java.util.Random. (long seed))]
@@ -38,15 +40,9 @@
   (if-not @gp/gpu-available?
     (gp/gpu-skip! "gemm split-k")
     (let [ze (do (require 'raster.gpu.ze-runtime) (find-ns 'raster.gpu.ze-runtime))
-          make-buffer   (ns-resolve ze 'make-buffer)
-          upload!       (ns-resolve ze 'array->buffer!)
-          download      (ns-resolve ze 'buffer->array)
-          free!         (ns-resolve ze 'free-buffer!)
           record-graph! (ns-resolve ze 'record-graph!)
           replay!       (ns-resolve ze 'replay-graph!)
           destroy!      (ns-resolve ze 'destroy-graph!)
-          convert!      (ns-resolve ze 'bind-registered-convert!)
-          gemm!         (ns-resolve ze 'bind-registered-gemm!)
           splitk!       (ns-resolve ze 'bind-registered-gemm-splitk!)
           reduce!       (ns-resolve ze 'bind-registered-splitk-reduce!)]
       (doseq [[m n k splits kc]
@@ -56,26 +52,47 @@
                [33 200 1000 3 352]      ;; ragged m, n and k; last chunk clipped
                [128 256 4096 8 512]]]
         (let [A (rnd (* m k) 1) B (rnd (* k n) 2)
-              af (make-buffer (* m k) :float) bf (make-buffer (* k n) :float)
-              a16 (make-buffer (* m k) :half) b16 (make-buffer (* k n) :half)
-              c-plain (make-buffer (* m n) :float)
-              c-split (make-buffer (* m n) :float)
-              parts (make-buffer (* splits m n) :float)]
-          (upload! af A)
-          (upload! bf B)
-          (let [g (record-graph! [{:bound (convert! af a16 (* m k))}
-                                  {:bound (convert! bf b16 (* k n))}
-                                  {:bound (gemm! a16 b16 c-plain m n k :float)}
-                                  {:bound (splitk! a16 b16 parts m n k kc splits)}
-                                  {:bound (reduce! parts c-split (* m n) splits)}])]
-            (replay! g)
-            (let [P (download c-plain) S (download c-split)
-                  err (rel-l1 S P)]
-              (testing (str "m=" m " n=" n " k=" k " splits=" splits)
-                (is (< err 1.0e-4)
-                    (str "split-k vs plain XMX gemm rel-L1 " err))))
-            (destroy! g))
-          (doseq [b [af bf a16 b16 c-plain c-split parts]] (free! b)))))))
+              scheduled (support/dense-dispatch :ze:0)
+              direct (support/matrix-artifact scheduled :xmx-direct)]
+          (gpu/with-gpu-session [session :ze:0]
+            (gpu/alloc! session {:a16 [:half (* m k) (support/half-array A)]
+                                 :b16 [:half (* k n) (support/half-array B)]
+                                 :c-plain [:float (* m n) nil]
+                                 :c-split [:float (* m n) nil]
+                                 :parts [:float (* splits m n) nil]})
+            (let [direct-handle
+                  (gpu/bind-kernel-executable!
+                   session [:typed-direct m n k] direct
+                   [:a16 :b16 :c-plain
+                    {:type :int :value m}
+                    {:type :int :value n}
+                    {:type :int :value k}])]
+              (try
+                (gpu/run-kernel-graph! session direct-handle)
+                ;; Explicit split factors remain a legacy benchmark surface until split count is
+                ;; represented as a finite compiler schedule candidate in the next increment.
+                (let [g (record-graph!
+                         [{:bound (splitk! (gpu/buffer session :a16)
+                                           (gpu/buffer session :b16)
+                                           (gpu/buffer session :parts)
+                                           m n k kc splits)
+                           :kernel-name "gemm_nonsquare_splitk"}
+                          {:bound (reduce! (gpu/buffer session :parts)
+                                           (gpu/buffer session :c-split)
+                                           (* m n) splits)
+                           :kernel-name "splitk_reduce"}])]
+                  (try
+                    (replay! g)
+                    (let [plain (gpu/download session :c-plain)
+                          split (gpu/download session :c-split)
+                          error (rel-l1 split plain)]
+                      (testing (str "m=" m " n=" n " k=" k " splits=" splits)
+                        (is (< error 1.0e-4)
+                            (str "split-k vs compiler-derived direct matrix rel-L1 " error))))
+                    (finally
+                      (destroy! g))))
+                (finally
+                  (gpu/release-kernel-graph! session direct-handle))))))))))
 
 (deftest unrolled-layout-convert-is-bit-exact
   ;; The f32→f16 operand cast schedules w statically unrolled, lane-owned elements per work-item.

--- a/test/raster/gpu/one_tile_source_test.clj
+++ b/test/raster/gpu/one_tile_source_test.clj
@@ -67,14 +67,16 @@
       ;; makes the change safe here and correct elsewhere
       (is (= (gc 4096 128) (gc 4096 block-n))))))
 
-(deftest resident-direct-and-autotune-sources-use-the-scheduled-body
-  (let [emit-resident (do (require 'raster.gpu.ze-runtime)
-                          (ns-resolve 'raster.gpu.ze-runtime 'emit-scheduled-gemm))
-        tile (hw/gemm-tile-for nil)]
+(deftest direct-and-autotune-sources-use-the-scheduled-body
+  (let [tile (hw/gemm-tile-for nil)]
     (with-redefs [opencl-codegen/emit-gemm-tiled
                   (fn [& _]
                     (throw (ex-info "legacy template was called" {:reason :test/failure})))]
-      (let [emitted (emit-resident "resident_body" :float tile nil)]
+      (let [emitted (gemm/emit-scheduled-matrix-kernel
+                     {:kernel-name "typed_matrix_body"
+                      :id :typed-matrix-body
+                      :a 'A :b 'B :c 'C :m 'M :n 'N :k 'K
+                      :tile tile :result-dtype :float})]
         (is (body/kernel-body? (:kernel-body emitted)))
         (is (= :float (:dtype (first (filter #(= :result (:role %))
                                              (get-in emitted [:kernel-body :parameters]))))))
@@ -82,42 +84,41 @@
                (:workgroup-size emitted)))
         (is (re-find #"__global float\* restrict C" (:source emitted)))))))
 
-(deftest resident-epilogues-use-typed-programs-and-body-owned-abi
-  (let [ze (do (require 'raster.gpu.ze-runtime) (find-ns 'raster.gpu.ze-runtime))
-        emit-resident (ns-resolve ze 'emit-scheduled-gemm)
-        resident-program (ns-resolve ze 'resident-epilogue-program)
-        tile (hw/gemm-tile-for nil)
+(deftest result-transforms-use-typed-programs-and-body-owned-abi
+  (let [tile (hw/gemm-tile-for nil)
         program {:acc 'acc
                  :expr '(raster.numeric/+ acc (aget bias j))
                  :operands [{:sym 'bias
                              :map (axis-map/of-axes [['j 'N]])
-                             :dtype :half}]}
-        descriptor (assoc program :bindings {'bias :resident-buffer})]
+                             :dtype :half}]}]
     (with-redefs [opencl-codegen/emit-gemm-tiled
                   (fn [& _]
                     (throw (ex-info "legacy template was called" {:reason :test/failure})))]
-      (let [emitted (emit-resident "resident_typed_epilogue" :float tile program)]
-        (is (= program (resident-program descriptor)))
+      (let [emitted (gemm/emit-scheduled-matrix-kernel
+                     {:kernel-name "typed_matrix_epilogue"
+                      :id :typed-matrix-epilogue
+                      :a 'A :b 'B :c 'C :m 'M :n 'N :k 'K
+                      :tile tile :result-dtype :float :epilogue program})]
         (is (= [['bias :input :half :epilogue]]
                (mapv (juxt :id :kind :dtype :role)
                      (filter #(= :epilogue (:role %))
                              (get-in emitted [:kernel-body :parameters])))))
         (is (re-find #"restrict bias" (:source emitted)))
-        (is (re-find #"bias\[[^]]*col" (:source emitted)))))
-    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"unsupported fields"
-                          (resident-program {:key :bias :fn identity :params "raw"
-                                             :bindings {}})))))
+        (is (re-find #"bias\[[^]]*col" (:source emitted)))))))
 
-(deftest resident-grid-z-sources-use-the-scheduled-body
-  (let [ze (do (require 'raster.gpu.ze-runtime) (find-ns 'raster.gpu.ze-runtime))
-        emit-split (ns-resolve ze 'emit-scheduled-split-k-gemm)
-        emit-batched (ns-resolve ze 'emit-scheduled-batched-gemm)
-        tile (hw/gemm-tile-for nil)]
+(deftest grid-z-sources-use-the-scheduled-body
+  (let [tile (hw/gemm-tile-for nil)]
     (with-redefs [opencl-codegen/emit-gemm-tiled
                   (fn [& _]
                     (throw (ex-info "legacy template was called" {:reason :test/failure})))]
-      (let [split (emit-split "resident_split_body" tile)
-            batched (emit-batched "resident_batched_body" tile)]
+      (let [split (gemm/emit-scheduled-split-k-kernel
+                   {:kernel-name "typed_split_body" :id :typed-split-body
+                    :a 'A :b 'B :c 'C :m 'M :n 'N :k 'K
+                    :kc 'KC :splits 'splits :tile tile})
+            batched (gemm/emit-scheduled-batched-matrix-kernel
+                     {:kernel-name "typed_batched_body" :id :typed-batched-body
+                      :a 'A :b 'B :c 'C :m 'M :n 'N :k 'K
+                      :batch 'batch :tile tile})]
         (is (= [256 1 1] (:workgroup-size split)))
         (is (= 1 (count (get-in split [:kernel-body :views]))))
         (is (re-find #"int KC, int splits" (:source split)))


### PR DESCRIPTION
## Summary
- route direct, tiled, fused-result-transform, and batched matrix device tests from ordinary TypedSOAC contractions
- bind and profile compiler-emitted KernelExecutable artifacts through the backend-neutral GPU session API
- delete the corresponding Level Zero GEMM compilation caches and bespoke ABI/launch binders
- retain only the explicit split-factor benchmark seam until split count becomes a finite compiler schedule dimension

## Focused verification
- typed matrix schedule device tests: 2 tests, 5 assertions
- one-tile-source: 7 tests, 31 assertions
- split-K/device conversion: 4 tests, 60 assertions
- tile/split autotune: 2 tests, 16 assertions; 13.0x measured split-K win
- affected source files pass cljfmt and ze-runtime reloads

The slow batched dV namespace was left to CI after its unrelated Typed Clojure attention analysis exceeded the laptop hot-loop budget.